### PR TITLE
Stricter type parameters of collection.mutable.HashEntry

### DIFF
--- a/src/library/scala/collection/mutable/HashEntry.scala
+++ b/src/library/scala/collection/mutable/HashEntry.scala
@@ -12,7 +12,7 @@ package mutable
 /** Class used internally.
  *  @since 2.8
  */
-trait HashEntry [A, E] {
+trait HashEntry [A, E <: HashEntry[A, E]] {
   val key: A
   var next: E = _
 }


### PR DESCRIPTION
`next` in `scala.collection.mutable.HashEntry` is of type `Object` in bytecode. This requires additional interface casts to `HashEntry` (e.g. in `HashTable.resize()`).

This change makes semantics of type parameters more clear and improves generated bytecode a little bit.