### PR TITLE
Integrate macro paradise under `-Ymacro-annotations`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,13 +32,12 @@
  *   - to modularize the Scala compiler or library further
  */
 
-import java.io.{PrintWriter, StringWriter}
-
 import sbt.TestResult
 import sbt.testing.TestSelector
 
 import scala.build._
 import VersionUtil._
+import scala.tools.nsc.util.ScalaClassLoader.URLClassLoader
 
 // Scala dependencies:
 val partestDep                   = scalaDep("org.scala-lang.modules", "scala-partest", versionProp = "partest")
@@ -117,6 +116,34 @@ lazy val instanceSettings = Seq[Setting[_]](
   ivyScala ~= (_ map (_ copy (overrideScalaVersion = false))),
   Quiet.silenceScalaBinaryVersionWarning
 )
+
+// be careful with using this instance, as it may cause performance problems (e.g., MetaSpace exhaustion)r
+lazy val quickInstanceSettings = Seq[Setting[_]](
+  organization := "org.scala-lang",
+  // we don't cross build Scala itself
+  crossPaths := false,
+  // do not add Scala library jar as a dependency automatically
+  autoScalaLibrary := false,
+  // Avoid circular dependencies for scalaInstance (see https://github.com/sbt/sbt/issues/1872)
+  managedScalaInstance := false,
+  scalaInstance := {
+    // TODO: express in terms of distDependencies?
+    val cpElems: Seq[java.io.File] = (fullClasspath in Compile in replFrontend).value.map(_.data) ++ (fullClasspath in Compile in scaladoc).value.map(_.data)
+    val libraryJar = cpElems.find(_.getPath.endsWith("classes/library")).get
+    val compilerJar = cpElems.find(_.getPath.endsWith("classes/compiler")).get
+    val extraJars = cpElems.filter(f => (f ne libraryJar) && (f ne compilerJar))
+    val v = (version in Global).value
+    new ScalaInstance(v, new URLClassLoader(cpElems.map(_.toURI.toURL).toArray[URL], null), libraryJar, compilerJar, extraJars, Some(v))
+  },
+  // As of sbt 0.13.12 (sbt/sbt#2634) sbt endeavours to align both scalaOrganization and scalaVersion
+  // in the Scala artefacts, for example scala-library and scala-compiler.
+  // This doesn't work in the scala/scala build because the version of scala-library and the scalaVersion of
+  // scala-library are correct to be different. So disable overriding.
+  ivyScala ~= (_ map (_ copy (overrideScalaVersion = false))),
+  Quiet.silenceScalaBinaryVersionWarning
+)
+
+
 
 lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories ++ publishSettings ++ Seq[Setting[_]](
   // we always assume that Java classes are standalone and do not have any dependency
@@ -560,6 +587,27 @@ lazy val junit = project.in(file("test") / "junit")
     unmanagedSourceDirectories in Test := List(baseDirectory.value)
   )
 
+// imported from scalamacros/paradise for the test suite -- TODO: integrate into build structure, get rid of quickInstanceSettings?
+lazy val macroAnnot = project.in(file("test") / "macro-annot")
+  .dependsOn(library, reflect, compiler, repl, replFrontend, scaladoc)
+  .settings(disableDocs)
+  .settings(disablePublishing)
+  .settings(quickInstanceSettings) // use quick compiler as Scala Instance
+  .settings(
+    fork in Test := true,
+    javaOptions in Test += "-Xss1M",
+    libraryDependencies ++= Seq(junitDep, junitInterfaceDep),
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v",
+                                  s"-Dsbt.paths.tests.classpath=${(fullClasspath in Test).value.files.map(_.getAbsolutePath).mkString(java.io.File.pathSeparatorChar.toString)}"),
+
+    baseDirectory in Compile := (baseDirectory in ThisBuild).value,
+    baseDirectory in Test := (baseDirectory in ThisBuild).value,
+
+    scalacOptions += "-Ymacro-annotations",
+    scalacOptions += "-Ywarn-unused-import",
+    scalacOptions += "-Xfatal-warnings"
+  )
+
 lazy val scalacheck = project.in(file("test") / "scalacheck")
   .dependsOn(library, reflect, compiler, scaladoc)
   .settings(clearSourceAndResourceDirectories)
