### PR TITLE
Optimize java generic signature creation

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -809,7 +809,12 @@ abstract class BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
       // classes, or when computing stack map frames) might fail.
       def enterReferencedClass(sym: Symbol): Unit = enteringJVM(classBTypeFromSymbol(sym))
 
-      val jsOpt: Option[String] = erasure.javaSig(sym, memberTpe, enterReferencedClass)
+      val erasedTypeSym = sym.info.typeSymbol
+      val jsOpt: Option[String] =
+        if (erasedTypeSym.isPrimitiveValueClass)
+          None // scala/bug#10351: don't emit a signature if field tp erases to a primitive
+        else
+          erasure.javaSig(sym, memberTpe, enterReferencedClass)
       if (jsOpt.isEmpty) { return null }
 
       val sig = jsOpt.get

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -70,9 +70,8 @@ abstract class Erasure extends InfoTransform
   }
 
   override protected def verifyJavaErasure = settings.Xverify || settings.debug
-  def needsJavaSig(tp: Type, throwsArgs: List[Type]) = !settings.Ynogenericsig && {
-    // scala/bug#10351: don't emit a signature if tp erases to a primitive
-    def needs(tp: Type) = NeedsSigCollector.collect(tp) && !erasure(tp.typeSymbol)(tp).typeSymbol.isPrimitiveValueClass
+  private def needsJavaSig(tp: Type, throwsArgs: List[Type]) = !settings.Ynogenericsig && {
+    def needs(tp: Type) = NeedsSigCollector.collect(tp)
     needs(tp) || throwsArgs.exists(needs)
   }
 
@@ -87,31 +86,6 @@ abstract class Erasure extends InfoTransform
       (initialSymbol.isMethod && initialSymbol.typeParams.contains(sym))
     )
   )
-
-  // Ensure every '.' in the generated signature immediately follows
-  // a close angle bracket '>'.  Any which do not are replaced with '$'.
-  // This arises due to multiply nested classes in the face of the
-  // rewriting explained at rebindInnerClass.   This should be done in a
-  // more rigorous way up front rather than catching it after the fact,
-  // but that will be more involved.
-  private def dotCleanup(sig: String): String = {
-    // OPT 50% of time in generic signatures (~1% of compile time) was in this method, hence the imperative rewrite.
-    var last: Char = '\u0000'
-    var i = 0
-    val len = sig.length
-    val copy: Array[Char] = sig.toCharArray
-    var changed = false
-    while (i < len) {
-      val ch = copy(i)
-      if (ch == '.' && last != '>') {
-         copy(i) = '$'
-         changed = true
-      }
-      last = ch
-      i += 1
-    }
-    if (changed) new String(copy) else sig
-  }
 
   /** This object is only used for sanity testing when -check:genjvm is set.
    *  In that case we make sure that the erasure of the `normalized` type
@@ -215,10 +189,14 @@ abstract class Erasure extends InfoTransform
   /** The Java signature of type 'info', for symbol sym. The symbol is used to give the right return
    *  type for constructors.
    */
