### PR TITLE
Optimize symbol substitution

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -147,6 +147,7 @@ trait Types
     override def termSymbol = underlying.termSymbol
     override def termSymbolDirect = underlying.termSymbolDirect
     override def typeParams = underlying.typeParams
+    @deprecated("No longer used in the compiler implementation", since = "2.12.3")
     override def boundSyms = underlying.boundSyms
     override def typeSymbol = underlying.typeSymbol
     override def typeSymbolDirect = underlying.typeSymbolDirect
@@ -468,8 +469,9 @@ trait Types
      *  the empty list for all other types */
     def typeParams: List[Symbol] = List()
 
-    /** For a (potentially wrapped) poly or existential type, its bound symbols,
-     *  the empty list for all other types */
+    /** For a (potentially wrapped) poly, method or existential type, its directly bound symbols,
+     *  the empty set for all other types */
+    @deprecated("No longer used in the compiler implementation", since = "2.12.3")
     def boundSyms: immutable.Set[Symbol] = emptySymbolSet
 
     /** Replace formal type parameter symbols with actual type arguments. ErrorType on arity mismatch.
@@ -1085,7 +1087,7 @@ trait Types
     override def baseTypeSeq: BaseTypeSeq = supertype.baseTypeSeq
     override def baseTypeSeqDepth: Depth = supertype.baseTypeSeqDepth
     override def baseClasses: List[Symbol] = supertype.baseClasses
-  }
+ }
 
   /** A base class for types that represent a single value
    *  (single-types and this-types).
@@ -1106,13 +1108,8 @@ trait Types
       if (pre.isOmittablePrefix) pre.fullName + ".type"
       else prefixString + "type"
     }
-/*
-    override def typeOfThis: Type = typeSymbol.typeOfThis
-    override def bounds: TypeBounds = TypeBounds(this, this)
-    override def prefix: Type = NoType
-    override def typeArgs: List[Type] = List()
-    override def typeParams: List[Symbol] = List()
-*/
+    @deprecated("No longer used in the compiler implementation", since = "2.12.3")
+    override def boundSyms: Set[Symbol] = emptySymbolSet
   }
 
   /** An object representing an erroneous type */
@@ -2505,6 +2502,7 @@ trait Types
 
     override def paramTypes = mapList(params)(symTpe) // OPT use mapList rather than .map
 
+    @deprecated("No longer used in the compiler implementation", since = "2.12.3")
     override def boundSyms = resultType.boundSyms ++ params
 
     override def resultType(actuals: List[Type]) =
@@ -2562,6 +2560,7 @@ trait Types
     override def baseTypeSeqDepth: Depth = resultType.baseTypeSeqDepth
     override def baseClasses: List[Symbol] = resultType.baseClasses
     override def baseType(clazz: Symbol): Type = resultType.baseType(clazz)
+    @deprecated("No longer used in the compiler implementation", since = "2.12.3")
     override def boundSyms = resultType.boundSyms
     override def safeToString: String = "=> "+ resultType
     override def kind = "NullaryMethodType"
@@ -2594,6 +2593,7 @@ trait Types
     override def decls: Scope = resultType.decls
     override def termSymbol: Symbol = resultType.termSymbol
     override def typeSymbol: Symbol = resultType.typeSymbol
+    @deprecated("No longer used in the compiler implementation", since = "2.12.3")
     override def boundSyms = immutable.Set[Symbol](typeParams ++ resultType.boundSyms: _*)
     override def prefix: Type = resultType.prefix
     override def baseTypeSeq: BaseTypeSeq = resultType.baseTypeSeq
@@ -2650,6 +2650,7 @@ trait Types
     override def isTrivial = false
     override def bounds = TypeBounds(maybeRewrap(underlying.bounds.lo), maybeRewrap(underlying.bounds.hi))
     override def parents = underlying.parents map maybeRewrap
