### PR TITLE
Fix regression under -Xcheckinit: param accessors don't need init checking

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
@@ -140,7 +140,7 @@ trait AccessorSynthesis extends Transform with ast.TreeDSL {
 
         if (field.isLazy)
           if (field hasAnnotation TransientAttr) BITMAP_TRANSIENT else BITMAP_NORMAL
-        else if (doCheckInit && !(field hasFlag DEFAULTINIT | PRESUPER))
+        else if (doCheckInit && !(field hasFlag DEFAULTINIT | PRESUPER | PARAMACCESSOR))
           if (field hasAnnotation TransientAttr) BITMAP_CHECKINIT_TRANSIENT else BITMAP_CHECKINIT
         else NO_NAME
       }
@@ -330,7 +330,7 @@ trait AccessorSynthesis extends Transform with ast.TreeDSL {
       /** Make getters check the initialized bit, and the class constructor & setters are changed to set the initialized bits. */
       def wrapRhsWithInitChecks(sym: Symbol)(rhs: Tree): Tree =
         if (sym.isConstructor) addInitBitsTransformer transform rhs
-        else if ((sym hasFlag ACCESSOR) && !(sym hasFlag LAZY)) {
+        else if ((sym hasFlag ACCESSOR) && !(sym hasFlag (LAZY | PARAMACCESSOR))) {
           val field = clazz.info.decl(sym.localName)
           if (field == NoSymbol) rhs
           else bitmapOf(field) match {

--- a/test/files/run/checkinit.check
+++ b/test/files/run/checkinit.check
@@ -1,0 +1,2 @@
+Uninitialized field: checkinit.scala: 26
+Uninitialized field: checkinit.scala: 30

--- a/test/files/run/checkinit.flags
+++ b/test/files/run/checkinit.flags
@@ -1,0 +1,1 @@
+-Xcheckinit

--- a/test/files/run/checkinit.scala
+++ b/test/files/run/checkinit.scala
@@ -1,0 +1,38 @@
+class C(val x: AnyRef, val y: AnyRef)
+class D(val x: AnyRef, val y: AnyRef) {
+  val z: AnyRef = ""
+}
+
+trait U {
+  val a = b
+  def b: AnyRef
+}
+
+abstract class V {
+  val a = b
+  def b: AnyRef
+}
+
+object Test {
+  def check(f: => Unit): Unit = try {
+    f
+    println("!!!")
+  } catch {
+    case e: UninitializedFieldError =>
+      println(e.getMessage)
+  }
+  def main(args: Array[String]): Unit = {
+    check {
+      class U1 extends U { val b = "" }
+      new U1
+    }
+    check {
+      class U1 extends V { val b = "" }
+      new U1
+    }
+
+    new C("", "")
+    assert(classOf[C].getDeclaredFields.size == 2) // no bitmp field when we just have paramaccessors
+    new D("", "")
+  }
+}


### PR DESCRIPTION
In #5936, some checks were removed that resulted in checkinit machinery
being synthesized for param accessor fields (ie, constructor vals).

This commit dials this back to the old behaviour, avoiding unnecessary
fields and code, and an unwanted VerifyError.

I've added a basic test case to show that checkinit errors are still
raised when we want them to be, and that the verify error is gone.

Fixes scala/community-builds#566