### PR TITLE
Fix scaladoc Try.fold example

### DIFF
--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -185,7 +185,7 @@ sealed abstract class Try[+T] extends Product with Serializable {
    * then `fa` is applied with this exception.
    *
    * @example {{{
-   * val result: Try[Throwable, Int] = Try { string.toInt }
+   * val result: Try[Int] = Try { string.toInt }
    * log(result.fold(
    *   ex => "Operation failed with " + ex,
    *   v => "Operation produced value: " + v


### PR DESCRIPTION
remove Throwable from the method's return type signature 
( previously borrowed probably from Either[Throwable, T] ) 
because of: 
error: wrong number of type arguments for scala.util.Try, should be 1