### PR TITLE
Fix error message for overriding type alias

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -336,7 +336,7 @@ abstract class RefChecks extends Transform {
           analyzer.foundReqMsg(pair.lowClassBound, pair.highClassBound)
         )
 
-        val indent = " "
+        val indent = "  "
         def overrideErrorMsg(msg: String): String = {
           val isConcreteOverAbstract =
             (other.owner isSubClass member.owner) && other.isDeferred && !member.isDeferred

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -336,20 +336,19 @@ abstract class RefChecks extends Transform {
           analyzer.foundReqMsg(pair.lowClassBound, pair.highClassBound)
         )
 
+        val indent = " "
         def overrideErrorMsg(msg: String): String = {
           val isConcreteOverAbstract =
             (other.owner isSubClass member.owner) && other.isDeferred && !member.isDeferred
           val addendum =
             if (isConcreteOverAbstract)
-              ";\n (Note that %s is abstract,\n  and is therefore overridden by concrete %s)".format(
-                infoStringWithLocation(other),
-                infoStringWithLocation(member)
-              )
+              s";\n${indent}(note that ${infoStringWithLocation(other)} is abstract,\n" +
+              s"${indent}and is therefore overridden by concrete ${infoStringWithLocation(member)})"
             else if (settings.debug)
               analyzer.foundReqMsg(member.tpe, other.tpe)
             else ""
 
-          s"overriding ${infoStringWithLocation(other)};\n ${infoString(member)} $msg$addendum"
+          s"overriding ${infoStringWithLocation(other)};\n$indent$msg$addendum"
         }
         def emitOverrideError(fullmsg: String) {
           if (member.owner == clazz) reporter.error(member.pos, fullmsg)
@@ -358,14 +357,15 @@ abstract class RefChecks extends Transform {
 
         def overrideError(msg: String) {
           if (noErrorType)
-            emitOverrideError(overrideErrorMsg(msg))
+            emitOverrideError(overrideErrorMsg(infoString(member) + " " + msg))
         }
 
         def overrideTypeError() {
           if (noErrorType) {
             emitOverrideError(
               if (member.isModule && other.isModule) objectOverrideErrorMsg
-              else overrideErrorMsg("has incompatible type")
+              else if (!other.isDeferred && other.isAliasType) overrideErrorMsg(s"overriding concrete type alias ${infoString(member)} is not allowed except when equivalent")
+              else overrideErrorMsg(s"${infoString(member)} has incompatible type")
             )
           }
         }
@@ -431,9 +431,10 @@ abstract class RefChecks extends Transform {
             // the default getter: one default getter might sometimes override, sometimes not. Example in comment on ticket.
               if (isNeitherInClass && !(other.owner isSubClass member.owner))
                 emitOverrideError(
-                  clazz + " inherits conflicting members:\n  "
-                    + infoStringWithLocation(other) + "  and\n  " + infoStringWithLocation(member)
-                    + "\n(Note: this can be resolved by declaring an override in " + clazz + ".)"
+                  clazz + " inherits conflicting members:\n"
+                    + indent + infoStringWithLocation(other) + " and\n"
+                    + indent + infoStringWithLocation(member) + "\n"
+                    + indent + s"(note: this can be resolved by declaring an `override' in $clazz.)"
                 )
               else
                 overrideError("needs `override' modifier")

--- a/test/files/neg/accesses.check
+++ b/test/files/neg/accesses.check
@@ -1,17 +1,17 @@
 accesses.scala:23: error: overriding method f2 in class A of type ()Unit;
- method f2 has weaker access privileges; it should not be private
+  method f2 has weaker access privileges; it should not be private
   private def f2(): Unit = ()
               ^
 accesses.scala:24: error: overriding method f3 in class A of type ()Unit;
- method f3 has weaker access privileges; it should be at least protected
+  method f3 has weaker access privileges; it should be at least protected
   private[p2] def f3(): Unit = ()
                   ^
 accesses.scala:25: error: overriding method f4 in class A of type ()Unit;
- method f4 has weaker access privileges; it should be at least private[p1]
+  method f4 has weaker access privileges; it should be at least private[p1]
   private[p2] def f4(): Unit
                   ^
 accesses.scala:26: error: overriding method f5 in class A of type ()Unit;
- method f5 has weaker access privileges; it should be at least protected[p1]
+  method f5 has weaker access privileges; it should be at least protected[p1]
   protected[p2] def f5(): Unit
                     ^
 four errors found

--- a/test/files/neg/accesses2.check
+++ b/test/files/neg/accesses2.check
@@ -1,12 +1,12 @@
 accesses2.scala:6: error: overriding method f2 in class A of type ()Int;
- method f2 has weaker access privileges; it should not be private
+  method f2 has weaker access privileges; it should not be private
     private def f2(): Int = 1
                 ^
 accesses2.scala:5: error: class B1 needs to be abstract, since method f2 in class A of type ()Int is not defined
   class B1 extends A {
         ^
 accesses2.scala:9: error: overriding method f2 in class A of type ()Int;
- method f2 has weaker access privileges; it should not be private
+  method f2 has weaker access privileges; it should not be private
     private def f2(): Int = 1
                 ^
 three errors found

--- a/test/files/neg/lazy-override.check
+++ b/test/files/neg/lazy-override.check
@@ -1,9 +1,9 @@
 lazy-override.scala:11: error: overriding value x in class A of type Int;
- lazy value x cannot override a concrete non-lazy value
+  lazy value x cannot override a concrete non-lazy value
     override lazy val x: Int = { print("/*B.x*/"); 3 }
                       ^
 lazy-override.scala:13: error: overriding lazy value y in class A of type Int;
- value y must be declared lazy to override a concrete lazy value
+  value y must be declared lazy to override a concrete lazy value
     override val y: Int = { print("/*B.y*/"); 3 }
                  ^
 two errors found

--- a/test/files/neg/macro-override-macro-overrides-abstract-method-a.check
+++ b/test/files/neg/macro-override-macro-overrides-abstract-method-a.check
@@ -1,5 +1,5 @@
 Impls_Macros_1.scala:12: error: overriding method foo in trait Foo of type (x: Int)Int;
- macro method foo cannot be used here - term macros cannot override abstract methods
+  macro method foo cannot be used here - term macros cannot override abstract methods
   def foo(x: Int): Int = macro Impls.impl
       ^
 one error found

--- a/test/files/neg/macro-override-macro-overrides-abstract-method-b.check
+++ b/test/files/neg/macro-override-macro-overrides-abstract-method-b.check
@@ -1,11 +1,11 @@
 Test_2.scala:3: error: <$anon: C with A> inherits conflicting members:
- macro method t in trait C of type ()Unit and
- method t in trait A of type ()Unit
- (note: this can be resolved by declaring an `override' in <$anon: C with A>.)
+  macro method t in trait C of type ()Unit and
+  method t in trait A of type ()Unit
+  (note: this can be resolved by declaring an `override' in <$anon: C with A>.)
   val c2 = new C with A {}
                ^
 Test_2.scala:5: error: overriding macro method t in trait C of type ()Unit;
- method t cannot be used here - only term macros can override term macros
+  method t cannot be used here - only term macros can override term macros
   val c4 = new C with A { override def t(): Unit = () }
                                        ^
 two errors found

--- a/test/files/neg/macro-override-macro-overrides-abstract-method-b.check
+++ b/test/files/neg/macro-override-macro-overrides-abstract-method-b.check
@@ -1,7 +1,7 @@
 Test_2.scala:3: error: <$anon: C with A> inherits conflicting members:
-  macro method t in trait C of type ()Unit  and
-  method t in trait A of type ()Unit
-(Note: this can be resolved by declaring an override in <$anon: C with A>.)
+ macro method t in trait C of type ()Unit and
+ method t in trait A of type ()Unit
+ (note: this can be resolved by declaring an `override' in <$anon: C with A>.)
   val c2 = new C with A {}
                ^
 Test_2.scala:5: error: overriding macro method t in trait C of type ()Unit;

--- a/test/files/neg/macro-override-method-overrides-macro.check
+++ b/test/files/neg/macro-override-method-overrides-macro.check
@@ -1,5 +1,5 @@
 Macros_Test_2.scala:8: error: overriding macro method foo in class B of type (x: String)Unit;
- method foo cannot be used here - only term macros can override term macros
+  method foo cannot be used here - only term macros can override term macros
   override def foo(x: String): Unit = println("fooDString")
                ^
 one error found

--- a/test/files/neg/names-defaults-neg-ref.check
+++ b/test/files/neg/names-defaults-neg-ref.check
@@ -10,7 +10,7 @@ The members with defaults are defined in class C and class B.
 class C extends B {
       ^
 names-defaults-neg-ref.scala:21: error: overriding method bar$default$1 in class B of type => String;
- method bar$default$1 has incompatible type
+  method bar$default$1 has incompatible type
   def bar(i: Int = 129083) = i
           ^
 four errors found

--- a/test/files/neg/override-concrete-type.check
+++ b/test/files/neg/override-concrete-type.check
@@ -1,0 +1,9 @@
+override-concrete-type.scala:13: error: overriding type A1 in class Foo, which equals Something;
+ overriding concrete type alias type A1 is not allowed except when equivalent
+  override type A1 = Something with Serializable
+                ^
+override-concrete-type.scala:14: error: overriding type A2 in class Foo with bounds <: Something;
+ type A2 has incompatible type
+  override type A2 = Any
+                ^
+two errors found

--- a/test/files/neg/override-concrete-type.check
+++ b/test/files/neg/override-concrete-type.check
@@ -1,9 +1,9 @@
 override-concrete-type.scala:13: error: overriding type A1 in class Foo, which equals Something;
- overriding concrete type alias type A1 is not allowed except when equivalent
+  overriding concrete type alias type A1 is not allowed except when equivalent
   override type A1 = Something with Serializable
                 ^
 override-concrete-type.scala:14: error: overriding type A2 in class Foo with bounds <: Something;
- type A2 has incompatible type
+  type A2 has incompatible type
   override type A2 = Any
                 ^
 two errors found

--- a/test/files/neg/override-concrete-type.scala
+++ b/test/files/neg/override-concrete-type.scala
@@ -1,0 +1,15 @@
+class Something
+
+trait X {
+  type A1
+}
+
+class Foo extends X {
+  type A1 = Something
+  type A2 <: Something
+}
+
+class Bar extends Foo {
+  override type A1 = Something with Serializable
+  override type A2 = Any
+}

--- a/test/files/neg/override-object-flag.check
+++ b/test/files/neg/override-object-flag.check
@@ -1,5 +1,5 @@
 override-object-flag.scala:3: error: overriding object Foo in trait A;
- object Foo cannot override final member
+  object Foo cannot override final member
 trait B extends A  { override object Foo }
                                      ^
 one error found

--- a/test/files/neg/override-object-no.check
+++ b/test/files/neg/override-object-no.check
@@ -11,7 +11,7 @@ an overriding object must conform to the overridden object's class bound;
   trait Quux2 extends Quux1 { override object Bar { def g = "abc" } } // err
                                               ^
 override-object-no.scala:25: error: overriding object Bar in trait Quux3;
- object Bar cannot override final member
+  object Bar cannot override final member
   trait Quux4 extends Quux3 { override object Bar  } // err
                                               ^
 override-object-no.scala:43: error: overriding object A in class Foo with object A in class P2:
@@ -21,11 +21,11 @@ an overriding object must conform to the overridden object's class bound;
     override object A extends Bar[List[String]]  // err
                     ^
 override-object-no.scala:52: error: overriding method x in trait A of type => SI9574.Foo.type;
- method x has incompatible type
+  method x has incompatible type
   trait B extends A { def x: Bar.type } // should not compile (scala/bug#9574)
                           ^
 override-object-no.scala:53: error: overriding method x in trait A of type => SI9574.Foo.type;
- object x has incompatible type
+  object x has incompatible type
   trait C extends A { override object x }
                                       ^
 6 errors found

--- a/test/files/neg/override.check
+++ b/test/files/neg/override.check
@@ -1,5 +1,5 @@
 override.scala:9: error: overriding type T in trait A with bounds >: Int <: Int;
- type T in trait B with bounds >: String <: String has incompatible type
+  type T in trait B with bounds >: String <: String has incompatible type
   lazy val x : A with B = {println(""); x}
                ^
 one error found

--- a/test/files/neg/sd128.check
+++ b/test/files/neg/sd128.check
@@ -1,17 +1,17 @@
 Test.scala:4: error: class C1 inherits conflicting members:
- method f in trait A of type ()Int and
- method f in trait T of type => Int
- (note: this can be resolved by declaring an `override' in class C1.)
+  method f in trait A of type ()Int and
+  method f in trait T of type => Int
+  (note: this can be resolved by declaring an `override' in class C1.)
 class C1 extends A with T // error
       ^
 Test.scala:5: error: class C2 inherits conflicting members:
- method f in trait T of type => Int and
- method f in trait A of type ()Int
- (note: this can be resolved by declaring an `override' in class C2.)
+  method f in trait T of type => Int and
+  method f in trait A of type ()Int
+  (note: this can be resolved by declaring an `override' in class C2.)
 class C2 extends T with A // error
       ^
 Test.scala:14: error: overriding method f in trait A of type ()Int;
- method f needs `override' modifier
+  method f needs `override' modifier
   def f() = 9999 // need override modifier
       ^
 three errors found

--- a/test/files/neg/sd128.check
+++ b/test/files/neg/sd128.check
@@ -1,13 +1,13 @@
 Test.scala:4: error: class C1 inherits conflicting members:
-  method f in trait A of type ()Int  and
-  method f in trait T of type => Int
-(Note: this can be resolved by declaring an override in class C1.)
+ method f in trait A of type ()Int and
+ method f in trait T of type => Int
+ (note: this can be resolved by declaring an `override' in class C1.)
 class C1 extends A with T // error
       ^
 Test.scala:5: error: class C2 inherits conflicting members:
-  method f in trait T of type => Int  and
-  method f in trait A of type ()Int
-(Note: this can be resolved by declaring an override in class C2.)
+ method f in trait T of type => Int and
+ method f in trait A of type ()Int
+ (note: this can be resolved by declaring an `override' in class C2.)
 class C2 extends T with A // error
       ^
 Test.scala:14: error: overriding method f in trait A of type ()Int;

--- a/test/files/neg/sip23-override.check
+++ b/test/files/neg/sip23-override.check
@@ -1,9 +1,9 @@
 sip23-override.scala:24: error: overriding value f2 in trait Overridden of type 4;
- value f2 has incompatible type
+  value f2 has incompatible type
   override val f2: 5 = 5
                ^
 sip23-override.scala:28: error: overriding method f5 in trait Overridden of type => 4;
- method f5 has incompatible type
+  method f5 has incompatible type
   override def f5: 5 = 5
                ^
 two errors found

--- a/test/files/neg/t1163.check
+++ b/test/files/neg/t1163.check
@@ -1,7 +1,7 @@
 t1163.scala:2: error: overriding method foo in trait Sub of type => Sub;
- method foo in trait Super of type => Super has incompatible type;
- (note that method foo in trait Sub of type => Sub is abstract,
- and is therefore overridden by concrete method foo in trait Super of type => Super)
+  method foo in trait Super of type => Super has incompatible type;
+  (note that method foo in trait Sub of type => Sub is abstract,
+  and is therefore overridden by concrete method foo in trait Super of type => Super)
 trait Sub extends Super { override def foo: Sub }
       ^
 one error found

--- a/test/files/neg/t1163.check
+++ b/test/files/neg/t1163.check
@@ -1,7 +1,7 @@
 t1163.scala:2: error: overriding method foo in trait Sub of type => Sub;
  method foo in trait Super of type => Super has incompatible type;
- (Note that method foo in trait Sub of type => Sub is abstract,
-  and is therefore overridden by concrete method foo in trait Super of type => Super)
+ (note that method foo in trait Sub of type => Sub is abstract,
+ and is therefore overridden by concrete method foo in trait Super of type => Super)
 trait Sub extends Super { override def foo: Sub }
       ^
 one error found

--- a/test/files/neg/t1364.check
+++ b/test/files/neg/t1364.check
@@ -1,5 +1,5 @@
 t1364.scala:9: error: overriding type T in trait A with bounds <: AnyRef{type S[-U]};
- type T has incompatible type
+  type T has incompatible type
  type T = { type S[U] = U }
       ^
 one error found

--- a/test/files/neg/t1477.check
+++ b/test/files/neg/t1477.check
@@ -1,5 +1,5 @@
 t1477.scala:13: error: overriding type V in trait C with bounds <: Middle.this.D;
- type V is a volatile type; cannot override a type with non-volatile upper bound
+  type V is a volatile type; cannot override a type with non-volatile upper bound
     type V <: (D with U)
          ^
 one error found

--- a/test/files/neg/t2066.check
+++ b/test/files/neg/t2066.check
@@ -1,21 +1,21 @@
 t2066.scala:6: error: overriding method f in trait A1 of type [T[_]]=> Unit;
- method f has incompatible type
+  method f has incompatible type
   override def f[T[+_]] = ()
                ^
 t2066.scala:10: error: overriding method f in trait A1 of type [T[_]]=> Unit;
- method f has incompatible type
+  method f has incompatible type
   override def f[T[-_]] = ()
                ^
 t2066.scala:23: error: overriding method f in trait A2 of type [T[+_]]=> Unit;
- method f has incompatible type
+  method f has incompatible type
   override def f[T[-_]] = ()
                ^
 t2066.scala:45: error: overriding method f in trait A4 of type [T[X[+_]]]=> Unit;
- method f has incompatible type
+  method f has incompatible type
   override def f[T[X[_]]] = ()
                ^
 t2066.scala:53: error: overriding method f in trait A5 of type [T[X[-_]]]=> Unit;
- method f has incompatible type
+  method f has incompatible type
   override def f[T[X[_]]] = ()
                ^
 5 errors found

--- a/test/files/neg/t2066b.check
+++ b/test/files/neg/t2066b.check
@@ -1,5 +1,5 @@
 t2066b.scala:7: error: overriding method f in trait A of type [T[_]](x: T[Int])T[Any];
- method f has incompatible type
+  method f has incompatible type
 	 def f[T[+_]](x : T[Int]) : T[Any] = x
              ^
 one error found

--- a/test/files/neg/t276.check
+++ b/test/files/neg/t276.check
@@ -1,5 +1,5 @@
 t276.scala:6: error: overriding type Bar in class Foo, which equals (Int, Int);
- class Bar cannot be used here - classes can only override abstract types
+  class Bar cannot be used here - classes can only override abstract types
   class Bar
         ^
 one error found

--- a/test/files/neg/t4137.check
+++ b/test/files/neg/t4137.check
@@ -1,9 +1,9 @@
 t4137.scala:9: error: overriding type EPC in trait A, which equals [X1]C[X1];
- type EPC has incompatible type
+ overriding concrete type alias type EPC is not allowed except when equivalent
   override type EPC = C[T]
                 ^
 t4137.scala:10: error: overriding type EPC2 in trait A, which equals [X1]C[X1];
- type EPC2 has incompatible type
+ overriding concrete type alias type EPC2 is not allowed except when equivalent
   override type EPC2[X1 <: String] = C[X1]
                 ^
 two errors found

--- a/test/files/neg/t4137.check
+++ b/test/files/neg/t4137.check
@@ -1,9 +1,9 @@
 t4137.scala:9: error: overriding type EPC in trait A, which equals [X1]C[X1];
- overriding concrete type alias type EPC is not allowed except when equivalent
+  overriding concrete type alias type EPC is not allowed except when equivalent
   override type EPC = C[T]
                 ^
 t4137.scala:10: error: overriding type EPC2 in trait A, which equals [X1]C[X1];
- overriding concrete type alias type EPC2 is not allowed except when equivalent
+  overriding concrete type alias type EPC2 is not allowed except when equivalent
   override type EPC2[X1 <: String] = C[X1]
                 ^
 two errors found

--- a/test/files/neg/t521.check
+++ b/test/files/neg/t521.check
@@ -2,14 +2,14 @@ t521.scala:10: error: class PlainFile needs to be abstract, since method path in
 class PlainFile(val file : File) extends AbstractFile {}
       ^
 t521.scala:13: error: overriding value file in class PlainFile of type java.io.File;
- value file needs `override' modifier
+  value file needs `override' modifier
 final class ZipArchive(val file : File, archive : ZipFile) extends PlainFile(file) {
                            ^
 t521.scala:13: error: class ZipArchive needs to be abstract, since method path in class AbstractFile of type => String is not defined
 final class ZipArchive(val file : File, archive : ZipFile) extends PlainFile(file) {
             ^
 t521.scala:15: error: overriding value path in class VirtualFile of type String;
- method path needs to be a stable, immutable value
+  method path needs to be a stable, immutable value
     override def path = "";
                  ^
 four errors found

--- a/test/files/neg/t5358.check
+++ b/test/files/neg/t5358.check
@@ -1,7 +1,7 @@
 t5358.scala:3: error: class C inherits conflicting members:
-  method hi in trait A of type => String  and
-  method hi in trait B of type => String
-(Note: this can be resolved by declaring an override in class C.)
+ method hi in trait A of type => String and
+ method hi in trait B of type => String
+ (note: this can be resolved by declaring an `override' in class C.)
 class C extends A with B
       ^
 one error found

--- a/test/files/neg/t5358.check
+++ b/test/files/neg/t5358.check
@@ -1,7 +1,7 @@
 t5358.scala:3: error: class C inherits conflicting members:
- method hi in trait A of type => String and
- method hi in trait B of type => String
- (note: this can be resolved by declaring an `override' in class C.)
+  method hi in trait A of type => String and
+  method hi in trait B of type => String
+  (note: this can be resolved by declaring an `override' in class C.)
 class C extends A with B
       ^
 one error found

--- a/test/files/neg/t5429.check
+++ b/test/files/neg/t5429.check
@@ -1,49 +1,49 @@
 t5429.scala:20: error: overriding value value in class A of type Int;
- object value needs `override' modifier
+  object value needs `override' modifier
   object value      // fail
          ^
 t5429.scala:21: error: overriding lazy value lazyvalue in class A of type Int;
- object lazyvalue needs `override' modifier
+  object lazyvalue needs `override' modifier
   object lazyvalue  // fail
          ^
 t5429.scala:22: error: overriding method nullary in class A of type => Int;
- object nullary needs `override' modifier
+  object nullary needs `override' modifier
   object nullary    // fail
          ^
 t5429.scala:23: error: overriding method emptyArg in class A of type ()Int;
- object emptyArg needs `override' modifier
+  object emptyArg needs `override' modifier
   object emptyArg   // fail
          ^
 t5429.scala:27: error: overriding value value in class A0 of type Any;
- object value needs `override' modifier
+  object value needs `override' modifier
   object value      // fail
          ^
 t5429.scala:28: error: overriding lazy value lazyvalue in class A0 of type Any;
- object lazyvalue needs `override' modifier
+  object lazyvalue needs `override' modifier
   object lazyvalue  // fail
          ^
 t5429.scala:29: error: overriding method nullary in class A0 of type => Any;
- object nullary needs `override' modifier
+  object nullary needs `override' modifier
   object nullary    // fail
          ^
 t5429.scala:30: error: overriding method emptyArg in class A0 of type ()Any;
- object emptyArg needs `override' modifier
+  object emptyArg needs `override' modifier
   object emptyArg   // fail
          ^
 t5429.scala:35: error: overriding value value in class A of type Int;
- object value has incompatible type
+  object value has incompatible type
   override object value     // fail
                   ^
 t5429.scala:36: error: overriding lazy value lazyvalue in class A of type Int;
- object lazyvalue must be declared lazy to override a concrete lazy value
+  object lazyvalue must be declared lazy to override a concrete lazy value
   override object lazyvalue // fail
                   ^
 t5429.scala:37: error: overriding method nullary in class A of type => Int;
- object nullary has incompatible type
+  object nullary has incompatible type
   override object nullary   // fail
                   ^
 t5429.scala:38: error: overriding method emptyArg in class A of type ()Int;
- object emptyArg has incompatible type
+  object emptyArg has incompatible type
   override object emptyArg  // fail
                   ^
 t5429.scala:39: error: object oneArg overrides nothing.
@@ -52,7 +52,7 @@ def oneArg(x: String): Int
   override object oneArg    // fail
                   ^
 t5429.scala:43: error: overriding lazy value lazyvalue in class A0 of type Any;
- object lazyvalue must be declared lazy to override a concrete lazy value
+  object lazyvalue must be declared lazy to override a concrete lazy value
   override object lazyvalue // !!! this fails, but should succeed (lazy over lazy)
                   ^
 t5429.scala:46: error: object oneArg overrides nothing.
@@ -61,23 +61,23 @@ def oneArg(x: String): Any
   override object oneArg    // fail
                   ^
 t5429.scala:50: error: overriding value value in class A of type Int;
- value value needs `override' modifier
+  value value needs `override' modifier
   val value = 0       // fail
       ^
 t5429.scala:51: error: overriding lazy value lazyvalue in class A of type Int;
- value lazyvalue needs `override' modifier
+  value lazyvalue needs `override' modifier
   val lazyvalue = 0   // fail
       ^
 t5429.scala:52: error: overriding method nullary in class A of type => Int;
- value nullary needs `override' modifier
+  value nullary needs `override' modifier
   val nullary = 5     // fail
       ^
 t5429.scala:53: error: overriding method emptyArg in class A of type ()Int;
- value emptyArg needs `override' modifier
+  value emptyArg needs `override' modifier
   val emptyArg = 10   // fail
       ^
 t5429.scala:58: error: overriding lazy value lazyvalue in class A0 of type Any;
- value lazyvalue must be declared lazy to override a concrete lazy value
+  value lazyvalue must be declared lazy to override a concrete lazy value
   override val lazyvalue = 0  // fail (non-lazy)
                ^
 t5429.scala:61: error: value oneArg overrides nothing.
@@ -86,27 +86,27 @@ def oneArg(x: String): Any
   override val oneArg = 15    // fail
                ^
 t5429.scala:65: error: overriding value value in class A of type Int;
- method value needs `override' modifier
+  method value needs `override' modifier
   def value = 0       // fail
       ^
 t5429.scala:66: error: overriding lazy value lazyvalue in class A of type Int;
- method lazyvalue needs `override' modifier
+  method lazyvalue needs `override' modifier
   def lazyvalue = 2   // fail
       ^
 t5429.scala:67: error: overriding method nullary in class A of type => Int;
- method nullary needs `override' modifier
+  method nullary needs `override' modifier
   def nullary = 5     // fail
       ^
 t5429.scala:68: error: overriding method emptyArg in class A of type ()Int;
- method emptyArg needs `override' modifier
+  method emptyArg needs `override' modifier
   def emptyArg = 10   // fail
       ^
 t5429.scala:72: error: overriding value value in class A0 of type Any;
- method value needs to be a stable, immutable value
+  method value needs to be a stable, immutable value
   override def value = 0      // fail
                ^
 t5429.scala:73: error: overriding lazy value lazyvalue in class A0 of type Any;
- method lazyvalue needs to be a stable, immutable value
+  method lazyvalue needs to be a stable, immutable value
   override def lazyvalue = 2  // fail
                ^
 t5429.scala:76: error: method oneArg overrides nothing.
@@ -115,23 +115,23 @@ def oneArg(x: String): Any
   override def oneArg = 15    // fail
                ^
 t5429.scala:80: error: overriding value value in class A of type Int;
- lazy value value needs `override' modifier
+  lazy value value needs `override' modifier
   lazy val value = 0       // fail
            ^
 t5429.scala:81: error: overriding lazy value lazyvalue in class A of type Int;
- lazy value lazyvalue needs `override' modifier
+  lazy value lazyvalue needs `override' modifier
   lazy val lazyvalue = 2   // fail
            ^
 t5429.scala:82: error: overriding method nullary in class A of type => Int;
- lazy value nullary needs `override' modifier
+  lazy value nullary needs `override' modifier
   lazy val nullary = 5     // fail
            ^
 t5429.scala:83: error: overriding method emptyArg in class A of type ()Int;
- lazy value emptyArg needs `override' modifier
+  lazy value emptyArg needs `override' modifier
   lazy val emptyArg = 10   // fail
            ^
 t5429.scala:87: error: overriding value value in class A0 of type Any;
- lazy value value cannot override a concrete non-lazy value
+  lazy value value cannot override a concrete non-lazy value
   override lazy val value = 0      // fail (strict over lazy)
                     ^
 t5429.scala:91: error: lazy value oneArg overrides nothing.

--- a/test/files/neg/t5687.check
+++ b/test/files/neg/t5687.check
@@ -2,7 +2,7 @@ t5687.scala:4: error: type arguments [T] do not conform to class Template's type
   type Repr[T]<:Template[T]
                 ^
 t5687.scala:20: error: overriding type Repr in class Template with bounds[T] <: Template[T];
- type Repr has incompatible type
+  type Repr has incompatible type
   type Repr = CurveTemplate[T]
        ^
 two errors found

--- a/test/files/neg/t630.check
+++ b/test/files/neg/t630.check
@@ -1,5 +1,5 @@
 t630.scala:20: error: overriding value foo in trait Bar of type Req2;
- object foo has incompatible type
+  object foo has incompatible type
         object foo extends Req1
                ^
 one error found

--- a/test/files/neg/t708.check
+++ b/test/files/neg/t708.check
@@ -1,5 +1,5 @@
 t708.scala:8: error: overriding type S in trait X with bounds <: A.this.T;
- type S has incompatible type
+  type S has incompatible type
     override private[A] type S = Any;
                              ^
 one error found

--- a/test/files/neg/t8143a.check
+++ b/test/files/neg/t8143a.check
@@ -1,5 +1,5 @@
 t8143a.scala:2: error: overriding method f in class Foo of type => Int;
- method f has weaker access privileges; it should not be private
+  method f has weaker access privileges; it should not be private
 class Bar extends Foo { private def f = 10 }
                                     ^
 one error found

--- a/test/files/neg/tcpoly_variance.check
+++ b/test/files/neg/tcpoly_variance.check
@@ -1,5 +1,5 @@
 tcpoly_variance.scala:6: error: overriding method str in class A of type => m[Object];
- method str has incompatible type
+  method str has incompatible type
  override def str: m[String]  = sys.error("foo") // since x in m[x] is invariant, ! m[String] <: m[Object]
               ^
 one error found

--- a/test/files/neg/trait_fields_conflicts.check
+++ b/test/files/neg/trait_fields_conflicts.check
@@ -1,273 +1,273 @@
 trait_fields_conflicts.scala:5: error: overriding value x in trait Val of type Int;
- value x needs `override' modifier
+  value x needs `override' modifier
 trait ValForVal extends Val { val x: Int = 1 } // needs override
                                   ^
 trait_fields_conflicts.scala:6: error: overriding value x in trait Val of type Int;
- variable x needs `override' modifier
+  variable x needs `override' modifier
 trait VarForVal extends Val { var x: Int = 1 } // needs override
                                   ^
 trait_fields_conflicts.scala:7: error: overriding value x in trait Val of type Int;
- method x needs `override' modifier
+  method x needs `override' modifier
 trait DefForVal extends Val { def x: Int = 1 } // needs override
                                   ^
 trait_fields_conflicts.scala:8: error: overriding variable x in trait Var of type Int;
- value x needs `override' modifier
+  value x needs `override' modifier
 trait ValForVar extends Var { val x: Int = 1 } // needs override
                                   ^
 trait_fields_conflicts.scala:9: error: overriding variable x in trait Var of type Int;
- variable x needs `override' modifier
+  variable x needs `override' modifier
 trait VarForVar extends Var { var x: Int = 1 } // needs override
                                   ^
 trait_fields_conflicts.scala:10: error: overriding variable x in trait Var of type Int;
- method x needs `override' modifier
+  method x needs `override' modifier
 trait DefForVar extends Var { def x: Int = 1 } // needs override
                                   ^
 trait_fields_conflicts.scala:11: error: overriding lazy value x in trait Lazy of type Int;
- value x needs `override' modifier
+  value x needs `override' modifier
 trait ValForLazy extends Lazy { val x: Int = 1 } // needs override
                                     ^
 trait_fields_conflicts.scala:12: error: overriding lazy value x in trait Lazy of type Int;
- variable x needs `override' modifier
+  variable x needs `override' modifier
 trait VarForLazy extends Lazy { var x: Int = 1 } // needs override
                                     ^
 trait_fields_conflicts.scala:13: error: overriding lazy value x in trait Lazy of type Int;
- method x needs `override' modifier
+  method x needs `override' modifier
 trait DefForLazy extends Lazy { def x: Int = 1 } // needs override
                                     ^
 trait_fields_conflicts.scala:16: error: overriding value x in trait Val of type Int;
- variable x needs to be a stable, immutable value
+  variable x needs to be a stable, immutable value
 trait VarForValOvr extends Val { override var x: Int = 1 } // bad override
                                               ^
 trait_fields_conflicts.scala:17: error: overriding value x in trait Val of type Int;
- method x needs to be a stable, immutable value
+  method x needs to be a stable, immutable value
 trait DefForValOvr extends Val { override def x: Int = 1 } // bad override
                                               ^
 trait_fields_conflicts.scala:18: error: overriding variable x in trait Var of type Int;
- value x cannot override a mutable variable
+  value x cannot override a mutable variable
 trait ValForVarOvr extends Var { override val x: Int = 1 } // bad override -- unsound if used in path and var changes
                                               ^
 trait_fields_conflicts.scala:19: error: overriding variable x in trait Var of type Int;
- variable x cannot override a mutable variable
+  variable x cannot override a mutable variable
 trait VarForVarOvr extends Var { override var x: Int = 1 } // bad override -- why?
                                               ^
 trait_fields_conflicts.scala:20: error: overriding variable x in trait Var of type Int;
- method x cannot override a mutable variable
+  method x cannot override a mutable variable
 trait DefForVarOvr extends Var { override def x: Int = 1 } // bad override -- why?
                                               ^
 trait_fields_conflicts.scala:21: error: overriding lazy value x in trait Lazy of type Int;
- value x must be declared lazy to override a concrete lazy value
+  value x must be declared lazy to override a concrete lazy value
 trait ValForLazyOvr extends Lazy { override val x: Int = 1 } // bad override -- why?
                                                 ^
 trait_fields_conflicts.scala:22: error: overriding lazy value x in trait Lazy of type Int;
- variable x needs to be a stable, immutable value
+  variable x needs to be a stable, immutable value
 trait VarForLazyOvr extends Lazy { override var x: Int = 1 } // bad override -- why?
                                                 ^
 trait_fields_conflicts.scala:23: error: overriding lazy value x in trait Lazy of type Int;
- method x needs to be a stable, immutable value
+  method x needs to be a stable, immutable value
 trait DefForLazyOvr extends Lazy { override def x: Int = 1 } // bad override -- why?
                                                 ^
 trait_fields_conflicts.scala:25: error: overriding value x in trait Val of type Int;
- value x needs `override' modifier
+  value x needs `override' modifier
 class CValForVal extends Val { val x: Int = 1 } // needs override
                                    ^
 trait_fields_conflicts.scala:26: error: overriding value x in trait Val of type Int;
- variable x needs `override' modifier
+  variable x needs `override' modifier
 class CVarForVal extends Val { var x: Int = 1 } // needs override
                                    ^
 trait_fields_conflicts.scala:27: error: overriding value x in trait Val of type Int;
- method x needs `override' modifier
+  method x needs `override' modifier
 class CDefForVal extends Val { def x: Int = 1 } // needs override
                                    ^
 trait_fields_conflicts.scala:28: error: overriding variable x in trait Var of type Int;
- value x needs `override' modifier
+  value x needs `override' modifier
 class CValForVar extends Var { val x: Int = 1 } // needs override
                                    ^
 trait_fields_conflicts.scala:29: error: overriding variable x in trait Var of type Int;
- variable x needs `override' modifier
+  variable x needs `override' modifier
 class CVarForVar extends Var { var x: Int = 1 } // needs override
                                    ^
 trait_fields_conflicts.scala:30: error: overriding variable x in trait Var of type Int;
- method x needs `override' modifier
+  method x needs `override' modifier
 class CDefForVar extends Var { def x: Int = 1 } // needs override
                                    ^
 trait_fields_conflicts.scala:31: error: overriding lazy value x in trait Lazy of type Int;
- value x needs `override' modifier
+  value x needs `override' modifier
 class CValForLazy extends Lazy { val x: Int = 1 } // needs override
                                      ^
 trait_fields_conflicts.scala:32: error: overriding lazy value x in trait Lazy of type Int;
- variable x needs `override' modifier
+  variable x needs `override' modifier
 class CVarForLazy extends Lazy { var x: Int = 1 } // needs override
                                      ^
 trait_fields_conflicts.scala:33: error: overriding lazy value x in trait Lazy of type Int;
- method x needs `override' modifier
+  method x needs `override' modifier
 class CDefForLazy extends Lazy { def x: Int = 1 } // needs override
                                      ^
 trait_fields_conflicts.scala:36: error: overriding value x in trait Val of type Int;
- variable x needs to be a stable, immutable value
+  variable x needs to be a stable, immutable value
 class CVarForValOvr extends Val { override var x: Int = 1 } // bad override
                                                ^
 trait_fields_conflicts.scala:37: error: overriding value x in trait Val of type Int;
- method x needs to be a stable, immutable value
+  method x needs to be a stable, immutable value
 class CDefForValOvr extends Val { override def x: Int = 1 } // bad override
                                                ^
 trait_fields_conflicts.scala:38: error: overriding variable x in trait Var of type Int;
- value x cannot override a mutable variable
+  value x cannot override a mutable variable
 class CValForVarOvr extends Var { override val x: Int = 1 } // bad override -- unsound if used in path and var changes
                                                ^
 trait_fields_conflicts.scala:39: error: overriding variable x in trait Var of type Int;
- variable x cannot override a mutable variable
+  variable x cannot override a mutable variable
 class CVarForVarOvr extends Var { override var x: Int = 1 } // bad override -- why?
                                                ^
 trait_fields_conflicts.scala:40: error: overriding variable x in trait Var of type Int;
- method x cannot override a mutable variable
+  method x cannot override a mutable variable
 class CDefForVarOvr extends Var { override def x: Int = 1 } // bad override -- why?
                                                ^
 trait_fields_conflicts.scala:41: error: overriding lazy value x in trait Lazy of type Int;
- value x must be declared lazy to override a concrete lazy value
+  value x must be declared lazy to override a concrete lazy value
 class CValForLazyOvr extends Lazy { override val x: Int = 1 } // bad override -- why?
                                                  ^
 trait_fields_conflicts.scala:42: error: overriding lazy value x in trait Lazy of type Int;
- variable x needs to be a stable, immutable value
+  variable x needs to be a stable, immutable value
 class CVarForLazyOvr extends Lazy { override var x: Int = 1 } // bad override -- why?
                                                  ^
 trait_fields_conflicts.scala:43: error: overriding lazy value x in trait Lazy of type Int;
- method x needs to be a stable, immutable value
+  method x needs to be a stable, immutable value
 class CDefForLazyOvr extends Lazy { override def x: Int = 1 } // bad override -- why?
                                                  ^
 trait_fields_conflicts.scala:49: error: overriding value x in class CVal of type Int;
- value x needs `override' modifier
+  value x needs `override' modifier
 trait ValForCVal extends CVal { val x: Int = 1 } // needs override
                                     ^
 trait_fields_conflicts.scala:50: error: overriding value x in class CVal of type Int;
- variable x needs `override' modifier
+  variable x needs `override' modifier
 trait VarForCVal extends CVal { var x: Int = 1 } // needs override
                                     ^
 trait_fields_conflicts.scala:51: error: overriding value x in class CVal of type Int;
- method x needs `override' modifier
+  method x needs `override' modifier
 trait DefForCVal extends CVal { def x: Int = 1 } // needs override
                                     ^
 trait_fields_conflicts.scala:52: error: overriding variable x in class CVar of type Int;
- value x needs `override' modifier
+  value x needs `override' modifier
 trait ValForCVar extends CVar { val x: Int = 1 } // needs override
                                     ^
 trait_fields_conflicts.scala:53: error: overriding variable x in class CVar of type Int;
- variable x needs `override' modifier
+  variable x needs `override' modifier
 trait VarForCVar extends CVar { var x: Int = 1 } // needs override
                                     ^
 trait_fields_conflicts.scala:54: error: overriding variable x in class CVar of type Int;
- method x needs `override' modifier
+  method x needs `override' modifier
 trait DefForCVar extends CVar { def x: Int = 1 } // needs override
                                     ^
 trait_fields_conflicts.scala:55: error: overriding lazy value x in class CLazy of type Int;
- value x needs `override' modifier
+  value x needs `override' modifier
 trait ValForCLazy extends CLazy { val x: Int = 1 } // needs override
                                       ^
 trait_fields_conflicts.scala:56: error: overriding lazy value x in class CLazy of type Int;
- variable x needs `override' modifier
+  variable x needs `override' modifier
 trait VarForCLazy extends CLazy { var x: Int = 1 } // needs override
                                       ^
 trait_fields_conflicts.scala:57: error: overriding lazy value x in class CLazy of type Int;
- method x needs `override' modifier
+  method x needs `override' modifier
 trait DefForCLazy extends CLazy { def x: Int = 1 } // needs override
                                       ^
 trait_fields_conflicts.scala:60: error: overriding value x in class CVal of type Int;
- variable x needs to be a stable, immutable value
+  variable x needs to be a stable, immutable value
 trait VarForCValOvr extends CVal { override var x: Int = 1 } // bad override
                                                 ^
 trait_fields_conflicts.scala:61: error: overriding value x in class CVal of type Int;
- method x needs to be a stable, immutable value
+  method x needs to be a stable, immutable value
 trait DefForCValOvr extends CVal { override def x: Int = 1 } // bad override
                                                 ^
 trait_fields_conflicts.scala:62: error: overriding variable x in class CVar of type Int;
- value x cannot override a mutable variable
+  value x cannot override a mutable variable
 trait ValForCVarOvr extends CVar { override val x: Int = 1 } // bad override -- unsound if used in path and var changes
                                                 ^
 trait_fields_conflicts.scala:63: error: overriding variable x in class CVar of type Int;
- variable x cannot override a mutable variable
+  variable x cannot override a mutable variable
 trait VarForCVarOvr extends CVar { override var x: Int = 1 } // bad override -- why?
                                                 ^
 trait_fields_conflicts.scala:64: error: overriding variable x in class CVar of type Int;
- method x cannot override a mutable variable
+  method x cannot override a mutable variable
 trait DefForCVarOvr extends CVar { override def x: Int = 1 } // bad override -- why?
                                                 ^
 trait_fields_conflicts.scala:65: error: overriding lazy value x in class CLazy of type Int;
- value x must be declared lazy to override a concrete lazy value
+  value x must be declared lazy to override a concrete lazy value
 trait ValForCLazyOvr extends CLazy { override val x: Int = 1 } // bad override -- why?
                                                   ^
 trait_fields_conflicts.scala:66: error: overriding lazy value x in class CLazy of type Int;
- variable x needs to be a stable, immutable value
+  variable x needs to be a stable, immutable value
 trait VarForCLazyOvr extends CLazy { override var x: Int = 1 } // bad override -- why?
                                                   ^
 trait_fields_conflicts.scala:67: error: overriding lazy value x in class CLazy of type Int;
- method x needs to be a stable, immutable value
+  method x needs to be a stable, immutable value
 trait DefForCLazyOvr extends CLazy { override def x: Int = 1 } // bad override -- why?
                                                   ^
 trait_fields_conflicts.scala:69: error: overriding value x in class CVal of type Int;
- value x needs `override' modifier
+  value x needs `override' modifier
 class CValForCVal extends CVal { val x: Int = 1 } // needs override
                                      ^
 trait_fields_conflicts.scala:70: error: overriding value x in class CVal of type Int;
- variable x needs `override' modifier
+  variable x needs `override' modifier
 class CVarForCVal extends CVal { var x: Int = 1 } // needs override
                                      ^
 trait_fields_conflicts.scala:71: error: overriding value x in class CVal of type Int;
- method x needs `override' modifier
+  method x needs `override' modifier
 class CDefForCVal extends CVal { def x: Int = 1 } // needs override
                                      ^
 trait_fields_conflicts.scala:72: error: overriding variable x in class CVar of type Int;
- value x needs `override' modifier
+  value x needs `override' modifier
 class CValForCVar extends CVar { val x: Int = 1 } // needs override
                                      ^
 trait_fields_conflicts.scala:73: error: overriding variable x in class CVar of type Int;
- variable x needs `override' modifier
+  variable x needs `override' modifier
 class CVarForCVar extends CVar { var x: Int = 1 } // needs override
                                      ^
 trait_fields_conflicts.scala:74: error: overriding variable x in class CVar of type Int;
- method x needs `override' modifier
+  method x needs `override' modifier
 class CDefForCVar extends CVar { def x: Int = 1 } // needs override
                                      ^
 trait_fields_conflicts.scala:75: error: overriding lazy value x in class CLazy of type Int;
- value x needs `override' modifier
+  value x needs `override' modifier
 class CValForCLazy extends CLazy { val x: Int = 1 } // needs override
                                        ^
 trait_fields_conflicts.scala:76: error: overriding lazy value x in class CLazy of type Int;
- variable x needs `override' modifier
+  variable x needs `override' modifier
 class CVarForCLazy extends CLazy { var x: Int = 1 } // needs override
                                        ^
 trait_fields_conflicts.scala:77: error: overriding lazy value x in class CLazy of type Int;
- method x needs `override' modifier
+  method x needs `override' modifier
 class CDefForCLazy extends CLazy { def x: Int = 1 } // needs override
                                        ^
 trait_fields_conflicts.scala:80: error: overriding value x in class CVal of type Int;
- variable x needs to be a stable, immutable value
+  variable x needs to be a stable, immutable value
 class CVarForCValOvr extends CVal { override var x: Int = 1 } // bad override
                                                  ^
 trait_fields_conflicts.scala:81: error: overriding value x in class CVal of type Int;
- method x needs to be a stable, immutable value
+  method x needs to be a stable, immutable value
 class CDefForCValOvr extends CVal { override def x: Int = 1 } // bad override
                                                  ^
 trait_fields_conflicts.scala:82: error: overriding variable x in class CVar of type Int;
- value x cannot override a mutable variable
+  value x cannot override a mutable variable
 class CValForCVarOvr extends CVar { override val x: Int = 1 } // bad override -- unsound if used in path and var changes
                                                  ^
 trait_fields_conflicts.scala:83: error: overriding variable x in class CVar of type Int;
- variable x cannot override a mutable variable
+  variable x cannot override a mutable variable
 class CVarForCVarOvr extends CVar { override var x: Int = 1 } // bad override -- why?
                                                  ^
 trait_fields_conflicts.scala:84: error: overriding variable x in class CVar of type Int;
- method x cannot override a mutable variable
+  method x cannot override a mutable variable
 class CDefForCVarOvr extends CVar { override def x: Int = 1 } // bad override -- why?
                                                  ^
 trait_fields_conflicts.scala:85: error: overriding lazy value x in class CLazy of type Int;
- value x must be declared lazy to override a concrete lazy value
+  value x must be declared lazy to override a concrete lazy value
 class CValForCLazyOvr extends CLazy { override val x: Int = 1 } // bad override -- why?
                                                    ^
 trait_fields_conflicts.scala:86: error: overriding lazy value x in class CLazy of type Int;
- variable x needs to be a stable, immutable value
+  variable x needs to be a stable, immutable value
 class CVarForCLazyOvr extends CLazy { override var x: Int = 1 } // bad override -- why?
                                                    ^
 trait_fields_conflicts.scala:87: error: overriding lazy value x in class CLazy of type Int;
- method x needs to be a stable, immutable value
+  method x needs to be a stable, immutable value
 class CDefForCLazyOvr extends CLazy { override def x: Int = 1 } // bad override -- why?
                                                    ^
 68 errors found

--- a/test/files/neg/trait_fields_var_override.check
+++ b/test/files/neg/trait_fields_var_override.check
@@ -1,5 +1,5 @@
 trait_fields_var_override.scala:2: error: overriding variable end in trait SizeChangeEvent of type Int;
- variable end cannot override a mutable variable
+  variable end cannot override a mutable variable
 class BackedUpListIterator[E](override protected var end: Int) extends SizeChangeEvent
                                                      ^
 one error found

--- a/test/files/neg/volatile_no_override.check
+++ b/test/files/neg/volatile_no_override.check
@@ -1,5 +1,5 @@
 volatile_no_override.scala:13: error: overriding value x in class A of type Volatile.this.D;
- value x has a volatile type; cannot override a member with non-volatile type
+  value x has a volatile type; cannot override a member with non-volatile type
   val x: A with D = null
       ^
 one error found

--- a/test/files/run/StubErrorTypeDef.check
+++ b/test/files/run/StubErrorTypeDef.check
@@ -1,5 +1,5 @@
 error: newSource1.scala:4: overriding type D in class B with bounds <: stuberrors.A;
- type D has incompatible type
+  type D has incompatible type
       new B { type D = E }
                    ^
 error: newSource1.scala:4: Symbol 'type stuberrors.A' is missing from the classpath.


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/6001

This fixes the error message for overriding a concrete type alias.

### before

```scala
override-concrete-type.scala:7: error: overriding type A1 in class Foo, which equals Something;
 type A1 has incompatible type
class Bar extends Foo { override type A1 = Something with Serializable }
                                      ^
one error found
```

### after

```scala
override-concrete-type.scala:7: error: overriding type A1 in class Foo, which equals Something;
 overriding concrete type alias type A1 is not allowed except when equivalent
class Bar extends Foo { override type A1 = Something with Serializable }
                                      ^
one error found
```

This error message was suggested in https://github.com/scala/bug/issues/6001#issuecomment-292407825.