### PR TITLE
Fix typo in JavaConverters doc

### DIFF
--- a/src/library/scala/collection/JavaConverters.scala
+++ b/src/library/scala/collection/JavaConverters.scala
@@ -18,12 +18,12 @@ import convert._
  *
  *  The following conversions are supported via `asScala` and `asJava`:
  *{{{
- *    scala.collection.Iterable               <=> java.lang.Iterable
- *    scala.collection.Iterator               <=> java.util.Iterator
- *    scala.collection.mutable.Buffer         <=> java.util.List
- *    scala.collection.mutable.Set            <=> java.util.Set
- *    scala.collection.mutable.Map            <=> java.util.Map
- *    scala.collection.mutable.concurrent.Map <=> java.util.concurrent.ConcurrentMap
+ *    scala.collection.Iterable       <=> java.lang.Iterable
+ *    scala.collection.Iterator       <=> java.util.Iterator
+ *    scala.collection.mutable.Buffer <=> java.util.List
+ *    scala.collection.mutable.Set    <=> java.util.Set
+ *    scala.collection.mutable.Map    <=> java.util.Map
+ *    scala.collection.concurrent.Map <=> java.util.concurrent.ConcurrentMap
  *}}}
  *  The following conversions are supported via `asScala` and through
  *  specially-named extension methods to convert to Java collections, as shown:


### PR DESCRIPTION
There is no such thing as scala.collection.mutable.concurrent.Map

    error: object concurrent is not a member of package scala.collection.mutable

Introduced in 2908236a.  Found by @cescude