### PR TITLE
SingletonTypes can have Any as their typeSymbol, confusing kinding and bounds checking logic.

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
@@ -127,10 +127,7 @@ private[internal] trait TypeConstraints {
     def addHiBound(tp: Type, isNumericBound: Boolean = false) {
       // My current test case only demonstrates the need to let Nothing through as
       // a lower bound, but I suspect the situation is symmetrical.
-      val mustConsider = tp.typeSymbol match {
-        case AnyClass => true
-        case _        => !(hibounds contains tp)
-      }
+      val mustConsider = typeIsAny(tp) || !(hibounds contains tp)
       if (mustConsider) {
         checkWidening(tp)
         if (isNumericBound && isNumericValueType(tp)) {

--- a/test/junit/scala/reflect/internal/TypesTest.scala
+++ b/test/junit/scala/reflect/internal/TypesTest.scala
@@ -313,4 +313,16 @@ class TypesTest {
       assert(polyType(A => Bar(Int, A)) <:< _F && _F <:< polyType(A => Bar(Any, A)))
     }
   }
+
+  @Test
+  def testAnyNothing(): Unit = {
+    object Foo { val a: Any = 23 ; val n: Nothing = ??? }
+    val aSym = typeOf[Foo.type].member(TermName("a"))
+    val nSym = typeOf[Foo.type].member(TermName("n"))
+
+    assert(typeIsAny(AnyTpe))
+    assert(typeIsNothing(NothingTpe))
+    assert(!typeIsAny(SingleType(NoPrefix, aSym)))
+    assert(!typeIsNothing(SingleType(NoPrefix, nSym)))
+  }
 }


### PR DESCRIPTION
This turned out to be the underlying cause of https://github.com/typelevel/scala/issues/139 reported against the SIP-23 implementation in Typelevel Scala.

It turns out that in a handful of places it's assumed that `tpe.typeSymbol(Direct) == AnyClass` tells us that tpe is `Any` ... this messes up bounds and kind checking in circumstances which only really practically arise where singleton types of values of type `Any` are expressible (ie. with literal types enabled) because these `SingleTypes` delegate `typeSymbol(Direct)` to their underlying, which is `Any`. Mutatis mutandis for `Nothing`.

After discussion with @retronym and @adriaanm we concluded that the various instances of these tests should be consolidated under `typeIsAny` and `typeIsNothing` in `Types` with an implementation of the form `tp.dealias match { case TypeRef(_, XXXClass, _) => true ; case _ => false }`.

I've added a unit test here ... once the SIP 23 work is merged we can add a pos test similar to the one included here: https://github.com/milessabin/scala/commit/5bfbd2f2d79ed7dfffb107349f890d86ceb4959f#diff-479c21233a4b966839a6800f0997a975.