### PR TITLE
Backtick underscore in REPL

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -287,7 +287,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
 
   def backticked(s: String): String = (
     (s split '.').toList map {
-      case "_"                               => "_"
+      case "_"                               => "`_`"
       case s if nme.keywords(newTermName(s)) => s"`$s`"
       case s                                 => s
     } mkString "."
@@ -314,8 +314,10 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
   /** For class based repl mode we use an .INSTANCE accessor. */
   val readInstanceName = if (isClassBased) ".INSTANCE" else ""
   def translateOriginalPath(p: String): String = {
-    val readName = java.util.regex.Matcher.quoteReplacement(sessionNames.read)
-    p.replaceFirst(readName, readName + readInstanceName)
+    if (isClassBased) {
+      val readName = java.util.regex.Matcher.quoteReplacement(sessionNames.read)
+      p.replaceFirst(readName, readName + readInstanceName)
+    } else p
   }
   def flatPath(sym: Symbol): String      = flatOp shift sym.javaClassName
 


### PR DESCRIPTION
Since underscore can be a member, it must be backticked
in a path such as `X._`.

Probably the underscore should be disallowed in the related ticket.

Also note the behavior in an import path, where underscore is a special identifier even if backticked.

The underscore was specifically not backticked; possibly there was a change in behavior?

Fixes scala/bug#10645