### PR TITLE
[SUPERSEDED] Adapt errors are emitted in patterns

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -892,7 +892,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         }
 
         def cantAdapt =
-          if (context.implicitsEnabled) MissingArgsForMethodTpeError(tree, meth)
+          if (context.implicitsEnabled || context.enrichmentEnabled) MissingArgsForMethodTpeError(tree, meth)
           else setError(tree)
 
         def emptyApplication: Tree = adapt(typed(Apply(tree, Nil) setPos tree.pos), mode, pt, original)

--- a/test/files/neg/t10474.check
+++ b/test/files/neg/t10474.check
@@ -1,0 +1,11 @@
+t10474.scala:8: error: missing argument list for method Foo in object Test
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `Foo _` or `Foo(_)` instead of `Foo`.
+    case Foo.Bar ⇒ true
+         ^
+t10474.scala:15: error: missing argument list for method Foo in trait hrhino
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `Foo _` or `Foo(_)` instead of `Foo`.
+  val Foo.Crash = ???
+      ^
+two errors found

--- a/test/files/neg/t10474.scala
+++ b/test/files/neg/t10474.scala
@@ -1,0 +1,16 @@
+
+object Test {
+  def Foo(a: Int): Char = ???
+
+  object Bar
+
+  def crash[A](): Boolean = Bar match {
+    case Foo.Bar ⇒ true
+    case _ ⇒ false
+  }
+}
+
+trait hrhino {
+  def Foo(i: Int) = i
+  val Foo.Crash = ???
+}

--- a/test/files/neg/t10731.check
+++ b/test/files/neg/t10731.check
@@ -1,0 +1,6 @@
+t10731.scala:3: error: missing argument list for method eq in class Object
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `eq _` or `eq(_)` instead of `eq`.
+  val eq.a = 1
+      ^
+one error found

--- a/test/files/neg/t10731.scala
+++ b/test/files/neg/t10731.scala
@@ -1,0 +1,4 @@
+
+class C {
+  val eq.a = 1
+}


### PR DESCRIPTION
In patterns, implicits aren't enabled, but
enrichments are. Emit errors in that case;
otherwise, erroneous trees leak.

Fixes scala/bug#10731

[s: waiting for push, better error message]