### PR TITLE
Revert to using ConsoleReporter during spin up

### DIFF
--- a/src/compiler/scala/tools/nsc/Driver.scala
+++ b/src/compiler/scala/tools/nsc/Driver.scala
@@ -1,9 +1,8 @@
 package scala
 package tools.nsc
 
-import scala.tools.nsc.reporters.DisplayReporter
-import Properties.{ versionMsg, residentPromptString }
-import scala.reflect.internal.Reporter
+import Properties.{versionMsg, residentPromptString}
+import scala.tools.nsc.reporters.Reporter
 import scala.reflect.internal.util.FakePos
 
 abstract class Driver {
@@ -40,13 +39,13 @@ abstract class Driver {
 
   def process(args: Array[String]): Boolean = {
     val ss   = new Settings(scalacError)
-    reporter = DisplayReporter(ss)    // for reporting early config errors, before compiler is constructed
+    reporter = Reporter(ss)
     command  = new CompilerCommand(args.toList, ss)
     settings = command.settings
 
     if (processSettingsHook()) {
       val compiler = newCompiler()
-      reporter     = compiler.reporter    // adopt the configured reporter
+      reporter     = compiler.reporter    // adopt the compiler's reporter, which may be custom
       try {
         if (reporter.hasErrors)
           reporter.flush()

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -17,7 +17,7 @@ import util.{ClassPath, returning}
 import reporters.{Reporter => LegacyReporter}
 import scala.reflect.ClassTag
 import scala.reflect.internal.{Reporter => InternalReporter}
-import scala.reflect.internal.util.{BatchSourceFile, FreshNameCreator, NoSourceFile, ScalaClassLoader, ScriptSourceFile, SourceFile, StatisticsStatics}
+import scala.reflect.internal.util.{BatchSourceFile, FreshNameCreator, NoSourceFile, ScriptSourceFile, SourceFile, StatisticsStatics}
 import scala.reflect.internal.pickling.PickleBuffer
 import symtab.{Flags, SymbolTable, SymbolTrackers}
 import symtab.classfile.Pickler
@@ -90,7 +90,7 @@ class Global(var currentSettings: Settings, reporter0: LegacyReporter)
     this(new Settings(err => reporter.error(null, err)), reporter)
 
   def this(settings: Settings) =
-    this(settings, Global.reporter(settings))
+    this(settings, LegacyReporter(settings))
 
   def picklerPhase: Phase = if (currentRun.isDefined) currentRun.picklerPhase else NoPhase
 
@@ -1659,15 +1659,8 @@ class Global(var currentSettings: Settings, reporter0: LegacyReporter)
 object Global {
   def apply(settings: Settings, reporter: LegacyReporter): Global = new Global(settings, reporter)
 
-  def apply(settings: Settings): Global = new Global(settings, reporter(settings))
+  def apply(settings: Settings): Global = new Global(settings, LegacyReporter(settings))
 
-  private def reporter(settings: Settings): LegacyReporter = {
-    //val loader = ScalaClassLoader(getClass.getClassLoader)  // apply does not make delegate
-    val loader = new ClassLoader(getClass.getClassLoader) with ScalaClassLoader
-    val res = loader.create[InternalReporter](settings.reporter.value, settings.errorFn)(settings)
-    if (res.isInstanceOf[LegacyReporter]) res.asInstanceOf[LegacyReporter]
-    else res: LegacyReporter  // adaptable
-  }
   private object InitPhase extends Phase(null) {
     def name = "<init phase>"
     override def keepsTypeParams = false

--- a/src/compiler/scala/tools/nsc/reporters/Reporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/Reporter.scala
@@ -7,7 +7,7 @@ package scala.tools.nsc
 package reporters
 
 import scala.reflect.internal.{ForwardingReporter, Reporter => InternalReporter}
-import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.{Position, ScalaClassLoader}
 
 /** Report information, warnings and errors.
  *
@@ -78,4 +78,15 @@ object Reporter {
         new LimitingReporter(settings, reporter)
       case _ => reporter
     }
+
+  /** The usual way to create the configured reporter.
+   *  Errors are reported through `settings.errorFn` and also by throwing an exception.
+   */
+  def apply(settings: Settings): Reporter = {
+    //val loader = ScalaClassLoader(getClass.getClassLoader)  // apply does not make delegate
+    val loader = new ClassLoader(getClass.getClassLoader) with ScalaClassLoader
+    val res = loader.create[InternalReporter](settings.reporter.value, settings.errorFn)(settings)
+    if (res.isInstanceOf[Reporter]) res.asInstanceOf[Reporter]
+    else res: Reporter  // adaptable
+  }
 }

--- a/test/files/run/nowarn.scala
+++ b/test/files/run/nowarn.scala
@@ -1,0 +1,18 @@
+
+import scala.tools.nsc.{Driver, Global}
+import scala.reflect.internal.util.NoPosition
+
+// ensure that nowarn is respected by the default reporter
+
+class Driven extends Driver {
+  override protected def processSettingsHook(): Boolean = {
+    settings.nowarn.value = true
+    true
+  }
+  protected def newCompiler(): Global = Global(settings, reporter)
+  override protected def doCompile(compiler: Global): Unit = reporter.warning(NoPosition, "I don't do anything.")
+  def run(): Unit = process(Array("file.scala"))
+}
+object Test {
+  def main(args: Array[String]): Unit = new Driven().run()
+}


### PR DESCRIPTION
It was a nice idea to use a minimal reporter until
Global is created, but not all clients (benchmark)
create a fresh reporter with their Global,
choosing to stick with the default provided
by Driver.

Also move reporter creation to `Reporter.apply`.

This is a follow-up to https://github.com/scala/scala/pull/6635#issuecomment-396445209