### PR TITLE
Make ArrayOps.startsWith return true for out-of-bounds empty array

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -1300,7 +1300,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     */
   def startsWith[B >: A](that: Array[B], offset: Int): Boolean = {
     val thatl = that.length
-    if(thatl > xs.length-offset) false
+    if(thatl > xs.length-offset) thatl == 0
     else {
       var i = 0
       while(i < thatl) {

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -70,6 +70,18 @@ class ArrayOpsTest {
   }
 
   @Test
+  def startsWith: Unit = {
+    val l0 = Nil
+    val l1 = 1 :: Nil
+    val a0 = Array[Int]()
+    val a1 = Array[Int](1)
+    assertEquals(l0.startsWith(l0, 0), a0.startsWith(a0, 0))
+    assertEquals(l0.startsWith(l0, 1), a0.startsWith(a0, 1))
+    assertEquals(l0.startsWith(l1, 0), a0.startsWith(a1, 0))
+    assertEquals(l0.startsWith(l1, 1), a0.startsWith(a1, 1))
+  }
+
+  @Test
   def patch(): Unit = {
     val a1 = Array.empty[Int]
     val v1 = a1.toVector


### PR DESCRIPTION
This is consistent with Seqs (both old and new).

Fixes https://github.com/scala/bug/issues/10931