### PR TITLE
Improve the scaladoc -d param description

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/AbsScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/AbsScalaSettings.scala
@@ -35,7 +35,7 @@ trait AbsScalaSettings {
   def IntSetting(name: String, descr: String, default: Int, range: Option[(Int, Int)], parser: String => Option[Int]): IntSetting
   def MultiStringSetting(name: String, helpArg: String, descr: String, helpText: Option[String] = None): MultiStringSetting
   def MultiChoiceSetting[E <: MultiChoiceEnumeration](name: String, helpArg: String, descr: String, domain: E, default: Option[List[String]]): MultiChoiceSetting[E]
-  def OutputSetting(outputDirs: OutputDirs, default: String): OutputSetting
+  def OutputSetting(outputDirs: OutputDirs, default: String, descr: String): OutputSetting
   def PathSetting(name: String, descr: String, default: String): PathSetting
   def PhasesSetting(name: String, descr: String, default: String): PhasesSetting
   def StringSetting(name: String, helpArg: String, descr: String, default: String, helpText: Option[String] = None): StringSetting

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -55,7 +55,7 @@ trait ScalaSettings extends AbsScalaSettings
   // argfiles is only for the help message
   /*val argfiles = */ BooleanSetting    ("@<file>", "A text file containing compiler arguments (options and source files)")
   val classpath     = PathSetting       ("-classpath", "Specify where to find user class files.", defaultClasspath) withAbbreviation "-cp"
-  val d             = OutputSetting     (outputDirs, ".")
+  val d             = OutputSetting     (outputDirs, ".", "Destination for generated classfiles.")
   val nospecialization = BooleanSetting ("-no-specialization", "Ignore @specialize annotations.")
 
   // Would be nice to build this dynamically from scala.languageFeature.

--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -17,6 +17,8 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
   // TODO 2.13 Remove
   private def removalIn213 = "This flag is scheduled for removal in 2.13. If you have a case where you need this flag then please report a bug."
 
+  override val d = OutputSetting(outputDirs, ".", "Destination for generated scaladoc files.")
+
   /** A setting that defines in which format the documentation is output. ''Note:'' this setting is currently always
     * `html`. */
   val docformat = ChoiceSetting (
@@ -345,4 +347,5 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
       true
     }
   }
+
 }

