### PR TITLE
merge 2.12.x to 2.13.x [ci: last-only]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,30 @@
-sudo: required # GCE VMs have better performance (will be upgrading to premium VMs soon)
+# GCE VMs have better performance (will be upgrading to premium VMs soon)
+sudo: required
 
 language: scala
 jdk: openjdk8
-
 
 cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt
-    - build/
-
-
-before_script:
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then (cd admin && ./init.sh); fi'
 
 stages:
-  - name: build # also builds the spec using jekyll
-  # tests are running into time limits (will re-enable once Jason's partest speedups are in)
-  - name: test
-    if: env(bla) = thisVarIsNotSet AND type != pull_request # just disabling tests for now, but commenting the stage here doesn't do the trick
-  - name: publish
-    if: type != pull_request
+  - name: build
 
-# see comment in `bootstrap_fun` for details on the procedure
-# env available in each stage
-#  - by travis config (see below): secret env vars
-#  - by `common` script: WORKSPACE, IVY2_DIR, SBT_CMD, integrationRepoUrl
-#  - by `bootstrap_fun`: publishPrivateTask, ...
-# env computed in first stage, passed on to later stages with the `build/env` file
-#  - by `determineScalaVersion`: SCALA_VER, publishToSonatype
-#  - by `buildModules` / `constructUpdatedModuleVersions`: updatedModuleVersions
 jobs:
     include:
+
+      # full bootstrap and publish
       - stage: build
-        # currently, not touching PR validation
-        # (also, we couldn't even, because the password to publish to artifactory is not there :-/)
         if: type != pull_request
         script:
+          # see comment in `bootstrap_fun` for details on the procedure
+          # env available in each stage
+          #  - by travis config (see below): secret env vars
+          #  - by `common` script: WORKSPACE, IVY2_DIR, SBT_CMD, integrationRepoUrl
+          #  - by `bootstrap_fun`: publishPrivateTask, ...
+          - (cd admin && ./init.sh)
           - source scripts/common
           - source scripts/bootstrap_fun
           - determineScalaVersion
@@ -45,38 +33,26 @@ jobs:
           - if [ ! -z "$STARR_REF" ]; then buildStarr; fi
           - buildLocker
           - buildQuick
-          - set | grep -E '^SCALA_VER=|^SCALA_BINARY_VER=|^XML_VER=|^PARTEST_VER=|^SCALACHECK_VER=|^XML_BUILT=|^PARTEST_BUILT=|^SCALACHECK_BUILT=|^updatedModuleVersions=|^publishToSonatype=' > build/env
-          - cat build/env
           - triggerScalaDist
 
-      # this builds the spec using jekyll
-      # based on http://www.paperplanes.de/2013/8/13/deploying-your-jekyll-blog-to-s3-with-travis-ci.html
+      # pull request validation (w/ mini-bootstrap)
       - stage: build
-        script: bundle exec jekyll build -s spec/ -d build/spec
+        if: type = pull_request
+        script:
+          - sbt -warn setupPublishCore generateBuildCharacterPropertiesFile publishLocal
+          - STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
+          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
+
+      # build the spec using jekyll
+      - stage: build
         rvm: 2.2
         install: bundle install
-        # the key is restricted using forced commands so that it can only upload to the directory we need here
-        after_success: ./scripts/travis-publish-spec.sh
+        script:
+        - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then (cd admin && ./init.sh); fi'
+        - bundle exec jekyll build -s spec/ -d build/spec
+        after_success:
+        - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./scripts/travis-publish-spec.sh; fi'
 
