### PR TITLE
Consistify trailing punctuation in spec

### DIFF
--- a/spec/03-types.md
+++ b/spec/03-types.md
@@ -507,7 +507,7 @@ Assume the class definitions
 
 ```scala
 class Ref[T]
-abstract class Outer { type T } .
+abstract class Outer { type T }
 ```
 
 Here are some examples of existential types:
@@ -530,7 +530,7 @@ Ref[_ <: java.lang.Number]
 The type `List[List[_]]` is equivalent to the existential type
 
 ```scala
-List[List[t] forSome { type t }] .
+List[List[t] forSome { type t }]
 ```
 
 ###### Example

--- a/spec/04-basic-declarations-and-definitions.md
+++ b/spec/04-basic-declarations-and-definitions.md
@@ -91,7 +91,7 @@ expands to
 ```scala
 case object Red extends Color
 case object Green extends Color
-case object Blue extends Color .
+case object Blue extends Color
 ```
 -->
 
@@ -144,7 +144,7 @@ value definition `val $p$ = $e$` is expanded as follows:
 val $\$ x$ = $e$ match {case $p$ => ($x_1 , \ldots , x_n$)}
 val $x_1$ = $\$ x$._1
 $\ldots$
-val $x_n$ = $\$ x$._n  .
+val $x_n$ = $\$ x$._n
 ```
 
 Here, $\$ x$ is a fresh name.

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -222,9 +222,14 @@ the linearization of class `D` is `{D, B, A, Root}`.
 Then we have:
 
 ```scala
-(new A).superA == "Root",
-                          (new C).superB = "Root", (new C).superC = "B",
-(new D).superA == "Root", (new D).superB = "A",    (new D).superD = "B",
+(new A).superA == "Root"
+
+(new C).superB == "Root"
+(new C).superC == "B"
+
+(new D).superA == "Root"
+(new D).superB == "A"
+(new D).superD == "B"
 ```
 
 Note that the `superB` function returns different results

--- a/spec/07-implicits.md
+++ b/spec/07-implicits.md
@@ -155,7 +155,7 @@ sort(yss)
 The call above will be completed by passing two nested implicit arguments:
 
 ```scala
-sort(yss)(xs: List[Int] => list2ordered[Int](xs)(int2ordered)) .
+sort(yss)(xs: List[Int] => list2ordered[Int](xs)(int2ordered))
 ```
 
 The possibility of passing implicit arguments to implicit arguments
@@ -218,7 +218,7 @@ which implicit arguments are searched is
 
 ```scala
 List[List[Int]] => Ordered[List[List[Int]]],
-List[Int] => Ordered[List[Int]]
+List[Int] => Ordered[List[Int]],
 Int => Ordered[Int]
 ```
 
@@ -290,7 +290,7 @@ or the call-by-name category).
 Class `scala.Ordered[A]` contains a method
 
 ```scala
-  def <= [B >: A](that: B)(implicit b2ordered: B => Ordered[B]): Boolean .
+  def <= [B >: A](that: B)(implicit b2ordered: B => Ordered[B]): Boolean
 ```
 
 Assume two lists `xs` and `ys` of type `List[Int]`


### PR DESCRIPTION
Three types of change,

 - Drop trailing comma on some lists
 - Add missed commas on some lists
 - Drop `  .` on some examples
 - Correct =/== on linearization examples

I have assumed trailing `  .` in `scala` examples was not significant - I couldn't infer any meaning in it but happy to be corrected.

## TODO
 - [x] Address linearization comments
 - [x] Address comments