### PR TITLE
Improve efficiency of dead code checks

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -413,6 +413,9 @@ trait Contexts { self: Analyzer =>
     @inline final def withinSecondTry[T](op: => T): T                      = withMode(enabled = SecondTry)(op)
     @inline final def withinPatAlternative[T](op: => T): T                 = withMode(enabled = PatternAlternative)(op)
 
+    @inline final def withSuppressDeadArgWarning[T](suppress: Boolean)(op: => T): T =
+      if (suppress) withMode(enabled = SuppressDeadArgWarning)(op) else withMode(disabled = SuppressDeadArgWarning)(op)
+
     /** TypeConstructorAllowed is enabled when we are typing a higher-kinded type.
      *  adapt should then check kind-arity based on the prototypical type's kind
      *  arity. Type arguments should not be inferred.
@@ -1590,6 +1593,9 @@ object ContextMode {
   /** Are unapplied type constructors allowed here? Formerly HKmode. */
   final val TypeConstructorAllowed: ContextMode   = 1 << 16
 
+  /** Should a dead code warning be issued for a Nothing-typed argument to the current application. */
+  final val SuppressDeadArgWarning: ContextMode   = 1 << 17
+
   /** TODO: The "sticky modes" are EXPRmode, PATTERNmode, TYPEmode.
    *  To mimic the sticky mode behavior, when captain stickyfingers
    *  comes around we need to propagate those modes but forget the other
@@ -1613,7 +1619,8 @@ object ContextMode {
     StarPatterns           -> "StarPatterns",
     SuperInit              -> "SuperInit",
     SecondTry              -> "SecondTry",
-    TypeConstructorAllowed -> "TypeConstructorAllowed"
+    TypeConstructorAllowed -> "TypeConstructorAllowed",
+    SuppressDeadArgWarning -> "SuppressDeadArgWarning"
   )
 }
 

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -466,6 +466,22 @@ trait TypeDiagnostics {
     }
   }
 
+  object checkDead {
+    private def treeOK(tree: Tree) = {
+      val isLabelDef = tree match { case _: LabelDef => true; case _ => false}
+      tree.tpe != null && tree.tpe.typeSymbol == NothingClass && !isLabelDef
+    }
+
+    def apply(context: Context, tree: Tree): Tree = {
+      if (settings.warnDeadCode && context.unit.exists && treeOK(tree) && !context.contextMode.inAny(ContextMode.SuppressDeadArgWarning))
+        context.warning(tree.pos, "dead code following this construct")
+      tree
+    }
+
+    // The checkDead call from typedArg is more selective.
+    def inMode(context: Context, mode: Mode, tree: Tree): Tree = if (mode.typingMonoExprByValue) apply(context, tree) else tree
+  }
+
   trait TyperDiagnostics {
     self: Typer =>
 
@@ -712,36 +728,6 @@ trait TypeDiagnostics {
           case "both"   => run(checkMacroExpandee)(body) ; run(skipMacroCall)(body)
         }
       }
-    }
-
-    object checkDead {
-      private val exprStack: mutable.Stack[Symbol] = mutable.Stack(NoSymbol)
-      // The method being applied to `tree` when `apply` is called.
-      private def expr = exprStack.top
-
-      private def exprOK =
-        (expr != Object_synchronized) &&
-        !(expr.isLabel && treeInfo.isSynthCaseSymbol(expr)) // it's okay to jump to matchEnd (or another case) with an argument of type nothing
-
-      private def treeOK(tree: Tree) = {
-        val isLabelDef = tree match { case _: LabelDef => true; case _ => false}
-        tree.tpe != null && tree.tpe.typeSymbol == NothingClass && !isLabelDef
-      }
-
-      @inline def updateExpr[A](fn: Tree)(f: => A) = {
-        if (fn.symbol != null && fn.symbol.isMethod && !fn.symbol.isConstructor) {
-          exprStack push fn.symbol
-          try f finally exprStack.pop()
-        } else f
-      }
-      def apply(tree: Tree): Tree = {
-        if (settings.warnDeadCode && context.unit.exists && treeOK(tree) && exprOK)
-          context.warning(tree.pos, "dead code following this construct")
-        tree
-      }
-
-      // The checkDead call from typedArg is more selective.
-      def inMode(mode: Mode, tree: Tree): Tree = if (mode.typingMonoExprByValue) apply(tree) else tree
     }
 
     private def symWasOverloaded(sym: Symbol) = sym.owner.isClass && sym.owner.info.member(sym.name).isOverloaded


### PR DESCRIPTION
  - Move the checkDead module out of Typer
  - Use a new bit in ContextMode to track when to suppress
    the warning, rather than maintaining the stack of the
    symbols of enclosing applications
  - Only do any of this when under -Ywarn-dead code

References scala/scala-dev#501