### PR TITLE
Drop old @version refs in docs

### DIFF
--- a/src/compiler/scala/reflect/reify/Reifier.scala
+++ b/src/compiler/scala/reflect/reify/Reifier.scala
@@ -9,7 +9,6 @@ import scala.reflect.reify.utils.Utils
  *  See more info in the comments to `reify` in scala.reflect.api.Universe.
  *
  *  @author   Martin Odersky
- *  @version  2.10
  *  @since    2.10
  */
 abstract class Reifier extends States

--- a/src/library/scala/App.scala
+++ b/src/library/scala/App.scala
@@ -34,7 +34,7 @@ import scala.collection.mutable.ListBuffer
  *  Future versions of this trait will no longer extend `DelayedInit`.
  *
  *  @author  Martin Odersky
- *  @version 2.1, 15/02/2011
+ *  @since   2.1
  */
 trait App extends DelayedInit {
 

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -44,7 +44,7 @@ class FallbackArrayBuilding {
  *  `Array(1, 2)`, `Array(0, 0)` and `Array(1, 2, 0, 0)`.
  *
  *  @author Martin Odersky
- *  @version 1.0
+ *  @since  1.0
  */
 object Array extends FallbackArrayBuilding {
   val emptyBooleanArray = new Array[Boolean](0)
@@ -481,7 +481,7 @@ object Array extends FallbackArrayBuilding {
  *  `WrappedArray`.
  *
  *  @author Martin Odersky
- *  @version 1.0
+ *  @since  1.0
  *  @see [[http://www.scala-lang.org/files/archive/spec/2.11/ Scala Language Specification]], for in-depth information on the transformations the Scala compiler makes on Arrays (Sections 6.6 and 6.15 respectively.)
  *  @see [[http://docs.scala-lang.org/sips/completed/scala-2-8-arrays.html "Scala 2.8 Arrays"]] the Scala Improvement Document detailing arrays since Scala 2.8.
  *  @see [[http://docs.scala-lang.org/overviews/collections/arrays.html "The Scala 2.8 Collections' API"]] section on `Array` by Martin Odersky for more information.

--- a/src/library/scala/Console.scala
+++ b/src/library/scala/Console.scala
@@ -106,7 +106,7 @@ import scala.util.DynamicVariable
  *  </table>
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 03/09/2003
+ *  @since   1.0
  *
  *  @groupname console-output Console Output
  *  @groupprio console-output 30

--- a/src/library/scala/Function.scala
+++ b/src/library/scala/Function.scala
@@ -13,7 +13,7 @@ package scala
 /** A module defining utility methods for higher-order functional programming.
  *
  *  @author  Martin Odersky
- *  @version 1.0, 29/11/2006
+ *  @since   1.0
  */
 object Function {
   /** Given a sequence of functions `f,,1,,`, ..., `f,,n,,`, return the

--- a/src/library/scala/MatchError.scala
+++ b/src/library/scala/MatchError.scala
@@ -16,7 +16,6 @@ package scala
  *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 1.1, 05/03/2004
  *  @since   2.0
  */
 final class MatchError(@transient obj: Any) extends RuntimeException {

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -76,7 +76,7 @@ object Option {
  *
  *  @author  Martin Odersky
  *  @author  Matthias Zenger
- *  @version 1.1, 16/01/2007
+ *  @since   1.1
  *  @define none `None`
  *  @define some [[scala.Some]]
  *  @define option [[scala.Option]]
@@ -327,7 +327,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
  *  `A`.
  *
  *  @author  Martin Odersky
- *  @version 1.0, 16/07/2003
+ *  @since   1.0
  */
 @SerialVersionUID(1234815782226070388L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
 final case class Some[+A](@deprecatedName('x, "2.12.0") value: A) extends Option[A] {
@@ -341,7 +341,7 @@ final case class Some[+A](@deprecatedName('x, "2.12.0") value: A) extends Option
 /** This case object represents non-existent values.
  *
  *  @author  Martin Odersky
- *  @version 1.0, 16/07/2003
+ *  @since   1.0
  */
 @SerialVersionUID(5066590221178148012L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
 case object None extends Option[Nothing] {

--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -50,7 +50,7 @@ package scala
  *
  *
  *  @author  Martin Odersky, Pavel Pavlov, Adriaan Moors
- *  @version 1.0, 16/07/2003
+ *  @since   1.0
  */
 trait PartialFunction[-A, +B] extends (A => B) { self =>
   import PartialFunction._

--- a/src/library/scala/Product.scala
+++ b/src/library/scala/Product.scala
@@ -14,7 +14,6 @@ package scala
  *  all case classes implement `Product` with synthetically generated methods.
  *
  *  @author  Burak Emir
- *  @version 1.0
  *  @since   2.3
  */
 trait Product extends Any with Equals {

--- a/src/library/scala/Proxy.scala
+++ b/src/library/scala/Proxy.scala
@@ -20,7 +20,7 @@ package scala
  *  an asymmetric equals method, which is not generally recommended.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 26/04/2004
+ *  @since   1.0
  */
 trait Proxy extends Any {
   def self: Any

--- a/src/library/scala/Responder.scala
+++ b/src/library/scala/Responder.scala
@@ -13,7 +13,6 @@ package scala
  *
  *  @author Martin Odersky
  *  @author Burak Emir
- *  @version 1.0
  *
  *  @see class Responder
  *  @since 2.1
@@ -56,7 +55,6 @@ object Responder {
  *
  *  @author Martin Odersky
  *  @author Burak Emir
- *  @version 1.0
  *  @since 2.1
  */
 @deprecated("this class will be removed", "2.11.0")

--- a/src/library/scala/Symbol.scala
+++ b/src/library/scala/Symbol.scala
@@ -18,7 +18,7 @@ package scala
  *  `Symbol("mysym")`.
  *
  *  @author  Martin Odersky, Iulian Dragos
- *  @version 1.8
+ *  @since   1.7
  */
 final class Symbol private (val name: String) extends Serializable {
   /** Converts this symbol to a string.

--- a/src/library/scala/annotation/Annotation.scala
+++ b/src/library/scala/annotation/Annotation.scala
@@ -15,7 +15,6 @@ package scala.annotation
  *  [[scala.annotation.ClassfileAnnotation]].
  *
  *  @author  Martin Odersky
- *  @version 1.1, 2/02/2007
  *  @since 2.4
  */
 abstract class Annotation {}

--- a/src/library/scala/annotation/ClassfileAnnotation.scala
+++ b/src/library/scala/annotation/ClassfileAnnotation.scala
@@ -13,7 +13,6 @@ package scala.annotation
  *  in classfiles.
  *
  *  @author  Martin Odersky
- *  @version 1.1, 2/02/2007
  *  @since 2.4
  */
 trait ClassfileAnnotation extends StaticAnnotation

--- a/src/library/scala/annotation/StaticAnnotation.scala
+++ b/src/library/scala/annotation/StaticAnnotation.scala
@@ -12,7 +12,6 @@ package scala.annotation
  *  to the Scala type checker, even across different compilation units.
  *
  *  @author  Martin Odersky
- *  @version 1.1, 2/02/2007
  *  @since   2.4
  */
 trait StaticAnnotation extends Annotation

--- a/src/library/scala/annotation/TypeConstraint.scala
+++ b/src/library/scala/annotation/TypeConstraint.scala
@@ -20,7 +20,6 @@ package scala.annotation
  *  would rewrite a type constraint.
  *
  *  @author  Lex Spoon
- *  @version 1.1, 2007-11-5
  *  @since   2.6
  */
 trait TypeConstraint extends Annotation

--- a/src/library/scala/annotation/strictfp.scala
+++ b/src/library/scala/annotation/strictfp.scala
@@ -12,7 +12,6 @@ package scala.annotation
  *  the strictfp flag will be emitted.
  *
  *  @author Paul Phillips
- *  @version 2.9
  *  @since 2.9
  */
 class strictfp extends scala.annotation.StaticAnnotation

--- a/src/library/scala/collection/BitSetLike.scala
+++ b/src/library/scala/collection/BitSetLike.scala
@@ -27,7 +27,6 @@ import mutable.StringBuilder
  *  variable-size arrays of bits packed into 64-bit words. The memory footprint of a bitset is
  *  determined by the largest number stored in it.
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since 2.8
  *  @define coll bitset
  *  @define Coll `BitSet`

--- a/src/library/scala/collection/BufferedIterator.scala
+++ b/src/library/scala/collection/BufferedIterator.scala
@@ -15,7 +15,6 @@ package collection
  *  that inspects the next element without discarding it.
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   2.8
  */
 trait BufferedIterator[+A] extends Iterator[A] {

--- a/src/library/scala/collection/IndexedSeqLike.scala
+++ b/src/library/scala/collection/IndexedSeqLike.scala
@@ -29,7 +29,6 @@ package collection
  *  @tparam A    the element type of the $coll
  *  @tparam Repr the type of the actual $coll containing the elements.
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.8
  *  @define willNotTerminateInf
  *  @define mayNotTerminateInf

--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -39,7 +39,6 @@ import immutable.Stream
  *    `TraversableLike` by an iterator version.
  *
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.8
  *  @tparam A    the element type of the collection
  *  @tparam Repr the type of the actual collection containing the elements.

--- a/src/library/scala/collection/IterableProxy.scala
+++ b/src/library/scala/collection/IterableProxy.scala
@@ -13,7 +13,6 @@ package collection
  *  to a different iterable object.
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   2.8
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.3")

--- a/src/library/scala/collection/IterableProxyLike.scala
+++ b/src/library/scala/collection/IterableProxyLike.scala
@@ -19,7 +19,6 @@ import generic._
  *  all calls to a different Iterable object.
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   2.8
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.0")

--- a/src/library/scala/collection/IterableViewLike.scala
+++ b/src/library/scala/collection/IterableViewLike.scala
@@ -21,7 +21,6 @@ import scala.language.implicitConversions
  *  All views for iterable collections are defined by re-interpreting the `iterator` method.
  *
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.8
  *  @tparam A    the element type of the view
  *  @tparam Coll the type of the underlying collection containing the elements.

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -18,7 +18,6 @@ import immutable.Stream
  *
  *  @author  Martin Odersky
  *  @author  Matthias Zenger
- *  @version 2.8
  *  @since   2.8
  */
 object Iterator {
@@ -323,7 +322,6 @@ import Iterator.empty
  *  }}}
  *
  *  @author  Martin Odersky, Matthias Zenger
- *  @version 2.8
  *  @since   1
  *  @define willNotTerminateInf
  *  Note: will not terminate for infinite iterators.

--- a/src/library/scala/collection/LinearSeqLike.scala
+++ b/src/library/scala/collection/LinearSeqLike.scala
@@ -21,7 +21,6 @@ import scala.annotation.tailrec
  *  Linear sequences do not add any new methods to `Seq`, but promise efficient implementations
  *  of linear access patterns.
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   2.8
  *
  *  @tparam A    the element type of the $coll

--- a/src/library/scala/collection/MapLike.scala
+++ b/src/library/scala/collection/MapLike.scala
@@ -47,7 +47,6 @@ import parallel.ParMap
  *  @tparam This the type of the map itself.
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *
  *  @define coll map
  *  @define Coll Map

--- a/src/library/scala/collection/MapProxy.scala
+++ b/src/library/scala/collection/MapProxy.scala
@@ -14,7 +14,6 @@ package collection
  *  dynamically using object composition and forwarding.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 21/07/2003
  *  @since   1
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.3")

--- a/src/library/scala/collection/MapProxyLike.scala
+++ b/src/library/scala/collection/MapProxyLike.scala
@@ -15,7 +15,6 @@ package collection
  *  all calls to a different Map object.
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   2.8
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.0")

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -42,7 +42,6 @@ import scala.math.Ordering
  *
  *  @author  Martin Odersky
  *  @author  Matthias Zenger
- *  @version 1.0, 16/07/2003
  *  @since   2.8
  *
  *  @define Coll `Seq`

--- a/src/library/scala/collection/SeqProxy.scala
+++ b/src/library/scala/collection/SeqProxy.scala
@@ -15,7 +15,6 @@ package collection
  *  all calls to a different sequence object.
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   2.8
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.0")

--- a/src/library/scala/collection/SeqProxyLike.scala
+++ b/src/library/scala/collection/SeqProxyLike.scala
@@ -20,7 +20,6 @@ import generic._
  *  all calls to a different sequence.
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   2.8
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.0")

--- a/src/library/scala/collection/SeqViewLike.scala
+++ b/src/library/scala/collection/SeqViewLike.scala
@@ -21,7 +21,6 @@ import Seq.fill
  * `apply` methods.
  *
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.8
  *  @tparam A    the element type of the view
  *  @tparam Coll the type of the underlying collection containing the elements.

--- a/src/library/scala/collection/SetLike.scala
+++ b/src/library/scala/collection/SetLike.scala
@@ -48,7 +48,6 @@ import parallel.ParSet
  *  @tparam This the type of the set itself.
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *
  *  @define coll set
  *  @define Coll Set

--- a/src/library/scala/collection/SetProxy.scala
+++ b/src/library/scala/collection/SetProxy.scala
@@ -15,7 +15,7 @@ package collection
  *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 2.0, 01/01/2007
+ *  @since   2.0
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.3")
 trait SetProxy[A] extends Set[A] with SetProxyLike[A, Set[A]]

--- a/src/library/scala/collection/SetProxyLike.scala
+++ b/src/library/scala/collection/SetProxyLike.scala
@@ -15,7 +15,7 @@ package collection
  *  all calls to a different set.
  *
  *  @author  Martin Odersky
- *  @version 2.8
+ *  @since   2.8
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.0")
 trait SetProxyLike[A, +This <: SetLike[A, This] with Set[A]] extends SetLike[A, This] with IterableProxyLike[A, This] {

--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -16,7 +16,6 @@ import mutable.Builder
  *
  *  @author Sean McDirmid
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.4
  */
 trait SortedMap[A, +B] extends Map[A, B] with SortedMapLike[A, B, SortedMap[A, B]] {

--- a/src/library/scala/collection/SortedMapLike.scala
+++ b/src/library/scala/collection/SortedMapLike.scala
@@ -17,7 +17,6 @@ import generic._
  *
  *  @author Sean McDirmid
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.8
  */
 trait SortedMapLike[A, +B, +This <: SortedMapLike[A, B, This] with SortedMap[A, B]] extends Sorted[A, This] with MapLike[A, B, This] {

--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -15,7 +15,6 @@ import generic._
  *
  *  @author Sean McDirmid
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.4
  */
 trait SortedSet[A] extends Set[A] with SortedSetLike[A, SortedSet[A]] {

--- a/src/library/scala/collection/SortedSetLike.scala
+++ b/src/library/scala/collection/SortedSetLike.scala
@@ -15,7 +15,6 @@ import generic._
  *
  *  @author Sean McDirmid
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.8
  */
 trait SortedSetLike[A, +This <: SortedSet[A] with SortedSetLike[A, This]] extends Sorted[A, This] with SetLike[A, This] {

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -58,7 +58,6 @@ import scala.language.higherKinds
  *  order they were inserted into the `HashMap`.
  *
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.8
  *  @tparam A    the element type of the collection
  *  @tparam Repr the type of the actual collection containing the elements.

--- a/src/library/scala/collection/TraversableOnce.scala
+++ b/src/library/scala/collection/TraversableOnce.scala
@@ -21,7 +21,6 @@ import scala.reflect.ClassTag
  *
  *  @author Martin Odersky
  *  @author Paul Phillips
- *  @version 2.8
  *  @since   2.8
  *
  *  @define coll traversable or iterator

--- a/src/library/scala/collection/TraversableProxy.scala
+++ b/src/library/scala/collection/TraversableProxy.scala
@@ -18,7 +18,6 @@ package collection
  *  all calls to a different traversable object
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   2.8
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.3")

--- a/src/library/scala/collection/TraversableProxyLike.scala
+++ b/src/library/scala/collection/TraversableProxyLike.scala
@@ -21,7 +21,6 @@ import scala.reflect.ClassTag
  *  all calls to a different Traversable object.
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   2.8
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.0")

--- a/src/library/scala/collection/TraversableViewLike.scala
+++ b/src/library/scala/collection/TraversableViewLike.scala
@@ -61,7 +61,6 @@ trait ViewMkString[+A] {
  *  All views for traversable collections are defined by creating a new `foreach` method.
  *
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.8
  *  @tparam A    the element type of the view
  *  @tparam Coll the type of the underlying collection containing the elements.

--- a/src/library/scala/collection/generic/BitSetFactory.scala
+++ b/src/library/scala/collection/generic/BitSetFactory.scala
@@ -20,7 +20,7 @@ import mutable.Builder
  *  @define factoryInfo
  *    This object provides a set of operations to create `$Coll` values.
  *    @author Martin Odersky
- *    @version 2.8
+ *    @since  2.8
  *  @define canBuildFromInfo
  *    The standard `CanBuildFrom` instance for $Coll objects.
  *    @see CanBuildFrom

--- a/src/library/scala/collection/generic/Clearable.scala
+++ b/src/library/scala/collection/generic/Clearable.scala
@@ -13,9 +13,8 @@ package generic
 /** This trait forms part of collections that can be cleared
  *  with a clear() call.
  *
- *  @author   Paul Phillips
- *  @version 2.10
- *  @since   2.10
+ *  @author Paul Phillips
+ *  @since  2.10
  *  @define coll clearable collection
  *  @define Coll `Clearable`
  */

--- a/src/library/scala/collection/generic/GenMapFactory.scala
+++ b/src/library/scala/collection/generic/GenMapFactory.scala
@@ -20,7 +20,6 @@ import scala.language.higherKinds
  *  @define factoryInfo
  *    This object provides a set of operations needed to create `$Coll` values.
  *    @author Martin Odersky
- *    @version 2.8
  *    @since 2.8
  *  @define canBuildFromInfo
  *    The standard `CanBuildFrom` instance for `$Coll` objects.

--- a/src/library/scala/collection/generic/GenSetFactory.scala
+++ b/src/library/scala/collection/generic/GenSetFactory.scala
@@ -22,8 +22,7 @@ import scala.language.higherKinds
  *  @define factoryInfo
  *    This object provides a set of operations needed to create `$Coll` values.
  *    @author Martin Odersky
- *    @version 2.8
- *    @since 2.8
+ *    @since  2.8
  *  @define canBuildFromInfo
  *    The standard `CanBuildFrom` instance for `$Coll` objects.
  *    @see CanBuildFrom

--- a/src/library/scala/collection/generic/GenTraversableFactory.scala
+++ b/src/library/scala/collection/generic/GenTraversableFactory.scala
@@ -24,7 +24,6 @@ import scala.language.higherKinds
  *  @define factoryInfo
  *    This object provides a set of operations to create `$Coll` values.
  *    @author Martin Odersky
- *    @version 2.8
  *  @define canBuildFromInfo
  *    The standard `CanBuildFrom` instance for $Coll objects.
  *    @see CanBuildFrom

--- a/src/library/scala/collection/generic/Growable.scala
+++ b/src/library/scala/collection/generic/Growable.scala
@@ -17,7 +17,6 @@ import scala.annotation.tailrec
  *  a `clear` method.
  *
  *  @author   Martin Odersky
- *  @version 2.8
  *  @since   2.8
  *  @define coll growable collection
  *  @define Coll `Growable`

--- a/src/library/scala/collection/generic/ImmutableMapFactory.scala
+++ b/src/library/scala/collection/generic/ImmutableMapFactory.scala
@@ -15,7 +15,6 @@ import scala.language.higherKinds
 
 /** A template for companion objects of `immutable.Map` and subclasses thereof.
  *    @author Martin Odersky
- *    @version 2.8
  *    @since 2.8
  */
 abstract class ImmutableMapFactory[CC[A, +B] <: immutable.Map[A, B] with immutable.MapLike[A, B, CC[A, B]]] extends MapFactory[CC]

--- a/src/library/scala/collection/generic/ImmutableSortedMapFactory.scala
+++ b/src/library/scala/collection/generic/ImmutableSortedMapFactory.scala
@@ -22,7 +22,6 @@ import scala.language.higherKinds
  *  @define factoryInfo
  *    This object provides a set of operations needed to create sorted maps of type `$Coll`.
  *    @author Martin Odersky
- *    @version 2.8
  *  @define sortedMapCanBuildFromInfo
  *    The standard `CanBuildFrom` instance for sorted maps
  */

--- a/src/library/scala/collection/generic/ImmutableSortedSetFactory.scala
+++ b/src/library/scala/collection/generic/ImmutableSortedSetFactory.scala
@@ -22,7 +22,6 @@ import scala.language.higherKinds
  *  @define factoryInfo
  *    This object provides a set of operations needed to create sorted sets of type `$Coll`.
  *    @author Martin Odersky
- *    @version 2.8
  *  @define sortedSetCanBuildFromInfo
  *    The standard `CanBuildFrom` instance for sorted sets
  */

--- a/src/library/scala/collection/generic/IterableForwarder.scala
+++ b/src/library/scala/collection/generic/IterableForwarder.scala
@@ -23,7 +23,6 @@ import scala.collection._
  *  target="ContentFrame">`IterableProxy`</a>.
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   2.8
  */
 @deprecated("forwarding is inherently unreliable since it is not automated and methods can be forgotten", "2.11.0")

--- a/src/library/scala/collection/generic/MapFactory.scala
+++ b/src/library/scala/collection/generic/MapFactory.scala
@@ -19,7 +19,6 @@ import scala.language.higherKinds
  *  @define factoryInfo
  *    This object provides a set of operations needed to create `$Coll` values.
  *    @author Martin Odersky
- *    @version 2.8
  *    @since 2.8
  *  @define canBuildFromInfo
  *    The standard `CanBuildFrom` instance for `$Coll` objects.

--- a/src/library/scala/collection/generic/MutableMapFactory.scala
+++ b/src/library/scala/collection/generic/MutableMapFactory.scala
@@ -17,7 +17,6 @@ import scala.language.higherKinds
 
 /** A template for companion objects of `mutable.Map` and subclasses thereof.
  *    @author Martin Odersky
- *    @version 2.8
  *    @since 2.8
  */
 abstract class MutableMapFactory[CC[A, B] <: mutable.Map[A, B] with mutable.MapLike[A, B, CC[A, B]]]

--- a/src/library/scala/collection/generic/SeqForwarder.scala
+++ b/src/library/scala/collection/generic/SeqForwarder.scala
@@ -22,7 +22,6 @@ import scala.collection.immutable.Range
  *  The above methods are forwarded by subclass `SeqProxy`.
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   2.8
  */
 @deprecated("forwarding is inherently unreliable since it is not automated and new methods can be forgotten", "2.11.0")

--- a/src/library/scala/collection/generic/Shrinkable.scala
+++ b/src/library/scala/collection/generic/Shrinkable.scala
@@ -14,7 +14,6 @@ package generic
  *  using a `-=` operator.
  *
  *  @author   Martin Odersky
- *  @version 2.8
  *  @since   2.8
  *  @define coll shrinkable collection
  *  @define Coll `Shrinkable`

--- a/src/library/scala/collection/generic/Subtractable.scala
+++ b/src/library/scala/collection/generic/Subtractable.scala
@@ -18,7 +18,6 @@ package generic
  *  @tparam   A    the type of the elements of the $coll.
  *  @tparam   Repr the type of the $coll itself
  *  @author   Martin Odersky
- *  @version  2.8
  *  @since    2.8
  *  @define   coll collection
  *  @define   Coll Subtractable

--- a/src/library/scala/collection/generic/TraversableFactory.scala
+++ b/src/library/scala/collection/generic/TraversableFactory.scala
@@ -24,7 +24,6 @@ import scala.language.higherKinds
  *  @define factoryInfo
  *    This object provides a set of operations to create `$Coll` values.
  *    @author Martin Odersky
- *    @version 2.8
  *  @define canBuildFromInfo
  *    The standard `CanBuildFrom` instance for $Coll objects.
  *    @see CanBuildFrom

--- a/src/library/scala/collection/generic/TraversableForwarder.scala
+++ b/src/library/scala/collection/generic/TraversableForwarder.scala
@@ -24,7 +24,6 @@ import scala.reflect.ClassTag
  *  All calls creating a new traversable of the same kind.
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   2.8
  */
 @deprecated("forwarding is inherently unreliable since it is not automated and new methods can be forgotten", "2.11.0")

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -23,7 +23,6 @@ import parallel.immutable.ParHashMap
  *
  *  @author  Martin Odersky
  *  @author  Tiark Rompf
- *  @version 2.8
  *  @since   2.3
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#hash-tries "Scala's Collection Library overview"]]
  *  section on `Hash Tries` for more information.

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -25,7 +25,6 @@ import scala.annotation.tailrec
  *
  *  @author  Martin Odersky
  *  @author  Tiark Rompf
- *  @version 2.8
  *  @since   2.3
  *  @define Coll `immutable.HashSet`
  *  @define coll immutable hash set

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -63,7 +63,6 @@ import java.io.{ObjectOutputStream, ObjectInputStream}
  *        each reference to it. I.e. structural sharing is lost after serialization/deserialization.
  *
  *  @author  Martin Odersky and others
- *  @version 2.8
  *  @since   1.0
  *  @see  [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#lists "Scala's Collection Library overview"]]
  *  section on `Lists` for more information.
@@ -418,7 +417,6 @@ sealed abstract class List[+A] extends AbstractSeq[A]
 /** The empty list.
  *
  *  @author  Martin Odersky
- *  @version 1.0, 15/07/2003
  *  @since   2.8
  */
 @SerialVersionUID(0 - 8256821097970055419L)
@@ -440,7 +438,6 @@ case object Nil extends List[Nothing] {
  *  @param tl   the list containing the remaining elements of this list after the first one.
  *  @tparam B   the type of the list elements.
  *  @author  Martin Odersky
- *  @version 1.0, 15/07/2003
  *  @since   2.8
  */
 @SerialVersionUID(509929039250432923L) // value computed by serialver for 2.11.2, annotation added in 2.11.4

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -57,7 +57,6 @@ object ListMap extends ImmutableMapFactory[ListMap] {
   *
   * @author Matthias Zenger
   * @author Martin Odersky
-  * @version 2.0, 01/01/2007
   * @since 1
   * @define Coll ListMap
   * @define coll list map

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -52,7 +52,6 @@ object ListSet extends ImmutableSetFactory[ListSet] {
   * @tparam A the type of the elements contained in this list set
   *
   * @author Matthias Zenger
-  * @version 1.0, 09/07/2003
   * @since 1
   * @define Coll ListSet
   * @define coll list set

--- a/src/library/scala/collection/immutable/MapLike.scala
+++ b/src/library/scala/collection/immutable/MapLike.scala
@@ -41,7 +41,6 @@ import parallel.immutable.ParMap
  *  @tparam This  The type of the actual map implementation.
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   2.8
  *  @define Coll immutable.Map
  *  @define coll immutable map

--- a/src/library/scala/collection/immutable/MapProxy.scala
+++ b/src/library/scala/collection/immutable/MapProxy.scala
@@ -20,7 +20,6 @@ package immutable
  *  dynamically using object composition and forwarding.
  *
  *  @author  Matthias Zenger, Martin Odersky
- *  @version 2.0, 31/12/2006
  *  @since   2.8
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.0")

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -30,7 +30,6 @@ package immutable
  *  }}}
  *
  *  @author  Paul Phillips
- *  @version 2.8
  *  @define Coll `NumericRange`
  *  @define coll numeric range
  *  @define mayNotTerminateInf

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -25,7 +25,6 @@ import mutable.{ Builder, ListBuffer }
  *  `n` remove operations with `O(1)` cost are guaranteed. Removing an item is on average `O(1)`.
  *
  *  @author  Erik Stenman
- *  @version 1.0, 08/07/2003
  *  @since   1
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable-queues "Scala's Collection Library overview"]]
  *  section on `Immutable Queues` for more information.

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -44,7 +44,6 @@ import scala.collection.parallel.immutable.ParRange
  *
  *  @author Martin Odersky
  *  @author Paul Phillips
- *  @version 2.8
  *  @since   2.5
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#ranges "Scala's Collection Library overview"]]
  *  section on `Ranges` for more information.

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -22,7 +22,6 @@ import mutable.Builder
  *
  *  @author Sean McDirmid
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.4
  *  @define Coll immutable.SortedMap
  *  @define coll immutable sorted map

--- a/src/library/scala/collection/immutable/SortedSet.scala
+++ b/src/library/scala/collection/immutable/SortedSet.scala
@@ -19,7 +19,6 @@ import generic._
  *
  *  @author Sean McDirmid
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.4
  *  @define Coll `immutable.SortedSet`
  *  @define coll immutable sorted set

--- a/src/library/scala/collection/immutable/Stack.scala
+++ b/src/library/scala/collection/immutable/Stack.scala
@@ -33,7 +33,6 @@ object Stack extends SeqFactory[Stack] {
  *  @tparam A    the type of the elements contained in this stack.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 10/07/2003
  *  @since   1
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable-stacks "Scala's Collection Library overview"]]
  *  section on `Immutable stacks` for more information.

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -186,7 +186,6 @@ import scala.language.implicitConversions
  *  @tparam A    the type of the elements contained in this stream.
  *
  *  @author Martin Odersky, Matthias Zenger
- *  @version 1.1 08/08/03
  *  @since   2.8
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#streams "Scala's Collection Library overview"]]
  *  section on `Streams` for more information.
@@ -1070,7 +1069,6 @@ final class StreamIterator[+A] private() extends AbstractIterator[A] with Iterat
  * The object `Stream` provides helper functions to manipulate streams.
  *
  * @author Martin Odersky, Matthias Zenger
- * @version 1.1 08/08/03
  * @since   2.8
  */
 object Stream extends SeqFactory[Stream] {

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -32,7 +32,6 @@ object TreeMap extends ImmutableSortedMapFactory[TreeMap] {
  *
  *  @author  Erik Stenman
  *  @author  Matthias Zenger
- *  @version 1.1, 03/05/2004
  *  @since   1
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
  *  section on `Red-Black Trees` for more information.

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -36,7 +36,6 @@ object TreeSet extends ImmutableSortedSetFactory[TreeSet] {
  *  @param ordering   the implicit ordering used to compare objects of type `A`
  *
  *  @author  Martin Odersky
- *  @version 2.0, 02/01/2007
  *  @since   1
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
  *  section on `Red-Black Trees` for more information.

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -22,7 +22,6 @@ import parallel.mutable.ParArray
  *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   1
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array-buffers "Scala's Collection Library overview"]]
  *  section on `Array Buffers` for more information.

--- a/src/library/scala/collection/mutable/ArrayLike.scala
+++ b/src/library/scala/collection/mutable/ArrayLike.scala
@@ -18,7 +18,6 @@ package mutable
  *  @tparam Repr  the type of the actual collection containing the elements.
  *
  *  @define Coll `ArrayLike`
- *  @version 2.8
  *  @since   2.8
  */
 trait ArrayLike[A, +Repr] extends Any with IndexedSeqOptimized[A, Repr] { self =>

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -20,7 +20,6 @@ import parallel.mutable.ParArray
  *  primitive types are boxed.
  *
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.8
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array-sequences "Scala's Collection Library overview"]]
  *  section on `Array Sequences` for more information.

--- a/src/library/scala/collection/mutable/Buffer.scala
+++ b/src/library/scala/collection/mutable/Buffer.scala
@@ -21,7 +21,6 @@ import generic._
  *
  *  @author Matthias Zenger
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   1
  *
  *  @tparam A    type of the elements contained in this buffer.

--- a/src/library/scala/collection/mutable/BufferLike.scala
+++ b/src/library/scala/collection/mutable/BufferLike.scala
@@ -30,7 +30,6 @@ import scala.annotation.migration
  *
  *  @author  Martin Odersky
  *  @author  Matthias Zenger
- *  @version 2.8
  *  @since   2.8
  *  @define buffernote @note
  *    This trait provides most of the operations of a `Buffer` independently of its representation.

--- a/src/library/scala/collection/mutable/BufferProxy.scala
+++ b/src/library/scala/collection/mutable/BufferProxy.scala
@@ -18,7 +18,6 @@ import script._
  *  dynamically using object composition and forwarding.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 16/04/2004
  *  @since   1
  *
  *  @tparam A     type of the elements the buffer proxy contains.

--- a/src/library/scala/collection/mutable/DefaultMapModel.scala
+++ b/src/library/scala/collection/mutable/DefaultMapModel.scala
@@ -16,7 +16,6 @@ package mutable
  *  class in terms of three functions: `findEntry`, `addEntry`, and `entries`.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 08/07/2003
  *  @since   1
  */
 @deprecated("this trait will be removed", "2.11.0")

--- a/src/library/scala/collection/mutable/DoubleLinkedList.scala
+++ b/src/library/scala/collection/mutable/DoubleLinkedList.scala
@@ -19,7 +19,6 @@ import generic._
  *
  *  @author Matthias Zenger
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   1
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#double-linked-lists "Scala's Collection Library overview"]]
  *  section on `Double Linked Lists` for more information.

--- a/src/library/scala/collection/mutable/DoubleLinkedListLike.scala
+++ b/src/library/scala/collection/mutable/DoubleLinkedListLike.scala
@@ -47,7 +47,6 @@ import scala.annotation.migration
  *  }}}
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 08/07/2003
  *  @since   2.8
  *
  *  @tparam A    type of the elements contained in the double linked list

--- a/src/library/scala/collection/mutable/GrowingBuilder.scala
+++ b/src/library/scala/collection/mutable/GrowingBuilder.scala
@@ -18,7 +18,6 @@ import generic._
  *  GrowableBuilders can produce only a single instance of the collection they are growing.
  *
  *  @author Paul Phillips
- *  @version 2.8
  *  @since 2.8
  *
  *  @define Coll `GrowingBuilder`

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -19,7 +19,6 @@ import scala.collection.parallel.mutable.ParHashSet
  *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 2.0, 31/12/2006
  *  @since   1
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
  *  section on `Hash Tables` for more information.

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -30,7 +30,6 @@ import scala.util.hashing.byteswap32
  *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 2.0, 31/12/2006
  *  @since   1
  *
  *  @tparam A     type of the elements contained in this hash table.

--- a/src/library/scala/collection/mutable/History.scala
+++ b/src/library/scala/collection/mutable/History.scala
@@ -19,7 +19,6 @@ package mutable
  *  up to maximum number of `maxHistory` events.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 08/07/2003
  *  @since   1
  *
  *  @tparam Evt   Type of events.

--- a/src/library/scala/collection/mutable/ImmutableMapAdaptor.scala
+++ b/src/library/scala/collection/mutable/ImmutableMapAdaptor.scala
@@ -22,7 +22,6 @@ import scala.annotation.migration
  *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 2.0, 01/01/2007
  *  @since   1
  */
 @deprecated("adaptors are inherently unreliable and prone to performance problems", "2.11.0")

--- a/src/library/scala/collection/mutable/ImmutableSetAdaptor.scala
+++ b/src/library/scala/collection/mutable/ImmutableSetAdaptor.scala
@@ -17,7 +17,6 @@ package mutable
  *  return the representation of an empty set.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 21/07/2003
  *  @since   1
  */
 @deprecated("adaptors are inherently unreliable and prone to performance problems", "2.11.0")

--- a/src/library/scala/collection/mutable/IndexedSeqLike.scala
+++ b/src/library/scala/collection/mutable/IndexedSeqLike.scala
@@ -29,7 +29,6 @@ package mutable
  *  @define coll mutable indexed sequence
  *  @define indexedSeqInfo
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.8
  *  @define willNotTerminateInf
  *  @define mayNotTerminateInf

--- a/src/library/scala/collection/mutable/IndexedSeqView.scala
+++ b/src/library/scala/collection/mutable/IndexedSeqView.scala
@@ -22,7 +22,6 @@ import TraversableView.NoBuilder
  *  others will just yield a plain indexed sequence of type `collection.IndexedSeq`.
  *  Because this is a leaf class there is no associated `Like` class.
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.8
  *  @tparam A    the element type of the view
  *  @tparam Coll the type of the underlying collection containing the elements.

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -19,7 +19,6 @@ import generic._
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
  *  @author  Pavel Pavlov
- *  @version 2.0, 31/12/2006
  *  @since   1
  *
  *  @tparam A     the type of the elements contained in this set.

--- a/src/library/scala/collection/mutable/LinkedList.scala
+++ b/src/library/scala/collection/mutable/LinkedList.scala
@@ -32,7 +32,6 @@ import generic._
   *
   *  @author Matthias Zenger
   *  @author Martin Odersky
-  *  @version 2.8
   *  @since   1
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#linked-lists "Scala's Collection Library overview"]]
   *  section on `Linked Lists` for more information.

--- a/src/library/scala/collection/mutable/LinkedListLike.scala
+++ b/src/library/scala/collection/mutable/LinkedListLike.scala
@@ -21,7 +21,6 @@ import scala.annotation.tailrec
  *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 1.0, 08/07/2003
  *  @since   2.8
  *
  *  @tparam A    type of the elements contained in the linked list

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -19,7 +19,6 @@ import java.io.{ObjectOutputStream, ObjectInputStream}
  *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   1
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#list-buffers "Scala's Collection Library overview"]]
  *  section on `List Buffers` for more information.

--- a/src/library/scala/collection/mutable/MapProxy.scala
+++ b/src/library/scala/collection/mutable/MapProxy.scala
@@ -17,7 +17,6 @@ package mutable
  *  dynamically using object composition and forwarding.
  *
  *  @author  Matthias Zenger, Martin Odersky
- *  @version 2.0, 31/12/2006
  *  @since   1
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.0")

--- a/src/library/scala/collection/mutable/MultiMap.scala
+++ b/src/library/scala/collection/mutable/MultiMap.scala
@@ -51,7 +51,6 @@ package mutable
  *  @define Coll `MultiMap`
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   1
  */
 trait MultiMap[A, B] extends Map[A, Set[B]] {

--- a/src/library/scala/collection/mutable/MutableList.scala
+++ b/src/library/scala/collection/mutable/MutableList.scala
@@ -19,7 +19,6 @@ import immutable.List
  *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   1
  *  @define Coll `mutable.MutableList`
  *  @define coll mutable list

--- a/src/library/scala/collection/mutable/ObservableBuffer.scala
+++ b/src/library/scala/collection/mutable/ObservableBuffer.scala
@@ -20,7 +20,6 @@ import script._
  *  events of the type `Message`.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 08/07/2003
  *  @since   1
  */
 @deprecated("observables are deprecated because scripting is deprecated", "2.11.0")

--- a/src/library/scala/collection/mutable/ObservableMap.scala
+++ b/src/library/scala/collection/mutable/ObservableMap.scala
@@ -22,7 +22,6 @@ import script._
  *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 2.0, 31/12/2006
  *  @since   1
  */
 @deprecated("observables are deprecated because scripting is deprecated", "2.11.0")

--- a/src/library/scala/collection/mutable/ObservableSet.scala
+++ b/src/library/scala/collection/mutable/ObservableSet.scala
@@ -20,7 +20,6 @@ import script._
  *  events of the type `Message`.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 08/07/2003
  *  @since   1
  */
 @deprecated("observables are deprecated because scripting is deprecated", "2.11.0")

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -36,7 +36,6 @@ import generic._
  *  @param ord   implicit ordering used to compare the elements of type `A`.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 03/05/2004
  *  @since   1
  *
  *  @define Coll PriorityQueue
@@ -357,7 +356,6 @@ object PriorityQueue extends OrderedTraversableFactory[PriorityQueue] {
   *  `Ordered[T]` class.
   *
   *  @author  Matthias Zenger
-  *  @version 1.0, 03/05/2004
   *  @since   1
   */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.0")
@@ -442,7 +440,6 @@ sealed abstract class PriorityQueueProxy[A](implicit ord: Ordering[A]) extends P
   *  @param ord   implicit ordering used to compared elements of type `A`
   *
   *  @author  Matthias Zenger
-  *  @version 1.0, 03/05/2004
   *  @since   1
   *  @define Coll `SynchronizedPriorityQueue`
   *  @define coll synchronized priority queue

--- a/src/library/scala/collection/mutable/Publisher.scala
+++ b/src/library/scala/collection/mutable/Publisher.scala
@@ -24,7 +24,6 @@ package mutable
  *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   1
  */
 trait Publisher[Evt] {

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -19,7 +19,6 @@ import generic._
  *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   1
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#queues "Scala's Collection Library overview"]]
  *  section on `Queues` for more information.

--- a/src/library/scala/collection/mutable/QueueProxy.scala
+++ b/src/library/scala/collection/mutable/QueueProxy.scala
@@ -18,7 +18,6 @@ package mutable
  *  @tparam A   type of the elements in this queue proxy.
  *
  *  @author  Matthias Zenger
- *  @version 1.1, 03/05/2004
  *  @since   1
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.0")

--- a/src/library/scala/collection/mutable/RedBlackTree.scala
+++ b/src/library/scala/collection/mutable/RedBlackTree.scala
@@ -9,7 +9,6 @@ import scala.collection.Iterator
  * The trees implemented in this object are *not* thread safe.
  *
  * @author Rui Gonçalves
- * @version 2.12
  * @since 2.12
  */
 private[collection] object RedBlackTree {

--- a/src/library/scala/collection/mutable/ResizableArray.scala
+++ b/src/library/scala/collection/mutable/ResizableArray.scala
@@ -19,7 +19,6 @@ import generic._
  *
  *  @author  Matthias Zenger, Burak Emir
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   1
  */
 trait ResizableArray[A] extends IndexedSeq[A]

--- a/src/library/scala/collection/mutable/RevertibleHistory.scala
+++ b/src/library/scala/collection/mutable/RevertibleHistory.scala
@@ -22,7 +22,6 @@ package mutable
  *  @tparam Pub   type of the publisher
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 08/07/2003
  *  @since   2.8
  */
 class RevertibleHistory[Evt <: Undoable, Pub] extends History[Evt, Pub] with Undoable with Serializable {

--- a/src/library/scala/collection/mutable/SetLike.scala
+++ b/src/library/scala/collection/mutable/SetLike.scala
@@ -26,7 +26,6 @@ import parallel.mutable.ParSet
  *  @tparam This the type of the set itself.
  *
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since 2.8
  *
  *  @define setNote

--- a/src/library/scala/collection/mutable/SetProxy.scala
+++ b/src/library/scala/collection/mutable/SetProxy.scala
@@ -15,7 +15,6 @@ package mutable
  *  dynamically using object composition and forwarding.
  *
  *  @author  Matthias Zenger
- *  @version 1.1, 09/05/2004
  *  @since   1
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.0")

--- a/src/library/scala/collection/mutable/SortedMap.scala
+++ b/src/library/scala/collection/mutable/SortedMap.scala
@@ -11,7 +11,6 @@ import generic._
  * @tparam B the type of the values associated with the keys.
  *
  * @author Rui Gonçalves
- * @version 2.12
  * @since 2.12
  *
  * @define Coll mutable.SortedMap

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -43,7 +43,6 @@ object Stack extends SeqFactory[Stack] {
  *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   1
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#stacks "Scala's Collection Library overview"]]
  *  section on `Stacks` for more information.

--- a/src/library/scala/collection/mutable/StackProxy.scala
+++ b/src/library/scala/collection/mutable/StackProxy.scala
@@ -16,7 +16,6 @@ package mutable
  *  @tparam A   type of the elements in this stack proxy.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 10/05/2004
  *  @since   1
  */
 @deprecated("proxying is deprecated due to lack of use and compiler-level support", "2.11.0")

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -20,7 +20,6 @@ import immutable.StringLike
  *
  *  @author Stephane Micheloud
  *  @author Martin Odersky
- *  @version 2.8
  *  @since   2.7
  *  @define Coll `mutable.IndexedSeq`
  *  @define coll string builder

--- a/src/library/scala/collection/mutable/Subscriber.scala
+++ b/src/library/scala/collection/mutable/Subscriber.scala
@@ -16,7 +16,6 @@ package mutable
  *
  *  @author  Matthias Zenger
  *  @author  Martin Odersky
- *  @version 2.8
  *  @since   1
  */
 trait Subscriber[-Evt, -Pub] {

--- a/src/library/scala/collection/mutable/SynchronizedBuffer.scala
+++ b/src/library/scala/collection/mutable/SynchronizedBuffer.scala
@@ -20,7 +20,6 @@ import script._
  *  @tparam A    type of the elements contained in this buffer.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 08/07/2003
  *  @since   1
  *  @define Coll `SynchronizedBuffer`
  *  @define coll synchronized buffer

--- a/src/library/scala/collection/mutable/SynchronizedMap.scala
+++ b/src/library/scala/collection/mutable/SynchronizedMap.scala
@@ -19,7 +19,6 @@ import scala.annotation.migration
  *  @tparam B     type of the values associated with keys.
  *
  *  @author  Matthias Zenger, Martin Odersky
- *  @version 2.0, 31/12/2006
  *  @since   1
  *  @define Coll `SynchronizedMap`
  *  @define coll synchronized map

--- a/src/library/scala/collection/mutable/SynchronizedQueue.scala
+++ b/src/library/scala/collection/mutable/SynchronizedQueue.scala
@@ -20,7 +20,6 @@ package mutable
  *  @tparam A     type of elements contained in this synchronized queue.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 03/05/2004
  *  @since   1
  *  @define Coll `SynchronizedQueue`
  *  @define coll synchronized queue

--- a/src/library/scala/collection/mutable/SynchronizedSet.scala
+++ b/src/library/scala/collection/mutable/SynchronizedSet.scala
@@ -19,7 +19,6 @@ import script._
  *  @tparam A    type of the elements contained in this synchronized set.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 08/07/2003
  *  @since   1
  *  @define Coll `SynchronizedSet`
  *  @define coll synchronized set

--- a/src/library/scala/collection/mutable/SynchronizedStack.scala
+++ b/src/library/scala/collection/mutable/SynchronizedStack.scala
@@ -20,7 +20,6 @@ package mutable
  *  @tparam A    type of the elements contained in this stack.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 03/05/2004
  *  @since   1
  *  @define Coll `SynchronizedStack`
  *  @define coll synchronized stack

--- a/src/library/scala/collection/mutable/TreeMap.scala
+++ b/src/library/scala/collection/mutable/TreeMap.scala
@@ -28,7 +28,6 @@ object TreeMap extends MutableSortedMapFactory[TreeMap] {
  * @tparam B the type of the values associated with the keys.
  *
  * @author Rui Gonçalves
- * @version 2.12
  * @since 2.12
  *
  * @define Coll mutable.TreeMap

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -40,7 +40,6 @@ object TreeSet extends MutableSortedSetFactory[TreeSet] {
  * @tparam A the type of the keys contained in this tree set.
  *
  * @author Rui Gonçalves
- * @version 2.12
  * @since 2.10
  *
  * @define Coll mutable.TreeSet

--- a/src/library/scala/collection/mutable/Undoable.scala
+++ b/src/library/scala/collection/mutable/Undoable.scala
@@ -17,7 +17,6 @@ package mutable
  *  `undo` which can be used to undo the last operation.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 08/07/2003
  *  @since   1
  */
 trait Undoable {

--- a/src/library/scala/collection/mutable/WrappedArray.scala
+++ b/src/library/scala/collection/mutable/WrappedArray.scala
@@ -26,7 +26,6 @@ import java.util.Arrays
  *  @tparam T    type of the elements in this wrapped array.
  *
  *  @author  Martin Odersky, Stephane Micheloud
- *  @version 1.0
  *  @since 2.8
  *  @define Coll `WrappedArray`
  *  @define coll wrapped array

--- a/src/library/scala/collection/script/Location.scala
+++ b/src/library/scala/collection/script/Location.scala
@@ -14,7 +14,6 @@ package script
  *  class [[scala.collection.script.Message]].
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 10/05/2004
  *  @since   2.8
  */
 

--- a/src/library/scala/collection/script/Message.scala
+++ b/src/library/scala/collection/script/Message.scala
@@ -18,7 +18,6 @@ import mutable.ArrayBuffer
  *  `Remove`, `Include`, `Reset`, and `Script`.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 08/07/2003
  *  @since   2.8
  */
 @deprecated("scripting is deprecated", "2.11.0")
@@ -28,7 +27,6 @@ trait Message[+A]
  *  to collection classes.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 08/07/2003
  */
 @deprecated("scripting is deprecated", "2.11.0")
 case class Include[+A](location: Location, elem: A) extends Message[A] {
@@ -39,7 +37,6 @@ case class Include[+A](location: Location, elem: A) extends Message[A] {
  *  of elements from collection classes.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 08/07/2003
  */
 @deprecated("scripting is deprecated", "2.11.0")
 case class Update[+A](location: Location, elem: A) extends Message[A] {
@@ -50,7 +47,6 @@ case class Update[+A](location: Location, elem: A) extends Message[A] {
  *  from collection classes.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 08/07/2003
  */
 @deprecated("scripting is deprecated", "2.11.0")
 case class Remove[+A](location: Location, elem: A) extends Message[A] {
@@ -60,7 +56,6 @@ case class Remove[+A](location: Location, elem: A) extends Message[A] {
 /** This command refers to reset operations.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 08/07/2003
  */
 @deprecated("scripting is deprecated", "2.11.0")
 case class Reset[+A]() extends Message[A]
@@ -69,7 +64,6 @@ case class Reset[+A]() extends Message[A]
  *  of a sequence of other messages.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 10/05/2004
  */
 @deprecated("scripting is deprecated", "2.11.0")
 class Script[A] extends ArrayBuffer[Message[A]] with Message[A] {

--- a/src/library/scala/collection/script/Scriptable.scala
+++ b/src/library/scala/collection/script/Scriptable.scala
@@ -14,7 +14,6 @@ package script
  *  objects of that class.
  *
  *  @author  Matthias Zenger
- *  @version 1.0, 09/05/2004
  *  @since   2.8
  */
 @deprecated("scripting is deprecated", "2.11.0")

--- a/src/library/scala/concurrent/Channel.scala
+++ b/src/library/scala/concurrent/Channel.scala
@@ -15,7 +15,6 @@ package scala.concurrent
  *
  *  @tparam A type of data exchanged
  *  @author  Martin Odersky
- *  @version 1.0, 10/03/2003
  */
 class Channel[A] {
   class LinkedList[A] {

--- a/src/library/scala/concurrent/DelayedLazyVal.scala
+++ b/src/library/scala/concurrent/DelayedLazyVal.scala
@@ -21,7 +21,7 @@ package scala.concurrent
  *  @param  body   the computation to run to completion in another thread
  *
  *  @author  Paul Phillips
- *  @version 2.8
+ *  @since 2.8
  */
 class DelayedLazyVal[T](f: () => T, body: => Unit)(implicit exec: ExecutionContext){
   @volatile private[this] var _isDone = false

--- a/src/library/scala/concurrent/Lock.scala
+++ b/src/library/scala/concurrent/Lock.scala
@@ -13,7 +13,6 @@ package scala.concurrent
 /** This class ...
  *
  *  @author  Martin Odersky
- *  @version 1.0, 10/03/2003
  */
 @deprecated("use java.util.concurrent.locks.Lock", "2.11.2")
 class Lock {

--- a/src/library/scala/concurrent/SyncChannel.scala
+++ b/src/library/scala/concurrent/SyncChannel.scala
@@ -13,7 +13,7 @@ package scala.concurrent
  *  data to be written has been read by a corresponding reader thread.
  *
  *  @author  Philipp Haller
- *  @version 2.0, 04/17/2008
+ *  @since 2.0
  */
 class SyncChannel[A] {
 

--- a/src/library/scala/concurrent/SyncVar.scala
+++ b/src/library/scala/concurrent/SyncVar.scala
@@ -15,7 +15,6 @@ import java.util.concurrent.TimeUnit
  *
  *  @tparam A type of the contained value
  *  @author  Martin Odersky
- *  @version 1.0, 10/03/2003
  */
 class SyncVar[A] {
   private var isDefined: Boolean = false

--- a/src/library/scala/inline.scala
+++ b/src/library/scala/inline.scala
@@ -37,6 +37,5 @@ package scala
  * }}}
  *
  * @author Lex Spoon
- * @version 1.0, 2007-5-21
  */
 class inline extends scala.annotation.StaticAnnotation

--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -17,7 +17,6 @@ import java.net.{ URI, URL }
  *  representation of a source file.
  *
  *  @author  Burak Emir, Paul Phillips
- *  @version 1.0, 19/08/2004
  */
 object Source {
   val DefaultBufSize = 2048

--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -18,7 +18,6 @@ import scala.collection.immutable.NumericRange
 /**
  *  @author  Stephane Micheloud
  *  @author  Rex Kerr
- *  @version 1.1
  *  @since 2.7
  */
 object BigDecimal {
@@ -394,7 +393,6 @@ object BigDecimal {
  *
  *  @author  Stephane Micheloud
  *  @author  Rex Kerr
- *  @version 1.1
  */
 final class BigDecimal(val bigDecimal: BigDec, val mc: MathContext)
 extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[BigDecimal] {

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -14,7 +14,6 @@ import scala.language.implicitConversions
 
 /**
  *  @author  Martin Odersky
- *  @version 1.0, 15/07/2003
  *  @since 2.1
  */
 object BigInt {
@@ -107,7 +106,6 @@ object BigInt {
 
 /**
  *  @author  Martin Odersky
- *  @version 1.0, 15/07/2003
  */
 final class BigInt(val bigInteger: BigInteger)
   extends ScalaNumber

--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -26,7 +26,6 @@ import java.util.Comparator
  *       `equiv(x, z) == true` for any `x`, `y`, and `z` of type `T`.
  *
  *  @author  Geoffrey Washburn, Paul Phillips
- *  @version 1.0, 2008-04-03
  *  @since 2.7
  */
 

--- a/src/library/scala/math/Ordered.scala
+++ b/src/library/scala/math/Ordered.scala
@@ -52,7 +52,6 @@ import scala.language.implicitConversions
  *
  *  @see [[scala.math.Ordering]], [[scala.math.PartiallyOrdered]]
  *  @author  Martin Odersky
- *  @version 1.1, 2006-07-24
  */
 trait Ordered[A] extends Any with java.lang.Comparable[A] {
 

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -61,7 +61,6 @@ import scala.language.{implicitConversions, higherKinds}
   * implicit orderings.
   *
   * @author Geoffrey Washburn
-  * @version 0.9.5, 2008-04-15
   * @since 2.7
   * @see [[scala.math.Ordered]], [[scala.util.Sorting]]
   */

--- a/src/library/scala/math/PartialOrdering.scala
+++ b/src/library/scala/math/PartialOrdering.scala
@@ -34,7 +34,6 @@ package math
  *  [[scala.math.Equiv Equiv]] trait.
  *
  *  @author  Geoffrey Washburn
- *  @version 1.0, 2008-04-0-3
  *  @since 2.7
  */
 

--- a/src/library/scala/math/PartiallyOrdered.scala
+++ b/src/library/scala/math/PartiallyOrdered.scala
@@ -14,7 +14,6 @@ package math
 /** A class for partially ordered data.
  *
  *  @author  Martin Odersky
- *  @version 1.0, 23/04/2004
  */
 trait PartiallyOrdered[+A] {
 

--- a/src/library/scala/noinline.scala
+++ b/src/library/scala/noinline.scala
@@ -37,7 +37,6 @@ package scala
  * }}}
  *
  * @author Lex Spoon
- * @version 1.0, 2007-5-21
  * @since 2.5
  */
 class noinline extends scala.annotation.StaticAnnotation

--- a/src/library/scala/runtime/ScalaNumberProxy.scala
+++ b/src/library/scala/runtime/ScalaNumberProxy.scala
@@ -18,7 +18,6 @@ import Proxy.Typed
  *  As with all classes in scala.runtime.*, this is not a supported API.
  *
  *  @author Paul Phillips
- *  @version 2.9
  *  @since   2.9
  */
 trait ScalaNumberProxy[T] extends Any with ScalaNumericAnyConversions with Typed[T] with OrderedProxy[T] {

--- a/src/library/scala/sys/Prop.scala
+++ b/src/library/scala/sys/Prop.scala
@@ -16,7 +16,6 @@ package sys
  *  See `scala.sys.SystemProperties` for an example usage.
  *
  *  @author Paul Phillips
- *  @version 2.9
  *  @since   2.9
  */
 trait Prop[+T] {

--- a/src/library/scala/sys/ShutdownHookThread.scala
+++ b/src/library/scala/sys/ShutdownHookThread.scala
@@ -13,7 +13,6 @@ package sys
  *  how to unregister itself.
  *
  *  @author Paul Phillips
- *  @version 2.9
  *  @since   2.9
  */
 class ShutdownHookThread private (name: String) extends Thread(name) {

--- a/src/library/scala/sys/SystemProperties.scala
+++ b/src/library/scala/sys/SystemProperties.scala
@@ -25,7 +25,6 @@ import scala.language.implicitConversions
  *  @define coll mutable map
  *
  *  @author Paul Phillips
- *  @version 2.9
  *  @since   2.9
  */
 class SystemProperties

--- a/src/library/scala/sys/package.scala
+++ b/src/library/scala/sys/package.scala
@@ -16,7 +16,6 @@ import scala.collection.JavaConverters._
  *  world outside of it.
  *
  *  @author Paul Phillips
- *  @version 2.9
  *  @since   2.9
  */
 package object sys {

--- a/src/library/scala/throws.scala
+++ b/src/library/scala/throws.scala
@@ -20,7 +20,6 @@ package scala
  * }}}
  *
  * @author  Nikolay Mihaylov
- * @version 1.0, 19/05/2006
  * @since   2.1
  */
 class throws[T <: Throwable](cause: String = "") extends scala.annotation.StaticAnnotation {

--- a/src/library/scala/util/DynamicVariable.scala
+++ b/src/library/scala/util/DynamicVariable.scala
@@ -35,7 +35,7 @@ import java.lang.InheritableThreadLocal
  *  are independent of those for the original thread.
  *
  *  @author  Lex Spoon
- *  @version 1.1, 2007-5-21
+ *  @since   2.6
  */
 class DynamicVariable[T](init: T) {
   private val tl = new InheritableThreadLocal[T] {

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -114,7 +114,6 @@ package util
  *  }}}
  *
  *  @author <a href="mailto:research@workingmouse.com">Tony Morris</a>, Workingmouse
- *  @version 2.0, 2016-07-15
  *  @since 2.7
  */
 sealed abstract class Either[+A, +B] extends Product with Serializable {
@@ -420,7 +419,6 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
 /** The left side of the disjoint union, as opposed to the [[scala.util.Right]] side.
  *
  *  @author <a href="mailto:research@workingmouse.com">Tony Morris</a>, Workingmouse
- *  @version 1.0, 11/10/2008
  */
 final case class Left[+A, +B](@deprecatedName('a, "2.12.0") value: A) extends Either[A, B] {
   def isLeft  = true
@@ -432,7 +430,6 @@ final case class Left[+A, +B](@deprecatedName('a, "2.12.0") value: A) extends Ei
 /** The right side of the disjoint union, as opposed to the [[scala.util.Left]] side.
  *
  *  @author <a href="mailto:research@workingmouse.com">Tony Morris</a>, Workingmouse
- *  @version 1.0, 11/10/2008
  */
 final case class Right[+A, +B](@deprecatedName('b, "2.12.0") value: B) extends Either[A, B] {
   def isLeft  = false
@@ -477,7 +474,6 @@ object Either {
   /** Projects an `Either` into a `Left`.
    *
    *  @author <a href="mailto:research@workingmouse.com">Tony Morris</a>, Workingmouse
-   *  @version 1.0, 11/10/2008
    *  @see [[scala.util.Either#left]]
    */
   final case class LeftProjection[+A, +B](e: Either[A, B]) {
@@ -622,7 +618,6 @@ object Either {
    *  2.11 and 2.12.)
    *
    *  @author <a href="mailto:research@workingmouse.com">Tony Morris</a>, Workingmouse
-   *  @version 1.0, 11/10/2008
    */
   final case class RightProjection[+A, +B](e: Either[A, B]) {
 

--- a/src/library/scala/util/MurmurHash.scala
+++ b/src/library/scala/util/MurmurHash.scala
@@ -16,7 +16,6 @@ package util
  *  tuples).
  *
  *  @author  Rex Kerr
- *  @version 2.9
  *  @since   2.9
  */
 

--- a/src/library/scala/util/Sorting.scala
+++ b/src/library/scala/util/Sorting.scala
@@ -34,7 +34,6 @@ import scala.math.Ordering
   * @author  Ross Judson
   * @author  Adriaan Moors
   * @author  Rex Kerr
-  * @version 1.1
   */
 object Sorting {
   /** Sort an array of Doubles using `java.util.Arrays.sort`. */

--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -182,7 +182,6 @@ import java.util.regex.{ Pattern, Matcher }
  *  @author  Thibaud Hottelier
  *  @author  Philipp Haller
  *  @author  Martin Odersky
- *  @version 1.1, 29/01/2008
  *
  *  @param pattern    The compiled pattern
  *  @param groupNames A mapping from names to indices in capture groups

--- a/src/manual/scala/man1/Command.scala
+++ b/src/manual/scala/man1/Command.scala
@@ -7,7 +7,6 @@ package scala.man1
 
 /**
  *  @author Stephane Micheloud
- *  @version 1.0
  */
 trait Command {
   import _root_.scala.tools.docutil.ManPage._

--- a/src/manual/scala/man1/fsc.scala
+++ b/src/manual/scala/man1/fsc.scala
@@ -7,7 +7,6 @@ package scala.man1
 
 /**
  *  @author Lex Spoon
- *  @version 1.0
  */
 object fsc extends Command {
   import _root_.scala.tools.docutil.ManPage._

--- a/src/manual/scala/man1/scala.scala
+++ b/src/manual/scala/man1/scala.scala
@@ -7,7 +7,6 @@ package scala.man1
 
 /**
  *  @author Stephane Micheloud
- *  @version 1.0
  */
 object scala extends Command {
   import _root_.scala.tools.docutil.ManPage._

--- a/src/manual/scala/man1/scaladoc.scala
+++ b/src/manual/scala/man1/scaladoc.scala
@@ -7,7 +7,6 @@ package scala.man1
 
 /**
  *  @author Gilles Dubochet
- *  @version 1.0
  */
 object scaladoc extends Command {
   import _root_.scala.tools.docutil.ManPage._

--- a/src/manual/scala/man1/scalap.scala
+++ b/src/manual/scala/man1/scalap.scala
@@ -7,7 +7,6 @@ package scala.man1
 
 /**
  *  @author Stephane Micheloud
- *  @version 1.0
  */
 object scalap extends Command {
   import _root_.scala.tools.docutil.ManPage._


### PR DESCRIPTION
Most of the `@version` entries are cruft in the Scaladoc output.  Doesn't seem they are useful.

![App.scala doc version field](https://user-images.githubusercontent.com/358615/39538929-5664dda0-4e0c-11e8-81f5-c1f52b2098af.png)

Maybe there was a time or plan to publish the library separately from the compiler?  The library is coupled with the compiler release, so they seem unnecessary.

I kept the `@since` entries, since those are helpful, and even added `@since` in a few spots where appropriate.

Now that the collections rewrite has dropped in 2.13, I'm going to do a similar change there, shortly.