### PR TITLE
`qual` is used in `qual.withFilter(fun)`, but `fun` is exempt

### DIFF
--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -91,14 +91,14 @@ object ScalaOptionParser {
     "-Yoverride-objects", "-Yoverride-vars", "-Ypatmat-debug", "-Yno-adapted-args", "-Ypartial-unification", "-Ypos-debug", "-Ypresentation-debug",
     "-Ypresentation-strict", "-Ypresentation-verbose", "-Yquasiquote-debug", "-Yrangepos", "-Yreify-copypaste", "-Yreify-debug", "-Yrepl-class-based",
     "-Yrepl-sync", "-Yshow-member-pos", "-Yshow-symkinds", "-Yshow-symowners", "-Yshow-syms", "-Yshow-trees", "-Yshow-trees-compact", "-Yshow-trees-stringified", "-Ytyper-debug",
-    "-Ywarn-adapted-args", "-Ywarn-dead-code", "-Ywarn-inaccessible", "-Ywarn-infer-any", "-Ywarn-nullary-override", "-Ywarn-nullary-unit", "-Ywarn-numeric-widen", "-Ywarn-unused", "-Ywarn-unused-import", "-Ywarn-value-discard",
+    "-Ywarn-adapted-args", "-Ywarn-dead-code", "-Ywarn-inaccessible", "-Ywarn-infer-any", "-Ywarn-nullary-override", "-Ywarn-nullary-unit", "-Ywarn-numeric-widen", "-Ywarn-unused-import", "-Ywarn-value-discard",
     "-deprecation", "-explaintypes", "-feature", "-help", "-no-specialization", "-nobootcp", "-nowarn", "-optimise", "-print", "-unchecked", "-uniqid", "-usejavacp", "-usemanifestcp", "-verbose", "-version")
   private def stringSettingNames = List("-Xgenerate-phase-graph", "-Xmain-class", "-Xpluginsdir", "-Xshow-class", "-Xshow-object", "-Xsource-reader", "-Ydump-classes", "-Ygen-asmp",
     "-Ypresentation-log", "-Ypresentation-replay", "-Yrepl-outdir", "-d", "-dependencyfile", "-encoding", "-Xscript")
   private def pathSettingNames = List("-bootclasspath", "-classpath", "-extdirs", "-javabootclasspath", "-javaextdirs", "-sourcepath", "-toolcp")
   private val phases = List("all", "parser", "namer", "packageobjects", "typer", "patmat", "superaccessors", "extmethods", "pickler", "refchecks", "uncurry", "tailcalls", "specialize", "explicitouter", "erasure", "posterasure", "fields", "lambdalift", "constructors", "flatten", "mixin", "cleanup", "delambdafy", "icode", "jvm", "terminal")
   private val phaseSettings = List("-Xprint-icode", "-Ystop-after", "-Yskip", "-Yshow", "-Ystop-before", "-Ybrowse", "-Ylog", "-Ycheck", "-Xprint")
-  private def multiStringSettingNames = List("-Xmacro-settings", "-Xplugin", "-Xplugin-disable", "-Xplugin-require")
+  private def multiStringSettingNames = List("-Xmacro-settings", "-Xplugin", "-Xplugin-disable", "-Xplugin-require", "-Ywarn-unused")
   private def intSettingNames = List("-Xmax-classfile-name", "-Xelide-below", "-Ypatmat-exhaust-depth", "-Ypresentation-delay", "-Yrecursion")
   private def choiceSettingNames = Map[String, List[String]](
     "-YclasspathImpl" -> List("flat", "recursive"),

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -63,10 +63,12 @@ trait StdAttachments {
    */
   case object BackquotedIdentifierAttachment extends PlainAttachment
 
-  /** Indicates that the host `Ident` has been created from a pattern2 binding, `case x @ p`.
-   *  In the absence of named parameters in patterns, allows nuanced warnings for unused variables.
-   *  Hence, `case X(x = _) =>` would not warn; for now, `case X(x @ _) =>` is documentary if x is unused.
-   */
+  /** A pattern binding exempt from unused warning.
+    *
+    * Its host `Ident` has been created from a pattern2 binding, `case x @ p`.
+    * In the absence of named parameters in patterns, allows nuanced warnings for unused variables.
+    * Hence, `case X(x = _) =>` would not warn; for now, `case X(x @ _) =>` is documentary if x is unused.
+    */
   case object AtBoundIdentifierAttachment extends PlainAttachment
 
   /** Indicates that a `ValDef` was synthesized from a pattern definition, `val P(x)`.

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -817,7 +817,7 @@ abstract class TreeGen {
     if (treeInfo.isVarPatternDeep(pat)) rhs
     else {
       val cases = List(
-        CaseDef(pat.duplicate, EmptyTree, Literal(Constant(true))),
+        CaseDef(pat.duplicate updateAttachment AtBoundIdentifierAttachment, EmptyTree, Literal(Constant(true))),
         CaseDef(Ident(nme.WILDCARD), EmptyTree, Literal(Constant(false)))
       )
       val visitor = mkVisitor(cases, checkExhaustive = false, nme.CHECK_IF_REFUTABLE_STRING)

--- a/test/files/pos/t10763.flags
+++ b/test/files/pos/t10763.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xlint:unused

--- a/test/files/pos/t10763.scala
+++ b/test/files/pos/t10763.scala
@@ -1,0 +1,7 @@
+class Test {
+  def xsUnused = {
+    val xs: List[Int] = List(0)
+
+    for (refute@1 <- xs) {}
+  }
+}


### PR DESCRIPTION
For unused warnings, make sure we record usages in `qual` of
the `withFilter` that's synthesized for refutability checks,
while excluding any patterns in the `match` that represents
the `isDefinedAt` of the partial function.

(Are these patterns vars in the isDefinedAt literal ever used?
It's not useful to simplify the trees, but an interesting
question to ponder regardless.)

Consider the expansions of the following tests:

  - test/files/pos/t10763.scala
```
xs.withFilter(((check$ifrefutable$1: Int) => (check$ifrefutable$1: Int @unchecked) match {
  case 1 => true
  case _ => false
}
```

  - test/files/pos/t10394.scala:
```
.withFilter(((check$ifrefutable$2: Int) => (check$ifrefutable$2: Int @unchecked) match {
  case (i @ (_: Int)) => true
  case _ => false
}
```

In the first case, we should identify `xs` as being used;
while the second example shows that pattern bindings in `match`
passed into `withFilter` should never yield warnings.

I was too lazy to rename `AtBoundIdentifierAttachment`, but I think
it could do with a name that more clearly signals the
intent ("exempt from usage check"), rather than the mechanism ("at binding")
used to indicate a pattern var should be exempt from (un)usage checking.

Reworks 3e28d97e.

Fix scala/bug#10763