@@ -804,6 +852,7 @@ lazy val root: Project = (project in file("."))
       val results = ScriptCommands.sequence[(Result[Unit], String)](List(
         (Keys.test in Test in junit).result map (_ -> "junit/test"),
         (Keys.test in Test in scalacheck).result map (_ -> "scalacheck/test"),
+        (Keys.test in Test in macroAnnot).result map (_ -> "macroAnnot/test"),
         (testOnly in IntegrationTest in testP).toTask(" -- run").result map (_ -> "partest run"),
         (testOnly in IntegrationTest in testP).toTask(" -- pos neg jvm").result map (_ -> "partest pos neg jvm"),
         (testOnly in IntegrationTest in testP).toTask(" -- res scalap specialized").result map (_ -> "partest res scalap specialized"),
@@ -871,7 +920,7 @@ lazy val root: Project = (project in file("."))
     }
   )
   .aggregate(library, reflect, compiler, interactive, repl, replFrontend,
-    scaladoc, scalap, partestExtras, junit, scalaDist).settings(
+    scaladoc, scalap, partestExtras, junit, scalaDist, macroAnnot).settings(
     sources in Compile := Seq.empty,
     onLoadMessage := """|*** Welcome to the sbt build definition for Scala! ***
       |Check README.md for more information.""".stripMargin

--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -87,7 +87,7 @@ object ScalaOptionParser {
     "-Ybreak-cycles", "-Ydebug", "-Ycompact-trees", "-YdisableFlatCpCaching", "-Ydoc-debug",
     "-Yide-debug", "-Yinfer-argument-types",
     "-Yissue-debug", "-Ylog-classpath", "-Ymacro-debug-lite", "-Ymacro-debug-verbose", "-Ymacro-no-expand",
-    "-Yno-completion", "-Yno-generic-signatures", "-Yno-imports", "-Yno-predef",
+    "-Yno-completion", "-Yno-generic-signatures", "-Yno-imports", "-Yno-predef", "-Ymacro-annotations",
     "-Yoverride-objects", "-Yoverride-vars", "-Ypatmat-debug", "-Yno-adapted-args", "-Ypos-debug", "-Ypresentation-debug",
     "-Ypresentation-strict", "-Ypresentation-verbose", "-Yquasiquote-debug", "-Yrangepos", "-Yreify-copypaste", "-Yreify-debug", "-Yrepl-class-based",
     "-Yrepl-sync", "-Yshow-member-pos", "-Yshow-symkinds", "-Yshow-symowners", "-Yshow-syms", "-Yshow-trees", "-Yshow-trees-compact", "-Yshow-trees-stringified", "-Ytyper-debug",

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -445,9 +445,9 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   // I only changed analyzer.
   //
   // factory for phases: namer, packageobjects, typer
-  lazy val analyzer = new {
-    val global: Global.this.type = Global.this
-  } with Analyzer
+  lazy val analyzer =
+    if (settings.YmacroAnnotations) new { val global: Global.this.type = Global.this } with Analyzer with MacroAnnotationNamers
+    else new { val global: Global.this.type = Global.this } with Analyzer
 
   // phaseName = "patmat"
   object patmat extends {

--- a/src/compiler/scala/tools/nsc/ast/TreeInfo.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeInfo.scala
@@ -6,12 +6,14 @@
 package scala.tools.nsc
 package ast
 
+import scala.reflect.internal.MacroAnnotionTreeInfo
+
 /** This class ...
  *
  *  @author Martin Odersky
  *  @version 1.0
  */
-abstract class TreeInfo extends scala.reflect.internal.TreeInfo {
+abstract class TreeInfo extends scala.reflect.internal.TreeInfo with MacroAnnotionTreeInfo {
   val global: Global
   import global._
   import definitions._

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -218,6 +218,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Yreifycopypaste = BooleanSetting    ("-Yreify-copypaste", "Dump the reified trees in copypasteable representation.")
   val Ymacroexpand    = ChoiceSetting     ("-Ymacro-expand", "policy", "Control expansion of macros, useful for scaladoc and presentation compiler.", List(MacroExpand.Normal, MacroExpand.None, MacroExpand.Discard), MacroExpand.Normal)
   val Ymacronoexpand  = BooleanSetting    ("-Ymacro-no-expand", "Don't expand macros. Might be useful for scaladoc and presentation compiler, but will crash anything which uses macros and gets past typer.") withDeprecationMessage(s"Use ${Ymacroexpand.name}:${MacroExpand.None}") withPostSetHook(_ => Ymacroexpand.value = MacroExpand.None)
+  val YmacroAnnotations = BooleanSetting  ("-Ymacro-annotations", "Enable support for macro annotations, formerly in macro paradise.")
   val Yreplsync       = BooleanSetting    ("-Yrepl-sync", "Do not use asynchronous code for repl startup")
   val Yreplclassbased = BooleanSetting    ("-Yrepl-class-based", "Use classes to wrap REPL snippets instead of objects")
   val Yreploutdir     = StringSetting     ("-Yrepl-outdir", "path", "Write repl-generated classfiles to given output directory (use \"\" to generate a temporary dir)" , "")

--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -24,6 +24,7 @@ trait Analyzer extends AnyRef
             with TypeDiagnostics
             with ContextErrors
             with StdAttachments
+            with MacroAnnotationAttachments
             with AnalyzerPlugins
 {
   val global : Global

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -898,6 +898,68 @@ trait ContextErrors {
 
       def MacroImplementationNotFoundError(expandee: Tree) =
         macroExpansionError(expandee, macroImplementationNotFoundMessage(expandee.symbol.name))
+
+      def MacroAnnotationShapeError(clazz: Symbol) = {
+        val sym = clazz.info.member(nme.macroTransform)
+        var actualSignature = sym.toString
+        if (sym.isOverloaded) actualSignature += "(...) = ..."
+        else if (sym.isMethod) {
+          if (sym.typeParams.nonEmpty) {
+            def showTparam(tparam: Symbol) =
+              tparam.typeSignature match {
+                case tpe @ TypeBounds(_, _) => s"${tparam.name}$tpe"
+                case _ => tparam.name
+              }
+            def showTparams(tparams: List[Symbol]) = "[" + (tparams map showTparam mkString ", ") + "]"
+            actualSignature += showTparams(sym.typeParams)
+          }
+          if (sym.paramss.nonEmpty) {
+            def showParam(param: Symbol) = s"${param.name}: ${param.typeSignature}"
+            def showParams(params: List[Symbol]) = {
+              val s_mods = if (params.nonEmpty && params(0).hasFlag(scala.reflect.internal.Flags.IMPLICIT)) "implicit " else ""
+              val s_params = params map showParam mkString ", "
+              "(" + s_mods + s_params + ")"
+            }
+            def showParamss(paramss: List[List[Symbol]]) = paramss map showParams mkString ""
+            actualSignature += showParamss(sym.paramss)
+          }
+          if (sym.isTermMacro) actualSignature = actualSignature.replace("macro method", "def") + " = macro ..."
+          else actualSignature = actualSignature.replace("method", "def") + " = ..."
+        }
+        issueSymbolTypeError(clazz, s"""
+                                       |macro annotation has wrong shape:
+                                       |  required: def macroTransform(annottees: Any*) = macro ...
+                                       |  found   : $actualSignature
+      """.trim.stripMargin)
+      }
+
+      def MacroAnnotationMustBeStaticError(clazz: Symbol) =
+        issueSymbolTypeError(clazz, s"macro annotation must extend scala.annotation.StaticAnnotation")
+
+      def MacroAnnotationCannotBeInheritedError(clazz: Symbol) =
+        issueSymbolTypeError(clazz, s"macro annotation cannot be @Inherited")
+
+      def MacroAnnotationCannotBeMemberError(clazz: Symbol) =
+        issueSymbolTypeError(clazz, s"macro annotation cannot be a member of another class")
+
+      def MacroAnnotationNotExpandedMessage: String = {
+        "macro annotation could not be expanded " + (
+          if (!settings.YmacroAnnotations) "(since these are experimental, you must enable them with -Ymacro-annotations)"
+          else "(you cannot use a macro annotation in the same compilation run that defines it)")
+      }
+
+      def MacroAnnotationOnlyDefinitionError(ann: Tree) =
+        issueNormalTypeError(ann, "macro annotations can only be put on definitions")
+
+      def MacroAnnotationTopLevelClassWithCompanionBadExpansion(ann: Tree) =
+        issueNormalTypeError(ann, "top-level class with companion can only expand into a block consisting in eponymous companions")
+
+      def MacroAnnotationTopLevelClassWithoutCompanionBadExpansion(ann: Tree) =
+        issueNormalTypeError(ann, "top-level class without companion can only expand either into an eponymous class or into a block consisting in eponymous companions")
+
+      def MacroAnnotationTopLevelModuleBadExpansion(ann: Tree) =
+        issueNormalTypeError(ann, "top-level object can only expand into an eponymous object")
+
     }
 
     /** This file will be the death of me. */

--- a/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
@@ -1,0 +1,772 @@
+package scala.tools.nsc.typechecker
+
+// imported from scalamacros/paradise
+trait MacroAnnotationNamers { self: Analyzer =>
+  import global._
+  import analyzer._
+  import definitions._
+  import scala.reflect.internal.Flags._
+  import scala.reflect.internal.Mode._
+
+  override def newNamer(context: Context): Namer = new MacroAnnotationNamer(context)
+
+  class MacroAnnotationNamer(context: Context) extends Namer(context) {
+    import NamerErrorGen._
+    import typer.TyperErrorGen._
+
+    override def standardEnterSym(tree: Tree): Context = {
+      def dispatch() = {
+        var returnContext = context
+        tree match {
+          case DocDef(_, mdef) =>
+            enterSym(mdef)
+          case tree @ Import(_, _) =>
+            createAssignAndEnterSymbol(tree)
+            finishSymbol(tree)
+            returnContext = context.make(tree)
+          case tree: MemberDef =>
+            createAssignAndEnterSymbol(tree)
+            finishSymbol(tree)
+          case _ =>
+        }
+        returnContext
+      }
+      tree.symbol match {
+        case NoSymbol => try dispatch() catch typeErrorHandler(tree, context)
+        case sym      => enterExistingSym(sym, tree)
+      }
+    }
+
+    protected def createAssignAndEnterSymbol(tree: Tree, mask: Long = -1L): Symbol = {
+      def coreCreateAssignAndEnterSymbol = {
+        val sym = tree match {
+          case PackageDef(pid, _) => createPackageSymbol(tree.pos, pid) // package symbols are entered elsewhere
+          case imp: Import        => createImportSymbol(imp) // import symbols are dummies, no need to enter them anywhere
+          case mdef: MemberDef    => enterInScope(setPrivateWithin(mdef, createMemberSymbol(mdef, mdef.name, mask)))
+          case _                  => abort("Unexpected tree: " + tree)
+        }
+        if (isPastTyper) sym.name.toTermName match {
+          case nme.IMPORT | nme.OUTER | nme.ANON_CLASS_NAME | nme.ANON_FUN_NAME | nme.CONSTRUCTOR => ()
+          case _                                                                                  =>
+            tree match {
+              case md: DefDef => log("[+symbol] " + sym.debugLocationString)
+              case _          =>
+            }
+        }
+        tree.symbol = sym
+        sym
+      }
+      def deriveSymbolFromSource(tree: Tree)(pf: PartialFunction[Tree, Symbol]): Symbol = {
+        val sym = pf(tree)
+        // can't do this in coreCreateAssignAndEnterSymbol
+        // because then we won't get to update sources for redefinitions
+        // this might be crucial when we have classfiles of the definition we're currently compiling
+        attachSource(sym, tree)
+        sym
+      }
+      deriveSymbolFromSource(tree) {
+        case tree @ ClassDef(mods, name, _, _) =>
+          val existing = context.scope.lookup(name)
+          val isRedefinition = (
+                               existing.isType
+                               && existing.isTopLevel
+                               && context.scope == existing.owner.info.decls
+                               && (
+                                  currentRun.canRedefine(existing) ||
+                                  isExpanded(existing)
+                                  )
+                               )
+          val clazz: Symbol = {
+            if (isRedefinition) {
+              updatePosFlags(existing, tree.pos, mods.flags)
+              setPrivateWithin(tree, existing)
+              clearRenamedCaseAccessors(existing)
+              tree.symbol = existing
+              existing
+            }
+            else coreCreateAssignAndEnterSymbol setFlag inConstructorFlag
+          }
+          if (clazz.isClass && clazz.isTopLevel) {
+            if (clazz.sourceFile != null && clazz.sourceFile != contextFile)
+              devWarning(s"Source file mismatch in $clazz: ${clazz.sourceFile} vs. $contextFile")
+
+            clazz.associatedFile = contextFile
+            if (clazz.sourceFile != null) {
+              assert(currentRun.canRedefine(clazz) || clazz.sourceFile == currentRun.symSource(clazz), clazz.sourceFile)
+              currentRun.symSource(clazz) = clazz.sourceFile
+            }
+            registerTopLevelSym(clazz)
+            assert(clazz.name.toString.indexOf('(') < 0, clazz.name)  // )
+          }
+          clazz
+        case tree @ ModuleDef(mods, name, _) =>
+          var m: Symbol = context.scope lookupModule name
+          val moduleFlags = mods.flags | MODULE
+          // TODO: inCurrentScope(m) check that's present in vanilla Namer is omitted here
+          // this fixes SI-3772, but may break something else - I didn't have time to look into that
+          if (m.isModule && !m.hasPackageFlag && (currentRun.canRedefine(m) || m.isSynthetic || isExpanded(m))) {
+            // This code accounts for the way the package objects found in the classpath are opened up
+            // early by the completer of the package itself. If the `packageobjects` phase then finds
+            // the same package object in sources, we have to clean the slate and remove package object
+            // members from the package class.
+            //
+            // TODO SI-4695 Pursue the approach in https://github.com/scala/scala/pull/2789 that avoids
+            //      opening up the package object on the classpath at all if one exists in source.
+            if (m.isPackageObject) {
+              val packageScope = m.enclosingPackageClass.rawInfo.decls
+              packageScope.filter(_.owner != m.enclosingPackageClass).toList.foreach(packageScope unlink _)
+            }
+            updatePosFlags(m, tree.pos, moduleFlags)
+            setPrivateWithin(tree, m)
+            m.moduleClass andAlso (setPrivateWithin(tree, _))
+            context.unit.synthetics -= m
+            tree.symbol = m
+          }
+          else {
+            m = coreCreateAssignAndEnterSymbol
+            m.moduleClass setFlag moduleClassFlags(moduleFlags)
+            setPrivateWithin(tree, m.moduleClass)
+          }
+          m.moduleClass setInfo namerOf(m).moduleClassTypeCompleter(tree)
+          if (m.isTopLevel && !m.hasPackageFlag) {
+            m.moduleClass.associatedFile = contextFile
+            currentRun.symSource(m) = m.moduleClass.sourceFile
+            registerTopLevelSym(m)
+          }
+          m
+        case _ =>
+          coreCreateAssignAndEnterSymbol
+      }
+    }
+
+    // reimplemented to integrate with weakEnsureCompanionObject
+    override def standardEnsureCompanionObject(cdef: ClassDef, creator: ClassDef => Tree = companionModuleDef(_)): Symbol = {
+      val m = patchedCompanionSymbolOf(cdef.symbol, context)
+
+      if (m != NoSymbol && currentRun.compiles(m) && !isWeak(m)) m
+      else unmarkWeak(enterSyntheticSym(atPos(cdef.pos.focus)(creator(cdef))))
+    }
+
+    /** Does the same as `ensureCompanionObject`, but also makes sure that the returned symbol destroys itself
+      *  if noone ends up using it (either by calling `ensureCompanionObject` or by `finishSymbol`).
+      */
+    // TODO: deduplicate
+    protected def weakEnsureCompanionObject(cdef: ClassDef, creator: ClassDef => Tree = companionModuleDef(_)): Symbol = {
+      val m = patchedCompanionSymbolOf(cdef.symbol, context)
+      if (m != NoSymbol && currentRun.compiles(m)) m
+      else { val mdef = atPos(cdef.pos.focus)(creator(cdef)); enterSym(mdef); markWeak(mdef.symbol) }
+    }
+
+    protected def finishSymbol(tree: Tree): Unit = {
+      // annotations on parameters expand together with their owners
+      // therefore when we actually get to enter the parameters, we shouldn't even bother checking
+      // TODO: we don't handle primary ctors that might get spuriously marked as maybe expandees because of primary paramss
+      val aprioriNotExpandable = (context.tree, tree) match {
+        case (ClassDef(_, _, _, _), TypeDef(_, _, _, _)) => true
+        case (Template(_, _, _), ValDef(mods, _, _, _)) if mods.isParamAccessor => true
+        // vparamss of primary ctors are entered in `enterValueParams`, which doesn't call us
+        case (DefDef(_, _, _, _, _, _), TypeDef(_, _, _, _)) => true
+        // vparamss of normal methods are also entered in `enterValueParams`, which doesn't call us
+        case (TypeDef(_, _, _, _), TypeDef(_, _, _, _)) => true
+        case _ => false
+      }
+
+      if (aprioriNotExpandable) finishSymbolNotExpandee(tree)
+      else {
+        treeInfo.getAnnotationZippers(tree) match {
+          case Nil => finishSymbolNotExpandee(tree)
+          case zippers => finishSymbolMaybeExpandee(tree, zippers)
+        }
+
+        // this will only show companions defined above ourselves
+        // so when finishing `class C` in `{ class C; object C }`
+        // we won't see `object C` in `companion` - we will see NoSymbol
+        // that's the limitation of how namer works, but nevertheless it's not a problem for us
+        // because if finishing `class C` doesn't set up the things, finishing `object C` will
+        val sym = tree.symbol
+        val companion = patchedCompanionSymbolOf(sym, context)
+
+        tree match {
+          // TODO: should we also support annotations on modules expanding companion classes?
+          case tree @ ClassDef(_, _, _, _) if isMaybeExpandee(sym) =>
+            val wasExpanded = isExpanded(companion)
+            val m = weakEnsureCompanionObject(tree)
+            finishSymbolMaybeExpandeeCompanion(attachedSource(m), m, sym)
+            if (wasExpanded) markExpanded(m) // why is this necessary? see files/run/macro-annotation-recursive-class
+          // TODO: in general, this first call to FSMEC usually only brings grief
+          // can we get rid of it completely without having to sweep its results under the carpet?
+          case tree @ ModuleDef(_, _, _) if isMaybeExpandee(companion) =>
+            finishSymbolMaybeExpandeeCompanion(tree, sym, companion)
+          case _ =>
+        }
+      }
+    }
+
+    protected def finishSymbolNotExpandee(tree: Tree): Unit = {
+      val sym = tree.symbol
+      def savingLock[T](op: => T): T = {
+        val wasLocked = sym.hasFlag(LOCKED)
+        val result = op
+        if (wasLocked) sym.setFlag(LOCKED)
+        result
+      }
+
+      savingLock {
+        tree match {
+          case tree @ PackageDef(_, _) =>
+            newNamer(context.make(tree, sym.moduleClass, sym.info.decls)) enterSyms tree.stats
+          case tree @ ClassDef(mods, name, tparams, impl) =>
+            val primaryConstructorArity = treeInfo.firstConstructorArgs(impl.body).size
+            // not entering
+            tree.symbol setInfo completerOf(tree)
+
+            if (mods.isCase) {
+              val m = ensureCompanionObject(tree, caseModuleDef)
+              m.moduleClass.updateAttachment(new ClassForCaseCompanionAttachment(tree))
+            }
+            val hasDefault = impl.body exists treeInfo.isConstructorWithDefault
+            if (hasDefault) {
+              val m = ensureCompanionObject(tree)
+              m.updateAttachment(new ConstructorDefaultsAttachment(tree, null))
+            }
+            val owner = tree.symbol.owner
+            if (settings.warnPackageObjectClasses && owner.isPackageObjectClass && !mods.isImplicit) {
+              reporter.warning(tree.pos,
+                               "it is not recommended to define classes/objects inside of package objects.\n" +
+                               "If possible, define " + tree.symbol + " in " + owner.skipPackageObject + " instead."
+                              )
+            }
+            // Suggested location only.
+            if (mods.isImplicit) {
+                if (primaryConstructorArity == 1) {
+                  log("enter implicit wrapper "+tree+", owner = "+owner)
+                  enterImplicitWrapper(tree)
+                }
+                else reporter.error(tree.pos, "implicit classes must accept exactly one primary constructor parameter")
+            }
+            validateCompanionDefs(tree)
+          case tree @ ModuleDef(_, _, _) =>
+            unmarkWeak(sym)
+            sym setInfo completerOf(tree)
+            validateCompanionDefs(tree)
+          case tree @ ValDef(_, _, _, _) =>
+            val isScala = !context.unit.isJava
+            if (isScala) {
+              if (nme.isSetterName(tree.name)) ValOrVarWithSetterSuffixError(tree)
+              if (tree.mods.isPrivateLocal && tree.mods.isCaseAccessor) PrivateThisCaseClassParameterError(tree)
+            }
+            if (isScala && deriveAccessors(tree)) {
+              // when refactoring enterSym, I needed to decouple symbol creation and various syntheses
+              // so that annotation expansion mechanism could be installed in-between of those
+              // it went well except for one thing - ValDef symbol creation is very closely tied to syntheses
+              // because depending on whether the ValDef is a val, var or a lazy val, different symbols need to be generated
+              // since I didn't have much time (and, back then, much understanding), I just decided to create dummies
+              // that live only to stand in as potential annottees and get destroyed if any sort of synthesis is necessary
+              // TODO: this is obviously ugly and needs to be fixed
+              context.scope.unlink(tree.symbol)
+              tree.symbol setInfo NoType
+              enterGetterSetter(tree)
+            } else {
+              tree.symbol setInfo completerOf(tree)
+            }
+            if (isEnumConstant(tree))
+              tree.symbol setInfo ConstantType(Constant(tree.symbol))
+          case tree @ DefDef(_, nme.CONSTRUCTOR, _, _, _, _) =>
+            sym setInfo completerOf(tree)
+          case tree @ DefDef(mods, name, tparams, _, _, _) =>
+            val completer =
+              if (sym hasFlag SYNTHETIC) {
+                if (name == nme.copy) copyMethodCompleter(tree)
+                else if (sym hasFlag CASE) applyUnapplyMethodCompleter(tree, context)
+                else completerOf(tree)
+              } else completerOf(tree)
+            sym setInfo completer
+          case tree @ TypeDef(_, _, _, _) =>
+            sym setInfo completerOf(tree)
+          case tree @ Import(_, _) =>
+            namerOf(tree.symbol) importTypeCompleter tree
+        }
+      }
+    }
+
+    // we have several occasions when so called "maybe expandees" need special care
+    // ("maybe expandees" = annotated members, which might or might not be annotated with a macro expansion)
+    // 1) (when called by Symbol.info) trigger the MaybeExpandeeCompleter and then immediately recur into a fresh completer
+    //    if we don't recur, we're doomed to fail, because there are only so many retries that Symbol.info can tolerate
+    //    and this retry threshold is already fine-tuned to the current chain of completers, which makes MaybeExpandeeCompleter one too many
+    // 2) (when called by expandMacroAnnotations from templateSig or typedBlock) in this situation noone needs us to fully complete
+    //    the underlying symbol. just making sure that we don't have any annotations to expand is the least and the most we should do.
+    //    if we're overeager like in mode #1, we might easily induce cyclic reference errors (like in tests/run/macro-annotations-packageobject)
+    // 3) (when called by Symbol.typeParams) this one is different from Symbol.info, because it calls load, not complete
+    //    from what I understand, this separation exists because it takes much less effort to figure out tparams rather than the full signature
+    //    for example, vanilla completers assigned in namer are created with typeParams already known
+    //    you can see for yourself in the distinction between monoTypeCompleter and PolyTypeCompleter
+    //    therefore, just as with Symbol.info we need to trigger the MaybeExpandeeCompleter
+    //    and then not forget to recur into the fresh completer's load, again because of the retry limit baked into Symbol.typeParams
+    // 4) TODO: (when called by Symbol.unsafeTypeParams) figure out what's the deal with them
+    //    existence of this method profoundly scares me, even though I never had a problem with it
+    abstract class MaybeExpandeeCompleter(val tree: Tree) extends LockingTypeCompleter with FlagAssigningCompleter {
+      def destroy(syms: Symbol*) = {
+        for (sym <- syms) {
+          context.unit.synthetics -= sym
+          context.scope.unlink(sym)
+          sym setInfo NoType
+          sym.moduleClass setInfo NoType
+          sym.removeAttachment[SymbolCompleterAttachment]
+        }
+      }
+
+      def complete(sym: Symbol, onlyExpansions: Boolean) = {
+        lockedCount += 1
+        try completeImpl(sym, onlyExpansions)
+        finally lockedCount -= 1
+      }
+
+      override def completeImpl(sym: Symbol): Unit = {
+        completeImpl(sym, onlyExpansions = false)
+      }
+
+      def completeImpl(sym: Symbol, onlyExpansions: Boolean): Unit = {
+        val thisCompleter = sym.rawInfo
+        maybeExpand()
+        assert(sym.rawInfo != thisCompleter, s"${sym.accurateKindString} ${sym.rawname}#${sym.id} with $kind")
+        if (onlyExpansions) sym.rawInfo.completeOnlyExpansions(sym)
+        else sym.rawInfo.complete(sym)
+      }
+
+      override def load(sym: Symbol): Unit = {
+        this.completeOnlyExpansions(sym)
+        sym.rawInfo.load(sym)
+      }
+
+      def maybeExpand(): Unit // TODO: should I also pass `sym` here?
+    }
+
+    abstract class MaybeExpandeeCompanionCompleter(tree: Tree) extends MaybeExpandeeCompleter(tree)
+
+    private implicit class RichType(tpe: Type) {
+      def completeOnlyExpansions(sym: Symbol) = tpe match {
+        case mec: MacroAnnotationNamer#MaybeExpandeeCompleter => mec.complete(sym, onlyExpansions = true)
+        case c                                                => ()
+      }
+    }
+
+    protected def finishSymbolMaybeExpandee(tree: Tree, annZippers: List[treeInfo.AnnotationZipper]) {
+      val sym = tree.symbol
+      unmarkWeak(sym)
+      markMaybeExpandee(sym)
+      sym.setInfo(new MaybeExpandeeCompleter(tree) {
+        override def kind = s"maybeExpandeeCompleter for ${sym.accurateKindString} ${sym.rawname}#${sym.id}"
+        override def maybeExpand(): Unit = {
+          val companion = if (tree.isInstanceOf[ClassDef]) patchedCompanionSymbolOf(sym, context) else NoSymbol
+
+          def maybeExpand(annotation: Tree, annottee: Tree, maybeExpandee: Tree): Option[List[Tree]] =
+            if (context.macrosEnabled) { // TODO: when is this bit flipped -- can we pull this check out farther?
+              val treeInfo.Applied(Select(New(tpt), nme.CONSTRUCTOR), _, _) = annotation
+              val mann = probeMacroAnnotation(context, tpt)
+              if (mann.isClass && mann.hasFlag(MACRO)) {
+                assert(!currentRun.compiles(mann), mann)
+                val annm = prepareAnnotationMacro(annotation, mann, sym, annottee, maybeExpandee)
+                expandAnnotationMacro(tree, annm)
+                // if we encounter an error, we just return None, so that other macro annotations can proceed
+                // this is unlike macroExpand1 when any error in an expandee blocks expansions
+                // there it's necessary in order not to exacerbate typer errors
+                // but when manning we aren't in typer, so we don't have to do as macroExpand1 does
+                // and also there's a good reason not to ban other macro annotations
+                // if we do ban them, we might get spurious compilation errors from non-existent members that could've been generated
+              } else None
+            } else None
+
+          annZippers.iterator.flatMap(annz => maybeExpand(annz.annotation, annz.annottee, annz.owner)).nextOption match {
+            case Some(expanded) =>
+              // TODO: The workaround employed in https://github.com/scalamacros/paradise/issues/19
+              // no longer works because of the REPL refactoring in 2.13.0-M2.
+              // See https://github.com/scalamacros/paradise/issues/102 for discussion.
+              //tellReplAboutExpansion(sym, companion, expanded)
+
+              markExpanded(sym)
+              markExpanded(companion)
+              // expansion brings new trees, probably wildly different from current ones. what do we do?
+              // the most robust thing would be to destroy ourselves (us and our companion), but we can't do that at top level
+              // therefore at top level we don't destroy, but rather rely on enterSyms to redefine ourselves
+              // however when nested we go all out
+              // TODO: unlinking distorts the order of symbols in scope
+              // note however that trees (calculated by expandMacroAnnotations) will be generated in correct order
+              if (!sym.isTopLevel) destroy(sym, companion)
+              enterSyms(expanded) // TODO: we can't reliably expand into imports, because they won't be accounted by definitions below us
+            case None =>
+              markNotExpandable(sym)
+              finishSymbolNotExpandee(tree)
+          }
+
+          // take care of the companion if it's no longer needed
+          // we can't do this in companion's completer, because that one isn't guaranteed to ever be called
+          val expandedWithoutCompanion = isExpanded(sym) && attachedExpansion(companion).map(_.isEmpty).getOrElse(false)
+          val companionHasReemerged = expandedWithoutCompanion && sym.isTopLevel && !isWeak(companion)
+          val notExpandableWeakCompanion = isNotExpandable(sym) && isWeak(companion)
+          if ((expandedWithoutCompanion && !companionHasReemerged) || notExpandableWeakCompanion) destroy(companion)
+        }
+      })
+    }
+
+    // how do we make sure that this completer falls back to the vanilla completer if the companion ends up not expanding?
+    // well, if a module symbol has a maybeExpandee companion then the last two calls to its setInfo will be one of:
+    //   * non-FSMEC completer for the module and then FSMEC => fallback should call native completer
+    //   * FSMEC from enterSyntheticSym for a phantom module and then FSMEC again => fallback should do nothing
+    // now it's easy to see that both are correctly handled here
+    protected def finishSymbolMaybeExpandeeCompanion(tree: Tree, m: Symbol, c: Symbol) {
+      val worthBackingUp = !m.rawInfo.isInstanceOf[MacroAnnotationNamer#MaybeExpandeeCompanionCompleter]
+      if (worthBackingUp) backupCompleter(m)
+      markMaybeExpandee(m)
+      m.setInfo(new MaybeExpandeeCompanionCompleter(tree) {
+        override def kind = s"maybeExpandeeCompanionCompleter for ${m.rawname}#${m.id}"
+        override def maybeExpand(): Unit = {
+          c.rawInfo.completeOnlyExpansions(c)
+          // this is a very tricky part of annotation expansion
+          // because now, after deferring to our companion's judgement for a while, we have to ourselves figure out:
+          //   1) whether we should start completing on our own
+          //   2) if we should do it on our own, then how exactly
+          // 1 is easy. If our companion's expansion has destroyed us (or hasn't materialized us if we were weak)
+          // then we no longer care and we silently go into oblivion. Otherwise, we should take care of ourselves.
+          // 2 is hard, because we have two distinct situations to handle:
+          //   2a) isExpanded(c) is true, which means that our companion has just expanded
+          //   2b) isNotExpandable(c) is true, which means that our companion has just been deemed unexpandable
+          // 2a is simple, because it means that we don't have to do anything, as we've either got destroyed
+          // or we've got entered in `enterSyms(expanded)` that follows expansions.
+          // 2b is tricky, because it means that we need to fall back to the most recent non-FSMEC completer.
+          // The hardest part here is that we can't just get to the completer that was preceding `this` as m.rawInfo
+          // (otherwise we run into issue #9, for more details see history of this change). Instead we need to track m's type history.
+          val destroyedDuringExpansion = m.rawInfo == NoType
+          val failedToMaterializeDuringExpansion = isWeak(m)
+          val aliveAndKicking = !destroyedDuringExpansion && !failedToMaterializeDuringExpansion
+          if (aliveAndKicking && isNotExpandable(c)) {
+            if (worthBackingUp) restoreCompleter(m)
+            val maybeExpandee = m.rawInfo.isInstanceOf[MacroAnnotationNamer#MaybeExpandeeCompleter]
+            if (maybeExpandee) markMaybeExpandee(m) else markNotExpandable(m)
+          }
+        }
+      })
+    }
+
+    // mostly copy/pasted and adapted from typedIdent
+    // adaptations = ignore error reporting + ignore java + don't force symbols being compiled
+    // the last requirement leads to us being imprecise in some situation wrt normal name resolution
+    // but that's okay, since it's the only way for manns to remain modular and not to cripple normal annotations
+    protected def probeMacroAnnotation(context: Context, tpt: Tree): Symbol = {
+      // SAFE HELPERS (can't cause unnecessary completions)
+      def reallyExists(sym: Symbol) = { if (newTyper(context).isStale(sym)) sym.setInfo(NoType); exists(sym) }
+      def qualifies(sym: Symbol): Boolean = sym.hasRawInfo && reallyExists(sym)
+
+      // UNSAFE HELPERS (need to guard against unnecessary completions)
+      def canDefineMann(sym: Symbol): Boolean = !currentRun.compiles(sym)
+      def exists(sym: Symbol) = if (canDefineMann(sym)) sym.exists else false
+      def importedSymbol(imp: ImportInfo, name: Name): Symbol = { // TODO: be more precise in reproducing importSig and importedSymbol
+      val impContext = context.enclosingContextChain.find(_.tree.symbol == imp.tree.symbol).get
+        val sym = imp.tree.cached("importQualProbe", probeMacroAnnotation(impContext.outer, imp.tree.expr))
+        val pre = if (reallyExists(sym) && isAccessible(impContext, sym)) sym.tpe else NoType
+        var result: Symbol = NoSymbol
+        var renamed = false
+        var selectors = imp.tree.selectors
+        def current = selectors.head
+        while (selectors != Nil && result == NoSymbol) {
+          if (current.rename == name.toTermName)
+            result = nonLocalMember(pre, if (name.isTypeName) current.name.toTypeName else current.name)
+          else if (selectors.head.name == name.toTermName)
+                 renamed = true
+          else if (selectors.head.name == nme.WILDCARD && !renamed)
+                 result = nonLocalMember(pre, name)
+          if (result == NoSymbol)
+            selectors = selectors.tail
+        }
+        if (settings.warnUnusedImport && selectors.nonEmpty && result != NoSymbol && imp.pos != NoPosition) {
+          val m_recordUsage = imp.getClass.getDeclaredMethods().find(_.getName == "recordUsage").get
+          m_recordUsage.setAccessible(true)
+          m_recordUsage.invoke(imp, current, result)
+        }
+        if (definitions isImportable result) result
+        else NoSymbol
+      }
+      // def isAccessible(cx: Context, sym: Symbol) = if (canDefineMann(cx.owner)) cx.isAccessible(sym, cx.prefix, superAccess = false) else false
+      def isAccessible(cx: Context, sym: Symbol) = true // TODO: sorry, it's 2am, and I can't figure this out
+      def member(tpe: Type, name: Name) = if (canDefineMann(tpe.typeSymbol)) tpe.member(name) else NoSymbol
+      def nonLocalMember(tpe: Type, name: Name) = if (canDefineMann(tpe.typeSymbol)) tpe.nonLocalMember(name) else NoSymbol
+
+      if (tpt.hasSymbolField && tpt.symbol != NoSymbol) tpt.symbol
+      else tpt match {
+        case Ident(name) =>
+
+          // STEP 1: RESOLVE THE NAME IN SCOPE
+          var defSym: Symbol = NoSymbol
+          var defEntry: ScopeEntry = null
+          var cx = context
+          while (defSym == NoSymbol && cx != NoContext && (cx.scope ne null)) {
+            defEntry = cx.scope.lookupEntry(name)
+            if ((defEntry ne null) && qualifies(defEntry.sym)) defSym = defEntry.sym
+            else {
+              cx = cx.enclClass
+              val foundSym = member(cx.prefix, name) filter qualifies
+              defSym = foundSym filter (isAccessible(cx, _))
+              if (defSym == NoSymbol) cx = cx.outer
+            }
+          }
+          if (defSym == NoSymbol && settings.exposeEmptyPackage) {
+            defSym = rootMirror.EmptyPackageClass.info member name
+          }
+
+          // STEP 2: RESOLVE THE NAME IN IMPORTS
+          val symDepth = if (defEntry eq null) cx.depth
+                         else cx.depth - ({
+                                            if (cx.scope ne null) cx.scope.nestingLevel
+                                            else 0 // TODO: fix this in toolboxes, not hack around here
+                                          } - defEntry.owner.nestingLevel)
+          var impSym: Symbol = NoSymbol
+          var imports = context.imports
+          while (!reallyExists(impSym) && !imports.isEmpty && imports.head.depth > symDepth) {
+            impSym = importedSymbol(imports.head, name)
+            if (!exists(impSym)) imports = imports.tail
+          }
+
+          // FIXME: repl hack. somehow imports that come from repl are doubled
+          // e.g. after `import $line7.$read.$iw.$iw.foo` you'll have another identical `import $line7.$read.$iw.$iw.foo`
+          // this is a crude workaround for the issue
+          imports match {
+            case fst :: snd :: _ if exists(impSym) && fst == snd => imports = imports.tail
+            case _ => // do nothing
+          }
+
+          // STEP 3: TRY TO RESOLVE AMBIGUITIES
+          if (exists(defSym) && exists(impSym)) {
+            if (defSym.isDefinedInPackage &&
+                (!currentRun.compiles(defSym) ||
+                 context.unit.exists && defSym.sourceFile != context.unit.source.file))
+              defSym = NoSymbol
+            else if (impSym.isError || impSym.name == nme.CONSTRUCTOR)
+                   impSym = NoSymbol
+          }
+          if (!exists(defSym) && exists(impSym)) {
+            var impSym1: Symbol = NoSymbol
+            var imports1 = imports.tail
+            while (!imports1.isEmpty &&
+                   (!imports.head.isExplicitImport(name) ||
+                    imports1.head.depth == imports.head.depth)) {
+              impSym1 = importedSymbol(imports1.head, name)
+              if (reallyExists(impSym1)) {
+                if (imports1.head.isExplicitImport(name)) {
+                  if (imports.head.isExplicitImport(name) ||
+                      imports1.head.depth != imports.head.depth) return NoSymbol // was possibly fixable ambiguous import
+                  impSym = impSym1
+                  imports = imports1
+                } else if (!imports.head.isExplicitImport(name) &&
+                           imports1.head.depth == imports.head.depth) return NoSymbol // was possibly fixable ambiguous import
+              }
+              imports1 = imports1.tail
+            }
+          }
+
+          // STEP 4: DEAL WITH WHAT WE HAVE
+          if (exists(defSym) && !exists(impSym)) defSym
+          else if (exists(defSym) && exists(impSym)) NoSymbol // was ambiguous import
+          else if (!exists(defSym) && exists(impSym)) impSym
+          else {
+            val lastTry = rootMirror.missingHook(rootMirror.RootClass, name)
+            if (lastTry != NoSymbol && isAccessible(context, lastTry)) lastTry
+            else NoSymbol
+          }
+        case Select(qualtree, name) => // TODO: be more precise wrt typedSelect
+          val qual = probeMacroAnnotation(context, qualtree)
+          val sym = if (canDefineMann(qual)) member(qual.tpe, name) else NoSymbol
+          if (reallyExists(sym) && isAccessible(context, sym)) sym else NoSymbol
+        case AppliedTypeTree(tpt, _) => // https://github.com/scalamacros/paradise/issues/2: expand manns with type parameters
+          probeMacroAnnotation(context, tpt)
+        case _ =>
+          NoSymbol
+      }
+    }
+
+    // see https://github.com/scalamacros/paradise/issues/7
+    // also see https://github.com/scalamacros/paradise/issues/64
+    protected def patchedCompanionSymbolOf(original: Symbol, ctx: Context): Symbol = if (original == NoSymbol) NoSymbol else {
+      val owner = original.owner
+      // SI-7264 Force the info of owners from previous compilation runs.
+      //         Doing this generally would trigger cycles; that's what we also
+      //         use the lower-level scan through the current Context as a fall back.
+      if (!currentRun.compiles(owner) &&
+          // NOTE: the following three lines of code are added to work around #7
+          !owner.enclosingTopLevelClass.isRefinementClass &&
+          !owner.ownerChain.exists(_.isLocalDummy) &&
+          owner.ownerChain.forall(!currentRun.compiles(_))) {
+        owner.initialize
+      }
+      original.companionSymbol orElse {
+        implicit class PatchedContext(ctx: Context) {
+          trait PatchedLookupResult { def suchThat(criterion: Symbol => Boolean): Symbol }
+          def patchedLookup(name: Name, expectedOwner: Symbol) = new PatchedLookupResult {
+            override def suchThat(criterion: Symbol => Boolean): Symbol = {
+              var res: Symbol = NoSymbol
+              var ctx = PatchedContext.this.ctx
+              while (res == NoSymbol && ctx.outer != ctx) {
+                // NOTE: original implementation says `val s = ctx.scope lookup name`
+                // but we can't use it, because Scope.lookup returns wrong results when the lookup is ambiguous
+                // and that triggers https://github.com/scalamacros/paradise/issues/64
+                val s = {
+                  val lookupResult = ctx.scope.lookupAll(name).filter(criterion).toList
+                  lookupResult match {
+                    case Nil => NoSymbol
+                    case List(unique) => unique
+                    case _ => abort(s"unexpected multiple results for a companion symbol lookup for $original#{$original.id}")
+                  }
+                }
+                if (s != NoSymbol && s.owner == expectedOwner)
+                  res = s
+                else
+                  ctx = ctx.outer
+              }
+              res
+            }
+          }
+        }
+        ctx.patchedLookup(original.name.companionName, owner).suchThat(sym =>
+                                                                         (original.isTerm || sym.hasModuleFlag) &&
+                                                                         (sym isCoDefinedWith original)
+                                                                      )
+      }
+    }
+
+    protected def prepareAnnotationMacro(ann: Tree, mann: Symbol, sym: Symbol, annottee: Tree, expandee: Tree): Tree = {
+      val companion = if (expandee.isInstanceOf[ClassDef]) patchedCompanionSymbolOf(sym, context) else NoSymbol
+      val companionSource = if (!isWeak(companion)) attachedSource(companion) else EmptyTree
+      val expandees = List(annottee, expandee, companionSource).distinct.filterNot(_.isEmpty)
+      val safeExpandees = expandees.map(expandee => duplicateAndKeepPositions(expandee)).map(_.setSymbol(NoSymbol))
+      val prefix = Select(ann, nme.macroTransform) setSymbol mann.info.member(nme.macroTransform) setPos ann.pos
+      Apply(prefix, safeExpandees) setPos ann.pos
+    }
+
+    protected def expandAnnotationMacro(original: Tree, expandee: Tree): Option[List[Tree]] = {
+      val sym = original.symbol
+      val companion = if (original.isInstanceOf[ClassDef]) patchedCompanionSymbolOf(sym, context) else NoSymbol
+      val wasWeak = isWeak(companion)
+      val wasTransient = companion == NoSymbol || companion.isSynthetic
+      def rollThroughImports(context: Context): Context = {
+        if (context.isInstanceOf[ImportContext]) rollThroughImports(context.outer)
+        else context
+      }
+      val typer = {
+        // expanding at top level => allow the macro to see everything
+        if (sym.isTopLevel) newTyper(context)
+        // expanding at template level => only allow to see outside of the enclosing class
+        // we have to skip two contexts:
+        //  1) the Template context that hosts members
+        //  2) the ImplDef context that hosts type params (and just them?)
+        // upd. actually, i don't think we should skip the second context
+        // that doesn't buy us absolutely anything wrt robustness
+        else if (sym.owner.isClass) newTyper(rollThroughImports(context).outer)
+             // expanding at block level => only allow to see outside of the block
+        else newTyper(rollThroughImports(context).outer)
+      }
+      def onlyIfExpansionAllowed[T](expand: => Option[T]): Option[T] = {
+        if (settings.Ymacroexpand.value == settings.MacroExpand.None) None
+        else {
+          val oldYmacroexpand = settings.Ymacroexpand.value
+          try { settings.Ymacroexpand.value = settings.MacroExpand.Normal; expand }
+          catch { case ex: Exception => settings.Ymacroexpand.value = oldYmacroexpand; throw ex }
+        }
+      }
+      def expand(): Option[Tree] = (new DefMacroExpander(typer, expandee, NOmode, WildcardType) {
+        override def onSuccess(expanded: Tree) = expanded
+      })(expandee) match {
+        case tree if tree.isErroneous => None
+        case tree => Some(tree)
+      }
+      def extract(expanded: Tree): List[Tree] = expanded match {
+        case Block(stats, Literal(Constant(()))) => stats // ugh
+        case tree => List(tree)
+      }
+      def validate(expanded: List[Tree]): Option[List[Tree]] = {
+        if (sym.owner.isPackageClass) {
+          original match {
+            case ClassDef(_, originalName, _, _) =>
+              expanded match {
+                case (expandedClass @ ClassDef(_, className, _, _)) :: Nil
+                  if className == originalName && wasWeak =>
+                  attachExpansion(sym, List(expandedClass))
+                  attachExpansion(companion, Nil)
+                  Some(expanded)
+                case (expandedCompanion @ ModuleDef(_, moduleName, _)) :: (expandedClass @ ClassDef(_, className, _, _)) :: Nil
+                  if className == originalName && moduleName == originalName.toTermName =>
+                  attachExpansion(sym, if (wasWeak) List(expandedClass, expandedCompanion) else List(expandedClass))
+                  attachExpansion(companion, List(expandedCompanion))
+                  Some(expanded)
+                case (expandedClass @ ClassDef(_, className, _, _)) :: (expandedCompanion @ ModuleDef(_, moduleName, _)) :: Nil
+                  if className == originalName && moduleName == originalName.toTermName =>
+                  attachExpansion(sym, if (wasWeak) List(expandedClass, expandedCompanion) else List(expandedClass))
+                  attachExpansion(companion, List(expandedCompanion))
+                  Some(expanded)
+                case _ =>
+                  if (wasWeak) MacroAnnotationTopLevelClassWithoutCompanionBadExpansion(expandee)
+                  else MacroAnnotationTopLevelClassWithCompanionBadExpansion(expandee)
+                  None
+              }
+            case ModuleDef(_, originalName, _) =>
+              expanded match {
+                case (expandedModule @ ModuleDef(_, expandedName, _)) :: Nil if expandedName == originalName =>
+                  attachExpansion(sym, List(expandedModule))
+                  Some(expanded)
+                case _ =>
+                  MacroAnnotationTopLevelModuleBadExpansion(expandee)
+                  None
+              }
+          }
+        } else {
+          if (wasTransient) {
+            attachExpansion(sym, expanded)
+            attachExpansion(companion, Nil)
+          } else {
+            def companionRelated(tree: Tree) = tree.isInstanceOf[ModuleDef] && tree.asInstanceOf[ModuleDef].name == companion.name
+            val (forCompanion, forSym) = expanded.partition(companionRelated)
+            attachExpansion(sym, forSym)
+            attachExpansion(companion, forCompanion)
+          }
+          Some(expanded)
+        }
+      }
+      for {
+        lowlevelExpansion <- onlyIfExpansionAllowed(expand())
+        expansion <- Some(extract(lowlevelExpansion))
+        duplicated = expansion.map(duplicateAndKeepPositions)
+        validatedExpansion <- validate(duplicated)
+      } yield validatedExpansion
+    }
+
+    override def expandMacroAnnotations(stats: List[Tree]): List[Tree] = {
+      def mightNeedTransform(stat: Tree): Boolean = stat match {
+        case stat: DocDef => mightNeedTransform(stat.definition)
+        case stat: MemberDef => isMaybeExpandee(stat.symbol) || hasAttachedExpansion(stat.symbol)
+        case _ => false
+      }
+      def rewrapAfterTransform(stat: Tree, transformed: List[Tree]): List[Tree] = (stat, transformed) match {
+        case (stat @ DocDef(comment, _), List(transformed: MemberDef)) => List(treeCopy.DocDef(stat, comment, transformed))
+        case (stat @ DocDef(comment, _), List(transformed: DocDef)) => List(transformed)
+        case (_, Nil | List(_: MemberDef)) => transformed
+        case (_, unexpected) => unexpected // NOTE: who knows how people are already using macro annotations, so it's scary to fail here
+      }
+      if (phase.id > currentRun.typerPhase.id || !stats.exists(mightNeedTransform)) stats
+      else stats.flatMap(stat => {
+        if (mightNeedTransform(stat)) {
+          val sym = stat.symbol
+          assert(sym != NoSymbol, (sym, stat))
+          if (isMaybeExpandee(sym)) {
+            def assert(what: Boolean) = Predef.assert(what, s"${sym.accurateKindString} ${sym.rawname}#${sym.id} with ${sym.rawInfo.kind}")
+            assert(sym.rawInfo.isInstanceOf[MacroAnnotationNamer#MaybeExpandeeCompleter])
+            sym.rawInfo.completeOnlyExpansions(sym)
+            assert(!sym.rawInfo.isInstanceOf[MacroAnnotationNamer#MaybeExpandeeCompleter])
+          }
+          val derivedTrees = attachedExpansion(sym).getOrElse(List(stat))
+          val (me, others) = derivedTrees.partition(_.symbol == sym)
+          rewrapAfterTransform(stat, me) ++ expandMacroAnnotations(others)
+        } else {
+          List(stat)
+        }
+      })
+    }
+  }
+}

--- a/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
@@ -209,3 +209,79 @@ trait StdAttachments {
   /** Added to trees that appear in a method value, e.g., to `f(x)` in `f(x) _` */
   case object MethodValueAttachment
 }
+
+
+// imported from scalamacros/paradise
+trait MacroAnnotationAttachments {
+  self: Analyzer =>
+
+  import global._
+  import scala.collection.{immutable, mutable}
+
+  case object WeakSymbolAttachment
+  def markWeak(sym: Symbol) = if (sym != null && sym != NoSymbol) sym.updateAttachment(WeakSymbolAttachment) else sym
+  def unmarkWeak(sym: Symbol) = if (sym != null && sym != NoSymbol) sym.removeAttachment[WeakSymbolAttachment.type] else sym
+  def isWeak(sym: Symbol) = sym == null || sym == NoSymbol || sym.attachments.get[WeakSymbolAttachment.type].isDefined
+
+  case class SymbolCompleterAttachment(info: Type)
+  def backupCompleter(sym: Symbol): Symbol = {
+    if (sym != null && sym != NoSymbol) {
+      assert(sym.rawInfo.isInstanceOf[LazyType], s"${sym.accurateKindString} ${sym.rawname}#${sym.id} with ${sym.rawInfo.kind}")
+      sym.updateAttachment(SymbolCompleterAttachment(sym.rawInfo))
+    } else sym
+  }
+  def restoreCompleter(sym: Symbol): Unit = {
+    if (sym != null && sym != NoSymbol) {
+      val oldCompleter = sym.attachments.get[SymbolCompleterAttachment].get.info
+      sym setInfo oldCompleter
+      sym.attachments.remove[SymbolCompleterAttachment]
+    } else ()
+  }
+
+  // here we should really store and retrieve duplicates of trees in order to avoid leakage through tree attributes
+  case class SymbolSourceAttachment(source: Tree)
+  def attachSource(sym: Symbol, tree: Tree): Symbol = if (sym != null && sym != NoSymbol) sym.updateAttachment(SymbolSourceAttachment(duplicateAndKeepPositions(tree))) else sym
+  def attachedSource(sym: Symbol): Tree = if (sym != null && sym != NoSymbol) sym.attachments.get[SymbolSourceAttachment].map(att => duplicateAndKeepPositions(att.source)).getOrElse(EmptyTree) else EmptyTree
+
+  // unfortunately we cannot duplicate here, because that would dissociate the symbol from its derived symbols
+  // that's because attachExpansion(tree) happens prior to enterSym(tree), so if we duplicate the assigned symbol never makes it into the att
+  // in its turn, that would mean that we won't be able to handle recursive expansions in typedTemplate
+  // because by the time typedTemplate gets activated, everything's already expanded by templateSig
+  // so we need to go from original trees/symbols to recursively expanded ones and that requires links to derived symbols
+  // TODO: should be a better solution
+  case class SymbolExpansionAttachment(expansion: List[Tree])
+  def hasAttachedExpansion(sym: Symbol) = sym.attachments.get[SymbolExpansionAttachment].isDefined
+  def attachExpansion(sym: Symbol, trees: List[Tree]): Symbol = if (sym != null && sym != NoSymbol) sym.updateAttachment(SymbolExpansionAttachment(trees/*.map(tree => duplicateAndKeepPositions(tree))*/)) else sym
+  def attachedExpansion(sym: Symbol): Option[List[Tree]] = if (sym != null && sym != NoSymbol) sym.attachments.get[SymbolExpansionAttachment].map(_.expansion/*.map(tree => duplicateAndKeepPositions(tree))*/) else None
+
+  import SymbolExpansionStatus._
+  private def checkExpansionStatus(sym: Symbol, p: SymbolExpansionStatus => Boolean) = sym.attachments.get[SymbolExpansionStatus].map(p).getOrElse(false)
+  def isMaybeExpandee(sym: Symbol): Boolean = checkExpansionStatus(sym, _.isUnknown)
+  def isExpanded(sym: Symbol): Boolean = checkExpansionStatus(sym, _.isExpanded)
+  def isNotExpandable(sym: Symbol): Boolean = checkExpansionStatus(sym, _.isNotExpandable)
+  def markMaybeExpandee(sym: Symbol): Symbol = if (sym != null && sym != NoSymbol) sym.updateAttachment(Unknown) else sym
+  def markExpanded(sym: Symbol): Symbol = if (sym != null && sym != NoSymbol) sym.updateAttachment(Expanded) else sym
+  def markNotExpandable(sym: Symbol): Symbol = if (sym != null && sym != NoSymbol) sym.updateAttachment(NotExpandable) else sym
+  def unmarkExpanded(sym: Symbol): Symbol = if (sym != null && sym != NoSymbol) sym.removeAttachment[SymbolExpansionStatus] else sym
+
+  case class CacheAttachment(cache: mutable.Map[String, Any])
+  implicit class RichTree(tree: Tree) {
+    def cached[T](key: String, op: => T): T = {
+      val cache = tree.attachments.get[CacheAttachment].map(_.cache).getOrElse(mutable.Map[String, Any]())
+      val result = cache.getOrElseUpdate(key, op).asInstanceOf[T]
+      tree.updateAttachment(CacheAttachment(cache))
+      result
+    }
+  }
+
+  private final class SymbolExpansionStatus private (val value: Int) { //extends AnyVal {
+    def isUnknown = this == SymbolExpansionStatus.Unknown
+    def isExpanded = this == SymbolExpansionStatus.Expanded
+    def isNotExpandable = this == SymbolExpansionStatus.NotExpandable
+  }
+  private object SymbolExpansionStatus {
+    val Unknown = new SymbolExpansionStatus(0)
+    val Expanded = new SymbolExpansionStatus(1)
+    val NotExpandable = new SymbolExpansionStatus(2)
+  }
+}

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1172,6 +1172,9 @@ trait Definitions extends api.StandardDefinitions {
     lazy val MethodTargetClass          = requiredClass[meta.companionMethod]    // TODO: module, moduleClass? package, packageObject?
     lazy val LanguageFeatureAnnot       = requiredClass[meta.languageFeature]
 
+    // Used by macro annotations
+    lazy val InheritedAttr = requiredClass[java.lang.annotation.Inherited]
+
     lazy val JUnitAnnotations = List("Test", "Ignore", "Before", "After", "BeforeClass", "AfterClass").map(n => getClassIfDefined("org.junit." + n))
 
     // Language features

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -379,6 +379,10 @@ trait StdNames {
     val STAR: NameType                     = "*"
     val THIS: NameType                     = "_$this"
 
+
+    val annottees: NameType               = "annottees"       // for macro annotations
+    val macroTransform: NameType          = "macroTransform"  // for macro annotations
+
     def isConstructorName(name: Name)       = name == CONSTRUCTOR || name == MIXIN_CONSTRUCTOR
     def isExceptionResultName(name: Name)   = name startsWith EXCEPTION_RESULT_PREFIX
     def isLocalDummyName(name: Name)        = name startsWith LOCALDUMMY_PREFIX

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2807,6 +2807,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def isValue     = !(isModule && hasFlag(PACKAGE | JAVA))
     override def isVariable  = isMutable && !isMethod
     override def isTermMacro = hasFlag(MACRO)
+    def isAnnotationMacro    = hasFlag(MACRO) && name == nme.macroTransform && owner.isClass && owner.hasFlag(MACRO)
 
     // interesting only for lambda lift. Captured variables are accessed from inner lambdas.
     override def isCapturedVariable = hasAllFlags(MUTABLE | CAPTURED) && !hasFlag(METHOD)

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -975,3 +975,129 @@ abstract class TreeInfo {
     case tree => isMacroApplication(tree)
   }
 }
+
+// imported from scalamacros/paradise
+trait MacroAnnotionTreeInfo { self: TreeInfo =>
+  import global._
+  import definitions._
+  import build.{SyntacticClassDef, SyntacticTraitDef}
+
+  def primaryConstructorArity(tree: ClassDef): Int = treeInfo.firstConstructor(tree.impl.body) match {
+    case DefDef(_, _, _, params :: _, _, _) => params.length
+  }
+
+  def anyConstructorHasDefault(tree: ClassDef): Boolean = tree.impl.body exists {
+    case DefDef(_, nme.CONSTRUCTOR, _, paramss, _, _) => mexists(paramss)(_.mods.hasDefault)
+    case _                                            => false
+  }
+
+  def isMacroAnnotation(tree: ClassDef): Boolean = {
+    val clazz = tree.symbol
+    def isAnnotation = clazz isNonBottomSubClass AnnotationClass
+    def hasMacroTransformMethod = clazz.info.member(nme.macroTransform) != NoSymbol
+    clazz != null && isAnnotation && hasMacroTransformMethod
+  }
+
+  case class AnnotationZipper(annotation: Tree, annottee: Tree, owner: Tree)
+
+  // TODO: no immediate idea how to write this in a sane way
+  def getAnnotationZippers(tree: Tree): List[AnnotationZipper] = {
+    def loop[T <: Tree](tree: T, deep: Boolean): List[AnnotationZipper] = tree match {
+      case SyntacticClassDef(mods, name, tparams, constrMods, vparamss, earlyDefs, parents, selfdef, body) =>
+        val cdef = tree.asInstanceOf[ClassDef]
+        val czippers = mods.annotations.map(ann => {
+          val mods1 = mods.mapAnnotations(_ diff List(ann))
+          val annottee = PatchedSyntacticClassDef(mods1, name, tparams, constrMods, vparamss, earlyDefs, parents, selfdef, body)
+          AnnotationZipper(ann, annottee, annottee)
+        })
+        if (!deep) czippers
+        else {
+          val tzippers = for {
+            tparam <- tparams
+            AnnotationZipper(ann, tparam1: TypeDef, _) <- loop(tparam, deep = false)
+            tparams1 = tparams.updated(tparams.indexOf(tparam), tparam1)
+          } yield AnnotationZipper(ann, tparam1, PatchedSyntacticClassDef(mods, name, tparams1, constrMods, vparamss, earlyDefs, parents, selfdef, body))
+          val vzippers = for {
+            vparams <- vparamss
+            vparam <- vparams
+            AnnotationZipper(ann, vparam1: ValDef, _) <- loop(vparam, deep = false)
+            vparams1 = vparams.updated(vparams.indexOf(vparam), vparam1)
+            vparamss1 = vparamss.updated(vparamss.indexOf(vparams), vparams1)
+          } yield AnnotationZipper(ann, vparam1, PatchedSyntacticClassDef(mods, name, tparams, constrMods, vparamss1, earlyDefs, parents, selfdef, body))
+          czippers ++ tzippers ++ vzippers
+        }
+      case SyntacticTraitDef(mods, name, tparams, earlyDefs, parents, selfdef, body) =>
+        val tdef = tree.asInstanceOf[ClassDef]
+        val czippers = mods.annotations.map(ann => {
+          val annottee = tdef.copy(mods = mods.mapAnnotations(_ diff List(ann)))
+          AnnotationZipper(ann, annottee, annottee)
+        })
+        if (!deep) czippers
+        else {
+          val tzippers = for {
+            tparam <- tparams
+            AnnotationZipper(ann, tparam1: TypeDef, _) <- loop(tparam, deep = false)
+            tparams1 = tparams.updated(tparams.indexOf(tparam), tparam1)
+          } yield AnnotationZipper(ann, tparam1, tdef.copy(tparams = tparams1))
+          czippers ++ tzippers
+        }
+      case mdef @ ModuleDef(mods, _, _) =>
+        mods.annotations.map(ann => {
+          val annottee = mdef.copy(mods = mods.mapAnnotations(_ diff List(ann)))
+          AnnotationZipper(ann, annottee, annottee)
+        })
+      case ddef @ DefDef(mods, _, tparams, vparamss, _, _) =>
+        val dzippers = mods.annotations.map(ann => {
+          val annottee = ddef.copy(mods = mods.mapAnnotations(_ diff List(ann)))
+          AnnotationZipper(ann, annottee, annottee)
+        })
+        if (!deep) dzippers
+        else {
+          val tzippers = for {
+            tparam <- tparams
+            AnnotationZipper(ann, tparam1: TypeDef, _) <- loop(tparam, deep = false)
+            tparams1 = tparams.updated(tparams.indexOf(tparam), tparam1)
+          } yield AnnotationZipper(ann, tparam1, ddef.copy(tparams = tparams1))
+          val vzippers = for {
+            vparams <- vparamss
+            vparam <- vparams
+            AnnotationZipper(ann, vparam1: ValDef, _) <- loop(vparam, deep = false)
+            vparams1 = vparams.updated(vparams.indexOf(vparam), vparam1)
+            vparamss1 = vparamss.updated(vparamss.indexOf(vparams), vparams1)
+          } yield AnnotationZipper(ann, vparam1, ddef.copy(vparamss = vparamss1))
+          dzippers ++ tzippers ++ vzippers
+        }
+      case vdef @ ValDef(mods, _, _, _) =>
+        mods.annotations.map(ann => {
+          val annottee = vdef.copy(mods = mods.mapAnnotations(_ diff List(ann)))
+          AnnotationZipper(ann, annottee, annottee)
+        })
+      case tdef @ TypeDef(mods, _, tparams, _) =>
+        val tzippers = mods.annotations.map(ann => {
+          val annottee = tdef.copy(mods = mods.mapAnnotations(_ diff List(ann)))
+          AnnotationZipper(ann, annottee, annottee)
+        })
+        if (!deep) tzippers
+        else {
+          val ttzippers = for {
+            tparam <- tparams
+            AnnotationZipper(ann, tparam1: TypeDef, _) <- loop(tparam, deep = false)
+            tparams1 = tparams.updated(tparams.indexOf(tparam), tparam1)
+          } yield AnnotationZipper(ann, tparam1, tdef.copy(tparams = tparams1))
+          tzippers ++ ttzippers
+        }
+      case _ =>
+        Nil
+    }
+    loop(tree, deep = true)
+  }
+
+  private object PatchedSyntacticClassDef {
+    def apply(mods: Modifiers, name: TypeName, tparams: List[Tree],
+              constrMods: Modifiers, vparamss: List[List[Tree]],
+              earlyDefs: List[Tree], parents: List[Tree], selfType: Tree, body: List[Tree]): ClassDef = {
+      // NOTE: works around SI-8771 and hopefully fixes https://github.com/scalamacros/paradise/issues/53 for good
+      SyntacticClassDef(mods, name, tparams, constrMods, vparamss.map(_.map(_.duplicate)), earlyDefs, parents, selfType, body)
+    }
+  }
+}

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -424,6 +424,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.ClassTargetClass
     definitions.MethodTargetClass
     definitions.LanguageFeatureAnnot
+    definitions.InheritedAttr
     definitions.JUnitAnnotations
     definitions.languageFeatureModule
     definitions.metaAnnotations

--- a/test/macro-annot/src/main/scala/argumentative.scala
+++ b/test/macro-annot/src/main/scala/argumentative.scala
@@ -1,0 +1,23 @@
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+import scala.annotation.StaticAnnotation
+
+object argumentativeMacro {
+  def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    import Flag._
+    val result = {
+      annottees.map(_.tree).toList match {
+        case ModuleDef(mods, name, Template(parents, self, body)) :: Nil =>
+          val Apply(Select(Apply(_, List(x, y)), _), _) = c.macroApplication
+          val toStringMethod = DefDef(Modifiers(OVERRIDE), TermName("toString"), List(), List(List()), TypeTree(), Literal(Constant(s"$x $y")))
+          ModuleDef(mods, name, Template(parents, self, body :+ toStringMethod))
+      }
+    }
+    c.Expr[Any](result)
+  }
+}
+
+class argumentative(val x: Int, y: Int) extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro argumentativeMacro.impl
+}

--- a/test/macro-annot/src/main/scala/doubler.scala
+++ b/test/macro-annot/src/main/scala/doubler.scala
@@ -1,0 +1,34 @@
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+import scala.annotation.StaticAnnotation
+
+object doublerMacro {
+  def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    val result = {
+      def double[T <: Name](name: T): T = {
+        val sdoubled = name.toString + name.toString
+        val doubled = if (name.isTermName) TermName(sdoubled) else TypeName(sdoubled)
+        doubled.asInstanceOf[T]
+      }
+      annottees.map(_.tree).toList match {
+        case ClassDef(mods, name, tparams, impl) :: rest => ClassDef(mods, double(name), tparams, impl) :: rest
+        case ModuleDef(mods, name, impl) :: rest => ModuleDef(mods, double(name), impl) :: rest
+        case DefDef(mods, name, tparams, vparamss, tpt, rhs) :: rest => DefDef(mods, double(name), tparams, vparamss, tpt, rhs) :: rest
+        case TypeDef(mods, name, tparams, rhs) :: rest => TypeDef(mods, double(name), tparams, rhs) :: rest
+        case ValDef(mods, name, tpt, rhs) :: rest => ValDef(mods, double(name), tpt, rhs) :: rest
+      }
+    }
+    c.Expr[Any](Block(result, Literal(Constant(()))))
+  }
+}
+
+class doubler extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro doublerMacro.impl
+}
+
+package pkg {
+  class doubler extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro doublerMacro.impl
+  }
+}

--- a/test/macro-annot/src/main/scala/explorer.scala
+++ b/test/macro-annot/src/main/scala/explorer.scala
@@ -1,0 +1,34 @@
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+import scala.annotation.StaticAnnotation
+
+object explorerMacro {
+  def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    import Flag._
+    def explore() = {
+      val a = c.mirror.staticModule("A")
+      val b = c.mirror.staticModule("B")
+      val i = c.inferImplicitValue(typeOf[Int])
+      "can see A, can see B, implicit is " + i
+    }
+    val result = {
+      annottees.map(_.tree).toList match {
+        case ModuleDef(mods, name, Template(parents, self, body)) :: Nil =>
+          val toStringMethod = DefDef(Modifiers(OVERRIDE), TermName("toString"), List(), List(List()), TypeTree(), Literal(Constant(explore())))
+          ModuleDef(mods, name, Template(parents, self, body :+ toStringMethod))
+      }
+    }
+    c.Expr[Any](result)
+  }
+}
+
+class explorer extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro explorerMacro.impl
+}
+
+package pkg {
+  class explorer extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro explorerMacro.impl
+  }
+}

--- a/test/macro-annot/src/main/scala/funny.scala
+++ b/test/macro-annot/src/main/scala/funny.scala
@@ -1,0 +1,35 @@
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+import scala.annotation.StaticAnnotation
+
+object funnyMacro {
+  def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    val (annottee: MemberDef) :: (expandee: MemberDef) :: rest = annottees.map(_.tree).toList
+    def funnify[T <: Name](name: T): T = {
+      val sfunnified = name.toString + annottee.name.toString
+      val funnified = if (name.isTermName) TermName(sfunnified) else TypeName(sfunnified)
+      funnified.asInstanceOf[T]
+    }
+    val expandee1 = {
+      expandee match {
+        case ClassDef(mods, name, tparams, impl) => ClassDef(mods, funnify(name), tparams, impl)
+        case ModuleDef(mods, name, impl) => ModuleDef(mods, funnify(name), impl)
+        case DefDef(mods, name, tparams, vparamss, tpt, rhs) => DefDef(mods, funnify(name), tparams, vparamss, tpt, rhs)
+        case TypeDef(mods, name, tparams, rhs) => TypeDef(mods, funnify(name), tparams, rhs)
+        case ValDef(mods, name, tpt, rhs) => ValDef(mods, funnify(name), tpt, rhs)
+      }
+    }
+    c.Expr[Any](Block(expandee1 :: rest, Literal(Constant(()))))
+  }
+}
+
+class funny extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro funnyMacro.impl
+}
+
+package pkg {
+  class funny extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro funnyMacro.impl
+  }
+}

--- a/test/macro-annot/src/main/scala/happytee.scala
+++ b/test/macro-annot/src/main/scala/happytee.scala
@@ -1,0 +1,25 @@
+import scala.language.experimental.macros
+import scala.annotation.StaticAnnotation
+import scala.reflect.macros.whitebox.Context
+
+object happyteeMacro {
+  def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    annottees.map(_.tree).toList match {
+      case (tsappa @ ValDef(_, _, tpt, _)) :: _ => {
+        val tpe = c.typecheck(q"(null.asInstanceOf[$tpt])").tpe
+        c.Expr(Block(List(tsappa), Literal(Constant(()))))
+      }
+    }
+  }
+}
+
+class happytee extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro happyteeMacro.impl
+}
+
+package pkg {
+  class happytee extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro happyteeMacro.impl
+  }
+}

