### PR TITLE
add deprecated DefaultMap in immutable package object

### DIFF
--- a/src/library/scala/collection/immutable/package.scala
+++ b/src/library/scala/collection/immutable/package.scala
@@ -11,4 +11,7 @@ package object immutable {
   type Traversable[+X] = Iterable[X]
   @deprecated("Use Iterable instead of Traversable", "2.13.0")
   val Traversable = Iterable
+
+  @deprecated("Use Map instead of DefaultMap", "2.13.0")
+  type DefaultMap[K, +V] = scala.collection.immutable.Map[K, V]
 }


### PR DESCRIPTION
`scala.collection.immutable.DefaultMap` is not deprecated in Scala 2.12.6. but deleted suddenly since Scala 2.13.0-M4

https://github.com/scala/scala/blob/v2.12.6/src/library/scala/collection/immutable/DefaultMap.scala