### PR TITLE
Disable parallelism in the scalacheck suite

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -598,6 +598,9 @@ lazy val scalacheck = project.in(file("test") / "scalacheck")
     libraryDependencies ++= Seq(scalacheckDep),
     unmanagedSourceDirectories in Compile := Nil,
     unmanagedSourceDirectories in Test := List(baseDirectory.value)
+  ).settings(
+    // Workaround for https://github.com/sbt/sbt/pull/3985
+    List(Keys.test, Keys.testOnly).map(task => parallelExecution in task := false) : _*
   )
 
 lazy val osgiTestFelix = osgiTestProject(


### PR DESCRIPTION
This is a workaround for a race condition we identified:

  https://github.com/scala/scala-jenkins-infra/issues/249

A future SBT version will include this fix:

  https://github.com/sbt/sbt/pull/3985

Fixes scala/scala-jenkins-infra#249 (we hope!)