### PR TITLE
Two fixes for overload resolution for PartialFunctions

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3368,50 +3368,80 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 catch { case _: IllegalArgumentException => args.map(_ => Nil) } // fail safe in case formalTypes fails to align to argslen
               else args.map(_ => Nil) // will type under argPt == WildcardType
 
-            val (args1, argTpes) = context.savingUndeterminedTypeParams() {
+            def typedSingleArg(arg: Tree, argPtAlts: List[(Type, Symbol)], amode: Mode, matchAsPartial: Boolean): (Tree, Type, Boolean) = {
+              def typedArg0(tree: Tree) = {
+                // if we have an overloaded HOF such as `(f: Int => Int)Int <and> (f: Char => Char)Char`,
+                // and we're typing a function like `x => x` for the argument, try to collapse
+                // the overloaded type into a single function type from which `typedFunction`
+                // can derive the argument type for `x` in the function literal above
+                val (argPt, maybeRetype) =
+                  if (argPtAlts.isEmpty) (WildcardType, false)
+                  else if (treeInfo.isFunctionMissingParamType(tree)) (functionProto(argPtAlts), false)
+                  else if (treeInfo.isPartialFunctionMissingParamType(tree)) {
+                    if(matchAsPartial) {
+                      val (pfAlts, nonPfAlts) = argPtAlts.partition(ts => isPartialFunctionType(ts._1))
+                      if (pfAlts.nonEmpty && nonPfAlts.nonEmpty) (partialFunctionProto(argPtAlts), true)
+                      else if (pfAlts.nonEmpty) (partialFunctionProto(argPtAlts), false)
+                      else (functionProto(argPtAlts), false)
+                    } else (functionProto(argPtAlts), false)
+                  } else (WildcardType, false)
+                val tree2 = if (maybeRetype) duplicateAndKeepPositions(tree) else tree
+                val argTyped = typedArg(tree2, amode, BYVALmode, argPt)
+                (argTyped, argTyped.tpe.deconst, maybeRetype)
+              }
+
+              arg match {
+                // scala/bug#8197/scala/bug#4592 call for checking whether this named argument could be interpreted as an assign
+                // infer.checkNames must not use UnitType: it may not be a valid assignment, or the setter may return another type from Unit
+                // TODO: just make it an error to refer to a non-existent named arg, as it's far more likely to be
+                //       a typo than an assignment passed as an argument
+                case AssignOrNamedArg(lhs@Ident(name), rhs) =>
+                  // named args: only type the righthand sides ("unknown identifier" errors otherwise)
+                  // the assign is untyped; that's ok because we call doTypedApply
+                  typedArg0(rhs) match {
+                    case (rhsTyped, tp, partial) => (treeCopy.AssignOrNamedArg(arg, lhs, rhsTyped), NamedType(name, tp), partial)
+                  }
+                case treeInfo.WildcardStarArg(_) =>
+                  typedArg0(arg) match {
+                    case (argTyped, tp, partial) => (argTyped, RepeatedType(tp), partial)
+                  }
+                case _ =>
+                  typedArg0(arg)
+              }
+            }
+
+            val (args1, argTpes, maybeRetypeArgs) = context.savingUndeterminedTypeParams() {
               val amode = forArgMode(fun, mode)
-
-              map2(args, altArgPts) { (arg, argPtAlts) =>
-                def typedArg0(tree: Tree) = {
-                  // if we have an overloaded HOF such as `(f: Int => Int)Int <and> (f: Char => Char)Char`,
-                  // and we're typing a function like `x => x` for the argument, try to collapse
-                  // the overloaded type into a single function type from which `typedFunction`
-                  // can derive the argument type for `x` in the function literal above
-                  val argPt =
-                    if (argPtAlts.isEmpty) WildcardType
-                    else if (treeInfo.isFunctionMissingParamType(tree)) functionProto(argPtAlts)
-                    else if (treeInfo.isPartialFunctionMissingParamType(tree)) partialFunctionProto(argPtAlts)
-                    else WildcardType
-
-                  val argTyped = typedArg(tree, amode, BYVALmode, argPt)
-                  (argTyped, argTyped.tpe.deconst)
-                }
-
-                arg match {
-                  // scala/bug#8197/scala/bug#4592 call for checking whether this named argument could be interpreted as an assign
-                  // infer.checkNames must not use UnitType: it may not be a valid assignment, or the setter may return another type from Unit
-                  // TODO: just make it an error to refer to a non-existent named arg, as it's far more likely to be
-                  //       a typo than an assignment passed as an argument
-                  case AssignOrNamedArg(lhs@Ident(name), rhs) =>
-                    // named args: only type the righthand sides ("unknown identifier" errors otherwise)
-                    // the assign is untyped; that's ok because we call doTypedApply
-                    typedArg0(rhs) match {
-                      case (rhsTyped, tp) => (treeCopy.AssignOrNamedArg(arg, lhs, rhsTyped), NamedType(name, tp))
-                    }
-                  case treeInfo.WildcardStarArg(_) =>
-                    typedArg0(arg) match {
-                      case (argTyped, tp) => (argTyped, RepeatedType(tp))
-                    }
-                  case _ =>
-                    typedArg0(arg)
-                }
-              }.unzip
+              map2(args, altArgPts) { (arg, argPtAlts) => typedSingleArg(arg, argPtAlts, amode, matchAsPartial = true) }.unzip3
             }
             if (context.reporter.hasErrors)
               setError(tree)
             else {
               inferMethodAlternative(fun, undetparams, argTpes, pt)
-              doTypedApply(tree, adaptAfterOverloadResolution(fun, mode.forFunMode, WildcardType), args1, mode, pt)
+              val args2 = if(maybeRetypeArgs contains true) {
+                // There were pattern-matching anonymous functions in the argument list which got typed as PartialFunction
+                // but if the inferred alternative does not actually need a PartialFunction we retype it as Function1.
+                def paramTypes(tpe: Type): List[Type] = tpe match {
+                  case ExistentialType(_, qtpe) => paramTypes(qtpe)
+                  case MethodType(syms, _) => syms.map(_.tpe)
+                  case TypeRef(_, _, tpes) => tpes.init
+                  case _ => Nil
+                }
+                val selectedParams = paramTypes(normalize(fun.tpe))
+                if(selectedParams.nonEmpty) {
+                  context.savingUndeterminedTypeParams() {
+                    val amode = forArgMode(fun, mode)
+                    val keepTypes = map3(selectedParams, maybeRetypeArgs, args1) { (param, maybeRetype, arg1) =>
+                      if (maybeRetype && !isPartialFunctionType(param)) None else Some(arg1)
+                    }
+                    map3(args, altArgPts, keepTypes) {
+                      case (_, _, Some(keep)) => keep
+                      case (arg, argPtAlts, None) => typedSingleArg(arg, argPtAlts, amode, matchAsPartial = false)._1
+                    }
+                  }
+                } else args1
+              } else args1
+              doTypedApply(tree, adaptAfterOverloadResolution(fun, mode.forFunMode, WildcardType), args2, mode, pt)
             }
           }
           handleOverloaded

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3340,13 +3340,17 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
             def funArgTypes(tpAlts: List[(Type, Symbol)]) = tpAlts.map { case (tp, alt) =>
               val relTp = tp.asSeenFrom(pre, alt.owner)
-              val argTps = functionOrSamArgTypes(relTp)
+              val argTps = functionOrPfOrSamArgTypes(relTp)
               //println(s"funArgTypes $argTps from $relTp")
               argTps.map(approximateAbstracts)
             }
 
             def functionProto(argTpWithAlt: List[(Type, Symbol)]): Type =
               try functionType(funArgTypes(argTpWithAlt).transpose.map(lub), WildcardType)
