### PR TITLE
Make operation aliases more compatible with previous Scala versions

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -185,9 +185,9 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
 
   class ResponseMap extends mutable.HashMap[SourceFile, Set[Response[Tree]]] {
     override def default(key: SourceFile): Set[Response[Tree]] = Set()
-    override def addOne (binding: (SourceFile, Set[Response[Tree]])) = {
+    override def += (binding: (SourceFile, Set[Response[Tree]])) = {
       assert(interruptsEnabled, "delayed operation within an ask")
-      super.addOne(binding)
+      super.+=(binding)
     }
   }
 

--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -280,8 +280,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
 
     override def empty = ValueSet.empty
     def contains(v: Value) = nnIds contains (v.id - bottomId)
-    def incl (value: Value) = new ValueSet(nnIds + (value.id - bottomId))
-    def excl (value: Value) = new ValueSet(nnIds - (value.id - bottomId))
+    def + (value: Value) = new ValueSet(nnIds + (value.id - bottomId))
+    def - (value: Value) = new ValueSet(nnIds - (value.id - bottomId))
     def iterator = nnIds.iterator map (id => thisenum.apply(bottomId + id))
     override def iteratorFrom(start: Value) = nnIds iteratorFrom start.id  map (id => thisenum.apply(bottomId + id))
     override def className = thisenum + ".ValueSet"
@@ -322,7 +322,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
     /** A builder object for value sets */
     def newBuilder: mutable.Builder[Value, ValueSet] = new mutable.Builder[Value, ValueSet] {
       private[this] val b = new mutable.BitSet
-      def addOne (x: Value) = { b += (x.id - bottomId); this }
+      def += (x: Value) = { b += (x.id - bottomId); this }
       def clear() = b.clear()
       def result() = new ValueSet(b.toImmutable)
     }

--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -182,14 +182,14 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
     coll.fromBitMaskNoCopy(a)
   }
 
