### PR TITLE
Separate project for java sources in library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -327,7 +327,7 @@ lazy val library = configureAsSubproject(project)
   .settings(
     name := "scala-library",
     description := "Scala Standard Library",
-    compileOrder := CompileOrder.Mixed, // needed for JFunction classes in scala.runtime.java8
+    javacOptions in Compile ++= Seq("-sourcepath", ((baseDirectory in ThisBuild).value / "src" / "shims").getAbsolutePath),
     scalacOptions in Compile ++= Seq[String]("-sourcepath", (scalaSource in Compile).value.toString),
     scalacOptions in Compile in doc ++= {
       val libraryAuxDir = (baseDirectory in ThisBuild).value / "src/library-aux"

--- a/src/shims/scala/Function0.java
+++ b/src/shims/scala/Function0.java
@@ -1,0 +1,3 @@
+package scala;
+
+public interface Function0 { }

--- a/src/shims/scala/Function1.java
+++ b/src/shims/scala/Function1.java
@@ -1,0 +1,3 @@
+package scala;
+
+public interface Function1 { }

--- a/src/shims/scala/Function2.java
+++ b/src/shims/scala/Function2.java
@@ -1,0 +1,3 @@
+package scala;
+
+public interface Function2 { }

--- a/src/shims/scala/runtime/EmptyMethodCache.java
+++ b/src/shims/scala/runtime/EmptyMethodCache.java
@@ -1,0 +1,3 @@
+package scala.runtime;
+
+public class EmptyMethodCache extends MethodCache { }

--- a/src/shims/scala/runtime/LambdaDeserializer$.java
+++ b/src/shims/scala/runtime/LambdaDeserializer$.java
@@ -1,0 +1,11 @@
+package scala.runtime;
+
+import java.lang.invoke.*;
+
+public class LambdaDeserializer$ {
+  public static LambdaDeserializer$ MODULE$;
+
+  public Object deserializeLambda(MethodHandles.Lookup lookup, java.util.Map<String, MethodHandle> cache, java.util.Map<String, MethodHandle> targetMethodMap, SerializedLambda serialized) {
+    return null;
+  }
+}

--- a/src/shims/scala/runtime/MethodCache.java
+++ b/src/shims/scala/runtime/MethodCache.java
@@ -1,0 +1,8 @@
+package scala.runtime;
+
+import java.lang.reflect.Method;
+
+public class MethodCache {
+  public Method find(Class<?> forReceiver) { return null; }
+  public MethodCache add(Class<?> forReceiver, Method forMethod) { return null; }
+}


### PR DESCRIPTION
Split java sources from the library into a separate sbt
project to avoid mixed compilation. This enables inlining
code that uses types defined in these classes, which is
quite common.

See scala/scala-dev#428

Certain Java sources cannot be moved (`JFunctionN$mc...`)
as they depend on Scala sources in the library, so we have
to keep mixed compilation for the library project itself.