### PR TITLE
Optimize baseTypeIndex

### DIFF
--- a/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
+++ b/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
@@ -45,10 +45,10 @@ trait BaseTypeSeqs {
     if (Statistics.canEnable) Statistics.incCounter(baseTypeSeqCount)
     if (Statistics.canEnable) Statistics.incCounter(baseTypeSeqLenTotal, elems.length)
     private[this] val typeSymbols = {
-      val tmp = new Array[Symbol](elems.length)
+      val tmp = new Array[Int](elems.length)
       var i = 0
       while (i < elems.length) {
-        tmp(i) = elems(i).typeSymbol
+        tmp(i) = elems(i).typeSymbol.id
         i += 1
       }
       tmp
@@ -105,13 +105,14 @@ trait BaseTypeSeqs {
     def rawElem(i: Int) = elems(i)
 
     /** The type symbol of the type at i'th position in this sequence */
-    def typeSymbol(i: Int): Symbol = typeSymbols(i)
+    def typeSymbol(i: Int): Symbol = elems(i).typeSymbol
 
     final def baseTypeIndex(sym: Symbol): Int = {
+      val symId = sym.id
       var i = 0
       val len = length
       while (i < len) {
-        if (typeSymbols(i) eq sym) return i
+        if (typeSymbols(i) == symId) return i
         i += 1
       }
       -1

--- a/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
+++ b/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
@@ -44,6 +44,15 @@ trait BaseTypeSeqs {
   self =>
     if (Statistics.canEnable) Statistics.incCounter(baseTypeSeqCount)
     if (Statistics.canEnable) Statistics.incCounter(baseTypeSeqLenTotal, elems.length)
+    private[this] val typeSymbols = {
+      val tmp = new Array[Symbol](elems.length)
+      var i = 0
+      while (i < elems.length) {
+        tmp(i) = elems(i).typeSymbol
+        i += 1
+      }
+      tmp
+    }
 
     /** The number of types in the sequence */
     def length: Int = elems.length
@@ -96,7 +105,17 @@ trait BaseTypeSeqs {
     def rawElem(i: Int) = elems(i)
 
     /** The type symbol of the type at i'th position in this sequence */
-    def typeSymbol(i: Int): Symbol = elems(i).typeSymbol
+    def typeSymbol(i: Int): Symbol = typeSymbols(i)
+
+    final def baseTypeIndex(sym: Symbol): Int = {
+      var i = 0
+      val len = length
+      while (i < len) {
+        if (typeSymbols(i) eq sym) return i
+        i += 1
+      }
+      -1
+    }
 
     /** Return all evaluated types in this sequence as a list */
     def toList: List[Type] = elems.toList
@@ -233,7 +252,6 @@ trait BaseTypeSeqs {
   class MappedBaseTypeSeq(orig: BaseTypeSeq, f: Type => Type) extends BaseTypeSeq(orig.parents map f, orig.elems) {
     override def apply(i: Int) = f(orig.apply(i))
     override def rawElem(i: Int) = f(orig.rawElem(i))
-    override def typeSymbol(i: Int) = orig.typeSymbol(i)
     override def toList = orig.toList map f
     override def copy(head: Type, offset: Int) = (orig map f).copy(head, offset)
     override def map(g: Type => Type) = lateMap(g)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -902,20 +902,7 @@ trait Types
      *  @return    the index of given class symbol in the BaseTypeSeq of this type,
      *             or -1 if no base type with given class symbol exists.
      */
-    def baseTypeIndex(sym: Symbol): Int = {
-      val bts = baseTypeSeq
-      var lo = 0
-      var hi = bts.length - 1
-      while (lo <= hi) {
-        val mid = (lo + hi) / 2
-        val btssym = bts.typeSymbol(mid)
-        if (sym == btssym) return mid
-        else if (sym isLess btssym) hi = mid - 1
-        else if (btssym isLess sym) lo = mid + 1
-        else abort("sym is neither `sym == btssym`, `sym isLess btssym` nor `btssym isLess sym`")
-      }
-      -1
-    }
+    def baseTypeIndex(sym: Symbol): Int = baseTypeSeq.baseTypeIndex(sym)
 
     /** If this is a ExistentialType, PolyType or MethodType, a copy with cloned type / value parameters
      *  owned by `owner`. Identity for all other types.

--- a/test/files/run/StubErrorHK.check
+++ b/test/files/run/StubErrorHK.check
@@ -1,6 +1,0 @@
-error: newSource1.scala:4: Symbol 'type stuberrors.A' is missing from the classpath.
-This symbol is required by 'type stuberrors.B.D'.
-Make sure that type A is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
-A full rebuild may help if 'B.class' was compiled against an incompatible version of stuberrors.
-      println(new B)
-                  ^

--- a/test/files/run/StubErrorReturnTypePolyFunction.check
+++ b/test/files/run/StubErrorReturnTypePolyFunction.check
@@ -7,9 +7,3 @@ A full rebuild may help if 'D.class' was compiled against an incompatible versio
 error: newSource1.scala:13: type arguments [stuberrors.D] do not conform to method foo's type parameter bounds [T <: stuberrors.A]
       b.foo[D]
            ^
-error: newSource1.scala:13: Symbol 'type stuberrors.A' is missing from the classpath.
-This symbol is required by 'type stuberrors.B.T'.
-Make sure that type A is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
-A full rebuild may help if 'B.class' was compiled against an incompatible version of stuberrors.
-      b.foo[D]
-      ^


### PR DESCRIPTION
Before:

```
[info] Benchmark                                   (extraArgs)  (source)    Mode  Cnt     Score   Error  Units
[info] HotScalacBenchmark.compile                                         sample  350  1468.390 ± 5.570  ms/op
```

After:

```
[info] Benchmark                                   (extraArgs)  (source)    Mode  Cnt     Score   Error  Units
[info] HotScalacBenchmark.compile                                         sample  385  1421.226 ± 5.465  ms/op
```

Which is a 3% improvement.