### PR TITLE
Reverse order of repeated tags

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -343,7 +343,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
           }
 
         def allTags(key: SimpleTagKey): List[Body] =
-          (bodyTags remove key).getOrElse(Nil).filterNot(_.blocks.isEmpty)
+          (bodyTags remove key).getOrElse(Nil).filterNot(_.blocks.isEmpty).reverse
 
         def allSymsOneTag(key: TagKey, filterEmpty: Boolean = true): Map[String, Body] = {
           val keys: Seq[SymbolTagKey] =

--- a/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
+++ b/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
@@ -770,7 +770,7 @@ object HtmlFactoryTest extends Properties("HtmlFactory") {
 
   property("scala/bug#9599 Multiple @todo formatted with comma on separate line") = {
     createTemplates("t9599.scala")("X.html") match {
-      case node: scala.xml.Node => node.text.contains("todo3todo2todo1")
+      case node: scala.xml.Node => node.text.contains("todo1todo2todo3")
       case _ => false
     }
   }

--- a/test/scaladoc/run/t10325.check
+++ b/test/scaladoc/run/t10325.check
@@ -1,0 +1,2 @@
+List(Body(List(Paragraph(Chain(List(Summary(Text(note1))))))), Body(List(Paragraph(Chain(List(Summary(Text(note2))))))), Body(List(Paragraph(Chain(List(Summary(Text(note3))))))))
+Done.

--- a/test/scaladoc/run/t10325.scala
+++ b/test/scaladoc/run/t10325.scala
@@ -1,0 +1,27 @@
+import scala.tools.nsc.doc.html.Page
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+  override def code = """
+    /**
+      * @note note1
+      * @note note2
+      * @note note3
+      */
+     class Foo
+  """
+
+  // no need for special settings
+  def scaladocSettings = ""
+
+  def testModel(rootPackage: Package) = {
+    import scala.tools.nsc.doc.base.comment._
+    import access._
+
+    val foo = rootPackage._class("Foo")
+
+    val notesInComment = foo.comment.get.note
+    println(notesInComment)
+  }
+}


### PR DESCRIPTION
closes https://github.com/scala/bug/issues/10325
alternatively the *RegEx cases of the parse0-method could be changed from prepending to appending the tag bodies