### PR TITLE
Fix typo/dead code in grammar production in SLS

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -32,7 +32,7 @@ SimpleExpr1  ::=  Literal
                |  Path
                |  ‘_’
                |  ‘(’ [Exprs] ‘)’
-               |  SimpleExpr ‘.’ id s
+               |  SimpleExpr ‘.’ id
                |  SimpleExpr TypeArgs
                |  SimpleExpr1 ArgumentExprs
                |  XmlExpr


### PR DESCRIPTION
Make the production for `SimpleExpr1` match with the ones from the appendix.

@martijnhoekstra said he learned it's in fact dead specification material, but should still be removed: https://gitter.im/scala/contributors?at=5a87302d17b16a237757b79e