### PR TITLE
Add a `completions` command to 2.13.x similar to the one found in sbt

### DIFF
--- a/test/files/run/repl-completions.check
+++ b/test/files/run/repl-completions.check
@@ -1,0 +1,35 @@
+
+scala> // completions!
+
+scala> object O { def x_y_x = 1; def x_y_z = 2; def getFooBarZot = 3}
+defined object O
+
+scala> :completions O.x
+[completions] O.x_y_x
+[completions] O.x_y_z
+
+scala> :completions O.x_y_x
+
+scala> :completions O.x_y_a
+
+scala> import O._
+import O._
+
+scala> :completions x_y_
+[completions] x_y_x
+[completions] x_y_z
+
+scala> :completions x_y_a
+
+scala> :completions fBZ
+[completions] getFooBarZot
+
+scala> :completions object O2 { val x = O.
+[completions] object O2 { val x = O.getFooBarZot
+[completions] object O2 { val x = O.x_y_x
+[completions] object O2 { val x = O.x_y_z
+
+scala> :completions :completion
+[completions] :completions
+
+scala> :quit

--- a/test/files/run/repl-completions.scala
+++ b/test/files/run/repl-completions.scala
@@ -1,0 +1,17 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code =
+    """|// completions!
+       |object O { def x_y_x = 1; def x_y_z = 2; def getFooBarZot = 3}
+       |:completions O.x
+       |:completions O.x_y_x
+       |:completions O.x_y_a
+       |import O._
+       |:completions x_y_
+       |:completions x_y_a
+       |:completions fBZ
+       |:completions object O2 { val x = O.
+       |:completions :completion
+       |""".stripMargin
+}


### PR DESCRIPTION
The command can be used by, for example, emacs to query completions.

This is a 2.13.x port of the #6379 (which targets 2.12.x branch).