### PR TITLE
Make ImplicitInfo hashCode consistent with equals.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -255,7 +255,10 @@ trait Implicits {
           this.sym == that.sym
       case _ => false
     }
-    override def hashCode = name.## + pre.## + sym.##
+    override def hashCode = {
+      import scala.util.hashing.MurmurHash3._
+      finalizeHash(mix(mix(productSeed, name.##), sym.##), 2)
+    }
     override def toString = (
       if (tpeCache eq null) name + ": ?"
       else name + ": " + tpe

--- a/test/junit/scala/tools/nsc/typechecker/Implicits.scala
+++ b/test/junit/scala/tools/nsc/typechecker/Implicits.scala
@@ -1,0 +1,39 @@
+package scala.tools.nsc
+package typechecker
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.BytecodeTesting
+
+@RunWith(classOf[JUnit4])
+class ImplicitsTests extends BytecodeTesting {
+  import compiler.global._, definitions._, analyzer._
+
+  @Test
+  def implicitInfoHashCode(): Unit = {
+    val run = new global.Run
+
+    enteringPhase(run.typerPhase) {
+      val T0 = IntClass.tpeHK
+      val T1 = refinedType(List(T0), NoSymbol)
+
+      assert(T0 =:= T1)
+      assert(T0 != T1)
+      assert(T0.hashCode != T1.hashCode)
+
+      val I0 = new ImplicitInfo(TermName("dummy"), T0, NoSymbol)
+      val I1 = new ImplicitInfo(TermName("dummy"), T1, NoSymbol)
+
+      assert(I0 == I1)
+      assert(I0.hashCode == I1.hashCode)
+
+      val pHash = (TermName("dummy"), NoSymbol).hashCode
+
+      assert(I0.hashCode == pHash)
+      assert(I1.hashCode == pHash)
+    }
+  }
+}


### PR DESCRIPTION
`equals` on `ImplicitInfo` is defined in terms of `=:=` on types,
```scala
override def equals(other: Any) = other match {
  case that: ImplicitInfo =>
    this.name == that.name &&
    this.pre =:= that.pre &&
    this.sym == that.sym
  case _ => false
}
```
which can identify non-equal but equivalent types. On the other hand `hashCode` is defined in terms of `##` which is unlikely to yield equal values for types which are equivalent under `=:=` but not equal,

```scala
override def hashCode = name.## + pre.## + sym.##
```
I noticed this while attempting to remove duplicates from a `List[ImplicitInfo]` using `distinct` ... the result contained multiple `ImplicitInfo`s which compared `==` because `distinct` is implemented in terms of a `HashSet`.

It's not clear to me what the impact of this bug is, but it could have an effect on the performance of the `improvesCache`.