### PR TITLE
In collections API, deprecate symbolic methods with multiple parameters

### DIFF
--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -285,9 +285,12 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
   }
 
   /** Adds a new key/value pair to this map and returns the map. */
-  def addOne(key: K, value: V): this.type = { update(key, value); this }
+  def +=(key: K, value: V): this.type = { update(key, value); this }
 
-  def addOne(kv: (K, V)): this.type = { update(kv._1, kv._2); this }
+  /** Adds a new key/value pair to this map and returns the map. */
+  @inline final def addOne(key: K, value: V): this.type = { update(key, value); this }
+
+  @inline override final def addOne(kv: (K, V)): this.type = { update(kv._1, kv._2); this }
 
   def subtractOne(key: K): this.type = {
     val i = seekEntry(hashOf(key), key)

--- a/src/library/scala/collection/mutable/Growable.scala
+++ b/src/library/scala/collection/mutable/Growable.scala
@@ -36,6 +36,7 @@ trait Growable[-A] extends Clearable {
    *  @param elems the remaining elements to $add.
    *  @return the $coll itself
    */
+  @deprecated("Use `++=` (addAll) instead of varargs `+=`", "2.13.0")
   @`inline` final def += (elem1: A, elem2: A, elems: A*): this.type = this += elem1 += elem2 ++= (elems: IterableOnce[A])
 
   /** ${Add}s all elements produced by an IterableOnce to this $coll.

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -342,7 +342,10 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
   /** Adds a new key/value pair to this map and returns the map. */
   def +=(key: Long, value: V): this.type = { update(key, value); this }
 
-  override def addOne(kv: (Long, V)): this.type = { update(kv._1, kv._2); this }
+  /** Adds a new key/value pair to this map and returns the map. */
+  @inline final def addOne(key: Long, value: V): this.type = { update(key, value); this }
+
+  @inline override final def addOne(kv: (Long, V)): this.type = { update(kv._1, kv._2); this }
 
   def subtractOne(key: Long): this.type = {
     if (key == -key) {

--- a/test/files/run/collections.check
+++ b/test/files/run/collections.check
@@ -1,3 +1,4 @@
+warning: there were two deprecation warnings (since 2.13.0); re-run with -deprecation for details
 ***** mutable.HashSet:
 test1: 14005
 test2: 25005003, iters = 5000


### PR DESCRIPTION
Scala 3.0 will probably drop support for infix operators with multiple
parameters.

Fixes https://github.com/scala/bug/issues/10828