### PR TITLE
Improve positioning of translated patterns

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -31,7 +31,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
 // the making of the trees
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   trait TreeMakers extends TypedSubstitution with CodegenCore {
-    def optimizeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type): (List[List[TreeMaker]], List[Tree])
+    def optimizeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type, selectorPos: Position): (List[List[TreeMaker]], List[Tree])
     def analyzeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type, suppression: Suppression): Unit
 
     def emitSwitch(scrut: Tree, scrutSym: Symbol, cases: List[List[TreeMaker]], pt: Type, matchFailGenOverride: Option[Tree => Tree], unchecked: Boolean): Option[Tree] =
@@ -546,14 +546,15 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
     }
 
     // calls propagateSubstitution on the treemakers
-    def combineCases(scrut: Tree, scrutSym: Symbol, casesRaw: List[List[TreeMaker]], pt: Type, owner: Symbol, matchFailGenOverride: Option[Tree => Tree]): Tree = {
+    def combineCases(scrut: Tree, scrutSym: Symbol, casesRaw: List[List[TreeMaker]], pt: Type, selectorPos: Position, owner: Symbol, matchFailGenOverride: Option[Tree => Tree]): Tree = {
       // drops SubstOnlyTreeMakers, since their effect is now contained in the TreeMakers that follow them
       val casesNoSubstOnly = casesRaw map (propagateSubstitution(_, EmptySubstitution))
-      combineCasesNoSubstOnly(scrut, scrutSym, casesNoSubstOnly, pt, owner, matchFailGenOverride)
+      combineCasesNoSubstOnly(scrut, scrutSym, casesNoSubstOnly, pt, selectorPos, owner, matchFailGenOverride)
     }
 
     // pt is the fully defined type of the cases (either pt or the lub of the types of the cases)
-    def combineCasesNoSubstOnly(scrut: Tree, scrutSym: Symbol, casesNoSubstOnly: List[List[TreeMaker]], pt: Type, owner: Symbol, matchFailGenOverride: Option[Tree => Tree]): Tree =
+    def combineCasesNoSubstOnly(scrut: Tree, scrutSym: Symbol, casesNoSubstOnly: List[List[TreeMaker]], pt: Type,
+                                selectorPos: Position, owner: Symbol, matchFailGenOverride: Option[Tree => Tree]): Tree =
       fixerUpper(owner, scrut.pos) {
         def matchFailGen = matchFailGenOverride orElse Some(Throw(MatchErrorClass.tpe, _: Tree))
 
@@ -609,7 +610,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
 
             analyzeCases(scrutSym, casesNoSubstOnly, pt, suppression)
 
-            val (cases, toHoist) = optimizeCases(scrutSym, casesNoSubstOnly, pt)
+            val (cases, toHoist) = optimizeCases(scrutSym, casesNoSubstOnly, pt, selectorPos)
 
             val matchRes = codegen.matcher(scrut, scrutSym, pt)(cases map combineExtractors, synthCatchAll)
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -59,7 +59,7 @@ trait PatternMatching extends Transform
       case Match(sel, cases) =>
         val origTp = tree.tpe
         // setType origTp intended for CPS -- TODO: is it necessary?
-        val translated = translator.translateMatch(treeCopy.Match(tree, transform(sel), transformTrees(cases).asInstanceOf[List[CaseDef]]))
+        val translated = translator(sel.pos).translateMatch(treeCopy.Match(tree, transform(sel), transformTrees(cases).asInstanceOf[List[CaseDef]]))
         try {
           localTyper.typed(translated) setType origTp
         } catch {
@@ -69,24 +69,25 @@ trait PatternMatching extends Transform
             translated
         }
       case Try(block, catches, finalizer) =>
-        treeCopy.Try(tree, transform(block), translator.translateTry(transformTrees(catches).asInstanceOf[List[CaseDef]], tree.tpe, tree.pos), transform(finalizer))
+        val selectorPos = catches.headOption.getOrElse(EmptyTree).orElse(finalizer).pos.focusEnd
+        treeCopy.Try(tree, transform(block), translator(selectorPos).translateTry(transformTrees(catches).asInstanceOf[List[CaseDef]], tree.tpe, tree.pos), transform(finalizer))
       case _ => super.transform(tree)
     }
 
     // TODO: only instantiate new match translator when localTyper has changed
     // override def atOwner[A](tree: Tree, owner: Symbol)(trans: => A): A
     // as this is the only time TypingTransformer changes it
-    def translator: MatchTranslator with CodegenCore = {
-      new OptimizingMatchTranslator(localTyper)
+    def translator(selectorPos: Position): MatchTranslator with CodegenCore = {
+      new OptimizingMatchTranslator(localTyper, selectorPos)
     }
   }
 
-  class PureMatchTranslator(val typer: analyzer.Typer, val matchStrategy: Tree) extends MatchTranslator with PureCodegen {
-    def optimizeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type) = (cases, Nil)
+  class PureMatchTranslator(val typer: analyzer.Typer, val matchStrategy: Tree, val selectorPos: Position) extends MatchTranslator with PureCodegen {
+    def optimizeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type, selectorPos: Position) = (cases, Nil)
     def analyzeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type, suppression: Suppression): Unit = {}
   }
 
