### PR TITLE
Use @implicitNotFound on SortedSet and SortedMap

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1665,7 +1665,7 @@ trait Implicits {
 
       val argTypes1 = if (prefix == NoType) paramTypeRefs else paramTypeRefs.map(t => t.asSeenFrom(prefix, fun.symbol.owner))
       val argTypes2 = fun match {
-        case TypeApply(_, targs) => argTypes1.map(_.instantiateTypeParams(fun.symbol.info.typeParams, targs.map(_.tpe)))
+        case treeInfo.Applied(_, targs, _) => argTypes1.map(_.instantiateTypeParams(fun.symbol.info.typeParams, targs.map(_.tpe)))
         case _ => argTypes1
       }
 

--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -28,6 +28,9 @@ trait BitSet extends SortedSet[Int] with BitSetOps[BitSet] {
 
 @SerialVersionUID(3L)
 object BitSet extends SpecificIterableFactory[Int, BitSet] {
+  private[collection] final val ordMsg = "No implicit Ordering[${B}] found to build a SortedSet[${B}]. You may want to upcast to a Set[Int] first by calling `unsorted`."
+  private[collection] final val zipOrdMsg = "No implicit Ordering[${B}] found to build a SortedSet[(Int, ${B})]. You may want to upcast to a Set[Int] first by calling `unsorted`."
+
   def empty: BitSet = immutable.BitSet.empty
   def newBuilder: Builder[Int, BitSet] = immutable.BitSet.newBuilder
   def fromSpecific(it: IterableOnce[Int]): BitSet = immutable.BitSet.fromSpecific(it)

--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -1,8 +1,8 @@
 package scala
 package collection
 
+import scala.annotation.implicitNotFound
 import scala.collection.immutable.TreeMap
-import scala.collection.mutable.Builder
 import scala.language.higherKinds
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.generic.DefaultSerializationProxy
@@ -144,7 +144,7 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
     *  @return       a new $coll resulting from applying the given function
     *                `f` to each element of this $coll and collecting the results.
     */
-  def map[K2, V2](f: ((K, V)) => (K2, V2))(implicit ordering: Ordering[K2]): CC[K2, V2] =
+  def map[K2, V2](f: ((K, V)) => (K2, V2))(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
     sortedMapFactory.from(new View.Map[(K, V), (K2, V2)](toIterable, f))
 
   /** Builds a new sorted map by applying a function to all elements of this $coll
@@ -154,7 +154,7 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
     *  @return       a new $coll resulting from applying the given collection-valued function
     *                `f` to each element of this $coll and concatenating the results.
     */
-  def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] =
+  def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)])(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
     sortedMapFactory.from(new View.FlatMap(toIterable, f))
 
   /** Builds a new sorted map by applying a partial function to all elements of this $coll
@@ -165,7 +165,7 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
     *                `pf` to each element on which it is defined and collecting the results.
     *                The order of the elements is preserved.
     */
-  def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] =
+  def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
     flatMap { kv =>
       if (pf.isDefinedAt(kv)) new View.Single(pf(kv))
       else View.Empty
@@ -186,6 +186,8 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
 }
 
 object SortedMapOps {
+  private final val ordMsg = "No implicit Ordering[${K2}] found to build a SortedMap[${K2}, ${V2}]. You may want to upcast to a Map[${K}, ${V}] first by calling `unsorted`."
+
   /** Specializes `MapWithFilter` for sorted Map collections
     *
     * @define coll sorted map collection

--- a/src/library/scala/collection/StrictOptimizedSortedSetOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSortedSetOps.scala
@@ -2,6 +2,7 @@ package scala
 package collection
 
 
+import scala.annotation.implicitNotFound
 import scala.annotation.unchecked.uncheckedVariance
 import scala.language.higherKinds
 
@@ -9,7 +10,7 @@ trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[
   extends SortedSetOps[A, CC, C]
     with StrictOptimizedIterableOps[A, Set, C] {
 
-  override def map[B : Ordering](f: A => B): CC[B] = {
+  override def map[B](f: A => B)(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] = {
     val b = sortedIterableFactory.newBuilder[B]
     val it = iterator
     while (it.hasNext) {
@@ -18,7 +19,7 @@ trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[
     b.result()
   }
 
-  override def flatMap[B : Ordering](f: A => IterableOnce[B]): CC[B] = {
+  override def flatMap[B](f: A => IterableOnce[B])(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] = {
     val b = sortedIterableFactory.newBuilder[B]
     val it = iterator
     while (it.hasNext) {
@@ -27,7 +28,7 @@ trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[
     b.result()
   }
 
-  override def zip[B](that: Iterable[B])(implicit ev: Ordering[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] = { // sound bcs of VarianceNot
+  override def zip[B](that: Iterable[B])(implicit @implicitNotFound(SortedSetOps.zipOrdMsg) ev: Ordering[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] = { // sound bcs of VarianceNot
     val b = sortedIterableFactory.newBuilder[(A, B)]
     val it1 = iterator
     val it2 = that.iterator
@@ -37,7 +38,7 @@ trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[
     b.result()
   }
 
-  override def collect[B : Ordering](pf: PartialFunction[A, B]): CC[B] = {
+  override def collect[B](pf: PartialFunction[A, B])(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] = {
     val b = sortedIterableFactory.newBuilder[B]
     val it = iterator
     while (it.hasNext) {

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -6,6 +6,7 @@ import java.io.{ObjectInputStream, ObjectOutputStream}
 
 import BitSetOps.{LogWL, updateArray}
 import mutable.{Builder, GrowableBuilder}
+import scala.annotation.implicitNotFound
 
 
 /** A class for immutable bitsets.
@@ -50,13 +51,20 @@ sealed abstract class BitSet
   protected def updateWord(idx: Int, w: Long): BitSet
 
   override def map(f: Int => Int): BitSet = super[BitSet].map(f)
-  override def map[B : Ordering](f: Int => B): SortedSet[B] = super[SortedSetOps].map(f)
+  override def map[B](f: Int => B)(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
+    super[SortedSetOps].map(f)
 
   override def flatMap(f: Int => IterableOnce[Int]): BitSet = super[BitSet].flatMap(f)
-  override def flatMap[B : Ordering](f: Int => IterableOnce[B]): SortedSet[B] = super[SortedSetOps].flatMap(f)
+  override def flatMap[B](f: Int => IterableOnce[B])(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
+    super[SortedSetOps].flatMap(f)
 
   override def collect(pf: PartialFunction[Int, Int]): BitSet = super[BitSet].collect(pf)
-  override def collect[B: Ordering](pf: scala.PartialFunction[Int, B]): SortedSet[B] = super[SortedSetOps].collect(pf)
+  override def collect[B](pf: scala.PartialFunction[Int, B])(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
+    super[SortedSetOps].collect(pf)
+
+  // necessary for disambiguation
+  override def zip[B](that: scala.Iterable[B])(implicit @implicitNotFound(collection.BitSet.zipOrdMsg) ev: Ordering[(Int, B)]): SortedSet[(Int, B)] =
+    super.zip(that)
 
   override protected[this] def writeReplace(): AnyRef = new BitSet.SerializationProxy(this)
 }

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -6,6 +6,7 @@ import java.io.{ObjectInputStream, ObjectOutputStream}
 
 import scala.collection.immutable.Range
 import BitSetOps.{LogWL, MaxSize}
+import scala.annotation.implicitNotFound
 
 
 /**
@@ -141,13 +142,20 @@ class BitSet(protected[collection] final var elems: Array[Long])
   def toImmutable: immutable.BitSet = immutable.BitSet.fromBitMask(elems)
 
   override def map(f: Int => Int): BitSet = super[BitSet].map(f)
-  override def map[B : Ordering](f: Int => B): SortedSet[B] = super[SortedSetOps].map(f)
+  override def map[B](f: Int => B)(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
+    super[SortedSetOps].map(f)
 
   override def flatMap(f: Int => IterableOnce[Int]): BitSet = super[BitSet].flatMap(f)
-  override def flatMap[B : Ordering](f: Int => IterableOnce[B]): SortedSet[B] = super[SortedSetOps].flatMap(f)
+  override def flatMap[B](f: Int => IterableOnce[B])(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
+    super[SortedSetOps].flatMap(f)
 
   override def collect(pf: PartialFunction[Int, Int]): BitSet = super[BitSet].collect(pf)
-  override def collect[B: Ordering](pf: scala.PartialFunction[Int, B]): SortedSet[B] = super[SortedSetOps].collect(pf)
+  override def collect[B](pf: scala.PartialFunction[Int, B])(implicit @implicitNotFound(collection.BitSet.ordMsg) ev: Ordering[B]): SortedSet[B] =
+    super[SortedSetOps].collect(pf)
+
+  // necessary for disambiguation
+  override def zip[B](that: scala.Iterable[B])(implicit @implicitNotFound(collection.BitSet.zipOrdMsg) ev: Ordering[(Int, B)]): SortedSet[(Int, B)] =
+    super.zip(that)
 
   override protected[this] def writeReplace(): AnyRef = new BitSet.SerializationProxy(this)
 }

--- a/test/files/neg/sortedImplicitNotFound.check
+++ b/test/files/neg/sortedImplicitNotFound.check
@@ -1,0 +1,80 @@
+sortedImplicitNotFound.scala:10: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  ms.map(_ => o)
+        ^
+sortedImplicitNotFound.scala:13: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  ms.flatMap(_ => List(o))
+            ^
+sortedImplicitNotFound.scala:16: error: No implicit Ordering[Object] found to build a SortedSet[(Int, Object)]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  ms.zip(List(o))
+        ^
+sortedImplicitNotFound.scala:19: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  ms.collect{case _ => o}
+            ^
+sortedImplicitNotFound.scala:24: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  is.map(_ => o)
+        ^
+sortedImplicitNotFound.scala:27: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  is.flatMap(_ => List(o))
+            ^
+sortedImplicitNotFound.scala:30: error: No implicit Ordering[Object] found to build a SortedSet[(Int, Object)]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  is.zip(List(o))
+        ^
+sortedImplicitNotFound.scala:33: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  is.collect{case _ => o}
+            ^
+sortedImplicitNotFound.scala:39: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  mb.map(_ => o)
+        ^
+sortedImplicitNotFound.scala:43: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  mb.flatMap(_ => List(o))
+            ^
+sortedImplicitNotFound.scala:47: error: No implicit Ordering[Object] found to build a SortedSet[(Int, Object)]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  mb.zip(List(o))
+        ^
+sortedImplicitNotFound.scala:51: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  mb.collect{case _ => o}
+            ^
+sortedImplicitNotFound.scala:57: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  ib.map(_ => o)
+        ^
+sortedImplicitNotFound.scala:61: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  ib.flatMap(_ => List(o))
+            ^
+sortedImplicitNotFound.scala:65: error: No implicit Ordering[Object] found to build a SortedSet[(Int, Object)]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  ib.zip(List(o))
+        ^
+sortedImplicitNotFound.scala:69: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Int] first by calling `unsorted`.
+  ib.collect{case _ => o}
+            ^
+sortedImplicitNotFound.scala:74: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Value] first by calling `unsorted`.
+  es.map(_ => o)
+        ^
+sortedImplicitNotFound.scala:77: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Value] first by calling `unsorted`.
+  es.flatMap(_ => List(o))
+            ^
+sortedImplicitNotFound.scala:80: error: diverging implicit expansion for type Ordering[(WeekDay.Value, Object)]
+starting with method $conforms in object Predef
+  es.zip(List(o)) // ah well...: diverging implicit expansion for type Ordering[(WeekDay.Value, Object)]
+        ^
+sortedImplicitNotFound.scala:83: error: No implicit Ordering[Object] found to build a SortedSet[Object]. You may want to upcast to a Set[Value] first by calling `unsorted`.
+  es.collect{case _ => o}
+            ^
+sortedImplicitNotFound.scala:88: error: No implicit Ordering[Object] found to build a SortedMap[Object, Object]. You may want to upcast to a Map[Int, Object] first by calling `unsorted`.
+  mm.map(_ => (o, o))
+        ^
+sortedImplicitNotFound.scala:91: error: No implicit Ordering[Object] found to build a SortedMap[Object, Object]. You may want to upcast to a Map[Int, Object] first by calling `unsorted`.
+  mm.flatMap(_ => List((o, o)))
+            ^
+sortedImplicitNotFound.scala:94: error: No implicit Ordering[Object] found to build a SortedMap[Object, Object]. You may want to upcast to a Map[Int, Object] first by calling `unsorted`.
+  mm.collect{case _ => (o, o)}
+            ^
+sortedImplicitNotFound.scala:99: error: No implicit Ordering[Object] found to build a SortedMap[Object, Object]. You may want to upcast to a Map[Int, Object] first by calling `unsorted`.
+  im.map(_ => (o, o))
+        ^
+sortedImplicitNotFound.scala:102: error: No implicit Ordering[Object] found to build a SortedMap[Object, Object]. You may want to upcast to a Map[Int, Object] first by calling `unsorted`.
+  im.flatMap(_ => List((o, o)))
+            ^
+sortedImplicitNotFound.scala:105: error: No implicit Ordering[Object] found to build a SortedMap[Object, Object]. You may want to upcast to a Map[Int, Object] first by calling `unsorted`.
+  im.collect{case _ => (o, o)}
+            ^
+26 errors found

--- a/test/files/neg/sortedImplicitNotFound.scala
+++ b/test/files/neg/sortedImplicitNotFound.scala
@@ -1,0 +1,107 @@
+import collection.{mutable => m, immutable => i}
+
+object WeekDay extends Enumeration { type WeekDay = Value; val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value }
+
+object Test {
+  val o = new Object
+
+  val ms = m.SortedSet(1,2,3)
+  ms.map(_ => "")
+  ms.map(_ => o)
+  ms.unsorted.map(_ => o)
+  ms.flatMap(_ => List(""))
+  ms.flatMap(_ => List(o))
+  ms.unsorted.flatMap(_ => List(o))
+  ms.zip(List(""))
+  ms.zip(List(o))
+  ms.unsorted.zip(List(o))
+  ms.collect{case _ => ""}
+  ms.collect{case _ => o}
+  ms.unsorted.collect{case _ => o}
+
+  val is = i.SortedSet(1,2,3)
+  is.map(_ => "")
+  is.map(_ => o)
+  is.unsorted.map(_ => o)
+  is.flatMap(_ => List(""))
+  is.flatMap(_ => List(o))
+  is.unsorted.flatMap(_ => List(o))
+  is.zip(List(""))
+  is.zip(List(o))
+  is.unsorted.zip(List(o))
+  is.collect{case _ => ""}
+  is.collect{case _ => o}
+  is.unsorted.collect{case _ => o}
+
+  val mb = m.BitSet(1,2,3)
+  mb.map(x => x) : m.BitSet
+  mb.map(_ => "")
+  mb.map(_ => o)
+  mb.unsorted.map(_ => o)
+  mb.flatMap(x => List(x)) : m.BitSet
+  mb.flatMap(_ => List(""))
+  mb.flatMap(_ => List(o))
+  mb.unsorted.flatMap(_ => List(o))
+  mb.zip(List(1)) : m.SortedSet[(Int, Int)]
+  mb.zip(List(""))
+  mb.zip(List(o))
+  mb.unsorted.zip(List(o))
+  mb.collect{case x => x} : m.BitSet
+  mb.collect{case _ => ""}
+  mb.collect{case _ => o}
+  mb.unsorted.collect{case _ => o}
+
+ val ib = i.BitSet(1,2,3)
+  ib.map(x => x) : i.BitSet
+  ib.map(_ => "")
+  ib.map(_ => o)
+  ib.unsorted.map(_ => o)
+  ib.flatMap(x => List(x)) : i.BitSet
+  ib.flatMap(_ => List(""))
+  ib.flatMap(_ => List(o))
+  ib.unsorted.flatMap(_ => List(o))
+  ib.zip(List(1)) : i.SortedSet[(Int, Int)]
+  ib.zip(List(""))
+  ib.zip(List(o))
+  ib.unsorted.zip(List(o))
+  ib.collect{case x => x} : i.BitSet
+  ib.collect{case _ => ""}
+  ib.collect{case _ => o}
+  ib.unsorted.collect{case _ => o}
+
+  val es = WeekDay.values
+  es.map(_ => "")
+  es.map(_ => o)
+  es.unsorted.map(_ => o)
+  es.flatMap(_ => List(""))
+  es.flatMap(_ => List(o))
+  es.unsorted.flatMap(_ => List(o))
+  es.zip(List(""))
+  es.zip(List(o)) // ah well...: diverging implicit expansion for type Ordering[(WeekDay.Value, Object)]
+  es.unsorted.zip(List(o))
+  es.collect{case _ => ""}
+  es.collect{case _ => o}
+  es.unsorted.collect{case _ => o}
+
+  val mm = m.SortedMap(1 -> o)
+  mm.map(_ => ("", o))
+  mm.map(_ => (o, o))
+  mm.unsorted.map(_ => (o, o))
+  mm.flatMap(_ => List(("", o)))
+  mm.flatMap(_ => List((o, o)))
+  mm.unsorted.flatMap(_ => List((o, o)))
+  mm.collect{case _ => ("", o)}
+  mm.collect{case _ => (o, o)}
+  mm.unsorted.collect{case _ => (o, o)}
+
+  val im = i.SortedMap(1 -> o)
+  im.map(_ => ("", o))
+  im.map(_ => (o, o))
+  im.unsorted.map(_ => (o, o))
+  im.flatMap(_ => List(("", o)))
+  im.flatMap(_ => List((o, o)))
+  im.unsorted.flatMap(_ => List((o, o)))
+  im.collect{case _ => ("", o)}
+  im.collect{case _ => (o, o)}
+  im.unsorted.collect{case _ => (o, o)}
+}


### PR DESCRIPTION
Also adds a few overrides to avoid ambiguous references.

Fixes https://github.com/scala/collection-strawman/issues/432