### PR TITLE
Improve line number fidelity after dce, inlining

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -141,6 +141,15 @@ object BytecodeUtils {
     else previousExecutableInstruction(prev, stopBefore)
   }
 
+  @tailrec def previousLineNumber(insn: AbstractInsnNode): Option[Int] = {
+    val prev = insn.getPrevious
+    prev match {
+      case null => None
+      case line: LineNumberNode => Some(line.line)
+      case _ => previousLineNumber(prev)
+    }
+  }
+
   @tailrec def nextExecutableInstruction(insn: AbstractInsnNode, alsoKeep: AbstractInsnNode => Boolean = Set()): Option[AbstractInsnNode] = {
     val next = insn.getNext
     if (next == null || isExecutable(next) || alsoKeep(next)) Option(next)

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -440,6 +440,19 @@ abstract class Inliner {
     // label for the exit of the inlined functions. xRETURNs are replaced by GOTOs to this label.
     val postCallLabel = newLabelNode
     clonedInstructions.add(postCallLabel)
+    if (sameSourceFile) {
+      BytecodeUtils.previousLineNumber(callsiteInstruction) match {
+        case Some(line) =>
+          BytecodeUtils.nextExecutableInstruction(callsiteInstruction).flatMap(BytecodeUtils.previousLineNumber) match {
+            case Some(line1) =>
+              if (line == line1)
+              // SD-479 code follows on the same line, restore the line number
+                clonedInstructions.add(new LineNumberNode(line, postCallLabel))
+            case None =>
+          }
+        case None =>
+      }
+    }
 
     // replace xRETURNs:
     //   - store the return value (if any)

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
@@ -524,6 +524,7 @@ abstract class LocalOpt {
         case i: IincInsnNode if isLive =>
           maxLocals = math.max(maxLocals, i.`var` + 1)
 
+        case _: LineNumberNode =>
         case _ =>
           if (!isLive || insn.getOpcode == NOP) {
             // Instruction iterators allow removing during iteration.

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -1551,11 +1551,11 @@ class InlinerTest extends BytecodeTesting {
 
     assertSameCode(is("t2"), List(
       Label(0), LineNumber(3, Label(0)), VarOp(ALOAD, 0), Invoke(INVOKEVIRTUAL, "B", "fx", "()V", false),
-      Label(4), LineNumber(4, Label(4)), Op(ICONST_1), Op(IRETURN), Label(8)))
+      Label(4), LineNumber(4, Label(4)), Op(ICONST_1), Label(7), LineNumber(13, Label(7)), Op(IRETURN), Label(10)))
 
     assertSameCode(is("t3"), List(
       Label(0), LineNumber(9, Label(0)), VarOp(ALOAD, 0), Invoke(INVOKEVIRTUAL, "C", "fx", "()V", false),
-      Label(4), LineNumber(10, Label(4)), Op(ICONST_1), Op(IRETURN), Label(8)))
+      Label(4), LineNumber(10, Label(4)), Op(ICONST_1), Label(7), LineNumber(14, Label(7)), Op(IRETURN), Label(10)))
   }
 
   @Test
@@ -1753,5 +1753,23 @@ class InlinerTest extends BytecodeTesting {
     val i = getMethod(t, "$init$")
     assertDoesNotInvoke(i, "f")
     assertInvoke(i, "T", "T$_setter_$x_$eq")
+  }
+
+  @Test
+  def sd479_same_unit_inlining_line_number(): Unit = {
+    val code =
+      """class Test {
+        |  @inline final def foo(b: Boolean): String = {
+        |    "foo"
+        |  }
+        |
+        |  def bar(a: AnyRef, b: Boolean): AnyRef = {
+        |    foo(b); a.toString // line 7
+        |  }
+        |}
+      """.stripMargin
+    val List(t) = compileClasses(code)
+    val i = getMethod(t, "bar")
+    assertSameCode(i.instructions, List(Label(0), LineNumber(7, Label(0)), VarOp(ALOAD, 1), Invoke(INVOKEVIRTUAL, "java/lang/Object", "toString", "()Ljava/lang/String;", false), Op(ARETURN), Label(5)))
   }
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/UnreachableCodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/UnreachableCodeTest.scala
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
+import scala.tools.asm.tree.ClassNode
 import scala.tools.partest.ASMConverters._
 import scala.tools.testing.AssertUtil._
 import scala.tools.testing.BytecodeTesting._
@@ -244,5 +245,22 @@ class UnreachableCodeTest extends ClearAfterClass {
     val cDCE = dceCompiler.compileClass(code)
     assertSameSummary(getMethod(cDCE, "t3"), List(ALOAD, NEW, DUP, LDC, "<init>", ATHROW))
     assertSameSummary(getMethod(cDCE, "t4"), List(ALOAD, ALOAD, "nt", ATHROW))
+  }
+
+  @Test
+  def patmatDefaultLineNumber(): Unit = {
+    val code =
+      """class Test {
+        |  def test = (this: AnyRef) match {
+        |    case _: String =>
+        |      "line4" // the synthetic `throw new MatchError` used to be positioned, here, despite the fact that patmat positions it at line 3.
+        |  }
+        |}
+        |""".stripMargin
+    val test: ClassNode = dceCompiler.compileClass(code)
+    val i = getAsmMethod(test, "test")
+    val instr = findInstrs(i, "NEW scala/MatchError").head
+    val lineNumber = BytecodeUtils.previousLineNumber(instr)
+    assertEquals(Some(2), lineNumber)
   }
 }


### PR DESCRIPTION
  - DCE was dropping line number nodes, which seems to affect
    the default case of translated pattern matches
  - Inlining from within the same source file failed to restore
    the callee instruction's line number, which meant that
    code the followed on the same line was wrongly positioned.

Fixes scala/scala-dev#479