### PR TITLE
Update check file to fix the build

### DIFF
--- a/test/files/neg/string-context-refchecked.check
+++ b/test/files/neg/string-context-refchecked.check
@@ -1,5 +1,5 @@
 string-context-refchecked.scala:3: error: overriding method foo in class C of type => Int;
- method foo cannot override final member
+  method foo cannot override final member
   s"foo${class D extends C { def foo = 2 }; new D}bar"
                                  ^
 one error found


### PR DESCRIPTION
Caused by the change in https://github.com/scala/scala/pull/6350.
Not sure how the race condition happened exactly, maybe the test case
was merged from 2.12.x somewhere in the meantime.