### PR TITLE
don't let Travis-CI fail on every PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 
 
 before_script:
-  - (cd admin && ./init.sh)
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then (cd admin && ./init.sh); fi'
 
 stages:
   - name: build # also builds the spec using jekyll


### PR DESCRIPTION
in order to test #6621 we needed to enable Travis-CI on pull
requests, but without this change, every PR failed