### PR TITLE
WIP mapOver/traverse/transform: refactor pattern match into virtual call [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
@@ -640,7 +640,7 @@ abstract class BCodeIdiomatic extends SubComponent {
    * The entry-value for a LabelDef entry-key always contains the entry-key.
    *
    */
-  class LabelDefsFinder(rhs: Tree) extends Traverser {
+  class LabelDefsFinder(rhs: Tree) extends InternalTraverser {
     val result = mutable.AnyRefMap.empty[Tree, List[LabelDef]]
     var acc: List[LabelDef] = Nil
     var directResult: List[LabelDef] = Nil
@@ -654,7 +654,7 @@ abstract class BCodeIdiomatic extends SubComponent {
     override def traverse(tree: Tree) {
       val saved = acc
       acc = Nil
-      super.traverse(tree)
+      tree.traverse(this)
       // acc contains all LabelDefs found under (but not at) `tree`
       tree match {
         case lblDf: LabelDef => acc ::= lblDf

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -374,7 +374,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
         // collecting symbols for entry points here (as opposed to GenBCode where they are used)
         // has the advantage of saving an additional pass over all ClassDefs.
         entryPoints ::= tree.symbol
-        super.transform(tree)
+        tree.transform(this)
 
       /* Transforms dynamic calls (i.e. calls to methods that are undefined
        * in the erased type space) to -- dynamically -- unsafe calls using
@@ -454,12 +454,12 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
       case Apply(fn @ Select(qual, _), (arg @ Literal(Constant(symname: String))) :: Nil)
         if treeInfo.isQualifierSafeToElide(qual) && fn.symbol == Symbol_apply && !currentClass.isTrait =>
 
-        super.transform(treeCopy.ApplyDynamic(tree, atPos(fn.pos)(Ident(SymbolLiteral_dummy).setType(SymbolLiteral_dummy.info)), LIT(SymbolLiteral_bootstrap) :: arg :: Nil))
+        treeCopy.ApplyDynamic(tree, atPos(fn.pos)(Ident(SymbolLiteral_dummy).setType(SymbolLiteral_dummy.info)), LIT(SymbolLiteral_bootstrap) :: arg :: Nil).transform(this)
 
       // Drop the TypeApply, which was used in Erasure to make `synchronized { ... } ` erase like `...`
       // (and to avoid boxing the argument to the polymorphic `synchronized` method).
       case app@Apply(TypeApply(fun, _), args) if fun.symbol == Object_synchronized =>
-        super.transform(treeCopy.Apply(app, fun, args))
+        treeCopy.Apply(app, fun, args).transform(this)
 
       // Replaces `Array(Predef.wrapArray(ArrayValue(...).$asInstanceOf[...]), <tag>)`
       // with just `ArrayValue(...).$asInstanceOf[...]`
@@ -467,10 +467,10 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
       // See scala/bug#6611; we must *only* do this for literal vararg arrays.
       case Apply(appMeth, List(Apply(wrapRefArrayMeth, List(arg @ StripCast(ArrayValue(_, _)))), _))
       if wrapRefArrayMeth.symbol == currentRun.runDefinitions.Predef_wrapRefArray && appMeth.symbol == ArrayModule_genericApply =>
-        super.transform(arg)
+        arg.transform(this)
       case Apply(appMeth, List(elem0, Apply(wrapArrayMeth, List(rest @ ArrayValue(elemtpt, _)))))
       if wrapArrayMeth.symbol == Predef_wrapArray(elemtpt.tpe) && appMeth.symbol == ArrayModule_apply(elemtpt.tpe) =>
-        super.transform(treeCopy.ArrayValue(rest, rest.elemtpt, elem0 :: rest.elems))
+        treeCopy.ArrayValue(rest, rest.elemtpt, elem0 :: rest.elems).transform(this)
 
       case _ =>
         super.transform(tree)

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -169,7 +169,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
       val omittables = mutable.Set.empty[Symbol] ++ (decls filter (sym => omittableParamAcc(sym) || omittableOuterAcc(sym))) // the closure only captures isEffectivelyFinal
 
       // no point traversing further once omittables is empty, all candidates ruled out already.
-      object detectUsages extends Traverser {
+      object detectUsages extends InternalTraverser {
         lazy val bodyOfOuterAccessor = defs.collect{ case dd: DefDef if omittableOuterAcc(dd.symbol) => dd.symbol -> dd.rhs }.toMap
 
         override def traverse(tree: Tree): Unit =
@@ -179,8 +179,8 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
               case _: DefDef if (sym.owner eq clazz) && omittableOuterAcc(sym) => // don't mark as "needed" the field supporting this outer-accessor (not just yet)
               case _: Select if omittables(sym) => omittables -= sym // mark usage
                 bodyOfOuterAccessor get sym foreach traverse // recurse to mark as needed the field supporting the outer-accessor-method
-                super.traverse(tree)
-              case _ => super.traverse(tree)
+                tree.traverse(this)
+              case _ => tree.traverse(this)
             }
           }
       }

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -427,7 +427,7 @@ abstract class Erasure extends InfoTransform
         case _ =>
           tree
       }
-      super.transform(tree1)
+      tree1.transform(this)
     }
   }
 

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -202,7 +202,7 @@ abstract class ExplicitOuter extends InfoTransform
    *  values for outer parameters of constructors.
    *  The class provides methods for referencing via outer.
    */
-  abstract class OuterPathTransformer(unit: CompilationUnit) extends TypingTransformer(unit) with UnderConstructionTransformer {
+  abstract class OuterPathTransformer(unit: CompilationUnit) extends TypingTransformer(unit) {
     /** The directly enclosing outer parameter, if we are in a constructor */
     protected var outerParam: Symbol = NoSymbol
 
@@ -267,6 +267,13 @@ abstract class ExplicitOuter extends InfoTransform
       else outerPath(outerSelect(base), from.outerClass, to)
     }
 
+
+    /** The stack of class symbols in which a call to this() or to the super
+      * constructor, or early definition is active
+      */
+    protected def isUnderConstruction(clazz: Symbol) = selfOrSuperCalls contains clazz
+    protected val selfOrSuperCalls = collection.mutable.Stack[Symbol]()
+
     override def transform(tree: Tree): Tree = {
       def sym = tree.symbol
       val savedOuterParam = outerParam
@@ -279,7 +286,13 @@ abstract class ExplicitOuter extends InfoTransform
             assert(outerParam.name startsWith nme.OUTER, outerParam.name)
           case _ =>
         }
-        super.transform(tree)
+        if ((treeInfo isSelfOrSuperConstrCall tree) || (treeInfo isEarlyDef tree)) {
+          selfOrSuperCalls push currentOwner.owner
+          val transformed = super.transform(tree)
+          selfOrSuperCalls.pop()
+          transformed
+        } else
+          super.transform(tree)
       }
       finally outerParam = savedOuterParam
     }

--- a/src/compiler/scala/tools/nsc/transform/Flatten.scala
+++ b/src/compiler/scala/tools/nsc/transform/Flatten.scala
@@ -118,10 +118,10 @@ abstract class Flatten extends InfoTransform {
       tree match {
         case PackageDef(_, _) =>
           liftedDefs(tree.symbol.moduleClass) = new ListBuffer
-          super.transform(tree)
+          tree.transform(this)
         case Template(_, _, _) if tree.symbol.isDefinedInPackage =>
           liftedDefs(tree.symbol.owner) = new ListBuffer
-          super.transform(tree)
+          tree.transform(this)
         case ClassDef(_, _, _, _) if tree.symbol.isNestedClass =>
           // scala/bug#5508 Ordering important. In `object O { trait A { trait B } }`, we want `B` to appear after `A` in
           //         the sequence of lifted trees in the enclosing package. Why does this matter? Currently, mixin
@@ -134,12 +134,12 @@ abstract class Flatten extends InfoTransform {
           //            - move the accessor creation to the Mixin info transformer
           val liftedBuffer = liftedDefs(tree.symbol.enclosingTopLevelClass.owner)
           val index = liftedBuffer.length
-          liftedBuffer.insert(index, super.transform(tree))
+          liftedBuffer.insert(index, tree.transform(this))
           if (tree.symbol.sourceModule.isStaticModule)
             removeSymbolInCurrentScope(tree.symbol.sourceModule)
           EmptyTree
         case _ =>
-          super.transform(tree)
+          tree.transform(this)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -186,7 +186,7 @@ abstract class LambdaLift extends InfoTransform {
     }
 
     /** The traverse function */
-    private val freeVarTraverser = new Traverser {
+    private val freeVarTraverser = new InternalTraverser {
       override def traverse(tree: Tree) {
 //       try { //debug
         val sym = tree.symbol
@@ -217,7 +217,7 @@ abstract class LambdaLift extends InfoTransform {
               markCalled(sym, logicallyEnclosingMember(currentOwner))
           case _ =>
         }
-        super.traverse(tree)
+        tree.traverse(this)
 //       } catch {//debug
 //         case ex: Throwable =>
 //           Console.println(s"$ex while traversing $tree")

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -423,7 +423,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL with AccessorSynthes
         val singleUseFields: Map[Symbol, List[Symbol]] = {
           val usedIn = mutable.HashMap[Symbol, List[Symbol]]() withDefaultValue Nil
 
-          object SingleUseTraverser extends Traverser {
+          object SingleUseTraverser extends InternalTraverser {
             override def traverse(tree: Tree) {
               tree match {
                 // assignment targets don't count as a dereference -- only check the rhs
@@ -438,8 +438,8 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL with AccessorSynthes
                     // println("added use in: " + currentOwner + " -- " + tree)
                     usedIn(sym) ::= currentOwner
                   }
-                  super.traverse(tree)
-                case _ => super.traverse(tree)
+                  tree.traverse(this)
+                case _ => tree.traverse(this)
               }
             }
           }
@@ -588,7 +588,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL with AccessorSynthes
      */
     override def transform(tree: Tree): Tree = {
       val saved = localTyper
-      val tree1 = super.transform(preTransform(tree))
+      val tree1 = preTransform(tree).transform(this)
       // localTyper needed when not flattening inner classes. parts after an
       // inner class will otherwise be typechecked with a wrong scope
       try exitingMixin(postTransform(tree1))

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1463,7 +1463,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
 
     /** Collect method bodies that are concrete specialized methods.
      */
-    class CollectMethodBodies extends Traverser {
+    class CollectMethodBodies extends InternalTraverser {
       override def traverse(tree: Tree) = tree match {
         case DefDef(_, _, _, vparams :: Nil, _, rhs) =>
           if (concreteSpecMethods(tree.symbol) || tree.symbol.isConstructor) {
@@ -1479,7 +1479,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
           // log("!!! adding body of a valdef " + tree.symbol + ": " + rhs)
           //super.traverse(tree)
         case _ =>
-          super.traverse(tree)
+          tree.traverse(this)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -276,7 +276,7 @@ abstract class TailCalls extends Transform {
       tree match {
         case dd: DefDef if tree.symbol.isLazy && tree.symbol.hasAnnotation(TailrecClass) =>
           reporter.error(tree.pos, "lazy vals are not tailcall transformed")
-          super.transform(tree)
+          tree.transform(this)
 
         case dd @ DefDef(_, name, _, vparamss0, _, rhs0) if isEligible(dd) =>
           val newCtx = new DefDefTailContext(dd)
@@ -402,7 +402,7 @@ abstract class TailCalls extends Transform {
         case EmptyTree | Super(_, _) | This(_) | Ident(_) | Literal(_) | Function(_, _) | TypeTree() =>
           tree
         case _ =>
-          super.transform(tree)
+          tree.transform(this)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/transform/TypingTransformers.scala
+++ b/src/compiler/scala/tools/nsc/transform/TypingTransformers.scala
@@ -37,11 +37,11 @@ trait TypingTransformers {
       tree match {
         case Template(_, _, _) =>
           // enter template into context chain
-          atOwner(currentOwner) { super.transform(tree) }
+          atOwner(currentOwner) { tree.transform(this) }
         case PackageDef(_, _) =>
-          atOwner(tree.symbol) { super.transform(tree) }
+          atOwner(tree.symbol) { tree.transform(this) }
         case _ =>
-          super.transform(tree)
+          tree.transform(this)
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -623,7 +623,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
     // TODO: do this during tree construction, but that will require tracking the current owner in treemakers
     // TODO: assign more fine-grained positions
     // fixes symbol nesting, assigns positions
-    protected def fixerUpper(origOwner: Symbol, pos: Position) = new Traverser {
+    protected def fixerUpper(origOwner: Symbol, pos: Position) = new InternalTraverser {
       currentOwner = origOwner
 
       override def traverse(t: Tree) {
@@ -646,7 +646,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
           debug.patmat("untouched "+ ((t, t.getClass, t.symbol.ownerChain, currentOwner.ownerChain)))
           case _ =>
         }
-        super.traverse(t)
+        t.traverse(this)
       }
 
       // override def apply

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -237,7 +237,7 @@ trait Interface extends ast.TreeDSL {
 
             val tree1 = tree match {
               case Ident(_) => subst(from, to)
-              case _        => super.transform(tree)
+              case _        => tree.transform(this)
             }
             tree1 match {
               case _: DefTree =>

--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -56,14 +56,14 @@ trait Analyzer extends AnyRef
       override val checkable = false
       import global._
 
-      val openPackageObjectsTraverser = new Traverser {
+      val openPackageObjectsTraverser = new InternalTraverser {
         override def traverse(tree: Tree): Unit = tree match {
           case ModuleDef(_, _, _) =>
             if (tree.symbol.name == nme.PACKAGEkw) {
               openPackageModule(tree.symbol, tree.symbol.owner)
             }
           case ClassDef(_, _, _, _) => () // make it fast
-          case _ => super.traverse(tree)
+          case _ => tree.traverse(this)
         }
       }
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1747,7 +1747,7 @@ abstract class RefChecks extends Transform {
           case ValDef(_, _, _, _) if treeInfo.hasSynthCaseSymbol(result) =>
             deriveValDef(result)(transform) // scala/bug#7716 Don't refcheck the tpt of the synthetic val that holds the selector.
           case _ =>
-            super.transform(result)
+            result.transform(this)
         }
         result match {
           case ClassDef(_, _, _, _)

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -2517,12 +2517,14 @@ trait Trees { self: Universe =>
    *  because pattern matching on abstract types we have here degrades performance.
    *  @group Traversal
    */
+  @deprecated("2.12.3", "Use Tree#traverse instead")
   protected def itraverse(traverser: Traverser, tree: Tree): Unit = throw new MatchError(tree)
 
   /** Provides an extension hook for the traversal strategy.
    *  Future-proofs against new node types.
    *  @group Traversal
    */
+  @deprecated("2.12.3", "Use Tree#traverse instead")
   protected def xtraverse(traverser: Traverser, tree: Tree): Unit = throw new MatchError(tree)
 
   /** A class that implement a default tree transformation strategy: breadth-first component-wise cloning.

--- a/src/reflect/scala/reflect/internal/Positions.scala
+++ b/src/reflect/scala/reflect/internal/Positions.scala
@@ -274,7 +274,7 @@ trait Positions extends api.Positions { self: SymbolTable =>
     override protected def isEligible(t: Tree) = super.isEligible(t) && t.tpe != null
   }
 
-  trait PosAssigner extends Traverser {
+  trait PosAssigner extends InternalTraverser {
     var pos: Position
   }
   protected[this] lazy val posAssigner: PosAssigner = new DefaultPosAssigner
@@ -285,7 +285,7 @@ trait Positions extends api.Positions { self: SymbolTable =>
       if (!t.canHaveAttrs) ()
       else if (t.pos == NoPosition) {
         t.setPos(pos)
-        super.traverse(t)   // TODO: bug? shouldn't the traverse be outside of the if?
+        t.traverse(this)   // TODO: bug? shouldn't the traverse be outside of the if?
         // @PP: it's pruning whenever it encounters a node with a
         // position, which I interpret to mean that (in the author's
         // mind at least) either the children of a positioned node will

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1762,25 +1762,6 @@ trait Trees extends api.Trees {
     }
   }
 
-  /** Tracks the classes currently under construction during a transform */
-  trait UnderConstructionTransformer extends Transformer {
-    import collection.mutable
-
-    protected def isUnderConstruction(clazz: Symbol) = selfOrSuperCalls contains clazz
-
-    /** The stack of class symbols in which a call to this() or to the super
-      * constructor, or early definition is active */
-    private val selfOrSuperCalls = mutable.Stack[Symbol]()
-
-    abstract override def transform(tree: Tree) = {
-      if ((treeInfo isSelfOrSuperConstrCall tree) || (treeInfo isEarlyDef tree)) {
-        selfOrSuperCalls push currentOwner.owner
-        try super.transform(tree)
-        finally selfOrSuperCalls.pop()
-      } else super.transform(tree)
-    }
-  }
-
   def duplicateAndKeepPositions(tree: Tree) = new Duplicator(focusPositions = false) transform tree
 
   // this is necessary to avoid crashes like https://github.com/scalamacros/paradise/issues/1

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -229,6 +229,8 @@ trait Trees extends api.Trees {
           else ""
         )
     }
+    def transform(transformer: Transformer): Tree = xtransform(transformer, this)
+    def traverse(traverser: Traverser): Unit = xtraverse(traverser, this)
   }
 
   trait TermTree extends Tree with TermTreeApi
@@ -281,12 +283,24 @@ trait Trees extends api.Trees {
       case ValDef(mods, _, _, _)    => if (mods hasFlag MUTABLE) "var" else "val"
       case _ => ""
     }
+
   }
 
   case class PackageDef(pid: RefTree, stats: List[Tree])
        extends MemberDef with PackageDefApi {
     def name = pid.name
     def mods = NoMods
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.PackageDef(
+        this, transformer.transform(pid).asInstanceOf[RefTree],
+        transformer.atOwner(mclass(this.symbol)) {
+          transformer.transformStats(stats, transformer.currentOwner)
+        }
+      )
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(pid)
+      traverser.traverseStats(stats, mclass(this.symbol))
+    }
   }
   object PackageDef extends PackageDefExtractor
 
@@ -295,7 +309,19 @@ trait Trees extends api.Trees {
   }
 
   case class ClassDef(mods: Modifiers, name: TypeName, tparams: List[TypeDef], impl: Template)
-       extends ImplDef with ClassDefApi
+       extends ImplDef with ClassDefApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.atOwner(this.symbol) {
+        transformer.treeCopy.ClassDef(this, transformer.transformModifiers(mods), name,
+          transformer.transformTypeDefs(tparams), transformer.transformTemplate(impl))
+      }
+    override def traverse(traverser: Traverser): Unit = traverser.atOwner(symbol) {
+      traverser.traverseModifiers(mods)
+      traverser.traverseName(name)
+      traverser.traverseParams(tparams)
+      traverser.traverse(impl)
+    }
+  }
   object ClassDef extends ClassDefExtractor {
     /** @param sym       the class symbol
      *  @param impl      the implementation template
@@ -318,7 +344,18 @@ trait Trees extends api.Trees {
   }
 
   case class ModuleDef(mods: Modifiers, name: TermName, impl: Template)
-        extends ImplDef with ModuleDefApi
+        extends ImplDef with ModuleDefApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.atOwner(mclass(this.symbol)) {
+        transformer.treeCopy.ModuleDef(this, transformer.transformModifiers(mods),
+          name, transformer.transformTemplate(impl))
+      }
+    override def traverse(traverser: Traverser): Unit = traverser.atOwner(mclass(symbol)) {
+      traverser.traverseModifiers(mods)
+      traverser.traverseName(name)
+      traverser.traverse(impl)
+    }
+  }
   object ModuleDef extends ModuleDefExtractor {
     /**
      *  @param sym       the class symbol
@@ -344,14 +381,42 @@ trait Trees extends api.Trees {
     }
   }
 
-  case class ValDef(mods: Modifiers, name: TermName, tpt: Tree, rhs: Tree) extends ValOrDefDef with ValDefApi
+  case class ValDef(mods: Modifiers, name: TermName, tpt: Tree, rhs: Tree) extends ValOrDefDef with ValDefApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.atOwner(this.symbol) {
+        transformer.treeCopy.ValDef(this, transformer.transformModifiers(mods),
+          name, transformer.transform(tpt), transformer.transform(rhs))
+      }
+    override def traverse(traverser: Traverser): Unit = traverser.atOwner(symbol) {
+      traverser.traverseModifiers(mods)
+      traverser.traverseName(name)
+      traverser.traverseTypeAscription(tpt)
+      traverser.traverse(rhs)
+    }
+  }
   object ValDef extends ValDefExtractor {
     def apply(sym: Symbol): ValDef            = newValDef(sym, EmptyTree)()
     def apply(sym: Symbol, rhs: Tree): ValDef = newValDef(sym, rhs)()
   }
 
   case class DefDef(mods: Modifiers, name: TermName, tparams: List[TypeDef],
-                    vparamss: List[List[ValDef]], tpt: Tree, rhs: Tree) extends ValOrDefDef with DefDefApi
+                    vparamss: List[List[ValDef]], tpt: Tree, rhs: Tree) extends ValOrDefDef with DefDefApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.atOwner(this.symbol) {
+        transformer.treeCopy.DefDef(this, transformer.transformModifiers(mods), name,
+          transformer.transformTypeDefs(tparams), transformer.transformValDefss(vparamss),
+          transformer.transform(tpt), transformer.transform(rhs))
+      }
+    override def traverse(traverser: Traverser): Unit = traverser.atOwner(symbol) {
+      traverser.traverseModifiers(mods)
+      traverser.traverseName(name)
+      traverser.traverseParams(tparams)
+      traverser.traverseParamss(vparamss)
+      traverser.traverseTypeAscription(tpt)
+      traverser.traverse(rhs)
+    }
+
+  }
   object DefDef extends DefDefExtractor {
     def apply(sym: Symbol, rhs: Tree): DefDef                                                = newDefDef(sym, rhs)()
     def apply(sym: Symbol, vparamss: List[List[ValDef]], rhs: Tree): DefDef                  = newDefDef(sym, rhs)(vparamss = vparamss)
@@ -361,7 +426,19 @@ trait Trees extends api.Trees {
   }
 
   case class TypeDef(mods: Modifiers, name: TypeName, tparams: List[TypeDef], rhs: Tree)
-       extends MemberDef with TypeDefApi
+       extends MemberDef with TypeDefApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.atOwner(this.symbol) {
+        transformer.treeCopy.TypeDef(this, transformer.transformModifiers(mods), name,
+          transformer.transformTypeDefs(tparams), transformer.transform(rhs))
+      }
+    override def traverse(traverser: Traverser): Unit = traverser.atOwner(symbol) {
+      traverser.traverseModifiers(mods)
+      traverser.traverseName(name)
+      traverser.traverseParams(tparams)
+      traverser.traverse(rhs)
+    }
+  }
   object TypeDef extends TypeDefExtractor {
     /** A TypeDef node which defines abstract type or type parameter for given `sym` */
     def apply(sym: Symbol): TypeDef            = newTypeDef(sym, TypeBoundsTree(sym))()
@@ -369,7 +446,15 @@ trait Trees extends api.Trees {
   }
 
   case class LabelDef(name: TermName, params: List[Ident], rhs: Tree)
-       extends DefTree with TermTree with LabelDefApi
+       extends DefTree with TermTree with LabelDefApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.LabelDef(this, name, transformer.transformIdents(params), transformer.transform(rhs)) //bq: Martin, once, atOwner(...) works, also change `LambdaLifter.proxy'
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverseName(name)
+      traverser.traverseParams(params)
+      traverser.traverse(rhs)
+    }
+  }
   object LabelDef extends LabelDefExtractor {
     def apply(sym: Symbol, params: List[Symbol], rhs: Tree): LabelDef =
       atPos(sym.pos) {
@@ -384,35 +469,90 @@ trait Trees extends api.Trees {
   }
 
   case class Import(expr: Tree, selectors: List[ImportSelector])
-       extends SymTree with ImportApi
+       extends SymTree with ImportApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Import(this, transformer.transform(expr), selectors)
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(expr)
+      selectors foreach traverser.traverseImportSelector
+    }
+  }
   object Import extends ImportExtractor
 
   case class Template(parents: List[Tree], self: ValDef, body: List[Tree])
-       extends SymTree with TemplateApi
+       extends SymTree with TemplateApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Template(this, transformer.transformTrees(parents), transformer.transformValDef(self), transformer.transformStats(body, this.symbol))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverseParents(parents)
+      traverser.traverseSelfType(self)
+      traverser.traverseStats(body, this.symbol)
+    }
+  }
   object Template extends TemplateExtractor
 
   case class Block(stats: List[Tree], expr: Tree)
-       extends TermTree with BlockApi
+       extends TermTree with BlockApi {
+    override def transform(transformer: Transformer): Tree =
+      treeCopy.Block(this, transformer.transformStats(stats, transformer.currentOwner), transformer.transform(expr))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverseTrees(stats)
+      traverser.traverse(expr)
+    }
+  }
   object Block extends BlockExtractor
 
   case class CaseDef(pat: Tree, guard: Tree, body: Tree)
-       extends Tree with CaseDefApi
+       extends Tree with CaseDefApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.CaseDef(this, transformer.transform(pat), transformer.transform(guard), transformer.transform(body))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traversePattern(pat)
+      traverser.traverseGuard(guard)
+      traverser.traverse(body)
+    }
+  }
   object CaseDef extends CaseDefExtractor
 
   case class Alternative(trees: List[Tree])
-       extends TermTree with AlternativeApi
+       extends TermTree with AlternativeApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Alternative(this, transformer.transformTrees(trees))
+    override def traverse(traverser: Traverser): Unit =
+      traverser.traverseTrees(trees)
+  }
   object Alternative extends AlternativeExtractor
 
   case class Star(elem: Tree)
-       extends TermTree with StarApi
+       extends TermTree with StarApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Star(this, transformer.transform(elem))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(elem)
+    }
+  }
   object Star extends StarExtractor
 
   case class Bind(name: Name, body: Tree)
-       extends DefTree with BindApi
+       extends DefTree with BindApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Bind(this, name, transformer.transform(body))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverseName(name)
+      traverser.traverse(body)
+    }
+  }
   object Bind extends BindExtractor
 
   case class UnApply(fun: Tree, args: List[Tree])
-       extends TermTree with UnApplyApi
+       extends TermTree with UnApplyApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.UnApply(this, transformer.transform(fun), transformer.transformTrees(args)) // bq: see test/.../unapplyContexts2.scala
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(fun)
+      traverser.traverseTrees(args)
+    }
+  }
   object UnApply extends UnApplyExtractor
 
   /** An array of expressions. This AST node needs to be translated in backend.
@@ -431,45 +571,122 @@ trait Trees extends api.Trees {
    *      Literal("%s%d"),
    *      ArrayValue(<Any>, List(Ident("foo"), Literal(42))))
    */
-  case class ArrayValue(elemtpt: Tree, elems: List[Tree]) extends TermTree
+  case class ArrayValue(elemtpt: Tree, elems: List[Tree]) extends TermTree {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.ArrayValue(this, transformer.transform(elemtpt), transformer.transformTrees(elems))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(elemtpt)
+      traverser.traverseTrees(elems)
+    }
+  }
 
   case class Function(vparams: List[ValDef], body: Tree)
-       extends SymTree with TermTree with FunctionApi
+       extends SymTree with TermTree with FunctionApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.atOwner(this.symbol) {
+        transformer.treeCopy.Function(this, transformer.transformValDefs(vparams), transformer.transform(body))
+      }
+    override def traverse(traverser: Traverser): Unit = traverser.atOwner(this.symbol) {
+      traverser.traverseParams(vparams) ; traverser.traverse(body)
+    }
+  }
   object Function extends FunctionExtractor
 
   case class Assign(lhs: Tree, rhs: Tree)
-       extends TermTree with AssignApi
+       extends TermTree with AssignApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Assign(this, transformer.transform(lhs), transformer.transform(rhs))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(lhs)
+      traverser.traverse(rhs)
+    }
+  }
   object Assign extends AssignExtractor
 
   case class AssignOrNamedArg(lhs: Tree, rhs: Tree)
-       extends TermTree with AssignOrNamedArgApi
+       extends TermTree with AssignOrNamedArgApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.AssignOrNamedArg(this, transformer.transform(lhs), transformer.transform(rhs))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(lhs)
+      traverser.traverse(rhs)
+    }
+  }
   object AssignOrNamedArg extends AssignOrNamedArgExtractor
 
   case class If(cond: Tree, thenp: Tree, elsep: Tree)
-       extends TermTree with IfApi
+       extends TermTree with IfApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.If(this, transformer.transform(cond), transformer.transform(thenp), transformer.transform(elsep))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(cond)
+      traverser.traverse(thenp)
+      traverser.traverse(elsep)
+    }
+  }
   object If extends IfExtractor
 
   case class Match(selector: Tree, cases: List[CaseDef])
-       extends TermTree with MatchApi
+       extends TermTree with MatchApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Match(this, transformer.transform(selector), transformer.transformCaseDefs(cases))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(selector)
+      traverser.traverseCases(cases)
+    }
+  }
   object Match extends MatchExtractor
 
   case class Return(expr: Tree)
-       extends SymTree with TermTree with ReturnApi
+       extends SymTree with TermTree with ReturnApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Return(this, transformer.transform(expr))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(expr)
+    }
+  }
   object Return extends ReturnExtractor
 
   case class Try(block: Tree, catches: List[CaseDef], finalizer: Tree)
