### PR TITLE
Speed up creation of [Abs]TypeErrors.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -21,7 +21,7 @@ trait ContextErrors {
   import global._
   import definitions._
 
-  sealed abstract class AbsTypeError extends Throwable {
+  sealed abstract class AbsTypeError {
     def errPos: Position
     def errMsg: String
     override def toString() = "[Type error at:" + errPos + "] " + errMsg

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3693,7 +3693,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
   /** An exception for cyclic references of symbol definitions */
   case class CyclicReference(sym: Symbol, info: Type)
   extends TypeError("illegal cyclic reference involving " + sym) {
-    if (settings.debug.value) printStackTrace()
+    if (settings.debug) printStackTrace()
   }
 
   /** A class for type histories */

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4629,6 +4629,9 @@ trait Types
   /** A throwable signalling a type error */
   class TypeError(var pos: Position, val msg: String) extends Throwable(msg) {
     def this(msg: String) = this(NoPosition, msg)
+
+    final override def fillInStackTrace() =
+      if (settings.debug) super.fillInStackTrace() else this
   }
 
   // TODO: RecoverableCyclicReference should be separated from TypeError,


### PR DESCRIPTION
`Throwable#fillInStackTrace` can be expensive, so minimize the number of calls we make to it.

- `AbsTypeError` and its subclasses are never thrown, so they don't need to extend `Throwable` at all.
- `TypeError`s are thrown, but if the user sees them it's a compiler bug anyhow, so only populate the stack trace if we're in `-Ydebug` mode.

This also adds a minute bit of clarity to the distinction between `TypeError` and `AbsTypeError`: you can't throw the ~former~ latter.

Contribution note: retronym did this independently last October, because all good ideas are already had. Found this out when asking for permission on gitter rather than forgiveness on github. Still committing, though, because I've noticed that smaller changes tend to get merged sooner.