### PR TITLE
Fix lub of structural types

### DIFF
--- a/test/files/pos/t10593.scala
+++ b/test/files/pos/t10593.scala
@@ -1,0 +1,20 @@
+object O {
+  type A = AnyRef { def x: Int; def a : Int }
+  type B = AnyRef { def x: Int; def b : Int }
+  type C = AnyRef { def x: Int }
+
+  class U[+X]
+
+  def f(a: U[A], b: U[B]): Seq[U[C]] = Seq(a, b)
+  def f_bound_R[X <: B](a: U[A], b: U[X]): Seq[U[C]] = Seq(a, b)
+  def f_bound_L[X <: A](a: U[X], b: U[B]): Seq[U[C]] = Seq(a, b)
+
+  type AA = AnyRef { def X: AnyRef { def x: Int; def a : Int } }
+  type BB = AnyRef { def X: AnyRef { def x: Int; def b : Int } }
+  type CC = AnyRef { def X: AnyRef { def x: Int } }
+
+  def g(a: U[AA], b: U[BB]): Seq[U[CC]] = Seq(a, b)
+  def g_bound_R[X <: AA](a: U[AA], b: U[X]): Seq[U[CC]] = Seq(a, b)
+  def g_bound_L[X <: BB](a: U[X], b: U[BB]): Seq[U[CC]] = Seq(a, b)
+
+}


### PR DESCRIPTION
- don't decrement the depth when proto.isTerm
- add refinement symbols which are refined by every types

Fixes [scala/bug#10593](https://github.com/scala/bug/issues/10593)

This PR does not enable the following code, which I would consider well-typed, hence it is consciously omitted from the test.
```
type A = AnyRef { def x: Int; def a : Int }
type B = AnyRef { def x: Int; def b : Int }
type C = AnyRef { def x: Int }

class U[+X]
def f_bound[X <: A, Y <: B](a: U[X], b: U[Y]): Seq[U[C]] = Seq(a, b)
```