### PR TITLE
Avoid repr call in ArrayOps

### DIFF
--- a/src/library/scala/collection/mutable/ArrayOps.scala
+++ b/src/library/scala/collection/mutable/ArrayOps.scala
@@ -63,7 +63,7 @@ sealed trait ArrayOps[T] extends Any with ArrayLike[T, Array[T]] with CustomPara
 
   def :+[B >: T: ClassTag](elem: B): Array[B] = {
     val currentLength = repr.length
-    val result = Array.ofDim[B](currentLength + 1)
+    val result = new Array[B](currentLength + 1)
     Array.copy(repr, 0, result, 0, currentLength)
     result(currentLength) = elem
     result
@@ -71,7 +71,7 @@ sealed trait ArrayOps[T] extends Any with ArrayLike[T, Array[T]] with CustomPara
 
   def +:[B >: T: ClassTag](elem: B): Array[B] = {
     val currentLength = repr.length
-    val result = Array.ofDim[B](currentLength + 1)
+    val result = new Array[B](currentLength + 1)
     result(0) = elem
     Array.copy(repr, 0, result, 1, currentLength)
     result

--- a/src/library/scala/collection/mutable/ArrayOps.scala
+++ b/src/library/scala/collection/mutable/ArrayOps.scala
@@ -42,12 +42,13 @@ sealed trait ArrayOps[T] extends Any with ArrayLike[T, Array[T]] with CustomPara
   }
 
   override def slice(from: Int, until: Int): Array[T] = {
+     val reprVal = repr
      val lo = math.max(from, 0)
-     val hi = math.min(math.max(until, 0), repr.length)
+     val hi = math.min(math.max(until, 0), reprVal.length)
      val size = math.max(hi - lo, 0)
      val result = java.lang.reflect.Array.newInstance(elementClass, size)
      if (size > 0) {
-      Array.copy(repr, lo, result, 0, size)
+      Array.copy(reprVal, lo, result, 0, size)
      }
      result.asInstanceOf[Array[T]]
   }
@@ -61,16 +62,18 @@ sealed trait ArrayOps[T] extends Any with ArrayLike[T, Array[T]] with CustomPara
   }
 
   def :+[B >: T: ClassTag](elem: B): Array[B] = {
-    val result = Array.ofDim[B](repr.length + 1)
-    Array.copy(repr, 0, result, 0, repr.length)
-    result(repr.length) = elem
+    val currentLength = repr.length
+    val result = Array.ofDim[B](currentLength + 1)
+    Array.copy(repr, 0, result, 0, currentLength)
+    result(currentLength) = elem
     result
   }
 
   def +:[B >: T: ClassTag](elem: B): Array[B] = {
-    val result = Array.ofDim[B](repr.length + 1)
+    val currentLength = repr.length
+    val result = Array.ofDim[B](currentLength + 1)
     result(0) = elem
-    Array.copy(repr, 0, result, 1, repr.length)
+    Array.copy(repr, 0, result, 1, currentLength)
     result
   }
 

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayOpsBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayOpsBenchmark.scala
@@ -1,0 +1,53 @@
+package scala.collection.mutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class ArrayOpsBenchmark {
+  @Param(Array("1000000"))
+  var size: Int = _
+
+  val integers = (1 to size).toList
+  val strings = integers.map(_.toString)
+
+  @Benchmark def appendInteger(bh: Blackhole): Unit = {
+    var arr = Array.empty[Int]
+    integers foreach { i =>
+      arr = arr.:+(i)
+    }
+    bh.consume(arr)
+  }
+
+  @Benchmark def appendString(bh: Blackhole): Unit = {
+    var arr = Array.empty[String]
+    strings foreach { i =>
+      arr = arr.:+(i)
+    }
+    bh.consume(arr)
+  }
+
+  @Benchmark def insertInteger(bh: Blackhole): Unit = {
+    var arr = Array.empty[Int]
+    integers foreach { i =>
+      arr = arr.+:(i)
+    }
+    bh.consume(arr)
+  }
+
+  @Benchmark def insertString(bh: Blackhole): Unit = {
+    var arr = Array.empty[String]
+    strings foreach { i =>
+      arr = arr.+:(i)
+    }
+    bh.consume(arr)
+  }
+}

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayOpsBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayOpsBenchmark.scala
@@ -13,11 +13,17 @@ import org.openjdk.jmh.infra.Blackhole
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
 class ArrayOpsBenchmark {
-  @Param(Array("1000000"))
-  var size: Int = _
 
-  val integers = (1 to size).toList
-  val strings = integers.map(_.toString)
+  @Param(Array("10", "1000", "10000"))
+  var size: Int = _
+  var integers: List[Int] = _
+  var strings: List[String] = _
+
+
+  @Setup(Level.Trial) def initNumbers: Unit = {
+    integers = (1 to size).toList
+    strings = integers.map(_.toString)
+  }
 
   @Benchmark def appendInteger(bh: Blackhole): Unit = {
     var arr = Array.empty[Int]


### PR DESCRIPTION
This PR is part of fixes for issue: rorygraves#23. It means to improve the performance of ArrayOps @mkeskells spotted.

This PR replaced the ofDim call, which involved Manifest resolving, for :+ and +: method in ArrayOps with constructor of scala Array.
According to jprofiler, the call percentage reduced from 14.4% (ofDim) to 3.5% (constructor of Array)

