### PR TITLE
optimise equals for IndexedSeq - 2.13 only [ci: last-only]

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -113,6 +113,10 @@ object ArrayOps {
       pos += 1
       r
     } catch { case _: ArrayIndexOutOfBoundsException => Iterator.empty.next() }
+    override def drop(n: Int): Iterator[A] = {
+      if (n > 0) pos = Math.min(xs.length, pos + n)
+      this
+    }
   }
 
   private final class ReverseIterator[@specialized(AnyRef, Int, Double, Long, Float, Char, Byte, Short, Boolean, Unit) A](xs: Array[A]) extends AbstractIterator[A] {
@@ -123,6 +127,11 @@ object ArrayOps {
       pos -= 1
       r
     } catch { case _: ArrayIndexOutOfBoundsException => Iterator.empty.next() }
+
+    override def drop(n: Int): Iterator[A] = {
+      if (n > 0) pos = Math.max( -1, pos - n)
+      this
+    }
   }
 
   private class GroupedIterator[A](xs: Array[A], groupSize: Int) extends AbstractIterator[Array[A]] {

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -30,7 +30,7 @@ trait Seq[+A]
 
   override def equals(o: scala.Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (
     o match {
-      case it: Seq[A] => (it canEqual this) && sameElements(it)
+      case it: Seq[A] => (it eq this) || (it canEqual this) && sameElements(it)
       case _ => false
     }
   )

--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -146,12 +146,7 @@ sealed abstract class ArraySeq[+A]
 
   override protected[this] def writeReplace(): AnyRef = this
 
-  override def equals(other: Any): Boolean = other match {
-    case that: ArraySeq[_] if this.unsafeArray.length != that.unsafeArray.length =>
-      false
-    case _ =>
-      super.equals(other)
-  }
+  override protected final def applyPreferredMaxLength: Int = Int.MaxValue
 }
 
 /**

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -209,6 +209,8 @@ sealed class NumericRange[T](
   }
 
   override lazy val hashCode: Int = super.hashCode()
+  override protected final def applyPreferredMaxLength: Int = Int.MaxValue
+
   override def equals(other: Any): Boolean = other match {
     case x: NumericRange[_] =>
       (x canEqual this) && (length == x.length) && (

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -383,6 +383,7 @@ sealed abstract class Range(
         }
       }
     }
+  override protected final def applyPreferredMaxLength: Int = Int.MaxValue
 
   final override def equals(other: Any) = other match {
     case x: Range =>
@@ -567,5 +568,18 @@ private class RangeIterator(
     _hasNext = value != lastElement
     _next = value + step
     value
+  }
+
+  override def drop(n: Int): Iterator[Int] = {
+    val longPos = _next.toLong + step * n
+    if (step > 0) {
+      _next = Math.min(lastElement, longPos).toInt
+      _hasNext = longPos <= lastElement
+    }
+    else if (step < 0) {
+      _next = Math.max(lastElement, longPos).toInt
+      _hasNext = longPos >= lastElement
+    }
+    this
   }
 }

--- a/src/library/scala/collection/immutable/Seq.scala
+++ b/src/library/scala/collection/immutable/Seq.scala
@@ -34,7 +34,61 @@ trait IndexedSeq[+A] extends Seq[A]
 
   final override def toIndexedSeq: IndexedSeq[A] = this
 
+  override def canEqual(that: Any): Boolean = that match {
+    case otherIndexedSeq: IndexedSeq[_] => length == otherIndexedSeq.length && super.canEqual(that)
+    case _ => super.canEqual (that)
+  }
+
+
+  override def sameElements[B >: A](o: IterableOnce[B]): Boolean = o match {
+    case that: IndexedSeq[_] =>
+      (this eq that) || {
+        val length = this.length
+        var equal = length == that.length
+        if (equal) {
+          var index = 0
+          // some IndexedSeq apply is less efficient than using Iterators
+          // e.g. Vector so we can compare the first few with apply and the rest with an iterator
+          // but if apply is more efficient than Iterators then we can use the apply for all the comparison
+          // we default to the minimum preferred length
+          val maxApplyCompare = {
+            val preferredLength = Math.min(applyPreferredMaxLength, that.applyPreferredMaxLength).toLong
+            if (preferredLength <= (length << 1)) Math.min(preferredLength, length) else length
+          }
+          while (index < maxApplyCompare && equal) {
+            equal = this (index) == that(index)
+            index += 1
+          }
+          if ((index < length) && equal) {
+            val thisIt = this.iterator.drop(index)
+            val thatIt = that.iterator.drop(index)
+            while (equal && thisIt.hasNext) {
+              equal = thisIt.next() == thatIt.next()
+            }
+          }
+        }
+        equal
+      }
+    case _ => super.sameElements(o)
+  }
+
+  /** a hint to the runtime when scanning values
+    * [[apply]] is perferred for scan with a max index less than this value
+    * [[iterator]] is preferred for scans above this range
+    * @return a hint about when to use [[apply]] or [[iterator]]
+    */
+  protected def applyPreferredMaxLength: Int = IndexedSeqDefaults.defaultApplyPreferredMaxLength
+
   override def iterableFactory: SeqFactory[IterableCC] = IndexedSeq
+}
+
+object IndexedSeqDefaults {
+  val defaultApplyPreferredMaxLength: Int =
+    try System.getProperty(
+      "scala.collection.immutable.IndexedSeq.defaultApplyPreferredMaxLength", "64").toInt
+    catch {
+      case _: SecurityException => 64
+    }
 }
 
 @SerialVersionUID(3L)

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -3,6 +3,7 @@ package collection
 package immutable
 
 import java.io.{ObjectInputStream, ObjectOutputStream}
+import java.util
 
 import scala.collection.mutable.{Builder, ReusableBuilder}
 import scala.annotation.unchecked.uncheckedVariance
@@ -19,14 +20,21 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
 
   def from[E](it: collection.IterableOnce[E]): Vector[E] =
     it match {
-      case v: Vector[E]           => v
+      case v: Vector[E] => v
       case _ if it.knownSize == 0 => empty[E]
-      case _                      => (newBuilder ++= it).result()
+      case _ => (newBuilder ++= it).result()
     }
 
   def newBuilder[A]: Builder[A, Vector[A]] = new VectorBuilder[A]
 
   private[immutable] val NIL = new Vector[Nothing](0, 0, 0)
