### PR TITLE
Added filterMap and mapFilter functionality in ArrayOps and tcpoly_seq_typealias

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -413,6 +413,24 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     */
   def filterNot(p: A => Boolean): Array[A] = filter(x => !p(x))
 
+  /** Selects all elements of this array which satisfy a predicate and then applying a function to the elements of this array.
+    *
+    * @param p the predicate used to test elements.
+    * @param f the function to apply to each element.
+    * @tparam B the element type of the returned array.
+    * @return a new array consisting of all elements of this array that satisfy the given predicate `p`.
+    */
+  def filterMap(p: A => Boolean)(f: A => B): Array[B] = {
+    var res = ArrayBuilder.make[B]
+    var i = 0
+    while (i < xs.length) {
+      val x = xs(i)
+      if (p(x)) res += f(x)
+      i += 1
+    }
+    res.result()
+  }
+
   /** Sorts this array according to an Ordering.
     *
     *  The sort is stable. That is, elements that are equal (as determined by
@@ -642,7 +660,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *  Example:
     *  {{{
     *    Array(1, 2, 3, 4).scanLeft(0)(_ + _) == Array(0, 1, 3, 6, 10)
-    *  }}}    
+    *  }}}
     *
     */
   def scanLeft[ B : ClassTag ](z: B)(op: (B, A) => B): Array[B] = {
@@ -655,7 +673,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
       i += 1
     }
     res(i) = v
-    res 
+    res
   }
 
   /** Computes a prefix scan of the elements of the array.
@@ -681,7 +699,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *  Example:
     *  {{{
     *    Array(4, 3, 2, 1).scanRight(0)(_ + _) == Array(10, 6, 3, 1, 0)
-    *  }}}    
+    *  }}}
     *
     */
   def scanRight[ B : ClassTag ](z: B)(op: (A, B) => B): Array[B] = {
@@ -694,7 +712,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
       res(i) = v
       i -= 1
     }
-    res 
+    res
   }
 
   /** Applies a binary operator to all elements of this array and a start value,
@@ -789,6 +807,25 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     var i = 0
     while (i < xs.length) {
       res(i) = f(xs(i))
+      i = i + 1
+    }
+    res
+  }
+
+  /** Builds a new array by selecting the elements of this array which satisfy a predicate after applying a function to all elements of this array.
+    *
+    * @param f the function to apply to each element.
+    * @tparam B the element type of the returned array.
+    * @param p the predicate used to test elements.
+    * @return a new aray resulting from applying the given function
+    *         `f` to each element of this array and collecting the results.
+    */
+  def mapFilter[B: ClassTag](f: A => B)(p: B => Boolean): Array[B] = {
+    var res = new Array[B](xs.length)
+    var i = 0
+    while (i < xs.length) {
+      var x = f(xs(i))
+      if (p(x)) res(i) = x
       i = i + 1
     }
     res

--- a/test/files/pos/tcpoly_seq_typealias.scala
+++ b/test/files/pos/tcpoly_seq_typealias.scala
@@ -30,10 +30,24 @@ trait HOSeq {
       buf.result
     }
 
+    def filterMap(p: t => Boolean)(f: t => s): m[s] = {
+      val buf = accumulator[s]
+      val elems = iterator
+      while (elems.hasNext) { val x = elems.next; if (p(x)) buf += f(x) }
+      buf.result
+    }
+
     def map[s](f: t => s): m[s] = {
       val buf = accumulator[s]
       val elems = iterator
       while (elems.hasNext) buf += f(elems.next)
+      buf.result
+    }
+
+    def mapFilter[s](f: t => s)(p: s => Boolean): m[s] = {
+      val buf = accumulator[s]
+      val elems = iterator
+      while (elems.hasNext) { val x = f(elems.next); if(p(x)) buf += x }
       buf.result
     }
 


### PR DESCRIPTION
Being a Scala developer, I have encountered the use of filter and map function together with one after other very frequently.
I go through the implementation of filter and map function then I realize that If I apply map and filter or vice versa together then at the end there are 2 iterations of while loop that takes place. This can be further optimized to single iteration if we have `filterMap` and `mapFilter` methods.
These methods wrap the functionality of 2 methods i.e. `map` & `filter`and are similar to what `flatMap` offers.

Please Take a look and let me know if this looks good I will love to make changes to other collections and methods also.
Now I only added these methods to the `ArrayOps` and `tcpoly_seq_typealias` file.

1. Added filterMap functionality in ArrayOps and tcpoly_seq_typealias
2. Added mapFilter functionality in ArrayOps and tcpoly_seq_typealias

Thanks 

@SethTisue @Ichoran