### PR TITLE
Add more diagnostics for compiler performance analysis

### DIFF
--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -89,15 +89,15 @@ object ScalaOptionParser {
     "-Yissue-debug", "-Ylog-classpath", "-Ymacro-debug-lite", "-Ymacro-debug-verbose", "-Ymacro-no-expand",
     "-Yno-completion", "-Yno-generic-signatures", "-Yno-imports", "-Yno-predef",
     "-Yoverride-objects", "-Yoverride-vars", "-Ypatmat-debug", "-Yno-adapted-args", "-Ypartial-unification", "-Ypos-debug", "-Ypresentation-debug",
-    "-Ypresentation-strict", "-Ypresentation-verbose", "-Yquasiquote-debug", "-Yrangepos", "-Yreify-copypaste", "-Yreify-debug", "-Yrepl-class-based",
+    "-Ypresentation-strict", "-Ypresentation-verbose", "-Yprofile-enabled", "-Yquasiquote-debug", "-Yrangepos", "-Yreify-copypaste", "-Yreify-debug", "-Yrepl-class-based",
     "-Yrepl-sync", "-Yshow-member-pos", "-Yshow-symkinds", "-Yshow-symowners", "-Yshow-syms", "-Yshow-trees", "-Yshow-trees-compact", "-Yshow-trees-stringified", "-Ytyper-debug",
     "-Ywarn-adapted-args", "-Ywarn-dead-code", "-Ywarn-inaccessible", "-Ywarn-infer-any", "-Ywarn-nullary-override", "-Ywarn-nullary-unit", "-Ywarn-numeric-widen", "-Ywarn-unused", "-Ywarn-unused-import", "-Ywarn-value-discard",
     "-deprecation", "-explaintypes", "-feature", "-help", "-no-specialization", "-nobootcp", "-nowarn", "-optimise", "-print", "-unchecked", "-uniqid", "-usejavacp", "-usemanifestcp", "-verbose", "-version")
   private def stringSettingNames = List("-Xgenerate-phase-graph", "-Xmain-class", "-Xpluginsdir", "-Xshow-class", "-Xshow-object", "-Xsource-reader", "-Ydump-classes", "-Ygen-asmp",
-    "-Ypresentation-log", "-Ypresentation-replay", "-Yrepl-outdir", "-d", "-dependencyfile", "-encoding", "-Xscript")
+    "-Ypresentation-log", "-Ypresentation-replay", "-Yrepl-outdir", "-Yprofile-destination", "-d", "-dependencyfile", "-encoding", "-Xscript")
   private def pathSettingNames = List("-bootclasspath", "-classpath", "-extdirs", "-javabootclasspath", "-javaextdirs", "-sourcepath", "-toolcp")
   private val phases = List("all", "parser", "namer", "packageobjects", "typer", "patmat", "superaccessors", "extmethods", "pickler", "refchecks", "uncurry", "tailcalls", "specialize", "explicitouter", "erasure", "posterasure", "fields", "lambdalift", "constructors", "flatten", "mixin", "cleanup", "delambdafy", "icode", "jvm", "terminal")
