### PR TITLE
 Handle unrelatable skolems in TypeVar bounds

### DIFF
--- a/src/reflect/scala/reflect/internal/ExistentialsAndSkolems.scala
+++ b/src/reflect/scala/reflect/internal/ExistentialsAndSkolems.scala
@@ -114,5 +114,5 @@ trait ExistentialsAndSkolems {
    */
   final def packSymbols(hidden: List[Symbol], tp: Type, rawOwner: Symbol = NoSymbol): Type =
     if (hidden.isEmpty) tp
-    else existentialTransform(hidden, tp, rawOwner)(existentialAbstraction)
+    else existentialTransform(hidden, tp, rawOwner)(existentialAbstraction(_, _))
 }

--- a/test/files/pos/t10519.scala
+++ b/test/files/pos/t10519.scala
@@ -1,0 +1,6 @@
+object Test {
+  case class D[A]()
+  val xs = Seq(D[Int](), D[Boolean]())
+  def g[Y](is: Seq[D[_ >: Y]]) = ???
+  g(xs)
+}

--- a/test/files/pos/t5559.flags
+++ b/test/files/pos/t5559.flags
@@ -1,0 +1,1 @@
+-language:implicitConversions

--- a/test/files/pos/t5559.scala
+++ b/test/files/pos/t5559.scala
@@ -1,0 +1,46 @@
+object Test {
+  def f[T](x1: Set[T]) = () => new {
+    def apply(x2: Set[_ <: T]) = List(x1, x2)
+  }
+
+
+  class Matcher[X]
+  object Problem2 {
+    def allOf[X](x: Matcher[_ >: X], y: Matcher[_ >: X]) = new Matcher[X]
+    def allOf[X](x: Matcher[_ >: X]*) = new Matcher[X]
+  }
+
+  def equalTo[X](x: X) = new Matcher[X]
+  val a = equalTo("g")
+  val b = Problem2.allOf(a)
+  val c = Problem2.allOf(a,a)
+
+
+  class JObserver[T]
+  class JSubscriber[T] extends JObserver[T]
+  class Converted
+  implicit def convertSubscriber[T](s: JSubscriber[_ >: T]): Converted = ???
+  implicit def convertObserver[T](s: JObserver[_ >: T]): Converted = ???
+  val jSubscriber: JSubscriber[_ >: Int] = ???
+  val conv: Converted = jSubscriber
+
+
+  sealed trait Foo[A]
+  case class Bar[A](f: A) extends Foo[A]
+  object Extractor {
+    def unapply[A](f: Bar[_ >: A]): Option[A] = ???
+  }
+
+  type X = Int
+  val t: Foo[X] = ???
+  t match {
+    case Extractor(f) => f
+    case _            => ???
+  }
+
+
+  class F[+T]
+  class I[T]
+  def f1[U](f: I[F[U]]) = f
+  def f2[U](f: I[F[_ <: U]]) = f1(f)
+}

--- a/test/files/pos/t5579.scala
+++ b/test/files/pos/t5579.scala
@@ -1,0 +1,13 @@
+object Test {
+  class Result[+A]
+  case class Success[A](x: A) extends Result[A]
+  class Apply[A]
+  object Apply {
+    def apply[A](f: Int => A): Apply[A] = new Apply[A]
+  }
+
+  def foo = Apply(i => i match {
+    case 1 => Success(Some(1))
+    case _ => Success(None)
+  })
+}


### PR DESCRIPTION
by existentially abstracting them.

Adds a necessary boolean flag to `existentialAbstraction` to flip
the variance for upper bounds which need to be minimized.

Fixes scala/bug#5559, fixes scala/bug#5579, fixes scala/bug#10519
and fixes scala/bug#10771

Depends on #6257 