### PR TITLE
It corrects the return type by the implicit conversion from Seq[T] to Seq[Source] 

### DIFF
--- a/src/library/scala/sys/process/Process.scala
+++ b/src/library/scala/sys/process/Process.scala
@@ -64,8 +64,7 @@ trait ProcessCreation {
     *
     * @example {{{ apply("cat", files) }}}
     */
-  def apply(command: String, arguments: scala.collection.Seq[String]): ProcessBuilder = apply(Seq(command) ++: arguments, None)
-  //TODO there should be a way to avoid wrapping `command` in `Seq`
+  def apply(command: String, arguments: scala.collection.Seq[String]): ProcessBuilder = apply(command +: arguments, None)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] with working dir set to `File` and extra
     * environment variables.
@@ -143,7 +142,7 @@ trait ProcessCreation {
   /** Creates a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence of
     * something else for which there's an implicit conversion to `Source`.
     */
-  def applySeq[T](builders: scala.collection.Seq[T])(implicit convert: T => Source): Seq[Source] = builders.map(convert)
+  def applySeq[T](builders: scala.collection.Seq[T])(implicit convert: T => Source): scala.collection.Seq[Source] = builders.map(convert)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from one or more
     * [[scala.sys.process.ProcessBuilder.Source]], which can then be
@@ -188,7 +187,7 @@ trait ProcessImplicits {
   /** Return a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence
     * of values for which an implicit conversion to `Source` is available.
     */
-  implicit def buildersToProcess[T](builders: scala.collection.Seq[T])(implicit convert: T => Source): Seq[Source] = applySeq(builders)
+  implicit def buildersToProcess[T](builders: scala.collection.Seq[T])(implicit convert: T => Source): scala.collection.Seq[Source] = applySeq(builders)
 
   /** Implicitly convert a `java.lang.ProcessBuilder` into a Scala one. */
   implicit def builderToProcess(builder: JProcessBuilder): ProcessBuilder = apply(builder)

--- a/test/junit/scala/sys/process/ProcessTest.scala
+++ b/test/junit/scala/sys/process/ProcessTest.scala
@@ -1,6 +1,6 @@
 package scala.sys.process
 
-import java.io.ByteArrayInputStream
+import java.io.{ByteArrayInputStream, File}
 // should test from outside the package to ensure implicits work
 //import scala.sys.process._
 import scala.util.Properties._
@@ -13,6 +13,7 @@ import org.junit.Assert.assertEquals
 @RunWith(classOf[JUnit4])
 class ProcessTest {
   private def testily(body: => Unit) = if (!isWin) body
+  private val tempFiles = Seq(File.createTempFile("foo", "tmp"), File.createTempFile("bar", "tmp"))
   @Test def t10007(): Unit = testily {
     val res = ("cat" #< new ByteArrayInputStream("lol".getBytes)).!!
     assertEquals("lol\n", res)
@@ -20,6 +21,16 @@ class ProcessTest {
   // test non-hanging
   @Test def t10055(): Unit = testily {
     val res = ("cat" #< ( () => -1 ) ).!
+    assertEquals(0, res)
+  }
+
+  @Test def t10953(): Unit = {
+    val res = Process.cat(tempFiles).!
+    assertEquals(0, res)
+  }
+
+  @Test def processApply(): Unit = {
+    val res = Process("cat", tempFiles.map(_.getAbsolutePath)).!
     assertEquals(0, res)
   }
 }


### PR DESCRIPTION
As all other methods in `Process.scala`, now the implicit conversion form scala.collection.Seq[T] will converto to scala.collection.Seq[T] instead of only Seq[T] which was the cause why it wasn't able to find the conversion.

Fixes scala/bug#10953