### PR TITLE
[nomerge] Optimise equals checking for IndexedSeq - 2.12 only

### DIFF
--- a/src/library/scala/collection/GenSeqLike.scala
+++ b/src/library/scala/collection/GenSeqLike.scala
@@ -474,7 +474,7 @@ trait GenSeqLike[+A, +Repr] extends Any with GenIterableLike[A, Repr] with Equal
    *            this sequence in the same order, `false` otherwise
    */
   override def equals(that: Any): Boolean = that match {
-    case that: GenSeq[_] => (that canEqual this) && (this sameElements that)
+    case that: GenSeq[_] => (that eq this.asInstanceOf[AnyRef]) || (that canEqual this) && (this sameElements that)
     case _               => false
   }
 

--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -288,13 +288,31 @@ self =>
   }
 
   def sameElements[B >: A](that: GenIterable[B]): Boolean = {
-    val these = this.iterator
-    val those = that.iterator
-    while (these.hasNext && those.hasNext)
-      if (these.next != those.next)
-        return false
+    that match {
+      case thatVector: Vector[_] if this.isInstanceOf[Vector[_]] =>
+        val thisVector = this.asInstanceOf[Vector[_]]
+        (thisVector eq thatVector) || {
+          var equal = thisVector.length == thatVector.length
+          if (equal) {
+            val length = thatVector.length
+            var index = 0
+            while (index < length && equal) {
+              equal = thisVector(index) == thatVector(index)
+              index += 1
+            }
+          }
+          equal
+        }
 
-    !these.hasNext && !those.hasNext
+      case _ =>
+        val these = this.iterator
+        val those = that.iterator
+        while (these.hasNext && those.hasNext)
+          if (these.next != those.next)
+            return false
+
+        !these.hasNext && !those.hasNext
+    }
   }
 
   override /*TraversableLike*/ def toStream: Stream[A] = iterator.toStream


### PR DESCRIPTION
Optimise implementation of equals for IndexedSeq

without this `equals` creates two iterators and walks the content

mimics https://github.com/scala/scala/pull/6833 but without binary changes