### PR TITLE
Add string interpolation to specification.

### DIFF
--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -317,6 +317,7 @@ Literal  ::=  [‘-’] integerLiteral
            |  booleanLiteral
            |  characterLiteral
            |  stringLiteral
+           |  interpolatedString
            |  symbolLiteral
            |  ‘null’
 ```
@@ -498,33 +499,35 @@ of the escape sequences [here](#escape-sequences) are interpreted.
 > [implicit conversion](06-expressions.html#implicit-conversions) from `String` to
 > `StringLike`, the method is applicable to all strings.
 
-#### Processed Strings
+#### Interpolated string
 
 ```ebnf
-processedStringLiteral ::= alphaid ‘"’ {printableChar \ (‘"’ | ‘\$’) | escape} ‘"’ 
+interpolatedString ::= alphaid ‘"’ {printableChar \ (‘"’ | ‘\$’) | escape} ‘"’ 
                          |  alphaid ‘"""’ {[‘"’] [‘"’] char \ (‘"’ | ‘\$’) | escape} {‘"’} ‘"""’
 escape                 ::= ‘\$\$’ 
-                         | ‘\$’ letter { letter | digit } 
+                         | ‘\$’ id
                          | ‘\$’ BlockExpr
 alphaid                ::= upper idrest
                          |  varid
 
 ```
 
-Processed strings consist of an identifier starting with a letter immediately 
+Interpolated string consist of an identifier starting with a letter immediately 
 followed by a string literal. There may be no whitespace characters or comments 
 between the leading identifier and the opening quote ‘”’ of the string. 
-The string literal in a processed string can be standard (single quote) 
+The string literal in a interpolated string can be standard (single quote) 
 or multi-line (triple quote).
 
-Inside a processed literal none of the usual escape characters are interpreted 
+Inside a interpolated string none of the usual escape characters are interpreted 
 (except for unicode escapes) no matter whether the string literal is normal 
 (enclosed in single quotes) or multi-line (enclosed in triple quotes). 
 Instead, there is are two new forms of dollar sign escape. 
 The most general form encloses an expression in \${ and }, i.e. \${expr}. 
-The expression enclosed in the braces that follow the leading $ character is of 
+The expression enclosed in the braces that follow the leading \$ character is of 
 syntactical category BlockExpr. Hence, it can contain multiple statements, 
-and newlines are significant. 
+and newlines are significant. Single ‘\$’-signs are not permitted in isolation 
+in a interpolated string. A single ‘\$’-sign can still be obtained by doubling the `\$’ 
+character: “\$\$”.
 
 The simpler form consists of a ‘\$’-sign followed by an identifier starting with 
 a letter and followed only by letters, digits, and underscore characters, 
@@ -532,28 +535,23 @@ e.g \$id. The simpler form is expanded by putting braces around the identifier,
 e.g \$id is equivalent to \${id}. In the following, unless we explicitly state otherwise, 
 we assume that this expansion has already been performed.
 
-A processed string literal of either of the forms
-```
-id"text0\${ expr1 }text1 … \${ exprn }textn"
-id"""text0\${ expr1 }text1 … \${ exprn }textn"""
-```
-where each texti is a possibly empty string not containing dollar sign escapes, is equivalent to:
-```
-StringContext("""text0""", …, """textn""").id(expr1, …, exprn)
-```
+The expanded expression is type checked normally. Usually, StringContext will resolve to 
+the default implementation in the scala package, 
+but it could also be user-defined. Note that new interpolators can also be added through 
+implicit conversion of the built-in scala.StringContext.
 
 One could write an extension
+```scala
+implicit class StringInterpolation(val sc: StringContext) {
+  def id(args: Any*) = ???
+}
+```
+or
 ````scala
 implicit class StringInterpolation(s: StringContext) = {
     object id {
        def apply(exprs: Any*) = ???
     }
-}
-```
-or
-```scala
-implicit class StringInterpolation(val sc: StringContext) {
-  def id(args: Any*) = ???
 }
 ```
 

--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -526,8 +526,8 @@ The most general form encloses an expression in \${ and }, i.e. \${expr}.
 The expression enclosed in the braces that follow the leading \$ character is of 
 syntactical category BlockExpr. Hence, it can contain multiple statements, 
 and newlines are significant. Single ‘\$’-signs are not permitted in isolation 
-in a interpolated string. A single ‘\$’-sign can still be obtained by doubling the `\$’ 
-character: “\$\$”.
+in a interpolated string. A single ‘\$’-sign can still be obtained by doubling the ‘\$’ 
+character: ‘\$\$’.
 
 The simpler form consists of a ‘\$’-sign followed by an identifier starting with 
 a letter and followed only by letters, digits, and underscore characters, 
