### PR TITLE
`CompleterWrapper` delegates `typeParams`.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -611,6 +611,9 @@ trait Namers extends MethodSynthesis {
     }
 
     class CompleterWrapper(completer: TypeCompleter) extends TypeCompleter {
+      // override important when completer.isInstanceOf[PolyTypeCompleter]!
+      override val typeParams = completer.typeParams
+
       val tree = completer.tree
 
       override def complete(sym: Symbol): Unit = {

--- a/test/files/pos/userdefined_apply_poly_overload.scala
+++ b/test/files/pos/userdefined_apply_poly_overload.scala
@@ -1,0 +1,13 @@
+object Foo {
+  // spurious error if:
+  //   - this definition precedes that of apply (which is overloaded with the synthetic one derived from the case class)
+  //   - AND `Foo.apply` is explicitly applied to `[A]` (no error if `[A]` is inferred)
+  //
+  def referToPolyOverloadedApply[A]: Foo[A] = Foo.apply[A]("bla")
+  //                                                   ^
+  //  found   : String("bla")
+  //  required: Int
+
+  def apply[A](x: Int): Foo[A] = ???
+}
+case class Foo[A](x: String) // must be polymorphic


### PR DESCRIPTION
Fixes the problem reported with #5730 by @xuwei-k and @sjrd in scala/scala-dev#352.