### PR TITLE
Make Ordering.by create a new Ordering for performance

### DIFF
--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -215,8 +215,13 @@ object Ordering extends LowPriorityOrderingImplicits {
     * This function is an analogue to Ordering.on where the Ordering[S]
     * parameter is passed implicitly.
     */
-  def by[T, S](f: T => S)(implicit ord: Ordering[S]): Ordering[T] =
-    fromLessThan((x, y) => ord.lt(f(x), f(y)))
+  def by[T, S](f: T => S)(implicit ord: Ordering[S]): Ordering[T] = new Ordering[T] {
+    def compare(x: T, y: T) = ord.compare(f(x), f(y))
+    override def lt(x: T, y: T): Boolean = ord.lt(f(x), f(y))
+    override def gt(x: T, y: T): Boolean = ord.gt(f(x), f(y))
+    override def gteq(x: T, y: T): Boolean = ord.gteq(f(x), f(y))
+    override def lteq(x: T, y: T): Boolean = ord.lteq(f(x), f(y))
+  }
 
   trait UnitOrdering extends Ordering[Unit] {
     def compare(x: Unit, y: Unit) = 0


### PR DESCRIPTION
The previous `Ordering.by` method was a wrapper for `Ordering.fromLessThan` that did not cache the values actually being compared. This meant the function had to be reevaluated if the first item was not less than the second. This reevaluation added a non-trivial performance cost to even simple extractor functions like `_.id`. Consequently `Ordering`s created with the `by` factory method are substantially slower than those created with the `fromLessThan` factory method.

This PR replaces `Ordering.by` with a new implementation that improves sort performance up to 40% and brings its performance close to that of `fromLessThan` in simple benchmarks as demonstrated in [this gist](https://gist.github.com/BrianLondon/2bad831eeeb1b7a7d65584a276231f20) and the following example output.

*Current Head*

```
Benchmark for Ordering.by (20 calls in 21.63 s)
  Time:    1.050 s   95% CI 1.036 s - 1.064 s   (n=20)
  Garbage: 31.30 ms   (n=67 sweeps measured)
Benchmark for Ordering.fromLessThan (20 calls in 11.92 s)
  Time:    595.4 ms   95% CI 587.3 ms - 603.6 ms   (n=20)
  Garbage: 700.0 us   (n=1 sweeps measured)
Benchmark for custom Ordering (20 calls in 9.800 s)
  Time:    485.2 ms   95% CI 481.2 ms - 489.1 ms   (n=19)
  Garbage: 700.0 us   (n=1 sweeps measured)
```

*This PR Version*

```
Benchmark for Ordering.by (20 calls in 12.61 s)
  Time:    598.6 ms   95% CI 590.4 ms - 606.8 ms   (n=19)
  Garbage: 28.85 ms   (n=50 sweeps measured)
Benchmark for Ordering.fromLessThan (20 calls in 11.22 s)
  Time:    555.4 ms   95% CI 551.8 ms - 559.1 ms   (n=18)
  Garbage: 650.0 us   (n=1 sweeps measured)
Benchmark for custom Ordering (20 calls in 9.770 s)
  Time:    486.0 ms   95% CI 481.1 ms - 491.0 ms   (n=19)
```

This code change does change the behavior of the `Ordering` created in certain edge cases. It is possible that someone passed a side-effecting `f` into `by`. Since `f` will be called fewer times the resulting output might change. It is hard to imagine a situation where this isn't already a bug, but in the interest of full disclosure here's sample code that produces different output with the new version.


```scala
var counter = 0

case class IntWrapper(n: Int)

implicit val badOrdering: Ordering[IntWrapper] = Ordering.by { x =>
  counter += 1
  if (counter > 10) counter else x.n
}

val pairs = List.fill(10)(IntWrapper(2) -> IntWrapper(2))
println(pairs map { case (l, r) => implicitly[Ordering[IntWrapper]].compare(l, r) })
```

That code will produce `List(0, 0, 0, 0, 0, -1, -1, -1, -1, -1)` for the PR version and `List(0, 0, 1, -1, -1, -1, -1, -1, -1, -1)` for the current 2.12.x head.


