### PR TITLE
SI-884, allow type arguments on patterns.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/MatchRewriter.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/MatchRewriter.scala
@@ -1,0 +1,113 @@
+package scala.tools.nsc
+package ast.parser
+
+class MatchRewriter[G <: scala.tools.nsc.Global](val global: G) {
+  import global._
+
+  /** Entry point. */
+  object rewrite extends Transformer {
+    def apply(t: Tree): Tree = {
+      logResult("Transforming: " + t)(transform(t))
+    }
+    override def transform(t: Tree): Tree = t match {
+      case m: Match => new TranslateMatch(super.transform(m).asInstanceOf[Match]) resultTree
+      case _        => super.transform(t)
+    }
+  }
+
+  object CaseDecompose {
+    /** That's right, the compiler generates a wrong AppliedTypeTree
+     *  instead of a TypeApply tree when there are type args in a pattern.
+     *  "We can rebuild it... we have the technology."
+     *
+     *  Unfortunately fixing it at the source revealed many other
+     *  points in the compiler which depend on things happening as
+     *  they presently do. You, dear reader, are welcome to try it.
+     */
+    def makeTermTree(t: Tree): Tree = t match {
+      case AppliedTypeTree(fun, args) => TypeApply(makeTermTree(fun), args)
+      case Select(qual, name)         => Select(makeTermTree(qual), name.toTermName)
+      case Ident(name)                => Ident(name.toTermName)
+    }
+    def unapply(t: Tree) = t match {
+      case CaseDef(Apply(AppliedTypeTree(fun, targs), patternVars), guard, expr) =>
+        Some((makeTermTree(fun), targs, patternVars, guard, expr))
+      case CaseDef(Apply(fn, patternVars), guard, expr) =>
+        Some((fn, Nil, patternVars, guard, expr))
+      case CaseDef(pat, guard, expr) =>
+        Some((pat, Nil, Nil, guard, expr))
+      case _ =>
+        None
+    }
+  }
+
+  class TranslateMatch(m: Match) {
+    val Match(expr, cases) = m
+
+    /** The list of valdefs to prepend to the rewritten match. */
+    var valDefs = Vector[Tree]()
+
+    /** Memoize the scrutinee expression. */
+    lazy val exprVal = currentUnit.freshTermName("Scrutinee")
+    lazy val expr1   = q"val $exprVal = $expr"
+
+    /** The transformed cases, side effecting valDefs as we go. */
+    val cases1 = cases map (x => (TranslateCaseDefs transform x).asInstanceOf[CaseDef])
+
+    /** The rewritten pattern match, if any type argument patterns were pulled out. */
+    val resultTree = valDefs match {
+      case Seq() => m
+      case _     => q"{ $expr1 ; ..$valDefs ; $exprVal match { case ..$cases1 } }"
+    }
+
+    object TranslateCaseDefs extends Transformer {
+      def apply(cd: CaseDef): CaseDef = transform(cd).asInstanceOf[CaseDef]
+
+      override def transform(t: Tree): Tree = t match {
+        case CaseDecompose(selector, targs, patternVars, guard, rhs) if targs.nonEmpty =>
+          log(s"CaseDecompose($selector, $targs, $patternVars, $guard, $rhs")
+
+          val stableName   = currentUnit.freshTermName("TypeArgsPattern")
+          val unapplyCall  = q"$selector.unapply[..$targs]($exprVal)"
+          val stableValDef = q"lazy val $stableName = $unapplyCall"
+
+          def isMatch: Tree = patternVars.size match {
+            case 0 => q"$stableName"
+            case _ => q"!$stableName.isEmpty"
+          }
+          def accessorTree(n: Int): Tree = patternVars match {
+            case Seq()  => q"()"
+            case Seq(_) => q"$stableName.get"
+            case _      => val acc = TermName("_" + ( n + 1 )) ; q"$stableName.get.$acc"
+          }
+
+          val newGuard = if (guard.isEmpty) isMatch else q"$isMatch && $guard"
+          val preRhs   = (
+            for ((pat, i) <- patternVars.zipWithIndex) yield
+              unBlockOne(q"val $pat = ${ accessorTree(i) }")
+          )
+          val allRhs = preRhs :+ rhs flatMap unBlock
+          valDefs    = valDefs :+ stableValDef
+
+          logResult("Rewrote CaseDef")(cq"_ if $newGuard => ..$allRhs")
+
+        case _ => super.transform(t)
+      }
+    }
+  }
+
+  object BlockStats {
+    def unapply(t: Tree): Option[List[Tree]] = t match {
+      case Block(stats, EmptyTree | Literal(Constant(()))) => Some(stats)
+      case _                                               => None
+    }
+  }
+  def unBlockOne(t: Tree): Tree = t match {
+    case BlockStats(stat :: Nil) => stat
+    case _                       => t
+  }
+  def unBlock(t: Tree): List[Tree] = t match {
+    case BlockStats(stats) => stats
+    case t                 => List(t)
+  }
+}

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -34,6 +34,10 @@ trait ParsersCommon extends ScannersCommon { self =>
   def newLiteral(const: Any) = Literal(Constant(const))
   def literalUnit            = gen.mkSyntheticUnit()
 
+  // Pulls type applications at extractor call sites into lazy vals
+  // which precede the match.
+  lazy val matchRewriter = new MatchRewriter[self.global.type](global)
+
   /** This is now an abstract class, only to work around the optimizer:
    *  methods in traits are never inlined.
    */
@@ -1569,7 +1573,7 @@ self =>
               }
             }
           } else if (in.token == MATCH) {
-            t = atPos(t.pos.start, in.skipToken())(Match(stripParens(t), inBracesOrNil(caseClauses())))
+            t = atPos(t.pos.start, in.skipToken())(matchRewriter.rewrite(Match(stripParens(t), inBracesOrNil(caseClauses()))))
           }
           // in order to allow anonymous functions as statements (as opposed to expressions) inside
           // templates, we have to disambiguate them from self type declarations - bug #1565
