### PR TITLE
Remove non existing dependencies from scala-partest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -558,6 +558,7 @@ lazy val partest = configureAsSubproject(project)
     name := "scala-partest",
     description := "Scala Compiler Testing Tool",
     libraryDependencies ++= List(testInterfaceDep, diffUtilsDep),
+    pomDependencyExclusions ++= List((organization.value, "scala-repl-frontend"), (organization.value, "scala-compiler-doc")),
     fixPom(
       "/project/name" -> <name>Scala Partest</name>,
       "/project/description" -> <description>Scala Compiler Testing Tool</description>,


### PR DESCRIPTION
The `scala-repl-frontend` and `scala-compiler-doc` sbt modules are
merged into `scala-compiler`.

Tested with `publishLocal`. Fixes https://github.com/scala/scala-dev/issues/512.