### PR TITLE
check system property in a Scala.js-friendly way

### DIFF
--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -126,8 +126,10 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   */
 object Map extends MapFactory[Map] {
 
+  // getenv not getProperty for Scala.js friendliness.
+  // TODO remove before 2.13.0-RC1? see scala/collection-strawman#572
   private final val useBaseline: Boolean =
-    scala.sys.props.get("scala.collection.immutable.useBaseline").contains("true")
+    System.getenv("SCALA_COLLECTION_IMMUTABLE_USE_BASELINE") == "true"
 
   @SerialVersionUID(3L)
   class WithDefault[K, +V](val underlying: Map[K, V], val defaultValue: K => V)

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -61,8 +61,10 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   */
 object Set extends IterableFactory[Set] {
 
+  // getenv not getProperty for Scala.js friendliness.
+  // TODO remove before 2.13.0-RC1? see scala/collection-strawman#572
   private final val useBaseline: Boolean =
-    scala.sys.props.get("scala.collection.immutable.useBaseline").contains("true")
+    System.getenv("SCALA_COLLECTION_IMMUTABLE_USE_BASELINE") == "true"
 
   def empty[A]: Set[A] = EmptySet.asInstanceOf[Set[A]]
 


### PR DESCRIPTION
avoids pulling in sys.Properties and all its dependencies,
as requested by Sébastien on Gitter

this is also friendlier to eventual modularization of the
standard library; scala.sys is on its way out the door