### PR TITLE
Factor out strict implementations of transformation operations.

### DIFF
--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -181,7 +181,9 @@ trait SeqOps[+A, +CC[_], +C] extends Any
 
   // Make `concat` an alias for `appendedAll` so that it benefits from performance
   // overrides of this method
-  @`inline` final override def concat[B >: A](suffix: Iterable[B]): CC[B] = appendedAll(suffix)
+  // TODO https://github.com/scala/bug/issues/10853 Uncomment final
+  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
+  @`inline` /*final*/ override def concat[B >: A](suffix: Iterable[B]): CC[B] = appendedAll(suffix)
 
  /** Produces a new sequence which contains all elements of this $coll and also all elements of
    *  a given sequence. `xs union ys`  is equivalent to `xs ++ ys`.

--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -186,7 +186,7 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
 }
 
 object SortedMapOps {
-  private final val ordMsg = "No implicit Ordering[${K2}] found to build a SortedMap[${K2}, ${V2}]. You may want to upcast to a Map[${K}, ${V}] first by calling `unsorted`."
+  private[collection] final val ordMsg = "No implicit Ordering[${K2}] found to build a SortedMap[${K2}, ${V2}]. You may want to upcast to a Map[${K}, ${V}] first by calling `unsorted`."
 
   /** Specializes `MapWithFilter` for sorted Map collections
     *

--- a/src/library/scala/collection/StrictOptimizedIterableOps.scala
+++ b/src/library/scala/collection/StrictOptimizedIterableOps.scala
@@ -5,9 +5,10 @@ import scala.annotation.unchecked.uncheckedVariance
 import scala.language.higherKinds
 
 /**
-  * Trait that overrides operations to take advantage of strict builders.
+  * Trait that overrides iterable operations to take advantage of strict builders.
   *
   * @tparam A  Elements type
+  * @tparam CC Collection type constructor
   * @tparam C  Collection type
   */
 trait StrictOptimizedIterableOps[+A, +CC[_], +C]
@@ -70,8 +71,17 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   // the view-based implementations, but they turn out to be slightly faster because
   // a couple of indirection levels are removed
 
