### PR TITLE
Implements dequeueAll reusing idea from Buffer filterInPlace collection-strawman#530

### DIFF
--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -163,7 +163,7 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
     *                The order of the elements is preserved.
     */
   def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] =
-    flatMap { (kv: (K, V)) =>
+    flatMap { kv =>
       if (pf.isDefinedAt(kv)) new View.Single(pf(kv))
       else View.Empty
     }

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -96,7 +96,25 @@ class Queue[A] protected (array: Array[AnyRef], start: Int, end: Int)
     *  @param f   the predicate used for choosing elements
     *  @return
     */
-  def dequeueAll(f: A => Boolean): scala.collection.immutable.Seq[A] = removeHeadWhile(f)
+  def dequeueAll(f: A => Boolean): scala.collection.immutable.Seq[A] = {
+    val elems = scala.collection.immutable.Seq.newBuilder[A]()
+    var i, j = 0
+    while (i < size) {
+      if (!f(apply(i))) {
+        if (i != j) {
+          this(j) = this(i)
+        }
+        j += 1
+      } else {
+        elems  += this(i)
+      }
+      i += 1
+    }
+
+    if (i == j) this else takeInPlace(j)
+
+    elems.result()
+  }
 
   /** Returns the first element in the queue, or throws an error if there
     *  is no element contained in the queue.

--- a/test/junit/scala/collection/FactoriesTest.scala
+++ b/test/junit/scala/collection/FactoriesTest.scala
@@ -80,12 +80,12 @@ class FactoriesTest {
         immutable.LazyList,
         immutable.Vector,
         immutable.ImmutableArray.untagged,
-        mutable.ListBuffer: SeqFactory[mutable.ListBuffer], // type ascription needed by dotty
-        mutable.ArrayBuffer: SeqFactory[mutable.ArrayBuffer] // type ascription needed by dotty
+        mutable.ListBuffer,
+        mutable.ArrayBuffer
       )
 
     val iterableFactories: List[IterableFactory[Iterable]] =
-      (immutable.HashSet: IterableFactory[immutable.HashSet]) :: // type ascription needed by dotty
+      immutable.HashSet ::
       mutable.HashSet ::
       (seqFactories: List[IterableFactory[Iterable]])
 

--- a/test/junit/scala/collection/mutable/QueueTest.scala
+++ b/test/junit/scala/collection/mutable/QueueTest.scala
@@ -1,23 +1,12 @@
-import scala.collection.mutable.Queue
+package scala.collection.mutable
 
-object Test {
-  // TODO-newColl: remove this workaround, https://github.com/scala/collection-strawman/issues/530
-  implicit class DQA(val q: Queue[Int]) {
-    def dqa(p: Int => Boolean) = {
-      val es = q.filter(p)
-      q.filterInPlace(x => !p(x))
-      es
-    }
-  }
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
 
-  def main(args: Array[String]) {
-    testEmpty
-    testEnqueue
-    testTwoEnqueues
-    testFewEnqueues
-    testMoreEnqueues
-  }
-
+@RunWith(classOf[JUnit4])
+class QueueTest {
+  @Test
   def testEmpty {
     val queue = new Queue[Int]
 
@@ -25,16 +14,17 @@ object Test {
     assert(queue.size == 0)
     assert(queue.length == 0)
     assert(queue.dequeueFirst(_ > 500) == None)
-    assert(queue.dqa(_ > 500).isEmpty)
+    assert(queue.dequeueAll(_ > 500).isEmpty)
 
     queue.clear
     assert(queue.isEmpty)
     assert(queue.size == 0)
     assert(queue.length == 0)
     assert(queue.dequeueFirst(_ > 500) == None)
-    assert(queue.dqa(_ > 500).isEmpty)
+    assert(queue.dequeueAll(_ > 500).isEmpty)
   }
 
+  @Test
   def testEnqueue {
     val queue = new Queue[Int]
 
@@ -72,6 +62,7 @@ object Test {
     assert(queue.isEmpty && queue.length == 0)
   }
 
+  @Test
   def testTwoEnqueues {
     val queue = new Queue[Int]
     queue.enqueue(30)
@@ -82,7 +73,7 @@ object Test {
     assert(queue.nonEmpty)
     assert(queue.front == 30)
 
-    val all = queue.dqa(_ > 20)
+    val all = queue.dequeueAll(_ > 20)
     assert(all.size == 2)
     assert(all.contains(30))
     assert(all.contains(40))
@@ -90,6 +81,7 @@ object Test {
     assert(queue.isEmpty)
   }
 
+  @Test
   def testFewEnqueues {
     val queue = new Queue[Int]
     queue.enqueue(10)
@@ -120,7 +112,7 @@ object Test {
     assert(queue.length == 1)
 
     queue.enqueue(40)
-    val all = queue.dqa(_ > 20)
+    val all = queue.dequeueAll(_ > 20)
     assert(all.size == 2)
     assert(all.contains(30))
     assert(all.contains(40))
@@ -129,14 +121,14 @@ object Test {
 
     queue.enqueue(50)
     queue.enqueue(60)
-    val allgt55 = queue.dqa(_ > 55)
+    val allgt55 = queue.dequeueAll(_ > 55)
     assert(allgt55.size == 1)
     assert(allgt55.contains(60))
     assert(queue.length == 1)
 
     queue.enqueue(70)
     queue.enqueue(80)
-    val alllt75 = queue.dqa(_ < 75)
+    val alllt75 = queue.dequeueAll(_ < 75)
     assert(alllt75.size == 2)
     assert(alllt75.contains(70))
     assert(alllt75.contains(50))
@@ -146,6 +138,7 @@ object Test {
     assert(queue.front == 80)
   }
 
+  @Test
   def testMoreEnqueues {
     val queue = new Queue[Int]
     for (i <- 0 until 10) queue.enqueue(i * 2)
@@ -162,7 +155,7 @@ object Test {
     assert(queue.length == 10)
     assert(queue.nonEmpty)
 
-    val gt5 = queue.dqa(_ > 4)
+    val gt5 = queue.dequeueAll(_ > 4)
     assert(gt5.size == 7)
     assert(queue.length == 3)
     assert(queue.nonEmpty)
@@ -174,14 +167,14 @@ object Test {
     for (i <- 0 until 10) queue.enqueue(i)
     assert(queue.length == 10)
 
-    val even = queue.dqa(_ % 2 == 0)
+    val even = queue.dequeueAll(_ % 2 == 0)
     assert(even.size == 5)
     assert(even.sameElements(List(0, 2, 4, 6, 8)))
     assert(queue.length == 5)
     assert(queue.head == 1)
     assert(queue.last == 9)
 
-    val odd = queue.dqa(_ %2 == 1)
+    val odd = queue.dequeueAll(_ %2 == 1)
     assert(odd.size == 5)
     assert(queue.length == 0)
     assert(queue.isEmpty)
@@ -197,7 +190,7 @@ object Test {
     assert(queue.length == 9)
     assert(queue.nonEmpty)
 
-    val lt30 = queue.dqa(_ < 30)
+    val lt30 = queue.dequeueAll(_ < 30)
     assert(lt30.size == 6)
     assert(queue.length == 3)
 
@@ -225,7 +218,7 @@ object Test {
     assert(queue.isEmpty)
 
     for (i <- 0 until 4) queue.enqueue(i)
-    val interv = queue.dqa(n => n > 0 && n < 3)
+    val interv = queue.dequeueAll(n => n > 0 && n < 3)
     assert(interv.sameElements(List(1, 2)))
     assert(queue.length == 2)
     assert(queue.head == 0)
@@ -244,14 +237,14 @@ object Test {
     for (i <- -100 until 100) queue.enqueue(i * i + i % 7 + 5)
     assert(queue.length == 200)
 
-    val manyodds = queue.dqa(_ % 2 == 1)
+    val manyodds = queue.dequeueAll(_ % 2 == 1)
     assert((manyodds.size + queue.length) == 200)
 
-    queue.dqa(_ > -10000)
+    queue.dequeueAll(_ > -10000)
     assert(queue.isEmpty)
 
     for (i <- 0 until 100) queue.enqueue(i)
-    val multof3 = queue.dqa(_ % 3 == 0)
+    val multof3 = queue.dequeueAll(_ % 3 == 0)
     assert(multof3.size == 34)
     assert(queue.size == 66)
 


### PR DESCRIPTION
The algorithm follow Buffer.filterInPlace, but instead of keeping the elements matching predicate, we skip it and store it in new elems collection, in the queue keeping only the ones that does not match the condition.

Fixes [collection-strawman#530](https://github.com/scala/collection-strawman/issues/530)

I also removed the work around on test/files/run/QueueTest.scala and move it into JUnit.

--hopefullynotbitingmorethanIcanchew--