### PR TITLE
Optimize Iterator.combinations

### DIFF
--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -232,7 +232,13 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
       if (idx < 0)
         _hasNext = false
       else {
-        var sum = nums.slice(idx + 1, nums.length).sum + 1
+        // OPT: hand rolled version of `sum = nums.view(idx + 1, nums.length).sum + 1`
+        var sum = 1
+        var i = idx + 1
+        while (i < nums.length) {
+          sum += nums(i)
+          i += 1
+        }
         nums(idx) -= 1
         for (k <- (idx+1) until nums.length) {
           nums(k) = sum min cnts(k)

--- a/test/junit/scala/collection/SeqLikeTest.scala
+++ b/test/junit/scala/collection/SeqLikeTest.scala
@@ -16,4 +16,11 @@ class SeqLikeTest {
     assertEquals(2, "abcde".toVector.indexWhere(_ == 'c', -1))
     assertEquals(2, "abcde".toVector.indexWhere(_ == 'c', -2))
   }
+
+  @Test def combinations(): Unit = {
+    assertEquals(List(Nil), Nil.combinations(0).toList)
+    assertEquals(Nil, Nil.combinations(1).toList)
+    assertEquals(List(List(1, 2), List(1, 3), List(2, 3)), List(1, 2, 3).combinations(2).toList)
+    assertEquals(List(List(1, 2, 3)), List(1, 2, 3).combinations(3).toList)
+  }
 }


### PR DESCRIPTION
Avoid a creating of temporary array just to calculate the sum
of a slice.

REPL session to show the equivalence of the new approach:
```
scala> Array(1,2,3,4).slice(1, 2).sum
res0: Int = 2

scala> Array(1,2,3,4).view(1, 2).sum
res1: Int = 2

scala> Array(1,2,3,4).slice(1, 2)
res2: Array[Int] = Array(2)

scala> Array(1,2,3,4).view(1, 2)
res3: scala.collection.mutable.IndexedSeqView[Int,Array[Int]] = SeqViewS(...)
```