### PR TITLE
fix IsIterableLike example code

### DIFF
--- a/src/library/scala/collection/generic/IsIterableLike.scala
+++ b/src/library/scala/collection/generic/IsIterableLike.scala
@@ -28,12 +28,12 @@ import scala.reflect.ClassTag
  * `String`.
  *
  * {{{
- *    import scala.collection.Iterable
+ *    import scala.collection.{Iterable, IterableOps}
  *    import scala.collection.generic.IsIterableLike
  *
- *    class ExtensionMethods[A, Repr](coll: IterableLike[A, Repr]) {
+ *    class ExtensionMethods[A, Repr](coll: IterableOps[A, Iterable, Repr]) {
  *      def mapReduce[B](mapper: A => B)(reducer: (B, B) => B): B = {
- *        val iter = coll.toIterator
+ *        val iter = coll.iterator
  *        var res = mapper(iter.next())
  *        while (iter.hasNext)
  *          res = reducer(res, mapper(iter.next()))


### PR DESCRIPTION
use `IterableOps` instead of `IterableLike`. `IterableLike` does not exists.

```
Welcome to Scala 2.13.0-M4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_172).
Type in expressions for evaluation. Or try :help.

scala> :paste
// Entering paste mode (ctrl-D to finish)

import scala.collection.Iterable
import scala.collection.generic.IsIterableLike

class ExtensionMethods[A, Repr](coll: IterableLike[A, Repr]) {
  def mapReduce[B](mapper: A => B)(reducer: (B, B) => B): B = {
    val iter = coll.toIterator
    var res = mapper(iter.next())
    while (iter.hasNext)
      res = reducer(res, mapper(iter.next()))
    res
  }
}
// Exiting paste mode, now interpreting.

       class ExtensionMethods[A, Repr](coll: IterableLike[A, Repr]) {
                                             ^
On line 4: error: not found: type IterableLike
```

use `iterator` instead of `toIterator` https://github.com/scala/scala/blob/d94d9bc334de165bcdbefcf29ae05d8542549c4b/src/library/scala/collection/IterableOnce.scala#L80-L81