### PR TITLE
Revert renaming of wrapArrayMethodName to wrapVarargsArrayMethodName.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -129,7 +129,7 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
   def mkWrapVarargsArray(tree: Tree, elemtp: Type) = {
     mkMethodCall(
       getWrapVarargsArrayModule,
-      wrapVarargsArrayMethodName(elemtp),
+      wrapArrayMethodName(elemtp),
       if (isPrimitiveValueType(elemtp)) Nil else List(elemtp),
       List(tree)
     )

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -355,7 +355,7 @@ trait Definitions extends api.StandardDefinitions {
 
     // This is a not the usual lazy val to prevent it from showing up as a separate module in JavaUniverseForce.scala
     def getWrapVarargsArrayModule        = if(isNewCollections) ScalaRunTimeModule else PredefModule
-    def wrapVarargsArrayMethod(tp: Type) = getMemberMethod(getWrapVarargsArrayModule, wrapVarargsArrayMethodName(tp))
+    def wrapVarargsArrayMethod(tp: Type) = getMemberMethod(getWrapVarargsArrayModule, wrapArrayMethodName(tp))
 
     /** Specialization.
      */
@@ -593,7 +593,7 @@ trait Definitions extends api.StandardDefinitions {
     def functionType(formals: List[Type], restpe: Type)         = FunctionClass.specificType(formals, restpe)
     def abstractFunctionType(formals: List[Type], restpe: Type) = AbstractFunctionClass.specificType(formals, restpe)
 
-    def wrapVarargsArrayMethodName(elemtp: Type): TermName = elemtp.typeSymbol match {
+    def wrapArrayMethodName(elemtp: Type): TermName = elemtp.typeSymbol match {
       case ByteClass    => nme.wrapByteArray
       case ShortClass   => nme.wrapShortArray
       case CharClass    => nme.wrapCharArray


### PR DESCRIPTION
This simplifies migration of existing code bases, especially code
bases that cross-compile with scala-reflect 2.12/2.13.

In particular, Scala.js testing support relies on that method.