### PR TITLE
REPL: More noise when entering :silent mode

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -742,7 +742,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter) extend
 
   def verbosity() = {
     intp.printResults = !intp.printResults
-    replinfo(s"Result printing is ${ if (intp.printResults) "on" else "off" }.")
+    if (in.interactive || isReplInfo) echo(s"Result printing is ${ if (intp.printResults) "on" else "off" }.")
   }
 
   /** Run one command submitted by the user.  Two values are returned:

--- a/test/files/run/t6507.check
+++ b/test/files/run/t6507.check
@@ -1,5 +1,6 @@
 
 scala> :silent
+Result printing is off.
 
 scala> class A { override def toString() = { println("!"); "A" } }
 
@@ -12,6 +13,7 @@ scala> b = new A
 scala> new A
 
 scala> :silent
+Result printing is on.
 
 scala> res0
 !


### PR DESCRIPTION
Report `silent` status with an interactive reader
or in friendly verbose `info` mode.

```
$ skala
Welcome to Scala 2.12.7 (OpenJDK 64-Bit Server VM 1.8.0_171)

scala> :load sc.sc
Loading sc.sc...
res0: String = hello
res2: String = goodbye

scala> :quit
$ skala -Dscala.repl.info
Welcome to Scala 2.12.7 (OpenJDK 64-Bit Server VM 1.8.0_171)
[info] started at Mon May 21 14:33:00 PDT 2018

scala 2.12.7-20180521-212215-2f5c49c> :load sc.sc
Loading sc.sc...
res0: String = hello
Result printing is off.
Result printing is on.
res2: String = goodbye

scala 2.12.7-20180521-212215-2f5c49c> :q
$ cat sc.sc
"hello"
:silent
"ha, no way"
:silent
"goodbye"
```