### PR TITLE
fix Predef.=:= example code compile error

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -639,7 +639,7 @@ object Predef extends LowPriorityImplicits {
    *  @tparam To a type which is proved equal to `From`
    *
    *  @example An in-place variant of [[scala.collection.mutable.ArrayBuffer#transpose]] {{{
-   *            implicit class BufOps[A](buf: ArrayBuffer[A]) extends AnyVal {
+   *            implicit class BufOps[A](private val buf: ArrayBuffer[A]) extends AnyVal {
    *              def inPlaceTranspose[E]()(implicit ev: A =:= ArrayBuffer[E]) = ???
    *              // Because ArrayBuffer is invariant, we can't make do with just a A <:< ArrayBuffer[E]
    *              // Getting buffers *out* from buf would work, but adding them back *in* wouldn't.


### PR DESCRIPTION
```
Welcome to Scala 2.13.0-M4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_172).
Type in expressions for evaluation. Or try :help.

scala> import scala.collection.mutable.ArrayBuffer
import scala.collection.mutable.ArrayBuffer

scala> implicit class BufOps[A](buf: ArrayBuffer[A]) extends AnyVal {
     | }
                                ^
       error: value class parameter must be a val and not be private[this]

scala> implicit class BufOps[A](private val buf: ArrayBuffer[A]) extends AnyVal {
     | }
defined class BufOps
```