### PR TITLE
Make updateDynamic work with context bounds

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4341,7 +4341,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       def typedAssign(lhs: Tree, rhs: Tree): Tree = {
         // see scala/bug#7617 for an explanation of why macro expansion is suppressed
-        def typedLhs(lhs: Tree) = typed(lhs, EXPRmode | LHSmode)
+        def typedLhs(lhs: Tree) = typed(lhs, EXPRmode | LHSmode | POLYmode)
         val lhs1    = unsuppressMacroExpansion(typedLhs(suppressMacroExpansion(lhs)))
         val varsym  = lhs1.symbol
 
@@ -4371,9 +4371,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           treeCopy.Assign(tree, lhs1, checkDead(rhs1)) setType UnitTpe
         }
         else if(dyna.isDynamicallyUpdatable(lhs1)) {
-          val rhs1 = typedByValueExpr(rhs)
-          val t = atPos(lhs1.pos.withEnd(rhs1.pos.end)) {
-            Apply(lhs1, List(rhs1))
+          val t = atPos(lhs1.pos.withEnd(rhs.pos.end)) {
+            Apply(lhs1, List(rhs))
           }
           dyna.wrapErrors(t, _.typed1(t, mode, pt))
         }

--- a/test/files/pos/t10406.scala
+++ b/test/files/pos/t10406.scala
@@ -1,0 +1,13 @@
+import language.dynamics
+
+trait Typeclass[T]
+class TCInstance
+object TCInstance {
+  implicit object instance extends Typeclass[TCInstance]
+}
+class Dyn extends Dynamic {
+  def updateDynamic[T: Typeclass](f: String)(t: T) = println(s"$f: $t")
+}
+object Dyn {
+  new Dyn().foo = new TCInstance
+}


### PR DESCRIPTION
Avoid inferring any type parameters to `updateDynamic` too early, and allow them to be inferred from the RHS.

Fixes scala/bug#10406