### PR TITLE
Scaladoc: Better icon for annotations

### DIFF
--- a/src/partest/scala/tools/partest/ScaladocModelTest.scala
+++ b/src/partest/scala/tools/partest/ScaladocModelTest.scala
@@ -109,6 +109,9 @@ abstract class ScaladocModelTest extends DirectTest {
       def _trait(name: String): DocTemplateEntity = getTheFirst(_traits(name), tpl.qualifiedName + ".trait(" + name + ")")
       def _traits(name: String): List[DocTemplateEntity] = tpl.templates.filter(_.name == name).collect({ case t: DocTemplateEntity with Trait => t})
 
+      def _annotation(name: String): DocTemplateEntity = getTheFirst(_annotations(name), tpl.qualifiedName + ".annotation(" + name + ")")
+      def _annotations(name: String): List[DocTemplateEntity] = tpl.templates.filter(_.name == name).collect({ case t: DocTemplateEntity with AnnotationClass => t})
+
       def _traitMbr(name: String): MemberTemplateEntity = getTheFirst(_traitsMbr(name), tpl.qualifiedName + ".traitMember(" + name + ")")
       def _traitsMbr(name: String): List[MemberTemplateEntity] = tpl.templates.filter(_.name == name).collect({ case t: MemberTemplateEntity if t.isTrait => t})
 

--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlFactory.scala
@@ -28,13 +28,16 @@ class HtmlFactory(val universe: doc.Universe, val reporter: Reporter) {
 
   def libResources = List(
     "class.svg",
+    "annotation.svg",
     "object.svg",
     "trait.svg",
     "package.svg",
     "class_comp.svg",
+    "annotation_comp.svg",
     "object_comp.svg",
     "trait_comp.svg",
     "object_comp_trait.svg",
+    "object_comp_annotation.svg",
     "abstract_type.svg",
     "lato-v11-latin-100.eot",
     "lato-v11-latin-100.ttf",

--- a/src/scaladoc/scala/tools/nsc/doc/html/Page.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/Page.scala
@@ -108,6 +108,7 @@ abstract class Page {
   def kindToString(mbr: MemberEntity) =
     mbr match {
       case c: Class => if (c.isCaseClass) "case class" else "class"
+      case c: AnnotationClass => if (c.isCaseClass) "case class" else "class"
       case _: Trait => "trait"
       case _: Package => "package"
       case _: Object => "object"

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/annotation.svg
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/annotation.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="72px" height="72px" viewBox="0 0 72 72" version="1.1">
+  <defs>
+    <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-1">
+      <feOffset dx="0" dy="4" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+      <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.14 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"/>
+      <feMerge>
+        <feMergeNode in="shadowMatrixOuter1"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <circle id="path-2" cx="32" cy="32" r="32"/>
+    <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-4">
+      <feOffset dx="0" dy="4" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+      <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.14 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"/>
+      <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetInner1"/>
+      <feGaussianBlur stdDeviation="0" in="shadowOffsetInner1" result="shadowBlurInner1"/>
+      <feComposite in="shadowBlurInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"/>
+      <feColorMatrix values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.14 0" in="shadowInnerInner1" type="matrix" result="shadowMatrixInner1"/>
+      <feOffset dx="0" dy="-1" in="SourceAlpha" result="shadowOffsetInner2"/>
+      <feGaussianBlur stdDeviation="0" in="shadowOffsetInner2" result="shadowBlurInner2"/>
+      <feComposite in="shadowBlurInner2" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner2"/>
+      <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.14 0" in="shadowInnerInner2" type="matrix" result="shadowMatrixInner2"/>
+      <feMerge>
+        <feMergeNode in="shadowMatrixOuter1"/>
+        <feMergeNode in="SourceGraphic"/>
+        <feMergeNode in="shadowMatrixInner1"/>
+        <feMergeNode in="shadowMatrixInner2"/>
+      </feMerge>
+    </filter>
+    <path id="path-5" d="M32 61C49.673112 61 64 48.0162577 64 32 64 15.9837423 49.673112 3 32 3 14.326888 3 0 15.9837423 0 32 0 48.0162577 14.326888 61 32 61Z"/>
+  </defs>
+  <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Artboard-1" transform="translate(-298.000000, -91.000000)">
+      <g id="BG" transform="translate(302.000000, 91.000000)">
+        <g id="Icon">
+          <mask id="mask-3" fill="white">
+            <use xlink:href="#path-2"/>
+          </mask>
+          <use id="Mask" fill="#50CC93" filter="url(#filter-1)" xlink:href="#path-2"/>
+          <mask id="mask-6" fill="white">
+            <use xlink:href="#path-5"/>
+          </mask>
+          <text id="@" mask="url(#mask-6)" font-family="Open Sans, Helvetica Neueu, Sans-serif" font-size="40" font-weight="normal" fill="#FFFFFF">
+            <tspan x="12" y="43">
+              @
+            </tspan>
+          </text>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/annotation.svg
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/annotation.svg
@@ -43,7 +43,7 @@
             <use xlink:href="#path-5"/>
           </mask>
           <text id="@" mask="url(#mask-6)" font-family="Open Sans, Helvetica Neueu, Sans-serif" font-size="40" font-weight="normal" fill="#FFFFFF">
-            <tspan x="12" y="43">
+            <tspan x="12" y="46">
               @
             </tspan>
           </text>

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/annotation_comp.svg
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/annotation_comp.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="72px" height="72px" viewBox="0 0 72 72" version="1.1">
+  <defs>
+    <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-1">
+      <feOffset dx="0" dy="4" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+      <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.14 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"/>
+      <feMerge>
+        <feMergeNode in="shadowMatrixOuter1"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <circle id="path-2" cx="32" cy="32" r="32"/>
+    <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-4">
+      <feOffset dx="0" dy="4" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+      <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.14 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"/>
+      <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetInner1"/>
+      <feGaussianBlur stdDeviation="0" in="shadowOffsetInner1" result="shadowBlurInner1"/>
+      <feComposite in="shadowBlurInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"/>
+      <feColorMatrix values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.14 0" in="shadowInnerInner1" type="matrix" result="shadowMatrixInner1"/>
+      <feOffset dx="0" dy="-1" in="SourceAlpha" result="shadowOffsetInner2"/>
+      <feGaussianBlur stdDeviation="0" in="shadowOffsetInner2" result="shadowBlurInner2"/>
+      <feComposite in="shadowBlurInner2" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner2"/>
+      <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.14 0" in="shadowInnerInner2" type="matrix" result="shadowMatrixInner2"/>
+      <feMerge>
+        <feMergeNode in="shadowMatrixOuter1"/>
+        <feMergeNode in="SourceGraphic"/>
+        <feMergeNode in="shadowMatrixInner1"/>
+        <feMergeNode in="shadowMatrixInner2"/>
+      </feMerge>
+    </filter>
+    <path id="path-5" d="M32 61C49.673112 61 64 48.0162577 64 32 64 15.9837423 49.673112 3 32 3 14.326888 3 0 15.9837423 0 32 0 48.0162577 14.326888 61 32 61Z"/>
+  </defs>
+  <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Artboard-1" transform="translate(-298.000000, -91.000000)">
+      <g id="BG" transform="translate(302.000000, 91.000000)">
+        <g id="Icon">
+          <mask id="mask-3" fill="white">
+            <use xlink:href="#path-2"/>
+          </mask>
+          <use id="Mask" fill="#2C6C8D" filter="url(#filter-1)" xlink:href="#path-2"/>
+          <rect id="Rectangle-2" opacity="0.3" fill="#000000" mask="url(#mask-3)" x="-8" y="33" width="80" height="31"/>
+          <mask id="mask-6" fill="white">
+            <use xlink:href="#path-5"/>
+          </mask>
+          <use id="Mask" fill="#50CC93" filter="url(#filter-4)" xlink:href="#path-5"/>
+          <text id="@" mask="url(#mask-6)" font-family="Open Sans, Helvetica Neueu, Sans-serif" font-size="40" font-weight="normal" fill="#FFFFFF">
+            <tspan x="12" y="43">
+              @
+            </tspan>
+          </text>
+          <rect id="Rectangle-2" opacity="0.190065299" fill="#000000" mask="url(#mask-6)" x="-8" y="2" width="80" height="31"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/annotation_comp.svg
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/annotation_comp.svg
@@ -45,7 +45,7 @@
           </mask>
           <use id="Mask" fill="#50CC93" filter="url(#filter-4)" xlink:href="#path-5"/>
           <text id="@" mask="url(#mask-6)" font-family="Open Sans, Helvetica Neueu, Sans-serif" font-size="40" font-weight="normal" fill="#FFFFFF">
-            <tspan x="12" y="43">
+            <tspan x="12" y="46">
               @
             </tspan>
           </text>

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.css
@@ -545,6 +545,11 @@ div#packages > ul > li > a.abstract.type {
   background-size: 0.9rem;
 }
 
+div#packages > ul > li > a.annotation {
+  background: url("annotation.svg") no-repeat center;
+  background-size: 0.9rem;
+}
+
 div#packages > ul > li > a {
   text-decoration: none !important;
   margin-left: 1px;
@@ -699,6 +704,12 @@ div#results-content > div#entity-results > ul.entities > li > .icon {
 div#results-content > div#member-results > ul.entities > li > .icon.class,
 div#results-content > div#entity-results > ul.entities > li > .icon.class {
   background: url("class.svg") no-repeat center;
+  background-size: 1em 1em;
+}
+
+div#results-content > div#member-results > ul.entities > li > .icon.annotation,
+div#results-content > div#entity-results > ul.entities > li > .icon.annotation {
+  background: url("annotation.svg") no-repeat center;
   background-size: 1em 1em;
 }
 

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/object_comp_annotation.svg
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/object_comp_annotation.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="72px" height="72px" viewBox="0 0 72 72" version="1.1">
+  <defs>
+    <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-1">
+      <feOffset dx="0" dy="4" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+      <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.14 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"/>
+      <feMerge>
+        <feMergeNode in="shadowMatrixOuter1"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <circle id="path-2" cx="32" cy="32" r="32"/>
+    <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-4">
+      <feOffset dx="0" dy="4" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+      <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.14 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"/>
+      <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetInner1"/>
+      <feGaussianBlur stdDeviation="0" in="shadowOffsetInner1" result="shadowBlurInner1"/>
+      <feComposite in="shadowBlurInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"/>
+      <feColorMatrix values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.14 0" in="shadowInnerInner1" type="matrix" result="shadowMatrixInner1"/>
+      <feOffset dx="0" dy="-1" in="SourceAlpha" result="shadowOffsetInner2"/>
+      <feGaussianBlur stdDeviation="0" in="shadowOffsetInner2" result="shadowBlurInner2"/>
+      <feComposite in="shadowBlurInner2" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner2"/>
+      <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.14 0" in="shadowInnerInner2" type="matrix" result="shadowMatrixInner2"/>
+      <feMerge>
+        <feMergeNode in="shadowMatrixOuter1"/>
+        <feMergeNode in="SourceGraphic"/>
+        <feMergeNode in="shadowMatrixInner1"/>
+        <feMergeNode in="shadowMatrixInner2"/>
+      </feMerge>
+    </filter>
+    <path id="path-5" d="M32 61C49.673112 61 64 48.0162577 64 32 64 15.9837423 49.673112 3 32 3 14.326888 3 0 15.9837423 0 32 0 48.0162577 14.326888 61 32 61Z"/>
+  </defs>
+  <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Artboard-1" transform="translate(-298.000000, -91.000000)">
+      <g id="BG" transform="translate(302.000000, 91.000000)">
+        <g id="Icon">
+          <mask id="mask-3" fill="white">
+            <use xlink:href="#path-2"/>
+          </mask>
+          <use id="Mask" fill="#50CC93" filter="url(#filter-1)" xlink:href="#path-2"/>
+          <rect id="Rectangle-2" opacity="0.3" fill="#000000" mask="url(#mask-3)" x="-8" y="33" width="80" height="31"/>
+          <mask id="mask-6" fill="white">
+            <use xlink:href="#path-5"/>
+          </mask>
+          <use id="Mask" fill="#2C6C8D" filter="url(#filter-4)" xlink:href="#path-5"/>
+          <text id="t" mask="url(#mask-6)" font-family="Open Sans, Helvetica Neueu, Sans-serif" font-size="40" font-weight="normal" fill="#FFFFFF">
+            <tspan x="17" y="47">
+              O
+            </tspan>
+          </text>
+          <rect id="Rectangle-2" opacity="0.190065299" fill="#000000" mask="url(#mask-6)" x="-8" y="2" width="80" height="31"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
@@ -244,6 +244,18 @@ span.symbol > a {
   background: url("package.svg") no-repeat center;
 }
 
+.big-circle.annotation {
+  background: url("annotation.svg") no-repeat center;
+}
+
+.big-circle.object-companion-annotation {
+  background: url("object_comp_annotation.svg") no-repeat center;
+}
+
+.big-circle.annotation-companion-object {
+  background: url("annotation_comp.svg") no-repeat center;
+}
+
 body.abstract.type div.big-circle {
   background: url("abstract_type.svg") no-repeat center;
 }

--- a/src/scaladoc/scala/tools/nsc/doc/model/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/Entity.scala
@@ -342,6 +342,11 @@ trait Object extends MemberTemplateEntity {
   def kind = "object"
 }
 
+/** An annotation template. Any class which extends `scala.annotation.Annotation` */
+trait AnnotationClass extends MemberTemplateEntity {
+  def kind = "annotation"
+}
+
 /** A package template. A package is in the universe if it is declared as a package object, or if it
   * contains at least one template. */
 trait Package extends DocTemplateEntity {

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -27,7 +27,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
                with MemberLookup =>
 
   import global._
-  import definitions.{ ObjectClass, NothingClass, AnyClass, AnyValClass, AnyRefClass }
+  import definitions.{ ObjectClass, NothingClass, AnyClass, AnyValClass, AnyRefClass, AnnotationClass }
   import rootMirror.{ RootPackage, EmptyPackage }
   import ModelFactory._
 
@@ -633,6 +633,8 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
           new DocTemplateImpl(bSym, inTpl) with Object {}
         else if (bSym.isTrait)
           new DocTemplateImpl(bSym, inTpl) with Trait {}
+        else if (bSym.isClass && bSym.asClass.baseClasses.contains(AnnotationClass))
+          new DocTemplateImpl(bSym, inTpl) with model.AnnotationClass {}
         else if (bSym.isClass || bSym == AnyRefClass)
           new DocTemplateImpl(bSym, inTpl) with Class {}
         else

--- a/test/scaladoc/run/t7367.scala
+++ b/test/scaladoc/run/t7367.scala
@@ -17,7 +17,7 @@ object Test extends ScaladocModelTest {
     import access._
     val annotations = root._class("B").annotations
     assert(annotations.size == 1)
-    assert(annotations(0).annotationClass == root._class("annot"))
+    assert(annotations(0).annotationClass == root._annotation("annot"))
     val args = annotations(0).arguments
     assert(args.size == 1)
     assert(args(0).value.expression == "0")


### PR DESCRIPTION
Use an `@` and a lighter shade of green for classes that extend `Annotation`
For a screenshot take a look at the issue.

Fixes scala/bug#4489