@@ -542,16 +542,8 @@ implicit conversion of the built-in scala.StringContext.
 
 One could write an extension
 ```scala
-implicit class StringInterpolation(val sc: StringContext) {
+implicit class StringInterpolation(s: StringContext) {
   def id(args: Any*) = ???
-}
-```
-or
-````scala
-implicit class StringInterpolation(s: StringContext) = {
-    object id {
-       def apply(exprs: Any*) = ???
-    }
 }
 ```
 

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -29,7 +29,6 @@ SimpleExpr   ::=  ‘new’ (ClassTemplate | TemplateBody)
                |  BlockExpr
                |  SimpleExpr1 [‘_’]
 SimpleExpr1  ::=  Literal
-               |  processedStringLiteral
                |  Path
                |  ‘_’
                |  ‘(’ [Exprs] ‘)’

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -29,6 +29,7 @@ SimpleExpr   ::=  ‘new’ (ClassTemplate | TemplateBody)
                |  BlockExpr
                |  SimpleExpr1 [‘_’]
 SimpleExpr1  ::=  Literal
+               |  processedStringLiteral
                |  Path
                |  ‘_’
                |  ‘(’ [Exprs] ‘)’

--- a/spec/08-pattern-matching.md
+++ b/spec/08-pattern-matching.md
@@ -20,6 +20,7 @@ chapter: 8
   SimplePattern   ::=  ‘_’
                     |  varid
                     |  Literal
+                    |  processedStringLiteral
                     |  StableId
                     |  StableId ‘(’ [Patterns] ‘)’
                     |  StableId ‘(’ [Patterns ‘,’] [id ‘@’] ‘_’ ‘*’ ‘)’
@@ -103,6 +104,52 @@ A pattern $p$ _implies_ a type $T$ if the pattern matches only values of the typ
 A _literal pattern_ $L$ matches any value that is equal (in terms of
 `==`) to the literal $L$. The type of $L$ must conform to the
 expected type of the pattern.
+
+### Processed string patterns
+
+```ebnf
+  SimplePattern   ::=  processedStringLiteral
+```
+
+The expansion of processed string literals in patterns is the same as 
+in expressions. If it occurs in a pattern, a processed string literal 
+of either of the forms
+```
+id "text0{ pat1 }text1 … { patn }textn"
+id """text0{ pat1 }text1 … { patn }textn"""
+```
+is equivalent to:
+```
+scala.StringContext("""text0""", …, """textn""").id(pat1, …, patn)
+```
+
+This expansion is well-typed if the member id evaluates to an extractor 
+object. If the extractor object has apply as well as unapply or 
+unapplySeq methods, processed strings can be used as either expressions
+or patterns.
+
+Taking XML as an example
+```scala
+implicit class XMLinterpolation(s: StringContext) = {
+    object xml {
+        def apply(exprs: Any*) =
+            // parse ‘s’ and build an XML tree with ‘exprs’ 
+            //in the holes
+        def unapplySeq(xml: Node): Option[Seq[Node]] =
+          // match `s’ against `xml’ tree and produce 
+          //subtrees in holes
+    }
+}
+```
+Then, XML pattern matching could be expressed like this:
+```scala
+case xml"""
+      <body>
+        <a href = "some link"> \$linktext </a>
+      </body>
+     """ => ...
+```
+where linktext is a variable bound by the pattern.
 
 ### Stable Identifier Patterns
 

--- a/spec/08-pattern-matching.md
+++ b/spec/08-pattern-matching.md
@@ -20,7 +20,6 @@ chapter: 8
   SimplePattern   ::=  ‘_’
                     |  varid
                     |  Literal
-                    |  processedStringLiteral
                     |  StableId
                     |  StableId ‘(’ [Patterns] ‘)’
                     |  StableId ‘(’ [Patterns ‘,’] [id ‘@’] ‘_’ ‘*’ ‘)’
@@ -105,14 +104,14 @@ A _literal pattern_ $L$ matches any value that is equal (in terms of
 `==`) to the literal $L$. The type of $L$ must conform to the
 expected type of the pattern.
 
-### Processed string patterns
+### Interpolated string patterns
 
 ```ebnf
-  SimplePattern   ::=  processedStringLiteral
+  Literal  ::=  interpolatedString
 ```
 
-The expansion of processed string literals in patterns is the same as 
-in expressions. If it occurs in a pattern, a processed string literal 
+The expansion of interpolated string literals in patterns is the same as 
+in expressions. If it occurs in a pattern, a interpolated string literal 
 of either of the forms
 ```
 id "text0{ pat1 }text1 … { patn }textn"
@@ -120,8 +119,10 @@ id """text0{ pat1 }text1 … { patn }textn"""
 ```
 is equivalent to:
 ```
