### PR TITLE
Better typing for overloaded higher-order methods

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -329,6 +329,8 @@ trait Implicits {
     result
   }
 
+  // TODO: use ProtoType for HasMember/HasMethodMatching
+
   /** An extractor for types of the form ? { name: ? }
    */
   object HasMember {
@@ -634,7 +636,7 @@ trait Implicits {
     private def matchesPtView(tp: Type, ptarg: Type, ptres: Type, undet: List[Symbol]): Boolean = tp match {
       case MethodType(p :: _, restpe) if p.isImplicit => matchesPtView(restpe, ptarg, ptres, undet)
       case MethodType(p :: Nil, restpe)               => matchesArgRes(p.tpe, restpe, ptarg, ptres, undet)
-      case ExistentialType(_, qtpe)                   => matchesPtView(normalize(qtpe), ptarg, ptres, undet)
+      case ExistentialType(_, qtpe)                   => matchesPtView(methodToExpressionTp(qtpe), ptarg, ptres, undet)
       case Function1(arg1, res1)                      => matchesArgRes(arg1, res1, ptarg, ptres, undet)
       case _                                          => false
     }
@@ -733,7 +735,7 @@ trait Implicits {
           }
         case NullaryMethodType(restpe)  => loop(restpe, pt)
         case PolyType(_, restpe)        => loop(restpe, pt)
-        case ExistentialType(_, qtpe)   => if (fast) loop(qtpe, pt) else normalize(tp) <:< pt // is !fast case needed??
+        case ExistentialType(_, qtpe)   => if (fast) loop(qtpe, pt) else methodToExpressionTp(tp) <:< pt // is !fast case needed??
         case _                          => if (fast) isPlausiblySubType(tp, pt) else tp <:< pt
       }
       loop(tp0, pt0)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -755,25 +755,6 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       case _ =>
     }
 
