### PR TITLE
Bad access modifier doesn't short-circuit typing

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -751,12 +751,10 @@ trait ContextErrors {
       def FinitaryError(tparam: Symbol) =
         issueSymbolTypeError(tparam, "class graph is not finitary because type parameter "+tparam.name+" is expansively recursive")
 
-      def QualifyingClassError(tree: Tree, qual: Name) = {
+      def QualifyingClassError(tree: Tree, qual: Name) =
         issueNormalTypeError(tree,
-          if (qual.isEmpty) tree + " can be used only in a class, object, or template"
-          else qual + " is not an enclosing class")
-        setError(tree)
-      }
+          if (qual.isEmpty) s"$tree can be used only in a class, object, or template"
+          else s"$qual is not an enclosing class")
 
       // def stabilize
       def NotAValueError(tree: Tree, sym: Symbol) = {

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -842,7 +842,7 @@ trait Namers extends MethodSynthesis {
 
     def monoTypeCompleter(tree: MemberDef) = new MonoTypeCompleter(tree)
     class MonoTypeCompleter(tree: MemberDef) extends TypeCompleterBase(tree) {
-      override def completeImpl(sym: Symbol): Unit = if (!tree.isErroneous) {
+      override def completeImpl(sym: Symbol): Unit = {
         // this early test is there to avoid infinite baseTypes when
         // adding setters and getters --> bug798
         // It is a def in an attempt to provide some insulation against

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -458,6 +458,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         case Some(c) if packageOK || !c.isPackageClass => c
         case _ =>
           QualifyingClassError(tree, qual)
+          // Delay `setError` in namer, scala/bug#10748
           if (immediate) setError(tree) else unit.toCheck += (() => setError(tree))
           NoSymbol
       }

--- a/test/files/neg/t10748.check
+++ b/test/files/neg/t10748.check
@@ -1,0 +1,10 @@
+t10748.scala:2: error: p is not an enclosing class
+class X { private[p] class C(i: Int = 42) ; def c = new C(17) }
+                           ^
+t10748.scala:5: error: p is not an enclosing class
+  private[p] class D(i: Int = 42) { def f = new Q }
+                   ^
+t10748.scala:5: error: not found: type Q
+  private[p] class D(i: Int = 42) { def f = new Q }
+                                                ^
+three errors found

--- a/test/files/neg/t10748.scala
+++ b/test/files/neg/t10748.scala
@@ -1,0 +1,56 @@
+
+class X { private[p] class C(i: Int = 42) ; def c = new C(17) }
+
+class Y {
+  private[p] class D(i: Int = 42) { def f = new Q }
+  class Z { def d = new D() }
+}
+
+/*
+ *
+test/files/pos/t10748.scala:2: error: p is not an enclosing class
+class X { private[p] class C(i: Int = 42) ; def c = new C(17) }
+                           ^
+error: java.lang.AssertionError: assertion failed:
+  C
+     while compiling: test/files/pos/t10748.scala
+        during phase: globalPhase=typer, enteringPhase=namer
+     library version: version 2.13.0-20180714-072842-414f884
+    compiler version: version 2.13.0-20180714-072842-414f884
+  reconstructed args: -d /tmp
+
+  last tree to typer: TypeTree(class C)
+       tree position: line 2 of test/files/pos/t10748.scala
+            tree tpe: X.this.C
+              symbol: class C in class X
+   symbol definition: class C extends AnyRef (a ClassSymbol)
+      symbol package: <empty>
+       symbol owners: class C -> class X
+           call site: constructor C in class C in package <empty>
+
+== Source file context for tree position ==
+
+     1
+     2 class X { private[p] class C(i: Int = 42) ; def c = new C(17) }
+     3
+     4
+	at scala.reflect.internal.SymbolTable.throwAssertionError(SymbolTable.scala:162)
+	at scala.reflect.internal.SymbolTable.assert(SymbolTable.scala:139)
+	at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1508)
+	at scala.reflect.internal.Symbols$Symbol.initialize(Symbols.scala:1675)
+	at scala.tools.nsc.typechecker.Namers$Namer$DefaultGetterInCompanion.<init>(Namers.scala:1601)
+	at scala.tools.nsc.typechecker.Namers$Namer$DefaultGetterNamerSearch$.apply(Namers.scala:1591)
+	at scala.tools.nsc.typechecker.Namers$Namer.addDefaultGetters(Namers.scala:1483)
+	at scala.tools.nsc.typechecker.Namers$Namer.methodSig(Namers.scala:1396)
+	at scala.tools.nsc.typechecker.Namers$Namer.memberSig(Namers.scala:1859)
+	at scala.tools.nsc.typechecker.Namers$Namer.typeSig(Namers.scala:1825)
+	at scala.tools.nsc.typechecker.Namers$Namer$MonoTypeCompleter.completeImpl(Namers.scala:849)
+	at scala.tools.nsc.typechecker.Namers$LockingTypeCompleter.complete(Namers.scala:2009)
+	at scala.tools.nsc.typechecker.Namers$LockingTypeCompleter.complete$(Namers.scala:2007)
+	at scala.tools.nsc.typechecker.Namers$TypeCompleterBase.complete(Namers.scala:2002)
+	at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1527)
+	at scala.reflect.internal.Symbols.argsDependOnPrefix(Symbols.scala:3763)
+	at scala.reflect.internal.Symbols.argsDependOnPrefix$(Symbols.scala:3751)
+	at scala.reflect.internal.SymbolTable.argsDependOnPrefix(SymbolTable.scala:17)
+	at scala.tools.nsc.typechecker.Typers$Typer.typedSelect$1(Typers.scala:5046)
+ */

--- a/test/files/neg/t10748b.check
+++ b/test/files/neg/t10748b.check
@@ -1,0 +1,7 @@
+t10748b.scala:2: error: p is not an enclosing class
+private[p] class C(i: Int = 42) { def c = new C() }
+                 ^
+t10748b.scala:4: error: p is not an enclosing class
+private[p] class D(i: Int = 42) { def f = new Q }
+                 ^
+two errors found

--- a/test/files/neg/t10748b.scala
+++ b/test/files/neg/t10748b.scala
@@ -1,0 +1,5 @@
+
+private[p] class C(i: Int = 42) { def c = new C() }
+
+private[p] class D(i: Int = 42) { def f = new Q }
+class X { def d = new D() }


### PR DESCRIPTION
Let namer/typer proceed without access modifier.
Defer marking the tree erroneous.

Fixes scala/bug#10748