### PR TITLE
Parse signatures when collecting referenced nested classes

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -805,7 +805,12 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
     def getGenericSignature(sym: Symbol, owner: Symbol, memberTpe: Type): String = {
       if (!needsGenericSignature(sym)) { return null }
 
-      val jsOpt: Option[String] = erasure.javaSig(sym, memberTpe)
+      // Make sure to build (and cache) a ClassBType for every type that is referenced in
+      // a generic signature. Otherwise, looking up the type later (when collecting nested
+      // classes, or when computing stack map frames) might fail.
+      def enterReferencedClass(sym: Symbol): Unit = enteringJVM(classBTypeFromSymbol(sym))
+
+      val jsOpt: Option[String] = erasure.javaSig(sym, memberTpe, enterReferencedClass)
       if (jsOpt.isEmpty) { return null }
 
       val sig = jsOpt.get

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -72,7 +72,9 @@ abstract class Erasure extends InfoTransform
 
   override protected def verifyJavaErasure = settings.Xverify || settings.debug
   def needsJavaSig(tp: Type, throwsArgs: List[Type]) = !settings.Ynogenericsig && {
-    NeedsSigCollector.collect(tp) || throwsArgs.exists(NeedsSigCollector.collect)
+    // scala/bug#10351: don't emit a signature if tp erases to a primitive
+    def needs(tp: Type) = NeedsSigCollector.collect(tp) && !erasure(tp.typeSymbol)(tp).typeSymbol.isPrimitiveValueClass
+    needs(tp) || throwsArgs.exists(needs)
   }
 
   // only refer to type params that will actually make it into the sig, this excludes:

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -218,7 +218,7 @@ abstract class Erasure extends InfoTransform
   /** The Java signature of type 'info', for symbol sym. The symbol is used to give the right return
    *  type for constructors.
    */
-  def javaSig(sym0: Symbol, info: Type): Option[String] = enteringErasure {
+  def javaSig(sym0: Symbol, info: Type, markClassUsed: Symbol => Unit): Option[String] = enteringErasure {
     val isTraitSignature = sym0.enclClass.isTrait
 
     def superSig(parents: List[Type]) = {
@@ -283,6 +283,7 @@ abstract class Erasure extends InfoTransform
                 boxedSig(tp)
             }
           def classSig = {
+            markClassUsed(sym)
             val preRebound = pre.baseType(sym.owner) // #2585
             val sigCls = {
               if (needsJavaSig(preRebound, Nil)) {

--- a/test/junit/scala/tools/nsc/backend/jvm/GenericSignaturesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/GenericSignaturesTest.scala
@@ -1,0 +1,31 @@
+package scala.tools.nsc.backend.jvm
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.collection.JavaConverters._
+import scala.tools.testing.BytecodeTesting
+
+@RunWith(classOf[JUnit4])
+class GenericSignaturesTest extends BytecodeTesting {
+  import compiler._
+
+  @Test
+  def nestedModules(): Unit = {
+    val code =
+      """class C[T] {
+        |  object O {
+        |    object I
+        |    class J[U]
+        |    class K[V] extends J[V]
+        |  }
+        |}
+      """.stripMargin
+    val List(c, o, i, j, k) = compileClasses(code)
+    assertEquals(o.name, "C$O$")
+    assertEquals(o.methods.asScala.find(_.name == "I").get.signature, "()LC<TT;>.O$I$;")
+    assertEquals(k.signature, "<V:Ljava/lang/Object;>LC<TT;>.O$J<TV;>;")
+  }
+}

--- a/test/junit/scala/tools/nsc/backend/jvm/GenericSignaturesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/GenericSignaturesTest.scala
@@ -28,4 +28,36 @@ class GenericSignaturesTest extends BytecodeTesting {
     assertEquals(o.methods.asScala.find(_.name == "I").get.signature, "()LC<TT;>.O$I$;")
     assertEquals(k.signature, "<V:Ljava/lang/Object;>LC<TT;>.O$J<TV;>;")
   }
+
+  @Test
+  def t10351(): Unit = {
+    val code =
+      """trait A[U] {
+        |  type B <: U
+        |}
+        |class C {
+        |  val a: A[Int] = ???
+        |  val b: a.B = ???
+        |}
+      """.stripMargin
+
+    val List(_, c) = compileClasses(code)
+    assertEquals(
+      List(("a", "LA<Ljava/lang/Object;>;"), ("b", null)),
+      c.fields.asScala.toList.map(f => (f.name, f.signature)).sorted)
+  }
+
+  @Test
+  def t9810(): Unit = {
+    val code =
+      """class A[+P] (final val id: Int) extends AnyVal
+        |class C extends AnyRef
+        |object C {
+        |  final val key: A[C] = new A(1)
+        |}
+      """.stripMargin
+    val List(a, aM, c, cM) = compileClasses(code)
+    assertEquals(List(("MODULE$", null), ("key", null)),
+      cM.fields.asScala.toList.map(f => (f.name, f.signature)).sorted)
+  }
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/InnerClassAttributeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/InnerClassAttributeTest.scala
@@ -1,0 +1,31 @@
+package scala.tools.nsc.backend.jvm
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.collection.JavaConverters._
+import scala.tools.testing.BytecodeTesting
+
+@RunWith(classOf[JUnit4])
+class InnerClassAttributeTest extends BytecodeTesting {
+  import compiler._
+
+  @Test
+  def javaInnerClassInGenericSignatureOnly(): Unit = {
+    val jCode =
+      """public class A {
+        |  public static class B { }
+        |}
+      """.stripMargin
+    val code =
+      """class C {
+        |  def foo: Option[A.B] = ???
+        |}
+      """.stripMargin
+    val c = compileClass(code, javaCode = List((jCode, "A.java")))
+    // No InnerClass entry for A$B due to scala/bug#10180
+    assert(c.innerClasses.asScala.isEmpty)
+  }
+}

--- a/test/junit/scala/tools/nsc/backend/jvm/NestedClassesCollectorTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/NestedClassesCollectorTest.scala
@@ -1,0 +1,115 @@
+package scala.tools.nsc.backend.jvm
+
+import org.junit.{Ignore, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Assert._
+
+import scala.tools.asm.tree.ClassNode
+import scala.tools.nsc.backend.jvm.BTypes.InternalName
+import scala.tools.nsc.backend.jvm.analysis.BackendUtils.NestedClassesCollector
+
+class Collector extends NestedClassesCollector[String] {
+  override def declaredNestedClasses(internalName: InternalName): List[String] = Nil
+  override def getClassIfNested(internalName: InternalName): Option[String] = Some(internalName)
+  def raiseError(msg: String, sig: String, e: Option[Throwable]): Unit =
+    throw e.getOrElse(new Exception(msg + " " + sig))
+}
+
+@RunWith(classOf[JUnit4])
+class NestedClassesCollectorTest {
+  val c = new Collector
+  def inners: List[String] = {
+    val res = c.innerClasses.toList.sorted
+    c.innerClasses.clear()
+    res
+  }
+
+  @Test
+  def referenceTypeSignatures(): Unit = {
+    def ref(sig: String, expect: List[String]) = {
+      c.visitFieldSignature(sig)
+      assertEquals(inners, expect)
+    }
+
+    // TypeVariableSignature
+    ref("THello;", Nil)
+    ref("TT;TU;", Nil)
+    ref("TT;TU;", Nil)
+
+    ref("LKlass;", List("Klass"))
+    ref("Lscala/pack/Kl;", List("scala/pack/Kl"))
+    ref("Lscala/pack/Kl;", List("scala/pack/Kl"))
+    ref("LA.B;", List("A", "A$B"))
+    ref("Lp/Kl.Ne.In;", List("p/Kl", "p/Kl$Ne", "p/Kl$Ne$In"))
+    ref("LA<*>;", List("A"))
+    ref("LA<**+[I[JTFoo;-TBar;LB;*>;", List("A", "B"))
+    ref("Lp/A<[I[LTBoo<*>;-[JTFoo;-TBar;Lp/B<[J+[Lp/C;>.N<+TT;*Lp/D;>;*>;", List("TBoo", "p/A", "p/B", "p/B$N", "p/C", "p/D"))
+    ref("Lp/A<[I[Lp/B<*>;>;", List("p/A", "p/B"))
+    ref("Lp/A<Lp/B;>.C<Lp/D;>.E;", List("p/A", "p/A$C", "p/A$C$E", "p/B", "p/D"))
+
+    ref("[I", Nil)
+    ref("[[[LA;", List("A"))
+    ref("[[[LA<**+[I-[LB;>;", List("A", "B"))
+  }
+
+  @Test
+  def classSignatures(): Unit = {
+    def cls(sig: String, expect: List[String]) = {
+      c.visitClassSignature(sig)
+      assertEquals(inners, expect)
+    }
+
+    cls("LA;", List("A"))
+    cls("LA;LB;", List("A", "B"))
+    cls("Lp/a/A;Lp/B;", List("p/B", "p/a/A"))
+    cls("<T:>LA;", List("A"))
+    cls("<T:LA;:[I:TU;:[TV;>LB;", List("A", "B"))
+    cls("<T:LA;:[Lp/B<+Lp/C;>;:TU;:[TV;>LC;", List("A", "C", "p/B", "p/C"))
+    cls("<T::TT;>LA;", List("A"))
+    cls("<T:LA;>LB;", List("A", "B")) // one type parameter T with class bound A
+    cls("<P:TT;>LA;", List("A")) // one type parameter
+
+    // Missing ClassBound without an interface bound. Probably the grammar only allows those by
+    // accident. Our parser doesn't. https://stackoverflow.com/q/44284928
+    // cls("<T:U:>LA;", List("A"))
+    // cls("<T:L:>LA;", List("A"))
+    // cls("<T:LA:>LB;", List("B")) // two type parameters, T and LA
+    // cls("<P:TT:>LA;", List("A")) // two type parameters
+    // cls("<T:U:LA;>LB;", List("A", "B"))
+  }
+
+  @Test
+  def methodSignatures(): Unit = {
+    def met(sig: String, expect: List[String]) = {
+      c.visitMethodSignature(sig)
+      assertEquals(inners, expect)
+    }
+
+    // type parameters implementation is the same as for class signatures, so only basic testing here
+    met("()V", Nil)
+    met("(BJI)Z", Nil)
+    met("(IJLp/A;Z)Lp/B;", List("p/A", "p/B"))
+    met("<X:LA;:[I:TU;:[TV;Y:[I:LB<+LC;>;>([I[[[LD<**>;)TT;", List("A", "B", "C", "D"))
+    met("(LA;ITT;)I^LB;", List("A", "B"))
+    met("()I^TT;^Lp/A<**+[[Lp/B;>;^TBA;", List("p/A", "p/B"))
+    met("()V^TT;", Nil)
+  }
+
+  @Test
+  @Ignore("manually run test")
+  def rtJar(): Unit = {
+    import java.nio.file._
+    import scala.collection.JavaConverters._
+    val zipfile = Paths.get("/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/rt.jar")
+    val fs = FileSystems.newFileSystem(zipfile, null)
+    val root = fs.getRootDirectories.iterator().next()
+    val contents = Files.walk(root).iterator().asScala.toList
+    for (f <- contents if Files.isRegularFile(f) && f.getFileName.toString.endsWith(".class")) {
+      val classNode = AsmUtils.classFromBytes(Files.readAllBytes(f))
+      c.visitClassSignature(classNode.signature)
+      classNode.methods.iterator().asScala.map(_.signature).foreach(c.visitMethodSignature)
+      classNode.fields.iterator().asScala.map(_.signature).foreach(c.visitFieldSignature)
+    }
+  }
+}


### PR DESCRIPTION
To emit the InnerClass table we visit ClassNodes after all code
generation is done. This is simpler than keeping track of things
during code generation and the optimizer.

Until now we didn't include references to nested classes that
appear only in generic signatures.

Fixes scala/bug#10180, scala/bug#10351, scala/bug#9810
