### PR TITLE
Fix link in comment

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -25,7 +25,7 @@ import parallel.immutable.ParHashMap
  *  @author  Tiark Rompf
  *  @version 2.8
  *  @since   2.3
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#hash_tries "Scala's Collection Library overview"]]
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#hash-tries "Scala's Collection Library overview"]]
  *  section on `Hash Tries` for more information.
  *  @define Coll `immutable.HashMap`
  *  @define coll immutable hash map


### PR DESCRIPTION
The link pointed to an anchor that wasn't present on the page.