### PR TITLE
Remove deprecated view bounds in library

### DIFF
--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -146,7 +146,7 @@ trait LowPriorityOrderingImplicits {
    *  turn up if nothing else works.  Since `Ordered[A]` extends
    *  `Comparable[A]` anyway, we can throw in some Java interop too.
    */
-  implicit def ordered[A <% Comparable[A]]: Ordering[A] = new Ordering[A] {
+  implicit def ordered[A](implicit @deprecatedName('evidence$1, "2.12.3") ev: A => Comparable[A]): Ordering[A] = new Ordering[A] {
     def compare(x: A, y: A): Int = x compareTo y
   }
   implicit def comparatorToOrdering[A](implicit cmp: Comparator[A]): Ordering[A] = new Ordering[A] {

--- a/src/library/scala/math/PartiallyOrdered.scala
+++ b/src/library/scala/math/PartiallyOrdered.scala
@@ -25,24 +25,24 @@ trait PartiallyOrdered[+A] {
    *  - `x == 0`   iff   `'''this''' == that`
    *  - `x > 0`    iff   `'''this''' &gt; that`
    */
-  def tryCompareTo [B >: A <% PartiallyOrdered[B]](that: B): Option[Int]
+  def tryCompareTo [B >: A](that: B)(implicit @deprecatedName('evidence$1, "2.12.3") ev: B => PartiallyOrdered[B]): Option[Int]
 
-  def <  [B >: A <% PartiallyOrdered[B]](that: B): Boolean =
+  def <  [B >: A](that: B)(implicit @deprecatedName('evidence$1, "2.12.3") ev: B => PartiallyOrdered[B]): Boolean =
     (this tryCompareTo that) match {
       case Some(x) if x < 0 => true
       case _ => false
     }
-  def >  [B >: A <% PartiallyOrdered[B]](that: B): Boolean =
+  def >  [B >: A](that: B)(implicit @deprecatedName('evidence$1, "2.12.3") ev: B => PartiallyOrdered[B]): Boolean =
     (this tryCompareTo that) match {
       case Some(x) if x > 0 => true
       case _ => false
     }
-  def <= [B >: A <% PartiallyOrdered[B]](that: B): Boolean =
+  def <= [B >: A](that: B)(implicit @deprecatedName('evidence$1, "2.12.3") ev: B => PartiallyOrdered[B]): Boolean =
     (this tryCompareTo that) match {
       case Some(x) if x <= 0 => true
       case _ => false
     }
-  def >= [B >: A <% PartiallyOrdered[B]](that: B): Boolean =
+  def >= [B >: A](that: B)(implicit @deprecatedName('evidence$1, "2.12.3") ev: B => PartiallyOrdered[B]): Boolean =
     (this tryCompareTo that) match {
       case Some(x) if x >= 0 => true
       case _ => false


### PR DESCRIPTION
Replace view bounds with implicit parameter.

`evidence$1` is the name used by the parser when converting the view bound
to a parameter. Picking this name instead of say `ev` results in an unchanged
method signature.