### PR TITLE
fix searching with weird parameters

### DIFF
--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -65,8 +65,11 @@ trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self =>
   @tailrec
   private[this] def binarySearch[B >: A](elem: B, from: Int, to: Int)
                                         (implicit ord: Ordering[B]): SearchResult = {
-    if (to == from) InsertionPoint(from) else {
-      val idx = from+(to-from-1)/2
+    if (from < 0) binarySearch(elem, 0, to)
+    else if (to > length) binarySearch(elem, from, length)
+    else if (to <= from) InsertionPoint(from)
+    else {
+      val idx = from + (to - from - 1) / 2
       math.signum(ord.compare(elem, apply(idx))) match {
         case -1 => binarySearch(elem, from, idx)(ord)
         case  1 => binarySearch(elem, idx + 1, to)(ord)

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -853,9 +853,12 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     * @return a `Found` value containing the index corresponding to the element in the
     *         sequence, or the `InsertionPoint` where the element would be inserted if
     *         the element is not in the sequence.
+    * 
+    * @note if `to <= from`, the search space is empty, and an `InsertionPoint` at `from`
+    *       is returned
     */
-  def search[B >: A](elem: B, from: Int, to: Int) (implicit ord: Ordering[B]): SearchResult =
-    linearSearch(view.slice(from, to), elem, from)(ord)
+  def search[B >: A](elem: B, from: Int, to: Int) (implicit ord: Ordering[B]): SearchResult = 
+    linearSearch(view.slice(from, to), elem, math.max(0, from))(ord)
 
   private[this] def linearSearch[B >: A](c: View[A], elem: B, offset: Int)
                                         (implicit ord: Ordering[B]): SearchResult = {

--- a/test/junit/scala/collection/SeqTests.scala
+++ b/test/junit/scala/collection/SeqTests.scala
@@ -1,0 +1,31 @@
+package scala.collection.immutable
+
+import org.junit.{Assert, Test}
+
+object SeqTests {
+  def checkSearch[A](seq: Seq[A], needle: A, ord: Ordering[A]): Unit = {
+    import scala.collection.Searching.{Found, InsertionPoint}
+    val size = seq.size
+    val indices = List(-1, -10, -99, Int.MinValue, 0, size -1, size, size + 1, size + 10, Int.MaxValue)
+    for {
+      from <- indices
+      to <- indices
+    } {
+      val sorted = seq.sorted(ord)
+      sorted.search(needle, from, to)(ord) match {
+        case Found(foundIndex: Int) => {
+          val found = sorted(foundIndex)
+          Assert.assertTrue(s"found value $found not equivalent to searched value $needle in List(0-1000) between indices $from and $to", ord.equiv(found, needle))
+        }
+        case InsertionPoint(insertionPoint: Int) =>
+          for ((e, i) <- sorted.zipWithIndex) {
+            if(i >= from && i < to) {
+              if(i < insertionPoint) Assert.assertFalse(s"a value before the insertion point was greater than $needle", ord.gt(e, needle))
+              else Assert.assertFalse(s"a values past the insertion point was smaller than $needle", ord.lt(e, needle))
+            }
+            //else we don't want to make any statements for values out of that range
+          }
+      }
+    }
+  }
+}

--- a/test/junit/scala/collection/immutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/immutable/ArraySeqTest.scala
@@ -73,4 +73,6 @@ class ArraySeqTest {
     assertEquals(ArraySeq.empty[T], array.slice(1, 1))
     assertEquals(ArraySeq.empty[T], array.slice(2, 1))
   }
+  
+  @Test def checkSearch: Unit = SeqTests.checkSearch(ArraySeq(0 to 1000: _*), 15,  implicitly[Ordering[Int]])
 }

--- a/test/junit/scala/collection/immutable/ListTest.scala
+++ b/test/junit/scala/collection/immutable/ListTest.scala
@@ -65,4 +65,6 @@ class ListTest {
       case e: IndexOutOfBoundsException => ()
     }
   }
+
+  @Test def checkSearch: Unit = SeqTests.checkSearch(List(0 to 1000: _*), 15,  implicitly[Ordering[Int]])
 }

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -39,4 +39,7 @@ class VectorTest {
       assertEquals(els, prefix.toList ++: suffix)
     }
   }
+
+  @Test def checkSearch: Unit = SeqTests.checkSearch(Vector(0 to 1000: _*), 15,  implicitly[Ordering[Int]])
+  
 }


### PR DESCRIPTION
closes scala/bug#11032

makes searching obey the following invariants:

* Terminates for finite collections (this was violated in the binary search version with to < from)
* If `search(e, from, t)(ord)` returns `InsertionPoint(i)`, then for each index` j`
  * if `from <= j < i` then  `e > col(j)`
  * if `i <= j < to` then `e < col(j)`
  * no promises otherwise
* If `search(e, from, t)(ord)` returns `Found(i)`, then `ord.equiv(e, col(i))` (this was violated in the linear search version with from < 0)