### PR TITLE
Fix description of the `next` method

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -286,7 +286,7 @@ import Iterator.empty
 /** Iterators are data structures that allow to iterate over a sequence
  *  of elements. They have a `hasNext` method for checking
  *  if there is a next element available, and a `next` method
- *  which returns the next element and discards it from the iterator.
+ *  which returns the next element and advances the iterator.
  *
  *  An iterator is mutable: most operations on it change its state. While it is often used
  *  to iterate through the elements of a collection, it can also be used without


### PR DESCRIPTION
closes https://github.com/scala/bug/issues/9423
the `next` method does not discard the element from the iterator