### PR TITLE
use Iterator.single instead of Iterator.apply

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -280,7 +280,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
 
   // A helper for tails and inits.
   private[this] def iterateUntilEmpty(f: Array[A] => Array[A]): Iterator[Array[A]] =
-    Iterator.iterate(xs)(f).takeWhile(x => x.length != 0) ++ Iterator(Array.empty[A])
+    Iterator.iterate(xs)(f).takeWhile(x => x.length != 0) ++ Iterator.single(Array.empty[A])
 
   /** An array containing the first `n` elements of this array. */
   def take(n: Int): Array[A] = slice(0, n)

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -681,7 +681,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   // A helper for tails and inits.
   private[this] def iterateUntilEmpty(f: Iterable[A] => Iterable[A]): Iterator[C] = {
     val it = Iterator.iterate(toIterable)(f).takeWhile(x => !x.isEmpty)
-    (it ++ Iterator(Iterable.empty)).map(fromSpecificIterable)
+    (it ++ Iterator.single(Iterable.empty)).map(fromSpecificIterable)
   }
 }
 

--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -174,7 +174,7 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeq
 
   /** $willForceEvaluation */
   override def tails: Iterator[C] =
-    Iterator.iterate(coll)(_.tail).takeWhile(_.nonEmpty) ++ Iterator(newSpecificBuilder.result())
+    Iterator.iterate(coll)(_.tail).takeWhile(_.nonEmpty) ++ Iterator.single(newSpecificBuilder.result())
 }
 
 trait StrictOptimizedLinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with StrictOptimizedLinearSeqOps[A, CC, C]] extends LinearSeqOps[A, CC, C] with StrictOptimizedSeqOps[A, CC, C] {

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -434,7 +434,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *  @example  `"abb".permutations = Iterator(abb, bab, bba)`
     */
   def permutations: Iterator[C] =
-    if (isEmpty) Iterator(coll)
+    if (isEmpty) Iterator.single(coll)
     else new PermutationsItr
 
   /** Iterates over combinations.  A _combination_ of length `n` is a subsequence of

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -1105,7 +1105,7 @@ final class StringOps(private val s: String) extends AnyVal {
 
   // A helper for tails and inits.
   private[this] def iterateUntilEmpty(f: String => String): Iterator[String] =
-    Iterator.iterate(s)(f).takeWhile(x => !x.isEmpty) ++ Iterator("")
+    Iterator.iterate(s)(f).takeWhile(x => !x.isEmpty) ++ Iterator.single("")
 
   /** Selects all chars of this string which satisfy a predicate. */
   def filter(pred: Char => Boolean): String = {


### PR DESCRIPTION
avoid intermediate `ArraySeq` object

```
$ scala -version
Scala code runner version 2.13.0-M4 -- Copyright 2002-2018, LAMP/EPFL and Lightbend, Inc.
$ scala -Xprint:jvm -e "Iterator(42)"
[[syntax trees at end of                       jvm]] // scalacmd2580201710484192553.scala
package <empty> {
  object Main extends Object {
    def main(args: Array[String]): Unit = {
      new <$anon: Object>();
      ()
    };
    def <init>(): Main.type = {
      Main.super.<init>();
      ()
    }
  };
  final class anon$1 extends Object {
    def <init>(): <$anon: Object> = {
      anon$1.super.<init>();
      scala.`package`.Iterator().apply(scala.runtime.ScalaRunTime.wrapIntArray(Array[Int]{42}));
      ()
    }
  }
}

$ scala -Xprint:jvm -e "Iterator.single(42)"
[[syntax trees at end of                       jvm]] // scalacmd515267445422354638.scala
package <empty> {
  object Main extends Object {
    def main(args: Array[String]): Unit = {
      new <$anon: Object>();
      ()
    };
    def <init>(): Main.type = {
      Main.super.<init>();
      ()
    }
  };
  final class anon$1 extends Object {
    def <init>(): <$anon: Object> = {
      anon$1.super.<init>();
      scala.`package`.Iterator().single(scala.Int.box(42));
      ()
    }
  }
}
```