-  private val phaseSettings = List("-Xprint-icode", "-Ystop-after", "-Yskip", "-Yshow", "-Ystop-before", "-Ybrowse", "-Ylog", "-Ycheck", "-Xprint")
+  private val phaseSettings = List("-Xprint-icode", "-Ystop-after", "-Yskip", "-Yshow", "-Ystop-before", "-Ybrowse", "-Ylog", "-Ycheck", "-Xprint", "-Yprofile-external-tool", "-Yprofile-run-gc")
   private def multiStringSettingNames = List("-Xmacro-settings", "-Xplugin", "-Xplugin-disable", "-Xplugin-require")
   private def intSettingNames = List("-Xmax-classfile-name", "-Xelide-below", "-Ypatmat-exhaust-depth", "-Ypresentation-delay", "-Yrecursion")
   private def choiceSettingNames = Map[String, List[String]](

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1407,11 +1407,14 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       reporter.reset()
       warnDeprecatedAndConflictingSettings(unitbuf.head)
       globalPhase = fromPhase
+      val profiler = profile.Profiler(settings)
 
       while (globalPhase.hasNext && !reporter.hasErrors) {
         val startTime = currentTime
         phase = globalPhase
+        val profileBefore=profiler.before(phase)
         globalPhase.run()
+        profiler.after(phase, profileBefore)
 
         // progress update
         informTime(globalPhase.description, startTime)
@@ -1446,6 +1449,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
         advancePhase()
       }
+      profiler.finished()
 
       reporting.summarizeErrors()
 

--- a/src/compiler/scala/tools/nsc/MainBench.scala
+++ b/src/compiler/scala/tools/nsc/MainBench.scala
@@ -16,7 +16,7 @@ object MainBench extends Driver with EvalLoop {
 
   override def newCompiler() = theCompiler
 
-  val NIter = 50
+  val NIter = System.getProperty("scala.benchmark.iterations", "50").toInt
   val NBest = 10
 
   override def main(args: Array[String]) = {

--- a/src/compiler/scala/tools/nsc/profile/ExtendedThreadMxBean.java
+++ b/src/compiler/scala/tools/nsc/profile/ExtendedThreadMxBean.java
@@ -1,0 +1,304 @@
+package scala.tools.nsc.profile;
+
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.lang.reflect.Method;
+
+@SuppressWarnings("unused")
+public abstract class ExtendedThreadMxBean implements ThreadMXBean {
+    static final ExtendedThreadMxBean proxy;
+
+    static {
+        ExtendedThreadMxBean local;
+        ThreadMXBean threadMx = ManagementFactory.getThreadMXBean();
+        try {
+            Class cls = Class.forName("com.sun.management.ThreadMXBean");
+            if (cls.isInstance(threadMx)) {
+                local = new SunThreadMxBean(threadMx);
+            } else {
+                local = new OtherThreadMxBean(threadMx);
+            }
+        } catch (ClassNotFoundException e) {
+            local = new OtherThreadMxBean(threadMx);
+        }
+        proxy = local;
+    }
+
+    protected final ThreadMXBean underlying;
+
+    protected ExtendedThreadMxBean(ThreadMXBean underlying) {
+        this.underlying = underlying;
+    }
+
+    public abstract long[] getThreadUserTime(long[] longs) throws Exception;
+
+    public abstract boolean isThreadAllocatedMemoryEnabled() throws Exception;
+
+    public abstract void setThreadAllocatedMemoryEnabled(boolean b) throws Exception;
+
+    public abstract long getThreadAllocatedBytes(long l) throws Exception;
+
+    public abstract long[] getThreadAllocatedBytes(long[] longs) throws Exception;
+
+    public abstract boolean isThreadAllocatedMemorySupported() throws Exception;
+
+    public abstract long[] getThreadCpuTime(long[] longs) throws Exception;
+    //common features from java.lang.management.ThreadMXBean
+
+    @Override
+    public int getThreadCount() {
+        return underlying.getThreadCount();
+    }
+
+    @Override
+    public int getPeakThreadCount() {
+        return underlying.getPeakThreadCount();
+    }
+
+    @Override
+    public long getTotalStartedThreadCount() {
+        return underlying.getTotalStartedThreadCount();
+    }
+
+    @Override
+    public int getDaemonThreadCount() {
+        return underlying.getDaemonThreadCount();
+    }
+
+    @Override
+    public long[] getAllThreadIds() {
+        return underlying.getAllThreadIds();
+    }
+
+    @Override
+    public ThreadInfo getThreadInfo(long id) {
+        return underlying.getThreadInfo(id);
+    }
+
+    @Override
+    public ThreadInfo[] getThreadInfo(long[] ids) {
+        return underlying.getThreadInfo(ids);
+    }
+
+    @Override
+    public ThreadInfo getThreadInfo(long id, int maxDepth) {
+        return underlying.getThreadInfo(id, maxDepth);
+    }
+
+    @Override
+    public ThreadInfo[] getThreadInfo(long[] ids, int maxDepth) {
+        return underlying.getThreadInfo(ids, maxDepth);
+    }
+
+    @Override
+    public boolean isThreadContentionMonitoringSupported() {
+        return underlying.isThreadContentionMonitoringSupported();
+    }
+
+    @Override
+    public boolean isThreadContentionMonitoringEnabled() {
+        return underlying.isThreadContentionMonitoringEnabled();
+    }
+
+    @Override
+    public void setThreadContentionMonitoringEnabled(boolean enable) {
+        underlying.setThreadContentionMonitoringEnabled(enable);
+    }
+
+    @Override
+    public long getCurrentThreadCpuTime() {
+        return underlying.getCurrentThreadCpuTime();
+    }
+
+    @Override
+    public long getCurrentThreadUserTime() {
+        return underlying.getCurrentThreadUserTime();
+    }
+
+    @Override
+    public long getThreadCpuTime(long id) {
+        return underlying.getThreadCpuTime(id);
+    }
+
+    @Override
+    public long getThreadUserTime(long id) {
+        return underlying.getThreadUserTime(id);
+    }
+
+    @Override
+    public boolean isThreadCpuTimeSupported() {
+        return underlying.isThreadCpuTimeSupported();
+    }
+
+    @Override
+    public boolean isCurrentThreadCpuTimeSupported() {
+        return underlying.isCurrentThreadCpuTimeSupported();
+    }
+
+    @Override
+    public boolean isThreadCpuTimeEnabled() {
+        return underlying.isThreadCpuTimeEnabled();
+    }
+
+    @Override
+    public void setThreadCpuTimeEnabled(boolean enable) {
+        underlying.setThreadCpuTimeEnabled(enable);
+    }
+
+    @Override
+    public long[] findMonitorDeadlockedThreads() {
+        return underlying.findMonitorDeadlockedThreads();
+    }
+
+    @Override
+    public void resetPeakThreadCount() {
+        underlying.resetPeakThreadCount();
+    }
+
+    @Override
+    public long[] findDeadlockedThreads() {
+        return underlying.findDeadlockedThreads();
+    }
+
+    @Override
+    public boolean isObjectMonitorUsageSupported() {
+        return underlying.isObjectMonitorUsageSupported();
+    }
+
+    @Override
+    public boolean isSynchronizerUsageSupported() {
+        return underlying.isSynchronizerUsageSupported();
+    }
+
+    @Override
+    public ThreadInfo[] getThreadInfo(long[] ids, boolean lockedMonitors, boolean lockedSynchronizers) {
+        return underlying.getThreadInfo(ids, lockedMonitors, lockedSynchronizers);
+    }
+
+    @Override
+    public ThreadInfo[] dumpAllThreads(boolean lockedMonitors, boolean lockedSynchronizers) {
+        return underlying.dumpAllThreads(lockedMonitors, lockedSynchronizers);
+    }
+
+    @Override
+    public ObjectName getObjectName() {
+        return underlying.getObjectName();
+    }
+}
+
+class OtherThreadMxBean extends ExtendedThreadMxBean {
+    OtherThreadMxBean(ThreadMXBean underlying) {
+        super(underlying);
+    }
+
+    @Override
+    public long[] getThreadUserTime(long[] longs) throws Exception {
+        return new long[0];
+    }
+
+    @Override
+    public boolean isThreadAllocatedMemoryEnabled() throws Exception {
+        return false;
+    }
+
+    @Override
+    public void setThreadAllocatedMemoryEnabled(boolean b) throws Exception {
+
+    }
+
+    @Override
+    public long getThreadAllocatedBytes(long l) throws Exception {
+        return -1;
+    }
+
+    @Override
+    public long[] getThreadAllocatedBytes(long[] longs) throws Exception {
+        return new long[0];
+    }
+
+    @Override
+    public boolean isThreadAllocatedMemorySupported() throws Exception {
+        return false;
+    }
+
+    @Override
+    public long[] getThreadCpuTime(long[] longs) throws Exception {
+        return new long[0];
+    }
+
+}
+
+
+class SunThreadMxBean extends ExtendedThreadMxBean {
+
+    private final ThreadMXBean real;
+
+    private final Method getThreadUserTimeMethod;
+    private final Method isThreadAllocatedMemoryEnabledMethod;
+    private final Method setThreadAllocatedMemoryEnabledMethod;
+    private final Method getThreadAllocatedBytesMethod1;
+    private final Method getThreadAllocatedBytesMethod2;
+    private final Method isThreadAllocatedMemorySupportedMethod;
+    private final Method getThreadCpuTimeMethod;
+
+
+    public SunThreadMxBean(ThreadMXBean underlying) {
+        super(underlying);
+        this.real = underlying;
+        try {
+            getThreadUserTimeMethod = real.getClass().getMethod("getThreadUserTime", long[].class);
+            isThreadAllocatedMemoryEnabledMethod = real.getClass().getMethod("isThreadAllocatedMemoryEnabled");
+            setThreadAllocatedMemoryEnabledMethod = real.getClass().getMethod("setThreadAllocatedMemoryEnabled", Boolean.TYPE);
+            getThreadAllocatedBytesMethod1 = real.getClass().getMethod("getThreadAllocatedBytes", Long.TYPE);
+            getThreadAllocatedBytesMethod2 = real.getClass().getMethod("getThreadAllocatedBytes", long[].class);
+            isThreadAllocatedMemorySupportedMethod = real.getClass().getMethod("isThreadAllocatedMemorySupported");
+            getThreadCpuTimeMethod = real.getClass().getMethod("getThreadCpuTime", long[].class);
+
+            getThreadUserTimeMethod.setAccessible(true);
+            isThreadAllocatedMemoryEnabledMethod.setAccessible(true);
+            setThreadAllocatedMemoryEnabledMethod.setAccessible(true);
+            getThreadAllocatedBytesMethod1.setAccessible(true);
+            getThreadAllocatedBytesMethod2.setAccessible(true);
+            isThreadAllocatedMemorySupportedMethod.setAccessible(true);
+            getThreadCpuTimeMethod.setAccessible(true);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+
+    public boolean isExtended() {
+        return true;
+    }
+
+    public long[] getThreadUserTime(long[] longs) throws Exception {
+        return (long[]) getThreadUserTimeMethod.invoke(real, longs);
+    }
+
+    public boolean isThreadAllocatedMemoryEnabled() throws Exception {
+        return (boolean) isThreadAllocatedMemoryEnabledMethod.invoke(real);
+    }
+
+    public void setThreadAllocatedMemoryEnabled(boolean b) throws Exception {
+        setThreadAllocatedMemoryEnabledMethod.invoke(real, b);
+    }
+
+    public long getThreadAllocatedBytes(long l) throws Exception {
+        return (long) getThreadAllocatedBytesMethod1.invoke(real, l);
+    }
+
+    public long[] getThreadAllocatedBytes(long[] longs) throws Exception {
+        return (long[]) getThreadAllocatedBytesMethod2.invoke(real, longs);
+    }
+
+    public boolean isThreadAllocatedMemorySupported() throws Exception {
+        return (boolean) isThreadAllocatedMemorySupportedMethod.invoke(real);
+    }
+
+    public long[] getThreadCpuTime(long[] longs) throws Exception {
+        return (long[]) getThreadCpuTimeMethod.invoke(real, longs);
+
+    }
+}

--- a/src/compiler/scala/tools/nsc/profile/ExternalToolHook.java
+++ b/src/compiler/scala/tools/nsc/profile/ExternalToolHook.java
@@ -1,0 +1,22 @@
+package scala.tools.nsc.profile;
+
+/**
+ * this is an external tool hook
+ * it allows an external tool such as YourKit or JProfiler to instrument a particular phase of the compiler
+ * <p>
+ * the use case is like this
+ * other profiling has indicated that a particular phase of the compiler requires some deep analysis via an external tool
+ * <p>
+ * configure the tool to start and stop profiling base on execution of these methods
+ * then add the -Yprofile-external-tool to call these methods for the pahse that you are interested in
+ */
+public class ExternalToolHook {
+    private ExternalToolHook() {
+    }
+
+    public static void before() {
+    }
+
+    public static void after() {
+    }
+}

--- a/src/compiler/scala/tools/nsc/profile/Profiler.scala
+++ b/src/compiler/scala/tools/nsc/profile/Profiler.scala
@@ -1,0 +1,153 @@
+package scala.tools.nsc.profile
+
+import java.io.{FileWriter, PrintWriter}
+import java.lang.management.ManagementFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.tools.nsc.{Phase, Settings}
+
+object Profiler {
+  def apply(settings: Settings): Profiler =
+    if (!settings.YprofileEnabled) NoOpProfiler
+    else {
+      val reporter = if (settings.YprofileDestination.isSetByUser)
+        new StreamProfileReporter(new PrintWriter(new FileWriter(settings.YprofileDestination.value, true)))
+      else ConsoleProfileReporter
+      new RealProfiler(reporter, settings)
+    }
+}
+
+
+case class ProfileCounters(wallClockTimeNanos: Long, cpuTimeNanos: Long, userTimeNanos: Long, allocatedBytes: Long,
+                           retainedHeapBytes: Long, gcTimeMillis: Long) {
+  def -(that: ProfileCounters): ProfileCounters = {
+    ProfileCounters(
+      this.wallClockTimeNanos - that.wallClockTimeNanos,
+      this.cpuTimeNanos - that.cpuTimeNanos,
+      this.userTimeNanos - that.userTimeNanos,
+      this.allocatedBytes - that.allocatedBytes,
+      this.retainedHeapBytes - that.retainedHeapBytes,
+      this.gcTimeMillis - that.gcTimeMillis)
+  }
+  def updateHeap(heapDetails: ProfileCounters): ProfileCounters = {
+    copy(retainedHeapBytes = heapDetails.retainedHeapBytes)
+  }
+  private def toMillis(ns: Long) = ns / 1000000.0D
+  private def toMegaBytes(bytes: Long) = bytes / 1000000.0D
+
+  def wallClockTimeMillis: Double = toMillis(wallClockTimeNanos)
+  def cpuTimeMillis: Double = toMillis(cpuTimeNanos)
+  def userTimeMillis: Double = toMillis(userTimeNanos)
+  def allocatedMB: Double = toMegaBytes(allocatedBytes)
+  def retainedHeapMB: Double = toMegaBytes(retainedHeapBytes)
+
+}
+
+sealed trait Profiler {
+  def finished(): Unit
+
+  def after(phase: Phase, profileBefore: ProfileCounters): Unit
+
+  def before(phase: Phase): ProfileCounters
+
+}
+
+private[profile] object NoOpProfiler extends Profiler {
+  val noSnap = ProfileCounters(0, 0, 0, 0, 0, 0)
+
+  override def before(phase: Phase): ProfileCounters = noSnap
+
+  override def after(phase: Phase, profileBefore: ProfileCounters): Unit = ()
+
+  override def finished(): Unit = ()
+}
+
+private[profile] object RealProfiler {
+  import scala.collection.JavaConverters._
+  private val runtimeMx = ManagementFactory.getRuntimeMXBean
+  private val memoryMx = ManagementFactory.getMemoryMXBean
+  private val gcMx = ManagementFactory.getGarbageCollectorMXBeans.asScala.toList
+  private val threadMx = ExtendedThreadMxBean.proxy
+  if (threadMx.isThreadCpuTimeSupported) threadMx.setThreadCpuTimeEnabled(true)
+  private val idGen = new AtomicInteger()
+}
+
+private[profile] class RealProfiler(reporter: ProfileReporter, val settings: Settings) extends Profiler {
+  def outDir: String = settings.outdir.value
+  val id: Int = RealProfiler.idGen.incrementAndGet()
+
+  private def snap: ProfileCounters = {
+    import RealProfiler._
+    ProfileCounters(System.nanoTime(), threadMx.getCurrentThreadCpuTime, threadMx.getCurrentThreadUserTime,
+      threadMx.getThreadAllocatedBytes(Thread.currentThread().getId), memoryMx.getHeapMemoryUsage.getUsed,
+      gcMx.foldLeft(0L) { case (sum, bean) => bean.getCollectionTime + sum })
+  }
+  private val overhead = {
+    val s1 = snap
+    val s2 = snap
+    s2 - s1
+  }
+  private def doGC(): Unit = {
+    System.gc()
+    System.runFinalization()
+  }
+  reporter.header(this)
+
+  override def finished(): Unit = reporter.close(this)
+
+  override def after(phase: Phase, profileBefore: ProfileCounters): Unit = {
+    val initialSnap = snap
+    if (settings.YprofileExternalTool.containsPhase(phase)) {
+      println("Profile hook stop")
+      ExternalToolHook.after()
+    }
+    val finalSnap = if (settings.YprofileRunGcBetweenPhases.containsPhase(phase)) {
+      doGC()
+      initialSnap.updateHeap(snap)
+    } else initialSnap
+    reporter.report(this, phase, finalSnap - profileBefore - overhead)
+  }
+  override def before(phase: Phase): ProfileCounters = {
+    if (settings.YprofileRunGcBetweenPhases.containsPhase(phase))
+      doGC()
+    if (settings.YprofileExternalTool.containsPhase(phase)) {
+      println("Profile hook start")
+      ExternalToolHook.before()
+    }
+
+    snap
+  }
+}
+
+sealed trait ProfileReporter {
+  def report(profiler: RealProfiler, phase: Phase, diff: ProfileCounters): Unit
+  def header(profiler: RealProfiler): Unit
+  def close(profiler: RealProfiler): Unit
+}
+
+object ConsoleProfileReporter extends ProfileReporter {
+  override def report(profiler: RealProfiler, phase: Phase, diff: ProfileCounters): Unit =
+    println(f"Profiler compile ${profiler.id} after phase ${phase.id}%2d:${phase.name}%20s wallClockTime: ${diff.wallClockTimeMillis}%12.4fms, cpuTime ${diff.cpuTimeMillis}%12.4fms, userTime ${diff.userTimeMillis}%12.4fms, allocatedBytes ${diff.allocatedMB}%12.4fMB, retainedHeapBytes ${diff.retainedHeapMB}%12.4fMB, gcTime ${diff.gcTimeMillis}%6dms")
+
+  override def close(profiler: RealProfiler): Unit = ()
+
+  override def header(profiler: RealProfiler): Unit = {
+    println(s"Profiler start (${profiler.id}) ${profiler.outDir}")
+  }
+}
+
+class StreamProfileReporter(out: PrintWriter) extends ProfileReporter {
+  override def header(profiler: RealProfiler): Unit = {
+    out.println(s"info, ${profiler.id}, ${profiler.outDir}")
+    out.println(s"header,id,phaseId,phaseName,wallClockTimeMs,cpuTimeMs,userTimeMs,allocatedMB,retainedHeapMB,gcTimeMs")
+  }
+  override def report(profiler: RealProfiler, phase: Phase, diff: ProfileCounters): Unit = {
+    out.println(s"data,${profiler.id},${phase.id},${phase.name},${diff.wallClockTimeMillis},${diff.cpuTimeMillis},${diff.userTimeMillis},${diff.allocatedMB},${diff.retainedHeapMB},${diff.gcTimeMillis}")
+  }
+
+  override def close(profiler: RealProfiler): Unit = {
+    out.flush()
+    out.close()
+  }
+}
+

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -338,6 +338,16 @@ trait ScalaSettings extends AbsScalaSettings
 
   def YstatisticsEnabled = Ystatistics.value.nonEmpty
 
+  val YprofileEnabled = BooleanSetting("-Yprofile-enabled", "Enable profiling.")
+  val YprofileDestination = StringSetting("-Yprofile-destination", "file", "where to send profiling output - specify a file, default is to the console.", "").
+    withPostSetHook( _ => YprofileEnabled.value = true )
+  val YprofileExternalTool = PhasesSetting("-Yprofile-external-tool", "Enable profiling for a phase using an external tool hook. Generally only useful for a single phase", "typer").
+    withPostSetHook( _ => YprofileEnabled.value = true )
+  val YprofileRunGcBetweenPhases = PhasesSetting("-Yprofile-run-gc", "Run a GC between phases - this allows heap size to be accurate at the expense of more time. Specify a list of phases, or *", "_").
+    withPostSetHook( _ => YprofileEnabled.value = true )
+
+
+
   /** Area-specific debug output.
    */
   val Ydocdebug               = BooleanSetting("-Ydoc-debug", "Trace all scaladoc activity.")


### PR DESCRIPTION
  - `-Yprofile` will output the difference between snapshots of GC and CPU
    snapshot data, sourced from platform MBeans
  - This output can be sent to a file with `-Yprofile-destination <filename>`
    By default, output is to console
  - Use `-Yprofile-external-tool` will generate a call to the static method
    `before` and `after` around each of the the given phases. This can be
    used to communicate with an external profiler, such as YourKit, to generate a
    profile for a subset of the compiler.
  - `-Yprofile-run-gc` runs the GC after each phase to help more accurately
     attribute retained heap to a given phase.