### PR TITLE
Fix completion of x.bar.<TAB>, where bar takes dependent implicits

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/ContextTrees.scala
+++ b/src/interactive/scala/tools/nsc/interactive/ContextTrees.scala
@@ -59,7 +59,8 @@ trait ContextTrees { self: Global =>
       c.retyping = false
       c
     }
-    locateContextTree(contexts, pos) map locateFinestContextTree map (ct => sanitizeContext(ct.context))
+    val tree = locateContextTree(contexts, pos)
+    tree map locateFinestContextTree map (ct => sanitizeContext(ct.context))
   }
 
   /** Returns the ContextTree containing `pos`, or the ContextTree positioned just before `pos`,

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1078,6 +1078,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     val shouldTypeQualifier = tree0.tpe match {
       case null           => true
       case mt: MethodType => mt.isImplicit
+      case pt: PolyType   => isImplicitMethodType(pt.resultType)
       case _              => false
     }
 


### PR DESCRIPTION
Extended the logic that typechecks the located tree if it is
an unapplied method to also work for polymorphic methods.

Fixes scala/bug#10353