### PR TITLE
New setting `-opt-inline-from` to control where to inline from

### DIFF
--- a/project/ScriptCommands.scala
+++ b/project/ScriptCommands.scala
@@ -20,7 +20,7 @@ object ScriptCommands {
     ) ++ (args match {
       case Seq(url) => publishTarget(url)
       case Nil => Nil
-    }) ++ noDocs ++ enableOptimizer
+    }) ++ noDocs ++ enableOptimizerOldFlag
   }
 
   /** Set up the environment for `validate/test`.
@@ -31,7 +31,7 @@ object ScriptCommands {
     ) ++ (args match {
       case Seq(url) => Seq(resolvers in Global += "scala-pr" at url)
       case Nil => Nil
-    }) ++ enableOptimizer
+    }) ++ enableOptimizerNewFlags
   }
 
   /** Set up the environment for building STARR in `validate/bootstrap`. The arguments are:
@@ -41,7 +41,7 @@ object ScriptCommands {
     Seq(
       baseVersion in Global := ver,
       baseVersionSuffix in Global := "SPLIT"
-    ) ++ publishTarget(url) ++ noDocs ++ enableOptimizer
+    ) ++ publishTarget(url) ++ noDocs ++ enableOptimizerOldFlag
   }
 
   /** Set up the environment for building locker in `validate/bootstrap`. The arguments are:
@@ -52,7 +52,7 @@ object ScriptCommands {
       baseVersion in Global := ver,
       baseVersionSuffix in Global := "SPLIT",
       resolvers in Global += "scala-pr" at url
-    ) ++ publishTarget(url) ++ noDocs ++ enableOptimizer
+    ) ++ publishTarget(url) ++ noDocs ++ enableOptimizerOldFlag
   }
 
   /** Set up the environment for building quick in `validate/bootstrap`. The arguments are:
@@ -64,7 +64,7 @@ object ScriptCommands {
       baseVersionSuffix in Global := "SPLIT",
       resolvers in Global += "scala-pr" at url,
       testOptions in IntegrationTest in LocalProject("test") ++= Seq(Tests.Argument("--show-log"), Tests.Argument("--show-diff"))
-    ) ++ publishTarget(url) ++ enableOptimizer
+    ) ++ publishTarget(url) ++ enableOptimizerNewFlags
   }
 
   /** Set up the environment for publishing in `validate/bootstrap`. The arguments are:
@@ -81,7 +81,7 @@ object ScriptCommands {
       publishTo in Global := Some("sonatype-releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"),
       credentials in Global += Credentials(Path.userHome / ".credentials-sonatype"),
       pgpPassphrase in Global := Some(Array.empty)
-    ) ++ enableOptimizer
+    ) ++ enableOptimizerNewFlags
   }
 
   private[this] def setup(name: String)(f: Seq[String] => Seq[Setting[_]]) =
@@ -92,8 +92,13 @@ object ScriptCommands {
     logLevel in update in ThisBuild := Level.Warn
   )
 
-  private[this] val enableOptimizer = Seq(
-    scalacOptions in Compile in ThisBuild += "-opt:l:classpath"
+  // TODO: remove this once the STARR accepts the new flags
+  private[this] val enableOptimizerOldFlag = Seq(
+    scalacOptions in Compile in ThisBuild ++= Seq("-opt:l:classpath")
+  )
+
+  private[this] val enableOptimizerNewFlags = Seq(
+    scalacOptions in Compile in ThisBuild ++= Seq("-opt:l:inline", "-opt-inline-from", "scala/**")
   )
 
   private[this] val noDocs = Seq(

--- a/project/ScriptCommands.scala
+++ b/project/ScriptCommands.scala
@@ -98,7 +98,7 @@ object ScriptCommands {
   )
 
   private[this] val enableOptimizerNewFlags = Seq(
-    scalacOptions in Compile in ThisBuild ++= Seq("-opt:l:inline", "-opt-inline-from", "scala/**")
+    scalacOptions in Compile in ThisBuild ++= Seq("-opt:l:inline", "-opt-inline-from:scala/**")
   )
 
   private[this] val noDocs = Seq(

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1295,7 +1295,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       unitbuf += unit
       compiledFiles += unit.source.file.path
     }
-    private def warnDeprecatedAndConflictingSettings(unit: CompilationUnit) {
+    private def warnDeprecatedAndConflictingSettings() {
       // issue warnings for any usage of deprecated settings
       settings.userSetSettings filter (_.isDeprecated) foreach { s =>
         currentRun.reporting.deprecationWarning(NoPosition, s.name + " is deprecated: " + s.deprecationMessage.get, "")
@@ -1396,7 +1396,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     def compileSources(sources: List[SourceFile]) = if (!reporter.hasErrors) {
 
       def checkDeprecations() = {
-        warnDeprecatedAndConflictingSettings(newCompilationUnit(""))
+        warnDeprecatedAndConflictingSettings()
         reporting.summarizeErrors()
       }
 
@@ -1418,7 +1418,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       val startTime = currentTime
 
       reporter.reset()
-      warnDeprecatedAndConflictingSettings(unitbuf.head)
+      warnDeprecatedAndConflictingSettings()
       globalPhase = fromPhase
 
       while (globalPhase.hasNext && !reporter.hasErrors) {

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
@@ -387,7 +387,7 @@ class CallGraph[BT <: BTypes](val btypes: BT) {
                           calleeInfoWarning: Option[CalleeInfoWarning]) {
     override def toString = s"Callee($calleeDeclarationClass.${callee.name})"
 
-    def canInlineFromSource = inlinerHeuristics.canInlineFromSource(sourceFilePath)
+    def canInlineFromSource = inlinerHeuristics.canInlineFromSource(sourceFilePath, calleeDeclarationClass.internalName)
     def isAbstract = isAbstractMethod(callee)
     def isSpecialMethod = isConstructor(callee) || isNativeMethod(callee) || hasCallerSensitiveAnnotation(callee)
 

--- a/src/compiler/scala/tools/nsc/settings/AbsScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/AbsScalaSettings.scala
@@ -38,6 +38,6 @@ trait AbsScalaSettings {
   def OutputSetting(outputDirs: OutputDirs, default: String): OutputSetting
   def PathSetting(name: String, descr: String, default: String): PathSetting
   def PhasesSetting(name: String, descr: String, default: String): PhasesSetting
-  def StringSetting(name: String, helpArg: String, descr: String, default: String): StringSetting
+  def StringSetting(name: String, helpArg: String, descr: String, default: String, helpText: Option[String] = None): StringSetting
   def PrefixSetting(name: String, prefix: String, descr: String): PrefixSetting
 }

--- a/src/compiler/scala/tools/nsc/settings/AbsScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/AbsScalaSettings.scala
@@ -33,7 +33,7 @@ trait AbsScalaSettings {
   def ChoiceSetting(name: String, helpArg: String, descr: String, choices: List[String], default: String, choicesHelp: List[String] = Nil): ChoiceSetting
   def ChoiceSettingForcedDefault(name: String, helpArg: String, descr: String, choices: List[String], default: String, choicesHelp: List[String] = Nil): ChoiceSetting
   def IntSetting(name: String, descr: String, default: Int, range: Option[(Int, Int)], parser: String => Option[Int]): IntSetting
-  def MultiStringSetting(name: String, helpArg: String, descr: String): MultiStringSetting
+  def MultiStringSetting(name: String, helpArg: String, descr: String, helpText: Option[String] = None): MultiStringSetting
   def MultiChoiceSetting[E <: MultiChoiceEnumeration](name: String, helpArg: String, descr: String, domain: E, default: Option[List[String]]): MultiChoiceSetting[E]
   def OutputSetting(outputDirs: OutputDirs, default: String): OutputSetting
   def PathSetting(name: String, descr: String, default: String): PathSetting

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -307,8 +307,26 @@ trait ScalaSettings extends AbsScalaSettings
   val optInlineFrom = StringSetting(
     "-opt-inline-from",
     "patterns",
-    "Classfile name patterns from which to allow inlining. ** = anything, * = package or class name, ! to exclude. Example: scala.**:!scala.Predef$:corp.*.util.*:corp.**.*Util*",
-    "")
+    "Patterns for classfile names from which to allow inlining, `help` for details.",
+    "",
+    helpText = Some(
+      """Patterns for classfile names from which the inliner is allowed to pull in code.
+        |  *              Matches classes in the empty package
+        |  **             All classes
+        |  a.C            Class a.C
+        |  a.*            Classes in package a
+        |  a.**           Classes in a and in sub-packages of a
+        |  **.Util        Classes named Util in any package (including the empty package)
+        |  a.**.*Util*    Classes in a and sub-packages with Util in their name (including a.Util)
+        |  a.C$D          The nested class D defined in class a.C
+        |  scala.Predef$  The scala.Predef object
+        |
+        |The setting accepts a colon-separated list of patterns. A leading `!` marks a pattern excluding.
+        |The last matching pattern defines whether a classfile is included or excluded (default: excluded).
+        |For example, `a.**:!a.b.**` includes classes in a and sub-packages, but not in a.b and sub-packages.
+        |
+        |Note: on the command-line you might need to quote patterns containing `*` to prevent the shell
+        |from expanding it to a list of files in the current directory.""".stripMargin))
 
   val YoptInlineHeuristics = ChoiceSetting(
     name = "-Yopt-inline-heuristics",

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -234,23 +234,36 @@ trait ScalaSettings extends AbsScalaSettings
     val boxUnbox                = Choice("box-unbox",                 "Eliminate box-unbox pairs within the same method (also tuples, xRefs, value class instances). Enables unreachable-code.")
     val nullnessTracking        = Choice("nullness-tracking",         "Track nullness / non-nullness of local variables and apply optimizations.")
     val closureInvocations      = Choice("closure-invocations" ,      "Rewrite closure invocations to the implementation method.")
-    val inlineProject           = Choice("inline-project",            "Inline only methods defined in the files being compiled. Enables unreachable-code.")
-    val inlineGlobal            = Choice("inline-global",             "Inline methods from any source, including classfiles on the compile classpath. Enables unreachable-code.")
+    val inline                  = Choice("inline",                    "Inline method invocations according to -Yopt-inline-heuristics and -opt-inlnie-from.")
 
     // note: unlike the other optimizer levels, "l:none" appears up in the `opt.value` set because it's not an expanding option (expandsTo is empty)
-    val lNone           = Choice("l:none",      "Disable optimizations. Takes precedence: `-opt:l:none,+box-unbox` / `-opt:l:none -opt:box-unbox` don't enable box-unbox.")
+    val lNone = Choice("l:none",
+      "Disable optimizations. Takes precedence: `-opt:l:none,+box-unbox` / `-opt:l:none -opt:box-unbox` don't enable box-unbox.")
 
     private val defaultChoices = List(unreachableCode)
-    val lDefault        = Choice("l:default",   "Enable default optimizations: "+ defaultChoices.mkString("", ",", "."),                                    expandsTo = defaultChoices)
+    val lDefault = Choice(
+      "l:default",
+      "Enable default optimizations: " + defaultChoices.mkString("", ",", "."),
+      expandsTo = defaultChoices)
 
     private val methodChoices = List(unreachableCode, simplifyJumps, compactLocals, copyPropagation, redundantCasts, boxUnbox, nullnessTracking, closureInvocations)
-    val lMethod         = Choice("l:method",    "Enable intra-method optimizations: "+ methodChoices.mkString("", ",", "."),                                expandsTo = methodChoices)
+    val lMethod = Choice(
+      "l:method",
+      "Enable intra-method optimizations: " + methodChoices.mkString("", ",", "."),
+      expandsTo = methodChoices)
 
-    private val projectChoices = List(lMethod, inlineProject)
-    val lProject        = Choice("l:project",   "Enable cross-method optimizations within the current project: "+ projectChoices.mkString("", ",", "."),    expandsTo = projectChoices)
+    private val inlineChoices = List(lMethod, inline)
+    val lInline = Choice("l:inline",
+      "Enable cross-method optimizations: " + inlineChoices.mkString("", ",", "."),
+      expandsTo = inlineChoices)
 
-    private val classpathChoices = List(lProject, inlineGlobal)
-    val lClasspath      = Choice("l:classpath", "Enable cross-method optimizations across the entire classpath: "+ classpathChoices.mkString("", ",", "."), expandsTo = classpathChoices)
+    val lProject = Choice(
+      "l:project",
+      "[deprecated, use -opt:l:inline, -opt-inlnie-from] Enable cross-method optimizations within the current project.")
+
+    val lClasspath = Choice(
+      "l:classpath",
+      "[deprecated, use -opt:l:inline, -opt-inlnie-from] Enable cross-method optimizations across the entire classpath.")
   }
 
   // We don't use the `default` parameter of `MultiChoiceSetting`: it specifies the default values
@@ -260,7 +273,11 @@ trait ScalaSettings extends AbsScalaSettings
     name = "-opt",
     helpArg = "optimization",
     descr = "Enable optimizations",
-    domain = optChoices)
+    domain = optChoices).withPostSetHook(s => {
+    import optChoices._
+    if (!s.value.contains(inline) && (s.value.contains(lProject) || s.value.contains(lClasspath)))
+        s.enable(lInline)
+    })
 
   private def optEnabled(choice: optChoices.Choice) = {
     !opt.contains(optChoices.lNone) && {
@@ -278,13 +295,20 @@ trait ScalaSettings extends AbsScalaSettings
   def optBoxUnbox                = optEnabled(optChoices.boxUnbox)
   def optNullnessTracking        = optEnabled(optChoices.nullnessTracking)
   def optClosureInvocations      = optEnabled(optChoices.closureInvocations)
+  def optInlinerEnabled          = optEnabled(optChoices.inline)
 
-  def optInlineProject           = optEnabled(optChoices.inlineProject)
-  def optInlineGlobal            = optEnabled(optChoices.inlineGlobal)
-  def optInlinerEnabled          = optInlineProject || optInlineGlobal
+  // deprecated inliner levels
+  def optLProject                = optEnabled(optChoices.lProject)
+  def optLClasspath              = optEnabled(optChoices.lClasspath)
 
   def optBuildCallGraph          = optInlinerEnabled || optClosureInvocations
   def optAddToBytecodeRepository = optBuildCallGraph || optInlinerEnabled || optClosureInvocations
+
+  val optInlineFrom = StringSetting(
+    "-opt-inline-from",
+    "patterns",
+    "Classfile name patterns from which to allow inlining. ** = anything, * = package or class name, ! to exclude. Example: scala.**:!scala.Predef$:corp.*.util.*:corp.**.*Util*",
+    "")
 
   val YoptInlineHeuristics = ChoiceSetting(
     name = "-Yopt-inline-heuristics",
@@ -360,8 +384,11 @@ trait ScalaSettings extends AbsScalaSettings
   val future        = BooleanSetting("-Xfuture", "Turn on future language features.") enablingIfNotSetByUser futureSettings
   val optimise      = BooleanSetting("-optimise", "Compiler flag for the optimizer in Scala 2.11")
     .withAbbreviation("-optimize")
-    .withDeprecationMessage("In 2.12, -optimise enables -opt:l:classpath. Check -opt:help for using the Scala 2.12 optimizer.")
-    .withPostSetHook(_ => opt.tryToSet(List(optChoices.lClasspath.name)))
+    .withDeprecationMessage("In 2.12, -optimise enables -opt:l:inline -opt-inline-from **. Check -opt:help for using the Scala 2.12 optimizer.")
+    .withPostSetHook(_ => {
+      opt.enable(optChoices.lInline)
+      optInlineFrom.value = "**"
+    })
   val Xexperimental = BooleanSetting("-Xexperimental", "Enable experimental extensions.") enablingIfNotSetByUser experimentalSettings
 
   // Feature extensions
@@ -405,6 +432,11 @@ trait ScalaSettings extends AbsScalaSettings
     }
     */
 
