### PR TITLE
Fix generation of derived value classes wrapping Unit, Null, and Nothing

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -528,8 +528,10 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
             else if (l.isPrimitive) {
               bc drop l
               if (cast) {
+                devWarning(s"Tried to emit impossible cast from primitive type $l to $r (at ${app.pos})")
                 mnode.visitTypeInsn(asm.Opcodes.NEW, jlClassCastExceptionRef.internalName)
                 bc dup ObjectRef
+                mnode.visitMethodInsn(asm.Opcodes.INVOKESPECIAL, jlClassCastExceptionRef.internalName, INSTANCE_CONSTRUCTOR_NAME, "()V", true)
                 emit(asm.Opcodes.ATHROW)
               } else {
                 bc boolconst false

--- a/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
+++ b/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
@@ -72,13 +72,17 @@ trait TypeAdaptingTransformer { self: TreeDSL =>
         val ldef = deriveLabelDef(tree)(unbox(_, pt))
         ldef setType ldef.rhs.tpe
       case _ =>
+        def preservingSideEffects(side: Tree, value: Tree): Tree =
+          if (treeInfo isExprSafeToInline side) value
+          else BLOCK(side, value)
         val tree1 = pt match {
+          case ErasedValueType(clazz, BoxedUnitTpe) =>
+            cast(preservingSideEffects(tree, REF(BoxedUnit_UNIT)), pt)
           case ErasedValueType(clazz, underlying) => cast(unboxValueClass(tree, clazz, underlying), pt)
           case _ =>
             pt.typeSymbol match {
               case UnitClass  =>
-                if (treeInfo isExprSafeToInline tree) UNIT
-                else BLOCK(tree, UNIT)
+                preservingSideEffects(tree, UNIT)
               case x          =>
                 assert(x != ArrayClass)
                 // don't `setType pt` the Apply tree, as the Apply's fun won't be typechecked if the Apply tree already has a type

--- a/test/files/run/wacky-value-classes.flags
+++ b/test/files/run/wacky-value-classes.flags
@@ -1,0 +1,1 @@
+-Xverify

--- a/test/files/run/wacky-value-classes.scala
+++ b/test/files/run/wacky-value-classes.scala
@@ -1,0 +1,20 @@
+// scala/bug#10361
+final class AnyValNothing(val self: Nothing) extends AnyVal
+final class AnyValNull   (val self: Null   ) extends AnyVal
+// scala/bug#9240
+final class AnyValUnit   (val self: Unit   ) extends AnyVal
+
+object Test extends App {
+  def avn = new AnyValNull(null)
+  assert(avn == avn)
+  /*this throws NPE right now b/c scala/bug#7396 */
+  //assert(avn.hashCode() == 0)
+
+  def avu = new AnyValUnit(())
+  assert((avu.self: Any).equals(()))
+  assert(avu equals avu)
+  assert((avu: Any).## == 0)
+
+  /* can't really test AnyValNothing, but summon it so it gets verified */
+  AnyValNothing.toString
+}


### PR DESCRIPTION
All sorts o' specialness going on here. `Unit` morphs into a `BoxedUnit` when it's in a field, but void when it's the return type of a method, which is expected. This means, though, that the unboxing method of a Unit-wrapping value class has the signature `()V`, not `()Lscala/runtime/BoxedUnit`, so attempting to use its value in the equals method spits out some wonderful invalid bytecode, instead. Similar sadness occurs for Nothing and Null as well.

The "solution" is to not even bother to check for equality, as we've only got at most one legitimate value of each of these types. Because the code is shared with `case class`es, this also changes the bytecode we generate for them. Obviously this is an "unrelated change" as far as the bugs this is meant to fix go, but it's innocuous enough as far as I can tell.

I also slipped a constructor call into the generated `ClassCastException` that gets thrown when we are asked to emit a cast for a primitive type in `BCodeBodyBuilder`, so we generate valid bytecode in that case. I've got no idea how `NEW; DUP; ATHROW` is possibly ever legitimate, but hey.

Fixes scala/bug#9240
Fixes scala/bug#10361