### PR TITLE
Clean up unnecessary strawman conversions

### DIFF
--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -1,6 +1,6 @@
 package scala.collection.immutable
 
-import scala.collection.{SeqFactory, IterableFactory, IterableOnce, Iterator, StrictOptimizedIterableOps, arrayToArrayOps}
+import scala.collection.{SeqFactory, IterableFactory, IterableOnce, Iterator, StrictOptimizedIterableOps}
 
 import java.lang.String
 
@@ -197,7 +197,7 @@ sealed class NumericRange[T](
       override def containsTyped(el: A) = underlyingRange exists (x => fm(x) == el)
 
       override def toString = {
-        def simpleOf(x: Any): String = collection.arrayToArrayOps(x.getClass.getName.split("\\.")).last
+        def simpleOf(x: Any): String = x.getClass.getName.split("\\.").last
         val stepped = simpleOf(underlyingRange.step)
         s"${super.toString} (using $underlyingRange of $stepped)"
       }

--- a/src/library/scala/collection/immutable/TrieIterator.scala
+++ b/src/library/scala/collection/immutable/TrieIterator.scala
@@ -184,7 +184,7 @@ private[collection] abstract class TrieIterator[+T](elems: Array[Iterable[T]]) e
           depth -= 1
           1 until arrayStack.length foreach (i => arrayStack(i - 1) = arrayStack(i))
           arrayStack(arrayStack.length - 1) = Array[Iterable[T]](null)
-          posStack = scala.collection.arrayToArrayOps(scala.collection.arrayToArrayOps(posStack).tail) ++ Array[Int](0)
+          posStack = posStack.tail ++ Array[Int](0)
           // we know that `this` is not empty, since it had something on the arrayStack and arrayStack elements are always non-empty
           ((newIterator(snd), szsnd), this)
         } else {

--- a/src/library/scala/collection/mutable/FlatHashTable.scala
+++ b/src/library/scala/collection/mutable/FlatHashTable.scala
@@ -3,8 +3,6 @@ package collection.mutable
 
 import collection.Iterator
 
-import collection.arrayToWrappedArray
-
 import java.lang.{Integer, ThreadLocal}
 
 import java.lang.Integer.rotateRight

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -10,7 +10,6 @@ package scala
 package collection.mutable
 
 import collection.Iterator
-import collection.arrayToWrappedArray
 
 import java.lang.Integer.{numberOfLeadingZeros, rotateRight}
 import scala.util.hashing.byteswap32

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -10,8 +10,6 @@ package scala.collection
 package mutable
 
 
-import scala.collection.toNewSeq
-
 /** `Queue` objects implement data structures that allow to
   *  insert and retrieve elements in a first-in-first-out (FIFO) manner.
   *

--- a/src/library/scala/collection/mutable/Seq.scala
+++ b/src/library/scala/collection/mutable/Seq.scala
@@ -1,6 +1,6 @@
 package scala.collection.mutable
 
-import scala.collection.{IterableOnce, SeqFactory, toNewSeq, toOldSeq}
+import scala.collection.{IterableOnce, SeqFactory}
 import scala.language.higherKinds
 
 trait Seq[A]

--- a/src/library/scala/collection/mutable/Shrinkable.scala
+++ b/src/library/scala/collection/mutable/Shrinkable.scala
@@ -3,8 +3,6 @@ package collection.mutable
 
 import scala.annotation.tailrec
 
-import collection.toNewSeq
-
 /** This trait forms part of collections that can be reduced
   *  using a `-=` operator.
   *

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -1,7 +1,7 @@
 package scala.collection.mutable
 
 import scala.annotation.migration
-import scala.collection.{IterableOnce, SeqFactory, StrictOptimizedSeqFactory, StrictOptimizedSeqOps, toNewSeq}
+import scala.collection.{IterableOnce, SeqFactory, StrictOptimizedSeqFactory, StrictOptimizedSeqOps}
 
 /** A stack implements a data structure which allows to store and retrieve
   *  objects in a last-in-first-out (LIFO) fashion.

--- a/src/library/scala/collection/package.scala
+++ b/src/library/scala/collection/package.scala
@@ -2,7 +2,7 @@ package scala
 
 import scala.language.higherKinds
 
-package object collection extends LowPriority {
+package object collection {
   @deprecated("Use Iterable instead of Traversable", "2.13.0")
   type Traversable[+X] = Iterable[X]
   @deprecated("Use Iterable instead of Traversable", "2.13.0")
@@ -41,39 +41,6 @@ package object collection extends LowPriority {
   @deprecated("Gen* collection types have been removed", "2.13.0")
   val GenMap = Map
 
-  import scala.language.implicitConversions
-  // ------------------ Decorators to add collection ops to existing types -----------------------
-
-  /** Decorator to add collection operations to strings. */
-  def stringToStringOps(s: String): StringOps = new StringOps(s)
-
-  /** Decorator to add collection operations to arrays. */
-  def arrayToArrayOps[A](as: Array[A]): ArrayOps[A] = new ArrayOps[A](as)
-
-  class toNewIterator[A](val it: scala.Iterator[A]) extends AnyVal {
-    def toStrawman = new scala.collection.Iterator[A] {
-      def hasNext = it.hasNext
-      def next() = it.next()
-    }
-  }
-
-  class toOldIterator[A](val it: scala.collection.Iterator[A]) extends AnyVal {
-    def toClassic = new scala.Iterator[A] {
-      def hasNext = it.hasNext
-      def next() = it.next()
-    }
-  }
-
-  class toNewSeq[A](val s: scala.collection.Seq[A]) extends AnyVal {
-    def toStrawman: scala.collection.Seq[A] =
-      new scala.collection.mutable.ArrayBuffer() ++= s.iterator
-  }
-
-  class toOldSeq[A](val s: scala.collection.Seq[A]) extends AnyVal {
-    def toClassic: scala.collection.Seq[A] =
-      new scala.collection.mutable.ArrayBuffer ++= s.iterator()
-  }
-
   /** Needed to circumvent a difficulty between dotty and scalac concerning
    *  the right top type for a type parameter of kind * -> *.
    *  In Scalac, we can provide `Any`, as `Any` is kind-polymorphic. In dotty this is not allowed.
@@ -107,13 +74,6 @@ package object collection extends LowPriority {
     }
   }
 
-  def optionToIterableOnce[A](maybeA: scala.Option[A]): IterableOnce[A] =
-     new Iterator[A] {
-       private var _hasNext = maybeA.nonEmpty
-       def next(): A = if (_hasNext) { _hasNext = false; maybeA.get } else Iterator.empty.next()
-       def hasNext: Boolean = _hasNext
-     }
-
   /** An extractor used to head/tail deconstruct sequences. */
   object +: {
     /** Splits a sequence into head :+ tail.
@@ -133,15 +93,4 @@ package object collection extends LowPriority {
       if(t.isEmpty) None
       else Some(t.init -> t.last)
   }
-}
-
-class LowPriority {
-  import scala.language.implicitConversions
-  import scala.collection._
-
-  /** Convert array to WrappedArray. Lower priority than ArrayOps */
-  def arrayToWrappedArray[T](xs: Array[T]): mutable.IndexedSeq[T] = mutable.WrappedArray.make(xs)
-
-  /** Convert String to Seq. Lower priority than StringOps */
-  def stringToSeq(s: String): immutable.WrappedString = new immutable.WrappedString(s)
 }

--- a/test/files/pos/virtpatmat_gadt_array.scala
+++ b/test/files/pos/virtpatmat_gadt_array.scala
@@ -11,5 +11,5 @@ object Test {
   //     (OptionMatching.guard(null.==(x1), x1.asInstanceOf[Array[T]]).flatMap(((x3: Array[T]) =>
   //         OptionMatching.one(null))): Option[scala.collection.mutable.ArrayOps[T]])): Option[scala.collection.mutable.ArrayOps[T]]).orElse((OptionMatching.zero: Option[scala.collection.mutable.ArrayOps[T]]))))
 
-  def refArrayOps[T <: AnyRef](xs: Array[T]): ArrayOps[T] = collection.arrayToArrayOps(xs)
+  def refArrayOps[T <: AnyRef](xs: Array[T]): ArrayOps[T] = new ArrayOps(xs)
 }


### PR DESCRIPTION
I noticed that the new collections still contained some cruft for interoperating between the strawman and the old collections, which is rendered useless after renaming packages and merging.
Feel free to close if this is unnecessary / irrelevant / too soon / ...