### PR TITLE
Don't derive type var constraints from type param bounds

### DIFF
--- a/test/files/neg/typevar_derive_alias.check
+++ b/test/files/neg/typevar_derive_alias.check
@@ -1,0 +1,7 @@
+typevar_derive_alias.scala:14: error: missing parameter type
+  def toSetMap2(ts: Sq[El]): St[El] = ts.toSt.map(x => x) // B occurs contravariantly, so we maximize
+                                                  ^
+typevar_derive_alias.scala:17: error: missing parameter type
+  def toSetMap3(ts: Sq[Alias]): St[Alias] = ts.toSt.map(x => x)
+                                                        ^
+two errors found

--- a/test/files/neg/typevar_derive_alias.scala
+++ b/test/files/neg/typevar_derive_alias.scala
@@ -1,0 +1,18 @@
+// documenting the status quo
+// all toSetMapN should type check, but 2 & 3 do not right now -- all type check in dotty!
+// (Before, the non-type-alias version type checked due to some gross hack -- I removed it so now they both fail)
+class Test {
+  trait St[T] { def map[U](f: T => U): St[U] }
+  trait Sq[+T] { def toSt[B >: T]: St[B] }
+
+  trait El
+  def toSetMap1(ts: Sq[El]): St[El] = {
+    val st = ts.toSt // here we infer B to be El because B occurs invariantly
+    st.map(x => x)
+  }
+
+  def toSetMap2(ts: Sq[El]): St[El] = ts.toSt.map(x => x) // B occurs contravariantly, so we maximize
+
+  type Alias = El
+  def toSetMap3(ts: Sq[Alias]): St[Alias] = ts.toSt.map(x => x)
+}

--- a/test/files/pos/S1.scala
+++ b/test/files/pos/S1.scala
@@ -8,24 +8,6 @@
 **           ^
 */
 class S1() {
-  def foo[T <: this.type](x: T) = x
-  def f = foo[this.type](this)
+    def foo[T <: this.type](x: T) = x;
+    foo[this.type](this);
 }
-
-class S2() {
-  def foo[T <: this.type](x: T) = x
-  def f = foo(this)
-}
-/*
- *
-$ scalac -d /tmp test/files/pos/S1.scala 
-test/files/pos/S1.scala:17: error: inferred type arguments [S2] do not conform to method foo's type parameter bounds [T <: S2.this.type]
-  def f = foo(this)
-          ^
-test/files/pos/S1.scala:17: error: type mismatch;
- found   : S2
- required: T
-  def f = foo(this)
-              ^
-two errors found
- */

--- a/test/files/pos/S1.scala
+++ b/test/files/pos/S1.scala
@@ -8,6 +8,24 @@
 **           ^
 */
 class S1() {
-    def foo[T <: this.type](x: T) = x;
-    foo[this.type](this);
+  def foo[T <: this.type](x: T) = x
+  def f = foo[this.type](this)
 }
+
+class S2() {
+  def foo[T <: this.type](x: T) = x
+  def f = foo(this)
+}
+/*
+ *
+$ scalac -d /tmp test/files/pos/S1.scala
+test/files/pos/S1.scala:17: error: inferred type arguments [S2] do not conform to method foo's type parameter bounds [T <: S2.this.type]
+  def f = foo(this)
+          ^
+test/files/pos/S1.scala:17: error: type mismatch;
+ found   : S2
+ required: T
+  def f = foo(this)
+              ^
+two errors found
+ */

--- a/test/files/run/t10819.scala
+++ b/test/files/run/t10819.scala
@@ -1,0 +1,23 @@
+import scala.tools.partest._
+
+object Test extends StoreReporterDirectTest {
+  override def extraSettings: String = "-usejavacp -Xprint:typer -Ystop-after:typer"
+
+  override def code =
+    """class C {
+      |  def id[T <: AnyVal](x: T): T = x
+      |  id(if (1 == 1) 1 else 2) // should infer id[Int], not id[AnyVal]
+      |}
+      |
+    """.stripMargin
+
+  def show(): Unit = {
+    val baos = new java.io.ByteArrayOutputStream()
+    Console.withOut(baos)(Console.withErr(baos)(compile()))
+    val out = baos.toString("UTF-8")
+
+    val inferredType = out.lines.filter(_.contains("C.this.id[")).map(_.trim).toList
+    assert(inferredType.length == 1)
+    assert(inferredType.forall(_.startsWith("C.this.id[Int]")), inferredType)
+  }
+}


### PR DESCRIPTION
This overly constrains type checking, as reported in #6739 and scala/bug#10819.
