### PR TITLE
Decouple warning unused implicit parameters

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -26,8 +26,9 @@ trait Warnings {
     val PatVars   = Choice("patvars",   "Warn if a variable bound in a pattern is unused.")
     val Privates  = Choice("privates",  "Warn if a private member is unused.")
     val Locals    = Choice("locals",    "Warn if a local definition is unused.")
-    val Params    = Choice("params",    "Warn if a value parameter is unused.")
+    val Explicits = Choice("explicits", "Warn if an explicit parameter is unused.")
     val Implicits = Choice("implicits", "Warn if an implicit parameter is unused.")
+    val Params    = Choice("params",    "Warn if a value parameter is unused.", expandsTo = List(Explicits, Implicits))
     val Linted    = Choice("linted",    "-Xlint:unused.", expandsTo = List(Imports, Privates, Locals, Implicits))
   }
 
@@ -44,14 +45,15 @@ trait Warnings {
   def warnUnusedPatVars   = warnUnused contains UnusedWarnings.PatVars
   def warnUnusedPrivates  = warnUnused contains UnusedWarnings.Privates
   def warnUnusedLocals    = warnUnused contains UnusedWarnings.Locals
-  def warnUnusedParams    = warnUnused contains UnusedWarnings.Params
+  def warnUnusedParams    = warnUnusedExplicits || warnUnusedImplicits
+  def warnUnusedExplicits = warnUnused contains UnusedWarnings.Explicits
   def warnUnusedImplicits = warnUnused contains UnusedWarnings.Implicits
 
   BooleanSetting("-Ywarn-unused-import", "Warn when imports are unused.") withPostSetHook { s =>
     warnUnused.add(s"${if (s) "" else "-"}imports")
   } //withDeprecationMessage s"Enable -Ywarn-unused:imports"
 
-  val warnExtraImplicit    = BooleanSetting("-Ywarn-extra-implicit", "Warn when more than one implicit parameter section is defined.")
+  val warnExtraImplicit   = BooleanSetting("-Ywarn-extra-implicit", "Warn when more than one implicit parameter section is defined.")
 
   // Experimental lint warnings that are turned off, but which could be turned on programmatically.
   // They are not activated by -Xlint and can't be enabled on the command line because they are not

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -603,7 +603,7 @@ trait TypeDiagnostics {
       private def warningsEnabled: Boolean = {
         val ss = settings
         import ss._
-        warnUnusedPatVars || warnUnusedPrivates || warnUnusedLocals || warnUnusedParams || warnUnusedImplicits
+        warnUnusedPatVars || warnUnusedPrivates || warnUnusedLocals || warnUnusedParams
       }
 
       def apply(unit: CompilationUnit): Unit = if (warningsEnabled && !unit.isJava) {
@@ -656,9 +656,9 @@ trait TypeDiagnostics {
           for (v <- p.unusedPatVars)
             context.warning(v.pos, s"pattern var ${v.name} in ${v.owner} is never used; `${v.name}@_' suppresses this warning")
         }
-        if (settings.warnUnusedParams || settings.warnUnusedImplicits) {
-          def classOf(s: Symbol): Symbol = if (s.isClass || s == NoSymbol) s else classOf(s.owner)
+        if (settings.warnUnusedParams) {
           def isImplementation(m: Symbol): Boolean = {
+            def classOf(s: Symbol): Symbol = if (s.isClass || s == NoSymbol) s else classOf(s.owner)
             val opc = new overridingPairs.Cursor(classOf(m))
             opc.iterator.exists(pair => pair.low == m)
           }
@@ -666,8 +666,9 @@ trait TypeDiagnostics {
             (p.name.decoded == "args" && p.owner.isMethod && p.owner.name.decoded == "main") ||
             (p.tpe =:= typeOf[scala.Predef.DummyImplicit])
           }
+          def warningIsOnFor(s: Symbol) = if (s.isImplicit) settings.warnUnusedImplicits else settings.warnUnusedExplicits
           def warnable(s: Symbol) = (
-               (settings.warnUnusedParams || s.isImplicit)
+               warningIsOnFor(s)
             && !isImplementation(s.owner)
             && !isConvention(s)
           )

--- a/test/files/pos/warn-unused-params-not-implicits.flags
+++ b/test/files/pos/warn-unused-params-not-implicits.flags
@@ -1,0 +1,1 @@
+-Ywarn-unused:params,-implicits -Xfatal-warnings

--- a/test/files/pos/warn-unused-params-not-implicits.scala
+++ b/test/files/pos/warn-unused-params-not-implicits.scala
@@ -1,0 +1,32 @@
+
+trait InterFace {
+  /** Call something. */
+  def call(a: Int, b: String, c: Double)(implicit s: String): Int
+}
+
+trait BadAPI extends InterFace {
+  def f(a: Int,
+        b: String,
+        c: Double
+       )(implicit s: String): Int = {  // no warn when disabled
+    println(b + c)
+    a
+  }
+  @deprecated ("no warn in deprecated API", since="yesterday")
+  def g(a: Int,
+        b: String,
+        c: Double
+       )(implicit s: String): Int = {  // no warn
+    println(b + c)
+    a
+  }
+  override def call(a: Int,
+                    b: String,
+                    c: Double
+                   )(implicit s: String): Int = {  // no warn, required by superclass
+    println(b + c)
+    a
+  }
+
+  def i(implicit s: String, t: Int) = t           // no, disabled
+}


### PR DESCRIPTION
Take separate flags for warning about implicit
and explicit parameters. `-Ywarn-unused:params`
is an expanding option that enables both. That
allows `-Ywarn-unused:params,-implicits` to turn
off warning for implicits, in lieu of the
equivalent `-Ywarn-unused:explicits`, which is
a ridiculous name for the flag.

Fixes https://github.com/scala/bug/issues/10447