### PR TITLE
Default getter is never assignment

### DIFF
--- a/test/files/neg/names-defaults-neg.scala
+++ b/test/files/neg/names-defaults-neg.scala
@@ -186,3 +186,21 @@ object t3685 {
   class u20 { val x: Int = u.f(x = "32") }
   class u21 { var x: Int = u.f(x = "32") }
 }
+
+trait t10336 {
+  case class C(a: Int = 10, b: String = "20")
+
+  class X {
+    def c(c: C): (Int, String) = (c.a, c.b)
+    def f() = {
+      val (x, y) = c(C(b = "30"))
+      val a = y.toInt
+      ()
+    }
+    def g() = {
+      val (x, y) = c(C(10, "20").copy(b = "30"))
+      val a = y.toInt
+      ()
+    }
+  }
+}


### PR DESCRIPTION
Don't check whether supplied `f(x = default$getter)`
is an assignment to `x`.

Fixes scala/bug#10336