-        # be careful to not set any env vars, as this will result in a cache miss
-      - &test
-        stage: test
-        before_script:
-          - source build/env
-          - if [ -z "$SCALA_VER" ]; then echo "Environment not propagated. Caching issue?"; cat build/env ; exit 1; fi
-          - source scripts/common
-          - source scripts/bootstrap_fun
-          # - find build -type f -exec touch {} + #  "set antStyle := true" seems to cause really long compiles for the test suite??
-        script: invokeQuick testRest # shouldn't rebuild, since build/ is cached
-      - <<: *test
-        script: invokeQuick testPosPres
-      - <<: *test
-        script: invokeQuick testRun
-      - script: testStability
-
-# cat /dev/urandom | head -c 10000 | openssl sha1 > ./secret
-# openssl aes-256-cbc -pass "file:./secret" -in id_dsa_spec212_b4096 -out spec/id_dsa_travis.enc -a
-# travis encrypt "PRIV_KEY_SECRET=`cat ./secret`"
 env:
   global:
     - secure: "TuJOUtALynPd+MV1AuMeIpVb8BUBHr7Ul7FS48XhS2PyuTRpEBkSWybYcNg3AXyzmWDAuOjUxbaNMQBvP8vvehTbIYls5H5wTGKvj0D0TNVaPIXjF8bA8KyNat9xGNzhnWm2/2BMaWpKBJWRF7Jb+zHhijMYCJEbkMtoiE5R/mY=" # PRIV_KEY_SECRET, for scripts/travis-publish-spec.sh
@@ -85,10 +61,6 @@ env:
     - secure: "ek3As5q2tL8UBXcxSBbv4v5YgsoPD41SCzPOSu72kzfbngyxgQxrcziU5pIM+Lib9KaWex7hVVWNL38tMyDbu+0OpDv8bPjMujzlDx5I2pJUfuOJo7QRYsJE1nsXcY4cA72cCLfbRcLEkvtDAhcdLSaUOqlyQe5BY4X4fY5eoPA=" # SONA_PASS
     - secure: "dbAvl6KEuLwZ0MVQPZihFsPzCdiLbX0EFk3so+hcfEbksrmLQ1tn4X5ZM7Wy1UDR8uN9lxngEwHch7a7lKqpugzmXMew9Wnikr9WBWbJT77Z+XJ/jHI6YuiCRpRo+nvxXGp9Ry80tSIgx5eju0J83IaJL41BWlBkvyAd7YAHORI=" # GPG_SUBKEY_SECRET
     - secure: "ee0z/1jehBjFa2M2JlBHRjeo6OEn/zmVl72ukBP1ISeKqz18Cswc4gDI5tV9RW9SlYFLkIlGsR2qnRCyJ/pqgQLcNdrpsCRFFc79oyLhfEtmPdAHlWfj4RSP68zINRtDdFuJ8iSy8XYP0NaqpVIYpkNdv9I6q7N85ljmMQpHO+U=" # TRAVIS_TOKEN (login with GitHub as lrytz)
-
-
-# using S3 would be simpler, but we want to upload to scala-lang.org
-# after_success: bundle exec s3_website push --headless
 
 before_cache:
   # Cleanup the cached directories to avoid unnecessary cache updates

--- a/scripts/travis-publish-spec.sh
+++ b/scripts/travis-publish-spec.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
-if [ "${PRIV_KEY_SECRET}" != "" -a "${TRAVIS_PULL_REQUEST}" = "false" ] ; then
-  openssl aes-256-cbc -pass "pass:$PRIV_KEY_SECRET" -in spec/id_dsa_travis.enc -out spec/id_dsa_travis -d -a
-  chmod 600 spec/id_dsa_travis
-  eval "$(ssh-agent)"
-  ssh-add -D
-  ssh-add spec/id_dsa_travis
-  rsync -e "ssh -o StrictHostKeyChecking=no" -rzv build/spec/ scalatest@chara.epfl.ch:/home/linuxsoft/archives/scala/spec/2.12/
-fi
+# based on http://www.paperplanes.de/2013/8/13/deploying-your-jekyll-blog-to-s3-with-travis-ci.html
 
+set -e
+openssl aes-256-cbc -pass "pass:$PRIV_KEY_SECRET" -in spec/id_dsa_travis.enc -out spec/id_dsa_travis -d -a
+chmod 600 spec/id_dsa_travis
+eval "$(ssh-agent)"
+ssh-add -D
+ssh-add spec/id_dsa_travis
+
+# the key is restricted using forced commands so that it can only upload to the directory we need here
+rsync -e "ssh -o StrictHostKeyChecking=no" -rzv build/spec/ \
+  scalatest@chara.epfl.ch:/home/linuxsoft/archives/scala/spec/2.12/

