### PR TITLE
Add -Xlint:non-local-return, to warn on non-local returns

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -103,6 +103,7 @@ trait Warnings {
     val StarsAlign             = LintWarning("stars-align",               "Pattern sequence wildcard must align with sequence component.")
     val Constant               = LintWarning("constant",                  "Evaluation of a constant arithmetic expression results in an error.")
     val Unused                 = LintWarning("unused",                    "Enable -Ywarn-unused:imports,privates,locals,implicits.")
+    val NonlocalReturn         = LintWarning("nonlocal-return",           "A return statement used an exception for flow control.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
   }
@@ -126,6 +127,7 @@ trait Warnings {
   def warnStarsAlign             = lint contains StarsAlign
   def warnConstant               = lint contains Constant
   def lintUnused                 = lint contains Unused
+  def warnNonlocalReturn         = lint contains NonlocalReturn
 
   // Lint warnings that are currently -Y, but deprecated in that usage
   @deprecated("Use warnAdaptedArgs", since="2.11.2")

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -623,6 +623,8 @@ abstract class UnCurry extends InfoTransform
           applyUnary()
         case ret @ Return(expr) if isNonLocalReturn(ret) =>
           log(s"non-local return from ${currentOwner.enclMethod} to ${ret.symbol}")
+          if (settings.warnNonlocalReturn)
+            reporter.warning(ret.pos, s"return statement uses an exception to pass control to the caller of the enclosing named ${ret.symbol}")
           atPos(ret.pos)(nonLocalReturnThrow(expr, ret.symbol))
         case TypeTree() =>
           tree

--- a/test/files/neg/t10820-warn.check
+++ b/test/files/neg/t10820-warn.check
@@ -1,0 +1,6 @@
+t10820-warn.scala:11: warning: return statement uses an exception to pass control to the caller of the enclosing named method result
+  def result: Option[Int] = Try(0/0).recoverWith { case _ => return Some(-1) }.toOption
+                                                             ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t10820-warn.flags
+++ b/test/files/neg/t10820-warn.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xlint:nonlocal-return

--- a/test/files/neg/t10820-warn.scala
+++ b/test/files/neg/t10820-warn.scala
@@ -1,0 +1,12 @@
+
+import util.Try
+
+trait Test {
+
+  /*
+   * Inspired by
+   * https://stackoverflow.com/questions/50297478/why-scala-allows-return-from-recoverwith
+   * "I actually saw the post Don't Use Return in Scala long ago never paid attention."
+   */
+  def result: Option[Int] = Try(0/0).recoverWith { case _ => return Some(-1) }.toOption
+}


### PR DESCRIPTION
Don't just log it, Xlint it!

Mention where control is returning to.