### PR TITLE
fix IterableOnce#flatMap example code

### DIFF
--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -262,7 +262,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *      def lettersOf(words: Seq[String]) = words flatMap (word => word.toSet)
     *
     *      // lettersOf will return a Set[Char], not a Seq
-    *      def lettersOf(words: Seq[String]) = words.toSet flatMap (word => word.toSeq)
+    *      def lettersOf(words: Seq[String]) = words.toSet flatMap ((word: String) => word.toSeq)
     *
     *      // xs will be an Iterable[Int]
     *      val xs = Map("a" -> List(11,111), "b" -> List(22,222)).flatMap(_._2)


### PR DESCRIPTION
https://stackoverflow.com/q/13130013

```
Welcome to Scala 2.13.0-M4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_172).
Type in expressions for evaluation. Or try :help.

scala> def lettersOf(words: Seq[String]) = words.toSet flatMap (word => word.toSeq)
                                                                ^
       error: missing parameter type

scala> def lettersOf(words: Seq[String]) = words.toSet flatMap ((word: String) => word.toSeq)
lettersOf: (words: Seq[String])scala.collection.immutable.Set[Char]
```