### PR TITLE
Add `->` alias for `Tuple2` to Predef

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -167,6 +167,20 @@ object Predef extends LowPriorityImplicits {
   /**  @group aliases */
   val Set         = immutable.Set
 
+  /**
+   * Allows destructuring tuples with the same syntax as constructing them.
+   *
+   * @example {{{
+   * val tup = "foobar" -> 3
+   *
+   * val c = tup match {
+   *   case str -> i => str.charAt(i)
+   * }
+   * }}}
+   * @group aliases
+   */
+  val ->        = Tuple2
+
   // Manifest types, companions, and incantations for summoning
   @annotation.implicitNotFound(msg = "No ClassManifest available for ${T}.")
   @deprecated("use `scala.reflect.ClassTag` instead", "2.10.0")

--- a/test/junit/scala/PredefTest.scala
+++ b/test/junit/scala/PredefTest.scala
@@ -1,0 +1,23 @@
+package scala
+
+import org.junit.Assert._
+import org.junit.Test
+
+
+class PredefTest {
+  @Test
+  def testTuple2Alias: Unit = {
+    val tup = "foobar" -> 3
+    val char = tup match {
+      case str -> i => str.charAt(i)
+    }
+    assertEquals('b', char)
+
+    val a -> b -> c = false -> 42 -> "bazzz"
+    val res: Int = if (a) b else c.length
+    assertEquals(false, a)
+    assertEquals(42, b)
+    assertEquals("bazzz", c)
+    assertEquals(5, res)
+  }
+}


### PR DESCRIPTION
I know lately we prefer less possible ways of doing a thing instead of more. However, in the case of `Tuple2` I would say that ship has sailed a long time ago, so it would be nice if at least constructing and destructing a tuple have consistent syntaxes:

```
42 -> "foo" match {
  case key -> value => ???
}
```

It would also help readability (in my opinion) with API's where you can end up with lots of nested tuples, like the `RDD` API in Spark.

By the way, as far as I can tell, bytecode for `case (key, value) =>` and `case key -> value =>`  is exactly the same.

I did __not__ add a corresponding type alias `->`, but can add it if someone strongly feels that it should be included.

ping @SethTisue @Blaisorblade @dwijnand 