### PR TITLE
Add deprecated `-` and `+` methods to collection.(Map|Set)

### DIFF
--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -48,6 +48,12 @@ trait Map[K, +V]
   override def hashCode(): Int = MurmurHash3.mapHash(toIterable)
 
   override protected[this] def writeReplace(): AnyRef = new DefaultSerializationProxy(mapFactory.mapFactory[K, V], this)
+
+  // These two methods are not in MapOps so that MapView is not forced to implement them
+  @deprecated("Use - or remove on an immutable Map", "2.13.0")
+  def - (key: K): Map[K, V]
+  @deprecated("Use -- or removeAll on an immutable Map", "2.13.0")
+  def - (key1: K, key2: K, keys: K*): Map[K, V]
 }
 
 /** Base Map implementation type
@@ -281,8 +287,11 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
   override def mkString(sep: String): String = super.mkString(sep)
   override def mkString: String = super.mkString
 
-  @deprecated("Consider requiring an immutable Map or fall back to Map.concat ", "2.13.0")
+  @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
   def + [V1 >: V](kv: (K, V1)): CC[K, V1] = mapFactory.from(new View.Appended(toIterable, kv))
+
+  @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
+  def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = mapFactory.from(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
 }
 
 object MapOps {

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -155,6 +155,12 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   @deprecated("Use &~ or diff instead of --", "2.13.0")
   @`inline` final def -- (that: Set[A]): C = diff(that)
 
+  @deprecated("Consider requiring an immutable Set or fall back to Set.diff", "2.13.0")
+  def - (elem: A): C = diff(Set(elem))
+
+  @deprecated("Use &- with an explicit collection argument instead of - with varargs", "2.13.0")
+  def - (elem1: A, elem2: A, elems: A*): C = diff(elems.toSet + elem1 + elem2)
+
   /** Creates a new $coll by adding all elements contained in another collection to this $coll, omitting duplicates.
     *
     * This method takes a collection of elements and adds all elements, omitting duplicates, into $coll.
@@ -170,9 +176,11 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     */
   def concat(that: collection.Iterable[A]): C = fromSpecificIterable(new View.Concat(toIterable, that))
 
-  @deprecated("Consider requiring an immutable Set or fall back to Set.union ", "2.13.0")
+  @deprecated("Consider requiring an immutable Set or fall back to Set.union", "2.13.0")
   def + (elem: A): C = fromSpecificIterable(new View.Appended(toIterable, elem))
-  //TODO We should be able to use `fromIterable` here but Dotty complains about a variance problem with no apparent workaround
+
+  @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
+  def + (elem1: A, elem2: A, elems: A*): C = fromSpecificIterable(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
 
   /** Alias for `concat` */
   @`inline` final def ++ (that: collection.Iterable[A]): C = concat(that)

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -61,7 +61,10 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   def remove(key: K): C
 
   /** Alias for `remove` */
-  @`inline` final def - (key: K): C = remove(key)
+  /* @`inline` final */ def - (key: K): C = remove(key)
+
+  @deprecated("Use -- with an explicit collection", "2.13.0")
+  def - (key1: K, key2: K, keys: K*): C = remove(key1).remove(key2).removeAll(keys)
 
   /** Creates a new $coll from this $coll by removing all elements of another
     *  collection.

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -43,7 +43,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   def excl(elem: A): C
 
   /** Alias for `excl` */
-  @`inline` final def - (elem: A): C = excl(elem)
+  /* @`inline` final */ override def - (elem: A): C = excl(elem)
 
   override def concat(that: collection.Iterable[A]): C = {
     var result: C = coll

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -59,6 +59,12 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
     with Growable[(K, V)]
     with Shrinkable[K] {
 
+  @deprecated("Use - or remove on an immutable Map", "2.13.0")
+  /* final */ def - (key: K): C = clone() -= key
+
+  @deprecated("Use -- or removeAll on an immutable Map", "2.13.0")
+  /* final */ def - (key1: K, key2: K, keys: K*): C = clone() -= key1 -= key2 --= keys
+
   /** Adds a new key/value pair to this map and optionally returns previously bound value.
     *  If the map already contains a
     *  mapping for the key, it will be overridden by the new value.

--- a/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
+++ b/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
@@ -249,7 +249,7 @@ final class WeakHashSet[A <: AnyRef](val initialCapacity: Int, val loadFactor: D
     }
   }
 
-  def -(elem: A) = subtractOne(elem)
+  override def -(elem: A) = subtractOne(elem)
 
   // empty this set
   override def clear(): Unit = {

--- a/test/files/pos/t247.scala
+++ b/test/files/pos/t247.scala
@@ -2,6 +2,8 @@ class Order[t](less:(t,t) => Boolean,equal:(t,t) => Boolean) {}
 
 trait Map[A, B] extends scala.collection.Map[A, B] {
   val factory:MapFactory[A]
+  def -(key1: A, key2: A, keys: A*): Map[A, B] = null
+  def -(key: A): Map[A, B] = null
 }
 abstract class MapFactory[A] {
   def Empty[B]:Map[A,B];


### PR DESCRIPTION
Fixes https://github.com/scala/collection-strawman/issues/540.

@lrytz I had to remove some `final` modifiers because of illegal bridge methods. I expected these would be gone after bootstrapping from M4 with https://github.com/scala/scala/pull/6531 but they still occur.