### PR TITLE
Fixes scala/bug#8150. inconsistent Float hashCode

### DIFF
--- a/src/library/scala/runtime/Statics.java
+++ b/src/library/scala/runtime/Statics.java
@@ -60,8 +60,10 @@ public final class Statics {
   }
 
   public static int floatHash(float fv) {
+    // https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.3
+    // when fv is too large, it becomes Integer.MAX_VALUE
     int iv = (int)fv;
-    if (iv == fv)
+    if (iv == fv && iv != Integer.MAX_VALUE)
       return iv;
 
     long lv = (long)fv;

--- a/test/junit/scala/runtime/ScalaRunTimeTest.scala
+++ b/test/junit/scala/runtime/ScalaRunTimeTest.scala
@@ -62,4 +62,17 @@ class ScalaRunTimeTest {
     assertEquals(stringOf(x), "this is the stringOf string")
     assertEquals(stringOf(x, 2), "this is the stringOf string")
   }
+
+  @Test
+  def testHashCode() {
+    for { i <- 0 to 31 } {
+      val x: Long = (1L << i)
+      assertEquals(x.##, x.toInt.##)
+      assertEquals(x.##, x.toFloat.##)
+      assertEquals(x.##, x.toDouble.##)
+      assertEquals(x.##, BigDecimal(x).##)
+    }
+
+    assertNotEquals(1.1f.##, 1.0f.##)
+  }
 }


### PR DESCRIPTION
Fixes scala/bug#8150

Before:

```
scala> (1L << 31).## == (1L << 31).toFloat.##
res2: Boolean = false
```

Given that the float value is identical to the long value, hashCode should be the same. As pointed by @sjrd in scala/bug#8150, there's a bug in Statics.java that's not catching when Int overflows to `Int.MaxValue` (2147483647), then happens to "equal" with the original `fv` (2147483648) when it gets converted to float.