-    None
+    if (opt.value.contains(optChoices.lProject))
+      Some("-opt:l:project is deprecated, use -opt:l:inline and -opt-inlnie-from")
+    else if (opt.value.contains(optChoices.lClasspath))
+      Some("-opt:l:classpath is deprecated, use -opt:l:inline and -opt-inlnie-from")
+    else
+      None
   }
 }

--- a/test/benchmarks/build.sbt
+++ b/test/benchmarks/build.sbt
@@ -1,6 +1,6 @@
 scalaHome := Some(file("../../build/pack"))
 scalaVersion := "2.12.1-dev"
-scalacOptions ++= Seq("-feature", "-opt:l:classpath")
+scalacOptions ++= Seq("-feature", "-opt:l:inline", "-opt-inline-from", "**")
 
 lazy val root = (project in file(".")).
   enablePlugins(JmhPlugin).

--- a/test/benchmarks/build.sbt
+++ b/test/benchmarks/build.sbt
@@ -1,6 +1,6 @@
 scalaHome := Some(file("../../build/pack"))
 scalaVersion := "2.12.1-dev"
-scalacOptions ++= Seq("-feature", "-opt:l:inline", "-opt-inline-from", "**")
+scalacOptions ++= Seq("-feature", "-opt:l:inline", "-opt-inline-from:**")
 
 lazy val root = (project in file(".")).
   enablePlugins(JmhPlugin).

