### PR TITLE
fix currentRun.compiles(Symbol)

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1330,7 +1330,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     def compiles(sym: Symbol): Boolean =
       if (sym == NoSymbol) false
       else if (symSource.isDefinedAt(sym)) true
-      else if (!sym.isTopLevel) compiles(sym.enclosingTopLevelClassOrDummy)
+      else if (!sym.isTopLevel) compiles(sym.originalEnclosingTopLevelClassOrDummy)
       else if (sym.isModuleClass) compiles(sym.sourceModule)
       else false
 

--- a/src/compiler/scala/tools/nsc/transform/Flatten.scala
+++ b/src/compiler/scala/tools/nsc/transform/Flatten.scala
@@ -57,8 +57,9 @@ abstract class Flatten extends InfoTransform {
   private val flattened = new TypeMap {
     def apply(tp: Type): Type = tp match {
       case TypeRef(pre, sym, args) if isFlattenablePrefix(pre) =>
-        assert(args.isEmpty && sym.enclosingTopLevelClass != NoSymbol, sym.ownerChain)
-        typeRef(sym.enclosingTopLevelClass.owner.thisType, sym, Nil)
+        val top = sym.enclosingTopLevelClass
+        assert(args.isEmpty && top != NoSymbol, sym.ownerChain)
+        typeRef(top.owner.thisType, sym, Nil)
       case ClassInfoType(parents, decls, clazz) =>
         var parents1 = parents
         val decls1 = scopeTransform(clazz) {

--- a/src/reflect/scala/reflect/internal/PrivateWithin.scala
+++ b/src/reflect/scala/reflect/internal/PrivateWithin.scala
@@ -20,8 +20,9 @@ trait PrivateWithin {
   // protected in java means package protected. #3946
   // See ticket #1687 for an example of when the enclosing top level class is NoSymbol;
   // it apparently occurs when processing v45.3 bytecode.
-  def setPackageAccessBoundary(sym: Symbol): Symbol = (
-    if (sym.enclosingTopLevelClass eq NoSymbol) sym
-    else sym setPrivateWithin sym.enclosingTopLevelClass.owner
-  )
+  def setPackageAccessBoundary(sym: Symbol): Symbol = {
+    val topLevel = sym.enclosingTopLevelClass
+    if (topLevel eq NoSymbol) sym
+    else sym setPrivateWithin topLevel.owner
+  }
 }

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2207,17 +2207,17 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       else if (isMethod || isClass || this == NoSymbol) this
       else owner.logicallyEnclosingMember
 
-    /** The top-level class containing this symbol. */
+    /** The top-level class containing this symbol, using the current owner chain. */
     def enclosingTopLevelClass: Symbol =
       if (isTopLevel) {
         if (isClass) this else moduleClass
       } else owner.enclosingTopLevelClass
 
-    /** The top-level class or local dummy symbol containing this symbol. */
-    def enclosingTopLevelClassOrDummy: Symbol =
+    /** The top-level class or local dummy symbol containing this symbol, using the original owner chain. */
+    def originalEnclosingTopLevelClassOrDummy: Symbol =
       if (isTopLevel) {
         if (isClass) this else moduleClass.orElse(this)
-      } else owner.enclosingTopLevelClassOrDummy
+      } else originalOwner.originalEnclosingTopLevelClassOrDummy
 
     /** Is this symbol defined in the same scope and compilation unit as `that` symbol? */
     def isCoDefinedWith(that: Symbol) = (
@@ -3554,7 +3554,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def enclClassChain = Nil
     override def enclClass: Symbol = this
     override def enclosingTopLevelClass: Symbol = this
-    override def enclosingTopLevelClassOrDummy: Symbol = this
+    override def originalEnclosingTopLevelClassOrDummy: Symbol = this
     override def enclosingPackageClass: Symbol = this
     override def enclMethod: Symbol = this
     override def associatedFile = NoAbstractFile


### PR DESCRIPTION
before GenBCode the owner of classes change, so the `enclosingTopLevelClass` misses the top level class (probably changed in delambify) 
this allows the `compiles` to check the `originalOwner`, which seems to work in my test cases