### PR TITLE
Fix bug in ArraysOps.slice

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -238,18 +238,18 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
   def slice(from: Int, until: Int): Array[A] = {
     import java.util.Arrays.copyOfRange
     val lo = max(from, 0)
-    if (until > lo) {
-      // TODO: Switch type to Array[_]. See scala/scala-dev#528.
-      ((xs: Any) match {
-        case x: Array[AnyRef]     => copyOfRange(x, lo, min(until, x.length))
-        case x: Array[Int]        => copyOfRange(x, lo, min(until, x.length))
-        case x: Array[Double]     => copyOfRange(x, lo, min(until, x.length))
-        case x: Array[Long]       => copyOfRange(x, lo, min(until, x.length))
-        case x: Array[Float]      => copyOfRange(x, lo, min(until, x.length))
-        case x: Array[Char]       => copyOfRange(x, lo, min(until, x.length))
-        case x: Array[Byte]       => copyOfRange(x, lo, min(until, x.length))
-        case x: Array[Short]      => copyOfRange(x, lo, min(until, x.length))
-        case x: Array[Boolean]    => copyOfRange(x, lo, min(until, x.length))
+    val hi = min(until, xs.length)
+    if (hi > lo) {
+      ((xs: Array[_]) match {
+        case x: Array[AnyRef]     => copyOfRange(x, lo, hi)
+        case x: Array[Int]        => copyOfRange(x, lo, hi)
+        case x: Array[Double]     => copyOfRange(x, lo, hi)
+        case x: Array[Long]       => copyOfRange(x, lo, hi)
+        case x: Array[Float]      => copyOfRange(x, lo, hi)
+        case x: Array[Char]       => copyOfRange(x, lo, hi)
+        case x: Array[Byte]       => copyOfRange(x, lo, hi)
+        case x: Array[Short]      => copyOfRange(x, lo, hi)
+        case x: Array[Boolean]    => copyOfRange(x, lo, hi)
       }).asInstanceOf[Array[A]]
     } else new Array[A](0)
   }

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -96,6 +96,8 @@ class ArrayOpsTest {
 
   @Test
   def slice: Unit = {
+    assertArrayEquals(Array[Int](2), Array[Int](1, 2).slice(1, 2))
     assertArrayEquals(Array[Int](), Array[Int](1).slice(1052471512, -1496048404))
+    assertArrayEquals(Array[Int](), Array[Int](1).slice(2, 3))
   }
 }


### PR DESCRIPTION
Array().slice(1, 2) should not throw exceptions.
See #6874.