### PR TITLE
Fix scala/bug#10490: Allow Java nested class selection

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -269,6 +269,7 @@ trait Contexts { self: Analyzer =>
     def inSecondTry_=(value: Boolean)         = this(SecondTry) = value
     def inReturnExpr                          = this(ReturnExpr)
     def inTypeConstructorAllowed              = this(TypeConstructorAllowed)
+    def inJavaTypeSelection                   = this(JavaTypeSelection)
 
     def defaultModeForTyped: Mode = if (inTypeConstructorAllowed) Mode.NOmode else Mode.EXPRmode
 
@@ -399,6 +400,7 @@ trait Contexts { self: Analyzer =>
     @inline final def withinSuperInit[T](op: => T): T                      = withMode(enabled = SuperInit)(op)
     @inline final def withinSecondTry[T](op: => T): T                      = withMode(enabled = SecondTry)(op)
     @inline final def withinPatAlternative[T](op: => T): T                 = withMode(enabled = PatternAlternative)(op)
+    @inline final def withinJavaTypeSelection[T](op: => T): T              = withMode(enabled = JavaTypeSelection)(op)
 
     /** TypeConstructorAllowed is enabled when we are typing a higher-kinded type.
      *  adapt should then check kind-arity based on the prototypical type's kind
@@ -1568,6 +1570,9 @@ object ContextMode {
   /** Are unapplied type constructors allowed here? Formerly HKmode. */
   final val TypeConstructorAllowed: ContextMode   = 1 << 16
 
+  /** Is the enclosing tree a Java source type selection? */
+  final val JavaTypeSelection: ContextMode        = 1 << 17
+
   /** TODO: The "sticky modes" are EXPRmode, PATTERNmode, TYPEmode.
    *  To mimic the sticky mode behavior, when captain stickyfingers
    *  comes around we need to propagate those modes but forget the other
@@ -1591,7 +1596,8 @@ object ContextMode {
     StarPatterns           -> "StarPatterns",
     SuperInit              -> "SuperInit",
     SecondTry              -> "SecondTry",
-    TypeConstructorAllowed -> "TypeConstructorAllowed"
+    TypeConstructorAllowed -> "TypeConstructorAllowed",
+    JavaTypeSelection      -> "JavaTypeSelection"
   )
 }
 

--- a/test/files/presentation/t8459.check
+++ b/test/files/presentation/t8459.check
@@ -10,6 +10,6 @@ scala.AnyRef {
   };
   private[this] val bar: F = new F();
   <stable> <accessor> def bar: F = Foo.this.bar;
-  Foo.this.bar.<selectDynamic: error>("<error>")
+  Foo.this.bar.<<error>: error>
 }
 ================================================================================

--- a/test/files/run/t10490-2.check
+++ b/test/files/run/t10490-2.check
@@ -1,0 +1,1 @@
+Foo$Bar was instantiated!

--- a/test/files/run/t10490-2/JavaClass.java
+++ b/test/files/run/t10490-2/JavaClass.java
@@ -1,0 +1,4 @@
+public class JavaClass {
+    // This is defined in ScalaClass
+    public static final Foo.Bar bar = new Foo.Bar();
+}

--- a/test/files/run/t10490-2/ScalaClass.scala
+++ b/test/files/run/t10490-2/ScalaClass.scala
@@ -1,0 +1,18 @@
+/* Similar to t10490 -- but defines `Foo` in the object.
+ * Placing this test within t10490 makes it work without a fix, that's why it's independent.
+ * Note that this was already working, we add it to make sure we don't regress
+ */
+
+class Foo
+object Foo {
+  class Bar {
+    override def toString: String = "Foo$Bar was instantiated!"
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    // JavaClass is the user of the Scala defined classes
+    println(JavaClass.bar)
+  }
+}

--- a/test/files/run/t10490.check
+++ b/test/files/run/t10490.check
@@ -1,0 +1,1 @@
+Foo$Bar was instantiated!

--- a/test/files/run/t10490/JavaClass.java
+++ b/test/files/run/t10490/JavaClass.java
@@ -1,0 +1,4 @@
+public class JavaClass {
+    // This is defined in ScalaClass
+    public static final Foo.Bar bar = (new Foo()).new Bar();
+}

--- a/test/files/run/t10490/ScalaClass.scala
+++ b/test/files/run/t10490/ScalaClass.scala
@@ -1,0 +1,13 @@
+class Foo {
+  class Bar {
+    override def toString: String = "Foo$Bar was instantiated!"
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    // JavaClass is the user of the Scala defined classes
+    println(JavaClass.bar)
+    //println(JavaClass.baz)
+  }
+}


### PR DESCRIPTION
Java type selections, for example `Foo.Bar`, can represent two different
trees depending on the context. On the one hand, it can be a type
selection over an object `Foo`. On the other hand, it can be a type
selection over a type (that is, a selection of a nested class).

However, when we parse the Scala signatures is not possible to know
which case the user meant. For example, `Foo.Bar` could be either:

1. `Select(Ident(TermName("Foo")), TypeName("Bar"))`; or
2. `SelectFromTypeTree(Ident(TypeName("Foo")), TypeName("Bar"))`.

By default, the Scala compiler parses `Foo.Bar` in a type position as
the first option, but it could very well be the case that the user meant
the second one, as specified by the tests in this commit.

To address the issue, then, there's nothing but the ugly solution of
injecting special logic into typer so that we try to typecheck both
trees for those different scenarios.

To handle this specific logic and try to make it as isolated as
possible, I've introduced a new context mode called `JavaTypeSelection`.
This context mode is set by `typedSelectOrSuperCall` when the
compilation unit is Java, the tree at hands selects a type name and the
qualifier is an identifier. `typedIdent` detects when this mode is on,
and if the default term symbol lookup fails it tries to find the type
symbol. If that succeeds, it then delegates to `typedType`. The
different returning trees are handled in `typedSelectOrSuperCall`.

Run tests in this commit illustrate both accesses. They are independent
because if t10490 had the `Foo` companion, the bug that this commit
fixes wouldn't have been required (i.e. it's a very subtle workaround).