### PR TITLE
Iterator.scanLeft is lazy at initial value

### DIFF
--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -296,4 +296,33 @@ class IteratorTest {
     assertEquals(v2, v4)
     assertEquals(Some(v1), v2)
   }
+  // scala/bug#10709
+  @Test def `scan is lazy enough`(): Unit = {
+    val results = collection.mutable.ListBuffer.empty[Int]
+    val it = new AbstractIterator[Int] {
+      var cur = 1
+      val max = 3
+      override def hasNext = {
+        results += -cur
+        cur < max
+      }
+      override def next() = {
+        val res = cur
+        results += -res
+        cur += 1
+        res
+      }
+    }
+    val xy = it.scanLeft(10)((sum, x) => {
+      results += -(sum + x)
+      sum + x
+    })
+    val scan = collection.mutable.ListBuffer.empty[Int]
+    for (i <- xy) {
+      scan += i
+      results += i
+    }
+    assertSameElements(List(10,11,13), scan)
+    assertSameElements(List(10,-1,-1,-11,11,-2,-2,-13,13,-3), results)
+  }
 }


### PR DESCRIPTION
Deliver the initial value before querying the iterator.

Fixes scala/bug#10709