### PR TITLE
Removed -Yliteral-types option and cleaned up docs

### DIFF
--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -86,7 +86,7 @@ object ScalaOptionParser {
     "-Xno-forwarders", "-Xno-patmat-analysis", "-Xno-uescape", "-Xnojline", "-Xprint-pos", "-Xprint-types", "-Xprompt", "-Xresident", "-Xshow-phases", "-Xstrict-inference", "-Xverify", "-Y",
     "-Ybreak-cycles", "-Ydebug", "-Ycompact-trees", "-YdisableFlatCpCaching", "-Ydoc-debug",
     "-Yide-debug", "-Yinfer-argument-types",
-    "-Yissue-debug", "-Yliteral-types", "-Ylog-classpath", "-Ymacro-debug-lite", "-Ymacro-debug-verbose", "-Ymacro-no-expand",
+    "-Yissue-debug", "-Ylog-classpath", "-Ymacro-debug-lite", "-Ymacro-debug-verbose", "-Ymacro-no-expand",
     "-Yno-completion", "-Yno-generic-signatures", "-Yno-imports", "-Yno-predef",
     "-Yoverride-objects", "-Yoverride-vars", "-Ypatmat-debug", "-Yno-adapted-args", "-Ypartial-unification", "-Ypos-debug", "-Ypresentation-debug",
     "-Ypresentation-strict", "-Ypresentation-verbose", "-Yquasiquote-debug", "-Yrangepos", "-Yreify-copypaste", "-Yreify-debug", "-Yrepl-class-based",

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -133,7 +133,6 @@ object Predef extends LowPriorityImplicits {
    * val foo = valueOf[Foo.type]
    * // foo is Foo.type = Foo
    *
-   * // If -Yliteral-types has been specified
    * val bar = valueOf[23]
    * // bar is 23.type = 23
    * }}}

--- a/src/library/scala/ValueOf.scala
+++ b/src/library/scala/ValueOf.scala
@@ -11,8 +11,7 @@ package scala
 /**
  * `ValueOf[T]` provides the unique value of the type `T` where `T` is a type which has a
  * single inhabitant. Eligible types are singleton types of the form `stablePath.type`,
- * Unit and, if the -Yliteral-types compiler option has been specified, singleton types
- * corresponding to value literals.
+ * Unit and singleton types corresponding to value literals.
  *
  * Instances of `ValueOf[T]` are provided implicitly for all eligible types. Typically
  * an instance would be required where a runtime value corresponding to a type level

--- a/test/files/pos/t6574.scala
+++ b/test/files/pos/t6574.scala
@@ -9,7 +9,7 @@ class Bad[X, Y](val v: Int) extends AnyVal {
   }
 
   // The original test case fails with the new is/asInstanceOf semantics
-  // introduced along with -Yliteral-types because the method has a
+  // introduced along with along with SIP-23 implementation because the method has a
   // singleton result type which cannot be erased correctly.
   // See: neg/sip23-tailrec-singleton.scala
   //@annotation.tailrec final def dependent[Z](a: Int)(b: String): b.type = {

--- a/test/files/pos/t6891.scala
+++ b/test/files/pos/t6891.scala
@@ -6,7 +6,7 @@ object O {
     }
 
     // The original test cases fail with the new is/asInstanceOf semantics
-    // introduced along with -Yliteral-types because the method has a
+    // introduced along with SIP-23 implementation because the method has a
     // singleton typed argument which cannot be erased correctly.
     // See: neg/sip23-tailrec-value-class.scala
     //def boppy() = {


### PR DESCRIPTION
This is PR addresses issue [#10710](https://github.com/scala/bug/issues/10710) regarding cleanup of `-Yliteral-types` flag.