### PR TITLE
fix typo. reifiee => reifier

### DIFF
--- a/src/compiler/scala/reflect/reify/phases/Calculate.scala
+++ b/src/compiler/scala/reflect/reify/phases/Calculate.scala
@@ -26,7 +26,7 @@ trait Calculate {
     }
 
   /**
-   *  Merely traverses the reifier and records symbols local to the reifee along with their metalevels.
+   *  Merely traverses the target and records symbols local to the reifee along with their metalevels.
    */
   val calculate = new Traverser {
     // see the explanation of metalevels in `Metalevels`

--- a/src/compiler/scala/reflect/reify/phases/Calculate.scala
+++ b/src/compiler/scala/reflect/reify/phases/Calculate.scala
@@ -26,7 +26,7 @@ trait Calculate {
     }
 
   /**
-   *  Merely traverses the reifiee and records symbols local to the reifee along with their metalevels.
+   *  Merely traverses the reifier and records symbols local to the reifee along with their metalevels.
    */
   val calculate = new Traverser {
     // see the explanation of metalevels in `Metalevels`


### PR DESCRIPTION
Sorry if it's wrong.