### PR TITLE
Warn-unused uses type alias in nesting check

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1965,8 +1965,7 @@ self =>
           atPos(p.pos.start, p.pos.start, body.pos.end) {
             val t = Bind(name, body)
             body match {
-              case Ident(nme.WILDCARD) => t updateAttachment AtBoundIdentifierAttachment
-              case _ if !settings.warnUnusedPatVars => t updateAttachment AtBoundIdentifierAttachment
+              case Ident(nme.WILDCARD) if settings.warnUnusedPatVars => t updateAttachment AtBoundIdentifierAttachment
               case _ => t
             }
           }

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -540,6 +540,9 @@ trait TypeDiagnostics {
                 case NullaryMethodType(_) =>
                 case MethodType(_, _)     =>
                 case SingleType(_, _)     =>
+                case ConstantType(Constant(k: Type)) =>
+                  log(s"classOf $k referenced from $currentOwner")
+                  treeTypes += k
                 case _                    =>
                   log(s"${if (isAlias) "alias " else ""}$tp referenced from $currentOwner")
                   treeTypes += tp

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4277,11 +4277,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         }
       }
 
-      def typedBind(tree: Bind) = {
-        val name = tree.name
-        val body = tree.body
-        name match {
-          case name: TypeName  =>
+      def typedBind(tree: Bind) =
+        tree match {
+          case Bind(name: TypeName, body)  =>
             assert(body == EmptyTree, s"${context.unit} typedBind: ${name.debugString} ${body} ${body.getClass}")
             val sym =
               if (tree.symbol != NoSymbol) tree.symbol
@@ -4297,7 +4295,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
             tree setSymbol sym setType sym.tpeHK
 
-          case name: TermName  =>
+          case Bind(name: TermName, body)  =>
             val sym =
               if (tree.symbol != NoSymbol) tree.symbol
               else context.owner.newValue(name, tree.pos)
@@ -4327,7 +4325,6 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             tree setSymbol sym
             treeCopy.Bind(tree, name, body1) setSymbol sym setType body1.tpe
         }
-      }
 
       def typedArrayValue(tree: ArrayValue) = {
         val elemtpt1 = typedType(tree.elemtpt, mode)

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -68,6 +68,10 @@ trait StdAttachments {
    */
   case object AtBoundIdentifierAttachment extends PlainAttachment
 
+  /** Indicates that a `ValDef` was synthesized from a pattern definition, `val P(x)`.
+   */
+  case object PatVarDefAttachment extends PlainAttachment
+
   /** Identifies trees are either result or intermediate value of for loop desugaring.
    */
   case object ForAttachment extends PlainAttachment

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -732,11 +732,16 @@ abstract class TreeGen {
   def mkPatDef(pat: Tree, rhs: Tree)(implicit fresh: FreshNameCreator): List[ValDef] =
     mkPatDef(Modifiers(0), pat, rhs)
 
+  private def cpAtBoundAttachment(from: Tree, to: ValDef): to.type =
+    if (from.hasAttachment[AtBoundIdentifierAttachment.type]) to.updateAttachment(AtBoundIdentifierAttachment) else to
+  private def cpPatVarDefAttachments(from: Tree, to: ValDef): to.type =
+    cpAtBoundAttachment(from, to).updateAttachment(PatVarDefAttachment)
+
   /** Create tree for pattern definition <mods val pat0 = rhs> */
   def mkPatDef(mods: Modifiers, pat: Tree, rhs: Tree)(implicit fresh: FreshNameCreator): List[ValDef] = matchVarPattern(pat) match {
     case Some((name, tpt)) =>
       List(atPos(pat.pos union rhs.pos) {
-        ValDef(mods, name.toTermName, tpt, rhs)
+        cpAtBoundAttachment(pat, ValDef(mods, name.toTermName, tpt, rhs))
       })
 
     case None =>
@@ -778,9 +783,9 @@ abstract class TreeGen {
           ))
       }
       vars match {
-        case List((vname, tpt, pos)) =>
+        case List((vname, tpt, pos, original)) =>
           List(atPos(pat.pos union pos union rhs.pos) {
-            ValDef(mods, vname.toTermName, tpt, matchExpr)
+            cpPatVarDefAttachments(original, ValDef(mods, vname.toTermName, tpt, matchExpr))
           })
         case _ =>
           val tmp = freshTermName()
@@ -790,9 +795,9 @@ abstract class TreeGen {
                      tmp, TypeTree(), matchExpr)
             }
           var cnt = 0
-          val restDefs = for ((vname, tpt, pos) <- vars) yield atPos(pos) {
+          val restDefs = for ((vname, tpt, pos, original) <- vars) yield atPos(pos) {
             cnt += 1
-            ValDef(mods, vname.toTermName, tpt, Select(Ident(tmp), newTermName("_" + cnt)))
+            cpPatVarDefAttachments(original, ValDef(mods, vname.toTermName, tpt, Select(Ident(tmp), newTermName("_" + cnt))))
           }
           firstDef :: restDefs
       }
@@ -845,7 +850,7 @@ abstract class TreeGen {
    *  synthetic for all nodes that contain a variable position.
    */
   class GetVarTraverser extends Traverser {
-    val buf = new ListBuffer[(Name, Tree, Position)]
+    val buf = new ListBuffer[(Name, Tree, Position, Tree)]
 
     def namePos(tree: Tree, name: Name): Position =
       if (!tree.pos.isRange || name.containsName(nme.raw.DOLLAR)) tree.pos.focus
@@ -857,7 +862,7 @@ abstract class TreeGen {
 
     override def traverse(tree: Tree): Unit = {
       def seenName(name: Name)     = buf exists (_._1 == name)
-      def add(name: Name, t: Tree) = if (!seenName(name)) buf += ((name, t, namePos(tree, name)))
+      def add(name: Name, t: Tree) = if (!seenName(name)) buf += ((name, t, namePos(tree, name), tree))
       val bl = buf.length
 
       tree match {
@@ -888,10 +893,9 @@ abstract class TreeGen {
   }
 
   /** Returns list of all pattern variables, possibly with their types,
-   *  without duplicates
+   *  without duplicates, plus position and original tree.
    */
-  private def getVariables(tree: Tree): List[(Name, Tree, Position)] =
-    new GetVarTraverser apply tree
+  private def getVariables(tree: Tree): List[(Name, Tree, Position, Tree)] = (new GetVarTraverser)(tree)
 
   /** Convert all occurrences of (lower-case) variables in a pattern as follows:
    *    x                  becomes      x @ _

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -41,6 +41,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.DelambdafyTarget
     this.BackquotedIdentifierAttachment
     this.AtBoundIdentifierAttachment
+    this.PatVarDefAttachment
     this.ForAttachment
     this.SyntheticUnitAttachment
     this.SubpatternsAttachment

--- a/test/files/neg/warn-unused-patvars.check
+++ b/test/files/neg/warn-unused-patvars.check
@@ -1,12 +1,6 @@
 warn-unused-patvars.scala:9: warning: private val x in trait Boundings is never used
   private val x = 42                      // warn, sanity check
               ^
-warn-unused-patvars.scala:28: warning: local val x in method v is never used
-    val D(x) = d                          // warn, fixme
-         ^
-warn-unused-patvars.scala:32: warning: local val x in method w is never used
-    val D(x @ _) = d                      // warn, fixme (valdef pos is different)
-         ^
 error: No warnings can be incurred under -Xfatal-warnings.
-three warnings found
+one warning found
 one error found

--- a/test/files/neg/warn-unused-patvars.scala
+++ b/test/files/neg/warn-unused-patvars.scala
@@ -25,11 +25,11 @@ trait Boundings {
   }
 
   def v() = {
-    val D(x) = d                          // warn, fixme
+    val D(x) = d                          // no warn
     17
   }
   def w() = {
-    val D(x @ _) = d                      // warn, fixme (valdef pos is different)
+    val D(x @ _) = d                      // no warn
     17
   }
 

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -61,24 +61,6 @@ warn-unused-privates.scala:137: warning: private method x in class OtherNames is
 warn-unused-privates.scala:138: warning: private method y_= in class OtherNames is never used
   private def y_=(i: Int): Unit = ???
               ^
-warn-unused-privates.scala:153: warning: local val x in method f is never used
-    val C(x, y, Some(z)) = c              // warn
-          ^
-warn-unused-privates.scala:153: warning: local val y in method f is never used
-    val C(x, y, Some(z)) = c              // warn
-             ^
-warn-unused-privates.scala:153: warning: local val z in method f is never used
-    val C(x, y, Some(z)) = c              // warn
-                     ^
-warn-unused-privates.scala:161: warning: local val z in method h is never used
-    val C(x @ _, y @ _, z @ Some(_)) = c  // warn for z?
-                        ^
-warn-unused-privates.scala:166: warning: local val x in method v is never used
-    val D(x) = d                          // warn
-         ^
-warn-unused-privates.scala:170: warning: local val x in method w is never used
-    val D(x @ _) = d                      // warn, fixme (valdef pos is different)
-         ^
 warn-unused-privates.scala:97: warning: local var x in method f2 is never updated: consider using immutable val
     var x = 100 // warn about it being a var
         ^
@@ -103,6 +85,21 @@ warn-unused-privates.scala:216: warning: private class for your eyes only in obj
 warn-unused-privates.scala:232: warning: private class D in class nonprivate alias is enclosing is never used
   private class D extends C2   // warn
                 ^
+warn-unused-privates.scala:153: warning: pattern var x in method f is never used; `x@_' suppresses this warning
+    val C(x, y, Some(z)) = c              // warn
+          ^
+warn-unused-privates.scala:153: warning: pattern var y in method f is never used; `y@_' suppresses this warning
+    val C(x, y, Some(z)) = c              // warn
+             ^
+warn-unused-privates.scala:153: warning: pattern var z in method f is never used; `z@_' suppresses this warning
+    val C(x, y, Some(z)) = c              // warn
+                     ^
+warn-unused-privates.scala:161: warning: pattern var z in method h is never used; `z@_' suppresses this warning
+    val C(x @ _, y @ _, z @ Some(_)) = c  // warn for z?
+                        ^
+warn-unused-privates.scala:166: warning: pattern var x in method v is never used; `x@_' suppresses this warning
+    val D(x) = d                          // warn
+         ^
 warn-unused-privates.scala:201: warning: pattern var z in method f is never used; `z@_' suppresses this warning
     case z => "warn"
          ^
@@ -119,5 +116,5 @@ warn-unused-privates.scala:138: warning: parameter value i in method y_= is neve
   private def y_=(i: Int): Unit = ???
                   ^
 error: No warnings can be incurred under -Xfatal-warnings.
-40 warnings found
+39 warnings found
 one error found

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -100,6 +100,9 @@ warn-unused-privates.scala:121: warning: local type OtherThing is never used
 warn-unused-privates.scala:216: warning: private class for your eyes only in object not even using companion privates is never used
   private implicit class `for your eyes only`(i: Int) {  // warn
                          ^
+warn-unused-privates.scala:232: warning: private class D in class nonprivate alias is enclosing is never used
+  private class D extends C2   // warn
+                ^
 warn-unused-privates.scala:201: warning: pattern var z in method f is never used; `z@_' suppresses this warning
     case z => "warn"
          ^
@@ -116,5 +119,5 @@ warn-unused-privates.scala:138: warning: parameter value i in method y_= is neve
   private def y_=(i: Int): Unit = ???
                   ^
 error: No warnings can be incurred under -Xfatal-warnings.
-39 warnings found
+40 warnings found
 one error found

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -28,7 +28,7 @@ warn-unused-privates.scala:45: warning: private var v3 in trait Accessors is nev
 warn-unused-privates.scala:56: warning: private var s1 in class StableAccessors is never used
   private var s1: Int = 0 // warn
               ^
-warn-unused-privates.scala:57: warning: private setter of s2 in class StableAccessors is never used
+warn-unused-privates.scala:57: warning: private var s2 in class StableAccessors is never updated: consider using immutable val
   private var s2: Int = 0 // warn, never set
               ^
 warn-unused-privates.scala:58: warning: private var s3 in class StableAccessors is never used
@@ -79,7 +79,7 @@ warn-unused-privates.scala:166: warning: local val x in method v is never used
 warn-unused-privates.scala:170: warning: local val x in method w is never used
     val D(x @ _) = d                      // warn, fixme (valdef pos is different)
          ^
-warn-unused-privates.scala:97: warning: local var x in method f2 is never set: consider using immutable val
+warn-unused-privates.scala:97: warning: local var x in method f2 is never updated: consider using immutable val
     var x = 100 // warn about it being a var
         ^
 warn-unused-privates.scala:104: warning: private class Bar1 in object Types is never used

--- a/test/files/neg/warn-unused-privates.scala
+++ b/test/files/neg/warn-unused-privates.scala
@@ -224,3 +224,10 @@ class `no warn in patmat anonfun isDefinedAt` {
     case s => s.length        // no warn (used to warn case s => true in isDefinedAt)
   }
 }
+
+// this is the ordinary case, as AnyRef is an alias of Object
+class `nonprivate alias is enclosing` {
+  class C
+  type C2 = C
+  private class D extends C2   // warn
+}

--- a/test/files/neg/warn-unused-privates.scala
+++ b/test/files/neg/warn-unused-privates.scala
@@ -236,3 +236,10 @@ object `classof something` {
   private class intrinsically
   def f = classOf[intrinsically].toString()
 }
+
+trait `short comings` {
+  def f: Int = {
+    val x = 42
+    17
+  }
+}

--- a/test/files/neg/warn-unused-privates.scala
+++ b/test/files/neg/warn-unused-privates.scala
@@ -231,3 +231,8 @@ class `nonprivate alias is enclosing` {
   type C2 = C
   private class D extends C2   // warn
 }
+
+object `classof something` {
+  private class intrinsically
+  def f = classOf[intrinsically].toString()
+}

--- a/test/files/neg/warn-unused-privates.scala
+++ b/test/files/neg/warn-unused-privates.scala
@@ -167,7 +167,7 @@ trait Boundings {
     17
   }
   def w() = {
-    val D(x @ _) = d                      // warn, fixme (valdef pos is different)
+    val D(x @ _) = d                      // no warn
     17
   }
 
@@ -185,7 +185,7 @@ trait Forever {
     val t = Option((17, 42))
     for {
       ns <- t
-      (i, j) = ns                        // warn, fixme
+      (i, j) = ns                        // no warn
     } yield 42                           // val emitted only if needed, hence nothing unused
   }
 }

--- a/test/files/pos/t10394.flags
+++ b/test/files/pos/t10394.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Ywarn-unused:patvars

--- a/test/files/pos/t10394.scala
+++ b/test/files/pos/t10394.scala
@@ -1,0 +1,4 @@
+
+trait T {
+  def f = for (i: Int <- List(42)) yield i
+}

--- a/test/files/pos/t10623.flags
+++ b/test/files/pos/t10623.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xlint:unused

--- a/test/files/pos/t10623.scala
+++ b/test/files/pos/t10623.scala
@@ -1,0 +1,15 @@
+
+import language.higherKinds
+
+object `package` {
+  def refl[A]: A Is A = ???
+}
+
+sealed trait Is[A, B] { ab =>
+  def subst[F[_]](fa: F[A]): F[B]
+  final def flip: B Is A = {
+    type f[a] = a Is A
+    subst[f](refl)
+  }
+}
+


### PR DESCRIPTION
A reference from the body of a class is not a usage
of the class, but a reference to a local type alias of it
is a usage of the type alias.

Also don't warn about filter for refutable pattern.

Also `classOf[C]` is a usage of `C`.

Simplify message for a `var` that isn't mutated.

Fixes scala/bug#10623
Fixes scala/bug#10394
Fixes scala/bug#9058
Fixes scala/bug#10282
Fixes scala/bug#10448