### PR TITLE
Allow main method without parameters [WIP]

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -787,25 +787,22 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
      */
     def addForwarders(jclass: asm.ClassVisitor, jclassName: String, moduleClass: Symbol) {
       assert(moduleClass.isModuleClass, moduleClass)
-      debuglog(s"Dumping mirror class for object: $moduleClass")
 
-      val linkedClass  = moduleClass.companionClass
+      val linkedClass = moduleClass.companionClass
       lazy val conflictingNames: Set[Name] = {
         (linkedClass.info.members collect { case sym if sym.name.isTermName => sym.name }).toSet
       }
-      debuglog(s"Potentially conflicting names for forwarders: $conflictingNames")
 
-      for (m <- moduleClass.info.membersBasedOnFlags(BCodeHelpers.ExcludedForwarderFlags, symtab.Flags.METHOD)) {
-        if (m.isType || m.isDeferred || (m.owner eq definitions.ObjectClass) || m.isConstructor)
-          debuglog(s"No forwarder for '$m' from $jclassName to '$moduleClass': ${m.isType} || ${m.isDeferred} || ${m.owner eq definitions.ObjectClass} || ${m.isConstructor}")
-        else if (conflictingNames(m.name))
-          log(s"No forwarder for $m due to conflict with ${linkedClass.info.member(m.name)}")
-        else if (m.hasAccessBoundary)
-          log(s"No forwarder for non-public member $m")
-        else {
-          log(s"Adding static forwarder for '$m' from $jclassName to '$moduleClass'")
-          addForwarder(jclass, moduleClass, m)
-        }
+      // Before erasure * to exclude bridge methods. Excluding them by flag doesn't work, because then
+      // the the method from the base class that the bridge overrides is included (scala/bug#10812).
+      // * using `exitingPickler` (not `enteringErasure`) because erasure enters bridges in traversal,
+      //   not in the InfoTransform, so it actually modifies the type from the previous phase.
+      val members = exitingPickler(moduleClass.info.membersBasedOnFlags(BCodeHelpers.ExcludedForwarderFlags, symtab.Flags.METHOD))
+      for (m <- members) {
+        val excl = m.isDeferred || m.isConstructor || m.hasAccessBoundary ||
+          { val o = m.owner; (o eq ObjectClass) || (o eq AnyRefClass) || (o eq AnyClass) } ||
+          conflictingNames(m.name)
+        if (!excl) addForwarder(jclass, moduleClass, m)
       }
     }
 
@@ -971,10 +968,10 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
 }
 
 object BCodeHelpers {
-  val ExcludedForwarderFlags = {
+  val ExcludedForwarderFlags: Long = {
     import scala.tools.nsc.symtab.Flags._
-    // Should include DEFERRED but this breaks findMember.
-    SPECIALIZED | LIFTED | PROTECTED | STATIC | EXPANDEDNAME | BridgeAndPrivateFlags | MACRO
+    // Don't include DEFERRED but filter afterwards, see comment on `findMembers`
+    SPECIALIZED | LIFTED | PROTECTED | STATIC | EXPANDEDNAME | PRIVATE | MACRO
   }
 
   /**

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -150,11 +150,8 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
       emitAnnotations(cnode, claszSymbol.annotations ++ ssa)
 
       if (isCZStaticModule || isCZParcelable) {
-
         if (isCZStaticModule) { addModuleInstanceField() }
-
       } else {
-
         if (!settings.noForwarders) {
           val lmoc = claszSymbol.companionModule
           // add static forwarders if there are no name conflicts; see bugs #363 and #1735

--- a/src/compiler/scala/tools/nsc/backend/jvm/PostProcessorFrontendAccess.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/PostProcessorFrontendAccess.scala
@@ -32,8 +32,6 @@ sealed abstract class PostProcessorFrontendAccess {
 
   def backendClassPath: BackendClassPath
 
-  def getEntryPoints: List[String]
-
   def javaDefinedClasses: Set[InternalName]
 
   def recordPerRunCache[T <: Clearable](cache: T): T
@@ -246,8 +244,6 @@ object PostProcessorFrontendAccess {
     object backendClassPath extends BackendClassPath {
       def findClassFile(className: String): Option[AbstractFile] = cp.get.findClassFile(className)
     }
-
-    def getEntryPoints: List[String] = frontendSynch(cleanup.getEntryPoints)
 
     def javaDefinedClasses: Set[InternalName] = frontendSynch {
       currentRun.symSource.keys.iterator.collect{

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -76,7 +76,7 @@ trait ScalaSettings extends AbsScalaSettings
       domain  = languageFeatures
     )
   }
-  val release = StringSetting("-release", "<release>", "Compile for a specific version of the Java platform. Supported targets: 6, 7, 8, 9", "").withPostSetHook { (value: StringSetting) =>
+  val release = StringSetting("-release", "release", "Compile for a specific version of the Java platform. Supported targets: 6, 7, 8, 9", "").withPostSetHook { (value: StringSetting) =>
     if (value.value != "" && !scala.util.Properties.isJavaAtLeast("9")) {
       errorFn.apply("-release is only supported on Java 9 and higher")
     } else {

--- a/src/library/scala/runtime/SymbolLiteral.java
+++ b/src/library/scala/runtime/SymbolLiteral.java
@@ -10,7 +10,7 @@ public final class SymbolLiteral {
                                      MethodType invokedType,
                                      String value) throws Throwable {
         ClassLoader classLoader = lookup.lookupClass().getClassLoader();
-        MethodType type = MethodType.fromMethodDescriptorString("(Ljava/lang/Object;)Ljava/lang/Object;", classLoader);
+        MethodType type = MethodType.fromMethodDescriptorString("(Ljava/lang/String;)Lscala/Symbol;", classLoader);
         Class<?> symbolClass = Class.forName("scala.Symbol", false, classLoader);
         MethodHandle factoryMethod = lookup.findStatic(symbolClass, "apply", type);
         Object symbolValue = factoryMethod.invokeWithArguments(value);

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -566,6 +566,12 @@ trait Definitions extends api.StandardDefinitions {
     def hasJavaMainMethod(sym: Symbol): Boolean =
       (sym.tpe member nme.main).alternatives exists isJavaMainMethod
 
+    def isPlainMainMethod(sym: Symbol) = (sym.name == nme.main) && (sym.info match {
+      case MethodType(Nil, r) => r.typeSymbol == UnitClass
+      case NullaryMethodType(r) => r.typeSymbol == UnitClass
+      case _ => false
+    })
+
     class VarArityClass(name: String, maxArity: Int, countFrom: Int = 0, init: Option[ClassSymbol] = None) extends VarArityClassApi {
       private val offset = countFrom - init.size
       private def isDefinedAt(i: Int) = i < seq.length + offset && i >= offset

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -16,6 +16,19 @@ class BytecodeTest extends BytecodeTesting {
   import compiler._
 
   @Test
+  def t10812(): Unit = {
+    val code =
+      """ A { def f: Object = null }
+        |object B extends A { override def f: String = "b" }
+      """.stripMargin
+    for (base <- List("trait", "class")) {
+      val List(a, bMirror, bModule) = compileClasses(base + code)
+      assertEquals(bMirror.name, "B")
+      assertEquals(bMirror.methods.asScala.filter(_.name == "f").map(m => m.name + m.desc).toList, List("f()Ljava/lang/String;"))
+    }
+  }
+
+  @Test
   def t6288bJumpPosition(): Unit = {
     val code =
       """object Case3 {                                 // 01


### PR DESCRIPTION
Feedback welcome

```
object C {
  def main: Unit = {
    println("hi")
  }
}
```

When there's a main without paramters (no param list, or single empty param list), inherited or declared, and there's no inherited or declared main method with an `Array[String]` parameter, generate a main method that forwards to the user-defined one.

If we go there:
  - deprecate App
  - do some cleanups
  - make sure jar entry points still work
  - tests
  - ...