### PR TITLE
Patternly apply reduces apparent parens

### DIFF
--- a/test/files/pos/t10667.scala
+++ b/test/files/pos/t10667.scala
@@ -1,0 +1,17 @@
+
+case class C(i: Int)(j: Int)(s: String)
+case class D(i: Int)(j: Int)(implicit s: String)
+
+trait T {
+  val v = C(42)(17)("hello")
+  def f: C = v match {
+    case c @ C(_) => c
+    case C(_) if true => v
+  }
+
+  val c @ C(_) = v
+
+  def g = D(42)(17)("hello") match {
+    case d @ D(_) => "OK"
+  }
+}


### PR DESCRIPTION
When typing an apply in pattern mode,
if a method type results, use the method
result directly. This adjustment was
previously applied in typedCase, but
not in typedBind. Now it should happen
in any pattern context. This occurs
when a case class has more than two
parameter lists.

Fixes scala/bug#10667