### PR TITLE
allow $" escapes in interpolations

### DIFF
--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -505,6 +505,7 @@ of the escape sequences [here](#escape-sequences) are interpreted.
 interpolatedString ::= alphaid ‘"’ {printableChar \ (‘"’ | ‘\$’) | escape} ‘"’ 
                          |  alphaid ‘"""’ {[‘"’] [‘"’] char \ (‘"’ | ‘\$’) | escape} {‘"’} ‘"""’
 escape                 ::= ‘\$\$’ 
+                         | ‘\$"’
                          | ‘\$’ id
                          | ‘\$’ BlockExpr
 alphaid                ::= upper idrest
@@ -521,13 +522,13 @@ or multi-line (triple quote).
 Inside a interpolated string none of the usual escape characters are interpreted 
 (except for unicode escapes) no matter whether the string literal is normal 
 (enclosed in single quotes) or multi-line (enclosed in triple quotes). 
-Instead, there is are two new forms of dollar sign escape. 
+Instead, there is are three new forms of dollar sign escape. 
 The most general form encloses an expression in \${ and }, i.e. \${expr}. 
 The expression enclosed in the braces that follow the leading \$ character is of 
 syntactical category BlockExpr. Hence, it can contain multiple statements, 
 and newlines are significant. Single ‘\$’-signs are not permitted in isolation 
 in a interpolated string. A single ‘\$’-sign can still be obtained by doubling the ‘\$’ 
-character: ‘\$\$’.
+character: ‘\$\$’. A single ‘"’-sign can be obtained by the escape sequence ‘\$"’
 
 The simpler form consists of a ‘\$’-sign followed by an identifier starting with 
 a letter and followed only by letters, digits, and underscore characters, 

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -70,6 +70,7 @@ interpolatedString
                  ::= alphaid ‘"’ {printableChar \ (‘"’ | ‘\$’) | escape} ‘"’ 
                  |  alphaid ‘"""’ {[‘"’] [‘"’] char \ (‘"’ | ‘\$’) | escape} {‘"’} ‘"""’
 escape           ::= ‘\$\$’ 
+                 | ‘\$"’ 
                  | ‘\$’ id 
                  | ‘\$’ BlockExpr
 alphaid          ::= upper idrest

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -791,7 +791,7 @@ trait Scanners extends ScannersCommon {
         }
       } else if (ch == '$') {
         nextRawChar()
-        if (ch == '$') {
+        if (ch == '$' || ch == '"') {
           putChar(ch)
           nextRawChar()
           getStringPart(multiLine)
@@ -817,7 +817,8 @@ trait Scanners extends ScannersCommon {
             next.token = kwArray(idx)
           }
         } else {
-          syntaxError(s"invalid string interpolation $$$ch, expected: $$$$, $$identifier or $${expression}")
+          val q = '"'
+          syntaxError(s"invalid string interpolation $$$ch, expected: $$$$, $$${q} $$identifier or $${expression}")
         }
       } else {
         val isUnclosedLiteral = !isUnicodeEscape && (ch == SU || (!multiLine && (ch == CR || ch == LF)))

--- a/test/files/neg/t5856.check
+++ b/test/files/neg/t5856.check
@@ -1,9 +1,6 @@
-t5856.scala:10: error: invalid string interpolation $", expected: $$, $identifier or ${expression}
-  val s9 = s"$"
-             ^
 t5856.scala:10: error: unclosed string literal
   val s9 = s"$"
-              ^
+             ^
 t5856.scala:2: error: error in interpolated string: identifier or block expected
   val s1 = s"$null"
               ^
@@ -28,4 +25,4 @@ t5856.scala:8: error: error in interpolated string: identifier or block expected
 t5856.scala:9: error: error in interpolated string: identifier or block expected
   val s8 = s"$super"
               ^
-10 errors found
+9 errors found

--- a/test/files/run/t5856.scala
+++ b/test/files/run/t5856.scala
@@ -7,4 +7,5 @@ object Test extends App {
   assert(s"$this.##" == "Test.##")
   assert(s"$this.toString" == "Test.toString")
   assert(s"$this=THIS" == "Test=THIS")
+  assert(raw"$"" == "\"")
 }


### PR DESCRIPTION
Closes scala/bug#6476 in spirit. Or crushes its spirit. Or at least someones spirit.

This is the least ambitious and hopefully least controversial proposal around that issue. Previous PRs, SIPs and/or SLIPs had this change as a rider, or had this change with a rider of various other interpolation improvements.

This makes it a lot easier to write a single quote in an interpolated string, by escaping it with a `$` character. This can't break anyones code, since the sequence `$"` in an interpolation is a parse error now.

I also don't believe that this gets in the way of any other work regarding interpolations, which may still be brewing. 