### PR TITLE
Return in PartialFun relative to right enclosing method

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -214,7 +214,12 @@ trait Contexts { self: Analyzer =>
     /** Is this context in all modes in the given `mask`? */
     def apply(mask: ContextMode): Boolean = contextMode.inAll(mask)
 
-    /** The next outer context whose tree is a method */
+    /** The next (logical) outer context whose tree is a method.
+      *
+      * NOTE: this is the "logical" enclosing method, which may not be the actual enclosing method when we
+      * synthesize a nested method, such as for lazy val getters (scala/bug#8245) or the methods that
+      * implement a PartialFunction literal (scala/bug#10291).
+      */
     var enclMethod: Context = _
 
     /** Variance relative to enclosing class */

--- a/test/files/run/t10291.scala
+++ b/test/files/run/t10291.scala
@@ -1,0 +1,8 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    def partially: Any = List(1).collect { case _ => return "a" }
+    def totally: Any = List(1).map { case _ => return "a" }
+    assert( partially == "a" )
+    assert( totally == "a" )
+  }
+}


### PR DESCRIPTION
Where the right enclosing method is the lexically enclosing one,
not the one the body ends up being type checked in (`applyOrElse`).
Since the current owner impacts more than just type checking
`Return` trees, we adjust the currently logically enclosing method
as we do for lazy getters (the owner also governs e.g., skolemization).

Fixes https://github.com/scala/bug/issues/10291.

I'm proposing to sneak this one into 2.12.4 since it's pretty embarrassing and the fix is pretty safe, I believe.