### PR TITLE
Add a custom test listener for usable JUnit XML reports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,11 @@
  *   - to modularize the Scala compiler or library further
  */
 
+import java.io.{PrintWriter, StringWriter}
+
+import sbt.TestResult
+import sbt.testing.TestSelector
+
 import scala.build._
 import VersionUtil._
 
@@ -629,6 +634,7 @@ lazy val partestJavaAgent = Project("partest-javaagent", file(".") / "src" / "pa
 
 lazy val test = project
   .dependsOn(compiler, interactive, replFrontend, scalap, partestExtras, partestJavaAgent, scaladoc)
+  .disablePlugins(plugins.JUnitXmlReportPlugin)
   .configs(IntegrationTest)
   .settings(commonSettings)
   .settings(disableDocs)
@@ -672,7 +678,8 @@ lazy val test = project
         result.copy(overall = TestResult.Error)
       }
       else result
-    }
+    },
+    testListeners in IntegrationTest += new PartestTestListener(target.value)
   )
 
 lazy val manual = configureAsSubproject(project)

--- a/project/PartestTestListener.scala
+++ b/project/PartestTestListener.scala
@@ -1,0 +1,93 @@
+package scala.build
+
+import java.io.{File, PrintWriter, StringWriter}
+import java.util.concurrent.TimeUnit
+
+import sbt.testing.TestSelector
+import sbt.{JUnitXmlTestsListener, TestEvent, TestResult, TestsListener, _}
+
+// The default JUnitXMLListener doesn't play well with partest: we end up clobbering the one-and-only partest.xml
+// file on group of tests run by `testAll`, and the test names in the XML file don't seem to show the path to the
+// test for tests defined in a single file.
+//
+// Let's roll our own to try to enable the Jenkins JUnit test reports.
+class PartestTestListener(target: File) extends TestsListener {
+  val delegate = new JUnitXmlTestsListener(target.getAbsolutePath)
+  import java.util.EnumSet
+
+  import sbt.testing.{Status => TStatus}
+  val errorStatus = EnumSet.of(TStatus.Error)
+  val failStatus = EnumSet.of(TStatus.Failure)
+  val skipStatus = EnumSet.of(TStatus.Skipped, TStatus.Ignored)
+
+  override def doInit(): Unit = ()
+  override def doComplete(finalResult: TestResult.Value): Unit = ()
+  override def endGroup(name: String, t: Throwable): Unit = ()
+  override def endGroup(name: String, result: TestResult.Value): Unit = ()
+  override def testEvent(event: TestEvent): Unit = {
+    // E.g "test.files.pos" or "test.scaladoc.run"
+    def groupOf(e: sbt.testing.Event) = {
+      val group = e.fullyQualifiedName().replace('/', '.') + "." + e.selector().asInstanceOf[TestSelector].testName().takeWhile(_ != '/')
+      // Don't even ask.
+      // You really want to know? Okay.. https://issues.jenkins-ci.org/browse/JENKINS-49832
+      group.replaceAll("""\brun\b""", "run_")
+    }
+
+    // "t1234.scala" or "t1235"
+    def testOf(e: sbt.testing.Event) = e.selector().asInstanceOf[TestSelector].testName().dropWhile(_ != '/').drop(1)
+
+    for ((group, events) <- event.detail.groupBy(groupOf(_))) {
+      val statii = events.map(_.status())
+      val errorCount = statii.count(errorStatus.contains)
+      val failCount = statii.count(failStatus.contains)
+      val skipCount = statii.count(skipStatus.contains)
+      val testCount = statii.size
+      val totalDurationMs = events.iterator.map(_.duration()).sum
+      val xml = <testsuite hostname={delegate.hostname} name={group}
+                           tests={"" + testCount} errors={"" + errorCount} failures={"" + failCount}
+                           skipped={"" + skipCount} time={(1.0 * totalDurationMs / 1000).toString}>
+        {delegate.properties}{for (e <- events) yield {
+          val trace: String = if (e.throwable.isDefined) {
+            val stringWriter = new StringWriter()
+            val writer = new PrintWriter(stringWriter)
+            e.throwable.get.printStackTrace(writer)
+            writer.flush()
+            ConsoleLogger.removeEscapeSequences(stringWriter.toString)
+          } else {
+            ""
+          }
+
+          <testcase classname={group} name={testOf(e)} time={(1.0 * e.duration() / 1000).toString}>
+            {e.status match {
+            case TStatus.Error if e.throwable.isDefined =>
+              <error message={ConsoleLogger.removeEscapeSequences(e.throwable.get.getMessage)} type={e.throwable.get.getClass.getName}>
+                {trace}
+              </error>
+            case TStatus.Error =>
+                <error message={"No Exception or message provided"}/>
+            case TStatus.Failure if e.throwable.isDefined =>
+              <failure message={ConsoleLogger.removeEscapeSequences(e.throwable.get.getMessage)} type={e.throwable.get.getClass.getName}>
+                {trace}
+              </failure>
+            case TStatus.Failure =>
+                <failure message={"No Exception or message provided"}/>
+            case TStatus.Ignored | TStatus.Skipped | sbt.testing.Status.Pending =>
+                <skipped/>
+            case _ =>
+          }}<system-out>
+            <![CDATA[]]>
+          </system-out>
+            <system-err>
+              <![CDATA[]]>
+            </system-err>
+          </testcase>
+        }}
+      </testsuite>
+      val partestTestReports = target / "test-reports" / "partest"
+      val xmlFile = (partestTestReports / (group + ".xml"))
+      xmlFile.getParentFile.mkdirs()
+      scala.xml.XML.save(xmlFile.getAbsolutePath, xml, "UTF-8", true, null)
+    }
+  }
+  override def startGroup(name: String): Unit = ()
+}

--- a/versions.properties
+++ b/versions.properties
@@ -19,6 +19,6 @@ scala.binary.version=2.13.0-M3
 #  - jline: shaded with JarJar and included in scala-compiler
 #  - partest: used for running the tests
 scala-xml.version.number=1.1.0
-partest.version.number=1.1.3
+partest.version.number=1.1.5
 scala-asm.version=6.0.0-scala-1
 jline.version=2.14.5


### PR DESCRIPTION
  - Update to partest that emits more detailed TestEvents
  - Group partest JUnit XML reports in, e.g, test.files.pos.xml
  - workaround Jenkins dislike of the work "run"
Requires a new version of partest to provide some missing metadata.

Sample files generated:

```
> ;partest --srcpath scaladoc --grep t7876; partest --grep default
...
```

```
⚡ (cd target/test/test-reports/partest && find . )
.
./test.files.jvm.xml
./test.files.neg.xml
./test.files.pos.xml
./test.files.presentation.xml
./test.files.run_.xml
./test.files.scalap.xml
./test.files.specialized.xml
./test.scaladoc.run_.xml
```
