### PR TITLE
performance improvements to Flag access

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -125,11 +125,10 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
   def checkAndClearOverriddenTraitSetter(setter: Symbol) = checkAndClear(OVERRIDDEN_TRAIT_SETTER)(setter)
   def checkAndClearNeedsTrees(setter: Symbol) = checkAndClear(NEEDS_TREES)(setter)
   def checkAndClear(flag: Long)(sym: Symbol) =
-    sym.hasFlag(flag) match {
-      case overridden =>
-        sym resetFlag flag
-        overridden
-    }
+    if (sym.hasFlag(flag)) {
+      sym resetFlag flag
+      true
+    } else false
 
 
   private def isOverriddenAccessor(member: Symbol, site: Symbol): Boolean = {

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -226,8 +226,8 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
           val decls = sym.info.decls
           for (s <- decls) {
             val privateWithin = s.privateWithin
-            if (privateWithin.isClass && !s.isProtected && !privateWithin.isModuleClass &&
-                !s.hasFlag(EXPANDEDNAME) && !s.isConstructor) {
+            if (privateWithin.isClass && !s.hasFlag(EXPANDEDNAME | PROTECTED) && !privateWithin.isModuleClass &&
+                !s.isConstructor) {
               val savedName = s.name
               decls.unlink(s)
               s.expandName(privateWithin)

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -225,11 +225,12 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
           checkCompanionNameClashes(sym)
           val decls = sym.info.decls
           for (s <- decls) {
-            if (s.privateWithin.isClass && !s.isProtected && !s.privateWithin.isModuleClass &&
+            val privateWithin = s.privateWithin
+            if (privateWithin.isClass && !s.isProtected && !privateWithin.isModuleClass &&
                 !s.hasFlag(EXPANDEDNAME) && !s.isConstructor) {
               val savedName = s.name
               decls.unlink(s)
-              s.expandName(s.privateWithin)
+              s.expandName(privateWithin)
               decls.enter(s)
               log("Expanded '%s' to '%s' in %s".format(savedName, s.name, sym))
             }

--- a/src/reflect/mima-filters/2.12.0.backwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.backwards.excludes
@@ -7,6 +7,7 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.Synchr
 
 ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$exists")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$getFlag")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$privateWithin")
 
 ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.IOStats")
 ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.IOStats$")

--- a/src/reflect/mima-filters/2.12.0.backwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.backwards.excludes
@@ -6,6 +6,7 @@ ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.reflect.runtime.Symbo
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedOps#SynchronizedBaseTypeSeq.lateMap")
 
 ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$exists")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$getFlag")
 
 ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.IOStats")
 ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.IOStats$")

--- a/src/reflect/mima-filters/2.12.0.backwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.backwards.excludes
@@ -8,6 +8,7 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.Synchr
 ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$exists")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$getFlag")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$privateWithin")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$annotations")
 
 ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.IOStats")
 ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.IOStats$")

--- a/src/reflect/mima-filters/2.12.0.forwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.forwards.excludes
@@ -17,6 +17,7 @@ ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.FileZipArchive$Lea
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.exists")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.getFlag")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.privateWithin")
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.annotations")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.Settings.isScala213")
 
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.FileZipArchive.this")

--- a/src/reflect/mima-filters/2.12.0.forwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.forwards.excludes
@@ -16,6 +16,7 @@ ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.FileZipArchive$Lea
 
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.exists")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.getFlag")
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.privateWithin")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.Settings.isScala213")
 
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.FileZipArchive.this")

--- a/src/reflect/mima-filters/2.12.0.forwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.forwards.excludes
@@ -15,6 +15,7 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive.
 ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.FileZipArchive$LeakyEntry")
 
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.exists")
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol.getFlag")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.Settings.isScala213")
 
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.FileZipArchive.this")

