### PR TITLE
Add apply methods to typeclass companion objects in scala.math

### DIFF
--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -43,10 +43,10 @@ trait LowPriorityEquiv {
 }
 
 object Equiv extends LowPriorityEquiv {
-  def reference[T <: AnyRef] : Equiv[T] = new Equiv[T] {
+  def reference[T <: AnyRef]: Equiv[T] = new Equiv[T] {
     def equiv(x: T, y: T) = x eq y
   }
-  def universal[T] : Equiv[T] = new Equiv[T] {
+  def universal[T]: Equiv[T] = new Equiv[T] {
     def equiv(x: T, y: T) = x == y
   }
   def fromComparator[T](cmp: Comparator[T]): Equiv[T] = new Equiv[T] {
@@ -58,5 +58,5 @@ object Equiv extends LowPriorityEquiv {
   def by[T, S: Equiv](f: T => S): Equiv[T] =
     fromFunction((x, y) => implicitly[Equiv[S]].equiv(f(x), f(y)))
 
-  def apply[T: Equiv] : Equiv[T] = implicitly[Equiv[T]]
+  @inline def apply[T: Equiv]: Equiv[T] = implicitly[Equiv[T]]
 }

--- a/src/library/scala/math/Fractional.scala
+++ b/src/library/scala/math/Fractional.scala
@@ -25,6 +25,8 @@ trait Fractional[T] extends Numeric[T] {
 }
 
 object Fractional {
+  @inline def apply[T](implicit frac: Fractional[T]): Fractional[T] = frac
+
   trait ExtraImplicits {
     implicit def infixFractionalOps[T](x: T)(implicit num: Fractional[T]): Fractional[T]#FractionalOps = new num.FractionalOps(x)
   }

--- a/src/library/scala/math/Integral.scala
+++ b/src/library/scala/math/Integral.scala
@@ -27,6 +27,8 @@ trait Integral[T] extends Numeric[T] {
 }
 
 object Integral {
+  @inline def apply[T](implicit int: Integral[T]): Integral[T] = int
+
   trait ExtraImplicits {
     /** The regrettable design of Numeric/Integral/Fractional has them all
      *  bumping into one another when searching for this implicit, so they

--- a/src/library/scala/math/Numeric.scala
+++ b/src/library/scala/math/Numeric.scala
@@ -15,6 +15,8 @@ import scala.language.implicitConversions
  * @since 2.8
  */
 object Numeric {
+  @inline def apply[T](implicit num: Numeric[T]): Numeric[T] = num
+
   trait ExtraImplicits {
     /** These implicits create conversions from a value for which an implicit Numeric
      *  exists to the inner class which creates infix operations.  Once imported, you

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -160,7 +160,7 @@ trait LowPriorityOrderingImplicits {
   * new orderings.
   */
 object Ordering extends LowPriorityOrderingImplicits {
-  def apply[T](implicit ord: Ordering[T]) = ord
+  @inline def apply[T](implicit ord: Ordering[T]) = ord
 
   trait ExtraImplicits {
     /** Not in the standard scope due to the potential for divergence:


### PR DESCRIPTION
Add apply methods to companion objects of `Numeric`, `Integral` and `Fractional`. Makes summoning an instance of the corresponding typeclass less verbose and cumbersome: `Numeric[T]` instead of `implicitly[Numeric[T]]`.
Make the apply methods in the companion objects of `Numeric`, `Integral`, `Fractional`, `Equiv` and `Ordering` `@inline`, in line with `implicitly`.