### PR TITLE
Use a single repository in the bootstrap job

### DIFF
--- a/scripts/jobs/integrate/bootstrap
+++ b/scripts/jobs/integrate/bootstrap
@@ -3,7 +3,7 @@
 # Script Overview
 #  - determine scala version
 #  - determine module versions
-#  - build minimal core (aka locker) of Scala, use the determined version number, publish to scala-release-temp
+#  - build minimal core (aka locker) of Scala, use the determined version number, publish to scala-integration
 #  - build those modules where a binary compatible version doesn't exist, publish to scala-integration
 #  - build Scala using the previously built core and bootstrap modules, publish to scala-integration
 #  - for releases
@@ -98,15 +98,10 @@ mkdir -p $baseDir/ivy2
 rm -rf $baseDir/resolutionScratch_
 mkdir -p $baseDir/resolutionScratch_
 
-# repo for the starr and locker builds
-releaseTempRepoUrl=${releaseTempRepoUrl-"https://scala-ci.typesafe.com/artifactory/scala-release-temp/"}
-# repo for the modules and the quick build
+# repo to publish builds
 integrationRepoUrl=${integrationRepoUrl-"https://scala-ci.typesafe.com/artifactory/scala-integration/"}
 
-# the `releaseTempRepoUrl` needs to be in the repositories file to get starr when building quick and the modules.
-# `integrationRepoUrl` is there to find modules when building quick and other modules (e.g., partest requires xml).
-# the file is re-generated for running the stability test, this time with only `integrationRepoUrl`.
-generateRepositoriesConfig $releaseTempRepoUrl $integrationRepoUrl
+generateRepositoriesConfig $integrationRepoUrl
 
 # ARGH trying to get this to work on multiple versions of sbt-extras...
 # the old version (on jenkins, and I don't want to upgrade for risk of breaking other builds) honors -sbt-dir
@@ -413,7 +408,7 @@ bootstrap() {
         git clone --reference $WORKSPACE/.git $WORKSPACE/.git $STARR_DIR
         cd $STARR_DIR
         git co $STARR_REF
-        $SBT_CMD -no-colors $sbtArgs --warn "setupBootstrapStarr $releaseTempRepoUrl $STARR_VER" $clean publish >> $baseDir/logs/builds 2>&1
+        $SBT_CMD -no-colors $sbtArgs --warn "setupBootstrapStarr $integrationRepoUrl $STARR_VER" $clean publish >> $baseDir/logs/builds 2>&1
       )
   fi
 
@@ -427,7 +422,7 @@ bootstrap() {
   # publish more than just core: partest needs scalap
   # in sabbus lingo, the resulting Scala build will be used as starr to build the released Scala compiler
   if [ ! -z "$STARR_VER" ]; then SET_STARR=-Dstarr.version=$STARR_VER; fi
-  $SBT_CMD -no-colors $sbtArgs $SET_STARR --warn "setupBootstrapLocker $releaseTempRepoUrl $SCALA_VER" $clean publish >> $baseDir/logs/builds 2>&1
+  $SBT_CMD -no-colors $sbtArgs $SET_STARR --warn "setupBootstrapLocker $integrationRepoUrl $SCALA_VER" $clean publish >> $baseDir/logs/builds 2>&1
 
   echo "### Building modules using locker"
 
@@ -530,12 +525,8 @@ determineScalaVersion
 deriveModuleVersions
 
 removeExistingBuilds $integrationRepoUrl
-removeExistingBuilds $releaseTempRepoUrl
 
 bootstrap
-
-# for stability testing and sonatype publishing, use artifacts in `integrationRepoUrl`
-generateRepositoriesConfig $integrationRepoUrl
 
 if [ "$testStability" == "yes" ]
   then testStability


### PR DESCRIPTION
Recently, I changed the bootstap script to publish the "locker" build to scala-release-temp
and only the bootstrapped "quick" build to scala-integration. This commit reverts back to the
previous mechanism where "locker" is published to the same repo (scala-integration) and later
overwritten.

The reason is that we want to use scala-release-temp for publishing integration builds of commits
that are not (yet) merged to scala/scala. Such builds are useful for preliminary testing /
benchmarking of PRs / development revisions. This means that we want to add scala-release-temp
as a resolver in the community build and the benchmark job. If we have same-named releases in
both repos (one "locker", one "quick", so they are not the same), we would not know which one
is being picked up.

If we want to avoid the overwriting in the future, we could work on a solution that sets a different
version number for "locker", but we have to be careful when building the modules; maybe setting the
scalaBinaryVersion would be enough.