### PR TITLE
Enforce some linting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -158,7 +158,7 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
     // END: Copy/pasted from SBT
   },
   fork in run := true,
-  //scalacOptions += "-Xlint:-nullary-override,-inaccessible,_",
+  scalacOptions += "-Xlint:-nullary-override,-inaccessible,_",
   //scalacOptions ++= Seq("-Xmaxerrs", "5", "-Xmaxwarns", "5"),
   scalacOptions in Compile in doc ++= Seq(
     "-doc-footer", "epfl",
@@ -577,6 +577,7 @@ lazy val junit = project.in(file("test") / "junit")
   .dependsOn(library, reflect, compiler, partest, scaladoc)
   .settings(clearSourceAndResourceDirectories)
   .settings(commonSettings)
+  .settings(scalacOptions += "-Xlint:-nullary-unit,-adapted-args")
   .settings(disableDocs)
   .settings(disablePublishing)
   .settings(
@@ -684,6 +685,7 @@ lazy val test = project
   .disablePlugins(plugins.JUnitXmlReportPlugin)
   .configs(IntegrationTest)
   .settings(commonSettings)
+  .settings(scalacOptions -= "-Xlint:-nullary-override,-inaccessible,_")
   .settings(disableDocs)
   .settings(disablePublishing)
   .settings(Defaults.itSettings)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -9,8 +9,7 @@ package backend.jvm
 
 import scala.tools.asm
 import BackendReporting._
-import scala.reflect.internal.Flags
-import scala.tools.asm.{ByteVector, ClassWriter}
+import scala.tools.asm.ClassWriter
 import scala.tools.nsc.backend.jvm.BCodeHelpers.ScalaSigBytes
 import scala.tools.nsc.reporters.NoReporter
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -6,8 +6,6 @@
 package scala.tools.nsc
 package backend.jvm
 
-import scala.collection.generic.Clearable
-import scala.collection.concurrent
 import scala.tools.asm
 import scala.tools.asm.Opcodes
 import scala.tools.nsc.backend.jvm.BTypes.{InlineInfo, InternalName}

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -13,7 +13,7 @@ import scala.tools.asm
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree._
 import scala.tools.asm.tree.analysis._
-import scala.tools.asm.{Handle, Label, Type}
+import scala.tools.asm.{Handle, Type}
 import scala.tools.nsc.backend.jvm.BTypes._
 import scala.tools.nsc.backend.jvm.GenBCode._
 import scala.tools.nsc.backend.jvm.analysis.BackendUtils._

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -9,7 +9,6 @@ package opt
 
 import scala.annotation.{tailrec, switch}
 
-import scala.PartialFunction.cond
 import scala.reflect.internal.util.Collections._
 import scala.tools.asm.commons.CodeSizeEvaluator
 import scala.tools.asm.tree.analysis._

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -6,7 +6,7 @@
 package scala.tools.nsc
 package typechecker
 
-import scala.collection.{ immutable, mutable }
+import scala.collection.{immutable, mutable}
 import scala.annotation.tailrec
 import scala.reflect.internal.util.shortClassOfInstance
 import scala.reflect.internal.Reporter
@@ -17,7 +17,7 @@ import scala.reflect.internal.Reporter
  */
 trait Contexts { self: Analyzer =>
   import global._
-  import definitions.{ AnyRefClass, JavaLangPackage, ScalaPackage, PredefModule, ScalaXmlTopScope, ScalaXmlPackage }
+  import definitions.{JavaLangPackage, ScalaPackage, PredefModule, ScalaXmlTopScope, ScalaXmlPackage}
   import ContextMode._
   import scala.reflect.internal.Flags._
 
@@ -265,7 +265,7 @@ trait Contexts { self: Analyzer =>
             val fresh = freshNameCreatorFor(this)
             val vname = newTermName(fresh.newName("rec$"))
             val vsym = owner.newValue(vname, newFlags = FINAL | SYNTHETIC) setInfo tpe
-            implicitDictionary +:= (tpe -> (vsym, EmptyTree))
+            implicitDictionary +:= (tpe, (vsym, EmptyTree))
             vsym
         }
       gen.mkAttributedRef(sym) setType tpe
@@ -323,7 +323,6 @@ trait Contexts { self: Analyzer =>
             (vsym, ValDef(Modifiers(FINAL | SYNTHETIC), vsym.name.toTermName, TypeTree(rhs.tpe), rhs.changeOwner(owner -> vsym)))
           }.unzip
 
-          val ctor = DefDef(NoMods, nme.CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(List(pendingSuperCall), Literal(Constant(()))))
           val mname = newTermName(typer.fresh.newName("LazyDefns$"))
           val mdef =
             ModuleDef(Modifiers(SYNTHETIC), mname,

--- a/src/library/scala/collection/mutable/Iterable.scala
+++ b/src/library/scala/collection/mutable/Iterable.scala
@@ -1,7 +1,6 @@
 package scala.collection.mutable
 
 import scala.collection.IterableFactory
-import scala.language.higherKinds
 
 trait Iterable[A]
   extends collection.Iterable[A]

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -2,7 +2,7 @@ package scala
 package collection
 package mutable
 
-import scala.collection.{IterableOnce, MapFactory}
+import scala.collection.MapFactory
 import scala.language.higherKinds
 
 /** Base type of mutable Maps */

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -1,6 +1,6 @@
 package scala.collection.mutable
 
-import scala.collection.{IterableFactory, IterableOnce}
+import scala.collection.IterableFactory
 import scala.language.higherKinds
 
 /** Base trait for mutable sets */

--- a/test/junit/scala/PartialFunctionSerializationTest.scala
+++ b/test/junit/scala/PartialFunctionSerializationTest.scala
@@ -1,7 +1,6 @@
 package scala
 
 import org.junit.Test
-import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 

--- a/test/junit/scala/collection/BuildFromTest.scala
+++ b/test/junit/scala/collection/BuildFromTest.scala
@@ -2,7 +2,7 @@ package scala.collection
 
 import org.junit.Test
 
-import scala.collection.mutable.{ArrayBuffer, Builder, Growable}
+import scala.collection.mutable.Builder
 import scala.math.Ordering
 
 class BuildFromTest {

--- a/test/junit/scala/collection/IndexedSeqTest.scala
+++ b/test/junit/scala/collection/IndexedSeqTest.scala
@@ -172,6 +172,7 @@ abstract class IndexedTest[T, E] {
   @Test def checkTakeTooBig: Unit = {
     val orig = underTest(size)
     val e = take(orig, 0)
+    assertNotNull(e)
     for (len <- List(size + 1, size + 10, Int.MaxValue)) {
       val all = take(orig, len)
       assertEquals(s"len $len", size, length(all))
@@ -547,7 +548,7 @@ package IndexedTestImpl {
     override def createEmpty(size: Int): StringBuilder = new StringBuilder(size)
 
     override protected def underTest(size: Int): StringBuilder = {
-      var res = createEmpty(size)
+      val res = createEmpty(size)
       for (i <- 0 until size)
         res += expectedValueAtIndex(i)
       res
@@ -556,7 +557,7 @@ package IndexedTestImpl {
   class StringOpsTest extends StringOpsBaseTest with CharTestData {
 
     override protected def underTest(size: Int): StringOps = {
-      var res = new StringBuilder(size)
+      val res = new StringBuilder(size)
       for (i <- 0 until size)
         res += expectedValueAtIndex(i)
       res.toString
@@ -567,7 +568,7 @@ package IndexedTestImpl {
     override def isTakeAllSame: Boolean = false
 
     override protected def underTest(size: Int):  WrappedString = {
-      var res = new StringBuilder(size)
+      val res = new StringBuilder(size)
       for (i <- 0 until size)
         res += expectedValueAtIndex(i)
       new WrappedString(res.toString)
@@ -576,7 +577,7 @@ package IndexedTestImpl {
   class VectorTest extends ImmutableIndexedSeqTest[Vector[String], String]  with StringTestData {
 
     override protected def underTest(size: Int): Vector[String] = {
-      var res = Vector.newBuilder[String]
+      val res = Vector.newBuilder[String]
       for (i <- 0 until size)
         res += expectedValueAtIndex(i)
       res.result()

--- a/test/junit/scala/collection/IterableViewLikeTest.scala
+++ b/test/junit/scala/collection/IterableViewLikeTest.scala
@@ -4,7 +4,6 @@ import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import language.postfixOps
 
 @RunWith(classOf[JUnit4])
 class IterableViewLikeTest {

--- a/test/junit/scala/collection/SeqTests.scala
+++ b/test/junit/scala/collection/SeqTests.scala
@@ -1,6 +1,6 @@
 package scala.collection.immutable
 
-import org.junit.{Assert, Test}
+import org.junit.Assert
 
 object SeqTests {
   def checkSearch[A](seq: Seq[A], needle: A, ord: Ordering[A]): Unit = {


### PR DESCRIPTION
Enforce some linting
    
People keep commiting unused imports, which are
the easiest to check, so create some noise if they do that.

Mitigate the warnings; other warnings are mitigated in other PRs.