### PR TITLE
Add deprecated `append` operation to `Stream`

### DIFF
--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -694,6 +694,9 @@ sealed abstract class Stream[+A] extends LinearSeq[A] with LazyListOps[A, Stream
     else tail.foldLeft(op(z, head))(op)
   }
 
+  @deprecated("The `append` operation has been renamed `lazyAppendAll`", "2.13.0")
+  @inline final def append[B >: A](suffix: IterableOnce[B]): Stream[B] = lazyAppendAll(suffix)
+
 }
 
 @deprecated("Use LazyList (which has a lazy head and tail) instead of Stream (which has a lazy tail only)", "2.13.0")

--- a/test/junit/scala/collection/immutable/StreamTest.scala
+++ b/test/junit/scala/collection/immutable/StreamTest.scala
@@ -213,4 +213,10 @@ class StreamTest {
     cyc.tail.tail.tail.tail
     assertEquals("Stream(1, 2, 3, 4, ...)", cyc.toString)
   }
+
+  @Test
+  def testAppendAliasToLazyAppendAll: Unit = {
+    val l = 1 #:: 2 #:: 3 #:: Stream.Empty
+    assertEquals(l.append(l), l.lazyAppendAll(l))
+  }
 }


### PR DESCRIPTION
The `append` operation is defined as an alias to `lazyAppendAll`. Note that I didn’t introduce `append` to `LazyList` because `LazyList` didn’t exist in 2.12. This could be a problem if one migrates `Stream` usages to `LazyList` (then, an old `append` call on `Stream` will not compile anymore), but shouldn’t be because the scalafix migration rule will anyway rewrite `append` calls to `lazyAppendAll` (as shown in the output of [this test](https://github.com/scala/scala-collection-compat/blob/master/scalafix/output/src/main/scala/fix/Collectionstrawman_v0_Stream.scala#L5)).

Fixes scala/collection-strawman#542