### PR TITLE
Issue macro expansion errors during "late expansion"

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -906,7 +906,12 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
           context.implicitsEnabled = typer.context.implicitsEnabled
           context.enrichmentEnabled = typer.context.enrichmentEnabled
           context.macrosEnabled = typer.context.macrosEnabled
-          macroExpand(newTyper(context), tree, EXPRmode, WildcardType)
+          try {
+            macroExpand(newTyper(context), tree, EXPRmode, WildcardType)
+          } finally {
+            if (context.reporter.isBuffering)
+              context.reporter.propagateErrorsTo(typer.context.reporter)
+          }
         case _ =>
           tree
       })

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -482,8 +482,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       if (cond) typerWithLocalContext(c)(f) else f(this)
 
     @inline
-    final def typerWithLocalContext[T](c: Context)(f: Typer => T): T =
-      c.reporter.propagatingErrorsTo(context.reporter)(f(newTyper(c)))
+    final def typerWithLocalContext[T](c: Context)(f: Typer => T): T = {
+      try f(newTyper(c))
+      finally c.reporter.propagateErrorsTo(context.reporter)
+    }
 
     /** The typer for a label definition. If this is part of a template we
      *  first have to enter the label definition.

--- a/test/files/neg/t10073.check
+++ b/test/files/neg/t10073.check
@@ -1,0 +1,4 @@
+t10073.scala:7: error: tpe Unused is an unresolved spliceable type
+  "".yo()
+  ^
+one error found

--- a/test/files/neg/t10073.scala
+++ b/test/files/neg/t10073.scala
@@ -1,0 +1,8 @@
+class Yo[Unused] {
+  def yo(hasDefault: Any = ""): String = ""
+}
+
+class MacroNotExpanded {
+  implicit def toYo[Unused](a: Any)(implicit ct: reflect.ClassTag[Unused]): Yo[Unused] = new Yo[Unused]
+  "".yo()
+}

--- a/test/files/neg/t10073b.check
+++ b/test/files/neg/t10073b.check
@@ -1,0 +1,4 @@
+t10073b.scala:7: error: tpe Unused is an unresolved spliceable type
+   "".yo()
+   ^
+one error found

--- a/test/files/neg/t10073b.scala
+++ b/test/files/neg/t10073b.scala
@@ -1,0 +1,8 @@
+class Yo[Unused] {
+  def yo(hasDefault: Any = ""): String = ""
+}
+
+class MacroNotExpanded {
+  implicit def toYo[Unused](a: Any)(implicit ct: reflect.ClassTag[Unused]): Yo[Unused] = new Yo[Unused]
+   "".yo()  
+}


### PR DESCRIPTION
The typechecker defers macro macro expansion while the macro
application has type arguments that are yet to be determined.
Instead, it proceed with typechecking the surrounding
expression, and then performs another pass on the resulting tree
when the type inference has fixed the type parameters.

This "late expansion" typechecks the macro application with a
typer focussed on the original Context of the application,
and any errors issued by the macro (either explicit c.error
or c.abort, or an exception) are issued to that contexts's
reporter.

However, if that reporter was setup to buffer errors, rather
than immediately report them, these macro expansion errors
would sit in the never be issued, and the unexpanded macro
application would remain in the tree, doomed to be flagged with
a "macro not expanded" error in refchecks.

This commit copies any buffered errors to the currently active
typer context reporter after late expansion.

I refactored the existing code that did this to make it more
easily reusable in this context.

Fixes scala/bug#10073