### PR TITLE
add type parameter in foreachKey and foreachValue

### DIFF
--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -235,7 +235,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     *
     * @param f The loop body
     */
-  final def foreachKey(f: Int => Unit): Unit = this match {
+  final def foreachKey[U](f: Int => U): Unit = this match {
     case IntMap.Bin(_, _, left, right) => { left.foreachKey(f); right.foreachKey(f) }
     case IntMap.Tip(key, _) => f(key)
     case IntMap.Nil =>
@@ -252,7 +252,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     *
     * @param f The loop body
     */
-  final def foreachValue(f: T => Unit): Unit = this match {
+  final def foreachValue[U](f: T => U): Unit = this match {
     case IntMap.Bin(_, _, left, right) => { left.foreachValue(f); right.foreachValue(f) }
     case IntMap.Tip(_, value) => f(value)
     case IntMap.Nil =>

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -230,7 +230,7 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     *
     * @param f The loop body
     */
-  final def foreachKey(f: Long => Unit): Unit = this match {
+  final def foreachKey[U](f: Long => U): Unit = this match {
     case LongMap.Bin(_, _, left, right) => { left.foreachKey(f); right.foreachKey(f) }
     case LongMap.Tip(key, _) => f(key)
     case LongMap.Nil =>
@@ -247,7 +247,7 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     *
     * @param f The loop body
     */
-  final def foreachValue(f: T => Unit): Unit = this match {
+  final def foreachValue[U](f: T => U): Unit = this match {
     case LongMap.Bin(_, _, left, right) => { left.foreachValue(f); right.foreachValue(f) }
     case LongMap.Tip(_, value) => f(value)
     case LongMap.Nil =>


### PR DESCRIPTION
useful if parameter does not return `Unit` type

```
Welcome to Scala 2.13.0-M4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> def f[A]: A => A = { x => println(x); x }
f: [A]=> A => A

scala> collection.mutable.AnyRefMap("a" -> "b").foreachKey(f)
a

scala> collection.immutable.IntMap(1 -> 2).foreachKey(f)
                                                      ^
       error: type mismatch;
        found   : scala.collection.immutable.IntMapUtils.Int => scala.collection.immutable.IntMapUtils.Int
           (which expands to)  Int => Int
        required: scala.collection.immutable.IntMapUtils.Int => Unit
           (which expands to)  Int => Unit

scala> collection.immutable.IntMap(1 -> 2).foreachKey(f(_))
1
```