### PR TITLE
Forward more methods for reverse orderings

### DIFF
--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -109,6 +109,13 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   override def reverse: Ordering[T] = new Ordering[T] {
     override def reverse = outer
     def compare(x: T, y: T) = outer.compare(y, x)
+    override def lteq(x: T, y: T) = outer.lteq(y, x)
+    override def gteq(x: T, y: T) = outer.gteq(y, x)
+    override def lt(x: T, y: T) = outer.lt(y, x)
+    override def gt(x: T, y: T) = outer.gt(y, x)
+    override def equiv(x: T, y: T) = outer.equiv(y, x)
+    override def max(x: T, y: T) = outer.min(x, y)
+    override def min(x: T, y: T) = outer.max(x, y)
   }
 
   /** Given f, a function from U into T, creates an Ordering[U] whose compare
@@ -306,8 +313,6 @@ object Ordering extends LowPriorityOrderingImplicits {
   implicit object Long extends LongOrdering
 
   trait FloatOrdering extends Ordering[Float] {
-    outer =>
-
     def compare(x: Float, y: Float) = java.lang.Float.compare(x, y)
 
     override def lteq(x: Float, y: Float): Boolean = x <= y
@@ -317,25 +322,10 @@ object Ordering extends LowPriorityOrderingImplicits {
     override def equiv(x: Float, y: Float): Boolean = x == y
     override def max(x: Float, y: Float): Float = math.max(x, y)
     override def min(x: Float, y: Float): Float = math.min(x, y)
-
-    override def reverse: Ordering[Float] = new FloatOrdering {
-      override def reverse = outer
-      override def compare(x: Float, y: Float) = outer.compare(y, x)
-
-      override def lteq(x: Float, y: Float): Boolean = outer.lteq(y, x)
-      override def gteq(x: Float, y: Float): Boolean = outer.gteq(y, x)
-      override def lt(x: Float, y: Float): Boolean = outer.lt(y, x)
-      override def gt(x: Float, y: Float): Boolean = outer.gt(y, x)
-      override def min(x: Float, y: Float): Float = outer.max(x, y)
-      override def max(x: Float, y: Float): Float = outer.min(x, y)
-
-    }
   }
   implicit object Float extends FloatOrdering
 
   trait DoubleOrdering extends Ordering[Double] {
-    outer =>
-
     def compare(x: Double, y: Double) = java.lang.Double.compare(x, y)
 
     override def lteq(x: Double, y: Double): Boolean = x <= y
@@ -345,18 +335,6 @@ object Ordering extends LowPriorityOrderingImplicits {
     override def equiv(x: Double, y: Double): Boolean = x == y
     override def max(x: Double, y: Double): Double = math.max(x, y)
     override def min(x: Double, y: Double): Double = math.min(x, y)
-
-    override def reverse: Ordering[Double] = new DoubleOrdering {
-      override def reverse = outer
-      override def compare(x: Double, y: Double) = outer.compare(y, x)
-
-      override def lteq(x: Double, y: Double): Boolean = outer.lteq(y, x)
-      override def gteq(x: Double, y: Double): Boolean = outer.gteq(y, x)
-      override def lt(x: Double, y: Double): Boolean = outer.lt(y, x)
-      override def gt(x: Double, y: Double): Boolean = outer.gt(y, x)
-      override def min(x: Double, y: Double): Double = outer.max(x, y)
-      override def max(x: Double, y: Double): Double = outer.min(x, y)
-    }
   }
   implicit object Double extends DoubleOrdering
 

--- a/src/library/scala/math/PartialOrdering.scala
+++ b/src/library/scala/math/PartialOrdering.scala
@@ -74,7 +74,11 @@ trait PartialOrdering[T] extends Equiv[T] {
 
   def reverse : PartialOrdering[T] = new PartialOrdering[T] {
     override def reverse = outer
-    def lteq(x: T, y: T) = outer.lteq(y, x)
     def tryCompare(x: T, y: T) = outer.tryCompare(y, x)
+    def lteq(x: T, y: T) = outer.lteq(y, x)
+    override def gteq(x: T, y: T) = outer.gteq(y, x)
+    override def lt(x: T, y: T) = outer.lt(y, x)
+    override def gt(x: T, y: T) = outer.gt(y, x)
+    override def equiv(x: T, y: T) = outer.equiv(y, x)
   }
 }


### PR DESCRIPTION
Forward most comparison methods (not just abstract
ones) in default implementations of `Ordering.reverse`
and `PartialOrdering.reverse`.

This may yield a small performance benefit if comparison
methods are overridden in the outer `Ordering`, and shouldn't
hurt performance if they are not.

This change may also be necessary depending how
scala/bug#10511 is resolved.