### PR TITLE
Clean up solveOne

### DIFF
--- a/test/files/pos/t10722.flags
+++ b/test/files/pos/t10722.flags
@@ -1,0 +1,1 @@
+-language:higherKinds

--- a/test/files/pos/t10722.scala
+++ b/test/files/pos/t10722.scala
@@ -1,0 +1,11 @@
+object Test {
+  sealed trait Coin[+A, +B]
+  case class Heads[+A](face: A) extends Coin[A, Nothing]
+  case class Tails[+B](back: B) extends Coin[Nothing, B]
+
+  def flip[F[_, _], G[x] <: F[x, String]](f: F[Int, String], g: G[Int]) = ???
+  def flop[F[_], G <: F[String]](f: F[String], g: G) = ???
+
+  flip(Tails("scala"): Coin[Int, String], Heads(50))
+  flop(Option("scala"), None)
+}

--- a/test/files/pos/t8602.flags
+++ b/test/files/pos/t8602.flags
@@ -1,0 +1,1 @@
+-language:higherKinds

--- a/test/files/pos/t8602.scala
+++ b/test/files/pos/t8602.scala
@@ -1,0 +1,8 @@
+object Test {
+  case class Foo[CC[_], D <: CC[Int]](d: D, cc: CC[Int])
+  Foo(Nil, List(1, 2, 3))
+
+  class H[F[_]]
+  def g[F[_], T, FT <: F[T]](h: H[F]) = 1
+  g(new H[Set])
+}


### PR DESCRIPTION
Be conservative in our changes, but at least use `=:=` when
comparing types, so that an eta-expanded type constructor
and its 0-arg type ref compare equal.

Since there will be a complete overhaul of type inference in dotty,
let's not cause small fluctuations here in the mean time.

Type inference hasn't changed much in 13 years, so it seems
unwise to start tweaking quirks users have come to rely on.

Also, don't do `tparam.subst(tparams, tvars)` -- iterate
over `tparams` and `tvars` simultaneously, and just say `tvar`.

Add a `configForeach` combinator that iterates over arrays,
in hopes of getting a bit more locality. It would be nice if
its HOF was inlined, but it doesn't seem to happen currently.

Fixes scala/bug#8602 and fixes scala/bug#10722