### PR TITLE
Limit the values that can be added to HashSet to Int.Max.

### DIFF
--- a/src/library/scala/collection/mutable/FlatHashTable.scala
+++ b/src/library/scala/collection/mutable/FlatHashTable.scala
@@ -219,7 +219,9 @@ trait FlatHashTable[A] extends FlatHashTable.HashUtils[A] {
     tableSize = 0
     nnSizeMapReset(table.length)
     seedvalue = tableSizeSeed
-    threshold = newThreshold(_loadFactor, table.length)
+    // If the table length reaches MaximumTableCapacity of Int.MaxValue / 2 then set the
+    // threshold to Int.MaxValue - 8 as a safe value
+    threshold = if (table.length >= MaximumTableCapacity) Int.MaxValue - 8 else newThreshold(_loadFactor, table.length)
     var i = 0
     while (i < oldtable.length) {
       val entry = oldtable(i)
@@ -383,6 +385,8 @@ private[collection] object FlatHashTable {
   final def seedGenerator = new ThreadLocal[scala.util.Random] {
     override def initialValue = new scala.util.Random
   }
+
+  private val MaximumTableCapacity = 1 << 30
 
   private object NullSentinel {
     override def hashCode = 0

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -269,7 +269,9 @@ trait HashTable[A, Entry >: Null <: HashEntry[A, Entry]] extends HashTable.HashU
       }
       i = i - 1
     }
-    threshold = newThreshold(_loadFactor, newSize)
+    // If the table length reaches MaximumTableCapacity of Int.MaxValue / 2 then set the
+    // threshold to Int.MaxValue - 8 as a safe value
+    threshold = if (table.length >= MaximumTableCapacity) Int.MaxValue - 8 else newThreshold(_loadFactor, table.length)
   }
 
   /* Size map handling code */
@@ -404,6 +406,8 @@ private[collection] object HashTable {
   private[collection] final def newThreshold(_loadFactor: Int, size: Int) = ((size.toLong * _loadFactor) / loadFactorDenum).toInt
 
   private[collection] final def sizeForThreshold(_loadFactor: Int, thr: Int) = ((thr.toLong * loadFactorDenum) / _loadFactor).toInt
+
+  private val MaximumTableCapacity = 1 << 30
 
   private[collection] final def capacity(expectedSize: Int) = nextPositivePowerOfTwo(expectedSize)
 

--- a/src/library/scala/collection/mutable/OpenHashMap.scala
+++ b/src/library/scala/collection/mutable/OpenHashMap.scala
@@ -21,6 +21,8 @@ object OpenHashMap {
   def apply[K, V](elems : (K, V)*) = new OpenHashMap[K, V] ++= elems
   def empty[K, V] = new OpenHashMap[K, V]
 
+  private val MaximumTableCapacity = 1 << 30
+
   /** A hash table entry.
     * 
     * The entry is occupied if and only if its `value` is a `Some`;
@@ -56,7 +58,7 @@ extends AbstractMap[Key, Value]
    with Map[Key, Value]
    with MapLike[Key, Value, OpenHashMap[Key, Value]] {
 
-  import OpenHashMap.OpenEntry
+  import OpenHashMap._
   private type Entry = OpenEntry[Key, Value]
 
   /** A default constructor creates a hashmap with initial size `8`.
@@ -97,7 +99,7 @@ extends AbstractMap[Key, Value]
     */
   private[this] def growTable() = {
     val oldSize = mask + 1
-    val newSize = 4 * oldSize
+    val newSize = if (oldSize >= MaximumTableCapacity) Int.MaxValue - 8 else 4 * oldSize
     val oldTable = table
     table = new Array[Entry](newSize)
     mask = newSize - 1


### PR DESCRIPTION
If the length of the hash table is Int.Max then throw an exception to notify that the element cannot be added. 
Earlier it used to throw NegativeArraySizeException.

Fixes: scala/bug#10409