### PR TITLE
optimise GenBCode flag generation

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -569,12 +569,12 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
 
       val isNative         = methSymbol.hasAnnotation(definitions.NativeAttr)
       val isAbstractMethod = rhs == EmptyTree
-      val flags = GenBCode.mkFlags(
-        javaFlags(methSymbol),
-        if (isAbstractMethod)        asm.Opcodes.ACC_ABSTRACT   else 0,
-        if (methSymbol.isStrictFP)   asm.Opcodes.ACC_STRICT     else 0,
-        if (isNative)                asm.Opcodes.ACC_NATIVE     else 0  // native methods of objects are generated in mirror classes
-      )
+      val flags =
+        javaFlags(methSymbol) |
+        (if (isAbstractMethod)        asm.Opcodes.ACC_ABSTRACT   else 0) |
+        (if (methSymbol.isStrictFP)   asm.Opcodes.ACC_STRICT     else 0) |
+        (if (isNative)                asm.Opcodes.ACC_NATIVE     else 0)  // native methods of objects are generated in mirror classes
+
 
       initJMethod(flags, params.map(_.symbol))
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -695,10 +695,9 @@ abstract class BTypes {
           internalName,
           outerName.orNull,
           innerName.orNull,
-          GenBCode.mkFlags(
-            // the static flag in the InnerClass table has a special meaning, see InnerClass comment
-            i.flags & ~Opcodes.ACC_STATIC,
-            if (isStaticNestedClass) Opcodes.ACC_STATIC else 0
+          // the static flag in the InnerClass table has a special meaning, see InnerClass comment
+          ( i.flags & ~Opcodes.ACC_STATIC |
+              (if (isStaticNestedClass) Opcodes.ACC_STATIC else 0)
           ) & BCodeHelpers.INNER_CLASSES_FLAGS
         )
     })

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -288,19 +288,17 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
         val hasAbstractMethod = classSym.info.decls.exists(s => s.isMethod && s.isDeferred)
         if (hasAbstractMethod) ACC_ABSTRACT else 0
       }
-      GenBCode.mkFlags(
         // scala/bug#9393: the classfile / java source parser make java annotation symbols look like classes.
         // here we recover the actual classfile flags.
-        if (classSym.hasJavaAnnotationFlag)                        ACC_ANNOTATION | ACC_INTERFACE | ACC_ABSTRACT else 0,
-        if (classSym.isPublic)                                     ACC_PUBLIC    else 0,
-        if (classSym.isFinal)                                      ACC_FINAL     else 0,
-        // see the link above. javac does the same: ACC_SUPER for all classes, but not interfaces.
-        if (classSym.isInterface)                                  ACC_INTERFACE else ACC_SUPER,
-        // for Java enums, we cannot trust `hasAbstractFlag` (see comment in enumFlags)
-        if (!classSym.hasJavaEnumFlag && classSym.hasAbstractFlag) ACC_ABSTRACT  else 0,
-        if (classSym.isArtifact)                                   ACC_SYNTHETIC else 0,
-        if (classSym.hasJavaEnumFlag)                              enumFlags     else 0
-      )
+        ( if (classSym.hasJavaAnnotationFlag)                        ACC_ANNOTATION | ACC_INTERFACE | ACC_ABSTRACT else 0) |
+      ( if (classSym.isPublic)                                     ACC_PUBLIC    else 0) |
+      ( if (classSym.isFinal)                                      ACC_FINAL     else 0) |
+       // see the link above. javac does the same: ACC_SUPER for all classes, but not interfaces.)
+      ( if (classSym.isInterface)                                  ACC_INTERFACE else ACC_SUPER) |
+       // for Java enums, we cannot trust `hasAbstractFlag` (see comment in enumFlags))
+      ( if (!classSym.hasJavaEnumFlag && classSym.hasAbstractFlag) ACC_ABSTRACT  else 0) |
+      ( if (classSym.isArtifact)                                   ACC_SYNTHETIC else 0) |
+      ( if (classSym.hasJavaEnumFlag)                              enumFlags     else 0)
     }
 
     // Check for hasAnnotationFlag for scala/bug#9393: the classfile / java source parsers add
@@ -731,27 +729,24 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
     // illegal combination of modifiers at the bytecode level so
     // suppress final if abstract is present.
     import asm.Opcodes._
