### PR TITLE
Use Scala 2.12.4 as the reference compiler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,7 @@ lazy val publishSettings : Seq[Setting[_]] = Seq(
 // should not be set directly. It is the same as the Maven version and derived automatically from `baseVersion` and
 // `baseVersionSuffix`.
 globalVersionSettings
-baseVersion in Global := "2.12.4"
+baseVersion in Global := "2.12.5"
 baseVersionSuffix in Global := "SNAPSHOT"
 mimaReferenceVersion in Global := Some("2.12.0")
 

--- a/versions.properties
+++ b/versions.properties
@@ -1,5 +1,5 @@
 # Scala version used for bootstrapping (see README.md)
-starr.version=2.12.3
+starr.version=2.12.4
 
 # The scala.binary.version determines how modules are resolved. It is set as follows:
 #  - After 2.x.0 is released, the binary version is 2.x


### PR DESCRIPTION
... and bump the current version to 2.12.5-SNAPSHOT