### PR TITLE
Collect all statistics and optimize checks

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1213,6 +1213,11 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
       checkPhaseSettings(including = true, inclusions.toSeq: _*)
       checkPhaseSettings(including = false, exclusions map (_.value): _*)
 
+      // Report the overhead of statistics measurements per every run
+      import scala.reflect.internal.util.Statistics
+      if (Statistics.canEnable)
+        Statistics.reportStatisticsOverhead(reporter)
+
       phase = first   //parserPhase
       first
     }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -370,6 +370,7 @@ trait ScalaSettings extends AbsScalaSettings
 
   val YoptLogInline = StringSetting("-Yopt-log-inline", "package/Class.method", "Print a summary of inliner activity; `_` to print all, prefix match to select.", "")
 
+  import scala.reflect.internal.util.Statistics
   object YstatisticsPhases extends MultiChoiceEnumeration { val parser, typer, patmat, erasure, cleanup, jvm = Value }
   val Ystatistics = {
     val description = "Print compiler statistics for specific phases"
@@ -379,10 +380,12 @@ trait ScalaSettings extends AbsScalaSettings
       descr   = description,
       domain  = YstatisticsPhases,
       default = Some(List("_"))
-    ) withPostSetHook { _ => scala.reflect.internal.util.Statistics.enabled = true }
+    ).withPostSetHook(_ => Statistics.enabled = true)
   }
 
   def YstatisticsEnabled = Ystatistics.value.nonEmpty
+  val YhotStatistics = BooleanSetting("-Yhot-statistics", "Print hot compiler statistics for all relevant phases")
+    .withPostSetHook(_ => Statistics.hotEnabled = true)
 
   val YprofileEnabled = BooleanSetting("-Yprofile-enabled", "Enable profiling.")
   val YprofileDestination = StringSetting("-Yprofile-destination", "file", "where to send profiling output - specify a file, default is to the console.", "").

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5562,10 +5562,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         else
           typedInternal(tree, mode, pt)
       )
-      val startByType = if (Statistics.canEnable) Statistics.pushTimer(byTypeStack, byTypeNanos(tree.getClass)) else null
-      if (Statistics.canEnable) Statistics.incCounter(visitsByType, tree.getClass)
+      val startByType = if (Statistics.hotEnabled) Statistics.pushTimer(byTypeStack, byTypeNanos(tree.getClass)) else null
+      if (Statistics.hotEnabled) Statistics.incCounter(visitsByType, tree.getClass)
       try body
