### PR TITLE
Improvements to the type variable solver.

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
@@ -200,10 +200,15 @@ private[internal] trait TypeConstraints {
         //Console.println("solveOne0(tv, tp, v, b)="+(tvar, tparam, variance, bound))
         var cyclic = bound contains tparam
 
+        // This is attempting to reorder the solving of TypeVars such that tvs which are
+        // mentioned in the active bound are solved first.
+        // 1. Is this reordering desirable? Should solving always be left to right instead?
+        // 2. Should this take account of the variance of tparam2 and flip the bounds if
+        //    necessary?
         foreach3(tvars, tparams, variances){ (tvar2, tparam2, variance2) =>
           val contributes = (tparam2 != tparam) && ((bound contains tparam2) || {
             val bound2 = if (up) tparam2.info.bounds.lo else tparam2.info.bounds.hi
-            bound2 =:= tparam.typeConstructor
+            bound2 contains tparam
           })
           if (contributes) {
             if (tvar2.constr.inst eq null) cyclic = true // came back to a tvar that's being solved --> cycle! (note that we capture the `cyclic` var)
@@ -212,6 +217,46 @@ private[internal] trait TypeConstraints {
         }
 
         if (!cyclic) {
+          def propagateBounds(tparam2: Symbol, tvar2: Type): Unit = {
+            def addBound(variance: Variance, bound: Type) = if (bound != NoType) {
+              debuglog(s"$tvar.addBound($variance, $bound.instantiateTypeParams($tparams, $tvars))")
+              if (variance.isInvariant || variance.isCovariant) tvar addHiBound bound
+              if (variance.isInvariant || variance.isContravariant) tvar addLoBound bound
+            }
+
+            def toInst(tp: Type): Type = tp match {
+              case tv: TypeVar =>
+                val inst = tv.inst
+                if (inst == null) NoType else inst
+              case _ => tp
+            }
+
+            // Try harder to propagate information we can discover from this type variable's
+            // occurence in bounds on other type variables. Also avoid some ill-kinding issues.
+            def propagate(variance: Variance, bound: Type, instantiate: Type): Unit = bound match {
+              // Propagate bounds of the same kind: F[A, B, C[_]] <: G[A, B, C] => F <: G
+              // Undoing eta-expansion to ensure the propagated bound is correct.
+              case GenPolyType(tparams, TypeRef(_, `tparam`, targs))
+                if tparams.corresponds(targs) { (tp, ta) => ta.typeArgs.isEmpty && ta.typeSymbolDirect == tp }
+                => addBound(variance, instantiate)
+              // Propagate type constructor: F[A] <: B => F <: B.typeConstructor
+              // Propagate type arguments: F[+A, -B] <: C => A <: C.typeArgs(0) && B >: C.typeArgs(1)
+              case TypeRef(_, tsym, targs) =>
+                val inst = toInst(instantiate)
+                if(inst != NoType) {
+                  if (tsym == tparam) addBound(variance, inst.typeConstructor)
+                  foreach3(tsym.typeParams, targs, inst.typeArgs) {
+                    (tparam, targ, inst) => propagate(tparam.variance * variance, targ, inst)
+                  }
+                }
+              case _ =>
+            }
+
+            val variance = if (up) Variance.Covariant else Variance.Contravariant
+            val bound = if (up) tparam2.info.bounds.lo else tparam2.info.bounds.hi
+            propagate(variance, bound.dealias, tvar2)
+          }
+
           if (up) {
             if (bound.typeSymbol != AnyClass) {
               debuglog(s"$tvar addHiBound $bound.instantiateTypeParams($tparams, $tvars)")
@@ -223,22 +268,7 @@ private[internal] trait TypeConstraints {
               tvar addLoBound bound.instantiateTypeParams(tparams, tvars)
             }
           }
-
-          // can we derive more constraints for `tvar` (and `tparam`) from its occurrences in the bounds of the other tparams?
-          foreach2(tparams, tvars) { (tparamOther, tvarOther) =>
-            if (tparamOther ne tparam) {
-              val boundOther =
-                if (up) tparamOther.info.bounds.lo else tparamOther.info.bounds.hi
-
-              boundOther.dealias match {
-                // `tparam` is the lower/upper bound of `tvarOther`. Flip that, and add `tvarOther` as an upper/lower bound for `tvar`
-                case TypeRef(_, `tparam`, _) =>
-                  debuglog(s"$tvar propagate bound from $tvarOther")
-                  if (up) tvar.addHiBound(tvarOther) else tvar.addLoBound(tvarOther)
-                case _                       =>
-              }
-            }
-          }
+          foreach2(tparams, tvars)(propagateBounds)
         }
 
         tvar.constr.inst = NoType // necessary because hibounds/lobounds may contain tvar

--- a/test/files/neg/t7289_status_quo.check
+++ b/test/files/neg/t7289_status_quo.check
@@ -1,22 +1,5 @@
-t7289_status_quo.scala:9: error: could not find implicit value for parameter e: Test1.Ext[List[Int]]
-  implicitly[Ext[List[Int]]]                    // fails - not found
+t7289_status_quo.scala:9: error: diverging implicit expansion for type Test1.Ext[List[Int]]
+starting with value m in object Test1
+  implicitly[Ext[List[Int]]]                    // fails - not found (as expected)
             ^
-t7289_status_quo.scala:11: error: could not find implicit value for parameter e: Test1.Ext[List[List[List[Int]]]]
-  implicitly[Ext[List[List[List[Int]]]]]        // fails - not found
-            ^
-t7289_status_quo.scala:15: error: ambiguous implicit values:
- both method f in object Test1 of type [A, Coll <: CC[A], CC[X] <: Traversable[X]](implicit xi: Test1.Ext[A])Test1.Ext[Coll]
- and value m in object Test1 of type => Test1.Ext[List[List[Int]]]
- match expected type Test1.Ext[_ <: List[List[Int]]]
-  implicitly[Ext[_ <: List[List[Int]]]]         // fails - ambiguous
-            ^
-t7289_status_quo.scala:20: error: could not find implicit value for parameter e: Test1.ExtCov[List[Int]]
-  implicitly[ExtCov[List[Int]]]                 // fails - not found
-            ^
-t7289_status_quo.scala:21: error: could not find implicit value for parameter e: Test1.ExtCov[List[List[Int]]]
-  implicitly[ExtCov[List[List[Int]]]]           // fails - not found
-            ^
-t7289_status_quo.scala:22: error: could not find implicit value for parameter e: Test1.ExtCov[List[List[List[Int]]]]
-  implicitly[ExtCov[List[List[List[Int]]]]]     // fails - not found
-            ^
-6 errors found
+one error found

--- a/test/files/neg/t7289_status_quo.scala
+++ b/test/files/neg/t7289_status_quo.scala
@@ -6,18 +6,21 @@ object Test1 {
   implicit def f[A, Coll <: CC[A], CC[X] <: Traversable[X]](implicit xi: Ext[A]): Ext[Coll] = ???
   implicit val m: Ext[List[List[Int]]] = new Ext[List[List[Int]]]{}
 
-  implicitly[Ext[List[Int]]]                    // fails - not found
+  implicitly[Ext[List[Int]]]                    // fails - not found (as expected)
   implicitly[Ext[List[List[Int]]]]              // compiles
-  implicitly[Ext[List[List[List[Int]]]]]        // fails - not found
+  implicitly[Ext[List[List[List[Int]]]]]        // compiles
 
   // Making Ext[+T] should incur the same behavior as these. (so says @paulp)
   implicitly[Ext[_ <: List[Int]]]               // compiles
-  implicitly[Ext[_ <: List[List[Int]]]]         // fails - ambiguous
+  implicitly[Ext[_ <: List[List[Int]]]]         // compiles
   implicitly[Ext[_ <: List[List[List[Int]]]]]   // compiles
 
-  // But, we currently get:
+  // And indeed it does:
   trait ExtCov[+T]
-  implicitly[ExtCov[List[Int]]]                 // fails - not found
-  implicitly[ExtCov[List[List[Int]]]]           // fails - not found
-  implicitly[ExtCov[List[List[List[Int]]]]]     // fails - not found
+  implicit def fCov[A, Coll <: CC[A], CC[X] <: Traversable[X]](implicit xi: ExtCov[A]): ExtCov[Coll] = ???
+  implicit val mCov: ExtCov[List[List[Int]]] = new ExtCov[List[List[Int]]]{}
+
+  implicitly[ExtCov[List[Int]]]                 // compiles
+  implicitly[ExtCov[List[List[Int]]]]           // compiles
+  implicitly[ExtCov[List[List[List[Int]]]]]     // compiles
 }

--- a/test/files/pos/bounds-propagation.scala
+++ b/test/files/pos/bounds-propagation.scala
@@ -1,0 +1,11 @@
+import scala.language.higherKinds
+
+object Test {
+  def foo[A <: List[B], B](x: A): Option[B] = None
+  val res0 = foo(List(0))
+  val res1: Option[Int] = res0
+
+  def bar[A <: F[Int], F[_]](x: A): Option[F[Boolean]] = None
+  val res2 = bar(List(0))
+  val res3: Option[List[Boolean]] = res2
+}


### PR DESCRIPTION
This is an attempt to fix some issues and make some small improvements in the type variable solver. It's not complete, but I'm pushing to get feedback and so that I can run a community build against it.

The main change is that I've added a more sophisticated test for the currently-being-solved `TypeVar` being used in the bounds of another type variable, allowing more information to be propagated. This also fixes a bug where the test `` case TypeRef(_, `tparam`, _) `` allows a fully applied type to be added to the bounds of a higher kinded type resulting in a blow up in glb/lub.

I've left various open issues in comments ... these should be pursued if this is followed up on.

Nb. the test cases compile in Dotty, so this is a move in the right direction.