### PR TITLE
add StringBuilder#length_=

### DIFF
--- a/src/library/scala/collection/mutable/Builder.scala
+++ b/src/library/scala/collection/mutable/Builder.scala
@@ -107,6 +107,8 @@ class StringBuilder(private val sb: java.lang.StringBuilder) extends AbstractSeq
 
   def length: Int = sb.length()
 
+  def length_=(n: Int): Unit = sb.setLength(n)
+
   def addOne(x: Char) = { sb.append(x); this }
 
   def clear() = sb.setLength(0)


### PR DESCRIPTION
Because Scala 2.12 has `def length_=`. I'm not sure why removed since Scala 2.13.0-M4.
https://github.com/scala/scala/blob/v2.12.6/src/library/scala/collection/mutable/StringBuilder.scala#L76