### PR TITLE
Add flag -Ydisable-divergence-checking

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -232,6 +232,7 @@ trait ScalaSettings extends AbsScalaSettings
   val YmaxQueue = IntSetting   ("-Ybackend-worker-queue", "backend threads worker queue size", 0, Some((0,1000)), (x: String) => None )
   val YjarCompressionLevel = IntSetting("-Yjar-compression-level", "compression level to use when writing jar files",
     Deflater.DEFAULT_COMPRESSION, Some((Deflater.DEFAULT_COMPRESSION,Deflater.BEST_COMPRESSION)), (x: String) => None)
+  val YdisableDivergenceChecking = BooleanSetting ("-Ydisable-divergence-checking", "Do not apply heuristics to detect potential infinite loops during implicit resolution.")
 
   object optChoices extends MultiChoiceEnumeration {
     val unreachableCode         = Choice("unreachable-code",          "Eliminate unreachable code, exception handlers guarding no instructions, redundant metadata (debug information, line numbers).")

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -501,7 +501,7 @@ trait Implicits {
         case OpenImplicit(nfo, tp, tree1) => !nfo.sym.isMacro && tree1.symbol == tree.symbol && dominates(pt, tp)
       }
 
-        if(existsDominatedImplicit) {
+        if (existsDominatedImplicit && !settings.YdisableDivergenceChecking) {
           //println("Pending implicit "+pending+" dominates "+pt+"/"+undetParams) //@MDEBUG
           DivergentSearchFailure
         } else {


### PR DESCRIPTION
Add flag -Ydisable-divergence-checking, to turn off heuristics for detecting potential infinite loops during implicit resolution.

Context: This allows my [latest work on coulomb](https://github.com/erikerlandson/coulomb/pull/24) to compile properly, instead of giving up too soon with a divergence failure.  A simplified example of the same problem can be seen [here](https://stackoverflow.com/questions/49088319/a-diverging-implicit-expansion-in-scala-involving-chained-implicits).

Submitting this against 2.12.x, however I believe it could be applied to 2.10.x and 2.11.x as well.