--- a/test/macro-annot/src/main/scala/hello.scala
+++ b/test/macro-annot/src/main/scala/hello.scala
@@ -1,0 +1,27 @@
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+import scala.annotation.StaticAnnotation
+
+object helloMacro {
+  def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    val result = {
+      annottees.map(_.tree).toList match {
+        case ModuleDef(mods, name, Template(parents, self, body)) :: Nil =>
+          val helloMethod = DefDef(NoMods, TermName("hello"), List(), List(List()), TypeTree(), Literal(Constant("hello")))
+          ModuleDef(mods, name, Template(parents, self, body :+ helloMethod))
+      }
+    }
+    c.Expr[Any](result)
+  }
+}
+
+class hello extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro helloMacro.impl
+}
+
+package pkg {
+  class hello extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro helloMacro.impl
+  }
+}

--- a/test/macro-annot/src/main/scala/identity.scala
+++ b/test/macro-annot/src/main/scala/identity.scala
@@ -1,0 +1,40 @@
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+import scala.annotation.StaticAnnotation
+
+object identityMacro {
+  def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    c.Expr[Any](Block(annottees.map(_.tree).toList, Literal(Constant(()))))
+  }
+}
+
+class identity extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro identityMacro.impl
+}
+
+class identity1 extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro identityMacro.impl
+}
+
+package pkg {
+  class identity extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro identityMacro.impl
+  }
+
+  class identity2 extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro identityMacro.impl
+  }
+
+  object Module3 {
+    class identity3 extends StaticAnnotation {
+      def macroTransform(annottees: Any*): Any = macro identityMacro.impl
+    }
+  }
+}
+
+object Module4 {
+  class identity4 extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro identityMacro.impl
+  }
+}