-    /**
-     * Convert a SAM type to the corresponding FunctionType,
-     * extrapolating BoundedWildcardTypes in the process
-     * (no type precision is lost by the extrapolation,
-     *  but this facilitates dealing with the types arising from Java's use-site variance).
-     */
-    def samToFunctionType(tp: Type, sam: Symbol = NoSymbol): Type = {
-      val samSym = sam orElse samOf(tp)
-
-      def correspondingFunctionSymbol = {
-        val numVparams = samSym.info.params.length
-        if (numVparams > definitions.MaxFunctionArity) NoSymbol
-        else FunctionClass(numVparams)
-      }
-
-      if (samSym.exists && tp.typeSymbol != correspondingFunctionSymbol) // don't treat Functions as SAMs
-        wildcardExtrapolation(normalize(tp memberInfo samSym))
-      else NoType
-    }
 
     /** Perform the following adaptations of expression, pattern or type `tree` wrt to
      *  given mode `mode` and given prototype `pt`:
@@ -835,7 +816,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           setError(tree)
         else
           withCondConstrTyper(treeInfo.isSelfOrSuperConstrCall(tree))(typer1 =>
-            if (original != EmptyTree && pt != WildcardType) {
+            if (original != EmptyTree && !pt.isWildcard) {
               typer1 silent { tpr =>
                 val withImplicitArgs = tpr.applyImplicitArgs(tree)
                 if (tpr.context.reporter.hasErrors) tree // silent will wrap it in SilentTypeError anyway
@@ -912,7 +893,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           adapt(typed(Apply(tree, Nil) setPos tree.pos), mode, pt, original)
         }
         // (4.3) eta-expand method value when function or sam type is expected (for experimentation, always eta-expand under 2.14 source level)
-        else if (isFunctionType(pt) || samOf(pt).exists || settings.isScala214) { // TODO: decide on `settings.isScala214`
+        else if (isFunctionProto(pt) || settings.isScala214) { // TODO: decide on `settings.isScala214`
           if (settings.isScala212 && mt.params.isEmpty) // implies isFunctionType(pt)
              currentRun.reporting.deprecationWarning(tree.pos, NoSymbol, "Eta-expansion of zero-argument methods is deprecated. "+
                     s"To avoid this warning, write ${Function(Nil, Apply(tree, Nil))}.", "2.12.0")
@@ -1240,7 +1221,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         && ((qual.symbol eq null) || !qual.symbol.isTerm || qual.symbol.isValue)
         && !qtpe.isError
         && !qtpe.typeSymbol.isBottomClass
-        && qtpe != WildcardType
+        && !qtpe.isWildcard
         && !qual.isInstanceOf[ApplyImplicitView] // don't chain views
         && (context.implicitsEnabled || context.enrichmentEnabled)
         // Elaborating `context.implicitsEnabled`:
@@ -1286,7 +1267,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         //util.trace("adaptToArgs "+qual+", name = "+name+", argtpes = "+(args map (_.tpe))+", pt = "+pt+" = ")
         adaptToMember(qual, HasMethodMatching(name, args map (_.tpe), restpe), reportAmbiguous, saveErrors)
 
-      if (pt == WildcardType)
+      if (pt.isWildcard)
         doAdapt(pt)
       else silent(_ => doAdapt(pt)) filter (_ != qual) orElse (_ =>
         logResult(s"fallback on implicits in adaptToArguments: $qual.$name")(doAdapt(WildcardType))
@@ -2407,11 +2388,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           block match {
             case Block(List(classDef @ ClassDef(_, _, _, _)), Apply(Select(New(_), _), _)) =>
               val classDecls = classDef.symbol.info.decls
-              lazy val visibleMembers = pt match {
-                case WildcardType                           => classDecls.toList
-                case BoundedWildcardType(TypeBounds(lo, _)) => lo.members
-                case _                                      => pt.members
-              }
+              lazy val visibleMembers =
+                pt.members match {
+                  case error: ErrorScope => classDecls.toList
+                  case ms => ms
+                }
+
               def matchesVisibleMember(member: Symbol) = visibleMembers exists { vis =>
                 (member.name == vis.name) &&
                 (member.tpe <:< vis.tpe.substThis(vis.owner, classDef.symbol))
@@ -2568,7 +2550,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     def synthesizePartialFunction(paramName: TermName, paramPos: Position, paramSynthetic: Boolean,
                                   tree: Tree, mode: Mode, pt: Type): Tree = {
       assert(pt.typeSymbol == PartialFunctionClass, s"PartialFunction synthesis for match in $tree requires PartialFunction expected type, but got $pt.")
-      val targs = pt.dealiasWiden.typeArgs
+      val targs = partialFunctionArgTypeFromProto(pt)
 
       // if targs.head isn't fully defined, we can't translate --> error
       targs match {
@@ -2819,7 +2801,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       case fun@Function(vparams, _) if !isFunctionType(pt) =>
         // TODO: can we ensure there's always a SAMFunction attachment, instead of looking up the sam again???
         // seems like overloading complicates things?
-        val sam = samOf(pt)
+        val sam = samOfProto(pt)
 
         if (!samMatchesFunctionBasedOnArity(sam, vparams)) false
         else {
@@ -2832,34 +2814,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             if (!sam.exists) NoType
             else if (fullyDefinedMeetsExpectedFunTp(pt)) pt
             else try {
-              val samClassSym = pt.typeSymbol
-
-              // we're trying to fully define the type arguments for this type constructor
-              val samTyCon = samClassSym.typeConstructor
-
-              // the unknowns
-              val tparams = samClassSym.typeParams
-              // ... as typevars
-              val tvars = tparams map freshVar
-
-              val ptVars = appliedType(samTyCon, tvars)
-
-              // carry over info from pt
-              ptVars <:< pt
-
-              val samInfoWithTVars = ptVars.memberInfo(sam)
-
-              // use function type subtyping, not method type subtyping (the latter is invariant in argument types)
-              fun.tpe <:< functionType(samInfoWithTVars.paramTypes, samInfoWithTVars.finalResultType)
-
-              val variances = tparams map varianceInType(sam.info)
-
-              // solve constraints tracked by tvars
-              val targs = solvedTypes(tvars, tparams, variances, upper = false, lubDepth(sam.info :: Nil))
-
-              debuglog(s"sam infer: $pt --> ${appliedType(samTyCon, targs)} by ${fun.tpe} <:< $samInfoWithTVars --> $targs for $tparams")
-
-              val ptFullyDefined = appliedType(samTyCon, targs)
+              val ptFullyDefined = instantiateSamFromFunction(fun.tpe, pt, sam)
               if (ptFullyDefined <:< pt && fullyDefinedMeetsExpectedFunTp(ptFullyDefined)) {
                 debuglog(s"sam fully defined expected type: $ptFullyDefined from $pt for ${fun.tpe}")
                 ptFullyDefined
@@ -2919,37 +2874,33 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         if (numVparams > definitions.MaxFunctionArity) NoSymbol
         else FunctionClass(numVparams)
 
-      val ptSym = pt.typeSymbol
-
-      /* The Single Abstract Member of pt, unless pt is the built-in function type of the expected arity,
-       * as `(a => a): Int => Int` should not (yet) get the sam treatment.
-       */
+      // The Single Abstract Member of pt, unless pt is the built-in function type of the expected arity.
       val sam =
-        if (ptSym == NoSymbol || ptSym == FunctionSymbol || ptSym == PartialFunctionClass) NoSymbol
-        else samOf(pt)
+        pt.typeSymbol match {
+          case NoSymbol | FunctionSymbol | PartialFunctionClass => NoSymbol
+          case _                                                => samOf(pt)
+        }
 
