### PR TITLE
Use AnyRefMap in pickler, we don't actually need a linked map

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -9,10 +9,11 @@ package classfile
 
 import java.lang.Float.floatToIntBits
 import java.lang.Double.doubleToLongBits
+
 import scala.io.Codec
-import scala.reflect.internal.pickling.{ PickleBuffer, PickleFormat }
+import scala.reflect.internal.pickling.{PickleBuffer, PickleFormat}
 import scala.reflect.internal.util.shortClassOfInstance
-import scala.collection.mutable.LinkedHashMap
+import scala.collection.mutable
 import PickleFormat._
 import Flags._
 
@@ -83,7 +84,7 @@ abstract class Pickler extends SubComponent {
     private val rootOwner = root.owner
     private var entries   = new Array[AnyRef](256)
     private var ep        = 0
-    private val index     = new LinkedHashMap[AnyRef, Int]
+    private val index     = new mutable.AnyRefMap[AnyRef, Int]
     private lazy val nonClassRoot = findSymbol(root.ownersIterator)(!_.isClass)
 
     private def isRootSym(sym: Symbol) =


### PR DESCRIPTION
AnyRefMap is quite a bit faster as it avoids cooperative equality and doesn't maintain the linked list of entries in insertion order.

The linked-ness of this particular map dates back to everyone's favourite commit, "Massive check-in for IDE." a205b6b0. I don't see any motivation for it, as the contents are never iterated.

Given that a number of maps were made linked in that commit, I conclude that this one was done speculatively while developing that change, but wasn't needed.
