### PR TITLE
Don't suggest using the global EC when an implicit EC cannot be found.

### DIFF
--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -54,8 +54,7 @@ import scala.annotation.implicitNotFound
  * Application callback execution can be configured separately.
  */
 @implicitNotFound("""Cannot find an implicit ExecutionContext. You might pass
-an (implicit ec: ExecutionContext) parameter to your method
-or import scala.concurrent.ExecutionContext.Implicits.global.""")
+an (implicit ec: ExecutionContext) parameter to your method.""")
 trait ExecutionContext {
 
   /** Runs a block of code on this execution context.

--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -54,7 +54,17 @@ import scala.annotation.implicitNotFound
  * Application callback execution can be configured separately.
  */
 @implicitNotFound("""Cannot find an implicit ExecutionContext. You might pass
-an (implicit ec: ExecutionContext) parameter to your method.""")
+an (implicit ec: ExecutionContext) parameter to your method.
+
+The ExecutionContext is used to configure how and on which
+thread pools Futures will run, so the specific ExecutionContext
+that is selected is important.
+
+If your application does not define an ExecutionContext elsewhere,
+consider using Scala's global ExecutionContext by defining
+the following:
+
+implicit val ec = ExecutionContext.global""")
 trait ExecutionContext {
 
   /** Runs a block of code on this execution context.


### PR DESCRIPTION
Fixes scala/bug#10808.

* I opened this against 2.12.x - is that okay or would you prefer to accept this in 2.13.x?
* Do you want a neg test that checks the error message is displayed?