### PR TITLE
Deprecations to prepare adherence to compact1 profile

### DIFF
--- a/src/library/scala/beans/BeanDescription.scala
+++ b/src/library/scala/beans/BeanDescription.scala
@@ -15,5 +15,6 @@ package scala.beans
  *
  *  @author Ross Judson (rjudson@managedobjects.com)
  */
+@deprecated(message = "the generation of BeanInfo classes is no longer supported", since = "2.12.5")
 class BeanDescription(val description: String) extends scala.annotation.Annotation
 

--- a/src/library/scala/beans/BeanDisplayName.scala
+++ b/src/library/scala/beans/BeanDisplayName.scala
@@ -14,5 +14,6 @@ package scala.beans
  *
  *  @author Ross Judson (rjudson@managedobjects.com)
  */
+@deprecated(message = "the generation of BeanInfo classes is no longer supported", since = "2.12.5")
 class BeanDisplayName(val name: String) extends scala.annotation.Annotation
 

--- a/src/library/scala/beans/BeanInfoSkip.scala
+++ b/src/library/scala/beans/BeanInfoSkip.scala
@@ -15,4 +15,5 @@ package scala.beans
  *
  *  @author Ross Judson (rjudson@managedobjects.com)
  */
+@deprecated(message = "the generation of BeanInfo classes is no longer supported", since = "2.12.5")
 class BeanInfoSkip extends scala.annotation.Annotation

--- a/src/library/scala/beans/ScalaBeanInfo.scala
+++ b/src/library/scala/beans/ScalaBeanInfo.scala
@@ -16,6 +16,7 @@ package scala.beans
  *
  *  @author Ross Judson (rjudson@managedobjects.com)
  */
+@deprecated(message = "the generation of BeanInfo classes is no longer supported", since = "2.12.5")
 abstract class ScalaBeanInfo(clazz: java.lang.Class[_],
                              props: Array[String],
                              methods: Array[String]) extends java.beans.SimpleBeanInfo {

--- a/src/library/scala/sys/process/package.scala
+++ b/src/library/scala/sys/process/package.scala
@@ -202,6 +202,7 @@ package scala.sys {
     */
   package object process extends ProcessImplicits {
     /** The arguments passed to `java` when creating this process */
+    @deprecated(message = "to adhere to the compact1 profile this method will be removed", since = "2.12.5") // https://github.com/scala/scala-dev/issues/437
     def javaVmArguments: List[String] = {
       import scala.collection.JavaConverters._
 


### PR DESCRIPTION
BeanInfo generation was already deprecated, but we only explicitly
noted this in the main entry point. For clarity, deprecate all involved
classes.

Sneak in one more deprecation (`scala.sys.process.javaVmArguments`),
and our diet can be completed in 2.13.0-M3!

See https://github.com/scala/scala/pull/6164