### PR TITLE
Trim stack trace in REPL print

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -587,11 +587,12 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
       val unwrapped = rootCause(t)
 
       // Example input: $line3.$read$$iw$$iw$
-      val classNameRegex = (lineRegex + ".*").r
-      def isWrapperInit(x: StackTraceElement) = cond(x.getClassName) {
-        case classNameRegex() if x.getMethodName == nme.CONSTRUCTOR.decoded => true
+      val classNameRegex = s"$lineRegex.*".r
+      def isWrapperCode(x: StackTraceElement) = cond(x.getClassName) {
+        case classNameRegex() =>
+          x.getMethodName == nme.CONSTRUCTOR.decoded || x.getMethodName == printName
       }
-      val stackTrace = unwrapped stackTracePrefixString (!isWrapperInit(_))
+      val stackTrace = unwrapped.stackTracePrefixString(!isWrapperCode(_))
 
       withLastExceptionLock[String]({
         directBind[Throwable]("lastException", unwrapped)(StdReplTags.tagOfThrowable, classTag[Throwable])

--- a/src/repl/scala/tools/nsc/interpreter/Naming.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Naming.scala
@@ -33,11 +33,15 @@ object Naming {
       cleaned map (ch => if (ch.isWhitespace || ch == ESC) ch else if (ch < 32) '?' else ch)
   }
 
+  // Uncompiled regex pattern to detect `line` package and members
+  // `read`, `eval`, `print`, for purposes of filtering output and stack traces.
+  //
   // The two name forms this is catching are the two sides of this assignment:
   //
   // $line3.$read.$iw.$iw.Bippy =
   //   $line3.$read$$iw$$iw$Bippy@4a6a00ca
-  lazy val lineRegex = {
+  //
+  lazy val lineRegex: String = {
     val sn = sessionNames
     val members = List(sn.read, sn.eval, sn.print) map Regex.quote mkString("(?:", "|", ")")
     Regex.quote(sn.line) + """\d+[./]""" + members + """[$.]"""

--- a/test/files/run/repl-trim-stack-trace.check
+++ b/test/files/run/repl-trim-stack-trace.check
@@ -23,4 +23,9 @@ java.lang.Exception
   at .f(<console>:1)
   ... ??? elided
 
+scala> null.asInstanceOf
+java.lang.NullPointerException
+  at .$print$lzycompute(<synthetic>:9)
+  ... ??? elided
+
 scala> :quit


### PR DESCRIPTION
Currently, the stack trace is trimmed at
the constructor of the `read` object that
evaluates the expression. If the exception
is thrown in printing, it is untrimmed;
so also look for the `print` method; the
regex for the class name already includes
`eval` for the print result object.