### PR TITLE
 Fix @inheritdoc on vals.

### DIFF
--- a/test/scaladoc/resources/t10621.scala
+++ b/test/scaladoc/resources/t10621.scala
@@ -1,0 +1,49 @@
+package test
+
+trait BaseTrait {
+  /** Some random integer. */
+  def someInt: Int
+
+  /** Another random integer. */
+  val anotherInt: Int
+
+  /** More integers, and mutable! */
+  var yetMoreInt: Int
+
+  /** The last integer. */
+  def theLastInt: Int
+}
+
+class BaseClass extends BaseTrait {
+  /** A doohickey. */
+  def doohickey: AnyRef
+
+  /** A whatzit. */
+  val whatzit: AnyRef
+
+  /** A fiddle. */
+  var fiddle: AnyRef
+
+  /** A surprise. */
+  def surprise: AnyRef
+}
+
+class Test extends BaseClass {
+  /**@inheritdoc */
+  val someInt    : Int = 7
+  /**@inheritdoc */
+  val anotherInt : Int = 77
+  /**@inheritdoc */
+  var yetMoreInt : Int = 777
+  /**@inheritdoc */
+  var theLastInt : Int = 7777
+
+  /**@inheritdoc */
+  val doohickey : AnyRef = new AnyRef
+  /**@inheritdoc */
+  val whatzit   : AnyRef = new AnyRef
+  /**@inheritdoc */
+  var fiddle    : AnyRef = new AnyRef
+  /**@inheritdoc */
+  var surprise  : AnyRef = new AnyRef
+}

--- a/test/scaladoc/run/t10621.check
+++ b/test/scaladoc/run/t10621.check
@@ -1,0 +1,25 @@
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(Some random integer), Text(.))))))))))
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(Some random integer), Text(.))))))))))
+
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(Another random integer), Text(.))))))))))
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(Another random integer), Text(.))))))))))
+
+Some(Body(List(Paragraph(Chain(List(Summary(Text(More integers, and mutable!))))))))
+Some(Body(List(Paragraph(Chain(List(Summary(Text(More integers, and mutable!))))))))
+
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(The last integer), Text(.))))))))))
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(The last integer), Text(.))))))))))
+
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(A doohickey), Text(.))))))))))
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(A doohickey), Text(.))))))))))
+
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(A whatzit), Text(.))))))))))
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(A whatzit), Text(.))))))))))
+
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(A fiddle), Text(.))))))))))
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(A fiddle), Text(.))))))))))
+
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(A surprise), Text(.))))))))))
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(A surprise), Text(.))))))))))
+
+Done.

--- a/test/scaladoc/run/t10621.scala
+++ b/test/scaladoc/run/t10621.scala
@@ -1,0 +1,31 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+import language._
+
+object Test extends ScaladocModelTest {
+  override def resourceFile = "t10621.scala"
+  override def scaladocSettings = ""
+  def testModel(root: Package) = {
+    import access._
+
+    val pkg = root._package("test")
+    val baseTrait    = pkg._trait("BaseTrait")
+    val baseClass    = pkg._class("BaseClass")
+    val test         = pkg._class("Test")
+
+    def printBoth(supr: DocTemplateEntity, name: String) = {
+      println(supr._member(name).comment.map(_.body))
+      println(test._member(name).comment.map(_.body))
+      println()
+    }
+
+    printBoth(baseTrait, "someInt")
+    printBoth(baseTrait, "anotherInt")
+    printBoth(baseTrait, "yetMoreInt")
+    printBoth(baseTrait, "theLastInt")
+    printBoth(baseClass, "doohickey")
+    printBoth(baseClass, "whatzit")
+    printBoth(baseClass, "fiddle")
+    printBoth(baseClass, "surprise")
+  }
+}


### PR DESCRIPTION
The field symbol doesn't override the superclass members; it's the responsibility of the getter to do that.

~The deprecated `getter` method in `Symbols.scala` stymied my ability to say `sym.getter.orElse(sym)`, so I got rid of it (and it's sibling `setter`, so it wouldn't be lonely). It's in `reflect.internal`, and it's been deprecated for quite a few releases, so I can't imagine anyone's using it.~ Nope, `compiler-interface` does. Woops.

I couldn't resist the urge to shoo away a gratuitous `var` in a related method. Apologies for the bloated diff.

Fixes scala/bug#10621.