### PR TITLE
Change @deprecatedName to take a String instead of a symbol

### DIFF
--- a/spec/11-annotations.md
+++ b/spec/11-annotations.md
@@ -92,7 +92,7 @@ Java platform, the following annotations have a standard meaning.
     Deprecated warnings are suppressed in code that belongs itself to a definition
     that is labeled deprecated.
 
-  * `@deprecatedName(name: <symbollit>)`<br/>
+  * `@deprecatedName(name: <stringlit>, since: <stringlit>)`<br/>
     Marks a formal parameter name as deprecated. Invocations of this entity
     using named parameter syntax referring to the deprecated parameter name cause a deprecation warning.
 

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -63,7 +63,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     array(n).asInstanceOf[A]
   }
 
-  def update(@deprecatedName('n, "2.13.0") index: Int, elem: A): Unit = {
+  def update(@deprecatedName("n", "2.13.0") index: Int, elem: A): Unit = {
     checkWithinBounds(index, index + 1)
     array(index) = elem.asInstanceOf[AnyRef]
   }
@@ -96,7 +96,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     this
   }
 
-  def insert(@deprecatedName('n, "2.13.0") index: Int, elem: A): Unit = {
+  def insert(@deprecatedName("n", "2.13.0") index: Int, elem: A): Unit = {
     checkWithinBounds(index, index)
     ensureSize(size0 + 1)
     Array.copy(array, index, array, index + 1, size0 - index)
@@ -109,7 +109,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     this
   }
 
-  def insertAll(@deprecatedName('n, "2.13.0") index: Int, elems: IterableOnce[A]): Unit = {
+  def insertAll(@deprecatedName("n", "2.13.0") index: Int, elems: IterableOnce[A]): Unit = {
     checkWithinBounds(index, index)
     elems match {
       case elems: collection.Iterable[A] =>
@@ -133,7 +133,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     }
   }
 
-  def remove(@deprecatedName('n, "2.13.0") index: Int): A = {
+  def remove(@deprecatedName("n", "2.13.0") index: Int): A = {
     checkWithinBounds(index, index + 1)
     val res = this(index)
     Array.copy(array, index + 1, array, index, size0 - (index + 1))
@@ -141,7 +141,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     res
   }
 
-  def remove(@deprecatedName('n, "2.13.0") index: Int, count: Int): Unit =
+  def remove(@deprecatedName("n", "2.13.0") index: Int, count: Int): Unit =
     if (count > 0) {
       checkWithinBounds(index, index + count)
       Array.copy(array, index + count, array, index, size0 - (index + count))

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -48,7 +48,7 @@ abstract class ArraySeq[T]
   def elemTag: ClassTag[_]
 
   /** Update element at given index */
-  def update(@deprecatedName('idx, "2.13.0") index: Int, elem: T): Unit
+  def update(@deprecatedName("idx", "2.13.0") index: Int, elem: T): Unit
 
   /** The underlying array. Its element type does not have to be equal to the element type of this ArraySeq. A primitive
     * ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an array of a supertype

--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -77,7 +77,7 @@ trait ExecutionContext {
    *
    *  @param cause  the cause of the failure
    */
-  def reportFailure(@deprecatedName('t) cause: Throwable): Unit
+  def reportFailure(@deprecatedName("t") cause: Throwable): Unit
 
   /** Prepares for the execution of a task. Returns the prepared
      *  execution context. The recommended implementation of

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -704,7 +704,7 @@ object Future {
    */
   @deprecated("use Future.foldLeft instead", "2.12.0")
   // not removed in 2.13, to facilitate 2.11/2.12/2.13 cross-building; remove in 2.14 (see scala/scala#6319)
-  def fold[T, R](futures: IterableOnce[Future[T]])(zero: R)(@deprecatedName('foldFun) op: (R, T) => R)(implicit executor: ExecutionContext): Future[R] = {
+  def fold[T, R](futures: IterableOnce[Future[T]])(zero: R)(@deprecatedName("foldFun") op: (R, T) => R)(implicit executor: ExecutionContext): Future[R] = {
     if (futures.isEmpty) successful(zero)
     else sequence(futures)(ArrayBuffer, executor).map(_.foldLeft(zero)(op))
   }

--- a/src/library/scala/deprecatedName.scala
+++ b/src/library/scala/deprecatedName.scala
@@ -22,7 +22,7 @@ import scala.annotation.meta._
   *  developers distinguish deprecations coming from different libraries:
   *
   *  {{{
-  *  def inc(x: Int, @deprecatedName('y, "FooLib 12.0") n: Int): Int = x + n
+  *  def inc(x: Int, @deprecatedName("y", "FooLib 12.0") n: Int): Int = x + n
   *  inc(1, y = 2)
   *  }}}
   *  will produce the following warning:
@@ -38,4 +38,7 @@ import scala.annotation.meta._
   *  @see    [[scala.deprecatedOverriding]]
   */
 @param
-class deprecatedName(name: Symbol = Symbol("<none>"), since: String = "") extends scala.annotation.StaticAnnotation
+class deprecatedName(name: String = "<none>", since: String = "") extends scala.annotation.StaticAnnotation {
+  @deprecated("The parameter name should be a String, not a symbol.", "2.13.0") def this(name: Symbol, since: String) = this(name.name, since)
+  @deprecated("The parameter name should be a String, not a symbol.", "2.13.0") def this(name: Symbol) = this(name.name, "")
+}

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -898,7 +898,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isDeprecated           = hasAnnotation(DeprecatedAttr)
     def deprecationMessage     = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 0)
     def deprecationVersion     = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 1)
-    def deprecatedParamName    = getAnnotation(DeprecatedNameAttr) flatMap (_ symbolArg 0 orElse Some(nme.NO_NAME))
+    def deprecatedParamName    = getAnnotation(DeprecatedNameAttr) flatMap (ann => ann.symbolArg(0).orElse(ann.stringArg(0).map(newTermName)).orElse(Some(nme.NO_NAME)))
     def deprecatedParamVersion = getAnnotation(DeprecatedNameAttr) flatMap (_ stringArg 1)
     def hasDeprecatedInheritanceAnnotation
                                = hasAnnotation(DeprecatedInheritanceAttr)

--- a/test/files/neg/names-defaults-neg-pu.check
+++ b/test/files/neg/names-defaults-neg-pu.check
@@ -107,11 +107,11 @@ names-defaults-neg-pu.scala:86: error: module extending its companion class cann
     object C extends C()
                      ^
 names-defaults-neg-pu.scala:90: error: deprecated parameter name x has to be distinct from any other parameter name (deprecated or not).
-  def deprNam1(x: Int, @deprecatedName('x) y: String) = 0
-                                           ^
+  def deprNam1(x: Int, @deprecatedName("x") y: String) = 0
+                                            ^
 names-defaults-neg-pu.scala:91: error: deprecated parameter name a has to be distinct from any other parameter name (deprecated or not).
-  def deprNam2(a: String)(@deprecatedName('a) b: Int) = 1
-                                              ^
+  def deprNam2(a: String)(@deprecatedName("a") b: Int) = 1
+                                               ^
 names-defaults-neg-pu.scala:93: warning: the parameter name y is deprecated: use b instead
   deprNam3(y = 10, b = 2)
              ^

--- a/test/files/neg/names-defaults-neg-pu.scala
+++ b/test/files/neg/names-defaults-neg-pu.scala
@@ -87,12 +87,12 @@ object Test extends App {
   }
 
   // deprecated names
-  def deprNam1(x: Int, @deprecatedName('x) y: String) = 0
-  def deprNam2(a: String)(@deprecatedName('a) b: Int) = 1
-  def deprNam3(@deprecatedName('x) a: Int, @deprecatedName('y) b: Int) = a + b
+  def deprNam1(x: Int, @deprecatedName("x") y: String) = 0
+  def deprNam2(a: String)(@deprecatedName("a") b: Int) = 1
+  def deprNam3(@deprecatedName("x") a: Int, @deprecatedName("y") b: Int) = a + b
   deprNam3(y = 10, b = 2)
 
-  def deprNam4(@deprecatedName('deprNam4Arg) deprNam4Arg: String) = 0
+  def deprNam4(@deprecatedName("deprNam4Arg") deprNam4Arg: String) = 0
   deprNam4(deprNam4Arg = null)
   def deprNam5(@deprecatedName deprNam5Arg: String) = 0
   deprNam5(deprNam5Arg = null)

--- a/test/files/neg/names-defaults-neg-warn.scala
+++ b/test/files/neg/names-defaults-neg-warn.scala
@@ -1,9 +1,9 @@
 object Test extends App {
   object deprNam2 {
-    def f(@deprecatedName('s) x: String) = 1
+    def f(@deprecatedName("s") x: String) = 1
     def f(s: Object) = 2
 
-    def g(@deprecatedName('x) s: Object) = 3
+    def g(@deprecatedName("x") s: Object) = 3
     def g(s: String) = 4
   }
 

--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -107,11 +107,11 @@ names-defaults-neg.scala:86: error: module extending its companion class cannot 
     object C extends C()
                      ^
 names-defaults-neg.scala:90: error: deprecated parameter name x has to be distinct from any other parameter name (deprecated or not).
-  def deprNam1(x: Int, @deprecatedName('x) y: String) = 0
-                                           ^
+  def deprNam1(x: Int, @deprecatedName("x") y: String) = 0
+                                            ^
 names-defaults-neg.scala:91: error: deprecated parameter name a has to be distinct from any other parameter name (deprecated or not).
-  def deprNam2(a: String)(@deprecatedName('a) b: Int) = 1
-                                              ^
+  def deprNam2(a: String)(@deprecatedName("a") b: Int) = 1
+                                               ^
 names-defaults-neg.scala:93: warning: the parameter name y is deprecated: use b instead
   deprNam3(y = 10, b = 2)
              ^
@@ -124,32 +124,38 @@ names-defaults-neg.scala:96: warning: naming parameter deprNam4Arg is deprecated
 names-defaults-neg.scala:98: warning: naming parameter deprNam5Arg is deprecated.
   deprNam5(deprNam5Arg = null)
                        ^
-names-defaults-neg.scala:102: error: unknown parameter name: m
+names-defaults-neg.scala:102: warning: the parameter name foo is deprecated: use deprNam6Arg instead
+  deprNam6(foo = null)
+               ^
+names-defaults-neg.scala:104: warning: the parameter name bar is deprecated (since 2.12.0): use deprNam7Arg instead
+  deprNam7(bar = null)
+               ^
+names-defaults-neg.scala:108: error: unknown parameter name: m
   f3818(y = 1, m = 1)
                  ^
-names-defaults-neg.scala:135: warning: a pure expression does nothing in statement position
+names-defaults-neg.scala:141: warning: a pure expression does nothing in statement position
   delay(var2 = 40)
                ^
-names-defaults-neg.scala:138: error: missing parameter type for expanded function ((x$1: <error>) => a = x$1)
+names-defaults-neg.scala:144: error: missing parameter type for expanded function ((x$1: <error>) => a = x$1)
   val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
                                          ^
-names-defaults-neg.scala:138: error: not found: value a
+names-defaults-neg.scala:144: error: not found: value a
   val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
                                      ^
-names-defaults-neg.scala:138: error: not found: value get
+names-defaults-neg.scala:144: error: not found: value get
   val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
                                                 ^
-names-defaults-neg.scala:139: error: parameter 'a' is already specified at parameter position 1
+names-defaults-neg.scala:145: error: parameter 'a' is already specified at parameter position 1
   val taf3 = testAnnFun(b = _: String, a = get(8))
                                          ^
-names-defaults-neg.scala:140: error: missing parameter type for expanded function ((x$3: <error>) => testAnnFun(x$3, ((x$4) => b = x$4)))
+names-defaults-neg.scala:146: error: missing parameter type for expanded function ((x$3: <error>) => testAnnFun(x$3, ((x$4) => b = x$4)))
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                ^
-names-defaults-neg.scala:140: error: missing parameter type for expanded function ((x$4: <error>) => b = x$4)
+names-defaults-neg.scala:146: error: missing parameter type for expanded function ((x$4: <error>) => b = x$4)
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                       ^
-names-defaults-neg.scala:140: error: not found: value b
+names-defaults-neg.scala:146: error: not found: value b
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                   ^
-5 warnings found
+7 warnings found
 36 errors found

--- a/test/files/neg/names-defaults-neg.scala
+++ b/test/files/neg/names-defaults-neg.scala
@@ -87,15 +87,21 @@ object Test extends App {
   }
 
   // deprecated names
-  def deprNam1(x: Int, @deprecatedName('x) y: String) = 0
-  def deprNam2(a: String)(@deprecatedName('a) b: Int) = 1
-  def deprNam3(@deprecatedName('x) a: Int, @deprecatedName('y) b: Int) = a + b
+  def deprNam1(x: Int, @deprecatedName("x") y: String) = 0
+  def deprNam2(a: String)(@deprecatedName("a") b: Int) = 1
+  def deprNam3(@deprecatedName("x") a: Int, @deprecatedName("y") b: Int) = a + b
   deprNam3(y = 10, b = 2)
 
-  def deprNam4(@deprecatedName('deprNam4Arg) deprNam4Arg: String) = 0
+  def deprNam4(@deprecatedName("deprNam4Arg") deprNam4Arg: String) = 0
   deprNam4(deprNam4Arg = null)
   def deprNam5(@deprecatedName deprNam5Arg: String) = 0
   deprNam5(deprNam5Arg = null)
+
+  // deprecated deprecatatedName constructors
+  def deprNam6(@deprecatedName('foo) deprNam6Arg: String) = 0
+  deprNam6(foo = null)
+  def deprNam7(@deprecatedName('bar, "2.12.0") deprNam7Arg: String) = 0
+  deprNam7(bar = null)
 
   // t3818
   def f3818(x: Int = 1, y: Int, z: Int = 1) = 0

--- a/test/files/run/names-defaults.scala
+++ b/test/files/run/names-defaults.scala
@@ -355,15 +355,15 @@ object Test extends App {
   (new DBLAH())
 
   // deprecated names
-  def deprNam1(@deprecatedName('x) a: Int, @deprecatedName('y) b: Int) = a + b
+  def deprNam1(@deprecatedName("x") a: Int, @deprecatedName("y") b: Int) = a + b
   deprNam1(y = 10, a = 1)
   deprNam1(b = 2, x = 10)
 
   object deprNam2 {
-    def f(@deprecatedName('s) x: String) = 1
+    def f(@deprecatedName("s") x: String) = 1
     def f(s: Object) = 2
 
-    def g(@deprecatedName('x) s: Object) = 3
+    def g(@deprecatedName("x") s: Object) = 3
     def g(s: String) = 4
   }
   println(deprNam2.f(s = "dlf"))


### PR DESCRIPTION
This removes the sole use of scala.Symbol in the standard library, this
is a first step to allow the deprecation of
symbols (https://github.com/scala/scala-dev/issues/459).

Deprecated secondary constructors are added for compatibility, note that
the deprecation warnings are currently not shown because of
scala/bug#11012.