### PR TITLE
Remove element type from mutable.ArraySeq.(elemTag|array)

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -1361,7 +1361,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *                ''n'' times in `that`, then the first ''n'' occurrences of `x` will not form
     *                part of the result, but any following occurrences will.
     */
-  def diff(that: Seq[_ >: A]): Array[A] = mutable.ArraySeq.make(xs).diff(that).array
+  def diff(that: Seq[_ >: A]): Array[A] = mutable.ArraySeq.make(xs).diff(that).array.asInstanceOf[Array[A]]
 
   /** Computes the multiset intersection between this array and another sequence.
     *
@@ -1372,7 +1372,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *                ''n'' times in `that`, then the first ''n'' occurrences of `x` will be retained
     *                in the result, but any following occurrences will be omitted.
     */
-  def intersect(that: Seq[_ >: A]): Array[A] = mutable.ArraySeq.make(xs).intersect(that).array
+  def intersect(that: Seq[_ >: A]): Array[A] = mutable.ArraySeq.make(xs).intersect(that).array.asInstanceOf[Array[A]]
 
   /** Groups chars in fixed size blocks by passing a "sliding window"
     *  over them (as opposed to partitioning them, as is done in grouped.)
@@ -1384,7 +1384,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *          last element (which may be the only element) will be truncated
     *          if there are fewer than `size` chars remaining to be grouped.
     */
-  def sliding(size: Int, step: Int = 1): Iterator[Array[A]] = mutable.ArraySeq.make(xs).sliding(size, step).map(_.array)
+  def sliding(size: Int, step: Int = 1): Iterator[Array[A]] = mutable.ArraySeq.make(xs).sliding(size, step).map(_.array.asInstanceOf[Array[A]])
 
   /** Iterates over combinations.  A _combination_ of length `n` is a subsequence of
     *  the original string, with the chars taken in order.  Thus, `"xy"` and `"yy"`
@@ -1399,14 +1399,14 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *  @return   An Iterator which traverses the possible n-element combinations of this string.
     *  @example  `"abbbc".combinations(2) = Iterator(ab, ac, bb, bc)`
     */
-  def combinations(n: Int): Iterator[Array[A]] = mutable.ArraySeq.make(xs).combinations(n).map(_.array)
+  def combinations(n: Int): Iterator[Array[A]] = mutable.ArraySeq.make(xs).combinations(n).map(_.array.asInstanceOf[Array[A]])
 
   /** Iterates over distinct permutations.
     *
     *  @return   An Iterator which traverses the distinct permutations of this string.
     *  @example  `"abb".permutations = Iterator(abb, bab, bba)`
     */
-  def permutations: Iterator[Array[A]] = mutable.ArraySeq.make(xs).permutations.map(_.array)
+  def permutations: Iterator[Array[A]] = mutable.ArraySeq.make(xs).permutations.map(_.array.asInstanceOf[Array[A]])
 
   // we have another overload here, so we need to duplicate this method
   /** Tests whether this array contains the given sequence at a given index.

--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -25,20 +25,22 @@ sealed abstract class ArraySeq[+A]
     with IndexedSeqOps[A, ArraySeq, ArraySeq[A]]
     with StrictOptimizedSeqOps[A, ArraySeq, ArraySeq[A]] {
 
-  /** The tag of the element type */
-  protected def elemTag: ClassTag[A] @uncheckedVariance
+  /** The tag of the element type. This does not have to be equal to the element type of this ArraySeq. A primitive
+    * ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an array of a supertype
+    * or subtype of the element type. */
+  protected def elemTag: ClassTag[_]
 
   override def iterableFactory: SeqFactory[ArraySeq] = ArraySeq.untagged
 
   /** The wrapped mutable `Array` that backs this `ArraySeq`. Any changes to this array will break
-    * the expected immutability. */
-  def unsafeArray: Array[A @uncheckedVariance]
-  // uncheckedVariance should be safe: Array[A] for reference types A is covariant at the JVM level. Array[A] for
-  // primitive types A can only be widened to Array[Any] which erases to Object.
+    * the expected immutability. Its element type does not have to be equal to the element type of this ArraySeq.
+    * A primitive ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an
+    * array of a supertype or subtype of the element type. */
+  def unsafeArray: Array[_]
 
