### PR TITLE
bug#10834 Override SortedMap#transform

### DIFF
--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -62,6 +62,8 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _]
         while (it.hasNext) result = result + it.next()
         result
     }
+
+    override def transform[W](f: (K, V) => W): CC[K, W] = map({ case (k, v) => (k, f(k, v)) })
 }
 
 object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {

--- a/test/junit/scala/collection/immutable/SortedMapTest.scala
+++ b/test/junit/scala/collection/immutable/SortedMapTest.scala
@@ -97,6 +97,12 @@ class SortedMapTest {
     assertEquals("element missing", newMap(4))
   }
 
+  @Test
+  def testTransformReturnsSortedMap(): Unit = {
+    val tm = SortedMap(1 -> 1).transform(_ + _)
+    assert((tm: SortedMap[Int, Int]).isInstanceOf[SortedMap[_, _]])
+  }
+
   private def defaultValueFunction: Int => String = {
     i => s"$i is not present in this map"
   }


### PR DESCRIPTION
Override SortedMap#transform to return a SortedMap.

Fixes scala/bug#10834