### PR TITLE
Default to no fsc

### DIFF
--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -16,8 +16,9 @@ class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
       "-howtorun",
       "how",
       "how to run the specified code",
-      List("object", "script", "jar", "repl", "guess"),
+      List("object", "script", "jar", "repl", "fsc", "guess"),
       "guess")
+    .withPostSetHook { s: ChoiceSetting => if (s.value == "fsc") { _useCompDaemon = true ; s.value = "script" } }
 
   val loadfiles =
     MultiStringSetting(
@@ -45,9 +46,10 @@ class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
 
   val nc = BooleanSetting(
       "-nc",
-      "do not use the fsc compilation daemon") withAbbreviation "-nocompdaemon" withPostSetHook((x: BooleanSetting) => {_useCompDaemon = !x.value })
+      "do not use the fsc compilation daemon and shut it down if it is running").withAbbreviation("-nocompdaemon")
+      //.withDeprecationMessage("scripts use cold compilation by default; use -howtorun:fsc to start the compilation daemon")
+      .withPostSetHook { x: BooleanSetting => _useCompDaemon = !x }
 
-
-  private[this] var _useCompDaemon = true
+  private[this] var _useCompDaemon = false
   def useCompDaemon: Boolean = _useCompDaemon
 }

--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -16,9 +16,8 @@ class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
       "-howtorun",
       "how",
       "how to run the specified code",
-      List("object", "script", "jar", "repl", "fsc", "guess"),
+      List("object", "script", "jar", "repl", "guess"),
       "guess")
-    .withPostSetHook { s: ChoiceSetting => if (s.value == "fsc") { _useCompDaemon = true ; s.value = "script" } }
 
   val loadfiles =
     MultiStringSetting(
@@ -46,10 +45,7 @@ class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
 
   val nc = BooleanSetting(
       "-nc",
-      "do not use the fsc compilation daemon and shut it down if it is running").withAbbreviation("-nocompdaemon")
-      //.withDeprecationMessage("scripts use cold compilation by default; use -howtorun:fsc to start the compilation daemon")
-      .withPostSetHook { x: BooleanSetting => _useCompDaemon = !x }
-
-  private[this] var _useCompDaemon = false
-  def useCompDaemon: Boolean = _useCompDaemon
+      "do not use the legacy fsc compilation daemon").withAbbreviation("-nocompdaemon")
+      .withDeprecationMessage("scripts use cold compilation by default; use -Yscriptrunner for custom behavior")
+      .withPostSetHook { x: BooleanSetting => Yscriptrunner.value = if (x) "default" else "resident" }
 }

--- a/src/compiler/scala/tools/nsc/ObjectRunner.scala
+++ b/src/compiler/scala/tools/nsc/ObjectRunner.scala
@@ -3,12 +3,12 @@
  * @author  Lex Spoon
  */
 
-
 package scala.tools.nsc
 
 import java.net.URL
 import util.Exceptional.rootCause
 import scala.reflect.internal.util.ScalaClassLoader
+import scala.util.control.NonFatal
 
 trait CommonRunner {
   /** Run a given object, specified by name, using a
@@ -18,17 +18,15 @@ trait CommonRunner {
    *  @throws NoSuchMethodException
    *  @throws InvocationTargetException
    */
-  def run(urls: Seq[URL], objectName: String, arguments: Seq[String]): Unit = {
-    (ScalaClassLoader fromURLs urls).run(objectName, arguments)
-  }
+  def run(urls: Seq[URL], objectName: String, arguments: Seq[String]): Unit =
+    ScalaClassLoader.fromURLs(urls).run(objectName, arguments)
 
-  /** Catches exceptions enumerated by run (in the case of InvocationTargetException,
-   *  unwrapping it) and returns it any thrown in Left(x).
+  /** Catches any non-fatal exception thrown by run (in the case of InvocationTargetException,
+   *  unwrapping it) and returns it in an Option.
    */
-  def runAndCatch(urls: Seq[URL], objectName: String, arguments: Seq[String]): Either[Throwable, Boolean] = {
-    try   { run(urls, objectName, arguments) ; Right(true) }
-    catch { case e: Throwable => Left(rootCause(e)) }
-  }
+  def runAndCatch(urls: Seq[URL], objectName: String, arguments: Seq[String]): Option[Throwable] =
+    try   { run(urls, objectName, arguments) ; None }
+    catch { case NonFatal(e) => Some(rootCause(e)) }
 }
 
 /** An object that runs another object specified by name.
@@ -36,4 +34,4 @@ trait CommonRunner {
  *  @author  Lex Spoon
  *  @version 1.1, 2007/7/13
  */
-object ObjectRunner extends CommonRunner { }
+object ObjectRunner extends CommonRunner

