### PR TITLE
Fix corner case in preErase's treatment of Apply trees.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -1268,6 +1268,11 @@ abstract class Erasure extends InfoTransform
               finally tpt setType specialErasure(tree1.symbol)(tree1.symbol.tpe).resultType
             case ApplyDynamic(qual, Literal(Constant(bootstrapMethodRef: Symbol)) :: _) =>
               tree
+            case _: Apply if tree1 ne tree =>
+              /* some Apply trees get replaced (in `preEraseApply`) with one of
+               * their subtrees, which needs to be `preErase`d in its entirety,
+               * not just recursed over by super.transform(). */
+              transform(tree1)
             case _ =>
               super.transform(tree1).clearType()
           }

--- a/test/files/run/t10611.scala
+++ b/test/files/run/t10611.scala
@@ -1,0 +1,7 @@
+object Test extends App {
+  /* crashes at jvm with AssertionError */
+  def q[T: reflect.ClassTag] = Array.empty[T].length.##
+
+  /* crashes at runtime with NoSuchMethodError */
+  this.##.##
+}


### PR DESCRIPTION
`preEraseApply` can return another `Apply` that's a subtree of the tree being transformed; if it does, then that tree needs `preErase`d itself, so just send it through the wash one more time.

fixes scala/bug#10611.