### PR TITLE
Fix up embarrassing typo.

### DIFF
--- a/src/compiler/scala/reflect/reify/package.scala
+++ b/src/compiler/scala/reflect/reify/package.scala
@@ -51,7 +51,7 @@ package object reify {
     import definitions._
     import analyzer.enclosingMacroPosition
 
-    if (global.phase.id < global.currentRun.erasurePhase.id)
+    if (global.phase.id >= global.currentRun.erasurePhase.id)
       devWarning(enclosingMacroPosition, s"reify Class[$tpe0] during ${global.phase.name}")
 
     // scala/bug#7375
@@ -72,7 +72,7 @@ package object reify {
     }
   }
 
-  // Note: If  current context is inside the constructor of an object or otherwise not inside
+  // Note: If current context is inside the constructor of an object or otherwise not inside
   // a class/object body, this will return an EmptyTree.
   def reifyEnclosingRuntimeClass(global: Global)(typer0: global.analyzer.Typer): global.Tree = {
     import global._


### PR DESCRIPTION
I put this in in cdf74190c442ff60dc6b4ed7c7567fb58448a90e, right before the PR got merged, and moved the condition that used to be in the `else` block into a `devWarning`, as I was pretty sure we'd never get here at or later than erasure (otherwise, there's a chance we'd let a `Constant(<unerased type>)` get to the backend. I wasn't willing to wager on it with an assertion, though.

In retrospect it would have been better to poke around with `-Xdev` on first, so I would notice the reversed condition. (I build with the flag at work so someone sees the warnings, is how I noticed.)

~This would be cool to get in 2.12.6, but I'll let the kitty assign it to 2.12.7 in case 2.12.6 is supposed to be code frozen.~ (edit: thanks, Seth 🙇)