### PR TITLE
De-aggregate the macro annotation subproject

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -939,7 +939,7 @@ lazy val root: Project = (project in file("."))
     }
   )
   .aggregate(library, reflect, compiler, interactive, repl, replFrontend,
-    scaladoc, scalap, partest, junit, scalaDist, macroAnnot).settings(
+    scaladoc, scalap, partest, junit, scalaDist).settings(
     sources in Compile := Seq.empty,
     onLoadMessage := """|*** Welcome to the sbt build definition for Scala! ***
       |Check README.md for more information.""".stripMargin


### PR DESCRIPTION
We can still run targets in there, but we no longer include it in,
for example `sbt test:compile`.

This is to unblock development on 2.13.x until the macro annotation
tests are ported to partest.