### PR TITLE
Add support for Views to IsIterableLike

### DIFF
--- a/src/library/scala/collection/Searching.scala
+++ b/src/library/scala/collection/Searching.scala
@@ -9,7 +9,7 @@
 package scala.collection
 
 import scala.language.implicitConversions
-import scala.collection.generic.IsSeqLike
+import scala.collection.generic.IsSeq
 
 object Searching {
   sealed abstract class SearchResult {
@@ -26,6 +26,6 @@ object Searching {
   class SearchImpl[Repr, A](private val coll: SeqOps[A, AnyConstr, _]) extends AnyVal
 
   @deprecated("Search methods are defined directly on SeqOps and do not require scala.collection.Searching any more", "2.13.0")
-  implicit def search[Repr, A](coll: Repr)(implicit fr: IsSeqLike[Repr]): SearchImpl[Repr, fr.A] =
+  implicit def search[Repr, A](coll: Repr)(implicit fr: IsSeq[Repr]): SearchImpl[Repr, fr.A] =
     new SearchImpl(fr.conversion(coll))
 }

--- a/src/library/scala/collection/generic/IsIterableOnce.scala
+++ b/src/library/scala/collection/generic/IsIterableOnce.scala
@@ -64,9 +64,9 @@ object IsIterableOnce extends IsIterableOnceLowPriority {
 
 trait IsIterableOnceLowPriority {
 
-  // Makes `IsIterableLike` instance visible in `IsIterableOnce` companion
+  // Makes `IsIterable` instance visible in `IsIterableOnce` companion
   implicit def isIterableLikeIsIterableOnce[Repr](implicit
-    isIterableLike: IsIterableLike[Repr]
+    isIterableLike: IsIterable[Repr]
   ): IsIterableOnce[Repr] { type A = isIterableLike.A } = isIterableLike
 
 }

--- a/src/library/scala/collection/generic/IsIterableOnce.scala
+++ b/src/library/scala/collection/generic/IsIterableOnce.scala
@@ -1,0 +1,72 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+package collection
+package generic
+
+/** Type class witnessing that a collection representation type `Repr` has
+ *  elements of type `A` and has a conversion to `IterableOnce[A]`.
+ *
+ *  This type enables simple enrichment of `IterableOnce`s with extension
+ *  methods which can make full use of the mechanics of the Scala collections
+ *  framework in their implementation.
+ *
+ *  Example usage,
+ * {{{
+ *    class FilterMapImpl[Repr, I <: IsIterableOnce[Repr]](coll: Repr, it: I) {
+ *      final def filterMap[B, That](f: it.A => Option[B])(implicit bf: BuildFrom[Repr, B, That]): That = {
+ *        val b = bf.newBuilder(coll)
+ *        for(e <- it(coll)) f(e) foreach (b +=)
+ *        b.result()
+ *      }
+ *    }
+ *    implicit def filterMap[Repr](coll: Repr)(implicit it: IsIterableOnce[Repr]): FilterMapImpl[Repr, it.type] =
+ *      new FilterMapImpl(coll, it)
+ *
+ *    List(1, 2, 3, 4, 5) filterMap (i => if(i % 2 == 0) Some(i) else None)
+ *    // == List(2, 4)
+ * }}}
+ *
+ * @author Miles Sabin
+ * @author J. Suereth
+ * @since 2.10
+ */
+trait IsIterableOnce[Repr] {
+
+  /** The type of elements we can traverse over (e.g. `Int`). */
+  type A
+
+  @deprecated("'conversion' is now a method named 'apply'", "2.13.0")
+  val conversion: Repr => IterableOnce[A] = apply(_)
+
+  /** A conversion from the representation type `Repr` to a `IterableOnce[A]`. */
+  def apply(coll: Repr): IterableOnce[A]
+
+}
+
+object IsIterableOnce extends IsIterableOnceLowPriority {
+  import scala.language.higherKinds
+
+  // Straightforward case: IterableOnce subclasses
+  implicit def iterableOnceIsIterableOnce[CC0[A] <: IterableOnce[A], A0]: IsIterableOnce[CC0[A0]] { type A = A0 } =
+    new IsIterableOnce[CC0[A0]] {
+      type A = A0
+      def apply(coll: CC0[A0]): IterableOnce[A0] = coll
+    }
+
+}
+
+trait IsIterableOnceLowPriority {
+
+  // Makes `IsIterableLike` instance visible in `IsIterableOnce` companion
+  implicit def isIterableLikeIsIterableOnce[Repr](implicit
+    isIterableLike: IsIterableLike[Repr]
+  ): IsIterableOnce[Repr] { type A = isIterableLike.A } = isIterableLike
+
+}

--- a/src/library/scala/collection/generic/IsMap.scala
+++ b/src/library/scala/collection/generic/IsMap.scala
@@ -1,7 +1,7 @@
 package scala.collection
 package generic
 
-import IsMapLike.Tupled
+import IsMap.Tupled
 import scala.collection.immutable.{IntMap, LongMap}
 import scala.language.higherKinds
 
@@ -12,10 +12,10 @@ import scala.language.higherKinds
   *
   * This type enables simple enrichment of `Map`s with extension methods.
   *
-  * @see [[scala.collection.generic.IsIterableLike]]
+  * @see [[scala.collection.generic.IsIterable]]
   * @tparam Repr Collection type (e.g. `Map[Int, String]`)
   */
-trait IsMapLike[Repr] extends IsIterableLike[Repr] {
+trait IsMap[Repr] extends IsIterable[Repr] {
 
   /** The type of keys */
   type K
@@ -35,7 +35,7 @@ trait IsMapLike[Repr] extends IsIterableLike[Repr] {
 
 }
 
-object IsMapLike {
+object IsMap {
 
   /** Convenient type level function that takes a unary type constructor `F[_]`
     * and returns a binary type constructor that tuples its parameters and passes
@@ -46,8 +46,8 @@ object IsMapLike {
   type Tupled[F[+_]] = { type Ap[X, Y] = F[(X, Y)] }
 
   // Map collections
-  implicit def mapOpsIsMapLike[CC0[X, Y] <: MapOps[X, Y, Tupled[Iterable]#Ap, CC0[X, Y]], K0, V0]: IsMapLike[CC0[K0, V0]] { type K = K0; type V = V0; type C = CC0[K, V] } =
-    new IsMapLike[CC0[K0, V0]] {
+  implicit def mapOpsIsMap[CC0[X, Y] <: MapOps[X, Y, Tupled[Iterable]#Ap, CC0[X, Y]], K0, V0]: IsMap[CC0[K0, V0]] { type K = K0; type V = V0; type C = CC0[K, V] } =
+    new IsMap[CC0[K0, V0]] {
       type K = K0
       type V = V0
       type C = CC0[K0, V0]
@@ -55,26 +55,26 @@ object IsMapLike {
     }
 
   // MapView
-  implicit def mapViewIsMapLike[CC0[X, Y] <: MapView[X, Y], K0, V0]: IsMapLike[CC0[K0, V0]] { type K = K0; type V = V0; type C = View[(K0, V0)] } =
-    new IsMapLike[CC0[K0, V0]] {
+  implicit def mapViewIsMap[CC0[X, Y] <: MapView[X, Y], K0, V0]: IsMap[CC0[K0, V0]] { type K = K0; type V = V0; type C = View[(K0, V0)] } =
+    new IsMap[CC0[K0, V0]] {
       type K = K0
       type V = V0
       type C = View[(K, V)]
       def apply(c: CC0[K0, V0]): MapOps[K0, V0, Tupled[Iterable]#Ap, View[(K0, V0)]] = c
     }
 
-  // AnyRefMap has stricter bounds than the ones used by the mapOpsIsMapLike definition
-  implicit def anyRefMapIsMapLike[K0 <: AnyRef, V0]: IsMapLike[mutable.AnyRefMap[K0, V0]] { type K = K0; type V = V0; type C = mutable.AnyRefMap[K0, V0] } =
-    new IsMapLike[mutable.AnyRefMap[K0, V0]] {
+  // AnyRefMap has stricter bounds than the ones used by the mapOpsIsMap definition
+  implicit def anyRefMapIsMap[K0 <: AnyRef, V0]: IsMap[mutable.AnyRefMap[K0, V0]] { type K = K0; type V = V0; type C = mutable.AnyRefMap[K0, V0] } =
+    new IsMap[mutable.AnyRefMap[K0, V0]] {
       type K = K0
       type V = V0
       type C = mutable.AnyRefMap[K0, V0]
       def apply(c: mutable.AnyRefMap[K0, V0]): MapOps[K0, V0, Tupled[Iterable]#Ap, mutable.AnyRefMap[K0, V0]] = c
     }
 
-  // IntMap takes one type parameter only whereas mapOpsIsMapLike uses a parameter CC0 with two type parameters
-  implicit def intMapIsMapLike[V0]: IsMapLike[IntMap[V0]] { type K = Int; type V = V0; type C = IntMap[V0] } =
-    new IsMapLike[IntMap[V0]] {
+  // IntMap takes one type parameter only whereas mapOpsIsMap uses a parameter CC0 with two type parameters
+  implicit def intMapIsMap[V0]: IsMap[IntMap[V0]] { type K = Int; type V = V0; type C = IntMap[V0] } =
+    new IsMap[IntMap[V0]] {
       type K = Int
       type V = V0
       type C = IntMap[V0]
@@ -82,8 +82,8 @@ object IsMapLike {
     }
 
   // LongMap is in a similar situation as IntMap
-  implicit def longMapIsMapLike[V0]: IsMapLike[LongMap[V0]] { type K = Long; type V = V0; type C = LongMap[V0] } =
-    new IsMapLike[LongMap[V0]] {
+  implicit def longMapIsMap[V0]: IsMap[LongMap[V0]] { type K = Long; type V = V0; type C = LongMap[V0] } =
+    new IsMap[LongMap[V0]] {
       type K = Long
       type V = V0
       type C = LongMap[V0]
@@ -91,8 +91,8 @@ object IsMapLike {
     }
 
   // mutable.LongMap is in a similar situation as LongMap and IntMap
-  implicit def mutableLongMapIsMapLike[V0]: IsMapLike[mutable.LongMap[V0]] { type K = Long; type V = V0; type C = mutable.LongMap[V0] } =
-    new IsMapLike[mutable.LongMap[V0]] {
+  implicit def mutableLongMapIsMap[V0]: IsMap[mutable.LongMap[V0]] { type K = Long; type V = V0; type C = mutable.LongMap[V0] } =
+    new IsMap[mutable.LongMap[V0]] {
       type K = Long
       type V = V0
       type C = mutable.LongMap[V0]

--- a/src/library/scala/collection/generic/IsMapLike.scala
+++ b/src/library/scala/collection/generic/IsMapLike.scala
@@ -1,0 +1,103 @@
+package scala.collection
+package generic
+
+import IsMapLike.Tupled
+import scala.collection.immutable.{IntMap, LongMap}
+import scala.language.higherKinds
+
+/**
+  * Type class witnessing that a collection type `Repr`
+  * has keys of type `K`, values of type `V` and has a conversion to
+  * `MapOps[K, V, Iterable, C]`, for some types `K`, `V` and `C`.
+  *
+  * This type enables simple enrichment of `Map`s with extension methods.
+  *
+  * @see [[scala.collection.generic.IsIterableLike]]
+  * @tparam Repr Collection type (e.g. `Map[Int, String]`)
+  */
+trait IsMapLike[Repr] extends IsIterableLike[Repr] {
+
+  /** The type of keys */
+  type K
+
+  /** The type of values */
+  type V
+
+  type A = (K, V)
+
+  /** A conversion from the type `Repr` to `MapOps[K, V, Iterable, C]`
+    *
+    * @note The third type parameter of the returned `MapOps` value is
+    *       still `Iterable` (and not `Map`) because `MapView[K, V]` only
+    *       extends `MapOps[K, V, View, View[A]]`.
+    */
+  override def apply(c: Repr): MapOps[K, V, Tupled[Iterable]#Ap, C]
+
+}
+
+object IsMapLike {
+
+  /** Convenient type level function that takes a unary type constructor `F[_]`
+    * and returns a binary type constructor that tuples its parameters and passes
+    * them to `F`.
+    *
+    * `Tupled[F]#Ap` is equivalent to `({ type Ap[X, +Y] = F[(X, Y)] })#Ap`.
+    */
+  type Tupled[F[+_]] = { type Ap[X, Y] = F[(X, Y)] }
+
+  // Map collections
+  implicit def mapOpsIsMapLike[CC0[X, Y] <: MapOps[X, Y, Tupled[Iterable]#Ap, CC0[X, Y]], K0, V0]: IsMapLike[CC0[K0, V0]] { type K = K0; type V = V0; type C = CC0[K, V] } =
+    new IsMapLike[CC0[K0, V0]] {
+      type K = K0
+      type V = V0
+      type C = CC0[K0, V0]
+      def apply(c: CC0[K0, V0]): MapOps[K0, V0, Tupled[Iterable]#Ap, C] = c
+    }
+
+  // MapView
+  implicit def mapViewIsMapLike[CC0[X, Y] <: MapView[X, Y], K0, V0]: IsMapLike[CC0[K0, V0]] { type K = K0; type V = V0; type C = View[(K0, V0)] } =
+    new IsMapLike[CC0[K0, V0]] {
+      type K = K0
+      type V = V0
+      type C = View[(K, V)]
+      def apply(c: CC0[K0, V0]): MapOps[K0, V0, Tupled[Iterable]#Ap, View[(K0, V0)]] = c
+    }
+
+  // AnyRefMap has stricter bounds than the ones used by the mapOpsIsMapLike definition
+  implicit def anyRefMapIsMapLike[K0 <: AnyRef, V0]: IsMapLike[mutable.AnyRefMap[K0, V0]] { type K = K0; type V = V0; type C = mutable.AnyRefMap[K0, V0] } =
+    new IsMapLike[mutable.AnyRefMap[K0, V0]] {
+      type K = K0
+      type V = V0
+      type C = mutable.AnyRefMap[K0, V0]
+      def apply(c: mutable.AnyRefMap[K0, V0]): MapOps[K0, V0, Tupled[Iterable]#Ap, mutable.AnyRefMap[K0, V0]] = c
+    }
+
+  // IntMap takes one type parameter only whereas mapOpsIsMapLike uses a parameter CC0 with two type parameters
+  implicit def intMapIsMapLike[V0]: IsMapLike[IntMap[V0]] { type K = Int; type V = V0; type C = IntMap[V0] } =
+    new IsMapLike[IntMap[V0]] {
+      type K = Int
+      type V = V0
+      type C = IntMap[V0]
+      def apply(c: IntMap[V0]): MapOps[Int, V0, Tupled[Iterable]#Ap, IntMap[V0]] = c
+    }
+
+  // LongMap is in a similar situation as IntMap
+  implicit def longMapIsMapLike[V0]: IsMapLike[LongMap[V0]] { type K = Long; type V = V0; type C = LongMap[V0] } =
+    new IsMapLike[LongMap[V0]] {
+      type K = Long
+      type V = V0
+      type C = LongMap[V0]
+      def apply(c: LongMap[V0]): MapOps[Long, V0, Tupled[Iterable]#Ap, LongMap[V0]] = c
+    }
+
+  // mutable.LongMap is in a similar situation as LongMap and IntMap
+  implicit def mutableLongMapIsMapLike[V0]: IsMapLike[mutable.LongMap[V0]] { type K = Long; type V = V0; type C = mutable.LongMap[V0] } =
+    new IsMapLike[mutable.LongMap[V0]] {
+      type K = Long
+      type V = V0
+      type C = mutable.LongMap[V0]
+      def apply(c: mutable.LongMap[V0]): MapOps[Long, V0, Tupled[Iterable]#Ap, mutable.LongMap[V0]] = c
+    }
+
+
+}

--- a/src/library/scala/collection/generic/IsSeq.scala
+++ b/src/library/scala/collection/generic/IsSeq.scala
@@ -12,9 +12,9 @@ import scala.language.higherKinds
   * can make full use of the mechanics of the Scala collections framework in
   * their implementation.
   *
-  * @see [[scala.collection.generic.IsIterableLike]]
+  * @see [[scala.collection.generic.IsIterable]]
   */
-trait IsSeqLike[Repr] extends IsIterableLike[Repr] {
+trait IsSeq[Repr] extends IsIterable[Repr] {
 
   @deprecated("'conversion' is now a method named 'apply'", "2.13.0")
   override val conversion: Repr => SeqOps[A, Iterable, C] = apply(_)
@@ -28,28 +28,28 @@ trait IsSeqLike[Repr] extends IsIterableLike[Repr] {
   def apply(coll: Repr): SeqOps[A, Iterable, C]
 }
 
-object IsSeqLike {
+object IsSeq {
   import scala.language.higherKinds
 
-  private val seqOpsIsSeqLikeVal: IsSeqLike[Seq[Any]] =
-    new IsSeqLike[Seq[Any]] {
+  private val seqOpsIsSeqVal: IsSeq[Seq[Any]] =
+    new IsSeq[Seq[Any]] {
       type A = Any
       type C = Any
       def apply(coll: Seq[Any]): SeqOps[Any, Iterable, Any] = coll
     }
 
-  implicit def seqOpsIsSeqLike[CC0[X] <: SeqOps[X, Iterable, CC0[X]], A0]: IsSeqLike[CC0[A0]] { type A = A0; type C = CC0[A0] } =
-    seqOpsIsSeqLikeVal.asInstanceOf[IsSeqLike[CC0[A0]] { type A = A0; type C = CC0[A0] }]
+  implicit def seqOpsIsSeq[CC0[X] <: SeqOps[X, Iterable, CC0[X]], A0]: IsSeq[CC0[A0]] { type A = A0; type C = CC0[A0] } =
+    seqOpsIsSeqVal.asInstanceOf[IsSeq[CC0[A0]] { type A = A0; type C = CC0[A0] }]
 
-  implicit def seqViewIsSeqLike[CC0[X] <: SeqView[X], A0]: IsSeqLike[CC0[A0]] { type A = A0; type C = View[A0] } =
-    new IsSeqLike[CC0[A0]] {
+  implicit def seqViewIsSeq[CC0[X] <: SeqView[X], A0]: IsSeq[CC0[A0]] { type A = A0; type C = View[A0] } =
+    new IsSeq[CC0[A0]] {
       type A = A0
       type C = View[A]
       def apply(coll: CC0[A0]): SeqOps[A0, View, View[A0]] = coll
     }
 
-  implicit val stringIsSeqLike: IsSeqLike[String] { type A = Char; type C = String } =
-    new IsSeqLike[String] {
+  implicit val stringIsSeq: IsSeq[String] { type A = Char; type C = String } =
+    new IsSeq[String] {
       type A = Char
       type C = String
       def apply(s: String): SeqOps[Char, immutable.IndexedSeq, String] =
@@ -65,15 +65,15 @@ object IsSeqLike {
         }
     }
 
-  implicit val stringViewIsSeqLike: IsSeqLike[StringView] { type A = Char; type C = View[Char] } =
-    new IsSeqLike[StringView] {
+  implicit val stringViewIsSeq: IsSeq[StringView] { type A = Char; type C = View[Char] } =
+    new IsSeq[StringView] {
       type A = Char
       type C = View[Char]
       def apply(coll: StringView): SeqOps[Char, View, View[Char]] = coll
     }
 
-  implicit def arrayIsSeqLike[A0 : ClassTag]: IsSeqLike[Array[A0]] { type A = A0; type C = Array[A0] } =
-    new IsSeqLike[Array[A0]] {
+  implicit def arrayIsSeq[A0 : ClassTag]: IsSeq[Array[A0]] { type A = A0; type C = Array[A0] } =
+    new IsSeq[Array[A0]] {
       type A = A0
       type C = Array[A0]
       def apply(a: Array[A0]): SeqOps[A0, Seq, Array[A0]] =
@@ -90,10 +90,10 @@ object IsSeqLike {
     }
 
   // `Range` can not be unified with the `CC0` parameter of the
-  // `seqOpsIsSeqLike` definition because it does not take a type parameter.
+  // `seqOpsIsSeq` definition because it does not take a type parameter.
   // Hence the need for a separate case:
-  implicit def rangeIsSeqLike[C0 <: Range]: IsSeqLike[C0] { type A = Int; type C = immutable.IndexedSeq[Int] } =
-    new IsSeqLike[C0] {
+  implicit def rangeIsSeq[C0 <: Range]: IsSeq[C0] { type A = Int; type C = immutable.IndexedSeq[Int] } =
+    new IsSeq[C0] {
       type A = Int
       type C = immutable.IndexedSeq[Int]
       def apply(coll: C0): SeqOps[Int, Seq, immutable.IndexedSeq[Int]] = coll

--- a/src/library/scala/collection/generic/IsSeqLike.scala
+++ b/src/library/scala/collection/generic/IsSeqLike.scala
@@ -1,9 +1,12 @@
 package scala.collection
 package generic
 
+import scala.reflect.ClassTag
+import scala.language.higherKinds
 
 /** Type class witnessing that a collection representation type `Repr` has
-  * elements of type `A` and has a conversion to `SeqOps[A, Seq, Repr]`.
+  * elements of type `A` and has a conversion to `SeqOps[A, Iterable, C]`, for
+  * some types `A` and `C`.
   *
   * This type enables simple enrichment of `Seq`s with extension methods which
   * can make full use of the mechanics of the Scala collections framework in
@@ -11,34 +14,89 @@ package generic
   *
   * @see [[scala.collection.generic.IsIterableLike]]
   */
-trait IsSeqLike[Repr] {
-  /** The type of elements we can traverse over. */
-  type A
-  /** A conversion from the representation type `Repr` to `SeqOps[A, Seq, Repr]`. */
-  val conversion: Repr => SeqOps[A, Seq, Repr]
+trait IsSeqLike[Repr] extends IsIterableLike[Repr] {
+
+  @deprecated("'conversion' is now a method named 'apply'", "2.13.0")
+  override val conversion: Repr => SeqOps[A, Iterable, C] = apply(_)
+
+  /** A conversion from the type `Repr` to `SeqOps[A, Iterable, C]`
+    *
+    * @note The second type parameter of the returned `SeqOps` value is
+    *       still `Iterable` (and not `Seq`) because `SeqView[A]` only
+    *       extends `SeqOps[A, View, View[A]]`.
+    */
+  def apply(coll: Repr): SeqOps[A, Iterable, C]
 }
 
 object IsSeqLike {
   import scala.language.higherKinds
 
-  implicit val stringRepr: IsSeqLike[String] { type A = Char } =
-    new IsSeqLike[String] {
-      type A = Char
-      val conversion: String => SeqOps[Char, Seq, String] = s => new SeqOps[Char, Seq, String] {
-        def length: Int = s.length
-        def apply(i: Int): Char = s.charAt(i)
-        def toIterable: Iterable[Char] = new immutable.WrappedString(s)
-        protected[this] def coll: String = s
-        protected[this] def fromSpecific(coll: IterableOnce[Char]): String = coll.mkString
-        def iterableFactory: IterableFactory[Seq] = Seq
-        protected[this] def newSpecificBuilder: mutable.Builder[Char, String] = new StringBuilder
-        def iterator: Iterator[Char] = s.iterator
-      }
+  private val seqOpsIsSeqLikeVal: IsSeqLike[Seq[Any]] =
+    new IsSeqLike[Seq[Any]] {
+      type A = Any
+      type C = Any
+      def apply(coll: Seq[Any]): SeqOps[Any, Iterable, Any] = coll
     }
 
-  implicit def SeqRepr[C[X] <: Seq[X], A0](implicit conv: C[A0] => SeqOps[A0, C, C[A0]]): IsSeqLike[C[A0]] { type A = A0 } =
-    new IsSeqLike[C[A0]] {
+  implicit def seqOpsIsSeqLike[CC0[X] <: SeqOps[X, Iterable, CC0[X]], A0]: IsSeqLike[CC0[A0]] { type A = A0; type C = CC0[A0] } =
+    seqOpsIsSeqLikeVal.asInstanceOf[IsSeqLike[CC0[A0]] { type A = A0; type C = CC0[A0] }]
+
+  implicit def seqViewIsSeqLike[CC0[X] <: SeqView[X], A0]: IsSeqLike[CC0[A0]] { type A = A0; type C = View[A0] } =
+    new IsSeqLike[CC0[A0]] {
       type A = A0
-      val conversion = conv
+      type C = View[A]
+      def apply(coll: CC0[A0]): SeqOps[A0, View, View[A0]] = coll
     }
+
+  implicit val stringIsSeqLike: IsSeqLike[String] { type A = Char; type C = String } =
+    new IsSeqLike[String] {
+      type A = Char
+      type C = String
+      def apply(s: String): SeqOps[Char, immutable.IndexedSeq, String] =
+        new SeqOps[Char, immutable.ArraySeq, String] {
+          def length: Int = s.length
+          def apply(i: Int): Char = s.charAt(i)
+          def toIterable: Iterable[Char] = new immutable.WrappedString(s)
+          protected[this] def coll: String = s
+          protected[this] def fromSpecific(coll: IterableOnce[Char]): String = coll.iterator.mkString
+          def iterableFactory: IterableFactory[immutable.ArraySeq] = immutable.ArraySeq.untagged
+          protected[this] def newSpecificBuilder: mutable.Builder[Char, String] = new StringBuilder
+          def iterator: Iterator[Char] = s.iterator
+        }
+    }
+
+  implicit val stringViewIsSeqLike: IsSeqLike[StringView] { type A = Char; type C = View[Char] } =
+    new IsSeqLike[StringView] {
+      type A = Char
+      type C = View[Char]
+      def apply(coll: StringView): SeqOps[Char, View, View[Char]] = coll
+    }
+
+  implicit def arrayIsSeqLike[A0 : ClassTag]: IsSeqLike[Array[A0]] { type A = A0; type C = Array[A0] } =
+    new IsSeqLike[Array[A0]] {
+      type A = A0
+      type C = Array[A0]
+      def apply(a: Array[A0]): SeqOps[A0, Seq, Array[A0]] =
+        new SeqOps[A, mutable.ArraySeq, Array[A]] {
+          def apply(i: Int): A = a(i)
+          def length: Int = a.length
+          def toIterable: Iterable[A] = mutable.ArraySeq.make(a)
+          protected def coll: Array[A] = a
+          protected def fromSpecific(coll: IterableOnce[A]): Array[A] = Array.from(coll)
+          def iterableFactory: IterableFactory[mutable.ArraySeq] = mutable.ArraySeq.untagged
+          protected def newSpecificBuilder: mutable.Builder[A, Array[A]] = Array.newBuilder
+          def iterator: Iterator[A] = a.iterator
+        }
+    }
+
+  // `Range` can not be unified with the `CC0` parameter of the
+  // `seqOpsIsSeqLike` definition because it does not take a type parameter.
+  // Hence the need for a separate case:
+  implicit def rangeIsSeqLike[C0 <: Range]: IsSeqLike[C0] { type A = Int; type C = immutable.IndexedSeq[Int] } =
+    new IsSeqLike[C0] {
+      type A = Int
+      type C = immutable.IndexedSeq[Int]
+      def apply(coll: C0): SeqOps[Int, Seq, immutable.IndexedSeq[Int]] = coll
+    }
+
 }

--- a/src/library/scala/collection/generic/package.scala
+++ b/src/library/scala/collection/generic/package.scala
@@ -13,4 +13,10 @@ package object generic {
 
   @deprecated("Shrinkable was moved from collection.generic to collection.mutable", "2.13.0")
   type Shrinkable[-A] = scala.collection.mutable.Shrinkable[A]
+
+  @deprecated("Use IsIterableLike instead", "2.13.0")
+  type IsTraversableLike[Repr] = IsIterableLike[Repr]
+
+  @deprecated("Use IsIterableOnce instead", "2.13.0")
+  type IsTraversableOnce[Repr] = IsIterableOnce[Repr]
 }

--- a/src/library/scala/collection/generic/package.scala
+++ b/src/library/scala/collection/generic/package.scala
@@ -14,8 +14,8 @@ package object generic {
   @deprecated("Shrinkable was moved from collection.generic to collection.mutable", "2.13.0")
   type Shrinkable[-A] = scala.collection.mutable.Shrinkable[A]
 
-  @deprecated("Use IsIterableLike instead", "2.13.0")
-  type IsTraversableLike[Repr] = IsIterableLike[Repr]
+  @deprecated("Use IsIterable instead", "2.13.0")
+  type IsTraversableLike[Repr] = IsIterable[Repr]
 
   @deprecated("Use IsIterableOnce instead", "2.13.0")
   type IsTraversableOnce[Repr] = IsIterableOnce[Repr]

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -9,14 +9,14 @@
 package scala
 package runtime
 
-import scala.collection.{ AbstractIterator, AnyConstr, SortedOps, StrictOptimizedIterableOps, StringOps, StringView, View }
-import scala.collection.generic.IsIterableLike
-import scala.collection.immutable.{ NumericRange, ArraySeq }
+import scala.collection.{AbstractIterator, AnyConstr, SortedOps, StrictOptimizedIterableOps, StringOps, StringView, View}
+import scala.collection.immutable.{ArraySeq, NumericRange}
 import scala.collection.mutable.StringBuilder
-import scala.reflect.{ ClassTag, classTag }
-import java.lang.{ Class => jClass }
+import scala.reflect.{ClassTag, classTag}
+import java.lang.{Class => jClass}
+import java.lang.reflect.{Method => JMethod}
 
-import java.lang.reflect.{ Method => JMethod }
+import scala.collection.generic.IsIterableLike
 
 /** The object ScalaRunTime provides support methods required by
  *  the scala runtime.  All these methods should be considered
@@ -30,8 +30,8 @@ object ScalaRunTime {
     clazz.isArray && (atLevel == 1 || isArrayClass(clazz.getComponentType, atLevel - 1))
 
   // A helper method to make my life in the pattern matcher a lot easier.
-  def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterableLike[Repr]): Repr =
-    iterable conversion coll drop num
+  def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterableLike[Repr] { type C <: Repr }): Repr =
+    iterable(coll) drop num
 
   /** Return the class object representing an array with element class `clazz`.
    */

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -16,7 +16,7 @@ import scala.reflect.{ClassTag, classTag}
 import java.lang.{Class => jClass}
 import java.lang.reflect.{Method => JMethod}
 
-import scala.collection.generic.IsIterableLike
+import scala.collection.generic.IsIterable
 
 /** The object ScalaRunTime provides support methods required by
  *  the scala runtime.  All these methods should be considered
@@ -30,7 +30,7 @@ object ScalaRunTime {
     clazz.isArray && (atLevel == 1 || isArrayClass(clazz.getComponentType, atLevel - 1))
 
   // A helper method to make my life in the pattern matcher a lot easier.
-  def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterableLike[Repr] { type C <: Repr }): Repr =
+  def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterable[Repr] { type C <: Repr }): Repr =
     iterable(coll) drop num
 
   /** Return the class object representing an array with element class `clazz`.

--- a/test/files/run/enrich-gentraversable.check
+++ b/test/files/run/enrich-gentraversable.check
@@ -1,8 +1,8 @@
 List(2, 4)
-Array(2, 4)
-HW
-Vector(72, 108, 108, 32, 114, 108, 100)
 List(2, 4)
 Array(2, 4)
 HW
 Vector(72, 108, 108, 32, 114, 108, 100)
+Map(bar -> 2)
+TreeMap(bar -> 2)
+Map(bar -> 2)

--- a/test/files/run/enrich-gentraversable.scala
+++ b/test/files/run/enrich-gentraversable.scala
@@ -3,7 +3,7 @@ import scala.language.implicitConversions
 import scala.language.postfixOps
 
 object Test extends App {
-  import scala.collection.generic.IsIterableLike
+  import scala.collection.generic.IsIterable
   import scala.collection.{BuildFrom, Iterable, IterableOps, View}
   import scala.collection.immutable.TreeMap
 
@@ -13,7 +13,7 @@ object Test extends App {
       final def filterMap[B, That](f: A => Option[B])(implicit bf: BuildFrom[Repr, B, That]): That =
         bf.fromSpecific(r)(it.flatMap(f(_)))
     }
-    implicit def filterMap[Repr](r: Repr)(implicit fr: IsIterableLike[Repr]): FilterMapImpl[fr.A, Repr] =
+    implicit def filterMap[Repr](r: Repr)(implicit fr: IsIterable[Repr]): FilterMapImpl[fr.A, Repr] =
       new FilterMapImpl[fr.A, Repr](r, fr(r))
 
     val l = List(1, 2, 3, 4, 5)

--- a/test/files/run/enrich-gentraversable.scala
+++ b/test/files/run/enrich-gentraversable.scala
@@ -4,21 +4,27 @@ import scala.language.postfixOps
 
 object Test extends App {
   import scala.collection.generic.IsIterableLike
-  import scala.collection.{BuildFrom, Iterable, IterableOps}
+  import scala.collection.{BuildFrom, Iterable, IterableOps, View}
+  import scala.collection.immutable.TreeMap
 
   def typed[T](t : => T): Unit = {}
   def testIterableOps = {
     class FilterMapImpl[A, Repr](r: Repr, it: IterableOps[A, Iterable, _]) {
       final def filterMap[B, That](f: A => Option[B])(implicit bf: BuildFrom[Repr, B, That]): That =
-        bf.fromSpecific(r)(it.flatMap(f(_).toSeq))
+        bf.fromSpecific(r)(it.flatMap(f(_)))
     }
-    implicit def filterMap[Repr, A](r: Repr)(implicit fr: IsIterableLike[Repr]): FilterMapImpl[fr.A, Repr] =
-      new FilterMapImpl[fr.A, Repr](r, fr.conversion(r))
+    implicit def filterMap[Repr](r: Repr)(implicit fr: IsIterableLike[Repr]): FilterMapImpl[fr.A, Repr] =
+      new FilterMapImpl[fr.A, Repr](r, fr(r))
 
     val l = List(1, 2, 3, 4, 5)
     val fml = l.filterMap(i => if(i % 2 == 0) Some(i) else None)
     typed[List[Int]](fml)
     println(fml)
+
+    val lv = l.view
+    val fmlv = lv.filterMap(i => if (i % 2 == 0) Some(i) else None)
+    typed[View[Int]](fmlv)
+    println(fmlv.toList)
 
     val a = Array(1, 2, 3, 4, 5)
     val fma = a.filterMap(i => if(i % 2 == 0) Some(i) else None)
@@ -33,38 +39,23 @@ object Test extends App {
     val fms2 = s.filterMap(c =>if(c % 2 == 0) Some(c.toInt) else None)
     typed[IndexedSeq[Int]](fms2)
     println(fms2)
-  }
-  def testIterable = {
-    class FilterMapImpl[A, Repr](r: Repr, it: IterableOps[A, Iterable, _]) {
-      final def filterMap[B, That](f: A => Option[B])(implicit bf: BuildFrom[Repr, B, That]): That = {
-        val b = bf.newBuilder(r)
-        for(e <- it) f(e) foreach (b +=)
-        b.result
-      }
-    }
-    implicit def filterMap[Repr, A](r: Repr)(implicit fr: IsIterableLike[Repr]): FilterMapImpl[fr.A,Repr] =
-      new FilterMapImpl[fr.A, Repr](r, fr.conversion(r))
 
-    val l = List(1, 2, 3, 4, 5)
-    val fml = l.filterMap(i => if(i % 2 == 0) Some(i) else None)
-    typed[List[Int]](fml)
-    println(fml)
+    val m = Map(1 -> "foo", 2 -> "bar")
+    val fmm = m.filterMap { case (k, v) => if (k % 2 == 0) Some(v -> k) else None }
+    typed[Map[String, Int]](fmm)
+    println(fmm)
 
-    val a = Array(1, 2, 3, 4, 5)
-    val fma = a.filterMap(i => if(i % 2 == 0) Some(i) else None)
-    typed[Array[Int]](fma)
-    println(fma.deep)
+    val tm = TreeMap(1 -> "foo", 2 -> "bar")
+    val tmm = tm.filterMap { case (k, v) => if (k % 2 == 0) Some(v -> k) else None }
+    typed[TreeMap[String, Int]](tmm)
+    println(tmm)
 
-    val s = "Hello World"
-    val fms1 = s.filterMap(c => if(c >= 'A' && c <= 'Z') Some(c) else None)
-    typed[String](fms1)
-    println(fms1)
+    val mv = m.view
+    val fmmv = mv.filterMap { case (k, v) => if (k % 2 == 0) Some(v -> k) else None }
+    typed[View[(String, Int)]](fmmv)
+    println(fmmv.toMap)
 
-    val fms2 = s.filterMap(c =>if(c % 2 == 0) Some(c.toInt) else None)
-    typed[IndexedSeq[Int]](fms2)
-    println(fms2)
   }
 
   testIterableOps
-  testIterable
 }

--- a/test/junit/scala/collection/generic/DecoratorsTest.scala
+++ b/test/junit/scala/collection/generic/DecoratorsTest.scala
@@ -36,9 +36,9 @@ class DecoratorsTest {
 
   @Test
   def iterableDecorator: Unit = {
-    implicit def IterableDecorator[Repr](coll: Repr)(implicit it: IsIterableLike[Repr]): IterableDecorator[Repr, it.type] =
+    implicit def IterableDecorator[Repr](coll: Repr)(implicit it: IsIterable[Repr]): IterableDecorator[Repr, it.type] =
       new IterableDecorator(coll)(it)
-    class IterableDecorator[Repr, I <: IsIterableLike[Repr]](coll: Repr)(implicit val it: I) {
+    class IterableDecorator[Repr, I <: IsIterable[Repr]](coll: Repr)(implicit val it: I) {
       final def filterMap[B, That](f: it.A => Option[B])(implicit bf: BuildFrom[Repr, B, That]): That =
         bf.fromSpecific(coll)(it(coll).flatMap(f(_)))
     }
@@ -97,9 +97,9 @@ class DecoratorsTest {
   @Test
   def seqDecorator: Unit = {
     // Taken from https://github.com/scala/collection-strawman/pull/286
-    implicit def SeqDecorator[Repr](coll: Repr)(implicit seq: IsSeqLike[Repr]): SeqDecorator[Repr, seq.type] =
+    implicit def SeqDecorator[Repr](coll: Repr)(implicit seq: IsSeq[Repr]): SeqDecorator[Repr, seq.type] =
       new SeqDecorator(coll)(seq)
-    class SeqDecorator[Repr, S <: IsSeqLike[Repr]](coll: Repr)(implicit val seq: S) {
+    class SeqDecorator[Repr, S <: IsSeq[Repr]](coll: Repr)(implicit val seq: S) {
       def groupedWith[Group, That](p: seq.A => Boolean)(implicit
         group: BuildFrom[Repr, seq.A, Group],
         bf: BuildFrom[Repr, Group, That]
@@ -159,10 +159,10 @@ class DecoratorsTest {
   @Test
   def mapDecorator: Unit = {
 
-    implicit def MapDecorator[Repr](coll: Repr)(implicit map: IsMapLike[Repr]): MapDecorator[Repr, map.type] =
+    implicit def MapDecorator[Repr](coll: Repr)(implicit map: IsMap[Repr]): MapDecorator[Repr, map.type] =
       new MapDecorator(coll)(map)
 
-    class MapDecorator[C, M <: IsMapLike[C]](coll: C)(implicit val map: M) {
+    class MapDecorator[C, M <: IsMap[C]](coll: C)(implicit val map: M) {
       def leftOuterJoin[W, That](other: Map[map.K, W])(implicit bf: BuildFrom[C, (map.K, (map.V, Option[W])), That]): That = {
         val b = bf.newBuilder(coll)
         for ((k, v) <- map(coll)) {

--- a/test/junit/scala/collection/generic/DecoratorsTest.scala
+++ b/test/junit/scala/collection/generic/DecoratorsTest.scala
@@ -1,0 +1,243 @@
+package scala.collection.generic
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.collection.immutable.{BitSet, IntMap, LongMap, TreeMap, TreeSet}
+import scala.collection.{BuildFrom, View, mutable}
+import scala.language.implicitConversions
+
+@RunWith(classOf[JUnit4])
+class DecoratorsTest {
+
+  @Test
+  def iterableOnceDecorator: Unit = {
+    implicit def filterMap[Repr](coll: Repr)(implicit it: IsIterableOnce[Repr]): FilterMapImpl[Repr, it.type] =
+      new FilterMapImpl(coll, it)
+    class FilterMapImpl[Repr, I <: IsIterableOnce[Repr]](coll: Repr, it: I) {
+      final def filterMap[B, That](f: it.A => Option[B])(implicit bf: BuildFrom[Repr, B, That]): That = {
+        val b = bf.newBuilder(coll)
+        for (e <- it(coll)) f(e) foreach (b +=)
+        b.result()
+      }
+    }
+
+    val f = (i: Int) => if (i % 2 == 0) Some(i) else None
+
+    val xs1 = Iterator(1, 2, 3, 4, 5)
+    val xs2 = xs1.filterMap(f)
+    val xs2T: Iterator[Int] = xs2
+
+    val xs3 = Array(1, 2, 3, 4, 5)
+    val xs4 = xs3.filterMap(f)
+    val xs4T: Array[Int] = xs4
+  }
+
+  @Test
+  def iterableDecorator: Unit = {
+    implicit def IterableDecorator[Repr](coll: Repr)(implicit it: IsIterableLike[Repr]): IterableDecorator[Repr, it.type] =
+      new IterableDecorator(coll)(it)
+    class IterableDecorator[Repr, I <: IsIterableLike[Repr]](coll: Repr)(implicit val it: I) {
+      final def filterMap[B, That](f: it.A => Option[B])(implicit bf: BuildFrom[Repr, B, That]): That =
+        bf.fromSpecific(coll)(it(coll).flatMap(f(_)))
+    }
+
+    val f: Int => Option[String] = x => if (x % 2 == 0) Some(x.toString) else None
+    val g: Char => Option[Int] = c => if (c.isDigit) Some(c.asDigit) else None
+    val h: ((Int, String)) => Option[(String, Int)] = {
+      case (x, s) => if (s.length == x) Some((s, x)) else None
+    }
+    val i: Int => Option[Int] = x => if (x % 2 == 0) Some(2 * x) else None
+
+    val xs1 = List(1, 2, 3).filterMap(f)
+    val xs1T: List[String] = xs1
+    val xs2 = List(1, 2, 3).view.filterMap(f)
+    val xs2T: View[String] = xs2
+    val xs3 = Vector(1, 2, 3).filterMap(f)
+    val xs3T: Vector[String] = xs3
+    val xs4 = Vector(1, 2, 3).view.filterMap(f)
+    val xs4T: View[String] = xs4
+    val xs5 = (1 to 10).filterMap(f)
+    val xs5T: IndexedSeq[String] = xs5
+    val xs6 = (1 to 10).view.filterMap(f)
+    val xs6T: View[String] = xs6
+    val xs7 = Array(1, 2, 3).filterMap(f)
+    val xs7T: Array[String] = xs7
+    val xs8 = Array(1, 2, 3).view.filterMap(f)
+    val xs8T: View[String] = xs8
+    val xs9 = "foo".filterMap(g)
+    val xs9T: IndexedSeq[Int] = xs9
+    val xs10 = "foo".view.filterMap(g)
+    val xs10T: View[Int] = xs10
+    val xs11 = Map(1 -> "foo").filterMap(h)
+    val xs11T: Map[String, Int] = xs11
+    val xs12 = Map(1 -> "foo").view.filterMap(h)
+    val xs12T: View[(String, Int)] = xs12
+    val xs13 = TreeMap(1 -> "foo").filterMap(h)
+    val xs13T: TreeMap[String, Int] = xs13
+    val xs14 = TreeMap(1 -> "foo").view.filterMap(h)
+    val xs14T: View[(String, Int)] = xs14
+    val xs15 = BitSet(1, 2, 3).filterMap(i)
+    val xs15T: BitSet = xs15
+    val xs16 = BitSet(1, 2, 3).view.filterMap(i)
+    val xs16T: View[Int] = xs16
+    val xs17 = Set(1, 2, 3).filterMap(f)
+    val xs17T: Set[String] = xs17
+    val xs18 = Set(1, 2, 3).view.filterMap(f)
+    val xs18T: View[String] = xs18
+    val xs19 = TreeSet(1, 2, 3).filterMap(f)
+    val xs19T: TreeSet[String] = xs19
+    val xs20 = TreeSet(1, 2, 3).view.filterMap(f)
+    val xs20T: View[String] = xs20
+    val xs21 = TreeSet(1, 2, 3).filterMap(f)
+    val xs21T: TreeSet[String] = xs21
+  }
+
+  @Test
+  def seqDecorator: Unit = {
+    // Taken from https://github.com/scala/collection-strawman/pull/286
+    implicit def SeqDecorator[Repr](coll: Repr)(implicit seq: IsSeqLike[Repr]): SeqDecorator[Repr, seq.type] =
+      new SeqDecorator(coll)(seq)
+    class SeqDecorator[Repr, S <: IsSeqLike[Repr]](coll: Repr)(implicit val seq: S) {
+      def groupedWith[Group, That](p: seq.A => Boolean)(implicit
+        group: BuildFrom[Repr, seq.A, Group],
+        bf: BuildFrom[Repr, Group, That]
+      ): That = {
+        val `this` = seq(coll)
+
+        val groups = bf.newBuilder(coll)
+        val it = `this`.iterator
+
+        var currentGroup = group.newBuilder(coll)
+        var lastTestResult = Option.empty[Boolean]
+
+        while (it.hasNext) {
+          val elem = it.next()
+          val currentTest = p(elem)
+
+          lastTestResult match {
+            case None =>
+              currentGroup.addOne(elem)
+            case Some(lastTest) if currentTest == lastTest =>
+              currentGroup.addOne(elem)
+            case Some(_) =>
+              groups.addOne(currentGroup.result())
+              currentGroup = group.newBuilder(coll).addOne(elem)
+          }
+
+          lastTestResult = Some(currentTest)
+        }
+
+        groups.addOne(currentGroup.result()).result()
+      }
+    }
+
+    val p: Int => Boolean = _ % 2 == 0
+    val xs = List(1, 2, 3).groupedWith(p)
+    val xsT: List[List[Int]] = xs
+    val xs2 = List(1, 2, 3).view.groupedWith(p)
+    val xs2T: View[View[Int]] = xs2
+    val xs3 = Vector(1, 2, 3).groupedWith(p)
+    val xs3T: Vector[Vector[Int]] = xs3
+    val xs4 = Vector(1, 2, 3).view.groupedWith(p)
+    val xs4T: View[View[Int]] = xs4
+    val xs5 = (1 to 10).groupedWith(p)
+    val xs5T: IndexedSeq[IndexedSeq[Int]] = xs5
+    val xs6 = (1 to 10).view.groupedWith(p)
+    val xs6T: View[View[Int]] = xs6
+    val xs7 = Array(1, 2, 3).groupedWith(p)
+    val xs7T: Array[Array[Int]] = xs7
+    val xs8 = Array(1, 2, 3).view.groupedWith(p)
+    val xs8T: View[View[Int]] = xs8
+    val xs9 = "foo".groupedWith(_.isLower)
+    val xs9T: IndexedSeq[String] = xs9
+    val xs10 = "foo".view.groupedWith(_.isLower)
+    val xs10T: View[View[Char]] = xs10
+  }
+
+  @Test
+  def mapDecorator: Unit = {
+
+    implicit def MapDecorator[Repr](coll: Repr)(implicit map: IsMapLike[Repr]): MapDecorator[Repr, map.type] =
+      new MapDecorator(coll)(map)
+
+    class MapDecorator[C, M <: IsMapLike[C]](coll: C)(implicit val map: M) {
+      def leftOuterJoin[W, That](other: Map[map.K, W])(implicit bf: BuildFrom[C, (map.K, (map.V, Option[W])), That]): That = {
+        val b = bf.newBuilder(coll)
+        for ((k, v) <- map(coll)) {
+          b += k -> (v, other.get(k))
+        }
+        b.result()
+      }
+      def rightOuterJoin[W, That](other: Map[map.K, W])(implicit bf: BuildFrom[C, (map.K, (Option[map.V], W)), That]): That = {
+        val b = bf.newBuilder(coll)
+        for ((k, w) <- other) {
+          b += k -> (map(coll).get(k), w)
+        }
+        b.result()
+      }
+    }
+
+    val map = Map(1 -> "foo")
+    val mapLJoin = map.leftOuterJoin(Map(1 -> "bar"))
+    val mapLJoinT: Map[Int, (String, Option[String])] = mapLJoin
+    val mapRJoin = map.rightOuterJoin(Map(1 -> "bar"))
+    val mapRJoinT: Map[Int, (Option[String], String)] = mapRJoin
+
+    val mapView = Map(1 -> "foo").view
+    val mapViewLJoin = mapView.leftOuterJoin(Map(1 -> "bar"))
+    val mapViewLJoinT: View[(Int, (String, Option[String]))] = mapViewLJoin
+    val mapViewRJoin = mapView.rightOuterJoin(Map(1 -> "bar"))
+    val mapViewRJoinT: View[(Int, (Option[String], String))] = mapViewRJoin
+
+    val treemap = TreeMap(1 -> "foo")
+    val treemapLJoin = treemap.leftOuterJoin(Map(1 -> "bar"))
+    val treemapLJoinT: TreeMap[Int, (String, Option[String])] = treemapLJoin
+    val treemapRJoin = treemap.rightOuterJoin(Map(1 -> "bar"))
+    val treemapRJoinT: TreeMap[Int, (Option[String], String)] = treemapRJoin
+
+    val treemapView = TreeMap(1 -> "foo").view
+    val treemapViewLJoin = treemapView.leftOuterJoin(Map(1 -> "bar"))
+    val treemapViewLJoinT: View[(Int, (String, Option[String]))] = treemapViewLJoin
+    val treemapViewRJoin = treemapView.rightOuterJoin(Map(1 -> "bar"))
+    val treemapViewRJoinT: View[(Int, (Option[String], String))] = treemapViewRJoin
+
+    val mmap = mutable.Map(1 -> "foo")
+    val mmapLJoin = mmap.leftOuterJoin(Map(1 -> "bar"))
+    val mmapLJoinT: mutable.Map[Int, (String, Option[String])] = mmapLJoin
+    val mmapRJoin = mmap.rightOuterJoin(Map(1 -> "bar"))
+    val mmapRJoinT: mutable.Map[Int, (Option[String], String)] = mmapRJoin
+
+    val mmapView = mutable.Map(1 -> "foo").view
+    val mmapViewLJoin = mmapView.leftOuterJoin(Map(1 -> "bar"))
+    val mmapViewLJoinT: View[(Int, (String, Option[String]))] = mmapViewLJoin
+    val mmapViewRJoin = mmapView.rightOuterJoin(Map(1 -> "bar"))
+    val mmapViewRJoinT: View[(Int, (Option[String], String))] = mmapViewRJoin
+
+    val anyrefmap = mutable.AnyRefMap("foo" -> 1)
+    val anyrefmapLJoin = anyrefmap.leftOuterJoin(Map("bar" -> true))
+    val anyrefmapLJoinT: mutable.AnyRefMap[String, (Int, Option[Boolean])] = anyrefmapLJoin
+    val anyrefmapRJoin = anyrefmap.rightOuterJoin(Map("bar" -> true))
+    val anyrefmapRJoinT: mutable.AnyRefMap[String, (Option[Int], Boolean)] = anyrefmapRJoin
+
+    val intmap = IntMap(1 -> "foo")
+    val intmapLJoin = intmap.leftOuterJoin(Map(1 -> "bar"))
+    val intmapLJoinT: IntMap[(String, Option[String])] = intmapLJoin
+    val intmapRJoin = intmap.rightOuterJoin(Map(1 -> "bar"))
+    val intmapRJoinT: IntMap[(Option[String], String)] = intmapRJoin
+
+    val longmap = LongMap(1L -> "foo")
+    val longmapLJoin = longmap.leftOuterJoin(Map(1L -> "bar"))
+    val longmapLJoinT: LongMap[(String, Option[String])] = longmapLJoin
+    val longmapRJoin = longmap.rightOuterJoin(Map(1L -> "bar"))
+    val longmapRJoinT: LongMap[(Option[String], String)] = longmapRJoin
+
+    val mlongmap = mutable.LongMap(1L -> "foo")
+    val mlongmapLJoin = mlongmap.leftOuterJoin(Map(1L -> "bar"))
+    val mlongmapLJoinT: mutable.LongMap[(String, Option[String])] = mlongmapLJoin
+    val mlongmapRJoin = mlongmap.rightOuterJoin(Map(1L -> "bar"))
+    val mlongmapRJoinT: mutable.LongMap[(Option[String], String)] = mlongmapRJoin
+  }
+
+}


### PR DESCRIPTION
The conversion from the `Repr` type now returns an `IterableOps[A, CC, C]`,
whereas it previously had to return an `IterableOps[A, Iterable, Repr]`.

This change makes it possible to create instances of `IsIterableLike`
for View collections.

Also, the `conversion` member has been refactored into an `apply` method.

In addition to `IsIterableLike` and `IsSeqLike`, the types `IsMapLike`
and `IsImmutableMapLike` have been introduced.

Last, the `IsXxxLike` types now form a hierarchy: `IsImmutableMapLike` specializes
`IsMapLike`, which itself specializes `IsIterableLike`.