### PR TITLE
Add synthetic value class companion near its class.

### DIFF
--- a/test/files/run/t10783.scala
+++ b/test/files/run/t10783.scala
@@ -1,0 +1,31 @@
+package com.example {
+  object X {
+    def bar: Int = (new Value(42)).foo
+    def baz: Int = (new Walue(42)).foo
+    def bip: Int = (new Xalue(42)).foo
+  }
+}
+
+package com.example {
+  class Value(val value: Int) extends AnyVal {
+    def foo: Int = value + 1
+  }
+  object Walue
+  class Walue(val value: Int) extends AnyVal {
+    def foo: Int = value + 1
+  }
+  class Xalue(val value: Int) extends AnyVal {
+    def foo: Int = value + 1
+  }
+  object Xalue
+}
+
+object Test {
+  import com.example._
+
+  def main(args: Array[String]): Unit = {
+    assert(X.bar == 43)
+    assert(X.baz == 43)
+    assert(X.bip == 43)
+  }
+}


### PR DESCRIPTION
Redux of 9e1de6ee81e9eaf9d8ac59446bc97c79b5ff0cb6.

Make sure that the class in question actually exists in the tree we're about to put the synthetic companion in. Otherwise extmethods might not see the extendable methods until after it's too late to add it to the companion stats.

Fixes scala/bug#10783.