### PR TITLE
Unmangle the output of //print in the REPL

### DIFF
--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ReplCompletion.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ReplCompletion.scala
@@ -7,6 +7,7 @@ package scala.tools.nsc.interpreter.shell
 import scala.util.control.NonFatal
 import scala.tools.nsc.interpreter.Repl
 import scala.tools.nsc.interpreter.jline
+import scala.tools.nsc.interpreter.Naming
 
 class ReplCompletion(intp: Repl) extends jline.JLineCompletion {
   import ReplCompletion._
@@ -58,13 +59,15 @@ class ReplCompletion(intp: Repl) extends jline.JLineCompletion {
 
     // secret handshakes
     val slashPrint  = """.*// *print *""".r
+    val slashPrintRaw  = """.*// *printRaw *""".r
     val slashTypeAt = """.*// *typeAt *(\d+) *(\d+) *""".r
     try {
       intp.presentationCompile(cursor, buf) match {
         case Left(_) => NoCompletions
         case Right(result) => try {
           buf match {
-            case slashPrint() if cursor == buf.length => CompletionResult(cursor, "" :: result.print :: Nil)
+            case slashPrint() if cursor == buf.length => CompletionResult(cursor, "" :: Naming.unmangle(result.print) :: Nil)
+            case slashPrintRaw() if cursor == buf.length => CompletionResult(cursor, "" :: result.print :: Nil)
             case slashTypeAt(start, end) if cursor == buf.length => CompletionResult(cursor, "" :: result.typeAt(start.toInt, end.toInt) :: Nil)
             case _ => val (c, r) = result.candidates(tabCount); CompletionResult(c, r)
           }


### PR DESCRIPTION
The old behavior is available as //printRaw.

Before:

```
scala> def foo = List(1, 2, 3)
foo: List[Int]

scala> for {i <- foo; j <- foo} yield i + j //print
   $line8.$read.$iw.$iw.foo.flatMap[Int](((i: Int) => $line8.$read.$iw.$iw.foo.map[Int](((j: Int) => i.+(j))))) // : List[Int]
```

After:
```
scala> for {i <- foo; j <- foo} yield i + j //print
   foo.flatMap[Int](((i: Int) => foo.map[Int](((j: Int) => i.+(j))))) // : List[Int]

scala> for {i <- foo; j <- foo} yield i + j //printRaw
   $line8.$read.$iw.$iw.foo.flatMap[Int](((i: Int) => $line8.$read.$iw.$iw.foo.map[Int](((j: Int) => i.+(j))))) // : List[Int]
```

My first thought was adding a command like `//printFilter`, inspired by `:javap -filter`. But I think cleaning up the REPL artifacts should be the default behavior in this case. And `//printRaw` sounds better...