### PR TITLE
Avoid allocation of Typer within typing transformers

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/TypingTransformers.scala
+++ b/src/compiler/scala/tools/nsc/transform/TypingTransformers.scala
@@ -25,10 +25,10 @@ trait TypingTransformers {
     override final def atOwner[A](owner: Symbol)(trans: => A): A = atOwner(curTree, owner)(trans)
 
     def atOwner[A](tree: Tree, owner: Symbol)(trans: => A): A = {
-      val savedLocalTyper = localTyper
-      localTyper = localTyper.atOwner(tree, if (owner.isModuleNotMethod) owner.moduleClass else owner)
+      val savedContext = localTyper.context
+      localTyper.context = localTyper.context.make(tree, if (owner.isModuleNotMethod) owner.moduleClass else owner)
       val result = super.atOwner(owner)(trans)
-      localTyper = savedLocalTyper
+      localTyper.context = savedContext
       result
     }
 


### PR DESCRIPTION
Rather than allocating a new Typer each time, we can just
mutate/restore `Typer.context`.

References scala/scala-dev#501