### PR TITLE
Be more explicit about the unsoundness holes used by the collections.

### DIFF
--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -286,8 +286,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
      *  new array of longs */
     def toBitMask: Array[Long] = nnIds.toBitMask
 
-    override protected[this] def fromSpecificIterable(coll: Iterable[Value]) = ValueSet.fromSpecific(coll)
-    override protected[this] def newSpecificBuilder() = ValueSet.newBuilder
+    override protected def fromSpecificIterable(coll: Iterable[Value]) = ValueSet.fromSpecific(coll)
+    override protected def newSpecificBuilder() = ValueSet.newBuilder
 
     def map(f: Value => Value): ValueSet = fromSpecificIterable(new View.Map(toIterable, f))
     def flatMap(f: Value => IterableOnce[Value]): ValueSet = fromSpecificIterable(new View.FlatMap(toIterable, f))

--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -1,6 +1,7 @@
 package scala
 package collection
 
+import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.mutable.Builder
 
 
@@ -17,8 +18,8 @@ import scala.collection.mutable.Builder
   * @define Coll `BitSet`
   */
 trait BitSet extends SortedSet[Int] with BitSetOps[BitSet] {
-  override protected[this] def fromSpecificIterable(coll: Iterable[Int]): BitSetC = bitSetFactory.fromSpecific(coll)
-  override protected[this] def newSpecificBuilder(): Builder[Int, BitSetC] = bitSetFactory.newBuilder()
+  override protected def fromSpecificIterable(coll: Iterable[Int]): BitSetC = bitSetFactory.fromSpecific(coll)
+  override protected def newSpecificBuilder(): Builder[Int, BitSetC] = bitSetFactory.newBuilder()
   override def empty: BitSetC = bitSetFactory.empty
 }
 
@@ -35,7 +36,14 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
 
   def bitSetFactory: SpecificIterableFactory[Int, BitSetC]
 
-  protected[this] type BitSetC = C
+  /**
+    * Type alias to `C`. It is used to provide a default implementation of the `fromSpecificIterable`
+    * and `newSpecificBuilder` operations.
+    *
+    * Due to the `@uncheckedVariance` annotation, usage of this type member can be unsound and is
+    * therefore not recommended.
+    */
+  protected type BitSetC = C @uncheckedVariance
 
   final def ordering: Ordering[Int] = Ordering.Int
 

--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -27,7 +27,7 @@ trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self =>
 
   override def view: IndexedView[A] = new IndexedView.Id[A](this)
 
-  override protected[this] def reversed: Iterable[A] = new IndexedView.Reverse(this)
+  override protected def reversed: Iterable[A] = new IndexedView.Reverse(this)
 
   // Override transformation operations to use more efficient views than the default ones
   override def prepended[B >: A](elem: B): CC[B] = iterableFactory.from(new IndexedView.Prepended(elem, this))

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -994,7 +994,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     else mutable.ArrayBuffer.from(this).toArray[B]
 
   // For internal use
