### PR TITLE
Deprecate floating-point Ranges

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -497,9 +497,11 @@ object Range {
     implicit val doubleAsIntegral = scala.math.Numeric.DoubleAsIfIntegral
     def toBD(x: Double): BigDecimal = scala.math.BigDecimal valueOf x
 
+    @deprecated("use Range.BigDecimal instead", "2.12.6")
     def apply(start: Double, end: Double, step: Double) =
       BigDecimal(toBD(start), toBD(end), toBD(step)) mapRange (_.doubleValue)
 
+    @deprecated("use Range.BigDecimal.inclusive instead", "2.12.6")
     def inclusive(start: Double, end: Double, step: Double) =
       BigDecimal.inclusive(toBD(start), toBD(end), toBD(step)) mapRange (_.doubleValue)
   }

--- a/src/library/scala/runtime/ScalaNumberProxy.scala
+++ b/src/library/scala/runtime/ScalaNumberProxy.scala
@@ -64,10 +64,10 @@ trait FractionalProxy[T] extends Any with ScalaNumberProxy[T] with RangedProxy[T
   type ResultWithoutStep = Range.Partial[T, NumericRange[T]]
 
   def isWhole() = false
-  def until(end: T): ResultWithoutStep                  = new Range.Partial(NumericRange(self, end, _))
-  def until(end: T, step: T): NumericRange.Exclusive[T] = NumericRange(self, end, step)
-  def to(end: T): ResultWithoutStep                     = new Range.Partial(NumericRange.inclusive(self, end, _))
-  def to(end: T, step: T): NumericRange.Inclusive[T]    = NumericRange.inclusive(self, end, step)
+  @deprecated("use BigDecimal range instead", "2.12.6") def until(end: T): ResultWithoutStep                  = new Range.Partial(NumericRange(self, end, _))
+  @deprecated("use BigDecimal range instead", "2.12.6") def until(end: T, step: T): NumericRange.Exclusive[T] = NumericRange(self, end, step)
+  @deprecated("use BigDecimal range instead", "2.12.6") def to(end: T): ResultWithoutStep                     = new Range.Partial(NumericRange.inclusive(self, end, _))
+  @deprecated("use BigDecimal range instead", "2.12.6") def to(end: T, step: T): NumericRange.Inclusive[T]    = NumericRange.inclusive(self, end, step)
 }
 
 trait OrderedProxy[T] extends Any with Ordered[T] with Typed[T] {

--- a/test/files/run/t3518.check
+++ b/test/files/run/t3518.check
@@ -1,0 +1,12 @@
+t3518.scala:2: warning: method to in trait FractionalProxy is deprecated (since 2.12.6): use BigDecimal range instead
+  val r1 = 1.0 to 10.0 by 0.5
+               ^
+t3518.scala:3: warning: method to in trait FractionalProxy is deprecated (since 2.12.6): use BigDecimal range instead
+  val r2 = 1.0 to 1.0 by 1.0
+               ^
+t3518.scala:4: warning: method to in trait FractionalProxy is deprecated (since 2.12.6): use BigDecimal range instead
+  val r3 = 10.0 to 1.0 by -0.5
+                ^
+t3518.scala:5: warning: method until in trait FractionalProxy is deprecated (since 2.12.6): use BigDecimal range instead
+  val r4 = 1.0 until 1.0 by 1.0
+               ^

--- a/test/files/run/t3518.flags
+++ b/test/files/run/t3518.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/files/run/t4201.check
+++ b/test/files/run/t4201.check
@@ -1,0 +1,3 @@
+t4201.scala:3: warning: method to in trait FractionalProxy is deprecated (since 2.12.6): use BigDecimal range instead
+    val f = 0.0 to 1.0 by 1.0 / 3.0
+                ^

--- a/test/files/run/t4201.flags
+++ b/test/files/run/t4201.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/files/run/t5857.check
+++ b/test/files/run/t5857.check
@@ -1,0 +1,6 @@
+t5857.scala:25: warning: method to in trait FractionalProxy is deprecated (since 2.12.6): use BigDecimal range instead
+    val numeric = 1.0 to sz.toDouble by 1
+                      ^
+t5857.scala:29: warning: method to in trait FractionalProxy is deprecated (since 2.12.6): use BigDecimal range instead
+    val numdesc = sz.toDouble to 1.0 by -1
+                              ^

--- a/test/files/run/t5857.flags
+++ b/test/files/run/t5857.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/files/run/t9656.check
+++ b/test/files/run/t9656.check
@@ -1,3 +1,9 @@
+t9656.scala:17: warning: method until in trait FractionalProxy is deprecated (since 2.12.6): use BigDecimal range instead
+  println(0.1 until 1.0 by 0.1)
+              ^
+t9656.scala:19: warning: method apply in object Double is deprecated (since 2.12.6): use Range.BigDecimal instead
+  println(Range.Double(0.1, 1.0, 0.1))
+                ^
 Range 1 to 10
 Range 1 to 10
 inexact Range 1 to 10 by 2

--- a/test/files/run/t9656.flags
+++ b/test/files/run/t9656.flags
@@ -1,0 +1,1 @@
+-deprecation


### PR DESCRIPTION
Ref scala/bug#10781

This is in preparation for Float range and Double range removal in 2.13.x (scala/scala#6468).