### PR TITLE
Add deprecated `union` operation to `collection.Seq`

### DIFF
--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -181,6 +181,17 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   // overrides of this method
   @`inline` final override def concat[B >: A](suffix: Iterable[B]): CC[B] = appendedAll(suffix)
 
+ /** Produces a new sequence which contains all elements of this $coll and also all elements of
+   *  a given sequence. `xs union ys`  is equivalent to `xs ++ ys`.
+   *
+   *  @param that   the sequence to add.
+   *  @tparam B     the element type of the returned $coll.
+   *  @return       a new collection which contains all elements of this $coll
+   *                followed by all elements of `that`.
+   */
+  @deprecated("Use `concat` instead", "2.13.0")
+  @inline final def union[B >: A, That](that: Seq[B]): CC[B] = concat(that)
+
   final override def size: Int = length
 
   /** Selects all the elements of this $coll ignoring the duplicates.

--- a/test/junit/scala/collection/SeqTest.scala
+++ b/test/junit/scala/collection/SeqTest.scala
@@ -69,4 +69,11 @@ class SeqTest {
 
     assertEquals(Seq(1, 3, 5), s1.intersect(s2))
   }
+
+  @Test
+  def unionAlias(): Unit = {
+    val s1 = Seq(1, 2, 3)
+    val s2 = Seq(4, 5, 6)
+    assertEquals(s1.concat(s2), s1.union(s2))
+  }
 }


### PR DESCRIPTION
Fix scala/collection-strawman#539