### PR TITLE
Proposal: make Set covariant

### DIFF
--- a/src/compiler/scala/tools/nsc/CompileServer.scala
+++ b/src/compiler/scala/tools/nsc/CompileServer.scala
@@ -68,7 +68,7 @@ class StandardCompileServer(fixPort: Int = 0) extends SocketServer(fixPort) {
   def unequalSettings(s1: Settings, s2: Settings): Set[Settings#Setting] = {
     val ignoreSettings = Set("-d", "-encoding", "-currentDir")
     def trim (s: Settings): Set[Settings#Setting] = (
-      s.userSetSettings.toSet[Settings#Setting] filterNot (ss => ignoreSettings exists (ss respondsTo _))
+      s.userSetSettings.toSet filterNot (ss => ignoreSettings exists (ss respondsTo _))
     )
     val ss1 = trim(s1)
     val ss2 = trim(s2)

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -166,7 +166,7 @@ abstract class Erasure extends InfoTransform
    * This is important on Android because there is otherwise an interface explosion.
    */
   def minimizeParents(cls: Symbol, parents: List[Type]): List[Type] = if (parents.isEmpty) parents else {
-    val requiredDirect: Symbol => Boolean = requiredDirectInterfaces.getOrElse(cls, Set.empty)
+    val requiredDirect: Symbol => Boolean = requiredDirectInterfaces.getOrElse(cls, Set.empty).contains
     var rest   = parents.tail
     var leaves = collection.mutable.ListBuffer.empty[Type] += parents.head
     while (rest.nonEmpty) {

--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -527,7 +527,7 @@ trait ScalaLogic extends Interface with Logic with TreeAndTypeAnalysis {
         val subConsts =
           enumerateSubtypes(staticTp, grouped = false)
           .headOption.map { tps =>
-          tps.toSet[Type].map{ tp =>
+          tps.toSet.map{ tp =>
             val domainC = TypeConst(tp)
             registerEquality(domainC)
             domainC

--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -268,7 +268,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
   class ValueSet private[ValueSet] (private[this] var nnIds: immutable.BitSet)
     extends immutable.AbstractSet[Value]
       with immutable.SortedSet[Value]
-      with immutable.SetOps[Value, immutable.Set, ValueSet]
+      with immutable.SortedSetOps[Value, immutable.SortedSet, ValueSet]
       with StrictOptimizedIterableOps[Value, immutable.Set, ValueSet]
       with Serializable {
 

--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -277,7 +277,10 @@ abstract class Enumeration (initial: Int) extends Serializable {
       new ValueSet(nnIds.rangeImpl(from.map(_.id - bottomId), until.map(_.id - bottomId)))
 
     override def empty = ValueSet.empty
-    def contains(v: Value) = nnIds contains (v.id - bottomId)
+    def contains [A1 >: Value](v: A1) = v match {
+      case v: Value => nnIds contains (v.id - bottomId)
+      case _ => false
+    }
     def incl (value: Value) = new ValueSet(nnIds + (value.id - bottomId))
     def excl (value: Value) = new ValueSet(nnIds - (value.id - bottomId))
     def iterator = nnIds.iterator map (id => thisenum.apply(bottomId + id))

--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -283,6 +283,10 @@ abstract class Enumeration (initial: Int) extends Serializable {
     }
     def incl (value: Value) = new ValueSet(nnIds + (value.id - bottomId))
     def excl (value: Value) = new ValueSet(nnIds - (value.id - bottomId))
+    def excl [A1 >: Value](value: A1) = value match {
+      case value: Value => excl(value)
+      case _ => this
+    }
     def iterator = nnIds.iterator map (id => thisenum.apply(bottomId + id))
     override def iteratorFrom(start: Value) = nnIds iteratorFrom start.id  map (id => thisenum.apply(bottomId + id))
     override def className = thisenum + ".ValueSet"

--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -94,6 +94,11 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
 
   def contains(elem: Int): Boolean =
     0 <= elem && (word(elem >> LogWL) & (1L << elem)) != 0L
+  def contains[A1 >: Int](elem: A1): Boolean =
+    elem match {
+      case elem: Int => contains(elem)
+      case _ => false
+    }
 
   def iterator: Iterator[Int] = iteratorFrom(0)
 

--- a/src/library/scala/collection/BuildFrom.scala
+++ b/src/library/scala/collection/BuildFrom.scala
@@ -70,7 +70,7 @@ object BuildFrom extends BuildFromLowPriority1 {
 trait BuildFromLowPriority1 extends BuildFromLowPriority2 {
 
   /** Build the source collection type from an Iterable with SortedOps */
-  implicit def buildFromSortedSetOps[CC[X] <: SortedSet[X] with SortedSetOps[X, CC, _], A0, A : Ordering]: BuildFrom[CC[A0], A, CC[A]] = new BuildFrom[CC[A0], A, CC[A]] {
+  implicit def buildFromSortedSetOps[CC[X] <: SortedSetOps[X, CC, CC[X]] with SortedSet[X], A0, A : Ordering]: BuildFrom[CC[A0], A, CC[A]] = new BuildFrom[CC[A0], A, CC[A]] {
     def newBuilder(from: CC[A0]): Builder[A, CC[A]] = from.sortedIterableFactory.newBuilder[A]
     def fromSpecificIterable(from: CC[A0])(it: Iterable[A]): CC[A] = from.sortedIterableFactory.from(it)
   }

--- a/src/library/scala/collection/InvariantSetOps.scala
+++ b/src/library/scala/collection/InvariantSetOps.scala
@@ -1,0 +1,8 @@
+package scala
+package collection
+
+import scala.language.higherKinds
+
+trait InvariantSetOps[A, +CC[X] <: InvariantSetOps[X, CC, _] with Set[X], +C <: InvariantSetOps[A, CC, C] with CC[A]]
+  extends SetOps[A, Set, C] {
+}

--- a/src/library/scala/collection/InvariantSetOps.scala
+++ b/src/library/scala/collection/InvariantSetOps.scala
@@ -5,4 +5,25 @@ import scala.language.higherKinds
 
 trait InvariantSetOps[A, +CC[X] <: InvariantSetOps[X, CC, _] with Set[X], +C <: InvariantSetOps[A, CC, C] with CC[A]]
   extends SetOps[A, Set, C] {
+  def concat(that: collection.Iterable[A]): C = fromSpecificIterable(new View.Concat(toIterable, that))
+
+  @deprecated("Consider requiring an immutable Set or fall back to Set.union", "2.13.0")
+  def + (elem: A): C = fromSpecificIterable(new View.Appended(toIterable, elem))
+
+  @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
+  def + (elem1: A, elem2: A, elems: A*): C = fromSpecificIterable(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
+
+  /** Alias for `concat` */
+  @`inline` final def ++ (that: collection.Iterable[A]): C = concat(that)
+
+  /** Computes the union between of set and another set.
+    *
+    *  @param   that  the set to form the union with.
+    *  @return  a new set consisting of all elements that are in this
+    *  set or in the given set `that`.
+    */
+  @`inline` final def union(that: collection.Iterable[A]): C = concat(that)
+
+  /** Alias for `union` */
+  @`inline` final def | (that: collection.Iterable[A]): C = concat(that)
 }

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -139,9 +139,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
 
   /** The implementation class of the set returned by `keySet`.
     */
-  protected class KeySet extends AbstractSet[K] with GenKeySet {
-    def diff(that: Set[K]): Set[K] = fromSpecificIterable(view.filterNot(that))
-  }
+  protected class KeySet extends AbstractSet[K] with GenKeySet
 
   /** A generic trait that is reused by keyset implementations */
   protected trait GenKeySet { this: Set[K] =>

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -144,7 +144,8 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
   /** A generic trait that is reused by keyset implementations */
   protected trait GenKeySet { this: Set[K] =>
     def iterator: Iterator[K] = MapOps.this.keysIterator
-    def contains(key: K): Boolean = MapOps.this.contains(key)
+    // FIXME: unsafe cast
+    def contains[K1 >: K](key: K1): Boolean = MapOps.this.contains(key.asInstanceOf[K])
     override def size: Int = MapOps.this.size
   }
 

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -40,7 +40,7 @@ trait Set[+A]
 trait SetOps[+A, +CC[+X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] with CC[A]]
   extends IterableOps[A, CC, C] {
 
-  def contains(elem: A @uV): Boolean
+  def contains[A1 >: A](elem: A1): Boolean
 
   /** Tests if some element is contained in this set.
     *
@@ -49,7 +49,7 @@ trait SetOps[+A, +CC[+X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C]
     *  @return  `true` if `elem` is contained in this set, `false` otherwise.
     */
   @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /*@`inline` final*/ def apply(elem: A @uV): Boolean = this.contains(elem)
+  /*@`inline` final*/ def apply[A1 >: A](elem: A1): Boolean = this.contains(elem)
 
   /** Tests whether this set is a subset of another set.
     *
@@ -174,16 +174,13 @@ trait SetOps[+A, +CC[+X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C]
     *  @param that     the collection containing the elements to add.
     *  @return a new $coll with the given elements added, omitting duplicates.
     */
-  def concat(that: collection.Iterable[A @uV]): C = fromSpecificIterable(new View.Concat(toIterable, that))
+  def concat[B >: A](that: collection.Iterable[B]): CC[B]
 
   @deprecated("Consider requiring an immutable Set or fall back to Set.union", "2.13.0")
-  def + (elem: A @uV): C = fromSpecificIterable(new View.Appended(toIterable, elem))
+  def + [B >: A](elem: B): CC[B] = fromIterable(new View.Appended(toIterable, elem))
 
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
-  def + (elem1: A @uV, elem2: A @uV, elems: (A @uV)*): C = fromSpecificIterable(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
-
-  /** Alias for `concat` */
-  @`inline` final def ++ (that: collection.Iterable[A @uV]): C = concat(that)
+  def + [B >: A](elem1: B, elem2: B, elems: B*): CC[B] = fromIterable(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
 
   /** Computes the union between of set and another set.
     *
@@ -191,10 +188,10 @@ trait SetOps[+A, +CC[+X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C]
     *  @return  a new set consisting of all elements that are in this
     *  set or in the given set `that`.
     */
-  @`inline` final def union(that: collection.Iterable[A @uV]): C = concat(that)
+  @`inline` final def union[B >: A](that: collection.Iterable[B]): CC[B] = concat(that)
 
   /** Alias for `union` */
-  @`inline` final def | (that: collection.Iterable[A @uV]): C = concat(that)
+  @`inline` final def | [B >: A](that: collection.Iterable[B]): CC[B] = concat(that)
 
   /** The empty set of the same type as this set
     * @return  an empty set of type `C`.

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -156,10 +156,10 @@ trait SetOps[+A, +CC[+X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C]
   @`inline` final def -- [A1 >: A](that: Set[A1]): C = diff(that)
 
   @deprecated("Consider requiring an immutable Set or fall back to Set.diff", "2.13.0")
-  def - (elem: A @uV): C = diff(Set(elem))
+  def - [A1 >: A](elem: A1): C = diff(Set(elem))
 
   @deprecated("Use &- with an explicit collection argument instead of - with varargs", "2.13.0")
-  def - (elem1: A @uV, elem2: A @uV, elems: (A @uV)*): C = diff(elems.toSet + elem1 + elem2)
+  def - [A1 >: A](elem1: A1, elem2: A1, elems: A1*): C = diff(elems.toSet + elem1 + elem2)
 
   /** Creates a new $coll by adding all elements contained in another collection to this $coll, omitting duplicates.
     *

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -37,7 +37,7 @@ trait Set[A]
   * @define coll set
   * @define Coll `Set`
   */
-trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
+trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] with CC[A]]
   extends IterableOps[A, CC, C]
      with (A => Boolean) {
 

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -135,10 +135,10 @@ trait SetOps[+A, +CC[+X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C]
     *  @return  a new set consisting of all elements that are both in this
     *  set and in the given set `that`.
     */
-  def intersect(that: Set[A @uV]): C = this.filter(that)
+  def intersect[A1 >: A](that: Set[A1]): C = this.filter(that)
 
   /** Alias for `intersect` */
-  @`inline` final def & (that: Set[A @uV]): C = intersect(that)
+  @`inline` final def & [A1 >: A](that: Set[A1]): C = intersect(that)
 
 
   /** Computes the difference of this set and another set.
@@ -147,13 +147,13 @@ trait SetOps[+A, +CC[+X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C]
     *  @return     a set containing those elements of this
     *              set that are not also contained in the given set `that`.
     */
-  def diff(that: Set[A @uV]): C = this.filterNot(that)
+  def diff[A1 >: A](that: Set[A1]): C = this.filterNot(that)
 
   /** Alias for `diff` */
-  @`inline` final def &~ (that: Set[A @uV]): C = this diff that
+  @`inline` final def &~ [A1 >: A](that: Set[A1]): C = this diff that
 
   @deprecated("Use &~ or diff instead of --", "2.13.0")
-  @`inline` final def -- (that: Set[A @uV]): C = diff(that)
+  @`inline` final def -- [A1 >: A](that: Set[A1]): C = diff(that)
 
   @deprecated("Consider requiring an immutable Set or fall back to Set.diff", "2.13.0")
   def - (elem: A @uV): C = diff(Set(elem))

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -57,7 +57,7 @@ trait SetOps[+A, +CC[+X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C]
     *  @return     `true` if this set is a subset of `that`, i.e. if
     *              every element of this set is also an element of `that`.
     */
-  def subsetOf(that: Set[A @uV]): Boolean = this.forall(that)
+  def subsetOf[A1 >: A](that: Set[A1]): Boolean = this.forall(that)
 
   /** An iterator over all subsets of this set of the given size.
     *  If the requested size is impossible, an empty iterator is returned.

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -1,14 +1,14 @@
 package scala
 package collection
 
-import scala.annotation.unchecked.uncheckedVariance
+import scala.annotation.unchecked.{uncheckedVariance => uV}
 import scala.language.higherKinds
 import scala.util.hashing.MurmurHash3
 import java.lang.String
 
 /** Base trait for set collections.
   */
-trait Set[A]
+trait Set[+A]
   extends Iterable[A]
     with SetOps[A, Set, Set[A]]
     with Equals {
@@ -29,7 +29,7 @@ trait Set[A]
 
   override def iterableFactory: IterableFactory[IterableCC] = Set
 
-  def empty: IterableCC[A] = iterableFactory.empty
+  def empty: IterableCC[A] @uV = iterableFactory.empty
 }
 
 /** Base trait for set operations
@@ -37,11 +37,10 @@ trait Set[A]
   * @define coll set
   * @define Coll `Set`
   */
-trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] with CC[A]]
-  extends IterableOps[A, CC, C]
-     with (A => Boolean) {
+trait SetOps[+A, +CC[+X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] with CC[A]]
+  extends IterableOps[A, CC, C] {
 
-  def contains(elem: A): Boolean
+  def contains(elem: A @uV): Boolean
 
   /** Tests if some element is contained in this set.
     *
@@ -50,7 +49,7 @@ trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] w
     *  @return  `true` if `elem` is contained in this set, `false` otherwise.
     */
   @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /*@`inline` final*/ def apply(elem: A): Boolean = this.contains(elem)
+  /*@`inline` final*/ def apply(elem: A @uV): Boolean = this.contains(elem)
 
   /** Tests whether this set is a subset of another set.
     *
@@ -58,7 +57,7 @@ trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] w
     *  @return     `true` if this set is a subset of `that`, i.e. if
     *              every element of this set is also an element of `that`.
     */
-  def subsetOf(that: Set[A]): Boolean = this.forall(that)
+  def subsetOf(that: Set[A @uV]): Boolean = this.forall(that)
 
   /** An iterator over all subsets of this set of the given size.
     *  If the requested size is impossible, an empty iterator is returned.
@@ -136,10 +135,11 @@ trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] w
     *  @return  a new set consisting of all elements that are both in this
     *  set and in the given set `that`.
     */
-  def intersect(that: Set[A]): C = this.filter(that)
+  def intersect(that: Set[A @uV]): C = this.filter(that)
 
   /** Alias for `intersect` */
-  @`inline` final def & (that: Set[A]): C = intersect(that)
+  @`inline` final def & (that: Set[A @uV]): C = intersect(that)
+
 
   /** Computes the difference of this set and another set.
     *
@@ -147,19 +147,19 @@ trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] w
     *  @return     a set containing those elements of this
     *              set that are not also contained in the given set `that`.
     */
-  def diff(that: Set[A]): C = this.filterNot(that)
+  def diff(that: Set[A @uV]): C = this.filterNot(that)
 
   /** Alias for `diff` */
-  @`inline` final def &~ (that: Set[A]): C = this diff that
+  @`inline` final def &~ (that: Set[A @uV]): C = this diff that
 
   @deprecated("Use &~ or diff instead of --", "2.13.0")
-  @`inline` final def -- (that: Set[A]): C = diff(that)
+  @`inline` final def -- (that: Set[A @uV]): C = diff(that)
 
   @deprecated("Consider requiring an immutable Set or fall back to Set.diff", "2.13.0")
-  def - (elem: A): C = diff(Set(elem))
+  def - (elem: A @uV): C = diff(Set(elem))
 
   @deprecated("Use &- with an explicit collection argument instead of - with varargs", "2.13.0")
-  def - (elem1: A, elem2: A, elems: A*): C = diff(elems.toSet + elem1 + elem2)
+  def - (elem1: A @uV, elem2: A @uV, elems: (A @uV)*): C = diff(elems.toSet + elem1 + elem2)
 
   /** Creates a new $coll by adding all elements contained in another collection to this $coll, omitting duplicates.
     *
@@ -174,16 +174,16 @@ trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] w
     *  @param that     the collection containing the elements to add.
     *  @return a new $coll with the given elements added, omitting duplicates.
     */
-  def concat(that: collection.Iterable[A]): C = fromSpecificIterable(new View.Concat(toIterable, that))
+  def concat(that: collection.Iterable[A @uV]): C = fromSpecificIterable(new View.Concat(toIterable, that))
 
   @deprecated("Consider requiring an immutable Set or fall back to Set.union", "2.13.0")
-  def + (elem: A): C = fromSpecificIterable(new View.Appended(toIterable, elem))
+  def + (elem: A @uV): C = fromSpecificIterable(new View.Appended(toIterable, elem))
 
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
-  def + (elem1: A, elem2: A, elems: A*): C = fromSpecificIterable(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
+  def + (elem1: A @uV, elem2: A @uV, elems: (A @uV)*): C = fromSpecificIterable(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
 
   /** Alias for `concat` */
-  @`inline` final def ++ (that: collection.Iterable[A]): C = concat(that)
+  @`inline` final def ++ (that: collection.Iterable[A @uV]): C = concat(that)
 
   /** Computes the union between of set and another set.
     *
@@ -191,10 +191,10 @@ trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] w
     *  @return  a new set consisting of all elements that are in this
     *  set or in the given set `that`.
     */
-  @`inline` final def union(that: collection.Iterable[A]): C = concat(that)
+  @`inline` final def union(that: collection.Iterable[A @uV]): C = concat(that)
 
   /** Alias for `union` */
-  @`inline` final def | (that: collection.Iterable[A]): C = concat(that)
+  @`inline` final def | (that: collection.Iterable[A @uV]): C = concat(that)
 
   /** The empty set of the same type as this set
     * @return  an empty set of type `C`.
@@ -208,8 +208,10 @@ trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] w
   * @define Coll `Set`
   */
 @SerialVersionUID(3L)
-object Set extends IterableFactory.Delegate[Set](immutable.Set)
+object Set extends IterableFactory.Delegate[Set](immutable.Set) {
+  implicit def setToFunction[A](set: Set[A]): A => Boolean = set.contains
+}
 
 /** Explicit instantiation of the `Set` trait to reduce class file size in subclasses. */
 @SerialVersionUID(3L)
-abstract class AbstractSet[A] extends AbstractIterable[A] with Set[A]
+abstract class AbstractSet[+A] extends AbstractIterable[A] with Set[A]

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -147,7 +147,7 @@ trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] w
     *  @return     a set containing those elements of this
     *              set that are not also contained in the given set `that`.
     */
-  def diff(that: Set[A]): C
+  def diff(that: Set[A]): C = this.filterNot(that)
 
   /** Alias for `diff` */
   @`inline` final def &~ (that: Set[A]): C = this diff that

--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -120,7 +120,6 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
 
   /** The implementation class of the set returned by `keySet` */
   protected class KeySortedSet extends SortedSet[K] with GenKeySet with GenKeySortedSet {
-    def diff(that: Set[K]): SortedSet[K] = fromSpecificIterable(view.filterNot(that))
     def rangeImpl(from: Option[K], until: Option[K]): SortedSet[K] = {
       val map = SortedMapOps.this.rangeImpl(from, until)
       new map.KeySortedSet

--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -26,7 +26,7 @@ trait SortedSet[A] extends Set[A] with SortedSetOps[A, SortedSet, SortedSet[A]] 
   override protected[this] def writeReplace(): AnyRef = new DefaultSerializationProxy(sortedIterableFactory.evidenceIterableFactory[A], this)
 }
 
-trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
+trait SortedSetOps[A, +CC[X] <: SortedSetOps[X, CC, _] with SortedSet[X], +C <: SortedSetOps[A, CC, C] with CC[A]]
   extends SetOps[A, Set, C]
      with SortedOps[A, C] {
 
@@ -84,7 +84,7 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
       rangeUntil(next)
   }
 
-  override def withFilter(p: A => Boolean): SortedSetOps.WithFilter[A, IterableCC, CC] = new SortedSetOps.WithFilter(this, p)
+  override def withFilter(p: A => Boolean): SortedSetOps.WithFilter[A, IterableCC, CC] = new SortedSetOps.WithFilter[A, IterableCC, CC](this, p)
 
   /** Builds a new sorted collection by applying a function to all elements of this $coll.
     *
@@ -138,7 +138,7 @@ object SortedSetOps {
     *
     * @define coll sorted collection
     */
-  class WithFilter[+A, +IterableCC[_], +CC[X] <: SortedSet[X]](
+  class WithFilter[+A, +IterableCC[_], +CC[X] <: SortedSetOps[X, CC, _] with SortedSet[X]](
     self: SortedSetOps[A, CC, _] with IterableOps[A, IterableCC, _],
     p: A => Boolean
   ) extends IterableOps.WithFilter[A, IterableCC](self, p) {

--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -27,7 +27,7 @@ trait SortedSet[A] extends Set[A] with SortedSetOps[A, SortedSet, SortedSet[A]] 
 }
 
 trait SortedSetOps[A, +CC[X] <: SortedSetOps[X, CC, _] with SortedSet[X], +C <: SortedSetOps[A, CC, C] with CC[A]]
-  extends SetOps[A, Set, C]
+  extends InvariantSetOps[A, CC, C]
      with SortedOps[A, C] {
 
   /**

--- a/src/library/scala/collection/StrictOptimizedSortedSetOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSortedSetOps.scala
@@ -5,7 +5,7 @@ package collection
 import scala.annotation.unchecked.uncheckedVariance
 import scala.language.higherKinds
 
-trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
+trait StrictOptimizedSortedSetOps[A, +CC[X] <: StrictOptimizedSortedSetOps[X, CC, _] with SortedSet[X], +C <: StrictOptimizedSortedSetOps[A, CC, C] with CC[A]]
   extends SortedSetOps[A, CC, C]
     with StrictOptimizedIterableOps[A, Set, C] {
 

--- a/src/library/scala/collection/convert/AsJavaConverters.scala
+++ b/src/library/scala/collection/convert/AsJavaConverters.scala
@@ -179,7 +179,7 @@ trait AsJavaConverters {
    */
   def setAsJavaSet[A](s: Set[A]): ju.Set[A] = s match {
     case null                 => null
-    case JSetWrapper(wrapped) => wrapped
+    case JSetWrapper(wrapped) => wrapped.asInstanceOf[ju.Set[A]]
     case _                    => new SetWrapper(s)
   }
 

--- a/src/library/scala/collection/convert/WrapAsJava.scala
+++ b/src/library/scala/collection/convert/WrapAsJava.scala
@@ -202,7 +202,7 @@ private[convert] trait LowPriorityWrapAsJava {
    */
   implicit def setAsJavaSet[A](s: Set[A]): ju.Set[A] = s match {
     case null                 => null
-    case JSetWrapper(wrapped) => wrapped
+    case JSetWrapper(wrapped) => wrapped.asInstanceOf[ju.Set[A]]
     case _                    => new SetWrapper(s)
   }
 

--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -160,7 +160,7 @@ private[collection] trait Wrappers {
         case Some(e) =>
           underlying match {
             case ms: mutable.Set[a] =>
-              ms remove e
+              ms.remove(e.asInstanceOf[a])
               prev = None
             case _ =>
               throw new UnsupportedOperationException("remove")

--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -191,7 +191,7 @@ private[collection] trait Wrappers {
 
     def iterator = underlying.iterator.asScala
 
-    def contains(elem: A): Boolean = underlying.contains(elem)
+    def contains[A1 >: A](elem: A1): Boolean = underlying.contains(elem)
 
     def addOne(elem: A): this.type = { underlying add elem; this }
     def subtractOne(elem: A): this.type = { underlying remove elem; this }

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -46,6 +46,10 @@ sealed abstract class BitSet
       updateWord(idx, word(idx) & ~(1L << elem))
     } else this
   }
+  def excl[A1 >: Int](elem: A1): BitSet = elem match {
+    case elem: Int => excl(elem)
+    case _ => this
+  }
 
   /** Update word at index `idx`; enlarge set if `idx` outside range of set.
     */

--- a/src/library/scala/collection/immutable/ChampHashSet.scala
+++ b/src/library/scala/collection/immutable/ChampHashSet.scala
@@ -21,7 +21,7 @@ import java.lang.System.arraycopy
   */
 final class ChampHashSet[A] private[immutable] (val rootNode: SetNode[A], val cachedJavaHashCode: Int, val cachedSize: Int)
   extends AbstractSet[A]
-    with SetOps[A, ChampHashSet, ChampHashSet[A]]
+    with InvariantSetOps[A, ChampHashSet, ChampHashSet[A]]
     with StrictOptimizedIterableOps[A, ChampHashSet, ChampHashSet[A]] {
 
   override def iterableFactory: IterableFactory[ChampHashSet] = ChampHashSet

--- a/src/library/scala/collection/immutable/ChampHashSet.scala
+++ b/src/library/scala/collection/immutable/ChampHashSet.scala
@@ -48,10 +48,10 @@ final class ChampHashSet[A] private[immutable] (val rootNode: SetNode[A], val ca
     else this
   }
 
-  def excl(element: A): ChampHashSet[A] = {
+  def excl[B >: A](element: B): ChampHashSet[A] = {
     val effect = SetEffect[A]()
     val elementHash = computeHash(element)
-    val newRootNode = rootNode.removed(element, elementHash, 0, effect)
+    val newRootNode = rootNode.removed(element.asInstanceOf[A], elementHash, 0, effect)
 
     if (effect.isModified)
       ChampHashSet(newRootNode, cachedJavaHashCode - elementHash, cachedSize - 1)

--- a/src/library/scala/collection/immutable/ChampHashSet.scala
+++ b/src/library/scala/collection/immutable/ChampHashSet.scala
@@ -36,7 +36,7 @@ final class ChampHashSet[A] private[immutable] (val rootNode: SetNode[A], val ca
 
   protected[immutable] def reverseIterator: Iterator[A] = new SetReverseIterator[A](rootNode)
 
-  def contains(element: A): Boolean = rootNode.contains(element, computeHash(element), 0)
+  def contains[A1 >: A](element: A1): Boolean = rootNode.contains(element.asInstanceOf[A], computeHash(element), 0)
 
   def incl(element: A): ChampHashSet[A] = {
     val effect = SetEffect[A]()

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -38,7 +38,7 @@ sealed abstract class HashSet[A]
 
   def incl(elem: A): HashSet[A] = updated0(elem, computeHash(elem), 0)
 
-  def excl(elem: A): HashSet[A] = nullToEmpty(removed0(elem, computeHash(elem), 0))
+  def excl[A1 >: A](elem: A1): HashSet[A] = nullToEmpty(removed0(elem.asInstanceOf[A], computeHash(elem), 0))
 
   override def subsetOf(that: collection.Set[A]): Boolean = that match {
     case that:HashSet[A] =>

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -25,7 +25,7 @@ import scala.annotation.tailrec
   */
 sealed abstract class HashSet[A]
   extends AbstractSet[A]
-    with SetOps[A, HashSet, HashSet[A]]
+    with InvariantSetOps[A, HashSet, HashSet[A]]
     with StrictOptimizedIterableOps[A, HashSet, HashSet[A]] {
 
   import HashSet.{bufferSize, LeafHashSet, nullToEmpty}

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -34,7 +34,7 @@ sealed abstract class HashSet[A]
 
   override def iterableFactory = HashSet
 
-  def contains(elem: A): Boolean = get0(elem, computeHash(elem), 0)
+  def contains[A1 >: A](elem: A1): Boolean = get0(elem.asInstanceOf[A], computeHash(elem), 0)
 
   def incl(elem: A): HashSet[A] = updated0(elem, computeHash(elem), 0)
 

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -40,7 +40,7 @@ sealed abstract class HashSet[A]
 
   def excl[A1 >: A](elem: A1): HashSet[A] = nullToEmpty(removed0(elem.asInstanceOf[A], computeHash(elem), 0))
 
-  override def subsetOf(that: collection.Set[A]): Boolean = that match {
+  override def subsetOf[A1 >: A](that: collection.Set[A1]): Boolean = that match {
     case that:HashSet[A] =>
       // call the specialized implementation with a level of 0 since both this and that are top-level hash sets
       subsetOf0(that, 0)

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -56,14 +56,14 @@ sealed abstract class HashSet[A]
     case _ => super.concat(that)
   }
 
-  override def intersect(that: collection.Set[A]): HashSet[A] = that match {
+  override def intersect[A1 >: A](that: collection.Set[A1]): HashSet[A] = that match {
     case that: HashSet[A] =>
       val buffer = new Array[HashSet[A]](bufferSize(this.size min that.size))
       nullToEmpty(intersect0(that, 0, buffer, 0))
     case _ => super.intersect(that)
   }
 
-  override def diff(that: collection.Set[A]): HashSet[A] = that match {
+  override def diff[A1 >: A](that: collection.Set[A1]): HashSet[A] = that match {
     case that: HashSet[A] =>
       val buffer = new Array[HashSet[A]](bufferSize(this.size))
       nullToEmpty(diff0(that, 0, buffer, 0))

--- a/src/library/scala/collection/immutable/InvariantSetOps.scala
+++ b/src/library/scala/collection/immutable/InvariantSetOps.scala
@@ -7,4 +7,23 @@ import scala.language.higherKinds
 trait InvariantSetOps[A, +CC[X] <: InvariantSetOps[X, CC, _] with Set[X], +C <: InvariantSetOps[A, CC, C] with CC[A]]
   extends collection.InvariantSetOps[A, CC, C]
      with SetOps[A, Set, C] {
+  /** Creates a new set with an additional element, unless the element is
+    *  already present.
+    *
+    *  @param elem the element to be added
+    *  @return a new set that contains all elements of this set and that also
+    *          contains `elem`.
+    */
+  def incl(elem: A): C
+
+  /** Alias for `incl` */
+  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
+  override /*final*/ def + (elem: A): C = incl(elem) // like in collection.Set but not deprecated
+
+  override def concat(that: collection.Iterable[A]): C = {
+    var result: C = coll
+    val it = that.iterator
+    while (it.hasNext) result = (result.incl(it.next()))
+    result
+  }
 }

--- a/src/library/scala/collection/immutable/InvariantSetOps.scala
+++ b/src/library/scala/collection/immutable/InvariantSetOps.scala
@@ -1,0 +1,10 @@
+package scala
+package collection
+package immutable
+
+import scala.language.higherKinds
+
+trait InvariantSetOps[A, +CC[X] <: InvariantSetOps[X, CC, _] with Set[X], +C <: InvariantSetOps[A, CC, C] with CC[A]]
+  extends collection.InvariantSetOps[A, CC, C]
+     with SetOps[A, Set, C] {
+}

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -38,7 +38,7 @@ sealed class ListSet[A]
   override def size: Int = 0
   override def isEmpty: Boolean = true
 
-  def contains(elem: A): Boolean = false
+  def contains[A1 >: A](elem: A1): Boolean = false
 
   def incl(elem: A): ListSet[A] = new Node(elem)
   def excl(elem: A): ListSet[A] = this
@@ -71,7 +71,7 @@ sealed class ListSet[A]
 
     override def isEmpty: Boolean = false
 
-    override def contains(e: A) = containsInternal(this, e)
+    override def contains[A1 >: A](e: A1) = containsInternal(this, e.asInstanceOf[A])
 
     @tailrec private[this] def containsInternal(n: ListSet[A], e: A): Boolean =
       !n.isEmpty && (n.elem == e || containsInternal(n.next, e))

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -30,7 +30,7 @@ import scala.annotation.tailrec
   */
 sealed class ListSet[A]
   extends AbstractSet[A]
-    with SetOps[A, ListSet, ListSet[A]]
+    with InvariantSetOps[A, ListSet, ListSet[A]]
     with StrictOptimizedIterableOps[A, ListSet, ListSet[A]] {
 
   override def className: String = "ListSet"

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -41,7 +41,7 @@ sealed class ListSet[A]
   def contains[A1 >: A](elem: A1): Boolean = false
 
   def incl(elem: A): ListSet[A] = new Node(elem)
-  def excl(elem: A): ListSet[A] = this
+  def excl[A1 >: A](elem: A1): ListSet[A] = this
 
   def iterator: scala.collection.Iterator[A] = {
     var curr: ListSet[A] = this
@@ -78,7 +78,7 @@ sealed class ListSet[A]
 
     override def incl(e: A): ListSet[A] = if (contains(e)) this else new Node(e)
 
-    override def excl(e: A): ListSet[A] = removeInternal(e, this, Nil)
+    override def excl[A1 >: A](e: A1): ListSet[A] = removeInternal(e.asInstanceOf[A], this, Nil)
 
     @tailrec private[this] def removeInternal(k: A, cur: ListSet[A], acc: List[ListSet[A]]): ListSet[A] =
       if (cur.isEmpty) acc.last

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -118,7 +118,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   /** The implementation class of the set returned by `keySet` */
   protected class ImmutableKeySet extends AbstractSet[K] with GenKeySet {
     override def incl[K1 >: K](elem: K1): Set[K1] = if (this(elem)) this else empty ++ this + elem
-    def excl(elem: K): Set[K] = if (this(elem)) empty ++ this - elem else this
+    def excl[K1 >: K](elem: K1): Set[K] = if (this(elem)) empty ++ this - elem else this
   }
 
 }

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -117,7 +117,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
 
   /** The implementation class of the set returned by `keySet` */
   protected class ImmutableKeySet extends AbstractSet[K] with GenKeySet {
-    def incl(elem: K): Set[K] = if (this(elem)) this else empty ++ this + elem
+    override def incl[K1 >: K](elem: K1): Set[K1] = if (this(elem)) this else empty ++ this + elem
     def excl(elem: K): Set[K] = if (this(elem)) empty ++ this - elem else this
   }
 

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -28,11 +28,11 @@ trait SetOps[+A, +CC[+X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C]
     *  @return a new set that contains all elements of this set and that also
     *          contains `elem`.
     */
-  def incl(elem: A @uV): C
+  def incl[B >: A](elem: B): CC[B] = fromIterable(new View.Appended(toIterable, elem))
 
   /** Alias for `incl` */
   @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  override /*final*/ def + (elem: A @uV): C = incl(elem) // like in collection.Set but not deprecated
+  override /*final*/ def + [B >: A](elem: B): CC[B] = incl(elem) // like in collection.Set but not deprecated
 
   /** Creates a new set with a given element removed from this set.
     *
@@ -45,8 +45,8 @@ trait SetOps[+A, +CC[+X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C]
   /** Alias for `excl` */
   /* @`inline` final */ override def - (elem: A @uV): C = excl(elem)
 
-  override def concat(that: collection.Iterable[A @uV]): C = {
-    var result: C = coll
+  override def concat[B >: A](that: collection.Iterable[B]): CC[B] = {
+    var result: CC[B] = coll
     val it = that.iterator
     while (it.hasNext) result = result + it.next()
     result
@@ -85,8 +85,8 @@ object Set extends IterableFactory[Set] {
   /** An optimized representation for immutable empty sets */
   private object EmptySet extends AbstractSet[Any] {
     override def size: Int = 0
-    def contains(elem: Any): Boolean = false
-    def incl(elem: Any): Set[Any] = new Set1(elem)
+    def contains[A1 >: Any](elem: A1): Boolean = false
+    override def incl[B >: Any](elem: B): Set[B] = new Set1(elem)
     def excl(elem: Any): Set[Any] = this
     def iterator: Iterator[Any] = Iterator.empty
     override def foreach[U](f: Any => U): Unit = ()
@@ -96,8 +96,8 @@ object Set extends IterableFactory[Set] {
   /** An optimized representation for immutable sets of size 1 */
   final class Set1[A] private[collection] (elem1: A) extends AbstractSet[A] with StrictOptimizedIterableOps[A, Set, Set[A]] {
     override def size: Int = 1
-    def contains(elem: A): Boolean = elem == elem1
-    def incl(elem: A): Set[A] =
+    def contains[A1 >: A](elem: A1): Boolean = elem == elem1
+    override def incl[B >: A](elem: B): Set[B] =
       if (contains(elem)) this
       else new Set2(elem1, elem)
     def excl(elem: A): Set[A] =
@@ -118,8 +118,8 @@ object Set extends IterableFactory[Set] {
   /** An optimized representation for immutable sets of size 2 */
   final class Set2[A] private[collection] (elem1: A, elem2: A) extends AbstractSet[A] with StrictOptimizedIterableOps[A, Set, Set[A]] {
     override def size: Int = 2
-    def contains(elem: A): Boolean = elem == elem1 || elem == elem2
-    def incl(elem: A): Set[A] =
+    def contains[A1 >: A](elem: A1): Boolean = elem == elem1 || elem == elem2
+    override def incl[B >: A](elem: B): Set[B] =
       if (contains(elem)) this
       else new Set3(elem1, elem2, elem)
     def excl(elem: A): Set[A] =
@@ -149,10 +149,10 @@ object Set extends IterableFactory[Set] {
   /** An optimized representation for immutable sets of size 3 */
   final class Set3[A] private[collection] (elem1: A, elem2: A, elem3: A) extends AbstractSet[A] with StrictOptimizedIterableOps[A, Set, Set[A]] {
     override def size: Int = 3
-    def contains(elem: A): Boolean =
+    def contains[A1 >: A](elem: A1): Boolean =
       elem == elem1 || elem == elem2 || elem == elem3
-    def incl(elem: A): Set[A] =
-      if (contains(elem)) this
+    override def incl[B >: A](elem: B): Set[B] =
+      if (contains(elem.asInstanceOf[A])) this
       else new Set4(elem1, elem2, elem3, elem)
     def excl(elem: A): Set[A] =
       if (elem == elem1) new Set2(elem2, elem3)
@@ -183,11 +183,11 @@ object Set extends IterableFactory[Set] {
   /** An optimized representation for immutable sets of size 4 */
   final class Set4[A] private[collection] (elem1: A, elem2: A, elem3: A, elem4: A) extends AbstractSet[A] with StrictOptimizedIterableOps[A, Set, Set[A]] {
     override def size: Int = 4
-    def contains(elem: A): Boolean =
+    def contains[A1 >: A](elem: A1): Boolean =
       elem == elem1 || elem == elem2 || elem == elem3 || elem == elem4
-    def incl(elem: A): Set[A] =
-      if (contains(elem)) this
-      else (if (useBaseline) HashSet.empty[A] else ChampHashSet.empty[A]) + elem1 + elem2 + elem3 + elem4 + elem
+    override def incl[B >: A](elem: B): Set[B] =
+      if (contains(elem.asInstanceOf[A])) this
+      else (if (useBaseline) HashSet.empty[B] else ChampHashSet.empty[B]) + elem1 + elem2 + elem3 + elem4 + elem
     def excl(elem: A): Set[A] =
       if (elem == elem1) new Set3(elem2, elem3, elem4)
       else if (elem == elem2) new Set3(elem1, elem3, elem4)

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -18,7 +18,7 @@ trait Set[A] extends Iterable[A] with collection.Set[A] with SetOps[A, Set, Set[
   * @define coll immutable set
   * @define Coll `immutable.Set`
   */
-trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
+trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] with CC[A]]
   extends collection.SetOps[A, CC, C] {
 
   /** Creates a new set with an additional element, unless the element is

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -40,10 +40,10 @@ trait SetOps[+A, +CC[+X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C]
     *  @return a new set that contains all elements of this set but that does not
     *          contain `elem`.
     */
-  def excl(elem: A @uV): C
+  def excl[A1 >: A](elem: A1): C
 
   /** Alias for `excl` */
-  /* @`inline` final */ override def - (elem: A @uV): C = excl(elem)
+  /* @`inline` final */ override def - [A1 >: A](elem: A1): C = excl(elem)
 
   override def concat[B >: A](that: collection.Iterable[B]): CC[B] = {
     var result: CC[B] = coll
@@ -87,7 +87,7 @@ object Set extends IterableFactory[Set] {
     override def size: Int = 0
     def contains[A1 >: Any](elem: A1): Boolean = false
     override def incl[B >: Any](elem: B): Set[B] = new Set1(elem)
-    def excl(elem: Any): Set[Any] = this
+    def excl[B >: Any](elem: B): Set[Any] = this
     def iterator: Iterator[Any] = Iterator.empty
     override def foreach[U](f: Any => U): Unit = ()
   }
@@ -100,7 +100,7 @@ object Set extends IterableFactory[Set] {
     override def incl[B >: A](elem: B): Set[B] =
       if (contains(elem)) this
       else new Set2(elem1, elem)
-    def excl(elem: A): Set[A] =
+    def excl[B >: A](elem: B): Set[A] =
       if (elem == elem1) Set.empty
       else this
     def iterator: Iterator[A] = Iterator.single(elem1)
@@ -122,7 +122,7 @@ object Set extends IterableFactory[Set] {
     override def incl[B >: A](elem: B): Set[B] =
       if (contains(elem)) this
       else new Set3(elem1, elem2, elem)
-    def excl(elem: A): Set[A] =
+    def excl[B >: A](elem: B): Set[A] =
       if (elem == elem1) new Set1(elem2)
       else if (elem == elem2) new Set1(elem1)
       else this
@@ -154,7 +154,7 @@ object Set extends IterableFactory[Set] {
     override def incl[B >: A](elem: B): Set[B] =
       if (contains(elem.asInstanceOf[A])) this
       else new Set4(elem1, elem2, elem3, elem)
-    def excl(elem: A): Set[A] =
+    def excl[B >: A](elem: B): Set[A] =
       if (elem == elem1) new Set2(elem2, elem3)
       else if (elem == elem2) new Set2(elem1, elem3)
       else if (elem == elem3) new Set2(elem1, elem2)
@@ -188,7 +188,7 @@ object Set extends IterableFactory[Set] {
     override def incl[B >: A](elem: B): Set[B] =
       if (contains(elem.asInstanceOf[A])) this
       else (if (useBaseline) HashSet.empty[B] else ChampHashSet.empty[B]) + elem1 + elem2 + elem3 + elem4 + elem
-    def excl(elem: A): Set[A] =
+    def excl[B >: A](elem: B): Set[A] =
       if (elem == elem1) new Set3(elem2, elem3, elem4)
       else if (elem == elem2) new Set3(elem1, elem3, elem4)
       else if (elem == elem3) new Set3(elem1, elem2, elem4)

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -5,11 +5,12 @@ package immutable
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
 import scala.collection.mutable.{Builder, ImmutableBuilder}
+import scala.annotation.unchecked.{uncheckedVariance => uV}
 import scala.language.higherKinds
 
 
 /** Base trait for immutable set collections */
-trait Set[A] extends Iterable[A] with collection.Set[A] with SetOps[A, Set, Set[A]] {
+trait Set[+A] extends Iterable[A] with collection.Set[A] with SetOps[A, Set, Set[A]] {
   override def iterableFactory: IterableFactory[IterableCC] = Set
 }
 
@@ -18,9 +19,8 @@ trait Set[A] extends Iterable[A] with collection.Set[A] with SetOps[A, Set, Set[
   * @define coll immutable set
   * @define Coll `immutable.Set`
   */
-trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] with CC[A]]
+trait SetOps[+A, +CC[+X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] with CC[A]]
   extends collection.SetOps[A, CC, C] {
-
   /** Creates a new set with an additional element, unless the element is
     *  already present.
     *
@@ -28,11 +28,11 @@ trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] w
     *  @return a new set that contains all elements of this set and that also
     *          contains `elem`.
     */
-  def incl(elem: A): C
+  def incl(elem: A @uV): C
 
   /** Alias for `incl` */
   @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  override /*final*/ def + (elem: A): C = incl(elem) // like in collection.Set but not deprecated
+  override /*final*/ def + (elem: A @uV): C = incl(elem) // like in collection.Set but not deprecated
 
   /** Creates a new set with a given element removed from this set.
     *
@@ -40,12 +40,12 @@ trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] w
     *  @return a new set that contains all elements of this set but that does not
     *          contain `elem`.
     */
-  def excl(elem: A): C
+  def excl(elem: A @uV): C
 
   /** Alias for `excl` */
-  /* @`inline` final */ override def - (elem: A): C = excl(elem)
+  /* @`inline` final */ override def - (elem: A @uV): C = excl(elem)
 
-  override def concat(that: collection.Iterable[A]): C = {
+  override def concat(that: collection.Iterable[A @uV]): C = {
     var result: C = coll
     val it = that.iterator
     while (it.hasNext) result = result + it.next()
@@ -224,4 +224,4 @@ object Set extends IterableFactory[Set] {
 
 /** Explicit instantiation of the `Set` trait to reduce class file size in subclasses. */
 @SerialVersionUID(3L)
-abstract class AbstractSet[A] extends scala.collection.AbstractSet[A] with Set[A]
+abstract class AbstractSet[+A] extends scala.collection.AbstractSet[A] with Set[A]

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -51,9 +51,6 @@ trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] w
     while (it.hasNext) result = result + it.next()
     result
   }
-
-  def diff(that: collection.Set[A]): C =
-    toIterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result + elem)
 }
 
 /**

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -50,7 +50,7 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _]
         new map.ImmutableKeySortedSet
       }
       def incl(elem: K): SortedSet[K] = fromSpecificIterable(this).incl(elem)
-      def excl(elem: K): SortedSet[K] = fromSpecificIterable(this).excl(elem)
+      def excl[K1 >: K](elem: K1): SortedSet[K] = fromSpecificIterable(this).excl(elem.asInstanceOf[K])
     }
 
     // We override these methods to fix their return type (which would be `Map` otherwise)

--- a/src/library/scala/collection/immutable/SortedSet.scala
+++ b/src/library/scala/collection/immutable/SortedSet.scala
@@ -17,7 +17,7 @@ trait SortedSet[A]
   * @define coll immutable sorted set
   * @define Coll `immutable.SortedSet`
   */
-trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
+trait SortedSetOps[A, +CC[X] <: SortedSetOps[X, CC, _] with SortedSet[X], +C <: SortedSetOps[A, CC, C] with CC[A]]
   extends SetOps[A, Set, C]
      with collection.SortedSetOps[A, CC, C]
 

--- a/src/library/scala/collection/immutable/SortedSet.scala
+++ b/src/library/scala/collection/immutable/SortedSet.scala
@@ -18,7 +18,7 @@ trait SortedSet[A]
   * @define Coll `immutable.SortedSet`
   */
 trait SortedSetOps[A, +CC[X] <: SortedSetOps[X, CC, _] with SortedSet[X], +C <: SortedSetOps[A, CC, C] with CC[A]]
-  extends SetOps[A, Set, C]
+  extends InvariantSetOps[A, CC, C]
      with collection.SortedSetOps[A, CC, C]
 
 /**

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -123,9 +123,9 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
     *  @param elem    a new element to add.
     *  @return        a new $coll containing all the elements of this $coll except `elem`.
     */
-  def excl(elem: A): TreeSet[A] =
-    if (!RB.contains(tree, elem)) this
-    else newSet(RB.delete(tree, elem))
+  def excl[A1 >: A](elem: A1): TreeSet[A] =
+    if (!RB.contains(tree, elem.asInstanceOf[A])) this
+    else newSet(RB.delete(tree, elem.asInstanceOf[A]))
 }
 
 /**

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -104,7 +104,8 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
     *  @param  elem    the element to check for membership.
     *  @return true, iff `elem` is contained in this set.
     */
-  def contains(elem: A): Boolean = RB.contains(tree, elem)
+  // FIXME: unsafe cast
+  def contains[A1 >: A](elem: A1): Boolean = RB.contains(tree, elem.asInstanceOf[A])
 
   override def range(from: A, until: A): TreeSet[A] = newSet(RB.range(tree, from, until))
 

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -41,7 +41,7 @@ final class HashSet[A]
 
   def clear(): Unit = table.clearTable()
 
-  def contains(elem: A): Boolean = table.containsElem(elem)
+  def contains[A1 >: A](elem: A1): Boolean = table.containsElem(elem.asInstanceOf[A])
 
   def get(elem: A): Option[A] = table.findEntry(elem)
 

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -60,7 +60,7 @@ class LinkedHashSet[A]
 
   override def size: Int = table.tableSize
 
-  def contains(elem: A): Boolean = table.findEntry(elem) ne null
+  def contains[A1 >: A](elem: A1): Boolean = table.findEntry(elem.asInstanceOf[A]) ne null
 
   def addOne(elem: A): this.type = {
     table.findOrAddEntry(elem, null)

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -16,7 +16,7 @@ trait Set[A]
   * @define coll mutable set
   * @define Coll `mutable.Set`
   */
-trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
+trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] with CC[A]]
   extends IterableOps[A, CC, C]
     with collection.SetOps[A, CC, C]
     with Cloneable[C]

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -18,7 +18,7 @@ trait Set[A]
   */
 trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] with CC[A]]
   extends IterableOps[A, CC, C]
-    with collection.SetOps[A, CC, C]
+    with collection.InvariantSetOps[A, CC, C]
     with Cloneable[C]
     with Growable[A]
     with Shrinkable[A] {

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -68,9 +68,6 @@ trait SetOps[A, +CC[X] <: SetOps[X, CC, _] with Set[X], +C <: SetOps[A, CC, C] w
     res
   }
 
-  def diff(that: collection.Set[A]): C =
-    toIterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result += elem)
-
   def flatMapInPlace(f: A => IterableOnce[A]): this.type = {
     val toAdd = Set[A]()
     val toRemove = Set[A]()

--- a/src/library/scala/collection/mutable/SortedSet.scala
+++ b/src/library/scala/collection/mutable/SortedSet.scala
@@ -19,7 +19,7 @@ trait SortedSet[A]
   * @define coll mutable sorted set
   * @define Coll `mutable.Sortedset`
   */
-trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
+trait SortedSetOps[A, +CC[X] <: SortedSetOps[X, CC, _] with SortedSet[X], +C <: SortedSetOps[A, CC, C] with CC[A]]
   extends SetOps[A, Set, C]
     with collection.SortedSetOps[A, CC, C]
 

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -54,7 +54,8 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
 
   def clear(): Unit = RB.clear(tree)
 
-  def contains(elem: A): Boolean = RB.contains(tree, elem)
+  // FIXME: unsafe cast
+  def contains[A1 >: A](elem: A1): Boolean = RB.contains(tree, elem.asInstanceOf[A])
 
   def get(elem: A): Option[A] = RB.getKey(tree, elem)
 
@@ -124,7 +125,7 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
     override def rangeImpl(from: Option[A], until: Option[A]): TreeSet[A] =
       new TreeSetProjection(pickLowerBound(from), pickUpperBound(until))
 
-    override def contains(key: A) = isInsideViewBounds(key) && RB.contains(tree, key)
+    override def contains[A1 >: A](key: A1) = isInsideViewBounds(key.asInstanceOf[A]) && RB.contains(tree, key.asInstanceOf[A])
 
     override def iterator = RB.keysIterator(tree, from, until)
     override def iteratorFrom(start: A) = RB.keysIterator(tree, pickLowerBound(Some(start)), until)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1378,9 +1378,9 @@ trait Definitions extends api.StandardDefinitions {
     lazy val symbolsNotPresentInBytecode = syntheticCoreClasses ++ syntheticCoreMethods ++ hijackedCoreClasses
 
     /** Is the symbol that of a parent which is added during parsing? */
-    lazy val isPossibleSyntheticParent = ProductClass.seq.toSet[Symbol] + ProductRootClass + SerializableClass
+    lazy val isPossibleSyntheticParent = ProductClass.seq.toSet + ProductRootClass + SerializableClass
 
-    private lazy val boxedValueClassesSet = boxedClass.values.toSet[Symbol] + BoxedUnitClass
+    private lazy val boxedValueClassesSet = boxedClass.values.toSet + BoxedUnitClass
 
     /** Is symbol a value class? */
     def isPrimitiveValueClass(sym: Symbol) = ScalaValueClasses contains sym
@@ -1481,8 +1481,8 @@ trait Definitions extends api.StandardDefinitions {
 
       lazy val boxMethod        = classesMap(x => valueCompanionMember(x, nme.box))
       lazy val unboxMethod      = classesMap(x => valueCompanionMember(x, nme.unbox))
-      lazy val isUnbox          = unboxMethod.values.toSet[Symbol]
-      lazy val isBox            = boxMethod.values.toSet[Symbol]
+      lazy val isUnbox          = unboxMethod.values.toSet
+      lazy val isBox            = boxMethod.values.toSet
 
       lazy val Boolean_and = definitions.Boolean_and
       lazy val Boolean_or = definitions.Boolean_or

--- a/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
+++ b/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
@@ -249,7 +249,7 @@ final class WeakHashSet[A <: AnyRef](val initialCapacity: Int, val loadFactor: D
     }
   }
 
-  override def -(elem: A) = subtractOne(elem)
+  override def -[A1 >: A](elem: A1) = subtractOne(elem.asInstanceOf[A])
 
   // empty this set
   override def clear(): Unit = {

--- a/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
+++ b/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
@@ -148,7 +148,7 @@ final class WeakHashSet[A <: AnyRef](val initialCapacity: Int, val loadFactor: D
     tableLoop(0)
   }
 
-  def contains(elem: A): Boolean = findEntry(elem) ne null
+  def contains[A1 >: A](elem: A1): Boolean = findEntry(elem.asInstanceOf[A]) ne null
 
   // from scala.reflect.internal.Set, find an element or null if it isn't contained
   def findEntry(elem: A): A = elem match {

--- a/test/files/neg/found-req-variance.check
+++ b/test/files/neg/found-req-variance.check
@@ -161,13 +161,6 @@ Note: Int <: AnyVal (and Misc.MyData <: Misc.Data[Int]), but class Data is invar
 You may wish to define A as +A instead. (SLS 4.5)
   def f1 = Set[Data[AnyVal]]() + new MyData
                                  ^
-found-req-variance.scala:100: error: type mismatch;
- found   : Set[String]
- required: Set[CharSequence]
-Note: String <: CharSequence, but trait Set is invariant in type A.
-You may wish to investigate a wildcard type such as `_ <: CharSequence`. (SLS 3.2.10)
-    foo(s)
-        ^
 found-req-variance.scala:104: error: type mismatch;
  found   : Misc.Trippy[String,String,String]
  required: Misc.Trippy[Object,Object,Object]
@@ -182,4 +175,4 @@ Note: AnyRef >: String, but trait Map is invariant in type A.
 You may wish to investigate a wildcard type such as `_ >: String`. (SLS 3.2.10)
   def g2 = Set[Map[String, String]]() + Map[AnyRef, String]()
                                                            ^
-28 errors found
+27 errors found

--- a/test/files/neg/t8035-deprecated.check
+++ b/test/files/neg/t8035-deprecated.check
@@ -1,5 +1,5 @@
 t8035-deprecated.scala:2: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
-        signature: SetOps.apply(elem: A @scala.annotation.unchecked.uncheckedVariance): Boolean
+        signature: SetOps.apply[A1 >: A](elem: A1): Boolean
   given arguments: <none>
  after adaptation: SetOps((): Unit)
   List(1,2,3).toSet()

--- a/test/files/neg/t8035-deprecated.check
+++ b/test/files/neg/t8035-deprecated.check
@@ -1,5 +1,5 @@
 t8035-deprecated.scala:2: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
-        signature: SetOps.apply(elem: A): Boolean
+        signature: SetOps.apply(elem: A @scala.annotation.unchecked.uncheckedVariance): Boolean
   given arguments: <none>
  after adaptation: SetOps((): Unit)
   List(1,2,3).toSet()

--- a/test/files/neg/t8035-removed.check
+++ b/test/files/neg/t8035-removed.check
@@ -1,5 +1,5 @@
 t8035-removed.scala:2: error: Adaptation of argument list by inserting () has been removed.
-        signature: SetOps.apply(elem: A @scala.annotation.unchecked.uncheckedVariance): Boolean
+        signature: SetOps.apply[A1 >: A](elem: A1): Boolean
   given arguments: <none>
   List(1,2,3).toSet()
                    ^

--- a/test/files/neg/t8035-removed.check
+++ b/test/files/neg/t8035-removed.check
@@ -1,5 +1,5 @@
 t8035-removed.scala:2: error: Adaptation of argument list by inserting () has been removed.
-        signature: SetOps.apply(elem: A): Boolean
+        signature: SetOps.apply(elem: A @scala.annotation.unchecked.uncheckedVariance): Boolean
   given arguments: <none>
   List(1,2,3).toSet()
                    ^

--- a/test/files/neg/unchecked.check
+++ b/test/files/neg/unchecked.check
@@ -1,9 +1,6 @@
 unchecked.scala:18: warning: non-variable type argument String in type pattern Iterable[String] (the underlying of Iterable[String]) is unchecked since it is eliminated by erasure
     case xs: Iterable[String] => xs.head // unchecked
              ^
-unchecked.scala:22: warning: non-variable type argument Any in type pattern scala.collection.immutable.Set[Any] (the underlying of Set[Any]) is unchecked since it is eliminated by erasure
-    case xs: Set[Any] => xs.head // unchecked
-             ^
 unchecked.scala:26: warning: non-variable type argument Any in type pattern scala.collection.immutable.Map[Any,Any] (the underlying of Map[Any,Any]) is unchecked since it is eliminated by erasure
     case xs: Map[Any, Any] => xs.head // unchecked
              ^
@@ -17,5 +14,5 @@ unchecked.scala:55: warning: non-variable type argument Array[T] in type pattern
     case ArrayApply(x: Exp[Array[T]], _, _) => x // unchecked
                        ^
 error: No warnings can be incurred under -Xfatal-warnings.
-6 warnings found
+5 warnings found
 one error found

--- a/test/files/neg/unchecked.scala
+++ b/test/files/neg/unchecked.scala
@@ -19,7 +19,7 @@ object Test {
     case _                    => 0
   }
   def f3(x: Any) = x match {
-    case xs: Set[Any] => xs.head // unchecked
+    case xs: Set[Any] => xs.head // okay
     case _            => 0
   }
   def f4(x: Any) = x match {

--- a/test/files/neg/unchecked3.check
+++ b/test/files/neg/unchecked3.check
@@ -31,12 +31,9 @@ unchecked3.scala:62: warning: non-variable type argument Array[String] in type p
 unchecked3.scala:63: warning: non-variable type argument String in type pattern Array[Array[List[String]]] is unchecked since it is eliminated by erasure
     /*   warn */ case _: Array[Array[List[String]]] => ()
                          ^
-unchecked3.scala:75: warning: abstract type A in type pattern scala.collection.immutable.Set[Q.this.A] (the underlying of Set[Q.this.A]) is unchecked since it is eliminated by erasure
-      /*   warn */ case xs: Set[A]  => xs.head
-                            ^
 unchecked3.scala:62: warning: unreachable code
     /*   warn */ case _: Array[List[Array[String]]] => ()
                                                        ^
 error: No warnings can be incurred under -Xfatal-warnings.
-13 warnings found
+12 warnings found
 one error found

--- a/test/files/neg/unchecked3.scala
+++ b/test/files/neg/unchecked3.scala
@@ -72,7 +72,7 @@ object Matching {
     def f(xs: Iterable[B]) = xs match {
       /* nowarn */ case xs: List[A] => xs.head
       /* nowarn */ case xs: Seq[B]  => xs.head
-      /*   warn */ case xs: Set[A]  => xs.head
+      /* nowarn */ case xs: Set[A]  => xs.head
     }
     def f2[T <: B](xs: Iterable[T]) = xs match {
       /* nowarn */ case xs: List[B with T] => xs.head

--- a/test/files/pos/virtpatmat_exist1.scala
+++ b/test/files/pos/virtpatmat_exist1.scala
@@ -10,7 +10,7 @@ class HS[A]
     with StrictOptimizedIterableOps[A, HS, HS[A]]
     with Serializable {
   def get(elem: A): Option[A] = ???
-  def contains(elem: A): Boolean = ???
+  def contains[A1 >: A](elem: A1): Boolean = ???
   def addOne(elem: A): HS.this.type = ???
   def clear(): Unit = ???
   def iterator: Iterator[A] = ???

--- a/test/files/run/repl-colon-type.check
+++ b/test/files/run/repl-colon-type.check
@@ -100,7 +100,7 @@ PolyType(
     params = List(TermSymbol(x: T), TermSymbol(y: U))
     resultType = TypeRef(
       TypeSymbol(
-        abstract trait Set[A] extends Iterable[A] with Set[A] with SetOps[A,scala.collection.immutable.Set,scala.collection.immutable.Set[A]]
+        abstract trait Set[+A] extends Iterable[A] with Set[A] with SetOps[A,scala.collection.immutable.Set,scala.collection.immutable.Set[A]]
 
       )
       args = List(TypeRef(TypeSymbol(abstract class Any extends )))

--- a/test/junit/scala/collection/immutable/SetTest.scala
+++ b/test/junit/scala/collection/immutable/SetTest.scala
@@ -12,7 +12,7 @@ class SetTest {
     val any2stringadd = "Disabled string conversions so as not to get confused!"
     
     def any[A](set: Set[A]): Set[Any] = {
-      val anyset = set.toSet[Any]
+      val anyset: Set[Any] = set
       assert((anyset + "fish") contains "fish")
       anyset
     }
@@ -20,7 +20,7 @@ class SetTest {
     // Make sure default immutable Set does not rebuild itself on widening with toSet
     // Need to cover 0, 1, 2, 3, 4 elements as special cases
     var si = Set.empty[Int]
-    assert(si eq si.toSet[Any])
+    assert(si eq si)
     for (i <- 1 to 5) {
       val s1 = Set(Array.range(1, i+1): _*)
       val s2 = si + i

--- a/test/junit/scala/collection/mutable/SetTest.scala
+++ b/test/junit/scala/collection/mutable/SetTest.scala
@@ -18,7 +18,7 @@ class SetTest {
 
     override def empty = new MySet(self.empty)
     def iterator = self.iterator
-    def contains(elem: String) = self.contains(elem)
+    def contains[A1 >: String](elem: A1) = self.contains(elem)
     def get(elem: String): Option[String] = self.get(elem)
     def clear(): Unit = self.clear()
   }

--- a/test/junit/scala/tools/nsc/transform/patmat/SolvingTest.scala
+++ b/test/junit/scala/tools/nsc/transform/patmat/SolvingTest.scala
@@ -590,7 +590,7 @@ class SolvingTest {
   def pairWiseEncoding(ops: List[Sym]) = {
     And(ops.combinations(2).collect {
       case a :: b :: Nil => Or(Not(a), Not(b))
-    }.toSet[TestSolver.TestSolver.Prop])
+    }.toSet)
   }
 
   @Test


### PR DESCRIPTION
There's no fundamental reason for Set being invariant, quoting Martin in 2011 (https://www.scala-lang.org/old/node/9764):
>  On the issue of sets, I believe the non-variance stems also from the implementations. Common sets are implemented as hashtables, which are non-variant arrays of the key type. I agree it's a slighly annoying irregularity.

This PR is an attempt at solving this irregularity, this is done in several steps:
- Make `Set[A]` stop extending `A => Boolean`, replacing it by an implicit conversion defined in the companion object. This is not 100% source compatible (there was one case in scala/scala where I had to add an explicit `.contains`) but it should be "good enough".
- Replace methods where `A` appears in contravariant position such as ` def + (elem: A): C` by `def + [B >: A](elem: B): CC[B]`.
- Add overloaded version of the replaced methods with their old signatures to `{collection,immutable}.InvariantSetOps`, these traits are mixed in by the subclasses of Set which must be invariant (that is, all mutable Sets as well as all SortedSets). These overloads are crucial for SortedSets since `SortedSet(1, 2, 3) + 42` should return a `SortedSet[Int]` and not a `Set[Int]`, but `SortedSet(1, 2, 3) + "42"` must return a `Set[Any]`.

This PR is missing a few things (more documentation, more tests, and proper implementations of `contains` for `GenKeySet` and `TreeSet`), but I'd like to know if this is something that is worth pursuing or if it's simply too late/risky to do such a change now. In any case, I'm happy I did this PR since it forced me to learn how the new collections work :).