### PR TITLE
Defer parameter alias computation until the end of typechecking

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -94,6 +94,7 @@ trait Analyzer extends AnyRef
           applyPhase(unit)
           undoLog.clear()
         }
+        finishComputeParamAlias()
         // defensive measure in case the bookkeeping in deferred macro expansion is buggy
         clearDelayed()
         if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(statistics.typerNanos, start)

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -291,7 +291,7 @@ trait ContextErrors {
       def DeprecatedParamNameError(param: Symbol, name: Name) =
         issueSymbolTypeError(param, "deprecated parameter name "+ name +" has to be distinct from any other parameter name (deprecated or not).")
 
-      // computeParamAliases
+      // analyzeSuperConsructor
       def SuperConstrReferenceError(tree: Tree) =
         NormalTypeError(tree, "super constructor cannot be passed a self reference unless parameter is declared by-name")
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -50,6 +50,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
   // Symbols of ValDefs for right-associative operator desugaring which are passed by name and have been inlined
   private val inlinedRightAssocValDefs = new mutable.HashSet[Symbol]
 
+  // For each class, we collect a mapping from constructor param accessors that are aliases of their superclass
+  // param accessors. At the end of the typer phase, when this information is available all the way up the superclass
+  // chain, this is used to determine which are true aliases, ones where the field can be elided from this class.
+  // And yes, if you were asking, this is yet another binary fragility, as we bake knowledge of the super class into
+  // this class.
+  private val superConstructorCalls: mutable.AnyRefMap[Symbol, collection.Map[Symbol, Symbol]] = perRunCaches.newAnyRefMap()
+
   // allows override of the behavior of the resetTyper method w.r.t comments
   def resetDocComments() = clearDocComments()
 
@@ -60,6 +67,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     resetDocComments()
     rightAssocValDefs.clear()
     inlinedRightAssocValDefs.clear()
+    superConstructorCalls.clear()
   }
 
   sealed abstract class SilentResult[+T] {
@@ -2092,9 +2100,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       vdef1
     }
 
