### PR TITLE
Avoid deprecation warning on explicit eta-expansion of nullary method

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1745,7 +1745,7 @@ self =>
           }
           simpleExprRest(app, canApply = true)
         case USCORE =>
-          atPos(t.pos.start, in.skipToken()) { makeMethodValue(stripParens(t)) }
+          atPos(t.pos.start, in.skipToken()) { MethodValue(stripParens(t)) }
         case _ =>
           t
       }

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -35,9 +35,6 @@ abstract class TreeBuilder {
   def repeatedApplication(tpe: Tree): Tree =
     AppliedTypeTree(rootScalaDot(tpnme.REPEATED_PARAM_CLASS_NAME), List(tpe))
 
-  // represents `expr _`, as specified in Method Values of spec/06-expressions.md
-  def makeMethodValue(expr: Tree): Tree = Typed(expr, Function(Nil, EmptyTree))
-
   def makeImportSelector(name: Name, nameOffset: Int): ImportSelector =
     ImportSelector(name, nameOffset, name, nameOffset)
 

--- a/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
@@ -182,4 +182,7 @@ trait StdAttachments {
    * track of other adapted trees.
    */
   case class OriginalTreeAttachment(original: Tree)
+
+  /** Added to trees that appear in a method value, e.g., to `f(x)` in `f(x) _` */
+  case object MethodValueAttachment
 }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4634,7 +4634,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             case Annotated(_, r)                    => treesInResult(r)
             case If(_, t, e)                        => treesInResult(t) ++ treesInResult(e)
             case Try(b, catches, _)                 => treesInResult(b) ++ catches
-            case Typed(r, Function(Nil, EmptyTree)) => treesInResult(r) // a method value
+            case MethodValue(r)                     => treesInResult(r)
             case Select(qual, name)                 => treesInResult(qual)
             case Apply(fun, args)                   => treesInResult(fun) ++ args.flatMap(treesInResult)
             case TypeApply(fun, args)               => treesInResult(fun) ++ args.flatMap(treesInResult)

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -473,6 +473,15 @@ trait Trees extends api.Trees {
        extends TermTree with TypedApi
   object Typed extends TypedExtractor
 
+  // represents `expr _`, as specified in Method Values of spec/06-expressions.md
+  object MethodValue {
+    def apply(expr: Tree): Tree = Typed(expr, Function(Nil, EmptyTree))
+    def unapply(tree: Tree): Option[Tree] = tree match {
+      case Typed(expr, Function(Nil, EmptyTree)) => Some(expr)
+      case _ => None
+    }
+  }
+
   abstract class GenericApply extends TermTree with GenericApplyApi {
     val fun: Tree
     val args: List[Tree]

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -85,6 +85,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.Throw
     this.New
     this.Typed
+    this.MethodValue
     this.TypeApply
     this.Apply
     this.ApplyDynamic

--- a/test/files/neg/t10279.check
+++ b/test/files/neg/t10279.check
@@ -1,7 +1,18 @@
-t10279.scala:9: error: could not find implicit value for parameter s: String
-  val bar = foo(1) _
-               ^
-t10279.scala:12: error: could not find implicit value for parameter x: Int
-  val barSimple = fooSimple _
+t10279.scala:5: error: could not find implicit value for parameter s: String
+  val t1 = foo(1) _     // error: no implicit string
+              ^
+t10279.scala:6: error: _ must follow method; cannot follow String
+  val t2 = foo(1)("") _ // error: _ must follow method
+                 ^
+t10279.scala:7: error: could not find implicit value for parameter s: String
+  val t3 = foo _        // error: no implicit string
+           ^
+t10279.scala:14: error: type mismatch;
+ found   : Int
+ required: ? => ?
+  val t6 = { implicit val i = 0; bar(0) _ } // error: type mismatch, found Int, required: ? => ?
+                                    ^
+t10279.scala:17: error: could not find implicit value for parameter x: Int
+  val barSimple = fooSimple _ // error: no implicit int
                   ^
-two errors found
+5 errors found

--- a/test/files/neg/t10279.scala
+++ b/test/files/neg/t10279.scala
@@ -1,13 +1,18 @@
 object Test {
 
-  def foo(i: Int)(implicit s: String): String = ???
+  def foo(i: Int)(implicit s: String): String = ""
 
-  def test(implicit s: String) {
-    // foo(1) _
-  }
+  val t1 = foo(1) _     // error: no implicit string
+  val t2 = foo(1)("") _ // error: _ must follow method
+  val t3 = foo _        // error: no implicit string
+  val t4 = { implicit val s = ""; foo _ } // eta-expansion over the non-implicit parameter list
+  val t4a: Int => String = t4             // ok
+  val t5 = { implicit val s = ""; foo(1) _ }       // compiles as Predef.wrapString(foo(1)(s))
+  val t5a: collection.immutable.WrappedString = t5 // don't ask me why
 
-  val bar = foo(1) _
+  def bar(i: Int)(implicit j: Int): Int = 0
+  val t6 = { implicit val i = 0; bar(0) _ } // error: type mismatch, found Int, required: ? => ?
 
   def fooSimple(implicit x: Int): Int = x
-  val barSimple = fooSimple _
+  val barSimple = fooSimple _ // error: no implicit int
 }

--- a/test/files/neg/t7187.check
+++ b/test/files/neg/t7187.check
@@ -1,6 +1,33 @@
-t7187.scala:3: warning: Eta-expansion of zero-argument method values is deprecated. Did you intend to write EtaExpandZeroArg.this.foo()?
-  val f: () => Any = foo
-                     ^
-error: No warnings can be incurred under -Xfatal-warnings.
-one warning found
-one error found
+t7187.scala:4: warning: Eta-expansion of zero-argument methods is deprecated. To avoid this warning, write (() => EtaExpandZeroArg.this.foo()).
+  val t1b: () => Any = foo   // eta-expansion (deprecated) in 2.12, `()`-insertion in 2.13
+                       ^
+t7187.scala:8: error: _ must follow method; cannot follow () => String
+  val t1f: Any       = foo() _ // error: _ must follow method
+                          ^
+t7187.scala:11: error: type mismatch;
+ found   : String
+ required: () => Any
+  val t2a: () => Any = bar   // error: no eta-expansion of zero-arglist-methods
+                       ^
+t7187.scala:12: error: not enough arguments for method apply: (index: Int)Char in class StringOps.
+Unspecified value parameter index.
+  val t2b: () => Any = bar() // error: bar doesn't take arguments, so expanded to bar.apply(), which misses an argument
+                          ^
+t7187.scala:15: error: not enough arguments for method apply: (index: Int)Char in class StringOps.
+Unspecified value parameter index.
+  val t2e: Any       = bar() _ // error: not enough arguments for method apply
+                          ^
+t7187.scala:18: warning: Eta-expansion of zero-argument methods is deprecated. To avoid this warning, write (() => EtaExpandZeroArg.this.baz()).
+  val t3a: () => Any = baz   // eta-expansion (deprecated) in 2.12, error in 2.13
+                       ^
+t7187.scala:21: error: _ must follow method; cannot follow String
+  val t3d: Any       = baz() _ // error: _ must follow method
+                          ^
+t7187.scala:24: warning: Eta-expansion of zero-argument methods is deprecated. To avoid this warning, write (() => EtaExpandZeroArg.this.zap()).
+  val t4a: () => Any = zap     // eta-expansion (deprecated) in 2.12, error in 2.13
+                       ^
+t7187.scala:25: warning: Eta-expansion of zero-argument methods is deprecated. To avoid this warning, write (() => EtaExpandZeroArg.this.zap()()).
+  val t4b: () => Any = zap()   // ditto
+                          ^
+four warnings found
+5 errors found

--- a/test/files/neg/t7187.scala
+++ b/test/files/neg/t7187.scala
@@ -1,6 +1,28 @@
 class EtaExpandZeroArg {
   def foo(): () => String = () => ""
-  val f: () => Any = foo
+  val t1a: () => Any = foo() // ok (obviously)
+  val t1b: () => Any = foo   // eta-expansion (deprecated) in 2.12, `()`-insertion in 2.13
+  val t1c: () => Any = { val t = foo; t } // ok, no expected type, `()`-insertion
+  val t1d: () => Any = foo _ // ok
+  val t1e: Any       = foo _ // ok
+  val t1f: Any       = foo() _ // error: _ must follow method
 
-  // f() would evaluate to <function0> instead of ""
+  def bar = ""
+  val t2a: () => Any = bar   // error: no eta-expansion of zero-arglist-methods
+  val t2b: () => Any = bar() // error: bar doesn't take arguments, so expanded to bar.apply(), which misses an argument
+  val t2c: () => Any = bar _ // ok
+  val t2d: Any       = bar _ // ok
+  val t2e: Any       = bar() _ // error: not enough arguments for method apply
+
+  def baz() = ""
+  val t3a: () => Any = baz   // eta-expansion (deprecated) in 2.12, error in 2.13
+  val t3b: () => Any = baz _ // ok
+  val t3c: Any       = baz _ // ok
+  val t3d: Any       = baz() _ // error: _ must follow method
+
+  def zap()() = ""
+  val t4a: () => Any = zap     // eta-expansion (deprecated) in 2.12, error in 2.13
+  val t4b: () => Any = zap()   // ditto
+  val t4c: () => Any = zap _   // ok
+  val t4d: () => Any = zap() _ // ok
 }

--- a/test/files/run/byname.check
+++ b/test/files/run/byname.check
@@ -1,4 +1,3 @@
-warning: there were two deprecation warnings (since 2.12.0); re-run with -deprecation for details
 test no braces completed properly
 test no braces r completed properly
 test plain completed properly


### PR DESCRIPTION
Scala 2.12.4 produces a false deprecation warning for explicit eta-expansion of nullary methods:
```
scala> def f() = 1
scala> f _
<console>:13: warning: Eta-expansion of zero-argument method values is deprecated. Did you intend to write f()?
       f _
```

This PR fixes that.

Nuances https://github.com/scala/scala/commit/c15b9b730e76f2c33399ce4ffc2ffb3c71025531 until method value syntax is deprecated entirely.

Fixes scala/bug#10612