### PR TITLE
Import selector respects backquotes [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -677,7 +677,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
         val qual = names.tail.init.foldLeft(Ident(names.head): Tree)(Select(_, _))
         val lastname = names.last
         val selector = lastname match {
-          case nme.WILDCARD => ImportSelector(lastname, lastnameOffset, null, -1)
+          case nme.WILDCARD => ImportSelector.wildAt(lastnameOffset)
           case _            => ImportSelector(lastname, lastnameOffset, lastname, lastnameOffset)
         }
         List(atPos(pos)(Import(qual, List(selector))))

--- a/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
@@ -484,12 +484,12 @@ trait MacroAnnotationNamers { self: Analyzer =>
         var selectors = imp.tree.selectors
         def current = selectors.head
         while (selectors != Nil && result == NoSymbol) {
-          if (current.rename == name.toTermName)
+          if (current.introduces(name.toTermName))
             result = nonLocalMember(pre, if (name.isTypeName) current.name.toTypeName else current.name)
           else if (selectors.head.name == name.toTermName)
-                 renamed = true
-          else if (selectors.head.name == nme.WILDCARD && !renamed)
-                 result = nonLocalMember(pre, name)
+            renamed = true
+          else if (current.isWildcard && !renamed)
+            result = nonLocalMember(pre, name)
           if (result == NoSymbol)
             selectors = selectors.tail
         }

--- a/src/reflect/scala/reflect/api/StandardLiftables.scala
+++ b/src/reflect/scala/reflect/api/StandardLiftables.scala
@@ -154,7 +154,10 @@ trait StandardLiftables { self: Universe =>
       case Apply(ScalaDot(stdnme.Symbol), List(Literal(Constant(name: String)))) => scala.Symbol(name)
     }
 
-    implicit def unliftName[T <: Name : ClassTag]: Unliftable[T] = Unliftable[T] { case Ident(name: T) => name; case Bind(name: T, Ident(stdnme.WILDCARD)) => name }
+    implicit def unliftName[T <: Name : ClassTag]: Unliftable[T] = Unliftable[T] {
+      case Ident(name: T)                        => name
+      case Bind(name: T, Ident(stdnme.WILDCARD)) => name
+    }
     implicit def unliftType: Unliftable[Type]                    = Unliftable[Type] { case tt: TypeTree if tt.tpe != null => tt.tpe }
     implicit def unliftConstant: Unliftable[Constant]            = Unliftable[Constant] { case Literal(const) => const }
 

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -758,7 +758,7 @@ trait Trees { self: Universe =>
    */
   val ImportSelector: ImportSelectorExtractor
 
-  /** An extractor class to create and pattern match with syntax `ImportSelector(name:, namePos, rename, renamePos)`.
+  /** An extractor class to create and pattern match with syntax `ImportSelector(name, namePos, rename, renamePos)`.
    *  This is not an AST node, it is used as a part of the `Import` node.
    *  @group Extractors
    */
@@ -788,6 +788,18 @@ trait Trees { self: Universe =>
      *  Is equal to -1 is the position is unknown.
      */
     def renamePos: Int
+
+    /** Does the selector mask or hide a name? `import x.{y => _}` */
+    def isMask: Boolean
+
+    /** Does the selector introduce a specific name? `import a.b, x.{y => z}` */
+    def isSpecific: Boolean
+
+    /** Does the selector introduce a specific name by rename? `x.{y => z}` */
+    def isRename: Boolean
+
+    /** Is the selector a wildcard import that introduces all available names? `import x._` */
+    def isWildcard: Boolean
   }
 
   /** Import clause
@@ -812,11 +824,11 @@ trait Trees { self: Universe =>
    *  Selectors are a list of ImportSelectors, which conceptually are pairs of names (from, to).
    *  The last (and maybe only name) may be a nme.WILDCARD. For instance:
    *
-   *    import qual.{x, y => z, _}
+   *    import qual.{w => _, x, y => z, _}
    *
    *  Would be represented as:
    *
-   *    Import(qual, List(("x", "x"), ("y", "z"), (WILDCARD, null)))
+   *    Import(qual, List(("w", WILDCARD), ("x", "x"), ("y", "z"), (WILDCARD, null)))
    *
    *  The symbol of an `Import` is an import symbol @see Symbol.newImport.
    *  It's used primarily as a marker to check that the import has been typechecked.

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -256,20 +256,18 @@ trait Printers extends api.Printers { self: SymbolTable =>
 
     protected def printImport(tree: Import, resSelect: => String) = {
       val Import(expr, selectors) = tree
-      // Is this selector renaming a name (i.e, {name1 => name2})
-      def isNotRename(s: ImportSelector): Boolean =
-        s.name == nme.WILDCARD || s.name == s.rename
 
       def selectorToString(s: ImportSelector): String = {
-        val from = quotedName(s.name)
-        if (isNotRename(s)) from
-        else from + "=>" + quotedName(s.rename)
+        def selectorName(n: Name): String = if (s.isWildcard) nme.WILDCARD.decoded else quotedName(n)
+        val from = selectorName(s.name)
+        if (s.isRename || s.isMask) from + "=>" + selectorName(s.rename)
+        else from
       }
       print("import ", resSelect, ".")
       selectors match {
         case List(s) =>
           // If there is just one selector and it is not renaming a name, no braces are needed
-          if (isNotRename(s)) print(selectorToString(s))
+          if (!s.isRename) print(selectorToString(s))
           else print("{", selectorToString(s), "}")
         // If there is more than one selector braces are always needed
         case many =>

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -852,11 +852,14 @@ abstract class TreeGen {
       case Typed(Ident(x), tpt) if x.toTermName == nme.WILDCARD => Some(tpt)
       case _                                                    => None
     }
-    tree match {
+    (tree match {
       case Ident(name)             => Some((name, TypeTree()))
       case Bind(name, body)        => wildType(body) map (x => (name, x))
       case Typed(Ident(name), tpt) => Some((name, tpt))
       case _                       => None
+    }).filter {
+      case (nme.WILDCARD, _) => false
+      case _                 => true
     }
   }
 

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -478,10 +478,21 @@ trait Trees extends api.Trees {
       }
   }
 
-  case class ImportSelector(name: Name, namePos: Int, rename: Name, renamePos: Int) extends ImportSelectorApi
+  case class ImportSelector(name: Name, namePos: Int, rename: Name, renamePos: Int) extends ImportSelectorApi {
+    assert(name == nme.WILDCARD && rename == null || rename != null)
+    def isWildcard = name == nme.WILDCARD && rename == null
+    def isMask = name != nme.WILDCARD && rename == nme.WILDCARD
+    def isSpecific = !isWildcard
+    def isRename = rename != null && rename != nme.WILDCARD && name != rename
+    private def isLiteralWildcard = name == nme.WILDCARD && rename == nme.WILDCARD
+    def introduces(target: Name) =
+      if (target == nme.WILDCARD) isLiteralWildcard
+      else target != null && target == rename
+  }
   object ImportSelector extends ImportSelectorExtractor {
     val wild     = ImportSelector(nme.WILDCARD, -1, null, -1)
     val wildList = List(wild) // OPT This list is shared for performance.
+    def wildAt(pos: Int) = ImportSelector(nme.WILDCARD, pos, null, -1)
   }
 
   case class Import(expr: Tree, selectors: List[ImportSelector])

--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -211,10 +211,10 @@ trait MemberHandlers {
       importableMembers(exitingTyper(targetType)).filterNot(isFlattenedSymbol).toList
 
     // non-wildcard imports
-    private def individualSelectors = selectors filter analyzer.isIndividualImport
+    private def individualSelectors = selectors.filter(_.isSpecific)
 
     /** Whether this import includes a wildcard import */
-    val importsWildcard = selectors exists analyzer.isWildcardImport
+    val importsWildcard = selectors.exists(_.isWildcard)
 
     def implicitSymbols = importedSymbols filter (_.isImplicit)
     def importedSymbols = individualSymbols ++ wildcardSymbols

--- a/test/files/neg/t10641.check
+++ b/test/files/neg/t10641.check
@@ -1,0 +1,4 @@
+t10641.scala:6: error: ';' expected but '=>' found.
+import collection._ => `not a rename, just dross`
+                    ^
+one error found

--- a/test/files/neg/t10641.scala
+++ b/test/files/neg/t10641.scala
@@ -1,0 +1,8 @@
+
+// previously ignored
+// progressed Wildcard import cannot be renamed
+// now ';' expected but '=>' found.
+
+import collection._ => `not a rename, just dross`
+
+

--- a/test/files/neg/t6426.check
+++ b/test/files/neg/t6426.check
@@ -1,0 +1,4 @@
+t6426.scala:4: error: not found: value _
+  def f = `_`.Buffer(0)
+          ^
+one error found

--- a/test/files/neg/t6426.scala
+++ b/test/files/neg/t6426.scala
@@ -1,0 +1,5 @@
+
+trait T {
+  import collection.{mutable => _, _}
+  def f = `_`.Buffer(0)
+}

--- a/test/files/neg/t7691.check
+++ b/test/files/neg/t7691.check
@@ -1,0 +1,19 @@
+t7691.scala:16: error: value _ is not a member of object X
+  def x = X.`_`       // value _ is not a member of object X
+            ^
+t7691.scala:18: error: value _ is not a member of object Y
+  def y = Y.`_`       // still not
+            ^
+t7691.scala:20: error: value _ is not a member of object Z
+  def z = Z.`_`       // still not
+            ^
+t7691.scala:22: error: value _ is not a member of object V
+  def v = V.`_`       // still not
+            ^
+t7691.scala:24: error: value _ is not a member of object W
+  def w = W.`_`       // still not
+            ^
+t7691.scala:26: error: value _ is not a member of object Q
+  def q = Q.`_`       // still not
+            ^
+6 errors found

--- a/test/files/neg/t7691.scala
+++ b/test/files/neg/t7691.scala
@@ -1,0 +1,32 @@
+
+object X { val _ = 42 }
+
+object Y { val (_, _) = (42, 17) }
+
+object Z { val _ = 42 ; val _ = 17 }             // was error
+
+object V { val _, _, _ = println("hi") }         // was error
+
+object W { val _: Int = 42 ; val _: Int = 17 }   // was error
+
+object Q { val _ @ _ = 42 ; val _ = 17 }         // was error
+
+
+object Test {
+  def x = X.`_`       // value _ is not a member of object X
+
+  def y = Y.`_`       // still not
+
+  def z = Z.`_`       // still not
+
+  def v = V.`_`       // still not
+
+  def w = W.`_`       // still not
+
+  def q = Q.`_`       // still not
+
+  def h = locally {
+    val _ = 42
+    val _ = 17        // was error
+  }
+}

--- a/test/files/pos/t10641/J_0.java
+++ b/test/files/pos/t10641/J_0.java
@@ -1,0 +1,8 @@
+
+// (use of '_' as an identifier might not be supported in releases after Java SE 8)
+
+public class J_0 {
+    public int _() { return 42; }
+    public String funkyJavaNameFactory() { return "funk"; }
+    public int underscore() { return _(); }
+}

--- a/test/files/pos/t10641/S_1.scala
+++ b/test/files/pos/t10641/S_1.scala
@@ -1,0 +1,7 @@
+
+class S_1 {
+  val j = new J_0
+  import j.{ `_` => u, funkyJavaNameFactory => f }   // was: Wildcard import must be in last position
+  val x = u
+  def y = f
+}

--- a/test/files/run/toolbox_typecheck_implicitsdisabled.scala
+++ b/test/files/run/toolbox_typecheck_implicitsdisabled.scala
@@ -6,8 +6,12 @@ import scala.tools.reflect.ToolBox
 object Test extends App {
   val toolbox = cm.mkToolBox()
 
+  //val wildcard = ImportSelector.wild
+  //error: value wild is not a member of reflect.runtime.universe.ImportSelectorExtractor
+  val wildcard = ImportSelector(termNames.WILDCARD, -1, null, -1)
+
   val tree1 = Block(List(
-    Import(Select(Ident(TermName("scala")), TermName("Predef")), List(ImportSelector(termNames.WILDCARD, -1, null, -1)))),
+    Import(Select(Ident(TermName("scala")), TermName("Predef")), List(wildcard))),
     Apply(Select(Literal(Constant(1)), TermName("$minus$greater")), List(Literal(Constant(2))))
   )
   val ttree1 = toolbox.typecheck(tree1, withImplicitViewsDisabled = false)
@@ -15,7 +19,7 @@ object Test extends App {
 
   try {
     val tree2 = Block(List(
-      Import(Select(Ident(TermName("scala")), TermName("Predef")), List(ImportSelector(termNames.WILDCARD, -1, null, -1)))),
+      Import(Select(Ident(TermName("scala")), TermName("Predef")), List(wildcard))),
       Apply(Select(Literal(Constant(1)), TermName("$minus$greater")), List(Literal(Constant(2))))
     )
     val ttree2 = toolbox.typecheck(tree2, withImplicitViewsDisabled = true)


### PR DESCRIPTION
An import selector from WILDCARD to WILDCARD is taken as importing member underscore, and WILDCARD to anything else not null as renaming it. Renaming unquoted wildcard is not allowed.

was:
To disambiguate backquoted underscore, the convention
for ImportSelector is tweaked by using EMPTY instead of
WILDCARD as the special value. So EMPTY => EMPTY is
wildcard import, nonempty => EMPTY is hidden.

This encoding also avoids a null value for the rename field.

A rename is detected more simply by name != rename.

This change would require communication with anyone who builds ImportSelector manually. It would be nice to use ImportSelector.wild instead of relying on the encoding. See the test that does that.

Fixes scala/bug#6426
Fixes scala/bug#10641
Fixes scala/bug#7691