### PR TITLE
[#8469] IterableOnce#copyToArray returns number of elements copied

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -1263,13 +1263,20 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *  @param  len    the maximal number of elements to copy.
     *  @tparam B      the type of the elements of the array.
     */
-  def copyToArray[B >: A](dest: Array[B], start: Int, len: Int = Int.MaxValue): dest.type = {
-    Array.copy(xs, 0, dest, start, min(xs.length, min(dest.length-start, len)))
-    dest
+  def copyToArray[B >: A](dest: Array[B], start: Int, len: Int = Int.MaxValue): Int = {
+    val copied = IterableOnce.elemsToCopyToArray(xs.length, dest.length, start, len)
+    if (copied > 0) {
+      Array.copy(xs, 0, dest, start, copied)
+    }
+    copied
   }
 
   /** Create a copy of this array with the specified element type. */
-  def toArray[B >: A: ClassTag]: Array[B] = copyToArray(new Array[B](xs.length), 0)
+  def toArray[B >: A: ClassTag]: Array[B] = {
+    val destination = new Array[B](xs.length)
+    copyToArray(destination, 0)
+    destination
+  }
 
   /** Counts the number of elements in this array which satisfy a predicate */
   def count(p: A => Boolean): Int = {

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -1141,16 +1141,14 @@ final class StringOps(private val s: String) extends AnyVal {
   @`inline` def filterNot(pred: Char => Boolean): String = filter(c => !pred(c))
 
   /** Copy chars of this string to an array.
-    * Fills the given array `xs` starting at index `start` with at most `len` chars.
-    * Copying will stop once either the entire string has been copied,
-    * or the end of the array is reached or `len` chars have been copied.
+    * Fills the given array `xs` starting at index 0.
+    * Copying will stop once either the entire string has been copied
+    * or the end of the array is reached
     *
     *  @param  xs     the array to fill.
-    *  @param  start  the starting index.
-    *  @param  len    the maximal number of elements to copy.
     */
-  def copyToArray(xs: Array[Char], start: Int, len: Int): Unit =
-    s.getChars(0, min(min(s.length, len), xs.length-start), xs, start)
+  @`inline` def copyToArray(xs: Array[Char]): Int =
+    copyToArray(xs, 0, Int.MaxValue)
 
   /** Copy chars of this string to an array.
     * Fills the given array `xs` starting at index `start`.
@@ -1159,10 +1157,26 @@ final class StringOps(private val s: String) extends AnyVal {
     *
     *  @param  xs     the array to fill.
     *  @param  start  the starting index.
+    */
+  @`inline` def copyToArray(xs: Array[Char], start: Int): Int =
+    copyToArray(xs, start, Int.MaxValue)
+
+  /** Copy chars of this string to an array.
+    * Fills the given array `xs` starting at index `start` with at most `len` chars.
+    * Copying will stop once either the entire string has been copied,
+    * or the end of the array is reached or `len` chars have been copied.
+    *
+    *  @param  xs     the array to fill.
+    *  @param  start  the starting index.
     *  @param  len    the maximal number of elements to copy.
     */
-  @`inline` def copyToArray(xs: Array[Char], start: Int): Unit =
-    copyToArray(xs, start, Int.MaxValue)
+  def copyToArray(xs: Array[Char], start: Int, len: Int): Int = {
+    val copied = IterableOnce.elemsToCopyToArray(s.length, xs.length, start, len)
+    if (copied > 0) {
+      s.getChars(0, copied, xs, start)
+    }
+    copied
+  }
 
   /** Finds index of the first char satisfying some predicate after or at some start index.
     *

--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -5,6 +5,7 @@ import java.io.{ObjectInputStream, ObjectOutputStream}
 
 import scala.collection.mutable.{ArrayBuffer, ArrayBuilder, Builder, ArraySeq => MutableArraySeq}
 import scala.collection.{ArrayOps, ClassTagSeqFactory, SeqFactory, StrictOptimizedClassTagSeqFactory, View}
+import scala.collection.IterableOnce
 import scala.annotation.unchecked.uncheckedVariance
 import scala.util.hashing.MurmurHash3
 import scala.reflect.ClassTag
@@ -133,12 +134,14 @@ sealed abstract class ArraySeq[+A]
 
   override protected[this] def className = "ArraySeq"
 
-  override def copyToArray[B >: A](xs: Array[B], start: Int = 0): xs.type = copyToArray[B](xs, start, length)
+  override def copyToArray[B >: A](xs: Array[B], start: Int = 0): Int = copyToArray[B](xs, start, length)
 
-  override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): xs.type = {
-    val l = scala.math.min(scala.math.min(len, length), xs.length-start)
-    if(l > 0) Array.copy(unsafeArray, 0, xs, start, l)
-    xs
+  override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {
+    val copied = IterableOnce.elemsToCopyToArray(length, xs.length, start, len)
+    if(copied > 0) {
+      Array.copy(unsafeArray, 0, xs, start, copied)
+    }
+    copied
   }
 
   override protected[this] def writeReplace(): AnyRef = this

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -2,9 +2,6 @@ package scala
 package collection
 package mutable
 
-import java.lang.{IndexOutOfBoundsException, IllegalArgumentException}
-
-
 /** An implementation of the `Buffer` class using an array to
   *  represent the assembled sequence internally. Append, update and random
   *  access take constant time (amortized time). Prepends and removes are
@@ -159,12 +156,14 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   override protected[this] def stringPrefix = "ArrayBuffer"
 
-  override def copyToArray[B >: A](xs: Array[B], start: Int): xs.type = copyToArray[B](xs, start, length)
+  override def copyToArray[B >: A](xs: Array[B], start: Int): Int = copyToArray[B](xs, start, length)
 
-  override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): xs.type = {
-    val l = scala.math.min(scala.math.min(len, length), xs.length-start)
-    if(l > 0) Array.copy(array, 0, xs, start, l)
-    xs
+  override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {
+    val copied = IterableOnce.elemsToCopyToArray(length, xs.length, start, len)
+    if(copied > 0) {
+      Array.copy(array, 0, xs, start, copied)
+    }
+    copied
   }
 
   /** Sorts this $coll in place according to an Ordering.

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -434,8 +434,13 @@ class ArrayDeque[A] protected (
 
   override def grouped(n: Int): Iterator[IterableCC[A]] = sliding(n, n)
 
-  override def copyToArray[B >: A](dest: Array[B], destStart: Int, len: Int): dest.type =
-    copySliceToArray(srcStart = 0, dest = dest, destStart = destStart, maxItems = len)
+  override def copyToArray[B >: A](dest: Array[B], destStart: Int, len: Int): Int = {
+    val copied = IterableOnce.elemsToCopyToArray(length, dest.length, destStart, len)
+    if (copied > 0) {
+      copySliceToArray(srcStart = 0, dest = dest, destStart = destStart, maxItems = len)
+    }
+    copied
+  }
 
   override def toArray[B >: A: ClassTag]: Array[B] =
     copySliceToArray(srcStart = 0, dest = new Array[B](length), destStart = 0, maxItems = length)

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -59,12 +59,14 @@ sealed abstract class ArraySeq[T]
   /** Clones this object, including the underlying Array. */
   override def clone(): ArraySeq[T] = ArraySeq.make(array.clone()).asInstanceOf[ArraySeq[T]]
 
-  override def copyToArray[B >: T](xs: Array[B], start: Int): xs.type = copyToArray[B](xs, start, length)
+  override def copyToArray[B >: T](xs: Array[B], start: Int): Int = copyToArray[B](xs, start, length)
 
-  override def copyToArray[B >: T](xs: Array[B], start: Int, len: Int): xs.type = {
-    val l = scala.math.min(scala.math.min(len, length), xs.length-start)
-    if(l > 0) Array.copy(array, 0, xs, start, l)
-    xs
+  override def copyToArray[B >: T](xs: Array[B], start: Int, len: Int): Int = {
+    val copied = IterableOnce.elemsToCopyToArray(length, xs.length, start, len)
+    if(copied > 0) {
+      Array.copy(array, 0, xs, start, copied)
+    }
+    copied
   }
 
   override protected[this] def writeReplace(): AnyRef = this

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -100,4 +100,10 @@ class ArrayOpsTest {
     assertArrayEquals(Array[Int](), Array[Int](1).slice(1052471512, -1496048404))
     assertArrayEquals(Array[Int](), Array[Int](1).slice(2, 3))
   }
+
+  @Test
+  def copyToArrayOutOfBoundsTest: Unit = {
+    val target = Array[Int]()
+    assertEquals(0, Array(1,2).copyToArray(target, 1, 0))
+  }
 }

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -7,6 +7,7 @@ import org.junit.runners.JUnit4
 import scala.collection.immutable.{ArraySeq, List, Range, Vector}
 import scala.language.higherKinds
 import scala.tools.testing.AssertUtil._
+import org.junit.Assert.assertEquals
 
 @RunWith(classOf[JUnit4])
 class IterableTest {
@@ -57,7 +58,7 @@ class IterableTest {
 
     val xs = Seq('a', 'b', 'b', 'c', 'a', 'a', 'a', 'b')
     val expected = Map('a' -> 4, 'b' -> 3, 'c' -> 1)
-    Assert.assertEquals(expected, occurrences(xs))
+    assertEquals(expected, occurrences(xs))
   }
 
   @Test
@@ -89,54 +90,46 @@ class IterableTest {
   }
 
   @Test def copyToArray(): Unit = {
-    def check(a: Array[Int], start: Int, end: Int) = {
+    def check(a: Array[Int], copyToArray: Array[Int] => Int, elemsWritten: Int, start: Int, end: Int) = {
+
+      assertEquals(copyToArray(a), elemsWritten)
+
       var i = 0
       while (i < start) {
-        assert(a(i) == 0)
+        assertEquals(a(i),0)
         i += 1
       }
       while (i < a.length && i < end) {
-        assert(a(i) == i - start)
+        assertEquals(a(i), i - start)
         i += 1
       }
       while (i < a.length) {
-        assert(a(i) == 0)
+        assertEquals(a(i), 0)
         i += 1
       }
     }
 
     val far = 100000
     val l = Iterable.from(Range(0, 100))
-    check(l.copyToArray(new Array(100)),
-      0, far)
-    check(l.copyToArray(new Array(10)),
-      0, far)
-    check(l.copyToArray(new Array(1000)),
-      0, 100)
+    check(new Array(100), l.copyToArray(_), 100, 0, far)
+    check(new Array(10), l.copyToArray(_), 10, 0, far)
+    check(new Array(100), l.copyToArray(_), 100, 0, 100)
 
-    check(l.copyToArray(new Array(100), 5),
-      5, 105)
-    check(l.copyToArray(new Array(10), 5),
-      5, 10)
-    check(l.copyToArray(new Array(1000), 5),
-      5, 105)
+    check(new Array(100), l.copyToArray(_, 5), 95, 5, 105)
+    check(new Array(10), l.copyToArray(_, 5), 5, 5, 10)
+    check(new Array(1000), l.copyToArray(_, 5), 100, 5, 105)
 
-    check(l.copyToArray(new Array(100), 5, 50),
-      5, 55)
-    check(l.copyToArray(new Array(10), 5, 50),
-      5, 10)
-    check(l.copyToArray(new Array(1000), 5, 50),
-      5, 55)
+    check(new Array(100), l.copyToArray(_, 5, 50), 50, 5, 55)
+    check(new Array(10), l.copyToArray(_, 5, 50), 5, 5, 10)
+    check(new Array(1000), l.copyToArray(_, 5, 50), 50, 5, 55)
 
-    assertThrows[ArrayIndexOutOfBoundsException](l.copyToArray(new Array(10), -1))
-    assertThrows[ArrayIndexOutOfBoundsException](l.copyToArray(new Array(10), -1, 10))
+    assertThrows[ArrayIndexOutOfBoundsException]( l.copyToArray(new Array(10), -1))
+    assertThrows[ArrayIndexOutOfBoundsException]( l.copyToArray(new Array(10), -1, 10))
+    assertEquals(l.copyToArray(new Array(10), 1, -1), 0)
 
-    check(l.copyToArray(new Array(10), 10),
-      0, 0)
-    check(l.copyToArray(new Array(10), 10, 10),
-      0, 0)
-    check(l.copyToArray(new Array(10), 0, -1),
-      0, 0)
+    check(new Array(10), l.copyToArray(_, 10), 0, 0, 0)
+    check(new Array(10), l.copyToArray(_, 10, 10), 0, 0, 0)
+    check(new Array(10), l.copyToArray(_, 0, -1), 0, 0, 0)
   }
 
   @Test
@@ -267,4 +260,5 @@ class IterableTest {
     val foo = new Foo
     Assert.assertEquals("Fu()", foo.toString)
   }
+
 }

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -428,54 +428,46 @@ class IteratorTest {
   }
 
   @Test def copyToArray(): Unit = {
-    def check(a: Array[Int], start: Int, end: Int) = {
+    def check(a: Array[Int], copyTo: Array[Int] => Int, elemsWritten: Int, start: Int, end: Int): Unit = {
+
+      val copied = copyTo(a)
+      assertEquals(elemsWritten, copied)
+
       var i = 0
       while (i < start) {
-        assert(a(i) == 0)
+        assertEquals(a(i), 0)
         i += 1
       }
       while (i < a.length && i < end) {
-        assert(a(i) == i - start)
+        assertEquals(a(i), i - start)
         i += 1
       }
       while (i < a.length) {
-        assert(a(i) == 0)
+        assertEquals(a(i), 0)
         i += 1
       }
     }
 
     val far = 100000
     def l = Iterable.from(Range(0, 100)).iterator
-    check(l.copyToArray(new Array(100)),
-      0, far)
-    check(l.copyToArray(new Array(10)),
-      0, far)
-    check(l.copyToArray(new Array(1000)),
-      0, 100)
+    check(new Array(100), l.copyToArray(_), 100, 0, far)
+    check(new Array(10), l.copyToArray(_), 10, 0, far)
+    check(new Array(1000), l.copyToArray(_), 100, 0, 100)
 
-    check(l.copyToArray(new Array(100), 5),
-      5, 105)
-    check(l.copyToArray(new Array(10), 5),
-      5, 10)
-    check(l.copyToArray(new Array(1000), 5),
-      5, 105)
+    check(new Array(100), l.copyToArray(_, 5), 95, 5, 105)
+    check(new Array(10), l.copyToArray(_, 5), 5, 5, 10)
+    check(new Array(1000), l.copyToArray(_, 5), 100, 5, 105)
 
-    check(l.copyToArray(new Array(100), 5, 50),
-      5, 55)
-    check(l.copyToArray(new Array(10), 5, 50),
-      5, 10)
-    check(l.copyToArray(new Array(1000), 5, 50),
-      5, 55)
+    check(new Array(100), l.copyToArray(_, 5, 50), 50, 5, 55)
+    check(new Array(10), l.copyToArray(_, 5, 50), 5, 5, 10)
+    check(new Array(1000), l.copyToArray(_, 5, 50), 50, 5, 55)
 
     assertThrows[ArrayIndexOutOfBoundsException](l.copyToArray(new Array(10), -1))
     assertThrows[ArrayIndexOutOfBoundsException](l.copyToArray(new Array(10), -1, 10))
 
-    check(l.copyToArray(new Array(10), 10),
-      0, 0)
-    check(l.copyToArray(new Array(10), 10, 10),
-      0, 0)
-    check(l.copyToArray(new Array(10), 0, -1),
-      0, 0)
+    check(new Array(10), l.copyToArray(_, 10), 0, 0, 0)
+    check(new Array(10), l.copyToArray(_, 10, 10), 0, 0, 0)
+    check(new Array(10), l.copyToArray(_, 0, -1), 0, 0, 0)
   }
 
   // scala/bug#10709

--- a/test/junit/scala/collection/StringOpsTest.scala
+++ b/test/junit/scala/collection/StringOpsTest.scala
@@ -1,9 +1,11 @@
 package scala.collection
 
-import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.junit.Assert.assertEquals
+import scala.tools.testing.AssertUtil.assertThrows
+
 
 @RunWith(classOf[JUnit4])
 class StringOpsTest {
@@ -24,6 +26,66 @@ class StringOpsTest {
 
   @Test def toArray(): Unit = {
     assert("".toArray[Any].length == 0) // should not throw
+    assertEquals("".mkString(""), "")
+    assertEquals("".mkString(","), "")
+    assertEquals("a".mkString(","), "a")
+    assertEquals("ab".mkString(","), "a,b")
+  }
+  // Test for scala/bug#8469
+  @Test def copyToArray(): Unit = {
+
+      def check(string: String, array: Array[Char], copied: Int, after: Array[Char]): Unit = {
+        assertEquals(copied, string.copyToArray(array))
+        assert(array.sameElements(after))
+      }
+
+      check(string = "", array = Array(), copied = 0, after = Array())
+      check(string = "", array = Array('a', 'b'), copied = 0, after = Array('a', 'b'))
+
+      check(string = "abc", array = Array('x', 'y', 'z'), copied = 3, after = Array('a', 'b', 'c'))
+      check(string = "abc", array = Array('x'), copied = 1, after = Array('a'))
+      check(string = "abc", array = Array(), copied = 0, after = Array())
+  }
+
+  // Test for scala/bug#8469
+  @Test def copyToArrayStart(): Unit = {
+    def check(string: String, start: Int, array: Array[Char], copied: Int, after: Array[Char]): Unit = {
+      assertEquals(copied, string.copyToArray(array,start))
+      assert(array.sameElements(after))
+    }
+
+    check(string = "", start = 0, array = Array(), copied = 0, after = Array())
+    check(string = "", start = 1, array = Array(), copied = 0, after = Array())
+    check(string = "", start = -1, array = Array(), copied = 0, after = Array())
+
+    assertThrows[ArrayIndexOutOfBoundsException](check(string = "abcd", start = -13, array = Array('x', 'y'), copied = 0, after = Array('x', 'y')))
+    check(string = "abcd", start = 0, array = Array('x', 'y'), copied = 2, after = Array('a', 'b'))
+    check(string = "abcd", start = 1, array = Array('x', 'y'), copied = 1, after = Array('x', 'a'))
+    check(string = "abcd", start = 2, array = Array('x', 'y'), copied = 0, after = Array('x', 'y'))
+    check(string = "abcd", start = 3, array = Array('x', 'y'), copied = 0, after = Array('x', 'y'))
+    check(string = "abcd", start = 4, array = Array('x', 'y'), copied = 0, after = Array('x', 'y'))
+    check(string = "abcd", start = 5, array = Array('x', 'y'), copied = 0, after = Array('x', 'y'))
+  }
+
+  // Test for scala/bug#8469
+  @Test def copyToArrayStartLen(): Unit = {
+
+    def check(string: String, start: Int, len: Int, array: Array[Char], copied: Int, after: Array[Char]): Unit = {
+      assertEquals(copied, string.copyToArray(array, start, len))
+      assert(array.sameElements(after))
+    }
+
+    check(string = "", start = 0, len = 0, array = Array(), copied = 0, after = Array())
+    check(string = "", start = 1, len = 0, array = Array(), copied = 0, after = Array())
+    check(string = "", start = 1, len = 1, array = Array(), copied = 0, after = Array())
+
+    check(string = "abcd", start = -1, len = 0, array = Array('x', 'y'), copied = 0, after = Array('x', 'y'))
+    check(string = "abcd", start = 0, len = 0, array = Array('x', 'y'), copied = 0, after = Array('x', 'y'))
+    check(string = "abcd", start = 0, len = 1, array = Array('x', 'y'), copied = 1, after = Array('a', 'y'))
+    check(string = "abcd", start = 1, len = 1, array = Array('x', 'y'), copied = 1, after = Array('x', 'a'))
+    check(string = "abcd", start = 0, len = 2, array = Array('x', 'y'), copied = 2, after = Array('a', 'b'))
+    check(string = "abcd", start = 0, len = 20, array = Array('x', 'y'), copied = 2, after = Array('a', 'b'))
+    check(string = "abcd", start = 7, len = 20, array = Array('x', 'y'), copied = 0, after = Array('x', 'y'))
   }
 
   @Test def *(): Unit = {

--- a/test/junit/scala/collection/immutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/immutable/ArraySeqTest.scala
@@ -63,6 +63,11 @@ class ArraySeqTest {
     a.toArray.update(0, 100)
     assertEquals(a, List(1,2,3))
   }
+  @Test
+  def copyToArrayReturnsNonNegative(): Unit = {
+    val a = ArraySeq(1,2,3)
+    assertEquals(a.copyToArray(Array(1,1,2), 0, -1), 0)
+  }
 
   private def check[T : ClassTag](array: ArraySeq[T], expectedSliceResult1: ArraySeq[T], expectedSliceResult2: ArraySeq[T]) {
     assertEquals(array, array.slice(-1, 4))

--- a/test/junit/scala/collection/immutable/QueueTest.scala
+++ b/test/junit/scala/collection/immutable/QueueTest.scala
@@ -4,6 +4,9 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
 
+
+import org.junit.Assert.assertEquals
+
 @RunWith(classOf[JUnit4])
 /* Tests for collection.immutable.Queue  */
 class QueueTest {
@@ -11,18 +14,27 @@ class QueueTest {
   val oneAdded = emptyQueue.enqueue(1)
   val threeAdded = emptyQueue.enqueue(1 to 3)
 
+
+
   @Test
   def dequeueOptionOnEmpty(): Unit = {
-    assert( emptyQueue.dequeueOption == None )
+    assertEquals(emptyQueue.dequeueOption, None)
   }
 
   @Test
   def dequeueOptionOneAdded(): Unit = {
-    assert( oneAdded.dequeueOption == Some((1,emptyQueue)) )
+    assertEquals(oneAdded.dequeueOption, Some((1,emptyQueue)))
   }
 
   @Test
   def dequeueOptionThreeAdded(): Unit = {
-    assert( threeAdded.dequeueOption == Some((1,Queue(2 to 3:_*))) )
+    assertEquals(threeAdded.dequeueOption, Some((1,Queue(2 to 3:_*))))
   }
+
+  @Test
+  def copyToArrayOutOfBounds: Unit = {
+    val target = Array[Int]()
+    assertEquals(0, Queue(1,2).copyToArray(target, 1, 0))
+  }
+
 }

--- a/test/junit/scala/collection/mutable/ArrayDequeTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayDequeTest.scala
@@ -14,9 +14,9 @@ class ArrayDequeTest {
 
     def apply[U](f: Buffer[Int] => U) = {
       //println(s"Before: [buffer1=${buffer}; buffer2=${buffer2}]")
-      assert(f(buffer) == f(buffer2))
-      assert(buffer == buffer2)
-      assert(buffer.reverse == buffer2.reverse)
+      assertEquals(f(buffer), f(buffer2))
+      assertEquals(buffer, buffer2)
+      assertEquals(buffer.reverse, buffer2.reverse)
     }
 
     apply(_ += (1, 2, 3, 4, 5))
@@ -40,15 +40,15 @@ class ArrayDequeTest {
     apply(_.addAll(collection.immutable.Vector.tabulate(10)(identity)))
 
     (-100 to 100) foreach {i =>
-      assert(buffer.splitAt(i) == buffer2.splitAt(i))
+      assertEquals(buffer.splitAt(i), buffer2.splitAt(i))
     }
 
     for {
       i <- -100 to 100
       j <- -100 to 100
     } {
-      assert(buffer.slice(i, j) == buffer2.slice(i, j))
-      if (i > 0 && j > 0) assert(List.from(buffer.sliding(i, j)) == List.from(buffer2.sliding(i, j)))
+      assertEquals(buffer.slice(i, j), buffer2.slice(i, j))
+      if (i > 0 && j > 0) assertEquals(List.from(buffer.sliding(i, j)), List.from(buffer2.sliding(i, j)))
     }
   }
 
@@ -64,5 +64,11 @@ class ArrayDequeTest {
 
     xs.insert(0, 0)
     assertEquals(Queue(0), xs)
+  }
+
+  @Test
+  def copyToArrayOutOfBounds: Unit = {
+    val target = Array[Int]()
+    assertEquals(0, collection.mutable.ArrayDeque(1, 2).copyToArray(target, 1, 0))
   }
 }

--- a/test/junit/scala/collection/mutable/QueueTest.scala
+++ b/test/junit/scala/collection/mutable/QueueTest.scala
@@ -4,7 +4,7 @@ import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import scala.collection.IterableFactory
+import scala.collection.mutable
 
 @RunWith(classOf[JUnit4])
 class QueueTest {
@@ -28,5 +28,11 @@ class QueueTest {
     assertEquals(s, List(2, 3, 4))
     assertEquals(q.enqueue(5), List(1, 2, 3, 4, 5))
     assertEquals(s, List(2, 3, 4))
+  }
+
+  @Test
+  def copyToArrayOutOfBounds: Unit = {
+    val target = Array[Int]()
+    assertEquals(0, mutable.Queue(1,2).copyToArray(target, 1, 0))
   }
 }

--- a/test/junit/scala/tools/nsc/DeterminismTest.scala
+++ b/test/junit/scala/tools/nsc/DeterminismTest.scala
@@ -2,7 +2,6 @@ package scala.tools.nsc
 
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
-import java.util
 
 import org.junit.Test
 


### PR DESCRIPTION
This fixes scala/bug#8469, and also adds `StringOps#copyToArray(Array[Char])`

This also fixes scala/bug#11048