### PR TITLE
Only cache ImplicitInfo erroneous status in isCyclicOrErroneous.

### DIFF
--- a/test/files/pos/t9122.scala
+++ b/test/files/pos/t9122.scala
@@ -1,0 +1,8 @@
+class X[A](a: A)
+object Test {
+  implicit val ImplicitBoolean: Boolean = true
+  def local = {
+    implicit object X extends X({ def local2 = implicitly[Boolean] ; "" })
+    implicitly[X[String]]
+  }
+}

--- a/test/files/run/implicit-caching.scala
+++ b/test/files/run/implicit-caching.scala
@@ -1,0 +1,25 @@
+trait Foo[T]
+
+trait FooSub[T] extends Foo[T] {
+  type Super = Foo[T]
+}
+
+object FooSub {
+  implicit def fooSub[T](implicit ft: Bar[T]): FooSub[T] =
+    new FooSub[T] {}
+}
+
+trait Bar[T]
+
+class Quux
+
+object Quux {
+  implicit val barQuux: Bar[Quux] = new Bar[Quux] {}
+
+  val fooSubQuux = implicitly[FooSub[Quux]]
+  implicit val fooQuux: fooSubQuux.Super = fooSubQuux
+}
+
+object Test extends App {
+  implicitly[Foo[Quux]]
+}


### PR DESCRIPTION
4aeb8acf99493a5b3f7c2e012796ded77ae40a7f slightly overreached as the cyclic error is context dependent and should not be globally cached.

Fixes scala/bug#9122