### PR TITLE
There is a bug in JavaMirror.makeScalaPackage 

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5238,6 +5238,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         val pdef = treeCopy.PackageDef(pdef0, pdef0.pid, pluginsEnterStats(this, pdef0.stats))
         val pid1 = typedQualifier(pdef.pid).asInstanceOf[RefTree]
         assert(sym.moduleClass ne NoSymbol, sym)
+        if(pid1.symbol.ne(NoSymbol) && !(pid1.symbol.hasPackageFlag || pid1.symbol.isModule ))
+          reporter.error(pdef.pos, s"There is name conflict between the ${pid1.symbol.fullName} and the package ${sym.fullName}.")
         val stats1 = newTyper(context.make(tree, sym.moduleClass, sym.info.decls))
           .typedStats(pdef.stats, NoSymbol)
         treeCopy.PackageDef(tree, pid1, stats1) setType NoType

--- a/test/files/neg/names-package-method-conflict.check
+++ b/test/files/neg/names-package-method-conflict.check
@@ -1,0 +1,4 @@
+names-package-method-conflict.scala:7: error: There is name conflict between the foo.bar and the package foo.bar.
+	package bar{
+                ^
+one error found

--- a/test/files/neg/names-package-method-conflict.scala
+++ b/test/files/neg/names-package-method-conflict.scala
@@ -1,0 +1,10 @@
+package object foo {
+	def bar: Unit = {}
+}
+
+package foo {
+
+	package bar{
+		class Baz
+	}
+}

--- a/test/files/run/reflection-package-name-conflict.check
+++ b/test/files/run/reflection-package-name-conflict.check
@@ -1,0 +1,4 @@
+class c
+class c
+class c
+class c

--- a/test/files/run/reflection-package-name-conflict/A_1.scala
+++ b/test/files/run/reflection-package-name-conflict/A_1.scala
@@ -1,0 +1,8 @@
+package a {
+  object `package` {
+    val b2 = 42
+  }
+  package b1 {
+    class c
+  }
+}

--- a/test/files/run/reflection-package-name-conflict/A_2.scala
+++ b/test/files/run/reflection-package-name-conflict/A_2.scala
@@ -1,0 +1,9 @@
+package a {
+  object `package` {
+    val b1 = 42
+  }
+
+  package b2 {
+    class c
+  }
+}

--- a/test/files/run/reflection-package-name-conflict/Test.scala
+++ b/test/files/run/reflection-package-name-conflict/Test.scala
@@ -1,0 +1,10 @@
+import reflect.runtime.universe._
+
+object Test {
+  def main(args: Array[String]) {
+    for (clsName <- List("a.b1.c", "a.b2.c")) {
+      println(rootMirror.classSymbol(Class.forName("a.b1.c")))
+      println(rootMirror.classSymbol(Class.forName("a.b2.c")))
+    }
+  }
+}


### PR DESCRIPTION
A conflict was fixed when searching for a symbol of subpackage when there is a collision between the names of the nested package and the method in the package object. For example there is package a.b and method b inside package object a. The search found any symbols inside the package, although only the symbol of the package was needed here. Because of this, there was an error (throw new ReflectError(opkg+" is not a package"))