### PR TITLE
Bump versions of OSGi testing dependencies for JDK 9 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -613,11 +613,11 @@ lazy val scalacheck = project.in(file("test") / "scalacheck")
 
 lazy val osgiTestFelix = osgiTestProject(
   project.in(file(".") / "target" / "osgiTestFelix"),
-  "org.apache.felix" % "org.apache.felix.framework" % "5.0.1")
+  "org.apache.felix" % "org.apache.felix.framework" % "5.6.10")
 
 lazy val osgiTestEclipse = osgiTestProject(
   project.in(file(".") / "target" / "osgiTestEclipse"),
-  "org.eclipse.tycho" % "org.eclipse.osgi" % "3.10.100.v20150521-1310")
+  "org.eclipse.tycho" % "org.eclipse.osgi" % "3.13.0.v20180226-1711")
 
 def osgiTestProject(p: Project, framework: ModuleID) = p
   .dependsOn(library, reflect, compiler)
@@ -629,7 +629,7 @@ def osgiTestProject(p: Project, framework: ModuleID) = p
     fork in Test := true,
     parallelExecution in Test := false,
     libraryDependencies ++= {
-      val paxExamVersion = "4.5.0" // Last version which supports Java 6
+      val paxExamVersion = "4.11.0" // Last version which supports Java 9+
       Seq(
         junitDep,
         junitInterfaceDep,

--- a/build.sbt
+++ b/build.sbt
@@ -645,6 +645,7 @@ def osgiTestProject(p: Project, framework: ModuleID) = p
       )
     },
     Keys.test in Test := (Keys.test in Test).dependsOn(packageBin in Compile).value,
+    Keys.testOnly in Test := (Keys.testOnly in Test).dependsOn(packageBin in Compile).evaluated,
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "-q"),
     unmanagedSourceDirectories in Test := List((baseDirectory in ThisBuild).value / "test" / "osgi" / "src"),
     unmanagedResourceDirectories in Compile := (unmanagedSourceDirectories in Test).value,

--- a/test/osgi/src/ScalaOsgiHelper.scala
+++ b/test/osgi/src/ScalaOsgiHelper.scala
@@ -20,7 +20,11 @@ trait ScalaOsgiHelper {
 
   def standardOptions: Array[exam.Option]  = {
     val bundles = (allBundleFiles map makeBundle)
-    bundles ++ Array[exam.Option](junitBundles())
+    bundles ++ Array[exam.Option](junitBundles(), bootDelegationPackages(
+      "sun.*",
+      "com.sun.*",
+      "jdk.*"
+    ))
     // to change the local repo used (for some operations, but not all -- which is why I didn't bother):
     // systemProperty("org.ops4j.pax.url.mvn.localRepository").value(sys.props("maven.repo.local")))
   }


### PR DESCRIPTION
And configure the test OSGi containers to expose `jdk.internal` from the platform (aka boot) classloader, which we need to resolve `@jdk.internal.HotSpotIntrinsicCandidate` when entering so-annotated methods, e.g. `Object.hashCode`.