### PR TITLE
Add partest for Unicode newline

### DIFF
--- a/test/files/neg/u000a.check
+++ b/test/files/neg/u000a.check
@@ -1,0 +1,4 @@
+u000a.scala:11: error: expected class or object definition
+// \u000a foo
+          ^
+one error found

--- a/test/files/neg/u000a.scala
+++ b/test/files/neg/u000a.scala
@@ -1,0 +1,11 @@
+// Unicode newline in a single-line comment?
+// Compiler will expect code on the line.
+// Here the code is invalid on line 11.
+
+/* \n foo */
+// \n foo
+/* \12 foo */
+// \12 foo
+/* \u000a foo */
+// foo \u000a
+// \u000a foo

--- a/test/files/pos/u000a.scala
+++ b/test/files/pos/u000a.scala
@@ -1,0 +1,11 @@
+// Unicode newline in a single-line comment?
+// Compiler will expect code on the line.
+// Here the code is valid.
+
+/* \n object foo */
+// \n object foo
+/* \12 object foo */
+// \12 object foo
+/* \u000a object foo */
+// object foo \u000a
+// \u000a object foo


### PR DESCRIPTION
I came across this while trying to document Unicode behavior in comments.  It was unpleasant to say the least.

I was surprised this isn't on scalapuzzlers.com.  However, I learned this silly behavior also exists in the Java compiler.

It's cryptically documented in the Scala specification.  Was there a test for this already and I just didn't see it?