### PR TITLE
Prefer java Math methods

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1562,7 +1562,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       addUnit(unit)
 
       if (firstPhase ne null) { // we might get here during initialization, is a source is newer than the binary
-        val maxId = math.max(globalPhase.id, typerPhase.id)
+        val maxId = Math.max(globalPhase.id, typerPhase.id)
         firstPhase.iterator takeWhile (_.id < maxId) foreach (ph =>
           enteringPhase(ph)(ph.asInstanceOf[GlobalPhase] applyPhase unit))
         refreshProgress()

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -501,10 +501,10 @@ abstract class BackendUtils extends PerRunInit {
           insn match {
             case v: VarInsnNode =>
               val longSize = if (isSize2LoadOrStore(v.getOpcode)) 1 else 0
-              maxLocals = math.max(maxLocals, v.`var` + longSize + 1) // + 1 because local numbers are 0-based
+              maxLocals = Math.max(maxLocals, v.`var` + longSize + 1) // + 1 because local numbers are 0-based
 
             case i: IincInsnNode =>
-              maxLocals = math.max(maxLocals, i.`var` + 1)
+              maxLocals = Math.max(maxLocals, i.`var` + 1)
 
             case _ =>
           }

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -540,7 +540,7 @@ abstract class Inliner {
       callsiteStackHeight + stackSlotForNullCheck
     }
 
-    callsiteMethod.maxStack = math.max(callsiteMethod.maxStack, math.max(stackHeightAtNullCheck, maxStackOfInlinedCode))
+    callsiteMethod.maxStack = Math.max(callsiteMethod.maxStack, Math.max(stackHeightAtNullCheck, maxStackOfInlinedCode))
 
     val added = addIndyLambdaImplMethod(callsiteClass.internalName, targetHandles)
     undo { removeIndyLambdaImplMethod(callsiteClass.internalName, added) }

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
@@ -510,7 +510,7 @@ abstract class LocalOpt {
     while (itr.hasNext) {
       val insn = itr.next()
       val isLive = frames(i) != null
-      if (isLive) maxStack = math.max(maxStack, frames(i).getStackSize)
+      if (isLive) maxStack = Math.max(maxStack, frames(i).getStackSize)
 
       insn match {
         case l: LabelNode =>
@@ -519,10 +519,10 @@ abstract class LocalOpt {
 
         case v: VarInsnNode if isLive =>
           val longSize = if (isSize2LoadOrStore(v.getOpcode)) 1 else 0
-          maxLocals = math.max(maxLocals, v.`var` + longSize + 1) // + 1 because local numbers are 0-based
+          maxLocals = Math.max(maxLocals, v.`var` + longSize + 1) // + 1 because local numbers are 0-based
 
         case i: IincInsnNode if isLive =>
-          maxLocals = math.max(maxLocals, i.`var` + 1)
+          maxLocals = Math.max(maxLocals, i.`var` + 1)
 
         case _: LineNumberNode =>
         case _ =>

--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -295,7 +295,7 @@ trait Logic extends Debugging  {
     // to govern how much time we spend analyzing matches for unreachability/exhaustivity
     object AnalysisBudget {
       val maxDPLLdepth = global.settings.YpatmatExhaustdepth.value
-      val maxFormulaSize = 100 * math.min(Int.MaxValue / 100, maxDPLLdepth)
+      val maxFormulaSize = 100 * Math.min(Int.MaxValue / 100, maxDPLLdepth)
 
       private def advice =
         s"Please try with scalac -Ypatmat-exhaust-depth ${maxDPLLdepth * 2} or -Ypatmat-exhaust-depth off."

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -485,7 +485,7 @@ trait MatchTranslation {
       def treeMakers(binder: Symbol, binderKnownNonNull: Boolean, pos: Position): List[TreeMaker] = {
         val paramAccessors = expectedExtractedType.typeSymbol.constrParamAccessors
         val numParams = paramAccessors.length
-        def paramAccessorAt(subPatIndex: Int) = paramAccessors(math.min(subPatIndex, numParams - 1))
+        def paramAccessorAt(subPatIndex: Int) = paramAccessors(Math.min(subPatIndex, numParams - 1))
         // binders corresponding to mutable fields should be stored (scala/bug#5158, scala/bug#6070)
         // make an exception for classes under the scala package as they should be well-behaved,
         // to optimize matching on List

--- a/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
@@ -57,7 +57,7 @@ trait Solving extends Logic {
       val symForVar: Map[Int, Sym] = variableForSymbol.map(_.swap)
 
       val relevantVars =
-        symForVar.keysIterator().map(math.abs).to(immutable.BitSet)
+        symForVar.keysIterator().map(Math.abs).to(immutable.BitSet)
 
       def lit(sym: Sym): Lit = Lit(variableForSymbol(sym))
 

--- a/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
@@ -189,7 +189,7 @@ abstract class ConstantFolder {
   private def foldBinop(op: Name, x: Constant, y: Constant): Constant = {
     val optag =
       if (x.tag == y.tag) x.tag
-      else if (x.isNumeric && y.isNumeric) math.max(x.tag, y.tag)
+      else if (x.isNumeric && y.isNumeric) Math.max(x.tag, y.tag)
       else NoTag
 
     optag match {

--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -61,7 +61,7 @@ trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self =>
                                         (implicit ord: Ordering[B]): SearchResult = {
     if (to == from) InsertionPoint(from) else {
       val idx = from+(to-from-1)/2
-      math.signum(ord.compare(elem, apply(idx))) match {
+      Math.signum(ord.compare(elem, apply(idx))) match {
         case -1 => binarySearch(elem, from, idx)(ord)
         case  1 => binarySearch(elem, idx + 1, to)(ord)
         case  _ => Found(idx)

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -660,7 +660,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
   def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): xs.type = {
     val it = iterator()
     var i = start
-    val end = start + math.min(len, xs.length - start)
+    val end = start + Math.min(len, xs.length - start)
     while (i < end && it.hasNext) {
       xs(i) = it.next()
       i += 1

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -329,7 +329,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
   }
 
   def indexWhere(p: A => Boolean, from: Int = 0): Int = {
-    var i = math.max(from, 0)
+    var i = Math.max(from, 0)
     drop(from)
     while (hasNext) {
       if (p(next())) return i

--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -147,7 +147,7 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeq
 
 
   override def indexWhere(p: A => Boolean, from: Int): Int = {
-    var i = math.max(from, 0)
+    var i = Math.max(from, 0)
     var these: LinearSeq[A] = this drop from
     while (these.nonEmpty) {
       if (p(these.head))

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -358,7 +358,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
       val l = knownSize
       val tl = that.knownSize
       if (l >= 0 && tl >= 0) {
-        val clippedFrom = math.max(0, from)
+        val clippedFrom = Math.max(0, from)
         if (from > l) -1
         else if (tl < 1) clippedFrom
         else if (l < tl) -1
@@ -387,7 +387,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   def lastIndexOfSlice[B >: A](that: Seq[B], end: Int = length - 1): Int = {
     val l = length
     val tl = that.length
-    val clippedL = math.min(l-tl, end)
+    val clippedL = Math.min(l-tl, end)
 
     if (end < 0) -1
     else if (tl < 1) clippedL

--- a/src/library/scala/collection/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSeqOps.scala
@@ -61,7 +61,7 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
   override def padTo[B >: A](len: Int, elem: B): CC[B] = {
     val b = iterableFactory.newBuilder[B]()
     val L = size
-    b.sizeHint(math.max(L, len))
+    b.sizeHint(Math.max(L, len))
     var diff = len - L
     b ++= this
     while (diff > 0) {

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -164,7 +164,7 @@ object HashMap extends MapFactory[HashMap] {
     * @param size the maximum size of the collection to be generated
     * @return the maximum buffer size
     */
-  @`inline` private def bufferSize(size: Int): Int = math.min(size + 6, 32 * 7)
+  @`inline` private def bufferSize(size: Int): Int = Math.min(size + 6, 32 * 7)
 
   /**
     * In many internal operations the empty map is represented as null for performance reasons. This method converts

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -246,8 +246,8 @@ sealed class NumericRange[T](
         // Try to compute sum with reasonable accuracy, avoiding over/underflow
         val numAsIntegral = num.asInstanceOf[Integral[B]]
         import numAsIntegral._
-        val a = math.abs(head.toDouble)
-        val b = math.abs(last.toDouble)
+        val a = Math.abs(head.toDouble)
+        val b = Math.abs(last.toDouble)
         val two = num fromInt 2
         val nre = num fromInt size
         if (a > 1e38 || b > 1e38) nre * ((head / two) + (last / two))  // Compute in parts to avoid Infinity if possible

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -122,9 +122,9 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     else new TreeMap(RB.slice(tree, from, until))
   }
 
-  override def dropRight(n: Int): TreeMap[K, V] = take(size - math.max(n, 0))
+  override def dropRight(n: Int): TreeMap[K, V] = take(size - Math.max(n, 0))
 
-  override def takeRight(n: Int): TreeMap[K, V] = drop(size - math.max(n, 0))
+  override def takeRight(n: Int): TreeMap[K, V] = drop(size - Math.max(n, 0))
 
   private[this] def countWhile(p: ((K, V)) => Boolean): Int = {
     var result = 0

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -69,9 +69,9 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
     else newSet(RB.slice(tree, from, until))
   }
 
-  override def dropRight(n: Int): TreeSet[A] = take(size - math.max(n, 0))
+  override def dropRight(n: Int): TreeSet[A] = take(size - Math.max(n, 0))
 
-  override def takeRight(n: Int): TreeSet[A] = drop(size - math.max(n, 0))
+  override def takeRight(n: Int): TreeSet[A] = drop(size - Math.max(n, 0))
 
   private[this] def countWhile(p: A => Boolean): Int = {
     var result = 0

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -563,7 +563,7 @@ class VectorIterator[+A](_startIndex: Int, endIndex: Int)
   private var blockIndex: Int = _startIndex & ~31
   private var lo: Int = _startIndex & 31
 
-  private var endLo = math.min(endIndex - blockIndex, 32)
+  private var endLo = Math.min(endIndex - blockIndex, 32)
 
   def hasNext = _hasNext
 
@@ -581,7 +581,7 @@ class VectorIterator[+A](_startIndex: Int, endIndex: Int)
         gotoNextBlockStart(newBlockIndex, blockIndex ^ newBlockIndex)
 
         blockIndex = newBlockIndex
-        endLo = math.min(endIndex - blockIndex, 32)
+        endLo = Math.min(endIndex - blockIndex, 32)
         lo = 0
       } else {
         _hasNext = false
@@ -1006,7 +1006,7 @@ private[immutable] trait VectorPointer[T] {
 
     private[immutable] final def copyRange(array: Array[AnyRef], oldLeft: Int, newLeft: Int) = {
       val elems = new Array[AnyRef](32)
-      java.lang.System.arraycopy(array, oldLeft, elems, newLeft, 32 - math.max(newLeft, oldLeft))
+      java.lang.System.arraycopy(array, oldLeft, elems, newLeft, 32 - Math.max(newLeft, oldLeft))
       elems
     }
 

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -494,7 +494,7 @@ object AnyRefMap {
    *  Equivalent to but more efficient than `AnyRefMap((keys zip values): _*)`.
    */
   def fromZip[K <: AnyRef, V](keys: Array[K], values: Array[V]): AnyRefMap[K, V] = {
-    val sz = math.min(keys.length, values.length)
+    val sz = Math.min(keys.length, values.length)
     val arm = new AnyRefMap[K, V](sz * 2)
     var i = 0
     while (i < sz) { arm(keys(i)) = values(i); i += 1 }
@@ -506,7 +506,7 @@ object AnyRefMap {
    *  Equivalent to but more efficient than `AnyRefMap((keys zip values): _*)`.
    */
   def fromZip[K <: AnyRef, V](keys: Iterable[K], values: Iterable[V]): AnyRefMap[K, V] = {
-    val sz = math.min(keys.size, values.size)
+    val sz = Math.min(keys.size, values.size)
     val arm = new AnyRefMap[K, V](sz * 2)
     val ki = keys.iterator()
     val vi = values.iterator()

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -211,7 +211,7 @@ object RefArrayUtils {
     // Use a Long to prevent overflows
     val arrayLength: Long = array.length
     def growArray = {
-      var newSize: Long = math.max(arrayLength * 2, 8)
+      var newSize: Long = Math.max(arrayLength * 2, 8)
       while (n > newSize)
         newSize = newSize * 2
       // Clamp newSize to Int.MaxValue

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -30,7 +30,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
     with StrictOptimizedIterableOps[Int, Set, BitSet]
     with Serializable {
 
-  def this(initSize: Int) = this(new Array[Long](math.max((initSize + 63) >> 6, 1)))
+  def this(initSize: Int) = this(new Array[Long](Math.max((initSize + 63) >> 6, 1)))
 
   def this() = this(0)
 
@@ -76,7 +76,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
     require(idx < MaxSize)
     if (idx >= nwords) {
       var newlen = nwords
-      while (idx >= newlen) newlen = math.min(newlen * 2, MaxSize)
+      while (idx >= newlen) newlen = Math.min(newlen * 2, MaxSize)
       val elems1 = new Array[Long](newlen)
       Array.copy(elems, 0, elems1, 0, nwords)
       elems = elems1

--- a/src/library/scala/collection/mutable/Buffer.scala
+++ b/src/library/scala/collection/mutable/Buffer.scala
@@ -108,7 +108,7 @@ trait Buffer[A]
   }
   def takeRightInPlace(n: Int): this.type = { remove(0, length - normalized(n)); this }
   def sliceInPlace(start: Int, end: Int): this.type = takeInPlace(end).dropInPlace(start)
-  private def normalized(n: Int): Int = math.min(math.max(n, 0), length)
+  private def normalized(n: Int): Int = Math.min(Math.max(n, 0), length)
 
   def dropWhileInPlace(p: A => Boolean): this.type = {
     val idx = indexWhere(!p(_))
@@ -154,10 +154,10 @@ trait IndexedOptimizedBuffer[A] extends IndexedOptimizedSeq[A] with Buffer[A] {
   }
 
   def patchInPlace(from: Int, patch: scala.collection.Seq[A], replaced: Int): this.type = {
-    val replaced0 = math.min(math.max(replaced, 0), length)
-    val i = math.min(math.max(from, 0), length)
+    val replaced0 = Math.min(Math.max(replaced, 0), length)
+    val i = Math.min(Math.max(from, 0), length)
     var j = 0
-    val n = math.min(patch.length, replaced0)
+    val n = Math.min(patch.length, replaced0)
     while (j < n && i + j < length) {
       update(i + j, patch(j))
       j += 1

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -271,11 +271,11 @@ class ListBuffer[A]
   }
 
   def patchInPlace(from: Int, patch: collection.Seq[A], replaced: Int): this.type = {
-    val i = math.min(math.max(from, 0), length)
-    val n = math.min(math.max(replaced, 0), length)
+    val i = Math.min(Math.max(from, 0), length)
+    val n = Math.min(Math.max(replaced, 0), length)
     ensureUnaliased()
     val p = locate(i)
-    removeAfter(p, math.min(n, len - i))
+    removeAfter(p, Math.min(n, len - i))
     insertAfter(p, patch.iterator())
     this
   }

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -591,7 +591,7 @@ object LongMap {
     *  Equivalent to but more efficient than `LongMap((keys zip values): _*)`.
     */
   def fromZip[V](keys: Array[Long], values: Array[V]): LongMap[V] = {
-    val sz = math.min(keys.length, values.length)
+    val sz = Math.min(keys.length, values.length)
     val lm = new LongMap[V](sz * 2)
     var i = 0
     while (i < sz) { lm(keys(i)) = values(i); i += 1 }
@@ -603,7 +603,7 @@ object LongMap {
     *  Equivalent to but more efficient than `LongMap((keys zip values): _*)`.
     */
   def fromZip[V](keys: scala.collection.Iterable[Long], values: scala.collection.Iterable[V]): LongMap[V] = {
-    val sz = math.min(keys.size, values.size)
+    val sz = Math.min(keys.size, values.size)
     val lm = new LongMap[V](sz * 2)
     val ki = keys.iterator()
     val vi = values.iterator()

--- a/src/library/scala/math/Numeric.scala
+++ b/src/library/scala/math/Numeric.scala
@@ -138,7 +138,7 @@ object Numeric {
     def toFloat(x: Float): Float = x
     def toDouble(x: Float): Double = x.toDouble
     // logic in Numeric base trait mishandles abs(-0.0f)
-    override def abs(x: Float): Float = math.abs(x)
+    override def abs(x: Float): Float = Math.abs(x)
   }
   trait FloatIsFractional extends FloatIsConflicted with Fractional[Float] {
     def div(x: Float, y: Float): Float = x / y
@@ -163,7 +163,7 @@ object Numeric {
     def toFloat(x: Double): Float = x.toFloat
     def toDouble(x: Double): Double = x
     // logic in Numeric base trait mishandles abs(-0.0)
-    override def abs(x: Double): Double = math.abs(x)
+    override def abs(x: Double): Double = Math.abs(x)
   }
   trait DoubleIsFractional extends DoubleIsConflicted with Fractional[Double] {
     def div(x: Double, y: Double): Double = x / y

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -315,8 +315,8 @@ object Ordering extends LowPriorityOrderingImplicits {
     override def lt(x: Float, y: Float): Boolean = x < y
     override def gt(x: Float, y: Float): Boolean = x > y
     override def equiv(x: Float, y: Float): Boolean = x == y
-    override def max(x: Float, y: Float): Float = math.max(x, y)
-    override def min(x: Float, y: Float): Float = math.min(x, y)
+    override def max(x: Float, y: Float): Float = Math.max(x, y)
+    override def min(x: Float, y: Float): Float = Math.min(x, y)
 
     override def reverse: Ordering[Float] = new FloatOrdering {
       override def reverse = outer
@@ -343,8 +343,8 @@ object Ordering extends LowPriorityOrderingImplicits {
     override def lt(x: Double, y: Double): Boolean = x < y
     override def gt(x: Double, y: Double): Boolean = x > y
     override def equiv(x: Double, y: Double): Boolean = x == y
-    override def max(x: Double, y: Double): Double = math.max(x, y)
-    override def min(x: Double, y: Double): Double = math.min(x, y)
+    override def max(x: Double, y: Double): Double = Math.max(x, y)
+    override def min(x: Double, y: Double): Double = Math.min(x, y)
 
     override def reverse: Ordering[Double] = new DoubleOrdering {
       override def reverse = outer

--- a/src/library/scala/runtime/ArrayCharSequence.scala
+++ b/src/library/scala/runtime/ArrayCharSequence.scala
@@ -18,7 +18,7 @@ final class ArrayCharSequence(val xs: Array[Char], start: Int, end: Int) extends
   //
   // def this(xs: Array[Char]) = this(xs, 0, xs.length)
 
-  def length: Int = math.max(0, end - start)
+  def length: Int = Math.max(0, end - start)
   def charAt(index: Int): Char = {
     if (0 <= index && index < length)
       xs(start + index)
@@ -35,8 +35,8 @@ final class ArrayCharSequence(val xs: Array[Char], start: Int, end: Int) extends
     }
   }
   override def toString = {
-    val start = math.max(this.start, 0)
-    val end = math.min(xs.length, start + length)
+    val start = Math.max(this.start, 0)
+    val end = Math.min(xs.length, start + length)
 
     if (start >= end) "" else new String(xs, start, end - start)
   }

--- a/src/library/scala/runtime/RichByte.scala
+++ b/src/library/scala/runtime/RichByte.scala
@@ -23,8 +23,8 @@ final class RichByte(val self: Byte) extends AnyVal with ScalaWholeNumberProxy[B
 
   override def isValidByte   = true
 
-  override def abs: Byte             = math.abs(self).toByte
-  override def max(that: Byte): Byte = math.max(self, that).toByte
-  override def min(that: Byte): Byte = math.min(self, that).toByte
-  override def signum: Int           = math.signum(self.toInt)
+  override def abs: Byte             = Math.abs(self).toByte
+  override def max(that: Byte): Byte = Math.max(self, that).toByte
+  override def min(that: Byte): Byte = Math.min(self, that).toByte
+  override def signum: Int           = Integer.signum(self.toInt)
 }

--- a/src/library/scala/runtime/RichChar.scala
+++ b/src/library/scala/runtime/RichChar.scala
@@ -26,9 +26,9 @@ final class RichChar(val self: Char) extends AnyVal with IntegralProxy[Char] {
   override def isValidChar   = true
 
   override def abs: Char             = self
-  override def max(that: Char): Char = math.max(self.toInt, that.toInt).toChar
-  override def min(that: Char): Char = math.min(self.toInt, that.toInt).toChar
-  override def signum: Int           = math.signum(self.toInt)
+  override def max(that: Char): Char = Math.max(self.toInt, that.toInt).toChar
+  override def min(that: Char): Char = Math.min(self.toInt, that.toInt).toChar
+  override def signum: Int           = Integer.signum(self.toInt)
 
   def asDigit: Int                      = Character.digit(self, Character.MAX_RADIX)
 

--- a/src/library/scala/runtime/RichDouble.scala
+++ b/src/library/scala/runtime/RichDouble.scala
@@ -38,25 +38,25 @@ final class RichDouble(val self: Double) extends AnyVal with FractionalProxy[Dou
   def isPosInfinity: Boolean = Double.PositiveInfinity == self
   def isNegInfinity: Boolean = Double.NegativeInfinity == self
 
-  override def abs: Double               = math.abs(self)
-  override def max(that: Double): Double = math.max(self, that)
-  override def min(that: Double): Double = math.min(self, that)
-  override def signum: Int               = math.signum(self).toInt  // !!! NaN
+  override def abs: Double               = Math.abs(self)
+  override def max(that: Double): Double = Math.max(self, that)
+  override def min(that: Double): Double = Math.min(self, that)
+  override def signum: Int               = Math.signum(self).toInt  // !!! NaN
 
-  def round: Long   = math.round(self)
-  def ceil: Double  = math.ceil(self)
-  def floor: Double = math.floor(self)
+  def round: Long   = Math.round(self)
+  def ceil: Double  = Math.ceil(self)
+  def floor: Double = Math.floor(self)
 
   /** Converts an angle measured in degrees to an approximately equivalent
    *  angle measured in radians.
    *
    *  @return the measurement of the angle x in radians.
    */
-  def toRadians: Double = math.toRadians(self)
+  def toRadians: Double = Math.toRadians(self)
 
   /** Converts an angle measured in radians to an approximately equivalent
    *  angle measured in degrees.
    *  @return the measurement of the angle x in degrees.
    */
-  def toDegrees: Double = math.toDegrees(self)
+  def toDegrees: Double = Math.toDegrees(self)
 }

--- a/src/library/scala/runtime/RichFloat.scala
+++ b/src/library/scala/runtime/RichFloat.scala
@@ -38,26 +38,26 @@ final class RichFloat(val self: Float) extends AnyVal with FractionalProxy[Float
   def isPosInfinity: Boolean = Float.PositiveInfinity == self
   def isNegInfinity: Boolean = Float.NegativeInfinity == self
 
-  override def abs: Float              = math.abs(self)
-  override def max(that: Float): Float = math.max(self, that)
-  override def min(that: Float): Float = math.min(self, that)
-  override def signum: Int             = math.signum(self).toInt  // !!! NaN
+  override def abs: Float              = Math.abs(self)
+  override def max(that: Float): Float = Math.max(self, that)
+  override def min(that: Float): Float = Math.min(self, that)
+  override def signum: Int             = Math.signum(self).toInt  // !!! NaN
 
-  def round: Int   = math.round(self)
-  def ceil: Float  = math.ceil(self.toDouble).toFloat
-  def floor: Float = math.floor(self.toDouble).toFloat
+  def round: Int   = Math.round(self)
+  def ceil: Float  = Math.ceil(self.toDouble).toFloat
+  def floor: Float = Math.floor(self.toDouble).toFloat
 
   /** Converts an angle measured in degrees to an approximately equivalent
    *  angle measured in radians.
    *
    *  @return the measurement of the angle `x` in radians.
    */
-  def toRadians: Float = math.toRadians(self.toDouble).toFloat
+  def toRadians: Float = Math.toRadians(self.toDouble).toFloat
 
   /** Converts an angle measured in radians to an approximately equivalent
    *  angle measured in degrees.
    *
    *  @return the measurement of the angle `x` in degrees.
    */
-  def toDegrees: Float = math.toDegrees(self.toDouble).toFloat
+  def toDegrees: Float = Math.toDegrees(self.toDouble).toFloat
 }

--- a/src/library/scala/runtime/RichInt.scala
+++ b/src/library/scala/runtime/RichInt.scala
@@ -32,10 +32,10 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
   override def isValidInt   = true
   def isValidLong  = true
 
-  override def abs: Int            = math.abs(self)
-  override def max(that: Int): Int = math.max(self, that)
-  override def min(that: Int): Int = math.min(self, that)
-  override def signum: Int         = math.signum(self)
+  override def abs: Int            = Math.abs(self)
+  override def max(that: Int): Int = Math.max(self, that)
+  override def min(that: Int): Int = Math.min(self, that)
+  override def signum: Int         = Integer.signum(self)
 
   /** There is no reason to round an `Int`, but this method is provided to avoid accidental loss of precision from a detour through `Float`. */
   @deprecated("this is an integer type; there is no reason to round it.  Perhaps you meant to call this on a floating-point value?", "2.11.0")

--- a/src/library/scala/runtime/RichLong.scala
+++ b/src/library/scala/runtime/RichLong.scala
@@ -28,10 +28,10 @@ final class RichLong(val self: Long) extends AnyVal with IntegralProxy[Long] {
   // override def isValidFloat = self.toFloat.toLong == self && self != Long.MaxValue
   // override def isValidDouble = self.toDouble.toLong == self && self != Long.MaxValue
 
-  override def abs: Long             = math.abs(self)
-  override def max(that: Long): Long = math.max(self, that)
-  override def min(that: Long): Long = math.min(self, that)
-  override def signum: Int           = math.signum(self).toInt
+  override def abs: Long             = Math.abs(self)
+  override def max(that: Long): Long = Math.max(self, that)
+  override def min(that: Long): Long = Math.min(self, that)
+  override def signum: Int           = Math.signum(self).toInt
 
   /** There is no reason to round a `Long`, but this method is provided to avoid accidental conversion to `Int` through `Float`. */
   @deprecated("this is an integer type; there is no reason to round it.  Perhaps you meant to call this on a floating-point value?", "2.11.0")

--- a/src/library/scala/runtime/RichShort.scala
+++ b/src/library/scala/runtime/RichShort.scala
@@ -23,8 +23,8 @@ final class RichShort(val self: Short) extends AnyVal with ScalaWholeNumberProxy
 
   override def isValidShort  = true
 
-  override def abs: Short              = math.abs(self.toInt).toShort
-  override def max(that: Short): Short = math.max(self.toInt, that.toInt).toShort
-  override def min(that: Short): Short = math.min(self.toInt, that.toInt).toShort
-  override def signum: Int             = math.signum(self.toInt)
+  override def abs: Short              = Math.abs(self.toInt).toShort
+  override def max(that: Short): Short = Math.max(self.toInt, that.toInt).toShort
+  override def min(that: Short): Short = Math.min(self.toInt, that.toInt).toShort
+  override def signum: Int             = Integer.signum(self.toInt)
 }

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -225,7 +225,7 @@ private[scala] trait PropertiesTrait {
   /** Compares the given specification version to the major version of the platform.
    *  @param version a specification major version number
    */
-  def isJavaAtLeast(version: Int): Boolean = isJavaAtLeast(math.max(version, 0).toString)
+  def isJavaAtLeast(version: Int): Boolean = isJavaAtLeast(Math.max(version, 0).toString)
 
   // provide a main method so version info can be obtained by running this
   def main(args: Array[String]) {

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -96,7 +96,7 @@ trait Names extends api.Names {
   final def newTermName(cs: Array[Char], offset: Int, len0: Int, cachedString: String): TermName = {
     def body = {
       require(offset >= 0, "offset must be non-negative, got " + offset)
-      val len = math.max(len0, 0)
+      val len = Math.max(len0, 0)
       val h = hashValue(cs, offset, len) & HASH_MASK
       var n = termHashtable(h)
       while ((n ne null) && (n.length != len || !equals(n.start, cs, offset, len)))

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -61,7 +61,7 @@ trait StdNames {
      */
     val marker = "$$$$"
     val maxSuffixLength = "$.class".length + 1 // potential module class suffix and file extension
-    val MaxNameLength = math.min(
+    val MaxNameLength = Math.min(
       settings.maxClassfileName.value - maxSuffixLength,
       2 * (settings.maxClassfileName.value - maxSuffixLength - 2*marker.length - 32)
     )

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -619,8 +619,8 @@ private[internal] trait TypeMaps {
     private[this] var fromSize = 0
     from.foreach {
       sym =>
-        fromMin = math.min(fromMin, sym.id)
-        fromMax = math.max(fromMax, sym.id)
+        fromMin = Math.min(fromMin, sym.id)
+        fromMax = Math.max(fromMax, sym.id)
         fromSize += 1
         if (sym.isTerm) fromHasTermSymbol = true
     }

--- a/src/reflect/scala/reflect/internal/util/HashSet.scala
+++ b/src/reflect/scala/reflect/internal/util/HashSet.scala
@@ -16,7 +16,7 @@ object HashSet {
 class HashSet[T >: Null <: AnyRef](val label: String, initialCapacity: Int) extends Set[T] with scala.collection.mutable.Clearable {
   private var used = 0
   private var table = new Array[AnyRef](initialCapacity)
-  private def index(x: Int): Int = math.abs(x % table.length)
+  private def index(x: Int): Int = Math.abs(x % table.length)
 
   def size: Int = used
   def clear() {

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -445,7 +445,7 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
   private def earliestPosition(tree: Tree): Int = {
     var pos = Int.MaxValue
     tree foreach { t =>
-      pos = math.min(pos, safePos(t, Int.MaxValue))
+      pos = Math.min(pos, safePos(t, Int.MaxValue))
     }
     pos
   }


### PR DESCRIPTION
Replace scala math calls with the java.lang version.

Done with: sed -i 's/\([^.]\)math\.\([a-z]\)/\1Math.\2/g'