### PR TITLE
implicit error formatter analyzer plugin

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
@@ -10,7 +10,7 @@ package typechecker
  *  @author Lukas Rytz
  *  @version 1.0
  */
-trait AnalyzerPlugins { self: Analyzer =>
+trait AnalyzerPlugins { self: Analyzer with ImplicitChains =>
   import global._
 
   trait AnalyzerPlugin {
@@ -160,7 +160,7 @@ trait AnalyzerPlugins { self: Analyzer =>
      * @param tree The tree that requested the implicit
      * @param param The implicit parameter that was resolved
      */
-    def noImplicitFoundError(tree: Tree, param: Symbol): Option[String] = None
+    def noImplicitFoundError(param: Symbol, errors: List[ImpFailReason]): Option[String] = None
   }
 
   /**
@@ -358,10 +358,10 @@ trait AnalyzerPlugins { self: Analyzer =>
   })
 
   /** @see AnalyzerPlugin.noImplicitFoundError */
-  def pluginsNoImplicitFoundError(tree: Tree, param: Symbol): Option[String] =
+  def pluginsNoImplicitFoundError(param: Symbol, errors: List[ImpFailReason]): Option[String] =
     invoke(new CumulativeOp[Option[String]] {
       def default = None
-      def accumulate = (tpe, p) => p.noImplicitFoundError(tree, param)
+      def accumulate = (tpe, p) => p.noImplicitFoundError(param, errors)
     })
 
   /** A list of registered macro plugins */

--- a/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
@@ -153,6 +153,14 @@ trait AnalyzerPlugins { self: Analyzer =>
      * @param pt    The return type of the enclosing method
      */
     def pluginsTypedReturn(tpe: Type, typer: Typer, tree: Return, pt: Type): Type = tpe
+
+    /**
+     * Construct a custom error message for implicit parameters that could not be resolved.
+     *
+     * @param tree The tree that requested the implicit
+     * @param param The implicit parameter that was resolved
+     */
+    def noImplicitFoundError(tree: Tree, param: Symbol): Option[String] = None
   }
 
   /**
@@ -348,6 +356,13 @@ trait AnalyzerPlugins { self: Analyzer =>
     def default = adaptTypeOfReturn(tree.expr, pt, tpe)
     def accumulate = (tpe, p) => p.pluginsTypedReturn(tpe, typer, tree, pt)
   })
+
+  /** @see AnalyzerPlugin.noImplicitFoundError */
+  def pluginsNoImplicitFoundError(tree: Tree, param: Symbol): Option[String] =
+    invoke(new CumulativeOp[Option[String]] {
+      def default = None
+      def accumulate = (tpe, p) => p.noImplicitFoundError(tree, param)
+    })
 
   /** A list of registered macro plugins */
   private var macroPlugins: List[MacroPlugin] = Nil

--- a/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
@@ -160,7 +160,7 @@ trait AnalyzerPlugins { self: Analyzer with ImplicitChains =>
      * @param tree The tree that requested the implicit
      * @param param The implicit parameter that was resolved
      */
-    def noImplicitFoundError(param: Symbol, errors: List[ImpFailReason]): Option[String] = None
+    def noImplicitFoundError(param: Symbol, errors: List[ImplicitError]): Option[String] = None
 
     /**
      * Construct a custom message for found/required errors
@@ -366,7 +366,7 @@ trait AnalyzerPlugins { self: Analyzer with ImplicitChains =>
   })
 
   /** @see AnalyzerPlugin.noImplicitFoundError */
-  def pluginsNoImplicitFoundError(param: Symbol, errors: List[ImpFailReason]): Option[String] =
+  def pluginsNoImplicitFoundError(param: Symbol, errors: List[ImplicitError]): Option[String] =
     invoke(new CumulativeOp[Option[String]] {
       def default = None
       def accumulate = (tpe, p) => p.noImplicitFoundError(param, errors)

--- a/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
@@ -161,6 +161,14 @@ trait AnalyzerPlugins { self: Analyzer with ImplicitChains =>
      * @param param The implicit parameter that was resolved
      */
     def noImplicitFoundError(param: Symbol, errors: List[ImpFailReason]): Option[String] = None
+
+    /**
+     * Construct a custom message for found/required errors
+     *
+     * @param found actual type
+     * @param req expected type
+     */
+    def foundReqMsg(found: Type, req: Type): Option[String] = None
   }
 
   /**
@@ -362,6 +370,13 @@ trait AnalyzerPlugins { self: Analyzer with ImplicitChains =>
     invoke(new CumulativeOp[Option[String]] {
       def default = None
       def accumulate = (tpe, p) => p.noImplicitFoundError(param, errors)
+    })
+
+  /** @see AnalyzerPlugin.foundReqMsg */
+  def pluginsFoundReqMsg(found: Type, req: Type): Option[String] =
+    invoke(new CumulativeOp[Option[String]] {
+      def default = None
+      def accumulate = (tpe, p) => p.foundReqMsg(found, req)
     })
 
   /** A list of registered macro plugins */

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -159,8 +159,17 @@ trait ContextErrors {
         case _ => s"could not find implicit value for $evOrParam $paramTp"
       }
     }
-    val errMsg = pluginsNoImplicitFoundError(tree, param).getOrElse(defaultErrMsg)
-    issueNormalTypeError(tree, errMsg)
+    if (!nestedImplicit) {
+      val errMsg = pluginsNoImplicitFoundError(param, implicitErrors).getOrElse(defaultErrMsg)
+      issueNormalTypeError(tree, errMsg)
+    }
+    else {
+      implicitTypeStack
+        .headOption
+        .map(ImpError(_, tree, implicitNesting, param))
+        .foreach(err => implicitErrors = err :: implicitErrors)
+        issueNormalTypeError(tree, defaultErrMsg)
+    }
   }
 
   trait TyperContextErrors {

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -146,7 +146,7 @@ trait ContextErrors {
     MacroIncompatibleEngineError("macro cannot be expanded, because it was compiled by an incompatible macro engine", internalMessage)
 
   def NoImplicitFoundError(tree: Tree, param: Symbol)(implicit context: Context): Unit = {
-    def errMsg = {
+    def defaultErrMsg = {
       val paramName = param.name
       val paramTp = param.tpe
       def evOrParam = (
@@ -159,6 +159,7 @@ trait ContextErrors {
         case _ => s"could not find implicit value for $evOrParam $paramTp"
       }
     }
+    val errMsg = pluginsNoImplicitFoundError(tree, param).getOrElse(defaultErrMsg)
     issueNormalTypeError(tree, errMsg)
   }
 

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -159,16 +159,16 @@ trait ContextErrors {
         case _ => s"could not find implicit value for $evOrParam $paramTp"
       }
     }
-    if (!nestedImplicit) {
-      val errMsg = pluginsNoImplicitFoundError(param, implicitErrors).getOrElse(defaultErrMsg)
+    if (!ImplicitError.nested) {
+      val errMsg = pluginsNoImplicitFoundError(param, ImplicitError.errors).getOrElse(defaultErrMsg)
       issueNormalTypeError(tree, errMsg)
     }
     else {
-      implicitTypeStack
+      ImplicitError.stack
         .headOption
-        .map(ImpError(_, tree, implicitNesting, param))
-        .foreach(err => implicitErrors = err :: implicitErrors)
-        issueNormalTypeError(tree, defaultErrMsg)
+        .map(ImplicitError.NotFound(_, tree, ImplicitError.nesting, param))
+        .foreach(err => ImplicitError.push(err))
+      issueNormalTypeError(tree, defaultErrMsg)
     }
   }
 

--- a/test/files/run/splain.check
+++ b/test/files/run/splain.check
@@ -1,3 +1,3 @@
-newSource1.scala:40: error: no implicit for value e
-  implicitly[T1]
+newSource1.scala:13: error: no implicit for value e; chains: g, i1, i1, g, i1, i1
+  implicitly[II]
             ^

--- a/test/files/run/splain.check
+++ b/test/files/run/splain.check
@@ -1,0 +1,3 @@
+newSource1.scala:40: error: no implicit for value e
+  implicitly[T1]
+            ^

--- a/test/files/run/splain.check
+++ b/test/files/run/splain.check
@@ -1,3 +1,7 @@
 newSource1.scala:13: error: no implicit for value e; chains: g, i1, i1, g, i1, i1
   implicitly[II]
             ^
+newSource1.scala:17: error: type mismatch
+found: ImplicitChain.I1, req: ImplicitChain.I2
+  f(a)
+    ^

--- a/test/files/run/splain.check
+++ b/test/files/run/splain.check
@@ -1,7 +1,10 @@
 newSource1.scala:13: error: no implicit for value e; chains: g, i1, i1, g, i1, i1
   implicitly[II]
             ^
-newSource1.scala:17: error: type mismatch
-found: ImplicitChain.I1, req: ImplicitChain.I2
-  f(a)
+newSource1.scala:6: error: type mismatch
+found: FoundReq.L, req: FoundReq.R
+  f(new L)
     ^
+newSource1.scala:7: error: no implicit for value e; chains: g: [Bounds.Arg/type A, Nothing/type B], g: [Bounds.Arg/type A, Nothing/type B]
+  implicitly[F[Arg]]
+            ^

--- a/test/files/run/splain.scala
+++ b/test/files/run/splain.scala
@@ -1,0 +1,70 @@
+import scala.tools.partest._
+import scala.tools.nsc._
+
+object Test
+extends DirectTest
+{
+  override def extraSettings: String = "-usejavacp"
+
+  def code = """
+object types
+{
+  class ***[A, B]
+  class >:<[A, B]
+  class C
+  trait D
+}
+import types._
+
+trait Low
+{
+  trait I1
+  trait I2
+  trait I3
+  trait I4
+  trait F[X[_]]
+  implicit def lowI1: I1 = ???
+  implicit def lowI2: I2 = ???
+}
+
+object ImplicitChain
+extends Low
+{
+  type T1 = C *** D >:< (C with D { type A = D; type B = C })
+  type T2 = D *** ((C >:< C) *** (D => Unit))
+  type T3 = (D *** (C *** String)) >:< ((C, D, C) *** D)
+  type T4 = C *** D *** C
+  type T5 = D *** C >:< D
+  type T7 = D >:< C >:< D
+  implicit def i1(implicit impPar7: I3): I1 = ???
+  implicit def i2a(implicit impPar8: I3): I2 = ???
+  implicit def i2b(implicit impPar8: I3): I2 = ???
+  implicit def i4(implicit impPar9: I2): I4 = ???
+  implicit def t7(implicit impPar14: F[({type λ[X] = Either[Int, X]})#λ]): T7 = ???
+  implicit def t4(implicit impPar12: T5): T4 = ???
+  implicit def t3a(implicit impPar11: T7): T3 = ???
+  implicit def t3b(implicit impPar10: T4): T3 = ???
+  implicit def f(implicit impPar4: I4, impPar2: T3): T2 = ???
+  implicit def g(implicit impPar3: I1, impPar1: T2): T1 = ???
+  implicitly[T1]
+}
+  """.trim
+
+
+  def show() {
+    val global = newCompiler()
+    import global._
+    import analyzer._
+
+    object analyzerPlugin extends AnalyzerPlugin {
+      override def noImplicitFoundError(tree: Tree, param: Symbol): Option[String] = {
+        Some(s"no implicit for $param")
+      }
+
+    }
+
+    addAnalyzerPlugin(analyzerPlugin)
+    compileString(global)(code)
+  }
+
+}

--- a/test/files/run/splain.scala
+++ b/test/files/run/splain.scala
@@ -1,5 +1,4 @@
 import scala.tools.partest._
-import scala.tools.nsc._
 
 object Test
 extends DirectTest
@@ -7,46 +6,19 @@ extends DirectTest
   override def extraSettings: String = "-usejavacp"
 
   def code = """
-object types
-{
-  class ***[A, B]
-  class >:<[A, B]
-  class C
-  trait D
-}
-import types._
-
-trait Low
+object ImplicitChain
 {
   trait I1
   trait I2
   trait I3
   trait I4
-  trait F[X[_]]
-  implicit def lowI1: I1 = ???
-  implicit def lowI2: I2 = ???
-}
-
-object ImplicitChain
-extends Low
-{
-  type T1 = C *** D >:< (C with D { type A = D; type B = C })
-  type T2 = D *** ((C >:< C) *** (D => Unit))
-  type T3 = (D *** (C *** String)) >:< ((C, D, C) *** D)
-  type T4 = C *** D *** C
-  type T5 = D *** C >:< D
-  type T7 = D >:< C >:< D
+  trait II
   implicit def i1(implicit impPar7: I3): I1 = ???
   implicit def i2a(implicit impPar8: I3): I2 = ???
   implicit def i2b(implicit impPar8: I3): I2 = ???
   implicit def i4(implicit impPar9: I2): I4 = ???
-  implicit def t7(implicit impPar14: F[({type λ[X] = Either[Int, X]})#λ]): T7 = ???
-  implicit def t4(implicit impPar12: T5): T4 = ???
-  implicit def t3a(implicit impPar11: T7): T3 = ???
-  implicit def t3b(implicit impPar10: T4): T3 = ???
-  implicit def f(implicit impPar4: I4, impPar2: T3): T2 = ???
-  implicit def g(implicit impPar3: I1, impPar1: T2): T1 = ???
-  implicitly[T1]
+  implicit def g(implicit impPar3: I1, impPar1: I4): II = ???
+  implicitly[II]
 }
   """.trim
 
@@ -57,14 +29,13 @@ extends Low
     import analyzer._
 
     object analyzerPlugin extends AnalyzerPlugin {
-      override def noImplicitFoundError(tree: Tree, param: Symbol): Option[String] = {
-        Some(s"no implicit for $param")
+      override def noImplicitFoundError(param: Symbol, errors: List[ImpFailReason]): Option[String] = {
+        val chain = errors.map(_.candidateName).mkString(", ")
+        Some(s"no implicit for $param; chains: $chain")
       }
-
     }
 
     addAnalyzerPlugin(analyzerPlugin)
     compileString(global)(code)
   }
-
 }

--- a/test/files/run/splain.scala
+++ b/test/files/run/splain.scala
@@ -50,11 +50,11 @@ object Bounds
     import analyzer._
 
     object analyzerPlugin extends AnalyzerPlugin {
-      override def noImplicitFoundError(param: Symbol, errors: List[ImpFailReason]): Option[String] = {
+      override def noImplicitFoundError(param: Symbol, errors: List[ImplicitError]): Option[String] = {
         val chain = errors
           .map {
-            case a @ ImpError(_, _, _, _) => a.candidateName
-            case b @ NonConfBounds(_, _, _, a, p) =>
+            case a @ ImplicitError.NotFound(_, _, _, _) => a.candidateName
+            case b @ ImplicitError.NonconformantBounds(_, _, _, a, p, _) =>
               val diff = a.zip(p).map { case (l, r) => s"$l/$r" }.mkString("[", ", ", "]")
               s"${b.candidateName}: $diff"
           }

--- a/test/files/run/splain.scala
+++ b/test/files/run/splain.scala
@@ -19,6 +19,10 @@ object ImplicitChain
   implicit def i4(implicit impPar9: I2): I4 = ???
   implicit def g(implicit impPar3: I1, impPar1: I4): II = ???
   implicitly[II]
+
+  val a = new I1 {}
+  def f(b: I2) = ???
+  f(a)
 }
   """.trim
 
@@ -32,6 +36,10 @@ object ImplicitChain
       override def noImplicitFoundError(param: Symbol, errors: List[ImpFailReason]): Option[String] = {
         val chain = errors.map(_.candidateName).mkString(", ")
         Some(s"no implicit for $param; chains: $chain")
+      }
+
+      override def foundReqMsg(found: Type, req: Type): Option[String] = {
+        Some(s"\nfound: $found, req: $req")
       }
     }
 


### PR DESCRIPTION
This is a port of the implicit chain caching functionality of https://github.com/tek/splain and adds two analyzer plugin hooks with which splain can inject the detailed errors into the compiler.

While resolving implicits, these changes push the involved types onto a stack each time a nested implicit resolution begins, removing successful ones afterwards and sending the complete list to the analyzer plugin in the case of an error.
Both regular implicit errors and nonconformant bounds errors are mixed in the stack.

As a second feature, found/required errors are filtered through the analyzer plugin.

See the examples in the splain readme for a visualization.

Please advise on making this conformant to the project standards.

The PR can be tested with splain by publishing locally and checking out the branch at https://github.com/tek/splain/tree/analyzer_plugin . Either run the tests or publish locally to try it with a real project.