### PR TITLE
Added type parameter to Iterator.empty and test cases

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -38,7 +38,7 @@ object Iterator {
   }
 
   /** The iterator which produces no values. */
-  def empty[T]: Iterator[T] = _empty
+  @inline final def empty[T]: Iterator[T] = _empty
 
   /** Creates an iterator which produces a single element.
    *  '''Note:''' Equivalent, but more efficient than Iterator(elem)

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -32,11 +32,13 @@ object Iterator {
     def traversableToColl[B](t: GenTraversable[B]) = t.toIterator
   }
 
-  /** The iterator which produces no values. */
-  val empty: Iterator[Nothing] = new AbstractIterator[Nothing] {
+  private[this] final val _empty: Iterator[Nothing] = new AbstractIterator[Nothing] {
     def hasNext: Boolean = false
     def next(): Nothing = throw new NoSuchElementException("next on empty iterator")
   }
+
+  /** The iterator which produces no values. */
+  def empty[T]: Iterator[T] = _empty
 
   /** Creates an iterator which produces a single element.
    *  '''Note:''' Equivalent, but more efficient than Iterator(elem)

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -296,4 +296,16 @@ class IteratorTest {
     assertEquals(v2, v4)
     assertEquals(Some(v1), v2)
   }
+
+  @Test def emptyTypedIteratorsShouldBeEqual(): Unit = {
+    val emptyDoubleIterator = Iterator.empty[Double]
+    val emptyIntIterator = Iterator.empty[Int]
+    assertEquals(emptyDoubleIterator, emptyIntIterator)
+  }
+
+  @Test def emptyIteratorInHigherOrderFunctions(): Unit = {
+    val seqOfIterators = Seq(Seq(1, 2, 3).iterator, Seq(3, 2, 1).iterator, Seq(1, 3, 2).iterator)
+    val unified = seqOfIterators.fold(Iterator.empty[Int])((a, b) => a ++ b)
+    assertEquals(List(1, 2, 3, 3, 2, 1, 1, 3, 2), unified.toList)
+  }
 }

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -300,7 +300,7 @@ class IteratorTest {
   @Test def emptyTypedIteratorsShouldBeEqual(): Unit = {
     val emptyDoubleIterator = Iterator.empty[Double]
     val emptyIntIterator = Iterator.empty[Int]
-    assertEquals(emptyDoubleIterator, emptyIntIterator)
+    assertSame(emptyDoubleIterator, emptyIntIterator)
   }
 
   @Test def emptyIteratorInHigherOrderFunctions(): Unit = {


### PR DESCRIPTION
This PR addresses issue [#10711](https://github.com/scala/bug/issues/10711) adding type parameter to method `Iterator.empty` and two test cases to `IteratorTest`.