### PR TITLE
Lazier LazyList.

### DIFF
--- a/src/library/scala/sys/process/BasicIO.scala
+++ b/src/library/scala/sys/process/BasicIO.scala
@@ -43,11 +43,11 @@ object BasicIO {
   private[process] object Streamed {
     def apply[T](nonzeroException: Boolean, capacity: Integer): Streamed[T] = {
       val q = new LinkedBlockingQueue[Either[Int, T]](capacity)
-      def next(): LazyList[T] = q.take match {
+      def next(): LazyList[T] = LazyList.suspend(q.take match {
         case Left(0)    => LazyList.empty
         case Left(code) => if (nonzeroException) scala.sys.error("Nonzero exit code: " + code) else LazyList.empty
         case Right(s)   => LazyList.cons(s, next())
-      }
+      })
       new Streamed((s: T) => q put Right(s), code => q put Left(code), () => next())
     }
   }

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -42,7 +42,7 @@ class LazyListTest {
     }
 
     val res = Try { op(ref(), gcAndThrowIfCollected) }.failed       // success is indicated by an
-    val msg = res.map(_.getMessage).getOrElse(msgFailureGC)         // exception with expected message 
+    val msg = res.map(_.getMessage).getOrElse(msgFailureGC)         // exception with expected message
                                                                     // failure is indicated by no
     assertTrue(msg == msgSuccessGC)                                 // exception, or one with different message
   }
@@ -76,7 +76,7 @@ class LazyListTest {
       if (shouldThrow && n == 5) throw new RuntimeException("n == 5") else n > 5
     }
 
-    assertEquals(true, Try { wf.map(identity) }.isFailure) // throws on n == 5
+    assertEquals(true, Try { wf.map(identity).force }.isFailure) // throws on n == 5
 
     shouldThrow = false                              // won't throw next time
 


### PR DESCRIPTION
As lamented in scala/bug#10696 and bemoaned in scala/collection-strawman#367, `LazyList` (and `Stream` before it) does not have a way of representing a collection with uncomputed emptiness. This adds a third subclass of `LazyList`, `LazyList.Suspended`, which wraps a closure returning a `LazyList`, and only evaluates it when needed. This is about as lazy of a list as I can imagine, now.

Two tests are currently failing, both because `ll.filter(...).map(...)` is even lazier than contemplated. I'm not sure how to test for the linked bug (scala/bug#9134); I'll take suggestions or think about it over the vacation.

BTW, this is the very first thing I've done with the new collections, so I hope it's stylistically alright. Let me know if I've broken convention or something.

Fixes scala/bug#10696.
Fixes scala/collection-strawman#367.