--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -216,6 +216,8 @@ abstract class AbstractScriptRunner(settings: GenericRunnerSettings) extends Scr
 }
 
 object ScriptRunner {
+  import scala.reflect.internal.util.ScalaClassLoader
+
   /** Default name to use for the wrapped script */
   val defaultScriptMain = "Main"
 
@@ -226,6 +228,12 @@ object ScriptRunner {
   }
 
   def apply(settings: GenericRunnerSettings): ScriptRunner =
-    if (settings.useCompDaemon) new ResidentScriptRunner(settings)
-    else new DefaultScriptRunner(settings)
+    settings.Yscriptrunner.value match {
+      case "default"  => new DefaultScriptRunner(settings)
+      case "resident" => new ResidentScriptRunner(settings)
+      case "shutdown" => new DaemonKiller(settings)
+      case custom =>
+        val loader = new ClassLoader(getClass.getClassLoader) with ScalaClassLoader
+        loader.create[ScriptRunner](custom, settings.errorFn)(settings)
+    }
 }

--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -74,6 +74,10 @@ class ScriptRunner extends HasCompileSocket {
     }
   }
 
+  private def shutdownDaemon() = {
+    new StandardCompileClient().process(Array("-shutdown"))
+  }
+
   protected def newGlobal(settings: Settings, reporter: Reporter) =
     Global(settings, reporter)
 
