### PR TITLE
Reducing the footprint of Context

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -244,8 +244,6 @@ trait Contexts { self: Analyzer =>
       openImplicits.nonEmpty && openImplicits.exists(x => !x.isView)
     }
 
-    /* For a named application block (`Tree`) the corresponding `NamedApplyInfo`. */
-    var namedApplyBlockInfo: Option[(Tree, NamedApplyInfo)] = None
     var prefix: Type = NoPrefix
 
     def inSuperInit_=(value: Boolean)         = this(SuperInit) = value
@@ -1584,11 +1582,11 @@ object ContextMode {
   /** Are unapplied type constructors allowed here? Formerly HKmode. */
   final val TypeConstructorAllowed: ContextMode   = 1 << 16
 
-  /** Were default arguments used? */
-  final val DiagUsedDefaults: ContextMode         = 1 << 18
-
   /** Should a dead code warning be issued for a Nothing-typed argument to the current application. */
   final val SuppressDeadArgWarning: ContextMode   = 1 << 17
+
+  /** Were default arguments used? */
+  final val DiagUsedDefaults: ContextMode         = 1 << 18
 
   /** TODO: The "sticky modes" are EXPRmode, PATTERNmode, TYPEmode.
    *  To mimic the sticky mode behavior, when captain stickyfingers

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -222,9 +222,6 @@ trait Contexts { self: Analyzer =>
       */
     var enclMethod: Context = _
 
-    /** Variance relative to enclosing class */
-    var variance: Variance = Variance.Invariant
-
     private var _undetparams: List[Symbol] = List()
 
     protected def outerDepth = if (outerIsNoContext) 0 else outer.depth
@@ -489,7 +486,6 @@ trait Contexts { self: Analyzer =>
         new Context(tree, owner, scope, unit, this, reporter)
 
       // Fields that are directly propagated
-      c.variance           = variance
       c.diagUsedDefaults   = diagUsedDefaults
       c.openImplicits      = openImplicits
       c.contextMode        = contextMode // note: ConstructorSuffix, a bit within `mode`, is conditionally overwritten below.

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -49,6 +49,13 @@ trait NamesDefaults { self: Analyzer =>
     vargss:     List[List[Tree]],
     blockTyper: Typer
   ) { }
+  object NamedApplyBlock {
+    private[this] val tag = reflect.classTag[NamedApplyInfo]
+    def unapply(b: Tree): Option[NamedApplyInfo] = b match {
+      case _: Block => b.attachments.get[NamedApplyInfo](tag)
+      case _ => None
+    }
+  }
 
   private def nameOfNamedArg(arg: Tree) = Some(arg) collect { case NamedArg(Ident(name), _) => name }
   def isNamedArg(arg: Tree) = arg match {
@@ -191,15 +198,13 @@ trait NamesDefaults { self: Analyzer =>
 
         val b = Block(List(vd), baseFunTransformed)
                   .setType(baseFunTransformed.tpe).setPos(baseFun.pos.makeTransparent)
-        context.namedApplyBlockInfo =
-          Some((b, NamedApplyInfo(Some(newQual), defaultTargs, Nil, blockTyper)))
+        b.updateAttachment(NamedApplyInfo(Some(newQual), defaultTargs, Nil, blockTyper))
         b
       }
 
       def blockWithoutQualifier(defaultQual: Option[Tree]) = {
         val b = atPos(baseFun.pos)(Block(Nil, baseFun).setType(baseFun.tpe))
-        context.namedApplyBlockInfo =
-          Some((b, NamedApplyInfo(defaultQual, defaultTargs, Nil, blockTyper)))
+        b.updateAttachment(NamedApplyInfo(defaultQual, defaultTargs, Nil, blockTyper))
         b
       }
 
@@ -327,17 +332,14 @@ trait NamesDefaults { self: Analyzer =>
     }
 
     // begin transform
-    if (isNamedApplyBlock(tree)) {
-      context.namedApplyBlockInfo.get._1
-    } else tree match {
+    tree match {
+      case NamedApplyBlock(info) => tree
       // `fun` is typed. `namelessArgs` might be typed or not, if they are types are kept.
       case Apply(fun, namelessArgs) =>
         val transformedFun = transformNamedApplication(typer, mode, pt)(fun, x => x)
         if (transformedFun.isErroneous) setError(tree)
         else {
-          assert(isNamedApplyBlock(transformedFun), transformedFun)
-          val NamedApplyInfo(qual, targs, vargss, blockTyper) =
-            context.namedApplyBlockInfo.get._2
+          val NamedApplyBlock(NamedApplyInfo(qual, targs, vargss, blockTyper)) = transformedFun
           val Block(stats, funOnly) = transformedFun
 
           // type the application without names; put the arguments in definition-site order
@@ -373,8 +375,7 @@ trait NamesDefaults { self: Analyzer =>
               val res = blockTyper.doTypedApply(tree, expr, refArgs, mode, pt)
               res.setPos(res.pos.makeTransparent)
               val block = Block(stats ::: valDefs.flatten, res).setType(res.tpe).setPos(tree.pos.makeTransparent)
-              context.namedApplyBlockInfo =
-                Some((block, NamedApplyInfo(qual, targs, vargss :+ refArgs, blockTyper)))
+              block.updateAttachment(NamedApplyInfo(qual, targs, vargss :+ refArgs, blockTyper))
               block
             case _ => tree
           }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -678,12 +678,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           val context1 = context.makeSilent(reportAmbiguousErrors, newtree)
           context1.undetparams = context.undetparams
           context1.savedTypeBounds = context.savedTypeBounds
-          context1.namedApplyBlockInfo = context.namedApplyBlockInfo
           val typer1 = newTyper(context1)
           val result = op(typer1)
           context.undetparams = context1.undetparams
           context.savedTypeBounds = context1.savedTypeBounds
-          context.namedApplyBlockInfo = context1.namedApplyBlockInfo
 
           // If we have a successful result, emit any warnings it created.
           if (!context1.reporter.hasErrors)
@@ -3290,11 +3288,6 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       }
     }
 
-    /** Is `tree` a block created by a named application?
-     */
-    def isNamedApplyBlock(tree: Tree) =
-      context.namedApplyBlockInfo exists (_._1 == tree)
-
     def callToCompanionConstr(context: Context, calledFun: Symbol) = {
       calledFun.isConstructor && {
         val methCtx = context.enclMethod
@@ -3526,7 +3519,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               } else if (!allArgsArePositional(argPos) && !sameLength(formals, params))
                 // !allArgsArePositional indicates that named arguments are used to re-order arguments
                 duplErrorTree(MultipleVarargError(tree))
-              else if (allArgsArePositional(argPos) && !isNamedApplyBlock(fun)) {
+              else if (allArgsArePositional(argPos) && !NamedApplyBlock.unapply(fun).isDefined) {
                 // if there's no re-ordering, and fun is not transformed, no need to transform
                 // more than an optimization, e.g. important in "synchronized { x = update-x }"
                 checkNotMacro()
@@ -3565,13 +3558,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               val fun1 = transformNamedApplication(Typer.this, mode, pt)(fun, x => x)
               if (fun1.isErroneous) duplErrTree
               else {
-                assert(isNamedApplyBlock(fun1), fun1)
-                val NamedApplyInfo(qual, targs, previousArgss, _) = context.namedApplyBlockInfo.get._2
+                val NamedApplyBlock(NamedApplyInfo(qual, targs, previousArgss, _)) = fun1
                 val blockIsEmpty = fun1 match {
                   case Block(Nil, _) =>
                     // if the block does not have any ValDef we can remove it. Note that the call to
                     // "transformNamedApplication" is always needed in order to obtain targs/previousArgss
-                    context.namedApplyBlockInfo = None
+                    fun1.attachments.remove[NamedApplyInfo]
                     true
                   case _ => false
                 }
@@ -3599,7 +3591,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
           if (!sameLength(formals, args) ||   // wrong nb of arguments
               (args exists isNamedArg) ||     // uses a named argument
-              isNamedApplyBlock(fun)) {       // fun was transformed to a named apply block =>
+              NamedApplyBlock.unapply(fun).isDefined) {       // fun was transformed to a named apply block =>
                                               // integrate this application into the block
             if (isApplyDynamicNamed(fun) && isDynamicRewrite(fun)) typedNamedApply(tree, fun, args, mode, pt)
             else tryNamesDefaults

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3587,7 +3587,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 } else if (lencmp2 == 0) {
                   // useful when a default doesn't match parameter type, e.g. def f[T](x:T="a"); f[Int]()
                   checkNotMacro()
-                  context.diagUsedDefaults = true
+                  context.set(ContextMode.DiagUsedDefaults)
                   doTypedApply(tree, if (blockIsEmpty) fun else fun1, allArgs, mode, pt)
                 } else {
                   rollbackNamesDefaultsOwnerChanges()


### PR DESCRIPTION
  - Rework named/defaults bookkeeping as a tree attachment
  - Move diagnostic tracking of whether defaults are in play to ContextMode
  - Remove an unused field from Context

This will conflict with #6617. I'll rebase this one after that is merged.