### PR TITLE
Make dropWhile in Stream and LazyList stack-safe

### DIFF
--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -54,15 +54,17 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeq
 
   // Optimized version of `drop` that avoids copying
   override def drop(n: Int): C = {
-    @tailrec def loop(n: Int, s: LinearSeq[A]): C =
-      if (n <= 0 || s.isEmpty) s.asInstanceOf[C]
-      // implicit contract to guarantee success of asInstanceOf:
-      //   (1) coll is of type C[A]
-      //   (2) The tail of a LinearSeq is of the same type as the type of the sequence itself
-      // it's surprisingly tricky/ugly to turn this into actual types, so we
-      // leave this contract implicit.
+    @tailrec def loop(n: Int, s: C): C =
+      if (n <= 0 || s.isEmpty) s
       else loop(n - 1, s.tail)
     loop(n, coll)
+  }
+
+  override def dropWhile(p: A => Boolean): C = {
+    @tailrec def loop(s: C): C =
+      if (s.nonEmpty && p(s.head)) loop(s.tail)
+      else s
+    loop(coll)
   }
 
   // `apply` is defined in terms of `drop`, which is in turn defined in

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -282,15 +282,6 @@ sealed abstract class List[+A]
     b.toList
   }
 
-  @inline final override def dropWhile(p: A => Boolean): List[A] = {
-    @tailrec
-    def loop(xs: List[A]): List[A] =
-      if (xs.isEmpty || !p(xs.head)) xs
-      else loop(xs.tail)
-
-    loop(this)
-  }
-
   @inline final override def span(p: A => Boolean): (List[A], List[A]) = {
     val b = new ListBuffer[A]
     var these = this

--- a/test/files/run/lazylist-dropwhile-stack-safe.check
+++ b/test/files/run/lazylist-dropwhile-stack-safe.check
@@ -1,0 +1,1 @@
+warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details

--- a/test/files/run/lazylist-dropwhile-stack-safe.scala
+++ b/test/files/run/lazylist-dropwhile-stack-safe.scala
@@ -1,0 +1,10 @@
+object Test extends App {
+  // Should not overflow the stack
+  val lazyList = Iterator.iterate(LazyList.from(0))(_.dropWhile(_ => false)).drop(10000).next
+  lazyList.head
+  lazyList.tail.head
+
+  val stream = Iterator.iterate(Stream.from(0))(_.dropWhile(_ => false)).drop(10000).next
+  stream.head // superfluous, because `head` should be eager
+  stream.tail.head
+}


### PR DESCRIPTION
Addresses at least part of @SethTisue's concern in scala/collection-strawman#197.