### PR TITLE
Make SeqLike.distinct access HashSet once per entry

### DIFF
--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -507,9 +507,8 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
     val b = newBuilder
     val seen = mutable.HashSet[A]()
     for (x <- this) {
-      if (!seen(x)) {
+      if (seen.add(x)) {
         b += x
-        seen += x
       }
     }
     b.result()


### PR DESCRIPTION
The old distinct first does a contains (`!seen(x)`), then does the insert, with each of these operations doing the full elemToEntry, index, and search dance. Since HashSet.add returns a true if the element was added (false otherwise) we can get away with doing that dance only once.