### PR TITLE
Add Seq.sortInPlace to mutable collections #471.

### DIFF
--- a/src/library/scala/collection/mutable/Seq.scala
+++ b/src/library/scala/collection/mutable/Seq.scala
@@ -1,6 +1,6 @@
 package scala.collection.mutable
 
-import scala.collection.{IterableOnce, SeqFactory}
+import scala.collection.SeqFactory
 import scala.language.higherKinds
 
 trait Seq[A]
@@ -42,6 +42,45 @@ trait SeqOps[A, +CC[_], +C <: AnyRef]
     */
   @throws[IndexOutOfBoundsException]
   def update(idx: Int, elem: A): Unit
+
+  /** Sorts this $coll in place according to an Ordering.
+    *
+    * @see [[scala.collection.SeqOps.sorted]]
+    *
+    * @param  ord the ordering to be used to compare elements.
+    * @return modified input $coll sorted according to the ordering `ord`.
+    */
+  def sortInPlace[B >: A](implicit ord: Ordering[B]): this.type = {
+    val len = this.length
+    if (len > 1) {
+      val arr = new Array[AnyRef](len)
+      var i = 0
+      for (x <- this) {
+        arr(i) = x.asInstanceOf[AnyRef]
+        i += 1
+      }
+      java.util.Arrays.sort(arr, ord.asInstanceOf[Ordering[Object]])
+      i = 0
+      while (i < arr.length) {
+        update(i, arr(i).asInstanceOf[A])
+        i += 1
+      }
+    }
+    this
+  }
+
+  /** Sorts this $coll in place according to a comparison function.
+    *
+    * @see [[scala.collection.SeqOps.sortWith]]
+    */
+  def sortInPlaceWith(lt: (A, A) => Boolean): this.type = sortInPlace(Ordering.fromLessThan(lt))
+
+  /** Sorts this $coll in place according to the Ordering which results from transforming
+    * an implicitly given Ordering with a transformation function.
+    *
+    * @see [[scala.collection.SeqOps.sortBy]]
+    */
+  def sortInPlaceBy[B](f: A => B)(implicit ord: Ordering[B]): this.type = sortInPlace(ord on f)
 }
 
 trait IndexedOptimizedSeq[A] extends Seq[A] {

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -289,4 +289,12 @@ class ArrayBufferTest {
 
     assertEquals(0, buffer.size)
   }
+
+  @Test
+  def testSortInPlace: Unit = {
+    val buffer = ArrayBuffer(3, 2, 1)
+    buffer.sortInPlace
+
+    assertEquals(ArrayBuffer(1, 2, 3), buffer)
+  }
 }


### PR DESCRIPTION
Added `sortInPlace`, `sortInPlaceWith`, `sortInPlaceBy` for `collection.mutable.Seq`.
Fixes #471.