### PR TITLE
Report an error when using an unstable qualifier in a type selection

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5037,9 +5037,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           // the qualifier type of a supercall constructor is its first parent class
           typedSelect(tree, typedSelectOrSuperQualifier(qual), nme.CONSTRUCTOR)
         case Select(qual, name) =>
-          if (name.isTypeName)
-            typedSelect(tree, typedTypeSelectionQualifier(tree.qualifier, WildcardType), name)
-          else {
+          if (name.isTypeName) {
+            val qualTyped = typedTypeSelectionQualifier(tree.qualifier, WildcardType)
+            val qualStableOrError =
+              if (qualTyped.isErrorTyped || treeInfo.admitsTypeSelection(qualTyped)) qualTyped
+              else UnstableTreeError(qualTyped)
+            typedSelect(tree, qualStableOrError, name)
+          } else {
             if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(typedSelectCount)
             val qualTyped = checkDead(typedQualifier(qual, mode))
             val tree1 = typedSelect(tree, qualTyped, name)

--- a/test/files/neg/t10619.check
+++ b/test/files/neg/t10619.check
@@ -1,0 +1,10 @@
+t10619.scala:4: error: stable identifier required, but Test.this.newOuter found.
+  val a: newOuter.Inner = { val o = newOuter; new o.Inner }
+         ^
+t10619.scala:5: error: stable identifier required, but Test.this.newOuter found.
+  val b: newOuter.Inner = a
+         ^
+t10619.scala:12: error: stable identifier required, but Test.this.newOuter found.
+  val f = new newOuter.Inner
+              ^
+three errors found

--- a/test/files/neg/t10619.scala
+++ b/test/files/neg/t10619.scala
@@ -1,0 +1,13 @@
+class Outer { class Inner }
+object Test {
+  def newOuter = new Outer
+  val a: newOuter.Inner = { val o = newOuter; new o.Inner }
+  val b: newOuter.Inner = a
+
+  val o = newOuter
+  val c: o.Inner = b
+  val d: o.Inner = new o.Inner
+  val e: o.Inner = d
+
+  val f = new newOuter.Inner
+}


### PR DESCRIPTION
The `treeInfo.admitsTypeSelection` check got lost in the refactoring
in 0b055c6cf697.

In 2.12.4, `typedType` of `newOuter.Inner` produces `Outer#Inner`:

    scala> val x: newOuter.Inner = null
    x: Outer#Inner = null

Fixes scala/bug#10619