### PR TITLE
continue supporting Exceptional.unwrap for now

### DIFF
--- a/src/compiler/scala/tools/nsc/util/Exceptional.scala
+++ b/src/compiler/scala/tools/nsc/util/Exceptional.scala
@@ -15,4 +15,8 @@ object Exceptional {
 
     case _ => x
   }
+  // partest still uses the old name.  once we re-in-source partest we
+  // can get rid of this, but in the meantime, we'd rather not branch
+  // partest just because one method got renamed
+  def unwrap(x: Throwable): Throwable = rootCause(x)
 }


### PR DESCRIPTION
since not having it is breaking building partest during bootstrap,
and it's not worth branching partest over