### PR TITLE
Classes can access `protected static` members of their Java superclasses

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1398,13 +1398,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       newNonClassSymbol(name, pos, newFlags)
 
     /**
-     * The class or term up to which this symbol is accessible, or RootClass if it is public. As
-     * Java protected statics are otherwise completely inaccessible in Scala, they are treated as
-     * public (scala/bug#1806).
+     * The class or term up to which this symbol is accessible, or else
+     * `enclosingRootClass` if it is public.
      */
     def accessBoundary(base: Symbol): Symbol = {
       if (hasFlag(PRIVATE) || isLocalToBlock) owner
-      else if (hasAllFlags(PROTECTED | STATIC | JAVA)) enclosingRootClass
       else if (hasAccessBoundary && !phase.erasedTypes) privateWithin // Phase check needed? See comment in Context.isAccessible.
       else if (hasFlag(PROTECTED)) base
       else enclosingRootClass

--- a/test/files/neg/t3871b.check
+++ b/test/files/neg/t3871b.check
@@ -4,7 +4,7 @@ t3871b.scala:61: error: not found: value protOT
 t3871b.scala:77: error: method prot in class A cannot be accessed in E.this.A
  Access to protected method prot not permitted because
  prefix type E.this.A does not conform to
- class B in class E where the access take place
+ class B in class E where the access takes place
       a.prot    // not allowed, prefix type `A` does not conform to `B`
         ^
 t3871b.scala:79: error: value protT is not a member of E.this.B
@@ -19,7 +19,7 @@ t3871b.scala:81: error: value protT is not a member of E.this.A
 t3871b.scala:91: error: method prot in class A cannot be accessed in E.this.A
  Access to protected method prot not permitted because
  prefix type E.this.A does not conform to
- object B in class E where the access take place
+ object B in class E where the access takes place
       a.prot    // not allowed
         ^
 t3871b.scala:93: error: value protT is not a member of E.this.B

--- a/test/files/neg/t3934.check
+++ b/test/files/neg/t3934.check
@@ -7,7 +7,7 @@ t3934.scala:15: error: method f2 in class J cannot be accessed in test.J
 t3934.scala:20: error: method f2 in class J cannot be accessed in test.J
  Access to protected method f2 not permitted because
  prefix type test.J does not conform to
- class S2 in package nest where the access take place
+ class S2 in package nest where the access takes place
   def g2(x: J) = x.f2()
                    ^
 two errors found

--- a/test/files/neg/t4541.check
+++ b/test/files/neg/t4541.check
@@ -1,7 +1,7 @@
 t4541.scala:11: error: variable data in class Sparse cannot be accessed in Sparse[Int]
  Access to protected variable data not permitted because
  prefix type Sparse[Int] does not conform to
- class Sparse$mcI$sp where the access take place
+ class Sparse$mcI$sp where the access takes place
     that.data
          ^
 one error found

--- a/test/files/neg/t4541b.check
+++ b/test/files/neg/t4541b.check
@@ -1,7 +1,7 @@
 t4541b.scala:13: error: variable data in class SparseArray cannot be accessed in SparseArray[Int]
  Access to protected variable data not permitted because
  prefix type SparseArray[Int] does not conform to
- class SparseArray$mcI$sp where the access take place
+ class SparseArray$mcI$sp where the access takes place
     use(that.data.clone)
              ^
 one error found

--- a/test/files/neg/t6934.check
+++ b/test/files/neg/t6934.check
@@ -1,0 +1,7 @@
+ScalaMain.scala:6: error: variable STATIC_PROTECTED_FIELD in object JavaClass cannot be accessed in object test.JavaClass
+ Access to protected variable STATIC_PROTECTED_FIELD not permitted because
+ enclosing object ScalaMain in package test2 is not a subclass of
+ object JavaClass in package test where target is defined
+    val a = test.JavaClass.STATIC_PROTECTED_FIELD
+                           ^
+one error found

--- a/test/files/neg/t6934/JavaClass.java
+++ b/test/files/neg/t6934/JavaClass.java
@@ -1,0 +1,8 @@
+package test;
+
+public class JavaClass {
+
+    protected static int STATIC_PROTECTED_FIELD = 4;
+
+}
+

--- a/test/files/neg/t6934/ScalaClass.scala
+++ b/test/files/neg/t6934/ScalaClass.scala
@@ -1,0 +1,6 @@
+package test
+
+class ScalaClass {
+  /* double-checking that we can still do this */
+  def hmm = JavaClass.STATIC_PROTECTED_FIELD
+}

--- a/test/files/neg/t6934/ScalaMain.scala
+++ b/test/files/neg/t6934/ScalaMain.scala
@@ -1,0 +1,9 @@
+package test2
+
+object ScalaMain {
+
+  def main(args: Array[String]) {
+    val a = test.JavaClass.STATIC_PROTECTED_FIELD
+  }
+
+}


### PR DESCRIPTION
This more-or-less reverts the fix added in 1ebbe029dd7ba. Instead of wantonly treating `protected static` Java members like they're public, it suffices to modify `isSubClassOrCompanion` to consider a class a "subclass or companion" of the companions of its parent classes, provided the parent is a Java-defined class.

It's a bit wacky, but comparing the Java and Scala definitions of `protected` access:

[SLS 5.2.8](https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#protected):

> Protected members of a class can be accessed from within
>
> - the template of the defining class,
> - all templates that have the defining class as a base class,
> - the companion module of any of those classes.

[JLS 6.6.1](https://docs.oracle.com/javase/specs/jls/se8/html/jls-6.html#jls-6.6.1):

> A member (class, interface, field, or method) of a reference type ... is accessible only if the type is accessible and the member or constructor is declared to permit access:
> ...
> - if the member or constructor is declared protected, then access is permitted only when one of the following is true:
>   - Access to the member or constructor occurs from within the package containing the class in which the protected member or constructor is declared.
>   - Access is correct as described in §6.6.2.

[JLS 6.6.2.1](https://docs.oracle.com/javase/specs/jls/se8/html/jls-6.html#jls-6.6.2.1):

> Let C be the class in which a protected member is declared. Access is permitted only within the body of a subclass S of C.

The important differences are that Java protected members are indeed accessible from the package that they're declared in (this behavior is implemented by `accessBoundary`, and that `static` methods are treated the same as instance methods for purposes of access control. Therefore, I feel comfortable adding the third case to `isSubClassOrCompanion`, thus taking the Java access control model when dealing with Java-defined types.

I also scouted a grammar tweak, which makes this have a few more files in the diff than would be expected.

Fixes scala/bug#6934; review by @adriaanm and (of course) whoever feels like swinging by and saying hi.