### PR TITLE
Remove sorting of implicit candidates by use frequency and divergent-prone Ordering implicit

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -957,8 +957,12 @@ trait Implicits {
           result
         }
 
-        // most frequent one first
-        matches sortBy (x => if (isView) -x.useCountView else -x.useCountArg)
+        if (settings.isScala213) matches
+        else {
+          // most frequent one first under Scala 2.12 mode. We've turned this optimization off to avoid
+          // compilation order variation in whether a search succeeds or diverges.
+          matches sortBy (x => if (isView) -x.useCountView else -x.useCountArg)
+        }
       }
       if (eligible.nonEmpty)
         printTyping(tree, eligible.size + s" eligible for pt=$pt at ${fullSiteString(context)}")

--- a/test/files/neg/divergent-implicit.check
+++ b/test/files/neg/divergent-implicit.check
@@ -4,7 +4,7 @@ divergent-implicit.scala:4: error: type mismatch;
   val x1: String = 1
                    ^
 divergent-implicit.scala:5: error: diverging implicit expansion for type Int => String
-starting with method $conforms in object Predef
+starting with method cast in object Test1
   val x2: String = cast[Int, String](1)
                                     ^
 divergent-implicit.scala:14: error: type mismatch;

--- a/test/files/neg/t2316.check
+++ b/test/files/neg/t2316.check
@@ -1,6 +1,6 @@
 t2316.scala:28: error: ambiguous implicit values:
- both method T1FromT3 in object T1 of type (implicit t3: test.T3)test.T1
- and method T1FromT2 in object T1 of type (implicit t2: test.T2)test.T1
+ both method T1FromT2 in object T1 of type (implicit t2: test.T2)test.T1
+ and method T1FromT3 in object T1 of type (implicit t3: test.T3)test.T1
  match expected type test.T1
       val t1 = requireT1
                ^


### PR DESCRIPTION
This performance optimization leads to compilation order dependent variations
in whether an implicit search will diverge or will find a successful result.

Let's try turning off this sorting and measuring the impact on compilation
speed.

It is worth noting that I have observed cases in the past where this sorting
was actually counterproductive, as it undermines the attempt of an macro
author to control the order of implicit searches with the subclass rule of
static overload resolution. The subclass rule is still applied correctly,
but the superclass implicit can be tried _before_ the subclass implicit 
which can explore more expensive parts of the search space that end
up being out-prioritized.

Refererences: scala/bug#10222, scala/bug#8541, scala/bug#10080