### PR TITLE
Put back one-argument require for the convenience of downstream users.

### DIFF
--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -132,16 +132,16 @@ abstract class SymbolTable extends macros.Universe
   }
 
   // Getting in front of Predef's asserts to supplement with more info; see `supplementErrorMessage`.
-  // This has the happy side effect of masking the one argument form of assert
-  // (but for now it's reproduced here, because there are a million uses to fix).
+  // This has the happy side effect of masking the one argument forms of assert/require
+  // (but for now they're reproduced here, because there are a million uses internal and external to fix).
   @inline
   final def assert(assertion: Boolean, message: => Any): Unit = {
     // calling Predef.assert would send a freshly allocated closure wrapping the one received as argument.
     if (!assertion) throwAssertionError(message)
   }
 
-  // for those of us who use IDEs, this will now at least show up struck-through
-  @deprecated("prefer to use the two-argument form", since = "2.12.5")
+  // Let's consider re-deprecating this in the 2.13 series, to encourage informative messages.
+  //@deprecated("prefer to use the two-argument form", since = "2.12.5")
   final def assert(assertion: Boolean): Unit = {
     assert(assertion, "")
   }
@@ -150,6 +150,12 @@ abstract class SymbolTable extends macros.Universe
   final def require(requirement: Boolean, message: => Any): Unit = {
     // calling Predef.require would send a freshly allocated closure wrapping the one received as argument.
     if (!requirement) throwRequirementError(message)
+  }
+
+  // Let's consider re-deprecating this in the 2.13 series, to encourage informative messages.
+  //@deprecated("prefer to use the two-argument form", since = "2.12.5")
+  final def require(requirement: Boolean): Unit = {
+    require(requirement, "")
   }
 
   // extracted from `assert`/`require` to make them as small (and inlineable) as possible


### PR DESCRIPTION
I was inspired by paulp's comment years ago that we can remove the one-argument forms of `assert` and `require` by shadowing them with two-argument versions in `Global` (now `SymbolTable`). I tried carrying out that hope, and was reminded by the community build that people write compiler plugins against the compiler "API", so that just won't fly.

I'm advised that it's kinder to put them back than to make plugin writers scramble to change their code in order to release for 2.12.5, so let's do that.

I'd also like us to consider deprecating them in a future release, since raw assertions make guessing what went wrong harder. Or not; it's not my call to make.