### PR TITLE
Avoid NPE in replStringOf

### DIFF
--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -254,12 +254,12 @@ object ScalaRunTime {
   }
 
   /** stringOf formatted for use in a repl result. */
-  def replStringOf(arg: Any, maxElements: Int): String = {
-    val s  = stringOf(arg, maxElements)
-    val nl = if (s contains "\n") "\n" else ""
-
-    nl + s + "\n"
-  }
+  def replStringOf(arg: Any, maxElements: Int): String =
+    stringOf(arg, maxElements) match {
+      case null => "null toString"
+      case s if s.indexOf('\n') >= 0 => "\n" + s + "\n"
+      case s => s + "\n"
+    }
 
   // Convert arrays to immutable.ArraySeq for use with Java varargs:
   def genericWrapArray[T](xs: Array[T]): ArraySeq[T] =

--- a/test/junit/scala/runtime/ScalaRunTimeTest.scala
+++ b/test/junit/scala/runtime/ScalaRunTimeTest.scala
@@ -10,7 +10,7 @@ import org.junit.runners.JUnit4
 class ScalaRunTimeTest {
   @Test
   def testStringOf(): Unit = {
-    import ScalaRunTime.stringOf
+    import ScalaRunTime.{replStringOf, stringOf}
     import scala.collection._
 
     assertEquals("null", stringOf(null))
@@ -51,9 +51,15 @@ class ScalaRunTimeTest {
     assertEquals("(Array(0),1,2)", stringOf((Array(0), 1, 2)))
 
     val x = new Object {
-        override def toString(): String = "this is the stringOf string"
+      override def toString(): String = "this is the stringOf string"
     }
-    assertEquals(stringOf(x), "this is the stringOf string")
-    assertEquals(stringOf(x, 2), "this is the stringOf string")
+    assertEquals("this is the stringOf string", stringOf(x))
+    assertEquals("this is the stringOf string", stringOf(x, 2))
+
+    val tpolecat = new Object {
+      override def toString(): String = null
+    }
+    assertEquals(null, stringOf(tpolecat))
+    assertEquals("null toString", replStringOf(tpolecat, 100))
   }
 }


### PR DESCRIPTION
If a value has a null-valued toString, print "null toString",
which distinguishes the value from `null`.