-      /* The SAM case comes first so that this works:
-       *   abstract class MyFun extends (Int => Int)
-       *   (a => a): MyFun
-       *
-       * Note that the arity of the sam must correspond to the arity of the function.
-       * TODO: handle vararg sams?
-       */
-      val ptNorm =
-        if (samMatchesFunctionBasedOnArity(sam, vparams)) samToFunctionType(pt, sam)
-        else pt
-      val (argpts, respt) =
+      val ptNorm = pt match {
+        case pt: ProtoType                                     => pt.asFunctionType
+        case _ if samMatchesFunctionBasedOnArity(sam, vparams) => samToFunctionType(pt, sam)
+        case _                                                 => pt
+      }
+
+      val (argProtos, resProto) =
         ptNorm baseType FunctionSymbol match {
           case TypeRef(_, FunctionSymbol, args :+ res) => (args, res)
-          case _                                       => (vparams map (if (pt == ErrorType) (_ => ErrorType) else (_ => NoType)), WildcardType)
+          case _                                       =>
+            val dummyPt = if (pt == ErrorType) ErrorType else NoType
+            (List.fill(numVparams)(dummyPt), WildcardType) // dummyPt is in CBN position
         }
 
       if (!FunctionSymbol.exists) MaxFunctionArityError(fun, s", but ${numVparams} given")
