### PR TITLE
Usability: compiler suggests possible names in NotAMemberError

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -565,7 +565,7 @@ trait Namers extends MethodSynthesis {
           if (isValid(from)) {
             // for Java code importing Scala objects
             if (!nme.isModuleName(from) || isValid(from.dropModule)) {
-              typer.TyperErrorGen.NotAMemberError(tree, expr, from)
+              typer.TyperErrorGen.NotAMemberError(tree, expr, from, context.outer)
             }
           }
           // Setting the position at the import means that if there is

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4287,9 +4287,15 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         if (name == nme.ERROR || qual.tpe.widen.isErroneous)
           NoSymbol
         else lookupInOwner(qual.tpe.typeSymbol, name) orElse {
-          NotAMemberError(tree, qual, name)
+          NotAMemberError(tree, qual, name, startingIdentContext)
           NoSymbol
         }
+      )
+
+      def startingIdentContext = (
+        // ignore current variable scope in patterns to enforce linearity
+        if (mode.inNone(PATTERNmode | TYPEPATmode)) context
+        else context.outer
       )
 
       def typedAnnotated(atd: Annotated): Tree = {
@@ -4583,7 +4589,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             && !(sym.isJavaAnnotation && context.inAnnotation))
           IsAbstractError(tree, sym)
         else if (isPrimitiveValueClass(sym)) {
-          NotAMemberError(tpt, TypeTree(tp), nme.CONSTRUCTOR)
+          NotAMemberError(tpt, TypeTree(tp), nme.CONSTRUCTOR, startingIdentContext)
           setError(tpt)
         }
         else if (!(  tp == sym.typeOfThis // when there's no explicit self type -- with (#3612) or without self variable

--- a/src/compiler/scala/tools/nsc/util/EditDistance.scala
+++ b/src/compiler/scala/tools/nsc/util/EditDistance.scala
@@ -1,0 +1,63 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.nsc
+package util
+
+import java.lang.Character.{ toLowerCase => lower }
+
+object EditDistance {
+
+  /**
+   * @author Paul Phillips
+   * Translated from the java version at
+   *    http://www.merriampark.com/ld.htm
+   *  which is declared to be public domain.
+   */
+  def levenshtein(
+      s: String,
+      t: String,
+      insertCost: Int = 1,
+      deleteCost: Int = 1,
+      subCost: Int = 1,
+      matchCost: Int = 0,
+      caseCost: Int = 1,
+      transpositions: Boolean = false
+  ): Int = {
+    val n = s.length
+    val m = t.length
+    if (n == 0) return m
+    if (m == 0) return n
+
+    val d = Array.ofDim[Int](n + 1, m + 1)
+    0 to n foreach (x => d(x)(0) = x)
+    0 to m foreach (x => d(0)(x) = x)
+
+    for (i <- 1 to n; s_i = s(i - 1); j <- 1 to m) {
+      val t_j = t(j - 1)
+      val cost = if (s_i == t_j) matchCost else if (lower(s_i) == lower(t_j)) caseCost else subCost
+
+      val c1 = d(i - 1)(j) + deleteCost
+      val c2 = d(i)(j - 1) + insertCost
+      val c3 = d(i - 1)(j - 1) + cost
+
+      d(i)(j) = c1 min c2 min c3
+
+      if (transpositions) {
+        if (i > 1 && j > 1 && s(i - 1) == t(j - 2) && s(i - 2) == t(j - 1))
+          d(i)(j) = d(i)(j) min (d(i - 2)(j - 2) + cost)
+      }
+    }
+
+    d(n)(m)
+  }
+}

--- a/src/compiler/scala/tools/nsc/util/StringUtil.scala
+++ b/src/compiler/scala/tools/nsc/util/StringUtil.scala
@@ -1,0 +1,29 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.nsc
+package util
+
+import scala.collection.immutable.Seq
+
+trait StringUtil {
+  def oxford(vs: Seq[String], conj: String): String = {
+    vs match {
+      case Seq()     => ""
+      case Seq(a)    => a
+      case Seq(a, b) => s"$a $conj $b"
+      case xs        => xs.dropRight(1).mkString(", ") + s", $conj " + xs.last
+    }
+  }
+}
+
+object StringUtil extends StringUtil

--- a/test/files/neg/macro-nontypeablebody.check
+++ b/test/files/neg/macro-nontypeablebody.check
@@ -1,4 +1,5 @@
 Macros_Test_2.scala:2: error: value foo2 is not a member of object Impls
+did you mean foo?
   def foo(x: Any) = macro Impls.foo2
                                 ^
 one error found

--- a/test/files/neg/noMember1.check
+++ b/test/files/neg/noMember1.check
@@ -1,5 +1,5 @@
 noMember1.scala:1: error: object IterableOnceOps is not a member of package collection
-Note: trait IterableOnceOps exists, but it has no companion object.
+note: trait IterableOnceOps exists, but it has no companion object.
 import scala.collection.IterableOnceOps._
                         ^
 one error found

--- a/test/files/neg/noMember2.check
+++ b/test/files/neg/noMember2.check
@@ -1,5 +1,5 @@
 noMember2.scala:2: error: object IterableOnceOps is not a member of package collection
-Note: trait IterableOnceOps exists, but it has no companion object.
+note: trait IterableOnceOps exists, but it has no companion object.
   val m = scala.collection.IterableOnceOps(1, 2, 3)
                            ^
 one error found

--- a/test/files/neg/suggest-similar.check
+++ b/test/files/neg/suggest-similar.check
@@ -1,10 +1,28 @@
-suggest-similar.scala:8: error: not found: value flippitx
-  flippitx = 123
-  ^
-suggest-similar.scala:9: error: not found: value identiyt
+suggest-similar.scala:10: error: value flippitx is not a member of object example.Weehawken
+did you mean flippity?
+  Weehawken.flippitx = 123
+            ^
+suggest-similar.scala:11: error: not found: value identiyt
   Nil map identiyt
           ^
-suggest-similar.scala:10: error: not found: type Bingus
-  new Bingus
-      ^
-three errors found
+suggest-similar.scala:12: error: type Eeehawken is not a member of package example
+did you mean Weehawken?
+  new example.Eeehawken
+              ^
+suggest-similar.scala:16: error: value readline is not a member of object scala.io.StdIn
+did you mean readLine?
+  import scala.io.StdIn.{readline, readInt}
+         ^
+suggest-similar.scala:20: error: object stdin is not a member of package io
+did you mean StdIn?
+  import scala.io.stdin.{readLine => line}
+                  ^
+suggest-similar.scala:37: error: value foo is not a member of object example.Hohokus
+did you mean foo1, foo2, foo3, or foo4?
+  Hohokus.foo
+          ^
+suggest-similar.scala:41: error: value bar is not a member of example.Hohokus
+did you mean bar2?
+  new Hohokus().bar // don't suggest bar1
+                ^
+7 errors found

--- a/test/files/neg/suggest-similar.scala
+++ b/test/files/neg/suggest-similar.scala
@@ -1,11 +1,42 @@
-class Dingus
-object Dingus {
+package example
+
+class Weehawken
+object Weehawken {
   var flippity = 1
+  type Blippitx = Int
 }
-import Dingus._
 
 class A {
-  flippitx = 123
+  Weehawken.flippitx = 123
   Nil map identiyt
-  new Bingus
+  new example.Eeehawken
+}
+
+object B {
+  import scala.io.StdIn.{readline, readInt}
+}
+
+object C {
+  import scala.io.stdin.{readLine => line}
+}
+
+class Hohokus {
+  protected def bar1
+  protected[example] def bar2
+}
+object Hohokus {
+  def foo1 = 1
+  def foo2 = 2
+  def foo3 = 3
+  def foo4 = 4
+  def foo5 = 5
+  def foo6 = 6
+}
+
+object D {
+  Hohokus.foo
+}
+
+object E {
+  new Hohokus().bar // don't suggest bar1
 }

--- a/test/files/neg/t10888.check
+++ b/test/files/neg/t10888.check
@@ -8,7 +8,7 @@ t10888.scala:5: error: package scala.collection is not a value
   val x = scala.collection           // package scala.collection is not a value
                 ^
 t10888.scala:7: error: object App is not a member of package scala
-Note: trait App exists, but it has no companion object.
+note: trait App exists, but it has no companion object.
   val z = scala.App                  // object App is not a member of package scala
                 ^
 four errors found

--- a/test/files/neg/t10935.check
+++ b/test/files/neg/t10935.check
@@ -1,6 +1,7 @@
 t10935.scala:4: error: value += is not a member of Int
   Expression does not convert to assignment because:
     value lengt is not a member of String
+    did you mean length?
     expansion: a.this.size = a.this.size.+(1.+("foo".<lengt: error>))
   size += 1 + "foo".lengt
        ^

--- a/test/files/neg/t3346c.check
+++ b/test/files/neg/t3346c.check
@@ -1,4 +1,5 @@
 t3346c.scala:60: error: value bar is not a member of Either[Int,String]
+did you mean map?
   eii.bar
       ^
 one error found

--- a/test/files/neg/t3871b.check
+++ b/test/files/neg/t3871b.check
@@ -8,12 +8,15 @@ t3871b.scala:77: error: method prot in class A cannot be accessed in E.this.A
       a.prot    // not allowed, prefix type `A` does not conform to `B`
         ^
 t3871b.scala:79: error: value protT is not a member of E.this.B
+did you mean prot or protE?
       b.protT   // not allowed
         ^
 t3871b.scala:80: error: value protT is not a member of E.this.C
+did you mean prot or protE?
       c.protT   // not allowed
         ^
 t3871b.scala:81: error: value protT is not a member of E.this.A
+did you mean protE?
       a.protT   // not allowed
         ^
 t3871b.scala:91: error: method prot in class A cannot be accessed in E.this.A
@@ -23,12 +26,15 @@ t3871b.scala:91: error: method prot in class A cannot be accessed in E.this.A
       a.prot    // not allowed
         ^
 t3871b.scala:93: error: value protT is not a member of E.this.B
+did you mean prot or protE?
       b.protT   // not allowed
         ^
 t3871b.scala:94: error: value protT is not a member of E.this.C
+did you mean prot or protE?
       c.protT   // not allowed
         ^
 t3871b.scala:95: error: value protT is not a member of E.this.A
+did you mean protE?
       a.protT   // not allowed
         ^
 t3871b.scala:102: error: method prot in class A cannot be accessed in E.this.B
@@ -50,12 +56,15 @@ t3871b.scala:104: error: method prot in class A cannot be accessed in E.this.A
       a.prot    // not allowed
         ^
 t3871b.scala:109: error: value protT is not a member of E.this.B
+did you mean protE?
       b.protT   // not allowed
         ^
 t3871b.scala:110: error: value protT is not a member of E.this.C
+did you mean protE?
       c.protT   // not allowed
         ^
 t3871b.scala:111: error: value protT is not a member of E.this.A
+did you mean protE?
       a.protT   // not allowed
         ^
 t3871b.scala:120: error: method prot in class A cannot be accessed in Other.this.e.B

--- a/test/files/neg/t4271.check
+++ b/test/files/neg/t4271.check
@@ -5,6 +5,7 @@ t4271.scala:10: error: value ensuring is not a member of Int
   5 ensuring true
     ^
 t4271.scala:11: error: value -> is not a member of Int
+did you mean >>>?
   3 -> 5
     ^
 three errors found

--- a/test/files/neg/t5801.check
+++ b/test/files/neg/t5801.check
@@ -1,4 +1,5 @@
 t5801.scala:1: error: object sth is not a member of package scala
+did you mean math or sys?
 import scala.sth
        ^
 t5801.scala:4: error: not found: value sth

--- a/test/files/run/macro-typecheck-implicitsdisabled.check
+++ b/test/files/run/macro-typecheck-implicitsdisabled.check
@@ -1,2 +1,3 @@
 scala.Predef.ArrowAssoc[Int](1).->[Int](2)
 scala.reflect.macros.TypecheckException: value -> is not a member of Int
+did you mean >>>?

--- a/test/files/run/repl-no-imports-no-predef.check
+++ b/test/files/run/repl-no-imports-no-predef.check
@@ -24,6 +24,7 @@ res6: (Int, Int) = (1,2)
 scala> 1 -> 2
          ^
        error: value -> is not a member of Int
+       did you mean >>>?
 
 scala> 1 → 2
          ^

--- a/test/files/run/toolbox_typecheck_implicitsdisabled.check
+++ b/test/files/run/toolbox_typecheck_implicitsdisabled.check
@@ -3,3 +3,4 @@
   scala.Predef.ArrowAssoc[Int](1).->[Int](2)
 }
 scala.tools.reflect.ToolBoxError: reflective typecheck has failed: value -> is not a member of Int
+did you mean >>>?


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/10181

With this change, NotAMemberError checks for possible members under target with edit distance of 2 or 1. To avoid false positives, candidates with size <2 (`eq`, `ne`, `_1` etc) are filtered out.

```scala
scala> import scala.io.StdIn.{readline, readInt}
              ^
       error: value readline is not a member of object scala.io.StdIn
       did you mean readLine?

scala> import scala.io.stdin.{readLine => line}
                       ^
       error: object stdin is not a member of package io
       did you mean StdIn?

scala> import scala.sth
              ^
       error: object sth is not a member of package scala
       did you mean sys or math?
```

### note

See also `-Ysuggest-idents` (https://github.com/scala/scala/commit/3e9e4ecf360e6eda5c26f798abfcb9bb882cf772), which got axed apparently for possible ["performance impact"](https://github.com/scala/scala/commit/9b9fb2cad46041c6cf101ec436b643e3e922bd35). Unlike that, this is a bit more constrained because I am just looking up the members of `target`, I think.
