### PR TITLE
Right-associative arguments don't lose singleton type

### DIFF
--- a/test/files/pos/t10726.scala
+++ b/test/files/pos/t10726.scala
@@ -1,0 +1,8 @@
+object Test {
+
+  def eat(foods: List["food"]): Unit = println(s"ate ${foods.size} foods")
+
+  eat("food" :: Nil)
+  eat(Nil.::("food"))
+
+}

--- a/test/files/run/t10751.check
+++ b/test/files/run/t10751.check
@@ -7,11 +7,9 @@
     };
     [20:43]private[this] val n: [38]Int = [42:43]1;
     [51:60]{
-      [51:52]final <synthetic> <artifact> val rassoc$1: [51]Int(1) = [51:52]1;
       [53:60]<53:60><53:60>C.foo_:[[53]Nothing]([51]1)
     };
     [67:81]{
-      [67:68]final <synthetic> <artifact> val rassoc$2: [67]Int(1) = [67:68]1;
       [69:81]<69:81><69:81>C.foo_:[[75:78]<type: [75:78]scala.Any>]([67]1)
     };
     [89:98]{
@@ -21,11 +19,9 @@
       [105:119]<107:119><107:119>C.foo_:[[113:116]<type: [113:116]scala.Any>]([105:106][105]Test.this.n)
     };
     [127:136]{
-      [127:128]final <synthetic> <artifact> val rassoc$5: [127]Int(1) = [127:128]1;
       [129:136]<129:136><129:136>C.bar_:[[129]Nothing]([127]1)
     };
     [143:157]{
-      [143:144]final <synthetic> <artifact> val rassoc$6: [143]Int(1) = [143:144]1;
       [145:157]<145:157><145:157>C.bar_:[[151:154]<type: [151:154]scala.Any>]([143]1)
     };
     [165:174]{

--- a/test/files/run/t10751.check
+++ b/test/files/run/t10751.check
@@ -1,15 +1,40 @@
 [[syntax trees at end of                     typer]] // newSource1.scala
-[0:56]package [0:0]<empty> {
-  [0:56]object Test extends [12:56][56]scala.AnyRef {
-    [56]def <init>(): [12]Test.type = [56]{
-      [56][56][56]Test.super.<init>();
+[0:201]package [0:0]<empty> {
+  [0:201]object Test extends [12:201][201]scala.AnyRef {
+    [201]def <init>(): [12]Test.type = [201]{
+      [201][201][201]Test.super.<init>();
       [12]()
     };
-    [20:29]{
-      [20:29]<22:29><22:29>C.foo_:[[22]Nothing]([20:21]1)
+    [20:43]private[this] val n: [38]Int = [42:43]1;
+    [51:60]{
+      [51:52]final <synthetic> <artifact> val rassoc$1: [51]Int(1) = [51:52]1;
+      [53:60]<53:60><53:60>C.foo_:[[53]Nothing]([51]1)
     };
-    [36:50]{
-      [36:50]<38:50><38:50>C.foo_:[[44:47]<type: [44:47]scala.Any>]([36:37]1)
+    [67:81]{
+      [67:68]final <synthetic> <artifact> val rassoc$2: [67]Int(1) = [67:68]1;
+      [69:81]<69:81><69:81>C.foo_:[[75:78]<type: [75:78]scala.Any>]([67]1)
+    };
+    [89:98]{
+      [89:98]<91:98><91:98>C.foo_:[[91]Nothing]([89:90][89]Test.this.n)
+    };
+    [105:119]{
+      [105:119]<107:119><107:119>C.foo_:[[113:116]<type: [113:116]scala.Any>]([105:106][105]Test.this.n)
+    };
+    [127:136]{
+      [127:128]final <synthetic> <artifact> val rassoc$5: [127]Int(1) = [127:128]1;
+      [129:136]<129:136><129:136>C.bar_:[[129]Nothing]([127]1)
+    };
+    [143:157]{
+      [143:144]final <synthetic> <artifact> val rassoc$6: [143]Int(1) = [143:144]1;
+      [145:157]<145:157><145:157>C.bar_:[[151:154]<type: [151:154]scala.Any>]([143]1)
+    };
+    [165:174]{
+      [165:166]final <synthetic> <artifact> val rassoc$7: [165]Int = [165:166][165]Test.this.n;
+      [167:174]<167:174><167:174>C.bar_:[[167]Nothing]([165]rassoc$7)
+    };
+    [181:195]{
+      [181:182]final <synthetic> <artifact> val rassoc$8: [181]Int = [181:182][181]Test.this.n;
+      [183:195]<183:195><183:195>C.bar_:[[189:192]<type: [189:192]scala.Any>]([181]rassoc$8)
     }
   }
 }

--- a/test/files/run/t10751.scala
+++ b/test/files/run/t10751.scala
@@ -7,8 +7,19 @@ object Test extends DirectTest {
 
   override def code = """
     object Test {
+      private[this] val n = 1
+
       1 foo_: C
       1 foo_:[Any] C
+
+      n foo_: C
+      n foo_:[Any] C
+
+      1 bar_: C
+      1 bar_:[Any] C
+
+      n bar_: C
+      n bar_:[Any] C
     }
   """.trim
 
@@ -21,7 +32,6 @@ object Test extends DirectTest {
 
 class C {
   def foo_:[Dummy](i: => Int): Int = i
-  def t(c: C) = 1 foo_: c
-  def u(c: C) = 1 foo_:[Any] c
+  def bar_:[Dummy](i:    Int): Int = i
 }
 object C extends C


### PR DESCRIPTION
`x :: y` becomes `{ val rassoc$1 = x ; y.::(rassoc$1) }` during parser. That `val` causes `rassoc$1` to get a non-singleton type, which isn't necessarily what you want. 

The secret handshake, of course, is to make `rassoc$1` a `final val`.

Fixes scala/bug#10726.