### PR TITLE
[SUPERSEDED] Correct Range.Double.last

### DIFF
--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -181,6 +181,8 @@ sealed class NumericRange[T](
       override def apply(idx: Int): A = fm(underlyingRange(idx))
       override def containsTyped(el: A) = underlyingRange exists (x => fm(x) == el)
 
+      override lazy val last = fm(underlyingRange.last)
+
       override def toString = {
         def simpleOf(x: Any): String = x.getClass.getName.split("\\.").last
         val stepped = simpleOf(underlyingRange.step)


### PR DESCRIPTION
I see now it's just correcting the currently unused `mapRange`.

I won't bother adding a test back in.