### PR TITLE
Implement `tails` method efficiently on List and Stream

### DIFF
--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -315,4 +315,7 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
     }
     last
   }
+
+  override /*TraversableLike*/
+  def tails: Iterator[Repr] = Iterator.iterate(repr)(_.tail).takeWhile(_.nonEmpty) ++ Iterator(newBuilder.result)
 }

--- a/test/junit/scala/collection/LinearSeqOptimizedTest.scala
+++ b/test/junit/scala/collection/LinearSeqOptimizedTest.scala
@@ -16,4 +16,20 @@ class LinearSeqOptimizedTest {
     assertEquals(2, "abcde".toList.indexWhere(_ == 'c', -1))
     assertEquals(2, "abcde".toList.indexWhere(_ == 'c', -2))
   }
+
+  @Test def test_efficientTails_list_SI9892: Unit = {
+    val tails = List(1,2,3,4).tails.toList
+
+    assert(tails(0).tail eq tails(1))
+    assert(tails(0).tail.tail eq tails(2))
+    assert(tails(1).tail eq tails(2))
+    assert(tails(3).tail eq tails(4))
+    assert(tails(4) eq List())
+  }
+
+  @Test def test_efficientTails_stream_SI9892: Unit = {
+    val stream = Stream.from(1)
+    val tails = stream.tails.toStream
+    assert(tails.head eq stream)
+  }
 }


### PR DESCRIPTION
I do not feel this is a complete solution, we are not sure Traversable[A] can be cast to Repr. Which is the case with StringOps.