### PR TITLE
Merge 2.12.x to 2.13.x (May 11, 2018) [ci: last-only]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 
 
 before_script:
-  - (cd admin && ./init.sh)
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then (cd admin && ./init.sh); fi'
 
 stages:
   - name: build # also builds the spec using jekyll

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1436,8 +1436,8 @@ trait Namers extends MethodSynthesis {
      * typechecked, the corresponding param would not yet have the "defaultparam"
      * flag.
      */
-    private def addDefaultGetters(meth: Symbol, ddef: DefDef, vparamss: List[List[ValDef]], tparams: List[TypeDef], overridden: Symbol) {
-      val DefDef(_, _, rtparams0, rvparamss0, _, _) = resetAttrs(ddef.duplicate)
+    private def addDefaultGetters(meth: Symbol, ddef: DefDef, vparamss: List[List[ValDef]], tparams: List[TypeDef], overridden: Symbol): Unit = {
+      val DefDef(_, _, rtparams0, rvparamss0, _, _) = resetAttrs(deriveDefDef(ddef)(_ => EmptyTree).duplicate)
       // having defs here is important to make sure that there's no sneaky tree sharing
       // in methods with multiple default parameters
       def rtparams = rtparams0.map(_.duplicate)
@@ -1523,7 +1523,7 @@ trait Namers extends MethodSynthesis {
                     return // fix #3649 (prevent crash in erroneous source code)
                 }
               }
-              val ClassDef(_, _, rtparams, _) = resetAttrs(cdef.duplicate)
+              val ClassDef(_, _, rtparams, _) = resetAttrs(deriveClassDef(cdef)(_ => Template(Nil, noSelfType, Nil)).duplicate)
               defTparams = rtparams.map(rt => copyTypeDef(rt)(mods = rt.mods &~ (COVARIANT | CONTRAVARIANT)))
               nmr
             }

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -60,7 +60,8 @@ trait Unapplies extends ast.TreeDSL {
   }
 
   private def constrTparamsInvariant(cdef: ClassDef): List[TypeDef] = {
-    val ClassDef(_, _, tparams, _) = resetAttrs(cdef.duplicate)
+    val prunedClassDef = deriveClassDef(cdef)(tmpl => Template(Nil, noSelfType, Nil))
+    val ClassDef(_, _, tparams, _) = resetAttrs(prunedClassDef.duplicate)
     val tparamsInvariant = tparams.map(tparam => copyTypeDef(tparam)(mods = tparam.mods &~ (COVARIANT | CONTRAVARIANT)))
     tparamsInvariant
   }


### PR DESCRIPTION
only one merge conflict which was trivial

motivation is to get #6624 onto 2.13.x pronto to avoid
spurious Travis-CI PR validation failures

* ae32078850 - (origin/2.12.x) Merge pull request #6624 from SethTisue/allow-travis-pr-validation (5 minutes ago) <Seth Tisue>
* 3237e03fad - (2.12.x) Merge pull request #6560 from retronym/topic/reset-duplicate (25 hours ago) <Lukas Rytz>
* 7844a54169 - Merge pull request #6529 from viktorklang/wip-10810-√ (32 hours ago) <Seth Tisue>