### PR TITLE
Bootstrap with Scala 2.13.0-M3-f73b161

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -1,5 +1,5 @@
 # Scala version used for bootstrapping (see README.md)
-starr.version=2.13.0-M3
+starr.version=2.13.0-M3-f73b161
 
 # The scala.binary.version determines how modules are resolved. It is set as follows:
 #  - After 2.x.0 is released, the binary version is 2.x
@@ -9,7 +9,7 @@ starr.version=2.13.0-M3
 # that binary compatibility does not break. For example, after releasing 2.12.0-M1, we continue
 # using scala-partest_2.12.0-M1 until releasing M2. Manual intervention is necessary for changes
 # that break binary compatibility, see for example PR #5003.
-scala.binary.version=2.13.0-M3
+scala.binary.version=2.13.0-M3-f73b161
 
 # These are the versions of the modules that go with this release.
 # Artifact dependencies:


### PR DESCRIPTION
This new build contains the necessary compiler changes to allow
building with the new collection library.