### PR TITLE
[SUPERSEDED] Class literal is a usage

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -533,6 +533,9 @@ trait TypeDiagnostics {
                 case NullaryMethodType(_) =>
                 case MethodType(_, _)     =>
                 case SingleType(_, _)     =>
+                case ConstantType(Constant(k: Type)) =>
+                  log(s"classOf $k referenced from $currentOwner")
+                  treeTypes += k
                 case _                    =>
                   log(s"$tp referenced from $currentOwner")
                   treeTypes += tp

--- a/test/files/neg/warn-unused-privates.scala
+++ b/test/files/neg/warn-unused-privates.scala
@@ -224,3 +224,8 @@ class `no warn in patmat anonfun isDefinedAt` {
     case s => s.length        // no warn (used to warn case s => true in isDefinedAt)
   }
 }
+
+object `classof something` {
+  private class intrinsically
+  def f = classOf[intrinsically].toString()
+}


### PR DESCRIPTION
Notice ConstantType and record it under -Ywarn-unused.

Fixes scala/bug#9058