### PR TITLE
No warn-unused:params for unimplemented method

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -513,7 +513,7 @@ trait TypeDiagnostics {
                   if (sym.isPrimaryConstructor)
                     for (cpa <- sym.owner.constrParamAccessors if cpa.isPrivateLocal) params += cpa
                   else if (sym.isSynthetic && sym.isImplicit) return
-                  else if (!sym.isConstructor)
+                  else if (!sym.isConstructor && rhs.symbol != Predef_???)
                     for (vs <- vparamss) params ++= vs.map(_.symbol)
                   defnTrees += m
                 case _ =>

--- a/test/files/neg/warn-unused-params.scala
+++ b/test/files/neg/warn-unused-params.scala
@@ -67,3 +67,7 @@ class Reusing(u: Int) extends Unusing(u)   // no warn
 class Main {
   def main(args: Array[String]): Unit = println("hello, args")  // no warn
 }
+
+trait Unimplementation {
+  def f(u: Int): Int = ???        // no warn for param in unimplementation
+}

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -53,13 +53,13 @@ warn-unused-privates.scala:113: warning: local object HiObject in method l1 is n
     object HiObject { def f = this } // warn
            ^
 warn-unused-privates.scala:136: warning: private method x_= in class OtherNames is never used
-  private def x_=(i: Int): Unit = ???
+  private def x_=(i: Int): Unit = ()
               ^
 warn-unused-privates.scala:137: warning: private method x in class OtherNames is never used
   private def x: Int = 42
               ^
 warn-unused-privates.scala:138: warning: private method y_= in class OtherNames is never used
-  private def y_=(i: Int): Unit = ???
+  private def y_=(i: Int): Unit = ()
               ^
 warn-unused-privates.scala:97: warning: local var x in method f2 is never updated: consider using immutable val
     var x = 100 // warn about it being a var
@@ -110,10 +110,10 @@ warn-unused-privates.scala:20: warning: parameter value msg0 in class B3 is neve
 class B3(msg0: String) extends A("msg")
          ^
 warn-unused-privates.scala:136: warning: parameter value i in method x_= is never used
-  private def x_=(i: Int): Unit = ???
+  private def x_=(i: Int): Unit = ()
                   ^
 warn-unused-privates.scala:138: warning: parameter value i in method y_= is never used
-  private def y_=(i: Int): Unit = ???
+  private def y_=(i: Int): Unit = ()
                   ^
 error: No warnings can be incurred under -Xfatal-warnings.
 39 warnings found

--- a/test/files/neg/warn-unused-privates.scala
+++ b/test/files/neg/warn-unused-privates.scala
@@ -133,9 +133,9 @@ trait Underwarn {
 }
 
 class OtherNames {
-  private def x_=(i: Int): Unit = ???
+  private def x_=(i: Int): Unit = ()
   private def x: Int = 42
-  private def y_=(i: Int): Unit = ???
+  private def y_=(i: Int): Unit = ()
   private def y: Int = 42
 
   def f = y


### PR DESCRIPTION
Cut some slack for `def f(i: Int) = ???`.