### PR TITLE
Don't assume final member class in another comp. unit will stay final

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -764,7 +764,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
           primaryConstrBody.expr)
       })
 
-      if (omittableAccessor.exists(_.isOuterField) && !constructorStats.exists(_.exists { case i: Ident if i.symbol.isOuterParam => true; case _ => false}))
+      if ((exitingPickler(clazz.isAnonymousClass) || clazz.originalOwner.isTerm) && omittableAccessor.exists(_.isOuterField) && !constructorStats.exists(_.exists { case i: Ident if i.symbol.isOuterParam => true; case _ => false}))
         primaryConstructor.symbol.updateAttachment(OuterArgCanBeElided)
 
       val constructors = primaryConstructor :: auxConstructors

--- a/test/files/run/t10423/A_1.scala
+++ b/test/files/run/t10423/A_1.scala
@@ -1,0 +1,11 @@
+class Outer {
+  final class Inner {
+    def foo: Unit = ()
+  }
+}
+object Test {
+  def main(args: Array[String]): Unit = {
+    val o = new Outer
+    new o.Inner().foo
+  }
+}

--- a/test/files/run/t10423/A_2.scala
+++ b/test/files/run/t10423/A_2.scala
@@ -1,0 +1,6 @@
+class Outer {
+  class Inner {
+    def foo: Unit = assert(Outer.this ne null)
+  }
+}
+


### PR DESCRIPTION
The optimization in #5099 that avoided needless capture of the enclosing
class, and hence improved serializability of local classes and functions,
went too far. It also caused constructor calls of member classes to
use `null` rather than the actual outer reference as the `$outer`
constructor argument. The enclosed test case exhibits this problem
by witnessing an null `Outer.this`.

This commit limits the strategy to use `null`-s to the outer refererences
of anonymous and local classes, which rules out cross compilation unit
effects (in absence of `-opt`.)

Fixes scala/bug#10423