### PR TITLE
Overriding pairs: consider redundant base classes by class, not by type

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -472,7 +472,7 @@ abstract class Erasure extends InfoTransform
     def computeAndEnter(): Unit = {
       while (opc.hasNext) {
         if (enteringExplicitOuter(!opc.low.isDeferred))
-          checkPair(opc. currentPair)
+          checkPair(opc.currentPair)
 
         opc.next()
       }

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -61,7 +61,8 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   def remove(key: K): C
 
   /** Alias for `remove` */
-  /* @`inline` final */ def - (key: K): C = remove(key)
+  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
+  /*@`inline` final*/ def - (key: K): C = remove(key)
 
   @deprecated("Use -- with an explicit collection", "2.13.0")
   def - (key1: K, key2: K, keys: K*): C = remove(key1).remove(key2).removeAll(keys)

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -43,7 +43,8 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   def excl(elem: A): C
 
   /** Alias for `excl` */
-  /* @`inline` final */ override def - (elem: A): C = excl(elem)
+  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
+  /*@`inline` final*/ override def - (elem: A): C = excl(elem)
 
   override def concat(that: collection.Iterable[A]): C = {
     var result: C = coll

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -59,10 +59,12 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
     with Shrinkable[K] {
 
   @deprecated("Use - or remove on an immutable Map", "2.13.0")
-  /* final */ def - (key: K): C = clone() -= key
+  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
+  /*final*/ def - (key: K): C = clone() -= key
 
   @deprecated("Use -- or removeAll on an immutable Map", "2.13.0")
-  /* final */ def - (key1: K, key2: K, keys: K*): C = clone() -= key1 -= key2 --= keys
+  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
+  /*final*/ def - (key1: K, key2: K, keys: K*): C = clone() -= key1 -= key2 --= keys
 
   /** Adds a new key/value pair to this map and optionally returns previously bound value.
     *  If the map already contains a

--- a/src/reflect/scala/reflect/internal/SymbolPairs.scala
+++ b/src/reflect/scala/reflect/internal/SymbolPairs.scala
@@ -35,7 +35,7 @@ abstract class SymbolPairs {
    *  when viewed from IterableClass.
    */
   def sameInBaseClass(baseClass: Symbol)(tp1: Type, tp2: Type) =
-    (tp1 baseType baseClass) =:= (tp2 baseType baseClass)
+    tp1.baseType(baseClass).typeSymbol == tp2.baseType(baseClass).typeSymbol
 
   final case class SymbolPair(base: Symbol, low: Symbol, high: Symbol) {
     private[this] val self  = base.thisType
@@ -125,7 +125,7 @@ abstract class SymbolPairs {
      *     i = index(p)
      *     j = index(b)
      *     p isSubClass b
-     *     p.baseType(b) == self.baseType(b)
+     *     p.baseType(b).typeSymbol == self.baseType(b).typeSymbol
      */
     private val subParents = new Array[BitSet](size)
 

--- a/test/files/run/t10853.scala
+++ b/test/files/run/t10853.scala
@@ -1,0 +1,12 @@
+trait F[T1, R] { def apply(funArg: T1): R }
+
+trait SetOps[A, +C] extends F[A, Boolean] { final def apply(setEl: A): Boolean = false }
+
+class AbstractSet[A] extends SetOps[A, AbstractSet[A]]
+class AbstractSet2[A] extends AbstractSet[A] with SetOps[A, AbstractSet2[A]]
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    new AbstractSet2[String]
+  }
+}

--- a/test/junit/scala/lang/traits/BytecodeTest.scala
+++ b/test/junit/scala/lang/traits/BytecodeTest.scala
@@ -25,6 +25,21 @@ class BytecodeTest extends BytecodeTesting {
   }
 
   @Test
+  def t10853(): Unit = {
+    val code =
+      """trait F[T1, R] { def apply(funArg: T1): R }
+        |
+        |trait SetOps[A, +C] extends F[A, Boolean] { final def apply(setEl: A): Boolean = false }
+        |
+        |class AbstractSet[A] extends SetOps[A, AbstractSet[A]]
+        |class AbstractSet2[A] extends AbstractSet[A] with SetOps[A, AbstractSet2[A]]
+      """.stripMargin
+    val cs = compileClasses(code)
+    val c = cs.find(_.name == "AbstractSet2").get
+    assertEquals(c.methods.asScala.map(_.name).toList, List("<init>")) // no bridge for apply (there's already one in AbstractSet)
+  }
+
+  @Test
   def traitMethodForwarders(): Unit = {
     val code =
       """trait T1 { def f = 1 }


### PR DESCRIPTION
Let's see how far I get with this attempt...

Fixes https://github.com/scala/bug/issues/10853