### PR TITLE
Tighten up check for List() to Nil rewrite

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3608,7 +3608,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                  *  forced during kind-arity checking, so it is guarded by additional
                  *  tests to ensure we're sufficiently far along.
                  */
-                if (args.isEmpty && canTranslateEmptyListToNil && fun.symbol.isInitialized && ListModule.hasCompleteInfo && (fun.symbol == List_apply))
+                def isSelectionFromListModule(tree: Tree) = tree match {
+                  case treeInfo.Applied(core @ Select(qual, _), _, _) => treeInfo.isQualifierSafeToElide(qual) && qual.symbol == ListModule
+                  case _ => false
+                }
+                if (args.isEmpty && canTranslateEmptyListToNil && fun.symbol.isInitialized && ListModule.hasCompleteInfo && (fun.symbol == List_apply && isSelectionFromListModule(fun)))
                   atPos(tree.pos)(gen.mkNil setType restpe)
                 else
                   constfold(treeCopy.Apply(tree, fun, args1) setType ifPatternSkipFormals(restpe))

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1505,11 +1505,6 @@ trait Definitions extends api.StandardDefinitions {
       lazy val Option_apply = getMemberMethod(OptionModule, nme.apply)
       lazy val List_apply = DefinitionsClass.this.List_apply
 
-      /**
-       * Is the given symbol `List.apply`?
-       * To to avoid bootstrapping cycles, this return false if the given symbol or List itself is not initialized.
-       */
-      def isListApply(sym: Symbol) = sym.isInitialized && ListModule.hasCompleteInfo && sym == List_apply
       def isPredefClassOf(sym: Symbol) = if (PredefModule.hasCompleteInfo) sym == Predef_classOf else isPredefMemberNamed(sym, nme.classOf)
 
       lazy val TagMaterializers = Map[Symbol, Symbol](


### PR DESCRIPTION
 Tested with the new collections, in which List.apply is an inherited method.

``` 
% /code/scala/build/quick/bin/scalac -Dscala.usejavacp=false -cp /code/scala-szeiger/build/quick/classes/library /tmp/test.scala -Xprint:typer
[[syntax trees at end of                     typer]] // test.scala
package <empty> {
  class Test extends scala.AnyRef {
    def <init>(): Test = {
      Test.super.<init>();
      ()
    };
    scala.collection.immutable.List.apply[Int](1);
    scala.Predef.Set.apply[Int](1);
    scala.Predef.Set.apply[Nothing]();
    scala.Predef.Set.apply[String]();
    scala.collection.immutable.Nil;
    scala.collection.immutable.Nil
  }
}
```

given:

```
class Test {
  List.apply(1)
  Set.apply(1)
  Set.apply()
  Set.apply[String]()
  List.apply()
  List.apply[String]()
}
```