### PR TITLE
Test that ScriptEngine loads

### DIFF
--- a/test/files/run/t10488.scala
+++ b/test/files/run/t10488.scala
@@ -1,0 +1,13 @@
+
+
+import javax.script._
+
+object Test {
+  def run() = {
+    val sem = new ScriptEngineManager()
+    val eng = sem.getEngineByName("scala")
+    assert(eng != null)
+    assert(eng.eval("42", eng.getContext).asInstanceOf[Int] == 42)
+  }
+  def main(args: Array[String]): Unit = run()
+}


### PR DESCRIPTION
Previously, changes around class path handling and a previous
bug with class loading may have conspired to break initialzing
the ScriptEngine.

This is just a test against fix on a related ticket.

Fixes scala/bug#10488