### PR TITLE
Propagate the DEFAULTINIT flag to the underlying field

### DIFF
--- a/src/reflect/scala/reflect/internal/Flags.scala
+++ b/src/reflect/scala/reflect/internal/Flags.scala
@@ -268,7 +268,7 @@ class Flags extends ModifierFlags {
    *  PRIVATE, LOCAL.
    */
   final val FieldFlags =
-    MUTABLE | CASEACCESSOR | PARAMACCESSOR | STATIC | FINAL | PRESUPER | LAZY
+    MUTABLE | CASEACCESSOR | PARAMACCESSOR | STATIC | FINAL | PRESUPER | LAZY | DEFAULTINIT
 
   /** Masks for getters and setters, where the flags are derived from those
    *  on the field's modifiers.  Both getters and setters get the ACCESSOR flag.

--- a/test/files/run/t10439.flags
+++ b/test/files/run/t10439.flags
@@ -1,0 +1,1 @@
+-Xcheckinit

--- a/test/files/run/t10439.scala
+++ b/test/files/run/t10439.scala
@@ -1,0 +1,14 @@
+object Test {
+  private var s: String = _
+
+  def getS: String = {
+    if (s == null) {
+      s = ""
+    }
+    s
+  }
+
+  def main(args: Array[String]): Unit = {
+    assert(getS == "")
+  }
+}


### PR DESCRIPTION
Fields initialized with `_` are excluded from initialization
checks under `-Xcheckinit`.

Since 5f86b1d94d, the compiler checks that flag on the field symbol
instead of the getter. Unfortunately the flag was not actually copied
to the field symbol, causing the init check to be added.

Fixes scala/bug#10439 and it also fixes scala/bug#10437.