### PR TITLE
Disentangle implicit-selection logic from specificity rules and make …

### DIFF
--- a/spec/07-implicits.md
+++ b/spec/07-implicits.md
@@ -90,11 +90,21 @@ The _parts_ of a type $T$ are:
 Note that packages are internally represented as classes with companion modules to hold the package members.
 Thus, implicits defined in a package object are part of the implicit scope of a type prefixed by that package.
 
-If there are several eligible arguments which match the implicit
-parameter's type, a most specific one will be chosen using the rules
-of static [overloading resolution](06-expressions.html#overloading-resolution).
-If the parameter has a default argument and no implicit argument can
-be found the default argument is used.
+If there are several eligible definitions which match an implicit parameters type, a most specific one will be
+chosen using the rules of static [overloading resolution](06-expressions.html#overloading-resolution) modified to
+accommodate the fact if any of these definitions themselves have implicit parameters then those parameters must be
+resolved during the application of the overloading rules.
+
+The relative ordering of a pair of candidate implicits is computed as follows,
+
+1. The candidates are compared by their result type, the most specific by normal overload rules being selected.
+2. If (1) is a tie then we compare the lengths of the implicit argument lists of the candidates (if any). The
+   candidate with the longest argument list wins.
+3. If (2) is a tie then we have a pair of candidates with implicit argument lists of equal length and which are both
+   equally specific wrt their result type/the expected type. We now apply the full normal overloading resolution
+   rules and choose the most specific according to those rules.
+
+If a parameter has a default argument and no implicit argument can be found the default argument is used.
 
 ###### Example
 Assuming the classes from the [`Monoid` example](#example-monoid), here is a

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -810,28 +810,41 @@ trait Infer extends Checkable {
     /** Is type `ftpe1` strictly more specific than type `ftpe2`
      *  when both are alternatives in an overloaded function?
      *  @see SLS (sec:overloading-resolution)
+     *
+     *  When adapting an explicit method call to an implicit argument list we don't take the implicit
+     *  argument list into account, if effect treating a method with an implicit argument list as if
+     *  the last component was a NullaryMethod ... see test/files/pos/t9943.scala for an example where
+     *  this makes a difference.
+     *
+     *  Rather than assuming this behavior for all methods with implicit arguments in all circumstances
+     *  we do so conditionally on nullaryImplicitArgs, which will only be true when we are adapting and
+     *  not where implicit arguments are explicitly supplied, or during implicit resolution. This makes
+     *  methods with implicit arguments behave more consistently when they are explicitly vs. implicitly
+     *  applied and also allows more intuitive implicit selection which aligns more closely with normal
+     *  overload resolution rules.
      */
-    def isAsSpecific(ftpe1: Type, ftpe2: Type): Boolean = {
+    def isAsSpecific(ftpe1: Type, ftpe2: Type, nullaryImplicitArgs: Boolean): Boolean = {
       def checkIsApplicable(argtpes: List[Type]) = isApplicable(Nil, ftpe2, argtpes, WildcardType)
       def bothAreVarargs                         = isVarArgsList(ftpe1.params) && isVarArgsList(ftpe2.params)
+      def nullaryImplicit(mt: MethodType): Boolean = mt.isImplicit && nullaryImplicitArgs
       def onRight = ftpe2 match {
-        case OverloadedType(pre, alts)                     => alts forall (alt => isAsSpecific(ftpe1, pre memberType alt))
-        case et: ExistentialType                           => et.withTypeVars(isAsSpecific(ftpe1, _))
-        case mt @ MethodType(_, restpe)                    => !mt.isImplicit || isAsSpecific(ftpe1, restpe)
-        case NullaryMethodType(res)                        => isAsSpecific(ftpe1, res)
-        case PolyType(tparams, NullaryMethodType(restpe))  => isAsSpecific(ftpe1, PolyType(tparams, restpe))
-        case PolyType(tparams, mt @ MethodType(_, restpe)) => !mt.isImplicit || isAsSpecific(ftpe1, PolyType(tparams, restpe))
+        case OverloadedType(pre, alts)                     => alts forall (alt => isAsSpecific(ftpe1, pre memberType alt, nullaryImplicitArgs))
+        case et: ExistentialType                           => et.withTypeVars(isAsSpecific(ftpe1, _, nullaryImplicitArgs))
+        case mt @ MethodType(_, restpe)                    => !nullaryImplicit(mt) || isAsSpecific(ftpe1, restpe, nullaryImplicitArgs)
+        case NullaryMethodType(res)                        => isAsSpecific(ftpe1, res, nullaryImplicitArgs)
+        case PolyType(tparams, NullaryMethodType(restpe))  => isAsSpecific(ftpe1, PolyType(tparams, restpe), nullaryImplicitArgs)
+        case PolyType(tparams, mt @ MethodType(_, restpe)) => !nullaryImplicit(mt) || isAsSpecific(ftpe1, PolyType(tparams, restpe), nullaryImplicitArgs)
         case _                                             => isAsSpecificValueType(ftpe1, ftpe2, Nil, Nil)
       }
       ftpe1 match {
-        case OverloadedType(pre, alts)                                      => alts exists (alt => isAsSpecific(pre memberType alt, ftpe2))
-        case et: ExistentialType                                            => isAsSpecific(et.skolemizeExistential, ftpe2)
-        case NullaryMethodType(restpe)                                      => isAsSpecific(restpe, ftpe2)
-        case mt @ MethodType(_, restpe) if mt.isImplicit                    => isAsSpecific(restpe, ftpe2)
+        case OverloadedType(pre, alts)                                      => alts exists (alt => isAsSpecific(pre memberType alt, ftpe2, nullaryImplicitArgs))
+        case et: ExistentialType                                            => isAsSpecific(et.skolemizeExistential, ftpe2, nullaryImplicitArgs)
+        case NullaryMethodType(restpe)                                      => isAsSpecific(restpe, ftpe2, nullaryImplicitArgs)
+        case mt @ MethodType(_, restpe) if nullaryImplicit(mt)              => isAsSpecific(restpe, ftpe2, nullaryImplicitArgs)
         case mt @ MethodType(_, _) if bothAreVarargs                        => checkIsApplicable(mt.paramTypes mapConserve repeatedToSingle)
         case mt @ MethodType(params, _) if params.nonEmpty                  => checkIsApplicable(mt.paramTypes)
-        case PolyType(tparams, NullaryMethodType(restpe))                   => isAsSpecific(PolyType(tparams, restpe), ftpe2)
-        case PolyType(tparams, mt @ MethodType(_, restpe)) if mt.isImplicit => isAsSpecific(PolyType(tparams, restpe), ftpe2)
+        case PolyType(tparams, NullaryMethodType(restpe))                   => isAsSpecific(PolyType(tparams, restpe), ftpe2, nullaryImplicitArgs)
+        case PolyType(tparams, mt @ MethodType(_, restpe)) if nullaryImplicit(mt) => isAsSpecific(PolyType(tparams, restpe), ftpe2, nullaryImplicitArgs)
         case PolyType(_, mt @ MethodType(params, _)) if params.nonEmpty     => checkIsApplicable(mt.paramTypes)
         case ErrorType                                                      => true
         case _                                                              => onRight
@@ -866,12 +879,12 @@ trait Infer extends Checkable {
       || isProperSubClassOrObject(sym1.safeOwner, sym2.owner)
     )
 
-    def isStrictlyMoreSpecific(ftpe1: Type, ftpe2: Type, sym1: Symbol, sym2: Symbol): Boolean = {
+    def isStrictlyMoreSpecific(ftpe1: Type, ftpe2: Type, sym1: Symbol, sym2: Symbol, nullaryImplicitArgs: Boolean): Boolean = {
       // ftpe1 / ftpe2 are OverloadedTypes (possibly with one single alternative) if they
       // denote the type of an "apply" member method (see "followApply")
       ftpe1.isError || {
-        val specificCount = (if (isAsSpecific(ftpe1, ftpe2)) 1 else 0) -
-                            (if (isAsSpecific(ftpe2, ftpe1) &&
+        val specificCount = (if (isAsSpecific(ftpe1, ftpe2, nullaryImplicitArgs)) 1 else 0) -
+                            (if (isAsSpecific(ftpe2, ftpe1, nullaryImplicitArgs) &&
                                  // todo: move to isAsSpecific test
 //                                 (!ftpe2.isInstanceOf[OverloadedType] || ftpe1.isInstanceOf[OverloadedType]) &&
                                  (!phase.erasedTypes || covariantReturnOverride(ftpe1, ftpe2))) 1 else 0)
@@ -1297,7 +1310,7 @@ trait Infer extends Checkable {
 
             (    (tp2 eq ErrorType)
               || isWeaklyCompatible(tp1, pt) && !isWeaklyCompatible(tp2, pt)
-              || isStrictlyMoreSpecific(tp1, tp2, sym1, sym2)
+              || isStrictlyMoreSpecific(tp1, tp2, sym1, sym2, nullaryImplicitArgs = true)
             )
           }
           // todo: missing test case for bests.isEmpty
@@ -1408,7 +1421,7 @@ trait Infer extends Checkable {
         private def followType(sym: Symbol) = followApply(pre memberType sym)
         // separate method to help the inliner
         private def isAltApplicable(pt: Type)(alt: Symbol) = context inSilentMode { isApplicable(undetparams, followType(alt), argtpes, pt) && !context.reporter.hasErrors }
-        private def rankAlternatives(sym1: Symbol, sym2: Symbol) = isStrictlyMoreSpecific(followType(sym1), followType(sym2), sym1, sym2)
+        private def rankAlternatives(sym1: Symbol, sym2: Symbol) = isStrictlyMoreSpecific(followType(sym1), followType(sym2), sym1, sym2, nullaryImplicitArgs = false)
         private def bestForExpectedType(pt: Type, isLastTry: Boolean): Unit = {
           val applicable  = overloadsToConsiderBySpecificity(alts filter isAltApplicable(pt), argtpes, varargsStar)
           val ranked      = bestAlternatives(applicable)(rankAlternatives)

--- a/test/files/neg/t7289_status_quo.check
+++ b/test/files/neg/t7289_status_quo.check
@@ -4,19 +4,13 @@ t7289_status_quo.scala:9: error: could not find implicit value for parameter e: 
 t7289_status_quo.scala:11: error: could not find implicit value for parameter e: Test1.Ext[List[List[List[Int]]]]
   implicitly[Ext[List[List[List[Int]]]]]        // fails - not found
             ^
-t7289_status_quo.scala:15: error: ambiguous implicit values:
- both method f in object Test1 of type [A, Coll <: CC[A], CC[X] <: Traversable[X]](implicit xi: Test1.Ext[A])Test1.Ext[Coll]
- and value m in object Test1 of type => Test1.Ext[List[List[Int]]]
- match expected type Test1.Ext[_ <: List[List[Int]]]
-  implicitly[Ext[_ <: List[List[Int]]]]         // fails - ambiguous
-            ^
-t7289_status_quo.scala:20: error: could not find implicit value for parameter e: Test1.ExtCov[List[Int]]
+t7289_status_quo.scala:23: error: could not find implicit value for parameter e: Test1.ExtCov[List[Int]]
   implicitly[ExtCov[List[Int]]]                 // fails - not found
             ^
-t7289_status_quo.scala:21: error: could not find implicit value for parameter e: Test1.ExtCov[List[List[Int]]]
+t7289_status_quo.scala:24: error: could not find implicit value for parameter e: Test1.ExtCov[List[List[Int]]]
   implicitly[ExtCov[List[List[Int]]]]           // fails - not found
             ^
-t7289_status_quo.scala:22: error: could not find implicit value for parameter e: Test1.ExtCov[List[List[List[Int]]]]
+t7289_status_quo.scala:25: error: could not find implicit value for parameter e: Test1.ExtCov[List[List[List[Int]]]]
   implicitly[ExtCov[List[List[List[Int]]]]]     // fails - not found
             ^
-6 errors found
+5 errors found

--- a/test/files/neg/t7289_status_quo.scala
+++ b/test/files/neg/t7289_status_quo.scala
@@ -12,7 +12,10 @@ object Test1 {
 
   // Making Ext[+T] should incur the same behavior as these. (so says @paulp)
   implicitly[Ext[_ <: List[Int]]]               // compiles
-  implicitly[Ext[_ <: List[List[Int]]]]         // fails - ambiguous
+  implicitly[Ext[_ <: List[List[Int]]]]         // compiles due to f and m having equally specific result types due
+                                                // to scala/bug#10545 but f now being selected over m because it has
+                                                // the longer implicit argument list. When the fix for 10545 is
+                                                // merged this should compile, selecting m.
   implicitly[Ext[_ <: List[List[List[Int]]]]]   // compiles
 
   // But, we currently get:

--- a/test/files/run/implicit-overload-1.scala
+++ b/test/files/run/implicit-overload-1.scala
@@ -1,0 +1,48 @@
+class Bar
+object Bar {
+  implicit val bar: Bar = new Bar
+}
+
+class Baz extends Bar
+
+object Foo {
+  def nullary: String = "foo0"
+  def nullary(implicit bar: Bar): Int = 23
+  def nullary(bar: Bar): Boolean = true
+
+  def unary(i: Int): String = "foo2"
+  def unary(i: Int)(implicit bar: Bar): Int = i
+
+  def unary1(bar: Bar): String = "foo4"
+  def unary1(baz: Baz): Int = 11
+  def unary1(bar: Bar)(implicit bar2: Bar): Boolean = true
+}
+
+object Test extends App {
+  val foo0: String = Foo.nullary
+  assert(foo0 == "foo0")
+
+  val foo1: Int = Foo.nullary
+  assert(foo1 == 23)
+
+  val foo2: String = Foo.unary(13)
+  assert(foo2 == "foo2")
+
+  val foo3: Int = Foo.unary(17)
+  assert(foo3 == 17)
+
+  val foo4: String = Foo.unary1(new Bar)
+  assert(foo4 == "foo4")
+
+  val foo5: String = Foo.unary1(new Baz)
+  assert(foo5 == "foo4")
+
+  val foo6: Boolean = Foo.unary1(new Baz)
+  assert(foo6)
+
+  val foo7: Int = Foo.nullary(new Bar)
+  assert(foo7 == 23)
+
+  val foo8: Boolean = Foo.nullary(new Bar)
+  assert(foo8)
+}

--- a/test/files/run/implicit-overload-2.scala
+++ b/test/files/run/implicit-overload-2.scala
@@ -1,0 +1,24 @@
+class Show[T](val i: Int)
+object Show extends Show0 {
+  def apply[T](implicit st: Show[T]): Int = st.i
+
+  implicit val showInt: Show[Int] = new Show[Int](0)
+}
+
+trait Show0 {
+  // if the fix for scala/bug#10545 was merged this could be moved up
+  // to object Show and would be beaten by Show[Int] due to specificity
+  implicit def fallback[T]: Show[T] = new Show[T](1)
+}
+
+class Generic
+object Generic {
+  implicit val gen: Generic = new Generic
+  implicit def showGen[T](implicit gen: Generic): Show[T] = new Show[T](2)
+}
+
+object Test extends App {
+  assert(Show[Int] == 0)
+  assert(Show[String] == 1)
+  assert(Show[Generic] == 2) // showGen beats fallback due to longer argument list
+}

--- a/test/files/run/implicit-overload-3.scala
+++ b/test/files/run/implicit-overload-3.scala
@@ -1,0 +1,36 @@
+class Low
+object Low {
+  implicit val low: Low = new Low
+}
+class Medium extends Low
+object Medium {
+  implicit val medium: Medium = new Medium
+}
+class High extends Medium
+object High {
+  implicit val high: High = new High
+}
+
+class Foo[T](val i: Int)
+object Foo {
+  def apply[T](implicit fooT: Foo[T]): Int = fooT.i
+
+  implicit def foo[T](implicit priority: Low): Foo[T] = new Foo[T](0)
+  implicit def foobar[T](implicit priority: Low): Foo[Bar[T]] = new Foo[Bar[T]](1)
+  implicit def foobarbaz(implicit priority: Low): Foo[Bar[Baz]] = new Foo[Bar[Baz]](2)
+}
+class Bar[T]
+object Bar {
+  implicit def foobar[T](implicit priority: Medium): Foo[Bar[T]] = new Foo[Bar[T]](3)
+  implicit def foobarbaz(implicit priority: Medium): Foo[Bar[Baz]] = new Foo[Bar[Baz]](4)
+}
+class Baz
+object Baz {
+  implicit def baz(implicit priority: High): Foo[Bar[Baz]] = new Foo[Bar[Baz]](5)
+}
+
+object Test extends App {
+  assert(Foo[Int] == 0)
+  assert(Foo[Bar[Int]] == 3)
+  assert(Foo[Bar[Baz]] == 5)
+}

--- a/test/files/run/implicit-overload-4.scala
+++ b/test/files/run/implicit-overload-4.scala
@@ -1,0 +1,22 @@
+class Show[T](val i: Int)
+object Show {
+  def apply[T](implicit st: Show[T]): Int = st.i
+
+  implicit val showInt: Show[Int] = new Show[Int](0)
+  // Now that the fix for scala/bug#10545 has been merged the fallback
+  // instance can live at this level and is beaten by Show[Int] due to
+  // specificity
+  implicit def fallback[T]: Show[T] = new Show[T](1)
+}
+
+class Generic
+object Generic {
+  implicit val gen: Generic = new Generic
+  implicit def showGen[T](implicit gen: Generic): Show[T] = new Show[T](2)
+}
+
+object Test extends App {
+  assert(Show[Int] == 0)
+  assert(Show[String] == 1)
+  assert(Show[Generic] == 2) // showGen beats fallback due to longer argument list
+}

--- a/test/files/run/t10526.scala
+++ b/test/files/run/t10526.scala
@@ -1,0 +1,9 @@
+object Test extends App {
+  class Foo
+  class Bar extends Foo
+
+  def overload(implicit foo: Foo): Int = 0
+  def overload(implicit bar: Bar): Int = 1
+
+  assert(overload(new Bar) == 1)
+}

--- a/test/junit/scala/reflect/internal/Infer.scala
+++ b/test/junit/scala/reflect/internal/Infer.scala
@@ -55,8 +55,12 @@ class InferTest extends BytecodeTesting {
       val foo1Tpe = foo1Sym.info
 
       // isStrictlyMoreSpecific uses existentialAbstraction
-      assert(!isStrictlyMoreSpecific(foo0Tpe, foo1Tpe, foo0Sym, foo1Sym))
-      assert(isStrictlyMoreSpecific(foo1Tpe, foo0Tpe, foo1Sym, foo0Sym))
+      assert(!isStrictlyMoreSpecific(foo0Tpe, foo1Tpe, foo0Sym, foo1Sym, nullaryImplicitArgs = false))
+      assert(isStrictlyMoreSpecific(foo1Tpe, foo0Tpe, foo1Sym, foo0Sym, nullaryImplicitArgs = false))
+
+      // isStrictlyMoreSpecific uses existentialAbstraction
+      assert(!isStrictlyMoreSpecific(foo0Tpe, foo1Tpe, foo0Sym, foo1Sym, nullaryImplicitArgs = true))
+      assert(isStrictlyMoreSpecific(foo1Tpe, foo0Tpe, foo1Sym, foo0Sym, nullaryImplicitArgs = true))
     }
   }
 }


### PR DESCRIPTION
…implicit selection more consistent with normal overload resolution.

This is an attempt to make implicit selection rules align more closely with people's intuitions and the spec's aspirations that it be consistent with normal overload resolution rules. It also fixes https://github.com/scala/bug/issues/10526.

Candidate implicits are ordered via `Infer#isStrictlyMoreSpecific` which delegates to `Infer#isAsSpecific`. Prior to this PR the latter treats all methods with an implicit argument list as if they were nullary methods, leading to https://github.com/scala/bug/issues/10526 ... I believe that the motivation for this behaviour was to allow methods which are intended to appear to users to be nullary to have implicit arguments without affecting their overload resolution behaviour wrt same-named methods which are _actually_ nullary. Whilst this does the right thing in some circumstances, it leads to oddities such as https://github.com/scala/bug/issues/10526 and also means that the specificity test used to order and select implicits is very crude, in effect _only_ considering the result type of an implicit method, not its implicit arguments.

This PR addresses these issues by making the "treat implicit methods as nullary" logic explicitly flagged and enabling it only at the relevant call site in `Inferencer#inferExprAlternative`. Normal overloading rules are unchanged, and the implicit selection logic is extracted out to `ImplicitSearch#Improves`. There the relative ordering of a pair of candidate implicits is computed as follows,
1. The candidates are compared by their result type, the most specific by normal overload rules being selected (this is consistent with the behaviour prior to this PR).
2. If (1) is a tie then we compare the lengths of the implicit argument lists of the candidates (if any). The candidate with the longest argument list wins (this matches users intuitions that methods with more implicit arguments are "more demanding" hence more specific).
3. If (2) is a tie then we have a pair of candidates with implicit argument lists of equal length and which are both equally specific wrt their result type/the expected type. We now apply the full normal overloading resolution rules and choose the most specific.

This change makes combining implicits from multiple implicit scopes a great deal more straightforward, since we can now rely on more than just the result type of the implicit definition to guide implicit selection. After this PR the following works as expected,
```scala
class Show[T](val i: Int)
object Show {
  def apply[T](implicit st: Show[T]): Int = st.i

  implicit val showInt: Show[Int] = new Show[Int](0)
  implicit def fallback[T]: Show[T] = new Show[T](1)
}

class Generic
object Generic {
  implicit val gen: Generic = new Generic
  implicit def showGen[T](implicit gen: Generic): Show[T] = new Show[T](2)
}

object Test extends App {
  assert(Show[Int] == 0)
  assert(Show[String] == 1)
  assert(Show[Generic] == 2) // showGen beats fallback due to longer argument list
}
```
Thanks to the use of normal overload resolution rules we also have the ability to use a "phantom" implicit parameter with arguments ordered by subtyping to explicitly prioritize implicit definitions, something for which language extensions of one form or another have occasionally been proposed,
```scala
class Low
object Low {
  implicit val low: Low = new Low
}
class Medium extends Low
object Medium {
  implicit val medium: Medium = new Medium
}
class High extends Medium
object High {
  implicit val high: High = new High
}

class Foo[T](val i: Int)
object Foo {
  def apply[T](implicit fooT: Foo[T]): Int = fooT.i

  implicit def foo[T](implicit priority: Low): Foo[T] = new Foo[T](0)
  implicit def foobar[T](implicit priority: Low): Foo[Bar[T]] = new Foo[Bar[T]](1)
  implicit def foobarbaz(implicit priority: Low): Foo[Bar[Baz]] = new Foo[Bar[Baz]](2)
}
class Bar[T]
object Bar {
  implicit def foobar[T](implicit priority: Medium): Foo[Bar[T]] = new Foo[Bar[T]](3)
  implicit def foobarbaz(implicit priority: Medium): Foo[Bar[Baz]] = new Foo[Bar[Baz]](4)
}
class Baz
object Baz {
  implicit def baz(implicit priority: High): Foo[Bar[Baz]] = new Foo[Bar[Baz]](5)
}

object Test extends App {
  assert(Foo[Int] == 0)
  assert(Foo[Bar[Int]] == 3)
  assert(Foo[Bar[Baz]] == 5)
}
```
This PR changes the outcome of only one partest (`test/files/neg/t7289_status_quo.scala`) which is intended to exactly capture the current failure behaviour in a specific implicit resolution scenario ... I believe the new (successful) behaviour is an improvement on the old.

With that exception all (par)tests pass. One shapeless test fails to compile after this change but is trivially fixable. I'll schedule a community build when this goes green ...