### PR TITLE
Disable macro/plugin class loader caching, by default

### DIFF
--- a/src/compiler/scala/tools/nsc/plugins/Plugins.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugins.scala
@@ -31,7 +31,7 @@ trait Plugins { global: Global =>
       def injectDefault(s: String) = if (s.isEmpty) Defaults.scalaPluginPath else s
       asPath(settings.pluginsDir.value) map injectDefault map Path.apply
     }
-    val maybes = Plugin.loadAllFrom(paths, dirs, settings.disable.value, settings.YdisablePluginsClassLoaderCaching.value)
+    val maybes = Plugin.loadAllFrom(paths, dirs, settings.disable.value, settings.YcachePluginClassLoader.value == settings.CachePolicy.None.name)
     val (goods, errors) = maybes partition (_.isSuccess)
     // Explicit parameterization of recover to avoid -Xlint warning about inferred Any
     errors foreach (_.recover[Any] {

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -72,7 +72,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
     import scala.tools.nsc.io.Jar
     import scala.reflect.io.{AbstractFile, Path}
     val locations = classpath.map(u => Path(AbstractFile.getURL(u).file))
-    val disableCache = settings.YdisableMacrosClassLoaderCaching.value
+    val disableCache = settings.YcacheMacroClassLoader.value == settings.CachePolicy.None.name
     if (disableCache || locations.exists(!Jar.isJarOrZip(_))) {
       if (disableCache) macroLogVerbose("macro classloader: caching is disabled by the user.")
       else {


### PR DESCRIPTION
https://github.com/scala/scala/pull/6314 introduced classpath caching for compiler plugins and macros, and enabled it by default. This PR switches the default in order to be conservative in a 2.12 minor release.

Currently, the only caching strategy is `last-modified`, which checks the last modified date of the JAR file. Caching can be enabled using `-Ycache-plugin-class-loader:last-modified` / `-Ycache-macro-class-loader:last-modified`

Change the relevant settings to be evolvable into a policy selection rather than just a on/off toggle.