### PR TITLE
Fold terms before converting to expected type

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
@@ -67,9 +67,10 @@ abstract class ConstantFolder {
    *  the conversion.
    */
   def apply(tree: Tree, pt: Type): Tree = {
-    tree.tpe match {
-      case tp@ConstantType(x) => fold(apply(tree), x convertTo pt, isConstantType(tp))
-      case _ => apply(tree)
+    val orig = apply(tree)
+    orig.tpe match {
+      case tp@ConstantType(x) => fold(orig, x convertTo pt, isConstantType(tp))
+      case _ => orig
     }
   }
 

--- a/test/files/pos/sd465.scala
+++ b/test/files/pos/sd465.scala
@@ -1,0 +1,7 @@
+object Test {
+  0: Byte
+  0: Int
+
+  (+0): Byte
+  (+0): Int
+}


### PR DESCRIPTION
The constant types of applications of `unary_+` et al aren't known until after the term has been constant folded, so defer the attempt to convert the term to an expected target type until that has been done.

Fixes https://github.com/scala/scala-dev/issues/465.