### PR TITLE
Don't attempt to publish if there's no private key.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,7 @@ env:
 
 # the key is restricted using forced commands so that it can only upload to the directory we need here
 after_success:
-  - if [ "${PRIV_KEY_SECRET}" != "" ] ; then
-      openssl aes-256-cbc -pass "pass:$PRIV_KEY_SECRET" -in spec/id_dsa_travis.enc -out spec/id_dsa_travis -d -a
-      chmod 600 spec/id_dsa_travis
-      eval "$(ssh-agent)"
-      '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && ssh-add -D && ssh-add spec/id_dsa_travis && rsync -e "ssh -o StrictHostKeyChecking=no" -rzv build/spec/ scalatest@chara.epfl.ch:/home/linuxsoft/archives/scala/spec/2.12/'
-    fi
+  - ./scripts/travis-publish-spec.sh
 
 # using S3 would be simpler, but we want to upload to scala-lang.org
 # after_success: bundle exec s3_website push --headless

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,12 @@ env:
 
 # the key is restricted using forced commands so that it can only upload to the directory we need here
 after_success:
-  - openssl aes-256-cbc -pass "pass:$PRIV_KEY_SECRET" -in spec/id_dsa_travis.enc -out spec/id_dsa_travis -d -a
-  - chmod 600 spec/id_dsa_travis
-  - eval "$(ssh-agent)"
-  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && ssh-add -D && ssh-add spec/id_dsa_travis && rsync -e "ssh -o StrictHostKeyChecking=no" -rzv build/spec/ scalatest@chara.epfl.ch:/home/linuxsoft/archives/scala/spec/2.12/'
+  - if [ "${PRIV_KEY_SECRET}" != "" ] ; then
+      openssl aes-256-cbc -pass "pass:$PRIV_KEY_SECRET" -in spec/id_dsa_travis.enc -out spec/id_dsa_travis -d -a
+      chmod 600 spec/id_dsa_travis
+      eval "$(ssh-agent)"
+      '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && ssh-add -D && ssh-add spec/id_dsa_travis && rsync -e "ssh -o StrictHostKeyChecking=no" -rzv build/spec/ scalatest@chara.epfl.ch:/home/linuxsoft/archives/scala/spec/2.12/'
+    fi
 
 # using S3 would be simpler, but we want to upload to scala-lang.org
 # after_success: bundle exec s3_website push --headless

--- a/scripts/travis-publish-spec.sh
+++ b/scripts/travis-publish-spec.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ "${PRIV_KEY_SECRET}" != "" -a "${TRAVIS_PULL_REQUEST}" = "false" ] ; then
+  openssl aes-256-cbc -pass "pass:$PRIV_KEY_SECRET" -in spec/id_dsa_travis.enc -out spec/id_dsa_travis -d -a
+  chmod 600 spec/id_dsa_travis
+  eval "$(ssh-agent)"
+  ssh-add -D
+  ssh-add spec/id_dsa_travis
+  rsync -e "ssh -o StrictHostKeyChecking=no" -rzv build/spec/ scalatest@chara.epfl.ch:/home/linuxsoft/archives/scala/spec/2.12/
+fi
+


### PR DESCRIPTION
Having the publish step only performed if the private key is available prevents [builds of forks from erroring](https://travis-ci.org/typelevel/scala/branches) unnecessarily. See gitter discussion [here](https://gitter.im/scala/contributors?at=5911803a4746d29d249a0a8d).

If this is merged I'll back/forward port to 2.11.x and 2.13.x.