### PR TITLE
comonadic comprehensions

### DIFF
--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -389,6 +389,10 @@ filter {
         problemName=MissingMethodProblem
     },
     {
+        matchName="scala.reflect.runtime.Settings.YcoforExtension"
+        problemName=MissingMethodProblem
+    },
+    {
         matchName="scala.reflect.runtime.Settings.YpartialUnification"
         problemName=MissingMethodProblem
     },

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -1095,7 +1095,11 @@ trait Scanners extends ScannersCommon {
 
   // ------------- keyword configuration -----------------------------------
 
-  private val allKeywords = List[(Name, Token)](
+  private[this] val addKeywords: List[(Name, Token)] => List[(Name, Token)] =
+    if (settings.YcoforExtension) ((nme.COFORkw -> COFOR) +: _)  else ( identity)
+  private val allKeywords =
+    addKeywords(
+      List[(Name, Token)](
     nme.ABSTRACTkw  -> ABSTRACT,
     nme.CASEkw      -> CASE,
     nme.CATCHkw     -> CATCH,
@@ -1148,6 +1152,7 @@ trait Scanners extends ScannersCommon {
     nme.ATkw        -> AT,
     nme.MACROkw     -> IDENTIFIER,
     nme.THENkw      -> IDENTIFIER)
+  )
 
   private var kwOffset: Offset = -1
   private val kwArray: Array[Token] = {

--- a/src/compiler/scala/tools/nsc/ast/parser/Tokens.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Tokens.scala
@@ -42,6 +42,8 @@ object Tokens extends CommonTokens {
   final val YIELD = 86
   final val MATCH = 95
 
+  final val COFOR = 126
+
   /** special symbols */
   final val HASH = 130
   final val USCORE = 131

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -33,7 +33,7 @@ trait ScalaSettings extends AbsScalaSettings
   protected def defaultClasspath = sys.env.getOrElse("CLASSPATH", ".")
 
   /** Enabled under -Xexperimental. */
-  protected def experimentalSettings = List[BooleanSetting](YmethodInfer, overrideObjects, overrideVars)
+  protected def experimentalSettings = List[BooleanSetting](YmethodInfer, overrideObjects, overrideVars, YcoforExtension)
 
   /** Enabled under -Xfuture. */
   protected def futureSettings = List[BooleanSetting]()
@@ -219,7 +219,8 @@ trait ScalaSettings extends AbsScalaSettings
   val YclasspathImpl  = ChoiceSetting     ("-YclasspathImpl", "implementation", "Choose classpath scanning method.", List(ClassPathRepresentationType.Recursive, ClassPathRepresentationType.Flat), ClassPathRepresentationType.Recursive)
   val YdisableFlatCpCaching  = BooleanSetting    ("-YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
   val YpartialUnification = BooleanSetting ("-Ypartial-unification", "Enable partial unification in type constructor inference")
-
+  val YcoforExtension   = BooleanSetting ("-Ycofor-extension", "Enable cofor keyword")
+  
   val YvirtClasses    = false // too embryonic to even expose as a -Y //BooleanSetting    ("-Yvirtual-classes", "Support virtual classes")
   val YdisableUnreachablePrevention = BooleanSetting("-Ydisable-unreachable-prevention", "Disable the prevention of unreachable blocks in code generation.")
   val YnoLoadImplClass = BooleanSetting   ("-Yno-load-impl-class", "Do not load $class.class files.")

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -46,6 +46,10 @@ trait StdAttachments {
    */
   case object ForAttachment extends PlainAttachment
 
+  /** Identifies trees are either result or intermediate value of cofor desugaring. 
+   */
+  case object CoforAttachment extends PlainAttachment
+  
   /** Identifies unit constants which were inserted by the compiler (e.g. gen.mkBlock)
    */
   case object SyntheticUnitAttachment extends PlainAttachment

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -169,6 +169,7 @@ trait StdNames {
     final val CASEkw: TermName      = kw("case")
     final val CLASSkw: TermName     = kw("class")
     final val CATCHkw: TermName     = kw("catch")
+    final val COFORkw: TermName     = kw("cofor")
     final val DEFkw: TermName       = kw("def")
     final val DOkw: TermName        = kw("do")
     final val ELSEkw: TermName      = kw("else")
@@ -665,6 +666,7 @@ trait StdNames {
     val canEqual_ : NameType           = "canEqual"
     val classOf: NameType              = "classOf"
     val clone_ : NameType              = "clone"
+    val coflatMap : NameType           = "coflatMap"
     val collection: NameType           = "collection"
     val conforms: NameType             = "$conforms" // dollar prefix to avoid accidental shadowing
     val copy: NameType                 = "copy"
@@ -685,6 +687,7 @@ trait StdNames {
     val error: NameType                = "error"
     val ex: NameType                   = "ex"
     val experimental: NameType         = "experimental"
+    val extract: NameType              = "extract"
     val f: NameType                    = "f"
     val false_ : NameType              = "false"
     val filter: NameType               = "filter"

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -689,6 +689,201 @@ abstract class TreeGen {
     }
   }
 
+  /** Create tree for cofor-comprehension <cofor (inputPattern) (enums) yield body> 
+  *  where mapName, coflatMapName and extract are used.
+  *  Note that the type of the tree is set by the call-site. It always returns a function
+  *  from some comonad to a result. It can't start an expression!
+  *  The creation performs the following rewrite rules:
+  *
+  *  1.
+  *	
+  *    cofor ((x1,x2,x3)) {P_1 <- G_1; P_2 <- G_2; ...} ...
+  *      ==>
+  *      input => { 
+  *      val enums1 =  input.map(input => (input._1, (input._2, (input._3, ())))).coflatMap(env => {
+  *      		val x1 = env1.map(((e1) => e1._1));
+  *					val x2 = env1.map(((e2) => e2._2._1));
+  *					val x3 = env1.map(((e2) => e2._2._2._1));
+  *					(G_1, env1.extract)
+  * 			}).coflatMap(env => {
+  * 				val P_1 = env1.map(((e1) => e1._1));
+  *      		val x1 = env1.map(((e1) => e1._2._1));
+  *					val x2 = env1.map(((e2) => e2._2._2._1));
+  *					val x3 = env1.map(((e2) => e2._2._2._2._1));
+  *					(G_2, env1.extract)			
+  * 			});
+  * 		{
+  * 			  val P_2 = env1.map(((e1) => e1._1));
+  * 			  val P_1 = env1.map(((e1) => e1._2._1));
+  *      		val x1 = env1.map(((e1) => e1._2._2._1));
+  *					val x2 = env1.map(((e2) => e2._2._2._2._1));
+  *					val x3 = env1.map(((e2) => e2._2._2._2._2._1));
+  * 				yield_expression
+  * 		}
+  * 		};
+  *
+  * 	note that: (x1,x2,x3...) and (P_1, P_2 .. ) can be any patten (e.g.: cofor (p @ Person(name, age)) )
+  * 
+  *
+  *  @param inputPattern     The input expression of the cofor
+  *  @param enums            The enumerators in the cofor expression
+  *  @param body    		     The body of the yield expression
+  *  @param fresh            A source of new names
+  */
+  def mkCoFor(inputPattern: Tree, enums: List[Tree], body: Tree)(implicit fresh: FreshNameCreator): Tree = {
+
+    def makeClosure(pos: Position, pat: Tree, body: Tree): Tree = {
+      def wrapped = wrappingPos(List(pat, body))
+      def splitpos = (if (pos != NoPosition) wrapped.withPoint(pos.point) else pos).makeTransparent
+      matchVarPattern(pat) match {
+        case Some((name, tpt)) =>
+          Function(
+            List(atPos(pat.pos) { ValDef(Modifiers(PARAM), name.toTermName, tpt, EmptyTree) }),
+            body) setPos splitpos
+        case None =>
+          atPos(splitpos) {
+            mkVisitor(List(CaseDef(pat, EmptyTree, body)), checkExhaustive = false)
+          }
+      }
+    }
+
+    def generateEnv(pos: Position, genIdx: Int, envNames: List[Tree], envName: Tree): List[Tree] = {
+
+      val allNames = envNames.take(genIdx).reverse 
+
+      // env.map(e$14 -> e$14._2._2._1)
+      def buildTupleExtractor(idx: Int) = Apply(Select(envName, nme.map) setPos pos, List {
+              val tmpe = Ident(freshTermName("e"))
+
+              // compose $idx times "._2" over $tmpe variable
+              // e.g.: (idx = 3) ===> e._2._2._2
+              val composeSnd: Tree => Tree = t => Select(t, nme._2) setPos pos 
+              val sndCompositions = List.fill(idx)(composeSnd).foldLeft[Tree](tmpe) {
+                (acc, e) => e(acc)
+              }
+              // at the end, add "._1" to the previous "._2" composition
+              makeClosure(pos, tmpe, Select(sndCompositions, nme._1) setPos pos)
+            })
+      
+      
+      allNames.zipWithIndex.flatMap {
+        case (Ident(name), idx) => // TODO: are we ever here or in the next case???
+          List(ValDef(Modifiers(0), name.toTermName , TypeTree(NoType), buildTupleExtractor(idx)))
+        case (Bind(name, _), idx) => 
+          List(ValDef(Modifiers(0), name.toTermName , TypeTree(NoType), buildTupleExtractor(idx)))
+        case (name, idx) =>
+          val comonadWithPatternToExtract = buildTupleExtractor(idx)
+          // (name, tree, pos)
+          val allVarsinCurrentGeneratorPattern = getVariables(name)
+          val tmpe = Ident(freshTermName("e"))
+          
+          val vars = allVarsinCurrentGeneratorPattern.map(v => (v._1, Match(
+          tmpe.duplicate,
+          List(
+              CaseDef(name.duplicate, EmptyTree, Ident(v._1))))))
+          //vars.foreach(v => println(s"${v._1} of type: ${v._2}"))
+           
+           /*
+            * for each variable (e.g. r1)
+            * val r1 = thecomonad.map(e$x => {
+            * 	val hahaha = e$x match {
+            * 		case ....... => .....
+            * 	}
+            *   hahaha.thepattern
+            * })
+            */
+          vars.map(v => 
+            ValDef(Modifiers(ARTIFACT) /* TODO: is needed? */, v._1.toTermName , TypeTree(NoType),
+               Apply(Select(comonadWithPatternToExtract.duplicate, nme.map) setPos pos updateAttachment CoforAttachment, 
+                   List{
+                     makeClosure(pos, tmpe.duplicate, v._2) setPos pos updateAttachment CoforAttachment
+                     }) setPos pos) )
+          // get all variables & patterns
+          
+      }
+    }
+    // for each generator we extract the previous environment into local variables
+    // and append it with (generatorExpr, env.extract)
+    // then, we put everything coflatMap'ed on the previous step
+    def makeCombination(pos: Position, genIdx: Int, envNames: List[Tree], prev: Tree, qual: Tree): Tree = {
+      val envName = Ident(freshTermName("env"))
+
+      val lastBlockExpr = mkTuple(qual +: (Select(envName, nme.extract) setPos qual.pos updateAttachment CoforAttachment) +: Nil)
+      val bodyExpr = generateEnv(pos, genIdx, envNames, envName) :+ lastBlockExpr
+
+      val envFunc = makeClosure(pos, envName, Block(bodyExpr: _*))
+
+
+      Apply(Select(prev, nme.coflatMap) setPos qual.pos updateAttachment CoforAttachment,
+        List(envFunc)) setPos pos
+    }
+
+    /* The position of the closure that starts with generator at position `genpos`. */
+    def closurePos(genpos: Position) =
+      if (genpos == NoPosition) NoPosition
+      else {
+        val end = body.pos match {
+          case NoPosition => genpos.point
+          case bodypos    => bodypos.end
+        }
+        rangePos(genpos.source, genpos.start, genpos.point, end)
+      }
+    
+    
+    def mkTuplePairs(ident: Ident, inputPattern: Tree): (Tree, List[Name]) = {
+      val inputVariables = getVariables(inputPattern)
+      val inputExtractions = inputVariables.map(v => Match(
+          ident.duplicate,
+          List(
+              CaseDef(inputPattern.duplicate, EmptyTree, Ident(v._1)))))
+      (inputExtractions.foldRight[Tree](Literal(Constant(()))) {
+        (elem, acc) => mkTuple(elem +: acc +: Nil)
+      }, inputVariables.map(_._1))
+    }
+
+    // we must have at least one generator (Parsers takes care of it). Where is NonEmptyList??
+    val pos = closurePos(enums.head.pos)
+    val inputTermName = Ident(freshTermName("input"))
+
+
+    /*
+     * creates the initial environment according to the inputNames
+     * inputNames.size match {
+     * 	case 1 => x => (x, ())
+     *  case n => x => (x._1, (x._2, (... , ())))
+     */
+    val xIdent = Ident("x")
+    
+    val (iEnv, inputVariables) = mkTuplePairs(xIdent, inputPattern)
+    val inputIdentifiers = inputVariables.map(Ident.apply) 
+    val inputNamesCount = inputVariables.size
+    
+    val initialEnv = makeClosure(pos, xIdent, iEnv) 
+
+    val firstPhase = Apply(Select(inputTermName, nme.map) setPos pos updateAttachment CoforAttachment,
+      List(initialEnv)) setPos pos
+
+    // names of enumerator patterns:
+    // x <- foo(...); y <- bar(...) ===> List(inputnames, x,y)
+    val envNames = inputIdentifiers.reverse ++ enums.map { case ValFrom(pat, _) => pat }
+
+    // compose generator desugared trees with the initial environment (firstPhase)
+    val enumsDesugar = enums.zipWithIndex.foldLeft[Tree](firstPhase) {
+      (acc, e) =>
+        val (enum @ ValFrom(pat, rhs), idx) = e
+        makeCombination(closurePos(enum.pos), idx + inputNamesCount, envNames, acc, rhs)
+    }
+    // assign the generators desugared trees to a local variable
+    val enumsBodyName = freshTermName("enums")
+    val enumsBody = ValDef(Modifiers(0), enumsBodyName, TypeTree(NoType), enumsDesugar)
+
+    // generate the body part of the cofor (the yield statement)
+    val lastPhase = generateEnv(pos, enums.size + inputNamesCount, envNames, Ident(enumsBodyName)) :+ body
+
+    // compose all
+    makeClosure(pos, inputTermName, Block(enumsBody, Block(lastPhase: _*))) setPos pos
+
+  }
   /** Create tree for pattern definition <val pat0 = rhs> */
   def mkPatDef(pat: Tree, rhs: Tree)(implicit fresh: FreshNameCreator): List[ValDef] =
     mkPatDef(Modifiers(0), pat, rhs)
@@ -764,6 +959,11 @@ abstract class TreeGen {
     val pat1 = patvarTransformer.transform(pat)
     if (valeq) ValEq(pat1, rhs).setPos(pos)
     else ValFrom(pat1, mkCheckIfRefutable(pat1, rhs)).setPos(pos)
+  }
+
+  def mkCoForGenerator(pos: Position, pat: Tree, rhs: Tree)(implicit fresh: FreshNameCreator): Tree = {
+    val pat1 = patvarTransformer.transform(pat)
+    ValFrom(pat1, rhs).setPos(pos)
   }
 
   def mkCheckIfRefutable(pat: Tree, rhs: Tree)(implicit fresh: FreshNameCreator) =

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -54,6 +54,7 @@ abstract class MutableSettings extends AbsSettings {
   def uniqid: BooleanSetting
   def verbose: BooleanSetting
   def YpartialUnification: BooleanSetting
+  def YcoforExtension: BooleanSetting
 
   def Yrecursion: IntSetting
   def maxClassfileName: IntSetting

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -39,6 +39,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.CompoundTypeTreeOriginalAttachment
     this.BackquotedIdentifierAttachment
     this.ForAttachment
+    this.CoforAttachment
     this.SyntheticUnitAttachment
     this.SubpatternsAttachment
     this.KnownDirectSubclassesCalled

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -48,6 +48,7 @@ private[reflect] class Settings extends MutableSettings {
   val uniqid            = new BooleanSetting(false)
   val verbose           = new BooleanSetting(false)
   val YpartialUnification = new BooleanSetting(false)
+  val YcoforExtension   = new BooleanSetting(false)
 
   val Yrecursion        = new IntSetting(0)
   val maxClassfileName  = new IntSetting(255)

--- a/test/files/neg/cofor.check
+++ b/test/files/neg/cofor.check
@@ -1,0 +1,7 @@
+cofor.scala:54: error: ')' expected but '@' found.
+  val result : StreamZipper[Person] => (Person, Boolean, Int) = cofor (p @ Person(_, age)) {
+                                                                         ^
+cofor.scala:54: error: ';' expected but ')' found.
+  val result : StreamZipper[Person] => (Person, Boolean, Int) = cofor (p @ Person(_, age)) {
+                                                                                         ^
+two errors found

--- a/test/files/neg/cofor.scala
+++ b/test/files/neg/cofor.scala
@@ -1,0 +1,70 @@
+object Test {
+
+  def unfold[A, B](a: A)(f: A => Option[(B, A)]): Stream[B] = f(a) match {
+    case Some((b, a)) => b #:: unfold(a)(f)
+    case None         => Stream.empty
+  }
+
+  case class StreamZipper[A](left: Stream[A], focus: A, right: Stream[A]) {
+    def next = right match {
+      case h +: rest => Some(StreamZipper(focus +: left, h, rest))
+      case _         => None
+
+    }
+    def previous = left match {
+      case h +: rest => Some(StreamZipper(rest, h, focus +: right))
+      case _         => None
+
+    }
+    def map[B](f: A => B) = StreamZipper(left map f, f(focus), right map f)
+    def extract = focus
+    def duplicate: StreamZipper[StreamZipper[A]] = {
+      val r = unfold(this)(z => z.next.map(x => (x, x)))
+      val l = unfold(this)(z => z.previous.map(x => (x, x)))
+      StreamZipper(l, this, r)
+    }
+    def coflatMap[B](f: StreamZipper[A] => B): StreamZipper[B] = duplicate map f
+
+    def toStream = left.reverse ++ (focus +: right)
+    
+  }
+  
+  def stream2zipper[A](sa: Stream[A]) = sa match {
+    case h +: rest => Some(StreamZipper(Stream.empty, h, rest))
+    case _ => None
+  }
+  
+  
+  case class Person(name: String, age: Int)
+  
+  
+  val people = Stream(Person("john", 40),Person("alice", 45),Person("jones", 50),Person("bob", 60),Person("jane", 50))
+  
+  
+  val Some(zi) = stream2zipper(people)
+  def isSandwitch(z : StreamZipper[Int]) = z match {
+    case StreamZipper(pi +: _, i, ni +: _) if (pi < i && i < ni) => true
+    case _ => false
+  }
+  
+  def fff(z : StreamZipper[Person]) = z.extract
+  def numberOfTruth(z: StreamZipper[Boolean]) : Int  = 
+    if (z.focus) 1 + z.right.takeWhile(true ==).size else 0
+  
+  val result : StreamZipper[Person] => (Person, Boolean, Int) = cofor (p @ Person(_, age)) {
+    tag <- isSandwitch(age)
+    count <- numberOfTruth(tag)
+  } yield (p.extract, tag.extract, count.extract)
+  
+  
+  zi.coflatMap(result).toStream
+  
+  val result2 : StreamZipper[Person] => (Person, Boolean, Int) = cofor (p) {
+    Person(_, age) <- fff(p)
+    tag <- isSandwitch(age)
+    count <- numberOfTruth(tag)
+  } yield (p.extract, tag.extract, count.extract)
+  
+  
+  zi.coflatMap(result2).toStream
+}

--- a/test/files/pos/cofor.flags
+++ b/test/files/pos/cofor.flags
@@ -1,0 +1,1 @@
+-Ycofor-extension

--- a/test/files/pos/cofor.scala
+++ b/test/files/pos/cofor.scala
@@ -1,0 +1,70 @@
+object Test {
+
+  def unfold[A, B](a: A)(f: A => Option[(B, A)]): Stream[B] = f(a) match {
+    case Some((b, a)) => b #:: unfold(a)(f)
+    case None         => Stream.empty
+  }
+
+  case class StreamZipper[A](left: Stream[A], focus: A, right: Stream[A]) {
+    def next = right match {
+      case h +: rest => Some(StreamZipper(focus +: left, h, rest))
+      case _         => None
+
+    }
+    def previous = left match {
+      case h +: rest => Some(StreamZipper(rest, h, focus +: right))
+      case _         => None
+
+    }
+    def map[B](f: A => B) = StreamZipper(left map f, f(focus), right map f)
+    def extract = focus
+    def duplicate: StreamZipper[StreamZipper[A]] = {
+      val r = unfold(this)(z => z.next.map(x => (x, x)))
+      val l = unfold(this)(z => z.previous.map(x => (x, x)))
+      StreamZipper(l, this, r)
+    }
+    def coflatMap[B](f: StreamZipper[A] => B): StreamZipper[B] = duplicate map f
+
+    def toStream = left.reverse ++ (focus +: right)
+    
+  }
+  
+  def stream2zipper[A](sa: Stream[A]) = sa match {
+    case h +: rest => Some(StreamZipper(Stream.empty, h, rest))
+    case _ => None
+  }
+  
+  
+  case class Person(name: String, age: Int)
+  
+  
+  val people = Stream(Person("john", 40),Person("alice", 45),Person("jones", 50),Person("bob", 60),Person("jane", 50))
+  
+  
+  val Some(zi) = stream2zipper(people)
+  def isSandwitch(z : StreamZipper[Int]) = z match {
+    case StreamZipper(pi +: _, i, ni +: _) if (pi < i && i < ni) => true
+    case _ => false
+  }
+  
+  def fff(z : StreamZipper[Person]) = z.extract
+  def numberOfTruth(z: StreamZipper[Boolean]) : Int  = 
+    if (z.focus) 1 + z.right.takeWhile(true ==).size else 0
+  
+  val result : StreamZipper[Person] => (Person, Boolean, Int) = cofor (p @ Person(_, age)) {
+    tag <- isSandwitch(age)
+    count <- numberOfTruth(tag)
+  } yield (p.extract, tag.extract, count.extract)
+  
+  
+  zi.coflatMap(result).toStream
+  
+  val result2 : StreamZipper[Person] => (Person, Boolean, Int) = cofor (p) {
+    Person(_, age) <- fff(p)
+    tag <- isSandwitch(age)
+    count <- numberOfTruth(tag)
+  } yield (p.extract, tag.extract, count.extract)
+  
+  
+  zi.coflatMap(result2).toStream
+}


### PR DESCRIPTION
This is a proposal (POC) to provide a new keyword (cofor) for co-monadic comprehensions in Scala.
The work is based over Dominic Orchard and Alan Mycroft paper: https://www.cl.cam.ac.uk/~dao29/publ/codo-notation-orchard-ifl12.pdf

If you find the implementation flawed, it is me to blame and not them!

The 'cofor' expression returns a function: (T[A] => B).
The function's type MUST be stated explicitly in the call-site. e.g.:
val result: Zipper[Person] => Boolean = cofor...

the syntax:
cofor(inputpatten) {
pattern1 <- gen1
pattern2 <- gen2
...
} yield body

the 'cofor' and generator must use types that provide:
def map(A => B)
def extract: A
def coflatMap(T[A] => B)

Implementation is much more complex than 'for' desugaring as stated in the paper.

Current implementation supports full Scala patterns in the input and generator patterns.

currently missing:
Desugared tree positioning validation (should not affect surrounding code)
Quasiquotes/macros/reification -- this is the next phase in the implementation.

The flag to control the keyword: -Ycofor-extension
If the flag is not enabled, current Scala code should not be affected.

Compatibility: adding a new keyword breaks existing use of 'cofor' identifier and it should be back-quoted.

Some discussion and example can is in: https://contributors.scala-lang.org/t/providing-co-monadic-comprehensions/518

A SIP was also submitted: http://docs.scala-lang.org/sips/pending/comonadic-comprehensions.html

This PR is targeted for TLS. The same PR was opened for 2.12.x: scala#5725