### PR TITLE
Fix glb of deeply structural types.

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -415,7 +415,7 @@ private[internal] trait GlbLubs {
     *  If the recursion is broken, no member is added to the glb.
     */
   private var globalGlbDepth = Depth.Zero
-  private final val globalGlbLimit = Depth(2)
+  private final val globalGlbLimit = Depth(8)
 
   /** The greatest lower bound of a list of types (as determined by `<:<`). */
   def glb(ts: List[Type]): Type = elimSuper(ts) match {
@@ -496,7 +496,7 @@ private[internal] trait GlbLubs {
               val symtypes = syms map glbThisType.memberInfo
               assert(!symtypes.isEmpty)
               proto.cloneSymbol(glbRefined.typeSymbol).setInfoOwnerAdjusted(
-                if (proto.isTerm) glb(symtypes, depth.decr)
+                if (proto.isTerm) glb(symtypes, depth)
                 else {
                   def isTypeBound(tp: Type) = tp match {
                     case TypeBounds(_, _) => true
@@ -544,7 +544,7 @@ private[internal] trait GlbLubs {
     }
     // if (settings.debug.value) { println(indent + "glb of " + ts + " at depth "+depth); indent = indent + "  " } //DEBUG
     if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(nestedLubCount)
-    glb0(ts)
+    glb0(ts.map(_.dealias))
     // if (settings.debug.value) { indent = indent.substring(0, indent.length() - 2); log(indent + "glb of " + ts + " is " + res) }//DEBUG
   }
 

--- a/test/files/neg/t10592.check
+++ b/test/files/neg/t10592.check
@@ -1,0 +1,13 @@
+t10592.scala:24: error: type mismatch;
+ found   : O.U[O.A]
+    (which expands to)  O.U[AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def a: Int}}}}}}}}]
+ required: O.U[AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef}}}}}}}]
+  def f(a: U[A], b: U[B]) = Seq(a, b)
+                                ^
+t10592.scala:24: error: type mismatch;
+ found   : O.U[O.B]
+    (which expands to)  O.U[AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def b: Int}}}}}}}}]
+ required: O.U[AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef{def X: AnyRef}}}}}}}]
+  def f(a: U[A], b: U[B]) = Seq(a, b)
+                                   ^
+two errors found

--- a/test/files/neg/t10592.scala
+++ b/test/files/neg/t10592.scala
@@ -1,0 +1,26 @@
+object O {
+  type A = AnyRef {
+      def X: AnyRef {
+        def X: AnyRef {
+          def X: AnyRef {
+            def X:AnyRef {
+              def X: AnyRef {
+                def X: AnyRef {
+                  def X: AnyRef {
+                    def a: Int }}}}}}}}
+
+  type B = AnyRef {
+    def X: AnyRef {
+      def X: AnyRef {
+        def X:AnyRef {
+          def X: AnyRef {
+            def X: AnyRef {
+              def X: AnyRef {
+                def X: AnyRef {
+                  def b: Int }}}}}}}}
+
+  class U[-X]
+
+  def f(a: U[A], b: U[B]) = Seq(a, b)
+
+}

--- a/test/files/pos/t10592.scala
+++ b/test/files/pos/t10592.scala
@@ -1,0 +1,37 @@
+object O {
+  type A = AnyRef {
+      def X: AnyRef {
+        def X: AnyRef {
+          def X:AnyRef {
+            def X: AnyRef {
+              def X: AnyRef {
+                def X: AnyRef {
+                    def a: Int }}}}}}}
+
+  type B = AnyRef {
+        def X: AnyRef {
+          def X:AnyRef {
+            def X: AnyRef {
+              def X: AnyRef {
+                def X: AnyRef {
+                  def X: AnyRef {
+                    def b: Int }}}}}}}
+
+  // glb of A and B
+  type C = AnyRef {
+        def X: AnyRef {
+          def X:AnyRef {
+            def X: AnyRef {
+              def X: AnyRef {
+                def X: AnyRef {
+                  def X: AnyRef {
+                    def a: Int; def b: Int }}}}}}}
+
+  class U[-X]
+
+  def f(a: U[A], b: U[B]) = Seq(a, b)
+  def f_bound_R[X >: A](a: U[X], b: U[B]): Seq[U[C]] = Seq(a, b)
+  def f_bound_L[X >: B](a: U[A], b: U[X]): Seq[U[C]] = Seq(a, b)
+  def f_bound[X >: A, Y >: B](a: U[X], b: U[Y]): Seq[U[C]] = Seq(a, b)
+
+}


### PR DESCRIPTION
- Perform `dealias` when calling glb0
- Don't decrement the depth when `proto. isTerm` in glb1. (Is this potentially dangerous?)
- Increase `globalGlbLimit`

Fixes  [scala/bug#10592](https://github.com/scala/bug/issues/10592).

According to my experiments, `globalGlbLimit` has to increase in proportion to the depth of nesting. The value `8` in this PR is chosen arbitrary (according to our use cases) and the supplemented positive and negative tests delineate the limit. 
Alternatively one may compute the nesting depth, for instance, on entering `glb1` -- this could be a less ad hoc and arguably more complicated solution (but I did not implement this alternative solution).