### PR TITLE
String Interpolation by macros

### DIFF
--- a/src/compiler/scala/tools/reflect/FastTrack.scala
+++ b/src/compiler/scala/tools/reflect/FastTrack.scala
@@ -25,6 +25,8 @@ class FastTrack[MacrosAndAnalyzer <: Macros with Analyzer](val macros: MacrosAnd
     new { val c: c0.type = c0 } with Taggers
   private implicit def context2macroimplementations(c0: MacroContext): FormatInterpolator { val c: c0.type } =
     new { val c: c0.type = c0 } with FormatInterpolator
+  private implicit def context2macroStringImplementations(c0: MacroContext): StringInterpolator { val c: c0.type } =
+    new { val c: c0.type = c0 } with StringInterpolator
   private implicit def context2quasiquote(c0: MacroContext): QuasiquoteImpls { val c: c0.type } =
     new { val c: c0.type = c0 } with QuasiquoteImpls
   private def makeBlackbox(sym: Symbol)(pf: PartialFunction[Applied, MacroContext => Tree]) =
@@ -51,6 +53,8 @@ class FastTrack[MacrosAndAnalyzer <: Macros with Analyzer](val macros: MacrosAnd
       makeBlackbox(         materializeTypeTag) { case Applied(_, ttag :: Nil, (u :: _) :: _)     => _.materializeTypeTag(u, EmptyTree, ttag.tpe, concrete = true) },
       makeBlackbox(           ApiUniverseReify) { case Applied(_, ttag :: Nil, (expr :: _) :: _)  => c => c.materializeExpr(c.prefix.tree, EmptyTree, expr) },
       makeBlackbox(            StringContext_f) { case _                                          => _.interpolate },
+      makeBlackbox(            StringContext_s) { case _                                          => _.interpolateString },
+      makeBlackbox(          StringContext_raw) { case _                                          => _.interpolateRaw },
       makeBlackbox(ReflectRuntimeCurrentMirror) { case _                                          => c => currentMirror(c).tree },
       makeWhitebox(  QuasiquoteClass_api_apply) { case _                                          => _.expandQuasiquote },
       makeWhitebox(QuasiquoteClass_api_unapply) { case _                                          => _.expandQuasiquote }

--- a/src/compiler/scala/tools/reflect/StringInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/StringInterpolator.scala
@@ -1,0 +1,154 @@
+package scala.tools.reflect
+
+import scala.annotation.tailrec
+import scala.reflect.macros.runtime.Context
+
+abstract class StringInterpolator {
+  val c: Context
+  val global: c.universe.type = c.universe
+
+  import c.universe.{Match => _, _}
+  import definitions._
+  import treeInfo.Applied
+
+  @inline private def truly(body: => Unit): Boolean = {
+    body
+    true
+  }
+
+  @inline private def falsely(body: => Unit): Boolean = {
+    body
+    false
+  }
+
+  private def bail(msg: String) = global.abort(msg)
+
+  def interpolateString: Tree = interpolateImpl(false)
+
+  def interpolateRaw: Tree = interpolateImpl(true)
+
+  def interpolateImpl(raw: Boolean): Tree = c.macroApplication match {
+    case Applied(Select(Apply(_, parts), _), _, argss) =>
+      val args = argss.flatten
+
+      def badlyInvoked = (parts.length != args.length + 1) && truly {
+        //probably cant use s"..." here as this is the macro for s
+        def because(s: String) = "too " + s + " arguments for interpolated string"
+
+        val (p, msg) =
+          if (args.length + 1 < parts.length)
+            (if (args.isEmpty) c.enclosingPosition else args.last.pos, because("few"))
+          else (args(parts.length - 1).pos, because("many"))
+        c.abort(p, msg)
+      }
+
+      if (badlyInvoked) c.macroApplication else {
+        val res = interpolated(raw, parts, args)
+        /*if (settings.debug) */reporter.echo(c.enclosingPosition, "rewrite expression to "+res)
+        res
+      }
+    case other =>
+      bail("Unexpected application " + showRaw(other))
+      other
+  }
+
+  def interpolated(raw: Boolean, parts: List[Tree], args: List[Tree]): Tree = {
+    val literals: List[List[Literal]] = parts map {
+      case lit@Literal(Constant(x: String)) =>
+        if (x.isEmpty) Nil
+        else {
+          if (raw) lit :: Nil
+          else (Literal(Constant(/*StringContext.*/ treatEscapes(x))) setPos (lit.pos)) :: Nil
+        }
+      case _ => throw new IllegalArgumentException("internal error: argument parts must be a list of string literals")
+    }
+    val argsIt = args.iterator
+    val literalsIt = literals.iterator
+    val plus = TermName("$plus")
+
+    // Note s"$foo" will produce
+    // "" + foo
+    // but the back end code writer will eliminate "" and concatenate with StringBuilder as appropriate
+
+    var expr = if (literals(0).isEmpty) parts(0)
+    else Literal(Constant("")) setPos c.macroApplication.pos
+
+    literalsIt.next()
+
+    while (literalsIt.hasNext) {
+      val literal = literalsIt.next()
+      val arg = argsIt.next()
+      expr = Apply(Select(expr, plus), arg :: Nil) setPos (arg.pos)
+      if (!literal.isEmpty) expr = Apply(Select(expr, plus), literal) setPos (literal.head.pos)
+    }
+    expr
+  }
+
+  def treatEscapes(str: String): String = treatEscapes0(str, strict = false)
+
+  /** Treats escapes, but disallows octal escape sequences. */
+  def processEscapes(str: String): String = treatEscapes0(str, strict = true)
+
+  private def treatEscapes0(str: String, strict: Boolean): String = {
+    val len = str.length
+
+    // replace escapes with given first escape
+    def replace(first: Int): String = {
+      val b = new java.lang.StringBuilder()
+
+      // append replacement starting at index `i`, with `next` backslash
+      @tailrec def loop(i: Int, next: Int): String = {
+        if (next >= 0) {
+          //require(str(next) == '\\')
+          if (next > i) b.append(str, i, next)
+          var idx = next + 1
+          if (idx >= len) throw new InvalidEscapeException(str, next)
+          val c = str(idx) match {
+            case 'b' => '\b'
+            case 't' => '\t'
+            case 'n' => '\n'
+            case 'f' => '\f'
+            case 'r' => '\r'
+            case '"' => '"'
+            case '\'' => '\''
+            case '\\' => '\\'
+            case o if '0' <= o && o <= '7' =>
+              if (strict) throw new InvalidEscapeException(str, next)
+              val leadch = str(idx)
+              var oct = leadch - '0'
+              idx += 1
+              if (idx < len && '0' <= str(idx) && str(idx) <= '7') {
+                oct = oct * 8 + str(idx) - '0'
+                idx += 1
+                if (idx < len && leadch <= '3' && '0' <= str(idx) && str(idx) <= '7') {
+                  oct = oct * 8 + str(idx) - '0'
+                  idx += 1
+                }
+              }
+              idx -= 1 // retreat
+              oct.toChar
+            case _ => throw new InvalidEscapeException(str, next)
+          }
+          idx += 1 // advance
+          b append c
+          loop(idx, str.indexOf('\\', idx))
+        } else {
+          if (i < len) b.append(str, i, len)
+          b.toString
+        }
+      }
+
+      loop(0, first)
+    }
+
+    str indexOf '\\' match {
+      case -1 => str
+      case i => replace(i)
+    }
+  }
+
+  class InvalidEscapeException(str: String, val index: Int) extends IllegalArgumentException(
+    "invalid escape"
+  )
+
+}

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -10,6 +10,7 @@ package scala
 
 import java.lang.{ StringBuilder => JLSBuilder }
 import scala.annotation.tailrec
+import scala.language.experimental.macros
 
 /** This class provides the basic mechanism to do String Interpolation.
  * String Interpolation allows users
@@ -92,7 +93,12 @@ case class StringContext(parts: String*) {
    *          if a `parts` string contains a backslash (`\`) character
    *          that does not start a valid escape sequence.
    */
-  def s(args: Any*): String = standardInterpolator(treatEscapes, args)
+  // The implementation is hardwired to `scala.tools.reflect.MacroImplementations.macro_StringInterpolation_s`
+  // Using the mechanism implemented in `scala.tools.reflect.FastTrack`
+  // and is logically the same as [[standardInterpolator(treatEscapes, args)]]
+  def sNew[A >: Any](args: A*): String = macro ???
+  def s[A >: Any](args: A*): String = standardInterpolator(treatEscapes, args)
+  private def sInternal(args: Any*): String = standardInterpolator(treatEscapes, args)
 
   /** The raw string interpolator.
    *
@@ -114,7 +120,11 @@ case class StringContext(parts: String*) {
    *          if the number of `parts` in the enclosing `StringContext` does not exceed
    *          the number of arguments `arg` by exactly 1.
    */
-  def raw(args: Any*): String = standardInterpolator(identity, args)
+  // The implementation is hardwired to `scala.tools.reflect.MacroImplementations.macro_StringInterpolation_raw`
+  // Using the mechanism implemented in `scala.tools.reflect.FastTrack`
+  // and is logically the same as [[standardInterpolator(identity, args)]]
+  def rawNew[A >: Any](args: A*): String = macro ???
+  def raw[A >: Any](args: A*): String =  standardInterpolator(identity, args)
 
   def standardInterpolator(process: String => String, args: Seq[Any]): String = {
     checkLengths(args)
@@ -176,10 +186,10 @@ object StringContext {
    *  @param  index   The index of the offending backslash character in `str`.
    */
   class InvalidEscapeException(str: String, @deprecatedName('idx) val index: Int) extends IllegalArgumentException(
-    s"""invalid escape ${
+    sInternal"""invalid escape ${
       require(index >= 0 && index < str.length)
       val ok = """[\b, \t, \n, \f, \r, \\, \", \']"""
-      if (index == str.length - 1) "at terminal" else s"'\\${str(index + 1)}' not one of $ok at"
+      if (index == str.length - 1) "at terminal" else sInternal"'\\${str(index + 1)}' not one of $ok at"
     } index $index in "$str". Use \\\\ for literal \\."""
   )
 

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1477,6 +1477,8 @@ trait Definitions extends api.StandardDefinitions {
       def isStringAddition(sym: Symbol) = sym == String_+ || sym == StringAdd_+
 
       lazy val StringContext_f = getMemberMethod(StringContextClass, nme.f)
+      lazy val StringContext_s = getMemberMethod(StringContextClass, nme.s)
+      lazy val StringContext_raw = getMemberMethod(StringContextClass, nme.rawMethod)
 
       lazy val ArrowAssocClass = getMemberClass(PredefModule, TypeName("ArrowAssoc")) // scala/bug#5731
       def isArrowAssoc(sym: Symbol) = sym.owner == ArrowAssocClass

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -689,6 +689,8 @@ trait StdNames {
     val ex: NameType                   = "ex"
     val experimental: NameType         = "experimental"
     val f: NameType                    = "f"
+    val s: NameType                    = "sNew"
+    val rawMethod: NameType            = "rawNew"
     val false_ : NameType              = "false"
     val filter: NameType               = "filter"
     val finalize_ : NameType           = "finalize"

--- a/test/benchmarks/.gitignore
+++ b/test/benchmarks/.gitignore
@@ -5,6 +5,9 @@
 # what appears to be a Scala IDE-generated file
 .cache-main
 
+# Intellij build diectory
+.idea
+
 # standard Eclipse output directory
 /bin/
 

--- a/test/benchmarks/src/main/scala/scala/StringInterpolationBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/StringInterpolationBenchmark.scala
@@ -1,0 +1,120 @@
+package scala
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+import org.openjdk.jmh.runner.IterationType
+import benchmark._
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class StringInterpolationBenchmark {
+  var yes = "yes"
+  var no = "no"
+
+  //////////////////////////////////////////////
+
+  @Benchmark def emptyS(bh: Blackhole) {
+    bh.consume(sNew"")
+  }
+  @Benchmark def emptyRAW(bh: Blackhole) {
+    bh.consume(rawNew"")
+  }
+
+  @Benchmark def literalS(bh: Blackhole) {
+    bh.consume(sNew"thisIsALiteral")
+  }
+  @Benchmark def literalRAW(bh: Blackhole) {
+    bh.consume(rawNew"thisIsALiteral")
+  }
+
+  @Benchmark def literalEscS(bh: Blackhole) {
+    bh.consume(sNew"thisIsA\nLiteral")
+  }
+  @Benchmark def literalEscRAW(bh: Blackhole) {
+    bh.consume(rawNew"thisIsA\nLiteral")
+  }
+
+  @Benchmark def singleS(bh: Blackhole) {
+    bh.consume(sNew"$yes")
+  }
+  @Benchmark def singleRAW(bh: Blackhole) {
+    bh.consume(rawNew"$yes")
+  }
+
+  @Benchmark def manyValuesS(bh: Blackhole) {
+    bh.consume(sNew"$yes$yes$yes$yes$yes$yes$yes$yes$yes$yes$yes$yes$no$no$no$no$no$no$no$no$no$no$no$no")
+  }
+  @Benchmark def manyValuesRAW(bh: Blackhole) {
+    bh.consume(rawNew"$yes$yes$yes$yes$yes$yes$yes$yes$yes$yes$yes$yes$no$no$no$no$no$no$no$no$no$no$no$no")
+  }
+
+  @Benchmark def manyBothS(bh: Blackhole) {
+    bh.consume(sNew""".1$yes.1$yes.1$yes.1$yes.1$yes.1$yes.1$yes.1$yes.1$yes.1$yes.1$yes.1$yes.1$no.1$no.1$no.1$no.1$no.1$no.1$no.1$no.1$no.1$no.1$no.1$no.1""")
+  }
+  @Benchmark def manyBothRAW(bh: Blackhole) {
+    bh.consume(rawNew""".1$yes.1$yes.1$yes.1$yes.1$yes.1$yes.1$yes.1$yes.1$yes.1$yes.1$yes.1$yes.1$no.1$no.1$no.1$no.1$no.1$no.1$no.1$no.1$no.1$no.1$no.1$no.1""")
+  }
+
+  @Benchmark def manyBothLongS(bh: Blackhole) {
+    bh.consume(sNew"""
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ""")
+  }
+  @Benchmark def manyBothLongRAW(bh: Blackhole) {
+    bh.consume(rawNew"""
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$yes
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$no
+123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ""")
+  }
+}


### PR DESCRIPTION
provide a macro based implementation of s"" and raw"" interpolation

The implementation avoids the generation of a StringContext, and the varargs, and wrappers etc

Instead it generate code that is close to what an optimal java  developer would generate using string contaculation or a java StringBuilder

This approach generated less bytecode, which runs faster and generates less garbage

- For trivial cases like s"", s"foo" and s"$foo" it avoids a StringBuilder completely, and has zero allocations and take 2ns instead of 20-50ns
- blank literals are silently skipped
- The escape handling from s""" to raw"" (the escape handling) is done at compile time to enhance performance

It also includes a jmh benchmark for some sample cases.

The end goal is to replace the  s and raw, but initially this PR provides support for sNew and rawNew as the migration would have multiple steps, firstly to introduce the macro, and secondly to migrate to it. 

as dicsussed briefly with @retronym If we can allow FastTrack to preserve the method but still use the macro for compilation then I believe this change will be forward and backward binary compatible as the same end result would occur with macro or method call

If this is not possible then this change would have to be re-targetted to 2.13 I think, but I would appreciate to views of maintainers

the full bytecode before and after are attached as commands, as are the full jmh results, but here is a summary of the runtime

Trivial cases before
```
[info] StringInterpolationBenchmark.emptyRAW                                          avgt   20     27.260 â–’   0.333   ns/op
[info] StringInterpolationBenchmark.emptyRAW:Ã€gc.alloc.rate.norm                      avgt   20    120.000 â–’   0.001    B/op

[info] StringInterpolationBenchmark.emptyS                                            avgt   20     39.060 â–’   0.324   ns/op
[info] StringInterpolationBenchmark.emptyS:Ã€gc.alloc.rate.norm                        avgt   20    136.000 â–’   0.001    B/op

[info] StringInterpolationBenchmark.literalEscRAW                                     avgt   20     39.401 â–’   0.609   ns/op
[info] StringInterpolationBenchmark.literalEscRAW:Ã€gc.alloc.rate.norm                 avgt   20    200.000 â–’   0.001    B/op

[info] StringInterpolationBenchmark.literalEscS                                       avgt   20     58.968 â–’   4.882   ns/op
[info] StringInterpolationBenchmark.literalEscS:Ã€gc.alloc.rate.norm                   avgt   20    216.000 â–’   0.001    B/op

[info] StringInterpolationBenchmark.literalRAW                                        avgt   20     40.765 â–’   0.497   ns/op
[info] StringInterpolationBenchmark.literalRAW:Ã€gc.alloc.rate.norm                    avgt   20    200.000 â–’   0.001    B/op

[info] StringInterpolationBenchmark.literalS                                          avgt   20     53.973 â–’   0.386   ns/op
[info] StringInterpolationBenchmark.literalS:Ã€gc.alloc.rate.norm                      avgt   20    216.000 â–’   0.001    B/op

[info] StringInterpolationBenchmark.singleRAW                                         avgt   20     62.092 â–’   1.603   ns/op
[info] StringInterpolationBenchmark.singleRAW:Ã€gc.alloc.rate.norm                     avgt   20    208.000 â–’   0.001    B/op

[info] StringInterpolationBenchmark.singleS                                           avgt   20     71.051 â–’   7.313   ns/op
[info] StringInterpolationBenchmark.singleS:Ã€gc.alloc.rate.norm                       avgt   20    208.000 â–’   0.001    B/op

```
and after (all  non allocating so a slightly confused display) and efffectively all the same
```
[info] Benchmark                                                                      Mode  Cnt     Score     Error   Units
[info] StringInterpolationBenchmark.emptyRAW                                          avgt   20     2.770 â–’   0.160   ns/op
[info] StringInterpolationBenchmark.emptyRAW:Ã€gc.alloc.rate                           avgt   20     0.001 â–’   0.002  MB/sec
[info] StringInterpolationBenchmark.emptyRAW:Ã€gc.alloc.rate.norm                      avgt   20    ? 10??              B/op
																																	   
[info] StringInterpolationBenchmark.emptyS                                            avgt   20     2.642 â–’   0.029   ns/op
[info] StringInterpolationBenchmark.emptyS:Ã€gc.alloc.rate                             avgt   20     0.001 â–’   0.002  MB/sec
[info] StringInterpolationBenchmark.emptyS:Ã€gc.alloc.rate.norm                        avgt   20    ? 10??              B/op
																																
[info] StringInterpolationBenchmark.literalEscRAW                                     avgt   20     2.837 â–’   0.239   ns/op
[info] StringInterpolationBenchmark.literalEscRAW:Ã€gc.alloc.rate                      avgt   20     0.001 â–’   0.002  MB/sec
[info] StringInterpolationBenchmark.literalEscRAW:Ã€gc.alloc.rate.norm                 avgt   20    ? 10??              B/op
																																
[info] StringInterpolationBenchmark.literalEscS                                       avgt   20     2.889 â–’   0.181   ns/op
[info] StringInterpolationBenchmark.literalEscS:Ã€gc.alloc.rate                        avgt   20     0.001 â–’   0.002  MB/sec
[info] StringInterpolationBenchmark.literalEscS:Ã€gc.alloc.rate.norm                   avgt   20    ? 10??              B/op
																																
[info] StringInterpolationBenchmark.literalRAW                                        avgt   20     2.839 â–’   0.213   ns/op
[info] StringInterpolationBenchmark.literalRAW:Ã€gc.alloc.rate                         avgt   20     0.001 â–’   0.002  MB/sec
[info] StringInterpolationBenchmark.literalRAW:Ã€gc.alloc.rate.norm                    avgt   20    ? 10??              B/op
																																
[info] StringInterpolationBenchmark.literalS                                          avgt   20     2.860 â–’   0.221   ns/op
[info] StringInterpolationBenchmark.literalS:Ã€gc.alloc.rate                           avgt   20     0.001 â–’   0.002  MB/sec
[info] StringInterpolationBenchmark.literalS:Ã€gc.alloc.rate.norm                      avgt   20    ? 10??              B/op

[info] StringInterpolationBenchmark.singleRAW                                         avgt   20     3.031 â–’   0.239   ns/op
[info] StringInterpolationBenchmark.singleRAW:Ã€gc.alloc.rate                          avgt   20     0.001 â–’   0.002  MB/sec
[info] StringInterpolationBenchmark.singleRAW:Ã€gc.alloc.rate.norm                     avgt   20    ? 10??              B/op
																																
[info] StringInterpolationBenchmark.singleS                                           avgt   20     3.398 â–’   0.284   ns/op
[info] StringInterpolationBenchmark.singleS:Ã€gc.alloc.rate                            avgt   20     0.001 â–’   0.002  MB/sec
[info] StringInterpolationBenchmark.singleS:Ã€gc.alloc.rate.norm                       avgt   20    ? 10??              B/op

```

more real-world cases are shown with the new version in **bold** and lines intersperced
<pre>
[info] Benchmark                                                                       Mode  Cnt      Score       Error   Units
[info] StringInterpolationBenchmark.manyBothLongRAW                                    avgt   20  1796.063 â–’   19.900   ns/op
<b>info] StringInterpolationBenchmark.manyBothLongRAW                                    avgt   20  1012.770 â–’   19.616   ns/op</b>
[info] StringInterpolationBenchmark.manyBothLongRAW:Ã€gc.alloc.rate.norm               avgt   20  13736.003 â–’   0.006    B/op
<b>info] StringInterpolationBenchmark.manyBothLongRAW:Ã€gc.alloc.rate.norm               avgt   20  7400.002 â–’    0.003    B/op</b>

[info] StringInterpolationBenchmark.manyBothLongS                                      avgt   20  2205.042 â–’   25.845   ns/op
<b>info] StringInterpolationBenchmark.manyBothLongS                                      avgt   20  1016.580 â–’   24.437   ns/op</b>
[info] StringInterpolationBenchmark.manyBothLongS:Ã€gc.alloc.rate.norm                 avgt   20  13736.004 â–’   0.007    B/op
<b>info] StringInterpolationBenchmark.manyBothLongS:Ã€gc.alloc.rate.norm                 avgt   20   7400.002 â–’   0.003    B/op</b>

[info] StringInterpolationBenchmark.manyBothRAW                                        avgt   20   619.386 â–’    6.743   ns/op
<b>info] StringInterpolationBenchmark.manyBothRAW                                        avgt   20   458.917 â–’   22.928   ns/op</b>
[info] StringInterpolationBenchmark.manyBothRAW:Ã€gc.alloc.rate.norm                   avgt   20   1224.001 â–’   0.002    B/op
<b>info] StringInterpolationBenchmark.manyBothRAW:Ã€gc.alloc.rate.norm                   avgt   20   712.001 â–’    0.001    B/op</b>

