### PR TITLE
Optimize dealiasWiden

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -531,21 +531,29 @@ trait Types
      *  !!! - and yet it is still inadequate, because aliases and singletons
      *  might lurk in the upper bounds of an abstract type. See scala/bug#7051.
      */
-    def dealiasWiden: Type = (
-      if (this ne widen) widen.dealiasWiden
-      else if (this ne dealias) dealias.dealiasWiden
-      else this
-    )
+    def dealiasWiden: Type = {
+      val widened = widen
+      if (this ne widened) widened.dealiasWiden
+      else {
+        val dealiased = dealias
+        if (this ne dealiased) dealiased.dealiasWiden
+        else this
+      }
+    }
 
     /** All the types encountered in the course of dealiasing/widening,
      *  including each intermediate beta reduction step (whereas calling
      *  dealias applies as many as possible.)
      */
-    def dealiasWidenChain: List[Type] = this :: (
-      if (this ne widen) widen.dealiasWidenChain
-      else if (this ne betaReduce) betaReduce.dealiasWidenChain
-      else Nil
-    )
+    def dealiasWidenChain: List[Type] = this :: {
+      val widened = widen
+      if (this ne widened) widened.dealiasWidenChain
+      else {
+        val betaReduced = betaReduce
+        if (this ne betaReduced) betaReduced.dealiasWidenChain
+        else Nil
+      }
+    }
 
     /** Performs a single step of beta-reduction on types.
      *  Given:


### PR DESCRIPTION
Avoids calling dealias/widen twice.

Before:
```
% for sha in 2.12.3-bin-ce0e5b2-SNAPSHOT 2.12.3-bin-<NEW>-SNAPSHOT ; do sbt "set scalaVersion in compilation := \"$sha\"" "hot -psource= -pextraArgs=-Ystop-after:typer -f3 -wi 10 -jvmArgs -Xmx1G -jvmArgs -XX:MaxInlineLevel=18"; done

[info] Benchmark                                          (extraArgs)  (source)    Mode  Cnt    Score   Error  Units
[info] HotScalacBenchmark.compile                  -Ystop-after:typer            sample  580  529.666 ± 1.278  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00    -Ystop-after:typer            sample       512.754          ms/op
[info] HotScalacBenchmark.compile:compile·p0.50    -Ystop-after:typer            sample       528.482          ms/op
[info] HotScalacBenchmark.compile:compile·p0.90    -Ystop-after:typer            sample       543.162          ms/op
[info] HotScalacBenchmark.compile:compile·p0.95    -Ystop-after:typer            sample       546.308          ms/op
[info] HotScalacBenchmark.compile:compile·p0.99    -Ystop-after:typer            sample       551.551          ms/op
[info] HotScalacBenchmark.compile:compile·p0.999   -Ystop-after:typer            sample       572.522          ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999  -Ystop-after:typer            sample       572.522          ms/op
[info] HotScalacBenchmark.compile:compile·p1.00    -Ystop-after:typer            sample       572.522          ms/op
```

After:

```
[info] Benchmark                                          (extraArgs)  (source)    Mode  Cnt    Score   Error  Units
[info] HotScalacBenchmark.compile                  -Ystop-after:typer            sample  593  523.784 ± 1.142  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00    -Ystop-after:typer            sample       507.511          ms/op
[info] HotScalacBenchmark.compile:compile·p0.50    -Ystop-after:typer            sample       522.191          ms/op
[info] HotScalacBenchmark.compile:compile·p0.90    -Ystop-after:typer            sample       536.347          ms/op
[info] HotScalacBenchmark.compile:compile·p0.95    -Ystop-after:typer            sample       538.968          ms/op
[info] HotScalacBenchmark.compile:compile·p0.99    -Ystop-after:typer            sample       545.322          ms/op
[info] HotScalacBenchmark.compile:compile·p0.999   -Ystop-after:typer            sample       551.551          ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999  -Ystop-after:typer            sample       551.551          ms/op
[info] HotScalacBenchmark.compile:compile·p1.00    -Ystop-after:typer            sample       551.551          ms/op
```