### PR TITLE
Check bounds on implicit macro applications

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -727,6 +727,16 @@ trait Implicits {
 
             // #2421: check that we correctly instantiated type parameters outside of the implicit tree:
             checkBounds(itree3, NoPrefix, NoSymbol, undetParams, targs, "inferred ")
+
+            // In case we stepped on a macro along the way, the macro was expanded during the call to adapt. Along the way,
+            // any type parameters that were instantiated were NOT yet checked for bounds, so we need to repeat the above
+            // bounds check on the expandee tree
+            itree3.attachments.get[MacroExpansionAttachment] match {
+              case Some(MacroExpansionAttachment(exp @ TypeApply(fun, targs), _)) =>
+                checkBounds(exp, NoPrefix, NoSymbol, fun.symbol.typeParams, targs.map(_.tpe), "inferred ")
+              case _ => ()
+            }
+
             context.reporter.firstError match {
               case Some(err) =>
                 return fail("type parameters weren't correctly instantiated outside of the implicit tree: " + err.errMsg)

--- a/test/files/pos/macro-bounds-check/MacroImpl_1.scala
+++ b/test/files/pos/macro-bounds-check/MacroImpl_1.scala
@@ -1,0 +1,48 @@
+package m
+
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+
+trait HList
+trait Coproduct
+
+abstract class Encoder[T]
+
+object Macros {
+  // these two implicits may be deemed ambiguous if the type argument is not checked for bounds
+  implicit def encodeHList[R <: HList]: Encoder[R] = macro DerivationMacros.encodeHList[R]
+  implicit def encodeCoproduct[R <: Coproduct]: Encoder[R] = macro DerivationMacros.encodeCoproduct[R]
+}
+
+
+object Auto {
+  final def deriveEncoder[A](implicit encode: Encoder[A]): Encoder[A] =
+    encode
+}
+
+class DerivationMacros(val c: whitebox.Context) {
+  import c.universe._
+
+  def encodeHList[R <: HList](implicit R: c.WeakTypeTag[R]): c.Expr[Encoder[R]] = {
+    c.Expr[Encoder[R]](
+      q"""
+        {
+          def e(a: $R): Object = a
+          Predef.???
+        }
+        """
+    )
+  }
+
+  def encodeCoproduct[R <: Coproduct](implicit R: c.WeakTypeTag[R]): c.Expr[Encoder[R]] = {
+    c.Expr[Encoder[R]](
+      q"""
+        {
+          def e(a: $R): Object = a
+
+          Predef.???
+        }
+        """
+    )
+  }
+}

--- a/test/files/pos/macro-bounds-check/TestLate_2.scala
+++ b/test/files/pos/macro-bounds-check/TestLate_2.scala
@@ -1,0 +1,15 @@
+package test
+
+
+import m.Macros._
+import m._
+
+// this case class should use the encodeHList implicit macro
+case class Bar(x: Int) extends HList
+
+class Foo {
+  // this tests that the encoder works even though there are two possible implicit macros,
+  // only one of which satisfies the type bounds. We're interested to see this type-check,
+  // instead of seeing an ambiguous implicit error
+  val encoder = Auto.deriveEncoder[Bar]
+}


### PR DESCRIPTION
If the tree that comes back during implicit search is the result of a macro expansion, check if the expandee was a type application and check bounds on it as well, just as we do for normal inferred types.

Current state: during implicit search type arguments may be inferred, but not checked for bounds until the last step. Along the way a call to `adapt` may expand the macro with inferred types even though they don't fit the bounds. When the actual bounds check is performed, the original tree was replaced with the result of the macro, so no error will be issued and things will go along their merry way (unless this is actually wrong and leads to an ambiguous implicit that would have been otherwise discarded).

I added a call to `checkBounds` on the original (unexpanded) tree at the point where we perform the usual checkBounds. However, I'm open to a better fix if there could be one that does NOT expand the macro at all if bounds don't fit. However, since the inferred type is added and then the macro expanded during [adapt](https://github.com/dragos/scala/blob/issue/8351-implicits-bounds-check/src/compiler/scala/tools/nsc/typechecker/Typers.scala#L1154) I'm not sure where to add the check.

Ref scala/bug#8351