--- a/test/macro-annot/src/main/scala/issue90Class.scala
+++ b/test/macro-annot/src/main/scala/issue90Class.scala
@@ -1,0 +1,16 @@
+import scala.annotation.compileTimeOnly
+import scala.annotation.StaticAnnotation
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox.Context
+
+object issue90Macro {
+    def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+      import c.universe._
+        c.Expr(EmptyTree)
+    }
+}
+
+@compileTimeOnly("this is the only annotation")
+final class issue90Class extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro issue90Macro.impl
+}

--- a/test/macro-annot/src/main/scala/kase.scala
+++ b/test/macro-annot/src/main/scala/kase.scala
@@ -1,0 +1,315 @@
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+import scala.language.postfixOps
+import scala.annotation.StaticAnnotation
+
+object kaseMacro {
+  // ======= DIFFERENCES WITH VANILLA CASE =======
+  // (this list is probably not exhaustive, since I didn't have time to study all details of the existing implementation
+  // 1) No CASE and SYNTHETIC flags (those have special treatment in the compiler, which I didn't want to interact with)
+  // 2) No warnings specially tailored for case classes, because the compiler knows how methods like equal will behave
+  // 3) No error messages specially tailored for case classes in case of synthesis conflicts (e.g. implicit case class)
+  // 4) No special treatment for case class pattern matching (constructor patterns, refutability checks)
+  // 5) No special treatment in RefChecks.relativeVariance (I don't even know why that one's necessary)
+  // 6) No specialized hashcode implementation for primitive fields (I didn't have time to go into all the details of codegen)
+  // 7) No referential transparency for methods like apply or copy that are injected into the companion, but should use kase class definition scope
+
+  abstract class kaseHelper[C <: Context](val c: C) {
+    import c.universe._
+    import c.universe.{Flag => PublicFlags}
+    import scala.reflect.internal.{Flags => InternalFlags}
+
+    def isTrait(mods: Modifiers) = (mods.flags.asInstanceOf[Long] & InternalFlags.TRAIT) != 0
+    def isFinal(mods: Modifiers) = (mods.flags.asInstanceOf[Long] & InternalFlags.FINAL) != 0
+    def isByName(mods: Modifiers) = (mods.flags.asInstanceOf[Long] & InternalFlags.BYNAMEPARAM) != 0
+    def isAbstract(mods: Modifiers) = (mods.flags.asInstanceOf[Long] & InternalFlags.ABSTRACT) != 0
+    val ParamMods = Modifiers(InternalFlags.PARAM.asInstanceOf[Long].asInstanceOf[FlagSet])
+    val SyntheticMods = Modifiers((0 /* | InternalFlags.SYNTHETIC */).asInstanceOf[Long].asInstanceOf[FlagSet])
+    val SyntheticCaseMods = Modifiers((0 /* | InternalFlags.SYNTHETIC | InternalFlags.CASE */).asInstanceOf[Long].asInstanceOf[FlagSet])
+    val OverrideSyntheticMods = Modifiers(PublicFlags.OVERRIDE /* | InternalFlags.SYNTHETIC.asInstanceOf[Long].asInstanceOf[FlagSet] */)
+    val FinalOverrideSyntheticMods = Modifiers(PublicFlags.FINAL | PublicFlags.OVERRIDE /* | InternalFlags.SYNTHETIC.asInstanceOf[Long].asInstanceOf[FlagSet] */)
+    def makeCase(mods: Modifiers) = {
+      val flags1 = mods.flags.asInstanceOf[Long] /* | InternalFlags.CASEACCESSOR */
+      Modifiers(flags1.asInstanceOf[FlagSet], mods.privateWithin, mods.annotations)
+    }
+    def makeCaseAccessor(mods: Modifiers) = {
+      if (isByName(mods)) c.abort(c.enclosingPosition, "`kase' parameters may not be call-by-name")
+      val flags1 = mods.flags.asInstanceOf[Long] /* | InternalFlags.CASEACCESSOR */ & ~InternalFlags.PRIVATE & ~InternalFlags.LOCAL
+      Modifiers(flags1.asInstanceOf[FlagSet], mods.privateWithin, mods.annotations)
+    }
+    def unmakeDefault(mods: Modifiers) = {
+      var flags1 = mods.flags.asInstanceOf[Long] & ~InternalFlags.DEFAULTPARAM
+      Modifiers(flags1.asInstanceOf[FlagSet], mods.privateWithin, mods.annotations)
+    }
+    def unmakeCaseAccessor(mods: Modifiers) = {
+      var flags1 = mods.flags.asInstanceOf[Long] & ~InternalFlags.PARAMACCESSOR & ~InternalFlags.CASEACCESSOR
+      Modifiers(flags1.asInstanceOf[FlagSet], mods.privateWithin, mods.annotations)
+    }
+    def makeDefault(mods: Modifiers) = Modifiers(mods.flags | PublicFlags.DEFAULTPARAM, mods.privateWithin, mods.annotations)
+    def unmakeParam(mods: Modifiers) = {
+      var flags1 = mods.flags.asInstanceOf[Long] & ~InternalFlags.PARAM
+      Modifiers(flags1.asInstanceOf[FlagSet], mods.privateWithin, mods.annotations)
+    }
+    def makeDeferredSynthetic(mods: Modifiers) = {
+      var flags1 = mods.flags.asInstanceOf[Long] | InternalFlags.DEFERRED /* | InternalFlags.SYNTHETIC */
+      Modifiers(flags1.asInstanceOf[FlagSet], mods.privateWithin, mods.annotations)
+    }
+    def unmakeVariant(mods: Modifiers) = {
+      var flags1 = mods.flags.asInstanceOf[Long] & ~InternalFlags.COVARIANT & ~InternalFlags.CONTRAVARIANT
+      Modifiers(flags1.asInstanceOf[FlagSet], mods.privateWithin, mods.annotations)
+    }
+
+    def expand(annottees: List[c.Tree]): List[c.Tree]
+  }
+
+  class kaseClassHelper[C <: Context](override val c: C) extends kaseHelper(c) {
+    import c.universe._
+    import definitions._
+
+    def expand(annottees: List[c.Tree]): List[c.Tree] = {
+      val cdef @ ClassDef(_, name, tparams, Template(_, _, cbody)) = annottees.head
+      val primaryCtor = cbody.collect{ case ddef @ DefDef(_, termNames.CONSTRUCTOR, _, _, _, _) => ddef }.head
+      if (primaryCtor.vparamss.isEmpty) c.abort(c.enclosingPosition, "`kase' is not appplicable to classes without a parameter list")
+      val primaryParamss = primaryCtor.vparamss
+      val primaryParams = primaryParamss.head
+      val secondaryParamss = primaryParamss.tail
+      val ourPolyType = if (tparams.nonEmpty) AppliedTypeTree(Ident(name), tparams.map(tparam => Ident(tparam.name))) else Ident(name)
+      val tparamUnderscores = tparams.zipWithIndex.map{ case (tdef, i) => TypeDef(makeDeferredSynthetic(unmakeParam(tdef.mods)), TypeName("x$" + (i+1)), tdef.tparams, tdef.rhs) }
+      val ourExistentialType = ExistentialTypeTree(AppliedTypeTree(Ident(name), tparamUnderscores.map(tdef => Ident(tdef.name))), tparamUnderscores)
+
+      val kaseClass = {
+        val ClassDef(cmods, _, _, Template(cparents, cself, _)) = cdef
+
+        // step 1: make it a case class
+        val cmods1 = makeCase(cmods)
+
+        // step 2: turn param accessors into case accessors
+        val cbody2 = cbody.map {
+          case ValDef(mods, name, tpt, rhs) if primaryParams.exists(_.name == name) => ValDef(makeCaseAccessor(mods), name, tpt, rhs)
+          case stat => stat
+        }
+
+        // step 3: inject copy if not defined
+        val cbody3 = {
+          if (cbody2.collect{ case ddef @ DefDef(_, name, _, _, _, _) if name == TermName("copy") => ddef }.nonEmpty) cbody2
+          else {
+            val copyTparams = tparams
+            val primaryCopyParamss = primaryParams.map(p => ValDef(makeDefault(unmakeCaseAccessor(p.mods)), p.name, p.tpt, Ident(p.name)))
+            val secondaryCopyParamss = secondaryParamss.map(_.map(p => ValDef(unmakeDefault(unmakeCaseAccessor(p.mods)), p.name, p.tpt, EmptyTree)))
+            val copyParamss = primaryCopyParamss :: secondaryCopyParamss
+            val copyArgss = copyParamss.map(_.map(p => Ident(p.name)))
+            val copyBody = copyArgss.foldLeft(Select(New(Ident(cdef.name)), termNames.CONSTRUCTOR): Tree)((callee, args) => Apply(callee, args))
+            val copyMethod = DefDef(SyntheticMods, TermName("copy"), copyTparams, copyParamss, TypeTree(), copyBody)
+            cbody2 :+ copyMethod
+          }
+        }
+
+        // step 4: implement product
+        val cparents4 = cparents :+ Select(Ident(TermName("scala")), TypeName("Product")) :+ Select(Ident(TermName("scala")), TypeName("Serializable"))
+        val cbody4 = {
+          val productPrefixMethod = DefDef(OverrideSyntheticMods, TermName("productPrefix"), Nil, Nil, TypeTree(), Literal(Constant(name.toString)))
+          val productArityMethod = DefDef(SyntheticMods, TermName("productArity"), Nil, Nil, TypeTree(), Literal(Constant(primaryParams.length)))
+          val productElementParam = ValDef(ParamMods, TermName("x$1"), Select(Ident(TermName("scala")), TypeName("Int")), EmptyTree)
+          def productElementByIndex(i: Int) = CaseDef(Literal(Constant(i)), EmptyTree, Select(This(name), primaryParams(i).name))
+          val productElementFallback = CaseDef(Ident(termNames.WILDCARD), EmptyTree, Throw(Apply(Select(New(TypeTree(c.mirror.staticClass("java.lang.IndexOutOfBoundsException").toType)), termNames.CONSTRUCTOR), List(Apply(Select(Ident(productElementParam.name), TermName("toString")), List())))))
+          val productElementBody = Match(Ident(productElementParam.name), (0 until primaryParams.length map productElementByIndex toList) :+ productElementFallback)
+          val productElementMethod = DefDef(SyntheticMods, TermName("productElement"), Nil, List(List(productElementParam )), TypeTree(), productElementBody)
+          val scalaRunTime = Select(Select(Ident(TermName("scala")), TermName("runtime")), TermName("ScalaRunTime"))
+          val productIteratorBody = Apply(TypeApply(Select(scalaRunTime, TermName("typedProductIterator")), List(Ident(TypeName("Any")))), List(This(name)))
+          val productIteratorMethod = DefDef(OverrideSyntheticMods, TermName("productIterator"), Nil, Nil, TypeTree(), productIteratorBody)
+          val canEqualParam = ValDef(ParamMods, TermName("x$1"), Select(Ident(TermName("scala")), TypeName("Any")), EmptyTree)
+          val canEqualBody = TypeApply(Select(Ident(canEqualParam.name), TermName("isInstanceOf")), List(ourExistentialType))
+          val canEqualMethod = DefDef(SyntheticMods, TermName("canEqual"), Nil, List(List(canEqualParam)), TypeTree(), canEqualBody)
+          cbody3 ++ List(productPrefixMethod, productArityMethod, productElementMethod, productIteratorMethod, canEqualMethod)
+        }
+
+        // step 5: inject hashcode
+        val cbody5 = {
+          val scalaRunTime = Select(Select(Ident(TermName("scala")), TermName("runtime")), TermName("ScalaRunTime"))
+          val hashcodeMethod = DefDef(OverrideSyntheticMods, TermName("hashCode"), Nil, Nil, TypeTree(), Apply(Select(scalaRunTime, TermName("_hashCode")), List(This(name))))
+          cbody4 :+ hashcodeMethod
+        }
+
+        // step 6: inject meaningful toString if not defined
+        val cbody6 = {
+          if (cbody5.collect{ case ddef @ DefDef(_, name, _, _, _, _) if name == TermName("toString") => ddef }.nonEmpty) cbody5
+          else {
+            val scalaRunTime = Select(Select(Ident(TermName("scala")), TermName("runtime")), TermName("ScalaRunTime"))
+            val toStringBody = Apply(Select(scalaRunTime, TermName("_toString")), List(This(name)))
+            val toStringMethod = DefDef(OverrideSyntheticMods, TermName("toString"), Nil, Nil, TypeTree(), toStringBody)
+            cbody5 :+ toStringMethod
+          }
+        }
+
+        // step 7: inject equals
+        val cbody7 = {
+          val equalsParam = ValDef(ParamMods, TermName("x$1"), Select(Ident(TermName("scala")), TypeName("Any")), EmptyTree)
+          val equalsBody = {
+            def thisEqThat = {
+              val thatAnyRef = TypeApply(Select(Ident(equalsParam.name), TermName("asInstanceOf")), List(Ident(TypeName("Object"))))
+              Apply(Select(This(name), TermName("eq")), List(thatAnyRef))
+            }
+            def thatCanEqualThis = {
+              val thatC = TypeApply(Select(Ident(equalsParam.name), TermName("asInstanceOf")), List(ourPolyType))
+              Apply(Select(thatC, TermName("canEqual")), List(This(name)))
+            }
+            def sameTypeCheck = {
+              val ifSameType = CaseDef(Typed(Ident(termNames.WILDCARD), ourPolyType), EmptyTree, Literal(Constant(true)))
+              val otherwise = CaseDef(Ident(termNames.WILDCARD), EmptyTree, Literal(Constant(false)))
+              Match(Ident(equalsParam.name), List(ifSameType, otherwise))
+            }
+            def sameFieldsCheck = {
+              val thatC = ValDef(SyntheticMods, TermName(name.toString + "$1"), ourPolyType, TypeApply(Select(Ident(equalsParam.name), TermName("asInstanceOf")), List(ourPolyType)))
+              val sameFieldsChecks = primaryParams.map(p => Apply(Select(Select(This(name), p.name), TermName("==").encodedName), List(Select(Ident(thatC.name), p.name))))
+              val thatCanEqualThis = Apply(Select(Ident(thatC.name), TermName("canEqual")), List(This(name)))
+              val sameFieldCheck = (sameFieldsChecks :+ thatCanEqualThis).reduceLeft((acc, check) => Apply(Select(acc, TermName("&&").encodedName), List(check)))
+              Block(List(thatC), sameFieldCheck)
+            }
+            if (primaryParamss.isEmpty) {
+              if (isFinal(cmods)) sameTypeCheck
+              else Apply(Select(sameTypeCheck, TermName("&&").encodedName), List(thatCanEqualThis))
+            } else {
+              val thisEqualsThat = Apply(Select(sameTypeCheck, TermName("&&").encodedName), List(sameFieldsCheck))
+              Apply(Select(thisEqThat, TermName("||").encodedName), List(thisEqualsThat))
+            }
+          }
+          val equalsMethod = DefDef(OverrideSyntheticMods, TermName("equals"), Nil, List(List(equalsParam)), TypeTree(), equalsBody)
+          cbody6 :+ equalsMethod
+        }
+
+        ClassDef(cmods1, name, tparams, Template(cparents4, cself, cbody7))
+      }
+
+      val kaseModule = {
+        val mdef @ ModuleDef(mmods, mname, Template(mparents, mself, mbody)) = annottees.tail.headOption getOrElse {
+          val shouldInheritFromFun = !isAbstract(cdef.mods) && tparams.isEmpty && primaryParamss.length == 1
+          val funClass = Select(Select(Ident(TermName("scala")), TermName("runtime")), TypeName("AbstractFunction" + primaryParams.length))
+          val funParent = AppliedTypeTree(funClass, primaryParams.map(_.tpt) :+ Ident(name))
+          val parents = if (shouldInheritFromFun) List(funParent) else List(Ident(AnyRefClass))
+          val emptyCtor = DefDef(Modifiers(), termNames.CONSTRUCTOR, List(), List(List()), TypeTree(), Block(List(Apply(Select(Super(This(typeNames.EMPTY), typeNames.EMPTY), termNames.CONSTRUCTOR), List())), Literal(Constant(()))))
+          ModuleDef(SyntheticMods, name.toTermName, Template(parents, noSelfType, List(emptyCtor)))
+        }
+
+        // step 1: inject toString if not defined
+        val mbody1 = {
+          if (mbody.collect{ case ddef @ DefDef(_, name, _, _, _, _) if name == TermName("toString") => ddef }.nonEmpty) mbody
+          else {
+            val toStringBody = Literal(Constant(name.toString))
+            val toStringMethod = DefDef(FinalOverrideSyntheticMods, TermName("toString"), Nil, Nil, TypeTree(), toStringBody)
+            mbody :+ toStringMethod
+          }
+        }
+
+        // step 2: inject apply
+        val mbody2 = {
+          val applyTparams = tparams.map(p => TypeDef(unmakeVariant(p.mods), p.name, p.tparams, p.rhs))
+          val applyParamss = primaryParamss.map(_.map(p => ValDef(unmakeCaseAccessor(p.mods), p.name, p.tpt, p.rhs)))
+          val applyArgss = applyParamss.map(_.map(p => Ident(p.name)))
+          val applyBody = applyArgss.foldLeft(Select(New(ourPolyType), termNames.CONSTRUCTOR): Tree)((callee, args) => Apply(callee, args))
+          val applyMethod = DefDef(SyntheticCaseMods, TermName("apply"), applyTparams, applyParamss, TypeTree(), applyBody)
+          mbody1 :+ applyMethod
+        }
+
+        // step 3: inject unapply
+        val mbody3 = {
+          val unapplyTparams = tparams.map(p => TypeDef(unmakeVariant(p.mods), p.name, p.tparams, p.rhs))
+          val unapplyParam = ValDef(ParamMods, TermName("x$0"), ourPolyType, EmptyTree)
+          val unapplyName = primaryParams match {
+            case _ :+ AppliedTypeTree(tpt: RefTree, _) if tpt.name == TypeName("<repeated>") => TermName("unapplySeq")
+            case _ => TermName("unapply")
+          }
+          val unapplyBody = {
+            val none = Select(Ident(TermName("scala")), TermName("None"))
+            def some(xs: Tree*) = Apply(Select(Ident(TermName("scala")), TermName("Some")), xs.toList)
+            val thisEqNull = Apply(Select(Ident(unapplyParam.name), TermName("==").encodedName), List(Literal(Constant(null))))
+            val failure = primaryParams match {
+              case Nil => Literal(Constant(false))
+              case _ => none
+            }
+            val success = primaryParams match {
+              case Nil => Literal(Constant(true))
+              case ps =>
+                val fs = ps.map(p => Select(Ident(unapplyParam.name), p.name))
+                val tuple = if (ps.length == 1) fs.head else Apply(Select(Ident(TermName("scala")), TermName("Tuple" + ps.length)), fs)
+                some(tuple)
+            }
+            If(thisEqNull, failure, success)
+          }
+          val unapplyMethod = DefDef(SyntheticCaseMods, unapplyName, unapplyTparams, List(List(unapplyParam)), TypeTree(), unapplyBody)
+          mbody2 :+ unapplyMethod
+        }
+
+        ModuleDef(mmods, mname, Template(mparents, mself, mbody3))
+      }
+
+      List(kaseClass, kaseModule)
+    }
+  }
+
+  class kaseObjectHelper[C <: Context](override val c: C) extends kaseHelper(c) {
+    import c.universe._
+
+    def expand(annottees: List[c.Tree]): List[c.Tree] = {
+      val mdef @ ModuleDef(mods, name, Template(parents, self, body)) :: Nil = annottees
+
+      // step 1: make it a case object
+      val mods1 = makeCase(mods)
+
+      // step 2: implement product
+      val parents2 = parents :+ Select(Ident(TermName("scala")), TypeName("Product")) :+ Select(Ident(TermName("scala")), TypeName("Serializable"))
+      val body2 = {
+        val productPrefixMethod = DefDef(OverrideSyntheticMods, TermName("productPrefix"), Nil, Nil, TypeTree(), Literal(Constant(name.toString)))
+        val productArityMethod = DefDef(SyntheticMods, TermName("productArity"), Nil, Nil, TypeTree(), Literal(Constant(0)))
+        val productElementParam = ValDef(ParamMods, TermName("x$1"), Select(Ident(TermName("scala")), TypeName("Int")), EmptyTree)
+        val productElementBody = Match(Ident(productElementParam.name), List(CaseDef(Ident(termNames.WILDCARD), EmptyTree, Throw(Apply(Select(New(TypeTree(c.mirror.staticClass("java.lang.IndexOutOfBoundsException").toType)), termNames.CONSTRUCTOR), List(Apply(Select(Ident(productElementParam.name), TermName("toString")), List())))))))
+        val productElementMethod = DefDef(SyntheticMods, TermName("productElement"), Nil, List(List(productElementParam )), TypeTree(), productElementBody)
+        val scalaRunTime = Select(Select(Ident(TermName("scala")), TermName("runtime")), TermName("ScalaRunTime"))
+        val productIteratorBody = Apply(TypeApply(Select(scalaRunTime, TermName("typedProductIterator")), List(Ident(TypeName("Any")))), List(This(name.toTypeName)))
+        val productIteratorMethod = DefDef(OverrideSyntheticMods, TermName("productIterator"), Nil, Nil, TypeTree(), productIteratorBody)
+        val canEqualParam = ValDef(ParamMods, TermName("x$1"), Select(Ident(TermName("scala")), TypeName("Any")), EmptyTree)
+        val canEqualBody = TypeApply(Select(Ident(canEqualParam.name), TermName("isInstanceOf")), List(SingletonTypeTree(Ident(name))))
+        val canEqualMethod = DefDef(SyntheticMods, TermName("canEqual"), Nil, List(List(canEqualParam)), TypeTree(), canEqualBody)
+        body ++ List(productPrefixMethod, productArityMethod, productElementMethod, productIteratorMethod, canEqualMethod)
+      }
+
+      // step 3: inject hashcode
+      val body3 = {
+        val hashcodeMethod = DefDef(OverrideSyntheticMods, TermName("hashCode"), Nil, Nil, TypeTree(), Literal(Constant((name.decodedName.toString.hashCode))))
+        body2 :+ hashcodeMethod
+      }
+
+      // step 4: inject meaningful toString if not defined
+      val body4 = {
+        if (body3.collect{ case ddef @ DefDef(_, name, _, _, _, _) if name == TermName("toString") => ddef }.nonEmpty) body3
+        else {
+          val toStringMethod = DefDef(OverrideSyntheticMods, TermName("toString"), Nil, Nil, TypeTree(), Literal(Constant(name.toString)))
+          body3 :+ toStringMethod
+        }
+      }
+
+      List(ModuleDef(mods1, name, Template(parents2, self, body4)))
+    }
+  }
+
+  def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    val helper = {
+      annottees.head.tree match {
+        case ClassDef(_, _, _, _) => new kaseClassHelper[c.type](c)
+        case ModuleDef(_, _, _) => new kaseObjectHelper[c.type](c)
+        case _ => c.abort(c.enclosingPosition, "`kase' is only applicable to classes and objects")
+      }
+    }
+    c.Expr[Any](Block(helper.expand(annottees.map(_.tree).toList), Literal(Constant(()))))
+  }
+}
+
+class kase extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro kaseMacro.impl
+}
+
+package pkg {
+  class kase extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro kaseMacro.impl
+  }
+}

