### PR TITLE
CommandLineParser improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -568,7 +568,7 @@ lazy val partest = configureAsSubproject(project)
   )
 
 lazy val bench = project.in(file("test") / "benchmarks")
-  .dependsOn(library)
+  .dependsOn(library, compiler)
   .settings(instanceSettings)
   .settings(disableDocs)
   .settings(disablePublishing)

--- a/test/benchmarks/src/main/scala/scala/tools/cmd/CommandLineParserBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/tools/cmd/CommandLineParserBenchmark.scala
@@ -1,0 +1,35 @@
+
+package scala.tools.cmd
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class CommandLineParserBenchmark {
+
+  import CommandLineParser.tokenize
+
+  @Param(Array("1000", "10000", "100000"))
+  var argCount: Int = _
+  var line: String = _
+  var quotyline: String = _
+  var embedded: String = _
+
+  @Setup(Level.Trial) def init(): Unit = {
+    line = List.tabulate(argCount)(n => s"arg$n").mkString(" ")
+    val q = "\""
+    quotyline = List.tabulate(argCount)(n => s"${q}arg${n}${q}").mkString(" ")
+    embedded  = List.tabulate(argCount)(n => s"${n}${q}arg${q}${n}").mkString(" ")
+  }
+  @Benchmark def parsingBenchmark              = tokenize(line)
+  @Benchmark def quoteUnquoteParsingBenchmark  = tokenize(quotyline)
+  @Benchmark def embeddedQuoteParsingBenchmark = tokenize(embedded)
+}

--- a/test/junit/scala/tools/cmd/CommandLineParserTest.scala
+++ b/test/junit/scala/tools/cmd/CommandLineParserTest.scala
@@ -1,0 +1,45 @@
+package scala.tools.cmd
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import scala.tools.testing.AssertUtil.assertThrows
+
+@RunWith(classOf[JUnit4])
+class CommandLineParserTest {
+  import CommandLineParser.{tokenize, ParseException}
+
+  @Test
+  def parserTokenizes(): Unit = {
+    assertEquals(Nil, tokenize(""))
+    assertEquals(List("x"), tokenize("x"))
+    assertEquals(List("x"), tokenize(" x "))
+    assertEquals(List("x","y"), tokenize("x y"))
+    assertEquals(List("x","y","z"), tokenize("x y z"))
+  }
+  @Test
+  def parserTrims(): Unit = {
+    assertEquals(Nil, tokenize(" "))
+    assertEquals(List("x"), tokenize(" x "))
+    assertEquals(List("x"), tokenize("\nx\n"))
+    assertEquals(List("x","y","z"), tokenize(" x y z "))
+  }
+  @Test
+  def parserQuotes(): Unit = {
+    assertEquals(List("x"), tokenize("'x'"))
+    assertEquals(List("x"), tokenize(""""x""""))
+    assertEquals(List("x","y","z"), tokenize("x 'y' z"))
+    assertEquals(List("x"," y ","z"), tokenize("x ' y ' z"))
+    assertEquals(List("x","y","z"), tokenize("""x "y" z"""))
+    assertEquals(List("x"," y ","z"), tokenize("""x " y " z"""))
+    // interior quotes
+    assertEquals(List("x y z"), tokenize("x' y 'z"))   // was assertEquals(List("x'","y","'z"), tokenize("x' y 'z"))
+    assertEquals(List("x\ny\nz"), tokenize("x'\ny\n'z"))
+    assertEquals(List("x'y'z"), tokenize("""x"'y'"z"""))
+    assertEquals(List("abcxyz"), tokenize(""""abc"xyz"""))
+    // missing quotes
+    assertThrows[ParseException](tokenize(""""x"""))         // was assertEquals(List("\"x"), tokenize(""""x"""))
+    assertThrows[ParseException](tokenize("""x'"""))
+  }
+}


### PR DESCRIPTION
Tokenizing used to snip the line and knit the args,
this commit denits the deknitting.

Adds a benchmark showing linear behavior and a unit test
to show correctness.

Departing from the previous notion of correctness,
internal quotes are respected. `"abc"xyz` is `abcxyz`.

"It is imperative that this be fixed!"