### PR TITLE
Respect BaseTypeSeq invar (3): symbols are distinct

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -881,24 +881,15 @@ trait Types
     /** Same as matches, except that non-method types are always assumed to match. */
     def looselyMatches(that: Type): Boolean = matchesType(this, that, alwaysMatchSimple = true)
 
-    /** The shortest sorted upwards closed array of types that contains
-     *  this type as first element.
-     *
-     *  A list or array of types ts is upwards closed if
-     *
-     *    for all t in ts:
-     *      for all typerefs p.s[args] such that t <: p.s[args]
-     *      there exists a typeref p'.s[args'] in ts such that
-     *      t <: p'.s['args] <: p.s[args],
-     *
-     *      and
-     *
-     *      for all singleton types p.s such that t <: p.s
-     *      there exists a singleton type p'.s in ts such that
-     *      t <: p'.s <: p.s
-     *
-     *  Sorting is with respect to Symbol.isLess() on type symbols.
-     */
+    /** The base type sequence of T is the smallest set of (potentially existentially quantified)
+      * class types Ti, so that for each supertype T' (T <:< T'),
+      * there is a Ti so that T <:< Ti <:< T'.
+      *
+      * This is also known as the upward closed set of the partially ordered set of
+      * class types under Symbol#isLess (a refinement of Symbol#isSubclass).
+      *
+      * See "Base Types and Member Definitions" in spec/03-types.md.
+      */
     def baseTypeSeq: BaseTypeSeq = baseTypeSingletonSeq(this)
 
     /** The maximum depth (@see typeDepth)
@@ -1090,7 +1081,8 @@ trait Types
     override def baseTypeSeq: BaseTypeSeq = supertype.baseTypeSeq
     override def baseTypeSeqDepth: Depth = supertype.baseTypeSeqDepth
     override def baseClasses: List[Symbol] = supertype.baseClasses
-  override def boundSyms: Set[Symbol] = emptySymbolSet}
+    override def boundSyms: Set[Symbol] = emptySymbolSet
+ }
 
   /** A base class for types that represent a single value
    *  (single-types and this-types).
@@ -1098,11 +1090,8 @@ trait Types
   abstract class SingletonType extends SubType with SimpleTypeProxy with SingletonTypeApi {
     def supertype = underlying
     override def isTrivial = false
-    override def widen: Type = underlying.widen
-    override def baseTypeSeq: BaseTypeSeq = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(singletonBaseTypeSeqCount)
-      underlying.baseTypeSeq prepend this
-    }
+// Spec: "The base types of a singleton type `$p$.type` are the base types of the type of $p$."
+//    override def baseTypeSeq: BaseTypeSeq = underlying.baseTypeSeq
     override def isHigherKinded = false // singleton type classifies objects, thus must be kind *
     override def safeToString: String = {
       // Avoiding printing Predef.type and scala.package.type as "type",
@@ -2091,6 +2080,7 @@ trait Types
     override def decls       = relativeInfo.decls
     override def bounds      = relativeInfo.bounds
 
+    // TODO: this deviates from the spec "The base types of an abstract type are the base types of its upper bound."
     override protected[Types] def baseTypeSeqImpl: BaseTypeSeq = bounds.hi.baseTypeSeq prepend this
     override protected[Types] def parentsImpl: List[Type] = relativeInfo.parents
 

--- a/test/files/pos/t11020.scala
+++ b/test/files/pos/t11020.scala
@@ -1,0 +1,7 @@
+// asSeenFrom crash related to BaseTypeSeq bug for singleton types
+trait Poly[T] { type TT = T
+  def foo: (this.type with Any)#TT
+}
+
+// equivalent:
+// class C { def meh[T](x: Poly[T]): (x.type with Any)#TT = ??? }


### PR DESCRIPTION
In a BTS, a singleton type is redundant with its underlying type.
In other words, what could we learn about the superclasses of
a singleton type that is not captured entirely by its super type?

This duplicate type symbol leads to confusion during ASF
when looking up the base class that defines the T type param
(Since `typeOf[this.type].typeSymbol == typeOf[Poly[_]].typeSymbol`,
 we return `this.type` for the base type at Poly,
 which does not have the expected type params.)

The interesting part is that you have to embed the singleton in
a compound type to trigger the bug because SubType
(a supertype of SingletonType) delegates `baseType` to its
underlying (super) type!

Fixes scala/bug#11020