-  protected[this] def reversed: Iterable[A] = {
+  protected def reversed: Iterable[A] = {
     var xs: immutable.List[A] = immutable.Nil
     val it = iterator()
     while (it.hasNext) xs = it.next() :: xs

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -26,10 +26,10 @@ final class StringOps(private val s: String)
 
   def toIterable = StringView(s)
   override def view: StringView = StringView(s)
-  protected[this] def coll: String = s
+  protected def coll: String = s
   override def toSeq: immutable.Seq[Char] = s.toCharArray
 
-  protected[this] def fromSpecificIterable(coll: Iterable[Char]): String = {
+  protected def fromSpecificIterable(coll: Iterable[Char]): String = {
     val sb = new StringBuilder
     for (ch <- coll) sb.append(ch)
     sb.toString
@@ -37,7 +37,7 @@ final class StringOps(private val s: String)
 
   def iterableFactory = immutable.IndexedSeq
 
-  override protected[this] def newSpecificBuilder() = new mutable.StringBuilder
+  protected def newSpecificBuilder() = new mutable.StringBuilder
 
   def length = s.length
 

--- a/src/library/scala/collection/generic/IsIterableLike.scala
+++ b/src/library/scala/collection/generic/IsIterableLike.scala
@@ -118,10 +118,10 @@ object IsIterableLike {
       type A = A0
       val conversion: Array[A] => IterableOps[A, Iterable, Array[A]] = a => new IterableOps[A, Iterable, Array[A]] {
         def toIterable: Iterable[A] = mutable.WrappedArray.make(a)
-        protected[this] def coll: Array[A] = a
-        protected[this] def fromSpecificIterable(coll: Iterable[A]): Array[A] = Array.from(coll)
+        protected def coll: Array[A] = a
+        protected def fromSpecificIterable(coll: Iterable[A]): Array[A] = Array.from(coll)
         def iterableFactory: IterableFactory[Iterable] = Iterable
-        protected[this] def newSpecificBuilder(): mutable.Builder[A, Array[A]] = Array.newBuilder
+        protected def newSpecificBuilder(): mutable.Builder[A, Array[A]] = Array.newBuilder
         def iterator(): Iterator[A] = a.iterator()
       }
     }

--- a/src/library/scala/collection/immutable/ImmutableArray.scala
+++ b/src/library/scala/collection/immutable/ImmutableArray.scala
@@ -24,7 +24,7 @@ sealed abstract class ImmutableArray[+A]
     with StrictOptimizedSeqOps[A, ImmutableArray, ImmutableArray[A]] {
 
   /** The tag of the element type */
-  protected[this] def elemTag: ClassTag[A]
+  protected def elemTag: ClassTag[A] @uncheckedVariance
 
   override def iterableFactory: SeqFactory[ImmutableArray] = ImmutableArray.untagged
 
@@ -34,9 +34,9 @@ sealed abstract class ImmutableArray[+A]
   // uncheckedVariance should be safe: Array[A] for reference types A is covariant at the JVM level. Array[A] for
   // primitive types A can only be widened to Array[Any] which erases to Object.
 
-  override protected[this] def fromSpecificIterable(coll: scala.collection.Iterable[A]): ImmutableArray[A] = ImmutableArray.from[A](coll)(elemTag)
+  override protected def fromSpecificIterable(coll: scala.collection.Iterable[A] @uncheckedVariance): ImmutableArray[A] = ImmutableArray.from[A](coll)(elemTag)
 
-  override protected[this] def newSpecificBuilder(): Builder[A, ImmutableArray[A]] = ImmutableArray.newBuilder[A]()(elemTag)
+  override protected def newSpecificBuilder(): Builder[A, ImmutableArray[A]] @uncheckedVariance = ImmutableArray.newBuilder[A]()(elemTag)
 
   @throws[ArrayIndexOutOfBoundsException]
   def apply(i: Int): A
@@ -200,7 +200,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   @SerialVersionUID(3L)
   final class ofByte(val unsafeArray: Array[Byte]) extends ImmutableArray[Byte] with Serializable {
-    protected[this] def elemTag = ClassTag.Byte
+    protected def elemTag = ClassTag.Byte
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Byte = unsafeArray(i)
@@ -213,7 +213,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   @SerialVersionUID(3L)
   final class ofShort(val unsafeArray: Array[Short]) extends ImmutableArray[Short] with Serializable {
-    protected[this] def elemTag = ClassTag.Short
+    protected def elemTag = ClassTag.Short
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Short = unsafeArray(i)
@@ -226,7 +226,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   @SerialVersionUID(3L)
   final class ofChar(val unsafeArray: Array[Char]) extends ImmutableArray[Char] with Serializable {
-    protected[this] def elemTag = ClassTag.Char
+    protected def elemTag = ClassTag.Char
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Char = unsafeArray(i)
@@ -239,7 +239,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   @SerialVersionUID(3L)
   final class ofInt(val unsafeArray: Array[Int]) extends ImmutableArray[Int] with Serializable {
-    protected[this] def elemTag = ClassTag.Int
+    protected def elemTag = ClassTag.Int
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Int = unsafeArray(i)
@@ -252,7 +252,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   @SerialVersionUID(3L)
   final class ofLong(val unsafeArray: Array[Long]) extends ImmutableArray[Long] with Serializable {
-    protected[this] def elemTag = ClassTag.Long
+    protected def elemTag = ClassTag.Long
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Long = unsafeArray(i)
@@ -265,7 +265,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   @SerialVersionUID(3L)
   final class ofFloat(val unsafeArray: Array[Float]) extends ImmutableArray[Float] with Serializable {
-    protected[this] def elemTag = ClassTag.Float
+    protected def elemTag = ClassTag.Float
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Float = unsafeArray(i)
@@ -278,7 +278,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   @SerialVersionUID(3L)
   final class ofDouble(val unsafeArray: Array[Double]) extends ImmutableArray[Double] with Serializable {
-    protected[this] def elemTag = ClassTag.Double
+    protected def elemTag = ClassTag.Double
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Double = unsafeArray(i)
@@ -291,7 +291,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   @SerialVersionUID(3L)
   final class ofBoolean(val unsafeArray: Array[Boolean]) extends ImmutableArray[Boolean] with Serializable {
-    protected[this] def elemTag = ClassTag.Boolean
+    protected def elemTag = ClassTag.Boolean
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Boolean = unsafeArray(i)
@@ -304,7 +304,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   @SerialVersionUID(3L)
   final class ofUnit(val unsafeArray: Array[Unit]) extends ImmutableArray[Unit] with Serializable {
-    protected[this] def elemTag = ClassTag.Unit
+    protected def elemTag = ClassTag.Unit
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Unit = unsafeArray(i)

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -10,9 +10,11 @@ package scala.collection
 package immutable
 
 import java.lang.IllegalStateException
+
 import scala.collection.generic.BitOperations
 import scala.collection.mutable.{Builder, ImmutableBuilder}
 import scala.annotation.tailrec
+import scala.annotation.unchecked.uncheckedVariance
 
 /** Utility class for integer maps.
   *  @author David MacIver
@@ -167,15 +169,15 @@ sealed abstract class IntMap[+T] extends Map[Int, T]
   with StrictOptimizedIterableOps[(Int, T), Iterable, IntMap[T]]
   with Serializable {
 
-  override protected[this] def fromSpecificIterable(coll: scala.collection.Iterable[(Int, T)]): IntMap[T] =
+  override protected def fromSpecificIterable(coll: scala.collection.Iterable[(Int, T) @uncheckedVariance]): IntMap[T] =
     intMapFromIterable[T](coll)
-  protected[this] def intMapFromIterable[V2](coll: scala.collection.Iterable[(Int, V2)]): IntMap[V2] = {
+  protected def intMapFromIterable[V2](coll: scala.collection.Iterable[(Int, V2)]): IntMap[V2] = {
     val b = IntMap.newBuilder[V2]()
     b.sizeHint(coll)
     b.addAll(coll)
     b.result()
   }
-  override protected[this] def newSpecificBuilder(): Builder[(Int, T), IntMap[T]] =
+  override protected def newSpecificBuilder(): Builder[(Int, T), IntMap[T]] @uncheckedVariance =
     new ImmutableBuilder[(Int, T), IntMap[T]](empty) {
       def addOne(elem: (Int, T)): this.type = { elems = elems + elem; this }
     }

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -185,7 +185,7 @@ import scala.collection.mutable.StringBuilder
 sealed abstract class LazyList[+A] extends LinearSeq[A] with LazyListOps[A, LazyList, LazyList[A]] {
   override def iterableFactory: LazyListFactory[LazyList] = LazyList
 
-  protected[this] def cons[T](hd: => T, tl: => LazyList[T]): LazyList[T] = new LazyList.Cons(hd, tl)
+  protected def cons[T](hd: => T, tl: => LazyList[T]): LazyList[T] = new LazyList.Cons(hd, tl)
 
   /** Apply the given function `f` to each element of this linear sequence
     * (while respecting the order of the elements).
@@ -229,7 +229,7 @@ sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with Laz
 
   def tail: C
 
-  protected[this] def cons[T](hd: => T, tl: => CC[T]): CC[T]
+  protected def cons[T](hd: => T, tl: => CC[T] @uncheckedVariance): CC[T]
 
   /** Forces evaluation of the whole `LazyList` and returns it.
     *
@@ -464,7 +464,7 @@ sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with Laz
 
 sealed private[immutable] trait LazyListFactory[+CC[+X] <: LinearSeq[X] with LazyListOps[X, CC, CC[X]]] extends SeqFactory[CC] {
 
-  protected[this] def newCons[T](hd: => T, tl: => CC[T]): CC[T]
+  protected def newCons[T](hd: => T, tl: => CC[T] @uncheckedVariance): CC[T]
 
   private[immutable] def withFilter[A](l: CC[A] @uncheckedVariance, p: A => Boolean): collection.WithFilter[A, CC] =
     new WithFilter[A](l, p)
@@ -552,7 +552,7 @@ sealed private[immutable] trait LazyListFactory[+CC[+X] <: LinearSeq[X] with Laz
   */
 object LazyList extends LazyListFactory[LazyList] {
 
-  protected[this] def newCons[T](hd: => T, tl: => LazyList[T]): LazyList[T] = new LazyList.Cons(hd, tl)
+  protected def newCons[T](hd: => T, tl: => LazyList[T]): LazyList[T] = new LazyList.Cons(hd, tl)
 
   object Empty extends LazyList[Nothing] {
     override def isEmpty: Boolean = true
@@ -659,7 +659,7 @@ sealed abstract class Stream[+A] extends LinearSeq[A] with LazyListOps[A, Stream
 
   override def className: String = "Stream"
 
-  protected[this] def cons[T](hd: => T, tl: => Stream[T]): Stream[T] = new Stream.Cons(hd, tl)
+  protected def cons[T](hd: => T, tl: => Stream[T]): Stream[T] = new Stream.Cons(hd, tl)
 
   /** Apply the given function `f` to each element of this linear sequence
     * (while respecting the order of the elements).
@@ -702,7 +702,7 @@ sealed abstract class Stream[+A] extends LinearSeq[A] with LazyListOps[A, Stream
 @deprecated("Use LazyList (which has a lazy head and tail) instead of Stream (which has a lazy tail only)", "2.13.0")
 object Stream extends LazyListFactory[Stream] {
 
-  protected[this] def newCons[T](hd: => T, tl: => Stream[T]): Stream[T] = new Stream.Cons(hd, tl)
+  protected def newCons[T](hd: => T, tl: => Stream[T]): Stream[T] = new Stream.Cons(hd, tl)
 
   object Empty extends Stream[Nothing] {
     override def isEmpty: Boolean = true

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -10,10 +10,12 @@ package scala.collection
 package immutable
 
 import java.lang.IllegalStateException
+
 import scala.collection.generic.BitOperations
 import scala.collection.mutable.{Builder, ImmutableBuilder, ListBuffer}
 import scala.annotation.tailrec
 import scala.annotation.tailrec
+import scala.annotation.unchecked.uncheckedVariance
 
 /** Utility class for long maps.
   *  @author David MacIver
@@ -160,14 +162,14 @@ sealed abstract class LongMap[+T] extends Map[Long, T]
   with StrictOptimizedIterableOps[(Long, T), Iterable, LongMap[T]]
   with Serializable {
 
-  override protected[this] def fromSpecificIterable(coll: scala.collection.Iterable[(Long, T)]): LongMap[T] = {
+  override protected def fromSpecificIterable(coll: scala.collection.Iterable[(Long, T)] @uncheckedVariance): LongMap[T] = {
     //TODO should this be the default implementation of this method in StrictOptimizedIterableOps?
     val b = newSpecificBuilder()
     b.sizeHint(coll)
     b.addAll(coll)
     b.result()
   }
-  override protected[this] def newSpecificBuilder(): Builder[(Long, T), LongMap[T]] =
+  override protected def newSpecificBuilder(): Builder[(Long, T), LongMap[T]] @uncheckedVariance =
     new ImmutableBuilder[(Long, T), LongMap[T]](empty) {
       def addOne(elem: (Long, T)): this.type = { elems = elems + elem; this }
     }

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -2,6 +2,7 @@ package scala
 package collection
 package immutable
 
+import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.mutable.Builder
 
 
@@ -47,7 +48,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   extends IterableOps[(K, V), Iterable, C]
     with collection.MapOps[K, V, CC, C] {
 
-  protected[this] def coll: C with CC[K, V]
+  protected def coll: C with CC[K, V]
 
   /** Removes a key from this map, returning a new map.
     *
@@ -150,10 +151,10 @@ object Map extends MapFactory[Map] {
 
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 
-    override protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): WithDefault[K, V] =
+    override protected def fromSpecificIterable(coll: collection.Iterable[(K, V)] @uncheckedVariance): WithDefault[K, V] =
       new WithDefault[K, V](mapFactory.from(coll), defaultValue)
 
-    override protected[this] def newSpecificBuilder(): Builder[(K, V), WithDefault[K, V]] =
+    override protected def newSpecificBuilder(): Builder[(K, V), WithDefault[K, V]] @uncheckedVariance =
       Map.newBuilder().mapResult((p: Map[K, V]) => new WithDefault[K, V](p, defaultValue))
   }
 

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -2,6 +2,7 @@ package scala
 package collection
 package immutable
 
+import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.mutable.Builder
 
 trait SortedMap[K, +V]
@@ -37,7 +38,7 @@ trait SortedMap[K, +V]
 trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
   extends MapOps[K, V, Map, C]
      with collection.SortedMapOps[K, V, CC, C] { self =>
-    protected[this] def coll: C with CC[K, V]
+    protected def coll: C with CC[K, V]
 
     override def keySet: SortedSet[K] = new ImmutableKeySortedSet
 
@@ -95,10 +96,10 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 
-    override protected[this] def fromSpecificIterable(coll: scala.collection.Iterable[(K, V)]): WithDefault[K, V] =
+    override protected def fromSpecificIterable(coll: scala.collection.Iterable[(K, V)] @uncheckedVariance): WithDefault[K, V] =
       new WithDefault[K, V](sortedMapFactory.from(coll), defaultValue)
 
-    override protected[this] def newSpecificBuilder(): Builder[(K, V), WithDefault[K, V]] =
+    override protected def newSpecificBuilder(): Builder[(K, V), WithDefault[K, V]] @uncheckedVariance =
       SortedMap.newBuilder().mapResult((p: SortedMap[K, V]) => new WithDefault[K, V](p, defaultValue))
   }
 }

--- a/src/library/scala/collection/immutable/WrappedString.scala
+++ b/src/library/scala/collection/immutable/WrappedString.scala
@@ -22,9 +22,9 @@ final class WrappedString(val self: String) extends AbstractSeq[Char] with Index
 
   def apply(i: Int): Char = self.charAt(i)
 
-  override protected[this] def fromSpecificIterable(coll: scala.collection.Iterable[Char]): WrappedString =
+  override protected def fromSpecificIterable(coll: scala.collection.Iterable[Char]): WrappedString =
     WrappedString.fromSpecific(coll)
-  override protected[this] def newSpecificBuilder(): Builder[Char, WrappedString] = WrappedString.newBuilder()
+  override protected def newSpecificBuilder(): Builder[Char, WrappedString] = WrappedString.newBuilder()
 
   override def slice(from: Int, until: Int): WrappedString = {
     val start = if (from < 0) 0 else from

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -73,7 +73,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
     mask = m; _size = sz; _vacant = vc; _hashes = hz; _keys = kz; _values = vz
   }
 
-  override protected[this] def fromSpecificIterable(coll: scala.collection.Iterable[(K, V)]): AnyRefMap[K,V] = {
+  override protected def fromSpecificIterable(coll: scala.collection.Iterable[(K, V)]): AnyRefMap[K,V] = {
     var sz = coll.knownSize
     if(sz < 0) sz = 4
     val arm = new AnyRefMap[K, V](sz * 2)
@@ -81,7 +81,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
     if (arm.size < (sz>>3)) arm.repack()
     arm
   }
-  override protected[this] def newSpecificBuilder(): Builder[(K, V), AnyRefMap[K,V]] = new AnyRefMapBuilder
+  override protected def newSpecificBuilder(): Builder[(K, V), AnyRefMap[K,V]] = new AnyRefMapBuilder
 
   override def size: Int = _size
   override def empty: AnyRefMap[K,V] = new AnyRefMap(defaultEntry)

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -14,6 +14,8 @@ import java.util.NoSuchElementException
   *  take amortized constant time. In general, removals and insertions at i-th index are O(min(i, n-i))
   *  and thus insertions and removals from end/beginning are fast.
   *
+  *  @note Subclasses ''must'' override the `ofArray` protected method to return a more specific type.
+  *
   *  @author  Pathikrit Bhowmick
   *  @version 2.13
   *  @since   2.13
@@ -368,7 +370,7 @@ class ArrayDeque[A] protected (
     elems.result()
   }
 
-  override def reverse: ArrayDeque[A] = {
+  override def reverse: IterableCC[A] = {
     val n = length
     val arr = ArrayDeque.alloc(n)
     var i = 0
@@ -376,7 +378,7 @@ class ArrayDeque[A] protected (
       arr(i) = this(n - i - 1).asInstanceOf[AnyRef]
       i += 1
     }
-    new ArrayDeque(arr, start = 0, end = n)
+    ofArray(arr, n)
   }
 
   @inline def ensureSize(hint: Int) = if (hint > length && isResizeNecessary(hint)) resize(hint + 1)
@@ -428,13 +430,13 @@ class ArrayDeque[A] protected (
   protected def ofArray(array: Array[AnyRef], end: Int): ArrayDeque[A] =
     new ArrayDeque[A](array, start = 0, end)
 
-  override def sliding(window: Int, step: Int): Iterator[ArrayDeque[A]] = {
+  override def sliding(window: Int, step: Int): Iterator[IterableCC[A]] = {
     require(window > 0 && step > 0, s"window=$window and step=$step, but both must be positive")
     val lag = if (window > step) window - step else 0
     Iterator.range(start = 0, end = length - lag, step = step).map(i => slice(i, i + window))
   }
 
-  override def grouped(n: Int): Iterator[ArrayDeque[A]] = sliding(n, n)
+  override def grouped(n: Int): Iterator[IterableCC[A]] = sliding(n, n)
 
   override def copyToArray[B >: A](dest: Array[B], destStart: Int, len: Int): dest.type =
     copySliceToArray(srcStart = 0, dest = dest, destStart = destStart, maxItems = len)

--- a/src/library/scala/collection/mutable/Builder.scala
+++ b/src/library/scala/collection/mutable/Builder.scala
@@ -102,10 +102,10 @@ class StringBuilder(private val sb: java.lang.StringBuilder) extends Builder[Cha
   // Methods required to make this an IndexedSeq:
   def apply(i: Int): Char = sb.charAt(i)
 
- override protected[this] def fromSpecificIterable(coll: scala.collection.Iterable[Char]): StringBuilder =
+ override protected def fromSpecificIterable(coll: scala.collection.Iterable[Char]): StringBuilder =
     new StringBuilder() ++= coll
 
-  override protected[this] def newSpecificBuilder(): Builder[Char, StringBuilder] =
+  override protected def newSpecificBuilder(): Builder[Char, StringBuilder] =
     new GrowableBuilder(new StringBuilder())
 
   def length: Int = sb.length()

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -34,14 +34,14 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
   def this() = this(LongMap.exceptionDefault, 16, true)
 
   def clear(): Unit = { keysIterator() foreach -= } // TODO optimize
-  override protected[this] def fromSpecificIterable(coll: scala.collection.Iterable[(Long, V)]): LongMap[V] = {
+  override protected def fromSpecificIterable(coll: scala.collection.Iterable[(Long, V)]): LongMap[V] = {
     //TODO should this be the default implementation of this method in StrictOptimizedIterableOps?
     val b = newSpecificBuilder()
     b.sizeHint(coll)
     b.addAll(coll)
     b.result()
   }
-  override protected[this] def newSpecificBuilder(): Builder[(Long, V),LongMap[V]] = new GrowableBuilder(LongMap.empty[V])
+  override protected def newSpecificBuilder(): Builder[(Long, V),LongMap[V]] = new GrowableBuilder(LongMap.empty[V])
 
   /** Creates a new `LongMap` that returns default values according to a supplied key-value mapping. */
   def this(defaultEntry: Long => V) = this(defaultEntry, 16, true)

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -189,10 +189,10 @@ object Map extends MapFactory.Delegate[Map](HashMap) {
 
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 
-    override protected[this] def fromSpecificIterable(coll: scala.collection.Iterable[(K, V)]): WithDefault[K, V] =
+    override protected def fromSpecificIterable(coll: scala.collection.Iterable[(K, V)]): WithDefault[K, V] =
       new WithDefault[K, V](mapFactory.from(coll), defaultValue)
 
-    override protected[this] def newSpecificBuilder(): Builder[(K, V), WithDefault[K, V]] =
+    override protected def newSpecificBuilder(): Builder[(K, V), WithDefault[K, V]] =
       Map.newBuilder().mapResult((p: Map[K, V]) => new WithDefault[K, V](p, defaultValue))
   }
 

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -78,8 +78,8 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   override def size: Int = length
   override def isEmpty: Boolean = resarr.p_size0 < 2
 
-  override protected[this] def fromSpecificIterable(coll: scala.collection.Iterable[A]): PriorityQueue[A] = PriorityQueue.from(coll)
-  override protected[this] def newSpecificBuilder(): Builder[A, PriorityQueue[A]] = PriorityQueue.newBuilder()
+  override protected def fromSpecificIterable(coll: scala.collection.Iterable[A]): PriorityQueue[A] = PriorityQueue.from(coll)
+  override protected def newSpecificBuilder(): Builder[A, PriorityQueue[A]] = PriorityQueue.newBuilder()
 
   def mapInPlace(f: A => A): this.type = {
     resarr.mapInPlace(f)

--- a/src/library/scala/collection/mutable/RedBlackTree.scala
+++ b/src/library/scala/collection/mutable/RedBlackTree.scala
@@ -476,7 +476,7 @@ private[collection] object RedBlackTree {
   private[this] abstract class TreeIterator[A, B, R](tree: Tree[A, B], start: Option[A], end: Option[A])
                                                     (implicit ord: Ordering[A]) extends Iterator[R] {
 
-    protected[this] def nextResult(node: Node[A, B]): R
+    protected def nextResult(node: Node[A, B]): R
 
     def hasNext: Boolean = nextNode ne null
 

--- a/src/library/scala/collection/mutable/SortedMap.scala
+++ b/src/library/scala/collection/mutable/SortedMap.scala
@@ -68,10 +68,10 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 
-    override protected[this] def fromSpecificIterable(coll: scala.collection.Iterable[(K, V)]): WithDefault[K, V] =
+    override protected def fromSpecificIterable(coll: scala.collection.Iterable[(K, V)]): WithDefault[K, V] =
       new WithDefault[K, V](sortedMapFactory.from(coll), defaultValue)
 
-    override protected[this] def newSpecificBuilder(): Builder[(K, V), WithDefault[K, V]] =
+    override protected def newSpecificBuilder(): Builder[(K, V), WithDefault[K, V]] =
       SortedMap.newBuilder().mapResult((p: SortedMap[K, V]) => new WithDefault[K, V](p, defaultValue))
   }
 }

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -63,8 +63,8 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
   private[collection] def lastPtr_=(last: Unrolled[T]) = lastptr = last
   private[collection] def size_=(s: Int) = sz = s
 
-  override protected[this] def fromSpecificIterable(coll: scala.collection.Iterable[T]) = UnrolledBuffer.from(coll)
-  override protected[this] def newSpecificBuilder(): Builder[T, UnrolledBuffer[T]] = new UnrolledBuffer[T]
+  override protected def fromSpecificIterable(coll: scala.collection.Iterable[T]) = UnrolledBuffer.from(coll)
+  override protected def newSpecificBuilder(): Builder[T, UnrolledBuffer[T]] = new UnrolledBuffer[T]
 
   override def iterableFactory: SeqFactory[UnrolledBuffer] = UnrolledBuffer.untagged
 

--- a/src/library/scala/collection/mutable/WrappedArray.scala
+++ b/src/library/scala/collection/mutable/WrappedArray.scala
@@ -34,14 +34,14 @@ abstract class WrappedArray[T]
 
   override def iterableFactory: scala.collection.SeqFactory[WrappedArray] = WrappedArray.untagged
 
-  override protected[this] def fromSpecificIterable(coll: scala.collection.Iterable[T]): WrappedArray[T] = {
+  override protected def fromSpecificIterable(coll: scala.collection.Iterable[T]): WrappedArray[T] = {
     val b = ArrayBuilder.make()(elemTag)
     val s = coll.knownSize
     if(s > 0) b.sizeHint(s)
     b ++= coll
     WrappedArray.make(b.result())
   }
-  override protected[this] def newSpecificBuilder(): Builder[T, WrappedArray[T]] = WrappedArray.newBuilder()(elemTag)
+  override protected def newSpecificBuilder(): Builder[T, WrappedArray[T]] = WrappedArray.newBuilder()(elemTag)
 
   /** The tag of the element type */
   def elemTag: ClassTag[T]

--- a/test/files/neg/abstract-report.check
+++ b/test/files/neg/abstract-report.check
@@ -7,10 +7,10 @@ it has 6 unimplemented members.
   def iterator(): Iterator[String] = ???
 
   // Members declared in scala.collection.IterableOps
-  protected[this] def coll: List[String] = ???
-  protected[this] def fromSpecificIterable(coll: Iterable[String]): List[String] = ???
+  protected def coll: List[String] = ???
+  protected def fromSpecificIterable(coll: Iterable[String]): List[String] = ???
   def iterableFactory: scala.collection.IterableFactory[[X]List[X]] = ???
-  protected[this] def newSpecificBuilder(): scala.collection.mutable.Builder[String,List[String]] = ???
+  protected def newSpecificBuilder(): scala.collection.mutable.Builder[String,List[String]] = ???
   def toIterable: Iterable[String] = ???
 
 class Unimplemented extends scala.collection.IterableOps[String, List, List[String]] { }

--- a/test/files/neg/abstract-report2.check
+++ b/test/files/neg/abstract-report2.check
@@ -70,10 +70,10 @@ it has 7 unimplemented members.
   def iterator(): Iterator[(Set[Int], String)] = ???
 
   // Members declared in scala.collection.IterableOps
-  protected[this] def coll: List[(Set[Int], String)] = ???
-  protected[this] def fromSpecificIterable(coll: Iterable[(Set[Int], String)]): List[(Set[Int], String)] = ???
+  protected def coll: List[(Set[Int], String)] = ???
+  protected def fromSpecificIterable(coll: Iterable[(Set[Int], String)]): List[(Set[Int], String)] = ???
   def iterableFactory: scala.collection.IterableFactory[[X]List[X]] = ???
-  protected[this] def newSpecificBuilder(): scala.collection.mutable.Builder[(Set[Int], String),List[(Set[Int], String)]] = ???
+  protected def newSpecificBuilder(): scala.collection.mutable.Builder[(Set[Int], String),List[(Set[Int], String)]] = ???
   def toIterable: Iterable[(Set[Int], String)] = ???
 
   // Members declared in Xyz

--- a/test/files/neg/noMember1.check
+++ b/test/files/neg/noMember1.check
@@ -1,5 +1,5 @@
-noMember1.scala:1: error: object IterableOps is not a member of package collection
-Note: trait IterableOps exists, but it has no companion object.
-import scala.collection.IterableOps._
+noMember1.scala:1: error: object IterableOnceOps is not a member of package collection
+Note: trait IterableOnceOps exists, but it has no companion object.
+import scala.collection.IterableOnceOps._
                         ^
 one error found

--- a/test/files/neg/noMember1.scala
+++ b/test/files/neg/noMember1.scala
@@ -1,3 +1,3 @@
-import scala.collection.IterableOps._
+import scala.collection.IterableOnceOps._
 
 class A

--- a/test/files/neg/noMember2.check
+++ b/test/files/neg/noMember2.check
@@ -1,5 +1,5 @@
-noMember2.scala:2: error: object IterableOps is not a member of package collection
-Note: trait IterableOps exists, but it has no companion object.
-  val m = scala.collection.IterableOps(1, 2, 3)
+noMember2.scala:2: error: object IterableOnceOps is not a member of package collection
+Note: trait IterableOnceOps exists, but it has no companion object.
+  val m = scala.collection.IterableOnceOps(1, 2, 3)
                            ^
 one error found

--- a/test/files/neg/noMember2.scala
+++ b/test/files/neg/noMember2.scala
@@ -1,3 +1,3 @@
 object Test {
-  val m = scala.collection.IterableOps(1, 2, 3)
+  val m = scala.collection.IterableOnceOps(1, 2, 3)
 }

--- a/test/files/run/t4535.check
+++ b/test/files/run/t4535.check
@@ -1,3 +1,3 @@
-ArrayDeque(1, 2, 3)
-ArrayDeque(1, 2, 3, 4, 5, 6)
+Stack(1, 2, 3)
+Stack(1, 2, 3, 4, 5, 6)
 Stack(6, 5, 4, 3, 2, 1)

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -30,7 +30,7 @@ class ArrayOpsTest {
   @Test
   def reverseIterator: Unit = {
     val a = Array(1,2,3)
-    assertEquals(List(3,2,1), a.reverseIterator.toList)
+    assertEquals(List(3,2,1), a.reverseIterator().toList)
   }
 
   @Test

--- a/test/junit/scala/collection/immutable/ChampMapSmokeTest.scala
+++ b/test/junit/scala/collection/immutable/ChampMapSmokeTest.scala
@@ -11,7 +11,7 @@ object ChampMapSmokeTest {
   private def mapOf[K, V](keyValuePairs: (K, V)*): ChampHashMap[K, V] = {
     val builder = ChampHashMap.newBuilder[K, V]()
     keyValuePairs.foreach(builder.addOne)
-    builder.result
+    builder.result()
   }
 
   def mkTuple[KV](keyValue: KV): (KV, KV) = keyValue -> keyValue

--- a/test/junit/scala/collection/immutable/ImmutableArrayTest.scala
+++ b/test/junit/scala/collection/immutable/ImmutableArrayTest.scala
@@ -5,6 +5,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.reflect.ClassTag
+
 @RunWith(classOf[JUnit4])
 class ImmutableArrayTest {
   @Test
@@ -42,20 +44,20 @@ class ImmutableArrayTest {
 
     def unit1(): Unit = {}
     def unit2(): Unit = {}
-    Assert.assertEquals(unit1, unit2)
+    Assert.assertEquals(unit1(), unit2())
     // unitArray is actually an instance of Immutable[BoxedUnit], the check to which is actually checked slice
     // implementation of ofRef
-    val unitArray: ImmutableArray[Unit] = Array(unit1, unit2, unit1, unit2)
-    check(unitArray, Array(unit1, unit1), Array(unit1, unit1))
+    val unitArray: ImmutableArray[Unit] = Array(unit1(), unit2(), unit1(), unit2())
+    check(unitArray, Array(unit1(), unit1()), Array(unit1(), unit1()))
   }
 
-  private def check[T](array: ImmutableArray[T], expectedSliceResult1: ImmutableArray[T], expectedSliceResult2: ImmutableArray[T]) {
+  private def check[T : ClassTag](array: ImmutableArray[T], expectedSliceResult1: ImmutableArray[T], expectedSliceResult2: ImmutableArray[T]) {
     Assert.assertEquals(array, array.slice(-1, 4))
     Assert.assertEquals(array, array.slice(0, 5))
     Assert.assertEquals(array, array.slice(-1, 5))
     Assert.assertEquals(expectedSliceResult1, array.slice(0, 2))
     Assert.assertEquals(expectedSliceResult2, array.slice(1, 3))
-    Assert.assertEquals(ImmutableArray.empty[Nothing], array.slice(1, 1))
-    Assert.assertEquals(ImmutableArray.empty[Nothing], array.slice(2, 1))
+    Assert.assertEquals(ImmutableArray.empty[T], array.slice(1, 1))
+    Assert.assertEquals(ImmutableArray.empty[T], array.slice(2, 1))
   }
 }

--- a/test/junit/scala/collection/mutable/QueueTest.scala
+++ b/test/junit/scala/collection/mutable/QueueTest.scala
@@ -1,0 +1,18 @@
+package scala.collection.mutable
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import scala.collection.IterableFactory
+
+@RunWith(classOf[JUnit4])
+class QueueTest {
+
+  @Test
+  def reversingReturnsAQueue(): Unit = {
+    val q1 = Queue(1, 2, 3)
+    val q2: Queue[Int] = q1.reverse
+    assertEquals("Queue", q2.className)
+  }
+}

--- a/test/junit/scala/collection/mutable/StackTest.scala
+++ b/test/junit/scala/collection/mutable/StackTest.scala
@@ -1,0 +1,18 @@
+package scala.collection.mutable
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import scala.collection.IterableFactory
+
+@RunWith(classOf[JUnit4])
+class StackTest {
+
+  @Test
+  def reversingReturnsAStack(): Unit = {
+    val s1 = Stack(1, 2, 3)
+    val s2: Stack[Int] = s1.reverse
+    assertEquals("Stack", s2.className)
+  }
+}


### PR DESCRIPTION
Insert explicit `@uncheckedVariance` annotations even for `private[this]` and `protected[this]` members.

This commit is a port of scala/collection-strawman#521.

These changes are not required by the Scala compiler, but they will be required if the Dotty project wants to compile the Scala collections. Or, if we disable the `protected[this]`/`private[this]` escape hatch in Scala too. For reference, here is the Dotty PR that made these changes required to be able to compile the collections with Dotty: lampepfl/dotty#4013

Fixes https://github.com/scala/collection-strawman/issues/475, scala/collection-strawman#505 and scala/collection-strawman#547.