### PR TITLE
When solving type variables propagate solutions to bounds of variables left undetermined

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -737,6 +737,7 @@ trait Implicits {
             // we must be conservative in leaving type params in undetparams
             // prototype == WildcardType: want to remove all inferred Nothings
             val AdjustedTypeArgs(okParams, okArgs) = adjustTypeArgs(undetParams, tvars, targs)
+            enhanceBounds(okParams, okArgs, undetParams)
 
             val subst: TreeTypeSubstituter =
               if (okParams.isEmpty) EmptyTreeTypeSubstituter

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -712,6 +712,17 @@ trait Infer extends Checkable {
         argtpes
     }
 
+    // This is primarily a duplicte of enhanceBounds in typedAppliedTypeTree
+    // modified to use updateInfo rather than setInfo to avoid wiping out 
+    // type history.
+    def enhanceBounds(okparams: List[Symbol], okargs: List[Type], undets: List[Symbol]): Unit =
+      undets.foreach { undet =>
+        val bounds = undet.info.bounds
+        val substBounds = bounds.subst(okparams, okargs)
+        if(bounds ne substBounds)
+          undet.updateInfo(substBounds)
+      }
+
     private def isApplicableToMethod(undetparams: List[Symbol], mt: MethodType, argtpes0: List[Type], pt: Type): Boolean = {
       val formals          = formalTypes(mt.paramTypes, argtpes0.length, removeByName = false)
       def missingArgs      = missingParams[Type](argtpes0, mt.params, x => Some(x) collect { case NamedType(n, _) => n })
@@ -728,6 +739,7 @@ trait Infer extends Checkable {
       def tryInstantiating(args: List[Type]) = falseIfNoInstance {
         val restpe = mt resultType args
         val AdjustedTypeArgs.Undets(okparams, okargs, leftUndet) = methTypeArgs(EmptyTree, undetparams, formals, restpe, args, pt)
+        enhanceBounds(okparams, okargs, leftUndet)
         val restpeInst = restpe.instantiateTypeParams(okparams, okargs)
         // #2665: must use weak conformance, not regular one (follow the monomorphic case above)
         exprTypeArgs(leftUndet, restpeInst, pt, useWeaklyCompatible = true) match {
@@ -936,11 +948,14 @@ trait Infer extends Checkable {
         List()
       } else {
         val AdjustedTypeArgs.Undets(okParams, okArgs, leftUndet) = adjustTypeArgs(tparams, tvars, targsStrict)
+        enhanceBounds(okParams, okArgs, leftUndet)
+
         def solved_s = map2(okParams, okArgs)((p, a) => s"$p=$a") mkString ","
         def undet_s = leftUndet match {
           case Nil => ""
           case ps  => ps.mkString(", undet=", ",", "")
         }
+
         printTyping(tree, s"infer solved $solved_s$undet_s")
         substExpr(tree, okParams, okArgs, pt)
         leftUndet
@@ -982,6 +997,7 @@ trait Infer extends Checkable {
 
           val AdjustedTypeArgs.AllArgsAndUndets(okparams, okargs, allargs, leftUndet) =
             methTypeArgs(fn, undetparams, formals, restpe, argtpes, pt)
+          enhanceBounds(okparams, okargs, leftUndet)
 
           if (checkBounds(fn, NoPrefix, NoSymbol, undetparams, allargs, "inferred ")) {
             val treeSubst = new TreeTypeSubstituter(okparams, okargs)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5188,6 +5188,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               val asym = arg.symbol
               def abounds = asym.info.bounds
               def tbounds = tparam.info.bounds
+              // TODO investigate whether this should be merged with the near duplicate in Inferencer
+              // and whether or not we should avoid using setInfo here as well to avoid potentially
+              // trampling on type history.
               def enhanceBounds(): Unit = {
                 val TypeBounds(lo0, hi0) = abounds
                 val TypeBounds(lo1, hi1) = tbounds.subst(tparams, argtypes)

--- a/test/files/pos/t10528.scala
+++ b/test/files/pos/t10528.scala
@@ -1,0 +1,35 @@
+object Test {
+  trait Holder[A]
+  trait NilHolder[A] extends Holder[A]
+
+  trait Solve[A, H <: Holder[A]] {
+    type Output <: Holder[A]
+  }
+  type SolveAux[A, H <: Holder[A], O <: Holder[A]] = Solve[A, H] {type Output = O}
+
+  implicit def nilSolve[A] = new Solve[A, NilHolder[A]] {
+    override type Output = NilHolder[A]
+  }
+
+  trait WrapSolve[A, H <: Holder[A]] {
+    type Output <: Holder[A]
+  }
+
+  implicit def wrapAux[A, H <: Holder[A], O <: Holder[A]](implicit one : SolveAux[A, H, O]) =
+    new WrapSolve[A, H] {
+      override type Output = O
+    }
+
+  val wrapped = implicitly[WrapSolve[String, NilHolder[String]]]
+}
+
+object Test2 {
+  class Inv[T]
+  class Foo[T, U <: Inv[T]]
+
+  implicit def foo[T]: Foo[T, Inv[T]] = new Foo[T, Inv[T]]
+
+  def bar[T, U <: Inv[T]](implicit foo: Foo[T, U]): Inv[T] = new Inv[T]
+
+  val baz: Inv[Int] = bar
+}


### PR DESCRIPTION
When instantiating type parameters and retracting unsolved ones via `adjustTypeArgs` and friends we end up with a list of solved type params/variables and a list of still-undetermined type parameters. Typically this is followed by a substitution of the solved variables into the positions of the corresponding parameters, and type checking proceeds with the substitutions eliminated from the list of undetermined type parameters. 

However, the substituted parameters might occur as components of the bounds of the type parameters which are yet to be determined and, prior to this PR, these occurrences are _not_ substituted into with the solved variables. This leads to issues of the form seen in https://github.com/scala/bug/issues/10528. This PR performs the substitution similarly to the way it is done in `enhanceBounds` in `typedAppliedTypeTree` and fixes https://github.com/scala/bug/issues/10528.

I didn't attempt to move this functionality into `AdjustedTypeArgs` where it probably belongs, because the way the latter is structured would mean that we'd be performing side effects in a pattern match, albeit an irrefutable one. I think some restructuring of this logic would be worthwhile. I think that it should also be possible now to reinstate a commented out call to `checkBounds` [here](https://github.com/milessabin/scala/blob/e7179bda5c0b0194e01f318eb303e72d38ad781b/src/compiler/scala/tools/nsc/typechecker/Infer.scala#L1053-L1055) with something similar, but I think that would also benefit from some reworking of `AdjustedTypeArgs`.

All (par)tests pass.