### PR TITLE
[#11017] Various Map.WithDefault classes expose the more specific WithDefault class as return type of concat method

### DIFF
--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -5,7 +5,6 @@ import scala.language.{higherKinds, implicitConversions}
 import scala.annotation.unchecked.uncheckedVariance
 import scala.math.{Numeric, Ordering}
 import scala.reflect.ClassTag
-import java.lang.{StringBuilder => JStringBuilder}
 import scala.collection.mutable.StringBuilder
 
 /**

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -153,6 +153,9 @@ object Map extends MapFactory[Map] {
 
     override def mapFactory: MapFactory[Map] = underlying.mapFactory
 
+    override def concat [V2 >: V](xs: collection.Iterable[(K, V2)]): WithDefault[K, V2] =
+      new WithDefault(underlying.concat(xs), defaultValue)
+
     def remove(key: K): WithDefault[K, V] = new WithDefault[K, V](underlying.remove(key), defaultValue)
 
     def updated[V1 >: V](key: K, value: V1): WithDefault[K, V1] =

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -96,8 +96,10 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
     override def updated[V1 >: V](key: K, value: V1): WithDefault[K, V1] =
       new WithDefault[K, V1](underlying.updated(key, value), defaultValue)
 
-    override def remove(key: K): WithDefault[K, V] =
-      new WithDefault[K, V](underlying.remove(key), defaultValue)
+    override def concat [V2 >: V](xs: collection.Iterable[(K, V2)]): WithDefault[K, V2] =
+      new WithDefault( underlying.concat(xs) , defaultValue)
+
+    override def remove(key: K): WithDefault[K, V] = new WithDefault[K, V](underlying.remove(key), defaultValue)
 
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -2,7 +2,6 @@ package scala
 package collection
 package mutable
 
-import scala.collection.MapFactory
 import scala.language.higherKinds
 
 /** Base type of mutable Maps */
@@ -186,6 +185,9 @@ object Map extends MapFactory.Delegate[Map](HashMap) {
     def subtractOne(elem: K): WithDefault.this.type = { underlying.subtractOne(elem); this }
 
     def addOne(elem: (K, V)): WithDefault.this.type = { underlying.addOne(elem); this }
+
+    override def concat[V2 >: V](suffix: collection.Iterable[(K, V2)]): WithDefault[K, V2] =
+      underlying.concat(suffix).withDefault(defaultValue)
 
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 

--- a/src/library/scala/collection/mutable/SortedMap.scala
+++ b/src/library/scala/collection/mutable/SortedMap.scala
@@ -73,6 +73,9 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 
+    override def concat[V2 >: V](suffix: collection.Iterable[(K, V2)]): WithDefault[K, V2] =
+      underlying.concat(suffix).withDefault(defaultValue)
+
     override protected def fromSpecificIterable(coll: scala.collection.Iterable[(K, V)]): WithDefault[K, V] =
       new WithDefault[K, V](sortedMapFactory.from(coll), defaultValue)
 

--- a/test/files/run/t3326.flags
+++ b/test/files/run/t3326.flags
@@ -1,0 +1,1 @@
+-opt-warnings

--- a/test/junit/scala/collection/immutable/HashMapTest.scala
+++ b/test/junit/scala/collection/immutable/HashMapTest.scala
@@ -68,10 +68,38 @@ class HashMapTest {
     assertEquals("a", m1.getOrElse(1, ???))
     assertEquals("c", m1.getOrElse(3, "c"))
 
-    class Collider { override def hashCode = 0 }
+    class Collider {
+      override def hashCode = 0
+    }
     val a, b, c = new Collider
     val m2 = HashMap(a -> "a", b -> "b")
     assertEquals("a", m2.getOrElse(a, ???))
     assertEquals("c", m2.getOrElse(c, "c"))
+  }
+
+  @Test
+  def testWithDefault: Unit = {
+    val m1 = HashMap(1 -> "a", 2 -> "b")
+
+    val m2: Map.WithDefault[Int, String] =
+      m1.withDefault(i => (i + 1).toString)
+        .updated(1, "aa")
+        .updated(100, "bb")
+        .concat(List(500 -> "c", 501 -> "c"))
+
+    assertEquals(m2(1), "aa")
+    assertEquals(m2(2), "b")
+    assertEquals(m2(3), "4")
+    assertEquals(m2(4), "5")
+    assertEquals(m2(500), "c")
+    assertEquals(m2(501), "c")
+    assertEquals(m2(502), "503")
+
+    val m3: Map.WithDefault[Int, String] = m2 - 1
+    assertEquals(m3(1), "2")
+
+    val m4: Map.WithDefault[Int, String] = m3 -- List(2, 100)
+    assertEquals(m4(2), "3")
+    assertEquals(m4(100), "101")
   }
 }

--- a/test/junit/scala/collection/immutable/SortedMapTest.scala
+++ b/test/junit/scala/collection/immutable/SortedMapTest.scala
@@ -106,4 +106,36 @@ class SortedMapTest {
   private def defaultValueFunction: Int => String = {
     i => s"$i is not present in this map"
   }
+  @Test
+  def testWithDefaultValue: Unit = {
+    val m1 = SortedMap(1 -> "a", 2 -> "b")
+    val m2 = m1.withDefaultValue(0)
+    assertEquals("a", m2(1))
+    assertEquals(0, m2(3))
+  }
+  @Test
+  def testWithDefault: Unit = {
+    val m1 = SortedMap(1 -> "a", 2 -> "b")
+
+    val m2: Map.WithDefault[Int, String] =
+      m1.withDefault(i => (i + 1).toString)
+        .updated(1, "aa")
+        .updated(100, "bb")
+        .concat(List(500 -> "c", 501 -> "c"))
+
+    assertEquals(m2(1), "aa")
+    assertEquals(m2(2), "b")
+    assertEquals(m2(3), "4")
+    assertEquals(m2(4), "5")
+    assertEquals(m2(500), "c")
+    assertEquals(m2(501), "c")
+    assertEquals(m2(502), "503")
+
+    val m3: Map.WithDefault[Int, String] = m2 - 1
+    assertEquals(m3(1), "2")
+
+    val m4: Map.WithDefault[Int, String] = m3 -- List(2, 100)
+    assertEquals(m4(2), "3")
+    assertEquals(m4(100), "101")
+  }
 }

--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -23,4 +23,36 @@ class TreeMapTest {
     val m = TreeMap("a" -> "a")
     assertSame(m, TreeMap.from(m))
   }
+  @Test
+  def testWithDefaultValue: Unit = {
+    val m1 = TreeMap(1 -> "a", 2 -> "b")
+    val m2 = m1.withDefaultValue(0)
+    assertEquals("a", m2(1))
+    assertEquals(0, m2(3))
+  }
+  @Test
+  def testWithDefault: Unit = {
+    val m1 = TreeMap(1 -> "a", 2 -> "b")
+
+    val m2: Map.WithDefault[Int, String] =
+      m1.withDefault(i => (i + 1).toString)
+        .updated(1, "aa")
+        .updated(100, "bb")
+        .concat(List(500 -> "c", 501 -> "c"))
+
+    assertEquals(m2(1), "aa")
+    assertEquals(m2(2), "b")
+    assertEquals(m2(3), "4")
+    assertEquals(m2(4), "5")
+    assertEquals(m2(500), "c")
+    assertEquals(m2(501), "c")
+    assertEquals(m2(502), "503")
+
+    val m3: Map.WithDefault[Int, String] = m2 - 1
+    assertEquals(m3(1), "2")
+
+    val m4: Map.WithDefault[Int, String] = m3 -- List(2, 100)
+    assertEquals(m4(2), "3")
+    assertEquals(m4(100), "101")
+  }
 }

