### PR TITLE
Remove irrelevant comment to add .gitignore entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ codebase and re-compiles too many files, resulting in long build times (check
 meantime you can:
   - Enable "Ant mode" in which sbt only re-compiles source files that were modified.
     Create a file `local.sbt` containing the line `antStyle := true`.
-    Add an entry `local.sbt` to your `~/.gitignore`.
   - Use IntelliJ IDEA for incremental compiles (see [IDE Setup](#ide-setup) below) - its
     incremental compiler is a bit less conservative, but usually correct.
 


### PR DESCRIPTION
The .gitignore file already contains an entry for local.sbt
and as such a developer of this library does not need to add
their own entry to their ~/.gitignore settings.