### PR TITLE
Correct link to StringOps [ci: last-only]

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -139,10 +139,12 @@ object Predef extends LowPriorityImplicits {
    */
   @inline def valueOf[T](implicit vt: ValueOf[T]): T = vt.value
 
-  /** The `String` type in Scala has methods that come either from the underlying
-   *  Java String (see the documentation corresponding to your Java version, for
-   *  example [[http://docs.oracle.com/javase/8/docs/api/java/lang/String.html]]) or
-   *  are added implicitly through [[scala.collection.immutable.StringOps]].
+  /** The `String` type in Scala has all the methods of the underlying
+   *  `java.lang.String`, of which it is just an alias.
+   *  (See the documentation corresponding to your Java version,
+   *  for example [[http://docs.oracle.com/javase/8/docs/api/java/lang/String.html]].)
+   *  In addition, extension methods in [[scala.collection.StringOps]]
+   *  are added implicitly through the conversion [[augmentString]].
    *  @group aliases
    */
   type String        = java.lang.String

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -1,6 +1,6 @@
 /*                     __                                               *\
 **     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2002-2013, LAMP/EPFL             **
+**    / __/ __// _ | / /  / _ |    (c) 2002-2018, LAMP/EPFL             **
 **  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
 ** /____/\___/_/ |_/____/_/ | |                                         **
 **                          |/                                          **
@@ -8,13 +8,10 @@
 
 package scala
 
-import scala.language.{ higherKinds, implicitConversions }
+import scala.language.{higherKinds, implicitConversions}
 
-import scala.collection.StringOps
-import scala.collection.{ mutable, immutable, ArrayOps }
-import scala.collection.immutable.WrappedString
-import scala.annotation.{ elidable, implicitNotFound }
-import scala.annotation.elidable.ASSERTION
+import scala.collection.{mutable, immutable, ArrayOps, StringOps}, immutable.WrappedString
+import scala.annotation.{elidable, implicitNotFound}, elidable.ASSERTION
 import scala.annotation.meta.companionMethod
 
 /** The `Predef` object provides definitions that are accessible in all Scala
@@ -748,7 +745,6 @@ object Predef extends LowPriorityImplicits {
 // compiled copy on the classpath.
 private[scala] abstract class LowPriorityImplicits extends LowPriorityImplicits2 {
   import mutable.ArraySeq
-  //import immutable.WrappedString
 
   /** We prefer the java.lang.* boxed types to these wrappers in
    *  any potential conflicts.  Conflicts do exist because the wrappers


### PR DESCRIPTION
The second commit floats a tweak to import style.

I'm aware folks prefer no extra space these days in import braces.

The one-liner relative imports may not be everyone's cup of tea; of course I will untweak if Seth asks me to, or Adriaan asks Seth to ask me. I'd be surprised if Lukas has a strong opinion here; they don't call him "Laidback Luke" for nothing. I almost wrote "string opinion."

I think learners (as I recall) look inside Predef, so there is a didactic component.