-scala.StringContext("""text0""", …, """textn""").id(pat1, …, patn)
+StringContext("""text0""", …, """textn""").id(pat1, …, patn)
 ```
+You could define your own StringContext to shadow the default one that's 
+in the scala package.
 
 This expansion is well-typed if the member id evaluates to an extractor 
 object. If the extractor object has apply as well as unapply or 

--- a/spec/08-pattern-matching.md
+++ b/spec/08-pattern-matching.md
@@ -114,19 +114,19 @@ The expansion of interpolated string literals in patterns is the same as
 in expressions. If it occurs in a pattern, a interpolated string literal 
 of either of the forms
 ```
-id "text0{ pat1 }text1 … { patn }textn"
-id """text0{ pat1 }text1 … { patn }textn"""
+id"text0{ pat1 }text1 … { patn }textn"
+id"""text0{ pat1 }text1 … { patn }textn"""
 ```
 is equivalent to:
 ```
 StringContext("""text0""", …, """textn""").id(pat1, …, patn)
 ```
-You could define your own StringContext to shadow the default one that's 
-in the scala package.
+You could define your own `StringContext` to shadow the default one that's 
+in the `scala` package.
 
-This expansion is well-typed if the member id evaluates to an extractor 
-object. If the extractor object has apply as well as unapply or 
-unapplySeq methods, processed strings can be used as either expressions
+This expansion is well-typed if the member `id` evaluates to an extractor 
+object. If the extractor object has `apply` as well as `unapply` or 
+`unapplySeq` methods, processed strings can be used as either expressions
 or patterns.
 
 Taking XML as an example

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -66,11 +66,11 @@ stringElement    ::=  charNoDoubleQuoteOrNewline
                  |  charEscapeSeq
 multiLineChars   ::=  {[‘"’] [‘"’] charNoDoubleQuote} {‘"’}
 
-processedStringLiteral 
+interpolatedString 
                  ::= alphaid ‘"’ {printableChar \ (‘"’ | ‘\$’) | escape} ‘"’ 
                  |  alphaid ‘"""’ {[‘"’] [‘"’] char \ (‘"’ | ‘\$’) | escape} {‘"’} ‘"""’
 escape           ::= ‘\$\$’ 
-                 | ‘\$’ letter { letter | digit } 
+                 | ‘\$’ id 
                  | ‘\$’ BlockExpr
 alphaid          ::= upper idrest
                  |  varid
@@ -95,6 +95,7 @@ grammar:
                       |  booleanLiteral
                       |  characterLiteral
                       |  stringLiteral
+                      |  interpolatedString
                       |  symbolLiteral
                       |  ‘null’
 
@@ -158,7 +159,6 @@ grammar:
                       |  BlockExpr
                       |  SimpleExpr1 [‘_’]
   SimpleExpr1       ::=  Literal
-                      |  processedStringLiteral
                       |  Path
                       |  ‘_’
                       |  ‘(’ [Exprs] ‘)’
@@ -199,7 +199,6 @@ grammar:
   SimplePattern     ::=  ‘_’
                       |  varid
                       |  Literal
-                      |  processedStringLiteral
                       |  StableId
                       |  StableId ‘(’ [Patterns] ‘)’
                       |  StableId ‘(’ [Patterns ‘,’] [varid ‘@’] ‘_’ ‘*’ ‘)’

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -66,6 +66,15 @@ stringElement    ::=  charNoDoubleQuoteOrNewline
                  |  charEscapeSeq
 multiLineChars   ::=  {[‘"’] [‘"’] charNoDoubleQuote} {‘"’}
 
+processedStringLiteral 
+                 ::= alphaid ‘"’ {printableChar \ (‘"’ | ‘\$’) | escape} ‘"’ 
+                 |  alphaid ‘"""’ {[‘"’] [‘"’] char \ (‘"’ | ‘\$’) | escape} {‘"’} ‘"""’
+escape           ::= ‘\$\$’ 
+                 | ‘\$’ letter { letter | digit } 
+                 | ‘\$’ BlockExpr
+alphaid          ::= upper idrest
+                 |  varid
+
 symbolLiteral    ::=  ‘'’ plainid
 
 comment          ::=  ‘/*’ “any sequence of characters; nested comments are allowed” ‘*/’
@@ -149,6 +158,7 @@ grammar:
                       |  BlockExpr
                       |  SimpleExpr1 [‘_’]
   SimpleExpr1       ::=  Literal
+                      |  processedStringLiteral
                       |  Path
                       |  ‘_’
                       |  ‘(’ [Exprs] ‘)’
@@ -189,6 +199,7 @@ grammar:
   SimplePattern     ::=  ‘_’
                       |  varid
                       |  Literal
+                      |  processedStringLiteral
                       |  StableId
                       |  StableId ‘(’ [Patterns] ‘)’
                       |  StableId ‘(’ [Patterns ‘,’] [varid ‘@’] ‘_’ ‘*’ ‘)’


### PR DESCRIPTION
>"SethTisue, post:5, topic:1964, full:true"
>Pull requests merging past SIPs into the Scala spec would be exceedingly welcome.

https://contributors.scala-lang.org/t/string-interpolation-in-pattern-matching/1964/5