### PR TITLE
Test to close scala/bug#6528.

### DIFF
--- a/test/files/neg/t6528.check
+++ b/test/files/neg/t6528.check
@@ -1,0 +1,4 @@
+t6528.scala:6: error: could not find implicit value for parameter e: CoSet[U,Any]
+  implicitly[CoSet[U, Any]]
+            ^
+one error found

--- a/test/files/neg/t6528.scala
+++ b/test/files/neg/t6528.scala
@@ -1,0 +1,13 @@
+trait CoSet[U, +A <: U]
+  extends CoSetLike[U, A, ({type S[A1 <: U] = CoSet[U, A1]})#S]
+
+trait CoSetLike[U, +A <: U, +This[X] <: CoSetLike[U, A, This] with CoSet[U, A]] {
+
+  implicitly[CoSet[U, Any]]
+  // should report "implicit not found"
+  // was triggering a StackOverflow as getClassParts looped over
+  // the steam of types:
+  // CoSet#6940[U#6966,A1#22868]
+  // CoSet#6940[U#6966,A1#22876]
+  // CoSet#6940[U#6966,A1#...]
+}


### PR DESCRIPTION
Test confirming that scala/bug#6528 is fixed, possibly as a result of https://github.com/scala/scala/pull/6010.