### PR TITLE
Fix OutOfMemoryError in mkString

### DIFF
--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -521,7 +521,7 @@ final class StringOps(private val s: String) extends AnyVal {
     while(i < len) {
       if(i != 0) b.append(sep)
       b.append(s.charAt(i))
-      i += i
+      i += 1
     }
     b.append(end)
     b

--- a/test/junit/scala/collection/StringOpsTest.scala
+++ b/test/junit/scala/collection/StringOpsTest.scala
@@ -1,0 +1,16 @@
+package scala.collection
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class StringOpsTest {
+  // Test for scala/bug#10951
+  @Test def mkstring(): Unit = {
+    assert("".mkString("") == "")
+    assert("".mkString(",") == "")
+    assert("a".mkString(",") == "a")
+    assert("ab".mkString(",") == "a,b")
+  }
+}


### PR DESCRIPTION
- fix i/1 mix-up
- add regression test

Fixes scala/bug#10951