### PR TITLE
Avoid IIOBE in phase stack

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1098,6 +1098,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
     var currentUnit: CompilationUnit = NoCompilationUnit
 
     val profiler: Profiler = Profiler(settings)
+    keepPhaseStack = settings.log.isSetByUser
 
     // used in sbt
     def uncheckedWarnings: List[(Position, String)]   = reporting.uncheckedWarnings.map{case (pos, (msg, since)) => (pos, msg)}

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -11,6 +11,8 @@ import scala.annotation.elidable
 import scala.collection.mutable
 import util._
 import java.util.concurrent.TimeUnit
+
+import scala.collection.mutable.ArrayBuffer
 import scala.reflect.internal.{TreeGen => InternalTreeGen}
 
 abstract class SymbolTable extends macros.Universe
@@ -181,12 +183,11 @@ abstract class SymbolTable extends macros.Universe
   final val NoRunId = 0
 
   // sigh, this has to be public or enteringPhase doesn't inline.
-  var phStack: Array[Phase] = new Array(128)
-  var phStackIndex = 0
+  val phStack: ArrayBuffer[Phase] = new ArrayBuffer(128)
   private[this] var ph: Phase = NoPhase
   private[this] var per = NoPeriod
 
-  final def atPhaseStack: List[Phase] = List.tabulate(phStackIndex)(i => phStack(i))
+  final def atPhaseStack: List[Phase] = phStack.toList
   final def phase: Phase = {
     if (StatisticsStatics.areSomeColdStatsEnabled)
       statistics.incCounter(statistics.phaseCounter)
@@ -207,15 +208,18 @@ abstract class SymbolTable extends macros.Universe
   final def pushPhase(ph: Phase): Phase = {
     val current = phase
     phase = ph
-    phStack(phStackIndex) = ph
-    phStackIndex += 1
+    if (keepPhaseStack) {
+      phStack += ph
+    }
     current
   }
   final def popPhase(ph: Phase) {
-    phStack(phStackIndex) = null
-    phStackIndex -= 1
+    if (keepPhaseStack) {
+      phStack.remove(phStack.size)
+    }
     phase = ph
   }
+  var keepPhaseStack: Boolean = false
 
   /** The current compiler run identifier. */
   def currentRunId: RunId


### PR DESCRIPTION
Flatten's info transform ends calls `enteringMixin(enteringFlaten(...))`
all the way up the prefix, which violate my assumption that 128 recursive
atPhase calls should enough for anyone when we encounter heavily nested
code (such as that regrettably still emitted by the REPL when many imports
precede the current line).

This commit switches to using an ArrayBuffer that will grow as needed,
and also disables the entire maintenance of the phase stack when logging
is disabled.