### PR TITLE
Avoid generic array instantation in hot paths

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -501,7 +501,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
       currentRun.symData get sym match {
         case Some(pickle) if !nme.isModuleName(newTermName(jclassName)) =>
           val scalaAnnot = {
-            val sigBytes = ScalaSigBytes(pickle.bytes.take(pickle.writeIndex))
+            val sigBytes = ScalaSigBytes(java.util.Arrays.copyOf(pickle.bytes, pickle.writeIndex))
             AnnotationInfo(sigBytes.sigAnnot, Nil, (nme.bytes, sigBytes) :: Nil)
           }
           pickledBytes += pickle.writeIndex

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -132,9 +132,14 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
       val flags = javaFlags(claszSymbol)
 
       val thisSignature = getGenericSignature(claszSymbol, claszSymbol.owner)
+      val interfaceNamesArray = if (interfaceNames.isEmpty) EMPTY_STRING_ARRAY else {
+        val result = new Array[String](interfaceNames.length)
+        interfaceNames.copyToArray(result)
+        result
+      }
       cnode.visit(classfileVersion, flags,
                   thisBType.internalName, thisSignature,
-                  superClass, interfaceNames.toArray)
+                  superClass, interfaceNamesArray)
 
       if (emitSource) {
         cnode.visitSource(cunit.source.toString, null /* SourceDebugExtension */)

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -531,7 +531,7 @@ abstract class Pickler extends SubComponent {
       writeNat(MinorVersion)
       writeNat(ep)
 
-      entries take ep foreach writeEntry
+      entries.iterator.take(ep).foreach(writeEntry)
     }
 
     override def toString = "" + rootName + " in " + rootOwner

--- a/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
+++ b/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
@@ -46,7 +46,7 @@ trait TypeAdaptingTransformer { self: TreeDSL =>
           case _ => tree.tpe.typeSymbol match {
             case UnitClass =>
               if (treeInfo isExprSafeToInline tree) REF(BoxedUnit_UNIT)
-              else BLOCK(tree, REF(BoxedUnit_UNIT))
+              else Block(tree :: Nil, REF(BoxedUnit_UNIT))
             case NothingClass => tree // a non-terminating expression doesn't need boxing
             case x =>
               assert(x != ArrayClass)

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -534,8 +534,8 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
           val scrutToInt: Tree =
             if (scrutSym.tpe =:= IntTpe) REF(scrutSym)
             else (REF(scrutSym) DOT (nme.toInt))
-          Some(BLOCK(
-            ValDef(scrutSym, scrut),
+          Some(Block(
+            ValDef(scrutSym, scrut) :: Nil,
             Match(scrutToInt, caseDefsWithDefault) // a switch
           ))
         }

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2743,7 +2743,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def defStringSeenAs(info: Type) = defStringCompose(infoString(info))
 
     /** Concatenate strings separated by spaces */
-    private def compose(ss: String*) = ss filter (_ != "") mkString " "
+    private def compose(ss: String*) = ss.iterator filter (_ != "") mkString " "
 
     def isSingletonExistential =
       nme.isSingletonName(name) && (info.bounds.hi.typeSymbol isSubClass SingletonClass)


### PR DESCRIPTION
Before:

```
[info] 
[info] Benchmark                                   (extraArgs)  (source)    Mode  Cnt     Score   Error  Units
[info] HotScalacBenchmark.compile                                         sample  500  1049.371 ± 3.062  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00                           sample       1000.342          ms/op
[info] HotScalacBenchmark.compile:compile·p0.50                           sample       1047.527          ms/op
[info] HotScalacBenchmark.compile:compile·p0.90                           sample       1075.839          ms/op
[info] HotScalacBenchmark.compile:compile·p0.95                           sample       1082.130          ms/op
[info] HotScalacBenchmark.compile:compile·p0.99                           sample       1113.462          ms/op
[info] HotScalacBenchmark.compile:compile·p0.999                          sample       1176.502          ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999                         sample       1176.502          ms/op
[info] HotScalacBenchmark.compile:compile·p1.00                           sample       1176.502          ms/op
```

After:

```
[info] Benchmark                                   (extraArgs)  (source)    Mode  Cnt     Score   Error  Units
[info] HotScalacBenchmark.compile                                         sample  500  1045.162 ± 2.888  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00                           sample        984.613          ms/op
[info] HotScalacBenchmark.compile:compile·p0.50                           sample       1046.479          ms/op
[info] HotScalacBenchmark.compile:compile·p0.90                           sample       1068.499          ms/op
[info] HotScalacBenchmark.compile:compile·p0.95                           sample       1075.839          ms/op
[info] HotScalacBenchmark.compile:compile·p0.99                           sample       1090.498          ms/op
[info] HotScalacBenchmark.compile:compile·p0.999                          sample       1117.782          ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999                         sample       1117.782          ms/op
[info] HotScalacBenchmark.compile:compile·p1.00                           sample       1117.782          ms/op
```