### PR TITLE
Merge 2.12 to 2.13 [ci: last-only]

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ https://groups.google.com/d/topic/scala-internals/gp5JsM1E0Fo/discussion.
 
 ### Using the sbt Build
 
-Core commands:
+Once you've started an `sbt` session you can run one of the core commands:
 
   - `compile` compiles all sub-projects (library, reflect, compiler, scaladoc, etc)
   - `scala` / `scalac` run the REPL / compiler directly from sbt (accept options /
@@ -112,6 +112,11 @@ Core commands:
       binary compatible, we recommend using `-pre`, e.g., `2.13.0-pre-abcd123-SNAPSHOT`.
     - Optionally `set publishArtifact in (Compile, packageDoc) in ThisBuild := false`
       to skip generating / publishing API docs (speeds up the process).
+
+If a command results in an error message like `a module is not authorized to depend on
+itself`, it may be that a global SBT plugin (such as [Ensime](http://ensime.org/)) is
+resulting in a cyclical dependency. Try disabling global SBT plugins (perhaps by
+temporarily commenting them out in `~/.sbt/0.13/plugins/plugins.sbt`).
 
 #### Sandbox
 

--- a/test/files/run/t5717.check
+++ b/test/files/run/t5717.check
@@ -1,1 +1,0 @@
-error: error writing a/B: java.nio.file.FileSystemException t5717-run.obj/a/B.class: Not a directory

--- a/test/files/run/t5717.scala
+++ b/test/files/run/t5717.scala
@@ -1,7 +1,7 @@
 import scala.tools.partest._
 import java.io.File
 
-object Test extends DirectTest {
+object Test extends StoreReporterDirectTest {
   def code = ???
 
   def compileCode(code: String) = {
@@ -17,5 +17,12 @@ object Test extends DirectTest {
     // Don't crash when we find a file 'a' where package 'a' should go.
     scala.reflect.io.File(testOutput.path + "/a").writeAll("a")
     compileCode("package a { class B }")
+    val List(i) = filteredInfos
+    // for some reason, nio doesn't throw the same exception on windows and linux/mac
+    val expected =
+      if (util.Properties.isWin) "error writing a/B: java.nio.file.FileAlreadyExistsException \\a"
+      else "error writing a/B: java.nio.file.FileSystemException /a/B.class: Not a directory"
+    val actual = i.msg.replace(testOutput.path, "")
+    assert(actual == expected, actual)
   }
 }


### PR DESCRIPTION
wanting the t7517 fix so 2.13.x-integrate-windows stops failing

clean merge, no conflicts

```
% export mb=$(git merge-base origin/2.12.x 2.13.x)
% git log --graph --oneline --decorate $mb..origin/2.12.x | cat
*   14ce0c89ec (origin/HEAD, origin/2.12.x) Merge pull request #5874 from ceedubs/readme-sbt-plugin-issue
|\  
| * 8201d3b470 README: note about potential SBT plugin dependency issues
|/  
* 1597d590e1 Merge pull request #5869 from lrytz/t5717-test-win
* 42ee207005 Fix t5717 on Windows
% git merge origin/2.12.x
Removing test/files/run/t5717.check
Merge made by the 'recursive' strategy.
 README.md                  | 7 ++++++-
 test/files/run/t5717.check | 1 -
 test/files/run/t5717.scala | 9 ++++++++-
 3 files changed, 14 insertions(+), 3 deletions(-)
 delete mode 100644 test/files/run/t5717.check
```