### PR TITLE
Merge IndexedOptimizedSeq into IndexedSeq

### DIFF
--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -1071,11 +1071,11 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
 
   def toIndexedSeq: immutable.IndexedSeq[A] = immutable.IndexedSeq.from(this)
 
-  @deprecated("Use Stream.from(it) instead of it.toStream", "2.13.0")
-  @`inline` final def toStream: immutable.Stream[A] = immutable.Stream.from(this)
+  @deprecated("Use .to(Stream) instead of .toStream", "2.13.0")
+  @`inline` final def toStream: immutable.Stream[A] = to(immutable.Stream)
 
-  @deprecated("Use ArrayBuffer.from(it) instead of it.toBuffer", "2.13.0")
-  @`inline` final def toBuffer[B >: A]: mutable.Buffer[B] = mutable.ArrayBuffer.from(this)
+  @deprecated("Use .to(Buffer) instead of .toBuffer", "2.13.0")
+  @`inline` final def toBuffer[B >: A]: mutable.Buffer[B] = to(mutable.Buffer)
 
   /** Convert collection to array. */
   def toArray[B >: A: ClassTag]: Array[B] =

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -28,9 +28,8 @@ import java.lang.{IndexOutOfBoundsException, IllegalArgumentException}
   */
 class ArrayBuffer[A] private (initElems: Array[AnyRef], initSize: Int)
   extends AbstractBuffer[A]
-    with IndexedSeq[A]
+    with IndexedBuffer[A]
     with IndexedSeqOps[A, ArrayBuffer, ArrayBuffer[A]]
