### PR TITLE
Eagerly enter default getters into scope

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
@@ -272,8 +272,13 @@ trait MacroAnnotationNamers { self: Analyzer =>
             if (isEnumConstant(tree))
               tree.symbol setInfo ConstantType(Constant(tree.symbol))
           case tree @ DefDef(_, nme.CONSTRUCTOR, _, _, _, _) =>
+            if (mexists(tree.vparamss)(_.mods.hasDefault))
+              enterDefaultGetters(tree.symbol, tree, tree.vparamss, tree.tparams)
             sym setInfo completerOf(tree)
           case tree @ DefDef(mods, name, tparams, _, _, _) =>
+            if (mexists(tree.vparamss)(_.mods.hasDefault))
+              enterDefaultGetters(tree.symbol, tree, tree.vparamss, tree.tparams)
+
             val completer =
               if (sym hasFlag SYNTHETIC) {
                 if (name == nme.copy) copyMethodCompleter(tree)

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -745,20 +745,24 @@ trait Namers extends MethodSynthesis {
 
     def enterTypeDef(tree: TypeDef) = assignAndEnterFinishedSymbol(tree)
 
-    def enterDefDef(tree: DefDef): Unit = tree match {
-      case DefDef(_, nme.CONSTRUCTOR, _, _, _, _) =>
-        assignAndEnterFinishedSymbol(tree)
-      case DefDef(mods, name, _, _, _, _) =>
-        val sym = enterInScope(assignMemberSymbol(tree))
+    def enterDefDef(tree: DefDef): Unit = {
+      tree match {
+        case DefDef(_, nme.CONSTRUCTOR, _, _, _, _) =>
+          assignAndEnterFinishedSymbol(tree)
+        case DefDef(mods, name, _, _, _, _) =>
+          val sym = enterInScope(assignMemberSymbol(tree))
 
-        val completer =
-          if (sym hasFlag SYNTHETIC) {
-            if (name == nme.copy) copyMethodCompleter(tree)
-            else if (sym hasFlag CASE) applyUnapplyMethodCompleter(tree, context)
-            else completerOf(tree)
-          } else completerOf(tree)
+          val completer =
+            if (sym hasFlag SYNTHETIC) {
+              if (name == nme.copy) copyMethodCompleter(tree)
+              else if (sym hasFlag CASE) applyUnapplyMethodCompleter(tree, context)
+              else completerOf(tree)
+            } else completerOf(tree)
 
-        sym setInfo completer
+          sym setInfo completer
+      }
+      if (mexists(tree.vparamss)(_.mods.hasDefault))
+        enterDefaultGetters(tree.symbol, tree, tree.vparamss, tree.tparams)
     }
 
     def enterClassDef(tree: ClassDef): Unit = {
@@ -1189,6 +1193,12 @@ trait Namers extends MethodSynthesis {
       val module = clazz.sourceModule
       for (cda <- module.attachments.get[ConstructorDefaultsAttachment]) {
         debuglog(s"Storing the template namer in the ConstructorDefaultsAttachment of ${module.debugLocationString}.")
+        if (cda.defaults.nonEmpty) {
+          for (sym <- cda.defaults) {
+            decls.enter(sym)
+          }
+          cda.defaults.clear()
+        }
         cda.companionModuleClassNamer = templateNamer
       }
       val classTp = ClassInfoType(parents, decls, clazz)
@@ -1420,6 +1430,42 @@ trait Namers extends MethodSynthesis {
     }
 
     /**
+     * For every default argument, insert a method symbol computing that default
+     */
+    def enterDefaultGetters(meth: Symbol, ddef: DefDef, vparamss: List[List[ValDef]], tparams: List[TypeDef]) {
+      val methOwner  = meth.owner
+      val search = DefaultGetterNamerSearch(context, meth, initCompanionModule = false)
+      var posCounter = 1
+
+      mforeach(vparamss){(vparam) =>
+        // true if the corresponding parameter of the base class has a default argument
+        if (vparam.mods.hasDefault) {
+          val name = nme.defaultGetterName(meth.name, posCounter)
+
+          search.createAndEnter { owner: Symbol =>
+            methOwner.resetFlag(INTERFACE) // there's a concrete member now
+            val default = owner.newMethodSymbol(name, vparam.pos, paramFlagsToDefaultGetter(meth.flags))
+            default.setPrivateWithin(meth.privateWithin)
+            default.referenced = meth
+            default.setInfo(ErrorType)
+            if (meth.name == nme.apply && meth.hasAllFlags(CASE | SYNTHETIC)) {
+              val att = meth.attachments.get[CaseApplyDefaultGetters].getOrElse({
+                val a = new CaseApplyDefaultGetters()
+                meth.updateAttachment(a)
+                a
+              })
+              att.defaultGetters += default
+            }
+            if (default.owner.isTerm)
+              saveDefaultGetter(meth, default)
+            default
+          }
+        }
+        posCounter += 1
+      }
+    }
+
+    /**
      * For every default argument, insert a method computing that default
      *
      * Also adds the "override" and "defaultparam" (for inherited defaults) flags
@@ -1491,24 +1537,6 @@ trait Namers extends MethodSynthesis {
             val defVparamss = mmap(rvparamss.take(previous.length)){ rvp =>
               copyValDef(rvp)(mods = rvp.mods &~ DEFAULTPARAM, rhs = EmptyTree)
             }
-            val defaultGetterSym = search.createAndEnter { owner: Symbol =>
-              methOwner.resetFlag(INTERFACE) // there's a concrete member now
-              val default = owner.newMethodSymbol(name, vparam.pos, paramFlagsToDefaultGetter(meth.flags))
-              default.setPrivateWithin(meth.privateWithin)
-              if (meth.name == nme.apply && meth.hasAllFlags(CASE | SYNTHETIC)) {
-                val att = meth.attachments.get[CaseApplyDefaultGetters].getOrElse({
-                  val a = new CaseApplyDefaultGetters()
-                  meth.updateAttachment(a)
-                  a
-                })
-                att.defaultGetters += default
-              }
-              if (default.owner.isTerm)
-                saveDefaultGetter(meth, default)
-              default
-            }
-            if (defaultGetterSym == NoSymbol) return
-
             search.addGetter(rtparams) {
               (parentNamer: Namer, defTparams: List[TypeDef]) =>
                 val defTpt =
@@ -1536,6 +1564,11 @@ trait Namers extends MethodSynthesis {
                 val defaultTree = atPos(vparam.pos.focus) {
                   DefDef(Modifiers(paramFlagsToDefaultGetter(meth.flags), ddef.mods.privateWithin) | oflag, name, defTparams, defVparamss, defTpt, defRhs)
                 }
+                def referencesThis(sym: Symbol) = sym match {
+                  case term: TermSymbol => term.referenced == meth
+                  case _ => false
+                }
+                val defaultGetterSym = parentNamer.context.scope.lookup(name).filter(referencesThis)
                 assert(defaultGetterSym != NoSymbol, (parentNamer.owner, name))
                 defaultTree.setSymbol(defaultGetterSym)
                 defaultGetterSym.setInfo(parentNamer.completerOf(defaultTree))
@@ -1562,7 +1595,7 @@ trait Namers extends MethodSynthesis {
     private abstract class DefaultGetterNamerSearch {
       def addGetter(rtparams0: List[TypeDef])(create: (Namer, List[TypeDef]) => Tree)
 
-      def createAndEnter(f: Symbol => Symbol): Symbol
+      def createAndEnter(f: Symbol => Symbol): Unit
     }
     private class DefaultGetterInCompanion(c: Context, meth: Symbol, initCompanionModule: Boolean) extends DefaultGetterNamerSearch {
       private val module = companionSymbolOf(meth.owner, context)
@@ -1570,14 +1603,19 @@ trait Namers extends MethodSynthesis {
       private val cda: Option[ConstructorDefaultsAttachment] = module.attachments.get[ConstructorDefaultsAttachment]
       private val moduleNamer = cda.flatMap(x => Option(x.companionModuleClassNamer))
 
-      def createAndEnter(f: Symbol => Symbol): Symbol = {
+      def createAndEnter(f: Symbol => Symbol): Unit = {
         val default = f(module.moduleClass)
         moduleNamer match {
           case Some(namer) =>
             namer.enterInScope(default)
           case None =>
-            // ignore error to fix #3649 (prevent crash in erroneous source code)
-            NoSymbol
+            cda match {
+              case Some(attachment) =>
+                // defer entry until the companion module body it type completed
+                attachment.defaults += default
+              case None =>
+              // ignore error to fix #3649 (prevent crash in erroneous source code)
+            }
         }
       }
       def addGetter(rtparams0: List[TypeDef])(create: (Namer, List[TypeDef]) => Tree): Unit = {
@@ -1603,7 +1641,7 @@ trait Namers extends MethodSynthesis {
         assert(ctx != NoContext, meth)
         newNamer(ctx)
       }
-      def createAndEnter(f: Symbol => Symbol): Symbol = {
+      def createAndEnter(f: Symbol => Symbol): Unit = {
         ownerNamer.enterInScope(f(ownerNamer.context.owner))
       }
       def addGetter(rtparams0: List[TypeDef])(create: (Namer, List[TypeDef]) => Tree): Unit = {

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -759,7 +759,7 @@ trait Namers extends MethodSynthesis {
           } else completerOf(tree)
 
         sym setInfo completer
-      }
+    }
 
     def enterClassDef(tree: ClassDef): Unit = {
       val ClassDef(mods, _, _, impl) = tree
@@ -1433,6 +1433,7 @@ trait Namers extends MethodSynthesis {
       // in methods with multiple default parameters
       def rtparams = rtparams0.map(_.duplicate)
       def rvparamss = rvparamss0.map(_.map(_.duplicate))
+      val search = DefaultGetterNamerSearch(context, meth, initCompanionModule = true)
       val methOwner  = meth.owner
       val isConstr   = meth.isConstructor
       val overrides  = overridden != NoSymbol && !overridden.isOverloaded
@@ -1448,9 +1449,6 @@ trait Namers extends MethodSynthesis {
         "" + meth.fullName + ", "+ overridden.fullName
       )
 
-      // cache the namer used for entering the default getter symbols
-      var ownerNamer: Option[Namer] = None
-      var moduleNamer: Option[(ClassDef, Namer)] = None
       var posCounter = 1
 
       // For each value parameter, create the getter method if it has a
@@ -1490,80 +1488,59 @@ trait Namers extends MethodSynthesis {
             val oflag = if (baseHasDefault) OVERRIDE else 0
             val name = nme.defaultGetterName(meth.name, posCounter)
 
-            var defTparams = rtparams
             val defVparamss = mmap(rvparamss.take(previous.length)){ rvp =>
               copyValDef(rvp)(mods = rvp.mods &~ DEFAULTPARAM, rhs = EmptyTree)
             }
-
-            val parentNamer = if (isConstr) {
-              val (cdef, nmr) = moduleNamer.getOrElse {
-                val module = companionSymbolOf(methOwner, context)
-                module.initialize // call type completer (typedTemplate), adds the
-                                  // module's templateNamer to classAndNamerOfModule
-                module.attachments.get[ConstructorDefaultsAttachment] match {
-                  // by martin: the null case can happen in IDE; this is really an ugly hack on top of an ugly hack but it seems to work
-                  case Some(cda) =>
-                    if (cda.companionModuleClassNamer == null) {
-                      devWarning(s"scala/bug#6576 The companion module namer for $meth was unexpectedly null")
-                      return
-                    }
-                    val p = (cda.classWithDefault, cda.companionModuleClassNamer)
-                    moduleNamer = Some(p)
-                    p
-                  case _ =>
-                    return // fix #3649 (prevent crash in erroneous source code)
-                }
-              }
-              val ClassDef(_, _, rtparams, _) = resetAttrs(deriveClassDef(cdef)(_ => Template(Nil, noSelfType, Nil)).duplicate)
-              defTparams = rtparams.map(rt => copyTypeDef(rt)(mods = rt.mods &~ (COVARIANT | CONTRAVARIANT)))
-              nmr
-            }
-            else ownerNamer getOrElse {
-              val ctx = context.nextEnclosing(c => c.scope.toList.contains(meth))
-              assert(ctx != NoContext, meth)
-              val nmr = newNamer(ctx)
-              ownerNamer = Some(nmr)
-              nmr
-            }
-
-            val defTpt =
-              // don't mess with tpt's of case copy default getters, because assigning something other than TypeTree()
-              // will break the carefully orchestrated naming/typing logic that involves copyMethodCompleter and caseClassCopyMeth
-              if (meth.isCaseCopy) TypeTree()
-              else {
-                // If the parameter type mentions any type parameter of the method, let the compiler infer the
-                // return type of the default getter => allow "def foo[T](x: T = 1)" to compile.
-                // This is better than always using Wildcard for inferring the result type, for example in
-                //    def f(i: Int, m: Int => Int = identity _) = m(i)
-                // if we use Wildcard as expected, we get "Nothing => Nothing", and the default is not usable.
-                // TODO: this is a very brittle approach; I sincerely hope that Denys's research into hygiene
-                //       will open the doors to a much better way of doing this kind of stuff
-                val tparamNames = defTparams map { case TypeDef(_, name, _, _) => name }
-                val eraseAllMentionsOfTparams = new TypeTreeSubstituter(tparamNames contains _)
-                eraseAllMentionsOfTparams(rvparam.tpt match {
-                  // default getter for by-name params
-                  case AppliedTypeTree(_, List(arg)) if sym.hasFlag(BYNAMEPARAM) => arg
-                  case t => t
-                })
-              }
-            val defRhs = rvparam.rhs
-
-            val defaultTree = atPos(vparam.pos.focus) {
-              DefDef(Modifiers(paramFlagsToDefaultGetter(meth.flags), ddef.mods.privateWithin) | oflag, name, defTparams, defVparamss, defTpt, defRhs)
-            }
-            if (!isConstr)
+            val defaultGetterSym = search.createAndEnter { owner: Symbol =>
               methOwner.resetFlag(INTERFACE) // there's a concrete member now
-            val default = parentNamer.enterSyntheticSym(defaultTree)
-            if (meth.name == nme.apply && meth.hasAllFlags(CASE | SYNTHETIC)) {
-              val att = meth.attachments.get[CaseApplyDefaultGetters].getOrElse({
-                val a = new CaseApplyDefaultGetters()
-                meth.updateAttachment(a)
-                a
-              })
-              att.defaultGetters += default
+              val default = owner.newMethodSymbol(name, vparam.pos, paramFlagsToDefaultGetter(meth.flags))
+              default.setPrivateWithin(meth.privateWithin)
+              if (meth.name == nme.apply && meth.hasAllFlags(CASE | SYNTHETIC)) {
+                val att = meth.attachments.get[CaseApplyDefaultGetters].getOrElse({
+                  val a = new CaseApplyDefaultGetters()
+                  meth.updateAttachment(a)
+                  a
+                })
+                att.defaultGetters += default
+              }
+              if (default.owner.isTerm)
+                saveDefaultGetter(meth, default)
+              default
             }
-            if (default.owner.isTerm)
-              saveDefaultGetter(meth, default)
+            if (defaultGetterSym == NoSymbol) return
+
+            search.addGetter(rtparams) {
+              (parentNamer: Namer, defTparams: List[TypeDef]) =>
+                val defTpt =
+                // don't mess with tpt's of case copy default getters, because assigning something other than TypeTree()
+                // will break the carefully orchestrated naming/typing logic that involves copyMethodCompleter and caseClassCopyMeth
+                  if (meth.isCaseCopy) TypeTree()
+                  else {
+                    // If the parameter type mentions any type parameter of the method, let the compiler infer the
+                    // return type of the default getter => allow "def foo[T](x: T = 1)" to compile.
+                    // This is better than always using Wildcard for inferring the result type, for example in
+                    //    def f(i: Int, m: Int => Int = identity _) = m(i)
+                    // if we use Wildcard as expected, we get "Nothing => Nothing", and the default is not usable.
+                    // TODO: this is a very brittle approach; I sincerely hope that Denys's research into hygiene
+                    //       will open the doors to a much better way of doing this kind of stuff
+                    val tparamNames = defTparams map { case TypeDef(_, name, _, _) => name }
+                    val eraseAllMentionsOfTparams = new TypeTreeSubstituter(tparamNames contains _)
+                    eraseAllMentionsOfTparams(rvparam.tpt match {
+                      // default getter for by-name params
+                      case AppliedTypeTree(_, List(arg)) if sym.hasFlag(BYNAMEPARAM) => arg
+                      case t => t
+                    })
+                  }
+                val defRhs = rvparam.rhs
+
+                val defaultTree = atPos(vparam.pos.focus) {
+                  DefDef(Modifiers(paramFlagsToDefaultGetter(meth.flags), ddef.mods.privateWithin) | oflag, name, defTparams, defVparamss, defTpt, defRhs)
+                }
+                assert(defaultGetterSym != NoSymbol, (parentNamer.owner, name))
+                defaultTree.setSymbol(defaultGetterSym)
+                defaultGetterSym.setInfo(parentNamer.completerOf(defaultTree))
+                defaultTree
+            }
           }
           else if (baseHasDefault) {
             // the parameter does not have a default itself, but the
@@ -1575,6 +1552,63 @@ trait Namers extends MethodSynthesis {
         })
         if (overrides) baseParamss = baseParamss.tail
         previous :+ vparams
+      }
+    }
+
+    private object DefaultGetterNamerSearch {
+      def apply(c: Context, meth: Symbol, initCompanionModule: Boolean) = if (meth.isConstructor) new DefaultGetterInCompanion(c, meth, initCompanionModule)
+      else new DefaultMethodInOwningScope(c, meth)
+    }
+    private abstract class DefaultGetterNamerSearch {
+      def addGetter(rtparams0: List[TypeDef])(create: (Namer, List[TypeDef]) => Tree)
+
+      def createAndEnter(f: Symbol => Symbol): Symbol
+    }
+    private class DefaultGetterInCompanion(c: Context, meth: Symbol, initCompanionModule: Boolean) extends DefaultGetterNamerSearch {
+      private val module = companionSymbolOf(meth.owner, context)
+      if (initCompanionModule) module.initialize
+      private val cda: Option[ConstructorDefaultsAttachment] = module.attachments.get[ConstructorDefaultsAttachment]
+      private val moduleNamer = cda.flatMap(x => Option(x.companionModuleClassNamer))
+
+      def createAndEnter(f: Symbol => Symbol): Symbol = {
+        val default = f(module.moduleClass)
+        moduleNamer match {
+          case Some(namer) =>
+            namer.enterInScope(default)
+          case None =>
+            // ignore error to fix #3649 (prevent crash in erroneous source code)
+            NoSymbol
+        }
+      }
+      def addGetter(rtparams0: List[TypeDef])(create: (Namer, List[TypeDef]) => Tree): Unit = {
+        cda match {
+          case Some(attachment) =>
+            moduleNamer match {
+              case Some(namer) =>
+                val cdef = attachment.classWithDefault
+                val ClassDef(_, _, rtparams, _) = resetAttrs(deriveClassDef(cdef)(_ => Template(Nil, noSelfType, Nil)).duplicate)
+                val defTparams = rtparams.map(rt => copyTypeDef(rt)(mods = rt.mods &~ (COVARIANT | CONTRAVARIANT)))
+                val tree = create(namer, defTparams)
+                namer.enterSyntheticSym(tree)
+              case None =>
+            }
+          case None =>
+        }
+
+      }
+    }
+    private class DefaultMethodInOwningScope(c: Context, meth: Symbol) extends DefaultGetterNamerSearch {
+      private lazy val ownerNamer: Namer = {
+        val ctx = context.nextEnclosing(c => c.scope.toList.contains(meth)) // TODO use lookup rather than toList.contains
+        assert(ctx != NoContext, meth)
+        newNamer(ctx)
+      }
+      def createAndEnter(f: Symbol => Symbol): Symbol = {
+        ownerNamer.enterInScope(f(ownerNamer.context.owner))
+      }
+      def addGetter(rtparams0: List[TypeDef])(create: (Namer, List[TypeDef]) => Tree): Unit = {
+        val tree = create(ownerNamer, rtparams0)
+        ownerNamer.enterSyntheticSym(tree)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -28,7 +28,7 @@ trait NamesDefaults { self: Analyzer =>
   // object, we need the templateNamer of that module class. These two are stored
   // as an attachment in the companion module symbol
   class ConstructorDefaultsAttachment(val classWithDefault: ClassDef, var companionModuleClassNamer: Namer) {
-    var defaults = mutable.ListBuffer[Symbol]()
+    val defaults = mutable.ListBuffer[Symbol]()
   }
 
   // Attached to the synthetic companion `apply` method symbol generated for case classes, holds

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -27,7 +27,9 @@ trait NamesDefaults { self: Analyzer =>
   // we need the ClassDef. To create and enter the symbols into the companion
   // object, we need the templateNamer of that module class. These two are stored
   // as an attachment in the companion module symbol
-  class ConstructorDefaultsAttachment(val classWithDefault: ClassDef, var companionModuleClassNamer: Namer)
+  class ConstructorDefaultsAttachment(val classWithDefault: ClassDef, var companionModuleClassNamer: Namer) {
+    var defaults = mutable.ListBuffer[Symbol]()
+  }
 
   // Attached to the synthetic companion `apply` method symbol generated for case classes, holds
   // the set contains all default getters for that method. If the synthetic `apply` is unlinked in

--- a/test/junit/scala/tools/nsc/typechecker/NamerTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/NamerTest.scala
@@ -18,6 +18,6 @@ class NamerTest extends BytecodeTesting {
     compiler.compileClasses("package p1; class Test { C.b(); C.a() }; object C { def a(x: Int = 0) = 0; def b(x: Int = 0) = 0 }")
     val methods = compiler.global.rootMirror.getRequiredModule("p1.C").info.decls.toList.map(_.name.toString).filter(_.matches("""(a|b).*"""))
     def getterName(s: String) = nme.defaultGetterName(TermName(s), 1).toString
-    Assert.assertEquals(List("a", "b", getterName("b"), getterName("a")), methods) // order depends on order of lazy type completion :(
+    Assert.assertEquals(List("a", getterName("a"), "b", getterName("b")), methods) // order depends on order of lazy type completion :(
   }
 }

--- a/test/junit/scala/tools/nsc/typechecker/NamerTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/NamerTest.scala
@@ -1,0 +1,23 @@
+package scala.tools.nsc.typechecker
+
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.BytecodeTesting
+
+@RunWith(classOf[JUnit4])
+class NamerTest extends BytecodeTesting {
+
+  import compiler.global._
+
+  override def compilerArgs: String = "-Ystop-after:typer"
+
+  @Test
+  def defaultMethodsInDeclarationOrder(): Unit = {
+    compiler.compileClasses("package p1; class Test { C.b(); C.a() }; object C { def a(x: Int = 0) = 0; def b(x: Int = 0) = 0 }")
+    val methods = compiler.global.rootMirror.getRequiredModule("p1.C").info.decls.toList.map(_.name.toString).filter(_.matches("""(a|b).*"""))
+    def getterName(s: String) = nme.defaultGetterName(TermName(s), 1).toString
+    Assert.assertEquals(List("a", "b", getterName("b"), getterName("a")), methods) // order depends on order of lazy type completion :(
+  }
+}

--- a/test/junit/scala/tools/nsc/typechecker/NamerTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/NamerTest.scala
@@ -18,6 +18,6 @@ class NamerTest extends BytecodeTesting {
     compiler.compileClasses("package p1; class Test { C.b(); C.a() }; object C { def a(x: Int = 0) = 0; def b(x: Int = 0) = 0 }")
     val methods = compiler.global.rootMirror.getRequiredModule("p1.C").info.decls.toList.map(_.name.toString).filter(_.matches("""(a|b).*"""))
     def getterName(s: String) = nme.defaultGetterName(TermName(s), 1).toString
-    Assert.assertEquals(List("a", getterName("a"), "b", getterName("b")), methods) // order depends on order of lazy type completion :(
+    Assert.assertEquals(List("a", getterName("a"), "b", getterName("b")), methods) // order no longer depends on order of lazy type completion :)
   }
 }


### PR DESCRIPTION
This stabilizes the order they appear in the owners scope. Previously,
their order was governed by the order that the methods bearing default
parameters were type completed.

References scala/scala-dev#405