### PR TITLE
Remove adaptation of 0-arg methods under -Xsource:3.0

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -625,7 +625,7 @@ abstract class BTypes {
         // synchronization required to ensure the apply is finished
         // which populates info. ClassBType doesnt escape apart from via the map
         // and the object mutex is locked prior to insertion. See apply
-        this.synchronized()
+        this.synchronized {}
       assert(_info != null, s"ClassBType.info not yet assigned: $this")
       _info
     }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -98,6 +98,8 @@ trait ScalaSettings extends AbsScalaSettings
   def isScala213: Boolean = source.value >= version213
   private[this] val version214 = ScalaVersion("2.14.0")
   def isScala214: Boolean = source.value >= version214
+  private[this] val version3_0 = ScalaVersion("3.0.0")
+  def isScala3: Boolean = source.value >= version3_0
 
   /**
    * -X "Advanced" settings

--- a/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
@@ -77,7 +77,7 @@ trait Adaptations {
         }
       } else if (settings.warnAdaptedArgs)
         context.warning(t.pos, adaptWarningMessage(
-          s"Adapting argument list by creating a ${args.size}-tuple: this may not be what you want.")
+          s"adapted the argument list to the expected ${args.size}-tuple: add additional parens instead")
         )
 
       // return `true` if the adaptation should be kept

--- a/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
@@ -67,13 +67,14 @@ trait Adaptations {
       }
 
       if (args.isEmpty) {
-        if (settings.future)
-          context.error(t.pos, adaptWarningMessage("Adaptation of argument list by inserting () has been removed.", showAdaptation = false))
+        def msg(what: String): String = s"adaptation of an empty argument list by appending () is $what"
+        if (settings.isScala3)
+          context.error(t.pos, adaptWarningMessage(msg("unsupported"), showAdaptation = false))
         else {
-          val msg = "Adaptation of argument list by inserting () is deprecated: " + (
-          if (isLeakyTarget) "leaky (Object-receiving) target makes this especially dangerous."
-          else "this is unlikely to be what you want.")
-          context.deprecationWarning(t.pos, t.symbol, adaptWarningMessage(msg), "2.11.0")
+          context.deprecationWarning(t.pos, t.symbol, adaptWarningMessage(
+            msg("deprecated") + ": " + (
+              if (isLeakyTarget) "leaky (Object-receiving) target makes this especially dangerous"
+              else "this is unlikely to be what you want")), "2.11.0")
         }
       } else if (settings.warnAdaptedArgs)
         context.warning(t.pos, adaptWarningMessage(
@@ -81,7 +82,7 @@ trait Adaptations {
         )
 
       // return `true` if the adaptation should be kept
-      !(args.isEmpty && settings.future)
+      !(args.isEmpty && settings.isScala3)
     }
   }
 }

--- a/test/files/jvm/future-spec.check
+++ b/test/files/jvm/future-spec.check
@@ -1,1 +1,0 @@
-warning: there was one deprecation warning (since 2.11.0); re-run with -deprecation for details

--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -1,3 +1,5 @@
+/* scalac: -Xsource:3.0 */
+
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.concurrent.duration.Duration.Inf
@@ -39,7 +41,8 @@ class FutureTests extends MinimalScalaTest {
       val ms = new concurrent.TrieMap[Throwable, Unit]
       implicit val ec = scala.concurrent.ExecutionContext.fromExecutor(new java.util.concurrent.ForkJoinPool(), {
         t =>
-        ms += (t -> ())
+        val u = ()
+        ms += (t -> u)
       })
 
       class ThrowableTest(m: String) extends Throwable(m)

--- a/test/files/neg/checksensible.check
+++ b/test/files/neg/checksensible.check
@@ -1,16 +1,16 @@
-checksensible.scala:45: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
+checksensible.scala:45: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
         signature: Any.==(x$1: Any): Boolean
   given arguments: <none>
  after adaptation: Any.==((): Unit)
   () == ()
      ^
-checksensible.scala:48: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
+checksensible.scala:48: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
         signature: Object.!=(x$1: Any): Boolean
   given arguments: <none>
  after adaptation: Object.!=((): Unit)
   scala.runtime.BoxedUnit.UNIT != ()
                                ^
-checksensible.scala:49: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
+checksensible.scala:49: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
         signature: Any.!=(x$1: Any): Boolean
   given arguments: <none>
  after adaptation: Any.!=((): Unit)

--- a/test/files/neg/t4851.check
+++ b/test/files/neg/t4851.check
@@ -10,19 +10,19 @@ S.scala:3: warning: Adaptation of argument list by inserting () is deprecated: l
  after adaptation: new J((): Unit)
   val x2 = new J()
            ^
-S.scala:4: warning: Adapting argument list by creating a 5-tuple: this may not be what you want.
+S.scala:4: warning: adapted the argument list to the expected 5-tuple: add additional parens instead
         signature: J(x: Any): J
   given arguments: 1, 2, 3, 4, 5
  after adaptation: new J((1, 2, 3, 4, 5): (Int, Int, Int, Int, Int))
   val x3 = new J(1, 2, 3, 4, 5)
            ^
-S.scala:6: warning: Adapting argument list by creating a 3-tuple: this may not be what you want.
+S.scala:6: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Some.apply[A](value: A): Some[A]
   given arguments: 1, 2, 3
  after adaptation: Some((1, 2, 3): (Int, Int, Int))
   val y1 = Some(1, 2, 3)
                ^
-S.scala:7: warning: Adapting argument list by creating a 3-tuple: this may not be what you want.
+S.scala:7: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Some(value: A): Some[A]
   given arguments: 1, 2, 3
  after adaptation: new Some((1, 2, 3): (Int, Int, Int))
@@ -40,7 +40,7 @@ S.scala:10: warning: Adaptation of argument list by inserting () is deprecated: 
  after adaptation: new J2((): Unit)
   val z2 = new J2()
            ^
-S.scala:14: warning: Adapting argument list by creating a 3-tuple: this may not be what you want.
+S.scala:14: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Test.anyId(a: Any): Any
   given arguments: 1, 2, 3
  after adaptation: Test.anyId((1, 2, 3): (Int, Int, Int))

--- a/test/files/neg/t4851.check
+++ b/test/files/neg/t4851.check
@@ -1,10 +1,10 @@
-S.scala:2: warning: Adaptation of argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous.
+S.scala:2: warning: adaptation of an empty argument list by appending () is deprecated: leaky (Object-receiving) target makes this especially dangerous
         signature: J(x: Any): J
   given arguments: <none>
  after adaptation: new J((): Unit)
   val x1 = new J
            ^
-S.scala:3: warning: Adaptation of argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous.
+S.scala:3: warning: adaptation of an empty argument list by appending () is deprecated: leaky (Object-receiving) target makes this especially dangerous
         signature: J(x: Any): J
   given arguments: <none>
  after adaptation: new J((): Unit)
@@ -28,13 +28,13 @@ S.scala:7: warning: adapted the argument list to the expected 3-tuple: add addit
  after adaptation: new Some((1, 2, 3): (Int, Int, Int))
   val y2 = new Some(1, 2, 3)
            ^
-S.scala:9: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
+S.scala:9: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
         signature: J2(x: T): J2[T]
   given arguments: <none>
  after adaptation: new J2((): Unit)
   val z1 = new J2
            ^
-S.scala:10: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
+S.scala:10: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
         signature: J2(x: T): J2[T]
   given arguments: <none>
  after adaptation: new J2((): Unit)

--- a/test/files/neg/t8035-deprecated.check
+++ b/test/files/neg/t8035-deprecated.check
@@ -1,16 +1,16 @@
-t8035-deprecated.scala:2: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
+t8035-deprecated.scala:2: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
         signature: SetOps.apply(elem: A): Boolean
   given arguments: <none>
  after adaptation: SetOps((): Unit)
   List(1,2,3).toSet()
                    ^
-t8035-deprecated.scala:5: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
+t8035-deprecated.scala:5: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
         signature: A(x: T): Foo.A[T]
   given arguments: <none>
  after adaptation: new A((): Unit)
   new A
   ^
-t8035-deprecated.scala:9: warning: Adaptation of argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous.
+t8035-deprecated.scala:9: warning: adaptation of an empty argument list by appending () is deprecated: leaky (Object-receiving) target makes this especially dangerous
         signature: Format.format(x$1: Any): String
   given arguments: <none>
  after adaptation: Format.format((): Unit)

--- a/test/files/neg/t8035-removed.check
+++ b/test/files/neg/t8035-removed.check
@@ -1,14 +1,14 @@
-t8035-removed.scala:2: error: Adaptation of argument list by inserting () has been removed.
+t8035-removed.scala:4: error: adaptation of an empty argument list by appending () is unsupported
         signature: SetOps.apply(elem: A): Boolean
   given arguments: <none>
   List(1,2,3).toSet()
                    ^
-t8035-removed.scala:5: error: Adaptation of argument list by inserting () has been removed.
+t8035-removed.scala:7: error: adaptation of an empty argument list by appending () is unsupported
         signature: A(x: T): Foo.A[T]
   given arguments: <none>
   new A
   ^
-t8035-removed.scala:9: error: Adaptation of argument list by inserting () has been removed.
+t8035-removed.scala:11: error: adaptation of an empty argument list by appending () is unsupported
         signature: Format.format(x$1: Any): String
   given arguments: <none>
   sdf.format()

--- a/test/files/neg/t8035-removed.flags
+++ b/test/files/neg/t8035-removed.flags
@@ -1,1 +1,0 @@
--Xfuture

--- a/test/files/neg/t8035-removed.scala
+++ b/test/files/neg/t8035-removed.scala
@@ -1,3 +1,5 @@
+/* scalac:-Xsource:3.0 */
+
 object Foo {
   List(1,2,3).toSet()
 

--- a/test/files/neg/t8417.check
+++ b/test/files/neg/t8417.check
@@ -1,10 +1,10 @@
-t8417.scala:5: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
+t8417.scala:5: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: T.f(x: Any)(y: Any): String
   given arguments: "hello", "world"
  after adaptation: T.f(("hello", "world"): (String, String))
   def g = f("hello", "world")("holy", "moly")
            ^
-t8417.scala:5: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
+t8417.scala:5: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: T.f(x: Any)(y: Any): String
   given arguments: "holy", "moly"
  after adaptation: T.f(("holy", "moly"): (String, String))

--- a/test/files/neg/t8525.check
+++ b/test/files/neg/t8525.check
@@ -1,4 +1,4 @@
-t8525.scala:7: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
+t8525.scala:7: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
  after adaptation: X.f((3, 4): (Int, Int))

--- a/test/files/neg/t8610.check
+++ b/test/files/neg/t8610.check
@@ -1,7 +1,7 @@
 t8610.scala:5: warning: possible missing interpolator: detected interpolated identifier `$name`
   def x = "Hi, $name"   // missing interp
           ^
-t8610.scala:7: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
+t8610.scala:7: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
  after adaptation: X.f((3, 4): (Int, Int))

--- a/test/files/pos/t5413.scala
+++ b/test/files/pos/t5413.scala
@@ -1,9 +1,11 @@
+/* scalac: -Xsource:3.0 */
+
 object Fail {
   def nom (guard : => Boolean) (something : => Unit): Unit = { }
   def main(args: Array[String]): Unit = {
     nom {
       val i = 0
       (i != 3)
-    }()
+    }(())
   }
 }

--- a/test/files/run/macro-range.flags
+++ b/test/files/run/macro-range.flags
@@ -1,1 +1,1 @@
--language:experimental.macros
+-language:experimental.macros -Xsource:3.0

--- a/test/files/run/macro-range/Common_1.scala
+++ b/test/files/run/macro-range/Common_1.scala
@@ -40,7 +40,7 @@ abstract class Utils {
   }
   def makeWhile(lname: TermName, cond: Tree, body: Tree): Tree = {
     val continu = Apply(Ident(lname), Nil)
-    val rhs = If(cond, Block(List(body), continu), Literal(Constant()))
+    val rhs = If(cond, Block(List(body), continu), Literal(Constant(())))
     LabelDef(lname, Nil, rhs)
   }
   def makeBinop(left: Tree, op: String, right: Tree): Tree =

--- a/test/files/run/t576.check
+++ b/test/files/run/t576.check
@@ -1,4 +1,3 @@
-warning: there was one deprecation warning (since 2.11.0); re-run with -deprecation for details
 1
 2
 3

--- a/test/files/run/t576.scala
+++ b/test/files/run/t576.scala
@@ -1,3 +1,5 @@
+/* -Xsource:3.0 */
+
 import scala.language.reflectiveCalls
 
 class A {
@@ -35,7 +37,10 @@ object Test {
 
     assert(x1 == x1)
     assert(x1 != x2)
-    assert(x1 != ())
+
+    // This is a workaround for x1 != (())
+    val unit = ()
+    assert(x1 != unit)
     assert(x2 != x1)
 
     assert(x3 == x3)

--- a/test/files/run/t6863.check
+++ b/test/files/run/t6863.check
@@ -1,13 +1,12 @@
-t6863.scala:38: warning: comparing values of types Unit and Unit using `==' will always yield true
-    assert({ () => x}.apply == ())
+t6863.scala:43: warning: comparing values of types Unit and Unit using `==' will always yield true
+    assert({ () => x}.apply == u)
                             ^
-t6863.scala:42: warning: comparing values of types Unit and Unit using `==' will always yield true
-    assert({ () => x}.apply == ())
+t6863.scala:47: warning: comparing values of types Unit and Unit using `==' will always yield true
+    assert({ () => x}.apply == u)
                             ^
-t6863.scala:46: warning: comparing values of types Unit and Unit using `==' will always yield true
-    assert({ () => x}.apply == ())
+t6863.scala:51: warning: comparing values of types Unit and Unit using `==' will always yield true
+    assert({ () => x}.apply == u)
                             ^
-t6863.scala:59: warning: comparing values of types Unit and Unit using `==' will always yield true
-    assert({ () => x }.apply == ())
+t6863.scala:64: warning: comparing values of types Unit and Unit using `==' will always yield true
+    assert({ () => x }.apply == u)
                              ^
-warning: there were four deprecation warnings (since 2.11.0); re-run with -deprecation for details

--- a/test/files/run/t6863.scala
+++ b/test/files/run/t6863.scala
@@ -1,5 +1,10 @@
+/* scalac: -Xsource:3.0 */
+
 /** Make sure that when a variable is captured its initialization expression is handled properly */
 object Test {
+  // This is a workaround for x == (())
+  val u = ()
+
   def lazyVal() = {
   	// internally lazy vals become vars which are initialized with "_", so they need to be tested just like vars do
   	lazy val x = "42"
@@ -35,15 +40,15 @@ object Test {
   def assign() = {
     var y = 1
     var x = y = 42
-    assert({ () => x}.apply == ())
+    assert({ () => x}.apply == u)
   }
   def valDef() = {
     var x = {val y = 42}
-    assert({ () => x}.apply == ())
+    assert({ () => x}.apply == u)
   }
   def `return`(): String = {
     var x = if (true) return "42" else ()
-    assert({ () => x}.apply == ())
+    assert({ () => x}.apply == u)
     "42"
   }
   def tryFinally() = {
@@ -56,7 +61,7 @@ object Test {
   }
   def `if`() = {
   	var x = if (true) ()
-    assert({ () => x }.apply == ())
+    assert({ () => x }.apply == u)
   }
   def ifElse() = {
     var x = if(true) "42" else "43"

--- a/test/files/run/t6935.check
+++ b/test/files/run/t6935.check
@@ -1,1 +1,0 @@
-warning: there was one deprecation warning (since 2.11.0); re-run with -deprecation for details

--- a/test/files/run/t6935.scala
+++ b/test/files/run/t6935.scala
@@ -1,3 +1,5 @@
+/* scalac: -Xsource:3.0 */
+
 object Test {
 
   def main(args: Array[String]): Unit = {
@@ -8,7 +10,9 @@ object Test {
     out.close()
     val buf = bytes.toByteArray
     val in = new ObjectInputStream(new ByteArrayInputStream(buf))
-    val unit = in.readObject()
-    assert(unit == ())
+    val actual = in.readObject()
+    // This is a workaround for actual == (())
+    val unit = ()
+    assert(actual == unit)
   }
 }

--- a/test/files/run/t8610.check
+++ b/test/files/run/t8610.check
@@ -1,4 +1,4 @@
-t8610.scala:6: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
+t8610.scala:6: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
  after adaptation: X.f((3, 4): (Int, Int))

--- a/test/junit/scala/lang/stringinterpol/StringContextTest.scala
+++ b/test/junit/scala/lang/stringinterpol/StringContextTest.scala
@@ -72,7 +72,7 @@ class StringContextTest {
 
   // verifying that the standard interpolators can be supplanted
   @Test def antiHijack_?() = {
-    object AllYourStringsAreBelongToMe { case class StringContext(args: Any*) { def s(args: Any) = "!!!!" } }
+    object AllYourStringsAreBelongToMe { case class StringContext(args: Any*) { def s(args: Any*) = "!!!!" } }
     import AllYourStringsAreBelongToMe._
     //assertEquals("????", s"????")
     assertEquals("!!!!", s"????") // OK to hijack core interpolator ids


### PR DESCRIPTION
Get thee to a nullary, go. Farewell -Xfuture.

Ref https://github.com/scala/bug/issues/8035