### PR TITLE
Optimize usage of builders in case when resulting collection is empty

### DIFF
--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -238,10 +238,13 @@ object Array extends FallbackArrayBuilding {
    *  @return   the array created from concatenating `xss`
    */
   def concat[T: ClassTag](xss: Array[T]*): Array[T] = {
-    val b = newBuilder[T]
-    b.sizeHint(xss.map(_.length).sum)
-    for (xs <- xss) b ++= xs
-    b.result()
+    if (xss.forall(_.isEmpty)) empty[T]
+    else {
+      val b = newBuilder[T]
+      b.sizeHint(xss.map(_.length).sum)
+      for (xs <- xss) b ++= xs
+      b.result()
+    }
   }
 
   /** Returns an array that contains the results of some element computation a number
@@ -259,14 +262,17 @@ object Array extends FallbackArrayBuilding {
    *  `elem`.
    */
   def fill[T: ClassTag](n: Int)(elem: => T): Array[T] = {
-    val b = newBuilder[T]
-    b.sizeHint(n)
-    var i = 0
-    while (i < n) {
-      b += elem
-      i += 1
+    if (n == 0) empty[T]
+    else {
+      val b = newBuilder[T]
+      b.sizeHint(n)
+      var i = 0
+      while (i < n) {
+        b += elem
+        i += 1
+      }
+      b.result()
     }
-    b.result()
   }
 
   /** Returns a two-dimensional array that contains the results of some element
@@ -323,14 +329,17 @@ object Array extends FallbackArrayBuilding {
    *  @return A traversable consisting of elements `f(0),f(1), ..., f(n - 1)`
    */
   def tabulate[T: ClassTag](n: Int)(f: Int => T): Array[T] = {
-    val b = newBuilder[T]
-    b.sizeHint(n)
-    var i = 0
-    while (i < n) {
-      b += f(i)
-      i += 1
+    if (n == 0) empty[T]
+    else {
+      val b = newBuilder[T]
+      b.sizeHint(n)
+      var i = 0
+      while (i < n) {
+        b += f(i)
+        i += 1
+      }
+      b.result()
     }
-    b.result()
   }
 
   /** Returns a two-dimensional array containing values of a given function
@@ -397,15 +406,20 @@ object Array extends FallbackArrayBuilding {
    */
   def range(start: Int, end: Int, step: Int): Array[Int] = {
     if (step == 0) throw new IllegalArgumentException("zero step")
-    val b = newBuilder[Int]
-    b.sizeHint(immutable.Range.count(start, end, step, isInclusive = false))
 
-    var i = start
-    while (if (step < 0) end < i else i < end) {
-      b += i
-      i += step
+    val size = immutable.Range.count(start, end, step, isInclusive = false)
+    if (size == 0) empty[Int]
+    else {
+      val b = newBuilder[Int]
+      b.sizeHint(size)
+
+      var i = start
+      while (if (step < 0) end < i else i < end) {
+        b += i
+        i += step
+      }
+      b.result()
     }
-    b.result()
   }
 
   /** Returns an array containing repeated applications of a function to a start value.
@@ -416,9 +430,10 @@ object Array extends FallbackArrayBuilding {
    *  @return      the array returning `len` values in the sequence `start, f(start), f(f(start)), ...`
    */
   def iterate[T: ClassTag](start: T, len: Int)(f: T => T): Array[T] = {
-    val b = newBuilder[T]
+    if (len == 0) empty[T]
+    else {
+      val b = newBuilder[T]
 
-    if (len > 0) {
       b.sizeHint(len)
       var acc = start
       var i = 1
@@ -429,8 +444,9 @@ object Array extends FallbackArrayBuilding {
         i += 1
         b += acc
       }
+
+      b.result()
     }
-    b.result()
   }
 
   /** Called in a pattern match like `{ case Array(x,y,z) => println('3 elements')}`.

--- a/src/library/scala/collection/generic/GenericClassTagCompanion.scala
+++ b/src/library/scala/collection/generic/GenericClassTagCompanion.scala
@@ -27,8 +27,11 @@ abstract class GenericClassTagCompanion[+CC[X] <: Traversable[X]] {
   def empty[A: ClassTag]: CC[A] = newBuilder[A].result()
 
   def apply[A](elems: A*)(implicit ord: ClassTag[A]): CC[A] = {
-    val b = newBuilder[A]
-    b ++= elems
-    b.result()
+    if (elems.isEmpty) empty[A]
+    else {
+      val b = newBuilder[A]
+      b ++= elems
+      b.result()
+    }
   }
 }

--- a/src/library/scala/collection/generic/GenericOrderedCompanion.scala
+++ b/src/library/scala/collection/generic/GenericOrderedCompanion.scala
@@ -27,9 +27,12 @@ abstract class GenericOrderedCompanion[+CC[X] <: Traversable[X]] {
   def empty[A: Ordering]: CC[A] = newBuilder[A].result()
 
   def apply[A](elems: A*)(implicit ord: Ordering[A]): CC[A] = {
-    val b = newBuilder[A]
-    b ++= elems
-    b.result()
+    if (elems.isEmpty) empty[A]
+    else {
+      val b = newBuilder[A]
+      b ++= elems
+      b.result()
+    }
   }
 }
 

--- a/test/benchmarks/src/main/scala/scala/ArrayBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/ArrayBenchmark.scala
@@ -1,0 +1,47 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+object ArrayBenchmark {
+  case class Content(value: Int)
+}
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class ArrayBenchmark {
+  import ArrayBenchmark._
+  @Param(Array("0", "1", "10", "100", "1000"))
+  var size: Int = _
+  var values: Array[Content] = _
+
+  @Setup(Level.Trial) def initKeys(): Unit = {
+    values = Array.tabulate(size)(v => Content(v))
+  }
+
+  @Benchmark def concat_raw: Any = {
+    Array.concat(values, values)
+  }
+
+  @Benchmark def fill_raw: Any = {
+    Array.fill(size)(Content(0))
+  }
+
+  @Benchmark def tabulate_raw: Any = {
+    Array.tabulate(size)(values.apply)
+  }
+
+  @Benchmark def range_raw: Any = {
+    Array.range(-size, size, 2)
+  }
+
+  @Benchmark def iterate_raw: Any = {
+    Array.iterate(Content(0), size)(v => v.copy(value = v.value + 10))
+  }
+}

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/ListBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/ListBenchmark.scala
@@ -64,7 +64,28 @@ class ListBenchmark {
   @Benchmark def mapConserve_modifyAll: Any = {
     values.mapConserve(x => replacement)
   }
+
   @Benchmark def mapConserve_modifyMid: Any = {
     values.mapConserve(x => if (x == mid) replacement else x)
+  }
+
+  @Benchmark def concat_raw: Any = {
+    List.concat(values, values)
+  }
+
+  @Benchmark def fill_raw: Any = {
+    List.fill(size)(last)
+  }
+
+  @Benchmark def tabulate_raw: Any = {
+    List.tabulate(size)(values.apply)
+  }
+
+  @Benchmark def range_raw: Any = {
+    List.range(-size, size, 2)
+  }
+
+  @Benchmark def iterate_raw: Any = {
+    List.iterate(last, size)(v => v.copy(value = v.value + 10))
   }
 }


### PR DESCRIPTION
A common pattern in the collection code is to create a builder, iterate a collection adding to the builder, and then call result. For the special case of a empty collection this can be optimized to call empty without the generation of the builder.

It shows quite significant speedups when generating empty arrays:
https://gist.github.com/pkukielka/88892b78beb941b1faeb343958c70c3f

Interestingly does not seem to benefit `List` in any way even though `List.empty` is defined as `override def empty[A]: List[A] = Nil` so it should avoid unnecessary objects creation.
I will investigate this.