### PR TITLE
Respell elidable checking function and make more similar to namesake

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -414,17 +414,16 @@ abstract class UnCurry extends InfoTransform
       def isLiftedLambdaMethod(funSym: Symbol) =
         funSym.isArtifact && funSym.name.containsName(nme.ANON_FUN_NAME) && funSym.isLocalToBlock
 
-      def checkIsElisible(sym: Symbol): Boolean =
-        (sym ne null) && sym.elisionLevel.exists { level =>
+      def checkIsElidable(sym: Symbol): Boolean = (sym ne null) && sym.elisionLevel.exists { level =>
           if (sym.isMethod) level < settings.elidebelow.value
           else {
-            if (settings.isScala213) reporter.error(sym.pos, s"${sym.name}: Only methods can be marked @elidable!")
+            if (settings.isScala213) reporter.error(sym.pos, s"${sym.name}: Only methods can be marked @elidable.")
             false
           }
         }
 
       val result =
-        if (checkIsElisible(sym))
+        if (checkIsElidable(sym))
           replaceElidableTree(tree)
         else translateSynchronized(tree) match {
           case dd @ DefDef(mods, name, tparams, _, tpt, rhs) =>

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1413,11 +1413,11 @@ abstract class RefChecks extends Transform {
         transformTrees(annots flatMap (_.args))
       }
 
-      def checkIsElisible(sym: Symbol) = if (sym ne null) sym.elisionLevel.foreach { level =>
+      def checkIsElidable(sym: Symbol): Unit = if (sym ne null) sym.elisionLevel.foreach { level =>
         if (!sym.isMethod || sym.isAccessor || sym.isLazy || sym.isDeferred)
           reporter.error(sym.pos, s"${sym.name}: Only methods can be marked @elidable.")
       }
-      if (settings.isScala213) checkIsElisible(tree.symbol)
+      if (settings.isScala213) checkIsElidable(tree.symbol)
 
       tree match {
         case m: MemberDef =>


### PR DESCRIPTION
The layout and message edits bring out the similarity of the methods.