-       extends TermTree with TryApi
+       extends TermTree with TryApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Try(this, transformer.transform(block), transformer.transformCaseDefs(catches), transformer.transform(finalizer))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(block)
+      traverser.traverseCases(catches)
+      traverser.traverse(finalizer)
+    }
+  }
   object Try extends TryExtractor
 
   case class Throw(expr: Tree)
-       extends TermTree with ThrowApi
+       extends TermTree with ThrowApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Throw(this, transformer.transform(expr))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(expr)
+    }
+  }
   object Throw extends ThrowExtractor
 
-  case class New(tpt: Tree) extends TermTree with NewApi
+  case class New(tpt: Tree) extends TermTree with NewApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.New(this, transformer.transform(tpt))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(tpt)
+    }
+  }
   object New extends NewExtractor
 
   case class Typed(expr: Tree, tpt: Tree)
-       extends TermTree with TypedApi
+       extends TermTree with TypedApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Typed(this, transformer.transform(expr), transformer.transform(tpt))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(expr)
+      traverser.traverseTypeAscription(tpt)
+    }
+  }
   object Typed extends TypedExtractor
 
   abstract class GenericApply extends TermTree with GenericApplyApi {
@@ -484,6 +701,12 @@ trait Trees extends api.Trees {
 
     override def symbol: Symbol = fun.symbol
     override def symbol_=(sym: Symbol) { fun.symbol = sym }
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.TypeApply(this, transformer.transform(fun), transformer.transformTrees(args))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(fun)
+      traverser.traverseTypeArgs(args)
+    }
   }
   object TypeApply extends TypeApplyExtractor
 
