### PR TITLE
LazyList head computed only once

### DIFF
--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -484,7 +484,10 @@ sealed private[immutable] trait LazyListFactory[+CC[+X] <: LinearSeq[X] with Laz
     *  @param f     the function that's repeatedly applied
     *  @return      the LazyList returning the infinite sequence of values `start, f(start), f(f(start)), ...`
     */
-  def iterate[A](start: => A)(f: A => A): CC[A] = newCons(start, iterate(f(start))(f))
+  def iterate[A](start: => A)(f: A => A): CC[A] = {
+    lazy val head = start
+    newCons(head, iterate(f(head))(f))
+  }
 
   /**
     * Create an infinite LazyList starting at `start` and incrementing by

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -288,4 +288,44 @@ class LazyListTest {
     assertEquals(0, lazeCount)
   }
 
+  @Test  // Strawman issue #529
+  def testLazyListMustComputeHeadOnlyOnce(): Unit = {
+    var seedCounter = 0
+    var fCounter = 0
+    def seed(): Int = {
+      seedCounter += 1
+      1
+    }
+    val f: Int => Int = { x =>
+      fCounter += 1
+      x + 1
+    }
+    val xs = LazyList.iterate(seed())(f)
+    assertEquals(0, seedCounter)
+    assertEquals(0, fCounter)
+
+    xs.head
+    assertEquals(1, seedCounter)
+    assertEquals(0, fCounter)
+
+    xs.tail
+    assertEquals(1, seedCounter)
+    assertEquals(0, fCounter)
+
+    xs.tail.head
+    assertEquals(1, seedCounter)
+    assertEquals(1, fCounter)
+
+    xs.tail.tail
+    assertEquals(1, seedCounter)
+    assertEquals(1, fCounter)
+
+    xs.tail.tail.head
+    assertEquals(1, seedCounter)
+    assertEquals(2, fCounter)
+
+    xs.take(10).toList
+    assertEquals(1, seedCounter)
+    assertEquals(9, fCounter)
+  }
 }


### PR DESCRIPTION
Original pull-request in [collection strawman ](https://github.com/scala/collection-strawman/pull/532), as suggested by @julienrf, if I understood correctly I should make PR here instead. I've added the test as suggested.