### PR TITLE
Fixes scala/bug#10328:PipedSource should join Source thread to wait for the exit value

### DIFF
--- a/src/library/scala/sys/process/ProcessImpl.scala
+++ b/src/library/scala/sys/process/ProcessImpl.scala
@@ -147,6 +147,7 @@ private[process] trait ProcessImpl {
           throw err
         }
       runInterruptible {
+        source.join()
         val exit1 = first.exitValue()
         val exit2 = second.exitValue()
         // Since file redirection (e.g. #>) is implemented as a piped process,


### PR DESCRIPTION
Try to fix https://github.com/scala/bug/issues/10328, this issue is caused by when try to wait `first.exitValue` and `second.exitValue`, we are hoping the `source: PipeSource` `thread` has finished running(finished transferring). 

Fix: when get the `exitValue`, we should block and wait the `source` `thread` finish running by `source.join()`.