### PR TITLE
sbt fun: don't call `set ...` after `setupBootstrapPublish`

### DIFF
--- a/scripts/bootstrap_fun
+++ b/scripts/bootstrap_fun
@@ -315,9 +315,9 @@ publishSonatype() {
       --warn \
       -Dstarr.version=$SCALA_VER \
       ${updatedModuleVersions[@]} \
-      "setupBootstrapPublish $integrationRepoUrl $SCALA_VER" \
       'set pgpSigningKey in Global := Some(new java.math.BigInteger("C03EF1D7D692BCFF", 16).longValue)' \
       'set pgpPassphrase in Global := Some(Array.empty)' \
+      "setupBootstrapPublish $integrationRepoUrl $SCALA_VER" \
       $publishSonatypeTaskCore
   travis_fold_end sona
 


### PR DESCRIPTION
After `cp admin/files/gpg.sbt ./project`:

    scala git:(2.12.x) ✗ sbt
    ...
    > setupBootstrapPublish "https://scala-ci.typesafe.com/artifactory/scala-integration" "2.12.5-foobarbaz"
    ...
    > version
    [info] repl-jline/*:version
    [info] 	2.12.5-foobarbaz
    ...
    > set pgpSigningKey in Global := Some(new java.math.BigInteger("C03EF1D7D692BCFF", 16).longValue)
    ...
    > version
    [info] repl-jline/*:version
    [info] 	2.12.5-bin-SNAPSHOT

So using `set` after `setupBootstrapPublish` resets those settings made
by `setupBootstrapPublish`. It seems to work the other way around

    scala git:(2.12.x) ✗ sbt
    ...
    > set pgpSigningKey in Global := Some(new java.math.BigInteger("C03EF1D7D692BCFF", 16).longValue)
    ...
    > setupBootstrapPublish "https://scala-ci.typesafe.com/artifactory/scala-integration" "2.12.5-foobarbaz"
    ...
    > pgpSigningKey
    [info] repl-jline/*:pgpSigningKey
    [info] Some(-4593968660551123713)
    ...
    > version
    [info] repl-jline/*:version
    [info] 2.12.5-foobarbaz