### PR TITLE
[WIP] Reestablish support for dependent types in TypeTags

### DIFF
--- a/src/compiler/scala/reflect/reify/codegen/GenSymbols.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenSymbols.scala
@@ -140,7 +140,7 @@ trait GenSymbols {
   def reifyFreeType(binding: Tree): Tree =
     reifyIntoSymtab(binding.symbol) { sym =>
       if (reifyDebug) println("Free type: %s (%s)".format(sym, sym.accurateKindString))
-      state.reificationIsConcrete = false
+      if (!sym.hasAttachment[TypeIsConcrete.type]) state.reificationIsConcrete = false
       val name: TermName = nme.REIFY_FREE_PREFIX append sym.name
       Reification(name, binding, mirrorBuildCall(nme.newFreeType, reify(sym.name.toString), mirrorBuildCall(nme.FlagsRepr, reify(sym.flags)), reify(origin(sym))))
     }

--- a/src/compiler/scala/reflect/reify/codegen/GenTypes.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenTypes.scala
@@ -55,6 +55,10 @@ trait GenTypes {
       case tpe @ ConstantType(value) =>
         mirrorBuildCall(nme.ConstantType, reifyProduct(value))
       case tpe @ TypeRef(pre, sym, args) =>
+        if (isPossibleConcretePath(pre, sym)) {
+          pre.typeSymbolDirect.updateAttachment(TypeIsConcrete)
+          sym.updateAttachment(TypeIsConcrete)
+        }
         reifyBuildCall(nme.TypeRef, pre, sym, args)
       case tpe @ TypeBounds(lo, hi) =>
         reifyBuildCall(nme.TypeBounds, lo, hi)

--- a/src/compiler/scala/reflect/reify/codegen/GenUtils.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenUtils.scala
@@ -99,6 +99,14 @@ trait GenUtils {
     case TypeRef(SingleType(_, _), sym, _) if sym.isAbstractType && !sym.isExistential => true
     case _ => false
   }
+  
+  def isPossibleConcretePath(pre: Type, sym: Symbol) = (pre, pre.widen) match {
+    case (SingleType(_,_), RefinedType(_,_)) => sym.info match {
+      case TypeBounds(_,_) => false
+      case _ => true
+    }
+    case _ => false
+  }
 
   def isCrossStageTypeBearer(tree: Tree): Boolean = tree match {
     case TypeApply(hk, _) => isCrossStageTypeBearer(hk)

--- a/src/compiler/scala/reflect/reify/utils/StdAttachments.scala
+++ b/src/compiler/scala/reflect/reify/utils/StdAttachments.scala
@@ -15,4 +15,6 @@ trait StdAttachments {
     }
 
   case class ReifyAliasAttachment(sym: Symbol, alias: TermName)
+  
+  case object TypeIsConcrete
 }

--- a/test/files/neg/macro-reify-typetag-deptypes.check
+++ b/test/files/neg/macro-reify-typetag-deptypes.check
@@ -1,0 +1,19 @@
+macro-reify-typetag-deptypes.scala:5: error: No TypeTag available for Test.a.T
+  typeOf[a.T]
+        ^
+macro-reify-typetag-deptypes.scala:8: error: No TypeTag available for Test.b.F[Int]
+  typeOf[b.F[Int]]
+        ^
+macro-reify-typetag-deptypes.scala:11: error: No TypeTag available for Test.c.T
+  typeOf[c.T]
+        ^
+macro-reify-typetag-deptypes.scala:14: error: No TypeTag available for Test.d.T
+  typeOf[d.T]
+        ^
+macro-reify-typetag-deptypes.scala:17: error: No TypeTag available for Test.e.T
+  typeOf[e.T]
+        ^
+macro-reify-typetag-deptypes.scala:20: error: No TypeTag available for Test.f.T
+  typeOf[f.T]
+        ^
+6 errors found

--- a/test/files/neg/macro-reify-typetag-deptypes.flags
+++ b/test/files/neg/macro-reify-typetag-deptypes.flags
@@ -1,0 +1,1 @@
+-language:existentials

--- a/test/files/neg/macro-reify-typetag-deptypes.scala
+++ b/test/files/neg/macro-reify-typetag-deptypes.scala
@@ -1,0 +1,21 @@
+object Test extends App {
+  import scala.reflect.runtime.universe.typeOf
+  
+  val a: AnyRef{ type T } = new { type T }
+  typeOf[a.T]
+  
+  val b: AnyRef{ type F[x] } = new { type F[x] }
+  typeOf[b.F[Int]]
+  
+  val c: AnyRef{ type T >: Some[Int] <: Option[Int] } = new { type T >: Some[Int] <: Option[Int] }
+  typeOf[c.T]
+  
+  val d: AnyRef{ type A; type T = A } = new { type A; type T = A }
+  typeOf[d.T]
+  
+  val e: AnyRef{ type T = a.T } = new { type T = a.T }
+  typeOf[e.T]
+  
+  val f = locally { class Local; new { type T = Local } }
+  typeOf[f.T]
+}

--- a/test/files/run/macro-reify-typetag-deptypes.check
+++ b/test/files/run/macro-reify-typetag-deptypes.check
@@ -1,0 +1,8 @@
+TypeTag[Test.a.T]
+true
+TypeTag[Test.b.F[Int]]
+true
+TypeTag[Test.c.T]
+true
+TypeTag[Test.d.T]
+true

--- a/test/files/run/macro-reify-typetag-deptypes.scala
+++ b/test/files/run/macro-reify-typetag-deptypes.scala
@@ -1,0 +1,20 @@
+object Test extends App {
+  import scala.reflect.runtime.universe.{typeTag, typeOf}
+  
+  val a: AnyRef{ type T = Int } = new { type T = Int }
+  println(typeTag[a.T])
+  println(typeOf[a.T] <:< typeOf[Int]) //TODO this should be =:= every time (issue 10254)
+  
+  val b: AnyRef{ type F[x] = Option[x] } = new { type F[x] = Option[x] }
+  println(typeTag[b.F[Int]])
+  println(typeOf[b.F[Int]] <:< typeOf[Option[Int]])
+  
+  trait Foo { type T }
+  val c: Foo { type T = String } = new Foo { type T = String }
+  println(typeTag[c.T])
+  println(typeOf[c.T] <:< typeOf[String])
+  
+  val d: Foo { type T = a.T } = new Foo { type T = a.T }
+  println(typeTag[d.T])
+  println(typeOf[d.T] <:< typeOf[Int])
+}


### PR DESCRIPTION
[This commit](https://github.com/scala/scala/commit/524c90d09f2fb4687b312f2c7597393978d50b6a) outlawed free types from TypeTag, for good reasons. Alas this also means things like the following don't work:

```
val a = new { type T = Int }
typeOf[a.T]

trait Foo { type T }
val foo = new Foo { type T = Int }
typeOf[foo.T]
```
But this does work, which seems a bit inconsistent to me:
```
object a { type T = Int }
typeOf[a.T]
```

This pull request attempts to bring back support for the first type of path dependent types, while keeping the other illegal cases like local classes in the land of WeakTypeTag.