### PR TITLE
Move the patmat phase after superaccessors

### DIFF
--- a/test/files/neg/t6446-additional.check
+++ b/test/files/neg/t6446-additional.check
@@ -4,8 +4,8 @@
          namer   2  resolve names, attach symbols to named trees
 packageobjects   3  load package objects
          typer   4  the meat and potatoes: type the trees
-        patmat   5  translate match expressions
-superaccessors   6  add super accessors in traits and nested classes
+superaccessors   5  add super accessors in traits and nested classes
+        patmat   6  translate match expressions
     extmethods   7  add extension methods for inline classes
        pickler   8  serialize symbol tables
      refchecks   9  reference/override checking, translate nested objects

--- a/test/files/neg/t6446-missing.check
+++ b/test/files/neg/t6446-missing.check
@@ -5,8 +5,8 @@ Error: unable to load class: t6446.Ploogin
          namer   2  resolve names, attach symbols to named trees
 packageobjects   3  load package objects
          typer   4  the meat and potatoes: type the trees
-        patmat   5  translate match expressions
-superaccessors   6  add super accessors in traits and nested classes
+superaccessors   5  add super accessors in traits and nested classes
+        patmat   6  translate match expressions
     extmethods   7  add extension methods for inline classes
        pickler   8  serialize symbol tables
      refchecks   9  reference/override checking, translate nested objects

--- a/test/files/neg/t6446-show-phases.check
+++ b/test/files/neg/t6446-show-phases.check
@@ -4,8 +4,8 @@
          namer   2  resolve names, attach symbols to named trees
 packageobjects   3  load package objects
          typer   4  the meat and potatoes: type the trees
-        patmat   5  translate match expressions
-superaccessors   6  add super accessors in traits and nested classes
+superaccessors   5  add super accessors in traits and nested classes
+        patmat   6  translate match expressions
     extmethods   7  add extension methods for inline classes
        pickler   8  serialize symbol tables
      refchecks   9  reference/override checking, translate nested objects

--- a/test/files/neg/t7494-no-options.check
+++ b/test/files/neg/t7494-no-options.check
@@ -5,8 +5,8 @@ error: Error: ploogin takes no options
          namer   2  resolve names, attach symbols to named trees
 packageobjects   3  load package objects
          typer   4  the meat and potatoes: type the trees
-        patmat   5  translate match expressions
-superaccessors   6  add super accessors in traits and nested classes
+superaccessors   5  add super accessors in traits and nested classes
+        patmat   6  translate match expressions
     extmethods   7  add extension methods for inline classes
        pickler   8  serialize symbol tables
      refchecks   9  reference/override checking, translate nested objects

--- a/test/files/run/programmatic-main.check
+++ b/test/files/run/programmatic-main.check
@@ -4,8 +4,8 @@
          namer   2  resolve names, attach symbols to named trees
 packageobjects   3  load package objects
          typer   4  the meat and potatoes: type the trees
-        patmat   5  translate match expressions
-superaccessors   6  add super accessors in traits and nested classes
+superaccessors   5  add super accessors in traits and nested classes
+        patmat   6  translate match expressions
     extmethods   7  add extension methods for inline classes
        pickler   8  serialize symbol tables
      refchecks   9  reference/override checking, translate nested objects


### PR DESCRIPTION
In dotty, pickling trees into Tasty is done after the super accessors
phase but before the pattern matching phase. But in scalac, patmat comes
before superaccessors. This commit simply swaps these phases around,
thus making it possible to write a compiler plugin for scalac that
produces a Tasty file from the output of the superaccessors phase.