### PR TITLE
Don't emit the serialVersionUID field on traits.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -103,7 +103,11 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
       }
 
       val optSerial: Option[Long] = serialVUID(claszSymbol)
-      if (optSerial.isDefined) { addSerialVUID(optSerial.get, cnode)}
+      /* serialVersionUID can't be put on interfaces (it's a private field).
+       * this is fine because it wouldn't do anything anyways. */
+      if (optSerial.isDefined && !claszSymbol.isTrait) {
+        addSerialVUID(optSerial.get, cnode)
+      }
 
       addClassFields()
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1432,7 +1432,7 @@ abstract class RefChecks extends Transform {
 
           if (sym.isClass && sym.hasAnnotation(SerialVersionUIDAttr)) {
             def warn(what: String) =
-              reporter.warning(tree.pos, s"@serialVersionUID has no effect on $what")
+              reporter.warning(tree.pos, s"@SerialVersionUID has no effect on $what")
 
             if (sym.isTrait) warn("traits")
             else if (!sym.isSerializable) warn("non-serializable classes")

--- a/test/files/jvm/t10610.check
+++ b/test/files/jvm/t10610.check
@@ -1,0 +1,3 @@
+t10610.scala:2: warning: @SerialVersionUID has no effect on traits
+trait T
+      ^

--- a/test/files/jvm/t10610.scala
+++ b/test/files/jvm/t10610.scala
@@ -1,0 +1,11 @@
+@SerialVersionUID(0L) // should have no effect
+trait T
+
+object Test extends App {
+  try {
+    classOf[T].getDeclaredField("serialVersionUID")
+    assert(false)
+  } catch {
+    case nsfe: NoSuchFieldException =>
+  }
+}

--- a/test/files/neg/warn-useless-svuid.check
+++ b/test/files/neg/warn-useless-svuid.check
@@ -1,16 +1,16 @@
-warn-useless-svuid.scala:2: warning: @serialVersionUID has no effect on non-serializable classes
+warn-useless-svuid.scala:2: warning: @SerialVersionUID has no effect on non-serializable classes
 class X
       ^
-warn-useless-svuid.scala:5: warning: @serialVersionUID has no effect on non-serializable classes
+warn-useless-svuid.scala:5: warning: @SerialVersionUID has no effect on non-serializable classes
 class Y extends X
       ^
-warn-useless-svuid.scala:17: warning: @serialVersionUID has no effect on traits
+warn-useless-svuid.scala:17: warning: @SerialVersionUID has no effect on traits
 trait T
       ^
-warn-useless-svuid.scala:20: warning: @serialVersionUID has no effect on traits
+warn-useless-svuid.scala:20: warning: @SerialVersionUID has no effect on traits
 trait U extends scala.Serializable
       ^
-warn-useless-svuid.scala:23: warning: @serialVersionUID has no effect on traits
+warn-useless-svuid.scala:23: warning: @SerialVersionUID has no effect on traits
 trait V extends java.io.Serializable
       ^
 error: No warnings can be incurred under -Xfatal-warnings.


### PR DESCRIPTION
[These days](https://github.com/scala/scala/pull/6141), it's `private`, and the JVM doesn't like private fields on interfaces. Since the field doesn't have an effect when put on an interface, we might as well just not.

Also, fix the capitalization of the annotation in the warning.

Fixes scala/bug#10610; references scala/collection-strawman#296.