### PR TITLE
Scaladoc: style <code> elements with monospace font

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
@@ -666,7 +666,7 @@ div#definition > h4#signature > span.modifier_kind > i.unfold-arrow,
 }
 
 .cmt code {
-  font-weight: bold;
+  font-family: "Source Code Pro", "Monaco", "Ubuntu Mono Regular", "Lucida Console", monospace;
 }
 
 .cmt a {


### PR DESCRIPTION
The 2.12 scaladoc redesign changed the css `<code>` from monospace to
bold. I wonder why?

https://github.com/scala/scala/commit/260661d16afe2266aecf9980476e386003cd50d1#diff-73c862a5ee9e3b9afafaba1a5a42e62eR699