### PR TITLE
-opt-inline-from:<sources> to allow inlining from compilation units

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -319,6 +319,8 @@ trait ScalaSettings extends AbsScalaSettings
         |  a.**.*Util*    Classes in a and sub-packages with Util in their name (including a.Util)
         |  a.C$D          The nested class D defined in class a.C
         |  scala.Predef$  The scala.Predef object
+        |  <sources>      Classes defined in source files compiled in the current compilation, either
+        |                 passed explicitly to the compiler or picked up from the `-sourcepath`
         |
         |The setting accepts a list of patterns: `-opt-inline-from:p1:p2`. The setting can be passed
         |multiple times, the list of patterns gets extended. A leading `!` marks a pattern excluding.


### PR DESCRIPTION
Introduces a new special `<sources>` pattern for the `-opt-inline-from`
setting. The flag allows inlining from any source file being compiled
in the current compilation run, including sources picked up from the
`-sourcepath`. This is equivalent to the `-opt:l:project` option in
2.12.0-2.