### PR TITLE
Assignment operator rewrite finds setter

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -284,11 +284,10 @@ abstract class TreeInfo {
   def isVariableOrGetter(tree: Tree) = {
     def sym       = tree.symbol
     def isVar     = sym.isVariable
-    def isGetter  = mayBeVarGetter(sym) && sym.owner.info.member(sym.setterName) != NoSymbol
 
     tree match {
       case Ident(_)                               => isVar
-      case Select(_, _)                           => isVar || isGetter
+      case Select(qual, _)                        => isVar || mayBeVarGetter(sym) && qual.tpe.member(sym.setterName) != NoSymbol
       case Applied(Select(qual, nme.apply), _, _) => qual.tpe.member(nme.update) != NoSymbol
       case _                                      => false
     }

--- a/test/files/pos/t10375.scala
+++ b/test/files/pos/t10375.scala
@@ -1,0 +1,19 @@
+
+package t10375
+
+trait T {
+  def x: Int = 42
+}
+class C extends T {
+  def x_=(n: Int) = ()
+}
+
+class D(final var y: Int) {
+  def f() = new D(42).y += 1
+}
+
+object Test {
+  val c = new C
+  c.x = c.x + 10
+  c.x += 10
+}


### PR DESCRIPTION
Previously, it looked where the getter was, instead of
where the getter was selected from.

Fixes scala/bug#10375