### PR TITLE
Branch-sensitive nullness analysis / optimization

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -165,7 +165,7 @@ abstract class Inliner {
    * Returns the callsites that can be inlined. Ensures that the returned inline request graph does
    * not contain cycles.
    *
-   * The resulting list is sorted such that the leaves of the inline request graph are on the left.
+   * The resulting list is sorted such that the leaves of the inline request tree are on the left.
    * Once these leaves are inlined, the successive elements will be leaves, etc.
    */
   private def collectAndOrderInlineRequests: List[InlineRequest] = {

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
@@ -221,4 +221,21 @@ class NullnessAnalyzerTest extends BytecodeTesting {
       (trim, 3, NotNullValue)  // receiver at `trim`
     )) testNullness(a, m, insn, index, nullness)
   }
+
+  @Test
+  def branching(): Unit = {
+    val code =
+      """def f(o: Object) = {
+        |  if (o == null) throw null
+        |  o.toString
+        |}
+      """.stripMargin
+    val m = compileAsmMethod(code)
+    val a = newNullnessAnalyzer(m)
+    for ((insn, index, nullness) <- List(
+      ("IFNULL", 1, UnknownValue1),
+      ("ACONST_NULL", 1, NullValue),
+      ("INVOKEVIRTUAL java/lang/Object.toString", 1, NotNullValue) // after branch: known not null
+    )) testNullness(a, m, insn, index, nullness)
+  }
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
@@ -290,6 +290,28 @@ class MethodLevelOptsTest extends BytecodeTesting {
   }
 
   @Test
+  def branchSensitiveNullness(): Unit = {
+    val code =
+      """class C {
+        |  def t1(x: Object) = {
+        |    if (x != null)
+        |      if (x == null) println() // eliminated
+        |    0
+        |  }
+        |
+        |  def t2(x: String) = {
+        |    x.trim
+        |    if (x == null) println() // eliminated
+        |    0
+        |  }
+        |}
+      """.stripMargin
+    val c = compileClass(code)
+    assertSameSummary(getMethod(c, "t1"), List(ICONST_0, IRETURN))
+    assertSameSummary(getMethod(c, "t2"), List(ALOAD, "trim", POP, ICONST_0, IRETURN))
+  }
+
+  @Test
   def t5313(): Unit = {
     val code =
       """class C {


### PR DESCRIPTION
Short pseudo-code of the analyzer:

```
analyze()
  while (numInstructionsToProcess > 0) {
    currentFrame = oldFrame.clone().execute(insnNode, interpreter)
    if (insnNode instanceof JumpInsnNode) {
      merge(insnIndex + 1, currentFrame, subroutine)
      merge(jumpInsnIndex, currentFrame, subroutine)

merge(int insnIndex, Frame frame)
  oldFrame = frames[insnIndex]
  if (oldFrame == null) frames[insnIndex] = newFrame(frame)
  else oldFrame.merge(frame, interpreter)
```

The `currentFrame` is a temporary frame with the status after executing the instruction.
It is then either passed to `frame.merge` or to `new Frame` as parameter.
Both of these methods are overwritten in NullnessFrame to invoke `postBranch()`. On the first
invocation it sets the state of `currentFrame` for the first branch, then for the second branch.
So `currentFrame` can have a different state for each branch.

I'm very interested in other ways to achieve this, there might be a less hacky solution.