### PR TITLE
Revert "Deprecate Tuple[23]Zipped.invert, rename to Tuple[23]Zipped.transpose."

### DIFF
--- a/src/library/scala/runtime/Tuple2Zipped.scala
+++ b/src/library/scala/runtime/Tuple2Zipped.scala
@@ -117,14 +117,7 @@ final class Tuple2Zipped[El1, Repr1, El2, Repr2](private val colls: (Traversable
 
 object Tuple2Zipped {
   final class Ops[T1, T2](private val x: (T1, T2)) extends AnyVal {
-    @deprecated("Use `transpose` instead", "2.13.0")
     def invert[El1, CC1[X] <: TraversableOnce[X], El2, CC2[X] <: TraversableOnce[X], That]
-      (implicit w1: T1 <:< CC1[El1],
-                w2: T2 <:< CC2[El2],
-                bf: scala.collection.generic.CanBuildFrom[CC1[_], (El1, El2), That]
-      ): That = transpose
-
-    def transpose[El1, CC1[X] <: TraversableOnce[X], El2, CC2[X] <: TraversableOnce[X], That]
       (implicit w1: T1 <:< CC1[El1],
                 w2: T2 <:< CC2[El2],
                 bf: scala.collection.generic.CanBuildFrom[CC1[_], (El1, El2), That]

--- a/src/library/scala/runtime/Tuple3Zipped.scala
+++ b/src/library/scala/runtime/Tuple3Zipped.scala
@@ -128,15 +128,7 @@ final class Tuple3Zipped[El1, Repr1, El2, Repr2, El3, Repr3](private val colls: 
 
 object Tuple3Zipped {
   final class Ops[T1, T2, T3](private val x: (T1, T2, T3)) extends AnyVal {
-    @deprecated("Use `transpose` instead", "2.13.0")
     def invert[El1, CC1[X] <: TraversableOnce[X], El2, CC2[X] <: TraversableOnce[X], El3, CC3[X] <: TraversableOnce[X], That]
-      (implicit w1: T1 <:< CC1[El1],
-                w2: T2 <:< CC2[El2],
-                w3: T3 <:< CC3[El3],
-                bf: scala.collection.generic.CanBuildFrom[CC1[_], (El1, El2, El3), That]
-      ): That = transpose
-
-    def transpose[El1, CC1[X] <: TraversableOnce[X], El2, CC2[X] <: TraversableOnce[X], El3, CC3[X] <: TraversableOnce[X], That]
       (implicit w1: T1 <:< CC1[El1],
                 w2: T2 <:< CC2[El2],
                 w3: T3 <:< CC3[El3],


### PR DESCRIPTION
Reverts scala/scala#6035 to unbreak community build. Let's discuss how to bring this back at the original PR