### PR TITLE
Mention caught throwables for trait Future.failed

### DIFF
--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -46,7 +46,7 @@ import scala.reflect.ClassTag
  *  executed in a particular order.
  *
  *  @define caughtThrowables
- *  The future may contain a throwable object and this means that the future failed.
+ *  This future may contain a throwable object and this means that the future failed.
  *  Futures obtained through combinators have the same exception as the future they were obtained from.
  *  The following throwable objects are not contained in the future:
  *  - `Error` - errors are not contained within futures
@@ -197,6 +197,8 @@ trait Future[+T] extends Awaitable[T] {
    *  if the original `Future` fails.
    *
    *  If the original `Future` is successful, the returned `Future` is failed with a `NoSuchElementException`.
+   *
+   *  $caughtThrowables
    *
    * @return a failed projection of this `Future`.
    * @group Transformations


### PR DESCRIPTION
Caught throwables / wrapping of fatal exceptions was documented for
`trait Future.onFailure`, but not for `trait Future.failed` which became
more prominent with the deprecation of `Future.onFailure` in 2.12.