### PR TITLE
Issue an error when trying to use a method as a qualifier.

### DIFF
--- a/src/compiler/scala/reflect/macros/compiler/Errors.scala
+++ b/src/compiler/scala/reflect/macros/compiler/Errors.scala
@@ -49,7 +49,7 @@ trait Errors extends Traces {
 
     def MacroImplWrongNumberOfTypeArgumentsError() = {
       val diagnostic = if (macroImpl.typeParams.length > targs.length) "has too few type arguments" else "has too many arguments"
-      implRefError(s"macro implementation reference $diagnostic for " + treeSymTypeMsg(macroImplRef))
+      implRefError(s"macro implementation reference $diagnostic for " + treeSymTypeMsg(macroImplRef)(context))
     }
 
     private def macroImplementationWording =

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -894,7 +894,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         def cantAdapt =
           if (context.implicitsEnabled) MissingArgsForMethodTpeError(tree, meth)
-          else setError(tree)
+          else if (mode.inQualMode) UnstableTreeError(tree)
+          else setError(tree) // scala/bug#10474 implies that not issuing an
+                              // error here might be harmful... can we get here
+                              // with implicits disabled and not in QUALmode?
 
         // constructors do not eta-expand
         if (meth.isConstructor) cantAdapt

--- a/test/files/neg/t10474.check
+++ b/test/files/neg/t10474.check
@@ -1,0 +1,10 @@
+t10474.scala:9: error: stable identifier required, but Test.this.Foo found.
+    case Foo.Bar ⇒ true
+         ^
+t10474.scala:13: error: stable identifier required, but Test.this.Foo found.
+  type Crash = Foo.type
+               ^
+t10474.scala:17: error: stable identifier required, but Test.this.bingo found.
+  val `bingo`.Fuzz = 1
+      ^
+three errors found

--- a/test/files/neg/t10474.check
+++ b/test/files/neg/t10474.check
@@ -1,10 +1,13 @@
-t10474.scala:9: error: stable identifier required, but Test.this.Foo found.
+t10474.scala:9: error: Unapplied method Foo is not allowed inside a pattern.
+Selections in patterns must be from stable values.
     case Foo.Bar ⇒ true
          ^
-t10474.scala:13: error: stable identifier required, but Test.this.Foo found.
+t10474.scala:13: error: Unapplied method Foo is not allowed inside a type expression.
+Selections in types must be from stable values or other types.
   type Crash = Foo.type
                ^
-t10474.scala:17: error: stable identifier required, but Test.this.bingo found.
+t10474.scala:17: error: Unapplied method bingo is not allowed inside a pattern.
+Selections in patterns must be from stable values.
   val `bingo`.Fuzz = 1
       ^
 three errors found

--- a/test/files/neg/t10474.scala
+++ b/test/files/neg/t10474.scala
@@ -1,0 +1,18 @@
+package t10474
+
+object Test {
+  def Foo(a: Int): Char = ???
+
+  object Bar
+
+  def crash[A](): Boolean = Bar match {
+    case Foo.Bar ⇒ true
+    case _ ⇒ false
+  }
+
+  type Crash = Foo.type
+
+  def bingo(l: Int, r: Int) = l + r
+
+  val `bingo`.Fuzz = 1
+}

--- a/test/files/neg/t10474b.check
+++ b/test/files/neg/t10474b.check
@@ -1,0 +1,59 @@
+t10474b.scala:14: error: method wat cannot be used as an identifier pattern;
+identifier patterns must refer to stable values.
+Perhaps you meant to define Crimp.wat as a `val`?
+    case Crimp.wat =>
+               ^
+t10474b.scala:15: error: method whut cannot be used as an identifier pattern;
+identifier patterns must refer to stable values.
+Perhaps you meant to define Crimp.whut as a `val`?
+    case Crimp.whut =>
+               ^
+t10474b.scala:16: error: method wat cannot be used as an identifier pattern;
+identifier patterns must refer to stable values.
+Perhaps you meant to define Crimp.wat as a `val`?
+    case `wat` =>
+         ^
+t10474b.scala:17: error: method whut cannot be used as an identifier pattern;
+identifier patterns must refer to stable values.
+Perhaps you meant to define Crimp.whut as a `val`?
+    case `whut` =>
+         ^
+t10474b.scala:19: error: method wat is not a case class, nor does it have an unapply/unapplySeq member
+    case Crimp.wat() =>
+               ^
+t10474b.scala:20: error: method whut is not a case class, nor does it have an unapply/unapplySeq member
+    case Crimp.whut() =>
+               ^
+t10474b.scala:21: error: method wat is not a case class, nor does it have an unapply/unapplySeq member
+    case wat() =>
+         ^
+t10474b.scala:22: error: method whut is not a case class, nor does it have an unapply/unapplySeq member
+    case whut() =>
+         ^
+t10474b.scala:24: error: method wat is not a case class, nor does it have an unapply/unapplySeq member
+    case Crimp.wat(_) =>
+               ^
+t10474b.scala:25: error: method whut is not a case class, nor does it have an unapply/unapplySeq member
+    case Crimp.whut(_) =>
+               ^
+t10474b.scala:26: error: method wat is not a case class, nor does it have an unapply/unapplySeq member
+    case wat(_) =>
+         ^
+t10474b.scala:27: error: method whut is not a case class, nor does it have an unapply/unapplySeq member
+    case whut(_) =>
+         ^
+t10474b.scala:29: error: value U is not a member of Int
+    case Crimp.wat.U =>
+                   ^
+t10474b.scala:30: error: Unapplied method whut is not allowed inside a pattern.
+Selections in patterns must be from stable values.
+    case Crimp.whut.U =>
+               ^
+t10474b.scala:31: error: value U is not a member of Int
+    case wat.U =>
+             ^
+t10474b.scala:32: error: Unapplied method whut is not allowed inside a pattern.
+Selections in patterns must be from stable values.
+    case whut.U =>
+         ^
+16 errors found

--- a/test/files/neg/t10474b.scala
+++ b/test/files/neg/t10474b.scala
@@ -1,0 +1,35 @@
+object Crimp {
+
+  def test(pf: PartialFunction[Any, Unit]) = ()
+
+  def wat: Int = 1
+  def whut(i: Int): Int = 1
+
+}
+
+object Clamp {
+  import Crimp._
+
+  test {
+    case Crimp.wat =>
+    case Crimp.whut =>
+    case `wat` =>
+    case `whut` =>
+
+    case Crimp.wat() =>
+    case Crimp.whut() =>
+    case wat() =>
+    case whut() =>
+
+    case Crimp.wat(_) =>
+    case Crimp.whut(_) =>
+    case wat(_) =>
+    case whut(_) =>
+
+    case Crimp.wat.U =>
+    case Crimp.whut.U =>
+    case wat.U =>
+    case whut.U =>
+  }
+
+}

--- a/test/files/neg/t3816.check
+++ b/test/files/neg/t3816.check
@@ -1,7 +1,11 @@
-t3816.scala:30: error: stable identifier required, but `syncID` found.
+t3816.scala:30: error: variable syncID cannot be used as an identifier pattern;
+identifier patterns must refer to stable values.
+Perhaps you meant to define Test.syncID as a `val`?
       case Some( `syncID` ) =>
                  ^
-t3816.scala:38: error: stable identifier required, but Test.this.foo found.
+t3816.scala:38: error: variable foo cannot be used as an identifier pattern;
+identifier patterns must refer to stable values.
+Perhaps you meant to define Test.foo as a `val`?
       case Some( `foo` ) =>
                  ^
 two errors found

--- a/test/files/neg/t7877.check
+++ b/test/files/neg/t7877.check
@@ -1,4 +1,4 @@
-t7877.scala:6: error: not found: value Y
+t7877.scala:6: error: method Y is not a case class, nor does it have an unapply/unapplySeq member
     case Y() => ()             // not allowed
          ^
 t7877.scala:7: error: OnNext[Any] does not take parameters


### PR DESCRIPTION
The check for `implicitsEnabled` here seems older even than that method; it appears to originally have looked at a flag `reportGeneralErrors`, which seems a reasonable flag if you want to check whether to report an error. An erroneous tree that we do not error on, however, can be use as a qualifier which will not necessarily cause an error until past typer, when something finally notices the mistake and blows up.

I tried, but I can't find how we can get to `cantAdapt` with disabled implicits other than by the tricks shown in the test case; running the partests with an assertion that at `cantAdapt` we either have `ImplicitsEnabled` or are in `QUALmode` never trips. The main un-setters of `ImplicitsEnabled` are `typedSingletonTypeTree` and `typedPattern`, which are the two at issue in this PR. 

I'm not completely sure about the use of `UnstableTreeError` as the error; originally I had a `CannotSelectFromMethodError` but abandoned it in light of:

```
scala> object Foo { def Bar(i: Int) = i }
defined object Foo

scala> (??? : Any) match { case Foo.Bar.Baz => }
java.lang.NullPointerException
  ... elided ...

scala> (??? : Any) match { case Foo.Bar => }
<console>:13: error: stable identifier required, but Foo.Bar found.
       (??? : Any) match { case Foo.Bar => }
                                    ^

scala> import Foo._
import Foo._

scala> (??? : Any) match { case Bar => }
<console>:16: error: stable identifier required, but Foo.Bar found.
       (??? : Any) match { case Bar => }
                                ^
```

Moreover, the relevant spec sections regarding [pattern matching](https://github.com/scala/scala/blame/v2.12.3/spec/08-pattern-matching.md#L105) and [singleton types](https://github.com/scala/scala/blame/v2.12.3/spec/03-types.md#L108) at least imply that instability is part of the problem here. I'm willing to add a new error message if this seems imprecise.

Fixes scala/bug#10474.