### PR TITLE
Avoid using STARR on the scalacheck classpath

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -612,10 +612,17 @@ lazy val scalacheck = project.in(file("test") / "scalacheck")
   .settings(disableDocs)
   .settings(disablePublishing)
   .settings(
-    fork in Test := false,
+    // enable forking to workaround https://github.com/sbt/sbt/issues/4009
+    fork in Test := true,
+    // customise framework for early acess to https://github.com/rickynils/scalacheck/pull/388
+    // TODO remove this when we upgrade scalacheck
+    testFrameworks := Seq(TestFramework("org.scalacheck.CustomScalaCheckFramework")),
     javaOptions in Test += "-Xss1M",
-    testOptions += Tests.Cleanup { loader =>
-      ModuleUtilities.getObject("scala.TestCleanup", loader).asInstanceOf[Runnable].run()
+    testOptions ++= {
+      if ((fork in Test).value) Nil
+      else List(Tests.Cleanup { loader =>
+        ModuleUtilities.getObject("scala.TestCleanup", loader).asInstanceOf[Runnable].run()
+      })
     },
     libraryDependencies ++= Seq(scalacheckDep),
     unmanagedSourceDirectories in Compile := Nil,

--- a/test/scalacheck/org/scalacheck/CustomScalaCheckRunner.scala
+++ b/test/scalacheck/org/scalacheck/CustomScalaCheckRunner.scala
@@ -1,0 +1,232 @@
+package org.scalacheck
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalacheck.Test.Parameters
+import sbt.testing._
+
+private abstract class CustomScalaCheckRunner extends Runner {
+
+  val args: Array[String]
+  val loader: ClassLoader
+  val applyCmdParams: Parameters => Parameters
+
+  val successCount = new AtomicInteger(0)
+  val failureCount = new AtomicInteger(0)
+  val errorCount = new AtomicInteger(0)
+  val testCount = new AtomicInteger(0)
+
+  def deserializeTask(task: String, deserializer: String => TaskDef) = {
+    val taskDef = deserializer(task)
+    val countTestSelectors = taskDef.selectors.toSeq.count {
+      case _:TestSelector => true
+      case _ => false
+    }
+    if (countTestSelectors == 0) rootTask(taskDef)
+    else checkPropTask(taskDef, single = true)
+  }
+
+  def serializeTask(task: Task, serializer: TaskDef => String) =
+    serializer(task.taskDef)
+
+  def tasks(taskDefs: Array[TaskDef]): Array[Task] = {
+    val isForked = taskDefs.exists(_.fingerprint().getClass.getName.contains("ForkMain"))
+    taskDefs.map { taskDef =>
+      if (isForked) checkPropTask(taskDef, single = false)
+      else rootTask(taskDef)
+    }
+  }
+
+  abstract class BaseTask(override val taskDef: TaskDef) extends Task {
+    val tags: Array[String] = Array()
+
+    val props: Seq[(String,Prop)] = {
+      val fp = taskDef.fingerprint.asInstanceOf[SubclassFingerprint]
+      val obj = if (fp.isModule) Platform.loadModule(taskDef.fullyQualifiedName,loader)
+                else Platform.newInstance(taskDef.fullyQualifiedName, loader)(Seq())
+      obj match {
+        case props: Properties => props.properties
+        case prop: Prop => Seq("" -> prop)
+      }
+    }
+
+    // TODO copypasted from props val
+    val properties: Option[Properties] = {
+      val fp = taskDef.fingerprint.asInstanceOf[SubclassFingerprint]
+      val obj = if (fp.isModule) Platform.loadModule(taskDef.fullyQualifiedName,loader)
+      else Platform.newInstance(taskDef.fullyQualifiedName, loader)(Seq())
+      obj match {
+        case props: Properties => Some(props)
+        case prop: Prop => None
+      }
+    }
+
+    def log(loggers: Array[Logger], ok: Boolean, msg: String) =
+      loggers foreach { l =>
+        val logstr =
+          if(!l.ansiCodesSupported) msg
+          else s"${if (ok) Console.GREEN else Console.RED}$msg${Console.RESET}"
+        l.info(logstr)
+      }
+
+    def execute(handler: EventHandler, loggers: Array[Logger],
+      continuation: Array[Task] => Unit
+    ): Unit  = continuation(execute(handler,loggers))
+  }
+
+  def rootTask(td: TaskDef) = {
+    new BaseTask(td) {
+      def execute(handler: EventHandler, loggers: Array[Logger]): Array[Task] = {
+        props.map(_._1).toSet.toArray map { name =>
+          checkPropTask(new TaskDef(td.fullyQualifiedName, td.fingerprint,
+            td.explicitlySpecified, Array(new TestSelector(name)))
+            , single = true)
+        }
+      }
+    }
+  }
+
+  def checkPropTask(taskDef: TaskDef, single: Boolean) = new BaseTask(taskDef) {
+    def execute(handler: EventHandler, loggers: Array[Logger]): Array[Task] = {
+      val params = applyCmdParams(properties.foldLeft(Parameters.default)((params, props) => props.overrideParameters(params)))
+      val propertyFilter = None
+
+      if (single) {
+        val names = taskDef.selectors flatMap {
+          case ts: TestSelector => Array(ts.testName)
+          case _ => Array.empty[String]
+        }
+        names foreach { name =>
+          for ((`name`, prop) <- props)
+            executeInternal(prop, name, handler, loggers, propertyFilter)
+        }
+      } else {
+        for ((name, prop) <- props)
+          executeInternal(prop, name, handler, loggers, propertyFilter)
+      }
+      Array.empty[Task]
+    }
+
+    def executeInternal(prop: Prop, name: String, handler: EventHandler, loggers: Array[Logger], propertyFilter: Option[scala.util.matching.Regex]): Unit = {
+      import util.Pretty.{Params, pretty}
+      val params = applyCmdParams(properties.foldLeft(Parameters.default)((params, props) => props.overrideParameters(params)))
+      val result = Test.check(params, prop)
+
+      val event = new Event {
+        val status = result.status match {
+          case Test.Passed => Status.Success
+          case _: Test.Proved => Status.Success
+          case _: Test.Failed => Status.Failure
+          case Test.Exhausted => Status.Failure
+          case _: Test.PropException => Status.Error
+        }
+        val throwable = result.status match {
+          case Test.PropException(_, e, _) => new OptionalThrowable(e)
+          case _: Test.Failed => new OptionalThrowable(
+            new Exception(pretty(result, Params(0)))
+          )
+          case _ => new OptionalThrowable()
+        }
+        val fullyQualifiedName = taskDef.fullyQualifiedName
+        val selector = new TestSelector(name)
+        val fingerprint = taskDef.fingerprint
+        val duration = -1L
+      }
+
+      handler.handle(event)
+
+      event.status match {
+        case Status.Success => successCount.incrementAndGet()
+        case Status.Error => errorCount.incrementAndGet()
+        case Status.Skipped => errorCount.incrementAndGet()
+        case Status.Failure => failureCount.incrementAndGet()
+        case _ => failureCount.incrementAndGet()
+      }
+      testCount.incrementAndGet()
+
+      // TODO Stack traces should be reported through event
+      val verbosityOpts = Set("-verbosity", "-v")
+      val verbosity =
+        args.grouped(2).filter(twos => verbosityOpts(twos.head))
+          .toSeq.headOption.map(_.last).map(_.toInt).getOrElse(0)
+      val s = if (result.passed) "+" else "!"
+      val n = if (name.isEmpty) taskDef.fullyQualifiedName else name
+      val logMsg = s"$s $n: ${pretty(result, Params(verbosity))}"
+      log(loggers, result.passed, logMsg)
+    }
+  }
+}
+
+
+final class CustomScalaCheckFramework extends Framework {
+
+  private def mkFP(mod: Boolean, cname: String, noArgCons: Boolean = true) =
+    new SubclassFingerprint {
+      def superclassName(): String = cname
+      val isModule = mod
+      def requireNoArgConstructor(): Boolean = noArgCons
+    }
+
+  val name = "ScalaCheck"
+
+  def fingerprints: Array[Fingerprint] = Array(
+    mkFP(false, "org.scalacheck.Properties"),
+    mkFP(false, "org.scalacheck.Prop"),
+    mkFP(true, "org.scalacheck.Properties"),
+    mkFP(true, "org.scalacheck.Prop")
+  )
+
+  def runner(_args: Array[String], _remoteArgs: Array[String],
+             _loader: ClassLoader
+            ): Runner = new CustomScalaCheckRunner {
+
+    val args = _args
+    val remoteArgs = _remoteArgs
+    val loader = _loader
+    val (prms,unknownArgs) = Test.cmdLineParser.parseParams(args)
+    val applyCmdParams = prms.andThen {
+      p => p.withTestCallback(new Test.TestCallback {})
+        .withCustomClassLoader(Some(loader))
+    }
+
+    def receiveMessage(msg: String): Option[String] = msg(0) match {
+      case 'd' =>
+        val Array(t,s,f,e) = msg.tail.split(',')
+        testCount.addAndGet(t.toInt)
+        successCount.addAndGet(s.toInt)
+        failureCount.addAndGet(f.toInt)
+        errorCount.addAndGet(e.toInt)
+        None
+    }
+
+    def done = if (testCount.get > 0) {
+      val heading = if (testCount.get == successCount.get) "Passed" else "Failed"
+      s"$heading: Total $testCount, " +
+        s"Failed $failureCount, Errors $errorCount, Passed $successCount" +
+        (if(unknownArgs.isEmpty) "" else
+          s"\nWarning: Unknown ScalaCheck args provided: ${unknownArgs.mkString(" ")}")
+    } else ""
+
+  }
+
+  def slaveRunner(_args: Array[String], _remoteArgs: Array[String],
+                  _loader: ClassLoader, send: String => Unit
+                 ): Runner = new ScalaCheckRunner {
+    val args = _args
+    val remoteArgs = _remoteArgs
+    val loader = _loader
+    val applyCmdParams = Test.cmdLineParser.parseParams(args)._1.andThen {
+      p => p.withTestCallback(new Test.TestCallback {})
+        .withCustomClassLoader(Some(loader))
+    }
+
+    def receiveMessage(msg: String) = None
+
+    def done = {
+      send(s"d$testCount,$successCount,$failureCount,$errorCount")
+      ""
+    }
+
+  }
+
+}

--- a/test/scalacheck/sanitycheck.scala
+++ b/test/scalacheck/sanitycheck.scala
@@ -1,0 +1,14 @@
+import java.io.File
+
+import org.scalacheck._
+
+object SanityCheck extends Properties("SanityCheck") {
+  property("classpath correct") = {
+    val codeSource = classOf[Option[_]].getProtectionDomain.getCodeSource.getLocation.toURI
+    val path = new File(codeSource).getAbsolutePath
+    if (path.endsWith("quick/classes/library"))
+      Prop.proved
+    else
+      Prop.falsified :| s"Unexpected code source for scala library: $path"
+  }
+}


### PR DESCRIPTION
Integrating Scalacheck into our SBT build is all frying pans
and fires. We disabled forking to get test failure reporting
working, but didn't realise that this put STARR on the classpath
of the tests.

This commits switches back to forking, but only after customizing
the framework to get early access to what hopefully will be part
of the next scalacheck release: https://github.com/rickynils/scalacheck/pull/388