### PR TITLE
Add Scaladoc tables

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -1,5 +1,5 @@
 /* NSC -- new Scala compiler
- * Copyright 2007-2017 LAMP/EPFL
+ * Copyright 2007-2018 LAMP/EPFL
  * @author  Manohar Jonnalagedda
  */
 
@@ -8,10 +8,12 @@ package doc
 package base
 
 import base.comment._
+import scala.annotation.tailrec
 import scala.collection._
 import scala.util.matching.Regex
 import scala.reflect.internal.util.Position
 import scala.language.postfixOps
+
 
 /** The comment parser transforms raw comment strings into `Comment` objects.
   * Call `parse` to run the parser. Note that the parser is stateless and
@@ -433,6 +435,9 @@ trait CommentFactoryBase { this: MemberLookupBase =>
   protected final class WikiParser(val buffer: String, pos: Position, site: Symbol) extends CharReader(buffer) { wiki =>
     var summaryParsed = false
 
+    // TODO: Convert to Char
+    private val TableCellStart = "|"
+
     def document(): Body = {
       val blocks = new mutable.ListBuffer[Block]
       while (char != endOfText)
@@ -442,7 +447,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
 
     /* BLOCKS */
 
-    /** {{{ block ::= code | title | hrule | listBlock | para }}} */
+    /** {{{ block ::= code | title | hrule | listBlock | table | para  }}} */
     def block(): Block = {
       if (checkSkipInitWhitespace("{{{"))
         code()
@@ -452,6 +457,8 @@ trait CommentFactoryBase { this: MemberLookupBase =>
         hrule()
       else if (checkList)
         listBlock
+      else if (check(TableCellStart))
+        table()
       else {
         para()
       }
@@ -490,7 +497,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
           jumpWhitespace()
           jump(style)
           val p = Paragraph(inline(isInlineEnd = false))
-          blockEnded("end of list line ")
+          blockEnded("end of list line")
           Some(p)
         }
 
@@ -542,6 +549,284 @@ trait CommentFactoryBase { this: MemberLookupBase =>
       repeatJump('-')
       blockEnded("horizontal rule")
       HorizontalRule()
+    }
+
+    /** {{{
+      * table         ::= headerRow '\n' delimiterRow '\n' dataRows '\n'
+      * content       ::= inline-content
+      * row           ::= '|' { content '|' }+
+      * headerRow     ::= row
+      * dataRows      ::= row*
+      * align         ::= ':' '-'+ | '-'+ | '-'+ ':' | ':' '-'+ ':'
+      * delimiterRow :: = '|' { align '|' }+
+      * }}}
+      */
+    def table(): Block = {
+
+      /* Helpers */
+
+      def peek(tag: String): Unit = {
+        val peek: String = buffer.substring(offset)
+        val limit = 60
+        val limitedPeek = peek.substring(0, limit min peek.length)
+        println(s"peek: $tag: '$limitedPeek'")
+      }
+
+      def nextIsCellStart = check(TableCellStart)
+
+      /* Accumulated state */
+
+      var header: Option[Row] = None
+
+      val rows = mutable.ListBuffer.empty[Row]
+
+      val cells = mutable.ListBuffer.empty[Cell]
+
+      def finalizeCells(): Unit = {
+        if (cells.nonEmpty) {
+          rows += Row(cells.toList)
+        }
+        cells.clear()
+      }
+
+      def finalizeHeaderCells(): Unit = {
+        if (cells.nonEmpty) {
+          if (header.isDefined) {
+            reportError(pos, "more than one table header")
+          } else {
+            header = Some(Row(cells.toList))
+          }
+        }
+        cells.clear()
+      }
+
+      def checkAny(terminators: List[String]) = terminators.exists(check)
+
+      def isEndOfText = char == endOfText
+
+      def isNewline = char == endOfLine
+
+      def skipNewline() = jump(endOfLine)
+
+      def contentNonEmpty(content: Inline) = content != Text("")
+
+      /**
+        * @param nextIsStartMark True if the next char is a cell mark prefix and not any non-cell mark.
+        * @param cellStartMark   The char the cell start mark is based on
+        * @param finalizeRow     Function to invoke when the row has been fully parsed
+        */
+      def parseCells(nextIsStartMark: => Boolean, cellStartMark: Char, finalizeRow: () => Unit): Unit = {
+        /* The first sequence of cellStartMark characters defines the markdown for new cells. */
+        def parseStartMark() = {
+          if (!jump(cellStartMark)) {
+            peek("Expected startMark")
+            sys.error("Precondition violated: Expected startMark.")
+          }
+          cellStartMark.toString
+        }
+
+        /* startMark is the only mark not requiring a newline first */
+        def makeInlineTerminators(startMark: String) = startMark :: Nil
+
+        val startPos = offset
+
+        val startMark = parseStartMark()
+
+        val inlineTerminators = makeInlineTerminators(startMark)
+
+        val content = Paragraph(inline(isInlineEnd = checkAny(inlineTerminators)))
+
+        parseCells0(content :: Nil, startMark, cellStartMark, inlineTerminators, nextIsStartMark, finalizeRow, startPos, offset)
+      }
+
+      // Continue parsing a table row.
+      //
+      // After reading inline content the follow conditions will be encountered,
+      //
+      //    Case : Next Chars
+      //    ..................
+      //      1  : end-of-text
+      //      2  : '|' '\n'
+      //      3  : '|'
+      //      4  : '\n'
+      //
+      // Case 1.
+      // State : End of text
+      // Action: Store the current contents, close the row, report warning, stop parsing.
+      //
+      // Case 2.
+      // State : The cell separator followed by a newline
+      // Action: Store the current contents, skip the cell separator and newline, close the row, stop parsing.
+      //
+      // Case 3.
+      // State : The cell separator not followed by a newline
+      // Action: Store the current contents, skip the cell separator, continue parsing the row.
+      //
+      // Case 4.
+      // State : A newline followed by anything
+      // Action: Store the current contents, report warning, skip the newline, close the row, stop parsing.
+      //
+      @tailrec def parseCells0(
+                                contents: List[Block],
+                                startMark: String,
+                                cellStartMark: Char,
+                                inlineTerminators: List[String],
+                                nextIsStartMark: => Boolean,
+                                finalizeRow: () => Unit,
+                                progressPreParse: Int,
+                                progressPostParse: Int
+                              ): Unit = {
+
+        def isStartMarkNewline = check(startMark + endOfLine)
+
+        def skipStartMarkNewline() = jump(startMark + endOfLine)
+
+        def isStartMark = check(startMark)
+
+        def skipStartMark() = jump(startMark)
+
+        def isNewlineCellStart = check(endOfLine.toString + cellStartMark)
+
+        def storeContents() = cells += Cell(contents.reverse)
+
+        val startPos = offset
+
+        // The ordering of the checks ensures the state checks are correct.
+        if (progressPreParse == progressPostParse) {
+          peek("no-progress-table-row-parsing")
+          sys.error("No progress while parsing table row")
+        } else if (isEndOfText) {
+          // peek("1: end-of-text")
+          // Case 1
+          storeContents()
+          finalizeRow()
+          reportError(pos, "unclosed table row")
+        } else if (isStartMarkNewline) {
+          // peek("2/1: start-mark-new-line")
+          // Case 2
+          storeContents()
+          finalizeRow()
+          skipStartMarkNewline()
+          // peek("2/2: start-mark-new-line")
+        } else if (isStartMark) {
+          // peek("3: start-mark")
+          // Case 3
+          storeContents()
+          skipStartMark()
+          val content = inline(isInlineEnd = checkAny(inlineTerminators))
+          // TrailingCellsEmpty produces empty content
+          val accContents = if (contentNonEmpty(content)) Paragraph(content) :: Nil else Nil
+          parseCells0(accContents, startMark, cellStartMark, inlineTerminators, nextIsStartMark, finalizeRow, startPos, offset)
+        } else if (isNewline) {
+          // peek("4: newline")
+          // Case 4
+          /* Fix and continue as there is no option to not return a table at present. */
+          reportError(pos, "missing trailing cell marker")
+          storeContents()
+          finalizeRow()
+          skipNewline()
+        } else {
+          // Case π√ⅈ
+          // When the impossible happens leave some clues.
+          reportError(pos, "unexpected table row markdown")
+          peek("parseCell0")
+          storeContents()
+          finalizeRow()
+        }
+      }
+
+      /* Parsing */
+
+      jumpWhitespace()
+
+      parseCells(nextIsCellStart, TableCellStart(0), finalizeHeaderCells)
+
+      while (nextIsCellStart) {
+        val initialOffset = offset
+
+        parseCells(nextIsCellStart, TableCellStart(0), finalizeCells)
+
+        /* Progress should always be made */
+        if (offset == initialOffset) {
+          peek("no-progress-table-parsing")
+          sys.error("No progress while parsing table")
+        }
+      }
+
+      /* Finalize */
+
+      /* Structural consistency checks */
+
+      /* Structural coercion */
+
+      // https://github.github.com/gfm/#tables-extension-
+      // TODO: The header row must match the delimiter row in the number of cells. If not, a table will not be recognized:
+      // TODO: Break at following block level element: The table is broken at the first empty line, or beginning of another block-level structure:
+      // TODO: Do not return a table when: The header row must match the delimiter row in the number of cells. If not, a table will not be recognized
+
+      if (cells.nonEmpty) {
+        reportError(pos, s"Parsed and unused content: $cells")
+      }
+      assert(header.isDefined, "table header was not parsed")
+      val enforcedCellCount = header.get.cells.size
+
+      def applyColumnCountConstraint(row: Row, defaultCell: Cell, rowType: String): Row = {
+        if (row.cells.size == enforcedCellCount)
+          row
+        else if (row.cells.size > enforcedCellCount) {
+          val excess = row.cells.size - enforcedCellCount
+          reportError(pos, s"Dropping $excess excess table $rowType cells from row.")
+          Row(row.cells.take(enforcedCellCount))
+        } else {
+          val missing = enforcedCellCount - row.cells.size
+          Row(row.cells ++ List.fill(missing)(defaultCell))
+        }
+      }
+
+      // TODO: Abandon table parsing when the delimiter is missing instead of fixing and continuing.
+      val delimiterRow :: dataRows = if (rows.nonEmpty)
+        rows.toList
+      else {
+        reportError(pos, "Fixing missing delimiter row")
+        Row(Cell(Paragraph(Text("-")) :: Nil) :: Nil) :: Nil
+      }
+
+      if (delimiterRow.cells.isEmpty) sys.error("TODO: Handle table with empty delimiter row")
+
+      val constrainedDelimiterRow = applyColumnCountConstraint(delimiterRow, delimiterRow.cells(0), "delimiter")
+
+      val constrainedDataRows = dataRows.toList.map(applyColumnCountConstraint(_, Cell(Nil), "data"))
+
+      /* Convert the row following the header row to column options */
+
+      val leftAlignmentPattern = "^:?-++$".r
+      val centerAlignmentPattern = "^:-++:$".r
+      val rightAlignmentPattern = "^-++:$".r
+
+      import ColumnOption._
+      /* Encourage user to fix by defaulting to least ignorable fix. */
+      val defaultColumnOption = ColumnOptionRight
+      val columnOptions = constrainedDelimiterRow.cells.map {
+        alignmentSpecifier =>
+          alignmentSpecifier.blocks match {
+            // TODO: Parse the second row without parsing inline markdown
+            // TODO: Save pos when delimiter row is parsed and use here in reported errors
+            case Paragraph(Text(as)) :: Nil =>
+              as.trim match {
+                case leftAlignmentPattern(_*) => ColumnOptionLeft
+                case centerAlignmentPattern(_*) => ColumnOptionCenter
+                case rightAlignmentPattern(_*) => ColumnOptionRight
+                case x =>
+                  reportError(pos, s"Fixing invalid column alignment: $x")
+                  defaultColumnOption
+              }
+            case x =>
+              reportError(pos, s"Fixing invalid column alignment: $x")
+              defaultColumnOption
+          }
+      }
+      blockEnded("table")
+      Table(header.get, columnOptions, constrainedDataRows)
     }
 
     /** {{{ para ::= inline '\n' }}} */
@@ -781,6 +1066,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
           checkSkipInitWhitespace('=') ||
           checkSkipInitWhitespace("{{{") ||
           checkList ||
+          check(TableCellStart) ||
           checkSkipInitWhitespace('\u003D')
         }
         offset = poff

