### PR TITLE
Avoid constraints of the wrong kind between TypeVars

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
@@ -218,7 +218,7 @@ private[internal] trait TypeConstraints {
             }
             for (tparam2 <- tparams)
               tparam2.info.bounds.lo.dealias match {
-                case TypeRef(_, `tparam`, _) =>
+                case TypeRef(_, `tparam`, Nil) =>
                   debuglog(s"$tvar addHiBound $tparam2.tpeHK.instantiateTypeParams($tparams, $tvars)")
                   tvar addHiBound tparam2.tpeHK.instantiateTypeParams(tparams, tvars)
                 case _ =>
@@ -230,7 +230,7 @@ private[internal] trait TypeConstraints {
             }
             for (tparam2 <- tparams)
               tparam2.info.bounds.hi.dealias match {
-                case TypeRef(_, `tparam`, _) =>
+                case TypeRef(_, `tparam`, Nil) =>
                   debuglog(s"$tvar addLoBound $tparam2.tpeHK.instantiateTypeParams($tparams, $tvars)")
                   tvar addLoBound tparam2.tpeHK.instantiateTypeParams(tparams, tvars)
                 case _ =>

--- a/test/files/pos/t10722.flags
+++ b/test/files/pos/t10722.flags
@@ -1,0 +1,1 @@
+-language:higherKinds

--- a/test/files/pos/t10722.scala
+++ b/test/files/pos/t10722.scala
@@ -1,0 +1,11 @@
+object Test {
+  sealed trait Coin[+A, +B]
+  case class Heads[+A](face: A) extends Coin[A, Nothing]
+  case class Tails[+B](back: B) extends Coin[Nothing, B]
+
+  def flip[F[_, _], G[x] <: F[x, String]](f: F[Int, String], g: G[Int]) = ???
+  def flop[F[_], G <: F[String]](f: F[String], g: G) = ???
+
+  flip(Tails("scala"): Coin[Int, String], Heads(50))
+  flop(Option("scala"), None)
+}

--- a/test/files/pos/t8602.flags
+++ b/test/files/pos/t8602.flags
@@ -1,0 +1,1 @@
+-language:higherKinds

--- a/test/files/pos/t8602.scala
+++ b/test/files/pos/t8602.scala
@@ -1,0 +1,8 @@
+object Test {
+  case class Foo[CC[_], D <: CC[Int]](d: D, cc: CC[Int])
+  Foo(Nil, List(1, 2, 3))
+
+  class H[F[_]]
+  def g[F[_], T, FT <: F[T]](h: H[F]) = 1
+  g(new H[Set])
+}


### PR DESCRIPTION
When solving a list of type variables, bounds between them should
not be added as constraints when they are of different kinds.

Fixes scala/bug#8602 and fixes scala/bug#10722