[info] StringInterpolationBenchmark.manyBothS                                          avgt   20   707.962 â–’    6.889   ns/op
<b>info] StringInterpolationBenchmark.manyBothS                                          avgt   20   458.003 â–’   33.455   ns/op</b>
[info] StringInterpolationBenchmark.manyBothS:Ã€gc.alloc.rate.norm                     avgt   20   1224.001 â–’   0.002    B/op
<b>info] StringInterpolationBenchmark.manyBothS:Ã€gc.alloc.rate.norm                     avgt   20   712.001 â–’    0.001    B/op</b>

[info] StringInterpolationBenchmark.manyValuesRAW                                      avgt   20   492.149 â–’   10.439   ns/op
<b>info] StringInterpolationBenchmark.manyValuesRAW                                      avgt   20   252.283 â–’    3.053   ns/op</b>
[info] StringInterpolationBenchmark.manyValuesRAW:Ã€gc.alloc.rate.norm                 avgt   20   752.001 â–’    0.002    B/op
<b>info] StringInterpolationBenchmark.manyValuesRAW:Ã€gc.alloc.rate.norm                 avgt   20   456.000 â–’    0.001    B/op</b>

[info] StringInterpolationBenchmark.manyValuesS                                        avgt   20   507.094 â–’   25.011   ns/op
<b>info] StringInterpolationBenchmark.manyValuesS                                        avgt   20   249.327 â–’    3.224   ns/op</b>
[info] StringInterpolationBenchmark.manyValuesS:Ã€gc.alloc.rate.norm                   avgt   20   752.001 â–’    0.002    B/op
<b>info] StringInterpolationBenchmark.manyValuesS:Ã€gc.alloc.rate.norm                   avgt   20   456.000 â–’    0.001    B/op</b>
</pre>