### PR TITLE
@implicitNotFound messages can access type args from prefixes

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1498,8 +1498,8 @@ trait Implicits {
   }
 
   class ImplicitAnnotationMsg(f: Symbol => Option[String], clazz: Symbol, annotationName: String) {
-    def unapply(sym: Symbol): Option[(Message)] = f(sym) match {
-      case Some(m) => Some(new Message(sym, m, annotationName))
+    def unapply(sym: Symbol): Option[Message] = f(sym) match {
+      case Some(msgStr) => Some(new Message(sym, msgStr, annotationName))
       case None if sym.isAliasType =>
         // perform exactly one step of dealiasing
         // this is necessary because ClassManifests are now aliased to ClassTags
@@ -1509,11 +1509,11 @@ trait Implicits {
     }
 
     // check the message's syntax: should be a string literal that may contain occurrences of the string "${X}",
-    // where `X` refers to a type parameter of `sym`
+    // where `X` refers to a type parameter of `sym` or any of its prefixes
     def check(sym: Symbol): Option[String] =
       sym.getAnnotation(clazz).flatMap(_.stringArg(0) match {
         case Some(m) => new Message(sym, m, annotationName).validate
-        case None => Some(s"Missing argument `msg` on $annotationName annotation.")
+        case None => Some(s"Missing argument `msg` on @$annotationName annotation.")
       })
   }
 
@@ -1531,10 +1531,33 @@ trait Implicits {
           // #3915: need to quote replacement string since it may include $'s (such as the interpreter's $iw)
       })
 
-    private lazy val typeParamNames: List[String] = sym.typeParams.map(_.decodedName)
-    private def typeArgsAtSym(paramTp: Type) = paramTp.baseType(sym).typeArgs
+    private lazy val typeParams: List[Symbol] = sym.ownerChain.flatMap(_.typeParams)
+    private lazy val typeParamNames: List[String] = typeParams.map(_.decodedName)
 
-    def format(paramName: Name, paramTp: Type): String = format(typeArgsAtSym(paramTp) map (_.toString))
+    def format(paramName: Name, paramTp: Type): String = {
+
+      def prefixTypeArgs(tp: Type): List[(String, String)] = {
+        tp match {
+          case TypeRef(pre0, sym0, args0) =>
+            (sym0.typeParams zip args0).map {
+              case (tparam, targ) =>
+                tparam.nameString -> targ.toString
+            } ::: (tp.parents flatMap prefixTypeArgs) ::: prefixTypeArgs(pre0)
+          case ClassInfoType(parents, _, _) =>
+            parents flatMap prefixTypeArgs
+          case RefinedType(parents, _) =>
+            parents flatMap prefixTypeArgs
+          case single @ SingleType(_, _) =>
+            prefixTypeArgs(single.widen)
+          case thiz @ ThisType(_) =>
+            prefixTypeArgs(sym.info.memberInfo(thiz.sym))
+          case other => Nil
+        }
+      }
+
+      //format(typeArgsAtSym(paramTp) map (_.toString))
+      interpolate(msg, prefixTypeArgs(paramTp baseType sym).reverse.toMap)
+    }
 
     def format(typeArgs: List[String]): String =
       interpolate(msg, Map((typeParamNames zip typeArgs): _*)) // TODO: give access to the name and type of the implicit argument, etc?
@@ -1549,7 +1572,19 @@ trait Implicits {
           val singular = unboundNames.size == 1
           val ess      = if (singular) "" else "s"
           val bee      = if (singular) "is" else "are"
-          Some(s"The type parameter$ess ${unboundNames mkString ", "} referenced in the message of the @$annotationName annotation $bee not defined by $sym.")
+          val invisMsg = s"The type parameter$ess ${unboundNames mkString ", "} referenced in the message of the @$annotationName annotation $bee not visible at $sym."
+          val hintMsg  =
+            if (decls.isEmpty)
+              s"Note that there are no type parameters visible at ${sym.name}."
+            else {
+              val locatedTparams = typeParams.map { tp =>
+                //tp.fullLocationString drop 5
+                s"${tp.name} (in ${tp.owner})"
+              }
+              s"Note that the following type parameters are visible at ${sym.name}: ${locatedTparams mkString ", "}"
+            }
+
+          Some(s"$invisMsg\n$hintMsg")
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1423,7 +1423,7 @@ abstract class RefChecks extends Transform {
           applyChecks(sym.annotations)
 
           def messageWarning(name: String)(warn: String) =
-            reporter.warning(tree.pos, f"Invalid $name message for ${sym}%s${sym.locationString}%s:%n$warn")
+            reporter.warning(tree.pos, f"Invalid @$name message for $sym%s${sym.locationString}%s:%n$warn")
 
           // validate implicitNotFoundMessage and implicitAmbiguousMessage
           analyzer.ImplicitNotFoundMsg.check(sym) foreach messageWarning("implicitNotFound")

--- a/test/files/neg/implicit-ambiguous-invalid.check
+++ b/test/files/neg/implicit-ambiguous-invalid.check
@@ -1,5 +1,6 @@
-implicit-ambiguous-invalid.scala:5: warning: Invalid implicitAmbiguous message for method neqAmbig1 in object Test:
-The type parameter B referenced in the message of the @implicitAmbiguous annotation is not defined by method neqAmbig1.
+implicit-ambiguous-invalid.scala:5: warning: Invalid @implicitAmbiguous message for method neqAmbig1 in object Test:
+The type parameter B referenced in the message of the @implicitAmbiguous annotation is not visible at method neqAmbig1.
+Note that the following type parameters are visible at neqAmbig1: A (in method neqAmbig1)
   implicit def neqAmbig1[A] : A =!= A = null
                ^
 error: No warnings can be incurred under -Xfatal-warnings.

--- a/test/files/neg/implicitNotFound-outer-validation.check
+++ b/test/files/neg/implicitNotFound-outer-validation.check
@@ -1,0 +1,23 @@
+implicitNotFound-outer-validation.scala:22: warning: Invalid @implicitNotFound message for trait Outer in package none-of-these-do:
+The type parameters M, Q referenced in the message of the @implicitNotFound annotation are not visible at trait Outer.
+Note that the following type parameters are visible at Outer: O (in trait Outer)
+  trait Outer[O] {
+        ^
+implicitNotFound-outer-validation.scala:24: warning: Invalid @implicitNotFound message for trait Mid in trait Outer:
+The type parameters I, Q referenced in the message of the @implicitNotFound annotation are not visible at trait Mid.
+Note that the following type parameters are visible at Mid: M (in trait Mid), O (in trait Outer)
+    trait Mid[M] {
+          ^
+implicitNotFound-outer-validation.scala:26: warning: Invalid @implicitNotFound message for trait Inner in trait Mid:
+The type parameters Q, Thwop referenced in the message of the @implicitNotFound annotation are not visible at trait Inner.
+Note that the following type parameters are visible at Inner: I (in trait Inner), M (in trait Mid), O (in trait Outer)
+      trait Inner[I]
+            ^
+implicitNotFound-outer-validation.scala:31: warning: Invalid @implicitNotFound message for trait Hrem in object Meh:
+The type parameters M, I referenced in the message of the @implicitNotFound annotation are not visible at trait Hrem.
+Note that the following type parameters are visible at Hrem: Q (in trait Hrem), O (in trait Outer)
+      trait Hrem[Q] extends meh.Inner[Q]
+            ^
+error: No warnings can be incurred under -Xfatal-warnings.
+four warnings found
+one error found

--- a/test/files/neg/implicitNotFound-outer-validation.flags
+++ b/test/files/neg/implicitNotFound-outer-validation.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Ystop-after:refchecks

--- a/test/files/neg/implicitNotFound-outer-validation.scala
+++ b/test/files/neg/implicitNotFound-outer-validation.scala
@@ -1,0 +1,36 @@
+import annotation.{implicitNotFound => inf}
+
+package `all-of-these-work` {
+  @inf("${O}")
+  trait Outer[O] {
+    @inf("${O} ${M}")
+    trait Mid[M] {
+      @inf("${O} ${M} ${I}")
+      trait Inner[I]
+    }
+
+    object Meh extends Mid[Int] { meh =>
+      @inf("${O} ${Q}")
+      trait Hrem[Q] extends meh.Inner[Q]
+    }
+  }
+}
+
+package `none-of-these-do` {
+  /* these don't */
+  @inf("${M} ${Q}")
+  trait Outer[O] {
+    @inf("${I} ${Q}")
+    trait Mid[M] {
+      @inf("${Q} ${Thwop}")
+      trait Inner[I]
+    }
+
+    object Meh extends Mid[Int] { meh =>
+      @inf("${M} ${I}")
+      trait Hrem[Q] extends meh.Inner[Q]
+    }
+
+  }
+
+}

--- a/test/files/neg/implicitNotFound-outer.check
+++ b/test/files/neg/implicitNotFound-outer.check
@@ -1,0 +1,31 @@
+implicitNotFound-outer.scala:19: error: Mid not found ... O1: Int; O2: String; M1: Long; M2: Long
+  implicitly[Outer[Int, String]#Mid[Long, Long]]
+            ^
+implicitNotFound-outer.scala:22: error: Mid not found ... O1: Int; O2: String; M1: Long; M2: Outer[Symbol,String]
+  implicitly[Outer[Int, String]#Mid[Long, Outer[Symbol, String]]]
+            ^
+implicitNotFound-outer.scala:25: error: Inner not found ... O1: Int; O2: Bar; M1: Foo; M2: Baz; I1: Foo
+  implicitly[Outer[Double, Bar]#Mid[Foo, Baz]#Inner[Int, Foo]]
+            ^
+implicitNotFound-outer.scala:30: error: Mid not found ... O1: Foo; O2: Long; M1: Bar; M2: Baz
+    implicitly[this.Mid[Bar, Baz]]
+              ^
+implicitNotFound-outer.scala:33: error: Inner not found ... O1: String; O2: Long; M1: Baz; M2: Nothing; I1: String
+    implicitly[Mid[Baz, Nothing]#Inner[String, String]]
+              ^
+implicitNotFound-outer.scala:38: error: Mid not found ... O1: Foo; O2: Long; M1: Long; M2: Bar
+      implicitly[ao.Mid[Long, Bar]]
+                ^
+implicitNotFound-outer.scala:41: error: Inner not found ... O1: Test.AnOuter.type; O2: Long; M1: Bar; M2: Long; I1: Long
+      implicitly[Inner[ao.type, Long]]
+                ^
+implicitNotFound-outer.scala:48: error: Mid not found ... O1: Foo; O2: Long; M1: Long; M2: Baz
+  implicitly[AnOuter.Mid[Long, Baz]]
+            ^
+implicitNotFound-outer.scala:55: error: Mid not found ... O1: java.time.Instant; O2: java.time.Instant; M1: Long; M2: Baz
+  implicitly[ho.Mid[Long, Baz]]
+            ^
+implicitNotFound-outer.scala:60: error: Inner not found ... O1: Bar; O2: Serializable; M1: Int; M2: Baz; I1: Long
+  implicitly[anon.Mid[Int, Baz]#Inner[Bar, Long]]
+            ^
+10 errors found

--- a/test/files/neg/implicitNotFound-outer.scala
+++ b/test/files/neg/implicitNotFound-outer.scala
@@ -1,0 +1,62 @@
+import annotation.{implicitNotFound => inf}
+
+trait Outer[O1, O2 <: Serializable] {
+
+  @inf("Mid not found ... O1: ${O1}; O2: ${O2}; M1: ${M1}; M2: ${M2}")
+  trait Mid[M1, M2 <: O1] {
+
+    @inf("Inner not found ... O1: ${O1}; O2: ${O2}; M1: ${M1}; M2: ${M2}; I1: ${I1}")
+    trait Inner[O1, I1]
+
+  }
+}
+
+trait Foo; trait Bar; trait Baz
+
+object Test {
+
+  // error: Mid not found ... O1: Int; O2: String; M1: Long; M2: Long
+  implicitly[Outer[Int, String]#Mid[Long, Long]]
+
+  // error: Mid not found ... O1: Int; O2: String; M1: Long; M2: Outer[Symbol,String]
+  implicitly[Outer[Int, String]#Mid[Long, Outer[Symbol, String]]]
+
+  // error: Inner not found ... O1: Int; O2: Bar; M1: Foo; M2: Baz; I1: Foo
+  implicitly[Outer[Double, Bar]#Mid[Foo, Baz]#Inner[Int, Foo]]
+
+  object AnOuter extends Outer[Foo, Long] { ao =>
+
+    // error: Mid not found ... O1: Foo; O2: Long; M1: Bar; M2: Baz
+    implicitly[this.Mid[Bar, Baz]]
+
+    // error: Inner not found ... O1: String; O2: Long; M1: Baz; M2: Nothing; I1: String
+    implicitly[Mid[Baz, Nothing]#Inner[String, String]]
+
+    object AnInner extends ao.Mid[Bar, Long] {
+
+      // error: Mid not found ... O1: Foo; O2: Long; M1: Long; M2: Bar
+      implicitly[ao.Mid[Long, Bar]]
+
+      // error: Inner not found ... O1: Test.AnOuter.type; O2: Long; M1: Bar; M2: Long; I1: Long
+      implicitly[Inner[ao.type, Long]]
+
+    }
+
+  }
+
+  // error: Mid not found ... O1: Foo; O2: Long; M1: Long; M2: Baz
+  implicitly[AnOuter.Mid[Long, Baz]]
+
+  class HalfOuter[R <: Serializable] extends Outer[R, R]
+
+  val ho = new HalfOuter[java.time.Instant]
+
+  // error: Mid not found ... O1: java.time.Instant; O2: java.time.Instant; M1: Long; M2: Baz
+  implicitly[ho.Mid[Long, Baz]]
+
+  val anon = new AnyRef with Outer[Symbol, Serializable]
+
+  // error: Inner not found ... O1: Bar; O2: Serializable; M1: Int; M2: Baz; I1: Long
+  implicitly[anon.Mid[Int, Baz]#Inner[Bar, Long]]
+}
+

--- a/test/files/neg/t2462b.check
+++ b/test/files/neg/t2462b.check
@@ -1,9 +1,11 @@
-t2462b.scala:6: warning: Invalid implicitNotFound message for trait Meh in package test:
-The type parameters Too, Elem referenced in the message of the @implicitNotFound annotation are not defined by trait Meh.
+t2462b.scala:6: warning: Invalid @implicitNotFound message for trait Meh in package test:
+The type parameters Too, Elem referenced in the message of the @implicitNotFound annotation are not visible at trait Meh.
+Note that the following type parameters are visible at Meh: From (in trait Meh), To (in trait Meh)
 trait Meh[-From, +To]
       ^
-t2462b.scala:9: warning: Invalid implicitNotFound message for trait Meh2 in package test:
-The type parameter Elem referenced in the message of the @implicitNotFound annotation is not defined by trait Meh2.
+t2462b.scala:9: warning: Invalid @implicitNotFound message for trait Meh2 in package test:
+The type parameter Elem referenced in the message of the @implicitNotFound annotation is not visible at trait Meh2.
+Note that the following type parameters are visible at Meh2: From (in trait Meh2), To (in trait Meh2)
 trait Meh2[-From, +To]
       ^
 error: No warnings can be incurred under -Xfatal-warnings.


### PR DESCRIPTION
Motivation:

```scala
class HMap[Rel[_, _]] {
  def get[K, V](k: K)(implicit rel: Rel[K, V]): V
  def add[K, V](k: K, v: V)(implicit rel: Rel[K, V]): HMap[Rel]
}

trait ListOf[Upper] {
  @implicitNotFound("Cannot add (${K}, ${V}) to a HMap (is ${V} =:= List[${K}] and <: ${Upper}?)")
  trait Lambda[K, V]
}
object ListOf {
  implicit def rel[Upper, T <: Upper]: ListOf[Upper]#Lambda[T,List[T]] = ...
}
```

and various other type-level weirdnesses.

The implementation is pretty simple: traverse the type, grabbing `(sym.tparams zip args)` for each `TypeRef` we can get our hands on. For `validate`, of course, we have the symbol of the type definition to go off of, and just grab the `tparams` from all of the types in the `ownerChain`.

I also buffed up the validation message since I was in the area anyways.

PR note: there are things like `TypeCollector` which seem almost what I want, but I couldn't get them to work exactly as expected. If that'd be a better solution I'm all for using it, but I could use a pointer on which one is what I want.