-      finally if (Statistics.canEnable) Statistics.popTimer(byTypeStack, startByType)
+      finally if (Statistics.hotEnabled) Statistics.popTimer(byTypeStack, startByType)
     }
 
     private def typedInternal(tree: Tree, mode: Mode, pt: Type): Tree = {

--- a/src/compiler/scala/tools/nsc/util/StatisticsInfo.scala
+++ b/src/compiler/scala/tools/nsc/util/StatisticsInfo.scala
@@ -19,12 +19,16 @@ abstract class StatisticsInfo {
 
   def print(phase: Phase) = if (settings.Ystatistics contains phase.name) {
     inform("*** Cumulative statistics at phase " + phase)
-    retainedCount.value = 0
-    for (c <- retainedByType.keys)
-      retainedByType(c).value = 0
-    for (u <- currentRun.units; t <- u.body) {
-      retainedCount.value += 1
-      retainedByType(t.getClass).value += 1
+
+    if (settings.YhotStatistics.value) {
+      // High overhead, only enable retained stats under hot stats
+      retainedCount.value = 0
+      for (c <- retainedByType.keys)
+        retainedByType(c).value = 0
+      for (u <- currentRun.units; t <- u.body) {
+        retainedCount.value += 1
+        retainedByType(t.getClass).value += 1
+      }
     }
 
     val quants =

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -178,7 +178,7 @@ abstract class SymbolTable extends macros.Universe
 
   final def atPhaseStack: List[Phase] = List.tabulate(phStackIndex)(i => phStack(i))
   final def phase: Phase = {
-    if (Statistics.hotEnabled)
+    if (Statistics.canEnable)
       Statistics.incCounter(SymbolTableStats.phaseCounter)
     ph
   }

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -766,7 +766,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     }
 
     final def flags: Long = {
-      if (Statistics.hotEnabled) Statistics.incCounter(flagsCount)
+      if (Statistics.canEnable) Statistics.incCounter(flagsCount)
       val fs = _rawflags & phase.flagMask
       (fs | ((fs & LateFlags) >>> LateShift)) & ~((fs & AntiFlags) >>> AntiShift)
     }
@@ -1196,7 +1196,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      * `assertOwner` aborts compilation immediately if called on NoSymbol.
      */
     def owner: Symbol = {
-      if (Statistics.hotEnabled) Statistics.incCounter(ownerCount)
+      if (Statistics.canEnable) Statistics.incCounter(ownerCount)
       rawowner
     }
     final def safeOwner: Symbol   = if (this eq NoSymbol) NoSymbol else owner
@@ -2767,7 +2767,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     private[this] var _rawname: TermName = initName
     def rawname = _rawname
     def name = {
-      if (Statistics.hotEnabled) Statistics.incCounter(nameCount)
+      if (Statistics.canEnable) Statistics.incCounter(nameCount)
       _rawname
     }
     override def name_=(name: Name) {
@@ -2901,13 +2901,13 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def moduleClass = referenced
 
     override def owner = {
-      if (Statistics.hotEnabled) Statistics.incCounter(ownerCount)
+      if (Statistics.canEnable) Statistics.incCounter(ownerCount)
       // a non-static module symbol gets the METHOD flag in uncurry's info transform -- see isModuleNotMethod
       if (!isMethod && needsFlatClasses) rawowner.owner
       else rawowner
     }
     override def name: TermName = {
-      if (Statistics.hotEnabled) Statistics.incCounter(nameCount)
+      if (Statistics.canEnable) Statistics.incCounter(nameCount)
       if (!isMethod && needsFlatClasses) {
         if (flatname eq null)
           flatname = nme.flattenedName(rawowner.name, rawname)
@@ -3039,7 +3039,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     def rawname = _rawname
     def name = {
-      if (Statistics.hotEnabled) Statistics.incCounter(nameCount)
+      if (Statistics.canEnable) Statistics.incCounter(nameCount)
       _rawname
     }
     final def asNameType(n: Name) = n.toTypeName
@@ -3166,7 +3166,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      * info for T in Test1 should be >: Nothing <: Test3[_]
      */
 
-    if (Statistics.hotEnabled) Statistics.incCounter(typeSymbolCount)
+    if (Statistics.canEnable) Statistics.incCounter(typeSymbolCount)
   }
   implicit val TypeSymbolTag = ClassTag[TypeSymbol](classOf[TypeSymbol])
 
@@ -3326,7 +3326,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     }
 
     override def owner: Symbol = {
-      if (Statistics.hotEnabled) Statistics.incCounter(ownerCount)
+      if (Statistics.canEnable) Statistics.incCounter(ownerCount)
       if (needsFlatClasses) rawowner.owner else rawowner
     }
 
@@ -3387,7 +3387,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       else super.toString
     )
 
-    if (Statistics.hotEnabled) Statistics.incCounter(classSymbolCount)
+    if (Statistics.canEnable) Statistics.incCounter(classSymbolCount)
   }
   implicit val ClassSymbolTag = ClassTag[ClassSymbol](classOf[ClassSymbol])
 

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -38,7 +38,7 @@ trait Trees extends api.Trees {
     val id = nodeCount // TODO: add to attachment?
     nodeCount += 1
 
-    if (Statistics.canEnable) Statistics.incCounter(TreesStats.nodeByType, getClass)
+    if (Statistics.hotEnabled) Statistics.incCounter(TreesStats.nodeByType, getClass)
 
     final override def pos: Position = rawatt.pos
 

--- a/src/reflect/scala/reflect/internal/util/AlmostFinalValue.java
+++ b/src/reflect/scala/reflect/internal/util/AlmostFinalValue.java
@@ -1,0 +1,94 @@
+package scala.reflect.internal.util;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
+import java.lang.invoke.SwitchPoint;
+
+/**
+ * Represents a value that is wrapped with JVM machinery to allow the JVM
+ * to speculate on its content and effectively optimize it as if it was final.
+ * 
+ * This file has been drawn from JSR292 cookbook created by Rémi Forax.
+ * https://code.google.com/archive/p/jsr292-cookbook/. The explanation of the strategy
+ * can be found in https://community.oracle.com/blogs/forax/2011/12/17/jsr-292-goodness-almost-static-final-field.
+ * 
+ * Before copying this file to the repository, I tried to adapt the most important
+ * parts of this implementation and special case it for `Statistics`, but that
+ * caused an important performance penalty (~10%). This performance penalty is
+ * due to the fact that using `static`s for the method handles and all the other
+ * fields is extremely important for the JVM to correctly optimize the code, and
+ * we cannot do that if we make `Statistics` an object extending `MutableCallSite`
+ * in Scala. We instead rely on the Java implementation that uses a boxed representation.
+ */
+public class AlmostFinalValue<V> {
+  private final AlmostFinalCallSite<V> callsite =
+      new AlmostFinalCallSite<>(this);
+  
+  protected V initialValue() {
+    return null;
+  }
+  
+  public MethodHandle createGetter() {
+    return callsite.dynamicInvoker();
+  }
+  
+  public void setValue(V value) {
+    callsite.setValue(value);
+  }
+  
+  private static class AlmostFinalCallSite<V> extends MutableCallSite {
+    private Object value;
+    private SwitchPoint switchPoint;
+    private final AlmostFinalValue<V> volatileFinalValue;
+    private final MethodHandle fallback;
+    private final Object lock;
+    
+    private static final Object NONE = new Object();
+    private static final MethodHandle FALLBACK;
+    static {
+      try {
+        FALLBACK = MethodHandles.lookup().findVirtual(AlmostFinalCallSite.class, "fallback",
+            MethodType.methodType(Object.class));
+      } catch (NoSuchMethodException|IllegalAccessException e) {
+        throw new AssertionError(e.getMessage(), e);
+      }
+    }
+    
+    AlmostFinalCallSite(AlmostFinalValue<V> volatileFinalValue) {
+      super(MethodType.methodType(Object.class));
+      Object lock = new Object();
+      MethodHandle fallback = FALLBACK.bindTo(this);
+      synchronized(lock) {
+        value = NONE;
+        switchPoint = new SwitchPoint();
+        setTarget(fallback);
+      }
+      this.volatileFinalValue = volatileFinalValue;
+      this.lock = lock;
+      this.fallback = fallback;
+    }
+
+    Object fallback() {
+      synchronized(lock) {
+        Object value = this.value;
+        if (value == NONE) {
+          value = volatileFinalValue.initialValue();
+        }
+        MethodHandle target = switchPoint.guardWithTest(MethodHandles.constant(Object.class, value), fallback);
+        setTarget(target);
+        return value;
+      }
+    }
+    
+    void setValue(V value) {
+      synchronized(lock) {
+        SwitchPoint switchPoint = this.switchPoint;
+        this.value = value;
+        this.switchPoint = new SwitchPoint();
+        SwitchPoint.invalidateAll(new SwitchPoint[] {switchPoint});
+      }
+    }
+  }
+}

--- a/src/reflect/scala/reflect/internal/util/BooleanContainer.java
+++ b/src/reflect/scala/reflect/internal/util/BooleanContainer.java
@@ -1,0 +1,30 @@
+package scala.reflect.internal.util;
+
+/**
+ * Represents a container with a boolean value that tells the compiler whether
+ * an option is enabled or not. This class is used for configuration purposes
+ * (see scala.reflect.internal.util.Statistics).
+ */
+class BooleanContainer {
+  private final boolean value;
+
+  public BooleanContainer(boolean value) {
+    this.value = value;
+  }
+  
+  public boolean isEnabledNow() {
+    return value;
+  }
+
+  protected final static class TrueContainer extends BooleanContainer {
+    TrueContainer() {
+        super(true);
+    }
+  }
+
+  protected final static class FalseContainer extends BooleanContainer {
+    FalseContainer() {
+        super(false);
+    }
+  }
+}

--- a/src/reflect/scala/reflect/internal/util/Statistics.scala
+++ b/src/reflect/scala/reflect/internal/util/Statistics.scala
@@ -256,7 +256,7 @@ quant)
    *
    *  to remove all Statistics code from build
    */
-  final val canEnable = _enabled
+  final def canEnable = _enabled
 
   /** replace with
    *

--- a/src/reflect/scala/reflect/internal/util/Statistics.scala
+++ b/src/reflect/scala/reflect/internal/util/Statistics.scala
@@ -3,51 +3,53 @@ package reflect.internal.util
 
 import scala.collection.mutable
 
+import java.lang.invoke.{SwitchPoint, MethodHandle, MethodHandles, MethodType}
+
 object Statistics {
 
   type TimerSnapshot = (Long, Long)
 
   /** If enabled, increment counter by one */
   @inline final def incCounter(c: Counter) {
-    if (_enabled && c != null) c.value += 1
+    if (canEnable && c != null) c.value += 1
   }
 
   /** If enabled, increment counter by given delta */
   @inline final def incCounter(c: Counter, delta: Int) {
-    if (_enabled && c != null) c.value += delta
+    if (canEnable && c != null) c.value += delta
   }
 
   /** If enabled, increment counter in map `ctrs` at index `key` by one */
   @inline final def incCounter[K](ctrs: QuantMap[K, Counter], key: K) =
-    if (_enabled && ctrs != null) ctrs(key).value += 1
+    if (canEnable && ctrs != null) ctrs(key).value += 1
 
   /** If enabled, start subcounter. While active it will track all increments of
    *  its base counter.
    */
   @inline final def startCounter(sc: SubCounter): (Int, Int) =
-    if (_enabled && sc != null) sc.start() else null
+    if (canEnable && sc != null) sc.start() else null
 
   /** If enabled, stop subcounter from tracking its base counter. */
   @inline final def stopCounter(sc: SubCounter, start: (Int, Int)) {
-    if (_enabled && sc != null) sc.stop(start)
+    if (canEnable && sc != null) sc.stop(start)
   }
 
   /** If enabled, start timer */
   @inline final def startTimer(tm: Timer): TimerSnapshot =
-    if (_enabled && tm != null) tm.start() else null
+    if (canEnable && tm != null) tm.start() else null
 
   /** If enabled, stop timer */
   @inline final def stopTimer(tm: Timer, start: TimerSnapshot) {
-    if (_enabled && tm != null) tm.stop(start)
+    if (canEnable && tm != null) tm.stop(start)
   }
 
   /** If enabled, push and start a new timer in timer stack */
   @inline final def pushTimer(timers: TimerStack, timer: => StackableTimer): TimerSnapshot =
-    if (_enabled && timers != null) timers.push(timer) else null
+    if (canEnable && timers != null) timers.push(timer) else null
 
   /** If enabled, stop and pop timer from timer stack */
   @inline final def popTimer(timers: TimerStack, prev: TimerSnapshot) {
-    if (_enabled && timers != null) timers.pop(prev)
+    if (canEnable && timers != null) timers.pop(prev)
   }
 
   /** Create a new counter that shows as `prefix` and is active in given phases */
@@ -247,29 +249,33 @@ quant)
     }
   }
 
