### PR TITLE
Don't emit a checkinit test for fields inherited from traits

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -117,7 +117,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
   private def setFieldFlags(accessor: Symbol, fieldInSubclass: TermSymbol): Unit =
     fieldInSubclass setFlag (NEEDS_TREES |
                              PrivateLocal
-                             | (accessor getFlag MUTABLE | LAZY)
+                             | (accessor getFlag MUTABLE | LAZY | DEFAULTINIT)
                              | (if (accessor hasFlag STABLE) 0 else MUTABLE)
       )
 

--- a/test/files/run/t10692.flags
+++ b/test/files/run/t10692.flags
@@ -1,0 +1,1 @@
+-Xcheckinit

--- a/test/files/run/t10692.scala
+++ b/test/files/run/t10692.scala
@@ -1,0 +1,26 @@
+trait T {
+  private var s: String = _
+  def getS: String = {
+    if (s == null) {
+      s = ""
+    }
+    s
+  }
+}
+
+class C {
+  private var f: String = _
+  def getF: String = {
+    if (f == null) {
+      f = ""
+    }
+    f
+  }
+}
+
+object Test extends C with T {
+  def main(args: Array[String]): Unit = {
+    assert(getS == "")
+    assert(getF == "")
+  }
+}


### PR DESCRIPTION
Fixes scala/bug#10692