### PR TITLE
Treat JAVA_CONST names as snake for completion

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1177,15 +1177,17 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
 
     }
     private val CamelRegex = "([A-Z][^A-Z]*)".r
-    private def camelComponents(s: String): List[String] = {
-      CamelRegex.findAllIn("X" + s).toList match { case head :: tail => head.drop(1) :: tail; case Nil => Nil }
+    private def camelComponents(s: String, allowSnake: Boolean): List[String] = {
+      if (allowSnake && s.forall(c => c.isUpper || c == '_')) s.split('_').toList.filterNot(_.isEmpty)
+      else CamelRegex.findAllIn("X" + s).toList match { case head :: tail => head.drop(1) :: tail; case Nil => Nil }
     }
     def camelMatch(entered: Name): Name => Boolean = {
       val enteredS = entered.toString
       val enteredLowercaseSet = enteredS.toLowerCase().toSet
+      val allowSnake = !enteredS.contains('_')
 
       (candidate: Name) => {
-        def candidateChunks = camelComponents(candidate.toString)
+        def candidateChunks = camelComponents(candidate.dropLocal.toString, allowSnake)
         // Loosely based on IntelliJ's autocompletion: the user can just write everything in
         // lowercase, as we'll let `isl` match `GenIndexedSeqLike` or `isLovely`.
         def lenientMatch(entered: String, candidate: List[String], matchCount: Int): Boolean = {

--- a/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
@@ -91,6 +91,8 @@ class CompletionTest {
     checkExact(completer, "object O { def xxxxYyyyyZzzz = 1; def xxxxYyZeee = 1 }; import O._; xYZ")("", "xxxxYyyyyZzzz", "xxxxYyZeee")
     checkExact(completer, "object O { def xxxxYyyyyZzzz = 1; def xxxxYyyyyZeee = 1 }; import O._; xYZ")("xxxxYyyyyZzzz", "xxxxYyyyyZeee")
     checkExact(completer, "object O { class AbstractMetaFactoryFactory }; new O.AMFF")("AbstractMetaFactoryFactory")
+    checkExact(completer, "object O { val DECIMAL_DIGIT_NUMBER = 0 }; import O._; L_")("DECIMAL_DIGIT_NUMBER")
+    checkExact(completer, "object O { val _unusualIdiom = 0 }; import O._; _ui")("_unusualIdiom")
   }
 
   @Test
@@ -99,7 +101,18 @@ class CompletionTest {
     val completer = new PresentationCompilerCompleter(intp)
     checkExact(completer, "object O { def theCatSatOnTheMat = 1 }; import O._; tcso")("theCatSatOnTheMat")
     checkExact(completer, "object O { def theCatSatOnTheMat = 1 }; import O._; sotm")("theCatSatOnTheMat")
+    checkExact(completer, "object O { def theCatSatOnTheMat = 1 }; import O._; caton")("theCatSatOnTheMat")
+    checkExact(completer, "object O { def theCatSatOnTheMat = 1; def catOnYoutube = 2 }; import O._; caton")("", "theCatSatOnTheMat", "catOnYoutube")
     checkExact(completer, "object O { def theCatSatOnTheMat = 1 }; import O._; TCSOTM")()
+  }
+
+  @Test
+  def snakeCompletions(): Unit = {
+    val intp = newIMain()
+    val completer = new PresentationCompilerCompleter(intp)
+    checkExact(completer, "object O { final val THE_CAT_SAT_ON_THE_MAT = 1 }; import O._; TCSO")("THE_CAT_SAT_ON_THE_MAT")
+    checkExact(completer, "object O { final val THE_CAT_SAT_ON_THE_MAT = 1 }; import O._; tcso")("THE_CAT_SAT_ON_THE_MAT")
+    checkExact(completer, "object C { def isIdentifierIgnorable = ??? ; val DECIMAL_DIGIT_NUMBER = 0 }; import C._; iii")("isIdentifierIgnorable")
   }
 
   @Test


### PR DESCRIPTION
The previous behavior is for every uppercase
letter to represent a camel hump, so "jon"
and "a_o" would complete to "JAVA_CONST".

This commit splits the identifier on underscore
if the user is not asking for underscore,
such as "_local", and if the candidate name looks
like an old-style Java constant, uppercase
with underscores.

Fixes scala/bug#10784