### PR TITLE
Failing scalacheck tests fail build again

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -579,7 +579,7 @@ lazy val scalacheck = project.in(file("test") / "scalacheck")
   .settings(disableDocs)
   .settings(disablePublishing)
   .settings(
-    fork in Test := true,
+    fork in Test := false,
     javaOptions in Test += "-Xss1M",
     libraryDependencies ++= Seq(scalacheckDep),
     unmanagedSourceDirectories in Compile := Nil,

--- a/build.sbt
+++ b/build.sbt
@@ -581,6 +581,9 @@ lazy val scalacheck = project.in(file("test") / "scalacheck")
   .settings(
     fork in Test := false,
     javaOptions in Test += "-Xss1M",
+    testOptions += Tests.Cleanup { loader =>
+      ModuleUtilities.getObject("scala.TestCleanup", loader).asInstanceOf[Runnable].run()
+    },
     libraryDependencies ++= Seq(scalacheckDep),
     unmanagedSourceDirectories in Compile := Nil,
     unmanagedSourceDirectories in Test := List(baseDirectory.value)

--- a/test/scalacheck/scala/tools/nsc/scaladoc/IndexScriptTest.scala
+++ b/test/scalacheck/scala/tools/nsc/scaladoc/IndexScriptTest.scala
@@ -5,39 +5,30 @@ import org.scalacheck.Prop._
 
 import scala.tools.nsc.doc
 import scala.tools.nsc.doc.html.page.IndexScript
-import java.net.{URLClassLoader, URLDecoder}
 
 object IndexScriptTest extends Properties("IndexScript") {
-
-  def getClasspath = {
-    // these things can be tricky
-    // this test previously relied on the assumption that the current thread's classloader is an url classloader and contains all the classpaths
-    // does partest actually guarantee this? to quote Leonard Nimoy: The answer, of course, is no.
-    // this test _will_ fail again some time in the future.
-    // Footnote: java.lang.ClassCastException: org.apache.tools.ant.loader.AntClassLoader5 cannot be cast to java.net.URLClassLoader
-    val loader = Thread.currentThread.getContextClassLoader.asInstanceOf[URLClassLoader]
-    val paths = loader.getURLs.map(u => URLDecoder.decode(u.getPath))
-    paths mkString java.io.File.pathSeparator
-  }
 
   val docFactory = {
     val settings = new doc.Settings({Console.err.println(_)})
     settings.scaladocQuietRun = true
     settings.nowarn.value = true
-    settings.classpath.value = getClasspath
+    SettingsUtil.configureClassAndSourcePath(settings)
+
     val reporter = new scala.tools.nsc.reporters.ConsoleReporter(settings)
     new doc.DocFactory(reporter, settings)
   }
 
   val indexModelFactory = doc.model.IndexModelFactory
 
-  def createIndexScript(path: String) =
-    docFactory.makeUniverse(Left(List(path))) match {
+  def createIndexScript(path: String) = {
+    val absolutePath: String = SettingsUtil.checkoutRoot.resolve(path).toAbsolutePath.toString
+    docFactory.makeUniverse(Left(List(absolutePath))) match {
       case Some(universe) =>
         Some(new IndexScript(universe))
       case _ =>
         None
     }
+  }
 
   property("allPackages") = {
     createIndexScript("src/scaladoc/scala/tools/nsc/doc/html/page/IndexScript.scala") match {

--- a/test/scalacheck/scala/tools/nsc/scaladoc/SettingsUtil.scala
+++ b/test/scalacheck/scala/tools/nsc/scaladoc/SettingsUtil.scala
@@ -1,0 +1,30 @@
+package scala.tools.nsc.scaladoc
+
+import java.net.{URLClassLoader, URLDecoder}
+import java.nio.file.{Files, Path, Paths}
+
+import scala.tools.nsc.Settings
+import scala.tools.nsc.scaladoc.HtmlFactoryTest.RESOURCES
+
+object SettingsUtil {
+  def configureClassAndSourcePath(settings: Settings): Settings = {
+    val ourClassLoader = HtmlFactoryTest.getClass.getClassLoader
+    Thread.currentThread.getContextClassLoader match {
+      case loader: URLClassLoader =>
+        val paths = loader.getURLs.map(u => URLDecoder.decode(u.getPath))
+        settings.classpath.value = paths mkString java.io.File.pathSeparator
+      case loader =>
+        settings.embeddedDefaults(ourClassLoader) // Running in SBT without forking, we have to ask the SBT classloader for the classpath
+    }
+
+    settings
+  }
+  val checkoutRoot: Path = {
+    // Don't assume the working dir is the root of the git checkout to make this work
+    // by default in IntelliJ.
+    val parents = Iterator.iterate(Paths.get(".").toAbsolutePath)(_.getParent).takeWhile(_ ne null).toList
+    val temp = parents.find(x => Files.exists(x.resolve(RESOURCES)))
+    val checkoutRoot = temp.getOrElse(Paths.get("."))
+    checkoutRoot.toAbsolutePath
+  }
+}

--- a/test/scaladoc/resources/t4421.scala
+++ b/test/scaladoc/resources/t4421.scala
@@ -4,4 +4,4 @@ abstract class test
  * @example 2.0
  * @todo do something better than finding scaladoc bugs
  * @note blah blah */
-class SI_4421 extends test
+class t4421 extends test

--- a/test/scaladoc/resources/t4507.scala
+++ b/test/scaladoc/resources/t4507.scala
@@ -16,4 +16,4 @@
  *     - throws a TestFailedException when evaluating false or false
  * </pre>
  */
-class SI_4507
+class t4507

--- a/test/scaladoc/resources/t4589.scala
+++ b/test/scaladoc/resources/t4589.scala
@@ -1,4 +1,4 @@
-class SI_4589 {
+class t4589 {
   /**
    * @param x012345678901234567890123456789 blah blah blah
    */

--- a/test/scaladoc/resources/t4715.scala
+++ b/test/scaladoc/resources/t4715.scala
@@ -1,4 +1,4 @@
-class SI_4715 {
+class t4715 {
   type :+:[X,Y] = Map[X,Y]
   val withType: Int :+: Double = sys.error("")
 

--- a/test/scaladoc/resources/t4898.scala
+++ b/test/scaladoc/resources/t4898.scala
@@ -1,4 +1,4 @@
-class SI_4898 {
+class t4898 {
 	
 	/**
 	 * A link to [[__root__

--- a/test/scaladoc/resources/t5054_q1.scala
+++ b/test/scaladoc/resources/t5054_q1.scala
@@ -1,4 +1,4 @@
-class SI_5054_q1 {
+class t5054_q1 {
   /**
     * A simple comment
     * 

--- a/test/scaladoc/resources/t5054_q2.scala
+++ b/test/scaladoc/resources/t5054_q2.scala
@@ -1,4 +1,4 @@
-class SI_5054_q2 {
+class t5054_q2 {
   /**
     * A simple comment
     * 

--- a/test/scaladoc/resources/t5054_q3.scala
+++ b/test/scaladoc/resources/t5054_q3.scala
@@ -1,4 +1,4 @@
-class SI_5054_q3 {
+class t5054_q3 {
   /**
     * A simple comment
     * 

--- a/test/scaladoc/resources/t5054_q4.scala
+++ b/test/scaladoc/resources/t5054_q4.scala
@@ -1,4 +1,4 @@
-abstract class SI_5054_q4 {
+abstract class t5054_q4 {
   /**
     * A simple comment
     * 

--- a/test/scaladoc/resources/t5054_q5.scala
+++ b/test/scaladoc/resources/t5054_q5.scala
@@ -1,4 +1,4 @@
-trait SI_5054_q5 {
+trait t5054_q5 {
   /**
     * A simple comment
     * 

--- a/test/scaladoc/resources/t5054_q6.scala
+++ b/test/scaladoc/resources/t5054_q6.scala
@@ -1,4 +1,4 @@
-trait SI_5054_q6 {
+trait t5054_q6 {
   /**
     * A simple comment
     * 

--- a/test/scaladoc/resources/t5054_q7.scala
+++ b/test/scaladoc/resources/t5054_q7.scala
@@ -1,4 +1,4 @@
-trait SI_5054_q7 {
+trait t5054_q7 {
   /**
    * The full definition, either used with an implicit value or with an explicit one.
    *

--- a/test/scaladoc/resources/t5287.scala
+++ b/test/scaladoc/resources/t5287.scala
@@ -1,12 +1,12 @@
-trait SI_5287_A {
+trait t5287_A {
 	def method(implicit a: Int): Int = a
 }
 
-trait SI_5287_B extends SI_5287_A {
+trait t5287_B extends t5287_A {
 	override def method(implicit a: Int): Int = a + 1
 }
 
-trait SI_5287 extends SI_5287_B{
+trait t5287 extends t5287_B{
 	/**
 	 * Some explanation
 	 * 


### PR DESCRIPTION
Avoid forking Scalacheck tests when run by SBT to avoid
a bug in Scalacheck itself that doensn't report failures.
We've been exposed to this since the refactoring that stopped
using partest to manage scalacheck test execution.

Address the failures we'd accumulated during this time:

  - A performance driven change to `Symbol#allOverridingSymbols`
    reversed the order of the result, which didn't matter in the
    compiler but is material in Scaladoc and the IDE. I've reworked
    this to restore the previous order.
  - After our JIRA to GitHub issues migration, test files in the
    project went through a big name to replace the `SI_` prefix with `t`.
    We also needed to update references to those filenames in the tests.
    For consistency, I've also updated the class names within the files
    to correspond to the file names.

Fixes scala/scala-dev#282