### PR TITLE
[REJECTED] Trim forwarders from Reporting [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/PhaseAssembly.scala
+++ b/src/compiler/scala/tools/nsc/PhaseAssembly.scala
@@ -184,7 +184,7 @@ trait PhaseAssembly {
           edges -= edge
           edge.frm.after -= edge
           if (edge.frm.phaseobj exists (lsc => !lsc.head.internal))
-            warning(msg)
+            reporter.warning(NoPosition, msg)
         }
       }
     }
@@ -242,7 +242,7 @@ trait PhaseAssembly {
               val tonode = graph.getNodeByPhase(phsname)
               graph.softConnectNodes(fromnode, tonode)
             } else {
-              globalError("[phase assembly, after dependency on terminal phase not allowed: " + fromnode.phasename + " => "+ phsname + "]")
+              reporter.error(NoPosition, "[phase assembly, after dependency on terminal phase not allowed: " + fromnode.phasename + " => "+ phsname + "]")
             }
           }
           for (phsname <- phs.runsBefore) {
@@ -250,7 +250,7 @@ trait PhaseAssembly {
               val tonode = graph.getNodeByPhase(phsname)
               graph.softConnectNodes(tonode, fromnode)
             } else {
-              globalError("[phase assembly, before dependency on parser phase not allowed: " + phsname + " => "+ fromnode.phasename + "]")
+              reporter.error(NoPosition, "[phase assembly, before dependency on parser phase not allowed: " + phsname + " => "+ fromnode.phasename + "]")
             }
           }
         case Some(phsname) =>
@@ -258,7 +258,7 @@ trait PhaseAssembly {
             val tonode = graph.getNodeByPhase(phsname)
             graph.hardConnectNodes(fromnode, tonode)
           } else {
-            globalError("[phase assembly, right after dependency on terminal phase not allowed: " + fromnode.phasename + " => "+ phsname + "]")
+            reporter.error(NoPosition, "[phase assembly, right after dependency on terminal phase not allowed: " + fromnode.phasename + " => "+ phsname + "]")
           }
       }
     }

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -20,7 +20,8 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
 
   // not deprecated yet, but a method called "error" imported into
   // nearly every trait really must go.  For now using globalError.
-  def error(msg: String) = globalError(msg)
+  @deprecated("deprecated now", since="now")
+  def error(msg: String) = reporter.error(NoPosition, msg)
 
   // a new instance of this class is created for every Run (access the current instance via `currentRun.reporting`)
   protected def PerRunReporting = new PerRunReporting

--- a/src/compiler/scala/tools/nsc/ast/Positions.scala
+++ b/src/compiler/scala/tools/nsc/ast/Positions.scala
@@ -16,8 +16,8 @@ trait Positions extends scala.reflect.internal.Positions {
           if (!c.canHaveAttrs) ()
           else if (c.pos == NoPosition) {
             reporter.warning(t.pos, " Positioned tree has unpositioned child in phase " + globalPhase)
-            inform("parent: " + treeSymStatus(t))
-            inform(" child: " + treeSymStatus(c) + "\n")
+            reporter.echo("parent: " + treeSymStatus(t))
+            reporter.echo(" child: " + treeSymStatus(c) + "\n")
           }
         }
       }

