### PR TITLE
Add deprecated TraversableOnce aliases

### DIFF
--- a/src/library/scala/collection/package.scala
+++ b/src/library/scala/collection/package.scala
@@ -6,6 +6,10 @@ package object collection extends LowPriority {
   type Traversable[+X] = Iterable[X]
   @deprecated("Use Iterable instead of Traversable", "2.13.0")
   val Traversable = Iterable
+  @deprecated("Use IterableOnce instead of TraversableOnce", "2.13.0")
+  type TraversableOnce[+X] = IterableOnce[X]
+  @deprecated("Use IterableOnce instead of TraversableOnce", "2.13.0")
+  val TraversableOnce = IterableOnce
   @deprecated("Use SeqOps instead of SeqLike", "2.13.0")
   type SeqLike[A, T] = SeqOps[A, Seq, T]
   @deprecated("Use SeqOps (for the methods) or IndexedSeqOps (for fast indexed access) instead of ArrayLike", "2.13.0")


### PR DESCRIPTION
Fixes https://github.com/scala/collection-strawman/issues/552