### PR TITLE
per run immutable settings

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -75,7 +75,6 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   // alternate constructors ------------------------------------------
 
   override def settings = currentSettings
-  def currentRunSettings = curRun.runSettings
 
   /** Switch to turn on detailed type logs */
   var printTypings = settings.Ytyperdebug.value

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1075,7 +1075,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
   /** A Run is a single execution of the compiler on a set of units.
    */
-  class Run extends RunContextApi with RunReporting with RunParsing {
+  class Run extends RunContextApi with RunReporting with RunParsing with RunSettings {
     /** Have been running into too many init order issues with Run
      *  during erroneous conditions.  Moved all these vals up to the
      *  top of the file so at least they're not trivially null.
@@ -1540,6 +1540,12 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     }
   } // class Run
 
+
+  class PerRunSettings extends PerRunSettingsBase {
+    override val isScala211: Boolean = settings.isScala211
+    override val isScala212: Boolean = settings.isScala212
+  }
+  override protected def PerRunSettings: PerRunSettings = new PerRunSettings
   def printAllUnits() {
     print("[[syntax trees at end of %25s]]".format(phase))
     exitingPhase(phase)(currentRun.units foreach { unit =>

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -274,7 +274,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       body
   }
 
-  override protected def isDeveloper = settings.developer || super.isDeveloper
+  override protected def isDeveloper = settings.developer.boolValue || super.isDeveloper
 
   /** This is for WARNINGS which should reach the ears of scala developers
    *  whenever they occur, but are not useful for normal users. They should
@@ -303,7 +303,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   }
 
   @inline final override def debuglog(msg: => String) {
-    if (settings.debug)
+    if (settings.debug.boolValue)
       log(msg)
   }
 

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1545,9 +1545,10 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
 
   class PerRunSettingsGlobal extends PerRunSettings {
-    override val isScala211: Boolean = settings.isScala211
-    override val isScala212: Boolean = settings.isScala212
-    val isScala213: Boolean = settings.isScala213
+    override val isScala213: Boolean = settings.isScala213
+    override val isScala212: Boolean = isScala213 || settings.isScala212
+    override val isScala211: Boolean = isScala212 || settings.isScala211
+
     val debug = settings.debug.boolValue
 
     override val Xexperimental = settings.Xexperimental

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1551,6 +1551,8 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     val isScala213: Boolean = settings.isScala213
     val debug = settings.debug.boolValue
 
+    override val Xexperimental = settings.Xexperimental
+
     val current = settings
     //optimise settings
     private def optEnabled(choice: current.optChoice) = {

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -10,6 +10,7 @@ package nsc
 import java.io.{File, FileNotFoundException, IOException}
 import java.net.URL
 import java.nio.charset.{Charset, CharsetDecoder, IllegalCharsetNameException, UnsupportedCharsetException}
+
 import scala.collection.{immutable, mutable}
 import io.{AbstractFile, Path, SourceReader}
 import reporters.Reporter
@@ -28,6 +29,8 @@ import transform._
 import backend.{JavaPlatform, ScalaPrimitives}
 import backend.jvm.GenBCode
 import scala.language.postfixOps
+import scala.reflect.internal.PerRunSettings
+import scala.tools.nsc
 import scala.tools.nsc.ast.{TreeGen => AstTreeGen}
 import scala.tools.nsc.classpath._
 
@@ -1541,11 +1544,67 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   } // class Run
 
 
-  class PerRunSettings extends PerRunSettingsBase {
+  class PerRunSettingsGlobal extends PerRunSettings {
     override val isScala211: Boolean = settings.isScala211
     override val isScala212: Boolean = settings.isScala212
+
+    val current = settings
+    //optimise settings
+    private def optEnabled(choice: current.optChoice) = {
+      !optNone && {
+        current.opt.value.contains(choice) ||
+          !settings.opt.isSetByUser && settings.optChoices.lDefault.expandsTo.contains(choice)
+      }
+    }
+
+    override val optNone: Boolean = current.opt.contains(current.optChoices.lNone)
+
+
+    override val optUnreachableCode         = optEnabled(current.optChoices.unreachableCode)
+    override val optSimplifyJumps           = optEnabled(current.optChoices.simplifyJumps)
+    override val optCompactLocals           = optEnabled(current.optChoices.compactLocals)
+    override val optCopyPropagation         = optEnabled(current.optChoices.copyPropagation)
+    override val optRedundantCasts          = optEnabled(current.optChoices.redundantCasts)
+    override val optBoxUnbox                = optEnabled(current.optChoices.boxUnbox)
+    override val optNullnessTracking        = optEnabled(current.optChoices.nullnessTracking)
+    override val optClosureInvocations      = optEnabled(current.optChoices.closureInvocations)
+
+    override val optInlineProject           = optEnabled(current.optChoices.inlineProject)
+    override val optInlineGlobal            = optEnabled(current.optChoices.inlineGlobal)
+    override val optInlinerEnabled          = optInlineProject || optInlineGlobal
+
+    override val optBuildCallGraph          = optInlinerEnabled || optClosureInvocations
+    override val optAddToBytecodeRepository = optBuildCallGraph || optInlinerEnabled || optClosureInvocations
+
+    override val YoptTrace_isSetByUser: Boolean = settings.YoptTrace.isSetByUser
+    override val YoptTrace: String =  settings.YoptTrace.value
+
+    //----
+
+
+    override val optWarningsSummaryOnly = {
+      val value = current.optWarnings.value
+        value == current.optWarningsChoices.none ||
+        value == current.optWarningsChoices.atInlineFailedSummary
+    }
+
+    override val optWarningEmitAtInlineFailed =
+      !current.optWarnings.isSetByUser ||
+        current.optWarnings.contains(current.optWarningsChoices.atInlineFailedSummary) ||
+        current.optWarnings.contains(current.optWarningsChoices.atInlineFailed) ||
+        current.optWarnings.contains(current.optWarningsChoices.anyInlineFailed)
+
+    override val optWarningNoInlineMixed                      = current.optWarnings.contains(current.optWarningsChoices.noInlineMixed)
+    override val optWarningNoInlineMissingBytecode            = current.optWarnings.contains(current.optWarningsChoices.noInlineMissingBytecode)
+    override val optWarningNoInlineMissingScalaInlineInfoAttr = current.optWarnings.contains(current.optWarningsChoices.noInlineMissingScalaInlineInfoAttr)
+
+    override val optWarningAnyInlineFailed: Boolean = current.optWarnings.contains(current.optWarningsChoices.anyInlineFailed)
+    //---
+    override val YoptLogInline = current.YoptLogInline.value
+    override val YoptLogInline_isSetByUser = current.YoptLogInline.isSetByUser
+    override val YoptInlineHeuristics = current.YoptInlineHeuristics.value
   }
-  override protected def PerRunSettings: PerRunSettings = new PerRunSettings
+  override protected def PerRunSettings = new PerRunSettingsGlobal
   def printAllUnits() {
     print("[[syntax trees at end of %25s]]".format(phase))
     exitingPhase(phase)(currentRun.units foreach { unit =>

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -75,6 +75,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   // alternate constructors ------------------------------------------
 
   override def settings = currentSettings
+  def currentRunSettings = curRun.runSettings
 
   /** Switch to turn on detailed type logs */
   var printTypings = settings.Ytyperdebug.value
@@ -1547,6 +1548,8 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   class PerRunSettingsGlobal extends PerRunSettings {
     override val isScala211: Boolean = settings.isScala211
     override val isScala212: Boolean = settings.isScala212
+    val isScala213: Boolean = settings.isScala213
+    val debug = settings.debug.boolValue
 
     val current = settings
     //optimise settings

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
@@ -393,7 +393,7 @@ abstract class BCodeIdiomatic extends SubComponent {
     def emitInvoke(opcode: Int, owner: String, name: String, desc: String, itf: Boolean, pos: Position): Unit = {
       val node = new MethodInsnNode(opcode, owner, name, desc, itf)
       jmethod.instructions.add(node)
-      if (settings.optInlinerEnabled) callsitePositions(node) = pos
+      if (runSettings.optInlinerEnabled) callsitePositions(node) = pos
     }
 
     // can-multi-thread

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -19,6 +19,7 @@ import scala.tools.nsc.backend.jvm.analysis.BackendUtils
 import scala.tools.nsc.backend.jvm.opt._
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
+import scala.reflect.internal.PerRunSettings
 import scala.tools.nsc.settings.ScalaSettings
 
 /**
@@ -62,6 +63,8 @@ abstract class BTypes {
 
   // Allows access to the compiler settings for backend components that don't have a global in scope
   def compilerSettings: ScalaSettings
+
+  def runSettings : PerRunSettings
 
   /**
    * A map from internal names to ClassBTypes. Every ClassBType is added to this map on its
@@ -289,7 +292,7 @@ abstract class BTypes {
     // The InlineInfo is built from the classfile (not from the symbol) for all classes that are NOT
     // being compiled. For those classes, the info is only needed if the inliner is enabled, otherwise
     // we can save the memory.
-    if (!compilerSettings.optInlinerEnabled) BTypes.EmptyInlineInfo
+    if (!runSettings.optInlinerEnabled) BTypes.EmptyInlineInfo
     else fromClassfileAttribute getOrElse fromClassfileWithoutAttribute
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -59,6 +59,8 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
 
   def compilerSettings: ScalaSettings = settings
 
+  def runSettings = currentRun.runSettings
+
   // helpers that need access to global.
   // TODO @lry create a separate component, they don't belong to BTypesFromSymbols
 
@@ -525,7 +527,7 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
     // enclosingTopLevelClass is being compiled. after flatten, all classes are considered top-level,
     // so `compiles` would return `false`.
     if (exitingPickler(currentRun.compiles(classSym))) buildFromSymbol    // InlineInfo required for classes being compiled, we have to create the classfile attribute
-    else if (!compilerSettings.optInlinerEnabled) BTypes.EmptyInlineInfo // For other classes, we need the InlineInfo only inf the inliner is enabled.
+    else if (!runSettings.optInlinerEnabled) BTypes.EmptyInlineInfo // For other classes, we need the InlineInfo only inf the inliner is enabled.
     else {
       // For classes not being compiled, the InlineInfo is read from the classfile attribute. This
       // fixes an issue with mixed-in methods: the mixin phase enters mixin methods only to class

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -227,20 +227,20 @@ abstract class GenBCode extends BCodeSyncAndTry {
 
         // add classes to the bytecode repo before building the call graph: the latter needs to
         // look up classes and methods in the code repo.
-        if (settings.optAddToBytecodeRepository) q2.asScala foreach {
+        if (runSettings.optAddToBytecodeRepository) q2.asScala foreach {
           case Item2(_, mirror, plain, bean, sourceFilePath, _) =>
             val someSourceFilePath = Some(sourceFilePath)
             if (mirror != null) byteCodeRepository.add(mirror, someSourceFilePath)
             if (plain != null)  byteCodeRepository.add(plain, someSourceFilePath)
             if (bean != null)   byteCodeRepository.add(bean, someSourceFilePath)
         }
-        if (settings.optBuildCallGraph) q2.asScala foreach { item =>
+        if (runSettings.optBuildCallGraph) q2.asScala foreach { item =>
           // skip call graph for mirror / bean: wd don't inline into tem, and they are not used in the plain class
           if (item.plain != null) callGraph.addClass(item.plain)
         }
-        if (settings.optInlinerEnabled)
+        if (runSettings.optInlinerEnabled)
           bTypes.inliner.runInliner()
-        if (settings.optClosureInvocations)
+        if (runSettings.optClosureInvocations)
           closureOptimizer.rewriteClosureApplyInvocations()
       }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
@@ -102,7 +102,7 @@ class CallGraph[BT <: BTypes](val btypes: BT) {
       // It is also used to get the stack height at the call site.
 
       val analyzer = {
-        if (compilerSettings.optNullnessTracking && AsmAnalyzer.sizeOKForNullness(methodNode)) {
+        if (runSettings.optNullnessTracking && AsmAnalyzer.sizeOKForNullness(methodNode)) {
           Some(new AsmAnalyzer(methodNode, definingClass.internalName, new NullnessAnalyzer(btypes, methodNode)))
         } else if (AsmAnalyzer.sizeOKForBasicValue(methodNode)) {
           Some(new AsmAnalyzer(methodNode, definingClass.internalName))

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -124,7 +124,7 @@ class Inliner[BT <: BTypes](val btypes: BT) {
       val Right(callee) = request.callsite.callee // collectAndOrderInlineRequests returns callsites with a known callee
       val warnings = inline(request)
       for (warning <- warnings) {
-        if (warning.emitWarning(compilerSettings))
+        if (warning.emitWarning(runSettings))
           backendReporting.inlinerWarning(request.callsite.callsitePosition, warning.toString)
       }
     }

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -455,6 +455,7 @@ class MutableSettings(val errorFn: String => Unit)
     type T = Boolean
     protected var v: Boolean = false
     override def value: Boolean = v
+    def boolValue: Boolean = v
 
     def tryToSet(args: List[String]) = { value = true ; Some(args) }
     def unparse: List[String] = if (value) List(name) else Nil

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -223,6 +223,7 @@ trait ScalaSettings extends AbsScalaSettings
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")
 
+  type optChoice = optChoices.Value
   object optChoices extends MultiChoiceEnumeration {
     val unreachableCode         = Choice("unreachable-code",          "Eliminate unreachable code, exception handlers guarding no instructions, redundant metadata (debug information, line numbers).")
     val simplifyJumps           = Choice("simplify-jumps",            "Simplify branching instructions, eliminate unnecessary ones.")
@@ -260,29 +261,29 @@ trait ScalaSettings extends AbsScalaSettings
     descr = "Enable optimizations",
     domain = optChoices)
 
-  private def optEnabled(choice: optChoices.Choice) = {
-    !opt.contains(optChoices.lNone) && {
-      opt.contains(choice) ||
-      !opt.isSetByUser && optChoices.lDefault.expandsTo.contains(choice)
-    }
-  }
-
-  def optNone                    = opt.contains(optChoices.lNone)
-  def optUnreachableCode         = optEnabled(optChoices.unreachableCode)
-  def optSimplifyJumps           = optEnabled(optChoices.simplifyJumps)
-  def optCompactLocals           = optEnabled(optChoices.compactLocals)
-  def optCopyPropagation         = optEnabled(optChoices.copyPropagation)
-  def optRedundantCasts          = optEnabled(optChoices.redundantCasts)
-  def optBoxUnbox                = optEnabled(optChoices.boxUnbox)
-  def optNullnessTracking        = optEnabled(optChoices.nullnessTracking)
-  def optClosureInvocations      = optEnabled(optChoices.closureInvocations)
-
-  def optInlineProject           = optEnabled(optChoices.inlineProject)
-  def optInlineGlobal            = optEnabled(optChoices.inlineGlobal)
-  def optInlinerEnabled          = optInlineProject || optInlineGlobal
-
-  def optBuildCallGraph          = optInlinerEnabled || optClosureInvocations
-  def optAddToBytecodeRepository = optBuildCallGraph || optInlinerEnabled || optClosureInvocations
+//  private def optEnabled(choice: optChoices.Choice) = {
+//    !opt.contains(optChoices.lNone) && {
+//      opt.contains(choice) ||
+//      !opt.isSetByUser && optChoices.lDefault.expandsTo.contains(choice)
+//    }
+//  }
+//
+//  def optNone                    = opt.contains(optChoices.lNone)
+//  def optUnreachableCode         = optEnabled(optChoices.unreachableCode)
+//  def optSimplifyJumps           = optEnabled(optChoices.simplifyJumps)
+//  def optCompactLocals           = optEnabled(optChoices.compactLocals)
+//  def optCopyPropagation         = optEnabled(optChoices.copyPropagation)
+//  def optRedundantCasts          = optEnabled(optChoices.redundantCasts)
+//  def optBoxUnbox                = optEnabled(optChoices.boxUnbox)
+//  def optNullnessTracking        = optEnabled(optChoices.nullnessTracking)
+//  def optClosureInvocations      = optEnabled(optChoices.closureInvocations)
+//
+//  def optInlineProject           = optEnabled(optChoices.inlineProject)
+//  def optInlineGlobal            = optEnabled(optChoices.inlineGlobal)
+//  def optInlinerEnabled          = optInlineProject || optInlineGlobal
+//
+//  def optBuildCallGraph          = optInlinerEnabled || optClosureInvocations
+//  def optAddToBytecodeRepository = optBuildCallGraph || optInlinerEnabled || optClosureInvocations
 
   val YoptInlineHeuristics = ChoiceSetting(
     name = "-Yopt-inline-heuristics",
@@ -308,17 +309,18 @@ trait ScalaSettings extends AbsScalaSettings
     domain = optWarningsChoices,
     default = Some(List(optWarningsChoices.atInlineFailed.name)))
 
+  //FIXME - should be in currentRun - needed for reporting
   def optWarningsSummaryOnly = optWarnings.value subsetOf Set(optWarningsChoices.none, optWarningsChoices.atInlineFailedSummary)
-
-  def optWarningEmitAtInlineFailed =
-    !optWarnings.isSetByUser ||
-      optWarnings.contains(optWarningsChoices.atInlineFailedSummary) ||
-      optWarnings.contains(optWarningsChoices.atInlineFailed) ||
-      optWarnings.contains(optWarningsChoices.anyInlineFailed)
-
-  def optWarningNoInlineMixed                      = optWarnings.contains(optWarningsChoices.noInlineMixed)
-  def optWarningNoInlineMissingBytecode            = optWarnings.contains(optWarningsChoices.noInlineMissingBytecode)
-  def optWarningNoInlineMissingScalaInlineInfoAttr = optWarnings.contains(optWarningsChoices.noInlineMissingScalaInlineInfoAttr)
+//
+//  def optWarningEmitAtInlineFailed =
+//    !optWarnings.isSetByUser ||
+//      optWarnings.contains(optWarningsChoices.atInlineFailedSummary) ||
+//      optWarnings.contains(optWarningsChoices.atInlineFailed) ||
+//      optWarnings.contains(optWarningsChoices.anyInlineFailed)
+//
+//  def optWarningNoInlineMixed                      = optWarnings.contains(optWarningsChoices.noInlineMixed)
+//  def optWarningNoInlineMissingBytecode            = optWarnings.contains(optWarningsChoices.noInlineMissingBytecode)
+//  def optWarningNoInlineMissingScalaInlineInfoAttr = optWarnings.contains(optWarningsChoices.noInlineMissingScalaInlineInfoAttr)
 
   val YoptTrace = StringSetting("-Yopt-trace", "package/Class.method", "Trace the optimizer progress for methods; `_` to print all, prefix match to select.", "")
 

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -418,7 +418,7 @@ abstract class UnCurry extends InfoTransform
         (sym ne null) && sym.elisionLevel.exists { level =>
           if (sym.isMethod) level < settings.elidebelow.value
           else {
-            if (settings.isScala213) reporter.error(sym.pos, s"${sym.name}: Only methods can be marked @elidable!")
+            if (currentRunSettings.isScala213) reporter.error(sym.pos, s"${sym.name}: Only methods can be marked @elidable!")
             false
           }
         }

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -807,7 +807,7 @@ trait Contexts { self: Analyzer =>
       isAccessible(sym, pre) &&
       !(imported && {
         val e = scope.lookupEntry(name)
-        (e ne null) && (e.owner == scope) && (!settings.isScala212 || e.sym.exists)
+        (e ne null) && (e.owner == scope) && (!currentRun.runSettings.isScala212 || e.sym.exists)
       })
 
     /** Do something with the symbols with name `name` imported via the import in `imp`,

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -807,7 +807,7 @@ trait Contexts { self: Analyzer =>
       isAccessible(sym, pre) &&
       !(imported && {
         val e = scope.lookupEntry(name)
-        (e ne null) && (e.owner == scope) && (!currentRun.runSettings.isScala212 || e.sym.exists)
+        (e ne null) && (e.owner == scope) && (!currentRunSettings.isScala212 || e.sym.exists)
       })
 
     /** Do something with the symbols with name `name` imported via the import in `imp`,

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1423,17 +1423,17 @@ trait Implicits {
               maybeInvalidConversionError(s"the result type of an implicit conversion must be more specific than ${sym.name}")
               true
             }
-            if (prohibit(AnyRefClass) || (settings.isScala211 && prohibit(AnyValClass)))
+            if (prohibit(AnyRefClass) || (currentRunSettings.isScala211 && prohibit(AnyValClass)))
               result = SearchFailure
           case _                 => false
         }
-        if (settings.isScala211 && isInvalidConversionSource(pt)) {
+        if (currentRunSettings.isScala211 && isInvalidConversionSource(pt)) {
           maybeInvalidConversionError("an expression of type Null is ineligible for implicit conversion")
           result = SearchFailure
         }
       }
 
-      if (result.isFailure && settings.debug) // debuglog is not inlined for some reason
+      if (result.isFailure && currentRunSettings.debug) // debuglog is not inlined for some reason
         log(s"no implicits found for ${pt} ${pt.typeSymbol.info.baseClasses} ${implicitsOfExpectedType}")
 
       result

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1517,7 +1517,7 @@ trait Namers extends MethodSynthesis {
               val valOwner = owner.owner
               // there's no overriding outside of classes, and we didn't use to do this in 2.11, so provide opt-out
 
-              if (!currentRun.runSettings.isScala212 || !valOwner.isClass) WildcardType
+              if (!currentRunSettings.isScala212 || !valOwner.isClass) WildcardType
               else {
                 // normalize to getter so that we correctly consider a val overriding a def
                 // (a val's name ends in a " ", so can't compare to def)

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -61,11 +61,6 @@ trait Namers extends MethodSynthesis {
     private lazy val innerNamer =
       if (isTemplateContext(context)) createInnerNamer() else this
 
-    // Cached as a val because `settings.isScala212` parses the Scala version each time...
-    // Not in Namers because then we need to go to outer first to check this.
-    // I do think it's ok to check every time we create a Namer instance (so, not a lazy val).
-    private[this] val isScala212 = settings.isScala212
-
     def createNamer(tree: Tree): Namer = {
       val sym = tree match {
         case ModuleDef(_, _, _) => tree.symbol.moduleClass
@@ -1522,7 +1517,7 @@ trait Namers extends MethodSynthesis {
               val valOwner = owner.owner
               // there's no overriding outside of classes, and we didn't use to do this in 2.11, so provide opt-out
 
-              if (!isScala212 || !valOwner.isClass) WildcardType
+              if (!currentRun.runSettings.isScala212 || !valOwner.isClass) WildcardType
               else {
                 // normalize to getter so that we correctly consider a val overriding a def
                 // (a val's name ends in a " ", so can't compare to def)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -133,7 +133,7 @@ abstract class RefChecks extends Transform {
           case _                          => false
         }
         val haveDefaults = methods filter (
-          if (settings.isScala211)
+          if (currentRunSettings.isScala211)
              (sym => mexists(sym.info.paramss)(_.hasDefault) && !nme.isProtectedAccessorName(sym.name))
           else
             (sym => hasDefaultParam(sym.info) && !nme.isProtectedAccessorName(sym.name))
@@ -1417,7 +1417,7 @@ abstract class RefChecks extends Transform {
         if (!sym.isMethod || sym.isAccessor || sym.isLazy || sym.isDeferred)
           reporter.error(sym.pos, s"${sym.name}: Only methods can be marked @elidable.")
       }
-      if (settings.isScala213) checkIsElisible(tree.symbol)
+      if (currentRunSettings.isScala213) checkIsElisible(tree.symbol)
 
       tree match {
         case m: MemberDef =>

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1866,7 +1866,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       val impl2  = finishMethodSynthesis(impl1, clazz, context)
 
-      if (settings.isScala211  && mdef.symbol == PredefModule)
+      if (currentRunSettings.isScala211  && mdef.symbol == PredefModule)
         ensurePredefParentsAreInSameSourceFile(impl2)
 
       treeCopy.ModuleDef(mdef, typedMods, mdef.name, impl2) setType NoType
@@ -3354,7 +3354,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             // and lubbing the argument types (we treat SAM and FunctionN types equally, but non-function arguments
             // do not receive special treatment: they are typed under WildcardType.)
             val altArgPts =
-              if (settings.isScala212 && args.exists(treeInfo.isFunctionMissingParamType))
+              if (currentRunSettings.isScala212 && args.exists(treeInfo.isFunctionMissingParamType))
                 try alts.map(alt => formalTypes(alt.info.paramTypes, argslen).map(ft => (ft, alt))).transpose // do least amount of work up front
                 catch { case _: IllegalArgumentException => args.map(_ => Nil) } // fail safe in case formalTypes fails to align to argslen
               else args.map(_ => Nil) // will type under argPt == WildcardType

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -150,7 +150,7 @@ trait Unapplies extends ast.TreeDSL {
       case _                                                          => nme.unapply
     }
     val cparams    = List(ValDef(Modifiers(PARAM | SYNTHETIC), unapplyParamName, classType(cdef, tparams), EmptyTree))
-    val resultType = if (!settings.isScala212) TypeTree() else { // fix for SI-6541 under -Xsource:2.12
+    val resultType = if (!currentRunSettings.isScala212) TypeTree() else { // fix for SI-6541 under -Xsource:2.12
     def repeatedToSeq(tp: Tree) = tp match {
         case AppliedTypeTree(Select(_, tpnme.REPEATED_PARAM_CLASS_NAME), tps) => AppliedTypeTree(gen.rootScalaDot(tpnme.Seq), tps)
         case _                                                                => tp

--- a/src/compiler/scala/tools/nsc/util/RunnableInPhase.scala
+++ b/src/compiler/scala/tools/nsc/util/RunnableInPhase.scala
@@ -1,0 +1,34 @@
+package scala.tools.nsc.util
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Awaitable, Future}
+import scala.tools.nsc.{Global, Phase}
+object RunnableInPhase {
+  val idGen = new AtomicInteger
+}
+/**
+  * a wrapper to allow Runnables to be associated to a phase. Primarily useful for profiling
+  */
+abstract class RunnableInPhase(global: Global, val phase:Phase, val comment:String) extends Runnable {
+
+  val id = RunnableInPhase.idGen.incrementAndGet()
+  private var idle = 0L
+
+
+  final def run(): Unit = {
+    doRun()
+  }
+
+  def doRun() : Unit
+
+  def idle(future: Future[_], duration:Duration = Duration.Inf): Unit = {
+    if (!future.isCompleted) {
+      val start = System.nanoTime()
+      try Await.ready(future, duration)
+      finally idle += (System.nanoTime() - start)
+    }
+  }
+
+}

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -513,7 +513,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val TypeCreatorClass      = getClassIfDefined("scala.reflect.api.TypeCreator") // defined in scala-reflect.jar, so we need to be careful
     lazy val TreeCreatorClass      = getClassIfDefined("scala.reflect.api.TreeCreator") // defined in scala-reflect.jar, so we need to be careful
 
-    private def Context_210               = if (settings.isScala211) NoSymbol else getClassIfDefined("scala.reflect.macros.Context") // needed under -Xsource:2.10
+    private def Context_210               = if (currentRun.runSettings.isScala211) NoSymbol else getClassIfDefined("scala.reflect.macros.Context") // needed under -Xsource:2.10
     lazy val BlackboxContextClass         = getClassIfDefined("scala.reflect.macros.blackbox.Context").orElse(Context_210) // defined in scala-reflect.jar, so we need to be careful
 
     lazy val WhiteboxContextClass         = getClassIfDefined("scala.reflect.macros.whitebox.Context").orElse(Context_210) // defined in scala-reflect.jar, so we need to be careful
@@ -835,7 +835,7 @@ trait Definitions extends api.StandardDefinitions {
       (sym eq PartialFunctionClass) || (sym eq AbstractPartialFunctionClass)
     }
 
-    private[this] val doSam = settings.isScala212 || (settings.isScala211 && settings.Xexperimental)
+    private[this] val doSam = currentRun.runSettings.isScala212 || (currentRun.runSettings.isScala211 && settings.Xexperimental)
 
     /** The single abstract method declared by type `tp` (or `NoSymbol` if it cannot be found).
      *

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -513,7 +513,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val TypeCreatorClass      = getClassIfDefined("scala.reflect.api.TypeCreator") // defined in scala-reflect.jar, so we need to be careful
     lazy val TreeCreatorClass      = getClassIfDefined("scala.reflect.api.TreeCreator") // defined in scala-reflect.jar, so we need to be careful
 
-    private def Context_210               = if (currentRun.runSettings.isScala211) NoSymbol else getClassIfDefined("scala.reflect.macros.Context") // needed under -Xsource:2.10
+    private def Context_210               = if (currentRunSettings.isScala211) NoSymbol else getClassIfDefined("scala.reflect.macros.Context") // needed under -Xsource:2.10
     lazy val BlackboxContextClass         = getClassIfDefined("scala.reflect.macros.blackbox.Context").orElse(Context_210) // defined in scala-reflect.jar, so we need to be careful
 
     lazy val WhiteboxContextClass         = getClassIfDefined("scala.reflect.macros.whitebox.Context").orElse(Context_210) // defined in scala-reflect.jar, so we need to be careful
@@ -835,7 +835,7 @@ trait Definitions extends api.StandardDefinitions {
       (sym eq PartialFunctionClass) || (sym eq AbstractPartialFunctionClass)
     }
 
-    private[this] val doSam = currentRun.runSettings.isScala212 || (currentRun.runSettings.isScala211 && settings.Xexperimental)
+    private[this] val doSam = currentRunSettings.isScala212 || (currentRunSettings.isScala211 && currentRunSettings.Xexperimental)
 
     /** The single abstract method declared by type `tp` (or `NoSymbol` if it cannot be found).
      *

--- a/src/reflect/scala/reflect/internal/PerRunSetting.scala
+++ b/src/reflect/scala/reflect/internal/PerRunSetting.scala
@@ -3,8 +3,8 @@ package scala.reflect.internal
 abstract class PerRunSettings {
 
   val isScala211: Boolean
-
   val isScala212: Boolean
+  val isScala213: Boolean
 
   //optimise settings
   val optNone: Boolean
@@ -35,15 +35,20 @@ abstract class PerRunSettings {
   val optWarningNoInlineMissingScalaInlineInfoAttr : Boolean
   val optWarningAnyInlineFailed                    : Boolean
 
+  val Xexperimental : Boolean
+
   //---
   val YoptLogInline : String
   val YoptLogInline_isSetByUser : Boolean
   val YoptInlineHeuristics : String
 
+  val debug : Boolean
+
 }
 class SimplePerRunSettings extends PerRunSettings {
   override val isScala211: Boolean = true
   override val isScala212: Boolean = true
+  override val isScala213: Boolean = true
   override val optNone: Boolean = true
   override val optUnreachableCode: Boolean = true
   override val optSimplifyJumps: Boolean = true
@@ -70,4 +75,5 @@ class SimplePerRunSettings extends PerRunSettings {
   override val YoptLogInline = ""
   override val YoptLogInline_isSetByUser = false
   override val YoptInlineHeuristics = "???"
+  override val debug = false
 }

--- a/src/reflect/scala/reflect/internal/PerRunSetting.scala
+++ b/src/reflect/scala/reflect/internal/PerRunSetting.scala
@@ -76,4 +76,5 @@ class SimplePerRunSettings extends PerRunSettings {
   override val YoptLogInline_isSetByUser = false
   override val YoptInlineHeuristics = "???"
   override val debug = false
+  override val Xexperimental = false
 }

--- a/src/reflect/scala/reflect/internal/PerRunSetting.scala
+++ b/src/reflect/scala/reflect/internal/PerRunSetting.scala
@@ -1,0 +1,73 @@
+package scala.reflect.internal
+
+abstract class PerRunSettings {
+
+  val isScala211: Boolean
+
+  val isScala212: Boolean
+
+  //optimise settings
+  val optNone: Boolean
+  val optUnreachableCode: Boolean
+  val optSimplifyJumps: Boolean
+  val optCompactLocals: Boolean
+  val optCopyPropagation: Boolean
+  val optRedundantCasts: Boolean
+  val optBoxUnbox: Boolean
+  val optNullnessTracking: Boolean
+  val optClosureInvocations: Boolean
+  val optInlineProject: Boolean
+  val optInlineGlobal: Boolean
+  val optInlinerEnabled: Boolean
+  val optBuildCallGraph: Boolean
+  val optAddToBytecodeRepository: Boolean
+
+
+  val YoptTrace_isSetByUser : Boolean
+  val YoptTrace : String
+
+  val optWarningsSummaryOnly : Boolean
+
+  val optWarningEmitAtInlineFailed : Boolean
+
+  val optWarningNoInlineMixed                      : Boolean
+  val optWarningNoInlineMissingBytecode            : Boolean
+  val optWarningNoInlineMissingScalaInlineInfoAttr : Boolean
+  val optWarningAnyInlineFailed                    : Boolean
+
+  //---
+  val YoptLogInline : String
+  val YoptLogInline_isSetByUser : Boolean
+  val YoptInlineHeuristics : String
+
+}
+class SimplePerRunSettings extends PerRunSettings {
+  override val isScala211: Boolean = true
+  override val isScala212: Boolean = true
+  override val optNone: Boolean = true
+  override val optUnreachableCode: Boolean = true
+  override val optSimplifyJumps: Boolean = true
+  override val optCompactLocals: Boolean = true
+  override val optCopyPropagation: Boolean = true
+  override val optRedundantCasts: Boolean = true
+  override val optBoxUnbox: Boolean = true
+  override val optNullnessTracking: Boolean = true
+  override val optClosureInvocations: Boolean = true
+  override val optInlineProject: Boolean = true
+  override val optInlineGlobal: Boolean = true
+  override val optInlinerEnabled: Boolean = true
+  override val optBuildCallGraph: Boolean = true
+  override val optAddToBytecodeRepository: Boolean = true
+  override val YoptTrace_isSetByUser: Boolean = false
+  override val YoptTrace: String = ""
+  override val optWarningsSummaryOnly: Boolean = true
+  override val optWarningEmitAtInlineFailed: Boolean = true
+  override val optWarningNoInlineMixed: Boolean = true
+  override val optWarningNoInlineMissingBytecode: Boolean = true
+  override val optWarningNoInlineMissingScalaInlineInfoAttr: Boolean = true
+  override val optWarningAnyInlineFailed                    = true
+  //---
+  override val YoptLogInline = ""
+  override val YoptLogInline_isSetByUser = false
+  override val YoptInlineHeuristics = "???"
+}

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -210,6 +210,18 @@ abstract class SymbolTable extends macros.Universe
   /** The run identifier of the given period. */
   final def runId(period: Period): RunId = period >> 8
 
+  trait RunSettings {
+    val runSettings: PerRunSettings = PerRunSettings
+  }
+
+  type PerRunSettings <: PerRunSettingsBase
+  protected def PerRunSettings: PerRunSettings
+  abstract class PerRunSettingsBase {
+    def isScala211: Boolean
+    def isScala212: Boolean
+  }
+  def currentRun: RunSettings with RunReporting
+
   /** The phase identifier of the given period. */
   final def phaseId(period: Period): Phase#Id = period & 0xFF
 

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -214,12 +214,8 @@ abstract class SymbolTable extends macros.Universe
     val runSettings: PerRunSettings = PerRunSettings
   }
 
-  type PerRunSettings <: PerRunSettingsBase
   protected def PerRunSettings: PerRunSettings
-  abstract class PerRunSettingsBase {
-    def isScala211: Boolean
-    def isScala212: Boolean
-  }
+
   def currentRun: RunSettings with RunReporting
 
   /** The phase identifier of the given period. */

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -217,6 +217,7 @@ abstract class SymbolTable extends macros.Universe
   protected def PerRunSettings: PerRunSettings
 
   def currentRun: RunSettings with RunReporting
+  def currentRunSettings = currentRun.runSettings
 
   /** The phase identifier of the given period. */
   final def phaseId(period: Period): Phase#Id = period & 0xFF

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -61,7 +61,7 @@ abstract class SymbolTable extends macros.Universe
 
   def shouldLogAtThisPhase = false
   def isPastTyper = false
-  protected def isDeveloper: Boolean = settings.debug
+  protected def isDeveloper: Boolean = settings.debug.boolValue
 
   @deprecated("use devWarning if this is really a warning; otherwise use log", "2.11.0")
   def debugwarn(msg: => String): Unit = devWarning(msg)

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -75,7 +75,7 @@ trait Variances {
           else if (isExemptFromVariance(sym)) Bivariant
           else if (sym.isAliasType) (
             // Unsound pre-2.11 behavior preserved under -Xsource:2.10
-            if (settings.isScala211 || sym.isOverridingSymbol) Invariant
+            if (currentRun.runSettings.isScala211 || sym.isOverridingSymbol) Invariant
             else {
               currentRun.reporting.deprecationWarning(sym.pos, "Construct depends on unsound variance analysis and will not compile in scala 2.11 and beyond", "2.11.0")
               Bivariant

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -75,7 +75,7 @@ trait Variances {
           else if (isExemptFromVariance(sym)) Bivariant
           else if (sym.isAliasType) (
             // Unsound pre-2.11 behavior preserved under -Xsource:2.10
-            if (currentRun.runSettings.isScala211 || sym.isOverridingSymbol) Invariant
+            if (currentRunSettings.isScala211 || sym.isOverridingSymbol) Invariant
             else {
               currentRun.reporting.deprecationWarning(sym.pos, "Construct depends on unsound variance analysis and will not compile in scala 2.11 and beyond", "2.11.0")
               Bivariant

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -13,7 +13,7 @@ package settings
 abstract class MutableSettings extends AbsSettings {
 
   type Setting <: SettingValue
-  type BooleanSetting <: Setting { type T = Boolean }
+  type BooleanSetting <: Setting { type T = Boolean; def boolValue: Boolean }
   type IntSetting <: Setting { type T = Int }
   type MultiStringSetting <: Setting { type T = List[String] }
 

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -173,11 +173,11 @@ trait TypeComparers {
   // SI-2066 This prevents overrides with incompatible variance in higher order type parameters.
   private def methodHigherOrderTypeParamsSameVariance(sym1: Symbol, sym2: Symbol) = {
     def ignoreVariance(sym: Symbol) = !(sym.isHigherOrderTypeParameter && sym.logicallyEnclosingMember.isMethod)
-    !currentRun.runSettings.isScala211 || ignoreVariance(sym1) || ignoreVariance(sym2) || sym1.variance == sym2.variance
+    !currentRunSettings.isScala211 || ignoreVariance(sym1) || ignoreVariance(sym2) || sym1.variance == sym2.variance
   }
 
   private def methodHigherOrderTypeParamsSubVariance(low: Symbol, high: Symbol) =
-    !currentRun.runSettings.isScala211 || methodHigherOrderTypeParamsSameVariance(low, high) || low.variance.isInvariant
+    !currentRunSettings.isScala211 || methodHigherOrderTypeParamsSameVariance(low, high) || low.variance.isInvariant
 
   def isSameType2(tp1: Type, tp2: Type): Boolean = {
     def retry(lhs: Type, rhs: Type) = ((lhs ne tp1) || (rhs ne tp2)) && isSameType(lhs, rhs)

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -173,11 +173,11 @@ trait TypeComparers {
   // SI-2066 This prevents overrides with incompatible variance in higher order type parameters.
   private def methodHigherOrderTypeParamsSameVariance(sym1: Symbol, sym2: Symbol) = {
     def ignoreVariance(sym: Symbol) = !(sym.isHigherOrderTypeParameter && sym.logicallyEnclosingMember.isMethod)
-    !settings.isScala211 || ignoreVariance(sym1) || ignoreVariance(sym2) || sym1.variance == sym2.variance
+    !currentRun.runSettings.isScala211 || ignoreVariance(sym1) || ignoreVariance(sym2) || sym1.variance == sym2.variance
   }
 
   private def methodHigherOrderTypeParamsSubVariance(low: Symbol, high: Symbol) =
-    !settings.isScala211 || methodHigherOrderTypeParamsSameVariance(low, high) || low.variance.isInvariant
+    !currentRun.runSettings.isScala211 || methodHigherOrderTypeParamsSameVariance(low, high) || low.variance.isInvariant
 
   def isSameType2(tp1: Type, tp2: Type): Boolean = {
     def retry(lhs: Type, rhs: Type) = ((lhs ne tp1) || (rhs ne tp2)) && isSameType(lhs, rhs)

--- a/src/reflect/scala/reflect/runtime/JavaUniverse.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverse.scala
@@ -28,11 +28,16 @@ class JavaUniverse extends InternalSymbolTable with JavaUniverseForce with Refle
   }
 
   // minimal Run to get Reporting wired
-  def currentRun = new RunReporting {}
+  def currentRun = new RunReporting with RunSettings{}
   class PerRunReporting extends PerRunReportingBase {
     def deprecationWarning(pos: Position, msg: String, since: String): Unit = reporter.warning(pos, msg)
   }
   protected def PerRunReporting = new PerRunReporting
+  class PerRunSettings extends PerRunSettingsBase {
+    override def isScala211: Boolean = settings.isScala211
+    override def isScala212: Boolean = settings.isScala212
+  }
+  protected def PerRunSettings = new PerRunSettings
 
 
   type TreeCopier = InternalTreeCopierOps

--- a/src/reflect/scala/reflect/runtime/JavaUniverse.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverse.scala
@@ -2,8 +2,7 @@ package scala
 package reflect
 package runtime
 
-import scala.reflect.internal.{TreeInfo, SomePhase}
-import scala.reflect.internal.{SymbolTable => InternalSymbolTable}
+import scala.reflect.internal.{PerRunSettings, SimplePerRunSettings, SomePhase, TreeInfo, SymbolTable => InternalSymbolTable}
 import scala.reflect.runtime.{SymbolTable => RuntimeSymbolTable}
 import scala.reflect.api.{TypeCreator, Universe}
 
@@ -33,11 +32,11 @@ class JavaUniverse extends InternalSymbolTable with JavaUniverseForce with Refle
     def deprecationWarning(pos: Position, msg: String, since: String): Unit = reporter.warning(pos, msg)
   }
   protected def PerRunReporting = new PerRunReporting
-  class PerRunSettings extends PerRunSettingsBase {
-    override def isScala211: Boolean = settings.isScala211
-    override def isScala212: Boolean = settings.isScala212
+  final class PerRunSettingsJava extends SimplePerRunSettings {
+    override val isScala211: Boolean = settings.isScala211
+    override val isScala212: Boolean = settings.isScala212
   }
-  protected def PerRunSettings = new PerRunSettings
+  protected def PerRunSettings = new PerRunSettingsJava
 
 
   type TreeCopier = InternalTreeCopierOps

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -14,6 +14,7 @@ private[reflect] class Settings extends MutableSettings {
 
   class BooleanSetting(x: Boolean) extends Setting {
     type T = Boolean
+    def boolValue = x
     protected var v: Boolean = x
     override def value: Boolean = v
   }

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
@@ -82,8 +82,14 @@ class SymbolTableForUnitTesting extends SymbolTable {
     protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = println(msg)
   }
 
+  class PerRunSettings extends PerRunSettingsBase {
+    def isScala211: Boolean = true
+    def isScala212: Boolean = true
+  }
+  protected def PerRunSettings: PerRunSettings = new PerRunSettings
+
   // minimal Run to get Reporting wired
-  def currentRun = new RunReporting {}
+  def currentRun = new RunReporting with RunSettings {}
   class PerRunReporting extends PerRunReportingBase {
     def deprecationWarning(pos: Position, msg: String, since: String): Unit = reporter.warning(pos, msg)
   }

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
@@ -2,7 +2,7 @@ package scala.tools.nsc
 package symtab
 
 import scala.reflect.ClassTag
-import scala.reflect.internal.{NoPhase, Phase, SomePhase}
+import scala.reflect.internal.{NoPhase, PerRunSettings, Phase, SimplePerRunSettings, SomePhase}
 import scala.tools.util.PathResolver
 import util.ClassPath
 import io.AbstractFile
@@ -82,11 +82,11 @@ class SymbolTableForUnitTesting extends SymbolTable {
     protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = println(msg)
   }
 
-  class PerRunSettings extends PerRunSettingsBase {
-    def isScala211: Boolean = true
-    def isScala212: Boolean = true
-  }
-  protected def PerRunSettings: PerRunSettings = new PerRunSettings
+  class PerRunSettingsUnitTest extends SimplePerRunSettings {
+    override def isScala211: Boolean = true
+    override def isScala212: Boolean = true
+ }
+  protected def PerRunSettings = new PerRunSettingsUnitTest
 
   // minimal Run to get Reporting wired
   def currentRun = new RunReporting with RunSettings {}


### PR DESCRIPTION
settings are mutable vars

within a run they dont change, so create a data structure with immutable data that is optimised for the read access

this build on work from @retronym 

based on the normal test config - this is a minor cpu gain. I expected to see some allocation gain, but I presume this is optimized away

based on the results below this is about a 2.8% gain based on the mean of after 10 90%

```

ALL
                  RunName	Count	           AllWallMS	                   CPU_MS	                Allocated
              00_baseline	60	 11620.94 [+2.46% -0.82%]	 11064.06 [+2.42% -0.85%]	  2793.84 [+1.11% -0.99%]
10_perRunImmutableSettings	60	 10728.01 [+2.59% -0.89%]	 10515.10 [+2.47% -0.90%]	  2798.69 [+1.11% -0.99%]

after 10 90%
                  RunName	Count	           AllWallMS	                   CPU_MS	                Allocated
              00_baseline	46	 10212.12 [+1.37% -0.93%]	  9996.60 [+1.25% -0.94%]	  2783.93 [+1.00% -1.00%]
10_perRunImmutableSettings	46	  9919.79 [+1.03% -0.96%]	  9780.57 [+1.03% -0.96%]	  2788.79 [+1.00% -1.00%]
```
here is a breakdown of the phases that seem to benefit most
```
after 10 90% typer, no GC
                  RunName	Count	           AllWallMS	                   CPU_MS	                Allocated
              00_baseline	42	  2620.33 [+1.40% -0.92%]	  2598.59 [+1.30% -0.92%]	   584.64 [+1.00% -1.00%]
10_perRunImmutableSettings	43	  2562.37 [+1.05% -0.95%]	  2556.32 [+1.05% -0.95%]	   583.26 [+1.00% -1.00%]

after 10 90% patmat, no GC
                  RunName	Count	           AllWallMS	                   CPU_MS	                Allocated
              00_baseline	44	   447.58 [+1.22% -0.87%]	   444.96 [+1.19% -0.88%]	   109.19 [+1.00% -1.00%]
10_perRunImmutableSettings	42	   428.68 [+1.18% -0.89%]	   421.88 [+1.19% -0.85%]	   110.05 [+1.00% -1.00%]


after 10 90% pickler, no GC
                  RunName	Count	           AllWallMS	                   CPU_MS	                Allocated
              00_baseline	46	   121.46 [+1.12% -0.91%]	   122.28 [+1.15% -0.77%]	    20.84 [+1.00% -1.00%]
10_perRunImmutableSettings	46	    93.08 [+1.43% -0.79%]	    92.73 [+1.52% -0.67%]	    20.82 [+1.00% -1.00%]

after 10 90% jvm, no GC
                  RunName	Count	           AllWallMS	                   CPU_MS	                Allocated
              00_baseline	37	  2725.29 [+1.24% -0.93%]	  2665.54 [+1.13% -0.94%]	   617.55 [+1.00% -1.00%]
10_perRunImmutableSettings	37	  2584.80 [+1.05% -0.97%]	  2559.54 [+1.05% -0.97%]	   617.08 [+1.00% -1.00%]

```