### PR TITLE
REPL command completion is cursor sensitive

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/Completion.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Completion.scala
@@ -21,7 +21,7 @@ object NoCompletion extends Completion {
 }
 
 object Completion {
-  case class Candidates(cursor: Int, candidates: List[String]) { }
+  case class Candidates(cursor: Int, candidates: List[String])
   val NoCandidates = Candidates(-1, Nil)
 
   // a leading dot plus something, but not ".." or "./", ignoring leading whitespace

--- a/src/repl/scala/tools/nsc/interpreter/LoopCommands.scala
+++ b/src/repl/scala/tools/nsc/interpreter/LoopCommands.scala
@@ -86,7 +86,7 @@ trait LoopCommands { self: { def echo(msg: String): Unit } =>
   }
   def ambiguousError(cmd: String): Result = {
     matchingCommands(cmd) match {
-      case Nil  => echo(cmd + ": no such command.  Type :help for help.")
+      case Nil  => echo(s"No such command '$cmd'.  Type :help for help.")
       case xs   => echo(cmd + " is ambiguous: did you mean " + xs.map(":" + _.name).mkString(" or ") + "?")
     }
     Result(keepRunning = true, None)
@@ -95,7 +95,7 @@ trait LoopCommands { self: { def echo(msg: String): Unit } =>
   // all commands with given prefix
   private def matchingCommands(cmd: String) = commands.filter(_.name.startsWith(cmd.stripPrefix(":")))
 
-  // extract command from partial name, or prefer exact match if multiple matches
+  // extract unique command from partial name, or prefer exact match if multiple matches
   private object CommandMatch {
     def unapply(name: String): Option[LoopCommand] =
       matchingCommands(name) match {
@@ -108,6 +108,7 @@ trait LoopCommands { self: { def echo(msg: String): Unit } =>
   // extract command name and rest of line
   private val commandish = """(\S+)(?:\s+)?(.*)""".r
 
+  // expect line includes leading colon
   def colonCommand(line: String): Result = line.trim match {
     case ""                                  => helpSummary()
     case commandish(CommandMatch(cmd), rest) => cmd(rest)
@@ -117,21 +118,30 @@ trait LoopCommands { self: { def echo(msg: String): Unit } =>
 
   import Completion.Candidates
 
-  def colonCompletion(line: String, cursor: Int): Completion = line.trim match {
-    case commandish(name @ CommandMatch(cmd), rest) =>
-      if (name.length > cmd.name.length) cmd.completion
-      else
-        new Completion {
-          def resetVerbosity(): Unit = ()
-          def complete(buffer: String, cursor: Int) = Candidates(cursor - name.length + 1, List(cmd.name))
+  def colonCompletion(line: String, cursor: Int): Completion =
+    line match {
+      case commandish(name0, rest) =>
+        val name = name0 take cursor
+        val cmds = matchingCommands(name)
+        val cursorAtName = cursor <= name.length
+        cmds match {
+          case Nil                            => NoCompletion
+          case cmd :: Nil if !cursorAtName    => cmd.completion
+          case cmd :: Nil if cmd.name == name => NoCompletion
+          case cmd :: Nil =>
+            val completion = if (cmd.isInstanceOf[NullaryCmd] || cursor < line.length) cmd.name else cmd.name + " "
+            new Completion {
+              def resetVerbosity(): Unit = ()
+              def complete(buffer: String, cursor: Int) = Candidates(cursor = 1, List(completion))
+            }
+          case cmd :: rest =>
+            new Completion {
+              def resetVerbosity(): Unit = ()
+              def complete(buffer: String, cursor: Int) = Candidates(cursor = 1, cmds.map(_.name))
+            }
         }
-    case commandish(name, _) if matchingCommands(name).nonEmpty =>
-      new Completion {
-        def resetVerbosity(): Unit = ()
-        def complete(buffer: String, cursor: Int) = Candidates(cursor - name.length + 1, matchingCommands(name).map(_.name))
-      }
-    case _ => NoCompletion
-  }
+      case _       => NoCompletion
+    }
 
   class NullaryCmd(name: String, help: String, detailedHelp: Option[String],
     f: String => Result) extends LoopCommand(name, help, detailedHelp) {


### PR DESCRIPTION
Completes `:lo^x.s` to `:load^x.s` and `:lo` to `:load ^`.

Fixes scala/bug#10757
Fixes scala/bug#10468