### PR TITLE
Position negative numeric literals starting at the minus sign.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1651,9 +1651,11 @@ self =>
       if (isUnaryOp) {
         atPos(in.offset) {
           if (lookingAhead(isSimpleExprIntro)) {
+            val namePos = in.offset
             val uname = nme.toUnaryName(rawIdent().toTermName)
             if (uname == nme.UNARY_- && isNumericLit)
-              simpleExprRest(literal(isNegated = true), canApply = true)
+              /* start at the -, not the number */
+              simpleExprRest(literal(isNegated = true, start = namePos), canApply = true)
             else
               Select(stripParens(simpleExpr()), uname)
           }

--- a/test/files/neg/stmt-expr-discard.check
+++ b/test/files/neg/stmt-expr-discard.check
@@ -3,7 +3,7 @@ stmt-expr-discard.scala:3: warning: a pure expression does nothing in statement 
     ^
 stmt-expr-discard.scala:4: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
     - 4
-      ^
+    ^
 error: No warnings can be incurred under -Xfatal-warnings.
 two warnings found
 one error found

--- a/test/files/run/t6288.check
+++ b/test/files/run/t6288.check
@@ -5,7 +5,7 @@
       [106][106][106]Case3.super.<init>();
       [13]()
     };
-    [21]def unapply([29]z: [32]<type: [32]scala.Any>): [21]Option[Int] = [56][52][52]scala.Some.apply[[52]Int]([58]-1);
+    [21]def unapply([29]z: [32]<type: [32]scala.Any>): [21]Option[Int] = [56][52][52]scala.Some.apply[[52]Int]([57]-1);
     [64]{
       [64]case <synthetic> val x1: [64]String = [64]"";
       [64]case5()[84]{

--- a/test/scaladoc/resources/negative-defaults.scala
+++ b/test/scaladoc/resources/negative-defaults.scala
@@ -1,0 +1,10 @@
+package test
+
+object Test {
+  def int(i: Int = -1)            : Int    = i
+  def long(l: Long = -2L)         : Long   = l
+  def float(f: Float = -3.4f)     : Float  = f
+  def double(d: Double = -5.6)    : Double = d
+
+  def spaces(d: Double = -   7d) : Double  = d
+}

--- a/test/scaladoc/run/t10391.check
+++ b/test/scaladoc/run/t10391.check
@@ -1,0 +1,6 @@
+Some(-1)
+Some(-2L)
+Some(-3.4f)
+Some(-5.6)
+Some(-   7d)
+Done.

--- a/test/scaladoc/run/t10391.scala
+++ b/test/scaladoc/run/t10391.scala
@@ -1,0 +1,24 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+import language._
+
+object Test extends ScaladocModelTest {
+  override def resourceFile = "negative-defaults.scala"
+  override def scaladocSettings = ""
+  def testModel(root: Package) = {
+    import access._
+
+    val pkg = root._package("test")
+    val intparam    = pkg._object("Test")._method("int").valueParams.head.head
+    val longparam   = pkg._object("Test")._method("long").valueParams.head.head
+    val floatparam  = pkg._object("Test")._method("float").valueParams.head.head
+    val doubleparam = pkg._object("Test")._method("double").valueParams.head.head
+    val spacesparam = pkg._object("Test")._method("spaces").valueParams.head.head
+
+    println(intparam.defaultValue)
+    println(longparam.defaultValue)
+    println(floatparam.defaultValue)
+    println(doubleparam.defaultValue)
+    println(spacesparam.defaultValue)
+  }
+}


### PR DESCRIPTION
Previously the start position was the first digit; this caused scaladoc to not pick up on the minus sign.

Fixes scala/bug#10391; review by @VladUreche / @janekdb