### PR TITLE
Prepare to make postfixOps syntax an error (not just a warning) unless the feature is explicitly enabled

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1438,6 +1438,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       units foreach addUnit
       reporter.reset()
       warnDeprecatedAndConflictingSettings()
+      checkGoldenUnits(units)
       globalPhase = fromPhase
 
       val timePhases = statistics.areStatisticsLocallyEnabled
@@ -1519,6 +1520,16 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
 
       // Clear any sets or maps created via perRunCaches.
       perRunCaches.clearAll()
+    }
+
+    // special dispensations for golden units
+    def checkGoldenUnits(units: List[CompilationUnit]): Unit = {
+      units match {
+        case u :: Nil if u.source.file.path.endsWith("xsbt/Compat.scala") =>
+          val ss = settings
+          ss.language.enable(ss.languageFeatures.postfixOps)
+        case _ =>
+      }
     }
 
     /** Compile list of abstract files. */

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -60,11 +60,11 @@ trait ScalaSettings extends AbsScalaSettings
   // The two requirements: delay error checking until you have symbols, and let compiler command build option-specific help.
   object languageFeatures extends MultiChoiceEnumeration {
     val dynamics            = Choice("dynamics",            "Allow direct or indirect subclasses of scala.Dynamic")
-    val postfixOps          = Choice("postfixOps",          "Allow postfix operator notation, such as `1 to 10 toList'")
-    val reflectiveCalls     = Choice("reflectiveCalls",     "Allow reflective access to members of structural types")
-    val implicitConversions = Choice("implicitConversions", "Allow definition of implicit functions called views")
-    val higherKinds         = Choice("higherKinds",         "Allow higher-kinded types")
     val existentials        = Choice("existentials",        "Existential types (besides wildcard types) can be written and inferred")
+    val higherKinds         = Choice("higherKinds",         "Allow higher-kinded types")
+    val implicitConversions = Choice("implicitConversions", "Allow definition of implicit functions called views")
+    val postfixOps          = Choice("postfixOps",          "Allow postfix operator notation, such as `1 to 10 toList` (not recommended)")
+    val reflectiveCalls     = Choice("reflectiveCalls",     "Allow reflective access to members of structural types")
     val macros              = Choice("experimental.macros", "Allow macro definition (besides implementation and application)")
   }
   val language      = {

--- a/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
@@ -188,10 +188,10 @@ trait AccessorSynthesis extends Transform with ast.TreeDSL {
         bitmapSyms
       }
 
-      fields groupBy bitmapCategory flatMap {
+      fields.groupBy(bitmapCategory).flatMap {
         case (category, fields) if category != nme.NO_NAME && fields.nonEmpty => allocateBitmaps(fields, category): Iterable[Symbol]
         case _ => Nil
-      } toList
+      }.toList
     }
 
     def slowPathFor(lzyVal: Symbol): Symbol = _slowPathFor(lzyVal)

--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -423,7 +423,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
 
         // afterOwnPhase, so traits receive trait setters for vals (needs to be at finest grain to avoid looping)
         val synthInSubclass =
-          clazz.mixinClasses.flatMap(mixin => afterOwnPhase{mixin.info}.decls.toList.filter(accessorImplementedInSubclass))
+          clazz.mixinClasses.flatMap(mixin => afterOwnPhase(mixin.info).decls.toList.filter(accessorImplementedInSubclass))
 
         // mixin field accessors --
         // invariant: (accessorsMaybeNeedingImpl, mixedInAccessorAndFields).zipped.forall(case (acc, clone :: _) => `clone` is clone of `acc` case _ => true)
@@ -679,14 +679,14 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
         synthAccessorInClass.expandLazyClassMember(lazyVar, getter, rhs)
       }
 
-      (afterOwnPhase { clazz.info.decls }.toList) filter checkAndClearNeedsTrees map {
+      afterOwnPhase(clazz.info.decls).toList.filter(checkAndClearNeedsTrees).map {
         case module if module hasAllFlags (MODULE | METHOD) => moduleAccessorBody(module)
         case getter if getter hasAllFlags (LAZY | METHOD)   => superLazy(getter)
         case setter if setter.isSetter                      => setterBody(setter)
         case getter if getter.hasFlag(ACCESSOR)             => getterBody(getter)
         case field  if !(field hasFlag METHOD)              => mkTypedValDef(field) // vals/vars and module vars (cannot have flags PACKAGE | JAVA since those never receive NEEDS_TREES)
         case _ => EmptyTree
-      } filterNot (_ == EmptyTree) // there will likely be many EmptyTrees, but perhaps no thicket blocks that need expanding
+      }.filterNot(_ == EmptyTree) // there will likely be many EmptyTrees, but perhaps no thicket blocks that need expanding
     }
 
     def rhsAtOwner(stat: ValOrDefDef, newOwner: Symbol): Tree =

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -730,21 +730,19 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
      *          if feature check is delayed or suppressed because we are past typer: true
      */
     def checkFeature(pos: Position, featureTrait: Symbol, construct: => String = "", immediate: Boolean = false): Boolean =
