### PR TITLE
[backport] AnyRefMap dropped entries with one hash code.

### DIFF
--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -79,13 +79,14 @@ extends AbstractMap[K, V]
     (_size + _vacant) > 0.5*mask || _vacant > _size
 
   private def hashOf(key: K): Int = {
+    // Note: this method must not return 0 or Int.MinValue, as these indicate no element
     if (key eq null) 0x41081989
     else {
       val h = key.hashCode
       // Part of the MurmurHash3 32 bit finalizer
       val i = (h ^ (h >>> 16)) * 0x85EBCA6B
-      val j = (i ^ (i >>> 13))
-      if (j==0) 0x41081989 else j & 0x7FFFFFFF
+      val j = (i ^ (i >>> 13)) & 0x7FFFFFFF
+      if (j==0) 0x41081989 else j
     }
   }
 

--- a/test/junit/scala/collection/mutable/AnyRefMapTest.scala
+++ b/test/junit/scala/collection/mutable/AnyRefMapTest.scala
@@ -1,0 +1,24 @@
+package scala.collection.mutable
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+import org.junit.Assert.assertTrue
+
+import scala.collection.mutable.AnyRefMap
+
+/* Test for scala/bug#10540 */
+@RunWith(classOf[JUnit4])
+class AnyRefMapTest {
+  @Test
+  def test10540: Unit = {
+    val badHashCode = -2105619938
+    val reported = "K00278:18:H7C2NBBXX:7:1111:7791:21465"
+    val equivalent = "JK1C=H"
+    val sameHashCode = java.lang.Integer.valueOf(badHashCode)
+    assertTrue(AnyRefMap(reported -> 1) contains reported)
+    assertTrue(AnyRefMap(equivalent -> 1) contains equivalent)
+    assertTrue(AnyRefMap(sameHashCode -> 1) contains sameHashCode)
+    assertTrue(sameHashCode.hashCode == badHashCode)  // Make sure test works
+  }
+}


### PR DESCRIPTION
Changed the internal hash code calculation to not produce zero values.

(cherry picked from commit 42e9a64e60c38bc77e67a4517ece097cf6a06cdf)

Backport of fix for for scala/bug#10540