### PR TITLE
Make Typer#dyna.mkInvoke more accurate

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -622,8 +622,10 @@ trait ContextErrors {
         NormalTypeError(tree, fun.tpe+" does not take parameters")
 
       // Dynamic
-      def DynamicVarArgUnsupported(tree: Tree, name: Name) =
-        issueNormalTypeError(tree, name+ " does not support passing a vararg parameter")
+      def DynamicVarArgUnsupported(tree: Tree, name: Name) = {
+        issueNormalTypeError(tree, name + " does not support passing a vararg parameter")
+        setError(tree)
+      }
 
       def DynamicRewriteError(tree: Tree, err: AbsTypeError) = {
         issueTypeError(PosAndMsgTypeError(err.errPos, err.errMsg +

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4183,7 +4183,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               val op = if(args.exists(_.isInstanceOf[AssignOrNamedArg])) nme.applyDynamicNamed else nme.applyDynamic
               // not supported: foo.bar(a1,..., an: _*)
               val fn1 = if(treeInfo.isWildcardStarArgList(args)) DynamicVarArgUnsupported(fn, op) else fn
-              Some((op, fn))
+              Some((op, fn1))
             case Assign(lhs, _) if matches(lhs) => Some((nme.updateDynamic, lhs))
             case _ if matches(t)                => Some((nme.selectDynamic, t))
             case _                              => t.children.flatMap(findSelection).headOption

--- a/test/files/neg/applydynamic_sip.check
+++ b/test/files/neg/applydynamic_sip.check
@@ -1,15 +1,30 @@
 applydynamic_sip.scala:7: error: applyDynamic does not support passing a vararg parameter
   qual.sel(a, a2: _*)
        ^
+applydynamic_sip.scala:7: error: value applyDynamic is not a member of Dynamic
+error after rewriting to Test.this.qual.<applyDynamic: error>("sel")
+possible cause: maybe a wrong Dynamic method signature?
+  qual.sel(a, a2: _*)
+  ^
 applydynamic_sip.scala:8: error: applyDynamicNamed does not support passing a vararg parameter
   qual.sel(arg = a, a2: _*)
        ^
+applydynamic_sip.scala:8: error: value applyDynamicNamed is not a member of Dynamic
+error after rewriting to Test.this.qual.<applyDynamicNamed: error>("sel")
+possible cause: maybe a wrong Dynamic method signature?
+  qual.sel(arg = a, a2: _*)
+  ^
 applydynamic_sip.scala:8: error: not found: value arg
   qual.sel(arg = a, a2: _*)
            ^
 applydynamic_sip.scala:9: error: applyDynamicNamed does not support passing a vararg parameter
   qual.sel(arg, arg2 = "a2", a2: _*)
        ^
+applydynamic_sip.scala:9: error: value applyDynamicNamed is not a member of Dynamic
+error after rewriting to Test.this.qual.<applyDynamicNamed: error>("sel")
+possible cause: maybe a wrong Dynamic method signature?
+  qual.sel(arg, arg2 = "a2", a2: _*)
+  ^
 applydynamic_sip.scala:9: error: not found: value arg
   qual.sel(arg, arg2 = "a2", a2: _*)
            ^
@@ -70,4 +85,4 @@ error after rewriting to Test.this.bad2.updateDynamic("sel")
 possible cause: maybe a wrong Dynamic method signature?
   bad2.sel = 1
   ^
-16 errors found
+19 errors found

--- a/test/files/pos/t7420.scala
+++ b/test/files/pos/t7420.scala
@@ -1,0 +1,13 @@
+import language.dynamics
+
+case class ArtifactGroup(org: String, pre: String, rev: String) extends Dynamic {
+  def selectDynamic(name: String) = s"$org:$pre-$name:$rev"
+}
+
+object Test {
+  val library = ArtifactGroup("org.scala", "amazing-library", "7.2.4")
+
+  def a = Seq(library.core, library.mail)
+  def b = Seq(a: _*)
+  def c = Seq(Seq(library.core, library.mail): _*)
+}


### PR DESCRIPTION
When searching the context for the tree in question, make sure to
actually check that the tree under scrutiny matches the one we're
looking for. This means that the check for varargs won't give a false
positive if the context is too large. Fixes scala/bug#7420.

Adjust the "vararg not supported" error so it doesn't hide other errors.