### PR TITLE
Deprecate string-building using `+` with a non-`String` type on the left (aka `any2stringadd`)

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -856,7 +856,7 @@ trait Contexts { self: Analyzer =>
       !({
         // [eed3si9n] ideally I'd like to do this: val fd = settings.isScala214 && sym.isDeprecated
         // but implicit caching currently does not report sym.isDeprecated correctly.
-        val fd = settings.isScala214 && (name ne null) && definitions.isPredefMemberNamed(sym, TermName("any2stringadd"))
+        val fd = settings.isScala214 && (sym == currentRun.runDefinitions.Predef_any2stringaddMethod)
         if (settings.XlogImplicits && fd) echo(sym.pos, sym + " is not a valid implicit value because:\n" + "-Xsource:2.14 removes scala.Predef.any2stringadd")
         fd
       }) &&

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -15,6 +15,7 @@ import scala.collection.{ mutable, immutable, ArrayOps }
 import scala.collection.immutable.{ ArraySeq, WrappedString }
 import scala.annotation.{ elidable, implicitNotFound }
 import scala.annotation.elidable.ASSERTION
+import scala.annotation.meta.companionMethod
 
 /** The `Predef` object provides definitions that are accessible in all Scala
  *  compilation units without explicit qualification.
@@ -366,6 +367,7 @@ object Predef extends LowPriorityImplicits {
 
   // scala/bug#8229 retaining the pre 2.11 name for source compatibility in shadowing this implicit
   /** @group implicit-classes-any */
+  @(deprecated @companionMethod)("Implicit injection of + is deprecated. Convert to String to call +", "2.13.0")
   implicit final class any2stringadd[A](private val self: A) extends AnyVal {
     def +(other: String): String = String.valueOf(self) + other
   }

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1504,6 +1504,7 @@ trait Definitions extends api.StandardDefinitions {
       lazy val Predef_classOf      = getMemberMethod(PredefModule, nme.classOf)
       lazy val Predef_implicitly   = getMemberMethod(PredefModule, nme.implicitly)
       lazy val Predef_???          = DefinitionsClass.this.Predef_???
+      lazy val Predef_any2stringaddMethod = getMemberMethod(PredefModule, nme.any2stringadd).suchThat(_.isMethod)
 
       lazy val arrayApplyMethod       = getMemberMethod(ScalaRunTimeModule, nme.array_apply)
       lazy val arrayUpdateMethod      = getMemberMethod(ScalaRunTimeModule, nme.array_update)

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -491,7 +491,7 @@ trait StdNames {
       if (isConstructorName(name))
         DEFAULT_GETTER_INIT_STRING + pos
       else
-        name + DEFAULT_GETTER_STRING + pos
+        name.toString + DEFAULT_GETTER_STRING + pos
     )
     // Nominally, name from name$default$N, CONSTRUCTOR for <init>
     def defaultGetterToMethod(name: Name): TermName = (
@@ -654,6 +654,7 @@ trait StdNames {
     val accessor: NameType             = "accessor"
     val add_ : NameType                = "add"
     val annotation: NameType           = "annotation"
+    val any2stringadd: NameType        = "any2stringadd"
     val anyHash: NameType              = "anyHash"
     val anyValClass: NameType          = "anyValClass"
     val apply: NameType                = "apply"

--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -202,13 +202,13 @@ class FutureTests extends MinimalScalaTest {
         a <- future0.mapTo[Int]  // returns 5
         b <- async(a)            // returns "10"
         c <- async(7)            // returns "14"
-      } yield b + "-" + c
+      } yield s"$b-$c"
 
       val future2 = for {
         a <- future0.mapTo[Int]
         b <- (Future { (a * 2).toString }).mapTo[Int]
         c <- Future { (7 * 2).toString }
-      } yield b + "-" + c
+      } yield s"$b-$c"
 
       Await.result(future1, defaultTimeout) mustBe ("10-14")
       assert(checkType(future1, manifest[String]))
@@ -227,13 +227,13 @@ class FutureTests extends MinimalScalaTest {
         Res(a: Int) <- async(Req("Hello"))
         Res(b: String) <- async(Req(a))
         Res(c: String) <- async(Req(7))
-      } yield b + "-" + c
+      } yield s"$b-$c"
 
       val future2 = for {
         Res(a: Int) <- async(Req("Hello"))
         Res(b: Int) <- async(Req(a))
         Res(c: Int) <- async(Req(7))
-      } yield b + "-" + c
+      } yield s"$b-$c"
 
       Await.result(future1, defaultTimeout) mustBe ("10-14")
       intercept[NoSuchElementException] { Await.result(future2, defaultTimeout) }

