### PR TITLE
add Either.left and Either.right typed as Either

### DIFF
--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -457,6 +457,16 @@ object Either {
   def cond[A, B](test: Boolean, right: => B, left: => A): Either[A, B] =
     if (test) Right(right) else Left(left)
 
+  /**
+   * Creates `Left` typed as `Either`
+   */
+  def left[A, B](value: A): Either[A, B] = Left(value)
+
+  /**
+   * Creates `Right` typed as `Either`
+   */
+  def right[A, B](value: B): Either[A, B] = Right(value)
+
   /** Allows use of a `merge` method to extract values from Either instances
    *  regardless of whether they are Left or Right.
    *

--- a/test/junit/scala/util/EitherTest.scala
+++ b/test/junit/scala/util/EitherTest.scala
@@ -1,0 +1,36 @@
+package scala.util
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+import org.junit.Assert._
+
+@RunWith(classOf[JUnit4])
+class EitherTest {
+
+  @Test
+  def testLeft: Unit = {
+
+    def rightSumOrLeftEmpty(l: List[Int]) =
+      l.foldLeft(Either.left[String, Int]("empty")) {
+        case (Left(_), i) => Right(i)
+        case (Right(s), i) => Right(s + i)
+      }
+
+    assertEquals(rightSumOrLeftEmpty(List(1, 2, 3)), Right(6))
+    assertEquals(rightSumOrLeftEmpty(Nil), Left("empty"))
+  }
+
+  @Test
+  def testRight: Unit = {
+
+    def leftSumOrRightEmpty(l: List[Int]) =
+      l.foldLeft(Either.right[Int, String]("empty")) {
+        case (Right(_), i) => Left(i)
+        case (Left(s), i) => Left(s + i)
+      }
+
+    assertEquals(leftSumOrRightEmpty(List(1, 2, 3)), Left(6))
+    assertEquals(leftSumOrRightEmpty(Nil), Right("empty"))
+  }
+}


### PR DESCRIPTION
motivation: `Left` and `Right` constructors are typed as `Left` and `Right` respectively, but sometimes we want something like `Option.empty` which returns `None` but typed as `Option`.

The test represents a code that would not compile if plain `Left`/`Right` constructors are used 

@SethTisue please take a look