### PR TITLE
Add bridges for overridden methods in lambda indy call

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -451,7 +451,7 @@ abstract class Erasure extends InfoTransform
 
   override def newTyper(context: Context) = new Eraser(context)
 
-  class ComputeBridges(unit: CompilationUnit, root: Symbol) {
+  class EnterBridges(unit: CompilationUnit, root: Symbol) {
 
     class BridgesCursor(root: Symbol) extends overridingPairs.Cursor(root) {
       override def parents              = root.info.firstParent :: Nil
@@ -462,22 +462,19 @@ abstract class Erasure extends InfoTransform
       override def exclude(sym: Symbol) = !sym.isMethod || super.exclude(sym)
     }
 
-    var toBeRemoved  = immutable.Set[Symbol]()
     val site         = root.thisType
     val bridgesScope = newScope
     val bridgeTarget = mutable.HashMap[Symbol, Symbol]()
-    var bridges      = List[Tree]()
 
     val opc = enteringExplicitOuter { new BridgesCursor(root) }
 
-    def compute(): (List[Tree], immutable.Set[Symbol]) = {
+    def computeAndEnter(): Unit = {
       while (opc.hasNext) {
         if (enteringExplicitOuter(!opc.low.isDeferred))
-          checkPair(opc.currentPair)
+          checkPair(opc. currentPair)
 
         opc.next()
       }
-      (bridges, toBeRemoved)
     }
 
     /** Check that a bridge only overrides members that are also overridden by the original member.
@@ -581,17 +578,35 @@ abstract class Erasure extends InfoTransform
 
       if (shouldAdd) {
         exitingErasure(root.info.decls enter bridge)
-        if (other.owner == root) {
-          exitingErasure(root.info.decls.unlink(other))
-          toBeRemoved += other
-        }
 
         bridgesScope enter bridge
-        bridges ::= makeBridgeDefDef(bridge, member, other)
+        addBridge(bridge, member, other)
+        //bridges ::= makeBridgeDefDef(bridge, member, other)
       }
     }
 
-    def makeBridgeDefDef(bridge: Symbol, member: Symbol, other: Symbol) = exitingErasure {
+    protected def addBridge(bridge: Symbol, member: Symbol, other: Symbol) {} // hook for GenerateBridges
+  }
+
+  class GenerateBridges(unit: CompilationUnit, root: Symbol) extends EnterBridges(unit, root) {
+
+    var bridges      = List.empty[Tree]
+    var toBeRemoved  = immutable.Set.empty[Symbol]
+
+    def generate(): (List[Tree], immutable.Set[Symbol]) = {
+      super.computeAndEnter()
+      (bridges, toBeRemoved)
+    }
+
+    override def addBridge(bridge: Symbol, member: Symbol, other: Symbol): Unit = {
+      if (other.owner == root) {
+        exitingErasure(root.info.decls.unlink(other))
+        toBeRemoved += other
+      }
+      bridges ::= makeBridgeDefDef(bridge, member, other)
+    }
+
+    final def makeBridgeDefDef(bridge: Symbol, member: Symbol, other: Symbol) = exitingErasure {
       // type checking ensures we can safely call `other`, but unless `member.tpe <:< other.tpe`,
       // calling `member` is not guaranteed to succeed in general, there's
       // nothing we can do about this, except for an unapply: when this subtype test fails,
@@ -627,6 +642,7 @@ abstract class Erasure extends InfoTransform
       }
       DefDef(bridge, rhs)
     }
+
   }
 
   /** The modifier typer which retypes with erased types. */
@@ -795,7 +811,7 @@ abstract class Erasure extends InfoTransform
       tree1 match {
         case fun: Function =>
           fun.attachments.get[SAMFunction] match {
-            case Some(SAMFunction(samTp, _)) => fun setType specialScalaErasure(samTp)
+            case Some(SAMFunction(samTp, _, _)) => fun setType specialScalaErasure(samTp)
             case _ => fun
           }
 
@@ -923,16 +939,22 @@ abstract class Erasure extends InfoTransform
      */
     private def bridgeDefs(owner: Symbol): (List[Tree], immutable.Set[Symbol]) = {
       assert(phase == currentRun.erasurePhase, phase)
-      new ComputeBridges(unit, owner) compute()
+      new GenerateBridges(unit, owner).generate()
     }
 
-    def addBridges(stats: List[Tree], base: Symbol): List[Tree] =
+    def addBridgesToTemplate(stats: List[Tree], base: Symbol): List[Tree] =
       if (base.isTrait) stats
       else {
         val (bridges, toBeRemoved) = bridgeDefs(base)
         if (bridges.isEmpty) stats
         else (stats filterNot (stat => toBeRemoved contains stat.symbol)) ::: bridges
       }
+
+    def addBridgesToLambda(lambdaClass: Symbol): Unit = {
+      assert(phase == currentRun.erasurePhase, phase)
+      assert(lambdaClass.isClass, lambdaClass)
+      new EnterBridges(unit, lambdaClass).computeAndEnter()
+    }
 
     /**  Transform tree at phase erasure before retyping it.
      *   This entails the following:
@@ -1210,7 +1232,7 @@ abstract class Erasure extends InfoTransform
         case Template(parents, self, body) =>
           //Console.println("checking no dble defs " + tree)//DEBUG
           checkNoDoubleDefs(tree.symbol.owner)
-          treeCopy.Template(tree, parents, noSelfType, addBridges(body, currentOwner))
+          treeCopy.Template(tree, parents, noSelfType, addBridgesToTemplate(body, currentOwner))
 
         case Match(selector, cases) =>
           Match(Typed(selector, TypeTree(selector.tpe)), cases)
@@ -1234,6 +1256,12 @@ abstract class Erasure extends InfoTransform
           copyDefDef(tree)(tparams = Nil)
         case TypeDef(_, _, _, _) =>
           EmptyTree
+
+        case fun: Function =>
+          fun.attachments.get[SAMFunction] foreach {
+            samf => addBridgesToLambda(samf.synthCls)
+          }
+          fun
 
         case _ =>
           tree

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -81,7 +81,7 @@ abstract class UnCurry extends InfoTransform
     private def mustExpandFunction(fun: Function) = {
       // (TODO: Can't use isInterface, yet, as it hasn't been updated for the new trait encoding)
       val canUseLambdaMetaFactory = (fun.attachments.get[SAMFunction] match {
-        case Some(SAMFunction(userDefinedSamTp, sam)) =>
+        case Some(SAMFunction(userDefinedSamTp, sam, _)) =>
           // LambdaMetaFactory cannot mix in trait members for us, or instantiate classes -- only pure interfaces need apply
           erasure.compilesToPureInterface(erasure.javaErasure(userDefinedSamTp).typeSymbol) &&
           // impl restriction -- we currently use the boxed apply, so not really useful to allow specialized sam types (https://github.com/scala/scala/pull/4971#issuecomment-198119167)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1101,9 +1101,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 // TODO: figure out how to avoid partially duplicating typedFunction (samMatchingFunction)
                 // Could we infer the SAM type, assign it to the tree and add the attachment,
                 // all in one fell swoop at the end of typedFunction?
-                val samAttach = inferSamType(tree, pt, mode)
+                val didInferSamType = inferSamType(tree, pt, mode)
 
-                if (samAttach.samTp ne NoType) tree.setType(samAttach.samTp).updateAttachment(samAttach)
+                if (didInferSamType) tree
                 else {  // (15) implicit view application
                   val coercion =
                     if (context.implicitsEnabled) inferView(tree, tree.tpe, pt)
@@ -2850,65 +2850,95 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       *     function type is a built-in FunctionN or some SAM type
       *
       */
-    def inferSamType(fun: Tree, pt: Type, mode: Mode): SAMFunction = {
-      val sam =
-        if (fun.isInstanceOf[Function] && !isFunctionType(pt)) {
-          // TODO: can we ensure there's always a SAMFunction attachment, instead of looking up the sam again???
-          // seems like overloading complicates things?
-          val sam = samOf(pt)
-          if (samMatchesFunctionBasedOnArity(sam, fun.asInstanceOf[Function].vparams)) sam
-          else NoSymbol
-        } else NoSymbol
+    def inferSamType(fun: Tree, pt: Type, mode: Mode): Boolean = fun match {
+      case fun@Function(vparams, _) if !isFunctionType(pt) =>
+        // TODO: can we ensure there's always a SAMFunction attachment, instead of looking up the sam again???
+        // seems like overloading complicates things?
+        val sam = samOf(pt)
 
-      def fullyDefinedMeetsExpectedFunTp(pt: Type): Boolean = isFullyDefined(pt) && {
-        val samMethType = pt memberInfo sam
-        fun.tpe <:< functionType(samMethType.paramTypes, samMethType.resultType)
-      }
-
-      SAMFunction(
-        if (!sam.exists) NoType
-        else if (fullyDefinedMeetsExpectedFunTp(pt)) pt
-        else try {
-          val samClassSym = pt.typeSymbol
-
-          // we're trying to fully define the type arguments for this type constructor
-          val samTyCon = samClassSym.typeConstructor
-
-          // the unknowns
-          val tparams = samClassSym.typeParams
-          // ... as typevars
-          val tvars = tparams map freshVar
-
-          val ptVars = appliedType(samTyCon, tvars)
-
-          // carry over info from pt
-          ptVars <:< pt
-
-          val samInfoWithTVars = ptVars.memberInfo(sam)
-
-          // use function type subtyping, not method type subtyping (the latter is invariant in argument types)
-          fun.tpe <:< functionType(samInfoWithTVars.paramTypes, samInfoWithTVars.finalResultType)
-
-          val variances = tparams map varianceInType(sam.info)
-
-          // solve constraints tracked by tvars
-          val targs = solvedTypes(tvars, tparams, variances, upper = false, lubDepth(sam.info :: Nil))
-
-          debuglog(s"sam infer: $pt --> ${appliedType(samTyCon, targs)} by ${fun.tpe} <:< $samInfoWithTVars --> $targs for $tparams")
-
-          val ptFullyDefined = appliedType(samTyCon, targs)
-          if (ptFullyDefined <:< pt && fullyDefinedMeetsExpectedFunTp(ptFullyDefined)) {
-            debuglog(s"sam fully defined expected type: $ptFullyDefined from $pt for ${fun.tpe}")
-            ptFullyDefined
-          } else {
-            debuglog(s"Could not define type $pt using ${fun.tpe} <:< ${pt memberInfo sam} (for $sam)")
-            NoType
+        if (!samMatchesFunctionBasedOnArity(sam, vparams)) false
+        else {
+          def fullyDefinedMeetsExpectedFunTp(pt: Type): Boolean = isFullyDefined(pt) && {
+            val samMethType = pt memberInfo sam
+            fun.tpe <:< functionType(samMethType.paramTypes, samMethType.resultType)
           }
-        } catch {
-          case e@(_: NoInstance | _: TypeError) =>
-            debuglog(s"Error during SAM synthesis: could not define type $pt using ${fun.tpe} <:< ${pt memberInfo sam} (for $sam)\n$e")
-            NoType
-        }, sam)
+
+          val samTp =
+            if (!sam.exists) NoType
+            else if (fullyDefinedMeetsExpectedFunTp(pt)) pt
+            else try {
+              val samClassSym = pt.typeSymbol
+
+              // we're trying to fully define the type arguments for this type constructor
+              val samTyCon = samClassSym.typeConstructor
+
+              // the unknowns
+              val tparams = samClassSym.typeParams
+              // ... as typevars
+              val tvars = tparams map freshVar
+
+              val ptVars = appliedType(samTyCon, tvars)
+
+              // carry over info from pt
+              ptVars <:< pt
+
+              val samInfoWithTVars = ptVars.memberInfo(sam)
+
+              // use function type subtyping, not method type subtyping (the latter is invariant in argument types)
+              fun.tpe <:< functionType(samInfoWithTVars.paramTypes, samInfoWithTVars.finalResultType)
+
+              val variances = tparams map varianceInType(sam.info)
+
+              // solve constraints tracked by tvars
+              val targs = solvedTypes(tvars, tparams, variances, upper = false, lubDepth(sam.info :: Nil))
+
+              debuglog(s"sam infer: $pt --> ${appliedType(samTyCon, targs)} by ${fun.tpe} <:< $samInfoWithTVars --> $targs for $tparams")
+
+              val ptFullyDefined = appliedType(samTyCon, targs)
+              if (ptFullyDefined <:< pt && fullyDefinedMeetsExpectedFunTp(ptFullyDefined)) {
+                debuglog(s"sam fully defined expected type: $ptFullyDefined from $pt for ${fun.tpe}")
+                ptFullyDefined
+              } else {
+                debuglog(s"Could not define type $pt using ${fun.tpe} <:< ${pt memberInfo sam} (for $sam)")
+                NoType
+              }
+            } catch {
+              case e@(_: NoInstance | _: TypeError) =>
+                debuglog(s"Error during SAM synthesis: could not define type $pt using ${fun.tpe} <:< ${pt memberInfo sam} (for $sam)\n$e")
+                NoType
+            }
+
+          if (samTp eq NoType) false
+          else {
+            /* Make a synthetic class symbol to represent the synthetic class that
+             * will be spun up by LMF for this function. This is necessary because
+             * it's possible that the SAM method might need bridges, and they have
+             * to go somewhere. Erasure knows to compute bridges for these classes
+             * just as if they were real templates extending the SAM type. */
+            val synthCls = fun.symbol.owner.newClassWithInfo(
+              name = tpnme.ANON_CLASS_NAME,
+              parents = ObjectTpe :: samTp :: Nil,
+              scope = newScope,
+              pos = sam.pos,
+              newFlags = SYNTHETIC | ARTIFACT
+            )
+
+            synthCls.info.decls.enter {
+              val newFlags = (sam.flags & ~DEFERRED) | SYNTHETIC
+              sam.cloneSymbol(synthCls, newFlags).setInfo(samTp memberInfo sam)
+            }
+
+            fun.setType(samTp)
+
+            /* Arguably I should do `fun.setSymbol(samCls)` rather than leaning
+             * on an attachment, but doing that confounds lambdalift's free var
+             * analysis in a way which does not seem to be trivially reparable. */
+            fun.updateAttachment(SAMFunction(samTp, sam, synthCls))
+
+            true
+          }
+        }
+      case _ => false
     }
 
     /** Type check a function literal.

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -51,10 +51,11 @@ trait StdAttachments {
     *
     * @param samTp the expected type that triggered sam conversion (may be a subtype of the type corresponding to sam's owner)
     * @param sam the single abstract method implemented by the Function we're attaching this to
+    * @param synthCls the (synthetic) class representing the eventual implementation class (spun at runtime by LMF on the JVM)
     *
     * @since 2.12.0-M4
     */
-  case class SAMFunction(samTp: Type, sam: Symbol) extends PlainAttachment
+  case class SAMFunction(samTp: Type, sam: Symbol, synthCls: Symbol) extends PlainAttachment
 
   case object DelambdafyTarget extends PlainAttachment
 

--- a/test/files/jvm/t10512a.scala
+++ b/test/files/jvm/t10512a.scala
@@ -1,0 +1,43 @@
+trait JsonValue
+class JsonObject extends JsonValue
+class JsonString extends JsonValue
+
+trait JsonEncoder[A] {
+  def encode(value: A): JsonValue
+}
+
+trait JsonObjectEncoder[A] extends JsonEncoder[A] {
+  def encode(value: A): JsonObject
+}
+
+object JsonEncoderInstances {
+
+  val seWorks: JsonEncoder[String] =
+    new JsonEncoder[String] {
+      def encode(value: String) = new JsonString
+    }
+
+  implicit val stringEncoder: JsonEncoder[String] =
+    s => new JsonString
+    //new JsonEncoder[String] {
+    //  def encode(value: String) = new JsonString
+    //}
+
+  def leWorks[A](implicit encoder: JsonEncoder[A]): JsonObjectEncoder[List[A]] =
+    new JsonObjectEncoder[List[A]] {
+      def encode(value: List[A]) = new JsonObject
+    }
+
+  implicit def listEncoder[A](implicit encoder: JsonEncoder[A]): JsonObjectEncoder[List[A]] =
+    l => new JsonObject
+//    new JsonObjectEncoder[List[A]] {
+//      def encode(value: List[A]) = new JsonObject
+//    }
+
+}
+
+object Test extends App {
+  import JsonEncoderInstances._
+
+  implicitly[JsonEncoder[List[String]]].encode("" :: Nil)
+}

--- a/test/files/jvm/t10512b.scala
+++ b/test/files/jvm/t10512b.scala
@@ -1,0 +1,54 @@
+trait A
+trait B extends A
+trait C extends B
+object it extends C
+
+/* try as many weird diamondy things as I can think of */
+trait SAM_A                 { def apply(): A }
+trait SAM_A1 extends SAM_A  { def apply(): A }
+trait SAM_B  extends SAM_A1 { def apply(): B }
+trait SAM_B1 extends SAM_A1 { def apply(): B }
+trait SAM_B2 extends SAM_B with SAM_B1
+trait SAM_C  extends SAM_B2 { def apply(): C }
+
+trait SAM_F  extends (() => A) with SAM_C
+trait SAM_F1 extends (() => C) with SAM_F
+
+
+object Test extends App {
+
+  val s1: SAM_A  = () => it
+  val s2: SAM_A1 = () => it
+  val s3: SAM_B  = () => it
+  val s4: SAM_B1 = () => it
+  val s5: SAM_B2 = () => it
+  val s6: SAM_C  = () => it
+  val s7: SAM_F  = () => it
+  val s8: SAM_F1 = () => it
+
+  (s1(): A)
+
+  (s2(): A)
+
+  (s3(): B)
+  (s3(): A)
+
+  (s4(): B)
+  (s4(): A)
+
+  (s5(): B)
+  (s5(): A)
+
+  (s6(): C)
+  (s6(): B)
+  (s6(): A)
+
+  (s7(): C)
+  (s7(): B)
+  (s7(): A)
+
+  (s8(): C)
+  (s8(): B)
+  (s8(): A)
+
+}


### PR DESCRIPTION
If a SAM trait's abstract method overrides a method in a supertrait while changing the return type, the generated invokedynamic instruction needs to pass the types of the overridden methods to `LambdaMetaFactory` so that bridge methods can be added to the generated lambda.

Java does this differently: it generates a default method in the subinterface overriding the superinterface method. Theoretically we could also generate the default bridges, but that is a binary-incompatible change, so I think it's safer to just add the bridges in the invokedynamic.

Honestly I'm surprised that this hasn't come up already.

Fixes scala/bug#10512.