### PR TITLE
Fix regression with curried implicit defs conforming to function types

### DIFF
--- a/test/files/pos/t10858.scala
+++ b/test/files/pos/t10858.scala
@@ -1,0 +1,6 @@
+import language.implicitConversions
+
+object Test {
+	implicit def foo(a: Int)(b: Int, c: Int): String = "" + a + b;
+	implicitly[Int => (Int, Int) => String].apply(1).apply(2, 3)
+}


### PR DESCRIPTION
Fixes scala/bug#10858

I introduced the regression [introduced in 2.12.x](#5875), so targetting the fix to the same branch.