### PR TITLE
Support cancellation of batch compilation

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1525,7 +1525,10 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
         profiler.afterPhase(Global.InitPhase, snap)
         compileSources(sources)
       }
-      catch { case ex: IOException => globalError(ex.getMessage()) }
+      catch {
+        case ex: InterruptedException => reporter.cancelled = true
+        case ex: IOException => globalError(ex.getMessage())
+      }
     }
 
     /** Compile list of files given by their names */

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -423,7 +423,10 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       }
     }
 
-    final def applyPhase(unit: CompilationUnit) = withCurrentUnit(unit)(apply(unit))
+    final def applyPhase(unit: CompilationUnit) = {
+      if (Thread.interrupted()) throw new InterruptedException
+      withCurrentUnit(unit)(apply(unit))
+    }
   }
 
   // phaseName = "parser"

--- a/src/compiler/scala/tools/nsc/backend/jvm/CodeGen.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CodeGen.scala
@@ -43,6 +43,7 @@ abstract class CodeGen[G <: Global](val global: G) extends PerRunInit {
         generatedClasses += GeneratedClass(beanClassNode, fullSymbolName, position, isArtifact = true)
       }
     } catch {
+      case ex: InterruptedException => throw ex
       case ex: Throwable =>
         ex.printStackTrace()
         error(s"Error while emitting ${unit.source}\n${ex.getMessage}")

--- a/src/compiler/scala/tools/nsc/backend/jvm/CodeGen.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CodeGen.scala
@@ -45,7 +45,7 @@ abstract class CodeGen[G <: Global](val global: G) extends PerRunInit {
     } catch {
       case ex: InterruptedException => throw ex
       case ex: Throwable =>
-        ex.printStackTrace()
+        if (settings.debug) ex.printStackTrace()
         error(s"Error while emitting ${unit.source}\n${ex.getMessage}")
     }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
@@ -1,6 +1,7 @@
 package scala.tools.nsc
 package backend.jvm
 
+import java.nio.channels.ClosedByInterruptException
 import java.nio.file.Path
 import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy
 import java.util.concurrent._
@@ -153,6 +154,8 @@ private[jvm] object GeneratedClassHandler {
           // We know the future is complete, throw the exception if it completed with a failure
           unitInPostProcess.task.value.get.get
         } catch {
+          case _: ClosedByInterruptException => throw new InterruptedException()
+          case ex: InterruptedException => throw ex
           case NonFatal(t) =>
             t.printStackTrace()
             frontendAccess.backendReporting.error(NoPosition, s"unable to write ${unitInPostProcess.paths.sourceFile} $t")

--- a/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
@@ -155,7 +155,6 @@ private[jvm] object GeneratedClassHandler {
           unitInPostProcess.task.value.get.get
         } catch {
           case _: ClosedByInterruptException => throw new InterruptedException()
-          case ex: InterruptedException => throw ex
           case NonFatal(t) =>
             t.printStackTrace()
             frontendAccess.backendReporting.error(NoPosition, s"unable to write ${unitInPostProcess.paths.sourceFile} $t")

--- a/src/compiler/scala/tools/nsc/backend/jvm/PostProcessor.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/PostProcessor.scala
@@ -1,6 +1,7 @@
 package scala.tools.nsc
 package backend.jvm
 
+import java.nio.channels.ClosedByInterruptException
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.reflect.internal.util.{NoPosition, Position, StringContextStripMarginOps}
@@ -63,6 +64,7 @@ abstract class PostProcessor extends PerRunInit {
         backendReporting.error(NoPosition,
           s"Could not write class ${internalName} because it exceeds JVM code size limits. ${e.getMessage}")
         null
+      case ex: ClosedByInterruptException => throw new InterruptedException
       case ex: Throwable =>
         ex.printStackTrace()
         backendReporting.error(NoPosition, s"Error while emitting ${internalName}\n${ex.getMessage}")

--- a/src/compiler/scala/tools/nsc/backend/jvm/PostProcessor.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/PostProcessor.scala
@@ -2,6 +2,7 @@ package scala.tools.nsc
 package backend.jvm
 
 import java.nio.channels.ClosedByInterruptException
+import java.nio.channels.ClosedByInterruptException
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.reflect.internal.util.{NoPosition, Position, StringContextStripMarginOps}
@@ -64,8 +65,10 @@ abstract class PostProcessor extends PerRunInit {
         backendReporting.error(NoPosition,
           s"Could not write class ${internalName} because it exceeds JVM code size limits. ${e.getMessage}")
         null
-      case ex: ClosedByInterruptException => throw new InterruptedException
+      case ex: InterruptedException => throw ex
       case ex: Throwable =>
+        // TODO hide this stack trace behind -Ydebug?
+        // TODO fail fast rather than continuing to write the rest of the class files?
         ex.printStackTrace()
         backendReporting.error(NoPosition, s"Error while emitting ${internalName}\n${ex.getMessage}")
         null

--- a/src/compiler/scala/tools/nsc/backend/jvm/PostProcessor.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/PostProcessor.scala
@@ -67,9 +67,8 @@ abstract class PostProcessor extends PerRunInit {
         null
       case ex: InterruptedException => throw ex
       case ex: Throwable =>
-        // TODO hide this stack trace behind -Ydebug?
         // TODO fail fast rather than continuing to write the rest of the class files?
-        ex.printStackTrace()
+        if (frontendAccess.compilerSettings.debug) ex.printStackTrace()
         backendReporting.error(NoPosition, s"Error while emitting ${internalName}\n${ex.getMessage}")
         null
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -843,6 +843,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
             if (openMacros.nonEmpty) popMacroContext() // weirdly we started popping on an empty stack when refactoring fatalWarnings logic
             val realex = ReflectionUtils.unwrapThrowable(ex)
             realex match {
+              case ex: InterruptedException => throw ex
               case ex: AbortMacroException => MacroGeneratedAbort(expandee, ex)
               case ex: ControlThrowable => throw ex
               case ex: TypeError => MacroGeneratedTypeError(expandee, ex)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5615,7 +5615,6 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       val statsEnabled = StatisticsStatics.areSomeHotStatsEnabled() && statistics.areHotStatsLocallyEnabled
       val startByType = if (statsEnabled) statistics.pushTimer(byTypeStack, byTypeNanos(tree.getClass)) else null
       if (statsEnabled) statistics.incCounter(visitsByType, tree.getClass)
-      if (Thread.interrupted()) throw new InterruptedException
       try body
       finally if (statsEnabled) statistics.popTimer(byTypeStack, startByType)
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5615,6 +5615,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       val statsEnabled = StatisticsStatics.areSomeHotStatsEnabled() && statistics.areHotStatsLocallyEnabled
       val startByType = if (statsEnabled) statistics.pushTimer(byTypeStack, byTypeNanos(tree.getClass)) else null
       if (statsEnabled) statistics.incCounter(visitsByType, tree.getClass)
+      if (Thread.interrupted()) throw new InterruptedException
       try body
       finally if (statsEnabled) statistics.popTimer(byTypeStack, startByType)
     }


### PR DESCRIPTION
A common means of cancelling a task is to shutdown the thread pool
executing it. That's what SBT's CTRL-C handler does, for example.
Typically, thread pools call `Thread.interrupt()` to cooperatively stop the
workload. We need to do our part by checking `interrupted()` from time to
time, and translating this into an exception that will stop compilation.

Side note: SBT's CTRL-C handler is not on by default, you need to add
the following to `build.sbt`.

```scala
cancelable in Global := true
```

We actually were doing this in some places, by accident, by virtue
of calling NIO file reading/writing APIs, which throw a specific exception
if the thread is interrupted. The first commits here harden the places
where we were preventing these exceptions from bubbling up and stopping the
compiler. Before this change, an interrupt during the parser or bcode phase
ended up issuing an stack trace and/or an error for each source/class file.

The final commit adds additional checks for the interrupt status. Perhaps the
check within `Typer.typed` is contentious, it aims to make cancellation
responsive even in large source files. We'll see if there is a performance
difference here, and perhaps move it to `typedDefDef` where it will fire
with an appropriate frequency.

Tested by using these commits as STARR for our SBT build and hitting
CTRL-C at different moments during `library/compile`.

## baseline behaviour

### Cancel during parser:
```
[error] IO error while decoding /Users/jz/code/scala/src/library/scala/Tuple5.scala with UTF-8
[error] Please try specifying another one using the -encoding option
[error] IO error while decoding /Users/jz/code/scala/src/library/scala/Tuple6.scala with UTF-8
[error] Please try specifying another one using the -encoding option
[error] IO error while decoding /Users/jz/code/scala/src/library/scala/Tuple7.scala with UTF-8
[error] Please try specifying another one using the -encoding option
[error] 704 errors found
```

### Cancel after parser

```
> library/compile
[info] Compiling 584 Scala sources and 120 Java sources to /Users/jz/code/scala/build/quick/classes/library...
^C
[warn] Canceling execution...

<BIG PAUSE/>

java.nio.channels.ClosedByInterruptException
    at java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:202)
    at sun.nio.ch.FileChannelImpl.writeInternal(FileChannelImpl.java:783)
    at sun.nio.ch.FileChannelImpl.write(FileChannelImpl.java:764)
    at scala.tools.nsc.backend.jvm.ClassfileWriters$ClassfileWriter$DirClassWriter.write(ClassfileWriters.scala:179)
    at scala.tools.nsc.backend.jvm.PostProcessor.sendToDisk(PostProcessor.scala:76)
...
java.nio.channels.ClosedByInterruptException
    at java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:202)
    at sun.nio.ch.FileChannelImpl.writeInternal(FileChannelImpl.java:783)
    at sun.nio.ch.FileChannelImpl.write(FileChannelImpl.java:764)
    at scala.tools.nsc.backend.jvm.ClassfileWriters$ClassfileWriter$DirClassWriter.write(ClassfileWriters.scala:179)
    at scala.tools.nsc.backend.jvm.PostProcessor.sendToDisk(PostProcessor.scala:76)
...
java.nio.channels.ClosedByInterruptException
    at java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:202)
    at sun.nio.ch.FileChannelImpl.writeInternal(FileChannelImpl.java:783)
    at sun.nio.ch.FileChannelImpl.write(FileChannelImpl.java:764)
    at scala.tools.nsc.backend.jvm.ClassfileWriters$ClassfileWriter$DirClassWriter.write(ClassfileWriters.scala:179)
    at scala.tools.nsc.backend.jvm.PostProcessor.sendToDisk(PostProcessor.scala:76)
...

[error] 584 errors found

```

## New behaviour

### Cancel any time

```
[info] Compiling 584 Scala sources and 120 Java sources to /Users/jz/code/scala/build/quick/classes/library...
^C
[warn] Canceling execution...
java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ExecutorCompletionService$QueueingFuture@35798cd0 rejected from java.util.concurrent.ThreadPoolExecutor@2fc70622[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 194]
	at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2063)
```