### PR TITLE
Implement ListBuffer.isEmpty / nonEmpty / head efficiently

### DIFF
--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -119,6 +119,10 @@ final class ListBuffer[A]
   // Don't use the inherited size, which forwards to a List and is O(n).
   override def size = length
 
+  // Override with efficient implementations using the extra size information available to ListBuffer.
+  override def isEmpty: Boolean = len == 0
+  override def nonEmpty: Boolean = len > 0
+
   // Implementations of abstract methods in Buffer
 
   override def apply(n: Int): A =


### PR DESCRIPTION
Uses the extra length information in comparison to list to provide efficient implementations.

Evaluating these three methods turns up with about 6-7% of akka-http message parsing.

From the profiles it looks the likely reason are polymorphic invokeinterface calls against List (i.e. just forwarding to `start.isEmpty` etc wouldn't help).