### PR TITLE
Fix code gen for Outer.super[Q].foo

### DIFF
--- a/test/files/run/t10290.scala
+++ b/test/files/run/t10290.scala
@@ -1,0 +1,28 @@
+trait A1 {
+  private val s = "A1"
+  def f = s
+}
+
+trait A2 {
+  private val s = "A2"
+  def f = s
+}
+
+class B extends A1 with A2 {
+  override def f = "B"
+  class C {
+    def t1 = B.super[A1].f
+    def t2 = B.super[A2].f
+    def t3 = B.this.f
+  }
+}
+
+object Test {
+  def main(args : Array[String]) : Unit = {
+    val b = new B
+    val c = new b.C
+    assert(c.t1 == "A1")
+    assert(c.t2 == "A2")
+    assert(c.t3 == "B")
+  }
+}


### PR DESCRIPTION
Consider

    class B extends T { class C { B.super[T].f }}

After flatten, that call is ` B$C.this.$outer().super[T].f()`.

In 2.11, mixin translates this to `A$class.f(B$C.this.$outer())`.
In 2.12, the tree is passed unchanged to the backend.

In `genApply` we assumed that in `Apply(Select(Super(qual, ... )))`,
`qual` is a `This` tree, so we just emitted `ALOAD_0`, which caused
the `$outer()` call to get lost. Now we invoke `genLoad(qual)`.

Fixes scala/bug#10290.