### PR TITLE
Improve error on absent import selector

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2276,16 +2276,18 @@ self =>
         newLineOptWhenFollowedBy(LPAREN)
       }
       if (ofCaseClass) {
+        def name = {
+          val s = owner.decodedName.toString
+          if (s != nme.ERROR.decodedName.toString) s else "C"
+        }
+        def elliptical = vds.map(_ => "(...)").mkString
         if (vds.isEmpty)
-          syntaxError(start, s"case classes must have a parameter list; try 'case class ${owner.encoded
-                                         }()' or 'case object ${owner.encoded}'")
+          syntaxError(start, s"case classes must have a parameter list; try 'case class $name()' or 'case object $name'")
         else if (vds.head.nonEmpty && vds.head.head.mods.isImplicit) {
           if (settings.isScala213)
-            syntaxError(start, s"case classes must have a non-implicit parameter list; try 'case class ${
-                                         owner.encoded}()${ vds.map(vs => "(...)").mkString }'")
+            syntaxError(start, s"case classes must have a non-implicit parameter list; try 'case class $name()$elliptical'")
           else {
-            deprecationWarning(start, s"case classes should have a non-implicit parameter list; adapting to 'case class ${
-                                         owner.encoded}()${ vds.map(vs => "(...)").mkString }'", "2.12.2")
+            deprecationWarning(start, s"case classes should have a non-implicit parameter list; adapting to 'case class $name()$elliptical'", "2.12.2")
             vds.insert(0, List.empty[ValDef])
             vds(1) = vds(1).map(vd => copyValDef(vd)(mods = vd.mods & ~Flags.CASEACCESSOR))
             if (implicitSection != -1) implicitSection += 1

--- a/test/files/neg/badimport.check
+++ b/test/files/neg/badimport.check
@@ -1,0 +1,4 @@
+badimport.scala:2: error: . expected
+import collection
+                 ^
+one error found

--- a/test/files/neg/badimport.scala
+++ b/test/files/neg/badimport.scala
@@ -1,0 +1,5 @@
+
+import collection
+import concurrent.Future
+
+trait T

--- a/test/files/neg/macro-deprecate-idents.check
+++ b/test/files/neg/macro-deprecate-idents.check
@@ -55,7 +55,7 @@ macro-deprecate-idents.scala:3: error: '=' expected but '}' found.
 macro-deprecate-idents.scala:7: error: '=' expected but '}' found.
 }
 ^
-macro-deprecate-idents.scala:42: error: '{' expected but ';' found.
+macro-deprecate-idents.scala:42: error: '{' expected.
 package foo {
 ^
 macro-deprecate-idents.scala:45: error: '{' expected but '}' found.

--- a/test/files/neg/t10097.check
+++ b/test/files/neg/t10097.check
@@ -7,4 +7,13 @@ case class D(implicit c: Int)(s: String)
 t10097.scala:4: error: an implicit parameter section must be last
 case class D(implicit c: Int)(s: String)
              ^
-three errors found
+t10097.scala:6: error: case classes must have a non-implicit parameter list; try 'case class *()(...)'
+case class *(implicit c: Int)
+            ^
+t10097.scala:9: error: identifier expected but 'import' found.
+import collection._
+^
+t10097.scala:9: error: case classes must have a parameter list; try 'case class C()' or 'case object C'
+import collection._
+                   ^
+6 errors found

--- a/test/files/neg/t10097.scala
+++ b/test/files/neg/t10097.scala
@@ -2,3 +2,8 @@
 case class C(implicit val c: Int)
 
 case class D(implicit c: Int)(s: String)
+
+case class *(implicit c: Int)
+
+case class
+import collection._

--- a/test/files/neg/t6810.check
+++ b/test/files/neg/t6810.check
@@ -16,13 +16,13 @@ t6810.scala:20: error: unclosed quoted identifier
 t6810.scala:21: error: unclosed quoted identifier
 ` = EOL               // not raw string literals aka triple-quoted, multiline strings
 ^
-t6810.scala:24: error: unclosed character literal
+t6810.scala:26: error: unclosed character literal
   val b = '
           ^
-t6810.scala:25: error: unclosed character literal
+t6810.scala:27: error: unclosed character literal
 '        // CR seen as EOL by scanner
 ^
-t6810.scala:24: error: '=' expected but ';' found.
-  val b = '
+t6810.scala:25: error: '=' expected.
+  val a = '\u000D'    // similar treatment of CR
 ^
 9 errors found

--- a/test/files/neg/t6810.scala
+++ b/test/files/neg/t6810.scala
@@ -20,6 +20,8 @@ trait t6810 {
   val `
 ` = EOL               // not raw string literals aka triple-quoted, multiline strings
 
+  val firebreak = 42  // help parser recovery, could also use rbrace
+
   val a = '\u000D'    // similar treatment of CR
   val b = ''        // CR seen as EOL by scanner
   val c = '\r'        // traditionally


### PR DESCRIPTION
It's easy to provide extra guidance to newbies on missing dot.

Also, when reporting on newline as statement separator, indicate that it is an inferred semi.

Fixes scala/bug#10550