### PR TITLE
[#11017] Widen Map#withDefault methods to their respective non-default types

### DIFF
--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -28,7 +28,7 @@ trait Map[K, +V]
     *  @param d     the function mapping keys to values, used for non-present keys
     *  @return      a wrapper of the map with a default value
     */
-  def withDefault[V1 >: V](d: K => V1): Map.WithDefault[K, V1] = new Map.WithDefault[K, V1](this, d)
+  def withDefault[V1 >: V](d: K => V1): Map[K, V1] = new Map.WithDefault[K, V1](this, d)
 
   /** The same map with a given default value.
     *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
@@ -39,7 +39,7 @@ trait Map[K, +V]
     *  @param d     default value used for non-present keys
     *  @return      a wrapper of the map with a default value
     */
-  def withDefaultValue[V1 >: V](d: V1): Map.WithDefault[K, V1] = new Map.WithDefault[K, V1](this, _ => d)
+  def withDefaultValue[V1 >: V](d: V1): Map[K, V1] = new Map.WithDefault[K, V1](this, _ => d)
 }
 
 /** Base trait of immutable Maps implementations

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -22,7 +22,7 @@ trait SortedMap[K, +V]
     *  @param d     the function mapping keys to values, used for non-present keys
     *  @return      a wrapper of the map with a default value
     */
-  override def withDefault[V1 >: V](d: K => V1): SortedMap.WithDefault[K, V1] = new SortedMap.WithDefault[K, V1](this, d)
+  override def withDefault[V1 >: V](d: K => V1): SortedMap[K, V1] = new SortedMap.WithDefault[K, V1](this, d)
 
   /** The same map with a given default value.
     *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
@@ -33,7 +33,7 @@ trait SortedMap[K, +V]
     *  @param d     default value used for non-present keys
     *  @return      a wrapper of the map with a default value
     */
-  override def withDefaultValue[V1 >: V](d: V1): SortedMap.WithDefault[K, V1] = new SortedMap.WithDefault[K, V1](this, _ => d)
+  override def withDefaultValue[V1 >: V](d: V1): SortedMap[K, V1] = new SortedMap.WithDefault[K, V1](this, _ => d)
 }
 
 trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -2,7 +2,6 @@ package scala
 package collection
 package mutable
 
-import scala.collection.{IterableOnce, MapFactory}
 import scala.language.higherKinds
 
 /** Base type of mutable Maps */
@@ -34,7 +33,7 @@ trait Map[K, V]
     *  @param d     the function mapping keys to values, used for non-present keys
     *  @return      a wrapper of the map with a default value
     */
-  def withDefault(d: K => V): Map.WithDefault[K, V] = new Map.WithDefault[K, V](this, d)
+  def withDefault(d: K => V): Map[K, V] = new Map.WithDefault[K, V](this, d)
 
   /** The same map with a given default value.
     *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
@@ -45,7 +44,7 @@ trait Map[K, V]
     *  @param d     default value used for non-present keys
     *  @return      a wrapper of the map with a default value
     */
-  def withDefaultValue(d: V): Map.WithDefault[K, V] = new Map.WithDefault[K, V](this, x => d)
+  def withDefaultValue(d: V): Map[K, V] = new Map.WithDefault[K, V](this, x => d)
 }
 
 /**

--- a/src/library/scala/collection/mutable/SortedMap.scala
+++ b/src/library/scala/collection/mutable/SortedMap.scala
@@ -23,7 +23,7 @@ trait SortedMap[K, V]
     *  @param d     the function mapping keys to values, used for non-present keys
     *  @return      a wrapper of the map with a default value
     */
-  override def withDefault(d: K => V): SortedMap.WithDefault[K, V] = new SortedMap.WithDefault[K, V](this, d)
+  override def withDefault(d: K => V): SortedMap[K, V] = new SortedMap.WithDefault[K, V](this, d)
 
   /** The same map with a given default value.
     * Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
@@ -34,7 +34,7 @@ trait SortedMap[K, V]
     * @param d default value used for non-present keys
     * @return a wrapper of the map with a default value
     */
