### PR TITLE
simplify Stream.fromIterator implementation

### DIFF
--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -862,10 +862,7 @@ object Stream extends LazyListFactory[Stream] {
   // `Stream` memoizes its elements
   def fromIterator[A](it: Iterator[A]): Stream[A] =
     if (it.hasNext) {
-      // Be sure that `it.next()` is called even when the `head`
-      // of our constructed lazy list is not evaluated (e.g. when one calls `drop`).
-      lazy val evaluatedElem = it.next()
-      new Stream.Cons(evaluatedElem, { evaluatedElem; fromIterator(it) })
+      new Stream.Cons(it.next(), fromIterator(it))
     } else Stream.Empty
 
   def empty[A]: Stream[A] = Empty


### PR DESCRIPTION
The first `hd: A` parameter of `LazyList.Cons` is "by name". But `Stream.Cons` is not "by name"
- https://github.com/scala/scala/blob/4046983cd937bf32fae8446729673ffdb34930ea/src/library/scala/collection/immutable/LazyList.scala#L616
- https://github.com/scala/scala/blob/4046983cd937bf32fae8446729673ffdb34930ea/src/library/scala/collection/immutable/LazyList.scala#L786