### PR TITLE
SI-8969 Accept poly+implicit for assignment syntax

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -274,6 +274,7 @@ abstract class TreeInfo {
   def mayBeVarGetter(sym: Symbol): Boolean = sym.info match {
     case NullaryMethodType(_)              => sym.owner.isClass && !sym.isStable
     case PolyType(_, NullaryMethodType(_)) => sym.owner.isClass && !sym.isStable
+    case PolyType(_, mt @ MethodType(_, _))=> mt.isImplicit && sym.owner.isClass && !sym.isStable
     case mt @ MethodType(_, _)             => mt.isImplicit && sym.owner.isClass && !sym.isStable
     case _                                 => false
   }

--- a/test/files/pos/t4237.scala
+++ b/test/files/pos/t4237.scala
@@ -2,5 +2,16 @@ class A {
   (new { def field = 0; def field_=(i: Int) = () }).field = 5 // compiles as expected
   (new { def field(implicit i: Int) = 0; def field_=(i: Int) = () }).field = 5 // compiles even with implicit params on getter
   (new { def field = 0; def field_=[T](i: Int) = () }).field = 5 // compiles with type param on setter
-  (new { def field[T] = 0; def field_=(i: Int) = () }).field = 5 // DOESN'T COMPILE
+  (new { def field[T] = 0; def field_=(i: Int) = () }).field = 5 // DIDN'T COMPILE
+
+  class Imp
+  implicit val imp: Imp = new Imp
+  implicit val implicitList: List[Int] = null
+
+  // compiles even with implicit params on setter
+  (new { def field(implicit i: Int) = 0; def field_=(i: Int)(implicit j: Imp) = () }).field = 5
+  (new { def field(implicit i: Int) = 0; def field_=[T <: Imp](i: Int)(implicit j: T) = () }).field = 5
+  // was reassignment to val
+  (new { def field[T](implicit ts: List[T]) = 0; def field_=[T](i: Int)(implicit ts: List[T]) = () }).field = 5
+  (new { def field[T](implicit ts: List[T]) = 0; def field_=[T](i: T)(implicit ts: List[T]) = () }).field = 5
 }


### PR DESCRIPTION
Follow-up to fb061f22d4c35df626d9651e017820a11f8fe56e
which allowed the type param only.

Reported:
```
scala> object Test {
     |   def a[R](implicit s: List[R]):Int = 0
     |   def a_=[R](v: Int)(implicit s: List[R]) = ()
     | }
```