### PR TITLE
Update error message for t5717

### DIFF
--- a/test/files/run/t5717.check
+++ b/test/files/run/t5717.check
@@ -1,1 +1,1 @@
-error: error writing a/B: t5717-run.obj/a/B.class: t5717-run.obj/a is not a directory
+error: error writing a/B: java.nio.file.FileSystemException t5717-run.obj/a/B.class: Not a directory


### PR DESCRIPTION
We started checking the error message of this test only recently,
in #5835. In 7a6dc1a, the backend was changed to use java.nio, and
the error message changed. Its PR was not rebased on the tip of
2.12.x, so the change of error message went unnoticed.

Fixes scala/scala-dev#377