### PR TITLE
Adds missing method .compare in SortedOps

### DIFF
--- a/src/library/scala/collection/SortedOps.scala
+++ b/src/library/scala/collection/SortedOps.scala
@@ -12,6 +12,11 @@ trait SortedOps[A, +C] {
   /** Returns the last key of the collection. */
   def lastKey: A
 
+  /** Comparison function that orders keys. */
+  @deprecated("Use ordering.compare instead", "2.13.0")
+  @deprecatedOverriding("Use ordering.compare instead", "2.13.0")
+  @inline def compare(k0: A, k1: A): Int = ordering.compare(k0, k1)
+
   /** Creates a ranged projection of this collection. Any mutations in the
     *  ranged projection will update this collection and vice versa.
     *


### PR DESCRIPTION
Fixes scala/bug#10980