--- a/test/files/jvm/future-spec/main.scala
+++ b/test/files/jvm/future-spec/main.scala
@@ -65,7 +65,7 @@ trait MinimalScalaTest extends Output with Features {
 
   implicit def objectops(obj: Any) = new {
 
-    def mustBe(other: Any) = assert(obj == other, obj + " is not " + other)
+    def mustBe(other: Any) = assert(obj == other, s"$obj is not $other")
     def mustEqual(other: Any) = mustBe(other)
 
   }

--- a/test/files/neg/implicit-any2stringadd-warning.check
+++ b/test/files/neg/implicit-any2stringadd-warning.check
@@ -1,0 +1,6 @@
+implicit-any2stringadd-warning.scala:2: warning: method any2stringadd in object Predef is deprecated (since 2.13.0): Implicit injection of + is deprecated. Convert to String to call +
+  true + "what"
+  ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/implicit-any2stringadd-warning.flags
+++ b/test/files/neg/implicit-any2stringadd-warning.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -deprecation

--- a/test/files/neg/implicit-any2stringadd-warning.scala
+++ b/test/files/neg/implicit-any2stringadd-warning.scala
@@ -1,0 +1,3 @@
+object Test {
+  true + "what"
+}

--- a/test/files/neg/implicit-any2stringadd.check
+++ b/test/files/neg/implicit-any2stringadd.check
@@ -1,0 +1,6 @@
+method any2stringadd is not a valid implicit value because:
+-Xsource:2.14 removes scala.Predef.any2stringadd
+implicit-any2stringadd.scala:2: error: value + is not a member of Boolean
+  true + "what"
+       ^
+one error found

--- a/test/files/neg/implicit-any2stringadd.flags
+++ b/test/files/neg/implicit-any2stringadd.flags
@@ -1,0 +1,1 @@
+-Xsource:2.14 -Xlog-implicits

--- a/test/files/neg/implicit-any2stringadd.scala
+++ b/test/files/neg/implicit-any2stringadd.scala
@@ -1,0 +1,3 @@
+object Test {
+  true + "what"
+}

--- a/test/files/run/collection-stacks.scala
+++ b/test/files/run/collection-stacks.scala
@@ -8,7 +8,7 @@ object Test extends App {
   }
 
   def check[T](expected: T, got: T): Unit = {
-    println(got + ": " + (expected == got))
+    println(s"$got: ${expected == got}")
   }
 
   // check #957

--- a/test/files/run/colltest1.scala
+++ b/test/files/run/colltest1.scala
@@ -10,8 +10,8 @@ object Test extends App {
     println("new test starting with "+empty)
     assert(empty.isEmpty)
     val ten = empty ++ List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-    println(ten.size+": "+ten)
-    println(ten.tail.size+": "+ten.tail)
+    println(s"${ten.size}: $ten")
+    println(s"${ten.tail.size}: ${ten.tail}")
     assert(ten == empty ++ (1 to 10))
     assert(ten.size == 10)
     assert(ten forall (_ <= 10))
@@ -43,7 +43,7 @@ object Test extends App {
     assert(ten.last == 10)
     assert(List(ten.head) ++ ten.tail == ten)
     assert(ten.init ++ List(ten.last) == ten, ten.init)
-    assert(vs1 == vs2, vs1+"!="+vs2)
+    assert(vs1 == vs2, s"$vs1!=$vs2")
     assert(vs1 == ten)
     assert((ten take 5) == firstFive)
     assert((ten drop 5) == secondFive)
@@ -185,7 +185,7 @@ object Test extends App {
     assert(m.keySet.size == 26)
     assert(m.size == 26)
     assert(m.keySet == Set() ++ m.keysIterator.to(LazyList))
-    assert(m.keySet == m.keysIterator.toList.toSet, m.keySet.toList+"!="+m.keysIterator.toList.toSet)
+    assert(m.keySet == m.keysIterator.toList.toSet, s"${m.keySet.toList}!=${m.keysIterator.toList.toSet}")
     val m1 = empty ++ m
     val ks = m.keySet
     val mm = m.filterKeys(k => !ks(k))

--- a/test/files/run/compiler-asSeenFrom.scala
+++ b/test/files/run/compiler-asSeenFrom.scala
@@ -164,7 +164,7 @@ package ll {
     for (x <- classes ++ terms) {
       afterEachPhase(signaturesIn(x.tpe)) collect {
         case (ph, sigs) if sigs.nonEmpty =>
-          println(sigs.mkString(x + " { // after " + ph + "\n  ", "\n  ", "\n}\n"))
+          println(sigs.mkString(x.toString + " { // after " + ph + "\n  ", "\n  ", "\n}\n"))
       }
     }
   }

--- a/test/files/run/equality.scala
+++ b/test/files/run/equality.scala
@@ -15,19 +15,19 @@ object Test
   def main(args: Array[String]): Unit = {
     var xs = makeFromInt(5)
     for (x <- xs ; y <- xs) {
-      assert(x == y, x + " == " + y)
+      assert(x == y, s"$x == $y")
       assert(hash(x) == hash(y), "hash(%s) == hash(%s)".format(x, y))
     }
 
     xs = makeFromInt(-5)
     for (x <- xs ; y <- xs) {
-      assert(x == y, x + " == " + y)
+      assert(x == y, s"$x == $y")
       assert(hash(x) == hash(y), "hash(%s) == hash(%s)".format(x, y))
     }
 
     xs = makeFromDouble(500.0)
     for (x <- xs ; y <- xs) {
-      assert(x == y, x + " == " + y)
+      assert(x == y, s"$x == $y")
       assert(hash(x) == hash(y), "hash(%s) == hash(%s)".format(x, y))
     }
 

--- a/test/files/run/fail-non-value-types.scala
+++ b/test/files/run/fail-non-value-types.scala
@@ -10,7 +10,7 @@ class CompletelyIndependentList[+A] {
 object Test {
   var failed = false
   def expectFailure[T](body: => T): Boolean = {
-    try { val res = body ; failed = true ; println(res + " failed to fail.") ; false }
+    try { val res = body ; failed = true ; println(s"$res failed to fail.") ; false }
     catch { case _: AssertionError => true }
   }
 

--- a/test/files/run/macroPlugins-enterStats.flags
+++ b/test/files/run/macroPlugins-enterStats.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/files/run/macroPlugins-enterStats.scala
+++ b/test/files/run/macroPlugins-enterStats.scala
@@ -22,7 +22,7 @@ object Test extends DirectTest {
     def logEnterStat(pluginName: String, stat: Tree): Unit = log(s"$pluginName:enterStat($stat)")
     def deriveStat(pluginName: String, typer: Typer, stat: Tree): List[Tree] = stat match {
       case DefDef(mods, name, Nil, Nil, TypeTree(), body) =>
-        val derived = DefDef(NoMods, TermName(name + pluginName), Nil, Nil, TypeTree(), Ident(TermName("$qmark$qmark$qmark")))
+        val derived = DefDef(NoMods, TermName(name.toString + pluginName), Nil, Nil, TypeTree(), Ident(TermName("$qmark$qmark$qmark")))
         newNamer(typer.context).enterSym(derived)
         List(derived)
       case _ =>

--- a/test/files/run/mixin-signatures.scala
+++ b/test/files/run/mixin-signatures.scala
@@ -84,7 +84,7 @@ object Test {
   }
 
   def show(clazz: Class[_]): Unit = {
-    print(clazz + " {")
+    print(clazz.toString + " {")
     clazz.getMethods.sortBy(x => (x.getName, x.isBridge, x.toString)) filter (_.getName.length == 1) foreach { m =>
       print("\n  " + m + flagsString(m))
       if ("" + m != "" + m.toGenericString) {

--- a/test/files/run/no-pickle-skolems/Test_2.scala
+++ b/test/files/run/no-pickle-skolems/Test_2.scala
@@ -28,7 +28,7 @@ object Test {
     }
     loop(m)
 
-    buf.reverse.distinct map (s => s.name + "#" + id(s))
+    buf.reverse.distinct map (s => s"${s.name}#${id(s)}")
   }
 
   def main(args: Array[String]): Unit = {

--- a/test/files/run/patmat-exprs.flags
+++ b/test/files/run/patmat-exprs.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/files/run/patmat-exprs.scala
+++ b/test/files/run/patmat-exprs.scala
@@ -462,7 +462,7 @@ trait Pattern {
     def derivative(v: Var[T]) = Mul(Mul(Const(num.two), expr), expr.derivative(v))
     def eval(f: Any => Any) = num.sqr(expr.eval(f))
     def mapArgs(f: EndoFunction[Expr[_]]) = Sqr(f(expr))
-    override def toString = expr + " ^ 2"
+    override def toString = expr.toString + " ^ 2"
     override lazy val hashCode = ScalaRunTime._hashCode(this);
   }
 

--- a/test/files/run/range.scala
+++ b/test/files/run/range.scala
@@ -4,7 +4,7 @@ object Test {
   def rangeForeach(range : Range) = {
     val buffer = new scala.collection.mutable.ListBuffer[Int];
     range.foreach(buffer += _);
-    assert(buffer.toList == range.iterator.toList, buffer.toList+"/"+range.iterator.toList)
+    assert(buffer.toList == range.iterator.toList, buffer.toList.toString + "/" + range.iterator.toList)
   }
 
   def boundaryTests() = {

--- a/test/files/run/reflection-magicsymbols-invoke.scala
+++ b/test/files/run/reflection-magicsymbols-invoke.scala
@@ -9,7 +9,7 @@ package scala {
 }
 
 object Test extends App {
-  def key(sym: Symbol) = sym + ": " + sym.info
+  def key(sym: Symbol) = s"$sym: ${sym.info}"
   def test(tpe: Type, receiver: Any, method: String, args: Any*): Unit = {
     def wrap[T](op: => T) =
       try {
@@ -20,7 +20,7 @@ object Test extends App {
       } catch {
         case ex: Throwable =>
           val realex = scala.ExceptionUtils.unwrapThrowable(ex)
-          println(realex.getClass + ": " + realex.getMessage)
+          println(s"${realex.getClass}: ${realex.getMessage}")
       }
     print(s"testing ${tpe.typeSymbol.name}.$method: ")
     wrap({

--- a/test/files/run/reflection-valueclasses-magic.flags
+++ b/test/files/run/reflection-valueclasses-magic.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/files/run/reflection-valueclasses-magic.scala
+++ b/test/files/run/reflection-valueclasses-magic.scala
@@ -15,7 +15,7 @@ object Test extends App {
       // initialize parameter symbols
       case meth: MethodSymbol => meth.paramLists.flatten.map(_.info)
     }
-    sym + ": " + sym.info
+    s"$sym: ${sym.info}"
   }
 
   def convert(value: Any, tpe: Type) = {
@@ -42,13 +42,13 @@ object Test extends App {
       } catch {
         case ex: Throwable =>
           val realex = scala.ExceptionUtils.unwrapThrowable(ex)
-          println(realex.getClass + ": " + realex.getMessage)
+          println(s"${realex.getClass}: ${realex.getMessage}")
       }
     val meth = tpe.decl(TermName(method).encodedName.toTermName)
     val testees = if (meth.isMethod) List(meth.asMethod) else meth.asTerm.alternatives.map(_.asMethod)
     testees foreach (testee => {
       val convertedArgs = args.zipWithIndex.map { case (arg, i) => convert(arg, testee.paramLists.flatten.apply(i).info) }
-      print(s"testing ${tpe.typeSymbol.name}.$method(${testee.paramLists.flatten.map(_.info).mkString(','.toString)}) with receiver = $receiver and args = ${convertedArgs.map(arg => arg + ' '.toString + arg.getClass).toList}: ")
+      print(s"testing ${tpe.typeSymbol.name}.$method(${testee.paramLists.flatten.map(_.info).mkString(','.toString)}) with receiver = $receiver and args = ${convertedArgs.map(arg => s"$arg ${arg.getClass}").toList}: ")
       wrap(cm.reflect(receiver).reflectMethod(testee)(convertedArgs: _*))
     })
   }

--- a/test/files/run/repl-no-imports-no-predef.check
+++ b/test/files/run/repl-no-imports-no-predef.check
@@ -48,9 +48,6 @@ res11: String = abctrue
 
 scala> 
 
-scala> { import scala.Predef.any2stringadd; true + "abc" }
-res12: String = trueabc
-
 scala> true + "abc"
             ^
        error: value + is not a member of Boolean
@@ -74,12 +71,12 @@ scala>
 scala> 2 ; 3
        ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-res14: Int = 3
+res13: Int = 3
 
 scala> { 2 ; 3 }
          ^
        warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
-res15: Int = 3
+res14: Int = 3
 
 scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
 bippy = {
@@ -97,56 +94,56 @@ bippy = {
 defined object Cow
 defined class Moo
 bippy: Int
-res16: Int = 105
+res15: Int = 105
 
 scala> 
 
 scala> object Bovine { var x: scala.List[_] = null } ; case class Ruminant(x: scala.Int) ; bippy * bippy * bippy
 defined object Bovine
 defined class Ruminant
-res17: Int = 216
+res16: Int = 216
 
 scala> Bovine.x = scala.List(Ruminant(5), Cow, new Moo)
 mutated Bovine.x
 
 scala> Bovine.x
-res18: List[Any] = List(Ruminant(5), Cow, Moooooo)
+res17: List[Any] = List(Ruminant(5), Cow, Moooooo)
 
 scala> 
 
 scala> (2)
-res19: Int = 2
+res18: Int = 2
 
 scala> (2 + 2)
-res20: Int = 4
+res19: Int = 4
 
 scala> ((2 + 2))
-res21: Int = 4
+res20: Int = 4
 
 scala>   ((2 + 2))
-res22: Int = 4
+res21: Int = 4
 
 scala>   (  (2 + 2))
-res23: Int = 4
+res22: Int = 4
 
 scala>   (  (2 + 2 )  )
-res24: Int = 4
+res23: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
        ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
                    ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-res25: Int = 5
+res24: Int = 5
 
 scala> (((2 + 2)), ((2 + 2)))
-res26: (Int, Int) = (4,4)
+res25: (Int, Int) = (4,4)
 
 scala> (((2 + 2)), ((2 + 2)), 2)
-res27: (Int, Int, Int) = (4,4,2)
+res26: (Int, Int, Int) = (4,4,2)
 
 scala> (((((2 + 2)), ((2 + 2)), 2).productIterator ++ scala.Iterator(3)).mkString)
-res28: String = 4423
+res27: String = 4423
 
 scala> 
 
@@ -155,27 +152,27 @@ scala> 55 ; ((2 + 2)) ; (1, 2, 3)
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
                 ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-res29: (Int, Int, Int) = (1,2,3)
+res28: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: scala.Int) => x + 1 ; () => ((5))
        ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
                            ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-res30: () => Int = <function0>
+res29: () => Int = <function0>
 
 scala> 
 
 scala> () => 5
-res31: () => Int = <function0>
+res30: () => Int = <function0>
 
 scala> 55 ; () => 5
        ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-res32: () => Int = <function0>
+res31: () => Int = <function0>
 
 scala> () => { class X ; new X }
-res33: () => AnyRef = <function0>
+res32: () => AnyRef = <function0>
 
 scala> 
 
@@ -183,12 +180,12 @@ scala> def foo(x: scala.Int)(y: scala.Int)(z: scala.Int) = x+y+z
 foo: (x: Int)(y: Int)(z: Int)Int
 
 scala> foo(5)(10)(15)+foo(5)(10)(15)
-res34: Int = 60
+res33: Int = 60
 
 scala> 
 
 scala> scala.List(1) ++ scala.List('a')
-res35: List[AnyVal] = List(1, a)
+res34: List[AnyVal] = List(1, a)
 
 scala> 
 
@@ -203,7 +200,7 @@ EOF
 defined class C
 
 scala> new C().c
-res36: Int = 42
+res35: Int = 42
 
 scala> :paste <| EOF
 // Entering paste mode (EOF to finish)
@@ -216,7 +213,7 @@ EOF
 defined class D
 
 scala> new D().d
-res37: Int = 42
+res36: Int = 42
 
 scala> 
 
@@ -257,7 +254,7 @@ scala> case class BippyBungus()
 defined class BippyBungus
 
 scala> x1 + x2 + x3
-res38: Int = 6
+res37: Int = 6
 
 scala> :reset
 Resetting interpreter state.
@@ -273,7 +270,6 @@ Forgetting this session history:
 val answer = 42
 { import scala.StringContext; s"answer: $answer" }
 "abc" + true
-{ import scala.Predef.any2stringadd; true + "abc" }
 var x = 10
 var y = 11
 x = 12

--- a/test/files/run/repl-no-imports-no-predef.scala
+++ b/test/files/run/repl-no-imports-no-predef.scala
@@ -27,7 +27,6 @@ s"answer: $answer"
 
 "abc" + true
 
-{ import scala.Predef.any2stringadd; true + "abc" }
 true + "abc"
 
 var x = 10

--- a/test/files/run/t10551.scala
+++ b/test/files/run/t10551.scala
@@ -11,7 +11,7 @@ object Test extends App {
   
   def check[A](cls: Class[A])(implicit tag: reflect.ClassTag[A]): Unit = {
     val suffix = if (cls != tag.runtimeClass) " != " + tag.runtimeClass else ""
-    println(cls + suffix)
+    println(cls.toString + suffix)
   }
 
   check(classOf[Id[Int]])

--- a/test/files/run/t1195-new.scala
+++ b/test/files/run/t1195-new.scala
@@ -11,7 +11,7 @@ object Test {
   val g1 = g()
   val h1 = h()
 
-  def m[T: WeakTypeTag](x: T) = println(weakTypeOf[T] + ", underlying = " + weakTypeOf[T].typeSymbol.info)
+  def m[T: WeakTypeTag](x: T) = println(weakTypeOf[T].toString + ", underlying = " + weakTypeOf[T].typeSymbol.info)
 
   def main(args: Array[String]): Unit = {
     m(f)

--- a/test/files/run/t1931.check
+++ b/test/files/run/t1931.check
@@ -3,6 +3,7 @@ scala> val x: Any = 42
 x: Any = 42
 
 scala> x + " works"
+warning: there was one deprecation warning (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: String = 42 works
 
 scala> import Predef.{ any2stringadd => _, _ }
@@ -16,6 +17,7 @@ scala> import Predef._
 import Predef._
 
 scala> x + " works"
+warning: there was one deprecation warning (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res2: String = 42 works
 
 scala> object Predef { def f = 42 }

--- a/test/files/run/t4027.scala
+++ b/test/files/run/t4027.scala
@@ -7,17 +7,17 @@ import collection._
 object Test extends App {
   val sortedmap = SortedMap(1 -> false, 2 -> true, 3 -> false, 4 -> true)
   println((sortedmap.filterKeys(_ % 2 == 0): MapView[Int, Boolean]).toMap)
-  println((sortedmap.mapValues(_ + "!"): MapView[Int, String]).toMap)
+  println((sortedmap.mapValues(_.toString + "!"): MapView[Int, String]).toMap)
   println((sortedmap.filterKeys(_ % 2 == 0).map(t => (t._1, t._2.toString.length)): View[(Int, Int)]).toMap)
-  println((sortedmap.mapValues(_ + "!").map(t => (t._1, t._2.toString.length)): View[(Int, Int)]).toMap)
+  println((sortedmap.mapValues(_.toString + "!").map(t => (t._1, t._2.toString.length)): View[(Int, Int)]).toMap)
   println((sortedmap.filterKeys(_ % 2 == 0).filter(t => t._1 < 2): View[(Int, Boolean)]).toMap)
-  println((sortedmap.mapValues(_ + "!").filter(t => t._1 < 2): View[(Int, String)]).toMap)
+  println((sortedmap.mapValues(_.toString + "!").filter(t => t._1 < 2): View[(Int, String)]).toMap)
 
   val immsortedmap = immutable.SortedMap(1 -> false, 2 -> true, 3 -> false, 4 -> true)
   println((immsortedmap.filterKeys(_ % 2 == 0): MapView[Int, Boolean]).toMap)
-  println((immsortedmap.mapValues(_ + "!"): MapView[Int, String]).toMap)
+  println((immsortedmap.mapValues(_.toString + "!"): MapView[Int, String]).toMap)
   println((immsortedmap.filterKeys(_ % 2 == 0).map(t => (t._1, t._2.toString.length)): View[(Int, Int)]).toMap)
-  println((immsortedmap.mapValues(_ + "!").map(t => (t._1, t._2.toString.length)): View[(Int, Int)]).toMap)
+  println((immsortedmap.mapValues(_.toString + "!").map(t => (t._1, t._2.toString.length)): View[(Int, Int)]).toMap)
   println((immsortedmap.filterKeys(_ % 2 == 0).filter(t => t._1 < 2): View[(Int, Boolean)]).toMap)
-  println((immsortedmap.mapValues(_ + "!").filter(t => t._1 < 2): View[(Int, String)]).toMap)
+  println((immsortedmap.mapValues(_.toString + "!").filter(t => t._1 < 2): View[(Int, String)]).toMap)
 }

--- a/test/files/run/t4122.scala
+++ b/test/files/run/t4122.scala
@@ -7,8 +7,8 @@ object Test {
 
   def main(args: Array[String]): Unit = {
     for (s1 <- all ; s2 <- all) {
-      assert(s1 == s2, s1 + " != " + s2)
-      assert(s1.## == s2.##, s1 + ".## != " + s2 + ".##")
+      assert(s1 == s2, s"$s1 != $s2")
+      assert(s1.## == s2.##, s"$s1.## != $s2.##")
     }
   }
 }

--- a/test/files/run/t6731.flags
+++ b/test/files/run/t6731.flags
@@ -1,1 +1,1 @@
--Yrangepos:false
+-Yrangepos:false -deprecation

--- a/test/files/run/t6731.scala
+++ b/test/files/run/t6731.scala
@@ -3,14 +3,14 @@ import scala.reflect.{ ClassTag, classTag }
 
 object Util {
   def show[T](x: T): T = { println(x) ; x }
-  def mkArgs(xs: Any*) = xs map { case ((k, v)) => k + "=" + v ; case x => "" + x } mkString ("(", ", ", ")")
+  def mkArgs(xs: Any*) = xs map { case ((k, v)) => s"$k=$v" ; case x => "" + x } mkString ("(", ", ", ")")
 }
 import Util._
 
 abstract class MonoDynamic extends Dynamic {
-  def selectDynamic(name: String): String                           = show(this + "." + name)
-  def applyDynamic(name: String)(args: Any*): String                = show(this + "." + name + mkArgs(args: _*))
-  def applyDynamicNamed(name: String)(args: (String, Any)*): String = show(this + "." + name + mkArgs(args: _*))
+  def selectDynamic(name: String): String                           = show(this.toString + "." + name)
+  def applyDynamic(name: String)(args: Any*): String                = show(this.toString + "." + name + mkArgs(args: _*))
+  def applyDynamicNamed(name: String)(args: (String, Any)*): String = show(this.toString + "." + name + mkArgs(args: _*))
 
   override def toString = (this.getClass.getName split '.').last
 }
@@ -74,11 +74,11 @@ object Nest1 extends Dynamic {
 
 object Named extends Dynamic {
   def applyDynamic(name: String)(args: Any*): Named.type = {
-    show(this + "." + name + mkArgs(args: _*))
+    show(this.toString + "." + name + mkArgs(args: _*))
     this
   }
   def applyDynamicNamed(name: String)(args: (String, Any)*): Named.type = {
-    show(this + "." + name + mkArgs(args: _*))
+    show(this.toString + "." + name + mkArgs(args: _*))
     this
   }
 
@@ -88,11 +88,11 @@ object Named extends Dynamic {
 
 object Named2 extends Dynamic {
   def applyDynamic(name: String)(a: Any)(b: Any = "b", c: Any = "c"): Named2.type = {
-    show(this + "." + name + mkArgs(a) + mkArgs(b, c))
+    show(this.toString + "." + name + mkArgs(a) + mkArgs(b, c))
     this
   }
   def applyDynamicNamed(name: String)(a: (String, Any))(b: (String, Any), c: (String, Any)): Named2.type = {
-    show(this + "." + name + mkArgs(a) + mkArgs(b, c))
+    show(this.toString + "." + name + mkArgs(a) + mkArgs(b, c))
     this
   }
 

--- a/test/files/run/virtpatmat_typetag.scala
+++ b/test/files/run/virtpatmat_typetag.scala
@@ -7,15 +7,15 @@ trait Extractors {
     def unapply(x: T) = Some(x)
   }
   def apply(a: Any) = a match {
-    case ExtractT(x)  => println(x +" is a "+ implicitly[ClassTag[T]])
-    case _ => println(a+ " is not a "+ implicitly[ClassTag[T]] +"; it's a "+ a.getClass)
+    case ExtractT(x)  => println(x.toString + " is a " + implicitly[ClassTag[T]])
+    case _ => println(a.toString + " is not a " + implicitly[ClassTag[T]] + "; it's a "+ a.getClass)
   }
 }
 
 object Test extends App {
   def typeMatch[T: ClassTag](a: Any) = a match {
-    case x : T => println(x +" is a "+ implicitly[ClassTag[T]])
-    case _ => println(a+ " is not a "+ implicitly[ClassTag[T]] +"; it's a "+ a.getClass)
+    case x : T => println(x.toString + " is a " + implicitly[ClassTag[T]])
+    case _ => println(a.toString + " is not a " + implicitly[ClassTag[T]] + "; it's a " + a.getClass)
   }
 
   // the same match as typeMatch, but using an extractor

--- a/test/junit/scala/tools/nsc/backend/jvm/StringConcatTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/StringConcatTest.scala
@@ -33,7 +33,6 @@ class StringConcatTest extends BytecodeTesting {
         |         chsq: java.lang.CharSequence,
         |         chrs: Array[Char]) = str + this + v + z + c + b + s + i + f + l + d + sbuf + chsq + chrs
         |
-        |  // similar, but starting off with any2stringadd
         |  def t2(
         |         v: Unit,
         |         z: Boolean,
@@ -47,23 +46,9 @@ class StringConcatTest extends BytecodeTesting {
         |         str: String,
         |         sbuf: java.lang.StringBuffer,
         |         chsq: java.lang.CharSequence,
-        |         chrs: Array[Char]) = this + str + v + z + c + b + s + i + f + l + d + sbuf + chsq + chrs
+        |         chrs: Array[Char]) = s"$str$this$v$z$c$b$s$i$f$l$d$sbuf$chsq$chrs"
         |
         |  def t3(
-        |         v: Unit,
-        |         z: Boolean,
-        |         c: Char,
-        |         b: Byte,
-        |         s: Short,
-        |         i: Int,
-        |         l: Long,
-        |         f: Float,
-        |         d: Double,
-        |         str: String,
-        |         sbuf: java.lang.StringBuffer,
-        |         chsq: java.lang.CharSequence,
-        |         chrs: Array[Char]) = s"$str$this$v$z$c$b$s$i$f$l$d$sbuf$chsq$chrs"
-        |  def t4(
         |         v: Unit,
         |         z: Boolean,
         |         c: Char,
@@ -104,28 +89,9 @@ class StringConcatTest extends BytecodeTesting {
       "toString()Ljava/lang/String;")
     assertEquals(invokeNameDesc("t1"), t1Expected)
 
-    assertEquals(invokeNameDesc("t2"), List(
-      "<init>(I)V",
-      "any2stringadd(Ljava/lang/Object;)Ljava/lang/Object;",
-      "$plus$extension(Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/String;",
-      "append(Ljava/lang/String;)Ljava/lang/StringBuilder;",
-      "append(Ljava/lang/Object;)Ljava/lang/StringBuilder;",
-      "append(Z)Ljava/lang/StringBuilder;",
-      "append(C)Ljava/lang/StringBuilder;",
-      "append(I)Ljava/lang/StringBuilder;",
-      "append(I)Ljava/lang/StringBuilder;",
-      "append(I)Ljava/lang/StringBuilder;",
-      "append(F)Ljava/lang/StringBuilder;",
-      "append(J)Ljava/lang/StringBuilder;",
-      "append(D)Ljava/lang/StringBuilder;",
-      "append(Ljava/lang/StringBuffer;)Ljava/lang/StringBuilder;",
-      "append(Ljava/lang/CharSequence;)Ljava/lang/StringBuilder;",
-      "append(Ljava/lang/Object;)Ljava/lang/StringBuilder;", // test that we're not using the [C overload
-      "toString()Ljava/lang/String;"))
-
     // intrinsics for StringContext.{raw,s}
+    assertEquals(invokeNameDesc("t2"), t1Expected)
     assertEquals(invokeNameDesc("t3"), t1Expected)
-    assertEquals(invokeNameDesc("t4"), t1Expected)
   }
 
   @Test
@@ -145,14 +111,12 @@ class StringConcatTest extends BytecodeTesting {
            sbuf: java.lang.StringBuffer,
            chsq: java.lang.CharSequence,
            chrs: Array[Char]) = {
-      val s1 = str + obj + v + z + c + b + s + i + f + l + d + sbuf + chsq + chrs
-      val s2 = obj + str + v + z + c + b + s + i + f + l + d + sbuf + chsq + chrs
-      s1 + "//" + s2
+      str + obj + v + z + c + b + s + i + f + l + d + sbuf + chsq + chrs
     }
     def sbuf = { val r = new java.lang.StringBuffer(); r.append("sbuf"); r }
     def chsq: java.lang.CharSequence = "chsq"
     val s = t((), true, 'd', 3: Byte, 12: Short, 3, -32l, 12.3f, -4.2d, "me", sbuf, chsq, Array('a', 'b'))
     val r = s.replaceAll("""\[C@\w+""", "<ARRAY>")
-    assertEquals(r, "meTTT()trued312312.3-32-4.2sbufchsq<ARRAY>//TTTme()trued312312.3-32-4.2sbufchsq<ARRAY>")
+    assertEquals(r, "meTTT()trued312312.3-32-4.2sbufchsq<ARRAY>")
   }
 }

--- a/test/scaladoc/run/implicits-known-type-classes.scala
+++ b/test/scaladoc/run/implicits-known-type-classes.scala
@@ -25,9 +25,9 @@ object Test extends ScaladocModelTest {
     val A = base._class("A")
 
     for (conversion <- A.conversions if !conversion.isHiddenConversion) {
-      assert(conversion.constraints.length == 1, conversion.constraints.length + " == 1 (in " + conversion + ")")
+      assert(conversion.constraints.length == 1, conversion.constraints.length.toString + " == 1 (in " + conversion + ")")
       assert(conversion.constraints.head.isInstanceOf[KnownTypeClassConstraint],
-             conversion.constraints.head + " is not a known type class constraint!")
+             conversion.constraints.head.toString + " is not a known type class constraint!")
     }
   }
 }

--- a/test/scaladoc/run/macro_annot.scala
+++ b/test/scaladoc/run/macro_annot.scala
@@ -11,7 +11,7 @@ object Test extends ScaladocModelTest {
     val docf = newDocFactory
 
     // first compile the macro
-    new docf.compiler.Run() compile List(new java.io.File(resourcePath + "/" + "simulacrum_1.scala").getPath)
+    new docf.compiler.Run() compile List(new java.io.File(resourcePath.toString + "/" + "simulacrum_1.scala").getPath)
     docf.makeUniverse(Right(code))
   }
 

--- a/test/scaladoc/run/t3314.flags
+++ b/test/scaladoc/run/t3314.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/scaladoc/run/t3314.scala
+++ b/test/scaladoc/run/t3314.scala
@@ -29,7 +29,7 @@ object Test extends ScaladocModelTest {
     assert(test1Constants.name == "Value", test1Constants.name + " == Value")
     assert(test1Constants.refEntity.size == 1, test1Constants.refEntity.size + " == 1")
     assert(test1Constants.refEntity(0)._1 == LinkToMember(test1._object("Constants")._class("Value"), test1._object("Constants")),
-           test1Constants.refEntity(0)._1 + " == LinkToMember(test1.Enum.Value)")
+           test1Constants.refEntity(0)._1.toString + " == LinkToMember(test1.Enum.Value)")
 
 
     // test2
@@ -42,7 +42,7 @@ object Test extends ScaladocModelTest {
         assert(doc._value(day).resultType.refEntity.size == 1,
                doc._value(day).resultType.refEntity.size + " == 1")
         assert(doc._value(day).resultType.refEntity(0)._1 == LinkToMember(doc._classMbr("Value"), doc),
-               doc._value(day).resultType.refEntity(0)._1 + " == LinkToMember(" + doc.qualifiedName + ".Value)")
+               doc._value(day).resultType.refEntity(0)._1.toString + " == LinkToMember(" + doc.qualifiedName + ".Value)")
       }
     }
     testDefinition(test2._trait("WeekDayTrait"))
@@ -70,9 +70,9 @@ object Test extends ScaladocModelTest {
         assert(doc._method(method).valueParams(0)(0).resultType.name == name,
                doc._method(method).valueParams(0)(0).resultType.name + " == " + name + " (in " + doc + "." + method + ")")
         assert(doc._method(method).valueParams(0)(0).resultType.refEntity.size == 1,
-               doc._method(method).valueParams(0)(0).resultType.refEntity.size + " == " + 1 + " (in " + doc + "." + method + ")")
+               doc._method(method).valueParams(0)(0).resultType.refEntity.size.toString + " == " + 1 + " (in " + doc + "." + method + ")")
         assert(doc._method(method).valueParams(0)(0).resultType.refEntity(0)._1 == LinkToMember(ref, ref.inTemplate),
-               doc._method(method).valueParams(0)(0).resultType.refEntity(0)._1 + " == LinkToMember(" + ref.qualifiedName + ") (in " + doc + "." + method + ")")
+               doc._method(method).valueParams(0)(0).resultType.refEntity(0)._1.toString + " == LinkToMember(" + ref.qualifiedName + ") (in " + doc + "." + method + ")")
       }
     }
     testUsage(test2._object("UserObject"))

--- a/test/scaladoc/run/t5235.scala
+++ b/test/scaladoc/run/t5235.scala
@@ -81,7 +81,7 @@ object Test extends ScaladocModelTest {
     assert(gcReverseType.refEntity(0)._1 == LinkToTpl(GenericColl),
            gcReverse.qualifiedName + "'s return type has a link to " + GenericColl.qualifiedName)
     assert(scReverseType.refEntity(0)._1 == Tooltip("BullSh"),
-           scReverseType.refEntity(0)._1 + " == Tooltip(\"BullSh\")")
+           scReverseType.refEntity(0)._1.toString + " == Tooltip(\"BullSh\")")
     assert(mcReverseType.refEntity(0)._1 == LinkToTpl(MyCollection),
            mcReverse.qualifiedName + "'s return type has a link to " + MyCollection.qualifiedName)
   }

--- a/test/scaladoc/run/t5784.scala
+++ b/test/scaladoc/run/t5784.scala
@@ -18,26 +18,26 @@ object Test extends ScaladocModelTest {
     assert(String.companion.isDefined, "test.templates.String should have a pseudo-companion object")
 
     val Base = main._trait("Base")
-    assert(Base.members.filter(_.inDefinitionTemplates.head == Base).length == 5, Base.members.filter(_.inDefinitionTemplates.head == Base).length + " == 5")
+    assert(Base.members.filter(_.inDefinitionTemplates.head == Base).length == 5, Base.members.filter(_.inDefinitionTemplates.head == Base).length.toString + " == 5")
     assert(Base.members.collect{case d: DocTemplateEntity => d}.length == 4, Base.members.collect{case d: DocTemplateEntity => d}.length == 4)
     testDiagram(Base, Base.contentDiagram, 2, 1)
 
     val BaseT = Base._absTypeTpl("T")
     val Foo = Base._trait("Foo")
-    assert(BaseT.members.filter(_.inDefinitionTemplates.head == Base).length == 0, BaseT.members.filter(_.inDefinitionTemplates.head == Base).length + " == 0")
-    assert(BaseT.members.map(_.name).sorted == Foo.members.map(_.name).sorted, BaseT.members.map(_.name).sorted + " == " + Foo.members.map(_.name).sorted)
+    assert(BaseT.members.filter(_.inDefinitionTemplates.head == Base).length == 0, BaseT.members.filter(_.inDefinitionTemplates.head == Base).length.toString + " == 0")
+    assert(BaseT.members.map(_.name).sorted == Foo.members.map(_.name).sorted, BaseT.members.map(_.name).sorted.toString + " == " + Foo.members.map(_.name).sorted)
     assert(BaseT.companion.isDefined, "test.templates.Base.T should have a pseudo-companion object")
     testDiagram(BaseT, BaseT.inheritanceDiagram, 2, 1)
 
     val Api = main._trait("Api")
-    assert(Api.members.filter(_.inDefinitionTemplates.head == Api).length == 2, Api.members.filter(_.inDefinitionTemplates.head == Api).length + " == 2") // FooApi and override type T
+    assert(Api.members.filter(_.inDefinitionTemplates.head == Api).length == 2, Api.members.filter(_.inDefinitionTemplates.head == Api).length.toString + " == 2") // FooApi and override type T
     assert(Api.members.collect{case d: DocTemplateEntity => d}.length == 5, Api.members.collect{case d: DocTemplateEntity => d}.length == 5)
     testDiagram(Api, Api.contentDiagram, 3, 2)
 
     val ApiT = Api._absTypeTpl("T")
     val FooApi = Api._trait("FooApi")
-    assert(ApiT.members.filter(_.inDefinitionTemplates.head == Api).length == 0, ApiT.members.filter(_.inDefinitionTemplates.head == Api).length + " == 0")
-    assert(ApiT.members.map(_.name).sorted == FooApi.members.map(_.name).sorted, ApiT.members.map(_.name).sorted + " == " + FooApi.members.map(_.name).sorted)
+    assert(ApiT.members.filter(_.inDefinitionTemplates.head == Api).length == 0, ApiT.members.filter(_.inDefinitionTemplates.head == Api).length.toString + " == 0")
+    assert(ApiT.members.map(_.name).sorted == FooApi.members.map(_.name).sorted, ApiT.members.map(_.name).sorted.toString + " == " + FooApi.members.map(_.name).sorted)
     assert(ApiT.companion.isDefined, "test.templates.Api.T should have a pseudo-companion object")
     testDiagram(ApiT, ApiT.inheritanceDiagram, 2, 1)
   }

--- a/test/scaladoc/run/t6509.scala
+++ b/test/scaladoc/run/t6509.scala
@@ -21,7 +21,7 @@ object Test extends ScaladocModelTest {
     def checkTemplateOwner(d: DocTemplateEntity) =
       for (mbr <- List("Symbol", "TypeSymbol", "TermSymbol", "MethodSymbol")) {
         val tpl = d._absTypeTpl(mbr).inTemplate
-        assert(tpl == X, tpl + " == X")
+        assert(tpl == X, tpl.toString + " == X")
       }
 
     for (tpl <- List(X, Y, Z, T))


### PR DESCRIPTION
Ref scala/bug#194

1. This deprecates scala.Predef.any2stringadd.
2. Another thing it does is to remove the conversion altogether under `-Xsource:2.14` flag.

### Background

Scala up till 2.12 has had two kinds of String concatenation operator `+` (also known as PLUS or ADD).

a. When the receiver is a non-String, it uses implicit `Predef.any2addstring` to inject `+`.
b. When the receiver is a String, the compiler injects a special method `String_+`.

In other words, `true + "what"` and `"what" + true` use different mechanisms.
This change addresses the first variant that introduces `+` operator into `Any`.
The rationale discussed in scala/bug#194 is that this implicit injection removes too much type safety, leading to confusing results.

Here some examples listed:

```scala
scala> var v = Vector[Int]()
v: scala.collection.immutable.Vector[Int] = Vector()

scala> v += 3
<console>:13: error: value += is not a member of scala.collection.immutable.Vector[Int]
  Expression does not convert to assignment because:
    type mismatch;
     found   : Int(3)
     required: String
    expansion: v = v.$plus(3)
       v += 3
         ^

scala> val xs = List(1, 2, 3)
xs: List[Int] = List(1, 2, 3)

scala> xs foreach { println _ + 1 }
<console>:13: error: type mismatch;
 found   : Int(1)
 required: String
       xs foreach { println _ + 1 }
                                ^
```

Note that in both examples the person who wrote the code were not trying to concatenate String.

### Implementation note

Initially I've attempted to implement what @adriaanm  proposed in 2014 (scala/bug#194 (comment)) and remove all deprecated implicits under `-Xfuture` flag. A simple implementation

```scala
val fd = settings.future && sym.isDeprecated
```

did not work, because the implicit caching is unware of the annotations?
