### PR TITLE
Avoid needless LUB of the cases after patmat translation

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -61,7 +61,10 @@ trait PatternMatching extends Transform
         // setType origTp intended for CPS -- TODO: is it necessary?
         val translated = translator.translateMatch(treeCopy.Match(tree, transform(sel), transformTrees(cases).asInstanceOf[List[CaseDef]]))
         try {
-          localTyper.typed(translated) setType origTp
+          // Keep 2.12 behaviour of using wildcard expected type, recomputing the LUB, then throwing it away for the continuations plugins
+          // but for the rest of us pass in top as the expected type to avoid waste.
+          val pt = if (origTp <:< definitions.AnyTpe) definitions.AnyTpe else WildcardType
+          localTyper.typed(translated, definitions.AnyTpe) setType origTp
         } catch {
           case x: (Types#TypeError) =>
             // TODO: this should never happen; error should've been reported during type checking


### PR DESCRIPTION
I've restricted the change to the non-CPS world, where we can't assume
that Any is a top type.

Fixes scala/bug#7611