### PR TITLE
[SUPERSEDED] CompileServer doesn't want to inherit I/O

### DIFF
--- a/src/compiler/scala/tools/nsc/CompileSocket.scala
+++ b/src/compiler/scala/tools/nsc/CompileSocket.scala
@@ -84,7 +84,7 @@ class CompileSocket extends CompileOutputCommon {
     val cmd = serverCommand((vmArgs split " ").toSeq)
     info(s"[Executing command: ${cmd.mkString(" ")}]")
 
-    new java.lang.ProcessBuilder(cmd.toArray: _*).inheritIO().start()
+    new java.lang.ProcessBuilder(cmd.toArray: _*).start()
   }
 
   /** The port identification file */


### PR DESCRIPTION
The changes so ScriptRunner doesn't use the
CompileServer by default resulted in redirected
I/O hanging, for example: `fsc | more` would
not terminate after displaying output. This
was noticed by the smoke test, which greps
output.

When the fsc CompileClient is run, it will
spawn a CompileServer process. A previous
change to start the process with `inheritIO`
means the pipe client waits on output from
the child server process.

The CompileServer redirects its output to
log files using bear knives, so this commit
just removes the `inheritIO` configuration.
During a client session, output is sent to
the client via socket.

Fixes scala/scala-dev#524