### PR TITLE
Support old info method in limiting reporter

### DIFF
--- a/src/compiler/scala/tools/nsc/reporters/LimitingReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/LimitingReporter.scala
@@ -13,4 +13,14 @@ class LimitingReporter(settings: Settings, override protected val delegate: Inte
       case WARNING => warningCount < settings.maxwarns.value
       case _       => true
     }
+  // work around fractured API to support `reporters.Reporter.info`
+  override protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = delegate match {
+    case r: Reporter =>
+      severity match {
+        case ERROR   => r.error(pos, msg)
+        case WARNING => r.warning(pos, msg)
+        case _       => if (force) r.echo(pos, msg) else r.info(pos, msg, force = false)
+      }
+    case _           => super.info0(pos, msg, severity, force)
+  }
 }

--- a/src/reflect/scala/reflect/internal/Reporting.scala
+++ b/src/reflect/scala/reflect/internal/Reporting.scala
@@ -126,7 +126,7 @@ trait ForwardingReporter extends Reporter {
   protected val delegate: Reporter
 
   /* Always throws `UnsupportedOperationException`. */
-  protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Nothing =
+  protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit =
     throw new UnsupportedOperationException(s"$msg ($pos)")
 
   override def echo(pos: Position, msg: String)    = delegate.echo(pos, msg)

--- a/test/junit/scala/tools/nsc/reporters/ConsoleReporterTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/ConsoleReporterTest.scala
@@ -197,4 +197,11 @@ class ConsoleReporterTest {
     testHelper(posWithSource, msg = "Testing display for maxerrs to pass", severity = "error: ")(filter.error(_, "Testing display for maxerrs to pass"))
     testHelper(msg = "")(filter.error(_, "Testing display for maxerrs to fail"))
   }
+
+  @Test
+  def filteredInfoTest(): Unit = {
+    val reporter = new LimitingReporter(new Settings, new StoreReporter)
+    // test obsolete API, make sure it doesn't throw
+    reporter.info(NoPosition, "goodbye, cruel world", force = false)
+  }
 }


### PR DESCRIPTION
The forwarding reporter knows the new API, so let
limiting reporter decode calls to info0 via info.

`info0` is protected and can't be forwarded.

Fixes scala/bug#10869