### PR TITLE
Fix Queue reversed append

### DIFF
--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -115,7 +115,9 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
           val thatQueue: Queue[B] = that.asInstanceOf[Queue[B]]
           thatQueue.in ++ (thatQueue.out reverse_::: this.in)
         } else {
-          (new ListBuffer[B] ++= that.seq).prependToList(this.in)
+          val lb = new ListBuffer[B]
+          that.seq.foreach(_ +=: lb)
+          lb.prependToList(this.in)
         }
       new Queue[B](newIn, this.out).asInstanceOf[That]
     } else {

--- a/test/files/run/t10298.scala
+++ b/test/files/run/t10298.scala
@@ -1,17 +1,19 @@
-import collection.immutable._
+import scala.collection.immutable._
 
 object Test {
 
   def main(args: Array[String]): Unit = {
-    assert((Queue(1) ++ Vector(2)) == Queue(1, 2))
+    val inputs: List[(Queue[Int], Vector[Int])] = List(
+      Queue.empty -> Vector(0, 1, 2),
+      (Queue.empty :+ 0) -> Vector(1, 2),
+      (0 +: Queue.empty) -> Vector(1, 2),
+      (0 +: (Queue.empty :+ 1)) -> Vector(2),
+      ((0 +: Queue.empty) :+ 1) -> Vector(2),
+      (0 +: 1 +: Queue.empty) -> Vector(2),
+      (Queue.empty :+ 0 :+ 1) -> Vector(2)
+    )
 
-    assert(((Queue(1).++(Vector(2))(collection.breakOut)): Vector[Int]) == Vector(1, 2))
-
-    assert(((Queue(1) :+ 2) ++ Vector(3)) == Queue(1, 2, 3))
-
-    assert(((1 +: Queue(2)) ++ Vector(3)) == Queue(1, 2, 3))
-
-    assert(((1 +: Queue(2)) ++ (3 +: Queue(4))) == Queue(1, 2, 3, 4))
+    inputs.foreach { case (q, v) => assert(q ++ v == Queue(0, 1, 2)) }
   }
 
 }


### PR DESCRIPTION
https://github.com/scala/scala/pull/5891 introduced yet another bug which is that collections appended to `Queue`s are appended reversed. This is the fix; thanks very much @mingthemerciless for pointing it out.