### PR TITLE
SI-10231 Skip outer parameter when classfile parsing java param names

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -553,6 +553,7 @@ abstract class ClassfileParser {
         val name = readName()
         val sym = ownerForFlags(jflags).newMethod(name.toTermName, NoPosition, sflags)
         var info = pool.getType(sym, u2)
+        var removedOuterParameter = false
         if (name == nme.CONSTRUCTOR)
           info match {
             case MethodType(params, restpe) =>
@@ -567,6 +568,7 @@ abstract class ClassfileParser {
                    * ClassfileParser for 1 executes, and clazz.owner is the package.
                    */
                   assert(params.head.tpe.typeSymbol == clazz.owner || clazz.owner.hasPackageFlag, params.head.tpe.typeSymbol + ": " + clazz.owner)
+                  removedOuterParameter = true
                   params.tail
                 case _ =>
                   params
@@ -586,7 +588,7 @@ abstract class ClassfileParser {
         // parsed from SignatureATTR
         sym setInfo info
         propagatePackageBoundary(jflags, sym)
-        parseAttributes(sym, info)
+        parseAttributes(sym, info, removedOuterParameter)
         if (jflags.isVarargs)
           sym modifyInfo arrayToRepeated
 
@@ -769,7 +771,7 @@ abstract class ClassfileParser {
     GenPolyType(ownTypeParams, tpe)
   } // sigToType
 
-  def parseAttributes(sym: Symbol, symtype: Type) {
+  def parseAttributes(sym: Symbol, symtype: Type, removedOuterParameter: Boolean = false) {
     def convertTo(c: Constant, pt: Type): Constant = {
       if (pt.typeSymbol == BooleanClass && c.tag == IntTag)
         Constant(c.value != 0)
@@ -804,16 +806,24 @@ abstract class ClassfileParser {
           else devWarning(s"failure to convert $c to $symtype")
         case tpnme.MethodParametersATTR =>
           def readParamNames(): Unit = {
-            import tools.asm.Opcodes.ACC_SYNTHETIC
+            import scala.tools.asm.Opcodes.ACC_SYNTHETIC
             val paramCount = u1
             var i = 0
+            if (removedOuterParameter && i < paramCount) {
+              in.skip(4)
+              i += 1
+            }
+            var remainingParams = sym.paramss.head // Java only has exactly one parameter list
             while (i < paramCount) {
               val name = pool.getName(u2)
               val access = u2
-              if ((access & ACC_SYNTHETIC) != ACC_SYNTHETIC) { // name not synthetic
-                val params = sym.paramss.head // Java only has exactly one parameter list
-                params(i).name = name.encode
-                params(i).resetFlag(SYNTHETIC)
+              if (remainingParams.nonEmpty) {
+                val param = remainingParams.head
+                remainingParams = remainingParams.tail
+                if ((access & ACC_SYNTHETIC) != ACC_SYNTHETIC) { // name not synthetic
+                  param.name = name.encode
+                  param.resetFlag(SYNTHETIC)
+                }
               }
               i += 1
             }

--- a/test/files/run/t10231/A_1.java
+++ b/test/files/run/t10231/A_1.java
@@ -1,0 +1,11 @@
+/*
+ * javac: -parameters
+ */
+public class A_1 {
+  public class Inner {
+    public int x;
+    public Inner(int i) {
+      x = i;
+    }
+  }
+}

--- a/test/files/run/t10231/Test_2.scala
+++ b/test/files/run/t10231/Test_2.scala
@@ -1,0 +1,5 @@
+object Test extends App {
+  val a = new A_1
+  val i = new a.Inner(i = 99)
+  assert(i.x == 99)
+}


### PR DESCRIPTION
Nested java classes have a synthetic outer parameter, which the classfile parser
skips for the constructor symbol. When assigning parameter names from the
MethodParameters classfile attribute, we also need to skip the first name in this
case.

JIRA: https://issues.scala-lang.org/browse/SI-10231