### PR TITLE
Bump JarJar version to avoid invalid bytecode on Java9

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ scalacOptions ++= Seq("-unchecked", "-feature", /*"-deprecation",*/
 
 libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.3.2"
 
-libraryDependencies += "org.pantsbuild" % "jarjar" % "1.6.3"
+libraryDependencies += "org.pantsbuild" % "jarjar" % "1.6.5"
 
 libraryDependencies += "biz.aQute.bnd" % "biz.aQute.bnd" % "2.4.1"
 


### PR DESCRIPTION
As previously done in Play: https://github.com/playframework/play-ws/pull/174