### PR TITLE
Support JEP 293 style long command-line options

### DIFF
--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -17,7 +17,7 @@ class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
       "how",
       "how to run the specified code",
       List("object", "script", "jar", "repl", "guess"),
-      "guess")
+      "guess") withAbbreviation "--how-to-run"
 
   val loadfiles =
     MultiStringSetting(
@@ -41,11 +41,11 @@ class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
   val save =
     BooleanSetting(
       "-save",
-      "save the compiled script (assumes the code is a script)") withAbbreviation "-savecompiled"
+      "save the compiled script (assumes the code is a script)") withAbbreviation "-savecompiled" withAbbreviation "--save"
 
   val nc = BooleanSetting(
       "-nc",
-      "do not use the legacy fsc compilation daemon").withAbbreviation("-nocompdaemon")
+      "do not use the legacy fsc compilation daemon").withAbbreviation("-nocompdaemon").withAbbreviation("--no-compilation-daemon")
       .withDeprecationMessage("scripts use cold compilation by default; use -Yscriptrunner for custom behavior")
       .withPostSetHook { x: BooleanSetting => Yscriptrunner.value = if (x) "default" else "resident" }
 }

--- a/src/compiler/scala/tools/nsc/fsc/FscSettings.scala
+++ b/src/compiler/scala/tools/nsc/fsc/FscSettings.scala
@@ -17,15 +17,15 @@ class FscSettings(error: String => Unit) extends Settings(error) {
     disable(resident)
   }
 
-  val currentDir   = StringSetting ("-current-dir", "path", "Base directory for resolving relative paths", "").internalOnly()
-  val reset        = BooleanSetting("-reset",    "Reset compile server caches")
-  val shutdown     = BooleanSetting("-shutdown", "Shutdown compile server")
-  val server       = StringSetting ("-server",   "hostname:portnumber", "Specify compile server socket", "")
+  val currentDir   = StringSetting ("-current-dir", "path", "Base directory for resolving relative paths", "").internalOnly() withAbbreviation "--current-directory"
+  val reset        = BooleanSetting("-reset",    "Reset compile server caches") withAbbreviation "--reset"
+  val shutdown     = BooleanSetting("-shutdown", "Shutdown compile server") withAbbreviation "--shutdown"
+  val server       = StringSetting ("-server",   "hostname:portnumber", "Specify compile server socket", "") withAbbreviation "--server"
   val port         = IntSetting    ("-port",     "Search and start compile server in given port only",
-                                       0, Some((0, Int.MaxValue)), (_: String) => None)
-  val preferIPv4   = BooleanSetting("-ipv4",     "Use IPv4 rather than IPv6 for the server socket")
+                                       0, Some((0, Int.MaxValue)), (_: String) => None) withAbbreviation "--port"
+  val preferIPv4   = BooleanSetting("-ipv4",     "Use IPv4 rather than IPv6 for the server socket") withAbbreviation "--ipv4"
   val idleMins     = IntSetting    ("-max-idle", "Set idle timeout in minutes for fsc (use 0 for no timeout)",
-                                       30, Some((0, Int.MaxValue)), (_: String) => None)
+                                       30, Some((0, Int.MaxValue)), (_: String) => None) withAbbreviation "--max-idle"
 
   // For improved help output, separating fsc options from the others.
   def fscSpecific = Set[Settings#Setting](

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -44,17 +44,17 @@ trait ScalaSettings extends AbsScalaSettings
 
   val jvmargs  = PrefixSetting("-J<flag>", "-J", "Pass <flag> directly to the runtime system.")
   val defines  = PrefixSetting("-Dproperty=value", "-D", "Pass -Dproperty=value directly to the runtime system.")
-  /*val toolcp =*/ PathSetting("-toolcp", "Add to the runner classpath.", "")
-  val nobootcp = BooleanSetting("-nobootcp", "Do not use the boot classpath for the scala jars.")
+  /*val toolcp =*/ PathSetting("-toolcp", "Add to the runner classpath.", "") withAbbreviation "--tool-class-path"
+  val nobootcp = BooleanSetting("-nobootcp", "Do not use the boot classpath for the scala jars.") withAbbreviation "--no-boot-class-path"
 
   /**
    *  Standard settings
    */
   // argfiles is only for the help message
   /*val argfiles = */ BooleanSetting    ("@<file>", "A text file containing compiler arguments (options and source files)")
-  val classpath     = PathSetting       ("-classpath", "Specify where to find user class files.", defaultClasspath) withAbbreviation "-cp"
+  val classpath     = PathSetting       ("-classpath", "Specify where to find user class files.", defaultClasspath) withAbbreviation "-cp" withAbbreviation "--class-path"
   val d             = OutputSetting     (outputDirs, ".")
-  val nospecialization = BooleanSetting ("-no-specialization", "Ignore @specialize annotations.")
+  val nospecialization = BooleanSetting ("-no-specialization", "Ignore @specialize annotations.") withAbbreviation "--no-specialization"
 
   // Would be nice to build this dynamically from scala.languageFeature.
   // The two requirements: delay error checking until you have symbols, and let compiler command build option-specific help.
@@ -74,7 +74,7 @@ trait ScalaSettings extends AbsScalaSettings
       helpArg = "feature",
       descr   = description,
       domain  = languageFeatures
-    )
+    ) withAbbreviation "--language"
   }
   val release = StringSetting("-release", "release", "Compile for a specific version of the Java platform. Supported targets: 6, 7, 8, 9", "").withPostSetHook { (value: StringSetting) =>
     if (value.value != "" && !scala.util.Properties.isJavaAtLeast("9")) {
@@ -83,7 +83,7 @@ trait ScalaSettings extends AbsScalaSettings
       // TODO validate numeric value
       // TODO validate release <= java.specification.version
     }
-  }
+  } withAbbreviation "--release"
   def releaseValue: Option[String] = Option(release.value).filter(_ != "")
 
   /*

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -18,32 +18,32 @@ trait StandardScalaSettings {
 
   /** Path related settings.
    */
