### PR TITLE
drop -Yuse-stupid-types

### DIFF
--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -119,7 +119,7 @@ object ScalaOptionParser {
   private def scalaStringSettingNames = List("-i", "-e")
   private def scalaBooleanSettingNames = List("-nc", "-save")
 
-  private def scalaDocBooleanSettingNames = List("-Yuse-stupid-types", "-implicits", "-implicits-debug", "-implicits-show-all", "-implicits-sound-shadowing", "-implicits-hide", "-author", "-diagrams", "-diagrams-debug", "-raw-output", "-no-prefixes", "-no-link-warnings", "-expand-all-types", "-groups")
+  private def scalaDocBooleanSettingNames = List("-implicits", "-implicits-debug", "-implicits-show-all", "-implicits-sound-shadowing", "-implicits-hide", "-author", "-diagrams", "-diagrams-debug", "-raw-output", "-no-prefixes", "-no-link-warnings", "-expand-all-types", "-groups")
   private def scalaDocIntSettingNames = List("-diagrams-max-classes", "-diagrams-max-implicits", "-diagrams-dot-timeout", "-diagrams-dot-restart")
   private def scalaDocChoiceSettingNames = Map("-doc-format" -> List("html"))
   private def scaladocStringSettingNames = List("-doc-title", "-doc-version", "-doc-footer", "-doc-no-compile", "-doc-source-url", "-doc-generator", "-skip-packages")

--- a/spec/10-xml-expressions-and-patterns.md
+++ b/spec/10-xml-expressions-and-patterns.md
@@ -80,7 +80,7 @@ CharData      ::=   { CharNoRef } $\textit{ without}$ {CharNoRef}‘{’CharB {C
                                   $\textit{ and without}$ {CharNoRef}‘]]>’{CharNoRef}
 ```
 
-<!-- {% raw  %} stupid liquid borks on the double brace below; brace yourself, liquid! -->
+<!-- {% raw  %} sigh: liquid borks on the double brace below; brace yourself, liquid! -->
 XML expressions may contain Scala expressions as attribute values or
 within nodes. In the latter case, these are embedded using a single opening
 brace `{` and ended by a closing brace `}`. To express a single opening braces

--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -79,11 +79,6 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
     "comma-separated list of classpath_entry_path#doc_URL pairs describing external dependencies."
   )
 
-  val useStupidTypes = BooleanSetting (
-    "-Yuse-stupid-types",
-    "Print the types of inherited members as seen from their original definition context. Hint: you don't want to do that!"
-  )
-
   val docgenerator = StringSetting (
     "-doc-generator",
     "class-name",
@@ -220,7 +215,7 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
 
   // For improved help output.
   def scaladocSpecific = Set[Settings#Setting](
-    docformat, doctitle, docfooter, docversion, docUncompilable, docsourceurl, docgenerator, docRootContent, useStupidTypes,
+    docformat, doctitle, docfooter, docversion, docUncompilable, docsourceurl, docgenerator, docRootContent,
     docExternalDoc,
     docAuthor, docDiagrams, docDiagramsDebug, docDiagramsDotPath,
     docDiagramsDotTimeout, docDiagramsDotRestart,

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -352,7 +352,7 @@ trait EntityPage extends HtmlPage {
           NodeSeq fromSeq (for ((superTpl, superType) <- (tpl.linearizationTemplates zip tpl.linearizationTypes)) yield
             <div class="parent" name={ superTpl.qualifiedName }>
               <h3>Inherited from {
-                typeToHtmlWithStupidTypes(tpl, superTpl, superType)
+                typeToHtml(superType, hasLinks = true)
               }</h3>
             </div>
           )
@@ -1064,18 +1064,6 @@ trait EntityPage extends HtmlPage {
     case comment.Paragraph(in) => Page.inlineToStr(in)
     case _ => block.toString
   }
-
-  private def typeToHtmlWithStupidTypes(tpl: TemplateEntity, superTpl: TemplateEntity, superType: TypeEntity): NodeSeq =
-    if (tpl.universe.settings.useStupidTypes.value)
-      superTpl match {
-        case dtpl: DocTemplateEntity =>
-          val sig = signature(dtpl, isSelf = false, isReduced = true) \ "_"
-          sig
-        case tpl: TemplateEntity =>
-          Text(tpl.name)
-      }
-  else
-    typeToHtml(superType, hasLinks = true)
 
   private def constraintToHtml(constraint: Constraint): NodeSeq = constraint match {
     case ktcc: KnownTypeClassConstraint =>

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -907,15 +907,12 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
 
   /** */
   def makeTypeInTemplateContext(aType: Type, inTpl: TemplateImpl, dclSym: Symbol): TypeEntity = {
-    def ownerTpl(sym: Symbol): Symbol =
-      if (sym.isClass || sym.isModule || sym == NoSymbol) sym else ownerTpl(sym.owner)
-    val tpe =
-      if (thisFactory.settings.useStupidTypes) aType else {
-        def ownerTpl(sym: Symbol): Symbol =
-          if (sym.isClass || sym.isModule || sym == NoSymbol) sym else ownerTpl(sym.owner)
-        val fixedSym = if (inTpl.sym.isModule) inTpl.sym.moduleClass else inTpl.sym
-        aType.asSeenFrom(fixedSym.thisType, ownerTpl(dclSym))
-      }
+    val tpe = {
+      def ownerTpl(sym: Symbol): Symbol =
+        if (sym.isClass || sym.isModule || sym == NoSymbol) sym else ownerTpl(sym.owner)
+      val fixedSym = if (inTpl.sym.isModule) inTpl.sym.moduleClass else inTpl.sym
+      aType.asSeenFrom(fixedSym.thisType, ownerTpl(dclSym))
+    }
     makeType(tpe, inTpl)
   }
 


### PR DESCRIPTION
this was added by Gilles in 2010 "for internal use" and with the
description "Print the types of inherited members as seen from their
original definition context. Hint: you don't want to do that!"

so, it isn't clear what this was even for originally. but, googling and
searching GitHub turns up no uses.