### PR TITLE
Act on collection ToDos to integrate with scala.collection namespace

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -8,57 +8,6 @@ import scala.reflect.ClassTag
 import scala.math.{max, min, Ordering}
 
 object ArrayOps {
-  //TODO Move this method to scala.Array in 2.13
-  /** Copy one array to another, truncating or padding with default values (if
-    * necessary) so the copy has the specified length.
-    *
-    * Equivalent to Java's
-    *   `java.util.Arrays.copyOf(original, newLength)`,
-    * except that this works for primitive and object arrays in a single method.
-    *
-    * @see `java.util.Arrays#copyOf`
-    */
-  def copyOf[A](original: Array[A], newLength: Int): Array[A] = (original match {
-    case x: Array[AnyRef]     => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Int]        => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Double]     => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Long]       => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Float]      => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Char]       => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Byte]       => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Short]      => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Boolean]    => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Unit]       =>
-      val dest = new Array[Unit](newLength)
-      Array.copy(original, 0, dest, 0, original.length)
-      dest
-  }).asInstanceOf[Array[A]]
-
-  //TODO Move this method to scala.Array in 2.13
-  /** Copy one array to another, truncating or padding with default values (if
-    * necessary) so the copy has the specified length. The new array can have
-    * a different type than the original one as long as the values are
-    * assignment-compatible. When copying between primitive and object arrays,
-    * boxing and unboxing are supported.
-    *
-    * Equivalent to Java's
-    *   `java.util.Arrays.copyOf(original, newLength, newType)`,
-    * except that this works for all combinations of primitive and object arrays
-    * in a single method.
-    *
-    * @see `java.util.Arrays#copyOf`
-    */
-  def copyAs[A](original: Array[_], newLength: Int)(implicit ct: ClassTag[A]): Array[A] = {
-    val destClass = ct.runtimeClass
-    if (destClass.isAssignableFrom(original.getClass)) {
-      if(destClass.getComponentType.isPrimitive) copyOf[A](original.asInstanceOf[Array[A]], newLength)
-      else java.util.Arrays.copyOf(original.asInstanceOf[Array[AnyRef]], newLength, destClass.asInstanceOf[Class[Array[AnyRef]]]).asInstanceOf[Array[A]]
-    } else {
-      val dest = new Array[A](newLength)
-      Array.copy(original, 0, dest, 0, original.length)
-      dest
-    }
-  }
 
   /** A lazy filtered array. No filtering is applied until one of `foreach`, `map` or `flatMap` is called. */
   class WithFilter[A](p: A => Boolean, xs: Array[A]) {
@@ -697,7 +646,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
 
   /** A copy of this array with an element appended. */
   def appended[B >: A : ClassTag](x: B): Array[B] = {
-    val dest = ArrayOps.copyAs[B](xs, xs.length+1)
+    val dest = Array.copyAs[B](xs, xs.length+1)
     dest(xs.length) = x
     dest
   }
@@ -886,7 +835,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
   def padTo[B >: A : ClassTag](len: Int, elem: B): Array[B] = {
     var i = xs.length
     val newlen = max(i, len)
-    val dest = ArrayOps.copyAs[B](xs, newlen)
+    val dest = Array.copyAs[B](xs, newlen)
     while(i < newlen) {
       dest(i) = elem
       i += 1
@@ -950,5 +899,5 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
   @`inline` final def toSeq: immutable.Seq[A] = toIndexedSeq
 
   def toIndexedSeq: immutable.IndexedSeq[A] =
-    ImmutableArray.unsafeWrapArray(ArrayOps.copyOf(xs, xs.length))
+    ImmutableArray.unsafeWrapArray(Array.copyOf(xs, xs.length))
 }

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -37,7 +37,7 @@ trait Map[K, +V]
       false
   }
 
-  override def hashCode(): Int = Set.unorderedHash(toIterable, "Map".##)
+  override def hashCode(): Int = MurmurHash3.mapHash(toIterable)
 
 }
 

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -34,19 +34,7 @@ trait Seq[+A]
       case _ => false
     }
 
-  override def hashCode(): Int = stableIterableHash(toIterable)
-
-  // Temporary: TODO move to MurmurHash3.scala
-  private def stableIterableHash(xs: Iterable[_]): Int = {
-    var n = 0
-    var h = "Seq".##
-    val it = xs.iterator()
-    while (it.hasNext) {
-      h = MurmurHash3.mix(h, it.next().##)
-      n += 1
-    }
-    MurmurHash3.finalizeHash(h, n)
-  }
+  override def hashCode(): Int = MurmurHash3.seqHash(toIterable)
 
   override def toString(): String = super[Iterable].toString()
 

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -24,7 +24,7 @@ trait Set[A]
       case _ => false
     }
 