-  val bootclasspath =     PathSetting ("-bootclasspath", "Override location of bootstrap class files.", Defaults.scalaBootClassPath)
+  val bootclasspath =     PathSetting ("-bootclasspath", "Override location of bootstrap class files.", Defaults.scalaBootClassPath) withAbbreviation "--boot-class-path"
   val classpath:          PathSetting // is mutated directly in various places (thus inspiring this very effort)
   val d:                OutputSetting // depends on mutable OutputDirs class
-  val extdirs =           PathSetting ("-extdirs", "Override location of installed extensions.", Defaults.scalaExtDirs)
-  val javabootclasspath = PathSetting ("-javabootclasspath", "Override java boot classpath.", Defaults.javaBootClassPath)
-  val javaextdirs =       PathSetting ("-javaextdirs", "Override java extdirs classpath.", Defaults.javaExtDirs)
-  val sourcepath =        PathSetting ("-sourcepath", "Specify location(s) of source files.", "") // Defaults.scalaSourcePath
+  val extdirs =           PathSetting ("-extdirs", "Override location of installed extensions.", Defaults.scalaExtDirs) withAbbreviation "--extension-directories"
+  val javabootclasspath = PathSetting ("-javabootclasspath", "Override java boot classpath.", Defaults.javaBootClassPath) withAbbreviation "--java-boot-class-path"
+  val javaextdirs =       PathSetting ("-javaextdirs", "Override java extdirs classpath.", Defaults.javaExtDirs) withAbbreviation "--java-extension-directories"
+  val sourcepath =        PathSetting ("-sourcepath", "Specify location(s) of source files.", "") withAbbreviation "--source-path" // Defaults.scalaSourcePath
 
   /** Other settings.
    */
-  val dependencyfile =  StringSetting ("-dependencyfile", "file", "Set dependency tracking file.", ".scala_dependencies")
-  val deprecation =    BooleanSetting ("-deprecation", "Emit warning and location for usages of deprecated APIs.")
-  val encoding =        StringSetting ("-encoding", "encoding", "Specify character encoding used by source files.", Properties.sourceEncoding)
-  val explaintypes =   BooleanSetting ("-explaintypes", "Explain type errors in more detail.")
-  val feature =        BooleanSetting ("-feature", "Emit warning and location for usages of features that should be imported explicitly.")
+  val dependencyfile =  StringSetting ("-dependencyfile", "file", "Set dependency tracking file.", ".scala_dependencies") withAbbreviation "--dependency-file"
+  val deprecation =    BooleanSetting ("-deprecation", "Emit warning and location for usages of deprecated APIs.") withAbbreviation "--deprecation"
+  val encoding =        StringSetting ("-encoding", "encoding", "Specify character encoding used by source files.", Properties.sourceEncoding) withAbbreviation "--encoding"
+  val explaintypes =   BooleanSetting ("-explaintypes", "Explain type errors in more detail.") withAbbreviation "--explain-types"
+  val feature =        BooleanSetting ("-feature", "Emit warning and location for usages of features that should be imported explicitly.") withAbbreviation "--feature"
   val g =               ChoiceSetting ("-g", "level", "Set level of generated debugging info.", List("none", "source", "line", "vars", "notailcalls"), "vars")
-  val help =           BooleanSetting ("-help", "Print a synopsis of standard options")
-  val nowarn =         BooleanSetting ("-nowarn", "Generate no warnings.")
+  val help =           BooleanSetting ("-help", "Print a synopsis of standard options") withAbbreviation "--help"
+  val nowarn =         BooleanSetting ("-nowarn", "Generate no warnings.") withAbbreviation "--no-warnings"
   val optimise:        BooleanSetting // depends on post hook which mutates other settings
