### PR TITLE
`replace` support in `SeqOps` 

### DIFF
--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -771,6 +771,18 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   def patch[B >: A](from: Int, other: IterableOnce[B], replaced: Int): CC[B] =
     fromIterable(new View.Patched(this, from, other, replaced))
 
+
+  /**
+    * A copy of this $coll with `elem` replaced by `replacement`
+    * @param   elem     the element belonging to the collection that needs to be replaced
+    * @param   replacement the replacing element
+    * @tparam  B        the element type of the returned $coll.
+    * @return a new $coll which is a copy of this $coll with the `elem` replaced by `replacement`.
+    */
+  def replaced[B >: A](elem: B, replacement: B): CC[B] =
+    map(a => if (a == elem) replacement else a)
+
+
   /** A copy of this $coll with one single replaced element.
     *  @param  index  the position of the replacement
     *  @param  elem   the replacing element

--- a/test/junit/scala/collection/SeqTest.scala
+++ b/test/junit/scala/collection/SeqTest.scala
@@ -76,4 +76,15 @@ class SeqTest {
     val s2 = Seq(4, 5, 6)
     assertEquals(s1.concat(s2), s1.union(s2))
   }
+
+  @Test
+  def replaced(): Unit = {
+    //check if the order is maintained in case of Seq
+    assertEquals(Seq(1, 2, 3, 4).replaced(2, -2), Seq(1, -2, 3, 4))
+    assertEquals(Seq(1, 2, 3, 2).replaced(2, -2), Seq(1, -2, 3, -2))
+    assertEquals(Seq("a", "b", "c").replaced("d", "e"), Seq("a", "b", "c"))
+    assertEquals(Seq("a", "b", "c").replaced("a", "e"), Seq("e", "b", "c"))
+    assertEquals(Seq.fill(100)(100).replaced(100, -1), Seq.fill(100)(-1))
+    assertEquals(Seq[Int]().replaced(1, 1), Seq[Int]())
+  }
 }


### PR DESCRIPTION
References: https://github.com/scala/collection-strawman/issues/339