### PR TITLE
Classpath improvements

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -7,9 +7,10 @@ package scala
 package tools
 package nsc
 
-import java.io.{File, FileNotFoundException, IOException}
+import java.io._
 import java.net.URL
 import java.nio.charset.{Charset, CharsetDecoder, IllegalCharsetNameException, UnsupportedCharsetException}
+
 import scala.collection.{immutable, mutable}
 import io.{AbstractFile, Path, SourceReader}
 import reporters.Reporter
@@ -27,7 +28,7 @@ import transform.patmat.PatternMatching
 import transform._
 import backend.{JavaPlatform, ScalaPrimitives}
 import backend.jvm.GenBCode
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 import scala.tools.nsc.ast.{TreeGen => AstTreeGen}
 import scala.tools.nsc.classpath._
@@ -831,7 +832,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     def assoc(path: String): Option[(ClassPath, ClassPath)] = {
       def origin(lookup: ClassPath): Option[String] = lookup match {
         case cp: JFileDirectoryLookup[_] => Some(cp.dir.getPath)
-        case cp: ZipArchiveFileLookup[_] => Some(cp.zipFile.getPath)
+        case cp: ZipArchiveFileLookup[_] => Some(cp.rootFile.getPath)
         case _ => None
       }
 
@@ -1076,6 +1077,14 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
   def newJavaUnitParser(unit: CompilationUnit): JavaUnitParser = new JavaUnitParser(unit)
 
+  var exec = ExecutionContext.fromExecutor(null, backgroundError)
+  def backgroundError(t: Throwable) = {
+    val buffer = new StringWriter
+
+    t.printStackTrace(new PrintWriter(buffer))
+    reporter.error(NoPosition, buffer.toString)
+  }
+
   /** A Run is a single execution of the compiler on a set of units.
    */
   class Run extends RunContextApi with RunReporting with RunParsing {
@@ -1151,7 +1160,12 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       curRun = this
       phase = SomePhase
       phaseWithId(phase.id) = phase
-      definitions.init()
+      val exec = Global.this.exec
+      classPath.startInUse(exec, false)
+      try {
+        classPath.makeCacheValid(exec, false)
+        definitions.init()
+      } finally classPath.endInUse()
 
       // the components to use, omitting those named by -Yskip and stopping at the -Ystop phase
       val components = {
@@ -1413,7 +1427,14 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       }
     }
 
-    def compileUnits(units: List[CompilationUnit], fromPhase: Phase): Unit =  compileUnitsInternal(units,fromPhase)
+    def compileUnits(units: List[CompilationUnit], fromPhase: Phase): Unit = {
+      val exec = Global.this.exec
+      classPath.startInUse(exec, true)
+      try {
+        classPath.makeCacheValid(exec,true)
+        compileUnitsInternal(units,fromPhase)
+      } finally classPath.endInUse()
+    }
     private def compileUnitsInternal(units: List[CompilationUnit], fromPhase: Phase) {
       def currentTime = java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime())
 

--- a/src/compiler/scala/tools/nsc/classpath/BasicClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/BasicClassPath.scala
@@ -1,0 +1,393 @@
+package scala.tools.nsc.classpath
+
+import java.io.{File, IOException, InputStream, OutputStream}
+import java.net.URL
+import java.nio.file._
+import java.nio.file.attribute.{BasicFileAttributes, FileTime}
+import java.util.zip.{ZipEntry, ZipFile}
+
+import scala.collection.{Seq, mutable}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.io.AbstractFile
+import scala.tools.nsc.classpath.ClassPathWatcher.{BaseChangeListener, DirectoryChangeListener, FileChangeListener}
+import scala.tools.nsc.util.ClassPath
+
+
+abstract class FileClassPath extends ClassPath {
+
+  val rootFile: File
+
+  assert(rootFile != null, "file cannot be null")
+
+  override final def asURLs: Seq[URL] = Seq(rootFile.toURI.toURL)
+
+  override final def asClassPathStrings: Seq[String] = Seq(rootFile.getPath)
+
+}
+
+abstract class BasicClassPath extends FileClassPath {
+  override private[nsc] final def packages(inPackage: String) = list(inPackage).packages
+}
+
+abstract class CommonClassPath[FileEntryType <: SingleClassRepresentation] extends BasicClassPath {
+  self: TypedClassPath[FileEntryType] =>
+
+  protected type ContentType >: Null <: ClassPathContent[FileEntryType]
+  protected var content: ContentType = _
+
+  /** Allows to get entries for packages and classes merged with sources possibly in one pass. */
+  override private[nsc] def list(inPackage: String) = content.data(inPackage).list
+
+  override private[nsc] def hasPackage(pkg: String) = content.data(pkg).isEmpty
+
+  private[nsc] def files(inPackage: String): Seq[FileEntryType] = content.data(inPackage).files
+
+  //liveness checking and the forwarderes
+  protected val livenessChecker : LivenessChecker
+
+
+  final override def startInUse(executionContext: ExecutionContext, proactive: Boolean) =
+    livenessChecker.startInUse(proactive)
+
+  final override def endInUse(): Unit = livenessChecker.endInUse()
+
+  final override def makeCacheValid(executionContext: ExecutionContext, proactive: Boolean): Long =
+    livenessChecker.validateAndLastModificationTime()
+
+  // liveness checking callabcks
+  // callback are only called with a lock managed by the livenessChecker
+  // and the livenessChecker ensure that content is not null when the classpath is in use
+  private[classpath] def contents:Option[ContentType] = Option(content)
+
+  private[classpath] def markInvalid() = {
+    content = null
+  }
+
+  private[classpath] def ensureContent(proactive: Boolean):ContentType = {
+    contents.getOrElse{
+      content = newContent()
+      if (proactive) {
+        content.reOpen()
+        //TODO - should we move the executors to the policy
+        //should be Ok as long as we can pick up the time in instrumentation
+        // TODO content.startScan()
+      }
+      content
+    }
+  }
+  protected def newContent():ContentType
+
+}
+
+abstract class CommonZipClassPath[FileEntryType <: SingleClassRepresentation](
+               override val rootFile: File, policy:LivenessChecker.ForFile) extends CommonClassPath[FileEntryType] {
+  self: TypedClassPath[FileEntryType] =>
+  type ContentType = ZipArchiveContent[FileEntryType]
+
+  val livenessChecker = policy(this)
+
+  override protected def newContent(): ZipArchiveContent[FileEntryType] = new ZipArchiveContent(rootFile, isValidFilename, toRepr)
+}
+
+
+abstract class CommonDirClassPath[FileEntryType <: SingleClassRepresentation](
+               override val rootFile: File, policy:LivenessChecker.ForDir)
+  extends CommonClassPath[FileEntryType] {
+
+  self: TypedClassPath[FileEntryType] =>
+  type ContentType = DirArchiveContent[FileEntryType]
+
+  val livenessChecker:LivenessChecker = policy(this)
+
+  override protected def newContent(): DirArchiveContent[FileEntryType] =
+    new DirArchiveContent(rootFile, isValidFilename, toRepr, livenessChecker)
+}
+
+class RawZipClassesPath(rootFile: File, policy:LivenessChecker.ForFile)
+  extends CommonZipClassPath[ClassFileEntry](rootFile, policy) with CommonNoSourcesClassPath
+
+class RawZipSourcesPath(rootFile: File, policy:LivenessChecker.ForFile)
+  extends CommonZipClassPath[SourceFileEntry](rootFile, policy) with CommonNoClassesClassPath
+
+class RawDirClassesPath(rootFile: File, policy:LivenessChecker.ForDir)
+  extends CommonDirClassPath[ClassFileEntry](rootFile, policy) with CommonNoSourcesClassPath
+
+class RawDirSourcesPath(rootFile: File, policy:LivenessChecker.ForDir)
+  extends CommonDirClassPath[SourceFileEntry](rootFile, policy) with CommonNoClassesClassPath
+
+abstract class ClassPathContent[FileEntryType <: SingleClassRepresentation](file: File,
+                                                                            isValid: String => Boolean,
+                                                                            toRepr: AbstractFile => FileEntryType) {
+
+  def startScan(executionContext: ExecutionContext): Unit = {
+    Future(data)(executionContext)
+  }
+
+  final lazy val data: Map[String, PackageInfo] = buildData()
+
+  protected def buildData(): Map[String, PackageInfo]
+
+  class PackageInfo(val packageName: String, val list: ClassPathEntries, val files: Seq[FileEntryType], val packages: Seq[PackageEntryImpl]) {
+    lazy val filesByName: Map[String, AbstractFile] = files.map {
+      file => file.name -> file.file
+    }(collection.breakOut)
+
+    def isEmpty :Boolean = list.classesAndSources.isEmpty
+  }
+
+  def reOpen(): Unit
+
+  def close(): Unit
+
+}
+
+class ZipArchiveContent[FileEntryType <: SingleClassRepresentation](zipFile: File,
+                                                                    isValid: String => Boolean,
+                                                                    toRepr: AbstractFile => FileEntryType) extends ClassPathContent(zipFile, isValid, toRepr) {
+  //TODO async
+  override def reOpen():Unit = withOpenZipFile
+
+  def withOpenZipFile() :ZipFile = this.synchronized {
+    zip.getOrElse {
+      val newZip = new ZipFile(zipFile)
+      zip = Some(newZip)
+      newZip
+    }
+  }
+
+  private var zip: Option[ZipFile] = Some(new ZipFile(zipFile))
+
+  //TODO async
+  override def close() = this.synchronized {
+    zip.foreach { z =>
+      z.close()
+    }
+    zip = None
+  }
+
+
+  protected def buildData(): Map[String, PackageInfo] = {
+    //TODO use ser format
+    class MutablePackageInfo(packageName: String) {
+      val packages = Vector.newBuilder[PackageEntryImpl]
+      val files = Vector.newBuilder[FileEntryType]
+
+      def result(): PackageInfo = {
+        val packagesResult = packages.result()
+        val filesResult = files.result()
+        val entries = new ClassPathEntries(packagesResult, filesResult)
+        new PackageInfo(packageName, entries, filesResult, packagesResult)
+      }
+    }
+    val staging = mutable.Map[String, MutablePackageInfo]()
+
+    def getPackageInfo(packageName: String): MutablePackageInfo = {
+      staging.get(packageName) match {
+        case Some(res) => res
+        case None =>
+          val res = new MutablePackageInfo(packageName)
+          staging.update(packageName, res)
+          if (packageName != "") {
+            val parentPackageName = packageName.take(packageName.lastIndexOf('.'))
+            getPackageInfo(parentPackageName).packages += PackageEntryImpl(packageName)
+          }
+          res
+      }
+    }
+
+    this.synchronized {
+      val toClose = if (zip isEmpty) Some(new ZipFile(zipFile)) else None
+      val myZip = zip.orElse(toClose).get
+      try {
+        val entries = myZip.entries()
+        while (entries.hasMoreElements) {
+          val entry = entries.nextElement()
+          val name = entry.getName
+          if (isValid(name)) {
+            val dirSeparator = name.lastIndexOf('/')
+            val packageName = name.take(dirSeparator).replace('/', '.')
+            val fileName = name.substring(dirSeparator + 1, name.lastIndexOf('.'))
+            getPackageInfo(packageName).files += toRepr(new ZipEntryFile(entry))
+          }
+        }
+      } finally toClose foreach (_.close())
+    }
+    val res: Map[String, PackageInfo] = staging.map {
+      case (k, v) => (k -> v.result())
+    }(collection.breakOut)
+    res.withDefaultValue(new PackageInfo("", ClassPathEntries.empty, Nil, Nil))
+  }
+
+  private class ZipEntryFile(private val entry: ZipEntry) extends AbstractFile {
+
+    /** Returns the name of this abstract file. */
+    override val name: String = entry.getName.substring(entry.getName.lastIndexOf('/') + 1)
+
+    /** returns an input stream so the file can be read */
+    override def input: InputStream = try {
+      //      println(s"reading ${entry.getName}")
+      withOpenZipFile().getInputStream(entry)
+    } catch {
+      case t: Throwable =>
+        println(s"failed to read ${ZipArchiveContent.this.zipFile}")
+        t.printStackTrace()
+        throw t
+    }
+
+    override def lastModified: Long = entry.getLastModifiedTime.toMillis
+
+    /** size of this file if it is a concrete file. */
+    //needed to make toByteArray efficient
+    override def sizeOption = Some(entry.getSize.toInt)
+
+
+    //the rest is minimal support from AbstractFile API
+    //used by toString()
+    override def path: String = entry.getName
+
+    override def absolute: AbstractFile = notImplemented
+
+    override def container: AbstractFile = notImplemented
+
+    override def file: File = notImplemented
+
+    override def create(): Unit = notImplemented
+
+    override def delete(): Unit = notImplemented
+
+    override def isDirectory: Boolean = notImplemented
+
+    override def output: OutputStream = notImplemented
+
+    override def iterator: Iterator[AbstractFile] = notImplemented
+
+    override def lookupName(name: String, directory: Boolean): AbstractFile = notImplemented
+
+    override def lookupNameUnchecked(name: String, directory: Boolean): AbstractFile = notImplemented
+
+    private def notImplemented = ???
+
+  }
+
+}
+
+class DirArchiveContent[FileEntryType <: SingleClassRepresentation](rootDir: File,
+                                                                    isValid: String => Boolean,
+                                                                    toRepr: AbstractFile => FileEntryType,
+                                                                    livenessChecker: LivenessChecker)
+  extends ClassPathContent(rootDir, isValid, toRepr) {
+  override def reOpen() = ()
+
+  override def close() = ()
+
+  protected def buildData(): Map[String, PackageInfo] = {
+    livenessChecker.removeAllWatches()
+    //TODO use ser format
+    class MutablePackageInfo(val packageName: String, val parent: MutablePackageInfo) {
+      val packages = Vector.newBuilder[PackageEntryImpl]
+      val files = Vector.newBuilder[FileEntryType]
+
+      def result(): PackageInfo = {
+        val packagesResult = packages.result()
+        val filesResult = files.result()
+        val entries = new ClassPathEntries(packagesResult, filesResult)
+        new PackageInfo(packageName, entries, filesResult, packagesResult)
+      }
+    }
+    val staging = mutable.Map[String, MutablePackageInfo]()
+
+    class DirVisitor extends FileVisitor[Path] {
+      val rootPath = rootDir.toPath
+      var current: MutablePackageInfo = null
+      val resultsBuilder = Map.newBuilder[String, PackageInfo]
+
+      override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
+        if (exc ne null) throw exc
+        val result = current.result()
+        current = current.parent
+        if (!result.isEmpty) {
+          if (current ne null)
+            current.packages += PackageEntryImpl(current.packageName + "." + dir.getFileName.toString)
+          resultsBuilder += ((result.packageName, result))
+        }
+        livenessChecker.addDirWatch(dir)
+        FileVisitResult.CONTINUE
+      }
+
+
+      override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        if (isValid(file.getFileName.toString)) {
+          val name = file.relativize(rootPath).toString
+          val dirSeparator = name.lastIndexOf('/')
+          val packageName = name.take(dirSeparator).replace('/', '.')
+          val fileName = name.substring(dirSeparator + 1, name.lastIndexOf('.'))
+          current.files += toRepr(new PathFile(file, attrs))
+        }
+        FileVisitResult.CONTINUE
+      }
+
+      override def visitFileFailed(file: Path, exc: IOException): FileVisitResult = throw exc
+
+      override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        val name = dir.getFileName.toString
+        if (name.startsWith(".") || name == "META-INF") FileVisitResult.SKIP_SUBTREE
+        else {
+          current = new MutablePackageInfo("", current)
+          FileVisitResult.CONTINUE
+        }
+      }
+    }
+    this.synchronized {
+      val visitor = new DirVisitor
+      Files.walkFileTree(visitor.rootPath, visitor)
+      val res: Map[String, PackageInfo] = staging.map {
+        case (k, v) => (k -> v.result())
+      }(collection.breakOut)
+      res.withDefaultValue(new PackageInfo("", ClassPathEntries.empty, Nil, Nil))
+    }
+  }
+
+  private class PathFile(private val jPath: Path, attr: BasicFileAttributes) extends AbstractFile {
+
+    /** Returns the name of this abstract file. */
+    override val name: String = jPath.getFileSystem.toString
+
+    /** returns an input stream so the file can be read */
+    override def input: InputStream = Files.newInputStream(jPath)
+
+    override def lastModified: Long = attr.lastAccessTime().toMillis
+
+
+    /** size of this file if it is a concrete file. */
+    //needed to make toByteArray efficient
+    override def sizeOption = Some(attr.size().toInt)
+
+    override def absolute: AbstractFile = notImplemented
+
+    override def container: AbstractFile = notImplemented
+
+    override def file: File = notImplemented
+
+    //the rest is minimal support from AbstractFile API
+    //used by toString()
+    override def path: String = jPath.toString
+
+    override def create(): Unit = notImplemented
+
+    override def delete(): Unit = notImplemented
+
+    override def isDirectory: Boolean = notImplemented
+
+    override def output: OutputStream = notImplemented
+
+    override def iterator: Iterator[AbstractFile] = notImplemented
+
+    override def lookupName(name: String, directory: Boolean): AbstractFile = notImplemented
+
+    override def lookupNameUnchecked(name: String, directory: Boolean): AbstractFile = notImplemented
+
+    private def notImplemented = ???
+
+  }
+
+}

