### PR TITLE
Optimize Symbol.typeParams

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1744,18 +1744,21 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      */
     // NOTE: overridden in SynchronizedSymbols with the code copy/pasted
     // don't forget to modify the code over there if you modify this method
-    def typeParams: List[Symbol] =
-      if (isMonomorphicType) Nil
-      else {
-        // analogously to the "info" getter, here we allow for two completions:
-        //   one: sourceCompleter to LazyType, two: LazyType to completed type
-        if (validTo == NoPeriod)
+    def typeParams: List[Symbol] = {
+      def completeTypeParams = {
+        if (isMonomorphicType) Nil
+        else {
+          // analogously to the "info" getter, here we allow for two completions:
+          //   one: sourceCompleter to LazyType, two: LazyType to completed type
           enteringPhase(phaseOf(infos.validFrom))(rawInfo load this)
-        if (validTo == NoPeriod)
-          enteringPhase(phaseOf(infos.validFrom))(rawInfo load this)
+          if (validTo == NoPeriod)
+            enteringPhase(phaseOf(infos.validFrom))(rawInfo load this)
 
-        rawInfo.typeParams
+          rawInfo.typeParams
+        }
       }
+      if (validTo != NoPeriod) rawInfo.typeParams else completeTypeParams
+    }
 
     /** The value parameter sections of this symbol.
      */

--- a/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
@@ -134,17 +134,19 @@ private[reflect] trait SynchronizedSymbols extends internal.Symbols { self: Symb
     override def typeParams: List[Symbol] = gilSynchronizedIfNotThreadsafe {
       if (isCompilerUniverse) super.typeParams
       else {
-        if (isMonomorphicType) Nil
-        else {
-          // analogously to the "info" getter, here we allow for two completions:
-          //   one: sourceCompleter to LazyType, two: LazyType to completed type
-          if (validTo == NoPeriod)
+        def completeTypeParams = {
+          if (isMonomorphicType) Nil
+          else {
+            // analogously to the "info" getter, here we allow for two completions:
+            //   one: sourceCompleter to LazyType, two: LazyType to completed type
             rawInfo load this
-          if (validTo == NoPeriod)
-            rawInfo load this
+            if (validTo == NoPeriod)
+              rawInfo load this
 
-          rawInfo.typeParams
+            rawInfo.typeParams
+          }
         }
+        if (validTo != NoPeriod) rawInfo.typeParams else completeTypeParams
       }
     }
     override def unsafeTypeParams: List[Symbol] = gilSynchronizedIfNotThreadsafe {


### PR DESCRIPTION
.. by avoiding calls to isMonomorphicType after the symbol is
completed.

AFAICT, this is a cycle avoidance mechanism. However, when the symbol
is already completed, it is faster to look at the infos.info rather
than winding back through infos.prev.prev.prev to the original info.

I'm seeing a 2.5% speedup in compiler-benchmark, testing with this benchmark
(scalap + better-files):

```
compiler-benchmark>hot -psource= -f4 -wi 10 -jvmArgs -Xmx1G -jvmArgs -XX:MaxInlineLevel=18
``` 

Before:

```
[info] # Run complete. Total time: 00:14:20
[info] 
[info] Benchmark                                   (extraArgs)  (source)    Mode  Cnt     Score   Error  Units
[info] HotScalacBenchmark.compile                                         sample  396  1083.772 ± 6.689  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00                           sample       1030.750          ms/op
[info] HotScalacBenchmark.compile:compile·p0.50                           sample       1075.839          ms/op
[info] HotScalacBenchmark.compile:compile·p0.90                           sample       1118.411          ms/op
[info] HotScalacBenchmark.compile:compile·p0.95                           sample       1183.108          ms/op
[info] HotScalacBenchmark.compile:compile·p0.99                           sample       1237.571          ms/op
[info] HotScalacBenchmark.compile:compile·p0.999                          sample       1314.914          ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999                         sample       1314.914          ms/op
[info] HotScalacBenchmark.compile:compile·p1.00                           sample       1314.914          ms/op
```

After:
```
[info] Benchmark                                   (extraArgs)  (source)    Mode  Cnt     Score   Error  Units
[info] HotScalacBenchmark.compile                                         sample  400  1057.908 ± 4.640  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00                           sample       1016.070          ms/op
[info] HotScalacBenchmark.compile:compile·p0.50                           sample       1053.819          ms/op
[info] HotScalacBenchmark.compile:compile·p0.90                           sample       1075.839          ms/op
[info] HotScalacBenchmark.compile:compile·p0.95                           sample       1088.317          ms/op
[info] HotScalacBenchmark.compile:compile·p0.99                           sample       1212.133          ms/op
[info] HotScalacBenchmark.compile:compile·p0.999                          sample       1252.000          ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999                         sample       1252.000          ms/op
[info] HotScalacBenchmark.compile:compile·p1.00                           sample       1252.000          ms/op
```