### PR TITLE
cache the result of an expensive canonical file lookup

### DIFF
--- a/src/reflect/scala/reflect/io/PlainFile.scala
+++ b/src/reflect/scala/reflect/io/PlainFile.scala
@@ -22,6 +22,9 @@ class PlainFile(val givenPath: Path) extends AbstractFile {
   assert(path ne null)
 
   val file = givenPath.jfile
+
+  override lazy val canonicalPath = super.canonicalPath
+
   override def underlyingSource = Some(this)
 
   private val fpath = givenPath.toAbsolute
@@ -102,6 +105,8 @@ private[scala] class PlainNioFile(nioPath: java.nio.file.Path) extends AbstractF
   } catch {
     case _: UnsupportedOperationException => null
   }
+
+  override lazy val canonicalPath = super.canonicalPath
 
   override def underlyingSource  = Some(this)
 

--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -66,6 +66,8 @@ import ZipArchive._
 abstract class ZipArchive(override val file: JFile) extends AbstractFile with Equals {
   self =>
 
+  override lazy val canonicalPath = super.canonicalPath
+
   override def underlyingSource = Some(this)
   def isDirectory = true
   def lookupName(name: String, directory: Boolean) = unsupported()


### PR DESCRIPTION
for abstract files that can have a canonicalPath cache the result as this may be frequently called

Not expected this to be a significant change, but will benchmark