--- a/src/compiler/scala/tools/nsc/classpath/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPath.scala
@@ -4,7 +4,7 @@
 package scala.tools.nsc.classpath
 
 import scala.reflect.io.AbstractFile
-import scala.tools.nsc.util.ClassRepresentation
+import scala.tools.nsc.util.{ClassRepresentation, Named}
 
 case class ClassPathEntries(packages: Seq[PackageEntry], classesAndSources: Seq[ClassRepresentation])
 
@@ -12,36 +12,35 @@ object ClassPathEntries {
   import scala.language.implicitConversions
   // to have working unzip method
   implicit def entry2Tuple(entry: ClassPathEntries): (Seq[PackageEntry], Seq[ClassRepresentation]) = (entry.packages, entry.classesAndSources)
+
+  val empty = ClassPathEntries(Seq.empty, Seq.empty)
 }
 
-trait ClassFileEntry extends ClassRepresentation {
+sealed trait SingleClassRepresentation extends ClassRepresentation {
   def file: AbstractFile
 }
+trait ClassFileEntry extends SingleClassRepresentation
 
-trait SourceFileEntry extends ClassRepresentation {
-  def file: AbstractFile
-}
+trait SourceFileEntry extends SingleClassRepresentation
 
-trait PackageEntry {
-  def name: String
-}
+trait PackageEntry extends Named
 
 private[nsc] case class ClassFileEntryImpl(file: AbstractFile) extends ClassFileEntry {
-  override def name = FileUtils.stripClassExtension(file.name) // class name
+  override val name = FileUtils.stripClassExtension(file.name) // class name
 
   override def binary: Option[AbstractFile] = Some(file)
   override def source: Option[AbstractFile] = None
 }
 
 private[nsc] case class SourceFileEntryImpl(file: AbstractFile) extends SourceFileEntry {
-  override def name = FileUtils.stripSourceExtension(file.name)
+  override val name = FileUtils.stripSourceExtension(file.name)
 
   override def binary: Option[AbstractFile] = None
   override def source: Option[AbstractFile] = Some(file)
 }
 
 private[nsc] case class ClassAndSourceFilesEntry(classFile: AbstractFile, srcFile: AbstractFile) extends ClassRepresentation {
-  override def name = FileUtils.stripClassExtension(classFile.name)
+  override val name = FileUtils.stripClassExtension(classFile.name)
 
   override def binary: Option[AbstractFile] = Some(classFile)
   override def source: Option[AbstractFile] = Some(srcFile)
@@ -50,11 +49,11 @@ private[nsc] case class ClassAndSourceFilesEntry(classFile: AbstractFile, srcFil
 private[nsc] case class PackageEntryImpl(name: String) extends PackageEntry
 
 private[nsc] trait NoSourcePaths {
-  def asSourcePathString: String = ""
-  private[nsc] def sources(inPackage: String): Seq[SourceFileEntry] = Seq.empty
+  final def asSourcePathString: String = ""
+  final private[nsc] def sources(inPackage: String): Seq[SourceFileEntry] = Seq.empty
 }
 
 private[nsc] trait NoClassPaths {
-  def findClassFile(className: String): Option[AbstractFile] = None
-  private[nsc] def classes(inPackage: String): Seq[ClassFileEntry] = Seq.empty
+  final def findClassFile(className: String): Option[AbstractFile] = None
+  private[nsc] final def classes(inPackage: String): Seq[ClassFileEntry] = Seq.empty
 }

--- a/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
@@ -3,6 +3,8 @@
  */
 package scala.tools.nsc.classpath
 
+import java.io.File
+
 import scala.reflect.io.{AbstractFile, VirtualDirectory}
 import scala.reflect.io.Path.string2path
 import scala.tools.nsc.Settings
@@ -63,7 +65,8 @@ class ClassPathFactory(settings: Settings) {
     if (file.isJarOrZip)
       ZipAndJarSourcePathFactory.create(file, settings)
     else if (file.isDirectory)
-      DirectorySourcePath(file.file)
+      if (settings.YClassPathRawDir) new RawDirSourcesPath(file.file, ClassPathFactory.dirPolicy(file.file, settings))
+      else new DirectorySourcePath(file.file)
     else
       sys.error(s"Unsupported sourcepath element: $file")
 }
@@ -75,8 +78,18 @@ object ClassPathFactory {
       if (file.isJarOrZip)
         ZipAndJarClassPathFactory.create(file, settings)
       else if (file.isDirectory)
-        DirectoryClassPath(file.file)
+        if (settings.YClassPathRawDir) new RawDirClassesPath(file.file, dirPolicy(file.file, settings))
+        else new DirectoryClassPath(file.file)
       else
         sys.error(s"Unsupported classpath element: $file")
   }
+  def dirPolicy(file:File, settings: Settings): LivenessChecker.ForDir = {
+    //TODO
+    LivenessChecker.FileWatcher
+  }
+  def filePolicy(file:File, settings: Settings): LivenessChecker.ForFile = {
+    //TODO
+    LivenessChecker.FileWatcher
+  }
+
 }

--- a/src/compiler/scala/tools/nsc/classpath/ClassPathWatcher.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPathWatcher.scala
@@ -1,0 +1,195 @@
+package scala.tools.nsc.classpath
+
+import java.util.concurrent.atomic.AtomicReference
+import java.util.{List => JList}
+import java.nio.file._
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+import scala.ref.WeakReference
+
+
+object ClassPathWatcher {
+
+  private val watchServices = mutable.Map[FileSystem, WatchInfo]()
+
+  private val CHANGES = Array[WatchEvent.Kind[_]](
+    StandardWatchEventKinds.ENTRY_CREATE,
+    StandardWatchEventKinds.ENTRY_DELETE,
+    StandardWatchEventKinds.ENTRY_MODIFY
+  )
+
+  private class WatchInfo(fileSystem: FileSystem) extends Runnable{
+    val watcher = fileSystem.newWatchService()
+    private val runningThread = new AtomicReference[Thread]
+
+    val watched = mutable.Map.empty[WatchKey, WeakReference[BaseChangeListener]]
+
+    def addWatch(listener: BaseChangeListener, path:Path): WatchKey = {
+      watched.synchronized {
+        val key = path.register(watcher, CHANGES)
+        watched.put(key, WeakReference(listener))
+        key
+      }
+    }
+    def removeWatch(listener: BaseChangeListener, keys: WatchKey *): Unit =  watched.synchronized  {
+      keys foreach cancel
+    }
+
+    def run(): Unit = {
+      import collection.JavaConverters._
+      while (true) {
+        val changed = watcher.take()
+        val events = changed.pollEvents().asInstanceOf[JList[WatchEvent[Path]]]
+        trace(s"detected a change ${events} - ${changed.watchable} ")
+        if (!changed.isValid) {
+          trace(s"Key invalid")
+          cancel(changed)
+        } else watched.synchronized(watched.get(changed)) match {
+          case Some(WeakReference(callback)) =>
+            callback.changed(changed, events.asScala)
+            if (!changed.isValid) {
+              trace(s"key invalid after callback. key cancelled")
+              cancel(changed)
+            } else changed.reset()
+          case None =>
+            trace(s"No associated watcher. key cancelled")
+            cancel(changed)
+        }
+      }
+    }
+    private def cancel(key:WatchKey) = {
+      key.cancel()
+      watched.synchronized( watched.remove(key))
+    }
+  }
+
+  private def getWatchInfo(path: Path) : WatchInfo = {
+    val fs = path.getFileSystem
+    watchServices.synchronized {watchServices.getOrElseUpdate(fs, new WatchInfo(fs))}
+  }
+
+  //hook to allow toggling of trace driven by settings, so public
+  var tracing = false
+  @inline private[ClassPathWatcher] def trace(msg: => String) {
+    if (tracing) println(s"Watcher - $msg")
+  }
+
+
+  abstract class BaseChangeListener (path:Path) {
+
+    def resumeIfSuspended(): Unit = if (suspended) resume(true)
+
+    private [ClassPathWatcher] def changed(key:WatchKey, events:Seq[WatchEvent[Path]])
+    @volatile private[ClassPathWatcher] var suspended = false
+
+    @tailrec private [ClassPathWatcher] final def clearPendingChanges(key:WatchKey): Unit = {
+      if (!key.pollEvents().isEmpty) clearPendingChanges(key)
+    }
+    protected def resume(clearPending:Boolean): Unit
+  }
+  abstract class FileChangeListener(path: Path) extends BaseChangeListener(path) {
+    require (Files.isRegularFile(path))
+
+    private [ClassPathWatcher]val watchInfo = getWatchInfo(path.getParent)
+    private [ClassPathWatcher]val key = watchInfo.addWatch(this, path.getParent)
+
+    protected override final def finalize(): Unit = {
+      watchInfo.removeWatch(this, key)
+    }
+
+    override final def changed(key: WatchKey, events:Seq[WatchEvent[Path]]): Unit = {
+      import collection.JavaConverters._
+      require(key eq this.key)
+
+      val events: List[WatchEvent[Path]] = key.pollEvents().asScala.collect {
+        case e: WatchEvent[Path] @unchecked if path.endsWith(e.context()) => e
+      }(collection.breakOut)
+
+      if (events.isEmpty) {
+        trace(s"all events are filtered, reset")
+        key.reset()
+      } else if (suspended) {
+        //dont need to record time as it will be reset for resume
+        trace(s"change ignored - suspended, $events")
+      } else {
+        trace(s"change detected, $events")
+        if (fileChanged(events)) {
+          trace(s"resetting")
+          key.reset()
+        } else {
+          trace(s"suspending")
+          suspended = true
+        }
+      }
+    }
+
+    /**
+      * inform the listener that the file has changed
+      * @param events the changes
+      * @return true to continue monitoring, false to suspend monitoring until the next call to {{{resume()}}}
+      */
+    protected def fileChanged(events:List[WatchEvent[Path]]) : Boolean
+
+    final def resume(clearPending:Boolean): Unit = {
+      suspended = false
+      if (clearPending) clearPendingChanges(key)
+      key.reset()
+    }
+  }
+
+  abstract class DirectoryChangeListener(path: Path) extends BaseChangeListener(path) {
+    require (Files.isDirectory(path))
+
+    private [ClassPathWatcher]val watchInfo = getWatchInfo(path.getParent)
+    private [ClassPathWatcher]val keysToPath = mutable.Map.empty[WatchKey, Path]
+
+    protected override final def finalize(): Unit = {
+      watchInfo.removeWatch(this, keysToPath.keySet.toSeq : _*)
+    }
+
+    def addDirWatch(path:Path): Unit = keysToPath.synchronized{
+      val key = watchInfo.addWatch(this, path)
+      keysToPath(key) = path
+    }
+    def removeAllWatches(): Unit = keysToPath.synchronized{
+      watchInfo.removeWatch(this, keysToPath.keySet.toSeq : _*)
+      keysToPath.clear()
+    }
+
+    override final def changed(key: WatchKey, events:Seq[WatchEvent[Path]]): Unit = keysToPath.synchronized{
+      import collection.JavaConverters._
+      val path = keysToPath(key)
+      val events:List[WatchEvent[Path]] = key.pollEvents().asScala.map{case e: WatchEvent[Path] @unchecked => e}(collection.breakOut)
+
+      if (suspended) {
+        //dont need to record time as it will be reset for resume
+        trace(s"change ignored - suspended, $events")
+      } else {
+        trace(s"change detected, $events")
+        if (dirChanged(path, events)) {
+          trace(s"resetting")
+          key.reset()
+        } else {
+          trace(s"suspending")
+          suspended = true
+        }
+      }
+    }
+
+    /**
+      * inform the listener that chnages have occured to a directory
+      * @param path the directory that changed
+      * @param events the changes
+      * @return true to continue monitoring, false to suspend monitoring until the next call to {{{resume()}}}
+      */
+    protected def dirChanged(path:Path, events:List[WatchEvent[Path]]) : Boolean
+
+    final def resume(clearPending:Boolean): Unit = keysToPath.synchronized{
+      suspended = false
+      if (clearPending) keysToPath.keys foreach clearPendingChanges
+
+      keysToPath.keys.foreach {_.reset()}
+    }
+  }
+}

--- a/src/compiler/scala/tools/nsc/classpath/FileUtils.scala
+++ b/src/compiler/scala/tools/nsc/classpath/FileUtils.scala
@@ -32,8 +32,11 @@ object FileUtils {
   implicit class FileOps(val file: JFile) extends AnyVal {
     def isPackage: Boolean = file.isDirectory && mayBeValidPackage(file.getName)
 
-    def isClass: Boolean = file.isFile && file.getName.endsWith(".class")
+    def isClass: Boolean = file.isFile && file.getName.endsWith(SUFFIX_CLASS)
   }
+  private val SUFFIX_CLASS = ".class"
+  private val SUFFIX_SCALA = ".scala"
+  private val SUFFIX_JAVA = ".java"
 
   def stripSourceExtension(fileName: String): String = {
     if (endsScala(fileName)) stripClassExtension(fileName)
@@ -43,23 +46,25 @@ object FileUtils {
 
   def dirPath(forPackage: String) = forPackage.replace('.', '/')
 
+  private def ends (filename:String, suffix:String) = filename.endsWith(suffix) && filename.length > suffix.length
+
   def endsClass(fileName: String): Boolean =
-    fileName.length > 6 && fileName.substring(fileName.length - 6) == ".class"
+    ends (fileName, SUFFIX_CLASS)
 
   def endsScalaOrJava(fileName: String): Boolean =
     endsScala(fileName) || endsJava(fileName)
 
   def endsJava(fileName: String): Boolean =
-    fileName.length > 5 && fileName.substring(fileName.length - 5) == ".java"
+    ends (fileName, SUFFIX_JAVA)
 
   def endsScala(fileName: String): Boolean =
-    fileName.length > 6 && fileName.substring(fileName.length - 6) == ".scala"
+    ends (fileName, SUFFIX_SCALA)
 
   def stripClassExtension(fileName: String): String =
-    fileName.substring(0, fileName.length - 6) // equivalent of fileName.length - ".class".length
+    fileName.substring(0, fileName.length - 6) // equivalent of fileName.length - SUFFIX_CLASS.length
 
   def stripJavaExtension(fileName: String): String =
-    fileName.substring(0, fileName.length - 5)
+    fileName.substring(0, fileName.length - 5) // equivalent of fileName.length - SUFFIX_JAVA.length
 
   // probably it should match a pattern like [a-z_]{1}[a-z0-9_]* but it cannot be changed
   // because then some tests in partest don't pass

--- a/src/compiler/scala/tools/nsc/classpath/ModificationDetection.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ModificationDetection.scala
@@ -1,0 +1,188 @@
+package scala.tools.nsc.classpath
+
+import java.nio.file.{Files, Path, WatchEvent}
+import java.nio.file.attribute.BasicFileAttributes
+import scala.tools.nsc.classpath.ClassPathWatcher._
+
+
+
+trait LivenessChecker {
+
+  def startInUse(proactive:Boolean) :Unit
+
+  def endInUse() :Unit
+
+  def validateAndLastModificationTime():Long
+
+  def removeAllWatches(): Unit = ()
+
+  def addDirWatch(dir:Path): Unit = ()
+
+}
+object LivenessChecker {
+  sealed trait ForDir {
+    def apply(classPath : CommonDirClassPath[_]) : LivenessChecker
+  }
+  sealed trait ForFile {
+    def apply(classPath : CommonZipClassPath[_]) : LivenessChecker
+  }
+  /**
+    * Policy to assume that the resource cannot change - useful for jar in maven repos and simple one off compiles
+   */
+  case object Static extends ForDir with ForFile{
+
+    override def apply(classPath: CommonZipClassPath[_]): LivenessChecker = init(classPath)
+
+    override def apply(classPath: CommonDirClassPath[_]): LivenessChecker = init(classPath)
+    private def init(classPath: CommonClassPath[_]) = {
+      classPath.ensureContent(true)
+      StaticLivenessChecker
+    }
+
+    private object StaticLivenessChecker extends LivenessChecker{
+      override def startInUse(proactive: Boolean): Unit = ()
+
+      override def endInUse(): Unit = ()
+
+      override def validateAndLastModificationTime(): Long = 0L
+    }
+  }
+  /**
+    * Policy to assume that the resource has changed when examined, if not already in use
+    * use where watcher doesnt work
+    */
+  case object NotMonitored extends ForDir with ForFile{
+    override def apply(classPath: CommonZipClassPath[_]): LivenessChecker =
+      new NotMonitoredLivenessChecker(classPath)
+
+    override def apply(classPath: CommonDirClassPath[_]): LivenessChecker =
+      new NotMonitoredLivenessChecker(classPath)
+
+    private class NotMonitoredLivenessChecker(classPath: CommonClassPath[_]) extends UsageTrackedLivenessChecker(classPath){
+      var lastCacheTime = System.nanoTime()
+      override def doStartInUse(proactive: Boolean): Unit = {
+        classPath.ensureContent(proactive)
+      }
+
+      override def doEndInUse(): Unit = {
+        classPath.markInvalid()
+        lastCacheTime = System.nanoTime()
+      }
+
+      override def validateAndLastModificationTime(): Long = lastCacheTime
+    }
+  }
+
+  case object SizeAndDateWatcher extends ForFile {
+    override def apply(classPath: CommonZipClassPath[_]):LivenessChecker = new SizeAndDateLivenessChecker(classPath)
+
+    private class SizeAndDateLivenessChecker(classPath: CommonZipClassPath[_]) extends UsageTrackedLivenessChecker(classPath){
+      val path = classPath.rootFile.toPath
+
+      private var lastCacheTime = 0L
+
+      private var fileInfo = Option.empty[BasicFileAttributes]
+
+      /**
+        * although [[doStartInUse]] is guaranteed to externally only be called once, the implementation is safe
+        * as masked with BasicAttributtes check, so we call that to encorage early opening of the file in background
+        */
+      doStartInUse(true)
+
+      override def doStartInUse(proactive: Boolean): Unit = {
+        val newAttributes = Files.readAttributes(path, classOf[BasicFileAttributes])
+        val stillValid = fileInfo exists {
+          oldAttributes => oldAttributes.size() == newAttributes.size() && oldAttributes.lastModifiedTime() == newAttributes.lastModifiedTime()
+        }
+        if (!stillValid) {
+          lastCacheTime = System.nanoTime()
+          fileInfo = Some(newAttributes)
+          classPath.markInvalid()
+          classPath.ensureContent(proactive)
+        }
+      }
+
+      override def validateAndLastModificationTime(): Long = lastCacheTime
+    }
+  }
+  case object FileWatcher extends ForDir with ForFile {
+    override def apply(classPath: CommonDirClassPath[_]):LivenessChecker = new DirWatcherFileLivenessChecker(classPath)
+
+    override def apply(classPath: CommonZipClassPath[_]):LivenessChecker = new FileWatcherFileLivenessChecker(classPath)
+
+    private abstract class FileWatcherLivenessChecker(classPath: CommonClassPath[_]) extends UsageTrackedLivenessChecker(classPath) {
+
+      protected var lastCacheTime = 0L
+
+      /**
+        * although [[doStartInUse]] is guaranteed to externally only be called once, the implementation is safe
+        * as masked with BasicAttributtes check, so we call that to encorage early opening of the file in background
+        */
+      override final def doStartInUse(proactive: Boolean): Unit = {
+        if (classPath.contents.isEmpty) {
+          fileChangeListener.resumeIfSuspended()
+          lastCacheTime = System.nanoTime()
+          classPath.ensureContent(proactive)
+        }
+      }
+
+      override def validateAndLastModificationTime(): Long = lastCacheTime
+
+      protected val fileChangeListener : BaseChangeListener
+    }
+    private class FileWatcherFileLivenessChecker(override val classPath: CommonZipClassPath[_]) extends FileWatcherLivenessChecker(classPath) {
+
+      protected override object fileChangeListener extends FileChangeListener(classPath.rootFile.toPath) {
+        override protected def fileChanged(events: List[WatchEvent[Path]]) =
+          FileWatcherFileLivenessChecker.this.synchronized {
+            classPath.markInvalid()
+            false
+          }
+      }
+    }
+    //similar to FileWatcherFileLivenessChecker, but has potential oppertunities to detect which directories have changed
+    //with changes to the classpath
+    private class DirWatcherFileLivenessChecker(override val classPath: CommonDirClassPath[_]) extends FileWatcherLivenessChecker(classPath) {
+
+      protected override object fileChangeListener extends DirectoryChangeListener(classPath.rootFile.toPath) {
+        override protected def dirChanged(path: Path, events: List[WatchEvent[Path]]) =
+          DirWatcherFileLivenessChecker.this.synchronized {
+            classPath.markInvalid()
+            false
+          }
+      }
+
+      override def removeAllWatches(): Unit = {
+        fileChangeListener.removeAllWatches()
+      }
+      override def addDirWatch(dir:Path): Unit = {
+        fileChangeListener.addDirWatch(dir)
+      }
+
+    }
+  }
+
+  abstract class UsageTrackedLivenessChecker(protected val classPath:CommonClassPath[_]) extends LivenessChecker {
+
+    protected final var inUseCount = 0
+    protected final val lock = new Object
+
+    protected def doStartInUse(proactive: Boolean): Unit
+    protected def doEndInUse(): Unit = ()
+
+    final override def startInUse(proactive: Boolean): Unit = lock.synchronized {
+      inUseCount += 1
+      if (inUseCount == 1)
+        doStartInUse(proactive)
+    }
+
+    final override def endInUse(): Unit = lock.synchronized {
+      inUseCount -= 1
+      if (inUseCount == 0) {
+        classPath.contents.foreach (_.close())
+
+        doEndInUse()
+      }
+    }
+  }
+}

--- a/src/compiler/scala/tools/nsc/classpath/TypedClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/TypedClassPath.scala
@@ -1,0 +1,44 @@
+package scala.tools.nsc.classpath
+
+import scala.reflect.io.AbstractFile
+
+sealed trait TypedClassPath[FileEntryType <: SingleClassRepresentation] extends BasicClassPath {
+  protected def isValidFilename(fileName:String):Boolean
+  protected def toRepr(abstractFile: AbstractFile):FileEntryType
+
+}
+
+trait BasicNoSourcesClassPath extends TypedClassPath[ClassFileEntry] with NoSourcePaths {
+  override protected final def isValidFilename(fileName: String): Boolean = fileName.endsWith(".class")
+  override protected final def toRepr(abstractFile: AbstractFile): ClassFileEntryImpl = ClassFileEntryImpl(abstractFile)
+}
+
+trait BasicNoClassesClassPath extends TypedClassPath[SourceFileEntry] with NoClassPaths{
+  override protected final def isValidFilename(fileName: String): Boolean =
+    fileName.endsWith(".java") || fileName.endsWith(".scala")
+
+  override protected final def toRepr(abstractFile: AbstractFile): SourceFileEntryImpl = SourceFileEntryImpl(abstractFile)
+
+}
+
+trait CommonNoSourcesClassPath extends BasicNoSourcesClassPath {
+  self : CommonClassPath[ClassFileEntry] =>
+
+  override private[nsc] def classes(inPackage: String) = files(inPackage)
+
+  override def findClassFile(className: String): Option[AbstractFile] = {
+    val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
+    content.data(pkg).filesByName.get(simpleClassName)
+  }
+
+
+
+}
+trait CommonNoClassesClassPath extends BasicNoClassesClassPath {
+  self : CommonClassPath[SourceFileEntry] =>
+  override private[nsc] def sources(inPackage: String) = files(inPackage)
+
+  /** The whole sourcepath in the form of one String.
+    */
+  override def asSourcePathString: String = asClassPathString
+}

--- a/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
@@ -3,11 +3,9 @@
  */
 package scala.tools.nsc.classpath
 
-import java.io.File
-import java.net.URL
-import scala.collection.Seq
-import scala.reflect.io.AbstractFile
-import scala.reflect.io.FileZipArchive
+
+import scala.collection.{Seq, mutable}
+import scala.reflect.io.{AbstractFile, FileZipArchive}
 import FileUtils.AbstractFileOps
 import scala.tools.nsc.util.{ClassPath, ClassRepresentation}
 
@@ -16,15 +14,10 @@ import scala.tools.nsc.util.{ClassPath, ClassRepresentation}
  * It provides common logic for classes handling class and source files.
  * It's aware of things like e.g. META-INF directory which is correctly skipped.
  */
-trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
-  val zipFile: File
+trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends FileClassPath {
+  assert(rootFile != null, "Zip file in ZipArchiveFileLookup cannot be null")
 
-  assert(zipFile != null, "Zip file in ZipArchiveFileLookup cannot be null")
-
-  override def asURLs: Seq[URL] = Seq(zipFile.toURI.toURL)
-  override def asClassPathStrings: Seq[String] = Seq(zipFile.getPath)
-
-  private val archive = new FileZipArchive(zipFile)
+  private val archive = new FileZipArchive(rootFile)
 
   override private[nsc] def packages(inPackage: String): Seq[PackageEntry] = {
     val prefix = PackageNameUtils.packagePrefix(inPackage)
@@ -63,7 +56,7 @@ trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPa
           fileBuf += createFileEntry(entry)
       }
       ClassPathEntries(pkgBuf, fileBuf)
-    } getOrElse ClassPathEntries(Seq.empty, Seq.empty)
+    } getOrElse ClassPathEntries.empty
   }
 
   private def findDirEntry(pkg: String): Option[archive.DirEntry] = {
@@ -73,4 +66,5 @@ trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPa
 
   protected def createFileEntry(file: FileZipArchive#Entry): FileEntryType
   protected def isRequiredFileType(file: AbstractFile): Boolean
+
 }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -421,6 +421,15 @@ trait ScalaSettings extends AbsScalaSettings
     })
   val Xexperimental = BooleanSetting("-Xexperimental", "Enable experimental extensions.") enablingIfNotSetByUser experimentalSettings
 
+  // classpath caching
+  val YClassPathCacheJarsSize = IntSetting("-Yclasspath-jar-cache-size", "Maximum size of the jar cache", 2000, Some(1, 20000), (_: String) => None)
+  val YClassPathCacheJars     = BooleanSetting("-Yclasspath-jar-cache-enabled", "Enable cache of individual jars and zips, including across compiles")
+  val YClassPathTopPrefetch   = BooleanSetting("-Yclasspath-top-prefetch", "Enable full classpath cache prefetch in a background thread")
+  val YClassPathCache         = BooleanSetting("-Yclasspath-cache-enabled", "Enable cache of the compile class path")
+  val YClassPathRawJar        = BooleanSetting("-Yclasspath-raw-jar", "use alternative jar classpath")
+  val YClassPathRawDir        = BooleanSetting("-Yclasspath-raw-dir", "use alternative dir classpath")
+
+
   // Feature extensions
   val XmacroSettings          = MultiStringSetting("-Xmacro-settings", "option", "Custom settings for macros.")
 

--- a/src/compiler/scala/tools/nsc/util/CachedClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/CachedClassPath.scala
@@ -1,0 +1,219 @@
+package scala.tools.nsc.util
+
+import java.net.URL
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+
+import scala.annotation.tailrec
+import scala.concurrent.{ExecutionContext, Future}
+import scala.tools.nsc.classpath._
+import scala.tools.nsc.io.AbstractFile
+import scala.collection.{mutable, Set => SSet}
+
+
+/**
+  * factory for classpath where some result are cached
+  */
+object CachedClassPath {
+  def apply(classPath:ClassPath): CachedClassPath = {
+    classPath match {
+      case cachedAlready: CachedClassPath => cachedAlready
+      case noSources: ClassPath with NoSourcePaths => CachedNoSourcesClassPath(noSources)
+      case noClasses: ClassPath with NoClassPaths => CachedNoClassesClassPath(noClasses)
+      case other: ClassPath => CachedAnyClassPath(other)
+    }
+  }
+  private case class CachedNoSourcesClassPath(underlying:ClassPath with NoSourcePaths) extends
+    ClassesCachedClassPath with NoSourcePaths
+
+  private case class CachedNoClassesClassPath(underlying:ClassPath with NoClassPaths) extends
+    SourcesCachedClassPath with NoClassPaths
+
+  private case class CachedAnyClassPath(underlying:ClassPath) extends
+    ClassesCachedClassPath with SourcesCachedClassPath
+
+  sealed trait CachedClassPath extends ClassPath {
+    protected val underlying: ClassPath
+
+    override def hashCode(): Int = underlying.hashCode() * 31
+
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case cached: CachedClassPath => (cached eq this) || (cached.getClass == getClass && (cached.underlying eq underlying))
+      case _ => false
+    }
+    override final lazy val asClassPathStrings: Seq[String] = underlying.asClassPathStrings
+    override final lazy val asURLs: Seq[URL] = underlying.asURLs
+
+    private val packagesCache = new CachedLazyMapping(underlying.packages, Nil)
+
+    override private[nsc] def hasPackage(pkg: String) = packagesCache(pkg).isEmpty
+
+    override private[nsc] final def packages(inPackage: String) = packagesCache(inPackage)
+
+    private val listCache = new CachedLazyMapping(underlying.list, ClassPathEntries.empty)
+    override private[nsc] final def list(inPackage: String) = listCache(inPackage)
+
+    // preetching status. Cant just roll this into an AtomicInteger though
+    // -2 => prefetch not requested
+    // -1 => cache valid but incomplete
+    // 0 => cache complete
+    // +ve number of prefetch requests pending
+    // critical atomic actions are synchronized on packagesCache
+    private var prefetchStatus = -2
+
+    def startPrefetch(exec: ExecutionContext): Option[Future[Unit]] = packagesCache.synchronized {
+      if (prefetchStatus < 0) {
+        prefetchStatus = 1
+        Some(Future(revalidateNow)(exec))
+      }
+      else None
+    }
+
+    @tailrec private def revalidateNow(): Unit = {
+      val initialState = packagesCache.synchronized(prefetchStatus)
+      println(s"start prefetch $this - prefetchStatus = $initialState")
+      val all = mutable.Set[String]()
+
+      def load(names: Iterable[PackageEntry]): Unit = {
+        names foreach { p =>
+          all += p.name
+          load(packages(p.name))
+        }
+      }
+
+      load(packages(""))
+      val cachedMappins = mappings
+      cachedMappins foreach { mapping =>
+        all.foreach(mapping.apply)
+      }
+      val retry = packagesCache.synchronized {
+        if (prefetchStatus == initialState) {
+          cachedMappins foreach { mapping =>
+            mapping.markComplete()
+            mapping.optimise()
+          }
+          false
+        } else true
+      }
+      if (retry) revalidateNow()
+    }
+
+    def mappings: List[BaseCachedLazyMapping[_]] = packagesCache :: listCache :: Nil
+
+    protected def stats = s"stats packages${packagesCache.stats} list${listCache.stats}"
+
+    override def toString: String = s"${getClass.getSimpleName} $underlying $stats"
+
+    override def startInUse(executionContext: ExecutionContext, proactive:Boolean): Unit = underlying.startInUse(executionContext, proactive)
+
+    override def endInUse(): Unit = underlying.endInUse()
+
+    var lastCacheValidTime = 0L
+
+    override def makeCacheValid(executionContext: ExecutionContext, proactive:Boolean) = {
+      val valid = underlying.makeCacheValid(executionContext, proactive)
+      if (valid > lastCacheValidTime) listCache.synchronized {
+        val cachedMappings = mappings
+        // clear the cache
+        cachedMappings foreach { _.reset()}
+        prefetchStatus match {
+          case -1 | -2 if !proactive =>
+            //do nothing
+          case -1 | -2 =>
+            prefetchStatus = 1
+            startPrefetch(executionContext)
+          case 0 =>
+            if (proactive) {
+              prefetchStatus = 1
+              startPrefetch(executionContext)
+            } else {
+              prefetchStatus = -2
+            }
+          case _ =>
+            //someone is working on it, but it may be updated, so cause a re-cycle
+            prefetchStatus += 1
+        }
+        lastCacheValidTime = valid
+      }
+      valid
+    }
+  }
+  private sealed trait ClassesCachedClassPath extends CachedClassPath {
+
+    private val classesCache = new CachedLazyMapping(underlying.classes, Nil)
+    override private[nsc] final def classes(inPackage: String) = classesCache(inPackage)
+
+    override def findClassFile(className: String): Option[AbstractFile] = underlying.findClassFile(className)
+
+    override def mappings: List[BaseCachedLazyMapping[_]] = classesCache :: super.mappings
+
+    override protected def stats = s"${super.stats} classes${classesCache.stats}"
+  }
+  private sealed trait SourcesCachedClassPath  extends CachedClassPath{
+
+    private val sourcesCache = new CachedLazyMapping(underlying.sources, Nil)
+    override private[nsc] def sources(inPackage: String) = sourcesCache(inPackage)
+
+    override lazy val asSourcePathString: String = underlying.asSourcePathString
+
+    override def mappings: List[BaseCachedLazyMapping[_]] = sourcesCache :: super.mappings
+
+    override protected def stats = s"${super.stats} sources${sourcesCache.stats}"
+  }
+
+}
+
+/**
+  * a Cached implementation of a mapping. This has to be threadsafe as a classpath may be cached and reused in a JVM
+  * @tparam V
+  */
+abstract class BaseCachedLazyMapping[V <: AnyRef] {
+
+  @volatile protected var complete = false
+  protected val cache: ConcurrentHashMap[String,_]
+
+  protected val hits = new AtomicInteger
+  protected val misses = new AtomicInteger
+  protected val defaulted = new AtomicInteger
+
+  def apply(key:String): V
+  def markComplete(): Unit = {
+    this.complete = true
+  }
+  def optimise()
+  def stats = s"H$hits M$misses D$defaulted"
+  def reset() :Unit = {
+    cache.clear()
+    complete = false
+  }
+}
+class CachedLazyMapping[V <: AnyRef] (miss : (String => V), defaultValue: V ) extends BaseCachedLazyMapping[V] {
+  override protected val cache =  new ConcurrentHashMap[String,V]
+
+  def apply(key:String): V = {
+    //note - order dependent. Must be before we check the cache
+    val alreadyComplete = complete
+    val cached = cache.get(key)
+    if (cached ne null) {
+      hits.incrementAndGet()
+      cached
+    } else if (alreadyComplete) {
+      defaulted.incrementAndGet()
+      defaultValue
+    } else {
+      misses.incrementAndGet()
+      val missed = miss(key)
+      val existing = cache.putIfAbsent(key, missed)
+      if (existing ne null) existing else missed
+    }
+  }
+  override def optimise : Unit = {
+    //remove the default values
+    //cant use cache.values.remove(All), they only remove a single instance
+    val it = cache.entrySet().iterator()
+    while (it.hasNext()) {
+      val curr = it.next()
+      if (curr.getValue == defaultValue) it.remove()
+    }
+  }
+}

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -14,6 +14,7 @@ import java.util.regex.PatternSyntaxException
 
 import File.pathSeparator
 import Jar.isJarOrZip
+import scala.concurrent.ExecutionContext
 
 /**
   * A representation of the compiler's class- or sourcepath.
@@ -93,6 +94,19 @@ trait ClassPath {
   /** The whole sourcepath in the form of one String.
     */
   def asSourcePathString: String
+
+
+  def startInUse(executionContext: ExecutionContext, proactive:Boolean) = ()
+  def endInUse() = ()
+
+  /**
+    * make some upstream cache valid, and perform to initial work if the underlying data may have changed
+    * return value is used by upstream caches to resync
+    * @param executionContext for any background work to be done
+    * @param proactive a hint as to whether to expend effort
+    * @return the time of the last known or possible change.
+    */
+  def makeCacheValid(executionContext: ExecutionContext, proactive:Boolean):Long = System.nanoTime()
 }
 
 object ClassPath {
@@ -169,9 +183,11 @@ object ClassPath {
   @deprecated("shim for sbt's compiler interface", since = "2.12.0")
   sealed abstract class JavaContext
 }
-
-trait ClassRepresentation {
+trait Named {
   def name: String
+}
+
+trait ClassRepresentation extends Named {
   def binary: Option[AbstractFile]
   def source: Option[AbstractFile]
 }

--- a/src/reflect/scala/reflect/io/Path.scala
+++ b/src/reflect/scala/reflect/io/Path.scala
@@ -37,10 +37,7 @@ object Path {
     ext == "jar" || ext == "zip"
   }
   def extension(name: String): String = {
-    var i = name.length - 1
-    while (i >= 0 && name.charAt(i) != '.')
-      i -= 1
-
+    val i = name.lastIndexOf('.')
     if (i < 0) ""
     else name.substring(i + 1).toLowerCase
   }


### PR DESCRIPTION
This PR provides a series of improvements to classpath handling

**12% reduced CPU, 23% reduction in allocation** overall based on the figures in comments below

- A clean implementation of ClassPath without  AbstractFile dependencies in the implementation ( still required in the specification though)
- Improvements to the data structures in the classpath implementation to facilitate efficient scanning and caching
- All new Classpath implementation allow for caching on lookups avoiding expensive aggregation and/or file access
- no locks maintained o ZipFiles to aid windows IDEs
- Use of NIO to speed file access
- Ability to scan files and dirs in background threads as this is not AST affecting


I had intended to do some more work on the prior to PR but as @retronym opened https://github.com/scala/scala/pull/5956 it seems worthwhile to combine these 2 approaches

