### PR TITLE
Allow monotonic group annotations in Scaladoc

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -237,7 +237,7 @@ trait EntityPage extends HtmlPage {
             <span class="filtertype">Ordering</span>
             <ol>
               {
-                if (!universe.settings.docGroups.value || (tpl.members.map(_.group).distinct.length == 1))
+                if (!universe.settings.docGroups.value || tpl.members.map(_.group).distinct.forall(_ == ModelFactory.defaultGroup))
                   NodeSeq.Empty
                 else
                   <li class="group out"><span>Grouped</span></li>

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -30,12 +30,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
   import global._
   import definitions.{ ObjectClass, NothingClass, AnyClass, AnyValClass, AnyRefClass }
   import rootMirror.{ RootPackage, EmptyPackage }
-
-  // Defaults for member grouping, that may be overridden by the template
-  val defaultGroup = "Ungrouped"
-  val defaultGroupName = "Ungrouped"
-  val defaultGroupDesc = None
-  val defaultGroupPriority = 1000
+  import ModelFactory._
 
   def templatesCount = docTemplatesCache.count(_._2.isDocTemplate) - droppedPackages.size
 
@@ -1028,4 +1023,11 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     (bSym.isAliasType || bSym.isAbstractType) &&
     { val rawComment = global.expandedDocComment(bSym, inTpl.sym)
       rawComment.contains("@template") || rawComment.contains("@documentable") }
+}
+object ModelFactory {
+  // Defaults for member grouping, that may be overridden by the template
+  val defaultGroup = "Ungrouped"
+  val defaultGroupName = "Ungrouped"
+  val defaultGroupDesc = None
+  val defaultGroupPriority = 1000
 }


### PR DESCRIPTION
In the special case that every member of a package used the same group
annotation, Scaladoc would ignore the group. This was due to filtering
that checked the number of extant groups (including the default
"Ungrouped" group), skipping groups if only one group was found.
Unfortunately, the "Ungrouped" group could be missing if all templates
used the same group!

Fix this by filtering out the "Ungrouped" group entirely, and checking
for the existence of any other groups. Make the solution a bit less
fragile by referencing the default group constant defined in
ModelFactory, rather than the default group's string directly.

Fixes scala/bug#10078