### PR TITLE
Remove get method on mutable Set

### DIFF
--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -199,9 +199,6 @@ private[collection] trait Wrappers {
     override def remove(elem: A): Boolean = underlying remove elem
     override def clear() = underlying.clear()
 
-    //TODO Should Set.get be supported? There is no efficient way to return the canonical element from a Java Set
-    def get(elem: A): Option[A] = if(underlying.contains(elem)) Some(elem) else None
-
     override def empty = JSetWrapper(new ju.HashSet[A])
     // Note: Clone cannot just call underlying.clone because in Java, only specific collections
     // expose clone methods.  Generically, they're protected.

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -85,8 +85,6 @@ class BitSet(protected[collection] final var elems: Array[Long])
     }
   }
 
-  def get(elem: Int): Option[Int] = if (contains(elem)) Some(elem) else None
-
   def unconstrained: collection.Set[Int] = this
 
   /** Updates this bitset to the union with another bitset by performing a bitwise "or".

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -46,8 +46,6 @@ final class HashSet[A]
 
   def contains(elem: A): Boolean = table.containsElem(elem)
 
-  def get(elem: A): Option[A] = table.findEntry(elem)
-
   override def knownSize: Int = table.size
 
   override def size: Int = table.size

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -53,11 +53,6 @@ class LinkedHashSet[A]
       }
     }
 
-  def get(elem: A): Option[A] = {
-    val entry = table.findEntry(elem)
-    if (entry != null) Some(entry.key) else None
-  }
-
   override def size: Int = table.tableSize
 
   def contains(elem: A): Boolean = table.findEntry(elem) ne null

--- a/src/library/scala/collection/mutable/RedBlackTree.scala
+++ b/src/library/scala/collection/mutable/RedBlackTree.scala
@@ -67,12 +67,6 @@ private[collection] object RedBlackTree {
     case node => Some(node.value)
   }
 
-  def getKey[A : Ordering](tree: Tree[A, _], key: A): Option[A] =
-    getNode(tree.root, key) match {
-      case null => None
-      case node => Some(node.key)
-    }
-
   @tailrec private[this] def getNode[A, B](node: Node[A, B], key: A)(implicit ord: Ordering[A]): Node[A, B] =
     if (node eq null) null
     else {
@@ -82,7 +76,7 @@ private[collection] object RedBlackTree {
       else node
     }
 
-  def contains[A: Ordering](tree: Tree[A, _], key: A) = getNode(tree.root, key) ne null
+  def contains[A: Ordering](tree: Tree[A, _], key: A): Boolean = getNode(tree.root, key) ne null
 
   def min[A, B](tree: Tree[A, B]): Option[(A, B)] = minNode(tree.root) match {
     case null => None

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -33,12 +33,6 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     this
   }
 
-  /**
-    * @return The reference of the contained element that is equal to `elem`, if found, otherwise `None`
-    * @param elem The element to get.
-    */
-  def get(elem: A): Option[A]
-
   def add(elem: A): Boolean =
     !contains(elem) && {
       coll += elem; true

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -56,8 +56,6 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
 
   def contains(elem: A): Boolean = RB.contains(tree, elem)
 
-  def get(elem: A): Option[A] = RB.getKey(tree, elem)
-
   def unconstrained: collection.Set[A] = this
 
   def rangeImpl(from: Option[A], until: Option[A]): TreeSet[A] = new TreeSetProjection(from, until)

--- a/test/junit/scala/collection/mutable/SetTest.scala
+++ b/test/junit/scala/collection/mutable/SetTest.scala
@@ -19,7 +19,6 @@ class SetTest {
     override def empty = new MySet(self.empty)
     def iterator = self.iterator
     def contains(elem: String) = self.contains(elem)
-    def get(elem: String): Option[String] = self.get(elem)
     def clear(): Unit = self.clear()
   }
 


### PR DESCRIPTION
This method on `mutable.Set` did not exist in 2.12, does not exist on `immutable.Set`, and has inconsistent behavior on different implementations. I am not convinced of its usefulness either.

Fixes scala/bug#11001