### PR TITLE
Update javaReflection check for jdk10

### DIFF
--- a/test/files/jvm/javaReflection.check
+++ b/test/files/jvm/javaReflection.check
@@ -208,218 +208,185 @@ A / A (canon) / A (simple)
 - declared cls: List(class A$B, interface A$C, class A$D$)
 - enclosing   : null (declaring cls) / null (cls) / null (constr) / null (meth)
 - properties  : false (local) / false (member)
-isAnonymous? false
 A$$anon$2 / null (canon) /  (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / null (meth)
 - properties  : false (local) / false (member)
-isAnonymous? true
+assert not class A$$anon$2 is anonymous
 assert not class A$$anon$2
 A$$anon$3 / null (canon) /  (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / public java.lang.Object A.f() (meth)
 - properties  : false (local) / false (member)
-isAnonymous? true
+assert not class A$$anon$3 is anonymous
 assert not class A$$anon$3
 A$$anon$4 / null (canon) /  (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / public java.lang.Object A.f() (meth)
 - properties  : false (local) / false (member)
-isAnonymous? true
+assert not class A$$anon$4 is anonymous
 assert not class A$$anon$4
 A$$anon$5 / null (canon) /  (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / null (meth)
 - properties  : false (local) / false (member)
-isAnonymous? true
+assert not class A$$anon$5 is anonymous
 assert not class A$$anon$5
 A$$anon$6 / null (canon) /  (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / null (meth)
 - properties  : false (local) / false (member)
-isAnonymous? true
+assert not class A$$anon$6 is anonymous
 assert not class A$$anon$6
 A$$anon$7 / null (canon) /  (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / public A(int) (constr) / null (meth)
 - properties  : false (local) / false (member)
-isAnonymous? true
+assert not class A$$anon$7 is anonymous
 assert not class A$$anon$7
 A$B / A.B (canon) / B (simple)
 - declared cls: List()
 - enclosing   : class A (declaring cls) / class A (cls) / null (constr) / null (meth)
 - properties  : false (local) / true (member)
-isAnonymous? false
 A$C / A.C (canon) / C (simple)
 - declared cls: List()
 - enclosing   : class A (declaring cls) / class A (cls) / null (constr) / null (meth)
 - properties  : false (local) / true (member)
-isAnonymous? false
 A$D$ / A.D$ (canon) / D$ (simple)
 - declared cls: List(class A$D$B, interface A$D$C, class A$D$D$)
 - enclosing   : class A (declaring cls) / class A (cls) / null (constr) / null (meth)
 - properties  : false (local) / true (member)
-isAnonymous? false
 A$D$$anon$1 / null (canon) /  (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A$D$ (cls) / null (constr) / null (meth)
 - properties  : false (local) / false (member)
-isAnonymous? true
+assert not class A$D$$anon$1 is anonymous
 assert not class A$D$$anon$1
 A$D$B / A.D$.B (canon) / B (simple)
 - declared cls: List()
 - enclosing   : class A$D$ (declaring cls) / class A$D$ (cls) / null (constr) / null (meth)
 - properties  : false (local) / true (member)
-isAnonymous? false
 A$D$C / A.D$.C (canon) / C (simple)
 - declared cls: List()
 - enclosing   : class A$D$ (declaring cls) / class A$D$ (cls) / null (constr) / null (meth)
 - properties  : false (local) / true (member)
-isAnonymous? false
 A$D$D$ / A.D$.D$ (canon) / D$ (simple)
 - declared cls: List()
 - enclosing   : class A$D$ (declaring cls) / class A$D$ (cls) / null (constr) / null (meth)
 - properties  : false (local) / true (member)
-isAnonymous? false
 A$D$KB$1 / null (canon) / KB$1 (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A$D$ (cls) / null (constr) / public void A$D$.f() (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$E$1 / null (canon) / E$1 (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / public java.lang.Object A.f() (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$F$1 / null (canon) / F$1 (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / public java.lang.Object A.f() (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$G$1$ / null (canon) / G$1$ (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / public java.lang.Object A.f() (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$H$1 / null (canon) / H$1 (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / public java.lang.Object A.f() (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$I$1 / null (canon) / I$1 (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / public java.lang.Object A.f() (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$J$1$ / null (canon) / J$1$ (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / public java.lang.Object A.f() (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$K$1 / null (canon) / K$1 (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / null (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$L$1 / null (canon) / L$1 (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / null (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$M$1$ / null (canon) / M$1$ (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / null (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$N$1 / null (canon) / N$1 (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / null (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$O$1 / null (canon) / O$1 (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / null (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$P$1$ / null (canon) / P$1$ (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / null (constr) / null (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$Q$1 / null (canon) / Q$1 (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / public A(int) (constr) / null (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$R$1 / null (canon) / R$1 (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / public A(int) (constr) / null (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 A$S$1$ / null (canon) / S$1$ (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class A (cls) / public A(int) (constr) / null (meth)
 - properties  : true (local) / false (member)
-isAnonymous? false
 AO / AO (canon) / AO (simple)
 - declared cls: List(class AO$B, interface AO$C, class AO$D$)
 - enclosing   : null (declaring cls) / null (cls) / null (constr) / null (meth)
 - properties  : false (local) / false (member)
-isAnonymous? false
 AO$ / AO$ (canon) / AO$ (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / null (cls) / null (constr) / null (meth)
 - properties  : false (local) / false (member)
-isAnonymous? false
 AO$$anon$8 / null (canon) /  (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / class AO$ (cls) / null (constr) / null (meth)
 - properties  : false (local) / false (member)
-isAnonymous? true
+assert not class AO$$anon$8 is anonymous
 assert not class AO$$anon$8
 AO$B / AO.B (canon) / B (simple)
 - declared cls: List()
 - enclosing   : class AO (declaring cls) / class AO (cls) / null (constr) / null (meth)
 - properties  : false (local) / true (member)
-isAnonymous? false
 AO$C / AO.C (canon) / C (simple)
 - declared cls: List()
 - enclosing   : class AO (declaring cls) / class AO (cls) / null (constr) / null (meth)
 - properties  : false (local) / true (member)
-isAnonymous? false
 AO$D$ / AO.D$ (canon) / D$ (simple)
 - declared cls: List()
 - enclosing   : class AO (declaring cls) / class AO (cls) / null (constr) / null (meth)
 - properties  : false (local) / true (member)
-isAnonymous? false
 AT / AT (canon) / AT (simple)
 - declared cls: List(class AT$B, interface AT$C, class AT$D$)
 - enclosing   : null (declaring cls) / null (cls) / null (constr) / null (meth)
 - properties  : false (local) / false (member)
-isAnonymous? false
 AT$$anon$9 / null (canon) /  (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / interface AT (cls) / null (constr) / null (meth)
 - properties  : false (local) / false (member)
-isAnonymous? true
+assert not class AT$$anon$9 is anonymous
 assert not class AT$$anon$9
 AT$B / AT.B (canon) / B (simple)
 - declared cls: List()
 - enclosing   : interface AT (declaring cls) / interface AT (cls) / null (constr) / null (meth)
 - properties  : false (local) / true (member)
-isAnonymous? false
 AT$C / AT.C (canon) / C (simple)
 - declared cls: List()
 - enclosing   : interface AT (declaring cls) / interface AT (cls) / null (constr) / null (meth)
 - properties  : false (local) / true (member)
-isAnonymous? false
 AT$D$ / AT.D$ (canon) / D$ (simple)
 - declared cls: List()
 - enclosing   : interface AT (declaring cls) / interface AT (cls) / null (constr) / null (meth)
 - properties  : false (local) / true (member)
-isAnonymous? false
 T / T (canon) / T (simple)
 - declared cls: List()
 - enclosing   : null (declaring cls) / null (cls) / null (constr) / null (meth)
 - properties  : false (local) / false (member)
-isAnonymous? false


### PR DESCRIPTION
Looks like I didn't update the split check file.

The mechanism is quite inconvenient. Consider `mytest-java8.check` instead?