### PR TITLE
Avoid quadratic complexity in iterators created by Iterator.apply

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -809,10 +809,7 @@ object Iterator extends IterableFactory[Iterator] {
     def next() = if (consumed) empty.next() else { consumed = true; a }
   }
 
-  override def apply[A](xs: A*): Iterator[A] = new IndexedView[A] {
-    val length = xs.length
-    def apply(n: Int) = xs(n)
-  }.iterator()
+  override def apply[A](xs: A*): Iterator[A] = xs.iterator()
 
   /**
     * @return A builder for $Coll objects.

--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -173,5 +173,4 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeq
 
   override def tails: Iterator[C] =
     Iterator.iterate(coll)(_.tail).takeWhile(_.nonEmpty) ++ Iterator(newSpecificBuilder().result())
-
 }

--- a/src/library/scala/collection/View.scala
+++ b/src/library/scala/collection/View.scala
@@ -86,7 +86,7 @@ object View extends IterableFactory[View] {
 
   /** A view with given elements */
   class Elems[A](xs: A*) extends View[A] {
-    def iterator() = Iterator(xs: _*)
+    def iterator() = xs.iterator()
     override def knownSize = xs.knownSize
   }
 


### PR DESCRIPTION
The varargs Iterator.apply now simply calls .iterator() on the varargs
parameter, instead of creating an iterator that calls the `apply` method
on the vararg. This reduces complexity, for example when passing a
List for the vararg.

For `run/t6253b.scala`, before:

    $  time ../build/quick/bin/scala Test
    166.96s user 0.61s system 100% cpu 2:46.53 total

After:

    $ time ../build/quick/bin/scala Test
    3.87s user 0.26s system 142% cpu 2.890 total

Stefan says the previous implementation was necessary to convert the
vararg collection between old and new collection types.