-  private var _enabled = false
   private val qs = new mutable.HashMap[String, Quantity]
 
-  /** replace with
-   *
-   *    final val canEnable = false
-   *
-   *  to remove all Statistics code from build
-   */
-  final def canEnable = _enabled
+  /** Represents whether normal statistics can or cannot be enabled. */
+  @inline final def canEnable: Boolean = StatisticsStatics.areColdStatsEnabled()
 
-  /** replace with
-   *
-   *   final def hotEnabled = _enabled
-   *
-   * and rebuild, to also count tiny but super-hot methods
-   * such as phase, flags, owner, name.
-   */
-  final val hotEnabled = false
-
-  def enabled = _enabled
+  @inline def enabled = canEnable
   def enabled_=(cond: Boolean) = {
-    if (cond && !_enabled) {
+    if (cond && !canEnable) {
+      StatisticsStatics.enableColdStats()
+    } else if (!cond && canEnable) {
+      StatisticsStatics.disableColdStats()
+    }
+  }
+
+  /** Represents whether hot statistics can or cannot be enabled. */
+  @inline def hotEnabled: Boolean = canEnable && StatisticsStatics.areHotStatsEnabled()
+  def hotEnabled_=(cond: Boolean) = {
+    if (cond && !hotEnabled) {
+      StatisticsStatics.enableHotStats()
+    } else if (!cond && hotEnabled) {
+      StatisticsStatics.disableHotStats()
+    }
+  }
+
+  import scala.reflect.internal.Reporter
+  /** Reports the overhead of measuring statistics via the nanoseconds variation. */
+  def reportStatisticsOverhead(reporter: Reporter): Unit = {
       val start = System.nanoTime()
       var total = 0L
       for (i <- 1 to 10000) {
@@ -277,9 +283,7 @@ quant)
         total += System.nanoTime() - time
       }
       val total2 = System.nanoTime() - start
-      println("Enabling statistics, measuring overhead = "+
-              total/10000.0+"ns to "+total2/10000.0+"ns per timer")
-      _enabled = true
-    }
+      val variation = s"${total/10000.0}ns to ${total2/10000.0}ns"
+      reporter.echo(NoPosition, s"Enabling statistics, measuring overhead = $variation per timer")
   }
 }

