### PR TITLE
Support serializable on MatchError

### DIFF
--- a/src/library/scala/MatchError.scala
+++ b/src/library/scala/MatchError.scala
@@ -19,9 +19,9 @@ package scala
  *  @version 1.1, 05/03/2004
  *  @since   2.0
  */
-final class MatchError(obj: Any) extends RuntimeException {
+final class MatchError(@transient obj: Any) extends RuntimeException {
   /** There's no reason we need to call toString eagerly,
-   *  so defer it until getMessage is called.
+   *  so defer it until getMessage is called or object is serialized
    */
   private lazy val objString = {
     def ofClass = "of class " + obj.getClass.getName
@@ -31,6 +31,12 @@ final class MatchError(obj: Any) extends RuntimeException {
     } catch {
       case _: Throwable => "an instance " + ofClass
     }
+  }
+
+  @throws[java.io.ObjectStreamException]
+  private def writeReplace(): Object = {
+    objString
+    this
   }
 
   override def getMessage() = objString

--- a/test/junit/scala/MatchErrorSerializationTest.scala
+++ b/test/junit/scala/MatchErrorSerializationTest.scala
@@ -1,0 +1,23 @@
+package scala
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+  * Created by estsauver on 6/15/17.
+  */
+@RunWith(classOf[JUnit4])
+class MatchErrorSerializationTest {
+
+  @Test
+  def canSerializeMatchError = {
+    import java.io._
+    val matchError = new MatchError(new Object)
+    val barrayOut = new ByteArrayOutputStream()
+    new ObjectOutputStream(barrayOut).writeObject(matchError)
+    val barrayIn = new ByteArrayInputStream(barrayOut.toByteArray)
+    val readMessage = new ObjectInputStream(barrayIn).readObject().asInstanceOf[MatchError].getMessage()
+    assert(readMessage.startsWith("java.lang.Object"))
+  }
+}


### PR DESCRIPTION
Since MatchError ultimately extends throwable, it needs to implement the Serializable interface. To do this, we need to eagerly evaluate the error message.

Closes scala/bug#10369