### PR TITLE
Compare positions in tryTypedApply by focus.

### DIFF
--- a/src/reflect/scala/reflect/internal/util/Position.scala
+++ b/src/reflect/scala/reflect/internal/util/Position.scala
@@ -94,6 +94,8 @@ sealed abstract class UndefinedPosition extends Position {
   override def start           = fail("start")
   override def point           = fail("point")
   override def end             = fail("end")
+
+  override def samePointAs(that: Position) = false
 }
 
 private[util] trait InternalPositionImpl {
@@ -199,6 +201,10 @@ private[util] trait InternalPositionImpl {
     else if (isDefined) s"[$point]"
     else "[NoPosition]"
   )
+
+  /* Same as `this.focus == that.focus`, but less allocation-y. */
+  def samePointAs(that: Position): Boolean =
+    that.isDefined && this.point == that.point && this.source.file == that.source.file
 
   private def asOffset(point: Int): Position = Position.offset(source, point)
   private def copyRange(source: SourceFile = source, start: Int = start, point: Int = point, end: Int = end): Position =

--- a/test/files/pos/t10643.flags
+++ b/test/files/pos/t10643.flags
@@ -1,0 +1,1 @@
+-Yrangepos

--- a/test/files/pos/t10643.scala
+++ b/test/files/pos/t10643.scala
@@ -1,0 +1,23 @@
+trait AA
+trait BB
+trait Foo {
+  def consume(a: AA): Unit
+}
+
+object FooOpss {
+  implicit class FooOps(val self: Foo) {
+    def consume(a: BB): Unit = ???
+  }
+}
+import FooOpss._
+
+class Test {
+  val theFoo: Foo = ???
+  def doIt(id: Long): Unit =
+    theFoo.consume(BBFactory.create(id))
+}
+
+object BBFactory {
+  def create(id: Long)(implicit i: DummyImplicit): BB = ???
+}
+


### PR DESCRIPTION
Synthetic trees usually get offset positions, even with range positions enabled. The comparison previously used by `errorInResult` did not consider the error issued by `AdaptTypeError` on an `ApplyToImplicitArgs` to be part of the result expression, meaning that an implicit view wouldn't be sought on a second try.

Fixes scala/bug#10643.