### PR TITLE
fix ArrayOps#collect parameter name

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -848,7 +848,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *                `pf` to each element on which it is defined and collecting the results.
     *                The order of the elements is preserved.
     */
-  def collect[B : ClassTag](f: PartialFunction[A, B]): Array[B] = {
+  def collect[B : ClassTag](pf: PartialFunction[A, B]): Array[B] = {
     var i = 0
     var matched = true
     def d(x: A): B = {
@@ -858,7 +858,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     val b = ArrayBuilder.make[B]
     while(i < xs.length) {
       matched = true
-      val v = f.applyOrElse(xs(i), d)
+      val v = pf.applyOrElse(xs(i), d)
       if(matched) b += v
       i += 1
     }


### PR DESCRIPTION
<del>or rename parameter name? 🤔 </del>

```
$ git rev-parse HEAD
6ff29f967f84cfe77cf1ff15e9ea343abde586be
$ git grep "def collect\[.*(pf: PartialF" -- src/library/scala/
src/library/scala/Enumeration.scala:    override def collect[B](pf: PartialFunction[Value, B])(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): SortedIterableCC[B] =
src/library/scala/Option.scala:  @inline final def collect[B](pf: PartialFunction[A, B]): Option[B] =
src/library/scala/collection/Iterable.scala:  def collect[B](pf: PartialFunction[A, B]): CC[B] =
src/library/scala/collection/IterableOnce.scala:  def collect[B](pf: PartialFunction[A, B]): CC[B]
src/library/scala/collection/Iterator.scala:  def collect[B](pf: PartialFunction[A, B]): Iterator[B] = new AbstractIterator[B] {
src/library/scala/collection/Map.scala:  def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)]): CC[K2, V2] =
src/library/scala/collection/SortedMap.scala:  def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
src/library/scala/collection/StrictOptimizedIterableOps.scala:  override def collect[B](pf: PartialFunction[A, B]): CC[B] = {
src/library/scala/collection/StrictOptimizedSortedSetOps.scala:  override def collect[B](pf: PartialFunction[A, B])(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] = {
src/library/scala/collection/immutable/IntMap.scala:  def collect[V2](pf: PartialFunction[(Int, T), (Int, V2)]): IntMap[V2] =
src/library/scala/collection/immutable/LazyList.scala:  override final def collect[B](pf: PartialFunction[A, B]): CC[B] = {
src/library/scala/collection/immutable/List.scala:  final override def collect[B](pf: PartialFunction[A, B]): List[B] = {
src/library/scala/collection/immutable/LongMap.scala:  def collect[V2](pf: PartialFunction[(Long, T), (Long, V2)]): LongMap[V2] =
src/library/scala/collection/mutable/AnyRefMap.scala:  def collect[K2 <: AnyRef, V2](pf: PartialFunction[(K with AnyRef, V), (K2, V2)]): AnyRefMap[K2, V2] =
src/library/scala/collection/mutable/LongMap.scala:  def collect[V2](pf: PartialFunction[(Long, V), (Long, V2)]): LongMap[V2] =
src/library/scala/concurrent/Future.scala:  def collect[S](pf: PartialFunction[T, S])(implicit executor: ExecutionContext): Future[S] =
src/library/scala/concurrent/Future.scala:    override def collect[S](pf: PartialFunction[Nothing, S])(implicit executor: ExecutionContext): Future[S] = this
src/library/scala/concurrent/impl/Promise.scala:      override def collect[S](pf: PartialFunction[T, S])(implicit executor: ExecutionContext): Future[S] = thisAs[S]
src/library/scala/util/Try.scala:  def collect[U](pf: PartialFunction[T, U]): Try[U]
src/library/scala/util/Try.scala:  override def collect[U](pf: PartialFunction[T, U]): Try[U] = this.asInstanceOf[Try[U]]
src/library/scala/util/Try.scala:  override def collect[U](pf: PartialFunction[T, U]): Try[U] =
```

```
$ git grep "def collect\[.*(f: PartialF" -- src/library/scala/
src/library/scala/collection/ArrayOps.scala:  def collect[B : ClassTag](f: PartialFunction[A, B]): Array[B] = {
```