### PR TITLE
Sync Equiv/PartialOrdering/Ordering scaladocs

### DIFF
--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -29,7 +29,7 @@ import java.util.Comparator
  *  @version 1.0, 2008-04-03
  *  @since 2.7
  */
-
+@annotation.implicitNotFound(msg = "No implicit Equiv defined for ${T}.")
 trait Equiv[T] extends Any with Serializable {
   /** Returns `true` iff `x` is equivalent to `y`.
    */

--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -11,19 +11,15 @@ package math
 
 import java.util.Comparator
 
-/** A trait for representing equivalence relations.  It is important to
- *  distinguish between a type that can be compared for equality or
- *  equivalence and a representation of equivalence on some type. This
- *  trait is for representing the latter.
+/** Defines an equivalence relations on some type `T`.
  *
  *  An [[http://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]]
- *  is a binary relation on a type. This relation is exposed as
- *  the `equiv` method of the `Equiv` trait.  The relation must be:
+ *  is a binary relation on a type `T`, exposed as
+ *  the `equiv` method of this trait, that must be:
  *
- *    1. reflexive: `equiv(x, x) == true` for any x of type `T`.
- *    1. symmetric: `equiv(x, y) == equiv(y, x)` for any `x` and `y` of type `T`.
- *    1. transitive: if `equiv(x, y) == true` and `equiv(y, z) == true`, then
- *       `equiv(x, z) == true` for any `x`, `y`, and `z` of type `T`.
+ *    1. reflexive: `x = x`
+ *    1. symmetric: if `x = y` then `y = x`
+ *    1. transitive: if `x = y` and `y = z`, then `x = z`
  *
  *  @author  Geoffrey Washburn, Paul Phillips
  *  @version 1.0, 2008-04-03

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -12,14 +12,26 @@ package math
 import java.util.Comparator
 import scala.language.{implicitConversions, higherKinds}
 
-/** Ordering is a trait whose instances each represent a strategy for sorting
-  * instances of a type.
+/** Defines a total ordering on some type `T`.
+  *
+  * A [[http://en.wikipedia.org/wiki/Total_order total ordering]]
+  * is a binary relation on a type `T`, exposed as the `compare`
+  * method of this trait, that must be:
+  *
+  *   1. total: `x <= y` or `y <= x`
+  *   1. antisymmetric:  if `x <= y && y <= x`, then `x == y`
+  *   1. transitive:  if `x <= y && y <= z`, then `x <= z`
+  *
+  * Additionally, a total ordering induces an
+  * [[http://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]].
+  * This equivalence relation is exposed as the `equiv` method,
+  * inherited from the [[scala.math.Equiv Equiv]] trait.
   *
   * Ordering's companion object defines many implicit objects to deal with
-  * subtypes of AnyVal (e.g. Int, Double), String, and others.
+  * subtypes of `AnyVal` (e.g. `Int`, `Double`), `String`, and others.
   *
   * To sort instances by one or more member variables, you can take advantage
-  * of these built-in orderings using Ordering.by and Ordering.on:
+  * of these built-in orderings using `Ordering.by` and `Ordering.on`:
   *
   * {{{
   * import scala.util.Sorting
@@ -32,33 +44,35 @@ import scala.language.{implicitConversions, higherKinds}
   * Sorting.quickSort(pairs)(Ordering[(Int, String)].on(x => (x._3, x._1)))
   * }}}
   *
-  * An Ordering[T] is implemented by specifying compare(a:T, b:T), which
-  * decides how to order two instances a and b. Instances of Ordering[T] can be
-  * used by things like scala.util.Sorting to sort collections like Array[T].
+  * An `Ordering[T]` is implemented by specifying `compare(a: T, b: T)`, which
+  * decides how to order two instances a and b. Instances of `Ordering[T]` can be
+  * used by things like [[scala.util.Sorting Sorting]] to sort collections like
+  * `Array[T]`.
   *
   * For example:
   *
   * {{{
   * import scala.util.Sorting
   *
-  * case class Person(name:String, age:Int)
+  * final case class Person(name: String, age: Int)
   * val people = Array(Person("bob", 30), Person("ann", 32), Person("carl", 19))
   *
   * // sort by age
   * object AgeOrdering extends Ordering[Person] {
-  *   def compare(a:Person, b:Person) = a.age compare b.age
+  *   def compare(a: Person, b: Person) = a.age compare b.age
   * }
   * Sorting.quickSort(people)(AgeOrdering)
   * }}}
   *
-  * This trait and scala.math.Ordered both provide this same functionality, but
-  * in different ways. A type T can be given a single way to order itself by
-  * extending Ordered. Using Ordering, this same type may be sorted in many
-  * other ways. Ordered and Ordering both provide implicits allowing them to be
+  * This trait and [[scala.math.Ordered Ordered]] both provide this
+  * same functionality, but in different ways. A class can be given
+  * a single way to order itself by extending `Ordered`. Using
+  * `Ordering`, this same class may be sorted in many other ways.
+  * `Ordered` and `Ordering` both provide implicits allowing them to be
   * used interchangeably.
   *
-  * You can import scala.math.Ordering.Implicits to gain access to other
-  * implicit orderings.
+  * You can import [[scala.math.Ordering.Implicits Ordering.Implicits]]
+  * to gain access to other implicit orderings.
   *
   * @author Geoffrey Washburn
   * @version 0.9.5, 2008-04-15

--- a/src/library/scala/math/PartialOrdering.scala
+++ b/src/library/scala/math/PartialOrdering.scala
@@ -9,27 +9,19 @@
 package scala
 package math
 
-/** A trait for representing partial orderings.  It is important to
- *  distinguish between a type that has a partial order and a representation
- *  of partial ordering on some type.  This trait is for representing the
- *  latter.
+/** Defines a partial ordering on some type `T`.
  *
  *  A [[http://en.wikipedia.org/wiki/Partially_ordered_set partial ordering]] is a
- *  binary relation on a type `T`, exposed as the `lteq` method of this trait.
- *  This relation must be:
+ *  binary relation on a type `T`, exposed as the `lteq` method of this trait,
+ *  that must be:
  *
- *  - reflexive: `lteq(x, x) == '''true'''`, for any `x` of type `T`.
- *  - anti-symmetric: if `lteq(x, y) == '''true'''` and
- *    `lteq(y, x) == '''true'''`
- *    then `equiv(x, y) == '''true'''`, for any `x` and `y` of type `T`.
- *  - transitive: if `lteq(x, y) == '''true'''` and
- *    `lteq(y, z) == '''true'''` then `lteq(x, z) == '''true'''`,
- *    for any `x`, `y`, and `z` of type `T`.
+ *    1. reflexive: `x <= x`
+ *    1. antisymmetric: if `x <= y` and `y <= x` then `x = y`
+ *    1. transitive: if `x <= y` and `y <= z` then `x <= z`
  *
  *  Additionally, a partial ordering induces an
  *  [[http://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]]
- *  on a type `T`: `x` and `y` of type `T` are equivalent if and only if
- *  `lteq(x, y) && lteq(y, x) == '''true'''`. This equivalence relation is
+ *  on a type `T`,
  *  exposed as the `equiv` method, inherited from the
  *  [[scala.math.Equiv Equiv]] trait.
  *

--- a/src/library/scala/math/PartialOrdering.scala
+++ b/src/library/scala/math/PartialOrdering.scala
@@ -37,7 +37,7 @@ package math
  *  @version 1.0, 2008-04-0-3
  *  @since 2.7
  */
-
+@annotation.implicitNotFound(msg = "No implicit PartialOrdering defined for ${T}.")
 trait PartialOrdering[T] extends Equiv[T] {
   outer =>
 


### PR DESCRIPTION
also give `Equiv` & `PartialOrdering` `@implicitNotFound`s.

submitted for early review: please let me know if this is of interest.