-  override def hashCode(): Int = Set.setHash(toIterable)
+  override def hashCode(): Int = MurmurHash3.setHash(toIterable)
 
   override def iterableFactory: IterableFactory[IterableCC] = Set
 
@@ -197,26 +197,4 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   * @define coll set
   * @define Coll `Set`
   */
-object Set extends IterableFactory.Delegate[Set](immutable.Set) {
-
-  // Temporary, TODO move to MurmurHash3
-  def setHash(xs: Iterable[_]): Int = unorderedHash(xs, "Set".##)
-
-  final def unorderedHash(xs: Iterable[_], seed: Int): Int = {
-    var a, b, n = 0
-    var c = 1
-    xs foreach { x =>
-      val h = x.##
-      a += h
-      b ^= h
-      if (h != 0) c *= h
-      n += 1
-    }
-    var h = seed
-    h = MurmurHash3.mix(h, a)
-    h = MurmurHash3.mix(h, b)
-    h = MurmurHash3.mixLast(h, c)
-    MurmurHash3.finalizeHash(h, n)
-  }
-
-}
+object Set extends IterableFactory.Delegate[Set](immutable.Set)

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -587,12 +587,12 @@ private[collection] final class CNode[K, V](val bitmap: Int, val array: Array[Ba
       case ln: LNode[K, V] => ln.entries.to(immutable.List)
       case cn: CNode[K, V] => cn.collectElems
     }
-  }: (BasicNode => IterableOnce[(K, V)])) //TODO remove type annotatation in 2.13
+  })
 
   private def collectLocalElems: Seq[String] = array.flatMap({
     case sn: SNode[K, V] => Some(sn.kvPair._2.toString): IterableOnce[String]
     case in: INode[K, V] => Some(scala.Predef.augmentString(in.toString).drop(14) + "(" + in.gen + ")"): IterableOnce[String]
-  }: (BasicNode => IterableOnce[String])) //TODO remove type annotatation in 2.13
+  })
 
   override def toString = {
     val elems = collectLocalElems

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -390,17 +390,17 @@ sealed abstract class IntMap[+T] extends Map[Int, T]
   def unionWith[S >: T](that: IntMap[S], f: (Int, S, S) => S): IntMap[S] = (this, that) match{
     case (IntMap.Bin(p1, m1, l1, r1), that@(IntMap.Bin(p2, m2, l2, r2))) =>
       if (shorter(m1, m2)) {
-        if (!hasMatch(p2, p1, m1)) join[S](p1, this, p2, that) // TODO: remove [S] when scala/bug#5548 is fixed
+        if (!hasMatch(p2, p1, m1)) join(p1, this, p2, that)
         else if (zero(p2, m1)) IntMap.Bin(p1, m1, l1.unionWith(that, f), r1)
         else IntMap.Bin(p1, m1, l1, r1.unionWith(that, f))
       } else if (shorter(m2, m1)){
-        if (!hasMatch(p1, p2, m2)) join[S](p1, this, p2, that) // TODO: remove [S] when scala/bug#5548 is fixed
+        if (!hasMatch(p1, p2, m2)) join(p1, this, p2, that)
         else if (zero(p1, m2)) IntMap.Bin(p2, m2, this.unionWith(l2, f), r2)
         else IntMap.Bin(p2, m2, l2, this.unionWith(r2, f))
       }
       else {
         if (p1 == p2) IntMap.Bin(p1, m1, l1.unionWith(l2,f), r1.unionWith(r2, f))
-        else join[S](p1, this, p2, that) // TODO: remove [S] when scala/bug#5548 is fixed
+        else join(p1, this, p2, that)
       }
     case (IntMap.Tip(key, value), x) => x.updateWith[S](key, value, (x, y) => f(key, y, x))
     case (x, IntMap.Tip(key, value)) => x.updateWith[S](key, value, (x, y) => f(key, x, y))

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -369,19 +369,19 @@ sealed abstract class LongMap[+T] extends Map[Long, T]
   def unionWith[S >: T](that: LongMap[S], f: (Long, S, S) => S): LongMap[S] = (this, that) match{
     case (LongMap.Bin(p1, m1, l1, r1), that@(LongMap.Bin(p2, m2, l2, r2))) =>
       if (shorter(m1, m2)) {
-        if (!hasMatch(p2, p1, m1)) join[S](p1, this, p2, that) // TODO: remove [S] when scala/bug#5548 is fixed
+        if (!hasMatch(p2, p1, m1)) join(p1, this, p2, that)
         else if (zero(p2, m1)) LongMap.Bin(p1, m1, l1.unionWith(that, f), r1)
         else LongMap.Bin(p1, m1, l1, r1.unionWith(that, f))
       } else if (shorter(m2, m1)){
-        if (!hasMatch(p1, p2, m2)) join[S](p1, this, p2, that) // TODO: remove [S] when scala/bug#5548 is fixed
+        if (!hasMatch(p1, p2, m2)) join(p1, this, p2, that)
         else if (zero(p1, m2)) LongMap.Bin(p2, m2, this.unionWith(l2, f), r2)
         else LongMap.Bin(p2, m2, l2, this.unionWith(r2, f))
       }
       else {
         if (p1 == p2) LongMap.Bin(p1, m1, l1.unionWith(l2,f), r1.unionWith(r2, f))
-        else join[S](p1, this, p2, that) // TODO: remove [S] when scala/bug#5548 is fixed
+        else join(p1, this, p2, that)
       }
-    case (LongMap.Tip(key, value), x) => x.updateWith[S](key, value, (x, y) => f(key, y, x)) // TODO: remove [S] when scala/bug#5548 is fixed
+    case (LongMap.Tip(key, value), x) => x.updateWith(key, value, (x, y) => f(key, y, x))
     case (x, LongMap.Tip(key, value)) => x.updateWith[S](key, value, (x, y) => f(key, x, y))
     case (LongMap.Nil, x) => x
     case (x, LongMap.Nil) => x

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -422,16 +422,15 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
   def clear(): Unit = keysIterator() foreach -=
 
   // The `K with AnyRef` parameter type is necessary to distinguish these methods from the base methods they overload (not override)
-  // TODO: Remove the unnecessary implicit in Scala 2.13; Dotty requires it for disambiguation
-  def map[K2 <: AnyRef, V2](f: ((K with AnyRef, V)) => (K2, V2))(implicit ev: K2 <:< AnyRef): AnyRefMap[K2, V2] =
+  def map[K2 <: AnyRef, V2](f: ((K with AnyRef, V)) => (K2, V2)): AnyRefMap[K2, V2] =
     AnyRefMap.from(new View.Map(toIterable, f))
-  def flatMap[K2 <: AnyRef, V2](f: ((K with AnyRef, V)) => IterableOnce[(K2, V2)])(implicit ev: K2 <:< AnyRef): AnyRefMap[K2, V2] =
+  def flatMap[K2 <: AnyRef, V2](f: ((K with AnyRef, V)) => IterableOnce[(K2, V2)]): AnyRefMap[K2, V2] =
     AnyRefMap.from(new View.FlatMap(toIterable, f))
-  def collect[K2 <: AnyRef, V2](pf: PartialFunction[(K with AnyRef, V), (K2, V2)])(implicit ev: K2 <:< AnyRef): AnyRefMap[K2, V2] =
+  def collect[K2 <: AnyRef, V2](pf: PartialFunction[(K with AnyRef, V), (K2, V2)]): AnyRefMap[K2, V2] =
     flatMap { kv: (K with AnyRef, V) =>
       if (pf.isDefinedAt(kv)) new View.Single(pf(kv))
       else View.Empty
-    }(ev)
+    }
 }
 
 object AnyRefMap {

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -1,5 +1,6 @@
 package scala.collection.mutable
 
+import scala.annotation.migration
 import scala.collection.{IterableOnce, SeqFactory, StrictOptimizedSeqFactory, StrictOptimizedSeqOps, toNewSeq}
 
 /** A stack implements a data structure which allows to store and retrieve
@@ -19,7 +20,7 @@ import scala.collection.{IterableOnce, SeqFactory, StrictOptimizedSeqFactory, St
   *  @define willNotTerminateInf
   */
 @SerialVersionUID(3L)
-//TODO add in scala.collection namespace: @migration("Stack is now based on an ArrayDeque instead of a linked list", "2.13.0")
+@migration("Stack is now based on an ArrayDeque instead of a linked list", "2.13.0")
 class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
   extends ArrayDeque[A](array, start, end)
     with IndexedSeqOps[A, Stack, Stack[A]]

--- a/src/library/scala/collection/mutable/WrappedArray.scala
+++ b/src/library/scala/collection/mutable/WrappedArray.scala
@@ -131,7 +131,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     def length: Int = array.length
     def apply(index: Int): T = array(index).asInstanceOf[T]
     def update(index: Int, elem: T): Unit = { array(index) = elem }
-    override def hashCode = wrappedArrayHash(array)
+    override def hashCode = MurmurHash3.wrappedArrayHash(array)
     override def equals(that: Any) = that match {
       case that: ofRef[_] => Arrays.equals(array.asInstanceOf[Array[AnyRef]], that.array.asInstanceOf[Array[AnyRef]])
       case _ => super.equals(that)
@@ -144,7 +144,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     def length: Int = array.length
     def apply(index: Int): Byte = array(index)
     def update(index: Int, elem: Byte): Unit = { array(index) = elem }
-    override def hashCode = wrappedBytesHash(array)
+    override def hashCode = MurmurHash3.wrappedBytesHash(array)
     override def equals(that: Any) = that match {
       case that: ofByte => Arrays.equals(array, that.array)
       case _ => super.equals(that)
@@ -157,7 +157,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     def length: Int = array.length
     def apply(index: Int): Short = array(index)
     def update(index: Int, elem: Short): Unit = { array(index) = elem }
-    override def hashCode = wrappedArrayHash(array)
+    override def hashCode = MurmurHash3.wrappedArrayHash(array)
     override def equals(that: Any) = that match {
       case that: ofShort => Arrays.equals(array, that.array)
       case _ => super.equals(that)
@@ -170,7 +170,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     def length: Int = array.length
     def apply(index: Int): Char = array(index)
     def update(index: Int, elem: Char): Unit = { array(index) = elem }
-    override def hashCode = wrappedArrayHash(array)
+    override def hashCode = MurmurHash3.wrappedArrayHash(array)
     override def equals(that: Any) = that match {
       case that: ofChar => Arrays.equals(array, that.array)
       case _ => super.equals(that)
@@ -183,7 +183,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     def length: Int = array.length
     def apply(index: Int): Int = array(index)
     def update(index: Int, elem: Int): Unit = { array(index) = elem }
-    override def hashCode = wrappedArrayHash(array)
+    override def hashCode = MurmurHash3.wrappedArrayHash(array)
     override def equals(that: Any) = that match {
       case that: ofInt => Arrays.equals(array, that.array)
       case _ => super.equals(that)
@@ -196,7 +196,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     def length: Int = array.length
     def apply(index: Int): Long = array(index)
     def update(index: Int, elem: Long): Unit = { array(index) = elem }
-    override def hashCode = wrappedArrayHash(array)
+    override def hashCode = MurmurHash3.wrappedArrayHash(array)
     override def equals(that: Any) = that match {
       case that: ofLong => Arrays.equals(array, that.array)
       case _ => super.equals(that)
@@ -209,7 +209,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     def length: Int = array.length
     def apply(index: Int): Float = array(index)
     def update(index: Int, elem: Float): Unit = { array(index) = elem }
-    override def hashCode = wrappedArrayHash(array)
+    override def hashCode = MurmurHash3.wrappedArrayHash(array)
     override def equals(that: Any) = that match {
       case that: ofFloat => Arrays.equals(array, that.array)
       case _ => super.equals(that)
@@ -222,7 +222,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     def length: Int = array.length
     def apply(index: Int): Double = array(index)
     def update(index: Int, elem: Double): Unit = { array(index) = elem }
-    override def hashCode = wrappedArrayHash(array)
+    override def hashCode = MurmurHash3.wrappedArrayHash(array)
     override def equals(that: Any) = that match {
       case that: ofDouble => Arrays.equals(array, that.array)
       case _ => super.equals(that)
@@ -235,7 +235,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     def length: Int = array.length
     def apply(index: Int): Boolean = array(index)
     def update(index: Int, elem: Boolean): Unit = { array(index) = elem }
-    override def hashCode = wrappedArrayHash(array)
+    override def hashCode = MurmurHash3.wrappedArrayHash(array)
     override def equals(that: Any) = that match {
       case that: ofBoolean => Arrays.equals(array, that.array)
       case _ => super.equals(that)
@@ -248,14 +248,10 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     def length: Int = array.length
     def apply(index: Int): Unit = array(index)
     def update(index: Int, elem: Unit): Unit = { array(index) = elem }
-    override def hashCode = wrappedArrayHash(array)
+    override def hashCode = MurmurHash3.wrappedArrayHash(array)
     override def equals(that: Any) = that match {
       case that: ofUnit => array.length == that.array.length
       case _ => super.equals(that)
     }
   }
-
-  //TODO Use MurmurHash3.wrappedArrayHash/wrappedBytesHash which are private[scala]
-  private def wrappedArrayHash[@specialized T](a: Array[T]): Int  = MurmurHash3.arrayHash(a, MurmurHash3.seqSeed)
-  private def wrappedBytesHash(data: Array[Byte]): Int            = MurmurHash3.bytesHash(data, MurmurHash3.seqSeed)
 }


### PR DESCRIPTION
We can now move new methods into non-collection classes like `Array`
and access `private[scala]` members (e.g. in `MurmurHash3`).