### PR TITLE
Performance improvements to position checking under -Yrangepos [ci: last-only]

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/ContextTrees.scala
+++ b/src/interactive/scala/tools/nsc/interactive/ContextTrees.scala
@@ -108,10 +108,14 @@ trait ContextTrees { self: Global =>
    */
   def addContext(contexts: Contexts, context: Context): Unit = {
     val cpos = context.tree.pos
-    if (cpos.isTransparent)
-      for (t <- context.tree.children flatMap solidDescendants)
-        addContext(contexts, context, t.pos)
-    else
+    if (cpos.isTransparent) {
+      val traverser = new ChildSolidDescendantsCollector() {
+        override def traverseSolidChild(t: Tree): Unit = {
+          addContext(contexts, context, t.pos)
+        }
+      }
+      traverser.apply(context.tree)
+    } else
       addContext(contexts, context, cpos)
   }
 

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -60,9 +60,9 @@ object ArrayBuilder {
     private var size: Int = 0
 
     private def mkArray(size: Int): Array[T] = {
-      val newelems = new Array[T](size)
-      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
-      newelems
+      if (capacity == size && capacity > 0) elems
+      else if (elems eq null) new Array[T](size)
+      else java.util.Arrays.copyOf[T](elems, size)
     }
 
     private def resize(size: Int) {

--- a/src/reflect/scala/reflect/internal/Positions.scala
+++ b/src/reflect/scala/reflect/internal/Positions.scala
@@ -3,7 +3,6 @@ package reflect
 package internal
 
 import util._
-import scala.collection.mutable.ListBuffer
 
 /** Handling range positions
  *  atPos, the main method in this trait, will add positions to a tree,
@@ -37,9 +36,22 @@ trait Positions extends api.Positions { self: SymbolTable =>
   def wrappingPos(default: Position, trees: List[Tree]): Position = wrappingPos(default, trees, focus = true)
   def wrappingPos(default: Position, trees: List[Tree], focus: Boolean): Position = {
     if (useOffsetPositions) default else {
-      val ranged = trees filter (_.pos.isRange)
-      if (ranged.isEmpty) if (focus) default.focus else default
-      else Position.range(default.source, (ranged map (_.pos.start)).min, default.point, (ranged map (_.pos.end)).max)
+      var rest = trees
+      var min = Int.MaxValue
+      var max = Int.MinValue
+      while (rest ne Nil) {
+        val head = rest.head
+        rest = rest.tail
+        val pos = head.pos
+        if (pos.isRange) {
+          min = Math.min(min, pos.start)
+          max = Math.max(max, pos.end)
+        }
+      }
+      if (min > max)
+      //there are no ranges
+        if (focus) default.focus else default
+      else Position.range(default.source, min, default.point, max)
     }
   }
 
@@ -66,12 +78,13 @@ trait Positions extends api.Positions { self: SymbolTable =>
     def isOverlapping(pos: Position) =
       pos.isRange && (others exists (pos overlaps _.pos))
 
-    if (isOverlapping(tree.pos)) {
+    val treePos = tree.pos
+    if (isOverlapping(treePos)) {
       val children = tree.children
       children foreach (ensureNonOverlapping(_, others, focus))
-      if (tree.pos.isOpaqueRange) {
-        val wpos = wrappingPos(tree.pos, children, focus)
-        tree setPos (if (isOverlapping(wpos)) tree.pos.makeTransparent else wpos)
+      if (treePos.isOpaqueRange) {
+        val wpos = wrappingPos(treePos, children, focus)
+        tree setPos (if (isOverlapping(wpos)) treePos.makeTransparent else wpos)
       }
     }
   }
@@ -80,124 +93,163 @@ trait Positions extends api.Positions { self: SymbolTable =>
     if (useOffsetPositions) Position.offset(source, point)
     else Position.range(source, start, point, end)
 
-  def validatePositions(tree: Tree) {
-    if (useOffsetPositions) return
 
-    def reportTree(prefix : String, tree : Tree) {
-      val source = if (tree.pos.isDefined) tree.pos.source else ""
-      inform("== "+prefix+" tree ["+tree.id+"] of type "+tree.productPrefix+" at "+tree.pos.show+source)
-      inform("")
-      inform(treeStatus(tree))
-      inform("")
+  abstract class ChildSolidDescendantsCollector extends Traverser {
+    // don't traverse annotations
+    override def traverseModifiers(mods: Modifiers): Unit = ()
+
+    override def traverse(tree: Tree): Unit =
+      if (tree ne EmptyTree) {
+        if (tree.pos.isTransparent) super.traverse(tree)
+        else {
+          traverseSolidChild(tree)
+        }
+      }
+    def traverseSolidChild(t: Tree): Unit
+    def apply(t: Tree): Unit = super.traverse(t)
+  }
+
+  private[this] def reportTree(prefix: String, tree: Tree) {
+    val source = if (tree.pos.isDefined) tree.pos.source else ""
+    inform("== " + prefix + " tree [" + tree.id + "] of type " + tree.productPrefix + " at " + tree.pos.show + source)
+    inform("")
+    inform(treeStatus(tree))
+    inform("")
+  }
+
+  private[this] def positionError(topTree: Tree, msg: String)(body: => Unit) {
+    inform("======= Position error\n" + msg)
+    body
+    inform("\nWhile validating #" + topTree.id)
+    inform(treeStatus(topTree))
+    inform("\nChildren:")
+    topTree.children foreach (t => inform("  " + treeStatus(t, topTree)))
+    inform("=======")
+    throw new ValidateException(msg)
+  }
+
+  private val posStartOrdering: Ordering[Tree] = new Ordering[Tree] {
+    override def compare(x: Tree, y: Tree): Int = {
+      @inline def posOf(t: Tree): Int = {
+        val pos = t.pos
+        if (pos eq NoPosition) Int.MinValue else pos.start
+      }
+      Integer.compare(posOf(x), posOf(y))
     }
+  }
+  def validatePositions(tree: Tree): Unit = if (!useOffsetPositions) {
+    object worker {
+      val trace = settings.Yposdebug && settings.verbose
+      val topTree = tree
 
-    def positionError(msg: String)(body : => Unit) {
-      inform("======= Position error\n" + msg)
-      body
-      inform("\nWhile validating #" + tree.id)
-      inform(treeStatus(tree))
-      inform("\nChildren:")
-      tree.children foreach (t => inform("  " + treeStatus(t, tree)))
-      inform("=======")
-      throw new ValidateException(msg)
-    }
+      object solidChildrenCollector extends ChildSolidDescendantsCollector {
+        private[this] var size = 0
+        private[this] var childSolidDescendants = new Array[Tree](32)
+        private[this] val spares = new java.util.ArrayList[Array[Tree]]
 
-    def validate(tree: Tree, encltree: Tree): Unit = {
+        def borrowArray:  Array[Tree] = {
+          val borrowed = childSolidDescendants
+          childSolidDescendants = if (spares.isEmpty) new Array[Tree](32) else spares.remove(spares.size - 1)
+          clear()
+          borrowed
+        }
+        def spareArray(array: Array[Tree]): Unit = {
+          spares.add(array)
+        }
 
-      if (!tree.isEmpty && tree.canHaveAttrs) {
-        if (settings.Yposdebug && settings.verbose)
-          inform("[%10s] %s".format("validate", treeStatus(tree, encltree)))
+        def child(i:Int) = childSolidDescendants(i)
+        def collectedSize = size
+        def sortedArray: Array[Tree] = {
+          if (size > 1)
+            java.util.Arrays.sort(childSolidDescendants, 0, size, posStartOrdering)
+          childSolidDescendants
+        }
 
-        if (!tree.pos.isDefined)
-          positionError("Unpositioned tree #"+tree.id) {
-            inform("%15s %s".format("unpositioned", treeStatus(tree, encltree)))
-            inform("%15s %s".format("enclosing", treeStatus(encltree)))
-            encltree.children foreach (t => inform("%15s %s".format("sibling", treeStatus(t, encltree))))
+        //we dont care about zeroing the array
+        def clear() {size = 0}
+
+        def traverseSolidChild(t: Tree): Unit = {
+          if (size == childSolidDescendants.length) {
+            spareArray(childSolidDescendants)
+            childSolidDescendants = java.util.Arrays.copyOf(childSolidDescendants, size << 1)
           }
-        if (tree.pos.isRange) {
-          if (!encltree.pos.isRange)
-            positionError("Synthetic tree ["+encltree.id+"] contains nonsynthetic tree ["+tree.id+"]") {
-            reportTree("Enclosing", encltree)
-            reportTree("Enclosed", tree)
-            }
-          if (!(encltree.pos includes tree.pos))
-            positionError("Enclosing tree ["+encltree.id+"] does not include tree ["+tree.id+"]") {
-              reportTree("Enclosing", encltree)
-              reportTree("Enclosed", tree)
+          childSolidDescendants(size) = t
+          size += 1
+        }
+      }
+
+      def loop(tree: Tree, encltree: Tree) {
+        if (!tree.isEmpty && tree.canHaveAttrs) {
+          val treePos = tree.pos
+          if (trace)
+            inform("[%10s] %s".format("validate", treeStatus(tree, encltree)))
+
+          if (!treePos.isDefined)
+            positionError(topTree, "Unpositioned tree #" + tree.id) {
+              inform("%15s %s".format("unpositioned", treeStatus(tree, encltree)))
+              inform("%15s %s".format("enclosing", treeStatus(encltree)))
+              encltree.children foreach (t => inform("%15s %s".format("sibling", treeStatus(t, encltree))))
             }
 
-          findOverlapping(tree.children flatMap solidDescendants) match {
-            case List() => ;
-            case xs => {
-              positionError("Overlapping trees "+xs.map { case (x, y) => (x.id, y.id) }.mkString("", ", ", "")) {
-                reportTree("Ancestor", tree)
-                for((x, y) <- xs) {
-                  reportTree("First overlapping", x)
-                  reportTree("Second overlapping", y)
+          solidChildrenCollector(tree)
+          val numChildren = solidChildrenCollector.collectedSize
+
+          if (treePos.isRange) {
+            val enclPos = encltree.pos
+            if (!enclPos.isRange)
+              positionError(topTree, "Synthetic tree [" + encltree.id + "] contains nonsynthetic tree [" + tree.id + "]") {
+                reportTree("Enclosing", encltree)
+                reportTree("Enclosed", tree)
+              }
+            if (!(enclPos includes treePos))
+              positionError(topTree, "Enclosing tree [" + encltree.id + "] does not include tree [" + tree.id + "]") {
+                reportTree("Enclosing", encltree)
+                reportTree("Enclosed", tree)
+              }
+
+            if (numChildren > 1) {
+              val childSolidDescendants = solidChildrenCollector.sortedArray
+              var t1 = childSolidDescendants(0)
+              var t1Pos = t1.pos
+              var i = 1
+              while (i < numChildren) {
+                val t2 = childSolidDescendants(i)
+                val t2Pos = t2.pos
+                if (t1Pos.overlaps(t2Pos)) {
+                  positionError(topTree, "Overlapping trees") {
+                    reportTree("Ancestor", tree)
+                    reportTree("First overlapping", t1)
+                    reportTree("Second overlapping", t2)
+                  }
                 }
+                //why only for range
+                if (t2Pos.isRange) {
+                  t1 = t2
+                  t1Pos = t2Pos
+                }
+                i += 1
               }
             }
           }
+          if (numChildren > 0) {
+            if (numChildren == 1) {
+              val first = solidChildrenCollector.child(0)
+              solidChildrenCollector.clear()
+              loop(first, tree)
+            } else {
+              val snap = solidChildrenCollector.borrowArray
+              var i = 0
+              while (i < numChildren) {
+                loop(snap(i), tree)
+                i += 1
+              }
+              solidChildrenCollector.spareArray(snap)
+            }
+          }
         }
-        for (ct <- tree.children flatMap solidDescendants) validate(ct, tree)
       }
     }
-
-    validate(tree, tree)
-  }
-
-  def solidDescendants(tree: Tree): List[Tree] =
-    if (tree.pos.isTransparent) tree.children flatMap solidDescendants
-    else List(tree)
-
-  /** A free range from `lo` to `hi` */
-  private def free(lo: Int, hi: Int): Range =
-    Range(Position.range(null, lo, lo, hi), EmptyTree)
-
-  /** The maximal free range */
-  private lazy val maxFree: Range = free(0, Int.MaxValue)
-
-  /** A singleton list of a non-empty range from `lo` to `hi`, or else the empty List */
-  private def maybeFree(lo: Int, hi: Int) =
-    if (lo < hi) List(free(lo, hi))
-    else List()
-
-  /** Insert `pos` into ranges `rs` if possible;
-   *  otherwise add conflicting trees to `conflicting`.
-   */
-  private def insert(rs: List[Range], t: Tree, conflicting: ListBuffer[Tree]): List[Range] = rs match {
-    case List() =>
-      assert(conflicting.nonEmpty)
-      rs
-    case r :: rs1 =>
-      assert(!t.pos.isTransparent)
-      if (r.isFree && (r.pos includes t.pos)) {
-//      inform("subdividing "+r+"/"+t.pos)
-        maybeFree(t.pos.end, r.pos.end) ::: List(Range(t.pos, t)) ::: maybeFree(r.pos.start, t.pos.start) ::: rs1
-      } else {
-        if (!r.isFree && (r.pos overlaps t.pos)) conflicting += r.tree
-        r :: insert(rs1, t, conflicting)
-      }
-  }
-
-  /** Replace elem `t` of `ts` by `replacement` list. */
-  private def replace(ts: List[Tree], t: Tree, replacement: List[Tree]): List[Tree] =
-    if (ts.head == t) replacement ::: ts.tail
-    else ts.head :: replace(ts.tail, t, replacement)
-
-  /** Does given list of trees have mutually non-overlapping positions?
-   *  pre: None of the trees is transparent
-   */
-  def findOverlapping(cts: List[Tree]): List[(Tree, Tree)] = {
-    var ranges = List(maxFree)
-    for (ct <- cts) {
-      if (ct.pos.isOpaqueRange) {
-        val conflicting = new ListBuffer[Tree]
-        ranges = insert(ranges, ct, conflicting)
-        if (conflicting.nonEmpty) return conflicting.toList map (t => (t, ct))
-      }
-    }
-    List()
+    worker.loop(tree, tree)
   }
 
   /** Set position of all children of a node
@@ -263,10 +315,6 @@ trait Positions extends api.Positions { self: SymbolTable =>
           }
       }
     }
-  }
-
-  case class Range(pos: Position, tree: Tree) {
-    def isFree = tree == EmptyTree
   }
 
   class TypedLocator(pos: Position) extends Locator(pos) {

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -9,6 +9,7 @@ package internal
 
 import Flags._
 import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
 import scala.reflect.macros.Attachments
 import util.{Statistics, StatisticsStatics}
 
@@ -150,13 +151,17 @@ trait Trees extends api.Trees {
       })
 
     override def children: List[Tree] = {
-      def subtrees(x: Any): List[Tree] = x match {
-        case EmptyTree   => Nil
-        case t: Tree     => List(t)
-        case xs: List[_] => xs flatMap subtrees
-        case _           => Nil
+      var builder: ListBuffer[Tree] = null
+      def subtrees(x: Any): Unit = x match {
+        case EmptyTree =>
+        case t: Tree =>
+          if (builder eq null) builder = new ListBuffer[Tree]
+          builder += t
+        case xs: List[_] => xs foreach subtrees
+        case _ =>
       }
-      productIterator.toList flatMap subtrees
+      productIterator foreach subtrees
+      if (builder eq null) Nil else builder.result()
     }
 
     def freeTerms: List[FreeTermSymbol] = freeSyms[FreeTermSymbol](_.isFreeTerm, _.termSymbol)

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -53,7 +53,6 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.KnownDirectSubclassesCalled
     this.noPrint
     this.typeDebug
-    this.Range
     // inaccessible: this.posAssigner
     this.ConsoleWriter
     this.RefTree

--- a/test/junit/scala/reflect/internal/PositionsTest.scala
+++ b/test/junit/scala/reflect/internal/PositionsTest.scala
@@ -1,0 +1,57 @@
+package scala.reflect.internal
+
+import org.junit.Test
+
+import scala.reflect.internal.util.NoSourceFile
+import scala.tools.nsc.reporters.StoreReporter
+import scala.tools.nsc.symtab.SymbolTableForUnitTesting
+import scala.tools.testing.AssertUtil
+
+class PositionsTest {
+
+  private object symbolTable extends SymbolTableForUnitTesting {
+    override def useOffsetPositions: Boolean = false
+    override val reporter = new StoreReporter
+  }
+
+  @Test def positionValidation(): Unit = {
+    import symbolTable._
+    def checkInvalid(tree: Tree): Unit = {
+      reporter.reset()
+      AssertUtil.assertThrows[ValidateException](validatePositions(tree))
+    }
+
+    def checkValid(tree: Tree): Unit = {
+      reporter.reset()
+      validatePositions(tree)
+      assert(!reporter.hasErrors)
+    }
+    def rangePos(start: Int, end: Int): util.Position = util.Position.range(NoSourceFile, start, start, end)
+    def offsetPos(point: Int): util.Position = util.Position.offset(NoSourceFile, point)
+    def tree: Tree = Ident(TermName("x"))
+    def rangePositioned(start: Int, end: Int): Tree = {
+      Ident(TermName("x")).setPos(rangePos(start, end))
+    }
+    // overlapping ranges
+    checkInvalid(Block(rangePositioned(0, 2), rangePositioned(1, 2), EmptyTree).setPos(rangePos(0, 2)))
+    checkInvalid(Block(rangePositioned(1, 2), rangePositioned(0, 2), EmptyTree).setPos(rangePos(0, 2)))
+
+    // transparent position not deemed to overlap itself
+    checkValid(Block(rangePositioned(0, 2), tree.setPos(rangePos(1, 2).makeTransparent), EmptyTree).setPos(rangePos(0, 2)))
+
+    // children of transparent position overlapping with sibling of transparent position.
+    checkInvalid(Block(rangePositioned(0, 2), Block(Nil, rangePositioned(1, 2)).setPos(rangePos(1, 2).makeTransparent), EmptyTree).setPos(rangePos(0, 2)))
+
+    // adjacent ranges are allowed to touch
+    checkValid(Block(rangePositioned(0, 1), rangePositioned(1, 2), EmptyTree).setPos(rangePos(0, 2)))
+
+    // offset position between overlapping ranges
+    checkInvalid(Block(rangePositioned(0, 2), tree.setPos(offsetPos(0)), rangePositioned(1, 2), EmptyTree).setPos(rangePos(0, 2)))
+
+    // child range position larger than parent
+    checkInvalid(Block(Nil, rangePositioned(0, 3)).setPos(rangePos(0, 2)))
+
+    // child offset position outside of parent
+    checkInvalid(Block(Nil, tree.setPos(offsetPos(3)).setPos(rangePos(0, 2))))
+  }
+}

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
@@ -2,7 +2,7 @@ package scala.tools.nsc
 package symtab
 
 import scala.reflect.ClassTag
-import scala.reflect.internal.{NoPhase, Phase, SomePhase}
+import scala.reflect.internal.{NoPhase, Phase, Reporter, SomePhase}
 import scala.reflect.internal.util.Statistics
 import scala.tools.util.PathResolver
 import util.ClassPath
@@ -81,7 +81,7 @@ class SymbolTableForUnitTesting extends SymbolTable {
   def erasurePhase: scala.reflect.internal.Phase = SomePhase
 
   // Members declared in scala.reflect.internal.Reporting
-  def reporter = new scala.reflect.internal.ReporterImpl {
+  def reporter: Reporter = new scala.reflect.internal.ReporterImpl {
     protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = println(msg)
   }
 


### PR DESCRIPTION
Fixes scala/scala-dev#487

Avoids almost all allocations during the traversal to collect solid children and when sorting them to detect overlaps.

Avoid recalculation of known results. Tune iteration and data structures to reduce allocation load and CPU load

Performance results were obtained on a different branch, where the first commit was to make the typer perform rangepos 10000 times for each compilation unit, so the numbers are exaggerated, but easier to spot performance changes - details below described as the distorted results

Also result non distorted in comments below


in summary from the baseline and last results
```
after 0 best 40%
                 Run Name	Cycle	samples	           Wall time (ms)	       All Wall time (ms)	                  CPU(ms)	           Idle time (ms)	           Allocated(MBs)
origin_mike_2.12.x_rangepos_pr-base-0	   1	  40	 7,350.00 [-6.26% +2.99%]	 7,350.00 [-6.26% +2.99%]	 7,206.55 [-5.70% +3.20%]	       0.00 [ NaN%  NaN%]	 1,667.57 [-1.24% +2.05%]
origin_mike_2.12.x_rangepos_pr-base-0	   2	  40	 7,404.93 [-4.85% +3.76%]	 7,404.93 [-4.85% +3.76%]	 7,282.73 [-4.97% +3.62%]	       0.00 [ NaN%  NaN%]	 1,654.94 [-1.20% +1.86%]
origin_mike_2.12.x_rangepos_pr-base-0	   3	  40	 7,381.78 [-5.16% +5.39%]	 7,381.78 [-5.16% +5.39%]	 7,265.10 [-5.81% +4.51%]	       0.00 [ NaN%  NaN%]	 1,645.14 [-1.31% +1.96%]
origin_mike_2.12.x_rangepos_pr-base-0	   4	  40	 7,342.05 [-2.56% +1.74%]	 7,342.05 [-2.56% +1.74%]	 7,201.98 [-2.80% +2.18%]	       0.00 [ NaN%  NaN%]	 1,648.48 [-1.22% +1.96%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   1	  40	 6,684.20 [-3.77% +3.50%]	 6,684.20 [-3.77% +3.50%]	 6,583.60 [-3.41% +3.71%]	       0.00 [ NaN%  NaN%]	 1,284.95 [-1.58% +2.39%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   2	  40	 6,638.98 [-3.72% +2.29%]	 6,638.98 [-3.72% +2.29%]	 6,541.78 [-3.27% +2.46%]	       0.00 [ NaN%  NaN%]	 1,263.01 [-1.66% +2.75%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   3	  40	 6,655.13 [-2.60% +2.39%]	 6,655.13 [-2.60% +2.39%]	 6,608.18 [-2.83% +2.62%]	       0.00 [ NaN%  NaN%]	 1,267.00 [-1.64% +2.70%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   4	  40	 6,517.85 [-3.23% +2.63%]	 6,517.85 [-3.23% +2.63%]	 6,424.58 [-2.72% +2.87%]	       0.00 [ NaN%  NaN%]	 1,272.53 [-1.68% +2.46%]
```
expected changes to parser and typer, but also unexpectedly to jvm as well
```
-----
after 0 best 40%, phase parser
                 Run Name	Cycle	samples	           Wall time (ms)	       All Wall time (ms)	                  CPU(ms)	           Idle time (ms)	           Allocated(MBs)
origin_mike_2.12.x_rangepos_pr-base-0	   1	  40	   282.58 [-4.45% +2.98%]	   282.58 [-4.45% +2.98%]	   282.38 [-6.15% +4.83%]	       0.00 [ NaN%  NaN%]	   211.09 [-0.00% +0.00%]
origin_mike_2.12.x_rangepos_pr-base-0	   2	  40	   284.33 [-3.63% +3.75%]	   284.33 [-3.63% +3.75%]	   284.23 [-6.76% +4.14%]	       0.00 [ NaN%  NaN%]	   211.21 [-0.00% +0.00%]
origin_mike_2.12.x_rangepos_pr-base-0	   3	  40	   286.33 [-3.61% +3.73%]	   286.33 [-3.61% +3.73%]	   286.23 [-7.42% +3.42%]	       0.00 [ NaN%  NaN%]	   211.22 [-0.00% +0.00%]
origin_mike_2.12.x_rangepos_pr-base-0	   4	  40	   295.18 [-3.45% +2.65%]	   295.18 [-3.45% +2.65%]	   292.60 [-9.43% +1.16%]	       0.00 [ NaN%  NaN%]	   211.03 [-0.00% +0.00%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   1	  40	   105.98 [-3.75% +4.74%]	   105.98 [-3.75% +4.74%]	  107.00 [-13.08% +1.87%]	       0.00 [ NaN%  NaN%]	    39.78 [-0.02% +0.02%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   2	  40	   110.43 [-1.29% +2.33%]	   110.43 [-1.29% +2.33%]	   109.00 [+0.00% +0.00%]	       0.00 [ NaN%  NaN%]	    39.69 [-0.01% +0.01%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   3	  40	   103.15 [-2.08% +2.76%]	   103.15 [-2.08% +2.76%]	   102.60 [-9.36% +6.24%]	       0.00 [ NaN%  NaN%]	    39.44 [-0.02% +0.01%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   4	  40	   102.75 [-2.68% +3.16%]	   102.75 [-2.68% +3.16%]	  105.00 [-11.43% +3.81%]	       0.00 [ NaN%  NaN%]	    39.62 [-0.02% +0.01%]
-----
after 0 best 40%, phase typer
                 Run Name	Cycle	samples	           Wall time (ms)	       All Wall time (ms)	                  CPU(ms)	           Idle time (ms)	           Allocated(MBs)
origin_mike_2.12.x_rangepos_pr-base-0	   1	  40	 2,232.78 [-2.32% +2.38%]	 2,232.78 [-2.32% +2.38%]	 2,224.25 [-3.07% +1.83%]	       0.00 [ NaN%  NaN%]	   549.17 [-0.00% +0.00%]
origin_mike_2.12.x_rangepos_pr-base-0	   2	  40	 2,161.28 [-3.25% +2.76%]	 2,161.28 [-3.25% +2.76%]	 2,158.08 [-3.02% +2.08%]	       0.00 [ NaN%  NaN%]	   543.13 [-0.00% +0.00%]
origin_mike_2.12.x_rangepos_pr-base-0	   3	  40	 2,125.73 [-2.48% +3.54%]	 2,125.73 [-2.48% +3.54%]	 2,121.03 [-2.78% +2.36%]	       0.00 [ NaN%  NaN%]	   542.15 [-0.00% +0.00%]
origin_mike_2.12.x_rangepos_pr-base-0	   4	  40	 2,216.90 [-2.30% +2.31%]	 2,216.90 [-2.30% +2.31%]	 2,212.05 [-2.53% +1.72%]	       0.00 [ NaN%  NaN%]	   541.70 [-0.00% +0.00%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   1	  40	 1,966.28 [-1.44% +1.21%]	 1,966.28 [-1.44% +1.21%]	 1,964.00 [-1.37% +1.02%]	       0.00 [ NaN%  NaN%]	   358.65 [-0.00% +0.00%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   2	  40	 1,928.93 [-1.14% +0.89%]	 1,928.93 [-1.14% +0.89%]	 1,925.58 [-1.85% +1.42%]	       0.00 [ NaN%  NaN%]	   350.84 [-0.00% +0.00%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   3	  40	 1,906.20 [-1.32% +1.14%]	 1,906.20 [-1.32% +1.14%]	 1,904.20 [-1.53% +1.72%]	       0.00 [ NaN%  NaN%]	   350.72 [-0.00% +0.00%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   4	  40	 1,877.25 [-0.97% +1.16%]	 1,877.25 [-0.97% +1.16%]	 1,875.08 [-1.71% +1.65%]	       0.00 [ NaN%  NaN%]	   351.72 [-0.00% +0.00%]
-----
after 0 best 40%, phase jvm
                 Run Name	Cycle	samples	           Wall time (ms)	       All Wall time (ms)	                  CPU(ms)	           Idle time (ms)	           Allocated(MBs)
origin_mike_2.12.x_rangepos_pr-base-0	   1	  40	 1,640.75 [-5.47% +2.21%]	 1,640.75 [-5.47% +2.21%]	 1,625.40 [-4.88% +2.81%]	       0.00 [ NaN%  NaN%]	   312.69 [-1.05% +1.47%]
origin_mike_2.12.x_rangepos_pr-base-0	   2	  40	 1,602.60 [-1.91% +2.77%]	 1,602.60 [-1.91% +2.77%]	 1,596.40 [-1.15% +1.79%]	       0.00 [ NaN%  NaN%]	   318.27 [-0.77% +1.00%]
origin_mike_2.12.x_rangepos_pr-base-0	   3	  40	 1,575.83 [-2.08% +2.30%]	 1,575.83 [-2.08% +2.30%]	 1,568.28 [-1.42% +1.58%]	       0.00 [ NaN%  NaN%]	   310.44 [-1.15% +1.53%]
origin_mike_2.12.x_rangepos_pr-base-0	   4	  40	 1,637.18 [-1.78% +1.33%]	 1,637.18 [-1.78% +1.33%]	 1,622.00 [-1.79% +1.11%]	       0.00 [ NaN%  NaN%]	   316.70 [-0.74% +1.03%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   1	  40	 1,572.18 [-3.57% +3.23%]	 1,572.18 [-3.57% +3.23%]	 1,546.48 [-2.04% +2.04%]	       0.00 [ NaN%  NaN%]	   311.30 [-0.91% +1.22%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   2	  40	 1,510.70 [-2.83% +2.20%]	 1,510.70 [-2.83% +2.20%]	 1,495.35 [-1.83% +2.38%]	       0.00 [ NaN%  NaN%]	   310.25 [-1.13% +1.59%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   3	  40	 1,506.15 [-3.00% +1.58%]	 1,506.15 [-3.00% +1.58%]	 1,499.25 [-3.08% +1.05%]	       0.00 [ NaN%  NaN%]	   311.14 [-0.99% +1.47%]
2.12.x_rangepos_pr=89227f46b3411c3b0ed347deedd2e1668d786027	   4	  40	 1,494.93 [-2.40% +2.08%]	 1,494.93 [-2.40% +2.08%]	 1,477.68 [-1.67% +1.51%]	       0.00 [ NaN%  NaN%]	   313.15 [-1.08% +1.44%]
-----
```

**in summary** of the result when using -Yrangepos this provides a 10% reduction in CPU load and 23% reduction in allocation
