### PR TITLE
Support -Ymax-implicit-cycle-depth

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -239,6 +239,7 @@ trait ScalaSettings extends AbsScalaSettings
 
   val YaddBackendThreads = IntSetting   ("-Ybackend-parallelism", "maximum worker threads for backend", 1, Some((1,16)), (x: String) => None )
   val YmaxQueue = IntSetting   ("-Ybackend-worker-queue", "backend threads worker queue size", 0, Some((0,1000)), (x: String) => None )
+  val YmaxImplicitCycleDepth = IntSetting("-Ymax-implicit-cycle-depth", "Fail with divergence on implicit resolution cycles > this depth", 0, Some((0,1000)), (x: String) => None )
   val YjarCompressionLevel = IntSetting("-Yjar-compression-level", "compression level to use when writing jar files",
     Deflater.DEFAULT_COMPRESSION, Some((Deflater.DEFAULT_COMPRESSION,Deflater.BEST_COMPRESSION)), (x: String) => None)
 

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -501,7 +501,7 @@ trait Implicits {
         case OpenImplicit(nfo, tp, tree1) => !nfo.sym.isMacro && tree1.symbol == tree.symbol && dominates(pt, tp)
       }
 
-        if(existsDominatedImplicit) {
+        if (existsDominatedImplicit && (context.openImplicits.length > settings.YmaxImplicitCycleDepth.value)) {
           //println("Pending implicit "+pending+" dominates "+pt+"/"+undetParams) //@MDEBUG
           DivergentSearchFailure
         } else {


### PR DESCRIPTION
Support -Ymax-implicit-cycle-depth to allow implicit resolution search up to a maximum depth before failing with divergence.

This is a slightly less-crude variation on #6383 that allows implicit resolution to proceed up to a maximum depth before failing with a divergence error.  Behaves like a "level of effort" that can be set larger to allow the compiler to try harder on categories of chained implicits that Scala's current heuristics [reject prematurely](https://stackoverflow.com/questions/49088319/a-diverging-implicit-expansion-in-scala-involving-chained-implicits).  Defaults to zero, which is equivalent to legacy behavior. 

Like #6383, this is a poor-man's version of #6050, which I am proposing as a workaround that could be applied prior to 2.13

On my pet coulomb project, setting -`Ymax-implicit-cycle-depth 10` has been allowing my [latest experiments](https://github.com/erikerlandson/coulomb/pull/24) to compile correctly.
