### PR TITLE
Partest supports Crash?! again and X failure in terse mode

### DIFF
--- a/src/partest/scala/tools/partest/ConsoleLog.scala
+++ b/src/partest/scala/tools/partest/ConsoleLog.scala
@@ -48,13 +48,14 @@ class ConsoleLog(colorEnabled: Boolean) {
   def echoMixed(msg: String)   = echo(bold(yellow(msg)))
   def echoWarning(msg: String) = echo(bold(red(msg)))
 
-  def printDot(): Unit = {
+  def printDot(): Unit = printProgress(".")
+  def printEx(): Unit  = printProgress(_failure + "X" + _default)
+  private def printProgress(icon: String): Unit =
     if (dotCount >= DotWidth) {
-      outline("\n.")
+      outline("\n" + icon)
       dotCount = 1
     } else {
-      outline(".")
+      outline(icon)
       dotCount += 1
     }
-  }
 }

--- a/src/partest/scala/tools/partest/TestState.scala
+++ b/src/partest/scala/tools/partest/TestState.scala
@@ -18,6 +18,8 @@ sealed abstract class TestState {
 
   def shortStatus    = if (isOk) "ok" else "!!"
 
+  final def andAlso(next: => TestState): TestState = if (isOk) next else this
+
   override def toString = status
 }
 
