### PR TITLE
Allow compilation of files in empty package to a -d <symlink>

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/ClassfileWriters.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/ClassfileWriters.scala
@@ -143,7 +143,10 @@ abstract class ClassfileWriters {
           try Files.createDirectories(parent, noAttributes: _*)
           catch {
             case e: FileAlreadyExistsException =>
-              throw new FileConflictException(s"Can't create directory $parent; there is an existing (non-directory) file in its path", e)
+              // `createDirectories` reports this exception if `parent` is an existing symlink to a directory
+              // but that's fine for us (and common enough, `scalac -d /tmp` on mac targets symlink).
+              if (!Files.isDirectory(parent))
+                throw new FileConflictException(s"Can't create directory $parent; there is an existing (non-directory) file in its path", e)
           }
           builtPaths.put(baseDir, TRUE)
           var current = parent


### PR DESCRIPTION
Fixes a regression in 2.12.5

Before:
```
⚡ mkdir /tmp/foo; ln -s /tmp/foo /tmp/foo-symlink

⚡ qscalac -d /tmp/foo-symlink $(f "package p1; class C")

⚡ qscalac -d /tmp/foo-symlink $(f "class C")
error: error writing C: Can't create directory /tmp/foo-symlink; there is an existing (non-directory) file in its path
one error found
```

After:

```
⚡ qscalac -d /tmp/foo-symlink $(f "package p1; class C")

⚡ qscalac -d /tmp/foo-symlink $(f "class C")

⚡ touch /tmp/exists
```

And after, error cases:

```
⚡ qscalac -d /tmp/exists $(f "class C")
scalac error: /tmp/exists does not exist or is not a directory
  scalac -help  gives more information

⚡ rm /tmp/exists

⚡ mkdir -p /tmp/out1/p1

⚡ qscalac -d /tmp/out1 $(f "class C")

⚡ qscalac -d /tmp/out1 $(f "package p2; class C")

⚡ qscalac -d /tmp/out1 $(f "package p1; class C")

⚡ touch /tmp/out1/p3

⚡ qscalac -d /tmp/out1 $(f "package p3; class C")
error: error writing p3/C: Can't create directory /tmp/out1/p3; there is an existing (non-directory) file in its path
one error found

⚡ mkdir -p /tmp/out; echo "" > /tmp/a-file; ln -s /tmp/a-file /tmp/out/p1; qscalac -d /tmp/out $(f "package p1; class C")
error: error writing p1/C: Can't create directory /tmp/out/p1; there is an existing (non-directory) file in its path
one error found
```