+    @deprecated("No longer used in the compiler implementation", since = "2.12.3")
     override def boundSyms = quantified.toSet
     override def prefix = maybeRewrap(underlying.prefix)
     override def typeArgs = underlying.typeArgs map maybeRewrap

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -698,18 +698,32 @@ private[internal] trait TypeMaps {
     // OPT this check was 2-3% of some profiles, demoted to -Xdev
     if (isDeveloper) assert(sameLength(from, to), "Unsound substitution from "+ from +" to "+ to)
 
+    private[this] var fromHasTermSymbol = false
+    private[this] var fromMin = Int.MaxValue
+    private[this] var fromMax = Int.MinValue
+    private[this] var fromSize = 0
+    from.foreach {
+      sym =>
+        fromMin = math.min(fromMin, sym.id)
+        fromMax = math.max(fromMax, sym.id)
+        fromSize += 1
+        if (sym.isTerm) fromHasTermSymbol = true
+    }
+
     /** Are `sym` and `sym1` the same? Can be tuned by subclasses. */
     protected def matches(sym: Symbol, sym1: Symbol): Boolean = sym eq sym1
 
     /** Map target to type, can be tuned by subclasses */
     protected def toType(fromtp: Type, tp: T): Type
 
+    // We don't need to recurse into the `restpe` below because we will encounter
+    // them in the next level of recursion, when the result of this method is passed to `mapOver`.
     protected def renameBoundSyms(tp: Type): Type = tp match {
-      case MethodType(ps, restp) =>
-        createFromClonedSymbols(ps, restp)((ps1, tp1) => copyMethodType(tp, ps1, renameBoundSyms(tp1)))
-      case PolyType(bs, restp) =>
-        createFromClonedSymbols(bs, restp)((ps1, tp1) => PolyType(ps1, renameBoundSyms(tp1)))
-      case ExistentialType(bs, restp) =>
+      case MethodType(ps, restp) if fromHasTermSymbol && fromContains(ps) =>
+        createFromClonedSymbols(ps, restp)((ps1, tp1) => copyMethodType(tp, ps1, tp1))
+      case PolyType(bs, restp) if fromContains(bs) =>
+        createFromClonedSymbols(bs, restp)((ps1, tp1) => PolyType(ps1, tp1))
+      case ExistentialType(bs, restp) if fromContains(bs) =>
         createFromClonedSymbols(bs, restp)(newExistentialType)
       case _ =>
         tp
@@ -722,10 +736,27 @@ private[internal] trait TypeMaps {
       else subst(tp, sym, from.tail, to.tail)
       )
 
+    private def fromContains(syms: List[Symbol]): Boolean = {
+      def fromContains(sym: Symbol): Boolean = {
+        // OPT Try cheap checks based on the range of symbol ids in from first.
+        //     Equivalent to `from.contains(sym)`
+        val symId = sym.id
+        val fromMightContainSym = symId >= fromMin && symId <= fromMax
+        fromMightContainSym && (
+          symId == fromMin || symId == fromMax || (fromSize > 2 && from.contains(sym))
+        )
+      }
+      var syms1 = syms
+      while (syms1 ne Nil) {
+        val sym = syms1.head
+        if (fromContains(sym)) return true
+        syms1 = syms1.tail
+      }
+      false
+    }
+
     def apply(tp0: Type): Type = if (from.isEmpty) tp0 else {
-      val boundSyms             = tp0.boundSyms
-      val tp1                   = if (boundSyms.nonEmpty && (boundSyms exists from.contains)) renameBoundSyms(tp0) else tp0
-      val tp                    = mapOver(tp1)
+      val tp                    = mapOver(renameBoundSyms(tp0))
       def substFor(sym: Symbol) = subst(tp, sym, from, to)
 
       tp match {


### PR DESCRIPTION
Rather than asking each type for its set of boundSyms, and then
intersecting that with `from`, just dive into `renameBoundSyms`
and compare the directly bound poly/method/existential params with
`from`.

Optimize this comparison by pre-computing the symbol id range of
`from` (typically small), to cheaply rule out some types without
needing to traverse `from`.

Deprecate the now-unused `Type#boundSyms`