### PR TITLE
bundle scala-parser-combinators 1.0.7

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -20,7 +20,7 @@ scala.binary.version=2.12
 #  - jline: shaded with JarJar and included in scala-compiler
 #  - partest: used for running the tests
 scala-xml.version.number=1.0.6
-scala-parser-combinators.version.number=1.0.6
+scala-parser-combinators.version.number=1.0.7
 scala-swing.version.number=2.0.0
 partest.version.number=1.1.1
 scala-asm.version=6.0.0-scala-1


### PR DESCRIPTION
it doesn't matter a whole lot what version we bundle with 2.12.5,
but on the balance, I suggest we bundle the latest 1.0.x release

(there is also a 1.1.0, but let's be conservative)