-    /** Enter all aliases of local parameter accessors.
-     */
-    def computeParamAliases(clazz: Symbol, vparamss: List[List[ValDef]], rhs: Tree): Unit = {
+    /** Analyze the super constructor call to record information used later to compute parameter aliases */
+    def analyzeSuperConsructor(meth: Symbol, vparamss: List[List[ValDef]], rhs: Tree): Unit = {
+      val clazz = meth.owner
       debuglog(s"computing param aliases for $clazz:${clazz.primaryConstructor.tpe}:$rhs")
       val pending = ListBuffer[AbsTypeError]()
 
@@ -2136,26 +2144,22 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         if (!superClazz.isJavaDefined) {
           val superParamAccessors = superClazz.constrParamAccessors
           if (sameLength(superParamAccessors, superArgs)) {
+            val accToSuperAcc = mutable.AnyRefMap[Symbol, Symbol]()
             for ((superAcc, superArg@Ident(name)) <- superParamAccessors zip superArgs) {
               if (mexists(vparamss)(_.symbol == superArg.symbol)) {
-                val alias = (
-                  superAcc.initialize.alias
-                  orElse (superAcc getterIn superAcc.owner)
-                  filter (alias => superClazz.info.nonPrivateMember(alias.name) == alias)
-                  )
-                if (alias.exists && !alias.accessed.isVariable && !isRepeatedParamType(alias.accessed.info)) {
-                  val ownAcc = clazz.info decl name suchThat (_.isParamAccessor) match {
-                    case acc if !acc.isDeferred && acc.hasAccessorFlag => acc.accessed
-                    case acc => acc
-                  }
-                  ownAcc match {
-                    case acc: TermSymbol if !acc.isVariable && !isByNameParamType(acc.info) =>
-                      debuglog(s"$acc has alias ${alias.fullLocationString}")
-                      acc setAlias alias
-                    case _ =>
-                  }
+                val ownAcc = clazz.info decl name suchThat (_.isParamAccessor) match {
+                  case acc if !acc.isDeferred && acc.hasAccessorFlag => acc.accessed
+                  case acc => acc
+                }
+                ownAcc match {
+                  case acc: TermSymbol if !acc.isVariable && !isByNameParamType(acc.info) =>
+                    accToSuperAcc(acc) = superAcc
+                  case _ =>
                 }
               }
+            }
+            if (!accToSuperAcc.isEmpty) {
+              superConstructorCalls(clazz) = accToSuperAcc
             }
           }
         }
@@ -2311,10 +2315,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       if (meth.isClassConstructor && !isPastTyper && !meth.owner.isSubClass(AnyValClass) && !meth.isJava) {
         // There are no supercalls for AnyVal or constructors from Java sources, which
-        // would blow up in computeParamAliases; there's nothing to be computed for them
+        // would blow up in analyzeSuperConsructor; there's nothing to be computed for them
         // anyway.
         if (meth.isPrimaryConstructor)
-          computeParamAliases(meth.owner, vparamss1, rhs1)
+          analyzeSuperConsructor(meth, vparamss1, rhs1)
         else
           checkSelfConstructorArgs(ddef, meth.owner)
       }
@@ -5937,6 +5941,35 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     final def lookupTransformed(tree: Tree): Option[Tree] =
       if (phase.erasedTypes) None // OPT save the hashmap lookup in erasure type and beyond
       else transformed remove tree
+  }
+
+
+  /** Finish computation of param aliases after typechecking is completed */
+  final def finishComputeParamAlias(): Unit = {
+    val classes = superConstructorCalls.keys.toArray
+    // superclasses before subclasses to avoid a data race between `superAcc.alias` and `acc.setAlias` below.
+    scala.util.Sorting.quickSort(classes)(Ordering.fromLessThan((a, b) => b.isLess(a)))
+
+    for (sym <- classes) {
+      for ((ownAcc, superAcc) <- superConstructorCalls.getOrElse(sym, Nil)) {
+        // We have a corresponding paramter in the super class.
+        val superClazz = sym.superClass
+        val alias = (
+          superAcc.initialize.alias // Is the param accessor is an alias for a field further up  the class heirarchy?
+            orElse (superAcc getterIn superAcc.owner) // otherwise, lookup the accessor for the super
+            filter (alias => superClazz.info.nonPrivateMember(alias.name) == alias) // the accessor must be public
+          )
+        if (alias.exists && !alias.accessed.isVariable && !isRepeatedParamType(alias.accessed.info)) {
+          ownAcc match {
+            case acc: TermSymbol if !acc.isVariable && !isByNameParamType(acc.info) =>
+              debuglog(s"$acc has alias ${alias.fullLocationString}")
+              acc setAlias alias
+            case _ =>
+          }
+        }
+      }
+    }
+    superConstructorCalls.clear()
   }
 }
 

--- a/test/junit/scala/tools/nsc/typechecker/ParamAliasTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/ParamAliasTest.scala
@@ -1,0 +1,60 @@
+package scala.tools.nsc.typechecker
+
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.reflect.io.VirtualDirectory
+import scala.tools.nsc.Global
+import scala.tools.nsc.classpath.{AggregateClassPath, VirtualDirectoryClassPath}
+import scala.tools.nsc.reporters.StoreReporter
+import scala.tools.testing.BytecodeTesting
+
+@RunWith(classOf[JUnit4])
+class ParamAliasTest extends BytecodeTesting {
+
+  @Test
+  def checkAliasWorksWhenSubclassesAreTypecheckedFirst(): Unit = {
+    def test(code: List[String], check: List[(String, String)], expected: List[String]): Unit = {
+      val compiler1 = BytecodeTesting.newCompiler(extraArgs = compilerArgs)
+      val r = new compiler1.global.Run
+      r.compileSources(code.map(compiler1.global.newSourceFile(_)))
+      Predef.assert(!compiler1.global.reporter.hasErrors, compiler1.global.reporter.asInstanceOf[StoreReporter].infos)
+      def aliasNames(g: Global) = {
+        check.map {
+          case (clsName, paramName) =>
+            val cls = g.rootMirror.getRequiredClass(clsName)
+            val field = g.exitingPickler(cls.info.decl(g.TermName(paramName)).suchThat(_.isParamAccessor).accessed)
+            assert(field.exists, (clsName, paramName, cls.info))
+            val alias = field.alias
+            s"${field.fullName} stored in ${alias.fullName}"
+        }
+      }
+      val aliasInfoAfterCompilation = aliasNames(compiler1.global)
+      val compiler2 = BytecodeTesting.newCompiler(extraArgs = compilerArgs)
+      val out = compiler1.global.settings.outputDirs.getSingleOutput.get.asInstanceOf[VirtualDirectory]
+      compiler2.global.platform.classPath
+      compiler2.global.platform.currentClassPath = Some(AggregateClassPath(new VirtualDirectoryClassPath(out) :: compiler2.global.platform.currentClassPath.get :: Nil))
+      val r2 = new compiler2.global.Run
+      val aliasInfoUnpickled = aliasNames(compiler2.global)
+      Assert.assertEquals(expected.sorted, aliasInfoAfterCompilation.sorted)
+      Assert.assertEquals(expected.sorted, aliasInfoUnpickled.sorted)
+    }
+
+    {
+      val code = List("package p1; class A(val a: Int) extends B(a)", "package p1; class B(b: Int) extends C(b)", "package p1; class C(val c: Int)")
+      val check = List("p1.A" -> "a")
+      val expected = List("p1.A.a stored in p1.C.c")
+      test(code, check, expected)
+      test(code.reverse, check, expected)
+    }
+
+    {
+      val code = List("package p1; class A(val a: Int) extends B(a)", "package p1; class B(val b: Int) extends C(b)", "package p1; class C(val c: Int)")
+      val check = List("p1.A" -> "a", "p1.B" -> "b")
+      val expected = List("p1.A.a stored in p1.C.c", "p1.B.b stored in p1.C.c")
+      test(code, check, expected)
+      test(code.reverse, check, expected)
+    }
+  }
+}


### PR DESCRIPTION
Previously, it was done while typechecking super calls, and would fail
to see the fact that a yet-to-be-typechecked super constructor itself
had a parameter aliased by a grand-parent class.

Part of scala/scala-dev#405