### PR TITLE
Fix wrong parenthesis order around creation of mutable.BitSet

### DIFF
--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -50,7 +50,7 @@ class BitSet(protected final var elems: Array[Long]) extends AbstractSet[Int]
    *
    *  @param initSize    initial size of the bitset.
    */
-  def this(initSize: Int) = this(new Array[Long]((initSize + 63) >> 6 max 1))
+  def this(initSize: Int) = this(new Array[Long](((initSize + 63) >> 6) max 1))
 
   def this() = this(0)
 


### PR DESCRIPTION
Exploring the implementation of `mutable.BitSet`, I've noticed that the parenthesis seemed to be misplaced, causing the expression `6 max 1` to be evaluated, instead of what I believe was meant to first calculate the initial bit-shifted size, and then max that with 1 in case we're in the lower 64 bits.