### PR TITLE
Enable issue navigation for IntelliJ.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -351,7 +351,7 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
       case mt @ MethodType(params, res) => copyMethodType(mt, selfParamSym :: params, res)
     })
     val selfParam = ValDef(selfParamSym)
-    val rhs = orig.rhs.substituteThis(newSym.owner, gen.mkAttributedIdent(selfParamSym)) // SD-186 intentionally leaving Ident($this) is unpositioned
+    val rhs = orig.rhs.substituteThis(newSym.owner, gen.mkAttributedIdent(selfParamSym)) // scala/scala-dev#186 intentionally leaving Ident($this) is unpositioned
       .substituteSymbols(origParams, newSym.info.params.drop(1)).changeOwner(origSym -> newSym)
     treeCopy.DefDef(orig, orig.mods, orig.name, orig.tparams, (selfParam :: orig.vparamss.head) :: Nil, orig.tpt, rhs).setSymbol(newSym)
   }

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -179,11 +179,12 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
      */
     private def addModuleInstanceField() {
       // TODO confirm whether we really don't want ACC_SYNTHETIC nor ACC_DEPRECATED
-      // SD-194 This can't be FINAL on JVM 1.9+ because we assign it from within the
-      //        instance constructor, not from <clinit> directly. Assignment from <clinit>,
-      //        after the constructor has completely finished, seems like the principled
-      //        thing to do, but it would change behaviour when "benign" cyclic references
-      //        between modules exist.
+      // scala/scala-dev#194:
+      //   This can't be FINAL on JVM 1.9+ because we assign it from within the
+      //   instance constructor, not from <clinit> directly. Assignment from <clinit>,
+      //   after the constructor has completely finished, seems like the principled
+      //   thing to do, but it would change behaviour when "benign" cyclic references
+      //   between modules exist.
       val mods = GenBCode.PublicStatic
       val fv =
         cnode.visitField(mods,

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
@@ -74,7 +74,7 @@ abstract class BCodeSyncAndTry extends BCodeBodyBuilder {
        *            Reached upon abrupt termination of (2).
        *            Protected by whatever protects the whole synchronized expression.
        *            null => "any" exception in bytecode, like we emit for finally.
-       *            Important not to use j/l/Throwable which dooms the method to a life of interpretation! (SD-233)
+       *            Important not to use j/l/Throwable which dooms the method to a life of interpretation! (scala/scala-dev#233)
        * ------
        */
       protect(startProtected, endProtected, currProgramPoint(), null)

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
@@ -313,7 +313,7 @@ abstract class CallGraph {
           // TODO: type analysis can render more calls statically resolved. Example:
           //   new A.f  // can be inlined, the receiver type is known to be exactly A.
           val isStaticallyResolved: Boolean = {
-            isNonVirtualCall(call) || // SD-86: super calls (invokespecial) can be inlined -- TODO: check if that's still needed, and if it's correct: scala-dev#143
+            isNonVirtualCall(call) || // scala/scala-dev#86: super calls (invokespecial) can be inlined -- TODO: check if that's still needed, and if it's correct: scala-dev#143
             methodInlineInfo.effectivelyFinal ||
               receiverType.info.orThrow.inlineInfo.isEffectivelyFinal // (1)
           }

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -152,13 +152,14 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
           }
         }
 
-        // SD-143: a call super[T].m that resolves to A.m cannot be translated to correct bytecode if
-        //   - A is a class (not a trait / interface), but not the direct superclass. Invokespecial
-        //     would select an overriding method in the direct superclass, rather than A.m.
-        //     We allow this if there are statically no intervening overrides.
-        //     https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokespecial
-        //   - A is a java-defined interface and not listed as direct parent of the class. In this
-        //     case, `invokespecial A.m` would be invalid.
+        // scala/scala-dev#143:
+        //   a call super[T].m that resolves to A.m cannot be translated to correct bytecode if
+        //     - A is a class (not a trait / interface), but not the direct superclass. Invokespecial
+        //       would select an overriding method in the direct superclass, rather than A.m.
+        //       We allow this if there are statically no intervening overrides.
+        //       https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokespecial
+        //     - A is a java-defined interface and not listed as direct parent of the class. In this
+        //       case, `invokespecial A.m` would be invalid.
         def hasClassOverride(member: Symbol, subclass: Symbol): Boolean = {
           if (subclass == ObjectClass || subclass == member.owner) false
           else if (member.overridingSymbol(subclass) != NoSymbol) true

--- a/src/intellij/scala.ipr.SAMPLE
+++ b/src/intellij/scala.ipr.SAMPLE
@@ -22,6 +22,16 @@
     </profile>
     <version value="1.0" />
   </component>
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="scala/([\w.-]+)#([0-9]+)" />
+          <option name="linkRegexp" value="https://github.com/scala/$1/pull/$2" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
   <component name="Palette2">
     <group name="Swing">
       <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.png" removable="false" auto-create-binding="false" can-attach-label="false">

--- a/test/junit/scala/lang/traits/BytecodeTest.scala
+++ b/test/junit/scala/lang/traits/BytecodeTest.scala
@@ -321,7 +321,7 @@ class BytecodeTest extends BytecodeTesting {
     val jCode = List("interface A { default int m() { return 1; } }" -> "A.java")
 
 
-    // used to crash in the backend (SD-210) under `-Xmixin-force-forwarders:true`
+    // used to crash in the backend (scala/scala-dev#210) under `-Xmixin-force-forwarders:true`
     val code1 =
       """trait B1 extends A // called "B1" not "B" due to scala-dev#214
         |class C extends B1


### PR DESCRIPTION
- Cmd-click (Ctrl-click) on scala/bug#1234 goes to that issue page on GitHub.

I've got these in other projects and I just realized that they're vanishing from scala because I keep running `intellijFromSample` when I go to/from `2.12.x`. 

Dunno if this has been considered and rejected, but I've found it pretty convenient.

- SD-1234 ticket references changed to scala/scala-dev#1234. 9acab45aee already normalized all bug references to this form.