### PR TITLE
Add a debugging option to print compiler arguments in a format suitab…

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilerCommand.scala
+++ b/src/compiler/scala/tools/nsc/CompilerCommand.scala
@@ -102,6 +102,11 @@ class CompilerCommand(arguments: List[String], val settings: Settings) {
     else if (genPhaseGraph.isSetByUser) {
       val components = global.phaseNames  // global.phaseDescriptors // one initializes
       s"Phase graph of ${components.size} components output to ${genPhaseGraph.value}*.dot."
+    } else if (printArgs.value) {
+      s"""
+         |${recreateArgs.mkString("\n")}
+         |${files.mkString("\n")}
+        """.stripMargin
     }
     else allSettings.filter(_.isHelping).map(_.help).mkString("\n\n")
   }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -36,7 +36,7 @@ trait ScalaSettings extends AbsScalaSettings
   protected def futureSettings = List[BooleanSetting]()
 
   /** If any of these settings is enabled, the compiler should print a message and exit.  */
-  def infoSettings = List[Setting](version, help, Xhelp, Yhelp, showPlugins, showPhases, genPhaseGraph)
+  def infoSettings = List[Setting](version, help, Xhelp, Yhelp, showPlugins, showPhases, genPhaseGraph, printArgs)
 
   /** Is an info setting set? Any -option:help? */
   def isInfo = infoSettings.exists(_.isSetByUser) || allSettings.exists(_.isHelping)
@@ -121,6 +121,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Xprint             = PhasesSetting       ("-Xprint", "Print out program after")
   val Xprintpos          = BooleanSetting      ("-Xprint-pos", "Print tree positions, as offsets.")
   val printtypes         = BooleanSetting      ("-Xprint-types", "Print tree types (debugging option).")
+  val printArgs          = BooleanSetting      ("-Xprint-args", "Print all compiler arguments and exit.")
   val prompt             = BooleanSetting      ("-Xprompt", "Display a prompt after each error (debugging option).")
   val resident           = BooleanSetting      ("-Xresident", "Compiler stays resident: read source filenames from standard input.")
   val script             = StringSetting       ("-Xscript", "object", "Treat the source file as a script and wrap it in a main method.", "")


### PR DESCRIPTION
…le for @file.

The option behaves like -Xshow-phases and stops the compiler after printing. This is consistent and makes it work out of the box when Sbt calls into the compiler (and probably all other Zinc based tools), even though the ticket suggested that compilation continues.

Fix scala/bug#10302.