### PR TITLE
Improve serializability of lambdas that call methods in module

### DIFF
--- a/test/files/run/t10233.scala
+++ b/test/files/run/t10233.scala
@@ -1,0 +1,34 @@
+import java.io.{ByteArrayOutputStream, NotSerializableException, ObjectOutputStream}
+
+object Test {
+  def plus(x: Int): Int = x + 1
+  def serialize(name: String, fn: Int => Int): Unit = {
+    try {
+      val oos = new ObjectOutputStream(new ByteArrayOutputStream)
+      oos.writeObject(fn)
+    } catch {
+      case e: NotSerializableException =>
+        println(s"NotSerializableException: $name")
+        e.printStackTrace()
+    }
+  }
+  object Inner {
+    def minus(x: Int): Int = x - 1 
+    def testInner(): Unit = {
+      serialize("plus", plus)
+      serialize("this.plus", Test.this.plus)
+      serialize("Test.plus", Test.plus)
+
+      serialize("minus", minus)
+      serialize("this.minus", this.minus)
+      serialize("Inner.minus", Inner.minus)
+    }
+  }
+  def main(args: Array[String]): Unit = {
+    serialize("plus", plus)
+    serialize("this.plus", this.plus)
+    serialize("Test.plus", Test.plus)
+
+    Inner.testInner()
+  }
+}


### PR DESCRIPTION
Depending on how it is written, a reference to an member of an
enclosing module can be either be qualified by `This(moduleClass)`
or by `Ident(module)`. The former was causing a unnecsseary capture
of the module class.

This commit substitutes eligible `this` references when lifting
the closure body into a method.

Fixes scala/bug#10233 