### PR TITLE
Fix for scala/bug#5946.

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -143,11 +143,15 @@ abstract class TreeGen {
 
   /** Builds a reference to given symbol with given stable prefix. */
   def mkAttributedRef(pre: Type, sym: Symbol): RefTree = {
-    val qual = mkAttributedQualifier(pre)
-    qual match {
-      case EmptyTree                                  => mkAttributedIdent(sym)
-      case This(clazz) if qual.symbol.isEffectiveRoot => mkAttributedIdent(sym)
-      case _                                          => mkAttributedSelect(qual, sym)
+    pre match {
+      case TypeRef(NoPrefix, _: TypeSkolem, Nil) => mkAttributedIdent(sym)
+      case _ =>
+        val qual = mkAttributedQualifier(pre)
+        qual match {
+          case EmptyTree                                  => mkAttributedIdent(sym)
+          case This(clazz) if qual.symbol.isEffectiveRoot => mkAttributedIdent(sym)
+          case _                                          => mkAttributedSelect(qual, sym)
+        }
     }
   }
 

--- a/test/files/neg/t4225.check
+++ b/test/files/neg/t4225.check
@@ -1,0 +1,7 @@
+t4225.scala:19: error: could not find implicit value for parameter b: _1.f0.Bar
+  f.op0
+    ^
+t4225.scala:20: error: could not find implicit value for parameter b: _1.f0.Bar
+  f.op1(23)
+       ^
+two errors found

--- a/test/files/neg/t4225.scala
+++ b/test/files/neg/t4225.scala
@@ -1,0 +1,21 @@
+object Test {
+  class Foo {
+    class Bar
+    object Bar {
+      implicit def mkBar: Bar = new Bar
+    }
+  }
+
+  implicit class Ops[F <: Foo](val f0: F) {
+    def op0(implicit b: f0.Bar): f0.Bar = b
+    def op1(i: Int)(implicit b: f0.Bar): f0.Bar = b
+  }
+
+  object f extends Foo
+
+  val ops = new Ops(f)
+  val i: f.Bar = ops.op0
+
+  f.op0
+  f.op1(23)
+}

--- a/test/files/neg/t5946.check
+++ b/test/files/neg/t5946.check
@@ -1,0 +1,4 @@
+t5946.scala:6: error: No TypeTag available for Int
+  Ops(scala.reflect.runtime.universe).op[Int]
+                                        ^
+one error found

--- a/test/files/neg/t5946.scala
+++ b/test/files/neg/t5946.scala
@@ -1,0 +1,7 @@
+object TestDep {
+  class Ops(val g: scala.reflect.api.JavaUniverse) {
+    def op[T: g.TypeTag] = ()
+  }
+  def Ops(g: scala.reflect.api.JavaUniverse): Ops = new Ops(g)
+  Ops(scala.reflect.runtime.universe).op[Int]
+}


### PR DESCRIPTION
This also turns the crasher reported in https://github.com/scala/bug/issues/4225 into an error.

Whilst this does the right thing, it's not clear to me that the failing case shouldn't have been caught further up the call chain.

I also attempted to modify and use `mkAttributedQualifierIfPossible` in `mkAttributedRef`, however this appears to reject cases which `mkAttributedQualifier` is happy to handle, and it's not clear to me if this is because the conditions in `mkAttributedQualifierIfPossible` are incorrect or if it has some more specific use than its name suggests.

I'd be more than happy to forward port this to 2.13.x.