### PR TITLE
SI-2458 Make spec example live test

### DIFF
--- a/test/files/neg/ambiguous-same.check
+++ b/test/files/neg/ambiguous-same.check
@@ -1,0 +1,6 @@
+ambiguous-same.scala:13: error: reference to x is ambiguous;
+it is both defined in object X and imported subsequently by
+import X.x
+    x
+    ^
+one error found

--- a/test/files/neg/ambiguous-same.scala
+++ b/test/files/neg/ambiguous-same.scala
@@ -1,0 +1,15 @@
+
+// When faced with ambiguities between imports,
+// an attempt is made to see if the imports intend
+// identical types.
+//
+// Here, no attempt is made to notice that x
+// names the same thing.
+//
+object X {
+  val x = 42
+  def f = {
+    import X.x
+    x
+  }
+}

--- a/test/files/neg/specification-scopes.check
+++ b/test/files/neg/specification-scopes.check
@@ -1,12 +1,12 @@
-P_2.scala:14: error: reference to x is ambiguous;
-it is both defined in object C and imported subsequently by
-import Q.X._
-          println("L14: "+x)   // reference to 'x' is ambiguous here
-                          ^
-P_2.scala:19: error: reference to y is ambiguous;
+P_2.scala:15: error: reference to x is ambiguous;
+it is both defined in value <local Y> and imported subsequently by
+import q.X._
+        println(s"L15: $x")   // reference to `x' is ambiguous here
+                        ^
+P_2.scala:21: error: reference to y is ambiguous;
 it is imported twice in the same scope by
-import P.X._
+import p.X._
 and import X.y
-            println("L19: "+y) // reference to 'y' is ambiguous here
-                            ^
+          println(s"L21: $y") // reference to `y' is ambiguous here
+                          ^
 two errors found

--- a/test/files/neg/specification-scopes/P_1.scala
+++ b/test/files/neg/specification-scopes/P_1.scala
@@ -1,6 +1,7 @@
-package P {
-  object X { val x = 1; val y = 2; }
+package p {
+  object X { val x = 1; val y = 2 }
 }
-package Q {
-  object X { val x = true; val y = "" }
+
+package q {
+  object X { val x = true; val y = false }
 }

--- a/test/files/neg/specification-scopes/P_2.scala
+++ b/test/files/neg/specification-scopes/P_2.scala
@@ -1,21 +1,24 @@
-package P {                    // 'X' bound by package clause
-  import Console._             // 'println' bound by wildcard import
-  object A {
-    println("L4: "+X)          // 'X' refers to 'P.X' here
-    object B {
-      import Q._               // 'X' bound by wildcard import
-      println("L7: "+X)        // 'X' refers to 'Q.X' here
-      import X._               // 'x' and 'y' bound by wildcard import
-      println("L8: "+x)        // 'x' refers to 'Q.X.x' here
-      object C {
-        val x = 3              // 'x' bound by local definition
-        println("L12: "+x);    // 'x' refers to constant '3' here
-        { import Q.X._         // 'x' and 'y' bound by wildcard
-          println("L14: "+x)   // reference to 'x' is ambiguous here
-          import X.y           // 'y' bound by explicit import
-          println("L16: "+y);  // 'y' refers to 'Q.X.y' here
-          { val x = "abc"      // 'x' bound by local definition
-            import P.X._       // 'x' and 'y' bound by wildcard
-            println("L19: "+y) // reference to 'y' is ambiguous here
-            println("L20: "+x) // 'x' refers to string ''abc'' here
+package p {                   // `X' bound by package clause
+import Console._              // `println' bound by wildcard import
+object Y {
+  println(s"L4: $X")          // `X' refers to `p.X' here
+  locally {
+    import q._                // `X' bound by wildcard import
+    println(s"L7: $X")        // `X' refers to `q.X' here
+    import X._                // `x' and `y' bound by wildcard import
+    println(s"L9: $x")        // `x' refers to `q.X.x' here
+    locally {
+      val x = 3               // `x' bound by local definition
+      println(s"L12: $x")     // `x' refers to constant `3' here
+      locally {
+        import q.X._          // `x' and `y' bound by wildcard import
+        println(s"L15: $x")   // reference to `x' is ambiguous here
+        import X.y            // `y' bound by explicit import
+        println(s"L17: $y")   // `y' refers to `q.X.y' here
+        locally {
+          val x = "abc"       // `x' bound by local definition
+          import p.X._        // `x' and `y' bound by wildcard import
+          println(s"L21: $y") // reference to `y' is ambiguous here
+          println(s"L22: $x") // `x' refers to string "abc" here
 }}}}}}
+


### PR DESCRIPTION
Synchronize the live test with the spec update,
which is trivial.

Also add a neg test showing that an imported name
remains ambiguous even if it resolves to the
definition in scope with which it is ambiguous.