### PR TITLE
SI-5621 Missing implicits are supplied by defaults

### DIFF
--- a/spec/04-basic-declarations-and-definitions.md
+++ b/spec/04-basic-declarations-and-definitions.md
@@ -669,6 +669,15 @@ def f(a: Int = 0)(b: Int = a + 1) = b // OK
 f(10)()                               // returns 11 (not 1)
 ```
 
+If an [implicit argument](07-implicits.html#implicit-parameters)
+is not found by implicit search, it may be supplied using a default argument.
+
+```scala
+implicit val i: Int = 2
+def f(implicit x: Int, s: String = "hi") = s * x
+f                                     // "hihi"
+```
+
 ### By-Name Parameters
 
 ```ebnf

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -320,7 +320,7 @@ would not typecheck.
 
 ### Named and Default Arguments
 
-If an application might uses named arguments $p = e$ or default
+If an application is to use named arguments $p = e$ or default
 arguments, the following conditions must hold.
 
 - For every named argument $p_i = e_i$ which appears left of a positional argument
@@ -330,7 +330,7 @@ arguments, the following conditions must hold.
   argument defines a parameter which is already specified by a
   positional argument.
 - Every formal parameter $p_j:T_j$ which is not specified by either a positional
-  or a named argument has a default argument.
+  or named argument has a default argument.
 
 If the application uses named or default
 arguments the following transformation is applied to convert it into


### PR DESCRIPTION
Specify that a method parameter that doesn't have
a corresponding argument, whether supplied by name,
position or implicitly, must have a default argument,
which by implication supplies the missing value.

Edit: moved the note to section on default args.