### PR TITLE
Additional analysis of simple catch cases

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -238,8 +238,12 @@ trait MatchTranslation {
     // unlike translateMatch, we type our result before returning it
     def translateTry(caseDefs: List[CaseDef], pt: Type, pos: Position): List[CaseDef] =
       // if they're already simple enough to be handled by the back-end, we're done
-      if (caseDefs forall treeInfo.isCatchCase) caseDefs
-      else {
+      if (caseDefs forall treeInfo.isCatchCase) {
+        // well, we do need to look for unreachable cases
+        if (!settings.XnoPatmatAnalysis) unreachableTypeSwitchCase(caseDefs).foreach(cd => reportUnreachable(cd.body.pos))
+
+        caseDefs
+      } else {
         val swatches = { // switch-catches
           // scala/bug#7459 must duplicate here as we haven't committed to switch emission, and just figuring out
           //         if we can ends up mutating `caseDefs` down in the use of `substituteSymbols` in

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -41,6 +41,10 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
     def emitTypeSwitch(bindersAndCases: List[(Symbol, List[TreeMaker])], pt: Type): Option[List[CaseDef]] =
       None
 
+    // Exposed separately from emitTypeSwitch, so that we can do the analysis for simple cases where we skip emitTypeSwitch
+    def unreachableTypeSwitchCase(cases: List[CaseDef]): Option[CaseDef] =
+      None
+
     abstract class TreeMaker {
       def pos: Position
 

--- a/test/files/neg/t10806.check
+++ b/test/files/neg/t10806.check
@@ -1,0 +1,12 @@
+t10806.scala:12: warning: unreachable code
+      case e: IllegalArgumentException ⇒ println(e.getMessage)
+                                                ^
+t10806.scala:18: warning: unreachable code
+      case e: IllegalArgumentException ⇒ println(e.getMessage)
+                                                ^
+t10806.scala:23: warning: unreachable code
+      case e: IllegalArgumentException ⇒ println(e.getMessage)
+                                                ^
+error: No warnings can be incurred under -Xfatal-warnings.
+three warnings found
+one error found

--- a/test/files/neg/t10806.flags
+++ b/test/files/neg/t10806.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t10806.scala
+++ b/test/files/neg/t10806.scala
@@ -1,0 +1,26 @@
+/* scalac: -Xfatal-warnings
+ */
+
+trait T {
+
+  object Nope extends Throwable
+
+  def f(): Unit = {
+    // anything but simple type tests forced analysis
+    try { 1 } catch {
+      case _: Exception ⇒ println("Something went wrong")
+      case e: IllegalArgumentException ⇒ println(e.getMessage)
+      case Nope ⇒ ???
+    }
+
+    try { 1 } catch {
+      case _: Exception ⇒ println("Something went wrong")
+      case e: IllegalArgumentException ⇒ println(e.getMessage)
+    }
+
+    (new IllegalArgumentException()) match {
+      case _: Exception ⇒ println("Something went very wrong")
+      case e: IllegalArgumentException ⇒ println(e.getMessage)
+    }
+  }
+}


### PR DESCRIPTION
Even for simple type tests, check for unreachable cases.

Fixes scala/bug#10806

Not sure if this is safe and sufficient, but @adriaanm would know.