+              catch { case _: IllegalArgumentException => WildcardType }
+
+            def partialFunctionProto(argTpWithAlt: List[(Type, Symbol)]): Type =
+              try appliedType(PartialFunctionClass, funArgTypes(argTpWithAlt).transpose.map(lub) :+ WildcardType)
               catch { case _: IllegalArgumentException => WildcardType }
 
             // To propagate as much information as possible to typedFunction, which uses the expected type to
@@ -3359,7 +3363,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             // and lubbing the argument types (we treat SAM and FunctionN types equally, but non-function arguments
             // do not receive special treatment: they are typed under WildcardType.)
             val altArgPts =
-              if (settings.isScala212 && args.exists(treeInfo.isFunctionMissingParamType))
+              if (settings.isScala212 && args.exists(t => treeInfo.isFunctionMissingParamType(t) || treeInfo.isPartialFunctionMissingParamType(t)))
                 try alts.map(alt => formalTypes(alt.info.paramTypes, argslen).map(ft => (ft, alt))).transpose // do least amount of work up front
                 catch { case _: IllegalArgumentException => args.map(_ => Nil) } // fail safe in case formalTypes fails to align to argslen
               else args.map(_ => Nil) // will type under argPt == WildcardType
@@ -3374,7 +3378,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                   // the overloaded type into a single function type from which `typedFunction`
                   // can derive the argument type for `x` in the function literal above
                   val argPt =