+
+  private val defaultApplyPreferredMaxLength: Int =
+    try System.getProperty("scala.collection.immutable.Vector.defaultApplyPreferredMaxLength",
+      "1024").toInt
+    catch {
+      case _: SecurityException => 1024
+    }
 
   // Constants governing concat strategy for performance
   private final val Log2ConcatFaster = 5
@@ -113,6 +121,45 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
       idx
     else
       throw new IndexOutOfBoundsException(index.toString)
+  }
+  // requires structure is at pos oldIndex = xor ^ index
+  private final def getElem(index: Int, xor: Int): A = {
+    if (xor < (1 << 5)) { // level = 0
+      (display0
+        (index & 31).asInstanceOf[A])
+    } else if (xor < (1 << 10)) { // level = 1
+      (display1
+        ((index >>> 5) & 31)
+        (index & 31).asInstanceOf[A])
+    } else if (xor < (1 << 15)) { // level = 2
+      (display2
+        ((index >>> 10) & 31)
+        ((index >>> 5) & 31)
+        (index & 31).asInstanceOf[A])
+    } else if (xor < (1 << 20)) { // level = 3
+      (display3
+        ((index >>> 15) & 31)
+        ((index >>> 10) & 31)
+        ((index >>> 5) & 31)
+        (index & 31).asInstanceOf[A])
+    } else if (xor < (1 << 25)) { // level = 4
+      (display4
+        ((index >>> 20) & 31)
+        ((index >>> 15) & 31)
+        ((index >>> 10) & 31)
+        ((index >>> 5) & 31)
+        (index & 31).asInstanceOf[A])
+    } else if (xor < (1 << 30)) { // level = 5
+      (display5
+        ((index >>> 25) & 31)
+        ((index >>> 20) & 31)
+        ((index >>> 15) & 31)
+        ((index >>> 10) & 31)
+        ((index >>> 5) & 31)
+        (index & 31).asInstanceOf[A])
+    } else { // level = 6
+      throw new IllegalArgumentException()
+    }
   }
 
   override def updated[B >: A](index: Int, elem: B): Vector[B] = updateAt(index, elem)
@@ -424,14 +471,14 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
     }
   }
 
