### PR TITLE
Applicative desugaring in for comprehensions

### DIFF
--- a/src/compiler/scala/reflect/quasiquotes/Parsers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Parsers.scala
@@ -176,10 +176,13 @@ trait Parsers { self: Quasiquotes =>
       }
 
       override def enumerator(isFirst: Boolean, allowNestedIf: Boolean = true) =
-        if (isHole && lookingAhead { in.token == EOF || in.token == RPAREN || isStatSep }) {
-          val res = ForEnumPlaceholder(in.name) :: Nil
+        if (isHole && lookingAhead { in.token == EOF || in.token == RPAREN || in.token == WITH || isStatSep }) {
+          val tree = ForEnumPlaceholder(in.name)
           in.nextToken()
-          res
+          if(in.token == WITH) {
+            in.nextToken()
+            gen.With(tree) :: Nil
+          } else tree :: Nil
         } else super.enumerator(isFirst, allowNestedIf)
     }
   }

--- a/src/compiler/scala/reflect/quasiquotes/Parsers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Parsers.scala
@@ -175,7 +175,7 @@ trait Parsers { self: Quasiquotes =>
           stats
       }
 
-      override def enumerator(isFirst: Boolean, allowNestedIf: Boolean = true) =
+      override def enumerator(isFirst: Boolean, allowNested: Boolean = true) =
         if (isHole && lookingAhead { in.token == EOF || in.token == RPAREN || in.token == WITH || isStatSep }) {
           val tree = ForEnumPlaceholder(in.name)
           in.nextToken()
@@ -183,7 +183,7 @@ trait Parsers { self: Quasiquotes =>
             in.nextToken()
             gen.With(tree) :: Nil
           } else tree :: Nil
-        } else super.enumerator(isFirst, allowNestedIf)
+        } else super.enumerator(isFirst, allowNested)
     }
   }
 
