### PR TITLE
Support by-name implicits with recursive dictionaries

### DIFF
--- a/spec/04-basic-declarations-and-definitions.md
+++ b/spec/04-basic-declarations-and-definitions.md
@@ -693,9 +693,7 @@ function. That is, the argument is evaluated using _call-by-name_.
 
 The by-name modifier is disallowed for parameters of classes that
 carry a `val` or `var` prefix, including parameters of case
-classes for which a `val` prefix is implicitly generated. The
-by-name modifier is also disallowed for
-[implicit parameters](07-implicits.html#implicit-parameters).
+classes for which a `val` prefix is implicitly generated.
 
 ###### Example
 The declaration

--- a/spec/07-implicits.md
+++ b/spec/07-implicits.md
@@ -177,22 +177,91 @@ expansion:
 sort(arg)(x => magic(x)(x => magic(x)(x => ... )))
 ```
 
-To prevent such infinite expansions, the compiler keeps track of
-a stack of “open implicit types” for which implicit arguments are currently being
-searched. Whenever an implicit argument for type $T$ is searched, the
-“core type” of $T$ is added to the stack. Here, the _core type_
-of $T$ is $T$ with aliases expanded, top-level type [annotations](11-annotations.html#user-defined-annotations) and
-[refinements](03-types.html#compound-types) removed, and occurrences
-of top-level existentially bound variables replaced by their upper
-bounds. The core type is removed from the stack once the search for
-the implicit argument either definitely fails or succeeds. Everytime a
-core type is added to the stack, it is checked that this type does not
-dominate any of the other types in the set.
+Such infinite expansions should be detected and reported as errors, however to support the deliberate
+implicit construction of recursive values we allow implicit arguments to be marked as by-name. At call
+sites recursive uses of implicit values are permitted if they occur in an implicit by-name argument.
 
-Here, a core type $T$ _dominates_ a type $U$ if $T$ is
-[equivalent](03-types.html#equivalence)
-to $U$, or if the top-level type constructors of $T$ and $U$ have a
-common element and $T$ is more complex than $U$.
+Consider the following example,
+
+```scala
+trait Foo {
+  def next: Foo
+}
+
+object Foo {
+  implicit def foo(implicit rec: Foo): Foo =
+    new Foo { def next = rec }
+}
+
+val foo = implicitly[Foo]
+assert(foo eq foo.next)
+```
+
+As with the `magic` case above this diverges due to the recursive implicit argument `rec` of method
+`foo`. If we mark the implicit argument as by-name,
+
+```scala
+trait Foo {
+  def next: Foo
+}
+
+object Foo {
+  implicit def foo(implicit rec: => Foo): Foo =
+    new Foo { def next = rec }
+}
+
+val foo = implicitly[Foo]
+assert(foo eq foo.next)
+```
+
+the example compiles with the assertion successful.
+
+When compiled, recursive by-name implicit arguments of this sort are extracted out as val members of a
+local synthetic object at call sites as follows,
+
+```scala
+val foo: Foo = scala.Predef.implicitly[Foo](
+  {
+    object LazyDefns$1 {
+      val rec$1: Foo = Foo.foo(rec$1)
+                       //      ^^^^^
+                       // recursive knot tied here
+    }
+    LazyDefns$1.rec$1
+  }
+)
+assert(foo eq foo.next)
+```
+
+Note that the recursive use of `rec$1` occurs within the by-name argument of `foo` and is consequently
+deferred. The desugaring matches what a programmer would do to construct such a recursive value
+explicitly.
+
+To prevent infinite expansions, such as the `magic` example above, the compiler keeps track of a stack
+of “open implicit types” for which implicit arguments are currently being searched. Whenever an
+implicit argument for type $T$ is searched, $T$ is added to the stack paired with the implicit
+definition which produces it, and whether it was required to satisfy a by-name implicit argument or
+not. The type is removed from the stack once the search for the implicit argument either definitely
+fails or succeeds. Everytime a type is about to be added to the stack, it is checked against
+existing entries which were produced by the same implicit definition and then,
+
++ if it is equivalent to some type which is already on the stack and there is a by-name argument between
+  that entry and the top of the stack. In this case the search for that type succeeds immediately and
+  the implicit argument is compiled as a recursive reference to the found argument.  That argument is
+  added as an entry in the synthesized implicit dictionary if it has not already been added.
++ otherwise if the _core_ of the type _dominates_ the core of a type already on the stack, then the
+  implicit expansion is said to _diverge_ and the search for that type fails immediately.
++ otherwise it is added to the stack paired with the implicit definition which produces it.
+  Implicit resolution continues with the implicit arguments of that definition (if any).
+
+Here, the _core type_ of $T$ is $T$ with aliases expanded,
+top-level type [annotations](11-annotations.html#user-defined-annotations) and
+[refinements](03-types.html#compound-types) removed, and occurrences of top-level existentially bound
+variables replaced by their upper bounds.
+
+A core type $T$ _dominates_ a type $U$ if $T$ is [equivalent](03-types.html#equivalence) to $U$,
+or if the top-level type constructors of $T$ and $U$ have a common element and $T$ is more complex
+than $U$ and the _covering sets_ of $T$ and $U$ are equal.
 
 The set of _top-level type constructors_ $\mathit{ttcs}(T)$ of a type $T$ depends on the form of
 the type:
@@ -210,6 +279,21 @@ the type:
 - For a singleton type denoting a package $p$, $\operatorname{complexity}(p.type) ~=~ 0$
 - For any other singleton type, $\operatorname{complexity}(p.type) ~=~ 1 + \operatorname{complexity}(T)$, provided $p$ has type $T$;
 - For a compound type, `$\operatorname{complexity}(T_1$ with $\ldots$ with $T_n)$` $= \Sigma\operatorname{complexity}(T_i)$
+
+The _covering set_ $\mathit{cs}(T)$ of a type $T$ is the set of type designators mentioned in a type.
+For example, given the following,
+
+```scala
+type A = List[(Int, Int)]
+type B = List[(Int, (Int, Int))]
+type C = List[(Int, String)]
+```
+
+the corresponding covering sets are:
+
+- $\mathit{cs}(A)$: List, Tuple2, Int
+- $\mathit{cs}(B)$: List, Tuple2, Int
+- $\mathit{cs}(C)$: List, Tuple2, Int, String
 
 ###### Example
 When typing `sort(xs)` for some list `xs` of type `List[List[List[Int]]]`,

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2402,10 +2402,6 @@ self =>
                 in.offset,
                 (if (mods.isMutable) "`var'" else "`val'") +
                 " parameters may not be call-by-name", skipIt = false)
