### PR TITLE
Change flags from Int to Long, and remove hasFlag(flag: Int) method.

### DIFF
--- a/src/compiler/scala/reflect/quasiquotes/Parsers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Parsers.scala
@@ -94,7 +94,7 @@ trait Parsers { self: Quasiquotes =>
       import treeBuilder.{global => _, unit => _}
 
       // q"def foo($x)"
-      override def param(owner: Name, implicitmod: Int, caseParam: Boolean): ValDef =
+      override def param(owner: Name, implicitmod: Long, caseParam: Boolean): ValDef =
         if (isHole && lookingAhead { in.token == COMMA || in.token == RPAREN }) {
           ParamPlaceholder(implicitmod, ident())
         } else super.param(owner, implicitmod, caseParam)

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2336,7 +2336,7 @@ self =>
       }
     }
 
-    def param(owner: Name, implicitmod: Int, caseParam: Boolean): ValDef = {
+    def param(owner: Name, implicitmod: Long, caseParam: Boolean): ValDef = {
       val start = in.offset
       val annots = annotations(skipNewLines = false)
       var mods = Modifiers(Flags.PARAM)
@@ -2356,7 +2356,7 @@ self =>
       }
       val nameOffset = in.offset
       val name = ident()
-      var bynamemod = 0
+      var bynamemod = 0L
       val tpt =
         if ((settings.YmethodInfer && !owner.isTypeName) && in.token != COLON) {
           TypeTree()
@@ -2383,7 +2383,7 @@ self =>
           expr()
         } else EmptyTree
       atPos(start, if (name == nme.ERROR) start else nameOffset) {
-        ValDef((mods | implicitmod.toLong | bynamemod) withAnnotations annots, name.toTermName, tpt, default)
+        ValDef((mods | implicitmod | bynamemod) withAnnotations annots, name.toTermName, tpt, default)
       }
     }
 
@@ -3204,10 +3204,10 @@ self =>
     }
     */
 
