### PR TITLE
Fix check for varargs calling convention in overrides of Java methods

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -580,7 +580,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     val runsRightAfter = None
   } with Delambdafy
 
-  // phaseName = "bcode"
+  // phaseName = "jvm"
   object genBCode extends {
     val global: Global.this.type = Global.this
     val runsAfter = List("cleanup")

--- a/test/files/run/t10368/Cache_1.java
+++ b/test/files/run/t10368/Cache_1.java
@@ -1,0 +1,5 @@
+public abstract class Cache_1<T> {
+  public T get(Object... args) {
+    return null;
+  }
+}

--- a/test/files/run/t10368/Test_2.scala
+++ b/test/files/run/t10368/Test_2.scala
@@ -1,0 +1,13 @@
+case class CASEntry()
+class CASCache extends Cache_1[CASEntry] {
+  override def get(keys: AnyRef*): CASEntry = {
+    super.get(keys: _*) // generates a direct `.super[Cache_1]` call, works
+    foo(super.get(keys: _*)) // generates a superaccessor call, fails
+  }
+
+  def foo[T](f: => T): T = f
+}
+
+object Test extends App {
+  new CASCache().get("")
+}


### PR DESCRIPTION
The comment explains it all, but to repeat: Scala-defined varargs methods take a `Seq` parameter; Java-defined varargs methods take an `Array`. `transformArgs` in `uncurry` needs to wrap the passed args in the right data structure. Checking for `fun.isJava` works quite nicely, except for when we've made a superaccessor for some Java-defined method, the superaccessor takes an `Array`, but does not have `isJava` set, and therefore we wrap the args in a `Seq`, netting us a tasty `ClassCastException` at runtime.

The solution: check with `isJavaVarArgsMethod` instead, which can capture this distinction correctly.

Alternate solution: change `superaccessors` to generate a scala-ish varargs method signature. I didn't pick this solution because, as of right now, `superaccessors` knows not of varargs, and it might be better left that way.

Fixes scala/bug#10368

Review by @retronym 

Quoth the jardiff on scala/scala: [No changes.](https://gist.github.com/hrhino/eb88a0ee510e81e1726448c0675bc653)