### PR TITLE
PipedSource should join Source thread to wait the exit value.

### DIFF
--- a/src/library/scala/sys/process/ProcessImpl.scala
+++ b/src/library/scala/sys/process/ProcessImpl.scala
@@ -147,6 +147,7 @@ private[process] trait ProcessImpl {
           throw err
         }
       runInterruptible {
+        source.join()
         val exit1 = first.exitValue()
         val exit2 = second.exitValue()
         // Since file redirection (e.g. #>) is implemented as a piped process,


### PR DESCRIPTION
Fixes scala/bug#10328