### PR TITLE
Remove -sourcepath from the options of library/console

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -375,6 +375,11 @@ lazy val library = configureAsSubproject(project)
         "-doc-root-content", (sourceDirectory in Compile).value + "/rootdoc.txt"
       )
     },
+    scalacOptions in (Compile, console) := {
+      val opts = (scalacOptions in console).value
+      val ix = (scalacOptions in console).value.indexOfSlice(Seq[String]("-sourcepath", (scalaSource in Compile).value.toString))
+      opts.patch(ix, Nil, 2)
+    },
     includeFilter in unmanagedResources in Compile := "*.tmpl" | "*.xml" | "*.js" | "*.css" | "rootdoc.txt",
     // Include *.txt files in source JAR:
     mappings in Compile in packageSrc ++= {


### PR DESCRIPTION
Before this change, library/{console, consoleQuick} REPL startup and
maybe each REPL line evaluation was typechecking src/library rather
than using the class files.

I never noticed this before because it isn't a common task to run,
I only tried it as part of some ad-hoc testing of the build in
our effort to upgrade to SBT 1.x.