--- a/test/junit/scala/collection/mutable/HashMapTest.scala
+++ b/test/junit/scala/collection/mutable/HashMapTest.scala
@@ -56,4 +56,58 @@ class HashMapTest {
     assertEquals("a", gotItAll.getOrElse("a", "b"))
     assertEquals("a", gotItAll.getOrElseUpdate("a", "b"))
   }
+  @Test
+  def testWithDefaultValue: Unit = {
+    val m1 = mutable.HashMap(1 -> "a", 2 -> "b")
+    val m2 = m1.withDefaultValue("")
+
+    assertEquals(m2(1), "a")
+    assertEquals(m2(3), "")
+
+    m2 += (3 -> "c")
+    assertEquals(m2(3), "c")
+    assertEquals(m2(4), "")
+
+    m2 ++= List(4 -> "d", 5 -> "e", 6 -> "f")
+    assertEquals(m2(3), "c")
+    assertEquals(m2(4), "d")
+    assertEquals(m2(5), "e")
+    assertEquals(m2(6), "f")
+    assertEquals(m2(7), "")
+
+    m2 --= List(3, 4, 5)
+    assertEquals(m2(3), "")
+    assertEquals(m2(4), "")
+    assertEquals(m2(5), "")
+    assertEquals(m2(6), "f")
+    assertEquals(m2(7), "")
+
+    val m3 = m2 ++ List(3 -> "333")
+    assertEquals(m2(3), "")
+    assertEquals(m3(3), "333")
+  }
+  @Test
+  def testWithDefault: Unit = {
+    val m1 = mutable.HashMap(1 -> "a", 2 -> "b")
+
+    val m2: mutable.Map.WithDefault[Int, String] = m1.withDefault(i => (i + 1).toString)
+    m2.update(1, "aa")
+    m2.update(100, "bb")
+    m2.addAll(List(500 -> "c", 501 -> "c"))
+
+    assertEquals(m2(1), "aa")
+    assertEquals(m2(2), "b")
+    assertEquals(m2(3), "4")
+    assertEquals(m2(4), "5")
+    assertEquals(m2(500), "c")
+    assertEquals(m2(501), "c")
+    assertEquals(m2(502), "503")
+
+    val m3: mutable.Map.WithDefault[Int, String] = m2 - 1
+    assertEquals(m3(1), "2")
+
+    val m4: mutable.Map.WithDefault[Int, String] = m3 -- List(2, 100)
+    assertEquals(m4(2), "3")
+    assertEquals(m4(100), "101")
+  }
 }

