### PR TITLE
[EXPERIMENT] Instringsic stripMargin

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -349,6 +349,7 @@ trait Definitions extends api.StandardDefinitions {
 
     lazy val PredefModule               = requiredModule[scala.Predef.type]
          def Predef_???                 = getMemberMethod(PredefModule, nme.???)
+         def Predef_augmentString       = getMemberMethod(PredefModule, nme.enhanceString)
     def isPredefMemberNamed(sym: Symbol, name: Name) = (
       (sym.name == name) && (sym.owner == PredefModule.moduleClass)
     )

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -598,6 +598,9 @@ trait StdNames {
 
     val ??? = encode("???")
 
+    val enhanceString: NameType    = "augmentString"
+    val stripMargin: NameType      = "stripMargin"
+
     val wrapRefArray: NameType     = "wrapRefArray"
     val wrapByteArray: NameType    = "wrapByteArray"
     val wrapShortArray: NameType   = "wrapShortArray"


### PR DESCRIPTION
When called on a string interpolation,
delegates to existing string building.
Supports either core interpolator
and `s"$x\n*$y".stripMargin('*')`.