### PR TITLE
Cache classloaders for compiler plugins and macros

### DIFF
--- a/src/compiler/scala/tools/nsc/plugins/Plugins.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugins.scala
@@ -31,7 +31,7 @@ trait Plugins { global: Global =>
       def injectDefault(s: String) = if (s.isEmpty) Defaults.scalaPluginPath else s
       asPath(settings.pluginsDir.value) map injectDefault map Path.apply
     }
-    val maybes = Plugin.loadAllFrom(paths, dirs, settings.disable.value)
+    val maybes = Plugin.loadAllFrom(paths, dirs, settings.disable.value, settings.YdisablePluginsClassLoaderCaching.value)
     val (goods, errors) = maybes partition (_.isSuccess)
     // Explicit parameterization of recover to avoid -Xlint warning about inferred Any
     errors foreach (_.recover[Any] {

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -220,6 +220,7 @@ trait ScalaSettings extends AbsScalaSettings
   val YmethodInfer    = BooleanSetting    ("-Yinfer-argument-types", "Infer types for arguments of overridden methods.")
   val YdisableFlatCpCaching  = BooleanSetting    ("-YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
   val YdisablePluginsClassLoaderCaching  = BooleanSetting    ("-YdisablePluginsClassLoaderCaching", "Do not cache classloaders for compiler plugins that are dynamically loaded.")
+  val YdisableMacrosClassLoaderCaching   = BooleanSetting    ("-YdisableMacrosClassLoaderCaching", "Do not cache classloaders for macros that are dynamically loaded.")
   val YpartialUnification = BooleanSetting ("-Ypartial-unification", "Enable partial unification in type constructor inference")
   val Yvirtpatmat     = BooleanSetting    ("-Yvirtpatmat", "Enable pattern matcher virtualization")
 

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -219,6 +219,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Yreploutdir     = StringSetting     ("-Yrepl-outdir", "path", "Write repl-generated classfiles to given output directory (use \"\" to generate a temporary dir)" , "")
   val YmethodInfer    = BooleanSetting    ("-Yinfer-argument-types", "Infer types for arguments of overridden methods.")
   val YdisableFlatCpCaching  = BooleanSetting    ("-YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
+  val YdisablePluginsClassLoaderCaching  = BooleanSetting    ("-YdisablePluginsClassLoaderCaching", "Do not cache classloaders for compiler plugins that are dynamically loaded.")
   val YpartialUnification = BooleanSetting ("-Ypartial-unification", "Enable partial unification in type constructor inference")
   val Yvirtpatmat     = BooleanSetting    ("-Yvirtpatmat", "Enable pattern matcher virtualization")
 


### PR DESCRIPTION
For the rationale and a detailed performance analysis, please check [this
issue](https://github.com/scala/scala-dev/issues/458).

This pull request continues the work started by @retronym on caching the
classpath, and extends it to caching compiler plugins classloaders. In short,
this change seems to yield compile-time performance improvements ranging from
16% to 35% for projects using compiler plugins.

The approach taken in this pull request is to cache only compiler plugins'
classpaths that contain zip or jar files (to avoid issues with validation). The
approach taken here is a little bit naive and I hope it improves in a follow-up
PR.

There is one missing item that I'll add to this pull request during the next
days: making the cache invalidation algorithm take into account the size of the
classpath entries to make the cache heuristics more robust.

However, as discussed in https://github.com/scala/scala-dev/issues/458, these
heuristics do not work in scenarios where the timestamp is zero'd and the size
does not change (this happens with tools that focus on reproducibility like
Pants and Bazel).

There is only one way we can fix this issue without relying on heuristics:
hashing the contents of the classpath. However, this is an expensive
computation for big classpaths and we want to probably stay away from it.

To solve this issue in a friendlier manner, I propose to add a compiler flag so
that the build tool can share the checksums of every jar they have with the
compiler and let the compiler invalidate the caches based on those. If this
sounds like a good solution to you, I will open another pull request
implementing it.

I'd like this change to target 2.12.5 if possible.