### PR TITLE
Fixes over aggressive pruning of implicit scope.

### DIFF
--- a/test/files/neg/t5340.check
+++ b/test/files/neg/t5340.check
@@ -1,6 +1,6 @@
-t5340.scala:17: error: type mismatch;
- found   : MyApp.r.E
- required: MyApp.s.E
-  println(b: s.E)
-          ^
+t5340.scala:15: error: type mismatch;
+ found   : Quux[MyApp.r.E,MyApp.s.E]
+ required: Int
+  (new Quux[r.E, s.E]): Int // fails due to pre-stripping implicits which
+   ^
 one error found

--- a/test/files/neg/t5340.scala
+++ b/test/files/neg/t5340.scala
@@ -1,29 +1,19 @@
+class Quux[T, U]
+
 class Poly {
   class E
   object E {
-    implicit def conv(value: Any): E = sys.error("")
+    implicit def conv[T, U](b: Quux[T, U]): Int = 1
   }
 }
 
 object MyApp {
-  val r: Poly = sys.error("")
-  val s: Poly = sys.error("")
-  val b: r.E = sys.error("")
+  val r: Poly = ???
+  val s: Poly = ???
 
-  // okay
-  s.E.conv(b): s.E
-
-  // compilation fails with error below
-  println(b: s.E)
-
-  // amb prefix: MyApp.s.type#class E MyApp.r.type#class E
-  // amb prefix: MyApp.s.type#class E MyApp.r.type#class E
-  // ../test/pending/run/t5310.scala:17: error: type mismatch;
-  //  found   : MyApp.r.E
-  //  required: MyApp.s.E
-  //   println(b: s.E)
-  //           ^
-
-  // The type error is as expected, but the `amb prefix` should be logged,
-  // rather than printed to standard out.
+  (new Quux[r.E, Int]): Int // ok
+  (new Quux[r.E, s.E]): Int // fails due to pre-stripping implicits which
+                            // are reachable via different prefixes but not
+                            // dependent on the prefix. Ambiguity not
+                            // reported as such.
 }

--- a/test/files/pos/t10425.scala
+++ b/test/files/pos/t10425.scala
@@ -1,0 +1,19 @@
+class Poly {
+  class E
+}
+
+object MyApp {
+  object r extends Poly {
+    implicit def conv(value: Any): E = sys.error("")
+  }
+  object s extends Poly {
+    implicit def conv(value: Any): E = sys.error("")
+  }
+  val b: r.E = sys.error("")
+
+  // okay
+  s.conv(b): s.E
+
+  // okay
+  println(b: s.E)
+}

--- a/test/files/pos/t4947.scala
+++ b/test/files/pos/t4947.scala
@@ -1,0 +1,31 @@
+class DependentImplicitTezt {
+  trait Bridge
+
+  class Outer {
+    class Inner extends Bridge
+
+    object Inner {
+      implicit def fromOther(b: Bridge): Inner = throw new Error("todo")
+    }
+
+    def run(x: Inner) = throw new Error("todo")
+  }
+
+  val o1 = new Outer
+  val o2 = new Outer
+  val i1 = new o1.Inner
+  val i2 = new o2.Inner
+
+  def doesntCompile {
+    o1.run(i2) // should compile
+  }
+
+  def workaround1 {
+    o1.run(i2: Bridge) // ok
+  }
+
+  def workaround2 {
+    import o1.Inner.fromOther
+    o1.run(i2) // ok
+  }
+}

--- a/test/files/pos/t5340.scala
+++ b/test/files/pos/t5340.scala
@@ -1,0 +1,18 @@
+class Poly {
+  class E
+  object E {
+    implicit def conv(value: Any): E = sys.error("")
+  }
+}
+
+object MyApp {
+  val r: Poly = sys.error("")
+  val s: Poly = sys.error("")
+  val b: r.E = sys.error("")
+
+  // okay
+  s.E.conv(b): s.E
+
+  // okay
+  println(b: s.E)
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/4947, https://github.com/scala/bug/issues/5340 and https://github.com/scala/bug/issues/10425.

When the implicit scope is constructed an initial pruning phase attempts to discard implicit members which it is believed would later be rejected as ambiguous. Members of a companion are discarded if they can be reached via more than one prefix, on the assumption that being visible via two or more paths means that the multiple values must conflict with one another. However, this does not take into account the possibility that the implicit members might depend on the prefix in a way which renders them non-ambiguous. This scenario is illustrated in https://github.com/scala/bug/issues/4947 and https://github.com/scala/bug/issues/5340. This PR address that by only pruning implicits which are independent of the prefix.

Whilst this PR tries to stay as close as possible to the current behaviour, I believe that it would be desirable to drop the early pruning of even the prefix-independent implicits. If we do that then we get improved error messages reporting ambiguity rather the ambiguous members being silently ignored which leads to otherwise unexplained failures of implicit resolution. For instance in the case of `test/files/neg/t5340.scala` which currently reports,
```
t5340.scala:15: error: type mismatch;
 found   : Quux[MyApp.r.E,MyApp.s.E]
 required: Int
  (new Quux[r.E, s.E]): Int // fails due to pre-stripping implicits which
   ^
one error found
``` 
we would get the following report,
```
t5340.scala:15: error: type mismatch;
 found   : Quux[MyApp.r.E,MyApp.s.E]
 required: Int
Note that implicit conversions are not applicable because they are ambiguous:
 both method conv in object E of type [T, U](b: Quux[T,U])Int
 and method conv in object E of type [T, U](b: Quux[T,U])Int
 are possible conversion functions from Quux[MyApp.r.E,MyApp.s.E] to Int
  (new Quux[r.E, s.E]): Int // fails due to pre-stripping implicits which
   ^
one error found
```
Which is clearly more informative (even if also a little baffling). I think that ambiguity via multiple paths is sufficiently rare that the performance benefits of this early pruning are likely to minimal and not enough to outweigh improved error messages.

Because this change can result in a symbol _legitimately_ being revisited, via a different prefix, we need to change the way that the a pruned path is represented. Instead of using empty lists, as introduced in #5951 (which fixes https://github.com/scala/bug/issues/10081) we use explicit sentinels to mark that a symbol has been visited at a given prefix yielding no additional implicits. Testing this yielded https://github.com/scala/bug/issues/10425 which appears to be a regression relative to 2.12.x. That's also fixed in this PR.