-  private def copyLeft(array: Array[AnyRef], right: Int): Array[AnyRef] = {
-    val copy = new Array[AnyRef](array.length)
-    java.lang.System.arraycopy(array, 0, copy, 0, right)
+  private def copyLeft[T <: AnyRef](array: Array[T], right: Int): Array[T] = {
+    val copy = array.clone()
+    java.util.Arrays.fill(copy.asInstanceOf[Array[AnyRef]], right, array.length, null)
     copy
   }
-  private def copyRight(array: Array[AnyRef], left: Int): Array[AnyRef] = {
-    val copy = new Array[AnyRef](array.length)
-    java.lang.System.arraycopy(array, left, copy, left, copy.length - left)
+  private def copyRight[T <: AnyRef](array: Array[T], left: Int): Array[T] = {
+    val copy = array.clone()
+    java.util.Arrays.fill(copy.asInstanceOf[Array[AnyRef]], 0, left, null)
     copy
   }
 
@@ -549,6 +596,25 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
     releaseFence()
     s
   }
+  override protected def applyPreferredMaxLength: Int = Vector.defaultApplyPreferredMaxLength
+
+  override def equals(o: Any): Boolean = o match {
+    case that: Vector[_] =>
+      if (this eq that) true
+      else if (this.length != that.length) false
+      else if ( //
+        this.startIndex == that.startIndex && //
+          this.endIndex == that.endIndex && //
+          (this.display0 eq that.display0) && //
+          (this.display1 eq that.display1) && //
+          (this.display2 eq that.display2) && //
+          (this.display3 eq that.display3) && //
+          (this.display4 eq that.display4) && //
+          (this.display5 eq that.display5) //
+      ) true
+      else super.equals(o)
+    case _ => super.equals(o)
+  }
 
   override def toVector: Vector[A] = this
 
@@ -567,6 +633,27 @@ class VectorIterator[+A](_startIndex: Int, endIndex: Int)
   def hasNext = _hasNext
 
   private[this] var _hasNext = blockIndex + lo < endIndex
+
+  override def drop(n: Int): Iterator[A] = {
+    if (n > 0) {
+      val longLo = lo.toLong + n
+      if (blockIndex + longLo < endIndex) {
+        // We only need to adjust the block if we are outside the current block
+        // We know that we are within the collection as < endIndex
+        lo = longLo.toInt
+        if (lo >= 32) {
+          blockIndex = (blockIndex + lo) & ~31
+          gotoNewBlockStart(blockIndex, depth)
+
+          endLo = Math.min(endIndex - blockIndex, 32)
+          lo = lo & 31
+        }
+      } else {
+        _hasNext = false
+      }
+    }
+    this
+  }
 
   def next(): A = {
     if (!_hasNext) throw new NoSuchElementException("reached iterator end")
@@ -654,11 +741,11 @@ final class VectorBuilder[A]() extends ReusableBuilder[A, Vector[A]] with Vector
 private[immutable] trait VectorPointer[T] {
     private[immutable] var depth:    Int = _
     private[immutable] var display0: Array[AnyRef] = _
-    private[immutable] var display1: Array[AnyRef] = _
-    private[immutable] var display2: Array[AnyRef] = _
-    private[immutable] var display3: Array[AnyRef] = _
-    private[immutable] var display4: Array[AnyRef] = _
-    private[immutable] var display5: Array[AnyRef] = _
+    private[immutable] var display1: Array[Array[AnyRef]] = _
+    private[immutable] var display2: Array[Array[Array[AnyRef]]] = _
+    private[immutable] var display3: Array[Array[Array[Array[AnyRef]]]] = _
+    private[immutable] var display4: Array[Array[Array[Array[Array[AnyRef]]]]] = _
+    private[immutable] var display5: Array[Array[Array[Array[Array[Array[AnyRef]]]]]] = _
 
     protected def preClean(depth: Int): Unit = {
       this.depth = depth
@@ -725,46 +812,6 @@ private[immutable] trait VectorPointer[T] {
       }
     }
 
-    // requires structure is at pos oldIndex = xor ^ index
-    private[immutable] final def getElem(index: Int, xor: Int): T = {
-      if        (xor < (1 <<  5)) { // level = 0
-        (display0
-          (index           & 31).asInstanceOf[T])
-      } else if (xor < (1 << 10)) { // level = 1
-        (display1
-          ((index >>>  5)  & 31).asInstanceOf[Array[AnyRef]]
-          (index & 31).asInstanceOf[T])
-      } else if (xor < (1 << 15)) { // level = 2
-        (display2
-          ((index >>> 10)  & 31).asInstanceOf[Array[AnyRef]]
-          ((index >>>  5)  & 31).asInstanceOf[Array[AnyRef]]
-          (index           & 31).asInstanceOf[T])
-      } else if (xor < (1 << 20)) { // level = 3
-        (display3
-          ((index >>> 15)  & 31).asInstanceOf[Array[AnyRef]]
-          ((index >>> 10)  & 31).asInstanceOf[Array[AnyRef]]
-          ((index >>>  5)  & 31).asInstanceOf[Array[AnyRef]]
-           (index          & 31).asInstanceOf[T])
-      } else if (xor < (1 << 25)) { // level = 4
-        (display4
-          ((index >>> 20)  & 31).asInstanceOf[Array[AnyRef]]
-          ((index >>> 15)  & 31).asInstanceOf[Array[AnyRef]]
-          ((index >>> 10)  & 31).asInstanceOf[Array[AnyRef]]
-          ((index >>>  5)  & 31).asInstanceOf[Array[AnyRef]]
-           (index          & 31).asInstanceOf[T])
-      } else if (xor < (1 << 30)) { // level = 5
-        (display5
-          ((index >>> 25)  & 31).asInstanceOf[Array[AnyRef]]
-          ((index >>> 20)  & 31).asInstanceOf[Array[AnyRef]]
-          ((index >>> 15)  & 31).asInstanceOf[Array[AnyRef]]
-          ((index >>> 10)  & 31).asInstanceOf[Array[AnyRef]]
-          ((index >>>  5)  & 31).asInstanceOf[Array[AnyRef]]
-           (index          & 31).asInstanceOf[T])
-      } else {                      // level = 6
-        throw new IllegalArgumentException()
-      }
-    }
-
     // go to specific position
     // requires structure is at pos oldIndex = xor ^ index,
     // ensures structure is at pos index
@@ -772,25 +819,25 @@ private[immutable] trait VectorPointer[T] {
       if        (xor < (1 <<  5)) { // level = 0
         // we're already at the block start pos
       } else if (xor < (1 << 10)) { // level = 1
-        display0 = display1((index >>>  5) & 31).asInstanceOf[Array[AnyRef]]
+        display0 = display1((index >>>  5) & 31)
       } else if (xor < (1 << 15)) { // level = 2
-        display1 = display2((index >>> 10) & 31).asInstanceOf[Array[AnyRef]]
-        display0 = display1((index >>>  5) & 31).asInstanceOf[Array[AnyRef]]
+        display1 = display2((index >>> 10) & 31)
+        display0 = display1((index >>>  5) & 31)
       } else if (xor < (1 << 20)) { // level = 3
-        display2 = display3((index >>> 15) & 31).asInstanceOf[Array[AnyRef]]
-        display1 = display2((index >>> 10) & 31).asInstanceOf[Array[AnyRef]]
-        display0 = display1((index >>>  5) & 31).asInstanceOf[Array[AnyRef]]
+        display2 = display3((index >>> 15) & 31)
+        display1 = display2((index >>> 10) & 31)
+        display0 = display1((index >>>  5) & 31)
       } else if (xor < (1 << 25)) { // level = 4
-        display3 = display4((index >>> 20) & 31).asInstanceOf[Array[AnyRef]]
-        display2 = display3((index >>> 15) & 31).asInstanceOf[Array[AnyRef]]
-        display1 = display2((index >>> 10) & 31).asInstanceOf[Array[AnyRef]]
-        display0 = display1((index >>>  5) & 31).asInstanceOf[Array[AnyRef]]
+        display3 = display4((index >>> 20) & 31)
+        display2 = display3((index >>> 15) & 31)
+        display1 = display2((index >>> 10) & 31)
+        display0 = display1((index >>>  5) & 31)
       } else if (xor < (1 << 30)) { // level = 5
-        display4 = display5((index >>> 25) & 31).asInstanceOf[Array[AnyRef]]
-        display3 = display4((index >>> 20) & 31).asInstanceOf[Array[AnyRef]]
-        display2 = display3((index >>> 15) & 31).asInstanceOf[Array[AnyRef]]
-        display1 = display2((index >>> 10) & 31).asInstanceOf[Array[AnyRef]]
-        display0 = display1((index >>>  5) & 31).asInstanceOf[Array[AnyRef]]
+        display4 = display5((index >>> 25) & 31)
+        display3 = display4((index >>> 20) & 31)
+        display2 = display3((index >>> 15) & 31)
+        display1 = display2((index >>> 10) & 31)
+        display0 = display1((index >>>  5) & 31)
       } else {                      // level = 6
         throw new IllegalArgumentException()
       }
@@ -801,29 +848,36 @@ private[immutable] trait VectorPointer[T] {
     // xor: oldIndex ^ index
     private[immutable] final def gotoNextBlockStart(index: Int, xor: Int): Unit = { // goto block start pos
       if        (xor < (1 << 10)) { // level = 1
-        display0 = display1((index >>>  5) & 31).asInstanceOf[Array[AnyRef]]
+        display0 = display1((index >>>  5) & 31)
       } else if (xor < (1 << 15)) { // level = 2
-        display1 = display2((index >>> 10) & 31).asInstanceOf[Array[AnyRef]]
-        display0 = display1(0).asInstanceOf[Array[AnyRef]]
+        display1 = display2((index >>> 10) & 31)
+        display0 = display1(0)
       } else if (xor < (1 << 20)) { // level = 3
-        display2 = display3((index >>> 15) & 31).asInstanceOf[Array[AnyRef]]
-        display1 = display2(0).asInstanceOf[Array[AnyRef]]
-        display0 = display1(0).asInstanceOf[Array[AnyRef]]
+        display2 = display3((index >>> 15) & 31)
+        display1 = display2(0)
+        display0 = display1(0)
       } else if (xor < (1 << 25)) { // level = 4
-        display3 = display4((index >>> 20) & 31).asInstanceOf[Array[AnyRef]]
-        display2 = display3(0).asInstanceOf[Array[AnyRef]]
-        display1 = display2(0).asInstanceOf[Array[AnyRef]]
-        display0 = display1(0).asInstanceOf[Array[AnyRef]]
+        display3 = display4((index >>> 20) & 31)
+        display2 = display3(0)
+        display1 = display2(0)
+        display0 = display1(0)
       } else if (xor < (1 << 30)) { // level = 5
-        display4 = display5((index >>> 25) & 31).asInstanceOf[Array[AnyRef]]
-        display3 = display4(0).asInstanceOf[Array[AnyRef]]
-        display2 = display3(0).asInstanceOf[Array[AnyRef]]
-        display1 = display2(0).asInstanceOf[Array[AnyRef]]
-        display0 = display1(0).asInstanceOf[Array[AnyRef]]
+        display4 = display5((index >>> 25) & 31)
+        display3 = display4(0)
+        display2 = display3(0)
+        display1 = display2(0)
+        display0 = display1(0)
       } else {                      // level = 6
         throw new IllegalArgumentException()
       }
     }
+  private[immutable] final def gotoNewBlockStart(index: Int, depth: Int): Unit = {
+    if (depth > 5) display4 = display5((index >>> 25) & 31)
+    if (depth > 4) display3 = display4((index >>> 20) & 31)
+    if (depth > 3) display2 = display3((index >>> 15) & 31)
+    if (depth > 2) display1 = display2((index >>> 10) & 31)
+    if (depth > 1) display0 = display1((index >>> 5) & 31)
+  }
 
     // USED BY BUILDER
 
@@ -876,16 +930,10 @@ private[immutable] trait VectorPointer[T] {
 
     // STUFF BELOW USED BY APPEND / UPDATE
 
-    private[immutable] final def copyOf(a: Array[AnyRef]): Array[AnyRef] = {
-      val copy = new Array[AnyRef](a.length)
-      java.lang.System.arraycopy(a, 0, copy, 0, a.length)
-      copy
-    }
-
-    private[immutable] final def nullSlotAndCopy(array: Array[AnyRef], index: Int): Array[AnyRef] = {
+    private[immutable] final def nullSlotAndCopy[T <: AnyRef](array: Array[Array[T]], index: Int): Array[T] = {
       val x = array(index)
       array(index) = null
-      copyOf(x.asInstanceOf[Array[AnyRef]])
+      x.clone()
     }
 
     // make sure there is no aliasing
@@ -894,39 +942,39 @@ private[immutable] trait VectorPointer[T] {
 
     private[immutable] final def stabilize(index: Int) = (depth - 1) match {
       case 5 =>
-        display5 = copyOf(display5)
-        display4 = copyOf(display4)
-        display3 = copyOf(display3)
-        display2 = copyOf(display2)
-        display1 = copyOf(display1)
+        display5 = display5.clone()
+        display4 = display4.clone()
+        display3 = display3.clone()
+        display2 = display2.clone()
+        display1 = display1.clone()
         display5((index >>> 25) & 31) = display4
         display4((index >>> 20) & 31) = display3
         display3((index >>> 15) & 31) = display2
         display2((index >>> 10) & 31) = display1
         display1((index >>>  5) & 31) = display0
       case 4 =>
-        display4 = copyOf(display4)
-        display3 = copyOf(display3)
-        display2 = copyOf(display2)
-        display1 = copyOf(display1)
+        display4 = display4.clone()
+        display3 = display3.clone()
+        display2 = display2.clone()
+        display1 = display1.clone()
         display4((index >>> 20) & 31) = display3
         display3((index >>> 15) & 31) = display2
         display2((index >>> 10) & 31) = display1
         display1((index >>>  5) & 31) = display0
       case 3 =>
-        display3 = copyOf(display3)
-        display2 = copyOf(display2)
-        display1 = copyOf(display1)
+        display3 = display3.clone()
+        display2 = display2.clone()
+        display1 = display1.clone()
         display3((index >>> 15) & 31) = display2
         display2((index >>> 10) & 31) = display1
         display1((index >>>  5) & 31) = display0
       case 2 =>
-        display2 = copyOf(display2)
-        display1 = copyOf(display1)
+        display2 = display2.clone()
+        display1 = display1.clone()
         display2((index >>> 10) & 31) = display1
         display1((index >>>  5) & 31) = display0
       case 1 =>
-        display1 = copyOf(display1)
+        display1 = display1.clone()
         display1((index >>>  5) & 31) = display0
       case 0 =>
     }
@@ -940,32 +988,32 @@ private[immutable] trait VectorPointer[T] {
     // ensures structure is dirty and at pos newIndex and writable at level 0
     private[immutable] final def gotoPosWritable0(newIndex: Int, xor: Int): Unit = (depth - 1) match {
       case 5 =>
-        display5 = copyOf(display5)
+        display5 = display5.clone()
         display4 = nullSlotAndCopy(display5, (newIndex >>> 25) & 31)
         display3 = nullSlotAndCopy(display4, (newIndex >>> 20) & 31)
         display2 = nullSlotAndCopy(display3, (newIndex >>> 15) & 31)
         display1 = nullSlotAndCopy(display2, (newIndex >>> 10) & 31)
         display0 = nullSlotAndCopy(display1, (newIndex >>>  5) & 31)
       case 4 =>
-        display4 = copyOf(display4)
+        display4 = display4.clone()
         display3 = nullSlotAndCopy(display4, (newIndex >>> 20) & 31)
         display2 = nullSlotAndCopy(display3, (newIndex >>> 15) & 31)
         display1 = nullSlotAndCopy(display2, (newIndex >>> 10) & 31)
         display0 = nullSlotAndCopy(display1, (newIndex >>>  5) & 31)
       case 3 =>
-        display3 = copyOf(display3)
+        display3 = display3.clone()
         display2 = nullSlotAndCopy(display3, (newIndex >>> 15) & 31)
         display1 = nullSlotAndCopy(display2, (newIndex >>> 10) & 31)
         display0 = nullSlotAndCopy(display1, (newIndex >>>  5) & 31)
       case 2 =>
-        display2 = copyOf(display2)
+        display2 = display2.clone()
         display1 = nullSlotAndCopy(display2, (newIndex >>> 10) & 31)
         display0 = nullSlotAndCopy(display1, (newIndex >>>  5) & 31)
       case 1 =>
-        display1 = copyOf(display1)
+        display1 = display1.clone()
         display0 = nullSlotAndCopy(display1, (newIndex >>>  5) & 31)
       case 0 =>
-        display0 = copyOf(display0)
+        display0 = display0.clone()
     }
 
 
@@ -973,22 +1021,22 @@ private[immutable] trait VectorPointer[T] {
     // ensures structure is dirty and at pos newIndex and writable at level 0
     private[immutable] final def gotoPosWritable1(oldIndex: Int, newIndex: Int, xor: Int): Unit = {
       if        (xor < (1 <<  5)) { // level = 0
-        display0 = copyOf(display0)
+        display0 = display0.clone()
       } else if (xor < (1 << 10)) { // level = 1
-        display1 = copyOf(display1)
+        display1 = display1.clone()
         display1((oldIndex >>>  5) & 31) = display0
         display0 = nullSlotAndCopy(display1, (newIndex >>>  5) & 31)
       } else if (xor < (1 << 15)) { // level = 2
-        display1 = copyOf(display1)
-        display2 = copyOf(display2)
+        display1 = display1.clone()
+        display2 = display2.clone()
         display1((oldIndex >>>  5) & 31) = display0
         display2((oldIndex >>> 10) & 31) = display1
         display1 = nullSlotAndCopy(display2, (newIndex >>> 10) & 31)
         display0 = nullSlotAndCopy(display1, (newIndex >>>  5) & 31)
       } else if (xor < (1 << 20)) { // level = 3
-        display1 = copyOf(display1)
-        display2 = copyOf(display2)
-        display3 = copyOf(display3)
+        display1 = display1.clone()
+        display2 = display2.clone()
+        display3 = display3.clone()
         display1((oldIndex >>>  5) & 31) = display0
         display2((oldIndex >>> 10) & 31) = display1
         display3((oldIndex >>> 15) & 31) = display2
@@ -996,10 +1044,10 @@ private[immutable] trait VectorPointer[T] {
         display1 = nullSlotAndCopy(display2, (newIndex >>> 10) & 31)
         display0 = nullSlotAndCopy(display1, (newIndex >>>  5) & 31)
       } else if (xor < (1 << 25)) { // level = 4
-        display1 = copyOf(display1)
-        display2 = copyOf(display2)
-        display3 = copyOf(display3)
-        display4 = copyOf(display4)
+        display1 = display1.clone()
+        display2 = display2.clone()
+        display3 = display3.clone()
+        display4 = display4.clone()
         display1((oldIndex >>>  5) & 31) = display0
         display2((oldIndex >>> 10) & 31) = display1
         display3((oldIndex >>> 15) & 31) = display2
@@ -1009,11 +1057,11 @@ private[immutable] trait VectorPointer[T] {
         display1 = nullSlotAndCopy(display2, (newIndex >>> 10) & 31)
         display0 = nullSlotAndCopy(display1, (newIndex >>>  5) & 31)
       } else if (xor < (1 << 30)) { // level = 5
-        display1 = copyOf(display1)
-        display2 = copyOf(display2)
-        display3 = copyOf(display3)
-        display4 = copyOf(display4)
-        display5 = copyOf(display5)
+        display1 = display1.clone()
+        display2 = display2.clone()
+        display3 = display3.clone()
+        display4 = display4.clone()
+        display5 = display5.clone()
         display1((oldIndex >>>  5) & 31) = display0
         display2((oldIndex >>> 10) & 31) = display1
         display3((oldIndex >>> 15) & 31) = display2
@@ -1032,9 +1080,9 @@ private[immutable] trait VectorPointer[T] {
 
     // USED IN DROP
 
-    private[immutable] final def copyRange(array: Array[AnyRef], oldLeft: Int, newLeft: Int) = {
-      val elems = new Array[AnyRef](32)
-      java.lang.System.arraycopy(array, oldLeft, elems, newLeft, 32 - math.max(newLeft, oldLeft))
+    private[immutable] final def copyRange[T <: AnyRef](array: Array[T], oldLeft: Int, newLeft: Int) = {
+      val elems = java.lang.reflect.Array.newInstance(array.getClass.getComponentType, 32).asInstanceOf[Array[T]]
+      java.lang.System.arraycopy(array, oldLeft, elems, newLeft, 32 - Math.max(newLeft, oldLeft))
       elems
     }
 
@@ -1060,7 +1108,7 @@ private[immutable] trait VectorPointer[T] {
           display2((oldIndex >>> 10) & 31) = display1
           depth += 1
         }
-        display1 = display2((newIndex >>> 10) & 31).asInstanceOf[Array[AnyRef]]
+        display1 = display2((newIndex >>> 10) & 31)
         if (display1 == null) display1 = new Array(32)
         display0 = new Array(32)
       } else if (xor < (1 << 20)) { // level = 3
@@ -1069,9 +1117,9 @@ private[immutable] trait VectorPointer[T] {
           display3((oldIndex >>> 15) & 31) = display2
           depth += 1
         }
-        display2 = display3((newIndex >>> 15) & 31).asInstanceOf[Array[AnyRef]]
+        display2 = display3((newIndex >>> 15) & 31)
         if (display2 == null) display2 = new Array(32)
-        display1 = display2((newIndex >>> 10) & 31).asInstanceOf[Array[AnyRef]]
+        display1 = display2((newIndex >>> 10) & 31)
         if (display1 == null) display1 = new Array(32)
         display0 = new Array(32)
       } else if (xor < (1 << 25)) { // level = 4
@@ -1080,11 +1128,11 @@ private[immutable] trait VectorPointer[T] {
           display4((oldIndex >>> 20) & 31) = display3
           depth += 1
         }
-        display3 = display4((newIndex >>> 20) & 31).asInstanceOf[Array[AnyRef]]
+        display3 = display4((newIndex >>> 20) & 31)
         if (display3 == null) display3 = new Array(32)
-        display2 = display3((newIndex >>> 15) & 31).asInstanceOf[Array[AnyRef]]
+        display2 = display3((newIndex >>> 15) & 31)
         if (display2 == null) display2 = new Array(32)
-        display1 = display2((newIndex >>> 10) & 31).asInstanceOf[Array[AnyRef]]
+        display1 = display2((newIndex >>> 10) & 31)
         if (display1 == null) display1 = new Array(32)
         display0 = new Array(32)
       } else if (xor < (1 << 30)) { // level = 5
@@ -1093,13 +1141,13 @@ private[immutable] trait VectorPointer[T] {
           display5((oldIndex >>> 25) & 31) = display4
           depth += 1
         }
-        display4 = display5((newIndex >>> 25) & 31).asInstanceOf[Array[AnyRef]]
+        display4 = display5((newIndex >>> 25) & 31)
         if (display4 == null) display4 = new Array(32)
-        display3 = display4((newIndex >>> 20) & 31).asInstanceOf[Array[AnyRef]]
+        display3 = display4((newIndex >>> 20) & 31)
         if (display3 == null) display3 = new Array(32)
-        display2 = display3((newIndex >>> 15) & 31).asInstanceOf[Array[AnyRef]]
+        display2 = display3((newIndex >>> 15) & 31)
         if (display2 == null) display2 = new Array(32)
-        display1 = display2((newIndex >>> 10) & 31).asInstanceOf[Array[AnyRef]]
+        display1 = display2((newIndex >>> 10) & 31)
         if (display1 == null) display1 = new Array(32)
         display0 = new Array(32)
       } else {                      // level = 6

--- a/src/library/scala/collection/immutable/WrappedString.scala
+++ b/src/library/scala/collection/immutable/WrappedString.scala
@@ -40,6 +40,7 @@ final class WrappedString(private val self: String) extends AbstractSeq[Char] wi
 
   override protected[this] def className = "WrappedString"
 
+  override protected final def applyPreferredMaxLength: Int = Int.MaxValue
   override def equals(other: Any): Boolean = other match {
     case that: WrappedString =>
       this.self == that.self

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/IndexedSeqEqualsBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/IndexedSeqEqualsBenchmark.scala
@@ -1,0 +1,53 @@
+package scala.collection.immutable
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+import org.openjdk.jmh.runner.IterationType
+import benchmark._
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10000)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class IndexedSeqEqualsBenchmark {
+//  @Param(Array("0", "1", "2", "3", "4", "6", "8", "10", "12", "14", "16"
+//    , "20", "24", "28", "32", "40", "48", "56", "64",
+//    "128", "256", "512", "1024", "2048", "65536"))
+  @Param(Array("128"))
+  var size: Int = _
+
+  @Param(Array("ArraySeq"))
+  var type1: String = _
+  @Param(Array("ArraySeq"))
+  var type2: String = _
+
+  var value: IndexedSeq[Any] = _
+  var valueEqual: IndexedSeq[Any] = _
+  var valueNotEqualFirst: IndexedSeq[Any] = _
+  var valueNotEqualLast: IndexedSeq[Any] = _
+  var valueNotEqualLength: IndexedSeq[Any] = _
+
+  @Setup(Level.Trial) def init(): Unit = {
+    def toSeq[T](data: Array[T], typeStr: String):IndexedSeq[T] = typeStr match {
+      case "Vector" => data.to(Vector)
+      case "ArraySeq" =>
+        ArraySeq.unsafeWrapArray(data.clone)
+    }
+
+    val data = Array.tabulate(size)(_.toString)
+    value = toSeq(data, type1)
+    valueEqual = toSeq(data, type2)
+
+    valueNotEqualLength = valueEqual + "xx"
+    valueNotEqualFirst = if (value.isEmpty) valueEqual else valueEqual.updated(0, "xx")
+    valueNotEqualLast = if (value.isEmpty) valueEqual else valueEqual.updated(valueEqual.length - 1, "xx")
+  }
+  @Benchmark def equal = value == valueEqual
+//  @Benchmark def notEqualLength = value == valueNotEqualLength
+//  @Benchmark def notEqualFirst = value == valueNotEqualFirst
+//  @Benchmark def notEqualLast = value == valueNotEqualLast
+}

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorIterationBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorIterationBenchmark.scala
@@ -1,0 +1,55 @@
+package scala.collection.immutable
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+import org.openjdk.jmh.runner.IterationType
+import benchmark._
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class VectorIterationBenchmark {
+  @Param(Array("0", "1", "2", "3", "4", "6", "8", "10", "12", "14", "16"
+    , "20", "24", "28", "32", "40", "48", "56", "64",
+    "128", "256", "512", "1024", "2048", "4096", "8192", "16384", "32768", "65536"))
+  var size: Int = _
+
+  var value: Vector[Any] = _
+  var larger: Vector[Any] = _
+
+  @Setup(Level.Trial) def init(): Unit = {
+    value = Vector.tabulate(size)(_.toString)
+    larger = value :+ "last"
+  }
+
+  @Benchmark def iterate(bh: Blackhole) = {
+    var i = 0
+    val it = value.iterator
+    while (i < size) {
+      bh.consume(it.next)
+      i += 1
+    }
+  }
+
+  @Benchmark def apply(bh: Blackhole) = {
+    var i = 0
+    while (i < size) {
+      bh.consume(value(i))
+      i += 1
+    }
+  }
+
+  @Benchmark def applySingle(bh: Blackhole) = {
+    bh.consume(larger(size))
+  }
+
+  @Benchmark def drop = {
+    val it = value.iterator
+    it.drop(size)
+  }
+}

--- a/test/junit/scala/collection/immutable/IndexedSeqTest.scala
+++ b/test/junit/scala/collection/immutable/IndexedSeqTest.scala
@@ -1,0 +1,106 @@
+package scala.collection.immutable
+
+import org.junit._
+import Assert._
+
+import scala.util.AllocationTest
+
+class IndexedSeqTest extends AllocationTest {
+
+  @Test def testEqualsSimple: Unit = {
+    assertTrue(Vector.empty == Vector.empty)
+    assertTrue(Vector(1, 2, 3) == Vector(1, 2, 3))
+    assertTrue(Vector(1, 2, 3, 4, 5, 6, 7, 8, 9) == Vector(1, 2, 3, 4, 5, 6, 7, 8, 9))
+
+    assertTrue(ArraySeq.empty == ArraySeq.empty)
+    assertTrue(ArraySeq(1, 2, 3) == ArraySeq(1, 2, 3))
+    assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) == ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9))
+  }
+
+  @Test def testNotEqualsSimple1: Unit = {
+    assertTrue(Vector.empty != Vector(1, 2, 3))
+    assertTrue(Vector(3, 2, 1) != Vector(1, 2, 3))
+    assertTrue(Vector(1, 2, 3) != Vector(1, 2))
+    assertTrue(Vector(1, 2) != Vector(1, 2, 3))
+    assertTrue(Vector(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 2, 3, 4, 5, 6, 7, 8, 99))
+  }
+
+  @Test def testNotEqualsSimple2: Unit = {
+    assertTrue(ArraySeq.empty != ArraySeq(1, 2, 3))
+    assertTrue(ArraySeq(3, 2, 1) != ArraySeq(1, 2, 3))
+    assertTrue(ArraySeq(1, 2, 3) != ArraySeq(1, 2))
+    assertTrue(ArraySeq(1, 2) != ArraySeq(1, 2, 3))
+    assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 99))
+  }
+
+  @Test def testNotEqualsSimple3: Unit = {
+    assertTrue(ArraySeq.empty != Vector(1, 2, 3))
+    assertTrue(ArraySeq(3, 2, 1) != Vector(1, 2, 3))
+    assertTrue(ArraySeq(1, 2, 3) != Vector(1, 2))
+    assertTrue(ArraySeq(1, 2) != Vector(1, 2, 3))
+    assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 2, 3, 4, 5, 6, 7, 8, 99))
+  }
+
+  @Test def testNotEqualsEdges: Unit = {
+    assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(10, 2, 3, 4, 5, 6, 7, 8, 9))
+    assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 20, 3, 4, 5, 6, 7, 8, 9))
+    assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 2, 30, 4, 5, 6, 7, 8, 9))
+    assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 2, 3, 40, 5, 6, 7, 8, 9))
+    assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 2, 3, 4, 50, 6, 7, 8, 9))
+    assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 2, 3, 4, 5, 60, 7, 8, 9))
+    assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 2, 3, 4, 5, 6, 70, 8, 9))
+    assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 2, 3, 4, 5, 6, 7, 80, 9))
+    assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 2, 3, 4, 5, 6, 7, 8, 90))
+  }
+
+  @Test def testEqualsSimpleNonAllocatingEmpty: Unit = {
+    nonAllocatingEqual(true, Vector.empty, Vector.empty)
+    nonAllocatingEqual(true, ArraySeq.empty, ArraySeq.empty)
+    nonAllocatingEqual(true, Vector.empty, ArraySeq.empty)
+  }
+
+  @Test def testEqualsSimpleNonAllocatingSmall: Unit = {
+    nonAllocatingEqual(true, Vector(1, 2, 3), Vector(1, 2, 3))
+    nonAllocatingEqual(true, ArraySeq(1, 2, 3), ArraySeq(1, 2, 3))
+    nonAllocatingEqual(true, Vector(1, 2, 3), ArraySeq(1, 2, 3))
+  }
+
+  @Test def testEqualsSimpleNonAllocatingDiffSize: Unit = {
+    nonAllocatingEqual(false, Vector(1, 2, 3, 4, 5, 6, 7, 8, 9), Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+    nonAllocatingEqual(false, ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+    nonAllocatingEqual(false, Vector(1, 2, 3, 4, 5, 6, 7, 8, 9), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+  }
+
+  @Test def testEqualsSimpleNonAllocatingDiffInFirstFew: Unit = {
+    nonAllocatingEqual(false, Vector(1, 2, 3, 14, 5, 6, 7, 8, 9), Vector(1, 2, 3, 4, 5, 6, 7, 8, 9))
+    nonAllocatingEqual(false, ArraySeq(1, 2, 3, 14, 5, 6, 7, 8, 9), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9))
+    nonAllocatingEqual(false, Vector(1, 2, 3, 14, 5, 6, 7, 8, 9), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9))
+  }
+
+  @Test def testEqualsArraySeqSpecialised1: Unit = {
+    nonAllocatingEqual(true, ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9))
+  }
+  @Test def testEqualsArraySeqSpecialised2: Unit = {
+    nonAllocatingEqual(true, ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9), Range(1,10))
+  }
+
+  @Test def testReflexiveEquality(): Unit = {
+    assertNotEquals(new MyRange(0, 1), List(0))
+    assertNotEquals(new MyRange(0, 1), Vector(0))
+    assertNotEquals(new MyRange(0, 1), Range(0,1))
+    assertNotEquals(List(0), new MyRange(0, 1))
+    assertNotEquals(Vector(0), new MyRange(0, 1))
+    assertNotEquals(Range(0,1), new MyRange(0, 1))
+    assertEquals(new MyRange(0, 1), new MyRange(0, 1))
+  }
+}
+final class MyRange(val start: Int, val end: Int) extends IndexedSeq[Int] {
+  def apply(idx: Int) = start + idx
+  def length = end - start
+  override def canEqual(other: Any) = other.isInstanceOf[MyRange]
+  override def equals(other: Any) = other match {
+    case other: MyRange => other.start == start && other.end == end
+    case _ => false
+  }
+  override def hashCode = start + end
+}

