### PR TITLE
lengthen timeout on some Future tests

### DIFF
--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -61,7 +61,7 @@ class FutureTests extends MinimalScalaTest {
       val waiting = Future {
         Thread.sleep(1000)
       }
-      Await.ready(waiting, 2000 millis)
+      Await.ready(waiting, 4000 millis)
 
       ms.size mustBe (4)
       ec.shutdownNow()
@@ -95,7 +95,7 @@ class FutureTests extends MinimalScalaTest {
 
       val t = new InterruptedException()
       val f = Future(throw t)(ec)
-      Await.result(p.future, 2.seconds) mustBe t
+      Await.result(p.future, 4.seconds) mustBe t
     }
   }
 


### PR DESCRIPTION
these have repeatedly (though intermittently) failed on Jenkins,
e.g. https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-windows/795/

not *that* often, but just often enough to be annoying

perhaps longer timeouts will make it happen less often