### PR TITLE
optimize immutable.ArraySeq#sorted

### DIFF
--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -149,6 +149,28 @@ sealed abstract class ArraySeq[+A]
     case _ =>
       super.equals(other)
   }
+
+  override def sorted[B >: A](implicit ord: Ordering[B]): ArraySeq[A] = {
+    val len = this.length
+    if (len <= 1) {
+      this
+    } else {
+      val arr = unsafeArray match {
+        case a: Array[AnyRef] =>
+          a.clone()
+        case _ =>
+          val xs = new Array[AnyRef](len)
+          var i = 0
+          while (i < len) {
+            xs(i) = unsafeArray(i).asInstanceOf[AnyRef]
+            i += 1
+          }
+          xs
+      }
+      java.util.Arrays.sort(arr, ord.asInstanceOf[Ordering[Object]])
+      ArraySeq.unsafeWrapArray(arr).asInstanceOf[ArraySeq[A]]
+    }
+  }
 }
 
 /**

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/ArraySeqBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/ArraySeqBenchmark.scala
@@ -1,0 +1,66 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import scala.reflect.ClassTag
+import scala.util.Random
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class ArraySeqBenchmark {
+  import ListBenchmark._
+  @Param(Array("0", "1", "10", "100", "1000"))
+  var size: Int = _
+
+  var intValues: ArraySeq[Int] = _
+  var refValues: ArraySeq[Option[Int]] = _
+
+  @Setup(Level.Trial) def initKeys(): Unit = {
+    intValues = ArraySeq.fill(size)(Random.nextInt)
+    refValues = intValues.map(Some(_))
+  }
+
+  @Benchmark def sortedNewInt: Any = {
+    intValues.sorted
+  }
+
+  @Benchmark def sortedOldInt: Any = {
+    sortedOldImpl(intValues)
+  }
+
+  @Benchmark def sortedNewRef: Any = {
+    refValues.sorted
+  }
+
+  @Benchmark def sortedOldRef: Any = {
+    sortedOldImpl(refValues)
+  }
+
+  // https://github.com/scala/scala/blob/eaeda754e2/src/library/scala/collection/Seq.scala#L590-L610
+  private[this] def sortedOldImpl[A](seq: ArraySeq[A])(implicit ord: Ordering[A], tag: ClassTag[A]): ArraySeq[A] = {
+    val len = seq.length
+    val b = ArraySeq.newBuilder[A](tag)
+    if (len == 1) b ++= seq.toIterable
+    else if (len > 1) {
+      b.sizeHint(len)
+      val arr = new Array[AnyRef](len)
+      var i = 0
+      for (x <- seq) {
+        arr(i) = x.asInstanceOf[AnyRef]
+        i += 1
+      }
+      java.util.Arrays.sort(arr, ord.asInstanceOf[Ordering[Object]])
+      i = 0
+      while (i < arr.length) {
+        b += arr(i).asInstanceOf[A]
+        i += 1
+      }
+    }
+    b.result()
+  }
+}

--- a/test/scalacheck/scala/collection/immutable/ArraySeqProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ArraySeqProperties.scala
@@ -1,0 +1,24 @@
+package scala.collection.immutable
+
+import org.scalacheck.Prop.forAll
+import org.scalacheck._
+import scala.reflect.ClassTag
+
+object ArraySeqProperties extends Properties("immutable.ArraySeq") {
+
+  private def sortedTest[A: Arbitrary: ClassTag: Ordering] = forAll{ (xs1: ArraySeq[A], x: A) =>
+    val array1 = xs1.toArray
+    assert(xs1.sorted == array1.sorted.to(ArraySeq))
+    assert(xs1 == array1.to(ArraySeq))
+
+    // check if internal `unsafeArray` is `Array[AnyRef]`
+    val xs2 = xs1 :+ x
+    assert(xs2.sorted == (array1 :+ x).sorted.to(ArraySeq))
+    true
+  }
+
+  property("sorted Int") = sortedTest[Int]
+
+  property("sorted Option[Int]") = sortedTest[Option[Int]]
+
+}


### PR DESCRIPTION
- avoid `Builder` and use `Array#clone` if possible https://github.com/scala/scala/blob/eaeda754e2/src/library/scala/collection/Seq.scala#L595-L601
- use `unsafeWrapArray` for avoid unnecessary copy https://github.com/scala/scala/blob/eaeda754e2/src/library/scala/collection/Seq.scala#L603-L607