### PR TITLE
Implement concat, intersect and diff in BitSet for better performance

### DIFF
--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -182,6 +182,36 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
     coll.fromBitMaskNoCopy(a)
   }
 
+  override def concat(other: collection.Iterable[Int]): C = other match {
+    case otherBitset: BitSet =>
+      val len = coll.nwords max otherBitset.nwords
+      val words = new Array[Long](len)
+      for (idx <- 0 until len)
+        words(idx) = this.word(idx) | otherBitset.word(idx)
+      fromBitMaskNoCopy(words)
+    case _ => super.concat(other)
+  }
+
+  override def intersect(other: Set[Int]): C = other match {
+    case otherBitset: BitSet =>
+      val len = coll.nwords min otherBitset.nwords
+      val words = new Array[Long](len)
+      for (idx <- 0 until len)
+        words(idx) = this.word(idx) & otherBitset.word(idx)
+      fromBitMaskNoCopy(words)
+    case _ => super.intersect(other)
+  }
+
+  abstract override def diff(other: Set[Int]): C = other match {
+    case otherBitset: BitSet =>
+      val len = coll.nwords
+      val words = new Array[Long](len)
+      for (idx <- 0 until len)
+        words(idx) = this.word(idx) & ~otherBitset.word(idx)
+      fromBitMaskNoCopy(words)
+    case _ => super.diff(other)
+  }
+
   /** Computes the symmetric difference of this bitset and another bitset by performing
     *  a bitwise "exclusive-or".
     *

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -84,4 +84,35 @@ class BitSetTest {
     assert(im.collect{case i if i%2 == 1 => i}.isInstanceOf[collection.immutable.BitSet])
     assert(im.collect{case i if i%2 == 1 => i} == collection.immutable.BitSet(1, 3))
   }
+
+  @Test def concat(): Unit = {
+    val a = BitSet(1, 2, 3)
+    val b = BitSet(2, 4, 6)
+    assert(a.concat(b) == BitSet(1, 2, 3, 4, 6))
+    assert(a.union(b) == BitSet(1, 2, 3, 4, 6))
+    assert(a.concat(BitSet()) == BitSet(1, 2, 3))
+    assert(BitSet().concat(a) == BitSet(1, 2, 3))
+    assert(BitSet().concat(BitSet()) == BitSet())
+  }
+
+  @Test def intersect(): Unit = {
+    val a = BitSet(1, 2, 3)
+    val b = BitSet(2, 4, 6)
+    assert(a.intersect(b) == BitSet(2))
+    assert(a.intersect(BitSet(4, 6)) == BitSet())
+    assert(a.intersect(BitSet()) == BitSet())
+    assert(BitSet().intersect(a) == BitSet())
+    assert(BitSet().intersect(BitSet()) == BitSet())
+  }
+
+  @Test def diff(): Unit = {
+    val a = BitSet(1, 2, 3)
+    val b = BitSet(2, 4, 6)
+    assert(a.diff(b) == BitSet(1, 3))
+    assert(b.diff(a) == BitSet(4, 6))
+    assert(a.diff(BitSet(4, 6)) == BitSet(1, 2, 3))
+    assert(a.diff(BitSet()) == BitSet(1, 2, 3))
+    assert(BitSet().diff(a) == BitSet())
+    assert(BitSet().diff(BitSet()) == BitSet())
+  }
 }


### PR DESCRIPTION
Uses the implementation from 2.12. 
Added tests.

Fixes scala/bug#10950