### PR TITLE
Fix race condition in quasiquotes in runtime reflection

### DIFF
--- a/src/reflect/mima-filters/2.12.0.backwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.backwards.excludes
@@ -4,3 +4,5 @@ ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.reflect.runtime.JavaM
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.reflect.runtime.SymbolLoaders#TopClassCompleter.this")
 
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedOps#SynchronizedBaseTypeSeq.lateMap")
+
+ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$exists")

--- a/src/reflect/mima-filters/2.12.0.forwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.forwards.excludes
@@ -12,3 +12,5 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUn
 ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.FileZipArchive$LazyEntry")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive.closeZipFile")
 ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.FileZipArchive$LeakyEntry")
+
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.exists")

--- a/src/reflect/scala/reflect/internal/ReificationSupport.scala
+++ b/src/reflect/scala/reflect/internal/ReificationSupport.scala
@@ -427,7 +427,7 @@ trait ReificationSupport { self: SymbolTable =>
 
     object SyntacticTuple extends SyntacticTupleExtractor {
       def apply(args: List[Tree]): Tree = {
-        require(args.isEmpty || TupleClass(args.length).exists, s"Tuples with ${args.length} arity aren't supported")
+        require(args.isEmpty || (TupleClass(args.length) != NoSymbol), s"Tuples with ${args.length} arity aren't supported")
         gen.mkTuple(args)
       }
 
@@ -447,7 +447,7 @@ trait ReificationSupport { self: SymbolTable =>
 
     object SyntacticTupleType extends SyntacticTupleExtractor {
       def apply(args: List[Tree]): Tree = {
-        require(args.isEmpty || TupleClass(args.length).exists, s"Tuples with ${args.length} arity aren't supported")
+        require(args.isEmpty || (TupleClass(args.length) != NoSymbol), s"Tuples with ${args.length} arity aren't supported")
         gen.mkTupleType(args)
       }
 
@@ -466,7 +466,7 @@ trait ReificationSupport { self: SymbolTable =>
 
     object SyntacticFunctionType extends SyntacticFunctionTypeExtractor {
       def apply(argtpes: List[Tree], restpe: Tree): Tree = {
-        require(FunctionClass(argtpes.length).exists, s"Function types with ${argtpes.length} arity aren't supported")
+        require(FunctionClass(argtpes.length) != NoSymbol, s"Function types with ${argtpes.length} arity aren't supported")
         gen.mkFunctionTypeTree(argtpes, restpe)
       }
 

--- a/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
@@ -118,7 +118,7 @@ private[reflect] trait SynchronizedSymbols extends internal.Symbols { self: Symb
     override def markFlagsCompleted(mask: Long): this.type = { _initializationMask = _initializationMask & ~mask; this }
     override def markAllCompleted(): this.type = { _initializationMask = 0L; _initialized = true; this }
 
-    def gilSynchronizedIfNotThreadsafe[T](body: => T): T = {
+    @inline final def gilSynchronizedIfNotThreadsafe[T](body: => T): T = {
       // TODO: debug and fix the race that doesn't allow us uncomment this optimization
       // if (isCompilerUniverse || isThreadsafe(purpose = AllOps)) body
       // else gilSynchronized { body }

--- a/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
@@ -128,6 +128,7 @@ private[reflect] trait SynchronizedSymbols extends internal.Symbols { self: Symb
     override def validTo = gilSynchronizedIfNotThreadsafe { super.validTo }
     override def info = gilSynchronizedIfNotThreadsafe { super.info }
     override def rawInfo: Type = gilSynchronizedIfNotThreadsafe { super.rawInfo }
+    override def exists: Boolean = gilSynchronizedIfNotThreadsafe(super.exists)
     override def typeSignature: Type = gilSynchronizedIfNotThreadsafe { super.typeSignature }
     override def typeSignatureIn(site: Type): Type = gilSynchronizedIfNotThreadsafe { super.typeSignatureIn(site) }
 

--- a/test/files/run/sd409.scala
+++ b/test/files/run/sd409.scala
@@ -1,0 +1,17 @@
+import reflect.runtime.universe._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val threads = collection.mutable.Buffer[Thread]()
+    for (i <- 1 to 22; j <- 1 to 8) {
+      val t = new Thread {
+        override def run(): Unit = {
+          internal.reificationSupport.SyntacticTuple.apply(List.fill(i)(EmptyTree))
+        }
+      }
+      threads += t
+      t.start()
+    }
+    threads.foreach(_.join())
+  }
+}


### PR DESCRIPTION
Quasiquotes expand into calls to `SyntacticTuple`, etc, which call
`Symbol#exists` as part of a bounds check against the maximal arity of
`TupleN`, etc.

However, `exists` was not threadsafe. This patch adds a test that
demonstrates this race condition, and adds the neccessary override to
synchronize this method.

It also includes some followup improvements/simplifications to the
territory.

Fixes scala/scala-dev#409