### PR TITLE
Remove statistics reporting code from some hot paths

### DIFF
--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -188,8 +188,6 @@ abstract class SymbolTable extends macros.Universe
 
   final def atPhaseStack: List[Phase] = phStack.toList
   final def phase: Phase = {
-    if (StatisticsStatics.areSomeColdStatsEnabled)
-      statistics.incCounter(statistics.phaseCounter)
     ph
   }
 
@@ -462,7 +460,6 @@ abstract class SymbolTable extends macros.Universe
 trait SymbolTableStats {
   self: TypesStats with Statistics =>
 
-  val phaseCounter = newCounter("#phase calls")
   // Defined here because `SymbolLoaders` is defined in `scala.tools.nsc`
   // and only has access to the `statistics` definition from `scala.reflect`.
   val classReadNanos = newSubTimer("time classfilereading", typerNanos)

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -769,7 +769,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     }
 
     final def flags: Long = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(flagsCount)
       val fs = _rawflags & phase.flagMask
       (fs | ((fs & LateFlags) >>> LateShift)) & ~((fs & AntiFlags) >>> AntiShift)
     }
@@ -1199,7 +1198,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      * `assertOwner` aborts compilation immediately if called on NoSymbol.
      */
     def owner: Symbol = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(ownerCount)
       rawowner
     }
     final def safeOwner: Symbol   = if (this eq NoSymbol) NoSymbol else owner
@@ -2785,7 +2783,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     private[this] var _rawname: TermName = initName
     def rawname = _rawname
     def name = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(nameCount)
       _rawname
     }
     override def name_=(name: Name) {
@@ -2917,13 +2914,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def moduleClass = referenced
 
     override def owner = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(ownerCount)
       // a non-static module symbol gets the METHOD flag in uncurry's info transform -- see isModuleNotMethod
       if (!isMethod && needsFlatClasses) rawowner.owner
       else rawowner
     }
     override def name: TermName = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(nameCount)
       if (!isMethod && needsFlatClasses) {
         if (flatname eq null)
           flatname = nme.flattenedName(rawowner.name, rawname)
@@ -3055,7 +3050,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     def rawname = _rawname
     def name = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(nameCount)
       _rawname
     }
     final def asNameType(n: Name) = n.toTypeName
@@ -3342,12 +3336,10 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     }
 
     override def owner: Symbol = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(ownerCount)
       if (needsFlatClasses) rawowner.owner else rawowner
     }
 
     override def name: TypeName = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(nameCount)
       if (needsFlatClasses) {
         if (flatname eq null)
           flatname = tpnme.flattenedName(rawowner.name, rawname)
@@ -3761,7 +3753,4 @@ trait SymbolsStats {
   val symbolsCount        = newView("#symbols")(symbolTable.getCurrentSymbolIdCount)
   val typeSymbolCount     = newCounter("#type symbols")
   val classSymbolCount    = newCounter("#class symbols")
-  val flagsCount          = newCounter("#flags ops")
-  val ownerCount          = newCounter("#owner ops")
-  val nameCount           = newCounter("#name ops")
 }


### PR DESCRIPTION
Recent changes to the implenentation of -Ystatistics had the goal of
having zero overhead in the common case: when statistics had never been
enabled in any instance of Global.

However, I still see evidence of method profile samples in
`areSomeColdStatsEnabled` via `phase`, `flags`, `lookupEntry` and `owner`.

I can't convince myself if this is profiler noise or a bona fide cost.
This commit doesn't show a clear speedup in our benchmarks, for example.

I haven't found those particular counters to be useful in directing performance profiling. Let's remove this a moving part the way we reason about the performance of these hot methods.