### PR TITLE
Fix error in HashMap.HashMapCollision1.merge0

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -297,7 +297,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
     protected override def merge0[B1 >: B](that: HashMap[A, B1], level: Int, merger: Merger[A, B1]): HashMap[A, B1] = {
       // this can be made more efficient by passing the entire ListMap at once
       var m = that
-      for (p <- kvs) m = m.updated0(p._1, this.hash, level, p._2, p, merger)
+      for (p <- kvs) m = m.updated0(p._1, this.hash, level, p._2, p, merger.invert)
       m
     }
   }

--- a/test/junit/scala/collection/immutable/HashMapTest.scala
+++ b/test/junit/scala/collection/immutable/HashMapTest.scala
@@ -45,4 +45,14 @@ class HashMapTest {
     }
     assertEquals(expected, mergedWithMergeFunction)
   }
+
+  @Test
+  def canMergeHashMapCollision1WithCorrectMerege() {
+    case class A(k: Int) { override def hashCode = 0 }
+    val m1 = HashMap(A(0) -> 2, A(1) -> 2)
+    val m2 = HashMap(A(0) -> 1, A(1) -> 1)
+    val merged = m1.merged(m2) { case ((k, l), (_, r)) => k -> (l - r) }
+    val expected = HashMap(A(0) -> 1, A(1) -> 1)
+    assertEquals(merged, expected)
+  }
 }


### PR DESCRIPTION
This is the same pull request with: https://github.com/scala/scala/pull/6873
@retronym commented that I should write a test code and pull request into 2.12.x version.
I closed the previous pull request on version 2.13.x.