### PR TITLE
Literal/constant-typed local lazy vals need refined values.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -609,10 +609,9 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
       val rhsAtComputer = rhs.changeOwner(lazySym -> computerSym)
 
       val computer = mkAccessor(computerSym)(gen.mkSynchronized(Ident(holderSym))(
-        refineLiteral(
-          If(initialized, getValue,
-            if (isUnit) Block(rhsAtComputer :: Nil, Apply(initialize, Nil))
-            else Apply(initialize, rhsAtComputer :: Nil)))))
+        If(initialized, getValue,
+          if (isUnit) Block(rhsAtComputer :: Nil, Apply(initialize, Nil))
+          else refineLiteral(Apply(initialize, rhsAtComputer :: Nil)))))
 
       val accessor = mkAccessor(lazySym)(
         refineLiteral(

--- a/test/files/pos/t10792.scala
+++ b/test/files/pos/t10792.scala
@@ -1,0 +1,6 @@
+object Test {
+  type Id[T] = T
+  def foo(x: Int): Id[x.type] = x
+
+  { lazy val result: 1 = foo(1) }
+}


### PR DESCRIPTION
Compiling the following,
```scala
object Test {
  type Id[T] = T
  def foo(x: Int): Id[x.type] = x

  { lazy val result: 1 = foo(1) }
}
```
crashes with an unexpected type error during the Fields phase,
```
error: scala.reflect.internal.Types$TypeError: type mismatch;
 found   : Int
 required: 1
```
This is because the translation of the local lazy val in Fields maps to a `LazyInt` which holds an `Int` value. This is too wide to assign to the `1`-typed val and results in a type error when the tree synthesized
during Fields is typechecked.

I've fixed this by inserting a cast to the narrower type, which is eliminated during erasure. In principle we could switch to a scheme similar to `LazyUnit` for literal typed local lazy vals, ie. eliminating the storage for the value whilst retaining the effects, but this seems like an unlikely enough scenario to not warrant the additional complexity that this optimization would entail.

This fixes scala/bug#10792.