### PR TITLE
SD-358 REPL power template more lint friendly

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -858,8 +858,8 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
       def envLines = {
         if (!isReplPower) Nil // power mode only for now
         else {
-          val escapedLine = Constant(originalLine).escapedStringValue
-          List(s"""def $$line = $escapedLine """, """def $trees = _root_.scala.Nil""")
+          val escapedLine = Constant(originalLine).escapedStringValue.replaceAllLiterally("$", "\"+\"$\"+\"")
+          List(s"""def $$line = $escapedLine""", s"""def $$trees = _root_.scala.Nil""")
         }
       }
       def preamble = s"""


### PR DESCRIPTION
Power mode exposes the current line of source as `$line`,
but a quoted interpolation looks like a missing interpolator.

Quote dollar by splitting and splicing the string.

Don't interpolate in the template because of fussiness
under `-Yno-predef`.

```
$ scala -Dscala.repl.power -Xlint
Welcome to Scala 2.12.1 (OpenJDK 64-Bit Server VM, Java 1.8.0_112).
Type in expressions for evaluation. Or try :help.

scala>  s"1 = ${42}" + " " + $line

scala> <console>:6: warning: possible missing interpolator: detected an interpolated expression
  def $line = "s\"1 = ${42}\" + \" \" + $line" ;
              ^
res0: String = 1 = 42 s"1 = ${42}" + " " + $line
```
is now

```
scala> s"1 = ${42}" + $line // show

scala> object $read extends scala.AnyRef {
  def $line = "s\"1 = ".+("$").+("{42}\" + ").+("$").+("line // show");
  def $trees = _root_.scala.Nil;
                                      val res0 = StringContext("1 = ", "").s(42).+($line)
res0: String = 1 = 42s"1 = ${42}" + $line // show
```