### PR TITLE
Extra caution in namer treating parents

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1115,7 +1115,7 @@ trait Namers extends MethodSynthesis {
       val pending = mutable.ListBuffer[AbsTypeError]()
       parentTrees foreach { tpt =>
         val ptpe = tpt.tpe
-        if(!ptpe.isError) {
+        if (!ptpe.isError) {
           val psym = ptpe.typeSymbol
           val sameSourceFile = context.unit.source.file == psym.sourceFile
 
@@ -1124,7 +1124,7 @@ trait Namers extends MethodSynthesis {
               psym addChild context.owner
             else
               pending += ParentSealedInheritanceError(tpt, psym)
-          if (psym.isLocalToBlock && !phase.erasedTypes)
+          if (psym.isLocalToBlock && psym.isClass && !phase.erasedTypes)
             psym addChild context.owner
         }
       }

--- a/test/files/neg/t10661.check
+++ b/test/files/neg/t10661.check
@@ -1,0 +1,4 @@
+t10661.scala:3: error: class type required but A found
+  def f[A] = new C with A
+                        ^
+one error found

--- a/test/files/neg/t10661.scala
+++ b/test/files/neg/t10661.scala
@@ -1,0 +1,4 @@
+
+class C {
+  def f[A] = new C with A
+}


### PR DESCRIPTION
Parents have not been validated yet, so only use `addChild`
when `isClass`.

Fixes scala/bug#10661