### PR TITLE
SI-9745 typedFunction keeps x => f(x)

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2901,7 +2901,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
     /** Type check a function literal.
      *
-     * Based on the expected type pt, potentially synthesize an instance of
+     *  Based on the expected type pt, potentially synthesize an instance of
      *   - PartialFunction,
      *   - a type with a Single Abstract Method (under -Xexperimental for now).
      */
@@ -2960,35 +2960,34 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         //
         // Note that method values are a separate thing (`m _`): they have the idiosyncratic shape
         // of `Typed(expr, Function(Nil, EmptyTree))`
-        val ptUnrollingEtaExpansion =
-          if (paramsMissingType.nonEmpty && pt != ErrorType) fun.body match {
+        val (fun2, ptUnrollingEtaExpansion) =
+          if (paramsMissingType.isEmpty || pt == ErrorType) (fun, null)
+          else fun.body match {
             // we can compare arguments and parameters by name because there cannot be a binder between
             // the function's valdefs and the Apply's arguments
             case Apply(meth, args) if (vparams corresponds args) { case (p, Ident(name)) => p.name == name case _ => false } =>
               // We're looking for a method (as indicated by FUNmode in the silent typed below),
               // so let's make sure our expected type is a MethodType
               val methArgs = NoSymbol.newSyntheticValueParams(argpts map { case NoType => WildcardType case tp => tp })
-
-              val result = silent(_.typed(meth, mode.forFunMode, MethodType(methArgs, respt)))
-              // we can't have results with undetermined type params
-              val resultMono = result filter (_ => context.undetparams.isEmpty)
-              resultMono map { methTyped =>
-                // if context.undetparams is not empty, the method was polymorphic,
-                // so we need the missing arguments to infer its type. See #871
+              val methTyped = typed(meth, mode.forFunMode, MethodType(methArgs, respt))
+              // if context.undetparams is not empty, the method was polymorphic,
+              // so we need the missing arguments to infer its type. See #871
+              val ptu = if (!context.undetparams.isEmpty) null else {
                 val funPt = normalize(methTyped.tpe) baseType FunctionClass(numVparams)
-                // println(s"typeUnEtaExpanded $meth : ${methTyped.tpe} --> normalized: $funPt")
+                // if (settings.debug) Console.println(s"typeUnEtaExpanded $meth : ${methTyped.tpe} --> normalized: $funPt")
 
                 // If we are sure this function type provides all the necessary info, so that we won't have
-                // any undetermined argument types, go ahead an recurse below (`typedFunction(fun, mode, ptUnrollingEtaExpansion)`)
+                // any undetermined argument types, go ahead and recurse below (`typedFunction(fun, mode, ptUnrollingEtaExpansion)`)
                 // and rest assured we won't end up right back here (and keep recursing)
-                if (isFunctionType(funPt) && funPt.typeArgs.iterator.take(numVparams).forall(isFullyDefined)) funPt
-                else null
-              } orElse { _ => null }
-            case _ => null
-          } else null
+                if (isFunctionType(funPt) && funPt.typeArgs.iterator.take(numVparams).forall(isFullyDefined)) funPt else null
+              }
+              // success or fail, use new tree
+              val upgraded = treeCopy.Function(fun, vparams, Apply(methTyped, args) setPos fun.body.pos)
+              (upgraded, ptu)
+            case _ => (fun, null)
+          }
 
-
-        if (ptUnrollingEtaExpansion ne null) typedFunction(fun, mode, ptUnrollingEtaExpansion)
+        if (ptUnrollingEtaExpansion ne null) typedFunction(fun2, mode, ptUnrollingEtaExpansion)
         else {
           // we ran out of things to try, missing parameter types are an irrevocable error
           var issuedMissingParameterTypeError = false
@@ -2998,7 +2997,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             issuedMissingParameterTypeError = true
           }
 
-          fun.body match {
+          fun2.body match {
             // translate `x => x match { <cases> }` : PartialFunction to
             // `new PartialFunction { def applyOrElse(x, default) = x match { <cases> } def isDefinedAt(x) = ... }`
             case Match(sel, cases) if (sel ne EmptyTree) && (pt.typeSymbol == PartialFunctionClass) =>
@@ -3009,7 +3008,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               val p = vparams.head
               if (p.tpt.tpe == null) p.tpt setType outerTyper.typedType(p.tpt).tpe
 
-              outerTyper.synthesizePartialFunction(p.name, p.pos, paramSynthetic = false, fun.body, mode, pt)
+              outerTyper.synthesizePartialFunction(p.name, p.pos, paramSynthetic = false, fun2.body, mode, pt)
 
             case _ =>
               val vparamSyms = vparams map { vparam =>
@@ -3019,11 +3018,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               }
               val vparamsTyped = vparams mapConserve typedValDef
               val formals = vparamSyms map (_.tpe)
-              val body1 = typed(fun.body, respt)
-              val restpe = packedType(body1, fun.symbol).deconst.resultType
+              val body1 = typed(fun2.body, respt)
+              val restpe = packedType(body1, fun2.symbol).deconst.resultType
               val funtpe = phasedAppliedType(FunctionSymbol, formals :+ restpe)
 
-              treeCopy.Function(fun, vparamsTyped, body1) setType funtpe
+              treeCopy.Function(fun2, vparamsTyped, body1) setType funtpe
           }
         }
       }
@@ -4363,7 +4362,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         }
 //      if (varsym.isVariable ||
 //        // setter-rewrite has been done above, so rule out methods here, but, wait a minute, why are we assigning to non-variables after erasure?!
