### PR TITLE
Fix regression with eta expansion of implicit method

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5296,7 +5296,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case Typed(expr, Function(Nil, EmptyTree)) =>
             typed1(suppressMacroExpansion(expr), mode, pt) match {
               case macroDef if treeInfo.isMacroApplication(macroDef) => MacroEtaError(macroDef)
-              case methodValue                                       => typedEta(checkDead(methodValue), tree)
+              case methodValue                                       => typedEta(checkDead(methodValue), expr)
             }
           case Typed(expr, tpt) =>
             val tpt1  = typedType(tpt, mode)                           // type the ascribed type first

--- a/test/files/neg/t10279.check
+++ b/test/files/neg/t10279.check
@@ -1,0 +1,4 @@
+t10279.scala:9: error: could not find implicit value for parameter s: String
+  foo(1) _
+     ^
+one error found

--- a/test/files/neg/t10279.check
+++ b/test/files/neg/t10279.check
@@ -1,4 +1,7 @@
 t10279.scala:9: error: could not find implicit value for parameter s: String
-  foo(1) _
-     ^
-one error found
+  val bar = foo(1) _
+               ^
+t10279.scala:12: error: could not find implicit value for parameter x: Int
+  val barSimple = fooSimple _
+                  ^
+two errors found

--- a/test/files/neg/t10279.scala
+++ b/test/files/neg/t10279.scala
@@ -1,0 +1,10 @@
+object Test {
+
+  def foo(i: Int)(implicit s: String): String = ???
+
+  def test(implicit s: String) {
+    // foo(1) _
+  }
+
+  foo(1) _
+}

--- a/test/files/neg/t10279.scala
+++ b/test/files/neg/t10279.scala
@@ -6,5 +6,8 @@ object Test {
     // foo(1) _
   }
 
-  foo(1) _
+  val bar = foo(1) _
+
+  def fooSimple(implicit x: Int): Int = x
+  val barSimple = fooSimple _
 }

--- a/test/files/run/byname.check
+++ b/test/files/run/byname.check
@@ -1,3 +1,4 @@
+warning: there were two deprecation warnings (since 2.12.0); re-run with -deprecation for details
 test no braces completed properly
 test no braces r completed properly
 test plain completed properly


### PR DESCRIPTION
In #5327, a change was made to typedEta to accept an
original (ie, pre-typechecked) tree to be used in a
fallback path.

However, the caller provided an original tree larger
than the actual tree being typechecked.

This commit just passes the part of the orig tree that
corresponds to the tree we're eta expanding, rather than
the entire `Typed(methodValue, functionPt)` tree.

That avoids an infinite loop in typechecking the erroneous
code in the test case.

Fixes scala/bug#10279