### PR TITLE
Parenthesize infix type constructors before using them as a prefix.

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -932,7 +932,10 @@ trait Types
     def trimPrefix(str: String) = str stripPrefix objectPrefix stripPrefix packagePrefix
 
     /** The string representation of this type used as a prefix */
-    def prefixString = trimPrefix(toString) + "#"
+    def prefixString = {
+      val pre = trimPrefix(toString)
+      if (isShowAsInfixType) s"($pre)#" else pre + "#"
+    }
 
    /** Convert toString avoiding infinite recursions by cutting off
      *  after `maxToStringRecursions` recursion levels. Uses `safeToString`

--- a/test/files/run/t4700.check
+++ b/test/files/run/t4700.check
@@ -41,4 +41,10 @@ foo: (Int && String) &: Boolean
 scala> def foo: Int && (Boolean &: String) = ???
 foo: Int && (Boolean &: String)
 
+scala> trait ^[A, B] { type T } /* scala/bug#10937 */
+defined trait $up
+
+scala> def x[A, B] : (A ^ B)#T = ???
+x: [A, B]=> (A ^ B)#T
+
 scala> :quit

--- a/test/files/run/t4700.scala
+++ b/test/files/run/t4700.scala
@@ -17,6 +17,8 @@ object Test extends ReplTest {
     |def foo: Int &: Boolean &: String = ???
     |def foo: (Int && String) &: Boolean = ???
     |def foo: Int && (Boolean &: String) = ???
+    |trait ^[A, B] { type T } /* scala/bug#10937 */
+    |def x[A, B] : (A ^ B)#T = ???
     |""".stripMargin
 }
 


### PR DESCRIPTION
Otherwise, `(A ^ B)#T` prints as `A ^ B#T`, which just ain't right.

Fixes scala/bug#10937.