### PR TITLE
Pretty print symbolic names in the REPL

### DIFF
--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -49,11 +49,16 @@ trait Printers extends api.Printers { self: SymbolTable =>
   /** Turns a path into a String, introducing backquotes
    *  as necessary.
    */
-  def backquotedPath(t: Tree): String = {
+  def backquotedPath(t: Tree): String = backquotedPathInternal(t, symName)
+  def decodedBackquotedPath(t: Tree): String = backquotedPathInternal(t, decodedSymName)
+  
+  private def backquotedPathInternal(t: Tree, stringify: (Tree, Name) => String): String = {
     t match {
-      case Select(qual, name) if name.isTermName  => s"${backquotedPath(qual)}.${symName(t, name)}"
-      case Select(qual, name) if name.isTypeName  => s"${backquotedPath(qual)}#${symName(t, name)}"
-      case Ident(name)                            => symName(t, name)
+      case Select(qual, name) if name.isTermName  => 
+        s"${backquotedPathInternal(qual, stringify)}.${stringify(t, name)}"
+      case Select(qual, name) if name.isTypeName  => 
+        s"${backquotedPathInternal(qual, stringify)}#${stringify(t, name)}"
+      case Ident(name)                            => stringify(t, name)
       case _                                      => t.toString
     }
   }

--- a/test/files/run/reflection-equality.check
+++ b/test/files/run/reflection-equality.check
@@ -10,7 +10,7 @@ scala> import scala.reflect.runtime.universe._
 import scala.reflect.runtime.universe._
 
 scala> import scala.reflect.runtime.{ currentMirror => cm }
-import scala.reflect.runtime.{currentMirror=>cm}
+import scala.reflect.runtime.{currentMirror => cm}
 
 scala> def im: InstanceMirror = cm.reflect(new X)
 im: reflect.runtime.universe.InstanceMirror

--- a/test/files/run/t1931.check
+++ b/test/files/run/t1931.check
@@ -6,7 +6,7 @@ scala> x + " works"
 res0: String = 42 works
 
 scala> import Predef.{ any2stringadd => _, _ }
-import Predef.{any2stringadd=>_, _}
+import Predef.{any2stringadd => _, _}
 
 scala> x + " works"
 <console>:14: error: value + is not a member of Any

--- a/test/files/run/t4700.check
+++ b/test/files/run/t4700.check
@@ -3,7 +3,7 @@ scala> import scala.annotation.showAsInfix
 import scala.annotation.showAsInfix
 
 scala> class &&[T,U]
-defined class $amp$amp
+defined class &&
 
 scala> def foo: Int && Boolean = ???
 foo: Int && Boolean
@@ -21,13 +21,13 @@ scala> def foo: Int Mappy (Boolean && String) = ???
 foo: Int Mappy (Boolean && String)
 
 scala> @showAsInfix(false) class ||[T,U]
-defined class $bar$bar
+defined class ||
 
 scala> def foo: Int || Boolean = ???
 foo: ||[Int,Boolean]
 
 scala> class &:[L, R]
-defined class $amp$colon
+defined class &:
 
 scala> def foo: Int &: String = ???
 foo: Int &: String

--- a/test/files/run/t5256d.check
+++ b/test/files/run/t5256d.check
@@ -3,7 +3,7 @@ scala> import scala.reflect.runtime.universe._
 import scala.reflect.runtime.universe._
 
 scala> import scala.reflect.runtime.{currentMirror => cm}
-import scala.reflect.runtime.{currentMirror=>cm}
+import scala.reflect.runtime.{currentMirror => cm}
 
 scala> class A { def foo = ??? }
 defined class A

--- a/test/files/run/t6549.check
+++ b/test/files/run/t6549.check
@@ -1,6 +1,6 @@
 
 scala> case class `X"`(var xxx: Any)
-defined class X$u0022
+defined class X"
 
 scala> val m = Map(("": Any) -> `X"`("\""), ('s: Any) -> `X"`("\""))
 m: scala.collection.immutable.Map[Any,X"] = Map("" -> X"("), 's -> X"("))

--- a/test/files/run/t6937.check
+++ b/test/files/run/t6937.check
@@ -1,12 +1,12 @@
 
 scala> import scala.reflect.runtime.{universe => ru}
-import scala.reflect.runtime.{universe=>ru}
+import scala.reflect.runtime.{universe => ru}
 
 scala>     import scala.reflect.runtime.{currentMirror => cm}
-import scala.reflect.runtime.{currentMirror=>cm}
+import scala.reflect.runtime.{currentMirror => cm}
 
 scala>     import scala.reflect.api.{Universe => ApiUniverse}
-import scala.reflect.api.{Universe=>ApiUniverse}
+import scala.reflect.api.{Universe => ApiUniverse}
 
 scala>     class A
 defined class A

--- a/test/files/run/t9880-9881.check
+++ b/test/files/run/t9880-9881.check
@@ -8,7 +8,7 @@ scala> import scala.util._
 import scala.util._
 
 scala> import scala.reflect.runtime.{universe => ru}
-import scala.reflect.runtime.{universe=>ru}
+import scala.reflect.runtime.{universe => ru}
 
 scala> import ru.TypeTag
 import ru.TypeTag
@@ -23,7 +23,7 @@ scala> :imports
  3) import scala.Predef._          (...)
  4) import java.util.Date          (...)
  5) import scala.util._            (...)
- 6) import scala.reflect.runtime.{universe=>ru} (...)
+ 6) import scala.reflect.runtime.{universe => ru} (...)
  7) import ru.TypeTag              (...)
 
 scala> 


### PR DESCRIPTION
Before, when you defined or imported things in the REPL, the encoded name is shown to the user. For some reason only vals are currently pretty printed:

```
scala> def + = ???
$plus: Nothing

scala> class +
defined class $plus

scala> type + = Nothing
defined type alias $plus

scala> object * { def + = ??? }
defined object $times

scala> import *.{+ => -}
import $times.{$plus=>$minus}

scala> lazy val + = ???
+: Nothing = <lazy>

scala> val + = null
+: Null = null
```
New behavior:

```
scala> def + = ???
+: Nothing

scala> class +
defined class +

scala> type + = Nothing
defined type alias +

scala> object * { def + = ??? }
defined object *

scala> import *.{+ => -}
import *.{+ => -}

scala> lazy val + = ???
+: Nothing = <lazy>

scala> val + = null
+: Null = null
```
For the imports I had to duplicate some code from `Printers`. An alternative would be to make `TreePrinter` print decoded names for imports, but I guess there's a reason why that isn't being done currently. 