### PR TITLE
Compile from irregular files

### DIFF
--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -176,20 +176,20 @@ class ScriptRunner extends HasCompileSocket {
     }
   }
 
-  /** Run a script file with the specified arguments and compilation
-   *  settings.
+  /** Run a script file with the specified arguments and compilation settings.
    *
-   * @return true if compilation and execution succeeded, false otherwise.
+   *  @return true if compilation and execution succeeded, false otherwise.
    */
-  def runScript(
-    settings: GenericRunnerSettings,
-    scriptFile: String,
-    scriptArgs: List[String]): Boolean =
-  {
-    if (File(scriptFile).isFile)
-      withCompiledScript(settings, scriptFile) { runCompiled(settings, _, scriptArgs) }
-    else
-      throw new IOException("no such file: " + scriptFile)
+  def runScript(settings: GenericRunnerSettings, scriptFile: String, scriptArgs: List[String]): Boolean = {
+    def checkedScript = {
+      val f = File(scriptFile)
+      if (!f.exists) throw new IOException(s"no such file: $scriptFile")
+      if (!f.canRead) throw new IOException(s"can't read: $scriptFile")
+      if (f.isDirectory) throw new IOException(s"can't compile a directory: $scriptFile")
+      if (!settings.nc && !f.isFile) throw new IOException(s"compile server requires a regular file: $scriptFile")
+      scriptFile
+    }
+    withCompiledScript(settings, checkedScript) { runCompiled(settings, _, scriptArgs) }
   }
 
   /** Calls runScript and catches the enumerated exceptions, routing

--- a/src/compiler/scala/tools/nsc/io/SourceReader.scala
+++ b/src/compiler/scala/tools/nsc/io/SourceReader.scala
@@ -27,10 +27,10 @@ class SourceReader(decoder: CharsetDecoder, reporter: Reporter) {
   /** The output character buffer */
   private var chars: CharBuffer = CharBuffer.allocate(0x4000)
 
-  private def reportEncodingError(filename:String) = {
+  private def reportEncodingError(filename: String, e: Exception) = {
+    val advice = "Please try specifying another one using the -encoding option"
     reporter.error(scala.reflect.internal.util.NoPosition,
-                   "IO error while decoding "+filename+" with "+decoder.charset()+"\n"+
-                   "Please try specifying another one using the -encoding option")
+      s"IO error while decoding $filename with ${decoder.charset()}: ${e.getMessage}\n$advice")
   }
 
   /** Reads the specified file. */
@@ -38,7 +38,7 @@ class SourceReader(decoder: CharsetDecoder, reporter: Reporter) {
     val c = new FileInputStream(file).getChannel
 
     try read(c)
-    catch { case e: Exception => reportEncodingError("" + file) ; Array() }
+    catch { case e: Exception => reportEncodingError("" + file, e) ; Array() }
     finally c.close()
   }
 
@@ -51,7 +51,7 @@ class SourceReader(decoder: CharsetDecoder, reporter: Reporter) {
       case _                   => read(ByteBuffer.wrap(file.toByteArray))
     }
     catch {
-      case e: Exception => reportEncodingError("" + file) ; Array()
+      case e: Exception => reportEncodingError("" + file, e) ; Array()
     }
   }
 

--- a/src/reflect/scala/reflect/io/AbstractFile.scala
+++ b/src/reflect/scala/reflect/io/AbstractFile.scala
@@ -30,7 +30,7 @@ object AbstractFile {
    * abstract regular file backed by it. Otherwise, returns `null`.
    */
   def getFile(file: File): AbstractFile =
-    if (file.isFile) new PlainFile(file) else null
+    if (!file.isDirectory) new PlainFile(file) else null
 
   /** Returns "getDirectory(new File(path))". */
   def getDirectory(path: Path): AbstractFile = getDirectory(path.toFile)


### PR DESCRIPTION
Non-directories that are not regular files do not report
`isFile`, but it can be useful to compile them.

```
$ skala <(echo 'println("Hello")')
java.io.IOException: compile server requires a regular file: /dev/fd/63
	at scala.tools.nsc.ScriptRunner.checkedScript$1(ScriptRunner.scala:189)
	at scala.tools.nsc.ScriptRunner.runScript(ScriptRunner.scala:192)
	at scala.tools.nsc.ScriptRunner.runScriptAndCatch(ScriptRunner.scala:203)
	at scala.tools.nsc.MainGenericRunner.runTarget$1(MainGenericRunner.scala:70)
	at scala.tools.nsc.MainGenericRunner.run$1(MainGenericRunner.scala:85)
	at scala.tools.nsc.MainGenericRunner.process(MainGenericRunner.scala:96)
	at scala.tools.nsc.MainGenericRunner$.main(MainGenericRunner.scala:101)
	at scala.tools.nsc.MainGenericRunner.main(MainGenericRunner.scala)
$ skala -nc <(echo 'println("Hello")')
Hello
$ skalac <(echo 'object X extends App { println("Hello")}') && skala X
Hello
```

Fixes scala/bug#8294