### PR TITLE
Add overrides for correct return types of `+` in some mutable maps

### DIFF
--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -169,27 +169,17 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
       else View.Empty
     }
 
-  /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
-    *  right hand operand. The element type of the $coll is the most specific superclass encompassing
-    *  the element types of the two operands.
-    *
-    *  @param xs   the traversable to append.
-    *  @tparam K2  the type of the keys of the returned $coll.
-    *  @tparam V2  the type of the values of the returned $coll.
-    *  @return     a new collection of type `CC[K2, V2]` which contains all elements
-    *              of this $coll followed by all elements of `xs`.
-    */
-  def concat[K2 >: K, V2 >: V](xs: Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = sortedMapFactory.from(new View.Concat(toIterable, xs))
+  override def concat[V2 >: V](xs: Iterable[(K, V2)]): CC[K, V2] = sortedMapFactory.from(new View.Concat(toIterable, xs))
 
   /** Alias for `concat` */
-  @`inline` final def ++ [K2 >: K, V2 >: V](xs: Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = concat(xs)
+  @`inline` override final def ++ [V2 >: V](xs: Iterable[(K, V2)]): CC[K, V2] = concat(xs)
 
-  @deprecated("Consider requiring an immutable SortedMap or fall back to SortedMap.concat ", "2.13.0")
+  @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
   override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = sortedMapFactory.from(new View.Appended(toIterable, kv))
 
-  // We override these methods to fix their return type (which would be `Map` otherwise)
-  override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = sortedMapFactory.from(new View.Concat(toIterable, xs))
-  override def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = concat(xs)
+  @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
+  override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = sortedMapFactory.from(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
+
   // TODO Also override mapValues
 
 }

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -349,6 +349,12 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
     arm
   }
 
+  @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
+  override def + [V1 >: V](kv: (K, V1)): AnyRefMap[K, V1] = AnyRefMap.from(new View.Appended(toIterable, kv))
+
+  @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
+  override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): AnyRefMap[K, V1] = AnyRefMap.from(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
+
   override def concat[V2 >: V](xs: scala.collection.Iterable[(K, V2)]): AnyRefMap[K, V2] = {
     val arm = clone().asInstanceOf[AnyRefMap[K, V2]]
     xs.foreach(kv => arm += kv)

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -425,13 +425,15 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
     lm
   }
 
-  /*
+  @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
   override def +[V1 >: V](kv: (Long, V1)): LongMap[V1] = {
     val lm = clone().asInstanceOf[LongMap[V1]]
     lm += kv
     lm
   }
-  */
+
+  @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
+  override def + [V1 >: V](elem1: (Long, V1), elem2: (Long, V1), elems: (Long, V1)*): LongMap[V1] = LongMap.from(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
 
   override def concat[V1 >: V](xs: scala.collection.Iterable[(Long, V1)]): LongMap[V1] = {
     val lm = clone().asInstanceOf[LongMap[V1]]

--- a/test/junit/scala/collection/mutable/AnyRefMapTest.scala
+++ b/test/junit/scala/collection/mutable/AnyRefMapTest.scala
@@ -32,4 +32,11 @@ class AnyRefMapTest {
     assertTrue(AnyRefMap(sameHashCode -> 1) contains sameHashCode)
     assertTrue(sameHashCode.hashCode == badHashCode)  // Make sure test works
   }
+
+  @Test
+  def t10876: Unit = {
+    val m = collection.mutable.AnyRefMap("fish" -> 3)
+    val m2 = m + (("birds", 2))
+    assertEquals(Map("fish" -> 3, "birds" -> 2), (m2: collection.mutable.AnyRefMap[String, Int]))
+  }
 }


### PR DESCRIPTION
Also make `SortedMap.concat` consistent with `SortedMap.++` in 2.12
and other specialized maps (AnyRefMap, LongMap) by disallowing
widening of the key type. This makes `concat` a simple override with
a more specific return type instead of an overload with a new
`Ordering` for the possibly widened key type.

Fixes https://github.com/scala/bug/issues/10876