### PR TITLE
Rightful owners for stub symbols

### DIFF
--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -254,7 +254,7 @@ abstract class UnPickler {
                     |A full rebuild may help if '$filename' was compiled against an incompatible version of ${owner.fullName}.$advice""".stripMargin
               val stubName = if (tag == EXTref) name else name.toTypeName
               // The position of the error message is set by `newStubSymbol`
-              NoSymbol.newStubSymbol(stubName, missingMessage)
+              owner.newStubSymbol(stubName, missingMessage)
             }
           }
         }

--- a/test/files/neg/t5148.check
+++ b/test/files/neg/t5148.check
@@ -4,10 +4,10 @@ Make sure that term memberHandlers is in your classpath and check for conflictin
 A full rebuild may help if 'Imports.class' was compiled against an incompatible version of scala.tools.nsc.interpreter.IMain.
 class IMain extends Imports
             ^
-t5148.scala:4: error: Symbol 'type <none>.Request.Wrapper' is missing from the classpath.
+t5148.scala:4: error: Symbol 'type scala.tools.nsc.interpreter.IMain.Request.Wrapper' is missing from the classpath.
 This symbol is required by 'value scala.tools.nsc.interpreter.Imports.wrapper'.
 Make sure that type Wrapper is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
-A full rebuild may help if 'Imports.class' was compiled against an incompatible version of <none>.Request.
+A full rebuild may help if 'Imports.class' was compiled against an incompatible version of scala.tools.nsc.interpreter.IMain.Request.
 class IMain extends Imports
       ^
 two errors found


### PR DESCRIPTION
Running:

```
object Test {
  def main(args: Array[String]): Unit = {
    import scala.tools.nsc._
    val settings = new Settings()
    settings.Ylogcp.value = true
    settings.usejavacp.value = false
    settings.classpath.value = "/code/scala/build/pack/lib/scala-library.jar:/tmp/foo"
    settings.bootclasspath.value = ""
    System.setProperty("scala.usejavacp", "false")
    val g = new Global(settings)
    import g._
    new Run()
    val DecodeModule = g.rootMirror.getModuleByName(TermName("scala.tools.scalap.Decode"))
    println(DecodeModule.moduleClass.info)
  }
}
```

Against:

```
$ find /tmp/foo -type f
/tmp/foo/scala/tools/scalap/Decode.class
```

Would show up the `NoSymbol` owners of stub symbols in
the full names of symbols:

```
AnyRef {
  def <init>(): scala.tools.scalap.Decode.type
  private def getAliasSymbol(t: <none>.scalasig.Type): <none>.scalasig.Symbol
  ...
```

After this patch, we instead see:

```
  private def getAliasSymbol(t: scala.tools.scalap.scalax.rules.scalasig.Type): scala.tools.scalap.scalax.rules.scalasig.Symbol
```

This makes it feasible to write tools like scalap in terms
of the Unpickler/ClassfileParser.