### PR TITLE
Avoid calling static initializers when reflecting on Java classes

### DIFF
--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -552,7 +552,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
     }
 
     def javaClass(path: String): jClass[_] =
-      jClass.forName(path, true, classLoader)
+      jClass.forName(path, false, classLoader)
 
     /** Does `path` correspond to a Java class with that fully qualified name in the current class loader? */
     def tryJavaClass(path: String): Option[jClass[_]] = (
@@ -1218,7 +1218,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
         // suggested in https://github.com/scala/bug/issues/4023#issuecomment-292387855
         var ownerClazz = classToJava(clazz.owner.asClass)
         if (childOfTopLevelObject)
-          ownerClazz = jClass.forName(ownerClazz.getName stripSuffix "$", true, ownerClazz.getClassLoader)
+          ownerClazz = jClass.forName(ownerClazz.getName stripSuffix "$", false, ownerClazz.getClassLoader)
 
         val ownerChildren = ownerClazz.getDeclaredClasses
 

--- a/test/files/run/reflection-clinit-nested/A.java
+++ b/test/files/run/reflection-clinit-nested/A.java
@@ -1,0 +1,8 @@
+package p1;
+
+public class A {
+  static { throww(); }
+  static void throww() { throw null; }
+  public class Inner { }
+  public static class StaticInner { static { throww(); } }
+}

--- a/test/files/run/reflection-clinit-nested/Test.scala
+++ b/test/files/run/reflection-clinit-nested/Test.scala
@@ -1,0 +1,8 @@
+import reflect.runtime._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    currentMirror.staticClass("p1.A").info.members.find(_.isType).get.name
+    currentMirror.staticModule("p1.A").info.members.find(_.isType).get.name
+  }
+}

--- a/test/files/run/reflection-clinit/A.java
+++ b/test/files/run/reflection-clinit/A.java
@@ -1,0 +1,6 @@
+package p1;
+
+public class A {
+  static { throww(); }
+  static void throww() { throw null; }
+}

--- a/test/files/run/reflection-clinit/Test.scala
+++ b/test/files/run/reflection-clinit/Test.scala
@@ -1,0 +1,8 @@
+import reflect.runtime.universe._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    typeOf[p1.A] // used to call C.<clinit>
+  }
+}
+


### PR DESCRIPTION
This means that `typeOf[C]` is now equivalent to `Class.forName("C", /*initialize*/ = false, loader`), which doesn't call the classes static initializer.
