### PR TITLE
Translate appropriate JVM accessor flags into annotations.

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -519,6 +519,7 @@ abstract class ClassfileParser {
       }
       propagatePackageBoundary(jflags, sym)
       parseAttributes(sym, info)
+      addJavaFlagsAnnotations(sym, jflags)
       getScope(jflags) enter sym
 
       // sealed java enums
@@ -589,6 +590,7 @@ abstract class ClassfileParser {
         sym setInfo info
         propagatePackageBoundary(jflags, sym)
         parseAttributes(sym, info, removedOuterParameter)
+        addJavaFlagsAnnotations(sym, jflags)
         if (jflags.isVarargs)
           sym modifyInfo arrayToRepeated
 
@@ -1047,6 +1049,12 @@ abstract class ClassfileParser {
     // begin parseAttributes
     for (i <- 0 until u2) parseAttribute()
   }
+
+  /** Apply `@native`/`@transient`/`@volatile` annotations to `sym`,
+    * if the corresponding flag is set in `flags`.
+    */
+  def addJavaFlagsAnnotations(sym: Symbol, flags: JavaAccFlags): Unit =
+    flags.toScalaAnnotations(symbolTable) foreach (ann => sym.addAnnotation(ann))
 
   /** Enter own inner classes in the right scope. It needs the scopes to be set up,
    *  and implicitly current class' superclasses.

--- a/src/reflect/scala/reflect/api/Annotations.scala
+++ b/src/reflect/scala/reflect/api/Annotations.scala
@@ -14,7 +14,7 @@ import scala.collection.immutable.ListMap
  *  <ul>
  *  <li>''Java annotations'': annotations on definitions produced by the Java compiler, i.e., subtypes of [[java.lang.annotation.Annotation]]
  *  attached to program definitions. When read by Scala reflection, the [[scala.annotation.ClassfileAnnotation]] trait
- *  is automatically added as a subclass to every Java annotation.</li>
+ *  is automatically added as a superclass to every Java annotation type.</li>
  *  <li>''Scala annotations'': annotations on definitions or types produced by the Scala compiler.</li>
  *  </ul>
  *

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -11,7 +11,8 @@ import java.lang.{Class => jClass, Package => jPackage}
 import java.lang.reflect.{
   Method => jMethod, Constructor => jConstructor, Field => jField,
   Member => jMember, Type => jType, TypeVariable => jTypeVariable,
-  GenericDeclaration, GenericArrayType, ParameterizedType, WildcardType, AnnotatedElement }
+  Modifier => jModifier, GenericDeclaration, GenericArrayType,
+  ParameterizedType, WildcardType, AnnotatedElement }
 import java.lang.annotation.{Annotation => jAnnotation}
 import java.io.IOException
 import scala.reflect.internal.{ MissingRequirementError, JavaAccFlags }
@@ -675,7 +676,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
 
     /**
      * Copy all annotations of Java annotated element `jann` over to Scala symbol `sym`.
-     * Also creates `@throws` annotations if necessary.
+     * Also creates `@throws`, `@transient`, `@native`, and `@volatile` annotations if necessary.
      *  Pre: `sym` is already initialized with a concrete type.
      *  Note: If `sym` is a method or constructor, its parameter annotations are copied as well.
      */
@@ -688,6 +689,11 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
         case _                        => Nil
       }
       jexTpes foreach (jexTpe => sym.addThrowsAnnotation(classSymbol(jexTpe)))
+      jann match {
+        case mem: jMember =>
+          mem.javaFlags.toScalaAnnotations(thisUniverse) foreach (ann => sym.addAnnotation(ann))
+        case _ =>
+      }
     }
 
     private implicit class jClassOps(val clazz: jClass[_]) {

--- a/test/files/run/t10042/Checks_0.scala
+++ b/test/files/run/t10042/Checks_0.scala
@@ -1,0 +1,47 @@
+package test
+
+import reflect.api.Universe
+
+class Checks[U <: Universe with Singleton](universe: U) {
+  import universe._
+
+  def check(subj: ClassSymbol): Unit = {
+    val tpe = subj.info
+
+    /* grab the fields */
+    val volatile  = tpe.decl(TermName("_volatile"))
+    val transient = tpe.decl(TermName("_transient"))
+    val synchronized = tpe.decl(TermName("_synchronized"))
+    val native = tpe.decl(TermName("_native"))
+
+    /* initialize the infos, sigh */
+    volatile.info; transient.info; synchronized.info; native.info
+
+    /* check for the annotations */
+    assert(volatile.annotations.exists(_.tree.tpe =:= typeOf[scala.volatile]))
+    assert(transient.annotations.exists(_.tree.tpe =:= typeOf[scala.transient]))
+    assert(native.annotations.exists(_.tree.tpe =:= typeOf[scala.native]))
+
+    /* and for bonus points...?
+     * There appears to be no very good way to check if a method is synchronized
+     * in the reflection API. This is probably for the better. If someone wants to
+     * come in and add it for the benefit of an unusually intrepid macro author,
+     * go right ahead. */
+    //import internal._, decorators._
+    //assert((synchronized.flags & InternalFlags.SYNCHRONIZED) != 0L)
+
+  }
+
+}
+
+object CheckMacro {
+  import language.experimental.macros
+  def check[T]: Unit = macro impl[T]
+
+  import reflect.macros.blackbox
+  def impl[T: c.WeakTypeTag](c: blackbox.Context): c.Tree = {
+    import c.universe._
+    new Checks[c.universe.type](c.universe).check(symbolOf[T].asClass)
+    Literal(Constant(()))
+  }
+}

--- a/test/files/run/t10042/Subject_0.java
+++ b/test/files/run/t10042/Subject_0.java
@@ -1,0 +1,12 @@
+package test;
+
+public class Subject_0 {
+    public volatile int _volatile = 0;
+    public transient int _transient = 0;
+
+    public synchronized int _synchonized() {
+        return 0;
+    }
+
+    public native int _native();
+}

--- a/test/files/run/t10042/Subject_1.java
+++ b/test/files/run/t10042/Subject_1.java
@@ -1,0 +1,12 @@
+package test;
+
+public class Subject_1 {
+    public volatile int _volatile = 0;
+    public transient int _transient = 0;
+
+    public synchronized int _synchonized() {
+        return 0;
+    }
+
+    public native int _native();
+}

--- a/test/files/run/t10042/Test_1.scala
+++ b/test/files/run/t10042/Test_1.scala
@@ -1,0 +1,11 @@
+object Test extends App {
+  import test._
+
+  CheckMacro.check[Subject_0]
+  CheckMacro.check[Subject_1]
+
+  import reflect.runtime.universe, universe._
+  val checks = new Checks[universe.type](universe)
+  checks.check(symbolOf[Subject_0].asClass)
+  checks.check(symbolOf[Subject_1].asClass)
+}


### PR DESCRIPTION
a.k.a., once more into the ClassfileParser fray.

I'm having enough fun on another branch with buffing up `JavaParsers` for dealing with pesky Java expression syntax, so I thought, why not go have some fun elsewhere. Thus:

In `JavaMirrors`, add these synthetic annotations along with the real ones (and the `@throws` annotation which we already synthesize in the same place). In `ClassfileParser`, inspect the access flags and apply the appropriate annotations then. 

Happily, we were already doing The Right Thing[tm] for these classes if we loaded their symbols via `JavaParsers`, so for today that file escapes unscathed.

I gave the ol' college try to doing the same for `synchronized`, but sadly, I dropped out. There's no sane way to access it from the reflection API unless you're very familiar with the internals of the compiler and love you some casts.

Fixes scala/bug#10042.