### PR TITLE
Enable multi essential type variable can be override

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4441,10 +4441,12 @@ trait Types
 
   /** A function implementing `tp1` matches `tp2`. */
   final def matchesType(tp1: Type, tp2: Type, alwaysMatchSimple: Boolean): Boolean = {
-    def matchesQuantified(tparams1: List[Symbol], tparams2: List[Symbol], res1: Type, res2: Type): Boolean = (
-      sameLength(tparams1, tparams2) &&
+    def matchesQuantified(tparams1: List[Symbol], tparams2: List[Symbol], res1: Type, res2: Type): Boolean = {
+      if (!sameLength(tparams1, tparams2)) {
+        return lastTry
+      }
       matchesType(res1, res2.substSym(tparams2, tparams1), alwaysMatchSimple)
-    )
+    }
     def lastTry =
       tp2 match {
         case ExistentialType(_, res2) if alwaysMatchSimple =>

--- a/test/files/pos/existential-type-override/override_existential_type.scala
+++ b/test/files/pos/existential-type-override/override_existential_type.scala
@@ -1,0 +1,12 @@
+class Foo[T]
+
+class DerivedFoo[T] extends Foo[T]
+
+class Bar(val foo: Foo[_])
+
+class DerivedBar(override val foo: DerivedFoo[_]) extends Bar(foo)
+
+class OtherDerivedFoo[T, U] extends Foo[T]
+
+//when with multiple existential type, also should compile with override
+class OtherDerivedBar(override val foo: OtherDerivedFoo[_,  _]) extends Bar(foo)


### PR DESCRIPTION
This issue is from [How to override value when value types have a different number of type parameters?
](https://stackoverflow.com/questions/49226928/how-to-override-value-when-value-types-have-a-different-number-of-type-parameter/49233001#49233001), I have tried to investigate issue and found: when compare **ExistentialType** with **this** and **that** has assert that their params length must be same by [sameLength](https://github.com/scala/scala/blob/2.13.x/src/reflect/scala/reflect/internal/Types.scala#L4445), but as the OP's question, there maybe has different length **existential type** params and their type still is legal be **override**.

So maybe when meet **sameLength** not equal, we need to try `lastTry` again to extract the **underlying** type again and check whether matches.