### PR TITLE
Move range position validation behind a flag.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -733,6 +733,7 @@ lazy val test = project
     // test sources are compiled in partest run, not here
     sources in IntegrationTest := Seq.empty,
     fork in IntegrationTest := true,
+    scalacOptions in Compile += "-Yvalidate-pos:parser,typer",
     javaOptions in IntegrationTest ++= List("-Xmx2G", "-Dpartest.exec.in.process=true", "-Dfile.encoding=UTF-8", "-Duser.language=en", "-Duser.country=US"),
     testOptions in IntegrationTest += Tests.Argument("-Dfile.encoding=UTF-8", "-Duser.language=en", "-Duser.country=US"),
     testFrameworks += new TestFramework("scala.tools.partest.sbt.Framework"),

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1472,6 +1472,9 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
         if (settings.browse containsPhase globalPhase)
           treeBrowser browse (phase.name, units)
 
+        if ((settings.Yvalidatepos containsPhase globalPhase) && !reporter.hasErrors)
+          currentRun.units.foreach(unit => validatePositions(unit.body))
+
         // move the pointer
         globalPhase = globalPhase.next
 

--- a/src/compiler/scala/tools/nsc/ast/parser/SyntaxAnalyzer.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/SyntaxAnalyzer.scala
@@ -98,9 +98,6 @@ abstract class SyntaxAnalyzer extends SubComponent with Parsers with MarkupParse
       if (unit.body == EmptyTree)
         unit.body = initialUnitBody(unit)
 
-      if (settings.Yrangepos && !reporter.hasErrors)
-        validatePositions(unit.body)
-
       if (settings.Ymemberpos.isSetByUser)
         new MemberPosReporter(unit) show (style = settings.Ymemberpos.value)
     }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -214,6 +214,7 @@ trait ScalaSettings extends AbsScalaSettings
   val stopAfter       = PhasesSetting     ("-Ystop-after", "Stop after") withAbbreviation ("-stop") // backward compat
   val stopBefore      = PhasesSetting     ("-Ystop-before", "Stop before")
   val Yrangepos       = BooleanSetting    ("-Yrangepos", "Use range positions for syntax trees.")
+  val Yvalidatepos    = PhasesSetting     ("-Yvalidate-pos", "Validate positions after the given phases") withPostSetHook (_ => Yrangepos.value = true)
   val Ymemberpos      = StringSetting     ("-Yshow-member-pos", "output style", "Show start and end positions of members", "") withPostSetHook (_ => Yrangepos.value = true)
   val Yreifycopypaste = BooleanSetting    ("-Yreify-copypaste", "Dump the reified trees in copypasteable representation.")
   val Ymacroexpand    = ChoiceSetting     ("-Ymacro-expand", "policy", "Control expansion of macros, useful for scaladoc and presentation compiler.", List(MacroExpand.Normal, MacroExpand.None, MacroExpand.Discard), MacroExpand.Normal)

--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -103,7 +103,6 @@ trait Analyzer extends AnyRef
         try {
           val typer = newTyper(rootContext(unit))
           unit.body = typer.typed(unit.body)
-          if (global.settings.Yrangepos && !global.reporter.hasErrors) global.validatePositions(unit.body)
           for (workItem <- unit.toCheck) workItem()
           if (settings.warnUnusedImport)
             warnUnusedImports(unit)

--- a/src/partest/scala/tools/partest/sbt/SBTRunner.scala
+++ b/src/partest/scala/tools/partest/sbt/SBTRunner.scala
@@ -50,7 +50,7 @@ class SBTRunner(val config: RunnerSpec.Config,
 
   val scalacOpts = {
     val l = defs.collect { case ("partest.scalac_opts", v) => v }
-    if(l.isEmpty) PartestDefaults.javaOpts
+    if(l.isEmpty) PartestDefaults.scalacOpts
     else l.mkString(" ")
   }
 

--- a/src/reflect/scala/reflect/internal/Positions.scala
+++ b/src/reflect/scala/reflect/internal/Positions.scala
@@ -108,7 +108,7 @@ trait Positions extends api.Positions { self: SymbolTable =>
     def validate(tree: Tree, encltree: Tree): Unit = {
 
       if (!tree.isEmpty && tree.canHaveAttrs) {
-        if (settings.Yposdebug && (settings.verbose || settings.Yrangepos))
+        if (settings.Yposdebug && settings.verbose)
           inform("[%10s] %s".format("validate", treeStatus(tree, encltree)))
 
         if (!tree.pos.isDefined)
@@ -146,8 +146,7 @@ trait Positions extends api.Positions { self: SymbolTable =>
       }
     }
 
-    if (!isPastTyper)
-      validate(tree, tree)
+    validate(tree, tree)
   }
 
   def solidDescendants(tree: Tree): List[Tree] =


### PR DESCRIPTION
The motivation is that the validation step isn't fast, and takes up a good chunk of the "rangepos penalty" time difference. Moreover, Alex Average User can't do much about a fatal rangepos error other than twiddle around their source until it goes away, so it's likely to bother end users less like this. However, since positions are important, turn the flag on unconditionally for partesting.

References scala/scala-dev#472.

~~Stacked on top of scala/scala#6423.~~

Partest will fail until I resurrect scala/scala#6335.

TODO: 
- [ ] enhance error message, and make it less violently fatal?
- [ ] get that other PR going so Jenkins goes green