### PR TITLE
Fix lookup of default getter in scope

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1211,11 +1211,14 @@ trait Contexts { self: Analyzer =>
       var res: Symbol = NoSymbol
       var ctx = this
       while (res == NoSymbol && ctx.outer != ctx) {
-        val s = ctx.scope lookup name
-        if (s != NoSymbol && s.owner == expectedOwner)
-          res = s
-        else
-          ctx = ctx.outer
+        ctx.scope.lookupUnshadowedEntries(name).filter(s => s.sym != NoSymbol && s.sym.owner == expectedOwner).toList match {
+          case Nil =>
+            ctx = ctx.outer
+          case found :: Nil =>
+            res = found.sym
+          case alts =>
+            res = expectedOwner.newOverloaded(NoPrefix, alts.map(_.sym))
+        }
       }
       res
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1065,8 +1065,11 @@ trait Contexts { self: Analyzer =>
         found1
       }
 
-      def lookupInScope(scope: Scope) =
-        (scope lookupUnshadowedEntries name filter (e => qualifies(e.sym))).toList
+      def lookupInScope(scope: Scope) = {
+        val entries = scope lookupUnshadowedEntries name
+        val result = entries.filter(e => qualifies(e.sym)).toList
+        result
+      }
 
       def newOverloaded(owner: Symbol, pre: Type, entries: List[ScopeEntry]) =
         logResult(s"overloaded symbol in $pre")(owner.newOverloaded(pre, entries map (_.sym)))
@@ -1198,32 +1201,14 @@ trait Contexts { self: Analyzer =>
       else finish(EmptyTree, NoSymbol)
     }
 
-    /**
-     * Find a symbol in this context or one of its outers.
-     *
-     * Used to find symbols are owned by methods (or fields), they can't be
-     * found in some scope.
-     *
-     * Examples: companion module of classes owned by a method, default getter
-     * methods of nested methods. See NamesDefaults.scala
-     */
-    def lookup(name: Name, expectedOwner: Symbol) = {
-      var res: Symbol = NoSymbol
-      var ctx = this
-      while (res == NoSymbol && ctx.outer != ctx) {
-        ctx.scope.lookupUnshadowedEntries(name).filter(s => s.sym != NoSymbol && s.sym.owner == expectedOwner).toList match {
-          case Nil =>
-            ctx = ctx.outer
-          case found :: Nil =>
-            res = found.sym
-          case alts =>
-            res = expectedOwner.newOverloaded(NoPrefix, alts.map(_.sym))
-        }
-      }
-      res
+    final def lookupCompanionInIncompleteOwner(original: Symbol): Symbol = {
+      // Must have both a class and module symbol, so that `{ class C; def C }` or `{ type T; object T }` are not companions.
+      def isCompanion(sym: Symbol): Boolean =
+        (original.isModule && sym.isClass || sym.isModule && original.isClass) && sym.isCoDefinedWith(original)
+      lookupSibling(original, original.name.companionName).filter(isCompanion)
     }
 
-    final def lookupCompanionInIncompleteOwner(original: Symbol): Symbol = {
+    final def lookupSibling(original: Symbol, name: Name): Symbol = {
       /* Search scopes in current and enclosing contexts for the definition of `symbol` */
       def lookupScopeEntry(symbol: Symbol): ScopeEntry = {
         var res: ScopeEntry = null
@@ -1238,15 +1223,12 @@ trait Contexts { self: Analyzer =>
         res
       }
 
-      // 1) Must be owned by the same Scope, to ensure that in
-      //   `{ class C; { ...; object C } }`, the class is not seen as a companion of the object.
-      // 2) Must be a class and module symbol, so that `{ class C; def C }` or `{ type T; object T }` are not companions.
+      // Must be owned by the same Scope, to ensure that in
+      // `{ class C; { ...; object C } }`, the class is not seen as a companion of the object.
       lookupScopeEntry(original) match {
         case null => NoSymbol
         case entry =>
-          def isCompanion(sym: Symbol): Boolean =
-            (original.isModule && sym.isClass || sym.isModule && original.isClass) && sym.isCoDefinedWith(original)
-          entry.owner.lookupNameInSameScopeAs(original, original.name.companionName).filter(isCompanion)
+          entry.owner.lookupNameInSameScopeAs(original, name)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -479,9 +479,8 @@ trait NamesDefaults { self: Analyzer =>
         if (param.owner.owner.isClass) {
           param.owner.owner.info.member(defGetterName)
         } else {
-          // the owner of the method is another method. find the default
-          // getter in the context.
-          context.lookup(defGetterName, param.owner.owner)
+          // the owner of the method is another method. find the default getter in the context.
+          context.lookupSibling(param.owner, defGetterName)
         }
       }
     } else NoSymbol

--- a/test/files/run/names-defaults-nest.scala
+++ b/test/files/run/names-defaults-nest.scala
@@ -1,10 +1,11 @@
 object Test {
   def multinest = {
-    def baz = bar();
+    def baz = {bar()}
     def bar(x: String = "a"): Any = {
       def bar(x: String = "b") = x
       bar() + x
     };
+    bar$default$1(0)
     assert(baz == "ba", baz)
   }
   def main(args: Array[String]) {

--- a/test/files/run/names-defaults-nest.scala
+++ b/test/files/run/names-defaults-nest.scala
@@ -1,0 +1,13 @@
+object Test {
+  def multinest = {
+    def baz = bar();
+    def bar(x: String = "a"): Any = {
+      def bar(x: String = "b") = x
+      bar() + x
+    };
+    assert(baz == "ba", baz)
+  }
+  def main(args: Array[String]) {
+    multinest
+  }
+}


### PR DESCRIPTION
By slightly modifying an existing test to force creation of default getters
for both `bar` methods _before_ typechecking the application, I was able to
show a latent bug in the way the default getter is looked up in scope.

The bespoke `Context.lookup` method did not respect shadowing, but rather
considered the two, same-named default getters as overloaded. Because the
overloaded symbol had NoSymbol as its owner, which didn't match the
expected owner, neither default was eligible.

This commit brings the code more into line with `Context.lookupSymbol` and
respects shadowing.

References scala/scala-dev#405