### PR TITLE
Eta-expanded tycon's type params need own owner

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -96,15 +96,16 @@ abstract class Pickler extends SubComponent {
     private def isRootSym(sym: Symbol) =
       sym.name.toTermName == rootName && sym.owner == rootOwner
 
-    /** Returns usually symbol's owner, but picks classfile root instead
-     *  for existentially bound variables that have a non-local owner.
-     *  Question: Should this be done for refinement class symbols as well?
-     *
-     *  Note: tree pickling also finds its way here; e.g. in scala/bug#7501 the pickling
-     *  of trees in annotation arguments considers the parameter symbol of a method
-     *  called in such a tree as "local". The condition `sym.isValueParameter` was
-     *  added to fix that bug, but there may be a better way.
-     */
+    /** Usually `sym.owner`, except when `sym` is pickle-local, while `sym.owner` is not.
+      *
+      * In the latter case, the alternative owner is the pickle root,
+      * or a non-class owner of root (so that term-owned parameters remain term-owned).
+      *
+      * Note: tree pickling also finds its way here; e.g. in scala/bug#7501 the pickling
+      * of trees in annotation arguments considers the parameter symbol of a method
+      * called in such a tree as "local". The condition `sym.isValueParameter` was
+      * added to fix that bug, but there may be a better way.
+      */
     private def localizedOwner(sym: Symbol) =
       if (isLocalToPickle(sym) && !isRootSym(sym) && !isLocalToPickle(sym.owner))
         // don't use a class as the localized owner for type parameters that are not owned by a class: those are not instantiated by asSeenFrom

--- a/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
@@ -240,7 +240,7 @@ trait PatternTypers {
       // as instantiateTypeVar's bounds would end up there
       val ctorContext = context.makeNewScope(tree, context.owner)
       freeVars foreach ctorContext.scope.enter
-      newTyper(ctorContext).infer.inferConstructorInstance(tree1, caseClass.typeParams, ptSafe)
+      newTyper(ctorContext).infer.inferConstructorInstance(tree1, caseClass, caseClassType, ptSafe)
 
       // simplify types without losing safety,
       // so that we get rid of unnecessary type slack, and so that error messages don't unnecessarily refer to skolems

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1778,6 +1778,7 @@ trait Types
                                          // (this can happen only for erroneous programs).
       }
 
+    // TODO should we pull this out to reduce memory footprint of ClassInfoType?
     private object enterRefs extends TypeMap {
       private var tparam: Symbol = _
 
@@ -2330,7 +2331,10 @@ trait Types
       // must initialise symbol, see test/files/pos/ticket0137.scala
       val tpars = initializedTypeParams
       if (tpars.isEmpty) this
-      else typeFunAnon(tpars, copyTypeRef(this, pre, sym, tpars map (_.tpeHK))) // todo: also beta-reduce?
+      else {
+        val tparsAtNonClass = cloneSymbolsAtOwner(tpars, sym.newLocalDummy(sym.pos))
+        PolyType(tparsAtNonClass, copyTypeRef(this, pre, sym, tparsAtNonClass map (_.typeConstructor)))
+      }
     }
 
     // only need to rebind type aliases, as typeRef already handles abstract types
@@ -3910,14 +3914,6 @@ trait Types
 
   @deprecated("use genPolyType(...) instead", "2.10.0") // Used in reflection API
   def polyType(params: List[Symbol], tpe: Type): Type = GenPolyType(params, tpe)
-
-  /** A creator for anonymous type functions, where the symbol for the type function still needs to be created.
-   *
-   * TODO:
-   * type params of anonymous type functions, which currently can only arise from normalising type aliases, are owned by the type alias of which they are the eta-expansion
-   * higher-order subtyping expects eta-expansion of type constructors that arise from a class; here, the type params are owned by that class, but is that the right thing to do?
-   */
-  def typeFunAnon(tps: List[Symbol], body: Type): Type = typeFun(tps, body)
 
   /** A creator for a type functions, assuming the type parameters tps already have the right owner. */
   def typeFun(tps: List[Symbol], body: Type): Type = PolyType(tps, body)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2332,7 +2332,8 @@ trait Types
       val tpars = initializedTypeParams
       if (tpars.isEmpty) this
       else {
-        val tparsAtNonClass = cloneSymbolsAtOwner(tpars, sym.newLocalDummy(sym.pos))
+        val tparsAtNonClass = cloneSymbolsAtOwnerAndModify(tpars, sym.newLocalDummy(sym.pos), _.asSeenFrom(pre, sym.owner))
+        debuglog(s"tparsAtNonClass ${tparsAtNonClass.map(_.info)}")
         PolyType(tparsAtNonClass, copyTypeRef(this, pre, sym, tparsAtNonClass map (_.typeConstructor)))
       }
     }