@@ -54,6 +56,7 @@ object TestState {
   case class Crash(testFile: java.io.File, caught: Throwable, transcript: Array[String]) extends TestState {
     def what = "crash"
     def reason = s"caught $caught_s - ${caught.getMessage}"
+    override def shortStatus = "?!"
 
     private def caught_s = (caught.getClass.getName split '.').last
     override def transcriptString = nljoin(super.transcriptString, caught_s)

--- a/src/partest/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AbstractRunner.scala
@@ -289,13 +289,14 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
 
   def runTest(testFile: File): TestState = {
     val start = System.nanoTime()
-    val runner = new Runner(testFile, this)
+    val info = TestInfo(testFile)
+    val runner = new Runner(info, this)
     var stopwatchDuration: Option[Long] = None
 
     // when option "--failed" is provided execute test only if log
     // is present (which means it failed before)
     val state =
-    if (config.optFailed && !runner.logFile.canRead)
+    if (config.optFailed && !info.logFile.canRead)
       runner.genPass()
     else {
       val (state, durationMs) =
@@ -304,8 +305,8 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
           case t: Throwable => throw new RuntimeException(s"Error running $testFile", t)
         }
       stopwatchDuration = Some(durationMs)
-      val more = reportTest(state, runner, durationMs, diffOnFail = config.optShowDiff || onlyIndividualTests , logOnFail = config.optShowLog || onlyIndividualTests)
-      runner.cleanup()
+      val more = reportTest(state, info, durationMs, diffOnFail = config.optShowDiff || onlyIndividualTests , logOnFail = config.optShowLog || onlyIndividualTests)
+      runner.cleanup(state)
       if (more.isEmpty) state
       else {
         state match {

--- a/src/partest/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AbstractRunner.scala
@@ -73,26 +73,32 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
     f"$word $testNumber - $testIdent%-40s$reasonString$durationString"
   }
 
-  def reportTest(state: TestState, info: TestInfo, durationMs: Long, diffOnFail: Boolean, logOnFail: Boolean): Unit = {
-    if (terse && state.isOk) printDot()
-    else {
-      echo(statusLine(state, durationMs))
-      if (!state.isOk) {
-        def showLog() = if (info.logFile.canRead) {
-          echo(bold(cyan(s"##### Log file '${info.logFile}' from failed test #####\n")))
-          echo(info.logFile.fileContents)
-        }
+  def reportTest(state: TestState, info: TestInfo, durationMs: Long, diffOnFail: Boolean, logOnFail: Boolean): List[String] = {
+    def errInfo: List[String] = {
+      def showLog() =
+        if (info.logFile.canRead) List (
+          bold(cyan(s"##### Log file '${info.logFile}' from failed test #####\n")),
+          info.logFile.fileContents
+        ) else Nil
+      val diffed = 
         if (diffOnFail) {
           val differ = bold(red("% ")) + "diff "
-          val diffed = state.transcript find (_ startsWith differ)
-          diffed match {
-            case Some(diff) => echo(diff)
+          state.transcript.find(_ startsWith differ) match {
+            case Some(diff) => diff :: Nil
             case None if !logOnFail && !verbose => showLog()
-            case _ => ()
+            case _ => Nil
           }
-        }
-        if (logOnFail) showLog()
-      }
+        } else Nil
+      val logged = if (logOnFail) showLog() else Nil
+      diffed ::: logged
+    }
+    if (terse) {
+      if (state.isOk) { printDot() ; Nil }
+      else { printEx() ; statusLine(state, durationMs) :: errInfo }
+    } else {
+      echo(statusLine(state, durationMs))
+      if (!state.isOk) errInfo.foreach(echo)
+      Nil
     }
   }
 
@@ -244,6 +250,7 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
           passedTests ++= passed
           failedTests ++= failed
           if (failed.nonEmpty) {
+            if (terse) failed.foreach(_.transcript.foreach(echo))
             comment(passFailString(passed.size, failed.size, 0) + " in " + kind)
           }
           echo("")
@@ -297,9 +304,15 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
           case t: Throwable => throw new RuntimeException(s"Error running $testFile", t)
         }
       stopwatchDuration = Some(durationMs)
-      reportTest(state, runner, durationMs, diffOnFail = config.optShowDiff || onlyIndividualTests , logOnFail = config.optShowLog || onlyIndividualTests)
+      val more = reportTest(state, runner, durationMs, diffOnFail = config.optShowDiff || onlyIndividualTests , logOnFail = config.optShowLog || onlyIndividualTests)
       runner.cleanup()
-      state
+      if (more.isEmpty) state
+      else {
+        state match {
+          case f: TestState.Fail => f.copy(transcript = more.toArray)
+          case _ => state
+        }
+      }
     }
     val end = System.nanoTime()
     val durationMs = stopwatchDuration.getOrElse(TimeUnit.NANOSECONDS.toMillis(end - start))
@@ -313,19 +326,8 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
     val futures           = kindFiles map (f => pool submit callable(runTest(f.getAbsoluteFile)))
 
     pool.shutdown()
-    Try (pool.awaitTermination(PartestDefaults.waitTime) {
-      throw TimeoutException(PartestDefaults.waitTime)
-    }) match {
-      case Success(_) => futures map (_.get)
-      case Failure(e) =>
-        e match {
-          case TimeoutException(d)      =>
-            warning("Thread pool timeout elapsed before all tests were complete!")
-          case ie: InterruptedException =>
-            warning("Thread pool was interrupted")
-            ie.printStackTrace()
-        }
-        pool.shutdownNow()     // little point in continuing
+    def aborted = {
+      pool.shutdownNow()     // little point in continuing
       // try to get as many completions as possible, in case someone cares
       val results = for (f <- futures) yield {
         try {
@@ -334,7 +336,23 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
           case _: Throwable => None
         }
       }
-        results.flatten
+      results.flatten
+    }
+    Try (pool.awaitTermination(PartestDefaults.waitTime) {
+      throw TimeoutException(PartestDefaults.waitTime)
+    }) match {
+      case Success(_) => futures.map(_.get)
+      case Failure(TimeoutException(e)) =>
+        warning("Thread pool timeout elapsed before all tests were complete!")
+        aborted
+      case Failure(ie: InterruptedException) =>
+        warning("Thread pool was interrupted")
+        ie.printStackTrace()
+        aborted
+      case Failure(e) =>
+        warning("Unexpected failure")
+        e.printStackTrace()
+        aborted
     }
   }
 }

--- a/src/partest/scala/tools/partest/nest/DirectCompiler.scala
+++ b/src/partest/scala/tools/partest/nest/DirectCompiler.scala
@@ -74,14 +74,17 @@ class DirectCompiler(val runner: Runner) {
   }
 
   def compile(opts0: List[String], sources: List[File]): TestState = {
-    import runner.{ sources => _, _ }
+    import runner.{sources => _, _}, testInfo._
 
     // adding codelib.jar to the classpath
     // codelib provides the possibility to override standard reify
     // this shields the massive amount of reification tests from changes in the API
-    val codeLib = runner.suiteRunner.pathSettings.srcCodeLib.fold[List[Path]](x => Nil, lib => List[Path](lib))
+    val codeLib = suiteRunner.pathSettings.srcCodeLib.fold[List[Path]](x => Nil, lib => List[Path](lib))
     // add the instrumented library version to classpath -- must come first
-    val specializedOverride: List[Path] = if (kind == "specialized") List(runner.suiteRunner.pathSettings.srcSpecLib.fold(sys.error, identity)) else Nil
+    val specializedOverride: List[Path] =
+      if (kind == "specialized")
+        List(suiteRunner.pathSettings.srcSpecLib.fold(sys.error, identity))
+      else Nil
 
     val classPath: List[Path] = specializedOverride ++ codeLib ++ fileManager.testClassPath ++ List[Path](outDir)
 
@@ -108,8 +111,7 @@ class DirectCompiler(val runner: Runner) {
       if (command.files.nonEmpty) reportError(command.files.mkString("flags file may only contain compiler options, found: ", space, ""))
     }
 
-    def ids = sources.map(_.testIdent) mkString space
-    suiteRunner.verbose(s"% scalac $ids")
+    suiteRunner.verbose(s"% scalac ${ sources.map(_.testIdent).mkString(space) }")
 
     def execCompile() =
       if (command.shouldStopWithInfo) {

--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -29,66 +29,52 @@ import FileManager.{compareContents, joinPaths, withTempFile}
 import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
 import scala.util.control.ControlThrowable
 
-trait TestInfo {
+/** pos/t1234.scala or pos/t1234 if dir */
+case class TestInfo(testFile: File) {
   /** pos/t1234 */
-  def testIdent: String
+  val testIdent: String = testFile.testIdent
 
   /** pos */
-  def kind: String
+  val kind: String = parentFile.getName
 
   // inputs
 
-  /** pos/t1234.scala or pos/t1234 if dir */
-  def testFile: File
-
   /** pos/t1234.check */
-  def checkFile: File
+  val checkFile: File = testFile.changeExtension("check")
 
   /** pos/t1234.flags */
-  def flagsFile: File
+  val flagsFile: File = testFile.changeExtension("flags")
 
   // outputs
 
-  /** pos/t1234-pos.obj */
-  def outFile: File
-
   /** pos/t1234-pos.log */
-  def logFile: File
+  val logFile: File = new File(parentFile, s"$fileBase-$kind.log")
+
+  /** pos/t1234-pos.obj */
+  val outFile: File = logFile.changeExtension("obj")
+
+  // enclosing dir
+  def parentFile: File = testFile.getParentFile
+
+  // test file name without extension
+  def fileBase: String = basename(testFile.getName)
 }
 
-/** Run a single test. Rubber meets road. */
-class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestInfo {
+/** Run a single test. */
+class Runner(val testInfo: TestInfo, val suiteRunner: AbstractRunner) {
   private val stopwatch = new Stopwatch()
 
+  import testInfo._
   import suiteRunner.{fileManager => fm, _}
   val fileManager = fm
 
   import fileManager._
 
-  // Override to true to have the outcome of this test displayed
-  // whether it passes or not; in general only failures are reported,
-  // except for a . per passing test to show progress.
-  def isEnumeratedTest = false
-
-  private var _lastState: TestState = null
   private val _transcript = new TestTranscript
 
-  def lastState                   = if (_lastState == null) Uninitialized(testFile) else _lastState
-  def setLastState(s: TestState)  = _lastState = s
-  def pushTranscript(msg: String) = _transcript add msg
-
-  val parentFile = testFile.getParentFile
-  val kind       = parentFile.getName
-  val fileBase   = basename(testFile.getName)
-  val logFile    = new File(parentFile, s"$fileBase-$kind.log")
-  val outFile    = logFile changeExtension "obj"
-  val checkFile  = testFile changeExtension "check"
-  val flagsFile  = testFile changeExtension "flags"
-  val testIdent  = testFile.testIdent // e.g. pos/t1234
+  def pushTranscript(msg: String) = _transcript.add(msg)
 
   lazy val outDir = { outFile.mkdirs() ; outFile }
-
-  type RanOneTest = (Boolean, LogContext)
 
   def showCrashInfo(t: Throwable): Unit = {
     System.err.println(s"Crashed running test $testIdent: " + t)
@@ -104,8 +90,9 @@ class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestIn
       genCrash(t)
   }
 
-  def genPass()                   = Pass(testFile)
+  def genPass(): TestState        = Pass(testFile)
   def genFail(reason: String)     = Fail(testFile, reason, transcript.toArray)
+  def genResult(b: Boolean)       = if (b) genPass() else genFail("predicate failed")
   def genSkip(reason: String)     = Skip(testFile, reason)
   def genTimeout()                = Fail(testFile, "timed out", transcript.toArray)
   def genCrash(caught: Throwable) = Crash(testFile, caught, transcript.toArray)
@@ -133,23 +120,12 @@ class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestIn
     }
   }
 
-  def testPrompt = kind match {
-    case "res"  => "nsc> "
-    case _      => "% "
-  }
-
-  /** Evaluate an action body and update the test state.
-   *  @param failFn optionally map a result to a test state.
-   */
-  def nextTestAction[T](body: => T)(failFn: PartialFunction[T, TestState]): T = {
-    val result = body
-    setLastState( if (failFn isDefinedAt result) failFn(result) else genPass() )
-    result
-  }
-  def nextTestActionExpectTrue(reason: String, body: => Boolean): Boolean = (
-    nextTestAction(body) { case false => genFail(reason) }
-  )
-  def nextTestActionFailing(reason: String): Boolean = nextTestActionExpectTrue(reason, false)
+  /** Evaluate an action body and judge whether it passed. */
+  def nextTestAction[T](body: => T)(eval: PartialFunction[T, TestState]): TestState = eval.applyOrElse(body, (_: T) => genPass)
+  /** If the action does not result in true, fail the action. */
+  def nextTestActionExpectTrue(reason: String, body: => Boolean): TestState = nextTestAction(body) { case false => genFail(reason) }
+  /** Fail the action. */
+  def nextTestActionFailing(reason: String): TestState = nextTestActionExpectTrue(reason, false)
 
   private def assembleTestCommand(outDir: File, logFile: File): List[String] = {
     // check whether there is a ".javaopts" file
@@ -241,7 +217,7 @@ class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestIn
     (pl buffer run) == 0
   }
 
-  private def execTest(outDir: File, logFile: File): Boolean = {
+  private def execTest(outDir: File, logFile: File): TestState = {
     val cmd = assembleTestCommand(outDir, logFile)
 
     pushTranscript((cmd mkString s" \\$EOL  ") + " > " + logFile.getName)
@@ -252,7 +228,7 @@ class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestIn
     }
   }
 
-  def execTestInProcess(classesDir: File, log: File): Boolean = {
+  def execTestInProcess(classesDir: File, log: File): TestState = {
     stopwatch.pause()
     suiteRunner.synchronized {
       stopwatch.start()
@@ -287,25 +263,14 @@ class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestIn
 
       TrapExit(() => run()) match {
         case Left((status, throwable)) if status != 0 =>
-          setLastState(genFail("non-zero exit code"))
-          false
+          genFail("non-zero exit code")
         case _ =>
-          setLastState(genPass())
-          true
+          genPass
       }
     }
   }
 
-  override def toString = s"""Test($testIdent, lastState = $lastState)"""
-
-  // result is unused
-  def newTestWriters() = {
-    val swr = new StringWriter
-    val wr  = new PrintWriter(swr, true)
-    // diff    = ""
-
-    ((swr, wr))
-  }
+  override def toString = s"Test($testIdent)"
 
   def fail(what: Any) = {
     suiteRunner.verbose("scalac: compilation of "+what+" failed\n")
@@ -432,50 +397,34 @@ class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestIn
     }
   }
 
-  def diffIsOk: Boolean = {
+  def diffIsOk: TestState = {
     // always normalize the log first
     normalizeLog()
-    val diff = currentDiff
-    // if diff is not empty, is update needed?
-    val updating: Option[Boolean] = (
-      if (diff == "") None
-      else Some(config.optUpdateCheck)
-    )
     pushTranscript(s"diff $checkFile $logFile")
-    nextTestAction(updating) {
-      case Some(true)  =>
+    currentDiff match {
+      case "" => genPass
+      case diff if config.optUpdateCheck =>
         suiteRunner.verbose("Updating checkfile " + checkFile)
         checkFile writeAll file2String(logFile)
         genUpdated()
-      case Some(false) =>
+      case diff =>
         // Get a word-highlighted diff from git if we can find it
         val bestDiff =
-          if (updating.isEmpty) ""
-          else if (checkFile.canRead)
-            gitRunner match {
-              case None => diff
-              case _    => withTempFile(outFile, fileBase, filteredCheck) { f =>
-                gitDiff(f, logFile) getOrElse diff
-              }
-            }
-          else diff
+          if (!checkFile.canRead) diff
+          else
+            gitRunner.flatMap(_ => withTempFile(outFile, fileBase, filteredCheck)(f =>
+                gitDiff(f, logFile))).getOrElse(diff)
         _transcript append bestDiff
         genFail("output differs")
-        // TestState.fail("output differs", "output differs",
-        // genFail("output differs")
-        // TestState.Fail("output differs", bestDiff)
-      case None        => genPass()  // redundant default case
-    } getOrElse true
+    }
   }
 
   /** 1. Creates log file and output directory.
    *  2. Runs script function, providing log file and output directory as arguments.
    *     2b. or, just run the script without context and return a new context
    */
-  def runInContext(body: => Boolean): (Boolean, LogContext) = {
-    val (swr, wr) = newTestWriters()
-    val succeeded = body
-    (succeeded, LogContext(logFile, swr, wr))
+  def runInContext(body: => TestState): TestState = {
+    body
   }
 
   /** Grouped files in group order, and lex order within each group. */
@@ -562,9 +511,8 @@ class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestIn
     lazy val result = { pushTranscript(description) ; attemptCompile(fs) }
   }
 
-  def compilationRounds(file: File): List[CompileRound] = (
-    (groupedFiles(sources(file)) map mixedCompileGroup).flatten
-  )
+  def compilationRounds(file: File): List[CompileRound] =
+    groupedFiles(sources(file)).map(mixedCompileGroup).flatten
   def mixedCompileGroup(allFiles: List[File]): List[CompileRound] = {
     val (scalaFiles, javaFiles) = allFiles partition (_.isScala)
     val round1                  = if (scalaFiles.isEmpty) None else Some(ScalaAndJava(allFiles))
@@ -573,24 +521,35 @@ class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestIn
     List(round1, round2).flatten
   }
 
-  def runNegTest() = runInContext {
-    val rounds = compilationRounds(testFile)
-
-    // failing means Does Not Compile
-    val failing = rounds find (x => nextTestActionExpectTrue("compilation failed", x.isOk) == false)
-
-    // which means passing if it checks and didn't crash the compiler
+  def runNegTest(): TestState = runInContext {
+    // pass if it checks and didn't crash the compiler
     // or, OK, we'll let you crash the compiler with a FatalError if you supply a check file
     def checked(r: CompileRound) = r.result match {
-      case Crash(_, t, _) if !checkFile.canRead || !t.isInstanceOf[FatalError] => false
-      case _ => diffIsOk
+      case crash @ Crash(_, t, _) if !checkFile.canRead || !t.isInstanceOf[FatalError] => crash
+      case dnc => diffIsOk
     }
 
-    failing map (checked) getOrElse nextTestActionFailing("expected compilation failure")
+    compilationRounds(testFile).find(!_.result.isOk).map(checked).getOrElse(genFail("expected compilation failure"))
   }
 
+  /*
   def runTestCommon(andAlso: => Boolean): (Boolean, LogContext) = runInContext {
-    compilationRounds(testFile).forall(x => nextTestActionExpectTrue("compilation failed", x.isOk)) && andAlso
+    compilationRounds(testFile).forall {
+      case r if r.result.isInstanceOf[Crash] => println("CRASH"); ???
+      case x => nextTestActionExpectTrue("compilation failed", x.isOk) && andAlso
+    }
+    //compilationRounds(testFile).forall(x => nextTestActionExpectTrue("compilation failed", x.isOk)) && andAlso
+  }
+  */
+
+  def runTestCommon(andAlso: => TestState = genPass): TestState = runInContext {
+    // DirectCompiler already says compilation failed
+    //compilationRounds(testFile).foldLeft(genPass)((result, round) => if (result.isOk) round.result else result)
+    val res = compilationRounds(testFile).foldLeft(genPass) {(result, round) =>
+      if (result.isOk) round.result else result
+    }
+
+    if (res.isOk) andAlso else res
   }
 
   def extraClasspath = kind match {
@@ -602,10 +561,9 @@ class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestIn
     case _              => Array.empty[String]
   }
 
-  def runResidentTest() = {
+  def runResidentTest(): TestState = {
     // simulate resident compiler loop
     val prompt = "\nnsc> "
-    val (swr, wr) = newTestWriters()
 
     suiteRunner.verbose(s"$this running test $fileBase")
     val dir = parentFile
@@ -636,7 +594,7 @@ class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestIn
     val command = new CompilerCommand(argList, settings)
     object compiler extends Global(command.settings, reporter)
 
-    def resCompile(line: String): Boolean = {
+    def resCompile(line: String): TestState = {
       // suiteRunner.verbose("compiling "+line)
       val cmdArgs = (line split ' ').toList map (fs => new File(dir, fs).getAbsolutePath)
       // suiteRunner.verbose("cmdArgs: "+cmdArgs)
@@ -653,20 +611,19 @@ class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestIn
         }
       )
     }
-    def loop(): Boolean = {
+    def loop(): TestState = {
       logWriter.print(prompt)
       resReader.readLine() match {
-        case null | ""  => logWriter.close() ; true
-        case line       => resCompile(line) && loop()
+        case null | ""  => logWriter.close() ; genPass
+        case line       => resCompile(line) andAlso loop()
       }
     }
     // res/t687.res depends on ignoring its compilation failure
     // and just looking at the diff, so I made them all do that
     // because this is long enough.
-    if (!Output.withRedirected(logWriter)(try loop() finally resReader.close()))
-      setLastState(genPass())
+    val res = Output.withRedirected(logWriter)(try loop() finally resReader.close())
 
-    (diffIsOk, LogContext(logFile, swr, wr))
+    /*res andAlso*/ diffIsOk
   }
 
   def run(): (TestState, Long) = {
@@ -674,25 +631,25 @@ class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestIn
     logFile.delete()
     stopwatch.start()
 
-    if (kind == "neg" || (kind endsWith "-neg")) runNegTest()
-    else kind match {
-      case "pos"          => runTestCommon(true)
+    val state =  kind match {
+      case "pos"          => runTestCommon()
+      case "neg"          => runNegTest()
       case "res"          => runResidentTest()
       case "scalap"       => runScalapTest()
       case "script"       => runScriptTest()
+      case k if k.endsWith("-neg") => runNegTest()
       case _              => runRunTest()
     }
-
-    (lastState, stopwatch.stop)
+    (state, stopwatch.stop)
   }
 
-  private def runRunTest(): Unit = {
+  private def runRunTest(): TestState = {
     val argsFile = testFile changeExtension "javaopts"
     val javaopts = readOptionsFile(argsFile)
     val execInProcess = PartestDefaults.execInProcess && javaopts.isEmpty && !Set("specialized", "instrumented").contains(testFile.getParentFile.getName)
     def exec() = if (execInProcess) execTestInProcess(outDir, logFile) else execTest(outDir, logFile)
-    def noexec() = suiteRunner.config.optNoExec && { setLastState(genSkip("no-exec: tests compiled but not run")) ; true }
-    runTestCommon(noexec() || exec() && diffIsOk)
+    def noexec() = genSkip("no-exec: tests compiled but not run")
+    runTestCommon(if (suiteRunner.config.optNoExec) noexec() else exec().andAlso(diffIsOk))
   }
 
   private def decompileClass(clazz: Class[_], isPackageObject: Boolean): String = {
@@ -721,7 +678,7 @@ class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestIn
     scalap.Main.decompileScala(bytes, isPackageObject)
   }
 
-  def runScalapTest() = runTestCommon {
+  def runScalapTest(): TestState = runTestCommon {
     val isPackageObject = testFile.getName startsWith "package"
     val className       = testFile.getName.stripSuffix(".scala").capitalize + (if (!isPackageObject) "" else ".package")
     val loader          = ScalaClassLoader.fromURLs(List(outDir.toURI.toURL), this.getClass.getClassLoader)
@@ -729,22 +686,21 @@ class Runner(val testFile: File, val suiteRunner: AbstractRunner) extends TestIn
     diffIsOk
   }
 
-  def runScriptTest() = {
+  def runScriptTest(): TestState = {
     import scala.sys.process._
-    val (swr, wr) = newTestWriters()
 
     val args = file2String(testFile changeExtension "args")
     val cmdFile = if (isWin) testFile changeExtension "bat" else testFile
-    val succeeded = (((cmdFile + " " + args) #> logFile !) == 0) && diffIsOk
+    val succeeded = (((cmdFile + " " + args) #> logFile !) == 0)
 
-    (succeeded, LogContext(logFile, swr, wr))
+    val result = if (succeeded) genPass else genFail(s"script $cmdFile failed to run")
+
+    result andAlso diffIsOk
   }
 
-  def cleanup(): Unit = {
-    if (lastState.isOk)
-      logFile.delete()
-    if (!suiteRunner.debug)
-      Directory(outDir).deleteRecursively()
+  def cleanup(state: TestState): Unit = {
+    if (state.isOk) logFile.delete()
+    if (!suiteRunner.debug) Directory(outDir).deleteRecursively()
   }
 
   // Colorize prompts according to pass/fail

--- a/test/files/res/t687.check
+++ b/test/files/res/t687.check
@@ -4,5 +4,5 @@ nsc> t687/QueryB.scala:3: error: name clash between defined and inherited member
 def equals(x$1: Any): Boolean in class Any and
 override def equals(o: Object): Boolean at line 3
 have same type after erasure: (x$1: Object)Boolean
-  override def equals(o : Object) = false;
+  override def equals(o : Object) = false
                ^

--- a/test/files/res/t687/QueryA.scala
+++ b/test/files/res/t687/QueryA.scala
@@ -1,4 +1,4 @@
-package t687;
+package t687
 trait Query {
-  override def equals(o : Any) = false;
+  override def equals(o : Any) = false
 }

--- a/test/files/res/t687/QueryB.scala
+++ b/test/files/res/t687/QueryB.scala
@@ -1,4 +1,4 @@
-package t687;
+package t687
 trait Query {
-  override def equals(o : Object) = false;
+  override def equals(o : Object) = false
 }

--- a/test/files/run/t7096.scala
+++ b/test/files/run/t7096.scala
@@ -47,7 +47,7 @@ abstract class CompilerTest extends DirectTest {
     def symbols = classes ++ terms filterNot (_ eq NoSymbol)
     def terms   = allMembers(pkg) filter (s => s.isTerm && !s.isConstructor)
     def tparams = classes flatMap (_.info.typeParams)
-    def tpes    = symbols map (_.tpe) distinct
+    def tpes    = symbols.map(_.tpe).distinct
   }
 }
 


### PR DESCRIPTION
More partest janitorial duty, inspired by SZ.

Notably, steps or actions in a test produce `TestState` instead of boolean, to support `Crash` status. Previously, a compiler crash resulted in a generic failure.

A crash `?!` result was witnessed manually by injecting a crasher; outright crashes are so rare now that I didn't go looking for one.
