### PR TITLE
Override map on BitSet to avoid ambiguity.

### DIFF
--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -50,6 +50,9 @@ sealed abstract class BitSet
   /** Update word at index `idx`; enlarge set if `idx` outside range of set.
     */
   protected def updateWord(idx: Int, w: Long): BitSet
+
+  override def map(f: Int => Int): BitSet = super[BitSet].map(f)
+  override def map[B : Ordering](f: Int => B): SortedSet[B] = super[SortedSetOps].map(f)
 }
 
 /**

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -139,6 +139,10 @@ class BitSet(protected[collection] final var elems: Array[Long])
     new BitSet(java.util.Arrays.copyOf(elems, elems.length))
 
   def toImmutable: immutable.BitSet = immutable.BitSet.fromBitMask(elems)
+
+  override def map(f: Int => Int): BitSet = super[BitSet].map(f)
+  override def map[B : Ordering](f: Int => B): SortedSet[B] = super[SortedSetOps].map(f)
+
 }
 
 object BitSet extends SpecificIterableFactory[Int, BitSet] {

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -48,4 +48,14 @@ class BitSetTest {
     val bsFromEmptyBitMaskNoCopy = BitSet.fromBitMaskNoCopy(Array.empty[Long])
     assert(bsFromEmptyBitMaskNoCopy.add(0))
   }
+
+  @Test def strawman_508: Unit = {
+    val m = BitSet(1)
+    assert(m.map(i => i.toLong).isInstanceOf[TreeSet[Long]])
+    assert(m.map(i => i + 1).isInstanceOf[BitSet])
+
+    val im = collection.immutable.BitSet(1)
+    assert(im.map(i=>i.toLong).isInstanceOf[collection.immutable.TreeSet[Long]])
+    assert(im.map(i=>i + 1).isInstanceOf[collection.immutable.BitSet])
+  } 
 }


### PR DESCRIPTION
Fixes scala/collection-strawman#508