### PR TITLE
Remove deprecated view bounds in library

### DIFF
--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -1,6 +1,6 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2017, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
@@ -183,15 +183,19 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
 }
 
 trait LowPriorityOrderingImplicits {
+
+  type AsComparable[A] = A => Comparable[A]
+
   /** This would conflict with all the nice implicit Orderings
    *  available, but thanks to the magic of prioritized implicits
    *  via subclassing we can make `Ordered[A] => Ordering[A]` only
    *  turn up if nothing else works.  Since `Ordered[A]` extends
    *  `Comparable[A]` anyway, we can throw in some Java interop too.
    */
-  implicit def ordered[A <% Comparable[A]]: Ordering[A] = new Ordering[A] {
+  implicit def ordered[A: AsComparable]: Ordering[A] = new Ordering[A] {
     def compare(x: A, y: A): Int = x compareTo y
   }
+
   implicit def comparatorToOrdering[A](implicit cmp: Comparator[A]): Ordering[A] = new Ordering[A] {
     def compare(x: A, y: A) = cmp.compare(x, y)
   }

--- a/src/library/scala/math/PartiallyOrdered.scala
+++ b/src/library/scala/math/PartiallyOrdered.scala
@@ -1,11 +1,10 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2017, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
 \*                                                                      */
-
 
 
 package scala
@@ -18,6 +17,8 @@ package math
  */
 trait PartiallyOrdered[+A] {
 
+  type AsPartiallyOrdered[B] = B => PartiallyOrdered[B]
+
   /** Result of comparing `'''this'''` with operand `that`.
    *  Returns `None` if operands are not comparable.
    *  If operands are comparable, returns `Some(x)` where
@@ -25,24 +26,27 @@ trait PartiallyOrdered[+A] {
    *  - `x == 0`   iff   `'''this''' == that`
    *  - `x > 0`    iff   `'''this''' &gt; that`
    */
-  def tryCompareTo [B >: A <% PartiallyOrdered[B]](that: B): Option[Int]
+  def tryCompareTo [B >: A: AsPartiallyOrdered](that: B): Option[Int]
 
-  def <  [B >: A <% PartiallyOrdered[B]](that: B): Boolean =
+  def < [B >: A: AsPartiallyOrdered](that: B): Boolean =
     (this tryCompareTo that) match {
       case Some(x) if x < 0 => true
       case _ => false
     }
-  def >  [B >: A <% PartiallyOrdered[B]](that: B): Boolean =
+
+  def > [B >: A: AsPartiallyOrdered](that: B): Boolean =
     (this tryCompareTo that) match {
       case Some(x) if x > 0 => true
       case _ => false
     }
-  def <= [B >: A <% PartiallyOrdered[B]](that: B): Boolean =
+
+  def <= [B >: A: AsPartiallyOrdered](that: B): Boolean =
     (this tryCompareTo that) match {
       case Some(x) if x <= 0 => true
       case _ => false
     }
-  def >= [B >: A <% PartiallyOrdered[B]](that: B): Boolean =
+
+  def >= [B >: A: AsPartiallyOrdered](that: B): Boolean =
     (this tryCompareTo that) match {
       case Some(x) if x >= 0 => true
       case _ => false


### PR DESCRIPTION
Replace view bounds with implicit parameter.

`evidence$1` is the name used by the parser when converting the view bound to a parameter but
`ev` is the conventional name. To ensure compatibility with code that might be using the
generated name parameter name deprecation is included.


## TODO

  - [x] Update the version following cherry-pick
  - [x] Use context bound and do not deprecate the implicit parameter name