### PR TITLE
No warn unused import on macro expansion

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1245,14 +1245,14 @@ trait Contexts { self: Analyzer =>
   trait ImportContext extends Context {
     private val impInfo: ImportInfo = {
       val info = new ImportInfo(tree.asInstanceOf[Import], outerDepth)
-      if (settings.warnUnusedImport && !isRootImport) // excludes java.lang/scala/Predef imports
+      if (settings.warnUnusedImport && openMacros.isEmpty && !isRootImport) // excludes java.lang/scala/Predef imports
         allImportInfos(unit) ::= info
       info
     }
     override final def imports      = impInfo :: super.imports
     override final def firstImport  = Some(impInfo)
     override final def isRootImport = !tree.pos.isDefined
-    override final def toString     = super.toString + " with " + s"ImportContext { $impInfo; outer.owner = ${outer.owner} }"
+    override final def toString     = s"${super.toString} with ImportContext { $impInfo; outer.owner = ${outer.owner} }"
   }
 
   /** A reporter for use during type checking. It has multiple modes for handling errors.

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -45,9 +45,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
   final val shortenImports = false
 
   // allows override of the behavior of the resetTyper method w.r.t comments
-  def resetDocComments() = {
-    clearDocComments()
-  }
+  def resetDocComments() = clearDocComments()
 
   def resetTyper() {
     //println("resetTyper called")
@@ -3054,7 +3052,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
     def typedImport(imp : Import) : Import = (transformed remove imp) match {
       case Some(imp1: Import) => imp1
-      case _                  => log("unhandled import: "+imp+" in "+unit); imp
+      case _                  => log(s"unhandled import: $imp in $unit"); imp
     }
 
     def typedStats(stats: List[Tree], exprOwner: Symbol, warnPure: Boolean = true): List[Tree] = {

--- a/test/files/neg/t10270.check
+++ b/test/files/neg/t10270.check
@@ -1,0 +1,6 @@
+Main_2.scala:5: warning: Unused import
+    import Implicits._
+                     ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t10270.flags
+++ b/test/files/neg/t10270.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Ywarn-unused:imports

--- a/test/files/neg/t10270/Macros_1.scala
+++ b/test/files/neg/t10270/Macros_1.scala
@@ -1,0 +1,16 @@
+import language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+// wraps a new Block so typer sees a local import on second typecheck
+//
+object Macro {
+  def apply(a: Any): Any = macro impl
+
+  def impl(c: Context)(a: c.Tree): c.Tree = {
+    import c.universe._
+    a match {
+      case Block(stmts, res) => Block(stmts, res)
+      case expr              => Block(Nil, expr)
+    }
+  }
+}

--- a/test/files/neg/t10270/Main_2.scala
+++ b/test/files/neg/t10270/Main_2.scala
@@ -1,0 +1,16 @@
+
+object Main extends App {
+
+  def f(): Any = Macro {
+    import Implicits._
+    //"world".greeting
+    "world"
+  }
+
+}
+
+object Implicits {
+  implicit class `strung out`(val s: String) {
+    def greeting = s"hello, $s"
+  }
+}

--- a/test/files/neg/warn-unused-imports.check
+++ b/test/files/neg/warn-unused-imports.check
@@ -51,8 +51,5 @@ warn-unused-imports_2.scala:149: warning: Unused import
 warn-unused-imports_2.scala:150: warning: Unused import
     import p1.A                         // warn
               ^
-warn-unused-imports_2.scala:158: warning: Unused import
-  def x = Macro.f  // warn, not crash
-                ^
-17 warnings found
+16 warnings found
 one error found

--- a/test/files/neg/warn-unused-imports/warn-unused-imports_2.scala
+++ b/test/files/neg/warn-unused-imports/warn-unused-imports_2.scala
@@ -155,5 +155,5 @@ trait Outsiders {
 }
 
 class MacroClient {
-  def x = Macro.f  // warn, not crash
+  def x = Macro.f  // don't crash; but also don't warn on expansion, see scala/bug#10270 and [pos|neg]/t10270
 }

--- a/test/files/pos/t10270.flags
+++ b/test/files/pos/t10270.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Ywarn-unused:imports

--- a/test/files/pos/t10270/Macros_1.scala
+++ b/test/files/pos/t10270/Macros_1.scala
@@ -1,0 +1,16 @@
+import language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+// wraps a new Block so typer sees a local import on second typecheck
+//
+object Macro {
+  def apply(a: Any): Any = macro impl
+
+  def impl(c: Context)(a: c.Tree): c.Tree = {
+    import c.universe._
+    a match {
+      case Block(stmts, res) => Block(stmts, res)
+      case expr              => Block(Nil, expr)
+    }
+  }
+}

--- a/test/files/pos/t10270/Main_2.scala
+++ b/test/files/pos/t10270/Main_2.scala
@@ -1,0 +1,15 @@
+
+object Main extends App {
+
+  def f(): Any = Macro {
+    import Implicits._
+    "world".greeting
+  }
+
+}
+
+object Implicits {
+  implicit class `strung out`(val s: String) {
+    def greeting = s"hello, $s"
+  }
+}


### PR DESCRIPTION
Creating an import context registers the import for the unused
warning. However, if the use site is already typechecked,
then on re-typechecking a macro expansion, the use won't be
registered.

As a quick fix, if there are open macros, don't register an
import for unused checking.

Fixes scala/bug#10270