### PR TITLE
Warn when Object/AnyRef is inferred.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -551,18 +551,18 @@ trait Infer extends Checkable {
         }
       }
       val targs = solvedTypes(tvars, tparams, tparams map varianceInTypes(formals), upper = false, lubDepth(formals) max lubDepth(argtpes))
-      // Can warn about inferring Any/AnyVal as long as they don't appear
+      // Can warn about inferring Any/AnyVal/Object as long as they don't appear
       // explicitly anywhere amongst the formal, argument, result, or expected type.
       // ...or lower bound of a type param, since they're asking for it.
       def canWarnAboutAny = {
         val loBounds = tparams map (_.info.bounds.lo)
-        def containsAny(t: Type) = (t contains AnyClass) || (t contains AnyValClass)
+        def containsAny(t: Type) = (t contains AnyClass) || (t contains AnyValClass) || (t contains ObjectClass)
         val hasAny = pt :: restpe :: formals ::: argtpes ::: loBounds exists (_.dealiasWidenChain exists containsAny)
         !hasAny
       }
       if (settings.warnInferAny && context.reportErrors && !fn.isEmpty && canWarnAboutAny) {
         targs.foreach(_.typeSymbol match {
-          case sym @ (AnyClass | AnyValClass) =>
+          case sym @ (AnyClass | AnyValClass | ObjectClass) =>
             reporter.warning(fn.pos, s"a type was inferred to be `${sym.name}`; this may indicate a programming error.")
           case _ =>
         })

--- a/test/files/neg/warn-inferred-any.check
+++ b/test/files/neg/warn-inferred-any.check
@@ -10,6 +10,9 @@ warn-inferred-any.scala:17: warning: a type was inferred to be `AnyVal`; this ma
 warn-inferred-any.scala:25: warning: a type was inferred to be `Any`; this may indicate a programming error.
   def za = f(1, "one")
            ^
+warn-inferred-any.scala:35: warning: a type was inferred to be `Object`; this may indicate a programming error.
+  cs.contains(new C2) // warns
+     ^
 error: No warnings can be incurred under -Xfatal-warnings.
-four warnings found
+5 warnings found
 one error found

--- a/test/files/neg/warn-inferred-any.scala
+++ b/test/files/neg/warn-inferred-any.scala
@@ -25,3 +25,12 @@ trait Zs {
   def za = f(1, "one")
   def zu = g(1, "one")
 }
+
+class C1
+class C2
+
+trait Cs {
+  val cs = List(new C1)
+  cs.contains[AnyRef](new C2) // doesn't warn
+  cs.contains(new C2) // warns
+}


### PR DESCRIPTION
Extends -Xlint:warn-any to also emit a warning when Object/AnyRef
is inferred.