### PR TITLE
[#10981] Add missing methods to ArrayBuffer

### DIFF
--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -150,6 +150,14 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
       throw new IllegalArgumentException("removing negative number of elements: " + count)
     }
 
+  @deprecated("Use 'this' instance instead", "2.13.0")
+  @deprecatedOverriding("ArrayBuffer[A] no longer extends Builder[A, ArrayBuffer[A]]", "2.13.0")
+  @inline def result(): this.type = this
+
+  @deprecated("Use 'new GrowableBuilder(this).mapResult(f)' instead", "2.13.0")
+  @deprecatedOverriding("ArrayBuffer[A] no longer extends Builder[A, ArrayBuffer[A]]", "2.13.0")
+  @inline def mapResult[NewTo](f: (ArrayBuffer[A]) ⇒ NewTo): Builder[A, NewTo] = new GrowableBuilder(this).mapResult(f)
+
   override protected[this] def stringPrefix = "ArrayBuffer"
 
   override def copyToArray[B >: A](xs: Array[B], start: Int = 0): xs.type = copyToArray[B](xs, start, length)
@@ -240,4 +248,5 @@ object RefArrayUtils {
       i += 1
     }
   }
+
 }

--- a/src/library/scala/collection/mutable/Buffer.scala
+++ b/src/library/scala/collection/mutable/Buffer.scala
@@ -42,6 +42,9 @@ trait Buffer[A]
   @deprecated("Use prependAll instead", "2.13.0")
   @`inline` final def prepend(elems: A*): this.type = prependAll(elems)
 
+  /** Alias for `prependAll` */
+  @inline final def ++=:(elems: IterableOnce[A]): this.type = prependAll(elems)
+
   /** Inserts a new element at a given index into this buffer.
     *
     *  @param idx    the index where the new elements is inserted.

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -297,4 +297,14 @@ class ArrayBufferTest {
 
     assertEquals(ArrayBuffer(1, 2, 3), buffer)
   }
+  @Test
+  def testMapResult: Unit = {
+    val buffer = ArrayBuffer(3, 2, 1)
+
+    val builder = buffer.mapResult(_.mkString(","))
+
+    buffer.prepend(4)
+
+    assertEquals(builder.result(), "4,3,2,1")
+  }
 }


### PR DESCRIPTION
Fixes scala/bug#10981

* Add ++=: to Buffer which is an alias to prependAll  
* Add deprecated result() to ArrayBuffer
* Add deprecated mapResult to ArrayBuffer