### PR TITLE
Improve scaladoc link refs and syntax

### DIFF
--- a/src/library/scala/DelayedInit.scala
+++ b/src/library/scala/DelayedInit.scala
@@ -43,7 +43,7 @@ package scala
  *
  *  @author  Martin Odersky
  */
-@deprecated("DelayedInit semantics can be surprising. Support for `App` will continue. See the release notes for more details: https://github.com/scala/scala/releases/tag/v2.11.0-RC1", "2.11.0")
+@deprecated("DelayedInit semantics can be surprising. Support for `App` will continue. See the release notes for more details: [[https://github.com/scala/scala/releases/tag/v2.11.0]]", "2.11.0")
 trait DelayedInit {
   def delayedInit(x: => Unit): Unit
 }

--- a/src/library/scala/Symbol.scala
+++ b/src/library/scala/Symbol.scala
@@ -13,7 +13,7 @@ package scala
  *  Instances of `Symbol` can be created easily with Scala's built-in quote
  *  mechanism.
  *
- *  For instance, the [[http://scala-lang.org/#_top Scala]] term `'mysym` will
+ *  For instance, the Scala term `'mysym` will
  *  invoke the constructor of the `Symbol` class in the following way:
  *  `Symbol("mysym")`.
  *

--- a/src/library/scala/annotation/ClassfileAnnotation.scala
+++ b/src/library/scala/annotation/ClassfileAnnotation.scala
@@ -9,7 +9,7 @@
 package scala.annotation
 
 /** A base class for classfile annotations. These are stored as
- *  [[http://docs.oracle.com/javase/7/docs/technotes/guides/language/annotations.html#_top Java annotations]]]
+ *  [[http://docs.oracle.com/javase/8/docs/technotes/guides/language/annotations.html Java annotations]]]
  *  in classfiles.
  *
  *  @author  Martin Odersky

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -411,7 +411,7 @@ trait TraversableLike[+A, +Repr] extends Any
    *  $orderDependent
    *  @return  a $coll consisting of all elements of this $coll
    *           except the first one.
-   *  @throws `UnsupportedOperationException` if the $coll is empty.
+   *  @throws java.lang.UnsupportedOperationException if the $coll is empty.
    */
   override def tail: Repr = {
     if (isEmpty) throw new UnsupportedOperationException("empty.tail")

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -621,7 +621,7 @@ private[concurrent] case class RDCSS_Descriptor[K, V](old: INode[K, V], expected
  *  iterator and clear operations. The cost of evaluating the (lazy) snapshot is
  *  distributed across subsequent updates, thus making snapshot evaluation horizontally scalable.
  *
- *  For details, see: http://lampwww.epfl.ch/~prokopec/ctries-snapshot.pdf
+ *  For details, see: [[http://lampwww.epfl.ch/~prokopec/ctries-snapshot.pdf]]
  *
  *  @author Aleksandar Prokopec
  *  @since 2.10

--- a/src/library/scala/collection/generic/BitOperations.scala
+++ b/src/library/scala/collection/generic/BitOperations.scala
@@ -12,7 +12,7 @@ package generic
 
 /** Some bit operations.
  *
- *  See http://www.drmaciver.com/2008/08/unsigned-comparison-in-javascala/ for
+ *  See [[http://www.drmaciver.com/2008/08/unsigned-comparison-in-javascala/]] for
  *  an explanation of unsignedCompare.
  */
 private[collection] object BitOperations {

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -18,7 +18,7 @@ import mutable.Builder
 
 /** A class for immutable bitsets.
  *  $bitsetinfo
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable_bitsets "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable-bitsets"Scala's Collection Library overview"]]
  *  section on `Immutable BitSets` for more information.
  *
  *  @define Coll `immutable.BitSet`

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -24,7 +24,7 @@ import scala.annotation.unchecked.{ uncheckedVariance=> uV }
  *  @author  Tiark Rompf
  *  @version 2.8
  *  @since   2.3
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#hash_tries "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#hash-tries "Scala's Collection Library overview"]]
  *  section on `Hash Tries` for more information.
  *  @define Coll `immutable.HashMap`
  *  @define coll immutable hash map

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -20,7 +20,7 @@ import scala.annotation.tailrec
   * n elements will take O(n^2^) time. This makes the builder suitable only for a small number of
   * elements.
   *
-  * @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#list_maps "Scala's Collection Library overview"]]
+  * @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#list-maps "Scala's Collection Library overview"]]
   * section on `List Maps` for more information.
   * @since 1
   * @define Coll ListMap

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -137,7 +137,7 @@ private[immutable] class LongMapKeyIterator[V](it: LongMap[V]) extends LongMapIt
 
 /**
  *  Specialised immutable map structure for long keys, based on
- *  <a href="http://citeseer.ist.psu.edu/okasaki98fast.html">Fast Mergeable Long Maps</a>
+ *  [[http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.37.5452 Fast Mergeable Long Maps]]
  *  by Okasaki and Gill. Essentially a trie based on binary digits of the integers.
  *
  *  Note: This class is as of 2.8 largely superseded by HashMap.

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -27,7 +27,7 @@ import mutable.{ Builder, ListBuffer }
  *  @author  Erik Stenman
  *  @version 1.0, 08/07/2003
  *  @since   1
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable_queues "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable-queues "Scala's Collection Library overview"]]
  *  section on `Immutable Queues` for more information.
  *
  *  @define Coll `immutable.Queue`

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -168,8 +168,8 @@ object RedBlackTree {
   }
 
   /* Based on Stefan Kahrs' Haskell version of Okasaki's Red&Black Trees
-   * Constructing Red-Black Trees, Ralf Hinze: http://www.cs.ox.ac.uk/ralf.hinze/publications/WAAAPL99b.ps.gz
-   * Red-Black Trees in a Functional Setting, Chris Okasaki: https://wiki.rice.edu/confluence/download/attachments/2761212/Okasaki-Red-Black.pdf */
+   * Constructing Red-Black Trees, Ralf Hinze: [[http://www.cs.ox.ac.uk/ralf.hinze/publications/WAAAPL99b.ps.gz]]
+   * Red-Black Trees in a Functional Setting, Chris Okasaki: [[https://wiki.rice.edu/confluence/download/attachments/2761212/Okasaki-Red-Black.pdf]] */
   private[this] def del[A, B](tree: Tree[A, B], k: A)(implicit ordering: Ordering[A]): Tree[A, B] = if (tree eq null) null else {
     def balance(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tl)) {
       if (isRedTree(tr)) {

--- a/src/library/scala/collection/immutable/Stack.scala
+++ b/src/library/scala/collection/immutable/Stack.scala
@@ -35,7 +35,7 @@ object Stack extends SeqFactory[Stack] {
  *  @author  Matthias Zenger
  *  @version 1.0, 10/07/2003
  *  @since   1
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable_stacks "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable-stacks "Scala's Collection Library overview"]]
  *  section on `Immutable stacks` for more information.
  *
  *  @define Coll `immutable.Stack`

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -34,7 +34,7 @@ object TreeMap extends ImmutableSortedMapFactory[TreeMap] {
  *  @author  Matthias Zenger
  *  @version 1.1, 03/05/2004
  *  @since   1
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#redblack_trees "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
  *  section on `Red-Black Trees` for more information.
  *
  *  @define Coll immutable.TreeMap

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -38,7 +38,7 @@ object TreeSet extends ImmutableSortedSetFactory[TreeSet] {
  *  @author  Martin Odersky
  *  @version 2.0, 02/01/2007
  *  @since   1
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#redblack_trees "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
  *  section on `Red-Black Trees` for more information.
  *
  *  @define Coll `immutable.TreeSet`

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -23,7 +23,7 @@ import generic._
  *  @author  Martin Odersky
  *  @version 2.8
  *  @since   1
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array_buffers "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array-buffers "Scala's Collection Library overview"]]
  *  section on `Array Buffers` for more information.
 
  *

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -21,7 +21,7 @@ import generic._
  *  @author Martin Odersky
  *  @version 2.8
  *  @since   2.8
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array_sequences "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array-sequences "Scala's Collection Library overview"]]
  *  section on `Array Sequences` for more information.
  *
  *  @tparam A      type of the elements contained in this array sequence.

--- a/src/library/scala/collection/mutable/ArrayStack.scala
+++ b/src/library/scala/collection/mutable/ArrayStack.scala
@@ -48,7 +48,7 @@ object ArrayStack extends SeqFactory[ArrayStack] {
  *
  *  @author David MacIver
  *  @since  2.7
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array_stacks "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array-stacks "Scala's Collection Library overview"]]
  *  section on `Array Stacks` for more information.
  *
  *  @tparam T    type of the elements contained in this array stack.

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -19,7 +19,7 @@ import BitSetLike.{LogWL, MaxSize}
  *
  *  $bitsetinfo
  *
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable_bitsets "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable-bitsets "Scala's Collection Library overview"]]
  *  section on `Mutable Bitsets` for more information.
  *
  *  @define Coll `BitSet`

--- a/src/library/scala/collection/mutable/DoubleLinkedList.scala
+++ b/src/library/scala/collection/mutable/DoubleLinkedList.scala
@@ -21,7 +21,7 @@ import generic._
  *  @author Martin Odersky
  *  @version 2.8
  *  @since   1
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#double_linked_lists "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#double-linked-lists "Scala's Collection Library overview"]]
  *  section on `Double Linked Lists` for more information.
 
  *

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -15,7 +15,7 @@ import generic._
 /** This class implements mutable maps using a hashtable.
  *
  *  @since 1
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash_tables "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
  *  section on `Hash Tables` for more information.
  *
  *  @tparam A    the type of the keys contained in this hash map.

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -20,7 +20,7 @@ import generic._
  *  @author  Martin Odersky
  *  @version 2.0, 31/12/2006
  *  @since   1
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash_tables "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
  *  section on `Hash Tables` for more information.
  *
  *  @define Coll `mutable.HashSet`

--- a/src/library/scala/collection/mutable/LinearSeq.scala
+++ b/src/library/scala/collection/mutable/LinearSeq.scala
@@ -20,7 +20,7 @@ import generic._
  *
  *  @define Coll `LinearSeq`
  *  @define coll linear sequence
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable_lists "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable-lists "Scala's Collection Library overview"]]
  *  section on `Mutable Lists` for more information.
  */
 trait LinearSeq[A] extends Seq[A]

--- a/src/library/scala/collection/mutable/LinkedList.scala
+++ b/src/library/scala/collection/mutable/LinkedList.scala
@@ -34,7 +34,7 @@ import generic._
   *  @author Martin Odersky
   *  @version 2.8
   *  @since   1
-  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#linked_lists "Scala's Collection Library overview"]]
+  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#linked-lists "Scala's Collection Library overview"]]
   *  section on `Linked Lists` for more information.
   *
   *  @tparam A     the type of the elements contained in this linked list.

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -21,7 +21,7 @@ import java.io.{ObjectOutputStream, ObjectInputStream}
  *  @author  Martin Odersky
  *  @version 2.8
  *  @since   1
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#list_buffers "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#list-buffers "Scala's Collection Library overview"]]
  *  section on `List Buffers` for more information.
  *
  *  @tparam A    the type of this list buffer's elements.

--- a/src/library/scala/collection/mutable/MutableList.scala
+++ b/src/library/scala/collection/mutable/MutableList.scala
@@ -23,7 +23,7 @@ import immutable.List
  *  @since   1
  *  @define Coll `mutable.MutableList`
  *  @define coll mutable list
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable_lists "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable-lists "Scala's Collection Library overview"]]
  *  section on `Mutable Lists` for more information.
  */
 @SerialVersionUID(5938451523372603072L)

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -24,7 +24,7 @@ import immutable.StringLike
  *  @since   2.7
  *  @define Coll `mutable.IndexedSeq`
  *  @define coll string builder
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html# "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#stringbuilders "Scala's Collection Library overview"]]
  *  section on `StringBuilders` for more information.
  */
 @SerialVersionUID(0 - 8525408645367278351L)

--- a/src/library/scala/collection/mutable/WeakHashMap.scala
+++ b/src/library/scala/collection/mutable/WeakHashMap.scala
@@ -21,7 +21,7 @@ import convert.Wrappers._
  *  @tparam B      type of values associated with the keys
  *
  *  @since 2.8
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#weak_hash_maps "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#weak-hash-maps "Scala's Collection Library overview"]]
  *  section on `Weak Hash Maps` for more information.
  *
  *  @define Coll `WeakHashMap`

--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -141,7 +141,7 @@ object ExecutionContext {
 
   /** Creates an `ExecutionContext` from the given `ExecutorService`.
    *
-   *  @param e         the `ExecutorService` to use. If `null`, a new `ExecutorService` is created with [[http://www.scala-lang.org/api/current/index.html#scala.concurrent.ExecutionContext$@global:scala.concurrent.ExecutionContextExecutor default configuration]].
+   *  @param e         the `ExecutorService` to use. If `null`, a new `ExecutorService` is created with [[scala.concurrent.ExecutionContext$.global default configuration]].
    *  @param reporter  a function for error reporting
    *  @return          the `ExecutionContext` using the given `ExecutorService`
    */
@@ -158,14 +158,14 @@ object ExecutionContext {
    *  val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
    *  }}}
    *
-   *  @param e the `ExecutorService` to use. If `null`, a new `ExecutorService` is created with [[http://www.scala-lang.org/api/current/index.html#scala.concurrent.ExecutionContext$@global:scala.concurrent.ExecutionContextExecutor default configuration]].
+   *  @param e the `ExecutorService` to use. If `null`, a new `ExecutorService` is created with [[scala.concurrent.ExecutionContext$.global default configuration]].
    *  @return  the `ExecutionContext` using the given `ExecutorService`
    */
   def fromExecutorService(e: ExecutorService): ExecutionContextExecutorService = fromExecutorService(e, defaultReporter)
 
   /** Creates an `ExecutionContext` from the given `Executor`.
    *
-   *  @param e         the `Executor` to use. If `null`, a new `Executor` is created with [[http://www.scala-lang.org/api/current/index.html#scala.concurrent.ExecutionContext$@global:scala.concurrent.ExecutionContextExecutor default configuration]].
+   *  @param e         the `Executor` to use. If `null`, a new `Executor` is created with [[scala.concurrent.ExecutionContext$.global default configuration]].
    *  @param reporter  a function for error reporting
    *  @return          the `ExecutionContext` using the given `Executor`
    */
@@ -174,7 +174,7 @@ object ExecutionContext {
 
   /** Creates an `ExecutionContext` from the given `Executor` with the [[scala.concurrent.ExecutionContext$.defaultReporter default reporter]].
    *
-   *  @param e the `Executor` to use. If `null`, a new `Executor` is created with [[http://www.scala-lang.org/api/current/index.html#scala.concurrent.ExecutionContext$@global:scala.concurrent.ExecutionContextExecutor default configuration]].
+   *  @param e the `Executor` to use. If `null`, a new `Executor` is created with [[scala.concurrent.ExecutionContext$.global default configuration]].
    *  @return  the `ExecutionContext` using the given `Executor`
    */
   def fromExecutor(e: Executor): ExecutionContextExecutor = fromExecutor(e, defaultReporter)

--- a/src/library/scala/concurrent/SyncVar.scala
+++ b/src/library/scala/concurrent/SyncVar.scala
@@ -40,7 +40,7 @@ class SyncVar[A] {
     wait(timeout)
     val elapsed = System.nanoTime() - start
     // nanoTime should be monotonic, but it's not possible to rely on that.
-    // See http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6458294.
+    // See http://bugs.java.com/view_bug.do?bug_id=6458294
     if (elapsed < 0) 0 else TimeUnit.NANOSECONDS.toMillis(elapsed)
   }
 

--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -87,10 +87,10 @@ private[concurrent] object Promise {
    /**
     * Latch used to implement waiting on a DefaultPromise's result.
     *
-    * Inspired by: http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+    * Inspired by: [[http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/util/concurrent/locks/AbstractQueuedSynchronizer.java]]
     * Written by Doug Lea with assistance from members of JCP JSR-166
     * Expert Group and released to the public domain, as explained at
-    * http://creativecommons.org/publicdomain/zero/1.0/
+    * [[http://creativecommons.org/publicdomain/zero/1.0/]]
     */
     private final class CompletionLatch[T] extends AbstractQueuedSynchronizer with (Try[T] => Unit) {
       override protected def tryAcquireShared(ignored: Int): Int = if (getState != 0) 1 else -1
@@ -150,8 +150,8 @@ private[concurrent] object Promise {
    * To make the chains flattenable, the concept of linking promises together
    * needed to become an explicit feature of the DefaultPromise implementation,
    * so that the implementation to navigate and rewire links as needed. The idea
-   * of linking promises is based on the [[Twitter promise implementation
-   * https://github.com/twitter/util/blob/master/util-core/src/main/scala/com/twitter/util/Promise.scala]].
+   * of linking promises is based on the [[https://github.com/twitter/util/blob/master/util-core/src/main/scala/com/twitter/util/Promise.scala
+   *  Twitter promise implementation]].
    *
    * In practice, flattening the chain cannot always be done perfectly. When a
    * promise is added to the end of the chain, it scans the chain and links

--- a/src/library/scala/io/Codec.scala
+++ b/src/library/scala/io/Codec.scala
@@ -21,8 +21,8 @@ import scala.language.implicitConversions
 // XML: optional encoding parameter.
 //   <?xml version="1.0" encoding="ISO8859-1" ?>
 //
-// MacRoman vs. UTF-8: see http://osdir.com/ml/lang-jruby-devel/2009-04/msg00071.html
-// -Dfile.encoding: see http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4375816
+// MacRoman vs. UTF-8: see https://groups.google.com/d/msg/jruby-developers/-qtwRhoE1WM/whSPVpTNV28J
+// -Dfile.encoding: see https://bugs.java.com/view_bug.do?bug_id=4375816
 
 /** A class for character encoding/decoding preferences.
  *

--- a/src/library/scala/math/PartialOrdering.scala
+++ b/src/library/scala/math/PartialOrdering.scala
@@ -14,7 +14,7 @@ package math
  *  of partial ordering on some type.  This trait is for representing the
  *  latter.
  *
- *  A [[http://en.wikipedia.org/wiki/Partial_order partial ordering]] is a
+ *  A [[http://en.wikipedia.org/wiki/Partially_ordered_set partial ordering]] is a
  *  binary relation on a type `T`, exposed as the `lteq` method of this trait.
  *  This relation must be:
  *

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -135,7 +135,7 @@ object ScalaRunTime {
     arr
   }
 
-  // Java bug: http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4071957
+  // Java bug: https://bugs.java.com/view_bug.do?bug_id=4071957
   // More background at ticket #2318.
   def ensureAccessible(m: JMethod): JMethod = scala.reflect.ensureAccessible(m)
 

--- a/src/library/scala/sys/process/Process.scala
+++ b/src/library/scala/sys/process/Process.scala
@@ -156,7 +156,7 @@ trait ProcessCreation {
     * import java.io.File
     *
     * val spde = new URL("http://technically.us/spde.html")
-    * val dispatch = new URL("http://dispatch.databinder.net/Dispatch.html")
+    * val dispatch = new URL("https://dispatchhttp.org/Dispatch.html")
     * val build = new File("project/build.properties")
     * cat(spde, dispatch, build) #| "grep -i scala" !
     * }}}

--- a/src/library/scala/util/MurmurHash.scala
+++ b/src/library/scala/util/MurmurHash.scala
@@ -10,7 +10,7 @@ package scala
 package util
 
 /** An implementation of Austin Appleby's MurmurHash 3.0 algorithm
- *  (32 bit version); reference: https://github.com/aappleby/smhasher
+ *  (32 bit version); reference: [[https://github.com/aappleby/smhasher]]
  *
  *  This is the hash used by collections and case classes (including
  *  tuples).

--- a/src/library/scala/util/control/TailCalls.scala
+++ b/src/library/scala/util/control/TailCalls.scala
@@ -15,7 +15,7 @@ package util.control
  *  of evaluating a tailcalling function can be retrieved from a `Tailrec`
  *  value using method `result`.
  *  Implemented as described in "Stackless Scala with Free Monads"
- *  http://blog.higher-order.com/assets/trampolines.pdf
+ *  [[http://blog.higher-order.com/assets/trampolines.pdf]]
  *
  *  Here's a usage example:
  *  {{{


### PR DESCRIPTION
- A couple of links to release notes are to non-existent RC tags
- Some links are not active in HTML because they're missing `[[` and `]]` brackets
- Some web sites links are broken or redirects
- There are unnecessary http apidoc links which Scaladoc could make
- Miscellaneous bogus syntax 