### PR TITLE
Demonstrate HtmlFactoryTest assertions are ignored

### DIFF
--- a/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
+++ b/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
@@ -130,6 +130,7 @@ object HtmlFactoryTest extends Properties("HtmlFactory") {
     }
 
     result
+    false
   }
 
   def shortComments(root: scala.xml.Node) =


### PR DESCRIPTION
Locally `HtmlFactoryTest` passes with this edit which should cause failed tests.

```
> scalacheck/testOnly scala.tools.nsc.scaladoc.HtmlFactoryTest
...some output...
[info] ! HtmlFactory.Comment inheritance: Correct explicit inheritance in corner cases: Falsified after 0 passed tests.
[info] + HtmlFactory.Trac #4325 - files: OK, proved property.
error: source file 'test/scaladoc/resources/SI_5054_q4.scala' could not be found
[info] ! HtmlFactory.scala/bug#5054: Use cases should keep their flags - real abstract should not be lost: Exception raised on property evaluation.
[info] > Exception: java.util.NoSuchElementException: key not found: SI_5054_q4.html
[info] + HtmlFactory.scala/bug#8144: Members' permalink - companion object: OK, proved property.
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[success] Total time: 21 s, completed 21-Jun-2017 11:45:18
```
I want to see if the full build passes with this failing test.

Relates to https://github.com/scala/bug/issues/10374

## TODO
 - [x] Close without merging when build outcome is known