--- a/src/compiler/scala/tools/reflect/ToolBox.scala
+++ b/src/compiler/scala/tools/reflect/ToolBox.scala
@@ -23,7 +23,7 @@ trait ToolBox[U <: scala.reflect.api.Universe] {
 
   /** Represents mode of operations of the typechecker underlying `c.typecheck` calls.
    *  Is necessary since the shape of the typechecked tree alone is not enough to guess how it should be typechecked.
-   *  Can be EXPRmode (typecheck as a term), TYPEmode (typecheck as a type) or PATTERNmode (typecheck as a pattern).
+   *  Can be TERMmode (typecheck as a term), TYPEmode (typecheck as a type) or PATTERNmode (typecheck as a pattern).
    */
   type TypecheckMode
 
@@ -47,7 +47,7 @@ trait ToolBox[U <: scala.reflect.api.Universe] {
     typecheck(tree, TERMmode, pt, silent, withImplicitViewsDisabled, withMacrosDisabled)
 
   /** Typechecks a tree against the expected type `pt`
-   *  under typechecking mode specified in `mode` with [[EXPRmode]] being default.
+   *  under typechecking mode specified in `mode` with [[TERMmode]] being default.
    *  This populates symbols and types of the tree and possibly transforms it to reflect certain desugarings.
    *
    *  If the tree has unresolved type variables (represented as instances of `FreeTypeSymbol` symbols),

--- a/src/library/scala/collection/mutable/BufferLike.scala
+++ b/src/library/scala/collection/mutable/BufferLike.scala
@@ -100,7 +100,7 @@ trait BufferLike[A, +This <: BufferLike[A, This] with Buffer[A]]
     *
     *  @param n  the index which refers to the element to delete.
     *  @return   the previous element at index `n`
-    *   @throws   IndexOutOfBoundsException if the if the index `n` is not in the valid range
+    *  @throws   IndexOutOfBoundsException if the index `n` is not in the valid range
     *            `0 <= n < length`.
     */
   def remove(n: Int): A

--- a/src/reflect/scala/reflect/macros/Typers.scala
+++ b/src/reflect/scala/reflect/macros/Typers.scala
@@ -25,7 +25,7 @@ trait Typers {
 
   /** Represents mode of operations of the typechecker underlying `c.typecheck` calls.
    *  Is necessary since the shape of the typechecked tree alone is not enough to guess how it should be typechecked.
-   *  Can be EXPRmode (typecheck as a term), TYPEmode (typecheck as a type) or PATTERNmode (typecheck as a pattern).
+   *  Can be TERMmode (typecheck as a term), TYPEmode (typecheck as a type) or PATTERNmode (typecheck as a pattern).
    */
   // I'd very much like to make use of https://github.com/dsl-paradise/dsl-paradise here!
   type TypecheckMode
@@ -58,7 +58,7 @@ trait Typers {
     typecheck(tree, TERMmode, pt, silent, withImplicitViewsDisabled, withMacrosDisabled)
 
   /** Typechecks the provided tree against the expected type `pt` in the macro callsite context
-   *  under typechecking mode specified in `mode` with [[EXPRmode]] being default.
+   *  under typechecking mode specified in `mode` with [[TERMmode]] being default.
    *  This populates symbols and types of the tree and possibly transforms it to reflect certain desugarings.
    *
    *  If `silent` is false, `TypecheckException` will be thrown in case of a typecheck error.


### PR DESCRIPTION
only trivial merge conflicts.

the goal is to get #6630 onto 2.13.x so we can start doing
PR validation on both Travis-CI and Jenkins for now, with
the goal of eventually eliminating the Jenkins one.

```
*   5331f0b41f - (origin/2.12.x) Merge pull request #6630 from SethTisue/pr-validation-via-travis-mark-ii (19 minutes ago) <Seth Tisue>
|\
| * e3b2ae9291 - use Travis for (vastly simpler) PR validation (3 days ago) <Seth Tisue>
* |   a987b3815a - Merge pull request #6634 from GeorgiChochov/patch-1 (11 hours ago) <Julien Richard-Foy>
|\ \
| |/
|/|
| * 64a1a5064b - Improve documentation on BufferLike::remove (3 days ago) <Georgi Chochov>
|/
* 534a929708 - Merge pull request #6613 from kamilduda/issue/10864 (4 days ago) <Seth Tisue>
* dfaf865ae8 - Fixes scala/bug#10864 (5 days ago) <Kamil Duda>
```