### PR TITLE
Fix configuration of SBT incremental compiler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -337,8 +337,6 @@ lazy val library = configureAsSubproject(project)
         "-doc-root-content", (sourceDirectory in Compile).value + "/rootdoc.txt"
       )
     },
-    // macros in library+reflect are hard-wired to implementations with `FastTrack`.
-    incOptions := incOptions.value.withRecompileOnMacroDef(false),
     includeFilter in unmanagedResources in Compile := "*.tmpl" | "*.xml" | "*.js" | "*.css" | "rootdoc.txt",
     // Include *.txt files in source JAR:
     mappings in Compile in packageSrc ++= {
@@ -366,8 +364,6 @@ lazy val reflect = configureAsSubproject(project)
   .settings(
     name := "scala-reflect",
     description := "Scala Reflection Library",
-    // macros in library+reflect are hard-wired to implementations with `FastTrack`.
-    incOptions := incOptions.value.withRecompileOnMacroDef(false),
     Osgi.bundleName := "Scala Reflect",
     scalacOptions in Compile in doc ++= Seq(
       "-skip-packages", "scala.reflect.macros.internal:scala.reflect.internal:scala.reflect.io"
@@ -881,7 +877,11 @@ lazy val root: Project = (project in file("."))
       }
     },
     antStyle := false,
-    incOptions := incOptions.value.withNameHashing(!antStyle.value).withAntStyle(antStyle.value)
+    incOptions := {
+      incOptions.value
+        .withNameHashing(!antStyle.value).withAntStyle(antStyle.value)
+        .withRecompileOnMacroDef(false) //     // macros in library+reflect are hard-wired to implementations with `FastTrack`.
+    }
   )
   .aggregate(library, reflect, compiler, interactive, repl, replJline, replJlineEmbedded,
     scaladoc, scalap, partestExtras, junit, libraryAll, scalaDist).settings(


### PR DESCRIPTION
We want to use the (old) rules for incremental compilation
after editing files with macro definitions, as the new
rules lead to a lot of recompiles.

We'd previously configured this, but the change had been
somehow broken by a more recent change to the incremental
compiler options.

This commit moves both of the configs to the same part of
our build, which seems to make it stick:

```
% sbt consoleProject
> (incOptions in LocalRootProject).eval.recompileOnMacroDef
false
```

Fixes scala/scala-dev#337