-      else if (argpts.lengthCompare(numVparams) != 0) WrongNumberOfParametersError(fun, argpts)
+      else if (argProtos.lengthCompare(numVparams) != 0) WrongNumberOfParametersError(fun, argProtos)
       else {
         val paramsMissingType = mutable.ArrayBuffer.empty[ValDef] //.sizeHint(numVparams) probably useless, since initial size is 16 and max fun arity is 22
         // first, try to define param types from expected function's arg types if needed
-        foreach2(vparams, argpts) { (vparam, argpt) =>
+        foreach2(vparams, argProtos) { (vparam, argpt) =>
           if (vparam.tpt.isEmpty) {
             if (isFullyDefined(argpt)) vparam.tpt setType argpt
             else paramsMissingType += vparam
@@ -2974,15 +2925,15 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             case Apply(meth, args) if (vparams corresponds args) { case (p, Ident(name)) => p.name == name case _ => false } =>
               // We're looking for a method (as indicated by FUNmode in the silent typed below),
               // so let's make sure our expected type is a MethodType
-              val methArgs = NoSymbol.newSyntheticValueParams(argpts map { case NoType => WildcardType case tp => tp })
+              val methArgs = NoSymbol.newSyntheticValueParams(argProtos map { case NoType => WildcardType case tp => tp })
 
-              val result = silent(_.typed(meth, mode.forFunMode, MethodType(methArgs, respt)))
+              val result = silent(_.typed(meth, mode.forFunMode, MethodType(methArgs, resProto)))
               // we can't have results with undetermined type params
               val resultMono = result filter (_ => context.undetparams.isEmpty)
               resultMono map { methTyped =>
                 // if context.undetparams is not empty, the method was polymorphic,
                 // so we need the missing arguments to infer its type. See #871
-                val funPt = normalize(methTyped.tpe) baseType FunctionClass(numVparams)
+                val funPt = methodToExpressionTp(methTyped.tpe) baseType FunctionClass(numVparams) // numVparams could be > 22...
                 // println(s"typeUnEtaExpanded $meth : ${methTyped.tpe} --> normalized: $funPt")
 
                 // If we are sure this function type provides all the necessary info, so that we won't have
@@ -3026,11 +2977,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               }
               val vparamsTyped = vparams mapConserve typedValDef
               val formals = vparamSyms map (_.tpe)
-              val body1 = typed(fun.body, respt)
+              val body1 = typed(fun.body, resProto)
               val restpe = {
                 val restpe0 = packedType(body1, fun.symbol).deconst.resultType
                 restpe0 match {
-                  case ct: ConstantType if (respt eq WildcardType) || (ct.widen <:< respt) => ct.widen
+                  case ct: ConstantType if (resProto eq WildcardType) || (ct.widen <:< resProto) => ct.widen
                   case tp => tp
                 }
               }
@@ -4631,8 +4582,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           if (tp.params.lengthCompare(definitions.MaxFunctionArity) > 0) MaxFunctionArityError(methodValue, s"; method ${methodValue.symbol.name} cannot be eta-expanded because it takes ${tp.params.length} arguments")
           else {
             val etaPt =
-              if (pt ne WildcardType) pt
-              else functionType(tp.params.map(_ => WildcardType), WildcardType) orElse WildcardType // arity overflow --> NoType
+              pt match {
+                case pt: ProtoType =>
+                  pt.asFunctionType orElse functionType(tp.params.map(_ => WildcardType), WildcardType) orElse WildcardType // arity overflow --> NoType
+                case _             => pt
+              }
 
             // We know syntactically methodValue can't refer to a constructor because you can't write `this _` for that (right???)
             typedEtaExpansion(methodValue, mode, etaPt)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -723,9 +723,12 @@ trait Definitions extends api.StandardDefinitions {
       )
 
     // @requires pt.typeSymbol == PartialFunctionClass
-    def partialFunctionArgTypeFromProto(pt: Type) =
+    def partialFunctionArgResTypeFromProto(pt: Type): (Type, Type) =
       pt match {
-        case _                          => pt.dealiasWiden.typeArgs
+        case oap: OverloadedArgFunProto => (oap.hofParamTypes.head, WildcardType)
+        case _                          =>
+          val arg :: res :: Nil = pt.baseType(PartialFunctionClass).typeArgs
+          (arg, res)
       }
 
     // the number of arguments expected by the function described by `tp` (a FunctionN or SAM type),

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -715,6 +715,19 @@ trait Definitions extends api.StandardDefinitions {
     // tends to change the course of events by forcing types.
     def isFunctionType(tp: Type)       = isFunctionTypeDirect(tp.dealiasWiden)
 
+    // Are we expecting something function-ish? This considers FunctionN / SAM / ProtoType that matches functions
+    def isFunctionProto(pt: Type): Boolean =
+      (isFunctionType(pt)
+       || (pt match { case pt: ProtoType => pt.expectsFunctionType  case _ => false })
+       || samOf(pt).exists
+      )
+
+    // @requires pt.typeSymbol == PartialFunctionClass
+    def partialFunctionArgTypeFromProto(pt: Type) =
+      pt match {
+        case _                          => pt.dealiasWiden.typeArgs
+      }
+
     // the number of arguments expected by the function described by `tp` (a FunctionN or SAM type),
     // or `-1` if `tp` does not represent a function type or SAM
     // for use during typers (after fields, samOf will be confused by abstract accessors for trait fields)
@@ -736,6 +749,49 @@ trait Definitions extends api.StandardDefinitions {
         case samSym if samSym.exists => tp.memberInfo(samSym).paramTypes
         case _ => Nil
       }
+    }
+
+    /**
+      * Convert a SAM type to the corresponding FunctionType,
+      * extrapolating BoundedWildcardTypes in the process
+      * (no type precision is lost by the extrapolation,
+      *  but this facilitates dealing with the types arising from Java's use-site variance).
+      */
+    def samToFunctionType(tp: Type, sam: Symbol = NoSymbol): Type =
+      tp match {
+        case pt: ProtoType => pt.asFunctionType
+        case _ =>
+          val samSym = sam orElse samOf(tp)
+
+          def correspondingFunctionSymbol = {
+            val numVparams = samSym.info.params.length
+            if (numVparams > definitions.MaxFunctionArity) NoSymbol
+            else FunctionClass(numVparams)
+          }
+
+          if (samSym.exists && tp.typeSymbol != correspondingFunctionSymbol) // don't treat Functions as SAMs
+            wildcardExtrapolation(methodToExpressionTp(tp memberInfo samSym))
+          else NoType
+      }
+
+    /** Automatically perform the following conversions on expression types:
+      *  A method type becomes the corresponding function type.
+      *  A nullary method type becomes its result type.
+      *  Implicit parameters are skipped.
+      *  This method seems to be performance critical.
+      */
+    def methodToExpressionTp(tp: Type): Type = tp match {
+      case PolyType(_, restpe) =>
+        logResult(sm"""|Normalizing PolyType in infer:
+                       |  was: $restpe
+                       |  now""")(methodToExpressionTp(restpe))
+      case mt @ MethodType(_, restpe) if mt.isImplicit             => methodToExpressionTp(restpe)
+      case mt @ MethodType(_, restpe) if !mt.isDependentMethodType =>
+        if (phase.erasedTypes) FunctionClass(mt.params.length).tpe
+        else functionType(mt.paramTypes, methodToExpressionTp(restpe))
+      case NullaryMethodType(restpe)                               => methodToExpressionTp(restpe)
+      case ExistentialType(tparams, qtpe)                          => newExistentialType(tparams, methodToExpressionTp(qtpe))
+      case _                                                       => tp // @MAT aliases already handled by subtyping
     }
 
     // the SAM's parameters and the Function's formals must have the same length
@@ -916,6 +972,12 @@ trait Definitions extends api.StandardDefinitions {
         else NoSymbol
       } else NoSymbol
     }
+
+    def samOfProto(pt: Type): Symbol =
+      pt match {
+        case proto: ProtoType => samOf(proto.underlying) // TODO: add more semantic accessor to ProtoType?
+        case pt               => samOf(pt)
+      }
 
     def arrayType(arg: Type)         = appliedType(ArrayClass, arg)
     def byNameType(arg: Type)        = appliedType(ByNameParamClass, arg)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1184,6 +1184,142 @@ trait Types
     def toVariantType: Type = NoType
   }
 
+  /** Help infer parameter types for function arguments to overloaded methods.
+    *
+    * Normally, overload resolution types the arguments to the alternatives without an expected type.
+    * However, typing function literals and eta-expansion are driven by the expected type:
+    *   - function literals usually don't have parameter types, which are derived from the expected type;
+    *   - eta-expansion right now only happens when a function/sam type is expected.
+    *
+    * Now that the collections are full of overloaded HO methods, we should try harder to type check them nicely.
+    *
+    * To avoid breaking existing code, we only provide an expected type (for each argument position) when:
+    *   - there is at least one FunctionN type expected by one of the overloads:
+    *     in this case, the expected type is a FunctionN[Ti, ?], where Ti are the argument types (they must all be =:=),
+    *     and the expected result type is elided using a wildcard.
+    *     This does not exclude any overloads that expect a SAM, because they conform to a function type through SAM conversion
+    *   - OR: all overloads expect a SAM type of the same class, but with potentially varying result types (argument types must be =:=)
+    *
+    * We allow polymorphic cases, as long as the types parameters are instantiated by the AntiPolyType prefix.
+    *
+    * In all other cases, the old behavior is maintained: Wildcard is expected.
+    */
+  case class OverloadedArgFunProto(argIdx: Int, pre: Type, alternatives: List[Symbol]) extends ProtoType with SimpleTypeProxy {
+    override def safeToString: String = underlying.safeToString
+    override def kind = "OverloadedArgFunProto"
+
+    override def underlying: Type = functionArgsProto
+
+    // Always match if we couldn't collapse the expected types contributed for this argument by the alternatives.
+    // TODO: could we just match all function-ish types as an optimization? We previously used WildcardType
+    override def isMatchedBy(tp: Type, depth: Depth): Boolean =
+      isPastTyper || underlying == WildcardType ||
+        isSubType(tp, underlying, depth) ||
+        // NOTE: converting tp to a function type won't work, since `tp` need not be an actual sam type,
+        // just some subclass of the sam expected by one of our overloads
+        sameTypesFoldedSam.exists { underlyingSam => isSubType(tp, underlyingSam, depth) } // overload_proto_collapse.scala:55
+
+    // Empty signals failure. We don't consider the 0-ary HOF case, since we are only concerned with inferring param types for these functions anyway
+    def hofParamTypes = functionOrPfOrSamArgTypes(underlying)
+
+    override def expectsFunctionType: Boolean = hofParamTypes.nonEmpty
+
+    // TODO: include result type?
+    override def asFunctionType =
+      if (expectsFunctionType) functionType(hofParamTypes, WildcardType)
+      else NoType
+
+    override def mapOver(map: TypeMap): Type = {
+      val pre1 = pre.mapOver(map)
+      val alts1 = map.mapOver(alternatives)
+      if ((pre ne pre1) || (alternatives ne alts1)) OverloadedArgFunProto(argIdx, pre1, alts1)
+      else this
+    }
+
+    // TODO
+    // override def registerTypeEquality(tp: Type): Boolean = functionArgsProto =:= tp
+
+
+    // TODO: use =:=, but `!(typeOf[String with AnyRef] =:= typeOf[String])` (https://github.com/scala/scala-dev/issues/530)
+    private def same(x: Type, y: Type) = (x <:< y) && (y <:< x)
+
+    private object ParamAtIdx {
+      def unapply(params: List[Symbol]): Option[Type] = {
+        lazy val lastParamTp = params.last.tpe
+
+        // if we're asking for the last argument, or past, and it happens to be a repeated param -- strip the vararg marker and return the type
+        if (params.nonEmpty && params.lengthCompare(argIdx + 1) <= 0 && isRepeatedParamType(lastParamTp)) {
+          Some(lastParamTp.dealiasWiden.typeArgs.head)
+        } else if (params.isDefinedAt(argIdx)) {
+          Some(params(argIdx).tpe)
+        } else None
+      }
+    }
+
+
+    private def toWild(tp: Type): Type = tp match {
+      case PolyType(tparams, tp) => new SubstWildcardMap(tparams).apply(tp)
+      case tp                    => tp
+    }
+
+    private lazy val sameTypesFolded = {
+      // Collect all expected types contributed by the various alternatives for this argument (TODO: repeated params?)
+      // Relative to `pre` at `alt.owner`, with `alt`'s type params approximated.
+      val altParamTps =
+        alternatives map { alt =>
+          // Use memberType so that a pre: AntiPolyType can instantiate its type params
+          pre.memberType(alt) match {
+            case PolyType(tparams, MethodType(ParamAtIdx(paramTp), res)) => PolyType(tparams, paramTp.asSeenFrom(pre, alt.owner))
+            case MethodType(ParamAtIdx(paramTp), res)                    => paramTp.asSeenFrom(pre, alt.owner)
+            case _                                                       => NoType
+          }
+        }
+
+      altParamTps.foldLeft(Nil: List[Type]) {
+        case (acc, NoType | WildcardType) => acc
+        case (acc, tp)                    => if (acc.exists(same(tp, _))) acc else tp :: acc
+      }
+    }
+
+    private lazy val sameTypesFoldedSam =
+      sameTypesFolded.iterator.map(toWild).filter(tp => samOf(tp).exists).toList
+
+    // Try to collapse all expected argument types (already distinct by =:=) into a single expected type,
+    // so that we can use it to as the expected type to drive parameter type inference for a function literal argument.
+    private lazy val functionArgsProto = {
+      val ABORT = (NoType, false, false)
+
+      // we also consider any function-ish type equal as long as the argument types are
+      def sameHOArgTypes(tp1: Type, tp2: Type) = tp1 == WildcardType || {
+        val hoArgTypes1 = functionOrPfOrSamArgTypes(tp1.resultType)
+        // println(s"sameHOArgTypes($tp1, $tp2) --> $hoArgTypes1 === $hoArgTypes2 : $res")
+        hoArgTypes1.nonEmpty && hoArgTypes1.corresponds(functionOrPfOrSamArgTypes(tp2.resultType))(same)
+      }
+
+      // TODO: compute functionOrPfOrSamArgTypes during fold?
+      val (sameHoArgTypesFolded, partialFun, regularFun) =
+        sameTypesFolded.foldLeft((WildcardType: Type, false, false)) {
+          case (ABORT, _)              => ABORT
+          case ((acc, partialFun, regularFun), tp) if sameHOArgTypes(acc, tp) =>
+            val wild = toWild(tp)
+            (tp, partialFun || isPartialFunctionType(wild), regularFun || isFunctionType(wild))
+          case _                       => ABORT // different HO argument types encountered
+        }
+
+      if ((sameHoArgTypesFolded eq WildcardType) || (sameHoArgTypesFolded eq NoType)) WildcardType
+      else functionOrPfOrSamArgTypes(toWild(sameHoArgTypesFolded)) match {
+        case Nil     => WildcardType // TODO: can we retain some of this?
+        case hofArgs =>
+          if (partialFun) appliedType(PartialFunctionClass, hofArgs :+ WildcardType)
+          else if (regularFun) functionType(hofArgs, WildcardType)
+          // if we saw a variety of SAMs, can't collapse them -- what if they were accidental sams and we're not going to supply a function literal?
+          else if (sameTypesFolded.lengthCompare(1) == 0) toWild(sameTypesFolded.head)
+          else WildcardType
+      }
+
+    }
+  }
+
   /** An object representing a non-existing type */
   case object NoType extends Type {
     override def isTrivial: Boolean = true

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -209,10 +209,10 @@ trait Variances {
 
     def inSym(sym: Symbol): Variance = if (sym.isAliasType) inType(sym.info).cut else inType(sym.info)
     def inType(tp: Type): Variance   = tp match {
-      case ErrorType | WildcardType | NoType | NoPrefix => Bivariant
+      case pt: ProtoType                                => inType(pt.toVariantType)
+      case ErrorType | NoType | NoPrefix                => Bivariant
       case ThisType(_) | ConstantType(_)                => Bivariant
       case TypeRef(_, `tparam`, _)                      => Covariant
-      case BoundedWildcardType(bounds)                  => inType(bounds)
       case NullaryMethodType(restpe)                    => inType(restpe)
       case SingleType(pre, sym)                         => inType(pre)
       case TypeRef(pre, _, _) if tp.isHigherKinded      => inType(pre)                 // a type constructor cannot occur in tp's args

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -935,12 +935,8 @@ private[internal] trait TypeMaps {
     *  type variable */
   object wildcardToTypeVarMap extends TypeMap {
     def apply(tp: Type): Type = tp match {
-      case WildcardType =>
-        TypeVar(tp, new TypeConstraint)
-      case BoundedWildcardType(bounds) =>
-        TypeVar(tp, new TypeConstraint(bounds))
-      case _ =>
-        tp.mapOver(this)
+      case pt: ProtoType => TypeVar(tp, new TypeConstraint(pt.toBounds))
+      case _ => tp.mapOver(this)
     }
   }
 

--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -162,9 +162,9 @@ trait Erasure {
         if (newParents eq parents) tp
         else ClassInfoType(newParents, decls, clazz)
 
-      // can happen while this map is being used before erasure (e.g. when reasoning about sam types)
+      // A BoundedWildcardType, e.g., can happen while this map is being used before erasure (e.g. when reasoning about sam types)
       // the regular mapOver will cause a class cast exception because TypeBounds don't erase to TypeBounds
-      case _: BoundedWildcardType => tp // skip
+      case pt: ProtoType => pt // skip
 
       case _ =>
         tp.mapOver(this)

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -142,6 +142,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.ErrorType
     this.WildcardType
     this.BoundedWildcardType
+    this.OverloadedArgFunProto
     this.NoType
     this.NoPrefix
     this.ThisType

--- a/test/files/neg/t6214.check
+++ b/test/files/neg/t6214.check
@@ -1,7 +1,4 @@
-t6214.scala:5: error: ambiguous reference to overloaded definition,
-both method m in object Test of type (f: Int => Unit)Int
-and  method m in object Test of type (f: String => Unit)Int
-match argument types (Any => Unit)
+t6214.scala:5: error: missing parameter type
   	m { s => case class Foo() }
-        ^
+            ^
 one error found

--- a/test/files/pos/overload_proto.scala
+++ b/test/files/pos/overload_proto.scala
@@ -1,0 +1,95 @@
+object Util {
+  def mono(x: Int) = x
+  def poly[T](x: T): T = x
+}
+
+trait FunSam[-T, +R] { def apply(x: T): R }
+
+
+trait TFun { def map[T](f: T => Int): Unit = () }
+object Fun extends TFun { import Util._
+  def map[T: scala.reflect.ClassTag](f: T => Int): Unit = ()
+
+  map(mono)
+  map(mono _)
+  map(x => mono(x))
+
+// can't infer polymorphic type for function parameter:
+//  map(poly)
+//  map(poly _)
+//  map(x => poly(x))
+}
+
+trait TSam { def map[T](f: T FunSam Int): Unit = () }
+object Sam extends TSam { import Util._
+  def map[T: scala.reflect.ClassTag](f: T `FunSam` Int): Unit = ()
+
+  map(mono) // sam
+  map(mono _) // sam
+  map(x => mono(x)) // sam
+
+// can't infer polymorphic type for function parameter:
+//  map(poly)
+//  map(poly _)
+//  map(x => poly(x))
+}
+
+trait IntFun { def map[T](f: Int => T): Unit = () }
+object int_Fun extends IntFun { import Util._
+  def map[T: scala.reflect.ClassTag](f: Int => T): Unit = ()
+
+  map(mono)
+  map(mono _)
+  map(x => mono(x))
+
+  map(poly)
+  map(poly _)
+  map(x => poly(x))
+}
+
+trait IntSam { def map[T](f: Int FunSam T): Unit = () }
+object int_Sam extends IntSam { import Util._
+  def map[T: scala.reflect.ClassTag](f: Int `FunSam` T): Unit = ()
+
+  map(mono) // sam
+  map(mono _) // sam
+  map(x => mono(x)) // sam
+
+  map(poly) // sam
+  map(poly _) // sam
+  map(x => poly(x)) // sam
+}
+
+
+/*
+eta_overload_hof.scala:27: error: missing argument list for method mono in object Util
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `mono _` or `mono(_)` instead of `mono`.
+  map(mono)
+      ^
+eta_overload_hof.scala:46: error: type mismatch;
+ found   : Nothing => Nothing
+ required: ?<: Int => ?
+  map(poly _)
+      ^
+eta_overload_hof.scala:54: error: missing argument list for method mono in object Util
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `mono _` or `mono(_)` instead of `mono`.
+  map(mono)
+      ^
+eta_overload_hof.scala:58: error: missing argument list for method poly in object Util
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `poly _` or `poly(_)` instead of `poly`.
+  map(poly)
+      ^
+eta_overload_hof.scala:59: error: overloaded method value map with alternatives:
+  [T](f: FunSam[Int,T])(implicit evidence$4: scala.reflect.ClassTag[T])Unit <and>
+  [T](f: FunSam[Int,T])Unit
+ cannot be applied to (Nothing => Nothing)
+  map(poly _)
+  ^
+eta_overload_hof.scala:60: error: missing parameter type
+  map(x => poly(x))
+      ^
+
+* */

--- a/test/files/pos/overload_proto_accisam.scala
+++ b/test/files/pos/overload_proto_accisam.scala
@@ -1,0 +1,7 @@
+// TODO make independent of java.io.OutputStream, but obvious way does not capture the bug (see didInferSamType and OverloadedArgFunProto)
+class Test {
+  def overloadedAccidentalSam(a: java.io.OutputStream, b: String) = ???
+  def overloadedAccidentalSam(a: java.io.OutputStream, b: Any)= ???
+
+  overloadedAccidentalSam(??? : java.io.OutputStream, null)
+}

--- a/test/files/pos/overload_proto_collapse.scala
+++ b/test/files/pos/overload_proto_collapse.scala
@@ -1,0 +1,57 @@
+
+class Test {
+  def prepended[B >: Char](elem: B): String = ???
+  def prepended(c: Char): String = ???
+
+  def +:[B >: Char](elem: B): String = prepended(elem)
+}
+
+
+trait DurationConversions {
+  trait Classifier[C] { type R }
+
+  def days: Int = ???
+  def days[C](c: C)(implicit ev: Classifier[C]): ev.R = ???
+
+  def day[C](c: C)(implicit ev: Classifier[C]): ev.R = days(c)
+}
+
+
+trait AnonMatch {
+  trait MapOps[K, +V, +CC[_, _]] {
+    def map[K2, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2] = ???
+    def map[K2 <: AnyRef, V2](f: ((K with AnyRef, V)) => (K2, V2)): MapOps[K2, V2, Map] = ???
+  }
+
+  (??? : MapOps[String, Int, Map]).map{ case (k,v) => ??? }
+}
+
+
+trait FBounds {
+  def f[A](x: A) = 11;
+  def f[A <: Ordered[A]](x: Ordered[A]) = 12;
+
+  f(1)
+}
+
+// Don't collapse A and Tree[A]. Naively replacing type params with ? gives ? and Tree[?],
+// which are equal because wildcard equals whatever
+// example from specs2
+class Trees { outer =>
+  trait Tree[B]
+
+  def clean[A](t: Tree[Option[A]]): Tree[A] =
+    prune(t, (a: Option[A]) => a).getOrElse(??? : Tree[A])
+
+  def prune[A, B](t: Tree[A], f: A => Option[B]): Option[Tree[B]] = ???
+  def prune[A](t: Tree[A], f: Tree[A] => Option[A])(implicit initial: A): Tree[A] = ???
+}
+
+
+// From gigahorse
+abstract class Sam[A] { def apply(a: String): A }
+
+class GigaHorse {
+  def map[A](f: String => A): A = map(new Sam[A] { def apply(a: String): A = f(a) })
+  def map[A](f: Sam[A]): A = ???
+}

--- a/test/files/pos/overloaded_ho_fun.scala
+++ b/test/files/pos/overloaded_ho_fun.scala
@@ -27,10 +27,10 @@ class StringLike(xs: String) {
 object Test {
   val of = new OverloadedFun[Int](1)
 
-  of.foo(_.toString)
+//  of.foo(_.toString) // not allowed -- different argument types for the hof arg
 
   of.poly(x => x / 2 )
-  of.polySam(x => x / 2 )
+//  of.polySam(x => x / 2) // not allowed -- need at least one regular function type in the mix
   of.polyJavaSam(x => x)
 
   val sl = new StringLike("a")


### PR DESCRIPTION
TODO: 
  - [x] spec update
  - [ ] performance
  - [x] clean up OverloadedArgFunProto

For better typing for an overloaded higher-order method such as `map` (prevalent in the new collections
/ spark apis), regardless of whether the actual argument is a function literal, a method reference that
will be eta-expanded (based on the expected type), or a method value (`m _`).

Before, we triggered this based on the syntactic shape of the arguments, but that results (in our case)
in difference between `foo`, `foo _` and `x => foo(x)` as arguments to overloaded method.

The first commit (ProtoType generalizes [Bounded]WildcardType) sneakily sets the scene, pretty
specifically for the second one, but I do expect it to be useful for other cases.

Normally, overload resolution types the arguments to the alternatives without an expected type.
However, typing function literals and eta-expansion are driven by the expected type:

  - function literals usually don't have parameter types, which are derived from the expected type;

  - eta-expansion right now only happens when a function/sam type is expected.

(Dotty side-steps these issues by eta-expanding regardless of expected type.)

Now that the collections are full of overloaded HO methods, we should try harder to type check them
nicely.

To avoid breaking existing code, we only provide an expected type (for each argument position) when:

 - there is at least one FunctionN type expected by one of the overloads: in this case, the expected
   type is a FunctionN[Ti, ?], where Ti are the argument types (they must all be =:=), and the expected
   result type is elided using a wildcard. This does not exclude any overloads that expect a SAM,
   because they conform to a function type through SAM conversion

 - OR: all overloads expect a SAM type of the same class, but with potentially varying result types
   (argument types must be =:=)

We allow polymorphic cases, as long as the types parameters are instantiated by the AntiPolyType prefix.

In all other cases, the old behavior is maintained: Wildcard is expected.

(Slightly) more formally:

Consider an overloaded method `m_i`, with `N` overloads `i = 1..N`, and an expected argument type at
index `j`, `a_ij`:

```
def m_1(... a_1j, ...)
..
def m_N(... a_Nj, ...)
```

Any polymorphic method `m_i` will be reduced to the monomorphic case by pushing down the method's
`PolyType` to its arguments `a_ij`.

The expected type for the argument at index `j` will be more precise than the usual `WildcardType`
(`?`), if all types `a_1j..a_Nj` are function-ish types that denote the same parameter types `p1..pM`.

A "function-ish" type is a `FunctionN[p1,...,pM]` (or `PartialFunction`), or the equivalent SAM type.
(We first unwrap any PolyTypes.)

The non-wildcard expected type will be
  - `PartialFunction[p1, ?]`, if an `a_ij` expects a partial function;
  - else, if there is a subclass of `FunctionM` among the `a_ij`, it is `FunctionM[p1, pM, ?]`;
  - else, if all `a_ij` are of the same SAM type (allowing for varying result types), 
    that SAM type (with `?` result type).

In each case, any type parameter not already resolved by overloading, or the outer context, it
approximated by `?`.

PS: type equivalence is decided as `tp1 <:< tp2 && tp2 <:< tp1`, and not `tp1 =:= tp2` (the latter is
actually stricter).
