### PR TITLE
Reduce allocation and CPU usage in distinct

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -474,25 +474,15 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     private[this] var nextElementDefined: Boolean = false
     private[this] var nextElement: A = _
 
-    def hasNext: Boolean = {
-      @tailrec
-      def loop(): Boolean = {
-        if (!self.hasNext) false
-        else {
-          nextElement = self.next()
-          val y = f(nextElement)
-          if (traversedValues.contains(y)) {
-            loop()
-          } else {
-            traversedValues += y
-            nextElementDefined = true
-            true
-          }
-        }
+    def hasNext: Boolean = nextElementDefined || (self.hasNext && {
+      val a = self.next()
+      if (traversedValues.add(f(a))) {
+        nextElement = a
+        nextElementDefined = true
+        true
       }
-
-      nextElementDefined || loop()
-    }
+      else hasNext
+    })
 
     def next(): A =
       if (hasNext) {

--- a/src/library/scala/collection/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSeqOps.scala
@@ -14,13 +14,10 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
   override def distinctBy[B](f: A => B): C = {
     val builder = newSpecificBuilder
     val seen = mutable.HashSet.empty[B]
-
-    for (x <- this) {
-      val y = f(x)
-      if (!seen.contains(y)) {
-        seen += y
-        builder += x
-      }
+    val it = this.iterator
+    while (it.hasNext) {
+      val next = it.next()
+      if (seen.add(f(next))) builder += next
     }
     builder.result()
   }

--- a/src/library/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -11,6 +11,21 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
   extends SeqOps[A, CC, C]
     with collection.StrictOptimizedSeqOps[A, CC, C] {
 
+  override def distinctBy[B](f: A => B): C = {
+    if (lengthCompare(1) <= 0) coll
+    else {
+      val builder = newSpecificBuilder
+      val seen = mutable.HashSet.empty[B]
+      val it = this.iterator
+      var different = false
+      while (it.hasNext) {
+        val next = it.next()
+        if (seen.add(f(next))) builder += next else different = true
+      }
+      if (different) builder.result() else coll
+    }
+  }
+
   override def updated[B >: A](index: Int, elem: B): CC[B] = {
     if (index < 0) throw new IndexOutOfBoundsException(index.toString)
     val b = iterableFactory.newBuilder[B]

--- a/test/benchmarks/src/main/scala/scala/collection/DistinctBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/DistinctBenchmark.scala
@@ -15,7 +15,7 @@ class DistinctBenchmark {
   @Param(Array("0", "1", "2", "5", "10", "20", "50", "100", "1000"))
   var size: Int = _
 
-  @Param(Array("List", "Vector"))
+  @Param(Array("List", "Vector", "ListBuffer"))
   var collectionType: String = _
 
   var distinctDataSet: Seq[String] = null
@@ -36,6 +36,7 @@ class DistinctBenchmark {
     val adjustCollectionType: (Seq[String] => Seq[String]) = collectionType match {
       case "List" => (col: Seq[String]) => col.toList
       case "Vector" => (col: Seq[String]) => col.toVector
+      case "ListBuffer" => (col: Seq[String]) => mutable.ListBuffer.from(col)
     }
 
     distinctDataSet = adjustCollectionType(b1.result())


### PR DESCRIPTION
<sup>THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.</sup>

This is port of that changes to 2.13.x:
https://github.com/scala/scala/pull/6316

I will add new benchmark results soon.