### PR TITLE
TaskSupport respects specific FJP

### DIFF
--- a/src/library/scala/collection/parallel/Tasks.scala
+++ b/src/library/scala/collection/parallel/Tasks.scala
@@ -391,12 +391,10 @@ trait ForkJoinTasks extends Tasks with HavingForkJoinPool {
   def execute[R, Tp](task: Task[R, Tp]): () => R = {
     val fjtask = newWrappedTask(task)
 
-    if (Thread.currentThread.isInstanceOf[ForkJoinWorkerThread]) {
-      fjtask.fork
-    } else {
-      forkJoinPool.execute(fjtask)
+    Thread.currentThread match {
+      case fjw: ForkJoinWorkerThread if fjw.getPool eq forkJoinPool => fjtask.fork()
+      case _ => forkJoinPool.execute(fjtask)
     }
-
     () => {
       fjtask.sync()
       fjtask.body.forwardThrowable()
@@ -414,12 +412,10 @@ trait ForkJoinTasks extends Tasks with HavingForkJoinPool {
   def executeAndWaitResult[R, Tp](task: Task[R, Tp]): R = {
     val fjtask = newWrappedTask(task)
 
-    if (Thread.currentThread.isInstanceOf[ForkJoinWorkerThread]) {
-      fjtask.fork
-    } else {
-      forkJoinPool.execute(fjtask)
+    Thread.currentThread match {
+      case fjw: ForkJoinWorkerThread if fjw.getPool eq forkJoinPool => fjtask.fork()
+      case _ => forkJoinPool.execute(fjtask)
     }
-
     fjtask.sync()
     // if (fjtask.body.throwable != null) println("throwing: " + fjtask.body.throwable + " at " + fjtask.body)
     fjtask.body.forwardThrowable()

--- a/test/junit/scala/collection/parallel/TaskTest.scala
+++ b/test/junit/scala/collection/parallel/TaskTest.scala
@@ -1,0 +1,30 @@
+package scala.collection.parallel
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+
+import java.util.concurrent.{ForkJoinPool, ForkJoinWorkerThread}, ForkJoinPool._
+
+@RunWith(classOf[JUnit4])
+class TaskTest {
+  @Test
+  def `t10577 task executes on foreign pool`(): Unit = {
+    def mkFactory(name: String) = new ForkJoinWorkerThreadFactory {
+      override def newThread(pool: ForkJoinPool) = {
+        val t = new ForkJoinWorkerThread(pool) {}
+        t.setName(name)
+        t
+      }
+    }
+    def mkPool(name: String) = new ForkJoinPool(1, mkFactory(name), null, false)
+
+    val one = List(1).par
+    val two = List(2).par
+
+    one.tasksupport = new ForkJoinTaskSupport(mkPool("one"))
+    two.tasksupport = new ForkJoinTaskSupport(mkPool("two"))
+
+    for (x <- one ; y <- two) assert(Thread.currentThread.getName == "two")
+  }
+}


### PR DESCRIPTION
ForkJoinTaskSupport forks if it seems to be running on
a ForkJoinPool, but it should only fork on its own FJP.
This change was added to the default FJP executor service
but not backported to parallel collections.

Fixes scala/scala-parallel-collections#284