--- a/src/compiler/scala/tools/nsc/backend/ScalaPrimitives.scala
+++ b/src/compiler/scala/tools/nsc/backend/ScalaPrimitives.scala
@@ -443,7 +443,7 @@ abstract class ScalaPrimitives {
   def addPrimitives(cls: Symbol, method: Name, code: Int): Unit = {
     val alts = (cls.info member method).alternatives
     if (alts.isEmpty)
-      inform(s"Unknown primitive method $cls.$method")
+      reporter.echo(s"Unknown primitive method $cls.$method")
     else alts foreach (s =>
       addPrimitive(s,
         if (code != ADD) code

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -405,7 +405,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
         val loc = Local(tk, sym.javaSimpleName.toString, nxtIdx, sym.isSynthetic)
         val existing = slots.put(sym, loc)
         if (existing.isDefined)
-          globalError(sym.pos, "attempt to create duplicate local var.")
+          reporter.error(sym.pos, "attempt to create duplicate local var.")
         assert(tk.size > 0, "makeLocal called for a symbol whose type is Unit.")
         nxtIdx += tk.size
         loc
@@ -635,7 +635,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
           rhs match {
             case Return(_) | Block(_, Return(_)) | Throw(_) | Block(_, Throw(_)) => ()
             case EmptyTree =>
-              globalError("Concrete method has no definition: " + dd + (
+              reporter.error(NoPosition, "Concrete method has no definition: " + dd + (
                 if (settings.debug) "(found: " + methSymbol.owner.info.decls.toList.mkString(", ") + ")"
                 else ""))
             case _ =>

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -179,7 +179,7 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
        */
 
       case tp =>
-        warning(tp.typeSymbol.pos,
+        reporter.warning(tp.typeSymbol.pos,
           s"an unexpected type representation reached the compiler backend while compiling $currentUnit: $tp. " +
             "If possible, please file a bug on https://github.com/scala/bug/issues.")
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/PostProcessorFrontendAccess.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/PostProcessorFrontendAccess.scala
@@ -229,11 +229,11 @@ object PostProcessorFrontendAccess {
       }
 
       def warning(pos: Position, message: String): Unit = frontendSynch {
-        global.warning(pos, message)
+        reporter.warning(pos, message)
       }
 
       def inform(message: String): Unit = frontendSynch {
-        global.inform(message)
+        reporter.echo(message)
       }
 
       def log(message: String): Unit = frontendSynch {

--- a/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
@@ -112,7 +112,7 @@ abstract class BrowsingLoaders extends GlobalSymbolLoaders {
     val browser = new BrowserTraverser
     browser.traverse(body)
     if (browser.entered == 0)
-      warning("No classes or objects found in "+source+" that go in "+root)
+      reporter.warning(NoPosition, "No classes or objects found in "+source+" that go in "+root)
   }
 
   /** Enter top-level symbols from a source file

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -47,7 +47,7 @@ abstract class SymbolLoaders {
 
   protected def signalError(root: Symbol, ex: Throwable): Unit = {
     if (settings.debug) ex.printStackTrace()
-    globalError(ex.getMessage() match {
+    reporter.error(NoPosition, ex.getMessage() match {
       case null => "i/o error while loading " + root.name
       case msg  => "error while loading " + root.name + ", " + msg
     })
@@ -97,14 +97,14 @@ abstract class SymbolLoaders {
           s"$root contains object and package with same name: $name\none of them needs to be removed from classpath"
         )
       else if (settings.termConflict.value == "package") {
-        warning(
+        reporter.warning(NoPosition,
           "Resolving package/object name conflict in favor of package " +
           preExisting.fullName + ".  The object will be inaccessible."
         )
         root.info.decls.unlink(preExisting)
       }
       else {
-        warning(
+        reporter.warning(NoPosition,
           "Resolving package/object name conflict in favor of object " +
           preExisting.fullName + ".  The package will be inaccessible."
         )
@@ -173,10 +173,10 @@ abstract class SymbolLoaders {
     ((classRep.binary, classRep.source) : @unchecked) match {
       case (Some(bin), Some(src))
       if platform.needCompile(bin, src) && !binaryOnly(owner, classRep.name) =>
-        if (settings.verbose) inform("[symloader] picked up newer source file for " + src.path)
+        if (settings.verbose) reporter.echo("[symloader] picked up newer source file for " + src.path)
         enterToplevelsFromSource(owner, classRep.name, src)
       case (None, Some(src)) =>
-        if (settings.verbose) inform("[symloader] no class, picked up source file for " + src.path)
+        if (settings.verbose) reporter.echo("[symloader] no class, picked up source file for " + src.path)
         enterToplevelsFromSource(owner, classRep.name, src)
       case (Some(bin), _) =>
         enterClassAndModule(owner, classRep.name, new ClassfileLoader(bin, _, _))

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -379,7 +379,7 @@ abstract class ClassfileParser {
     //   - better owner than `NoSymbol`
     //   - remove eager warning
     val msg = s"Class $name not found - continuing with a stub."
-    if ((!settings.isScaladoc) && (settings.verbose || settings.developer)) warning(msg)
+    if ((!settings.isScaladoc) && (settings.verbose || settings.developer)) reporter.warning(NoPosition, msg)
     NoSymbol.newStubSymbol(name.toTypeName, msg)
   }
 
@@ -991,7 +991,7 @@ abstract class ClassfileParser {
         val s = module.info.decls.lookup(n)
         if (s != NoSymbol) Some(LiteralAnnotArg(Constant(s)))
         else {
-          warning(
+          reporter.warning(NoPosition,
             sm"""While parsing annotations in ${in.file}, could not find $n in enum ${module.nameString}.
                 |This is likely due to an implementation restriction: an annotation argument cannot refer to a member of the annotated class (scala/bug#7014)."""
           )
@@ -1041,7 +1041,7 @@ abstract class ClassfileParser {
       // the classpath would *not* end up here. A class not found is signaled
       // with a `FatalError` exception, handled above. Here you'd end up after a NPE (for example),
       // and that should never be swallowed silently.
-      warning(s"Caught: $ex while parsing annotations in ${in.file}")
+      reporter.warning(NoPosition, s"Caught: $ex while parsing annotations in ${in.file}")
       if (settings.debug) ex.printStackTrace()
       None // ignore malformed annotations
   }

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -232,7 +232,7 @@ abstract class ExplicitOuter extends InfoTransform
           // The caller will report the error with more information.
           EmptyTree
         } else {
-          globalError(currentOwner.pos, s"Internal error: unable to find the outer accessor symbol of $baseSym")
+          reporter.error(currentOwner.pos, s"Internal error: unable to find the outer accessor symbol of $baseSym")
           EmptyTree
         }
       } else {

--- a/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
@@ -58,7 +58,7 @@ abstract class ConstantFolder {
     } catch {
       case e: ArithmeticException =>
         if (settings.warnConstant)
-          warning(tree.pos, s"Evaluation of a constant expression results in an arithmetic error: ${e.getMessage}")
+          reporter.warning(tree.pos, s"Evaluation of a constant expression results in an arithmetic error: ${e.getMessage}")
         tree
     }
   }

--- a/src/interactive/scala/tools/nsc/interactive/ContextTrees.scala
+++ b/src/interactive/scala/tools/nsc/interactive/ContextTrees.scala
@@ -163,7 +163,7 @@ trait ContextTrees { self: Global =>
               if ((lopos precedes cpos) && (cpos precedes hipos))
                 contexts.insert(hi, new ContextTree(cpos, context))
               else
-                inform("internal error? skewed positions: "+lopos+" !< "+cpos+" !< "+hipos)
+                reporter.echo("internal error? skewed positions: "+lopos+" !< "+cpos+" !< "+hipos)
             }
           }
           loop(0, hi)

--- a/src/reflect/scala/reflect/internal/Positions.scala
+++ b/src/reflect/scala/reflect/internal/Positions.scala
@@ -87,20 +87,20 @@ trait Positions extends api.Positions { self: SymbolTable =>
 
     def reportTree(prefix : String, tree : Tree): Unit = {
       val source = if (tree.pos.isDefined) tree.pos.source else ""
-      inform("== "+prefix+" tree ["+tree.id+"] of type "+tree.productPrefix+" at "+tree.pos.show+source)
-      inform("")
-      inform(treeStatus(tree))
-      inform("")
+      reporter.echo("== "+prefix+" tree ["+tree.id+"] of type "+tree.productPrefix+" at "+tree.pos.show+source)
+      reporter.echo("")
+      reporter.echo(treeStatus(tree))
+      reporter.echo("")
     }
 
     def positionError(msg: String)(body : => Unit): Unit = {
-      inform("======= Position error\n" + msg)
+      reporter.echo("======= Position error\n" + msg)
       body
-      inform("\nWhile validating #" + tree.id)
-      inform(treeStatus(tree))
-      inform("\nChildren:")
-      tree.children foreach (t => inform("  " + treeStatus(t, tree)))
-      inform("=======")
+      reporter.echo("\nWhile validating #" + tree.id)
+      reporter.echo(treeStatus(tree))
+      reporter.echo("\nChildren:")
+      tree.children foreach (t => reporter.echo("  " + treeStatus(t, tree)))
+      reporter.echo("=======")
       throw new ValidateException(msg)
     }
 
@@ -108,13 +108,13 @@ trait Positions extends api.Positions { self: SymbolTable =>
 
       if (!tree.isEmpty && tree.canHaveAttrs) {
         if (settings.Yposdebug && (settings.verbose || settings.Yrangepos))
-          inform("[%10s] %s".format("validate", treeStatus(tree, encltree)))
+          reporter.echo("[%10s] %s".format("validate", treeStatus(tree, encltree)))
 
         if (!tree.pos.isDefined)
           positionError("Unpositioned tree #"+tree.id) {
-            inform("%15s %s".format("unpositioned", treeStatus(tree, encltree)))
-            inform("%15s %s".format("enclosing", treeStatus(encltree)))
-            encltree.children foreach (t => inform("%15s %s".format("sibling", treeStatus(t, encltree))))
+            reporter.echo("%15s %s".format("unpositioned", treeStatus(tree, encltree)))
+            reporter.echo("%15s %s".format("enclosing", treeStatus(encltree)))
+            encltree.children foreach (t => reporter.echo("%15s %s".format("sibling", treeStatus(t, encltree))))
           }
         if (tree.pos.isRange) {
           if (!encltree.pos.isRange)
@@ -224,7 +224,7 @@ trait Positions extends api.Positions { self: SymbolTable =>
     }
   } catch {
     case ex: Exception =>
-      inform("error while set children pos "+pos+" of "+trees)
+      reporter.echo("error while set children pos "+pos+" of "+trees)
       throw ex
   }
 

--- a/src/reflect/scala/reflect/internal/Reporting.scala
+++ b/src/reflect/scala/reflect/internal/Reporting.scala
@@ -45,6 +45,12 @@ trait Reporting { self : Positions =>
 
   def supplementErrorMessage(errorMessage: String) = currentRun.reporting.supplementErrorMessage(errorMessage)
 
+  // used by sbt of a certain vintage
+  @deprecated("use reporter.echo", "2.13.0")
+  def inform(msg: String): Unit      = reporter.echo(NoPosition, msg)
+  @deprecated("use reporter.warning", "2.13.0")
+  def warning(msg: String): Unit     = reporter.warning(NoPosition, msg)
+
   def abort(msg: String): Nothing = {
     val augmented = supplementErrorMessage(msg)
     // Needs to call error to make sure the compile fails.

--- a/src/reflect/scala/reflect/internal/Reporting.scala
+++ b/src/reflect/scala/reflect/internal/Reporting.scala
@@ -45,28 +45,12 @@ trait Reporting { self : Positions =>
 
   def supplementErrorMessage(errorMessage: String) = currentRun.reporting.supplementErrorMessage(errorMessage)
 
-  @deprecatedOverriding("This forwards to the corresponding method in reporter -- override reporter instead", "2.11.2")
-  def inform(msg: String): Unit      = inform(NoPosition, msg)
-  @deprecatedOverriding("This forwards to the corresponding method in reporter -- override reporter instead", "2.11.2")
-  def warning(msg: String): Unit     = warning(NoPosition, msg)
-  // globalError(msg: String) used to abort -- not sure that was a good idea, so I made it more regular
-  // (couldn't find any uses that relied on old behavior)
-  @deprecatedOverriding("This forwards to the corresponding method in reporter -- override reporter instead", "2.11.2")
-  def globalError(msg: String): Unit = globalError(NoPosition, msg)
-
   def abort(msg: String): Nothing = {
     val augmented = supplementErrorMessage(msg)
     // Needs to call error to make sure the compile fails.
-    globalError(augmented)
+    reporter.error(NoPosition, augmented)
     throw new FatalError(augmented)
   }
-
-  @deprecatedOverriding("This forwards to the corresponding method in reporter -- override reporter instead", "2.11.2")
-  def inform(pos: Position, msg: String)      = reporter.echo(pos, msg)
-  @deprecatedOverriding("This forwards to the corresponding method in reporter -- override reporter instead", "2.11.2")
-  def warning(pos: Position, msg: String)     = reporter.warning(pos, msg)
-  @deprecatedOverriding("This forwards to the corresponding method in reporter -- override reporter instead", "2.11.2")
-  def globalError(pos: Position, msg: String) = reporter.error(pos, msg)
 }
 
 import util.Position

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -67,7 +67,7 @@ abstract class SymbolTable extends macros.Universe
   protected def elapsedMessage(msg: String, start: Long) =
     msg + " in " + (TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start) + "ms"
 
-  def informProgress(msg: String)          = if (settings.verbose) inform("[" + msg + "]")
+  def informProgress(msg: String)          = if (settings.verbose) reporter.echo("[" + msg + "]")
   def informTime(msg: String, start: Long) = informProgress(elapsedMessage(msg, start))
 
   def shouldLogAtThisPhase = false

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3395,7 +3395,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def children = childSet
     override def addChild(sym: Symbol): Unit = {
       if(!isPastTyper && hasAttachment[KnownDirectSubclassesCalled.type] && !childSet.contains(sym))
-        globalError(s"knownDirectSubclasses of ${this.name} observed before subclass ${sym.name} registered")
+        reporter.error(NoPosition, s"knownDirectSubclasses of ${this.name} observed before subclass ${sym.name} registered")
 
       childSet = childSet + sym
     }
@@ -3512,7 +3512,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     private def fail[T](alt: T): T = {
       // Avoid issuing lots of redundant errors
       if (!hasFlag(IS_ERROR)) {
-        globalError(pos, missingMessage)
+        reporter.error(pos, missingMessage)
         if (settings.debug.value)
           (new Throwable).printStackTrace
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1597,7 +1597,7 @@ trait Types
         def what = tpe.typeSymbol.toString + " in " + tpe.typeSymbol.owner.fullNameString
         val bcs  = computeBaseClasses(tpe)
         tpe.baseClassesCache = bcs
-        warning(s"Breaking cycle in base class computation of $what ($bcs)")
+        reporter.warning(NoPosition, s"Breaking cycle in base class computation of $what ($bcs)")
       }
     }
     else {
@@ -4830,11 +4830,11 @@ trait Types
 
   /** Perform operation `p` on arguments `tp1`, `arg2` and print trace of computation. */
   protected def explain[T](op: String, p: (Type, T) => Boolean, tp1: Type, arg2: T): Boolean = {
-    inform(indent + tp1 + " " + op + " " + arg2 + "?" /* + "("+tp1.getClass+","+arg2.getClass+")"*/)
+    reporter.echo(indent + tp1 + " " + op + " " + arg2 + "?" /* + "("+tp1.getClass+","+arg2.getClass+")"*/)
     indent = indent + "  "
     val result = p(tp1, arg2)
     indent = indent stripSuffix "  "
-    inform(indent + result)
+    reporter.echo(indent + result)
     result
   }
 

--- a/src/scaladoc/scala/tools/nsc/doc/Uncompilable.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Uncompilable.scala
@@ -15,7 +15,7 @@ trait Uncompilable {
   val global: Global
   val settings: Settings
 
-  import global.{ reporter, inform, warning, newTypeName, newTermName, Symbol, DocComment, NoSymbol }
+  import global.{reporter, newTypeName, newTermName, Symbol, DocComment, NoPosition, NoSymbol}
   import global.definitions.AnyRefClass
   import global.rootMirror.RootClass
 
@@ -29,7 +29,7 @@ trait Uncompilable {
   lazy val pairs = files flatMap { f =>
     val comments = docPairs(f.slurp())
     if (settings.verbose)
-      inform("Found %d doc comments in parse-only file %s: %s".format(comments.size, f, comments.map(_._1).mkString(", ")))
+      reporter.echo("Found %d doc comments in parse-only file %s: %s".format(comments.size, f, comments.map(_._1).mkString(", ")))
 
     comments
   }
@@ -38,10 +38,10 @@ trait Uncompilable {
   def templates = symbols filter (x => x.isClass || x.isTrait || x == AnyRefClass/* which is now a type alias */) toSet
   def comments = {
     if (settings.debug || settings.verbose)
-      inform("Found %d uncompilable files: %s".format(files.size, files mkString ", "))
+      reporter.echo("Found %d uncompilable files: %s".format(files.size, files mkString ", "))
 
     if (pairs.isEmpty)
-      warning("no doc comments read from " + settings.docUncompilable.value)
+      reporter.warning(NoPosition, "no doc comments read from " + settings.docUncompilable.value)
 
     pairs
   }

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -270,7 +270,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     docTemplatesCache += (sym -> this)
 
     if (settings.verbose)
-      inform("Creating doc template for " + sym)
+      reporter.echo("Creating doc template for " + sym)
 
     override def linkTarget: DocTemplateImpl = this
     override def toRoot: List[DocTemplateImpl] = this :: inTpl.toRoot

--- a/test/files/run/t4841-isolate-plugins/ploogin.scala
+++ b/test/files/run/t4841-isolate-plugins/ploogin.scala
@@ -23,7 +23,7 @@ class Ploogin(val global: Global, val name: String = "ploogin") extends Plugin {
     class TestPhase(prev: Phase) extends StdPhase(prev) {
       override def description = TestComponent.this.description
       def apply(unit: CompilationUnit): Unit = {
-        if (settings.developer) inform(s"My phase name is $phaseName")
+        if (settings.developer) reporter.echo(s"My phase name is $phaseName")
       }
     }
   }


### PR DESCRIPTION
The forwarders `inform`, `globalError`, `warning` were
marked `deprecatedOverriding`, but this commit just removes
them in favor of `reporter.error` etc. This reduces the
`global` namespace and focuses attention on the `Reporter`
interface, reducing confusion as to which `warning` to use.