-//        (phase.erasedTypes && varsym.isValue && !varsym.isMethod)) {
+//        (phase.erasedTypes && varsym.isValue && !varsym.isMethod))
         if (varsym.isVariable || varsym.isValue && phase.assignsFields) {
           val rhs1 = typedByValueExpr(rhs, lhs1.tpe)
           treeCopy.Assign(tree, lhs1, checkDead(rhs1)) setType UnitTpe

--- a/src/compiler/scala/tools/nsc/typechecker/TypersTracking.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypersTracking.scala
@@ -66,7 +66,7 @@ trait TypersTracking {
       if (s1.length < 60 || settings.debug.value) s1 else s1.take(57) + "..."
     }
 
-    private class Frame(val tree: Tree) { }
+    private class Frame(val tree: Tree)
     private def greenType(tp: Type): String = tpe_s(tp, inGreen)
     private def greenType(tree: Tree): String = tree match {
       case null                              => "[exception]"
@@ -91,12 +91,10 @@ trait TypersTracking {
       trees = trees.tail
       depth -= 1
     }
-    def show(s: String)     { if (s != "") out.println(s) }
+    def show(s: String) = if (s != "") out.println(s)
 
-    def showPush(tree: Tree, context: Context) {
-      showPush(tree, NOmode, WildcardType, context)
-    }
-    def showPush(tree: Tree, mode: Mode, pt: Type, context: Context) {
+    def showPush(tree: Tree, context: Context): Unit = showPush(tree, NOmode, WildcardType, context)
+    def showPush(tree: Tree, mode: Mode, pt: Type, context: Context): Unit = {
       def tree_s = truncAndOneLine(ptTree(tree))
       def pt_s = if (pt.isWildcard || context.inTypeConstructorAllowed) "" else s": pt=$pt"
       def all_s = List(tree_s, pt_s, mode, fullSiteString(context)) filterNot (_ == "") mkString " "
@@ -108,7 +106,7 @@ trait TypersTracking {
       show(resetIfEmpty(indented("""\-> """ + s)))
       typedTree
     }
-    def showAdapt(original: Tree, adapted: Tree, pt: Type, context: Context) {
+    def showAdapt(original: Tree, adapted: Tree, pt: Type, context: Context) = {
       if (!noPrintAdapt(original, adapted)) {
         def tree_s1 = inLightCyan(truncAndOneLine(ptTree(original)))
         def pt_s = if (pt.isWildcard) "" else s" based on pt $pt"
@@ -119,7 +117,7 @@ trait TypersTracking {
         show(indented(s"[adapt] $tree_s1 $tree_s2"))
       }
     }
-    def showTyped(tree: Tree) {
+    def showTyped(tree: Tree) = {
       def class_s = tree match {
         case _: RefTree => ""
         case _          => " " + tree.shortClass

--- a/test/files/neg/t9745.check
+++ b/test/files/neg/t9745.check
@@ -1,0 +1,27 @@
+t9745.scala:3: error: not found: value x
+  val func = Seq { x += 1; 42 } apply _
+                   ^
+t9745.scala:9: error: not found: value y
+  val g = x => f(y += 1)(x)
+                 ^
+t9745.scala:9: error: missing parameter type
+  val g = x => f(y += 1)(x)
+          ^
+t9745.scala:15: error: not found: value x
+  val g = x => f(x += 1)(x)
+                 ^
+t9745.scala:15: error: missing parameter type
+  val g = x => f(x += 1)(x)
+          ^
+t9745.scala:20: error: type mismatch;
+ found   : (z: Any)Int
+ required: (x$1: ?, x$2: ?)?
+  val g = (x, y) => f(42)(x, y)
+                     ^
+t9745.scala:20: error: missing parameter type
+  val g = (x, y) => f(42)(x, y)
+           ^
+t9745.scala:20: error: missing parameter type
+  val g = (x, y) => f(42)(x, y)
+              ^
+8 errors found

--- a/test/files/neg/t9745.scala
+++ b/test/files/neg/t9745.scala
@@ -1,0 +1,21 @@
+
+class C {
+  val func = Seq { x += 1; 42 } apply _
+}
+
+class D {
+  var i = 0
+  def f(n: Unit)(j: Int): Int = ???
+  val g = x => f(y += 1)(x)
+}
+
+class E {
+  var i = 0
+  def f(n: Unit)(j: Int): Int = ???
+  val g = x => f(x += 1)(x)
+}
+
+class Convo {
+  def f(i: Int)(z: Any): Int = ???
+  val g = (x, y) => f(42)(x, y)
+}

--- a/test/files/pos/t9745.scala
+++ b/test/files/pos/t9745.scala
@@ -1,0 +1,15 @@
+
+class C {
+  val func = Seq { var i = 0; i += 1; i } apply _
+}
+
+class D {
+  var i = 0
+  def f(n: Unit)(j: Int): Int = ???
+  val g = x => f(i += 1)(x)
+}
+
+class Convo {
+  def f(i: Int)(z: Any): Int = ???
+  val g = (x: Int, y: Int) => f(42)(x, y)
+}


### PR DESCRIPTION
To type `x => f(x)`, `typedFunction` uses the expected
type and `f` to type `x`. Previously, it discarded the
result of typechecking `f`, which was a problem in the
case of a `g(e)` where `e` is "erroneous" but rewriteable
to an expr that checks, e.g., `g(i += 1)`.

This commit keeps the rewritten `g(i = i + 1)` instead
of trying to recover the erroneous tree.