### PR TITLE
add Either.left and Either.right typed as Either

### DIFF
--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -468,6 +468,35 @@ object Either {
   def cond[A, B](test: Boolean, right: => B, left: => A): Either[A, B] =
     if (test) Right(right) else Left(left)
 
+  /**
+   * Creates `FromLeftPartiallyApplied[B]` that given an argument of type `A`
+   * produces a `Left` typed as `Either[A,B]`
+   * {{
+   *   val l = Either.left[Int]("boo")
+   *   //l: Either[String, Int] = Left("boo")
+   * }}
+   */
+  def left[B]: FromLeftPartiallyApplied[B] = new FromLeftPartiallyApplied[B]
+
+  private[util] final class FromLeftPartiallyApplied[B](private val dummy: Unit) extends AnyVal {
+    def apply[A](value: A): Either[A, B] = Left(value)
+  }
+
+  /**
+   * Creates `FromRightPartiallyApplied[A]` that given an argument of type `B`
+   * produces a `Right` typed as `Either[A,B]`
+   * {{
+   *   val r = Either.right[String](5)
+   *   //r: Either[String, Int] = Right(5)
+   * }}
+   */
+  def right[A]: FromRightPartiallyApplied[A] = new FromRightPartiallyApplied[A]
+
+  private[util] final class FromRightPartiallyApplied[A](private val dummy: Unit) extends AnyVal {
+    def apply[B](value: B): Either[A, B] = Right(value)
+  }
+
+
   /** Allows use of a `merge` method to extract values from Either instances
    *  regardless of whether they are Left or Right.
    *

--- a/test/junit/scala/util/EitherTest.scala
+++ b/test/junit/scala/util/EitherTest.scala
@@ -1,6 +1,7 @@
 package scala.util
 
 import org.junit.{ Assert, Test }
+import org.junit.Assert._
 
 class EitherTest {
 
@@ -13,9 +14,34 @@ class EitherTest {
     val flatrl: Either[String, Int] = rl.flatten
     val flatrr: Either[String, Int] = rr.flatten
 
-    Assert.assertEquals(Left("pancake"), flatl)
-    Assert.assertEquals(Left("flounder"), flatrl)
-    Assert.assertEquals(Right(7), flatrr)
-    
+    assertEquals(Left("pancake"), flatl)
+    assertEquals(Left("flounder"), flatrl)
+    assertEquals(Right(7), flatrr)
+  }
+
+  @Test
+  def testLeft: Unit = {
+
+    def rightSumOrLeftEmpty(l: List[Int]) =
+      l.foldLeft(Either.left[Int]("empty")) {
+        case (Left(_), i) => Right(i)
+        case (Right(s), i) => Right(s + i)
+      }
+
+    assertEquals(rightSumOrLeftEmpty(List(1, 2, 3)), Right(6))
+    assertEquals(rightSumOrLeftEmpty(Nil), Left("empty"))
+  }
+
+  @Test
+  def testRight: Unit = {
+
+    def leftSumOrRightEmpty(l: List[Int]) =
+      l.foldLeft(Either.right[Int]("empty")) {
+        case (Right(_), i) => Left(i)
+        case (Left(s), i) => Left(s + i)
+      }
+
+    assertEquals(leftSumOrRightEmpty(List(1, 2, 3)), Left(6))
+    assertEquals(leftSumOrRightEmpty(Nil), Right("empty"))
   }
 }


### PR DESCRIPTION
this is another implementation of #6328 inspired by @LukaJCB and others in gitter(https://gitter.im/typelevel/general?at=5a85d126ce68c3bc748f61d4) (thanks!)

motivation: `Left` and `Right` constructors are typed as `Left` and `Right` respectively, but sometimes we want something like `Option.empty` which returns `None` but typed as `Option`.

The test represents a code that would not compile if plain `Left`/`Right` constructors are used 

@SethTisue please check it again, thanks!
If this looks better (it does to me) then #6328 should be closed