### PR TITLE
Fix scala/bug#10900: Add back 'Set.--(IterableOnce)'

### DIFF
--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -155,8 +155,8 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   /** Alias for `diff` */
   @`inline` final def &~ (that: Set[A]): C = this diff that
 
-  @deprecated("Use &~ or diff instead of --", "2.13.0")
-  @`inline` final def -- (that: Set[A]): C = diff(that)
+  @deprecated("Consider requiring an immutable Set", "2.13.0")
+  def -- (that: IterableOnce[A]): C = fromSpecificIterable(coll.toSet.removeAll(that))
 
   @deprecated("Consider requiring an immutable Set or fall back to Set.diff", "2.13.0")
   def - (elem: A): C = diff(Set(elem))

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -194,10 +194,10 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     *  @return  a new set consisting of all elements that are in this
     *  set or in the given set `that`.
     */
-  @`inline` final def union(that: collection.Iterable[A]): C = concat(that)
+  @`inline` final def union(that: Set[A]): C = concat(that)
 
   /** Alias for `union` */
-  @`inline` final def | (that: collection.Iterable[A]): C = concat(that)
+  @`inline` final def | (that: Set[A]): C = concat(that)
 
   /** The empty set of the same type as this set
     * @return  an empty set of type `C`.

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -54,6 +54,18 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
 
   def diff(that: collection.Set[A]): C =
     toIterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result + elem)
+
+  /** Creates a new $coll from this $coll by removing all elements of another
+    *  collection.
+    *
+    *  @param that the collection containing the elements to remove.
+    *  @return a new $coll with the given elements removed, omitting duplicates.
+    */
+  def removeAll(that: IterableOnce[A]): C = that.iterator.foldLeft[C](coll)(_ - _)
+
+  /** Alias for removeAll */
+  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
+  override /*final*/ def -- (that: IterableOnce[A]): C = removeAll(that)
 }
 
 /**

--- a/test/junit/scala/collection/immutable/SetTest.scala
+++ b/test/junit/scala/collection/immutable/SetTest.scala
@@ -78,4 +78,24 @@ class SetTest {
     val mapseta = any(mapset)
     assert(mapset eq mapseta)
   }
+
+  @Test
+  def testRemoveAll(): Unit = {
+    val s0 = Set(1, 2, 3) -- List(1, 2)
+    assertEquals(Set(3), s0)
+
+    val s1 = Set(1, 2, 3) -- List(1, 2, 3)
+    assertEquals(Set(), s1)
+
+    val s2 = Set(1, 2, 3) -- List(1, 2, 2, 3, 4)
+    assertEquals(Set(), s2)
+
+    // deprecated
+    val s3 = collection.Set(1, 2, 3) -- List(2, 3)
+    assertEquals(Set(1), s3)
+
+    // deprecated
+    val s4 = collection.mutable.Set(1, 2, 3) -- List(2, 3)
+    assertEquals(Set(1), s4)
+  }
 }


### PR DESCRIPTION
Alternative fix to scala/bug#10900 suggested by @julienrf. Original PR is #6782

`--` is now an alias for `immutable.Set.removeAll`. `--` is deprecated in `collection.Set`. User should consider using an `immutable.Set`.