@@ -491,6 +714,12 @@ trait Trees extends api.Trees {
        extends GenericApply with ApplyApi {
     override def symbol: Symbol = fun.symbol
     override def symbol_=(sym: Symbol) { fun.symbol = sym }
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Apply(this, transformer.transform(fun), transformer.transformTrees(args))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(fun)
+      traverser.traverseTrees(args)
+    }
   }
   object Apply extends ApplyExtractor
 
@@ -514,16 +743,35 @@ trait Trees extends api.Trees {
     Apply(init, args.toList)
   }
 
-  case class ApplyDynamic(qual: Tree, args: List[Tree]) extends SymTree with TermTree
+  case class ApplyDynamic(qual: Tree, args: List[Tree]) extends SymTree with TermTree {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.ApplyDynamic(this, transformer.transform(qual), transformer.transformTrees(args))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(qual)
+      traverser.traverseTrees(args)
+    }
+  }
 
   case class Super(qual: Tree, mix: TypeName) extends TermTree with SuperApi {
     override def symbol: Symbol = qual.symbol
     override def symbol_=(sym: Symbol) { qual.symbol = sym }
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Super(this, transformer.transform(qual), mix)
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(qual)
+      traverser.traverseName(mix)
+    }
   }
   object Super extends SuperExtractor
 
   case class This(qual: TypeName)
