### PR TITLE
Add original tree attachment

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
@@ -165,4 +165,21 @@ trait StdAttachments {
   def markDynamicRewrite(tree: Tree): Tree = tree.updateAttachment(DynamicRewriteAttachment)
   def unmarkDynamicRewrite(tree: Tree): Tree = tree.removeAttachment[DynamicRewriteAttachment.type]
   def isDynamicRewrite(tree: Tree): Boolean = tree.attachments.get[DynamicRewriteAttachment.type].isDefined
+
+  /**
+   * Marks a tree that has been adapted by typer and sets the original tree that was in place before.
+   * 
+   * Keeping track of the original trees were is an important feature for some compiler plugins (like
+   * Scalameta) and the incremental compiler (Zinc). In both cases, adapting trees loses information
+   * in some sense and do not allow external tools to capture some information stored in user-defined
+   * trees that are optimized away by early phases (mostly, typer).
+   * 
+   * See how the absence of this attachment blocks Zinc: https://github.com/sbt/zinc/issues/227.
+   * Related: https://github.com/scala/scala-dev/issues/340.
+   * 
+   * This attachment is, at the moment, only used to keep track of constant-folded constants. It
+   * has a generic wording in the hope that in the future can be reused in the same context to keep
+   * track of other adapted trees.
+   */
+  case class OriginalTreeAttachment(original: Tree)
 }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -995,8 +995,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         val sym = tree.symbol
         if (sym != null && sym.isDeprecated)
           context.deprecationWarning(tree.pos, sym)
-
-        treeCopy.Literal(tree, value)
+        // Keep the original tree in an annotation to avoid losing tree information for plugins
+        treeCopy.Literal(tree, value).updateAttachment(OriginalTreeAttachment(original))
       }
 
       // Ignore type errors raised in later phases that are due to mismatching types with existential skolems


### PR DESCRIPTION
Adds an original tree attachment that allows external tools (compiler
plugins like scalameta & zinc) to keep track of the previous, unadapted
tree. The reason why this is required is explained in SD-340: https://github.com/scala/scala-dev/issues/340.

This change enables the incremental compiler to detect changes in `final
val`s: https://github.com/sbt/zinc/issues/227.

It also enables a fix for scala/bug#10426 by allowing the scaladoc
compiler to let the compiler adapt constants without losing the tree that
will be shown in the Scaladoc UI.

To maintainers: I was thinking of the best way to test this, but
couldn't come up with an elegant one. Do you suggest a way I could write
a test for this? Is there a precedent in testing information carried in
the trees?

I think @lrytz is the right person to review this, since he suggested
this fix in the first place.

Fixes scala/bug#7173