### PR TITLE
Prune polymorphic implicits more aggressively (2.12.x backport)

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -105,7 +105,9 @@ trait ContextErrors {
 
     def issueTypeError(err: AbsTypeError)(implicit context: Context) { context.issue(err) }
 
-    def typeErrorMsg(found: Type, req: Type) = "type mismatch" + foundReqMsg(found, req)
+    def typeErrorMsg(context: Context, found: Type, req: Type) =
+      if (context.openImplicits.nonEmpty && !settings.XlogImplicits.value) "type mismatch"
+      else "type mismatch" + foundReqMsg(found, req)
   }
 
   def notAnyRefMessage(found: Type): String = {
@@ -216,7 +218,7 @@ trait ContextErrors {
         assert(!foundType.isErroneous, s"AdaptTypeError - foundType is Erroneous: $foundType")
         assert(!req.isErroneous, s"AdaptTypeError - req is Erroneous: $req")
 
-        issueNormalTypeError(callee, withAddendum(callee.pos)(typeErrorMsg(foundType, req)))
+        issueNormalTypeError(callee, withAddendum(callee.pos)(typeErrorMsg(context, foundType, req)))
         infer.explainTypes(foundType, req)
       }
 
@@ -1016,7 +1018,7 @@ trait ContextErrors {
       }
 
       def NoBestExprAlternativeError(tree: Tree, pt: Type, lastTry: Boolean) = {
-        issueNormalTypeError(tree, withAddendum(tree.pos)(typeErrorMsg(tree.symbol.tpe, pt)))
+        issueNormalTypeError(tree, withAddendum(tree.pos)(typeErrorMsg(context, tree.symbol.tpe, pt)))
         setErrorOnLastTry(lastTry, tree)
       }
 
@@ -1284,7 +1286,7 @@ trait ContextErrors {
                sm"""|Note that implicit conversions are not applicable because they are ambiguous:
                     |${coreMsg}are possible conversion functions from $found to $req"""
           }
-          typeErrorMsg(found, req) + (
+          typeErrorMsg(context, found, req) + (
             if (explanation == "") "" else "\n" + explanation
           )
         }

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -401,7 +401,7 @@ trait Implicits {
 
     def pos = if (pos0 != NoPosition) pos0 else tree.pos
 
-    def failure(what: Any, reason: String, pos: Position = this.pos): SearchResult = {
+    @inline final def failure(what: Any, reason: => String, pos: Position = this.pos): SearchResult = {
       if (settings.XlogImplicits)
         reporter.echo(pos, what+" is not a valid implicit value for "+pt+" because:\n"+reason)
       SearchFailure
@@ -664,7 +664,7 @@ trait Implicits {
       val itree1 = if (isBlackbox(info.sym)) suppressMacroExpansion(itree0) else itree0
       typingLog("considering", typeDebug.ptTree(itree1))
 
-      def fail(reason: String): SearchResult = failure(itree0, reason)
+      @inline def fail(reason: => String): SearchResult = failure(itree0, reason)
       def fallback = typed1(itree1, EXPRmode, wildPt)
       try {
         val itree2 = if (!isView) fallback else pt match {
@@ -725,7 +725,7 @@ trait Implicits {
             info.sym.fullLocationString, itree2.symbol.fullLocationString))
         else {
           val tvars = undetParams map freshVar
-          def ptInstantiated = pt.instantiateTypeParams(undetParams, tvars)
+          val ptInstantiated = pt.instantiateTypeParams(undetParams, tvars)
 
           if (matchesPt(itree3.tpe, ptInstantiated, undetParams)) {
             if (tvars.nonEmpty)

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -993,11 +993,11 @@ trait Implicits {
        *   - if it matches, forget about all others it improves upon
        */
 
-      // the pt for views can have embedded unification type variables or BoundedWildcardTypes which
-      // can't be solved for. Rather than attempt to patch things up later we just skip those cases
-      // altogether.
+      // the pt for views can have embedded unification type variables, BoundedWildcardTypes or 
+      // Nothings which can't be solved for. Rather than attempt to patch things up later we
+      // just skip those cases altogether.
       lazy val wildPtIsInstantiable =
-        !isView || !wildPt.exists { case _: BoundedWildcardType | _: TypeVar => true ; case _ => false }
+        !isView || !wildPt.exists { case _: BoundedWildcardType | _: TypeVar => true ; case tp if typeIsNothing(tp) => true; case _ => false }
 
       @tailrec private def rankImplicits(pending: Infos, acc: List[(SearchResult, ImplicitInfo)]): List[(SearchResult, ImplicitInfo)] = pending match {
         case Nil                          => acc

--- a/test/files/neg/divergent-implicit.check
+++ b/test/files/neg/divergent-implicit.check
@@ -4,7 +4,7 @@ divergent-implicit.scala:4: error: type mismatch;
   val x1: String = 1
                    ^
 divergent-implicit.scala:5: error: diverging implicit expansion for type Int => String
-starting with method $conforms in object Predef
+starting with method cast in object Test1
   val x2: String = cast[Int, String](1)
                                     ^
 divergent-implicit.scala:14: error: type mismatch;

--- a/test/files/pos/f-bounded-view.scala
+++ b/test/files/pos/f-bounded-view.scala
@@ -1,0 +1,19 @@
+object Foo {
+  implicit def toBar[T <: Bar[T]](t: T): Baz = ???
+}
+
+import Foo._
+
+trait Bar[T]
+
+class Baz {
+  def wibble = 23
+}
+
+class Quux extends Bar[Quux] {
+  def blah = this.wibble
+}
+
+object Test {
+  (new Quux).blah
+}

--- a/test/files/pos/infer-nothing.scala
+++ b/test/files/pos/infer-nothing.scala
@@ -1,0 +1,12 @@
+object Test {
+  trait Pure[+A]
+  trait Stream[+F[_], +O]
+  object Stream {
+    implicit def covaryPure[F[_], O, O2 >: O](s: Stream[Pure, O]): Stream[F, O2] = ???
+    def empty: Stream[Pure, Nothing] = ???
+  }
+
+  type EntityBody[+F[_]] = Stream[F, Byte]
+
+  val EmptyBody: EntityBody[Nothing] = Stream.empty
+}


### PR DESCRIPTION
This is a backport to 2.12.x of #6580.

In `rankImplicits`, before we attempt to fully typecheck the pending candidate implicit, we first attempt to partially instantiate type variables in both the candidate and the target type and check for compatibility. If the compatibility check fails we can immediately prune the the candidate without having to fully typecheck it.

In the kinds of implicit searches typical of the inductive style found in shapeless and related libraries this can result in a drastic reduction in the search space and a corresponding reduction in compile times.

This commit is much simpler, more generally applicable, and less invasive than my earlier work on inductive implicits in #6481 which was doing similar pruning almost by accident. It turns out that almost all of the speedups in that earlier PR were due to the pruning rather than to any special casing of inductive patterns.

The compilation benchmark (a shapeless-style "select element by type from a large HList") from that PR is carried over here (in test/induction) and shows the same performance improvements,

```
  1) baseline - scalac 2.12.5
  2)            scalac 2.12.5 with matchesPtInst

               (1)   (2)
  HList Size
   50           4     3
  100           7     4
  150          14     4
  200          25     5
  250          46     5
  300          74     6
  350         118     8
  400         183    10
  450         298    12
  500         421    15

           Compile time in seconds
```
As an added bonus users of shapeless and shapeless-based libraries which use shapeless's `Lazy` type will see benefits immediately without needing to wait for and port to byname implicit arguments.

### Trying this change with your project

To test this with your shapeless-using project checkout out this branch and fire up the sbt repl then `clean`, `compile` and `dist/mkPack`. This should give you a Scala distribution in `<path to scala checkout>/build/pack`.

If you now fire up an sbt repl on the project you want to build with this compiler you can then set the Scala version at the prompt via `++2.12.5=<path to scala checkout>/build/pack`. You should now be able to `compile` and `test:compile` as if with 2.12.5, but with this optimization in place.