-  def javaSig(sym0: Symbol, info: Type, markClassUsed: Symbol => Unit): Option[String] = enteringErasure {
+
+  final def javaSig(sym0: Symbol, info: Type, markClassUsed: Symbol => Unit): Option[String] = enteringErasure { javaSig0(sym0, info, markClassUsed) }
+  @noinline
+  private final def javaSig0(sym0: Symbol, info: Type, markClassUsed: Symbol => Unit): Option[String] = {
+    val builder = new java.lang.StringBuilder(64)
     val isTraitSignature = sym0.enclClass.isTrait
 
-    def superSig(cls: Symbol, parents: List[Type]) = {
+    def superSig(cls: Symbol, parents: List[Type]): Unit = {
       def isInterfaceOrTrait(sym: Symbol) = sym.isInterface || sym.isTrait
 
       // a signature should always start with a class
@@ -236,30 +214,39 @@ abstract class Erasure extends InfoTransform
         else minParents
 
       val ps = ensureClassAsFirstParent(validParents)
-
-      (ps map boxedSig).mkString
+      ps.foreach(boxedSig)
     }
-    def boxedSig(tp: Type) = jsig(tp, primitiveOK = false)
-    def boundsSig(bounds: List[Type]) = {
+    def boxedSig(tp: Type): Unit = jsig(tp, primitiveOK = false)
+    def boundsSig(bounds: List[Type]): Unit = {
       val (isTrait, isClass) = bounds partition (_.typeSymbol.isTrait)
-      val classPart = isClass match {
-        case Nil    => ":" // + boxedSig(ObjectTpe)
-        case x :: _ => ":" + boxedSig(x)
+      isClass match {
+        case Nil    => builder.append(':') // + boxedSig(ObjectTpe)
+        case x :: _ => builder.append(':'); boxedSig(x)
       }
-      classPart :: (isTrait map boxedSig) mkString ":"
+      isTrait.foreach { tp =>
+        builder.append(':')
+        boxedSig(tp)
+      }
     }
-    def paramSig(tsym: Symbol) = tsym.name + boundsSig(hiBounds(tsym.info.bounds))
-    def polyParamSig(tparams: List[Symbol]) = (
-      if (tparams.isEmpty) ""
-      else tparams map paramSig mkString ("<", "", ">")
+    def paramSig(tsym: Symbol): Unit = {
+      builder.append(tsym.name)
+      boundsSig(hiBounds(tsym.info.bounds))
+    }
+    def polyParamSig(tparams: List[Symbol]): Unit = (
+      if (!tparams.isEmpty) {
+        builder.append('<')
+        tparams foreach paramSig
+        builder.append('>')
+      }
     )
 
     // Anything which could conceivably be a module (i.e. isn't known to be
     // a type parameter or similar) must go through here or the signature is
     // likely to end up with Foo<T>.Empty where it needs Foo<T>.Empty$.
-    def fullNameInSig(sym: Symbol) = "L" + enteringJVM(sym.javaBinaryNameString)
+    def fullNameInSig(sym: Symbol): Unit = builder.append('L').append(enteringJVM(sym.javaBinaryNameString))
 
-    def jsig(tp0: Type, existentiallyBound: List[Symbol] = Nil, toplevel: Boolean = false, primitiveOK: Boolean = true): String = {
+    @noinline
+    def jsig(tp0: Type, existentiallyBound: List[Symbol] = Nil, toplevel: Boolean = false, primitiveOK: Boolean = true): Unit = {
       val tp = tp0.dealias
       tp match {
         case st: SubType =>
@@ -267,51 +254,67 @@ abstract class Erasure extends InfoTransform
         case ExistentialType(tparams, tpe) =>
           jsig(tpe, tparams, toplevel, primitiveOK)
         case TypeRef(pre, sym, args) =>
-          def argSig(tp: Type) =
+          def argSig(tp: Type): Unit =
             if (existentiallyBound contains tp.typeSymbol) {
               val bounds = tp.typeSymbol.info.bounds
-              if (!(AnyRefTpe <:< bounds.hi)) "+" + boxedSig(bounds.hi)
-              else if (!(bounds.lo <:< NullTpe)) "-" + boxedSig(bounds.lo)
-              else "*"
+              if (!(AnyRefTpe <:< bounds.hi)) {
+                builder.append('+')
+                boxedSig(bounds.hi)
+              }
+              else if (!(bounds.lo <:< NullTpe)) {
+                builder.append('-')
+                boxedSig(bounds.lo)
+              }
+              else builder.append('*')
             } else tp match {
               case PolyType(_, res) =>
-                "*" // scala/bug#7932
+                builder.append('*') // scala/bug#7932
               case _ =>
                 boxedSig(tp)
             }
-          def classSig = {
+          def classSig: Unit = {
             markClassUsed(sym)
             val preRebound = pre.baseType(sym.owner) // #2585
-            val sigCls = {
-              if (needsJavaSig(preRebound, Nil)) {
-                val s = jsig(preRebound, existentiallyBound)
-                if (s.charAt(0) == 'L') {
-                  val withoutSemi = s.substring(0, s.length - 1)
-                  // If the prefix is a module, drop the '$'. Classes (or modules) nested in modules
-                  // are separated by a single '$' in the filename: `object o { object i }` is o$i$.
-                  val withoutOwningModuleDollar =
-                    if (preRebound.typeSymbol.isModuleClass) withoutSemi.stripSuffix(nme.MODULE_SUFFIX_STRING)
-                    else withoutSemi
-                  withoutOwningModuleDollar + "." + sym.javaSimpleName
-                } else fullNameInSig(sym)
-              }
-              else fullNameInSig(sym)
+            if (needsJavaSig(preRebound, Nil)) {
+              val i = builder.length()
+              jsig(preRebound, existentiallyBound)
+              if (builder.charAt(i) == 'L') {
+                builder.delete(builder.length() - 1, builder.length())// delete ';'
+                // If the prefix is a module, drop the '$'. Classes (or modules) nested in modules
+                // are separated by a single '$' in the filename: `object o { object i }` is o$i$.
+                if (preRebound.typeSymbol.isModuleClass)
+                  builder.delete(builder.length() - 1, builder.length())
+
+                // Ensure every '.' in the generated signature immediately follows
+                // a close angle bracket '>'.  Any which do not are replaced with '$'.
+                // This arises due to multiply nested classes in the face of the
+                // rewriting explained at rebindInnerClass.
+
+                // TODO revisit this. Does it align with javac for code that can be expressed in both languages?
+                val delimiter = if (builder.charAt(builder.length() - 1) == '>') '.' else '$'
+                builder.append(delimiter).append(sym.javaSimpleName)
+              } else fullNameInSig(sym)
+            } else fullNameInSig(sym)
+
+            if (!args.isEmpty) {
+              builder.append('<')
+              args foreach argSig
+              builder.append('>')
             }
-            val sigArgs = {
-              if (args.isEmpty) ""
-              else "<"+(args map argSig).mkString+">"
-            }
-            dotCleanup(sigCls + sigArgs + ";")
+            builder.append(';')
           }
 
           // If args isEmpty, Array is being used as a type constructor
           if (sym == ArrayClass && args.nonEmpty) {
             if (unboundedGenericArrayLevel(tp) == 1) jsig(ObjectTpe)
-            else ARRAY_TAG.toString+(args map (jsig(_))).mkString
+            else {
+              builder.append(ARRAY_TAG)
+              args.foreach(jsig(_))
+            }
           }
           else if (isTypeParameterInSig(sym, sym0)) {
             assert(!sym.isAliasType, "Unexpected alias type: " + sym)
-            "" + TVAR_TAG + sym.name + ";"
+            builder.append(TVAR_TAG).append(sym.name).append(';')
           }
           else if (sym == AnyClass || sym == AnyValClass || sym == SingletonClass)
             jsig(ObjectTpe)
@@ -324,7 +327,7 @@ abstract class Erasure extends InfoTransform
           else if (isPrimitiveValueClass(sym)) {
             if (!primitiveOK) jsig(ObjectTpe)
             else if (sym == UnitClass) jsig(BoxedUnitTpe)
-            else abbrvTag(sym).toString
+            else builder.append(abbrvTag(sym))
           }
           else if (sym.isDerivedValueClass) {
             val unboxed     = sym.derivedValueClassUnbox.tpe_*.finalResultType
@@ -343,11 +346,11 @@ abstract class Erasure extends InfoTransform
             jsig(erasure(sym0)(tp), existentiallyBound, toplevel, primitiveOK)
         case PolyType(tparams, restpe) =>
           assert(tparams.nonEmpty)
-          val poly = if (toplevel) polyParamSig(tparams) else ""
-          poly + jsig(restpe)
+          if (toplevel) polyParamSig(tparams)
+          jsig(restpe)
 
         case MethodType(params, restpe) =>
-          val buf = new StringBuffer("(")
+          builder.append('(')
           params foreach (p => {
             val tp = p.attachments.get[TypeParamVarargsAttachment] match {
               case Some(att) =>
@@ -355,14 +358,13 @@ abstract class Erasure extends InfoTransform
                 // instead of Array[T], as the latter would erase to Object (instead of Array[Object]).
                 // To make the generic signature correct ("[T", not "[Object"), an attachment on the
                 // parameter symbol stores the type T that was replaced by Object.
-                buf.append("["); att.typeParamRef
+                builder.append('['); att.typeParamRef
               case _         => p.tpe
             }
-            buf append jsig(tp)
+            jsig(tp)
           })
-          buf append ")"
-          buf append (if (restpe.typeSymbol == UnitClass || sym0.isConstructor) VOID_TAG.toString else jsig(restpe))
-          buf.toString
+          builder.append(')')
+          if (restpe.typeSymbol == UnitClass || sym0.isConstructor) builder.append(VOID_TAG) else jsig(restpe)
 
         case RefinedType(parents, decls) =>
           jsig(intersectionDominator(parents), primitiveOK = primitiveOK)
@@ -381,7 +383,14 @@ abstract class Erasure extends InfoTransform
     }
     val throwsArgs = sym0.annotations flatMap ThrownException.unapply
     if (needsJavaSig(info, throwsArgs)) {
-      try Some(jsig(info, toplevel = true) + throwsArgs.map("^" + jsig(_, toplevel = true)).mkString(""))
+      try {
+        jsig(info, toplevel = true)
+        throwsArgs.foreach { t =>
+          builder.append('^')
+          jsig(t, toplevel = true)
+        }
+        Some(builder.toString)
+      }
       catch { case ex: UnknownSig => None }
     }
     else None

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -182,7 +182,7 @@ trait Names extends api.Names {
    *  or Strings as Names.  Give names the key functions the absence of which
    *  make people want Strings all the time.
    */
-  sealed abstract class Name(protected val index: Int, protected val len: Int) extends NameApi {
+  sealed abstract class Name(protected val index: Int, protected val len: Int) extends NameApi with CharSequence {
     type ThisNameType >: Null <: Name
     protected[this] def thisName: ThisNameType
 
@@ -211,6 +211,7 @@ trait Names extends api.Names {
 
     /** Return the subname with characters from from to to-1. */
     def subName(from: Int, to: Int): Name with ThisNameType
+    override def subSequence(from: Int, to: Int): CharSequence = subName(from, to)
 
     /** Return a new name of the same variety. */
     def newName(str: String): Name with ThisNameType


### PR DESCRIPTION
References scala/scala-dev#418.

I haven't changed the logic to use `$` rather than `.`, but I
think we should clarify the intent of this and compare with
javac's behaviour.