### PR TITLE
compiler options exporter for docs.scala-lang

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -422,6 +422,22 @@ lazy val reflect = configureAsSubproject(project)
   )
   .dependsOn(library)
 
+lazy val exporter = configureAsSubproject(project)
+  .dependsOn(compiler, reflect, library)
+  .settings(clearSourceAndResourceDirectories)
+  .settings(commonSettings)
+  .settings(disableDocs)
+  .settings(disablePublishing)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.fasterxml.jackson.core" % "jackson-core" % "2.9.5",
+      "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.5",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.5",
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.9.5",
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.5"
+    )
+  )
+
 lazy val compiler = configureAsSubproject(project)
   .settings(generatePropertiesFileSettings)
   .settings(generateBuildCharacterFileSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -422,7 +422,7 @@ lazy val reflect = configureAsSubproject(project)
   )
   .dependsOn(library)
 
-lazy val exporter = configureAsSubproject(project)
+lazy val compilerOptionsExporter = Project("compilerOptionsExporter", file(".") / "src" / "compilerOptionsExporter")
   .dependsOn(compiler, reflect, library)
   .settings(clearSourceAndResourceDirectories)
   .settings(commonSettings)
@@ -953,7 +953,7 @@ lazy val root: Project = (project in file("."))
         .withRecompileOnMacroDef(false) //     // macros in library+reflect are hard-wired to implementations with `FastTrack`.
     }
   )
