### PR TITLE
Add `requiring` function to `Predef`

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -357,6 +357,47 @@ object Predef extends LowPriorityImplicits {
   }
 
   /** @group implicit-classes-any */
+  implicit final class Requiring[A](private val self: A) extends AnyVal {
+    /**
+      * Tests an expression, throwing an `IllegalArgumentException` if false.
+      * This method is similar to `assert`, but blames the caller of the method
+      * for violating the condition.
+      *
+      * @param requirement  the expression to test
+      */
+    def requiring(requirement: Boolean): A = { require(requirement); self }
+
+    /**
+      * Tests an expression, throwing an `IllegalArgumentException` if false.
+      * This method is similar to `assert`, but blames the caller of the method
+      * for violating the condition.
+      *
+      * @param requirement  the expression to test
+      * @param message      a String to include in the failure message
+      */
+    def requiring(requirement: Boolean, message: ⇒ Any): A = { require(requirement, message); self }
+
+    /**
+      * Tests an expression, throwing an `IllegalArgumentException` if false.
+      * This method is similar to `assert`, but blames the caller of the method
+      * for violating the condition.
+      *
+      * @param requirement  the expression to test
+      */
+    def requiring(requirement: A ⇒ Boolean): A = { require(requirement(self)); self }
+
+    /**
+      * Tests an expression, throwing an `IllegalArgumentException` if false.
+      * This method is similar to `assert`, but blames the caller of the method
+      * for violating the condition.
+      *
+      * @param requirement  the expression to test
+      * @param message      a String to include in the failure message
+      */
+    def requiring(requirement: A ⇒ Boolean, message: ⇒ Any): A = { require(requirement(self), message); self }
+  }
+
+  /** @group implicit-classes-any */
   implicit final class StringFormat[A](private val self: A) extends AnyVal {
     /** Returns string formatted according to given `format` string.
      *  Format strings are as for `String.format`

--- a/test/junit/scala/PredefTest.scala
+++ b/test/junit/scala/PredefTest.scala
@@ -1,7 +1,11 @@
 package scala
 
+import org.hamcrest.CoreMatchers._
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert._
 import org.junit.Test
+
+import scala.util.{Failure, Success, Try}
 
 
 class PredefTest {
@@ -20,4 +24,35 @@ class PredefTest {
     assertEquals("bazzz", c)
     assertEquals(5, res)
   }
+
+  @Test
+  def given_requirementIsMet_when_requiring_then_selfIsReturned(): Unit = {
+    val func = () => "val"
+
+    assertThat(func().requiring(true), equalTo("val"))
+    assertThat(func().requiring(true), equalTo("val"))
+    assertThat(func().requiring(true, "testRequiring"), equalTo("val"))
+    assertThat(func().requiring(_ => true), equalTo("val"))
+    assertThat(func().requiring(_ => true, "testRequiring"), equalTo("val"))
+  }
+
+  @Test
+  def given_requirementIsNotMet_when_requiring_then_IllegalArgumentExceptionIsThrown(): Unit = {
+    val func = () => "val"
+
+    assertThrows(classOf[IllegalArgumentException], () => func().requiring(false))
+    assertThrows(classOf[IllegalArgumentException], () => func().requiring(false, "testRequiring"), Some("testRequiring"))
+    assertThrows(classOf[IllegalArgumentException], () => func().requiring(_ => false))
+    assertThrows(classOf[IllegalArgumentException], () => func().requiring(_ => false, "testRequiring"), Some("testRequiring"))
+  }
+
+  private def assertThrows[T <: Throwable](exceptionType: Class[T], f: () => Any, message: Option[String] = None): Unit =
+    Try(f()) match {
+      case Success(_) => fail(s"Expected exception of type $exceptionType")
+      case Failure(e) if exceptionType.isInstance(e) =>
+        if (message.isDefined) {
+          assertThat(e.getMessage, containsString(message.get))
+        }
+      case Failure(e) => fail(s"Expected exception of type $exceptionType, but was ${e.getClass}")
+    }
 }


### PR DESCRIPTION
The new implicit class `Requiring[A]` design is based on `Predef.Ensuring[A]`. The difference is that it is calling `Predef.require` instead of `Predef.assert`, thus throwing `IllegalArgumentException` instead of `AssertionError`.

Akka has implemented such a [helper function](https://github.com/akka/akka/blob/57615f1e8880bdbc9ac173553203f73b66476484/akka-actor/src/main/scala/akka/util/Helpers.scala#L103) internally, but I think it should be part of the Scala library.