### PR TITLE
Add `sortInPlace` to `collection.mutable.IndexedSeq`.

### DIFF
--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -159,6 +159,17 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initSize: Int)
     if(l > 0) Array.copy(array, 0, xs, start, l)
     xs
   }
+
+  /** Sorts this $coll in place according to an Ordering.
+    *
+    * @see [[scala.collection.mutable.IndexedSeqOps.sortInPlace]]
+    * @param  ord the ordering to be used to compare elements.
+    * @return modified input $coll sorted according to the ordering `ord`.
+    */
+  override def sortInPlace[B >: A]()(implicit ord: Ordering[B]): this.type = {
+    if (length > 1) scala.util.Sorting.stableSort(array.asInstanceOf[Array[B]])
+    this
+  }
 }
 
 /**

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -76,6 +76,11 @@ abstract class ArraySeq[T]
     case _ =>
       super.equals(other)
   }
+
+  override def sortInPlace[B >: T]()(implicit ord: Ordering[B]): this.type = {
+    if (length > 1) scala.util.Sorting.stableSort(array.asInstanceOf[Array[B]])
+    this
+  }
 }
 
 /** A companion object used to create instances of `ArraySeq`.

--- a/src/library/scala/collection/mutable/IndexedSeq.scala
+++ b/src/library/scala/collection/mutable/IndexedSeq.scala
@@ -15,4 +15,44 @@ object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](ArrayBuffer)
 
 trait IndexedSeqOps[A, +CC[_], +C <: AnyRef]
   extends scala.collection.IndexedSeqOps[A, CC, C]
-  with SeqOps[A, CC, C]
+    with SeqOps[A, CC, C] {
+
+  /** Sorts this $coll in place according to an Ordering.
+    *
+    * @see [[scala.collection.SeqOps.sorted]]
+    * @param  ord the ordering to be used to compare elements.
+    * @return modified input $coll sorted according to the ordering `ord`.
+    */
+  def sortInPlace[B >: A]()(implicit ord: Ordering[B]): this.type = {
+    val len = this.length
+    if (len > 1) {
+      val arr = new Array[AnyRef](len)
+      var i = 0
+      for (x <- this) {
+        arr(i) = x.asInstanceOf[AnyRef]
+        i += 1
+      }
+      java.util.Arrays.sort(arr, ord.asInstanceOf[Ordering[Object]])
+      i = 0
+      while (i < arr.length) {
+        update(i, arr(i).asInstanceOf[A])
+        i += 1
+      }
+    }
+    this
+  }
+
+  /** Sorts this $coll in place according to a comparison function.
+    *
+    * @see [[scala.collection.SeqOps.sortWith]]
+    */
+  def sortInPlaceWith(lt: (A, A) => Boolean): this.type = sortInPlace()(Ordering.fromLessThan(lt))
+
+  /** Sorts this $coll in place according to the Ordering which results from transforming
+    * an implicitly given Ordering with a transformation function.
+    *
+    * @see [[scala.collection.SeqOps.sortBy]]
+    */
+  def sortInPlaceBy[B](f: A => B)(implicit ord: Ordering[B]): this.type = sortInPlace()(ord on f)
+
+}

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -289,4 +289,12 @@ class ArrayBufferTest {
 
     assertEquals(0, buffer.size)
   }
+
+  @Test
+  def testSortInPlace: Unit = {
+    val buffer = ArrayBuffer(3, 2, 1)
+    buffer.sortInPlace()
+
+    assertEquals(ArrayBuffer(1, 2, 3), buffer)
+  }
 }

--- a/test/junit/scala/collection/mutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/mutable/ArraySeqTest.scala
@@ -25,6 +25,20 @@ class ArraySeqTest {
     a.toArray.update(0, 100)
     assertEquals(a, List(1,2,3))
   }
+
+  @Test
+  def testSortInPlaceAnyRef: Unit = {
+    val arr = ArraySeq[Integer](3, 2, 1)
+    arr.sortInPlace()
+    assertEquals(ArraySeq[Integer](1, 2, 3), arr)
+  }
+
+  @Test
+  def testSortInPlaceInt: Unit = {
+    val arr = ArraySeq.make(Array[Int](3, 2, 1))
+    arr.sortInPlace()
+    assertEquals(ArraySeq.make(Array[Int](1, 2, 3)), arr)
+  }
 }
 
 /*

--- a/test/junit/scala/collection/mutable/ArraySortingTest.scala
+++ b/test/junit/scala/collection/mutable/ArraySortingTest.scala
@@ -3,6 +3,7 @@ package scala.collection.mutable
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
+import org.junit.Assert.assertEquals
 
 /* Tests various maps by making sure they all agree on the same answers. */
 @RunWith(classOf[JUnit4])
@@ -25,5 +26,13 @@ class ArraySortingTest {
     scala.util.Sorting.quickSort(cant)(CanOrder)
     assert( test(6) == 1 )
     assert( (test,cant).zipped.forall(_ == _.i) )
+  }
+
+  @Test
+  def testSortInPlace: Unit = {
+    val arr = Array(3, 2, 1)
+    arr.sortInPlace()
+
+    assertEquals(ArraySeq(1, 2, 3), ArraySeq.make(arr))
   }
 }


### PR DESCRIPTION
Add `sortInPlace`, `sortInPlaceWith`, `sortInPlaceBy` to `collection.mutable.Seq`.
Fixes https://github.com/scala/collection-strawman/issues/471.