### PR TITLE
Merge 2.12.x into 2.13.x

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -337,7 +337,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
      */
     object locals {
 
-      private val slots = mutable.Map.empty[Symbol, Local] // (local-or-param-sym -> Local(BType, name, idx, isSynth))
+      private val slots = mutable.AnyRefMap.empty[Symbol, Local] // (local-or-param-sym -> Local(BType, name, idx, isSynth))
 
       private var nxtIdx = -1 // next available index for local-var
 
@@ -369,10 +369,11 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
       }
 
       private def makeLocal(sym: Symbol, tk: BType): Local = {
-        assert(!slots.contains(sym), "attempt to create duplicate local var.")
         assert(nxtIdx != -1, "not a valid start index")
         val loc = Local(tk, sym.javaSimpleName.toString, nxtIdx, sym.isSynthetic)
-        slots += (sym -> loc)
+        val existing = slots.put(sym, loc)
+        if (existing.isDefined)
+          globalError(sym.pos, "attempt to create duplicate local var.")
         assert(tk.size > 0, "makeLocal called for a symbol whose type is Unit.")
         nxtIdx += tk.size
         loc

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -76,8 +76,6 @@ abstract class ClassfileParser {
 
   def srcfile = srcfile0
 
-  private def optimized         = settings.optimise.value
-
   // u1, u2, and u4 are what these data types are called in the JVM spec.
   // They are an unsigned byte, unsigned char, and unsigned int respectively.
   // We bitmask u1 into an Int to make sure it's 0-255 (and u1 isn't used
@@ -534,7 +532,7 @@ abstract class ClassfileParser {
     val jflags = readFieldFlags()
     val sflags = jflags.toScalaFlags
 
-    if ((sflags & PRIVATE) != 0L && !optimized) {
+    if ((sflags & PRIVATE) != 0L) {
       in.skip(4); skipAttributes()
     } else {
       val name    = readName()
@@ -572,13 +570,13 @@ abstract class ClassfileParser {
   def parseMethod() {
     val jflags = readMethodFlags()
     val sflags = jflags.toScalaFlags
-    if (jflags.isPrivate && !optimized) {
+    if (jflags.isPrivate) {
       val name = readName()
       if (name == nme.CONSTRUCTOR)
         sawPrivateConstructor = true
       in.skip(2); skipAttributes()
     } else {
-      if ((sflags & PRIVATE) != 0L && optimized) { // TODO this should be !optimized, no? See c4181f656d.
+      if ((sflags & PRIVATE) != 0L) {
         in.skip(4); skipAttributes()
       } else {
         val name = readName()
@@ -885,6 +883,7 @@ abstract class ClassfileParser {
               case Some(san: AnnotationInfo) =>
                 val bytes =
                   san.assocs.find({ _._1 == nme.bytes }).get._2.asInstanceOf[ScalaSigBytes].bytes
+
                 unpickler.unpickle(bytes, 0, clazz, staticModule, in.file.name)
               case None =>
                 throw new RuntimeException("Scala class file does not contain Scala annotation")

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -704,7 +704,7 @@ abstract class RefChecks extends Transform {
                           // Compilation has already failed so we shouldn't have to worry overmuch
                           // about forcing types.
                           if (underlying.isJavaDefined && pa.typeArgs.isEmpty && abstractSym.typeParams.nonEmpty)
-                            ". To implement a raw type, use %s[_]".format(pa)
+                            s". To implement this raw type, use ${rawToExistential(pa)}"
                           else if (pa.prefix =:= pc.prefix)
                             ": their type parameters differ"
                           else

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1398,13 +1398,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       newNonClassSymbol(name, pos, newFlags)
 
     /**
-     * The class or term up to which this symbol is accessible, or RootClass if it is public. As
-     * Java protected statics are otherwise completely inaccessible in Scala, they are treated as
-     * public (scala/bug#1806).
+     * The class or term up to which this symbol is accessible, or else
+     * `enclosingRootClass` if it is public.
      */
     def accessBoundary(base: Symbol): Symbol = {
       if (hasFlag(PRIVATE) || isLocalToBlock) owner
-      else if (hasAllFlags(PROTECTED | STATIC | JAVA)) enclosingRootClass
       else if (hasAccessBoundary && !phase.erasedTypes) privateWithin // Phase check needed? See comment in Context.isAccessible.
       else if (hasFlag(PROTECTED)) base
       else enclosingRootClass

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3876,8 +3876,8 @@ trait Types
   }
 
   def typeParamsToExistentials(clazz: Symbol, tparams: List[Symbol]): List[Symbol] = {
-    val eparams = mapWithIndex(tparams)((tparam, i) =>
-      clazz.newExistential(newTypeName("?"+i), clazz.pos) setInfo tparam.info.bounds)
+    val eparams = tparams map (tparam =>
+      clazz.newExistential(tparam.name.toTypeName, clazz.pos) setInfo tparam.info.bounds)
 
     eparams map (_ substInfo (tparams, eparams))
   }

--- a/test/files/neg/abstract-class-error.check
+++ b/test/files/neg/abstract-class-error.check
@@ -1,5 +1,5 @@
 S.scala:1: error: class S needs to be abstract, since method g in class J of type (y: Int, z: java.util.List)Int is not defined
-(Note that java.util.List does not match java.util.List[String]. To implement a raw type, use java.util.List[_])
+(Note that java.util.List does not match java.util.List[String]. To implement this raw type, use java.util.List[_])
 class S extends J {
       ^
 one error found

--- a/test/files/neg/t10260.check
+++ b/test/files/neg/t10260.check
@@ -1,0 +1,17 @@
+Test.scala:1: error: class IAImpl needs to be abstract, since method foo in trait IA of type (a: A)Unit is not defined
+(Note that A does not match A[_]. To implement this raw type, use A[T] forSome { type T <: A[T] })
+class IAImpl extends IA { def foo(a: A[_]) = ??? }
+      ^
+Test.scala:2: error: class IBImpl needs to be abstract, since method foo in trait IB of type (a: B)Unit is not defined
+(Note that B does not match B[_, _]. To implement this raw type, use B[T,R] forSome { type T; type R <: java.util.List[_ >: T] })
+class IBImpl extends IB { def foo(a: B[_,_]) = ??? }
+      ^
+Test.scala:3: error: class ICImpl needs to be abstract, since method foo in trait IC of type (a: Int, b: C, c: String)C is not defined
+(Note that C does not match C[_]. To implement this raw type, use C[_ <: String])
+class ICImpl extends IC { def foo(a: Int, b: C[_], c: String) = ??? }
+      ^
+Test.scala:4: error: class IDImpl needs to be abstract, since method foo in trait ID of type (a: D)Unit is not defined
+(Note that D does not match D[_ <: String]. To implement this raw type, use D[_])
+class IDImpl extends ID { def foo(a: D[_ <: String]) = ??? }
+      ^
+four errors found

--- a/test/files/neg/t10260/A.java
+++ b/test/files/neg/t10260/A.java
@@ -1,0 +1,2 @@
+public class A<T extends A<T>> {}
+

--- a/test/files/neg/t10260/B.java
+++ b/test/files/neg/t10260/B.java
@@ -1,0 +1,2 @@
+public class B<T, R extends java.util.List<? super T>> {}
+

--- a/test/files/neg/t10260/C.java
+++ b/test/files/neg/t10260/C.java
@@ -1,0 +1,2 @@
+public class C<T extends String> {}
+

--- a/test/files/neg/t10260/D.java
+++ b/test/files/neg/t10260/D.java
@@ -1,0 +1,2 @@
+public class D<T> {}
+

--- a/test/files/neg/t10260/IA.java
+++ b/test/files/neg/t10260/IA.java
@@ -1,0 +1,3 @@
+public interface IA {
+    void foo(A a);
+}

--- a/test/files/neg/t10260/IB.java
+++ b/test/files/neg/t10260/IB.java
@@ -1,0 +1,3 @@
+public interface IB {
+    void foo(B a);
+}

--- a/test/files/neg/t10260/IC.java
+++ b/test/files/neg/t10260/IC.java
@@ -1,0 +1,3 @@
+public interface IC {
+    C foo(int a, C b, String c);
+}

--- a/test/files/neg/t10260/ID.java
+++ b/test/files/neg/t10260/ID.java
@@ -1,0 +1,3 @@
+public interface ID {
+    void foo(D a);
+}

--- a/test/files/neg/t10260/Test.scala
+++ b/test/files/neg/t10260/Test.scala
@@ -1,0 +1,4 @@
+class IAImpl extends IA { def foo(a: A[_]) = ??? }
+class IBImpl extends IB { def foo(a: B[_,_]) = ??? }
+class ICImpl extends IC { def foo(a: Int, b: C[_], c: String) = ??? }
+class IDImpl extends ID { def foo(a: D[_ <: String]) = ??? }

--- a/test/files/neg/t3871b.check
+++ b/test/files/neg/t3871b.check
@@ -4,7 +4,7 @@ t3871b.scala:61: error: not found: value protOT
 t3871b.scala:77: error: method prot in class A cannot be accessed in E.this.A
  Access to protected method prot not permitted because
  prefix type E.this.A does not conform to
- class B in class E where the access take place
+ class B in class E where the access takes place
       a.prot    // not allowed, prefix type `A` does not conform to `B`
         ^
 t3871b.scala:79: error: value protT is not a member of E.this.B
@@ -19,7 +19,7 @@ t3871b.scala:81: error: value protT is not a member of E.this.A
 t3871b.scala:91: error: method prot in class A cannot be accessed in E.this.A
  Access to protected method prot not permitted because
  prefix type E.this.A does not conform to
- object B in class E where the access take place
+ object B in class E where the access takes place
       a.prot    // not allowed
         ^
 t3871b.scala:93: error: value protT is not a member of E.this.B

--- a/test/files/neg/t3934.check
+++ b/test/files/neg/t3934.check
@@ -7,7 +7,7 @@ t3934.scala:15: error: method f2 in class J cannot be accessed in test.J
 t3934.scala:20: error: method f2 in class J cannot be accessed in test.J
  Access to protected method f2 not permitted because
  prefix type test.J does not conform to
- class S2 in package nest where the access take place
+ class S2 in package nest where the access takes place
   def g2(x: J) = x.f2()
                    ^
 two errors found

--- a/test/files/neg/t4541.check
+++ b/test/files/neg/t4541.check
@@ -1,7 +1,7 @@
 t4541.scala:11: error: variable data in class Sparse cannot be accessed in Sparse[Int]
  Access to protected variable data not permitted because
  prefix type Sparse[Int] does not conform to
- class Sparse$mcI$sp where the access take place
+ class Sparse$mcI$sp where the access takes place
     that.data
          ^
 one error found

--- a/test/files/neg/t4541b.check
+++ b/test/files/neg/t4541b.check
@@ -1,7 +1,7 @@
 t4541b.scala:13: error: variable data in class SparseArray cannot be accessed in SparseArray[Int]
  Access to protected variable data not permitted because
  prefix type SparseArray[Int] does not conform to
- class SparseArray$mcI$sp where the access take place
+ class SparseArray$mcI$sp where the access takes place
     use(that.data.clone)
              ^
 one error found

--- a/test/files/neg/t6934.check
+++ b/test/files/neg/t6934.check
@@ -1,0 +1,7 @@
+ScalaMain.scala:6: error: variable STATIC_PROTECTED_FIELD in object JavaClass cannot be accessed in object test.JavaClass
+ Access to protected variable STATIC_PROTECTED_FIELD not permitted because
+ enclosing object ScalaMain in package test2 is not a subclass of
+ object JavaClass in package test where target is defined
+    val a = test.JavaClass.STATIC_PROTECTED_FIELD
+                           ^
+one error found

--- a/test/files/neg/t6934/JavaClass.java
+++ b/test/files/neg/t6934/JavaClass.java
@@ -1,0 +1,8 @@
+package test;
+
+public class JavaClass {
+
+    protected static int STATIC_PROTECTED_FIELD = 4;
+
+}
+

--- a/test/files/neg/t6934/ScalaClass.scala
+++ b/test/files/neg/t6934/ScalaClass.scala
@@ -1,0 +1,6 @@
+package test
+
+class ScalaClass {
+  /* double-checking that we can still do this */
+  def hmm = JavaClass.STATIC_PROTECTED_FIELD
+}

--- a/test/files/neg/t6934/ScalaMain.scala
+++ b/test/files/neg/t6934/ScalaMain.scala
@@ -1,0 +1,9 @@
+package test2
+
+object ScalaMain {
+
+  def main(args: Array[String]) {
+    val a = test.JavaClass.STATIC_PROTECTED_FIELD
+  }
+
+}

--- a/test/files/neg/t8244.check
+++ b/test/files/neg/t8244.check
@@ -1,4 +1,4 @@
-Test_2.scala:9: error: value exxx is not a member of ?0
+Test_2.scala:9: error: value exxx is not a member of T
     raw.t.exxx // java.lang.ClassCastException: java.lang.String cannot be cast to X
           ^
 one error found

--- a/test/files/neg/t8244e.check
+++ b/test/files/neg/t8244e.check
@@ -1,4 +1,4 @@
-Test.scala:9: error: value exxx is not a member of ?0
+Test.scala:9: error: value exxx is not a member of T
     raw.t.exxx // java.lang.ClassCastException: java.lang.String cannot be cast to X
           ^
 one error found

--- a/test/files/pos/t9122.scala
+++ b/test/files/pos/t9122.scala
@@ -1,0 +1,8 @@
+class X[A](a: A)
+object Test {
+  implicit val ImplicitBoolean: Boolean = true
+  def local = {
+    implicit object X extends X({ def local2 = implicitly[Boolean] ; "" })
+    implicitly[X[String]]
+  }
+}

--- a/test/files/run/existentials-in-compiler.check
+++ b/test/files/run/existentials-in-compiler.check
@@ -2,16 +2,16 @@ abstract trait Bippy[A <: AnyRef, B] extends AnyRef
     extest.Bippy[_ <: AnyRef, _]
 
 abstract trait BippyBud[A <: AnyRef, B, C <: List[A]] extends AnyRef
-    extest.BippyBud[?0,?1,?2] forSome { type ?0 <: AnyRef; type ?1; type ?2 <: List[?0] }
+    extest.BippyBud[A,B,C] forSome { type A <: AnyRef; type B; type C <: List[A] }
 
 abstract trait BippyLike[A <: AnyRef, B <: List[A], This <: extest.BippyLike[A,B,This] with extest.Bippy[A,B]] extends AnyRef
-    extest.BippyLike[?0,?1,?2] forSome { type ?0 <: AnyRef; type ?1 <: List[?0]; type ?2 <: extest.BippyLike[?0,?1,?2] with extest.Bippy[?0,?1] }
+    extest.BippyLike[A,B,This] forSome { type A <: AnyRef; type B <: List[A]; type This <: extest.BippyLike[A,B,This] with extest.Bippy[A,B] }
 
 abstract trait Contra[-A >: AnyRef, -B] extends AnyRef
     extest.Contra[_ >: AnyRef, _]
 
 abstract trait ContraLike[-A >: AnyRef, -B >: List[A]] extends AnyRef
-    extest.ContraLike[?0,?1] forSome { type ?0 >: AnyRef; type ?1 >: List[?0] }
+    extest.ContraLike[A,B] forSome { type A >: AnyRef; type B >: List[A] }
 
 abstract trait Cov01[+A <: AnyRef, +B] extends AnyRef
     extest.Cov01[_ <: AnyRef, _]
@@ -95,28 +95,28 @@ abstract trait Cov29[-A, -B] extends AnyRef
     extest.Cov29[_, _]
 
 abstract trait Cov31[+A, +B, C <: (A, B)] extends AnyRef
-    extest.Cov31[?0,?1,?2] forSome { type ?0; type ?1; type ?2 <: (?0, ?1) }
+    extest.Cov31[A,B,C] forSome { type A; type B; type C <: (A, B) }
 
 abstract trait Cov32[+A, B, C <: (A, B)] extends AnyRef
-    extest.Cov32[?0,?1,?2] forSome { type ?0; type ?1; type ?2 <: (?0, ?1) }
+    extest.Cov32[A,B,C] forSome { type A; type B; type C <: (A, B) }
 
 abstract trait Cov33[+A, -B, C <: Tuple2[A, _]] extends AnyRef
-    extest.Cov33[?0,?1,?2] forSome { type ?0; type ?1; type ?2 <: Tuple2[?0, _] }
+    extest.Cov33[A,B,C] forSome { type A; type B; type C <: Tuple2[A, _] }
 
 abstract trait Cov34[A, +B, C <: (A, B)] extends AnyRef
-    extest.Cov34[?0,?1,?2] forSome { type ?0; type ?1; type ?2 <: (?0, ?1) }
+    extest.Cov34[A,B,C] forSome { type A; type B; type C <: (A, B) }
 
 abstract trait Cov35[A, B, C <: (A, B)] extends AnyRef
-    extest.Cov35[?0,?1,?2] forSome { type ?0; type ?1; type ?2 <: (?0, ?1) }
+    extest.Cov35[A,B,C] forSome { type A; type B; type C <: (A, B) }
 
 abstract trait Cov36[A, -B, C <: Tuple2[A, _]] extends AnyRef
-    extest.Cov36[?0,?1,?2] forSome { type ?0; type ?1; type ?2 <: Tuple2[?0, _] }
+    extest.Cov36[A,B,C] forSome { type A; type B; type C <: Tuple2[A, _] }
 
 abstract trait Cov37[-A, +B, C <: Tuple2[_, B]] extends AnyRef
-    extest.Cov37[?0,?1,?2] forSome { type ?0; type ?1; type ?2 <: Tuple2[_, ?1] }
+    extest.Cov37[A,B,C] forSome { type A; type B; type C <: Tuple2[_, B] }
 
 abstract trait Cov38[-A, B, C <: Tuple2[_, B]] extends AnyRef
-    extest.Cov38[?0,?1,?2] forSome { type ?0; type ?1; type ?2 <: Tuple2[_, ?1] }
+    extest.Cov38[A,B,C] forSome { type A; type B; type C <: Tuple2[_, B] }
 
 abstract trait Cov39[-A, -B, C <: Tuple2[_, _]] extends AnyRef
     extest.Cov39[_, _, _ <: Tuple2[_, _]]
@@ -152,5 +152,5 @@ abstract trait Covariant[+A <: AnyRef, +B] extends AnyRef
     extest.Covariant[_ <: AnyRef, _]
 
 abstract trait CovariantLike[+A <: AnyRef, +B <: List[A], +This <: extest.CovariantLike[A,B,This] with extest.Covariant[A,B]] extends AnyRef
-    extest.CovariantLike[?0,?1,?2] forSome { type ?0 <: AnyRef; type ?1 <: List[?0]; type ?2 <: extest.CovariantLike[?0,?1,?2] with extest.Covariant[?0,?1] }
+    extest.CovariantLike[A,B,This] forSome { type A <: AnyRef; type B <: List[A]; type This <: extest.CovariantLike[A,B,This] with extest.Covariant[A,B] }
 

--- a/test/files/run/implicit-caching.scala
+++ b/test/files/run/implicit-caching.scala
@@ -1,0 +1,25 @@
+trait Foo[T]
+
+trait FooSub[T] extends Foo[T] {
+  type Super = Foo[T]
+}
+
+object FooSub {
+  implicit def fooSub[T](implicit ft: Bar[T]): FooSub[T] =
+    new FooSub[T] {}
+}
+
+trait Bar[T]
+
+class Quux
+
+object Quux {
+  implicit val barQuux: Bar[Quux] = new Bar[Quux] {}
+
+  val fooSubQuux = implicitly[FooSub[Quux]]
+  implicit val fooQuux: fooSubQuux.Super = fooSubQuux
+}
+
+object Test extends App {
+  implicitly[Foo[Quux]]
+}

--- a/test/files/run/t5418b.check
+++ b/test/files/run/t5418b.check
@@ -1,2 +1,2 @@
 new Object().getClass()
-TypeRef(ThisType(java.lang), java.lang.Class, List(TypeRef(NoPrefix, TypeName("?0"), List())))
+TypeRef(ThisType(java.lang), java.lang.Class, List(TypeRef(NoPrefix, TypeName("T"), List())))

--- a/test/junit/scala/sys/process/PipedProcessTest.scala
+++ b/test/junit/scala/sys/process/PipedProcessTest.scala
@@ -11,14 +11,16 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.control.Exception.ignoring
 import org.junit.Assert.assertEquals
 
-// Each test normally ends in a moment, but for failure cases, waits two seconds.
+// Each test normally ends in a moment, but for failure cases, waits four seconds.
 // scala/bug#7350, scala/bug#8768
 
 // one second wasn't always enough --
 // https://github.com/scala/scala-dev/issues/313
+// two seconds wasn't always enough --
+// https://github.com/scala/community-builds/issues/569
 object TestDuration {
   import scala.concurrent.duration.{Duration, SECONDS}
-  val Standard = Duration(2, SECONDS)
+  val Standard = Duration(4, SECONDS)
 }
 
 @RunWith(classOf[JUnit4])

--- a/test/junit/scala/tools/nsc/classpath/ZipAndJarFileLookupFactoryTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/ZipAndJarFileLookupFactoryTest.scala
@@ -8,6 +8,8 @@ import scala.reflect.io.AbstractFile
 
 class ZipAndJarFileLookupFactoryTest {
   @Test def cacheInvalidation(): Unit = {
+    if (scala.util.Properties.isWin) return // can't overwrite an open file on windows.
+
     val f = Files.createTempFile("test-", ".jar")
     Files.delete(f)
     val g = new scala.tools.nsc.Global(new scala.tools.nsc.Settings())


### PR DESCRIPTION
Straightforward, one conflict in ClassFileParser due to whitespace changes (resolved automatically in IntelliJ).

Fixes https://github.com/scala/scala-dev/issues/429