### PR TITLE
makes Iterable.scan and IterableOnce.fold deprecated.

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -523,6 +523,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     *
     *  @return           a new $coll containing the prefix scan of the elements in this $coll
     */
+  @deprecated("Use scanLeft instead", "2.13.0")
   def scan[B >: A](z: B)(op: (B, B) => B): CC[B] = scanLeft(z)(op)
 
   def scanLeft[B](z: B)(op: (B, A) => B): CC[B] = fromIterable(new View.ScanLeft(this, z, op))

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -488,6 +488,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *  @param op      a binary operator that must be associative.
     *  @return        the result of applying the fold operator `op` between all the elements and `z`, or `z` if this $coll is empty.
     */
+  @deprecated("Use foldLeft instead", "2.13.0")
   def fold[A1 >: A](z: A1)(op: (A1, A1) => A1): A1 = foldLeft(z)(op)
 
   /** Reduces the elements of this $coll using the specified associative binary operator.


### PR DESCRIPTION
Fixes scala/bug#10962