### PR TITLE
Adds three Java 8 new Constant Pool structures to scalap.

### DIFF
--- a/src/scalap/scala/tools/scalap/Classfile.scala
+++ b/src/scalap/scala/tools/scalap/Classfile.scala
@@ -79,6 +79,9 @@ class Classfile(in: ByteArrayReader) {
     case class DoubleConst(x: Double) extends PoolEntry(CONSTANT_DOUBLE)
     case class NameAndType(nameId: Int, typeId: Int) extends PoolEntry(CONSTANT_NAMEANDTYPE)
     case object Empty extends PoolEntry(0) { }
+    case class MethodHandle(kindId: Int, refId: Int) extends PoolEntry(CONSTANT_METHODHANDLE)
+    case class InvokeDynamic(bootMethodId: Int, nameTypeId: Int) extends PoolEntry(CONSTANT_INVDYNAMIC)
+    case class MethodType(descId: Int) extends PoolEntry(CONSTANT_METHODTYPE)
 
     val entries = {
       val pool = new Array[PoolEntry](in.nextChar.toInt)
@@ -102,6 +105,9 @@ class Classfile(in: ByteArrayReader) {
           case CONSTANT_NAMEANDTYPE     => NameAndType(in.nextChar, in.nextChar)
           case CONSTANT_INTEGER         => IntegerConst(in.nextInt)
           case CONSTANT_FLOAT           => FloatConst(in.nextFloat)
+          case CONSTANT_METHODHANDLE    => MethodHandle(in.nextByte, in.nextChar)
+          case CONSTANT_METHODTYPE      => MethodType(in.nextChar)
+          case CONSTANT_INVDYNAMIC      => InvokeDynamic(in.nextChar, in.nextChar)
         }
 
         i += 1

--- a/src/scalap/scala/tools/scalap/Classfiles.scala
+++ b/src/scalap/scala/tools/scalap/Classfiles.scala
@@ -26,6 +26,9 @@ object Classfiles {
   final val CONSTANT_METHODREF = 10
   final val CONSTANT_INTFMETHODREF = 11
   final val CONSTANT_NAMEANDTYPE = 12
+  final val CONSTANT_METHODHANDLE = 15
+  final val CONSTANT_METHODTYPE = 16
+  final val CONSTANT_INVDYNAMIC = 18
 
   final val constantTagToString = Map(
     CONSTANT_UTF8 -> "UTF8",
@@ -39,7 +42,10 @@ object Classfiles {
     CONSTANT_FIELDREF -> "Field",
     CONSTANT_METHODREF -> "Method",
     CONSTANT_INTFMETHODREF -> "InterfaceMethod",
-    CONSTANT_NAMEANDTYPE -> "NameAndType"
+    CONSTANT_NAMEANDTYPE -> "NameAndType",
+    CONSTANT_METHODHANDLE -> "MethodHandle",
+    CONSTANT_METHODTYPE -> "MethodType",
+    CONSTANT_INVDYNAMIC -> "InvokeDynamic"
   )
 }
 


### PR DESCRIPTION
There are three new structures in Constant Pool added in Java 8 and not understand by Scalap which reveal by `MatchError` when `pool` is constructed. To verify current scalap behavior with error run please: `scalap -verbose scala.Array$`.