### PR TITLE
Avoid hard failure with older standard library

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1111,7 +1111,7 @@ trait Definitions extends api.StandardDefinitions {
 
     // Annotation base classes
     lazy val AnnotationClass            = requiredClass[scala.annotation.Annotation]
-    lazy val ConstantAnnotationClass    = getRequiredClass("scala.annotation.ConstantAnnotation")
+    lazy val ConstantAnnotationClass    = getClassIfDefined("scala.annotation.ConstantAnnotation")
     lazy val StaticAnnotationClass      = requiredClass[scala.annotation.StaticAnnotation]
 
     // Java retention annotations


### PR DESCRIPTION
New entrants to Definitions should generally use
`getClassIfDefined`, which allows the new compiler to
work with an older standard library. This can happen in
IDE use cases.