### PR TITLE
Update -Ywarn-unused:params description

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -40,7 +40,7 @@ trait Warnings {
     val Locals    = Choice("locals",    "Warn if a local definition is unused.")
     val Explicits = Choice("explicits", "Warn if an explicit parameter is unused.")
     val Implicits = Choice("implicits", "Warn if an implicit parameter is unused.")
-    val Params    = Choice("params",    "Warn if a value parameter is unused.", expandsTo = List(Explicits, Implicits))
+    val Params    = Choice("params",    "Enable -Ywarn-unused:explicits,implicits.", expandsTo = List(Explicits, Implicits))
     val Linted    = Choice("linted",    "-Xlint:unused.", expandsTo = List(Imports, Privates, Locals, Implicits))
   }
 


### PR DESCRIPTION
In 2.12.4, `-Ywarn-unused:params` changed to be an expanding option that enables both `explicits` and `implicits`.

This has implications that may break builds that use `-Ywarn-unused:-params`.

This PR updates the flag description to make the relationship clear and avoid confusion.

Relates to https://github.com/scala/bug/issues/10572