### PR TITLE
SI-6714 Update assignment preserves apply args

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4781,14 +4781,18 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               mkAssign(Select(qq1, vname) setPos qual.pos)
             }
 
+          case Apply(fn, extra) if qual.isInstanceOf[ApplyToImplicitArgs] =>
+            fn match {
+              case treeInfo.Applied(Select(table, nme.apply), _, indices :: Nil) =>
+                // table(indices)(implicits)
+                mkUpdate(table, indices, extra :: Nil)
+              case _  => UnexpectedTreeAssignmentConversionError(qual)
+            }
+
           case Apply(fn, indices) =>
             fn match {
-              case treeInfo.Applied(Select(table, nme.apply), _, argss) =>
-                if (argss.isEmpty) mkUpdate(table, indices, Nil)
-                else {
-                  // table(indices)(cruft)(implicits)
-                  mkUpdate(table, argss.head, argss.drop(1) :+ indices)
-                }
+              case treeInfo.Applied(Select(table, nme.apply), _, Nil) =>
+                mkUpdate(table, indices, Nil)
               case _  => UnexpectedTreeAssignmentConversionError(qual)
             }
         }

--- a/test/files/neg/t6714.check
+++ b/test/files/neg/t6714.check
@@ -1,0 +1,7 @@
+t6714.scala:19: error: Unexpected tree during assignment conversion.
+  a(1)(9000) += 20  // Not OK
+      ^
+t6714.scala:21: error: Unexpected tree during assignment conversion.
+  b(1)(5) += 20     // Not OK
+      ^
+two errors found

--- a/test/files/neg/t6714.scala
+++ b/test/files/neg/t6714.scala
@@ -1,0 +1,22 @@
+
+case class A(a: Int, index: Int) {
+  def apply(i: Int)(implicit ev: Int): A = new A(ev, i)
+  def update(i: Int, value: Int): A = if (i == index) A(i, value) else A(i, 0)
+  def +(j: Int) = a + j
+}
+
+case class B(a: Int, index: Int) {
+  def apply(i: Int)(j: Int)(implicit ev: Int): B = new B(j + ev, i)
+  def update(i: Int, value: Int): B = if (i == index) B(i, value) else B(i, 0)
+  def +(j: Int) = a + j
+}
+
+object Test extends App {
+  implicit def ev: Int = 8000
+  val a = A(5, 1)
+  a(1) = 10         // OK
+  a(1) += 20        // OK
+  a(1)(9000) += 20  // Not OK
+  val b = B(5, 1)
+  b(1)(5) += 20     // Not OK
+}

--- a/test/files/run/t6714.scala
+++ b/test/files/run/t6714.scala
@@ -5,25 +5,15 @@ case class A(a: Int, index: Int) {
   def +(j: Int) = a + j
 }
 
-case class B(a: Int, index: Int) {
-  def apply(i: Int)(j: Int)(implicit ev: Int): B = new B(j + ev, i)
-  def update(i: Int, value: Int): B = if (i == index) B(i, value) else B(i, 0)
-  def +(j: Int) = a + j
-}
-
 object Test extends App {
   def checkA(x: A, y: Int, z: Int) = assert(x == A(y, z))
-  def checkB(x: B, y: Int, z: Int) = assert(x == B(y, z))
   implicit def ev: Int = 8000
   val a = A(5, 1)
   checkA(a(1) = 10, 1, 10)
   checkA(a(1) += 20, 1, 8020)
-  val b = B(5, 1)
-  checkB(b(1)(5) += 20, 1, 8025)
 }
 
 /*
  A(1,10)
  A(1,8020) // was A(8000,0)
- B(1,8025)
  */

--- a/test/files/run/t6714.scala
+++ b/test/files/run/t6714.scala
@@ -1,0 +1,29 @@
+
+case class A(a: Int, index: Int) {
+  def apply(i: Int)(implicit ev: Int): A = new A(ev, i)
+  def update(i: Int, value: Int): A = if (i == index) A(i, value) else A(i, 0)
+  def +(j: Int) = a + j
+}
+
+case class B(a: Int, index: Int) {
+  def apply(i: Int)(j: Int)(implicit ev: Int): B = new B(j + ev, i)
+  def update(i: Int, value: Int): B = if (i == index) B(i, value) else B(i, 0)
+  def +(j: Int) = a + j
+}
+
+object Test extends App {
+  def checkA(x: A, y: Int, z: Int) = assert(x == A(y, z))
+  def checkB(x: B, y: Int, z: Int) = assert(x == B(y, z))
+  implicit def ev: Int = 8000
+  val a = A(5, 1)
+  checkA(a(1) = 10, 1, 10)
+  checkA(a(1) += 20, 1, 8020)
+  val b = B(5, 1)
+  checkB(b(1)(5) += 20, 1, 8025)
+}
+
+/*
+ A(1,10)
+ A(1,8020) // was A(8000,0)
+ B(1,8025)
+ */


### PR DESCRIPTION
Previously, extra arg lists to apply were ignored
when transforming to update. In particular, apply
could have an implicit param list, which might be
supplied explicitly. Just keep any and all params
in the expression passed to update. Indices are
always the first arg list.