### PR TITLE
Stabilizing definitions fixes

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
@@ -183,5 +183,22 @@ trait StdAttachments {
    */
   case class OriginalTreeAttachment(original: Tree)
 
-  case class StabilizingDefinition(vdef: ValDef)
+  case class StabilizingDefinitions(vdefs: List[ValDef])
+
+  def addStabilizingDefinition(tree: Tree, vdef: ValDef): Tree =
+    tree.updateAttachment(StabilizingDefinitions(
+      tree.attachments.get[StabilizingDefinitions] match {
+        case Some(StabilizingDefinitions(vdefs)) => vdef :: vdefs
+        case _ => List(vdef)
+      }
+    ))
+
+  def stabilizingDefinitions(tree: Tree): List[ValDef] =
+    tree.attachments.get[StabilizingDefinitions] match {
+      case Some(StabilizingDefinitions(vdefs)) => vdefs
+      case _ => Nil
+    }
+
+  def removeStabilizingDefinitions(tree: Tree): Tree =
+    tree.removeAttachment[StabilizingDefinitions]
 }

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3737,7 +3737,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     @annotation.tailrec
     def loop(mt: Type): Boolean = {
       mt match {
-        case MethodType(params, restpe) => params.exists(_.info.exists(_ == tt)) || loop(restpe)
+        case MethodType(params, restpe) => params.exists(_.info.dealias.exists(_ == tt)) || loop(restpe)
         case PolyType(tparams, restpe) => loop(restpe)
         case _ => false
       }

--- a/test/files/pos/t10714.scala
+++ b/test/files/pos/t10714.scala
@@ -1,0 +1,15 @@
+object Test {
+  class Foo {
+    type Out
+  }
+  object Foo {
+    implicit def foo: Foo { type Out = Bar } = ???
+  }
+
+  class Bar {
+    type Baz = Foo
+    def foo(implicit foo: Baz): foo.Out = ???
+  }
+
+  (new Bar).foo.foo
+}

--- a/test/files/pos/t10714b.scala
+++ b/test/files/pos/t10714b.scala
@@ -1,0 +1,14 @@
+object Test {
+  class Bar {
+    class Foo {
+      type Out
+    }
+    object Foo {
+      implicit def foo: Foo { type Out = Bar } = ???
+    }
+
+    def foo(implicit foo: Foo): foo.Out = ???
+  }
+
+  (new Bar).foo.foo
+}

--- a/test/files/pos/t10714c.scala
+++ b/test/files/pos/t10714c.scala
@@ -1,0 +1,16 @@
+object Test {
+  class Foo
+  trait Bar {
+    val foo: Foo
+    def baz(implicit quux: Quux[foo.type]): Unit = ???
+  }
+  implicit def mkBar(foo0: Foo): Bar { val foo: foo0.type } = ???
+
+  trait Quux[T]
+  object Quux {
+    implicit def mkQuux[T]: Quux[T] = ???
+  }
+
+  (new Foo).baz
+}
+

--- a/test/files/pos/t10714d.scala
+++ b/test/files/pos/t10714d.scala
@@ -1,0 +1,19 @@
+object Test {
+  class Foo
+  trait Bar {
+    trait Baz
+    object Baz {
+      implicit val qb: Quux[Baz] = ???
+    }
+    def baz(implicit quux: Quux[Baz]): Unit = ???
+  }
+  implicit def mkBar(foo0: Foo): Bar = ???
+
+  trait Quux[T]
+  object Quux {
+    implicit def mkQuux[T]: Quux[T] = ???
+  }
+
+  (new Foo).baz
+}
+

--- a/test/files/pos/t10736.scala
+++ b/test/files/pos/t10736.scala
@@ -1,0 +1,26 @@
+object ImplicitRegression {
+
+  import scala.language.{implicitConversions, higherKinds}
+
+  trait Map[K, +V] extends MapOps[K, V, Map, Map[K, V]]
+
+  trait MapOps[K, +V, +CC[_, _], +C]
+
+  trait BuildFrom[-From, -A, +C]
+
+  object BuildFrom {
+    implicit def buildFromMapOps[CC[X, Y] <: Map[X, Y] with MapOps[X, Y, CC, _], K0, V0, K, V]: BuildFrom[CC[K0, V0], (K, V), CC[K, V]] = ???
+  }
+
+  trait MapDecorator[K, V] {
+    val foo: Map[K, V]
+    def zipByKeyWith[W, X, C1](that: Map[K, W])(f: (V, W) => X)(implicit bf: BuildFrom[foo.type, (K, X), C1]): C1 = ???
+  }
+
+  implicit def MapDecorator[K, V](map: Map[K, V]): MapDecorator[K, V] { val foo: map.type } = ???
+
+  def test[A, B, C0](map1: Map[A, B], map2: Map[A, B], f: (B, B) => C0): Unit = {
+    val map3 = map1.zipByKeyWith(map2)(f)/*(BuildFrom.buildFromMapOps)*/
+    map3: Map[A, C0]
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/10714. Also fixes https://github.com/scala/bug/issues/10736.

https://github.com/scala/scala/pull/5999 introduces a synthetic val for the unstable LHS of an implicit method application where the method type depends on the LHS. Unfortunately this only handles the case where an expression requires a _single_ stabilizing val: if the expression involves chained method applications, each requiring a stabilizing val, then only the last of these is emitted resulting in a failure during bytecode generation,

```scala
object Test {
  class Bar {
    class Foo {
      type Out
    }
    object Foo {
      implicit def foo: Foo { type Out = Bar } = ???
    }

    def foo(implicit foo: Foo): foo.Out = ???
  }

  (new Bar).foo.foo
}
```
results in a `NoSuchElementException`,
```
java.util.NoSuchElementException: value stabilizer$1
        at scala.collection.mutable.AnyRefMap$ExceptionDefault.apply(AnyRefMap.scala:425)
        at scala.collection.mutable.AnyRefMap$ExceptionDefault.apply(AnyRefMap.scala:424)
        at scala.collection.mutable.AnyRefMap.apply(AnyRefMap.scala:180)
        at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder$locals$.load(BCodeSkelBuilder.scala:392)
...
```
Prior to this PR only a single stabilizer is recorded on the expression tree which is overwritten by later ones. This is fixed here by allowing multiple stabilizers to be recorded and emitted.

In addition to that, previously spurious dependencies were picked up due to insufficient dealiasing. The following,
```scala
object Test {
  class Bar {
    class Foo {
      type Out
    }
    object Foo {
      implicit def foo: Foo { type Out = Bar } = ???
    }

    def foo(implicit foo: Foo): foo.Out = ???
  }

  (new Bar).foo.foo
}
```
triggered the preceding error despite not having a true dependency which would require a stabilizer in the first place. The test for a dependent argument now dealiases to eliminate these spurious dependencies.

Finally we avoid retyping stabilizing definitions when they are emitted, fixing scala/bug#10736.