### PR TITLE
Conditionally lint macros and expansions

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -16,7 +16,19 @@ trait Warnings {
   val fatalWarnings = BooleanSetting("-Xfatal-warnings", "Fail the compilation if there are any warnings.")
 
   // Non-lint warnings.
-
+  val warnMacros           = ChoiceSetting(
+    name    = "-Ywarn-macros",
+    helpArg = "mode",
+    descr   = "Enable lint warnings on macro expansions.",
+    choices = List("none", "before", "after", "both"),
+    default = "before",
+    choicesHelp = List(
+      "Do not inspect expansions or their original trees when generating unused symbol warnings.",
+      "Only inspect unexpanded user-written code for unused symbols.",
+      "Only inspect expanded trees when generating unused symbol warnings.",
+      "Inspect both user-written code and expanded trees when generating unused symbol warnings."
+    )
+  )
   val warnDeadCode         = BooleanSetting("-Ywarn-dead-code", "Warn when dead code is identified.")
   val warnValueDiscard     = BooleanSetting("-Ywarn-value-discard", "Warn when non-Unit expression results are unused.")
   val warnNumericWiden     = BooleanSetting("-Ywarn-numeric-widen", "Warn when numerics are widened.")

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -15,7 +15,7 @@ trait Warnings {
   // Warning semantics.
   val fatalWarnings = BooleanSetting("-Xfatal-warnings", "Fail the compilation if there are any warnings.")
 
-  // Non-lint warnings.
+  // Non-lint warnings. -- TODO turn into MultiChoiceEnumeration
   val warnMacros           = ChoiceSetting(
     name    = "-Ywarn-macros",
     helpArg = "mode",

--- a/test/files/neg/t10296-after.check
+++ b/test/files/neg/t10296-after.check
@@ -1,0 +1,6 @@
+Unused_2.scala:7: warning: private method g in object Unused is never used
+  private def g(): Int = 17
+              ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t10296-after.flags
+++ b/test/files/neg/t10296-after.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xlint:unused -Ywarn-macros:after

--- a/test/files/neg/t10296-after/UnusedMacro_1.scala
+++ b/test/files/neg/t10296-after/UnusedMacro_1.scala
@@ -1,0 +1,10 @@
+
+import scala.reflect.macros.whitebox.Context
+
+object UnusedMacro {
+  def macroImpl(c: Context)(body: c.Expr[Int]): c.Tree = {
+    import c.universe._
+    val _ = body
+    Literal(Constant(42))
+  }
+}

--- a/test/files/neg/t10296-after/Unused_2.scala
+++ b/test/files/neg/t10296-after/Unused_2.scala
@@ -1,0 +1,13 @@
+
+import scala.language.experimental.macros
+
+object Unused extends App {
+  def m(body: Int): Int = macro UnusedMacro.macroImpl
+
+  private def g(): Int = 17
+
+  // g is used before but not after expansion
+  def f(): Int = m(g())
+
+  println(f())
+}

--- a/test/files/neg/t10296-both.check
+++ b/test/files/neg/t10296-both.check
@@ -1,0 +1,9 @@
+Unused_2.scala:8: warning: private method k in object Unused is never used
+  private def k(): Int = 17
+              ^
+Unused_2.scala:7: warning: private method g in object Unused is never used
+  private def g(): Int = 17
+              ^
+error: No warnings can be incurred under -Xfatal-warnings.
+two warnings found
+one error found

--- a/test/files/neg/t10296-both.flags
+++ b/test/files/neg/t10296-both.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xlint:unused -Ywarn-macros:both

--- a/test/files/neg/t10296-both/UnusedMacro_1.scala
+++ b/test/files/neg/t10296-both/UnusedMacro_1.scala
@@ -1,0 +1,10 @@
+
+import scala.reflect.macros.whitebox.Context
+
+object UnusedMacro {
+  def macroImpl(c: Context)(body: c.Expr[Int]): c.Tree = {
+    import c.universe._
+    val _ = body
+    q"k()"
+  }
+}

--- a/test/files/neg/t10296-both/Unused_2.scala
+++ b/test/files/neg/t10296-both/Unused_2.scala
@@ -1,0 +1,14 @@
+
+import scala.language.experimental.macros
+
+object Unused extends App {
+  def m(body: Int): Int = macro UnusedMacro.macroImpl
+
+  private def g(): Int = 17
+  private def k(): Int = 17
+
+  // g is used before but not after expansion
+  def f(): Int = m(g())
+
+  println(f())
+}

--- a/test/files/neg/t10296-warn.check
+++ b/test/files/neg/t10296-warn.check
@@ -1,0 +1,6 @@
+Unused_2.scala:9: warning: private method unusedMacro in object Unused is never used
+  private def unusedMacro(): Unit = macro UnusedMacro.usedMacroImpl
+              ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t10296-warn.flags
+++ b/test/files/neg/t10296-warn.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xlint:unused 

--- a/test/files/neg/t10296-warn/UnusedMacro_1.scala
+++ b/test/files/neg/t10296-warn/UnusedMacro_1.scala
@@ -1,0 +1,9 @@
+
+import scala.reflect.macros.blackbox
+
+object UnusedMacro {
+  def usedMacroImpl(c: blackbox.Context)(): c.Tree = {
+    import c.universe._
+    q"""println("apparently unused macro")"""
+  }
+}

--- a/test/files/neg/t10296-warn/Unused_2.scala
+++ b/test/files/neg/t10296-warn/Unused_2.scala
@@ -1,0 +1,12 @@
+
+import scala.language.experimental.macros
+
+object Unused {
+  // seen as used before expansion
+  private def usedMacro(): Unit = macro UnusedMacro.usedMacroImpl
+
+  // never used
+  private def unusedMacro(): Unit = macro UnusedMacro.usedMacroImpl
+
+  def f() = usedMacro()
+}

--- a/test/files/pos/t10296-before.flags
+++ b/test/files/pos/t10296-before.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xlint:unused -Ywarn-macros:before

--- a/test/files/pos/t10296-before/UnusedMacro_1.scala
+++ b/test/files/pos/t10296-before/UnusedMacro_1.scala
@@ -1,0 +1,10 @@
+
+import scala.reflect.macros.whitebox.Context
+
+object UnusedMacro {
+  def macroImpl(c: Context)(body: c.Expr[Int]): c.Tree = {
+    import c.universe._
+    val _ = body
+    q"42"
+  }
+}

--- a/test/files/pos/t10296-before/Unused_2.scala
+++ b/test/files/pos/t10296-before/Unused_2.scala
@@ -1,0 +1,13 @@
+
+import scala.language.experimental.macros
+
+object Unused extends App {
+  def m(body: Int): Int = macro UnusedMacro.macroImpl
+
+  private def g(): Int = 17
+
+  // g is used before but not after expansion
+  def f(): Int = m(g())
+
+  println(f())
+}

--- a/test/files/pos/t10296.flags
+++ b/test/files/pos/t10296.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xlint:unused

--- a/test/files/pos/t10296/UnusedMacro_1.scala
+++ b/test/files/pos/t10296/UnusedMacro_1.scala
@@ -1,0 +1,9 @@
+
+import scala.reflect.macros.blackbox
+
+object UnusedMacro {
+  def usedMacroImpl(c: blackbox.Context)(): c.Tree = {
+    import c.universe._
+    q"""println("apparently unused macro")"""
+  }
+}

--- a/test/files/pos/t10296/Unused_2.scala
+++ b/test/files/pos/t10296/Unused_2.scala
@@ -1,0 +1,8 @@
+
+import scala.language.experimental.macros
+
+object Unused {
+  private def usedMacro(): Unit = macro UnusedMacro.usedMacroImpl
+
+  def f() = usedMacro()
+}


### PR DESCRIPTION
Adds a flag `-Ywarn-macros`.

Don't lint macros unless they request it.

If warning, then traverse the original tree of
macro expansions to witness usages.

Fixes scala/bug#10296