### PR TITLE
SI-10240 Better pos for infix type arg

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -824,7 +824,10 @@ self =>
 
       def mkSelection(t: Tree) = {
         def sel = atPos(opPos union t.pos)(Select(stripParens(t), op.encode))
-        if (targs.isEmpty) sel else atPos(left.pos)(TypeApply(sel, targs))
+        if (targs.isEmpty) sel
+        else atPos(sel.pos union targs.last.pos withPoint sel.pos.point) {
+          TypeApply(sel, targs)
+        }
       }
       def mkNamed(args: List[Tree]) = if (isExpr) args map treeInfo.assignmentToMaybeNamedArg else args
       val arguments = right match {

--- a/test/files/pos/dotless-targs-ranged.flags
+++ b/test/files/pos/dotless-targs-ranged.flags
@@ -1,0 +1,1 @@
+-Yrangepos:true

--- a/test/files/pos/dotless-targs-ranged.scala
+++ b/test/files/pos/dotless-targs-ranged.scala
@@ -1,0 +1,15 @@
+class A {
+  def fn1 = List apply 1
+  def fn2 = List apply[Int] 2
+
+  def g1: Char = "g1" toList 0
+  def g2: Char = "g2" apply 1
+
+  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+
+  def op[A, B](i: Int): Int = 2*i
+
+  def eval = 1 ->[Int] 2
+  def evil = new A() op  [Int,   String     ]  42
+}
+


### PR DESCRIPTION
The range position for the type apply in `1 ->[Int] 2`
should include the last type arg.

It would be nice to include the right bracket.