### PR TITLE
Adapt to change in Java 9 classloader hierarchy

### DIFF
--- a/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
@@ -6,8 +6,9 @@
 package scala
 package reflect.internal.util
 
-import scala.language.implicitConversions
+import java.lang.invoke.{MethodHandles, MethodType}
 
+import scala.language.implicitConversions
 import java.lang.{ClassLoader => JClassLoader}
 import java.lang.reflect.Modifier
 import java.net.{URLClassLoader => JURLClassLoader}
@@ -140,8 +141,9 @@ object ScalaClassLoader {
     }
   }
 
-  def fromURLs(urls: Seq[URL], parent: ClassLoader = null): URLClassLoader =
-    new URLClassLoader(urls, parent)
+  def fromURLs(urls: Seq[URL], parent: ClassLoader = null): URLClassLoader = {
+    new URLClassLoader(urls, if (parent == null) bootClassLoader else parent)
+  }
 
   /** True if supplied class exists in supplied path */
   def classExists(urls: Seq[URL], name: String): Boolean =
@@ -150,4 +152,18 @@ object ScalaClassLoader {
   /** Finding what jar a clazz or instance came from */
   def originOfClass(x: Class[_]): Option[URL] =
     Option(x.getProtectionDomain.getCodeSource) flatMap (x => Option(x.getLocation))
+
+  private[this] val bootClassLoader: ClassLoader = {
+    if (!util.Properties.isJavaAtLeast("9")) null
+    else {
+      try {
+        MethodHandles.lookup().findStatic(classOf[ClassLoader], "getPlatformClassLoader", MethodType.methodType(classOf[ClassLoader])).invoke()
+      } catch {
+        case _: Throwable =>
+          null
+      }
+    }
+
+
+  }
 }


### PR DESCRIPTION
Prior to Java 9, using `null` as the parent of an URLClassLoader would
designate the entire boot classpath. This behaviour has changed, and
now it only designates the classes encompassed by the `java.base` module.

This commit uses reflection to call the newly added method,
`ClassLoader.getPlatformClassloader` on Java 9, and uses this as the parent.

Tested manually with:

```
for V in 1.8 9; do (java_use $V; java -version; qscalac $(f 'package p1; object Test extends App { println(Class.forName("javax.tools.ToolProvider")) }') && qscala -nobootcp p1.Test); done
java version "1.8.0_144"
Java(TM) SE Runtime Environment (build 1.8.0_144-b01)
Java HotSpot(TM) 64-Bit Server VM (build 25.144-b01, mixed mode)
class javax.tools.ToolProvider
java version "9"
Java(TM) SE Runtime Environment (build 9+181)
Java HotSpot(TM) 64-Bit Server VM (build 9+181, mixed mode)
class javax.tools.ToolProvider
```

Prior to this change, we ran into:

```
java.lang.ClassNotFoundException: javax.tools.ToolProvider
    at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:466)
    at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:563)
```

Fixes scala/bug#10520