### PR TITLE
fix NumericRange example code

### DIFF
--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -16,7 +16,7 @@ import scala.collection.mutable.Builder
   *  the `Int`-based `scala.Range` should be more performant.
   *
   *  {{{
-  *     val r1 = new Range(0, 100, 1)
+  *     val r1 = Range(0, 100, 1)
   *     val veryBig = Int.MaxValue.toLong + 1
   *     val r2 = Range.Long(veryBig, veryBig + 100, 1)
   *     assert(r1 sameElements r2.map(_ - veryBig))


### PR DESCRIPTION
Range is abstract class since Scala 2.13.0-M4

https://github.com/scala/scala/commit/909d28a66942c00ba4ff969f4513cebafa218318#diff-09b965e7f015588f3ee211a10cfae75eR44

```
Welcome to Scala 2.13.0-M4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_172).
Type in expressions for evaluation. Or try :help.

scala> new Range(0, 100, 1)
       ^
       error: class Range is abstract; cannot be instantiated

scala> Range(0, 100, 1)
res1: scala.collection.immutable.Range.Exclusive = Range 0 until 100
```