-        extends SymTree with TermTree with ThisApi
+        extends SymTree with TermTree with ThisApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.This(this, qual)
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverseName(qual)
+    }
+  }
   object This extends ThisExtractor
 
   case class Select(qualifier: Tree, name: Name)
@@ -531,46 +779,95 @@ trait Trees extends api.Trees {
 
     // !!! assert disabled due to test case pos/annotDepMethType.scala triggering it.
     // assert(qualifier.isTerm, qualifier)
+
+    override def transform(transformer: Transformer): Tree = {
+      transformer.treeCopy.Select(this, transformer.transform(qualifier), name)
+    }
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(qualifier)
+      traverser.traverseName(name)
+    }
   }
   object Select extends SelectExtractor
 
   case class Ident(name: Name) extends RefTree with IdentApi {
     def qualifier: Tree = EmptyTree
     def isBackquoted = this.hasAttachment[BackquotedIdentifierAttachment.type]
+    override def transform(transformer: Transformer): Tree = {
+      transformer.treeCopy.Ident(this, name)
+    }
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverseName(name)
+    }
   }
   object Ident extends IdentExtractor
 
   case class ReferenceToBoxed(ident: Ident) extends TermTree with ReferenceToBoxedApi {
     override def symbol: Symbol = ident.symbol
     override def symbol_=(sym: Symbol) { ident.symbol = sym }
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.ReferenceToBoxed(this, transformer.transform(ident) match { case idt1: Ident => idt1 })
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(ident)
+    }
   }
   object ReferenceToBoxed extends ReferenceToBoxedExtractor
 
   case class Literal(value: Constant)
         extends TermTree with LiteralApi {
     assert(value ne null)
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Literal(this, value)
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverseConstant(value)
+    }
   }
   object Literal extends LiteralExtractor
 
 //  @deprecated("will be removed and then be re-introduced with changed semantics, use Literal(Constant(x)) instead")
 //  def Literal(x: Any) = new Literal(Constant(x))
 
-  case class Annotated(annot: Tree, arg: Tree) extends Tree with AnnotatedApi
+  case class Annotated(annot: Tree, arg: Tree) extends Tree with AnnotatedApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.Annotated(this, transformer.transform(annot), transformer.transform(arg))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(annot)
+      traverser.traverse(arg)
+    }
+  }
   object Annotated extends AnnotatedExtractor
 
   case class SingletonTypeTree(ref: Tree)
-        extends TypTree with SingletonTypeTreeApi
+        extends TypTree with SingletonTypeTreeApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.SingletonTypeTree(this, transformer.transform(ref))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(ref)
+    }
+  }
   object SingletonTypeTree extends SingletonTypeTreeExtractor
 
   case class SelectFromTypeTree(qualifier: Tree, name: TypeName)
        extends RefTree with TypTree with SelectFromTypeTreeApi {
 
     assert(qualifier.isType, qualifier)
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.SelectFromTypeTree(this, transformer.transform(qualifier), name)
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(qualifier)
+      traverser.traverseName(name)
+    }
   }
   object SelectFromTypeTree extends SelectFromTypeTreeExtractor
 
   case class CompoundTypeTree(templ: Template)
-       extends TypTree with CompoundTypeTreeApi
+       extends TypTree with CompoundTypeTreeApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.CompoundTypeTree(this, transformer.transformTemplate(templ))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(templ)
+    }
+  }
   object CompoundTypeTree extends CompoundTypeTreeExtractor
 
   case class AppliedTypeTree(tpt: Tree, args: List[Tree])
@@ -580,15 +877,35 @@ trait Trees extends api.Trees {
 
     override def symbol: Symbol = tpt.symbol
     override def symbol_=(sym: Symbol) { tpt.symbol = sym }
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.AppliedTypeTree(this, transformer.transform(tpt), transformer.transformTrees(args))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(tpt)
+      traverser.traverseTypeArgs(args)
+    }
   }
   object AppliedTypeTree extends AppliedTypeTreeExtractor
 
   case class TypeBoundsTree(lo: Tree, hi: Tree)
-       extends TypTree with TypeBoundsTreeApi
+       extends TypTree with TypeBoundsTreeApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.TypeBoundsTree(this, transformer.transform(lo), transformer.transform(hi))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(lo)
+      traverser.traverse(hi)
+    }
+  }
   object TypeBoundsTree extends TypeBoundsTreeExtractor
 
   case class ExistentialTypeTree(tpt: Tree, whereClauses: List[MemberDef])
-       extends TypTree with ExistentialTypeTreeApi
+       extends TypTree with ExistentialTypeTreeApi {
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.ExistentialTypeTree(this, transformer.transform(tpt), transformer.transformMemberDefs(whereClauses))
+    override def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(tpt)
+      traverser.traverseTrees(whereClauses)
+    }
+  }
   object ExistentialTypeTree extends ExistentialTypeTreeExtractor
 
   case class TypeTree() extends TypTree with TypeTreeApi {
@@ -630,6 +947,11 @@ trait Trees extends api.Trees {
       }
       this
     }
+    override def transform(transformer: Transformer): Tree =
+      transformer.treeCopy.TypeTree(this)
+    override def traverse(traverser: Traverser): Unit =
+      ()
+
   }
   object TypeTree extends TypeTreeExtractor
 
@@ -1089,9 +1411,15 @@ trait Trees extends api.Trees {
           (new Throwable).printStackTrace
       }
     )
+    override def traverse(traverser: Traverser): Unit =
+      ()
   }
 
-  case object EmptyTree extends TermTree with CannotHaveAttrs { override def isEmpty = true; val asList = List(this) }
+  case object EmptyTree extends TermTree with CannotHaveAttrs {
+    override def isEmpty = true
+    val asList = List(this)
+    override def transform(transformer: Transformer): Tree = this
+  }
   object noSelfType extends ValDef(Modifiers(PRIVATE), nme.WILDCARD, TypeTree(NoType), EmptyTree) with CannotHaveAttrs
   object pendingSuperCall extends Apply(Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR), List()) with CannotHaveAttrs
 
