### PR TITLE
Avoid accumulating ill-kinded bounds during unification

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3275,44 +3275,49 @@ trait Types
        *  type parameter we're trying to infer (the result will be sanity-checked later).
        */
       def unifyFull(tpe: Type): Boolean = {
+        def unifiableKinds(lhs: List[Symbol], rhs: List[Symbol]): Boolean =
+          sameLength(lhs, rhs) && !exists2(lhs, rhs)((l, r) => !unifiableKinds(l.typeParams, r.typeParams))
+
         def unifySpecific(tp: Type) = {
           val tpTypeArgs = tp.typeArgs
-          val arityDelta = compareLengths(typeArgs, tpTypeArgs)
-          if (arityDelta == 0) {
-            val lhs = if (isLowerBound) tpTypeArgs else typeArgs
-            val rhs = if (isLowerBound) typeArgs else tpTypeArgs
-            // This is a higher-kinded type var with same arity as tp.
-            // If so (see scala/bug#7517), side effect: adds the type constructor itself as a bound.
-            isSubArgs(lhs, rhs, params, AnyDepth) && {addBound(tp.typeConstructor); true}
-          } else if (settings.YpartialUnification && arityDelta < 0 && typeArgs.nonEmpty) {
-            // Simple algorithm as suggested by Paul Chiusano in the comments on scala/bug#2712
-            //
-            //   https://github.com/scala/bug/issues/2712#issuecomment-292374655
-            //
-            // Treat the type constructor as curried and partially applied, we treat a prefix
-            // as constants and solve for the suffix. For the example in the ticket, unifying
-            // M[A] with Int => Int this unifies as,
-            //
-            //   M[t] = [t][Int => t]  --> abstract on the right to match the expected arity
-            //   A = Int               --> capture the remainder on the left
-            //
-            // A more "natural" unifier might be M[t] = [t][t => t]. There's lots of scope for
-            // experimenting with alternatives here.
-            val numCaptured = tpTypeArgs.length - typeArgs.length
-            val (captured, abstractedArgs) = tpTypeArgs.splitAt(numCaptured)
+          val numCaptured = tpTypeArgs.length - typeArgs.length
+          val tpSym = tp.typeSymbolDirect
+          val abstractedTypeParams = tpSym.typeParams.drop(numCaptured)
+          if(!unifiableKinds(typeSymbolDirect.typeParams, abstractedTypeParams)) false
+          else {
+            if (numCaptured == 0) {
+              val lhs = if (isLowerBound) tpTypeArgs else typeArgs
+              val rhs = if (isLowerBound) typeArgs else tpTypeArgs
+              // This is a higher-kinded type var with same arity as tp.
+              // If so (see scala/bug#7517), side effect: adds the type constructor itself as a bound.
+              isSubArgs(lhs, rhs, params, AnyDepth) && {addBound(tp.typeConstructor); true}
+            } else if (settings.YpartialUnification && numCaptured > 0) {
+              // Simple algorithm as suggested by Paul Chiusano in the comments on scala/bug#2712
+              //
+              //   https://github.com/scala/bug/issues/2712#issuecomment-292374655
+              //
+              // Treat the type constructor as curried and partially applied, we treat a prefix
+              // as constants and solve for the suffix. For the example in the ticket, unifying
+              // M[A] with Int => Int this unifies as,
+              //
+              //   M[t] = [t][Int => t]  --> abstract on the right to match the expected arity
+              //   A = Int               --> capture the remainder on the left
+              //
+              // A more "natural" unifier might be M[t] = [t][t => t]. There's lots of scope for
+              // experimenting with alternatives here.
+              val (captured, abstractedArgs) = tpTypeArgs.splitAt(numCaptured)
 
-            val (lhs, rhs) =
-              if (isLowerBound) (abstractedArgs, typeArgs)
-              else (typeArgs, abstractedArgs)
+              val (lhs, rhs) =
+                if (isLowerBound) (abstractedArgs, typeArgs)
+                else (typeArgs, abstractedArgs)
 
-            isSubArgs(lhs, rhs, params, AnyDepth) && {
-              val tpSym = tp.typeSymbolDirect
-              val abstractedTypeParams = tpSym.typeParams.drop(numCaptured).map(_.cloneSymbol(tpSym))
-
-              addBound(PolyType(abstractedTypeParams, appliedType(tp.typeConstructor, captured ++ abstractedTypeParams.map(_.tpeHK))))
-              true
-            }
-          } else false
+              isSubArgs(lhs, rhs, params, AnyDepth) && {
+                val clonedParams = abstractedTypeParams.map(_.cloneSymbol(tpSym))
+                addBound(PolyType(clonedParams, appliedType(tp.typeConstructor, captured ++ clonedParams.map(_.tpeHK))))
+                true
+              }
+            } else false
+          }
         }
         // The type with which we can successfully unify can be hidden
         // behind singleton types and type aliases.

--- a/test/files/neg/names-defaults-neg-pu.check
+++ b/test/files/neg/names-defaults-neg-pu.check
@@ -1,0 +1,155 @@
+names-defaults-neg-pu.scala:5: error: type mismatch;
+ found   : String("#")
+ required: Int
+  test1(b = 2, a = "#")
+                   ^
+names-defaults-neg-pu.scala:5: error: type mismatch;
+ found   : Int(2)
+ required: String
+  test1(b = 2, a = "#")
+            ^
+names-defaults-neg-pu.scala:8: error: positional after named argument.
+  test1(b = "(*", 23)
+                  ^
+names-defaults-neg-pu.scala:13: warning: a pure expression does nothing in statement position
+  test2(x = 1)
+            ^
+names-defaults-neg-pu.scala:14: error: unknown parameter name: y
+  test2(y = 1)
+          ^
+names-defaults-neg-pu.scala:15: error: unknown parameter name: c
+  test1(c = 0, b = "joke")
+          ^
+names-defaults-neg-pu.scala:16: error: not found: value m
+  test7((m = 1))  // named arguments must be top-level assignments
+         ^
+names-defaults-neg-pu.scala:17: error: not found: value m
+  test7({m = 1})
+         ^
+names-defaults-neg-pu.scala:18: error: not found: value m
+  test7 { m = 1 } // no named arguments in argument block
+          ^
+names-defaults-neg-pu.scala:22: error: parameter 'a' is already specified at parameter position 1
+  test1(1, a = 2)
+             ^
+names-defaults-neg-pu.scala:23: error: parameter 'b' is already specified at parameter position 1
+  test1(b = 1, b = "2")
+                 ^
+names-defaults-neg-pu.scala:26: error: Int does not take parameters
+  test3(b = 3, a = 1)(3)
+                     ^
+names-defaults-neg-pu.scala:35: error: ambiguous reference to overloaded definition,
+both method f in object t1 of type (b: String, a: Int)String
+and  method f in object t1 of type (a: Int, b: String)String
+match argument types (b: String,a: Int)
+  t1.f(b = "dkljf", a = 1)
+     ^
+names-defaults-neg-pu.scala:42: error: ambiguous reference to overloaded definition,
+both method f in object t3 of type (a2: Int)(b: Int)String
+and  method f in object t3 of type (a1: Int)String
+match argument types (Int)
+  t3.f(1)
+     ^
+names-defaults-neg-pu.scala:43: error: ambiguous reference to overloaded definition,
+both method f in object t3 of type (a2: Int)(b: Int)String
+and  method f in object t3 of type (a1: Int)String
+match argument types (Int)
+  t3.f(1)(2)
+     ^
+names-defaults-neg-pu.scala:49: error: ambiguous reference to overloaded definition,
+both method g in object t7 of type (a: B)String
+and  method g in object t7 of type (a: C, b: Int*)String
+match argument types (C)
+  t7.g(new C()) // ambiguous reference
+     ^
+names-defaults-neg-pu.scala:53: error: parameter 'b' is already specified at parameter position 2
+  test5(a = 1, b = "dkjl", b = "dkj")
+                             ^
+names-defaults-neg-pu.scala:54: error: parameter 'b' is already specified at parameter position 2
+  test5(1, "2", b = 3)
+                  ^
+names-defaults-neg-pu.scala:55: error: when using named arguments, the vararg parameter has to be specified exactly once
+  test5(b = "dlkj")
+       ^
+names-defaults-neg-pu.scala:61: error: ambiguous reference to overloaded definition,
+both method f in object t8 of type (b: String, a: Int)String
+and  method f in object t8 of type (a: Int, b: Object)String
+match argument types (a: Int,b: String) and expected result type Any
+  println(t8.f(a = 0, b = "1")) // ambiguous reference
+             ^
+names-defaults-neg-pu.scala:65: error: not enough arguments for method apply: (a: Int, b: String)(c: Int*)Fact in object Fact.
+Unspecified value parameter b.
+  val fac = Fact(1)(2, 3)
+                ^
+names-defaults-neg-pu.scala:69: error: wrong number of arguments for pattern A1(x: Int,y: String)
+  A1() match { case A1(_) => () }
+                      ^
+names-defaults-neg-pu.scala:76: error: no type parameters for method test4: (x: T[T[List[T[X forSome { type X }]]]])T[T[List[T[X forSome { type X }]]]] exist so that it can be applied to arguments (List[Int])
+ --- because ---
+argument expression's type is not compatible with formal parameter type;
+ found   : List[Int]
+ required: ?T[?T[List[?T[X forSome { type X }]]]]
+Error occurred in an application involving default arguments.
+  test4()
+  ^
+names-defaults-neg-pu.scala:79: error: type mismatch;
+ found   : List[Int]
+ required: List[List[?]]
+  def test6[T](x: List[List[T]] = List(1,2)) = x
+                                      ^
+names-defaults-neg-pu.scala:82: error: type mismatch;
+ found   : Int
+ required: String
+Error occurred in an application involving default arguments.
+  new A2[String]()
+  ^
+names-defaults-neg-pu.scala:86: error: module extending its companion class cannot use default constructor arguments
+    object C extends C()
+                     ^
+names-defaults-neg-pu.scala:90: error: deprecated parameter name x has to be distinct from any other parameter name (deprecated or not).
+  def deprNam1(x: Int, @deprecatedName('x) y: String) = 0
+                                           ^
+names-defaults-neg-pu.scala:91: error: deprecated parameter name a has to be distinct from any other parameter name (deprecated or not).
+  def deprNam2(a: String)(@deprecatedName('a) b: Int) = 1
+                                              ^
+names-defaults-neg-pu.scala:93: warning: the parameter name y is deprecated: use b instead
+  deprNam3(y = 10, b = 2)
+             ^
+names-defaults-neg-pu.scala:93: error: parameter 'b' is already specified at parameter position 1
+  deprNam3(y = 10, b = 2)
+                     ^
+names-defaults-neg-pu.scala:96: warning: naming parameter deprNam4Arg is deprecated.
+  deprNam4(deprNam4Arg = null)
+                       ^
+names-defaults-neg-pu.scala:98: warning: naming parameter deprNam5Arg is deprecated.
+  deprNam5(deprNam5Arg = null)
+                       ^
+names-defaults-neg-pu.scala:102: error: unknown parameter name: m
+  f3818(y = 1, m = 1)
+                 ^
+names-defaults-neg-pu.scala:135: warning: a pure expression does nothing in statement position
+  delay(var2 = 40)
+               ^
+names-defaults-neg-pu.scala:138: error: missing parameter type for expanded function ((x$1: <error>) => a = x$1)
+  val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
+                                         ^
+names-defaults-neg-pu.scala:138: error: not found: value a
+  val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
+                                     ^
+names-defaults-neg-pu.scala:138: error: not found: value get
+  val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
+                                                ^
+names-defaults-neg-pu.scala:139: error: parameter 'a' is already specified at parameter position 1
+  val taf3 = testAnnFun(b = _: String, a = get(8))
+                                         ^
+names-defaults-neg-pu.scala:140: error: missing parameter type for expanded function ((x$3: <error>) => testAnnFun(x$3, ((x$4) => b = x$4)))
+  val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
+                                               ^
+names-defaults-neg-pu.scala:140: error: missing parameter type for expanded function ((x$4: <error>) => b = x$4)
+  val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
+                                                      ^
+names-defaults-neg-pu.scala:140: error: not found: value b
+  val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
+                                                  ^
+5 warnings found
+36 errors found

--- a/test/files/neg/names-defaults-neg-pu.flags
+++ b/test/files/neg/names-defaults-neg-pu.flags
@@ -1,0 +1,1 @@
+-deprecation -Ypartial-unification

--- a/test/files/neg/names-defaults-neg-pu.scala
+++ b/test/files/neg/names-defaults-neg-pu.scala
@@ -1,0 +1,188 @@
+object Test extends App {
+  // TESTS
+
+  // re-ordering
+  test1(b = 2, a = "#")
+
+  // mixing named and positional
+  test1(b = "(*", 23)
+
+  // assignment / names
+  var x = 0
+  var y = 0
+  test2(x = 1)
+  test2(y = 1)
+  test1(c = 0, b = "joke")
+  test7((m = 1))  // named arguments must be top-level assignments
+  test7({m = 1})
+  test7 { m = 1 } // no named arguments in argument block
+  test8(x = 1)
+
+  // argument specified twice
+  test1(1, a = 2)
+  test1(b = 1, b = "2")
+
+  // error message when there are too many argument lists (not very nice..)
+  test3(b = 3, a = 1)(3)
+
+
+
+  // overloading resolution
+  object t1 {
+    def f(a: Int, b: String) = "first"
+    def f(b: String, a: Int) = "second"
+  }
+  t1.f(b = "dkljf", a = 1)
+
+
+  object t3 {
+    def f(a1: Int) = "first"
+    def f(a2: Int)(b: Int) = "second"
+  }
+  t3.f(1)
+  t3.f(1)(2)
+
+  object t7 {
+    def g(a: C, b: Int*) = "third"
+    def g(a: B) = "fourth"
+  }
+  t7.g(new C()) // ambiguous reference
+
+  // vararg
+  def test5(a: Int, b: String*) = a
+  test5(a = 1, b = "dkjl", b = "dkj")
+  test5(1, "2", b = 3)
+  test5(b = "dlkj")
+
+  object t8 {
+    def f(a: Int, b: Object) = "first"
+    def f(b: String, a: Int) = "second"
+  }
+  println(t8.f(a = 0, b = "1")) // ambiguous reference
+
+
+  // case class copy does not exist if there's a vararg
+  val fac = Fact(1)(2, 3)
+  val facc = fac.copy(b = "dlkfj")()
+
+  // no defaults in patterns
+  A1() match { case A1(_) => () }
+
+
+  // return types of default getters
+
+  // definition compiles, but default cannot  be used, it doesn't conform
+  def test4[T[P]](x: T[T[List[T[X forSome { type X }]]]] = List(1,2)) = x
+  test4()
+
+  // doesn't compile
+  def test6[T](x: List[List[T]] = List(1,2)) = x
+
+  // correct error message
+  new A2[String]()
+
+  object t3648 {
+    class C(val s: String = "")
+    object C extends C()
+  }
+
+  // deprecated names
+  def deprNam1(x: Int, @deprecatedName('x) y: String) = 0
+  def deprNam2(a: String)(@deprecatedName('a) b: Int) = 1
+  def deprNam3(@deprecatedName('x) a: Int, @deprecatedName('y) b: Int) = a + b
+  deprNam3(y = 10, b = 2)
+
+  def deprNam4(@deprecatedName('deprNam4Arg) deprNam4Arg: String) = 0
+  deprNam4(deprNam4Arg = null)
+  def deprNam5(@deprecatedName deprNam5Arg: String) = 0
+  deprNam5(deprNam5Arg = null)
+
+  // t3818
+  def f3818(x: Int = 1, y: Int, z: Int = 1) = 0
+  f3818(y = 1, m = 1)
+
+  // DEFINITIONS
+  def test1(a: Int, b: String) = a +": "+ b
+  def test2(x: Unit) = println("test2")
+  def test3(a: Int, b: Int) = a + b
+  def test7(m: Int) = m
+  def test8[T](x: => T) = println("test8")
+}
+
+class B {
+  def foo(a: Int) = a
+  def bar(u: String = "ldksj") = u
+}
+
+class C extends B {
+  override def foo(a: Int = 1092) = a
+  def foo(b: String = "lskdfj")
+
+  def bar(i: Int = 129083) = i
+}
+
+case class Fact(a: Int, b: String)(c: Int*)
+
+case class A1(x: Int = 1, y: String = "2")
+
+class A2[T](a: T = 1)
+
+
+// anonymous functions
+object anfun {
+  var var2 = 0
+  def delay(var2: => Unit) { var2 }
+  delay(var2 = 40)
+
+  def testAnnFun(a: Int, b: String) = println(a +": "+ b)
+  val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
+  val taf3 = testAnnFun(b = _: String, a = get(8))
+  val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
+}
+
+object t3685 {
+  object t { def f(x: Int) = x }
+
+  def t1 { def x = t.f(x = 1) }
+  def t2 { val x = t.f(x = 1) }
+  def t3 { var x = t.f(x = 1) }
+  object t4 { def x = t.f(x = 1) }
+  object t5 { val x = t.f(x = 1) }
+  object t6 { var x = t.f(x = 1) }
+  class t7 { def x = t.f(x = 1) }
+  class t8 { val x = t.f(x = 1) }
+  class t9 { var x = t.f(x = 1) }
+
+  def t10 { def x: Int = t.f(x = 1) }
+  def t11 { val x: Int = t.f(x = 1) }
+  def t12 { var x: Int = t.f(x = 1) }
+  class t13 { def x: Int = t.f(x = 1) }
+  class t14 { val x: Int = t.f(x = 1) }
+  class t15 { var x: Int = t.f(x = 1) }
+
+
+  object u { def f[T](x: T) = 100 }
+
+  def u1 { def x = u.f(x = 1) }
+  def u2 { val x = u.f(x = 1) }
+  def u3 { var x = u.f(x = 1) }
+  def u4 { def x = u.f(x = "23") }
+  def u5 { val x = u.f(x = "32") }
+  def u6 { var x = u.f(x = "32") }
+  def u7 { def x: Int = u.f(x = 1) }
+  def u8 { val x: Int = u.f(x = 1) }
+  def u9 { var x: Int = u.f(x = 1) }
+  def u10 { def x: Int = u.f(x = "32") }
+  def u11 { val x: Int = u.f(x = "32") }
+  def u12 { var x: Int = u.f(x = "32") }
+
+  class u13 { def x = u.f(x = 1) }
+  class u14 { val x = u.f(x = 1) }
+  class u15 { var x = u.f(x = 1) }
+  class u16 { def x: Int = u.f(x = 1) }
+  class u17 { val x: Int = u.f(x = 1) }
+  class u18 { var x: Int = u.f(x = 1) }
+  class u19 { def x: Int = u.f(x = "32") }
+  class u20 { val x: Int = u.f(x = "32") }
+  class u21 { var x: Int = u.f(x = "32") }
+}

--- a/test/files/neg/t2712-8.check
+++ b/test/files/neg/t2712-8.check
@@ -1,0 +1,13 @@
+t2712-8.scala:9: error: no type parameters for method foo: (x: D[D[Boolean]])Nothing exist so that it can be applied to arguments (Test.Quux[Int])
+ --- because ---
+argument expression's type is not compatible with formal parameter type;
+ found   : Test.Quux[Int]
+ required: ?D[?D[Boolean]]
+  foo(bar)
+  ^
+t2712-8.scala:9: error: type mismatch;
+ found   : Test.Quux[Int]
+ required: D[D[Boolean]]
+  foo(bar)
+      ^
+two errors found

--- a/test/files/neg/t2712-8.flags
+++ b/test/files/neg/t2712-8.flags
@@ -1,0 +1,1 @@
+-Ypartial-unification

--- a/test/files/neg/t2712-8.scala
+++ b/test/files/neg/t2712-8.scala
@@ -1,0 +1,10 @@
+object Test extends App {
+  class L[A]
+  class Quux0[B, CC[_]]
+  class Quux[C] extends Quux0[C, L]
+
+  def foo[D[_]](x: D[D[Boolean]]) = ???
+  def bar: Quux[Int] = ???
+
+  foo(bar)
+}

--- a/test/files/neg/t8237-default-pu.check
+++ b/test/files/neg/t8237-default-pu.check
@@ -1,0 +1,13 @@
+t8237-default-pu.scala:5: error: no type parameters for method test4: (x: T[T[List[T[X forSome { type X }]]]])Nothing exist so that it can be applied to arguments (List[Int])
+ --- because ---
+argument expression's type is not compatible with formal parameter type;
+ found   : List[Int]
+ required: ?T[?T[List[?T[X forSome { type X }]]]]
+  test4(test4$default$1)
+  ^
+t8237-default-pu.scala:5: error: type mismatch;
+ found   : List[Int]
+ required: T[T[List[T[X forSome { type X }]]]]
+  test4(test4$default$1)
+        ^
+two errors found

--- a/test/files/neg/t8237-default-pu.flags
+++ b/test/files/neg/t8237-default-pu.flags
@@ -1,0 +1,1 @@
+-Ypartial-unification

--- a/test/files/neg/t8237-default-pu.scala
+++ b/test/files/neg/t8237-default-pu.scala
@@ -1,0 +1,29 @@
+// This test case was extracted from `names-defaults-neg.scala`
+// It pinpoints an improvement an error message that results from
+// a type inference failure
+object Test extends App {
+  test4(test4$default$1)
+
+  def test4[T[P]](x: T[T[List[T[X forSome { type X }]]]]) = ???
+  def test4$default$1[T[P]]: List[Int] = ???
+}
+
+/*
+OLD:
+ no type parameters for method test4: (x: T[T[List[T[X forSome { type X }]]]])Nothing exist so that it can be applied to arguments (List[Int])
+ --- because ---
+argument expression's type is not compatible with formal parameter type;
+ found   : List[Int]
+ required: ?T
+  test4(test4$default$1)
+  ^
+
+NEW:
+
+no type parameters for method test4: (x: T[T[List[T[X forSome { type X }]]]])Nothing exist so that it can be applied to arguments (List[Int])
+ --- because ---
+argument expression's type is not compatible with formal parameter type;
+ found   : List[Int]
+ required: ?T[?T[List[?T[X forSome { type X }]]]
+  test4(test4$default$1)
+*/


### PR DESCRIPTION
This PR is a precondition for being able to enable partial unification unconditionally.

Turning partial unification on unconditionally revealed that in some error cases it was possible for the partial unification branch of `unifySpecific` to add inappropriately kinded bounds to the type variable
being solved. These later blow up in `matchingBounds` in `GlbLubs` where the mismatched kinds result in a `NoCommonType` exception being thrown which crashes the compiler reporting "lub/glb of incompatible types".

This commit prevents that from happening by checking that the added bounds will match the kind of the TypeVar they're being added to. If they don't then the bound is not added and unification fails.
