### PR TITLE
[REVERTED] Add infer Product with Serializable linter flag

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -73,7 +73,8 @@ trait Warnings {
     val NullaryUnit            = LintWarning("nullary-unit",              "Warn when nullary methods return Unit.",                                    true)
     val Inaccessible           = LintWarning("inaccessible",              "Warn about inaccessible types in method signatures.",                       true)
     val NullaryOverride        = LintWarning("nullary-override",          "Warn when non-nullary `def f()' overrides nullary `def f'.",                true)
-    val InferAny               = LintWarning("infer-any",                 "Warn when a type argument is inferred to be `Any`.",                        true)
+    val InferAny               = LintWarning("infer-any",                 "Warn when a type argument, variable definition or method definition is inferred to be `Any`.", true)
+    val InferPwS               = LintWarning("infer-pws",                 "Warn when a type argument, variable definition, or method definition is inferred to be `Product with Serializable`.")
     val MissingInterpolator    = LintWarning("missing-interpolator",      "A string literal appears to be missing an interpolator id.")
     val DocDetached            = LintWarning("doc-detached",              "A Scaladoc comment appears to be detached from its element.")
     val PrivateShadow          = LintWarning("private-shadow",            "A private field (or class parameter) shadows a superclass field.")
@@ -97,6 +98,7 @@ trait Warnings {
   def warnInaccessible           = lint contains Inaccessible
   def warnNullaryOverride        = lint contains NullaryOverride
   def warnInferAny               = lint contains InferAny
+  def warnInferPwS               = lint contains InferPwS
   def warnMissingInterpolator    = lint contains MissingInterpolator
   def warnDocDetached            = lint contains DocDetached
   def warnPrivateShadow          = lint contains PrivateShadow

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -551,21 +551,37 @@ trait Infer extends Checkable {
         }
       }
       val targs = solvedTypes(tvars, tparams, tparams map varianceInTypes(formals), upper = false, lubDepth(formals) max lubDepth(argtpes))
+      def warnIfInferred(warn: Type => Boolean) = {
+        if (context.reportErrors && !fn.isEmpty) {
+          targs.withFilter(warn).foreach { targ =>
+            reporter.warning(fn.pos, s"a type was inferred to be `$targ`; this may indicate a programming error.")
+          }
+        }
+      }
+      def canWarnAbout(explicitlyTyped: List[Type] => Boolean): Boolean = {
+        val loBounds = tparams map (_.info.bounds.lo)
+        val hasExplicitType = pt :: restpe :: formals ::: argtpes ::: loBounds exists (tp => explicitlyTyped(tp.dealiasWidenChain))
+        !hasExplicitType
+      }
       // Can warn about inferring Any/AnyVal as long as they don't appear
       // explicitly anywhere amongst the formal, argument, result, or expected type.
       // ...or lower bound of a type param, since they're asking for it.
-      def canWarnAboutAny = {
-        val loBounds = tparams map (_.info.bounds.lo)
-        def containsAny(t: Type) = (t contains AnyClass) || (t contains AnyValClass)
-        val hasAny = pt :: restpe :: formals ::: argtpes ::: loBounds exists (_.dealiasWidenChain exists containsAny)
-        !hasAny
+      def canWarnAboutAny = canWarnAbout(_ exists (t => (t contains AnyClass) || (t contains AnyValClass)))
+      if (settings.warnInferAny && canWarnAboutAny) {
+        warnIfInferred {
+          _.typeSymbol match {
+            case AnyClass | AnyValClass => true
+            case _ => false
+          }
+        }
       }
-      if (settings.warnInferAny && context.reportErrors && !fn.isEmpty && canWarnAboutAny) {
-        targs.foreach(_.typeSymbol match {
-          case sym @ (AnyClass | AnyValClass) =>
-            reporter.warning(fn.pos, s"a type was inferred to be `${sym.name}`; this may indicate a programming error.")
-          case _ =>
-        })
+      // Ditto for Product with Serializable
+      def canWarnAboutPwS = canWarnAbout(tps => (tps exists (_ contains ProductRootClass)) && (tps exists (_ contains SerializableClass)))
+      if (settings.warnInferPwS && canWarnAboutPwS) {
+        warnIfInferred {
+          case RefinedType(ProductRootTpe :: SerializableTpe :: _, scope) if scope.isEmpty => true
+          case _ => false
+        }
       }
       adjustTypeArgs(tparams, tvars, targs, restpe)
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1070,7 +1070,24 @@ trait Namers extends MethodSynthesis {
 
       val defnTpe = widenIfNecessary(tree.symbol, rhsTpe, pt)
       tree.tpt defineType defnTpe setPos tree.pos.focus
-      tree.tpt.tpe
+      val tpe = tree.tpt.tpe
+      // if enabled, validate that the now inferred val or def type isn't PwS
+      if (settings.warnInferPwS && context.reportErrors) {
+        tpe match {
+          case RefinedType(ProductRootTpe :: SerializableTpe :: _, scope) if scope.isEmpty =>
+            reporter.warning(tree.pos, s"a type was inferred to be `$tpe`; this may indicate a programming error")
+          case _ =>
+        }
+      }
+      // if enabled, validate the now inferred type isn't Any or AnyVal
+      if (settings.warnInferAny && context.reportErrors) {
+        tpe match {
+          case AnyTpe | AnyValTpe =>
+            reporter.warning(tree.pos, s"a type was inferred to be `$tpe`; this may indicate a programming error")
+          case _ =>
+        }
+      }
+      tpe
     }
 
     // owner is the class with the self type

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -712,6 +712,7 @@ trait Definitions extends api.StandardDefinitions {
     def tupleComponents(tp: Type)      = tp.dealiasWiden.typeArgs
 
     lazy val ProductRootClass: ClassSymbol = requiredClass[scala.Product]
+    lazy val ProductRootTpe: Type          = ProductRootClass.tpe
       def Product_productArity          = getMemberMethod(ProductRootClass, nme.productArity)
       def Product_productElement        = getMemberMethod(ProductRootClass, nme.productElement)
       def Product_iterator              = getMemberMethod(ProductRootClass, nme.productIterator)

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -339,6 +339,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.AbstractFunctionClass
     definitions.MacroContextType
     definitions.ProductRootClass
+    definitions.ProductRootTpe
     definitions.Any_$eq$eq
     definitions.Any_$bang$eq
     definitions.Any_equals

--- a/test/files/neg/warn-inferred-any.check
+++ b/test/files/neg/warn-inferred-any.check
@@ -10,6 +10,18 @@ warn-inferred-any.scala:17: warning: a type was inferred to be `AnyVal`; this ma
 warn-inferred-any.scala:25: warning: a type was inferred to be `Any`; this may indicate a programming error.
   def za = f(1, "one")
            ^
+warn-inferred-any.scala:30: warning: a type was inferred to be `AnyVal`; this may indicate a programming error
+  def get(b: Boolean) = if (b) 42 else true // warn (AnyVal)
+      ^
+warn-inferred-any.scala:31: warning: a type was inferred to be `Any`; this may indicate a programming error
+  def got(b: Boolean) = if (b) 42 else "42" // warn (Any)
+      ^
+warn-inferred-any.scala:35: warning: a type was inferred to be `AnyVal`; this may indicate a programming error
+  val foo = if (true) 42 else false // warn (AnyVal)
+      ^
+warn-inferred-any.scala:36: warning: a type was inferred to be `Any`; this may indicate a programming error
+  val bar = if (true) 42 else "42" // warn (Any)
+      ^
 error: No warnings can be incurred under -Xfatal-warnings.
-four warnings found
+8 warnings found
 one error found

--- a/test/files/neg/warn-inferred-any.scala
+++ b/test/files/neg/warn-inferred-any.scala
@@ -25,3 +25,21 @@ trait Zs {
   def za = f(1, "one")
   def zu = g(1, "one")
 }
+
+trait DefAny {
+  def get(b: Boolean) = if (b) 42 else true // warn (AnyVal)
+  def got(b: Boolean) = if (b) 42 else "42" // warn (Any)
+}
+
+trait ValAny {
+  val foo = if (true) 42 else false // warn (AnyVal)
+  val bar = if (true) 42 else "42" // warn (Any)
+}
+
+// these should not warn due to explicit types
+trait ExplicitAny {
+  def get(b: Boolean): AnyVal = if (b) 42 else true
+  def got(b: Boolean): Any = if (b) 42 else "42"
+  val foo: AnyVal = if (true) 42 else false
+  val bar: Any = if (true) 42 else "42"
+}

--- a/test/files/neg/warn-inferred-pws.check
+++ b/test/files/neg/warn-inferred-pws.check
@@ -1,0 +1,15 @@
+warn-inferred-pws.scala:2: warning: a type was inferred to be `Product with Serializable`; this may indicate a programming error
+  def get(list: Boolean) = if (list) List(1, 2, 3) else (1, 2, 3) // warn
+      ^
+warn-inferred-pws.scala:6: warning: a type was inferred to be `Product with Serializable`; this may indicate a programming error
+  val foo = if (true) List(1, 2) else (1, 2) // warn
+      ^
+warn-inferred-pws.scala:11: warning: a type was inferred to be `Product with Serializable`; this may indicate a programming error.
+  val g = f((1, 2), List(1, 2)) // warn
+          ^
+warn-inferred-pws.scala:15: warning: a type was inferred to be `Product with Serializable`; this may indicate a programming error.
+  { List(List(1, 2)) contains ((1, 2)) } // warn
+                     ^
+error: No warnings can be incurred under -Xfatal-warnings.
+four warnings found
+one error found

--- a/test/files/neg/warn-inferred-pws.flags
+++ b/test/files/neg/warn-inferred-pws.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xlint:infer-pws

--- a/test/files/neg/warn-inferred-pws.scala
+++ b/test/files/neg/warn-inferred-pws.scala
@@ -1,0 +1,28 @@
+trait DefPwS {
+  def get(list: Boolean) = if (list) List(1, 2, 3) else (1, 2, 3) // warn
+}
+
+trait ValPwS {
+  val foo = if (true) List(1, 2) else (1, 2) // warn
+}
+
+trait ParamPwS {
+  def f[A](as: A*) = 42
+  val g = f((1, 2), List(1, 2)) // warn
+}
+
+trait GenericTraitPwS[+A] {
+  { List(List(1, 2)) contains ((1, 2)) } // warn
+}
+
+// these should not warn as they have explicit types
+trait NoWarning {
+  def get(list: Boolean): Product with Serializable =
+    if (list) List(1, 2) else (1, 2)
+  lazy val foo: Product with Serializable = if (true) List(1, 2) else (1, 2)
+  lazy val bar: Any = if (true) List(1, 2) else (1, 2)
+  def f[A](as: A*) = 42
+  lazy val baz = f[Product with Serializable]((1, 2), List(1, 2))
+  def g[A >: Product with Serializable](as: A*) = 42
+  lazy val biz = g((1, 2), List(1, 2))
+}


### PR DESCRIPTION
This adds a new lint warning, -Xlint:infer-product-with-serializable
which warns when an inferred value or method type is Product with
Serializable. This is oftentimes a programmer error from mixing up what
would otherwise be incompatible types (which could be caught by the
-Xlint:infer-any flag otherwise) that have the common PwS supertype. As
this inferred type tends to be useless, this lint flag helps avoid
errors related to this inference.

Requesting review by @adriaanm in particular as this seems related to his expertise.