### PR TITLE
Improve error message when using a Java class as a value.

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -970,7 +970,10 @@ abstract class ClassfileParser {
           val s = module.info.decls.lookup(n)
           if (s != NoSymbol) Some(LiteralAnnotArg(Constant(s)))
           else {
-            warning(s"""While parsing annotations in ${in.file}, could not find $n in enum $module.\nThis is likely due to an implementation restriction: an annotation argument cannot refer to a member of the annotated class (scala/bug#7014).""")
+            warning(
+              sm"""While parsing annotations in ${in.file}, could not find $n in enum ${module.nameString}.
+                  |This is likely due to an implementation restriction: an annotation argument cannot refer to a member of the annotated class (scala/bug#7014)."""
+            )
             None
           }
 

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -750,7 +750,12 @@ trait ContextErrors {
 
       // def stabilize
       def NotAValueError(tree: Tree, sym: Symbol) = {
-        issueNormalTypeError(tree, sym.kindString + " " + sym.fullName + " is not a value")
+        /* Give a better error message for `val thread = java.lang.Thread`. */
+        val betterKindString =
+          if (sym.isJavaDefined && sym.isTrait) "Java interface"
+          else if (sym.isJavaDefined && (sym.isClass || sym.isModule)) "Java class"
+          else sym.kindString
+        issueNormalTypeError(tree, s"$betterKindString ${sym.fullName} is not a value")
         setError(tree)
       }
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -197,7 +197,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def paramLists: List[List[Symbol]] = paramss
   }
 
-  private[reflect] case class SymbolKind(accurate: String, sanitized: String, abbreviation: String)
+  private[reflect] final case class SymbolKind(accurate: String, sanitized: String, abbreviation: String) {
+    def skolemize: SymbolKind = copy(accurate = s"$accurate skolem", abbreviation = s"$abbreviation#SKO")
+  }
 
   protected def newStubSymbol(owner: Symbol,
                               name: Name,
@@ -2579,7 +2581,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       else ""
 
     private def symbolKind: SymbolKind = {
-      var kind =
+      implicit val triple2SK = (SymbolKind.apply _).tupled
+      val kind: SymbolKind =
         if (isTermMacro)                         ("term macro",           "macro method",    "MACM")
         else if (isInstanceOf[FreeTermSymbol])   ("free term",            "free term",       "FTE")
         else if (isInstanceOf[FreeTypeSymbol])   ("free type",            "free type",       "FTY")
@@ -2589,6 +2592,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         else if (isPackageObjectClass)           ("package object class", "package",         "PKOC")
         else if (isAnonymousClass)               ("anonymous class",      "anonymous class", "AC")
         else if (isRefinementClass)              ("refinement class",     "",                "RC")
+        else if (isJavaAnnotation)               ("Java annotation",      "Java annotation", "JANN")
+        else if (isJavaEnum
+            || companion.isJavaEnum)             ("Java enumeration",     "Java enum",       "JENUM")
+        else if (isJava && isModule)             ("Java module",          "class",           "JMOD")
+        else if (isJava && isModuleClass)        ("Java module class",    "class",           "JMODC")
         else if (isModule)                       ("module",               "object",          "MOD")
         else if (isModuleClass)                  ("module class",         "object",          "MODC")
         else if (isAccessor &&
@@ -2606,9 +2614,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         else if (isTerm)                         ("value",                "value",           "VAL")
         else                                     ("",                     "",                "???")
 
-      if (isSkolem) kind = (kind._1, kind._2, kind._3 + "#SKO")
-
-      SymbolKind(kind._1, kind._2, kind._3)
+      if (isSkolem) kind.skolemize else kind
     }
 
     /** Accurate string representation of symbols' kind, suitable for developers. */

--- a/test/files/neg/object-not-a-value.check
+++ b/test/files/neg/object-not-a-value.check
@@ -1,4 +1,4 @@
-object-not-a-value.scala:5: error: object java.util.List is not a value
+object-not-a-value.scala:5: error: Java class java.util.List is not a value
     List(1) map (_ + 1)
     ^
 one error found

--- a/test/files/neg/protected-static-fail.check
+++ b/test/files/neg/protected-static-fail.check
@@ -1,4 +1,4 @@
-S.scala:5: error: method f in object J cannot be accessed in object bippy.J
+S.scala:5: error: method f in class J cannot be accessed in object bippy.J
     J.f()
       ^
 S.scala:6: error: method f1 in object S1 cannot be accessed in object bippy.S1

--- a/test/files/neg/t0673.check
+++ b/test/files/neg/t0673.check
@@ -1,4 +1,4 @@
-Test.scala:2: error: object JavaClass.InnerClass is not a value
+Test.scala:2: error: Java class JavaClass.InnerClass is not a value
   val x = JavaClass.InnerClass
                     ^
 one error found

--- a/test/files/neg/t6934.check
+++ b/test/files/neg/t6934.check
@@ -1,7 +1,7 @@
-ScalaMain.scala:6: error: variable STATIC_PROTECTED_FIELD in object JavaClass cannot be accessed in object test.JavaClass
+ScalaMain.scala:6: error: variable STATIC_PROTECTED_FIELD in class JavaClass cannot be accessed in object test.JavaClass
  Access to protected variable STATIC_PROTECTED_FIELD not permitted because
  enclosing object ScalaMain in package test2 is not a subclass of
- object JavaClass in package test where target is defined
+ class JavaClass in package test where target is defined
     val a = test.JavaClass.STATIC_PROTECTED_FIELD
                            ^
 one error found

--- a/test/files/neg/t7014.check
+++ b/test/files/neg/t7014.check
@@ -1,4 +1,4 @@
-warning: While parsing annotations in t7014-neg.obj/t7014/ThreadSafetyLevel_1.class, could not find COMPLETELY_THREADSAFE in enum object ThreadSafetyLevel_1.
+warning: While parsing annotations in t7014-neg.obj/t7014/ThreadSafetyLevel_1.class, could not find COMPLETELY_THREADSAFE in enum ThreadSafetyLevel_1.
 This is likely due to an implementation restriction: an annotation argument cannot refer to a member of the annotated class (scala/bug#7014).
 error: No warnings can be incurred under -Xfatal-warnings.
 one warning found

--- a/test/files/neg/t7251.check
+++ b/test/files/neg/t7251.check
@@ -1,4 +1,4 @@
-B_2.scala:5: error: object s.Outer$Triple$ is not a value
+B_2.scala:5: error: Java class s.Outer$Triple$ is not a value
     println( s.Outer$Triple$ )
                ^
 one error found

--- a/test/files/run/reflection-fancy-java-classes.check
+++ b/test/files/run/reflection-fancy-java-classes.check
@@ -9,4 +9,4 @@ isAnonymousClass = true
 
 ===== SCALA POV =====
 class 1
-object Foo_1
+class Foo_1

--- a/test/files/run/t6814.check
+++ b/test/files/run/t6814.check
@@ -1,6 +1,6 @@
 List[Int]
 scala.collection.immutable.List.type
-object java.lang.RuntimeException is not a value
+Java class java.lang.RuntimeException is not a value
 List[Int]
 List
 scala.collection.immutable.List.type

--- a/test/files/run/t6989.check
+++ b/test/files/run/t6989.check
@@ -47,43 +47,43 @@ isProtected = false
 isPublic = true
 privateWithin = <none>
 ============
-sym = object PackagePrivateJavaClass, signature = foo.PackagePrivateJavaClass.type, owner = package foo
+sym = class PackagePrivateJavaClass, signature = foo.PackagePrivateJavaClass.type, owner = package foo
 isPrivate = false
 isProtected = false
 isPublic = false
 privateWithin = package foo
 ============
-sym = variable privateStaticField, signature = Int, owner = object PackagePrivateJavaClass
+sym = variable privateStaticField, signature = Int, owner = class PackagePrivateJavaClass
 isPrivate = true
 isProtected = false
 isPublic = false
 privateWithin = <none>
 ============
-sym = method privateStaticMethod, signature = ()Unit, owner = object PackagePrivateJavaClass
+sym = method privateStaticMethod, signature = ()Unit, owner = class PackagePrivateJavaClass
 isPrivate = true
 isProtected = false
 isPublic = false
 privateWithin = <none>
 ============
-sym = variable protectedStaticField, signature = Int, owner = object PackagePrivateJavaClass
+sym = variable protectedStaticField, signature = Int, owner = class PackagePrivateJavaClass
 isPrivate = false
 isProtected = true
 isPublic = false
 privateWithin = package foo
 ============
-sym = method protectedStaticMethod, signature = ()Unit, owner = object PackagePrivateJavaClass
+sym = method protectedStaticMethod, signature = ()Unit, owner = class PackagePrivateJavaClass
 isPrivate = false
 isProtected = true
 isPublic = false
 privateWithin = package foo
 ============
-sym = variable publicStaticField, signature = Int, owner = object PackagePrivateJavaClass
+sym = variable publicStaticField, signature = Int, owner = class PackagePrivateJavaClass
 isPrivate = false
 isProtected = false
 isPublic = true
 privateWithin = <none>
 ============
-sym = method publicStaticMethod, signature = ()Unit, owner = object PackagePrivateJavaClass
+sym = method publicStaticMethod, signature = ()Unit, owner = class PackagePrivateJavaClass
 isPrivate = false
 isProtected = false
 isPublic = true
@@ -113,7 +113,7 @@ isProtected = false
 isPublic = false
 privateWithin = package foo
 ============
-sym = object $PrivateJavaClass, signature = JavaClass_1.this.$PrivateJavaClass.type, owner = class JavaClass_1
+sym = class $PrivateJavaClass, signature = JavaClass_1.this.$PrivateJavaClass.type, owner = class JavaClass_1
 isPrivate = true
 isProtected = false
 isPublic = false
@@ -137,7 +137,7 @@ isProtected = false
 isPublic = false
 privateWithin = package foo
 ============
-sym = object $ProtectedJavaClass, signature = JavaClass_1.this.$ProtectedJavaClass.type, owner = class JavaClass_1
+sym = class $ProtectedJavaClass, signature = JavaClass_1.this.$ProtectedJavaClass.type, owner = class JavaClass_1
 isPrivate = false
 isProtected = false
 isPublic = false
@@ -161,7 +161,7 @@ isProtected = false
 isPublic = false
 privateWithin = package foo
 ============
-sym = object $PublicJavaClass, signature = JavaClass_1.this.$PublicJavaClass.type, owner = class JavaClass_1
+sym = class $PublicJavaClass, signature = JavaClass_1.this.$PublicJavaClass.type, owner = class JavaClass_1
 isPrivate = false
 isProtected = false
 isPublic = true
@@ -173,13 +173,13 @@ isProtected = false
 isPublic = true
 privateWithin = <none>
 ============
-sym = object JavaClass_1, signature = foo.JavaClass_1.type, owner = package foo
+sym = class JavaClass_1, signature = foo.JavaClass_1.type, owner = package foo
 isPrivate = false
 isProtected = false
 isPublic = true
 privateWithin = <none>
 ============
-sym = class PrivateStaticJavaClass, signature = ClassInfoType(...), owner = object JavaClass_1
+sym = class PrivateStaticJavaClass, signature = ClassInfoType(...), owner = class JavaClass_1
 isPrivate = true
 isProtected = false
 isPublic = false
@@ -191,13 +191,13 @@ isProtected = false
 isPublic = true
 privateWithin = <none>
 ============
-sym = object PrivateStaticJavaClass, signature = foo.JavaClass_1.PrivateStaticJavaClass.type, owner = object JavaClass_1
+sym = class PrivateStaticJavaClass, signature = foo.JavaClass_1.PrivateStaticJavaClass.type, owner = class JavaClass_1
 isPrivate = true
 isProtected = false
 isPublic = false
 privateWithin = <none>
 ============
-sym = class ProtectedStaticJavaClass, signature = ClassInfoType(...), owner = object JavaClass_1
+sym = class ProtectedStaticJavaClass, signature = ClassInfoType(...), owner = class JavaClass_1
 isPrivate = true
 isProtected = false
 isPublic = false
@@ -209,13 +209,13 @@ isProtected = false
 isPublic = true
 privateWithin = <none>
 ============
-sym = object ProtectedStaticJavaClass, signature = foo.JavaClass_1.ProtectedStaticJavaClass.type, owner = object JavaClass_1
+sym = class ProtectedStaticJavaClass, signature = foo.JavaClass_1.ProtectedStaticJavaClass.type, owner = class JavaClass_1
 isPrivate = true
 isProtected = false
 isPublic = false
 privateWithin = <none>
 ============
-sym = class PublicStaticJavaClass, signature = ClassInfoType(...), owner = object JavaClass_1
+sym = class PublicStaticJavaClass, signature = ClassInfoType(...), owner = class JavaClass_1
 isPrivate = false
 isProtected = false
 isPublic = true
@@ -227,13 +227,13 @@ isProtected = false
 isPublic = true
 privateWithin = <none>
 ============
-sym = object PublicStaticJavaClass, signature = foo.JavaClass_1.PublicStaticJavaClass.type, owner = object JavaClass_1
+sym = class PublicStaticJavaClass, signature = foo.JavaClass_1.PublicStaticJavaClass.type, owner = class JavaClass_1
 isPrivate = false
 isProtected = false
 isPublic = true
 privateWithin = <none>
 ============
-sym = variable staticField, signature = Int, owner = object JavaClass_1
+sym = variable staticField, signature = Int, owner = class JavaClass_1
 isPrivate = true
 isProtected = false
 isPublic = false

--- a/test/files/run/t7582-private-within.check
+++ b/test/files/run/t7582-private-within.check
@@ -1,6 +1,6 @@
 private[package pack] class JavaPackagePrivate
-private[package pack] module JavaPackagePrivate
-private[package pack] module class JavaPackagePrivate
+private[package pack] Java module JavaPackagePrivate
+private[package pack] Java module class JavaPackagePrivate
 private[package pack] field field
 private[package pack] primary constructor <init>
 private[package pack] method meth


### PR DESCRIPTION
As pointed out in gitter, it's kinda unfair to our users to refer to a Java class as an `object` in error messages, despite that being what the compiler sees.

Also, the `enum object` error emitted by `ClassfileParser` sounds kinda strange to my picky ears. `enum Foobar` is perfectly fine IM(V)HO.
  