### PR TITLE
Scaladoc member filter placeholder is hard to read in some web browser.

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
@@ -847,6 +847,19 @@ div.fullcomment dl.paramcmts > dd {
   font-family: "Open Sans";
 }
 
+#memberfilter > .input > input::-webkit-input-placeholder {
+  color: #fff;
+  opacity: 0.6;
+}
+#memberfilter > .input > input:-ms-input-placeholder {
+  color: #fff;
+  opacity: 0.6;
+}
+#memberfilter > .input > input::placeholder  {
+  color: #fff;
+  opacity: 0.6;
+}
+
 #memberfilter > .clear {
   display: none;
   position: absolute;


### PR DESCRIPTION
Fixes scala/bug#10634

Firefox 60 is fine without explicit styling for placeholder
However, the cosmetic issue can be seen on latest Chrome 67 and Edge 42.

Translucent white (`#fff` with `opacity: 0.6`) is used as similar as Firefox's built-in style. 
I think this might looks better than simple gray. Because translucent color can adapt to background color.

![image](https://user-images.githubusercontent.com/127635/40886155-0993ad78-676e-11e8-9b5b-d98da9a0c063.png)

Tested on 

* Firefox 60
* Chrome 67 
* Edge 42

`::placeholder` selector is supported in modern browser. Edge and older browsers needs vendor-specific 
See https://caniuse.com/#feat=css-placeholder