-  override protected def fromSpecificIterable(coll: scala.collection.Iterable[A] @uncheckedVariance): ArraySeq[A] = ArraySeq.from[A](coll)(elemTag)
+  override protected def fromSpecificIterable(coll: scala.collection.Iterable[A] @uncheckedVariance): ArraySeq[A] = ArraySeq.from(coll)(elemTag.asInstanceOf[ClassTag[A]])
 
-  override protected def newSpecificBuilder: Builder[A, ArraySeq[A]] @uncheckedVariance = ArraySeq.newBuilder[A](elemTag)
+  override protected def newSpecificBuilder: Builder[A, ArraySeq[A]] @uncheckedVariance = ArraySeq.newBuilder[A](elemTag.asInstanceOf[ClassTag[A]])
 
   @throws[ArrayIndexOutOfBoundsException]
   def apply(i: Int): A
@@ -95,19 +97,19 @@ sealed abstract class ArraySeq[+A]
         fromIterable(new View.Zip(toIterable, that))
     }
 
-  override def take(n: Int): ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).take(n))
+  override def take(n: Int): ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).take(n)).asInstanceOf[ArraySeq[A]]
 
-  override def takeRight(n: Int): ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).takeRight(n))
+  override def takeRight(n: Int): ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).takeRight(n)).asInstanceOf[ArraySeq[A]]
 
-  override def drop(n: Int): ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).drop(n))
+  override def drop(n: Int): ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).drop(n)).asInstanceOf[ArraySeq[A]]
 
-  override def dropRight(n: Int): ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).dropRight(n))
+  override def dropRight(n: Int): ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).dropRight(n)).asInstanceOf[ArraySeq[A]]
 
-  override def slice(from: Int, until: Int): ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).slice(from, until))
+  override def slice(from: Int, until: Int): ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).slice(from, until)).asInstanceOf[ArraySeq[A]]
 
-  override def tail: ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).tail)
+  override def tail: ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).tail).asInstanceOf[ArraySeq[A]]
 
-  override def reverse: ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).reverse)
+  override def reverse: ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).reverse).asInstanceOf[ArraySeq[A]]
 
   override def className = "ArraySeq"
 

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -34,22 +34,26 @@ abstract class ArraySeq[T]
   override def iterableFactory: scala.collection.SeqFactory[ArraySeq] = ArraySeq.untagged
 
   override protected def fromSpecificIterable(coll: scala.collection.Iterable[T]): ArraySeq[T] = {
-    val b = ArrayBuilder.make(elemTag)
+    val b = ArrayBuilder.make(elemTag).asInstanceOf[ArrayBuilder[T]]
     val s = coll.knownSize
     if(s > 0) b.sizeHint(s)
     b ++= coll
     ArraySeq.make(b.result())
   }
-  override protected def newSpecificBuilder: Builder[T, ArraySeq[T]] = ArraySeq.newBuilder(elemTag)
+  override protected def newSpecificBuilder: Builder[T, ArraySeq[T]] = ArraySeq.newBuilder(elemTag).asInstanceOf[Builder[T, ArraySeq[T]]]
 
-  /** The tag of the element type */
-  def elemTag: ClassTag[T]
+  /** The tag of the element type. This does not have to be equal to the element type of this ArraySeq. A primitive
+    * ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an array of a supertype
+    * or subtype of the element type. */
+  def elemTag: ClassTag[_]
 
   /** Update element at given index */
   def update(index: Int, elem: T): Unit
 
