### PR TITLE
Add missing methods to Iterator

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -140,6 +140,8 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   @deprecated("Use toIterable instead", "2.13.0")
   final def toTraversable: Traversable[A] = toIterable
 
+  override def isTraversableAgain: Boolean = true
+
   /**
     * @return This collection as a `C`.
     */
@@ -222,9 +224,6 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     *           `None` if it is empty.
     */
   def lastOption: Option[A] = if (isEmpty) None else Some(last)
-
-  @deprecated("Use .knownSize >=0 instead of .hasDefiniteSize", "2.13.0")
-  @`inline` final def hasDefiniteSize = knownSize >= 0
 
   /** A view over the elements of this collection. */
   def view: View[A] = View.fromIteratorProvider(() => iterator)
@@ -309,7 +308,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     */
   def withFilter(p: A => Boolean): collection.WithFilter[A, CC] = new IterableOps.WithFilter(this, p)
 
-  /** A pair of, first, all elements that satisfy prediacte `p` and, second,
+  /** A pair of, first, all elements that satisfy predicate `p` and, second,
     *  all elements that do not. Interesting because it splits a collection in two.
     *
     *  The default implementation provided here needs to traverse the collection twice.

--- a/src/library/scala/collection/View.scala
+++ b/src/library/scala/collection/View.scala
@@ -310,19 +310,8 @@ object View extends IterableFactory[View] {
 
   @SerialVersionUID(3L)
   class PadTo[A](underlying: SomeIterableOps[A], len: Int, elem: A) extends AbstractView[A] {
-    def iterator: Iterator[A] = new AbstractIterator[A] {
-      private[this] var i = 0
-      private[this] val it = underlying.iterator
-      def next(): A = {
-        val a =
-          if (it.hasNext) it.next()
-          else if (i < len) elem
-          else Iterator.empty.next()
-        i += 1
-        a
-      }
-      def hasNext: Boolean = it.hasNext || i < len
-    }
+    def iterator: Iterator[A] = underlying.iterator.padTo(len, elem)
+
     override def knownSize: Int = if (underlying.knownSize >= 0) underlying.knownSize max len else -1
   }
 

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -152,7 +152,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   override protected[this] def stringPrefix = "ArrayBuffer"
 
-  override def copyToArray[B >: A](xs: Array[B], start: Int = 0): xs.type = copyToArray[B](xs, start, length)
+  override def copyToArray[B >: A](xs: Array[B], start: Int): xs.type = copyToArray[B](xs, start, length)
 
   override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): xs.type = {
     val l = scala.math.min(scala.math.min(len, length), xs.length-start)

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -60,7 +60,7 @@ abstract class ArraySeq[T]
   /** Clones this object, including the underlying Array. */
   override def clone(): ArraySeq[T] = ArraySeq.make(array.clone()).asInstanceOf[ArraySeq[T]]
 
-  override def copyToArray[B >: T](xs: Array[B], start: Int = 0): xs.type = copyToArray[B](xs, start, length)
+  override def copyToArray[B >: T](xs: Array[B], start: Int): xs.type = copyToArray[B](xs, start, length)
 
   override def copyToArray[B >: T](xs: Array[B], start: Int, len: Int): xs.type = {
     val l = scala.math.min(scala.math.min(len, length), xs.length-start)

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -404,6 +404,29 @@ class IteratorTest {
     assertSame(Iterator.empty, iteratorBuilder.result())
   }
 
+  @Test def partition: Unit = {
+    val it = Iterator(1, 2, 3, 4, 5, 6, 7)
+    val (even, odd) = it.partition(n => (n & 1) == 0)
+    assertSameElements(List.from(even), List(2, 4, 6))
+    assertSameElements(List.from(odd), List(1, 3, 5, 7))
+  }
+
+  @Test def padTo: Unit = {
+    val it = Iterator(2, 4, 6, 8)
+    val padded = it.padTo(7, 10)
+    assertSameElements(List.from(padded), List(2, 4, 6, 8, 10, 10, 10))
+  }
+
+  @Test def corresponds: Unit = {
+    val it = Iterator(1, 2, 3, 4, 5)
+    assertTrue(it.corresponds(Seq(1, 4, 9, 16, 25)) { (a, b) => b == a*a })
+  }
+
+  @Test def aggregate: Unit = {
+    val result = Iterator('a', 'b', 'c').aggregate(0)({ (sum, ch) => sum + ch.toInt }, { (p1, p2) => p1 + p2 })
+    assertEquals(result, 294)
+  }
+
   @Test def copyToArray(): Unit = {
     def check(a: Array[Int], start: Int, end: Int) = {
       var i = 0


### PR DESCRIPTION
Adds the following methods to `IterableOnceOps`:
 - `def aggregate[B](z: ⇒ B)(seqop: (B, A) ⇒ B, combop: (B, B) ⇒ B): B` (deprecated)
 - `def corresponds[B](that: GenTraversableOnce[B])(p: (A, B) ⇒ Boolean): Boolean`
 - `def hasDefiniteSize: Boolean` (deprecated)
 - `def copyToArray(xs: Array[A]): xs.type`
 - `def isTraversableAgain: Boolean`

and the following to `Iterator`:
 - `def padTo(len: Int, elem: A): Iterator[A]`
 - `def partition(p: (A) ⇒ Boolean): (Iterator[A], Iterator[A])`
 - `def scanRight[B](z: B)(op: (A, B) => B): Iterator[B]` (deprecated)

Fixes scala/bug#10961