-  override def concat(other: collection.Iterable[Int]): C = other match {
+  override def ++ (other: collection.Iterable[Int]): C = other match {
     case otherBitset: BitSet =>
       val len = coll.nwords max otherBitset.nwords
       val words = new Array[Long](len)
       for (idx <- 0 until len)
         words(idx) = this.word(idx) | otherBitset.word(idx)
       fromBitMaskNoCopy(words)
-    case _ => super.concat(other)
+    case _ => super.++(other)
   }
 
   override def intersect(other: Set[Int]): C = other match {

--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -34,7 +34,7 @@ trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self =>
   override protected def reversed: Iterable[A] = new IndexedSeqView.Reverse(this)
 
   // Override transformation operations to use more efficient views than the default ones
-  override def prepended[B >: A](elem: B): CC[B] = iterableFactory.from(new IndexedSeqView.Prepended(elem, this))
+  override def +: [B >: A](elem: B): CC[B] = iterableFactory.from(new IndexedSeqView.Prepended(elem, this))
 
   override def take(n: Int): C = fromSpecificIterable(new IndexedSeqView.Take(this, n))
 

--- a/src/library/scala/collection/IndexedSeqView.scala
+++ b/src/library/scala/collection/IndexedSeqView.scala
@@ -9,7 +9,7 @@ trait IndexedSeqView[+A] extends IndexedSeqOps[A, View, View[A]] with SeqView[A]
 
   override def iterator: Iterator[A] = new IndexedSeqView.IndexedSeqViewIterator(this)
 
-  override def prepended[B >: A](elem: B): IndexedSeqView[B] = new IndexedSeqView.Prepended(elem, this)
+  override def +: [B >: A](elem: B): IndexedSeqView[B] = new IndexedSeqView.Prepended(elem, this)
   override def take(n: Int): IndexedSeqView[A] = new IndexedSeqView.Take(this, n)
   override def takeRight(n: Int): IndexedSeqView[A] = new IndexedSeqView.TakeRight(this, n)
   override def drop(n: Int): IndexedSeqView[A] = new IndexedSeqView.Drop(this, n)

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -569,6 +569,9 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
       else View.Empty
     }
 
+  /** Alias for `++` */
+  @`inline` final def concat[B >: A](suffix: Iterable[B]): CC[B] = this ++ suffix
+
   /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
     *  right hand operand. The element type of the $coll is the most specific superclass encompassing
     *  the element types of the two operands.
@@ -578,10 +581,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     *  @return       a new $coll which contains all elements
     *                of this $coll followed by all elements of `suffix`.
     */
-  def concat[B >: A](suffix: Iterable[B]): CC[B] = fromIterable(new View.Concat(this, suffix))
-
-  /** Alias for `concat` */
-  @`inline` final def ++ [B >: A](suffix: Iterable[B]): CC[B] = concat(suffix)
+  def ++ [B >: A](suffix: Iterable[B]): CC[B] = fromIterable(new View.Concat(this, suffix))
 
   /** Returns a $coll formed from this $coll and another iterable collection
     *  by combining corresponding elements in pairs.

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -893,7 +893,7 @@ object Iterator extends IterableFactory[Iterator] {
     */
   def newBuilder[A]: Builder[A, Iterator[A]] =
     new ImmutableBuilder[A, Iterator[A]](empty[A]) {
-      override def addOne(elem: A): this.type = { elems = elems ++ single(elem); this }
+      override def += (elem: A): this.type = { elems = elems ++ single(elem); this }
     }
 
   /** Creates iterator that produces the results of some element computation a number of times.

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -87,6 +87,9 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     */
   def toSeq: immutable.Seq[A]
 
+  /** Alias for `+:`. */
+  @`inline` final def prepended[B >: A](elem: B): CC[B] = elem +: this
+
   /** A copy of the $coll with an element prepended.
     *
     * Also, the original $coll is not modified, so you will want to capture the result.
@@ -103,20 +106,19 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *      List(1)
     *    }}}
     *
+    * Note that :-ending operators are right associative (see example).
+    * A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
+    *
     *  @param  elem   the prepended element
     *  @tparam B      the element type of the returned $coll.
     *
     *    @return a new $coll consisting of `value` followed
     *            by all elements of this $coll.
     */
-  def prepended[B >: A](elem: B): CC[B] = fromIterable(new View.Prepended(elem, this))
+  def +: [B >: A](elem: B): CC[B] = fromIterable(new View.Prepended(elem, this))
 
-  /** Alias for `prepended`.
-    *
-    * Note that :-ending operators are right associative (see example).
-    * A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
-    */
-  @`inline` final def +: [B >: A](elem: B): CC[B] = prepended(elem)
+  /** Alias for `:+` */
+  @`inline` final def appended[B >: A](elem: B): CC[B] = this :+ elem
 
   /** A copy of this $coll with an element appended.
     *
@@ -134,19 +136,18 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *    List(1)
     * }}}
     *
+    * Note that :-ending operators are right associative (see example).
+    * A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
+    *
     * @param  elem   the appended element
     * @tparam B      the element type of the returned $coll.
     * @return a new $coll consisting of
     *         all elements of this $coll followed by `value`.
     */
-  def appended[B >: A](elem: B): CC[B] = fromIterable(new View.Appended(this, elem))
+  def :+ [B >: A](elem: B): CC[B] = fromIterable(new View.Appended(this, elem))
 
-  /** Alias for `appended`
-    *
-    * Note that :-ending operators are right associative (see example).
-    * A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
-    */
-  @`inline` final def :+ [B >: A](elem: B): CC[B] = appended(elem)
+  /** Alias for `++:` */
+  @`inline` final def prependedAll[B >: A](prefix: Iterable[B]): CC[B] = prefix ++: this
 
   /** As with `:++`, returns a new collection containing the elements from the left operand followed by the
     *  elements from the right operand.
@@ -160,10 +161,10 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *  @return       a new $coll which contains all elements of `prefix` followed
     *                  by all the elements of this $coll.
     */
-  def prependedAll[B >: A](prefix: Iterable[B]): CC[B] = fromIterable(new View.Concat(prefix, this))
+  def ++: [B >: A](prefix: Iterable[B]): CC[B] = fromIterable(new View.Concat(prefix, this))
 
-  /** Alias for `prependedAll` */
-  @`inline` final def ++: [B >: A](prefix: Iterable[B]): CC[B] = prependedAll(prefix)
+  /** Alias for `:++` */
+  @`inline` final def appendedAll[B >: A](suffix: Iterable[B]): CC[B] = this :++ suffix
 
   /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
     *  right hand operand. The element type of the $coll is the most specific superclass encompassing
@@ -174,14 +175,11 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *  @return       a new collection of type `CC[B]` which contains all elements
     *                of this $coll followed by all elements of `suffix`.
     */
-  def appendedAll[B >: A](suffix: Iterable[B]): CC[B] = super.concat(suffix)
+  def :++ [B >: A](suffix: Iterable[B]): CC[B] = super.++(suffix)
 
-  /** Alias for `appendedAll` */
-  @`inline` final def :++ [B >: A](suffix: Iterable[B]): CC[B] = appendedAll(suffix)
-
-  // Make `concat` an alias for `appendedAll` so that it benefits from performance
+  // Make `++` an alias for `:++` so that it benefits from performance
   // overrides of this method
-  @`inline` final override def concat[B >: A](suffix: Iterable[B]): CC[B] = appendedAll(suffix)
+  @`inline` final override def ++ [B >: A](suffix: Iterable[B]): CC[B] = this :++ suffix
 
  /** Produces a new sequence which contains all elements of this $coll and also all elements of
    *  a given sequence. `xs union ys`  is equivalent to `xs ++ ys`.

--- a/src/library/scala/collection/SeqView.scala
+++ b/src/library/scala/collection/SeqView.scala
@@ -8,7 +8,7 @@ trait SeqView[+A] extends SeqOps[A, View, View[A]] with View[A] {
 
   override def map[B](f: A => B): SeqView[B] = new SeqView.Map(this, f)
 
-  override def prepended[B >: A](elem: B): SeqView[B] = new SeqView.Prepended(elem, this)
+  override def +: [B >: A](elem: B): SeqView[B] = new SeqView.Prepended(elem, this)
 
   override def take(n: Int): SeqView[A] = new SeqView.Take(this, n)
 

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -150,7 +150,7 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     *  @return     a set containing those elements of this
     *              set that are not also contained in the given set `that`.
     */
-  def diff(that: Set[A]): C
+  def diff(that: Set[A]): C = filterNot(that)
 
   /** Alias for `diff` */
   @`inline` final def &~ (that: Set[A]): C = this diff that
@@ -159,7 +159,7 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   def -- (that: IterableOnce[A]): C = fromSpecificIterable(coll.toSet.removeAll(that))
 
   @deprecated("Consider requiring an immutable Set or fall back to Set.diff", "2.13.0")
-  def - (elem: A): C = diff(Set(elem))
+  def - (elem: A): C
 
   @deprecated("Use &- with an explicit collection argument instead of - with varargs", "2.13.0")
   def - (elem1: A, elem2: A, elems: A*): C = diff(elems.toSet + elem1 + elem2)
@@ -177,16 +177,16 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     *  @param that     the collection containing the elements to add.
     *  @return a new $coll with the given elements added, omitting duplicates.
     */
-  def concat(that: collection.Iterable[A]): C = fromSpecificIterable(new View.Concat(toIterable, that))
+  def ++ (that: collection.Iterable[A]): C = fromSpecificIterable(new View.Concat(toIterable, that))
 
   @deprecated("Consider requiring an immutable Set or fall back to Set.union", "2.13.0")
-  def + (elem: A): C = fromSpecificIterable(new View.Appended(toIterable, elem))
+  def + (elem: A): C
 
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   def + (elem1: A, elem2: A, elems: A*): C = fromSpecificIterable(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
 
-  /** Alias for `concat` */
-  @`inline` final def ++ (that: collection.Iterable[A]): C = concat(that)
+  /** Alias for `++` */
+  @`inline` final def concat(that: collection.Iterable[A]): C = this ++ that
 
   /** Computes the union between of set and another set.
     *

--- a/src/library/scala/collection/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSeqOps.scala
@@ -22,7 +22,7 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
     builder.result()
   }
 
-  override def prepended[B >: A](elem: B): CC[B] = {
+  override def +: [B >: A](elem: B): CC[B] = {
     val b = iterableFactory.newBuilder[B]
     if (knownSize >= 0) {
       b.sizeHint(size + 1)
@@ -32,7 +32,7 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
     b.result()
   }
 
-  override def appended[B >: A](elem: B): CC[B] = {
+  override def :+ [B >: A](elem: B): CC[B] = {
     val b = iterableFactory.newBuilder[B]
     if (knownSize >= 0) {
       b.sizeHint(size + 1)
@@ -42,14 +42,14 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
     b.result()
   }
 
-  override def appendedAll[B >: A](suffix: Iterable[B]): CC[B] = {
+  override def :++ [B >: A](suffix: Iterable[B]): CC[B] = {
     val b = iterableFactory.newBuilder[B]
     b ++= this
     b ++= suffix
     b.result()
   }
 
-  override def prependedAll[B >: A](prefix: Iterable[B]): CC[B] = {
+  override def ++: [B >: A](prefix: Iterable[B]): CC[B] = {
     val b = iterableFactory.newBuilder[B]
     b ++= prefix
     b ++= this

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -858,7 +858,7 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     inserthc(k, hc, v)
   }
 
-  def addOne(kv: (K, V)) = {
+  def += (kv: (K, V)) = {
     update(kv._1, kv._2)
     this
   }
@@ -868,7 +868,7 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     removehc(k, null.asInstanceOf[V], hc)
   }
 
-  def subtractOne(k: K) = {
+  def -= (k: K) = {
     remove(k)
     this
   }

--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -99,8 +99,8 @@ private[collection] trait Wrappers {
     override def iterator: Iterator[A] = underlying.iterator.asScala
     def apply(i: Int) = underlying.get(i)
     def update(i: Int, elem: A) = underlying.set(i, elem)
-    def prepend(elem: A) = { underlying.subList(0, 0) add elem; this }
-    def addOne(elem: A): this.type = { underlying add elem; this }
+    def +=: (elem: A) = { underlying.subList(0, 0) add elem; this }
+    def += (elem: A): this.type = { underlying add elem; this }
     def insert(idx: Int,elem: A): Unit = underlying.subList(0, idx).add(elem)
     def insertAll(i: Int, elems: IterableOnce[A]) = {
       val ins = underlying.subList(0, i)
@@ -139,7 +139,7 @@ private[collection] trait Wrappers {
       this
     }
     override def iterableFactory = mutable.ArrayBuffer
-    override def subtractOne(elem: A): this.type = { underlying.remove(elem.asInstanceOf[AnyRef]); this }
+    override def -= (elem: A): this.type = { underlying.remove(elem.asInstanceOf[AnyRef]); this }
   }
 
   @SerialVersionUID(3L)
@@ -193,8 +193,8 @@ private[collection] trait Wrappers {
 
     def contains(elem: A): Boolean = underlying.contains(elem)
 
-    def addOne(elem: A): this.type = { underlying add elem; this }
-    def subtractOne(elem: A): this.type = { underlying remove elem; this }
+    def += (elem: A): this.type = { underlying add elem; this }
+    def -= (elem: A): this.type = { underlying remove elem; this }
 
     override def remove(elem: A): Boolean = underlying remove elem
     override def clear() = underlying.clear()
@@ -322,8 +322,8 @@ private[collection] trait Wrappers {
         None
     }
 
-    def addOne(kv: (K, V)): this.type = { underlying.put(kv._1, kv._2); this }
-    def subtractOne(key: K): this.type = { underlying remove key; this }
+    def += (kv: (K, V)): this.type = { underlying.put(kv._1, kv._2); this }
+    def -= (key: K): this.type = { underlying remove key; this }
 
     override def put(k: K, v: V): Option[V] = Option(underlying.put(k, v))
 
@@ -435,8 +435,8 @@ private[collection] trait Wrappers {
 
     def get(k: A) = Option(underlying get k)
 
-    def addOne(kv: (A, B)): this.type = { underlying.put(kv._1, kv._2); this }
-    def subtractOne(key: A): this.type = { underlying remove key; this }
+    def += (kv: (A, B)): this.type = { underlying.put(kv._1, kv._2); this }
+    def -= (key: A): this.type = { underlying remove key; this }
 
     override def put(k: A, v: B): Option[B] = Option(underlying.put(k, v))
 
@@ -462,8 +462,8 @@ private[collection] trait Wrappers {
       if (v != null) Some(v.asInstanceOf[String]) else None
     }
 
-    def addOne(kv: (String, String)): this.type = { underlying.put(kv._1, kv._2); this }
-    def subtractOne(key: String): this.type = { underlying remove key; this }
+    def += (kv: (String, String)): this.type = { underlying.put(kv._1, kv._2); this }
+    def -= (key: String): this.type = { underlying remove key; this }
 
     override def put(k: String, v: String): Option[String] = {
       val r = underlying.put(k, v)

--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -54,21 +54,21 @@ sealed abstract class ArraySeq[+A]
 
   override def map[B](f: A => B): ArraySeq[B] = iterableFactory.tabulate(length)(i => f(apply(i)))
 
-  override def prepended[B >: A](elem: B): ArraySeq[B] = {
+  override def +: [B >: A](elem: B): ArraySeq[B] = {
     val dest = new Array[Any](length + 1)
     dest(0) = elem
     Array.copy(unsafeArray, 0, dest, 1, length)
     ArraySeq.unsafeWrapArray(dest).asInstanceOf[ArraySeq[B]]
   }
 
-  override def appended[B >: A](elem: B): ArraySeq[B] = {
+  override def :+ [B >: A](elem: B): ArraySeq[B] = {
     val dest = new Array[Any](length + 1)
     Array.copy(unsafeArray, 0, dest, 0, length)
     dest(length) = elem
     ArraySeq.unsafeWrapArray(dest).asInstanceOf[ArraySeq[B]]
   }
 
-  override def appendedAll[B >: A](suffix: collection.Iterable[B]): ArraySeq[B] = {
+  override def :++ [B >: A](suffix: collection.Iterable[B]): ArraySeq[B] = {
     val b = ArrayBuilder.make[Any]
     val k = suffix.knownSize
     if(k >= 0) b.sizeHint(k + unsafeArray.length)
@@ -77,7 +77,7 @@ sealed abstract class ArraySeq[+A]
     ArraySeq.unsafeWrapArray(b.result()).asInstanceOf[ArraySeq[B]]
   }
 
-  override def prependedAll[B >: A](prefix: collection.Iterable[B]): ArraySeq[B] = {
+  override def ++: [B >: A](prefix: collection.Iterable[B]): ArraySeq[B] = {
     val b = ArrayBuilder.make[Any]
     val k = prefix.knownSize
     if(k >= 0) b.sizeHint(k + unsafeArray.length)

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -28,7 +28,7 @@ sealed abstract class BitSet
 
   protected[collection] def fromBitMaskNoCopy(elems: Array[Long]): BitSet = BitSet.fromBitMaskNoCopy(elems)
 
-  def incl(elem: Int): BitSet = {
+  def + (elem: Int): BitSet = {
     require(elem >= 0, "bitset element must be >= 0")
     if (contains(elem)) this
     else {
@@ -37,7 +37,7 @@ sealed abstract class BitSet
     }
   }
 
-  def excl(elem: Int): BitSet = {
+  def - (elem: Int): BitSet = {
     require(elem >= 0, "bitset element must be >= 0")
     if (contains(elem)) {
       val idx = elem >> LogWL

--- a/src/library/scala/collection/immutable/ChampHashMap.scala
+++ b/src/library/scala/collection/immutable/ChampHashMap.scala
@@ -73,7 +73,7 @@ final class ChampHashMap[K, +V] private[immutable] (private val rootNode: MapNod
     else this
   }
 
-  def remove(key: K): ChampHashMap[K, V] = {
+  def - (key: K): ChampHashMap[K, V] = {
     val keyHash = computeHash(key)
     val newRootNode = rootNode.removed(key, keyHash, 0)
 
@@ -668,7 +668,7 @@ object ChampHashMap extends MapFactory[ChampHashMap] {
 
   def newBuilder[K, V]: Builder[(K, V), ChampHashMap[K, V]] =
     new ImmutableBuilder[(K, V), ChampHashMap[K, V]](empty) {
-      def addOne(element: (K, V)): this.type = {
+      def += (element: (K, V)): this.type = {
         elems = elems + element
         this
       }

--- a/src/library/scala/collection/immutable/ChampHashSet.scala
+++ b/src/library/scala/collection/immutable/ChampHashSet.scala
@@ -41,7 +41,7 @@ final class ChampHashSet[A] private[immutable] (val rootNode: SetNode[A], val ca
 
   def contains(element: A): Boolean = rootNode.contains(element, computeHash(element), 0)
 
-  def incl(element: A): ChampHashSet[A] = {
+  def + (element: A): ChampHashSet[A] = {
     val elementHash = computeHash(element)
     val newRootNode = rootNode.updated(element, elementHash, 0)
 
@@ -50,7 +50,7 @@ final class ChampHashSet[A] private[immutable] (val rootNode: SetNode[A], val ca
     else this
   }
 
-  def excl(element: A): ChampHashSet[A] = {
+  def - (element: A): ChampHashSet[A] = {
     val elementHash = computeHash(element)
     val newRootNode = rootNode.removed(element, elementHash, 0)
 
@@ -596,7 +596,7 @@ object ChampHashSet extends IterableFactory[ChampHashSet] {
 
   def newBuilder[A]: Builder[A, ChampHashSet[A]] =
     new ImmutableBuilder[A, ChampHashSet[A]](empty) {
-      def addOne(element: A): this.type = {
+      def += (element: A): this.type = {
         elems = elems + element
         this
       }

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -35,7 +35,7 @@ sealed abstract class HashMap[K, +V]
 
   override def mapFactory: MapFactory[HashMap] = HashMap
 
-  def remove(key: K): HashMap[K, V] = removed0(key, computeHash(key), 0)
+  def - (key: K): HashMap[K, V] = removed0(key, computeHash(key), 0)
 
   final def updated[V1 >: V](key: K, value: V1): HashMap[K, V1] =
     updated0(key, computeHash(key), 0, value, null, null)
@@ -111,7 +111,7 @@ object HashMap extends MapFactory[HashMap] {
 
   def newBuilder[K, V]: Builder[(K, V), HashMap[K, V]] =
     new ImmutableBuilder[(K, V), HashMap[K, V]](empty) {
-      def addOne(elem: (K, V)): this.type = { elems = elems + elem; this }
+      def += (elem: (K, V)): this.type = { elems = elems + elem; this }
     }
 
   private[collection] abstract class Merger[A, B] {

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -36,9 +36,9 @@ sealed abstract class HashSet[A]
 
   def contains(elem: A): Boolean = get0(elem, computeHash(elem), 0)
 
-  def incl(elem: A): HashSet[A] = updated0(elem, computeHash(elem), 0)
+  def + (elem: A): HashSet[A] = updated0(elem, computeHash(elem), 0)
 
-  def excl(elem: A): HashSet[A] = nullToEmpty(removed0(elem, computeHash(elem), 0))
+  def - (elem: A): HashSet[A] = nullToEmpty(removed0(elem, computeHash(elem), 0))
 
   override def subsetOf(that: collection.Set[A]): Boolean = that match {
     case that:HashSet[A] =>
@@ -49,11 +49,11 @@ sealed abstract class HashSet[A]
       super.subsetOf(that)
   }
 
-  override def concat(that: collection.Iterable[A]): HashSet[A] = that match {
+  override def ++ (that: collection.Iterable[A]): HashSet[A] = that match {
     case that: HashSet[A] =>
       val buffer = new Array[HashSet[A]](bufferSize(this.size + that.size))
       nullToEmpty(union0(that, 0, buffer, 0))
-    case _ => super.concat(that)
+    case _ => super.++(that)
   }
 
   override def intersect(that: collection.Set[A]): HashSet[A] = that match {
@@ -164,7 +164,7 @@ object HashSet extends IterableFactory[HashSet] {
 
   def newBuilder[A]: Builder[A, HashSet[A]] =
     new ImmutableBuilder[A, HashSet[A]](empty) {
-      def addOne(elem: A): this.type = { elems = elems + elem; this }
+      def += (elem: A): this.type = { elems = elems + elem; this }
     }
 
   private object EmptyHashSet extends HashSet[Any] {

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -81,7 +81,7 @@ object IntMap {
 
   def newBuilder[V]: Builder[(Int, V), IntMap[V]] =
     new ImmutableBuilder[(Int, V), IntMap[V]](empty) {
-      def addOne(elem: (Int, V)): this.type = { elems = elems + elem; this }
+      def += (elem: (Int, V)): this.type = { elems = elems + elem; this }
     }
 
   implicit def toFactory[V](dummy: IntMap.type): Factory[(Int, V), IntMap[V]] = ToFactory.asInstanceOf[Factory[(Int, V), IntMap[V]]]
@@ -194,7 +194,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
   }
   override protected def newSpecificBuilder: Builder[(Int, T), IntMap[T]] @uncheckedVariance =
     new ImmutableBuilder[(Int, T), IntMap[T]](empty) {
-      def addOne(elem: (Int, T)): this.type = { elems = elems + elem; this }
+      def += (elem: (Int, T)): this.type = { elems = elems + elem; this }
     }
 
   override def empty: IntMap[T] = IntMap.Nil
@@ -358,7 +358,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil => IntMap.Tip(key, value)
   }
 
-  def remove (key: Int): IntMap[T] = this match {
+  def - (key: Int): IntMap[T] = this match {
     case IntMap.Bin(prefix, mask, left, right) =>
       if (!hasMatch(key, prefix, mask)) this
       else if (zero(key, mask)) bin(prefix, mask, left - key, right)

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -305,7 +305,7 @@ sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with Laz
   override final def withFilter(p: A => Boolean): collection.WithFilter[A, CC] =
     iterableFactory.withFilter(coll, p)
 
-  override final def prepended[B >: A](elem: B): CC[B] = cons(elem, coll)
+  override final def +: [B >: A](elem: B): CC[B] = cons(elem, coll)
 
   override final def map[B](f: A => B): CC[B] =
     if (isEmpty) iterableFactory.empty

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -121,18 +121,18 @@ sealed abstract class List[+A]
     these
   }
 
-  override def prepended[B >: A](elem: B): List[B] = elem :: this
+  override def +: [B >: A](elem: B): List[B] = elem :: this
 
   // When calling prependAll with another list `prefix`, avoid copying `this`
-  override def prependedAll[B >: A](prefix: collection.Iterable[B]): List[B] = prefix match {
+  override def ++: [B >: A](prefix: collection.Iterable[B]): List[B] = prefix match {
     case xs: List[B] => xs ::: this
-    case _ => super.prependedAll(prefix)
+    case _ => super.++:(prefix)
   }
 
   // When calling appendAll with another list `suffix`, avoid copying `suffix`
-  override def appendedAll[B >: A](suffix: collection.Iterable[B]): List[B] = suffix match {
+  override def :++ [B >: A](suffix: collection.Iterable[B]): List[B] = suffix match {
     case xs: List[B] => this ::: xs
-    case _ => super.appendedAll(suffix)
+    case _ => super.:++(suffix)
   }
 
   override def take(n: Int): List[A] = if (isEmpty || n <= 0) Nil else {

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -53,9 +53,9 @@ sealed class ListMap[K, +V]
 
   def get(key: K): Option[V] = None
 
-  def updated[B1 >: V](key: K, value: B1): ListMap[K, B1] = new Node[B1](key, value)
+  def updated[V1 >: V](key: K, value: V1): ListMap[K, V1] = new Node[V1](key, value)
 
-  def remove(key: K): ListMap[K, V] = this
+  def - (key: K): ListMap[K, V] = this
 
   def iterator: Iterator[(K, V)] = {
     var curr: ListMap[K, V] = this
@@ -114,7 +114,7 @@ sealed class ListMap[K, +V]
       new m.Node[V2](k, v)
     }
 
-    override def remove(k: K): ListMap[K, V1] = removeInternal(k, this, Nil)
+    override def - (k: K): ListMap[K, V1] = removeInternal(k, this, Nil)
 
     @tailrec private[this] def removeInternal(k: K, cur: ListMap[K, V1], acc: List[ListMap[K, V1]]): ListMap[K, V1] =
       if (cur.isEmpty) acc.last
@@ -156,7 +156,7 @@ object ListMap extends MapFactory[ListMap] {
 
   def newBuilder[K, V]: Builder[(K, V), ListMap[K, V]] =
     new ImmutableBuilder[(K, V), ListMap[K, V]](empty) {
-      def addOne(elem: (K, V)): this.type = { elems = elems + elem; this }
+      def += (elem: (K, V)): this.type = { elems = elems + elem; this }
     }
 
   // scalac generates a `readReplace` method to discard the deserialized state (see https://github.com/scala/bug/issues/10412).

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -40,8 +40,8 @@ sealed class ListSet[A]
 
   def contains(elem: A): Boolean = false
 
-  def incl(elem: A): ListSet[A] = new Node(elem)
-  def excl(elem: A): ListSet[A] = this
+  def + (elem: A): ListSet[A] = new Node(elem)
+  def - (elem: A): ListSet[A] = this
 
   def iterator: scala.collection.Iterator[A] = {
     var curr: ListSet[A] = this
@@ -76,9 +76,9 @@ sealed class ListSet[A]
     @tailrec private[this] def containsInternal(n: ListSet[A], e: A): Boolean =
       !n.isEmpty && (n.elem == e || containsInternal(n.next, e))
 
-    override def incl(e: A): ListSet[A] = if (contains(e)) this else new Node(e)
+    override def + (e: A): ListSet[A] = if (contains(e)) this else new Node(e)
 
-    override def excl(e: A): ListSet[A] = removeInternal(e, this, Nil)
+    override def - (e: A): ListSet[A] = removeInternal(e, this, Nil)
 
     @tailrec private[this] def removeInternal(k: A, cur: ListSet[A], acc: List[ListSet[A]]): ListSet[A] =
       if (cur.isEmpty) acc.last
@@ -120,7 +120,7 @@ object ListSet extends IterableFactory[ListSet] {
 
   def newBuilder[A]: Builder[A, ListSet[A]] =
     new ImmutableBuilder[A, ListSet[A]](empty) {
-      def addOne(elem: A): this.type = { elems = elems + elem; this }
+      def += (elem: A): this.type = { elems = elems + elem; this }
     }
 
   // scalac generates a `readReplace` method to discard the deserialized state (see https://github.com/scala/bug/issues/10412).

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -56,7 +56,7 @@ object LongMap {
 
   def newBuilder[V]: Builder[(Long, V), LongMap[V]] =
     new ImmutableBuilder[(Long, V), LongMap[V]](empty) {
-      def addOne(elem: (Long, V)): this.type = { elems = elems + elem; this }
+      def += (elem: (Long, V)): this.type = { elems = elems + elem; this }
     }
 
   private[immutable] case object Nil extends LongMap[Nothing] {
@@ -189,7 +189,7 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
   }
   override protected def newSpecificBuilder: Builder[(Long, T), LongMap[T]] @uncheckedVariance =
     new ImmutableBuilder[(Long, T), LongMap[T]](empty) {
-      def addOne(elem: (Long, T)): this.type = { elems = elems + elem; this }
+      def += (elem: (Long, T)): this.type = { elems = elems + elem; this }
     }
 
   override def empty: LongMap[T] = LongMap.Nil
@@ -341,7 +341,7 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil => LongMap.Tip(key, value)
   }
 
-  def remove(key: Long): LongMap[T] = this match {
+  def - (key: Long): LongMap[T] = this match {
     case LongMap.Bin(prefix, mask, left, right) =>
       if (!hasMatch(key, prefix, mask)) this
       else if (zero(key, mask)) bin(prefix, mask, left - key, right)

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -58,10 +58,10 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
     * @param key the key to be removed
     * @return a new map without a binding for ''key''
     */
-  def remove(key: K): C
+  def - (key: K): C
 
   /** Alias for `remove` */
-  /* @`inline` final */ def - (key: K): C = remove(key)
+  @`inline` final def remove(key: K): C = this - key
 
   @deprecated("Use -- with an explicit collection", "2.13.0")
   def - (key1: K, key2: K, keys: K*): C = remove(key1).remove(key2).removeAll(keys)
@@ -73,11 +73,10 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
     *  @return a new $coll that contains all elements of the current $coll
     *  except one less occurrence of each of the elements of `elems`.
     */
-  def removeAll(keys: IterableOnce[K]): C = keys.iterator.foldLeft[C](coll)(_ - _)
+  def -- (keys: IterableOnce[K]): C = keys.iterator.foldLeft[C](coll)(_ - _)
 
-  /** Alias for `removeAll` */
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /* @`inline` final */ override def -- (keys: IterableOnce[K]): C = removeAll(keys)
+  /** Alias for `--` */
+  @`inline` final def removeAll(keys: IterableOnce[K]): C = this -- keys
 
   /** Creates a new map obtained by updating this map with a given key/value pair.
     *  @param    key the key
@@ -97,7 +96,10 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
     * @tparam V1 the type of the value in the key/value pair.
     * @return A new map with the new binding added to this map.
     */
-  override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
+  @`inline` /*final*/ def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
+
+  @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
+  def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = this + elem1 + elem2 ++ elems
 
   /** This function transforms all the values of mappings contained
     *  in this map with function `f`.
@@ -118,8 +120,8 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
 
   /** The implementation class of the set returned by `keySet` */
   protected class ImmutableKeySet extends AbstractSet[K] with GenKeySet {
-    def incl(elem: K): Set[K] = if (this(elem)) this else empty ++ this + elem
-    def excl(elem: K): Set[K] = if (this(elem)) empty ++ this - elem else this
+    def + (elem: K): Set[K] = if (this(elem)) this else empty ++ this + elem
+    def - (elem: K): Set[K] = if (this(elem)) empty ++ this - elem else this
   }
 
 }
@@ -151,7 +153,7 @@ object Map extends MapFactory[Map] {
 
     override def mapFactory: MapFactory[Map] = underlying.mapFactory
 
-    def remove(key: K): WithDefault[K, V] = new WithDefault[K, V](underlying.remove(key), defaultValue)
+    def - (key: K): WithDefault[K, V] = new WithDefault[K, V](underlying.remove(key), defaultValue)
 
     def updated[V1 >: V](key: K, value: V1): WithDefault[K, V1] =
       new WithDefault[K, V1](underlying.updated(key, value), defaultValue)
@@ -175,7 +177,7 @@ object Map extends MapFactory[Map] {
 
   def newBuilder[K, V]: Builder[(K, V), Map[K, V]] =
     new ImmutableBuilder[(K, V), Map[K, V]](empty) {
-      def addOne(elem: (K, V)): this.type = { elems = elems + elem; this }
+      def += (elem: (K, V)): this.type = { elems = elems + elem; this }
     }
 
   private object EmptyMap extends AbstractMap[Any, Nothing] {
@@ -187,7 +189,7 @@ object Map extends MapFactory[Map] {
     override def getOrElse [V1](key: Any, default: => V1): V1 = default
     def iterator: Iterator[(Any, Nothing)] = Iterator.empty
     def updated [V1] (key: Any, value: V1): Map[Any, V1] = new Map1(key, value)
-    def remove(key: Any): Map[Any, Nothing] = this
+    def - (key: Any): Map[Any, Nothing] = this
   }
 
   final class Map1[K, +V](key1: K, value1: V) extends AbstractMap[K, V] with StrictOptimizedIterableOps[(K, V), Iterable, Map[K, V]] {
@@ -203,7 +205,7 @@ object Map extends MapFactory[Map] {
     def updated[V1 >: V](key: K, value: V1): Map[K, V1] =
       if (key == key1) new Map1(key1, value)
       else new Map2(key1, value1, key, value)
-    def remove(key: K): Map[K, V] =
+    def - (key: K): Map[K, V] =
       if (key == key1) Map.empty else this
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1))
@@ -231,7 +233,7 @@ object Map extends MapFactory[Map] {
       if (key == key1) new Map2(key1, value, key2, value2)
       else if (key == key2) new Map2(key1, value1, key2, value)
       else new Map3(key1, value1, key2, value2, key, value)
-    def remove(key: K): Map[K, V] =
+    def - (key: K): Map[K, V] =
       if (key == key1) new Map1(key2, value2)
       else if (key == key2) new Map1(key1, value1)
       else this
@@ -265,7 +267,7 @@ object Map extends MapFactory[Map] {
       else if (key == key2) new Map3(key1, value1, key2, value, key3, value3)
       else if (key == key3) new Map3(key1, value1, key2, value2, key3, value)
       else new Map4(key1, value1, key2, value2, key3, value3, key, value)
-    def remove(key: K): Map[K, V] =
+    def - (key: K): Map[K, V] =
       if (key == key1)      new Map2(key2, value2, key3, value3)
       else if (key == key2) new Map2(key1, value1, key3, value3)
       else if (key == key3) new Map2(key1, value1, key2, value2)
@@ -304,7 +306,7 @@ object Map extends MapFactory[Map] {
       else if (key == key3) new Map4(key1, value1, key2, value2, key3, value, key4, value4)
       else if (key == key4) new Map4(key1, value1, key2, value2, key3, value3, key4, value)
       else (if (useBaseline) HashMap.empty[K, V1] else ChampHashMap.empty[K, V1]).updated(key1,value1).updated(key2, value2).updated(key3, value3).updated(key4, value4).updated(key, value)
-    def remove(key: K): Map[K, V] =
+    def - (key: K): Map[K, V] =
       if (key == key1)      new Map3(key2, value2, key3, value3, key4, value4)
       else if (key == key2) new Map3(key1, value1, key3, value3, key4, value4)
       else if (key == key3) new Map3(key1, value1, key2, value2, key4, value4)

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -95,11 +95,11 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
   /** Returns the length of the queue. */
   override def length = in.length + out.length
 
-  override def prepended[B >: A](elem: B): Queue[B] = new Queue(in, elem :: out)
+  override def +: [B >: A](elem: B): Queue[B] = new Queue(in, elem :: out)
 
-  override def appended[B >: A](elem: B): Queue[B] = enqueue(elem)
+  override def :+ [B >: A](elem: B): Queue[B] = enqueue(elem)
 
-  override def appendedAll[B >: A](that: scala.collection.Iterable[B]): Queue[B] = {
+  override def :++ [B >: A](that: scala.collection.Iterable[B]): Queue[B] = {
     val newIn = that match {
       case that: Queue[B] => that.in ++ (that.out reverse_::: this.in)
       case _ => ListBuffer.from(that).toList reverse_::: this.in

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -49,15 +49,18 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _]
         val map = self.rangeImpl(from, until)
         new map.ImmutableKeySortedSet
       }
-      def incl(elem: K): SortedSet[K] = fromSpecificIterable(this).incl(elem)
-      def excl(elem: K): SortedSet[K] = fromSpecificIterable(this).excl(elem)
+      def + (elem: K): SortedSet[K] = fromSpecificIterable(this).incl(elem)
+      def - (elem: K): SortedSet[K] = fromSpecificIterable(this).excl(elem)
     }
 
     // We override these methods to fix their return type (which would be `Map` otherwise)
     def updated[V1 >: V](key: K, value: V1): CC[K, V1]
-    @`inline` final override def +[V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
+    @`inline` final override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
 
-    override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = {
+  @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
+  override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = this + elem1 + elem2 ++ elems
+
+  override def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = {
         var result: CC[K, V2] = coll
         val it = xs.iterator
         while (it.hasNext) result = result + it.next()
@@ -92,8 +95,8 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
     override def updated[V1 >: V](key: K, value: V1): WithDefault[K, V1] =
       new WithDefault[K, V1](underlying.updated(key, value), defaultValue)
 
-    override def remove(key: K): WithDefault[K, V] =
-      new WithDefault[K, V](underlying.remove(key), defaultValue)
+    override def - (key: K): WithDefault[K, V] =
+      new WithDefault[K, V](underlying - key, defaultValue)
 
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -45,7 +45,7 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
   def get(key: K): Option[V] = RB.get(tree, key)
 
-  def remove(key: K): TreeMap[K,V] =
+  def - (key: K): TreeMap[K,V] =
     if (!RB.contains(tree, key)) this
     else new TreeMap(RB.delete(tree, key))
 
@@ -159,7 +159,7 @@ object TreeMap extends SortedMapFactory[TreeMap] {
 
   def newBuilder[K : Ordering, V]: Builder[(K, V), TreeMap[K, V]] =
     new ImmutableBuilder[(K, V), TreeMap[K, V]](empty) {
-      def addOne(elem: (K, V)): this.type = { elems = elems + elem; this }
+      def += (elem: (K, V)): this.type = { elems = elems + elem; this }
     }
 
 }

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -117,14 +117,14 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
     *  @param elem    a new element to add.
     *  @return        a new $coll containing `elem` and all the elements of this $coll.
     */
-  def incl(elem: A): TreeSet[A] = newSet(RB.update(tree, elem, (), overwrite = false))
+  def + (elem: A): TreeSet[A] = newSet(RB.update(tree, elem, (), overwrite = false))
 
   /** Creates a new `TreeSet` with the entry removed.
     *
     *  @param elem    a new element to add.
     *  @return        a new $coll containing all the elements of this $coll except `elem`.
     */
-  def excl(elem: A): TreeSet[A] =
+  def - (elem: A): TreeSet[A] =
     if (!RB.contains(tree, elem)) this
     else newSet(RB.delete(tree, elem))
 
@@ -150,7 +150,7 @@ object TreeSet extends SortedIterableFactory[TreeSet] {
 
   def newBuilder[A : Ordering]: Builder[A, TreeSet[A]] =
     new ImmutableBuilder[A, TreeSet[A]](empty) {
-      def addOne(elem: A): this.type = { elems = elems + elem; this }
+      def += (elem: A): this.type = { elems = elems + elem; this }
     }
 
 }

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -172,7 +172,7 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
   }
 
   // appendAll (suboptimal but avoids worst performance gotchas)
-  override def appendedAll[B >: A](suffix: collection.Iterable[B]): Vector[B] = {
+  override def :++ [B >: A](suffix: collection.Iterable[B]): Vector[B] = {
     import Vector.{Log2ConcatFaster, TinyAppendFaster}
     if (suffix.isEmpty) this
     else {
@@ -187,12 +187,12 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
           val ri = this.reverseIterator
           while (ri.hasNext) v = ri.next() +: v
           v
-        case _ => super.appendedAll(suffix)
+        case _ => super.:++(suffix)
       }
     }
   }
 
-  override def prependedAll[B >: A](prefix: collection.Iterable[B]): Vector[B] = {
+  override def ++: [B >: A](prefix: collection.Iterable[B]): Vector[B] = {
     // Implementation similar to `appendAll`: when of the collections to concatenate (either `this` or `prefix`)
     // has a small number of elements compared to the other, then we add them using `:+` or `+:` in a loop
     import Vector.{Log2ConcatFaster, TinyAppendFaster}
@@ -209,7 +209,7 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
           val it = this.iterator
           while (it.hasNext) v = v :+ it.next()
           v
-        case _ => super.prependedAll(prefix)
+        case _ => super.++:(prefix)
       }
     }
   }
@@ -240,7 +240,7 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
     dirty = true
   }
 
-  override def prepended[B >: A](value: B): Vector[B] = {
+  override def +: [B >: A](value: B): Vector[B] = {
     if (endIndex != startIndex) {
       val blockIndex = (startIndex - 1) & ~31
       val lo = (startIndex - 1) & 31
@@ -318,7 +318,7 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
     }
   }
 
-  override def appended[B >: A](value: B): Vector[B] = {
+  override def :+ [B >: A](value: B): Vector[B] = {
     if (endIndex != startIndex) {
       val blockIndex = endIndex & ~31
       val lo = endIndex & 31
@@ -602,7 +602,7 @@ final class VectorBuilder[A]() extends ReusableBuilder[A, Vector[A]] with Vector
   def isEmpty: Boolean = size == 0
   def nonEmpty: Boolean = size != 0
 
-  def addOne(elem: A): this.type = {
+  def += (elem: A): this.type = {
     if (lo >= display0.length) {
       val newBlockIndex = blockIndex + 32
       gotoNextBlockStartWritable(newBlockIndex, blockIndex ^ newBlockIndex)

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -283,11 +283,11 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
   }
 
   /** Adds a new key/value pair to this map and returns the map. */
-  def addOne(key: K, value: V): this.type = { update(key, value); this }
+  def += (key: K, value: V): this.type = { update(key, value); this }
 
-  def addOne(kv: (K, V)): this.type = { update(kv._1, kv._2); this }
+  def += (kv: (K, V)): this.type = { update(kv._1, kv._2); this }
 
-  def subtractOne(key: K): this.type = {
+  def -= (key: K): this.type = {
     val i = seekEntry(hashOf(key), key)
     if (i >= 0) {
       _size -= 1
@@ -459,7 +459,7 @@ object AnyRefMap {
    */
   final class AnyRefMapBuilder[K <: AnyRef, V] extends ReusableBuilder[(K, V), AnyRefMap[K, V]] {
     private[collection] var elems: AnyRefMap[K, V] = new AnyRefMap[K, V]
-    def addOne(entry: (K, V)): this.type = {
+    def += (entry: (K, V)): this.type = {
       elems += entry
       this
     }

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -75,7 +75,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   def clear(): Unit = reduceToSize(0)
 
-  def addOne(elem: A): this.type = {
+  def += (elem: A): this.type = {
     val i = size0
     ensureSize(size0 + 1)
     size0 += 1
@@ -84,13 +84,13 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   }
 
   // Overridden to use array copying for efficiency where possible.
-  override def addAll(elems: IterableOnce[A]): this.type = {
+  override def ++= (elems: IterableOnce[A]): this.type = {
     elems match {
       case elems: ArrayBuffer[_] =>
         ensureSize(length + elems.length)
         Array.copy(elems.array, 0, array, length, elems.length)
         size0 = length + elems.length
-      case _ => super.addAll(elems)
+      case _ => super.++=(elems)
     }
     this
   }
@@ -103,7 +103,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     this(index) = elem
   }
 
-  def prepend(elem: A): this.type = {
+  def +=: (elem: A): this.type = {
     insert(0, elem)
     this
   }

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -45,7 +45,7 @@ sealed abstract class ArrayBuilder[T]
     this
   }
 
-  override def addAll(xs: IterableOnce[T]): this.type = {
+  override def ++= (xs: IterableOnce[T]): this.type = {
     val k = xs.knownSize
     if(k > 0) {
       ensureSize(this.size + k)
@@ -54,7 +54,7 @@ sealed abstract class ArrayBuilder[T]
         case _ => xs.iterator.copyToArray(elems, this.size)
       }
       size += k
-    } else if(k < 0) super.addAll(xs)
+    } else if(k < 0) super.++=(xs)
     this
   }
 }
@@ -108,7 +108,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def addOne(elem: T): this.type = {
+    def += (elem: T): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -155,7 +155,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def addOne(elem: Byte): this.type = {
+    def += (elem: Byte): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -197,7 +197,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def addOne(elem: Short): this.type = {
+    def += (elem: Short): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -239,7 +239,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def addOne(elem: Char): this.type = {
+    def += (elem: Char): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -281,7 +281,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def addOne(elem: Int): this.type = {
+    def += (elem: Int): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -323,7 +323,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def addOne(elem: Long): this.type = {
+    def += (elem: Long): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -365,7 +365,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def addOne(elem: Float): this.type = {
+    def += (elem: Float): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -407,7 +407,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def addOne(elem: Double): this.type = {
+    def += (elem: Double): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -449,7 +449,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def addOne(elem: Boolean): this.type = {
+    def += (elem: Boolean): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -480,12 +480,12 @@ object ArrayBuilder {
 
     protected def elems: Array[Unit] = throw new UnsupportedOperationException()
 
-    def addOne(elem: Unit): this.type = {
+    def += (elem: Unit): this.type = {
       size += 1
       this
     }
 
-    override def addAll(xs: IterableOnce[Unit]): this.type = {
+    override def ++= (xs: IterableOnce[Unit]): this.type = {
       size += xs.iterator.size
       this
     }

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -60,12 +60,12 @@ class ArrayDeque[A] protected (
     _set(idx, elem)
   }
 
-  def addOne(elem: A) = {
+  def += (elem: A) = {
     ensureSize(length + 1)
     appendAssumingCapacity(elem)
   }
 
-  def prepend(elem: A) = {
+  def +=: (elem: A) = {
     ensureSize(length + 1)
     prependAssumingCapacity(elem)
   }
@@ -82,7 +82,7 @@ class ArrayDeque[A] protected (
     this
   }
 
-  override def prependAll(elems: IterableOnce[A]): this.type = {
+  override def ++=: (elems: IterableOnce[A]): this.type = {
     val it = elems.iterator
     if (it.nonEmpty) {
       val n = length
@@ -114,7 +114,7 @@ class ArrayDeque[A] protected (
     this
   }
 
-  override def addAll(elems: IterableOnce[A]): this.type = {
+  override def ++= (elems: IterableOnce[A]): this.type = {
     elems.knownSize match {
       case srcLength if srcLength > 0 =>
         ensureSize(srcLength + length)
@@ -252,7 +252,7 @@ class ArrayDeque[A] protected (
     elem
   }
 
-  override def subtractOne(elem: A): this.type = {
+  override def -= (elem: A): this.type = {
     val idx = indexOf(elem)
     if (idx >= 0) remove(idx, 1) //TODO: SeqOps should be fluent API
     this

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -47,7 +47,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
     if (elems.length == 0) empty
     else new BitSet(elems)
 
-  def addOne(elem: Int): this.type = {
+  def += (elem: Int): this.type = {
     require(elem >= 0)
     if (!contains(elem)) {
       val idx = elem >> LogWL
@@ -56,7 +56,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
     this
   }
 
-  def subtractOne(elem: Int): this.type = {
+  def -= (elem: Int): this.type = {
     require(elem >= 0)
     if (contains(elem)) {
       val idx = elem >> LogWL

--- a/src/library/scala/collection/mutable/Buffer.scala
+++ b/src/library/scala/collection/mutable/Buffer.scala
@@ -11,19 +11,22 @@ trait Buffer[A]
 
   override def iterableFactory: SeqFactory[Buffer] = Buffer
 
-  //TODO Prepend is a logical choice for a readable name of `+=:` but it conflicts with the renaming of `append` to `add`
   /** Prepends a single element at the front of this $coll.
     *
     *  @param elem  the element to $add.
     *  @return the $coll itself
     */
-  def prepend(elem: A): this.type
+  def +=: (elem: A): this.type
+
+  //TODO Prepend is a logical choice for a readable name of `+=:` but it conflicts with the renaming of `append` to `add`
+  /** Alias for `+=:` */
+  @`inline` final def prepend(elem: A): this.type = this.+=:(elem)
 
   /** Appends the given elements to this buffer.
     *
     *  @param elem  the element to append.
     */
-  @`inline` final def append(elem: A): this.type = addOne(elem)
+  @`inline` final def append(elem: A): this.type = this += elem
 
   @deprecated("Use appendAll instead", "2.13.0")
   @`inline` final def append(elems: A*): this.type = addAll(elems)
@@ -33,17 +36,18 @@ trait Buffer[A]
     */
   @`inline` final def appendAll(xs: IterableOnce[A]): this.type = addAll(xs)
 
+  /** Prepends elements to this buffer.
+    *
+    *  @param elems  the collection containing the elements to prepend.
+    *  @return the buffer itself.
+    */
+  def ++=: (elems: IterableOnce[A]): this.type = { insertAll(0, elems); this }
 
-  /** Alias for `prepend` */
-  @`inline` final def +=: (elem: A): this.type = prepend(elem)
-
-  def prependAll(elems: IterableOnce[A]): this.type = { insertAll(0, elems); this }
+  /** Alias for `++=:` */
+  @inline final def prependAll(elems: IterableOnce[A]): this.type = this.++=:(elems)
 
   @deprecated("Use prependAll instead", "2.13.0")
   @`inline` final def prepend(elems: A*): this.type = prependAll(elems)
-
-  /** Alias for `prependAll` */
-  @inline final def ++=:(elems: IterableOnce[A]): this.type = prependAll(elems)
 
   /** Inserts a new element at a given index into this buffer.
     *
@@ -93,7 +97,7 @@ trait Buffer[A]
     *  @param x  the element to remove.
     *  @return   the buffer itself
     */
-  def subtractOne (x: A): this.type = {
+  def -= (x: A): this.type = {
     val i = indexOf(x)
     if (i != -1) remove(i)
     this

--- a/src/library/scala/collection/mutable/Builder.scala
+++ b/src/library/scala/collection/mutable/Builder.scala
@@ -61,9 +61,9 @@ trait Builder[-A, +To] extends Growable[A] { self =>
 
   /** A builder resulting from this builder my mapping the result using `f`. */
   def mapResult[NewTo](f: To => NewTo): Builder[A, NewTo] = new Builder[A, NewTo] {
-    def addOne(x: A): this.type = { self += x; this }
+    def += (x: A): this.type = { self += x; this }
     def clear(): Unit = self.clear()
-    override def addAll(xs: IterableOnce[A]): this.type = { self ++= xs; this }
+    override def ++= (xs: IterableOnce[A]): this.type = { self ++= xs; this }
     override def sizeHint(size: Int): Unit = self.sizeHint(size)
     def result(): NewTo = f(self.result())
   }
@@ -123,15 +123,15 @@ class StringBuilder(private val underlying: java.lang.StringBuilder) extends Abs
 
   def length_=(n: Int): Unit = underlying.setLength(n)
 
-  def addOne(x: Char) = { underlying.append(x); this }
+  def += (x: Char) = { underlying.append(x); this }
 
   def clear() = underlying.setLength(0)
 
-  /** Overloaded version of `addAll` that takes a string */
-  def addAll(s: String): this.type = { underlying.append(s); this }
+  /** Overloaded version of `++=` that takes a string */
+  def ++= (s: String): this.type = { underlying.append(s); this }
 
-  /** Alias for `addAll` */
-  def ++= (s: String): this.type = addAll(s)
+  /** Alias for `++=` */
+  final def addAll(s: String): this.type = this ++= s
 
   def result() = underlying.toString
 

--- a/src/library/scala/collection/mutable/Growable.scala
+++ b/src/library/scala/collection/mutable/Growable.scala
@@ -20,10 +20,10 @@ trait Growable[-A] extends Clearable {
    *  @param elem  the element to $add.
    *  @return the $coll itself
    */
-  def addOne(elem: A): this.type
+  def += (elem: A): this.type
 
-  /** Alias for `addOne` */
-  @`inline` final def += (elem: A): this.type = addOne(elem)
+  /** Alias for `+=` */
+  @`inline` final def addOne(elem: A): this.type = this += elem
 
   //TODO This causes a conflict in StringBuilder; looks like a compiler bug
   //@deprecated("Use addOne or += instead of append", "2.13.0")
@@ -36,6 +36,7 @@ trait Growable[-A] extends Clearable {
    *  @param elems the remaining elements to $add.
    *  @return the $coll itself
    */
+  @deprecated("Use ++= with a collection instead of += with varargs", "2.13.0")
   @`inline` final def += (elem1: A, elem2: A, elems: A*): this.type = this += elem1 += elem2 ++= (elems: IterableOnce[A])
 
   /** ${Add}s all elements produced by an IterableOnce to this $coll.
@@ -43,7 +44,7 @@ trait Growable[-A] extends Clearable {
    *  @param xs   the IterableOnce producing the elements to $add.
    *  @return  the $coll itself.
    */
-  def addAll(xs: IterableOnce[A]): this.type = {
+  def ++= (xs: IterableOnce[A]): this.type = {
     val it = xs.iterator
     while (it.hasNext) {
       addOne(it.next())
@@ -51,8 +52,8 @@ trait Growable[-A] extends Clearable {
     this
   }
 
-  /** Alias for `addAll` */
-  @`inline` final def ++= (xs: IterableOnce[A]): this.type = addAll(xs)
+  /** Alias for `++=` */
+  @`inline` final def addAll(xs: IterableOnce[A]): this.type = this ++= xs
 }
 
 object Growable {

--- a/src/library/scala/collection/mutable/GrowableBuilder.scala
+++ b/src/library/scala/collection/mutable/GrowableBuilder.scala
@@ -20,6 +20,6 @@ class GrowableBuilder[Elem, To <: Growable[Elem]](protected val elems: To)
 
   def result(): To = elems
 
-  def addOne(elem: Elem): this.type = { elems += elem; this }
+  def += (elem: Elem): this.type = { elems += elem; this }
 
 }

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -45,7 +45,7 @@ class HashMap[K, V]
     if (e eq null) None else Some(e.value)
   }
 
-  def addOne(kv: (K, V)): this.type = {
+  def += (kv: (K, V)): this.type = {
     val e = table.findOrAddEntry(kv._1, kv._2)
     if (e ne null) e.value = kv._2
     this
@@ -53,7 +53,7 @@ class HashMap[K, V]
 
   override def clear(): Unit = table.clearTable()
 
-  def subtractOne(key: K): this.type = { table.removeEntry(key); this }
+  def -= (key: K): this.type = { table.removeEntry(key); this }
 
   override def size: Int = table.size
 

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -29,11 +29,11 @@ final class HashSet[A]
 
   override def iterableFactory: IterableFactory[HashSet] = HashSet
 
-  def addOne(elem: A): this.type = {
+  def += (elem: A): this.type = {
     table.addElem(elem)
     this
   }
-  def subtractOne(elem: A): this.type = {
+  def -= (elem: A): this.type = {
     table.removeElem(elem)
     this
   }

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -114,9 +114,9 @@ class LinkedHashMap[K, V]
     }
   }
 
-  def addOne(kv: (K, V)): this.type = { put(kv._1, kv._2); this }
+  def += (kv: (K, V)): this.type = { put(kv._1, kv._2); this }
 
-  def subtractOne(key: K): this.type = { remove(key); this }
+  def -= (key: K): this.type = { remove(key); this }
 
   def iterator: Iterator[(K, V)] = new AbstractIterator[(K, V)] {
     private[this] var cur = firstEntry

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -57,12 +57,12 @@ class LinkedHashSet[A]
 
   def contains(elem: A): Boolean = table.findEntry(elem) ne null
 
-  def addOne(elem: A): this.type = {
+  def += (elem: A): this.type = {
     table.findOrAddEntry(elem, null)
     this
   }
 
-  def subtractOne(elem: A): this.type = {
+  def -= (elem: A): this.type = {
     remove(elem)
     this
   }

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -86,7 +86,7 @@ class ListBuffer[A]
     aliased = false
   }
 
-  def addOne(elem: A): this.type = {
+  def += (elem: A): this.type = {
     ensureUnaliased()
     val last1 = new ::[A](elem, Nil)
     if (len == 0) first = last1 else last0.next = last1
@@ -95,7 +95,7 @@ class ListBuffer[A]
     this
   }
 
-  override def subtractOne(elem: A): this.type = {
+  override def -= (elem: A): this.type = {
     ensureUnaliased()
     if (isEmpty) {}
     else if (first.head == elem) {
@@ -171,7 +171,7 @@ class ListBuffer[A]
     }
   }
 
-  def prepend(elem: A): this.type = {
+  def +=: (elem: A): this.type = {
     insert(0, elem)
     this
   }

--- a/src/library/scala/collection/mutable/ListMap.scala
+++ b/src/library/scala/collection/mutable/ListMap.scala
@@ -38,9 +38,9 @@ class ListMap[K, V]
   def get(key: K): Option[V] = elems find (_._1 == key) map (_._2)
   def iterator: Iterator[(K, V)] = elems.iterator
 
-  final override def addOne(kv: (K, V)) = { elems = remove(kv._1, elems, List()); elems = kv :: elems; siz += 1; this }
+  final override def += (kv: (K, V)) = { elems = remove(kv._1, elems, List()); elems = kv :: elems; siz += 1; this }
 
-  final override def subtractOne(key: K) = { elems = remove(key, elems, List()); this }
+  final override def -= (key: K) = { elems = remove(key, elems, List()); this }
 
   @tailrec
   private def remove(key: K, elems: List[(K, V)], acc: List[(K, V)]): List[(K, V)] = {

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -340,9 +340,9 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
   /** Adds a new key/value pair to this map and returns the map. */
   def +=(key: Long, value: V): this.type = { update(key, value); this }
 
-  override def addOne(kv: (Long, V)): this.type = { update(kv._1, kv._2); this }
+  override def += (kv: (Long, V)): this.type = { update(kv._1, kv._2); this }
 
-  def subtractOne(key: Long): this.type = {
+  def -= (key: Long): this.type = {
     if (key == -key) {
       if (key == 0L) {
         extraKeys &= 0x2
@@ -547,7 +547,7 @@ object LongMap {
     */
   final class LongMapBuilder[V] extends ReusableBuilder[(Long, V), LongMap[V]] {
     private[collection] var elems: LongMap[V] = new LongMap[V]
-    override def addOne(entry: (Long, V)): this.type = {
+    override def += (entry: (Long, V)): this.type = {
       elems += entry
       this
     }

--- a/src/library/scala/collection/mutable/OpenHashMap.scala
+++ b/src/library/scala/collection/mutable/OpenHashMap.scala
@@ -145,11 +145,11 @@ class OpenHashMap[Key, Value](initialSize : Int)
   // TODO refactor `put` to extract `findOrAddEntry` and implement this in terms of that to avoid Some boxing.
   override def update(key: Key, value: Value): Unit = put(key, value)
 
-  @deprecatedOverriding("addOne should not be overridden in order to maintain consistency with put.", "2.11.0")
-  def addOne (kv: (Key, Value)): this.type = { put(kv._1, kv._2); this }
+  @deprecatedOverriding("+= should not be overridden in order to maintain consistency with put.", "2.11.0")
+  def += (kv: (Key, Value)): this.type = { put(kv._1, kv._2); this }
 
-  @deprecatedOverriding("subtractOne should not be overridden in order to maintain consistency with remove.", "2.11.0")
-  def subtractOne (key: Key): this.type = { remove(key); this }
+  @deprecatedOverriding("-= should not be overridden in order to maintain consistency with remove.", "2.11.0")
+  def -= (key: Key): this.type = { remove(key); this }
 
   override def put(key: Key, value: Value): Option[Value] =
     put(key, hashOf(key), value)

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -119,7 +119,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     *  @param  elem        the element to insert.
     *  @return             this $coll.
     */
-  def addOne(elem: A): this.type = {
+  def += (elem: A): this.type = {
     resarr.p_ensureSize(resarr.p_size0 + 1)
     resarr.p_array(resarr.p_size0) = elem.asInstanceOf[AnyRef]
     fixUp(resarr.p_array, resarr.p_size0)
@@ -127,7 +127,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     this
   }
 
-  override def addAll(xs: IterableOnce[A]): this.type = {
+  override def ++= (xs: IterableOnce[A]): this.type = {
     val from = resarr.p_size0
     for (x <- xs.iterator) unsafeAdd(x)
     heapify(from)
@@ -348,7 +348,7 @@ object PriorityQueue extends SortedIterableFactory[PriorityQueue] {
   def newBuilder[A : Ordering]: Builder[A, PriorityQueue[A]] = {
     new Builder[A, PriorityQueue[A]] {
       val pq = new PriorityQueue[A]
-      def addOne(elem: A): this.type = { pq.unsafeAdd(elem); this }
+      def += (elem: A): this.type = { pq.unsafeAdd(elem); this }
       def result(): PriorityQueue[A] = { pq.heapify(1); pq }
       def clear(): Unit = pq.clear()
     }

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -1,6 +1,6 @@
 package scala.collection.mutable
 
-import scala.collection.{IterableFactory, IterableOnce}
+import scala.collection.{IterableFactory, IterableOnce, View}
 import scala.language.higherKinds
 
 /** Base trait for mutable sets */
@@ -22,6 +22,10 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     with Growable[A]
     with Shrinkable[A] {
 
+  @deprecated("Consider requiring an immutable Set or fall back to Set.union", "2.13.0")
+  def + (elem: A): C = fromSpecificIterable(new View.Appended(this, elem))
+  @deprecated("Consider requiring an immutable Set or fall back to Set.diff", "2.13.0")
+  def - (elem: A): C = diff(Set(elem))
 
   def add(elem: A): Boolean =
     !contains(elem) && {
@@ -51,9 +55,6 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     coll -= elem
     res
   }
-
-  def diff(that: collection.Set[A]): C =
-    toIterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result += elem)
 
   @deprecated("Use filterInPlace instead", "2.13.0")
   @inline final def retain(p: A => Boolean): Unit = filterInPlace(p)

--- a/src/library/scala/collection/mutable/Shrinkable.scala
+++ b/src/library/scala/collection/mutable/Shrinkable.scala
@@ -18,10 +18,10 @@ trait Shrinkable[-A] {
     *  @param elem  the element to remove.
     *  @return the $coll itself
     */
-  def subtractOne(elem: A): this.type
+  def -= (elem: A): this.type
 
-  /** Alias for `subtractOne` */
-  @`inline` final def -= (elem: A): this.type = subtractOne(elem)
+  /** Alias for `-=` */
+  @`inline` final def subtractOne(elem: A): this.type = this -= elem
 
   /** Removes two or more elements from this $coll.
     *
@@ -30,6 +30,7 @@ trait Shrinkable[-A] {
     *  @param elems the remaining elements to remove.
     *  @return the $coll itself
     */
+  @deprecated("Use --= with a collection instead of -= with varargs", "2.13.0")
   def -= (elem1: A, elem2: A, elems: A*): this.type = {
     this -= elem1
     this -= elem2
@@ -41,7 +42,7 @@ trait Shrinkable[-A] {
     *  @param xs   the iterator producing the elements to remove.
     *  @return the $coll itself
     */
-  def subtractAll(xs: collection.IterableOnce[A]): this.type = {
+  def --= (xs: collection.IterableOnce[A]): this.type = {
     @tailrec def loop(xs: collection.LinearSeq[A]): Unit = {
       if (xs.nonEmpty) {
         subtractOne(xs.head)
@@ -55,7 +56,7 @@ trait Shrinkable[-A] {
     this
   }
 
-  /** Alias for `subtractAll` */
-  @`inline` final def --= (xs: collection.IterableOnce[A]): this.type = subtractAll(xs)
+  /** Alias for `--=` */
+  @`inline` final def subtractAll(xs: collection.IterableOnce[A]): this.type = this --= xs
 
 }

--- a/src/library/scala/collection/mutable/SortedMap.scala
+++ b/src/library/scala/collection/mutable/SortedMap.scala
@@ -62,9 +62,9 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
     // Need to override following methods to match type signatures of `SortedMap.WithDefault`
     // for operations preserving default value
-    override def subtractOne(elem: K): WithDefault.this.type = { underlying.subtractOne(elem); this }
+    override def -= (elem: K): WithDefault.this.type = { underlying.subtractOne(elem); this }
 
-    override def addOne(elem: (K, V)): WithDefault.this.type = { underlying.addOne(elem); this }
+    override def += (elem: (K, V)): WithDefault.this.type = { underlying.addOne(elem); this }
 
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 

--- a/src/library/scala/collection/mutable/TreeMap.scala
+++ b/src/library/scala/collection/mutable/TreeMap.scala
@@ -42,9 +42,9 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
   override def valuesIteratorFrom(start: K): Iterator[V] = RB.valuesIterator(tree, Some(start))
 
-  def addOne(elem: (K, V)): this.type = { RB.insert(tree, elem._1, elem._2); this }
+  def += (elem: (K, V)): this.type = { RB.insert(tree, elem._1, elem._2); this }
 
-  def subtractOne(elem: K): this.type = { RB.delete(tree, elem); this }
+  def -= (elem: K): this.type = { RB.delete(tree, elem); this }
 
   override def clear(): Unit = RB.clear(tree)
 

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -42,12 +42,12 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
 
   def iteratorFrom(start: A): collection.Iterator[A] = RB.keysIterator(tree, Some(start))
 
-  def addOne(elem: A): this.type = {
+  def += (elem: A): this.type = {
     RB.insert(tree, elem, null)
     this
   }
 
-  def subtractOne(elem: A): this.type = {
+  def -= (elem: A): this.type = {
     RB.delete(tree, elem)
     this
   }

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -109,7 +109,7 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
     this
   }
 
-  def addOne(elem: T) = {
+  def += (elem: T) = {
     lastptr = lastptr.append(elem)
     sz += 1
     this
@@ -174,7 +174,7 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
       remove(idx, count-1)
     }
 
-  def prepend(elem: T) = {
+  def +=: (elem: T) = {
     headptr = headptr prepend elem
     sz += 1
     this
@@ -188,7 +188,7 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
       sz += headptr.insertAll(idx, elems, this)
     } else throw new IndexOutOfBoundsException(idx.toString)
 
-  override def subtractOne(elem: T): this.type = {
+  override def -= (elem: T): this.type = {
     headptr.subtractOne(elem, this)
     this
   }

--- a/src/library/scala/sys/SystemProperties.scala
+++ b/src/library/scala/sys/SystemProperties.scala
@@ -48,8 +48,8 @@ extends mutable.AbstractMap[String, String] {
     wrapAccess(super.contains(key)) exists (x => x)
 
   override def clear(): Unit = wrapAccess(System.getProperties().clear())
-  def subtractOne (key: String): this.type = { wrapAccess(System.clearProperty(key)) ; this }
-  def addOne (kv: (String, String)): this.type = { wrapAccess(System.setProperty(kv._1, kv._2)) ; this }
+  def -= (key: String): this.type = { wrapAccess(System.clearProperty(key)) ; this }
+  def += (kv: (String, String)): this.type = { wrapAccess(System.setProperty(kv._1, kv._2)) ; this }
 
   def wrapAccess[T](body: => T): Option[T] =
     try Some(body) catch { case _: AccessControlException => None }

--- a/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
+++ b/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
@@ -201,7 +201,7 @@ final class WeakHashSet[A <: AnyRef](val initialCapacity: Int, val loadFactor: D
   }
 
   // add an element to this set unless it's already in there and return this set
-  override def addOne (elem: A): this.type = elem match {
+  override def += (elem: A): this.type = elem match {
     case null => throw new NullPointerException("WeakHashSet cannot hold nulls")
     case _    => {
       removeStaleEntries()
@@ -228,7 +228,7 @@ final class WeakHashSet[A <: AnyRef](val initialCapacity: Int, val loadFactor: D
   }
 
   // remove an element from this set and return this set
-  override def subtractOne(elem: A): this.type = elem match {
+  override def -= (elem: A): this.type = elem match {
     case null => this
     case _ => {
       removeStaleEntries()

--- a/src/scalacheck/org/scalacheck/util/ArrayListBuilder.scala
+++ b/src/scalacheck/org/scalacheck/util/ArrayListBuilder.scala
@@ -8,7 +8,7 @@ import scala.collection.mutable
 private[scalacheck] class ArrayListBuilder[T]
   extends mutable.Builder[T, util.ArrayList[T]] {
   val al = new ArrayList[T]
-  def addOne(x: T) = {
+  def += (x: T) = {
     al.add(x)
     this
   }

--- a/src/scaladoc/scala/tools/nsc/doc/Index.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Index.scala
@@ -8,7 +8,7 @@ package scala.tools.nsc.doc
 import scala.collection._
 
 trait Index {
-  type SymbolMap = SortedMap[String, SortedSet[model.MemberEntity]]
+  type SymbolMap = immutable.SortedMap[String, SortedSet[model.MemberEntity]]
 
   def firstLetterIndex: Map[Char, SymbolMap]
 

--- a/test/files/pos/spec-sparsearray-new.scala
+++ b/test/files/pos/spec-sparsearray-new.scala
@@ -16,9 +16,9 @@ class SparseArray[@specialized(Int) T:ClassTag] extends collection.mutable.Map[I
     sys.error("impl doesn't matter")
   }
 
-  def addOne(elem: (Int, T)): SparseArray.this.type = ???
+  def += (elem: (Int, T)): SparseArray.this.type = ???
   def iterator: Iterator[(Int, T)] = ???
-  def subtractOne(elem: Int): SparseArray.this.type = ???
+  def -= (elem: Int): SparseArray.this.type = ???
 
   override protected[this] def fromSpecificIterable(coll: Iterable[(Int, T)]): SparseArray[T] = ???
   override protected[this] def newSpecificBuilder: mutable.Builder[(Int, T), SparseArray[T]] = ???

--- a/test/files/pos/spec-sparsearray-old.scala
+++ b/test/files/pos/spec-sparsearray-old.scala
@@ -15,9 +15,9 @@ class SparseArray[@specialized(Int) T:ClassManifest] extends collection.mutable.
     sys.error("impl doesn't matter")
   }
 
-  def addOne(elem: (Int, T)): SparseArray.this.type = ???
+  def += (elem: (Int, T)): SparseArray.this.type = ???
   def iterator: Iterator[(Int, T)] = ???
-  def subtractOne(elem: Int): SparseArray.this.type = ???
+  def -= (elem: Int): SparseArray.this.type = ???
 
   override protected[this] def fromSpecificIterable(coll: Iterable[(Int, T)]): SparseArray[T] = ???
   override protected[this] def newSpecificBuilder: mutable.Builder[(Int, T), SparseArray[T]] = ???

--- a/test/files/pos/t247.scala
+++ b/test/files/pos/t247.scala
@@ -4,6 +4,8 @@ trait Map[A, B] extends scala.collection.Map[A, B] {
   val factory:MapFactory[A]
   def -(key1: A, key2: A, keys: A*): Map[A, B] = null
   def -(key: A): Map[A, B] = null
+  def +[V1 >: B](elem1: (A, V1), elem2: (A, V1), elems: (A, V1)*): scala.collection.Map[A,V1] = null
+  def +[V1 >: B](kv: (A, V1)): scala.collection.Map[A,V1] = null
 }
 abstract class MapFactory[A] {
   def Empty[B]:Map[A,B];
@@ -25,4 +27,5 @@ class TreeMap[KEY,VALUE](_factory:TreeMapFactory[KEY]) extends Tree[KEY,Tuple2[K
   def get(key:KEY) = null;
   def iterator:Iterator[Tuple2[KEY,VALUE]] = null;
   override def size = super[Tree].size
+  def -- (keys: IterableOnce[KEY]): Map[KEY, VALUE] = null
 }

--- a/test/files/pos/virtpatmat_exist1.scala
+++ b/test/files/pos/virtpatmat_exist1.scala
@@ -11,10 +11,10 @@ class HS[A]
     with Serializable {
   def get(elem: A): Option[A] = ???
   def contains(elem: A): Boolean = ???
-  def addOne(elem: A): HS.this.type = ???
+  def += (elem: A): HS.this.type = ???
   def clear(): Unit = ???
   def iterator: Iterator[A] = ???
-  def subtractOne(elem: A): HS.this.type = ???
+  def -= (elem: A): HS.this.type = ???
 }
 
 object Test {

--- a/test/files/run/collections.scala
+++ b/test/files/run/collections.scala
@@ -36,7 +36,7 @@ object Test extends App {
     println("***** "+msg+":")
     var s = s0
     s = s.clone() += 2
-    s = s.clone += (3, 4000, 10000)
+    s = s.clone ++= Set(3, 4000, 10000)
     println("test1: "+sum(s))
     time {
       s = s ++ (List.range(0, iters) map (2*))
@@ -89,7 +89,7 @@ object Test extends App {
     println("***** "+msg+":")
     var s = s0
     s = s.clone() += (2 -> 2)
-    s = s.clone() += (3 -> 3, 4000 -> 4000, 10000 -> 10000)
+    s = s.clone() ++= Map(3 -> 3, 4000 -> 4000, 10000 -> 10000)
     println("test1: "+sum(s map (_._2)))
     time {
       s = s ++ (List.range(0, iters) map (x => x * 2 -> x * 2))

--- a/test/junit/scala/collection/mutable/SetTest.scala
+++ b/test/junit/scala/collection/mutable/SetTest.scala
@@ -13,8 +13,8 @@ class SetTest {
     override protected[this] def fromSpecificIterable(coll: scala.collection.Iterable[String]): MySet = new MySet(fromIterable(coll))
     override protected[this] def newSpecificBuilder: Builder[String, MySet] = iterableFactory.newBuilder[String].mapResult(new MySet(_))
 
-    def subtractOne(elem: String) = { self -= elem; this }
-    def addOne(elem: String) = { self += elem; this }
+    def -= (elem: String) = { self -= elem; this }
+    def += (elem: String) = { self += elem; this }
 
     override def empty = new MySet(self.empty)
     def iterator = self.iterator


### PR DESCRIPTION
Fixes scala/bug#11009

- Define alphabetic aliases to symbolic operators when such
  operators used to exist in 2.12,
- Excepted in Set, where intersection and difference where
  defined by alphabetic operations, aliased by symbolic
  operators,
- Excepted in Map, where it is more efficient to let concrete
  collections implement `updated`, and to alias it by the `+`
  operator.