### PR TITLE
Make extractor patterns null safe

### DIFF
--- a/spec/08-pattern-matching.md
+++ b/spec/08-pattern-matching.md
@@ -192,6 +192,9 @@ a case class, the stable identifier $x$ denotes an object which has a
 member method named `unapply` or `unapplySeq` that matches
 the pattern.
 
+An extractor pattern cannot match the value `null`. The implementation
+ensures that the `unapply`/`unapplySeq` method is not applied to `null`.
+
 An `unapply` method in an object $x$ _matches_ the pattern
 $x(p_1 , \ldots , p_n)$ if it takes exactly one argument and one of
 the following applies:

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -344,6 +344,7 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
             case AlternativesTreeMaker(_, altss, _)                   => \/(altss map (alts => /\(alts map this)))
             case ProductExtractorTreeMaker(testedBinder, None)        => uniqueNonNullProp(binderToUniqueTree(testedBinder))
             case SubstOnlyTreeMaker(_, _)                             => True
+            case NonNullTestTreeMaker(prevBinder, _, _)               => uniqueNonNullProp(binderToUniqueTree(prevBinder))
             case GuardTreeMaker(guard) =>
               guard.tpe match {
                 case ConstantTrue  => True

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -498,11 +498,7 @@ object Array {
    *  @return  sequence wrapped in a [[scala.Some]], if `x` is an Array, otherwise `None`
    */
   def unapplySeq[T](x: Array[T]): Option[IndexedSeq[T]] =
-    if (x == null) None else Some(ArraySeq.unsafeWrapArray[T](x))
-    // !!! the null check should to be necessary, but without it 2241 fails. Seems to be a bug
-    // in pattern matcher.  @PP: I noted in #4364 I think the behavior is correct.
-    // Is ArraySeq safe here? In 2.12 we used to call .toIndexedSeq which copied the array
-    // instead of wrapping it in a ArraySeq but it appears unnecessary.
+    Some(ArraySeq.unsafeWrapArray[T](x))
 }
 
 /** Arrays are mutable, indexed collections of values. `Array[T]` is Scala's representation

--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -279,10 +279,8 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *  @param  s     The string to match
    *  @return       The matches
    */
-  def unapplySeq(s: CharSequence): Option[List[String]] = s match {
-    case null => None
-    case _    =>
-      val m = pattern matcher s
+  def unapplySeq(s: CharSequence): Option[List[String]] = {
+    val m = pattern matcher s
       if (runMatcher(m)) Some(List.tabulate(m.groupCount) { i => m.group(i + 1) })
       else None
   }
@@ -336,7 +334,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *  and the result of that match is used.
    */
   def unapplySeq(m: Match): Option[List[String]] =
-    if (m == null || m.matched == null) None
+    if (m.matched == null) None
     else if (m.matcher.pattern == this.pattern) Regex.extractGroupsFromMatch(m)
     else unapplySeq(m.matched)
 

--- a/test/files/run/name-based-patmat.check
+++ b/test/files/run/name-based-patmat.check
@@ -1,3 +1,6 @@
+name-based-patmat.scala:73: warning: unreachable code
+      case Foo(5, 10)             => 4 // should warn unreachable
+                                     ^
 `catdog only` has 11 chars
 `catdog only, no product` has 23 chars
 catdog

--- a/test/files/run/patmatnew.check
+++ b/test/files/run/patmatnew.check
@@ -1,21 +1,21 @@
-patmatnew.scala:351: warning: a pure expression does nothing in statement position
+patmatnew.scala:352: warning: a pure expression does nothing in statement position
         case 1 => "OK"
                   ^
-patmatnew.scala:352: warning: a pure expression does nothing in statement position
-        case 2 => assert(false); "KO"
-                                 ^
-patmatnew.scala:352: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
-        case 2 => assert(false); "KO"
-                                 ^
 patmatnew.scala:353: warning: a pure expression does nothing in statement position
-        case 3 => assert(false); "KO"
+        case 2 => assert(false); "KO"
                                  ^
 patmatnew.scala:353: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
+        case 2 => assert(false); "KO"
+                                 ^
+patmatnew.scala:354: warning: a pure expression does nothing in statement position
         case 3 => assert(false); "KO"
                                  ^
-patmatnew.scala:670: warning: This catches all Throwables. If this is really intended, use `case e : Throwable` to clear this warning.
+patmatnew.scala:354: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
+        case 3 => assert(false); "KO"
+                                 ^
+patmatnew.scala:671: warning: This catches all Throwables. If this is really intended, use `case e : Throwable` to clear this warning.
             case e => {
                  ^
-patmatnew.scala:489: warning: unreachable code
+patmatnew.scala:490: warning: unreachable code
         case _ if false =>
                         ^

--- a/test/files/run/patmatnew.flags
+++ b/test/files/run/patmatnew.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/files/run/t6288.check
+++ b/test/files/run/t6288.check
@@ -8,12 +8,17 @@
     [21]def unapply([29]z: [32]<type: [32]scala.Any>): [21]Option[Int] = [56][52][52]scala.Some.apply[[52]Int]([57]-1);
     [64]{
       [64]case <synthetic> val x1: [64]String = [64]"";
-      [64]case5()[84]{
-        [84]<synthetic> val o7: [84]Option[Int] = [84][84]Case3.unapply([84]x1);
-        [84]if ([84]o7.isEmpty.unary_!)
-          [97][97]matchEnd4([97]())
+      [64]case5(){
+        [89]if ([89][89]x1.ne([89]null))
+          [84]{
+            [84]<synthetic> val o7: [84]Option[Int] = [84][84]Case3.unapply([84]x1);
+            [84]if ([84]o7.isEmpty.unary_!)
+              [97][97]matchEnd4([97]())
+            else
+              [84][84]case6()
+          }
         else
-          [84][84]case6()
+          [89][89]case6()
       };
       [64]case6(){
         [64][64]matchEnd4([64]throw [64][64][64]new [64]MatchError([64]x1))
@@ -31,12 +36,17 @@
     [127]def unapplySeq([138]z: [141]<type: [141]scala.Any>): [127]Option[List[Int]] = [167]scala.None;
     [175]{
       [175]case <synthetic> val x1: [175]String = [175]"";
-      [175]case5()[195]{
-        [195]<synthetic> val o7: [195]Option[List[Int]] = [195][195]Case4.unapplySeq([195]x1);
-        [195]if ([195][195]o7.isEmpty.unary_!.&&([195][195][195][195]o7.get.!=([195]null).&&([195][195][195][195]o7.get.lengthCompare([195]1).==([195]0))))
-          [208][208]matchEnd4([208]())
+      [175]case5(){
+        [200]if ([200][200]x1.ne([200]null))
+          [195]{
+            [195]<synthetic> val o7: [195]Option[List[Int]] = [195][195]Case4.unapplySeq([195]x1);
+            [195]if ([195][195]o7.isEmpty.unary_!.&&([195][195][195][195]o7.get.!=([195]null).&&([195][195][195][195]o7.get.lengthCompare([195]1).==([195]0))))
+              [208][208]matchEnd4([208]())
+            else
+              [195][195]case6()
+          }
         else
-          [195][195]case6()
+          [200][200]case6()
       };
       [175]case6(){
         [175][175]matchEnd4([175]throw [175][175][175]new [175]MatchError([175]x1))
@@ -46,26 +56,54 @@
       }
     }
   };
-  [224]object Case5 extends [230][312]scala.AnyRef {
-    [312]def <init>(): [230]Case5.type = [312]{
-      [312][312][312]Case5.super.<init>();
+  [224]object Case5 extends [230][313]scala.AnyRef {
+    [313]def <init>(): [230]Case5.type = [313]{
+      [313][313][313]Case5.super.<init>();
       [230]()
     };
     [238]def unapply([246]z: [249]<type: [249]scala.Any>): [238]Boolean = [265]true;
     [273]{
       [273]case <synthetic> val x1: [273]String = [273]"";
-      [273]case5()[293]{
-        [293]<synthetic> val o7: [293]Option[List[Int]] = [293][293]Case4.unapplySeq([293]x1);
-        [293]if ([293][293]o7.isEmpty.unary_!.&&([293][293][293][293]o7.get.!=([293]null).&&([293][293][293][293]o7.get.lengthCompare([293]0).==([293]0))))
-          [304][304]matchEnd4([304]())
+      [273]case5(){
+        [298]if ([298][298]x1.ne([298]null))
+          [293]{
+            [293]<synthetic> val o7: [293]Option[List[Int]] = [293][293]Case4.unapplySeq([293]x1);
+            [293]if ([293][293]o7.isEmpty.unary_!.&&([293][293][293][293]o7.get.!=([293]null).&&([293][293][293][293]o7.get.lengthCompare([293]0).==([293]0))))
+              [304][304]matchEnd4([304]())
+            else
+              [293][293]case6()
+          }
         else
-          [293][293]case6()
+          [298][298]case6()
       };
       [273]case6(){
         [273][273]matchEnd4([273]throw [273][273][273]new [273]MatchError([273]x1))
       };
       [273]matchEnd4(x: [NoPosition]Unit){
         [273]x
+      }
+    }
+  };
+  [320]object Case6 extends [326][417]scala.AnyRef {
+    [417]def <init>(): [326]Case6.type = [417]{
+      [417][417][417]Case6.super.<init>();
+      [326]()
+    };
+    [334]def unapply([342]z: [345]<type: [345]scala.Int>): [334]Option[Int] = [369][365][365]scala.Some.apply[[365]Int]([370]-1);
+    [377]{
+      [377]case <synthetic> val x1: [377]Int = [377]0;
+      [377]case5()[396]{
+        [396]<synthetic> val o7: [396]Option[Int] = [396][396]Case6.unapply([396]x1);
+        [396]if ([396]o7.isEmpty.unary_!)
+          [409][409]matchEnd4([409]())
+        else
+          [396][396]case6()
+      };
+      [377]case6(){
+        [377][377]matchEnd4([377]throw [377][377][377]new [377]MatchError([377]x1))
+      };
+      [377]matchEnd4(x: [NoPosition]Unit){
+        [377]x
       }
     }
   }

--- a/test/files/run/t6288.scala
+++ b/test/files/run/t6288.scala
@@ -28,7 +28,13 @@ object Test extends DirectTest {
       |    case Case4() => ()
       |  }
       |}
+      |object Case6 {
+      |  def unapply(z: Int): Option[Int] = Some(-1)
       |
+      |  0 match {
+      |    case Case6(nr) => ()
+      |  }
+      |}
       |""".stripMargin.trim
 
   override def show(): Unit = {

--- a/test/files/run/t7039.check
+++ b/test/files/run/t7039.check
@@ -1,1 +1,1 @@
-Matched!
+null matched

--- a/test/files/run/t7039.scala
+++ b/test/files/run/t7039.scala
@@ -7,5 +7,6 @@ object Test extends App {
     case UnapplySeqTest(5) => println("uh-oh")
     case UnapplySeqTest(5, 1) => println("Matched!") // compiles
     case UnapplySeqTest(5, xs @ _*) => println("toooo long: "+ (xs: Seq[Int]))
+    case _ => println("null matched")
   }
 }

--- a/test/files/run/t9349/test.scala
+++ b/test/files/run/t9349/test.scala
@@ -16,6 +16,7 @@ object Test {
     null match {
       case Extractor(o2) =>
         val i = new o2.Inner
+      case _ =>
     }
   }
 }

--- a/test/junit/scala/util/matching/RegexTest.scala
+++ b/test/junit/scala/util/matching/RegexTest.scala
@@ -26,23 +26,6 @@ class RegexTest {
     assertEquals("1", y)
   }
 
-  @Test def t8787nullMatch() = {
-    val r = """\d+""".r
-    val s: String = null
-    val x = s match { case r() => 1 ; case _ => 2 }
-    assertEquals(2, x)
-  }
-
-  @Test def t8787nullMatcher() = {
-    val r = """(\d+):(\d+)""".r
-    val s = "1:2 3:4 5:6"
-    val z = ((r findAllMatchIn s).toList :+ null) flatMap {
-      case r(x, y) => Some((x.toInt, y.toInt))
-      case _       => None
-    }
-    assertEquals(List((1,2),(3,4),(5,6)), z)
-  }
-
   @Test def `t9666: use inline group names`(): Unit = {
     val r = new Regex("a(?<Bee>b*)c")
     val ms = r findAllIn "stuff abbbc more abc and so on"


### PR DESCRIPTION
Ref scala/bug#4364
This is a general fix for https://github.com/scala/bug/issues/2241 and https://github.com/scala/bug/issues/8787.

scala/bug#4364 raises the question of what should the pattern matcher do when encountering a `null` and an extractor pattern. As it stands, SLS does not say anything about `null` for extractor pattern, which leads:
- Pattern matcher will happily pass `null` into your extractor.
- I can write a `null`-matching extractor MyNull.
- Thus, all extractor authors must check for `null` if they would like to access the passed in argument `x`.

There are potentially two things we can do.
1. Be ok with the status quo. Clarify in SLS that all extractor authors must handle `null`.
2. Not be ok with the status quo. Change SLS and implementation such that `null` is treated as no match (empty).

I've already sent option 1 as https://github.com/scala/scala/pull/6374.
This implements option 2.