### PR TITLE
continue to make StringContext's checkLengths available to clients

### DIFF
--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -55,6 +55,10 @@ case class StringContext(parts: String*) {
 
   import StringContext._
 
+  @deprecated("use same-named method on StringContext companion object", "2.13.0")
+  def checkLengths(args: scala.collection.Seq[Any]): Unit =
+    StringContext.checkLengths(args, parts)
+
   /** The simple string interpolator.
    *
    *  It inserts its arguments between corresponding parts of the string context.
@@ -223,7 +227,7 @@ object StringContext {
   }
 
   private def standardInterpolator(process: String => String, args: scala.collection.Seq[Any], parts: Seq[String]): String = {
-    checkLengths(args, parts)
+    StringContext.checkLengths(args, parts)
     val pi = parts.iterator
     val ai = args.iterator
     val bldr = new JLSBuilder(process(pi.next()))
@@ -239,7 +243,7 @@ object StringContext {
    *
    *  @throws IllegalArgumentException  if this is not the case.
    */
-  private def checkLengths(args: scala.collection.Seq[Any], parts: Seq[String]): Unit =
+  def checkLengths(args: scala.collection.Seq[Any], parts: Seq[String]): Unit =
     if (parts.length != args.length + 1)
       throw new IllegalArgumentException("wrong number of arguments ("+ args.length
         +") for interpolated string with "+ parts.length +" parts")


### PR DESCRIPTION
partially reverts #6774. I found in the community build that at least
one string interpolator in the wild (hello lightbend-emoji!) was using
this method -- because it's rather useful, so actually we should
continue to provide it.

I agree with the part where we moved it to the companion object, so I
kept that, but I made it public there.

and I left the old one around as deprecated, to facilitate
cross-building.  that means we still have a "funny interpolator"
around for one more cycle, but oh well.

review by @lrytz