--- a/src/scaladoc/scala/tools/nsc/doc/base/comment/Body.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/comment/Body.scala
@@ -1,5 +1,5 @@
 /* NSC -- new Scala compiler
- * Copyright 2007-2013 LAMP/EPFL
+ * Copyright 2007-2018 LAMP/EPFL
  * @author  Manohar Jonnalagedda
  */
 
@@ -55,6 +55,15 @@ final case class UnorderedList(items: Seq[Block]) extends Block
 final case class OrderedList(items: Seq[Block], style: String) extends Block
 final case class DefinitionList(items: SortedMap[Inline, Block]) extends Block
 final case class HorizontalRule() extends Block
+final case class Table(header: Row, columnOptions: Seq[ColumnOption], rows: Seq[Row]) extends Block
+final case class ColumnOption(option: Char) { require(option == 'L' || option == 'C' || option == 'R') }
+object ColumnOption {
+  val ColumnOptionLeft = ColumnOption('L')
+  val ColumnOptionCenter = ColumnOption('C')
+  val ColumnOptionRight = ColumnOption('R')
+}
+final case class Row(cells: Seq[Cell])
+final case class Cell(blocks: Seq[Block])
 
 /** An section of text inside a block, possibly with formatting. */
 sealed abstract class Inline

--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
@@ -104,6 +104,7 @@ abstract class HtmlPage extends Page { thisPage =>
       <dl>{items map { case (t, d) => <dt>{ inlineToHtml(t) }</dt><dd>{ blockToHtml(d) }</dd> } }</dl>
     case HorizontalRule() =>
       <hr/>
+    case tbl: Table => tableToHtml(tbl)
   }
 
   def listItemsToHtml(items: Seq[Block]) =
