### PR TITLE
JEP-238 (Multi-Release JAR) and JEP-247 (Compiler for older JDKs) support

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/FileUtils.scala
+++ b/src/compiler/scala/tools/nsc/classpath/FileUtils.scala
@@ -37,6 +37,7 @@ object FileUtils {
   private val SUFFIX_CLASS = ".class"
   private val SUFFIX_SCALA = ".scala"
   private val SUFFIX_JAVA = ".java"
+  private val SUFFIX_SIG = ".sig"
 
   def stripSourceExtension(fileName: String): String = {
     if (endsScala(fileName)) stripClassExtension(fileName)
@@ -49,7 +50,7 @@ object FileUtils {
   @inline private def ends (filename:String, suffix:String) = filename.endsWith(suffix) && filename.length > suffix.length
 
   def endsClass(fileName: String): Boolean =
-    ends (fileName, SUFFIX_CLASS)
+    ends (fileName, SUFFIX_CLASS) || fileName.endsWith(SUFFIX_SIG)
 
   def endsScalaOrJava(fileName: String): Boolean =
     endsScala(fileName) || endsJava(fileName)
@@ -61,7 +62,7 @@ object FileUtils {
     ends (fileName, SUFFIX_SCALA)
 
   def stripClassExtension(fileName: String): String =
-    fileName.substring(0, fileName.length - 6) // equivalent of fileName.length - SUFFIX_CLASS.length
+    fileName.substring(0, fileName.lastIndexOf('.'))
 
   def stripJavaExtension(fileName: String): String =
     fileName.substring(0, fileName.length - 5) // equivalent of fileName.length - SUFFIX_JAVA.length

--- a/src/compiler/scala/tools/nsc/classpath/PackageNameUtils.scala
+++ b/src/compiler/scala/tools/nsc/classpath/PackageNameUtils.scala
@@ -24,6 +24,11 @@ object PackageNameUtils {
 
   def packagePrefix(inPackage: String): String = if (inPackage == RootPackage) "" else inPackage + "."
 
+  /**
+   * `true` if `packageDottedName` is a package directly nested in `inPackage`, for example:
+   *   - `packageContains("scala", "scala.collection")`
+   *   - `packageContains("", "scala")`
+   */
   def packageContains(inPackage: String, packageDottedName: String) = {
     if (packageDottedName.contains("."))
       packageDottedName.startsWith(inPackage) && packageDottedName.lastIndexOf('.') == inPackage.length

--- a/src/compiler/scala/tools/nsc/classpath/PackageNameUtils.scala
+++ b/src/compiler/scala/tools/nsc/classpath/PackageNameUtils.scala
@@ -14,7 +14,7 @@ object PackageNameUtils {
    * @param fullClassName full class name with package
    * @return (package, simple class name)
    */
-  def separatePkgAndClassNames(fullClassName: String): (String, String) = {
+  @inline def separatePkgAndClassNames(fullClassName: String): (String, String) = {
     val lastDotIndex = fullClassName.lastIndexOf('.')
     if (lastDotIndex == -1)
       (RootPackage, fullClassName)
@@ -23,4 +23,10 @@ object PackageNameUtils {
   }
 
   def packagePrefix(inPackage: String): String = if (inPackage == RootPackage) "" else inPackage + "."
+
+  def packageContains(inPackage: String, packageDottedName: String) = {
+    if (packageDottedName.contains("."))
+      packageDottedName.startsWith(inPackage) && packageDottedName.lastIndexOf('.') == inPackage.length
+    else inPackage == ""
+  }
 }

--- a/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
@@ -23,14 +23,14 @@ sealed trait ZipAndJarFileLookupFactory {
   private val cache = new FileBasedCache[ClassPath]
 
   def create(zipFile: AbstractFile, settings: Settings): ClassPath = {
-    if (settings.YdisableFlatCpCaching || zipFile.file == null) createForZipFile(zipFile, Option(settings.release.value).filter(_ != ""))
+    if (settings.YdisableFlatCpCaching || zipFile.file == null) createForZipFile(zipFile, settings.releaseValue)
     else createUsingCache(zipFile, settings)
   }
 
   protected def createForZipFile(zipFile: AbstractFile, release: Option[String]): ClassPath
 
   private def createUsingCache(zipFile: AbstractFile, settings: Settings): ClassPath = {
-    cache.getOrCreate(List(zipFile.file.toPath), () => createForZipFile(zipFile, Option(settings.release.value).filter(_ != "")))
+    cache.getOrCreate(List(zipFile.file.toPath), () => createForZipFile(zipFile, settings.releaseValue))
   }
 }
 

--- a/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
@@ -23,14 +23,14 @@ sealed trait ZipAndJarFileLookupFactory {
   private val cache = new FileBasedCache[ClassPath]
 
   def create(zipFile: AbstractFile, settings: Settings): ClassPath = {
-    if (settings.YdisableFlatCpCaching || zipFile.file == null) createForZipFile(zipFile)
+    if (settings.YdisableFlatCpCaching || zipFile.file == null) createForZipFile(zipFile, Option(settings.release.value).filter(_ != ""))
     else createUsingCache(zipFile, settings)
   }
 
-  protected def createForZipFile(zipFile: AbstractFile): ClassPath
+  protected def createForZipFile(zipFile: AbstractFile, release: Option[String]): ClassPath
 
   private def createUsingCache(zipFile: AbstractFile, settings: Settings): ClassPath = {
-    cache.getOrCreate(List(zipFile.file.toPath), () => createForZipFile(zipFile))
+    cache.getOrCreate(List(zipFile.file.toPath), () => createForZipFile(zipFile, Option(settings.release.value).filter(_ != "")))
   }
 }
 
@@ -39,7 +39,7 @@ sealed trait ZipAndJarFileLookupFactory {
  * It should be the only way of creating them as it provides caching.
  */
 object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
-  private case class ZipArchiveClassPath(zipFile: File)
+  private case class ZipArchiveClassPath(zipFile: File, override val release: Option[String])
     extends ZipArchiveFileLookup[ClassFileEntryImpl]
     with NoSourcePaths {
 
@@ -143,9 +143,9 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
     case class PackageInfo(packageName: String, subpackages: List[AbstractFile])
   }
 
-  override protected def createForZipFile(zipFile: AbstractFile): ClassPath =
+  override protected def createForZipFile(zipFile: AbstractFile, release: Option[String]): ClassPath =
     if (zipFile.file == null) createWithoutUnderlyingFile(zipFile)
-    else ZipArchiveClassPath(zipFile.file)
+    else ZipArchiveClassPath(zipFile.file, release)
 
   private def createWithoutUnderlyingFile(zipFile: AbstractFile) = zipFile match {
     case manifestRes: ManifestResources =>
@@ -164,6 +164,7 @@ object ZipAndJarSourcePathFactory extends ZipAndJarFileLookupFactory {
   private case class ZipArchiveSourcePath(zipFile: File)
     extends ZipArchiveFileLookup[SourceFileEntryImpl]
     with NoClassPaths {
+    def release: Option[String] = None
 
     override def asSourcePathString: String = asClassPathString
 
@@ -173,7 +174,7 @@ object ZipAndJarSourcePathFactory extends ZipAndJarFileLookupFactory {
     override protected def isRequiredFileType(file: AbstractFile): Boolean = file.isScalaOrJavaSource
   }
 
-  override protected def createForZipFile(zipFile: AbstractFile): ClassPath = ZipArchiveSourcePath(zipFile.file)
+  override protected def createForZipFile(zipFile: AbstractFile, release: Option[String]): ClassPath = ZipArchiveSourcePath(zipFile.file)
 }
 
 final class FileBasedCache[T] {

--- a/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
@@ -18,13 +18,14 @@ import scala.tools.nsc.util.{ClassPath, ClassRepresentation}
  */
 trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
   val zipFile: File
+  def release: Option[String]
 
   assert(zipFile != null, "Zip file in ZipArchiveFileLookup cannot be null")
 
   override def asURLs: Seq[URL] = Seq(zipFile.toURI.toURL)
   override def asClassPathStrings: Seq[String] = Seq(zipFile.getPath)
 
-  private val archive = new FileZipArchive(zipFile)
+  private val archive = new FileZipArchive(zipFile, release)
 
   override private[nsc] def packages(inPackage: String): Seq[PackageEntry] = {
     val prefix = PackageNameUtils.packagePrefix(inPackage)

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -87,6 +87,7 @@ trait ScalaSettings extends AbsScalaSettings
       // TODO validate release <= java.specification.version
     }
   }
+  def releaseValue: Option[String] = Option(release.value).filter(_ != "")
 
   /*
    * The previous "-source" option is intended to be used mainly

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -79,6 +79,14 @@ trait ScalaSettings extends AbsScalaSettings
       domain  = languageFeatures
     )
   }
+  val release = StringSetting("-release", "<release>", "Compile for a specific version of the Java platform. Supported targets: 6, 7, 8, 9", "").withPostSetHook { (value: StringSetting) =>
+    if (value.value != "" && !scala.util.Properties.isJavaAtLeast("9")) {
+      errorFn.apply("-release is only supported on Java 9 and higher")
+    } else {
+      // TODO validate numeric value
+      // TODO validate release <= java.specification.version
+    }
+  }
 
   /*
    * The previous "-source" option is intended to be used mainly

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -232,9 +232,11 @@ final class PathResolver(settings: Settings) {
 
     import classPathFactory._
 
+    private def release: Option[String] = Option(settings.release.value).filter(_ != "")
+
     // Assemble the elements!
     def basis = List[Traversable[ClassPath]](
-      JrtClassPath.apply(),                         // 0. The Java 9 classpath (backed by the jrt:/ virtual system, if available)
+      JrtClassPath.apply(release),                  // 0. The Java 9 classpath (backed by the jrt:/ virtual system, if available)
       classesInPath(javaBootClassPath),             // 1. The Java bootstrap class path.
       contentsOfDirsInPath(javaExtDirs),            // 2. The Java extension class path.
       classesInExpandedPath(javaUserClassPath),     // 3. The Java application class path.

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -232,11 +232,9 @@ final class PathResolver(settings: Settings) {
 
     import classPathFactory._
 
-    private def release: Option[String] = Option(settings.release.value).filter(_ != "")
-
     // Assemble the elements!
     def basis = List[Traversable[ClassPath]](
-      JrtClassPath.apply(release),                  // 0. The Java 9 classpath (backed by the jrt:/ virtual system, if available)
+      JrtClassPath.apply(settings.releaseValue),    // 0. The Java 9 classpath (backed by the jrt:/ virtual system, if available)
       classesInPath(javaBootClassPath),             // 1. The Java bootstrap class path.
       contentsOfDirsInPath(javaExtDirs),            // 2. The Java extension class path.
       classesInExpandedPath(javaUserClassPath),     // 3. The Java application class path.

--- a/src/reflect/mima-filters/2.12.0.forwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.forwards.excludes
@@ -16,3 +16,7 @@ ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.FileZipArchive$Lea
 
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.exists")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.Settings.isScala213")
+
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.FileZipArchive.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive.getDir")

--- a/src/reflect/scala/reflect/internal/JDK9Reflectors.java
+++ b/src/reflect/scala/reflect/internal/JDK9Reflectors.java
@@ -1,0 +1,91 @@
+package scala.reflect.internal;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.jar.JarFile;
+
+public final class JDK9Reflectors {
+    private static final MethodHandle RUNTIME_VERSION_PARSE;
+    private static final MethodHandle RUNTIME_VERSION;
+    private static final MethodHandle RUNTIME_VERSION_MAJOR;
+    private static final MethodHandle NEW_JAR_FILE;
+
+    static {
+        RUNTIME_VERSION_PARSE = lookupRuntimeVersionParse();
+        RUNTIME_VERSION = lookupRuntimeVersion();
+        RUNTIME_VERSION_MAJOR = lookupRuntimeVersionMajor();
+        NEW_JAR_FILE = lookupNewJarFile();
+    }
+
+    public static /*java.lang.Runtime.Version*/ Object runtimeVersionParse(String string) {
+        try {
+            return RUNTIME_VERSION_PARSE == null ? null : RUNTIME_VERSION_PARSE.invoke(string);
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    public static /*java.lang.Runtime.Version*/ Object runtimeVersion() {
+        try {
+            return RUNTIME_VERSION == null ? null : RUNTIME_VERSION.invoke();
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    public static /*java.lang.Runtime.Version*/ Integer runtimeVersionMajor(/*java.lang.Runtime.Version*/ Object version) {
+        try {
+            return RUNTIME_VERSION_MAJOR == null ? null : (Integer) (int) RUNTIME_VERSION_MAJOR.invoke(version);
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    public static JarFile newJarFile(java.io.File file, boolean verify, int mode, /*java.lang.Runtime.Version*/ Object version) throws IOException {
+        try {
+            if (version == null) return new JarFile(file, verify, mode);
+            else {
+                return (JarFile) NEW_JAR_FILE.invoke(file, verify, mode, version);
+            }
+        } catch (IOException | IllegalArgumentException | SecurityException ex) {
+            throw ex;
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+
+    }
+
+    private static MethodHandle lookupRuntimeVersionParse() {
+        try {
+            return MethodHandles.lookup().findStatic(runtimeVersionClass(), "parse", MethodType.methodType(runtimeVersionClass(), String.class));
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+    private static MethodHandle lookupRuntimeVersion() {
+        try {
+            return MethodHandles.lookup().findStatic(Class.forName("java.lang.Runtime"), "version", MethodType.methodType(runtimeVersionClass()));
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+    private static MethodHandle lookupRuntimeVersionMajor() {
+        try {
+            return MethodHandles.lookup().findVirtual(runtimeVersionClass(), "major", MethodType.methodType(Integer.TYPE));
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+    private static MethodHandle lookupNewJarFile() {
+        try {
+            return MethodHandles.lookup().findConstructor(java.util.jar.JarFile.class, MethodType.methodType(void.class, java.io.File.class, java.lang.Boolean.TYPE, Integer.TYPE, Class.forName("java.lang.Runtime$Version")));
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+    private static Class<?> runtimeVersionClass() throws ClassNotFoundException {
+        return Class.forName("java.lang.Runtime$Version");
+    }
+}

--- a/src/reflect/scala/reflect/internal/JDK9Reflectors.java
+++ b/src/reflect/scala/reflect/internal/JDK9Reflectors.java
@@ -47,7 +47,7 @@ public final class JDK9Reflectors {
         try {
             if (version == null) return new JarFile(file, verify, mode);
             else {
-                return (JarFile) NEW_JAR_FILE.invoke(file, verify, mode, version);
+                return NEW_JAR_FILE == null ? null : (JarFile) NEW_JAR_FILE.invoke(file, verify, mode, version);
             }
         } catch (IOException | IllegalArgumentException | SecurityException ex) {
             throw ex;
@@ -66,7 +66,7 @@ public final class JDK9Reflectors {
     }
     private static MethodHandle lookupRuntimeVersion() {
         try {
-            return MethodHandles.lookup().findStatic(Class.forName("java.lang.Runtime"), "version", MethodType.methodType(runtimeVersionClass()));
+            return MethodHandles.lookup().findStatic(java.lang.Runtime.class, "version", MethodType.methodType(runtimeVersionClass()));
         } catch (Throwable t) {
             return null;
         }
@@ -80,7 +80,7 @@ public final class JDK9Reflectors {
     }
     private static MethodHandle lookupNewJarFile() {
         try {
-            return MethodHandles.lookup().findConstructor(java.util.jar.JarFile.class, MethodType.methodType(void.class, java.io.File.class, java.lang.Boolean.TYPE, Integer.TYPE, Class.forName("java.lang.Runtime$Version")));
+            return MethodHandles.lookup().findConstructor(java.util.jar.JarFile.class, MethodType.methodType(void.class, java.io.File.class, java.lang.Boolean.TYPE, Integer.TYPE, runtimeVersionClass()));
         } catch (Throwable t) {
             return null;
         }

--- a/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
@@ -26,7 +26,7 @@ class JrtClassPathTest {
         val elements = new ClassPathFactory(settings).classesInPath(resolver.Calculated.javaBootClassPath)
         AggregateClassPath(elements)
       }
-      else JrtClassPath().get
+      else JrtClassPath(None).get
 
     assertEquals(Nil, cp.classes(""))
     assertTrue(cp.packages("java").toString, cp.packages("java").exists(_.name == "java.lang"))

--- a/test/junit/scala/tools/nsc/classpath/MultiReleaseJarTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/MultiReleaseJarTest.scala
@@ -1,0 +1,105 @@
+package scala.tools.nsc.classpath
+
+import java.io.ByteArrayOutputStream
+import java.nio.file.{FileSystems, Files, Path}
+import java.util.jar.Attributes
+import java.util.jar.Attributes.Name
+
+import org.junit.{Assert, Test}
+
+import scala.tools.nsc.{Global, Settings}
+import scala.tools.testing.BytecodeTesting
+import scala.util.Properties
+
+class MultiReleaseJarTest extends BytecodeTesting {
+  import compiler._
+  @Test
+  def mrJar(): Unit = {
+    if (!Properties.isJavaAtLeast("9")) { println("skipping mrJar() on old JdK"); return} // TODO test that the compiler warns that --release is unsupported.
+
+    val temp1 = Files.createTempFile("mr-jar-test-", ".jar")
+
+    // TODO test fails if both Global runs look at the same JAR on disk. Caching problem in our classpath implementation?
+    // val temp2 = temp1
+    val temp2 = Files.createTempFile("mr-jar-test-", ".jar")
+
+    try {
+      def code(newApi: String) = s"package p1; abstract class Versioned { def oldApi: Int; $newApi }"
+
+      val oldC = compileToBytes(code("")).head._2
+      val newC = compileToBytes(code("def newApi: Int")).head._2
+      List(temp1, temp2).foreach(temp => createZip(temp, List(
+        "/p1/Versioned.class" -> oldC,
+        "/META-INF/versions/9/p1/Versioned.class" -> newC,
+        "/META-INF/MANIFEST.MF" -> createManifest)
+      ))
+
+      def declsOfC(jarPath: Path, release: String) = {
+        val settings = new Settings()
+        settings.usejavacp.value = true
+        settings.classpath.value = jarPath.toAbsolutePath.toString
+        val g = new Global(settings)
+        settings.release.value = release
+        new g.Run
+        val decls = g.rootMirror.staticClass("p1.Versioned").info.decls.filterNot(_.isConstructor).map(_.name.toString).toList.sorted
+        decls
+      }
+
+      Assert.assertEquals(List("newApi", "oldApi"), declsOfC(temp1, "9"))
+      Assert.assertEquals(List("oldApi"), declsOfC(temp2, "8"))
+    } finally
+      List(temp1, temp2).foreach(Files.deleteIfExists)
+  }
+
+  @Test
+  def ctSymTest(): Unit = {
+    if (!Properties.isJavaAtLeast("9")) { println("skipping mrJar() on old JDK"); return} // TODO test that the compiler warns that --release is unsupported.
+
+    def lookup(className: String, release: String): Boolean = {
+      val settings = new Settings()
+      settings.usejavacp.value = true
+      val g = new Global(settings)
+      import g._
+      settings.release.value = release
+      new Run
+      rootMirror.getClassIfDefined(TypeName(className)) != NoSymbol
+    }
+    Assert.assertTrue(lookup("java.lang.invoke.LambdaMetafactory", "8"))
+    Assert.assertFalse(lookup("java.lang.invoke.LambdaMetafactory", "7"))
+    Assert.assertTrue(lookup("java.lang.invoke.LambdaMetafactory", "9"))
+  }
+
+  private def createManifest = {
+    val manifest = new java.util.jar.Manifest()
+    manifest.getMainAttributes.put(Name.MANIFEST_VERSION, "1.0")
+    manifest.getMainAttributes.put(new Attributes.Name("Multi-Release"), String.valueOf(true))
+    val os = new ByteArrayOutputStream()
+    manifest.write(os)
+    val manifestBytes = os.toByteArray
+    manifestBytes
+  }
+  private def createZip(zipLocation: Path, content: List[(String, Array[Byte])]): Unit = {
+    val env = new java.util.HashMap[String, String]()
+    Files.deleteIfExists(zipLocation)
+    env.put("create", String.valueOf(true))
+    val fileUri = zipLocation.toUri
+    val zipUri = new java.net.URI("jar:" + fileUri.getScheme, fileUri.getPath, null)
+    val zipfs = FileSystems.newFileSystem(zipUri, env)
+    try {
+      try {
+        for ((internalPath, contentBytes) <- content) {
+          val internalTargetPath = zipfs.getPath(internalPath)
+          Files.createDirectories(internalTargetPath.getParent)
+          Files.write(internalTargetPath, contentBytes)
+        }
+      } finally {
+        if (zipfs != null) zipfs.close()
+      }
+    } finally {
+      zipfs.close()
+    }
+  }
+
+
+
+}


### PR DESCRIPTION
Introduces a `-release N` compiler flag which accepts a JDK major version `N` (8, 9, 10). This flag only has an effect when the compiler runs on a JDK >= 9.

Specifying `-release` has two effects:
  - For multi-release JARs ([JEP-238](http://openjdk.java.net/jeps/238)) on the classpath, the visible classfiles correspond to the selected JDK version
  - The JDK on the classpath corresponds to the selected JDK version ([JEP-247](http://openjdk.java.net/jeps/247)).

Technical detail: JDKs >= 9 ship with a `ct.sym` file, which is a zip file containing stripped-down classfiles with no code, only signatures, renamed with a `.sig` file extension. The folder structure within `ct.sym` allows selecting the `sig` files for a specific JDK major version.

This option is currently incompatible with the `scaladoc` tool.