### PR TITLE
Handle escaping characters in URL -> file

### DIFF
--- a/src/reflect/scala/reflect/io/AbstractFile.scala
+++ b/src/reflect/scala/reflect/io/AbstractFile.scala
@@ -52,7 +52,7 @@ object AbstractFile {
    */
   def getURL(url: URL): AbstractFile =
     if (url.getProtocol == "file") {
-      val f = new java.io.File(url.getPath)
+      val f = new java.io.File(url.toURI)
       if (f.isDirectory) getDirectory(f)
       else getFile(f)
     } else null

--- a/test/junit/scala/reflect/io/AbstractFileSpec.scala
+++ b/test/junit/scala/reflect/io/AbstractFileSpec.scala
@@ -1,0 +1,30 @@
+package scala.reflect.io
+
+import java.nio.file.Files
+
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.TempDir
+
+@RunWith(classOf[JUnit4])
+class AbstractFileSpec {
+  @Test
+  def handleURLEscapedCharacters(): Unit = {
+    val tempDir = TempDir.createTempDir().toPath
+    val scalaPath = tempDir.resolve("this is a file?.scala")
+    Files.createFile(scalaPath)
+    val scalaFile = scalaPath.toFile
+
+    try {
+      val fileFromURLPath = new java.io.File(scalaFile.toURI.toURL.getPath)
+      Assert.assertTrue(!fileFromURLPath.exists())
+      val scalacFile = AbstractFile.getURL(scalaFile.toURI.toURL)
+      Assert.assertTrue(scalacFile.file.exists())
+    } finally {
+      Files.deleteIfExists(scalaPath)
+      Files.deleteIfExists(tempDir)
+    }
+  }
+}


### PR DESCRIPTION
This bug was discovered in
https://github.com/scala/scala/pull/6314#issuecomment-371385148 when
caching classloaders for compiler plugins. The issue discovered is
unrelated to that PR and is rather a bug in how scalac converts URLs to
File in the `AbstractFile.getURL` method.

That method was using `getPath` in `java.net.URL` when the returned path
gives back a file path with escaped characters. When that incorrect file
path is passed through the constructor of `java.io.File`, the
construction succeeds but the underlying file is a different one (and
doesn't exist).

The fix to this bug is to use the safe `toURI()` method, which is
correctly used in other parts of the scalac classpath infrastructure
(like in the `asURLs` method in `DirectoryClasspath` and
`ZipArchiveFileLookup`). The `toURI` method returns the file path with
all the special characters unescaped.

Fixes https://github.com/scala/bug/issues/10764.