### PR TITLE
allow per-run init to be used with java collections

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/PostProcessorFrontendAccess.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/PostProcessorFrontendAccess.scala
@@ -2,10 +2,10 @@ package scala.tools.nsc
 package backend.jvm
 
 import scala.collection.generic.Clearable
-import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.{JavaClearable, Position}
 import scala.reflect.io.AbstractFile
 import scala.tools.nsc.backend.jvm.BTypes.InternalName
-import java.util.{Map => JMap, Collection => JCollection}
+import java.util.{Collection => JCollection, Map => JMap}
 
 /**
  * Functionality needed in the post-processor whose implementation depends on the compiler
@@ -170,16 +170,13 @@ object PostProcessorFrontendAccess {
     def recordPerRunCache[T <: Clearable](cache: T): T = frontendSynch(perRunCaches.recordCache(cache))
 
     def recordPerRunJavaMapCache[T <: JMap[_,_]](cache: T): T = {
-      recordPerRunJavaCache(cache.keySet())
+      recordPerRunCache(JavaClearable.forMap(cache))
       cache
     }
 
     def recordPerRunJavaCache[T <: JCollection[_]](cache: T): T = {
-      recordPerRunCache(new JavaClearable(cache))
+      recordPerRunCache(JavaClearable.forCollection(cache))
       cache
-    }
-    private class JavaClearable(data: JCollection[_]) extends Clearable {
-      override def clear(): Unit = data.clear
     }
   }
 }

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -365,9 +365,15 @@ abstract class SymbolTable extends macros.Universe
     // letting us know when a cache is really out of commission.
     import java.lang.ref.WeakReference
     private var caches = List[WeakReference[Clearable]]()
+    private var javaCaches = List[JavaClearable[_]]()
 
     def recordCache[T <: Clearable](cache: T): T = {
-      caches ::= new WeakReference(cache)
+      cache match {
+        case jc: JavaClearable[_] =>
+          javaCaches ::= jc
+        case _ =>
+          caches ::= new WeakReference(cache)
+      }
       cache
     }
 
@@ -376,13 +382,21 @@ abstract class SymbolTable extends macros.Universe
      * compiler and then inspect the state of a cache.
      */
     def unrecordCache[T <: Clearable](cache: T): Unit = {
-      caches = caches.filterNot(_.get eq cache)
+      cache match {
+        case jc: JavaClearable[_] =>
+          javaCaches = javaCaches.filterNot(cache == _)
+        case _ =>
+          caches = caches.filterNot(_.get eq cache)
+      }
     }
 
     def clearAll() = {
-      debuglog("Clearing " + caches.size + " caches.")
+      debuglog("Clearing " + (caches.size + javaCaches.size) + " caches.")
       caches foreach (ref => Option(ref.get).foreach(_.clear))
       caches = caches.filterNot(_.get == null)
+
+      javaCaches foreach (_.clear)
+      javaCaches = javaCaches.filter(_.isValid)
     }
 
     def newWeakMap[K, V]()        = recordCache(mutable.WeakHashMap[K, V]())

--- a/src/reflect/scala/reflect/internal/util/JavaClearable.scala
+++ b/src/reflect/scala/reflect/internal/util/JavaClearable.scala
@@ -1,0 +1,38 @@
+package scala.reflect.internal.util
+
+import java.lang.ref.WeakReference
+import java.util.{Collection => JCollection, Map => JMap}
+
+import scala.collection.generic.Clearable
+
+object JavaClearable {
+  def forCollection[T <: JCollection[_]](data: T): JavaClearable[T] = new JavaClearableCollection(new WeakReference(data))
+  def forMap[T <: JMap[_,_]](data: T): JavaClearable[T] = new JavaClearableMap(new WeakReference(data))
+
+  private final class JavaClearableMap[T <: JMap[_,_]](dataRef:WeakReference[T]) extends JavaClearable(dataRef) {
+    override def clear: Unit = Option(dataRef.get) foreach (_.clear())
+  }
+  private final class JavaClearableCollection[T <: JCollection[_]](dataRef:WeakReference[T]) extends JavaClearable(dataRef) {
+    override def clear: Unit = Option(dataRef.get) foreach (_.clear())
+  }
+}
+sealed abstract class JavaClearable[T <: AnyRef] protected (protected val dataRef: WeakReference[T]) extends Clearable {
+
+  //just maintained hashCode to be consistent with equals
+  override val hashCode = System.identityHashCode(dataRef.get())
+  override def equals(obj: scala.Any) = obj match {
+    case that: JavaClearable[_] => {
+      if (this eq that) true
+      else {
+        val thisData = this.dataRef.get
+        val thatData = that.dataRef.get
+        (thisData eq thatData) && (thisData ne null)
+      }
+    }
+    case _ => false
+  }
+
+  def clear : Unit
+
+  def isValid = dataRef.get() ne null
+}

