### PR TITLE
Fix overzealous protected access check for Java static members.

### DIFF
--- a/test/files/pos/parallel-classloader.scala
+++ b/test/files/pos/parallel-classloader.scala
@@ -1,0 +1,3 @@
+class Loader extends ClassLoader {
+  ClassLoader.registerAsParallelCapable()
+}

--- a/test/files/pos/t10568/Converter.java
+++ b/test/files/pos/t10568/Converter.java
@@ -1,0 +1,8 @@
+package x;
+
+public interface Converter {
+    static final String STRING = "STRING";
+    abstract class FactoryFactory {
+        protected static String getString() { return "string"; }
+    }
+}

--- a/test/files/pos/t10568/Impl.scala
+++ b/test/files/pos/t10568/Impl.scala
@@ -1,0 +1,9 @@
+package y
+
+import x._
+
+class Impl extends Converter.FactoryFactory {
+  import Converter.FactoryFactory._
+  def method: String =
+    getString + Converter.STRING
+}


### PR DESCRIPTION
Both Java and Scala require that, to access a protected member of a class `C`, the access must occur inside a class `S` which extends `C`. Moreover, the type of the qualifier needs to be a subclass of `S`. However, when a Java `static` member is being selected, Java doesn't care about the prefix (there is no such concept in Java-land). In Scala, however, the selection occurs from a fictional companion module made to house all the static members, and it's not likely to have any subclass relationship with the classes that we care about.

Therefore, when selecting from Java-defined modules, ignore the prefix check.

There's an existing test for this (`pos/protected-static`) which I relied upon in [the PR which introduced this regression](https://github.com/scala/scala/pull/6058), but I failed to notice that it only accesses _types_ from the Java superclass. (Types are exempted fully from the access check since 321439e3).

I know I cleaned up the string interpolation last time I was here, but it turns out that `toString + locationString` has a shorter and clearer name, so I've cleaned up a bit more.

Fixes scala/bug#10568, and fixes scala/bug#10597 (but does not fix my dignity).