### PR TITLE
Apply no warn attachment to binds

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1969,7 +1969,7 @@ self =>
           atPos(p.pos.start, p.pos.start, body.pos.end) {
             val t = Bind(name, body)
             body match {
-              case Ident(nme.WILDCARD) if settings.warnUnusedPatVars => t updateAttachment AtBoundIdentifierAttachment
+              case Ident(nme.WILDCARD) if settings.warnUnusedPatVars => t updateAttachment NoWarnAttachment
               case _ => t
             }
           }

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -80,7 +80,7 @@ trait TypeDiagnostics {
   }
 
   // Bind of pattern var was `x @ _`
-  private def atBounded(t: Tree) = t.hasAttachment[AtBoundIdentifierAttachment.type]
+  private def atBounded(t: Tree) = t.hasAttachment[NoWarnAttachment.type]
 
   // ValDef was a PatVarDef `val P(x) = ???`
   private def wasPatVarDef(t: Tree) = t.hasAttachment[PatVarDefAttachment.type]

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -64,12 +64,12 @@ trait StdAttachments {
   case object BackquotedIdentifierAttachment extends PlainAttachment
 
   /** A pattern binding exempt from unused warning.
-    *
-    * Its host `Ident` has been created from a pattern2 binding, `case x @ p`.
-    * In the absence of named parameters in patterns, allows nuanced warnings for unused variables.
-    * Hence, `case X(x = _) =>` would not warn; for now, `case X(x @ _) =>` is documentary if x is unused.
-    */
-  case object AtBoundIdentifierAttachment extends PlainAttachment
+   *
+   *  Its host `Ident` has been created from a pattern2 binding, `case x @ p`.
+   *  In the absence of named parameters in patterns, allows nuanced warnings for unused variables.
+   *  Hence, `case X(x = _) =>` would not warn; for now, `case X(x @ _) =>` is documentary if x is unused.
+   */
+  case object NoWarnAttachment extends PlainAttachment
 
   /** Indicates that a `ValDef` was synthesized from a pattern definition, `val P(x)`.
    */

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -813,11 +813,19 @@ abstract class TreeGen {
     else ValFrom(pat1, mkCheckIfRefutable(pat1, rhs)).setPos(pos)
   }
 
+  private def unwarnable(pat: Tree): Tree = {
+    pat foreach {
+      case b @ Bind(_, _) => b updateAttachment AtBoundIdentifierAttachment
+      case _ =>
+    }
+    pat
+  }
+
   def mkCheckIfRefutable(pat: Tree, rhs: Tree)(implicit fresh: FreshNameCreator) =
     if (treeInfo.isVarPatternDeep(pat)) rhs
     else {
       val cases = List(
-        CaseDef(pat.duplicate updateAttachment AtBoundIdentifierAttachment, EmptyTree, Literal(Constant(true))),
+        CaseDef(unwarnable(pat.duplicate), EmptyTree, Literal(Constant(true))),
         CaseDef(Ident(nme.WILDCARD), EmptyTree, Literal(Constant(false)))
       )
       val visitor = mkVisitor(cases, checkExhaustive = false, nme.CHECK_IF_REFUTABLE_STRING)

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -40,7 +40,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.SAMFunction
     this.DelambdafyTarget
     this.BackquotedIdentifierAttachment
-    this.AtBoundIdentifierAttachment
+    this.NoWarnAttachment
     this.PatVarDefAttachment
     this.ForAttachment
     this.SyntheticUnitAttachment

--- a/test/files/pos/t10763.flags
+++ b/test/files/pos/t10763.flags
@@ -1,1 +1,1 @@
--Xfatal-warnings -Xlint:unused
+-Xfatal-warnings -Ywarn-unused

--- a/test/files/pos/t10763.scala
+++ b/test/files/pos/t10763.scala
@@ -4,4 +4,5 @@ class Test {
 
     for (refute@1 <- xs) {}
   }
+  def f() = for (Some(i: Int) <- List(Option(42))) println(i)
 }


### PR DESCRIPTION
The warning in TypeDiagnostics checks for
an attachment where a variable is introduced.

This tweaks Adriaan's tweak.

Note the flag wasn't actually on for the test.

@adriaanm @SethTisue Maybe this is a good candidate for 2.12.6