### PR TITLE
use ScalaCheck built for M3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,11 +43,11 @@ import VersionUtil._
 // Scala dependencies:
 val scalaXmlDep                  = scalaDep("org.scala-lang.modules", "scala-xml")
 val partestDep                   = scalaDep("org.scala-lang.modules", "scala-partest", versionProp = "partest")
+val scalacheckDep                = scalaDep("org.scalacheck", "scalacheck", versionProp = "scalacheck", compatibility = "scalacheck-binary", scope = "test")
 
 // Non-Scala dependencies:
 val junitDep          = "junit"                  % "junit"                % "4.11"
 val junitInterfaceDep = "com.novocode"           % "junit-interface"      % "0.11"                            % "test"
-val scalacheckDep     = "org.scalacheck"         % "scalacheck_2.13.0-M1" % "1.13.5"                          % "test"
 val jolDep            = "org.openjdk.jol"        % "jol-core"             % "0.5"
 val asmDep            = "org.scala-lang.modules" % "scala-asm"            % versionProps("scala-asm.version")
 val jlineDep          = "jline"                  % "jline"                % versionProps("jline.version")

--- a/src/intellij/scala.ipr.SAMPLE
+++ b/src/intellij/scala.ipr.SAMPLE
@@ -390,7 +390,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-5.2.0-scala-2.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.13.0-M3/bundles/scala-xml_2.13.0-M3-1.1.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.5.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scalacheck/scalacheck_2.13.0-M1/jars/scalacheck_2.13.0-M1-1.13.5.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scalacheck/scalacheck_2.13.0-M3/jars/scalacheck_2.13.0-M3-1.13.5.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />
       </CLASSES>
       <JAVADOC />

--- a/versions.properties
+++ b/versions.properties
@@ -10,6 +10,8 @@ starr.version=2.13.0-M3-f73b161
 # using scala-partest_2.12.0-M1 until releasing M2. Manual intervention is necessary for changes
 # that break binary compatibility, see for example PR #5003.
 scala.binary.version=2.13.0-M3-f73b161
+# separate in case we don't want to wait for Rickard to publish
+scala.scalacheck-binary.version=2.13.0-M3
 
 # These are the versions of the modules that go with this release.
 # Artifact dependencies:
@@ -17,8 +19,9 @@ scala.binary.version=2.13.0-M3-f73b161
 # Other usages:
 #  - scala-asm: jar content included in scala-compiler
 #  - jline: shaded with JarJar and included in scala-compiler
-#  - partest: used for running the tests
+#  - partest, scalacheck: used for running tests
 scala-xml.version.number=1.1.0
 partest.version.number=1.1.7
+scalacheck.version.number=1.13.5
 scala-asm.version=6.0.0-scala-1
 jline.version=2.14.5


### PR DESCRIPTION
I assume it was inadvertent that we were still using an M1 build
of ScalaCheck.  It wasn't causing any problems we know of,
but we should still be on the newer one.