### PR TITLE
optimize IndexedSeqOps#last

### DIFF
--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -50,6 +50,8 @@ trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self =>
 
   override def slice(from: Int, until: Int): C = fromSpecificIterable(new IndexedSeqView.Slice(this, from, until))
 
+  override def last: A = apply(length - 1)
+
   override def lengthCompare(len: Int): Int = length - len
 
   final override def knownSize: Int = length


### PR DESCRIPTION
change `O(n)` to `O(1)`

https://github.com/scala/scala/blob/6dfcda8e98c371d3292c2f7b65277b1b4c48ece6/src/library/scala/collection/Iterable.scala#L203-L213