--- a/test/macro-annot/src/main/scala/placebo.scala
+++ b/test/macro-annot/src/main/scala/placebo.scala
@@ -1,0 +1,5 @@
+class placebo extends scala.annotation.StaticAnnotation
+
+package pkg {
+  class placebo extends scala.annotation.StaticAnnotation
+}

--- a/test/macro-annot/src/main/scala/pretty.scala
+++ b/test/macro-annot/src/main/scala/pretty.scala
@@ -1,0 +1,28 @@
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+import scala.annotation.StaticAnnotation
+
+object prettyMacro {
+  def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    import Flag._
+    val result = {
+      annottees.map(_.tree).toList match {
+        case ModuleDef(mods, name, Template(parents, self, body)) :: Nil =>
+          val toStringMethod = DefDef(Modifiers(OVERRIDE), TermName("toString"), List(), List(List()), TypeTree(), Literal(Constant(name.toString)))
+          ModuleDef(mods, name, Template(parents, self, body :+ toStringMethod))
+      }
+    }
+    c.Expr[Any](result)
+  }
+}
+
+class pretty extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro prettyMacro.impl
+}
+
+package pkg {
+  class pretty extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro prettyMacro.impl
+  }
+}

--- a/test/macro-annot/src/main/scala/shove.scala
+++ b/test/macro-annot/src/main/scala/shove.scala
@@ -1,0 +1,48 @@
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+import scala.annotation.StaticAnnotation
+
+object shoveMacro {
+  def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    import Flag._
+    val Apply(Select(New(AppliedTypeTree(_, List(victim))), _), _) = c.prefix.tree
+    val result = {
+      annottees.map(_.tree).toList match {
+        case ValDef(mods, name, tpt, rhs) :: Nil =>
+          ClassDef(
+            Modifiers(IMPLICIT),
+            TypeName(s"${victim}With$name"),
+            List(),
+            Template(
+              List(Select(Ident(TermName("scala")), TypeName("AnyRef"))),
+              noSelfType,
+              List(
+                ValDef(Modifiers(PRIVATE | LOCAL), TermName("x"), victim, EmptyTree),
+                DefDef(
+                  Modifiers(),
+                  termNames.CONSTRUCTOR,
+                  List(),
+                  List(List(ValDef(Modifiers(PARAM), TermName("x"), victim, EmptyTree))),
+                  TypeTree(),
+                  Block(List(Apply(Select(Super(This(typeNames.EMPTY), typeNames.EMPTY), termNames.CONSTRUCTOR), List())), Literal(Constant(())))
+                ),
+                ValDef(mods, name, tpt, rhs)
+              )
+            )
+          )
+      }
+    }
+    c.Expr[Any](result)
+  }
+}
+
+class shove[A] extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro shoveMacro.impl
+}
+
+package pkg {
+  class shove extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro shoveMacro.impl
+  }
+}

--- a/test/macro-annot/src/main/scala/simulacrum.scala
+++ b/test/macro-annot/src/main/scala/simulacrum.scala
@@ -1,0 +1,15 @@
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+import scala.annotation.StaticAnnotation
+
+object simulacrumMacro {
+  def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    if (annottees.head.tree.getClass.getName.contains("DocDef")) c.abort(c.enclosingPosition, "annottee is a DocDef")
+    c.Expr[Any](Block(annottees.map(_.tree).toList, Literal(Constant(()))))
+  }
+}
+
+class simulacrum extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro simulacrumMacro.impl
+}

--- a/test/macro-annot/src/main/scala/social.scala
+++ b/test/macro-annot/src/main/scala/social.scala
@@ -1,0 +1,52 @@
+import scala.reflect.macros.whitebox.Context
+import scala.language.experimental.macros
+import scala.annotation.StaticAnnotation
+
+object socialMacros {
+  def plusOne(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    import Flag._
+    val result = {
+      annottees.map(_.tree).toList match {
+        case ClassDef(mods, name, tparams, Template(parents, self, body)) :: rest =>
+          val beforeToString = body.collect{ case ddef @ DefDef(_, name, _, _, _, _) if name == TermName("toString") => ddef }
+          val List(DefDef(_, _, _, _, _, Literal(Constant(before: String)))) = beforeToString
+          val after = before + "+1"
+          val afterToString = DefDef(Modifiers(OVERRIDE), TermName("toString"), List(), List(List()), TypeTree(), Literal(Constant(after)))
+          val body1 = body.diff(beforeToString) :+ afterToString
+          ClassDef(mods, name, tparams, Template(parents, self, body1)) :: rest
+      }
+    }
+    c.Expr[Any](Block(result, Literal(Constant(()))))
+  }
+  def plusTwo(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    val result = {
+      annottees.map(_.tree).toList match {
+        case ClassDef(mods, name, tparams, impl) :: rest =>
+          def plusOne = Apply(Select(New(Ident(TypeName("plusOne"))), termNames.CONSTRUCTOR), Nil)
+          val mods1 = Modifiers(mods.flags, mods.privateWithin, mods.annotations :+ plusOne :+ plusOne)
+          ClassDef(mods1, name, tparams, impl) :: rest
+      }
+    }
+    c.Expr[Any](Block(result, Literal(Constant(()))))
+  }
+}
+
+class plusOne extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro socialMacros.plusOne
+}
+
+class plusTwo extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro socialMacros.plusTwo
+}
+
+package pkg {
+  class plusOne extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro socialMacros.plusOne
+  }
+
+  class plusTwo extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro socialMacros.plusTwo
+  }
+}

--- a/test/macro-annot/src/main/scala/thingy.scala
+++ b/test/macro-annot/src/main/scala/thingy.scala
@@ -1,0 +1,43 @@
+// http://stackoverflow.com/questions/22549647/whats-the-right-way-to-generate-a-companion-class-de-novo-using-quasiquotes
+import scala.annotation.StaticAnnotation
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox.Context
+
+object thingyMacro {
+  def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    val toEmit = c.Expr(q"""
+class Thingy(i: Int) {
+  def stuff = println(i)
+}
+
+object Thingy {
+  def apply(x: Int) = new Thingy(x)
+}
+""")
+    annottees.map(_.tree) match {
+      case Nil => {
+        c.abort(c.enclosingPosition, "No test target")
+      }
+      case (classDeclaration: ClassDef) :: Nil => {
+        // println("No companion provided")
+        toEmit
+      }
+      case (classDeclaration: ClassDef) :: (companionDeclaration: ModuleDef) :: Nil => {
+        // println("Companion provided")
+        toEmit
+      }
+      case _ => c.abort(c.enclosingPosition, "Invalid test target")
+    }
+  }
+}
+
+class thingy extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro thingyMacro.impl
+}
+
+package pkg {
+  class thingy extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro thingyMacro.impl
+  }
+}

--- a/test/macro-annot/src/test/scala/run/42/42.scala
+++ b/test/macro-annot/src/test/scala/run/42/42.scala
@@ -1,0 +1,5 @@
+package issue42
+
+object M {
+  implicit class TimestampOps[@specialized(Int, Long) A](val i: A){}
+}

--- a/test/macro-annot/src/test/scala/run/Acyclic.scala
+++ b/test/macro-annot/src/test/scala/run/Acyclic.scala
@@ -1,0 +1,29 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+
+@RunWith(classOf[JUnit4])
+class Acyclic {
+  @Test
+  def testA: Unit = {
+    import acyclica._
+    assertEquals(C.toString, "C")
+    assertEquals(D.toString, "D")
+    assertEquals(new CX().toString, "CX")
+    assertEquals(new DX().toString, "DX")
+  }
+
+  @Test
+  def testB: Unit = {
+    import acyclicb._
+    assertEquals(CC.x.toString, "DX")
+    assertEquals(DD.x.toString, "CX")
+  }
+
+  @Test
+  def testC: Unit = {
+    import Module4._
+    @identity4 class C4
+  }
+}

--- a/test/macro-annot/src/test/scala/run/Argumentative.scala
+++ b/test/macro-annot/src/test/scala/run/Argumentative.scala
@@ -1,0 +1,13 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+
+@RunWith(classOf[JUnit4])
+class Argumentative {
+  @Test
+  def combo: Unit = {
+    @argumentative(1, 2) object X
+    assertEquals(X.toString, "1 2")
+  }
+}

--- a/test/macro-annot/src/test/scala/run/Assorted.scala
+++ b/test/macro-annot/src/test/scala/run/Assorted.scala
@@ -1,0 +1,46 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+import scala.reflect.runtime.universe._
+
+class AssortedZoo {
+  @doubler def foo(x: Int) = x
+  @doubler val bar = 2
+  @doubler var baz = 3
+  @doubler lazy val bax = 4
+  @doubler type T = Int
+}
+
+@RunWith(classOf[JUnit4])
+class Assorted {
+  @Test
+  def nested: Unit = {
+    assertEquals(typeOf[AssortedZoo].decls.sorted.map(_.toString).mkString("\n"), """
+      |constructor AssortedZoo
+      |method foofoo
+      |value barbar
+      |value barbar
+      |variable bazbaz
+      |variable bazbaz
+      |variable bazbaz
+      |lazy value baxbax
+      |type TT
+    """.trim.stripMargin)
+  }
+
+  @Test
+  def local: Unit = {
+    @doubler def foo(x: Int) = x
+    @doubler val bar = 2
+    @doubler var baz = 3
+    @doubler lazy val bax = 4
+    @doubler type T = Int
+
+    assertEquals(foofoo(1), 1)
+    assertEquals(barbar, 2)
+    assertEquals(bazbaz, 3)
+    assertEquals(baxbax, 4)
+    assertEquals(List[TT](5), List(5))
+  }
+}

