### PR TITLE
Narrow scope of sensibility check for equals

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1084,7 +1084,12 @@ abstract class RefChecks extends Transform {
           nonSensiblyNew()
         else if (isNew(other) && (receiver.isEffectivelyFinal || isReferenceOp))   // object X ; X == new Y
           nonSensiblyNew()
-        else if (receiver.isEffectivelyFinal && !(receiver isSubClass actual) && !actual.isRefinementClass) {  // object X, Y; X == Y
+        else if (!(receiver.isRefinementClass || actual.isRefinementClass) &&
+                 // Rule out receiver of refinement class because checking receiver.isEffectivelyFinal does not work for them.
+                 // (the owner of the refinement depends on where the refinement was inferred, which has no bearing on the finality of the intersected classes)
+                 // TODO: should we try to decide finality for refinements?
+                 // TODO: Also, is subclassing really the right relationship to detect non-sensible equals between "effectively final" types??
+                 receiver.isEffectivelyFinal && !(receiver isSubClass actual)) {  // object X, Y; X == Y
           if (isEitherNullable)
             nonSensible("non-null ", false)
           else

--- a/test/files/pos/t10644.flags
+++ b/test/files/pos/t10644.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t10644/Objs_1.scala
+++ b/test/files/pos/t10644/Objs_1.scala
@@ -1,0 +1,8 @@
+case object A ; case object B
+object C {
+// inferred refinement type `Product with Serializable` of val `objs` has owner `C`
+// (and thus the receiver of the equality check was seen as effectivelyFinal,
+// which then boosted our confidence in being able to say something about how
+// final types compare for equality...)
+  val objs = Seq(A, B)
+}

--- a/test/files/pos/t10644/Test_2.scala
+++ b/test/files/pos/t10644/Test_2.scala
@@ -1,0 +1,6 @@
+object Test {
+  // Should not result in the spurious warning:
+  //   comparing non-null values of types Product with Serializable
+  //   and A.type using `==' will always yield false
+  assert(C.objs.head == A)
+}


### PR DESCRIPTION
I have my doubts whether it's correct, but at least it's less ambitious in its erring.

Fixes scala/bug#10644