### PR TITLE
Fixup symbol ownership in eta expansion

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3053,7 +3053,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       if (tree.tpe.isDependentMethodType) DependentMethodTpeConversionToFunctionError(tree, tree.tpe) // TODO: support this
       else {
-        val expansion = etaExpand(context.unit, tree, this)
+        val expansion = etaExpand(context.unit, tree, context.owner)
         if (context.undetparams.isEmpty) typed(expansion, mode, pt)
         else instantiate(typed(expansion, mode), mode, pt)
       }


### PR DESCRIPTION
The fix for scala/bug#6274 did this selectively when function symbols
were introduced, but we really ought to insert the eta$n temp vals into
the owner chain of all lifted expressions.