### PR TITLE
Reduce allocations in findMember

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
@@ -14,7 +14,7 @@ trait FindMembers {
 
   /** Implementation of `Type#{findMember, findMembers}` */
   private[internal] abstract class FindMemberBase[T](tpe: Type, name: Name, excludedFlags: Long, requiredFlags: Long) {
-    protected val initBaseClasses: List[Symbol] = tpe.baseClasses
+    protected[this] final val initBaseClasses: List[Symbol] = tpe.baseClasses
 
     // The first base class, or the symbol of the ThisType
     // e.g in:
@@ -73,9 +73,9 @@ trait FindMembers {
       // Have we seen a candidate deferred member?
       var deferredSeen = false
 
-      // All direct parents of refinement classes in the base class sequence
+      // All refinement classes in the base class sequence
       // from the current `walkBaseClasses`
-      var refinementParents: List[Symbol] = Nil
+      var refinementClasses: List[Symbol] = Nil
 
       // Has the current `walkBaseClasses` encountered a non-refinement class?
       var seenFirstNonRefinementClass = false
@@ -93,7 +93,7 @@ trait FindMembers {
           if (meetsRequirements) {
             val excl: Long = flags & excluded
             val isExcluded: Boolean = excl != 0L
-            if (!isExcluded && isPotentialMember(sym, flags, currentBaseClass, seenFirstNonRefinementClass, refinementParents)) {
+            if (!isExcluded && isPotentialMember(sym, flags, currentBaseClass, seenFirstNonRefinementClass, refinementClasses)) {
               if (shortCircuit(sym)) return false
               else addMemberIfNew(sym)
             } else if (excl == DEFERRED) {
@@ -110,7 +110,7 @@ trait FindMembers {
           //           the component types T1, ..., Tn and the refinement {R }
           //
           //           => private members should be included from T1, ... Tn. (scala/bug#7475)
-          refinementParents :::= currentBaseClass.parentSymbols
+          refinementClasses ::= currentBaseClass
         else if (currentBaseClass.isClass)
           seenFirstNonRefinementClass = true // only inherit privates of refinement parents after this point
 
@@ -130,23 +130,22 @@ trait FindMembers {
     // Q. When does a potential member fail to be an actual member?
     // A. if it is subsumed by an member in a subclass.
     private def isPotentialMember(sym: Symbol, flags: Long, owner: Symbol,
-                                  seenFirstNonRefinementClass: Boolean, refinementParents: List[Symbol]): Boolean = {
+                                  seenFirstNonRefinementClass: Boolean, refinementClasses: List[Symbol]): Boolean = {
       // conservatively (performance wise) doing this with flags masks rather than `sym.isPrivate`
       // to avoid multiple calls to `Symbol#flags`.
       val isPrivate      = (flags & PRIVATE) == PRIVATE
       val isPrivateLocal = (flags & PrivateLocal) == PrivateLocal
 
       // TODO Is the special handling of `private[this]` vs `private` backed up by the spec?
-      def admitPrivate(sym: Symbol): Boolean =
-        (selectorClass == owner) || (
-             !isPrivateLocal // private[this] only a member from within the selector class. (Optimization only? Does the spec back this up?)
-          && (
-                  !seenFirstNonRefinementClass
-               || refinementParents.contains(owner)
-             )
+      def admitPrivate: Boolean =
+          // private[this] only a member from within the selector class.
+          // (Optimization only? Does the spec back this up?)
+        !isPrivateLocal && ( !seenFirstNonRefinementClass ||
+          refinementClasses.exists(_.info.parents.exists(_.typeSymbol == owner))
         )
 
-      (!isPrivate || admitPrivate(sym)) && (sym.name != nme.CONSTRUCTOR || owner == initBaseClasses.head)
+      (sym.name != nme.CONSTRUCTOR || owner == initBaseClasses.head) &&
+        (!isPrivate || owner == selectorClass || admitPrivate)
     }
 
     // True unless the already-found member of type `memberType` matches the candidate symbol `other`.

--- a/test/benchmarks/src/main/scala/scala/reflect/internal/FindMemberBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/reflect/internal/FindMemberBenchmark.scala
@@ -1,0 +1,53 @@
+package scala.reflect.internal
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.tools.nsc.{Global, Settings}
+
+@BenchmarkMode(Array(org.openjdk.jmh.annotations.Mode.Throughput))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+class FindMemberBenchmark {
+  type G <: Global with Singleton
+  var Type_List: G#Type = _
+  var Type_ListRefined: G#Type = _
+  var Name_Blerg: G#TermName = _
+  var Name_toString: G#TermName = _
+  var Name_isEmpty: G#TermName = _
+
+  @Setup(Level.Trial) def setup(): Unit = {
+    val settings = new Settings()
+    settings.usejavacp.value = true
+    settings.stopAfter.value = List("typer")
+    val global = new Global(settings).asInstanceOf[G]
+    import global._
+    new Run()
+    Type_List = typeOf[List[_]]
+    Type_ListRefined = typeOf[List[_] with String { def foo: Int }] // this sort of type turns up in LUBs (search "val lubRefined = ")
+    Name_Blerg = TermName("Blerg")
+    Name_toString = TermName("toString")
+    Name_isEmpty = TermName("isEmpty")
+
+  }
+
+  @Benchmark
+  def findMember(bh: Blackhole): Unit = {
+    bh.consume(Type_List.member(Name_Blerg))
+    bh.consume(Type_List.member(Name_isEmpty))
+    bh.consume(Type_List.member(Name_toString))
+  }
+
+  @Benchmark
+  def findMemberRefined(bh: Blackhole): Unit = {
+    bh.consume(Type_ListRefined.member(Name_Blerg))
+    bh.consume(Type_ListRefined.member(Name_isEmpty))
+    bh.consume(Type_ListRefined.member(Name_toString))
+  }
+}


### PR DESCRIPTION
This commit tries to reduce memory allocations noticed in the issue https://github.com/scala/scala-dev/issues/493 by @retronym.

#### Possible Cause of the Excessive Allocations

The following line:
```Scala
refinementParents :::= currentBaseClass.parentSymbols
```
Is pre-prending the list `currentBaseClass.parentSymbols` to the previous `refinementParens`. Now, suppose `initBaseClasses` contains `n` symbols for which `initBaseClasses` is true, and suppose that each of those symbols has `m` elements in its `parentSymbols`. You would then end up with a list of length `m * n`, which would have that many cons (`::`) objects. Moreover, each call to `parentSymbols` is not to a `val`, but a `def`, which means that it creates a list of length `m`, and then has to copy that list (to prepend is to copy) and throw that away. 

####  Fix

Instead of concatenating, we keep a list of lists, one for each refinement class. This could, ideally, halve the memory leak due to that line. For the previous example, it will reduce the number of `Cons` object created from `2 * m * n` to `n + n * m`. This will be more effective if those `parentSymbols` lists are longer.