### PR TITLE
Deprecate `Either#right` and `Either#left` projections

### DIFF
--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -162,12 +162,14 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *   for (e <- interactWithDB(someQuery).left) log(s"query failed, reason was $e")
    *   }}}
    */
+  @deprecated("use swap instead", "2.13.0")
   def left = Either.LeftProjection(this)
 
   /** Projects this `Either` as a `Right`.
    *
    *  Because `Either` is right-biased, this method is not normally needed.
    */
+  @deprecated("Either is now right-biased", "2.13.0")
   def right = Either.RightProjection(this)
 
   /** Applies `fa` if this is a `Left` or `fb` if this is a `Right`.
@@ -476,6 +478,7 @@ object Either {
    *  @version 1.0, 11/10/2008
    *  @see [[scala.util.Either#left]]
    */
+  @deprecated("use swap instead", "2.13.0")
   final case class LeftProjection[+A, +B](e: Either[A, B]) {
     /** Returns the value from this `Left` or throws `java.util.NoSuchElementException`
      *  if this is a `Right`.
@@ -620,6 +623,7 @@ object Either {
    *  @author <a href="mailto:research@workingmouse.com">Tony Morris</a>, Workingmouse
    *  @version 1.0, 11/10/2008
    */
+  @deprecated("Either is now right-biased", "2.13.0")
   final case class RightProjection[+A, +B](e: Either[A, B]) {
 
     /** Returns the value from this `Right` or throws


### PR DESCRIPTION
Deprecates the Either projections again for 2.13.x

Originally deprecated in https://github.com/scala/scala/pull/5135

Deprecation made undone in https://github.com/scala/scala/pull/5433 which indicates

> for two reasons:
> * to facilitate warning-free cross-compilation between Scala 2.11
>   and 2.12
> * because it's not clear that .swap is a good replacement for .left
> 
> Either.right seems almost certain to be deprecated in 2.13.
> Either.left's future is uncertain; see discussion (and links to
> additional discussions) at #5135

Warning-free cross-compilation between 2.11 and 2.13 is probably not a big requirement, and not really a feasible aim in the first place.

.swap seems to have proven itself.