--- a/test/junit/scala/collection/mutable/SortedMapTest.scala
+++ b/test/junit/scala/collection/mutable/SortedMapTest.scala
@@ -7,6 +7,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.collection.mutable
 import scala.{Option, Unit}
 
 @RunWith(classOf[JUnit4])
@@ -104,5 +105,59 @@ class SortedMapTest {
 
   private def defaultValueFunction: Int => String = {
     i => s"$i is not present in this map"
+  }
+  @Test
+  def testWithDefaultValue: Unit = {
+    val m1 = mutable.SortedMap(1 -> "a", 2 -> "b")
+    val m2 = m1.withDefaultValue("")
+
+    assertEquals(m2(1), "a")
+    assertEquals(m2(3), "")
+
+    m2 += (3 -> "c")
+    assertEquals(m2(3), "c")
+    assertEquals(m2(4), "")
+
+    m2 ++= List(4 -> "d", 5 -> "e", 6 -> "f")
+    assertEquals(m2(3), "c")
+    assertEquals(m2(4), "d")
+    assertEquals(m2(5), "e")
+    assertEquals(m2(6), "f")
+    assertEquals(m2(7), "")
+
+    m2 --= List(3, 4, 5)
+    assertEquals(m2(3), "")
+    assertEquals(m2(4), "")
+    assertEquals(m2(5), "")
+    assertEquals(m2(6), "f")
+    assertEquals(m2(7), "")
+
+    val m3 = m2 ++ List(3 -> "333")
+    assertEquals(m2(3), "")
+    assertEquals(m3(3), "333")
+  }
+  @Test
+  def testWithDefault: Unit = {
+    val m1 = mutable.SortedMap(1 -> "a", 2 -> "b")
+
+    val m2: mutable.Map.WithDefault[Int, String] = m1.withDefault(i => (i + 1).toString)
+    m2.update(1, "aa")
+    m2.update(100, "bb")
+    m2.addAll(List(500 -> "c", 501 -> "c"))
+
+    assertEquals(m2(1), "aa")
+    assertEquals(m2(2), "b")
+    assertEquals(m2(3), "4")
+    assertEquals(m2(4), "5")
+    assertEquals(m2(500), "c")
+    assertEquals(m2(501), "c")
+    assertEquals(m2(502), "503")
+
+    val m3: mutable.Map.WithDefault[Int, String] = m2 - 1
+    assertEquals(m3(1), "2")
+
+    val m4: mutable.Map.WithDefault[Int, String] = m3 -- List(2, 100)
+    assertEquals(m4(2), "3")
+    assertEquals(m4(100), "101")
   }
 }


### PR DESCRIPTION
This overrides all possible methods in various versions of `Map.WithDefault`, to keep the return time as `WithDefault` through transformations (wherever possible).  
  
This nullifies https://github.com/scala/bug/issues/11017

This is an alternative to https://github.com/scala/scala/pull/6941 -- that is, only at most one of these two PR's can be merged.