### PR TITLE
Correctly synthesize `manifest[T]` when `T` is an alias

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1304,7 +1304,7 @@ trait Implicits {
               manifestFactoryCall("arrayType", args.head, findManifest(args.head))
             } else if (sym.isClass) {
               val classarg0 = gen.mkClassOf(tp1)
-              val classarg = tp match {
+              val classarg = tp.dealias match {
                 case _: ExistentialType => gen.mkCast(classarg0, ClassType(tp))
                 case _                  => classarg0
               }

--- a/test/files/pos/t9155.scala
+++ b/test/files/pos/t9155.scala
@@ -1,0 +1,19 @@
+class A[T]
+object A {
+  type T = A[_]
+  manifest[T]
+}
+
+class B[T]
+object B {
+  type Any = B[ _ <: String]
+  manifest[B[_ <: String]]
+  manifest[B.Any]
+}
+
+class C[T]
+object C {
+  def f[T](implicit m: Manifest[T]) = 0
+  type CAlias = C[_]
+  val x = f[CAlias]
+}


### PR DESCRIPTION
This

    class A[T]
    object A {
      type T = A[_]
      manifest[T]
    }

crashed the compiler. Comparing the AST generated for `manifest[T]` with
the working version `manifest[A[_]]` shows that a cast is inserted to
the `classOf` argument in the latter case, but not the former.

For `manifest[T]`:

    scala.Predef.manifest[A.T](
      scala.reflect.ManifestFactory.classType[A.T](
        classOf[A],
        ...

For `manifest[A[_]]`

    scala.Predef.manifest[A[_]](
      scala.reflect.ManifestFactory.classType[A[_]](
        classOf[A].asInstanceOf[Class[A[_]]],
        ...

My approach for fixing this was simply to see what makes the compiler
insert the cast. The condition is here:

    private def manifestOfType(tp: Type, flavor: Symbol): SearchResult = {
      ...
      def mot(tp0: Type, from: List[Symbol], to: List[Type]): SearchResult = {
        val tp1 = tp0.dealias
        ...
        val classarg = tp.dealias match {
          case _: ExistentialType => gen.mkCast(classarg0, ClassType(tp))
          case _                  => classarg0
        }

`tp` is `A.T`, the type alias. In the first call to `mot`, `tp0` is
`A.T`. `tp1 = tp0.dealias` is an `ExistentialType`, so `mot` called
recursively with `tp0 = tp1.skolemizeExistential`.

A cast seems to be needed if the original type `tp` is an existential
(not sure why that is), but we need to dealias. Not sure if we should
cast to `tp` or `tp.dealias`, I guess it doesn't matter.

Fixes https://github.com/scala/bug/issues/9155