### PR TITLE
Structural invocation: find method by name if by signature fails

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -108,7 +108,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
               if (method ne null)
                 return method
               else {
-                method = ScalaRunTime.ensureAccessible(forReceiver.getMethod("xyz", methodCache.parameterTypes()))
+                method = ScalaRunTime.lookupStructuralMethod(forReceiver, "xyz", methodCache.parameterTypes())
                 methodCache.add(forReceiver, method)
                 return method
               }
@@ -129,10 +129,10 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
               IF (REF(methodSym) OBJ_NE NULL) .
                 THEN (Return(REF(methodSym)))
               ELSE {
-                def methodSymRHS  = ((REF(forReceiverSym) DOT Class_getMethod)(LIT(method), (REF(methodCache) DOT StructuralCallSite_getParameterTypes)()))
-                def cacheAdd      = ((REF(methodCache) DOT StructuralCallSite_add)(REF(forReceiverSym), REF(methodSym)))
+                val lookupMeth = REF(currentRun.runDefinitions.lookupStructuralMethod) APPLY (REF(forReceiverSym), LIT(method), (REF(methodCache) DOT StructuralCallSite_getParameterTypes)())
+                val cacheAdd   = REF(methodCache) DOT StructuralCallSite_add APPLY (REF(forReceiverSym), REF(methodSym))
                 BLOCK(
-                  REF(methodSym)        === (REF(currentRun.runDefinitions.ensureAccessibleMethod) APPLY (methodSymRHS)),
+                  REF(methodSym) === lookupMeth,
                   cacheAdd,
                   Return(REF(methodSym))
                 )

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -139,6 +139,19 @@ object ScalaRunTime {
   // More background at ticket #2318.
   def ensureAccessible(m: JMethod): JMethod = scala.reflect.ensureAccessible(m)
 
+  def lookupStructuralMethod(c: Class[_], m: String, params: Array[Class[_]]): JMethod = {
+    val res =
+      try c.getMethod(m, params: _*)
+      catch {
+        case e: java.lang.NoSuchMethodException =>
+          // Workaround for scala/bug#10334
+          val ms = c.getMethods.filter(x => x.getName == m && !x.isBridge)
+          if (ms.length == 1) ms(0)
+          else throw e
+      }
+    ensureAccessible(res)
+  }
+
   def _toString(x: Product): String =
     x.productIterator.mkString(x.productPrefix + "(", ",", ")")
 

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1530,7 +1530,7 @@ trait Definitions extends api.StandardDefinitions {
       lazy val arrayUpdateMethod      = getMemberMethod(ScalaRunTimeModule, nme.array_update)
       lazy val arrayLengthMethod      = getMemberMethod(ScalaRunTimeModule, nme.array_length)
       lazy val arrayCloneMethod       = getMemberMethod(ScalaRunTimeModule, nme.array_clone)
-      lazy val ensureAccessibleMethod = getMemberMethod(ScalaRunTimeModule, nme.ensureAccessible)
+      lazy val lookupStructuralMethod = getMemberMethod(ScalaRunTimeModule, nme.lookupStructuralMethod)
       lazy val arrayClassMethod       = getMemberMethod(ScalaRunTimeModule, nme.arrayClass)
       lazy val traversableDropMethod  = getMemberMethod(ScalaRunTimeModule, nme.drop)
 

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -679,7 +679,7 @@ trait StdNames {
     val drop: NameType                 = "drop"
     val elem: NameType                 = "elem"
     val noSelfType: NameType           = "noSelfType"
-    val ensureAccessible : NameType    = "ensureAccessible"
+    val lookupStructuralMethod : NameType = "lookupStructuralMethod"
     val eq: NameType                   = "eq"
     val equalsNumChar : NameType       = "equalsNumChar"
     val equalsNumNum : NameType        = "equalsNumNum"

--- a/test/files/run/t10334.scala
+++ b/test/files/run/t10334.scala
@@ -1,0 +1,70 @@
+import scala.language.reflectiveCalls
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    assert(t1 == "hi")
+    assert(t2 == 1)
+    t3()
+  }
+
+  def t1: Object = {
+    val f: { def apply(s: String): Object } = (x: String) => x
+    f("hi")
+  }
+
+  def t2: Int = {
+    def byName(b: => Int): Int = b
+    def namer[A, B](f: A => B): (A => B) { def apply(i: A): B } = f
+
+    val namedFunction = namer(byName _)
+    namedFunction(1)
+  }
+
+  // Not sure how to fix this one.. https://github.com/scala/bug/issues/10334
+  def t3(): Unit = {
+    val f1 = new T[A] {
+      def m(x: A) = "f1-a"
+      def m(x: B) = "f1-b"
+       // the m(Object)Object bridge method invokes (A)Object
+    }
+
+    val f2 = new T[B] {
+      def m(x: A) = "f2-a"
+      def m(x: B) = "f2-b"
+       // the (Object)Object bridge method invokes (B)Object
+    }
+
+    val g1: T[C] = f1
+    val g2: T[C] = f2
+
+    assert(g1.m(new C) == "f1-a")
+    assert(g2.m(new C) == "f2-b")
+
+    val s1: { def m(s: C): Object } = g1
+    val s2: { def m(s: C): Object } = g2
+
+    // the reflective lookup doesn't find `m(C)Object`
+    try {
+      s1.m(new C) // should invoke `m(A)Object`
+      throw new Error()
+    } catch {
+      case _: java.lang.NoSuchMethodException =>
+    }
+
+    // the reflective lookup doesn't find `m(C)Object`
+    try {
+      s2.m(new C) // should invoke `m(B)Object`
+      throw new Error()
+    } catch {
+      case _: java.lang.NoSuchMethodException =>
+    }
+  }
+}
+
+class A
+class B extends A
+class C extends B
+
+trait T[-A] {
+  def m(a: A): Object
+}


### PR DESCRIPTION
In a structural invocation, if the receiver object doesn't have
a method with the expected paramter types, check if there's a
single method matching the name. If so, invoke this method.

This fixes parts of https://github.com/scala/bug/issues/10334,
namely the parts that regressed with the new lambda encoding.
But the underlying issue still remains.