### PR TITLE
Add Iterable.seq and Iterator.seq

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -36,6 +36,9 @@ trait Iterable[+A] extends IterableOnce[A] with IterableOps[A, Iterable, Iterabl
     * @return The factory of this collection.
     */
   def iterableFactory: IterableFactory[IterableCC] = Iterable
+
+  @deprecated("Iterable.seq always returns the iterable itself", "2.13.0")
+  def seq: this.type = this
 }
 
 /** Base trait for Iterable operations

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -823,6 +823,9 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    *  @note    Reuse: $preservesIterator
    */
   override def toString = (if (hasNext) "non-empty" else "empty")+" iterator"
+
+  @deprecated("Iterator.seq always returns the iterator itself", "2.13.0")
+  def seq: this.type = this
 }
 
 object Iterator extends IterableFactory[Iterator] {

--- a/test/junit/scala/collection/SearchingTest.scala
+++ b/test/junit/scala/collection/SearchingTest.scala
@@ -16,7 +16,6 @@ class SearchingTest {
       var elementsAccessed = immutable.Set.empty[Int]
 
       protected[this] def newBuilder = ??? // not needed for this test
-      def seq = list
       def iterator = list.iterator
       def length = list.length
       def apply(idx: Int) = { elementsAccessed += idx; list(idx) }
@@ -35,7 +34,6 @@ class SearchingTest {
       var elementsAccessed = immutable.Set.empty[Int]
 
       protected[this] def newBuilder = ??? // not needed for this test
-      def seq = vec
       def length = vec.length
       def apply(idx: Int) = { elementsAccessed += idx; vec(idx) }
     }


### PR DESCRIPTION
There is no `IterableOnce.seq` or `IterableOnceExtensionMethods.seq`.
We don’t want to add more methods directly to `IterableOnce`. Adding it
as an extension method would prevent us from adding a proper `seq`
implementation to parallel collections (which are supposed to extend
`IterableOnce`).

Fixes https://github.com/scala/collection-strawman/issues/554