-                    if (argPtAlts.nonEmpty && treeInfo.isFunctionMissingParamType(tree)) functionProto(argPtAlts)
+                    if (argPtAlts.isEmpty) WildcardType
+                    else if (treeInfo.isFunctionMissingParamType(tree)) functionProto(argPtAlts)
+                    else if (treeInfo.isPartialFunctionMissingParamType(tree)) partialFunctionProto(argPtAlts)
                     else WildcardType
 
                   val argTyped = typedArg(tree, amode, BYVALmode, argPt)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3422,12 +3422,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 // There were pattern-matching anonymous functions in the argument list which got typed as PartialFunction
                 // but if the inferred alternative does not actually need a PartialFunction we retype it as Function1.
                 def paramTypes(tpe: Type): List[Type] = tpe match {
-                  case ExistentialType(_, qtpe) => paramTypes(qtpe)
+                  case PolyType(_, restpe) => paramTypes(restpe)
                   case MethodType(syms, _) => syms.map(_.tpe)
-                  case TypeRef(_, _, tpes) => tpes.init
                   case _ => Nil
                 }
-                val selectedParams = paramTypes(normalize(fun.tpe))
+                val selectedParams = paramTypes(fun.tpe)
                 if(selectedParams.nonEmpty) {
                   context.savingUndeterminedTypeParams() {
                     val amode = forArgMode(fun, mode)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -691,11 +691,11 @@ trait Definitions extends api.StandardDefinitions {
       }
     }
 
-    // the argument types expected by the function described by `tp` (a FunctionN or SAM type),
-    // or `Nil` if `tp` does not represent a function type or SAM (or if it happens to be Function0...)
-    def functionOrSamArgTypes(tp: Type): List[Type] = {
+    // the argument types expected by the function described by `tp` (a FunctionN or PartialFunction or SAM type),
+    // or `Nil` if `tp` does not represent a function type or PartialFunction or SAM (or if it happens to be Function0...)
+    def functionOrPfOrSamArgTypes(tp: Type): List[Type] = {
       val dealiased = tp.dealiasWiden
-      if (isFunctionTypeDirect(dealiased)) dealiased.typeArgs.init
+      if (isFunctionTypeDirect(dealiased) || isPartialFunctionType(dealiased)) dealiased.typeArgs.init
       else samOf(tp) match {
         case samSym if samSym.exists => tp.memberInfo(samSym).paramTypes
         case _ => Nil

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -265,6 +265,10 @@ abstract class TreeInfo {
 
   def isFunctionMissingParamType(tree: Tree): Boolean = tree match {
     case Function(vparams, _) => vparams.exists(_.tpt.isEmpty)
+    case _ => false
+  }
+
+  def isPartialFunctionMissingParamType(tree: Tree): Boolean = tree match {
     case Match(EmptyTree, _) => true
     case _ => false
   }

--- a/test/files/run/InferOverloadedPartialFunction.scala
+++ b/test/files/run/InferOverloadedPartialFunction.scala
@@ -45,3 +45,12 @@ object Test extends App {
   def h[R](pf: PartialFunction[(Double, Double), R]): Int = 2
   assert(h { case (a: Double, b: Double) => 42: Int } == 2)
 }
+
+trait SortedMap {
+  def collect[B](pf: PartialFunction[(String, Int), B]): Int = 0
+  def collect[K2 : Ordering, V2](pf: PartialFunction[(String, Int), (K2, V2)]): Int = 0
+  def collectF[B](pf: Function1[(String, Int), B]): Int = 0
+  def collectF[K2 : Ordering, V2](pf: Function1[(String, Int), (K2, V2)]): Int = 0
+  def foo(xs: SortedMap) = xs.collect { case (k, v) => 1 }
+  def fooF(xs: SortedMap) = xs.collectF { case (k, v) => 1 }
+}

--- a/test/files/run/InferOverloadedPartialFunction.scala
+++ b/test/files/run/InferOverloadedPartialFunction.scala
@@ -44,13 +44,30 @@ object Test extends App {
   def h[R](pf: Function2[Int, String, R]): Int = 1
   def h[R](pf: PartialFunction[(Double, Double), R]): Int = 2
   assert(h { case (a: Double, b: Double) => 42: Int } == 2)
+
+  val xs = new SortedMap
+  assert(xs.collectF { kv => 1 } == 0)
+  assert(xs.collectF { case (k, v) => 1 } == 0)
+  assert(xs.collectF { case (k, v) => (1, 1) } == 2)
+  assert(xs.collect { case (k, v) => 1 } == 0)
+  assert(xs.collect { case (k, v) => (1, 1) } == 1)
+
+  val ys = new SortedMapMixed
+  assert(ys.collect { kv => 1 } == 0)
+  assert(ys.collect { kv => (1, 1) } == 0)
+  assert(ys.collect { case (k, v) => 1 } == 0)
+  assert(ys.collect { case (k, v) => (1, 1) } == 2)
 }
 
-trait SortedMap {
+class SortedMap {
   def collect[B](pf: PartialFunction[(String, Int), B]): Int = 0
-  def collect[K2 : Ordering, V2](pf: PartialFunction[(String, Int), (K2, V2)]): Int = 0
-  def collectF[B](pf: Function1[(String, Int), B]): Int = 0
-  def collectF[K2 : Ordering, V2](pf: Function1[(String, Int), (K2, V2)]): Int = 0
-  def foo(xs: SortedMap) = xs.collect { case (k, v) => 1 }
-  def fooF(xs: SortedMap) = xs.collectF { case (k, v) => 1 }
+  def collect[K2 : Ordering, V2](pf: PartialFunction[(String, Int), (K2, V2)]): Int = 1
+  def collectF[B](pf: Function1[(String, Int), B]): Int = if(pf.isInstanceOf[PartialFunction[_, _]]) 1 else 0
+  def collectF[K2 : Ordering, V2](pf: Function1[(String, Int), (K2, V2)]): Int = if(pf.isInstanceOf[PartialFunction[_, _]]) 3 else 2
+}
+
+class SortedMapMixed {
+  type PF[-A, +B] = PartialFunction[A, B]
+  def collect[B](pf: Function1[(String, Int), B]): Int = if(pf.isInstanceOf[PartialFunction[_, _]]) 1 else 0
+  def collect[K2 : Ordering, V2](pf: PF[(String, Int), (K2, V2)]): Int = 2
 }


### PR DESCRIPTION
The extension of shape-based overload resolutions for pattern-matching
anonymous functions in https://github.com/scala/scala/pull/5698 did not
work correctly in all cases:

- Type unification for shapes needs to treat `PartialFunction` types
  the same as `FunctionN` and SAM types. They were considered for
  unification but the parameter type was not extracted correctly.

- When the matched argument types are constructed after a successful
  shape match, a pattern-matching anonymous function has to be typed as
  `PartialFunction` instead of `FunctionN`.