### PR TITLE
improve construction of ClassBTypes

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -607,7 +607,7 @@ abstract class BTypes {
    * a missing info. In order not to crash the compiler unnecessarily, the inliner does not force
    * infos using `get`, but it reports inliner warnings for missing infos that prevent inlining.
    */
-  final case class ClassBType(internalName: InternalName)(cache: mutable.Map[InternalName, ClassBType]) extends RefBType {
+  final class ClassBType private (val internalName: InternalName) extends RefBType {
     /**
      * Write-once variable allows initializing a cyclic graph of infos. This is required for
      * nested classes. Example: for the definition `class A { class B }` we have
@@ -615,20 +615,19 @@ abstract class BTypes {
      *   B.info.nestedInfo.outerClass == A
      *   A.info.nestedClasses contains B
      */
-    private var _info: Either[NoClassBTypeInfo, ClassInfo] = null
+    // volatile is required to ensure no early initialisation in apply
+    // like classic double checked lock in java
+    @volatile private var _info: Either[NoClassBTypeInfo, ClassInfo] = null
 
     def info: Either[NoClassBTypeInfo, ClassInfo] = {
+      if (_info eq null)
+        // synchronization required to ensure the apply is finished
+        // which populates info. ClassBType doesnt escape apart from via the map
+        // and the object mutex is locked prior to insertion. See apply
+        this.synchronized()
       assert(_info != null, s"ClassBType.info not yet assigned: $this")
       _info
     }
-
-    def info_=(i: Either[NoClassBTypeInfo, ClassInfo]): Unit = {
-      assert(_info == null, s"Cannot set ClassBType.info multiple times: $this")
-      _info = i
-      checkInfoConsistency()
-    }
-
-    cache(internalName) = this
 
     private def checkInfoConsistency(): Unit = {
       if (info.isLeft) return
@@ -783,6 +782,15 @@ abstract class BTypes {
       } while (fcs == null)
       fcs
     }
+
+    // equallity and hashcode is based on internalName
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case o:ClassBType => internalName == o.internalName
+      case _ => false
+    }
+
+    // equallity and hashcode is based on internalName
+    override def hashCode(): Int = internalName.hashCode
   }
 
   object ClassBType {
@@ -804,6 +812,19 @@ abstract class BTypes {
       "scala/Null",
       "scala/Nothing"
     )
+    def unapply(cr:ClassBType) = Some(cr.internalName)
+
+    def apply(internalName: InternalName, cache: mutable.Map[InternalName, ClassBType])(init: (ClassBType) => Either[NoClassBTypeInfo, ClassInfo]) = {
+      val res = new ClassBType(internalName)
+      // synchronized s required to ensure proper initialisation if info.
+      // see comment on def info
+      res.synchronized {
+        cache(internalName) = res
+        res._info = init(res)
+        res.checkInfoConsistency()
+      }
+      res
+    }
   }
 
   /**

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -783,15 +783,6 @@ abstract class BTypes {
       } while (fcs == null)
       fcs
     }
-
-    // equallity and hashcode is based on internalName
-    override def equals(obj: scala.Any): Boolean = obj match {
-      case o:ClassBType => internalName == o.internalName
-      case _ => false
-    }
-
-    // equallity and hashcode is based on internalName
-    override def hashCode(): Int = internalName.hashCode
   }
 
   object ClassBType {

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
@@ -47,7 +47,7 @@ abstract class BTypesFromClassfile {
    */
   def classBTypeFromParsedClassfile(internalName: InternalName): ClassBType = {
     cachedClassBType(internalName).getOrElse{
-      ClassBType(internalName, classBTypeCacheFromClassfile){ res:ClassBType =>
+      ClassBType(internalName, false){ res:ClassBType =>
         byteCodeRepository.classNode(internalName) match {
           case Left(msg) => Left(NoClassBTypeInfoMissingBytecode(msg))
           case Right(c) => computeClassInfoFromClassNode(c, res)
@@ -61,7 +61,7 @@ abstract class BTypesFromClassfile {
    */
   def classBTypeFromClassNode(classNode: ClassNode): ClassBType = {
     cachedClassBType(classNode.name).getOrElse {
-      ClassBType(classNode.name, classBTypeCacheFromClassfile) { res: ClassBType =>
+      ClassBType(classNode.name, false) { res: ClassBType =>
         computeClassInfoFromClassNode(classNode, res)
       }
     }

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
@@ -46,25 +46,28 @@ abstract class BTypesFromClassfile {
    * be found in the `byteCodeRepository`, the `info` of the resulting ClassBType is undefined.
    */
   def classBTypeFromParsedClassfile(internalName: InternalName): ClassBType = {
-    cachedClassBType(internalName).getOrElse({
-      val res = ClassBType(internalName)(classBTypeCacheFromClassfile)
-      byteCodeRepository.classNode(internalName) match {
-        case Left(msg) => res.info = Left(NoClassBTypeInfoMissingBytecode(msg)); res
-        case Right(c)  => setClassInfoFromClassNode(c, res)
+    cachedClassBType(internalName).getOrElse{
+      ClassBType(internalName, classBTypeCacheFromClassfile){ res:ClassBType =>
+        byteCodeRepository.classNode(internalName) match {
+          case Left(msg) => Left(NoClassBTypeInfoMissingBytecode(msg))
+          case Right(c) => computeClassInfoFromClassNode(c, res)
+        }
       }
-    })
+    }
   }
 
   /**
    * Construct the [[ClassBType]] for a parsed classfile.
    */
   def classBTypeFromClassNode(classNode: ClassNode): ClassBType = {
-    cachedClassBType(classNode.name).getOrElse({
-      setClassInfoFromClassNode(classNode, ClassBType(classNode.name)(classBTypeCacheFromClassfile))
-    })
+    cachedClassBType(classNode.name).getOrElse {
+      ClassBType(classNode.name, classBTypeCacheFromClassfile) { res: ClassBType =>
+        computeClassInfoFromClassNode(classNode, res)
+      }
+    }
   }
 
-  private def setClassInfoFromClassNode(classNode: ClassNode, classBType: ClassBType): ClassBType = {
+  private def computeClassInfoFromClassNode(classNode: ClassNode, classBType: ClassBType): Right[Nothing, ClassInfo] = {
     val superClass = classNode.superName match {
       case null =>
         assert(classNode.name == ObjectRef.internalName, s"class with missing super type: ${classNode.name}")
@@ -119,8 +122,7 @@ abstract class BTypesFromClassfile {
 
     val interfaces: List[ClassBType] = classNode.interfaces.asScala.map(classBTypeFromParsedClassfile)(collection.breakOut)
 
-    classBType.info = Right(ClassInfo(superClass, interfaces, flags, Lazy.withoutLock(nestedClasses), Lazy.withoutLock(nestedInfo), inlineInfo))
-    classBType
+    Right(ClassInfo(superClass, interfaces, flags, Lazy.withoutLock(nestedClasses), Lazy.withoutLock(nestedInfo), inlineInfo))
   }
 
   /**

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -96,12 +96,12 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
       cachedClassBType(internalName) match {
         case Some(bType) =>
           if (currentRun.compiles(classSym))
-            assert(classBTypeCacheFromSymbol.contains(internalName), s"ClassBType for class being compiled was already created from a classfile: ${classSym.fullName}")
+            assert(bType fromSymbol, s"ClassBType for class being compiled was already created from a classfile: ${classSym.fullName}")
           bType
         case None =>
           // The new ClassBType is added to the map via its apply, before we set its info. This
           // allows initializing cyclic dependencies, see the comment on variable ClassBType._info.
-          ClassBType(internalName, classBTypeCacheFromSymbol) { res:ClassBType =>
+          ClassBType(internalName, true) { res:ClassBType =>
             if (completeSilentlyAndCheckErroneous(classSym))
               Left(NoClassBTypeInfoClassSymbolInfoFailedSI9111(classSym.fullName))
             else computeClassInfo(classSym, res)
@@ -624,7 +624,7 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
     assert(isTopLevelModuleClass(moduleClassSym), s"not a top-level module class: $moduleClassSym")
     val internalName = moduleClassSym.javaBinaryNameString.stripSuffix(nme.MODULE_SUFFIX_STRING)
     cachedClassBType(internalName).getOrElse {
-      ClassBType(internalName, classBTypeCacheFromSymbol) { c: ClassBType =>
+      ClassBType(internalName, true) { c: ClassBType =>
         val shouldBeLazy = moduleClassSym.isJavaDefined || !currentRun.compiles(moduleClassSym)
         val nested = Lazy.withLockOrEager(shouldBeLazy, exitingPickler(memberClassesForInnerClassTable(moduleClassSym)) map classBTypeFromSymbol)
         Right(ClassInfo(
@@ -641,7 +641,7 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
   def beanInfoClassClassBType(mainClass: Symbol): ClassBType = {
     val internalName = mainClass.javaBinaryNameString + "BeanInfo"
     cachedClassBType(internalName).getOrElse {
-      ClassBType(internalName, classBTypeCacheFromSymbol) { c: ClassBType =>
+      ClassBType(internalName, true) { c: ClassBType =>
         Right(ClassInfo(
           superClass = Some(sbScalaBeanInfoRef),
           interfaces = Nil,

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
@@ -30,8 +30,7 @@ class BTypesFromClassfileTest extends BytecodeTesting {
   }
 
   def clearCache() = {
-    bTypes.classBTypeCacheFromSymbol.clear()
-    bTypes.classBTypeCacheFromClassfile.clear()
+    bTypes.classBTypeCache.clear()
   }
 
   def sameBType(fromSym: ClassBType, fromClassfile: ClassBType, checked: Set[InternalName] = Set.empty): Set[InternalName] = {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
@@ -36,7 +36,7 @@ class BTypesFromClassfileTest extends BytecodeTesting {
   def sameBType(fromSym: ClassBType, fromClassfile: ClassBType, checked: Set[InternalName] = Set.empty): Set[InternalName] = {
     if (checked(fromSym.internalName)) checked
     else {
-      assert(fromSym == fromClassfile, s"$fromSym != $fromClassfile")
+      assert(fromSym.internalName == fromClassfile.internalName, s"${fromSym.internalName} != ${fromClassfile.internalName}")
       sameInfo(fromSym.info.get, fromClassfile.info.get, checked + fromSym.internalName)
     }
   }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
@@ -24,8 +24,7 @@ class CallGraphTest extends BytecodeTesting {
 
 
   compiler.keepPerRunCachesAfterRun(List(
-    bTypes.classBTypeCacheFromSymbol,
-    bTypes.classBTypeCacheFromClassfile,
+    bTypes.classBTypeCache,
     postProcessor.byteCodeRepository.compilingClasses,
     postProcessor.byteCodeRepository.parsedClasses,
     postProcessor.callGraph.callsites))

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
@@ -20,8 +20,7 @@ class InlineInfoTest extends BytecodeTesting {
   override def compilerArgs = "-opt:l:inline -opt-inline-from:**"
 
   compiler.keepPerRunCachesAfterRun(List(
-    bTypes.classBTypeCacheFromSymbol,
-    bTypes.classBTypeCacheFromClassfile,
+    bTypes.classBTypeCache,
     postProcessor.byteCodeRepository.compilingClasses,
     postProcessor.byteCodeRepository.parsedClasses))
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerIllegalAccessTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerIllegalAccessTest.scala
@@ -26,8 +26,7 @@ class InlinerIllegalAccessTest extends BytecodeTesting {
     throw new AssertionError(textify(i))
 
   def clearClassBTypeCaches(): Unit = {
-    classBTypeCacheFromSymbol.clear()
-    classBTypeCacheFromClassfile.clear()
+    classBTypeCache.clear()
   }
 
   @Test

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -26,8 +26,7 @@ class InlinerTest extends BytecodeTesting {
 
 
   compiler.keepPerRunCachesAfterRun(List(
-    bTypes.classBTypeCacheFromSymbol,
-    bTypes.classBTypeCacheFromClassfile,
+    bTypes.classBTypeCache,
     postProcessor.byteCodeRepository.compilingClasses,
     postProcessor.byteCodeRepository.parsedClasses,
     postProcessor.callGraph.callsites))


### PR DESCRIPTION
change spun out of #6124 to aid review

initialise ClassBType info field as part of construction
ban external mutation of info
provide memory barriers for late initialised info field