--- a/test/files/neg/hk-typevar-unification.check
+++ b/test/files/neg/hk-typevar-unification.check
@@ -1,6 +1,6 @@
 hk-typevar-unification.scala:16: error: inferred kinds of the type arguments ([_ <: B]Foo[_]) do not conform to the expected kinds of the type parameters (type F).
 [_ <: B]Foo[_]'s type parameters do not match type F's expected parameters:
-type _ (in class Foo)'s bounds <: B are stricter than type _'s declared bounds >: Nothing <: Any
+type _'s bounds <: B are stricter than type _'s declared bounds >: Nothing <: Any
   f(tcFoo)
   ^
 hk-typevar-unification.scala:16: error: type mismatch;
@@ -10,8 +10,8 @@ hk-typevar-unification.scala:16: error: type mismatch;
     ^
 hk-typevar-unification.scala:19: error: inferred kinds of the type arguments ([_ <: B]Foo[_]) do not conform to the expected kinds of the type parameters (type F).
 [_ <: B]Foo[_]'s type parameters do not match type F's expected parameters:
-type _ (in class Foo) is invariant, but type _ is declared covariant
-type _ (in class Foo)'s bounds <: B are stricter than type _'s declared bounds >: Nothing <: Any
+type _ is invariant, but type _ is declared covariant
+type _'s bounds <: B are stricter than type _'s declared bounds >: Nothing <: Any
   g(tcFoo)
   ^
 hk-typevar-unification.scala:19: error: type mismatch;

--- a/test/files/pos/pattern_relative_types.scala
+++ b/test/files/pos/pattern_relative_types.scala
@@ -1,0 +1,12 @@
+trait Outer[O] {
+  case class C[T <: O](x: T, y: Outer.this.type)
+}
+
+object Foo extends Outer[String]
+
+class Tst {
+  val c = new Foo.C("a", Foo)
+  c match {
+    case Foo.C(a, o) => a
+  }
+}

--- a/test/files/pos/t10762/t10762_1.scala
+++ b/test/files/pos/t10762/t10762_1.scala
@@ -1,0 +1,12 @@
+import language.higherKinds
+
+trait Tycon[A]
+trait MatcherFactory1X[TC1[_]]
+trait Matcher[T]{
+  class X {
+        def be = {
+      def inferTycon[TC1[_]](other: MatcherFactory1X[TC1]): MatcherFactory1X[TC1] = ???
+          inferTycon(??? : MatcherFactory1X[Tycon])
+        }
+  }
+}

--- a/test/files/pos/t10762/t10762_2.scala
+++ b/test/files/pos/t10762/t10762_2.scala
@@ -1,0 +1,4 @@
+object Test {
+  val m: Matcher[_] = ???
+  val tpinfer = (new m.X).be
+}


### PR DESCRIPTION
Since #6069, it is possible to have type variables compared to the eta
expansion of a class type, which is `[CLASSTPARAM] => Class[CLASSTPARAM]`.

After separate compilation, the owner of this type constructor param
is adjusted to the root class (see the comments and special cases in
Pickler.localizedOwner), which makes it show up to certain subsequent
as-seen-from maps as a type parameter of an enclosing class. SBT's
ExtractAPI phase runs into this problem.

Eta expansion of the tycon type ref uses an owner (NoSymbol) that
will not become a class after pickling.

Fixes scala/bug#10762