### PR TITLE
Support @Repeatable Java annotations.

### DIFF
--- a/src/reflect/mima-filters/2.12.0.forwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.forwards.excludes
@@ -9,6 +9,7 @@ ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.PlainNioFile")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedOps.newMappedBaseTypeSeq")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUniverse.newMappedBaseTypeSeq")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUniverse.statistics")
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaMirrors#JavaMirror#JavaAnnotationProxy.transformArgs")
 
 ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.FileZipArchive$LazyEntry")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive.closeZipFile")

--- a/src/reflect/scala/reflect/internal/AnnotationInfos.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationInfos.scala
@@ -338,6 +338,9 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
     def argAtIndex(index: Int): Option[Tree] =
       if (index < args.size) Some(args(index)) else None
 
+    def transformArgs(f: List[Tree] => List[Tree]): AnnotationInfo =
+      new CompleteAnnotationInfo(atp, f(args), assocs)
+
     override def hashCode = atp.## + args.## + assocs.##
     override def equals(other: Any) = other match {
       case x: AnnotationInfo  => (atp == x.atp) && (args == x.args) && (assocs == x.assocs)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1118,9 +1118,10 @@ trait Definitions extends api.StandardDefinitions {
     lazy val ClassfileAnnotationClass   = requiredClass[scala.annotation.ClassfileAnnotation]
     lazy val StaticAnnotationClass      = requiredClass[scala.annotation.StaticAnnotation]
 
-    // Java retention annotations
+    // Java annotation annotations
     lazy val AnnotationRetentionAttr       = requiredClass[java.lang.annotation.Retention]
     lazy val AnnotationRetentionPolicyAttr = requiredClass[java.lang.annotation.RetentionPolicy]
+    lazy val AnnotationRepeatableAttr      = requiredClass[java.lang.annotation.Repeatable]
 
     // Annotations
     lazy val BridgeClass                = requiredClass[scala.annotation.bridge]

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -176,6 +176,8 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
           TermName(m.getName) -> toAnnotArg(m.getReturnType -> m.invoke(jann))
         )
       )
+
+      override def transformArgs(f: List[Tree] => List[Tree]) = this
     }
 
     def reflect[T: ClassTag](obj: T): InstanceMirror = new JavaInstanceMirror(obj)

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -384,6 +384,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.StaticAnnotationClass
     definitions.AnnotationRetentionAttr
     definitions.AnnotationRetentionPolicyAttr
+    definitions.AnnotationRepeatableAttr
     definitions.BridgeClass
     definitions.ElidableMethodClass
     definitions.ImplicitNotFoundClass

--- a/test/files/neg/t9529.check
+++ b/test/files/neg/t9529.check
@@ -1,0 +1,4 @@
+t9529.scala:7: error: Java annotation Resource may not appear multiple times on class TooMany
+class TooMany
+      ^
+one error found

--- a/test/files/neg/t9529.scala
+++ b/test/files/neg/t9529.scala
@@ -1,0 +1,7 @@
+@deprecated("foo", "")
+@deprecated("bar", "")
+class `scala ftw`
+
+@javax.annotation.Resource(name = "baz")
+@javax.annotation.Resource(name = "quux")
+class TooMany

