### PR TITLE
Avoid cyclic error in runtime reflection w. ref to inner class in parent

### DIFF
--- a/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
+++ b/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
@@ -42,9 +42,10 @@ private[reflect] trait SymbolLoaders { self: SymbolTable =>
     val module = owner.newModule(name.toTermName)
     // without this check test/files/run/t5256g and test/files/run/t5256h will crash
     // todo. reflection meeting verdict: need to enter the symbols into the first symbol in the owner chain that has a non-empty scope
-    if (owner.info.decls != EmptyScope) {
-      owner.info.decls enter clazz
-      owner.info.decls enter module
+    val rawInfo = owner.rawInfo
+    if (rawInfo.decls != EmptyScope) {
+      rawInfo.decls enter clazz
+      rawInfo.decls enter module
     }
     initClassAndModule(clazz, module, completer(clazz, module))
     (clazz, module)

--- a/test/files/run/reflect-cycle-inner.check
+++ b/test/files/run/reflect-cycle-inner.check
@@ -1,0 +1,4 @@
+Scope{
+  def iterator(): java.util.Iterator[example.Example.Inner];
+  def <init>(): example.Example
+}

--- a/test/files/run/reflect-cycle-inner/Example.java
+++ b/test/files/run/reflect-cycle-inner/Example.java
@@ -1,0 +1,14 @@
+package example;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+public class Example implements Iterable<Example.Inner> {
+    public static class Inner {
+
+    }
+
+    public Iterator<Inner> iterator() {
+        return Collections.emptyIterator();
+    }
+}

--- a/test/files/run/reflect-cycle-inner/Test.scala
+++ b/test/files/run/reflect-cycle-inner/Test.scala
@@ -1,0 +1,8 @@
+object Test {
+
+  def main(args: Array[String]): Unit = {
+    import scala.reflect.runtime.universe._
+    val decls = typeOf[example.Example].decls // throws scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving class ExampleClass
+    println(decls)
+  }
+}


### PR DESCRIPTION
This brings it into line with the regular compiler. The mechanics are
a bit different: ClassFileParser has an internal map of declared inner
classes of the currently parsed outer class, and any class references
look at this first before looking up the owner's info.

That was a too big a change to contemplate for runtime reflection,
so I've opted instead to assign a parent-free info to the class and
module first, use the existing code to enter the inner classes
(changing it to use rawInfo to avoid the cyclic error detection
in info), and then to add the accumulated member classes in the
real ClassInfo types created below.