### PR TITLE
Move compilation daemon portfile to homedir

### DIFF
--- a/src/compiler/scala/tools/nsc/CompileSocket.scala
+++ b/src/compiler/scala/tools/nsc/CompileSocket.scala
@@ -5,12 +5,16 @@
 
 package scala.tools.nsc
 
-import java.io.{ FileNotFoundException, PrintWriter, FileOutputStream }
+import java.math.BigInteger
 import java.security.SecureRandom
-import io.{ File, Path, Directory, Socket }
-import scala.tools.util.CompileOutputCommon
+
+import scala.reflect.internal.util.OwnerOnlyChmod
 import scala.reflect.internal.util.StringOps.splitWhere
 import scala.sys.process._
+import scala.tools.nsc.Properties.scalacDir
+import scala.tools.nsc.io.{File, Socket}
+import scala.tools.util.CompileOutputCommon
+import scala.util.control.NonFatal
 
 trait HasCompileSocket {
   def compileSocket: CompileSocket
@@ -46,14 +50,11 @@ trait HasCompileSocket {
 class CompileSocket extends CompileOutputCommon {
   protected lazy val compileClient: StandardCompileClient = CompileClient
   def verbose = compileClient.verbose
-  
+  def verbose_=(v: Boolean) = compileClient.verbose = v
+
   /* Fixes the port where to start the server, 0 yields some free port */
   var fixPort = 0
 
-  /** The prefix of the port identification file, which is followed
-   *  by the port number.
-   */
-  protected lazy val dirName = "scalac-compile-server-port"
   protected def cmdName = Properties.scalaCmd
 
   /** The vm part of the command to start a new scala compile server */
@@ -67,22 +68,10 @@ class CompileSocket extends CompileOutputCommon {
 
   /** The class name of the scala compile server */
   protected val serverClass     = "scala.tools.nsc.CompileServer"
-  protected def serverClassArgs = (if (verbose) List("-v") else Nil) ::: (if (fixPort > 0) List("-p", fixPort.toString) else Nil) 
-
-  /** A temporary directory to use */
-  val tmpDir = {
-    val udir  = Option(Properties.userName) getOrElse "shared"
-    val f     = (Path(Properties.tmpDir) / ("scala-devel" + udir)).createDirectory()
-
-    if (f.isDirectory && f.canWrite) {
-      info("[Temp directory: " + f + "]")
-      f
-    }
-    else fatal("Could not find a directory for temporary files")
-  }
+  protected def serverClassArgs = (if (verbose) List("-v") else Nil) ::: (if (fixPort > 0) List("-p", fixPort.toString) else Nil)
 
   /* A directory holding port identification files */
-  val portsDir = (tmpDir / dirName).createDirectory()
+  private lazy val portsDir = mkDaemonDir("fsc_port")
 
   /** The command which starts the compile server, given vm arguments.
     *
@@ -104,7 +93,7 @@ class CompileSocket extends CompileOutputCommon {
   }
 
   /** The port identification file */
-  def portFile(port: Int) = portsDir / File(port.toString)
+  def portFile(port: Int): File = portsDir / File(port.toString)
 
   /** Poll for a server port number; return -1 if none exists yet */
   private def pollPort(): Int = if (fixPort > 0) {
@@ -138,19 +127,19 @@ class CompileSocket extends CompileOutputCommon {
     }
     info("[Port number: " + port + "]")
     if (port < 0)
-      fatal("Could not connect to compilation daemon after " + attempts + " attempts.")
+      fatal(s"Could not connect to compilation daemon after $attempts attempts. To run without it, use `-nocompdaemon` or `-nc`.")
     port
   }
 
   /** Set the port number to which a scala compile server is connected */
-  def setPort(port: Int) {
+  def setPort(port: Int): Unit = {
     val file    = portFile(port)
-    val secret  = new SecureRandom().nextInt.toString
+    val secretBytes = new Array[Byte](16)
+    new SecureRandom().nextBytes(secretBytes)
+    val secretDigits = new BigInteger(secretBytes).toString().getBytes("UTF-8")
 
-    try file writeAll secret catch {
-      case e @ (_: FileNotFoundException | _: SecurityException) =>
-        fatal("Cannot create file: %s".format(file.path))
-    }
+    try OwnerOnlyChmod().chmodAndWrite(file.jfile, secretDigits)
+    catch chmodFailHandler(s"Cannot create file: ${file}")
   }
 
   /** Delete the port number to which a scala compile server was connected */
@@ -196,7 +185,7 @@ class CompileSocket extends CompileOutputCommon {
     catch { case _: NumberFormatException => None }
 
   def getSocket(serverAdr: String): Option[Socket] = (
-    for ((name, portStr) <- splitWhere(serverAdr, _ == ':', doDropIndex = true) ; port <- parseInt(portStr)) yield    	
+    for ((name, portStr) <- splitWhere(serverAdr, _ == ':', doDropIndex = true) ; port <- parseInt(portStr)) yield
       getSocket(name, port)
   ) getOrElse fatal("Malformed server address: %s; exiting" format serverAdr)
 
@@ -205,7 +194,7 @@ class CompileSocket extends CompileOutputCommon {
     if (sock.isEmpty) warn("Unable to establish connection to server %s:%d".format(hostName, port))
     sock
   }
-  
+
   def getPassword(port: Int): String = {
     val ff  = portFile(port)
     val f   = ff.bufferedReader()
@@ -223,6 +212,24 @@ class CompileSocket extends CompileOutputCommon {
     f.close()
     result
   }
+
+  private def chmodFailHandler(msg: String): PartialFunction[Throwable, Unit] = {
+    case NonFatal(e) =>
+      if (verbose) e.printStackTrace()
+      fatal(msg)
+  }
+
+  def mkDaemonDir(name: String) = {
+    val dir = (scalacDir / name).createDirectory()
+
+    if (dir.isDirectory && dir.canWrite) info(s"[Temp directory: $dir]")
+    else fatal(s"Could not create compilation daemon directory $dir")
+
+    try OwnerOnlyChmod().chmod(dir.jfile)
+    catch chmodFailHandler(s"Failed to change permissions on $dir. The compilation daemon requires a secure directory; use -nc to disable the daemon.")
+    dir
+  }
+
 }
 
 

--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -47,11 +47,6 @@ class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
       "-nc",
       "do not use the fsc compilation daemon") withAbbreviation "-nocompdaemon" withPostSetHook((x: BooleanSetting) => {_useCompDaemon = !x.value })
 
-  private def defaultUseCompdaemon = {
-    // can't reliably lock down permissions on the portfile in this environment => disable by default.
-    !scala.util.Properties.isWin || scala.util.Properties.isJavaAtLeast("7")
-  }
-  private[this] var _useCompDaemon = defaultUseCompdaemon
-
+  private[this] var _useCompDaemon = true
   def useCompDaemon: Boolean = _useCompDaemon
 }

--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -45,5 +45,13 @@ class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
 
   val nc = BooleanSetting(
       "-nc",
-      "do not use the fsc compilation daemon") withAbbreviation "-nocompdaemon"
+      "do not use the fsc compilation daemon") withAbbreviation "-nocompdaemon" withPostSetHook((x: BooleanSetting) => {_useCompDaemon = !x.value })
+
+  private def defaultUseCompdaemon = {
+    // can't reliably lock down permissions on the portfile in this environment => disable by default.
+    !scala.util.Properties.isWin || scala.util.Properties.isJavaAtLeast("7")
+  }
+  private[this] var _useCompDaemon = defaultUseCompdaemon
+
+  def useCompDaemon: Boolean = _useCompDaemon
 }

--- a/src/compiler/scala/tools/nsc/Properties.scala
+++ b/src/compiler/scala/tools/nsc/Properties.scala
@@ -5,6 +5,8 @@
 
 package scala.tools.nsc
 
+import scala.tools.nsc.io.Path
+
 /** Loads `compiler.properties` from the jar archive file.
  */
 object Properties extends scala.util.PropertiesTrait {
@@ -28,4 +30,7 @@ object Properties extends scala.util.PropertiesTrait {
 
   // derived values
   def isEmacsShell         = propOrEmpty("env.emacs") != ""
+
+  // Where we keep fsc's state (ports/redirection)
+  lazy val scalacDir = (Path(Properties.userHome) / ".scalac").createDirectory(force = false)
 }

--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -67,7 +67,10 @@ class ScriptRunner extends HasCompileSocket {
     val coreCompArgs     = compSettings flatMap (_.unparse)
     val compArgs         = coreCompArgs ++ List("-Xscript", scriptMain(settings), scriptFile)
 
-    CompileSocket getOrCreateSocket "" match {
+    // TODO: untangle this mess of top-level objects with their own little view of the mutable world of settings
+    compileSocket.verbose = settings.verbose.value
+
+    compileSocket getOrCreateSocket "" match {
       case Some(sock) => compileOnServer(sock, compArgs)
       case _          => false
     }
@@ -99,7 +102,7 @@ class ScriptRunner extends HasCompileSocket {
 
       settings.outdir.value = compiledPath.path
 
-      if (settings.nc) {
+      if (!settings.useCompDaemon) {
         /* Setting settings.script.value informs the compiler this is not a
          * self contained compilation unit.
          */

--- a/src/reflect/scala/reflect/internal/util/OwnerOnlyChmod.scala
+++ b/src/reflect/scala/reflect/internal/util/OwnerOnlyChmod.scala
@@ -1,0 +1,110 @@
+/* NSC -- new Scala compiler
+ * Copyright 2017 LAMP/EPFL
+ * @author  Martin Odersky
+ */
+package scala.reflect.internal.util
+
+import java.io.{File, FileOutputStream, IOException}
+
+
+trait OwnerOnlyChmod {
+  /** Remove group/other permisisons for `file`, it if exists */
+  def chmod(file: java.io.File): Unit
+
+  /** Delete `file` if it exists, recreate it with no group/other permissions, and write `contents` */
+  final def chmodAndWrite(file: File, contents: Array[Byte]): Unit = {
+    file.delete()
+    val fos = new FileOutputStream(file)
+    fos.close()
+    chmod(file)
+    val fos2 = new FileOutputStream(file)
+    try {
+      fos2.write(contents)
+    } finally {
+      fos2.close()
+    }
+  }
+
+  // TODO: use appropriate NIO call instead of two-step exists?/create!
+  final def chmodOrCreateEmpty(file: File): Unit =
+    if (!file.exists()) chmodAndWrite(file, Array[Byte]()) else chmod(file)
+
+}
+
+object OwnerOnlyChmod {
+  def apply(): OwnerOnlyChmod = {
+    if (!util.Properties.isWin) Java6UnixChmod
+    else if (util.Properties.isJavaAtLeast("7")) new NioAclChmodReflective
+    else NoOpOwnerOnlyChmod
+  }
+}
+
+object NoOpOwnerOnlyChmod extends OwnerOnlyChmod {
+  override def chmod(file: File): Unit = ()
+}
+
+
+/** Adjust permissions with `File.{setReadable, setWritable}` */
+object Java6UnixChmod extends OwnerOnlyChmod {
+
+  def chmod(file: File): Unit = if (file.exists()) {
+    def clearAndSetOwnerOnly(f: (Boolean, Boolean) => Boolean): Unit = {
+      def fail() = throw new IOException("Unable to modify permissions of " + file)
+      // attribute = false, ownerOwnly = false
+      if (!f(false, false)) fail()
+      // attribute = true, ownerOwnly = true
+      if (!f(true, true)) fail()
+    }
+    if (file.isDirectory) {
+      clearAndSetOwnerOnly(file.setExecutable)
+    }
+    clearAndSetOwnerOnly(file.setReadable)
+    clearAndSetOwnerOnly(file.setWritable)
+  }
+}
+
+
+object NioAclChmodReflective {
+  private class Reflectors {
+    val file_toPath = classOf[java.io.File].getMethod("toPath")
+    val files = Class.forName("java.nio.file.Files")
+    val path_class = Class.forName("java.nio.file.Path")
+    val getFileAttributeView = files.getMethod("getFileAttributeView", path_class, classOf[Class[_]], Class.forName("[Ljava.nio.file.LinkOption;"))
+    val linkOptionEmptyArray = java.lang.reflect.Array.newInstance(Class.forName("java.nio.file.LinkOption"), 0)
+    val aclFileAttributeView_class = Class.forName("java.nio.file.attribute.AclFileAttributeView")
+    val aclEntry_class = Class.forName("java.nio.file.attribute.AclEntry")
+    val aclEntryBuilder_class = Class.forName("java.nio.file.attribute.AclEntry$Builder")
+    val newBuilder = aclEntry_class.getMethod("newBuilder")
+    val aclEntryBuilder_build = aclEntryBuilder_class.getMethod("build")
+    val userPrinciple_class = Class.forName("java.nio.file.attribute.UserPrincipal")
+    val setPrincipal = aclEntryBuilder_class.getMethod("setPrincipal", userPrinciple_class)
+    val setPermissions = aclEntryBuilder_class.getMethod("setPermissions", Class.forName("[Ljava.nio.file.attribute.AclEntryPermission;"))
+    val aclEntryType_class = Class.forName("java.nio.file.attribute.AclEntryType")
+    val setType = aclEntryBuilder_class.getMethod("setType", aclEntryType_class)
+    val aclEntryPermission_class = Class.forName("java.nio.file.attribute.AclEntryPermission")
+    val aclEntryPermissionValues = aclEntryPermission_class.getDeclaredMethod("values")
+    val aclEntryType_ALLOW = aclEntryType_class.getDeclaredField("ALLOW")
+  }
+  private val reflectors = try { new Reflectors } catch { case ex: Throwable => null }
+}
+
+/** Reflective version of `NioAclChmod` */
+final class NioAclChmodReflective extends OwnerOnlyChmod {
+  import NioAclChmodReflective.reflectors._
+  def chmod(file: java.io.File): Unit = {
+    val path = file_toPath.invoke(file)
+    val view = getFileAttributeView.invoke(null, path, aclFileAttributeView_class, linkOptionEmptyArray)
+    val setAcl = aclFileAttributeView_class.getMethod("setAcl", classOf[java.util.List[_]])
+    val getOwner = aclFileAttributeView_class.getMethod("getOwner")
+    val owner = getOwner.invoke(view)
+    setAcl.invoke(view, acls(owner))
+  }
+
+  private def acls(owner: Object) = {
+    val builder = newBuilder.invoke(null)
+    setPrincipal.invoke(builder, owner)
+    setPermissions.invoke(builder, aclEntryPermissionValues.invoke(null))
+    setType.invoke(builder, aclEntryType_ALLOW.get(null))
+    java.util.Collections.singletonList(aclEntryBuilder_build.invoke(builder))
+  }
+}

--- a/src/repl-jline/scala/tools/nsc/interpreter/jline/FileBackedHistory.scala
+++ b/src/repl-jline/scala/tools/nsc/interpreter/jline/FileBackedHistory.scala
@@ -8,15 +8,37 @@ package scala.tools.nsc.interpreter.jline
 import _root_.jline.console.history.PersistentHistory
 
 import scala.tools.nsc.interpreter
-import scala.reflect.io.{ File, Path }
-import scala.tools.nsc.Properties.{ propOrNone, userHome }
+import scala.reflect.io.{File, Path}
+import scala.tools.nsc.Properties.{propOrNone, userHome}
+import scala.reflect.internal.util.OwnerOnlyChmod
+import scala.util.control.NonFatal
 
 /** TODO: file locking.
   */
 trait FileBackedHistory extends JLineHistory with PersistentHistory {
   def maxSize: Int
 
-  protected lazy val historyFile: File = FileBackedHistory.defaultFile
+  // For a history file in the standard location, always try to restrict permission,
+  // creating an empty file if none exists.
+  // For a user-specified location, only lock down permissions on if we're the ones
+  // creating it, otherwise responsibility for permissions is up to the caller.
+  protected lazy val historyFile: File = File {
+    propOrNone("scala.shell.histfile").map(Path.apply) match {
+      case Some(p) => if (!p.exists) secure(p) else p
+      case None => secure(Path(userHome) / FileBackedHistory.defaultFileName)
+    }
+  }
+
+  private def secure(p: Path): Path = {
+    try OwnerOnlyChmod().chmodOrCreateEmpty(p.jfile)
+    catch { case NonFatal(e) =>
+      if (interpreter.isReplDebug) e.printStackTrace()
+      interpreter.replinfo(s"Warning: history file ${p}'s permissions could not be restricted to owner-only.")
+    }
+
+    p
+  }
+
   private var isPersistent = true
 
   locally {
@@ -86,8 +108,4 @@ object FileBackedHistory {
   //   val ContinuationNL: String = Array('\003', '\n').mkString
 
   final val defaultFileName = ".scala_history"
-
-  def defaultFile: File = File(
-    propOrNone("scala.shell.histfile") map (Path.apply) getOrElse (Path(userHome) / defaultFileName)
-  )
 }

--- a/src/repl-jline/scala/tools/nsc/interpreter/jline/FileBackedHistory.scala
+++ b/src/repl-jline/scala/tools/nsc/interpreter/jline/FileBackedHistory.scala
@@ -20,7 +20,7 @@ trait FileBackedHistory extends JLineHistory with PersistentHistory {
 
   // For a history file in the standard location, always try to restrict permission,
   // creating an empty file if none exists.
-  // For a user-specified location, only lock down permissions on if we're the ones
+  // For a user-specified location, only lock down permissions if we're the ones
   // creating it, otherwise responsibility for permissions is up to the caller.
   protected lazy val historyFile: File = File {
     propOrNone("scala.shell.histfile").map(Path.apply) match {


### PR DESCRIPTION
Store the compilation daemon's administrativia (port file, redirection)
under `~/.scalac/`, instead of the less standard
`/tmp/scala-devel/${USER:shared}/scalac-compile-server-port`.

On creation, remove group- and other-permissions from these
private files, ditto for the repl's history file.

On Java 6 on Windows, opt in to compilation daemon using `-nc:false`.