### PR TITLE
bug#10855 Fix IterableOnceOps.min and .max

### DIFF
--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -724,7 +724,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
   def min[B >: A](implicit ord: Ordering[B]): A = {
     if (isEmpty)
       throw new UnsupportedOperationException("empty.min")
-    reduceLeft((x, y) => if (ord.lteq(x, y)) x else y)
+    reduceLeft(ord.min)
   }
 
   /** Finds the smallest element.
@@ -761,7 +761,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
   def max[B >: A](implicit ord: Ordering[B]): A = {
     if (isEmpty)
       throw new UnsupportedOperationException("empty.max")
-    reduceLeft((x, y) => if (ord.gteq(x, y)) x else y)
+    reduceLeft(ord.max)
   }
 
   /** Finds the largest element.

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -101,10 +101,10 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   override def equiv(x: T, y: T): Boolean = compare(x, y) == 0
 
   /** Return `x` if `x` >= `y`, otherwise `y`. */
-  def max(x: T, y: T): T = if (gteq(x, y)) x else y
+  def max[U <: T](x: U, y: U): U = if (gteq(x, y)) x else y
 
   /** Return `x` if `x` <= `y`, otherwise `y`. */
-  def min(x: T, y: T): T = if (lteq(x, y)) x else y
+  def min[U <: T](x: U, y: U): U = if (lteq(x, y)) x else y
 
   /** Return the opposite ordering of this one. */
   override def reverse: Ordering[T] = new Ordering[T] {
@@ -115,8 +115,8 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
     override def lt(x: T, y: T) = outer.lt(y, x)
     override def gt(x: T, y: T) = outer.gt(y, x)
     override def equiv(x: T, y: T) = outer.equiv(y, x)
-    override def max(x: T, y: T) = outer.min(x, y)
-    override def min(x: T, y: T) = outer.max(x, y)
+    override def max[U <: T](x: U, y: U) = outer.min(x, y)
+    override def min[U <: T](x: U, y: U) = outer.max(x, y)
   }
 
   /** Given f, a function from U into T, creates an Ordering[U] whose compare
@@ -363,8 +363,8 @@ object Ordering extends LowPriorityOrderingImplicits {
       override def lt(x: Float, y: Float): Boolean = x < y
       override def gt(x: Float, y: Float): Boolean = x > y
       override def equiv(x: Float, y: Float): Boolean = x == y
-      override def max(x: Float, y: Float): Float = math.max(x, y)
-      override def min(x: Float, y: Float): Float = math.min(x, y)
+      override def max[U <: Float](x: U, y: U): U = math.max(x, y).asInstanceOf[U]
+      override def min[U <: Float](x: U, y: U): U = math.min(x, y).asInstanceOf[U]
     }
     implicit object IeeeOrdering extends IeeeOrdering
   }
@@ -423,8 +423,8 @@ object Ordering extends LowPriorityOrderingImplicits {
       override def lt(x: Double, y: Double): Boolean = x < y
       override def gt(x: Double, y: Double): Boolean = x > y
       override def equiv(x: Double, y: Double): Boolean = x == y
-      override def max(x: Double, y: Double): Double = math.max(x, y)
-      override def min(x: Double, y: Double): Double = math.min(x, y)
+      override def max[U <: Double](x: U, y: U): U = math.max(x, y).asInstanceOf[U]
+      override def min[U <: Double](x: U, y: U): U = math.min(x, y).asInstanceOf[U]
     }
     implicit object IeeeOrdering extends IeeeOrdering
   }

--- a/test/junit/scala/collection/TraversableOnceTest.scala
+++ b/test/junit/scala/collection/TraversableOnceTest.scala
@@ -92,4 +92,12 @@ class TraversableOnceTest {
     assert(Seq(1).minByOption(identity) == Some(1), "minByOption on a Non Empty Iterable has value")
   }
 
+  @Test
+  def testMinMaxCorrectness(): Unit = {
+    import Ordering.Double.IeeeOrdering
+    val seq = Seq(5.0, 3.0, Double.NaN, 4.0)
+    assert(seq.min.isNaN)
+    assert(seq.max.isNaN)
+  }
+
 }


### PR DESCRIPTION
Use `Ordering.min` and `.max` to implement
`IterableOnceOps.min` and `.max`, instead of using
`Ordering.lteq` and `.gteq`.

Fixes scala/bug#10855