### PR TITLE
Deeply focus the qualifier before using it as the RHS of the stabilizing val.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5038,14 +5038,14 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 isInsertionNode(ctx.tree) && !isInsertionNode(ctx.outer.tree)
               }
 
-              if(insertionContext != NoContext) {
+              if (insertionContext != NoContext) {
                 val vsym = insertionContext.owner.newValue(unit.freshTermName(nme.STABILIZER_PREFIX), qual.pos.focus, SYNTHETIC | ARTIFACT | STABLE)
                 vsym.setInfo(uncheckedBounds(qual.tpe))
                 insertionContext.scope enter vsym
-                val vdef = atPos(vsym.pos.makeTransparent)(ValDef(vsym, qual))
+                val vdef = atPos(vsym.pos)(ValDef(vsym, focusInPlace(qual)))
                 qual.changeOwner(insertionContext.owner -> vsym)
                 insertionContext.tree.updateAttachment(StabilizingDefinition(vdef))
-                val newQual = Ident(vsym) setType singleType(NoPrefix, vsym) setPos qual.pos
+                val newQual = Ident(vsym) setType singleType(NoPrefix, vsym) setPos qual.pos.focus
                 return typedSelect(tree, newQual, name)
               }
             }

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1772,6 +1772,16 @@ trait Trees extends api.Trees {
       t1
     }
   }
+
+  final def focusInPlace(t: Tree): t.type =
+    if (useOffsetPositions) t else { focuser traverse t; t }
+  private object focuser extends InternalTraverser {
+    override def traverse(t: Tree) = {
+      t setPos t.pos.focus
+      t traverse this
+    }
+  }
+
   trait TreeStackTraverser extends InternalTraverser {
     import collection.mutable
     val path: mutable.Stack[Tree] = mutable.Stack()

--- a/test/files/neg/t5946.flags
+++ b/test/files/neg/t5946.flags
@@ -1,0 +1,1 @@
+-Yrangepos

--- a/test/files/pos/t3995.flags
+++ b/test/files/pos/t3995.flags
@@ -1,0 +1,1 @@
+-Yrangepos

--- a/test/files/pos/t4225b.flags
+++ b/test/files/pos/t4225b.flags
@@ -1,0 +1,1 @@
+-Yrangepos

--- a/test/files/pos/t4225c.flags
+++ b/test/files/pos/t4225c.flags
@@ -1,0 +1,1 @@
+-Yrangepos

--- a/test/files/pos/t5946.flags
+++ b/test/files/pos/t5946.flags
@@ -1,0 +1,1 @@
+-Yrangepos

--- a/test/files/run/t4225d.flags
+++ b/test/files/run/t4225d.flags
@@ -1,0 +1,1 @@
+-Yrangepos

--- a/test/files/run/t4225e.flags
+++ b/test/files/run/t4225e.flags
@@ -1,0 +1,1 @@
+-Yrangepos


### PR DESCRIPTION
...because rangepos expects offset-positioned trees not to contain range-positioned trees. This is the same approach that default arguments use when moving the RHS of the parameter val into a default getter.

Alternatives:
- Remove that assertion: I'm not sure what it's for, but the validation seems quite insistent on that point. I suspect that the IDE or PC or something using positions may break on that.
- Use the tree duplicator (and don't make a focuser traverser). This is how the default args are currently done, but since we're not reusing `qual` here that I can see it doesn't seem too useful to waste the allocations that it would take to duplicate that tree.

The test cases are just slapping `-Yrangepos` on all of the test cases introduced in bcbe993e (where this feature was introduced).

`test/files/pos/t4225.scala` is not thus enhanced, since there's a similar rangeposly error with by-name arguments of right-associative methods.

Fixes scala/bug#10706, references scala/scala-dev#472.