### PR TITLE
Remove early type members under -Xsource:2.14

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2989,7 +2989,9 @@ self =>
       case vdef @ ValDef(mods, _, _, _) if !mods.isDeferred =>
         copyValDef(vdef)(mods = mods | Flags.PRESUPER)
       case tdef @ TypeDef(mods, name, tparams, rhs) =>
-        deprecationWarning(tdef.pos.point, "early type members are deprecated. Move them to the regular body: the semantics are the same.", "2.11.0")
+        def msg(what: String): String = s"early type members are $what: move them to the regular body; the semantics are the same"
+        if (settings.isScala214) syntaxError(tdef.pos.point, msg("unsupported"))
+        else deprecationWarning(tdef.pos.point, msg("deprecated"), "2.11.0")
         treeCopy.TypeDef(tdef, mods | Flags.PRESUPER, name, tparams, rhs)
       case docdef @ DocDef(comm, rhs) =>
         treeCopy.DocDef(docdef, comm, rhs)

--- a/test/files/neg/early-type-defs.check
+++ b/test/files/neg/early-type-defs.check
@@ -1,0 +1,4 @@
+early-type-defs.scala:1: error: early type members are unsupported: move them to the regular body; the semantics are the same
+object Test extends { type A1 = Int } with App
+                           ^
+one error found

--- a/test/files/neg/early-type-defs.flags
+++ b/test/files/neg/early-type-defs.flags
@@ -1,0 +1,1 @@
+-deprecation -Xsource:2.14

--- a/test/files/neg/early-type-defs.scala
+++ b/test/files/neg/early-type-defs.scala
@@ -1,0 +1,1 @@
+object Test extends { type A1 = Int } with App

--- a/test/files/neg/t2796.check
+++ b/test/files/neg/t2796.check
@@ -1,4 +1,4 @@
-t2796.scala:11: warning: early type members are deprecated. Move them to the regular body: the semantics are the same.
+t2796.scala:11: warning: early type members are deprecated: move them to the regular body; the semantics are the same
   type X = Int                       // warn
        ^
 t2796.scala:7: warning: Implementation restriction: early definitions in traits are not initialized before the super class is initialized.

--- a/test/files/run/deprecate-early-type-defs.check
+++ b/test/files/run/deprecate-early-type-defs.check
@@ -1,3 +1,3 @@
-deprecate-early-type-defs.scala:1: warning: early type members are deprecated. Move them to the regular body: the semantics are the same.
+deprecate-early-type-defs.scala:1: warning: early type members are deprecated: move them to the regular body; the semantics are the same
 object Test extends { type T = Int } with App
                            ^


### PR DESCRIPTION
Ref https://github.com/scala/bug/issues/3572
> I shudder to think of the possible consequences this could have for type soundness.
>
> We agreed to deprecate them instead.

Ref https://github.com/scala/scala/pull/2861