### PR TITLE
Optimize classpath implementation to speed up SBT

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/AggregateClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/AggregateClassPath.scala
@@ -21,32 +21,29 @@ import scala.tools.nsc.util.ClassRepresentation
  */
 case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
   override def findClassFile(className: String): Option[AbstractFile] = {
-    @tailrec
-    def find(aggregates: Seq[ClassPath]): Option[AbstractFile] =
-      if (aggregates.nonEmpty) {
-        val classFile = aggregates.head.findClassFile(className)
-        if (classFile.isDefined) classFile
-        else find(aggregates.tail)
-      } else None
-
-    find(aggregates)
+    val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
+    aggregatesForPackage(pkg).iterator.map(_.findClassFile(className)).collectFirst {
+      case Some(x) => x
+    }
+  }
+  private[this] val packageIndex: collection.mutable.Map[String, Seq[ClassPath]] = collection.mutable.Map()
+  private def aggregatesForPackage(pkg: String): Seq[ClassPath] = packageIndex.synchronized {
+    packageIndex.getOrElseUpdate(pkg, aggregates.filter(_.hasPackage(pkg)))
   }
 
+  // This method is performance sensitive as it is used by SBT's ExtractDependencies phase.
   override def findClass(className: String): Option[ClassRepresentation] = {
-    @tailrec
-    def findEntry(aggregates: Seq[ClassPath], isSource: Boolean): Option[ClassRepresentation] =
-      if (aggregates.nonEmpty) {
-        val entry = aggregates.head.findClass(className) match {
-          case s @ Some(_: SourceFileEntry) if isSource => s
-          case s @ Some(_: ClassFileEntry) if !isSource => s
-          case _ => None
-        }
-        if (entry.isDefined) entry
-        else findEntry(aggregates.tail, isSource)
-      } else None
+    val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
 
-    val classEntry = findEntry(aggregates, isSource = false)
-    val sourceEntry = findEntry(aggregates, isSource = true)
+    def findEntry(isSource: Boolean): Option[ClassRepresentation] = {
+      aggregatesForPackage(pkg).iterator.map(_.findClass(className)).collectFirst {
+        case Some(s: SourceFileEntry) if isSource => s
+        case Some(s: ClassFileEntry) if !isSource => s
+      }
+    }
+
+    val classEntry = findEntry(isSource = false)
+    val sourceEntry = findEntry(isSource = true)
 
     (classEntry, sourceEntry) match {
       case (Some(c: ClassFileEntry), Some(s: SourceFileEntry)) => Some(ClassAndSourceFilesEntry(c.file, s.file))
@@ -72,6 +69,7 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
   override private[nsc] def sources(inPackage: String): Seq[SourceFileEntry] =
     getDistinctEntries(_.sources(inPackage))
 
+  override private[nsc] def hasPackage(pkg: String) = aggregates.exists(_.hasPackage(pkg))
   override private[nsc] def list(inPackage: String): ClassPathEntries = {
     val (packages, classesAndSources) = aggregates.map { cp =>
       try {

--- a/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
@@ -45,6 +45,7 @@ trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
       getSubDir(packageDirName)
     }
   }
+  override private[nsc] def hasPackage(pkg: String) = getDirectory(pkg).isDefined
 
   private[nsc] def packages(inPackage: String): Seq[PackageEntry] = {
     val dirForPackage = getDirectory(inPackage)
@@ -157,6 +158,8 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with No
     ps.map(p => (p.toString.stripPrefix("/packages/"), lookup(p))).toMap
   }
 
+  /** Empty string represents root package */
+  override private[nsc] def hasPackage(pkg: String) = packageToModuleBases.contains(pkg)
   override private[nsc] def packages(inPackage: String): Seq[PackageEntry] = {
     def matches(packageDottedName: String) =
       if (packageDottedName.contains("."))

--- a/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
@@ -5,9 +5,10 @@ package scala.tools.nsc.classpath
 
 import java.io.File
 import java.net.URL
+
 import scala.annotation.tailrec
-import scala.reflect.io.{AbstractFile, FileZipArchive, ManifestResources}
-import scala.tools.nsc.util.ClassPath
+import scala.reflect.io.{ AbstractFile, FileZipArchive, ManifestResources }
+import scala.tools.nsc.util.{ClassPath, ClassRepresentation}
 import scala.tools.nsc.Settings
 import FileUtils._
 
@@ -50,7 +51,12 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
 
     override def findClassFile(className: String): Option[AbstractFile] = {
       val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
-      classes(pkg).find(_.name == simpleClassName).map(_.file)
+      file(pkg, simpleClassName + ".class").map(_.file)
+    }
+    // This method is performance sensitive as it is used by SBT's ExtractDependencies phase.
+    override def findClass(className: String): Option[ClassRepresentation] = {
+      val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
+      file(pkg, simpleClassName + ".class")
     }
 
     override private[nsc] def classes(inPackage: String): Seq[ClassFileEntry] = files(inPackage)
@@ -133,6 +139,8 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
         (for (file <- pkg if file.isClass) yield ClassFileEntryImpl(file))(collection.breakOut)
     }
 
+
+    override private[nsc] def hasPackage(pkg: String) = cachedPackages.contains(pkg)
     override private[nsc] def list(inPackage: String): ClassPathEntries = ClassPathEntries(packages(inPackage), classes(inPackage))
   }
 

--- a/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
@@ -40,6 +40,14 @@ trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPa
       entry <- dirEntry.iterator if isRequiredFileType(entry)
     } yield createFileEntry(entry)
 
+  protected def file(inPackage: String, name: String): Option[FileEntryType] =
+    for {
+      dirEntry <- findDirEntry(inPackage)
+      entry <- Option(dirEntry.lookupName(name, directory = false))
+      if isRequiredFileType(entry)
+    } yield createFileEntry(entry)
+
+  override private[nsc] def hasPackage(pkg: String) = findDirEntry(pkg).isDefined
   override private[nsc] def list(inPackage: String): ClassPathEntries = {
     val foundDirEntry = findDirEntry(inPackage)
 
@@ -59,7 +67,7 @@ trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPa
   }
 
   private def findDirEntry(pkg: String): Option[archive.DirEntry] = {
-    val dirName = s"${FileUtils.dirPath(pkg)}/"
+    val dirName = FileUtils.dirPath(pkg) + "/"
     archive.allDirs.get(dirName)
   }
 

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -23,6 +23,7 @@ trait ClassPath {
   def asURLs: Seq[URL]
 
   /** Empty string represents root package */
+  private[nsc] def hasPackage(pkg: String): Boolean
   private[nsc] def packages(inPackage: String): Seq[PackageEntry]
   private[nsc] def classes(inPackage: String): Seq[ClassFileEntry]
   private[nsc] def sources(inPackage: String): Seq[SourceFileEntry]

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -22,19 +22,43 @@ trait ClassPath {
   import scala.tools.nsc.classpath._
   def asURLs: Seq[URL]
 
-  /** Empty string represents root package */
+  /*
+   * These methods are mostly used in the ClassPath implementation to implement the `list` and
+   * `findX` methods below.
+   *
+   * However, there are some other uses in the compiler, to implement `invalidateClassPathEntries`,
+   * which is used by the repl's `:require` (and maybe the spark repl, https://github.com/scala/scala/pull/4051).
+   * Using these methods directly is more efficient than calling `list`.
+   *
+   * The `inPackage` string is a full package name, e.g. "" or "scala.collection".
+   */
+
   private[nsc] def hasPackage(pkg: String): Boolean
   private[nsc] def packages(inPackage: String): Seq[PackageEntry]
   private[nsc] def classes(inPackage: String): Seq[ClassFileEntry]
   private[nsc] def sources(inPackage: String): Seq[SourceFileEntry]
 
-  /** Allows to get entries for packages and classes merged with sources possibly in one pass. */
+  /**
+   * Returns packages and classes (source or classfile) that are members of `inPackage` (not
+   * recursively). The `inPackage` string is a full package name, e.g., "scala.collection".
+   *
+   * This is the main method uses to find classes, see class `PackageLoader`. The
+   * `rootMirror.rootLoader` is created with `inPackage = ""`.
+   */
   private[nsc] def list(inPackage: String): ClassPathEntries
 
   /**
-    * It returns both classes from class file and source files (as our base ClassRepresentation).
-    * So note that it's not so strictly related to findClassFile.
-    */
+   * Returns the class file and / or source file for a given external name, e.g., "java.lang.String".
+   * If there is both a class file and source file, the compiler can decide whether to read the
+   * class file or compile the source file.
+   *
+   * Internally this seems to be used only by `ScriptRunner`, but only to call `.isDefined`. That
+   * could probably be implemented differently.
+   *
+   * Externally, it is used by sbt's compiler interface:
+   * https://github.com/sbt/sbt/blob/v0.13.15/compile/interface/src/main/scala/xsbt/CompilerInterface.scala#L249
+   * Jason has some improvements for that in the works (https://github.com/scala/bug/issues/10289#issuecomment-310022699)
+   */
   def findClass(className: String): Option[ClassRepresentation] = {
     // A default implementation which should be overridden, if we can create the more efficient
     // solution for a given type of ClassPath
@@ -45,6 +69,16 @@ trait ClassPath {
 
     foundClassFromClassFiles orElse findClassInSources
   }
+
+  /**
+   * Returns the classfile for an external name, e.g., "java.lang.String". This method does not
+   * return source files.
+   *
+   * This method is used by the classfile parser. When parsing a Java class, its own inner classes
+   * are entered with a `ClassfileLoader` that parses the classfile returned by this method.
+   * It is also used in the backend, by the inliner, to obtain the bytecode when inlining from the
+   * classpath. It's also used by scalap.
+   */
   def findClassFile(className: String): Option[AbstractFile]
 
   def asClassPathStrings: Seq[String]

--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -91,8 +91,8 @@ abstract class ZipArchive(override val file: JFile) extends AbstractFile with Eq
     override def isDirectory = true
     override def iterator: Iterator[Entry] = entries.valuesIterator
     override def lookupName(name: String, directory: Boolean): Entry = {
-      if (directory) entries(name + "/")
-      else entries(name)
+      if (directory) entries.get(name + "/").orNull
+      else entries.get(name).orNull
     }
   }
 

--- a/test/junit/scala/tools/nsc/classpath/AggregateClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/AggregateClassPathTest.scala
@@ -21,6 +21,7 @@ import scala.tools.nsc.util.ClassPath
 class AggregateClassPathTest {
 
   private abstract class TestClassPathBase extends ClassPath {
+    override private[nsc] def hasPackage(pkg: String) = true
     override def packages(inPackage: String): Seq[PackageEntry] = unsupported
     override def sources(inPackage: String): Seq[SourceFileEntry] = unsupported
     override def classes(inPackage: String): Seq[ClassFileEntry] = unsupported


### PR DESCRIPTION
SBT is a heavy user of `Classpath.findClass`, and its performance regressed, especially for large classpaths, under the new "flat" classpath implementation. The new implementation shipped in 2.11 experimentally (`-YclasspathImpl:flat`), and was promoted to the default an only implementation in 2.12.

In 2.12, the performance was improved some in 0f9a704a71 / #5112. This commit goes further by optimizing the lookup of a given class in a JAR classpath entry, and, most importantly, by avoiding a linear scan of the classpath on each lookup by indexing which classpath entries contribute classes to each package.

I tested a [2.11 backport](https://github.com/retronym/scala/tree/backport/fasterFindClass) of this patch using https://github.com/guardian/frontend as a test case.

Results: https://gist.github.com/3c89c21c54d27e566dec57a16a4bf208

tl;dr; No significant difference in performance between the classpath implementations after this change. The baseline performance was 55s, which regressed to 79s under `-YclasspathImpl:flat` and then progressed back to 55s using the same flat classpath implementation as in this PR.

I've also tried to [patch SBT](https://github.com/sbt/sbt/compare/0.13...retronym:faster-flatclasspath?expand=1) to use `Symbol.associatedFile` rather than scanning the classpath, but I haven't got that change into shape yet.

Fixes scala/bug#10289