### PR TITLE
Use partest 1.1.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,6 +19,6 @@ scala.binary.version=2.12
 #  - jline: shaded with JarJar and included in scala-compiler
 #  - partest: used for running the tests
 scala-xml.version.number=1.0.6
-partest.version.number=1.1.0
+partest.version.number=1.1.1
 scala-asm.version=5.1.0-scala-2
 jline.version=2.14.3


### PR DESCRIPTION
During bootstrapping 2.13.x, partest is re-built. Partest has Xlint
fatal warnings enabled.

scala/scala#5402 enabled new unused warnings, which fails the 1.1.0
build.