### PR TITLE
Deprecate early definitions under -Xsource:2.14

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -3000,9 +3000,14 @@ self =>
     def template(): (List[Tree], ValDef, List[Tree]) = {
       newLineOptWhenFollowedBy(LBRACE)
       if (in.token == LBRACE) {
+        val braceOffset = in.offset
         // @S: pre template body cannot stub like post body can!
         val (self, body) = templateBody(isPre = true)
         if (in.token == WITH && (self eq noSelfType)) {
+          val advice =
+            if (settings.isScala214) "use trait parameters instead."
+            else "they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits."
+          deprecationWarning(braceOffset, s"early initializers are deprecated; $advice", "2.13.0")
           val earlyDefs: List[Tree] = body.map(ensureEarlyDef).filter(_.nonEmpty)
           in.nextToken()
           val parents = templateParents()

--- a/test/files/neg/early-type-defs.check
+++ b/test/files/neg/early-type-defs.check
@@ -1,4 +1,8 @@
-early-type-defs.scala:3: error: early type members are unsupported: move them to the regular body; the semantics are the same
-object Test extends { type A1 = Int } with App
+early-type-defs.scala:4: warning: early initializers are deprecated; use trait parameters instead.
+object Test extends { type A1 = Int } with Runnable { def run() = () }
+                    ^
+early-type-defs.scala:4: error: early type members are unsupported: move them to the regular body; the semantics are the same
+object Test extends { type A1 = Int } with Runnable { def run() = () }
                            ^
+one warning found
 one error found

--- a/test/files/neg/early-type-defs.scala
+++ b/test/files/neg/early-type-defs.scala
@@ -1,3 +1,4 @@
+//
 // scalac: -deprecation -Xsource:2.14
 //
-object Test extends { type A1 = Int } with App
+object Test extends { type A1 = Int } with Runnable { def run() = () }

--- a/test/files/neg/t2796.check
+++ b/test/files/neg/t2796.check
@@ -1,9 +1,18 @@
-t2796.scala:13: warning: early type members are deprecated: move them to the regular body; the semantics are the same
+t2796.scala:9: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+trait T1 extends {
+                 ^
+t2796.scala:13: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+trait T2 extends {
+                 ^
+t2796.scala:14: warning: early type members are deprecated: move them to the regular body; the semantics are the same
   type X = Int                       // warn
        ^
-t2796.scala:9: warning: Implementation restriction: early definitions in traits are not initialized before the super class is initialized.
+t2796.scala:17: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+class C1 extends {
+                 ^
+t2796.scala:10: warning: Implementation restriction: early definitions in traits are not initialized before the super class is initialized.
   val abstractVal = "T1.abstractVal" // warn
       ^
 error: No warnings can be incurred under -Xfatal-warnings.
-two warnings found
+5 warnings found
 one error found

--- a/test/files/neg/t2796.scala
+++ b/test/files/neg/t2796.scala
@@ -1,3 +1,4 @@
+//
 // scalac: -deprecation -Xfatal-warnings
 //
 trait Base {

--- a/test/files/neg/t6595.check
+++ b/test/files/neg/t6595.check
@@ -1,0 +1,6 @@
+t6595.scala:5: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+class Foo extends {
+                  ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t6595.scala
+++ b/test/files/neg/t6595.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings
+// scalac: -Xfatal-warnings -deprecation
 //
 import scala.annotation.switch
 

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -1,120 +1,123 @@
-warn-unused-privates.scala:4: warning: private constructor in class Bippy is never used
+warn-unused-privates.scala:31: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+class Boppy extends {
+                    ^
+warn-unused-privates.scala:5: warning: private constructor in class Bippy is never used
   private def this(c: Int) = this(c, c)           // warn
               ^
-warn-unused-privates.scala:6: warning: private method boop in class Bippy is never used
+warn-unused-privates.scala:7: warning: private method boop in class Bippy is never used
   private def boop(x: Int)            = x+a+b     // warn
               ^
-warn-unused-privates.scala:8: warning: private val MILLIS2 in class Bippy is never used
+warn-unused-privates.scala:9: warning: private val MILLIS2 in class Bippy is never used
   final private val MILLIS2: Int      = 1000      // warn
                     ^
-warn-unused-privates.scala:15: warning: private val HEY_INSTANCE in object Bippy is never used
+warn-unused-privates.scala:16: warning: private val HEY_INSTANCE in object Bippy is never used
   private val HEY_INSTANCE: Int = 1000    // warn
               ^
-warn-unused-privates.scala:16: warning: private val BOOL in object Bippy is never used
+warn-unused-privates.scala:17: warning: private val BOOL in object Bippy is never used
   private lazy val BOOL: Boolean = true   // warn
                    ^
-warn-unused-privates.scala:40: warning: private val hummer in class Boppy is never used
+warn-unused-privates.scala:41: warning: private val hummer in class Boppy is never used
   private val hummer = "def" // warn
               ^
-warn-unused-privates.scala:47: warning: private var v1 in trait Accessors is never used
+warn-unused-privates.scala:48: warning: private var v1 in trait Accessors is never used
   private var v1: Int = 0 // warn
               ^
-warn-unused-privates.scala:48: warning: private var v2 in trait Accessors is never used
+warn-unused-privates.scala:49: warning: private var v2 in trait Accessors is never used
   private var v2: Int = 0 // warn, never set
               ^
-warn-unused-privates.scala:49: warning: private var v3 in trait Accessors is never used
+warn-unused-privates.scala:50: warning: private var v3 in trait Accessors is never used
   private var v3: Int = 0 // warn, never got
               ^
-warn-unused-privates.scala:60: warning: private var s1 in class StableAccessors is never used
+warn-unused-privates.scala:61: warning: private var s1 in class StableAccessors is never used
   private var s1: Int = 0 // warn
               ^
-warn-unused-privates.scala:61: warning: private var s2 in class StableAccessors is never updated: consider using immutable val
+warn-unused-privates.scala:62: warning: private var s2 in class StableAccessors is never updated: consider using immutable val
   private var s2: Int = 0 // warn, never set
               ^
-warn-unused-privates.scala:62: warning: private var s3 in class StableAccessors is never used
+warn-unused-privates.scala:63: warning: private var s3 in class StableAccessors is never used
   private var s3: Int = 0 // warn, never got
               ^
-warn-unused-privates.scala:74: warning: private default argument in trait DefaultArgs is never used
+warn-unused-privates.scala:75: warning: private default argument in trait DefaultArgs is never used
   private def bippy(x1: Int, x2: Int = 10, x3: Int = 15): Int = x1 + x2 + x3
                              ^
-warn-unused-privates.scala:74: warning: private default argument in trait DefaultArgs is never used
+warn-unused-privates.scala:75: warning: private default argument in trait DefaultArgs is never used
   private def bippy(x1: Int, x2: Int = 10, x3: Int = 15): Int = x1 + x2 + x3
                                            ^
-warn-unused-privates.scala:90: warning: local var x in method f0 is never used
+warn-unused-privates.scala:91: warning: local var x in method f0 is never used
     var x = 1 // warn
         ^
-warn-unused-privates.scala:97: warning: local val b in method f1 is never used
+warn-unused-privates.scala:98: warning: local val b in method f1 is never used
     val b = new Outer // warn
         ^
-warn-unused-privates.scala:107: warning: private object Dongo in object Types is never used
+warn-unused-privates.scala:108: warning: private object Dongo in object Types is never used
   private object Dongo { def f = this } // warn
                  ^
-warn-unused-privates.scala:117: warning: local object HiObject in method l1 is never used
+warn-unused-privates.scala:118: warning: local object HiObject in method l1 is never used
     object HiObject { def f = this } // warn
            ^
-warn-unused-privates.scala:140: warning: private method x_= in class OtherNames is never used
+warn-unused-privates.scala:141: warning: private method x_= in class OtherNames is never used
   private def x_=(i: Int): Unit = ()
               ^
-warn-unused-privates.scala:141: warning: private method x in class OtherNames is never used
+warn-unused-privates.scala:142: warning: private method x in class OtherNames is never used
   private def x: Int = 42
               ^
-warn-unused-privates.scala:142: warning: private method y_= in class OtherNames is never used
+warn-unused-privates.scala:143: warning: private method y_= in class OtherNames is never used
   private def y_=(i: Int): Unit = ()
               ^
-warn-unused-privates.scala:101: warning: local var x in method f2 is never updated: consider using immutable val
+warn-unused-privates.scala:102: warning: local var x in method f2 is never updated: consider using immutable val
     var x = 100 // warn about it being a var
         ^
-warn-unused-privates.scala:108: warning: private class Bar1 in object Types is never used
+warn-unused-privates.scala:109: warning: private class Bar1 in object Types is never used
   private class Bar1 // warn
                 ^
-warn-unused-privates.scala:110: warning: private type Alias1 in object Types is never used
+warn-unused-privates.scala:111: warning: private type Alias1 in object Types is never used
   private type Alias1 = String // warn
                ^
-warn-unused-privates.scala:118: warning: local class Hi is never used
+warn-unused-privates.scala:119: warning: local class Hi is never used
     class Hi { // warn
           ^
-warn-unused-privates.scala:122: warning: local class DingDongDoobie is never used
+warn-unused-privates.scala:123: warning: local class DingDongDoobie is never used
     class DingDongDoobie // warn
           ^
-warn-unused-privates.scala:125: warning: local type OtherThing is never used
+warn-unused-privates.scala:126: warning: local type OtherThing is never used
     type OtherThing = String // warn
          ^
-warn-unused-privates.scala:220: warning: private class for your eyes only in object not even using companion privates is never used
+warn-unused-privates.scala:221: warning: private class for your eyes only in object not even using companion privates is never used
   private implicit class `for your eyes only`(i: Int) {  // warn
                          ^
-warn-unused-privates.scala:236: warning: private class D in class nonprivate alias is enclosing is never used
+warn-unused-privates.scala:237: warning: private class D in class nonprivate alias is enclosing is never used
   private class D extends C2   // warn
                 ^
-warn-unused-privates.scala:157: warning: pattern var x in method f is never used; `x@_' suppresses this warning
+warn-unused-privates.scala:158: warning: pattern var x in method f is never used; `x@_' suppresses this warning
     val C(x, y, Some(z)) = c              // warn
           ^
-warn-unused-privates.scala:157: warning: pattern var y in method f is never used; `y@_' suppresses this warning
+warn-unused-privates.scala:158: warning: pattern var y in method f is never used; `y@_' suppresses this warning
     val C(x, y, Some(z)) = c              // warn
              ^
-warn-unused-privates.scala:157: warning: pattern var z in method f is never used; `z@_' suppresses this warning
+warn-unused-privates.scala:158: warning: pattern var z in method f is never used; `z@_' suppresses this warning
     val C(x, y, Some(z)) = c              // warn
                      ^
-warn-unused-privates.scala:165: warning: pattern var z in method h is never used; `z@_' suppresses this warning
+warn-unused-privates.scala:166: warning: pattern var z in method h is never used; `z@_' suppresses this warning
     val C(x @ _, y @ _, z @ Some(_)) = c  // warn for z?
                         ^
-warn-unused-privates.scala:170: warning: pattern var x in method v is never used; `x@_' suppresses this warning
+warn-unused-privates.scala:171: warning: pattern var x in method v is never used; `x@_' suppresses this warning
     val D(x) = d                          // warn
          ^
-warn-unused-privates.scala:205: warning: pattern var z in method f is never used; `z@_' suppresses this warning
+warn-unused-privates.scala:206: warning: pattern var z in method f is never used; `z@_' suppresses this warning
     case z => "warn"
          ^
-warn-unused-privates.scala:212: warning: pattern var z in method f is never used; `z@_' suppresses this warning
+warn-unused-privates.scala:213: warning: pattern var z in method f is never used; `z@_' suppresses this warning
     case Some(z) => "warn"
               ^
-warn-unused-privates.scala:22: warning: parameter value msg0 in class B3 is never used
+warn-unused-privates.scala:23: warning: parameter value msg0 in class B3 is never used
 class B3(msg0: String) extends A("msg")
          ^
-warn-unused-privates.scala:140: warning: parameter value i in method x_= is never used
+warn-unused-privates.scala:141: warning: parameter value i in method x_= is never used
   private def x_=(i: Int): Unit = ()
                   ^
-warn-unused-privates.scala:142: warning: parameter value i in method y_= is never used
+warn-unused-privates.scala:143: warning: parameter value i in method y_= is never used
   private def y_=(i: Int): Unit = ()
                   ^
 error: No warnings can be incurred under -Xfatal-warnings.
-39 warnings found
+40 warnings found
 one error found

--- a/test/files/neg/warn-unused-privates.scala
+++ b/test/files/neg/warn-unused-privates.scala
@@ -1,4 +1,5 @@
-// scalac: -Ywarn-unused -Xfatal-warnings
+//
+// scalac: -deprecation -Ywarn-unused -Xfatal-warnings
 //
 class Bippy(a: Int, b: Int) {
   private def this(c: Int) = this(c, c)           // warn

--- a/test/files/run/analyzerPlugins.check
+++ b/test/files/run/analyzerPlugins.check
@@ -1,3 +1,4 @@
+warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details
 adaptBoundsToAnnots(List( <: Int), List(type T), List(Int @testAnn)) [2]
 annotationsConform(Boolean @testAnn, Boolean @testAnn) [2]
 annotationsConform(Boolean @testAnn, Boolean) [1]

--- a/test/files/run/ctor-order.check
+++ b/test/files/run/ctor-order.check
@@ -1,2 +1,3 @@
+warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details
 10
 10

--- a/test/files/run/delay-bad.check
+++ b/test/files/run/delay-bad.check
@@ -4,7 +4,9 @@ delay-bad.scala:53: warning: a pure expression does nothing in statement positio
 delay-bad.scala:73: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
     f(new { val x = 5 } with E() { 5 })
                                    ^
-warning: there was one deprecation warning (since 2.11.0); re-run with -deprecation for details
+warning: there was one deprecation warning (since 2.11.0)
+warning: there were four deprecation warnings (since 2.13.0)
+warning: there were 5 deprecation warnings in total; re-run with -deprecation for details
 
 
 // new C { }

--- a/test/files/run/delay-good.check
+++ b/test/files/run/delay-good.check
@@ -4,6 +4,7 @@ delay-good.scala:53: warning: a pure expression does nothing in statement positi
 delay-good.scala:73: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
     f(new { val x = 5 } with E() { 5 })
                                    ^
+warning: there were four deprecation warnings (since 2.13.0); re-run with -deprecation for details
 
 
 // new C { }

--- a/test/files/run/deprecate-early-type-defs.check
+++ b/test/files/run/deprecate-early-type-defs.check
@@ -1,3 +1,6 @@
+deprecate-early-type-defs.scala:3: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+object Test extends { type T = Int } with App
+                    ^
 deprecate-early-type-defs.scala:3: warning: early type members are deprecated: move them to the regular body; the semantics are the same
 object Test extends { type T = Int } with App
                            ^

--- a/test/files/run/outertest.check
+++ b/test/files/run/outertest.check
@@ -1,2 +1,1 @@
 warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details
-reload: Base.scala, Class.scala, Derived.scala

--- a/test/files/run/preinits.check
+++ b/test/files/run/preinits.check
@@ -4,6 +4,7 @@ trait B extends { override val x = 1 } with A { println("B") }
 preinits.scala:3: warning: Implementation restriction: early definitions in traits are not initialized before the super class is initialized.
 trait C extends { override val x = 2 } with A
                                ^
+warning: there were two deprecation warnings (since 2.13.0); re-run with -deprecation for details
 A
 B
 2

--- a/test/files/run/t0911.check
+++ b/test/files/run/t0911.check
@@ -1,2 +1,1 @@
 warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details
-reload: Base.scala, Class.scala, Derived.scala

--- a/test/files/run/t4680.check
+++ b/test/files/run/t4680.check
@@ -4,7 +4,9 @@ t4680.scala:51: warning: a pure expression does nothing in statement position; m
 t4680.scala:69: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
     new { val x = 5 } with E() { 5 }
                                  ^
-warning: there was one deprecation warning (since 2.11.0); re-run with -deprecation for details
+warning: there was one deprecation warning (since 2.11.0)
+warning: there were four deprecation warnings (since 2.13.0)
+warning: there were 5 deprecation warnings in total; re-run with -deprecation for details
 
 
 // new C { }

--- a/test/files/run/t5603.check
+++ b/test/files/run/t5603.check
@@ -27,3 +27,4 @@
   }
 }
 
+warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details

--- a/test/files/run/t6259.check
+++ b/test/files/run/t6259.check
@@ -1,2 +1,1 @@
 warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details
-reload: Base.scala, Class.scala, Derived.scala

--- a/test/files/run/t6309.check
+++ b/test/files/run/t6309.check
@@ -1,1 +1,2 @@
+warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details
 7

--- a/test/files/specialized/spec-early.check
+++ b/test/files/specialized/spec-early.check
@@ -1,3 +1,4 @@
+warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details
 a
 abc
 42

--- a/test/scaladoc/run/t7767.check
+++ b/test/scaladoc/run/t7767.check
@@ -1,1 +1,2 @@
+warning: there were two deprecation warnings (since 2.13.0); re-run with -deprecation for details
 Done.


### PR DESCRIPTION
Under -Xsource:2.14, offer trait parameters,
otherwise the mirage of a distant oasis.

Eerily, github nailed the suggested reviewer again. (In the sense of "hit the nail on the head.")

Cf https://github.com/scala/scala/pull/6349

Fixes scala/scala-dev#513