### PR TITLE
don't evaluate the head of a traversable twice in last

### DIFF
--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -428,13 +428,10 @@ trait TraversableLike[+A, +Repr] extends Any
     * @throws NoSuchElementException If the $coll is empty.
     */
   def last: A = {
-    var lst: A = null.asInstanceOf[A]
-    var hasElements = false
-    for (x <- this){
-      hasElements = true
+    var lst = head
+    for (x <- this)
       lst = x
-    }
-    if (hasElements) lst else throw new NoSuchElementException("last of empty traversable")
+    lst
   }
 
   /** Optionally selects the last element.

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -428,10 +428,13 @@ trait TraversableLike[+A, +Repr] extends Any
     * @throws NoSuchElementException If the $coll is empty.
     */
   def last: A = {
-    var lst = head
-    for (x <- this)
+    var lst: A = null.asInstanceOf[A]
+    var hasElements = false
+    for (x <- this){
+      hasElements = true
       lst = x
-    lst
+    }
+    if (hasElements) lst else throw new NoSuchElementException("last of empty traversable")
   }
 
   /** Optionally selects the last element.

--- a/src/library/scala/collection/TraversableViewLike.scala
+++ b/src/library/scala/collection/TraversableViewLike.scala
@@ -112,6 +112,18 @@ trait TraversableViewLike[+A,
 
       None
     }
+
+    override def last: B = {
+      // (Should be) better than allocating a Some for every element.
+      var empty = true
+      var result: B = null.asInstanceOf[B]
+      for (x <- this) {
+        empty = false
+        result = x
+      }
+      if (empty) throw new NoSuchElementException("last of empty traversable") else result
+    }
+
     override def lastOption: Option[B] = {
       // (Should be) better than allocating a Some for every element.
       var empty = true

--- a/test/files/run/view-headoption.check
+++ b/test/files/run/view-headoption.check
@@ -17,8 +17,6 @@ f3: Some(5)
 fail
 success
 fail
-success
-fail
 fail
 success
 fail

--- a/test/junit/scala/collection/TraversableLikeTest.scala
+++ b/test/junit/scala/collection/TraversableLikeTest.scala
@@ -66,4 +66,17 @@ class TraversableLikeTest {
     val frenchLowercase = Foo.mkFrenchLowercase()
     assertEquals("étrangeNomDeClasseMinuscules", frenchLowercase.stringPrefix)
   }
+
+  @Test
+  def test_SI10631 {
+    val baselist = List(1, 2)
+    var checklist = List.empty[Int]
+    val lst = baselist.view.map { x =>
+      checklist = x :: checklist
+      x
+    }
+
+    assertEquals(2, lst.last)
+    assertEquals(baselist.reverse, checklist)
+  }
 }


### PR DESCRIPTION
don't call head before looping over the traversable
fixes scala/bug#10631