### PR TITLE
Reduce overhead of enabling -Ystatistics

### DIFF
--- a/src/reflect/scala/reflect/internal/util/StatisticsStatics.java
+++ b/src/reflect/scala/reflect/internal/util/StatisticsStatics.java
@@ -48,7 +48,8 @@ public final class StatisticsStatics extends BooleanContainer {
   }
 
   public static void enableColdStats() {
-    COLD_STATS.setValue(new TrueContainer());
+    if (!areSomeColdStatsEnabled())
+      COLD_STATS.setValue(new TrueContainer());
   }
 
   public static void disableColdStats() {
@@ -56,7 +57,8 @@ public final class StatisticsStatics extends BooleanContainer {
   }
 
   public static void enableHotStats() {
-    HOT_STATS.setValue(new TrueContainer());
+    if (!areSomeHotStatsEnabled())
+      HOT_STATS.setValue(new TrueContainer());
   }
 
   public static void disableHotStats() {


### PR DESCRIPTION
The implementation trick of using an AlmostFinalValue to have zero
cost for the "isEnabled" check in the common case has a small flaw:
the switchpoint is tripped _every_ time stats is enabled, rather
than just on the first time. This discards a swathe of JIT compiled
code each time a Global is started with `-Ystatistics`.

This commit avoids tripping the switchpoint redundantly.

Performance:

```
⚡ for extra in "-Ystatistics:_" ""; do for v in 2.12.5-bin-91649d1-SNAPSHOT 2.12.4; do echo $v $extra; sbt 'set scalaVersion in compilation := "'$v'"' 'hot -psource=scalap -f1 -wi 5 -i 3 -pextraArgs='$extra | egrep 'HotScalacBenchmark.compile\s'; done; done
2.12.5-bin-91649d1-SNAPSHOT -Ystatistics:_
[info] HotScalacBenchmark.compile                          a8c43dc  -Ystatistics:_       false    scalap  sample   33   973.523 ± 23.389  ms/op
2.12.4 -Ystatistics:_
[info] HotScalacBenchmark.compile                          a8c43dc  -Ystatistics:_       false    scalap  sample   12  2921.333 ± 177.831  ms/op
2.12.5-bin-91649d1-SNAPSHOT
[info] HotScalacBenchmark.compile                          a8c43dc                    false    scalap  sample   38  811.846 ± 13.436  ms/op
2.12.4
[info] HotScalacBenchmark.compile                          a8c43dc                    false    scalap  sample   38  820.814 ± 17.809  ms/op
```

There is still more overhead than I would like, and it might still make
sense to move a few stats back into the "hot" category.