-            else if (implicitmod != 0)
-              syntaxError(
-                in.offset,
-                "implicit parameters may not be call-by-name", skipIt = false)
             else bynamemod = Flags.BYNAMEPARAM
           }
           paramType()

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -320,7 +320,7 @@ trait Contexts { self: Analyzer =>
         if(pruned.isEmpty) result
         else {
           val (vsyms, vdefs) = pruned.map { case (vsym, rhs) =>
-            (vsym, ValDef(Modifiers(FINAL | SYNTHETIC), vsym.name.toTermName, TypeTree(rhs.tpe), rhs))
+            (vsym, ValDef(Modifiers(FINAL | SYNTHETIC), vsym.name.toTermName, TypeTree(rhs.tpe), rhs.changeOwner(owner -> vsym)))
           }.unzip
 
           val ctor = DefDef(NoMods, nme.CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(List(pendingSuperCall), Literal(Constant(()))))
@@ -352,7 +352,7 @@ trait Contexts { self: Analyzer =>
           }
 
           val tree0 = patchRefs.transform(result.tree)
-          val tree1 = Block(mdef0, tree0).substituteSymbols(vsyms.toList, vsyms0.toList) setType tree.tpe
+          val tree1 = Block(mdef0, tree0).substituteSymbols(vsyms, vsyms0) setType tree.tpe
 
           new SearchResult(atPos(pos.focus)(tree1), result.subst, result.undetparams)
         }

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -262,7 +262,8 @@ trait Contexts { self: Analyzer =>
         implicitDictionary.find(_._1 =:= tpe) match {
           case Some((_, (sym, _))) => sym
           case None =>
-            val vname = unit.freshTermName("rec$")
+            val fresh = freshNameCreatorFor(this)
+            val vname = newTermName(fresh.newName("rec$"))
             val vsym = owner.newValue(vname, newFlags = FINAL | SYNTHETIC) setInfo tpe
             implicitDictionary +:= (tpe -> (vsym, EmptyTree))
             vsym
@@ -323,7 +324,7 @@ trait Contexts { self: Analyzer =>
           }.unzip
 
           val ctor = DefDef(NoMods, nme.CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(List(pendingSuperCall), Literal(Constant(()))))
-          val mname = unit.freshTermName("LazyDefns$")
+          val mname = newTermName(typer.fresh.newName("LazyDefns$"))
           val mdef =
             ModuleDef(Modifiers(SYNTHETIC), mname,
               Template(List(Ident(AnyRefClass)), noSelfType, ctor :: vdefs.toList)

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -334,8 +334,9 @@ trait Contexts { self: Analyzer =>
 
           val mdef0 = typer.typed(mdef)
           val msym0 = mdef0.symbol
+          val moduleClassInfo = mdef0.symbol.moduleClass.info
           val vsyms0 = vsyms.map { vsym =>
-            mdef0.symbol.moduleClass.asClass.toType.decl(vsym.name)
+            moduleClassInfo.decl(vsym.name)
           }
 
           val vsymMap = (vsyms zip vsyms0).toMap

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -249,7 +249,7 @@ trait Contexts { self: Analyzer =>
     private type ImplicitDict = List[(Type, (Symbol, Tree))]
     private var implicitDictionary: ImplicitDict = null
 
-    def implicitRootContext: Context = {
+    @tailrec final def implicitRootContext: Context = {
       if(implicitDictionary != null) this
       else if(outerIsNoContext || outer.openImplicits.isEmpty) {
         implicitDictionary = Nil
@@ -271,7 +271,7 @@ trait Contexts { self: Analyzer =>
       gen.mkAttributedRef(sym) setType tpe
     }
 
-    def linkByNameImplicit(tpe: Type): Tree = implicitRootContext.linkImpl(tpe)
+    final def linkByNameImplicit(tpe: Type): Tree = implicitRootContext.linkImpl(tpe)
 
     private def refImpl(tpe: Type): Tree =
       implicitDictionary.find(_._1 =:= tpe) match {
@@ -281,7 +281,7 @@ trait Contexts { self: Analyzer =>
           EmptyTree
       }
 
-    def refByNameImplicit(tpe: Type): Tree = implicitRootContext.refImpl(tpe)
+    final def refByNameImplicit(tpe: Type): Tree = implicitRootContext.refImpl(tpe)
 
     private def defineImpl(tpe: Type, result: SearchResult): SearchResult = {
       @tailrec
@@ -316,7 +316,7 @@ trait Contexts { self: Analyzer =>
             else prune(in.map(_._2) ++ trees, out, in ++ acc)
         }
 
-        val pruned = prune(List(result.tree), implicitDictionary.map(_._2), List.empty[(Symbol, Tree)])
+        val pruned = prune(List(result.tree), implicitDictionary.map(_._2), Nil)
         if(pruned.isEmpty) result
         else {
           val (vsyms, vdefs) = pruned.map { case (vsym, rhs) =>

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -17,8 +17,10 @@ import scala.reflect.internal.Reporter
  */
 trait Contexts { self: Analyzer =>
   import global._
-  import definitions.{ JavaLangPackage, ScalaPackage, PredefModule, ScalaXmlTopScope, ScalaXmlPackage }
+  import definitions.{ AnyRefClass, JavaLangPackage, ScalaPackage, PredefModule, ScalaXmlTopScope, ScalaXmlPackage }
   import ContextMode._
+  import scala.reflect.internal.Flags._
+
 
   protected def onTreeCheckerError(pos: Position, msg: String): Unit = ()
 
@@ -243,6 +245,117 @@ trait Contexts { self: Analyzer =>
     final def isSearchingForImplicitParam: Boolean = {
       openImplicits.nonEmpty && openImplicits.exists(x => !x.isView)
     }
+
+    private type ImplicitDict = List[(Type, (Symbol, Tree))]
+    private var implicitDictionary: ImplicitDict = null
+
+    def implicitRootContext: Context = {
+      if(implicitDictionary != null) this
+      else if(outerIsNoContext || outer.openImplicits.isEmpty) {
+        implicitDictionary = Nil
+        this
+      } else outer.implicitRootContext
+    }
+
+    private def linkImpl(tpe: Type): Tree = {
+      val sym =
+        implicitDictionary.find(_._1 =:= tpe) match {
+          case Some((_, (sym, _))) => sym
+          case None =>
+            val vname = unit.freshTermName("rec$")
+            val vsym = owner.newValue(vname, newFlags = FINAL | SYNTHETIC) setInfo tpe
+            implicitDictionary +:= (tpe -> (vsym, EmptyTree))
+            vsym
+        }
+      gen.mkAttributedRef(sym) setType tpe
+    }
+
+    def linkByNameImplicit(tpe: Type): Tree = implicitRootContext.linkImpl(tpe)
+
+    private def refImpl(tpe: Type): Tree =
+      implicitDictionary.find(_._1 =:= tpe) match {
+        case Some((_, (sym, _))) =>
+          gen.mkAttributedRef(sym) setType tpe
+        case None =>
+          EmptyTree
+      }
+
+    def refByNameImplicit(tpe: Type): Tree = implicitRootContext.refImpl(tpe)
+
+    private def defineImpl(tpe: Type, result: SearchResult): SearchResult = {
+      @tailrec
+      def patch(d: ImplicitDict, acc: ImplicitDict): (ImplicitDict, SearchResult) = d match {
+        case Nil => (implicitDictionary, result)
+        case (tp, (sym, EmptyTree)) :: tl if tp =:= tpe =>
+          val ref = gen.mkAttributedRef(sym) setType tpe
+          val res = new SearchResult(ref, result.subst, result.undetparams)
+          (acc reverse_::: ((tpe, (sym, result.tree)) :: tl), res)
+        case hd :: tl =>
+          patch(tl, hd :: acc)
+      }
+
+      val (d, res) = patch(implicitDictionary, Nil)
+      implicitDictionary = d
+      res
+    }
+
+    def defineByNameImplicit(tpe: Type, result: SearchResult): SearchResult = implicitRootContext.defineImpl(tpe, result)
+
+    def emitImplicitDictionary(result: SearchResult): SearchResult =
+      if(implicitDictionary == null || implicitDictionary.isEmpty || result.tree == EmptyTree) result
+      else {
+        val typer = newTyper(this)
+
+        @tailrec
+        def prune(trees: List[Tree], pending: List[(Symbol, Tree)], acc: List[(Symbol, Tree)]): List[(Symbol, Tree)] = pending match {
+          case Nil => acc
+          case ps =>
+            val (in, out) = ps.partition { case (vsym, rhs) => trees.exists(_.exists(_.symbol == vsym)) }
+            if(in.isEmpty) acc
+            else prune(in.map(_._2) ++ trees, out, in ++ acc)
+        }
+
+        val pruned = prune(List(result.tree), implicitDictionary.map(_._2), List.empty[(Symbol, Tree)])
+        if(pruned.isEmpty) result
+        else {
+          val (vsyms, vdefs) = pruned.map { case (vsym, rhs) =>
+            (vsym, ValDef(Modifiers(FINAL | SYNTHETIC), vsym.name.toTermName, TypeTree(rhs.tpe), rhs))
+          }.unzip
+
+          val ctor = DefDef(NoMods, nme.CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(List(pendingSuperCall), Literal(Constant(()))))
+          val mname = unit.freshTermName("LazyDefns$")
+          val mdef =
+            ModuleDef(Modifiers(SYNTHETIC), mname,
+              Template(List(Ident(AnyRefClass)), noSelfType, ctor :: vdefs.toList)
+            )
+
+          typer.namer.enterSym(mdef)
+
+          val mdef0 = typer.typed(mdef)
+          val msym0 = mdef0.symbol
+          val vsyms0 = vsyms.map { vsym =>
+            mdef0.symbol.moduleClass.asClass.toType.decl(vsym.name)
+          }
+
+          val vsymMap = (vsyms zip vsyms0).toMap
+
+          object patchRefs extends Transformer {
+            override def transform(tree: Tree): Tree = {
+              tree match {
+                case i: Ident if vsymMap.contains(i.symbol) =>
+                  gen.mkAttributedSelect(gen.mkAttributedRef(msym0), vsymMap(i.symbol)) setType i.tpe
+                case _ =>
+                  super.transform(tree)
+              }
+            }
+          }
+
+          val tree0 = patchRefs.transform(result.tree)
+          val tree1 = Block(mdef0, tree0).substituteSymbols(vsyms.toList, vsyms0.toList) setType tree.tpe
+
+          new SearchResult(tree1, result.subst, result.undetparams)
+        }
+      }
 
     var prefix: Type = NoPrefix
 

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -302,7 +302,7 @@ trait Contexts { self: Analyzer =>
 
     def defineByNameImplicit(tpe: Type, result: SearchResult): SearchResult = implicitRootContext.defineImpl(tpe, result)
 
-    def emitImplicitDictionary(result: SearchResult): SearchResult =
+    def emitImplicitDictionary(pos: Position, result: SearchResult): SearchResult =
       if(implicitDictionary == null || implicitDictionary.isEmpty || result.tree == EmptyTree) result
       else {
         val typer = newTyper(this)
@@ -354,7 +354,7 @@ trait Contexts { self: Analyzer =>
           val tree0 = patchRefs.transform(result.tree)
           val tree1 = Block(mdef0, tree0).substituteSymbols(vsyms.toList, vsyms0.toList) setType tree.tpe
 
-          new SearchResult(tree1, result.subst, result.undetparams)
+          new SearchResult(atPos(pos.focus)(tree1), result.subst, result.undetparams)
         }
       }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -327,7 +327,7 @@ trait Contexts { self: Analyzer =>
           val mname = newTermName(typer.fresh.newName("LazyDefns$"))
           val mdef =
             ModuleDef(Modifiers(SYNTHETIC), mname,
-              Template(List(Ident(AnyRefClass)), noSelfType, ctor :: vdefs.toList)
+              gen.mkTemplate(gen.mkParents(NoMods, Nil), noSelfType, NoMods, ListOfNil, vdefs)
             )
 
           typer.namer.enterSym(mdef)

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -117,7 +117,7 @@ trait Implicits {
       if (context.owner.hasTransOwner(s))
         context.warning(result.tree.pos, s"Implicit resolves to enclosing ${result.tree.symbol}")
     }
-    implicitSearchContext.emitImplicitDictionary(result)
+    implicitSearchContext.emitImplicitDictionary(search.pos, result)
   }
 
   /** A friendly wrapper over inferImplicit to be used in macro contexts and toolboxes.
@@ -579,7 +579,7 @@ trait Implicits {
 
           recursiveImplicit match {
             case Some(rec) =>
-              val ref = context.linkByNameImplicit(dropByName(rec.pt))
+              val ref = atPos(pos.focus)(context.linkByNameImplicit(dropByName(rec.pt)))
               new SearchResult(ref, EmptyTreeTypeSubstituter, Nil)
             case None =>
               try {

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -117,7 +117,7 @@ trait Implicits {
       if (context.owner.hasTransOwner(s))
         context.warning(result.tree.pos, s"Implicit resolves to enclosing ${result.tree.symbol}")
     }
-    result
+    implicitSearchContext.emitImplicitDictionary(result)
   }
 
   /** A friendly wrapper over inferImplicit to be used in macro contexts and toolboxes.
@@ -450,21 +450,6 @@ trait Implicits {
      *  if one or both are intersection types with a pair of overlapping parent types.
      */
     private def dominates(dtor: Type, dted: Type): Boolean = {
-      def core(tp: Type): Type = tp.dealiasWiden match {
-        case RefinedType(parents, defs)         => intersectionType(parents map core, tp.typeSymbol.owner)
-        case AnnotatedType(annots, tp)          => core(tp)
-        case ExistentialType(tparams, result)   => core(result).subst(tparams, tparams map (t => core(t.info.bounds.hi)))
-        case PolyType(tparams, result)          => core(result).subst(tparams, tparams map (t => core(t.info.bounds.hi)))
-        case TypeRef(pre, sym, args)            => typeRef(pre, sym, args.map(core))
-        case _                                  => tp
-      }
-      def stripped(tp: Type): Type = {
-        // `t.typeSymbol` returns the symbol of the normalized type. If that normalized type
-        // is a `PolyType`, the symbol of the result type is collected. This is precisely
-        // what we require for scala/bug#5318.
-        val syms = for (t <- tp; if t.typeSymbol.isTypeParameter) yield t.typeSymbol
-        deriveTypeWithWildcards(syms.distinct)(tp)
-      }
       def complexity(tp: Type): Int = tp.dealias match {
         case NoPrefix                => 0
         case SingleType(pre, sym)    => if (sym.hasPackageFlag) 0 else complexity(tp.dealiasWiden)
@@ -481,6 +466,43 @@ trait Implicits {
       val dtor1 = stripped(core(dtor))
       val dted1 = stripped(core(dted))
       overlaps(dtor1, dted1) && (dtor1 =:= dted1 || complexity(dtor1) > complexity(dted1))
+    }
+
+    private def core(tp: Type): Type = tp.dealiasWiden match {
+      case RefinedType(parents, defs)         => intersectionType(parents map core, tp.typeSymbol.owner)
+      case AnnotatedType(annots, tp)          => core(tp)
+      case ExistentialType(tparams, result)   => core(result).subst(tparams, tparams map (t => core(t.info.bounds.hi)))
+      case PolyType(tparams, result)          => core(result).subst(tparams, tparams map (t => core(t.info.bounds.hi)))
+      case TypeRef(pre, sym, args)            => typeRef(pre, sym, args.map(core))
+      case _                                  => tp
+    }
+
+    private def stripped(tp: Type): Type = {
+      // `t.typeSymbol` returns the symbol of the normalized type. If that normalized type
+      // is a `PolyType`, the symbol of the result type is collected. This is precisely
+      // what we require for scala/bug#5318.
+      val syms = for (t <- tp; if t.typeSymbol.isTypeParameter) yield t.typeSymbol
+      deriveTypeWithWildcards(syms.distinct)(tp)
+    }
+
+    private def allSymbols(tp: Type): Set[Symbol] = {
+      @tailrec
+      def loop(tps: List[Type], acc: Set[Symbol]): Set[Symbol] = tps match {
+        case Nil => acc
+        case hd :: tl =>
+          def hdSym(syms: Set[Symbol]) = {
+            val sym = hd.typeSymbol
+            if(sym != NoSymbol) syms + sym else syms
+          }
+          hd.dealias match {
+            case SingleType(pre, sym)    => loop(pre :: hd.dealiasWiden :: tl, hdSym(acc + sym))
+            case ThisType(sym)           => loop(tl, hdSym(acc + sym))
+            case TypeRef(pre, sym, args) => loop(pre :: args ++ tl, hdSym(acc + sym))
+            case RefinedType(parents, _) => loop(parents ++ tl, hdSym(acc))
+            case _ => loop(tl, hdSym(acc))
+          }
+        }
+      loop(List(tp), Set())
     }
 
     /** The expected type with all undetermined type parameters replaced with wildcards. */
@@ -507,28 +529,75 @@ trait Implicits {
       // otherwise, the macro writer could check `c.openMacros` and `c.openImplicits` and do `c.abort` when expansions are deemed to be divergent
       // upon receiving `c.abort` the typechecker will decide that the corresponding implicit search has failed
       // which will fail the entire stack of implicit searches, producing a nice error message provided by the programmer
-      val existsDominatedImplicit = tree != EmptyTree && context.openImplicits.exists {
-        case OpenImplicit(nfo, tp, tree1) => !nfo.sym.isMacro && tree1.symbol == tree.symbol && dominates(pt, tp)
-      }
+      val existsDominatedImplicit: Boolean =
+        if(tree == EmptyTree) false
+        else {
+          val ptByName = isByNameParamType(pt)
+          val dpt = if (ptByName) dropByName(pt) else pt
+          lazy val spt = stripped(core(dpt))
+          lazy val sptSyms = allSymbols(spt)
+          // Are all the symbols of the stripped core of pt contained in the stripped core of tp?
+          def coversPt(tp: Type): Boolean = {
+            val stp = stripped(core(tp))
+            (stp =:= spt) || (sptSyms == allSymbols(stp))
+          }
 
-        if(existsDominatedImplicit) {
-          //println("Pending implicit "+pending+" dominates "+pt+"/"+undetParams) //@MDEBUG
-          DivergentSearchFailure
-        } else {
-         try {
-           context.openImplicits = OpenImplicit(info, pt, tree, isView) :: context.openImplicits
-           // println("  "*context.openImplicits.length+"typed implicit "+info+" for "+pt) //@MDEBUG
-           val result = typedImplicit0(info, ptChecked, isLocalToCallsite)
-           if (result.isDivergent) {
-             //println("DivergentImplicit for pt:"+ pt +", open implicits:"+context.openImplicits) //@MDEBUG
-             if (context.openImplicits.tail.isEmpty && !pt.isErroneous)
-               DivergingImplicitExpansionError(tree, pt, info.sym)(context)
-           }
-           result
-         } finally {
-           context.openImplicits = context.openImplicits.tail
-         }
-       }
+          @tailrec
+          def loop(ois: List[OpenImplicit], belowByName: Boolean): Boolean = {
+            ois match {
+              case Nil => false
+              case (hd@OpenImplicit(info1, tp, tree1)) :: tl =>
+                val byName = isByNameParamType(tp)
+                val dtp = if (byName) dropByName(tp) else tp
+                (if (!info1.sym.isMacro && tree1.symbol == tree.symbol) {
+                  if(belowByName && (dtp =:= dpt)) Some(false) // if there is a byname argument between tp and pt we can tie the knot
+                  else if (dominates(dpt, dtp) && coversPt(dtp)) Some(true)
+                  else None
+                } else None) match {
+                  case Some(res) => res
+                  case None => loop(tl, byName || belowByName)
+                }
+            }
+          }
+          loop(context.openImplicits, ptByName)
+        }
+
+      if(existsDominatedImplicit) {
+        //println("Pending implicit "+pending+" dominates "+pt+"/"+undetParams) //@MDEBUG
+        DivergentSearchFailure
+      } else {
+        val ref = context.refByNameImplicit(dropByName(pt))
+        if(ref != EmptyTree)
+          new SearchResult(ref, EmptyTreeTypeSubstituter, Nil)
+        else {
+          val recursiveImplicit: Option[OpenImplicit] =
+            if(tree == EmptyTree) None
+            else context.openImplicits find {
+              case OpenImplicit(info, tp, tree1) =>
+                (isByNameParamType(tp) || isByNameParamType(pt)) && dropByName(tp) <:< dropByName(pt)
+            }
+
+          recursiveImplicit match {
+            case Some(rec) =>
+              val ref = context.linkByNameImplicit(dropByName(rec.pt))
+              new SearchResult(ref, EmptyTreeTypeSubstituter, Nil)
+            case None =>
+              try {
+                context.openImplicits = OpenImplicit(info, pt, tree, isView) :: context.openImplicits
+                //println("  "*context.openImplicits.length+"typed implicit "+info+" for "+pt) //@MDEBUG
+                val result = typedImplicit0(info, ptChecked, isLocalToCallsite)
+                if (result.isDivergent) {
+                  //println("DivergentImplicit for pt:"+ pt +", open implicits:"+context.openImplicits) //@MDEBUG
+                  if (context.openImplicits.tail.isEmpty && !pt.isErroneous)
+                    DivergingImplicitExpansionError(tree, pt, info.sym)(context)
+                  result
+                } else context.defineByNameImplicit(dropByName(pt), result)
+              } finally {
+                context.openImplicits = context.openImplicits.tail
+              }
+          }
+        }
+      }
     }
 
     /** Does type `tp` match expected type `pt`
@@ -619,7 +688,7 @@ trait Implicits {
         case NullaryMethodType(restpe)  => loop(restpe, pt)
         case PolyType(_, restpe)        => loop(restpe, pt)
         case ExistentialType(_, qtpe)   => if (fast) loop(qtpe, pt) else normalize(tp) <:< pt // is !fast case needed??
-        case _                          => if (fast) isPlausiblySubType(tp, pt) else tp <:< pt
+        case _                          => if (fast) isPlausiblySubType(tp, if(isView) pt else dropByName(pt)) else tp <:< dropByName(pt)
       }
       loop(tp0, pt0)
     }
@@ -646,7 +715,7 @@ trait Implicits {
             val impossible = if ((sym1 eq sym2) && (args1 ne Nil)) !corresponds3(sym1.typeParams, args1, args2) {(tparam, arg1, arg2) =>
               if (tparam.isCovariant) isPlausiblySubType(arg1, arg2) else isPlausiblySubType(arg2, arg1)
             } else {
-              ((sym1 eq ByNameParamClass) != (sym2 eq ByNameParamClass)) || (sym2.isClass && !(sym1 isWeakSubClass sym2))
+              (sym2.isClass && !(sym1 isWeakSubClass sym2))
             }
             impossible
           case RefinedType(parents, decls) =>
@@ -689,7 +758,7 @@ trait Implicits {
       typingLog("considering", typeDebug.ptTree(itree1))
 
       @inline def fail(reason: => String): SearchResult = failure(itree0, reason)
-      def fallback = typed1(itree1, EXPRmode, wildPt)
+      def fallback = typed1(itree1, EXPRmode, dropByName(wildPt))
       try {
         val itree2 = if (!isView) fallback else pt match {
           case Function1(arg1, arg2) =>
@@ -727,7 +796,7 @@ trait Implicits {
         if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(typedImplicits)
 
         val itree3 = if (isView) treeInfo.dissectApplied(itree2).callee
-                     else adapt(itree2, EXPRmode, wildPt)
+                     else adapt(itree2, EXPRmode, dropByName(wildPt))
 
         typingStack.showAdapt(itree0, itree3, pt, context)
 

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1133,7 +1133,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
       val applicableViews: List[SearchResult] =
         if (ownerTpe.isErroneous) List()
         else new ImplicitSearch(
-          tree, functionType(List(ownerTpe), AnyTpe), isView = true,
+          tree, functionType(List(ownerTpe), AnyTpe), isView = true, isByNamePt = false,
           context0 = context.makeImplicit(reportAmbiguousErrors = false)).allImplicits
       for (view <- applicableViews) {
         val vtree = viewApply(view)

--- a/test/files/neg/byname-implicits-11.check
+++ b/test/files/neg/byname-implicits-11.check
@@ -1,0 +1,5 @@
+byname-implicits-11.scala:8: error: diverging implicit expansion for type Foo[Int]
+starting with method foo in object Foo
+  implicitly[Foo[Int]]
+            ^
+one error found

--- a/test/files/neg/byname-implicits-11.scala
+++ b/test/files/neg/byname-implicits-11.scala
@@ -1,0 +1,9 @@
+trait Foo[T]
+
+object Foo {
+  implicit def foo[T](implicit fooFoo: => Foo[Foo[T]]): Foo[T] = ???
+}
+
+object Test {
+  implicitly[Foo[Int]]
+}

--- a/test/files/neg/byname-implicits-16.check
+++ b/test/files/neg/byname-implicits-16.check
@@ -1,0 +1,5 @@
+byname-implicits-16.scala:14: error: diverging implicit expansion for type Test.O[Test.Z]
+starting with method expande in object Expand
+  implicitly[O[Z]]
+            ^
+one error found

--- a/test/files/neg/byname-implicits-16.scala
+++ b/test/files/neg/byname-implicits-16.scala
@@ -1,0 +1,15 @@
+object Test {
+  class Z
+  class O[T]
+  class E[T]
+
+  class Expand[T, U]
+  object Expand {
+    implicit def expando[T]: Expand[O[T], E[O[T]]] = ???
+    implicit def expande[T]: Expand[E[T], O[E[T]]] = ???
+  }
+
+  implicit def mkN[T, U](implicit e: => Expand[T, U], u: => U): T = ???
+
+  implicitly[O[Z]]
+}

--- a/test/files/neg/byname-implicits-18.check
+++ b/test/files/neg/byname-implicits-18.check
@@ -1,0 +1,5 @@
+byname-implicits-18.scala:52: error: diverging implicit expansion for type Test.Tc[Test.Bootstrap[Int]]
+starting with method tcGen in object Tc
+  implicitly[Tc[Bootstrap[Int]]]
+            ^
+one error found

--- a/test/files/neg/byname-implicits-18.scala
+++ b/test/files/neg/byname-implicits-18.scala
@@ -1,0 +1,53 @@
+/*
+ * Demo of using by name implicits to resolve (hidden) divergence issues when
+ * traversing recursive generic structures.
+ *
+ * See http://stackoverflow.com/questions/25923974
+ */
+sealed trait HList
+object HList {
+  implicit class Syntax[L <: HList](l: L) {
+    def ::[U](u: U): U :: L = new ::(u, l)
+  }
+}
+
+sealed trait HNil extends HList
+object HNil extends HNil
+case class ::[+H, +T <: HList](head : H, tail : T) extends HList
+
+trait Generic[T] {
+  type Repr
+  def to(t: T): Repr
+  def from(r: Repr): T
+}
+
+object Generic {
+  type Aux[T, Repr0] = Generic[T] { type Repr = Repr0 }
+}
+
+object Test extends App {
+  case class Bootstrap[+A](head: A, tail: Option[Bootstrap[(A, A)]])
+  object Bootstrap {
+    type BootstrapRepr[+A] = A :: Option[Bootstrap[(A, A)]] :: HNil
+    implicit def bootstrapGen[A]: Generic.Aux[Bootstrap[A], BootstrapRepr[A]] =
+      new Generic[Bootstrap[A]] {
+        type Repr = BootstrapRepr[A]
+        def to(t: Bootstrap[A]): Repr = t.head :: t.tail :: HNil
+        def from(r: Repr): Bootstrap[A] = Bootstrap(r.head, r.tail.head)
+      }
+  }
+
+  class Tc[A]
+  object Tc {
+    implicit val tcInt: Tc[Int] = new Tc
+    implicit def tcOpt[A: Tc]: Tc[Option[A]] = new Tc
+    implicit def tcTuple[A: Tc, B: Tc]: Tc[(A, B)] = new Tc
+    implicit val tcHNil: Tc[HNil] = new Tc
+    implicit def tcHCons[H: Tc, T <: HList: Tc]: Tc[H :: T] = new Tc
+    implicit def tcGen[A, R <: HList](
+      implicit gen: Generic.Aux[A, R], tcR: => Tc[R]
+    ): Tc[A] = new Tc
+  }
+
+  implicitly[Tc[Bootstrap[Int]]]
+}

--- a/test/files/neg/byname-implicits-21.check
+++ b/test/files/neg/byname-implicits-21.check
@@ -1,0 +1,5 @@
+byname-implicits-21.scala:20: error: diverging implicit expansion for type Test.Foo[Test.A[Unit]]
+starting with method fooGen in object Foo
+  implicitly[Foo[A[Unit]]]
+            ^
+one error found

--- a/test/files/neg/byname-implicits-21.scala
+++ b/test/files/neg/byname-implicits-21.scala
@@ -1,0 +1,21 @@
+object Test {
+  trait Generic[T] {
+    type Repr
+  }
+  object Generic {
+    type Aux[T, R] = Generic[T] { type Repr = R }
+  }
+
+  trait Foo[T]
+  object Foo {
+    implicit def fooOption[T](implicit fooT: Foo[T]): Foo[Option[T]] = ???
+    implicit def fooGen[T, R](implicit gen: Generic.Aux[T, R], fr: => Foo[R]): Foo[T] = ???
+  }
+
+  trait A[T]
+  object A {
+    implicit def genA[T]: Generic[A[T]] { type Repr = Option[A[A[T]]] } = ???
+  }
+
+  implicitly[Foo[A[Unit]]]
+}

--- a/test/files/neg/byname-implicits-26.check
+++ b/test/files/neg/byname-implicits-26.check
@@ -1,0 +1,5 @@
+byname-implicits-26.scala:34: error: diverging implicit expansion for type Test.Foo[Test.A]
+starting with method fooGen in object Foo
+  implicitly[Foo[A]]
+            ^
+one error found

--- a/test/files/neg/byname-implicits-26.scala
+++ b/test/files/neg/byname-implicits-26.scala
@@ -1,0 +1,35 @@
+object Test {
+  trait Generic[T] {
+    type Repr
+  }
+  object Generic {
+    type Aux[T, R] = Generic[T] { type Repr = R }
+  }
+
+  trait GNil
+
+  trait Foo[T]
+  object Foo {
+    implicit val fooUnit: Foo[Unit] = ???
+    implicit val fooInt: Foo[Int] = ???
+    implicit def fooPair[T, U](implicit fooT: Foo[T], fooU: Foo[U]): Foo[(T, U)] = ???
+    implicit def fooGen[T, R](implicit gen: Generic.Aux[T, R], fr: Foo[R]): Foo[T] = ???
+  }
+
+  case class A(b: B, c: C, i: Int)
+  object A {
+    implicit val genA: Generic[A] { type Repr = (B, (C, (Int, Unit))) } = ???
+  }
+
+  case class B(c0: C, c1: C, c2: C, i: Int)
+  object B {
+    implicit val genB: Generic[B] { type Repr = (C, (C, (C, (Int, Unit)))) } = ???
+  }
+
+  case class C(b: A, i: Int)
+  object C {
+    implicit val genC: Generic[C] { type Repr = (A, (Int, Unit)) } = ???
+  }
+
+  implicitly[Foo[A]]
+}

--- a/test/files/neg/implicit-log.check
+++ b/test/files/neg/implicit-log.check
@@ -2,6 +2,10 @@ implicit-log.scala:61: byVal is not a valid implicit value for Int(7) => ?{def u
 incompatible: (x: 7)7 does not match expected type Int(7) => ?{def unwrap: ?}
     val res = 7.unwrap() // doesn't work
               ^
+implicit-log.scala:61: byVal is not a valid implicit value for (=> Int(7)) => ?{def unwrap: ?} because:
+incompatible: (x: 7)7 does not match expected type (=> Int(7)) => ?{def unwrap: ?}
+    val res = 7.unwrap() // doesn't work
+              ^
 implicit-log.scala:70: materializing requested scala.reflect.type.ClassTag[String] using scala.reflect.`package`.materializeClassTag[String]()
   val x: java.util.List[String] = List("foo")
                                       ^

--- a/test/files/pos/byname-implicits-1.scala
+++ b/test/files/pos/byname-implicits-1.scala
@@ -1,0 +1,8 @@
+trait Foo
+object Foo {
+  implicit def foo(implicit rec: => Foo): Foo = ???
+}
+
+object Test {
+  implicitly[Foo]
+}

--- a/test/files/pos/byname-implicits-10.scala
+++ b/test/files/pos/byname-implicits-10.scala
@@ -1,0 +1,11 @@
+trait Foo[T]
+
+object Foo {
+  implicit def pair[T, U](implicit fooT: => Foo[(T, U)], fooU: => Foo[(U, T)]): Foo[(T, U)] = new Foo[(T, U)] {}
+  implicit def int: Foo[Int] = new Foo[Int] {}
+  implicit def string: Foo[String] = new Foo[String] {}
+}
+
+object Test {
+  implicitly[Foo[(Int, String)]]
+}

--- a/test/files/pos/byname-implicits-12.scala
+++ b/test/files/pos/byname-implicits-12.scala
@@ -1,0 +1,15 @@
+trait Foo[T]
+object Foo {
+  implicit def unit: Foo[Unit] = ???
+  implicit def int: Foo[Int] = ???
+  implicit def pair[T, U](implicit ft: Foo[T], fu: Foo[U]): Foo[(T, U)] = ???
+}
+
+class Bar
+object Bar {
+  implicit def bar(implicit f: => Foo[(Int, (Int, Unit))]): Foo[Bar] = ???
+}
+
+object Test {
+  implicitly[Foo[(Bar, Unit)]]
+}

--- a/test/files/pos/byname-implicits-13.scala
+++ b/test/files/pos/byname-implicits-13.scala
@@ -1,0 +1,192 @@
+// deriving/src/main/scala/by-name-implicit-test.scala.scala
+sealed trait AABB
+case class AA(a: String) extends AABB
+case class BB(a: String) extends AABB
+case class DAABB(d: Double, aabb: AABB)
+case class IDAABBS(i: Int, daabb: DAABB, s: String)
+
+case class Dog(age: Long)
+case class Cat(name: String, friend: Either[Cat, Dog])
+
+// Definitions from Shapeless ---------------------------------------------------------------------
+
+sealed trait HList extends Product with Serializable
+final case class ::[+H, +T <: HList](head: H, tail: T) extends HList
+sealed trait HNil extends HList
+final case object HNil extends HNil
+
+sealed trait Coproduct extends Product with Serializable
+sealed trait :+:[+H, +T <: Coproduct] extends Coproduct
+final case class Inl[+H, +T <: Coproduct](head: H) extends :+:[H, T]
+final case class Inr[+H, +T <: Coproduct](tail: T) extends :+:[H, T]
+sealed trait CNil extends Coproduct
+
+trait Generic[T] {
+  type Repr
+  def to(t: T): Repr
+  def from(r: Repr): T
+}
+
+// Manual Generic macro expansions ----------------------------------------------------------------
+
+object GenericInstances {
+  implicit val genAABB: Generic[AABB] { type Repr = AA :+: BB :+: CNil } =
+    new Generic[AABB] {
+      type Repr = AA :+: BB :+: CNil
+      def to(t: AABB): Repr = t match {
+        case x: AA => Inl(x)
+        case x: BB => Inr(Inl(x))
+      }
+      def from(r: Repr): AABB = r match {
+        case Inl(x) => x
+        case Inr(Inl(x)) => x
+        case _ => ???
+      }
+    }
+
+  implicit val genAA: Generic[AA] { type Repr = String :: HNil } =
+    new Generic[AA] {
+      type Repr = String :: HNil
+      def to(t: AA): Repr = t match { case AA(x) => ::(x, HNil) }
+      def from(r: Repr): AA = r match { case ::(x, HNil) => AA(x) }
+    }
+
+  implicit val genBB: Generic[BB] { type Repr = String :: HNil } =
+    new Generic[BB] {
+      type Repr = String :: HNil
+      def to(t: BB): Repr = t match { case BB(x) => ::(x, HNil) }
+      def from(r: Repr): BB = r match { case ::(x, HNil) => BB(x) }
+    }
+
+  implicit val genDAABB: Generic[DAABB] { type Repr = Double :: AABB :: HNil } =
+    new Generic[DAABB] {
+      type Repr = Double :: AABB :: HNil
+      def to(t: DAABB): Repr = t match { case DAABB(x, y) => ::(x, ::(y, HNil)) }
+      def from(r: Repr): DAABB = r match { case ::(x, ::(y, HNil)) => DAABB(x, y) }
+    }
+
+  implicit val genIDAABBS: Generic[IDAABBS] { type Repr = Int :: DAABB :: String :: HNil } =
+    new Generic[IDAABBS] {
+      type Repr = Int :: DAABB :: String :: HNil
+      def to(t: IDAABBS): Repr = t match { case IDAABBS(x, y, z) => ::(x, ::(y, ::(z, HNil))) }
+      def from(r: Repr): IDAABBS = r match { case ::(x, ::(y, ::(z, HNil))) => IDAABBS(x, y, z) }
+    }
+
+  implicit val genDog: Generic[Dog] { type Repr = Long :: HNil } =
+    new Generic[Dog] {
+      type Repr = Long :: HNil
+      def to(t: Dog): Repr = t match { case Dog(x) => ::(x, HNil) }
+      def from(r: Repr): Dog = r match { case ::(x, HNil) => Dog(x) }
+    }
+
+  implicit val genCat: Generic[Cat] { type Repr = String :: Either[Cat, Dog] :: HNil } =
+    new Generic[Cat] {
+      type Repr = String :: Either[Cat, Dog] :: HNil
+      def to(t: Cat): Repr = t match { case Cat(x, y) => ::(x, ::(y, HNil)) }
+      def from(r: Repr): Cat = r match { case ::(x, ::(y, HNil)) => Cat(x, y) }
+    }
+
+  implicit def genEither[A, B]: Generic[Either[A, B]] { type Repr = Left[A, B] :+: Right[A, B] :+: CNil } =
+    new Generic[Either[A, B]] {
+      type Repr = Left[A, B] :+: Right[A, B] :+: CNil
+      def to(t: Either[A, B]): Repr = t match {
+        case (x: Left[A, B]  @unchecked) => Inl(x)
+        case (x: Right[A, B] @unchecked) => Inr(Inl(x))
+      }
+      def from(r: Repr): Either[A, B] = r match {
+        case Inl(x) => x
+        case Inr(Inl(x)) => x
+        case _ => ???
+      }
+    }
+
+  implicit def genLeft[A, B]: Generic[Left[A, B]] { type Repr = A :: HNil } =
+    new Generic[Left[A, B]] {
+      type Repr = A :: HNil
+      def to(t: Left[A, B]): Repr = t match { case Left(x) => ::(x, HNil) }
+      def from(r: Repr): Left[A, B] = r match { case ::(x, HNil) => Left(x) }
+    }
+
+  implicit def genRight[A, B]: Generic[Right[A, B]] { type Repr = B :: HNil } =
+    new Generic[Right[A, B]] {
+      type Repr = B :: HNil
+      def to(t: Right[A, B]): Repr = t match { case Right(x) => ::(x, HNil) }
+      def from(r: Repr): Right[A, B] = r match { case ::(x, HNil) => Right(x) }
+    }
+}
+
+// First example from https://github.com/milessabin/shapeless-type-class-derivation-2015-demo
+object equal {
+  trait Eq[T] {
+    def eqv(x: T, y: T): Boolean
+  }
+
+  object Eq {
+    implicit val eqInt: Eq[Int] =
+      new Eq[Int] {
+        def eqv(x: Int, y: Int): Boolean = x == y
+      }
+
+    implicit val eqString: Eq[String] =
+      new Eq[String] {
+        def eqv(x: String, y: String): Boolean = x == y
+      }
+
+    implicit def eqGeneric[T, R]
+      (implicit
+        gen: Generic[T] { type Repr = R },
+        eqRepr: => Eq[R]
+      ): Eq[T] =
+        new Eq[T] {
+          def eqv(x: T, y: T): Boolean =
+            eqRepr.eqv(gen.to(x), gen.to(y))
+        }
+
+    implicit val eqHNil: Eq[HNil] = new Eq[HNil] {
+      def eqv(x: HNil, y: HNil): Boolean = true
+    }
+
+    implicit def eqHCons[H, T <: HList]
+      (implicit
+        eqH: Eq[H],
+        eqT: Eq[T]
+      ): Eq[H :: T] =
+        new Eq[H :: T] {
+          def eqv(x: H :: T, y: H :: T): Boolean =
+            eqH.eqv(x.head, y.head) && eqT.eqv(x.tail, y.tail)
+        }
+
+    implicit val eqCNil: Eq[CNil] = new Eq[CNil] {
+      def eqv(x: CNil, y: CNil): Boolean = true
+    }
+
+    implicit def eqCNCons[H, T <: Coproduct]
+      (implicit
+        eqH: Eq[H],
+        eqT: Eq[T]
+      ): Eq[H :+: T] =
+        new Eq[H :+: T] {
+          def eqv(x: H :+: T, y: H :+: T): Boolean =
+            (x, y) match {
+              case (Inl(xh), Inl(yh)) => eqH.eqv(xh, yh)
+              case (Inr(xt), Inr(yt)) => eqT.eqv(xt, yt)
+              case _ => false
+            }
+        }
+  }
+
+  implicit class EqOps[T](x: T)(implicit eqT: Eq[T]) {
+    def ===(y: T): Boolean = eqT.eqv(x, y)
+  }
+
+  import GenericInstances._
+
+  implicit val EqLongInstance:   Eq[Long]   = new Eq[Long]   { def eqv(x: Long, y: Long):     Boolean = x == y }
+  implicit val EqDoubleInstance: Eq[Double] = new Eq[Double] { def eqv(x: Double, y: Double): Boolean = x == y }
+  implicit val EqIntInstance:    Eq[Int]    = new Eq[Int]    { def eqv(x: Int, y: Int):       Boolean = x == y }
+  implicit val EqStringInstance: Eq[String] = new Eq[String] { def eqv(x: String, y: String): Boolean = x == y }
+
+  implicitly[Eq[Dog]]
+  implicitly[Eq[Cat]]
+  implicitly[Eq[IDAABBS]]
+}

--- a/test/files/pos/byname-implicits-14.scala
+++ b/test/files/pos/byname-implicits-14.scala
@@ -1,0 +1,192 @@
+// deriving/src/main/scala/by-name-implicit-test.scala.scala
+sealed trait AABB
+case class AA(a: String) extends AABB
+case class BB(a: String) extends AABB
+case class DAABB(d: Double, aabb: AABB)
+case class IDAABBS(i: Int, daabb: DAABB, s: String)
+
+case class Dog(age: Long)
+case class Cat(name: String, friend: Either[Cat, Dog])
+
+// Definitions from Shapeless ---------------------------------------------------------------------
+
+sealed trait HList extends Product with Serializable
+final case class ::[+H, +T <: HList](head: H, tail: T) extends HList
+sealed trait HNil extends HList
+final case object HNil extends HNil
+
+sealed trait Coproduct extends Product with Serializable
+sealed trait :+:[+H, +T <: Coproduct] extends Coproduct
+final case class Inl[+H, +T <: Coproduct](head: H) extends :+:[H, T]
+final case class Inr[+H, +T <: Coproduct](tail: T) extends :+:[H, T]
+sealed trait CNil extends Coproduct
+
+trait Generic[T] {
+  type Repr
+  def to(t: T): Repr
+  def from(r: Repr): T
+}
+
+// Manual Generic macro expansions ----------------------------------------------------------------
+
+object GenericInstances {
+  implicit val genAABB: Generic[AABB] { type Repr = AA :+: BB :+: CNil } =
+    new Generic[AABB] {
+      type Repr = AA :+: BB :+: CNil
+      def to(t: AABB): Repr = t match {
+        case x: AA => Inl(x)
+        case x: BB => Inr(Inl(x))
+      }
+      def from(r: Repr): AABB = r match {
+        case Inl(x) => x
+        case Inr(Inl(x)) => x
+        case _ => ???
+      }
+    }
+
+  implicit val genAA: Generic[AA] { type Repr = String :: HNil } =
+    new Generic[AA] {
+      type Repr = String :: HNil
+      def to(t: AA): Repr = t match { case AA(x) => ::(x, HNil) }
+      def from(r: Repr): AA = r match { case ::(x, HNil) => AA(x) }
+    }
+
+  implicit val genBB: Generic[BB] { type Repr = String :: HNil } =
+    new Generic[BB] {
+      type Repr = String :: HNil
+      def to(t: BB): Repr = t match { case BB(x) => ::(x, HNil) }
+      def from(r: Repr): BB = r match { case ::(x, HNil) => BB(x) }
+    }
+
+  implicit val genDAABB: Generic[DAABB] { type Repr = Double :: AABB :: HNil } =
+    new Generic[DAABB] {
+      type Repr = Double :: AABB :: HNil
+      def to(t: DAABB): Repr = t match { case DAABB(x, y) => ::(x, ::(y, HNil)) }
+      def from(r: Repr): DAABB = r match { case ::(x, ::(y, HNil)) => DAABB(x, y) }
+    }
+
+  implicit val genIDAABBS: Generic[IDAABBS] { type Repr = Int :: DAABB :: String :: HNil } =
+    new Generic[IDAABBS] {
+      type Repr = Int :: DAABB :: String :: HNil
+      def to(t: IDAABBS): Repr = t match { case IDAABBS(x, y, z) => ::(x, ::(y, ::(z, HNil))) }
+      def from(r: Repr): IDAABBS = r match { case ::(x, ::(y, ::(z, HNil))) => IDAABBS(x, y, z) }
+    }
+
+  implicit val genDog: Generic[Dog] { type Repr = Long :: HNil } =
+    new Generic[Dog] {
+      type Repr = Long :: HNil
+      def to(t: Dog): Repr = t match { case Dog(x) => ::(x, HNil) }
+      def from(r: Repr): Dog = r match { case ::(x, HNil) => Dog(x) }
+    }
+
+  implicit val genCat: Generic[Cat] { type Repr = String :: Either[Cat, Dog] :: HNil } =
+    new Generic[Cat] {
+      type Repr = String :: Either[Cat, Dog] :: HNil
+      def to(t: Cat): Repr = t match { case Cat(x, y) => ::(x, ::(y, HNil)) }
+      def from(r: Repr): Cat = r match { case ::(x, ::(y, HNil)) => Cat(x, y) }
+    }
+
+  implicit def genEither[A, B]: Generic[Either[A, B]] { type Repr = Left[A, B] :+: Right[A, B] :+: CNil } =
+    new Generic[Either[A, B]] {
+      type Repr = Left[A, B] :+: Right[A, B] :+: CNil
+      def to(t: Either[A, B]): Repr = t match {
+        case (x: Left[A, B]  @unchecked) => Inl(x)
+        case (x: Right[A, B] @unchecked) => Inr(Inl(x))
+      }
+      def from(r: Repr): Either[A, B] = r match {
+        case Inl(x) => x
+        case Inr(Inl(x)) => x
+        case _ => ???
+      }
+    }
+
+  implicit def genLeft[A, B]: Generic[Left[A, B]] { type Repr = A :: HNil } =
+    new Generic[Left[A, B]] {
+      type Repr = A :: HNil
+      def to(t: Left[A, B]): Repr = t match { case Left(x) => ::(x, HNil) }
+      def from(r: Repr): Left[A, B] = r match { case ::(x, HNil) => Left(x) }
+    }
+
+  implicit def genRight[A, B]: Generic[Right[A, B]] { type Repr = B :: HNil } =
+    new Generic[Right[A, B]] {
+      type Repr = B :: HNil
+      def to(t: Right[A, B]): Repr = t match { case Right(x) => ::(x, HNil) }
+      def from(r: Repr): Right[A, B] = r match { case ::(x, HNil) => Right(x) }
+    }
+}
+
+// First example from https://github.com/milessabin/shapeless-type-class-derivation-2015-demo
+object equal {
+  trait Eq[T] {
+    def eqv(x: T, y: T): Boolean
+  }
+
+  object Eq {
+    implicit val eqInt: Eq[Int] =
+      new Eq[Int] {
+        def eqv(x: Int, y: Int): Boolean = x == y
+      }
+
+    implicit val eqString: Eq[String] =
+      new Eq[String] {
+        def eqv(x: String, y: String): Boolean = x == y
+      }
+
+    implicit def eqGeneric[T, R]
+      (implicit
+        gen: Generic[T] { type Repr = R },
+        eqRepr: => Eq[R]
+      ): Eq[T] =
+        new Eq[T] {
+          def eqv(x: T, y: T): Boolean =
+            eqRepr.eqv(gen.to(x), gen.to(y))
+        }
+
+    implicit val eqHNil: Eq[HNil] = new Eq[HNil] {
+      def eqv(x: HNil, y: HNil): Boolean = true
+    }
+
+    implicit def eqHCons[H, T <: HList]
+      (implicit
+        eqH: => Eq[H],
+        eqT: => Eq[T]
+      ): Eq[H :: T] =
+        new Eq[H :: T] {
+          def eqv(x: H :: T, y: H :: T): Boolean =
+            eqH.eqv(x.head, y.head) && eqT.eqv(x.tail, y.tail)
+        }
+
+    implicit val eqCNil: Eq[CNil] = new Eq[CNil] {
+      def eqv(x: CNil, y: CNil): Boolean = true
+    }
+
+    implicit def eqCNCons[H, T <: Coproduct]
+      (implicit
+        eqH: => Eq[H],
+        eqT: => Eq[T]
+      ): Eq[H :+: T] =
+        new Eq[H :+: T] {
+          def eqv(x: H :+: T, y: H :+: T): Boolean =
+            (x, y) match {
+              case (Inl(xh), Inl(yh)) => eqH.eqv(xh, yh)
+              case (Inr(xt), Inr(yt)) => eqT.eqv(xt, yt)
+              case _ => false
+            }
+        }
+  }
+
+  implicit class EqOps[T](x: T)(implicit eqT: Eq[T]) {
+    def ===(y: T): Boolean = eqT.eqv(x, y)
+  }
+
+  import GenericInstances._
+
+  implicit val EqLongInstance:   Eq[Long]   = new Eq[Long]   { def eqv(x: Long, y: Long):     Boolean = x == y }
+  implicit val EqDoubleInstance: Eq[Double] = new Eq[Double] { def eqv(x: Double, y: Double): Boolean = x == y }
+  implicit val EqIntInstance:    Eq[Int]    = new Eq[Int]    { def eqv(x: Int, y: Int):       Boolean = x == y }
+  implicit val EqStringInstance: Eq[String] = new Eq[String] { def eqv(x: String, y: String): Boolean = x == y }
+
+  implicitly[Eq[Dog]]
+  implicitly[Eq[Cat]]
+  implicitly[Eq[IDAABBS]]
+}

--- a/test/files/pos/byname-implicits-15.scala
+++ b/test/files/pos/byname-implicits-15.scala
@@ -1,0 +1,27 @@
+object Test {
+  trait Generic[T] {
+    type Repr
+  }
+
+  object Generic {
+    type Aux[T, R] = Generic[T] { type Repr = R }
+    implicit def genTuple3[T, U, V]: Aux[(T, U, V), (T, (U, (V, Unit)))] = ???
+    implicit def genTuple5[T, U, V, W, X]: Aux[(T, U, V, W, X), (T, (U, (V, (W, (X, Unit)))))] = ???
+  }
+
+  trait Show[T]
+  object Show {
+    implicit val showUnit: Show[Unit] = ???
+    implicit val showInt: Show[Int] = ???
+    implicit def showPair[T, U](implicit st: Show[T], su: Show[U]): Show[(T, U)] = ???
+    implicit def showGen[T, R](implicit gen: Generic.Aux[T, R], sr: => Show[R]): Show[T] = ???
+  }
+
+  type I5 = (Int, Int, Int, Int, Int)
+
+  // Demonstrates that the bynamity of sr suppresses the false positive divergence test
+  // which would otherwise see 5 nested pairs dominating 3 nested pairs.
+  implicitly[Show[(I5, I5, I5)]]
+  implicitly[Show[(Int, I5, Int)]]
+  implicitly[Show[(I5, (I5, I5, I5), Int)]]
+}

--- a/test/files/pos/byname-implicits-19.scala
+++ b/test/files/pos/byname-implicits-19.scala
@@ -1,0 +1,42 @@
+object Test {
+  class A
+  class B
+  class C
+  class D
+
+  {
+    implicit def parentA(implicit arg: => B): A = ???
+    implicit def parentB(implicit arg: C): B = ???
+    implicit def parentC(implicit arg: D): C = ???
+    implicit def parentD(implicit arg: A): D = ???
+
+    implicitly[A]
+  }
+
+  {
+    implicit def parentA(implicit arg: B): A = ???
+    implicit def parentB(implicit arg: => C): B = ???
+    implicit def parentC(implicit arg: D): C = ???
+    implicit def parentD(implicit arg: A): D = ???
+
+    implicitly[A]
+  }
+
+  {
+    implicit def parentA(implicit arg: B): A = ???
+    implicit def parentB(implicit arg: C): B = ???
+    implicit def parentC(implicit arg: => D): C = ???
+    implicit def parentD(implicit arg: A): D = ???
+
+    implicitly[A]
+  }
+
+  {
+    implicit def parentA(implicit arg: B): A = ???
+    implicit def parentB(implicit arg: C): B = ???
+    implicit def parentC(implicit arg: D): C = ???
+    implicit def parentD(implicit arg: => A): D = ???
+
+    implicitly[A]
+  }
+}

--- a/test/files/pos/byname-implicits-2.scala
+++ b/test/files/pos/byname-implicits-2.scala
@@ -1,0 +1,25 @@
+trait Foo[T]
+object Foo {
+  implicit val fooInt: Foo[Int] = ???
+  implicit def fooPair[H, T](implicit h: Foo[H], t: Foo[T]): Foo[(H, T)] = ???
+}
+
+trait Bar
+object Bar {
+  implicit def fooBar(implicit repr: => Foo[(Int, (Int, Int))]): Foo[Bar] = ???
+}
+
+trait Baz
+object Baz {
+  implicit def fooBaz(implicit i: Foo[Int], rec: => Foo[Baz]): Foo[Baz] = ???
+}
+
+object Test {
+  implicitly[Foo[Int]]
+  implicitly[Foo[(Int, Int)]]
+  implicitly[Foo[(Int, (Int, Int))]]
+  implicitly[Foo[(Int, (Int, (Int, Int)))]]
+  implicitly[Foo[Bar]]
+  implicitly[Foo[(Int, Bar)]]
+  implicitly[Foo[Baz]]
+}

--- a/test/files/pos/byname-implicits-20.scala
+++ b/test/files/pos/byname-implicits-20.scala
@@ -1,0 +1,28 @@
+object Test {
+  trait Generic[T] {
+    type Repr
+  }
+  object Generic {
+    type Aux[T, R] = Generic[T] { type Repr = R }
+  }
+
+  trait Foo[T]
+  object Foo {
+    implicit val fooUnit: Foo[Unit] = ???
+    implicit val fooInt: Foo[Int] = ???
+    implicit def fooPair[T, U](implicit fooT: Foo[T], fooU: Foo[U]): Foo[(T, U)] = ???
+    implicit def fooGen[T, R](implicit gen: Generic.Aux[T, R], fr: => Foo[R]): Foo[T] = ???
+  }
+
+  trait A
+  object A {
+    implicit val genA: Generic[A] { type Repr = (B, Unit) } = ???
+  }
+
+  trait B
+  object B {
+    implicit val genB: Generic[B] { type Repr = (Int, (Int, Unit)) } = ???
+  }
+
+  implicitly[Foo[A]]
+}

--- a/test/files/pos/byname-implicits-22.scala
+++ b/test/files/pos/byname-implicits-22.scala
@@ -1,0 +1,44 @@
+object repro {
+  import scala.reflect.runtime.universe._
+
+  trait +[L, R]
+
+  case class Atomic[V](val name: String)
+  object Atomic {
+    def apply[V](implicit vtt: TypeTag[V]): Atomic[V] = Atomic[V](vtt.tpe.typeSymbol.name.toString)
+  }
+
+  case class Assign[V, X](val name: String)
+  object Assign {
+    def apply[V, X](implicit vtt: TypeTag[V]): Assign[V, X] = Assign[V, X](vtt.tpe.typeSymbol.name.toString)
+  }
+
+  trait AsString[X] {
+    def str: String
+  }
+  object AsString {
+    implicit def atomic[V](implicit a: Atomic[V]): AsString[V] =
+      new AsString[V] { val str = a.name }
+    implicit def assign[V, X](implicit a: Assign[V, X], asx: AsString[X]): AsString[V] =
+      new AsString[V] { val str = asx.str }
+    implicit def plus[L, R](implicit asl: AsString[L], asr: AsString[R]): AsString[+[L, R]] =
+      new AsString[+[L, R]] { val str = s"(${asl.str}) + (${asr.str})" }
+  }
+
+  trait X
+  implicit val declareX = Atomic[X]
+  trait Y
+  implicit val declareY = Atomic[Y]
+  trait Z
+  implicit val declareZ = Atomic[Z]
+
+  trait Q
+  implicit val declareQ = Assign[Q, (X + Y) + Z]
+  trait R
+  implicit val declareR = Assign[R, Q + Z]
+
+  implicitly[AsString[X]]
+  implicitly[AsString[X + Y]]
+  implicitly[AsString[Q]]
+  implicitly[AsString[R]]
+}

--- a/test/files/pos/byname-implicits-23.scala
+++ b/test/files/pos/byname-implicits-23.scala
@@ -1,0 +1,30 @@
+object Test {
+  trait Generic[T] {
+    type Repr
+  }
+  object Generic {
+    type Aux[T, R] = Generic[T] { type Repr = R }
+  }
+
+  trait GNil
+
+  trait Foo[T]
+  object Foo {
+    implicit val fooUnit: Foo[Unit] = ???
+    implicit val fooInt: Foo[Int] = ???
+    implicit def fooPair[T, U](implicit fooT: Foo[T], fooU: Foo[U]): Foo[(T, U)] = ???
+    implicit def fooGen[T, R](implicit gen: Generic.Aux[T, R], fr: Foo[R]): Foo[T] = ???
+  }
+
+  trait A
+  object A {
+    implicit val genA: Generic[A] { type Repr = (B, (Int, Unit)) } = ???
+  }
+
+  trait B
+  object B {
+    implicit val genB: Generic[B] { type Repr = (Int, (Int, (Int, Unit))) } = ???
+  }
+
+  implicitly[Foo[A]]
+}

--- a/test/files/pos/byname-implicits-24.scala
+++ b/test/files/pos/byname-implicits-24.scala
@@ -1,0 +1,30 @@
+object Test {
+  trait Generic[T] {
+    type Repr
+  }
+  object Generic {
+    type Aux[T, R] = Generic[T] { type Repr = R }
+  }
+
+  trait GNil
+
+  trait Foo[T]
+  object Foo {
+    implicit val fooUnit: Foo[Unit] = ???
+    implicit val fooInt: Foo[Int] = ???
+    implicit def fooPair[T, U](implicit fooT: Foo[T], fooU: Foo[U]): Foo[(T, U)] = ???
+    implicit def fooGen[T, R](implicit gen: Generic.Aux[T, R], fr: Foo[R]): Foo[T] = ???
+  }
+
+  trait A
+  object A {
+    implicit val genA: Generic[A] { type Repr = (B, (Unit, Unit)) } = ???
+  }
+
+  trait B
+  object B {
+    implicit val genB: Generic[B] { type Repr = (Unit, (Unit, (Unit, Unit))) } = ???
+  }
+
+  implicitly[Foo[A]]
+}

--- a/test/files/pos/byname-implicits-25.scala
+++ b/test/files/pos/byname-implicits-25.scala
@@ -1,0 +1,35 @@
+object Test {
+  trait Generic[T] {
+    type Repr
+  }
+  object Generic {
+    type Aux[T, R] = Generic[T] { type Repr = R }
+  }
+
+  trait GNil
+
+  trait Foo[T]
+  object Foo {
+    implicit val fooUnit: Foo[Unit] = ???
+    implicit val fooInt: Foo[Int] = ???
+    implicit def fooPair[T, U](implicit fooT: Foo[T], fooU: Foo[U]): Foo[(T, U)] = ???
+    implicit def fooGen[T, R](implicit gen: Generic.Aux[T, R], fr: Foo[R]): Foo[T] = ???
+  }
+
+  case class A(b: B, c: C, i: Int)
+  object A {
+    implicit val genA: Generic[A] { type Repr = (B, (C, (Int, Unit))) } = ???
+  }
+
+  case class B(c0: C, c1: C, c2: C, i: Int)
+  object B {
+    implicit val genB: Generic[B] { type Repr = (C, (C, (C, (Int, Unit)))) } = ???
+  }
+
+  case class C(i0: Int, i1: Int, i2: Int, i3: Int, i4: Int)
+  object C {
+    implicit val genC: Generic[C] { type Repr = (Int, (Int, (Int, (Int, (Int, Unit))))) } = ???
+  }
+
+  implicitly[Foo[A]]
+}

--- a/test/files/pos/byname-implicits-27.scala
+++ b/test/files/pos/byname-implicits-27.scala
@@ -1,0 +1,37 @@
+object Test {
+  trait Generic[T] {
+    type Repr
+  }
+  object Generic {
+    type Aux[T, R] = Generic[T] { type Repr = R }
+  }
+
+  trait GNil
+
+  trait Foo[T]
+  object Foo {
+    implicit val fooUnit: Foo[Unit] = ???
+    implicit val fooInt: Foo[Int] = ???
+    implicit val fooString: Foo[String] = ???
+    implicit val fooBoolean: Foo[Boolean] = ???
+    implicit def fooPair[T, U](implicit fooT: Foo[T], fooU: Foo[U]): Foo[(T, U)] = ???
+    implicit def fooGen[T, R](implicit gen: Generic.Aux[T, R], fr: Foo[R]): Foo[T] = ???
+  }
+
+  case class A(b: B, i: Int)
+  object A {
+    implicit val genA: Generic[A] { type Repr = (B, (Int, Unit)) } = ???
+  }
+
+  case class B(c: C, i: Int, b: Boolean)
+  object B {
+    implicit val genB: Generic[B] { type Repr = (C, (Int, (Boolean, Unit))) } = ???
+  }
+
+  case class C(i: Int, s: String, b: Boolean)
+  object C {
+    implicit val genC: Generic[C] { type Repr = (Int, (String, (Boolean, Unit))) } = ???
+  }
+
+  implicitly[Foo[A]]
+}

--- a/test/files/pos/byname-implicits-3.scala
+++ b/test/files/pos/byname-implicits-3.scala
@@ -1,0 +1,11 @@
+trait Foo[T]
+
+object Foo {
+  implicit val int: Foo[Int] = ???
+  implicit val bool: Foo[Boolean] = ???
+  implicit def pair[T, U](implicit ftu0: => Foo[(T, U)], ftu1: => Foo[(T, U)]): Foo[(T, U)] = ???
+}
+
+object Test {
+  implicitly[Foo[(Int, Boolean)]]
+}

--- a/test/files/pos/byname-implicits-7.scala
+++ b/test/files/pos/byname-implicits-7.scala
@@ -1,0 +1,17 @@
+trait Foo {
+  type Out
+  def out: Out
+}
+
+object Foo {
+  type Aux[Out0] = Foo { type Out = Out0 }
+
+  implicit val fooInt: Aux[Int] = new Foo { type Out = Int ; def out = 23 }
+}
+
+object Test {
+  def bar[T](t: T)(implicit foo: => Foo.Aux[T]): T = foo.out
+
+  val i = bar(13)
+  i: Int
+}

--- a/test/files/pos/byname-implicits-8.scala
+++ b/test/files/pos/byname-implicits-8.scala
@@ -1,0 +1,31 @@
+// shapeless's Lazy implemented in terms of byname implicits
+trait Lazy[T] {
+  val value: T
+}
+
+object Lazy {
+  implicit def apply[T](implicit t: => T): Lazy[T] =
+    new Lazy[T] {
+      lazy val value = t
+    }
+
+  def unapply[T](lt: Lazy[T]): Option[T] = Some(lt.value)
+}
+
+trait Foo {
+  type Out
+  def out: Out
+}
+
+object Foo {
+  type Aux[Out0] = Foo { type Out = Out0 }
+
+  implicit val fooInt: Aux[Int] = new Foo { type Out = Int ; def out = 23 }
+}
+
+object Test {
+  def bar[T](t: T)(implicit foo: Lazy[Foo.Aux[T]]): foo.value.Out = foo.value.out
+
+  val i = bar(13)
+  i: Int
+}

--- a/test/files/pos/byname-implicits-9.scala
+++ b/test/files/pos/byname-implicits-9.scala
@@ -1,0 +1,73 @@
+trait Generic[T] {
+  type Repr
+  def to(t: T): Repr
+  def from(r: Repr): T
+}
+
+object Generic {
+  type Aux[T, Repr0] = Generic[T] { type Repr = Repr0 }
+}
+
+object ListInstances {
+  type LRepr[T] = Either[::[T], Either[Nil.type, Unit]]
+  type CRepr[T] = (T, (List[T], Unit))
+  type NRepr = Unit
+
+  implicit def genList[T]: Generic.Aux[List[T], LRepr[T]] = new Generic[List[T]] {
+    type Repr = LRepr[T]
+    def to(t: List[T]): Repr = t match {
+      case hd :: tl => Left(::(hd, tl))
+      case n@Nil => Right(Left(Nil))
+    }
+    def from(r: Repr): List[T] = r match {
+      case Left(c) => c
+      case Right(Left(n)) => n
+    }
+  }
+
+  implicit def genCons[T]: Generic.Aux[::[T], CRepr[T]] = new Generic[::[T]] {
+    type Repr = CRepr[T]
+    def to(t: ::[T]): Repr = (t.head, (t.tail, ()))
+    def from(r: Repr): ::[T] = ::(r._1, r._2._1)
+  }
+
+  implicit def genNil: Generic.Aux[Nil.type, NRepr] = new Generic[Nil.type] {
+    type Repr = NRepr
+    def to(t: Nil.type): Repr = ()
+    def from(r: Repr): Nil.type = Nil
+  }
+}
+
+trait Show[T] {
+  def show(t: T): String
+}
+
+object Show {
+  implicit def showUnit: Show[Unit] = new Show[Unit] {
+    def show(u: Unit): String = "()"
+  }
+
+  implicit def showInt: Show[Int] = new Show[Int] {
+    def show(i: Int): String = i.toString
+  }
+
+  implicit def showPair[T, U](implicit st: Show[T], su: Show[U]): Show[(T, U)] = new Show[(T, U)] {
+    def show(t: (T, U)): String = s"(${st.show(t._1)}, ${su.show(t._2)}"
+  }
+
+  implicit def showEither[T, U](implicit st: Show[T], su: Show[U]): Show[Either[T, U]] = new Show[Either[T, U]] {
+    def show(t: Either[T, U]): String = t match {
+      case Left(t) => s"Left(${st.show(t)})"
+      case Right(u) => s"Right(${su.show(u)})"
+    }
+  }
+
+  implicit def showGen[T, R](implicit gen: Generic.Aux[T, R], sr: => Show[R]): Show[T] = new Show[T] {
+    def show(t: T) = sr.show(gen.to(t))
+  }
+}
+
+object Test {
+  import ListInstances._
+  implicitly[Show[List[Int]]]
+}

--- a/test/files/run/byname-implicits-17.scala
+++ b/test/files/run/byname-implicits-17.scala
@@ -1,0 +1,76 @@
+trait Generic[T] {
+  type Repr
+  def to(t: T): Repr
+  def from(r: Repr): T
+}
+
+object Generic {
+  type Aux[T, Repr0] = Generic[T] { type Repr = Repr0 }
+}
+
+object ListInstances {
+  type LRepr[T] = Either[::[T], Either[Nil.type, Unit]]
+  type CRepr[T] = (T, (List[T], Unit))
+  type NRepr = Unit
+
+  implicit def genList[T]: Generic.Aux[List[T], LRepr[T]] = new Generic[List[T]] {
+    type Repr = LRepr[T]
+    def to(t: List[T]): Repr = t match {
+      case hd :: tl => Left(::(hd, tl))
+      case n@Nil => Right(Left(Nil))
+    }
+    def from(r: Repr): List[T] = (r: @unchecked) match {
+      case Left(c) => c
+      case Right(Left(n)) => n
+    }
+  }
+
+  implicit def genCons[T]: Generic.Aux[::[T], CRepr[T]] = new Generic[::[T]] {
+    type Repr = CRepr[T]
+    def to(t: ::[T]): Repr = (t.head, (t.tail, ()))
+    def from(r: Repr): ::[T] = ::(r._1, r._2._1)
+  }
+
+  implicit def genNil: Generic.Aux[Nil.type, NRepr] = new Generic[Nil.type] {
+    type Repr = NRepr
+    def to(t: Nil.type): Repr = ()
+    def from(r: Repr): Nil.type = Nil
+  }
+}
+
+trait Show[T] {
+  def show(t: T): String
+}
+
+object Show {
+  def apply[T](implicit st: => Show[T]): Show[T] = st
+
+  implicit def showUnit: Show[Unit] = new Show[Unit] {
+    def show(u: Unit): String = "()"
+  }
+
+  implicit def showInt: Show[Int] = new Show[Int] {
+    def show(i: Int): String = i.toString
+  }
+
+  implicit def showPair[T, U](implicit st: Show[T], su: Show[U]): Show[(T, U)] = new Show[(T, U)] {
+    def show(t: (T, U)): String = s"(${st.show(t._1)}, ${su.show(t._2)}"
+  }
+
+  implicit def showEither[T, U](implicit st: Show[T], su: Show[U]): Show[Either[T, U]] = new Show[Either[T, U]] {
+    def show(t: Either[T, U]): String = t match {
+      case Left(t) => s"Left(${st.show(t)})"
+      case Right(u) => s"Right(${su.show(u)})"
+    }
+  }
+
+  implicit def showGen[T, R](implicit gen: Generic.Aux[T, R], sr: => Show[R]): Show[T] = new Show[T] {
+    def show(t: T) = sr.show(gen.to(t))
+  }
+}
+
+object Test extends App {
+  import ListInstances._
+  val sl = Show[List[Int]]
+  assert(sl.show(List(1, 2, 3)) == "Left((1, (Left((2, (Left((3, (Right(Left(())), ()), ()), ())")
+}

--- a/test/files/run/byname-implicits-28.scala
+++ b/test/files/run/byname-implicits-28.scala
@@ -1,0 +1,173 @@
+object Loop0 {
+  trait Link0 {
+    def next0: Link0
+  }
+  object Link0 {
+    implicit def mkLink0(implicit l0: => Link0): Link0 =
+      new Link0 { lazy val next0 = l0 }
+  }
+
+  def check: Boolean = {
+    val loop = implicitly[Link0]
+    loop eq loop.next0
+  }
+}
+
+object Loop1 {
+  trait Link0 {
+    def next0: Link0
+    def next1: Link1
+  }
+  object Link0 {
+    implicit def mkLink0(implicit l0: => Link0, l1: => Link1): Link0 =
+      new Link0 { lazy val next0 = l0 ; lazy val next1 = l1 }
+  }
+
+  trait Link1 {
+    def next0: Link0
+    def next1: Link1
+  }
+  object Link1 {
+    implicit def mkLink1(implicit l0: => Link0, l1: => Link1): Link1 =
+      new Link1 { lazy val next0 = l0 ; lazy val next1 = l1 }
+  }
+
+  def check: Boolean = {
+    val loop = implicitly[Link0]
+    loop eq loop.next0
+    loop.next1 eq loop.next1.next1
+  }
+}
+
+object Loop2 {
+  trait Link0 {
+    def next0: Link0
+    def next1: Link1
+    def next2: Link2
+  }
+  object Link0 {
+    implicit def mkLink0(implicit l0: => Link0, l1: => Link1, l2: => Link2): Link0 =
+      new Link0 { lazy val next0 = l0 ; lazy val next1 = l1 ; lazy val next2 = l2 }
+  }
+
+  trait Link1 {
+    def next0: Link0
+    def next1: Link1
+    def next2: Link2
+  }
+  object Link1 {
+    implicit def mkLink1(implicit l0: => Link0, l1: => Link1, l2: => Link2): Link1 =
+      new Link1 { lazy val next0 = l0 ; lazy val next1 = l1 ; lazy val next2 = l2 }
+  }
+
+  trait Link2 {
+    def next0: Link0
+    def next1: Link1
+    def next2: Link2
+  }
+  object Link2 {
+    implicit def mkLink2(implicit l0: => Link0, l1: => Link1, l2: => Link2): Link2 =
+      new Link2 { lazy val next0 = l0 ; lazy val next1 = l1 ; lazy val next2 = l2 }
+  }
+
+  def check: Boolean = {
+    val loop = implicitly[Link0]
+    loop eq loop.next0
+    loop.next1 eq loop.next1.next1
+    loop.next2 eq loop.next2.next2
+  }
+}
+
+object Loop3 {
+  trait Link0 {
+    def next0: Link0
+    def next1: Link1
+    def next2: Link2
+    def next3: Link3
+  }
+  object Link0 {
+    implicit def mkLink0(implicit l0: => Link0, l1: => Link1, l2: => Link2, l3: => Link3): Link0 =
+      new Link0 { lazy val next0 = l0 ; lazy val next1 = l1 ; lazy val next2 = l2 ; lazy val next3 = l3 }
+  }
+
+  trait Link1 {
+    def next0: Link0
+    def next1: Link1
+    def next2: Link2
+    def next3: Link3
+  }
+  object Link1 {
+    implicit def mkLink1(implicit l0: => Link0, l1: => Link1, l2: => Link2, l3: => Link3): Link1 =
+      new Link1 { lazy val next0 = l0 ; lazy val next1 = l1 ; lazy val next2 = l2 ; lazy val next3 = l3 }
+  }
+
+  trait Link2 {
+    def next0: Link0
+    def next1: Link1
+    def next2: Link2
+    def next3: Link3
+  }
+  object Link2 {
+    implicit def mkLink2(implicit l0: => Link0, l1: => Link1, l2: => Link2, l3: => Link3): Link2 =
+      new Link2 { lazy val next0 = l0 ; lazy val next1 = l1 ; lazy val next2 = l2 ; lazy val next3 = l3 }
+  }
+
+  trait Link3 {
+    def next0: Link0
+    def next1: Link1
+    def next2: Link2
+    def next3: Link3
+  }
+  object Link3 {
+    implicit def mkLink3(implicit l0: => Link0, l1: => Link1, l2: => Link2, l3: => Link3): Link3 =
+      new Link3 { lazy val next0 = l0 ; lazy val next1 = l1 ; lazy val next2 = l2 ; lazy val next3 = l3 }
+  }
+
+  def check: Boolean = {
+    val loop = implicitly[Link0]
+    loop eq loop.next0
+    loop.next1 eq loop.next1.next1
+    loop.next2 eq loop.next2.next2
+    loop.next3 eq loop.next3.next3
+  }
+}
+
+object Loop2b {
+  trait Link0 {
+    def next0: Link0
+    def next1: Link1
+    def next2: Link2
+  }
+  object Link0 {
+    implicit def mkLink0(implicit l0: => Link0, l1: => Link1, l2: => Link2): Link0 =
+      new Link0 { lazy val next0 = l0 ; lazy val next1 = l1 ; lazy val next2 = l2 }
+  }
+
+  trait Link1 {
+    def next1: Link1
+    def next2: Link2
+  }
+  object Link1 {
+    implicit def mkLink1(implicit l1: => Link1, l2: => Link2): Link1 =
+      new Link1 { lazy val next1 = l1 ; lazy val next2 = l2 }
+  }
+
+  trait Link2 {
+    def next2: Link2
+  }
+  object Link2 {
+    implicit def mkLink2(implicit l2: => Link2): Link2 =
+      new Link2 { lazy val next2 = l2 }
+  }
+
+  def check: Boolean = {
+    val loop = implicitly[Link0]
+    loop eq loop.next0
+    loop.next1 eq loop.next1.next1
+    loop.next2 eq loop.next2.next2
+  }
+}
+
+object Test extends App {
+  assert(Loop0.check && Loop1.check && Loop2.check && Loop3.check && Loop2b.check)
+}

--- a/test/files/run/byname-implicits-4.scala
+++ b/test/files/run/byname-implicits-4.scala
@@ -1,0 +1,10 @@
+trait Foo { def next: Foo }
+object Foo {
+  implicit def foo(implicit rec: => Foo): Foo = new Foo { def next = rec }
+}
+
+object Test extends App {
+  val foo = implicitly[Foo]
+  assert(foo eq foo.next)
+}
+

--- a/test/files/run/byname-implicits-5.scala
+++ b/test/files/run/byname-implicits-5.scala
@@ -1,0 +1,15 @@
+import scala.language.higherKinds
+
+object Test extends App {
+  var x = 0
+
+  def foo(implicit y0: => Int): Int = {
+    x = 0
+    val y = y0 // side effect
+    y*x
+  }
+
+  implicit lazy val bar: Int = { x = 1 ; 23 }
+
+  assert(foo == 23)
+}

--- a/test/files/run/byname-implicits-6.scala
+++ b/test/files/run/byname-implicits-6.scala
@@ -1,0 +1,131 @@
+/*
+ * Demo of using by name implicits to resolve (hidden) divergence issues when
+ * traversing recursive generic structures.
+ *
+ * See http://stackoverflow.com/questions/25923974
+ */
+sealed trait HList
+object HList {
+  implicit class Syntax[L <: HList](l: L) {
+    def ::[U](u: U): U :: L = new ::(u, l)
+  }
+}
+
+sealed trait HNil extends HList
+object HNil extends HNil
+case class ::[+H, +T <: HList](head : H, tail : T) extends HList
+
+trait Generic[T] {
+  type Repr
+  def to(t: T): Repr
+  def from(r: Repr): T
+}
+
+object Generic {
+  type Aux[T, Repr0] = Generic[T] { type Repr = Repr0 }
+}
+
+trait DeepHLister[R] {
+  type Out
+  def apply(r: R): Out
+}
+
+object DeepHLister extends DeepHLister0 {
+  def apply[R](implicit dh: DeepHLister[R]): Aux[R, dh.Out] = dh
+
+  implicit def consDeepHLister[H, OutH <: HList, T <: HList, OutT <: HList](implicit
+    dhh: DeepHLister.Aux[H, OutH],
+    dht: DeepHLister.Aux[T, OutT]
+  ): Aux[H :: T, OutH :: OutT] = new DeepHLister[H :: T] {
+    type Out = OutH :: OutT
+    def apply(r: H :: T) = dhh(r.head) :: dht(r.tail)
+  }
+
+  implicit object hnilDeepHLister extends DeepHLister[HNil] {
+    type Out = HNil
+    def apply(r: HNil) = HNil
+  }
+}
+
+trait DeepHLister0 extends DeepHLister1 {
+  implicit def genDeepHLister[T, R <: HList, OutR <: HList](implicit
+    gen: Generic.Aux[T, R],
+    dhr: => DeepHLister.Aux[R, OutR]
+  ): Aux[T, OutR] = new DeepHLister[T] {
+    type Out = OutR
+    def apply(r: T) = dhr(gen.to(r))
+  }
+}
+
+trait DeepHLister1 {
+  type Aux[R, Out0] = DeepHLister[R] { type Out = Out0 }
+
+  implicit def default[T]: Aux[T, T] = new DeepHLister[T] {
+    type Out = T
+    def apply(r: T): T = r
+  }
+}
+
+object Test extends App {
+}
+
+object DeepHListerDemo extends App {
+  case class A(x: Int, y: String)
+  object A {
+    type ARepr = Int :: String :: HNil
+    implicit val aGen: Generic.Aux[A, ARepr] = new Generic[A] {
+      type Repr = ARepr
+      def to(t: A): Repr = t.x :: t.y :: HNil
+      def from(r: Repr): A = A(r.head, r.tail.head)
+    }
+  }
+
+  case class B(x: A, y: A)
+  object B {
+    type BRepr = A :: A :: HNil
+    implicit val bGen: Generic.Aux[B, BRepr] = new Generic[B] {
+      type Repr = BRepr
+      def to(t: B): Repr = t.x :: t.y :: HNil
+      def from(r: Repr): B = B(r.head, r.tail.head)
+    }
+  }
+
+  case class C(b: B, a: A)
+  object C {
+    type CRepr = B :: A :: HNil
+    implicit val cGen: Generic.Aux[C, CRepr] = new Generic[C] {
+      type Repr = CRepr
+      def to(t: C): Repr = t.b :: t.a :: HNil
+      def from(r: Repr): C = C(r.head, r.tail.head)
+    }
+  }
+
+  case class D(a: A, b: B)
+  object D {
+    type DRepr = A :: B :: HNil
+    implicit val dGen: Generic.Aux[D, DRepr] = new Generic[D] {
+      type Repr = DRepr
+      def to(t: D): Repr = t.a :: t.b :: HNil
+      def from(r: Repr): D = D(r.head, r.tail.head)
+    }
+  }
+
+  def typed[T](t : => T): Unit = {}
+
+  type ARepr = Int :: String :: HNil
+  type BRepr = ARepr :: ARepr :: HNil
+  type CRepr = BRepr :: ARepr :: HNil
+  type DRepr = ARepr :: BRepr :: HNil
+
+  val adhl = DeepHLister[A :: HNil]
+  typed[DeepHLister.Aux[A :: HNil, ARepr :: HNil]](adhl)
+
+  val bdhl = DeepHLister[B :: HNil]
+  typed[DeepHLister.Aux[B :: HNil, BRepr :: HNil]](bdhl)
+
+  val cdhl = DeepHLister[C :: HNil]
+  typed[DeepHLister.Aux[C :: HNil, CRepr :: HNil]](cdhl)
+
+  val ddhl = DeepHLister[D :: HNil]
+  typed[DeepHLister.Aux[D :: HNil, DRepr :: HNil]](ddhl)
+}


### PR DESCRIPTION
**This Typelevel Scala collaboration sponsored by Lightbend ...**

This is an implementation of byname implicit parameters with recursive dictionaries, intended as a language-level replacement for shapeless's `Lazy` type. As of this PR, implicit arguments can be marked as byname and at call sites recursive uses of implicit values are permitted if they occur in an implicit byname argument.

There is a SIP describing this language change in greater detail [here](http://docs.scala-lang.org/sips/byname-implicits.html).

Consider the following example,

```scala
trait Foo { def next: Foo }
object Foo {
  implicit def foo(implicit rec: Foo): Foo = new Foo { def next = rec }
}
val foo = implicitly[Foo]
assert(foo eq foo.next)
```
In current Scala this would diverge due to the recursive implicit argument `rec` of method `foo`. Under the scheme implemented in this PR we can mark the recursive implicit parameter as byname,

```scala
trait Foo { def next: Foo }
object Foo {
  implicit def foo(implicit rec: => Foo): Foo = new Foo { def next = rec }
                              // ^^
}
val foo = implicitly[Foo]
assert(foo eq foo.next)
```
and recursive occurrences of this sort are extracted out as `val` members of a local synthetic object as follows,
```scala
val foo: Foo = scala.Predef.implicitly[Foo](
  {
    object LazyDefns$1 {
      val rec$1: Foo = Foo.foo(rec$1)
                       //      ^^^^^
                       // recursive knot tied here
    }
    LazyDefns$1.rec$1
  }
)
assert(foo eq foo.next)
```
The example now compiles with the assertion successful. Note that the recursive use of `rec$1` occurs within the byname argument of `foo` and is consequently deferred. The desugaring matches what a programmer would do to construct such a recursive value explicitly.

This general pattern is essential to the derivation of type class instances for recursive data types, one of shapeless's most common applications. Byname implicits have a number of benefits over the macro implementation of `Lazy` in shapeless,

+ the implementation of `Lazy` in shapeless is extremely delicate, relying on non-portable compiler internals. By contrast there is already an initial implementation of byname implicits in Dotty: lampepfl/dotty#1998.
+ the shapeless implementation is unable to modify divergence checking, so to solve recursive instances it effectively disables divergence checking altogether ... this means that incautious use of `Lazy` can cause the typechecker to loop indefinitely. The byname implicits implementation is able to both solve recursive occurrences and check for divergence.
+ the implementation of `Lazy` interferes with the heuristics for solving inductive implicits in #6481 because the latter depends on being able to verify that induction steps strictly reduce the size of the types being solved for; the additional `Lazy` type constructors make the type appear be non-decreasing in size. Whilst this could be special-cased, doing so would require some knowledge of shapeless to be incorporated into the compiler. Being a language-level feature, byname implicits can be accommodated directly in the induction heuristics.
+ in common cases more implicit arguments would have to be marked as `Lazy` than would have to be marked as byname under this PR due to restrictions on what the `Lazy` macro is able to do. Given that there is a runtime cost associated with capturing the thunks required for both `Lazy` and byname arguments, any reduction in the number is beneficial.