### PR TITLE
Remove assertion in computing the EnclosingMethod attribute

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -198,7 +198,6 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
     if (isAnonymousOrLocalClass(classSym) && !considerAsTopLevelImplementationArtifact(classSym)) {
       val enclosingClass = enclosingClassForEnclosingMethodAttribute(classSym)
       val methodOpt = enclosingMethodForEnclosingMethodAttribute(classSym)
-      for (m <- methodOpt) assert(m.owner == enclosingClass, s"the owner of the enclosing method ${m.locationString} should be the same as the enclosing class $enclosingClass")
       Some(EnclosingMethodEntry(
         classDesc(enclosingClass),
         methodOpt.map(_.javaSimpleName.toString).orNull,


### PR DESCRIPTION
The EnclosingMethod / InnerClass attribute values are computed
using the `originalOwner` chain, as they speak about source-code
level properties. There was an assertion checking that
`originalEnclosingMethod.owner == originalEnclosingClass`. This
can fail if the `originalEnclosingMethod` is moved around, for
example by a compiler plugin, and its owner changes.

The correct assertion would be
`originalEnclosingClass(originalEnclosingMethod) == originalEnclosingClass`,
but this is like testing `1 == 1`, so I removed the assertion.