### PR TITLE
Use a final module instance field, assigned in <clinit> where possible

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -562,18 +562,13 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
         case Apply(fun @ Select(sup @ Super(superQual, _), _), args) =>
           def initModule(): Unit = {
             // we initialize the MODULE$ field immediately after the super ctor
-            if (!isModuleInitialized &&
+            if (!initModuleInClinit && !isModuleInitialized &&
               jMethodName == INSTANCE_CONSTRUCTOR_NAME &&
               fun.symbol.javaSimpleName.toString == INSTANCE_CONSTRUCTOR_NAME &&
               isStaticModuleClass(claszSymbol)) {
               isModuleInitialized = true
               mnode.visitVarInsn(asm.Opcodes.ALOAD, 0)
-              mnode.visitFieldInsn(
-                asm.Opcodes.PUTSTATIC,
-                thisBType.internalName,
-                strMODULE_INSTANCE_FIELD,
-                thisBType.descriptor
-              )
+              assignModuleInstanceField(mnode)
             }
           }
 

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -610,6 +610,7 @@ trait Definitions extends api.StandardDefinitions {
 
     def isTupleSymbol(sym: Symbol) = TupleClass.seq contains unspecializedSymbol(sym)
     def isFunctionSymbol(sym: Symbol) = FunctionClass.seq contains unspecializedSymbol(sym)
+    def isAbstractFunctionSymbol(sym: Symbol) = AbstractFunctionClass.seq contains unspecializedSymbol(sym)
     def isProductNSymbol(sym: Symbol) = ProductClass.seq contains unspecializedSymbol(sym)
 
     def unspecializedSymbol(sym: Symbol): Symbol = {

--- a/test/junit/scala/tools/nsc/backend/jvm/ModuleFieldTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/ModuleFieldTest.scala
@@ -1,0 +1,39 @@
+package scala.tools.nsc.backend.jvm
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.reflect.NameTransformer
+import scala.tools.asm.Opcodes
+import scala.tools.testing.BytecodeTesting
+
+@RunWith(classOf[JUnit4])
+class ModuleFieldTest extends BytecodeTesting {
+  import compiler._
+
+  @Test
+  def moduleFieldIsFinalForPureModules(): Unit = {
+    val code =
+      """
+        |object Pure1
+        |case class Pure2(x: Int) // companion extends FunctionN, but we know that's pure
+        |object Impure1 { println("") }
+        |class UnknownPurity
+        |object Impure2 extends UnknownPurity
+      """.stripMargin
+    val classes = compileClasses(code)
+
+    def check(name: String, expected: Boolean): Unit = {
+      val moduleField = classes.find(_.name == name).get.fields.get(0)
+      assert(moduleField.name == NameTransformer.MODULE_INSTANCE_NAME)
+      val isFinal = (moduleField.access & Opcodes.ACC_FINAL) != 0
+      assertEquals(expected, isFinal)
+    }
+    check("Pure1$", true)
+    check("Pure2$", true)
+    check("Impure1$", false)
+    check("Impure2$", false)
+  }
+}


### PR DESCRIPTION
For modules without side effects in their constructors, and that only extend `Object` or `(Abstract)FunctionN`, we can defer assignment of the module instance field, and make that field final.

