### PR TITLE
Fix problem in Jenkins bootstrap script after recent changes to scripts

### DIFF
--- a/scripts/jobs/integrate/bootstrap
+++ b/scripts/jobs/integrate/bootstrap
@@ -9,10 +9,10 @@ sbtArgs="-ivy $IVY2_DIR -Dsbt.override.build.repos=true -Dsbt.repository.config=
 
 source scripts/bootstrap_fun
 
+generateRepositoriesConfig $integrationRepoUrl
+
 determineScalaVersion
 deriveModuleVersions
-
-generateRepositoriesConfig $integrationRepoUrl
 
 removeExistingBuilds $integrationRepoUrl
 clearIvyCache


### PR DESCRIPTION
Fixes scala/scala-dev#481

Although to make the bootstrap jobs work, we also need to configure the integration repo credentials as environment variables on the Jenkins workers, as the scripts now expect. An alternative would be to make the scripts work with either env vars or the credentials file in the home dir.