### PR TITLE
Rule out more implicit based on bounds of type parameters

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -626,17 +626,31 @@ trait Implicits {
     /** This expresses more cleanly in the negative: there's a linear path
      *  to a final true or false.
      */
-    private def isPlausiblySubType(tp1: Type, tp2: Type) = !isImpossibleSubType(tp1, tp2)
-    private def isImpossibleSubType(tp1: Type, tp2: Type) = tp1.dealiasWiden match {
+    private def isPlausiblySubType(tp1: Type, tp2: Type): Boolean = !isImpossibleSubType(tp1, tp2)
+    private def isImpossibleSubType(tp1: Type, tp2: Type): Boolean = tp1.dealiasWiden match {
       // We can only rule out a subtype relationship if the left hand
       // side is a class, else we may not know enough.
-      case tr1 @ TypeRef(_, sym1, _) if sym1.isClass =>
+      case tr1 @ TypeRef(_, sym1, args1) if sym1.isClass =>
         def typeRefHasMember(tp: TypeRef, name: Name) = {
           tp.baseClasses.exists(_.info.decls.lookupEntry(name) != null)
         }
-        tp2.dealiasWiden match {
-          case TypeRef(_, sym2, _)         => ((sym1 eq ByNameParamClass) != (sym2 eq ByNameParamClass)) || (sym2.isClass && !(sym1 isWeakSubClass sym2))
-          case RefinedType(parents, decls) => decls.nonEmpty && !typeRefHasMember(tr1, decls.head.name) // opt avoid full call to .member
+
+        def existentialUnderlying(t: Type) = t match {
+          case et: ExistentialType => et.underlying
+          case tp => tp
+        }
+        val tp2Bounds = existentialUnderlying(tp2.dealiasWiden.bounds.hi)
+        tp2Bounds match {
+          case TypeRef(_, sym2, args2) if sym2 ne SingletonClass =>
+            val impossible = if ((sym1 eq sym2) && (args1 ne Nil)) !corresponds3(sym1.typeParams, args1, args2) {(tparam, arg1, arg2) =>
+              if (tparam.isCovariant) isPlausiblySubType(arg1, arg2) else isPlausiblySubType(arg2, arg1)
+            } else {
+              ((sym1 eq ByNameParamClass) != (sym2 eq ByNameParamClass)) || (sym2.isClass && !(sym1 isWeakSubClass sym2))
+            }
+            impossible
+          case RefinedType(parents, decls) =>
+            val impossible = decls.nonEmpty && !typeRefHasMember(tr1, decls.head.name) // opt avoid full call to .member
+            impossible
           case _                           => false
         }
       case _ => false

--- a/test/files/pos/implicit-implausible.scala
+++ b/test/files/pos/implicit-implausible.scala
@@ -1,0 +1,12 @@
+trait Foo[T]
+object Foo {
+	implicit def javaEnumFoo[T <: java.lang.Enum[_]]: Foo[T] = ???
+	implicit def stringFoo: Foo[String] = ???
+}
+
+object Test {
+	// -Ytyper-debug output shows whether or not `javaEnumFoo` is considered
+	// By making `isImpossibleSubtype` a little smarter, we can exclude it
+	// on the grounds that `String` can't be a subtpe of the bounds ot `Enum[_]`.
+	implicitly[Foo[String]]
+}

--- a/test/files/pos/sip23-singleton-view.scala
+++ b/test/files/pos/sip23-singleton-view.scala
@@ -1,0 +1,6 @@
+import language.implicitConversions
+
+class Test {
+  implicit def singletonToString(c: Singleton): String = ""
+  def foo(a: 1): String = a // implicit was being ruled out because Int(1).widen was not a subclass of Singletom
+}


### PR DESCRIPTION
Implicit search does an initial pass at pruning candidates based on an approximation of typechecking that doesn't infer type arguments or implicit arguments.

Until now, this simplified typechecking bailed out when it saw existentials or uninstantiated type params. This commit unwraps the existential and uses the bounds of type parameters to find more impossible candidates.

For the enclosed test case `-Ytyper-debug` shows the difference:

Before:

```
implicitly[Foo[String]] BYVALmode-EXPRmode (site: value <local Test> in Test)
 |-- implicitly BYVALmode-EXPRmode-FUNmode-POLYmode-TAPPmode (site: value <local Test> in Test)
 |    \-> [T](implicit e: T)T
 |-- Foo[String] TYPEmode (site: value <local Test> in Test)
 |    |-- String TYPEmode (site: value <local Test> in Test)
 |    |    [adapt] String is now a TypeTree(String)
 |    |    \-> String
 |    \-> Foo[String]
 [search #1] start `[T](implicit e: T)T`, searching for adaptation to pt=Foo[String] (silent: value <local Test> in Test) implicits disabled
 [search #1] considering Foo.javaEnumFoo
 solving for (T: ?T)
 [adapt] [T]=> Foo[T] adapted to [T]=> Foo[T] based on pt Foo[String]
 [search #1] success inferred value of type Foo[String] is SearchResult(Foo.javaEnumFoo[String], )
 |-- [T](implicit e: T)T BYVALmode-EXPRmode (site: value <local Test> in Test)
 |    \-> Foo[String]
 [adapt] [T](implicit e: T)T adapted to [T](implicit e: T)T
```

After:

```
implicitly[Foo[String]] BYVALmode-EXPRmode (site: value <local Test> in Test)
 |-- implicitly BYVALmode-EXPRmode-FUNmode-POLYmode-TAPPmode (site: value <local Test> in Test)
 |    \-> [T](implicit e: T)T
 |-- Foo[String] TYPEmode (site: value <local Test> in Test)
 |    |-- String TYPEmode (site: value <local Test> in Test)
 |    |    [adapt] String is now a TypeTree(String)
 |    |    \-> String
 |    \-> Foo[String]
 [search #1] start `[T](implicit e: T)T`, searching for adaptation to pt=Foo[String] (silent: value <local Test> in Test) implicits disabled
 [search #1] considering Foo.stringFoo
 [search #1] success inferred value of type Foo[String] is SearchResult(Foo.stringFoo, )
 |-- [T](implicit e: T)T BYVALmode-EXPRmode (site: value <local Test> in Test)
 |    \-> Foo[String]
 [adapt] [T](implicit e: T)T adapted to [T](implicit e: T)T
 \-> Foo[String]

```