### PR TITLE
[REJECTED] Add scanLeft with no zero element

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -658,6 +658,21 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     res 
   }
 
+  def scanLeft1[B >: A : ClassTag](op: (B, A) => B): Array[B] =
+    if (xs.length == 0) Array.empty[B]
+    else {
+      var v: B = xs(0)
+      var i = 1
+      var res = new Array[B](xs.length)
+      res(0) = v
+      while (i < xs.length) {
+        v = op(v, xs(i))
+        res(i) = v
+        i += 1
+      }
+      res
+    }
+
   /** Computes a prefix scan of the elements of the array.
     *
     *  Note: The neutral element `z` may be applied more than once.

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -568,6 +568,8 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
 
   def scanLeft[B](z: B)(op: (B, A) => B): CC[B] = fromIterable(new View.ScanLeft(this, z, op))
 
+  def scanLeft1[B >: A](op: (B, A) => B): CC[B] = fromIterable(new View.ScanLeft1(this, op))
+
   /** Produces a collection containing cumulative results of applying the operator going right to left.
     *  The head of the collection is the last cumulative result.
     *  $willNotTerminateInf

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -165,6 +165,19 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     */
   def scanLeft[B](z: B)(op: (B, A) => B): CC[B]
 
+  /** Produces a $coll containing cumulative results of applying the
+    * operator going left to right.
+    *
+    *  $willNotTerminateInf
+    *  $orderDependent
+    *
+    *  @tparam B      the type of the elements in the resulting collection
+    *  @param op      the binary operator applied to the intermediate result and the element
+    *  @return        collection with intermediate results
+    *  @note          Reuse: $consumesAndProducesIterator
+    */
+   def scanLeft1[B >: A](op: (B, A) => B): CC[B]
+
   /** Selects all elements of this $coll which satisfy a predicate.
     *
     *  @param p     the predicate used to test elements.

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -328,6 +328,17 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     def hasNext: Boolean = current.hasNext
   }
 
+  def scanLeft1[B >: A](op: (B, A) => B): Iterator[B] = new AbstractIterator[B] {
+    private[this] var first = true
+    private[this] var acc: B = _
+    def hasNext = self.hasNext
+    def next()  = {
+      val v = self.next()
+      acc = if (first) { first = false ; v } else op(acc, v)
+      acc
+    }
+  }
+
   def indexWhere(p: A => Boolean, from: Int = 0): Int = {
     var i = math.max(from, 0)
     drop(from)

--- a/src/library/scala/collection/StrictOptimizedIterableOps.scala
+++ b/src/library/scala/collection/StrictOptimizedIterableOps.scala
@@ -143,6 +143,21 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
+  override def scanLeft1[B >: A](op: (B, A) => B): CC[B] = {
+    val it = iterator
+    val b = iterableFactory.newBuilder[B]
+    b.sizeHint(toIterable, delta = 0)
+    if (it.hasNext) {
+      var acc: B = it.next()
+      b += acc
+      while (it.hasNext) {
+        acc = op(acc, it.next())
+        b += acc
+      }
+    }
+    b.result()
+  }
+
   override def filter(pred: A => Boolean): C = filterImpl(pred, isFlipped = false)
 
   override def filterNot(pred: A => Boolean): C = filterImpl(pred, isFlipped = true)

--- a/src/library/scala/collection/View.scala
+++ b/src/library/scala/collection/View.scala
@@ -198,6 +198,11 @@ object View extends IterableFactory[View] {
       if (underlying.knownSize >= 0) underlying.knownSize + 1 else -1
   }
 
+  class ScanLeft1[A, +B >: A](underlying: SomeIterableOps[A], op: (B, A) => B) extends AbstractView[B] {
+    def iterator: Iterator[B] = underlying.iterator.scanLeft1[B]((b: B, a: A) => op(b,a))
+    override def knownSize = underlying.knownSize
+  }
+
   /** A view that maps elements of the underlying collection. */
   @SerialVersionUID(3L)
   class Map[+A, +B](underlying: SomeIterableOps[A], f: A => B) extends AbstractView[B] {

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -264,6 +264,10 @@ sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with Laz
     if (isEmpty) z +: iterableFactory.empty
     else cons(z, tail.scanLeft(op(z, head))(op))
 
+  override def scanLeft1[B >: A](op: (B, A) => B): CC[B] =
+    if (this.isEmpty) iterableFactory.empty
+    else tail.scanLeft[B](head)(op)
+
   /** LazyList specialization of reduceLeft which allows GC to collect
     *  along the way.
     *

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -56,6 +56,20 @@ class ArrayOpsTest {
   }
 
   @Test
+  def scanLeft1(): Unit = {
+    val arr = Array(1,2,3,4)
+    val sums = arr.scanLeft1(_ + _)
+    assertArrayEquals(Array(1, 3, 6, 10), sums)
+  }
+
+  @Test
+  def scanLeft1Empty(): Unit = {
+    val arr = Array[Int]()
+    val res = arr.scanLeft1(_ + _)
+    assertArrayEquals(Array[Int](), res)
+  }
+
+  @Test
   def scanRight(): Unit = {
     val arr = Array(4,3,2)
     val sums = arr.scanRight(1)(_ + _)


### PR DESCRIPTION
aka scanl1

I thought this would be a good way to get my feet wet, dip my toes in, etc, but it errors on the signature in View.ScanLeft1.

This was a test of the overload, and it failed.

Also, not sure if the additional API is desirable.

Fixes scala/bug#10898