### PR TITLE
use collection.Seq instead of scala.Seq in Array scaladoc

### DIFF
--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -532,7 +532,7 @@ object Array {
  *  {{{
  *  val arr = Array(1, 2, 3)
  *  val arrReversed = arr.reverse
- *  val seqReversed : Seq[Int] = arr.reverse
+ *  val seqReversed : collection.Seq[Int] = arr.reverse
  *  }}}
  *
  *  Value `arrReversed` will be of type `Array[Int]`, with an implicit conversion to `ArrayOps` occurring


### PR DESCRIPTION
```
Welcome to Scala 2.13.0-M4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_172).
Type in expressions for evaluation. Or try :help.

scala> val arr = Array(1, 2, 3)
arr: Array[Int] = Array(1, 2, 3)

scala> val seqReversed : Seq[Int] = arr.reverse
                                        ^
       warning: method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated (since 2.13.0): Implicit conversions from Array to immutable.IndexedSeq are implemented by copying; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call
seqReversed: Seq[Int] = ArraySeq(3, 2, 1)

scala> val seqReversed : collection.Seq[Int] = arr.reverse
seqReversed: scala.collection.Seq[Int] = ArraySeq(3, 2, 1)
```