### PR TITLE
Optimize mkString and addString

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -376,7 +376,7 @@ object Predef extends LowPriorityImplicits {
     def length: Int                                     = sequenceOfChars.length
     def charAt(index: Int): Char                        = sequenceOfChars(index)
     def subSequence(start: Int, end: Int): CharSequence = new SeqCharSequence(sequenceOfChars.slice(start, end))
-    override def toString                               = sequenceOfChars mkString ""
+    override def toString                               = sequenceOfChars.mkString
   }
 
   /** @group implicit-classes-char */
@@ -384,7 +384,7 @@ object Predef extends LowPriorityImplicits {
     def length: Int                                     = arrayOfChars.length
     def charAt(index: Int): Char                        = arrayOfChars(index)
     def subSequence(start: Int, end: Int): CharSequence = new runtime.ArrayCharSequence(arrayOfChars, start, end)
-    override def toString                               = arrayOfChars mkString ""
+    override def toString                               = arrayOfChars.mkString
   }
 
   /** @group conversions-string */

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -3,6 +3,7 @@ package collection
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.generic.DefaultSerializationProxy
+import scala.collection.mutable.StringBuilder
 import scala.language.{higherKinds, implicitConversions}
 import scala.util.hashing.MurmurHash3
 
@@ -281,12 +282,8 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
   /** Alias for `concat` */
   /*@`inline` final*/ def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = concat(xs)
 
-  override def mkString(start: String, sep: String, end: String): String =
-    iterator.map { case (k, v) => s"$k -> $v" }.mkString(start, sep, end)
-
-  // these dummy overrides are necessary for disambiguation
-  override def mkString(sep: String): String = super.mkString(sep)
-  override def mkString: String = super.mkString
+  override def addString(sb: StringBuilder, start: String, sep: String, end: String): StringBuilder =
+    iterator.map { case (k, v) => s"$k -> $v" }.addString(sb, start, sep, end)
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat.", "2.13.0")
   def + [V1 >: V](kv: (K, V1)): CC[K, V1] =

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -1,10 +1,11 @@
 package scala
 package collection
 
-import java.lang.StringBuilder
+import java.lang.{StringBuilder => JStringBuilder}
 import java.util.NoSuchElementException
 
 import scala.collection.immutable.{ArraySeq, WrappedString}
+import scala.collection.mutable.StringBuilder
 import scala.math.{ScalaNumber, max, min}
 import scala.reflect.ClassTag
 import scala.util.matching.Regex
