### PR TITLE
Revive productElementName to extract case class field names

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -38,7 +38,7 @@ trait SyntheticMethods extends ast.TreeDSL {
   import definitions._
   import CODE._
 
-  private lazy val productSymbols    = List(Product_productPrefix, Product_productArity, Product_productElement, Product_iterator, Product_canEqual)
+  private lazy val productSymbols    = List(Product_productPrefix, Product_productArity, Product_productElement, Product_productElementName, Product_iterator, Product_canEqual)
   private lazy val valueSymbols      = List(Any_hashCode, Any_equals)
   private lazy val caseSymbols       = List(Object_hashCode, Object_toString) ::: productSymbols
   private lazy val caseValueSymbols  = Any_toString :: valueSymbols ::: productSymbols
@@ -117,11 +117,11 @@ trait SyntheticMethods extends ast.TreeDSL {
       )
     }
 
-    /* Common code for productElement and (currently disabled) productElementName */
+    /* Common code for productElement and productElementName */
     def perElementMethod(name: Name, returnType: Type)(caseFn: Symbol => Tree): Tree =
       createSwitchMethod(name, accessors.indices, returnType)(idx => caseFn(accessors(idx)))
 
-    // def productElementNameMethod = perElementMethod(nme.productElementName, StringTpe)(x => LIT(x.name.toString))
+     def productElementNameMethod = perElementMethod(nme.productElementName, StringTpe)(x => LIT(x.name.toString))
 
     var syntheticCanEqual = false
 
@@ -248,14 +248,12 @@ trait SyntheticMethods extends ast.TreeDSL {
     // methods for both classes and objects
     def productMethods = {
       List(
-        Product_productPrefix   -> (() => constantNullary(nme.productPrefix, clazz.name.decode)),
-        Product_productArity    -> (() => constantNullary(nme.productArity, arity)),
-        Product_productElement  -> (() => perElementMethod(nme.productElement, AnyTpe)(mkThisSelect)),
-        Product_iterator        -> (() => productIteratorMethod),
-        Product_canEqual        -> (() => canEqualMethod)
-        // This is disabled pending a reimplementation which doesn't add any
-        // weight to case classes (i.e. inspects the bytecode.)
-        // Product_productElementName  -> (() => productElementNameMethod(accessors)),
+        Product_productPrefix       -> (() => constantNullary(nme.productPrefix, clazz.name.decode)),
+        Product_productArity        -> (() => constantNullary(nme.productArity, arity)),
+        Product_productElement      -> (() => perElementMethod(nme.productElement, AnyTpe)(mkThisSelect)),
+        Product_productElementName  -> (() => productElementNameMethod),
+        Product_iterator            -> (() => productIteratorMethod),
+        Product_canEqual            -> (() => canEqualMethod)
       )
     }
 

--- a/src/library/scala/Product.scala
+++ b/src/library/scala/Product.scala
@@ -48,4 +48,15 @@ trait Product extends Any with Equals {
    *  @return   in the default implementation, the empty string
    */
   def productPrefix = ""
+
+  def productElementName(n: Int): String =
+    if (n >= 0 && n  < n) ""
+    else throw new IndexOutOfBoundsException(n.toString)
+
+  def productElementNames: Iterator[String] = new scala.collection.AbstractIterator[String] {
+    private[this] var c: Int = 0
+    private[this] val cmax = productArity
+    def hasNext = c < cmax
+    def next() = { val result = productElementName(c); c += 1; result }
+  }
 }

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -728,6 +728,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val ProductRootClass: ClassSymbol = requiredClass[scala.Product]
       def Product_productArity          = getMemberMethod(ProductRootClass, nme.productArity)
       def Product_productElement        = getMemberMethod(ProductRootClass, nme.productElement)
+      def Product_productElementName    = getMemberMethod(ProductRootClass, nme.productElementName)
       def Product_iterator              = getMemberMethod(ProductRootClass, nme.productIterator)
       def Product_productPrefix         = getMemberMethod(ProductRootClass, nme.productPrefix)
       def Product_canEqual              = getMemberMethod(ProductRootClass, nme.canEqual_)

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -767,6 +767,7 @@ trait StdNames {
     val prefix : NameType              = "prefix"
     val productArity: NameType         = "productArity"
     val productElement: NameType       = "productElement"
+    val productElementName: NameType   = "productElementName"
     val productIterator: NameType      = "productIterator"
     val productPrefix: NameType        = "productPrefix"
     val raw_ : NameType                = "raw"

--- a/test/files/run/productElementName.check
+++ b/test/files/run/productElementName.check
@@ -1,0 +1,1 @@
+User(name=Susan, age=42)

--- a/test/files/run/productElementName.scala
+++ b/test/files/run/productElementName.scala
@@ -1,0 +1,11 @@
+
+case class User(name: String, age: Int)
+
+object Test extends App {
+  def pretty(p: Product): String =
+    p.productElementNames.zip(p.productIterator)
+     .map { case (name, value) => s"$name=$value" }
+     .mkString(p.productPrefix + "(", ", ", ")")
+  println(pretty(User("Susan", 42)))
+}
+


### PR DESCRIPTION
This commit adds two methods to the `scala.Product` trait:
```scala
trait Product {
  /** Returns the field name of element at index n */
  def productElementName(n: Int): String
  /** Returns field names of this product. Must have same length as productIterator */
  def productElementNames: Iterator[String]
}
```

Both methods have a default implementation which returns the empty
string for all field names.

This commit then changes the code-generation for case classes to
synthesize a `productElementName` method with actual class field names.

The benefit of this change is that it becomes possible to pretty-print
case classes with field names, for example
```scala
case class User(name: String, age: Int)

def toPrettyString(p: Product): String =
  p.productElementNames.zip(p.productIterator)
   .map { case (name, value) => s"$name=$value" }
   .mkString(p.productPrefix + "(", ", ", ")")

toPrettyString(User("Susan", 42))
// res0: String = User(name=Susan, age=42)
```

The downside of this change is that it produces more bytecode for each
case-class definition. Running `:javacp -c` for a case class with three
fields yields the following results
```scala
> case class A(a: Int, b: Int, c: Int)
> :javap -c A
  public java.lang.String productElementName(int);
    Code:
       0: iload_1
       1: istore_2
       2: iload_2
       3: tableswitch   { // 0 to 2
                     0: 28
                     1: 33
                     2: 38
               default: 43
          }
      28: ldc           78                 // String a
      30: goto          58
      33: ldc           79                 // String b
      35: goto          58
      38: ldc           80                 // String c
      40: goto          58
      43: new           67                 // class java/lang/IndexOutOfBoundsException
      46: dup
      47: iload_1
      48: invokestatic  65                 // Method scala/runtime/BoxesRunTime.boxToInteger:(I)Ljava/lang/Integer;
      51: invokevirtual 70                 // Method java/lang/Object.toString:()Ljava/lang/String;
      54: invokespecial 73                 // Method java/lang/IndexOutOfBoundsException."<init>":(Ljava/lang/String;)V
      57: athrow
      58: areturn
```

Thanks to Adriaan's help, the estimated cost per `productElementName`
appears to be fixed 56 bytes and then 10 bytes for each field with
the following breakdown:

* 3 bytes for the
  [string info](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.3)
  (the actual characters are already in the constant pool)
* 4 bytes for the tableswitch entry
* 2 bytes for the ldc to load the string
* 1 byte for areturn

In my opinion, the bytecode cost is acceptably low thanks to the fact
that field name literals are already available in the constant pool.