### PR TITLE
fix JavaConverters example code

### DIFF
--- a/src/library/scala/collection/JavaConverters.scala
+++ b/src/library/scala/collection/JavaConverters.scala
@@ -58,7 +58,7 @@ import convert._
  *    vs: java.util.List[String] = [hi, bye]
  *
  *    scala> val ss = asScalaIterator(vs.iterator)
- *    ss: Iterator[String] = non-empty iterator
+ *    ss: Iterator[String] = <iterator>
  *
  *    scala> .toList
  *    res0: List[String] = List(hi, bye)


### PR DESCRIPTION
`Iterator#toString` changed https://github.com/scala/scala/commit/1c65114542f0b378414e0c7559835c89f0126846