### PR TITLE
Set scala.binary.version to 2.12 until 2.13.0-M1 is out

### DIFF
--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -163,10 +163,7 @@ object VersionUtil {
   /** Build a dependency to a Scala module with the given group and artifact ID */
   def scalaDep(group: String, artifact: String, versionProp: String = null, scope: String = null, compatibility: String = "binary") = {
     val vp = if(versionProp eq null) artifact else versionProp
-    // TODO for 2.13.0-M1 -- eventually it will no longer work to use 2.12 modules,
-    // but at the moment, there aren't any 2.13.0-M1 modules to use yet, so hardcode 2.12 for now.
-    // val m = group % (artifact + "_" + versionProps(s"scala.$compatibility.version")) % versionNumber(vp)
-    val m = group % (artifact + "_2.12") % versionNumber(vp)
+    val m = group % (artifact + "_" + versionProps(s"scala.$compatibility.version")) % versionNumber(vp)
     val m2 = if(scope eq null) m else m % scope
     // exclusion of the scala-library transitive dependency avoids eviction warnings during `update`:
     m2.exclude("org.scala-lang", "*")

--- a/versions.properties
+++ b/versions.properties
@@ -9,7 +9,7 @@ starr.version=2.12.1
 # that binary compatibility does not break. For example, after releasing 2.12.0-M1, we continue
 # using scala-partest_2.12.0-M1 until releasing M2. Manual intervention is necessary for changes
 # that break binary compatibility, see for example PR #5003.
-scala.binary.version=2.13.0-M1
+scala.binary.version=2.12
 
 # These are the versions of the modules that go with this release.
 # Artifact dependencies:


### PR DESCRIPTION
The current override in VersionUtil hard-codes the binary version
to `2.12`, which means that the `-Dscala.binary.version` override
in the bootstrap script does not have its intended effect. So we
were in fact using the 2.12 binary modules also when testing the
boostrapped 2.13 builds.