--- a/test/files/pos/annotations.scala
+++ b/test/files/pos/annotations.scala
@@ -103,8 +103,10 @@ object Test3 {
 class Test4 {
   @Ann3(arr = Array("dlkfj", "DSF"))
   @Ann4(i = 2908)
-  @Ann4(i = Test3.i)
   @Ann5(value = classOf[Int])
-  @Ann5(Test3.cls)
   def foo {}
+
+  @Ann4(i = Test3.i)
+  @Ann5(Test3.cls)
+  def bar {}
 }

--- a/test/files/pos/attributes.scala
+++ b/test/files/pos/attributes.scala
@@ -19,8 +19,6 @@ object O5 {
   final val n = 2;
   @SerialVersionUID(0)  class C1;
   @SerialVersionUID(n)  class C2;
-  @SerialVersionUID(0) @SerialVersionUID(n)  class C3;
-  @SerialVersionUID(0) @SerialVersionUID(n)  class C4;
 }
 
 abstract class A1 {

--- a/test/files/run/reify_ann1b.check
+++ b/test/files/run/reify_ann1b.check
@@ -1,33 +1,38 @@
 reify_ann1b.scala:6: warning: Implementation restriction: subclassing Classfile does not
 make your annotation visible at runtime.  If that is what
 you want, you must write the annotation class in Java.
-class ann(bar: String) extends annotation.ClassfileAnnotation
+class ann0(bar: String) extends annotation.ClassfileAnnotation
+      ^
+reify_ann1b.scala:7: warning: Implementation restriction: subclassing Classfile does not
+make your annotation visible at runtime.  If that is what
+you want, you must write the annotation class in Java.
+class ann1(bar: String) extends annotation.ClassfileAnnotation
       ^
 {
-  @new ann(bar = "1a") @new ann(bar = "1b") class C[@new ann(bar = "2a") @new ann(bar = "2b") T] extends AnyRef {
-    @new ann(bar = "3a") @new ann(bar = "3b") <paramaccessor> private[this] val x: T @ann(bar = "4a") @ann(bar = "4b") = _;
-    def <init>(@new ann(bar = "3a") @new ann(bar = "3b") x: T @ann(bar = "4a") @ann(bar = "4b")) = {
+  @new ann0(bar = "1a") @new ann1(bar = "1b") class C[@new ann0(bar = "2a") @new ann1(bar = "2b") T] extends AnyRef {
+    @new ann0(bar = "3a") @new ann1(bar = "3b") <paramaccessor> private[this] val x: T @ann0(bar = "4a") @ann1(bar = "4b") = _;
+    def <init>(@new ann0(bar = "3a") @new ann1(bar = "3b") x: T @ann0(bar = "4a") @ann1(bar = "4b")) = {
       super.<init>();
       ()
     };
-    @new ann(bar = "5a") @new ann(bar = "5b") def f(x: Int @ann(bar = "6a") @ann(bar = "6b")) = {
-      @new ann(bar = "7a") @new ann(bar = "7b") val r = x.$plus(3): @ann(bar = "8a"): @ann(bar = "8b");
-      val s = (4: Int @ann(bar = "9a") @ann(bar = "9b"));
+    @new ann0(bar = "5a") @new ann1(bar = "5b") def f(x: Int @ann0(bar = "6a") @ann1(bar = "6b")) = {
+      @new ann0(bar = "7a") @new ann1(bar = "7b") val r = x.$plus(3): @ann0(bar = "8a"): @ann1(bar = "8b");
+      val s = (4: Int @ann0(bar = "9a") @ann1(bar = "9b"));
       r.$plus(s)
     }
   };
   ()
 }
 {
-  @ann(bar = "1a") @ann(bar = "1b") class C[@ann(bar = "2a") @ann(bar = "2b") T] extends AnyRef {
-    @ann(bar = "3a") @ann(bar = "3b") <paramaccessor> private[this] val x: T @ann(bar = "4b") @ann(bar = "4a") = _;
-    def <init>(@ann(bar = "3a") @ann(bar = "3b") x: T @ann(bar = "4b") @ann(bar = "4a")): C[T] = {
+  @ann0(bar = "1a") @ann1(bar = "1b") class C[@ann0(bar = "2a") @ann1(bar = "2b") T] extends AnyRef {
+    @ann0(bar = "3a") @ann1(bar = "3b") <paramaccessor> private[this] val x: T @ann1(bar = "4b") @ann0(bar = "4a") = _;
+    def <init>(@ann0(bar = "3a") @ann1(bar = "3b") x: T @ann1(bar = "4b") @ann0(bar = "4a")): C[T] = {
       C.super.<init>();
       ()
     };
-    @ann(bar = "5a") @ann(bar = "5b") def f(x: Int @ann(bar = "6b") @ann(bar = "6a")): Int = {
-      @ann(bar = "7a") @ann(bar = "7b") val r: Int @ann(bar = "8b") @ann(bar = "8a") = ((x.+(3): Int @ann(bar = "8a")): Int @ann(bar = "8b") @ann(bar = "8a"));
-      val s: Int @ann(bar = "9b") @ann(bar = "9a") = (4: Int @ann(bar = "9b") @ann(bar = "9a"));
+    @ann0(bar = "5a") @ann1(bar = "5b") def f(x: Int @ann1(bar = "6b") @ann0(bar = "6a")): Int = {
+      @ann0(bar = "7a") @ann1(bar = "7b") val r: Int @ann1(bar = "8b") @ann0(bar = "8a") = ((x.+(3): Int @ann0(bar = "8a")): Int @ann1(bar = "8b") @ann0(bar = "8a"));
+      val s: Int @ann1(bar = "9b") @ann0(bar = "9a") = (4: Int @ann1(bar = "9b") @ann0(bar = "9a"));
       r.+(s)
     }
   };

--- a/test/files/run/reify_ann1b.scala
+++ b/test/files/run/reify_ann1b.scala
@@ -3,15 +3,16 @@ import scala.reflect.runtime.{universe => ru}
 import scala.reflect.runtime.{currentMirror => cm}
 import scala.tools.reflect.ToolBox
 
-class ann(bar: String) extends annotation.ClassfileAnnotation
+class ann0(bar: String) extends annotation.ClassfileAnnotation
+class ann1(bar: String) extends annotation.ClassfileAnnotation
 
 object Test extends App {
   // test 1: reify
   val tree = reify{
-    @ann(bar="1a") @ann(bar="1b") class C[@ann(bar="2a") @ann(bar="2b") T](@ann(bar="3a") @ann(bar="3b") x: T @ann(bar="4a") @ann(bar="4b")) {
-      @ann(bar="5a") @ann(bar="5b") def f(x: Int @ann(bar="6a") @ann(bar="6b")) = {
-        @ann(bar="7a") @ann(bar="7b") val r = (x + 3): @ann(bar="8a") @ann(bar="8b")
-        val s = 4: Int @ann(bar="9a") @ann(bar="9b")
+    @ann0(bar="1a") @ann1(bar="1b") class C[@ann0(bar="2a") @ann1(bar="2b") T](@ann0(bar="3a") @ann1(bar="3b") x: T @ann0(bar="4a") @ann1(bar="4b")) {
+      @ann0(bar="5a") @ann1(bar="5b") def f(x: Int @ann0(bar="6a") @ann1(bar="6b")) = {
+        @ann0(bar="7a") @ann1(bar="7b") val r = (x + 3): @ann0(bar="8a") @ann1(bar="8b")
+        val s = 4: Int @ann0(bar="9a") @ann1(bar="9b")
         r + s
       }
     }

--- a/test/files/run/t9529-types.check
+++ b/test/files/run/t9529-types.check
@@ -1,0 +1,15 @@
+[[syntax trees at end of                   pickler]] // newSource1.scala
+package <empty> {
+  import anns._;
+  abstract trait Foo extends AnyRef with Int @anns.TypeAnn_0(value = "b") @anns.TypeAnn_0(value = "a") => String @anns.TypeAnn_0(value = "y") @anns.TypeAnn_0(value = "x") {
+    type Meh = Any @anns.TypeAnn_0(value = "q") @anns.TypeAnn_0(value = "p")
+  }
+}
+
+[[syntax trees at end of                 refchecks]] // newSource1.scala
+package <empty> {
+  abstract trait Foo extends AnyRef with Int @anns.TypeAnn_0.Anns(value = [anns.TypeAnn_0(value = "b"), anns.TypeAnn_0(value = "a")]) => String @anns.TypeAnn_0.Anns(value = [anns.TypeAnn_0(value = "y"), anns.TypeAnn_0(value = "x")]) {
+    type Meh = Any @anns.TypeAnn_0.Anns(value = [anns.TypeAnn_0(value = "q"), anns.TypeAnn_0(value = "p")])
+  }
+}
+

--- a/test/files/run/t9529-types/Test_1.scala
+++ b/test/files/run/t9529-types/Test_1.scala
@@ -1,0 +1,29 @@
+/* evidently annotations on types don't make it into bytecode yet, even though
+ * such a thing is allowed in Java 8 and onwards. Here's a test that it'll work
+ * with repeatable annotations anyways.
+ *
+ * nb. currently multiple annotations on type trees get reversed by typer
+ */
+
+import scala.tools.partest._
+
+import anns._
+
+@TypeAnn_0("")
+object Test extends DirectTest {
+
+  override def extraSettings: String =
+    s"-usejavacp -cp ${testOutput.path} -Xprint:pic,ref -Ystop-after:ref -d ${testOutput.path}"
+
+  override def code =
+    """import anns._
+      |trait Foo extends (
+      |  (Int @TypeAnn_0("a") @TypeAnn_0("b"))
+      |    => (String @TypeAnn_0("x") @TypeAnn_0("y"))
+      |) {
+      |  type Meh = Any@TypeAnn_0("p")@TypeAnn_0("q")
+      |}
+    """.stripMargin
+
+  override def show() = compile()
+}

--- a/test/files/run/t9529-types/TypeAnn_0.java
+++ b/test/files/run/t9529-types/TypeAnn_0.java
@@ -1,0 +1,16 @@
+package anns;
+
+import java.lang.annotation.*;
+
+@Repeatable(TypeAnn_0.Anns.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE_USE)
+public @interface TypeAnn_0 {
+    String value();
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    public static @interface Anns {
+        TypeAnn_0[] value();
+    }
+}

--- a/test/files/run/t9529.check
+++ b/test/files/run/t9529.check
@@ -1,0 +1,16 @@
+A: List()
+B: List(@javax.annotation.Resource(shareable=true, lookup=, name=B, description=, authenticationType=CONTAINER, type=class java.lang.Object, mappedName=))
+C: List(@anns.Ann_0(name=C, value=see))
+D: List(@anns.Ann_0$Container(value=[@anns.Ann_0(name=D, value=dee), @anns.Ann_0(name=D, value=dye)]))
+
+x: List(@anns.Ann_0(name=x, value=eks))
+y: List(@anns.Ann_0$Container(value=[@anns.Ann_0(name=y, value=why), @anns.Ann_0(name=y, value=wye)]))
+
+t: List(@anns.Ann_0(name=t, value=tee))
+u: List(@anns.Ann_0$Container(value=[@anns.Ann_0(name=u, value=you), @anns.Ann_0(name=u, value=yew)]))
+
+1: List(@anns.Ann_0(name=1, value=one))
+2: List(@anns.Ann_0$Container(value=[@anns.Ann_0(name=2, value=two), @anns.Ann_0(name=2, value=tew)]))
+
+List(@anns.Ann_0$Container(value=[@anns.Ann_0(name=<init>, value=constructor), @anns.Ann_0(name=<init>, value=initializer)]))
+

--- a/test/files/run/t9529/Ann_0.java
+++ b/test/files/run/t9529/Ann_0.java
@@ -1,0 +1,15 @@
+package anns;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(Ann_0.Container.class)
+public @interface Ann_0 {
+    String name();
+    String value();
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public static @interface Container {
+        public Ann_0[] value() default {};
+    }
+}

--- a/test/files/run/t9529/Test_1.scala
+++ b/test/files/run/t9529/Test_1.scala
@@ -1,0 +1,59 @@
+import java.lang.reflect._
+import anns._
+
+class A
+@javax.annotation.Resource(name = "B") class B
+@Ann_0(name = "C", value = "see") class C
+@Ann_0(name = "D", value = "dee") @Ann_0(name = "D", value = "dye") class D
+
+class Test @Ann_0(name = "<init>", value = "constructor") @Ann_0(name = "<init>", value = "initializer") () {
+  @Ann_0(name = "x", value = "eks") val x = 1
+  @Ann_0(name = "y", value = "why") @Ann_0(name = "y", value = "wye") val y = 2
+
+  @Ann_0(name = "t", value = "tee") def t = 1
+  @Ann_0(name = "u", value = "you") @Ann_0(name = "u", value = "yew") def u = 2
+
+  def meh(
+    @Ann_0(name = "1", value = "one") `1`: Int,
+    @Ann_0(name = "2", value = "two") @Ann_0(name = "2", value = "tew") `2`: Int,
+  ) = ()
+
+  // todo: annotations on types
+  // todo? annotaitons on packages
+}
+
+object Test extends App {
+  val cls_test = classOf[Test]
+
+  prints {
+    List(classOf[A], classOf[B], classOf[C], classOf[D])
+      .map(cls => s"${cls.getName}: ${anns(cls)}")
+  }
+
+  prints {
+    List("x", "y")
+      .map(cls_test.getDeclaredField)
+      .map(f => s"${f.getName}: ${anns(f)}")
+  }
+
+  prints {
+    List("t", "u")
+      .map(cls_test.getDeclaredMethod(_))
+      .map(m => s"${m.getName}: ${anns(m)}")
+  }
+
+  prints {
+    cls_test
+      .getDeclaredMethod("meh", classOf[Int], classOf[Int])
+      .getParameters.toList
+      .map(p => s"${p.getName}: ${anns(p)}")
+  }
+
+  println {
+    anns(cls_test.getConstructor()).map(_.toString)
+  } ; println()
+
+  def anns(ae: AnnotatedElement) =
+    ae.getAnnotations.toList.filterNot(_.isInstanceOf[reflect.ScalaSignature])
+  def prints(l: List[String]) = { println(l mkString "\n") ; println() }
+}


### PR DESCRIPTION
Currently, duplicate classfile annotations cause a runtime crash when the JVM sees them (due to a call to `getAnnotations` or the like). Do instead exactly what Java does (since JEP-120): if the annotation type is (meta-)annotated with `@Repeatable`, wrap the annotations in an array and annotate the original element with a new annotation of the type given by `Repeatable#value`.

It is now an error to have multiple annotations on the same tree with the same `typeSymbol` if the symbol is a classfile annotation.

Fixes scala/bug#9529.