### PR TITLE
Provide capacity for ProcessBuilder.lineStream

### DIFF
--- a/src/library/scala/sys/process/BasicIO.scala
+++ b/src/library/scala/sys/process/BasicIO.scala
@@ -42,8 +42,8 @@ object BasicIO {
   )
 
   private[process] object Streamed {
-    def apply[T](nonzeroException: Boolean): Streamed[T] = {
-      val q = new LinkedBlockingQueue[Either[Int, T]]
+    def apply[T](nonzeroException: Boolean, capacity: Integer): Streamed[T] = {
+      val q = new LinkedBlockingQueue[Either[Int, T]](capacity)
       def next(): Stream[T] = q.take match {
         case Left(0)    => Stream.empty
         case Left(code) => if (nonzeroException) scala.sys.error("Nonzero exit code: " + code) else Stream.empty

--- a/src/library/scala/sys/process/ProcessBuilder.scala
+++ b/src/library/scala/sys/process/ProcessBuilder.scala
@@ -173,6 +173,17 @@ trait ProcessBuilder extends Source with Sink {
     */
   def lineStream: Stream[String]
 
+  /** Starts the process represented by this builder.  The output is returned as
+   * a Stream that blocks when lines are not available but the process has not
+   * completed.
+   * The producer process will block if the given capacity of lines if filled
+   * without being consumed from the stream.
+   * Standard error is sent to the console.  If the process exits
+   * with a non-zero value, the Stream will provide all lines up to termination
+   * and then throw an exception.
+   */
+  def lineStream(capacity: Integer): Stream[String]
+
   /** Deprecated (renamed). Use `lineStream` instead. */
   @deprecated("use lineStream instead", "2.11.0")
   def lines: Stream[String] = lineStream
@@ -184,6 +195,17 @@ trait ProcessBuilder extends Source with Sink {
     * to termination and then throw an exception.
     */
   def lineStream(log: ProcessLogger): Stream[String]
+
+  /** Starts the process represented by this builder.  The output is returned as
+   * a Stream that blocks when lines are not available but the process has not
+   * completed.
+   * The producer process will block if the given capacity of lines if filled
+   * without being consumed from the stream.
+   * Standard error is sent to the provided ProcessLogger.  If the
+   * process exits with a non-zero value, the Stream will provide all lines up
+   * to termination and then throw an exception.
+   */
+  def lineStream(log: ProcessLogger, capacity: Integer): Stream[String]
 
   /** Deprecated (renamed).  Use `lineStream(log: ProcessLogger)` instead. */
   @deprecated("use lineStream instead", "2.11.0")
@@ -197,6 +219,17 @@ trait ProcessBuilder extends Source with Sink {
     */
   def lineStream_! : Stream[String]
 
+  /** Starts the process represented by this builder.  The output is returned as
+   * a Stream that blocks when lines are not available but the process has not
+   * completed.
+   * The producer process will block if the given capacity of lines if filled
+   * without being consumed from the stream.
+   * Standard error is sent to the console. If the process exits
+   * with a non-zero value, the Stream will provide all lines up to termination
+   * but will not throw an exception.
+   */
+  def lineStream_!(capacity: Integer): Stream[String]
+
   /** Deprecated (renamed).  Use `lineStream_!` instead. */
   @deprecated("use lineStream_! instead", "2.11.0")
   def lines_! : Stream[String] = lineStream_!
@@ -208,6 +241,17 @@ trait ProcessBuilder extends Source with Sink {
     * to termination but will not throw an exception.
     */
   def lineStream_!(log: ProcessLogger): Stream[String]
+
+  /** Starts the process represented by this builder.  The output is returned as
+   * a Stream that blocks when lines are not available but the process has not
+   * completed.
+   * The producer process will block if the given capacity of lines if filled
+   * without being consumed from the stream.
+   * Standard error is sent to the provided ProcessLogger. If the
+   * process exits with a non-zero value, the Stream will provide all lines up
+   * to termination but will not throw an exception.
+   */
+  def lineStream_!(log: ProcessLogger, capacity: Integer): Stream[String]
 
   /** Deprecated (renamed).  Use `lineStream_!(log: ProcessLogger)` instead. */
   @deprecated("use lineStream_! instead", "2.11.0")

--- a/src/library/scala/sys/process/ProcessBuilderImpl.scala
+++ b/src/library/scala/sys/process/ProcessBuilderImpl.scala
@@ -88,7 +88,7 @@ private[process] trait ProcessBuilderImpl {
     protected def toSource = this
     protected def toSink = this
 
-    private val defaultStreamCapacity = 65536
+    private val defaultStreamCapacity = 4096
 
     def #|(other: ProcessBuilder): ProcessBuilder  = {
       require(other.canPipeTo, "Piping to multiple processes is not supported.")

--- a/src/library/scala/sys/process/ProcessBuilderImpl.scala
+++ b/src/library/scala/sys/process/ProcessBuilderImpl.scala
@@ -88,6 +88,8 @@ private[process] trait ProcessBuilderImpl {
     protected def toSource = this
     protected def toSink = this
 
+    private val defaultStreamCapacity = 65536
+
     def #|(other: ProcessBuilder): ProcessBuilder  = {
       require(other.canPipeTo, "Piping to multiple processes is not supported.")
       new PipedBuilder(this, other, false)
@@ -106,10 +108,14 @@ private[process] trait ProcessBuilderImpl {
     def !!<                     = slurp(None, withIn = true)
     def !!<(log: ProcessLogger) = slurp(Some(log), withIn = true)
 
-    def lineStream: Stream[String]                       = lineStream(withInput = false, nonZeroException = true, None)
-    def lineStream(log: ProcessLogger): Stream[String]   = lineStream(withInput = false, nonZeroException = true, Some(log))
-    def lineStream_! : Stream[String]                    = lineStream(withInput = false, nonZeroException = false, None)
-    def lineStream_!(log: ProcessLogger): Stream[String] = lineStream(withInput = false, nonZeroException = false, Some(log))
+    def lineStream: Stream[String]                       = lineStream(withInput = false, nonZeroException = true, None, defaultStreamCapacity)
+    def lineStream(log: ProcessLogger): Stream[String]   = lineStream(withInput = false, nonZeroException = true, Some(log), defaultStreamCapacity)
+    def lineStream_! : Stream[String]                    = lineStream(withInput = false, nonZeroException = false, None, defaultStreamCapacity)
+    def lineStream_!(log: ProcessLogger): Stream[String] = lineStream(withInput = false, nonZeroException = false, Some(log), defaultStreamCapacity)
+    def lineStream(capacity: Integer): Stream[String]                       = lineStream(withInput = false, nonZeroException = true, None, capacity)
+    def lineStream(log: ProcessLogger, capacity: Integer): Stream[String]   = lineStream(withInput = false, nonZeroException = true, Some(log), capacity)
+    def lineStream_!(capacity: Integer) : Stream[String]                    = lineStream(withInput = false, nonZeroException = false, None, capacity)
+    def lineStream_!(log: ProcessLogger, capacity: Integer): Stream[String] = lineStream(withInput = false, nonZeroException = false, Some(log), capacity)
 
     def !                      = run(connectInput = false).exitValue()
     def !(io: ProcessIO)       = run(io).exitValue()
@@ -137,9 +143,10 @@ private[process] trait ProcessBuilderImpl {
     private[this] def lineStream(
       withInput: Boolean,
       nonZeroException: Boolean,
-      log: Option[ProcessLogger]
+      log: Option[ProcessLogger],
+      capacity: Integer
     ): Stream[String] = {
-      val streamed = Streamed[String](nonZeroException)
+      val streamed = Streamed[String](nonZeroException, capacity)
       val process  = run(BasicIO(withInput, streamed.process, log))
 
       Spawn(streamed done process.exitValue())


### PR DESCRIPTION
ProcessBuilder.lineStream will create a Stream[String] backed by a LinkedBlockingQueue with a default constructor that gives it a default capacity of Integer.MAX_VALUE.
If the produced stream is very large, and the consumer cannot keep up with consuming it, such a large buffer will cause OOMs.

Implement an option to specify buffer capacity, and reduce the default one to a safer value.