-  class OptimizingMatchTranslator(val typer: analyzer.Typer) extends MatchTranslator
+  class OptimizingMatchTranslator(val typer: analyzer.Typer, val selectorPos: Position) extends MatchTranslator
                                                              with MatchOptimizer
                                                              with MatchAnalyzer
                                                              with Solver

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2584,7 +2584,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         else newTyper(context.makeImplicit(reportAmbiguousErrors = false)).silent(_.typed(Ident(vpmName._match)), reportAmbiguousErrors = false) orElse (_ => null)
 
       if (matchStrategy ne null) // virtualize
-        typed((new PureMatchTranslator(this.asInstanceOf[patmat.global.analyzer.Typer] /*TODO*/, matchStrategy)).translateMatch(match_), mode, pt)
+        typed((new PureMatchTranslator(this.asInstanceOf[patmat.global.analyzer.Typer] /*TODO*/, matchStrategy, match_.selector.pos.focusEnd)).translateMatch(match_), mode, pt)
       else
         match_ // will be translated in phase `patmat`
     }

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -545,6 +545,8 @@ trait Trees extends api.Trees {
   object Select extends SelectExtractor
 
   case class Ident(name: Name) extends RefTree with IdentApi {
+    if (name.string_==("rc6"))
+      "".reverse
     def qualifier: Tree = EmptyTree
     def isBackquoted = this.hasAttachment[BackquotedIdentifierAttachment.type]
   }

--- a/test/files/run/sd187.check
+++ b/test/files/run/sd187.check
@@ -1,0 +1,100 @@
+[[syntax trees at end of                    patmat]] // newSource1.scala
+[7]package [7]<empty> {
+  [7]class C extends [9][2302]scala.AnyRef {
+    [2302]def <init>(): [9]C = [2302]{
+      [2302][2302][2302]C.super.<init>();
+      [9]()
+    };
+    [107]def commonSubPattern([124]x: [127]<type: [127]scala.Any>): [107]AnyVal = [205]{
+      [412]<synthetic> var rc6: [412]Boolean = [412]false;
+      [412]<synthetic> var x3: [412]String = [412][412][412]null.asInstanceOf[[412]String];
+      [205]{
+        [205]case <synthetic> val x1: [205]Any = [205]x;
+        [205]case8(){
+          [313]if ([313][313]x1.isInstanceOf[[313]Option[_]])
+            [325][325]matchEnd7([325]())
+          else
+            [313][313]case9()
+        };
+        [205]case9(){
+          [412]if ([412][412]x1.isInstanceOf[[412]String])
+            [412]{
+              [412][412]rc6 = [412]true;
+              [412][412]x3 = [412]([412][412]x1.asInstanceOf[[412]String]: [412]String);
+              [412]if ([427][427]x3.==([430]"4"))
+                [512][512]matchEnd7([512][512]x3.hashCode())
+              else
+                [412][412]case10()
+            }
+          else
+            [412][412]case10()
+        };
+        [205]case10(){
+          [205]if ([205][205]rc6.&&([627][627]x3.==([630]"6")))
+            [712][712]matchEnd7([712][712]x3.hashCode())
+          else
+            [205][205]case11()
+        };
+        [205]case11(){
+          [205][205]matchEnd7([205]throw [205][205][205]new [205]MatchError([205]x1))
+        };
+        [205]matchEnd7(x: [NoPosition]AnyVal){
+          [205]x
+        }
+      }
+    };
+    [1007]def extractor([1017]x: [1020]<type: [1020]scala.Any>): [1007]Any = [1027]{
+      [1027]case <synthetic> val x1: [1027]Any = [1027]x;
+      [1027]case6(){
+        [1120]if ([1120][1120]x1.isInstanceOf[[1120]Product2[T1,T2]])
+          [1120]{
+            [1120]<synthetic> val x2: [1120]Product2[T1,T2] = [1120]([1120][1120]x1.asInstanceOf[[1120]Product2[T1,T2]]: [1120]Product2[T1,T2]);
+            [1112]{
+              [1112]<synthetic> val o8: [1112]Option[Product2[T1,T2]] = [1112][1112][1112]scala.Product2.unapply[[1112]T1, [1112]T2]([1112]x2);
+              [1112]if ([1112]o8.isEmpty.unary_!)
+                [1112]{
+                  [1121]val a: [1121]Any = [1121]o8.get._1;
+                  [1210][1210]matchEnd5([1210]a)
+                }
+              else
+                [1112][1112]case7()
+            }
+          }
+        else
+          [1120][1120]case7()
+      };
+      [1027]case7(){
+        [1027][1027]matchEnd5([1027]throw [1027][1027][1027]new [1027]MatchError([1027]x1))
+      };
+      [1027]matchEnd5(x: [NoPosition]Any){
+        [1027]x
+      }
+    };
+    [1407]def swatch: [1407]String = [1505]try {
+      [1607][1607][1607]C.this.toString()
+    } catch {
+      [1505]case [1505](ex6 @ [1505]_) => [1505]{
+        [1505]<synthetic> val x4: [1505]Throwable = [1505]ex6;
+        [1505]case9(){
+          [1812]if ([1812][1812]x4.ne([1812]null))
+            [1812]{
+              [1812]<synthetic> val x5: [1812]Throwable = [1812]x4;
+              [1812]if ([1915][1915][1912]"".isEmpty())
+                [2014][2014]matchEnd8([2014][2014]x5.toString())
+              else
+                [1812][1812]case10()
+            }
+          else
+            [1812][1812]case10()
+        };
+        [1505]case10(){
+          [1505][1505]matchEnd8([1505]throw [1505]ex6)
+        };
+        [1505]matchEnd8(x: [NoPosition]String){
+          [1505]x
+        }
+      }
+    }
+  }
+}
+

--- a/test/files/run/sd187.check
+++ b/test/files/run/sd187.check
@@ -6,8 +6,8 @@
       [9]()
     };
     [107]def commonSubPattern([124]x: [127]<type: [127]scala.Any>): [107]AnyVal = [205]{
-      [412]<synthetic> var rc6: [412]Boolean = [412]false;
-      [412]<synthetic> var x3: [412]String = [412][412][412]null.asInstanceOf[[412]String];
+      [205]<synthetic> var rc6: [205]Boolean = [205]false;
+      [205]<synthetic> var x3: [205]String = [205][205][205]null.asInstanceOf[[205]String];
       [205]{
         [205]case <synthetic> val x1: [205]Any = [205]x;
         [205]case8(){
@@ -30,10 +30,10 @@
             [412][412]case10()
         };
         [205]case10(){
-          [205]if ([205][205]rc6.&&([627][627]x3.==([630]"6")))
+          [612]if ([612][612]rc6.&&([627][627]x3.==([630]"6")))
             [712][712]matchEnd7([712][712]x3.hashCode())
           else
-            [205][205]case11()
+            [612][612]case11()
         };
         [205]case11(){
           [205][205]matchEnd7([205]throw [205][205][205]new [205]MatchError([205]x1))
@@ -74,7 +74,7 @@
       [1607][1607][1607]C.this.toString()
     } catch {
       [1505]case [1505](ex6 @ [1505]_) => [1505]{
-        [1505]<synthetic> val x4: [1505]Throwable = [1505]ex6;
+        [1812]<synthetic> val x4: [1812]Throwable = [1812]ex6;
         [1505]case9(){
           [1812]if ([1812][1812]x4.ne([1812]null))
             [1812]{

--- a/test/files/run/sd187.scala
+++ b/test/files/run/sd187.scala
@@ -1,0 +1,42 @@
+import scala.tools.partest._
+import java.io.{Console => _, _}
+
+object Test extends DirectTest {
+
+  override def extraSettings: String = "-usejavacp -Xprint-pos -Xprint:patmat -Ystop-after:patmat -d " + testOutput.path
+
+  override def code =
+    """
+    |class C {                                                                                        //
+    |  def commonSubPattern(x: Any) = {                                                               //
+    |    x match {                                                                                    //
+    |      case _: Option[_] =>                                                                       //
+    |      case s: String if s == "4" =>                                                              //
+    |         s.hashCode                                                                              //
+    |      case s: String if s == "6" =>                                                              //
+    |         s.hashCode                                                                              //
+    |    }                                                                                            //
+    |  }                                                                                              //
+    |  def extractor(x: Any) = x match {                                                              //
+    |      case Product2(a, b) =>                                                                     //
+    |         a                                                                                       //
+    |    }                                                                                            //
+    |  def swatch = {                                                                                 //
+    |    try {                                                                                        //
+    |      toString                                                                                   //
+    |    } catch {                                                                                    //
+    |      case t: Throwable                                                                          //
+    |        if "".isEmpty =>                                                                         //
+    |           t.toString                                                                            //
+    |    }                                                                                            //
+    |  }                                                                                              //
+    |}
+    |""".stripMargin
+
+
+  override def show(): Unit = {
+    Console.withErr(System.out) {
+      compile()
+    }
+  }
+}


### PR DESCRIPTION
- Definitions of temp vars supporting CSE are positioned
   at the position of the `match` (was at the first pattern that referred
   to them)
 - References to these vars are positioned at the pattern that references
   them (was the position of the `match`)

Some of these problems have been worked around in the IntelliJ debugger, as
discussed in scala/scala-dev#187. Hopefully fixing the problems here at the
source obviates those fixes (but doesn't clash with them.)

Fixes scala/scala-dev#187

I'll prepare a diff of the bytecode of build/pack after bootstrapping
through this change.

This PR contains commits from an in-flight PR that improves handling of
positions in the optimizer. Basing this PR on that one should let us
get a cleaner bytecode diff to look at the end result of this change.