--- a/src/reflect/scala/reflect/internal/util/StatisticsStatics.java
+++ b/src/reflect/scala/reflect/internal/util/StatisticsStatics.java
@@ -1,0 +1,65 @@
+package scala.reflect.internal.util;
+
+import scala.reflect.internal.util.AlmostFinalValue;
+import java.lang.invoke.MethodHandle;
+
+/**
+ * Represents all the simulated statics for Statistics.
+ * 
+ * Its implementation delegates to {@link scala.reflect.internal.util.AlmostFinalValue},
+ * which helps performance (see docs to find out why).
+ */
+public final class StatisticsStatics extends BooleanContainer {
+  public StatisticsStatics(boolean value) {
+    super(value);
+  }
+
+  private static final AlmostFinalValue<BooleanContainer> COLD_STATS = new AlmostFinalValue<BooleanContainer>() {
+    @Override
+    protected BooleanContainer initialValue() {
+        return new FalseContainer();
+    }
+  };
+
+  private static final AlmostFinalValue<BooleanContainer> HOT_STATS = new AlmostFinalValue<BooleanContainer>() {
+    @Override
+    protected BooleanContainer initialValue() {
+        return new FalseContainer();
+    }
+  };
+
+  private static final MethodHandle COLD_STATS_GETTER = COLD_STATS.createGetter();
+  private static final MethodHandle HOT_STATS_GETTER = HOT_STATS.createGetter();
+  
+  public static boolean areColdStatsEnabled() {
+    try {
+      return ((BooleanContainer)(Object) COLD_STATS_GETTER.invokeExact()).isEnabledNow();
+    } catch (Throwable e) {
+      throw new AssertionError(e.getMessage(), e);
+    }
+  }
+
+  public static boolean areHotStatsEnabled() {
+    try {
+      return ((BooleanContainer)(Object) HOT_STATS_GETTER.invokeExact()).isEnabledNow();
+    } catch (Throwable e) {
+      throw new AssertionError(e.getMessage(), e);
+    }
+  }
+
+  public static void enableColdStats() {
+    COLD_STATS.setValue(new TrueContainer());
+  }
+
+  public static void disableColdStats() {
+    COLD_STATS.setValue(new FalseContainer());
+  }
+
+  public static void enableHotStats() {
+    HOT_STATS.setValue(new TrueContainer());
+  }
+
+  public static void disableHotStats() {
+    HOT_STATS.setValue(new FalseContainer());
+  }
+}


