### PR TITLE
Eliminate TypeVars and Wildcards early in glb/lub

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -158,31 +158,30 @@ private[internal] trait GlbLubs {
         rest filter (t => !first.typeSymbol.isSubClass(t.typeSymbol)))
   }
 
+  /** From a list of types, retain only maximal types as determined by the partial order `po`. */
+  private def maxTypes(ts: List[Type])(po: (Type, Type) => Boolean): List[Type] = {
+    def loop(ts: List[Type]): List[Type] = ts match {
+      case t :: ts1 =>
+        val ts2 = loop(ts1.filterNot(po(_, t)))
+        if (ts2.exists(po(t, _))) ts2 else t :: ts2
+      case Nil => Nil
+    }
+
+    loop(ts)
+  }
+
   /** Eliminate from list of types all elements which are a supertype
     *  of some other element of the list. */
-  private def elimSuper(ts: List[Type]): List[Type] = ts match {
-    case List() | List(_) => ts
-    case t :: ts1 =>
-      val rest = elimSuper(ts1 filter (t1 => !(t <:< t1)))
-      if (rest exists (t1 => t1 <:< t)) rest else t :: rest
-  }
+  private def elimSuper(ts: List[Type]): List[Type] =
+    maxTypes(ts)((t1, t2) => t2 <:< t1)
 
   /** Eliminate from list of types all elements which are a subtype
     *  of some other element of the list. */
-  private def elimSub(ts: List[Type], depth: Depth): List[Type] = {
-    def elimSub0(ts: List[Type]): List[Type] = ts match {
-      case List() => ts
-      case List(t) => ts
-      case t :: ts1 =>
-        val rest = elimSub0(ts1 filter (t1 => !isSubType(t1, t, depth.decr)))
-        if (rest exists (t1 => isSubType(t, t1, depth.decr))) rest else t :: rest
-    }
-    val ts0 = elimSub0(ts)
-    if (ts0.isEmpty || ts0.tail.isEmpty) ts0
-    else {
-      val ts1 = ts0 mapConserve (t => elimAnonymousClass(t.dealiasWiden))
-      if (ts1 eq ts0) ts0
-      else elimSub(ts1, depth)
+  @tailrec private def elimSub(ts: List[Type], depth: Depth): List[Type] = {
+    val ts1 = maxTypes(ts)(isSubType(_, _, depth.decr))
+    if (ts1.lengthCompare(1) <= 0) ts1 else {
+      val ts2 = ts1.mapConserve(t => elimAnonymousClass(t.dealiasWiden))
+      if (ts1 eq ts2) ts1 else elimSub(ts2, depth)
     }
   }
 

--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -167,7 +167,14 @@ private[internal] trait GlbLubs {
       case Nil => Nil
     }
 
-    loop(ts)
+    // The order here matters because type variables and
+    // wildcards can act both as subtypes and supertypes.
+    val (ts2, ts1) = ts.partition(_ exists {
+      case tv: TypeVar => !tv.isGround
+      case t => t.isWildcard
+    })
+
+    loop(ts1 ::: ts2)
   }
 
   /** Eliminate from list of types all elements which are a supertype

--- a/test/files/pos/t10686.scala
+++ b/test/files/pos/t10686.scala
@@ -1,0 +1,6 @@
+object Test {
+  def ltr[A](implicit ev: (Int, A) =:= (Int, String)) = null
+  def rtl[A](implicit ev: (Int, String) =:= (Int, A)) = null
+  ltr
+  rtl
+}

--- a/test/files/pos/t10740.scala
+++ b/test/files/pos/t10740.scala
@@ -1,0 +1,11 @@
+object Test {
+  case class Inv[A](x: A)
+  def diff1[A](i: Inv[A], j: Inv[_ <: A]) = 1
+  def diff2[A](i: Inv[_ >: A], j: Inv[A]) = 2
+  def diff3[A](i: Inv[_ >: A], j: Inv[_ <: A]) = 3
+  val i = Inv(Option(42))
+  val j = Inv(Some(42))
+  diff1(i, j)
+  diff2(i, j)
+  diff3(i, j)
+}


### PR DESCRIPTION
Type variables and wildcards can act both as subtypes and
supertypes depending on the direction of the test. This means
types with variables and/or wildcards can shadow other types in
`glb/lub`.

Consider the following examples:
```scala
lub((Int, ? ) :: (Int, String) :: Nil)
glb((Int, ?A) :: (Int, String) :: Nil)
```

Intuitively both should return `(Int, String)`, but this depends
on the order of types in the list passed to `glb/lub`.
This commit incorporates the simple heuristic of moving types that
contain variables and/or wildcards to the end of the list.

Fixes scala/bug#10686 and fixes scala/bug#10740