### PR TITLE
SI-10226 REPL handles paste when colorized

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -768,7 +768,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
     result
   }
 
-  private object paste extends Pasted(prompt) {
+  private object paste extends Pasted(replProps.promptText) {
     def interpret(line: String) = intp interpret line
     def echo(message: String)   = ILoop.this echo message
 

--- a/src/repl/scala/tools/nsc/interpreter/Pasted.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Pasted.scala
@@ -38,10 +38,9 @@ abstract class Pasted(prompt: String) {
   def matchesContinue(line: String) = matchesString(line, ContinueString)
   def running = isRunning
 
-  private def matchesString(line: String, target: String): Boolean = (
-    (line startsWith target) ||
-    (line.nonEmpty && spacey(line.head) && matchesString(line.tail, target))
-  )
+  private def matchesString(line: String, target: String): Boolean =
+    line.startsWith(target) || (line.nonEmpty && spacey(line.head) && matchesString(line.tail, target))
+
   private def stripString(line: String, target: String) = line indexOf target match {
     case -1   => line
     case idx  => line drop (idx + target.length)


### PR DESCRIPTION
Colorization or Colourisation tripped up REPL
on paste. Prompt detection should use the plain
text prompt, not the ansified prompt.

Manual test since .flags doesn't like it:

```
$ ./build/pack/bin/scala -Dscala.repl.prompt="%nhello > "
Welcome to Scala 2.12.2-20170314-033334-d0c2620 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_111).
Type in expressions for evaluation. Or try :help.

hello > 42
res0: Int = 42

hello > hello > 42

// Detected repl transcript. Paste more, or ctrl-D to finish.

hello > "wtf?"
// Replaying 2 commands from transcript.

hello > 42
res1: Int = 42

hello > "wtf?"
res2: String = wtf?

hello >

```