### PR TITLE
[SUPERSEDED] Unit companion is disallowed

### DIFF
--- a/project/GenerateAnyVals.scala
+++ b/project/GenerateAnyVals.scala
@@ -319,16 +319,16 @@ override def toString = "object scala.@name@"
   def nonUnitCompanions = ""  // todo
 
   def cardinalCompanion = """
-/** The smallest value representable as a @name@. */
+/** The smallest value representable as @name@. */
 final val MinValue = @boxed@.MIN_VALUE
 
-/** The largest value representable as a @name@. */
+/** The largest value representable as @name@. */
 final val MaxValue = @boxed@.MAX_VALUE
 """
 
   def floatingCompanion = """
 /** The smallest positive value greater than @zero@ which is
- *  representable as a @name@.
+ *  representable as @name@.
  */
 final val MinPositiveValue = @boxed@.MIN_VALUE
 final val NaN              = @boxed@.NaN
@@ -336,13 +336,13 @@ final val PositiveInfinity = @boxed@.POSITIVE_INFINITY
 final val NegativeInfinity = @boxed@.NEGATIVE_INFINITY
 
 /** The negative number with the greatest (finite) absolute value which is representable
- *  by a @name@.  Note that it differs from [[java.lang.@name@.MIN_VALUE]], which
- *  is the smallest positive value representable by a @name@.  In Scala that number
+ *  as @name@.  Note that it differs from [[java.lang.@name@.MIN_VALUE]], which
+ *  is the smallest positive value representable as @name@.  In Scala that number
  *  is called @name@.MinPositiveValue.
  */
 final val MinValue = -@boxed@.MAX_VALUE
 
-/** The largest finite positive number representable as a @name@. */
+/** The largest finite positive number representable as @name@. */
 final val MaxValue = @boxed@.MAX_VALUE
 """
 }
@@ -459,6 +459,9 @@ override def getClass(): Class[Boolean] = ???
     )
     def objectLines = interpolate(allCompanions).lines.toList
 
+    override def mkObject =
+      s"""@scala.annotation.compileTimeOnly("not for use in source code. The unit value is written '()'.")\n""" + super.mkObject
+
     override def boxUnboxInterpolations = Map(
       "@boxRunTimeDoc@" -> "",
       "@unboxRunTimeDoc@" -> "",
@@ -486,7 +489,7 @@ object GenerateAnyVals {
 
     av.make() foreach { case (name, code ) =>
       val file = new java.io.File(outDir, name + ".scala")
-      sbt.IO.write(file, code, java.nio.charset.Charset.forName("UTF-8"), false)
+      sbt.IO.write(file, code, java.nio.charset.StandardCharsets.UTF_8, false)
     }
   }
 }

