### PR TITLE
allow custom indices start in zipWithIndex

### DIFF
--- a/src/library/scala/collection/GenIterableLike.scala
+++ b/src/library/scala/collection/GenIterableLike.scala
@@ -96,7 +96,7 @@ trait GenIterableLike[+A, +Repr] extends Any with GenTraversableLike[A, Repr] {
    *                 result class `That` from the current representation type `Repr`
    *                 and the new element type `(A1, Int)`.
    *  @return        A new collection of type `That` containing pairs consisting of all elements of this
-   *                 $coll paired with their index. Indices start at `0`.
+   *                 $coll paired with their index. Indices start at `indicesStart`.
    *
    *  @usecase def zipWithIndex: $Coll[(A, Int)]
    *    @inheritdoc
@@ -104,12 +104,15 @@ trait GenIterableLike[+A, +Repr] extends Any with GenTraversableLike[A, Repr] {
    *    $orderDependent
    *
    *    @return        A new $coll containing pairs consisting of all elements of this
-   *                   $coll paired with their index. Indices start at `0`.
+   *                   $coll paired with their index. Indices start at `indicesStart`.
    *    @example
    *      `List("a", "b", "c").zipWithIndex = List(("a", 0), ("b", 1), ("c", 2))`
+   *      `List("a", "b", "c").zipWithIndex(42) = List(("a", 42), ("b", 43), ("c", 44))`
    *
    */
-  def zipWithIndex[A1 >: A, That](implicit bf: CBF[Repr, (A1, Int), That]): That
+  def zipWithIndex[A1 >: A, That](indicesStart: Int)(implicit bf: CBF[Repr, (A1, Int), That]): That
+
+  def zipWithIndex[A1 >: A, That](implicit bf: CBF[Repr, (A1, Int), That]): That = zipWithIndex(0)
 
   /** Returns a $coll formed from this $coll and another iterable collection
    *  by combining corresponding elements in pairs.

--- a/src/library/scala/collection/IndexedSeqOptimized.scala
+++ b/src/library/scala/collection/IndexedSeqOptimized.scala
@@ -93,17 +93,20 @@ trait IndexedSeqOptimized[+A, +Repr] extends Any with IndexedSeqLike[A, Repr] { 
   }
 
   override /*IterableLike*/
-  def zipWithIndex[A1 >: A, That](implicit bf: CanBuildFrom[Repr, (A1, Int), That]): That = {
+  def zipWithIndex[A1 >: A, That](indicesStart: Int = 0)(implicit bf: CanBuildFrom[Repr, (A1, Int), That]): That = {
     val b = bf(repr)
     val len = length
     b.sizeHint(len)
     var i = 0
     while (i < len) {
-      b += ((this(i), i))
+      b += ((this(i), i + indicesStart))
       i += 1
     }
     b.result()
   }
+
+  override /*IterableLike*/
+  def zipWithIndex[A1 >: A, That](implicit bf: CanBuildFrom[Repr, (A1, Int), That]): That = zipWithIndex(0)
 
   override /*IterableLike*/
   def slice(from: Int, until: Int): Repr = {

--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -277,15 +277,17 @@ self =>
     b.result()
   }
 
-  def zipWithIndex[A1 >: A, That](implicit bf: CanBuildFrom[Repr, (A1, Int), That]): That = {
+  def zipWithIndex[A1 >: A, That](indicesStart: Int = 0)(implicit bf: CanBuildFrom[Repr, (A1, Int), That]): That = {
     val b = bf(repr)
-    var i = 0
+    var i = indicesStart
     for (x <- this) {
       b += ((x, i))
       i += 1
     }
     b.result()
   }
+
+  override def zipWithIndex[A1 >: A, That](implicit bf: CanBuildFrom[Repr, (A1, Int), That]): That = zipWithIndex(0)
 
   def sameElements[B >: A](that: GenIterable[B]): Boolean = {
     val these = this.iterator

--- a/src/library/scala/collection/IterableProxyLike.scala
+++ b/src/library/scala/collection/IterableProxyLike.scala
@@ -34,7 +34,8 @@ trait IterableProxyLike[+A, +Repr <: IterableLike[A, Repr] with Iterable[A]]
   override def dropRight(n: Int): Repr = self.dropRight(n)
   override def zip[A1 >: A, B, That](that: GenIterable[B])(implicit bf: CanBuildFrom[Repr, (A1, B), That]): That = self.zip[A1, B, That](that)(bf)
   override def zipAll[B, A1 >: A, That](that: GenIterable[B], thisElem: A1, thatElem: B)(implicit bf: CanBuildFrom[Repr, (A1, B), That]): That = self.zipAll(that, thisElem, thatElem)(bf)
-  override def zipWithIndex[A1 >: A, That](implicit bf: CanBuildFrom[Repr, (A1, Int), That]): That = self.zipWithIndex(bf)
+  override def zipWithIndex[A1 >: A, That](indicesStart: Int = 0)(implicit bf: CanBuildFrom[Repr, (A1, Int), That]): That = self.zipWithIndex(indicesStart)(bf)
+  override def zipWithIndex[A1 >: A, That](implicit bf: CanBuildFrom[Repr, (A1, Int), That]): That = zipWithIndex(0)
   override def sameElements[B >: A](that: GenIterable[B]): Boolean = self.sameElements(that)
   override def view = self.view
   override def view(from: Int, until: Int) = self.view(from, until)

--- a/src/library/scala/collection/IterableViewLike.scala
+++ b/src/library/scala/collection/IterableViewLike.scala
@@ -139,8 +139,10 @@ trait IterableViewLike[+A,
 //    else super.zip[A1, B, That](that)(bf)
   }
 
-  override def zipWithIndex[A1 >: A, That](implicit bf: CanBuildFrom[This, (A1, Int), That]): That =
-    zip[A1, Int, That](Stream from 0)(bf)
+  override def zipWithIndex[A1 >: A, That](indicesStart: Int = 0)(implicit bf: CanBuildFrom[This, (A1, Int), That]): That =
+    zip[A1, Int, That](Stream from indicesStart)(bf)
+
+  override def zipWithIndex[A1 >: A, That](implicit bf: CanBuildFrom[This, (A1, Int), That]): That = zipWithIndex(0)
 
   override def zipAll[B, A1 >: A, That](that: GenIterable[B], thisElem: A1, thatElem: B)(implicit bf: CanBuildFrom[This, (A1, B), That]): That =
     newZippedAll(that, thisElem, thatElem).asInstanceOf[That]

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -861,14 +861,14 @@ trait Iterator[+A] extends TraversableOnce[A] {
   }
 
   /** Creates an iterator that pairs each element produced by this iterator
-   *  with its index, counting from 0.
+   *  with its index, counting from `indicesStart`.
    *
    *  @return        a new iterator containing pairs consisting of
    *                 corresponding elements of this iterator and their indices.
    *  @note          Reuse: $consumesAndProducesIterator
    */
-  def zipWithIndex: Iterator[(A, Int)] = new AbstractIterator[(A, Int)] {
-    var idx = 0
+  def zipWithIndex(indicesStart: Int = 0): Iterator[(A, Int)] = new AbstractIterator[(A, Int)] {
+    var idx = indicesStart
     def hasNext = self.hasNext
     def next = {
       val ret = (self.next(), idx)
@@ -876,6 +876,17 @@ trait Iterator[+A] extends TraversableOnce[A] {
       ret
     }
   }
+
+  /** Creates an iterator that pairs each element produced by this iterator
+   *  with its index, counting from `0`.
+   *
+   *  @return        a new iterator containing pairs consisting of
+   *                 corresponding elements of this iterator and their indices.
+   *  @note          Reuse: $consumesAndProducesIterator
+   *                 As a separate method, to avoid collisions in code like "foo.zipWithIndex"
+   */
+
+  def zipWithIndex: Iterator[(A, Int)] = zipWithIndex(0)
 
   /** Creates an iterator formed from this iterator and another iterator
    *  by combining corresponding elements in pairs.

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -647,8 +647,10 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
    * // (5,4)
    * }}}
    */
-  override def zipWithIndex[A1 >: A, That](implicit bf: CanBuildFrom[Stream[A], (A1, Int), That]): That =
-    this.zip[A1, Int, That](Stream.from(0))
+  override def zipWithIndex[A1 >: A, That](indicesStart: Int = 0)(implicit bf: CanBuildFrom[Stream[A], (A1, Int), That]): That =
+    this.zip[A1, Int, That](Stream.from(indicesStart))
+
+  override def zipWithIndex[A1 >: A, That](implicit bf: CanBuildFrom[Stream[A], (A1, Int), That]): That = zipWithIndex(0)
 
   /** Write all defined elements of this iterable into given string builder.
    *  The written text begins with the string `start` and is finished by the string

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -823,7 +823,9 @@ self: ParIterableLike[T, Repr, Sequential] =>
     tasksupport.executeAndWaitResult(new Zip(combinerFactory(() => bf(repr).asCombiner), splitter, thatseq.splitter) mapResult { _.resultWithTaskSupport })
   } else setTaskSupport(seq.zip(that)(bf2seq(bf)), tasksupport)
 
-  def zipWithIndex[U >: T, That](implicit bf: CanBuildFrom[Repr, (U, Int), That]): That = this zip immutable.ParRange(0, size, 1, inclusive = false)
+  def zipWithIndex[U >: T, That](indicesStart: Int = 0)(implicit bf: CanBuildFrom[Repr, (U, Int), That]): That = this zip immutable.ParRange(indicesStart, size + indicesStart, 1, inclusive = false)
+
+  override def zipWithIndex[U >: T, That](implicit bf: CanBuildFrom[Repr, (U, Int), That]): That = zipWithIndex(0)
 
   def zipAll[S, U >: T, That](that: GenIterable[S], thisElem: U, thatElem: S)(implicit bf: CanBuildFrom[Repr, (U, S), That]): That = if (bf(repr).isCombiner && that.isParSeq) {
     val thatseq = that.asParSeq

--- a/test/junit/scala/collection/IndexedSeqOptimizedTest.scala
+++ b/test/junit/scala/collection/IndexedSeqOptimizedTest.scala
@@ -26,4 +26,10 @@ class IndexedSeqOptimizedTest {
     assertArrayEquals(Array(1, 2, 3), Array(1, 2, 3) drop Int.MinValue)
     assertArrayEquals(Array(1, 2, 3), Array(1, 2, 3) dropRight Int.MinValue)
   }
+
+  @Test
+  def zipWithIndex() = {
+    assertEquals("abc".zipWithIndex.toList, List(('a', 0), ('b', 1), ('c', 2)))
+    assertEquals("abc".zipWithIndex(42).toList, List(('a', 42), ('b', 43), ('c', 44)))
+  }
 }

--- a/test/junit/scala/collection/IterableViewLikeTest.scala
+++ b/test/junit/scala/collection/IterableViewLikeTest.scala
@@ -19,4 +19,10 @@ class IterableViewLikeTest {
     assertEquals(iter, iter.view drop Int.MinValue force)
     assertEquals(iter, iter.view dropRight Int.MinValue force)
   }
+
+  @Test
+  def zipWithIndex() {
+   assertEquals(Iterable(1, 2, 3).view.zipWithIndex.toList, List((1, 0), (2, 1), (3, 2)))
+   assertEquals(Iterable(1, 2, 3).view.zipWithIndex(42).toList, List((1, 42), (2, 43), (3, 44)))
+  }
 }

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -248,4 +248,10 @@ class IteratorTest {
     assertEquals(v2, v4)
     assertEquals(Some(v1), v2)
   }
+
+  @Test
+  def zipWithIndex(): Unit = {
+    assertEquals(List(1,2,3).iterator.zipWithIndex.toList, List((1, 0), (2, 1), (3, 2)))
+    assertEquals(List(1,2,3).iterator.zipWithIndex(42).toList, List((1, 42), (2, 43), (3, 44)))
+  }
 }

--- a/test/junit/scala/collection/immutable/StreamTest.scala
+++ b/test/junit/scala/collection/immutable/StreamTest.scala
@@ -123,4 +123,10 @@ class StreamTest {
     assertEquals(Stream(None, Some(1)), None #:: Stream(Some(1)))
     assertEquals(Stream(None, Some(1)), Stream(None) #::: Stream(Some(1)))
   }
+
+  @Test
+  def zipWithIndex: Unit = {
+    assertEquals(Stream(1, 2, 3).zipWithIndex.toList, Stream((1, 0), (2, 1), (3, 2)))
+    assertEquals(Stream(1, 2, 3).zipWithIndex(42).toList, Stream((1,42), (2, 43), (3, 44)))
+  }
 }

--- a/test/junit/scala/collection/parallel/immutable/ParRangeTest.scala
+++ b/test/junit/scala/collection/parallel/immutable/ParRangeTest.scala
@@ -12,4 +12,10 @@ class ParRangeTest {
     assert(ParRange(1, 5, 1, true).toString == "ParRange 1 to 5")
   }
 
+  @Test
+  def zipWithIndex {
+    assert((1 to 3).par.zipWithIndex.toList == List((1, 0), (2, 1), (3, 2)))
+    assert((1 to 3).par.zipWithIndex(42).toList == List((1, 42), (2, 43), (3, 44)))
+  }
+
 }


### PR DESCRIPTION
Motivation -- sometimes I want to use other than 0 start index in `zipWithIndex`. Some alternatives -- implicit class or manual addition, like `for ((x, _i) <- list.zipWithIndex; i = _i + start) ...`. However, probably would be useful to have this functionality built in stdlib, to reduce overhead and simplify user code.

Example:
```
scala> List(1, 2, 3).zipWithIndex(42)
res0: List[(Int, Int)] = List((1,42), (2,43), (3,44))
```

Goals:
1. Already existing syntax `list.zipWithIndex ...` must be preserved, so no user code should be changed.
2. New method must have the same name, so it looks like `list.zipWithIndex(42) ...`.
3. `list.zipWithIndex() ...` must behave exactly the same as `list.zipWithIndex ...`.

In current implementation, there are few debatable decisions:
1. To achieve first goal, I had to create explicit overloaded `zipWithIndex` method. That slightly complicates collection's code. However, I don't know any alternative.
2. `zipWithIndex` calls `zipWithIndex(0)`, thus +1 method call. That can be overcome with copy-pasted implementation of `zipWithIndex` in both cases, however, runtime should optimize it away.

Any comments and suggestions are welcome.