### PR TITLE
Make Range.numRangeElements private again.

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -71,7 +71,7 @@ sealed abstract class Range(
       || (start == end && !isInclusive)
     )
 
-  val numRangeElements: Int = {
+  private val numRangeElements: Int = {
     if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
     else if (isEmpty) 0
     else {


### PR DESCRIPTION
It was made private in 4c2f6f3cb1e0eee11facae8c44e3cd7db11378f1, but it was reverted to public in the big collection overhaul, in 878e7d3e0d14633d19bac47dc9b532a54eab6379. I believe this was an accident, so here is a commit to make it private again.