### PR TITLE
Fixed issue of repl string of immutable.Queue #10303

### DIFF
--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -92,6 +92,8 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
   override def exists(p: A => Boolean): Boolean =
     in.exists(p) || out.exists(p)
 
+  override def stringPrefix = "Queue"
+
   /** Returns the length of the queue.
    */
   override def length = in.length + out.length


### PR DESCRIPTION
 Reference scala/bug#10303

Fixed issue where scala repl showed Queue.EmptyQueue() instead of Queue()

```
scala> scala.collection.immutable.Queue.empty[Int]
res0: scala.collection.immutable.Queue[Int] = Queue.EmptyQueue()

```

Fixed by adding stringPrefix in Queue.scala