--- a/test/junit/scala/tools/nsc/backend/jvm/PerRunInitTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/PerRunInitTest.scala
@@ -1,0 +1,127 @@
+package scala.tools.nsc.backend.jvm
+import java.util
+
+import org.junit._
+import org.junit.Assert._
+
+import scala.collection.mutable
+import scala.ref.WeakReference
+import scala.reflect.internal.util.JavaClearable
+import scala.tools.nsc.{Global, Settings}
+import scala.tools.nsc.backend.jvm.PostProcessorFrontendAccess.PostProcessorFrontendAccessImpl
+import scala.tools.nsc.reporters.StoreReporter
+
+class PerRunInitTestMap extends PerRunInitTest {
+  type Data =  mutable.Map[String, String]
+  override def newData(): Data = underTest.recordPerRunCache(mutable.Map.empty)
+  override def dontClear(data: Data): Unit = underTest.global.perRunCaches.unrecordCache(data)
+
+  override def add(id: Int, data: Data): Unit = data.put(s"key $id", s"value $id")
+
+  override def sizeOf(data: Data): Int = data.size
+
+}
+class PerRunInitTestSet extends PerRunInitTest {
+  type Data =  mutable.Set[String]
+  override def newData(): Data = underTest.recordPerRunCache(mutable.Set.empty)
+  override def dontClear(data: Data): Unit = underTest.global.perRunCaches.unrecordCache(data)
+
+  override def add(id: Int, data: Data): Unit = data += s"value $id"
+
+  override def sizeOf(data: Data): Int = data.size
+}
+class PerRunInitTestJMap extends PerRunInitTest {
+  type Data =  java.util.Map[String, String]
+  override def newData(): Data = underTest.recordPerRunJavaMapCache(new util.HashMap[String,String]())
+  override def dontClear(data: Data): Unit = underTest.global.perRunCaches.unrecordCache(JavaClearable.forMap(data))
+
+  override def add(id: Int, data: Data): Unit = data.put(s"key $id", s"value $id")
+
+  override def sizeOf(data: Data): Int = data.size
+}
+class PerRunInitTestJSet extends PerRunInitTest {
+  type Data =  java.util.Set[String]
+  override def newData(): Data = underTest.recordPerRunJavaCache(new util.HashSet[String]())
+  override def dontClear(data: Data): Unit = underTest.global.perRunCaches.unrecordCache(JavaClearable.forCollection(data))
+
+  override def add(id: Int, data: Data): Unit = data.add(s"value $id")
+
+  override def sizeOf(data: Data): Int = data.size
+}
+class PerRunInitTestJCMap extends PerRunInitTestJMap {
+  override def newData(): Data = underTest.recordPerRunJavaMapCache(new java.util.concurrent.ConcurrentHashMap[String,String]())
+}
+abstract class PerRunInitTest {
+  type Data >: Null <: AnyRef
+  var underTest : PostProcessorFrontendAccessImpl = _
+  @Before def init() = {
+    def global = {
+      def showError(s: String) = throw new Exception(s)
+
+      val settings = new Settings(showError)
+
+      new Global(settings, new StoreReporter)
+    }
+    underTest = new PostProcessorFrontendAccessImpl(global)
+  }
+  @After def clear() = {
+    underTest = null
+  }
+
+  def newData(): Data
+  def dontClear(data:Data): Unit
+
+  def add(id: Int, data: Data): Unit
+
+  def sizeOf(data: Data): Int
+
+  def clearCaches() = underTest.global.perRunCaches.clearAll()
+
+  def doGc() = {
+    System.gc()
+    System.runFinalization()
+  }
+
+  @Test
+  def clearedWhenExpired: Unit = {
+    val data = newData()
+
+    add(1, data)
+
+    assertEquals(s"$data", 1, sizeOf(data))
+    doGc()
+    assertEquals(s"$data", 1, sizeOf(data))
+
+    clearCaches()
+    assertEquals(s"$data", 0, sizeOf(data))
+  }
+
+  @Test
+  def clearedWeakOnly: Unit = {
+    var data = newData()
+    val ref = WeakReference(data)
+
+    assertTrue(ref.get.isDefined)
+    data = null
+    doGc()
+    assertFalse(ref.get.isDefined)
+    //to check that dereference doesn't cause a problem
+    clearCaches()
+  }
+
+  @Test
+  def notClearedIfRequested: Unit = {
+    val data = newData()
+    dontClear(data)
+
+    add(1, data)
+    assertEquals(s"$data", 1, sizeOf(data))
+    doGc()
+    assertEquals(s"$data", 1, sizeOf(data))
+    clearCaches()
+    assertEquals(s"$data", 1, sizeOf(data))
+  }
+
+
+
+}


### PR DESCRIPTION
change spun out of https://github.com/scala/scala/pull/6124 to aid review

add tests for per run caches, for java and scala collections

add fixes to java collections used in per-run, as detected in https://github.com/scala/scala-dev/issues/457
  