### PR TITLE
WIP: Deduplicate safeToInt - Approach undecided - comments please

### DIFF
--- a/src/compiler/scala/tools/cmd/FromString.scala
+++ b/src/compiler/scala/tools/cmd/FromString.scala
@@ -22,44 +22,45 @@ abstract class FromString[+T](implicit m: OptManifest[T]) extends PartialFunctio
   def targetString: String = m.toString
 }
 
-object FromString {
+//object FromString {
   // We need this because we clash with the String => Path implicits.
-  private def toDir(s: String)  = new Directory(new java.io.File(s))
+//  private def toDir(s: String)  = new Directory(new java.io.File(s))
 
   /** Path related stringifiers.
    */
-  val ExistingDir: FromString[Directory] = new FromString[Directory] {
-    override def isDefinedAt(s: String) = toDir(s).isDirectory
-    def apply(s: String): Directory =
-      if (isDefinedAt(s)) toDir(s)
-      else cmd.runAndExit(println("'%s' is not an existing directory." format s))
-  }
-  def ExistingDirRelativeTo(root: Directory) = new FromString[Directory] {
-    private def resolve(s: String) = (toDir(s) toAbsoluteWithRoot root).toDirectory
-    override def isDefinedAt(s: String) = resolve(s).isDirectory
-    def apply(s: String): Directory =
-      if (isDefinedAt(s)) resolve(s)
-      else cmd.runAndExit(println("'%s' is not an existing directory." format resolve(s)))
-  }
+//  val ExistingDir: FromString[Directory] = new FromString[Directory] {
+//    override def isDefinedAt(s: String) = toDir(s).isDirectory
+//    def apply(s: String): Directory =
+//      if (isDefinedAt(s)) toDir(s)
+//      else cmd.runAndExit(println("'%s' is not an existing directory." format s))
+//  }
+//  def ExistingDirRelativeToXXX(root: Directory) = new FromString[Directory] {
+//    private def resolve(s: String) = (toDir(s) toAbsoluteWithRoot root).toDirectory
+//    override def isDefinedAt(s: String) = resolve(s).isDirectory
+//    def apply(s: String): Directory =
+//      if (isDefinedAt(s)) resolve(s)
+//      else cmd.runAndExit(println("'%s' is not an existing directory." format resolve(s)))
+//  }
 
   /** Argument expander, i.e. turns single argument "foo bar baz" into argument
    *  list "foo", "bar", "baz".
    */
-  val ArgumentsFromString: FromString[List[String]] = new FromString[List[String]] {
-    def apply(s: String) = toArgs(s)
-  }
+//  val ArgumentsFromString: FromString[List[String]] = new FromString[List[String]] {
+//    def apply(s: String) = toArgs(s)
+//  }
 
   /** Identity.
    */
-  implicit val StringFromString: FromString[String] = new FromString[String] {
-    def apply(s: String): String = s
-  }
+//  implicit val StringFromString: FromString[String] = new FromString[String] {
+//    def apply(s: String): String = s
+//  }
 
   /** Implicit as the most likely to be useful as-is.
    */
-  implicit val IntFromString: FromString[Int] = new FromString[Int] {
-    override def isDefinedAt(s: String)   = safeToInt(s).isDefined
-    def apply(s: String)                  = safeToInt(s).get
-    def safeToInt(s: String): Option[Int] = try Some(java.lang.Integer.parseInt(s)) catch { case _: NumberFormatException => None }
-  }
-}
+//  implicit val IntFromString: FromString[Int] = new FromString[Int] {
+//    override def isDefinedAt(s: String)   = safeToInt(s).isDefined
+//    def apply(s: String)                  = safeToInt(s).get
+//    // MARK
+//    def safeToInt(s: String): Option[Int] = try Some(java.lang.Integer.parseInt(s)) catch { case _: NumberFormatException => None }
+//  }
+//}

--- a/src/compiler/scala/tools/nsc/CompileSocket.scala
+++ b/src/compiler/scala/tools/nsc/CompileSocket.scala
@@ -191,6 +191,8 @@ class CompileSocket extends CompileOutputCommon {
   }
 
   // XXX way past time for this to be central
+  // MARK
+  // Compact but misses NumberFormatException: Try(x.toInt).toOption
   def parseInt(x: String): Option[Int] =
     try   { Some(x.toInt) }
     catch { case _: NumberFormatException => None }

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -426,6 +426,7 @@ class MutableSettings(val errorFn: String => Unit)
 
     def parseArgument(x: String): Option[Int] = {
       parser(x) orElse {
+// MARK
         try   { Some(x.toInt) }
         catch { case _: NumberFormatException => None }
       }


### PR DESCRIPTION
Not ready for merge.

I started looking at this,

```
  // XXX way past time for this to be central
  def parseInt(x: String): Option[Int] =
    try   { Some(x.toInt) }
    catch { case _: NumberFormatException => None }
```

Along the way I found one near duplication of this could be removed without compile or test errors.

I'm looking for some guidance on whether the object commented out in this PR should be removed or not.