### PR TITLE
SI-9937 find nested java classes if InnerClass entry is missing

### DIFF
--- a/test/files/run/t9937/Test_1.java
+++ b/test/files/run/t9937/Test_1.java
@@ -1,0 +1,11 @@
+class C$D { public int i() { return 1; } }
+class C$E { public int i() { return 1; } }
+class C$F$G { public int i() { return 1; } }
+
+// Test1 has a reference to C$D, which is a top-level class in this case,
+// so there's no INNERCLASS attribute in Test1
+class Test_1 {
+  static C$D mD(C$D cd) { return cd; }
+  static C$E mE(C$E ce) { return ce; }
+  static C$F$G mG(C$F$G cg ) { return cg; }
+}

--- a/test/files/run/t9937/Test_2.java
+++ b/test/files/run/t9937/Test_2.java
@@ -1,0 +1,12 @@
+class C {
+  class D { public int i() { return 2; } }
+  static class E { public int i() { return 2; } }
+  static class F { static class G { public int i() { return 2; } } }
+}
+
+// Test2 has an INNERCLASS attribute for C$D
+class Test_2 {
+  public static int acceptD(C.D cd) { return cd.i(); }
+  public static int acceptE(C.E ce) { return ce.i(); }
+  public static int acceptG(C.F.G cg ) { return cg.i(); }
+}

--- a/test/files/run/t9937/Test_3.scala
+++ b/test/files/run/t9937/Test_3.scala
@@ -1,0 +1,8 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val c = new C
+    assert(Test_2.acceptD(Test_1.mD(new c.D)) == 2)
+    assert(Test_2.acceptE(Test_1.mE(new C.E)) == 2)
+    assert(Test_2.acceptG(Test_1.mG(new C.F.G)) == 2)
+  }
+}


### PR DESCRIPTION
When a classfile has a reference to an inner class C$D but no
InnerClass entry for it, the classfile parser would use the
top-level symbol C$D. In a different classfile, if there's also
a reference to C$D, but the InnerClass entry exists, the
symbol D owned by C (C.D) would be used. Therefore the two
signatures would be incompatible, which can lead to a spurious
type error.

Also, when an inner symbol C.D is resolved, the top-level
symbol C$D is invalidated and removed from the scope. A
subsequent lookup of the top-level symbol C$D (from a classfile
with a missing InnerClass entry) would fail.

This patch identifies the case when a class name containing
a $ is being looked up in a package. It splits the name, resolves
the outer class, and then searches for a member class.