### PR TITLE
bundle newer scala-parser-combinators (1.0.5->1.0.6)

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -20,7 +20,7 @@ scala.binary.version=2.12
 #  - jline: shaded with JarJar and included in scala-compiler
 #  - partest: used for running the tests
 scala-xml.version.number=1.0.6
-scala-parser-combinators.version.number=1.0.5
+scala-parser-combinators.version.number=1.0.6
 scala-swing.version.number=2.0.0
 partest.version.number=1.1.1
 scala-asm.version=5.1.0-scala-2


### PR DESCRIPTION
the main change is that scala.util.parsing.json is now deprecated

[1.0.6 release notes](https://github.com/scala/scala-parser-combinators/releases/tag/v1.0.6)

fyi @gourlaysama 