### PR TITLE
Singleton typed args/results don't interfere with tailcalls

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -117,9 +117,7 @@ abstract class TailCalls extends Transform {
       def tailLabels: Set[Symbol]
 
       def enclosingType = method.enclClass.typeOfThis
-      def isEligible    = method.isEffectivelyFinalOrNotOverridden && !isExcludedBySingletonArg && !isExcludedBySingletonResult
-      def isExcludedBySingletonArg = mexists(method.paramss)(_.tpe_*.isInstanceOf[SingletonType])
-      def isExcludedBySingletonResult = method.tpe_*.finalResultType.isInstanceOf[SingletonType]
+      def isEligible    = method.isEffectivelyFinalOrNotOverridden
       def isMandatory   = method.hasAnnotation(TailrecClass)
       def isTransformed = isEligible && accessed(label)
 
@@ -258,11 +256,7 @@ abstract class TailCalls extends Transform {
           }
         }
 
-        if (ctx.isExcludedBySingletonArg)
-                                        fail("it has a singleton typed argument which cannot be erased correctly")
-        else if (ctx.isExcludedBySingletonResult)
-                                        fail("it has a singleton result type which cannot be erased correctly")
-        else if (!ctx.isEligible)       fail("it is neither private nor final so can be overridden")
+        if (!ctx.isEligible)            fail("it is neither private nor final so can be overridden")
         else if (!isRecursiveCall) {
           if (ctx.isMandatory && receiverIsSuper) // OPT expensive check, avoid unless we will actually report the error
                                         failHere("it contains a recursive call targeting a supertype")

--- a/test/files/neg/sip23-tailrec.check
+++ b/test/files/neg/sip23-tailrec.check
@@ -1,7 +1,0 @@
-sip23-tailrec.scala:2: error: could not optimize @tailrec annotated method loop$extension: it has a singleton result type which cannot be erased correctly
-  @annotation.tailrec final def loop(b: String): b.type = {
-                                ^
-sip23-tailrec.scala:7: error: could not optimize @tailrec annotated method loop: it has a singleton typed argument which cannot be erased correctly
-    @annotation.tailrec def loop(x: value.type): Unit = loop(x)
-                            ^
-two errors found

--- a/test/files/neg/sip23-tailrec.scala
+++ b/test/files/neg/sip23-tailrec.scala
@@ -1,9 +1,0 @@
-class Foo(val value: String) extends AnyVal {
-  @annotation.tailrec final def loop(b: String): b.type = {
-    loop(b)
-  }
-
-  def boppy() = {
-    @annotation.tailrec def loop(x: value.type): Unit = loop(x)
-  }
-}

--- a/test/files/pos/sd467.scala
+++ b/test/files/pos/sd467.scala
@@ -1,0 +1,63 @@
+import scala.annotation.tailrec
+
+class TestA {
+  @tailrec
+  final def loop0(i: Int): this.type = {
+    if(i == 0) this
+    else loop0(i-1)
+  }
+
+  @tailrec
+  final def loop1(i: Int, self: this.type): Int = {
+    if(i == 0) 0
+    else loop1(i-1, this)
+  }
+
+  @tailrec
+  final def loop2(i: Int, self: this.type): this.type = {
+    if(i == 0) this
+    else loop2(i-1, this)
+  }
+}
+
+object TestB {
+  object Done
+
+  @tailrec
+  def loop0(i: Int): Done.type = {
+    if(i == 0) Done
+    else loop0(i-1)
+  }
+
+  @tailrec
+  def loop1(i: Int, done: Done.type): Int = {
+    if(i == 0) 0
+    else loop1(i-1, Done)
+  }
+
+  @tailrec
+  def loop2(i: Int, done: Done.type): Done.type = {
+    if(i == 0) done
+    else loop2(i-1, done)
+  }
+}
+
+object TestC {
+  @tailrec
+  def loop0(i: Int): 0 = {
+    if(i == 0) 0
+    else loop0(i-1)
+  }
+
+  @tailrec
+  def loop1(i: Int, zero: 0): Int = {
+    if(i == 0) 0
+    else loop1(i-1, 0)
+  }
+
+  @tailrec
+  def loop2(i: Int, zero: 0): 0 = {
+    if(i == 0) 0
+    else loop2(i-1, 0)
+  }
+}


### PR DESCRIPTION
At one point the literal types PR modified the semantics of `asInstanceOf` to check for equality of the target value with the value embedded in the singleton type. This interacted badly with `mkAttributedCastHack` in `Tailcalls`, because the [inserted casts](https://github.com/dotta/scala/commit/c2534bf61b61b76cebaad09ba303234193709b60) could end up referring to a non-existent symbol which would be needed to implement the equality check during erasure.

The fix at the time was to make the use of a singleton type as a method argument or result type disqualify the method from having the tailcall optimization applied. A later decision by the SIP committee decided for unrelated reasons that an `asInstanceOf` test should not perform an equality check, so this disqualification became unnecessary. It was not removed, however.

This came to light because singleton types are used as method argument and result types in methods which are expected to have the tail call optimization applied, resulting in https://github.com/scala/scala-dev/issues/467. We fix that here by doing what should have been done earlier: removing the disqualification.

Fixes https://github.com/scala/scala-dev/issues/467.