### PR TITLE
Add missing BuildFrom and Factory instances.

### DIFF
--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -10,7 +10,6 @@ package scala.collection
 package immutable
 
 import java.io.{ObjectInputStream, ObjectOutputStream}
-import java.lang.IllegalStateException
 
 import scala.collection.generic.{BitOperations, DefaultSerializationProxy}
 import scala.collection.mutable.{Builder, ImmutableBuilder}
@@ -99,13 +98,14 @@ object IntMap {
     def newBuilder(from: Any) = IntMap.newBuilder[AnyRef]
   }
 
+  implicit def iterableFactory[V]: Factory[(Int, V), IntMap[V]] = toFactory(this)
+  implicit def buildFromIntMap[V]: BuildFrom[IntMap[_], (Int, V), IntMap[V]] = toBuildFrom(this)
+
   // scalac generates a `readReplace` method to discard the deserialized state (see https://github.com/scala/bug/issues/10412).
   // This prevents it from serializing it in the first place:
   private[this] def writeObject(out: ObjectOutputStream): Unit = ()
   private[this] def readObject(in: ObjectInputStream): Unit = ()
 }
-
-import IntMap._
 
 // Iterator over a non-empty IntMap.
 private[immutable] abstract class IntMapIterator[V, T](it: IntMap[V]) extends AbstractIterator[T] {

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -95,6 +95,9 @@ object LongMap {
     def newBuilder(from: Any) = LongMap.newBuilder[AnyRef]
   }
 
+  implicit def iterableFactory[V]: Factory[(Long, V), LongMap[V]] = toFactory(this)
+  implicit def buildFromLongMap[V]: BuildFrom[LongMap[_], (Long, V), LongMap[V]] = toBuildFrom(this)
+
   // scalac generates a `readReplace` method to discard the deserialized state (see https://github.com/scala/bug/issues/10412).
   // This prevents it from serializing it in the first place:
   private[this] def writeObject(out: ObjectOutputStream): Unit = ()

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -542,6 +542,9 @@ object AnyRefMap {
     def newBuilder(from: Any) = AnyRefMap.newBuilder[AnyRef, AnyRef]
   }
 
+  implicit def iterableFactory[K <: AnyRef, V]: Factory[(K, V), AnyRefMap[K, V]] = toFactory[K, V](this)
+  implicit def buildFromAnyRefMap[K <: AnyRef, V]: BuildFrom[AnyRefMap[_, _], (K, V), AnyRefMap[K, V]] = toBuildFrom(this)
+
   // scalac generates a `readReplace` method to discard the deserialized state (see https://github.com/scala/bug/issues/10412).
   // This prevents it from serializing it in the first place:
   private[this] def writeObject(out: ObjectOutputStream): Unit = ()

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -626,6 +626,9 @@ object LongMap {
     def newBuilder(from: Any) = LongMap.newBuilder[AnyRef]
   }
 
+  implicit def iterableFactory[V]: Factory[(Long, V), LongMap[V]] = toFactory(this)
+  implicit def buildFromLongMap[V]: BuildFrom[LongMap[_], (Long, V), LongMap[V]] = toBuildFrom(this)
+
   // scalac generates a `readReplace` method to discard the deserialized state (see https://github.com/scala/bug/issues/10412).
   // This prevents it from serializing it in the first place:
   private[this] def writeObject(out: ObjectOutputStream): Unit = ()

--- a/test/junit/scala/collection/BuildFromTest.scala
+++ b/test/junit/scala/collection/BuildFromTest.scala
@@ -1,8 +1,8 @@
 package scala.collection
 
 import org.junit.Test
-import scala.collection.mutable.{ArrayBuffer, Builder, Growable}
 
+import scala.collection.mutable.{ArrayBuffer, Builder, Growable}
 import scala.math.Ordering
 
 class BuildFromTest {
@@ -152,10 +152,18 @@ class BuildFromTest {
   implicitly[BuildFrom[BitSet, Int, BitSet]]
   implicitly[BuildFrom[immutable.BitSet, Int, immutable.BitSet]]
   implicitly[BuildFrom[mutable.BitSet, Int, mutable.BitSet]]
+  implicitly[BuildFrom[immutable.IntMap[_], (Int, String), immutable.IntMap[String]]]
+  implicitly[BuildFrom[mutable.LongMap[_], (Long, String), mutable.LongMap[String]]]
+  implicitly[BuildFrom[immutable.LongMap[_], (Long, String), immutable.LongMap[String]]]
+  implicitly[BuildFrom[mutable.AnyRefMap[_ <: AnyRef, _], (String, String), mutable.AnyRefMap[String, String]]]
 
   // Check that collection companions can implicitly be converted to a `BuildFrom` instance
   Iterable: BuildFrom[_, Int, Iterable[Int]]
   Map: BuildFrom[_, (Int, String), Map[Int, String]]
   SortedSet: BuildFrom[_, Int, SortedSet[Int]]
   SortedMap: BuildFrom[_, (Int, String), SortedMap[Int, String]]
+  immutable.IntMap: BuildFrom[_, (Int, String), immutable.IntMap[String]]
+  immutable.LongMap: BuildFrom[_, (Long, String), immutable.LongMap[String]]
+  mutable.LongMap: BuildFrom[_, (Long, String), mutable.LongMap[String]]
+  mutable.AnyRefMap: BuildFrom[_, (String, String), mutable.AnyRefMap[String, String]]
 }

--- a/test/junit/scala/collection/FactoriesTest.scala
+++ b/test/junit/scala/collection/FactoriesTest.scala
@@ -102,5 +102,9 @@ class FactoriesTest {
   implicitly[Factory[Int, BitSet]]
   implicitly[Factory[Int, mutable.BitSet]]
   implicitly[Factory[Int, immutable.BitSet]]
+  implicitly[Factory[(Int, Boolean), immutable.IntMap[Boolean]]]
+  implicitly[Factory[(Long, Boolean), immutable.LongMap[Boolean]]]
+  implicitly[Factory[(Long, Boolean), mutable.LongMap[Boolean]]]
+  implicitly[Factory[(String, Boolean), mutable.AnyRefMap[String, Boolean]]]
 
 }


### PR DESCRIPTION
Adds instances for IntMap, LongMap and AnyRefMap.

While working on #6674 I noticed that these types were missing implicit `Factory` and `BuildFrom` instances.

(note that they do have implicit *conversions*, which are useful when the companion object is used in a place where a `Factory` or a `BuildFrom` value is expected)