### PR TITLE
Fix scala/bug#10900: Add Set.diff(IterableOnce)

### DIFF
--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -143,7 +143,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
   /** The implementation class of the set returned by `keySet`.
     */
   protected class KeySet extends AbstractSet[K] with GenKeySet {
-    def diff(that: Set[K]): Set[K] = fromSpecificIterable(view.filterNot(that))
+    def diff(that: IterableOnce[K]): Set[K] = fromSpecificIterable(view.filterNot(that.toSet))
   }
 
   /** A generic trait that is reused by keyset implementations */

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -142,24 +142,25 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   /** Alias for `intersect` */
   @`inline` final def & (that: Set[A]): C = intersect(that)
 
-  /** Computes the difference of this set and another set.
+  /** Creates a new $coll from this $coll by removing all elements of another
+    *  collection.
     *
-    *  @param that the set of elements to exclude.
-    *  @return     a set containing those elements of this
-    *              set that are not also contained in the given set `that`.
+    *  @param that the collection containing the removed elements.
+    *  @return     a new $coll that contains all elements of the current
+    *              $coll except the ones from `that`.
     */
-  def diff(that: Set[A]): C
+  def diff(that: IterableOnce[A]): C
 
   /** Alias for `diff` */
-  @`inline` final def &~ (that: Set[A]): C = this diff that
+  @`inline` final def -- (that: IterableOnce[A]): C = diff(that)
 
-  @deprecated("Use &~ or diff instead of --", "2.13.0")
-  @`inline` final def -- (that: Set[A]): C = diff(that)
+  @deprecated("Use -- or diff instead of &~", "2.13.0")
+  @`inline` final def &~ (that: Set[A]): C = diff(that)
 
   @deprecated("Consider requiring an immutable Set or fall back to Set.diff", "2.13.0")
   def - (elem: A): C = diff(Set(elem))
 
-  @deprecated("Use &- with an explicit collection argument instead of - with varargs", "2.13.0")
+  @deprecated("Use -- with an explicit collection argument instead of - with varargs", "2.13.0")
   def - (elem1: A, elem2: A, elems: A*): C = diff(elems.toSet + elem1 + elem2)
 
   /** Creates a new $coll by adding all elements contained in another collection to this $coll, omitting duplicates.

--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -122,7 +122,7 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
 
   /** The implementation class of the set returned by `keySet` */
   protected class KeySortedSet extends SortedSet[K] with GenKeySet with GenKeySortedSet {
-    def diff(that: Set[K]): SortedSet[K] = fromSpecificIterable(view.filterNot(that))
+    def diff(that: IterableOnce[K]): SortedSet[K] = fromSpecificIterable(view.filterNot(that.toSet))
     def rangeImpl(from: Option[K], until: Option[K]): SortedSet[K] = {
       val map = SortedMapOps.this.rangeImpl(from, until)
       new map.KeySortedSet

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -63,7 +63,7 @@ sealed abstract class HashSet[A]
     case _ => super.intersect(that)
   }
 
-  override def diff(that: collection.Set[A]): HashSet[A] = that match {
+  override def diff(that: IterableOnce[A]): HashSet[A] = that match {
     case that: HashSet[A] =>
       val buffer = new Array[HashSet[A]](bufferSize(this.size))
       nullToEmpty(diff0(that, 0, buffer, 0))

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -52,8 +52,8 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     result
   }
 
-  def diff(that: collection.Set[A]): C =
-    toIterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result + elem)
+  def diff(that: IterableOnce[A]): C =
+    that.foldLeft(coll)(_ - _)
 }
 
 /**

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -68,8 +68,11 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     res
   }
 
-  def diff(that: collection.Set[A]): C =
-    toIterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result += elem)
+  def diff(that: IterableOnce[A]): C = {
+    val result = clone()
+    that.foreach(result -= _)
+    result
+  }
 
   def flatMapInPlace(f: A => IterableOnce[A]): this.type = {
     val toAdd = Set[A]()

--- a/test/junit/scala/collection/immutable/SetTest.scala
+++ b/test/junit/scala/collection/immutable/SetTest.scala
@@ -78,4 +78,23 @@ class SetTest {
     val mapseta = any(mapset)
     assert(mapset eq mapseta)
   }
+
+  @Test
+  def testDiff(): Unit = {
+    val s0 = Set(1, 2, 3).diff(List(1, 2))
+    assertEquals(Set(3), s0)
+
+    val s1 = Set(1, 2, 3).diff(List(1, 2, 3))
+    assertEquals(Set(), s1)
+
+    val s2 = Set(1, 2, 3).diff(List(1, 2, 2, 3, 4))
+    assertEquals(Set(), s2)
+
+    val s3 = Map(1 -> 2, 2 -> 3).keySet.diff(List(1))
+    assertEquals(Set(2), s3)
+
+    val s4 = SortedMap(3 -> 4, 1 -> 2, 2 -> 3).keySet.diff(List(1))
+    assertEquals(2, s4.firstKey)
+    assertEquals(3, s4.lastKey)
+  }
 }

--- a/test/junit/scala/collection/mutable/SetTest.scala
+++ b/test/junit/scala/collection/mutable/SetTest.scala
@@ -51,4 +51,16 @@ class SetTest {
     val fmip = set.flatMapInPlace(_ => empty)
     assert(fmip.size == 0)
   }
+
+  @Test
+  def testDiff(): Unit = {
+    val s0 = Set(1, 2, 3).diff(List(1, 2))
+    assertEquals(Set(3), s0)
+
+    val s1 = Set(1, 2, 3).diff(List(1, 2, 3))
+    assertEquals(Set(), s1)
+
+    val s2 = Set(1, 2, 3).diff(List(1, 2, 2, 3, 4))
+    assertEquals(Set(), s2)
+  }
 }


### PR DESCRIPTION
'--' is now an alias for diff. '&~' is deprecated in favor of '--'.