### PR TITLE
Update to JLine 2.14.6 for better Emacs integration

### DIFF
--- a/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-unix.tmpl
@@ -78,7 +78,6 @@ SEP=":"
 
 # Possible additional command line options
 WINDOWS_OPT=""
-EMACS_OPT="-Denv.emacs=$EMACS"
 
 # Remove spaces from SCALA_HOME on windows
 if [[ -n "$cygwin" ]]; then
@@ -216,7 +215,6 @@ execCommand \
   "${classpath_args[@@]}" \
   -Dscala.home="$SCALA_HOME" \
   $OVERRIDE_USEJAVACP \
-  "$EMACS_OPT" \
   $WINDOWS_OPT \
   @properties@ @class@ @toolflags@ "$@@"
 

--- a/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
+++ b/src/compiler/scala/tools/ant/templates/tool-windows.tmpl
@@ -134,7 +134,7 @@ if "%_TOOL_CLASSPATH%"=="" (
 
 if not "%_LINE_TOOLCP%"=="" call :add_cpath "%_LINE_TOOLCP%"
 
-set _PROPS=-Dscala.home="!_SCALA_HOME!" -Denv.emacs="%EMACS%" %_OVERRIDE_USEJAVACP% @properties@
+set _PROPS=-Dscala.home="!_SCALA_HOME!" %_OVERRIDE_USEJAVACP% @properties@
 
 rem echo "%_JAVACMD%" %_JAVA_OPTS% %_PROPS% -cp "%_TOOL_CLASSPATH%" @class@ @toolflags@ %*
 "%_JAVACMD%" %_JAVA_OPTS% %_PROPS% -cp "%_TOOL_CLASSPATH%" @class@ @toolflags@ %*

--- a/src/compiler/scala/tools/nsc/Properties.scala
+++ b/src/compiler/scala/tools/nsc/Properties.scala
@@ -28,9 +28,6 @@ object Properties extends scala.util.PropertiesTrait {
   // a newline so as not to break the user's terminal)
   def shellInterruptedString = scalaPropOrElse("shell.interrupted", f":quit$lineSeparator")
 
-  // derived values
-  def isEmacsShell         = propOrEmpty("env.emacs") != ""
-
   // Where we keep fsc's state (ports/redirection)
   lazy val scalacDir = (Path(Properties.userHome) / ".scalac").createDirectory(force = false)
 }

--- a/src/compiler/scala/tools/nsc/Properties.scala
+++ b/src/compiler/scala/tools/nsc/Properties.scala
@@ -28,6 +28,10 @@ object Properties extends scala.util.PropertiesTrait {
   // a newline so as not to break the user's terminal)
   def shellInterruptedString = scalaPropOrElse("shell.interrupted", f":quit$lineSeparator")
 
+  // derived values
+  @deprecated("Emacs support is fully handled by JLine, this will be removed in next release", "2.12.6")
+  def isEmacsShell         = propOrEmpty("env.emacs") != ""
+
   // Where we keep fsc's state (ports/redirection)
   lazy val scalacDir = (Path(Properties.userHome) / ".scalac").createDirectory(force = false)
 }

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -909,7 +909,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter) extend
    *  supplied as a `() => Completion`; the Completion object provides a concrete Completer.
    */
   def chooseReader(settings: Settings): InteractiveReader = {
-    if (settings.Xnojline || Properties.isEmacsShell) SimpleReader()
+    if (settings.Xnojline) SimpleReader()
     else {
       type Completer = () => Completion
       type ReaderMaker = Completer => InteractiveReader

--- a/versions.properties
+++ b/versions.properties
@@ -24,4 +24,4 @@ scala-parser-combinators.version.number=1.0.7
 scala-swing.version.number=2.0.0
 partest.version.number=1.1.7
 scala-asm.version=6.0.0-scala-1
-jline.version=2.14.5
+jline.version=2.14.6


### PR DESCRIPTION
This version of Jline fixes three things for Emacs, which means all
the special handling of emacs can be removed from scala-code.

The things fixed in Jline 2.14.6 are:
- ANSI colors are now enabled for Emacs.
- Terminal echo is now disabled for Emacs.
- History is enabled for all dump terminals.

This PR should be cherry-picked or merged also to the 2.11 and 2.13 branches.