### PR TITLE
Enable implicits to check completion enrichment

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1106,7 +1106,10 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
      */
     def viewApply(view: SearchResult): Tree = {
       assert(view.tree != EmptyTree)
-      analyzer.newTyper(context.makeImplicit(reportAmbiguousErrors = false))
+      val t = analyzer.newTyper(context.makeImplicit(reportAmbiguousErrors = false))
+        .typed(Apply(view.tree, List(tree)) setPos tree.pos)
+      if (!t.tpe.isErroneous) t
+      else analyzer.newTyper(context.makeSilent(reportAmbiguousErrors = true))
         .typed(Apply(view.tree, List(tree)) setPos tree.pos)
         .onTypeError(EmptyTree)
     }

--- a/test/files/presentation/infix-completion.check
+++ b/test/files/presentation/infix-completion.check
@@ -3,7 +3,7 @@ reload: Snippet.scala
 askTypeCompletion at Snippet.scala(1,34)
 ================================================================================
 [response] askTypeCompletion at (1,34)
-retrieved 192 members
+retrieved 211 members
 [inaccessible] protected def integralNum: math.Numeric.DoubleAsIfIntegral.type
 [inaccessible] protected def num: math.Numeric.DoubleIsFractional.type
 [inaccessible] protected def ord: math.Ordering.Double.type
@@ -109,10 +109,16 @@ def ^(x: Short): Int
 def byteValue(): Byte
 def ceil: Double
 def compare(y: Double): Int
+def compare(y: Float): Int
+def compare(y: Int): Int
 def compare(y: Long): Int
 def compareTo(that: Double): Int
+def compareTo(that: Float): Int
+def compareTo(that: Int): Int
 def compareTo(that: Long): Int
 def compareTo(x$1: Double): Int
+def compareTo(x$1: Float): Int
+def compareTo(x$1: Integer): Int
 def compareTo(x$1: Long): Int
 def doubleValue(): Double
 def ensuring(cond: Boolean): Int
@@ -136,6 +142,10 @@ def round: Long
 def shortValue(): Short
 def to(end: Double): Range.Partial[Double,scala.collection.immutable.NumericRange[Double]]
 def to(end: Double,step: Double): scala.collection.immutable.NumericRange.Inclusive[Double]
+def to(end: Float): Range.Partial[Float,scala.collection.immutable.NumericRange[Float]]
+def to(end: Float,step: Float): scala.collection.immutable.NumericRange.Inclusive[Float]
+def to(end: Int): scala.collection.immutable.Range.Inclusive
+def to(end: Int,step: Int): scala.collection.immutable.Range.Inclusive
 def to(end: Long): scala.collection.immutable.NumericRange.Inclusive[Long]
 def to(end: Long,step: Long): scala.collection.immutable.NumericRange.Inclusive[Long]
 def toBinaryString: String
@@ -157,6 +167,10 @@ def unary_~: Int
 def underlying(): AnyRef
 def until(end: Double): Range.Partial[Double,scala.collection.immutable.NumericRange[Double]]
 def until(end: Double,step: Double): scala.collection.immutable.NumericRange.Exclusive[Double]
+def until(end: Float): Range.Partial[Float,scala.collection.immutable.NumericRange[Float]]
+def until(end: Float,step: Float): scala.collection.immutable.NumericRange.Exclusive[Float]
+def until(end: Int): scala.collection.immutable.Range
+def until(end: Int,step: Int): scala.collection.immutable.Range
 def until(end: Long): scala.collection.immutable.NumericRange.Exclusive[Long]
 def until(end: Long,step: Long): scala.collection.immutable.NumericRange.Exclusive[Long]
 def |(x: Byte): Int
@@ -185,8 +199,12 @@ override def isValidInt: Boolean
 override def isValidShort: Boolean
 override def isWhole(): Boolean
 override def max(that: Double): Double
+override def max(that: Float): Float
+override def max(that: Int): Int
 override def max(that: Long): Long
 override def min(that: Double): Double
+override def min(that: Float): Float
+override def min(that: Int): Int
 override def min(that: Long): Long
 override def signum: Int
 private[this] val self: Double

--- a/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
@@ -50,6 +50,10 @@ class CompletionTest {
 
     // Output is sorted
     assertEquals(List("prefix_aaa", "prefix_nnn", "prefix_zzz"), completer.complete( """class C { def prefix_nnn = 0; def prefix_zzz = 0; def prefix_aaa = 0; prefix_""").candidates)
+
+    // Enable implicits to check completion enrichment
+    assert(completer.complete("""'c'.""").candidates.contains("toUpper"))
+    assert(completer.complete("""val c = 'c'; c.""").candidates.contains("toUpper"))
   }
 
   @Test


### PR DESCRIPTION
Fixes scala/bug#10721

Conservatively retries applying a view with implicits enabled, for purposes of collecting enrichments. Not sure if that should be the initial attempt; the given implicit def has already been deemed applicable.

A test would be welcome.