@@ -1201,262 +1529,15 @@ trait Trees extends api.Trees {
 
   // --- generic traversers and transformers
 
+  @deprecated("2.12.3", "Use Tree#traverse instead")
   override protected def itraverse(traverser: Traverser, tree: Tree): Unit = {
-    import traverser._
-
-    def traverseMemberDef(md: MemberDef, owner: Symbol): Unit = atOwner(owner) {
-      traverseModifiers(md.mods)
-      traverseName(md.name)
-      md match {
-        case ClassDef(_, _, tparams, impl)             => traverseParams(tparams) ; traverse(impl)
-        case ModuleDef(_, _, impl)                     => traverse(impl)
-        case ValDef(_, _, tpt, rhs)                    => traverseTypeAscription(tpt) ; traverse(rhs)
-        case TypeDef(_, _, tparams, rhs)               => traverseParams(tparams) ; traverse(rhs)
-        case DefDef(_, _, tparams, vparamss, tpt, rhs) =>
-          traverseParams(tparams)
-          traverseParamss(vparamss)
-          traverseTypeAscription(tpt)
-          traverse(rhs)
-      }
-    }
-    def traverseComponents(): Unit = tree match {
-      case LabelDef(name, params, rhs) =>
-        traverseName(name)
-        traverseParams(params)
-        traverse(rhs)
-      case Import(expr, selectors) =>
-        traverse(expr)
-        selectors foreach traverseImportSelector
-      case Annotated(annot, arg) =>
-        traverse(annot)
-        traverse(arg)
-      case Template(parents, self, body) =>
-        traverseParents(parents)
-        traverseSelfType(self)
-        traverseStats(body, tree.symbol)
-      case Block(stats, expr) =>
-        traverseTrees(stats)
-        traverse(expr)
-      case CaseDef(pat, guard, body) =>
-        traversePattern(pat)
-        traverseGuard(guard)
-        traverse(body)
-      case Alternative(trees) =>
-        traverseTrees(trees)
-      case Star(elem) =>
-        traverse(elem)
-      case Bind(name, body) =>
-        traverseName(name)
-        traverse(body)
-      case UnApply(fun, args) =>
-        traverse(fun)
-        traverseTrees(args)
-      case ArrayValue(elemtpt, trees) =>
-        traverse(elemtpt)
-        traverseTrees(trees)
-      case Assign(lhs, rhs) =>
-        traverse(lhs)
-        traverse(rhs)
-      case AssignOrNamedArg(lhs, rhs) =>
-        traverse(lhs)
-        traverse(rhs)
-      case If(cond, thenp, elsep) =>
-        traverse(cond)
-        traverse(thenp)
-        traverse(elsep)
-      case Match(selector, cases) =>
-        traverse(selector)
-        traverseCases(cases)
-      case Return(expr) =>
-        traverse(expr)
-      case Try(block, catches, finalizer) =>
-        traverse(block)
-        traverseCases(catches)
-        traverse(finalizer)
-      case Throw(expr) =>
-        traverse(expr)
-      case New(tpt) =>
-        traverse(tpt)
-      case Typed(expr, tpt) =>
-        traverse(expr)
-        traverseTypeAscription(tpt)
-      case TypeApply(fun, args) =>
-        traverse(fun)
-        traverseTypeArgs(args)
-      case Apply(fun, args) =>
-        traverse(fun)
-        traverseTrees(args)
-      case ApplyDynamic(qual, args) =>
-        traverse(qual)
-        traverseTrees(args)
-      case Super(qual, mix) =>
-        traverse(qual)
-        traverseName(mix)
-      case This(qual) =>
-        traverseName(qual)
-      case Select(qualifier, selector) =>
-        traverse(qualifier)
-        traverseName(selector)
-      case Ident(name) =>
-        traverseName(name)
-      case ReferenceToBoxed(idt) =>
-        traverse(idt)
-      case Literal(const) =>
-        traverseConstant(const)
-      case TypeTree() =>
-        ;
-      case SingletonTypeTree(ref) =>
-        traverse(ref)
-      case SelectFromTypeTree(qualifier, selector) =>
-        traverse(qualifier)
-        traverseName(selector)
-      case CompoundTypeTree(templ) =>
-        traverse(templ)
-      case AppliedTypeTree(tpt, args) =>
-        traverse(tpt)
-        traverseTypeArgs(args)
-      case TypeBoundsTree(lo, hi) =>
-        traverse(lo)
-        traverse(hi)
-      case ExistentialTypeTree(tpt, whereClauses) =>
-        traverse(tpt)
-        traverseTrees(whereClauses)
-      case _ =>
-        xtraverse(traverser, tree)
-    }
-
-    if (tree.canHaveAttrs) {
-      tree match {
-        case PackageDef(pid, stats)  => traverse(pid) ; traverseStats(stats, mclass(tree.symbol))
-        case md: ModuleDef           => traverseMemberDef(md, mclass(tree.symbol))
-        case md: MemberDef           => traverseMemberDef(md, tree.symbol)
-        case Function(vparams, body) => atOwner(tree.symbol) { traverseParams(vparams) ; traverse(body) }
-        case _                       => traverseComponents()
-      }
-    }
+    tree.traverse(traverser)
   }
 
   //OPT ordered according to frequency to speed it up.
+  @deprecated("2.12.3", "Use Tree#transform instead")
   override protected def itransform(transformer: Transformer, tree: Tree): Tree = {
-    import transformer._
-    val treeCopy = transformer.treeCopy
-
-    // begin itransform
-    tree match {
-      case Ident(name) =>
-        treeCopy.Ident(tree, name)
-      case Select(qualifier, selector) =>
-        treeCopy.Select(tree, transform(qualifier), selector)
-      case Apply(fun, args) =>
-        treeCopy.Apply(tree, transform(fun), transformTrees(args))
-      case TypeTree() =>
-        treeCopy.TypeTree(tree)
-      case Literal(value) =>
-        treeCopy.Literal(tree, value)
-      case This(qual) =>
-        treeCopy.This(tree, qual)
-      case ValDef(mods, name, tpt, rhs) =>
-        atOwner(tree.symbol) {
-          treeCopy.ValDef(tree, transformModifiers(mods),
-                          name, transform(tpt), transform(rhs))
-        }
-      case DefDef(mods, name, tparams, vparamss, tpt, rhs) =>
-        atOwner(tree.symbol) {
-          treeCopy.DefDef(tree, transformModifiers(mods), name,
-                          transformTypeDefs(tparams), transformValDefss(vparamss),
-                          transform(tpt), transform(rhs))
-        }
-      case Block(stats, expr) =>
-        treeCopy.Block(tree, transformStats(stats, currentOwner), transform(expr))
-      case If(cond, thenp, elsep) =>
-        treeCopy.If(tree, transform(cond), transform(thenp), transform(elsep))
-      case CaseDef(pat, guard, body) =>
-        treeCopy.CaseDef(tree, transform(pat), transform(guard), transform(body))
-      case TypeApply(fun, args) =>
-        treeCopy.TypeApply(tree, transform(fun), transformTrees(args))
-      case AppliedTypeTree(tpt, args) =>
-        treeCopy.AppliedTypeTree(tree, transform(tpt), transformTrees(args))
-      case Bind(name, body) =>
-        treeCopy.Bind(tree, name, transform(body))
-      case Function(vparams, body) =>
-        atOwner(tree.symbol) {
-          treeCopy.Function(tree, transformValDefs(vparams), transform(body))
-        }
-      case Match(selector, cases) =>
-        treeCopy.Match(tree, transform(selector), transformCaseDefs(cases))
-      case New(tpt) =>
-        treeCopy.New(tree, transform(tpt))
-      case Assign(lhs, rhs) =>
-        treeCopy.Assign(tree, transform(lhs), transform(rhs))
-      case AssignOrNamedArg(lhs, rhs) =>
-        treeCopy.AssignOrNamedArg(tree, transform(lhs), transform(rhs))
-      case Try(block, catches, finalizer) =>
-        treeCopy.Try(tree, transform(block), transformCaseDefs(catches), transform(finalizer))
-      case EmptyTree =>
-        tree
-      case Throw(expr) =>
-        treeCopy.Throw(tree, transform(expr))
-      case Super(qual, mix) =>
-        treeCopy.Super(tree, transform(qual), mix)
-      case TypeBoundsTree(lo, hi) =>
-        treeCopy.TypeBoundsTree(tree, transform(lo), transform(hi))
-      case Typed(expr, tpt) =>
-        treeCopy.Typed(tree, transform(expr), transform(tpt))
-      case Import(expr, selectors) =>
-        treeCopy.Import(tree, transform(expr), selectors)
-      case Template(parents, self, body) =>
-        treeCopy.Template(tree, transformTrees(parents), transformValDef(self), transformStats(body, tree.symbol))
-      case ClassDef(mods, name, tparams, impl) =>
-        atOwner(tree.symbol) {
-          treeCopy.ClassDef(tree, transformModifiers(mods), name,
-                            transformTypeDefs(tparams), transformTemplate(impl))
-        }
-      case ModuleDef(mods, name, impl) =>
-        atOwner(mclass(tree.symbol)) {
-          treeCopy.ModuleDef(tree, transformModifiers(mods),
-                             name, transformTemplate(impl))
-        }
-      case TypeDef(mods, name, tparams, rhs) =>
-        atOwner(tree.symbol) {
-          treeCopy.TypeDef(tree, transformModifiers(mods), name,
-                           transformTypeDefs(tparams), transform(rhs))
-        }
-      case LabelDef(name, params, rhs) =>
-        treeCopy.LabelDef(tree, name, transformIdents(params), transform(rhs)) //bq: Martin, once, atOwner(...) works, also change `LambdaLifter.proxy'
-      case PackageDef(pid, stats) =>
-        treeCopy.PackageDef(
-          tree, transform(pid).asInstanceOf[RefTree],
-          atOwner(mclass(tree.symbol)) {
-            transformStats(stats, currentOwner)
-          }
-        )
-      case Annotated(annot, arg) =>
-        treeCopy.Annotated(tree, transform(annot), transform(arg))
-      case SingletonTypeTree(ref) =>
-        treeCopy.SingletonTypeTree(tree, transform(ref))
-      case SelectFromTypeTree(qualifier, selector) =>
-        treeCopy.SelectFromTypeTree(tree, transform(qualifier), selector)
-      case CompoundTypeTree(templ) =>
-        treeCopy.CompoundTypeTree(tree, transformTemplate(templ))
-      case ExistentialTypeTree(tpt, whereClauses) =>
-        treeCopy.ExistentialTypeTree(tree, transform(tpt), transformMemberDefs(whereClauses))
-      case Return(expr) =>
-        treeCopy.Return(tree, transform(expr))
-      case Alternative(trees) =>
-        treeCopy.Alternative(tree, transformTrees(trees))
-      case Star(elem) =>
-        treeCopy.Star(tree, transform(elem))
-      case UnApply(fun, args) =>
-        treeCopy.UnApply(tree, transform(fun), transformTrees(args)) // bq: see test/.../unapplyContexts2.scala
-      case ArrayValue(elemtpt, trees) =>
-        treeCopy.ArrayValue(tree, transform(elemtpt), transformTrees(trees))
-      case ApplyDynamic(qual, args) =>
-        treeCopy.ApplyDynamic(tree, transform(qual), transformTrees(args))
-      case ReferenceToBoxed(idt) =>
-        treeCopy.ReferenceToBoxed(tree, transform(idt) match { case idt1: Ident => idt1 })
-      case _ =>
-        xtransform(transformer, tree)
-    }
+    tree.transform(transformer)
   }
 
   private def mclass(sym: Symbol) = sym map (_.asModule.moduleClass)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -786,7 +786,7 @@ trait Types
 
     /** Apply `f` to each part of this type; children get mapped before their parents */
     def map(f: Type => Type): Type = new TypeMap {
-      def apply(x: Type) = f(mapOver(x))
+      def apply(x: Type) = f(x.mapOver(this))
     } apply this
 
     /** Is there part of this type which satisfies predicate `p`? */
@@ -1520,13 +1520,13 @@ trait Types
           val varToParam = new TypeMap {
             def apply(tp: Type) = varToParamMap get tp match {
               case Some(sym) => sym.tpe_*
-              case _ => mapOver(tp)
+              case _ => tp.mapOver(this)
             }
           }
           val paramToVar = new TypeMap {
             def apply(tp: Type) = tp match {
               case TypeRef(_, tsym, _) if paramToVarMap.isDefinedAt(tsym) => paramToVarMap(tsym)
-              case _ => mapOver(tp)
+              case _ => tp.mapOver(this)
             }
           }
           val bts = copyRefinedType(tpe.asInstanceOf[RefinedType], tpe.parents map varToParam, varToParam mapOver tpe.decls).baseTypeSeq
@@ -1811,7 +1811,7 @@ trait Types
             }
           case _ =>
         }
-        mapOver(tp)
+        tp.mapOver(this)
       }
       def enter(tparam0: Symbol, parent: Type) {
         this.tparam = tparam0

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1059,6 +1059,8 @@ trait Types
 
     /** The kind of this type; used for debugging */
     def kind: String = "unknown type of class "+getClass()
+
+    def mapOver(map: TypeMap): Type = this
   }
 
 // Subclasses ------------------------------------------------------------
