### PR TITLE
bug#5674 Remove calls to System.exit/sys.exit

### DIFF
--- a/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
@@ -11,6 +11,7 @@ import java.io.{BufferedReader, PrintWriter}
 import scala.reflect.internal.util.{Position, StringOps}
 import Position.formatMessage
 import StringOps.{countElementsAsString => countAs, trimAllTrailingSpace => trimTrailing}
+import scala.tools.util.SystemExit
 
 /** This class implements a Reporter that displays messages on a text console.
  */
@@ -79,7 +80,7 @@ class ConsoleReporter(val settings: Settings, reader: BufferedReader, writer: Pr
       reader.read match {
         case 'a' | 'A' =>
           new Throwable().printStackTrace(writer)
-          System.exit(1)
+          throw SystemExit(1)
         case 's' | 'S' =>
           new Throwable().printStackTrace(writer)
           writer.println()

--- a/src/compiler/scala/tools/util/SocketServer.scala
+++ b/src/compiler/scala/tools/util/SocketServer.scala
@@ -20,7 +20,7 @@ trait CompileOutputCommon {
   def info(msg: String)  = if (verbose) echo(msg)
   def echo(msg: String)  = printlnFlush(msg, Console.out)
   def warn(msg: String)  = printlnFlush(msg, Console.err)
-  def fatal(msg: String) = { warn(msg) ; System.exit(1) ; ??? }
+  def fatal(msg: String) = { warn(msg) ; throw SystemExit(1) }
 
   private def printlnFlush(msg: String, out: PrintStream) = {
     out.println(msg)

--- a/src/compiler/scala/tools/util/SystemExit.scala
+++ b/src/compiler/scala/tools/util/SystemExit.scala
@@ -1,0 +1,11 @@
+package scala.tools.util
+
+import scala.util.control.ControlThrowable
+
+/** This class exists to replace existing calls to `System.exit` or `sys.exit`
+  * in the compiler. It is recommended to avoid using this class where possible,
+  * and instead use a design that does not require terminating the JVM.
+  *
+  * @param code the exit code
+  */
+final case class SystemExit(code: Int) extends Throwable(s"exit code $code") with ControlThrowable


### PR DESCRIPTION
Remove calls to `System.exit`/`sys.exit` from the compiler module.

Fixes scala/bug#5674