### PR TITLE
optimizations in the specialization phase

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -309,9 +309,9 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
 
   private def specializedSubclasses(cls: Symbol): List[Symbol] = {
     exitingSpecialize(cls.info) // the `transformInfo` method of specialization adds specialized subclasses to the `specializedClass` map
-    specializeTypes.specializedClass.collect({
-      case ((`cls`, _), specCls) => specCls
-    }).toList
+    val map = specializeTypes.specializedClass.getOrNull(cls)
+    if (map == null) Nil
+    else map.values.toList
   }
 
   // scala/Tuple3 -> MethodNameAndType(<init>,(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V)

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -201,8 +201,8 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     override def run(): Unit = {
       super.run()
       exitingSpecialize {
-        FunctionClass.seq.map(_.info)
-        TupleClass.seq.map(_.info)
+        FunctionClass.seq.take(MaxFunctionAritySpecialized + 1).foreach(_.info)
+        TupleClass.seq.take(MaxTupleAritySpecialized).foreach(_.info)
       }
 
       // Remove the final modifier and @inline annotation from anything in the

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1676,8 +1676,11 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
           val specMembers = makeSpecializedMembers(tree.symbol.enclClass) ::: (implSpecClasses(body) map localTyper.typed)
           if (!symbol.isPackageClass)
             (new CollectMethodBodies)(tree)
-          val parents1 = map2(currentOwner.info.parents, parents)((tpe, parent) =>
-            TypeTree(tpe) setPos parent.pos)
+          val parents1 = map2Conserve(parents, currentOwner.info.parents)((parent, tpe) =>
+            parent match {
+              case tt @ TypeTree() if tpe eq tt.tpe => tt
+              case _ => TypeTree(tpe) setPos parent.pos
+            })
 
           treeCopy.Template(tree,
             parents1    /*currentOwner.info.parents.map(tpe => TypeTree(tpe) setPos parents.head.pos)*/ ,

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -8,7 +8,7 @@ package tools.nsc
 package transform
 
 import scala.tools.nsc.symtab.Flags
-import scala.collection.{ mutable, immutable }
+import scala.collection.{immutable, mutable}
 import scala.annotation.tailrec
 
 /** Specialize code on types.
@@ -1454,12 +1454,23 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     && originalClass(clazz).parentSymbols.exists(p => hasSpecializedParams(p) && !p.isTrait)
   )
 
-  def specializeCalls(unit: CompilationUnit) = new TypingTransformer(unit) {
+  class SpecializationTransformer(unit: CompilationUnit) extends TypingTransformer(unit) {
+
+    override def transformUnit(unit: CompilationUnit): Unit = if (!settings.nospecialization) {
+      informProgress("specializing " + unit)
+      try {
+        exitingSpecialize(super.transformUnit(unit))
+      } catch {
+        case te: TypeError =>
+          reporter.error(te.pos, te.msg)
+      }
+    }
+
     /** Map a specializable method to its rhs, when not deferred. */
-    val body = perRunCaches.newMap[Symbol, Tree]()
+    val body = new mutable.AnyRefMap[Symbol, Tree]()
 
     /** Map a specializable method to its value parameter symbols. */
-    val parameters = perRunCaches.newMap[Symbol, List[Symbol]]()
+    val parameters = new mutable.AnyRefMap[Symbol, List[Symbol]]()
 
     /** Collect method bodies that are concrete specialized methods.
      */
@@ -1502,18 +1513,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       }
     }
 
