### PR TITLE
Fix handling of out-of-range sizes in ArrayOps.patch

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -1048,11 +1048,12 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
   def patch[B >: A : ClassTag](from: Int, other: IterableOnce[B], replaced: Int): Array[B] = {
     val b = ArrayBuilder.make[B]
     val k = other.knownSize
-    if(k >= 0) b.sizeHint(xs.length + k - replaced)
+    val r = if(replaced < 0) 0 else replaced
+    if(k >= 0) b.sizeHint(xs.length + k - r)
     val chunk1 = if(from > 0) min(from, xs.length) else 0
     if(chunk1 > 0) b.addAll(xs, 0, chunk1)
     b ++= other
-    val remaining = xs.length - chunk1 - replaced
+    val remaining = xs.length - chunk1 - r
     if(remaining > 0) b.addAll(xs, xs.length - remaining, remaining)
     b.result()
   }

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -69,5 +69,16 @@ class ArrayOpsTest {
     assertArrayEquals(Array(0), zero)
   }
 
-
+  @Test
+  def patch(): Unit = {
+    val a1 = Array.empty[Int]
+    val v1 = a1.toVector
+    val a2 = Array[Int](1,2,3,4,5)
+    val v2 = a2.toVector
+    assertEquals(v1.patch(0, a1, -1), a1.patch(0, v1, -1).toSeq)
+    assertEquals(v2.patch(0, a2, 0), a2.patch(0, v2, 0).toSeq)
+    assertEquals(v2.patch(0, a2, 3), a2.patch(0, v2, 3).toSeq)
+    assertEquals(v2.patch(0, a2, 8), a2.patch(0, v2, 8).toSeq)
+    assertEquals(v1.patch(-1, a2, 1), a1.patch(-1, v2, 1).toSeq)
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/10877