### PR TITLE
Several entries with the same key in mutable.HashMap

### DIFF
--- a/test/junit/scala/collection/mutable/HashMapTest.scala
+++ b/test/junit/scala/collection/mutable/HashMapTest.scala
@@ -35,4 +35,17 @@ class HashMapTest {
     hm.put(0, 0)
     hm.getOrElseUpdate(0, throw new AssertionError())
   }
+
+  @Test
+  def getOrElseUpdate_keyIdempotence_t10703(): Unit = {
+    val map = mutable.HashMap[String, String]()
+
+    val key = "key"
+    map.getOrElseUpdate(key, {
+      map.getOrElseUpdate(key, "value1")
+      "value2"
+    })
+
+    assertEquals(List((key, "value2")), map.toList)
+  }
 }


### PR DESCRIPTION
- Add HashMap test to check scala/collection-strawman#382 /
  scala/bug#10703
 - Clean code.
 - Repeat search of key after evaluating default value.
 - Fix code style.

Cherry pick of 0c30c04a6920f7f7daa08df8ee22349f12686906

Fixes scala/bug#10703 in 2.12.x (the fix is already in 2.13.x)