### PR TITLE
Add older version notice & version in spec title

### DIFF
--- a/spec/_config.yml
+++ b/spec/_config.yml
@@ -1,4 +1,6 @@
 baseurl: /files/archive/spec/2.12
+latestScalaVersion: 2.12
+thisScalaVersion: 2.12
 safe: true
 lsi: false
 highlighter: false

--- a/spec/_includes/version-notice.yml
+++ b/spec/_includes/version-notice.yml
@@ -1,0 +1,3 @@
+{% if site.thisScalaVersion != site.latestScalaVersion %}
+<div class="version-notice">This is the specification of a previous version of Scala. See the <a href="{{ site.baseurl}}/../{{ site.latestScalaVersion }}/">Scala {{ site.latestScalaVersion }} spec</a>.</div>
+{% endif %}

--- a/spec/_layouts/default.yml
+++ b/spec/_layouts/default.yml
@@ -45,6 +45,7 @@
   <aside class="left"><nav id="toc"></nav></aside>
 
   <main id="content">
+{% include version-notice.yml %}
 {{ content }}
   </main>
 

--- a/spec/_layouts/default.yml
+++ b/spec/_layouts/default.yml
@@ -26,12 +26,21 @@
   <link rel="stylesheet" type="text/css" media="(max-width: 1400px), (orientation: portrait)" href="public/stylesheets/screen-small.css">
   <link rel="stylesheet" type="text/css" media="print" href="public/stylesheets/print.css">
   <link rel="stylesheet" type="text/css" href="public/stylesheets/fonts.css">
-  <title>{{ page.title }}</title>
+  <title>{{ page.title }} | Scala {{ site.thisScalaVersion }}</title>
 </head>
 
 <body>
   <header>
-    <nav id="chapters"><a id="github" href="https://github.com/scala/scala/tree/2.12.x/spec"><img src="public/images/github-logo@2x.png" alt="Edit at GitHub"></a>{% assign sorted_pages = site.pages | sort:"name" %}{% for post in sorted_pages %}{% if post.chapter >= 0 %}<a href="{{site.baseurl}}{{ post.url }}">{{post.chapter}} {{ post.title }}</a>{% endif %}{% endfor %}</nav>
+    <nav id="chapters">
+      <a href="{{site.baseurl}}/" title="Table of Contents">Scala {{ site.thisScalaVersion }}</a>
+      <a id="github" href="https://github.com/scala/scala/tree/2.12.x/spec"><img src="public/images/github-logo@2x.png" alt="Edit at GitHub"></a>
+      {% assign sorted_pages = site.pages | sort:"name" %}
+      {% for post in sorted_pages %}
+        {% if post.chapter >= 0 %}
+        <a href="{{site.baseurl}}{{ post.url }}">{{post.chapter}} {{ post.title }}</a>
+        {% endif %}
+      {% endfor %}
+    </nav>
   </header>
   <aside class="left"><nav id="toc"></nav></aside>
 

--- a/spec/_layouts/toc.yml
+++ b/spec/_layouts/toc.yml
@@ -24,6 +24,7 @@
   <div id="header-sub">Version {{ site.thisScalaVersion }}</div>
 </header>
 <main>
+{% include version-notice.yml %}
 {{ content }}
 </main>
 </body>

--- a/spec/_layouts/toc.yml
+++ b/spec/_layouts/toc.yml
@@ -7,7 +7,7 @@
   <link rel="shortcut icon" type="image/png" href="public/favicon.ico">
 
   <script src="//code.jquery.com/jquery-2.1.3.min.js"></script>
-  <title>{{ page.title }}</title>
+  <title>{{ page.title }} | Scala {{ site.thisScalaVersion }}</title>
 
   <link rel="stylesheet" type="text/css" href="public/stylesheets/screen.css">
   <link rel="stylesheet" type="text/css" href="public/stylesheets/screen-toc.css">
@@ -19,9 +19,9 @@
   <div id="header-main">
   <img id="scala-logo" src="public/images/scala-spiral-white.png" />
   <span id="title">Scala Language Specification</span>
-  <a id="github" href="https://github.com/scala/scala/tree/2.12.x/spec"><img src="public/images/github-logo@2x.png" alt="Edit at GitHub"></a>
+  <a id="github" href="https://github.com/scala/scala/tree/{{ site.thisScalaVersion }}.x/spec"><img src="public/images/github-logo@2x.png" alt="Edit at GitHub"></a>
   </div>
-  <div id="header-sub">Version 2.12</div>
+  <div id="header-sub">Version {{ site.thisScalaVersion }}</div>
 </header>
 <main>
 {{ content }}

--- a/spec/public/stylesheets/screen.css
+++ b/spec/public/stylesheets/screen.css
@@ -502,3 +502,16 @@ header {
 /* proper rendering of MathJax into highlighted code blocks */
 .fixws { white-space: pre; }
 .fixws .math { white-space: nowrap; }
+
+.version-notice {
+    background-color: #C93A3A;
+    color: #f2f2f2;
+    border:1px solid #ccc;
+    padding: 1em;
+    margin-bottom: 1em;
+}
+.version-notice a {
+    color: #f2f2f2;
+    font-weight: bold;
+    text-decoration: underline;
+}


### PR DESCRIPTION
* Add older version notice (warning) to spec pages
* Add Scala version in `<title>` and navigation bar for chapters

Fixes scala/scala-lang#851.

If this PR is accepted, I will backport the changes to `2.11.x` and `2.12.x` branches.

# Older version notice (warning)

The notice appears if spec version as `thisScalaVersion` defined in `_config.yml` does not equal to latest spec version as `latestScalaVersion`.

It can lead the readers to "latest" spec. It also maybe help Google crawlers to find latest spec.

Note: The style and notice message are inspired by [Elasticsearch Reference](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/index.html)


## Notice for ToC
![version-notice-1](https://user-images.githubusercontent.com/127635/39611795-81b7020a-4f95-11e8-8c70-c01b9d277b63.jpg)

## Notice for each chapter 
![version-notice](https://user-images.githubusercontent.com/127635/39611796-81f8de6e-4f95-11e8-997d-362d551d37c9.jpg)



# Scala version in HTML <title> and nav bar

intended for 

* User-friendliness for bookmark or social sharing
* SEO

## ToC
![2018-05-04-121935](https://user-images.githubusercontent.com/127635/39611794-81915cbc-4f95-11e8-922e-b5adf1b440c5.jpg)

## Chapter

Note: Scala version in nav bar leads to ToC

![2018-05-04-121958](https://user-images.githubusercontent.com/127635/39611793-816915ae-4f95-11e8-9c65-95213da5fbee.jpg)

