### PR TITLE
Don't copy the OVERRIDE flag in refinement decls

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3773,7 +3773,7 @@ trait Types
         else refinedType(parents, owner)
       val syms1 = decls.toList
       for (sym <- syms1)
-        result.decls.enter(sym.cloneSymbol(result.typeSymbol))
+        result.decls.enter(sym.cloneSymbol(result.typeSymbol).resetFlag(OVERRIDE))
       val syms2 = result.decls.toList
       val resultThis = result.typeSymbol.thisType
       for (sym <- syms2)


### PR DESCRIPTION
`typedRefinement` defers the setting of this flag until the end of the
compilation unit, which means that inferred types that are derived from the
written refinement type can be unstable depending on whether they were
computed before or after the flag was set.

An alternative fix might be to just remove the setting of `OVERRIDE` in
in `typedRefinement.unitToCheck`.

The (last!) part of scala/scala-dev#405

Includes the commits of #6300 as it adds a new test case to `DeterminismTest`. Only the final commit is the subject of this pull request.