### PR TITLE
Support Java 9 bytecode by adding "-target:jvm-1.9"

### DIFF
--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -106,7 +106,7 @@ object ScalaOptionParser {
     "-Ymacro-expand" -> List("discard", "none"),
     "-Yresolve-term-conflict" -> List("error", "object", "package"),
     "-g" -> List("line", "none", "notailcails", "source", "vars"),
-    "-target" -> List("jvm-1.5", "jvm-1.6", "jvm-1.7", "jvm-1.8"))
+    "-target" -> List("jvm-1.5", "jvm-1.6", "jvm-1.7", "jvm-1.8", "jvm-9"))
   private def multiChoiceSettingNames = Map[String, List[String]](
     "-Xlint" -> List("adapted-args", "nullary-unit", "inaccessible", "nullary-override", "infer-any", "missing-interpolator", "doc-detached", "private-shadow", "type-parameter-shadow", "poly-implicit-overload", "option-implicit", "delayedinit-select", "by-name-right-associative", "package-object-classes", "unsound-match", "stars-align"),
     "-language" -> List("help", "_", "dynamics", "postfixOps", "reflectiveCalls", "implicitConversions", "higherKinds", "existentials", "experimental.macros"),

--- a/src/compiler/scala/tools/ant/Scalac.scala
+++ b/src/compiler/scala/tools/ant/Scalac.scala
@@ -95,7 +95,7 @@ class Scalac extends ScalaMatchingTask with ScalacShared {
 
   /** Defines valid values for the `target` property. */
   object Target extends PermissibleValue {
-    val values = List("jvm-1.5", "jvm-1.6", "jvm-1.7", "jvm-1.8")
+    val values = List("jvm-1.5", "jvm-1.6", "jvm-1.7", "jvm-1.8", "jvm-9")
   }
 
   /** Defines valid values for the `deprecation` and `unchecked` properties. */

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1323,7 +1323,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
         currentRun.reporting.deprecationWarning(NoPosition, s.name + " is deprecated: " + s.deprecationMessage.get, "")
       }
       val supportedTarget = "jvm-1.8"
-      if (settings.target.value != supportedTarget) {
+      if (settings.target.value != supportedTarget && settings.target.value != "jvm-9") {
         currentRun.reporting.deprecationWarning(NoPosition, settings.target.name + ":" + settings.target.value + " is deprecated and has no effect, setting to " + supportedTarget, "2.12.0")
         settings.target.value = supportedTarget
       }

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -62,6 +62,7 @@ abstract class BackendUtils extends PerRunInit {
 
   lazy val classfileVersion: LazyVar[Int] = perRunLazy(this)(compilerSettings.target match {
     case "jvm-1.8" => asm.Opcodes.V1_8
+    case "jvm-9" => asm.Opcodes.V1_9
   })
 
 

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -39,7 +39,7 @@ trait StandardScalaSettings {
   val optimise:        BooleanSetting // depends on post hook which mutates other settings
   val print =          BooleanSetting ("-print", "Print program with Scala-specific features removed.")
   val target =         ChoiceSettingForcedDefault ("-target", "target", "Target platform for object files. All JVM 1.5 - 1.7 targets are deprecated.",
-                          List("jvm-1.5", "jvm-1.6", "jvm-1.7", "jvm-1.8"), "jvm-1.8")
+                          List("jvm-1.5", "jvm-1.6", "jvm-1.7", "jvm-1.8", "jvm-9"), "jvm-1.8")
   val unchecked =      BooleanSetting ("-unchecked", "Enable additional warnings where generated code depends on assumptions.")
   val uniqid =         BooleanSetting ("-uniqid", "Uniquely tag all identifiers in debugging output.")
   val usejavacp =      BooleanSetting ("-usejavacp", "Utilize the java.class.path in classpath resolution.")


### PR DESCRIPTION
Thanks to upgrading `scala-asm` to `5.2-scala-2` in #6116 we now have support for [Java 9 bytecode](https://github.com/scala/scala-asm/commit/e0a7f2469dc53cae947416a43a23c5009dba72bf) because asm now provides `Opcodes.V1_9`.

Note: asm 6.0 renames the constant to `Opcodes.V9`, see https://github.com/scala/scala-asm/commit/f7f44a8e306dd2bd70f0db50194f6366938579c5

This should also be cherry-picked to the `2.13.x` branch I assume.