--- a/test/files/instrumented/inline-in-constructors.flags
+++ b/test/files/instrumented/inline-in-constructors.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/instrumented/inline-in-constructors.flags
+++ b/test/files/instrumented/inline-in-constructors.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/neg/inlineIndyLambdaPrivate.flags
+++ b/test/files/neg/inlineIndyLambdaPrivate.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from ** -Yopt-inline-heuristics:everything -opt-warnings:_ -Xfatal-warnings
+-opt:l:inline -opt-inline-from:** -Yopt-inline-heuristics:everything -opt-warnings:_ -Xfatal-warnings

--- a/test/files/neg/inlineIndyLambdaPrivate.flags
+++ b/test/files/neg/inlineIndyLambdaPrivate.flags
@@ -1,1 +1,1 @@
--opt:l:classpath -Yopt-inline-heuristics:everything -opt-warnings:_ -Xfatal-warnings
+-opt:l:inline -opt-inline-from ** -Yopt-inline-heuristics:everything -opt-warnings:_ -Xfatal-warnings

--- a/test/files/neg/inlineMaxSize.flags
+++ b/test/files/neg/inlineMaxSize.flags
@@ -1,1 +1,1 @@
--Ydelambdafy:method -opt:l:classpath -opt-warnings -Xfatal-warnings
+-Ydelambdafy:method -opt:l:inline -opt-inline-from ** -opt-warnings -Xfatal-warnings

--- a/test/files/neg/inlineMaxSize.flags
+++ b/test/files/neg/inlineMaxSize.flags
@@ -1,1 +1,1 @@
--Ydelambdafy:method -opt:l:inline -opt-inline-from ** -opt-warnings -Xfatal-warnings
+-Ydelambdafy:method -opt:l:inline -opt-inline-from:** -opt-warnings -Xfatal-warnings

--- a/test/files/neg/optimiseDeprecated.check
+++ b/test/files/neg/optimiseDeprecated.check
@@ -1,4 +1,4 @@
-warning: -optimise is deprecated: In 2.12, -optimise enables -opt:l:classpath. Check -opt:help for using the Scala 2.12 optimizer.
+warning: -optimise is deprecated: In 2.12, -optimise enables -opt:l:inline -opt-inline-from **. Check -opt:help for using the Scala 2.12 optimizer.
 error: No warnings can be incurred under -Xfatal-warnings.
 one warning found
 one error found

--- a/test/files/neg/optimiseDeprecated.check
+++ b/test/files/neg/optimiseDeprecated.check
@@ -1,4 +1,4 @@
-warning: -optimise is deprecated: In 2.12, -optimise enables -opt:l:inline -opt-inline-from **. Check -opt:help for using the Scala 2.12 optimizer.
+warning: -optimise is deprecated: In 2.12, -optimise enables -opt:l:inline -opt-inline-from:**. Check -opt:help for using the Scala 2.12 optimizer.
 error: No warnings can be incurred under -Xfatal-warnings.
 one warning found
 one error found

