### PR TITLE
Add XML tests to partest

### DIFF
--- a/test/files/neg/xml-doctype.check
+++ b/test/files/neg/xml-doctype.check
@@ -1,0 +1,10 @@
+xml-doctype.scala:4: error: in XML literal: '-' expected instead of 'D'
+    <!DOCTYPE html>
+      ^
+xml-doctype.scala:4: error: in XML literal: '-' expected instead of 'O'
+    <!DOCTYPE html>
+       ^
+xml-doctype.scala:7: error: input ended while parsing XML
+}
+ ^
+three errors found

--- a/test/files/neg/xml-doctype.scala
+++ b/test/files/neg/xml-doctype.scala
@@ -1,0 +1,7 @@
+object foo {
+  val html =
+    <?xml version="1.0"?>
+    <!DOCTYPE html>
+    <html>
+    </html>
+}

--- a/test/files/neg/xml-entitydecl.check
+++ b/test/files/neg/xml-entitydecl.check
@@ -1,0 +1,10 @@
+xml-entitydecl.scala:4: error: in XML literal: '-' expected instead of 'D'
+    <!DOCTYPE html [
+      ^
+xml-entitydecl.scala:4: error: in XML literal: '-' expected instead of 'O'
+    <!DOCTYPE html [
+       ^
+xml-entitydecl.scala:9: error: input ended while parsing XML
+}
+ ^
+three errors found

--- a/test/files/neg/xml-entitydecl.scala
+++ b/test/files/neg/xml-entitydecl.scala
@@ -1,0 +1,9 @@
+object foo {
+  val xml =
+    <?xml version="1.0"?>
+    <!DOCTYPE html [
+      <!ENTITY html (head, body)>
+    ]>
+    <html>
+    </html>
+}

--- a/test/files/pos/xml-attributes.flags
+++ b/test/files/pos/xml-attributes.flags
@@ -1,0 +1,1 @@
+-Ystop-after:parser

--- a/test/files/pos/xml-attributes.scala
+++ b/test/files/pos/xml-attributes.scala
@@ -1,0 +1,8 @@
+object foo {
+  val bar = "baz"
+  val xml =
+    <root lang="en" type='xml'>
+      <child attr="&quot;" foo={bar}/>
+      <child ns:attr="" foo={bar}/>
+    </root>
+}

--- a/test/files/pos/xml-comments.flags
+++ b/test/files/pos/xml-comments.flags
@@ -1,0 +1,1 @@
+-Ystop-after:parser

--- a/test/files/pos/xml-comments.scala
+++ b/test/files/pos/xml-comments.scala
@@ -1,0 +1,8 @@
+object foo {
+  val bar = "baz"
+  val xml = 
+    <root>
+      <!---->
+      <!-- {bar} --->
+    </root>
+}

--- a/test/files/pos/xml-entityref.flags
+++ b/test/files/pos/xml-entityref.flags
@@ -1,0 +1,1 @@
+-Ystop-after:parser

--- a/test/files/pos/xml-entityref.scala
+++ b/test/files/pos/xml-entityref.scala
@@ -1,0 +1,7 @@
+object foo {
+  val bar = "baz"
+  val xml =
+    <root>
+      &amp; &quot; &#x27; &lt; &gt;
+    </root>
+}

--- a/test/files/pos/xml-interpolation.flags
+++ b/test/files/pos/xml-interpolation.flags
@@ -1,0 +1,1 @@
+-Ystop-after:parser

--- a/test/files/pos/xml-interpolation.scala
+++ b/test/files/pos/xml-interpolation.scala
@@ -1,0 +1,9 @@
+object foo {
+  val bar = "baz"
+  val xml = 
+    <root>
+      {bar}
+      { bar }
+      {{ bar }}
+    </root>
+}

--- a/test/files/pos/xml-ns.flags
+++ b/test/files/pos/xml-ns.flags
@@ -1,0 +1,1 @@
+-Ystop-after:parser

--- a/test/files/pos/xml-ns.scala
+++ b/test/files/pos/xml-ns.scala
@@ -1,0 +1,7 @@
+object foo {
+  val bar = "baz"
+  val xml = 
+    <foo:root>
+      <bar:child baz:foo={bar}>{bar}</bar:child>
+    </foo:root>
+}

--- a/test/files/pos/xml-pcdata.flags
+++ b/test/files/pos/xml-pcdata.flags
@@ -1,0 +1,1 @@
+-Ystop-after:parser

--- a/test/files/pos/xml-pcdata.scala
+++ b/test/files/pos/xml-pcdata.scala
@@ -1,0 +1,8 @@
+object foo {
+  val bar = "baz"
+  val xml =
+    <root>
+      <![CDATA[]]>
+      <![CDATA[{bar}]]>
+    </root>
+}

--- a/test/files/pos/xml-procinstr.flags
+++ b/test/files/pos/xml-procinstr.flags
@@ -1,0 +1,1 @@
+-Ystop-after:parser

--- a/test/files/pos/xml-procinstr.scala
+++ b/test/files/pos/xml-procinstr.scala
@@ -1,0 +1,8 @@
+object foo {
+  val bar = "baz"
+  val xml =
+    <?xml-stylesheet href="style.xslt" type="text/xsl"?>
+    <root>
+      <?foo {bar}?>
+    </root>
+}

--- a/test/files/pos/xml-xmlns.flags
+++ b/test/files/pos/xml-xmlns.flags
@@ -1,0 +1,1 @@
+-Ystop-after:parser

--- a/test/files/pos/xml-xmlns.scala
+++ b/test/files/pos/xml-xmlns.scala
@@ -1,0 +1,5 @@
+object foo {
+  val html =
+    <html xmlns="http://www.w3.org/TR/html4/" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    </html>
+}


### PR DESCRIPTION
The dependency on scala-xml was dropped from the build for 2.13 in #6436.  There weren't really very many compiler tests for the XML syntax support, so this will probably be more coverage than there was before.  Because the dependency is dropped we need to use the `-Ystop-after:parser` flag for the `pos` tests.

The tests in the compiler that depend on a scala-xml at runtime are being moved in scala/scala-xml#213.