-    def reportError[T](body: =>T)(handler: TypeError => T): T =
-      try body
-      catch {
-        case te: TypeError =>
-          reporter.error(te.pos, te.msg)
-          handler(te)
-      }
-
-    override def transform(tree: Tree): Tree =
-      reportError { transform1(tree) } {_ => tree}
-
-    def transform1(tree: Tree) = {
+    override def transform(tree: Tree): Tree = {
       val symbol = tree.symbol
       /* The specialized symbol of 'tree.symbol' for tree.tpe, if there is one */
       def specSym(qual: Tree): Symbol = {
@@ -1602,7 +1602,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
             val found = specializedType(tpt.tpe)
             if (found.typeSymbol ne tpt.tpe.typeSymbol) { // the ctor can be specialized
               val inst = New(found, transformTrees(args): _*)
-              reportError(localTyper.typedPos(tree.pos)(inst))(_ => super.transform(tree))
+              localTyper.typedPos(tree.pos)(inst)
             }
             else
               super.transform(tree)
@@ -1693,13 +1693,13 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
             if (symbol.isPrimaryConstructor)
               localTyper.typedPos(symbol.pos)(deriveDefDef(tree)(_ => Block(List(t), Literal(Constant(())))))
             else // duplicate the original constructor
-              reportError(duplicateBody(ddef, info(symbol).target))(_ => ddef)
+              duplicateBody(ddef, info(symbol).target)
           }
           else info(symbol) match {
             case Implementation(target) =>
               assert(body.isDefinedAt(target), "sym: " + symbol.fullName + " target: " + target.fullName)
               // we have an rhs, specialize it
-              val tree1 = reportError(duplicateBody(ddef, target))(_ => ddef)
+              val tree1 = duplicateBody(ddef, target)
               debuglog("implementation: " + tree1)
               deriveDefDef(tree1)(transform)
 
@@ -1707,7 +1707,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
               logResult("constraints")(satisfiabilityConstraints(typeEnv(symbol))) match {
                 case Some(constraint) if !target.isDeferred =>
                   // we have an rhs, specialize it
-                  val tree1 = reportError(duplicateBody(ddef, target, constraint))(_ => ddef)
+                  val tree1 = duplicateBody(ddef, target, constraint)
                   debuglog("implementation: " + tree1)
                   deriveDefDef(tree1)(transform)
                 case _ =>
@@ -1738,21 +1738,13 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
               })
               debuglog("created special overload tree " + t)
               debuglog("created " + t)
-              reportError {
-                localTyper.typed(t)
-              } {
-                _ => super.transform(tree)
-              }
+              localTyper.typed(t)
 
             case fwd @ Forward(_) =>
               debuglog("forward: " + fwd + ", " + ddef)
               val rhs1 = forwardCall(tree.pos, gen.mkAttributedRef(symbol.owner.thisType, fwd.target), vparamss)
               debuglog("-->d completed forwarder to specialized overload: " + fwd.target + ": " + rhs1)
-              reportError {
-                localTyper.typed(deriveDefDef(tree)(_ => rhs1))
-              } {
-                _ => super.transform(tree)
-              }
+              localTyper.typed(deriveDefDef(tree)(_ => rhs1))
 
             case SpecializedAccessor(target) =>
               val rhs1 = if (symbol.isGetter)
@@ -2037,12 +2029,5 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     map2(fun.info.paramTypes, vparams)((tp, arg) => gen.maybeMkAsInstanceOf(Ident(arg), tp, arg.tpe))
   )
 
-  class SpecializationTransformer(unit: CompilationUnit) extends Transformer {
-    informProgress("specializing " + unit)
-    override def transform(tree: Tree) = {
-      if (settings.nospecialization) tree
-      else exitingSpecialize(specializeCalls(unit).transform(tree))
-    }
-  }
   object SpecializedSuperConstructorCallArgument
 }

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -582,6 +582,8 @@ trait Definitions extends api.StandardDefinitions {
     object VarArityClass
 
     val MaxTupleArity, MaxProductArity, MaxFunctionArity = 22
+    // A unit test checks these are kept in synch with the library.
+    val MaxTupleAritySpecialized, MaxProductAritySpecialized, MaxFunctionAritySpecialized = 2
 
     lazy val ProductClass          = new VarArityClass("Product", MaxProductArity, countFrom = 1, init = Some(UnitClass))
     lazy val TupleClass            = new VarArityClass("Tuple", MaxTupleArity, countFrom = 1)

--- a/test/junit/scala/tools/nsc/transform/SpecializationTest.scala
+++ b/test/junit/scala/tools/nsc/transform/SpecializationTest.scala
@@ -1,0 +1,45 @@
+package scala.tools.nsc.transform
+
+import org.junit.Assert.assertEquals
+import org.junit.{Assert, Test}
+
+import scala.tools.nsc.symtab.SymbolTableForUnitTesting
+
+class SpecializationTest {
+  object symbolTable extends SymbolTableForUnitTesting
+
+  @Test def testHardCodedAssumptionsAboutTupleAndFunction(): Unit = {
+    // The specialization phase always runs its info transform on the specialized Function and Tuple types
+    // so that the later phases can see them, even with the optimization in the specialization info transform
+    // that makes it a no-op after the global phase has passed specialize.
+    //
+    // Initially, we just called `exitingSpecialize { TupleClass.seq.map(_.info); Function.seq.map(_.info) }`
+    // but this was wasteful, as it loaded the seldom used, high-arity Tuple and Function classes, some of which
+    // are pretty big in bytecode!
+    //
+    // So we know bake the knowledge about the max arity for which specialization is used into that code.
+    // This test asserts the assumption still holds.
+    import symbolTable.definitions._
+
+    for (i <- (0 to MaxFunctionArity)) {
+      val cls = FunctionClass.apply(i)
+      val actual = cls.typeParams.exists(_.isSpecialized)
+      val expected = i <= MaxFunctionAritySpecialized
+      assertEquals(cls.toString, expected, actual)
+    }
+
+    for (i <- (1 to MaxTupleArity)) {
+      val cls = TupleClass.apply(i)
+      val actual = cls.typeParams.exists(_.isSpecialized)
+      val expected = i <= MaxTupleAritySpecialized
+      assertEquals(cls.toString, expected, actual)
+    }
+
+    for (i <- (1 to MaxProductArity)) {
+      val cls = ProductClass.apply(i)
+      val actual = cls.typeParams.exists(_.isSpecialized)
+      val expected = i <= MaxProductAritySpecialized
+      assertEquals(cls.toString, expected, actual)
+    }
+  }
+}


### PR DESCRIPTION
 - Use an internal `Map` for bookkeeping as intended, avoiding iterating through all bindings.
 - Limit eager loading of `TupleN` and `FunctionN` to the once we know are actually specialized.
 - Conserve trees through identity transforms
 - Remove use of error handling combinator at each level of recursion in the transformer, let's just rely on the exception being reported at the top level now that specialization has matured.