### PR TITLE
Type calculation leads to broken a correct class loading order.

### DIFF
--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -552,7 +552,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
     }
 
     def javaClass(path: String): jClass[_] =
-      jClass.forName(path, true, classLoader)
+      jClass.forName(path, false, classLoader)
 
     /** Does `path` correspond to a Java class with that fully qualified name in the current class loader? */
     def tryJavaClass(path: String): Option[jClass[_]] = (

--- a/test/junit/scala/reflect/classloading/ClassLoadingOrderTest.scala
+++ b/test/junit/scala/reflect/classloading/ClassLoadingOrderTest.scala
@@ -1,0 +1,26 @@
+package scala.reflect.classloading
+
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.reflect.runtime.universe._
+
+
+@RunWith(classOf[JUnit4])
+class Launcher {
+	@Test def testLoadingOrder(){
+		//The computation of types should not lead to the loading of classes
+		typeOf[SomeClass[MustLoadedSecond]]
+
+		Class.forName(classOf[MustLoadedFirst].getName, true, getClass.getClassLoader)
+		Class.forName(classOf[MustLoadedSecond].getName, true, getClass.getClassLoader)
+
+		assert(LoadingOrder.loadedClasses.size == 2)
+		assert(LoadingOrder.loadedClasses.get(0) == classOf[MustLoadedFirst])
+		assert(LoadingOrder.loadedClasses.get(1) == classOf[MustLoadedSecond])
+	}
+}
+
+class  SomeClass[T <: MustLoadedSecond]

--- a/test/junit/scala/reflect/classloading/LoadingOrder.java
+++ b/test/junit/scala/reflect/classloading/LoadingOrder.java
@@ -1,0 +1,7 @@
+package scala.reflect.classloading;
+
+import java.util.ArrayList;
+
+public class LoadingOrder {
+	public static final ArrayList<Class<?>> loadedClasses = new ArrayList<>();
+}

--- a/test/junit/scala/reflect/classloading/MustLoadedFirst.java
+++ b/test/junit/scala/reflect/classloading/MustLoadedFirst.java
@@ -1,0 +1,7 @@
+package scala.reflect.classloading;
+
+public class MustLoadedFirst {
+	static {
+		LoadingOrder.loadedClasses.add(MustLoadedFirst.class);
+	}
+}

--- a/test/junit/scala/reflect/classloading/MustLoadedSecond.java
+++ b/test/junit/scala/reflect/classloading/MustLoadedSecond.java
@@ -1,0 +1,7 @@
+package scala.reflect.classloading;
+
+public class MustLoadedSecond {
+	static {
+		LoadingOrder.loadedClasses.add(MustLoadedSecond.class);
+	}
+}


### PR DESCRIPTION
Bug fix. Type calculation leads to reading a certain number of classes in runtime (for example, when using TypeTag). This can broke correct class loading order due to reading the classes with the load attribute.