--- a/test/junit/scala/collection/immutable/RangeTest.scala
+++ b/test/junit/scala/collection/immutable/RangeTest.scala
@@ -39,4 +39,21 @@ class RangeTest {
     assertThrows[java.util.NoSuchElementException](Range.inclusive(9, 1, 1).min)
     assertThrows[java.util.NoSuchElementException](Range.inclusive(9, 1, 1).max)
   }
+
+  @Test
+  def dropToEnd(): Unit = {
+    val test = 10 to 11
+    val it = test.iterator
+    it.drop(1)
+
+    assertEquals(11, it.next)
+  }
+  @Test
+  def dropToEnd2(): Unit = {
+    val test = 10 until 11
+    val it = test.iterator
+    it.drop(0)
+
+    assertEquals(10, it.next)
+  }
 }

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -62,4 +62,91 @@ class VectorTest {
     val i = Iterator.from(1).take(3)
     assertEquals(Vector(1, 2, 3, 0), Vector(0).prependedAll(i))
   }
+
+  @Test
+  def vectorIteratorDrop(): Unit = {
+    val underlying = Vector(0 to 10010: _*)
+
+    val totalSize = underlying.size
+
+    for (start <- 1056 to 10000) {
+      val it = underlying.iterator.drop(start)
+      assertEquals(totalSize - start, it.knownSize)
+      assertEquals(totalSize - start, it.size)
+      assertTrue(it.hasNext)
+      assertEquals(start, it.next())
+    }
+  }
+  def intercept[T <: Throwable: Manifest](fn: => Any): T = {
+    try {
+      fn
+      fail(s"expected a ${manifest[T].runtimeClass.getName} to be thrown")
+      ???
+    } catch {
+      case x: T => x
+    }
+  }
+  @Test
+  def vectorIteratorDropToEnd(): Unit = {
+    val underlying = Vector(0)
+
+    for (start <- List(1,2,3,4,99)) {
+      {
+        var it = underlying.iterator.drop(start)
+        assertFalse(it.hasNext)
+        intercept[NoSuchElementException](it.next)
+        it = it.drop(0)
+        assertFalse(it.hasNext)
+        it = it.drop(1)
+        assertFalse(it.hasNext)
+        it = it.drop(99)
+        assertFalse(it.hasNext)
+        intercept[NoSuchElementException](it.next)
+      }
+
+      {
+        var it = underlying.iterator.drop(start)
+        intercept[NoSuchElementException](it.next)
+        it = it.drop(0)
+        it = it.drop(1)
+        it = it.drop(99)
+        intercept[NoSuchElementException](it.next)
+      }
+    }
+  }
+  @Test
+  def vectorIteratorRepeated(): Unit = {
+    val underlying = Vector(1 to 10001: _*)
+
+
+    for (stepSize <- List(0, 1, 2, 3, 4, 8, 10, 24, 32, 63, 64, 100)) {
+      var it:Iterator[Int] = underlying.iterator
+      for (stepCount <- 1 to 10) {
+        it = it.drop(stepSize)
+        assertTrue(it.hasNext)
+        val expected = (stepSize + 1) * stepCount
+        assertEquals(expected, it.next())
+      }
+    }
+  }
+  @Test
+  def vectorFill(): Unit = {
+    var i = 0
+    val test = Vector.fill(10){
+      i += 1
+      i * 10
+    }
+    assertEquals(List(10,20,30,40,50,60,70,80,90,100), test)
+    assertEquals(10, test.length)
+    assertEquals(10, test.head)
+    assertEquals(10, test(0))
+    assertEquals(20, test(1))
+    assertEquals(80, test(7))
+    assertEquals(100, test(9))
+
+    assertEquals(0, test.indexOf(10))
+    assertEquals(8, test.indexOf(90))
+    assertEquals(-1, test.indexOf(1000))
+  }
+
 }

