### PR TITLE
Improve efficiency of scope lookup

### DIFF
--- a/test/files/pos/constructor-pattern-name-class.scala
+++ b/test/files/pos/constructor-pattern-name-class.scala
@@ -1,0 +1,10 @@
+case class ClassDef(a: Any)
+
+trait T {
+  def ClassDef(a: Any): Any
+}
+class C extends T {
+  def ClassDef(a: Any) = a match {
+    case t @ ClassDef(_) => t // when typing constructor pattern, we skip method symbols
+  }
+}


### PR DESCRIPTION
  - Avoid indirection through Iterator in Context.lookup

Fixes scala/scala-dev#502