@@ -222,7 +222,7 @@ trait Parsers { self: Quasiquotes =>
 
   object ForEnumeratorParser extends Parser {
     def entryPoint = { parser =>
-      val enums = parser.enumerator(isFirst = false, allowNestedIf = false)
+      val enums = parser.enumerator(isFirst = false, allowNested = false)
       assert(enums.length == 1)
       implodePatDefs(enums.head)
     }

--- a/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
@@ -178,6 +178,8 @@ trait Reifiers { self: Quasiquotes =>
         reifyBuildCall(nme.SyntacticValEq, pat, rhs)
       case SyntacticFilter(cond) =>
         reifyBuildCall(nme.SyntacticFilter, cond)
+      case SyntacticWith(enum) =>
+        reifyBuildCall(nme.SyntacticWith, enum)
       case SyntacticFor(enums, body) =>
         reifyBuildCall(nme.SyntacticFor, enums, body)
       case SyntacticForYield(enums, body) =>

--- a/src/reflect/scala/reflect/api/Internals.scala
+++ b/src/reflect/scala/reflect/api/Internals.scala
@@ -737,6 +737,13 @@ trait Internals { self: Universe =>
       def unapply(tree: Tree): Option[(Tree)]
     }
 
+    val SyntacticWith: SyntacticWithExtractor
+
+    trait SyntacticWithExtractor {
+      def apply(enum: Tree): Tree
+      def unapply(tree: Tree): Option[Tree]
+    }
+
     val SyntacticEmptyTypeTree: SyntacticEmptyTypeTreeExtractor
 
     trait SyntacticEmptyTypeTreeExtractor {

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -748,6 +748,7 @@ trait StdNames {
     val null_ : NameType               = "null"
     val pendingSuperCall: NameType     = "pendingSuperCall"
     val prefix : NameType              = "prefix"
+    val product: NameType              = "product"
     val productArity: NameType         = "productArity"
     val productElement: NameType       = "productElement"
     val productIterator: NameType      = "productIterator"
@@ -852,6 +853,7 @@ trait StdNames {
     val SyntacticValEq: NameType            = "SyntacticValEq"
     val SyntacticValFrom: NameType          = "SyntacticValFrom"
     val SyntacticVarDef: NameType           = "SyntacticVarDef"
+    val SyntacticWith: NameType             = "SyntacticWith"
 
     // unencoded operators
     object raw {

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -577,6 +577,25 @@ abstract class TreeGen {
     }
   }
 
+  object With {
+    def apply(tree: Tree) =
+      Select(tree, nme.WITHkw).updateAttachment(ForAttachment)
+    def unapply(tree: Tree): Option[Tree] = tree match {
+      case Select(enum, nme.WITHkw)
+        if tree.hasAttachment[ForAttachment.type] => Some(enum)
+      case _ => None
+    }
+  }
+
+  object MaybeWith {
+    def apply(tree: Tree, prod: Boolean) =
+      if (prod) With(tree) else tree
+    def unapply(tree: Tree): Option[(Tree, Boolean)] = tree match {
+      case With(t) => Some((t, true))
+      case t => Some((t, false))
+    }
+  }
+
   /** Encode/decode body of for yield loop as q"`yield`($tree)" */
   object Yield {
     def apply(tree: Tree): Tree =
@@ -692,20 +711,46 @@ abstract class TreeGen {
         rangePos(genpos.source, genpos.start, genpos.point, end)
       }
 
+    def makeProduct(posOfWith: Position, lhs: Tree, rhs: Tree): Tree = {
+      val selectPos =
+        if (posOfWith == NoPosition) NoPosition
+        else if(lhs.pos == NoPosition) posOfWith
+        else rangePos(posOfWith.source, lhs.pos.start, posOfWith.point, posOfWith.end)
+      Apply(
+        Select(lhs, nme.product).setPos(selectPos).updateAttachment(ForAttachment),
+        List(rhs)
+      ).setPos(wrappingPos(posOfWith, List(lhs, rhs)).makeTransparent)
+    }
+
+
+    def maybeMakeWith(tree: Tree, posOfWith: Position, wrap: Boolean) =
+      if(wrap) With(tree).setPos(posOfWith union tree.pos) else tree
+
     enums match {
-      case (t @ ValFrom(pat, rhs)) :: Nil =>
+      case (t @ MaybeWith(ValFrom(pat, rhs), _)) :: Nil =>
         makeCombination(closurePos(t.pos), mapName, rhs, pat, body)
-      case (t @ ValFrom(pat, rhs)) :: (rest @ (ValFrom(_, _) :: _)) =>
-        makeCombination(closurePos(t.pos), flatMapName, rhs, pat,
-                        mkFor(rest, sugarBody))
-      case (t @ ValFrom(pat, rhs)) :: Filter(test) :: rest =>
-        mkFor(ValFrom(pat, makeCombination(rhs.pos union test.pos, nme.withFilter, rhs, pat.duplicate, test)).setPos(t.pos) :: rest, sugarBody)
-      case (t @ ValFrom(pat, rhs)) :: rest =>
-        val valeqs = rest.take(definitions.MaxTupleArity - 1).takeWhile { ValEq.unapply(_).nonEmpty }
-        assert(!valeqs.isEmpty)
+      case (wt1 @ With(t1 @ ValFrom(pat1, rhs1))) :: (wt2 @ MaybeWith(t2 @ ValFrom(pat2, rhs2), hasWith)) :: rest =>
+        val pat = atPos((pat1.pos union pat2.pos).makeTransparent) { mkTuple(List(pat1, pat2)) }
+        val rhs = makeProduct(wt1.pos, rhs1, rhs2)
+        val combined = maybeMakeWith(ValFrom(pat, rhs).setPos(t1.pos union t2.pos), wt2.pos, hasWith)
+        mkFor(combined :: rest, sugarBody)
+      case (t @ ValFrom(pat, rhs)) :: (rest @ MaybeWith(ValFrom(_, _), _) :: _) =>
+        makeCombination(closurePos(t.pos), flatMapName, rhs, pat, mkFor(rest, sugarBody))
+      case (t1 @ MaybeWith(ValFrom(pat, rhs), hasWith1)) :: (t2 @ MaybeWith(Filter(test), hasWith2)) :: rest =>
+        val filteredRhs = makeCombination(rhs.pos union test.pos, nme.withFilter, rhs, pat.duplicate, test)
+        val filtered = maybeMakeWith(ValFrom(pat, filteredRhs).setPos(t1.pos), t2.pos, hasWith1 && hasWith2)
+        mkFor(filtered :: rest, sugarBody)
+      case (t @ MaybeWith(ValFrom(pat, rhs), hasWith)) :: rest =>
+        val valeqs = rest.take(definitions.MaxTupleArity - 1).takeWhile {
+          case MaybeWith(ValEq(_, _), _) => true
+          case _ => false
+        }
+        assert(valeqs.nonEmpty)
         val rest1 = rest.drop(valeqs.length)
-        val pats = valeqs map { case ValEq(pat, _) => pat }
-        val rhss = valeqs map { case ValEq(_, rhs) => rhs }
+        val pats = valeqs map { case MaybeWith(ValEq(pat, _), _) => pat }
+        val rhss = valeqs map { case MaybeWith(ValEq(_, rhs), _) => rhs }
+        val allHaveWith = hasWith && (valeqs forall { case With(_) => true; case _ => false })
+        val lastWithPos = valeqs.last.pos
         val defpat1 = makeBind(pat)
         val defpats = pats map makeBind
         val pdefs = (defpats, rhss).zipped flatMap mkPatDef
@@ -717,7 +762,9 @@ abstract class TreeGen {
         val pos1 =
           if (t.pos == NoPosition) NoPosition
           else rangePos(t.pos.source, t.pos.start, t.pos.point, rhs1.pos.end)
-        val vfrom1 = ValFrom(atPos(wrappingPos(allpats)) { mkTuple(allpats) }, rhs1).setPos(pos1)
+        val vfrom1 = maybeMakeWith(
+          ValFrom(atPos(wrappingPos(allpats)) { mkTuple(allpats)}, rhs1).setPos(pos1),
+          lastWithPos, allHaveWith)
         mkFor(vfrom1 :: rest1, sugarBody)
       case _ =>
         EmptyTree //may happen for erroneous input

--- a/test/files/run/forwith.check
+++ b/test/files/run/forwith.check
@@ -1,0 +1,32 @@
+creating a having 1
+creating mapped a having (1,2,3)
+flatMapping mapped a having (1,2,3)
+creating b having 2
+creating c having 3
+creating b with c having (2,3)
+creating d having 4
+creating b with c with d having ((2,3),4)
+creating filtered b with c with d having ((2,3),4)
+creating mapped filtered b with c with d having (((2,3),4),9)
+flatMapping mapped filtered b with c with d having (((2,3),4),9)
+creating e having 5
+creating f having 6
+creating e with f having (5,6)
+creating mapped e with f having 21
+
+creating a having 1
+creating mapped a having (1,2,3)
+foreach mapped a having (1,2,3)
+creating b having 2
+creating c having 3
+creating b with c having (2,3)
+creating d having 4
+creating b with c with d having ((2,3),4)
+creating filtered b with c with d having ((2,3),4)
+creating mapped filtered b with c with d having (((2,3),4),9)
+foreach mapped filtered b with c with d having (((2,3),4),9)
+creating e having 5
+creating f having 6
+creating e with f having (5,6)
+foreach e with f having (5,6)
+finished

--- a/test/files/run/forwith.scala
+++ b/test/files/run/forwith.scala
@@ -1,0 +1,59 @@
+// test `with` keyword in for comprehensions
+
+object Test {
+  case class Fut[+A](value: Option[A], name: String) {
+    println(s"creating $this")
+    def map[B](f: A => B): Fut[B] =
+      Fut(value.map(f), s"mapped $name")
+    def withFilter(p: A => Boolean): Fut[A] =
+      Fut(value.filter(p), s"filtered $name")
+    def product[B](other: Fut[B]): Fut[(A, B)] =
+      Fut((for (v <- value; ov <- other.value) yield (v, ov)), s"$name with ${other.name}")
+    def flatMap[B](f: A => Fut[B]): Fut[B] = {
+      println(s"flatMapping $this")
+      value.fold(Fut[B](None, name))(f)
+    }
+    def foreach(f: A => Unit): Unit = {
+      println(s"foreach $this")
+      value.foreach(f)
+    }
+    override def toString = name + value.fold("")(" having " + _)
+  }
+  object Fut {
+    def apply[A](a: A, name: String): Fut[A] = Fut(Option(a), name)
+  }
+
+  {
+    for {
+      a <- Fut(1, "a")
+      a2 = a * 2
+      a3 = a * 3
+      b <- Fut(2, "b") with
+      c <- Fut(3, "c") with
+      d <- Fut(4, "d") if d > a && d > b && d > c
+      d2 = b + c + d
+      e <- Fut(5, "e") with
+      f <- Fut(6, "f")
+    } yield a + b + c + d + e + f
+  }
+
+  println()
+
+  {
+    for {
+      a <- Fut(1, "a")
+      a2 = a * 2
+      a3 = a * 3
+      b <- Fut(2, "b") with
+      c <- Fut(3, "c") with
+      d <- Fut(4, "d") if d > a && d > b && d > c
+      d2 = b + c + d
+      e <- Fut(5, "e") with
+      f <- Fut(6, "f")
+    } {
+      println("finished")
+    }
+  }
+
+  def main(args: Array[String]) {}
+}

--- a/test/scalacheck/scala/reflect/quasiquotes/ForProps.scala
+++ b/test/scalacheck/scala/reflect/quasiquotes/ForProps.scala
@@ -4,11 +4,15 @@ import org.scalacheck._, Prop._, Gen._, Arbitrary._
 import scala.reflect.runtime.universe._, Flag._, internal.reificationSupport._
 
 object ForProps extends QuasiquoteProperties("for") {
-  case class ForEnums(val value: List[Tree])
+  case class ForEnums(value: List[Tree])
 
   def genSimpleBind: Gen[Bind] =
     for(name <- genTermName)
       yield pq"$name @ _"
+
+  def maybeWith(enumGen: Gen[Tree]): Gen[Tree] =
+    for(enum <- enumGen; wrap <- Arbitrary.arbitrary[Boolean])
+      yield if (wrap) fq"$enum with" else enum
 
   def genForFilter: Gen[Tree] =
     for(cond <- genIdent(genTermName))
@@ -23,19 +27,50 @@ object ForProps extends QuasiquoteProperties("for") {
       yield fq"$lhs = $rhs"
 
   def genForEnums(size: Int): Gen[ForEnums] =
-    for(first <- genForFrom; rest <- listOfN(size, oneOf(genForFrom, genForFilter, genForEq)))
-      yield new ForEnums(first :: rest)
+    for(first <- maybeWith(genForFrom); rest <- listOfN(size, maybeWith(oneOf(genForFrom, genForFilter, genForEq))))
+      yield ForEnums(first :: rest)
 
   implicit val arbForEnums: Arbitrary[ForEnums] = arbitrarySized(genForEnums)
 
+  object MaybeWith {
+    def apply(tree: Tree, hasWith: Boolean): Tree =
+      if (hasWith) fq"$tree with" else tree
+    def unapply(tree: Tree): Option[(Tree, Boolean)] = tree match {
+      case fq"$enum with" => Some((enum, true))
+      case _ => Some((tree, false))
+    }
+  }
+
+  // `with` keyword after Filter and ValEq is allowed, but all the Filters and ValEqs between two ValFroms must
+  // have that keyword or otherwise it's ignored and lost during parsing
+  private def stripRedundantWiths(enums: List[Tree]): List[Tree] = {
+    def loop(enums: List[Tree], keepWithUp: Boolean): (List[Tree], Boolean) = enums match {
+      case MaybeWith(t@fq"$pat <- $res", hasWith) :: rest =>
+        val (tailRes, keepWithDown) = loop(rest, hasWith)
+        (MaybeWith(t, hasWith && keepWithDown) :: tailRes, true)
+      case MaybeWith(t, hasWith) :: rest =>
+        val (tailRes, keepWithDown) = loop(rest, keepWithUp && hasWith)
+        (MaybeWith(t, hasWith && keepWithUp && keepWithDown) :: tailRes, hasWith && keepWithDown)
+      case Nil =>
+        (Nil, false)
+    }
+    val (result, _) = loop(enums, keepWithUp = false)
+    result
+  }
+
   property("construct-reconstruct for") = forAll { (enums: ForEnums, body: Tree) =>
-    val SyntacticFor(recoveredEnums, recoveredBody) = SyntacticFor(enums.value, body)
-    recoveredEnums ≈ enums.value && recoveredBody ≈ body
+    try {
+      val SyntacticFor(recoveredEnums, recoveredBody) = SyntacticFor(enums.value, body)
+      recoveredEnums ≈ stripRedundantWiths(enums.value) && recoveredBody ≈ body
+    } catch {
+      case e => e.printStackTrace()
+        throw e
+    }
   }
 
   property("construct-reconstruct for-yield") = forAll { (enums: ForEnums, body: Tree) =>
     val SyntacticForYield(recoveredEnums, recoveredBody) = SyntacticForYield(enums.value, body)
-    recoveredEnums ≈ enums.value && recoveredBody ≈ body
+    recoveredEnums ≈ stripRedundantWiths(enums.value) && recoveredBody ≈ body
   }
 
   val abcde = List(fq"a <-b", fq"if c", fq"d = e")


### PR DESCRIPTION
This PR is a proof of concept of new syntax bringing support of applicative desugaring into `for` comprehensions.

I know that such a change requires prior discussion and ultimately, a SIP. Here's a topic on Scala contributors forum where all the details of the proposal are explained: https://contributors.scala-lang.org/t/new-syntax-applicative-desugaring-in-for-comprehensions-with-pr/690