--- a/test/files/neg/sealed-final-neg.flags
+++ b/test/files/neg/sealed-final-neg.flags
@@ -1,1 +1,1 @@
--Xfatal-warnings -opt:l:inline -opt-inline-from ** -opt-warnings
+-Xfatal-warnings -opt:l:inline -opt-inline-from:** -opt-warnings

--- a/test/files/neg/sealed-final-neg.flags
+++ b/test/files/neg/sealed-final-neg.flags
@@ -1,1 +1,1 @@
--Xfatal-warnings -opt:l:project -opt-warnings
+-Xfatal-warnings -opt:l:inline -opt-inline-from ** -opt-warnings

--- a/test/files/pos/inline-access-levels.flags
+++ b/test/files/pos/inline-access-levels.flags
@@ -1,1 +1,1 @@
--opt:l:classpath -Xfatal-warnings -opt-warnings
+-opt:l:inline -opt-inline-from ** -Xfatal-warnings -opt-warnings

--- a/test/files/pos/inline-access-levels.flags
+++ b/test/files/pos/inline-access-levels.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from ** -Xfatal-warnings -opt-warnings
+-opt:l:inline -opt-inline-from:** -Xfatal-warnings -opt-warnings

--- a/test/files/pos/t3234.flags
+++ b/test/files/pos/t3234.flags
@@ -1,1 +1,1 @@
--opt:l:project -opt-warnings -Xfatal-warnings
+-opt:l:inline -opt-inline-from ** -opt-warnings -Xfatal-warnings

--- a/test/files/pos/t3234.flags
+++ b/test/files/pos/t3234.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from ** -opt-warnings -Xfatal-warnings
+-opt:l:inline -opt-inline-from:** -opt-warnings -Xfatal-warnings

--- a/test/files/pos/t3420.flags
+++ b/test/files/pos/t3420.flags
@@ -1,1 +1,1 @@
--opt-warnings -opt:l:classpath -Xfatal-warnings
+-opt-warnings -opt:l:inline -opt-inline-from ** -Xfatal-warnings

--- a/test/files/pos/t3420.flags
+++ b/test/files/pos/t3420.flags
@@ -1,1 +1,1 @@
--opt-warnings -opt:l:inline -opt-inline-from ** -Xfatal-warnings
+-opt-warnings -opt:l:inline -opt-inline-from:** -Xfatal-warnings

--- a/test/files/pos/t4840.flags
+++ b/test/files/pos/t4840.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/pos/t4840.flags
+++ b/test/files/pos/t4840.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/pos/t8410.flags
+++ b/test/files/pos/t8410.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from ** -Xfatal-warnings -deprecation:false -opt-warnings:none
+-opt:l:inline -opt-inline-from:** -Xfatal-warnings -deprecation:false -opt-warnings:none

--- a/test/files/pos/t8410.flags
+++ b/test/files/pos/t8410.flags
@@ -1,1 +1,1 @@
--opt:l:project -Xfatal-warnings -deprecation:false -opt-warnings:none
+-opt:l:inline -opt-inline-from ** -Xfatal-warnings -deprecation:false -opt-warnings:none