@@ -156,6 +157,34 @@ abstract class HtmlPage extends Page { thisPage =>
         <span class="extype" name={ dtpl.qualifiedName }>{ inlineToHtml(text) }</span>
     case _ =>
       inlineToHtml(text)
+  }
+
+  private def tableToHtml(table: Table): NodeSeq = {
+
+    val Table(header, columnOptions, rows) = table
+
+    val colClass = Map(
+      ColumnOption.ColumnOptionLeft -> "doctbl-left",
+      ColumnOption.ColumnOptionCenter -> "doctbl-center",
+      ColumnOption.ColumnOptionRight -> "doctbl-right"
+    )
+    val cc = columnOptions.map(colClass)
+
+    <table class="doctbl">
+      <thead>
+        <tr>{ (header.cells zip cc).map{ case (cell, cls) => <th class={ cls }>{ cell.blocks.map(blockToHtml) }</th>} }</tr>
+      </thead>
+      {
+        if (rows.nonEmpty) {
+          <tbody>{
+            rows.map {
+              row => <tr>{ (row.cells zip cc).map{ case (cell, cls) => <td class={ cls }>{ cell.blocks.map(blockToHtml) }</td>} }</tr>
+            }
+          }
+          </tbody>
+        }
+      }
+    </table>
   }
 
   def typeToHtml(tpes: List[model.TypeEntity], hasLinks: Boolean): NodeSeq = tpes match {

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
@@ -819,6 +819,38 @@ div.fullcomment dl.paramcmts > dd {
   min-height: 15px;
 }
 
+/* Author Content Table formatting */
+
+.doctbl {
+  border-collapse: collapse;
+  margin: 1.0em 0em;
+}
+
+.doctbl-left {
+  text-align: left;
+}
+
+.doctbl-center {
+  text-align: center;
+}
+
+.doctbl-right {
+  text-align: right;
+}
+
+table.doctbl th {
+  border: 1px dotted #364550;
+  background-color: #c2d2dc;
+  padding: 5px;
+  color: #103a51;
+  font-weight: bold;
+}
+
+table.doctbl td {
+  border: 1px dotted #364550;
+  padding: 5px;
+}
+
 /* Members filter tool */
 
 #memberfilter {

--- a/test/scaladoc/resources/tables-warnings.scala
+++ b/test/scaladoc/resources/tables-warnings.scala
@@ -1,0 +1,33 @@
+package scala.test.scaladoc.tables.warnings {
+
+  /**
+    * |Header|
+    * |-|
+    * |cell*/
+  trait PrematureEndOfText
+
+  /**
+    * |Unterminated|
+    * |-|
+    * |r1c1|
+    * |r2c1
+    * |r3c1|
+    *
+    */
+  trait MissingTrailingCellMark
+
+  /**
+    * |colon-colon|middle-colon|random|center|
+    * |::-|-:-|??|:----------------:|
+    * |a|b|c|d|
+    * */
+  trait InvalidColumnOptions
+
+  /**
+    * |Sequence|
+    * |''---''|
+    * |9|
+    * */
+  trait InvalidMarkdownUsingColumnOptions
+
+}

--- a/test/scaladoc/resources/tables.scala
+++ b/test/scaladoc/resources/tables.scala
@@ -1,0 +1,218 @@
+package scala.test.scaladoc.tables {
+
+  /**
+    * |First Header|
+    * |---|
+    * |Content Cell|
+    */
+  trait Minimal
+
+  /**
+    * |No Data Rows|
+    * |---|
+    */
+  trait NoDataRows
+
+  /**
+    * |First Header|Second Header|Third Header|
+    * |:---|:---:|---:|
+    * |Cell 1|Cell 2|Cell 3|
+    */
+  trait ColumnOptionsAllTypes
+
+  /**
+    * |First Header|Second Header|Third Header|
+    * |:----|:-----:|------:|
+    * |Cell 1|Cell 2|Cell 3|
+    */
+  trait ColumnOptionsMoreThanThreeHyphens
+
+  /**
+    * |First Header|Second Header|Third Header|
+    * |-|:--:|---:|
+    */
+  trait ColumnOptionsHyphenRepetitions
+
+  /**
+    * |First Header|Second Header|
+    * |:---:|:---:|----|
+    * |Pork|Veal|Yak|
+    * |Yam|
+    *
+    */
+  trait HeaderConstraints
+
+  /**
+    * |Edibles|
+    * |---|
+    * |Oranges __and__ Aubergines|
+    * |Peaches `or` Pears|
+    */
+  trait CellsUsingMarkdown
+
+  /**
+    * |'''Nibbles'''|''Main''|`Desert`|
+    * |:--:|:---:|----|
+    * |Bread|Yak|Vodka|
+    * |Figs|Cheese on toast^three ways^|Coffee|
+    */
+  trait CellsUsingMarkdownInHeader
+
+  /**
+    * |Header 1|Header 2||
+    * |---|---|---|
+    * |Fig||
+    * |Cherry|||
+    * |Walnut|
+    */
+  trait TrailingCellsEmpty
+
+  // Headers
+
+  /**
+    * |Fruits, ,,Beverages,, and Vegetables|Semiconductors, ''Raptors'', and Poultry|
+    * |---|---|
+    * |Out of stock|7 left|
+    */
+  trait HeadersUsingInlineMarkdown
+
+  /**
+    * |Item|Price|
+    * |---|---:|
+    * |Rookworst|€ 15,00|
+    * |Apple Sauce|€ 5,00|
+    */
+  trait Combined
+
+  /**
+    * |Header|
+    * |---|
+    * |<a href="tttt">link</a>|
+    */
+  trait CellInlineMarkdown
+
+  /**
+    * |Hill Dweller|
+    * |---|
+    * |Ant|
+    *
+    * |Hive Dweller|
+    * |---|
+    * |Bee|
+    *
+    */
+  trait MultipleTables1
+
+  /**
+    * |Hill Dweller|
+    * |---|
+    * |Ant|
+    *
+    * |Hive Dweller|
+    * |---|
+    * |Bee|
+    *
+    * |Forest Dweller|
+    * |---|
+    * |Cricket|
+    *
+    */
+  trait MultipleTables2
+
+  /**
+    * |Hill Dweller|
+    * |---|
+    * |Ant|
+    *
+    * Ants are cool.
+    *
+    * |Hive Dweller|
+    * |---|
+    * |Bee|
+    *
+    * But bees are better.
+    */
+  trait MixedContent
+
+  /**
+    * Summary
+    *
+    * Paragraph text should end here.
+    * |type|
+    * |-|
+    * |nuttiest|
+    */
+  trait ParagraphEnd
+
+  // Known suboptimal behaviour. Candidates for improving later.
+
+  /**
+    * |First \|Header|
+    * |---|---|
+    * |\|Content 1|
+    * |C\|ontent 2|
+    * |Content\| 3|
+    * |Content \|4|
+    * |Content 5\||
+    */
+  trait CellMarkerEscaped
+
+  /**
+    * |Domain|Symbol|Operation|Extra|
+    * |---|:---:|---|---|
+    * |Bitwise| \| |Or||
+    */
+  trait CellMarkerEscapedTwice
+
+  /**
+    * ||Header 1|Header 2|
+    * |---|---|---|
+    * |||Fig|
+    * ||Cherry||
+    * |Walnut|||
+    */
+  trait LeadingCellsEmpty
+
+  // Should not lose r2c1 or warn
+  /**
+    * |Unstarted|
+    * |-|
+    * |r1c1|
+    * r2c1|
+    * |r3c1|
+    *
+    */
+  trait MissingInitialCellMark
+
+  /**
+    * |Split|
+    * |-|
+    * |Accidental
+    * newline|
+    * |~FIN~|
+    *
+    */
+  trait SplitCellContent
+
+  /**
+    * |Hill Dweller|
+    * |---|
+    * |Ant|
+    * Ants are cool.
+    * |Hive Dweller|
+    * |---|
+    * |Bee|
+    * But bees are better.
+    */
+  trait MixedContentUnspaced
+
+  // Should parse to table with a header, defaulted delimiter and no rows.
+  /**
+    * |Leading|
+    *  |-|
+    *   |whitespace before marks|
+    *    |Not Yet Skipped|Maybe TO DO|
+    */
+  trait LeadingWhitespaceNotSkipped
+
+}

--- a/test/scaladoc/run/tables-warnings.check
+++ b/test/scaladoc/run/tables-warnings.check
@@ -1,0 +1,19 @@
+newSource:3: warning: unclosed table row
+  /**
+  ^
+newSource:9: warning: missing trailing cell marker
+  /**
+  ^
+newSource:19: warning: Fixing invalid column alignment: ::-
+  /**
+  ^
+newSource:19: warning: Fixing invalid column alignment: -:-
+  /**
+  ^
+newSource:19: warning: Fixing invalid column alignment: ??
+  /**
+  ^
+newSource:26: warning: Fixing invalid column alignment: List(Paragraph(Italic(Text(---))))
+  /**
+  ^
+Done.

--- a/test/scaladoc/run/tables-warnings.scala
+++ b/test/scaladoc/run/tables-warnings.scala
@@ -1,0 +1,99 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.nsc.doc.base.comment._
+import scala.tools.partest.ScaladocModelTest
+import ColumnOption._
+
+// Test with:
+// partest --verbose --srcpath scaladoc test/scaladoc/run/tables-warnings.scala
+
+object Test extends ScaladocModelTest {
+
+  import access._
+
+  override def resourceFile = "tables-warnings.scala"
+
+  def scaladocSettings = ""
+
+  def testModel(rootPackage: Package): Unit = {
+
+    val base = rootPackage._package("scala")._package("test")._package("scaladoc")._package("tables")._package("warnings")
+
+    val printCommentName = false
+
+    def withComment(commentNames: String*)(test: Comment => Unit) = {
+      commentNames foreach {
+        commentName =>
+          if (printCommentName) {
+            println(commentName)
+          }
+          val comment = getComment(commentName, base)
+          test(comment)
+      }
+    }
+
+    /* Compact table creation */
+
+    def pt(content: String): Paragraph = Paragraph(Text(content))
+
+    def c(contents: String*): Cell = Cell(contents.toList.map(pt))
+
+    def r(contents: String*): Row = Row(contents.toList.map(content => c(content)))
+
+    withComment("PrematureEndOfText") { comment =>
+      val header = r("Header")
+      val colOpts = ColumnOptionLeft :: Nil
+      val row = r("cell")
+      val rows = row :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    withComment("MissingTrailingCellMark") { comment =>
+      val header = r("Unterminated")
+      val colOpts = ColumnOptionLeft :: Nil
+      val rows = r("r1c1") :: r("r2c1") :: r("r3c1") :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    withComment("InvalidColumnOptions") { comment =>
+      val header = r("colon-colon", "middle-colon", "random", "center")
+      val colOpts = ColumnOptionRight :: ColumnOptionRight :: ColumnOptionRight :: ColumnOptionCenter :: Nil
+      val row = r("a", "b", "c", "d")
+      val rows = row :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    withComment("InvalidMarkdownUsingColumnOptions") { comment =>
+      val header = r("Sequence")
+      val colOpts = ColumnOptionRight :: Nil
+      val row = r("9")
+      val rows = row :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+  }
+
+  private def getComment(traitName: String, containingPackage: Package): Comment = {
+    containingPackage._trait(traitName).comment.get
+  }
+
+  private def assertTableEquals(expectedTable: Table, actualBody: Body): Unit = {
+    actualBody.blocks.toList match {
+      case (actualTable: Table) :: Nil =>
+        assert(expectedTable == actualTable, s"\n\nExpected:\n${multilineFormat(expectedTable)}\n\nActual:\n${multilineFormat(actualTable)}\n")
+      case _ =>
+        val expectedBody = Body(List(expectedTable))
+        assert(expectedBody == actualBody, s"Expected: $expectedBody, Actual: $actualBody")
+    }
+  }
+
+  private def assertTableEquals(expectedTable: Table, actualBlock: Block): Unit = {
+    assert(expectedTable == actualBlock, s"Expected: $expectedTable, Actual: $actualBlock")
+  }
+
+  private def multilineFormat(table: Table): String = {
+    "header       : " + table.header + "\n" +
+      "columnOptions: " + table.columnOptions.size + "\n" +
+      (table.columnOptions mkString "\n") + "\n" +
+      "rows         : " + table.rows.size + "\n" +
+      (table.rows mkString "\n")
+  }
+}

--- a/test/scaladoc/run/tables.check
+++ b/test/scaladoc/run/tables.check
@@ -1,0 +1,16 @@
+newSource:36: warning: Dropping 1 excess table delimiter cells from row.
+  /**
+  ^
+newSource:36: warning: Dropping 1 excess table data cells from row.
+  /**
+  ^
+newSource:160: warning: Dropping 1 excess table data cells from row.
+  /**
+  ^
+newSource:177: warning: no additional content on same line after table
+  /**
+  ^
+newSource:177: warning: Fixing missing delimiter row
+  /**
+  ^
+Done.

--- a/test/scaladoc/run/tables.scala
+++ b/test/scaladoc/run/tables.scala
@@ -1,0 +1,343 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.nsc.doc.base.comment._
+import scala.tools.partest.ScaladocModelTest
+import ColumnOption._
+
+// Test with:
+// partest --verbose --srcpath scaladoc test/scaladoc/run/tables.scala
+
+object Test extends ScaladocModelTest {
+
+  import access._
+
+  override def resourceFile = "tables.scala"
+
+  def scaladocSettings = ""
+
+  def testModel(rootPackage: Package): Unit = {
+
+    val base = rootPackage._package("scala")._package("test")._package("scaladoc")._package("tables")
+
+    val allTests = true
+    val whitelist = Set[String]()
+    val blacklist = Set[String]()
+    val whitelistPrefix: Option[String] = None
+    val printCommentName = false
+
+    def includeTest(commentName: String) = {
+      val whitelisted = whitelist(commentName) || whitelistPrefix.map(commentName startsWith _).getOrElse(false)
+      (allTests && !blacklist(commentName)) || whitelisted
+    }
+
+    def withComment(commentNames: String*)(test: Comment => Unit) = {
+      commentNames foreach {
+        commentName =>
+          if (includeTest(commentName)) {
+            if (printCommentName) {
+              println(commentName)
+            }
+            val comment = getComment(commentName, base)
+            test(comment)
+          }
+      }
+    }
+
+    /* Compact table creation */
+
+    def pt(content: String): Paragraph = Paragraph(Text(content))
+
+    def c(contents: String*): Cell = Cell(contents.toList.map(pt))
+
+    def ci(content: Inline): Cell = Cell(Paragraph(content) :: Nil)
+
+    /* None transforms to an empty block list */
+    def r(contents: Any*): Row = {
+      val cells = contents.toList.map {
+        case "" => Cell(Nil)
+        case x: String => c(x)
+        case None => Cell(Nil)
+      }
+      Row(cells)
+    }
+
+    withComment("Minimal") { comment =>
+      val header = r("First Header")
+      val colOpts = ColumnOptionLeft :: Nil
+      val row = r("Content Cell")
+      assertTableEquals(Table(header, colOpts, row :: Nil), comment.body)
+    }
+
+    withComment("NoDataRows") { comment =>
+      val header = r("No Data Rows")
+      val colOpts = ColumnOptionLeft :: Nil
+      assertTableEquals(Table(header, colOpts, Nil), comment.body)
+    }
+
+    withComment("ColumnOptionsAllTypes", "ColumnOptionsMoreThanThreeHyphens") { comment =>
+      val header = r("First Header", "Second Header", "Third Header")
+      val colOpts = ColumnOptionLeft :: ColumnOptionCenter :: ColumnOptionRight :: Nil
+      val row = r("Cell 1", "Cell 2", "Cell 3")
+      assertTableEquals(Table(header, colOpts, row :: Nil), comment.body)
+    }
+
+    withComment("ColumnOptionsHyphenRepetitions") { comment =>
+      val header = r("First Header", "Second Header", "Third Header")
+      val colOpts = ColumnOptionLeft :: ColumnOptionCenter :: ColumnOptionRight :: Nil
+      assertTableEquals(Table(header, colOpts, Nil), comment.body)
+    }
+
+    withComment("HeaderConstraints") { comment =>
+      val header = r("First Header", "Second Header")
+      val colOpts = ColumnOptionCenter :: ColumnOptionCenter :: Nil
+      val row1 = r("Pork", "Veal")
+      val row2 = r("Yam", "")
+      val rows = row1 :: row2 :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    withComment("CellsUsingMarkdown") { comment =>
+      val header = r("Edibles")
+      val colOpts = ColumnOptionLeft :: Nil
+
+      val cell1 = ci(Chain(List(Text("Oranges "), Underline(Text("and")), Text(" Aubergines"))))
+
+      val cell2 = ci(Chain(List(Text("Peaches "), Monospace(Text("or")), Text(" Pears"))))
+
+      val row1 = Row(cell1 :: Nil)
+      val row2 = Row(cell2 :: Nil)
+      val rows = row1 :: row2 :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    withComment("CellsUsingMarkdownInHeader") { comment =>
+      val header = {
+        val cell1 = ci(Bold(Text("Nibbles")))
+        val cell2 = ci(Italic(Text("Main")))
+        val cell3 = ci(Monospace(Text("Desert")))
+        Row(cell1 :: cell2 :: cell3 :: Nil)
+      }
+      val colOpts = ColumnOptionCenter :: ColumnOptionCenter :: ColumnOptionLeft :: Nil
+
+      val row1 = r("Bread", "Yak", "Vodka")
+      val row2 = {
+        val cell1 = c("Figs")
+        val cell2 = ci(Chain(Text("Cheese on toast") :: Superscript(Text("three ways")) :: Nil))
+        val cell3 = c("Coffee")
+        Row(cell1 :: cell2 :: cell3 :: Nil)
+      }
+      val rows = row1 :: row2 :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    withComment("TrailingCellsEmpty") { comment =>
+      val header = r("Header 1", "Header 2", "")
+      val colOpts = ColumnOptionLeft :: ColumnOptionLeft :: ColumnOptionLeft :: Nil
+
+      val row1 = r("Fig", "", "")
+      val row2 = r("Cherry", "", "")
+      val row3 = r("Walnut", "", "")
+      val rows = row1 :: row2 :: row3 :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    withComment("LeadingCellsEmpty") { comment =>
+      val nilCell = Cell(Nil)
+      val emptyCell = c("")
+
+      val header = Row(emptyCell :: c("Header 1") :: c("Header 2") :: Nil)
+      val colOpts = ColumnOptionLeft :: ColumnOptionLeft :: ColumnOptionLeft :: Nil
+
+      val row1 = Row(emptyCell :: nilCell :: c("Fig") :: Nil)
+      val row2 = Row(emptyCell :: c("Cherry") :: nilCell :: Nil)
+      val row3 = Row(c("Walnut") :: nilCell :: nilCell :: Nil)
+      val rows = row1 :: row2 :: row3 :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    withComment("HeadersUsingInlineMarkdown") { comment =>
+      val headerCell1 = ci(
+        Chain(
+          Text("Fruits, ") :: Subscript(Text("Beverages")) :: Text(" and Vegetables") :: Nil
+        )
+      )
+      val headerCell2 = ci(
+        Chain(
+          Text("Semiconductors, ") :: Italic(Text("Raptors")) :: Text(", and Poultry") :: Nil
+        )
+      )
+
+      val header = Row(headerCell1 :: headerCell2 :: Nil)
+      val colOpts = ColumnOptionLeft :: ColumnOptionLeft :: Nil
+
+      val row = r("Out of stock", "7 left")
+      val rows = row :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    withComment("Combined") { comment =>
+
+      val header = r("Item", "Price")
+      val colOpts = ColumnOptionLeft :: ColumnOptionRight :: Nil
+
+      val row1 = r("Rookworst", "€ 15,00")
+      val row2 = r("Apple Sauce", "€ 5,00")
+      val rows = row1 :: row2 :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    withComment("CellInlineMarkdown") { comment =>
+
+      val header = r("Header")
+      val colOpts = ColumnOptionLeft :: Nil
+
+      val row = Row(ci(HtmlTag("<a href=\"tttt\">link</a>")) :: Nil)
+
+      val rows = row :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    withComment("MultipleTables1") { comment =>
+
+      val colOpts = ColumnOptionLeft :: Nil
+
+      val table1 = Table(r("Hill Dweller"), colOpts, r("Ant") :: Nil)
+      val table2 = Table(r("Hive Dweller"), colOpts, r("Bee") :: Nil)
+
+      assertTablesEquals(table1 :: table2 :: Nil, comment.body)
+    }
+
+    withComment("MultipleTables2") { comment =>
+
+      val colOpts = ColumnOptionLeft :: Nil
+
+      val table1 = Table(r("Hill Dweller"), colOpts, r("Ant") :: Nil)
+      val table2 = Table(r("Hive Dweller"), colOpts, r("Bee") :: Nil)
+      val table3 = Table(r("Forest Dweller"), colOpts, r("Cricket") :: Nil)
+
+      assertTablesEquals(table1 :: table2 :: table3 :: Nil, comment.body)
+    }
+
+    {
+      val colOpts = ColumnOptionLeft :: Nil
+
+      val table1 = Table(r("Hill Dweller"), colOpts, r("Ant") :: Nil)
+      val table2 = Table(r("Hive Dweller"), colOpts, r("Bee") :: Nil)
+
+      val content1 = Paragraph(Chain(List(Summary(Chain(List(Text("Ants are cool"), Text(".")))))))
+      val content2 = pt("But bees are better.\n")
+
+      val body = Body(table1 :: content1 :: table2 :: content2 :: Nil)
+
+      withComment("MixedContent") { comment =>
+        assertBodiesEquals(body, comment.body)
+      }
+    }
+
+    withComment("ParagraphEnd") { comment =>
+
+      val summary = Paragraph(Chain(List(Summary(Text("Summary")))))
+      val paragraph = pt("Paragraph text should end here.")
+      val header = r("type")
+      val colOpts = ColumnOptionLeft :: Nil
+      val table = Table(header, colOpts, r("nuttiest") :: Nil)
+      val expected = Body(List(summary, paragraph, table))
+
+      assertBodiesEquals(expected, comment.body)
+    }
+
+    /* Deferred Enhancements.
+     *
+     * When these improvements are made corresponding test updates to any new or
+     * changed error messages and parsed content and would be included.
+     */
+
+    // Deferred pipe escape functionality.
+    withComment("CellMarkerEscaped") { comment =>
+      val header = r("First \\", "Header")
+      val colOpts = ColumnOptionLeft :: ColumnOptionLeft :: Nil
+
+      val row1 = r("\\", "Content 1")
+      val row2 = r("C\\", "ontent 2")
+      val row3 = r("Content\\", " 3")
+      val row4 = r("Content \\", "4")
+      val row5 = Row(Cell(List(Paragraph(Text("Content 5\\")))) :: Cell(Nil) :: Nil)
+
+      val rows = row1 :: row2 :: row3 :: row4 :: row5 :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    // Deferred pipe escape functionality.
+    withComment("CellMarkerEscapedTwice") { comment =>
+      val header = r("Domain", "Symbol", "Operation", "Extra")
+      val colOpts = ColumnOptionLeft :: ColumnOptionCenter :: ColumnOptionLeft :: ColumnOptionLeft :: Nil
+
+      val row = r("Bitwise", " \\", " ", "Or")
+
+      val rows = row :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    withComment("MissingInitialCellMark") { comment =>
+
+      val colOpts = ColumnOptionLeft :: Nil
+
+      val table1 = Table(r("Unstarted"), colOpts, r("r1c1") :: Nil)
+      val table2 = Table(r("r3c1"), colOpts, Nil)
+
+      assertTablesEquals(table1 :: table2 :: Nil, comment.body)
+    }
+
+    // TODO: Add assertions for MixedContentUnspaced which is similar to MissingInitialCellMark
+
+    withComment("SplitCellContent") { comment =>
+      val header = r("Split")
+      val colOpts = ColumnOptionLeft :: Nil
+      val rows = r("Accidental\nnewline") :: r("~FIN~") :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    // TODO: As a later enhancement skip whitespace before table marks to reduce rate of silently incorrect table markdown.
+    /* Confirm current suboptimal behaviour */
+    // TODO: Restore this test by updating the expected value
+    if (false) {
+      withComment("LeadingWhitespaceNotSkipped") { comment =>
+        val colOpts = ColumnOptionLeft :: Nil
+        val table1 = Table(r("Leading"), colOpts, Nil)
+        val table2 = Table(r("whitespace before marks"), colOpts, Nil)
+        val body = Body(table1 :: table2 :: Nil)
+        assertBodiesEquals(body, comment.body)
+      }
+    }
+  }
+
+  private def getComment(traitName: String, containingPackage: Package): Comment = {
+    containingPackage._trait(traitName).comment.get
+  }
+
+  private def assertTableEquals(expectedTable: Table, actualBody: Body): Unit = {
+    actualBody.blocks.toList match {
+      case (actualTable: Table) :: Nil =>
+        assert(expectedTable == actualTable, s"\n\nExpected:\n${multilineFormat(expectedTable)}\n\nActual:\n${multilineFormat(actualTable)}\n")
+      case _ =>
+        val expectedBody = Body(List(expectedTable))
+        assert(expectedBody == actualBody, s"Expected: $expectedBody, Actual: $actualBody")
+    }
+  }
+
+  private def assertTablesEquals(expectedTables: Seq[Table], actualBody: Body): Unit = {
+    val expectedBody = Body(expectedTables)
+    assert(expectedBody == actualBody, s"Expected: $expectedBody, Actual: $actualBody")
+  }
+
+  private def assertBodiesEquals(expectedBody: Body, actualBody: Body): Unit = {
+    assert(expectedBody == actualBody, s"Expected: $expectedBody, Actual: $actualBody")
+  }
+
+  private def multilineFormat(table: Table): String = {
+    "header       : " + table.header + "\n" +
+      "columnOptions: " + table.columnOptions.size + "\n" +
+      (table.columnOptions mkString "\n") + "\n" +
+      "rows         : " + table.rows.size + "\n" +
+      (table.rows mkString "\n")
+  }
+}


### PR DESCRIPTION
Parse a subset of GitHub flavoured markdown to define simple tables which can include inline wiki markdown. The specification for the table markdown is based on [GitHub Flavored Markdown Spec, Version 0.28-gfm (2017-08-01)](https://github.github.com/gfm/#tables-extension-).

The markdown used to structure the table follows [GitHub Flavoured Markdown Table Extension](https://github.github.com/gfm/#tables-extension-) with the restriction that pipe symbols at the start and end of row are mandatory and the clarification that delimiter row cells must have a minimum of three hyphens.

Note: Most of the following is irrelevant now the markdown is GHFM based..

```
  |     Define table cells
  ---   Default text alignment
  :---  Left text alignment
  ---:  Right text alignment
  :---: Center text alignment
```

Example.

A simple 2x2 table with a caption and header row,

```
  {|
  |+ Caption: Example Table
  ! header 1        ! header 2        !
  | row 1, column 1 | row 1, column 2 |
  | row 2, column 1 | row 2, column 2 |
  |}
```

Header and cell markdown can be repeated at the start of the heaer or row to allow | and ! to be included in content,

```
  {|
  !!  Disjunction!    !!  Conjunction!     !!
  ||| Logical OR = || ||| Logical AND = && |||
  |}
```

Fuller example including longer cell marks,

```
  {|
  |+ Caption: Example Table
  ! Header cell 1 ! Header cell 2 !
  | Row 1, column 1 | Row 1, column 2 |
  || Content with pipe symbol:  |A| := det(A) || final cell over
  two lines||
  |}
```

Caption, header and cell content can be broken over multiple lines and
include paragraphs and inline markdown,

```
    |Multiline
    cell
    content with __inline__ markdown

    Paragraph two.
```

Block level elements other than paragraphs are not yet parsed. Specifically these types are not yet supported,

 - Code blocks
 - Horizontal rules
 - Titles
 - Lists

A warning is issued when the rows and optional header do not all have the same number of cells.
This reserves an option to do something "wiki-ish" when cell counts differ.

Inspired by MediaWiki markdown with new row conciseness following GitHub flavoured markdown.

GitHub Project with subtasks: https://github.com/janekdb/scala/projects/1

## Live Demo

http://janekdb.github.io/scala/PR-6043/scala/test/scaladoc/tables/code/index.html

This page contains the unit test tables with the table markdown duplicated into a code block,

![image](https://user-images.githubusercontent.com/1123855/37338723-337e0696-26b0-11e8-8228-634415c99228.png)

I'm hoping this makes it easier to review the PR and also furnishes a good idea of what you get for what you give.

## PR Status

WIP

## Review Comments

 - [x] More compact way of introducing new rows

## TODO: Move to GHFM

 - [x] Make GHFM compliant
 - [x] Add GHFM column alignment options
 - [x] Update commit message
 - [x] Document requirement for delimiting pipes on rows per @lrytz comment
 - [x] Add negative test for missing pipes

## TODO: Support multiline content cell with GHFM extension

 - [ ] Understand dotty 3rd party markdown parser
 - [ ] Explore conversion of pre-dotty markdown to allow dotty markdown parser to be used
 - [ ] Retain multiline support subject to review of dotty approach

## TODO

 - [x] Include table start in check for new paragraph
 - [x] Fix lines numbers in `table-warnings.check`
 - [x] Add progress check in `parseCells0`
 - [x] Parse `Caption` as `Seq[Block]` matching `Cell`.
 - [x] Fix missing paragraphs in cell content starting with `CellsParagraphsB` and friends 
 - [x] Remove new row markdown `|-` because final cell termination is sufficient
 - [x] Consolidate or remove identically structured test traits
 - [x] CSS style table to blend into current Scaladoc themes not including row alternation styles
 - [x] Consider review comment regarding paragraph element remembering CSS is the correct way to address this
 - [x] Decide which other block elements other than Paragraph to parse: Code, Lists, Title, HRule.
 - [x] Review commit message
 - [x] Update grammar on table() method comment
 - [x] Remove `isNewlineAnyTableMarks` or the duplicate
 - [x] Run static analysis
 - [x] Squash commits

## WONT

Item | Reason | Comment
--- | --- | ---
Be more lenient toward leading whitespace below table marks|Deliver current tables sooner|Possible future improvement|
Support code blocks in cells in first merge|Deliver current tables sooner|Parsing code blocks will be the next improvement. I'd rather separate this off into new work because parsing code block while avoid code duplication could be quite a significant transformation requiring some recursion to be added at the top level of the WikiParser.|
Drop requirement for table start and end markers|Deliver current tables sooner|Without the start and end markers detecting transitions into and out of table parsing mode would be more complex and invasive. If ever we want some table level options around table formatting etc there would be no where to locate this information. Main reason is the implementation complexity.

## Acceptance Testing

 - [x] Check HTML rendering of test traits
 - [x] No regressions on existing non-table markdown in Scala library

## Review

 - [x] Create version of tables.scala which includes the table markdown as a code block and share it
 
## Target Outcome Over the Course of a few PRs :)

 - [ ] Tables as seen in ScalaTest docs can be created without requiring non-markdown work

## Follow Ons

- Support code blocks.
- Support other block elements: Horizontal Rules, Titles, List
- Make table css responsive
- Make styling in CaptionsB, CaptionsMultilineB effective instead of code style being bold and indistinguisable for other text
- Consider applying a minimum width for table to avoid caption wrapping as seen in CaptionsC
- Make styling of "and" in CellsC style the word differently to surrounding text.
- Left/right/centre cell alignment