### PR TITLE
Don't abort on glb/lub of TypeVar

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4669,7 +4669,7 @@ trait Types
         case tv@TypeVar(_, constr) =>
           if (tv.instValid) stripType(constr.inst)
           else if (tv.untouchable) stripped += tv
-          else abort("trying to do lub/glb of typevar " + tv)
+          else {} // ignore when this happens (neg/t10514.scala) -- don't abort("trying to do lub/glb of typevar " + tv)
         case tp => stripped += tp
       }
       ts foreach stripType

--- a/test/files/neg/t10514.check
+++ b/test/files/neg/t10514.check
@@ -1,0 +1,13 @@
+t10514.scala:8: error: no type parameters for constructor Foo: (value: F[C[G[Foo[F,G]]]])Foo[F,G] exist so that it can be applied to arguments (Some[C[Foo[Option,Test.this.Id]]])
+ --- because ---
+argument expression's type is not compatible with formal parameter type;
+ found   : Some[C[Foo[Option,Test.this.Id]]]
+ required: ?F[C[?G[Foo[?F,?G]]]]
+  new Foo(Some(new C(new Foo[Option, Id](None))))
+  ^
+t10514.scala:8: error: type mismatch;
+ found   : Some[C[Foo[Option,Test.this.Id]]]
+ required: F[C[G[Foo[F,G]]]]
+  new Foo(Some(new C(new Foo[Option, Id](None))))
+              ^
+two errors found

--- a/test/files/neg/t10514.flags
+++ b/test/files/neg/t10514.flags
@@ -1,0 +1,1 @@
+-language:higherKinds

--- a/test/files/neg/t10514.scala
+++ b/test/files/neg/t10514.scala
@@ -1,0 +1,9 @@
+// document status quo (used to crash, now just fails to infer)
+// to make this compile, explicitly provide type args
+class C[T](x: T)
+class Foo[F[_], G[_]](value: F[C[G[Foo[F, G]]]])
+
+class Test {
+  type Id[A] = A
+  new Foo(Some(new C(new Foo[Option, Id](None))))
+}


### PR DESCRIPTION
Instead throw a `NoCommonType` exception and catch it when solving
type variables to avoid a compiler crash when type inference
cannot satisfy all constraints.

Fixes scala/bug#10514 by turning the crash into an error message.

scala/bug#10519 and scala/bug#5559 also produce error messages,
but are not fixed IMO, because it looks like they should compile.