### PR TITLE
Propagate fatal errors during macro expansion.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -13,6 +13,7 @@ import scala.reflect.internal.util.ListOfNil
 import scala.reflect.macros.runtime.{AbortMacroException, MacroRuntimes}
 import scala.reflect.macros.compiler.DefaultMacroCompiler
 import scala.tools.reflect.FastTrack
+import scala.util.control.NonFatal
 import Fingerprint._
 
 /**
@@ -815,7 +816,8 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
               case ex: AbortMacroException => MacroGeneratedAbort(expandee, ex)
               case ex: ControlThrowable => throw ex
               case ex: TypeError => MacroGeneratedTypeError(expandee, ex)
-              case _ => MacroGeneratedException(expandee, realex)
+              case NonFatal(_) => MacroGeneratedException(expandee, realex)
+              case fatal => throw fatal
             }
         } finally {
           expandee.removeAttachment[MacroRuntimeAttachment]

--- a/test/files/run/macro-sip19-revised/Impls_Macros_1.scala
+++ b/test/files/run/macro-sip19-revised/Impls_Macros_1.scala
@@ -4,6 +4,10 @@ object Macros {
   def impl(c: Context) = {
     import c.universe._
 
+    val thisMacro = c.macroApplication.symbol
+    val depth = c.enclosingMacros.count(_.macroApplication.symbol == thisMacro)
+    if (depth > 1) c.abort(c.enclosingPosition, "") // avoid StackOverflow
+
     val inscope = c.inferImplicitValue(c.mirror.staticClass("SourceLocation").toType)
     val outer = c.Expr[SourceLocation](if (!inscope.isEmpty) inscope else Literal(Constant(null)))
 

--- a/test/files/run/t10552/Macros_1.scala
+++ b/test/files/run/t10552/Macros_1.scala
@@ -1,0 +1,7 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+object A {
+  def f: Unit = macro f_impl
+  implicit def f_impl(c: whitebox.Context): c.Expr[Unit] =
+    throw new OutOfMemoryError("OOM") with scala.util.control.NoStackTrace
+}

--- a/test/files/run/t10552/Test_2.scala
+++ b/test/files/run/t10552/Test_2.scala
@@ -1,0 +1,14 @@
+import scala.tools.partest._
+
+object Test extends DirectTest {
+  override def extraSettings: String = "-usejavacp -Ystop-after:typer"
+
+  def code = "class C { A.f }"
+
+  def show(): Unit = try {
+    compile()
+    throw new Error("Expected OutOfMemoryError")
+  } catch {
+    case e: OutOfMemoryError if e.getMessage == "OOM" =>
+  }
+}


### PR DESCRIPTION
Fixes scala/bug#10552. Previously, fatal errors got swallowed during macro
expansion.  In the case of implicit blackbox macros, a fatal error (for
example OutOfMemoryException) got reported with the message "exception
during macro expansion". For implicit whitebox macros the fatal error is
not even reported unless -Xlog-implicits is enabled. By default, the
user only sees a cryptic "implicit not found" error message.  See #10649.

This commit changes the error handling of exceptions during macro
expansion to propagate fatal errors. Now fatal errors are left uncaught
and crash compilation with a full stack trace instead of getting
swallowed.

```
error: java.lang.OutOfMemoryError
    at Macros$BlackBox$.materializeImpl(so.scala:8)
```

This change caused the sip-19-macro-revised partest to fail since it
previously relied on triggering a stack overflow to fail expansion if
another implicit SourceContext was in scope. Instead, the test now
guards against infinite recursion itself.