### PR TITLE
Case also ends block stats in special cases

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -3217,11 +3217,12 @@ self =>
      *  }}}
      */
     def blockStatSeq(): List[Tree] = checkNoEscapingPlaceholders {
+      def acceptStatSepOptOrEndCase() = if (!isCaseDefEnd) acceptStatSepOpt()
       val stats = new ListBuffer[Tree]
       while (!isStatSeqEnd && !isCaseDefEnd) {
         if (in.token == IMPORT) {
           stats ++= importClause()
-          acceptStatSepOpt()
+          acceptStatSepOptOrEndCase()
         }
         else if (isDefIntro || isLocalModifier || isAnnotation) {
           if (in.token == IMPLICIT) {
@@ -3231,11 +3232,11 @@ self =>
           } else {
             stats ++= localDef(0)
           }
-          acceptStatSepOpt()
+          acceptStatSepOptOrEndCase()
         }
         else if (isExprIntro) {
           stats += statement(InBlock)
-          if (!isCaseDefEnd) acceptStatSep()
+          acceptStatSepOptOrEndCase()
         }
         else if (isStatSep) {
           in.nextToken()

--- a/test/files/pos/t10684.scala
+++ b/test/files/pos/t10684.scala
@@ -1,0 +1,13 @@
+
+
+trait T {
+
+  def f = List(1) map { case i if i > 0 => implicit j: Int => i + implicitly[Int]  case _ => implicit j: Int => 42 }
+
+  def g = List(1) map { case i if i > 0 => import concurrent._  case _ => implicit j: Int => 42 }
+
+  def h = List(1) map { case i if i > 0 => val x = 42  case _ => implicit j: Int => () }
+
+  // separator is optional
+  def k = List(1) map { case i if i > 0 => implicit j: Int => i + implicitly[Int] ; case _ => implicit j: Int => 42 }
+}


### PR DESCRIPTION
In a few special cases, block statement sequence would finish on `}` but not on `case`.

Possibly other statement sequences would also necessarily terminate on `case` keyword, but that was not tested here.

Fixes scala/bug#10684