--- a/test/macro-annot/src/test/scala/run/Definition.scala
+++ b/test/macro-annot/src/test/scala/run/Definition.scala
@@ -1,0 +1,13 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+import scala.reflect.runtime.{currentMirror => cm}
+
+@RunWith(classOf[JUnit4])
+class Definition {
+  @Test
+  def macroAnnotationsMarkedWithMACRO: Unit = {
+    assertEquals(cm.staticClass("identity").isMacro, true)
+  }
+}

--- a/test/macro-annot/src/test/scala/run/InteropCaseSynthesis.scala
+++ b/test/macro-annot/src/test/scala/run/InteropCaseSynthesis.scala
@@ -1,0 +1,20 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+
+@identity case class InteropIdentity(x: Int)
+@placebo case class InteropPlacebo(x: Int)
+
+@RunWith(classOf[JUnit4])
+class InteropCaseSynthesis {
+  @Test
+  def caseModuleSynthesisForIdentity: Unit = {
+    assertEquals(InteropIdentity.toString, "InteropIdentity")
+  }
+
+  @Test
+  def caseModuleSynthetisForPlacebo: Unit = {
+    assertEquals(InteropPlacebo.toString, "InteropPlacebo")
+  }
+}

--- a/test/macro-annot/src/test/scala/run/Issue09.scala
+++ b/test/macro-annot/src/test/scala/run/Issue09.scala
@@ -1,0 +1,12 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+
+object C09
+@identity @placebo class C09
+
+@RunWith(classOf[JUnit4])
+class Issue09 {
+  @Test
+  def compiles: Unit = {}
+}

--- a/test/macro-annot/src/test/scala/run/Issue10.scala
+++ b/test/macro-annot/src/test/scala/run/Issue10.scala
@@ -1,0 +1,9 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+
+@RunWith(classOf[JUnit4])
+class Issue10 {
+  @Test
+  def compiles: Unit = {}
+}

--- a/test/macro-annot/src/test/scala/run/Issue90.scala
+++ b/test/macro-annot/src/test/scala/run/Issue90.scala
@@ -1,0 +1,18 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+import scala.reflect.runtime.{currentMirror => cm}
+
+@RunWith(classOf[JUnit4])
+class Issue90 {
+  @Test
+  def compileTimeOnlyOnceOnly: Unit = {
+    assertEquals(cm.staticClass("issue90Class").annotations.length, 1)
+  }
+
+  @Test
+  def compileTimeOnlyOnceOnlyMessage: Unit = {
+    assertEquals(cm.staticClass("issue90Class").annotations.head.toString, "scala.annotation.compileTimeOnly(\"this is the only annotation\")")
+  }
+}

--- a/test/macro-annot/src/test/scala/run/KaseClass.scala
+++ b/test/macro-annot/src/test/scala/run/KaseClass.scala
@@ -1,0 +1,85 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+
+@kase class KaseClassPreToplevelNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+object KaseClassPreToplevelPrecomp
+@kase class KaseClassPreToplevelPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+@kase class KaseClassPreToplevelPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+object KaseClassPreToplevelPostcomp
+
+@RunWith(classOf[JUnit4])
+class KaseClass {
+  val objects = scala.collection.mutable.ListBuffer[Any]()
+  objects += KaseClassPreToplevelNocomp(42)(true)
+  objects += KaseClassPreToplevelPrecomp(42)(true)
+  objects += KaseClassPreToplevelPostcomp(42)(true)
+  objects += KaseClassPostToplevelNocomp(42)(true)
+  objects += KaseClassPostToplevelPrecomp(42)(true)
+  objects += KaseClassPostToplevelPostcomp(42)(true)
+
+  @kase class KaseClassPreMemberNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  object KaseClassPreMemberPrecomp
+  @kase class KaseClassPreMemberPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  @kase class KaseClassPreMemberPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  object KaseClassPreMemberPostcomp
+  objects += KaseClassPreMemberNocomp(42)(true)
+  objects += KaseClassPreMemberPrecomp(42)(true)
+  objects += KaseClassPreMemberPostcomp(42)(true)
+  objects += KaseClassPostMemberNocomp(42)(true)
+  objects += KaseClassPostMemberPrecomp(42)(true)
+  objects += KaseClassPostMemberPostcomp(42)(true)
+  @kase class KaseClassPostMemberNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  object KaseClassPostMemberPrecomp
+  @kase class KaseClassPostMemberPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  @kase class KaseClassPostMemberPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  object KaseClassPostMemberPostcomp
+
+  @Test
+  def combo: Unit = {
+    @kase class KaseClassPreLocalNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    object KaseClassPreLocalPrecomp
+    @kase class KaseClassPreLocalPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    @kase class KaseClassPreLocalPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    object KaseClassPreLocalPostcomp
+    objects += KaseClassPreLocalNocomp(42)(true)
+    objects += KaseClassPreLocalPrecomp(42)(true)
+    objects += KaseClassPreLocalPostcomp(42)(true)
+    objects += KaseClassPostLocalNocomp(42)(true)
+    objects += KaseClassPostLocalPrecomp(42)(true)
+    objects += KaseClassPostLocalPostcomp(42)(true)
+    @kase class KaseClassPostLocalNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    object KaseClassPostLocalPrecomp
+    @kase class KaseClassPostLocalPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    @kase class KaseClassPostLocalPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    object KaseClassPostLocalPostcomp
+
+    assertEquals(objects.mkString("\n"), """
+      |KaseClassPreToplevelNocomp(42,2)
+      |KaseClassPreToplevelPrecomp(42,2)
+      |KaseClassPreToplevelPostcomp(42,2)
+      |KaseClassPostToplevelNocomp(42,2)
+      |KaseClassPostToplevelPrecomp(42,2)
+      |KaseClassPostToplevelPostcomp(42,2)
+      |KaseClassPreMemberNocomp(42,2)
+      |KaseClassPreMemberPrecomp(42,2)
+      |KaseClassPreMemberPostcomp(42,2)
+      |KaseClassPostMemberNocomp(42,2)
+      |KaseClassPostMemberPrecomp(42,2)
+      |KaseClassPostMemberPostcomp(42,2)
+      |KaseClassPreLocalNocomp(42,2)
+      |KaseClassPreLocalPrecomp(42,2)
+      |KaseClassPreLocalPostcomp(42,2)
+      |KaseClassPostLocalNocomp(42,2)
+      |KaseClassPostLocalPrecomp(42,2)
+      |KaseClassPostLocalPostcomp(42,2)
+    """.trim.stripMargin)
+  }
+}
+
+@kase class KaseClassPostToplevelNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+object KaseClassPostToplevelPrecomp
+@kase class KaseClassPostToplevelPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+@kase class KaseClassPostToplevelPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+object KaseClassPostToplevelPostcomp

--- a/test/macro-annot/src/test/scala/run/KaseIdentityClass.scala
+++ b/test/macro-annot/src/test/scala/run/KaseIdentityClass.scala
@@ -1,0 +1,88 @@
+package kaseannot.identity.klass
+
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+import pkg._
+
+@kase class CPreToplevelNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+@identity object CPreToplevelPrecomp
+@kase class CPreToplevelPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+@kase class CPreToplevelPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+@identity object CPreToplevelPostcomp
+
+@RunWith(classOf[JUnit4])
+class KaseIdentityClass {
+  val objects = scala.collection.mutable.ListBuffer[Any]()
+  objects += CPreToplevelNocomp(42)(true)
+  objects += CPreToplevelPrecomp(42)(true)
+  objects += CPreToplevelPostcomp(42)(true)
+  objects += CPostToplevelNocomp(42)(true)
+  objects += CPostToplevelPrecomp(42)(true)
+  objects += CPostToplevelPostcomp(42)(true)
+
+  @kase class CPreMemberNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  @identity object CPreMemberPrecomp
+  @kase class CPreMemberPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  @kase class CPreMemberPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  @identity object CPreMemberPostcomp
+  objects += CPreMemberNocomp(42)(true)
+  objects += CPreMemberPrecomp(42)(true)
+  objects += CPreMemberPostcomp(42)(true)
+  objects += CPostMemberNocomp(42)(true)
+  objects += CPostMemberPrecomp(42)(true)
+  objects += CPostMemberPostcomp(42)(true)
+  @kase class CPostMemberNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  @identity object CPostMemberPrecomp
+  @kase class CPostMemberPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  @kase class CPostMemberPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  @identity object CPostMemberPostcomp
+
+  @Test
+  def combo: Unit = {
+    @kase class CPreLocalNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    @identity object CPreLocalPrecomp
+    @kase class CPreLocalPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    @kase class CPreLocalPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    @identity object CPreLocalPostcomp
+    objects += CPreLocalNocomp(42)(true)
+    objects += CPreLocalPrecomp(42)(true)
+    objects += CPreLocalPostcomp(42)(true)
+    objects += CPostLocalNocomp(42)(true)
+    objects += CPostLocalPrecomp(42)(true)
+    objects += CPostLocalPostcomp(42)(true)
+    @kase class CPostLocalNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    @identity object CPostLocalPrecomp
+    @kase class CPostLocalPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    @kase class CPostLocalPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    @identity object CPostLocalPostcomp
+
+    assertEquals(objects.mkString("\n"), """
+      |CPreToplevelNocomp(42,2)
+      |CPreToplevelPrecomp(42,2)
+      |CPreToplevelPostcomp(42,2)
+      |CPostToplevelNocomp(42,2)
+      |CPostToplevelPrecomp(42,2)
+      |CPostToplevelPostcomp(42,2)
+      |CPreMemberNocomp(42,2)
+      |CPreMemberPrecomp(42,2)
+      |CPreMemberPostcomp(42,2)
+      |CPostMemberNocomp(42,2)
+      |CPostMemberPrecomp(42,2)
+      |CPostMemberPostcomp(42,2)
+      |CPreLocalNocomp(42,2)
+      |CPreLocalPrecomp(42,2)
+      |CPreLocalPostcomp(42,2)
+      |CPostLocalNocomp(42,2)
+      |CPostLocalPrecomp(42,2)
+      |CPostLocalPostcomp(42,2)
+    """.trim.stripMargin)
+  }
+}
+
+@kase class CPostToplevelNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+@identity object CPostToplevelPrecomp
+@kase class CPostToplevelPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+@kase class CPostToplevelPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+@identity object CPostToplevelPostcomp

--- a/test/macro-annot/src/test/scala/run/KaseIdentityObject.scala
+++ b/test/macro-annot/src/test/scala/run/KaseIdentityObject.scala
@@ -1,0 +1,83 @@
+package kaseannot.identity.objekt
+
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+import pkg._
+
+@kase object CPreToplevelNocomp
+@identity class CPreToplevelPrecomp
+@kase object CPreToplevelPrecomp
+@kase object CPreToplevelPostcomp
+@identity class CPreToplevelPostcomp
+
+@RunWith(classOf[JUnit4])
+class KaseIdentityObject {
+  val objects = scala.collection.mutable.ListBuffer[Any]()
+  objects += CPreToplevelNocomp
+  objects += CPreToplevelPrecomp
+  objects += CPreToplevelPostcomp
+  objects += CPostToplevelNocomp
+  objects += CPostToplevelPrecomp
+  objects += CPostToplevelPostcomp
+
+  // TODO: doesn't work in sbt, though does work in the command line
+  // @kase object CPreMemberNocomp
+  // @identity class CPreMemberPrecomp
+  // @kase object CPreMemberPrecomp
+  // @kase object CPreMemberPostcomp
+  // @identity class CPreMemberPostcomp
+  // objects += CPreMemberNocomp
+  // objects += CPreMemberPrecomp
+  // objects += CPreMemberPostcomp
+  // objects += CPostMemberNocomp
+  // objects += CPostMemberPrecomp
+  // objects += CPostMemberPostcomp
+  // @kase object CPostMemberNocomp
+  // @identity class CPostMemberPrecomp
+  // @kase object CPostMemberPrecomp
+  // @kase object CPostMemberPostcomp
+  // @identity class CPostMemberPostcomp
+
+  @Test
+  def combo: Unit = {
+    @kase object CPreLocalNocomp
+    @identity class CPreLocalPrecomp
+    @kase object CPreLocalPrecomp
+    @kase object CPreLocalPostcomp
+    @identity class CPreLocalPostcomp
+    objects += CPreLocalNocomp
+    objects += CPreLocalPrecomp
+    objects += CPreLocalPostcomp
+    objects += CPostLocalNocomp
+    objects += CPostLocalPrecomp
+    objects += CPostLocalPostcomp
+    @kase object CPostLocalNocomp
+    @identity class CPostLocalPrecomp
+    @kase object CPostLocalPrecomp
+    @kase object CPostLocalPostcomp
+    @identity class CPostLocalPostcomp
+
+    assertEquals(objects.mkString("\n"), """
+      |CPreToplevelNocomp
+      |CPreToplevelPrecomp
+      |CPreToplevelPostcomp
+      |CPostToplevelNocomp
+      |CPostToplevelPrecomp
+      |CPostToplevelPostcomp
+      |CPreLocalNocomp
+      |CPreLocalPrecomp
+      |CPreLocalPostcomp
+      |CPostLocalNocomp
+      |CPostLocalPrecomp
+      |CPostLocalPostcomp
+    """.trim.stripMargin)
+  }
+}
+
+@kase object CPostToplevelNocomp
+@identity class CPostToplevelPrecomp
+@kase object CPostToplevelPrecomp
+@kase object CPostToplevelPostcomp
+@identity class CPostToplevelPostcomp

--- a/test/macro-annot/src/test/scala/run/KaseObject.scala
+++ b/test/macro-annot/src/test/scala/run/KaseObject.scala
@@ -1,0 +1,80 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+
+@kase object KaseObjectPreToplevelNocomp
+class KaseObjectPreToplevelPrecomp
+@kase object KaseObjectPreToplevelPrecomp
+@kase object KaseObjectPreToplevelPostcomp
+class KaseObjectPreToplevelPostcomp
+
+@RunWith(classOf[JUnit4])
+class KaseObject {
+  val objects = scala.collection.mutable.ListBuffer[Any]()
+  objects += KaseObjectPreToplevelNocomp
+  objects += KaseObjectPreToplevelPrecomp
+  objects += KaseObjectPreToplevelPostcomp
+  objects += KaseObjectPostToplevelNocomp
+  objects += KaseObjectPostToplevelPrecomp
+  objects += KaseObjectPostToplevelPostcomp
+
+  // TODO: doesn't work in sbt, though does work in the command line
+  // @kase object KaseObjectPreMemberNocomp
+  // class KaseObjectPreMemberPrecomp
+  // @kase object KaseObjectPreMemberPrecomp
+  // @kase object KaseObjectPreMemberPostcomp
+  // class KaseObjectPreMemberPostcomp
+  // objects += KaseObjectPreMemberNocomp
+  // objects += KaseObjectPreMemberPrecomp
+  // objects += KaseObjectPreMemberPostcomp
+  // objects += KaseObjectPostMemberNocomp
+  // objects += KaseObjectPostMemberPrecomp
+  // objects += KaseObjectPostMemberPostcomp
+  // @kase object KaseObjectPostMemberNocomp
+  // class KaseObjectPostMemberPrecomp
+  // @kase object KaseObjectPostMemberPrecomp
+  // @kase object KaseObjectPostMemberPostcomp
+  // class KaseObjectPostMemberPostcomp
+
+  @Test
+  def combo: Unit = {
+    @kase object KaseObjectPreLocalNocomp
+    class KaseObjectPreLocalPrecomp
+    @kase object KaseObjectPreLocalPrecomp
+    @kase object KaseObjectPreLocalPostcomp
+    class KaseObjectPreLocalPostcomp
+    objects += KaseObjectPreLocalNocomp
+    objects += KaseObjectPreLocalPrecomp
+    objects += KaseObjectPreLocalPostcomp
+    objects += KaseObjectPostLocalNocomp
+    objects += KaseObjectPostLocalPrecomp
+    objects += KaseObjectPostLocalPostcomp
+    @kase object KaseObjectPostLocalNocomp
+    class KaseObjectPostLocalPrecomp
+    @kase object KaseObjectPostLocalPrecomp
+    @kase object KaseObjectPostLocalPostcomp
+    class KaseObjectPostLocalPostcomp
+
+    assertEquals(objects.mkString("\n"), """
+      |KaseObjectPreToplevelNocomp
+      |KaseObjectPreToplevelPrecomp
+      |KaseObjectPreToplevelPostcomp
+      |KaseObjectPostToplevelNocomp
+      |KaseObjectPostToplevelPrecomp
+      |KaseObjectPostToplevelPostcomp
+      |KaseObjectPreLocalNocomp
+      |KaseObjectPreLocalPrecomp
+      |KaseObjectPreLocalPostcomp
+      |KaseObjectPostLocalNocomp
+      |KaseObjectPostLocalPrecomp
+      |KaseObjectPostLocalPostcomp
+    """.trim.stripMargin)
+  }
+}
+
+@kase object KaseObjectPostToplevelNocomp
+class KaseObjectPostToplevelPrecomp
+@kase object KaseObjectPostToplevelPrecomp
+@kase object KaseObjectPostToplevelPostcomp
+class KaseObjectPostToplevelPostcomp

--- a/test/macro-annot/src/test/scala/run/KasePlaceboClass.scala
+++ b/test/macro-annot/src/test/scala/run/KasePlaceboClass.scala
@@ -1,0 +1,88 @@
+package kaseannot.placebo.klass
+
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+import pkg._
+
+@kase class CPreToplevelNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+@placebo object CPreToplevelPrecomp
+@kase class CPreToplevelPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+@kase class CPreToplevelPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+@placebo object CPreToplevelPostcomp
+
+@RunWith(classOf[JUnit4])
+class KasePlaceboClass {
+  val objects = scala.collection.mutable.ListBuffer[Any]()
+  objects += CPreToplevelNocomp(42)(true)
+  objects += CPreToplevelPrecomp(42)(true)
+  objects += CPreToplevelPostcomp(42)(true)
+  objects += CPostToplevelNocomp(42)(true)
+  objects += CPostToplevelPrecomp(42)(true)
+  objects += CPostToplevelPostcomp(42)(true)
+
+  @kase class CPreMemberNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  @placebo object CPreMemberPrecomp
+  @kase class CPreMemberPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  @kase class CPreMemberPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  @placebo object CPreMemberPostcomp
+  objects += CPreMemberNocomp(42)(true)
+  objects += CPreMemberPrecomp(42)(true)
+  objects += CPreMemberPostcomp(42)(true)
+  objects += CPostMemberNocomp(42)(true)
+  objects += CPostMemberPrecomp(42)(true)
+  objects += CPostMemberPostcomp(42)(true)
+  @kase class CPostMemberNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  @placebo object CPostMemberPrecomp
+  @kase class CPostMemberPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  @kase class CPostMemberPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+  @placebo object CPostMemberPostcomp
+
+  @Test
+  def combo: Unit = {
+    @kase class CPreLocalNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    @placebo object CPreLocalPrecomp
+    @kase class CPreLocalPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    @kase class CPreLocalPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    @placebo object CPreLocalPostcomp
+    objects += CPreLocalNocomp(42)(true)
+    objects += CPreLocalPrecomp(42)(true)
+    objects += CPreLocalPostcomp(42)(true)
+    objects += CPostLocalNocomp(42)(true)
+    objects += CPostLocalPrecomp(42)(true)
+    objects += CPostLocalPostcomp(42)(true)
+    @kase class CPostLocalNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    @placebo object CPostLocalPrecomp
+    @kase class CPostLocalPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    @kase class CPostLocalPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+    @placebo object CPostLocalPostcomp
+
+    assertEquals(objects.mkString("\n"), """
+      |CPreToplevelNocomp(42,2)
+      |CPreToplevelPrecomp(42,2)
+      |CPreToplevelPostcomp(42,2)
+      |CPostToplevelNocomp(42,2)
+      |CPostToplevelPrecomp(42,2)
+      |CPostToplevelPostcomp(42,2)
+      |CPreMemberNocomp(42,2)
+      |CPreMemberPrecomp(42,2)
+      |CPreMemberPostcomp(42,2)
+      |CPostMemberNocomp(42,2)
+      |CPostMemberPrecomp(42,2)
+      |CPostMemberPostcomp(42,2)
+      |CPreLocalNocomp(42,2)
+      |CPreLocalPrecomp(42,2)
+      |CPreLocalPostcomp(42,2)
+      |CPostLocalNocomp(42,2)
+      |CPostLocalPrecomp(42,2)
+      |CPostLocalPostcomp(42,2)
+    """.trim.stripMargin)
+  }
+}
+
+@kase class CPostToplevelNocomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+@placebo object CPostToplevelPrecomp
+@kase class CPostToplevelPrecomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+@kase class CPostToplevelPostcomp[T](x: T, y: Int = 2)(z: Boolean, w: String = "")
+@placebo object CPostToplevelPostcomp

