### PR TITLE
Avoid IllegalAccessError with Java package-protected class

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -172,7 +172,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
           // There is no test left for this warning, as I have been unable to come up with an example that would trigger it.
           // For a `super.m` selection, there must be a direct parent from which `m` can be selected. This parent will be used
           // as receiver in the invokespecial call.
-          val receiverInBytecode = erasure.accessibleOwnerOrParentDefiningMember(sym, sup.tpe.typeSymbol.parentSymbols, localTyper.context).getOrElse(sym.owner)
+          val receiverInBytecode = erasure.accessibleOwnerOrParentDefiningMember(sym, sup.tpe.typeSymbol.parentSymbols, localTyper.context.asInstanceOf[erasure.Context]).getOrElse(sym.owner)
           if (!clazz.parentSymbols.contains(receiverInBytecode))
             reporter.error(sel.pos, s"unable to emit super call unless interface ${owner.name} (which declares $sym) is directly extended by $clazz.")
         }

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1397,15 +1397,15 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def newTypeSymbol(name: TypeName, pos: Position = NoPosition, newFlags: Long = 0L): TypeSymbol =
       newNonClassSymbol(name, pos, newFlags)
 
-    /** The class or term up to which this symbol is accessible,
-     *  or RootClass if it is public.  As java protected statics are
-     *  otherwise completely inaccessible in scala, they are treated
-     *  as public.
+    /**
+     * The class or term up to which this symbol is accessible, or RootClass if it is public. As
+     * Java protected statics are otherwise completely inaccessible in Scala, they are treated as
+     * public (scala/bug#1806).
      */
     def accessBoundary(base: Symbol): Symbol = {
       if (hasFlag(PRIVATE) || isLocalToBlock) owner
       else if (hasAllFlags(PROTECTED | STATIC | JAVA)) enclosingRootClass
-      else if (hasAccessBoundary && !phase.erasedTypes) privateWithin
+      else if (hasAccessBoundary && !phase.erasedTypes) privateWithin // Phase check needed? See comment in Context.isAccessible.
       else if (hasFlag(PROTECTED)) base
       else enclosingRootClass
     }

--- a/test/files/run/t10450/A.java
+++ b/test/files/run/t10450/A.java
@@ -1,0 +1,20 @@
+/*
+ * filter: unchecked
+ */
+package a;
+
+class B<T extends B<T>> {
+    private int connectTimeout = 10000;
+    private int failedAttempts = 3;
+
+    public T setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+        return (T) this;
+    }
+
+    public T setFailedAttempts(int slaveFailedAttempts) {
+        this.failedAttempts = slaveFailedAttempts;
+        return (T) this;
+    }
+}
+public class A extends B<A> { }

--- a/test/files/run/t10450/Test.scala
+++ b/test/files/run/t10450/Test.scala
@@ -1,0 +1,16 @@
+package b {
+  import a._
+
+  object C {
+    def m = {
+      val a = new A()
+        .setConnectTimeout(1)
+        .setFailedAttempts(1)
+      0
+    }
+  }
+}
+
+object Test extends App {
+  assert(b.C.m == 0)
+}


### PR DESCRIPTION
When accessing a public member of a Java-defined package-protected
class through a public subclass, we need to ensure to use the public
subclass as receiver type in order to avoid an IllegalAccessError.

Fixes scala/bug#10450