### PR TITLE
-Xlint:unused -Ywarn-unused is intuitive

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -748,6 +748,12 @@ class MutableSettings(val errorFn: String => Unit)
 
     def contains(choice: domain.Value): Boolean = value contains choice
 
+    // programmatically.
+    def enable(choice: domain.Value): Unit = { nays -= choice ; yeas += choice ; compute() }
+
+    // programmatically. Disabling expanding option is otherwise disallowed.
+    def disable(choice: domain.Value): Unit = { yeas -= choice ; nays += choice ; compute() }
+
     override def isHelping: Boolean = sawHelp
 
     override def help: String = {

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -28,6 +28,7 @@ trait Warnings {
     val Locals    = Choice("locals",    "Warn if a local definition is unused.")
     val Params    = Choice("params",    "Warn if a value parameter is unused.")
     val Implicits = Choice("implicits", "Warn if an implicit parameter is unused.")
+    val Linted    = Choice("linted",    "-Xlint:unused.", expandsTo = List(Imports, Privates, Locals, Implicits))
   }
 
   // The -Ywarn-unused warning group.
@@ -130,8 +131,8 @@ trait Warnings {
     domain  = LintWarnings,
     default = Some(List("_"))
   ).withPostSetHook { s =>
-    val unused = List("imports", "privates", "locals", "implicits")
-    if (s contains Unused) unused.foreach(warnUnused.add)
+    if (s contains Unused) warnUnused.enable(UnusedWarnings.Linted)
+    else warnUnused.disable(UnusedWarnings.Linted)
   }
 
   allLintWarnings foreach {


### PR DESCRIPTION
The `-Xlint:unused` setting is just a boolean, but it
drives an expanding option on `-Ywarn-unused`.
Normally, expanding options can't be unset, so add
API for that.

This makes `-Xlint:_,-unused` work as advertised.
Other combinations such as `-Xlint -Ywarn-unused:-imports`
are also supported. That's because explicit unset trumps
an expanding option.