### PR TITLE
Add -Xlint:non-local-return, to warn on non-local returns.

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -103,6 +103,7 @@ trait Warnings {
     val StarsAlign             = LintWarning("stars-align",               "Pattern sequence wildcard must align with sequence component.")
     val Constant               = LintWarning("constant",                  "Evaluation of a constant arithmetic expression results in an error.")
     val Unused                 = LintWarning("unused",                    "Enable -Ywarn-unused:imports,privates,locals,implicits.")
+    val NonLocalReturn         = LintWarning("non-local-return",          "Warn whenever a `return` statement will use exceptions for control flow.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
   }
@@ -126,6 +127,7 @@ trait Warnings {
   def warnStarsAlign             = lint contains StarsAlign
   def warnConstant               = lint contains Constant
   def lintUnused                 = lint contains Unused
+  def warnNonLocalReturn         = lint contains NonLocalReturn
 
   // Lint warnings that are currently -Y, but deprecated in that usage
   @deprecated("Use warnAdaptedArgs", since="2.11.2")

--- a/test/files/neg/lint-non-local-return.check
+++ b/test/files/neg/lint-non-local-return.check
@@ -1,0 +1,18 @@
+lint-non-local-return.scala:6: warning: this `return` statement is invoked in a lazy val and will use an exception for control flow.
+    lazy val lzy: Int = return i * 2                // non-local
+                        ^
+lint-non-local-return.scala:10: warning: this `return` statement is invoked in an anonymous function and will use an exception for control flow.
+    else if (i == 2) invoke  { return i }           // non-local
+                               ^
+lint-non-local-return.scala:11: warning: this `return` statement is invoked in an anonymous function and will use an exception for control flow.
+    else if (i == 3) invoke1 { _ => return i }      // non-local
+                                    ^
+lint-non-local-return.scala:12: warning: this `return` statement is invoked in an anonymous function and will use an exception for control flow.
+    else if (i == 4) collect { case _ => return i } // non-local; cf. run/t10291.scala
+                                         ^
+lint-non-local-return.scala:31: warning: this `return` statement is invoked in an anonymous function and will use an exception for control flow.
+    ( try { 10/i } catch { case _: Exception => return 0 } ) + 1
+                                                ^
+error: No warnings can be incurred under -Xfatal-warnings.
+5 warnings found
+one error found

--- a/test/files/neg/lint-non-local-return.flags
+++ b/test/files/neg/lint-non-local-return.flags
@@ -1,0 +1,1 @@
+-Xlint:non-local-return -Xfatal-warnings

--- a/test/files/neg/lint-non-local-return.scala
+++ b/test/files/neg/lint-non-local-return.scala
@@ -1,0 +1,42 @@
+object Test {
+
+  def test(i: Int): Int = {
+    def escape(x: Int): Int = return x + 1          //     local
+
+    lazy val lzy: Int = return i * 2                // non-local
+
+         if (i == 0) i
+    else if (i == 1) return i                       //     local
+    else if (i == 2) invoke  { return i }           // non-local
+    else if (i == 3) invoke1 { _ => return i }      // non-local
+    else if (i == 4) collect { case _ => return i } // non-local; cf. run/t10291.scala
+    else if (i == 5) escape(i)
+    else if (i == 6) lzy
+    else             i
+  }
+
+  def invoke[T](fn: => T): T = fn
+
+  def invoke1(f: Int => Int): Int = f(4)
+
+  def collect(f: PartialFunction[Int, Int]): Int = f(5)
+}
+
+object Ichoran {
+
+  def trivial(i: Int): Int =
+    try {10/i } catch { case _: Exception => return 0 }
+
+  def simple(i: Int): Int =
+    ( try { 10/i } catch { case _: Exception => return 0 } ) + 1
+
+  def expanded(i: Int): Int = {
+    val temp = try { 10/i } catch { case _: Exception => return 0 }
+    temp + 1
+  }
+
+  def alternate(i: Int): Int = {
+    (try { 10/i } catch { case _: Exception => -1 }) + 1
+
+  }
+}


### PR DESCRIPTION
Inspired by conversation on scala/bug#10820.

I'm not prepared for arguments as to its appropriateness, but I'm very prepared for arguments over the wording.