### PR TITLE
Document negative inputs for `take` and `drop`

### DIFF
--- a/src/library/scala/collection/GenTraversableLike.scala
+++ b/src/library/scala/collection/GenTraversableLike.scala
@@ -301,6 +301,7 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
    *  @param  n    the number of elements to take from this $coll.
    *  @return a $coll consisting only of the first `n` elements of this $coll,
    *          or else the whole $coll, if it has less than `n` elements.
+   *          If `n` is negative, returns an empty $coll.
    */
   def take(n: Int): Repr
 
@@ -309,6 +310,7 @@ trait GenTraversableLike[+A, +Repr] extends Any with GenTraversableOnce[A] with 
    *  @param  n    the number of elements to drop from this $coll.
    *  @return a $coll consisting of all elements of this $coll except the first `n` ones, or else the
    *          empty $coll, if this $coll has less than `n` elements.
+   *          If `n` is negative, don't drop any elements.
    */
   def drop(n: Int): Repr
 


### PR DESCRIPTION
Adds documentation for `take` and `drop` what happens if the input is negative.