-      if (isPastTyper) true
-      else {
+      isPastTyper || {
         val nestedOwners =
           featureTrait.owner.ownerChain.takeWhile(_ != languageFeatureModule.moduleClass).reverse
         val featureName = (nestedOwners map (_.name + ".")).mkString + featureTrait.name
         def action(): Boolean = {
           def hasImport = inferImplicitByType(featureTrait.tpe, context).isSuccess
           def hasOption = settings.language contains featureName
-          val OK = hasImport || hasOption
-          if (!OK) {
+          hasOption || hasImport || {
             val Some(AnnotationInfo(_, List(Literal(Constant(featureDesc: String)), Literal(Constant(required: Boolean))), _)) =
               featureTrait getAnnotation LanguageFeatureAnnot
             context.featureWarning(pos, featureName, featureDesc, featureTrait, construct, required)
+            false
           }
-          OK
         }
         if (immediate) {
           action()

--- a/src/library/scala/language.scala
+++ b/src/library/scala/language.scala
@@ -22,11 +22,11 @@ package scala
  *
  *  The language features are:
  *   - [[dynamics            `dynamics`]]            enables defining calls rewriting using the [[scala.Dynamic `Dynamic`]] trait
- *   - [[postfixOps          `postfixOps`]]          enables postfix operators
- *   - [[reflectiveCalls     `reflectiveCalls`]]     enables using structural types
- *   - [[implicitConversions `implicitConversions`]] enables defining implicit methods and members
- *   - [[higherKinds         `higherKinds`]]         enables writing higher-kinded types
  *   - [[existentials        `existentials`]]        enables writing existential types
+ *   - [[higherKinds         `higherKinds`]]         enables writing higher-kinded types
+ *   - [[implicitConversions `implicitConversions`]] enables defining implicit methods and members
+ *   - [[postfixOps          `postfixOps`]]          enables postfix operator notation
+ *   - [[reflectiveCalls     `reflectiveCalls`]]     enables using structural types
  *   - [[experimental        `experimental`]]        contains newer features that have not yet been tested in production
  *
  *  @groupname production   Language Features
@@ -37,10 +37,11 @@ object language {
 
   import languageFeature._
 
-  /** Where enabled, direct or indirect subclasses of trait scala.Dynamic can
-   *  be defined. Unless dynamics is enabled, a definition of a class, trait,
-   *  or object that has Dynamic as a base trait is rejected. Dynamic member
-   *  selection of existing subclasses of trait Dynamic are unaffected;
+  /** Only where this feature is enabled, can direct or indirect subclasses of trait scala.Dynamic
+   *  be defined. If `dynamics` is not enabled, a definition of a class, trait,
+   *  or object that has `Dynamic` as a base trait is rejected by the compiler.
+   *
+   *  Selections of dynamic members of existing subclasses of trait `Dynamic` are unaffected;
    *  they can be used anywhere.
    *
    *  '''Why introduce the feature?''' To enable flexible DSLs and convenient interfacing
@@ -54,19 +55,28 @@ object language {
    */
   implicit lazy val dynamics: dynamics = languageFeature.dynamics
 
-  /** Only where enabled, postfix operator notation `(expr op)` will be allowed.
+  /** Only where this feature is enabled, is postfix operator notation `(expr op)` permitted.
+   *  If `postfixOps` is not enabled, an expression using postfix notation is rejected by the compiler.
    *
-   *  '''Why keep the feature?''' Several DSLs written in Scala need the notation.
+   *  '''Why keep the feature?''' Postfix notation is preserved for backward
+   *  compatibility only. Historically, several DSLs written in Scala need the notation.
    *
    *  '''Why control it?''' Postfix operators interact poorly with semicolon inference.
-   *   Most programmers avoid them for this reason.
+   *   Most programmers avoid them for this reason alone. Postfix syntax is
+   *   associated with an abuse of infix notation, `a op1 b op2 c op3`,
+   *   that can be harder to read than ordinary method invocation with judicious
+   *   use of parentheses. It is recommended not to enable this feature except for
+   *   legacy code.
    *
    *  @group production
    */
   implicit lazy val postfixOps: postfixOps = languageFeature.postfixOps
 
-  /** Only where enabled, accesses to members of structural types that need
-   *  reflection are supported. Reminder: A structural type is a type of the form
+  /** Where this feature is enabled, accesses to members of structural types that need
+   *  reflection are supported. If `reflectiveCalls` is not enabled, an expression
+   *  requiring reflection will trigger a warning from the compiler.
+   *
+   *  A structural type is a type of the form
    *  `Parents { Decls }` where `Decls` contains declarations of new members that do
    *  not override any member in `Parents`. To access one of these members, a
    *  reflective call is needed.
@@ -83,8 +93,11 @@ object language {
    */
   implicit lazy val reflectiveCalls: reflectiveCalls = languageFeature.reflectiveCalls
 
-  /** Only where enabled, definitions of implicit conversions are allowed. An
-   *  implicit conversion is an implicit value of unary function type `A => B`,
+  /** Where this feature is enabled, definitions of implicit conversions are allowed.
+   *  If `implicitConversions` is not enabled, the definition of an implicit
+   *  conversion will trigger a warning from the compiler.
+   *
+   *  An implicit conversion is an implicit value of unary function type `A => B`,
    *  or an implicit method that has in its first parameter section a single,
    *  non-implicit parameter. Examples:
    *
@@ -94,8 +107,8 @@ object language {
    *     implicit def listToX(xs: List[T])(implicit f: T => X): X = ...
    *  }}}
    *
-   *  implicit values of other types are not affected, and neither are implicit
-   *  classes.
+   *  Implicit classes and implicit values of other types are not governed by this
+   *  language feature.
    *
    *  '''Why keep the feature?''' Implicit conversions are central to many aspects
    *  of Scala’s core libraries.
@@ -110,7 +123,9 @@ object language {
    */
   implicit lazy val implicitConversions: implicitConversions = languageFeature.implicitConversions
 
-  /** Only where this flag is enabled, higher-kinded types can be written.
+  /** Where this feature is enabled, higher-kinded types can be written.
+   *  If `higherKinds` is not enabled, a higher-kinded type such as `F[A]`
+   *  will trigger a warning from the compiler.
    *
    *  '''Why keep the feature?''' Higher-kinded types enable the definition of very general
    *  abstractions such as functor, monad, or arrow. A significant set of advanced
@@ -133,9 +148,12 @@ object language {
    */
   implicit lazy val higherKinds: higherKinds = languageFeature.higherKinds
 
-  /** Only where enabled, existential types that cannot be expressed as wildcard
+  /** Where this feature is enabled, existential types that cannot be expressed as wildcard
    *  types can be written and are allowed in inferred types of values or return
-   *  types of methods. Existential types with wildcard type syntax such as `List[_]`,
+   *  types of methods. If `existentials` is not enabled, those cases will trigger
+   *  a warning from the compiler.
+   *
+   *  Existential types with wildcard type syntax such as `List[_]`,
    *  or `Map[String, _]` are not affected.
    *
    *  '''Why keep the feature?''' Existential types are needed to make sense of Java’s wildcard
@@ -151,8 +169,8 @@ object language {
    */
   implicit lazy val existentials: existentials = languageFeature.existentials
 
-  /** The experimental object contains features that have been recently added but have not
-   *  been thoroughly tested in production yet.
+  /** The experimental object contains features that are known to have unstable API or
+   *  behavior that may change in future releases.
    *
    *  Experimental features '''may undergo API changes''' in future releases, so production
    *  code should not rely on them.
@@ -167,8 +185,11 @@ object language {
 
     import languageFeature.experimental._
 
-    /** Where enabled, macro definitions are allowed. Macro implementations and
-     *  macro applications are unaffected; they can be used anywhere.
+    /** Only where this feature is enabled, are macro definitions allowed.
+     *  If `macros` is not enabled, macro definitions are rejected by the compiler.
+     *
+     *  Macro implementations and macro applications are not governed by this
+     *  language feature; they can be used anywhere.
      *
      *  '''Why introduce the feature?''' Macros promise to make the language more regular,
      *  replacing ad-hoc language constructs with a general powerful abstraction

--- a/src/library/scala/language.scala
+++ b/src/library/scala/language.scala
@@ -25,7 +25,7 @@ package scala
  *   - [[existentials        `existentials`]]        enables writing existential types
  *   - [[higherKinds         `higherKinds`]]         enables writing higher-kinded types
  *   - [[implicitConversions `implicitConversions`]] enables defining implicit methods and members
- *   - [[postfixOps          `postfixOps`]]          enables postfix operator notation
+ *   - [[postfixOps          `postfixOps`]]          enables postfix operators (not recommended)
  *   - [[reflectiveCalls     `reflectiveCalls`]]     enables using structural types
  *   - [[experimental        `experimental`]]        contains newer features that have not yet been tested in production
  *

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/InteractiveReader.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/InteractiveReader.scala
@@ -86,11 +86,11 @@ class SplashLoop(in: InteractiveReader, prompt: String) extends Runnable {
     var help = f"// Entering paste mode (ctrl-D to finish)%n%n"
 
     val text =
-      try Iterator.continually(in.readLine(help))
-                  .takeWhile { x => help = ""
-                               x != null && running }
-                  .mkString(EOL)
-                  .trim
+      try
+        Iterator.continually(in.readLine(help)).takeWhile { x =>
+          help = ""
+          x != null && running
+        }.mkString(EOL).trim
       catch { case ie: InterruptedException => "" } // TODO let the exception bubble up, or at least signal the interrupt happened?
 
     val next =

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Pasted.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Pasted.scala
@@ -53,10 +53,10 @@ abstract class Pasted(prompt: String, continuePrompt: String, continueText: Stri
   private val resAssign    = """^val (res\d+).*""".r
 
   private class PasteAnalyzer(val lines: List[String]) {
-    val referenced = lines.flatMap(resReference findAllIn _.trim.stripPrefix("res")).toSet
-    val ActualPromptString = lines find matchesPrompt map (s =>
-      if (matchesString(s, PromptString)) PromptString else AltPromptString) getOrElse PromptString
-    val cmds       = (lines reduceLeft append split ActualPromptString filterNot(_.trim == "")).toList
+    val referenced = lines.flatMap(s => resReference.findAllIn(s.trim.stripPrefix("res"))).toSet
+    val ActualPromptString = lines.find(matchesPrompt).map(s =>
+      if (matchesString(s, PromptString)) PromptString else AltPromptString).getOrElse(PromptString)
+    val cmds       = lines.reduceLeft(append).split(ActualPromptString).filterNot(_.trim == "").toList
 
     /** If it's a prompt or continuation line, strip the formatting bits and
      *  assemble the code.  Otherwise ship it off to be analyzed for res references

--- a/src/repl/scala/tools/nsc/interpreter/AbstractOrMissingHandler.scala
+++ b/src/repl/scala/tools/nsc/interpreter/AbstractOrMissingHandler.scala
@@ -16,22 +16,22 @@ class AbstractOrMissingHandler[T](onError: String => Unit, value: T) extends Par
     case _                          => false
   }
   def apply(t: Throwable) = t match {
-    case x @ (_: AbstractMethodError | _: NoSuchMethodError | _: NoClassDefFoundError) =>
-      onError("""
-        |Failed to initialize compiler: %s.
+    case e @ (_: AbstractMethodError | _: NoSuchMethodError | _: NoClassDefFoundError) =>
+      onError(s"""
+        |Failed to initialize compiler: ${e.getClass.getName.split('.').last}.
         |This is most often remedied by a full clean and recompile.
         |Otherwise, your classpath may continue bytecode compiled by
         |different and incompatible versions of scala.
-        |""".stripMargin.format(x.getClass.getName.split('.').last)
+        |""".stripMargin
       )
-      x.printStackTrace()
+      e.printStackTrace()
       value
-    case x: MissingRequirementError =>
-      onError("""
-        |Failed to initialize compiler: %s not found.
+    case e: MissingRequirementError =>
+      onError(s"""
+        |Failed to initialize compiler: ${e.req} not found.
         |** Note that as of 2.8 scala does not assume use of the java classpath.
         |** For the old behavior pass -usejavacp to scala, or if using a Settings
-        |** object programmatically, settings.usejavacp.value = true.""".stripMargin.format(x.req)
+        |** object programmatically, settings.usejavacp.value = true.""".stripMargin
       )
       value
   }

--- a/src/repl/scala/tools/nsc/interpreter/Imports.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Imports.scala
@@ -44,9 +44,7 @@ trait Imports {
    *  scope twiddling which should be swept away in favor of digging
    *  into the compiler scopes.
    */
-  def sessionWildcards: List[Type] = {
-    importHandlers filter (_.importsWildcard) map (_.targetType) distinct
-  }
+  def sessionWildcards: List[Type] = importHandlers.filter(_.importsWildcard).map(_.targetType).distinct
 
   def languageSymbols        = languageWildcardSyms flatMap membersAtPickler
   def sessionImportedSymbols = importHandlers flatMap (_.importedSymbols)

--- a/src/repl/scala/tools/nsc/interpreter/Power.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Power.scala
@@ -242,7 +242,7 @@ class Power[ReplValsImpl <: ReplVals : ru.TypeTag: ClassTag](val intp: IMain, re
     // make an url out of the string
     def u: URL = (
       if (s contains ":") new URL(s)
-      else if ((new java.io.File(s)).exists) new java.io.File(s).toURI.toURL
+      else if (new java.io.File(s).exists) new java.io.File(s).toURI.toURL
       else new URL("http://" + s)
     )
   }

--- a/test/files/run/macro-expand-varargs-explicit-over-nonvarargs-good/Impls_1.scala
+++ b/test/files/run/macro-expand-varargs-explicit-over-nonvarargs-good/Impls_1.scala
@@ -3,7 +3,7 @@ import scala.reflect.macros.blackbox.Context
 object Impls {
   def foo(c: Context)(xs: c.Expr[Int]*) = {
     import c.universe._
-    val stripped_xs = xs map (_.tree) toList match {
+    val stripped_xs = xs.map(_.tree).toList match {
       case List(Typed(stripped, Ident(wildstar))) if wildstar == typeNames.WILDCARD_STAR => List(stripped)
       case _ => ???
     }

--- a/test/files/run/reflection-magicsymbols-repl.check
+++ b/test/files/run/reflection-magicsymbols-repl.check
@@ -15,11 +15,10 @@ scala> class A {
 defined class A
 
 scala> def test(n: Int): Unit = {
-  val sig = typeOf[A] member TermName("foo" + n) info
+  val sig = typeOf[A].member(TermName("foo" + n)).info
   val x = sig.asInstanceOf[MethodType].params.head
   println(x.info)
 }
-warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 test: (n: Int)Unit
 
 scala> for (i <- 1 to 8) test(i)

--- a/test/files/run/reflection-magicsymbols-repl.scala
+++ b/test/files/run/reflection-magicsymbols-repl.scala
@@ -14,7 +14,7 @@ object Test extends ReplTest {
     |  def foo8(x: Singleton) = ???
     |}
     |def test(n: Int): Unit = {
-    |  val sig = typeOf[A] member TermName("foo" + n) info
+    |  val sig = typeOf[A].member(TermName("foo" + n)).info
     |  val x = sig.asInstanceOf[MethodType].params.head
     |  println(x.info)
     |}

--- a/test/scalacheck/redblacktree.scala
+++ b/test/scalacheck/redblacktree.scala
@@ -178,7 +178,7 @@ object TestRange extends RedBlackTreeTest with RedBlackTreeInvariants  {
   override type ModifyParm = (Option[Int], Option[Int])
   override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = for {
     from <- choose(0, iterator(tree).size)
-    to <- choose(0, iterator(tree).size) suchThat (from <=)
+    to <- choose(0, iterator(tree).size) suchThat (from <= _)
     optionalFrom <- oneOf(Some(from), None, Some(from)) // Double Some(n) to get around a bug
     optionalTo <- oneOf(Some(to), None, Some(to)) // Double Some(n) to get around a bug
   } yield (optionalFrom, optionalTo)
@@ -200,8 +200,8 @@ object TestRange extends RedBlackTreeTest with RedBlackTreeInvariants  {
     val from = parm._1 flatMap (nodeAt(tree, _) map (_._1))
     val to = parm._2 flatMap (nodeAt(tree, _) map (_._1))
     val filteredTree = (keysIterator(tree)
-      .filter(key => from forall (key >=))
-      .filter(key => to forall (key <))
+      .filter(key => from forall (key >= _))
+      .filter(key => to forall (key < _))
       .toList)
     filteredTree == keysIterator(newTree).toList
   }


### PR DESCRIPTION
Require postfixOps opt-in instead of just warning.

Fixes scala/scala-dev#462