### PR TITLE
Future.firstCompletedOf introduces a memory leak when at least one of the futures is long-lived

### DIFF
--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -9,12 +9,11 @@
 package scala.concurrent
 
 import scala.language.higherKinds
-
 import java.util.concurrent.{CountDownLatch, TimeUnit}
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 
 import scala.util.control.NonFatal
-import scala.util.{Try, Success, Failure}
+import scala.util.{Failure, Success, Try}
 import scala.concurrent.duration._
 import scala.collection.generic.CanBuildFrom
 import scala.reflect.ClassTag
@@ -677,8 +676,15 @@ object Future {
    */
   def firstCompletedOf[T](futures: TraversableOnce[Future[T]])(implicit executor: ExecutionContext): Future[T] = {
     val p = Promise[T]()
-    val completeFirst: Try[T] => Unit = p tryComplete _
-    futures foreach { _ onComplete completeFirst }
+    val firstCompleteHandler = new AtomicReference[Promise[T]](p) with (Try[T] => Unit) {
+      override def apply(v1: Try[T]): Unit = {
+        val p = getAndSet(null)
+        if( null != p ){
+          p tryComplete v1
+        }
+      }
+    }
+    futures foreach { _ onComplete firstCompleteHandler }
     p.future
   }
 

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -677,11 +677,9 @@ object Future {
   def firstCompletedOf[T](futures: TraversableOnce[Future[T]])(implicit executor: ExecutionContext): Future[T] = {
     val p = Promise[T]()
     val firstCompleteHandler = new AtomicReference[Promise[T]](p) with (Try[T] => Unit) {
-      override def apply(v1: Try[T]): Unit = {
-        val p = getAndSet(null)
-        if( null != p ){
-          p tryComplete v1
-        }
+      override def apply(v1: Try[T]): Unit = getAndSet(null) match {
+        case null => ()
+        case some => some tryComplete v1
       }
     }
     futures foreach { _ onComplete firstCompleteHandler }

--- a/test/files/run/t10513.scala
+++ b/test/files/run/t10513.scala
@@ -6,27 +6,28 @@ import scala.util.{Random, Try}
 import ExecutionContext.Implicits.global
 
 /** This test uses recursive calls to Future.flatMap to create arrays whose
- *  combined size is slightly greater than the JVM heap size. A previous
- *  implementation of Future.flatMap would retain references to each array,
- *  resulting in a speedy OutOfMemoryError. Now, each array should be freed soon
- *  after it is created and the test should complete without problems.
- */
+  * combined size is slightly greater than the JVM heap size. A previous
+  * implementation of Future.flatMap would retain references to each array,
+  * resulting in a speedy OutOfMemoryError. Now, each array should be freed soon
+  * after it is created and the test should complete without problems.
+  */
 object Test {
- val arrSz = 50 * 10000
-  val numFutures = 4000
-
-  val rng = new Random()
-
 
   def main(args: Array[String]) {
+    val arrSz = 50 * 10000
+    val numFutures = 4000
+
+    val rng = new Random()
     val longStandingPromise = Promise[Nothing]
 
-    val futures = List.tabulate(numFutures){ i =>
+    val futures = List.tabulate(numFutures) { i =>
       val arr = Array.tabulate(arrSz)(identity)
       val idx = rng.nextInt(arrSz)
-      val f1 = Future{ arr }
+      val f1 = Future {
+        arr
+      }
       val f2 = Future.firstCompletedOf(List(longStandingPromise.future, f1))
-      f2.map( arr => arr(idx))
+      f2.map(arr => arr(idx))
     }
     val fSeq = Future.sequence(futures)
     val finalF = fSeq.map(_.sum)

--- a/test/files/run/t10513.scala
+++ b/test/files/run/t10513.scala
@@ -1,5 +1,6 @@
 //package scala.concurrent
 import scala.concurrent._
+import duration._
 
 import scala.util.{Random, Try}
 import ExecutionContext.Implicits.global
@@ -29,6 +30,6 @@ object Test {
     }
     val fSeq = Future.sequence(futures)
     val finalF = fSeq.map(_.sum)
-    val res = Await.result(finalF, duration.Duration.Inf)
+    val res = Await.result(finalF, 2.minutes)
   }
 }

--- a/test/files/run/t10513.scala
+++ b/test/files/run/t10513.scala
@@ -12,7 +12,7 @@ import ExecutionContext.Implicits.global
  */
 object Test {
  val arrSz = 50 * 10000
-  val numFutures = 10000
+  val numFutures = 4000
 
   val rng = new Random()
 

--- a/test/files/run/t10513.scala
+++ b/test/files/run/t10513.scala
@@ -1,0 +1,34 @@
+//package scala.concurrent
+import scala.concurrent._
+
+import scala.util.{Random, Try}
+import ExecutionContext.Implicits.global
+
+/** This test uses recursive calls to Future.flatMap to create arrays whose
+ *  combined size is slightly greater than the JVM heap size. A previous
+ *  implementation of Future.flatMap would retain references to each array,
+ *  resulting in a speedy OutOfMemoryError. Now, each array should be freed soon
+ *  after it is created and the test should complete without problems.
+ */
+object Test {
+ val arrSz = 50 * 10000
+  val numFutures = 10000
+
+  val rng = new Random()
+
+
+  def main(args: Array[String]) {
+    val longStandingPromise = Promise[Nothing]
+
+    val futures = List.tabulate(numFutures){ i =>
+      val arr = Array.tabulate(arrSz)(identity)
+      val idx = rng.nextInt(arrSz)
+      val f1 = Future{ arr }
+      val f2 = Future.firstCompletedOf(List(longStandingPromise.future, f1))
+      f2.map( arr => arr(idx))
+    }
+    val fSeq = Future.sequence(futures)
+    val finalF = fSeq.map(_.sum)
+    val res = Await.result(finalF, duration.Duration.Inf)
+  }
+}

--- a/test/junit/scala/concurrent/FutureTest.scala
+++ b/test/junit/scala/concurrent/FutureTest.scala
@@ -23,17 +23,5 @@ class FutureTest {
     assertNotReachable(result, unfulfilled) {
       quick.complete(Try(result))
     }
-
-    /* The test has this structure:
-    val p = Promise[String]
-    val q = Promise[String]
-    val res = Promise[String]
-    val s = "hi"
-    p.future.onComplete(t => res.complete(t))
-    q.future.onComplete(t => res.complete(t))
-    assertNotReachable(s, q) {
-      p.complete(Try(s))
-    }
-    */
   }
 }

--- a/test/junit/scala/concurrent/FutureTest.scala
+++ b/test/junit/scala/concurrent/FutureTest.scala
@@ -1,0 +1,39 @@
+
+package scala.concurrent
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.AssertUtil._
+import scala.util.Try
+
+import java.util.concurrent.CountDownLatch
+
+@RunWith(classOf[JUnit4])
+class FutureTest {
+  @Test
+  def `bug/issues#10513 firstCompletedOf must not leak references`: Unit = {
+    import ExecutionContext.Implicits._
+    val unfulfilled = Promise[AnyRef]
+    val quick = Promise[AnyRef]
+    val result = new AnyRef
+    val first = Future.firstCompletedOf(List(quick.future, unfulfilled.future))
+    assertNotReachable(result, unfulfilled) {
+      quick.complete(Try(result))
+    }
+
+    /* The test has this structure:
+    val p = Promise[String]
+    val q = Promise[String]
+    val res = Promise[String]
+    val s = "hi"
+    p.future.onComplete(t => res.complete(t))
+    q.future.onComplete(t => res.complete(t))
+    assertNotReachable(s, q) {
+      p.complete(Try(s))
+    }
+    */
+  }
+}


### PR DESCRIPTION
introduce a specialized function implementation that clears the reference to the result promise on its first execution.

Fixes scala/bug#10513

cc: @axel22 , @viktorklang 
