### PR TITLE
fix scala.reflect.Manifest scaladoc

### DIFF
--- a/src/library/scala/reflect/Manifest.scala
+++ b/src/library/scala/reflect/Manifest.scala
@@ -26,13 +26,13 @@ import scala.collection.mutable.{ArrayBuilder, ArraySeq}
  *    def arr[T](implicit m: Manifest[T]) = new Array[T](0) // compiles
  *    def arr[T: Manifest] = new Array[T](0)                // shorthand for the preceding
  *
- *    // Methods manifest, classManifest, and optManifest are in [[scala.Predef]].
+ *    // Methods manifest and optManifest are in [[scala.Predef]].
  *    def isApproxSubType[T: Manifest, U: Manifest] = manifest[T] <:< manifest[U]
  *    isApproxSubType[List[String], List[AnyRef]] // true
  *    isApproxSubType[List[String], List[Int]]    // false
  *
- *    def methods[T: ClassManifest] = classManifest[T].erasure.getMethods
- *    def retType[T: ClassManifest](name: String) =
+ *    def methods[T: Manifest] = manifest[T].runtimeClass.getMethods
+ *    def retType[T: Manifest](name: String) =
  *      methods[T] find (_.getName == name) map (_.getGenericReturnType)
  *
  *    retType[Map[_, _]]("values")  // Some(scala.collection.Iterable<B>)


### PR DESCRIPTION
- `Predef.classManifest` no longer exists https://github.com/scala/scala/commit/ed614acf789b2ef5dd0624a90ea5f43714d5da0d#diff-532a778b9b259c18ed28fd43a22e44feL207
- `ClassManifest` is deprecated. use `Manifest`
- `erasure` is deprecated. use `runtimeClass`

```
Welcome to Scala 2.13.0-M4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_172).
Type in expressions for evaluation. Or try :help.

scala> def methods[T: Manifest] = manifest[T].runtimeClass.getMethods
methods: [T](implicit evidence$1: Manifest[T])Array[java.lang.reflect.Method]

scala> def retType[T: Manifest](name: String) =
     |   methods[T] find (_.getName == name) map (_.getGenericReturnType)
retType: [T](name: String)(implicit evidence$1: Manifest[T])Option[java.lang.reflect.Type]

scala> retType[Map[_, _]]("values")
res0: Option[java.lang.reflect.Type] = Some(scala.collection.Iterable<V>)
```