### PR TITLE
Warn when implicit is enclosing owner

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -67,6 +67,8 @@ trait Warnings {
 
   val warnExtraImplicit   = BooleanSetting("-Ywarn-extra-implicit", "Warn when more than one implicit parameter section is defined.")
 
+  val warnSelfImplicit    = BooleanSetting("-Ywarn-self-implicit", "Warn when an implicit resolves to an enclosing self-definition.")
+
   // Experimental lint warnings that are turned off, but which could be turned on programmatically.
   // They are not activated by -Xlint and can't be enabled on the command line because they are not
   // created using the standard factory methods.

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -109,6 +109,14 @@ trait Implicits {
     if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopCounter(findMemberImpl, findMemberStart)
     if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopCounter(subtypeImpl, subtypeStart)
 
+    if (result.isSuccess && settings.warnSelfImplicit && result.tree.symbol != null) {
+      val s =
+        if (result.tree.symbol.isAccessor) result.tree.symbol.accessed
+        else if (result.tree.symbol.isModule) result.tree.symbol.moduleClass
+        else result.tree.symbol
+      if (context.owner.hasTransOwner(s))
+        context.warning(result.tree.pos, s"Implicit resolves to enclosing ${result.tree.symbol}")
+    }
     result
   }
 

--- a/test/files/neg/implicitly-self.check
+++ b/test/files/neg/implicitly-self.check
@@ -1,0 +1,15 @@
+implicitly-self.scala:5: warning: Implicit resolves to enclosing method c
+  implicit def c: Char = implicitly[Char]
+                                   ^
+implicitly-self.scala:6: warning: Implicit resolves to enclosing value s
+  implicit val s: String = implicitly[String]
+                                     ^
+implicitly-self.scala:8: warning: Implicit resolves to enclosing value t
+    def f = implicitly[Int]
+                      ^
+implicitly-self.scala:11: warning: Implicit resolves to enclosing object tcString
+  implicit object tcString extends TC[String] { def ix = implicitly[TC[String]].ix + 1 }
+                                                                   ^
+error: No warnings can be incurred under -Xfatal-warnings.
+four warnings found
+one error found

--- a/test/files/neg/implicitly-self.flags
+++ b/test/files/neg/implicitly-self.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Ywarn-self-implicit

--- a/test/files/neg/implicitly-self.scala
+++ b/test/files/neg/implicitly-self.scala
@@ -1,0 +1,12 @@
+
+trait TC[T] { def ix: Int }
+
+object Test {
+  implicit def c: Char = implicitly[Char]
+  implicit val s: String = implicitly[String]
+  implicit val t: Int = {
+    def f = implicitly[Int]
+    f
+  }
+  implicit object tcString extends TC[String] { def ix = implicitly[TC[String]].ix + 1 }
+}


### PR DESCRIPTION
Maybe put it behind a flag?

Fixes scala/bug#10760