### PR TITLE
Explicit return type on Option.toRight/toLeft

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -308,7 +308,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
    * @param left the expression to evaluate and return if this is empty
    * @see toLeft
    */
-  @inline final def toRight[X](left: => X) =
+  @inline final def toRight[X](left: => X): Either[X, A] =
     if (isEmpty) Left(left) else Right(this.get)
 
   /** Returns a [[scala.util.Right]] containing the given
@@ -319,7 +319,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
    * @param right the expression to evaluate and return if this is empty
    * @see toRight
    */
-  @inline final def toLeft[X](right: => X) =
+  @inline final def toLeft[X](right: => X): Either[A, X] =
     if (isEmpty) Right(right) else Left(this.get)
 }
 


### PR DESCRIPTION
Adds an explicit return type to the `toRight` and `toLeft` methods on
`Option`.

Note that before `Either` extended `Product with Serializable`
the inferred return type was `Product with Serializable with Either[A, B]`. (Side note: this return type was annoying as it messed with type-class based syntax enrichment.) But now that `Either` extends `Product with Serializable`, the inferred return type is `Either[A, B]`, so we can explicitly annotate it without breaking compatibility.