### PR TITLE
A pair of developer convenience enhancements.

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1,5 +1,5 @@
 /* NSC -- new Scala compiler
- * Copyright 2005-2013 LAMP/EPFL
+ * Copyright 2005-2018 LAMP/EPFL
  * @author  Martin Odersky
  */
 
@@ -76,7 +76,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   override def settings = currentSettings
 
   /** Switch to turn on detailed type logs */
-  var printTypings = settings.Ytyperdebug.value
+  final def printTypings = settings.Ytyperdebug.value
 
   def this(reporter: Reporter) =
     this(new Settings(err => reporter.error(null, err)), reporter)

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -1,5 +1,5 @@
 /* NSC -- new Scala compiler
- * Copyright 2005-2016 LAMP/EPFL
+ * Copyright 2005-2018 LAMP/EPFL
  * @author Alexander Spoon
  */
 package scala
@@ -1005,10 +1005,8 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter) extend
         }
       case _ =>
     }
-    // ctl-D on first line of repl zaps the intp
-    def globalOrNull = if (intp != null) intp.global else null
     // wait until after startup to enable noisy settings; intp is used only after body completes
-    def startup(): String = IMain.withSuppressedSettings(settings, globalOrNull) {
+    def startup(): String = IMain.withSuppressedSettings(settings) {
       // -e is non-interactive
       val splash =
         runnerSettings.filter(_.execute.isSetByUser).map(ss => batchLoop(ss.execute.value)).getOrElse {

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -1,5 +1,5 @@
 /* NSC -- new Scala compiler
- * Copyright 2005-2016 LAMP/EPFL
+ * Copyright 2005-2018 LAMP/EPFL
  * @author  Martin Odersky
  */
 
@@ -963,7 +963,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
 
         // compile the result-extraction object
         val handls = if (printResults) handlers else Nil
-        IMain.withSuppressedSettings(settings, global)(lineRep compile ResultObjectSourceCode(handls))
+        IMain.withSuppressedSettings(settings)(lineRep compile ResultObjectSourceCode(handls))
       }
     }
 
@@ -1247,7 +1247,7 @@ object IMain {
   private def removeIWPackages(s: String)  = s.replaceAll("""\$(iw|read|eval|print)[$.]""", "")
   def stripString(s: String)               = removeIWPackages(removeLineWrapper(s))
 
-  private[interpreter] def withSuppressedSettings[A](settings: Settings, global: => Global)(body: => A): A = {
+  private[interpreter] def withSuppressedSettings[A](settings: Settings)(body: => A): A = {
     import settings._
     val wasWarning = !nowarn
     val noisy = List(Xprint, Ytyperdebug, browse)
@@ -1265,11 +1265,6 @@ object IMain {
         Ytyperdebug.value  = current._2
         browse.value       = current._3
         if (wasWarning) nowarn.value = false
-        // ctl-D in repl can result in no compiler
-        val g = global
-        if (g != null) {
-          g.printTypings = current._2
-        }
       }
     }
   }

--- a/src/repl/scala/tools/nsc/interpreter/ReplVals.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplVals.scala
@@ -1,5 +1,5 @@
 /* NSC -- new Scala compiler
- * Copyright 2005-2013 LAMP/EPFL
+ * Copyright 2005-2018 LAMP/EPFL
  * @author Paul Phillips
  */
 
@@ -47,7 +47,9 @@ class StdReplVals(final val r: ILoop) extends ReplVals {
 
   final lazy val replImplicits = new ReplImplicits
 
-  def typed[T <: analyzer.global.Tree](tree: T): T = typer.typed(tree).asInstanceOf[T]
+  // expose `typer.typed` for easy repl fiddling
+  def typed(tree: global.Tree, mode: Mode = EXPRmode, pt: global.Type = global.WildcardType): global.Tree =
+    typer.typed(tree, mode, pt)
 }
 
 object ReplVals {

--- a/test/files/run/repl-no-imports-no-predef-power.check
+++ b/test/files/run/repl-no-imports-no-predef-power.check
@@ -21,9 +21,14 @@ scala> val m = LIT(10)                           // treedsl
 m: $r.treedsl.global.Literal = 10
 
 scala> typed(m).tpe                              // typed is in scope
-res2: $r.treedsl.global.Type = Int(10)
+res2: $r.global.Type = Int(10)
+
+scala> typed(tq"Int", mode = Mode.TYPEmode)      // typed types types
+<console>:37: error: not found: value StringContext
+       typed(tq"Int", mode = Mode.TYPEmode)      // typed types types
+             ^
 
 scala> """escaping is hard, m'kah"""
-res3: String = escaping is hard, m'kah
+res4: String = escaping is hard, m'kah
 
 scala> :quit

--- a/test/files/run/repl-no-imports-no-predef-power.scala
+++ b/test/files/run/repl-no-imports-no-predef-power.scala
@@ -16,6 +16,7 @@ val tp = ArrayClass[scala.util.Random]    // magic with tags
 tp.memberType(Array_apply)                // evidence
 val m = LIT(10)                           // treedsl
 typed(m).tpe                              // typed is in scope
+typed(tq"Int", mode = Mode.TYPEmode)      // typed types types
 ${tripleQuote("escaping is hard, m'kah")}
   """.trim
 }

--- a/test/files/run/repl-power.check
+++ b/test/files/run/repl-power.check
@@ -21,9 +21,12 @@ scala> val m = LIT(10)                           // treedsl
 m: $r.treedsl.global.Literal = 10
 
 scala> typed(m).tpe                              // typed is in scope
-res2: $r.treedsl.global.Type = Int(10)
+res2: $r.global.Type = Int(10)
+
+scala> typed(tq"Int", mode = Mode.TYPEmode)      // typed types types
+res3: $r.global.Tree = Int
 
 scala> """escaping is hard, m'kah"""
-res3: String = escaping is hard, m'kah
+res4: String = escaping is hard, m'kah
 
 scala> :quit

--- a/test/files/run/repl-power.scala
+++ b/test/files/run/repl-power.scala
@@ -11,6 +11,7 @@ val tp = ArrayClass[scala.util.Random]    // magic with tags
 tp.memberType(Array_apply)                // evidence
 val m = LIT(10)                           // treedsl
 typed(m).tpe                              // typed is in scope
+typed(tq"Int", mode = Mode.TYPEmode)      // typed types types
 ${tripleQuote("escaping is hard, m'kah")}
   """.trim
 }


### PR DESCRIPTION
In case anyone else wants them.

- `typed` in power mode had an odd signature, wherein it assumed that the type of a typed tree is the same as the type of the tree that was typed, which isn't necessarily true. Never again will I type `typed(tq"Int":Tree)` to avoid a `ClassCastException`.

- `Global#printTypings` was a `var`. I can't tell why; it started out as a `var`, became a `val`, re-became a `var`, was mutated in `withSuppressedSettings` to work around the fact that setting its setting didn't set it itself, and now has become a `def` like you probably expected. Now, `:settings -Ytyper-debug` turns the verbosity on, and `:settings -Ytyper-debug:false` turns it off.

I doubt the latter change is going to cause a performance impact, but if it does it's obviously not worth the benefit to my convenience. If you'd like me to run one I will, otherwise I'm inclined to let the mergely bencher bench on merge.

Also, I [read around](https://github.com/scala/bug/issues/9026#issuecomment-363590768) that maybe keeping copyright years up to date is a good thing. 2013 was a pretty okay year but we're in the brave new world now, so unless people object I'm going to start swapping `3` for `8` on files I touch.