### PR TITLE
Expand check for value-class-wrapping-value-class errors to include parents

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1433,7 +1433,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               case Some(acc) if acc.isProtectedLocal =>
                 context.error(paramAccessor.pos, "value class parameter must not be protected[this]")
               case Some(acc) =>
-                if (acc.tpe.typeSymbol.isDerivedValueClass)
+                /* check all base classes, since derived value classes might lurk in refinement parents */
+                if (acc.tpe.typeSymbol.baseClasses exists (_.isDerivedValueClass))
                   context.error(acc.pos, "value class may not wrap another user-defined value class")
                 checkEphemeral(clazz, body filterNot (stat => stat.symbol != null && stat.symbol.accessedOrSelf == paramAccessor))
             }

--- a/test/files/neg/t10530.check
+++ b/test/files/neg/t10530.check
@@ -1,0 +1,25 @@
+t10530.scala:1: error: value class may not wrap another user-defined value class
+class X(val u: Any with X) extends AnyVal
+            ^
+t10530.scala:2: error: value class may not wrap another user-defined value class
+class Y(val u: Y with Y) extends AnyVal
+            ^
+t10530.scala:3: error: value class may not wrap another user-defined value class
+class Z(val u: Z with String) extends AnyVal
+            ^
+t10530.scala:4: error: value class may not wrap another user-defined value class
+class U(val u: U with Int) extends AnyVal
+            ^
+t10530.scala:6: error: value class may not wrap another user-defined value class
+class W(val u: Z with U) extends AnyVal
+            ^
+t10530.scala:7: error: value class may not wrap another user-defined value class
+class R(val u: Z {}) extends AnyVal
+            ^
+t10530.scala:9: error: value class may not wrap another user-defined value class
+class Q(val u: AnyRef with X) extends AnyVal
+            ^
+t10530.scala:12: error: value class may not wrap another user-defined value class
+class B[T <: A](val a: T) extends AnyVal
+                    ^
+8 errors found

--- a/test/files/neg/t10530.scala
+++ b/test/files/neg/t10530.scala
@@ -1,0 +1,12 @@
+class X(val u: Any with X) extends AnyVal
+class Y(val u: Y with Y) extends AnyVal
+class Z(val u: Z with String) extends AnyVal
+class U(val u: U with Int) extends AnyVal
+
+class W(val u: Z with U) extends AnyVal
+class R(val u: Z {}) extends AnyVal
+
+class Q(val u: AnyRef with X) extends AnyVal
+
+class A(val a: Int) extends AnyVal
+class B[T <: A](val a: T) extends AnyVal


### PR DESCRIPTION
Refinement types were getting a pass here because the check didn't look at parents, so a type like `Any with X`, which erases to `X`, wasn't caught.

Fixes scala/bug#10530.