-    def localDef(implicitMod: Int): List[Tree] = {
+    def localDef(implicitMod: Long): List[Tree] = {
       val annots = annotations(skipNewLines = true)
       val pos = in.offset
-      val mods = (localModifiers() | implicitMod.toLong) withAnnotations annots
+      val mods = (localModifiers() | implicitMod) withAnnotations annots
       val defs =
         if (!(mods hasFlag ~(Flags.IMPLICIT | Flags.LAZY))) defOrDcl(pos, mods)
         else List(tmplDef(pos, mods))

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1225,12 +1225,12 @@ trait ContextErrors {
       }
 
 
-      def AbstractMemberWithModiferError(sym: Symbol, flag: Int) =
-        issueSymbolTypeError(sym, "abstract member may not have " + Flags.flagsToString(flag.toLong) + " modifier")
+      def AbstractMemberWithModiferError(sym: Symbol, flag: Long) =
+        issueSymbolTypeError(sym, "abstract member may not have " + Flags.flagsToString(flag) + " modifier")
 
-      def IllegalModifierCombination(sym: Symbol, flag1: Int, flag2: Int) =
+      def IllegalModifierCombination(sym: Symbol, flag1: Long, flag2: Long) =
         issueSymbolTypeError(sym, "illegal combination of modifiers: %s and %s for: %s".format(
-            Flags.flagsToString(flag1.toLong), Flags.flagsToString(flag2.toLong), sym))
+            Flags.flagsToString(flag1), Flags.flagsToString(flag2), sym))
 
       def IllegalDependentMethTpeError(sym: Symbol)(context: Context) = {
         val errorAddendum =

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1855,8 +1855,8 @@ trait Namers extends MethodSynthesis {
       import SymValidateErrors._
       def fail(kind: SymValidateErrors.Value) = SymbolValidationError(sym, kind)
 
-      def checkNoConflict(flag1: Int, flag2: Int) = {
-        if (sym hasAllFlags flag1.toLong | flag2)
+      def checkNoConflict(flag1: Long, flag2: Long) = {
+        if (sym hasAllFlags flag1 | flag2)
           IllegalModifierCombination(sym, flag1, flag2)
       }
       if (sym.isImplicit) {
@@ -1894,7 +1894,7 @@ trait Namers extends MethodSynthesis {
         checkNoConflict(ABSTRACT, FINAL)
 
       if (sym.isDeferred) {
-        def checkWithDeferred(flag: Int) = {
+        def checkWithDeferred(flag: Long) = {
           if (sym hasFlag flag)
             AbstractMemberWithModiferError(sym, flag)
         }

--- a/src/reflect/scala/reflect/internal/Flags.scala
+++ b/src/reflect/scala/reflect/internal/Flags.scala
@@ -81,36 +81,36 @@ package internal
 /** Flags set on Modifiers instances in the parsing stage.
  */
 class ModifierFlags {
-  final val IMPLICIT      = 1 << 9
-  final val FINAL         = 1 << 5    // May not be overridden. Note that java final implies much more than scala final.
-  final val PRIVATE       = 1 << 2
-  final val PROTECTED     = 1 << 0
+   final val IMPLICIT      = 1L << 9
+  final val FINAL         = 1L << 5    // May not be overridden. Note that java final implies much more than scala final.
+  final val PRIVATE       = 1L << 2
+  final val PROTECTED     = 1L << 0
 
-  final val SEALED        = 1 << 10
-  final val OVERRIDE      = 1 << 1
-  final val CASE          = 1 << 11
-  final val ABSTRACT      = 1 << 3        // abstract class, or used in conjunction with abstract override.
+  final val SEALED        = 1L << 10
+  final val OVERRIDE      = 1L << 1
+  final val CASE          = 1L << 11
+  final val ABSTRACT      = 1L << 3        // abstract class, or used in conjunction with abstract override.
                                           // Note difference to DEFERRED!
-  final val DEFERRED      = 1 << 4        // was `abstract' for members | trait is virtual
-  final val INTERFACE     = 1 << 7        // symbol is an interface. the flag is set for:
+  final val DEFERRED      = 1L << 4        // was `abstract' for members | trait is virtual
+  final val INTERFACE     = 1L << 7        // symbol is an interface. the flag is set for:
                                           //  - scala-defined traits with only abstract methods or fields
                                           //  - any java-defined interface (even if it has default methods)
-  final val MUTABLE       = 1 << 12       // symbol is a mutable variable.
-  final val PARAM         = 1 << 13       // symbol is a (value or type) parameter to a method
-  final val MACRO         = 1 << 15       // symbol is a macro definition
+  final val MUTABLE       = 1L << 12       // symbol is a mutable variable.
+  final val PARAM         = 1L << 13       // symbol is a (value or type) parameter to a method
+  final val MACRO         = 1L << 15       // symbol is a macro definition
 
-  final val COVARIANT     = 1 << 16       // symbol is a covariant type variable
-  final val BYNAMEPARAM   = 1 << 16       // parameter is by name
-  final val CONTRAVARIANT = 1 << 17       // symbol is a contravariant type variable
-  final val ABSOVERRIDE   = 1 << 18       // combination of abstract & override
-  final val LOCAL         = 1 << 19       // symbol is local to current class (i.e. private[this] or protected[this]
+  final val COVARIANT     = 1L << 16       // symbol is a covariant type variable
+  final val BYNAMEPARAM   = 1L << 16       // parameter is by name
+  final val CONTRAVARIANT = 1L << 17       // symbol is a contravariant type variable
+  final val ABSOVERRIDE   = 1L << 18       // combination of abstract & override
+  final val LOCAL         = 1L << 19       // symbol is local to current class (i.e. private[this] or protected[this]
                                           // pre: PRIVATE or PROTECTED are also set
-  final val JAVA          = 1 << 20       // symbol was defined by a Java class
-  final val STATIC        = 1 << 23       // static field, method or class
-  final val CASEACCESSOR  = 1 << 24       // symbol is a case parameter (or its accessor, or a GADT skolem)
-  final val TRAIT         = 1 << 25       // symbol is a trait
-  final val DEFAULTPARAM  = 1 << 25       // the parameter has a default value
-  final val PARAMACCESSOR = 1 << 29       // for field definitions generated for primary constructor
+  final val JAVA          = 1L << 20       // symbol was defined by a Java class
+  final val STATIC        = 1L << 23       // static field, method or class
+  final val CASEACCESSOR  = 1L << 24       // symbol is a case parameter (or its accessor, or a GADT skolem)
+  final val TRAIT         = 1L << 25       // symbol is a trait
+  final val DEFAULTPARAM  = 1L << 25       // the parameter has a default value
+  final val PARAMACCESSOR = 1L << 29       // for field definitions generated for primary constructor
                                           //   parameters (no matter if it's a 'val' parameter or not)
                                           // for parameters of a primary constructor ('val' or not)
                                           // for the accessor methods generated for 'val' or 'var' parameters
@@ -134,22 +134,22 @@ object ModifierFlags extends ModifierFlags
 
 /** All flags and associated operations */
 class Flags extends ModifierFlags {
-  final val METHOD        = 1 << 6        // a method
-  final val MODULE        = 1 << 8        // symbol is module or class implementing a module
-  final val PACKAGE       = 1 << 14       // symbol is a java package
+  final val METHOD        = 1L << 6        // a method
+  final val MODULE        = 1L << 8        // symbol is module or class implementing a module
+  final val PACKAGE       = 1L << 14       // symbol is a java package
 
-  final val CAPTURED      = 1 << 16       // variable is accessed from nested function.  Set by LambdaLift.
-  final val LABEL         = 1 << 17       // method symbol is a label. Set by TailCall
-  final val INCONSTRUCTOR = 1 << 17       // class symbol is defined in this/superclass constructor.
-  final val SYNTHETIC     = 1 << 21       // symbol is compiler-generated (compare with ARTIFACT)
-  final val STABLE        = 1 << 22       // functions that are assumed to be stable
+  final val CAPTURED      = 1L << 16       // variable is accessed from nested function.  Set by LambdaLift.
+  final val LABEL         = 1L << 17       // method symbol is a label. Set by TailCall
+  final val INCONSTRUCTOR = 1L << 17       // class symbol is defined in this/superclass constructor.
+  final val SYNTHETIC     = 1L << 21       // symbol is compiler-generated (compare with ARTIFACT)
+  final val STABLE        = 1L << 22       // functions that are assumed to be stable
                                           // (typically, access methods for valdefs)
                                           // or classes that do not contain abstract types.
-  final val BRIDGE        = 1 << 26       // function is a bridge method. Set by Erasure
-  final val ACCESSOR      = 1 << 27       // a value or variable accessor (getter or setter)
+  final val BRIDGE        = 1L << 26       // function is a bridge method. Set by Erasure
+  final val ACCESSOR      = 1L << 27       // a value or variable accessor (getter or setter)
 
-  final val SUPERACCESSOR = 1 << 28       // a super accessor
-  final val MODULEVAR     = 1 << 30       // for variables: is the variable caching a module value
+  final val SUPERACCESSOR = 1L << 28       // a super accessor
+  final val MODULEVAR     = 1L << 30       // for variables: is the variable caching a module value
 
   final val IS_ERROR      = 1L << 32      // symbol is an error symbol
   final val OVERLOADED    = 1L << 33      // symbol is overloaded
@@ -340,18 +340,18 @@ class Flags extends ModifierFlags {
   // The flags from 0x001 to 0x800 are different in the raw flags
   // and in the pickled format.
 
-  private final val IMPLICIT_PKL   = (1 << 0)
-  private final val FINAL_PKL      = (1 << 1)
-  private final val PRIVATE_PKL    = (1 << 2)
-  private final val PROTECTED_PKL  = (1 << 3)
-  private final val SEALED_PKL     = (1 << 4)
-  private final val OVERRIDE_PKL   = (1 << 5)
-  private final val CASE_PKL       = (1 << 6)
-  private final val ABSTRACT_PKL   = (1 << 7)
-  private final val DEFERRED_PKL   = (1 << 8)
-  private final val METHOD_PKL     = (1 << 9)
-  private final val MODULE_PKL     = (1 << 10)
-  private final val INTERFACE_PKL  = (1 << 11)
+  private final val IMPLICIT_PKL   = (1L << 0)
+  private final val FINAL_PKL      = (1L << 1)
+  private final val PRIVATE_PKL    = (1L << 2)
+  private final val PROTECTED_PKL  = (1L << 3)
+  private final val SEALED_PKL     = (1L << 4)
+  private final val OVERRIDE_PKL   = (1L << 5)
+  private final val CASE_PKL       = (1L << 6)
+  private final val ABSTRACT_PKL   = (1L << 7)
+  private final val DEFERRED_PKL   = (1L << 8)
+  private final val METHOD_PKL     = (1L << 9)
+  private final val MODULE_PKL     = (1L << 10)
+  private final val INTERFACE_PKL  = (1L << 11)
 
   private final val PKL_MASK       = 0x00000FFF
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -742,7 +742,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       if (!isCompilerUniverse && !isThreadsafe(purpose = FlagOps(mask))) initialize
       (flags & mask) != 0
     }
-    def hasFlag(mask: Int): Boolean = hasFlag(mask.toLong)
 
     /** Does symbol have ALL the flags in `mask` set? */
     final def hasAllFlags(mask: Long): Boolean = {

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -984,12 +984,12 @@ trait Types
     /** If this is a symbol loader type, load and assign a new type to `sym`. */
     def load(sym: Symbol) {}
 
-    private def findDecl(name: Name, excludedFlags: Int): Symbol = {
+    private def findDecl(name: Name, excludedFlags: Long): Symbol = {
       var alts: List[Symbol] = List()
       var sym: Symbol = NoSymbol
       var e: ScopeEntry = decls.lookupEntry(name)
       while (e ne null) {
-        if (!e.sym.hasFlag(excludedFlags.toLong)) {
+        if (!e.sym.hasFlag(excludedFlags)) {
           if (sym == NoSymbol) sym = e.sym
           else {
             if (alts.isEmpty) alts = sym :: Nil


### PR DESCRIPTION
Performance report:
https://gist.github.com/ccjoywang/8b99fca36e05d3a7a61d6502109e2095

another run with 100 iterations 5 processors:
-----
```
ALL
                 Run Name	Cycle	samples	           Wall time (ms)	       All Wall time (ms)	                  CPU(ms)	           Idle time (ms)	           Allocated(MBs)
                     base	   1	 100	8,677.92 [-8.45% +150.87%]	8,677.92 [-8.45% +150.87%]	5,447.52 [-13.10% +211.77%]	       0.00 [ NaN%  NaN%]	1,695.55 [-0.34% +11.73%]
                     base	   2	 100	8,682.64 [-8.27% +122.24%]	8,682.64 [-8.27% +122.24%]	5,440.05 [-13.55% +182.33%]	       0.00 [ NaN%  NaN%]	1,719.55 [-0.26% +11.10%]
                     base	   3	 100	8,399.41 [-5.27% +122.19%]	8,399.41 [-5.27% +122.19%]	5,293.33 [-9.09% +178.94%]	       0.00 [ NaN%  NaN%]	 1,728.22 [-0.93% +9.76%]
                     base	   4	 100	8,574.71 [-4.85% +120.57%]	8,574.71 [-4.85% +120.57%]	5,465.21 [-11.09% +171.02%]	       0.00 [ NaN%  NaN%]	1,722.77 [-0.39% +11.07%]
                     base	   5	 100	8,542.09 [-5.71% +121.99%]	8,542.09 [-5.71% +121.99%]	5,395.94 [-9.38% +177.12%]	       0.00 [ NaN%  NaN%]	1,712.81 [-0.44% +11.20%]
                    after	   1	 100	9,240.10 [-11.97% +166.23%]	9,240.10 [-11.97% +166.23%]	5,591.61 [-12.82% +162.11%]	       0.00 [ NaN%  NaN%]	1,691.40 [-0.39% +11.32%]
                    after	   2	 100	8,383.17 [-5.41% +125.62%]	8,383.17 [-5.41% +125.62%]	5,312.51 [-11.47% +178.23%]	       0.00 [ NaN%  NaN%]	1,716.79 [-0.40% +10.56%]
                    after	   3	 100	8,536.65 [-5.22% +122.52%]	8,536.65 [-5.22% +122.52%]	5,416.58 [-9.15% +166.83%]	       0.00 [ NaN%  NaN%]	1,710.51 [-0.35% +11.52%]
                    after	   4	 100	8,611.46 [-5.53% +136.80%]	8,611.46 [-5.53% +136.80%]	5,478.93 [-9.60% +171.49%]	       0.00 [ NaN%  NaN%]	1,719.18 [-0.37% +11.79%]
                    after	   5	 100	8,429.95 [-5.40% +124.45%]	8,429.95 [-5.40% +124.45%]	5,340.49 [-9.32% +176.19%]	       0.00 [ NaN%  NaN%]	1,701.43 [-0.30% +10.92%]

```