### PR TITLE
introduce scala.collection.Searching.searchBy

### DIFF
--- a/src/library/scala/collection/Searching.scala
+++ b/src/library/scala/collection/Searching.scala
@@ -54,8 +54,8 @@ object Searching {
       */
     final def search[B >: A](elem: B)(implicit ord: Ordering[B]): SearchResult =
       coll match {
-        case _: IndexedSeqLike[A, Repr] => binarySearch(elem, 0, coll.length)(ord)
-        case _ => linearSearch(coll.view, elem, 0)(ord)
+        case _: IndexedSeqLike[A, Repr] => binarySearchBy(elem, 0, coll.length, identity)(ord)
+        case _ => linearSearchBy(coll.view, elem, 0, identity)(ord)
       }
 
     /** Search within an interval in the sorted sequence for a specific element. If the
@@ -81,29 +81,82 @@ object Searching {
     final def search[B >: A](elem: B, from: Int, to: Int)
     (implicit ord: Ordering[B]): SearchResult =
       coll match {
-        case _: IndexedSeqLike[A, Repr] => binarySearch(elem, from, to)(ord)
-        case _ => linearSearch(coll.view(from, to), elem, from)(ord)
+        case _: IndexedSeqLike[A, Repr] => binarySearchBy(elem, from, to, identity)(ord)
+        case _ => linearSearchBy(coll.view(from, to), elem, from, identity)(ord)
       }
 
+
+    /** Search the sorted sequence for a specific element. If the sequence is an
+      * `IndexedSeqLike`, a binary search is used. Otherwise, a linear search is used.
+      *
+      * The sequence should be sorted with the same `Ordering` before calling; otherwise,
+      * the results are undefined.
+      *
+      * @see [[scala.collection.IndexedSeqLike]]
+      * @see [[scala.math.Ordering]]
+      * @see [[scala.collection.SeqLike]], method `sorted`
+      *
+      * @param elem the element to find.
+      * @param from the index where the search starts.
+      * @param to   the index following where the search ends.*
+      * @param by   function to convert elements of collection to ordering elements
+      * @param ord  the ordering to be used to compare elements.
+      *
+      * @return a `Found` value containing the index corresponding to the element in the
+      *         sequence, or the `InsertionPoint` where the element would be inserted if
+      *         the element is not in the sequence.
+      */
+    final def searchBy[B](elem:B, from: Int, to: Int, by:A => B)(implicit ord: Ordering[B]):SearchResult = {
+      coll match {
+        case _: IndexedSeqLike[A, Repr] => binarySearchBy(elem, from, to, by)(ord)
+        case _ => linearSearchBy(coll.view(from, to), elem, from, by)(ord)
+      }
+    }
+
+    /** Search the sorted sequence for a specific element. If the sequence is an
+      * `IndexedSeqLike`, a binary search is used. Otherwise, a linear search is used.
+      *
+      * The sequence should be sorted with the same `Ordering` before calling; otherwise,
+      * the results are undefined.
+      *
+      * @see [[scala.collection.IndexedSeqLike]]
+      * @see [[scala.math.Ordering]]
+      * @see [[scala.collection.SeqLike]], method `sorted`
+      *
+      * @param elem the element to find.
+      * @param by   function to convert elements of collection to ordering elements
+      * @param ord  the ordering to be used to compare elements.
+      *
+      * @return a `Found` value containing the index corresponding to the element in the
+      *         sequence, or the `InsertionPoint` where the element would be inserted if
+      *         the element is not in the sequence.
+      */
+    final def searchBy[B](elem:B, by:A => B)(implicit ord: Ordering[B]):SearchResult = {
+      coll match {
+        case _: IndexedSeqLike[A, Repr] => binarySearchBy(elem, 0, coll.length, by)(ord)
+        case _ => linearSearchBy(coll.view, elem, 0, by)(ord)
+      }
+    }
+
     @tailrec
-    private def binarySearch[B >: A](elem: B, from: Int, to: Int)
+    private def binarySearchBy[B](elem: B, from: Int, to: Int, by:A => B)
     (implicit ord: Ordering[B]): SearchResult = {
       if (to == from) InsertionPoint(from) else {
         val idx = from+(to-from-1)/2
-        math.signum(ord.compare(elem, coll(idx))) match {
-          case -1 => binarySearch(elem, from, idx)(ord)
-          case  1 => binarySearch(elem, idx + 1, to)(ord)
+        math.signum(ord.compare(elem, by(coll(idx)))) match {
+          case -1 => binarySearchBy(elem, from, idx, by)(ord)
+          case  1 => binarySearchBy(elem, idx + 1, to, by)(ord)
           case  _ => Found(idx)
         }
       }
     }
 
-    private def linearSearch[B >: A](c: SeqView[A, Repr], elem: B, offset: Int)
+    private def linearSearchBy[B](c: SeqView[A, Repr], elem: B, offset: Int, by: A => B)
     (implicit ord: Ordering[B]): SearchResult = {
       var idx = offset
       val it = c.iterator
       while (it.hasNext) {
-        val cur = it.next()
+        val cur = by(it.next())
         if (ord.equiv(elem, cur)) return Found(idx)
         else if (ord.lt(elem, cur)) return InsertionPoint(idx)
         idx += 1

--- a/test/junit/scala/collection/SearchingTest.scala
+++ b/test/junit/scala/collection/SearchingTest.scala
@@ -4,45 +4,77 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Assert._
 import org.junit.Test
+
 import scala.collection.Searching._
 
 @RunWith(classOf[JUnit4])
 class SearchingTest {
+  class TestSeq[A](list: List[A]) extends SeqLike[A, TestSeq[A]] {
+    var elementsAccessed = Set.empty[Int]
+
+    protected[this] def newBuilder = ??? // not needed for this test
+    def seq = list
+    def iterator = list.iterator
+    def length = list.length
+    def apply(idx: Int) = { elementsAccessed += idx; list(idx) }
+  }
 
   @Test
   def doesLinearSearchOnLinearSeqs() {
-
-    class TestSeq[A](list: List[A]) extends SeqLike[A, TestSeq[A]] {
-      var elementsAccessed = Set.empty[Int]
-
-      protected[this] def newBuilder = ??? // not needed for this test
-      def seq = list
-      def iterator = list.iterator
-      def length = list.length
-      def apply(idx: Int) = { elementsAccessed += idx; list(idx) }
-    }
-
     val coll = new TestSeq((0 to 6).toList)
 
     assertEquals(Found(5), coll.search(5))
     assertEquals(Set.empty, coll.elementsAccessed) // linear search should not access elements via apply()
   }
 
+  class TestIndexedSeq[A](vec: Vector[A]) extends IndexedSeqLike[A, TestIndexedSeq[A]] {
+    var elementsAccessed = Set.empty[Int]
+
+    protected[this] def newBuilder = ??? // not needed for this test
+    def seq = vec
+    def length = vec.length
+    def apply(idx: Int) = { elementsAccessed += idx; vec(idx) }
+  }
+
   @Test
   def doesBinarySearchOnIndexedSeqs() {
-
-    class TestIndexedSeq[A](vec: Vector[A]) extends IndexedSeqLike[A, TestIndexedSeq[A]] {
-      var elementsAccessed = Set.empty[Int]
-
-      protected[this] def newBuilder = ??? // not needed for this test
-      def seq = vec
-      def length = vec.length
-      def apply(idx: Int) = { elementsAccessed += idx; vec(idx) }
-    }
-
     val coll = new TestIndexedSeq((0 to 6).toVector)
-
     assertEquals(Found(5), coll.search(5))
     assertEquals(Set(3, 5), coll.elementsAccessed)
+  }
+
+  @Test
+  def doesLinearSearchOnLinerSeqWithLimitedRange(): Unit = {
+    val coll = (0 to 6).toList
+    assertEquals(Found(5), coll.search(5, 3, 6))
+    assertEquals(InsertionPoint(5), coll.search(5, 0, 5))
+  }
+
+  @Test
+  def doesLinearSearchOnIndexedSeqsWithLimitedRange(): Unit = {
+    val coll = (0 to 6).toVector
+    assertEquals(Found(5), coll.search(5, 5, 6))
+    assertEquals(InsertionPoint(5), coll.search(5, 0, 5))
+  }
+
+  @Test
+  def doesSearchByOnLinearSeq(): Unit = {
+    val coll = (0 to 5).toList
+    assertEquals(Found(1), coll.searchBy("1", _.toString))
+    assertEquals(InsertionPoint(0), coll.searchBy("-1", _.toString))
+  }
+
+  @Test
+  def doesSearchByOnIndexedSeq(): Unit = {
+    val coll = (0 to 5).toVector
+    assertEquals(Found(1), coll.searchBy("1", _.toString))
+    assertEquals(InsertionPoint(6), coll.searchBy("6", _.toString))
+  }
+
+  @Test
+  def doesSearchByOnLinerSeqWithLimitedRange():Unit = {
+    val coll = (0 to 5).toList
+    assertEquals(Found(3), coll.searchBy("3", 2, 5, _.toString))
+    assertEquals(InsertionPoint(3), coll.searchBy("6", 2, 3, _.toString))
   }
 }


### PR DESCRIPTION
Introduce searchBy. 
In case when you have a collection ordered not by regular ordering of elements and don't want to generate fake element for search.

works like this - 
```
val coll = (0 to 5).toVector
assertEquals(Found(1), coll.searchBy("1", _.toString))
```