### PR TITLE
Underscore is lower case

### DIFF
--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -35,8 +35,7 @@ classes (Unicode general category given in parentheses):
 1. Whitespace characters. `\u0020 | \u0009 | \u000D | \u000A`.
 1. Letters, which include lower case letters (`Ll`), upper case letters (`Lu`),
    titlecase letters (`Lt`), other letters (`Lo`), letter numerals (`Nl`) and the
-   two characters `\u0024 ‘$’` and `\u005F ‘_’`, which both count as upper case
-   letters.
+   two characters `\u0024 ‘$’` and `\u005F ‘_’`.
 1. Digits `‘0’ | … | ‘9’`.
 1. Parentheses `‘(’ | ‘)’ | ‘[’ | ‘]’ | ‘{’ | ‘}’ `.
 1. Delimiter characters ``‘`’ | ‘'’ | ‘"’ | ‘.’ | ‘;’ | ‘,’ ``.
@@ -78,9 +77,13 @@ big_bob++=`def`
 ```
 
 decomposes into the three identifiers `big_bob`, `++=`, and
-`def`. The rules for pattern matching further distinguish between
+`def`.
+
+The rules for pattern matching further distinguish between
 _variable identifiers_, which start with a lower case letter, and
-_constant identifiers_, which do not.
+_constant identifiers_, which do not. For this purpose,
+underscore `‘_‘` is taken as lower case, and the ‘\$’ character
+is taken as upper case.
 
 The ‘\$’ character is reserved for compiler-synthesized identifiers.
 User programs should not define identifiers which contain ‘\$’ characters.


### PR DESCRIPTION
For purposes of varid:

scala> val i = 42
i: Int = 42

scala> val _x = 43
_x: Int = 43

scala> val $x = 43
$x: Int = 43

scala> i match { case _x => _x }
res0: Int = 42

scala> i match { case $x => $x }
scala.MatchError: 42 (of class java.lang.Integer)
  ... 29 elided