### PR TITLE
[WIP] Skip over contexts with the same our outer nested scopes during name lookup.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1081,7 +1081,7 @@ trait Contexts { self: Analyzer =>
             else newOverloaded(cx.owner, pre, entries)
         }
         if (!defSym.exists)
-          cx = cx.outer // push further outward
+          cx = outerContextWithDistinctScope(cx) // push further outward
       }
       if (symbolDepth < 0)
         symbolDepth = cx.depth
@@ -1183,6 +1183,13 @@ trait Contexts { self: Analyzer =>
       else finish(EmptyTree, NoSymbol)
     }
 
+    @inline final def outerContextWithDistinctScope(ctx0: Context): Context = {
+      var ctx = ctx0
+      while((ctx.outer.scope eq ctx.scope) || ctx.scope.nestingLevel > 0)
+        ctx = ctx.outer
+      ctx.outer
+    }
+
     /**
      * Find a symbol in this context or one of its outers.
      *
@@ -1200,7 +1207,7 @@ trait Contexts { self: Analyzer =>
         if (s != NoSymbol && s.owner == expectedOwner)
           res = s
         else
-          ctx = ctx.outer
+          ctx = outerContextWithDistinctScope(ctx)
       }
       res
     }
@@ -1215,7 +1222,7 @@ trait Contexts { self: Analyzer =>
           if (s != null)
             res = s
           else
-            ctx = ctx.outer
+            ctx = outerContextWithDistinctScope(ctx)
         }
         res
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1207,7 +1207,7 @@ trait Contexts { self: Analyzer =>
         if (s != NoSymbol && s.owner == expectedOwner)
           res = s
         else
-          ctx = outerContextWithDistinctScope(ctx)
+          ctx = ctx.outer
       }
       res
     }
@@ -1222,7 +1222,7 @@ trait Contexts { self: Analyzer =>
           if (s != null)
             res = s
           else
-            ctx = outerContextWithDistinctScope(ctx)
+            ctx = ctx.outer
         }
         res
       }

--- a/test/files/pos/skip-contexts.scala
+++ b/test/files/pos/skip-contexts.scala
@@ -1,0 +1,14 @@
+abstract class Test {
+  trait Symbol
+  trait Type
+
+  @noinline
+  private final def javaSig0(sym0: Symbol, info: Type, markClassUsed: Symbol => Unit): Option[String] = {
+    def boxedSig(tp: Type): Unit = jsig(tp, primitiveOK = false)
+
+    @noinline
+    def jsig(tp0: Type, existentiallyBound: List[Symbol] = Nil, toplevel: Boolean = false, primitiveOK: Boolean = true): Unit = ()
+
+    None
+  }
+}


### PR DESCRIPTION
This avoids researching the scope of an enclosing context if the scope is identical or if the inner scope was nested in the outer (which would mean that we have searched the outer scopes definitions already).

This does result in fewer searches, but if anything appears to very marginally increase compile times ... I'm mainly submitting this PR to see what peoples opinions are on why this doesn't result in any sort of speedup.