### PR TITLE
Make more ValueSet operations return a ValueSet

### DIFF
--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -268,7 +268,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
   class ValueSet private[ValueSet] (private[this] var nnIds: immutable.BitSet)
     extends immutable.AbstractSet[Value]
       with immutable.SortedSet[Value]
-      with immutable.SetOps[Value, immutable.Set, ValueSet]
+      with immutable.SortedSetOps[Value, immutable.SortedSet, ValueSet]
       with StrictOptimizedIterableOps[Value, immutable.Set, ValueSet]
       with Serializable {
 

--- a/test/files/run/enums.scala
+++ b/test/files/run/enums.scala
@@ -96,7 +96,8 @@ object Test5 {
     println(s2.toBitMask.map(_.toBinaryString).toList)
     println(D1.ValueSet.fromBitMask(s1.toBitMask))
     println(D2.ValueSet.fromBitMask(s2.toBitMask))
-    println(WeekDays.values.range(WeekDays.Tue, WeekDays.Sat))
+    val r: WeekDays.ValueSet = WeekDays.values.range(WeekDays.Tue, WeekDays.Sat)
+    println(r)
   }
 }
 


### PR DESCRIPTION
Previously, ValueSet ended up inheriting SortedSetOps from SortedSet,
meaning that SortedSetOps#C was set to SortedSet[Value] instead of
ValueSet.