### PR TITLE
Translate a virtual call on sealed trait/class with a single concrete subclass to a virtual call on that subclass.

### DIFF
--- a/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
@@ -359,4 +359,24 @@ class OptimizedBytecodeTest extends BytecodeTesting {
     val List(c) = readAsmClasses(newCompiler(extraArgs = "-optimise -deprecation").compileToBytes(code, allowMessage = _.msg.contains("is deprecated")))
     assertInvoke(getMethod(c, "t"), "C", "$anonfun$t$1") // range-foreach inlined from classpath
   }
+
+  @Test
+  def virtualCallWithSingleImplementationInlined(): Unit = {
+    val code =
+      """sealed trait Foo {
+        |  def foo(s: String): Unit
+        |}
+        |
+        |class FooImpl extends Foo {
+        |  @inline
+        |  final def foo(s: String): Unit = ()
+        |}
+        |
+        |class Test {
+        |  def go(f: Foo): Unit = f.foo("Hi!")
+        |}
+      """.stripMargin
+    val List(f, fi, t) = compileClasses(code)
+    assertNoInvoke(getMethod(t, "go"))
+  }
 }


### PR DESCRIPTION
Translate a virtual call on sealed trait/class with a single concrete subclass to a virtual call on that subclass.

This enables the call to later be inlined.

As an example, consider

```scala
sealed trait Foo {
  def foo(s: String): Unit
}

class FooImpl extends Foo {
  @inline
  final def foo(s: String): Unit = ()
}

class Test extends {
  def go(f: Foo): Unit = f.foo("Hi")
}
```

With Scala 2.12.3,
```
scalac -opt:l:inline '-opt-inline-from:**' -opt-warnings test.scala
```

compiles the `Test#go` method to

```
 0: aload_1
 1: ldc           #13                 // String Hi
 3: invokeinterface #19,  2           // InterfaceMethod Foo.foo:(Ljava/lang/String;)V
 8: return
```

With this PR, `f` in `f.foo("Hi")` is first cast to `FooImpl` and then a (virtual) call to `FooImpl#foo` is made. However, this virtual call to a `final` method is later inlined, resulting in the following bytecode:

```
 0: aload_1
 1: checkcast     #13                 // class FooImpl
 4: ifnonnull     9
 7: aconst_null
 8: athrow
 9: return
```