### PR TITLE
Use an extra-lazy Iterator for LinearSeq by default

### DIFF
--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -236,8 +236,6 @@ sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with Laz
 
   protected def cons[T](hd: => T, tl: => CC[T] @uncheckedVariance): CC[T]
 
-  override def iterator(): Iterator[A] = new LazyListIterator[A, CC, C](this)
-
   /** Forces evaluation of the whole `LazyList` and returns it.
     *
     * @note Often we use `LazyList`s to represent an infinite set or series.  If
@@ -876,26 +874,4 @@ object Stream extends LazyListFactory[Stream] {
   // This prevents it from serializing it in the first place:
   private[this] def writeObject(out: ObjectOutputStream): Unit = ()
   private[this] def readObject(in: ObjectInputStream): Unit = ()
-}
-
-/** A specialized, extra-lazy implementation of a stream iterator, so it can
-  *  iterate as lazily as it traverses the tail.
-  */
-private[immutable] final class LazyListIterator[+A, +CC[+X] <: LinearSeq[X] with LazyListOps[X, CC, CC[X]], +C <: CC[A] with LazyListOps[A, CC, C]](self: LazyListOps[A, CC, C]) extends AbstractIterator[A] {
-  // A call-by-need cell.
-  final class LazyCell(st: => LazyListOps[A, CC, C]) {
-    lazy val v = st
-  }
-
-  private var these: LazyCell = new LazyCell(self)
-
-  def hasNext: Boolean = these.v.nonEmpty
-  def next(): A =
-    if (isEmpty) Iterator.empty.next()
-    else {
-      val cur    = these.v
-      val result = cur.head
-      these = new LazyCell(cur.tail)
-      result
-    }
 }

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -72,6 +72,7 @@ sealed abstract class List[+A]
   extends AbstractSeq[A]
     with LinearSeq[A]
     with LinearSeqOps[A, List, List[A]]
+    with StrictOptimizedLinearSeqOps[A, List, List[A]]
     with StrictOptimizedSeqOps[A, List, List[A]] {
 
   override def iterableFactory: SeqFactory[List] = List

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -39,6 +39,7 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
   extends AbstractSeq[A]
     with LinearSeq[A]
     with LinearSeqOps[A, Queue, Queue[A]]
+    with StrictOptimizedLinearSeqOps[A, Queue, Queue[A]]
     with StrictOptimizedSeqOps[A, Queue, Queue[A]] {
 
   override def iterableFactory: SeqFactory[Queue] = Queue

--- a/test/files/run/repl-colon-type.check
+++ b/test/files/run/repl-colon-type.check
@@ -79,7 +79,7 @@ TypeRef(
     )
     TypeRef(
       TypeSymbol(
-        sealed abstract class List[+A] extends AbstractSeq[A] with LinearSeq[A] with LinearSeqOps[A,List,List[A]] with StrictOptimizedSeqOps[A,List,List[A]]
+        sealed abstract class List[+A] extends AbstractSeq[A] with LinearSeq[A] with LinearSeqOps[A,List,List[A]] with StrictOptimizedLinearSeqOps[A,List,List[A]] with StrictOptimizedSeqOps[A,List,List[A]]
 
       )
       args = List(
@@ -147,7 +147,7 @@ TypeRef(
       args = List(
         TypeRef(
           TypeSymbol(
-            sealed abstract class List[+A] extends AbstractSeq[A] with LinearSeq[A] with LinearSeqOps[A,List,List[A]] with StrictOptimizedSeqOps[A,List,List[A]]
+            sealed abstract class List[+A] extends AbstractSeq[A] with LinearSeq[A] with LinearSeqOps[A,List,List[A]] with StrictOptimizedLinearSeqOps[A,List,List[A]] with StrictOptimizedSeqOps[A,List,List[A]]
 
           )
           args = List(
@@ -181,7 +181,7 @@ PolyType(
           args = List(
             TypeRef(
               TypeSymbol(
-                sealed abstract class List[+A] extends AbstractSeq[A] with LinearSeq[A] with LinearSeqOps[A,List,List[A]] with StrictOptimizedSeqOps[A,List,List[A]]
+                sealed abstract class List[+A] extends AbstractSeq[A] with LinearSeq[A] with LinearSeqOps[A,List,List[A]] with StrictOptimizedLinearSeqOps[A,List,List[A]] with StrictOptimizedSeqOps[A,List,List[A]]
 
               )
               args = List(TypeParamTypeRef(TypeParam(T <: AnyVal)))
@@ -204,7 +204,7 @@ PolyType(
     params = List(TermSymbol(x: T), TermSymbol(y: List[U]))
     resultType = TypeRef(
       TypeSymbol(
-        sealed abstract class List[+A] extends AbstractSeq[A] with LinearSeq[A] with LinearSeqOps[A,List,List[A]] with StrictOptimizedSeqOps[A,List,List[A]]
+        sealed abstract class List[+A] extends AbstractSeq[A] with LinearSeq[A] with LinearSeqOps[A,List,List[A]] with StrictOptimizedLinearSeqOps[A,List,List[A]] with StrictOptimizedSeqOps[A,List,List[A]]
 
       )
       args = List(TypeParamTypeRef(TypeParam(U >: T)))


### PR DESCRIPTION
Strict LinearSeqs can mix in the new StrictOptimizedLinearSeqOps trait
to get the old, more efficient but not quite as lazy implementation.

Fixes https://github.com/scala/bug/issues/10899