### PR TITLE
Warn when Unit object is discarded

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1096,12 +1096,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               case (Apply(Select(receiver, _), _), SingleType(_, sym)) => sym == receiver.symbol
               case _ => false
             }
-            if (!isThisTypeResult) {
-              if (tree.tpe.termSymbol == UnitClass.companionModule)
-                context.warning(tree.pos, "discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.")
-              else if (settings.warnValueDiscard)
-                context.warning(tree.pos, "discarded non-Unit value")
-            }
+            if (tree.tpe.termSymbol == UnitClass.companionModule)
+              context.warning(tree.pos, "discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.")
+            else if (settings.warnValueDiscard && !isThisTypeResult)
+              context.warning(tree.pos, "discarded non-Unit value")
           }
           @inline def warnNumericWiden(): Unit =
             if (!isPastTyper && settings.warnNumericWiden) context.warning(tree.pos, "implicit numeric widening")

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1097,7 +1097,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               case _ => false
             }
             if (tree.tpe.termSymbol == UnitModule)
-              context.warning(tree.pos, "discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.")
+              context.warning(tree.pos, "discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.")
             else if (settings.warnValueDiscard && !isThisTypeResult)
               context.warning(tree.pos, "discarded non-Unit value")
           }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1096,7 +1096,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               case (Apply(Select(receiver, _), _), SingleType(_, sym)) => sym == receiver.symbol
               case _ => false
             }
-            if (tree.tpe.termSymbol == UnitClass.companionModule)
+            if (tree.tpe.termSymbol == UnitModule)
               context.warning(tree.pos, "discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.")
             else if (settings.warnValueDiscard && !isThisTypeResult)
               context.warning(tree.pos, "discarded non-Unit value")

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -81,6 +81,13 @@ trait Definitions extends api.StandardDefinitions {
       }
     }
 
+    private[Definitions] def valueClassCompanion(name: TermName): ModuleSymbol = {
+      getMember(ScalaPackageClass, name) match {
+        case x: ModuleSymbol => x
+        case _               => catastrophicFailure()
+      }
+    }
+
     private[Definitions] def classesMap[T](f: Name => T): Map[Symbol, T] = symbolsMap(ScalaValueClassesNoUnit, f)
     private def symbolsMap[T](syms: List[Symbol], f: Name => T): Map[Symbol, T] = mapFrom(syms)(x => f(x.name))
     private def symbolsMapFilt[T](syms: List[Symbol], p: Name => Boolean, f: Name => T) = symbolsMap(syms filter (x => p(x.name)), f)
