### PR TITLE
Add orderedCompanion method to mutable.PriorityQueue

### DIFF
--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -334,6 +334,9 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     pq
   }
 
+  @deprecated("Use `PriorityQueue` instead", "2.13.0")
+  def orderedCompanion: PriorityQueue.type = PriorityQueue
+
   override protected[this] def writeReplace(): AnyRef = new DefaultSerializationProxy(PriorityQueue.evidenceIterableFactory[A], this)
 
   override protected[this] def className = "PriorityQueue"

--- a/test/junit/scala/collection/mutable/PriorityQueueTest.scala
+++ b/test/junit/scala/collection/mutable/PriorityQueueTest.scala
@@ -14,6 +14,12 @@ class PriorityQueueTest {
   priorityQueue.enqueue(elements :_*)
 
   @Test
+  def orderedCompanion(): Unit = {
+    val pq = new mutable.PriorityQueue[Int]()
+    assert(pq.orderedCompanion == PriorityQueue)
+  }
+
+  @Test
   def orderingReverseReverse(): Unit = {
     val pq = new mutable.PriorityQueue[Nothing]()((_,_)=>42)
     assert(pq.ord eq pq.reverse.reverse.ord)


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/10989