@@ -1129,6 +1131,7 @@ trait Types
     override def safeToString: String = "<error>"
     override def narrow: Type = this
     override def kind = "ErrorType"
+    override def mapOver(map: TypeMap): Type = this
   }
 
   /** An object representing an unknown type, used during type inference.
@@ -1138,6 +1141,7 @@ trait Types
     override def isWildcard = true
     override def safeToString: String = "?"
     override def kind = "WildcardType"
+    override def mapOver(map: TypeMap): Type = this
   }
   /** BoundedWildcardTypes, used only during type inference, are created in
    *  two places that I can find:
@@ -1153,6 +1157,11 @@ trait Types
     override def isWildcard = true
     override def safeToString: String = "?" + bounds
     override def kind = "BoundedWildcardType"
+    override def mapOver(map: TypeMap): Type = {
+      val bounds1 = map(bounds)
+      if (bounds1 eq bounds) this
+      else BoundedWildcardType(bounds1.asInstanceOf[TypeBounds])
+    }
   }
 
   object BoundedWildcardType extends BoundedWildcardTypeExtractor
@@ -1162,6 +1171,7 @@ trait Types
     override def isTrivial: Boolean = true
     override def safeToString: String = "<notype>"
     override def kind = "NoType"
+    override def mapOver(map: TypeMap): Type = this
   }
 
   /** An object representing a non-existing prefix */
@@ -1170,6 +1180,7 @@ trait Types
     override def prefixString = ""
     override def safeToString: String = "<noprefix>"
     override def kind = "NoPrefixType"
+    override def mapOver(map: TypeMap): Type = this
   }
 
   /** A class for this-types of the form <sym>.this.type
@@ -1196,6 +1207,7 @@ trait Types
       else super.safeToString
     override def narrow: Type = this
     override def kind = "ThisType"
+    override def mapOver(map: TypeMap): Type = this
   }
 
   final class UniqueThisType(sym: Symbol) extends ThisType(sym) { }
@@ -1258,6 +1270,14 @@ trait Types
       else pre.prefixString + sym.nameString + "."
     )
     override def kind = "SingleType"
+    override def mapOver(map: TypeMap): Type = {
+      if (sym.isPackageClass) this // short path
+      else {
+        val pre1 = map(pre)
+        if (pre1 eq pre) this
+        else singleType(pre1, sym)
+      }
+    }
   }
 
   final class UniqueSingleType(pre: Type, sym: Symbol) extends SingleType(pre, sym)
@@ -1292,6 +1312,12 @@ trait Types
     override def prefixString = thistpe.prefixString.replaceAll("""\bthis\.$""", "super.")
     override def narrow: Type = thistpe.narrow
     override def kind = "SuperType"
+    override def mapOver(map: TypeMap): Type = {
+      val thistp1 = map(thistpe)
+      val supertp1 = map(supertpe)
+      if ((thistp1 eq thistpe) && (supertp1 eq supertpe)) this
+      else SuperType(thistp1, supertp1)
+    }
   }
 
   final class UniqueSuperType(thistp: Type, supertp: Type) extends SuperType(thistp, supertp)
@@ -1335,6 +1361,12 @@ trait Types
       else "(%s, %s)" format (typeString(lo), typeString(hi))
     }
     override def kind = "TypeBoundsType"
+    override def mapOver(map: TypeMap): Type = {
+      val lo1 = map.flipped(map(lo))
+      val hi1 = map(hi)
+      if ((lo1 eq lo) && (hi1 eq hi)) this
+      else TypeBounds(lo1, hi1)
+    }
   }
 
   final class UniqueTypeBounds(lo: Type, hi: Type) extends TypeBounds(lo, hi)
@@ -1657,6 +1689,11 @@ trait Types
     }
 
     override def kind = "RefinedType"
+    override def mapOver(map: TypeMap): Type = {
+      val parents1 = parents mapConserve map
+      val decls1 = map.mapOver(decls)
+      copyRefinedType(this, parents1, decls1)
+    }
   }
 
   final class RefinedType0(parents: List[Type], decls: Scope, clazz: Symbol) extends RefinedType(parents, decls) {
@@ -1832,6 +1869,7 @@ trait Types
     override protected def shouldForceScope = settings.debug || decls.size > 1
     override protected def scopeString      = initDecls.mkString(" {\n  ", "\n  ", "\n}")
     override def safeToString               = if (shouldForceScope) formattedToString else super.safeToString
+    override def mapOver(map: TypeMap): Type = this
   }
 
   object ClassInfoType extends ClassInfoTypeExtractor
@@ -1849,6 +1887,7 @@ trait Types
     override def safeToString: String =
       underlying.toString + "(" + value.escapedStringValue + ")"
     override def kind = "ConstantType"
+    override def mapOver(map: TypeMap): Type = this
   }
 
   final class UniqueConstantType(value: Constant) extends ConstantType(value)
@@ -2098,6 +2137,22 @@ trait Types
    * @M: a higher-kinded type is represented as a TypeRef with sym.typeParams.nonEmpty, but args.isEmpty
    */
   abstract case class TypeRef(pre: Type, sym: Symbol, args: List[Type]) extends UniqueType with TypeRefApi {
+    override def mapOver(map: TypeMap): Type = {
+      val pre1 = map(pre)
+      val args1 = (
+        if (map.trackVariance && args.nonEmpty && !map.variance.isInvariant) {
+          val tparams = sym.typeParams
+          if (tparams.isEmpty)
+            args mapConserve map
+          else
+            map.mapOverArgs(args, tparams)
+        } else {
+          args mapConserve map
+        }
+      )
+      if ((pre1 eq pre) && (args1 eq args)) this
+      else copyTypeRef(this, pre1, this.coevolveSym(pre1), args1)
+    }
     private var trivial: ThreeValue = UNKNOWN
     override def isTrivial: Boolean = {
       if (trivial == UNKNOWN)
@@ -2537,6 +2592,12 @@ trait Types
         this
 
     override def kind = "MethodType"
+    override def mapOver(map: TypeMap): Type = {
+      val params1 = map.flipped(map.mapOver(params))
+      val result1 = map(resultType)
+      if ((params1 eq params) && (result1 eq resultType)) this
+      else copyMethodType(this, params1, result1.substSym(params, params1))
+    }
   }
 
   object MethodType extends MethodTypeExtractor
@@ -2562,6 +2623,12 @@ trait Types
     override def boundSyms = resultType.boundSyms
     override def safeToString: String = "=> "+ resultType
     override def kind = "NullaryMethodType"
+    override def mapOver(map: TypeMap): Type = {
+      val result1 = map(resultType)
+      if (result1 eq resultType) this
+      else NullaryMethodType(result1)
+    }
+
   }
 
   object NullaryMethodType extends NullaryMethodTypeExtractor
@@ -2626,6 +2693,13 @@ trait Types
         this
 
     override def kind = "PolyType"
+    override def mapOver(map: TypeMap): Type = {
+      val tparams1 = map.flipped(map.mapOver(typeParams))
+      val result1 = map(resultType)
+      if ((tparams1 eq typeParams) && (result1 eq resultType)) this
+      else PolyType(tparams1, result1.substSym(typeParams, tparams1))
+    }
+
   }
 
   object PolyType extends PolyTypeExtractor
@@ -2799,6 +2873,12 @@ trait Types
         isWithinBounds(NoPrefix, NoSymbol, quantifiedFresh, tvars map (_.inst))
       }
     }
+    override def mapOver(map: TypeMap): Type = {
+      val quantified1 = map.mapOver(quantified)
+      val underlying1 = map(underlying)
+      if ((quantified1 eq quantified) && (underlying1 eq underlying)) this
+      else newExistentialType(quantified1, underlying1.substSym(quantified, quantified1))
+    }
   }
 
   object ExistentialType extends ExistentialTypeExtractor
@@ -2811,6 +2891,11 @@ trait Types
     override def safeToString =
       (alternatives map pre.memberType).mkString("", " <and> ", "")
     override def kind = "OverloadedType"
+    override def mapOver(map: TypeMap): Type = {
+      val pre1 = if (pre.isInstanceOf[ClassInfoType]) pre else map(pre)
+      if (pre1 eq pre) this
+      else OverloadedType(pre1, alternatives)
+    }
   }
 
   /** The canonical creator for OverloadedTypes.
@@ -2823,6 +2908,7 @@ trait Types
 
   case class ImportType(expr: Tree) extends Type {
     override def safeToString = "ImportType("+expr+")"
+    override def mapOver(map: TypeMap): Type = this
   }
 
   /** A class remembering a type instantiation for some a set of overloaded
@@ -2835,6 +2921,12 @@ trait Types
 
     override def memberType(sym: Symbol) = appliedType(pre.memberType(sym), targs)
     override def kind = "AntiPolyType"
+    override def mapOver(map: TypeMap): Type = {
+      val pre1 = map(pre)
+      val targs1 = targs mapConserve map
+      if ((pre1 eq pre) && (targs1 eq targs)) this
+      else AntiPolyType(pre1, targs1)
+    }
   }
 
   object HasTypeMember {
@@ -3345,6 +3437,10 @@ trait Types
         TypeVar(origin, constr.cloneInternal, typeArgs, params)
       )
     }
+    override def mapOver(map: TypeMap): Type = {
+      if (constr.instValid) map(constr.inst)
+      else this.applyArgs(map.mapOverArgs(this.typeArgs, this.params))  //@M !args.isEmpty implies !typeParams.isEmpty
+    }
   }
 
   /** A type carrying some annotations. Created by the typechecker
@@ -3415,6 +3511,13 @@ trait Types
      }
 
     override def kind = "AnnotatedType"
+    override def mapOver(map: TypeMap): Type = {
+      val annotations1 = map.mapOverAnnotations(annotations)
+      val underlying1 = map(underlying)
+      if ((annotations1 eq annotations) && (underlying1 eq underlying)) this
+      else if (annotations1.isEmpty) underlying1
+      else AnnotatedType(annotations1, underlying1)
+    }
   }
 
   /** Creator for AnnotatedTypes.  It returns the underlying type if annotations.isEmpty
@@ -3439,6 +3542,7 @@ trait Types
    */
   case class NamedType(name: Name, tp: Type) extends Type {
     override def safeToString: String = name.toString +": "+ tp
+    override def mapOver(map: TypeMap): Type = throw new UnsupportedOperationException
   }
   /** As with NamedType, used only when calling isApplicable.
    *  Records that the application has a wildcard star (aka _*)
@@ -3446,6 +3550,7 @@ trait Types
    */
   case class RepeatedType(tp: Type) extends Type {
     override def safeToString: String = tp + ": _*"
+    override def mapOver(map: TypeMap): Type = throw new UnsupportedOperationException
   }
 
   /** A temporary type representing the erasure of a user-defined value type.
@@ -3462,6 +3567,7 @@ trait Types
    */
   abstract case class ErasedValueType(valueClazz: Symbol, erasedUnderlying: Type) extends UniqueType {
     override def safeToString = s"ErasedValueType($valueClazz, $erasedUnderlying)"
+    override def mapOver(map: TypeMap): Type = this
   }
 
   final class UniqueErasedValueType(valueClazz: Symbol, erasedUnderlying: Type) extends ErasedValueType(valueClazz, erasedUnderlying)
