### PR TITLE
Allow Nothing sequence argument

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
@@ -133,8 +133,9 @@ trait PatternTypers {
       val Typed(expr, tpt) = tree
       val exprTyped = typed(expr, mode)
       val baseClass = exprTyped.tpe.typeSymbol match {
-        case ArrayClass => ArrayClass
-        case _          => SeqClass
+        case ArrayClass   => ArrayClass
+        case NothingClass => NothingClass
+        case _            => SeqClass
       }
       val starType = baseClass match {
         case ArrayClass if isPrimitiveValueType(pt) || !isFullyDefined(pt) => arrayType(pt)
@@ -143,8 +144,9 @@ trait PatternTypers {
       }
       val exprAdapted = adapt(exprTyped, mode, starType)
       exprAdapted.tpe baseType baseClass match {
-        case TypeRef(_, _, elemtp :: Nil) => treeCopy.Typed(tree, exprAdapted, tpt setType elemtp) setType elemtp
-        case _                            => setError(tree)
+        case TypeRef(_, _, elemtp :: Nil)   => treeCopy.Typed(tree, exprAdapted, tpt setType elemtp) setType elemtp
+        case _ if baseClass eq NothingClass => exprAdapted
+        case _                              => setError(tree)
       }
     }
 

--- a/test/files/pos/t8343.scala
+++ b/test/files/pos/t8343.scala
@@ -1,0 +1,4 @@
+
+trait T {
+  def f = List[Int](??? : _*)
+}


### PR DESCRIPTION
There's nothing wrong with `List(??? : _*)` pun intended.

Previously, nothing was trivially adapted to seq, and marked erroneous without emitting an error.

Fixes scala/bug#8343