### PR TITLE
Make methods in StringContext private

### DIFF
--- a/test/files/presentation/t8941/src/Source.scala
+++ b/test/files/presentation/t8941/src/Source.scala
@@ -1,7 +1,7 @@
 object Foo {
   implicit class MatCreator(val ctx: StringContext) extends AnyVal {
     def m(args: Any*): Unit = {
-      ctx.checkLengths(args)
+      ctx.s(args: _*)
     }
     ???/*?*/
   }


### PR DESCRIPTION
Scala ships with some funny interpolators

    scala> standardInterpolator"oh ${_*2} hai ${Seq(1,2)}"
    res0: String = oh oh 1 hai  hai 2

    scala> checkLengths"swush ${Seq(0)} gone"

    scala>