### PR TITLE
Avoid compiler hang in implicit resolution

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -455,6 +455,7 @@ trait Implicits {
         case AnnotatedType(annots, tp)          => core(tp)
         case ExistentialType(tparams, result)   => core(result).subst(tparams, tparams map (t => core(t.info.bounds.hi)))
         case PolyType(tparams, result)          => core(result).subst(tparams, tparams map (t => core(t.info.bounds.hi)))
+        case TypeRef(pre, sym, args)            => typeRef(pre, sym, args.map(core))
         case _                                  => tp
       }
       def stripped(tp: Type): Type = {

--- a/test/files/neg/hidden-complexity.check
+++ b/test/files/neg/hidden-complexity.check
@@ -1,0 +1,9 @@
+hidden-complexity.scala:12: error: diverging implicit expansion for type Foo[List]
+starting with method mkFoo in object Foo
+  implicitly[Foo[List]]
+            ^
+hidden-complexity.scala:13: error: diverging implicit expansion for type Bar[List]
+starting with method mkBar in object Bar
+  implicitly[Bar[List]]
+            ^
+two errors found

--- a/test/files/neg/hidden-complexity.scala
+++ b/test/files/neg/hidden-complexity.scala
@@ -1,0 +1,14 @@
+trait Foo[F[_]]
+object Foo {
+  implicit def mkFoo[F[_]](implicit ff: Foo[({ type λ[t] = F[F[t]] })#λ]): Foo[F] = ???
+}
+
+trait Bar[F[_]]
+object Bar {
+  implicit def mkBar[F[_]](implicit bb: Bar[λ forSome { type λ[t] <: F[t] }]): Bar[F] = ???
+}
+
+object Test {
+  implicitly[Foo[List]]
+  implicitly[Bar[List]]
+}


### PR DESCRIPTION
The current divergence checker computes the "stripped core" of the types it's resolving implicits for before computing their relative complexity. Unfortunately a missed case in the core computation means that divergent types can be smuggled into the resolution as arguments to a `TypeRef` and are not counted towards the overall complexity of the type. This causes implicit resolution to loop until stack overflow.

```scala
trait Foo[F[_]]
object Foo {
  implicit def mkFoo[F[_]](implicit ff: Foo[({ type λ[t] = F[F[t]] })#λ]): Foo[F] = ???
}

trait Bar[F[_]]
object Bar {
  implicit def mkBar[F[_]](implicit bb: Bar[λ forSome { type λ[t] <: F[t] }]): Bar[F] = ???
}

implicitly[Foo[List]] // compile time hang
implicitly[Bar[List]] // compile time hang
```

Issue reported as https://github.com/scala/bug/issues/10833.

~~The fix is to have the computation of the core type traverse through the arguments of `TypeRefs`.~~

~~Nb. this fix will also be in the byname implicits PR shortly, but I thought it would be useful to get this change reviewed independently.~~

See comment below ...