### PR TITLE
Optimize tailcalls even when called with different type arguments.

### DIFF
--- a/test/files/neg/t6574.check
+++ b/test/files/neg/t6574.check
@@ -1,7 +1,4 @@
 t6574.scala:4: error: could not optimize @tailrec annotated method notTailPos$extension: it contains a recursive call not in tail position
     println("tail")
     ^
-t6574.scala:8: error: could not optimize @tailrec annotated method differentTypeArgs$extension: it is called recursively with different type arguments
-    {(); new Bad[String, Unit](0)}.differentTypeArgs
-                                   ^
-two errors found
+one error found

--- a/test/files/neg/t6574.scala
+++ b/test/files/neg/t6574.scala
@@ -3,8 +3,4 @@ class Bad[X, Y](val v: Int) extends AnyVal {
     this.notTailPos[Z](a)(b)
     println("tail")
   }
-
-  @annotation.tailrec final def differentTypeArgs {
-    {(); new Bad[String, Unit](0)}.differentTypeArgs
-  }
 }

--- a/test/files/neg/tailrec.check
+++ b/test/files/neg/tailrec.check
@@ -7,9 +7,9 @@ tailrec.scala:50: error: could not optimize @tailrec annotated method fail1: it 
 tailrec.scala:53: error: could not optimize @tailrec annotated method fail2: it contains a recursive call not in tail position
   @tailrec final def fail2[T](xs: List[T]): List[T] = xs match {
                                                       ^
-tailrec.scala:59: error: could not optimize @tailrec annotated method fail3: it is called recursively with different type arguments
-  @tailrec final def fail3[T](x: Int): Int = fail3(x - 1)
-                                             ^
+tailrec.scala:59: error: could not optimize @tailrec annotated method fail3: it is called recursively with different specialized type arguments
+  @tailrec final def fail3[@specialized(Int) T](x: Int): Int = fail3(x - 1)
+                                                               ^
 tailrec.scala:63: error: could not optimize @tailrec annotated method fail4: it changes type of 'this' on a polymorphic recursive call
     @tailrec final def fail4[U](other: Tom[U], x: Int): Int = other.fail4[U](other, x - 1)
                                                                     ^

--- a/test/files/neg/tailrec.scala
+++ b/test/files/neg/tailrec.scala
@@ -56,7 +56,7 @@ class Failures {
   }
 
   // unsafe
-  @tailrec final def fail3[T](x: Int): Int = fail3(x - 1)
+  @tailrec final def fail3[@specialized(Int) T](x: Int): Int = fail3(x - 1)
 
   // unsafe
   class Tom[T](x: Int) {

--- a/test/files/pos/t6574.scala
+++ b/test/files/pos/t6574.scala
@@ -11,6 +11,10 @@ class Bad[X, Y](val v: Int) extends AnyVal {
   @annotation.tailrec final def dependent[Z](a: Int)(b: String): b.type = {
     this.dependent[Z](a)(b)
   }
+
+  @annotation.tailrec final def differentTypeArgs {
+    {(); new Bad[String, Unit](0)}.differentTypeArgs
+  }
 }
 
 class HK[M[_]](val v: Int) extends AnyVal {

--- a/test/files/pos/t9647.scala
+++ b/test/files/pos/t9647.scala
@@ -1,0 +1,13 @@
+sealed trait HList
+case class HCons[H, T <: HList](head: H, tail: T) extends HList
+case object HNil extends HList
+
+object Test {
+
+  @annotation.tailrec
+  def foo[L <: HList](l: L): Unit = l match {
+    case HNil => ()
+    case HCons(h, t) => foo(t)
+  }
+
+}

--- a/test/files/run/tailcalls.check
+++ b/test/files/run/tailcalls.check
@@ -56,6 +56,9 @@ test FancyTailCalls.tcInIfCond was successful
 test FancyTailCalls.tcInPatternGuard was successful
 test FancyTailCalls.differentInstance was successful
 test PolyObject.tramp was successful
+test PolyObject.size was successful
+test PolyObject.specializedSize[Int] was successful
+test PolyObject.specializedSize[String] was successful
 #partest avian
 test Object   .f was successful
 test Final    .f was successful
@@ -114,3 +117,6 @@ test FancyTailCalls.tcInIfCond was successful
 test FancyTailCalls.tcInPatternGuard was successful
 test FancyTailCalls.differentInstance was successful
 test PolyObject.tramp was successful
+test PolyObject.size was successful
+test PolyObject.specializedSize[Int] was successful
+test PolyObject.specializedSize[String] was successful

--- a/test/files/run/tailcalls.scala
+++ b/test/files/run/tailcalls.scala
@@ -199,6 +199,19 @@ object PolyObject extends App {
       tramp[A](x - 1)
     else
       0
+
+  def size[A](a: A, len: A => Int, tail: List[Either[String, Int]], acc: Int): Int = {
+    val acc1 = acc + len(a)
+    tail match {
+      case Nil           =>                              acc1
+      case Left(s)  :: t => size[String](s, _.length, t, acc1)
+      case Right(i) :: t => size[Int]   (i, _ => 1,   t, acc1)
+    }
+  }
+
+  def specializedSize[@specialized(Int) A](len: A => Int, as: List[A], acc: Int): Int =
+    if(as.isEmpty) acc
+    else specializedSize[A](len, as.tail, acc + len(as.head))
 }
 
 
@@ -410,6 +423,9 @@ object Test {
     check_success_b("FancyTailCalls.tcInPatternGuard", FancyTailCalls.tcInPatternGuard(max, max), true)
     check_success("FancyTailCalls.differentInstance", FancyTailCalls.differentInstance(max, 42), 42)
     check_success("PolyObject.tramp", PolyObject.tramp[Int](max), 0)
+    check_success("PolyObject.size", PolyObject.size[Int](1, _ => 1, (1 to 5000).toList.flatMap(_ => List(Left("hi"), Right(5))), 0), 15001)
+    check_success("PolyObject.specializedSize[Int]", PolyObject.specializedSize[Int](_ => 1, (1 to 5000).toList, 0), 5000)
+    check_success("PolyObject.specializedSize[String]", PolyObject.specializedSize[String](_.length, List.fill(5000)("hi"), 0), 10000)
   }
 
   // testing explicit tailcalls.

--- a/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
@@ -111,7 +111,7 @@ class OptimizedBytecodeTest extends BytecodeTesting {
   def t8062(): Unit = {
     val c1 =
       """package warmup
-        |object Warmup { def filter[A](p: Any => Boolean): Any = filter[Any](p) }
+        |object Warmup { def filter[A](p: Any => Boolean): Int = 1 + filter[Any](p) }
       """.stripMargin
     val c2 = "class C { def t = warmup.Warmup.filter[Any](x => false) }"
     val List(c, _, _) = compileClassesSeparately(List(c1, c2), extraArgs = compilerArgs)


### PR DESCRIPTION
This PR turns off the check that the recursive tail-call is made with the same type arguments, if the tailcall optimization is requested explicitly via `@tailrec`.

This allows to tail-optimize, for example, operations on type-aligned sequences.

I believe the check was there for a reason. However, the tests pass and I can't think of a case where it would be unsafe. Please let me know if I'm wrong.