@@ -137,6 +144,8 @@ trait Definitions extends api.StandardDefinitions {
     lazy val FloatTpe     = FloatClass.tpe
     lazy val DoubleTpe    = DoubleClass.tpe
     lazy val BooleanTpe   = BooleanClass.tpe
+
+    lazy val UnitModule   = valueClassCompanion(tpnme.Unit.toTermName)
 
     lazy val ScalaNumericValueClasses = ScalaValueClasses filterNot Set[Symbol](UnitClass, BooleanClass)
     lazy val ScalaValueClassesNoUnit  = ScalaValueClasses filterNot (_ eq UnitClass)
@@ -1461,13 +1470,6 @@ trait Definitions extends api.StandardDefinitions {
 
       lazy val Boxes_isNumberOrBool  = getDecl(BoxesRunTimeClass, nme.isBoxedNumberOrBoolean)
       lazy val Boxes_isNumber        = getDecl(BoxesRunTimeClass, nme.isBoxedNumber)
-
-      private def valueClassCompanion(name: TermName): ModuleSymbol = {
-        getMember(ScalaPackageClass, name) match {
-          case x: ModuleSymbol => x
-          case _               => catastrophicFailure()
-        }
-      }
 
       private def valueCompanionMember(className: Name, methodName: TermName): TermSymbol =
         getMemberMethod(valueClassCompanion(className.toTermName).moduleClass, methodName)

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -465,6 +465,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.FloatTpe
     definitions.DoubleTpe
     definitions.BooleanTpe
+    definitions.UnitModule
     definitions.ScalaNumericValueClasses
     definitions.ScalaValueClassesNoUnit
     definitions.ScalaValueClasses

--- a/test/files/neg/warn-discarded-companion-unit-alt.check
+++ b/test/files/neg/warn-discarded-companion-unit-alt.check
@@ -1,28 +1,28 @@
-warn-discarded-companion-unit-alt.scala:2: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit-alt.scala:2: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
   def u1: Unit = Unit
                  ^
-warn-discarded-companion-unit-alt.scala:3: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit-alt.scala:3: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
   val u2: Unit = Unit
                  ^
-warn-discarded-companion-unit-alt.scala:6: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit-alt.scala:6: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
     Unit
     ^
-warn-discarded-companion-unit-alt.scala:11: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit-alt.scala:11: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
     Unit
     ^
-warn-discarded-companion-unit-alt.scala:15: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit-alt.scala:15: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
   runA(Unit)
        ^
-warn-discarded-companion-unit-alt.scala:16: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit-alt.scala:16: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
   runA({ println(1 + 1); Unit })
                          ^
-warn-discarded-companion-unit-alt.scala:19: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit-alt.scala:19: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
   runB { _ => println(2 + 3); Unit }
                               ^
-warn-discarded-companion-unit-alt.scala:22: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit-alt.scala:22: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
     if (util.Random.nextInt % 2 == 0) Right(Unit) else Left(Unit)
                                             ^
-warn-discarded-companion-unit-alt.scala:22: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit-alt.scala:22: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
     if (util.Random.nextInt % 2 == 0) Right(Unit) else Left(Unit)
                                                             ^
 error: No warnings can be incurred under -Xfatal-warnings.

--- a/test/files/neg/warn-discarded-companion-unit-alt.check
+++ b/test/files/neg/warn-discarded-companion-unit-alt.check
@@ -1,0 +1,30 @@
+warn-discarded-companion-unit-alt.scala:2: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+  def u1: Unit = Unit
+                 ^
+warn-discarded-companion-unit-alt.scala:3: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+  val u2: Unit = Unit
+                 ^
+warn-discarded-companion-unit-alt.scala:6: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+    Unit
+    ^
+warn-discarded-companion-unit-alt.scala:11: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+    Unit
+    ^
+warn-discarded-companion-unit-alt.scala:15: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+  runA(Unit)
+       ^
+warn-discarded-companion-unit-alt.scala:16: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+  runA({ println(1 + 1); Unit })
+                         ^
+warn-discarded-companion-unit-alt.scala:19: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+  runB { _ => println(2 + 3); Unit }
+                              ^
+warn-discarded-companion-unit-alt.scala:22: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+    if (util.Random.nextInt % 2 == 0) Right(Unit) else Left(Unit)
+                                            ^
+warn-discarded-companion-unit-alt.scala:22: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+    if (util.Random.nextInt % 2 == 0) Right(Unit) else Left(Unit)
+                                                            ^
+error: No warnings can be incurred under -Xfatal-warnings.
+9 warnings found
+one error found

--- a/test/files/neg/warn-discarded-companion-unit-alt.flags
+++ b/test/files/neg/warn-discarded-companion-unit-alt.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/warn-discarded-companion-unit-alt.scala
+++ b/test/files/neg/warn-discarded-companion-unit-alt.scala
@@ -1,0 +1,25 @@
+object Test {
+  def u1: Unit = Unit
+  val u2: Unit = Unit
+  lazy val u3: Unit = {
+    println(5)
+    Unit
+  }
+
+  def not_println(s: String): Unit = {
+    println(s)
+    Unit
+  }
+
+  def runA(thunk: => Unit) = thunk
+  runA(Unit)
+  runA({ println(1 + 1); Unit })
+
+  def runB(f: Unit => Unit) = f(())
+  runB { _ => println(2 + 3); Unit }
+
+  lazy val ou: Either[Unit, Unit] =
+    if (util.Random.nextInt % 2 == 0) Right(Unit) else Left(Unit)
+
+  def noWarnNecessary: Unit.type = Unit
+}

--- a/test/files/neg/warn-discarded-companion-unit.check
+++ b/test/files/neg/warn-discarded-companion-unit.check
@@ -1,0 +1,30 @@
+warn-discarded-companion-unit.scala:2: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+  def u1: Unit = Unit
+                 ^
+warn-discarded-companion-unit.scala:3: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+  val u2: Unit = Unit
+                 ^
+warn-discarded-companion-unit.scala:6: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+    Unit
+    ^
+warn-discarded-companion-unit.scala:11: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+    Unit
+    ^
+warn-discarded-companion-unit.scala:15: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+  runA(Unit)
+       ^
+warn-discarded-companion-unit.scala:16: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+  runA({ println(1 + 1); Unit })
+                         ^
+warn-discarded-companion-unit.scala:19: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+  runB { _ => println(2 + 3); Unit }
+                              ^
+warn-discarded-companion-unit.scala:22: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+    if (util.Random.nextInt % 2 == 0) Right(Unit) else Left(Unit)
+                                            ^
+warn-discarded-companion-unit.scala:22: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+    if (util.Random.nextInt % 2 == 0) Right(Unit) else Left(Unit)
+                                                            ^
+error: No warnings can be incurred under -Xfatal-warnings.
+9 warnings found
+one error found

--- a/test/files/neg/warn-discarded-companion-unit.check
+++ b/test/files/neg/warn-discarded-companion-unit.check
@@ -1,28 +1,28 @@
-warn-discarded-companion-unit.scala:2: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit.scala:2: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
   def u1: Unit = Unit
                  ^
-warn-discarded-companion-unit.scala:3: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit.scala:3: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
   val u2: Unit = Unit
                  ^
-warn-discarded-companion-unit.scala:6: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit.scala:6: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
     Unit
     ^
-warn-discarded-companion-unit.scala:11: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit.scala:11: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
     Unit
     ^
-warn-discarded-companion-unit.scala:15: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit.scala:15: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
   runA(Unit)
        ^
-warn-discarded-companion-unit.scala:16: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit.scala:16: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
   runA({ println(1 + 1); Unit })
                          ^
-warn-discarded-companion-unit.scala:19: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit.scala:19: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
   runB { _ => println(2 + 3); Unit }
                               ^
-warn-discarded-companion-unit.scala:22: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit.scala:22: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
     if (util.Random.nextInt % 2 == 0) Right(Unit) else Left(Unit)
                                             ^
-warn-discarded-companion-unit.scala:22: warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
+warn-discarded-companion-unit.scala:22: warning: discarded companion object of Unit. Write '()' for the unit value, the only value of type Unit.
     if (util.Random.nextInt % 2 == 0) Right(Unit) else Left(Unit)
                                                             ^
 error: No warnings can be incurred under -Xfatal-warnings.

--- a/test/files/neg/warn-discarded-companion-unit.flags
+++ b/test/files/neg/warn-discarded-companion-unit.flags
@@ -1,0 +1,1 @@
+-Ywarn-value-discard -Xfatal-warnings

--- a/test/files/neg/warn-discarded-companion-unit.scala
+++ b/test/files/neg/warn-discarded-companion-unit.scala
@@ -1,0 +1,25 @@
+object Test {
+  def u1: Unit = Unit
+  val u2: Unit = Unit
+  lazy val u3: Unit = {
+    println(5)
+    Unit
+  }
+
+  def not_println(s: String): Unit = {
+    println(s)
+    Unit
+  }
+
+  def runA(thunk: => Unit) = thunk
+  runA(Unit)
+  runA({ println(1 + 1); Unit })
+
+  def runB(f: Unit => Unit) = f(())
+  runB { _ => println(2 + 3); Unit }
+
+  lazy val ou: Either[Unit, Unit] =
+    if (util.Random.nextInt % 2 == 0) Right(Unit) else Left(Unit)
+
+  def noWarnNecessary: Unit.type = Unit
+}


### PR DESCRIPTION
Currently this kind of code is possible to write:
```scala
def either(b: Boolean): Either[Unit, Unit] = if (b) Right(Unit) else Left(Unit)
```
This is not only terrible practice, it is also misleading for someone who does not know how to create a value of type `Unit`. After the PR, a warning would be emitted:
```
warning: discarded companion object Unit of type Unit.type. Use () to obtain a value of type Unit.
       def either(b: Boolean): Either[Unit, Unit] = if (b) Right(Unit) else Left(Unit)
                                                                 ^
```
The warning intentionally takes precedence over the `-Ywarn-value-discard` one. Currently with `-Ywarn-value-discard`, a somewhat-misleading warning about a non-unit value being discarded is emitted, so it seems like the warning added in this PR is preferrable.

See discussion & longer explanations here: https://contributors.scala-lang.org/t/warn-when-unit-is-used-where-is-expected/1663 .

Note: to be honest, I have no idea what does `isThisTypeResult` represent. It seems to me that if the normal discard value warning shouldn't be emitted if it is `true`, this one should not be emitted either, but I may be wrong.