### PR TITLE
Enforce maxerrs more robustly

### DIFF
--- a/src/compiler/scala/tools/nsc/reporters/AbstractReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/AbstractReporter.scala
@@ -9,11 +9,8 @@ package reporters
 import scala.collection.mutable
 import scala.tools.nsc.Settings
 import scala.reflect.internal.util.Position
-// TODO
-//import scala.reflect.internal.Reporter
 
-/**
- * This reporter implements filtering.
+/** This reporter implements filtering by severity and position.
  */
 abstract class AbstractReporter extends Reporter {
   val settings: Settings

--- a/src/compiler/scala/tools/nsc/reporters/AbstractReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/AbstractReporter.scala
@@ -9,6 +9,8 @@ package reporters
 import scala.collection.mutable
 import scala.tools.nsc.Settings
 import scala.reflect.internal.util.Position
+// TODO
+//import scala.reflect.internal.Reporter
 
 /**
  * This reporter implements filtering.

--- a/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
@@ -62,6 +62,7 @@ class ConsoleReporter(val settings: Settings, reader: BufferedReader, writer: Pr
     for (k <- List(WARNING, ERROR) if k.count > 0) printMessage(s"${countAs(k.count, label(k))} found")
 
   def display(pos: Position, msg: String, severity: Severity): Unit = {
+    // the count includes the current message
     val ok = severity match {
       case ERROR   => ERROR.count   <= settings.maxerrs.value
       case WARNING => WARNING.count <= settings.maxwarns.value

--- a/src/compiler/scala/tools/nsc/reporters/LimitingReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/LimitingReporter.scala
@@ -1,0 +1,18 @@
+package scala.tools.nsc
+package reporters
+
+// TODO
+//import scala.reflect.internal.Reporter
+import scala.reflect.internal.{Reporter => InternalReporter, FilteringReporter}
+import scala.reflect.internal.util.Position
+
+/** A `Filter` that respects `-Xmaxerrs` and `-Xmaxwarns`.
+ */
+class LimitingReporter(settings: Settings, override protected val delegate: InternalReporter) extends Reporter with FilteringReporter {
+  override protected def filter(pos: Position, msg: String, severity: Severity) =
+    severity match {
+      case ERROR   => errorCount   < settings.maxerrs.value
+      case WARNING => warningCount < settings.maxwarns.value
+      case _       => true
+    }
+}

--- a/src/compiler/scala/tools/nsc/reporters/LimitingReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/LimitingReporter.scala
@@ -1,8 +1,6 @@
 package scala.tools.nsc
 package reporters
 
-// TODO
-//import scala.reflect.internal.Reporter
 import scala.reflect.internal.{Reporter => InternalReporter, FilteringReporter}
 import scala.reflect.internal.util.Position
 

--- a/src/compiler/scala/tools/nsc/reporters/NoReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/NoReporter.scala
@@ -1,9 +1,12 @@
 package scala.tools.nsc.reporters
+
 import scala.reflect.internal.util.Position
+// TODO
+//import scala.reflect.internal.Reporter
 
 /**
-  * A reporter that ignores reports
+  * A reporter that ignores reports.
   */
-object NoReporter extends Reporter{
+object NoReporter extends Reporter {
   override protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = ()
 }

--- a/src/compiler/scala/tools/nsc/reporters/NoReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/NoReporter.scala
@@ -1,12 +1,11 @@
 package scala.tools.nsc.reporters
 
 import scala.reflect.internal.util.Position
-// TODO
-//import scala.reflect.internal.Reporter
 
-/**
-  * A reporter that ignores reports.
-  */
+/** A reporter that ignores reports.
+ *
+ *  It should probably be called RudeReporter.
+ */
 object NoReporter extends Reporter {
-  override protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = ()
+  protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = ()
 }

--- a/src/compiler/scala/tools/nsc/reporters/Reporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/Reporter.scala
@@ -10,11 +10,10 @@ import scala.reflect.internal.util._
 
 /** Report information, warnings and errors.
  *
- * This describes the internal interface for issuing information, warnings and errors.
- * The only abstract method in this class must be info0.
+ *  This describes the internal interface for issuing information, warnings and errors.
+ *  The only abstract method in this class must be info0.
  *
- * TODO: Move external clients (sbt/ide/partest) to reflect.internal.Reporter,
- *       and remove this class.
+ *  TODO: Move external clients (sbt/ide/partest) to reflect.internal.Reporter, and remove this class.
  */
 abstract class Reporter extends scala.reflect.internal.Reporter {
   /** Informational messages. If `!force`, they may be suppressed. */

--- a/src/compiler/scala/tools/nsc/reporters/StoreReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/StoreReporter.scala
@@ -8,18 +8,14 @@ package reporters
 
 import scala.collection.mutable
 import scala.reflect.internal.util.Position
-// TODO
-//import scala.reflect.internal.Reporter
 
-/**
- * This class implements a Reporter that stores its reports in the set `infos`.
- */
+/** This class implements a Reporter that stores its reports in the set `infos`. */
 class StoreReporter extends Reporter {
   case class Info(pos: Position, msg: String, severity: Severity) {
     override def toString() = s"pos: $pos $msg $severity"
   }
   val infos = new mutable.LinkedHashSet[Info]
-  override protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = {
+  protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = {
     if (!force) {
       infos += Info(pos, msg, severity)
       severity.count += 1

--- a/src/compiler/scala/tools/nsc/reporters/StoreReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/StoreReporter.scala
@@ -8,22 +8,23 @@ package reporters
 
 import scala.collection.mutable
 import scala.reflect.internal.util.Position
+// TODO
+//import scala.reflect.internal.Reporter
 
 /**
  * This class implements a Reporter that stores its reports in the set `infos`.
  */
 class StoreReporter extends Reporter {
   case class Info(pos: Position, msg: String, severity: Severity) {
-    override def toString() = "pos: " + pos + " " + msg + " " + severity
+    override def toString() = s"pos: $pos $msg $severity"
   }
   val infos = new mutable.LinkedHashSet[Info]
-  protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean) {
+  override protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = {
     if (!force) {
       infos += Info(pos, msg, severity)
       severity.count += 1
     }
   }
-
   override def reset() {
     super.reset()
     infos.clear()

--- a/test/files/run/maxerrs.scala
+++ b/test/files/run/maxerrs.scala
@@ -1,0 +1,34 @@
+
+import scala.tools.partest._
+import scala.tools.nsc._
+import scala.tools.nsc.{Global, Settings}
+import scala.tools.nsc.reporters.StoreReporter
+
+object Test extends DirectTest {
+
+  override def code = """
+    class C {
+      def f(vs: Int*) = vs.sum
+
+      def g = f("","","","","","","","","","")
+    }
+  """.trim
+
+  override def extraSettings = "-usejavacp"
+
+  // a reporter that ignores all limits
+  lazy val store = new StoreReporter
+
+  final val limit = 3
+
+  override def show(): Unit = {
+    compile()
+    assert(store.infos.size == limit)
+  }
+  override def newSettings(args: List[String]) = {
+    val s = super.newSettings(args)
+    s.maxerrs.value = limit
+    s
+  }
+  override def reporter(s: Settings) = store
+}


### PR DESCRIPTION
`-Xmaxerrs` is currently advisory and depends on the good will
of the reporter. The standard console reporter is well-advised,
but others are not, such as sbt, which uses an sbt setting to
control logging.

This commit adds a simple filter in front of any reporter
deemed untrustworthy, if `-Xmaxerrs` has been set to a value
lower than the default.