### PR TITLE
Deprecate PartialFunction.apply

### DIFF
--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -245,6 +245,7 @@ object PartialFunction {
   /** Converts ordinary function to partial one
    *  @since   2.10
    */
+  @deprecated("""For converting an ordinary function f to a partial function pf, use `val pf: PartialFunction[A, B] = { case x => f(x) }`. For creating a new PartialFunction, use an explicit type annotation instead, like in `val pf: PartialFunction[Int, String] = { case 1 => "one" }`.""", "2.12.5")
   def apply[A, B](f: A => B): PartialFunction[A, B] = { case x => f(x) }
 
   private[this] val constFalse: Any => Boolean = { _ => false}


### PR DESCRIPTION
Follow up of #5897.

Unfortunately `apply` can't be overloaded...
I suggest replacing this `apply` with one that accepts a `PartialFunction` as soon as possible. In my opinion
```
val pf = PartialFunction[Int, String] { case 1 => "one" }
```
looks and feels better than
```
val pf: PartialFunction[Int, String] = { case 1 => "one" }
```

I am open to suggestions for improving the deprecation message. It doesn't cover the fact that for instance `def foo(pf: PartialFunction[Int, String]) = ???; foo{ case 1 => "one" }` just works without explicit types at the use site. But I fail to put that in a short, understandable message that doesn't throw terms like "expected type" in an unsuspecting user's face. I might be overthinking this.