--- a/test/files/run/settings-parse.check
+++ b/test/files/run/settings-parse.check
@@ -1,566 +1,566 @@
 0) List(-cp, ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 1) List(-cp, , ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 2) List(, -cp, ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 3) List(-cp, , -deprecation) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 4) List(-cp, , , -deprecation) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 5) List(-cp, , -deprecation, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 6) List(, -cp, , -deprecation) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 7) List(-cp, , -deprecation, foo.scala) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 8) List(-cp, , , -deprecation, foo.scala) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 9) List(-cp, , -deprecation, , foo.scala) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 10) List(-cp, , -deprecation, foo.scala, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 11) List(, -cp, , -deprecation, foo.scala) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 12) List(-cp, , foo.scala) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 13) List(-cp, , , foo.scala) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 14) List(-cp, , foo.scala, ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 15) List(, -cp, , foo.scala) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 16) List(-cp, , foo.scala, -deprecation) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 17) List(-cp, , , foo.scala, -deprecation) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 18) List(-cp, , foo.scala, , -deprecation) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 19) List(-cp, , foo.scala, -deprecation, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 20) List(, -cp, , foo.scala, -deprecation) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 21) List(-deprecation, -cp, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 22) List(, -deprecation, -cp, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 23) List(-deprecation, -cp, , ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 24) List(-deprecation, , -cp, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 25) List(-deprecation, -cp, , foo.scala) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 26) List(, -deprecation, -cp, , foo.scala) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 27) List(-deprecation, -cp, , , foo.scala) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 28) List(-deprecation, -cp, , foo.scala, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 29) List(-deprecation, , -cp, , foo.scala) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 30) List(-deprecation, foo.scala, -cp, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 31) List(, -deprecation, foo.scala, -cp, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 32) List(-deprecation, , foo.scala, -cp, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 33) List(-deprecation, foo.scala, -cp, , ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 34) List(-deprecation, foo.scala, , -cp, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 35) List(foo.scala, -cp, ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 36) List(, foo.scala, -cp, ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 37) List(foo.scala, -cp, , ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 38) List(foo.scala, , -cp, ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 39) List(foo.scala, -cp, , -deprecation) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 40) List(, foo.scala, -cp, , -deprecation) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 41) List(foo.scala, -cp, , , -deprecation) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 42) List(foo.scala, -cp, , -deprecation, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 43) List(foo.scala, , -cp, , -deprecation) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 44) List(foo.scala, -deprecation, -cp, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 45) List(, foo.scala, -deprecation, -cp, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 46) List(foo.scala, , -deprecation, -cp, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 47) List(foo.scala, -deprecation, -cp, , ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 48) List(foo.scala, -deprecation, , -cp, ) ==> Settings {
+  -classpath = ""
   -d = .
   -deprecation = true
-  -classpath = ""
 }
 
 0) List(-cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 1) List(-cp, /tmp:/bippy, ) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 2) List(, -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 3) List(-cp, /tmp:/bippy, -deprecation) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 4) List(-cp, /tmp:/bippy, , -deprecation) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 5) List(-cp, /tmp:/bippy, -deprecation, ) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 6) List(, -cp, /tmp:/bippy, -deprecation) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 7) List(-cp, /tmp:/bippy, -deprecation, foo.scala) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 8) List(-cp, /tmp:/bippy, , -deprecation, foo.scala) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 9) List(-cp, /tmp:/bippy, -deprecation, , foo.scala) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 10) List(-cp, /tmp:/bippy, -deprecation, foo.scala, ) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 11) List(, -cp, /tmp:/bippy, -deprecation, foo.scala) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 12) List(-cp, /tmp:/bippy, foo.scala) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 13) List(-cp, /tmp:/bippy, , foo.scala) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 14) List(-cp, /tmp:/bippy, foo.scala, ) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 15) List(, -cp, /tmp:/bippy, foo.scala) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 16) List(-cp, /tmp:/bippy, foo.scala, -deprecation) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 17) List(-cp, /tmp:/bippy, , foo.scala, -deprecation) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 18) List(-cp, /tmp:/bippy, foo.scala, , -deprecation) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 19) List(-cp, /tmp:/bippy, foo.scala, -deprecation, ) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 20) List(, -cp, /tmp:/bippy, foo.scala, -deprecation) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 21) List(-deprecation, -cp, /tmp:/bippy) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 22) List(, -deprecation, -cp, /tmp:/bippy) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 23) List(-deprecation, -cp, /tmp:/bippy, ) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 24) List(-deprecation, , -cp, /tmp:/bippy) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 25) List(-deprecation, -cp, /tmp:/bippy, foo.scala) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 26) List(, -deprecation, -cp, /tmp:/bippy, foo.scala) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 27) List(-deprecation, -cp, /tmp:/bippy, , foo.scala) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 28) List(-deprecation, -cp, /tmp:/bippy, foo.scala, ) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 29) List(-deprecation, , -cp, /tmp:/bippy, foo.scala) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 30) List(-deprecation, foo.scala, -cp, /tmp:/bippy) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 31) List(, -deprecation, foo.scala, -cp, /tmp:/bippy) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 32) List(-deprecation, , foo.scala, -cp, /tmp:/bippy) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 33) List(-deprecation, foo.scala, -cp, /tmp:/bippy, ) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 34) List(-deprecation, foo.scala, , -cp, /tmp:/bippy) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 35) List(foo.scala, -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 36) List(, foo.scala, -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 37) List(foo.scala, -cp, /tmp:/bippy, ) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 38) List(foo.scala, , -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 39) List(foo.scala, -cp, /tmp:/bippy, -deprecation) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 40) List(, foo.scala, -cp, /tmp:/bippy, -deprecation) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 41) List(foo.scala, -cp, /tmp:/bippy, , -deprecation) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 42) List(foo.scala, -cp, /tmp:/bippy, -deprecation, ) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 43) List(foo.scala, , -cp, /tmp:/bippy, -deprecation) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 44) List(foo.scala, -deprecation, -cp, /tmp:/bippy) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 45) List(, foo.scala, -deprecation, -cp, /tmp:/bippy) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 46) List(foo.scala, , -deprecation, -cp, /tmp:/bippy) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 47) List(foo.scala, -deprecation, -cp, /tmp:/bippy, ) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 
 48) List(foo.scala, -deprecation, , -cp, /tmp:/bippy) ==> Settings {
+  -classpath = /tmp:/bippy
   -d = .
   -deprecation = true
-  -classpath = /tmp:/bippy
 }
 

--- a/test/files/run/settings-parse.scala
+++ b/test/files/run/settings-parse.scala
@@ -10,10 +10,12 @@ object Test {
     val permutations = permutations0 flatMap ("-cp CPTOKEN" :: _ permutations)
 
     for ((p, i) <- permutations.distinct.sortBy(_ mkString "").zipWithIndex) {
+
       val args           = p flatMap (_ split "\\s+") map (x => if (x == "CPTOKEN") cp else x)
       val s              = new settings.MutableSettings(println)
       val (ok, residual) = s.processArguments(args, processAll = true)
 
+      s.toString()
       val expected = args filter (_ == "foo.scala")
       assert(residual == expected, residual)
       assert(ok, args)

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -247,4 +247,20 @@ class SettingsTest {
       marginallyEquals(expected, m.help)
     })
   }
+
+  @Test def addSettingKeepsLastSetting(): Unit = {
+
+    val desc = "Test new setting with same name"
+
+    class OriginalSettings() extends MutableSettings(msg => throw new IllegalArgumentException(msg)) {
+      val param = add(StringSetting("-x", "test", "Test original setting", "test", None))
+    }
+    class NewSettings() extends OriginalSettings {
+      override val param = add(StringSetting("-x", "test-new", desc, "test-new", None))
+    }
+
+    val newSettings = new NewSettings()
+    val setting = newSettings.allSettings.find(_.name == "-x").get
+    assertEquals(desc, setting.helpDescription)
+  }
 }


### PR DESCRIPTION
Overriding the MutableSettings settings will keep the last setting added.
This enables scaladoc to use same -d param with different description
from scalac.

fixes scala/bug#9609