### PR TITLE
Enforce explicit return type for macros [ci: last-only]

### DIFF
--- a/src/compiler/scala/reflect/macros/compiler/Validators.scala
+++ b/src/compiler/scala/reflect/macros/compiler/Validators.scala
@@ -156,7 +156,7 @@ trait Validators {
           else mmap(macroDdef.vparamss)(param)
         val macroDefRet =
           if (!macroDdef.tpt.isEmpty) typer.typedType(macroDdef.tpt).tpe
-          else computeMacroDefTypeFromMacroImplRef(macroDdef, macroImplRef) orElse AnyTpe
+          else AnyTpe
         val implReturnType = sigma(increaseMetalevel(ctxPrefix, macroDefRet))
 
         object SigmaTypeMap extends TypeMap {

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -323,48 +323,6 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
     fastTrackBoxity orElse bindingBoxity getOrElse false
   }
 
-  def computeMacroDefTypeFromMacroImplRef(macroDdef: DefDef, macroImplRef: Tree): Type = {
-    def computeIt(macroImpl: Symbol, targs: List[Tree]): Type = {
-      // Step I. Transform c.Expr[T] to T and everything else to Any
-      val runtimeType0 = decreaseMetalevel(macroImpl.info.finalResultType)
-
-      // Step II. Transform type parameters of a macro implementation into type arguments in a macro definition's body
-      val runtimeType = runtimeType0.substituteTypes(macroImpl.typeParams, targs.map(_.tpe))
-
-      // Step III. Transform c.prefix.value.XXX to this.XXX and implParam.value.YYY to defParam.YYY
-      def unsigma(tpe: Type): Type =
-        transformTypeTagEvidenceParams(macroImplRef, (param, tparam) => NoSymbol) match {
-          case (implCtxParam :: Nil) :: implParamss =>
-            val implToDef = flatMap2(implParamss, macroDdef.vparamss)(map2(_, _)((_, _))).toMap
-            object UnsigmaTypeMap extends TypeMap {
-              def apply(tp: Type): Type = tp match {
-                case TypeRef(pre, sym, args) =>
-                  val pre1 = pre match {
-                    case SingleType(SingleType(SingleType(NoPrefix, c), prefix), value) if c == implCtxParam && prefix == MacroContextPrefix && value == ExprValue =>
-                      ThisType(macroDdef.symbol.owner)
-                    case SingleType(SingleType(NoPrefix, implParam), value) if value == ExprValue =>
-                      implToDef get implParam map (defParam => SingleType(NoPrefix, defParam.symbol)) getOrElse pre
-                    case _ =>
-                      pre
-                  }
-                  val args1 = args map mapOver
-                  TypeRef(pre1, sym, args1)
-                case _ =>
-                  mapOver(tp)
-              }
-            }
-            UnsigmaTypeMap(tpe)
-          case _ =>
-            tpe
-        }
-      unsigma(runtimeType)
-    }
-    macroImplRef match {
-      case MacroImplReference(_, _, _, macroImpl, targs) => computeIt(macroImpl, targs)
-      case _ => ErrorType
-    }
-  }
-
   /** Verifies that the body of a macro def typechecks to a reference to a static public non-overloaded method or a top-level macro bundle,
    *  and that that method is signature-wise compatible with the given macro definition.
    *

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5906,11 +5906,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       assert(context.owner.isMacro, context.owner)
       assert(ddef.symbol.isMacro, ddef.symbol)
 
+      // macro defs are typechecked in `methodSig` (by calling this method) in order to establish their link to macro implementation asap
+      // if a macro def doesn't have explicitly specified return type, this method will be called again by `assignTypeToTree`
+      // here we guard against this case
       val rhs1 =
         if (transformed contains ddef.rhs) {
-          // macro defs are typechecked in `methodSig` (by calling this method) in order to establish their link to macro implementation asap
-          // if a macro def doesn't have explicitly specified return type, this method will be called again by `assignTypeToTree`
-          // here we guard against this case
           transformed(ddef.rhs)
         } else {
           val rhs1 = typedMacroBody(this, ddef)
@@ -5926,17 +5926,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           ddef.symbol.setFlag(IS_ERROR)
           context.error(ddef.pos, commonMessage)
         }
-        def reportWarning(inferredType: Type) = {
-          val explanation = s"inference of $inferredType from macro impl's c.Expr[$inferredType] is deprecated and is going to stop working in 2.12"
-          context.deprecationWarning(ddef.pos, ddef.symbol, s"$commonMessage ($explanation)", "2.12.0")
-        }
-        computeMacroDefTypeFromMacroImplRef(ddef, rhs1) match {
-          case ErrorType => ErrorType
-          case NothingTpe => NothingTpe
-          case NoType => reportFailure(); AnyTpe
-          case tpe => reportWarning(tpe); tpe
-        }
-      } else AnyTpe
+        reportFailure()
+      }
+      AnyTpe
     }
 
     @inline final def transformedOr(tree: Tree, op: => Tree): Tree = lookupTransformed(tree) match {

--- a/test/files/neg/macro-abort/Macros_1.scala
+++ b/test/files/neg/macro-abort/Macros_1.scala
@@ -5,5 +5,5 @@ object Macros {
   def impl(c: Context) = {
     c.abort(c.enclosingPosition, "aborted")
   }
-  def abort = macro impl
+  def abort: Any = macro impl
 }

--- a/test/files/neg/macro-bundle-object.check
+++ b/test/files/neg/macro-bundle-object.check
@@ -1,8 +1,8 @@
 macro-bundle-object.scala:10: error: macro implementation has incompatible shape:
- required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Nothing]
+ required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Any]
  or      : (c: scala.reflect.macros.blackbox.Context): c.Tree
  found   : : Nothing
 number of parameter sections differ
-  def foo = macro Bundle.impl
-                         ^
+  def foo: Any = macro Bundle.impl
+                              ^
 one error found

--- a/test/files/neg/macro-bundle-object.scala
+++ b/test/files/neg/macro-bundle-object.scala
@@ -7,5 +7,5 @@ object Bundle {
 }
 
 object Macros {
-  def foo = macro Bundle.impl
+  def foo: Any = macro Bundle.impl
 }

--- a/test/files/neg/macro-exception/Macros_1.scala
+++ b/test/files/neg/macro-exception/Macros_1.scala
@@ -5,5 +5,5 @@ object Macros {
   def impl(c: Context) = {
     throw new Exception()
   }
-  def exception = macro impl
+  def exception: Any = macro impl
 }

--- a/test/files/neg/macro-invalidimpl.check
+++ b/test/files/neg/macro-invalidimpl.check
@@ -1,53 +1,53 @@
-Macros_Test_2.scala:5: error: macro implementation reference has wrong shape. required:
+Macros_Test_2.scala:6: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
-  def foo(x: Any) = macro impls.foo
-                                ^
-Macros_Test_2.scala:10: error: macro implementation reference has wrong shape. required:
+  def foo(x: Any): Any = macro impls.foo
+                                     ^
+Macros_Test_2.scala:11: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
-  def foo(x: Any) = macro impls.foo
-                                ^
-Macros_Test_2.scala:18: error: macro implementation reference has wrong shape. required:
+  def foo(x: Any): Any = macro impls.foo
+                                     ^
+Macros_Test_2.scala:19: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
-  def foo(x: Any) = macro Impls3.foo
-                                 ^
-Macros_Test_2.scala:22: error: macro implementation reference has wrong shape. required:
+  def foo(x: Any): Any = macro Impls3.foo
+                                      ^
+Macros_Test_2.scala:23: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
-  def foo(x: Any) = macro Impls4.foo
-                                 ^
-Macros_Test_2.scala:26: error: ambiguous reference to overloaded definition,
-both method foo in object Impls5 of type (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Any], y: c.Expr[Any])Nothing
-and  method foo in object Impls5 of type (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Any])Nothing
-match expected type ?
-  def foo(x: Any) = macro Impls5.foo
-                                 ^
+  def foo(x: Any): Any = macro Impls4.foo
+                                      ^
 Macros_Test_2.scala:27: error: ambiguous reference to overloaded definition,
 both method foo in object Impls5 of type (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Any], y: c.Expr[Any])Nothing
 and  method foo in object Impls5 of type (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Any])Nothing
 match expected type ?
-  def foo(x: Any, y: Any) = macro Impls5.foo
-                                         ^
-Macros_Test_2.scala:31: error: macro implementation has incompatible shape:
- required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Unit]
+  def foo(x: Any): Any = macro Impls5.foo
+                                      ^
+Macros_Test_2.scala:28: error: ambiguous reference to overloaded definition,
+both method foo in object Impls5 of type (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Any], y: c.Expr[Any])Nothing
+and  method foo in object Impls5 of type (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Any])Nothing
+match expected type ?
+  def foo(x: Any, y: Any): Any = macro Impls5.foo
+                                              ^
+Macros_Test_2.scala:32: error: macro implementation has incompatible shape:
+ required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Any]
  or      : (c: scala.reflect.macros.blackbox.Context): c.Tree
  found   : (c: scala.reflect.macros.blackbox.Context)(): c.Expr[Unit]
 number of parameter sections differ
-  def foo1 = macro Impls6.fooEmpty
-                          ^
-Macros_Test_2.scala:32: error: macro implementation has incompatible shape:
- required: (c: scala.reflect.macros.blackbox.Context)(): c.Expr[Unit]
+  def foo1: Any = macro Impls6.fooEmpty
+                               ^
+Macros_Test_2.scala:33: error: macro implementation has incompatible shape:
+ required: (c: scala.reflect.macros.blackbox.Context)(): c.Expr[Any]
  or      : (c: scala.reflect.macros.blackbox.Context)(): c.Tree
  found   : (c: scala.reflect.macros.blackbox.Context): c.Expr[Unit]
 number of parameter sections differ
-  def bar1() = macro Impls6.fooNullary
-                            ^
-Macros_Test_2.scala:36: error: type arguments [String] do not conform to method foo's type parameter bounds [U <: Int]
-  def foo = macro Impls7.foo[String]
-                            ^
-Macros_Test_2.scala:53: error: macro implementation must be public
-    def foo = macro Impls8.impl
-                           ^
+  def bar1(): Any = macro Impls6.fooNullary
+                                 ^
+Macros_Test_2.scala:37: error: type arguments [String] do not conform to method foo's type parameter bounds [U <: Int]
+  def foo: Any = macro Impls7.foo[String]
+                                 ^
+Macros_Test_2.scala:54: error: macro implementation must be public
+    def foo: Any = macro Impls8.impl
+                                ^
 10 errors found

--- a/test/files/neg/macro-invalidimpl.flags
+++ b/test/files/neg/macro-invalidimpl.flags
@@ -1,1 +1,0 @@
--language:experimental.macros

--- a/test/files/neg/macro-invalidimpl/Macros_Test_2.scala
+++ b/test/files/neg/macro-invalidimpl/Macros_Test_2.scala
@@ -1,13 +1,14 @@
+import language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 
 object Macros1 {
   val impls = new Impls1
-  def foo(x: Any) = macro impls.foo
+  def foo(x: Any): Any = macro impls.foo
 }
 
 object Macros2 {
   val impls = Impls2
-  def foo(x: Any) = macro impls.foo
+  def foo(x: Any): Any = macro impls.foo
 }
 
 class Macros3 {
@@ -15,25 +16,25 @@ class Macros3 {
     def foo(c: Context)(x: c.Expr[Any]) = ???
   }
 
-  def foo(x: Any) = macro Impls3.foo
+  def foo(x: Any): Any = macro Impls3.foo
 }
 
 class Macros4 extends MacroHelpers {
-  def foo(x: Any) = macro Impls4.foo
+  def foo(x: Any): Any = macro Impls4.foo
 }
 
 object Macros5 {
-  def foo(x: Any) = macro Impls5.foo
-  def foo(x: Any, y: Any) = macro Impls5.foo
+  def foo(x: Any): Any = macro Impls5.foo
+  def foo(x: Any, y: Any): Any = macro Impls5.foo
 }
 
 object Macros6 {
-  def foo1 = macro Impls6.fooEmpty
-  def bar1() = macro Impls6.fooNullary
+  def foo1: Any = macro Impls6.fooEmpty
+  def bar1(): Any = macro Impls6.fooNullary
 }
 
 object Macros7 {
-  def foo = macro Impls7.foo[String]
+  def foo: Any = macro Impls7.foo[String]
 }
 
 object Test extends App {
@@ -50,6 +51,6 @@ object Test extends App {
 
 package foo {
   object Test extends App {
-    def foo = macro Impls8.impl
+    def foo: Any = macro Impls8.impl
   }
 }

--- a/test/files/neg/macro-invalidret.check
+++ b/test/files/neg/macro-invalidret.check
@@ -1,34 +1,57 @@
-Macros_Test_2.scala:2: error: macro implementation has incompatible shape:
+Macros_Test_2.scala:5: error: macro implementation has incompatible shape:
  required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Any]
  or      : (c: scala.reflect.macros.blackbox.Context): c.Tree
  found   : (c: scala.reflect.macros.blackbox.Context): Int
 type mismatch for return type: Int does not conform to c.Expr[Any]
   def foo1 = macro Impls.foo1
                          ^
-Macros_Test_2.scala:3: error: macro implementation has incompatible shape:
+Macros_Test_2.scala:6: error: macro implementation has incompatible shape:
  required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Any]
  or      : (c: scala.reflect.macros.blackbox.Context): c.Tree
  found   : (c: scala.reflect.macros.blackbox.Context): reflect.runtime.universe.Literal
 type mismatch for return type: reflect.runtime.universe.Literal does not conform to c.Expr[Any]
   def foo2 = macro Impls.foo2
                          ^
-Macros_Test_2.scala:6: error: macro defs must have explicitly specified return types
+Macros_Test_2.scala:7: error: macro defs must have explicitly specified return types
+  def foo3 = macro Impls.foo3
+      ^
+Macros_Test_2.scala:8: error: macro defs must have explicitly specified return types
+  def foo4 = macro ???
+      ^
+Macros_Test_2.scala:9: error: macro defs must have explicitly specified return types
   def foo5 = macro Impls.foo5
       ^
-Macros_Test_2.scala:7: warning: macro defs must have explicitly specified return types (inference of Int from macro impl's c.Expr[Int] is deprecated and is going to stop working in 2.12)
+Macros_Test_2.scala:10: error: macro defs must have explicitly specified return types
   def foo6 = macro Impls.foo6
       ^
-Macros_Test_2.scala:14: error: exception during macro expansion:
+Macros_Test_2.scala:13: error: macro implementation has incompatible shape:
+ required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Int]
+ or      : (c: scala.reflect.macros.blackbox.Context): c.Tree
+ found   : (c: scala.reflect.macros.blackbox.Context): Int
+type mismatch for return type: Int does not conform to c.Expr[Int]
+  def bar1: Int = macro Impls.foo1
+                              ^
+Macros_Test_2.scala:14: error: macro implementation has incompatible shape:
+ required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Int]
+ or      : (c: scala.reflect.macros.blackbox.Context): c.Tree
+ found   : (c: scala.reflect.macros.blackbox.Context): reflect.runtime.universe.Literal
+type mismatch for return type: reflect.runtime.universe.Literal does not conform to c.Expr[Int]
+  def bar2: Int = macro Impls.foo2
+                              ^
+Macros_Test_2.scala:32: error: exception during macro expansion:
 java.lang.NullPointerException
 	at Impls$.foo3(Impls_1.scala:7)
 
-  foo3
+  bar3
   ^
-Macros_Test_2.scala:15: error: macro implementation is missing
-  foo4
+Macros_Test_2.scala:33: error: macro implementation is missing
+  bar4
   ^
-Macros_Test_2.scala:17: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-  foo6
+Macros_Test_2.scala:34: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  bar5
+  ^
+Macros_Test_2.scala:35: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  bar6
   ^
 two warnings found
-5 errors found
+10 errors found

--- a/test/files/neg/macro-invalidret/Macros_Test_2.scala
+++ b/test/files/neg/macro-invalidret/Macros_Test_2.scala
@@ -1,10 +1,21 @@
+import language.experimental.macros
+
 object Macros {
+  // result type required
   def foo1 = macro Impls.foo1
   def foo2 = macro Impls.foo2
   def foo3 = macro Impls.foo3
   def foo4 = macro ???
   def foo5 = macro Impls.foo5
   def foo6 = macro Impls.foo6
+
+  // various flawed attempts to implement
+  def bar1: Int = macro Impls.foo1
+  def bar2: Int = macro Impls.foo2
+  def bar3: Int = macro Impls.foo3
+  def bar4: Int = macro ???
+  def bar5: Int = macro Impls.foo5
+  def bar6: Int = macro Impls.foo6
 }
 
 object Test extends App {
@@ -15,4 +26,11 @@ object Test extends App {
   foo4
   foo5
   foo6
+
+  bar1
+  bar2
+  bar3
+  bar4
+  bar5
+  bar6
 }

--- a/test/files/neg/macro-invalidsig-params-badtype.check
+++ b/test/files/neg/macro-invalidsig-params-badtype.check
@@ -1,8 +1,8 @@
-Impls_Macros_1.scala:8: error: macro implementation has incompatible shape:
+Impls_Macros_1.scala:9: error: macro implementation has incompatible shape:
  required: (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Int]): c.Expr[Nothing]
  or      : (c: scala.reflect.macros.blackbox.Context)(x: c.Tree): c.Tree
  found   : (c: scala.reflect.macros.blackbox.Context)(x: Int): Nothing
 type mismatch for parameter x: c.Expr[Int] does not conform to Int
-  def foo(x: Int) = macro Impls.foo
-                                ^
+  def foo(x: Int): Nothing = macro Impls.foo
+                                         ^
 one error found

--- a/test/files/neg/macro-invalidsig-params-badtype.flags
+++ b/test/files/neg/macro-invalidsig-params-badtype.flags
@@ -1,1 +1,0 @@
--language:experimental.macros

--- a/test/files/neg/macro-invalidsig-params-badtype/Impls_Macros_1.scala
+++ b/test/files/neg/macro-invalidsig-params-badtype/Impls_Macros_1.scala
@@ -1,3 +1,4 @@
+import language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 
 object Impls {
@@ -5,5 +6,5 @@ object Impls {
 }
 
 object Macros {
-  def foo(x: Int) = macro Impls.foo
+  def foo(x: Int): Nothing = macro Impls.foo
 }

--- a/test/files/neg/macro-invalidsig.check
+++ b/test/files/neg/macro-invalidsig.check
@@ -2,80 +2,80 @@ Macros_Test_2.scala:2: error: macro implementations cannot have implicit paramet
   def foo[U]: Int = macro Impls1.foo[U]
                                  ^
 Macros_Test_2.scala:6: error: macro implementation has incompatible shape:
- required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Nothing]
+ required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Any]
  or      : (c: scala.reflect.macros.blackbox.Context): c.Tree
  found   : : Nothing
 number of parameter sections differ
-  def foo = macro Impls2.foo
-                         ^
+  def foo: Any = macro Impls2.foo
+                              ^
 Macros_Test_2.scala:10: error: macro implementation has incompatible shape:
- required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Nothing]
+ required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Any]
  or      : (c: scala.reflect.macros.blackbox.Context): c.Tree
  found   : (c: scala.reflect.api.Universe): Nothing
 type mismatch for parameter c: scala.reflect.macros.blackbox.Context does not conform to scala.reflect.api.Universe
-  def foo = macro Impls3.foo
-                         ^
+  def foo: Any = macro Impls3.foo
+                              ^
 Macros_Test_2.scala:14: error: macro implementation has incompatible shape:
- required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Nothing]
+ required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Any]
  or      : (c: scala.reflect.macros.blackbox.Context): c.Tree
  found   : (cs: scala.reflect.macros.blackbox.Context*): Nothing
 types incompatible for parameter cs: corresponding is not a vararg parameter
-  def foo = macro Impls4.foo
-                         ^
+  def foo: Any = macro Impls4.foo
+                              ^
 Macros_Test_2.scala:18: error: macro implementation has incompatible shape:
- required: (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Any]): c.Expr[Nothing]
+ required: (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Any]): c.Expr[Any]
  or      : (c: scala.reflect.macros.blackbox.Context)(x: c.Tree): c.Tree
  found   : (c: scala.reflect.macros.blackbox.Context): Nothing
 number of parameter sections differ
-  def foo(x: Any) = macro Impls5.foo
-                                 ^
+  def foo(x: Any): Any = macro Impls5.foo
+                                      ^
 Macros_Test_2.scala:22: error: macro implementations cannot have implicit parameters other than WeakTypeTag evidences
-  def foo[U](x: Int) = macro Impls6.foo[T, U]
-                                    ^
+  def foo[U](x: Int): Any = macro Impls6.foo[T, U]
+                                         ^
 Macros_Test_2.scala:26: error: macro implementation has incompatible shape:
- required: (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Int]): c.Expr[Nothing]
+ required: (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Int]): c.Expr[Any]
  or      : (c: scala.reflect.macros.blackbox.Context)(x: c.Tree): c.Tree
  found   : (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Int], y: c.Expr[Int]): Nothing
 parameter lists have different length, found extra parameter y: c.Expr[Int]
-  def foo(x: Int) = macro Impls7.foo
-                                 ^
+  def foo(x: Int): Any = macro Impls7.foo
+                                      ^
 Macros_Test_2.scala:30: error: macro implementation has incompatible shape:
- required: (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Int]): c.Expr[Nothing]
+ required: (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Int]): c.Expr[Any]
  or      : (c: scala.reflect.macros.blackbox.Context)(x: c.Tree): c.Tree
  found   : (c: scala.reflect.macros.blackbox.Context)(x: c.universe.Symbol): Nothing
 type mismatch for parameter x: c.Expr[Int] does not conform to c.universe.Symbol
-  def foo(x: Int) = macro Impls8.foo
-                                 ^
+  def foo(x: Int): Any = macro Impls8.foo
+                                      ^
 Macros_Test_2.scala:34: error: macro implementation has incompatible shape:
- required: (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Int], y: c.Expr[Int]): c.Expr[Nothing]
+ required: (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Int], y: c.Expr[Int]): c.Expr[Any]
  or      : (c: scala.reflect.macros.blackbox.Context)(x: c.Tree, y: c.Tree): c.Tree
  found   : (c: scala.reflect.macros.blackbox.Context)(xs: c.Expr[Int]*): Nothing
 parameter lists have different length, required extra parameter y: c.Expr[Int]
-  def foo(x: Int, y: Int) = macro Impls9.foo
-                                         ^
+  def foo(x: Int, y: Int): Any = macro Impls9.foo
+                                              ^
 Macros_Test_2.scala:38: error: macro implementation has incompatible shape:
- required: (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Int], y: c.Expr[Int]): c.Expr[Nothing]
+ required: (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Int], y: c.Expr[Int]): c.Expr[Any]
  or      : (c: scala.reflect.macros.blackbox.Context)(x: c.Tree, y: c.Tree): c.Tree
  found   : (c: scala.reflect.macros.blackbox.Context)(y: c.Expr[Int], x: c.Expr[Int]): Nothing
 parameter names differ: x != y
-  def foo(x: Int, y: Int) = macro Impls10.foo
-                                          ^
+  def foo(x: Int, y: Int): Any = macro Impls10.foo
+                                               ^
 Macros_Test_2.scala:42: error: macro implementation has incompatible shape:
- required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Nothing]
+ required: (c: scala.reflect.macros.blackbox.Context): c.Expr[Any]
  or      : (c: scala.reflect.macros.blackbox.Context): c.Tree
  found   : (c: scala.reflect.macros.blackbox.Context)(U: c.universe.Type): Nothing
 number of parameter sections differ
-  def foo[U] = macro Impls11.foo[U]
-                             ^
+  def foo[U]: Any = macro Impls11.foo[U]
+                                  ^
 Macros_Test_2.scala:46: error: type arguments [U] do not conform to method foo's type parameter bounds [U <: String]
-  def foo[U] = macro Impls12.foo[U]
-                                ^
+  def foo[U]: Any = macro Impls12.foo[U]
+                                     ^
 Macros_Test_2.scala:50: error: type arguments [U] do not conform to method foo's type parameter bounds [U <: String]
-  def foo[U <: Int] = macro Impls13.foo[U]
-                                       ^
+  def foo[U <: Int]: Any = macro Impls13.foo[U]
+                                            ^
 Macros_Test_2.scala:54: error: macro implementation reference has too few type arguments for method foo: [U](c: scala.reflect.macros.blackbox.Context)(implicit evidence$4: c.WeakTypeTag[U])Nothing
-  def foo = macro Impls14.foo
-                          ^
+  def foo: Any = macro Impls14.foo
+                               ^
 Macros_Test_2.scala:59: error: macro implementation reference has too few type arguments for method foo: [T, U, V](c: scala.reflect.macros.blackbox.Context)(implicit evidence$5: c.WeakTypeTag[T], implicit evidence$6: c.WeakTypeTag[U], implicit V: c.WeakTypeTag[V])c.Expr[Unit]
     def foo15[V]: Unit = macro Impls15.foo
                                        ^

--- a/test/files/neg/macro-invalidsig/Macros_Test_2.scala
+++ b/test/files/neg/macro-invalidsig/Macros_Test_2.scala
@@ -3,55 +3,55 @@ object Macros1 {
 }
 
 object Macros2 {
-  def foo = macro Impls2.foo
+  def foo: Any = macro Impls2.foo
 }
 
 object Macros3 {
-  def foo = macro Impls3.foo
+  def foo: Any = macro Impls3.foo
 }
 
 object Macros4 {
-  def foo = macro Impls4.foo
+  def foo: Any = macro Impls4.foo
 }
 
 object Macros5 {
-  def foo(x: Any) = macro Impls5.foo
+  def foo(x: Any): Any = macro Impls5.foo
 }
 
 class Macros6[T] {
-  def foo[U](x: Int) = macro Impls6.foo[T, U]
+  def foo[U](x: Int): Any = macro Impls6.foo[T, U]
 }
 
 object Macros7 {
-  def foo(x: Int) = macro Impls7.foo
+  def foo(x: Int): Any = macro Impls7.foo
 }
 
 object Macros8 {
-  def foo(x: Int) = macro Impls8.foo
+  def foo(x: Int): Any = macro Impls8.foo
 }
 
 object Macros9 {
-  def foo(x: Int, y: Int) = macro Impls9.foo
+  def foo(x: Int, y: Int): Any = macro Impls9.foo
 }
 
 object Macros10 {
-  def foo(x: Int, y: Int) = macro Impls10.foo
+  def foo(x: Int, y: Int): Any = macro Impls10.foo
 }
 
 object Macros11 {
-  def foo[U] = macro Impls11.foo[U]
+  def foo[U]: Any = macro Impls11.foo[U]
 }
 
 object Macros12 {
-  def foo[U] = macro Impls12.foo[U]
+  def foo[U]: Any = macro Impls12.foo[U]
 }
 
 object Macros13 {
-  def foo[U <: Int] = macro Impls13.foo[U]
+  def foo[U <: Int]: Any = macro Impls13.foo[U]
 }
 
 object Macros14 {
-  def foo = macro Impls14.foo
+  def foo: Any = macro Impls14.foo
 }
 
 class D[T] {

--- a/test/files/neg/macro-invalidusage-nontypeable/Impls_Macros_1.scala
+++ b/test/files/neg/macro-invalidusage-nontypeable/Impls_Macros_1.scala
@@ -9,5 +9,5 @@ object Impls {
 }
 
 object Macros {
-  def foo = macro Impls.foo
+  def foo: Int = macro Impls.foo
 }

--- a/test/files/neg/macro-noexpand/Macros_Test_2.scala
+++ b/test/files/neg/macro-noexpand/Macros_Test_2.scala
@@ -1,5 +1,5 @@
 object Macros {
-  def foo(x: Any) = macro Impls.foo
+  def foo(x: Any): Any = macro Impls.foo
 }
 
 object Test extends App {

--- a/test/files/neg/macro-qmarkqmarkqmark.scala
+++ b/test/files/neg/macro-qmarkqmarkqmark.scala
@@ -1,13 +1,13 @@
 import language.experimental.macros
 
 object Macros {
-  def foo1 = macro ???
+  def foo1: Any = macro ???
   foo1
 
-  def foo2(x: Int) = macro ???
+  def foo2(x: Int): Any = macro ???
   foo2
   foo2(1)
 
-  def foo3[T] = macro ???
+  def foo3[T]: Any = macro ???
   foo3[Int]
 }

--- a/test/files/neg/t7157/Impls_Macros_1.scala
+++ b/test/files/neg/t7157/Impls_Macros_1.scala
@@ -5,28 +5,28 @@ object Macros {
   def impl1_0_0(c: Context)() = { import c.universe._; c.Expr[Unit](q"""println("hello world")""") }
   def impl1_1_1(c: Context)(x: c.Expr[Int]) = { import c.universe._; c.Expr[Unit](q"""println("hello world")""") }
   def impl1_2_2(c: Context)(x: c.Expr[Int], y: c.Expr[Int]) = { import c.universe._; c.Expr[Unit](q"""println("hello world")""") }
-  def m1_0_0() = macro impl1_0_0
-  def m1_1_1(x: Int) = macro impl1_1_1
-  def m1_2_2(x: Int, y: Int) = macro impl1_2_2
+  def m1_0_0(): Unit = macro impl1_0_0
+  def m1_1_1(x: Int): Unit = macro impl1_1_1
+  def m1_2_2(x: Int, y: Int): Unit = macro impl1_2_2
 
   def impl1_0_inf(c: Context)(x: c.Expr[Int]*) = { import c.universe._; c.Expr[Unit](q"""println("hello world")""") }
   def impl1_1_inf(c: Context)(x: c.Expr[Int], y: c.Expr[Int]*) = { import c.universe._; c.Expr[Unit](q"""println("hello world")""") }
   def impl1_2_inf(c: Context)(x: c.Expr[Int], y: c.Expr[Int], z: c.Expr[Int]*) = { import c.universe._; c.Expr[Unit](q"""println("hello world")""") }
-  def m1_0_inf(x: Int*) = macro impl1_0_inf
-  def m1_1_inf(x: Int, y: Int*) = macro impl1_1_inf
-  def m1_2_inf(x: Int, y: Int, z: Int*) = macro impl1_2_inf
+  def m1_0_inf(x: Int*): Unit = macro impl1_0_inf
+  def m1_1_inf(x: Int, y: Int*): Unit = macro impl1_1_inf
+  def m1_2_inf(x: Int, y: Int, z: Int*): Unit = macro impl1_2_inf
 
   def impl2_0_0(c: Context)()() = { import c.universe._; c.Expr[Unit](q"""println("hello world")""") }
   def impl2_1_1(c: Context)()(x: c.Expr[Int]) = { import c.universe._; c.Expr[Unit](q"""println("hello world")""") }
   def impl2_2_2(c: Context)()(x: c.Expr[Int], y: c.Expr[Int]) = { import c.universe._; c.Expr[Unit](q"""println("hello world")""") }
-  def m2_0_0()() = macro impl2_0_0
-  def m2_1_1()(x: Int) = macro impl2_1_1
-  def m2_2_2()(x: Int, y: Int) = macro impl2_2_2
+  def m2_0_0()(): Unit = macro impl2_0_0
+  def m2_1_1()(x: Int): Unit = macro impl2_1_1
+  def m2_2_2()(x: Int, y: Int): Unit = macro impl2_2_2
 
   def impl2_0_inf(c: Context)()(x: c.Expr[Int]*) = { import c.universe._; c.Expr[Unit](q"""println("hello world")""") }
   def impl2_1_inf(c: Context)()(x: c.Expr[Int], y: c.Expr[Int]*) = { import c.universe._; c.Expr[Unit](q"""println("hello world")""") }
   def impl2_2_inf(c: Context)()(x: c.Expr[Int], y: c.Expr[Int], z: c.Expr[Int]*) = { import c.universe._; c.Expr[Unit](q"""println("hello world")""") }
-  def m2_0_inf()(x: Int*) = macro impl2_0_inf
-  def m2_1_inf()(x: Int, y: Int*) = macro impl2_1_inf
-  def m2_2_inf()(x: Int, y: Int, z: Int*) = macro impl2_2_inf
+  def m2_0_inf()(x: Int*): Unit = macro impl2_0_inf
+  def m2_1_inf()(x: Int, y: Int*): Unit = macro impl2_1_inf
+  def m2_2_inf()(x: Int, y: Int, z: Int*): Unit = macro impl2_2_inf
 }

--- a/test/files/pos/annotated-original/M_1.scala
+++ b/test/files/pos/annotated-original/M_1.scala
@@ -3,5 +3,5 @@ import scala.reflect.macros.blackbox.Context
 
 object M {
   def impl(c: Context)(a: c.Expr[Any]) = c.Expr[Any](c.untypecheck(a.tree))
-  def m(a: Any) = macro impl
+  def m(a: Any): Any = macro impl
 }

--- a/test/files/pos/attachments-typed-another-ident/Impls_1.scala
+++ b/test/files/pos/attachments-typed-another-ident/Impls_1.scala
@@ -14,5 +14,5 @@ object Macros {
     c.Expr[Int](typed)
   }
 
-  def foo = macro impl
+  def foo: Int = macro impl
 }

--- a/test/files/pos/attachments-typed-ident/Impls_1.scala
+++ b/test/files/pos/attachments-typed-ident/Impls_1.scala
@@ -14,5 +14,5 @@ object Macros {
     c.Expr[Int](typed)
   }
 
-  def foo = macro impl
+  def foo: Int = macro impl
 }

--- a/test/files/pos/macro-qmarkqmarkqmark.scala
+++ b/test/files/pos/macro-qmarkqmarkqmark.scala
@@ -1,7 +1,7 @@
 import language.experimental.macros
 
 object Macros {
-  def foo1 = macro ???
-  def foo2(x: Int) = macro ???
-  def foo3[T] = macro ???
+  def foo1: Nothing = macro ???
+  def foo2(x: Int): Nothing = macro ???
+  def foo3[T]: Nothing = macro ???
 }

--- a/test/files/pos/t5692a/Macros_1.scala
+++ b/test/files/pos/t5692a/Macros_1.scala
@@ -3,5 +3,5 @@ import language.experimental.macros
 
 object Macros {
   def impl[T](c: Context) = { import c.universe._; c.Expr[Unit](q"()") }
-  def foo[T] = macro impl[T]
+  def foo[T]: Unit = macro impl[T]
 }

--- a/test/files/pos/t5692b/Macros_1.scala
+++ b/test/files/pos/t5692b/Macros_1.scala
@@ -3,5 +3,5 @@ import language.experimental.macros
 
 object Macros {
   def impl[T, U](c: Context) = { import c.universe._; c.Expr[Unit](q"()") }
-  def foo[T, U] = macro impl[T, U]
+  def foo[T, U]: Unit = macro impl[T, U]
 }

--- a/test/files/pos/t5706.scala
+++ b/test/files/pos/t5706.scala
@@ -3,8 +3,8 @@ import scala.reflect.macros.whitebox.{Context => WhiteboxContext}
 import language.experimental.macros
 
 class Logger {
-  def error1(message: String) = macro Impls.error1
-  def error2(message: String) = macro Impls.error2
+  def error1(message: String): Unit = macro Impls.error1
+  def error2(message: String): Unit = macro Impls.error2
 }
 
 object Impls {

--- a/test/files/pos/t5744/Macros_1.scala
+++ b/test/files/pos/t5744/Macros_1.scala
@@ -2,8 +2,8 @@ import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 
 object Macros {
-  def foo[U: Numeric](x: U) = macro foo_impl[U]
-  def bar[U: Numeric : Equiv, Y <% String](x: U)(implicit s: String) = macro bar_impl[U, Y]
+  def foo[U: Numeric](x: U): Unit = macro foo_impl[U]
+  def bar[U: Numeric : Equiv, Y <% String](x: U)(implicit s: String): Unit = macro bar_impl[U, Y]
 
   def foo_impl[U](c: Context)(x: c.Expr[U])(numeric: c.Expr[Numeric[U]]) = {
     import c.universe._

--- a/test/files/pos/t6485a/Test_2.scala
+++ b/test/files/pos/t6485a/Test_2.scala
@@ -1,5 +1,5 @@
 import scala.language.experimental.macros
 
 final class Ops[T](val x: T) extends AnyVal {
-  def f = macro Macros.crash
+  def f: Unit = macro Macros.crash
 }

--- a/test/files/pos/t6485b/Test.scala
+++ b/test/files/pos/t6485b/Test.scala
@@ -2,7 +2,7 @@ import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 
 final class Ops[T](val x: T) extends AnyVal {
-  def f = macro Macros.crash
+  def f: Unit = macro Macros.crash
 }
 
 object Macros {

--- a/test/files/pos/t6516.scala
+++ b/test/files/pos/t6516.scala
@@ -5,7 +5,7 @@ import scala.collection.IterableOps
 // This one compiles
 object Test {
   type Alias[T, CC[_]] = Context { type PrefixType = IterableOps[T, CC, CC[T]] }
-  def f() = macro f_impl
+  def f(): Nothing = macro f_impl
   def f_impl(c: Alias[Int, List])() = ???
 }
 
@@ -14,6 +14,6 @@ object Test2 {
   type Ctx = scala.reflect.macros.blackbox.Context
   type Alias[T, CC[_]] = Ctx { type PrefixType = IterableOps[T, CC, CC[T]] }
 
-  def f() = macro f_impl
+  def f(): Nothing = macro f_impl
   def f_impl(c: Alias[Int, List])() = ???
 }

--- a/test/files/pos/t7461/Macros_1.scala
+++ b/test/files/pos/t7461/Macros_1.scala
@@ -9,5 +9,5 @@ object Macros {
     c.Expr[Unit](q"()")
   }
 
-  def foo = macro impl
+  def foo: Unit = macro impl
 }

--- a/test/files/run/macro-abort-fresh/Macros_1.scala
+++ b/test/files/run/macro-abort-fresh/Macros_1.scala
@@ -11,5 +11,5 @@ object Impls {
 }
 
 object Macros {
-  def foo = macro Impls.impl
+  def foo: Nothing = macro Impls.impl
 }

--- a/test/files/run/macro-auto-duplicate/Macros_1.scala
+++ b/test/files/run/macro-auto-duplicate/Macros_1.scala
@@ -13,5 +13,5 @@ object Macros {
     c.Expr[String](Apply(Select(xs2, newTermName("$plus")), List(xi4)))
   }
 
-  def foo = macro impl
+  def foo: String = macro impl
 }

--- a/test/files/run/macro-bundle-static/Impls_Macros_1.scala
+++ b/test/files/run/macro-bundle-static/Impls_Macros_1.scala
@@ -5,13 +5,13 @@ object Enclosing {
   class Impl(val c: Context) {
     def mono = { import c.universe._; c.Expr[Unit](q"()") }
     def poly[T: c.WeakTypeTag] = { import c.universe._; c.Expr[String](q"${c.weakTypeOf[T].toString}") }
-    def weird = macro mono
+    def weird: Unit = macro mono
   }
 }
 
 object Macros {
-  def mono = macro Enclosing.Impl.mono
-  def poly[T] = macro Enclosing.Impl.poly[T]
+  def mono: Unit = macro Enclosing.Impl.mono
+  def poly[T]: String = macro Enclosing.Impl.poly[T]
 }
 
 package pkg {
@@ -19,12 +19,12 @@ package pkg {
     class Impl(val c: Context) {
       def mono = { import c.universe._; c.Expr[Boolean](q"true") }
       def poly[T: c.WeakTypeTag] = { import c.universe._; c.Expr[String](q"${c.weakTypeOf[T].toString + c.weakTypeOf[T].toString}") }
-      def weird = macro mono
+      def weird: Boolean = macro mono
     }
   }
 
   object Macros {
-    def mono = macro Enclosing.Impl.mono
-    def poly[T] = macro Enclosing.Impl.poly[T]
+    def mono: Boolean = macro Enclosing.Impl.mono
+    def poly[T]: String = macro Enclosing.Impl.poly[T]
   }
 }

--- a/test/files/run/macro-bundle-toplevel.flags
+++ b/test/files/run/macro-bundle-toplevel.flags
@@ -1,1 +1,0 @@
--language:experimental.macros

--- a/test/files/run/macro-bundle-toplevel/Impls_Macros_1.scala
+++ b/test/files/run/macro-bundle-toplevel/Impls_Macros_1.scala
@@ -1,25 +1,26 @@
+import language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 
 class Impl(val c: Context) {
   def mono = { import c.universe._; c.Expr[Unit](q"()") }
   def poly[T: c.WeakTypeTag] = { import c.universe._; c.Expr[String](q"${c.weakTypeOf[T].toString}") }
-  def weird = macro mono
+  def weird: Unit = macro mono
 }
 
 object Macros {
-  def mono = macro Impl.mono
-  def poly[T] = macro Impl.poly[T]
+  def mono: Unit = macro Impl.mono
+  def poly[T]: String = macro Impl.poly[T]
 }
 
 package pkg {
   class Impl(val c: Context) {
     def mono = { import c.universe._; c.Expr[Boolean](q"true") }
     def poly[T: c.WeakTypeTag] = { import c.universe._; c.Expr[String](q"${c.weakTypeOf[T].toString + c.weakTypeOf[T].toString}") }
-    def weird = macro mono
+    def weird: Boolean = macro mono
   }
 
   object Macros {
-    def mono = macro Impl.mono
-    def poly[T] = macro Impl.poly[T]
+    def mono: Boolean = macro Impl.mono
+    def poly[T]: String = macro Impl.poly[T]
   }
 }

--- a/test/files/run/macro-bundle-whitebox-decl/Impls_Macros_1.scala
+++ b/test/files/run/macro-bundle-whitebox-decl/Impls_Macros_1.scala
@@ -4,23 +4,23 @@ import scala.reflect.macros.whitebox.Context
 class Impl(val c: Context) {
   def mono = { import c.universe._; c.Expr[Unit](q"()") }
   def poly[T: c.WeakTypeTag] = { import c.universe._; c.Expr[String](q"${c.weakTypeOf[T].toString}") }
-  def weird = macro mono
+  def weird: Unit = macro mono
 }
 
 object Macros {
-  def mono = macro Impl.mono
-  def poly[T] = macro Impl.poly[T]
+  def mono: Unit = macro Impl.mono
+  def poly[T]: String = macro Impl.poly[T]
 }
 
 package pkg {
   class Impl(val c: Context) {
     def mono = { import c.universe._; c.Expr[Boolean](q"true") }
     def poly[T: c.WeakTypeTag] = { import c.universe._; c.Expr[String](q"${c.weakTypeOf[T].toString + c.weakTypeOf[T].toString}") }
-    def weird = macro mono
+    def weird: Boolean = macro mono
   }
 
   object Macros {
-    def mono = macro Impl.mono
-    def poly[T] = macro Impl.poly[T]
+    def mono: Boolean = macro Impl.mono
+    def poly[T]: String = macro Impl.poly[T]
   }
 }

--- a/test/files/run/macro-duplicate/Impls_Macros_1.scala
+++ b/test/files/run/macro-duplicate/Impls_Macros_1.scala
@@ -25,5 +25,5 @@ object Macros {
     c.Expr[Unit](Block(cdef1 :: Nil, Literal(Constant(()))))
   }
 
-  def foo = macro impl
+  def foo: Unit = macro impl
 }

--- a/test/files/run/macro-expand-implicit-argument/Macros_1.scala
+++ b/test/files/run/macro-expand-implicit-argument/Macros_1.scala
@@ -19,7 +19,7 @@ object Macros {
    *
    * "As seen on scala-internals!"
    */
-  def array[A](as:A*)(implicit ct: ClassTag[A]) = macro arrayMacro[A]
+  def array[A](as:A*)(implicit ct: ClassTag[A]): Array[A] = macro arrayMacro[A]
 
   /**
    * Takes in something like:

--- a/test/files/run/macro-expand-tparams-prefix/Impls_1.scala
+++ b/test/files/run/macro-expand-tparams-prefix/Impls_1.scala
@@ -33,7 +33,7 @@ object Impls345 {
 object Macros4 {
   class D[T] {
     class C[U] {
-      def foo[V] = macro Impls345.foo[T, U, V]
+      def foo[V]: Unit = macro Impls345.foo[T, U, V]
     }
   }
 }

--- a/test/files/run/macro-impl-default-params/Impls_Macros_1.scala
+++ b/test/files/run/macro-impl-default-params/Impls_Macros_1.scala
@@ -16,5 +16,5 @@ object Impls {
 }
 
 class Macros[T] {
-  def foo_targs[U](x: Int) = macro Impls.foo_targs[T, U]
+  def foo_targs[U](x: Int): Unit = macro Impls.foo_targs[T, U]
 }

--- a/test/files/run/macro-impl-rename-context/Impls_Macros_1.scala
+++ b/test/files/run/macro-impl-rename-context/Impls_Macros_1.scala
@@ -8,5 +8,5 @@ object Impls {
 }
 
 object Macros {
-  def foo(x: Int) = macro Impls.foo
+  def foo(x: Int): Unit = macro Impls.foo
 }

--- a/test/files/run/macro-invalidret-nontypeable/Impls_Macros_1.scala
+++ b/test/files/run/macro-invalidret-nontypeable/Impls_Macros_1.scala
@@ -9,5 +9,5 @@ object Impls {
 }
 
 object Macros {
-  def foo = macro Impls.foo
+  def foo: Int = macro Impls.foo
 }

--- a/test/files/run/macro-invalidusage-badret/Impls_Macros_1.scala
+++ b/test/files/run/macro-invalidusage-badret/Impls_Macros_1.scala
@@ -5,5 +5,5 @@ object Impls {
 }
 
 object Macros {
-  def foo(x: Int) = macro Impls.foo
+  def foo(x: Int): Int = macro Impls.foo
 }

--- a/test/files/run/macro-invalidusage-partialapplication-with-tparams/Impls_Macros_1.scala
+++ b/test/files/run/macro-invalidusage-partialapplication-with-tparams/Impls_Macros_1.scala
@@ -9,5 +9,5 @@ object Impls {
 }
 
 object Macros {
-  def foo[T](x: T) = macro Impls.foo[T]
+  def foo[T](x: T): Unit = macro Impls.foo[T]
 }

--- a/test/files/run/macro-invalidusage-partialapplication/Impls_Macros_1.scala
+++ b/test/files/run/macro-invalidusage-partialapplication/Impls_Macros_1.scala
@@ -10,5 +10,5 @@ object Impls {
 }
 
 object Macros {
-  def foo(x: Int)(y: Int) = macro Impls.foo
+  def foo(x: Int)(y: Int): Unit = macro Impls.foo
 }

--- a/test/files/run/macro-openmacros/Impls_Macros_1.scala
+++ b/test/files/run/macro-openmacros/Impls_Macros_1.scala
@@ -21,5 +21,5 @@ object Macros {
     }
   }
 
-  def foo = macro impl
+  def foo: Unit = macro impl
 }

--- a/test/files/run/macro-quasiinvalidbody-c/Impls_Macros_1.scala
+++ b/test/files/run/macro-quasiinvalidbody-c/Impls_Macros_1.scala
@@ -5,5 +5,5 @@ object Macros {
     def foo(c: Context)(x: c.Expr[Any]) = x
   }
 
-  def foo(x: Any) = macro Impls.foo
+  def foo(x: Any): Any = macro Impls.foo
 }

--- a/test/files/run/macro-reflective-ma-normal-mdmi/Impls_Macros_1.scala
+++ b/test/files/run/macro-reflective-ma-normal-mdmi/Impls_Macros_1.scala
@@ -9,5 +9,5 @@ object Impls {
 }
 
 object Macros {
-  def foo(x: Int) = macro Impls.foo
+  def foo(x: Int): Int = macro Impls.foo
 }

--- a/test/files/run/macro-reify-basic/Macros_1.scala
+++ b/test/files/run/macro-reify-basic/Macros_1.scala
@@ -1,7 +1,7 @@
 import scala.reflect.macros.blackbox.Context
 
 object Macros {
-  def foo(s: String) = macro Impls.foo
+  def foo(s: String): Unit = macro Impls.foo
 
   object Impls {
     def foo(c: Context)(s: c.Expr[String]) = c.universe.reify {

--- a/test/files/run/macro-reify-splice-outside-reify/Impls_Macros_1.scala
+++ b/test/files/run/macro-reify-splice-outside-reify/Impls_Macros_1.scala
@@ -9,5 +9,5 @@ object Impls {
 }
 
 object Macros {
-  def foo(x: Int) = macro Impls.foo
+  def foo(x: Int): Int = macro Impls.foo
 }

--- a/test/files/run/macro-reify-staticXXX/Macros_1.scala
+++ b/test/files/run/macro-reify-staticXXX/Macros_1.scala
@@ -26,7 +26,7 @@ object packageless {
     }
   }
 
-  def test = macro impl
+  def test: Any = macro impl
 }
 
 package packageful {
@@ -43,6 +43,6 @@ package packageful {
       }
     }
 
-    def test = macro impl
+    def test: Any = macro impl
   }
 }

--- a/test/files/run/macro-reify-tagful-a/Macros_1.scala
+++ b/test/files/run/macro-reify-tagful-a/Macros_1.scala
@@ -2,7 +2,7 @@ import scala.reflect.runtime.universe._
 import scala.reflect.macros.blackbox.Context
 
 object Macros {
-  def foo[T](s: T) = macro Impls.foo[T]
+  def foo[T](s: T): List[T] = macro Impls.foo[T]
 
   object Impls {
     def foo[T: c.WeakTypeTag](c: Context)(s: c.Expr[T]) = c.universe.reify {

--- a/test/files/run/macro-reify-tagless-a/Impls_Macros_1.scala
+++ b/test/files/run/macro-reify-tagless-a/Impls_Macros_1.scala
@@ -1,7 +1,7 @@
 import scala.reflect.macros.blackbox.Context
 
 object Macros {
-  def foo[T](s: T) = macro Impls.foo[T]
+  def foo[T](s: T): List[T] = macro Impls.foo[T]
 
   object Impls {
     def foo[T](c: Context)(s: c.Expr[T]) = c.universe.reify {

--- a/test/files/run/macro-reify-unreify/Macros_1.scala
+++ b/test/files/run/macro-reify-unreify/Macros_1.scala
@@ -1,7 +1,7 @@
 import scala.reflect.macros.blackbox.Context
 
 object Macros {
-  def foo(s: String) = macro Impls.foo
+  def foo(s: String): Unit = macro Impls.foo
 
   object Impls {
     def foo(c: Context)(s: c.Expr[String]) = {

--- a/test/files/run/macro-repl-dontexpand.check
+++ b/test/files/run/macro-repl-dontexpand.check
@@ -2,13 +2,13 @@
 scala> def bar1(c: scala.reflect.macros.blackbox.Context) = ???
 bar1: (c: scala.reflect.macros.blackbox.Context)Nothing
 
-scala> def foo1 = macro bar1
+scala> def foo1: Nothing = macro bar1
 defined term macro foo1: Nothing
 
 scala> def bar2(c: scala.reflect.macros.whitebox.Context) = ???
 bar2: (c: scala.reflect.macros.whitebox.Context)Nothing
 
-scala> def foo2 = macro bar2
+scala> def foo2: Nothing = macro bar2
 defined term macro foo2: Nothing
 
 scala> :quit

--- a/test/files/run/macro-repl-dontexpand.scala
+++ b/test/files/run/macro-repl-dontexpand.scala
@@ -4,8 +4,8 @@ object Test extends ReplTest {
   override def extraSettings = "-language:experimental.macros"
   def code = """
     |def bar1(c: scala.reflect.macros.blackbox.Context) = ???
-    |def foo1 = macro bar1
+    |def foo1: Nothing = macro bar1
     |def bar2(c: scala.reflect.macros.whitebox.Context) = ???
-    |def foo2 = macro bar2
+    |def foo2: Nothing = macro bar2
     |""".stripMargin
 }

--- a/test/files/run/macro-settings/Impls_Macros_1.scala
+++ b/test/files/run/macro-settings/Impls_Macros_1.scala
@@ -10,5 +10,5 @@ object Impls {
 }
 
 object Macros {
-  def foo = macro Impls.impl
+  def foo: Unit = macro Impls.impl
 }

--- a/test/files/run/macro-term-declared-in-annotation/Macros_2.scala
+++ b/test/files/run/macro-term-declared-in-annotation/Macros_2.scala
@@ -3,6 +3,6 @@ class foo(val bar: String) extends annotation.StaticAnnotation
 object Api {
   // foo in ann must have a different name
   // otherwise, we get bitten by https://github.com/scala/bug/issues/5544
-  @foo({def fooInAnn = macro Impls.foo; fooInAnn})
+  @foo({def fooInAnn: String = macro Impls.foo; fooInAnn})
   def foo = println("it works")
 }

--- a/test/files/run/macro-term-declared-in-implicit-class/Impls_Macros_1.scala
+++ b/test/files/run/macro-term-declared-in-implicit-class/Impls_Macros_1.scala
@@ -14,6 +14,6 @@ object Macros {
   implicit def foo(x: String): Foo = new Foo(x)
 
   class Foo(val x: String) {
-    def toOptionOfInt = macro Impls.toOptionOfInt
+    def toOptionOfInt: Option[Int] = macro Impls.toOptionOfInt
   }
 }

--- a/test/files/run/macro-typecheck-implicitsdisabled/Impls_Macros_1.scala
+++ b/test/files/run/macro-typecheck-implicitsdisabled/Impls_Macros_1.scala
@@ -9,7 +9,7 @@ object Macros {
     c.Expr[String](Literal(Constant(ttree1.toString)))
   }
 
-  def foo_with_implicits_enabled = macro impl_with_implicits_enabled
+  def foo_with_implicits_enabled: String = macro impl_with_implicits_enabled
 
   def impl_with_implicits_disabled(c: Context) = {
     import c.universe._
@@ -24,5 +24,5 @@ object Macros {
     }
   }
 
-  def foo_with_implicits_disabled = macro impl_with_implicits_disabled
+  def foo_with_implicits_disabled: String = macro impl_with_implicits_disabled
 }

--- a/test/files/run/macro-typecheck-macrosdisabled/Impls_Macros_1.scala
+++ b/test/files/run/macro-typecheck-macrosdisabled/Impls_Macros_1.scala
@@ -10,7 +10,7 @@ object Macros {
     c.Expr[String](Literal(Constant(ttree1.toString)))
   }
 
-  def foo_with_macros_enabled = macro impl_with_macros_enabled
+  def foo_with_macros_enabled: String = macro impl_with_macros_enabled
 
   def impl_with_macros_disabled(c: Context) = {
     import c.universe._
@@ -27,5 +27,5 @@ object Macros {
     c.Expr[String](Literal(Constant(ttree2.toString)))
   }
 
-  def foo_with_macros_disabled = macro impl_with_macros_disabled
+  def foo_with_macros_disabled: String = macro impl_with_macros_disabled
 }

--- a/test/files/run/macro-typecheck-macrosdisabled2/Impls_Macros_1.scala
+++ b/test/files/run/macro-typecheck-macrosdisabled2/Impls_Macros_1.scala
@@ -10,7 +10,7 @@ object Macros {
     c.Expr[String](Literal(Constant(ttree1.toString)))
   }
 
-  def foo_with_macros_enabled = macro impl_with_macros_enabled
+  def foo_with_macros_enabled: String = macro impl_with_macros_enabled
 
   def impl_with_macros_disabled(c: Context) = {
     import c.universe._
@@ -27,5 +27,5 @@ object Macros {
     c.Expr[String](Literal(Constant(ttree2.toString)))
   }
 
-  def foo_with_macros_disabled = macro impl_with_macros_disabled
+  def foo_with_macros_disabled: String = macro impl_with_macros_disabled
 }

--- a/test/files/run/macro-undetparams-macroitself/Impls_Macros_1.scala
+++ b/test/files/run/macro-undetparams-macroitself/Impls_Macros_1.scala
@@ -7,5 +7,5 @@ object Macros {
     reify { println(c.Expr[String](Literal(Constant(implicitly[c.WeakTypeTag[T]].toString))).splice) }
   }
 
-  def foo[T](foo: T) = macro impl[T]
+  def foo[T](foo: T): Unit = macro impl[T]
 }

--- a/test/files/run/t5753_1/Impls_Macros_1.scala
+++ b/test/files/run/t5753_1/Impls_Macros_1.scala
@@ -6,5 +6,5 @@ trait Impls {
 }
 
 object Macros extends Impls {
-    def foo(x: Any) = macro impl
+    def foo(x: Any): Any = macro impl
 }

--- a/test/files/run/t5753_2/Impls_Macros_1.scala
+++ b/test/files/run/t5753_2/Impls_Macros_1.scala
@@ -5,6 +5,6 @@ trait Macro_T {
 }
 
 object Macros {
-  def foo[T](s: T) = macro Impls.foo[T]
+  def foo[T](s: T): T = macro Impls.foo[T]
   object Impls extends Macro_T
 }

--- a/test/files/run/t7008-scala-defined/Impls_Macros_2.scala
+++ b/test/files/run/t7008-scala-defined/Impls_Macros_2.scala
@@ -9,5 +9,5 @@ object Macros {
     reify(println(c.Expr[String](Literal(Constant(s))).splice))
   }
 
-  def foo = macro impl
+  def foo: Unit = macro impl
 }

--- a/test/files/run/t7008/Impls_Macros_2.scala
+++ b/test/files/run/t7008/Impls_Macros_2.scala
@@ -9,5 +9,5 @@ object Macros {
     reify(println(c.Expr[String](Literal(Constant(s))).splice))
   }
 
-  def foo = macro impl
+  def foo: Unit = macro impl
 }

--- a/test/files/run/t7047/Impls_Macros_1.scala
+++ b/test/files/run/t7047/Impls_Macros_1.scala
@@ -15,5 +15,5 @@ object Macros {
     c.Expr[Null](Literal(Constant(null)))
   }
 
-  def foo = macro impl
+  def foo: Any = macro impl
 }

--- a/test/files/run/t7375b/Macros_1.scala
+++ b/test/files/run/t7375b/Macros_1.scala
@@ -8,7 +8,7 @@ object Macros {
   type F1 = C1
   type F2 = C2
 
-  def foo = macro impl
+  def foo: Unit = macro impl
   def impl(c: Context) = {
     import c.universe._
     def test[T: c.TypeTag] = reify(println(c.Expr[String](Literal(Constant(c.reifyRuntimeClass(c.typeOf[T]).toString))).splice)).tree

--- a/test/files/run/typed-annotated/Macros_1.scala
+++ b/test/files/run/typed-annotated/Macros_1.scala
@@ -13,5 +13,5 @@ object Macros {
       Apply(Ident(newTermName("println")), List(Ident(newTermName("x"))))))
   }
 
-  def foo = macro impl
+  def foo: Unit = macro impl
 }


### PR DESCRIPTION
The previous warning already expired.
    
Fix offending tests.

Apologies in advance if there's a good reason the stern warning was never followed up.
