### PR TITLE
Drop unused elements on flatMapInPlace for mutable Set and Map

### DIFF
--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -130,15 +130,19 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
 
   def flatMapInPlace(f: ((K, V)) => IterableOnce[(K, V)]): this.type = {
     val toAdd = Map[K, V]()
-    val toRemove = Set[K]()
-    for (elem <- this)
-      for (mapped <- f(elem).iterator())
-        if (!contains(mapped._1)) {
-          toAdd += mapped
-          toRemove -= elem._1
+    val toKeep = Map[K, V]()
+    for (elem <- this) {
+      for ((k,v) <- f(elem).iterator()){
+        if (contains(k) && this(k) == v) {
+          toKeep += ((k,v)) 
+        } else {
+          toAdd += ((k,v)) 
         }
-    for (elem <- toRemove) coll -= elem
-    for (elem <- toAdd) coll += elem
+      }
+    }
+    coll.clear()
+    coll ++= toKeep
+    coll ++= toAdd
     this
   }
 

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -74,14 +74,18 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   def flatMapInPlace(f: A => IterableOnce[A]): this.type = {
     val toAdd = Set[A]()
     val toRemove = Set[A]()
-    for (elem <- this)
+    toRemove ++= this
+
+    for (elem <- this){
       for (mapped <- f(elem).iterator())
-        if (!contains(mapped)) {
-          toAdd += mapped
-          toRemove -= elem
+        if(contains(mapped)) {
+          toRemove -= mapped 
+        } else  {
+          toAdd += mapped 
         }
-    for (elem <- toRemove) coll -= elem
-    for (elem <- toAdd) coll += elem
+    }
+    coll --= toRemove
+    coll ++= toAdd 
     this
   }
 

--- a/test/junit/scala/collection/mutable/HashMapTest.scala
+++ b/test/junit/scala/collection/mutable/HashMapTest.scala
@@ -68,4 +68,29 @@ class HashMapTest {
     assert(hm.size == 1)
     assert(hm.toList.head._2 > 1)
   }
+
+  @Test
+  def flatMapInPlace(): Unit = {
+    val hm = mutable.HashMap(1 -> 1, 2 -> 2)
+    val fmip = hm.flatMapInPlace { case (k, v) => HashMap(k * 2 -> v * 2) }
+    assert(fmip.size == 2)
+    assert(fmip == HashMap(2 -> 2, 4 -> 4))
+  }
+
+  @Test
+  def flatMapInPlace_reducedToOneKey(): Unit = {
+    val hm = mutable.HashMap(1 -> 1, 2 -> 2, 3->3)
+    val fmip = hm.flatMapInPlace { case (_, v) => HashMap(1 -> v) }
+    assert(fmip.size == 1)
+    assert(fmip.contains(1))
+    assert(fmip(1) == 1 || fmip(1) == 2 || fmip(1) == 3)
+  }
+
+  @Test // From collection/strawman #509
+  def flatMapInPlace_dropElements(): Unit = {
+    val hm = mutable.HashMap(1 -> 1)
+    val empty = mutable.HashMap.empty[Int, Int]
+    val fmip = hm.flatMapInPlace(_ => empty)
+    assert(fmip.size == 0)
+  }
 }

--- a/test/junit/scala/collection/mutable/SetTest.scala
+++ b/test/junit/scala/collection/mutable/SetTest.scala
@@ -29,4 +29,26 @@ class SetTest {
     s.clear()
     assertEquals(new MySet(Set()), s)
   }
+
+  @Test
+  def flatMapInPlace(): Unit = {
+    val s = Set(1, 2)
+    val tens = s.flatMapInPlace(e => Set(e, e + 10))
+    assert(tens == Set(1, 11, 2, 12))
+  }
+
+  @Test
+  def flatMapInPlaceAddOne(): Unit = {
+    val s = Set(1, 2, 3)
+    val ss = s.flatMapInPlace(e => Set(e + 1, e + 2))
+    assert(ss == Set(2, 3, 4, 5))
+  }
+
+  @Test // From strawman collection #509
+  def flatMapInPlace_dropElements(): Unit = {
+    val set = Set(1)
+    val empty = Set.empty[Int]
+    val fmip = set.flatMapInPlace(_ => empty)
+    assert(fmip.size == 0)
+  }
 }


### PR DESCRIPTION
Change the approach instead of using toAdd and toRemove, now using `toAdd` and `toKeep`.
After getting these two, clear the collection and combine them both.


Fix scala/collection-strawman#509