@@ -1766,7 +1770,7 @@ self =>
      */
     def blockExpr(): Tree = atPos(in.offset) {
       inBraces {
-        if (in.token == CASE) Match(EmptyTree, caseClauses())
+        if (in.token == CASE) matchRewriter.rewrite(Match(EmptyTree, caseClauses()))
         else block()
       }
     }
@@ -2243,7 +2247,7 @@ self =>
       val vds   = new ListBuffer[List[ValDef]]
       val start = in.offset
       def paramClause(): List[ValDef] = if (in.token == RPAREN) Nil else {
-        val implicitmod = 
+        val implicitmod =
           if (in.token == IMPLICIT) {
             if (implicitOffset == -1) { implicitOffset = in.offset ; implicitSection = vds.length }
             else if (warnAt == -1) warnAt = in.offset

--- a/test/files/neg/gadts1.check
+++ b/test/files/neg/gadts1.check
@@ -1,9 +1,16 @@
-gadts1.scala:20: error: Test.Cell[a] does not take parameters
+gadts1.scala:17: error: type mismatch;
+ found   : Test.Term[a(in method f)]
+ required: Test.Cell[a(in lazy value TypeArgsPattern1)]
+  t match {
+    ^
+gadts1.scala:20: error: type mismatch;
+ found   : Any
+ required: Test.Int
     case Cell[a](x: Int) => c.x = 5
-                ^
+                 ^
 gadts1.scala:20: error: type mismatch;
  found   : Int(5)
  required: a
     case Cell[a](x: Int) => c.x = 5
                                   ^
-two errors found
+three errors found

--- a/test/files/neg/t7877.check
+++ b/test/files/neg/t7877.check
@@ -1,7 +1,7 @@
+t7877.scala:4: error: not found: value OnNext
+  (null: Any) match {
+              ^
 t7877.scala:6: error: not found: value Y
     case Y() => ()             // not allowed
          ^
-t7877.scala:7: error: OnNext[Any] does not take parameters
-    case OnNext[Any]() => ()   // should *not* be allowed, but was.
-                    ^
 two errors found

--- a/test/files/run/t884.check
+++ b/test/files/run/t884.check
@@ -1,0 +1,22 @@
+optImplicitTest
+Show[Int]
+Eq[Int]
+Nothing
+fromStringTest
+(Int,55)
+(Double,99)
+((Double,Double),57)
+(Unknown,0)
+associatedIntTest
+abcdefghijklmnopqrstuvwxyz: String -> 26
+true: Boolean -> 1
+false: Boolean -> 0
+Array[Boolean] -> 3
+71: Int -> 4
+981: Long -> 8
+Array[Int] -> 16
+Array[Long] -> 40
+whatListTest
+string
+int
+blub

--- a/test/files/run/t884.flags
+++ b/test/files/run/t884.flags
@@ -1,0 +1,1 @@
+-language:_

--- a/test/files/run/t884.scala
+++ b/test/files/run/t884.scala
@@ -1,0 +1,174 @@
+import scala.util.Try
+
+import scala.reflect.runtime.{ universe => ru }
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val p = new PatternTests
+    p.optImplicitTest
+    p.fromStringTest
+    p.associatedIntTest
+    p.whatListTest
+  }
+}
+
+class PatternTests {
+  private def optimp[A](x: A)(implicit SA: OptImp[Show[A]], SE: OptImp[Eq[A]]): String = x match {
+    case OptImp[Show](z) => "Show[Int]"
+    case OptImp[Eq](z)   => "Eq[Int]"
+    case _               => "Nothing"
+  }
+
+  /** Demonstrating the conversion of the scrutinee into
+   *  various types and arities based on the supplied type args.
+   */
+  private def fromString(s: String): (String, Int) = s match {
+    case FromString[Int](n)                   => "Int" -> n
+    case FromString[Double](n)                => "Double" -> n.toInt
+    case FromString[(Double, Double)]((a, b)) => "(Double,Double)" -> (a + b).toInt
+    case _                                    => "Unknown" -> 0
+  }
+
+  /** Demonstrating calculating a value based on the
+   *  supplied type argument if the scrutinee is of that type.
+   */
+  private def associatedInt(x: Any): String = x match {
+    case AssociatedInt[Boolean](n)        => s"$x: Boolean -> $n"
+    case AssociatedInt[Int](n)            => s"$x: Int -> $n"
+    case AssociatedInt[Long](n)           => s"$x: Long -> $n"
+    case AssociatedInt[String](n)         => s"$x: String -> $n"
+    case AssociatedInt[Array[Int]](n)     => s"Array[Int] -> $n"
+    case AssociatedInt[Array[Long]](n)    => s"Array[Long] -> $n"
+    case AssociatedInt[Array[Boolean]](n) => s"Array[Boolean] -> $n"
+    case AssociatedInt[Array[Float]](n)   => s"Array[Float] -> $n"
+    case _                                => s"$x: ?"
+  }
+  private def whatList[A: ru.TypeTag](xs: List[A]): String = xs match {
+    case IsType[List[String]]() => "string"
+    case IsType[List[Int]]()    => "int"
+    case _                      => "blub"
+  }
+
+  def optImplicitTest(): Unit = {
+    println("optImplicitTest");
+
+    {
+      implicit val z = new Show[Int] { }
+      println(optimp(0))
+    }
+
+    {
+      implicit val z = new Eq[Int] { }
+      println(optimp(0))
+    }
+
+    println(optimp(0))
+  }
+
+  def fromStringTest(): Unit = {
+    println("fromStringTest")
+    println(fromString("55"))
+    println(fromString("99.9"))
+    println(fromString("12.3,45.6"))
+    println(fromString("donkey"))
+  }
+
+  def associatedIntTest(): Unit = {
+    println("associatedIntTest")
+    println(associatedInt("abcdefghijklmnopqrstuvwxyz"))
+    println(associatedInt(true))
+    println(associatedInt(false))
+    println(associatedInt(Array[Boolean](true, true, true, false)))
+    println(associatedInt(71))
+    println(associatedInt(981L))
+    println(associatedInt(Array[Int](1, 2, 3, 4)))
+    println(associatedInt(Array[Long](1, 2, 3, 4, 5)))
+  }
+  def whatListTest(): Unit = {
+    println("whatListTest")
+    println(whatList(List[String]()))
+    println(whatList(List[Int]()))
+    println(whatList(List[Boolean]()))
+  }
+}
+
+/*** Auxiliary classes. ***/
+
+trait Show[A]
+trait Eq[A]
+
+sealed trait OptImp[+A] {
+  def toOption: Option[A] = this match {
+    case Empty() => scala.None
+    case Some(x) => scala.Some(x)
+  }
+}
+final case class Empty[A]() extends OptImp[A]
+final case class Some[A](x: A) extends OptImp[A]
+
+object OptImp {
+  implicit def convert[A](implicit z: A = null.asInstanceOf[A]): OptImp[A] =
+    if (z == null) Empty() else Some(z)
+
+  class Aux[F[_]] {
+    def apply[A](x: A)(implicit z: OptImp[F[A]]): Option[F[A]] = z.toOption
+  }
+
+  def unapply[F[_]]: Aux[F] = new Aux[F]
+}
+
+object IsType {
+  import scala.reflect.runtime.universe._
+
+  class Aux[A] {
+    def apply[V](x: V)(implicit vt: TypeTag[V], at: TypeTag[A]): Boolean = typeOf[V] <:< typeOf[A]
+  }
+
+  def unapply[A]: Aux[A] = new Aux[A]
+}
+
+trait FromString[A] {
+  def apply(s: String): Option[A]
+}
+object FromString {
+  def unapply[R] : Helper[R] = new Helper
+
+  def apply[A](f: String => Option[A]): FromString[A]                       = new FromString[A] { def apply(x: String) = f(x) }
+  def partial[A](pf: PartialFunction[String, A]): FromString[A]             = apply[A](pf.lift)
+  def partialFlat[A](pf: PartialFunction[String, Option[A]]): FromString[A] = apply[A](pf lift _ flatten)
+
+  implicit val intFromString: FromString[Int]       = apply(s => Try(s.toInt).toOption)
+  implicit val doubleFromString: FromString[Double] = apply(s => Try(s.toDouble).toOption)
+
+  implicit val doubleDoubleFromString: FromString[(Double, Double)] = {
+    val Regex = """^([^,]+),(.*)$""".r
+    FromString partialFlat {
+      case Regex(a, b) => Try((a.toDouble, b.toDouble)).toOption
+      case _           => None
+    }
+  }
+
+  class Helper[R] {
+    def apply(s: String)(implicit z: FromString[R]): Option[R] = z(s)
+  }
+}
+
+trait AssociatedInt[A] {
+  def associated(x: A): Int
+}
+object AssociatedInt {
+  def unapply[A] = new Helper[A]
+
+  class Helper[A] {
+    def apply(x: Any)(implicit z: AssociatedInt[A] = null): Option[Int] =
+      if (z eq null) None else Try(z associated x.asInstanceOf[A]).toOption
+  }
+
+  implicit val booleanAssoc: AssociatedInt[Boolean]                                 = make(b => if (b) 1 else 0)
+  implicit val intAssoc: AssociatedInt[Int]                                         = make(_ => 4)
+  implicit val longAssoc: AssociatedInt[Long]                                       = make(_ => 8)
+  implicit val stringAssoc: AssociatedInt[String]                                   = make(_.length)
+  implicit def arrayAssoc[A](implicit z: AssociatedInt[A]): AssociatedInt[Array[A]] = make(_ map z.associated sum)
+
+  private def make[A](f: A => Int): AssociatedInt[A] = new AssociatedInt[A] { def associated(x: A): Int = f(x) }
+}


### PR DESCRIPTION
Also offers a way to achieve the goal in SI-6517, seen in the test.

The mechanism is to rewrite casedefs which contain type applications
so that they no longer contain type applications, by pulling the
unapply call into a lazy val which precedes the match. Example using
an extractor which parses a string based on a specified type:
```scala
  expr match {
    case FromString[Int](n)                   => n
    case FromString[(Double, Double)]((a, b)) => (a + b).toInt
  }
```
becomes (with the generated names unique of course)
```scala
  {
    val Scrutinee = expr;
    lazy val TypeArgsPattern1 = FromString.unapply[Int](Scrutinee);
    lazy val TypeArgsPattern2 = FromString.unapply[(Double, Double)](Scrutinee);

    Scrutinee match {
      case _ if !TypeArgsPattern1.isEmpty =>
        val n = TypeArgsPattern1.get
        n
      case _ if !TypeArgsPattern2.isEmpty =>
        val x$1 = TypeArgsPattern2.get
        val a = x$1._1
        val b = x$1._2
        (a + b).toInt
    }
  }
```
This approach means that the various machinery which swirls around
type application should work (e.g. and especially, implicit selection.)