### PR TITLE
Add deprecated `copyToBuffer` operation to `IterableOnceOps`

### DIFF
--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -617,6 +617,9 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     }
   }
 
+  @deprecated("Use `dest ++= coll` instead", "2.13.0")
+  @inline final def copyToBuffer[B >: A](dest: mutable.Buffer[B]): Unit = dest ++= this
+
   /** Copy elements of this collection to an array.
     *  Fills the given array `xs` starting at index `start`.
     *  Copying will stop once either the all elements of this collection have been copied,

--- a/test/junit/scala/collection/TraversableOnceTest.scala
+++ b/test/junit/scala/collection/TraversableOnceTest.scala
@@ -67,4 +67,13 @@ class TraversableOnceTest {
     assert(evaluatedCountOfMinBy == list.length, s"minBy: should evaluate f only ${list.length} times, but it evaluated $evaluatedCountOfMinBy times.")
   }
 
+  @Test
+  def copyToBuffer(): Unit = {
+    val b1 = mutable.ArrayBuffer.empty[Int]
+    list.copyToBuffer(b1)
+    val b2 = mutable.ArrayBuffer.empty[Int]
+    b2 ++= list
+    assert(b1 == b2)
+  }
+
 }


### PR DESCRIPTION
I’ve added the operation to `IterableOnceOps` since it was previously defined in `TraversableOnce`.

Fixes scala/collection-strawman#538