--- a/test/macro-annot/src/test/scala/run/KasePlaceboObject.scala
+++ b/test/macro-annot/src/test/scala/run/KasePlaceboObject.scala
@@ -1,0 +1,83 @@
+package kaseannot.placebo.objekt
+
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+import pkg._
+
+@kase object CPreToplevelNocomp
+@placebo class CPreToplevelPrecomp
+@kase object CPreToplevelPrecomp
+@kase object CPreToplevelPostcomp
+@placebo class CPreToplevelPostcomp
+
+@RunWith(classOf[JUnit4])
+class KasePlaceboObject {
+  val objects = scala.collection.mutable.ListBuffer[Any]()
+  objects += CPreToplevelNocomp
+  objects += CPreToplevelPrecomp
+  objects += CPreToplevelPostcomp
+  objects += CPostToplevelNocomp
+  objects += CPostToplevelPrecomp
+  objects += CPostToplevelPostcomp
+
+  // TODO: doesn't work in sbt, though does work in the command line
+  // @kase object CPreMemberNocomp
+  // @placebo class CPreMemberPrecomp
+  // @kase object CPreMemberPrecomp
+  // @kase object CPreMemberPostcomp
+  // @placebo class CPreMemberPostcomp
+  // objects += CPreMemberNocomp
+  // objects += CPreMemberPrecomp
+  // objects += CPreMemberPostcomp
+  // objects += CPostMemberNocomp
+  // objects += CPostMemberPrecomp
+  // objects += CPostMemberPostcomp
+  // @kase object CPostMemberNocomp
+  // @placebo class CPostMemberPrecomp
+  // @kase object CPostMemberPrecomp
+  // @kase object CPostMemberPostcomp
+  // @placebo class CPostMemberPostcomp
+
+  @Test
+  def combo: Unit = {
+    @kase object CPreLocalNocomp
+    @placebo class CPreLocalPrecomp
+    @kase object CPreLocalPrecomp
+    @kase object CPreLocalPostcomp
+    @placebo class CPreLocalPostcomp
+    objects += CPreLocalNocomp
+    objects += CPreLocalPrecomp
+    objects += CPreLocalPostcomp
+    objects += CPostLocalNocomp
+    objects += CPostLocalPrecomp
+    objects += CPostLocalPostcomp
+    @kase object CPostLocalNocomp
+    @placebo class CPostLocalPrecomp
+    @kase object CPostLocalPrecomp
+    @kase object CPostLocalPostcomp
+    @placebo class CPostLocalPostcomp
+
+    assertEquals(objects.mkString("\n"), """
+      |CPreToplevelNocomp
+      |CPreToplevelPrecomp
+      |CPreToplevelPostcomp
+      |CPostToplevelNocomp
+      |CPostToplevelPrecomp
+      |CPostToplevelPostcomp
+      |CPreLocalNocomp
+      |CPreLocalPrecomp
+      |CPreLocalPostcomp
+      |CPostLocalNocomp
+      |CPostLocalPrecomp
+      |CPostLocalPostcomp
+    """.trim.stripMargin)
+  }
+}
+
+@kase object CPostToplevelNocomp
+@placebo class CPostToplevelPrecomp
+@kase object CPostToplevelPrecomp
+@kase object CPostToplevelPostcomp
+@placebo class CPostToplevelPostcomp

--- a/test/macro-annot/src/test/scala/run/KaseThorough.scala
+++ b/test/macro-annot/src/test/scala/run/KaseThorough.scala
@@ -1,0 +1,55 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+
+@kase class C[T](x: T, y: Int = 2)(val z: Boolean, val w: String = "")
+
+@RunWith(classOf[JUnit4])
+class KaseThorough {
+  val c = C("42")(true)
+
+  @Test
+  def construction: Unit = {
+    assertEquals(c.toString, "C(42,2)")
+    assertEquals(new C("42")(true).toString, "C(42,2)")
+    assertEquals(c.x, "42")
+    assertEquals(c.y, 2)
+    assertEquals(c.z, true)
+    assertEquals(c.w, "")
+  }
+
+  @Test
+  def deconstruction: Unit = {
+    val C(x, y) = c
+    assertEquals(x, "42")
+    assertEquals(y, 2)
+  }
+
+  @Test
+  def copy: Unit = {
+    val c1 = c.copy(x = 42)(false, "copied")
+    assertEquals(c1.toString, "C(42,2)")
+    assertEquals(c1.x, 42)
+    assertEquals(c1.y, 2)
+    assertEquals(c1.z, false)
+    assertEquals(c1.w, "copied")
+  }
+
+  @Test
+  def product: Unit = {
+    assertEquals((c: Product).productPrefix, "C")
+    assertEquals(c.productElement(0), "42")
+    assertEquals(c.productElement(1), 2)
+    assertEquals(c.productIterator.toList, List("42", 2))
+  }
+
+  @Test
+  def equality: Unit = {
+    assertEquals(c, c)
+    assertNotNull(c)
+    assertEquals(c, C("42")(true))
+    assertEquals(c, C("42")(false, "something different"))
+    assertNotEquals(c, C(43)(true))
+  }
+}

--- a/test/macro-annot/src/test/scala/run/Multiple.scala
+++ b/test/macro-annot/src/test/scala/run/Multiple.scala
@@ -1,0 +1,14 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+
+@RunWith(classOf[JUnit4])
+class Multiple {
+  @doubler @doubler case object D
+
+  @Test
+  def multiple: Unit = {
+    assertEquals(DDDD.toString, "DDDD")
+  }
+}

--- a/test/macro-annot/src/test/scala/run/NameResolution.scala
+++ b/test/macro-annot/src/test/scala/run/NameResolution.scala
@@ -1,0 +1,30 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+
+@identity1 class C1
+@pkg.identity2 class C2
+@pkg.Module3.identity3 class C3
+@Module4.identity4 class C4
+
+@RunWith(classOf[JUnit4])
+class NameResolution {
+  import pkg._
+  import Module3._
+  import Module4._
+  @identity1 class C1
+  @identity2 class C2
+  @identity3 class C3
+  @identity4 class C4
+
+  @Test
+  def verifiedAtCompileTime: Unit = {
+  }
+}
+
+package pkg {
+  // @identity1 class C1
+  @identity2 class C2
+  @Module3.identity3 class C3
+  // @Module4.identity4 class C4
+}

--- a/test/macro-annot/src/test/scala/run/PackageObject.scala
+++ b/test/macro-annot/src/test/scala/run/PackageObject.scala
@@ -1,0 +1,34 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+
+package object pkg1 {
+  @doubler def foo(x: Int) = x
+  @doubler val bar = 2
+  @doubler var baz = 3
+  @doubler lazy val bax = 4
+  @doubler type T = Int
+}
+
+package pkg2 {
+  @hello object `package`
+}
+
+@RunWith(classOf[JUnit4])
+class PackageObject {
+  @Test
+  def packageObjectMembers: Unit = {
+    import pkg1._
+    assertEquals(foofoo(1), 1)
+    assertEquals(barbar, 2)
+    assertEquals(bazbaz, 3)
+    assertEquals(baxbax, 4)
+    assertEquals(List[TT](5), List(5))
+  }
+
+  @Test
+  def packageObjectItself: Unit = {
+    assertEquals(pkg2.hello, "hello")
+  }
+}

--- a/test/macro-annot/src/test/scala/run/PackagePackageObject.scala
+++ b/test/macro-annot/src/test/scala/run/PackagePackageObject.scala
@@ -1,0 +1,7 @@
+package object pkgTest {
+}
+
+package pkgTest {
+  @placebo
+  class Z
+}

--- a/test/macro-annot/src/test/scala/run/Parameters.scala
+++ b/test/macro-annot/src/test/scala/run/Parameters.scala
@@ -1,0 +1,26 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+import scala.reflect.runtime.universe._
+
+class ParameterZoo {
+  class C[@funny T](@funny val x: Int)
+  object С
+  def m[@funny T, @funny U](@funny x: Int)(@funny y: Int) = ???
+  type T[@funny U] = U
+}
+
+@RunWith(classOf[JUnit4])
+class Parameters {
+  @Test
+  def combo: Unit = {
+    assertEquals(typeOf[ParameterZoo].decls.sorted.map(_.toString).mkString("\n"), """
+      |constructor ParameterZoo
+      |object С
+      |class CTx
+      |method mTUxy
+      |type TU
+    """.trim.stripMargin)
+  }
+}

--- a/test/macro-annot/src/test/scala/run/PlaceboAssorted.scala
+++ b/test/macro-annot/src/test/scala/run/PlaceboAssorted.scala
@@ -1,0 +1,46 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+import scala.reflect.runtime.universe._
+
+class PlaceboAssortedZoo {
+  @placebo def foo(x: Int) = x
+  @placebo val bar = 2
+  @placebo var baz = 3
+  @placebo lazy val bax = 4
+  @placebo type T = Int
+}
+
+@RunWith(classOf[JUnit4])
+class PlaceboAssorted {
+  @Test
+  def nested: Unit = {
+    assertEquals(typeOf[PlaceboAssortedZoo].decls.sorted.map(_.toString).mkString("\n"), """
+      |constructor PlaceboAssortedZoo
+      |method foo
+      |type T
+      |value bar
+      |value bar
+      |variable baz
+      |variable baz
+      |variable baz
+      |lazy value bax
+    """.trim.stripMargin)
+  }
+
+  @Test
+  def local: Unit = {
+    @placebo def foo(x: Int) = x
+    @placebo val bar = 2
+    @placebo var baz = 3
+    @placebo lazy val bax = 4
+    @placebo type T = Int
+
+    assertEquals(foo(1), 1)
+    assertEquals(bar, 2)
+    assertEquals(baz, 3)
+    assertEquals(bax, 4)
+    assertEquals(List[T](5), List(5))
+  }
+}

--- a/test/macro-annot/src/test/scala/run/PlaceboClass.scala
+++ b/test/macro-annot/src/test/scala/run/PlaceboClass.scala
@@ -1,0 +1,88 @@
+package placeboannot.klass
+
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+import pkg._
+
+@placebo class CPreToplevelNocomp { override def toString = "CPreToplevelNocomp" }
+object CPreToplevelPrecomp { def apply() = new CPreToplevelPrecomp }
+@placebo class CPreToplevelPrecomp { override def toString = "CPreToplevelPrecomp" }
+@placebo class CPreToplevelPostcomp { override def toString = "CPreToplevelPostcomp" }
+object CPreToplevelPostcomp { def apply() = new CPreToplevelPostcomp }
+
+@RunWith(classOf[JUnit4])
+class PlaceboClass {
+  val objects = scala.collection.mutable.ListBuffer[Any]()
+  objects += new CPreToplevelNocomp()
+  objects += CPreToplevelPrecomp()
+  objects += CPreToplevelPostcomp()
+  objects += new CPostToplevelNocomp()
+  objects += CPostToplevelPrecomp()
+  objects += CPostToplevelPostcomp()
+
+  @placebo class CPreMemberNocomp { override def toString = "CPreMemberNocomp" }
+  object CPreMemberPrecomp { def apply() = new CPreMemberPrecomp }
+  @placebo class CPreMemberPrecomp { override def toString = "CPreMemberPrecomp" }
+  @placebo class CPreMemberPostcomp { override def toString = "CPreMemberPostcomp" }
+  object CPreMemberPostcomp { def apply() = new CPreMemberPostcomp }
+  objects += new CPreMemberNocomp()
+  objects += CPreMemberPrecomp()
+  objects += CPreMemberPostcomp()
+  objects += new CPostMemberNocomp()
+  objects += CPostMemberPrecomp()
+  objects += CPostMemberPostcomp()
+  @placebo class CPostMemberNocomp { override def toString = "CPostMemberNocomp" }
+  object CPostMemberPrecomp { def apply() = new CPostMemberPrecomp }
+  @placebo class CPostMemberPrecomp { override def toString = "CPostMemberPrecomp" }
+  @placebo class CPostMemberPostcomp { override def toString = "CPostMemberPostcomp" }
+  object CPostMemberPostcomp { def apply() = new CPostMemberPostcomp }
+
+  @Test
+  def combo: Unit = {
+    @placebo class CPreLocalNocomp { override def toString = "CPreLocalNocomp" }
+    object CPreLocalPrecomp { def apply() = new CPreLocalPrecomp }
+    @placebo class CPreLocalPrecomp { override def toString = "CPreLocalPrecomp" }
+    @placebo class CPreLocalPostcomp { override def toString = "CPreLocalPostcomp" }
+    object CPreLocalPostcomp { def apply() = new CPreLocalPostcomp }
+    objects += new CPreLocalNocomp()
+    objects += CPreLocalPrecomp()
+    objects += CPreLocalPostcomp()
+    objects += new CPostLocalNocomp()
+    objects += CPostLocalPrecomp()
+    objects += CPostLocalPostcomp()
+    @placebo class CPostLocalNocomp { override def toString = "CPostLocalNocomp" }
+    object CPostLocalPrecomp { def apply() = new CPostLocalPrecomp }
+    @placebo class CPostLocalPrecomp { override def toString = "CPostLocalPrecomp" }
+    @placebo class CPostLocalPostcomp { override def toString = "CPostLocalPostcomp" }
+    object CPostLocalPostcomp { def apply() = new CPostLocalPostcomp }
+
+    assertEquals(objects.mkString("\n"), """
+      |CPreToplevelNocomp
+      |CPreToplevelPrecomp
+      |CPreToplevelPostcomp
+      |CPostToplevelNocomp
+      |CPostToplevelPrecomp
+      |CPostToplevelPostcomp
+      |CPreMemberNocomp
+      |CPreMemberPrecomp
+      |CPreMemberPostcomp
+      |CPostMemberNocomp
+      |CPostMemberPrecomp
+      |CPostMemberPostcomp
+      |CPreLocalNocomp
+      |CPreLocalPrecomp
+      |CPreLocalPostcomp
+      |CPostLocalNocomp
+      |CPostLocalPrecomp
+      |CPostLocalPostcomp
+    """.trim.stripMargin)
+  }
+}
+
+@placebo class CPostToplevelNocomp { override def toString = "CPostToplevelNocomp" }
+object CPostToplevelPrecomp { def apply() = new CPostToplevelPrecomp }
+@placebo class CPostToplevelPrecomp { override def toString = "CPostToplevelPrecomp" }
+@placebo class CPostToplevelPostcomp { override def toString = "CPostToplevelPostcomp" }
+object CPostToplevelPostcomp { def apply() = new CPostToplevelPostcomp }

--- a/test/macro-annot/src/test/scala/run/PlaceboObject.scala
+++ b/test/macro-annot/src/test/scala/run/PlaceboObject.scala
@@ -1,0 +1,88 @@
+package placeboannot.objekt
+
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+import pkg._
+
+@placebo object CPreToplevelNocomp { override def toString = "CPreToplevelNocomp" }
+class CPreToplevelPrecomp
+@placebo object CPreToplevelPrecomp { override def toString = "CPreToplevelPrecomp" }
+@placebo object CPreToplevelPostcomp { override def toString = "CPreToplevelPostcomp" }
+class CPreToplevelPostcomp
+
+@RunWith(classOf[JUnit4])
+class PlaceboClass {
+  val classs = scala.collection.mutable.ListBuffer[Any]()
+  classs += CPreToplevelNocomp
+  classs += CPreToplevelPrecomp
+  classs += CPreToplevelPostcomp
+  classs += CPostToplevelNocomp
+  classs += CPostToplevelPrecomp
+  classs += CPostToplevelPostcomp
+
+  @placebo object CPreMemberNocomp { override def toString = "CPreMemberNocomp" }
+  class CPreMemberPrecomp
+  @placebo object CPreMemberPrecomp { override def toString = "CPreMemberPrecomp" }
+  @placebo object CPreMemberPostcomp { override def toString = "CPreMemberPostcomp" }
+  class CPreMemberPostcomp
+  classs += CPreMemberNocomp
+  classs += CPreMemberPrecomp
+  classs += CPreMemberPostcomp
+  classs += CPostMemberNocomp
+  classs += CPostMemberPrecomp
+  classs += CPostMemberPostcomp
+  @placebo object CPostMemberNocomp { override def toString = "CPostMemberNocomp" }
+  class CPostMemberPrecomp
+  @placebo object CPostMemberPrecomp { override def toString = "CPostMemberPrecomp" }
+  @placebo object CPostMemberPostcomp { override def toString = "CPostMemberPostcomp" }
+  class CPostMemberPostcomp
+
+  @Test
+  def combo: Unit = {
+    @placebo object CPreLocalNocomp { override def toString = "CPreLocalNocomp" }
+    class CPreLocalPrecomp
+    @placebo object CPreLocalPrecomp { override def toString = "CPreLocalPrecomp" }
+    @placebo object CPreLocalPostcomp { override def toString = "CPreLocalPostcomp" }
+    class CPreLocalPostcomp
+    classs += CPreLocalNocomp
+    classs += CPreLocalPrecomp
+    classs += CPreLocalPostcomp
+    classs += CPostLocalNocomp
+    classs += CPostLocalPrecomp
+    classs += CPostLocalPostcomp
+    @placebo object CPostLocalNocomp { override def toString = "CPostLocalNocomp" }
+    class CPostLocalPrecomp
+    @placebo object CPostLocalPrecomp { override def toString = "CPostLocalPrecomp" }
+    @placebo object CPostLocalPostcomp { override def toString = "CPostLocalPostcomp" }
+    class CPostLocalPostcomp
+
+    assertEquals(classs.mkString("\n"), """
+      |CPreToplevelNocomp
+      |CPreToplevelPrecomp
+      |CPreToplevelPostcomp
+      |CPostToplevelNocomp
+      |CPostToplevelPrecomp
+      |CPostToplevelPostcomp
+      |CPreMemberNocomp
+      |CPreMemberPrecomp
+      |CPreMemberPostcomp
+      |CPostMemberNocomp
+      |CPostMemberPrecomp
+      |CPostMemberPostcomp
+      |CPreLocalNocomp
+      |CPreLocalPrecomp
+      |CPreLocalPostcomp
+      |CPostLocalNocomp
+      |CPostLocalPrecomp
+      |CPostLocalPostcomp
+    """.trim.stripMargin)
+  }
+}
+
+@placebo object CPostToplevelNocomp { override def toString = "CPostToplevelNocomp" }
+class CPostToplevelPrecomp
+@placebo object CPostToplevelPrecomp { override def toString = "CPostToplevelPrecomp" }
+@placebo object CPostToplevelPostcomp { override def toString = "CPostToplevelPostcomp" }
+class CPostToplevelPostcomp

--- a/test/macro-annot/src/test/scala/run/PlaceboParameters.scala
+++ b/test/macro-annot/src/test/scala/run/PlaceboParameters.scala
@@ -1,0 +1,26 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+import scala.reflect.runtime.universe._
+
+class PlaceboParameterZoo {
+  class C[@placebo T](@placebo val x: Int)
+  object С
+  def m[@placebo T, @placebo U](@placebo x: Int)(@placebo y: Int) = ???
+  type T[@placebo U] = U
+}
+
+@RunWith(classOf[JUnit4])
+class PlaceboParameters {
+  @Test
+  def combo: Unit = {
+    assertEquals(typeOf[PlaceboParameterZoo].decls.sorted.map(_.toString).mkString("\n"), """
+      |constructor PlaceboParameterZoo
+      |class C
+      |object С
+      |method m
+      |type T
+    """.trim.stripMargin)
+  }
+}

--- a/test/macro-annot/src/test/scala/run/Recursive.scala
+++ b/test/macro-annot/src/test/scala/run/Recursive.scala
@@ -1,0 +1,88 @@
+package recursive
+
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+import pkg._
+
+@plusTwo class CPreToplevelNocomp { override def toString = "CPreToplevelNocomp" }
+object CPreToplevelPrecomp { def apply() = new CPreToplevelPrecomp }
+@plusTwo class CPreToplevelPrecomp { override def toString = "CPreToplevelPrecomp" }
+@plusTwo class CPreToplevelPostcomp { override def toString = "CPreToplevelPostcomp" }
+object CPreToplevelPostcomp { def apply() = new CPreToplevelPostcomp }
+
+@RunWith(classOf[JUnit4])
+class Recursive {
+  val objects = scala.collection.mutable.ListBuffer[Any]()
+  objects += new CPreToplevelNocomp()
+  objects += CPreToplevelPrecomp()
+  objects += CPreToplevelPostcomp()
+  objects += new CPostToplevelNocomp()
+  objects += CPostToplevelPrecomp()
+  objects += CPostToplevelPostcomp()
+
+  @plusTwo class CPreMemberNocomp { override def toString = "CPreMemberNocomp" }
+  object CPreMemberPrecomp { def apply() = new CPreMemberPrecomp }
+  @plusTwo class CPreMemberPrecomp { override def toString = "CPreMemberPrecomp" }
+  @plusTwo class CPreMemberPostcomp { override def toString = "CPreMemberPostcomp" }
+  object CPreMemberPostcomp { def apply() = new CPreMemberPostcomp }
+  objects += new CPreMemberNocomp()
+  objects += CPreMemberPrecomp()
+  objects += CPreMemberPostcomp()
+  objects += new CPostMemberNocomp()
+  objects += CPostMemberPrecomp()
+  objects += CPostMemberPostcomp()
+  @plusTwo class CPostMemberNocomp { override def toString = "CPostMemberNocomp" }
+  object CPostMemberPrecomp { def apply() = new CPostMemberPrecomp }
+  @plusTwo class CPostMemberPrecomp { override def toString = "CPostMemberPrecomp" }
+  @plusTwo class CPostMemberPostcomp { override def toString = "CPostMemberPostcomp" }
+  object CPostMemberPostcomp { def apply() = new CPostMemberPostcomp }
+
+  @Test
+  def combo: Unit = {
+    @plusTwo class CPreLocalNocomp { override def toString = "CPreLocalNocomp" }
+    object CPreLocalPrecomp { def apply() = new CPreLocalPrecomp }
+    @plusTwo class CPreLocalPrecomp { override def toString = "CPreLocalPrecomp" }
+    @plusTwo class CPreLocalPostcomp { override def toString = "CPreLocalPostcomp" }
+    object CPreLocalPostcomp { def apply() = new CPreLocalPostcomp }
+    objects += new CPreLocalNocomp()
+    objects += CPreLocalPrecomp()
+    objects += CPreLocalPostcomp()
+    objects += new CPostLocalNocomp()
+    objects += CPostLocalPrecomp()
+    objects += CPostLocalPostcomp()
+    @plusTwo class CPostLocalNocomp { override def toString = "CPostLocalNocomp" }
+    object CPostLocalPrecomp { def apply() = new CPostLocalPrecomp }
+    @plusTwo class CPostLocalPrecomp { override def toString = "CPostLocalPrecomp" }
+    @plusTwo class CPostLocalPostcomp { override def toString = "CPostLocalPostcomp" }
+    object CPostLocalPostcomp { def apply() = new CPostLocalPostcomp }
+
+    assertEquals(objects.mkString("\n"), """
+      |CPreToplevelNocomp+1+1
+      |CPreToplevelPrecomp+1+1
+      |CPreToplevelPostcomp+1+1
+      |CPostToplevelNocomp+1+1
+      |CPostToplevelPrecomp+1+1
+      |CPostToplevelPostcomp+1+1
+      |CPreMemberNocomp+1+1
+      |CPreMemberPrecomp+1+1
+      |CPreMemberPostcomp+1+1
+      |CPostMemberNocomp+1+1
+      |CPostMemberPrecomp+1+1
+      |CPostMemberPostcomp+1+1
+      |CPreLocalNocomp+1+1
+      |CPreLocalPrecomp+1+1
+      |CPreLocalPostcomp+1+1
+      |CPostLocalNocomp+1+1
+      |CPostLocalPrecomp+1+1
+      |CPostLocalPostcomp+1+1
+    """.trim.stripMargin)
+  }
+}
+
+@plusTwo class CPostToplevelNocomp { override def toString = "CPostToplevelNocomp" }
+object CPostToplevelPrecomp { def apply() = new CPostToplevelPrecomp }
+@plusTwo class CPostToplevelPrecomp { override def toString = "CPostToplevelPrecomp" }
+@plusTwo class CPostToplevelPostcomp { override def toString = "CPostToplevelPostcomp" }
+object CPostToplevelPostcomp { def apply() = new CPostToplevelPostcomp }

