### PR TITLE
SI-7960 and SI-10023 Improve REPL Output for val/var and Method Definitions

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2526,7 +2526,12 @@ trait Types
     //TODO this may be generalised so that the only constraint is dependencies are acyclic
     def approximate: MethodType = MethodType(params, resultApprox)
 
-    override def safeToString = paramString(this) + resultType
+    override def safeToString = {
+      resultType match {
+        case MethodType(_, _) => paramString(this) + resultType
+        case _                => paramString(this) + ": " + resultType
+      }
+    }
 
     override def cloneInfo(owner: Symbol) = {
       val vparams = cloneSymbolsAtOwner(params, owner)

--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -141,7 +141,8 @@ trait MemberHandlers {
           if (replProps.vids) s"""" + f"@$${System.identityHashCode($path)}%8x" + """"
           else ""
 
-        val nameString = colorName(prettyName) + vidString
+        val modifier = if (member.mods.isMutable) "var" else "val"
+        val nameString = s"$modifier ${colorName(prettyName)}" + vidString
         val typeString = colorType(req typeOf name)
         s""" + "$nameString: $typeString = " + $resultString"""
       }

--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -154,7 +154,9 @@ trait MemberHandlers {
     override def resultExtractionCode(req: Request) = {
       val nameString = colorName(name)
       val typeString = colorType(req typeOf name)
-      if (mods.isPublic) s""" + "$nameString: $typeString\\n"""" else ""
+      val nameSeparator = if (member.vparamss.isEmpty) ": " else ""
+
+      if (mods.isPublic) s""" + "def $nameString$nameSeparator$typeString\\n"""" else ""
     }
   }
 


### PR DESCRIPTION
Proposed fix for SI-7960 and SI-10023.  REPL now prints vals vars and defs as follows:

```
scala> val a = 1
val a: Int = 1

scala> var b = 2
var b: Int = 2

scala> def foo = 3
def foo: Int

scala> def foo() = 4
def foo(): Int

scala> def foo2(a: Int, b: Int) = a + b
def foo2(a: Int, b: Int): Int

scala> def foo3(a: Int)(b: Int) = (c: Int) => a + b + c
def foo3(a: Int)(b: Int): Int => Int
```

For `def foo = 3` it's not clear to me if this should actually output `val foo: Int` which is what is actually defined, but would be slightly confusing.

Not sure if it might also make sense to put "defined" in front of the outputs here to make it consistent with elsewhere.

If this looks good I can update the failing REPL based tests.  It looks like some error outputs are affected as well (see t7157.check for example).