@@ -101,6 +105,8 @@ class ScriptRunner extends HasCompileSocket {
       settings.outdir.value = compiledPath.path
 
       if (!settings.useCompDaemon) {
+        if (settings.nc) shutdownDaemon()
+
         /* Setting settings.script.value informs the compiler this is not a
          * self contained compilation unit.
          */

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -224,6 +224,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Yreploutdir     = StringSetting     ("-Yrepl-outdir", "path", "Write repl-generated classfiles to given output directory (use \"\" to generate a temporary dir)" , "")
   @deprecated("Unused setting will be removed", since="2.13")
   val Yreplsync       = new BooleanSetting    ("-Yrepl-sync", "Legacy setting for sbt compatibility, unused.").internalOnly()
+  val Yscriptrunner   = StringSetting     ("-Yscriptrunner", "classname", "Specify a scala.tools.nsc.ScriptRunner (default, resident, shutdown, or a class name).", "default")
   val YdisableFlatCpCaching  = BooleanSetting    ("-YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
   val YcachePluginClassLoader  = CachePolicy.setting("plugin", "compiler plugins")
   val YcacheMacroClassLoader   = CachePolicy.setting("macro", "macros")

--- a/src/compiler/scala/tools/nsc/util/Exceptional.scala
+++ b/src/compiler/scala/tools/nsc/util/Exceptional.scala
@@ -1,8 +1,7 @@
-package scala.tools.nsc
-package util
+package scala.tools.nsc.util
 
 import java.util.concurrent.ExecutionException
-import java.lang.reflect.{ InvocationTargetException, UndeclaredThrowableException }
+import java.lang.reflect.{InvocationTargetException, UndeclaredThrowableException}
 
 object Exceptional {
   def rootCause(x: Throwable): Throwable = x match {
@@ -15,8 +14,4 @@ object Exceptional {
 
     case _ => x
   }
-  // partest still uses the old name.  once we re-in-source partest we
-  // can get rid of this, but in the meantime, we'd rather not branch
-  // partest just because one method got renamed
-  def unwrap(x: Throwable): Throwable = rootCause(x)
 }

--- a/src/partest/scala/tools/partest/package.scala
+++ b/src/partest/scala/tools/partest/package.scala
@@ -35,7 +35,7 @@ package object partest {
     Thread.setDefaultUncaughtExceptionHandler(
       new Thread.UncaughtExceptionHandler {
         def uncaughtException(thread: Thread, t: Throwable): Unit = {
-          val t1 = Exceptional unwrap t
+          val t1 = Exceptional.rootCause(t)
           System.err.println(s"Uncaught exception on thread $thread: $t1")
           t1.printStackTrace()
         }

--- a/src/repl-frontend/scala/tools/nsc/MainGenericRunner.scala
+++ b/src/repl-frontend/scala/tools/nsc/MainGenericRunner.scala
@@ -62,9 +62,9 @@ class MainGenericRunner {
         case AsObject =>
           ObjectRunner.runAndCatch(settings.classpathURLs, thingToRun, command.arguments)
         case AsScript if isE =>
-          Right(ScriptRunner.runCommand(settings, combinedCode, thingToRun +: command.arguments))
+          Right(!ScriptRunner(settings).runScriptText(combinedCode, thingToRun +: command.arguments).isDefined)
         case AsScript =>
-          ScriptRunner.runScriptAndCatch(settings, thingToRun, command.arguments)
+          ScriptRunner(settings).runScript(thingToRun, command.arguments).fold[Either[Throwable, Boolean]](Right(true))(Left(_))
         case AsJar    =>
           JarRunner.runJar(settings, thingToRun, command.arguments)
         case Error =>

--- a/src/repl-frontend/scala/tools/nsc/MainGenericRunner.scala
+++ b/src/repl-frontend/scala/tools/nsc/MainGenericRunner.scala
@@ -8,7 +8,7 @@ package scala.tools.nsc
 import interpreter.shell.{ILoop, ShellConfig}
 
 object JarRunner extends CommonRunner {
-  def runJar(settings: GenericRunnerSettings, jarPath: String, arguments: Seq[String]): Either[Throwable, Boolean] = {
+  def runJar(settings: GenericRunnerSettings, jarPath: String, arguments: Seq[String]): Option[Throwable] = {
     val jar       = new io.Jar(jarPath)
     val mainClass = jar.mainClass getOrElse (throw new IllegalArgumentException(s"Cannot find main class for jar: $jarPath"))
     val jarURLs   = util.ClassPath expandManifestPath jarPath
@@ -29,8 +29,8 @@ object JarRunner extends CommonRunner {
  */
 class MainGenericRunner {
   def errorFn(str: String, e: Option[Throwable] = None, isFailure: Boolean = true): Boolean = {
-    if (str.nonEmpty) Console.err println str
-    e foreach (_.printStackTrace())
+    if (str.nonEmpty) Console.err.println(str)
+    e.foreach(_.printStackTrace())
     !isFailure
   }
 
@@ -58,17 +58,17 @@ class MainGenericRunner {
       }
 
       import GenericRunnerCommand.{AsObject, AsScript, AsJar, Error}
-      def runTarget(): Either[Throwable, Boolean] = howToRun match {
+      def runTarget(): Option[Throwable] = howToRun match {
         case AsObject =>
           ObjectRunner.runAndCatch(settings.classpathURLs, thingToRun, command.arguments)
         case AsScript if isE =>
-          Right(!ScriptRunner(settings).runScriptText(combinedCode, thingToRun +: command.arguments).isDefined)
+          ScriptRunner(settings).runScriptText(combinedCode, thingToRun +: command.arguments)
         case AsScript =>
-          ScriptRunner(settings).runScript(thingToRun, command.arguments).fold[Either[Throwable, Boolean]](Right(true))(Left(_))
+          ScriptRunner(settings).runScript(thingToRun, command.arguments)
         case AsJar    =>
           JarRunner.runJar(settings, thingToRun, command.arguments)
         case Error =>
-          Right(false)
+          None
         case _  =>
           // We start the repl when no arguments are given.
           // If user is agnostic about both -feature and -deprecation, turn them on.
@@ -77,12 +77,13 @@ class MainGenericRunner {
             settings.feature.value = true
           }
           val config = ShellConfig(settings)
-          Right(new ILoop(config).run(settings))
+          new ILoop(config).run(settings)
+          None
       }
 
       runTarget() match {
-        case Left(ex) => errorFn("", Some(ex))  // there must be a useful message of hope to offer here
-        case Right(b) => b
+        case e @ Some(ex) => errorFn("", e)  // there must be a useful message of hope to offer here
+        case _            => true
       }
     }
 

--- a/test/junit/scala/tools/nsc/ScriptRunnerTest.scala
+++ b/test/junit/scala/tools/nsc/ScriptRunnerTest.scala
@@ -10,14 +10,13 @@ class ScriptRunnerTest {
   @Test
   def testEmptyScriptSucceeds: Unit = {
     val s = new GenericRunnerSettings(s => ())
-    s.nc.value = true
     s.usejavacp.value = true
 
-    // scala -nc -e ''
-    assertTrue(ScriptRunner.runCommand(s, "", Nil))
+    // scala -e ''
+    assertTrue(ScriptRunner(s).runScriptText("", Nil).isEmpty)
 
-    // scala -nc -save -e ''
+    // scala -save -e ''
     s.save.value = true
-    assertTrue(ScriptRunner.runCommand(s, "", Nil))
+    assertTrue(ScriptRunner(s).runScriptText("", Nil).isEmpty)
   }
 }


### PR DESCRIPTION
Let the script runner default to not firing up a compilation daemon.

Accept `-howtorun:fsc` to mean use the server.

Take `-nc` to mean shut it down. This is much more convenient than
using `fsc -shutdown`.

Edit: Use `-Yscriptrunner flavor`, where flavor is `default`, `resident`, `shutdown`, or a class name.

For `shutdown` to run, use `scala -Yscriptrunner shutdown -e ""`. Without `-e` or a file, it goes to REPL. An empty filename `""` is not sufficient.