### PR TITLE
Drive bitmap computation from field, not accessor

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -782,8 +782,8 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
         if (settings.checkInit) {
           val addChecks = new SynthInitCheckedAccessorsIn(currentOwner)
           prunedStats mapConserve {
-            case dd: DefDef => deriveDefDef(dd)(addChecks.wrapRhsWithInitChecks(dd.symbol))
-            case stat       => stat
+            case dd: DefDef if addChecks.needsWrapping(dd) => deriveDefDef(dd)(addChecks.wrapRhsWithInitChecks(dd.symbol))
+            case stat                                      => stat
           }
         } else prunedStats
 

--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -505,7 +505,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
             mixedInAccessorAndFields foreach enterAll
 
             // both oldDecls and mixedInAccessorAndFields (a list of lists) contribute
-            val bitmapSyms = accessorSymbolSynth.computeBitmapInfos(newDecls.toList)
+            val bitmapSyms = accessorSymbolSynth.computeBitmapInfos(newDecls.filter(sym => sym.isValue && !sym.isMethod).toList)
 
             bitmapSyms foreach enter
 

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -1040,6 +1040,7 @@ trait StdNames {
     }
 
     def newBitmapName(bitmapPrefix: Name, n: Int) = bitmapPrefix append ("" + n)
+    def isTransientBitmap(name: Name) = name == nme.BITMAP_TRANSIENT || name == nme.BITMAP_CHECKINIT_TRANSIENT
 
     val BITMAP_NORMAL: NameType              = BITMAP_PREFIX + ""           // initialization bitmap for public/protected lazy vals
     val BITMAP_TRANSIENT: NameType           = BITMAP_PREFIX + "trans$"     // initialization bitmap for transient lazy vals

--- a/test/files/run/t10244.scala
+++ b/test/files/run/t10244.scala
@@ -1,0 +1,39 @@
+class NotSerializable { def foo = "bar" }
+
+// transient lazy val gets transient bitmap, is initialized after deserializing,
+// regardless of whether it was initialized before serializing
+trait HasUnserializableLazy extends Serializable {
+  @transient
+  protected lazy val notSerializable = new NotSerializable
+}
+
+class Serializes extends HasUnserializableLazy {
+  def check = notSerializable.foo == "bar"
+}
+
+object SerializeHelpers {
+  def serialize[A](o: A): Array[Byte] = {
+    val ba = new java.io.ByteArrayOutputStream(512)
+    val out = new java.io.ObjectOutputStream(ba)
+    out.writeObject(o)
+    out.close()
+    ba.toByteArray()
+  }
+  def deserialize[A](buffer: Array[Byte]): A = {
+    val in =
+      new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(buffer))
+    in.readObject().asInstanceOf[A]
+  }
+}
+
+object Test {
+  import SerializeHelpers._
+
+  def main(args: Array[String]): Unit = {
+    assert(deserialize[Serializes](serialize(new Serializes)).check)
+
+    // check that transient lazy val uses a transient bitmap,
+    // so that it doesn't care whether the lazy val was initialized before serialization or not
+    assert(deserialize[Serializes](serialize { val i = new Serializes ; i.check ; i }).check)
+  }
+}


### PR DESCRIPTION
Since bitmaps are only needed if there is a field, and the field carries
the transient annotation, don't go around via the accessor (we'd miss the
annotation).

Before we had a fields phase, this was tricky to do, but now it's
pretty straightforward to operate on field symbols, as we synthesize
the relevant ones, along with their bitmaps, during the fields phase
instead of waiting until mixin. As an extra bonus, the "artifact" fields
such as outer pointers etc don't exist yet, so we don't have to
exclude them.
 
With thanks to @sarahgerweck for the analysis!

TODO:
  - [x] jardiff

Fix scala/bug#10244