-  override def map[B](f: A => B): CC[B] = {
-    val b = iterableFactory.newBuilder[B]
+  override def map[B](f: A => B): CC[B] =
+    strictOptimizedMap(iterableFactory.newBuilder, f)
+
+  /**
+    * @param b Builder to use to build the resulting collection
+    * @param f Element transformation function
+    * @tparam B Type of elements of the resulting collection (e.g. `String`)
+    * @tparam C2 Type of the resulting collection (e.g. `List[String]`)
+    * @return The resulting collection
+    */
+  @inline protected[this] final def strictOptimizedMap[B, C2](b: mutable.Builder[B, C2], f: A => B): C2 = {
     val it = iterator
     while (it.hasNext) {
       b += f(it.next())
@@ -79,8 +89,17 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
-  override def flatMap[B](f: A => IterableOnce[B]): CC[B] = {
-    val b = iterableFactory.newBuilder[B]
+  override def flatMap[B](f: A => IterableOnce[B]): CC[B] =
+    strictOptimizedFlatMap(iterableFactory.newBuilder, f)
+
+  /**
+    * @param b Builder to use to build the resulting collection
+    * @param f Element transformation function
+    * @tparam B Type of elements of the resulting collection (e.g. `String`)
+    * @tparam C2 Type of the resulting collection (e.g. `List[String]`)
+    * @return The resulting collection
+    */
+  @inline protected[this] final def strictOptimizedFlatMap[B, C2](b: mutable.Builder[B, C2], f: A => IterableOnce[B]): C2 = {
     val it = iterator
     while (it.hasNext) {
       b ++= f(it.next())
@@ -88,8 +107,35 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
-  override def collect[B](pf: PartialFunction[A, B]): CC[B] = {
-    val b = iterableFactory.newBuilder[B]
+  override def concat[B >: A](suffix: Iterable[B]): CC[B] =
+    strictOptimizedConcat(suffix, iterableFactory.newBuilder[B])
+
+  /**
+    * @param that Elements to concatenate to this collection
+    * @param b Builder to use to build the resulting collection
+    * @tparam B Type of elements of the resulting collections (e.g. `Int`)
+    * @tparam C2 Type of the resulting collection (e.g. `List[Int]`)
+    * @return The resulting collection
+    */
+  @inline protected[this] final def strictOptimizedConcat[B >: A, C2](that: Iterable[B], b: mutable.Builder[B, C2]): C2 = {
+    val it1 = iterator
+    val it2 = that.iterator
+    b ++= it1
+    b ++= it2
+    b.result()
+  }
+
+  override def collect[B](pf: PartialFunction[A, B]): CC[B] =
+    strictOptimizedCollect(iterableFactory.newBuilder, pf)
+
+  /**
+    * @param b Builder to use to build the resulting collection
+    * @param pf Element transformation partial function
+    * @tparam B Type of elements of the resulting collection (e.g. `String`)
+    * @tparam C2 Type of the resulting collection (e.g. `List[String]`)
+    * @return The resulting collection
+    */
+  @inline protected[this] final def strictOptimizedCollect[B, C2](b: mutable.Builder[B, C2], pf: PartialFunction[A, B]): C2 = {
     val it = iterator
     while (it.hasNext) {
       val elem = it.next()
@@ -100,8 +146,17 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
-  override def flatten[B](implicit toIterableOnce: A => IterableOnce[B]): CC[B] = {
-    val b = iterableFactory.newBuilder[B]
+  override def flatten[B](implicit toIterableOnce: A => IterableOnce[B]): CC[B] =
+    strictOptimizedFlatten(iterableFactory.newBuilder)
+
+  /**
+    * @param b Builder to use to build the resulting collection
+    * @param toIterableOnce Evidence that `A` can be seen as an `IterableOnce[B]`
+    * @tparam B Type of elements of the resulting collection (e.g. `Int`)
+    * @tparam C2 Type of the resulting collection (e.g. `List[Int]`)
+    * @return The resulting collection
+    */
+  @inline protected[this] final def strictOptimizedFlatten[B, C2](b: mutable.Builder[B, C2])(implicit toIterableOnce: A => IterableOnce[B]): C2 = {
     val it = iterator
     while (it.hasNext) {
       b ++= toIterableOnce(it.next())
@@ -109,8 +164,17 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
-  override def zip[B](that: Iterable[B]): CC[(A @uncheckedVariance, B)] = {
-    val b = iterableFactory.newBuilder[(A, B)]
+  override def zip[B](that: Iterable[B]): CC[(A @uncheckedVariance, B)] =
+    strictOptimizedZip(that, iterableFactory.newBuilder[(A, B)])
+
+  /**
+    * @param that Collection to zip with this collection
+    * @param b Builder to use to build the resulting collection
+    * @tparam B Type of elements of the second collection (e.g. `String`)
+    * @tparam C2 Type of the resulting collection (e.g. `List[(Int, String)]`)
+    * @return The resulting collection
+    */
+  @inline protected[this] final def strictOptimizedZip[B, C2](that: Iterable[B], b: mutable.Builder[(A, B), C2]): C2 = {
     val it1 = iterator
     val it2 = that.iterator
     while (it1.hasNext && it2.hasNext) {

--- a/src/library/scala/collection/StrictOptimizedMapOps.scala
+++ b/src/library/scala/collection/StrictOptimizedMapOps.scala
@@ -1,0 +1,29 @@
+package scala.collection
+
+import scala.language.higherKinds
+
+/**
+  * Trait that overrides map operations to take advantage of strict builders.
+  *
+  * @tparam K  Type of keys
+  * @tparam V  Type of values
+  * @tparam CC Collection type constructor
+  * @tparam C  Collection type
+  */
+trait StrictOptimizedMapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
+  extends MapOps[K, V, CC, C]
+    with StrictOptimizedIterableOps[(K, V), Iterable, C] {
+
+  override def map[K2, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2] =
+    strictOptimizedMap(mapFactory.newBuilder, f)
+
+  override def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]): CC[K2, V2] =
+    strictOptimizedFlatMap(mapFactory.newBuilder, f)
+
+  override def concat[V2 >: V](suffix: Iterable[(K, V2)]): CC[K, V2] =
+    strictOptimizedConcat(suffix, mapFactory.newBuilder)
+
+  override def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)]): CC[K2, V2] =
+    strictOptimizedCollect(mapFactory.newBuilder, pf)
+
+}

--- a/src/library/scala/collection/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSeqOps.scala
@@ -8,8 +8,8 @@ import scala.language.higherKinds
   */
 trait StrictOptimizedSeqOps [+A, +CC[_], +C]
   extends Any
-    with SeqOps[A, CC, C]
-    with StrictOptimizedIterableOps[A, CC, C] {
+    with StrictOptimizedIterableOps[A, CC, C]
+    with SeqOps[A, CC, C] {
 
   override def distinctBy[B](f: A => B): C = {
     val builder = newSpecificBuilder
@@ -45,12 +45,8 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
     b.result()
   }
 
-  override def appendedAll[B >: A](suffix: Iterable[B]): CC[B] = {
-    val b = iterableFactory.newBuilder[B]
-    b ++= this
-    b ++= suffix
-    b.result()
-  }
+  override def appendedAll[B >: A](suffix: Iterable[B]): CC[B] =
+    strictOptimizedConcat(suffix, iterableFactory.newBuilder)
 
   override def prependedAll[B >: A](prefix: Iterable[B]): CC[B] = {
     val b = iterableFactory.newBuilder[B]

--- a/src/library/scala/collection/StrictOptimizedSetOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSetOps.scala
@@ -1,0 +1,17 @@
+package scala.collection
+
+/**
+  * Trait that overrides set operations to take advantage of strict builders.
+  *
+  * @tparam A  Elements type
+  * @tparam CC Collection type constructor
+  * @tparam C  Collection type
+  */
+trait StrictOptimizedSetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
+  extends SetOps[A, CC, C]
+    with StrictOptimizedIterableOps[A, CC, C] {
+
+  override def concat(that: Iterable[A]): C =
+    strictOptimizedConcat(that, newSpecificBuilder)
+
+}

--- a/src/library/scala/collection/StrictOptimizedSortedMapOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSortedMapOps.scala
@@ -1,0 +1,29 @@
+package scala.collection
+
+import scala.annotation.implicitNotFound
+
+/**
+  * Trait that overrides sorted map operations to take advantage of strict builders.
+  *
+  * @tparam K  Type of keys
+  * @tparam V  Type of values
+  * @tparam CC Collection type constructor
+  * @tparam C  Collection type
+  */
+trait StrictOptimizedSortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
+  extends SortedMapOps[K, V, CC, C]
+    with StrictOptimizedMapOps[K, V, Map, C] {
+
+  override def map[K2, V2](f: ((K, V)) => (K2, V2))(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
+    strictOptimizedMap(sortedMapFactory.newBuilder, f)
+
+  override def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)])(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
+    strictOptimizedFlatMap(sortedMapFactory.newBuilder, f)
+
+  override def concat[V2 >: V](xs: Iterable[(K, V2)]): CC[K, V2] =
+    strictOptimizedConcat(xs, sortedMapFactory.newBuilder)
+
+  override def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
+    strictOptimizedCollect(sortedMapFactory.newBuilder, pf)
+
+}

--- a/src/library/scala/collection/StrictOptimizedSortedSetOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSortedSetOps.scala
@@ -6,48 +6,27 @@ import scala.annotation.implicitNotFound
 import scala.annotation.unchecked.uncheckedVariance
 import scala.language.higherKinds
 
+/**
+  * Trait that overrides sorted set operations to take advantage of strict builders.
+  *
+  * @tparam A  Elements type
+  * @tparam CC Collection type constructor
+  * @tparam C  Collection type
+  */
 trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SortedSetOps[A, CC, C]
-    with StrictOptimizedIterableOps[A, Set, C] {
+    with StrictOptimizedSetOps[A, Set, C] {
 
-  override def map[B](f: A => B)(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] = {
-    val b = sortedIterableFactory.newBuilder[B]
-    val it = iterator
-    while (it.hasNext) {
-      b += f(it.next())
-    }
-    b.result()
-  }
+  override def map[B](f: A => B)(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] =
+    strictOptimizedMap(sortedIterableFactory.newBuilder, f)
 
-  override def flatMap[B](f: A => IterableOnce[B])(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] = {
-    val b = sortedIterableFactory.newBuilder[B]
-    val it = iterator
-    while (it.hasNext) {
-      b ++= f(it.next())
-    }
-    b.result()
-  }
+  override def flatMap[B](f: A => IterableOnce[B])(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] =
+    strictOptimizedFlatMap(sortedIterableFactory.newBuilder, f)
 
-  override def zip[B](that: Iterable[B])(implicit @implicitNotFound(SortedSetOps.zipOrdMsg) ev: Ordering[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] = { // sound bcs of VarianceNot
-    val b = sortedIterableFactory.newBuilder[(A, B)]
-    val it1 = iterator
-    val it2 = that.iterator
-    while (it1.hasNext && it2.hasNext) {
-      b += ((it1.next(), it2.next()))
-    }
-    b.result()
-  }
+  override def zip[B](that: Iterable[B])(implicit @implicitNotFound(SortedSetOps.zipOrdMsg) ev: Ordering[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] =
+    strictOptimizedZip(that, sortedIterableFactory.newBuilder[(A, B)])
 
-  override def collect[B](pf: PartialFunction[A, B])(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] = {
-    val b = sortedIterableFactory.newBuilder[B]
-    val it = iterator
-    while (it.hasNext) {
-      val elem = it.next()
-      if (pf.isDefinedAt(elem)) {
-        b += pf.apply(elem)
-      }
-    }
-    b.result()
-  }
+  override def collect[B](pf: PartialFunction[A, B])(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] =
+    strictOptimizedCollect(sortedIterableFactory.newBuilder, pf)
 
 }

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -22,7 +22,8 @@ sealed abstract class BitSet
     with collection.BitSet
     with SortedSetOps[Int, SortedSet, BitSet]
     with collection.BitSetOps[BitSet]
-    with StrictOptimizedIterableOps[Int, Set, BitSet] {
+    with StrictOptimizedIterableOps[Int, Set, BitSet]
+    with StrictOptimizedSortedSetOps[Int, SortedSet, BitSet] {
 
   def bitSetFactory = BitSet
 
@@ -49,17 +50,17 @@ sealed abstract class BitSet
     */
   protected def updateWord(idx: Int, w: Long): BitSet
 
-  override def map(f: Int => Int): BitSet = super[BitSet].map(f)
+  override def map(f: Int => Int): BitSet = strictOptimizedMap(newSpecificBuilder, f)
   override def map[B](f: Int => B)(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
-    super[SortedSetOps].map(f)
+    super[StrictOptimizedSortedSetOps].map(f)
 
-  override def flatMap(f: Int => IterableOnce[Int]): BitSet = super[BitSet].flatMap(f)
+  override def flatMap(f: Int => IterableOnce[Int]): BitSet = strictOptimizedFlatMap(newSpecificBuilder, f)
   override def flatMap[B](f: Int => IterableOnce[B])(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
-    super[SortedSetOps].flatMap(f)
+    super[StrictOptimizedSortedSetOps].flatMap(f)
 
-  override def collect(pf: PartialFunction[Int, Int]): BitSet = super[BitSet].collect(pf)
+  override def collect(pf: PartialFunction[Int, Int]): BitSet = strictOptimizedCollect(newSpecificBuilder, pf)
   override def collect[B](pf: scala.PartialFunction[Int, B])(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
-    super[SortedSetOps].collect(pf)
+    super[StrictOptimizedSortedSetOps].collect(pf)
 
   // necessary for disambiguation
   override def zip[B](that: scala.Iterable[B])(implicit @implicitNotFound(collection.BitSet.zipOrdMsg) ev: Ordering[(Int, B)]): SortedSet[(Int, B)] =

--- a/src/library/scala/collection/immutable/ChampHashMap.scala
+++ b/src/library/scala/collection/immutable/ChampHashMap.scala
@@ -2,14 +2,13 @@ package scala
 package collection.immutable
 
 import java.io.{ObjectInputStream, ObjectOutputStream}
-
-import collection.{Iterator, MapFactory, StrictOptimizedIterableOps}
-import collection.Hashing.computeHash
-import scala.annotation.unchecked.{uncheckedVariance => uV}
 import java.lang.Integer.bitCount
 import java.lang.System.arraycopy
 
+import scala.annotation.unchecked.{uncheckedVariance => uV}
+import scala.collection.Hashing.computeHash
 import scala.collection.mutable.{Builder, ImmutableBuilder}
+import scala.collection.{Iterator, MapFactory, StrictOptimizedIterableOps, StrictOptimizedMapOps}
 
 /** This class implements immutable maps using a Compressed Hash-Array Mapped Prefix-tree.
   * See paper https://michael.steindorfer.name/publications/oopsla15.pdf for more details.
@@ -26,7 +25,8 @@ import scala.collection.mutable.{Builder, ImmutableBuilder}
 final class ChampHashMap[K, +V] private[immutable] (val rootNode: MapNode[K, V], val cachedJavaKeySetHashCode: Int, val cachedSize: Int)
   extends AbstractMap[K, V]
     with MapOps[K, V, ChampHashMap, ChampHashMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), Iterable /* ChampHashMap */, ChampHashMap[K, V]] {
+    with StrictOptimizedIterableOps[(K, V), Iterable, ChampHashMap[K, V]]
+    with StrictOptimizedMapOps[K, V, ChampHashMap, ChampHashMap[K, V]] {
 
   override def mapFactory: MapFactory[ChampHashMap] = ChampHashMap
 
@@ -162,8 +162,8 @@ private[immutable] sealed abstract class MapNode[K, +V] extends MapNodeSource[K,
 
 private class BitmapIndexedMapNode[K, +V](val dataMap: Int, val nodeMap: Int, val content: Array[Any]) extends MapNode[K, V] {
 
-  import Node._
   import MapNode._
+  import Node._
 
   /*
   assert(checkInvariantContentIsWellTyped())

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -3,7 +3,7 @@ package collection.immutable
 
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
-import collection.{Iterator, MapFactory, StrictOptimizedIterableOps}
+import collection.{Iterator, MapFactory, StrictOptimizedIterableOps, StrictOptimizedMapOps}
 import collection.Hashing.{computeHash, keepBits}
 import scala.annotation.unchecked.{uncheckedVariance => uV}
 import java.lang.{Integer, String, System}
@@ -29,7 +29,8 @@ import scala.collection.mutable.{Builder, ImmutableBuilder}
 sealed abstract class HashMap[K, +V]
   extends AbstractMap[K, V]
     with MapOps[K, V, HashMap, HashMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), Iterable, HashMap[K, V]] {
+    with StrictOptimizedIterableOps[(K, V), Iterable, HashMap[K, V]]
+    with StrictOptimizedMapOps[K, V, HashMap, HashMap[K, V]] {
 
   import HashMap.{bufferSize, liftMerger, Merger, MergeFunction, nullToEmpty}
 

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -43,7 +43,8 @@ import scala.collection.mutable.{Builder, ImmutableBuilder}
 sealed class ListMap[K, +V]
   extends AbstractMap[K, V]
     with MapOps[K, V, ListMap, ListMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), Iterable, ListMap[K, V]] {
+    with StrictOptimizedIterableOps[(K, V), Iterable, ListMap[K, V]]
+    with StrictOptimizedMapOps[K, V, ListMap, ListMap[K, V]] {
 
   override def mapFactory: MapFactory[ListMap] = ListMap
 

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -29,7 +29,8 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   extends AbstractMap[K, V]
     with SortedMap[K, V]
     with SortedMapOps[K, V, TreeMap, TreeMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), Iterable, TreeMap[K, V]] {
+    with StrictOptimizedIterableOps[(K, V), Iterable, TreeMap[K, V]]
+    with StrictOptimizedSortedMapOps[K, V, TreeMap, TreeMap[K, V]] {
 
   def this()(implicit ordering: Ordering[K]) = this(null)(ordering)
 

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -30,7 +30,8 @@ class BitSet(protected[collection] final var elems: Array[Long])
     with collection.BitSet
     with SortedSetOps[Int, SortedSet, BitSet]
     with collection.BitSetOps[BitSet]
-    with StrictOptimizedIterableOps[Int, Set, BitSet] {
+    with StrictOptimizedIterableOps[Int, Set, BitSet]
+    with StrictOptimizedSortedSetOps[Int, SortedSet, BitSet] {
 
   def this(initSize: Int) = this(new Array[Long](math.max((initSize + 63) >> 6, 1)))
 
@@ -141,17 +142,17 @@ class BitSet(protected[collection] final var elems: Array[Long])
 
   def toImmutable: immutable.BitSet = immutable.BitSet.fromBitMask(elems)
 
-  override def map(f: Int => Int): BitSet = super[BitSet].map(f)
+  override def map(f: Int => Int): BitSet = strictOptimizedMap(newSpecificBuilder, f)
   override def map[B](f: Int => B)(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
-    super[SortedSetOps].map(f)
+    super[StrictOptimizedSortedSetOps].map(f)
 
-  override def flatMap(f: Int => IterableOnce[Int]): BitSet = super[BitSet].flatMap(f)
+  override def flatMap(f: Int => IterableOnce[Int]): BitSet = strictOptimizedFlatMap(newSpecificBuilder, f)
   override def flatMap[B](f: Int => IterableOnce[B])(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
-    super[SortedSetOps].flatMap(f)
+    super[StrictOptimizedSortedSetOps].flatMap(f)
 
-  override def collect(pf: PartialFunction[Int, Int]): BitSet = super[BitSet].collect(pf)
+  override def collect(pf: PartialFunction[Int, Int]): BitSet = strictOptimizedCollect(newSpecificBuilder, pf)
   override def collect[B](pf: scala.PartialFunction[Int, B])(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
-    super[SortedSetOps].collect(pf)
+    super[StrictOptimizedSortedSetOps].collect(pf)
 
   // necessary for disambiguation
   override def zip[B](that: scala.Iterable[B])(implicit @implicitNotFound(collection.BitSet.zipOrdMsg) ev: Ordering[(Int, B)]): SortedSet[(Int, B)] =

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -1,8 +1,7 @@
 package scala
 package collection.mutable
 
-import scala.collection.{Iterator, MapFactory, StrictOptimizedIterableOps}
-
+import scala.collection.{Iterator, MapFactory, StrictOptimizedIterableOps, StrictOptimizedMapOps}
 import java.lang.String
 
 /** This class implements mutable maps using a hashtable.
@@ -22,7 +21,8 @@ import java.lang.String
 class HashMap[K, V]
   extends AbstractMap[K, V]
     with MapOps[K, V, HashMap, HashMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), Iterable, HashMap[K, V]] {
+    with StrictOptimizedIterableOps[(K, V), Iterable, HashMap[K, V]]
+    with StrictOptimizedMapOps[K, V, HashMap, HashMap[K, V]] {
 
   override def mapFactory: MapFactory[HashMap] = HashMap
 

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -47,7 +47,8 @@ object LinkedHashMap extends MapFactory[LinkedHashMap] {
 class LinkedHashMap[K, V]
   extends AbstractMap[K, V]
     with MapOps[K, V, LinkedHashMap, LinkedHashMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), Iterable, LinkedHashMap[K, V]] {
+    with StrictOptimizedIterableOps[(K, V), Iterable, LinkedHashMap[K, V]]
+    with StrictOptimizedMapOps[K, V, LinkedHashMap, LinkedHashMap[K, V]] {
 
   override def mapFactory: MapFactory[LinkedHashMap] = LinkedHashMap
 

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -22,7 +22,8 @@ package mutable
  */
 class LinkedHashSet[A]
   extends AbstractSet[A]
-    with SetOps[A, LinkedHashSet, LinkedHashSet[A]] {
+    with SetOps[A, LinkedHashSet, LinkedHashSet[A]]
+    with StrictOptimizedIterableOps[A, LinkedHashSet, LinkedHashSet[A]] {
 
   override def iterableFactory: IterableFactory[LinkedHashSet] = LinkedHashSet
 

--- a/src/library/scala/collection/mutable/ListMap.scala
+++ b/src/library/scala/collection/mutable/ListMap.scala
@@ -28,7 +28,8 @@ import scala.collection.immutable.List
 class ListMap[K, V]
   extends AbstractMap[K, V]
     with MapOps[K, V, ListMap, ListMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), Iterable, ListMap[K, V]] {
+    with StrictOptimizedIterableOps[(K, V), Iterable, ListMap[K, V]]
+    with StrictOptimizedMapOps[K, V, ListMap, ListMap[K, V]] {
 
   override def mapFactory: MapFactory[ListMap] = ListMap
 

--- a/src/library/scala/collection/mutable/TreeMap.scala
+++ b/src/library/scala/collection/mutable/TreeMap.scala
@@ -1,9 +1,8 @@
 package scala
 package collection.mutable
 
-import collection.{Iterator, SortedMapFactory, StrictOptimizedIterableOps}
+import collection.{Iterator, SortedMapFactory, StrictOptimizedIterableOps, StrictOptimizedSortedMapOps}
 import collection.mutable.{RedBlackTree => RB}
-
 import java.lang.String
 
 /**
@@ -23,7 +22,8 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   extends AbstractMap[K, V]
     with SortedMap[K, V]
     with SortedMapOps[K, V, TreeMap, TreeMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), Iterable, TreeMap[K, V]] {
+    with StrictOptimizedIterableOps[(K, V), Iterable, TreeMap[K, V]]
+    with StrictOptimizedSortedMapOps[K, V, TreeMap, TreeMap[K, V]] {
 
   override def sortedMapFactory = TreeMap
 


### PR DESCRIPTION
Factor out common operations of StrictOptimizedIterableOps and StrictOptimizedSortedSetOps.

Add StrictOptimizedMapOps and StrictOptimizedSortedMapOps.

Only operations that were implemented more than once have been factored
out. Some other operations could be factored out, though, so that they could
be reused by custom collection implementations (like, for instance, [here](https://github.com/scala/docs.scala-lang/blob/92e5c4d97dfa231e41d677807ecf899be88a4bd4/_overviews/core/custom-collections.md#final-version-of-rna-strands-class)).

Fixes scala/collection-strawman#325