### PR TITLE
Outer parameters have the ACC_SYNTHETIC flag in bytecode.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -160,7 +160,7 @@ abstract class ExplicitOuter extends InfoTransform
 
       val paramsWithOuter =
         if (sym.isClassConstructor && isInner(sym.owner)) // 1
-          sym.newValueParameter(nme.OUTER_ARG, sym.pos).setInfo(sym.owner.outerClass.thisType) :: params
+          sym.newValueParameter(nme.OUTER_ARG, sym.pos, ARTIFACT).setInfo(sym.owner.outerClass.thisType) :: params
         else params
 
       if ((resTpTransformed ne resTp) || (paramsWithOuter ne params)) MethodType(paramsWithOuter, resTpTransformed)
@@ -399,7 +399,7 @@ abstract class ExplicitOuter extends InfoTransform
                       reporter.error(tree.pos, s"Implementation restriction: ${clazz.fullLocationString} requires premature access to ${clazz.outerClass}.")
                     }
                     val outerParam =
-                      sym.newValueParameter(nme.OUTER, sym.pos) setInfo clazz.outerClass.thisType
+                      sym.newValueParameter(nme.OUTER, sym.pos, ARTIFACT) setInfo clazz.outerClass.thisType
                     ((ValDef(outerParam) setType NoType) :: vparamss.head) :: vparamss.tail
                   } else vparamss
                 super.transform(copyDefDef(tree)(vparamss = vparamss1))

--- a/test/files/jvm/t10880.check
+++ b/test/files/jvm/t10880.check
@@ -1,0 +1,2 @@
+List(class Provides, Provides<T>)
+List(Provides<T>)

--- a/test/files/jvm/t10880.scala
+++ b/test/files/jvm/t10880.scala
@@ -1,0 +1,18 @@
+trait Provider[T] {
+  def provide: T
+}
+
+class Provides[T] {
+  def provide(t: T): Provider[T] = new Provider[T] { def provide = t }
+}
+
+object Test extends App {
+
+  val ctor = Class.forName("Provides$$anon$1")
+    .getDeclaredConstructors
+    .head
+
+  println(ctor.getParameters.map(_.getParameterizedType).toList)
+  println(ctor.getGenericParameterTypes.toList)
+
+}


### PR DESCRIPTION
Apparently the generic signature for constructors is not expected to mention the outer accessor, but the descriptor obviously must. This discrepancy must be handled by the Java reflection method `Parameter#getParameterizedType`, which knows to ignore synthetic (or "mandated") method parameters that it sees in the descriptor while parsing the signature.

This relies heavily on the `MethodParameters` classfile attribute, and experimentation shows that stripping that information from the classfile causes `getParameterizedType` to report only the erased types that it sees in the descriptor.

Javac, with `-parameters`, emits the outer accessor with the `ACC_MANDATED` flag, which we don't emit (and doesn't appear to be a public API yet). However, it interprets `ACC_SYNTHETIC` in the same way, and we do emit that (now).

This should be a one-liner, but GenBCode reads the parameter symbols off the `DefDef`, not the method's symbol's info. This shouldn't matter, but I did notice that we make another, *different* symbol for the parameter to use in the method's info. (It's also got a different name: `arg$outer` rather than `$outer`.) To be safe, I marked them both `ARTIFACT`. (PR only note: this hails from [the massive named/default args commit](390ccacfe0caa4c07af6193dec3e172c0fcd7896); `nme.OUTER_ARG` seems otherwise unused. What are the negative consequences of the param tree having a different symbol than the param in the info?)

Fixes scala/bug#10880.