### PR TITLE
Failing tests for type comparisons.

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2982,17 +2982,22 @@ trait Types
   trait UntouchableTypeVar extends TypeVar {
     override def untouchable = true
     override def isGround = true
-    override def registerTypeEquality(tp: Type, typeVarLHS: Boolean) = tp match {
-      case t: TypeVar if !t.untouchable =>
-        t.registerTypeEquality(this, !typeVarLHS)
-      case _ =>
-        super.registerTypeEquality(tp, typeVarLHS)
+    override def registerTypeEquality(tp: Type, typeVarLHS: Boolean) = {
+      assert((params.size - typeArgs.size) == (tp.typeParams.size))
+      tp match {
+        case t: TypeVar if !t.untouchable =>
+          t.registerTypeEquality(this, !typeVarLHS)
+        case _ =>
+          super.registerTypeEquality(tp, typeVarLHS)
+      }
     }
-    override def registerBound(tp: Type, isLowerBound: Boolean, isNumericBound: Boolean = false): Boolean = tp match {
-      case t: TypeVar if !t.untouchable =>
-        t.registerBound(this, !isLowerBound, isNumericBound)
-      case _ =>
-        super.registerBound(tp, isLowerBound, isNumericBound)
+    override def registerBound(tp: Type, isLowerBound: Boolean, isNumericBound: Boolean = false): Boolean = {
+      tp match {
+        case t: TypeVar if !t.untouchable =>
+          t.registerBound(this, !isLowerBound, isNumericBound)
+        case _ =>
+          super.registerBound(tp, isLowerBound, isNumericBound)
+      }
     }
   }
 
@@ -3277,6 +3282,7 @@ trait Types
     }
 
     def registerTypeEquality(tp: Type, typeVarLHS: Boolean): Boolean = {
+      assert((params.size - typeArgs.size) == (tp.typeParams.size))
 //      println("regTypeEq: "+(safeToString, debugString(tp), tp.getClass, if (typeVarLHS) "in LHS" else "in RHS", if (suspended) "ZZ" else if (instValid) "IV" else "")) //@MDEBUG
       def checkIsSameType(tp: Type) = (
         if (typeVarLHS) inst =:= tp


### PR DESCRIPTION
These tests show that for types `Foo[A]`, `Bar[A, B]` and type variables `F[_]`, `G[_, _]`:

 1. It is possible to unify the type variable `?G` with `[A]Bar[A, A]`, which is incorrect because of the different number of type parameters (2 vs 1).
 2. Both `Foo <:< ?F` and `?F <:< [A]Bar[Int, A]` _simultaneously_, which by transitivity means `Foo <:< [A]Bar[Int, A]`, which is not true.

I don't know if these are reproducible through compilation, but they hinder my progress on correctly implementing and testing #6069.

For starters, is there agreement that these are bugs that need to be addressed?