--- a/src/reflect/scala/reflect/internal/Flags.scala
+++ b/src/reflect/scala/reflect/internal/Flags.scala
@@ -202,10 +202,12 @@ class Flags extends ModifierFlags {
   final val AntiShift     = 56
 
   /** all of the flags that are unaffected by phase */
-  // (-1L & ~LateFlags & ~AntiFlags & ~(LateFlags >>> LateShift) & ~(AntiFlags >>> AntiShift))
-  // will revert to a formula before commit, but currently constant folder does not fold this to a constant
-  // but we need this to be a constant now for benchmarking
   final val PhaseIndependentFlags = 0xF807FFFFFFFFFE08L
+  //this should be
+  // final val PhaseIndependentFlags = (-1L & ~LateFlags & ~AntiFlags & ~(LateFlags >>> LateShift) & ~(AntiFlags >>> AntiShift)))
+  // but the constant folder doesnt optimise this! Good news is that is expected to be fixed soon :-)
+  assert (PhaseIndependentFlags == (-1L & ~LateFlags & ~AntiFlags & ~(LateFlags >>> LateShift) & ~(AntiFlags >>> AntiShift)))
+
 
   // Flags which sketchily share the same slot
   // 16:   BYNAMEPARAM/M      CAPTURED COVARIANT/M

--- a/src/reflect/scala/reflect/internal/Flags.scala
+++ b/src/reflect/scala/reflect/internal/Flags.scala
@@ -201,12 +201,18 @@ class Flags extends ModifierFlags {
   final val LateShift     = 47
   final val AntiShift     = 56
 
+  /** all of the flags that are unaffected by phase */
+  // (-1L & ~LateFlags & ~AntiFlags & ~(LateFlags >>> LateShift) & ~(AntiFlags >>> AntiShift))
+  // will revert to a formula before commit, but currently constant folder does not fold this to a constant
+  // but we need this to be a constant now for benchmarking
+  final val PhaseIndependentFlags = 0xF807FFFFFFFFFE08L
+
   // Flags which sketchily share the same slot
   // 16:   BYNAMEPARAM/M      CAPTURED COVARIANT/M
   // 17: CONTRAVARIANT/M INCONSTRUCTOR       LABEL
   // 25:  DEFAULTPARAM/M       TRAIT/M
   // 35:     EXISTENTIAL       MIXEDIN
-  val OverloadedFlagsMask = 0L | BYNAMEPARAM | CONTRAVARIANT | DEFAULTPARAM | EXISTENTIAL
+  final val OverloadedFlagsMask = 0L | BYNAMEPARAM | CONTRAVARIANT | DEFAULTPARAM | EXISTENTIAL
 
   // ------- late flags (set by a transformer phase) ---------------------------------
   //

--- a/src/reflect/scala/reflect/internal/ReificationSupport.scala
+++ b/src/reflect/scala/reflect/internal/ReificationSupport.scala
@@ -666,7 +666,7 @@ trait ReificationSupport { self: SymbolTable =>
       def transformStats(trees: List[Tree]): List[Tree] = trees match {
         case Nil => Nil
         case ValDef(mods, _, SyntacticEmptyTypeTree(), Match(MaybeTyped(MaybeUnchecked(value), tpt), CaseDef(pat, EmptyTree, SyntacticTuple(ids)) :: Nil)) :: tail
-          if mods.hasFlag(SYNTHETIC) && mods.hasFlag(ARTIFACT) =>
+          if mods.hasAllFlags(SYNTHETIC | ARTIFACT) =>
           ids match {
             case Nil =>
               ValDef(NoMods, nme.QUASIQUOTE_PAT_DEF, Typed(pat, tpt), transform(value)) :: transformStats(tail)
@@ -704,7 +704,7 @@ trait ReificationSupport { self: SymbolTable =>
     protected object UnSyntheticParam {
       def unapply(tree: Tree): Option[TermName] = tree match {
         case ValDef(mods, name, _, EmptyTree)
-          if mods.hasFlag(SYNTHETIC) && mods.hasFlag(PARAM) =>
+          if mods.hasAllFlags(SYNTHETIC | PARAM) =>
           Some(name)
         case _ => None
       }
@@ -899,7 +899,7 @@ trait ReificationSupport { self: SymbolTable =>
           if pf.tpe != null && pf.tpe.typeSymbol.eq(PartialFunctionClass) &&
              abspf.tpe != null && abspf.tpe.typeSymbol.eq(AbstractPartialFunctionClass) &&
              ser.tpe != null && ser.tpe.typeSymbol.eq(SerializableClass) &&
-             clsMods.hasFlag(FINAL) && clsMods.hasFlag(SYNTHETIC) =>
+             clsMods.hasAllFlags(FINAL | SYNTHETIC) =>
           Some(cases)
         case _ => None
       }

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -737,19 +737,12 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       flags & mask
     }
     /** Does symbol have ANY flag in `mask` set? */
-    final def hasFlag(mask: Long): Boolean = {
-      // See `getFlag` to learn more about the `isThreadsafe` call in the body of this method.
-      if (!isCompilerUniverse && !isThreadsafe(purpose = FlagOps(mask))) initialize
-      (flags & mask) != 0
-    }
+    final def hasFlag(mask: Long): Boolean = getFlag(mask) != 0
+
     def hasFlag(mask: Int): Boolean = hasFlag(mask.toLong)
 
     /** Does symbol have ALL the flags in `mask` set? */
-    final def hasAllFlags(mask: Long): Boolean = {
-      // See `getFlag` to learn more about the `isThreadsafe` call in the body of this method.
-      if (!isCompilerUniverse && !isThreadsafe(purpose = FlagOps(mask))) initialize
-      (flags & mask) == mask
-    }
+    final def hasAllFlags(mask: Long): Boolean = getFlag(mask) == mask
 
     def setFlag(mask: Long): this.type   = { _rawflags |= mask ; this }
     def resetFlag(mask: Long): this.type = { _rawflags &= ~mask ; this }

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1421,15 +1421,16 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      */
     private[this] var _privateWithin: Symbol = _
     def privateWithin = {
-      // See `getFlag` to learn more about the `isThreadsafe` call in the body of this method.
-      if (!isCompilerUniverse && !isThreadsafe(purpose = AllOps)) initialize
       _privateWithin
     }
     def privateWithin_=(sym: Symbol) { _privateWithin = sym }
     def setPrivateWithin(sym: Symbol): this.type = { privateWithin_=(sym) ; this }
 
     /** Does symbol have a private or protected qualifier set? */
-    final def hasAccessBoundary = (privateWithin != null) && (privateWithin != NoSymbol)
+    final def hasAccessBoundary = {
+      val pw = privateWithin
+      (pw ne null) && (pw ne NoSymbol)
+    }
 
 // ------ info and type -------------------------------------------------------------------
 
@@ -2476,8 +2477,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      */
     final def caseModule: Symbol = {
       var modname = name.toTermName
-      if (privateWithin.isClass && !privateWithin.isModuleClass && !hasFlag(EXPANDEDNAME))
-        modname = nme.expandedName(modname, privateWithin)
+      val pw = privateWithin
+      if (pw.isClass && !pw.isModuleClass && !hasFlag(EXPANDEDNAME))
+        modname = nme.expandedName(modname, pw)
       initialize.owner.info.decl(modname).suchThat(_.isModule)
     }
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -104,7 +104,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     // `isByNameParam` is only true for a call-by-name parameter of a *method*,
     // an argument of the primary constructor seen in the class body is excluded by `isValueParameter`
     def isByNameParam: Boolean = this.isValueParameter && (this hasFlag BYNAMEPARAM)
-    def isImplementationArtifact: Boolean = (this hasFlag BRIDGE) || (this hasFlag VBRIDGE) || (this hasFlag ARTIFACT)
+    def isImplementationArtifact: Boolean = this hasFlag (BRIDGE | VBRIDGE | ARTIFACT)
     def isJava: Boolean = isJavaDefined
 
     def isField: Boolean = isTerm && !isModule && (!isMethod || owner.isTrait && isAccessor)
@@ -113,8 +113,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isVar: Boolean = isField && !isLazy && isMutableVal
 
     def isAbstract: Boolean = isAbstractClass || isDeferred || isAbstractType
-    def isPrivateThis = (this hasFlag PRIVATE) && (this hasFlag LOCAL)
-    def isProtectedThis = (this hasFlag PROTECTED) && (this hasFlag LOCAL)
+    def isPrivateThis = this hasAllFlags (PRIVATE | LOCAL)
+    def isProtectedThis = this hasAllFlags (PROTECTED | LOCAL)
 
     def isJavaEnum: Boolean = hasJavaEnumFlag
     def isJavaAnnotation: Boolean = hasJavaAnnotationFlag

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -732,9 +732,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      *  we'd like to expose to reflection users. Therefore a proposed solution is to check whether we're in a
      *  runtime reflection universe, and if yes and if we've not yet loaded the requested info, then to commence initialization.
      */
-    final def getFlag(mask: Long): Long = {
-      if (!isCompilerUniverse && !isThreadsafe(purpose = FlagOps(mask))) initialize
-      flags & mask
+    def getFlag(mask: Long): Long = {
+      mask & (if ((mask & PhaseIndependentFlags) == mask) rawflags else flags)
     }
     /** Does symbol have ANY flag in `mask` set? */
     final def hasFlag(mask: Long): Boolean = getFlag(mask) != 0
@@ -746,7 +745,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     def setFlag(mask: Long): this.type   = { _rawflags |= mask ; this }
     def resetFlag(mask: Long): this.type = { _rawflags &= ~mask ; this }
-    def resetFlags() { rawflags = 0 }
+    def resetFlags() { rawflags = 0L }
 
     /** Default implementation calls the generic string function, which
      *  will print overloaded flags as <flag1/flag2/flag3>.  Subclasses

--- a/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
@@ -92,6 +92,12 @@ private[reflect] trait SynchronizedSymbols extends internal.Symbols { self: Symb
       else purpose.isFlagRelated && (_initializationMask & purpose.mask & TopLevelPickledFlags) == 0
     }
 
+    override final def privateWithin: Symbol = {
+      // See `getFlag` to learn more about the `isThreadsafe` call in the body of this method.
+      if (!isCompilerUniverse && !isThreadsafe(purpose = AllOps)) initialize
+      super.privateWithin
+    }
+
     /** Communicates with completers declared in scala.reflect.runtime.SymbolLoaders
      *  about the status of initialization of the underlying symbol.
      *

--- a/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
@@ -125,6 +125,11 @@ private[reflect] trait SynchronizedSymbols extends internal.Symbols { self: Symb
       gilSynchronized { body }
     }
 
+    override final def getFlag(mask: Long): Long = {
+      if (!isCompilerUniverse && !isThreadsafe(purpose = FlagOps(mask))) initialize
+      super.getFlag(mask)
+    }
+
     override def validTo = gilSynchronizedIfNotThreadsafe { super.validTo }
     override def info = gilSynchronizedIfNotThreadsafe { super.info }
     override def rawInfo: Type = gilSynchronizedIfNotThreadsafe { super.rawInfo }

--- a/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
@@ -98,6 +98,12 @@ private[reflect] trait SynchronizedSymbols extends internal.Symbols { self: Symb
       super.privateWithin
     }
 
+    override def annotations: List[AnnotationInfo] = {
+      // See `getFlag` to learn more about the `isThreadsafe` call in the body of this method.
+      if (!isCompilerUniverse && !isThreadsafe(purpose = AllOps)) initialize
+      super.annotations
+    }
+
     /** Communicates with completers declared in scala.reflect.runtime.SymbolLoaders
      *  about the status of initialization of the underlying symbol.
      *


### PR DESCRIPTION
Removes outer class access and other operations if not needed

 - Use bulk flag query where possible
 - Push down auto-initialization logic into overrides in runtime reflection
 - Avoid lookup of the phase-indexed flag mask for flags known to be phase independent (e.g. `ERROR`)
 - Make more flag masks constant foldable