### PR TITLE
Fix bridging at the nexus of lambdas, dep. types, local modules

### DIFF
--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1602,15 +1602,19 @@ trait Trees extends api.Trees {
         subst(from, to)
         tree match {
           case _: DefTree =>
-            val newInfo = symSubst(tree.symbol.info)
-            if (!(newInfo =:= tree.symbol.info)) {
-              debuglog(sm"""
-                |TreeSymSubstituter: updated info of symbol ${tree.symbol}
-                |  Old: ${showRaw(tree.symbol.info, printTypes = true, printIds = true)}
-                |  New: ${showRaw(newInfo, printTypes = true, printIds = true)}""")
-              mutatedSymbols ::= tree.symbol
-              tree.symbol updateInfo newInfo
+            def update(sym: Symbol) = {
+              val newInfo = symSubst(sym.info)
+              if (!(newInfo =:= sym.info)) {
+                debuglog(sm"""
+                  |TreeSymSubstituter: updated info of symbol ${sym}
+                  |  Old: ${showRaw(sym.info, printTypes = true, printIds = true)}
+                  |  New: ${showRaw(newInfo, printTypes = true, printIds = true)}""")
+                mutatedSymbols ::= sym
+                sym updateInfo newInfo
+              }
             }
+            update(tree.symbol)
+            if (tree.symbol.isModule) update(tree.symbol.moduleClass)
           case _          =>
             // no special handling is required for Function or Import nodes here.
             // as they don't have interesting infos attached to their symbols.

--- a/test/files/run/sd336.scala
+++ b/test/files/run/sd336.scala
@@ -1,0 +1,16 @@
+object Test {
+  final def main(args: Array[String]): Unit = {
+    val f: A => Any = { a =>
+      case class Case(abc: a.b.C)
+      foo(Case, new a.b.C)
+    }
+    f(new A(new B))
+  }
+
+  def foo[A, B](f: A => B, a: A): B = f(a)
+}
+
+class A(val b: B)
+class B {
+  class C
+}


### PR DESCRIPTION
When we move the lambda RHS into a method (which is the target
of the LambdaMetaFactory invokedynamic bootstrap), we have to
substitute references to the lambda parameters with references
to the parameters of the lambda impl. method.

Turns out out substitution utility failed to do anything with
module classes info. The failure to substitute manifested as
an type mismatch between the inherited apply method and the one
defined in the companion factory method, which meant the requisite
bridge was skipped.

Fixes scala/scala-dev#336