### PR TITLE
Add Automatic-Module-Name attribute to library, reflect, compiler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -337,6 +337,7 @@ lazy val bootstrap = project in file("target/bootstrap")
 lazy val library = configureAsSubproject(project)
   .settings(generatePropertiesFileSettings)
   .settings(Osgi.settings)
+  .settings(AutomaticModuleName.settings("scala.library"))
   .settings(
     name := "scala-library",
     description := "Scala Standard Library",
@@ -375,6 +376,7 @@ lazy val library = configureAsSubproject(project)
 lazy val reflect = configureAsSubproject(project)
   .settings(generatePropertiesFileSettings)
   .settings(Osgi.settings)
+  .settings(AutomaticModuleName.settings("scala.reflect"))
   .settings(
     name := "scala-reflect",
     description := "Scala Reflection Library",
@@ -400,6 +402,7 @@ lazy val compiler = configureAsSubproject(project)
   .settings(generatePropertiesFileSettings)
   .settings(generateBuildCharacterFileSettings)
   .settings(Osgi.settings)
+  .settings(AutomaticModuleName.settings("scala.tools.nsc"))
   .settings(
     name := "scala-compiler",
     description := "Scala Compiler",

--- a/project/AutomaticModuleName.scala
+++ b/project/AutomaticModuleName.scala
@@ -1,0 +1,22 @@
+package scala.build
+
+import sbt.{Def, _}
+import sbt.Keys._
+
+/**
+ * Helper to set Automatic-Module-Name in projects.
+ *
+ * !! DO NOT BE TEMPTED INTO AUTOMATICALLY DERIVING THE NAMES FROM PROJECT NAMES !!
+ *
+ * The names carry a lot of implications and DO NOT have to always align 1:1 with the group ids or package names,
+ * though there should be of course a strong relationship between them.
+ */
+object AutomaticModuleName  {
+  def settings(name: String): Seq[Def.Setting[_]] = {
+    val pair = ("Automatic-Module-Name" -> name)
+    Seq(
+      packageOptions in (Compile, packageBin) += Package.ManifestAttributes(pair),
+      Osgi.headers += pair
+    )
+  }
+}


### PR DESCRIPTION
Adds a `Automatic-Module-Name` entry to the `MANIFEST.MF` files of `scala-library` / `scala-reflect` and `scala-compiler`, see / fixes scala/bug#10734. 