### PR TITLE
Fixes #10399: Adding an element will enter dead loop while constructing a mutable BitSet with an empty array.

### DIFF
--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -77,7 +77,13 @@ class BitSet(protected final var elems: Array[Long]) extends AbstractSet[Int]
     }
   }
 
-  protected def fromBitMaskNoCopy(words: Array[Long]): BitSet = new BitSet(words)
+  protected def fromBitMaskNoCopy(words: Array[Long]): BitSet = {
+    if (words.length == 0) {
+      empty
+    } else {
+      new BitSet(words)
+    }
+  }
 
   override def add(elem: Int): Boolean = {
     require(elem >= 0)
@@ -190,13 +196,23 @@ object BitSet extends BitSetFactory[BitSet] {
   /** A bitset containing all the bits in an array */
   def fromBitMask(elems: Array[Long]): BitSet = {
     val len = elems.length
-    val a = new Array[Long](len)
-    Array.copy(elems, 0, a, 0, len)
-    new BitSet(a)
+    if (len == 0) {
+      empty
+    } else {
+      val a = new Array[Long](len)
+      Array.copy(elems, 0, a, 0, len)
+      new BitSet(a)
+    }
   }
 
   /** A bitset containing all the bits in an array, wrapping the existing
    *  array without copying.
    */
-  def fromBitMaskNoCopy(elems: Array[Long]): BitSet = new BitSet(elems)
+  def fromBitMaskNoCopy(elems: Array[Long]): BitSet = {
+    if (elems.length == 0) {
+      empty
+    } else {
+      new BitSet(elems)
+    }
+  }
 }

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -41,4 +41,11 @@ class BitSetTest {
     val last = (bs ++ (0 to 128)).last  // Just needs not to throw
     assert(last == 128)
   }
+
+  @Test def t10399(): Unit = {
+    val bsFromEmptyBitMask = BitSet.fromBitMask(Array.empty[Long])
+    assert(bsFromEmptyBitMask.add(0))
+    val bsFromEmptyBitMaskNoCopy = BitSet.fromBitMaskNoCopy(Array.empty[Long])
+    assert(bsFromEmptyBitMaskNoCopy.add(0))
+  }
 }


### PR DESCRIPTION
Constructing a mutable BitSet with an empty array will return an empty instance. 
Fixes scala/bug#10399