--- a/src/library/scala/Byte.scala
+++ b/src/library/scala/Byte.scala
@@ -439,10 +439,10 @@ final abstract class Byte private extends AnyVal {
 }
 
 object Byte extends AnyValCompanion {
-  /** The smallest value representable as a Byte. */
+  /** The smallest value representable as Byte. */
   final val MinValue = java.lang.Byte.MIN_VALUE
 
-  /** The largest value representable as a Byte. */
+  /** The largest value representable as Byte. */
   final val MaxValue = java.lang.Byte.MAX_VALUE
 
   /** Transform a value type into a boxed reference type.

--- a/src/library/scala/Char.scala
+++ b/src/library/scala/Char.scala
@@ -439,10 +439,10 @@ final abstract class Char private extends AnyVal {
 }
 
 object Char extends AnyValCompanion {
-  /** The smallest value representable as a Char. */
+  /** The smallest value representable as Char. */
   final val MinValue = java.lang.Character.MIN_VALUE
 
-  /** The largest value representable as a Char. */
+  /** The largest value representable as Char. */
   final val MaxValue = java.lang.Character.MAX_VALUE
 
   /** Transform a value type into a boxed reference type.

--- a/src/library/scala/Double.scala
+++ b/src/library/scala/Double.scala
@@ -206,7 +206,7 @@ final abstract class Double private extends AnyVal {
 
 object Double extends AnyValCompanion {
   /** The smallest positive value greater than 0.0d which is
-   *  representable as a Double.
+   *  representable as Double.
    */
   final val MinPositiveValue = java.lang.Double.MIN_VALUE
   final val NaN              = java.lang.Double.NaN
@@ -214,13 +214,13 @@ object Double extends AnyValCompanion {
   final val NegativeInfinity = java.lang.Double.NEGATIVE_INFINITY
 
   /** The negative number with the greatest (finite) absolute value which is representable
-   *  by a Double.  Note that it differs from [[java.lang.Double.MIN_VALUE]], which
-   *  is the smallest positive value representable by a Double.  In Scala that number
+   *  as Double.  Note that it differs from [[java.lang.Double.MIN_VALUE]], which
+   *  is the smallest positive value representable as Double.  In Scala that number
    *  is called Double.MinPositiveValue.
    */
   final val MinValue = -java.lang.Double.MAX_VALUE
 
-  /** The largest finite positive number representable as a Double. */
+  /** The largest finite positive number representable as Double. */
   final val MaxValue = java.lang.Double.MAX_VALUE
 
   /** Transform a value type into a boxed reference type.

--- a/src/library/scala/Float.scala
+++ b/src/library/scala/Float.scala
@@ -206,7 +206,7 @@ final abstract class Float private extends AnyVal {
 
 object Float extends AnyValCompanion {
   /** The smallest positive value greater than 0.0f which is
-   *  representable as a Float.
+   *  representable as Float.
    */
   final val MinPositiveValue = java.lang.Float.MIN_VALUE
   final val NaN              = java.lang.Float.NaN
@@ -214,13 +214,13 @@ object Float extends AnyValCompanion {
   final val NegativeInfinity = java.lang.Float.NEGATIVE_INFINITY
 
   /** The negative number with the greatest (finite) absolute value which is representable
-   *  by a Float.  Note that it differs from [[java.lang.Float.MIN_VALUE]], which
-   *  is the smallest positive value representable by a Float.  In Scala that number
+   *  as Float.  Note that it differs from [[java.lang.Float.MIN_VALUE]], which
+   *  is the smallest positive value representable as Float.  In Scala that number
    *  is called Float.MinPositiveValue.
    */
   final val MinValue = -java.lang.Float.MAX_VALUE
 
-  /** The largest finite positive number representable as a Float. */
+  /** The largest finite positive number representable as Float. */
   final val MaxValue = java.lang.Float.MAX_VALUE
 
   /** Transform a value type into a boxed reference type.

--- a/src/library/scala/Function0.scala
+++ b/src/library/scala/Function0.scala
@@ -6,7 +6,7 @@
 **                          |/                                          **
 \*                                                                      */
 // GENERATED CODE: DO NOT EDIT.
-// genprod generated these sources at: Mon Jun 08 18:05:40 CEST 2015
+// genprod generated these sources at: Wed Apr 04 13:18:39 PDT 2018
 
 package scala
 

--- a/src/library/scala/Int.scala
+++ b/src/library/scala/Int.scala
@@ -439,10 +439,10 @@ final abstract class Int private extends AnyVal {
 }
 
 object Int extends AnyValCompanion {
-  /** The smallest value representable as an Int. */
+  /** The smallest value representable as Int. */
   final val MinValue = java.lang.Integer.MIN_VALUE
 
-  /** The largest value representable as an Int. */
+  /** The largest value representable as Int. */
   final val MaxValue = java.lang.Integer.MAX_VALUE
 
   /** Transform a value type into a boxed reference type.

--- a/src/library/scala/Long.scala
+++ b/src/library/scala/Long.scala
@@ -439,10 +439,10 @@ final abstract class Long private extends AnyVal {
 }
 
 object Long extends AnyValCompanion {
-  /** The smallest value representable as a Long. */
+  /** The smallest value representable as Long. */
   final val MinValue = java.lang.Long.MIN_VALUE
 
-  /** The largest value representable as a Long. */
+  /** The largest value representable as Long. */
   final val MaxValue = java.lang.Long.MAX_VALUE
 
   /** Transform a value type into a boxed reference type.

--- a/src/library/scala/Short.scala
+++ b/src/library/scala/Short.scala
@@ -439,10 +439,10 @@ final abstract class Short private extends AnyVal {
 }
 
 object Short extends AnyValCompanion {
-  /** The smallest value representable as a Short. */
+  /** The smallest value representable as Short. */
   final val MinValue = java.lang.Short.MIN_VALUE
 
-  /** The largest value representable as a Short. */
+  /** The largest value representable as Short. */
   final val MaxValue = java.lang.Short.MAX_VALUE
 
   /** Transform a value type into a boxed reference type.

--- a/src/library/scala/Specializable.scala
+++ b/src/library/scala/Specializable.scala
@@ -13,6 +13,7 @@ package scala
  */
 trait Specializable
 
+@annotation.compileTimeOnly("used to support specialization")
 object Specializable {
   // No type parameter in @specialized annotation.
   trait SpecializedGroup { }

--- a/src/library/scala/Unit.scala
+++ b/src/library/scala/Unit.scala
@@ -23,6 +23,7 @@ final abstract class Unit private extends AnyVal {
   override def getClass(): Class[Unit] = ???
 }
 
+@scala.annotation.compileTimeOnly("not for use in source code. The unit value is written '()'.")
 object Unit extends AnyValCompanion {
 
   /** Transform a value type into a boxed reference type.

--- a/src/library/scala/specialized.scala
+++ b/src/library/scala/specialized.scala
@@ -26,6 +26,7 @@ import Specializable._
  */
 // class tspecialized[T](group: Group[T]) extends scala.annotation.StaticAnnotation {
 
+@annotation.compileTimeOnly("used for annotating specialized type parameters")
 class specialized(group: SpecializedGroup) extends scala.annotation.StaticAnnotation {
   def this(types: Specializable*) = this(new Group(types.toList))
   def this() = this(Primitives)

--- a/test/files/neg/warn-unit.check
+++ b/test/files/neg/warn-unit.check
@@ -1,0 +1,7 @@
+warn-unit.scala:13: error: please don't
+    println(X)
+            ^
+warn-unit.scala:14: error: not for use in source code. The unit value is written '()'.
+    Unit
+    ^
+two errors found

--- a/test/files/neg/warn-unit.scala
+++ b/test/files/neg/warn-unit.scala
@@ -1,0 +1,16 @@
+
+@scala.annotation.compileTimeOnly("please don't")
+object X extends Specializable
+
+class C[@specialized(X, Int) A] {
+  def f(a: A) = 42
+}
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val c = new C[Int]
+    println(c.f(42))
+    println(X)
+    Unit
+  }
+}


### PR DESCRIPTION
Use `compileTimeOnly` mechanism to enforce it.

Slap some `compileTimeOnly` on specialization to
permit the infrastructure; and also explicitly
omit specialized itself in check to allow
`requiredClass[specialized]`.