### PR TITLE
Deprecate static forwarders along with their forwardees.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -818,9 +818,9 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
        */
       // TODO: evaluate the other flags we might be dropping on the floor here.
       // TODO: ACC_SYNTHETIC ?
-      val flags = GenBCode.PublicStatic | (
-        if (m.isVarargsMethod) asm.Opcodes.ACC_VARARGS else 0
-      )
+      val flags = GenBCode.PublicStatic |
+        (if (m.isVarargsMethod) asm.Opcodes.ACC_VARARGS else 0) |
+        (if (m.isDeprecated) asm.Opcodes.ACC_DEPRECATED else 0)
 
       // TODO needed? for(ann <- m.annotations) { ann.symbol.initialize }
       val jgensig = staticForwarderGenericSignature

--- a/test/files/neg/t10701.check
+++ b/test/files/neg/t10701.check
@@ -1,0 +1,6 @@
+t10701/Test.java:6: warning: [deprecation] whatever() in Meh has been deprecated
+        Meh.whatever();
+           ^
+error: warnings found and -Werror specified
+1 error
+1 warning

--- a/test/files/neg/t10701/Meh.scala
+++ b/test/files/neg/t10701/Meh.scala
@@ -1,0 +1,3 @@
+object Meh {
+  @deprecated("","") def whatever {}
+}

--- a/test/files/neg/t10701/Test.java
+++ b/test/files/neg/t10701/Test.java
@@ -1,0 +1,8 @@
+/*
+ * javac: -Werror -deprecation
+ */
+public class Test {
+    public static void main(String [] args) {
+        Meh.whatever();
+    }
+}


### PR DESCRIPTION
Evaluates one of the flags that was being dropped on the floor in `addForwarder`, and finds it being unjustly so.

The attached test case shows the issue: javac won't warn on deprecation as scalac would. I'm willing to be told that we shouldn't depend explicitly on the javac output, and change it to a `DirectTest` or similar that inspects the bytecode directly.

Fixes scala/bug#10701.