### PR TITLE
Optimizer: avoid inlining of accidental SAM types

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -550,7 +550,10 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
     val isEffectivelyFinal = classSym.isEffectivelyFinal
 
     val sam = {
-      if (classSym.isEffectivelyFinal) None
+      val considerSam = !classSym.isEffectivelyFinal && {
+        isFunctionSymbol(classSym) || classSym.hasAnnotation(FunctionalInterfaceClass)
+      }
+      if (!considerSam) None
       else {
         // Phase travel necessary. For example, nullary methods (getter of an abstract val) get an
         // empty parameter list in uncurry and would therefore be picked as SAM.

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1180,6 +1180,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val UncheckedBoundsClass       = getClassIfDefined("scala.reflect.internal.annotations.uncheckedBounds")
     lazy val UnspecializedClass         = requiredClass[scala.annotation.unspecialized]
     lazy val VolatileAttr               = requiredClass[scala.volatile]
+    lazy val FunctionalInterfaceClass   = requiredClass[java.lang.FunctionalInterface]
 
     // Meta-annotations
     lazy val BeanGetterTargetClass      = requiredClass[meta.beanGetter]

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -411,6 +411,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.UncheckedBoundsClass
     definitions.UnspecializedClass
     definitions.VolatileAttr
+    definitions.FunctionalInterfaceClass
     definitions.BeanGetterTargetClass
     definitions.BeanSetterTargetClass
     definitions.FieldTargetClass

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
@@ -159,12 +159,16 @@ class CallGraphTest extends BytecodeTesting {
         |  def t2(i: Int, f: Int => Int, z: Int) = h(f) + i - z
         |  def t3(f: Int => Int) = h(x => f(x + 1))
         |}
-        |trait D {
-        |  def iAmASam(x: Int): Int
-        |  def selfSamCall = iAmASam(10)
+        |@FunctionalInterface trait D {
+        |  def iAmASamD(x: Int): Int
+        |  def selfSamCallD = iAmASamD(10)
+        |}
+        |trait E {
+        |  def iAmASamE(x: Int): Int
+        |  def selfSamCallE = iAmASamE(10)
         |}
         |""".stripMargin
-    val List(c, d) = compile(code)
+    val List(c, d, e) = compile(code)
 
     def callIn(m: String) = callGraph.callsites.find(_._1.name == m).get._2.values.head
     val t1h = callIn("t1")
@@ -176,8 +180,11 @@ class CallGraphTest extends BytecodeTesting {
     val t3h = callIn("t3")
     assertEquals(t3h.argInfos.toList, List((1, FunctionLiteral)))
 
-    val selfSamCall = callIn("selfSamCall")
-    assertEquals(selfSamCall.argInfos.toList, List((0,ForwardedParam(0))))
+    val selfSamCallD = callIn("selfSamCallD")
+    assertEquals(selfSamCallD.argInfos.toList, List((0,ForwardedParam(0))))
+
+    val selfSamCallE = callIn("selfSamCallE")
+    assertEquals(selfSamCallE.argInfos.toList, List())
   }
 
   @Test

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ScalaInlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ScalaInlineInfoTest.scala
@@ -145,26 +145,29 @@ class ScalaInlineInfoTest extends BytecodeTesting {
   @Test
   def inlineInfoSam(): Unit = {
     val code =
-      """trait C { // expected to be seen as sam: g(I)I
+      """@FunctionalInterface trait C { // expected to be seen as sam: g(I)I
         |  def f = 0
         |  def g(x: Int): Int
         |  val foo = "hi"
         |}
-        |abstract class D {
+        |@FunctionalInterface abstract class D { // not actually a functional interface, but scalac doesn't error
         |  val biz: Int
         |}
-        |trait T { // expected to be seen as sam: h(Ljava/lang/String;)I
+        |@FunctionalInterface trait T { // expected to be seen as sam: h(Ljava/lang/String;)I
         |  def h(a: String): Int
         |}
-        |trait E extends T { // expected to be seen as sam: h(Ljava/lang/String;)I
+        |@FunctionalInterface trait E extends T { // expected to be seen as sam: h(Ljava/lang/String;)I
         |  def hihi(x: Int) = x
         |}
-        |class F extends T {
+        |@FunctionalInterface class F extends T { // not actually a functional interface, but scalac doesn't error
         |  def h(a: String) = 0
         |}
-        |trait U {
+        |@FunctionalInterface trait U {
         |  def conc() = 10
         |  def nullary: Int
+        |}
+        |trait V { // not annotated @FunctionalInterface, therefore not treated as SAM by the optimizer
+        |  def h(a: String): Int
         |}
       """.stripMargin
     val cs = compileClasses(code)
@@ -176,7 +179,8 @@ class ScalaInlineInfoTest extends BytecodeTesting {
         ("E",Some("h(Ljava/lang/String;)I")),
         ("F",None),
         ("T",Some("h(Ljava/lang/String;)I")),
-        ("U",None)))
+        ("U",None),
+        ("V", None)))
   }
 
   @Test


### PR DESCRIPTION
Before, any Scala defined class that happened to have a SAM was considered
a function type for the inliner heuristics. This can lead to unexpected
inlining, large methods and degraded performance. Jason recently saw such a
case when adding an abstract method `mapOver` to `Type`:

```
def typed1(tree: Tree, mode: Mode, pt: Type): Tree = {
  def typedInAnyMode(tree: Tree): Tree = ...

  ... typedInAnyMode(tree) ...
}
```

Lambdalift adds a `pt: Type` parameter to `typedInAnyMode`, so the callsite
forwards the `pt` parameter. This tirggered inlining once `Type` was a SAM,
and method `typed1` became very large.

Now we only consider `scala.FunctionN` and types annotated `@FunctionalInterface`
as SAM types.