### PR TITLE
Remove reference to wall-time

### DIFF
--- a/src/library/scala/concurrent/duration/Deadline.scala
+++ b/src/library/scala/concurrent/duration/Deadline.scala
@@ -19,7 +19,7 @@ package scala.concurrent.duration
  *
  * Its main purpose is to manage repeated attempts to achieve something (like
  * awaiting a condition) by offering the methods `hasTimeLeft` and `timeLeft`.  All
- * durations are measured according to `System.nanoTime` aka wall-time; this
+ * durations are measured according to `System.nanoTime`; this
  * does not take into account changes to the system clock (such as leap
  * seconds).
  */


### PR DESCRIPTION
Calling `System.nanoTime` "aka wall-time" is confusing, as it (as the rest of the comment correctly mentions) it does not take into account changes to the clock - indeed, the [upstream docs](https://docs.oracle.com/javase/9/docs/api/java/lang/System.html#nanoTime--) mention it is "not related to any other notion of system or wall-clock time" (though of course it does deal with 'wall clock' time as opposed to 'cpu time', but it might be best to leave that implicit).