### PR TITLE
Avoid ScalaRuntime for generic arrays that are refined to concrete arrays

### DIFF
--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -56,9 +56,9 @@ trait Erasure {
   /** Arrays despite their finality may turn up as refined type parents,
    *  e.g. with "tagged types" like Array[Int] with T.
    */
-  protected def unboundedGenericArrayLevel(tp: Type): Int = tp match {
+  def unboundedGenericArrayLevel(tp: Type): Int = tp match {
     case GenericArray(level, core) if !(core <:< AnyRefTpe) => level
-    case RefinedType(ps, _) if ps.nonEmpty                  => logResult(s"Unbounded generic level for $tp is")((ps map unboundedGenericArrayLevel).max)
+    case RefinedType(ps, _) if ps.nonEmpty                  => logResult(s"Unbounded generic level for $tp is")(unboundedGenericArrayLevel(intersectionDominator(ps)))
     case _                                                  => 0
   }
 

--- a/test/junit/scala/tools/nsc/transform/ErasureTest.scala
+++ b/test/junit/scala/tools/nsc/transform/ErasureTest.scala
@@ -1,0 +1,41 @@
+package scala.tools.nsc.transform
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+import scala.tools.nsc.symtab.SymbolTableForUnitTesting
+import scala.tools.testing.BytecodeTesting
+import scala.tools.testing.BytecodeTesting.{assertNoInvoke, getMethod}
+
+class ErasureTest extends BytecodeTesting {
+  object symbolTable extends SymbolTableForUnitTesting
+
+  @Test def testGenericArray(): Unit = {
+    import symbolTable._
+    import definitions._
+    val T = NoSymbol.newTypeParameter(TypeName("T")).setInfo(TypeBounds.empty)
+    val U = NoSymbol.newTypeParameter(TypeName("U")).setInfo(TypeBounds.empty)
+    val arrayTWithArrayString: Type = refinedType(appliedType(ArrayClass, T.tpeHK) :: appliedType(ArrayClass, StringTpe) :: Nil, NoSymbol)
+    val arrayTWithArrayU: Type = refinedType(appliedType(ArrayClass, T.tpeHK) :: appliedType(ArrayClass, U.tpeHK) :: Nil, NoSymbol)
+
+    assertEquals(1, erasure.unboundedGenericArrayLevel(appliedType(ArrayClass, T.tpeHK)))
+    assertEquals(0, erasure.unboundedGenericArrayLevel(arrayTWithArrayString))
+    assertEquals(1, erasure.unboundedGenericArrayLevel(arrayTWithArrayU))
+  }
+
+  import compiler._
+
+  @Test
+  def noScalaRuntimeForRefinedTypeWithGenericAndConcreteArray(): Unit = {
+    val code =
+      """class C {
+        |  def t[T](xs: Array[T]): Unit = xs match {
+        |    case x: Array[AnyRef] => x(0)
+        |    case _ =>
+        |  }
+        |}
+      """.stripMargin
+    val c = compileClass(code)
+    assertNoInvoke(getMethod(c, "t"))
+  }
+}


### PR DESCRIPTION
The value bound by a type pattern takes on an intersection type of the
scrutinee type and the pattern type. In the enclosed test, this leads
to a type like `Array[T] with Array[AnyRef]`.

This is erased to `Array[Object]`, thanks to use of `intersectionDominator`
in `ErasureMap`. However, some related code in the erasure tree transform
was unable to see through this refinment type and emitted the slower
code for array access using runtime type checks in ScalaRuntime.

Fixes scala/scala-dev#528