@@ -3480,6 +3586,7 @@ trait Types
     override def complete(sym: Symbol)
     override def safeToString = "<?>"
     override def kind = "LazyType"
+    override def mapOver(map: TypeMap): Type = this
   }
 
   /** A marker trait representing an as-yet unevaluated type

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -125,11 +125,11 @@ trait Variances {
           case _ if isUncheckedVariance(tp)                    =>
           case _ if resultTypeOnly(tp)                         => this(tp.resultType)
           case TypeRef(_, sym, _) if shouldDealias(sym)        => this(tp.normalize)
-          case TypeRef(_, sym, _) if !sym.variance.isInvariant => checkVarianceOfSymbol(sym) ; mapOver(tp)
-          case RefinedType(_, _)                               => withinRefinement(mapOver(tp))
+          case TypeRef(_, sym, _) if !sym.variance.isInvariant => checkVarianceOfSymbol(sym) ; tp.mapOver(this)
+          case RefinedType(_, _)                               => withinRefinement(tp.mapOver(this))
           case ClassInfoType(parents, _, _)                    => parents foreach this
           case mt @ MethodType(_, result)                      => flipped(mt.paramTypes foreach this) ; this(result)
-          case _                                               => mapOver(tp)
+          case _                                               => tp.mapOver(this)
         }
         // We're using TypeMap here for type traversal only. To avoid wasteful symbol
         // cloning during the recursion, it is important to return the input `tp`, rather

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -19,7 +19,7 @@ trait Variances {
   /** Used in Refchecks.
    *  TODO - eliminate duplication with varianceInType
    */
-  class VarianceValidator extends Traverser {
+  class VarianceValidator extends InternalTraverser {
     private val escapedLocals = mutable.HashSet[Symbol]()
     // A flag for when we're in a refinement, meaning method parameter types
     // need to be checked.
@@ -170,10 +170,10 @@ trait Variances {
           debuglog(s"Skipping variance check of ${sym.defString}")
         case ClassDef(_, _, _, _) | TypeDef(_, _, _, _) =>
           validateVariance(sym)
-          super.traverse(tree)
+          tree.traverse(this)
         case ModuleDef(_, _, _) =>
           validateVariance(sym.moduleClass)
-          super.traverse(tree)
+          tree.traverse(this)
         case ValDef(_, _, _, _) =>
           validateVariance(sym)
         case DefDef(_, _, tparams, vparamss, _, _) =>
@@ -181,16 +181,16 @@ trait Variances {
           traverseTrees(tparams)
           traverseTreess(vparamss)
         case Template(_, _, _) =>
-          super.traverse(tree)
+          tree.traverse(this)
         case CompoundTypeTree(templ) =>
-          super.traverse(tree)
+          tree.traverse(this)
 
         // scala/bug#7872 These two cases make sure we don't miss variance exploits
         // in originals, e.g. in `foo[({type l[+a] = List[a]})#l]`
         case tt @ TypeTree() if tt.original != null =>
-          super.traverse(tt.original)
+          tt.original.traverse(this)
         case tt : TypTree =>
-          super.traverse(tt)
+          tt.traverse(this)
 
         case _ =>
       }

--- a/src/reflect/scala/reflect/internal/tpe/CommonOwners.scala
+++ b/src/reflect/scala/reflect/internal/tpe/CommonOwners.scala
@@ -43,7 +43,7 @@ private[internal] trait CommonOwners {
       case ThisType(sym)                => register(sym)
       case TypeRef(NoPrefix, sym, args) => register(sym.owner) ; args foreach traverse
       case SingleType(NoPrefix, sym)    => register(sym.owner)
-      case _                            => mapOver(tp)
+      case _                            => tp.mapOver(this)
     }
   }
 

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -17,11 +17,11 @@ private[internal] trait TypeMaps {
     *  so it is no longer carries the too-stealthy name "deAlias".
     */
   object normalizeAliases extends TypeMap {
-    def apply(tp: Type): Type = mapOver(tp match {
+    def apply(tp: Type): Type = (tp match {
       case TypeRef(_, sym, _) if sym.isAliasType && tp.isHigherKinded => logResult(s"Normalized type alias function $tp")(tp.normalize)
       case TypeRef(_, sym, _) if sym.isAliasType                      => tp.normalize
       case tp                                                         => tp
-    })
+    }).mapOver(this)
   }
 
   /** Remove any occurrence of type <singleton> from this type and its parents */
@@ -33,11 +33,11 @@ private[internal] trait TypeMaps {
         case tp1 @ RefinedType(parents, decls) =>
           parents filter (_.typeSymbol != SingletonClass) match {
             case Nil                       => AnyTpe
-            case p :: Nil if decls.isEmpty => mapOver(p)
-            case ps                        => mapOver(copyRefinedType(tp1, ps, decls))
+            case p :: Nil if decls.isEmpty => p.mapOver(this)
+            case ps                        => copyRefinedType(tp1, ps, decls).mapOver(this)
           }
         case tp1 =>
-          mapOver(tp1)
+          tp1.mapOver(this)
       }
     }
   }
@@ -48,7 +48,7 @@ private[internal] trait TypeMaps {
       case TypeRef(_, sym, _) if sym.isAliasType    => apply(tp.dealias)
       case TypeRef(_, sym, _) if sym.isAbstractType => apply(tp.bounds.hi)
       case rtp @ RefinedType(parents, decls)        => copyRefinedType(rtp, parents mapConserve this, decls)
-      case AnnotatedType(_, _)                      => mapOver(tp)
+      case AnnotatedType(_, _)                      => tp.mapOver(this)
       case _                                        => tp             // no recursion - top level only
     }
   }
@@ -66,7 +66,7 @@ private[internal] trait TypeMaps {
       case TypeRef(_, RepeatedParamClass, arg :: Nil) =>
         seqType(arg)
       case _ =>
-        mapOver(tp)
+        tp.mapOver(this)
     }
   }
 
@@ -154,7 +154,7 @@ private[internal] trait TypeMaps {
 
     def mapOver(annot: AnnotationInfo): AnnotationInfo = {
       val AnnotationInfo(atp, args, assocs) = annot
-      val atp1  = mapOver(atp)
+      val atp1  = atp.mapOver(this)
       val args1 = mapOverAnnotArgs(args)
       // there is no need to rewrite assocs, as they are constants
 
@@ -242,7 +242,7 @@ private[internal] trait TypeMaps {
           expanded -= sym
         }
       case _ =>
-        mapOver(tp)
+        tp.mapOver(this)
     }
   }
   /***
@@ -316,7 +316,7 @@ private[internal] trait TypeMaps {
           if ((pre1 eq pre) || !pre1.isStable) tp
           else singleType(pre1, sym)
         }
-      case _ => super.mapOver(tp)
+      case _ => tp.mapOver(this)
     }
 
     // Do not discard the types of existential idents. The
@@ -341,7 +341,7 @@ private[internal] trait TypeMaps {
       tp match {
         case BoundedWildcardType(TypeBounds(lo, AnyTpe)) if variance.isContravariant => lo
         case BoundedWildcardType(TypeBounds(NothingTpe, hi)) if variance.isCovariant => hi
-        case tp => mapOver(tp)
+        case tp => tp.mapOver(this)
       }
   }
 
@@ -391,7 +391,7 @@ private[internal] trait TypeMaps {
       case tp @ ThisType(_)                                            => thisTypeAsSeen(tp)
       case tp @ SingleType(_, sym)                                     => if (sym.isPackageClass) tp else singleTypeAsSeen(tp)
       case tp @ TypeRef(_, sym, _) if isTypeParamOfEnclosingClass(sym) => classParameterAsSeen(tp)
-      case _                                                           => mapOver(tp)
+      case _                                                           => tp.mapOver(this)
     }
 
     private var _capturedSkolems: List[Symbol] = Nil
@@ -505,7 +505,7 @@ private[internal] trait TypeMaps {
         def nextBase = (pre baseType clazz).deconst
         //@M! see test pos/tcpoly_return_overriding.scala why mapOver is necessary
         if (skipPrefixOf(pre, clazz))
-          mapOver(classParam)
+          classParam.mapOver(this)
         else if (!matchesPrefixAndClass(pre, clazz)(tparam.owner))
           loop(nextBase.prefix, clazz.owner)
         else nextBase match {
@@ -585,7 +585,7 @@ private[internal] trait TypeMaps {
           case _                     => pre
         }
         if (skipPrefixOf(pre, clazz))
-          mapOver(tp) // TODO - is mapOver necessary here?
+          tp.mapOver(this) // TODO - is mapOver necessary here?
         else if (!matchesPrefixAndClass(pre, clazz)(tp.sym))
           loop((pre baseType clazz).prefix, clazz.owner)
         else if (pre1.isStable)
@@ -640,7 +640,7 @@ private[internal] trait TypeMaps {
     def apply(tp0: Type): Type = if (from.isEmpty) tp0 else {
       val boundSyms             = tp0.boundSyms
       val tp1                   = if (boundSyms.nonEmpty && (boundSyms exists from.contains)) renameBoundSyms(tp0) else tp0
-      val tp                    = mapOver(tp1)
+      val tp                    = tp1.mapOver(this)
       def substFor(sym: Symbol) = subst(tp, sym, from, to)
 
       tp match {
@@ -695,11 +695,11 @@ private[internal] trait TypeMaps {
         case TypeRef(pre, sym, args) if pre ne NoPrefix =>
           val newSym = substFor(sym)
           // mapOver takes care of subst'ing in args
-          mapOver ( if (sym eq newSym) tp else copyTypeRef(tp, pre, newSym, args) )
+          ( if (sym eq newSym) tp else copyTypeRef(tp, pre, newSym, args) ).mapOver(this)
         // assert(newSym.typeParams.length == sym.typeParams.length, "typars mismatch in SubstSymMap: "+(sym, sym.typeParams, newSym, newSym.typeParams))
         case SingleType(pre, sym) if pre ne NoPrefix =>
           val newSym = substFor(sym)
-          mapOver( if (sym eq newSym) tp else singleType(pre, newSym) )
+          ( if (sym eq newSym) tp else singleType(pre, newSym) ).mapOver(this)
         case _ =>
           super.apply(tp)
       }
@@ -768,7 +768,7 @@ private[internal] trait TypeMaps {
   class SubstThisMap(from: Symbol, to: Type) extends TypeMap {
     def apply(tp: Type): Type = tp match {
       case ThisType(sym) if (sym == from) => to
-      case _ => mapOver(tp)
+      case _ => tp.mapOver(this)
     }
   }
 
@@ -778,7 +778,7 @@ private[internal] trait TypeMaps {
         case TypeRef(_, sym, _) if from contains sym =>
           BoundedWildcardType(sym.info.bounds)
         case _ =>
-          mapOver(tp)
+          tp.mapOver(this)
       }
     } catch {
       case ex: MalformedType =>
@@ -790,14 +790,14 @@ private[internal] trait TypeMaps {
   object IsDependentCollector extends TypeCollector(false) {
     def traverse(tp: Type) {
       if (tp.isImmediatelyDependent) result = true
-      else if (!result) mapOver(tp.dealias)
+      else if (!result) tp.dealias.mapOver(this)
     }
   }
 
   object ApproximateDependentMap extends TypeMap {
     def apply(tp: Type): Type =
       if (tp.isImmediatelyDependent) WildcardType
-      else mapOver(tp)
+      else tp.mapOver(this)
   }
 
   /** Note: This map is needed even for non-dependent method types, despite what the name might imply.
@@ -866,7 +866,7 @@ private[internal] trait TypeMaps {
      */
     def apply(tp: Type): Type = tp match {
       case SingleType(NoPrefix, StabilizedArgTp(tp)) => tp
-      case _                                         => mapOver(tp)
+      case _                                         => tp.mapOver(this)
     }
 
     //AM propagate more info to annotations -- this seems a bit ad-hoc... (based on code by spoon)
