### PR TITLE
Fix t3346e

### DIFF
--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -25,6 +25,8 @@ sealed abstract class BitSet
 
   def bitSetFactory = BitSet
 
+  override def className: String = "BitSet"
+
   protected[collection] def fromBitMaskNoCopy(elems: Array[Long]): BitSet = BitSet.fromBitMaskNoCopy(elems)
 
   def incl(elem: Int): BitSet = {

--- a/test/files/run/t3346e.scala
+++ b/test/files/run/t3346e.scala
@@ -1,20 +1,19 @@
 import scala.language.implicitConversions
-import scala.collection.generic.CanBuildFrom
 import scala.math.Ordering
-import collection.{TraversableLike, SeqLike}
+import collection.{AnyConstr, BuildFrom, Iterable, IterableOps, SeqOps}
 import collection.immutable.BitSet
 
 class QuickSort[Coll](a: Coll) {
   //should be able to sort only something with defined order (someting like a Seq)
-  def quickSort[T](implicit ev0: Coll => SeqLike[T, Coll],
-                   cbf: CanBuildFrom[Coll, T, Coll],
+  def quickSort[T](implicit ev0: Coll => SeqOps[T, AnyConstr, Iterable[T]],
+                   bf: BuildFrom[Coll, T, Coll],
                    n: Ordering[T]): Coll = {
-    quickSortAnything(ev0, cbf, n)
+    quickSortAnything(ev0, bf, n)
   }
 
   //we can even sort a Set, if we really want to
-  def quickSortAnything[T](implicit ev0: Coll => TraversableLike[T, Coll],
-                           cbf: CanBuildFrom[Coll, T, Coll],
+  def quickSortAnything[T](implicit ev0: Coll => IterableOps[T, AnyConstr, Iterable[T]],
+                           bf: BuildFrom[Coll, T, Coll],
                            n: Ordering[T]): Coll = {
     import n._
     if (a.size < 2) {
@@ -24,7 +23,7 @@ class QuickSort[Coll](a: Coll) {
       val pivot = a.head
       val (lower, tmp) = a.partition(_ < pivot)
       val (upper, same) = tmp.partition(_ > pivot)
-      val b = cbf()
+      val b = bf.newBuilder(a)
       b.sizeHint(a.size)
       b ++= new QuickSort(lower).quickSortAnything
       b ++= same
@@ -35,22 +34,22 @@ class QuickSort[Coll](a: Coll) {
 }
 
 class FilterMap[Repr](a: Repr) {
-  def filterMap[A, B, That](f: A => Option[B])(implicit ev0: Repr => TraversableLike[A, Repr],
-                                               cbf: CanBuildFrom[Repr, B, That]): That = {
-    a.flatMap(e => f(e).toSeq)
+  def filterMap[A, B, That](f: A => Option[B])(implicit ev0: Repr => IterableOps[A, Iterable, _],
+                                               bf: BuildFrom[Repr, B, That]): That = {
+    bf.fromSpecificIterable(a)(a.flatMap(e => f(e).toSeq))
   }
 }
 
-class FilterMapFixed[A, Repr <% TraversableLike[A, Repr]](a: Repr) {
-  def filterMap2[B, That](f: A => Option[B])(implicit cbf: CanBuildFrom[Repr, B, That]): That = {
-    a.flatMap(e => f(e).toSeq)
+class FilterMapFixed[A, Repr <% IterableOps[A, Iterable, _]](a: Repr) {
+  def filterMap2[B, That](f: A => Option[B])(implicit bf: BuildFrom[Repr, B, That]): That = {
+    bf.fromSpecificIterable(a)(a.flatMap(e => f(e).toSeq))
   }
 }
 
 object MyEnhancements {
   implicit def toQS[Coll](a: Coll) = new QuickSort(a)
   implicit def toFM[Coll](a: Coll) = new FilterMap(a)
-  implicit def toFM2[A, Repr <% TraversableLike[A, Repr]](a: Repr) = new FilterMapFixed(a)
+  implicit def toFM2[A, Repr <% IterableOps[A, Iterable, _]](a: Repr) = new FilterMapFixed(a)
 }
 
 object Test extends App {


### PR DESCRIPTION
- A fallback BuildFrom instance from String to IndexedSeq was missing
- Priorities were not right between BuildFrom instances for BitSet
  and SortedSet
- immutable.BitSet.toString was leaking an internal class name