### PR TITLE
use a 2.13-specific partest version with no scala-xml dependency

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -18,6 +18,6 @@ scala.binary.version=2.13.0-M4-pre-20d3c21
 #  - scala-asm: jar content included in scala-compiler
 #  - jline: shaded with JarJar and included in scala-compiler
 #  - partest: used for running the tests
-partest.version.number=1.1.8
+partest.version.number=1.2.0
 scala-asm.version=6.0.0-scala-1
 jline.version=2.14.5


### PR DESCRIPTION
I have verified in advance that this fixes the bootstrap, which was
failing since we ditched scala-xml from this repo