-  val print =          BooleanSetting ("-print", "Print program with Scala-specific features removed.")
+  val print =          BooleanSetting ("-print", "Print program with Scala-specific features removed.") withAbbreviation "--print"
   val target =         ChoiceSettingForcedDefault ("-target", "target", "Target platform for object files. All JVM 1.5 - 1.7 targets are deprecated.",
-                          List("jvm-1.5", "jvm-1.6", "jvm-1.7", "jvm-1.8"), "jvm-1.8")
-  val unchecked =      BooleanSetting ("-unchecked", "Enable additional warnings where generated code depends on assumptions.")
-  val uniqid =         BooleanSetting ("-uniqid", "Uniquely tag all identifiers in debugging output.")
-  val usejavacp =      BooleanSetting ("-usejavacp", "Utilize the java.class.path in classpath resolution.")
-  val usemanifestcp =  BooleanSetting ("-usemanifestcp", "Utilize the manifest in classpath resolution.")
-  val verbose =        BooleanSetting ("-verbose", "Output messages about what the compiler is doing.")
-  val version =        BooleanSetting ("-version", "Print product version and exit.")
+                          List("jvm-1.5", "jvm-1.6", "jvm-1.7", "jvm-1.8"), "jvm-1.8") withAbbreviation "--target"
+  val unchecked =      BooleanSetting ("-unchecked", "Enable additional warnings where generated code depends on assumptions.") withAbbreviation "--unchecked"
+  val uniqid =         BooleanSetting ("-uniqid", "Uniquely tag all identifiers in debugging output.") withAbbreviation "--unique-id"
+  val usejavacp =      BooleanSetting ("-usejavacp", "Utilize the java.class.path in classpath resolution.") withAbbreviation "--use-java-class-path"
+  val usemanifestcp =  BooleanSetting ("-usemanifestcp", "Utilize the manifest in classpath resolution.") withAbbreviation "--use-manifest-class-path"
+  val verbose =        BooleanSetting ("-verbose", "Output messages about what the compiler is doing.") withAbbreviation "--verbose"
+  val version =        BooleanSetting ("-version", "Print product version and exit.") withAbbreviation "--version"
 }

--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -223,7 +223,7 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
     docDiagramsMaxNormalClasses, docDiagramsMaxImplicitClasses,
     docNoPrefixes, docNoLinkWarnings, docRawOutput, docSkipPackages,
     docExpandAllTypes, docGroups, docNoJavaComments
-  )
+  ).map(s => s.withAbbreviation("-" + s.name))
   val isScaladocSpecific: String => Boolean = scaladocSpecific map (_.name)
 
   override def isScaladoc = true


### PR DESCRIPTION
[JEP 293](http://openjdk.java.net/jeps/293) specifies GNU-like styles for java/javac/etc. command-line options, which is supported by OpenJDK/Oracle JDK from version 9.

This patch adds synonyms with two hyphens for each options.

Option summary:

`scala` options:

|short|long|
|-----|----|
|-howtorun|--how-to-run|
|-I|(no long option)|
|-i|(no long option)|
|-e|(no long option)|
|-save|--save|
|-nc|--no-compilation-daemon|

`fsc` options:

|short|long|
|-----|----|
|-current-dir|--current-directory|
|-reset|--reset|
|-shutdown|--shutdown|
|-server|--server|
|-port|--port|
|-ipv4|--ipv4|
|-max-idle|--max-idle|

`scalac` options:

|short|long|
|-----|----|
|-bootclasspath|--boot-class-path|
|-extdirs|--extension-directories|
|-javabootclasspath|--java-boot-class-path|
|-javaextdirs|--java-extension-directories|
|-sourcepath|--source-path|
|-dependencyfile|--dependency-file|
|-deprecation|--deprecation|
|-encoding|--encoding|
|-explaintypes|--explain-types|
|-feature|--feature|
|-g|(no long option)|
|-help|--help|
|-nowarn|--no-warnings|
|-print|--print|
|-target|--target|
|-unchecked|--unchecked|
|-uniqid|--unique-id|
|-usejavacp|--use-java-class-path|
|-usemanifestcp|--use-manifest-class-path|
|-verbose|--verbose|
|-version|--version|
|-toolcp|--tool-class-path|
|-nobootcp|--no-boot-class-path|
|-classpath|--class-path|
|-no-specialization|--no-specialization|
|-language|--language|
|-release|--release|
|-X*|(no long option)|
|-Y*|(no long option)|
|-J*|(no long option)|
|-D*|(no long option)|
|-opt*|(no long option)|
|-optimise|(no long option)|
|-P|(no long option)|
