### PR TITLE
Optimize overriding pair cursor by caching the low member type

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -870,7 +870,7 @@ abstract class Erasure extends InfoTransform
         || super.exclude(sym)
         || !sym.hasTypeAt(currentRun.refchecksPhase.id)
       )
-      override def matches(lo: Symbol, high: Symbol) = !high.isPrivate
+      override def matches(high: Symbol) = !high.isPrivate
     }
 
     /** Emit an error if there is a double definition. This can happen if:

--- a/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
+++ b/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
@@ -31,11 +31,11 @@ abstract class OverridingPairs extends SymbolPairs {
     /** Types always match. Term symbols match if their member types
      *  relative to `self` match.
      */
-    override protected def matches(lo: Symbol, high: Symbol) = lo.isType || (
-         (lo.owner != high.owner)     // don't try to form pairs from overloaded members
-      && !high.isPrivate              // private or private[this] members never are overridden
-      && !exclude(lo)                 // this admits private, as one can't have a private member that matches a less-private member.
-      && ((self memberType lo) matches (self memberType high))
+    override protected def matches(high: Symbol) = low.isType || (
+         (low.owner != high.owner)     // don't try to form pairs from overloaded members
+      && !high.isPrivate               // private or private[this] members never are overridden
+      && !exclude(low)                 // this admits private, as one can't have a private member that matches a less-private member.
+      && (lowMemberType matches (self memberType high))
     ) // TODO we don't call exclude(high), should we?
   }
 }

--- a/src/reflect/scala/reflect/internal/SymbolPairs.scala
+++ b/src/reflect/scala/reflect/internal/SymbolPairs.scala
@@ -100,11 +100,11 @@ abstract class SymbolPairs {
      */
     protected def exclude(sym: Symbol): Boolean
 
-    /** Does `sym1` match `sym2` such that (sym1, sym2) should be
-     *  considered as a (lo, high) pair? Types always match. Term symbols
+    /** Does `this.low` match `high` such that (low, high) should be
+     *  considered as a pair? Types always match. Term symbols
      *  match if their member types relative to `self` match.
      */
-    protected def matches(lo: Symbol, high: Symbol): Boolean
+    protected def matches(high: Symbol): Boolean
 
     /** The parents and base classes of `base`.  Can be refined in subclasses.
      */
@@ -148,6 +148,16 @@ abstract class SymbolPairs {
     // The current low and high symbols; the high may be null.
     private[this] var lowSymbol: Symbol  = _
     private[this] var highSymbol: Symbol = _
+    def lowMemberType: Type = {
+      if (lowSymbol ne lowMemberTypeCacheSym) {
+        lowMemberTypeCache = self.memberType(lowSymbol)
+        lowMemberTypeCacheSym = lowSymbol
+      }
+      lowMemberTypeCache
+    }
+
+    private[this] var lowMemberTypeCache: Type = _
+    private[this] var lowMemberTypeCacheSym: Symbol = _
 
     // The current entry candidates for low and high symbol.
     private[this] var curEntry  = decls.elems
@@ -229,7 +239,7 @@ abstract class SymbolPairs {
         nextEntry = decls lookupNextEntry nextEntry
         if (nextEntry ne null) {
           val high    = nextEntry.sym
-          val isMatch = matches(lowSymbol, high) && { visited addEntry nextEntry ; true } // side-effect visited on all matches
+          val isMatch = matches(high) && { visited addEntry nextEntry ; true } // side-effect visited on all matches
 
           // skip nextEntry if a class in `parents` is a subclass of the
           // owners of both low and high.


### PR DESCRIPTION
In #5865, I re-added caching of MethodSymbol.memberType, which would
make caching at this level redundant, but I was only able to re-add
it with for the typer phase. Overriding pairs are computed in refchecks
and erasure (for bridge generation and double-definition checks).

This commit caches the `pre.memberType(lowSymbol)` which is a win
when we must iterate through candidate `highSymbol`-s.

Compilation time of the standary library improves by 3% after this
change. I don't expect that benefit to generalize to much user code
which don't have the same deep inheritance heirarchy as the collections.