### PR TITLE
Revert error message refinement in NotAValueError.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -567,7 +567,7 @@ trait ContextErrors {
           val unknowns = (namelessArgs zip args) collect {
             case (_: Assign, AssignOrNamedArg(Ident(name), _)) => name
           }
-          val suppl = 
+          val suppl =
             unknowns.size match {
               case 0 => ""
               case 1 => s"\nNote that '${unknowns.head}' is not a parameter name of the invoked method."
@@ -752,12 +752,7 @@ trait ContextErrors {
 
       // def stabilize
       def NotAValueError(tree: Tree, sym: Symbol) = {
-        /* Give a better error message for `val thread = java.lang.Thread`. */
-        val betterKindString =
-          if (sym.isJavaDefined && sym.isTrait) "Java interface"
-          else if (sym.isJavaDefined && (sym.isClass || sym.isModule)) "Java class"
-          else sym.kindString
-        issueNormalTypeError(tree, s"$betterKindString ${sym.fullName} is not a value")
+        issueNormalTypeError(tree, sym.kindString + " " + sym.fullName + " is not a value")
         setError(tree)
       }
 

--- a/test/files/neg/object-not-a-value.check
+++ b/test/files/neg/object-not-a-value.check
@@ -1,4 +1,4 @@
-object-not-a-value.scala:5: error: Java class java.util.List is not a value
+object-not-a-value.scala:5: error: class java.util.List is not a value
     List(1) map (_ + 1)
     ^
 one error found

--- a/test/files/neg/t0673.check
+++ b/test/files/neg/t0673.check
@@ -1,4 +1,4 @@
-Test.scala:2: error: Java class JavaClass.InnerClass is not a value
+Test.scala:2: error: class JavaClass.InnerClass is not a value
   val x = JavaClass.InnerClass
                     ^
 one error found

--- a/test/files/neg/t10888.check
+++ b/test/files/neg/t10888.check
@@ -1,0 +1,14 @@
+t10888.scala:3: error: package java.lang is not a value
+  val v = java.lang                  // package java.lang is not a value
+               ^
+t10888.scala:4: error: class java.lang.Thread is not a value
+  val w = java.lang.Thread           // class java.lang.Thread is not a value
+                    ^
+t10888.scala:5: error: package scala.collection is not a value
+  val x = scala.collection           // package scala.collection is not a value
+                ^
+t10888.scala:7: error: object App is not a member of package scala
+Note: trait App exists, but it has no companion object.
+  val z = scala.App                  // object App is not a member of package scala
+                ^
+four errors found

--- a/test/files/neg/t10888.scala
+++ b/test/files/neg/t10888.scala
@@ -1,0 +1,9 @@
+object t10888 {
+
+  val v = java.lang                  // package java.lang is not a value
+  val w = java.lang.Thread           // class java.lang.Thread is not a value
+  val x = scala.collection           // package scala.collection is not a value
+  val y = scala.collection.`package`
+  val z = scala.App                  // object App is not a member of package scala
+
+}

--- a/test/files/neg/t7251.check
+++ b/test/files/neg/t7251.check
@@ -1,4 +1,4 @@
-B_2.scala:5: error: Java class s.Outer$Triple$ is not a value
+B_2.scala:5: error: class s.Outer$Triple$ is not a value
     println( s.Outer$Triple$ )
                ^
 one error found

--- a/test/files/run/t6814.check
+++ b/test/files/run/t6814.check
@@ -1,6 +1,6 @@
 List[Int]
 scala.collection.immutable.List.type
-Java class java.lang.RuntimeException is not a value
+class java.lang.RuntimeException is not a value
 List[Int]
 List
 scala.collection.immutable.List.type


### PR DESCRIPTION
I refined it further during PR review in `symbolKind`, and apparently didn't notice that those changes weren't being used in favor of the half-baked implementation in `NotAValueError`.

Fixes scala/bug#10888.