--- a/test/junit/scala/util/AllocationTest.scala
+++ b/test/junit/scala/util/AllocationTest.scala
@@ -1,0 +1,72 @@
+package scala.util
+
+import java.lang.management.ManagementFactory
+
+import org.junit.Assert.{assertEquals, assertTrue, fail}
+
+object AllocationTest {
+  val allocationCounter = ManagementFactory.getThreadMXBean.asInstanceOf[com.sun.management.ThreadMXBean]
+  assertTrue(allocationCounter.isThreadAllocatedMemorySupported)
+  allocationCounter.setThreadAllocatedMemoryEnabled(true)
+  val cost = {
+    val id = Thread.currentThread().getId
+    for (i <- 1 to 1000) yield {
+      val before = allocationCounter.getThreadAllocatedBytes(id)
+      val after = allocationCounter.getThreadAllocatedBytes(id)
+      (after - before)
+    }
+  }.min
+
+  println(s"cost of tracking allocations = $cost")
+}
+
+trait AllocationTest {
+
+  import AllocationTest._
+
+  def nonAllocatingEqual(expected: Boolean, a: AnyRef, b: AnyRef): Unit = {
+    assertEquals(expected, nonAllocating(a == b))
+  }
+
+  def nonAllocating[T](fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): T = {
+    val result = allocationInfo(fn)
+    val expected = fn
+
+    if (result.min != 0) {
+      result.allocations foreach {
+        x => println(s"allocation $x")
+      }
+      fail(s"allocating min = ${result.min}")
+    }
+    result.result
+  }
+
+  def allocationInfo[T](fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): AllocationInfo[T] = {
+    val expected = fn
+    val id = Thread.currentThread().getId
+
+    //warmup
+    for (i <- 0 until execution.warmupCount) {
+      val actual = fn
+      assertEquals(s"warmup at index $i $expected $actual", expected, actual)
+    }
+
+   //test
+    val counts = new Array[Long](execution.executionCount)
+    for (i <- 0 until execution.executionCount) {
+      val before = allocationCounter.getThreadAllocatedBytes(id)
+      val actual = fn
+      val after = allocationCounter.getThreadAllocatedBytes(id)
+      counts(i) = after - cost - before
+      assertEquals(s"at index $i $expected $actual", expected, actual)
+    }
+    AllocationInfo(expected, counts)
+  }
+
+}
+
+case class AllocationExecution(executionCount: Int = 1000, warmupCount: Int = 1000)
+
+case class AllocationInfo[T](result: T, allocations: Array[Long]) {
+  def min = allocations.iterator.min
+}


### PR DESCRIPTION
Optimise implementation of equals for IndexedSeq

without this `equals` creates two iterators and walks the content