-    GenBCode.mkFlags(
-      if (privateFlag) ACC_PRIVATE else ACC_PUBLIC,
-      if ((sym.isDeferred && !sym.hasFlag(symtab.Flags.JAVA_DEFAULTMETHOD))|| sym.hasAbstractFlag) ACC_ABSTRACT else 0,
-      if (sym.isTraitOrInterface) ACC_INTERFACE else 0,
-      if (finalFlag && !sym.hasAbstractFlag) ACC_FINAL else 0,
-      if (sym.isStaticMember) ACC_STATIC else 0,
-      if (sym.isBridge) ACC_BRIDGE | ACC_SYNTHETIC else 0,
-      if (sym.isArtifact) ACC_SYNTHETIC else 0,
-      if (sym.isClass && !sym.isTraitOrInterface) ACC_SUPER else 0,
-      if (sym.hasJavaEnumFlag) ACC_ENUM else 0,
-      if (sym.isVarargsMethod) ACC_VARARGS else 0,
-      if (sym.hasFlag(symtab.Flags.SYNCHRONIZED)) ACC_SYNCHRONIZED else 0,
-      if (sym.isDeprecated) asm.Opcodes.ACC_DEPRECATED else 0
-    )
+      ( if (privateFlag) ACC_PRIVATE else ACC_PUBLIC) |
+        ( if ((sym.isDeferred && !sym.hasFlag(symtab.Flags.JAVA_DEFAULTMETHOD))|| sym.hasAbstractFlag) ACC_ABSTRACT else 0) |
+        ( if (sym.isTraitOrInterface) ACC_INTERFACE else 0) |
+        ( if (finalFlag && !sym.hasAbstractFlag) ACC_FINAL else 0) |
+        ( if (sym.isStaticMember) ACC_STATIC else 0) |
+        ( if (sym.isBridge) ACC_BRIDGE | ACC_SYNTHETIC else 0) |
+        ( if (sym.isArtifact) ACC_SYNTHETIC else 0) |
+        ( if (sym.isClass && !sym.isTraitOrInterface) ACC_SUPER else 0) |
+        ( if (sym.hasJavaEnumFlag) ACC_ENUM else 0) |
+        ( if (sym.isVarargsMethod) ACC_VARARGS else 0) |
+        ( if (sym.hasFlag(symtab.Flags.SYNCHRONIZED)) ACC_SYNCHRONIZED else 0) |
+        ( if (sym.isDeprecated) asm.Opcodes.ACC_DEPRECATED else 0)
   }
 
   def javaFieldFlags(sym: Symbol) = {
-    javaFlags(sym) | GenBCode.mkFlags(
-      if (sym hasAnnotation TransientAttr) asm.Opcodes.ACC_TRANSIENT else 0,
-      if (sym hasAnnotation VolatileAttr)  asm.Opcodes.ACC_VOLATILE  else 0,
-      if (sym.isMutable) 0 else asm.Opcodes.ACC_FINAL
-    )
+    javaFlags(sym) |
+      ( if (sym hasAnnotation TransientAttr) asm.Opcodes.ACC_TRANSIENT else 0) |
+      ( if (sym hasAnnotation VolatileAttr)  asm.Opcodes.ACC_VOLATILE  else 0) |
+      ( if (sym.isMutable) 0 else asm.Opcodes.ACC_FINAL)
   }
 }

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -77,8 +77,6 @@ abstract class GenBCode extends SubComponent {
 }
 
 object GenBCode {
-  def mkFlags(args: Int*) = args.foldLeft(0)(_ | _)
-
   final val PublicStatic = Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC
   final val PublicStaticFinal = Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -69,10 +69,10 @@ abstract class BackendUtils extends PerRunInit {
 
   lazy val emitStackMapFrame: LazyVar[Boolean] = perRunLazy(this)(majorVersion.get >= 50)
 
-  lazy val extraProc: LazyVar[Int] = perRunLazy(this)(GenBCode.mkFlags(
-    asm.ClassWriter.COMPUTE_MAXS,
-    if (emitStackMapFrame.get) asm.ClassWriter.COMPUTE_FRAMES else 0
-  ))
+  lazy val extraProc: LazyVar[Int] = perRunLazy(this)(
+    asm.ClassWriter.COMPUTE_MAXS |
+      (if (emitStackMapFrame.get) asm.ClassWriter.COMPUTE_FRAMES else 0)
+  )
 
   /**
    * A wrapper to make ASM's Analyzer a bit easier to use.


### PR DESCRIPTION
GenBCode.mkFlags is not an efficient way to OR explicit Ints

Not sure if the correct fix is this, or to replace GenBCode.mkFlags with a macro, both would yield the same results, efficient OR.

existing implementation is vararg based so generates an array, ArrayWrapper, and performs a foldLeft with a lambda 

Modest but simple gains in reduced CPU and allocation

timings for 50 cycles JVM phase after 10 warmup, removing top 10%, no GC
```
                  RunName	                AllWallMS	                   CPU_MS	                Allocated
      00_backend-baseline	  28	 4,695.13 [-5.42% +5.85%]	 4,488.84 [-5.67% +6.17%]	   388.84 [-0.06% +0.12%]
               00_mkFlags	  32	 4,521.65 [-4.65% +9.38%]	 4,344.24 [-3.97% +7.90%]	   377.68 [-0.24% +0.08%]

```