### PR TITLE
Set encoding to UTF-8 for partest to avoid failures on windows

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -677,7 +677,8 @@ lazy val test = project
     // test sources are compiled in partest run, not here
     sources in IntegrationTest := Seq.empty,
     fork in IntegrationTest := true,
-    javaOptions in IntegrationTest += "-Xmx2G",
+    javaOptions in IntegrationTest ++= "-Xmx2G" :: "-Dfile.encoding=UTF-8" :: Nil,
+    testOptions in IntegrationTest += Tests.Argument("-Dfile.encoding=UTF-8"),
     testFrameworks += new TestFramework("scala.tools.partest.sbt.Framework"),
     testOptions in IntegrationTest += Tests.Argument("-Dpartest.java_opts=-Xmx1024M -Xms64M"),
     testOptions in IntegrationTest += Tests.Argument("-Dpartest.scalac_opts=" + (scalacOptions in Compile).value.mkString(" ")),


### PR DESCRIPTION
Partest uses the default encoding to load checkfiles, etc
[in](https://github.com/scala/scala-partest/blob/bd2d2c6c/src/main/scala/scala/tools/partest/package.scala#L83):

```
def fileContents: String    = try sf.slurp() catch { case _: java.io.FileNotFoundException => "" }
```

When it forks processes to run the compiled `run` tests, it explicitly
[sets](https://github.com/scala/scala-partest/blob/1c263205/src/main/scala/scala/tools/partest/nest/Runner.scala#L174)
`-Dfile.encoding=UTF-8`.

The old `./test/partest` script (removed in 0bf343e0) used to also set `-Dfile.encoding=UTF-8` to the top-level
partest process. We forgot to port this into the part of our SBT build that forks partest.

Fixes scala/scala-dev#412