@@ -909,7 +909,7 @@ private[internal] trait TypeMaps {
       case BoundedWildcardType(bounds) =>
         TypeVar(tp, new TypeConstraint(bounds))
       case _ =>
-        mapOver(tp)
+        tp.mapOver(this)
     }
   }
 
@@ -917,7 +917,7 @@ private[internal] trait TypeMaps {
   object typeVarToOriginMap extends TypeMap {
     def apply(tp: Type): Type = tp match {
       case TypeVar(origin, _) => origin
-      case _ => mapOver(tp)
+      case _ => tp.mapOver(this)
     }
   }
 
@@ -932,15 +932,15 @@ private[internal] trait TypeMaps {
             //
             // We can just map over the components and wait until we see the underlying type before we call
             // normalize.
-            mapOver(tp)
+            tp.mapOver(this)
           case _ =>
             tp.normalize match {
               case TypeRef(_, sym1, _) if (sym == sym1) => result = true
               case refined: RefinedType =>
-                mapOver(tp.prefix)
-                mapOver(refined)
+                tp.prefix.mapOver(this)
+                refined.mapOver(this)
               case SingleType(_, sym1) if (sym == sym1) => result = true
-              case _ => mapOver(tp)
+              case _ => tp.mapOver(this)
             }
         }
       }
@@ -962,7 +962,7 @@ private[internal] trait TypeMaps {
 
     def traverse(tp: Type) {
       if (p(tp)) result ::= tp
-      mapOver(tp)
+      tp.mapOver(this)
     }
   }
 
@@ -972,14 +972,14 @@ private[internal] trait TypeMaps {
 
     def traverse(tp: Type) {
       if (pf.isDefinedAt(tp)) result ::= pf(tp)
-      mapOver(tp)
+      tp.mapOver(this)
     }
   }
 
   class ForEachTypeTraverser(f: Type => Unit) extends TypeTraverser {
     def traverse(tp: Type) {
       f(tp)
-      mapOver(tp)
+      tp.mapOver(this)
     }
   }
 
@@ -988,7 +988,7 @@ private[internal] trait TypeMaps {
     def traverse(tp: Type) {
       if (result.isEmpty) {
         if (p(tp)) result = Some(tp)
-        mapOver(tp)
+        tp.mapOver(this)
       }
     }
   }
@@ -998,7 +998,7 @@ private[internal] trait TypeMaps {
     def traverse(tp: Type) {
       if (!result) {
         result = tp.isError
-        mapOver(tp)
+        tp.mapOver(this)
       }
     }
   }
@@ -1117,11 +1117,11 @@ private[internal] trait TypeMaps {
         val parents1 = parents mapConserve (this)
         if (parents1 eq parents) tp
         else refinedType(parents1, tp.typeSymbol.owner, decls, tp.typeSymbol.owner.pos)
-      case SuperType(_, _) => mapOver(tp)
-      case TypeBounds(_, _) => mapOver(tp)
-      case TypeVar(_, _) => mapOver(tp)
-      case AnnotatedType(_, _) => mapOver(tp)
-      case ExistentialType(_, _) => mapOver(tp)
+      case SuperType(_, _) => tp.mapOver(this)
+      case TypeBounds(_, _) => tp.mapOver(this)
+      case TypeVar(_, _) => tp.mapOver(this)
+      case AnnotatedType(_, _) => tp.mapOver(this)
+      case ExistentialType(_, _) => tp.mapOver(this)
       case _ => tp
     }
   }

--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -167,7 +167,7 @@ trait Erasure {
       case _: BoundedWildcardType => tp // skip
 
       case _ =>
-        mapOver(tp)
+        tp.mapOver(this)
     }
 
     def applyInArray(tp: Type): Type = tp match {

--- a/src/reflect/scala/reflect/internal/transform/PostErasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/PostErasure.scala
@@ -10,7 +10,8 @@ trait PostErasure {
     def apply(tp: Type) = tp match {
       case ConstantType(Constant(tp: Type)) => ConstantType(Constant(apply(tp)))
       case ErasedValueType(_, underlying)   => underlying
-      case _                                => mapOver(tp)
+      case null                             => null
+      case _                                => tp.mapOver(this)
     }
   }
 

--- a/src/reflect/scala/reflect/internal/transform/UnCurry.scala
+++ b/src/reflect/scala/reflect/internal/transform/UnCurry.scala
@@ -50,7 +50,7 @@ trait UnCurry {
         case DesugaredParameterType(desugaredTpe) =>
           apply(desugaredTpe)
         case _ =>
-          expandAlias(mapOver(tp))
+          expandAlias(tp.mapOver(this))
       }
     }
   }
@@ -94,7 +94,7 @@ trait UnCurry {
           } // @MAT normalize in decls??
 
         case PolyType(_, _) =>
-          mapOver(tp)
+          tp.mapOver(this)
 
         case _ =>
           tp


### PR DESCRIPTION
Pushing the WIP branch here for the record.

The performance gains of ~2% need further attribution to individual commits
and analysis of the underlying reasons.

```
2.12.3-bin-2f52c61-SNAPSHOT

[info] 
[info] Benchmark                                   (extraArgs)  (source)    Mode  Cnt     Score   Error  Units
[info] HotScalacBenchmark.compile                                         sample  365  1146.958 ± 6.225  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00                           sample       1088.422          ms/op
[info] HotScalacBenchmark.compile:compile·p0.50                           sample       1147.142          ms/op
[info] HotScalacBenchmark.compile:compile·p0.90                           sample       1172.308          ms/op
[info] HotScalacBenchmark.compile:compile·p0.95                           sample       1234.174          ms/op
[info] HotScalacBenchmark.compile:compile·p0.99                           sample       1289.077          ms/op
[info] HotScalacBenchmark.compile:compile·p0.999                          sample       1317.011          ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999                         sample       1317.011          ms/op
[info] HotScalacBenchmark.compile:compile·p1.00                           sample       1317.011          ms/op
[success] Total time: 869 s, completed 15/05/2017 5:41:30 PM

2518bc6e2c Spread Tree transform/traverse into virtual methods of Tree
2.12.3-bin-c26c401-SNAPSHOT: Spread mapOver into invokevirtual of Type.mapOver

[info] 
[info] Benchmark                                   (extraArgs)  (source)    Mode  Cnt     Score   Error  Units
[info] HotScalacBenchmark.compile                                         sample  361  1138.783 ± 4.662  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00                           sample       1086.325          ms/op
[info] HotScalacBenchmark.compile:compile·p0.50                           sample       1136.656          ms/op
[info] HotScalacBenchmark.compile:compile·p0.90                           sample       1165.597          ms/op
[info] HotScalacBenchmark.compile:compile·p0.95                           sample       1184.471          ms/op
[info] HotScalacBenchmark.compile:compile·p0.99                           sample       1255.187          ms/op
[info] HotScalacBenchmark.compile:compile·p0.999                          sample       1272.971          ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999                         sample       1272.971          ms/op
[info] HotScalacBenchmark.compile:compile·p1.00                           sample       1272.971          ms/op
[success] Total time: 858 s, completed 15/05/2017 5:55:53 PM

4755750513 Favour direct use of Type.mapOver
372d1526f3 Revert "SI-3832 Extract tracking of under-construction classes to a mixin"
2.12.3-bin-14fe4f1-SNAPSHOT: Avoid indirection through bridges

[info] # Run complete. Total time: 00:13:52
[info] 
[info] Benchmark                                   (extraArgs)  (source)    Mode  Cnt     Score   Error  Units
[info] HotScalacBenchmark.compile                                         sample  362  1125.296 ± 4.625  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00                           sample       1090.519          ms/op
[info] HotScalacBenchmark.compile:compile·p0.50                           sample       1119.879          ms/op
[info] HotScalacBenchmark.compile:compile·p0.90                           sample       1138.754          ms/op
[info] HotScalacBenchmark.compile:compile·p0.95                           sample       1155.531          ms/op
[info] HotScalacBenchmark.compile:compile·p0.99                           sample       1258.522          ms/op
[info] HotScalacBenchmark.compile:compile·p0.999                          sample       1277.166          ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999                         sample       1277.166          ms/op
[info] HotScalacBenchmark.compile:compile·p1.00                           sample       1277.166          ms/op
    
```