### PR TITLE
fix PriorityQueue example code

### DIFF
--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -29,7 +29,7 @@ import scala.math.Ordering
   *  @example {{{
   *  val pq = collection.mutable.PriorityQueue(1, 2, 5, 3, 7)
   *  println(pq)                  // elements probably not in order
-  *  println(pq.clone.dequeueAll) // prints Vector(7, 5, 3, 2, 1)
+  *  println(pq.clone.dequeueAll) // prints ArrayBuffer(7, 5, 3, 2, 1)
   *  }}}
   *
   *  @tparam A    type of the elements in this priority queue.


### PR DESCRIPTION
`PriorityQueue#dequeueAll` return `ArrayBuffer`. not `Vector`
(since Scala 2.13.0-M4)

https://github.com/scala/scala/blob/a8d355ae859e8e7afabc1052ab0262cdb522325b/src/library/scala/collection/mutable/PriorityQueue.scala#L221-L227