### PR TITLE
Use by-name parameter for Properties.*OrElse

### DIFF
--- a/src/compiler/scala/tools/reflect/WrappedProperties.scala
+++ b/src/compiler/scala/tools/reflect/WrappedProperties.scala
@@ -20,12 +20,12 @@ trait WrappedProperties extends PropertiesTrait {
   protected def pickJarBasedOn = this.getClass
 
   override def propIsSet(name: String)               = wrap(super.propIsSet(name)) exists (x => x)
-  override def propOrElse(name: String, alt: String) = wrap(super.propOrElse(name, alt)) getOrElse alt
+  override def propOrElse(name: String, alt: => String) = wrap(super.propOrElse(name, alt)) getOrElse alt
   override def setProp(name: String, value: String)  = wrap(super.setProp(name, value)).orNull
   override def clearProp(name: String)               = wrap(super.clearProp(name)).orNull
-  override def envOrElse(name: String, alt: String)  = wrap(super.envOrElse(name, alt)) getOrElse alt
+  override def envOrElse(name: String, alt: => String)  = wrap(super.envOrElse(name, alt)) getOrElse alt
   override def envOrNone(name: String)               = wrap(super.envOrNone(name)).flatten
-  override def envOrSome(name: String, alt: Option[String]) = wrap(super.envOrNone(name)).flatten orElse alt
+  override def envOrSome(name: String, alt: => Option[String]) = wrap(super.envOrNone(name)).flatten orElse alt
 
   def systemProperties: List[(String, String)] = {
     import scala.collection.JavaConverters._

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -49,7 +49,7 @@ private[scala] trait PropertiesTrait {
 
   def propIsSet(name: String)                   = System.getProperty(name) != null
   def propIsSetTo(name: String, value: String)  = propOrNull(name) == value
-  def propOrElse(name: String, alt: String)     = System.getProperty(name, alt)
+  def propOrElse(name: String, alt: => String)     = Option(System.getProperty(name)).getOrElse(alt)
   def propOrEmpty(name: String)                 = propOrElse(name, "")
   def propOrNull(name: String)                  = propOrElse(name, null)
   def propOrNone(name: String)                  = Option(propOrNull(name))
@@ -57,13 +57,13 @@ private[scala] trait PropertiesTrait {
   def setProp(name: String, value: String)      = System.setProperty(name, value)
   def clearProp(name: String)                   = System.clearProperty(name)
 
-  def envOrElse(name: String, alt: String)      = Option(System getenv name) getOrElse alt
+  def envOrElse(name: String, alt: => String)      = Option(System getenv name) getOrElse alt
   def envOrNone(name: String)                   = Option(System getenv name)
 
-  def envOrSome(name: String, alt: Option[String])       = envOrNone(name) orElse alt
+  def envOrSome(name: String, alt: => Option[String])       = envOrNone(name) orElse alt
 
   // for values based on propFilename, falling back to System properties
-  def scalaPropOrElse(name: String, alt: String): String = scalaPropOrNone(name).getOrElse(alt)
+  def scalaPropOrElse(name: String, alt: => String): String = scalaPropOrNone(name).getOrElse(alt)
   def scalaPropOrEmpty(name: String): String             = scalaPropOrElse(name, "")
   def scalaPropOrNone(name: String): Option[String]      = Option(scalaProps.getProperty(name)).orElse(propOrNone("scala." + name))
 

--- a/test/junit/scala/util/PropertiesTest.scala
+++ b/test/junit/scala/util/PropertiesTest.scala
@@ -1,0 +1,43 @@
+package scala.util
+
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert._
+
+class PropertiesTest {
+  final val TestProperty = "scala.util.PropertiesTest.__test_property__"
+
+  @Before
+  def beforeEach(): Unit = {
+    Properties.clearProp(TestProperty)
+  }
+
+  @Test
+  def testPropOrNone(): Unit = {
+    assertEquals(Properties.propOrNone(TestProperty), None)
+
+    Properties.setProp(TestProperty, "foo")
+
+    assertEquals(Properties.propOrNone(TestProperty), Some("foo"))
+  }
+
+  @Test
+  def testPropOrElse(): Unit = {
+    assertEquals(Properties.propOrElse(TestProperty, "bar"), "bar")
+
+    Properties.setProp(TestProperty, "foo")
+
+    var done = false
+    assertEquals(Properties.propOrElse(TestProperty, { done = true; "bar" }), "foo")
+    assertTrue("Does not evaluate alt if not needed", done == false)
+  }
+
+  @Test
+  def testEnvOrElse(): Unit = {
+    assertEquals(Properties.envOrElse("_PropertiesTest_NOT_DEFINED", "test"), "test")
+
+    var done = false
+    assertNotEquals(Properties.envOrElse("JAVA_HOME", { done = true; "bar" }), "bar")
+    assertTrue("Does not evaluate alt if not needed", done == false)
+  }
+}


### PR DESCRIPTION
Adds a by-name parameter to the *OrElse methods in `scala.util.PropertiesTrait` and its inheritors. This matches the convention in `Option` and other scala types with similar methods, and avoids doing potentially expensive computation of the default value.

Fixes scala/bug#9246.