### PR TITLE
Use the correct Context in AmbiguousImplicitError

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1293,7 +1293,7 @@ trait ContextErrors {
           case _ => Nil
         }
 
-        context.issueAmbiguousError(AmbiguousImplicitTypeError(tree,
+        context0.issueAmbiguousError(AmbiguousImplicitTypeError(tree,
           (info1.sym, info2.sym) match {
             case (ImplicitAmbiguousMsg(msg), _) => msg.format(treeTypeArgs(tree1))
             case (_, ImplicitAmbiguousMsg(msg)) => msg.format(treeTypeArgs(tree2))


### PR DESCRIPTION
`context0` is the `Context` passed as an argument to `AmbiguousImplicitError` whereas `context` is the `var context` inherited from `Typer` via the self type of `ImplicitSearch`.

I believe that the intention was that the argument, `context0`, be used as the target for `issueAmbiguousError` but that the error was missed because the only current call site passes in the typer context anyway.

This has tripped me up now, because I've been attempting to use `AmbiguousImplicitError` with a different context (with a different value for `ambiguousErrors`) and it has been completely ignored.

All (par)test pass.