### PR TITLE
Prevent Int overflow in ArrayOps.slice size calculation

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -237,8 +237,8 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     */
   def slice(from: Int, until: Int): Array[A] = {
     val lo = max(from, 0)
-    val hi = min(until, xs.length)
-    val len = hi - lo
+    val hi = min(max(until, 0), xs.length)
+    val len = max(hi - lo, 0)
     if(len > 0) {
       ((xs: Array[_]) match {
         case x: Array[AnyRef]     => java.util.Arrays.copyOfRange(x, lo, hi)

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -81,4 +81,9 @@ class ArrayOpsTest {
     assertEquals(v2.patch(0, a2, 8), a2.patch(0, v2, 8).toSeq)
     assertEquals(v1.patch(-1, a2, 1), a1.patch(-1, v2, 1).toSeq)
   }
+
+  @Test
+  def slice: Unit = {
+    assertArrayEquals(Array[Int](), Array[Int](1).slice(1052471512, -1496048404))
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/10930