### PR TITLE
Fix 5355: wrong error message for cyclic structural types

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -717,9 +717,9 @@ trait TypeDiagnostics {
      *  to a cyclic reference, and None otherwise.
      */
     def cyclicReferenceMessage(sym: Symbol, tree: Tree) = condOpt(tree) {
-      case ValDef(_, _, tpt, _) if tpt.tpe == null        => "recursive "+sym+" needs type"
-      case DefDef(_, _, _, _, tpt, _) if tpt.tpe == null  => List(cyclicAdjective(sym), sym, "needs result type") mkString " "
-      case Import(expr, selectors)                        =>
+      case ValDef(_, _, TypeTree(), _)       => "recursive "+sym+" needs type"
+      case DefDef(_, _, _, _, TypeTree(), _) => List(cyclicAdjective(sym), sym, "needs result type") mkString " "
+      case Import(expr, selectors)           =>
         ( "encountered unrecoverable cycle resolving import." +
           "\nNote: this is often due in part to a class depending on a definition nested within its companion." +
           "\nIf applicable, you may wish to try moving some members into another object."

--- a/test/files/neg/t5355.check
+++ b/test/files/neg/t5355.check
@@ -1,0 +1,16 @@
+t5355.scala:2: error: illegal cyclic reference involving method a
+  type A = { def a(b: A): A }
+                          ^
+t5355.scala:3: error: illegal cyclic reference involving method a
+  type B = { def a: B }
+                    ^
+t5355.scala:4: error: illegal cyclic reference involving method a
+  type C = { def a(b: C): AnyRef }
+                      ^
+t5355.scala:5: error: illegal cyclic reference involving value a
+  type D = { val a: D }
+                    ^
+t5355.scala:6: error: illegal cyclic reference involving method a
+  val e: { def a: e.type }
+                  ^
+5 errors found

--- a/test/files/neg/t5355.scala
+++ b/test/files/neg/t5355.scala
@@ -1,0 +1,7 @@
+trait Test {
+  type A = { def a(b: A): A }
+  type B = { def a: B }
+  type C = { def a(b: C): AnyRef }
+  type D = { val a: D }
+  val e: { def a: e.type }
+}


### PR DESCRIPTION
The pattern match in `TypeDiagnostics` also matched methods in structural types that do have a return type.
Strictly match on vals and defs with an empty `TypeTree` as return type. Show the default error message otherwise.

Fixes scala/bug#5355

I could add an extra case to add a custom error message for structural types, but I think the default error message is sufficient. The information about which reference exactly is cyclic seems to have been thrown away anyway, except for the position.