### PR TITLE
Use MathContext in BigDecimal operations

### DIFF
--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -481,11 +481,11 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
 
   /** Addition of BigDecimals
    */
-  def +  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal add that.bigDecimal, mc)
+  def +  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.add(that.bigDecimal, mc), mc)
 
   /** Subtraction of BigDecimals
    */
-  def -  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal subtract that.bigDecimal, mc)
+  def -  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.subtract(that.bigDecimal, mc), mc)
 
   /** Multiplication of BigDecimals
    */
@@ -499,14 +499,14 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    *  divideToIntegralValue and the remainder.  The computation is exact: no rounding is applied.
    */
   def /% (that: BigDecimal): (BigDecimal, BigDecimal) =
-    this.bigDecimal.divideAndRemainder(that.bigDecimal) match {
+    this.bigDecimal.divideAndRemainder(that.bigDecimal, mc) match {
       case Array(q, r)  => (new BigDecimal(q, mc), new BigDecimal(r, mc))
     }
 
   /** Divide to Integral value.
    */
   def quot (that: BigDecimal): BigDecimal =
-    new BigDecimal(this.bigDecimal divideToIntegralValue that.bigDecimal, mc)
+    new BigDecimal(this.bigDecimal.divideToIntegralValue(that.bigDecimal, mc), mc)
 
   /** Returns the minimum of this and that, or this if the two are equal
    */
@@ -524,11 +524,11 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
 
   /** Remainder after dividing this by that.
    */
-  def remainder (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal remainder that.bigDecimal, mc)
+  def remainder (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.remainder(that.bigDecimal, mc), mc)
 
   /** Remainder after dividing this by that.
    */
-  def % (that: BigDecimal): BigDecimal = this remainder that
+  def % (that: BigDecimal): BigDecimal = this.remainder(that)
 
   /** Returns a BigDecimal whose value is this ** n.
    */
@@ -536,7 +536,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
 
   /** Returns a BigDecimal whose value is the negation of this BigDecimal
    */
-  def unary_- : BigDecimal = new BigDecimal(this.bigDecimal.negate(), mc)
+  def unary_- : BigDecimal = new BigDecimal(this.bigDecimal.negate(mc), mc)
 
   /** Returns the absolute value of this BigDecimal
    */

--- a/test/junit/scala/math/BigDecimalTest.scala
+++ b/test/junit/scala/math/BigDecimalTest.scala
@@ -4,6 +4,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
 import java.math.{BigDecimal => BD, MathContext => MC}
+import java.util.Formatter.BigDecimalLayoutForm
 
 /* Tests various maps by making sure they all agree on the same answers. */
 @RunWith(classOf[JUnit4])
@@ -257,6 +258,29 @@ class BigDecimalTest {
 
     testPrecision()
     testRounded()
+  }
+
+  // Motivated by scala/bug#10882: Operators for BigDecimal don't use value of mc (MathContext)
+  @Test
+  def testUsesMathContextInOperators(): Unit = {
+    def isAE[A](a: => A): Boolean = try { a; false } catch { case e: ArithmeticException => true }
+
+    val bd128 = BigDecimal("4.2e1000", MC.DECIMAL128)
+    assert(bd128 + 10 == bd128)
+    assert(bd128 - 10 == bd128)
+    assert(bd128 + BigDecimal("1e100", MC.UNLIMITED) == bd128)
+    assert(bd128 - BigDecimal("1e100", MC.UNLIMITED) == bd128)
+    assert(bd128.quot(BigDecimal("1e100", MC.UNLIMITED)) == BigDecimal("4.2e900", MC.DECIMAL128))
+    assert(isAE(bd128.quot(BigDecimal("1e100", MC.UNLIMITED) + 1)))
+    assert(isAE(bd128 % (BigDecimal("1e100", MC.UNLIMITED) + 1)))
+    assert(isAE(bd128 /% (BigDecimal("1e100", MC.UNLIMITED) + 1)))
+
+    val bdUnlimited = BigDecimal("4.2e1000", MC.UNLIMITED)
+    assert(bdUnlimited + 10 > bdUnlimited)
+    assert(bdUnlimited - 10 < bdUnlimited)
+    assert(bdUnlimited + BigDecimal("1e100", MC.DECIMAL128) > bdUnlimited)
+    assert(bdUnlimited - BigDecimal("1e100", MC.DECIMAL128) < bdUnlimited)
+    assert(bdUnlimited.quot(BigDecimal("1e100", MC.DECIMAL128)) == BigDecimal("4.2e900", MC.UNLIMITED))
   }
 
   @Test


### PR DESCRIPTION
Since a `BigDecimal` contains a `MathContext`, one would expect that to be used for all the operators where the Java API allows it. Currently that is not always the case. This adds the `MathContext` to all operations where it makes sense to use it, passing it along as an extra parameter to the Java method.

I believe this makes sense because we are already doing it for `*` and `/`, and it appears the `MathContext` was omitted from the others for no particular reason.

Fixes scala/bug#10882.