-    with IndexedOptimizedBuffer[A]
     with StrictOptimizedSeqOps[A, ArrayBuffer, ArrayBuffer[A]] {
 
   def this() = this(new Array[AnyRef](16), 0)

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -33,9 +33,8 @@ class ArrayDeque[A] protected (
     private[ArrayDeque] var start: Int,
     private[ArrayDeque] var end: Int
 ) extends AbstractBuffer[A]
-    with IndexedSeq[A]
+    with IndexedBuffer[A]
     with IndexedSeqOps[A, ArrayDeque, ArrayDeque[A]]
-    with IndexedOptimizedBuffer[A]
     with StrictOptimizedSeqOps[A, ArrayDeque, ArrayDeque[A]] {
 
   reset(array, start, end)

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -28,7 +28,6 @@ abstract class ArraySeq[T]
   extends AbstractSeq[T]
     with IndexedSeq[T]
     with IndexedSeqOps[T, ArraySeq, ArraySeq[T]]
-    with IndexedOptimizedSeq[T]
     with StrictOptimizedSeqOps[T, ArraySeq, ArraySeq[T]] {
 
   override def iterableFactory: scala.collection.SeqFactory[ArraySeq] = ArraySeq.untagged

--- a/src/library/scala/collection/mutable/Buffer.scala
+++ b/src/library/scala/collection/mutable/Buffer.scala
@@ -137,7 +137,11 @@ trait Buffer[A]
   override protected[this] def stringPrefix = "Buffer"
 }
 
-trait IndexedOptimizedBuffer[A] extends IndexedOptimizedSeq[A] with Buffer[A] {
+trait IndexedBuffer[A] extends IndexedSeq[A]
+  with IndexedSeqOps[A, IndexedBuffer, IndexedBuffer[A]]
+  with Buffer[A] {
+
+  override def iterableFactory: SeqFactory[IndexedBuffer] = IndexedBuffer
 
   def flatMapInPlace(f: A => IterableOnce[A]): this.type = {
     // There's scope for a better implementation which copies elements in place.
@@ -183,6 +187,9 @@ trait IndexedOptimizedBuffer[A] extends IndexedOptimizedSeq[A] with Buffer[A] {
 
 @SerialVersionUID(3L)
 object Buffer extends SeqFactory.Delegate[Buffer](ArrayBuffer)
+
+@SerialVersionUID(3L)
+object IndexedBuffer extends SeqFactory.Delegate[IndexedBuffer](ArrayBuffer)
 
 /** Explicit instantiation of the `Buffer` trait to reduce class file size in subclasses. */
 @SerialVersionUID(3L)

--- a/src/library/scala/collection/mutable/Builder.scala
+++ b/src/library/scala/collection/mutable/Builder.scala
@@ -87,7 +87,6 @@ class StringBuilder(private val sb: java.lang.StringBuilder) extends AbstractSeq
   with Builder[Char, String]
   with IndexedSeq[Char]
   with IndexedSeqOps[Char, IndexedSeq, StringBuilder]
-  with IndexedOptimizedSeq[Char]
   with java.lang.CharSequence {
 
   def this() = this(new java.lang.StringBuilder)

--- a/src/library/scala/collection/mutable/IndexedSeq.scala
+++ b/src/library/scala/collection/mutable/IndexedSeq.scala
@@ -17,6 +17,13 @@ trait IndexedSeqOps[A, +CC[_], +C <: AnyRef]
   extends scala.collection.IndexedSeqOps[A, CC, C]
     with SeqOps[A, CC, C] {
 
+  def mapInPlace(f: A => A): this.type = {
+    var i = 0
+    val siz = size
+    while (i < siz) { this(i) = f(this(i)); i += 1 }
+    this
+  }
+
   /** Sorts this $coll in place according to an Ordering.
     *
     * @see [[scala.collection.SeqOps.sorted]]

--- a/src/library/scala/collection/mutable/Seq.scala
+++ b/src/library/scala/collection/mutable/Seq.scala
@@ -47,16 +47,6 @@ trait SeqOps[A, +CC[_], +C <: AnyRef]
   def update(idx: Int, elem: A): Unit
 }
 
-trait IndexedOptimizedSeq[A] extends Seq[A] {
-
-  def mapInPlace(f: A => A): this.type = {
-    var i = 0
-    val siz = size
-    while (i < siz) { this(i) = f(this(i)); i += 1 }
-    this
-  }
-}
-
 /** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses. */
 @SerialVersionUID(3L)
 abstract class AbstractSeq[A] extends scala.collection.AbstractSeq[A] with Seq[A]

--- a/src/library/scala/collection/mutable/package.scala
+++ b/src/library/scala/collection/mutable/package.scala
@@ -20,4 +20,10 @@ package object mutable {
 
   @deprecated("GrowingBuilder has been renamed to GrowableBuilder", "2.13.0")
   type GrowingBuilder[Elem, To <: Growable[Elem]] = GrowableBuilder[Elem, To]
+
+  @deprecated("IndexedOptimizedSeq has been renamed to IndexedSeq", "2.13.0")
+  type IndexedOptimizedSeq[A] = IndexedSeq[A]
+
+  @deprecated("IndexedOptimizedBuffer has been renamed to IndexedBuffer", "2.13.0")
+  type IndexedOptimizedBuffer[A] = IndexedBuffer[A]
 }

--- a/test/junit/scala/collection/CollectionConversionsTest.scala
+++ b/test/junit/scala/collection/CollectionConversionsTest.scala
@@ -17,13 +17,13 @@ class CollectionConversionsTest {
   val testArray = Array(1,2,3)
 
   @Test def testAll: Unit = {
-    testConversion("iterator", (1 to 3).iterator)
-    testConversion("Vector", Vector(1,2,3))
-    testConversion("List", List(1,2,3))
-    testConversion("Buffer", Buffer(1,2,3))
-    testConversion("Set", Set(1,2,3))
-    testConversion("SetView", Set(1,2,3).view)
-    testConversion("BufferView", Buffer(1,2,3).view)
+    testConversion("iterator", () => (1 to 3).iterator)
+    testConversion("Vector", () => Vector(1,2,3))
+    testConversion("List", () => List(1,2,3))
+    testConversion("Buffer", () => Buffer(1,2,3))
+    testConversion("Set", () => Set(1,2,3))
+    testConversion("SetView", () => Set(1,2,3).view)
+    testConversion("BufferView", () => Buffer(1,2,3).view)
   }
 
   def printResult[A,B](msg: String, obj: A, expected: B)(implicit tag: ClassTag[A], tag2: ClassTag[B]): Boolean = {
@@ -45,19 +45,18 @@ class CollectionConversionsTest {
     ok
   }
 
-  def testConversion[A: ClassTag](name: String, col: => GenTraversableOnce[A]): Unit = {
-    val tmp = col
+  def testConversion[A: ClassTag](name: String, col: () => IterableOnce[A]): Unit = {
     out ++= ("-- Testing " + name + " ---\n")
     if(!(
-      printResult("[Direct] Vector   ", col.toVector, testVector) &&
-      printResult("[Copy]   Vector   ", col.to(Vector), testVector) &&
-      printResult("[Direct] Buffer   ", col.toBuffer, testBuffer) &&
-      printResult("[Copy]   Buffer   ", col.to(Buffer), testBuffer) &&
-      printResult("[Copy]   Seq      ", col.to(Seq), testSeq) &&
-      printResult("[Direct] Stream   ", col.toStream, testStream) &&
-      printResult("[Copy]   Stream   ", col.to(Stream), testStream) &&
-      printResult("[Direct] Array    ", col.toArray, testArray) &&
-      printResult("[Copy]   Array    ", col.to(Array), testArray)
+      printResult("[Direct] Vector   ", col().iterator.toVector, testVector) &&
+      printResult("[Copy]   Vector   ", col().iterator.to(Vector), testVector) &&
+      printResult("[Direct] Buffer   ", col().iterator.toBuffer, testBuffer) &&
+      printResult("[Copy]   Buffer   ", col().iterator.to(Buffer), testBuffer) &&
+      printResult("[Copy]   Seq      ", col().iterator.to(Seq), testSeq) &&
+      printResult("[Direct] Stream   ", col().iterator.toStream, testStream) &&
+      printResult("[Copy]   Stream   ", col().iterator.to(Stream), testStream) &&
+      printResult("[Direct] Array    ", col().iterator.toArray, testArray) &&
+      printResult("[Copy]   Array    ", col().iterator.to(Array), testArray)
     )) {
       print(out)
       fail("Not all tests successful")


### PR DESCRIPTION
The implementation of mapInPlace was provided by IndexedOptimizedSeq,
although it could have been implemented in IndexedSeq as well.

Also rename IndexedOptimizedBuffer into IndexedBuffer, and provide
deprecated aliases for backward compatibility.

Fixes scala/bug#11006