### PR TITLE
Optimize isRawIfWithoutArgs: check flags before forcing type params

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3881,7 +3881,7 @@ trait Types
   def typeParamsToExistentials(clazz: Symbol): List[Symbol] =
     typeParamsToExistentials(clazz, clazz.typeParams)
 
-  def isRawIfWithoutArgs(sym: Symbol) = sym.isClass && sym.typeParams.nonEmpty && sym.isJavaDefined
+  def isRawIfWithoutArgs(sym: Symbol) = sym.isClass && sym.isJavaDefined && sym.typeParams.nonEmpty
   /** Is type tp a ''raw type''? */
   //  note: it's important to write the two tests in this order,
   //  as only typeParams forces the classfile to be read. See #400


### PR DESCRIPTION
Even when symbol's info is complete, the fast path through
`Symbol#typeParams` is still a bit slower than testing for the
JAVA flag.

Benchmarked with:

```
sbt "set scalaVersion in compilation := \"$sha\"" "hot -psource= -jvmArgs -XX:MaxInlineLevel=18 -f5
```

Comparing baseline of #5907 with this commit rebased on top it.

Before:
```
[info] Benchmark                                   (extraArgs)  (source)    Mode  Cnt     Score   Error  Units
[info] HotScalacBenchmark.compile                                         sample  501  1029.743 ± 3.180  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00                           sample        970.981          ms/op
[info] HotScalacBenchmark.compile:compile·p0.50                           sample       1028.653          ms/op
[info] HotScalacBenchmark.compile:compile·p0.90                           sample       1057.803          ms/op
[info] HotScalacBenchmark.compile:compile·p0.95                           sample       1070.596          ms/op
[info] HotScalacBenchmark.compile:compile·p0.99                           sample       1088.422          ms/op
[info] HotScalacBenchmark.compile:compile·p0.999                          sample       1111.491          ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999                         sample       1111.491          ms/op
[info] HotScalacBenchmark.compile:compile·p1.00                           sample       1111.491          ms/op
```

After:

```
[info] Benchmark                                   (extraArgs)  (source)    Mode  Cnt     Score   Error  Units
[info] HotScalacBenchmark.compile                                         sample  504  1021.960 ± 3.805  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00                           sample        969.933          ms/op
[info] HotScalacBenchmark.compile:compile·p0.50                           sample       1020.264          ms/op
[info] HotScalacBenchmark.compile:compile·p0.90                           sample       1047.527          ms/op
[info] HotScalacBenchmark.compile:compile·p0.95                           sample       1059.062          ms/op
[info] HotScalacBenchmark.compile:compile·p0.99                           sample       1108.345          ms/op
[info] HotScalacBenchmark.compile:compile·p0.999                          sample       1327.497          ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999                         sample       1327.497          ms/op
[info] HotScalacBenchmark.compile:compile·p1.00                           sample       1327.497          ms/op
```