### PR TITLE
Add description why -Ywarn-value-discard do not warn on this.type

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -30,7 +30,7 @@ trait Warnings {
     )
   )
   val warnDeadCode         = BooleanSetting("-Ywarn-dead-code", "Warn when dead code is identified.")
-  val warnValueDiscard     = BooleanSetting("-Ywarn-value-discard", "Warn when non-Unit expression results are unused.")
+  val warnValueDiscard     = BooleanSetting("-Ywarn-value-discard", "Warn when non-Unit expression results are unused. No warn if results are `this.type` to reduce noises for idiom.")
   val warnNumericWiden     = BooleanSetting("-Ywarn-numeric-widen", "Warn when numerics are widened.")
 
   object UnusedWarnings extends MultiChoiceEnumeration {


### PR DESCRIPTION
Addresses https://github.com/scala/bug/issues/10761

This PR updates a description for `-Ywarn-value-discard` compiler option.

No warning on `this.type` make sense to reduce noises for idiom like `def add(x: X): Unit = listBuffer += x.`, as addressed in https://github.com/scala/scala/pull/5393
However, as an user of scala, I was surprised when `-Ywarn-value-discard` does not warn on such case and does not explain the reason.

So I suppose it would be helpfuli for scala user to understand the special treatment.