### PR TITLE
Check for error in qual of select in type

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -895,7 +895,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         def cantAdapt =
           if (context.implicitsEnabled) MissingArgsForMethodTpeError(tree, meth)
-          else setError(tree)
+          else UnstableTreeError(tree)
 
         def emptyApplication: Tree = adapt(typed(Apply(tree, Nil) setPos tree.pos), mode, pt, original)
 

--- a/test/files/neg/t10474.check
+++ b/test/files/neg/t10474.check
@@ -1,0 +1,7 @@
+t10474.scala:8: error: stable identifier required, but Test.this.Foo found.
+    case Foo.Bar ⇒ true
+         ^
+t10474.scala:15: error: stable identifier required, but hrhino.this.Foo found.
+  val Foo.Crash = ???
+      ^
+two errors found

--- a/test/files/neg/t10474.scala
+++ b/test/files/neg/t10474.scala
@@ -1,0 +1,16 @@
+
+object Test {
+  def Foo(a: Int): Char = ???
+
+  object Bar
+
+  def crash[A](): Boolean = Bar match {
+    case Foo.Bar ⇒ true
+    case _ ⇒ false
+  }
+}
+
+trait hrhino {
+  def Foo(i: Int) = i
+  val Foo.Crash = ???
+}

--- a/test/files/neg/t10695.check
+++ b/test/files/neg/t10695.check
@@ -1,0 +1,4 @@
+t10695.scala:6: error: stable identifier required, but X.raw found.
+  val node: raw.Node = null
+            ^
+one error found

--- a/test/files/neg/t10695.scala
+++ b/test/files/neg/t10695.scala
@@ -1,0 +1,14 @@
+
+import X._
+
+object Main extends App {
+
+  val node: raw.Node = null
+
+  Seq().fold(node)(_ => _)
+
+}
+
+object X {
+  def raw(s: String) = ???
+}

--- a/test/files/neg/t10731.check
+++ b/test/files/neg/t10731.check
@@ -1,0 +1,4 @@
+t10731.scala:3: error: stable identifier required, but C.this.eq found.
+  val eq.a = 1
+      ^
+one error found

--- a/test/files/neg/t10731.scala
+++ b/test/files/neg/t10731.scala
@@ -1,0 +1,4 @@
+
+class C {
+  val eq.a = 1
+}


### PR DESCRIPTION
Typing select of terms and types was unified, with
the change that implicits are disabled in
`typedTypeSelectionQualifer`, with the side effect
or lack thereof that `instantiateToMethodType` no
longer issued an error.

Not sure if it's better to figure out from context whether to emit the 
failure to adapt, or whether a nicer message at this location
is warranted. @adriaanm probably has an opinion.

Also, updated a test that shows a cycle on imports; the new message
additionally shows what triggered the lookup, which is arguably
a feature.

Fixes scala/bug#10695