### PR TITLE
Move compilation daemon portfile under `~/.scalac/`

### DIFF
--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -45,5 +45,9 @@ class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
 
   val nc = BooleanSetting(
       "-nc",
-      "do not use the fsc compilation daemon") withAbbreviation "-nocompdaemon"
+      "do not use the fsc compilation daemon") withAbbreviation "-nocompdaemon" withPostSetHook((x: BooleanSetting) => {_useCompDaemon = !x.value })
+
+
+  private[this] var _useCompDaemon = true
+  def useCompDaemon: Boolean = _useCompDaemon
 }

--- a/src/compiler/scala/tools/nsc/Properties.scala
+++ b/src/compiler/scala/tools/nsc/Properties.scala
@@ -5,6 +5,8 @@
 
 package scala.tools.nsc
 
+import scala.tools.nsc.io.Path
+
 /** Loads `compiler.properties` from the jar archive file.
  */
 object Properties extends scala.util.PropertiesTrait {
@@ -28,4 +30,7 @@ object Properties extends scala.util.PropertiesTrait {
 
   // derived values
   def isEmacsShell         = propOrEmpty("env.emacs") != ""
+
+  // Where we keep fsc's state (ports/redirection)
+  lazy val scalacDir = (Path(Properties.userHome) / ".scalac").createDirectory(force = false)
 }

--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -65,7 +65,10 @@ class ScriptRunner extends HasCompileSocket {
     val coreCompArgs     = compSettings flatMap (_.unparse)
     val compArgs         = coreCompArgs ++ List("-Xscript", scriptMain(settings), scriptFile)
 
-    CompileSocket getOrCreateSocket "" match {
+    // TODO: untangle this mess of top-level objects with their own little view of the mutable world of settings
+    compileSocket.verbose = settings.verbose.value
+
+    compileSocket getOrCreateSocket "" match {
       case Some(sock) => compileOnServer(sock, compArgs)
       case _          => false
     }
@@ -97,7 +100,7 @@ class ScriptRunner extends HasCompileSocket {
 
       settings.outdir.value = compiledPath.path
 
-      if (settings.nc) {
+      if (!settings.useCompDaemon) {
         /* Setting settings.script.value informs the compiler this is not a
          * self contained compilation unit.
          */

--- a/src/reflect/scala/reflect/internal/util/OwnerOnlyChmod.scala
+++ b/src/reflect/scala/reflect/internal/util/OwnerOnlyChmod.scala
@@ -1,0 +1,59 @@
+/* NSC -- new Scala compiler
+ * Copyright 2017 LAMP/EPFL
+ * @author  Martin Odersky
+ */
+package scala.reflect.internal.util
+
+import java.nio.ByteBuffer
+import java.nio.file.StandardOpenOption.{CREATE, TRUNCATE_EXISTING, WRITE}
+import java.nio.file.attribute.PosixFilePermission.{OWNER_EXECUTE, OWNER_READ, OWNER_WRITE}
+import java.nio.file.attribute.PosixFilePermissions.asFileAttribute
+import java.nio.file.attribute._
+import java.nio.file.{Files, Path}
+import java.util.EnumSet
+
+
+object OwnerOnlyChmod {
+  private def canPosix(path: Path) =
+    Files.getFileStore(path).supportsFileAttributeView(classOf[PosixFileAttributeView])
+
+  private val posixDir  = EnumSet.of(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE)
+  private val posixFile = EnumSet.of(OWNER_READ, OWNER_WRITE)
+  private def fileAttributes(path: Path) =
+    if (canPosix(path)) Array(asFileAttribute(posixFile)) else Array.empty[FileAttribute[_]]
+
+  /** Remove group/other permissions for `file`, it if exists, and if the runtime environment supports modifying permissions. */
+  def chmod(path: Path): Unit = {
+    if (canPosix(path)) Files.setPosixFilePermissions(path, if (Files.isDirectory(path)) posixDir else posixFile)
+    else {
+      // if getting this view fails, we fail
+      val view = Files.getFileAttributeView(path, classOf[AclFileAttributeView])
+      if (view == null) throw new UnsupportedOperationException(s"Cannot get file attribute view for $path")
+
+      val acls = {
+        val builder = AclEntry.newBuilder
+        builder.setPrincipal(view.getOwner)
+        builder.setPermissions(AclEntryPermission.values(): _*)
+        builder.setType(AclEntryType.ALLOW)
+        val entry = builder.build
+        java.util.Collections.singletonList(entry)
+      }
+
+      view.setAcl(acls)
+    }
+  }
+
+  def chmodFileOrCreateEmpty(path: Path): Unit = {
+    // Create new file if none existed, with appropriate permissions via the fileAttributes attributes (if supported).
+    Files.newByteChannel(path, EnumSet.of(WRITE, CREATE), fileAttributes(path): _*).close()
+    // Change (if needed -- either because the file already existed, or the FS needs a separate call to set the ACL)
+    chmod(path)
+  }
+
+  def chmodFileAndWrite(path: Path, contents: Array[Byte]): Unit = {
+    val sbc = Files.newByteChannel(path, EnumSet.of(WRITE, TRUNCATE_EXISTING), fileAttributes(path): _*)
+    try sbc.write(ByteBuffer.wrap(contents)) finally sbc.close()
+    chmod(path) // for acl-based FS
+  }
+}
+

--- a/src/repl-jline/scala/tools/nsc/interpreter/jline/FileBackedHistory.scala
+++ b/src/repl-jline/scala/tools/nsc/interpreter/jline/FileBackedHistory.scala
@@ -8,15 +8,37 @@ package scala.tools.nsc.interpreter.jline
 import _root_.jline.console.history.PersistentHistory
 
 import scala.tools.nsc.interpreter
-import scala.reflect.io.{ File, Path }
-import scala.tools.nsc.Properties.{ propOrNone, userHome }
+import scala.reflect.io.{File, Path}
+import scala.tools.nsc.Properties.{propOrNone, userHome}
+import scala.reflect.internal.util.OwnerOnlyChmod
+import scala.util.control.NonFatal
 
 /** TODO: file locking.
   */
 trait FileBackedHistory extends JLineHistory with PersistentHistory {
   def maxSize: Int
 
-  protected lazy val historyFile: File = FileBackedHistory.defaultFile
+  // For a history file in the standard location, always try to restrict permission,
+  // creating an empty file if none exists.
+  // For a user-specified location, only lock down permissions if we're the ones
+  // creating it, otherwise responsibility for permissions is up to the caller.
+  protected lazy val historyFile: File = File {
+    propOrNone("scala.shell.histfile").map(Path.apply) match {
+      case Some(p) => if (!p.exists) secure(p) else p
+      case None => secure(Path(userHome) / FileBackedHistory.defaultFileName)
+    }
+  }
+
+  private def secure(p: Path): Path = {
+    try OwnerOnlyChmod.chmodFileOrCreateEmpty(p.jfile.toPath)
+    catch { case NonFatal(e) =>
+      if (interpreter.isReplDebug) e.printStackTrace()
+      interpreter.replinfo(s"Warning: history file ${p}'s permissions could not be restricted to owner-only.")
+    }
+
+    p
+  }
+
   private var isPersistent = true
 
   locally {
@@ -86,8 +108,4 @@ object FileBackedHistory {
   //   val ContinuationNL: String = Array('\003', '\n').mkString
 
   final val defaultFileName = ".scala_history"
-
-  def defaultFile: File = File(
-    propOrNone("scala.shell.histfile") map (Path.apply) getOrElse (Path(userHome) / defaultFileName)
-  )
 }


### PR DESCRIPTION
Store the compilation daemon's administrativia (port file, redirection)
under `~/.scalac/`, instead of the less standard
`/tmp/scala-devel/${USER:shared}/scalac-compile-server-port`.

On creation, remove group- and other-permissions from these
private files, ditto for the repl's history file.

Based on b64ad85