### PR TITLE
Deprecate subtype notation for trait extends

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2886,9 +2886,8 @@ self =>
       val name = ident()
       val tstart = in.offset
       atPos(start, if (name == nme.ERROR) start else nameOffset) {
-        val mods1 = if (in.token == SUBTYPE) mods | Flags.DEFERRED else mods
-        val template = templateOpt(mods1, name, NoMods, Nil, tstart)
-        ModuleDef(mods1, name.toTermName, template)
+        val template = templateOpt(mods, name, NoMods, Nil, tstart)
+        ModuleDef(mods, name.toTermName, template)
       }
     }
 
@@ -2990,13 +2989,17 @@ self =>
 
     /** {{{
      *  ClassTemplateOpt ::= `extends' ClassTemplate | [[`extends'] TemplateBody]
-     *  TraitTemplateOpt ::= TraitExtends TraitTemplate | [[`extends'] TemplateBody] | `<:' TemplateBody
-     *  TraitExtends     ::= `extends' | `<:'
+     *  TraitTemplateOpt ::= TraitExtends TraitTemplate | [[TraitExtends] TemplateBody]
+     *  TraitExtends     ::= `extends' | `<:' (deprecated)
      *  }}}
      */
     def templateOpt(mods: Modifiers, name: Name, constrMods: Modifiers, vparamss: List[List[ValDef]], tstart: Offset): Template = {
+      def deprecatedUsage(): Boolean = {
+        deprecationWarning(in.offset, "Using `<:` for `extends` is deprecated", since = "2.12.5")
+        true
+      }
       val (parents, self, body) = (
-        if (in.token == EXTENDS || in.token == SUBTYPE && mods.isTrait) {
+        if (in.token == EXTENDS || in.token == SUBTYPE && mods.isTrait && deprecatedUsage()) {
           in.nextToken()
           template()
         }

--- a/test/files/neg/t10678.check
+++ b/test/files/neg/t10678.check
@@ -1,0 +1,11 @@
+t10678.scala:4: warning: Using `<:` for `extends` is deprecated
+trait U <: T
+        ^
+t10678.scala:6: error: ';' expected but '<:' found.
+class C <: T {
+        ^
+t10678.scala:9: error: ';' expected but '<:' found.
+object O <: T {
+         ^
+one warning found
+two errors found

--- a/test/files/neg/t10678.flags
+++ b/test/files/neg/t10678.flags
@@ -1,0 +1,1 @@
+-deprecation -Xfatal-warnings

--- a/test/files/neg/t10678.scala
+++ b/test/files/neg/t10678.scala
@@ -1,0 +1,10 @@
+
+trait T
+
+trait U <: T
+
+class C <: T {
+}
+
+object O <: T {
+}


### PR DESCRIPTION

Fixes scala/bug#10678