### PR TITLE
Increase the counter while looking for the ScalaSignature annotation

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -1211,15 +1211,18 @@ abstract class ClassfileParser {
       val numAnnots = u2
       var i = 0
       var bytes: Array[Byte] = null
-      while (i < numAnnots && bytes == null) pool.getType(u2) match {
-        case SigTpe =>
-          checkScalaSigAnnotArg()
-          bytes = parseScalaSigBytes()
-        case LongSigTpe =>
-          checkScalaSigAnnotArg()
-          bytes = parseScalaLongSigBytes()
-        case _ =>
-          skipAnnotArgs()
+      while (i < numAnnots && bytes == null) {
+        pool.getType(u2) match {
+          case SigTpe =>
+            checkScalaSigAnnotArg()
+            bytes = parseScalaSigBytes()
+          case LongSigTpe =>
+            checkScalaSigAnnotArg()
+            bytes = parseScalaLongSigBytes()
+          case t =>
+            skipAnnotArgs()
+        }
+        i += 1
       }
 
       AnyRefClass // Force scala.AnyRef, otherwise we get "error: Symbol AnyRef is missing from the classpath"


### PR DESCRIPTION
Scala classfiles have a `Scala` classfile attribute as a marker. The
pickle is stored in the `ScalaSignature` RuntimeVisibleAnnotation.

After seeing the marker attribute, we traverse the annotations until
finding the signature. But in case the classfile doesn't actually have
the signature annotation, the loop would overflow.