### PR TITLE
scala/bug#4364. Mention null in extractor pattern

### DIFF
--- a/spec/08-pattern-matching.md
+++ b/spec/08-pattern-matching.md
@@ -216,6 +216,9 @@ $x(q_1 , \ldots , q_m, p_1 , \ldots , p_n)$ if it takes exactly one argument
 and its result type is of the form `Option[($T_1 , \ldots , T_m$, Seq[S])]` (if `m = 0`, the type `Option[Seq[S]]` is also accepted).
 This case is further discussed [below](#pattern-sequences).
 
+Note that `null` is one of the values that could be passed into `unapply` or `unapplySeq`.
+If an extractor wishes to not match on `null`, it must check for it and return `false`/`None`.
+
 ###### Example
 
 If we define an extractor object `Pair`:
@@ -223,7 +226,9 @@ If we define an extractor object `Pair`:
 ```scala
 object Pair {
   def apply[A, B](x: A, y: B) = Tuple2(x, y)
-  def unapply[A, B](x: Tuple2[A, B]): Option[Tuple2[A, B]] = Some(x)
+  def unapply[A, B](x: Tuple2[A, B]): Option[Tuple2[A, B]] =
+    if (x eq null) None
+    else Some(x)
 }
 ```
 
@@ -235,6 +240,10 @@ Hence, the following is possible:
 val x = (1, 2)
 val y = x match {
   case Pair(i, s) => Pair(s + i, i * i)
+}
+val z = null match {
+  case Pair(_, _) => "a pair"
+  case _          => "not a pair"
 }
 ```
 


### PR DESCRIPTION
Ref https://github.com/scala/bug/issues/4364

The specification clarification that is needed is this: What should the pattern matcher do when encountering a `null` and an extractor pattern?

As it stands, SLS does not say anything about `null` for extractor pattern, which leads:
- Pattern matcher will happily pass `null` into your extractor.
- I can write a `null`-matching extractor MyNull.
- Thus, all extractor authors must check for `null` if they would like to access the passed in argument `x`. See `Animal` example below.

There are potentially two things we can do.
1. Be ok with the status quo. Clarify in SLS that all extractor authors must handle null.
2. Not be ok with the status quo. Change SLS and implementation such that null is treated as no match (empty). I've sent in the change as https://github.com/scala/scala/pull/6485.

I think Paul is suggesting option 1 in https://github.com/scala/bug/issues/4364, not spec change. Given that there are no outcry of `null` handling besides https://github.com/scala/bug/issues/2241, I think that's fine too.

### MyNull

```scala
scala> object MyNull {
     |   def unapply(x: AnyRef): Option[AnyRef] =
     |     if (x eq null) Some(x) else None
     | }
defined object MyNull

scala> null match { case MyNull(_) => "yes"; case _ => "no" }
res4: String = yes
```

### Animal

```scala
scala> object Animal {
     |   def unapply(x: AnyRef): Option[AnyRef] =
     |     if (x.toString == "Animal") Some(x)
     |     else None
     | }
defined object Animal

scala> null match { case Animal(_) => "yes"; case _ => "no" }
java.lang.NullPointerException
  at Animal$.unapply(<console>:13)
  ... 37 elided
```