### PR TITLE
[SUPERSEDED] No illegal stars in typed select

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -914,7 +914,7 @@ trait Namers extends MethodSynthesis {
           }
 
         // must use typeSig, not memberSig (TODO: when do we need to switch namers?)
-        val sig = typeSig(tree, annots)
+        val sig = dropIllegalStarTypes(typeSig(tree, annots))
 
         fieldOrGetterSym setInfo (if (isGetter) NullaryMethodType(sig) else sig)
 

--- a/test/files/neg/t5355.check
+++ b/test/files/neg/t5355.check
@@ -10,7 +10,7 @@ t5355.scala:4: error: illegal cyclic reference involving method a
 t5355.scala:5: error: illegal cyclic reference involving value a
   type D = { val a: D }
                     ^
-t5355.scala:6: error: illegal cyclic reference involving method a
+t5355.scala:6: error: illegal cyclic reference involving value e
   val e: { def a: e.type }
                   ^
 5 errors found

--- a/test/files/neg/t8923.check
+++ b/test/files/neg/t8923.check
@@ -1,13 +1,7 @@
-t8923.scala:9: error: 3 more arguments than can be applied to method apply: (v1: Seq[Int])Int in trait Function1
-  def f() = Other.total(1, 2, 3, 4)
-                           ^
-t8923.scala:13: error: 3 more arguments than can be applied to method apply: (v1: Seq[Int])Int in trait Function1
-    total(1, 2, 3, 4)
-             ^
-t8923.scala:18: error: too many arguments (3) for method apply: (v1: Seq[A])A in trait Function1
-  def f() = Other.heady(1, 2, 3)
-                           ^
-t8923.scala:22: error: too many arguments (3) for method apply: (v1: Seq[A])A in trait Function1
-    heady(1, 2, 3)
-             ^
-four errors found
+t8923.scala:3: error: repeated parameters are only allowed in method signatures; use Seq instead
+  def total: (Int*) => Int = _.sum
+                  ^
+t8923.scala:5: error: repeated parameters are only allowed in method signatures; use Seq instead
+  def heady[A]: (A*) => A = _.head
+                   ^
+two errors found

--- a/test/files/neg/t8923.check
+++ b/test/files/neg/t8923.check
@@ -1,0 +1,13 @@
+t8923.scala:9: error: 3 more arguments than can be applied to method apply: (v1: Seq[Int])Int in trait Function1
+  def f() = Other.total(1, 2, 3, 4)
+                           ^
+t8923.scala:13: error: 3 more arguments than can be applied to method apply: (v1: Seq[Int])Int in trait Function1
+    total(1, 2, 3, 4)
+             ^
+t8923.scala:18: error: too many arguments (3) for method apply: (v1: Seq[A])A in trait Function1
+  def f() = Other.heady(1, 2, 3)
+                           ^
+t8923.scala:22: error: too many arguments (3) for method apply: (v1: Seq[A])A in trait Function1
+    heady(1, 2, 3)
+             ^
+four errors found

--- a/test/files/neg/t8923.scala
+++ b/test/files/neg/t8923.scala
@@ -1,0 +1,24 @@
+
+object Other {
+  def total: (Int*) => Int = _.sum
+
+  def heady[A]: (A*) => A = _.head
+}
+
+object TotallyRad {
+  def f() = Other.total(1, 2, 3, 4)
+
+  def g() = {
+    import Other._
+    total(1, 2, 3, 4)
+  }
+}
+
+object HeadingForTrouble {
+  def f() = Other.heady(1, 2, 3)
+
+  def g() = {
+    import Other._
+    heady(1, 2, 3)
+  }
+}

--- a/test/files/run/byname.scala
+++ b/test/files/run/byname.scala
@@ -45,7 +45,8 @@ val testAllR = testAll _
 test("all r", 7, testAllR(2, 3, Seq(34, 35)))
 
 val testAllS: (Int, =>Int, Int*) => Int = testAll _
-test("all s", 8, testAllS(1, 5, 78, 89))
+//test("all s", 8, testAllS(1, 5, 78, 89))
+test("all s", 8, testAllS(1, 5, Seq(78, 89)))
 
 // test currying
 
@@ -66,9 +67,9 @@ val testCVVR = testCVV _
 test("cvv r", 3, testCVVR(Seq(1))("", Seq(8, 9)))
 
 val testCVVRS: (String, Int*) => Int = testCVV(2, 3)
-test("cvv rs", 4, testCVVRS("", 5, 6))
+//test("cvv rs", 4, testCVVRS("", 5, 6))
+test("cvv rs", 4, testCVVRS("", Seq(5, 6)))
 
 println("$")
 
-// vim: set ts=4 sw=4 et:
 }

--- a/test/files/run/byname.scala
+++ b/test/files/run/byname.scala
@@ -44,8 +44,9 @@ test("all", 5, testAll(1, 2, 22, 23))
 val testAllR = testAll _
 test("all r", 7, testAllR(2, 3, Seq(34, 35)))
 
-val testAllS: (Int, =>Int, Int*) => Int = testAll _
+//val testAllS: (Int, =>Int, Int*) => Int = testAll _
 //test("all s", 8, testAllS(1, 5, 78, 89))
+val testAllS: (Int, =>Int, Seq[Int]) => Int = testAll _
 test("all s", 8, testAllS(1, 5, Seq(78, 89)))
 
 // test currying
@@ -66,8 +67,9 @@ test("cvv", 3, testCVV(1, 2)("", 8))
 val testCVVR = testCVV _
 test("cvv r", 3, testCVVR(Seq(1))("", Seq(8, 9)))
 
-val testCVVRS: (String, Int*) => Int = testCVV(2, 3)
+//val testCVVRS: (String, Int*) => Int = testCVV(2, 3)
 //test("cvv rs", 4, testCVVRS("", 5, 6))
+val testCVVRS: (String, Seq[Int]) => Int = testCVV(2, 3)
 test("cvv rs", 4, testCVVRS("", Seq(5, 6)))
 
 println("$")

--- a/test/files/run/reify_magicsymbols.check
+++ b/test/files/run/reify_magicsymbols.check
@@ -9,5 +9,4 @@ List[AnyRef]
 List[Null]
 List[Nothing]
 AnyRef{def foo(x: Int): Int}
-Int* => Unit
 (=> Int) => Unit

--- a/test/files/run/reify_magicsymbols.scala
+++ b/test/files/run/reify_magicsymbols.scala
@@ -12,6 +12,6 @@ object Test extends App {
   println(typeOf[List[Null]])
   println(typeOf[List[Nothing]])
   println(typeOf[{def foo(x: Int): Int}])
-  println(typeOf[(Int*) => Unit])
+  //println(typeOf[(Int*) => Unit])
   println(typeOf[(=> Int) => Unit])
 }

--- a/test/files/run/t5610.scala
+++ b/test/files/run/t5610.scala
@@ -17,8 +17,8 @@ object Test {
     fun3(1)()
     fun4(1)()
 
-    val f: (String, Int*) => Unit = m(2, 3)
-    f("", 5, 6)
+    val f: (String, Seq[Int]) => Unit = m(2, 3)
+    f("", Seq(5, 6))
   }
 
   def foo(s: => String)(dummy: Int) = () => println(s)


### PR DESCRIPTION
`typedIdent` converts repeated params as required,
and `typedSelect` should do the same.

There is a more generic issue in scala/bug#6929

Fixes scala/bug#8923