@@ -90,7 +91,7 @@ object StringOps {
       */
     def map(f: Char => Char): String = {
       val len = s.length
-      val sb = new StringBuilder(len)
+      val sb = new JStringBuilder(len)
       var i = 0
       while (i < len) {
         val x = s.charAt(i)
@@ -128,7 +129,7 @@ object StringOps {
       */
     def flatMap(f: Char => String): String = {
       val len = s.length
-      val sb = new StringBuilder
+      val sb = new JStringBuilder
       var i = 0
       while (i < len) {
         val x = s.charAt(i)
@@ -216,7 +217,7 @@ final class StringOps(private val s: String) extends AnyVal {
     */
   def flatMap(f: Char => String): String = {
     val len = s.length
-    val sb = new StringBuilder
+    val sb = new JStringBuilder
     var i = 0
     while (i < len) {
       sb append f(s.charAt(i))
@@ -250,7 +251,7 @@ final class StringOps(private val s: String) extends AnyVal {
     */
   def concat(suffix: IterableOnce[Char]): String = {
     val k = suffix.knownSize
-    val sb = new StringBuilder(s.length + (if(k >= 0) k else 16))
+    val sb = new JStringBuilder(s.length + (if(k >= 0) k else 16))
     sb.append(s)
     for (ch <- suffix.iterator) sb.append(ch)
     sb.toString
@@ -308,7 +309,7 @@ final class StringOps(private val s: String) extends AnyVal {
   def padTo(len: Int, elem: Char): String = {
     val sLen = s.length
     if (sLen >= len) s else {
-      val sb = new StringBuilder(len)
+      val sb = new JStringBuilder(len)
       sb.append(s)
       // With JDK 11, this can written as:
       // sb.append(String.valueOf(elem).repeat(len - sLen))
@@ -335,7 +336,7 @@ final class StringOps(private val s: String) extends AnyVal {
 
   /** A copy of the String with an char prepended */
   def prepended(c: Char): String =
-    new StringBuilder(s.length + 1).append(c).append(s).toString
+    new JStringBuilder(s.length + 1).append(c).append(s).toString
 
   /** Alias for `prepended` */
   @`inline` def +: (c: Char): String = prepended(c)
@@ -373,7 +374,7 @@ final class StringOps(private val s: String) extends AnyVal {
 
   /** A copy of the String with an element appended */
   def appended(c: Char): String =
-    new StringBuilder(s.length + 1).append(s).append(c).toString
+    new JStringBuilder(s.length + 1).append(s).append(c).toString
 
   /** Alias for `appended` */
   @`inline` def :+ (c: Char): String = appended(c)
@@ -451,7 +452,7 @@ final class StringOps(private val s: String) extends AnyVal {
     */
   def patch(from: Int, other: String, replaced: Int): String = {
     val len = s.length
-    val sb = new StringBuilder(len + other.size - replaced)
+    val sb = new JStringBuilder(len + other.size - replaced)
     val chunk1 = if(from > 0) min(from, len) else 0
     if(chunk1 > 0) sb.append(s, 0, chunk1)
     sb.append(other)
@@ -467,7 +468,7 @@ final class StringOps(private val s: String) extends AnyVal {
     *  @throws IndexOutOfBoundsException if `index` does not satisfy `0 <= index < length`.
     */
   def updated(index: Int, elem: Char): String = {
-    val sb = new StringBuilder(s.length).append(s)
+    val sb = new JStringBuilder(s.length).append(s)
     sb.setCharAt(index, elem)
     sb.toString
   }
@@ -491,8 +492,8 @@ final class StringOps(private val s: String) extends AnyVal {
     *               `end`. Inside, the string chars of this string are separated by
     *               the string `sep`.
     */
-  def mkString(start: String, sep: String, end: String): String =
-    addString(new mutable.StringBuilder(), start, sep, end).toString
+  final def mkString(start: String, sep: String, end: String): String =
+    addString(new StringBuilder(), start, sep, end).toString
 
   /** Displays all elements of this string in a string using a separator string.
     *
@@ -500,30 +501,39 @@ final class StringOps(private val s: String) extends AnyVal {
     *  @return      In the resulting string
     *               the chars of this string are separated by the string `sep`.
     */
-  def mkString(sep: String): String = mkString("", sep, "")
+  @inline final def mkString(sep: String): String =
+    if (sep.isEmpty || s.length < 2) s
+    else mkString("", sep, "")
 
   /** Returns this String */
-  def mkString: String = s
+  @inline final def mkString: String = s
 
   /** Appends this string to a string builder. */
-  def addString(b: mutable.StringBuilder): mutable.StringBuilder =
-    b.append(s)
+  @inline final def addString(b: StringBuilder): StringBuilder = b.append(s)
 
   /** Appends this string to a string builder using a separator string. */
-  def addString(b: mutable.StringBuilder, sep: String): mutable.StringBuilder =
+  @inline final def addString(b: StringBuilder, sep: String): StringBuilder =
     addString(b, "", sep, "")
 
   /** Appends this string to a string builder using start, end and separator strings. */
-  def addString(b: mutable.StringBuilder, start: String, sep: String, end: String): mutable.StringBuilder = {
-    b.append(start)
+  final def addString(b: StringBuilder, start: String, sep: String, end: String): StringBuilder = {
+    val jsb = b.underlying
+    if (start.length != 0) jsb.append(start)
     val len = s.length
-    var i = 0
-    while(i < len) {
-      if(i != 0) b.append(sep)
-      b.append(s.charAt(i))
-      i += 1
+    if (len != 0) {
+      if (sep.isEmpty) jsb.append(s)
+      else {
+        jsb.ensureCapacity(jsb.length + len + end.length + (len - 1) * sep.length)
+        jsb.append(s.charAt(0))
+        var i = 1
+        while (i < len) {
+          jsb.append(sep)
+          jsb.append(s.charAt(i))
+          i += 1
+        }
+      }
     }
-    b.append(end)
+    if (end.length != 0) jsb.append(end)
     b
   }
 
@@ -551,7 +561,7 @@ final class StringOps(private val s: String) extends AnyVal {
   /** Return the current string concatenated `n` times.
     */
   def *(n: Int): String = {
-    val sb = new StringBuilder(s.length * n)
+    val sb = new JStringBuilder(s.length * n)
     var i = 0
     while (i < n) {
       sb.append(s)
@@ -652,7 +662,7 @@ final class StringOps(private val s: String) extends AnyVal {
     *  followed by `marginChar` from the line.
     */
   def stripMargin(marginChar: Char): String = {
-    val sb = new StringBuilder(s.length)
+    val sb = new JStringBuilder(s.length)
     for (line <- linesWithSeparators) {
       val len = line.length
       var index = 0
@@ -756,11 +766,11 @@ final class StringOps(private val s: String) extends AnyVal {
    * @throws java.lang.IllegalArgumentException  If the string does not contain a parsable `Boolean`.
    */
   def toBoolean: Boolean               = toBooleanImpl(s)
-  
+
   /**
    * Try to parse as a `Boolean`
    * @return `Some(true)` if the string is "true" case insensitive,
-   * `Some(false)` if the string is "false" case insensitive, 
+   * `Some(false)` if the string is "false" case insensitive,
    * and `None` if the string is anything else
    * @throws java.lang.NullPointerException if the string is `null`
    */
@@ -797,7 +807,7 @@ final class StringOps(private val s: String) extends AnyVal {
     * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Int`.
     */
   def toInt: Int                       = java.lang.Integer.parseInt(s)
-  
+
   /**
    * Try to parse as an `Int`
    * @return `Some(value)` if the string contains a valid Int value, otherwise `None`
@@ -1044,7 +1054,7 @@ final class StringOps(private val s: String) extends AnyVal {
   @`inline` def nonEmpty: Boolean = !s.isEmpty
 
   /** Returns new sequence with elements in reversed order. */
-  def reverse: String = new StringBuilder(s).reverse().toString
+  def reverse: String = new JStringBuilder(s).reverse().toString
 
   /** An iterator yielding chars in reversed order.
     *
@@ -1110,7 +1120,7 @@ final class StringOps(private val s: String) extends AnyVal {
   /** Selects all chars of this string which satisfy a predicate. */
   def filter(pred: Char => Boolean): String = {
     val len = s.length
-    val sb = new StringBuilder(len)
+    val sb = new JStringBuilder(len)
     var i = 0
     while (i < len) {
       val x = s.charAt(i)
@@ -1247,7 +1257,7 @@ final class StringOps(private val s: String) extends AnyVal {
 
   /** A pair of, first, all chars that satisfy predicate `p` and, second, all chars that do not. */
   def partition(p: Char => Boolean): (String, String) = {
-    val res1, res2 = new StringBuilder
+    val res1, res2 = new JStringBuilder
     var i = 0
     val len = s.length
     while(i < len) {

--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -3,7 +3,7 @@ package collection.immutable
 
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
-import scala.collection.mutable.{ArrayBuffer, ArrayBuilder, Builder}
+import scala.collection.mutable.{ArrayBuffer, ArrayBuilder, Builder, ArraySeq => MutableArraySeq}
 import scala.collection.{ArrayOps, ClassTagSeqFactory, SeqFactory, StrictOptimizedClassTagSeqFactory, View}
 import scala.annotation.unchecked.uncheckedVariance
 import scala.util.hashing.MurmurHash3
@@ -205,7 +205,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
    * `ArraySeq.unsafeWrapArray(a.asInstanceOf[Array[Int]])` does not work, it throws a
    * `ClassCastException` at runtime.
    */
-  def unsafeWrapArray[T](x: Array[T]): ArraySeq[T] = (x.asInstanceOf[Array[_]] match {
+  def unsafeWrapArray[T](x: Array[T]): ArraySeq[T] = ((x: Array[_]) match {
     case null              => null
     case x: Array[AnyRef]  => new ofRef[AnyRef](x)
     case x: Array[Int]     => new ofInt(x)
@@ -269,6 +269,9 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofChar => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+
+    override def addString(sb: StringBuilder, start: String, sep: String, end: String): StringBuilder =
+      (new MutableArraySeq.ofChar(unsafeArray)).addString(sb, start, sep, end)
   }
 
   @SerialVersionUID(3L)

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -3,6 +3,7 @@ package collection
 package immutable
 
 import java.io.{ObjectInputStream, ObjectOutputStream}
+import java.lang.{StringBuilder => JStringBuilder}
 
 import scala.collection.mutable.{ArrayBuffer, Builder}
 import scala.annotation.tailrec
@@ -370,14 +371,20 @@ sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with Laz
     *  @param end   the ending string.
     *  @return      the string builder `b` to which elements were appended.
     */
-  override def addString(b: StringBuilder, start: String, sep: String, end: String): b.type = {
-    b append start
+  override def addString(sb: StringBuilder, start: String, sep: String, end: String): StringBuilder = {
+    force
+    addStringNoForce(sb.underlying, start, sep, end)
+    sb
+  }
+
+  private[this] def addStringNoForce(b: JStringBuilder, start: String, sep: String, end: String): JStringBuilder = {
+    b.append(start)
     if (nonEmpty) {
-      if (headDefined) b append head else b append "_"
+      if (headDefined) b.append(head) else b.append('_')
       var cursor = this
-      def appendCursorElement(): Unit = {
-        b append sep
-        if (cursor.headDefined) b append cursor.head else b append "_"
+      def appendCursorElement() = {
+        b.append(sep)
+        if (cursor.headDefined) b.append(cursor.head) else b.append('_')
       }
       if (tailDefined) {  // If tailDefined, also !isEmpty
         var scout = tail
@@ -437,22 +444,12 @@ sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with Laz
       }
       if (cursor.nonEmpty) {
         // Either undefined or cyclic; we can check with tailDefined
-        if (!cursor.tailDefined) b append sep append "?"
-        else b append sep append "..."
+        if (!cursor.tailDefined) b.append(sep).append('?')
+        else b.append(sep).append("...")
       }
     }
-    b append end
-    b
+    b.append(end)
   }
-
-  override def mkString(start: String, sep: String, end: String): String = {
-    this.force
-    super.mkString(start, sep, end)
-  }
-
-  // override here to ensure disambiguation between the overloaded methods works correctly
-  override def mkString(sep: String): String = super.mkString(sep)
-  override def mkString: String = super.mkString
 
   protected[this] def className: String
 
@@ -470,7 +467,7 @@ sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with Laz
     *           - `"LazyList(1, 2, 3, ...)"`, an infinite lazy list that contains
     *             a cycle at the fourth element.
     */
-  override def toString = super.mkString(className + "(", ", ", ")")
+  override def toString = addStringNoForce(new JStringBuilder(className), "(", ", ", ")").toString
 }
 
 private[immutable] object LazyListOps {

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -24,7 +24,7 @@ import java.util.Arrays
   *  @define willNotTerminateInf
   */
 @SerialVersionUID(3L)
-abstract class ArraySeq[T]
+sealed abstract class ArraySeq[T]
   extends AbstractSeq[T]
     with IndexedSeq[T]
     with IndexedSeqOps[T, ArraySeq, ArraySeq[T]]
@@ -183,6 +183,27 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
     override def equals(that: Any) = that match {
       case that: ofChar => Arrays.equals(array, that.array)
       case _ => super.equals(that)
+    }
+
+    override def addString(sb: StringBuilder, start: String, sep: String, end: String): StringBuilder = {
+      val jsb = sb.underlying
+      if (start.length != 0) jsb.append(start)
+      val len = array.length
+      if (len != 0) {
+        if (sep.isEmpty) jsb.append(array)
+        else {
+          jsb.ensureCapacity(jsb.length + len + end.length + (len - 1) * sep.length)
+          jsb.append(array(0))
+          var i = 1
+          while (i < len) {
+            jsb.append(sep)
+            jsb.append(array(i))
+            i += i
+          }
+        }
+      }
+      if (end.length != 0) jsb.append(end)
+      sb
     }
   }
 

--- a/src/library/scala/collection/mutable/Builder.scala
+++ b/src/library/scala/collection/mutable/Builder.scala
@@ -83,7 +83,7 @@ trait Builder[-A, +To] extends Growable[A] { self =>
   *  section on `StringBuilders` for more information.
   */
 @SerialVersionUID(3L)
-class StringBuilder(private val underlying: java.lang.StringBuilder) extends AbstractSeq[Char]
+final class StringBuilder(val underlying: java.lang.StringBuilder) extends AbstractSeq[Char]
   with Builder[Char, String]
   with IndexedSeq[Char]
   with IndexedSeqOps[Char, IndexedSeq, StringBuilder]
@@ -119,7 +119,7 @@ class StringBuilder(private val underlying: java.lang.StringBuilder) extends Abs
   override protected def newSpecificBuilder: Builder[Char, StringBuilder] =
     new GrowableBuilder(new StringBuilder())
 
-  def length: Int = underlying.length()
+  def length: Int = underlying.length
 
   def length_=(n: Int): Unit = underlying.setLength(n)
 
@@ -137,6 +137,22 @@ class StringBuilder(private val underlying: java.lang.StringBuilder) extends Abs
 
   override def toString = result()
 
+  override def toArray[B >: Char](implicit  ct: scala.reflect.ClassTag[B]) =
+    ct.runtimeClass match {
+      case java.lang.Character.TYPE => toCharArray.asInstanceOf[Array[B]]
+      case _ => super.toArray
+    }
+
+  /** Returns the contents of this StringBuilder as an `Array[Char]`.
+   *
+   *  @return  An array with the characters from this builder.
+   */
+  def toCharArray: Array[Char] = {
+    val len = underlying.length
+    val arr = new Array[Char](len)
+    underlying.getChars(0, len, arr, 0)
+    arr
+  }
   // append* methods delegate to the underlying java.lang.StringBuilder:
 
   def appendAll(xs: String): StringBuilder = {

--- a/src/library/scala/io/BufferedSource.scala
+++ b/src/library/scala/io/BufferedSource.scala
@@ -11,6 +11,7 @@ package scala.io
 import java.io.{ InputStream, BufferedReader, InputStreamReader, PushbackReader }
 import Source.DefaultBufSize
 import scala.collection.{ Iterator, AbstractIterator }
+import scala.collection.mutable.StringBuilder
 
 /** This object provides convenience methods to create an iterable
  *  representation of a source file.
@@ -83,17 +84,29 @@ class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val cod
 
   override def getLines(): Iterator[String] = new BufferedLineIterator
 
-  /** Efficiently converts the entire remaining input into a string. */
-  override def mkString = {
-    // Speed up slurping of whole data set in the simplest cases.
-    val allReader = decachedReader
-    val sb = new StringBuilder
-    val buf = new Array[Char](bufferSize)
-    var n = 0
-    while (n != -1) {
-      n = allReader.read(buf)
-      if (n>0) sb.appendAll(buf, 0, n)
-    }
-    sb.result
-  }
+  /** Efficiently appends the entire remaining input.
+   *
+   *  Note: This function may temporarily load the entire buffer into
+   *  memory.
+   */
+  override def addString(sb: StringBuilder, start: String, sep: String, end: String): StringBuilder =
+    if (sep.isEmpty) {
+      val allReader = decachedReader
+      val buf = new Array[Char](bufferSize)
+      val jsb = sb.underlying
+
+      if (start.length != 0) jsb.append(start)
+      var n = allReader.read(buf)
+      while (n != -1) {
+        jsb.append(buf, 0, n)
+        n = allReader.read(buf)
+      }
+      if (end.length != 0) jsb.append(end)
+      sb
+    // This case is expected to be uncommon, so we're reusing code at
+    // the cost of temporary memory allocations.
+    // mkString will callback into BufferedSource.addString to read
+    // the Buffer into a String, and then we use StringOps.addString
+    // for the interspersing of sep.
+    } else mkString.addString(sb, start, sep, end)
 }

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -419,8 +419,8 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
     @deprecated("use `toList.reverse` instead", "2.10.0") // Used in sbt 0.12.4
     def reverse: List[Symbol] = toList.reverse
 
-    override def mkString(start: String, sep: String, end: String) =
-      toList.map(_.defString).mkString(start, sep, end)
+    override def addString(sb: StringBuilder, start: String, sep: String, end: String) =
+      toList.map(_.defString).addString(sb, start, sep, end)
 
     override def toString(): String = mkString("Scope{\n  ", ";\n  ", "\n}")
   }

--- a/test/junit/scala/collection/MapTest.scala
+++ b/test/junit/scala/collection/MapTest.scala
@@ -24,4 +24,17 @@ class MapTest {
 
     assertEquals(expected, actual)
   }
+
+  @Test def mkString(): Unit = {
+    assert(Map().mkString == "")
+    assert(Map(1 -> 1).mkString(",") == "1 -> 1")
+    assert(Map(1 -> 1, 2 -> 2).mkString(",") == "1 -> 1,2 -> 2")
+  }
+
+  @Test def addString(): Unit = {
+    assert(Map().addString(new StringBuilder).toString == "")
+    assert(Map(1 -> 1).addString(new StringBuilder).toString == "1 -> 1")
+    assert(Map(1 -> 1, 2 -> 2).mkString("foo [", ", ", "] bar").toString ==
+      "foo [1 -> 1, 2 -> 2] bar")
+  }
 }

--- a/test/junit/scala/collection/StringOpsTest.scala
+++ b/test/junit/scala/collection/StringOpsTest.scala
@@ -12,5 +12,12 @@ class StringOpsTest {
     assert("".mkString(",") == "")
     assert("a".mkString(",") == "a")
     assert("ab".mkString(",") == "a,b")
+    assert("ab".mkString("foo", ",", "bar") == "fooa,bbar")
+  }
+
+  @Test def addString(): Unit = {
+    assert("".addString(new StringBuilder).toString == "")
+    assert("a".addString(new StringBuilder, ",").toString == "a")
+    assert("".addString(new StringBuilder, "foo", ",", "bar").toString == "foobar")
   }
 }

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -340,28 +340,22 @@ class LazyListTest {
 
     def precyc(n: Int, m: Int) = pre(n) #::: cyc(m)
 
-    def str(s: Stream[Int]) = {
-      val b = new StringBuilder
-      s.addString(b, "", "", "")
-      b.toString
-    }
-
     def goal(n: Int, m: Int) = (-n until m).mkString + "..."
 
     // Check un-forced cyclic and non-cyclic streams
-    assertEquals(pre(2).take(1).toList.mkString + "?", str(pre(2)))
-    assertEquals(cyc(2).take(1).toList.mkString + "?", str(cyc(2)))
-    assertEquals(precyc(2,2).take(1).toList.mkString + "?", str(precyc(2,2)))
+    assertEquals("Stream(-2, ?)", pre(2).toString)
+    assertEquals("Stream(0, ?)", cyc(2).toString)
+    assertEquals("Stream(-2, ?)", precyc(2,2).toString)
 
     // Check forced cyclic and non-cyclic streams
-    assertEquals((-2 to -1).mkString, str(pre(2).force))
-    assertEquals((0 until 2).mkString + "...", str(cyc(2).force))
-    assertEquals((-2 until 2).mkString + "...", str(precyc(2,2).force))
+    assertEquals("Stream(-2, -1)", pre(2).force.toString)
+    assertEquals("Stream(0, 1, ...)", cyc(2).force.toString)
+    assertEquals("Stream(-2, -1, 0, 1, ...)", precyc(2,2).force.toString)
 
     // Special cases
-    assertEquals(goal(0,1), str(cyc(1).force))
-    assertEquals(goal(1,6), str(precyc(1,6).force))
-    assertEquals(goal(6,1), str(precyc(6,1).force))
+    assertEquals("Stream(0, ...)", cyc(1).force.toString)
+    assertEquals("Stream(-1, 0, 1, 2, 3, 4, 5, ...)", precyc(1,6).force.toString)
+    assertEquals("Stream(-6, -5, -4, -3, -2, -1, 0, ...)", precyc(6,1).force.toString)
 
     // Make sure there are no odd/even problems
     for (n <- 3 to 4; m <- 3 to 4) {

--- a/test/junit/scala/collection/mutable/StringBuilderTest.scala
+++ b/test/junit/scala/collection/mutable/StringBuilderTest.scala
@@ -1,6 +1,6 @@
 package scala.collection.mutable
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
@@ -19,5 +19,13 @@ class StringBuilderTest {
     val b2 = b.map(c => (c + 1).toChar)
     val b2t: IndexedSeq[Char] = b2
     assertEquals(b2t.toString, "ArrayBuffer(b, c, d, e)")
+  }
+
+
+  @Test
+  def testToArray(): Unit = {
+    val b = new StringBuilder("ab")
+    assertArrayEquals(Array('a', 'b'), b.toCharArray)
+    assertArrayEquals(Array('a', 'b'), b.toArray)
   }
 }


### PR DESCRIPTION
- Short circuit empty collections
- Switch to java Stringbuilder
- mark `mkString`/`addString` methods final, create a overridable
  function
- fix Map.addString regression and add test