### PR TITLE
Warn on function literal as statement

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -207,6 +207,7 @@ abstract class TreeInfo {
    */
   def isPureExprForWarningPurposes(tree: Tree): Boolean = tree match {
     case Typed(expr, _)                    => isPureExprForWarningPurposes(expr)
+    case Function(_, _)                    => true
     case EmptyTree | Literal(Constant(())) => false
     case _                                 =>
       def isWarnableRefTree = tree match {

--- a/test/files/jvm/innerClassAttribute.check
+++ b/test/files/jvm/innerClassAttribute.check
@@ -1,0 +1,12 @@
+Classes_1.scala:117: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  ((x: String) => x + "3")
+               ^
+Classes_1.scala:124: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+    ((x: String) => x + "2")
+                 ^
+Classes_1.scala:130: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+    {(s: String) => ()}
+                 ^
+Classes_1.scala:129: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  (s: String) => {
+              ^

--- a/test/files/jvm/javaReflection.check
+++ b/test/files/jvm/javaReflection.check
@@ -1,3 +1,21 @@
+Classes_1.scala:16: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+    (() => "-1")
+        ^
+Classes_1.scala:24: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  (() => "1")
+      ^
+Classes_1.scala:31: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+    (() => "2")
+        ^
+Classes_1.scala:66: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+    (() => () => "5")
+        ^
+Classes_1.scala:75: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  (() => "1")
+      ^
+Classes_1.scala:83: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  (() => "1")
+      ^
 A / A (canon) / A (simple)
 - declared cls: List(class A$B, interface A$C, class A$D$)
 - enclosing   : null (declaring cls) / null (cls) / null (constr) / null (meth)

--- a/test/files/neg/sammy_restrictions.check
+++ b/test/files/neg/sammy_restrictions.check
@@ -1,62 +1,62 @@
 sammy_restrictions.scala:38: error: type mismatch;
  found   : () => Int
  required: NoAbstract
-  (() => 0)      : NoAbstract
-      ^
+  def f0 = (() => 0)      : NoAbstract
+               ^
 sammy_restrictions.scala:39: error: type mismatch;
  found   : Int => Int
  required: TwoAbstract
-  ((x: Int) => 0): TwoAbstract
-            ^
+  def f1 = ((x: Int) => 0): TwoAbstract
+                     ^
 sammy_restrictions.scala:40: error: type mismatch;
  found   : Int => Int
  required: NoEmptyConstructor
-  ((x: Int) => 0): NoEmptyConstructor
-            ^
+  def f2 = ((x: Int) => 0): NoEmptyConstructor
+                     ^
 sammy_restrictions.scala:41: error: type mismatch;
  found   : Int => Int
  required: MultipleConstructorLists
-  ((x: Int) => 0): MultipleConstructorLists
-            ^
+  def f3 = ((x: Int) => 0): MultipleConstructorLists
+                     ^
 sammy_restrictions.scala:42: error: type mismatch;
  found   : Int => Int
  required: OneEmptySecondaryConstructor
-  ((x: Int) => 0): OneEmptySecondaryConstructor // derived class must have an empty *primary* to call.
-            ^
+  def f4 = ((x: Int) => 0): OneEmptySecondaryConstructor // derived class must have an empty *primary* to call.
+                     ^
 sammy_restrictions.scala:43: error: type mismatch;
  found   : Int => Int
  required: MultipleMethodLists
-  ((x: Int) => 0): MultipleMethodLists
-            ^
+  def f5 = ((x: Int) => 0): MultipleMethodLists
+                     ^
 sammy_restrictions.scala:44: error: type mismatch;
  found   : Int => Int
  required: ImplicitConstructorParam
-  ((x: Int) => 0): ImplicitConstructorParam
-            ^
+  def f6 = ((x: Int) => 0): ImplicitConstructorParam
+                     ^
 sammy_restrictions.scala:45: error: type mismatch;
  found   : Int => Int
  required: ImplicitMethodParam
-  ((x: Int) => 0): ImplicitMethodParam
-            ^
+  def f7 = ((x: Int) => 0): ImplicitMethodParam
+                     ^
 sammy_restrictions.scala:46: error: type mismatch;
  found   : Int => Int
  required: PolyMethod
-  ((x: Int) => 0): PolyMethod
-            ^
+  def f8 = ((x: Int) => 0): PolyMethod
+                     ^
 sammy_restrictions.scala:47: error: type mismatch;
  found   : Int => Int
  required: SelfTp
-  ((x: Int) => 0): SelfTp
-            ^
+  def f9 = ((x: Int) => 0): SelfTp
+                     ^
 sammy_restrictions.scala:48: error: type mismatch;
  found   : Int => Int
  required: T1 with U1
-  ((x: Int) => 0): T1 with U1
-            ^
+  def g0 = ((x: Int) => 0): T1 with U1
+                     ^
 sammy_restrictions.scala:49: error: type mismatch;
  found   : Int => Int
  required: Test.NonClassTypeRefinement
     (which expands to)  DerivedOneAbstract with OneAbstract
-  ((x: Int) => 0): NonClassTypeRefinement
-            ^
+  def g1 = ((x: Int) => 0): NonClassTypeRefinement
+                     ^
 12 errors found

--- a/test/files/neg/sammy_restrictions.scala
+++ b/test/files/neg/sammy_restrictions.scala
@@ -35,23 +35,23 @@ object Test {
   type NonClassType = DerivedOneAbstract
 
   // errors:
-  (() => 0)      : NoAbstract
-  ((x: Int) => 0): TwoAbstract
-  ((x: Int) => 0): NoEmptyConstructor
-  ((x: Int) => 0): MultipleConstructorLists
-  ((x: Int) => 0): OneEmptySecondaryConstructor // derived class must have an empty *primary* to call.
-  ((x: Int) => 0): MultipleMethodLists
-  ((x: Int) => 0): ImplicitConstructorParam
-  ((x: Int) => 0): ImplicitMethodParam
-  ((x: Int) => 0): PolyMethod
-  ((x: Int) => 0): SelfTp
-  ((x: Int) => 0): T1 with U1
-  ((x: Int) => 0): NonClassTypeRefinement
+  def f0 = (() => 0)      : NoAbstract
+  def f1 = ((x: Int) => 0): TwoAbstract
+  def f2 = ((x: Int) => 0): NoEmptyConstructor
+  def f3 = ((x: Int) => 0): MultipleConstructorLists
+  def f4 = ((x: Int) => 0): OneEmptySecondaryConstructor // derived class must have an empty *primary* to call.
+  def f5 = ((x: Int) => 0): MultipleMethodLists
+  def f6 = ((x: Int) => 0): ImplicitConstructorParam
+  def f7 = ((x: Int) => 0): ImplicitMethodParam
+  def f8 = ((x: Int) => 0): PolyMethod
+  def f9 = ((x: Int) => 0): SelfTp
+  def g0 = ((x: Int) => 0): T1 with U1
+  def g1 = ((x: Int) => 0): NonClassTypeRefinement
 
   // allowed:
-  ((x: Int) => 0): OneEmptyConstructor
-  ((x: Int) => 0): DerivedOneAbstract
-  ((x: Int) => 0): NonClassType                 // we also allow type aliases in instantiation expressions, if they resolve to a class type
-  ((x: Int) => 0): PolyClass[Int]
-  ((x: Int) => 0): SelfVar
+  def g2 = ((x: Int) => 0): OneEmptyConstructor
+  def g3 = ((x: Int) => 0): DerivedOneAbstract
+  def g4 = ((x: Int) => 0): NonClassType                 // we also allow type aliases in instantiation expressions, if they resolve to a class type
+  def g5 = ((x: Int) => 0): PolyClass[Int]
+  def g6 = ((x: Int) => 0): SelfVar
 }

--- a/test/files/neg/sammy_wrong_arity.check
+++ b/test/files/neg/sammy_wrong_arity.check
@@ -1,52 +1,52 @@
 sammy_wrong_arity.scala:6: error: type mismatch;
  found   : () => Int
  required: T1
-  (() => 0): T1
-      ^
+  def f0 = (() => 0): T1
+               ^
 sammy_wrong_arity.scala:7: error: type mismatch;
  found   : Any => Int
  required: T2
-  ((x: Any) => 0): T2
-            ^
+  def f1 = ((x: Any) => 0): T2
+                     ^
 sammy_wrong_arity.scala:9: error: type mismatch;
  found   : Any => Int
  required: T0
-  ((x: Any) => 0): T0
-            ^
+  def f2 = ((x: Any) => 0): T0
+                     ^
 sammy_wrong_arity.scala:10: error: type mismatch;
  found   : Any => Int
  required: T2
-  ((x: Any) => 0): T2
-            ^
+  def f3 = ((x: Any) => 0): T2
+                     ^
 sammy_wrong_arity.scala:12: error: type mismatch;
  found   : (Any, Any) => Int
  required: T0
-  ((x: Any, y: Any) => 0): T0
-                    ^
+  def f4 = ((x: Any, y: Any) => 0): T0
+                             ^
 sammy_wrong_arity.scala:13: error: type mismatch;
  found   : (Any, Any) => Int
  required: T1
-  ((x: Any, y: Any) => 0): T1
-                    ^
+  def f5 = ((x: Any, y: Any) => 0): T1
+                             ^
 sammy_wrong_arity.scala:15: error: missing parameter type
-  ((x) => 0): T2
-    ^
+  def f6 = ((x) => 0): T2
+             ^
 sammy_wrong_arity.scala:17: error: missing parameter type
-  ((x) => 0): T0
-    ^
+  def f7 = ((x) => 0): T0
+             ^
 sammy_wrong_arity.scala:18: error: missing parameter type
-  ((x) => 0): T2
-    ^
+  def f8 = ((x) => 0): T2
+             ^
 sammy_wrong_arity.scala:20: error: missing parameter type
-  ((x, y) => 0): T0
-    ^
+  def f9 = ((x, y) => 0): T0
+             ^
 sammy_wrong_arity.scala:20: error: missing parameter type
-  ((x, y) => 0): T0
-       ^
+  def f9 = ((x, y) => 0): T0
+                ^
 sammy_wrong_arity.scala:21: error: missing parameter type
-  ((x, y) => 0): T1
-    ^
+  def g0 = ((x, y) => 0): T1
+             ^
 sammy_wrong_arity.scala:21: error: missing parameter type
-  ((x, y) => 0): T1
-       ^
+  def g0 = ((x, y) => 0): T1
+                ^
 13 errors found

--- a/test/files/neg/sammy_wrong_arity.scala
+++ b/test/files/neg/sammy_wrong_arity.scala
@@ -3,20 +3,20 @@ trait T1 { def ap(a: Any): Int }
 trait T2 { def ap(a: Any, b: Any): Int }
 
 class Test {
-  (() => 0): T1
-  ((x: Any) => 0): T2
+  def f0 = (() => 0): T1
+  def f1 = ((x: Any) => 0): T2
 
-  ((x: Any) => 0): T0
-  ((x: Any) => 0): T2
+  def f2 = ((x: Any) => 0): T0
+  def f3 = ((x: Any) => 0): T2
 
-  ((x: Any, y: Any) => 0): T0
-  ((x: Any, y: Any) => 0): T1
+  def f4 = ((x: Any, y: Any) => 0): T0
+  def f5 = ((x: Any, y: Any) => 0): T1
 
-  ((x) => 0): T2
+  def f6 = ((x) => 0): T2
 
-  ((x) => 0): T0
-  ((x) => 0): T2
+  def f7 = ((x) => 0): T0
+  def f8 = ((x) => 0): T2
 
-  ((x, y) => 0): T0
-  ((x, y) => 0): T1
+  def f9 = ((x, y) => 0): T0
+  def g0 = ((x, y) => 0): T1
 }

--- a/test/files/neg/t1181.scala
+++ b/test/files/neg/t1181.scala
@@ -3,7 +3,7 @@ package test
 import scala.collection.immutable.Map
 
 class CompilerTest(val valueList: List[Symbol]) {
-	def buildMap(map: Map[Symbol, Symbol], keyList: List[Symbol], valueList: List[Symbol]): Map[Symbol, Symbol] = {
+  def buildMap(map: Map[Symbol, Symbol], keyList: List[Symbol], valueList: List[Symbol]): Map[Symbol, Symbol] = {
    (keyList, valueList) match {
      case (Nil, Nil) => map
      _ => buildMap(map.updated(keyList.head, valueList.head), keyList.tail, valueList.tail)

--- a/test/files/neg/t3691.check
+++ b/test/files/neg/t3691.check
@@ -1,16 +1,16 @@
 t3691.scala:4: error: type mismatch;
  found   : Test.A[String]
  required: AnyRef{type A[x]}
- val b = (new A[String]{}): { type A[x] } // not ok
-          ^
+  val b = (new A[String]{}): { type A[x] } // not ok
+           ^
 t3691.scala:5: error: type mismatch;
  found   : Test.A[String]
  required: AnyRef{type A}
- val c = (new A[String]{}): { type A } // not ok
-          ^
+  val c = (new A[String]{}): { type A } // not ok
+           ^
 t3691.scala:7: error: type mismatch;
  found   : AnyRef{type A = String}
  required: AnyRef{type A[X]}
- val x = (new { type A = String }): { type A[X] } // not ok
-          ^
+  val x = (new { type A = String }): { type A[X] } // not ok
+           ^
 three errors found

--- a/test/files/neg/t3691.scala
+++ b/test/files/neg/t3691.scala
@@ -1,11 +1,11 @@
 object Test {
- trait A[X] { type A[x <: X] = x }
- val a = (new A[String]{}): { type A[x <: String] } // ok
- val b = (new A[String]{}): { type A[x] } // not ok
- val c = (new A[String]{}): { type A } // not ok
+  trait A[X] { type A[x <: X] = x }
+  val a = (new A[String]{}): { type A[x <: String] } // ok
+  val b = (new A[String]{}): { type A[x] } // not ok
+  val c = (new A[String]{}): { type A } // not ok
 
- val x = (new { type A = String }): { type A[X] } // not ok
+  val x = (new { type A = String }): { type A[X] } // not ok
 //a: AnyRef{type A[X]}
 
-  identity[x.A[Any]] _
+  def f = identity[x.A[Any]] _
 }

--- a/test/files/neg/t6260-named.scala
+++ b/test/files/neg/t6260-named.scala
@@ -4,8 +4,8 @@ trait T[A] {
 }
 
 object Test {
-  (x: C[Any]) => {println(s"f($x)"); x} // okay
-  new T[C[Any]] { def apply(a: C[Any]) = a } // okay
+  def f = (x: C[Any]) => {println(s"f($x)"); x} // okay
+  def g = new T[C[Any]] { def apply(a: C[Any]) = a } // okay
 
   // we can't rename the specific apply method to avoid the clash
   object O extends Function1[C[Any], C[Any]] {

--- a/test/files/neg/t6526.scala
+++ b/test/files/neg/t6526.scala
@@ -10,7 +10,7 @@ class TailRec {
   }.length
 
   // transform the body of a function
-  () => {
+  def f = () => {
     @tailrec def inner(i: Int): Int = 1 + inner(i)
     inner(0)
   }

--- a/test/files/neg/t6558b.scala
+++ b/test/files/neg/t6558b.scala
@@ -7,7 +7,7 @@ class AnnotNotFound {
     foo
   }
 
-  () => {
+  def f = () => {
     @infunction
     def foo = 0
     ()

--- a/test/files/neg/t6758.scala
+++ b/test/files/neg/t6758.scala
@@ -7,13 +7,13 @@ class AnnotNotFound {
     foo
   }
 
-  () => {
+  def f = () => {
     @infunction
     def foo = 0
     ()
   }
 
-  () => {
+  def g = () => {
     val bar: Int = {
       @nested
       val bar2: Int = 2

--- a/test/files/neg/t7285.scala
+++ b/test/files/neg/t7285.scala
@@ -11,7 +11,7 @@ object Test1 {
     case object Up extends Base {
     }
 
-    (d1: Base, d2: Base) =>
+    val test = (d1: Base, d2: Base) =>
       (d1, d2) match {
         case (Up, Up) | (Down, Down) => false
         case (Down, Up)              => true
@@ -29,7 +29,7 @@ object Test2 {
     case object Up extends Base {
     }
 
-    (d1: Base, d2: Base) =>
+    val test = (d1: Base, d2: Base) =>
       (d1) match {
         case Test2.Base.Up => false
       }
@@ -47,7 +47,7 @@ object Test4 {
   }
 
   import Test4.Base._
-  (d1: Base, d2: Base) =>
+  val test = (d1: Base, d2: Base) =>
     (d1, d2) match {
       case (Up, Up) | (Down, Down) => false
       case (Down, Test4.Base.Up)   => true

--- a/test/files/neg/t8430.check
+++ b/test/files/neg/t8430.check
@@ -1,27 +1,27 @@
 t8430.scala:15: warning: match may not be exhaustive.
 It would fail on the following inputs: LetC, LetF, LetL(BooleanLit), LetL(IntLit), LetL(UnitLit), LetP
-  (tree: Tree) => tree match {case LetL(CharLit) => ??? }
-                  ^
+  val f0 = (tree: Tree) => tree match {case LetL(CharLit) => ??? }
+                           ^
 t8430.scala:16: warning: match may not be exhaustive.
 It would fail on the following inputs: LetC, LetF, LetL(BooleanLit), LetL(IntLit), LetL(UnitLit), LetP
-  (tree: Tree) => tree match {case LetL(CharLit) => ??? }
-                  ^
+  val f1 = (tree: Tree) => tree match {case LetL(CharLit) => ??? }
+                           ^
 t8430.scala:17: warning: match may not be exhaustive.
 It would fail on the following inputs: LetC, LetF, LetL(BooleanLit), LetL(IntLit), LetL(UnitLit), LetP
-  (tree: Tree) => tree match {case LetL(CharLit) => ??? }
-                  ^
+  val f2 = (tree: Tree) => tree match {case LetL(CharLit) => ??? }
+                           ^
 t8430.scala:18: warning: match may not be exhaustive.
 It would fail on the following inputs: LetC, LetF, LetL(BooleanLit), LetL(IntLit), LetL(UnitLit), LetP
-  (tree: Tree) => tree match {case LetL(CharLit) => ??? }
-                  ^
+  val f3 = (tree: Tree) => tree match {case LetL(CharLit) => ??? }
+                           ^
 t8430.scala:19: warning: match may not be exhaustive.
 It would fail on the following inputs: LetC, LetF, LetL(BooleanLit), LetL(IntLit), LetL(UnitLit), LetP
-  (tree: Tree) => tree match {case LetL(CharLit) => ??? }
-                  ^
+  val f4 = (tree: Tree) => tree match {case LetL(CharLit) => ??? }
+                           ^
 t8430.scala:20: warning: match may not be exhaustive.
 It would fail on the following inputs: LetC, LetF, LetL(BooleanLit), LetL(IntLit), LetL(UnitLit), LetP
-  (tree: Tree) => tree match {case LetL(CharLit) => ??? }
-                  ^
+  val f5 = (tree: Tree) => tree match {case LetL(CharLit) => ??? }
+                           ^
 error: No warnings can be incurred under -Xfatal-warnings.
 6 warnings found
 one error found

--- a/test/files/neg/t8430.scala
+++ b/test/files/neg/t8430.scala
@@ -12,12 +12,12 @@ case object LetC extends Tree
 case object LetF extends Tree
  
 object Test {
-  (tree: Tree) => tree match {case LetL(CharLit) => ??? }
-  (tree: Tree) => tree match {case LetL(CharLit) => ??? }
-  (tree: Tree) => tree match {case LetL(CharLit) => ??? }
-  (tree: Tree) => tree match {case LetL(CharLit) => ??? }
-  (tree: Tree) => tree match {case LetL(CharLit) => ??? }
-  (tree: Tree) => tree match {case LetL(CharLit) => ??? }
+  val f0 = (tree: Tree) => tree match {case LetL(CharLit) => ??? }
+  val f1 = (tree: Tree) => tree match {case LetL(CharLit) => ??? }
+  val f2 = (tree: Tree) => tree match {case LetL(CharLit) => ??? }
+  val f3 = (tree: Tree) => tree match {case LetL(CharLit) => ??? }
+  val f4 = (tree: Tree) => tree match {case LetL(CharLit) => ??? }
+  val f5 = (tree: Tree) => tree match {case LetL(CharLit) => ??? }
   // After the first patch for scala/bug#8430, we achieve stability: all of
   // these get the same warning:
   //

--- a/test/files/neg/tailrec-4.scala
+++ b/test/files/neg/tailrec-4.scala
@@ -1,7 +1,7 @@
 import annotation._
 
 object Tail {
-  def tcInFunc: Unit = {
+  def tcInFunc: () => Unit = {
     () => {
       @tailrec def foo: Int = foo + 1
     }

--- a/test/files/neg/warn-inferred-any.scala
+++ b/test/files/neg/warn-inferred-any.scala
@@ -1,7 +1,7 @@
 trait Foo[-A <: AnyRef, +B <: AnyRef] {
   def run[U](x: A)(action: B => U): Boolean = ???
 
-  { run(_: A)(_: B => String) }
+  def foo = { run(_: A)(_: B => String) }
 }
 
 trait Xs[+A] {

--- a/test/files/pos/t7011.scala
+++ b/test/files/pos/t7011.scala
@@ -2,6 +2,6 @@ object bar {
 	def foo: Unit = {
     lazy val x = 42
 
-    {()=>x}
+    def f = {()=>x}
   }
 }

--- a/test/files/pos/t7285a.scala
+++ b/test/files/pos/t7285a.scala
@@ -23,7 +23,7 @@ object Test1 {
     case object Up extends Base {
     }
 
-    (d1: Base, d2: Base) =>
+    def f = (d1: Base, d2: Base) =>
       (d1, d2) match {
         case (Up, Up) | (Down, Down) => false
         case (Down, Up)              => true
@@ -42,7 +42,7 @@ object Test2 {
     case object Up extends Base {
     }
 
-    (d1: Base, d2: Base) =>
+    def f = (d1: Base, d2: Base) =>
       (d1) match {
         case Up | Down => false
       }
@@ -55,7 +55,7 @@ object Test3 {
   object Base {
     case object Down extends Base
 
-    (d1: Base, d2: Base) =>
+    def f = (d1: Base, d2: Base) =>
       (d1, d2) match {
         case (Down, Down) => false
       }
@@ -74,7 +74,7 @@ object Test4 {
 
   }
   import Test4.Base._
-  (d1: Base, d2: Base) =>
+  def f = (d1: Base, d2: Base) =>
     (d1, d2) match {
       case (Up, Up) | (Down, Down) => false
       case (Down, Test4.Base.Up)   => true

--- a/test/files/run/repl-no-imports-no-predef.check
+++ b/test/files/run/repl-no-imports-no-predef.check
@@ -160,6 +160,8 @@ res29: (Int, Int, Int) = (1,2,3)
 scala> 55 ; (x: scala.Int) => x + 1 ; () => ((5))
        ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+                           ^
+       warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
 res30: () => Int = <function0>
 
 scala> 

--- a/test/files/run/repl-parens.check
+++ b/test/files/run/repl-parens.check
@@ -45,6 +45,8 @@ res10: (Int, Int, Int) = (1,2,3)
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
        ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+                     ^
+       warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
 res11: () => Int = <function0>
 
 scala> 

--- a/test/files/run/t1167.scala
+++ b/test/files/run/t1167.scala
@@ -3,7 +3,7 @@
  */
 
 trait Test1 {
-  def testFunc(i:Int): Unit = {
+  def testFunc(i:Int) = {
     (i:Int) => i + 5
   }
 }

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -102,6 +102,8 @@ res15: (Int, Int, Int) = (1,2,3)
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
        ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+                     ^
+       warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
 res16: () => Int = <function0>
 
 scala> 

--- a/test/files/run/t8888.scala
+++ b/test/files/run/t8888.scala
@@ -1,5 +1,5 @@
 class C {
-  final def resume: Unit = (this: Any) match {
+  final def resume: Any = (this: Any) match {
     case x : C => (x: Any) match {
       case y : C =>
         () => (x, y) // used to trigger a ClassFormatError under -Ydelambdafy:method

--- a/test/files/run/t9387.check
+++ b/test/files/run/t9387.check
@@ -1,0 +1,3 @@
+t9387.scala:12: warning: a pure expression does nothing in statement position
+  A[Unit](G.v(() => ())) // Was VerifyError
+                 ^

--- a/test/files/run/t9387b.check
+++ b/test/files/run/t9387b.check
@@ -1,1 +1,7 @@
+t9387b.scala:2: warning: a pure expression does nothing in statement position
+  val f: Unit = () => ()
+                   ^
+t9387b.scala:8: warning: a pure expression does nothing in statement position
+  f[Unit](() => ())
+             ^
 ()


### PR DESCRIPTION
A function literal in statement position
is probably an error due to syntax.

After updating tests, wish I'd targeted 2.13 in case of conflicts.

TODO:
  - [x] this should target 2.13.x