### PR TITLE
Optimize CommandLineParser to avoid exponential cost

### DIFF
--- a/src/compiler/scala/tools/cmd/CommandLineParser.scala
+++ b/src/compiler/scala/tools/cmd/CommandLineParser.scala
@@ -39,7 +39,7 @@ object CommandLineParser {
     private val regex = """(\S+)""".r
     def unapply(s: String): Option[(String, String)] = {
       regex.findPrefixOf(s) match {
-        case Some(prefix) => Some(prefix, s.substring(prefix.length, s.length))
+        case Some(prefix) => Some(prefix, s.substring(prefix.length))
         case None => None
       }
     }
@@ -61,7 +61,7 @@ object CommandLineParser {
     else argument(trimmed) match {
       case Right((arg, next)) =>
         val leadingWhitespaceLen = next.prefixLength(Character.isWhitespace)
-        val rest = next.substring(leadingWhitespaceLen, next.length)
+        val rest = next.substring(leadingWhitespaceLen)
         if (leadingWhitespaceLen == 0 && rest.nonEmpty)
           Left("Arguments should be separated by whitespace.") // TODO: can this happen?
         else

--- a/src/compiler/scala/tools/cmd/CommandLineParser.scala
+++ b/src/compiler/scala/tools/cmd/CommandLineParser.scala
@@ -35,7 +35,15 @@ object CommandLineParser {
   }
   private object DoubleQuoted extends QuotedExtractor('"')
   private object SingleQuoted extends QuotedExtractor('\'')
-  private val Word = """(\S+)(.*)""".r
+  object Word {
+    private val regex = """(\S+)""".r
+    def unapply(s: String): Option[(String, String)] = {
+      regex.findPrefixOf(s) match {
+        case Some(prefix) => Some(prefix, s.substring(prefix.length, s.length))
+        case None => None
+      }
+    }
+  }
 
   // parse `in` for an argument, return it and the remainder of the input (or an error message)
   // (argument may be in single/double quotes, taking escaping into account, quotes are stripped)
@@ -52,10 +60,12 @@ object CommandLineParser {
     if (trimmed.isEmpty) Right((accum.reverse, ""))
     else argument(trimmed) match {
       case Right((arg, next)) =>
-        (next span Character.isWhitespace) match {
-          case("", rest) if rest.nonEmpty => Left("Arguments should be separated by whitespace.") // TODO: can this happen?
-          case(ws, rest)                  => commandLine(rest, arg :: accum)
-        }
+        val leadingWhitespaceLen = next.prefixLength(Character.isWhitespace)
+        val rest = next.substring(leadingWhitespaceLen, next.length)
+        if (leadingWhitespaceLen == 0 && rest.nonEmpty)
+          Left("Arguments should be separated by whitespace.") // TODO: can this happen?
+        else
+          commandLine(rest, arg :: accum)
       case Left(msg) => Left(msg)
     }
   }


### PR DESCRIPTION
Echoing the performance bug in the bash scripts (scala/bug#9279),
the command line parser exhibited exponential performance.

When using the command line arguments used to compile the standard
library, which contains ~ 700 source files, I noticed about 1% of
compilation time was being spend in evaluating the regex `(\S+)(.*)`.
Inspection of the parser reveals that this was repeatedly being
called on the rest of the command line as the parser consumed
each argument.

This commit switches to using a regex that only matches the
current argument, and then makes sure to split the input
string using structural sharing of the backing char[] (by using
`String.substring`, rather than high level Scala collections
operations from `StringLike#span`).

After this change, I no longer observed this area of code in the
top profiler results.