### PR TITLE
Precompute Setting.isScala211 etc

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -83,11 +83,19 @@ trait ScalaSettings extends AbsScalaSettings
    * The previous "-source" option is intended to be used mainly
    * though this helper.
    */
-  def isScala211: Boolean = source.value >= ScalaVersion("2.11.0")
-  private[this] val version212 = ScalaVersion("2.12.0")
-  def isScala212: Boolean = source.value >= version212
-  private[this] val version213 = ScalaVersion("2.13.0")
-  def isScala213: Boolean = source.value >= version213
+  private[this] var _isScala211: Boolean = _
+  private[this] var _isScala212: Boolean = _
+  private[this] var _isScala213: Boolean = _
+  private[this] val defaultScalaVersion = ScalaVersion("2.12.0")
+  def isScala211: Boolean = _isScala211
+  def isScala212: Boolean = _isScala212
+  def isScala213: Boolean = _isScala213
+  private def initIsScala(value: ScalaVersion): Unit = {
+    _isScala211 = value >= ScalaVersion("2.11.0")
+    _isScala212 = value >= ScalaVersion("2.12.0")
+    _isScala213 = value >= ScalaVersion("2.13.0")
+  }
+  initIsScala(defaultScalaVersion)
 
   /**
    * -X "Advanced" settings
@@ -131,7 +139,7 @@ trait ScalaSettings extends AbsScalaSettings
   val sourceReader       = StringSetting       ("-Xsource-reader", "classname", "Specify a custom method for reading source files.", "")
   val reporter           = StringSetting       ("-Xreporter", "classname", "Specify a custom reporter for compiler messages.", "scala.tools.nsc.reporters.ConsoleReporter")
   val strictInference    = BooleanSetting      ("-Xstrict-inference", "Don't infer known-unsound types")
-  val source             = ScalaVersionSetting ("-Xsource", "version", "Treat compiler input as Scala source for the specified version, see scala/bug#8126.", initial = ScalaVersion("2.12"))
+  val source             = ScalaVersionSetting ("-Xsource", "version", "Treat compiler input as Scala source for the specified version, see scala/bug#8126.", initial = defaultScalaVersion).withPostSetHook(setting => initIsScala(setting.value))
 
   val XnoPatmatAnalysis = BooleanSetting ("-Xno-patmat-analysis", "Don't perform exhaustivity/unreachability analysis. Also, ignore @switch annotation.")
   val XfullLubs         = BooleanSetting ("-Xfull-lubs", "Retains pre 2.10 behavior of less aggressive truncation of least upper bounds.")

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1424,9 +1424,9 @@ trait Implicits {
             val outSym = out.typeSymbol
 
             val fail =
-              if (out.annotations.isEmpty && (outSym == ObjectClass || (isScala211 && outSym == AnyValClass)))
+              if (out.annotations.isEmpty && (outSym == ObjectClass || (settings.isScala211 && outSym == AnyValClass)))
                 maybeInvalidConversionError(s"the result type of an implicit conversion must be more specific than $out")
-              else if (isScala211 && in.annotations.isEmpty && in.typeSymbol == NullClass)
+              else if (settings.isScala211 && in.annotations.isEmpty && in.typeSymbol == NullClass)
                 maybeInvalidConversionError("an expression of type Null is ineligible for implicit conversion")
               else false
 
@@ -1441,9 +1441,6 @@ trait Implicits {
 
       result
     }
-
-    // this setting is expensive to check, actually....
-    private[this] val isScala211 = settings.isScala211
 
     def allImplicits: List[SearchResult] = {
       def search(iss: Infoss, isLocalToCallsite: Boolean) = applicableInfos(iss, isLocalToCallsite).values

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -58,11 +58,6 @@ trait Namers extends MethodSynthesis {
     private lazy val innerNamer =
       if (isTemplateContext(context)) createInnerNamer() else this
 
-    // Cached as a val because `settings.isScala212` parses the Scala version each time...
-    // Not in Namers because then we need to go to outer first to check this.
-    // I do think it's ok to check every time we create a Namer instance (so, not a lazy val).
-    private[this] val isScala212 = settings.isScala212
-
     def createNamer(tree: Tree): Namer = {
       val sym = tree match {
         case ModuleDef(_, _, _) => tree.symbol.moduleClass
@@ -1586,7 +1581,7 @@ trait Namers extends MethodSynthesis {
               val valOwner = owner.owner
               // there's no overriding outside of classes, and we didn't use to do this in 2.11, so provide opt-out
 
-              if (!isScala212 || !valOwner.isClass) WildcardType
+              if (!settings.isScala212 || !valOwner.isClass) WildcardType
               else {
                 // normalize to getter so that we correctly consider a val overriding a def
                 // (a val's name ends in a " ", so can't compare to def)


### PR DESCRIPTION
This avoids the small, but non-neglible cost of evaluating
the regex that implements `source.value >= version212`, etc.

This is a less ambitious alternative to #5825 which
addresses the worst culprit of inefficient settings lookups.