### PR TITLE
Assorted optimizations to the new collections

### DIFF
--- a/src/library/scala/collection/immutable/ChampCommon.scala
+++ b/src/library/scala/collection/immutable/ChampCommon.scala
@@ -66,8 +66,8 @@ private[immutable] abstract class ChampBaseIterator[T <: Node[T]] {
   protected var currentValueNode: T = _
 
   private var currentStackLevel: Int = -1
-  private val nodeCursorsAndLengths: Array[Int] = Array.ofDim[Int](MaxDepth * 2)
-  private val nodes: Array[T] = Array.ofDim[Node[T]](MaxDepth).asInstanceOf[Array[T]]
+  private val nodeCursorsAndLengths: Array[Int] = new Array[Int](MaxDepth * 2)
+  private val nodes: Array[T] = new Array[Node[T]](MaxDepth).asInstanceOf[Array[T]]
 
   def this(rootNode: T) = {
     this()
@@ -143,8 +143,8 @@ private[immutable] abstract class ChampBaseReverseIterator[T <: Node[T]] {
   protected var currentValueNode: T = _
 
   private var currentStackLevel: Int = -1
-  private val nodeIndex: Array[Int] = Array.ofDim[Int](MaxDepth + 1)
-  private val nodeStack: Array[T] = Array.ofDim[Node[T]](MaxDepth + 1).asInstanceOf[Array[T]]
+  private val nodeIndex: Array[Int] = new Array[Int](MaxDepth + 1)
+  private val nodeStack: Array[T] = new Array[Node[T]](MaxDepth + 1).asInstanceOf[Array[T]]
 
   def this(rootNode: T) = {
     this()

--- a/src/library/scala/collection/immutable/ImmutableArray.scala
+++ b/src/library/scala/collection/immutable/ImmutableArray.scala
@@ -42,7 +42,7 @@ sealed abstract class ImmutableArray[+A]
   def apply(i: Int): A
 
   override def updated[B >: A](index: Int, elem: B): ImmutableArray[B] = {
-    val dest = Array.ofDim[Any](length)
+    val dest = new Array[Any](length)
     Array.copy(unsafeArray, 0, dest, 0, length)
     dest(index) = elem
     ImmutableArray.unsafeWrapArray(dest)
@@ -51,14 +51,14 @@ sealed abstract class ImmutableArray[+A]
   override def map[B](f: A => B): ImmutableArray[B] = iterableFactory.tabulate(length)(i => f(apply(i)))
 
   override def prepended[B >: A](elem: B): ImmutableArray[B] = {
-    val dest = Array.ofDim[Any](length + 1)
+    val dest = new Array[Any](length + 1)
     dest(0) = elem
     Array.copy(unsafeArray, 0, dest, 1, length)
     ImmutableArray.unsafeWrapArray(dest)
   }
 
   override def appended[B >: A](elem: B): ImmutableArray[B] = {
-    val dest = Array.ofDim[Any](length + 1)
+    val dest = new Array[Any](length + 1)
     Array.copy(unsafeArray, 0, dest, 0, length)
     dest(length) = elem
     ImmutableArray.unsafeWrapArray(dest)

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -333,6 +333,67 @@ sealed abstract class List[+A]
     acc
   }
 
+  // Copy/Paste overrides to avoid interface calls inside loops.
+
+  override final def length: Int = {
+    var these = this
+    var len = 0
+    while (!these.isEmpty) {
+      len += 1
+      these = these.tail
+    }
+    len
+  }
+
+  override final def lengthCompare(len: Int): Int = {
+    @tailrec def loop(i: Int, xs: List[A]): Int = {
+      if (i == len)
+        if (xs.isEmpty) 0 else 1
+      else if (xs.isEmpty)
+        -1
+      else
+        loop(i + 1, xs.tail)
+    }
+    if (len < 0) 1
+    else loop(0, coll)
+  }
+
+  override final def forall(p: A => Boolean): Boolean = {
+    var these: List[A] = coll
+    while (!these.isEmpty) {
+      if (!p(these.head)) return false
+      these = these.tail
+    }
+    true
+  }
+
+  override final def exists(p: A => Boolean): Boolean = {
+    var these: List[A] = coll
+    while (!these.isEmpty) {
+      if (p(these.head)) return true
+      these = these.tail
+    }
+    false
+  }
+
+  override final def contains[A1 >: A](elem: A1): Boolean = {
+    var these: List[A] = coll
+    while (!these.isEmpty) {
+      if (these.head == elem) return true
+      these = these.tail
+    }
+    false
+  }
+
+  override final def find(p: A => Boolean): Option[A] = {
+    var these: List[A] = this
+    while (!these.isEmpty) {
+      if (p(these.head)) return Some(these.head)
+      these = these.tail
+    }
+    None
+  }
+
   // Create a proxy for Java serialization that allows us to avoid mutation
   // during deserialization.  This is the Serialization Proxy Pattern.
   protected final def writeReplace(): AnyRef = new List.SerializationProxy(this)

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -7,6 +7,7 @@ import java.io.{ObjectInputStream, ObjectOutputStream}
 import scala.annotation.unchecked.uncheckedVariance
 import scala.annotation.tailrec
 import mutable.{Builder, ListBuffer, ReusableBuilder}
+import scala.collection.{LinearSeq, Seq}
 
 
 
@@ -393,6 +394,24 @@ sealed abstract class List[+A]
   }
 
   final override def toList: List[A] = this
+
+  // Override for performance
+  override def equals(o: scala.Any): Boolean = {
+    @tailrec def listEq(a: List[_], b: List[_]): Boolean =
+      (a eq b) || {
+        if (a.nonEmpty && b.nonEmpty && a.head == b.head) {
+          listEq(a.tail, b.tail)
+        }
+        else {
+          a.isEmpty && b.isEmpty
+        }
+      }
+
+    o match {
+      case that: List[_] => listEq(this, that)
+      case _ => super.equals(o)
+    }
+  }
 
 }
 

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -359,7 +359,7 @@ sealed abstract class List[+A]
   }
 
   override final def forall(p: A => Boolean): Boolean = {
-    var these: List[A] = coll
+    var these: List[A] = this
     while (!these.isEmpty) {
       if (!p(these.head)) return false
       these = these.tail
@@ -368,7 +368,7 @@ sealed abstract class List[+A]
   }
 
   override final def exists(p: A => Boolean): Boolean = {
-    var these: List[A] = coll
+    var these: List[A] = this
     while (!these.isEmpty) {
       if (p(these.head)) return true
       these = these.tail
@@ -377,7 +377,7 @@ sealed abstract class List[+A]
   }
 
   override final def contains[A1 >: A](elem: A1): Boolean = {
-    var these: List[A] = coll
+    var these: List[A] = this
     while (!these.isEmpty) {
       if (these.head == elem) return true
       these = these.tail

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -93,7 +93,7 @@ class ListBuffer[A]
 
   def addOne(elem: A): this.type = {
     ensureUnaliased()
-    val last1 = (elem :: Nil).asInstanceOf[::[A]]
+    val last1 = new ::[A](elem, Nil)
     if (len == 0) first = last1 else last0.next = last1
     last0 = last1
     len += 1


### PR DESCRIPTION
I spotted some inefficiencies while profiling a compiler build
with the new collections.

The benchmark score regressed by 15%. With these changes, results are
about at parity again.