### PR TITLE
Don't lose track of imports in presentation compiler

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -281,7 +281,11 @@ trait Namers extends MethodSynthesis {
       }
       tree.symbol match {
         case NoSymbol => try dispatch() catch typeErrorHandler(tree, this.context)
-        case sym      => enterExistingSym(sym, tree)
+        case sym      =>
+          tree match {
+            case tree@Import(_, _) => enterExistingSym(sym, tree).make(tree)
+            case _ => enterExistingSym(sym, tree)
+          }
       }
     }
 

--- a/test/files/presentation/t9238.scala
+++ b/test/files/presentation/t9238.scala
@@ -1,0 +1,65 @@
+import scala.reflect.internal.util.BatchSourceFile
+import scala.tools.nsc.{interactive, Settings}
+import scala.tools.nsc.reporters.ConsoleReporter
+
+object Test {
+
+  def main(args: Array[String]) {
+    val settings = new Settings
+    settings.usejavacp.value = true
+    val reporter = new ConsoleReporter(settings)
+
+    val iglobal = new interactive.Global(settings, reporter)
+    import iglobal._
+
+    def getOrThrow[T](resp: Response[T]) = resp.get match {
+      case Left(res) => res
+      case Right(t) => throw t
+    }
+
+    def load(sourceFile: BatchSourceFile) = {
+      val resp = new Response[Tree]
+      askLoadedTyped(sourceFile, resp)
+      getOrThrow(resp)
+    }
+
+    val prestestSrc = new BatchSourceFile("Prestest.scala",
+      """
+        |package prestest
+        |
+        |object Prestest {
+        |  trait Root {
+        |    def meth = 5
+        |  }
+        |}
+        |
+      """.stripMargin
+    )
+
+    load(prestestSrc)
+
+    val opsSrc = new BatchSourceFile("ops.scala",
+      """
+        |package com.whatever
+        |
+        |//import prestest.Prestest.Root // this was okay
+        |
+        |object Utils {
+        |
+        |  import prestest.Prestest.Root // but this import was not recognised when typecking the implicit class parameter formal type
+        |
+        |  implicit class rootOps(root: Root) {
+        |    def implicitMethod: Int = 42
+        |  }
+        |
+        |}
+      """.stripMargin)
+
+    load(opsSrc)
+
+    if(reporter.hasErrors) {
+      throw new Exception("There were errors")
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes regression in that the reporter bisected to #4079.

I haven't reverted that change, but rather noticed that
the path through namers that enters trees that already
have symbols assigned was not extending the context chain
for imports.

Fixes scala/bug#9283