### PR TITLE
Fix scaladoc links for Any{Ref,Val,} and Nothing.

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/model/MemberLookup.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/MemberLookup.scala
@@ -9,7 +9,7 @@ trait MemberLookup extends base.MemberLookupBase {
   thisFactory: ModelFactory =>
 
   import global._
-  import definitions.{ NothingClass, AnyClass, AnyValClass, AnyRefClass, ListClass }
+  import definitions.{ NothingClass, AnyClass, AnyValClass, AnyRefClass }
 
   override def internalLink(sym: Symbol, site: Symbol): Option[LinkTo] =
     findTemplateMaybe(sym) match {
@@ -39,7 +39,8 @@ trait MemberLookup extends base.MemberLookupBase {
 
   override def findExternalLink(sym: Symbol, name: String): Option[LinkTo] = {
     val sym1 =
-      if (sym == AnyClass || sym == AnyRefClass || sym == AnyValClass || sym == NothingClass) ListClass
+      if (sym == AnyClass || sym == AnyRefClass || sym == AnyValClass || sym == NothingClass)
+        definitions.ScalaPackageClass.info.member(newTermName("package"))
       else if (sym.hasPackageFlag)
         /* Get package object which has associatedFile ne null */
         sym.info.member(newTermName("package"))
@@ -61,7 +62,7 @@ trait MemberLookup extends base.MemberLookupBase {
     }
     classpathEntryFor(sym1) flatMap { path =>
       settings.extUrlMapping get path map { url => {
-         LinkToExternalTpl(name, url, makeTemplate(sym1))
+         LinkToExternalTpl(name, url, makeTemplate(sym))
         }
       }
     }

--- a/test/scaladoc/run/t10673.check
+++ b/test/scaladoc/run/t10673.check
@@ -1,0 +1,4 @@
+'scala.AnyRef' links to scala.AnyRef
+'scala.collection.immutable.Seq' links to scala.collection.immutable.Seq
+'scala.Nothing' links to scala.Nothing
+Done.

--- a/test/scaladoc/run/t10673.scala
+++ b/test/scaladoc/run/t10673.scala
@@ -1,0 +1,43 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.nsc.doc.base._
+import scala.tools.nsc.doc.base.comment._
+import scala.tools.nsc.doc.html.Page
+import scala.tools.partest.ScaladocModelTest
+import java.net.{URI, URL}
+import java.io.File
+
+object Test extends ScaladocModelTest {
+
+  override def code =
+    """
+        trait Foo extends AnyRef
+
+        class Bar extends scala.collection.immutable.Seq[Nothing]
+    """
+
+  def scalaURL = "http://bog.us"
+
+  override def scaladocSettings = {
+    val samplePath = getClass.getClassLoader.getResource("scala/Function1.class").getPath
+    val scalaLibPath = if(samplePath.contains("!")) { // in scala-library.jar
+      val scalaLibUri = samplePath.split("!")(0)
+      new URI(scalaLibUri).getPath
+    } else { // individual class files on disk
+      samplePath.replace('\\', '/').dropRight("scala/Function1.class".length)
+    }
+    s"-no-link-warnings -doc-external-doc $scalaLibPath#$scalaURL"
+  }
+
+  def testModel(rootPackage: Package) {
+    import access._
+    def showParents(e: MemberTemplateEntity): Unit = {
+      e.parentTypes.foreach(_._2.refEntity.foreach {
+        case (_, (LinkToExternalTpl(name, _, tpl), _)) => println(s"'$name' links to $tpl")
+        case (_, (Tooltip(name), _))                   => println(s"'$name' no link!")
+      })
+    }
+
+    showParents(rootPackage._trait("Foo"))
+    showParents(rootPackage._class("Bar"))
+  }
+}


### PR DESCRIPTION
The symbols for `Any`, `AnyRef` and friends don't have an
`associatedFile`, so another (hardcoded) symbol is used to make
scaladoc pick the url for scala-library. Same thing is done for
package objects using the `package` member.

But once the external url is picked from the mapping list, we
should link to the real symbol, not the fake one.

That part regressed in #5799 (c6ed953).

Also, using `ListClass` as the replacement symbol doesn't work if the
codebase being documented doesn't reference `List` at all: in that case it
has no `associatedFile` either. The Akka codebase (from the ticket)
obviously uses `List`, so it worked for them, but failed when minimized.
There is some symbol initialization magic here that I don't understand,
but using the root scala package always works and makes more sense
anyway.

Fixes scala/bug#10673.