### PR TITLE
Revert "optimise use of indyLamdaMethods map"

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/PostProcessor.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/PostProcessor.scala
@@ -49,9 +49,9 @@ abstract class PostProcessor(statistics: Statistics with BackendStats) extends P
       val bytes = try {
         if (!isArtifact) {
           localOptimizations(classNode)
-          backendUtils.onIndyLambdaImplMethodIfPresent(classNode.name) {
-            methods => if (methods.nonEmpty) backendUtils.addLambdaDeserialize(classNode, methods)
-          }
+          val lambdaImplMethods = backendUtils.getIndyLambdaImplMethods(classNode.name)
+          if (lambdaImplMethods.nonEmpty)
+            backendUtils.addLambdaDeserialize(classNode, lambdaImplMethods)
         }
         setInnerClasses(classNode)
         serializeClass(classNode)

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -7,8 +7,6 @@ import java.lang.invoke.LambdaMetafactory
 import scala.annotation.{switch, tailrec}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import java.util.concurrent.ConcurrentHashMap
-
 import scala.tools.asm
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree._
@@ -37,7 +35,7 @@ abstract class BackendUtils extends PerRunInit {
   import bTypes._
   import callGraph.ClosureInstantiation
   import coreBTypes._
-  import frontendAccess.{compilerSettings, recordPerRunJavaMapCache}
+  import frontendAccess.{compilerSettings, recordPerRunCache}
 
   /**
    * Classes with indyLambda closure instantiations where the SAM type is serializable (e.g. Scala's
@@ -46,9 +44,7 @@ abstract class BackendUtils extends PerRunInit {
    * inlining: when inlining an indyLambda instruction into a class, we need to make sure the class
    * has the method.
    */
-  private val indyLambdaImplMethods: ConcurrentHashMap[InternalName, mutable.LinkedHashSet[asm.Handle]] = recordPerRunJavaMapCache{
-    new ConcurrentHashMap[InternalName, mutable.LinkedHashSet[asm.Handle]]
-  }
+  val indyLambdaImplMethods: mutable.AnyRefMap[InternalName, mutable.LinkedHashSet[asm.Handle]] = recordPerRunCache(mutable.AnyRefMap())
 
   // unused objects created by these constructors are eliminated by pushPop
   private[this] lazy val sideEffectFreeConstructors: LazyVar[Set[(String, String)]] = perRunLazy(this) {
@@ -368,47 +364,38 @@ abstract class BackendUtils extends PerRunInit {
     }
   }
 
-  def onIndyLambdaImplMethodIfPresent(hostClass: InternalName) (action : mutable.LinkedHashSet[asm.Handle] => Unit): Unit =
-    indyLambdaImplMethods.get(hostClass) match {
-      case null =>
-      case xs => xs.synchronized(action(xs))
-    }
-
-  def onIndyLambdaImplMethod[T](hostClass: InternalName) (action: mutable.LinkedHashSet[asm.Handle] => T): T ={
-    val methods = indyLambdaImplMethods.computeIfAbsent(hostClass, (_) => mutable.LinkedHashSet[asm.Handle]())
-
-    methods.synchronized (action(methods))
-  }
-
-      /**
+  /**
    * add methods
    * @return the added methods. Note the order is undefined
    */
   def addIndyLambdaImplMethod(hostClass: InternalName, handle: Seq[asm.Handle]): Seq[asm.Handle] = {
-    if (handle.isEmpty) Nil else onIndyLambdaImplMethod(hostClass) {
-      case set =>
-        if (set.isEmpty) {
-          set ++= handle
-          handle
-        } else {
-          var added = List.empty[asm.Handle]
-          handle foreach { h => if (set.add(h)) added ::= h }
-          added
-        }
+    if (handle.isEmpty) Nil else {
+      val set = indyLambdaImplMethods.getOrElseUpdate(hostClass, mutable.LinkedHashSet())
+      if (set.isEmpty) {
+        set ++= handle
+        handle
+      } else {
+        var added = List.empty[asm.Handle]
+        handle foreach { h => if (set.add(h)) added ::= h}
+        added
+      }
     }
   }
 
   def addIndyLambdaImplMethod(hostClass: InternalName, handle: asm.Handle): Boolean = {
-    onIndyLambdaImplMethod(hostClass) {
-      _ add handle
-    }
+    indyLambdaImplMethods.getOrElseUpdate(hostClass, mutable.LinkedHashSet()).add(handle)
   }
 
   def removeIndyLambdaImplMethod(hostClass: InternalName, handle: Seq[asm.Handle]): Unit = {
     if (handle.nonEmpty)
-      onIndyLambdaImplMethodIfPresent(hostClass) {
-        _ --= handle
-      }
+      indyLambdaImplMethods.get(hostClass).foreach(_ --= handle)
+  }
+
+  def getIndyLambdaImplMethods(hostClass: InternalName): Iterable[asm.Handle] = {
+    indyLambdaImplMethods.getOrNull(hostClass) match {
+      case null => Nil
+      case xs => xs
+    }
   }
 
   /**


### PR DESCRIPTION
This reverts commit fe0165c6863a64accea4c6c87c2af5fc1c79d368.
See scala/scala-dev#457