### PR TITLE
Correct, stable position for mixed-in outer accessors

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -182,7 +182,7 @@ abstract class ExplicitOuter extends InfoTransform
               debuglog(s"Reusing outer accessor symbol of $clazz for the mixin outer accessor of $mc")
             else {
               if (decls1 eq decls) decls1 = decls.cloneScope
-              val newAcc = mixinOuterAcc.cloneSymbol(clazz, mixinOuterAcc.flags & ~DEFERRED)
+              val newAcc = mixinOuterAcc.cloneSymbol(clazz, mixinOuterAcc.flags & ~DEFERRED).setPos(clazz.pos)
               newAcc setInfo (clazz.thisType memberType mixinOuterAcc)
               decls1 enter newAcc
             }

--- a/test/junit/scala/tools/nsc/transform/MixinTest.scala
+++ b/test/junit/scala/tools/nsc/transform/MixinTest.scala
@@ -1,0 +1,39 @@
+package scala.tools.nsc
+package transform
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.partest.ASMConverters.LineNumber
+import scala.tools.testing.BytecodeTesting
+import scala.tools.testing.BytecodeTesting._
+
+@RunWith(classOf[JUnit4])
+class MixinTest extends BytecodeTesting {
+  import compiler._
+
+  @Test
+  def outerAccessorPosition(): Unit = {
+    val code =
+      """                        // 1
+        |class a {               // 2
+        |  trait inner {         // 3
+        |    def aa = a.this     // 4
+        |  }                     // 5
+        |}                       // 6
+        |class b extends a {     // 7
+        |  class z extends inner // 8
+        |}                       // 9
+        |""".stripMargin
+
+    val List(_, _, _, bz) = compileClasses(code)
+    assertEquals("b$z", bz.name)
+    val method = getMethod(bz, "a$inner$$$outer")
+    val lineNumbers = method.instructions.collect {
+      case LineNumber(l, _) => l
+    }
+    assertEquals(List(8), lineNumbers) // this used to be "line 3".
+  }
+}


### PR DESCRIPTION
Previously, the position was incorrectly taken from the
outer accessor in the base trait. Not only was this wrong,
but it was only available when jointly compiling the trait
and subclass, so it also a source of unstable output.

References scala/scala-dev#405

Fixes scala/bug#7851