### PR TITLE
Fix bounds of higher-kinded existentials

### DIFF
--- a/src/reflect/scala/reflect/internal/ExistentialsAndSkolems.scala
+++ b/src/reflect/scala/reflect/internal/ExistentialsAndSkolems.scala
@@ -62,8 +62,8 @@ trait ExistentialsAndSkolems {
     // Hanging onto lower bound in case anything interesting
     // happens with it.
     mapFrom(hidden)(s => s.existentialBound match {
-      case TypeBounds(lo, hi) => TypeBounds(lo, hiBound(s))
-      case _                  => hiBound(s)
+      case GenPolyType(tparams, TypeBounds(lo, _)) => GenPolyType(tparams, TypeBounds(lo, hiBound(s)))
+      case _ => hiBound(s)
     })
   }
 

--- a/test/files/neg/hk-existential-lb.check
+++ b/test/files/neg/hk-existential-lb.check
@@ -1,0 +1,8 @@
+hk-existential-lb.scala:3: error: type mismatch;
+ found   : Functor[Option]
+ required: Functor[_[x] >: List[x]]
+Note: Option <: [x]Any, but class Functor is invariant in type F.
+You may wish to define F as +F instead. (SLS 4.5)
+  val someF: Functor[F] forSome { type F[x] >: List[x] } = new Functor[Option]
+                                                           ^
+one error found

--- a/test/files/neg/hk-existential-lb.flags
+++ b/test/files/neg/hk-existential-lb.flags
@@ -1,0 +1,1 @@
+-language:higherKinds,existentials -Xfatal-warnings

--- a/test/files/neg/hk-existential-lb.scala
+++ b/test/files/neg/hk-existential-lb.scala
@@ -1,0 +1,4 @@
+class Functor[F[_]]
+object Functor {
+  val someF: Functor[F] forSome { type F[x] >: List[x] } = new Functor[Option]
+}

--- a/test/files/pos/hk-existential-subtype.flags
+++ b/test/files/pos/hk-existential-subtype.flags
@@ -1,0 +1,1 @@
+-language:higherKinds,existentials -Xfatal-warnings

--- a/test/files/pos/hk-existential-subtype.scala
+++ b/test/files/pos/hk-existential-subtype.scala
@@ -1,0 +1,4 @@
+class Functor[F[_]]
+object Functor {
+  val someF: Functor[F] forSome { type F[_] } = new Functor[Option]
+}

--- a/test/files/run/t1427.check
+++ b/test/files/run/t1427.check
@@ -1,3 +1,0 @@
-t1427.scala:6: warning: abstract type X in type pattern Bob[_[_] <: Any] is unchecked since it is eliminated by erasure
-    case x: (Bob[X] forSome { type X[_] })  => true
-                    ^


### PR DESCRIPTION
Which in turn restores the correct subtyping relation.
See the test for an example.

Fixes scala/bug#9325, fixes scala/bug#9445 and fixes scala/bug#10258