### PR TITLE
Add deprecated method keysIteratorFrom on SortedSet

### DIFF
--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -60,6 +60,9 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
     * @param start The lower-bound (inclusive) of the iterator
     */
   def iteratorFrom(start: A): Iterator[A]
+  
+  @deprecated("Use `iteratorFrom` instead.", "2.13.0")
+  @`inline` def keysIteratorFrom(start: A): Iterator[A] = iteratorFrom(start)
 
   def firstKey: A = head
   def lastKey: A = last


### PR DESCRIPTION
This method was previously on `Sorted` but does not make sense on sets because they have no concept of keys. I added it deprecated to `SortedSetOps` for compatibility.

Fixes scala/bug#10992