### PR TITLE
Emit serialVersionUID fields as private.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -864,14 +864,16 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
     val MIN_SWITCH_DENSITY = 0.7
 
     /*
-     *  Add public static final field serialVersionUID with value `id`
+     *  Add private static final field serialVersionUID with value `id`.
      *
      *  can-multi-thread
      */
     def addSerialVUID(id: Long, jclass: asm.ClassVisitor) {
       // add static serialVersionUID field if `clasz` annotated with `@SerialVersionUID(uid: Long)`
+      // private for ease of binary compatibility (docs for java.io.Serializable
+      // claim that the access modifier can be anything we want).
       jclass.visitField(
-        GenBCode.PublicStaticFinal,
+        GenBCode.PrivateStaticFinal,
         "serialVersionUID",
         "J",
         null, // no java-generic-signature

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -81,6 +81,7 @@ object GenBCode {
 
   final val PublicStatic = Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC
   final val PublicStaticFinal = Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL
+  final val PrivateStaticFinal = Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL
 
   val CLASS_CONSTRUCTOR_NAME = "<clinit>"
   val INSTANCE_CONSTRUCTOR_NAME = "<init>"

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1430,6 +1430,14 @@ abstract class RefChecks extends Transform {
           analyzer.ImplicitNotFoundMsg.check(sym) foreach messageWarning("implicitNotFound")
           analyzer.ImplicitAmbiguousMsg.check(sym) foreach messageWarning("implicitAmbiguous")
 
+          if (sym.isClass && sym.hasAnnotation(SerialVersionUIDAttr)) {
+            def warn(what: String) =
+              reporter.warning(tree.pos, s"@serialVersionUID has no effect on $what")
+
+            if (sym.isTrait) warn("traits")
+            else if (!sym.isSerializable) warn("non-serializable classes")
+          }
+
         case tpt@TypeTree() =>
           if (tpt.original != null) {
             tpt.original foreach {

--- a/src/library/scala/SerialVersionUID.scala
+++ b/src/library/scala/SerialVersionUID.scala
@@ -1,6 +1,6 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2002-2013, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2002-2017, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
@@ -9,7 +9,14 @@
 package scala
 
 /**
- * Annotation for specifying the `static SerialVersionUID` field
- * of a serializable class.
- */
+  * Annotation for specifying the `serialVersionUID` field of a (serializable) class.
+  *
+  * On the JVM, a class with this annotation will receive a `private`, `static`,
+  * and `final` field called `serialVersionUID` with the provided [[value]],
+  * which the JVM's serialization mechanism uses to determine serialization
+  * compatibility between different versions of a class.
+  *
+  * @see [[http://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html `java.io.Serializable`]]
+  * @see [[Serializable]]
+  */
 class SerialVersionUID(value: Long) extends scala.annotation.ClassfileAnnotation

--- a/test/files/neg/warn-useless-svuid.check
+++ b/test/files/neg/warn-useless-svuid.check
@@ -1,0 +1,18 @@
+warn-useless-svuid.scala:2: warning: @serialVersionUID has no effect on non-serializable classes
+class X
+      ^
+warn-useless-svuid.scala:5: warning: @serialVersionUID has no effect on non-serializable classes
+class Y extends X
+      ^
+warn-useless-svuid.scala:17: warning: @serialVersionUID has no effect on traits
+trait T
+      ^
+warn-useless-svuid.scala:20: warning: @serialVersionUID has no effect on traits
+trait U extends scala.Serializable
+      ^
+warn-useless-svuid.scala:23: warning: @serialVersionUID has no effect on traits
+trait V extends java.io.Serializable
+      ^
+error: No warnings can be incurred under -Xfatal-warnings.
+5 warnings found
+one error found

--- a/test/files/neg/warn-useless-svuid.flags
+++ b/test/files/neg/warn-useless-svuid.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/warn-useless-svuid.scala
+++ b/test/files/neg/warn-useless-svuid.scala
@@ -1,0 +1,23 @@
+@SerialVersionUID(1L)
+class X
+
+@SerialVersionUID(1L)
+class Y extends X
+
+@SerialVersionUID(1L)
+class Z extends scala.Serializable
+
+@SerialVersionUID(1L)
+class W extends java.io.Serializable
+
+@SerialVersionUID(1L)
+class Q extends Z
+
+@SerialVersionUID(1L)
+trait T
+
+@SerialVersionUID(1L)
+trait U extends scala.Serializable
+
+@SerialVersionUID(1L)
+trait V extends java.io.Serializable

--- a/test/files/run/t8549b.scala
+++ b/test/files/run/t8549b.scala
@@ -1,15 +1,19 @@
+import java.lang.reflect.Modifier._
 
 @SerialVersionUID(42)
-class C
+class C extends Serializable
 
 @SerialVersionUID(43 - 1)
-class D
+class D extends Serializable
 
 
 object Test extends App {
   def checkId(cls: Class[_]) {
-    val id = cls.getDeclaredField("serialVersionUID").get(null)
-    assert(id == 42, (cls, id))  
+    val field = cls.getDeclaredField("serialVersionUID")
+    assert(isPrivate(field.getModifiers))
+    field.setAccessible(true)
+    val id = field.get(null)
+    assert(id == 42, (cls, id))
   }
   checkId(classOf[C])
   checkId(classOf[D])

--- a/test/files/run/t8960.scala
+++ b/test/files/run/t8960.scala
@@ -8,6 +8,7 @@ object Test extends App {
       o.getClass.getName)
 
     val Some(f) = o.getClass.getDeclaredFields.find(_.getName == "serialVersionUID")
+    f.setAccessible(true)
     assert(f.getLong(null) == 0l)
   }
 


### PR DESCRIPTION
The JVM serialization code doesn't care either way, and leaving them as public leads to annoying (but mostly harmless) MiMa errors if the annotation is added. Since the generated field is synthetic, it can only be referenced from Java, so privatizing it is unlikely to break anyone's use of it, or so I'd hope.

See scala/scala#6101 and scala/scala#6138 for examples of places where this has caused troubles before.

Also, because the diff was too small otherwise, have a warning for putting the annotation where it cannot possibly do any good. No one asked for it but me, but maybe it'll save someone's skin, at some time in the future.