### PR TITLE
Minor optimizations in implicit search.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1071,17 +1071,20 @@ trait Implicits {
      *  bound, the implicits infos which are members of these companion objects.
      */
     private def companionImplicitMap(tp: Type): InfoMap = {
+      val isScala213 = settings.isScala213
 
       /* Populate implicit info map by traversing all parts of type `tp`.
        * Parameters as for `getParts`.
        */
-      def getClassParts(tp: Type)(implicit infoMap: InfoMap, seen: mutable.Set[Type], pending: Set[Symbol]) = tp match {
+      def getClassParts(tp: Type)(implicit infoMap: InfoMap, seen: mutable.HashSet[Type], pending: Set[Symbol]) = tp match {
         case TypeRef(pre, sym, args) =>
           infoMap get sym match {
             case Some(infos1) =>
-              if (infos1.nonEmpty && !(pre =:= infos1.head.pre.prefix)) {
-                log(s"Ignoring implicit members of $pre#$sym as it is also visible via another prefix: ${infos1.head.pre.prefix}")
-                infoMap(sym) = List() // ambiguous prefix - ignore implicit members
+              infos1 match {
+                case head :: _ if !(pre =:= head.pre.prefix) =>
+                  log(s"Ignoring implicit members of $pre#$sym as it is also visible via another prefix: ${infos1.head.pre.prefix}")
+                  infoMap(sym) = List() // ambiguous prefix - ignore implicit members
+                case _ =>
               }
             case None =>
               if (pre.isStable && !pre.typeSymbol.isExistentiallyBound) {
@@ -1090,7 +1093,7 @@ trait Implicits {
                   else singleType(pre, companionSymbolOf(sym, context))
                 val infos = pre1.implicitMembers.iterator.map(mem => new ImplicitInfo(mem.name, pre1, mem)).toList
                 if (infos.nonEmpty)
-                  infoMap += (sym -> infos)
+                  infoMap(sym) = infos
               }
               val bts = tp.baseTypeSeq
               var i = 1
@@ -1110,14 +1113,11 @@ trait Implicits {
        * @param pending  The set of static symbols for which we are currently trying to collect their parts
        *                 in order to cache them in infoMapCache
        */
-      def getParts(tp: Type)(implicit infoMap: InfoMap, seen: mutable.Set[Type], pending: Set[Symbol]) {
-        if (seen(tp))
-          return
-        seen += tp
-        tp match {
+      def getParts(tp: Type)(implicit infoMap: InfoMap, seen: mutable.HashSet[Type], pending: Set[Symbol]) {
+        if (seen add tp) tp match {
           case TypeRef(pre, sym, args) =>
             if (sym.isClass && !sym.isRoot &&
-                (settings.isScala213 || !sym.isAnonOrRefinementClass)) {
+                (isScala213 || !sym.isAnonOrRefinementClass)) {
               if (sym.isStatic && !(pending contains sym))
                 infoMap ++= {
                   infoMapCache get sym match {
@@ -1140,7 +1140,7 @@ trait Implicits {
               //  - if `T` is an abstract type, the parts of its upper bound;
               getParts(tp.bounds.hi)
 
-              if(settings.isScala213) {
+              if (isScala213) {
                 //  - if `T` is a parameterized type `S[T1,…,Tn]`, the union of the parts of `S` and `T1,…,Tn`
                 args foreach getParts
 


### PR DESCRIPTION
- cache `settings.isScala213`
- use `mutable.Set#add` rather than `contains` followed by `+=`
- match on `_ :: _` rather than `nonEmpty` followed by `head`
- use `mutable.Map#update` rather than `+=` (avoiding a tuple alloc)

I was looking into scala/bug#10954 and figured that I may as well try this out as a drive-by. `scala` corpus appears to fall within the margin of error on my laptop; a run on the benchmark server may show better results.

~A somewhat more daring change would be to stop recursing at `ObjectCls`, since that requires a traversal over `Object`, `Any`, `java.lang`, `java`, `<root>`, and `scala`, none of which are going to contribute implicits. (right?)~ EDIT: nah, the static `InfoMap` cache handles that pretty well already.