### PR TITLE
Deprecate override of stringPrefix

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -201,7 +201,19 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     *           applied to this $coll. By default the string prefix is the
     *           simple name of the collection class $coll.
     */
-  def className: String = {
+  @`inline` protected[this] def className: String = stringPrefix
+
+  /** Forwarder to `className` for use in `scala.runtime.ScalaRunTime`.
+    * 
+    * This allows the proper visibility for `className` to be
+    * published, but provides the exclusive access needed by
+    * `scala.runtime.ScalaRunTime.stringOf` (and a few tests in
+    * the test suite).
+    */
+  private[scala] final def collectionClassName: String = className
+
+  @deprecatedOverriding("Override className instead", "2.13.0")
+  protected[this] def stringPrefix: String = {
     /* This method is written in a style that avoids calling `String.split()`
      * as well as methods of java.lang.Character that require the Unicode
      * database information. This is mostly important for Scala.js, so that
@@ -265,9 +277,6 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     // dead code
     result
   }
-
-  @deprecated("Use className instead of stringPrefix", "2.13.0")
-  @`inline` final def stringPrefix: String = className
 
   /** Converts this $coll to a string.
     *

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -238,8 +238,8 @@ object ScalaRunTime {
       case x: String                    => if (x.head.isWhitespace || x.last.isWhitespace) "\"" + x + "\"" else x
       case x if useOwnToString(x)       => x.toString
       case x: AnyRef if isArray(x)      => arrayToString(x)
-      case x: scala.collection.Map[_, _] => x.iterator take maxElements map mapInner mkString (x.className + "(", ", ", ")")
-      case x: Iterable[_]               => x.iterator take maxElements map inner mkString (x.className + "(", ", ", ")")
+      case x: scala.collection.Map[_, _] => x.iterator take maxElements map mapInner mkString (x.collectionClassName + "(", ", ", ")")
+      case x: Iterable[_]               => x.iterator take maxElements map inner mkString (x.collectionClassName + "(", ", ", ")")
       case x: Product1[_] if isTuple(x) => "(" + inner(x._1) + ",)" // that special trailing comma
       case x: Product if isTuple(x)     => x.productIterator map inner mkString ("(", ",", ")")
       case x                            => x.toString

--- a/test/junit/scala/collection/FactoriesTest.scala
+++ b/test/junit/scala/collection/FactoriesTest.scala
@@ -17,7 +17,7 @@ class FactoriesTest {
     def cloneCollection[A, C](xs: Iterable[A])(implicit bf: BuildFrom[xs.type, A, C]): C =
       bf.fromSpecificIterable(xs)(xs)
 
-    Assert.assertEquals("ArrayBuffer", cloneCollection(seq).className)
+    Assert.assertEquals("ArrayBuffer", cloneCollection(seq).collectionClassName)
   }
 
   @Test def factoryIgnoresSourceCollectionFactory(): Unit = {
@@ -25,7 +25,7 @@ class FactoriesTest {
     def cloneElements[A, C](xs: Iterable[A])(cb: Factory[A, C]): C =
       cb.fromSpecific(xs)
 
-    Assert.assertEquals("List", cloneElements(seq)(Seq).className)
+    Assert.assertEquals("List", cloneElements(seq)(Seq).collectionClassName)
   }
 
   def apply(factory: IterableFactory[Iterable]): Unit = {

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -121,4 +121,37 @@ class IterableTest {
     Assert.assertTrue(Seq('a', 'b', 'c').sameElements(s2))
     Assert.assertTrue(Seq(true, false, true).sameElements(s3))
   }
+
+  @Test
+  def overrideClassName: Unit = {
+    class Foo[+A] extends Iterable[A] {
+      def iterator = Iterator.empty[A]
+      override def className = "Fu"
+    }
+    val foo = new Foo
+    Assert.assertEquals("Fu()", foo.toString)
+  }
+
+  @Test
+  def overrideStringPrefix: Unit = {
+    class Foo[+A] extends Iterable[A] {
+      def iterator = Iterator.empty[A]
+      override def stringPrefix = "Bar"
+
+    }
+    val foo = new Foo
+    Assert.assertEquals("Bar()", foo.toString)
+  }
+
+  @Test
+  def overrideClassNameAndStringPrefix: Unit = {
+    class Foo[+A] extends Iterable[A] {
+      def iterator = Iterator.empty[A]
+      override def className = "Fu"
+      override def stringPrefix = "Bar"
+
+    }
+    val foo = new Foo
+    Assert.assertEquals("Fu()", foo.toString)
+  }
 }

--- a/test/junit/scala/collection/TraversableLikeTest.scala
+++ b/test/junit/scala/collection/TraversableLikeTest.scala
@@ -51,20 +51,20 @@ class TraversableLikeTest {
     }
 
     val bar = Foo.mkBar()
-    assertEquals("Bar", bar.stringPrefix)  // Previously would have been outermost class, TraversableLikeTest
+    assertEquals("Bar", bar.collectionClassName)  // Previously would have been outermost class, TraversableLikeTest
 
     val baz = new Baz[Int]()
-    assertEquals("TraversableLikeTest.Baz", baz.stringPrefix)  // Make sure we don't see specialization $mcI$sp stuff
+    assertEquals("TraversableLikeTest.Baz", baz.collectionClassName)  // Make sure we don't see specialization $mcI$sp stuff
 
-    // The false positive unfortunately produces an empty stringPrefix
+    // The false positive unfortunately produces an empty collectionClassName
     val falsePositive = Foo.mkFalsePositiveToSyntheticTest()
-    assertEquals("", falsePositive.stringPrefix)
+    assertEquals("", falsePositive.collectionClassName)
 
     val french = Foo.mkFrench()
-    assertEquals("ÉtrangeNomDeClasse", french.stringPrefix)
+    assertEquals("ÉtrangeNomDeClasse", french.collectionClassName)
 
     val frenchLowercase = Foo.mkFrenchLowercase()
-    assertEquals("étrangeNomDeClasseMinuscules", frenchLowercase.stringPrefix)
+    assertEquals("étrangeNomDeClasseMinuscules", frenchLowercase.collectionClassName)
   }
 
   @Test

--- a/test/junit/scala/collection/mutable/QueueTest.scala
+++ b/test/junit/scala/collection/mutable/QueueTest.scala
@@ -13,7 +13,7 @@ class QueueTest {
   def reversingReturnsAQueue(): Unit = {
     val q1 = Queue(1, 2, 3)
     val q2: Queue[Int] = q1.reverse
-    assertEquals("Queue", q2.className)
+    assertEquals("Queue", q2.collectionClassName)
   }
 
   @Test

--- a/test/junit/scala/collection/mutable/StackTest.scala
+++ b/test/junit/scala/collection/mutable/StackTest.scala
@@ -13,6 +13,6 @@ class StackTest {
   def reversingReturnsAStack(): Unit = {
     val s1 = Stack(1, 2, 3)
     val s2: Stack[Int] = s1.reverse
-    assertEquals("Stack", s2.className)
+    assertEquals("Stack", s2.collectionClassName)
   }
 }

--- a/test/junit/scala/runtime/ScalaRunTimeTest.scala
+++ b/test/junit/scala/runtime/ScalaRunTimeTest.scala
@@ -28,12 +28,12 @@ class ScalaRunTimeTest {
         stringOf(Array(Array("", 1, Array(5)), Array(1))))
 
     val map = Map(1->"", 2->"a", 3->" a", 4->null)
-    assertEquals(s"""${map.stringPrefix}(1 -> "", 2 -> a, 3 -> " a", 4 -> null)""", stringOf(map))
-    assertEquals(s"""${map.stringPrefix}(1 -> "", 2 -> a)""", stringOf(map, 2))
+    assertEquals(s"""Map.Map4(1 -> "", 2 -> a, 3 -> " a", 4 -> null)""", stringOf(map))
+    assertEquals(s"""Map.Map4(1 -> "", 2 -> a)""", stringOf(map, 2))
 
     val iterable = Iterable("a", "", " c", null)
-    assertEquals(s"""${iterable.stringPrefix}(a, "", " c", null)""", stringOf(iterable))
-    assertEquals(s"""${iterable.stringPrefix}(a, "")""", stringOf(iterable, 2))
+    assertEquals(s"""List(a, "", " c", null)""", stringOf(iterable))
+    assertEquals(s"""List(a, "")""", stringOf(iterable, 2))
 
     val tuple1 = Tuple1(0)
     assertEquals("(0,)", stringOf(tuple1))


### PR DESCRIPTION
While working on updating scala-xml to 2.13.0-M4, I ran across a problem with its overriding `stringPrefix`:

```
[error]   scala-xml/shared/src/main/scala/scala/xml/NodeBuffer.scala:24:
[error]   overriding method stringPrefix in trait IterableOps of type => String;
[error]   method stringPrefix cannot override final member
[error]   override def stringPrefix: String = "NodeBuffer"
```

Looks like it was marked `deprecated` in 2.13.0, but it's been changed to `final`, so any existing code that overrides it will no longer work.

Is the plan to remove it in 2.14.0?  My guess is nobody is actually calling `stringPrefix`, since the point is to override it with something else so that it is used by `toString`.