### PR TITLE
Spec relaxed import behavior

### DIFF
--- a/spec/02-identifiers-names-and-scopes.md
+++ b/spec/02-identifiers-names-and-scopes.md
@@ -92,7 +92,10 @@ without introducing an ambiguity.
 ```scala
 object X { type T = annotation.tailrec }
 object Y { type T = annotation.tailrec }
-object Z { import X._, Y._, annotation.{tailrec => T} ; @T def f: Int = { f ; 42 } }
+object Z {
+  import X._, Y._, annotation.{tailrec => T}  // OK, all T mean tailrec
+  @T def f: Int = { f ; 42 }                  // error, f is not tail recursive
+}
 ```
 
 ###### Example

--- a/spec/02-identifiers-names-and-scopes.md
+++ b/spec/02-identifiers-names-and-scopes.md
@@ -83,6 +83,18 @@ package util {
 }
 ```
 
+As a convenience, multiple bindings of a type identifier to the same
+underlying type is permitted. This is possible when import clauses introduce
+a binding of a member type alias with the same binding precedence, typically
+through wildcard imports. This allows redundant type aliases to be imported
+without introducing an ambiguity.
+
+```scala
+object X { type T = annotation.tailrec }
+object Y { type T = annotation.tailrec }
+object Z { import X._, Y._, annotation.{tailrec => T} ; @T def f: Int = { f ; 42 } }
+```
+
 ###### Example
 
 Assume the following two definitions of objects named `X` in packages `p` and `q`

--- a/spec/04-basic-declarations-and-definitions.md
+++ b/spec/04-basic-declarations-and-definitions.md
@@ -873,7 +873,7 @@ An import clause has the form `import $p$.$I$` where $p$ is a
 [stable identifier](03-types.html#paths) and $I$ is an import expression.
 The import expression determines a set of names of importable members of $p$
 which are made available without qualification.  A member $m$ of $p$ is
-_importable_ if it is not [object-private](05-classes-and-objects.html#modifiers).
+_importable_ if it is [accessible](05-classes-and-objects.html#modifiers).
 The most general form of an import expression is a list of _import selectors_
 
 ```scala


### PR DESCRIPTION
Implementation was massaged to fix 2133, 3160, 3836
and related tickets around import ergonomics, but
the spec lagged.

This specifies importing multiple type aliases and
that importable requires accessible.

Fixes scala/bug#2133