### PR TITLE
[WIP] bug#10511 Restructure Numeric/Ordering [ci: last-only]

### DIFF
--- a/src/library/scala/math/Fractional.scala
+++ b/src/library/scala/math/Fractional.scala
@@ -22,6 +22,9 @@ trait Fractional[T] extends Numeric[T] {
   }
   override implicit def mkNumericOps(lhs: T): FractionalOps =
     new FractionalOps(lhs)
+
+  @deprecated("It doesn't make sense to reverse a Fractional", "2.13.0")
+  override def reverse: PartialOrdering[T] = new ReversePartialOrdering
 }
 
 object Fractional {

--- a/src/library/scala/math/Integral.scala
+++ b/src/library/scala/math/Integral.scala
@@ -14,7 +14,7 @@ import scala.language.implicitConversions
 /**
  * @since 2.8
  */
-trait Integral[T] extends Numeric[T] {
+trait Integral[T] extends Ordering[T] with Numeric[T] {
   def quot(x: T, y: T): T
   def rem(x: T, y: T): T
 

--- a/src/library/scala/math/Integral.scala
+++ b/src/library/scala/math/Integral.scala
@@ -24,6 +24,11 @@ trait Integral[T] extends Ordering[T] with Numeric[T] {
     def /%(rhs: T) = (quot(lhs, rhs), rem(lhs, rhs))
   }
   override implicit def mkNumericOps(lhs: T): IntegralOps = new IntegralOps(lhs)
+
+  @deprecated("It doesn't make sense to reverse an Integral", "2.13.0")
+  override def reverse: Ordering[T] = new ReverseOrdering
+
+  override protected def deprecatedAsOrdering: Ordering[T] = this
 }
 
 object Integral {

--- a/src/library/scala/math/Numeric.scala
+++ b/src/library/scala/math/Numeric.scala
@@ -268,12 +268,30 @@ trait Numeric[T] extends PartialOrdering[T] {
   }
   implicit def mkNumericOps(lhs: T): Ops = new Ops(lhs)
 
+  @deprecated("It doesn't make sense to reverse a Numeric", "2.13.0")
+  override def reverse: PartialOrdering[T] = super.reverse
+
   /** Used for deprecated conversion to [[scala.math.Ordering `Ordering`]].
     *
     * Override if you wish to support exact previous `Ordering` semantics.
+    *
+    * This method is only expected to exist for two deprecation cycles.
     */
+  // TODO: deprecate in 2.14
   protected def deprecatedAsOrdering: Ordering[T] = {
     if (this.isInstanceOf[Ordering[_]]) this.asInstanceOf[Ordering[T]]
     else new AnyRef with AsUnsafeTotalOrdering
   }
+
+  /* deprecated methods previously inherited from Ordering */
+  @deprecated("Numeric no longer extends Ordering, as it is not always consistent", "2.13.0")
+  def compare(x: T, y: T): Int = deprecatedAsOrdering.compare(x, y)
+  @deprecated("Numeric no longer extends Ordering, as it is not always consistent", "2.13.0")
+  def max(x: T, y: T): T = deprecatedAsOrdering.max(x, y)
+  @deprecated("Numeric no longer extends Ordering, as it is not always consistent", "2.13.0")
+  def min(x: T, y: T): T = deprecatedAsOrdering.min(x, y)
+  @deprecated("Numeric no longer extends Ordering, as it is not always consistent", "2.13.0")
+  def on[U](f: U => T): Ordering[U] = deprecatedAsOrdering.on(f)
+  @deprecated("Numeric no longer extends Ordering, as it is not always consistent", "2.13.0")
+  implicit def mkOrderingOps(lhs: T): Ordering[T]#Ops = deprecatedAsOrdering.mkOrderingOps(lhs)
 }

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -109,6 +109,12 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   override def reverse: Ordering[T] = new Ordering[T] {
     override def reverse = outer
     def compare(x: T, y: T) = outer.compare(y, x)
+    override def lteq(x: T, y: T) = outer.lteq(y, x)
+    override def gteq(x: T, y: T) = outer.gteq(y, x)
+    override def lt(x: T, y: T) = outer.lt(y, x)
+    override def gt(x: T, y: T) = outer.gt(y, x)
+    override def max(x: T, y: T) = outer.min(x, y)
+    override def min(x: T, y: T) = outer.max(x, y)
   }
 
   /** Given f, a function from U into T, creates an Ordering[U] whose compare

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -105,17 +105,19 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   /** Return `x` if `x` <= `y`, otherwise `y`. */
   def min(x: T, y: T): T = if (lteq(x, y)) x else y
 
-  /** Return the opposite ordering of this one. */
-  override def reverse: Ordering[T] = new Ordering[T] {
-    override def reverse = outer
-    def compare(x: T, y: T) = outer.compare(y, x)
-    override def lteq(x: T, y: T) = outer.lteq(y, x)
-    override def gteq(x: T, y: T) = outer.gteq(y, x)
-    override def lt(x: T, y: T) = outer.lt(y, x)
-    override def gt(x: T, y: T) = outer.gt(y, x)
-    override def max(x: T, y: T) = outer.min(x, y)
-    override def min(x: T, y: T) = outer.max(x, y)
+  private[math] class ReverseOrdering extends Ordering[T] {
+    override def reverse: Ordering[T] = outer
+    def compare(x: T, y: T): Int = outer.compare(y, x)
+    override def lteq(x: T, y: T): Boolean = outer.lteq(y, x)
+    override def gteq(x: T, y: T): Boolean = outer.gteq(y, x)
+    override def lt(x: T, y: T): Boolean = outer.lt(y, x)
+    override def gt(x: T, y: T): Boolean = outer.gt(y, x)
+    override def max(x: T, y: T): T = outer.min(x, y)
+    override def min(x: T, y: T): T = outer.max(x, y)
   }
+
+  /** Return the opposite ordering of this one. */
+  override def reverse: Ordering[T] = new ReverseOrdering
 
   /** Given f, a function from U into T, creates an Ordering[U] whose compare
     * function is equivalent to:

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -312,57 +312,12 @@ object Ordering extends LowPriorityOrderingImplicits {
   implicit object Long extends LongOrdering
 
   trait FloatOrdering extends Ordering[Float] {
-    outer =>
-
     def compare(x: Float, y: Float) = java.lang.Float.compare(x, y)
-
-    override def lteq(x: Float, y: Float): Boolean = x <= y
-    override def gteq(x: Float, y: Float): Boolean = x >= y
-    override def lt(x: Float, y: Float): Boolean = x < y
-    override def gt(x: Float, y: Float): Boolean = x > y
-    override def equiv(x: Float, y: Float): Boolean = x == y
-    override def max(x: Float, y: Float): Float = math.max(x, y)
-    override def min(x: Float, y: Float): Float = math.min(x, y)
-
-    override def reverse: Ordering[Float] = new FloatOrdering {
-      override def reverse = outer
-      override def compare(x: Float, y: Float) = outer.compare(y, x)
-
-      override def lteq(x: Float, y: Float): Boolean = outer.lteq(y, x)
-      override def gteq(x: Float, y: Float): Boolean = outer.gteq(y, x)
-      override def lt(x: Float, y: Float): Boolean = outer.lt(y, x)
-      override def gt(x: Float, y: Float): Boolean = outer.gt(y, x)
-      override def min(x: Float, y: Float): Float = outer.max(x, y)
-      override def max(x: Float, y: Float): Float = outer.min(x, y)
-
-    }
   }
   implicit object Float extends FloatOrdering
 
   trait DoubleOrdering extends Ordering[Double] {
-    outer =>
-
     def compare(x: Double, y: Double) = java.lang.Double.compare(x, y)
-
-    override def lteq(x: Double, y: Double): Boolean = x <= y
-    override def gteq(x: Double, y: Double): Boolean = x >= y
-    override def lt(x: Double, y: Double): Boolean = x < y
-    override def gt(x: Double, y: Double): Boolean = x > y
-    override def equiv(x: Double, y: Double): Boolean = x == y
-    override def max(x: Double, y: Double): Double = math.max(x, y)
-    override def min(x: Double, y: Double): Double = math.min(x, y)
-
-    override def reverse: Ordering[Double] = new DoubleOrdering {
-      override def reverse = outer
-      override def compare(x: Double, y: Double) = outer.compare(y, x)
-
-      override def lteq(x: Double, y: Double): Boolean = outer.lteq(y, x)
-      override def gteq(x: Double, y: Double): Boolean = outer.gteq(y, x)
-      override def lt(x: Double, y: Double): Boolean = outer.lt(y, x)
-      override def gt(x: Double, y: Double): Boolean = outer.gt(y, x)
-      override def min(x: Double, y: Double): Double = outer.max(x, y)
-      override def max(x: Double, y: Double): Double = outer.min(x, y)
-    }
   }
   implicit object Double extends DoubleOrdering
 

--- a/src/library/scala/math/PartialOrdering.scala
+++ b/src/library/scala/math/PartialOrdering.scala
@@ -72,14 +72,16 @@ trait PartialOrdering[T] extends Equiv[T] {
    */
   def equiv(x: T, y: T): Boolean = lteq(x,y) && lteq(y,x)
 
-  def reverse : PartialOrdering[T] = new PartialOrdering[T] {
-    override def reverse = outer
-    def tryCompare(x: T, y: T) = outer.tryCompare(y, x)
-    def lteq(x: T, y: T) = outer.lteq(y, x)
-    override def gteq(x: T, y: T) = outer.gteq(y, x)
-    override def lt(x: T, y: T) = outer.lt(y, x)
-    override def gt(x: T, y: T) = outer.gt(y, x)
+  private[math] class ReversePartialOrdering extends PartialOrdering[T] {
+    override def reverse: PartialOrdering[T] = outer
+    def tryCompare(x: T, y: T): Option[Int] = outer.tryCompare(y, x)
+    def lteq(x: T, y: T): Boolean = outer.lteq(y, x)
+    override def gteq(x: T, y: T): Boolean = outer.gteq(y, x)
+    override def lt(x: T, y: T): Boolean = outer.lt(y, x)
+    override def gt(x: T, y: T): Boolean = outer.gt(y, x)
   }
+
+  def reverse : PartialOrdering[T] = new ReversePartialOrdering
 
   /** An [[scala.math.Ordering `Ordering`]] which behaves the same
     * as this `PartialOrdering` when comparisons are supported,

--- a/src/library/scala/math/PartialOrdering.scala
+++ b/src/library/scala/math/PartialOrdering.scala
@@ -74,7 +74,10 @@ trait PartialOrdering[T] extends Equiv[T] {
 
   def reverse : PartialOrdering[T] = new PartialOrdering[T] {
     override def reverse = outer
-    def lteq(x: T, y: T) = outer.lteq(y, x)
     def tryCompare(x: T, y: T) = outer.tryCompare(y, x)
+    def lteq(x: T, y: T) = outer.lteq(y, x)
+    override def gteq(x: T, y: T) = outer.gteq(y, x)
+    override def lt(x: T, y: T) = outer.lt(y, x)
+    override def gt(x: T, y: T) = outer.gt(y, x)
   }
 }

--- a/test/junit/scala/SerializationStabilityTest.scala
+++ b/test/junit/scala/SerializationStabilityTest.scala
@@ -81,7 +81,7 @@ object SerializationStability extends App {
     }
   }
 
-  // Generated on 20170710-04:55:44 with Scala version 2.13.0-20170709-181218-287a569)
+  // Generated on 20180305-04:42:35 with Scala version 2.13.0-20180305-034251-c8e7abf)
   overwrite.foreach(updateComment)
 
   check(Some(1))("rO0ABXNyAApzY2FsYS5Tb21lESLyaV6hi3QCAAFMAAV2YWx1ZXQAEkxqYXZhL2xhbmcvT2JqZWN0O3hyAAxzY2FsYS5PcHRpb27+aTf92w5mdAIAAHhwc3IAEWphdmEubGFuZy5JbnRlZ2VyEuKgpPeBhzgCAAFJAAV2YWx1ZXhyABBqYXZhLmxhbmcuTnVtYmVyhqyVHQuU4IsCAAB4cAAAAAE=")

--- a/test/junit/scala/collection/immutable/RangeConsistencyTest.scala
+++ b/test/junit/scala/collection/immutable/RangeConsistencyTest.scala
@@ -151,7 +151,7 @@ class RangeConsistencyTest {
 
   @Test
   def test_SI9388()  {
-    val possiblyNotDefaultNumeric = new scala.math.Numeric[Int] {
+    val possiblyNotDefaultNumeric = new scala.math.Numeric[Int] with scala.math.Ordering[Int] {
       def fromInt(x: Int) = x
       def parseString(str: String): Option[Int] = Try(str.toInt).toOption
       def minus(x: Int, y: Int): Int = x - y

--- a/test/scalacheck/nan-ordering.scala
+++ b/test/scalacheck/nan-ordering.scala
@@ -41,20 +41,6 @@ object NanOrderingTest extends Properties("NaN-Ordering") {
 
   property("Float equiv") = forAll(specFloats, specFloats) { (d1, d2) => numFloat.equiv(d1, d2) == (d1 == d2) }
 
-  property("Float reverse.min") = forAll(specFloats, specFloats) { (d1, d2) => {
-      val mathmax = math.max(d1, d2)
-      val numericmin = numFloat.reverse.min(d1, d2)
-      mathmax == numericmin || mathmax.isNaN && numericmin.isNaN
-    }
-  }
-
-  property("Float reverse.max") = forAll(specFloats, specFloats) { (d1, d2) => {
-      val mathmin = math.min(d1, d2)
-      val numericmax = numFloat.reverse.max(d1, d2)
-      mathmin == numericmax || mathmin.isNaN && numericmax.isNaN
-    }
-  }
-
   property("Float reverse.lt") = forAll(specFloats, specFloats) { (d1, d2) => numFloat.reverse.lt(d1, d2) == d2 < d1 }
 
   property("Float reverse.lteq") = forAll(specFloats, specFloats) { (d1, d2) => numFloat.reverse.lteq(d1, d2) == d2 <= d1 }
@@ -103,20 +89,6 @@ object NanOrderingTest extends Properties("NaN-Ordering") {
   property("Double gteq") = forAll(specDoubles, specDoubles) { (d1, d2) => numDouble.gteq(d1, d2) == d1 >= d2 }
 
   property("Double equiv") = forAll(specDoubles, specDoubles) { (d1, d2) => numDouble.equiv(d1, d2) == (d1 == d2) }
-
-  property("Double reverse.min") = forAll(specDoubles, specDoubles) { (d1, d2) => {
-    val mathmax = math.max(d1, d2)
-    val numericmin = numDouble.reverse.min(d1, d2)
-    mathmax == numericmin || mathmax.isNaN && numericmin.isNaN
-  }
-  }
-
-  property("Double reverse.max") = forAll(specDoubles, specDoubles) { (d1, d2) => {
-    val mathmin = math.min(d1, d2)
-    val numericmax = numDouble.reverse.max(d1, d2)
-    mathmin == numericmax || mathmin.isNaN && numericmax.isNaN
-  }
-  }
 
   property("Double reverse.lt") = forAll(specDoubles, specDoubles) { (d1, d2) => numDouble.reverse.lt(d1, d2) == d2 < d1 }
 

--- a/test/scalacheck/range.scala
+++ b/test/scalacheck/range.scala
@@ -161,7 +161,7 @@ abstract class RangeTest(kind: String) extends Properties("Range "+kind) {
 /* checks that sum respects custom Numeric */
   property("sumCustomNumeric") = forAll(myGen) { r =>
     val mod = 65536
-    object mynum extends Numeric[Int] {
+    object mynum extends Numeric[Int] with Ordering[Int] {
         def plus(x: Int, y: Int): Int = (x + y) % mod
         override def zero = 0
 


### PR DESCRIPTION
Change `Numeric` to inherit from `PartialOrdering` instead of `Ordering`. `Integral` still inherits from `Ordering`.

Add deprecated conversion from `Numeric` to `Ordering`, to help mitigate transition pains.

Fixes scala/bug#10511 (hopefully).

See also the discussion on #6323.

I don't know if these changes are viable or not, but I believe they fix (or at least reduce) the inconsistency in the behaviour of `Numeric[Float]` and `Numeric[Double]`. Feedback is greatly appreciated.