### PR DESCRIPTION
References: scala/scala-dev#149.

This PR does the two following things, all in the domain of statistics:

1. It allows the collection of all the statistics (before, we were only
   reporting on a very narrow set of the available statistics). This is
   achieved by turning `canEnable` into a `def` instead of `val`. Related
   history: ebb719f#diff-438d9e5ac0dd1965aabd4776e1ee70eaR246/
2. It adds a mechanism to remove the overhead of checking for statistics
   in the common case (where statistics are disabled). It does so by
   reusing a mechanism proposed by Rémi Forax and brought to my
   attention by @retronym (more here: scala/scala-dev#149).

There is one pending issues with this PR, which hasn't been solved yet:

* How do we keep this implementation runtime-agnostic, allowing
  compilers like Scalajs and Scala.native to default to a correct, inefficient
  implementation?

I don't know how to do this (or how these compilers are replacing JVM-specific
implementations), so I would appreciate insights from @sjrd and @densh.

In the future, I could look into ways of expanding this implementation to all
our flag checking infrastructure, which is what the referenced ticket on the
top is about. However, I'd prefer to do this in a separate PR if possible. For
now, I wanted to create a very small change to see the prior results.

This PR is work-in-progress and I've just opened it to check the
performance penalty of my changes. Afterwards, I would like to detect
what's the performance penalty of having statistics enabled by default,
I'm sure we can draw interesting results from there.