--- a/test/files/pos/t9111-inliner-workaround.flags
+++ b/test/files/pos/t9111-inliner-workaround.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/pos/t9111-inliner-workaround.flags
+++ b/test/files/pos/t9111-inliner-workaround.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/bcodeInlinerMixed.flags
+++ b/test/files/run/bcodeInlinerMixed.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/bcodeInlinerMixed.flags
+++ b/test/files/run/bcodeInlinerMixed.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/classfile-format-51.scala
+++ b/test/files/run/classfile-format-51.scala
@@ -16,7 +16,7 @@ import Opcodes._
 // verify. So the test includes a version check that short-circuits the whole test
 // on JDK 6
 object Test extends DirectTest {
-  override def extraSettings: String = "-opt:l:classpath -usejavacp -d " + testOutput.path + " -cp " + testOutput.path
+  override def extraSettings: String = "-opt:l:inline -opt-inline-from ** -usejavacp -d " + testOutput.path + " -cp " + testOutput.path
 
   def generateClass() {
     val invokerClassName =  "DynamicInvoker"

--- a/test/files/run/classfile-format-51.scala
+++ b/test/files/run/classfile-format-51.scala
@@ -16,7 +16,7 @@ import Opcodes._
 // verify. So the test includes a version check that short-circuits the whole test
 // on JDK 6
 object Test extends DirectTest {
-  override def extraSettings: String = "-opt:l:inline -opt-inline-from ** -usejavacp -d " + testOutput.path + " -cp " + testOutput.path
+  override def extraSettings: String = "-opt:l:inline -opt-inline-from:** -usejavacp -d " + testOutput.path + " -cp " + testOutput.path
 
   def generateClass() {
     val invokerClassName =  "DynamicInvoker"

--- a/test/files/run/classfile-format-52.scala
+++ b/test/files/run/classfile-format-52.scala
@@ -13,7 +13,7 @@ import Opcodes._
 // By its nature the test can only work on JDK 8+ because under JDK 7- the
 // interface won't verify.
 object Test extends DirectTest {
-  override def extraSettings: String = "-opt:l:classpath -usejavacp -d " + testOutput.path + " -cp " + testOutput.path
+  override def extraSettings: String = "-opt:l:inline -opt-inline-from ** -usejavacp -d " + testOutput.path + " -cp " + testOutput.path
 
   def generateInterface() {
     val interfaceName =  "HasDefaultMethod"

--- a/test/files/run/classfile-format-52.scala
+++ b/test/files/run/classfile-format-52.scala
@@ -13,7 +13,7 @@ import Opcodes._
 // By its nature the test can only work on JDK 8+ because under JDK 7- the
 // interface won't verify.
 object Test extends DirectTest {
-  override def extraSettings: String = "-opt:l:inline -opt-inline-from ** -usejavacp -d " + testOutput.path + " -cp " + testOutput.path
+  override def extraSettings: String = "-opt:l:inline -opt-inline-from:** -usejavacp -d " + testOutput.path + " -cp " + testOutput.path
 
   def generateInterface() {
     val interfaceName =  "HasDefaultMethod"

--- a/test/files/run/finalvar.flags
+++ b/test/files/run/finalvar.flags
@@ -1,1 +1,1 @@
--Yoverride-vars -opt:l:project
+-Yoverride-vars -opt:l:inline -opt-inline-from **

--- a/test/files/run/finalvar.flags
+++ b/test/files/run/finalvar.flags
@@ -1,1 +1,1 @@
--Yoverride-vars -opt:l:inline -opt-inline-from **
+-Yoverride-vars -opt:l:inline -opt-inline-from:**

--- a/test/files/run/icode-reader-dead-code.scala
+++ b/test/files/run/icode-reader-dead-code.scala
@@ -36,7 +36,7 @@ object Test extends DirectTest {
 
     // If inlining fails, the compiler will issue an inliner warning that is not present in the
     // check file
-    compileString(newCompiler("-usejavacp", "-opt:l:classpath"))(bCode)
+    compileString(newCompiler("-usejavacp", "-opt:l:inline", "-opt-inline-from", "**"))(bCode)
   }
 
   def readClass(file: String) = {

--- a/test/files/run/icode-reader-dead-code.scala
+++ b/test/files/run/icode-reader-dead-code.scala
@@ -36,7 +36,7 @@ object Test extends DirectTest {
 
     // If inlining fails, the compiler will issue an inliner warning that is not present in the
     // check file
-    compileString(newCompiler("-usejavacp", "-opt:l:inline", "-opt-inline-from", "**"))(bCode)
+    compileString(newCompiler("-usejavacp", "-opt:l:inline", "-opt-inline-from:**"))(bCode)
   }
 
   def readClass(file: String) = {

--- a/test/files/run/noInlineUnknownIndy/Test.scala
+++ b/test/files/run/noInlineUnknownIndy/Test.scala
@@ -11,7 +11,7 @@ object Test extends DirectTest {
 
   def compileCode(code: String) = {
     val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
-    compileString(newCompiler("-cp", classpath, "-d", testOutput.path, "-opt:l:classpath", "-Yopt-inline-heuristics:everything", "-opt-warnings:_"))(code)
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path, "-opt:l:inline", "-opt-inline-from", "**", "-Yopt-inline-heuristics:everything", "-opt-warnings:_"))(code)
   }
 
   def show(): Unit = {

--- a/test/files/run/noInlineUnknownIndy/Test.scala
+++ b/test/files/run/noInlineUnknownIndy/Test.scala
@@ -11,7 +11,7 @@ object Test extends DirectTest {
 
   def compileCode(code: String) = {
     val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
-    compileString(newCompiler("-cp", classpath, "-d", testOutput.path, "-opt:l:inline", "-opt-inline-from", "**", "-Yopt-inline-heuristics:everything", "-opt-warnings:_"))(code)
+    compileString(newCompiler("-cp", classpath, "-d", testOutput.path, "-opt:l:inline", "-opt-inline-from:**", "-Yopt-inline-heuristics:everything", "-opt-warnings:_"))(code)
   }
 
   def show(): Unit = {

--- a/test/files/run/repl-inline.scala
+++ b/test/files/run/repl-inline.scala
@@ -15,7 +15,7 @@ assert(h == "h", h)
   def main(args: Array[String]) {
     def test(f: Settings => Unit): Unit = {
       val settings = new Settings()
-      settings.processArgumentString("-opt:l:classpath")
+      settings.processArgumentString("-opt:l:inline -opt-inline-from **")
       f(settings)
       settings.usejavacp.value = true
       val repl = new interpreter.IMain(settings)

--- a/test/files/run/repl-inline.scala
+++ b/test/files/run/repl-inline.scala
@@ -15,7 +15,7 @@ assert(h == "h", h)
   def main(args: Array[String]) {
     def test(f: Settings => Unit): Unit = {
       val settings = new Settings()
-      settings.processArgumentString("-opt:l:inline -opt-inline-from **")
+      settings.processArgumentString("-opt:l:inline -opt-inline-from:**")
       f(settings)
       settings.usejavacp.value = true
       val repl = new interpreter.IMain(settings)

--- a/test/files/run/synchronized.flags
+++ b/test/files/run/synchronized.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/synchronized.flags
+++ b/test/files/run/synchronized.flags
@@ -1,1 +1,1 @@
--opt:l:project
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/t2106.flags
+++ b/test/files/run/t2106.flags
@@ -1,1 +1,1 @@
--opt-warnings -opt:l:inline -opt-inline-from **
+-opt-warnings -opt:l:inline -opt-inline-from:**

--- a/test/files/run/t2106.flags
+++ b/test/files/run/t2106.flags
@@ -1,1 +1,1 @@
--opt-warnings -opt:l:classpath
+-opt-warnings -opt:l:inline -opt-inline-from **

--- a/test/files/run/t3509.flags
+++ b/test/files/run/t3509.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/t3509.flags
+++ b/test/files/run/t3509.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/t3569.flags
+++ b/test/files/run/t3569.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/t3569.flags
+++ b/test/files/run/t3569.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/t4285.flags
+++ b/test/files/run/t4285.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/t4285.flags
+++ b/test/files/run/t4285.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/t4935.flags
+++ b/test/files/run/t4935.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/t4935.flags
+++ b/test/files/run/t4935.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/t5789.scala
+++ b/test/files/run/t5789.scala
@@ -5,7 +5,7 @@ import scala.tools.partest.ReplTest
 
 
 object Test extends ReplTest {
-  override def extraSettings = "-opt:l:inline -opt-inline-from **"
+  override def extraSettings = "-opt:l:inline -opt-inline-from:**"
   def code = """
     val n = 2
     () => n

--- a/test/files/run/t5789.scala
+++ b/test/files/run/t5789.scala
@@ -5,7 +5,7 @@ import scala.tools.partest.ReplTest
 
 
 object Test extends ReplTest {
-  override def extraSettings = "-opt:l:classpath"
+  override def extraSettings = "-opt:l:inline -opt-inline-from **"
   def code = """
     val n = 2
     () => n

--- a/test/files/run/t6102.flags
+++ b/test/files/run/t6102.flags
@@ -1,1 +1,1 @@
--opt:l:classpath -Xfatal-warnings
+-opt:l:inline -opt-inline-from ** -Xfatal-warnings

--- a/test/files/run/t6102.flags
+++ b/test/files/run/t6102.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from ** -Xfatal-warnings
+-opt:l:inline -opt-inline-from:** -Xfatal-warnings

--- a/test/files/run/t6188.flags
+++ b/test/files/run/t6188.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/t6188.flags
+++ b/test/files/run/t6188.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/t7459b-optimize.flags
+++ b/test/files/run/t7459b-optimize.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/t7459b-optimize.flags
+++ b/test/files/run/t7459b-optimize.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/t7582.flags
+++ b/test/files/run/t7582.flags
@@ -1,1 +1,1 @@
--opt:l:classpath -opt-warnings
+-opt:l:inline -opt-inline-from ** -opt-warnings

--- a/test/files/run/t7582.flags
+++ b/test/files/run/t7582.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from ** -opt-warnings
+-opt:l:inline -opt-inline-from:** -opt-warnings

--- a/test/files/run/t7582b.flags
+++ b/test/files/run/t7582b.flags
@@ -1,1 +1,1 @@
--opt:l:classpath -opt-warnings
+-opt:l:inline -opt-inline-from ** -opt-warnings

--- a/test/files/run/t7582b.flags
+++ b/test/files/run/t7582b.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from ** -opt-warnings
+-opt:l:inline -opt-inline-from:** -opt-warnings

--- a/test/files/run/t8601-closure-elim.flags
+++ b/test/files/run/t8601-closure-elim.flags
@@ -1,1 +1,1 @@
--Ydelambdafy:method -opt:l:inline -opt-inline-from **
+-Ydelambdafy:method -opt:l:inline -opt-inline-from:**

--- a/test/files/run/t8601-closure-elim.flags
+++ b/test/files/run/t8601-closure-elim.flags
@@ -1,1 +1,1 @@
--Ydelambdafy:method -opt:l:classpath
+-Ydelambdafy:method -opt:l:inline -opt-inline-from **

--- a/test/files/run/t8601.flags
+++ b/test/files/run/t8601.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/t8601.flags
+++ b/test/files/run/t8601.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/t8601b.flags
+++ b/test/files/run/t8601b.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/t8601b.flags
+++ b/test/files/run/t8601b.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/t8601c.flags
+++ b/test/files/run/t8601c.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/t8601c.flags
+++ b/test/files/run/t8601c.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/t8601d.flags
+++ b/test/files/run/t8601d.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/t8601d.flags
+++ b/test/files/run/t8601d.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/t8601e.flags
+++ b/test/files/run/t8601e.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/t8601e.flags
+++ b/test/files/run/t8601e.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/t9003.flags
+++ b/test/files/run/t9003.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/t9003.flags
+++ b/test/files/run/t9003.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/t9403.flags
+++ b/test/files/run/t9403.flags
@@ -1,1 +1,1 @@
--opt:l:classpath
+-opt:l:inline -opt-inline-from **

--- a/test/files/run/t9403.flags
+++ b/test/files/run/t9403.flags
@@ -1,1 +1,1 @@
--opt:l:inline -opt-inline-from **
+-opt:l:inline -opt-inline-from:**

--- a/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
@@ -11,7 +11,7 @@ import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class OptimizedBytecodeTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:l:classpath -opt-warnings"
+  override def compilerArgs = "-opt:l:inline -opt-inline-from ** -opt-warnings"
   import compiler._
 
   @Test

--- a/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
@@ -11,7 +11,7 @@ import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class OptimizedBytecodeTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:l:inline -opt-inline-from ** -opt-warnings"
+  override def compilerArgs = "-opt:l:inline -opt-inline-from:** -opt-warnings"
   import compiler._
 
   @Test

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
@@ -15,7 +15,7 @@ import scala.tools.testing.BytecodeTesting
 @RunWith(classOf[JUnit4])
 class BTypesFromClassfileTest extends BytecodeTesting {
   // inliner enabled -> inlineInfos are collected (and compared) in ClassBTypes
-  override def compilerArgs = "-opt:inline -opt-inline-from **"
+  override def compilerArgs = "-opt:inline -opt-inline-from:**"
 
   import compiler.global._
   import definitions._

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
@@ -15,7 +15,7 @@ import scala.tools.testing.BytecodeTesting
 @RunWith(classOf[JUnit4])
 class BTypesFromClassfileTest extends BytecodeTesting {
   // inliner enabled -> inlineInfos are collected (and compared) in ClassBTypes
-  override def compilerArgs = "-opt:inline-global"
+  override def compilerArgs = "-opt:inline -opt-inline-from **"
 
   import compiler.global._
   import definitions._

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
@@ -18,7 +18,7 @@ import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class CallGraphTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:inline-global -opt-warnings"
+  override def compilerArgs = "-opt:inline -opt-inline-from ** -opt-warnings"
   import compiler._
   import global.genBCode.bTypes
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
@@ -18,7 +18,7 @@ import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class CallGraphTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:inline -opt-inline-from ** -opt-warnings"
+  override def compilerArgs = "-opt:inline -opt-inline-from:** -opt-warnings"
   import compiler._
   import global.genBCode.bTypes
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
@@ -13,7 +13,7 @@ import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class ClosureOptimizerTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:l:inline -opt-inline-from ** -opt-warnings:_"
+  override def compilerArgs = "-opt:l:inline -opt-inline-from:** -opt-warnings:_"
   import compiler._
 
   @Test

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
@@ -13,7 +13,7 @@ import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class ClosureOptimizerTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:l:classpath -opt-warnings:_"
+  override def compilerArgs = "-opt:l:inline -opt-inline-from ** -opt-warnings:_"
   import compiler._
 
   @Test

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
@@ -18,7 +18,7 @@ class InlineInfoTest extends BytecodeTesting {
   import compiler._
   import global.genBCode.bTypes
 
-  override def compilerArgs = "-opt:l:classpath"
+  override def compilerArgs = "-opt:l:inline -opt-inline-from **"
 
   compiler.keepPerRunCachesAfterRun(List(
     bTypes.classBTypeCacheFromSymbol,

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
@@ -18,7 +18,7 @@ class InlineInfoTest extends BytecodeTesting {
   import compiler._
   import global.genBCode.bTypes
 
-  override def compilerArgs = "-opt:l:inline -opt-inline-from **"
+  override def compilerArgs = "-opt:l:inline -opt-inline-from:**"
 
   compiler.keepPerRunCachesAfterRun(List(
     bTypes.classBTypeCacheFromSymbol,

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineSourceMatcherTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineSourceMatcherTest.scala
@@ -1,0 +1,168 @@
+package scala.tools.nsc.backend.jvm.opt
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.nsc.backend.jvm.BTypes.InternalName
+import scala.tools.nsc.backend.jvm.opt.InlineSourceMatcherTest._
+import scala.tools.nsc.backend.jvm.opt.InlinerHeuristics._
+
+@RunWith(classOf[JUnit4])
+class InlineSourceMatcherTest {
+  case class E(regex: String, negated: Boolean = false, terminal: Boolean = true)
+
+  def check(pat: String, expect: E*): InlineSourceMatcher = {
+    val m = new InlineSourceMatcher(pat)
+    val es = m.entries
+    assertEquals(es.length, expect.length)
+
+    for ((a, e) <- (es, expect).zipped) {
+      assertEquals(a.pattern.pattern, e.regex)
+      assertEquals(a.negated, e.negated)
+      assertEquals(a.terminal, e.terminal)
+    }
+
+    m
+  }
+
+  @Test
+  def matcherTest(): Unit = {
+    {
+      val m = check("a.D", E("a/D"))
+      m.a("a/D")
+      m.d("a/C")
+      m.d("a.D")
+      m.d("D")
+    }
+    {
+      val m = check("!a.D", E("a/D", true, true))
+      m.d("a/D")
+      m.d("a/C")
+    }
+    {
+      val m = check("a.*", E("a/[^/]*"))
+      m.a("a/A")
+      m.a("a/alKD@(ßª™˜∆≤$N1")
+      m.a("a/") // it's maybe a bit weird that this matches, but doesn't matter in practice, we always check real internal names
+      m.d("a//")
+      m.d("a//A")
+      m.d("A")
+      m.d("a/b/A")
+    }
+    {
+      val m = check("a.*:!a.C", E("a/[^/]*", false, false), E("a/C", true, true))
+      m.a("a/A")
+      m.a("a/CC")
+      m.d("a/C")
+      m.d("a/b/C")
+    }
+    {
+      val m = check("a.*:!a.*C*", E("a/[^/]*", false, false), E("a/[^/]*C[^/]*", true, true))
+      m.a("a/A")
+      m.a("a/SDEJAB")
+      m.d("a/C")
+      m.d("a/baC")
+      m.d("a/Cal")
+      m.d("a/IENABCEKL")
+      m.d("a/AlCmalCu")
+    }
+
+    {
+      // no entry for **, sets the matcher's `startAllow` boolean
+      val m = check("**")
+      m.a("")
+      m.a("a/b/C")
+    }
+    {
+      val m = check("!**", E(".*", true, true))
+      m.d("")
+      m.d("a/b/C")
+    }
+    {
+      // no entry for **, sets the matcher's `startAllow` boolean
+      val m = check("**:!scala.Predef$:!java.**", E("scala/\\QPredef$\\E", true, true), E("java/.*", true, true))
+      m.a("Predef$")
+      m.a("skala/Predef$")
+      m.a("scala/Predef")
+      m.d("scala/Predef$")
+      m.a("javax/Swing")
+      m.d("java/lang/Object")
+      m.d("java/Foo")
+    }
+
+    {
+      val m = check("a.**.c.D", E("a/(?:.*/|)c/D"))
+      m.a("a/c/D")
+      m.a("a/b/c/D")
+      m.a("a/b/i/a/c/c/c/D")
+      m.a("a//c/D")
+      m.d("a/D")
+      m.d("ac/D")
+    }
+    {
+      val m = check("a**.c.D", E("a.*/c/D"))
+      m.a("alpha/c/D")
+      m.a("alpa/c/a/c/D")
+      m.a("a/c/D")
+      m.a("a//c/D")
+      m.d("ac/D")
+      m.d("alp/ac/D")
+    }
+    {
+      val m = check("a**c.D", E("a.*c/D"))
+      m.a("ac/D")
+      m.a("a/c/D")
+      m.a("alpac/D")
+      m.a("a/b/c/D")
+    }
+    {
+      val m = check("**.A", E("(?:.*/|)A"))
+      m.a("A")
+      m.a("p/A")
+      m.a("a/b/c/A")
+      m.d("pA")
+    }
+    {
+      val m = check("**.*Util*", E("(?:.*/|)[^/]*Util[^/]*"))
+      m.a("Util")
+      m.a("SourceUtilTools")
+      m.a("/Util")
+      m.a("/SUtils")
+      m.a("a/b/Util")
+      m.a("a/b/Utils")
+    }
+    {
+      val m = check("**.*Util*:!**.AUtil*:a/b/AUtil*",
+        E("(?:.*/|)[^/]*Util[^/]*", false, false),
+        E("(?:.*/|)AUtil[^/]*", true, false),
+        E("a/b/AUtil[^/]*", false, true))
+      m.a("a/b/AUtils")
+      m.d("a/c/AUtils")
+      m.d("AUtils")
+      m.a("a/c/SAUtils")
+    }
+
+    {
+      val m = check("**:!a.*:a.C", E("a/[^/]*", true, false), E("a/C", false, true))
+      m.d("a/A")
+      m.a("a/C")
+      m.a("a/A/K")
+      m.a("a/C/K")
+      m.d("a/")
+    }
+    {
+      val m = check("**:!**.C:C", E("(?:.*/|)C", true, false), E("C", false, true))
+      m.a("C")
+      m.d("a/C")
+    }
+  }
+}
+
+object InlineSourceMatcherTest {
+  implicit class AssertAllow(val m: InlineSourceMatcher) extends AnyVal {
+    def a(internalName: InternalName): Unit = assertTrue(m.allow(internalName))
+    def d(internalName: InternalName): Unit = assertFalse(m.allow(internalName))
+  }
+}

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineSourceMatcherTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineSourceMatcherTest.scala
@@ -17,7 +17,7 @@ class InlineSourceMatcherTest extends BytecodeTesting {
 
   override def compilerArgs = "-opt:l:inline -opt-warnings"
   def setInlineFrom(s: String): Unit = {
-    global.settings.optInlineFrom.value = s
+    global.settings.optInlineFrom.value = s.split(':').toList
     // the setting is read once per run
     global.perRunCaches.clearAll()
   }
@@ -25,7 +25,7 @@ class InlineSourceMatcherTest extends BytecodeTesting {
   case class E(regex: String, negated: Boolean = false, terminal: Boolean = true)
 
   def check(pat: String, expect: E*): InlineSourceMatcher = {
-    val m = new InlineSourceMatcher(pat)
+    val m = new InlineSourceMatcher(pat.split(':').toList)
     val es = m.entries
     assertEquals(es.length, expect.length)
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
@@ -11,12 +11,12 @@ import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InlineWarningTest extends BytecodeTesting {
-  def optCp = "-opt:l:classpath"
-  override def compilerArgs = s"$optCp -opt-warnings"
+  def optInline = "-opt:l:inline -opt-inline-from **"
+  override def compilerArgs = s"$optInline -opt-warnings"
 
   import compiler._
 
-  val compilerWarnAll = cached("compilerWarnAll", () => newCompiler(extraArgs = s"$optCp -opt-warnings:_"))
+  val compilerWarnAll = cached("compilerWarnAll", () => newCompiler(extraArgs = s"$optInline -opt-warnings:_"))
 
   @Test
   def nonFinal(): Unit = {
@@ -87,10 +87,10 @@ class InlineWarningTest extends BytecodeTesting {
     assert(c == 1, c)
 
     // no warnings here
-    newCompiler(extraArgs = s"$optCp -opt-warnings:none").compileToBytes(scalaCode, List((javaCode, "A.java")))
+    newCompiler(extraArgs = s"$optInline -opt-warnings:none").compileToBytes(scalaCode, List((javaCode, "A.java")))
 
     c = 0
-    newCompiler(extraArgs = s"$optCp -opt-warnings:no-inline-mixed").compileToBytes(scalaCode, List((javaCode, "A.java")), allowMessage = i => {c += 1; warns.exists(i.msg contains _)})
+    newCompiler(extraArgs = s"$optInline -opt-warnings:no-inline-mixed").compileToBytes(scalaCode, List((javaCode, "A.java")), allowMessage = i => {c += 1; warns.exists(i.msg contains _)})
     assert(c == 2, c)
   }
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
@@ -11,7 +11,7 @@ import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InlineWarningTest extends BytecodeTesting {
-  def optInline = "-opt:l:inline -opt-inline-from **"
+  def optInline = "-opt:l:inline -opt-inline-from:**"
   override def compilerArgs = s"$optInline -opt-warnings"
 
   import compiler._

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
@@ -10,7 +10,7 @@ import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InlinerSeparateCompilationTest {
-  val args = "-opt:l:classpath"
+  val args = "-opt:l:inline -opt-inline-from **"
 
   @Test
   def inlineMixedinMember(): Unit = {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
@@ -10,7 +10,7 @@ import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InlinerSeparateCompilationTest {
-  val args = "-opt:l:inline -opt-inline-from **"
+  val args = "-opt:l:inline -opt-inline-from:**"
 
   @Test
   def inlineMixedinMember(): Unit = {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -19,9 +19,9 @@ import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InlinerTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:l:inline -opt-inline-from ** -opt-warnings"
+  override def compilerArgs = "-opt:l:inline -opt-inline-from:** -opt-warnings"
 
-  val inlineOnlyCompiler = cached("inlineOnlyCompiler", () => newCompiler(extraArgs = "-opt:inline -opt-inline-from **"))
+  val inlineOnlyCompiler = cached("inlineOnlyCompiler", () => newCompiler(extraArgs = "-opt:inline -opt-inline-from:**"))
 
   import compiler._
   import global.genBCode.bTypes
@@ -1447,7 +1447,7 @@ class InlinerTest extends BytecodeTesting {
     val codeA = "final class A { @inline def f = 1 }"
     val codeB = "class B { def t(a: A) = a.f }"
     // tests that no warning is emitted
-    val List(a, b) = compileClassesSeparately(List(codeA, codeB), extraArgs = "-opt:l:inline -opt-inline-from B -opt-warnings")
+    val List(a, b) = compileClassesSeparately(List(codeA, codeB), extraArgs = "-opt:l:inline -opt-inline-from:B -opt-warnings")
     assertInvoke(getMethod(b, "t"), "A", "f")
   }
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -19,9 +19,9 @@ import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InlinerTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:l:classpath -opt-warnings"
+  override def compilerArgs = "-opt:l:inline -opt-inline-from ** -opt-warnings"
 
-  val inlineOnlyCompiler = cached("inlineOnlyCompiler", () => newCompiler(extraArgs = "-opt:inline-project"))
+  val inlineOnlyCompiler = cached("inlineOnlyCompiler", () => newCompiler(extraArgs = "-opt:inline -opt-inline-from **"))
 
   import compiler._
   import global.genBCode.bTypes
@@ -1447,7 +1447,7 @@ class InlinerTest extends BytecodeTesting {
     val codeA = "final class A { @inline def f = 1 }"
     val codeB = "class B { def t(a: A) = a.f }"
     // tests that no warning is emitted
-    val List(a, b) = compileClassesSeparately(List(codeA, codeB), extraArgs = "-opt:l:project -opt-warnings")
+    val List(a, b) = compileClassesSeparately(List(codeA, codeB), extraArgs = "-opt:l:inline -opt-inline-from B -opt-warnings")
     assertInvoke(getMethod(b, "t"), "A", "f")
   }
 

--- a/test/junit/scala/tools/nsc/transform/patmat/PatmatBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/transform/patmat/PatmatBytecodeTest.scala
@@ -12,7 +12,7 @@ import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class PatmatBytecodeTest extends BytecodeTesting {
-  val optCompiler = cached("optCompiler", () => newCompiler(extraArgs = "-opt:l:project"))
+  val optCompiler = cached("optCompiler", () => newCompiler(extraArgs = "-opt:l:inline -opt-inline-from **"))
 
   import compiler._
 

--- a/test/junit/scala/tools/nsc/transform/patmat/PatmatBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/transform/patmat/PatmatBytecodeTest.scala
@@ -12,7 +12,7 @@ import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class PatmatBytecodeTest extends BytecodeTesting {
-  val optCompiler = cached("optCompiler", () => newCompiler(extraArgs = "-opt:l:inline -opt-inline-from **"))
+  val optCompiler = cached("optCompiler", () => newCompiler(extraArgs = "-opt:l:inline -opt-inline-from:**"))
 
   import compiler._
 


### PR DESCRIPTION
Deprecates `-opt:l:classpath` and `-opt:l:project`, introduces `-opt:l:inline` which enables cross-method optimizations. The inliner will only inline code from classes listed in `-opt-inline-from`, which is empty by default. So specifying only `-opt:l:inline` actually doesn't enable any inlining.

Proposed syntax for `-opt-inline-from`:
  - slices of qualified class names: `List`, `scala.collection.List`, `collection.mutable`, etc
  - `*`: longest match of identifier parts (not `.`)
  - `**`: longest match of anything
  - `<sources>`: allows inlining from classes being compiled in the current compilation run (implemented in a follow-up PR https://github.com/scala/scala/pull/5989)
  - leading `!` to make a rule excluding

Examples

|                       |                                                                           |
| --------------------- | ------------------------------------------------------------------------- |
| `*`                   | classes in the empty package                                              |
| `scala.*`             | classes in package scala, including the package object (`scala.package$`) |
| `**`                  | any class                                                                 |
| `scala.collection.**` | classes in package scala.collection, or any sub-package                   |
| `com.corp.**.util.*`  | classes in a util package below com.corp, including com.corp.util.Foo     |
| `**.Util`             | classes named Util in any package, including `_root_.Util`                |
| `**.*Util*`           | classes containing Util                                                   |

There's a special case to make `.**.` match `.`, so `a.**.b.C` matches `a.b.C`. Similarly, `**.A` matches `A`.

Note that we're talking about classfile names here, so a nested class `foo.C#D` would be `foo.C$D`, a module class is `scala.Predef$`.

More examples:
  - `scalac -opt:l:inline -opt-inline-from:scala.**:com.corp.**`: white-listing is recommended, because
  - Trying to exclude everything from `rt.jar` is not easy (and also platform-dependent)! The following is just a start, there are many more packages: `**:!java.**:!javax.**:!jdk.**:!apple.**:!com.apple.**:!com.oracle.**:!com.sun.**:...`
  - `**:!foo.**:foo.util.**`: the last matching rule counts.


Fixes scala/scala-dev#148

