### PR TITLE
Don't skip the ValTypeCompleter from AccessorTypeCompleter

### DIFF
--- a/test/files/run/t10471.scala
+++ b/test/files/run/t10471.scala
@@ -1,0 +1,28 @@
+import scala.tools.partest._
+
+object Test extends StoreReporterDirectTest {
+  override def extraSettings: String = "-usejavacp -Xprint:typer -Ystop-after:typer"
+
+  override def code =
+    """@scala.annotation.meta.field class blort extends scala.annotation.StaticAnnotation
+      |class C1 {
+      |  @blort val foo = "hi"
+      |}
+      |object X {
+      |  def accessIt(c: C2) = c.foo
+      |}
+      |class C2 extends C1 {
+      |  @blort override val foo = "bye"
+      |}
+    """.stripMargin
+
+  def show(): Unit = {
+    val baos = new java.io.ByteArrayOutputStream()
+    Console.withOut(baos)(Console.withErr(baos)(compile()))
+    val out = baos.toString("UTF-8")
+
+    val fooDefs = out.lines.filter(_.contains("private[this] val foo")).map(_.trim).toList
+    assert(fooDefs.length == 2)
+    assert(fooDefs.forall(_.startsWith("@blort private[this] val foo: String =")), fooDefs)
+  }
+}


### PR DESCRIPTION
Don't skip the ValTypeCompleter in the AccessorTypeCompleter
When the AccessorTypeCompleter gets the type signature of the
ValDef, ensure that the ValTypeCompleter runs (which sets the
annotations on the field symbol) instead of just calling typeSig.

Fixes scala/bug#10471
