### PR TITLE
SI-8939 warn about non-sensible equals in anonymous functions

### DIFF
--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -108,7 +108,7 @@ object ScalaOptionParser {
     "-g" -> List("line", "none", "notailcails", "source", "vars"),
     "-target" -> List("jvm-1.5", "jvm-1.6", "jvm-1.7", "jvm-1.8"))
   private def multiChoiceSettingNames = Map[String, List[String]](
-    "-Xlint" -> List("adapted-args", "nullary-unit", "inaccessible", "nullary-override", "infer-any", "missing-interpolator", "doc-detached", "private-shadow", "type-parameter-shadow", "poly-implicit-overload", "option-implicit", "delayedinit-select", "by-name-right-associative", "package-object-classes", "unsound-match", "stars-align"),
+    "-Xlint" -> List("adapted-args", "nullary-unit", "inaccessible", "nullary-override", "infer-any", "missing-interpolator", "doc-detached", "private-shadow", "type-parameter-shadow", "poly-implicit-overload", "option-implicit", "delayedinit-select", "by-name-right-associative", "package-object-classes", "mismatched-types-equals", "unsound-match", "stars-align"),
     "-language" -> List("help", "_", "dynamics", "postfixOps", "reflectiveCalls", "implicitConversions", "higherKinds", "existentials", "experimental.macros"),
     "-opt" -> List("l:none", "l:default", "l:method", "l:project", "l:classpath", "unreachable-code", "simplify-jumps", "empty-line-numbers", "empty-labels", "compact-locals", "nullness-tracking", "closure-elimination", "inline-project", "inline-global"),
     "-Ystatistics" -> List("parser", "typer", "patmat", "erasure", "cleanup", "jvm")

--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -91,7 +91,7 @@ object ScalaOptionParser {
     "-Yoverride-objects", "-Yoverride-vars", "-Ypatmat-debug", "-Yno-adapted-args", "-Ypartial-unification", "-Ypos-debug", "-Ypresentation-debug",
     "-Ypresentation-strict", "-Ypresentation-verbose", "-Yquasiquote-debug", "-Yrangepos", "-Yreify-copypaste", "-Yreify-debug", "-Yrepl-class-based",
     "-Yrepl-sync", "-Yshow-member-pos", "-Yshow-symkinds", "-Yshow-symowners", "-Yshow-syms", "-Yshow-trees", "-Yshow-trees-compact", "-Yshow-trees-stringified", "-Ytyper-debug",
-    "-Ywarn-adapted-args", "-Ywarn-dead-code", "-Ywarn-inaccessible", "-Ywarn-infer-any", "-Ywarn-nullary-override", "-Ywarn-nullary-unit", "-Ywarn-numeric-widen", "-Ywarn-unused-import", "-Ywarn-value-discard",
+    "-Ywarn-adapted-args", "-Ywarn-dead-code", "-Ywarn-inaccessible", "-Ywarn-infer-any", "-Ywarn-nullary-override", "-Ywarn-nullary-unit", "-Ywarn-numeric-widen", "-Ywarn-unused-import", "-Ywarn-value-discard", "-Ywarn-strict-equals",
     "-deprecation", "-explaintypes", "-feature", "-help", "-no-specialization", "-nobootcp", "-nowarn", "-optimise", "-print", "-unchecked", "-uniqid", "-usejavacp", "-usemanifestcp", "-verbose", "-version")
   private def stringSettingNames = List("-Xgenerate-phase-graph", "-Xmain-class", "-Xpluginsdir", "-Xshow-class", "-Xshow-object", "-Xsource-reader", "-Ydump-classes", "-Ygen-asmp",
     "-Ypresentation-log", "-Ypresentation-replay", "-Yrepl-outdir", "-d", "-dependencyfile", "-encoding", "-Xscript")
@@ -108,7 +108,7 @@ object ScalaOptionParser {
     "-g" -> List("line", "none", "notailcails", "source", "vars"),
     "-target" -> List("jvm-1.5", "jvm-1.6", "jvm-1.7", "jvm-1.8"))
   private def multiChoiceSettingNames = Map[String, List[String]](
-    "-Xlint" -> List("adapted-args", "nullary-unit", "inaccessible", "nullary-override", "infer-any", "missing-interpolator", "doc-detached", "private-shadow", "type-parameter-shadow", "poly-implicit-overload", "option-implicit", "delayedinit-select", "by-name-right-associative", "package-object-classes", "mismatched-types-equals", "unsound-match", "stars-align"),
+    "-Xlint" -> List("adapted-args", "nullary-unit", "inaccessible", "nullary-override", "infer-any", "missing-interpolator", "doc-detached", "private-shadow", "type-parameter-shadow", "poly-implicit-overload", "option-implicit", "delayedinit-select", "by-name-right-associative", "package-object-classes", "unsound-match", "stars-align"),
     "-language" -> List("help", "_", "dynamics", "postfixOps", "reflectiveCalls", "implicitConversions", "higherKinds", "existentials", "experimental.macros"),
     "-opt" -> List("l:none", "l:default", "l:method", "l:project", "l:classpath", "unreachable-code", "simplify-jumps", "empty-line-numbers", "empty-labels", "compact-locals", "nullness-tracking", "closure-elimination", "inline-project", "inline-global"),
     "-Ystatistics" -> List("parser", "typer", "patmat", "erasure", "cleanup", "jvm")

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -102,6 +102,7 @@ trait Warnings {
     val UnsoundMatch           = LintWarning("unsound-match",             "Pattern match may not be typesafe.")
     val StarsAlign             = LintWarning("stars-align",               "Pattern sequence wildcard must align with sequence component.")
     val Constant               = LintWarning("constant",                  "Evaluation of a constant arithmetic expression results in an error.")
+    val MismatchedTypesEquals  = LintWarning("mismatched-types-equals",   "Comparison of mismatched types")
     val Unused                 = LintWarning("unused",                    "Enable -Ywarn-unused:imports,privates,locals,implicits.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
@@ -125,6 +126,7 @@ trait Warnings {
   def warnUnsoundMatch           = lint contains UnsoundMatch
   def warnStarsAlign             = lint contains StarsAlign
   def warnConstant               = lint contains Constant
+  def warnMismatchedTypesEquals  = lint contains MismatchedTypesEquals
   def lintUnused                 = lint contains Unused
 
   // Lint warnings that are currently -Y, but deprecated in that usage

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -29,9 +29,10 @@ trait Warnings {
       "Inspect both user-written code and expanded trees when generating unused symbol warnings."
     )
   )
-  val warnDeadCode         = BooleanSetting("-Ywarn-dead-code", "Warn when dead code is identified.")
-  val warnValueDiscard     = BooleanSetting("-Ywarn-value-discard", "Warn when non-Unit expression results are unused.")
-  val warnNumericWiden     = BooleanSetting("-Ywarn-numeric-widen", "Warn when numerics are widened.")
+  val warnDeadCode               = BooleanSetting("-Ywarn-dead-code", "Warn when dead code is identified.")
+  val warnValueDiscard           = BooleanSetting("-Ywarn-value-discard", "Warn when non-Unit expression results are unused.")
+  val warnNumericWiden           = BooleanSetting("-Ywarn-numeric-widen", "Warn when numerics are widened.")
+  val warnStrictEquals  = BooleanSetting("-Ywarn-strict-equals", "Comparison of mismatched types")
 
   object UnusedWarnings extends MultiChoiceEnumeration {
     val Imports   = Choice("imports",   "Warn if an import selector is not referenced.")
@@ -102,7 +103,6 @@ trait Warnings {
     val UnsoundMatch           = LintWarning("unsound-match",             "Pattern match may not be typesafe.")
     val StarsAlign             = LintWarning("stars-align",               "Pattern sequence wildcard must align with sequence component.")
     val Constant               = LintWarning("constant",                  "Evaluation of a constant arithmetic expression results in an error.")
-    val MismatchedTypesEquals  = LintWarning("mismatched-types-equals",   "Comparison of mismatched types")
     val Unused                 = LintWarning("unused",                    "Enable -Ywarn-unused:imports,privates,locals,implicits.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
@@ -126,7 +126,6 @@ trait Warnings {
   def warnUnsoundMatch           = lint contains UnsoundMatch
   def warnStarsAlign             = lint contains StarsAlign
   def warnConstant               = lint contains Constant
-  def warnMismatchedTypesEquals  = lint contains MismatchedTypesEquals
   def lintUnused                 = lint contains Unused
 
   // Lint warnings that are currently -Y, but deprecated in that usage

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1007,6 +1007,7 @@ abstract class RefChecks extends Transform {
       // Whether this == or != is one of those defined in Any/AnyRef or an overload from elsewhere.
       def isUsingDefaultScalaOp = sym == Object_== || sym == Object_!= || sym == Any_== || sym == Any_!=
       def haveSubclassRelationship = (actual isSubClass receiver) || (receiver isSubClass actual)
+      def isSameClass = (actual isSubClass receiver) && (receiver isSubClass actual)
 
       // Whether the operands+operator represent a warnable combo (assuming anyrefs)
       // Looking for comparisons performed with ==/!= in combination with either an
@@ -1101,6 +1102,8 @@ abstract class RefChecks extends Transform {
       // this is especially important to enable transitioning from
       // regular to value classes without silent failures.
       if (isNonsenseValueClassCompare)
+        unrelatedTypes()
+      else if (settings.warnMismatchedTypesEquals && !isSameClass)
         unrelatedTypes()
       // possibleNumericCount is insufficient or this will warn on e.g. Boolean == j.l.Boolean
       else if (isWarnable && nullCount == 0 && !(isSpecial(receiver) && isSpecial(actual))) {

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1007,7 +1007,7 @@ abstract class RefChecks extends Transform {
       // Whether this == or != is one of those defined in Any/AnyRef or an overload from elsewhere.
       def isUsingDefaultScalaOp = sym == Object_== || sym == Object_!= || sym == Any_== || sym == Any_!=
       def haveSubclassRelationship = (actual isSubClass receiver) || (receiver isSubClass actual)
-      def isSameClass = (actual isSubClass receiver) && (receiver isSubClass actual)
+      def isSameClass = qual.tpe.widen =:= other.tpe.widen
 
       // Whether the operands+operator represent a warnable combo (assuming anyrefs)
       // Looking for comparisons performed with ==/!= in combination with either an

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1007,7 +1007,10 @@ abstract class RefChecks extends Transform {
       // Whether this == or != is one of those defined in Any/AnyRef or an overload from elsewhere.
       def isUsingDefaultScalaOp = sym == Object_== || sym == Object_!= || sym == Any_== || sym == Any_!=
       def haveSubclassRelationship = (actual isSubClass receiver) || (receiver isSubClass actual)
-      def isSameClass = qual.tpe.widen =:= other.tpe.widen
+      def isSameClass = {
+        val common = global.lub(List(qual.tpe, other.tpe))
+        !(ObjectTpe <:< common) && (qual.tpe.widen <:< other.tpe.widen || other.tpe.widen <:< qual.tpe.widen)
+      }
 
       // Whether the operands+operator represent a warnable combo (assuming anyrefs)
       // Looking for comparisons performed with ==/!= in combination with either an

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1103,7 +1103,7 @@ abstract class RefChecks extends Transform {
       // regular to value classes without silent failures.
       if (isNonsenseValueClassCompare)
         unrelatedTypes()
-      else if (settings.warnMismatchedTypesEquals && !isSameClass)
+      else if (settings.warnStrictEquals && !isSameClass)
         unrelatedTypes()
       // possibleNumericCount is insufficient or this will warn on e.g. Boolean == j.l.Boolean
       else if (isWarnable && nullCount == 0 && !(isSpecial(receiver) && isSpecial(actual))) {

--- a/test/files/neg/t8939.check
+++ b/test/files/neg/t8939.check
@@ -1,0 +1,6 @@
+t8939.scala:5: warning: Option[UserId] and UserId are unrelated: they will most likely never compare equal
+  l.find(_.id == UserId(1))
+              ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t8939.check
+++ b/test/files/neg/t8939.check
@@ -19,6 +19,12 @@ t8939.scala:13: warning: Any and User are unrelated: they will most likely never
 t8939.scala:14: warning: comparing values of types Boolean and Long using `==' will always yield false
   val c5 = true == 1L
                 ^
+t8939.scala:15: warning: String and Long are unrelated: they will most likely never compare equal
+  val c6 = "" == 1L
+              ^
+t8939.scala:16: warning: String and Int are unrelated: they will most likely never compare equal
+  val c7 = "" == 42
+              ^
 error: No warnings can be incurred under -Xfatal-warnings.
-7 warnings found
+9 warnings found
 one error found

--- a/test/files/neg/t8939.check
+++ b/test/files/neg/t8939.check
@@ -1,9 +1,24 @@
-t8939.scala:6: warning: Option[UserId] and UserId are unrelated: they will most likely never compare equal
+t8939.scala:7: warning: Option[UserId] and UserId are unrelated: they will most likely never compare equal
   l.find(_.id == UserId(1))
               ^
-t8939.scala:7: warning: Option[UserId] and Option[Int] are unrelated: they will most likely never compare equal
+t8939.scala:8: warning: Option[UserId] and Option[Int] are unrelated: they will most likely never compare equal
   l.find(_.id == Option(1))
               ^
+t8939.scala:10: warning: OtherUser and UserId are unrelated: they will most likely never compare equal
+  val c1 = OtherUser(Some(UserId(1)), 2) == UserId(3)
+                                         ^
+t8939.scala:11: warning: OtherUser and User are unrelated: they will most likely never compare equal
+  val c2 = OtherUser(Some(UserId(1)), 2) == User(Some(UserId(1)), 2)
+                                         ^
+t8939.scala:12: warning: Some[OtherUser] and Some[User] are unrelated: they will most likely never compare equal
+  val c3 = Some(OtherUser(Some(UserId(1)), 2)) == Some(User(Some(UserId(1)), 2))
+                                               ^
+t8939.scala:13: warning: Any and User are unrelated: they will most likely never compare equal
+  val c4 = (OtherUser(Some(UserId(1)), 2): Any) == User(Some(UserId(1)), 2)
+                                                ^
+t8939.scala:14: warning: comparing values of types Boolean and Long using `==' will always yield false
+  val c5 = true == 1L
+                ^
 error: No warnings can be incurred under -Xfatal-warnings.
-two warnings found
+7 warnings found
 one error found

--- a/test/files/neg/t8939.check
+++ b/test/files/neg/t8939.check
@@ -4,27 +4,30 @@ t8939.scala:7: warning: Option[UserId] and UserId are unrelated: they will most 
 t8939.scala:8: warning: Option[UserId] and Option[Int] are unrelated: they will most likely never compare equal
   l.find(_.id == Option(1))
               ^
-t8939.scala:10: warning: OtherUser and UserId are unrelated: they will most likely never compare equal
+t8939.scala:9: warning: Option[UserId] and List[UserId] are unrelated: they will most likely never compare equal
+  l.find(_.id == List(UserId(1)))
+              ^
+t8939.scala:11: warning: OtherUser and UserId are unrelated: they will most likely never compare equal
   val c1 = OtherUser(Some(UserId(1)), 2) == UserId(3)
                                          ^
-t8939.scala:11: warning: OtherUser and User are unrelated: they will most likely never compare equal
+t8939.scala:12: warning: OtherUser and User are unrelated: they will most likely never compare equal
   val c2 = OtherUser(Some(UserId(1)), 2) == User(Some(UserId(1)), 2)
                                          ^
-t8939.scala:12: warning: Some[OtherUser] and Some[User] are unrelated: they will most likely never compare equal
+t8939.scala:13: warning: Some[OtherUser] and Some[User] are unrelated: they will most likely never compare equal
   val c3 = Some(OtherUser(Some(UserId(1)), 2)) == Some(User(Some(UserId(1)), 2))
                                                ^
-t8939.scala:13: warning: Any and User are unrelated: they will most likely never compare equal
+t8939.scala:14: warning: Any and User are unrelated: they will most likely never compare equal
   val c4 = (OtherUser(Some(UserId(1)), 2): Any) == User(Some(UserId(1)), 2)
                                                 ^
-t8939.scala:14: warning: comparing values of types Boolean and Long using `==' will always yield false
+t8939.scala:15: warning: comparing values of types Boolean and Long using `==' will always yield false
   val c5 = true == 1L
                 ^
-t8939.scala:15: warning: String and Long are unrelated: they will most likely never compare equal
+t8939.scala:16: warning: String and Long are unrelated: they will most likely never compare equal
   val c6 = "" == 1L
               ^
-t8939.scala:16: warning: String and Int are unrelated: they will most likely never compare equal
+t8939.scala:17: warning: String and Int are unrelated: they will most likely never compare equal
   val c7 = "" == 42
               ^
 error: No warnings can be incurred under -Xfatal-warnings.
-9 warnings found
+10 warnings found
 one error found

--- a/test/files/neg/t8939.check
+++ b/test/files/neg/t8939.check
@@ -1,6 +1,9 @@
-t8939.scala:5: warning: Option[UserId] and UserId are unrelated: they will most likely never compare equal
+t8939.scala:6: warning: Option[UserId] and UserId are unrelated: they will most likely never compare equal
   l.find(_.id == UserId(1))
               ^
+t8939.scala:7: warning: Option[UserId] and Option[Int] are unrelated: they will most likely never compare equal
+  l.find(_.id == Option(1))
+              ^
 error: No warnings can be incurred under -Xfatal-warnings.
-one warning found
+two warnings found
 one error found

--- a/test/files/neg/t8939.flags
+++ b/test/files/neg/t8939.flags
@@ -1,0 +1,1 @@
+-Xlint:mismatched-types-equals -Xfatal-warnings

--- a/test/files/neg/t8939.flags
+++ b/test/files/neg/t8939.flags
@@ -1,1 +1,1 @@
--Xlint:mismatched-types-equals -Xfatal-warnings
+-Ywarn-strict-equals -Xfatal-warnings

--- a/test/files/neg/t8939.scala
+++ b/test/files/neg/t8939.scala
@@ -6,6 +6,7 @@ object Test {
   val l: List[User] = List(User(Some(UserId(1)), 2))
   l.find(_.id == UserId(1))
   l.find(_.id == Option(1))
+  l.find(_.id == List(UserId(1)))
   l.find(_.id.get == new UId(1))
   val c1 = OtherUser(Some(UserId(1)), 2) == UserId(3)
   val c2 = OtherUser(Some(UserId(1)), 2) == User(Some(UserId(1)), 2)

--- a/test/files/neg/t8939.scala
+++ b/test/files/neg/t8939.scala
@@ -12,4 +12,6 @@ object Test {
   val c3 = Some(OtherUser(Some(UserId(1)), 2)) == Some(User(Some(UserId(1)), 2))
   val c4 = (OtherUser(Some(UserId(1)), 2): Any) == User(Some(UserId(1)), 2)
   val c5 = true == 1L
+  val c6 = "" == 1L
+  val c7 = "" == 42
 }

--- a/test/files/neg/t8939.scala
+++ b/test/files/neg/t8939.scala
@@ -1,0 +1,6 @@
+final case class UserId(value: Int)
+final case class User(id: Option[UserId], other: Int)
+object Test {
+  val l: List[User] = List(User(Some(UserId(1)), 2))
+  l.find(_.id == UserId(1))
+}

--- a/test/files/neg/t8939.scala
+++ b/test/files/neg/t8939.scala
@@ -1,6 +1,9 @@
 final case class UserId(value: Int)
 final case class User(id: Option[UserId], other: Int)
 object Test {
+  type UId = UserId
   val l: List[User] = List(User(Some(UserId(1)), 2))
   l.find(_.id == UserId(1))
+  l.find(_.id == Option(1))
+  l.find(_.id.get == new UId(1))
 }

--- a/test/files/neg/t8939.scala
+++ b/test/files/neg/t8939.scala
@@ -1,9 +1,15 @@
 final case class UserId(value: Int)
 final case class User(id: Option[UserId], other: Int)
+final case class OtherUser(id: Option[UserId], other: Int)
 object Test {
   type UId = UserId
   val l: List[User] = List(User(Some(UserId(1)), 2))
   l.find(_.id == UserId(1))
   l.find(_.id == Option(1))
   l.find(_.id.get == new UId(1))
+  val c1 = OtherUser(Some(UserId(1)), 2) == UserId(3)
+  val c2 = OtherUser(Some(UserId(1)), 2) == User(Some(UserId(1)), 2)
+  val c3 = Some(OtherUser(Some(UserId(1)), 2)) == Some(User(Some(UserId(1)), 2))
+  val c4 = (OtherUser(Some(UserId(1)), 2): Any) == User(Some(UserId(1)), 2)
+  val c5 = true == 1L
 }

--- a/test/files/pos/t8939.flags
+++ b/test/files/pos/t8939.flags
@@ -1,0 +1,1 @@
+-Xlint:mismatched-types-equals -Xfatal-warnings

--- a/test/files/pos/t8939.flags
+++ b/test/files/pos/t8939.flags
@@ -1,1 +1,1 @@
--Xlint:mismatched-types-equals -Xfatal-warnings
+-Ywarn-strict-equals -Xfatal-warnings

--- a/test/files/pos/t8939.scala
+++ b/test/files/pos/t8939.scala
@@ -1,0 +1,8 @@
+final case class UserId(value: Int)
+final case class User(id: Option[UserId], other: Int)
+object Test {
+  val l: List[User] = List(User(Some(UserId(1)), 2))
+  l.find(_.id == Option(UserId(1)))
+  l.find(_.id.get == UserId(1))
+  l.find(_.id.get.value == 1)
+}

--- a/test/files/pos/t8939.scala
+++ b/test/files/pos/t8939.scala
@@ -1,8 +1,11 @@
 final case class UserId(value: Int)
 final case class User(id: Option[UserId], other: Int)
 object Test {
+  type UId = UserId
   val l: List[User] = List(User(Some(UserId(1)), 2))
   l.find(_.id == Option(UserId(1)))
+  l.find(_.id == Option(new UId(1)))
   l.find(_.id.get == UserId(1))
+  l.find(_.id.get == new UId(1))
   l.find(_.id.get.value == 1)
 }

--- a/test/files/pos/t8939.scala
+++ b/test/files/pos/t8939.scala
@@ -4,6 +4,8 @@ object Test {
   type UId = UserId
   val l: List[User] = List(User(Some(UserId(1)), 2))
   l.find(_.id == Option(UserId(1)))
+  l.find(_.id == None)
+  l.find(_.id == Some(UserId(1)))
   l.find(_.id == Option(new UId(1)))
   l.find(_.id.get == UserId(1))
   l.find(_.id.get == new UId(1))


### PR DESCRIPTION
Adds a new ~~Xlint~~ Ywarn that warns on comparison of mismatched types.

I understand that this is a bit of a ham-fisted approach, but something like this, in the vein of warn-me-if-i-am-comparing-any-unequal-types, seems to be something that (a) people want but doesn't exist and (b) would solve a lot of issues when combined with fatal warnings.

Closes https://github.com/scala/bug/issues/8939 (https://issues.scala-lang.org/browse/SI-8939)