### PR TITLE
Support implicitNotFound on parameters

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1595,7 +1595,7 @@ trait Implicits {
   }
 
   class ImplicitAnnotationMsg(f: Symbol => Option[String], clazz: Symbol, annotationName: String) {
-    def unapply(sym: Symbol): Option[(Message)] = f(sym) match {
+    def unapply(sym: Symbol): Option[Message] = f(sym) match {
       case Some(m) => Some(new Message(sym, m, annotationName))
       case None if sym.isAliasType =>
         // perform exactly one step of dealiasing
@@ -1628,25 +1628,65 @@ trait Implicits {
           // #3915: need to quote replacement string since it may include $'s (such as the interpreter's $iw)
       })
 
-    private lazy val typeParamNames: List[String] = sym.typeParams.map(_.decodedName)
+    def referencedTypeParams: List[String] = Intersobralator.findAllMatchIn(msg).map(_.group(1)).distinct.toList
+
+    private def symTypeParamNames: List[String] = sym.typeParams.map(_.decodedName)
+
+    def lookupTypeParam(name: String): Symbol = {
+      val n = newTypeName(name)
+      var r: Symbol = NoSymbol
+      var o = sym.owner
+      while (r == NoSymbol && o != NoSymbol) {
+        o.typeParams.find(_.name == n) match {
+          case Some(p) => r = p
+          case _ =>
+            do { o = o.owner } while (!(o.isClass || o.isMethod || o == NoSymbol))
+        }
+      }
+      r
+    }
+
     private def typeArgsAtSym(paramTp: Type) = paramTp.baseType(sym).typeArgs
 
-    def format(paramName: Name, paramTp: Type): String = format(typeArgsAtSym(paramTp) map (_.toString))
+    def formatDefSiteMessage(paramTp: Type): String =
+      formatDefSiteMessage(typeArgsAtSym(paramTp) map (_.toString))
 
-    def format(typeArgs: List[String]): String =
-      interpolate(msg, Map((typeParamNames zip typeArgs): _*)) // TODO: give access to the name and type of the implicit argument, etc?
+    def formatDefSiteMessage(typeArgs: List[String]): String =
+      interpolate(msg, Map(symTypeParamNames zip typeArgs: _*))
+
+    def formatParameterMessage(fun: Tree): String = {
+      val paramNames = referencedTypeParams
+      val paramSyms = paramNames.map(lookupTypeParam).filterNot(_ == NoSymbol)
+      val paramTypeRefs = paramSyms.map(sym => typeRef(NoPrefix, sym, sym.typeParams.map(_ => WildcardType)))
+      val prefix = fun match {
+        case TypeApply(Select(qual, _), _) => qual.tpe
+        case Select(qual, _) => qual.tpe
+        case _ => NoType
+      }
+      val argTypes1 = if (prefix == NoType) paramTypeRefs else paramTypeRefs.map(t => t.asSeenFrom(prefix, fun.symbol.owner))
+      val argTypes2 = fun match {
+        case TypeApply(_, targs) => argTypes1.map(_.instantiateTypeParams(fun.symbol.info.typeParams, targs.map(_.tpe)))
+        case _ => argTypes1
+      }
+      val argTypes = argTypes2.map(_.toString)
+      interpolate(msg, Map(paramNames zip argTypes: _*))
+    }
 
     def validate: Option[String] = {
-      val refs  = Intersobralator.findAllMatchIn(msg).map(_ group 1).toSeq.distinct
-      val decls = typeParamNames.toSeq.distinct
+      val refs  = referencedTypeParams
+      val isMessageOnParameter = sym.isParameter
+      val decls =
+        if (isMessageOnParameter) referencedTypeParams.filterNot(p => lookupTypeParam(p) == NoSymbol)
+        else symTypeParamNames.distinct
 
-      (refs.diff(decls)) match {
+      refs.diff(decls) match {
         case s if s.isEmpty => None
         case unboundNames   =>
           val singular = unboundNames.size == 1
           val ess      = if (singular) "" else "s"
           val bee      = if (singular) "is" else "are"
-          Some(s"The type parameter$ess ${unboundNames mkString ", "} referenced in the message of the @$annotationName annotation $bee not defined by $sym.")
+          val where    = if (isMessageOnParameter) s"in scope" else s"defined by $sym"
+          Some(s"The type parameter$ess ${unboundNames mkString ", "} referenced in the message of the @$annotationName annotation $bee not $where.")
       }
     }
   }

--- a/src/library/scala/annotation/implicitNotFound.scala
+++ b/src/library/scala/annotation/implicitNotFound.scala
@@ -10,10 +10,44 @@ package scala.annotation
 
 /**
  * To customize the error message that's emitted when an implicit of type
- * C[T1,..., TN] cannot be found, annotate the class C with @implicitNotFound.
- * Assuming C has type parameters X1,..., XN, the error message will be the
- * result of replacing all occurrences of ${Xi} in the string msg with the
- * string representation of the corresponding type argument Ti. *
+ * `C[T1,..., TN]` cannot be found, annotate the class `C` with `@implicitNotFound`.
+ * Assuming `C` has type parameters `X1, ..., XN`, the error message will be the
+ * result of replacing all occurrences of `${Xi}` in the string `msg` with the
+ * string representation of the corresponding type argument `Ti`.
+ *
+ * The annotation can also be attached to implicit parameters. In this case, `${Xi}`
+ * can refer to type parameters in the current scope. The `@implicitNotFound` message
+ * on the parameter takes precedence over the one on the parameter's type.
+ *
+ * {{{
+ *   import scala.annotation.implicitNotFound
+ *
+ *   @implicitNotFound("Could not find an implicit C[${T}, ${U}]")
+ *   class C[T, U]
+ *
+ *   class K[A] {
+ *     def m[B](implicit c: C[List[A], B]) = 0
+ *     def n[B](implicit @implicitNotFound("Specific message for C of list of ${A} and ${B}") c: C[List[A], B]) = 1
+ *   }
+ *
+ *   object Test {
+ *     val k = new K[Int]
+ *     k.m[String]
+ *     k.n[String]
+ *   }
+ * }}}
+ *
+ * The compiler issues the following error messages:
+ *
+ * <pre>
+ * Test.scala:13: error: Could not find an implicit C[List[Int], String]
+ *   k.m[String]
+ *      ^
+ * Test.scala:14: error: Specific message for C of list of Int and String
+ *   k.n[String]
+ *      ^
+ * </pre>
+ *
  *
  * @author Adriaan Moors
  * @since 2.8.1

--- a/test/files/neg/t2462b.check
+++ b/test/files/neg/t2462b.check
@@ -6,6 +6,15 @@ t2462b.scala:9: warning: Invalid implicitNotFound message for trait Meh2 in pack
 The type parameter Elem referenced in the message of the @implicitNotFound annotation is not defined by trait Meh2.
 trait Meh2[-From, +To]
       ^
+t2462b.scala:13: warning: Invalid implicitNotFound message for value theC:
+The type parameter Uuh referenced in the message of the @implicitNotFound annotation is not in scope.
+  def m[Aaa](implicit @implicitNotFound("I see no C[${Uuh}]") theC: C[Aaa]) = ???
+                                                              ^
+t2462b.scala:19: warning: Invalid implicitNotFound message for value i:
+The type parameters XX, ZZ, Nix referenced in the message of the @implicitNotFound annotation are not in scope.
+    def m[S](implicit @implicitNotFound("${X} ${Y} ${ Z } ${R} ${S} -- ${XX} ${ZZ} ${ Nix }") i: Int) = ???
+                                                                                              ^
+warning: there were two feature warnings; re-run with -feature for details
 error: No warnings can be incurred under -Xfatal-warnings.
-two warnings found
+5 warnings found
 one error found

--- a/test/files/neg/t2462b.scala
+++ b/test/files/neg/t2462b.scala
@@ -7,3 +7,15 @@ trait Meh[-From, +To]
 
 @implicitNotFound(msg = "Cannot construct a collection of type ${To} ${Elem}.")
 trait Meh2[-From, +To]
+
+class C[T]
+trait T {
+  def m[Aaa](implicit @implicitNotFound("I see no C[${Uuh}]") theC: C[Aaa]) = ???
+  def n[Aaa](implicit @implicitNotFound("I see no C[${Aaa}]") theC: C[Aaa]) = ???
+}
+
+trait U[X, Y[_], Z[_, ZZ]] {
+  class I[R] {
+    def m[S](implicit @implicitNotFound("${X} ${Y} ${ Z } ${R} ${S} -- ${XX} ${ZZ} ${ Nix }") i: Int) = ???
+  }
+}

--- a/test/files/neg/t2462c.check
+++ b/test/files/neg/t2462c.check
@@ -10,7 +10,7 @@ t2462c.scala:33: error: No C of Foo[Int]
 t2462c.scala:36: error: I see no C[Foo[Int]]
   h[Foo[Int]]
    ^
-t2462c.scala:40: error: String List[?] List[C[_]] Int Option[Long] -- .
+t2462c.scala:40: error: String List [?T0, ZZ] -> List[C[_]] Int Option[Long] -- .
   i.m[Option[Long]]
      ^
 5 errors found

--- a/test/files/neg/t2462c.check
+++ b/test/files/neg/t2462c.check
@@ -1,7 +1,16 @@
-t2462c.scala:18: error: No C of X$Y
+t2462c.scala:24: error: No C of X$Y
   f[X$Y]
    ^
-t2462c.scala:24: error: No C of Foo[Int]
+t2462c.scala:30: error: No C of Foo[Int]
   f[Foo[Int]]
    ^
-two errors found
+t2462c.scala:33: error: No C of Foo[Int]
+  g[Foo[Int]]
+   ^
+t2462c.scala:36: error: I see no C[Foo[Int]]
+  h[Foo[Int]]
+   ^
+t2462c.scala:40: error: String List[?] List[C[_]] Int Option[Long] -- .
+  i.m[Option[Long]]
+     ^
+5 errors found

--- a/test/files/neg/t2462c.scala
+++ b/test/files/neg/t2462c.scala
@@ -13,6 +13,12 @@ trait X$$$$Y
 
 trait Foo[A]
 
+trait U[X, Y[_], Z[_, ZZ]] {
+  class I[R] {
+    def m[S](implicit @implicitNotFound("${X} ${Y} ${ Z } ${R} ${S} -- ${XX}.") i: Int) = ???
+  }
+}
+
 class Test {
   def f[A: C] = ???
   f[X$Y]
@@ -22,4 +28,14 @@ class Test {
   f[X$$$$Y]
  */
   f[Foo[Int]]
+
+  def g[Aaa](implicit theC: C[Aaa]) = ???
+  g[Foo[Int]]
+
+  def h[Aaa](implicit @implicitNotFound("I see no C[${Aaa}]") theC: C[Aaa]) = ???
+  h[Foo[Int]]
+
+  val u = new U[String, List, ({type T[A, _] = List[C[_]]})#T] { }
+  val i = new u.I[Int]
+  i.m[Option[Long]]
 }


### PR DESCRIPTION
This allows a more specific message for individual implicit parameters
that are not found.

This allows improving error message, for example in overloading
resolution:

```
scala> trait Iterable[A] { def map[B](f: A => B): Iterable[B] }
scala> trait SortedSet[A] { def map[B: Ordering](f: A => B): SortedSet[B] }

scala> def t(s: SortedSet[Int]) = s.map(x => x) // OK
t: (s: SortedSet[Int])SortedSet[Int]

scala> def t[T](s: SortedSet[T]) = s.map(x => x) // Confusing error
                                        ^
       error: No implicit Ordering defined for T.
```

better:

```
scala> trait SortedSet[A] { def map[B](f: A => B)(implicit @annotation.implicitNotFound("No implicit Ordering[${B}] found to build a SortedSet[${B}]. You can build an unordered Set[${B}] by calling `unsorted` before `map`.") ord: Ordering[B]): SortedSet[B] }
defined trait SortedSet

scala> def t[T](s: SortedSet[T]) = s.map(x => x)
                                        ^
       error: No implicit Ordering[T] found to build a SortedSet[T]. You can build an unordered Set[T] by calling `unsorted` before `map`.
```