-  override def withDefaultValue(d: V): SortedMap.WithDefault[K, V] = new SortedMap.WithDefault[K, V](this, _ => d)
+  override def withDefaultValue(d: V): SortedMap[K, V] = new SortedMap.WithDefault[K, V](this, _ => d)
 }
 
 trait SortedMapOps[K, V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]

--- a/test/junit/scala/collection/immutable/MapTest.scala
+++ b/test/junit/scala/collection/immutable/MapTest.scala
@@ -1,0 +1,19 @@
+package scala.collection.immutable
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class MapTest {
+
+  @Test
+  // Test for bug/#11017
+  // Compile-time test only
+  def testMapWithDefaultReassignableToMap(): Unit = {
+    var map = Map.empty[Int, Int].withDefaultValue(0)
+    map = map + (1 -> 1)
+  }
+
+
+}

--- a/test/junit/scala/collection/immutable/SortedMapTest.scala
+++ b/test/junit/scala/collection/immutable/SortedMapTest.scala
@@ -9,15 +9,14 @@ import org.junit.runners.JUnit4
 class SortedMapTest {
   @Test
   def testWithDefaultValueReturnsSortedMapWithDeaultValue(): Unit = {
-    val tree: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
-      .withDefault(defaultValueFunction)
+    val tree: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two")).withDefault(defaultValueFunction)
 
     assertEquals("3 is not present in this map", tree(3))
   }
 
   @Test
   def testDefaultValueIsPersistedAfterAnElementIsAddedToUnderlyingMap(): Unit = {
-    val tree: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two")).withDefault(defaultValueFunction)
+    val tree: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two")).withDefault(defaultValueFunction)
     val newTree = tree + (3 -> "Three")
 
     assertEquals("5 is not present in this map", newTree(5))
@@ -25,7 +24,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedAfterCreatingEmptyMapFromUnderlyingSortedMap(): Unit = {
-    val emptyMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
+    val emptyMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
       .withDefault(defaultValueFunction)
       .empty
 
@@ -34,7 +33,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedAfterRangeOperationOnSortedMap(): Unit = {
-    val rangedProjectOfTreeMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
+    val rangedProjectOfTreeMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
       .withDefault(defaultValueFunction)
       .range(1, 3) // range `to` parameter is not inclusive
 
@@ -43,7 +42,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedAfterAnElementFromUnderlyingMapIsRemoved(): Unit = {
-    val originalTreeMap : SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
+    val originalTreeMap : SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
       .withDefault(defaultValueFunction)
 
     val newTreeMap = originalTreeMap - 3
@@ -54,7 +53,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsLostWhenNewSortedMapIsCreatedFromIterablesInOperationsLikeFlatMap(): Unit = {
-    val originalMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
+    val originalMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
       .withDefault(defaultValueFunction)
 
     val newTreeMap: SortedMap[String, Int] = originalMap.flatMap((kv: (Int, String)) => TreeMap(kv._2 -> kv._1))
@@ -71,7 +70,8 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedWhenNewSortedMapIsCreatedFromSpecificIterableInOperationsLikeFilter(): Unit = {
-    val evenNumbers: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 4 -> "Four", 5 -> "Five"))
+    val evenNumbers: SortedMap[Int, String] =
+      SortedMap.from(Map(1 -> "One", 2 -> "Two", 4 -> "Four", 5 -> "Five"))
       .withDefault(defaultValueFunction)
       .filter((kv: (Int, String)) => kv._1 % 2 == 0)
 
@@ -80,7 +80,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedWhenNewSpecificBuilderIsCreatedFromSortedMapInOperationsLikeGroupBy(): Unit = {
-    val numbers: Map[String, SortedMap.WithDefault[Int, String]] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 4 -> "Four", 5 -> "Five"))
+    val numbers: Map[String, SortedMap[Int, String]] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 4 -> "Four", 5 -> "Five"))
       .withDefault(defaultValueFunction)
       .groupBy((kv: (Int, String)) => if (kv._1 % 2 == 0) "even" else "odd")
 
@@ -90,7 +90,7 @@ class SortedMapTest {
 
   @Test
   def testDefaulValueIsPersistedWhenNewMapIterableIsConcatenatedToOriginalMap(): Unit = {
-    val originaMap: SortedMap.WithDefault[Int, String] = TreeMap(1 -> "One", 2 -> "Two")
+    val originaMap: SortedMap[Int, String] = TreeMap(1 -> "One", 2 -> "Two")
       .withDefaultValue("element missing")
     val newMap: SortedMap[Int, String] = originaMap ++ Map(3 -> "Three")
 

--- a/test/junit/scala/collection/mutable/SortedMapTest.scala
+++ b/test/junit/scala/collection/mutable/SortedMapTest.scala
@@ -1,28 +1,22 @@
 package scala.collection.mutable
 
-import java.util.NoSuchElementException
 
 import org.junit.Assert.{assertEquals, assertNotEquals}
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.{Option, Unit}
-
 @RunWith(classOf[JUnit4])
 class SortedMapTest {
   @Test
   def testWithDefaultValueReturnsSortedMapWithDefaultValue(): Unit = {
-    val tree: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
-      .withDefault(defaultValueFunction)
-
+    val tree: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two")).withDefault(defaultValueFunction)
     assertEquals("3 is not present in this map", tree(3))
   }
 
   @Test
   def testDefaultValueIsPersistedAfterAnElementIsAddedToUnderlyingMap(): Unit = {
-    val tree: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
-      .withDefault(defaultValueFunction)
+    val tree: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two")).withDefault(defaultValueFunction)
 
     tree.addOne(3 -> "Three")
 
@@ -31,7 +25,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedAfterCreatingEmptyMapFromUnderlyingSortedMap(): Unit = {
-    val originalMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
+    val originalMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
       .withDefault(defaultValueFunction)
 
     val emptyMapWithDefault = originalMap.empty
@@ -41,7 +35,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedAfterRangeOperationOnSortedMap(): Unit = {
-    val rangedProjectOfTreeMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
+    val rangedProjectOfTreeMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
       .withDefault(defaultValueFunction)
       .range(1, 3) // range `to` parameter is not inclusive
 
@@ -50,7 +44,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedAfterAnElementFromUnderlyingMapIsRemoved(): Unit = {
-    val originalTreeMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
+    val originalTreeMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
       .withDefault(defaultValueFunction)
 
     originalTreeMap.remove(3)
@@ -61,7 +55,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsLostWhenNewSortedMapIsCreatedFromIterablesInOperationsLikeFlatMap(): Unit = {
-    val originalMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
+    val originalMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
       .withDefault(defaultValueFunction)
 
     val newTreeMap: SortedMap[String, Int] = originalMap.flatMap((kv: (Int, String)) => TreeMap(kv._2 -> kv._1))
@@ -78,7 +72,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedWhenNewSortedMapIsCreatedFromSpecificIterableInOperationsLikeFilter(): Unit = {
-    val evenNumbers: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 4 -> "Four", 5 -> "Five"))
+    val evenNumbers: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 4 -> "Four", 5 -> "Five"))
       .withDefault(defaultValueFunction)
       .filter((kv: (Int, String)) => kv._1 % 2 == 0)
 
@@ -87,7 +81,7 @@ class SortedMapTest {
 
   @Test
   def testDefaulValueIsNotPersistedWhenNewMapIterableIsConcatenatedToOriginalMutableMap(): Unit = {
-    val originaMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
+    val originaMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
       .withDefaultValue("element missing")
 
     val newMap: SortedMap[Int, String] = originaMap ++ SortedMap.from(Map(3 -> "Three")).withDefaultValue("foobar")
@@ -100,6 +94,14 @@ class SortedMapTest {
         assertEquals("key not found: 4", e.getMessage)
       }
     }
+  }
+
+  @Test
+  // Test for bug/#11017
+  // Compile-time test only
+  def testMapWithDefaultReassignableToMap(): Unit = {
+    var map = SortedMap.empty[Int, Int].withDefaultValue(0)
+    map = map + (1 -> 1)
   }
 
   private def defaultValueFunction: Int => String = {


### PR DESCRIPTION
This fixes https://github.com/scala/bug/issues/11017

This is an alternative to https://github.com/scala/scala/pull/6943 -- that is, only at most one of these two PR's can be accepted. I'd like to consider merging the other PR rather than this one if it is acceptable.