--- a/test/macro-annot/src/test/scala/run/Repl.scala
+++ b/test/macro-annot/src/test/scala/run/Repl.scala
@@ -1,0 +1,83 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import scala.tools.nsc.Settings
+import scala.tools.nsc.interpreter.shell._
+
+@RunWith(classOf[JUnit4])
+class Repl {
+  private def repl(code: String): String = {
+    val s = new Settings
+    s.Xnojline.value = true
+    s.usejavacp.value = false
+    s.classpath.value = sys.props("sbt.paths.tests.classpath")
+    s.plugin.value = List(sys.props("sbt.paths.plugin.jar"))
+    val lines = ILoop.runForTranscript(code, s).lines.toList
+    lines.drop(3).dropRight(2).mkString("\n").trim.stripSuffix("scala>").trim
+  }
+
+  @Ignore
+  @Test
+  def precompiledMacrosExpand: Unit = {
+    // TODO: The workaround employed in https://github.com/scalamacros/paradise/issues/19
+    // no longer works because of the REPL refactoring in 2.13.0-M2.
+    // See https://github.com/scalamacros/paradise/issues/102 for discussion.
+    // assertEquals(repl("""
+    //   |@thingy class Thingy
+    //   |@thingy class NonThingy
+    // """.stripMargin.trim), """
+    //   |scala> @thingy class Thingy
+    //   |defined class Thingy
+    //   |defined object Thingy
+    //   |
+    //   |scala> @thingy class NonThingy
+    //   |defined class Thingy
+    //   |defined object Thingy
+    // """.stripMargin.trim)
+  }
+
+  @Ignore
+  @Test
+  def adhocMacrosExpand = {
+    // TODO: The workaround employed in https://github.com/scalamacros/paradise/issues/19
+    // no longer works because of the REPL refactoring in 2.13.0-M2.
+    // See https://github.com/scalamacros/paradise/issues/102 for discussion.
+    // val printout = repl("""
+    //   |import scala.language.experimental.macros
+    //   |import scala.reflect.macros.whitebox.Context
+    //   |import scala.annotation.StaticAnnotation
+    //   |
+    //   |object thingyAdhocMacro {
+    //   |  def impl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    //   |    import c.universe._
+    //   |    val toEmit = c.Expr(q"class Thingy(i: Int) { def stuff = println(i) }; object Thingy { def apply(x: Int) = new Thingy(x) }")
+    //   |    annottees.map(_.tree) match {
+    //   |      case Nil => {
+    //   |        c.abort(c.enclosingPosition, "No test target")
+    //   |      }
+    //   |      case (classDeclaration: ClassDef) :: Nil => {
+    //   |        // println("No companion provided")
+    //   |        toEmit
+    //   |      }
+    //   |      case (classDeclaration: ClassDef) :: (companionDeclaration: ModuleDef) :: Nil => {
+    //   |        // println("Companion provided")
+    //   |        toEmit
+    //   |      }
+    //   |      case _ => c.abort(c.enclosingPosition, "Invalid test target")
+    //   |    }
+    //   |  }
+    //   |}
+    //   |
+    //   |class thingyAdhoc extends StaticAnnotation {
+    //   |  def macroTransform(annottees: Any*): Any = macro thingyAdhocMacro.impl
+    //   |}
+    //   |
+    //   |@thingyAdhoc class Thingy
+    //   |@thingyAdhoc class NonThingy
+    // """.stripMargin.trim)
+    // assert(printout.contains("defined class Thingy"))
+    // assert(printout.contains("defined object Thingy"))
+    // assert(!printout.contains("defined class NonThingy"))
+    // assert(!printout.contains("defined object NonThingy"))
+  }
+}

--- a/test/macro-annot/src/test/scala/run/Scopes.scala
+++ b/test/macro-annot/src/test/scala/run/Scopes.scala
@@ -1,0 +1,39 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+
+@RunWith(classOf[JUnit4])
+class Scopes {
+  implicit val x = 42
+  @explorer object C
+
+  @Test
+  def toplevel: Unit = {
+    assertEquals(A.toString, "can see A, can see B, implicit is <empty>")
+    assertEquals(B.toString, "can see A, can see B, implicit is <empty>")
+  }
+
+  @Test
+  def member: Unit = {
+    assertEquals(C.toString, "can see A, can see B, implicit is <empty>")
+  }
+
+  @Test
+  def local: Unit = {
+    @explorer object D
+    assertEquals(D.toString, "can see A, can see B, implicit is Scopes.this.x")
+
+    {
+      val x = 42
+      @explorer object E
+      assertEquals(E.toString, "can see A, can see B, implicit is Scopes.this.x")
+
+      {
+        implicit val x = 42
+        @explorer object F
+        assertEquals(F.toString, "can see A, can see B, implicit is <empty>")
+      }
+    }
+  }
+}

--- a/test/macro-annot/src/test/scala/run/TypeArgs.scala
+++ b/test/macro-annot/src/test/scala/run/TypeArgs.scala
@@ -1,0 +1,15 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+
+@RunWith(classOf[JUnit4])
+class TypeArgs {
+  @Test
+  def macroAnnotationsWithTypeArgsExpand: Unit = {
+    @shove[Int] val description = "I’m an Int!"
+    @shove[String] val bar = "I’m a String!"
+    assertEquals(5.description, "I’m an Int!")
+    assertEquals("foo".bar, "I’m a String!")
+  }
+}

--- a/test/macro-annot/src/test/scala/run/acyclic-a/C.scala
+++ b/test/macro-annot/src/test/scala/run/acyclic-a/C.scala
@@ -1,0 +1,12 @@
+package acyclica
+
+import pkg._
+
+import D._
+
+class DX extends X
+
+@pretty
+object C {
+  class X { override def toString = "CX" }
+}

--- a/test/macro-annot/src/test/scala/run/acyclic-a/D.scala
+++ b/test/macro-annot/src/test/scala/run/acyclic-a/D.scala
@@ -1,0 +1,10 @@
+package acyclica
+
+import C._
+
+class CX extends X
+
+@pkg.pretty
+object D {
+  class X { override def toString = "DX" }
+}

--- a/test/macro-annot/src/test/scala/run/acyclic-b/C.scala
+++ b/test/macro-annot/src/test/scala/run/acyclic-b/C.scala
@@ -1,0 +1,14 @@
+package acyclicb
+
+import pkg._
+
+object CC {
+  import DD.DD._
+
+  val x = new X
+
+  @doubler
+  object C {
+    class X { override def toString = "CX" }
+  }
+}

--- a/test/macro-annot/src/test/scala/run/acyclic-b/D.scala
+++ b/test/macro-annot/src/test/scala/run/acyclic-b/D.scala
@@ -1,0 +1,12 @@
+package acyclicb
+
+object DD {
+  import CC.CC._
+
+  val x = new X
+
+  @pkg.doubler
+  object D {
+    class X { override def toString = "DX" }
+  }
+}

--- a/test/macro-annot/src/test/scala/run/companion-symbol-of/A.scala
+++ b/test/macro-annot/src/test/scala/run/companion-symbol-of/A.scala
@@ -1,0 +1,125 @@
+// upd. oops, this is was a neg test in scala/scala, so we can't put it here :)
+// // if this file compiles, then we're good
+// package a
+
+// class C(a: Any)
+// object F {
+//   def byname(a: => Any) = println(a)
+//   def hof(a: () => Any) = println(a())
+// }
+
+// class COkay extends C(0) {
+//   def this(a: Any) {
+//     this()
+//     def x = "".toString
+//     F.byname(x)
+//   }
+// }
+
+// //
+// // The thunk's apply method accesses the MODULE$
+// // field before it is set.
+// //
+// //   0: getstatic #23; //Field O1$.MODULE$:LO1$;
+// //   3: invokevirtual #26; //Method O1$.O1$$x$1:()Ljava/lang/String;
+// object O1 extends C({
+//   def x = "".toString
+//   F.byname(x)
+// })
+
+// // java.lang.NullPointerException
+// //   at O2$$anonfun$$init$$1.apply(<console>:11)
+// object O2 extends C({
+//   lazy val x = "".toString
+//   F.byname(x)
+// })
+
+// // java.lang.NullPointerException
+// //   at O3$$anonfun$$init$$1.apply(<console>:11)
+// object O3 extends C({
+//   def x = "".toString
+//   F.hof(() => x)
+// })
+
+// // Okay, the nested classes don't get an outer pointer passed,
+// // just an extra param for `x: String`.
+// object O6 extends C({
+//   val x = "".toString
+//   F.byname(x); F.hof(() => x); (new { val xx = x }.xx)
+// })
+
+
+// class C1 extends C({
+//   def x = "".toString
+//   F.byname(x)
+// })
+// class C2 extends C({
+//   lazy val x = "".toString
+//   F.byname(x)
+// })
+// class C3 extends C({
+//   def x = "".toString
+//   F.hof(() => x)
+// })
+// class C4 extends C({
+//   def x = "".toString
+//   object Nested { def xx = x}
+//   Nested.xx
+// })
+
+// // okay, for same reason as O6
+// class C6 extends C({
+//   val x = "".toString
+//   F.byname(x); F.hof(() => x); (new { val xx = x }.xx)
+// })
+
+// class C11(a: Any) {
+//   def this() = {
+//     this({
+//      def x = "".toString
+//       F.byname(x)
+//     })
+//   }
+// }
+
+// // Crashes earlier in lazyVals.
+// // class C12(a: Any) {
+// //   def this() = {
+// //     this({
+// //       lazy val x = "".toString
+// //       F.byname(x)
+// //     })
+// //   }
+// // }
+
+// class C13(a: Any) {
+//   def this() = {
+//     this({
+//       def x = "".toString
+//       F.hof(() => x)
+//     })
+//   }
+// }
+
+// class C14(a: Any) {
+//   def this() = {
+//     this({
+//       def x = "".toString
+//       object Nested { def xx = x}
+//       Nested.xx
+//     })
+//   }
+// }
+
+// class COuter extends C({
+//   def foo = 0
+//   class CInner extends C({foo})
+// })
+
+
+// class CEarly(a: Any) extends {
+//   val early = {def x = "".toString
+//     object Nested { def xx = x}
+//     Nested.xx
+//   }
+// } with AnyRef

--- a/test/macro-annot/src/test/scala/run/companion-symbol-of/B.scala
+++ b/test/macro-annot/src/test/scala/run/companion-symbol-of/B.scala
@@ -1,0 +1,57 @@
+// if this file compiles, then we're good
+package b
+
+import scala.reflect.runtime.universe._
+
+class A[X](implicit val tt: TypeTag[X]) {}
+object B extends A[String]
+
+object C {
+  object D extends A[String]
+}
+
+trait E {
+  object F extends A[String]
+}
+
+class G {
+  object H extends A[String]
+}
+
+object HasX {
+  val x = {
+    object InVal extends A[String]
+    InVal
+    5
+  }
+
+}
+
+trait NeedsEarly {
+ val x: AnyRef
+}
+
+object Early extends {
+  // Drops to this.getClass and is not ok...
+  val x = { object EarlyOk extends A[String]; EarlyOk }
+} with NeedsEarly
+
+
+class DoubleTrouble[X](x: AnyRef)(implicit override val tt: TypeTag[X]) extends A[X]
+
+object DoubleOk extends DoubleTrouble[String]({
+  // Drops to this.getClass and is an issue
+  object InnerTrouble extends A[String];
+  InnerTrouble
+})
+
+object Test extends App {
+  B
+  C.D
+  val e = new E {}; e.F
+  val g = new G; g.H
+
+  locally(HasX.x)
+  // locally(Early.x) TODO sort out VerifyError in Early$.<init>
+  // DoubleOk         TODO sort out VerifyError in DoubleOk$.<init>
+}

--- a/test/macro-annot/src/test/scala/run/companion-symbol-of/C.scala
+++ b/test/macro-annot/src/test/scala/run/companion-symbol-of/C.scala
@@ -1,0 +1,6 @@
+// if this file compiles, then we're good
+package c
+
+class foo(x: Any) extends annotation.StaticAnnotation
+
+@foo(new AnyRef { }) trait A

--- a/test/macro-annot/src/test/scala/run/issue10/Test1.scala
+++ b/test/macro-annot/src/test/scala/run/issue10/Test1.scala
@@ -1,0 +1,5 @@
+package issue10
+
+class X {
+  def foo: Unit = new C()
+}

--- a/test/macro-annot/src/test/scala/run/issue10/Test2.scala
+++ b/test/macro-annot/src/test/scala/run/issue10/Test2.scala
@@ -1,0 +1,3 @@
+package issue10
+
+@pkg.identity @pkg.placebo class C

--- a/test/macro-annot/src/test/scala/run/issue14/Test1.scala
+++ b/test/macro-annot/src/test/scala/run/issue14/Test1.scala
@@ -1,0 +1,8 @@
+package issue14
+
+trait P1[T] { def foo: T }
+object test1 {
+  class PWrapper[T] {
+    @pkg.happytee val self: P1[T] = ???
+  }
+}

--- a/test/macro-annot/src/test/scala/run/issue14/Test2.scala
+++ b/test/macro-annot/src/test/scala/run/issue14/Test2.scala
@@ -1,0 +1,12 @@
+package issue14
+
+trait P2[T] { def foo: T }
+object test2 {
+  class PWrapper[T] {
+    import java.util // make sure that macro expansion logic skips import contexts
+    import java.lang.reflect
+    val dummy1: util.List[_] = ???
+    val dummy2: reflect.Method = ???
+    @pkg.happytee val self: P2[T] = ???
+  }
+}

--- a/test/macro-annot/src/test/scala/run/issue46/Test.scala
+++ b/test/macro-annot/src/test/scala/run/issue46/Test.scala
@@ -1,0 +1,35 @@
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+import scala.collection.immutable.List
+
+@scala.annotation.unchecked.uncheckedVariance
+class ExponentialDummy {
+  def dummy: List[_] = ???
+}

--- a/test/macro-annot/src/test/scala/run/issue48/Test1.scala
+++ b/test/macro-annot/src/test/scala/run/issue48/Test1.scala
@@ -1,0 +1,8 @@
+package issue48
+
+class Test {
+  def foo: Unit = {
+    C();
+    ()
+  }
+}

--- a/test/macro-annot/src/test/scala/run/issue48/Test2.scala
+++ b/test/macro-annot/src/test/scala/run/issue48/Test2.scala
@@ -1,0 +1,3 @@
+package issue48
+
+@pkg.placebo case class C()

--- a/test/macro-annot/src/test/scala/run/issue64/Test.scala
+++ b/test/macro-annot/src/test/scala/run/issue64/Test.scala
@@ -1,0 +1,9 @@
+package issue64
+
+object Test extends App {
+  class ann extends scala.annotation.StaticAnnotation
+  def Foo = ???
+  @ann trait Foo[T]
+  def Bar = ???
+  @pkg.identity trait Bar[T]
+}

--- a/test/macro-annot/src/test/scala/run/module-class/A.scala
+++ b/test/macro-annot/src/test/scala/run/module-class/A.scala
@@ -1,0 +1,13 @@
+package moduleclass
+
+final class Foo[A](implicit f: Factory[A])
+
+object Factory {
+  implicit val factory: Factory[Bar] = ???
+}
+
+trait Factory[A]
+
+object A {
+  val fails = new Foo[Bar]()
+}

--- a/test/macro-annot/src/test/scala/run/module-class/B.scala
+++ b/test/macro-annot/src/test/scala/run/module-class/B.scala
@@ -1,0 +1,6 @@
+package moduleclass
+
+@pkg.placebo
+object Bar
+
+trait Bar

--- a/test/macro-annot/src/test/scala/run/scopes/A.scala
+++ b/test/macro-annot/src/test/scala/run/scopes/A.scala
@@ -1,0 +1,1 @@
+@explorer object A

--- a/test/macro-annot/src/test/scala/run/scopes/B.scala
+++ b/test/macro-annot/src/test/scala/run/scopes/B.scala
@@ -1,0 +1,1 @@
+@explorer object B

--- a/test/macro-annot/src/test/scala/scaladoc/ScaladocSuite.scala
+++ b/test/macro-annot/src/test/scala/scaladoc/ScaladocSuite.scala
@@ -1,0 +1,41 @@
+import org.junit._
+import org.junit.runner._
+import org.junit.runners._
+import Assert._
+import java.io._
+import java.security.Permission
+import scala.tools.nsc.ScalaDoc
+
+@RunWith(classOf[JUnit4])
+class ScaladocSuite {
+  private def virtualizedPopen(body: => Unit): (Int, String) = {
+    val outputStorage = new ByteArrayOutputStream()
+    val outputStream = new PrintStream(outputStorage)
+    case class SystemExitException(exitCode: Int) extends SecurityException
+    val manager = System.getSecurityManager()
+    System.setSecurityManager(new SecurityManager {
+      override def checkPermission(permission: Permission): Unit = ()
+      override def checkPermission(permission: Permission, context: AnyRef): Unit = ()
+      override def checkExit(exitCode: Int): Unit = throw new SystemExitException(exitCode)
+    })
+    try { scala.Console.withOut(outputStream)(scala.Console.withErr(outputStream)(body)); throw new Exception("failed to capture exit code") }
+    catch { case SystemExitException(exitCode) => outputStream.close(); (exitCode, outputStorage.toString) }
+    finally System.setSecurityManager(manager)
+  }
+
+  private def runScaladocTest(testDir: File): Unit = {
+    val sources = testDir.listFiles().filter(_.getName.endsWith(".scala")).map(_.getAbsolutePath).toList
+    val cp = List("-cp", sys.props("sbt.paths.tests.classpath"))
+    val paradise = List("-Ymacro-annotations")
+    val tempDir = File.createTempFile("temp", System.nanoTime.toString); tempDir.delete(); tempDir.mkdir()
+    val output = List("-d", tempDir.getAbsolutePath)
+    val options = cp ++ paradise ++ output ++ sources
+    val (exitCode, stdout) = virtualizedPopen(ScalaDoc.main(options.toArray))
+    if (exitCode != 0) fail("scaladoc has exited with code " + exitCode + ":\n" + stdout)
+  }
+
+  // val resourceDir = new File(System.getProperty("sbt.paths.tests.scaladoc") + File.separatorChar + "resources")
+  // val testDirs = resourceDir.listFiles().filter(_.listFiles().nonEmpty).filter(!_.getName().endsWith("_disabled"))
+  // testDirs.foreach(testDir => test(testDir.getName)(runScaladocTest(testDir)))
+  @Test def simulacrum = runScaladocTest(new File("test/macro-annot/src/test/scala/scaladoc/resources/Simulacrum"))
+}

--- a/test/macro-annot/src/test/scala/scaladoc/resources/Simulacrum/Test.scala
+++ b/test/macro-annot/src/test/scala/scaladoc/resources/Simulacrum/Test.scala
@@ -1,0 +1,16 @@
+import scala.language.higherKinds
+
+/**
+ */
+@simulacrum trait Applicative[F[_]] {
+  def pure[A](x: A): F[A]
+}
+
+class TestSimulacrum {
+  @simulacrum def no1 = ???
+  /** 1 */ @simulacrum def yes1 = ???
+
+  class ann extends scala.annotation.StaticAnnotation
+  @ann def no2 = ???
+  /** 2 */ @ann def yes2 = ???
+}


### PR DESCRIPTION
Importing from scalamacros/paradise, since xeno-by has stepped down
as maintainer. Since the eco-system has come to rely on macro paradise,
we acknowledge the status quo by integrating paradise.

HOWEVER, please note that support for macro annotations remains
EXPERIMENTAL, and support for them will be much more restricted
in Scala 3. We will try to provide a preview of this subset in 2.14.

Most notably, we do not intend to let macro annotations
synthesize code that is visible during synthesis. Concretely,
you'd have to first compile the macros, then the code that
uses them as annotations, and finally the code that needs to
see the code synthesized by the annotation macros. This is
the same workflow as usual with code generation.

The tests are included as a new project (macroAnnot),
which uses the quick compiler as a scalaInstance to compile
the tests, so that we could integrate the test suite more easily.

Finally, note the diff re: `List toStream flatMap headOption`:
its behavior changed with the new collections.