### PR TITLE
Add missing parens

### DIFF
--- a/spec/07-implicits.md
+++ b/spec/07-implicits.md
@@ -155,7 +155,7 @@ sort(yss)
 The call above will be completed by passing two nested implicit arguments:
 
 ```scala
-sort(yss)(xs: List[Int] => list2ordered[Int](xs)(int2ordered))
+sort(yss)((xs: List[Int]) => list2ordered[Int](xs)(int2ordered))
 ```
 
 The possibility of passing implicit arguments to implicit arguments


### PR DESCRIPTION
reported here: https://contributors.scala-lang.org/t/small-correction-to-an-example-in-the-scala-spec/1288
interestingly, they are present in the Scala Overview paper: http://scala-lang.org/docu/files/ScalaOverview.pdf