### PR TITLE
[backport] Fix runtime reflection of empty package members under Java 9.

### DIFF
--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -937,7 +937,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
      * The Scala package with given fully qualified name. Unlike `packageNameToScala`,
      *  this one bypasses the cache.
      */
-    private[JavaMirrors] def makeScalaPackage(fullname: String): ModuleSymbol = gilSynchronized {
+    private[JavaMirrors] def makeScalaPackage(fullname: String): ModuleSymbol = if (fullname == "") EmptyPackage else gilSynchronized {
       val split = fullname lastIndexOf '.'
       val ownerModule: ModuleSymbol =
         if (split > 0) packageNameToScala(fullname take split) else this.RootPackage

--- a/test/files/run/sd304.check
+++ b/test/files/run/sd304.check
@@ -1,0 +1,1 @@
+class Test

--- a/test/files/run/sd304/ReflectTest.scala
+++ b/test/files/run/sd304/ReflectTest.scala
@@ -1,0 +1,8 @@
+package p1
+
+class ReflectTest {
+  def test(a: AnyRef): Unit = {
+    val mirror = reflect.runtime.universe.runtimeMirror(a.getClass.getClassLoader)
+    println(mirror.reflect(a).symbol)
+  }
+}

--- a/test/files/run/sd304/Test.java
+++ b/test/files/run/sd304/Test.java
@@ -1,0 +1,5 @@
+public class Test {
+    public static void main(String[] args) {
+        new p1.ReflectTest().test(new Test());
+    }
+}


### PR DESCRIPTION
We used to rely on `cls.getPackage == null` for `cls` defined in the
empty package. Under Java 9, we actually get the empty package back
from that call.

This commit ensures we use the one true empty package symbol on
either Java 8 or 9.

(cherry picked from commit b81bc778822de33e73fda59d5014baa1292856d4)