-  .aggregate(library, reflect, compiler, interactive, repl, replJline, replJlineEmbedded,
+  .aggregate(library, reflect, compiler, compilerOptionsExporter, interactive, repl, replJline, replJlineEmbedded,
     scaladoc, scalap, partestExtras, junit, libraryAll, scalaDist).settings(
     sources in Compile := Seq.empty,
     onLoadMessage := """|*** Welcome to the sbt build definition for Scala! ***
@@ -1149,7 +1149,9 @@ intellij := {
       moduleDeps(scalacheck, config = Test).value,
       moduleDeps(scaladoc).value,
       moduleDeps(scalap).value,
-      moduleDeps(testP).value)
+      moduleDeps(testP).value,
+      moduleDeps(compilerOptionsExporter).value
+    )
   }
 
   def moduleDep(name: String, jars: Seq[File]) = {

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -530,7 +530,7 @@ class MutableSettings(val errorFn: String => Unit)
     name: String,
     val arg: String,
     descr: String,
-    initial: ScalaVersion,
+    val initial: ScalaVersion,
     default: Option[ScalaVersion])
   extends Setting(name, descr) {
     type T = ScalaVersion
@@ -631,7 +631,7 @@ class MutableSettings(val errorFn: String => Unit)
    */
   class MultiChoiceSetting[E <: MultiChoiceEnumeration] private[nsc](
     name: String,
-    helpArg: String,
+    val helpArg: String,
     descr: String,
     val domain: E,
     val default: Option[List[String]]
@@ -838,7 +838,7 @@ class MutableSettings(val errorFn: String => Unit)
    */
   class ChoiceSetting private[nsc](
     name: String,
-    helpArg: String,
+    val helpArg: String,
     descr: String,
     override val choices: List[String],
     val default: String,
@@ -893,7 +893,7 @@ class MutableSettings(val errorFn: String => Unit)
   class PhasesSetting private[nsc](
     name: String,
     descr: String,
-    default: String
+    val default: String
   ) extends Setting(name, mkPhasesHelp(descr, default)) with Clearable {
     private[nsc] def this(name: String, descr: String) = this(name, descr, "")
 

--- a/src/compilerOptionsExporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
+++ b/src/compilerOptionsExporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
@@ -152,5 +152,7 @@ object ScalaCompilerOptionsExporter {
     mapper
       .writer(new DefaultPrettyPrinter())
       .writeValue(writer, source)
+    // TODO: println can be deleted if write can write to file
+    println(writer.toString)
   }
 }

--- a/src/compilerOptionsExporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
+++ b/src/compilerOptionsExporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
@@ -60,6 +60,8 @@ object ScalaCompilerOptionsExporter {
   }
 
   def main(args: Array[String]): Unit = {
+    val writer = new java.io.StringWriter(2000)
+
     val runtimeMirror = scala.reflect.runtime.currentMirror
 
     val settings = new scala.tools.nsc.Settings(s => ())
@@ -147,9 +149,8 @@ object ScalaCompilerOptionsExporter {
       .registerModule(DefaultScalaModule)
       .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
 
-    val yaml = mapper
+    mapper
       .writer(new DefaultPrettyPrinter())
-      .writeValueAsString(source)
-    println(yaml)
+      .writeValue(writer, source)
   }
 }

--- a/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
+++ b/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
@@ -32,7 +32,7 @@ object ScalaCompilerOptionsExporter {
     option: String,
     schema: Schema,
     description: String,
-    abbreviation: Option[String] = None,
+    abbreviations: Seq[String] = Seq.empty,
     deprecated: Option[String] = None,
     note: Option[String] = None
   )
@@ -87,8 +87,14 @@ object ScalaCompilerOptionsExporter {
           case str: settings.StringSetting => new Schema(_type="String", arg = Some(str.arg), default = Some(str.default))
           case ms: settings.MultiStringSetting => new Schema(_type="String", multiple = Some(true), arg = Some(ms.arg))
         }
-        new ScalacOption(option = s.name, schema = schema, description = s.helpDescription,
-          deprecated = Some("EXPLAIN_ALTERNATIVE").filter(_ => s.helpDescription.toLowerCase.contains("deprecated")))
+
+        new ScalacOption(
+          option = s.name,
+          schema = schema,
+          description = s.helpDescription,
+          abbreviations = s.abbreviations,
+          deprecated = Some("EXPLAIN_ALTERNATIVE").filter(_ => s.helpDescription.toLowerCase.contains("deprecated"))
+        )
     }
 
 

--- a/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
+++ b/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
@@ -100,7 +100,7 @@ object ScalaCompilerOptionsExporter {
 
     val categoriezed = extractedSettings.groupBy { option =>
       val name = option.option
-      if (name.startsWith("-Xfatal-warnings") || name.startsWith("-Ywarn")) {
+      if (name.startsWith("-Xfatal-warnings") || name == "-Xlint" || name.startsWith("-Ywarn")) {
         WarningSettings
       } else if (name.startsWith("-X")) {
         AdvancedSettings

--- a/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
+++ b/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
@@ -5,7 +5,7 @@ import collection.JavaConverters._
 import com.fasterxml.jackson.annotation._
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.dataformat.yaml.{YAMLFactory, YAMLGenerator}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 
 object ScalaCompilerOptionsExporter {
@@ -119,8 +119,9 @@ object ScalaCompilerOptionsExporter {
       new Section(key, Some("ADD_NICE_DESCRIPTION_HERE"),options = options)
     }
 
-    val mapper = new ObjectMapper(new YAMLFactory())
-    mapper
+    val yamlFactory = new YAMLFactory()
+      .disable(YAMLGenerator.Feature.SPLIT_LINES)
+    val mapper = new ObjectMapper(yamlFactory)
       .registerModule(DefaultScalaModule)
       .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
 

--- a/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
+++ b/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
@@ -47,6 +47,12 @@ object ScalaCompilerOptionsExporter {
   )
   case class Choice(choice: String, description: Option[String] = None, deprecated: Option[String] = None)
 
+  private val quoted = """`([^`']+)'""".r
+
+  def markdownifyBackquote(string: String) : String = {
+    quoted.replaceAllIn(string, "`$1`")
+  }
+
   def main(args: Array[String]): Unit = {
     val runtimeMirror = scala.reflect.runtime.currentMirror
 
@@ -63,7 +69,7 @@ object ScalaCompilerOptionsExporter {
       } yield {
         Choice(
           choice,
-          description = Option(d).filter(_.nonEmpty),
+          description = Option(d).map(markdownifyBackquote).filter(_.nonEmpty),
           deprecated = Some("EXPLAIN_ALTERNATIVE").filter(_ => d.toLowerCase.contains("deprecated"))
         )
       }
@@ -91,7 +97,7 @@ object ScalaCompilerOptionsExporter {
         new ScalacOption(
           option = s.name,
           schema = schema,
-          description = s.helpDescription,
+          description = markdownifyBackquote(s.helpDescription),
           abbreviations = s.abbreviations,
           deprecated = Some("EXPLAIN_ALTERNATIVE").filter(_ => s.helpDescription.toLowerCase.contains("deprecated"))
         )

--- a/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
+++ b/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
@@ -104,7 +104,7 @@ object ScalaCompilerOptionsExporter {
         WarningSettings
       } else if (name.startsWith("-X")) {
         AdvancedSettings
-      } else if (name.startsWith("-Y") || name.startsWith("-opt")) {
+      } else if (name.startsWith("-Y") || name.startsWith("-opt") && name != "-optimise") {
         PrivateSettings
       } else if (name.startsWith("-P")) {
         PluginSettings

--- a/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
+++ b/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
@@ -19,6 +19,7 @@ object ScalaCompilerOptionsExporter {
   val AdvancedSettings = Category("Advanced Settings", 3)
   val PrivateSettings = Category("Private Settings", 4)
   val WarningSettings = Category("Warning Settings", 5)
+  val IDESpecificSettings = Category("IDE Specific Settings", 6)
 
   trait JacksonWorkaround {
      val category: String
@@ -121,6 +122,8 @@ object ScalaCompilerOptionsExporter {
       val name = option.option
       if (name.startsWith("-Xfatal-warnings") || name == "-Xlint" || name.startsWith("-Ywarn")) {
         WarningSettings
+      } else if (name.startsWith("-Ypresentation")) {
+        IDESpecificSettings
       } else if (name.startsWith("-X")) {
         AdvancedSettings
       } else if (name.startsWith("-Y") || name.startsWith("-opt") && name != "-optimise") {

--- a/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
+++ b/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
@@ -83,23 +83,31 @@ object ScalaCompilerOptionsExporter {
     val extractedSettings : List[ScalacOption] = accessors.map(acc => instanceMirror.reflectMethod(acc).apply()).collect {
       case s: settings.Setting =>
         val schema = s match {
-          case b: settings.BooleanSetting => new Schema(_type="Boolean")
-          case i: settings.IntSetting => new Schema(_type="Int", default = Some(i.default), min = i.range.map(_._1), max = i.range.map(_._2))
+          case b: settings.BooleanSetting =>
+            Schema(_type = "Boolean")
+          case i: settings.IntSetting =>
+            Schema(_type="Int", default = Some(i.default), min = i.range.map(_._1), max = i.range.map(_._2))
           case c: settings.ChoiceSetting =>
             val choices = mergeChoice(c.choices, c.choicesHelp)
-            new Schema(_type="Choice", arg = Some(c.helpArg).map(dehtmlfy), default = Option(c.default), choices = choices)
+            Schema(_type="Choice", arg = Some(c.helpArg).map(dehtmlfy), default = Option(c.default), choices = choices)
           case mc: settings.MultiChoiceSetting[_] =>
             val choices = mergeChoice(mc.choices, mc.descriptions)
-            new Schema(_type="Choice", multiple = Some(true), arg = Some(mc.helpArg).map(dehtmlfy), choices = choices)
-          case ps: settings.PhasesSetting => new Schema(_type="Phases", default = Option(ps.default))
-          case px: settings.PrefixSetting => new Schema(_type="Prefix")
-          case sv: settings.ScalaVersionSetting => new Schema(_type="ScalaVerion", arg = Some(sv.arg).map(dehtmlfy), default = Some(sv.initial.unparse))
-          case pathStr: settings.PathSetting => new Schema(_type="Path", arg = Some(pathStr.arg), default = Some(pathStr.default))
-          case str: settings.StringSetting => new Schema(_type="String", arg = Some(str.arg).map(dehtmlfy), default = Some(str.default))
-          case ms: settings.MultiStringSetting => new Schema(_type="String", multiple = Some(true), arg = Some(ms.arg).map(dehtmlfy))
+            Schema(_type="Choice", multiple = Some(true), arg = Some(mc.helpArg).map(dehtmlfy), choices = choices)
+          case ps: settings.PhasesSetting =>
+            Schema(_type="Phases", default = Option(ps.default))
+          case px: settings.PrefixSetting =>
+            Schema(_type="Prefix")
+          case sv: settings.ScalaVersionSetting =>
+            Schema(_type="ScalaVersion", arg = Some(sv.arg).map(dehtmlfy), default = Some(sv.initial.unparse))
+          case pathStr: settings.PathSetting =>
+            Schema(_type="Path", arg = Some(pathStr.arg), default = Some(pathStr.default))
+          case str: settings.StringSetting =>
+            Schema(_type="String", arg = Some(str.arg).map(dehtmlfy), default = Some(str.default))
+          case ms: settings.MultiStringSetting =>
+            Schema(_type="String", multiple = Some(true), arg = Some(ms.arg).map(dehtmlfy))
         }
 
-        new ScalacOption(
+        ScalacOption(
           option = s.name,
           schema = schema,
           description = dehtmlfy(markdownifyBackquote(s.helpDescription)),
@@ -127,7 +135,7 @@ object ScalaCompilerOptionsExporter {
     }
 
     val source = categoriezed.toSeq.sortBy(_._1).map { case (key, options) =>
-      new Section(key, Some("ADD_NICE_DESCRIPTION_HERE"),options = options)
+      Section(key, Some("ADD_NICE_DESCRIPTION_HERE"),options = options)
     }
 
     val yamlFactory = new YAMLFactory()

--- a/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
+++ b/src/exporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
@@ -1,0 +1,126 @@
+package scala.tools.nsc
+
+import scala.reflect.runtime.universe._
+import collection.JavaConverters._
+import com.fasterxml.jackson.annotation._
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
+object ScalaCompilerOptionsExporter {
+
+  case class Category(name: String, load: Int) extends Ordered[Category] {
+    def compare(that: Category): Int = (this.load) compare (that.load)
+  }
+  val StandardSettings = Category("Standard Settings", 0)
+  val JVMSettings = Category("JVM Settings", 1)
+  val PluginSettings = Category("Plugin Settings", 2)
+  val AdvancedSettings = Category("Advanced Settings", 3)
+  val PrivateSettings = Category("Private Settings", 4)
+  val WarningSettings = Category("Warning Settings", 5)
+
+  trait JacksonWorkaround {
+     val category: String
+  }
+  @JsonIgnoreProperties(Array("_category"))
+  @JsonPropertyOrder(Array("category", "description", "options"))
+  case class Section(_category: Category, description: Option[String], options: List[ScalacOption]) extends JacksonWorkaround{
+    val category: String = _category.name
+  }
+  case class ScalacOption(
+    option: String,
+    schema: Schema,
+    description: String,
+    abbreviation: Option[String] = None,
+    deprecated: Option[String] = None,
+    note: Option[String] = None
+  )
+  case class Schema(
+    @JsonProperty("type") _type: String,
+    arg: Option[String] = None,
+    multiple: Option[Boolean] = None,
+    default: Option[Any] = None,
+    choices: Seq[Choice] = Seq.empty,
+    min: Option[Any] = None,
+    max: Option[Any] = None
+  )
+  case class Choice(choice: String, description: Option[String] = None, deprecated: Option[String] = None)
+
+  def main(args: Array[String]): Unit = {
+    val runtimeMirror = scala.reflect.runtime.currentMirror
+
+    val settings = new scala.tools.nsc.Settings(s => ())
+    val instanceMirror = runtimeMirror.reflect(settings)
+    val sortedInOrderOfAppearance = runtimeMirror.classSymbol(settings.getClass).toType.members.sorted
+    val accessors = sortedInOrderOfAppearance.collect {
+      case m: MethodSymbol if m.isGetter && m.isPublic => m
+    }
+
+    def mergeChoice(labels: Seq[String], descriptions: Seq[String]): Seq[Choice] = {
+      for {
+        (choice, d) <- (labels zipAll (descriptions, "", ""))
+      } yield {
+        Choice(
+          choice,
+          description = Option(d).filter(_.nonEmpty),
+          deprecated = Some("EXPLAIN_ALTERNATIVE").filter(_ => d.toLowerCase.contains("deprecated"))
+        )
+      }
+    }
+
+    val extractedSettings : List[ScalacOption] = accessors.map(acc => instanceMirror.reflectMethod(acc).apply()).collect {
+      case s: settings.Setting =>
+        val schema = s match {
+          case b: settings.BooleanSetting => new Schema(_type="Boolean")
+          case i: settings.IntSetting => new Schema(_type="Int", default = Some(i.default), min = i.range.map(_._1), max = i.range.map(_._2))
+          case c: settings.ChoiceSetting =>
+            val choices = mergeChoice(c.choices, c.choicesHelp)
+            new Schema(_type="Choice", arg = Some(c.helpArg), default = Option(c.default), choices = choices)
+          case mc: settings.MultiChoiceSetting[_] =>
+            val choices = mergeChoice(mc.choices, mc.descriptions)
+            new Schema(_type="Choice", multiple = Some(true), arg = Some(mc.helpArg), choices = choices)
+          case ps: settings.PhasesSetting => new Schema(_type="Phases", default = Option(ps.default))
+          case px: settings.PrefixSetting => new Schema(_type="Prefix")
+          case sv: settings.ScalaVersionSetting => new Schema(_type="ScalaVerion", arg = Some(sv.arg), default = Some(sv.initial.unparse))
+          case pathStr: settings.PathSetting => new Schema(_type="Path", arg = Some(pathStr.arg), default = Some(pathStr.default))
+          case str: settings.StringSetting => new Schema(_type="String", arg = Some(str.arg), default = Some(str.default))
+          case ms: settings.MultiStringSetting => new Schema(_type="String", multiple = Some(true), arg = Some(ms.arg))
+        }
+        new ScalacOption(option = s.name, schema = schema, description = s.helpDescription,
+          deprecated = Some("EXPLAIN_ALTERNATIVE").filter(_ => s.helpDescription.toLowerCase.contains("deprecated")))
+    }
+
+
+    val categoriezed = extractedSettings.groupBy { option =>
+      val name = option.option
+      if (name.startsWith("-Xfatal-warnings") || name.startsWith("-Ywarn")) {
+        WarningSettings
+      } else if (name.startsWith("-X")) {
+        AdvancedSettings
+      } else if (name.startsWith("-Y") || name.startsWith("-opt")) {
+        PrivateSettings
+      } else if (name.startsWith("-P")) {
+        PluginSettings
+      } else if (name.startsWith("-J") || name.startsWith("-D") || name.startsWith("-nobootcp")) {
+        JVMSettings
+      } else {
+        StandardSettings
+      }
+    }
+
+    val source = categoriezed.toSeq.sortBy(_._1).map { case (key, options) =>
+      new Section(key, Some("ADD_NICE_DESCRIPTION_HERE"),options = options)
+    }
+
+    val mapper = new ObjectMapper(new YAMLFactory())
+    mapper
+      .registerModule(DefaultScalaModule)
+      .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+
+    val yaml = mapper
+      .writer(new DefaultPrettyPrinter())
+      .writeValueAsString(source)
+    println(yaml)
+  }
+}


### PR DESCRIPTION
Extract compiler options and generate YAML for https://docs.scala-lang.org/overviews/compiler-options/index.html

This was part of https://github.com/scala/docs.scala-lang/pull/1063