-  /** The underlying array */
-  def array: Array[T]
+  /** The underlying array. Its element type does not have to be equal to the element type of this ArraySeq. A primitive
+    * ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an array of a supertype
+    * or subtype of the element type. */
+  def array: Array[_]
 
   override def toArray[U >: T : ClassTag]: Array[U] = {
     val thatElementClass = implicitly[ClassTag[U]].runtimeClass
@@ -62,7 +66,7 @@ abstract class ArraySeq[T]
   override def className = "ArraySeq"
 
   /** Clones this object, including the underlying Array. */
-  override def clone(): ArraySeq[T] = ArraySeq.make(array.clone())
+  override def clone(): ArraySeq[T] = ArraySeq.make(array.clone()).asInstanceOf[ArraySeq[T]]
 
   override def copyToArray[B >: T](xs: Array[B], start: Int = 0): xs.type = copyToArray[B](xs, start, length)
 

--- a/test/junit/scala/collection/immutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/immutable/ArraySeqTest.scala
@@ -1,6 +1,6 @@
 package scala.collection.immutable
 
-import org.junit.Assert
+import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -44,20 +44,26 @@ class ArraySeqTest {
 
     def unit1(): Unit = {}
     def unit2(): Unit = {}
-    Assert.assertEquals(unit1(), unit2())
+    assertEquals(unit1(), unit2())
     // unitArray is actually an instance of Immutable[BoxedUnit], the check to which is actually checked slice
     // implementation of ofRef
     val unitArray: ArraySeq[Unit] = Array(unit1(), unit2(), unit1(), unit2())
     check(unitArray, Array(unit1(), unit1()), Array(unit1(), unit1()))
   }
 
+  @Test
+  def t10851(): Unit = {
+    val s1 = collection.immutable.ArraySeq.untagged(1,2,3)
+    assertTrue(s1.unsafeArray.getClass == classOf[Array[AnyRef]])
+  }
+
   private def check[T : ClassTag](array: ArraySeq[T], expectedSliceResult1: ArraySeq[T], expectedSliceResult2: ArraySeq[T]) {
-    Assert.assertEquals(array, array.slice(-1, 4))
-    Assert.assertEquals(array, array.slice(0, 5))
-    Assert.assertEquals(array, array.slice(-1, 5))
-    Assert.assertEquals(expectedSliceResult1, array.slice(0, 2))
-    Assert.assertEquals(expectedSliceResult2, array.slice(1, 3))
-    Assert.assertEquals(ArraySeq.empty[T], array.slice(1, 1))
-    Assert.assertEquals(ArraySeq.empty[T], array.slice(2, 1))
+    assertEquals(array, array.slice(-1, 4))
+    assertEquals(array, array.slice(0, 5))
+    assertEquals(array, array.slice(-1, 5))
+    assertEquals(expectedSliceResult1, array.slice(0, 2))
+    assertEquals(expectedSliceResult2, array.slice(1, 3))
+    assertEquals(ArraySeq.empty[T], array.slice(1, 1))
+    assertEquals(ArraySeq.empty[T], array.slice(2, 1))
   }
 }

--- a/test/junit/scala/collection/mutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/mutable/ArraySeqTest.scala
@@ -1,0 +1,38 @@
+package scala.collection.mutable
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.reflect.ClassTag
+
+@RunWith(classOf[JUnit4])
+class ArraySeqTest {
+  @Test
+  def t10851(): Unit = {
+    val s1 = ArraySeq.untagged(1,2,3)
+    assertTrue(s1.array.getClass == classOf[Array[AnyRef]])
+    val s2 = ArraySeq.make(Array(1))
+    assertTrue(s2.array.getClass == classOf[Array[Int]])
+    val s3 = ArraySeq.make(Array(1): Array[Any]).asInstanceOf[ArraySeq[Int]]
+    assertTrue(s3.array.getClass == classOf[Array[AnyRef]])
+  }
+}
+
+/*
+scala> import scala.collection.mutable.WrappedArray
+import scala.collection.mutable.WrappedArray
+
+scala> val a = WrappedArray.make(Array(1))
+a: scala.collection.mutable.WrappedArray[Int] = WrappedArray(1)
+
+scala> a.array.getClass
+res0: Class[_ <: Array[Int]] = class [I
+
+scala> val a = WrappedArray.make(Array(1): Array[Any]).asInstanceOf[WrappedArray[Int]]
+a: scala.collection.mutable.WrappedArray[Int] = WrappedArray(1)
+
+scala> a.array.getClass
+res1: Class[_ <: Array[Int]] = class [Ljava.lang.Object;
+ */


### PR DESCRIPTION
ArraySeq can be boxed or unboxed for primitives and could have been
created with an `Array[AnyRef]` for arbitrary reference types, so we
cannot guarantee any specific element type for the backing array.

Fixes https://github.com/scala/bug/issues/10851