### PR TITLE
Enhance the right set of type bounds

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -968,7 +968,6 @@ trait Infer extends Checkable {
 
           val AdjustedTypeArgs.AllArgsAndUndets(okparams, okargs, allargs, leftUndet) =
             methTypeArgs(fn, undetparams, formals, restpe, argtpes, pt)
-          enhanceBounds(okparams, okargs, leftUndet)
 
           if (checkBounds(fn, NoPrefix, NoSymbol, undetparams, allargs, "inferred ")) {
             val treeSubst = new TreeTypeSubstituter(okparams, okargs)
@@ -982,7 +981,7 @@ trait Infer extends Checkable {
                 val xs1 = treeSubst.typeMap mapOver xs
                 if (xs ne xs1)
                   new TreeSymSubstTraverser(xs, xs1) traverseTrees fn :: args
-
+                enhanceBounds(okparams, okargs, xs1)
                 xs1
             }
           } else Nil

--- a/test/files/pos/t10758/Macros_1.scala
+++ b/test/files/pos/t10758/Macros_1.scala
@@ -1,0 +1,24 @@
+import scala.language.experimental.macros
+
+import scala.reflect.macros.whitebox.Context
+
+final class TwoFaceInt[T](val value : Int) {
+  def + [R](that : TwoFaceInt[R]) = ???
+}
+object TwoFaceInt {
+  def apply[T <: Int, Out <: T](value : T) : TwoFaceInt[Out] = macro Builder.Macro.fromNumValue[T]
+}
+
+object Builder {
+  final class Macro(val c: Context) {
+    def fromNumValue[T](value : c.Tree)(implicit t : c.WeakTypeTag[T]) : c.Tree = {
+      import c.universe._
+      val tTpe = weakTypeOf[T]
+      val valueTpe = value match {
+        case Literal(Constant(t : Int)) => c.internal.constantType(Constant(t))
+        case _ => tTpe
+      }
+      q"new TwoFaceInt[$valueTpe]($value)"
+    }
+  }
+}

--- a/test/files/pos/t10758/Main_2.scala
+++ b/test/files/pos/t10758/Main_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  TwoFaceInt(1) + TwoFaceInt(2)
+}


### PR DESCRIPTION
In `inferMethodInstance` a new list of undetermined symbols is computed and returned. However, the bounds enhancement introduced in #6140 is applied to the list of previously undetermined symbols, rather than the new list. This commit applies the bounds enhancement to the newly computed list.

None of the other callsites of `enhanceBounds` appear to have the same issue.

Fixes scala/bug#10758.