### PR TITLE
Remove val in for comprehension under -Xsource:2.14

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1826,7 +1826,7 @@ self =>
      *  Enumerators ::= Generator {semi Enumerator}
      *  Enumerator  ::=  Generator
      *                |  Guard
-     *                |  val Pattern1 `=' Expr
+     *                |  Pattern1 `=' Expr
      *  }}}
      */
     def enumerators(): List[Tree] = {
@@ -1858,8 +1858,13 @@ self =>
       val hasEq = in.token == EQUALS
 
       if (hasVal) {
-        if (hasEq) deprecationWarning(in.offset, "val keyword in for comprehension is deprecated", "2.10.0")
-        else syntaxError(in.offset, "val in for comprehension must be followed by assignment")
+        def msg(what: String, instead: String): String = s"`val` keyword in for comprehension is $what: $instead"
+        if (hasEq) {
+          val without = "instead, bind the value without `val`"
+          if (settings.isScala214) syntaxError(in.offset, msg("unsupported", without))
+          else deprecationWarning(in.offset, msg("deprecated", without), "2.10.0")
+        }
+        else syntaxError(in.offset, msg("unsupported", "just remove `val`"))
       }
 
       if (hasEq && eqOK) in.nextToken()

--- a/test/files/neg/for-comprehension-old.check
+++ b/test/files/neg/for-comprehension-old.check
@@ -1,25 +1,25 @@
-for-comprehension-old.scala:3: warning: val keyword in for comprehension is deprecated
+for-comprehension-old.scala:3: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
   for (x <- 1 to 5 ; val y = x) yield x+y       // fail
                            ^
-for-comprehension-old.scala:5: warning: val keyword in for comprehension is deprecated
+for-comprehension-old.scala:5: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
                                ^
-for-comprehension-old.scala:8: warning: val keyword in for comprehension is deprecated
+for-comprehension-old.scala:8: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
   for (z <- 1 to 2 ; x <- 1 to 5 ; val y = x) yield x+y       // fail
                                          ^
-for-comprehension-old.scala:10: warning: val keyword in for comprehension is deprecated
+for-comprehension-old.scala:10: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
                                              ^
-for-comprehension-old.scala:4: error: val in for comprehension must be followed by assignment
+for-comprehension-old.scala:4: error: `val` keyword in for comprehension is unsupported: just remove `val`
   for (val x <- 1 to 5 ; y = x) yield x+y       // fail
              ^
-for-comprehension-old.scala:5: error: val in for comprehension must be followed by assignment
+for-comprehension-old.scala:5: error: `val` keyword in for comprehension is unsupported: just remove `val`
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
              ^
-for-comprehension-old.scala:9: error: val in for comprehension must be followed by assignment
+for-comprehension-old.scala:9: error: `val` keyword in for comprehension is unsupported: just remove `val`
   for (z <- 1 to 2 ; val x <- 1 to 5 ; y = x) yield x+y       // fail
                            ^
-for-comprehension-old.scala:10: error: val in for comprehension must be followed by assignment
+for-comprehension-old.scala:10: error: `val` keyword in for comprehension is unsupported: just remove `val`
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
                            ^
 four warnings found

--- a/test/files/neg/for-comprehension-val.check
+++ b/test/files/neg/for-comprehension-val.check
@@ -1,0 +1,25 @@
+for-comprehension-val.scala:3: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+  for (x <- 1 to 5 ; val y = x) yield x+y       // fail
+                           ^
+for-comprehension-val.scala:4: error: `val` keyword in for comprehension is unsupported: just remove `val`
+  for (val x <- 1 to 5 ; y = x) yield x+y       // fail
+             ^
+for-comprehension-val.scala:5: error: `val` keyword in for comprehension is unsupported: just remove `val`
+  for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
+             ^
+for-comprehension-val.scala:5: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+  for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
+                               ^
+for-comprehension-val.scala:8: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+  for (z <- 1 to 2 ; x <- 1 to 5 ; val y = x) yield x+y       // fail
+                                         ^
+for-comprehension-val.scala:9: error: `val` keyword in for comprehension is unsupported: just remove `val`
+  for (z <- 1 to 2 ; val x <- 1 to 5 ; y = x) yield x+y       // fail
+                           ^
+for-comprehension-val.scala:10: error: `val` keyword in for comprehension is unsupported: just remove `val`
+  for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
+                           ^
+for-comprehension-val.scala:10: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+  for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
+                                             ^
+8 errors found

--- a/test/files/neg/for-comprehension-val.flags
+++ b/test/files/neg/for-comprehension-val.flags
@@ -1,0 +1,1 @@
+-deprecation -Xsource:2.14

--- a/test/files/neg/for-comprehension-val.scala
+++ b/test/files/neg/for-comprehension-val.scala
@@ -1,0 +1,11 @@
+class A {
+  for (x <- 1 to 5 ; y = x) yield x+y           // ok
+  for (x <- 1 to 5 ; val y = x) yield x+y       // fail
+  for (val x <- 1 to 5 ; y = x) yield x+y       // fail
+  for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
+
+  for (z <- 1 to 2 ; x <- 1 to 5 ; y = x) yield x+y           // ok
+  for (z <- 1 to 2 ; x <- 1 to 5 ; val y = x) yield x+y       // fail
+  for (z <- 1 to 2 ; val x <- 1 to 5 ; y = x) yield x+y       // fail
+  for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
+}


### PR DESCRIPTION
The use of `val` keyword in for comprehension has been deprecated since 2.10.
Ref https://github.com/scala/bug/issues/4918
Ref https://github.com/scala/scala/commit/cda4650d4d6486d6dc07766cd00c92d4712cca3f.

1. This improves the deprecation warning
2. This also removes it under -Xsource:2.14