### PR TITLE
Prevent `inferImplicitValue` from reporting false divergent implicits

### DIFF
--- a/test/files/run/macro-implicit-decorator.check
+++ b/test/files/run/macro-implicit-decorator.check
@@ -1,0 +1,3 @@
+Successful()
+Failed(List(MyTC[Boolean]))
+Failed(List(MyTC[Boolean]))

--- a/test/files/run/macro-implicit-decorator.flags
+++ b/test/files/run/macro-implicit-decorator.flags
@@ -1,0 +1,1 @@
+-language:experimental.macros

--- a/test/files/run/macro-implicit-decorator/Macros_1.scala
+++ b/test/files/run/macro-implicit-decorator/Macros_1.scala
@@ -1,0 +1,33 @@
+import scala.reflect.macros.whitebox
+
+trait Derivation[A]
+
+object Derivation {
+  case class Successful[A]() extends Derivation[A]
+  case class Failed[A](failures: List[String]) extends Derivation[A]
+
+  var failures = List.empty[String]
+
+  def materializeDerivationImpl[A](c: whitebox.Context)(implicit tt: c.WeakTypeTag[A]): c.Tree = {
+    import c.universe._
+
+    c.inferImplicitValue(weakTypeOf[A]) match {
+      case EmptyTree if c.openImplicits.length == 1 =>
+        q"Derivation.Failed[${weakTypeOf[A]}](Nil)"
+
+      case EmptyTree =>
+        failures ::= weakTypeOf[A].toString
+        q"Derivation.Failed[${weakTypeOf[A]}](Nil)"
+
+      case _ if c.openImplicits.length == 1 && failures.nonEmpty =>
+        val tree = q"Derivation.Failed[${weakTypeOf[A]}](List(..$failures))"
+        failures = Nil
+        tree
+
+      case _ =>
+        q"Derivation.Successful[${weakTypeOf[A]}]()"
+    }
+  }
+
+  implicit def materializeDerivation[A]: Derivation[A] = macro materializeDerivationImpl[A]
+}

--- a/test/files/run/macro-implicit-decorator/Test_2.scala
+++ b/test/files/run/macro-implicit-decorator/Test_2.scala
@@ -1,0 +1,17 @@
+// https://github.com/scala/bug/issues/10398
+
+class CustomClass
+
+trait MyTC[A]
+
+object MyTC {
+  implicit val forInt = new MyTC[Int] {}
+  implicit def forList[A](implicit a: Derivation[MyTC[A]]) = new MyTC[List[A]] {}
+  implicit def forCustomClass(implicit a: Derivation[MyTC[List[Boolean]]]) = new MyTC[CustomClass] {}
+}
+
+object Test extends App {
+  println(implicitly[Derivation[MyTC[List[Int]]]])
+  println(implicitly[Derivation[MyTC[List[Boolean]]]])
+  println(implicitly[Derivation[MyTC[CustomClass]]])
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/10398.

`universe.analyzer.inferImplicit` requires the tree in which the implicit is going to be inserted, which is used to detect divergent implicits. This PR makes `Typers#inferImplicitValue` provide a tree from `openImplicits` if such a tree exists. This seems more accurate than always providing `EmptyTree`, which for the purposes of divergent implicit detection doesn't provide the means to distinguish between searches made by macros at different call sites.

This is my first contribution to the Scala compiler and I do not have enough insight about its architecture to know if this is the right approach or if this will affect negatively something else. Please let me know if I missed something or if there is a better option!
