### PR TITLE
Improve presentation compiler with Shapeless macros

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -237,6 +237,9 @@ trait Contexts { self: Analyzer =>
 
     /** Types for which implicit arguments are currently searched */
     var openImplicits: List[OpenImplicit] = List()
+    final def isSearchingForImplicitParam: Boolean = {
+      openImplicits.nonEmpty && openImplicits.exists(x => !x.isView)
+    }
 
     /* For a named application block (`Tree`) the corresponding `NamedApplyInfo`. */
     var namedApplyBlockInfo: Option[(Tree, NamedApplyInfo)] = None

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -262,7 +262,21 @@ trait Implicits {
 
   /** A class which is used to track pending implicits to prevent infinite implicit searches.
    */
-  case class OpenImplicit(info: ImplicitInfo, pt: Type, tree: Tree)
+  case class OpenImplicit(info: ImplicitInfo, pt: Type, tree: Tree) {
+    // JZ: should be a case class parameter, but I have reason to believe macros/plugins peer into OpenImplicit
+    // so I'm avoiding a signature change
+    def isView: Boolean = _isView
+    private def isView_=(value: Boolean): Unit = _isView = value
+
+    private[this] var _isView: Boolean = false
+  }
+  object OpenImplicit {
+    def apply(info: ImplicitInfo, pt: Type, tree: Tree, isView: Boolean): OpenImplicit = {
+      val result = new OpenImplicit(info, pt, tree)
+      result.isView = isView
+      result
+    }
+  }
 
   /** A sentinel indicating no implicit was found */
   val NoImplicitInfo = new ImplicitInfo(null, NoType, NoSymbol) {
@@ -470,7 +484,7 @@ trait Implicits {
            DivergentSearchFailure
          case None =>
            try {
-             context.openImplicits = OpenImplicit(info, pt, tree) :: context.openImplicits
+             context.openImplicits = OpenImplicit(info, pt, tree, isView) :: context.openImplicits
              // println("  "*context.openImplicits.length+"typed implicit "+info+" for "+pt) //@MDEBUG
              val result = typedImplicit0(info, ptChecked, isLocalToCallsite)
              if (result.isDivergent) {

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -594,7 +594,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
                 // also see http://groups.google.com/group/scala-internals/browse_thread/thread/492560d941b315cc
                 val expanded1 = try onSuccess(duplicateAndKeepPositions(expanded)) finally popMacroContext()
                 if (!hasMacroExpansionAttachment(expanded1)) linkExpandeeAndExpanded(expandee, expanded1)
-                if (settings.Ymacroexpand.value == settings.MacroExpand.Discard) {
+                if (settings.Ymacroexpand.value == settings.MacroExpand.Discard && !typer.context.isSearchingForImplicitParam) {
                   suppressMacroExpansion(expandee)
                   expandee.setType(expanded1.tpe)
                 }


### PR DESCRIPTION
`-Ymacro-expand` discard was introduced to leave prefixes and
arguments of implicit applications in the typechecked tree in the
presentation compiler to facilite completion, type-at-cursor, etc
within those trees.

It seems that this mode interferes with implicit searches that involve
Shapeless's `mkLazy` macro.

This commit simply turns off the macro expansion discarding if
the current macro application is part of an application of implicit
arguments. There is no trees corresponding to source code in that
position, so we the concerns about IDE functionality are moot.

I couldn't disentangle the bug report from circe and shapeless,
so I've manually tested that the compiler from this commit
makes the following test project compile.

https://github.com/retronym/t9716

Fixes scala/bug#9716