### PR TITLE
Exclude ScalaJS sub-projects from scala-xml in bootstrap build

### DIFF
--- a/scripts/jobs/integrate/bootstrap
+++ b/scripts/jobs/integrate/bootstrap
@@ -199,7 +199,12 @@ buildXML() {
   else
     update scala scala-xml "$XML_REF" && gfxd
     doc="$(docTask $XML_BUILT)"
-    sbtBuild 'set version := "'$XML_VER'-DOC"' $clean "$doc" 'set version := "'$XML_VER'"' test "${buildTasks[@]}"
+
+    # Exclude Scala JS https://github.com/scala/scala/pull/6341#issuecomment-372051392
+    buildTasksXml=("${buildTasks[@]/#/xmlJVM\/}")
+    if [[ "$doc" != "" ]]; then docXml="xmlJVM/$doc"; fi
+
+    sbtBuild 'set every version := "'$XML_VER'-DOC"' $clean "$docXml" 'set every version := "'$XML_VER'"' xmlJVM/test "${buildTasksXml[@]}"
     XML_BUILT="yes" # ensure the module is built and published when buildXML is invoked for the second time, see comment above
   fi
 }


### PR DESCRIPTION
Seeking to avoid:

```
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: org.scala-js#scalajs-library_2.13.0-pre-f993373;0.6.22: not found
[warn]  :: org.scala-js#scalajs-test-interface_2.13.0-pre-f993373;0.6.22: not found
[warn]  :: org.scala-js#scalajs-junit-test-runtime_2.13.0-pre-f993373;0.6.22: not found
[warn]  :: org.scala-js#scalajs-compiler_2.13.0-pre-f993373;0.6.22: not found
[warn]  :: org.scala-js#scalajs-junit-test-plugin_2.13.0-pre-f993373;0.6.22: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
```

Testing in https://scala-ci.typesafe.com/view/scala-bench/job/bootstrap-benchmark/638