### PR TITLE
Adds regression test for local lazy val of type Unit

### DIFF
--- a/test/files/pos/t8277.scala
+++ b/test/files/pos/t8277.scala
@@ -1,0 +1,7 @@
+class A{
+  def p()  = {
+    lazy val s = 1
+    lazy val d = ()
+    s
+  }
+}


### PR DESCRIPTION
Closes scala/bug#8277
The reported issue worked in 2.12.4, but it was kept open waiting for this regression test.
