### PR TITLE
Allow user-defined `[un]apply` in case companion

### DIFF
--- a/spec/05-classes-and-objects.md
+++ b/spec/05-classes-and-objects.md
@@ -876,10 +876,9 @@ If a type parameter section is missing in the class, it is also missing in the `
 
 If the companion object $c$ is already defined,
 the  `apply` and `unapply` methods are added to the existing object.
+If the object $c$ already has a [matching](#definition-matching)
+`apply` (or `unapply`) member, no new definition is added.
 The definition of `apply` is omitted if class $c$ is `abstract`.
-If the object $c$ already defines a [matching](#definition-matching) member of the
-same name as the synthetic member to be added, the synthetic member
-is not added (overloading or mutual recursion is allowed, however).
 
 If the case class definition contains an empty value parameter list, the
 `unapply` method returns a `Boolean` instead of an `Option` type and

--- a/spec/05-classes-and-objects.md
+++ b/spec/05-classes-and-objects.md
@@ -854,9 +854,8 @@ a `val` or `var` modifier. Hence, an accessor
 definition for the parameter is [generated](#class-definitions).
 
 A case class definition of `$c$[$\mathit{tps}\,$]($\mathit{ps}_1\,$)$\ldots$($\mathit{ps}_n$)` with type
-parameters $\mathit{tps}$ and value parameters $\mathit{ps}$ implicitly
-generates an [extractor object](08-pattern-matching.html#extractor-patterns) which is
-defined as follows:
+parameters $\mathit{tps}$ and value parameters $\mathit{ps}$ implies
+the definition of a companion object, which serves as an [extractor object](08-pattern-matching.html#extractor-patterns). It has the following shape:
 
 ```scala
 object $c$ {
@@ -873,11 +872,14 @@ each $\mathit{xs}\_i$ denotes the parameter names of the parameter
 section $\mathit{ps}\_i$, and
 $\mathit{xs}\_{11}, \ldots , \mathit{xs}\_{1k}$ denote the names of all parameters
 in the first parameter section $\mathit{xs}\_1$.
-If a type parameter section is missing in the
-class, it is also missing in the `apply` and
-`unapply` methods.
-The definition of `apply` is omitted if class $c$ is
-`abstract`.
+If a type parameter section is missing in the class, it is also missing in the `apply` and `unapply` methods.
+
+If the companion object $c$ is already defined,
+the  `apply` and `unapply` methods are added to the existing object.
+The definition of `apply` is omitted if class $c$ is `abstract`.
+If the object $c$ already defines a [matching](#definition-matching) member of the
+same name as the synthetic member to be added, the synthetic member
+is not added (overloading or mutual recursion is allowed, however).
 
 If the case class definition contains an empty value parameter list, the
 `unapply` method returns a `Boolean` instead of an `Option` type and
@@ -890,9 +892,6 @@ def unapply[$\mathit{tps}\,$]($x$: $c$[$\mathit{tps}\,$]) = x ne null
 The name of the `unapply` method is changed to `unapplySeq` if the first
 parameter section $\mathit{ps}_1$ of $c$ ends in a
 [repeated parameter](04-basic-declarations-and-definitions.html#repeated-parameters).
-If a companion object $c$ exists already, no new object is created,
-but the `apply` and `unapply` methods are added to the existing
-object instead.
 
 A method named `copy` is implicitly added to every case class unless the
 class already has a member (directly defined or inherited) with that name, or the

--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -223,7 +223,7 @@ trait MethodSynthesis {
       val methDef = factoryMeth(classDef.mods & AccessFlags | METHOD | IMPLICIT | SYNTHETIC, classDef.name.toTermName, classDef)
       val methSym = enterInScope(assignMemberSymbol(methDef))
       context.unit.synthetics(methSym) = methDef
-      methSym setInfo implicitFactoryMethodCompleter(methDef, classDef.symbol, completerOf(methDef).asInstanceOf[LockingTypeCompleter])
+      methSym setInfo implicitFactoryMethodCompleter(methDef, classDef.symbol)
     }
 
 

--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -146,8 +146,8 @@ trait MethodSynthesis {
         // if there's no field symbol, the ValDef tree receives the getter symbol and thus is not a synthetic
         if (fieldSym != NoSymbol) {
           context.unit.synthetics(getterSym) = getter.derivedTree(getterSym)
-          getterSym setInfo namer.accessorTypeCompleter(tree, tree.tpt.isEmpty, isBean = false, isSetter = false)
-        } else getterSym setInfo namer.valTypeCompleter(tree)
+          getterSym setInfo new namer.AccessorTypeCompleter(tree, tree.tpt.isEmpty, isBean = false, isSetter = false)
+        } else getterSym setInfo new namer.ValTypeCompleter(tree)
 
         enterInScope(getterSym)
 
@@ -155,17 +155,17 @@ trait MethodSynthesis {
           val setter = Setter(tree)
           val setterSym = setter.createSym
           context.unit.synthetics(setterSym) = setter.derivedTree(setterSym)
-          setterSym setInfo namer.accessorTypeCompleter(tree, tree.tpt.isEmpty, isBean = false, isSetter = true)
+          setterSym setInfo new namer.AccessorTypeCompleter(tree, tree.tpt.isEmpty, isBean = false, isSetter = true)
           enterInScope(setterSym)
         }
 
         // TODO: delay emitting the field to the fields phase (except for private[this] vals, which only get a field and no accessors)
         if (fieldSym != NoSymbol) {
-          fieldSym setInfo namer.valTypeCompleter(tree)
+          fieldSym setInfo new namer.ValTypeCompleter(tree)
           enterInScope(fieldSym)
         }
       } else {
-        getterSym setInfo namer.valTypeCompleter(tree)
+        getterSym setInfo new namer.ValTypeCompleter(tree)
         enterInScope(getterSym)
       }
 
@@ -208,11 +208,11 @@ trait MethodSynthesis {
           sym
         }
 
-        val getterCompleter = namer.accessorTypeCompleter(tree, missingTpt, isBean = true, isSetter = false)
+        val getterCompleter = new namer.AccessorTypeCompleter(tree, missingTpt, isBean = true, isSetter = false)
         enterInScope(deriveBeanAccessor(if (hasBeanProperty) "get" else "is") setInfo getterCompleter)
 
         if (tree.mods.isMutable) {
-          val setterCompleter = namer.accessorTypeCompleter(tree, missingTpt, isBean = true, isSetter = true)
+          val setterCompleter = new namer.AccessorTypeCompleter(tree, missingTpt, isBean = true, isSetter = true)
           enterInScope(deriveBeanAccessor("set") setInfo setterCompleter)
         }
       }

--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -221,7 +221,7 @@ trait MethodSynthesis {
 
     def enterImplicitWrapper(classDef: ClassDef): Unit = {
       val methDef = factoryMeth(classDef.mods & AccessFlags | METHOD | IMPLICIT | SYNTHETIC, classDef.name.toTermName, classDef)
-      val methSym = assignAndEnterSymbol(methDef)
+      val methSym = enterInScope(assignMemberSymbol(methDef))
       context.unit.synthetics(methSym) = methDef
       methSym setInfo implicitFactoryMethodCompleter(methDef, classDef.symbol, completerOf(methDef).asInstanceOf[LockingTypeCompleter])
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -600,12 +600,10 @@ trait Namers extends MethodSynthesis {
     }
 
     def copyMethodCompleter(copyDef: DefDef): TypeCompleter = {
-      val sym      = copyDef.symbol
-      val lazyType = completerOf(copyDef)
-
       /* Assign the types of the class parameters to the parameters of the
-       * copy method. See comment in `Unapplies.caseClassCopyMeth` */
-      def assignParamTypes() {
+       * copy method. See comment in `Unapplies.caseClassCopyMeth`
+       */
+      def assignParamTypes(copyDef: DefDef, sym: Symbol) {
         val clazz = sym.owner
         val constructorType = clazz.primaryConstructor.tpe
         val subst = new SubstSymMap(clazz.typeParams, copyDef.tparams map (_.symbol))
@@ -618,9 +616,11 @@ trait Namers extends MethodSynthesis {
         )
       }
 
-      mkTypeCompleter(copyDef) { sym =>
-        assignParamTypes()
-        lazyType complete sym
+      new CompleterWrapper(completerOf(copyDef)) {
+        override def complete(sym: Symbol): Unit = {
+          assignParamTypes(tree.asInstanceOf[DefDef], sym)
+          super.complete(sym)
+        }
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -869,13 +869,14 @@ trait Namers extends MethodSynthesis {
 
     import AnnotationInfo.{mkFilter => annotationFilter}
 
-    def implicitFactoryMethodCompleter(tree: DefDef, classSym: Symbol, sigCompleter: LockingTypeCompleter) = mkTypeCompleter(tree) { methSym =>
-      sigCompleter.completeImpl(methSym)
+    def implicitFactoryMethodCompleter(tree: DefDef, classSym: Symbol) = new CompleterWrapper(completerOf(tree)) {
+      override def complete(methSym: Symbol): Unit = {
+        super.complete(methSym)
+        val annotations = classSym.initialize.annotations
 
-      val annotations = classSym.initialize.annotations
-
-      methSym setAnnotations (annotations filter annotationFilter(MethodTargetClass, defaultRetention = false))
-      classSym setAnnotations (annotations filter annotationFilter(ClassTargetClass, defaultRetention = true))
+        methSym setAnnotations (annotations filter annotationFilter(MethodTargetClass, defaultRetention = false))
+        classSym setAnnotations (annotations filter annotationFilter(ClassTargetClass, defaultRetention = true))
+      }
     }
 
     // complete the type of a value definition (may have a method symbol, for those valdefs that never receive a field,

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -614,6 +614,9 @@ trait Namers extends MethodSynthesis {
     }
 
     class CompleterWrapper(completer: TypeCompleter) extends TypeCompleter {
+      // override important when completer.isInstanceOf[PolyTypeCompleter]!
+      override val typeParams = completer.typeParams
+
       val tree = completer.tree
 
       override def complete(sym: Symbol): Unit = {

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3099,8 +3099,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           || (looker.hasAccessorFlag && !accessed.hasAccessorFlag && accessed.isPrivate)
         )
 
-      def checkNoDoubleDefs: Unit = {
-        val scope = if (inBlock) context.scope else context.owner.info.decls
+      def checkNoDoubleDefs(scope: Scope): Unit = {
         var e = scope.elems
         while ((e ne null) && e.owner == scope) {
           var e1 = scope.lookupNextEntry(e)
@@ -3143,8 +3142,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         }
       }
 
-      def addSynthetics(stats: List[Tree]): List[Tree] = {
-        val scope = if (inBlock) context.scope else context.owner.info.decls
+      def addSynthetics(stats: List[Tree], scope: Scope): List[Tree] = {
         var newStats = new ListBuffer[Tree]
         var moreToAdd = true
         while (moreToAdd) {
@@ -3219,11 +3217,14 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       val stats1 = stats mapConserve typedStat
       if (phase.erasedTypes) stats1
       else {
+        val scope = if (inBlock) context.scope else context.owner.info.decls
+
         // As packages are open, it doesn't make sense to check double definitions here. Furthermore,
         // it is expensive if the package is large. Instead, such double definitions are checked in `Namers.enterInScope`
         if (!context.owner.isPackageClass)
-          checkNoDoubleDefs
-        addSynthetics(stats1)
+          checkNoDoubleDefs(scope)
+
+        addSynthetics(stats1, scope)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -24,7 +24,7 @@ trait Unapplies extends ast.TreeDSL {
   private def unapplyParamName = nme.x_0
   private def caseMods         = Modifiers(SYNTHETIC | CASE)
 
-  // In the typeCompleter (templateSig) of a case class (resp it's module),
+  // In the typeCompleter (templateSig) of a case class (resp its module),
   // synthetic `copy` (reps `apply`, `unapply`) methods are added. To compute
   // their signatures, the corresponding ClassDef is needed. During naming (in
   // `enterClassDef`), the case class ClassDef is added as an attachment to the

--- a/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
@@ -285,4 +285,18 @@ trait FindMembers {
       initBaseClasses.head.newOverloaded(tpe, members)
     }
   }
+
+  private[scala] final class HasMember(tpe: Type, name: Name, excludedFlags: Long, requiredFlags: Long) extends FindMemberBase[Boolean](tpe, name, excludedFlags, requiredFlags) {
+    private[this] var _result = false
+    override protected def result: Boolean = _result
+
+    protected def shortCircuit(sym: Symbol): Boolean = {
+      _result = true
+      true // prevents call to addMemberIfNew
+    }
+
+    // Not used
+    protected def addMemberIfNew(sym: Symbol): Unit = {}
+  }
+
 }

--- a/test/files/neg/userdefined_apply.check
+++ b/test/files/neg/userdefined_apply.check
@@ -1,0 +1,13 @@
+userdefined_apply.scala:3: error: overloaded method apply needs result type
+  private def apply(x: Int) = if (x > 0) new ClashOverloadNoSig(x) else apply("")
+                                                                             ^
+userdefined_apply.scala:12: error: overloaded method apply needs result type
+  private def apply(x: Int) = if (x > 0) ClashRecNoSig(1) else ???
+                                         ^
+userdefined_apply.scala:19: error: overloaded method apply needs result type
+  private def apply(x: Boolean) = if (x) NoClashNoSig(1) else ???
+                                         ^
+userdefined_apply.scala:26: error: overloaded method apply needs result type
+  private def apply(x: Boolean) = if (x) NoClashOverload(1) else apply("")
+                                                        ^
+four errors found

--- a/test/files/neg/userdefined_apply.check
+++ b/test/files/neg/userdefined_apply.check
@@ -1,13 +1,25 @@
 userdefined_apply.scala:3: error: overloaded method apply needs result type
   private def apply(x: Int) = if (x > 0) new ClashOverloadNoSig(x) else apply("")
                                                                              ^
-userdefined_apply.scala:12: error: overloaded method apply needs result type
+userdefined_apply.scala:14: error: overloaded method apply needs result type
   private def apply(x: Int) = if (x > 0) ClashRecNoSig(1) else ???
                                          ^
-userdefined_apply.scala:19: error: overloaded method apply needs result type
+userdefined_apply.scala:21: error: overloaded method apply needs result type
   private def apply(x: Boolean) = if (x) NoClashNoSig(1) else ???
                                          ^
-userdefined_apply.scala:26: error: overloaded method apply needs result type
+userdefined_apply.scala:28: error: overloaded method apply needs result type
   private def apply(x: Boolean) = if (x) NoClashOverload(1) else apply("")
                                                         ^
-four errors found
+userdefined_apply.scala:45: error: recursive method apply needs result type
+case class NoClashNoSigPoly private(x: Int)
+           ^
+userdefined_apply.scala:39: error: NoClashNoSigPoly.type does not take parameters
+  def apply(x: T) = if (???) NoClashNoSigPoly(1) else ???
+                                             ^
+userdefined_apply.scala:57: error: recursive method apply needs result type
+case class ClashNoSigPoly private(x: Int)
+           ^
+userdefined_apply.scala:51: error: ClashNoSigPoly.type does not take parameters
+  def apply(x: T) = if (???) ClashNoSigPoly(1) else ???
+                                           ^
+8 errors found

--- a/test/files/neg/userdefined_apply.scala
+++ b/test/files/neg/userdefined_apply.scala
@@ -1,0 +1,31 @@
+object ClashOverloadNoSig {
+  // error: overloaded method apply needs result type
+  private def apply(x: Int) = if (x > 0) new ClashOverloadNoSig(x) else apply("")
+
+  def apply(x: String): ClashOverloadNoSig = ???
+}
+
+case class ClashOverloadNoSig private(x: Int)
+
+object ClashRecNoSig {
+  // error: recursive method apply needs result type
+  private def apply(x: Int) = if (x > 0) ClashRecNoSig(1) else ???
+}
+
+case class ClashRecNoSig private(x: Int)
+
+object NoClashNoSig {
+  // error: overloaded method apply needs result type
+  private def apply(x: Boolean) = if (x) NoClashNoSig(1) else ???
+}
+
+case class NoClashNoSig private(x: Int)
+
+object NoClashOverload {
+  // error: overloaded method apply needs result type
+  private def apply(x: Boolean) = if (x) NoClashOverload(1) else apply("")
+
+  def apply(x: String): NoClashOverload = ???
+}
+
+case class NoClashOverload private(x: Int)

--- a/test/files/neg/userdefined_apply.scala
+++ b/test/files/neg/userdefined_apply.scala
@@ -8,6 +8,8 @@ object ClashOverloadNoSig {
 case class ClashOverloadNoSig private(x: Int)
 
 object ClashRecNoSig {
+  // TODO: status quo is that the error refers to an overloaded method, which is actually recursive
+  // (we should have unlinked the symbol in the `if(suppress)` part of `applyUnapplyMethodCompleter`)
   // error: recursive method apply needs result type
   private def apply(x: Int) = if (x > 0) ClashRecNoSig(1) else ???
 }
@@ -29,3 +31,27 @@ object NoClashOverload {
 }
 
 case class NoClashOverload private(x: Int)
+
+
+class BaseNCNSP[T] {
+  // TODO: suppress the following error
+  // error: NoClashNoSigPoly.type does not take parameters
+  def apply(x: T) = if (???) NoClashNoSigPoly(1) else ???
+}
+
+object NoClashNoSigPoly extends BaseNCNSP[Boolean]
+// TODO: position error at definition of apply in superclass instead of on case clss
+// error: recursive method apply needs result type
+case class NoClashNoSigPoly private(x: Int)
+
+
+class BaseCNSP[T] {
+  // TODO: suppress the following error
+  // error: ClashNoSigPoly.type does not take parameters
+  def apply(x: T) = if (???) ClashNoSigPoly(1) else ???
+}
+
+object ClashNoSigPoly extends BaseCNSP[Int]
+// TODO: position error at definition of apply in superclass instead of on case clss
+// error: recursive method apply needs result type
+case class ClashNoSigPoly private(x: Int)

--- a/test/files/pos/userdefined_apply.scala
+++ b/test/files/pos/userdefined_apply.scala
@@ -1,0 +1,36 @@
+// NOTE: the companion inherits a public apply method from Function1!
+case class NeedsCompanion private (x: Int)
+
+object ClashNoSig { // ok
+  private def apply(x: Int) = if (x > 0) new ClashNoSig(x) else ???
+}
+case class ClashNoSig private (x: Int)
+
+
+object Clash {
+  private def apply(x: Int) = if (x > 0) new Clash(x) else ???
+}
+case class Clash private (x: Int)
+
+object ClashSig {
+  private def apply(x: Int): ClashSig = if (x > 0) new ClashSig(x) else ???
+}
+case class ClashSig private (x: Int)
+
+object ClashOverload {
+  private def apply(x: Int): ClashOverload = if (x > 0) new ClashOverload(x) else apply("")
+  def apply(x: String): ClashOverload = ???
+}
+case class ClashOverload private (x: Int)
+
+object NoClashSig {
+  private def apply(x: Boolean): NoClashSig = if (x) NoClashSig(1) else ???
+}
+case class NoClashSig private (x: Int)
+
+object NoClashOverload {
+  // needs full sig
+  private def apply(x: Boolean): NoClashOverload = if (x) NoClashOverload(1) else apply("")
+  def apply(x: String): NoClashOverload = ???
+}
+case class NoClashOverload private (x: Int)

--- a/test/files/pos/userdefined_apply.scala
+++ b/test/files/pos/userdefined_apply.scala
@@ -34,3 +34,21 @@ object NoClashOverload {
   def apply(x: String): NoClashOverload = ???
 }
 case class NoClashOverload private (x: Int)
+
+
+
+class BaseNCP[T] {
+  // error: overloaded method apply needs result type
+  def apply(x: T): NoClashPoly = if (???) NoClashPoly(1) else ???
+}
+
+object NoClashPoly extends BaseNCP[Boolean]
+case class NoClashPoly private(x: Int)
+
+
+class BaseCP[T] {
+  // error: overloaded method apply needs result type
+  def apply(x: T): ClashPoly = if (???) ClashPoly(1) else ???
+}
+object ClashPoly extends BaseCP[Int]
+case class ClashPoly private(x: Int)

--- a/test/files/pos/userdefined_apply_poly_overload.scala
+++ b/test/files/pos/userdefined_apply_poly_overload.scala
@@ -1,0 +1,13 @@
+object Foo {
+  // spurious error if:
+  //   - this definition precedes that of apply (which is overloaded with the synthetic one derived from the case class)
+  //   - AND `Foo.apply` is explicitly applied to `[A]` (no error if `[A]` is inferred)
+  //
+  def referToPolyOverloadedApply[A]: Foo[A] = Foo.apply[A]("bla")
+  //                                                   ^
+  //  found   : String("bla")
+  //  required: Int
+
+  def apply[A](x: Int): Foo[A] = ???
+}
+case class Foo[A](x: String) // must be polymorphic


### PR DESCRIPTION
Don't emit a synthetic `apply` (or `unapply`) when it would
clash with an existing one. This allows e.g., a `private apply`,
along with a `case class` with a `private` constructor.

We have to retract the synthetic method in a pretty roundabout way,
as we need the other methods and the owner to be completed already.
Unless we have to complete the synthetic `apply` while completing
the user-defined one, this should not be a problem. If this does
happen, this implies there's a cycle in computing the user-defined
signature and the synthetic one, which is not allowed.

First submitted as #5730 for 2.11.9, see also scala/scala-dev#352 (as in, to be investigated if the change relates to this change, though unlikely since it already regressed in 2.12.1)