### PR TITLE
Dummy override BitSet collect to avoid ambiguity

### DIFF
--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -204,6 +204,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
 
   def flatMap(f: Int => IterableOnce[Int]): C = fromSpecificIterable(new View.FlatMap(toIterable, f))
 
+  def collect(pf: PartialFunction[Int, Int]): C = fromSpecificIterable(super[SortedSetOps].collect(pf).toIterable)
 }
 
 object BitSetOps {

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -55,6 +55,8 @@ sealed abstract class BitSet
   override def map[B : Ordering](f: Int => B): SortedSet[B] = super[SortedSetOps].map(f)
 
   override protected[this] def writeReplace(): AnyRef = new BitSet.SerializationProxy(this)
+  override def collect(pf: PartialFunction[Int, Int]): BitSet = super[BitSet].collect(pf)
+  override def collect[B: Ordering](pf: scala.PartialFunction[Int, B]): SortedSet[B] = super[SortedSetOps].collect(pf)
 }
 
 /**

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -143,7 +143,9 @@ class BitSet(protected[collection] final var elems: Array[Long])
   override def map(f: Int => Int): BitSet = super[BitSet].map(f)
   override def map[B : Ordering](f: Int => B): SortedSet[B] = super[SortedSetOps].map(f)
 
-  override protected[this] def writeReplace(): AnyRef = new BitSet.SerializationProxy(this)
+  override protected[this] def writeReplace(): AnyRef = new BitSet.SerializationProxy(this) 
+  override def collect(pf: PartialFunction[Int, Int]): BitSet = super[BitSet].collect(pf)
+  override def collect[B: Ordering](pf: scala.PartialFunction[Int, B]): SortedSet[B] = super[SortedSetOps].collect(pf) 
 }
 
 object BitSet extends SpecificIterableFactory[Int, BitSet] {

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -58,4 +58,20 @@ class BitSetTest {
     assert(im.map(i=>i.toLong).isInstanceOf[collection.immutable.TreeSet[Long]])
     assert(im.map(i=>i + 1).isInstanceOf[collection.immutable.BitSet])
   } 
+
+  @Test def strawman_507: Unit = {
+    val m = BitSet(1,2,3)
+    assert(m.collect{case i if i%2 == 1 => i.toLong}.isInstanceOf[TreeSet[Long]])
+    assert(m.collect{case i if i%2 == 1 => i.toLong} == TreeSet(1L, 3L))
+
+    assert(m.collect{case i if i%2 == 1 => i}.isInstanceOf[BitSet])
+    assert(m.collect{case i if i%2 == 1 => i} == BitSet(1, 3))
+
+    val im = collection.immutable.BitSet(1,2,3)
+    assert(im.collect{case i if i%2 == 1 => i.toLong}.isInstanceOf[collection.immutable.TreeSet[Long]])
+    assert(im.collect{case i if i%2 == 1 => i.toLong} == collection.immutable.TreeSet(1L, 3L))
+
+    assert(im.collect{case i if i%2 == 1 => i}.isInstanceOf[collection.immutable.BitSet])
+    assert(im.collect{case i if i%2 == 1 => i} == collection.immutable.BitSet(1, 3))
+  }
 }


### PR DESCRIPTION
Fixes scala/collection-strawman#507

I use the same trick when fixing map on scala/collection-strawman#508 overriding (im)mutable.BitSet collect for both `PartialFunction[Int,Int]` and `PartialFunction[Int,B]` for ordered B.

The difference is that in 508 `collection.BitSet` already have map defined, here I have to introduce collect producing BitSet that will be used for `PartialFunction[Int,Int]` in the (im)mutable overrides.

While working on scala/collection-strawman#508 @julienrf  suggest to handle flatMap also, when I tried current implementation seems not to have ambiguity for flatMap, so I don't do anything with it.