### PR TITLE
minor BTypes optimisations

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -1357,7 +1357,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
       val markers = if (addScalaSerializableMarker) classBTypeFromSymbol(definitions.SerializableClass).toASMType :: Nil else Nil
       visitInvokeDynamicInsnLMF(bc.jmethod, sam.name.toString, invokedType, samMethodType, implMethodHandle, constrainedType, isSerializable, markers)
       if (isSerializable)
-        addIndyLambdaImplMethod(cnode.name, implMethodHandle :: Nil)
+        addIndyLambdaImplMethod(cnode.name, implMethodHandle)
     }
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -123,17 +123,30 @@ abstract class BTypes {
    * has the method.
    */
   val indyLambdaImplMethods: mutable.AnyRefMap[InternalName, mutable.LinkedHashSet[asm.Handle]] = recordPerRunCache(mutable.AnyRefMap())
+
+  /**
+    * add methods
+    * @return the added methods. Note the order is undefined
+    */
   def addIndyLambdaImplMethod(hostClass: InternalName, handle: Seq[asm.Handle]): Seq[asm.Handle] = {
     if (handle.isEmpty) Nil else {
       val set = indyLambdaImplMethods.getOrElseUpdate(hostClass, mutable.LinkedHashSet())
-      val added = handle.filterNot(set)
-      set ++= handle
-      added
+      if (set isEmpty) {
+        set ++= handle
+        handle
+      } else {
+        var added = List.empty[asm.Handle]
+        handle foreach { h => if (set.add(h)) added ::= h}
+        added
+      }
     }
+  }
+  def addIndyLambdaImplMethod(hostClass: InternalName, handle: asm.Handle): Boolean = {
+    indyLambdaImplMethods.getOrElseUpdate(hostClass, mutable.LinkedHashSet()).add(handle)
   }
   def removeIndyLambdaImplMethod(hostClass: InternalName, handle: Seq[asm.Handle]): Unit = {
     if (handle.nonEmpty)
-      indyLambdaImplMethods.getOrElseUpdate(hostClass, mutable.LinkedHashSet()) --= handle
+      indyLambdaImplMethods.get(hostClass).foreach(_ --= handle)
   }
 
   def getIndyLambdaImplMethods(hostClass: InternalName): Iterable[asm.Handle] = {
@@ -258,7 +271,7 @@ abstract class BTypes {
   def inlineInfoFromClassfile(classNode: ClassNode): InlineInfo = {
     def fromClassfileAttribute: Option[InlineInfo] = {
       if (classNode.attrs == null) None
-      else classNode.attrs.asScala.collect({ case a: InlineInfoAttribute => a}).headOption.map(_.inlineInfo)
+      else classNode.attrs.asScala.collectFirst{ case a: InlineInfoAttribute => a.inlineInfo}
     }
 
     def fromClassfileWithoutAttribute = {
@@ -272,13 +285,13 @@ abstract class BTypes {
       // require special handling. Excluding is OK because they are never inlined.
       // Here we are parsing from a classfile and we don't need to do anything special. Many of these
       // primitives don't even exist, for example Any.isInstanceOf.
-      val methodInfos = classNode.methods.asScala.map(methodNode => {
+      val methodInfos:Map[String,MethodInlineInfo] = classNode.methods.asScala.map(methodNode => {
         val info = MethodInlineInfo(
           effectivelyFinal                    = BytecodeUtils.isFinalMethod(methodNode),
           annotatedInline                     = false,
           annotatedNoInline                   = false)
         (methodNode.name + methodNode.desc, info)
-      }).toMap
+      })(scala.collection.breakOut)
       InlineInfo(
         isEffectivelyFinal = BytecodeUtils.isFinalClass(classNode),
         sam = inlinerHeuristics.javaSam(classNode.name),
@@ -895,11 +908,6 @@ abstract class BTypes {
 
       assert(info.get.nestedClasses.forall(c => ifInit(c)(_.isNestedClass.get)), info.get.nestedClasses)
     }
-
-    /**
-     * @return The class name without the package prefix
-     */
-    def simpleName: String = internalName.split("/").last
 
     def isInterface: Either[NoClassBTypeInfo, Boolean] = info.map(i => (i.flags & asm.Opcodes.ACC_INTERFACE) != 0)
 


### PR DESCRIPTION
performance result - disapointing - havent looked why
```
after 10 90% jvm, no GC
                  RunName	Count	           AllWallMS	                   CPU_MS	                Allocated
              00_baseline	36	  2499.87 [+1.05% -0.95%]	  2472.66 [+1.06% -0.96%]	   602.25 [+1.00% -1.00%]
          12_minor_BTypes	34	  2513.46 [+1.03% -0.97%]	  2501.84 [+1.02% -0.97%]	   603.24 [+1.00% -1.00%]
```