### PR TITLE
Add a `completions` command to REPL for better Emacs integration

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -177,6 +177,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter) extend
 
   /** Standard commands **/
   lazy val standardCommands = List(
+    cmd("completions", "<string>", "output completions for the given string", completionsCommand),
     cmd("edit", "<id>|<line>", "edit history", editCommand),
     cmd("help", "[command]", "print this summary or command-specific help", helpCommand),
     historyCommand,
@@ -538,6 +539,22 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter) extend
   }
 
   def lineCommand(what: String): Result = editCommand(what, None)
+
+  def completionsCommand(what: String): Result = {
+    val completions = new ReplCompletion(intp).complete(what, what.length)
+    val prefix = if (completions == NoCandidates) "" else what.substring(0, completions.cursor)
+
+    val completionLines =
+      completions.candidates.map { c =>
+        s"[completions] $prefix$c"
+      }
+
+    if (completionLines.nonEmpty) {
+      echo(completionLines.mkString("\n"))
+    }
+
+    Result.default // never record completions
+  }
 
   // :edit id or :edit line
   def editCommand(what: String): Result = editCommand(what, Properties.envOrNone("EDITOR"))

--- a/test/files/run/repl-completions.check
+++ b/test/files/run/repl-completions.check
@@ -1,0 +1,35 @@
+
+scala> // completions!
+
+scala> object O { def x_y_x = 1; def x_y_z = 2; def getFooBarZot = 3}
+defined object O
+
+scala> :completions O.x
+[completions] O.x_y_x
+[completions] O.x_y_z
+
+scala> :completions O.x_y_x
+
+scala> :completions O.x_y_a
+
+scala> import O._
+import O._
+
+scala> :completions x_y_
+[completions] x_y_x
+[completions] x_y_z
+
+scala> :completions x_y_a
+
+scala> :completions fBZ
+[completions] getFooBarZot
+
+scala> :completions object O2 { val x = O.
+[completions] object O2 { val x = O.getFooBarZot
+[completions] object O2 { val x = O.x_y_x
+[completions] object O2 { val x = O.x_y_z
+
+scala> :completions :completion
+[completions] :completions 
+
+scala> :quit

--- a/test/files/run/repl-completions.scala
+++ b/test/files/run/repl-completions.scala
@@ -1,0 +1,17 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code =
+    """|// completions!
+       |object O { def x_y_x = 1; def x_y_z = 2; def getFooBarZot = 3}
+       |:completions O.x
+       |:completions O.x_y_x
+       |:completions O.x_y_a
+       |import O._
+       |:completions x_y_
+       |:completions x_y_a
+       |:completions fBZ
+       |:completions object O2 { val x = O.
+       |:completions :completion
+       |""".stripMargin
+}


### PR DESCRIPTION
The command can be used by, for example, emacs to query completions.

There is a related PR #6382 for the 2.13.x branch