### PR TITLE
[WIP] fix Array.unapplySeq

### DIFF
--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -11,7 +11,6 @@ package scala
 //import scala.collection.generic._
 import scala.collection.{Factory, immutable, mutable}
 import mutable.ArrayBuilder
-import immutable.ArraySeq
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime
@@ -497,8 +496,9 @@ object Array {
    *  @param x the selector value
    *  @return  sequence wrapped in a [[scala.Some]], if `x` is an Array, otherwise `None`
    */
-  def unapplySeq[T](x: Array[T]): Option[IndexedSeq[T]] =
-    Some(ArraySeq.unsafeWrapArray[T](x))
+  def unapplySeq[T](x: Array[T]): Option[scala.collection.Seq[T]] = {
+    Some(mutable.ArraySeq.make[T](x))
+  }
 }
 
 /** Arrays are mutable, indexed collections of values. `Array[T]` is Scala's representation

--- a/test/junit/scala/ArrayTest.scala
+++ b/test/junit/scala/ArrayTest.scala
@@ -1,0 +1,15 @@
+package scala
+
+import org.junit.Assert._
+import org.junit.Test
+
+class ArrayTest {
+  @Test
+  def testUnapplySeq: Unit = {
+    val array = Array(1, 2, 3)
+    val seq = array match {
+      case Array(xs @ _*) => xs
+    }
+    seq: scala.collection.immutable.Seq[Int] // compile success !?
+  }
+}


### PR DESCRIPTION
`immutable.ArraySeq.unsafeWrapArray` is really unsafe!

```
Welcome to Scala 2.13.0-pre-8970bec (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> val array = Array(1, 2, 3)
array: Array[Int] = Array(1, 2, 3)

scala> val seq: collection.immutable.Seq[Int] = array match { case Array(xs @ _*) => xs }
seq: Seq[Int] = ArraySeq(1, 2, 3)

scala> array(0) = 10

scala> seq
res1: Seq[Int] = ArraySeq(10, 2, 3)
```