### PR TITLE
Merge 2.12 to 2.13

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -146,8 +146,8 @@ trait MethodSynthesis {
         // if there's no field symbol, the ValDef tree receives the getter symbol and thus is not a synthetic
         if (fieldSym != NoSymbol) {
           context.unit.synthetics(getterSym) = getter.derivedTree(getterSym)
-          getterSym setInfo new namer.AccessorTypeCompleter(tree, tree.tpt.isEmpty, isBean = false, isSetter = false)
-        } else getterSym setInfo new namer.ValTypeCompleter(tree)
+          getterSym setInfo namer.accessorTypeCompleter(tree, tree.tpt.isEmpty, isBean = false, isSetter = false)
+        } else getterSym setInfo namer.valTypeCompleter(tree)
 
         enterInScope(getterSym)
 
@@ -155,17 +155,17 @@ trait MethodSynthesis {
           val setter = Setter(tree)
           val setterSym = setter.createSym
           context.unit.synthetics(setterSym) = setter.derivedTree(setterSym)
-          setterSym setInfo new namer.AccessorTypeCompleter(tree, tree.tpt.isEmpty, isBean = false, isSetter = true)
+          setterSym setInfo namer.accessorTypeCompleter(tree, tree.tpt.isEmpty, isBean = false, isSetter = true)
           enterInScope(setterSym)
         }
 
         // TODO: delay emitting the field to the fields phase (except for private[this] vals, which only get a field and no accessors)
         if (fieldSym != NoSymbol) {
-          fieldSym setInfo new namer.ValTypeCompleter(tree)
+          fieldSym setInfo namer.valTypeCompleter(tree)
           enterInScope(fieldSym)
         }
       } else {
-        getterSym setInfo new namer.ValTypeCompleter(tree)
+        getterSym setInfo namer.valTypeCompleter(tree)
         enterInScope(getterSym)
       }
 
@@ -208,11 +208,11 @@ trait MethodSynthesis {
           sym
         }
 
-        val getterCompleter = new namer.AccessorTypeCompleter(tree, missingTpt, isBean = true, isSetter = false)
+        val getterCompleter = namer.accessorTypeCompleter(tree, missingTpt, isBean = true, isSetter = false)
         enterInScope(deriveBeanAccessor(if (hasBeanProperty) "get" else "is") setInfo getterCompleter)
 
         if (tree.mods.isMutable) {
-          val setterCompleter = new namer.AccessorTypeCompleter(tree, missingTpt, isBean = true, isSetter = true)
+          val setterCompleter = namer.accessorTypeCompleter(tree, missingTpt, isBean = true, isSetter = true)
           enterInScope(deriveBeanAccessor("set") setInfo setterCompleter)
         }
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -664,7 +664,17 @@ trait Namers extends MethodSynthesis {
 
           if (suppress) {
             sym setInfo ErrorType
+
+            // There are two ways in which we exclude the symbol from being added in typedStats::addSynthetics,
+            // because we don't know when the completer runs with respect to this loop in addSynthetics
+            //  for (sym <- scope)
+            //    for (tree <- context.unit.synthetics.get(sym) if shouldAdd(sym)) {
+            //      if (!sym.initialize.hasFlag(IS_ERROR))
+            //        newStats += typedStat(tree)
+            // If we're already in the loop, set the IS_ERROR flag and trigger the condition `sym.initialize.hasFlag(IS_ERROR)`
             sym setFlag IS_ERROR
+            // Or, if we are not yet in the addSynthetics loop, we can just retract our symbol from the synthetics for this unit.
+            companionContext.unit.synthetics -= sym
 
             // Don't unlink in an error situation to generate less confusing error messages.
             // Ideally, our error reporting would distinguish overloaded from recursive user-defined apply methods without signature,

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3168,7 +3168,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           for (sym <- scope)
             // OPT: shouldAdd is usually true. Call it here, rather than in the outer loop
             for (tree <- context.unit.synthetics.get(sym) if shouldAdd(sym)) {
-              newStats += typedStat(tree) // might add even more synthetics to the scope
+              // if the completer set the IS_ERROR flag, retract the stat (currently only used by applyUnapplyMethodCompleter)
+              if (!sym.initialize.hasFlag(IS_ERROR))
+                newStats += typedStat(tree) // might add even more synthetics to the scope
               context.unit.synthetics -= sym
             }
           // the type completer of a synthetic might add more synthetics. example: if the

--- a/test/files/run/t10261/Companion_1.scala
+++ b/test/files/run/t10261/Companion_1.scala
@@ -1,0 +1,4 @@
+trait Companion[T] {
+  def parse(value: String): Option[T]
+  def apply(value: String): T = parse(value).get
+}

--- a/test/files/run/t10261/Test_2.scala
+++ b/test/files/run/t10261/Test_2.scala
@@ -1,0 +1,14 @@
+import scala.util.Try
+
+object C extends Companion[C] {
+  def parse(v: String) = if (v.nonEmpty) Some(new C(v)) else None
+}
+
+case class C(value: String)
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    assert(Try{C("")}.isFailure, "Empty value should fail to parse") // check that parse is used to validate input
+    assert(C("a").value == "a", "Unexpected value")
+  }
+}


### PR DESCRIPTION
```
> git fetch upstream -f
> git checkout -b merge-2.12-to-2.13-apr-13
Switched to a new branch 'merge-2.12-to-2.13-apr-13'
> git lg -n 1 | cat
*   6f0f1624d0 - (HEAD -> merge-2.12-to-2.13-apr-13, upstream/2.13.x, 2.13.x) Merge pull request #5849 from lrytz/partest-1.1.1 (2 minutes ago) <Lukas Rytz>
> export mb=$(git merge-base upstream/2.12.x 2.13.x)
> git log --graph --oneline --decorate $mb..upstream/2.12.x | cat
*   21d12e9f5e (upstream/2.12.x) Merge pull request #5845 from adriaanm/t10261
|\
| * 747e223223 Actually retract clashing synthetic apply/unapply
|/
* 12c240d69b Merge pull request #5844 from adriaanm/rework-5816
* 2804c6316e Revert some of ade53a123. Use completer factory methods.
> git merge upstream/2.12.x
```
No conflicts