### PR TITLE
No noisy options for REPL eval compilation

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -1007,28 +1007,10 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
         }
       case _ =>
     }
-    // wait until after startup to enable noisy settings
-    def withSuppressedSettings[A](body: => A): A = {
-      val ss = this.settings
-      import ss._
-      val noisy = List(Xprint, Ytyperdebug, browse)
-      val noisesome = noisy.exists(!_.isDefault)
-      val current = (Xprint.value, Ytyperdebug.value, browse.value)
-      if (isReplDebug || !noisesome) body
-      else {
-        this.settings.Xprint.value = List.empty
-        this.settings.browse.value = List.empty
-        this.settings.Ytyperdebug.value = false
-        try body
-        finally {
-          Xprint.value       = current._1
-          Ytyperdebug.value  = current._2
-          browse.value      = current._3
-          intp.global.printTypings = current._2
-        }
-      }
-    }
-    def startup(): String = withSuppressedSettings {
+    // ctl-D on first line of repl zaps the intp
+    def globalOrNull = if (intp != null) intp.global else null
+    // wait until after startup to enable noisy settings; intp is used only after body completes
+    def startup(): String = IMain.withSuppressedSettings(settings, globalOrNull) {
       // -e is non-interactive
       val splash =
         runnerSettings.filter(_.execute.isSetByUser).map(ss => batchLoop(ss.execute.value)).getOrElse {

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -105,6 +105,29 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
     try body
     finally if (!saved) settings.nowarn.value = false
   }
+  def withSuppressedSettings[A](body: => A): A = {
+    val ss = this.settings
+    import ss._
+    val wasWarning = !nowarn
+    val noisy = List(Xprint, Ytyperdebug, browse)
+    val current = (Xprint.value, Ytyperdebug.value, browse.value)
+    val noisesome = wasWarning || noisy.exists(!_.isDefault)
+    if (isReplDebug || !noisesome) body
+    else {
+      Xprint.value = List.empty
+      browse.value = List.empty
+      Ytyperdebug.value = false
+      if (wasWarning) nowarn.value = true
+      try body
+      finally {
+        Xprint.value       = current._1
+        Ytyperdebug.value  = current._2
+        browse.value       = current._3
+        if (wasWarning) nowarn.value = false
+        global.printTypings = current._2
+      }
+    }
+  }
   // Apply a temporary label for compilation (for example, script name)
   def withLabel[A](temp: String)(body: => A): A = {
     val saved = label
@@ -960,7 +983,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
 
         // compile the result-extraction object
         val handls = if (printResults) handlers else Nil
-        withoutWarnings(lineRep compile ResultObjectSourceCode(handls))
+        withSuppressedSettings(lineRep compile ResultObjectSourceCode(handls))
       }
     }
 


### PR DESCRIPTION
As for REPL startup code, disable noisy options
when compiling the uninteresting `eval` object
used for printing results. (Unless debug is on.)