### PR TITLE
Enforce library/reflect restriction to compat1 profile

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -805,6 +805,8 @@ lazy val root: Project = (project in file("."))
       state
     },
 
+    testJDeps := TestJDeps.testJDepsImpl.value,
+
     testAll := {
       val results = ScriptCommands.sequence[(Result[Unit], String)](List(
         (Keys.test in Test in junit).result map (_ -> "junit/test"),
@@ -819,6 +821,7 @@ lazy val root: Project = (project in file("."))
         (Keys.test in Test in osgiTestEclipse).result map (_ -> "osgiTestEclipse/test"),
         (mimaReportBinaryIssues in library).result map (_ -> "library/mimaReportBinaryIssues"),
         (mimaReportBinaryIssues in reflect).result map (_ -> "reflect/mimaReportBinaryIssues"),
+        testJDeps.result map (_ -> "testJDeps"),
         (compile in Compile in bench).map(_ => ()).result map (_ -> "bench/compile"),
         Def.task(()).dependsOn( // Run these in parallel:
           doc in Compile in library,
@@ -938,6 +941,8 @@ lazy val mkBin = taskKey[Seq[File]]("Generate shell script (bash or Windows batc
 lazy val mkQuick = taskKey[File]("Generate a full build, including scripts, in build/quick")
 lazy val mkPack = taskKey[File]("Generate a full build, including scripts, in build/pack")
 lazy val testAll = taskKey[Unit]("Run all test tasks sequentially")
+
+val testJDeps = taskKey[Unit]("Run jdeps to check dependencies")
 
 // Defining these settings is somewhat redundant as we also redefine settings that depend on them.
 // However, IntelliJ's project import works better when these are set correctly.

--- a/project/TestJDeps.scala
+++ b/project/TestJDeps.scala
@@ -1,0 +1,21 @@
+package scala.build
+
+import sbt._, Keys._
+
+object TestJDeps {
+  val testJDepsImpl: Def.Initialize[Task[Unit]] = Def.task {
+    val libraryJar = (packageBin in Compile in LocalProject("library")).value
+    val reflectJar = (packageBin in Compile in LocalProject("reflect")).value
+
+    // jdeps -s -P build/pack/lib/scala-{library,reflect}.jar | grep -v build/pack | perl -pe 's/.*\((.*)\)$/$1/' | sort -u
+    val jdepsOut = Process("jdeps", Seq("-s", "-P", libraryJar.getPath, reflectJar.getPath)).lines
+
+    val profilePart = ".*\\((.*)\\)$".r
+    val profiles = jdepsOut.collect {
+      case profilePart(profile) => profile
+    }.toSet
+
+    if (profiles != Set("compact1"))
+      throw new RuntimeException(jdepsOut.mkString("Detected dependency outside of compact1:\n", "\n", ""))
+  }
+}


### PR DESCRIPTION
Enforcement of scala/scala#6164

Tested manually by reverting the sys.process.javaVmArguments change
07ff7ac357f4a31dad31dc0f65faa26a21d166e4 and then running testJDepsImpl:

    > testJDeps
    [info] Compiling 1 Scala source to /d/scala/build/quick/classes/library...
    [info] Packaging /d/scala/build/pack/lib/scala-library.jar ...
    [info] Packaging /d/scala/build/pack/lib/scala-reflect.jar ...
    [info] Done packaging.
    [info] Done packaging.
    [trace] Stack trace suppressed: run last root/*:testJDeps for the full output.
    [error] (root/*:testJDeps) Detected dependency outside of compact1:
    [error] scala-library.jar -> /Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home/jre/lib/rt.jar (compact3)
    [error] scala-reflect.jar -> /Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home/jre/lib/rt.jar (compact1)
    [error] scala-reflect.jar -> /d/scala/build/pack/lib/scala-library.jar
    [error] Total time: 4 s, completed 14-Jun-2018 14:20:02

Fixes scala/scala-dev#437
Fixes scala/bug#10559