### PR TITLE
Replace stray tab with spaces

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -700,7 +700,7 @@ trait EntityPage extends HtmlPage {
                  exampleXml.reduceLeft(_ ++ Text(", ") ++ _)
               }</ol>
             </div>
-	        }
+          }
 
         val version: NodeSeq =
           orEmpty(comment.version) {


### PR DESCRIPTION
this really fixes the alignment instead of https://github.com/scala/scala/pull/6009/commits/29eaf2243cc80d6f9af37e931c54d4419d9f6acf