### PR TITLE
Avoid complaining about implicit evidence

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -698,10 +698,14 @@ trait TypeDiagnostics {
           val opc = new overridingPairs.Cursor(classOf(m))
           opc.iterator.exists(pair => pair.low == m)
         }
+        import PartialFunction._
         def isConvention(p: Symbol): Boolean = {
-          (p.name.decoded == "args" && p.owner.isMethod && p.owner.name.decoded == "main") ||
-            (p.tpe =:= typeOf[scala.Predef.DummyImplicit])
-        }
+          val ds = currentRun.runDefinitions
+          import ds._ ; (
+            p.name.decoded == "args" && p.owner.isMethod && p.owner.name.decoded == "main"
+          ||
+            p.isImplicit && cond(p.tpe.typeSymbol) { case Predef_=:= | Predef_<:< | Predef_Dummy => true }
+        )}
         def warningIsOnFor(s: Symbol) = if (s.isImplicit) settings.warnUnusedImplicits else settings.warnUnusedExplicits
         def warnable(s: Symbol) = (
           warningIsOnFor(s)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1468,6 +1468,10 @@ trait Definitions extends api.StandardDefinitions {
       lazy val StringContext_raw = getMemberMethod(StringContextClass, nme.raw_)
       lazy val StringContext_apply = getMemberMethod(StringContextModule, nme.apply)
 
+      lazy val Predef_=:= = getMemberClass(PredefModule, nme.=:=)
+      lazy val Predef_<:< = getMemberClass(PredefModule, nme.<:<)
+      lazy val Predef_Dummy = getMemberClass(PredefModule, nme.DummyImplicit)
+
       lazy val ArrowAssocClass = getMemberClass(PredefModule, TypeName("ArrowAssoc")) // scala/bug#5731
       def isArrowAssoc(sym: Symbol) = sym.owner == ArrowAssocClass
 

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -590,6 +590,10 @@ trait StdNames {
     }
 
     val ??? = encode("???")
+    val =:= = encode("=:=")
+    val <:< = encode("<:<")
+
+    val DummyImplicit: NameType    = "DummyImplicit"
 
     val wrapRefArray: NameType     = "wrapRefArray"
     val wrapByteArray: NameType    = "wrapByteArray"

--- a/test/files/neg/warn-unused-params.check
+++ b/test/files/neg/warn-unused-params.check
@@ -13,6 +13,15 @@ case class CaseyAtTheBat(k: Int)(s: String)        // warn
 warn-unused-params.scala:62: warning: parameter value readResolve in method f is never used
   def f(readResolve: Int) = 42           // warn
         ^
+warn-unused-params.scala:77: warning: parameter value dummy in method g is never used
+  def g(dummy: DummyImplicit) = 42
+        ^
+warn-unused-params.scala:82: warning: parameter value ev in method f2 is never used
+  def f2[A, B](ev: A =:= B) = 42
+               ^
+warn-unused-params.scala:83: warning: parameter value ev in method g2 is never used
+  def g2[A, B](ev: A <:< B) = 42
+               ^
 error: No warnings can be incurred under -Xfatal-warnings.
-5 warnings found
+8 warnings found
 one error found

--- a/test/files/neg/warn-unused-params.scala
+++ b/test/files/neg/warn-unused-params.scala
@@ -71,3 +71,14 @@ class Main {
 trait Unimplementation {
   def f(u: Int): Int = ???        // no warn for param in unimplementation
 }
+
+trait DumbStuff {
+  def f(implicit dummy: DummyImplicit) = 42
+  def g(dummy: DummyImplicit) = 42
+}
+trait Proofs {
+  def f[A, B](implicit ev: A =:= B) = 42
+  def g[A, B](implicit ev: A <:< B) = 42
+  def f2[A, B](ev: A =:= B) = 42
+  def g2[A, B](ev: A <:< B) = 42
+}


### PR DESCRIPTION
Besides DummyImplicit, notice `<:<` and `=:=`.