### PR TITLE
[WIP] Implement annotation parsing in JavaParsers.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -88,6 +88,23 @@ trait ParsersCommon extends ScannersCommon { self =>
      */
     @inline final def makeParens(body: => List[Tree]): Parens =
       Parens(inParens(if (in.token == RPAREN) Nil else body))
+
+    /** {{{ part { `sep` part } }}}, or if sepFirst is true, {{{ { `sep` part } }}}. */
+    final def tokenSeparated[T](separator: Token, sepFirst: Boolean, part: => T): List[T] = {
+      val ts = new ListBuffer[T]
+      if (!sepFirst)
+        ts += part
+
+      while (in.token == separator) {
+        in.nextToken()
+        ts += part
+      }
+      ts.toList
+    }
+
+    /** {{{ tokenSeparated }}}, with the separator fixed to commas. */
+    @inline final def commaSeparated[T](part: => T): List[T] =
+      tokenSeparated(COMMA, sepFirst = false, part)
   }
 }
 
@@ -777,20 +794,6 @@ self =>
         errorTypeTree
       }
     }
-
-    /** {{{ part { `sep` part } }}},or if sepFirst is true, {{{ { `sep` part } }}}. */
-    final def tokenSeparated[T](separator: Token, sepFirst: Boolean, part: => T): List[T] = {
-      val ts = new ListBuffer[T]
-      if (!sepFirst)
-        ts += part
-
-      while (in.token == separator) {
-        in.nextToken()
-        ts += part
-      }
-      ts.toList
-    }
-    @inline final def commaSeparated[T](part: => T): List[T] = tokenSeparated(COMMA, sepFirst = false, part)
     @inline final def caseSeparated[T](part: => T): List[T] = tokenSeparated(CASE, sepFirst = true, part)
     def readAnnots(part: => Tree): List[Tree] = tokenSeparated(AT, sepFirst = true, part)
 

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -32,6 +32,9 @@ trait ScannersCommon {
   }
 
   trait ScannerCommon extends CommonTokenData {
+    /** Consume and discard the next token. */
+    def nextToken(): Unit
+
     // things to fill in, in addition to buf, decodeUni which come from CharArrayReader
     def error(off: Offset, msg: String): Unit
     def incompleteInputError(off: Offset, msg: String): Unit

--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -234,11 +234,21 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
 
     // -------------------- specific parsing routines ------------------
 
-    def qualId(): RefTree = {
-      var t: RefTree = atPos(in.currentPos) { Ident(ident()) }
-      while (in.token == DOT) {
+    def qualId(orClassLiteral: Boolean = false): Tree = {
+      var t: Tree = atPos(in.currentPos) { Ident(ident()) }
+      var done = false
+      while (!done && in.token == DOT) {
         in.nextToken()
-        t = atPos(in.currentPos) { Select(t, ident()) }
+        t = atPos(in.currentPos) {
+          if (orClassLiteral && in.token == CLASS) {
+            in.nextToken()
+            done = true
+            val tpeArg = convertToTypeId(t)
+            TypeApply(q"_root_.scala.Predef.classOf", tpeArg :: Nil)
+          } else {
+            Select(t, ident())
+          }
+        }
       }
       t
     }
@@ -267,7 +277,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
       }
 
     def typ(): Tree = {
-      annotations()
+      annotations() // TODO: put these somewhere?
       optArrayBrackets {
         if (in.token == FINAL) in.nextToken()
         if (in.token == IDENTIFIER) {
@@ -326,20 +336,59 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
     }
 
     def annotations(): List[Tree] = {
-      //var annots = new ListBuffer[Tree]
+      var annots = new ListBuffer[Tree]
       while (in.token == AT) {
         in.nextToken()
-        annotation()
+        annots += annotation()
       }
-      List() // don't pass on annotations for now
+      annots.toList
     }
 
-    /** Annotation ::= TypeName [`(` AnnotationArgument {`,` AnnotationArgument} `)`]
+    /** Annotation ::= TypeName [`(` [AnnotationArgument {`,` AnnotationArgument}] `)`]
      */
-    def annotation() {
-      qualId()
-      if (in.token == LPAREN) { skipAhead(); accept(RPAREN) }
-      else if (in.token == LBRACE) { skipAhead(); accept(RBRACE) }
+    def annotation(): Tree = {
+      def annArg(): Tree = {
+        def annVal(): Tree = {
+          tryLiteral() match {
+            case Some(lit) => atPos(in.currentPos)(Literal(lit))
+            case _ if in.token == AT =>
+              in.nextToken()
+              annotation()
+            case _ if in.token == LBRACE =>
+              atPos(in.pos) {
+                val elts = inBracesOrNil(commaSeparated(annVal()))
+                Apply(ArrayModule_overloadedApply, elts: _*)
+              }
+            case _ if in.token == IDENTIFIER =>
+              qualId(orClassLiteral = true)
+          }
+        }
+
+        if (in.token == IDENTIFIER) {
+          qualId(orClassLiteral = true) match {
+            case name: Ident if in.token == EQUALS =>
+              in.nextToken()
+              /* name = value */
+              gen.mkNamedArg(name, annVal())
+            case rhs =>
+              /* implicit `value` arg with constant value */
+              gen.mkNamedArg(nme.value, rhs)
+          }
+        } else {
+          /* implicit `value` arg */
+          gen.mkNamedArg(nme.value, annVal())
+        }
+      }
+
+      atPos(in.pos) {
+        val id = convertToTypeId(qualId())
+        val args =
+          if (in.token == LPAREN) inParensOrNil {
+            if (in.token == RPAREN) Nil
+            else commaSeparated(atPos(in.pos)(annArg()))
+          } else Nil
+        New(id, args :: Nil)
+      }
     }
 
     def modifiers(inInterface: Boolean): Modifiers = {
@@ -353,7 +402,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
         in.token match {
           case AT if (in.lookaheadToken != INTERFACE) =>
             in.nextToken()
-            annotation()
+            annots :+= annotation()
           case PUBLIC =>
             isPackageAccess = false
             in.nextToken()
@@ -408,10 +457,10 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
 
     def typeParam(): TypeDef =
       atPos(in.currentPos) {
-        annotations()
+        val anns = annotations()
         val name = identForType()
         val hi = if (in.token == EXTENDS) { in.nextToken() ; bound() } else EmptyTree
-        TypeDef(Modifiers(Flags.JAVA | Flags.DEFERRED | Flags.PARAM), name, Nil, TypeBoundsTree(EmptyTree, hi))
+        TypeDef(Modifiers(Flags.JAVA | Flags.DEFERRED | Flags.PARAM, typeNames.EMPTY, anns), name, Nil, TypeBoundsTree(EmptyTree, hi))
       }
 
     def bound(): Tree =
@@ -435,7 +484,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
 
     def formalParam(): ValDef = {
       if (in.token == FINAL) in.nextToken()
-      annotations()
+      val anns = annotations()
       var t = typ()
       if (in.token == DOTDOTDOT) {
         in.nextToken()
@@ -443,7 +492,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
           AppliedTypeTree(scalaDot(tpnme.JAVA_REPEATED_PARAM_CLASS_NAME), List(t))
         }
       }
-     varDecl(in.currentPos, Modifiers(Flags.JAVA | Flags.PARAM), t, ident().toTermName)
+     varDecl(in.currentPos, Modifiers(Flags.JAVA | Flags.PARAM, typeNames.EMPTY, anns), t, ident().toTermName)
     }
 
     def optThrows() {
@@ -841,7 +890,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
     }
 
     def enumConst(enumType: Tree): (ValDef, Boolean) = {
-      annotations()
+      val anns = annotations()
       var hasClassBody = false
       val res = atPos(in.currentPos) {
         val name = ident()
@@ -856,7 +905,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
           skipAhead()
           accept(RBRACE)
         }
-        ValDef(Modifiers(Flags.JAVA_ENUM | Flags.STABLE | Flags.JAVA | Flags.STATIC), name.toTermName, enumType, blankExpr)
+        ValDef(Modifiers(Flags.JAVA_ENUM | Flags.STABLE | Flags.JAVA | Flags.STATIC, typeNames.EMPTY, anns), name.toTermName, enumType, blankExpr)
       }
       (res, hasClassBody)
     }
@@ -894,10 +943,10 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
       var pos = in.currentPos
       val pkg: RefTree =
         if (in.token == AT || in.token == PACKAGE) {
-          annotations()
+          annotations() // TODO: put these somewhere?
           pos = in.currentPos
           accept(PACKAGE)
-          val pkg = qualId()
+          val pkg = qualId().asInstanceOf[RefTree]
           accept(SEMI)
           pkg
         } else {

--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -244,7 +244,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
             in.nextToken()
             done = true
             val tpeArg = convertToTypeId(t)
-            TypeApply(q"_root_.scala.Predef.classOf", tpeArg :: Nil)
+            TypeApply(Select(gen.mkAttributedRef(definitions.PredefModule), nme.classOf), tpeArg :: Nil)
           } else {
             Select(t, ident())
           }

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -1051,7 +1051,12 @@ abstract class ClassfileParser {
         case Some(scalaSig) if scalaSig.atp == ScalaLongSignatureAnnotation.tpe =>
           scalaSigAnnot = Some(scalaSig)
         case Some(annot) =>
-          sym.addAnnotation(annot)
+          /* `sym.addAnnotation(annot)` adds the annotation to the front of the list,
+           * so if we parsed in classfile order we would wind up with the annotations
+           * in reverse order in `sym.annotations`. Instead we just read them out the
+           * other way around, for now. TODO: sym.addAnnotation add to the end?
+           */
+          sym.setAnnotations(sym.annotations :+ annot)
         case None =>
       }
       scalaSigAnnot

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3747,6 +3747,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         case Typed(t, _) =>
           tree2ConstArg(t, pt)
 
+        case tree if pt.typeSymbol.isSubClass(ArrayClass) && unit.isJava =>
+          /* If we get here, we have a Java array annotation argument which was passed
+           * as a single value, and needs to be wrapped. */
+          trees2ConstArg(tree :: Nil, pt.typeArgs.head)
+
         case tree =>
           tryConst(tree, pt)
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3747,7 +3747,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         case Typed(t, _) =>
           tree2ConstArg(t, pt)
 
-        case tree if pt.typeSymbol.isSubClass(ArrayClass) && unit.isJava =>
+        case tree if unit.isJava && pt.typeSymbol.isNonBottomSubClass(ArrayClass) =>
           /* If we get here, we have a Java array annotation argument which was passed
            * as a single value, and needs to be wrapped. */
           trees2ConstArg(tree :: Nil, pt.typeArgs.head)

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1355,7 +1355,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     val symbols =
       Set(UnitClass, BooleanClass, ByteClass,
           ShortClass, IntClass, LongClass, FloatClass,
-          DoubleClass, NilModule, ListClass) ++ TupleClass.seq
+          DoubleClass, NilModule, ListClass, PredefModule) ++ TupleClass.seq ++ ArrayModule_overloadedApply.alternatives
     symbols.foreach(_.initialize)
   }
 

--- a/test/files/run/t4788-separate-compilation.check
+++ b/test/files/run/t4788-separate-compilation.check
@@ -1,5 +1,5 @@
 Some(@Ljava/lang/Deprecated;())
 None
-Some(@LSAnnotation;())
-Some(@LCAnnotation;())
+None
+Some(@LCAnnotation;() // invisible)
 Some(@LRAnnotation;())

--- a/test/files/run/t4788.check
+++ b/test/files/run/t4788.check
@@ -1,5 +1,5 @@
 Some(@Ljava/lang/Deprecated;())
 None
-Some(@LSAnnotation;())
-Some(@LCAnnotation;())
+None
+Some(@LCAnnotation;() // invisible)
 Some(@LRAnnotation;())

--- a/test/files/run/t8928/Annotated_0.java
+++ b/test/files/run/t8928/Annotated_0.java
@@ -1,0 +1,19 @@
+package test;
+
+// This should stay in sync with Annotated_1 to test annotations defined in the same compilation run
+
+@NoArgs_0
+@Simple_0(_byte = 1, _char = '2', _short = Simple_0.THREE, _int = 4, _long = 5, _float = 6.7f, _double = 8.9, _string = "ten", _class = Object.class)
+@Nested_0(
+    inner = @Nested_0.Inner("turkey")
+)
+@Array_0.Repeated({
+        @Array_0({8, 6, 7, 5, 3, 0, Annotated_0.NINE}),
+        @Array_0(6)
+})
+@Enum_0(choice = Enum_0.Enum.ONE)
+@Empty_0()
+public class Annotated_0 {
+    public static final int NINE = 9;
+}
+

--- a/test/files/run/t8928/Annotated_1.java
+++ b/test/files/run/t8928/Annotated_1.java
@@ -1,0 +1,19 @@
+package test;
+
+// This should stay in sync with Annotated_0 to test annotations defined in an earlier compilation run
+
+@NoArgs_0
+@Simple_0(_byte = 1, _char = '2', _short = Simple_0.THREE, _int = 4, _long = 5, _float = 6.7f, _double = 8.9, _string = "ten", _class = Object.class)
+@Nested_0(
+    inner = @Nested_0.Inner("turkey")
+)
+@Array_0.Repeated({
+        @Array_0({8, 6, 7, 5, 3, 0, Annotated_1.NINE}),
+        @Array_0(6)
+})
+@Enum_0(choice = Enum_0.Enum.ONE)
+@Empty_0()
+public class Annotated_1 {
+    public static final int NINE = 9;
+}
+

--- a/test/files/run/t8928/Array_0.java
+++ b/test/files/run/t8928/Array_0.java
@@ -1,0 +1,15 @@
+package test;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+//TODO: make this work
+//@java.lang.annotation.Repeatable(Array_0.Repeated.class)
+public @interface Array_0 {
+    int[] value();
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Repeated {
+        Array_0[] value();
+    }
+}

--- a/test/files/run/t8928/Checks_0.scala
+++ b/test/files/run/t8928/Checks_0.scala
@@ -1,0 +1,84 @@
+package test
+
+import reflect.api.Universe
+
+class Checks[U <: Universe with Singleton](val universe: U, ordered: Boolean) {
+  import universe._
+
+  def check(tpe: Type): Unit = {
+    val ObjectTpe = typeOf[Object]
+
+    def assertMatch(name: String, v: Tree)(pf: PartialFunction[Tree, Any]): Unit =
+      if (!pf.isDefinedAt(v)) throw new AssertionError(s"$name: ${showRaw(v)}")
+
+    val anns: List[Annotation] = tpe.typeSymbol.annotations
+
+    anns match {
+      case List(noArgs, simple, nested, arrays, enum, empty) =>
+        assert(noArgs.tree.tpe =:= typeOf[NoArgs_0])
+        assert(noArgs.tree.children.size == 1)
+
+        assert(simple.tree.tpe =:= typeOf[Simple_0])
+
+        val parameters: List[(String, Tree)] =
+          simple.tree.children.tail.map {
+            case AssignOrNamedArg(Ident(TermName(name)), value) =>
+              name -> value
+          }
+
+        /* Runtime reflection does not preserve ordering on java annotations,
+         * so check only when we're in a macro universe. */
+        if (ordered) {
+          assert(parameters.map(_._1) == List(
+            "_byte", "_char", "_short", "_int", "_long", "_float", "_double", "_string", "_class"))
+        }
+
+        parameters.sortBy(_._1) match {
+          case ("_byte", byte)     :: ("_char", char)
+            :: ("_class", clasz)   :: ("_double", double)
+            :: ("_float", float)   :: ("_int", int)
+            :: ("_long", long)     :: ("_short", short)
+            :: ("_string", string) :: Nil =>
+
+            assertMatch("byte", byte)     { case Literal(Constant(1))         =>  }
+            assertMatch("char", char)     { case Literal(Constant('2'))       =>  }
+            assertMatch("short", short)   { case Literal(Constant(3))         =>  }
+            assertMatch("int", int)       { case Literal(Constant(4))         =>  }
+            assertMatch("long", long)     { case Literal(Constant(5L))        =>  }
+            assertMatch("float", float)   { case Literal(Constant(6.7f))      =>  }
+            assertMatch("double", double) { case Literal(Constant(8.9d))      =>  }
+            assertMatch("string", string) { case Literal(Constant("ten"))     =>  }
+            assertMatch("class", clasz)   { case Literal(Constant(ObjectTpe)) =>  }
+        }
+
+        assert(nested.tree.tpe =:= typeOf[Nested_0])
+        nested.tree.children match {
+          case _ :: inner :: Nil =>
+            assertMatch("inner", inner) {
+              case AssignOrNamedArg(Ident(TermName("inner")), Apply(Select(New(tpe), nme.CONSTRUCTOR), AssignOrNamedArg(Ident(TermName("value")), Literal(Constant("turkey"))) :: Nil))
+                if tpe.tpe =:= typeOf[Nested_0.Inner] =>
+            }
+        }
+
+        assert(arrays.tree.tpe =:= typeOf[Array_0.Repeated])
+        arrays.tree.children match {
+          case _ :: AssignOrNamedArg(Ident(TermName("value")), Apply(arr, fst :: snd :: Nil)) :: Nil =>
+            assertMatch("value(0)", fst) {
+              case Apply(Select(New(tpe), nme.CONSTRUCTOR), AssignOrNamedArg(Ident(TermName("value")), Apply(arr, args)) :: Nil)
+                if ((args zip Seq(8, 6, 7, 5, 3, 0, 9)) forall { case (Literal(Constant(l)), r) => l == r }) &&
+                  tpe.tpe =:= typeOf[Array_0] =>
+            }
+            assertMatch("value(1)", snd) {
+              case Apply(Select(New(tpe), nme.CONSTRUCTOR), AssignOrNamedArg(Ident(TermName("value")), Apply(arr, args)) :: Nil)
+                if ((args zip Seq(6)) forall { case (Literal(Constant(l)), r) => l == r }) &&
+                  tpe.tpe =:= typeOf[Array_0] =>
+            }
+        }
+        assert(enum.tree.tpe =:= typeOf[Enum_0])
+
+        assert(empty.tree.tpe =:= typeOf[Empty_0])
+        assert(empty.tree.children.size == 1)
+    }
+  }
+
+}

--- a/test/files/run/t8928/Empty_0.java
+++ b/test/files/run/t8928/Empty_0.java
@@ -1,0 +1,7 @@
+package test;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Empty_0 {}

--- a/test/files/run/t8928/Enum_0.java
+++ b/test/files/run/t8928/Enum_0.java
@@ -1,0 +1,12 @@
+package test;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Enum_0 {
+    Enum choice();
+
+    public enum Enum {
+        ONE, OTHER
+    }
+}

--- a/test/files/run/t8928/Macros_0.scala
+++ b/test/files/run/t8928/Macros_0.scala
@@ -1,0 +1,16 @@
+package test
+
+object Macros {
+  import language.experimental.macros
+  def apply[T]: Unit = macro impl[T]
+
+  import reflect.macros.whitebox
+  def impl[T: c.WeakTypeTag](c: whitebox.Context): c.Tree = {
+    import c.universe._
+
+    new Checks[c.universe.type](c.universe, ordered = true)
+      .check(weakTypeOf[T])
+
+    Literal(Constant(()))
+  }
+}

--- a/test/files/run/t8928/Nested_0.java
+++ b/test/files/run/t8928/Nested_0.java
@@ -1,0 +1,13 @@
+package test;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Nested_0 {
+    Inner inner();
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Inner {
+        String value();
+    }
+}

--- a/test/files/run/t8928/NoArgs_0.java
+++ b/test/files/run/t8928/NoArgs_0.java
@@ -1,0 +1,7 @@
+package test;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoArgs_0 {}
+

--- a/test/files/run/t8928/Simple_0.java
+++ b/test/files/run/t8928/Simple_0.java
@@ -1,0 +1,18 @@
+package test;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Simple_0 {
+    byte _byte();
+    char _char();
+    short _short();
+    int _int();
+    long _long();
+    float _float();
+    double _double();
+    String _string();
+    Class<?> _class();
+
+    short THREE = 3;
+}

--- a/test/files/run/t8928/Test_1.scala
+++ b/test/files/run/t8928/Test_1.scala
@@ -1,0 +1,16 @@
+import test._
+
+object Test extends App {
+  Macros.apply[Annotated_0]
+  Macros.apply[Annotated_1]
+
+  import reflect.runtime.universe
+  import universe._
+
+  /* consistency check with runtime universe */
+  val checks = new Checks[universe.type](universe, ordered = false)
+  checks.check(weakTypeOf[Annotated_0])
+  checks.check(weakTypeOf[Annotated_1])
+
+
+}


### PR DESCRIPTION
This causes the java parser to get somewhat more complex, but allows for macros and compiler plugins to correctly inspect java-defined classes for annotations.

Moved a few utility methods into `{Parsers,Scanners}Common` as well, so I can reuse them in the java ones.

This involves a change to the t4788 tests, as `SAnnotation` now correctly has `RetentionPolicy.SOURCE`, and is therefore ignored by the check in `BCodeHelpers#BCAnnotGen.shouldEmitAnnotation`; also, ASM Textifier emits an `// invisible` marker now that `CAnnotation` has `RetentionPolicy.CLASS`. I'm not sure what the chances that anyone is relying upon this behavior are, but since it does the Right Thing for separate compilation runs, they probably should not be too disappointed.

This still drops the annotations in `typ()` and `compilationUnit()`, because I don't know where the right place to put them is. `PackageDef` has `def mods = NoMods`, which I could change to `var mods = NoMods` but I'm not sure where I'd have to change to make them stick to which `Symbol`. `typ()` makes a `RefTree` and I have no idea how to reasonably annotate that.

Either way it should be better than what we have right now.

Review by @densh 

Fixes scala/bug#8928.