### PR TITLE
Add disambiguating overloads to Enumeration.ValueSet.(map|flatMap)

### DIFF
--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -293,6 +293,10 @@ abstract class Enumeration (initial: Int) extends Serializable {
     def map(f: Value => Value): ValueSet = fromSpecificIterable(new View.Map(toIterable, f))
     def flatMap(f: Value => IterableOnce[Value]): ValueSet = fromSpecificIterable(new View.FlatMap(toIterable, f))
 
+    // necessary for disambiguation:
+    override def map[B : Ordering](f: Value => B): SortedIterableCC[B] = super[SortedSet].map[B](f)
+    override def flatMap[B : Ordering](f: Value => IterableOnce[B]): SortedIterableCC[B] = super[SortedSet].flatMap[B](f)
+
     override protected[this] def writeReplace(): AnyRef = this
   }
 

--- a/test/junit/scala/EnumerationTest.scala
+++ b/test/junit/scala/EnumerationTest.scala
@@ -1,0 +1,22 @@
+package scala.collection
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class EnumerationTest {
+
+  @Test def t10906: Unit = {
+    object A extends Enumeration
+    val s1 = A.values.map(x => 42)
+    assertEquals(Set.empty, (s1: scala.collection.immutable.SortedSet[Int]))
+    val s2 = A.values.map(x => x)
+    assertEquals(Set.empty, (s2: A.ValueSet))
+    val s3 = A.values.flatMap(x => Set(42))
+    assertEquals(Set.empty, (s3: scala.collection.immutable.SortedSet[Int]))
+    val s4 = A.values.flatMap(x => Set(x))
+    assertEquals(Set.empty, (s4: A.ValueSet))
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/10906