### PR TITLE
Revert SD-301 to improve skip count in test

### DIFF
--- a/test/junit/scala/collection/IndexedSeqTest.scala
+++ b/test/junit/scala/collection/IndexedSeqTest.scala
@@ -1,14 +1,9 @@
 package scala.collection
 
 import org.junit.Test
-import org.junit.Ignore
-import org.junit.Assert.{assertEquals, _}
+import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-
-// with the Ant JUnit runner, it's necessary to @Ignore the abstract
-// classes here, or JUnit tries to instantiate them.  the annotations
-// can be removed when this is merged forward (TODO 2.12.x)
 
 /**
   * base class for testing common methods on a various implementations
@@ -17,7 +12,6 @@ import org.junit.runners.JUnit4
   * @tparam E the element type
   */
 @RunWith(classOf[JUnit4])
-@Ignore
 abstract class IndexedTest[T, E] {
 
   protected def size = 10
@@ -317,7 +311,6 @@ package IndexedTestImpl {
     def toType(n: Int)= if ((n & 0) == 0) null else BoxedUnit.UNIT
   }
 
-  @Ignore
   abstract class ArrayTest[E] (
                                //the object or primitive type of the array
                                val TYPE: Class[_]) extends IndexedTest[Array[E], E]{
@@ -348,8 +341,6 @@ package IndexedTestImpl {
     }
   }
 
-
-  @Ignore
   abstract class ArraySeqTest[E](
                                       //the object or primitive type of the array
                                       val TYPE: Class[_]) extends IndexedTest[mutable.ArraySeq[E], E]  with DataProvider[E]{
@@ -383,7 +374,6 @@ package IndexedTestImpl {
 
   //construct the data using java as much as possible to avoid invalidating the test
 
-  @Ignore
   abstract class MutableIndexedSeqTest[T <: mutable.Seq[E], E] extends IndexedTest[T, E]   with DataProvider[E]{
     override final def length(underTest: T) = underTest.length
 
@@ -413,7 +403,7 @@ package IndexedTestImpl {
     }
 
   }
-  @Ignore
+
   abstract class ImmutableIndexedSeqTest[T <: SeqOps[E, Seq, T], E] extends IndexedTest[T, E]   with DataProvider[E] {
     override final def length(underTest: T) = underTest.length
 
@@ -434,7 +424,7 @@ package IndexedTestImpl {
     }
 
   }
-  @Ignore
+
   abstract class StringOpsBaseTest extends IndexedTest[StringOps, Char] with DataProvider[Char]  {
     override final def length(underTest: StringOps) = underTest.size
 

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -1,11 +1,11 @@
 package scala.collection.immutable
 
-import scala.collection.Iterator
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import org.junit.{Test, Ignore}
+import org.junit.Test
 import org.junit.Assert._
 
+import scala.collection.Iterator
 import scala.ref.WeakReference
 import scala.util.Try
 

--- a/test/junit/scala/tools/nsc/symtab/CannotHaveAttrsTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/CannotHaveAttrsTest.scala
@@ -47,7 +47,7 @@ class CannotHaveAttrsTest {
       assertEquals(t.tpe, NoType)
     }
 
-  @Test @org.junit.Ignore // scala/bug#8816
+  @Test @org.junit.Ignore("scala/bug#8816")
   def nonDefaultPosAssignmentFails = {
     val pos = new OffsetPosition(null, 0)
     attrlessTrees.foreach { t =>
@@ -56,7 +56,7 @@ class CannotHaveAttrsTest {
     }
   }
 
-  @Test @org.junit.Ignore // scala/bug#8816
+  @Test @org.junit.Ignore("scala/bug#8816")
   def nonDefaultTpeAssignmentFails = {
     val tpe = typeOf[Int]
     attrlessTrees.foreach { t =>


### PR DESCRIPTION
Sbt test runner no longer requires Ignore annotation
on abstract classes. This reverts the previous workaround.