### PR TITLE
Eta-expand methods passed as functions to overloaded methods

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -263,11 +263,6 @@ abstract class TreeInfo {
     true
   }
 
-  def isFunctionWithParamType(tree: Tree): Boolean = tree match {
-    case Function(vparams, _) => vparams.exists(_.tpt.nonEmpty)
-    case _ => false
-  }
-
   def isFunctionMissingParamType(tree: Tree): Boolean = tree match {
     case Function(vparams, _) => vparams.exists(_.tpt.isEmpty)
     case _ => false

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -263,6 +263,11 @@ abstract class TreeInfo {
     true
   }
 
+  def isFunctionWithParamType(tree: Tree): Boolean = tree match {
+    case Function(vparams, _) => vparams.exists(_.tpt.nonEmpty)
+    case _ => false
+  }
+
   def isFunctionMissingParamType(tree: Tree): Boolean = tree match {
     case Function(vparams, _) => vparams.exists(_.tpt.isEmpty)
     case _ => false

--- a/test/files/pos/overloaded_ho_fun.scala
+++ b/test/files/pos/overloaded_ho_fun.scala
@@ -68,7 +68,38 @@ object SI10194 {
 // Perform eta-expansion of methods passed as functions to overloaded functions
 trait A { def map[T](f: Int => T): Unit = () }
 object B extends A {
+  def noover(f: SAM[Int, Any]): Unit = ()
   def map[T: scala.reflect.ClassTag](f: Int => T): Unit = ()
   def f(x: Int) = x
-  map(f)
+  noover(f)
+  noover(identity)
+  map(f) // same param type, monomorphic method
+  map(identity) // same param type, polymorphic method
+
+  // must not lub to an incompatible function type
+  object t { def f(x: Int => Int): Int = 0; def f(y: String => Int): String = "1" }
+  def fun(x: Int) = x
+  def fun2[T] = (x: T) => 42
+  t.f(fun) // different param type, monomorphic method
+  //t.f(fun2) // different param type, polymorphic method - not possible
+}
+
+// The same for SAM types
+trait SAM[-T, +R] { def apply(x: T): R }
+trait A2 { def map[T](f: SAM[Int, T]): Unit = () }
+object B2 extends A2 {
+  def noover(f: SAM[Int, Any]): Unit = ()
+  def map[T: scala.reflect.ClassTag](f: SAM[Int, T]): Unit = ()
+  def f(x: Int) = x
+  noover(f)
+  noover(identity)
+  map(f) // same param type, monomorphic method
+  //map(identity) // same param type, polymorphic method - not possible for SAMs
+
+  // must not lub to an incompatible function type
+  object t { def f(x: SAM[Int, Int]): Int = 0; def f(y: SAM[String, Int]): String = "1" }
+  def fun(x: Int) = x
+  def fun2[T] = (x: T) => 42
+  t.f(fun) // different param type, monomorphic method
+  //t.f(fun2) // different param type, polymorphic method - not possible
 }

--- a/test/files/pos/overloaded_ho_fun.scala
+++ b/test/files/pos/overloaded_ho_fun.scala
@@ -64,3 +64,11 @@ object SI10194 {
   (null: Y[Int]).map(x => x.toString) // compiled
   (null: Z[Int]).map(x => x.toString) // didn't compile
 }
+
+// Perform eta-expansion of methods passed as functions to overloaded functions
+trait A { def map[T](f: Int => T): Unit = () }
+object B extends A {
+  def map[T: scala.reflect.ClassTag](f: Int => T): Unit = ()
+  def f(x: Int) = x
+  map(f)
+}


### PR DESCRIPTION
The stricter automatic eta-expansion of method types to function
types in 2.13 interacts badly with the improved overload resolution
for higher-order methods. When a method reference is passed to such a
method without explicit eta-expansion, the shape-based lubbing
is not applied. Therefore the method is checked without an expected
type and does not eta-expand as it would when passed to a
non-overloaded method.

This is an attempt to fix the problem by using lubs more aggressively.
Unlike function and pattern-matching function literals method references
cannot be detected syntactically as early as we would like (as they are
only Idents without a symbol or type at that point) so we try to lub
all argument types and use that for typing the alternatives unless a
typed function literal is passed (because that might not typecheck
against the lub).