### PR TITLE
Add toString to PartialFunction's orElse & andThen

### DIFF
--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -177,6 +177,8 @@ object PartialFunction {
 
     override def andThen[C](k: B => C) =
       new OrElse[A, C] (f1 andThen k, f2 andThen k)
+
+    override def toString: String = s"$f1.orElse($f2)"
   }
 
   /** Composite function produced by `PartialFunction#andThen` method
@@ -190,6 +192,8 @@ object PartialFunction {
       val z = pf.applyOrElse(x, checkFallback[B])
       if (!fallbackOccurred(z)) k(z) else default(x)
     }
+
+    override def toString: String = s"$pf.andThen($k)"
   }
 
   /** To implement patterns like {{{ if(pf isDefinedAt x) f1(pf(x)) else f2(x) }}} efficiently

--- a/test/junit/scala/PartialFunctionTest.scala
+++ b/test/junit/scala/PartialFunctionTest.scala
@@ -1,0 +1,48 @@
+package scala
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class PartialFunctionTest {
+
+  private val odds = new PartialFunction[Int, String] {
+    def isDefinedAt(x: Int): Boolean = x % 2 != 0
+    def apply(x: Int): String = x.toString
+    override def toString: String = "odds"
+  }
+
+  private val evens = new PartialFunction[Int, String] {
+    def isDefinedAt(x: Int): Boolean = x % 2 == 0
+    def apply(x: Int): String = x.toString
+    override def toString: String = "evens"
+  }
+
+  private val stringToInt = new PartialFunction[String, Int] {
+    def isDefinedAt(x: String): Boolean = {
+      try {
+        x.toInt
+        true
+      } catch { case _: NumberFormatException =>
+        false
+      }
+    }
+    def apply(x: String): Int = x.toInt
+    override def toString: String = "stringToInt"
+  }
+
+  @Test
+  def orElseToString: Unit = {
+    val orElse = odds.orElse(evens)
+    assertEquals("odds.orElse(evens)", orElse.toString)
+  }
+
+  @Test
+  def andThenToString: Unit = {
+    val andThen = odds.andThen(stringToInt)
+    assertEquals("odds.andThen(stringToInt)", andThen.toString)
+  }
+
+}


### PR DESCRIPTION
Problem

A `PartialFunction` may have a nice `toString` but it is lost when
combined with `orElse` or `andThen`.

Solution

Improve the `toString` for `OrElse` and `AndThen`.

Result

The `toString` is no longer lost.