### PR TITLE
Make Array.copyAs Scala.js-friendly.

### DIFF
--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -153,25 +153,16 @@ object Array {
     val destClass = ct.runtimeClass.asInstanceOf[Class[A]]
     if (destClass.isAssignableFrom(original.getClass.getComponentType)) {
       if(destClass.isPrimitive) copyOf[A](original.asInstanceOf[Array[A]], newLength)
-      else java.util.Arrays.copyOf(original.asInstanceOf[Array[AnyRef]], newLength, getArrayClass(destClass).asInstanceOf[Class[Array[AnyRef]]]).asInstanceOf[Array[A]]
+      else {
+        val destArrayClass = java.lang.reflect.Array.newInstance(destClass, 0).getClass.asInstanceOf[Class[Array[AnyRef]]]
+        java.util.Arrays.copyOf(original.asInstanceOf[Array[AnyRef]], newLength, destArrayClass).asInstanceOf[Array[A]]
+      }
     } else {
       val dest = new Array[A](newLength)
       Array.copy(original, 0, dest, 0, original.length)
       dest
     }
   }
-
-  private def getArrayClass[A](c: Class[A]): Class[Array[A]] = {
-    if(c eq classOf[Int]) classOf[Array[Int]]
-    else if(c eq classOf[Long]) classOf[Array[Long]]
-    else if(c eq classOf[Char]) classOf[Array[Char]]
-    else if(c eq classOf[Boolean]) classOf[Array[Boolean]]
-    else if(c eq classOf[Double]) classOf[Array[Double]]
-    else if(c eq classOf[Byte]) classOf[Array[Byte]]
-    else if(c eq classOf[Float]) classOf[Array[Float]]
-    else if(c eq classOf[Short]) classOf[Array[Short]]
-    else Class.forName(if(c.isArray) "["+c.getName else "[L"+c.getName+";", true, c.getClassLoader)
-  }.asInstanceOf[Class[Array[A]]]
 
   /** Returns an array of length 0 */
   def empty[T: ClassTag]: Array[T] = new Array[T](0)


### PR DESCRIPTION
When copying between object arrays, `Array.copyAs` needs to produce a `Class[Array[destClass]]`. The previous version used an incantation with `Class.forName` to do so, but that is not supported in Scala.js. It uselessly tested for cases where `c` is a primitive type, but that never happens because `copyAs` has a different code path when `destClass.isPrimitive`.

This commit uses `Array.newInstance(destClass, 0).getClass` instead, which is supported by Scala.js.

Discussion: https://gitter.im/scala/contributors?at=5af9ca7da2d95136333c2145
The performance impact on the JVM is unclear. @Ichoran has a "wonky" benchmark showing the new version would be faster.