### PR TITLE
Copy arrays that are explicitly passed as varargs with `: _*`

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -247,7 +247,7 @@ abstract class UnCurry extends InfoTransform
           ArrayValue(TypeTree(elemtp), ts) setType arrayType(elemtp)
 
         // when calling into scala varargs, make sure it's a sequence.
-        def arrayToSequence(tree: Tree, elemtp: Type) = {
+        def arrayToSequence(tree: Tree, elemtp: Type, copy: Boolean) = {
           exitingUncurry {
             localTyper.typedPos(pos) {
               val pt = arrayType(elemtp)
@@ -255,7 +255,12 @@ abstract class UnCurry extends InfoTransform
                 if (tree.tpe <:< pt) tree
                 else gen.mkCastArray(tree, elemtp, pt)
 
-              gen.mkWrapVarargsArray(adaptedTree, elemtp)
+              if(copy) {
+                currentRun.reporting.deprecationWarning(tree.pos, NoSymbol,
+                  "Passing an explicit array value to a Scala varargs method is deprecated (since 2.13.0) and will result in a defensive copy; "+
+                    "Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call", "2.13.0")
+                gen.mkMethodCall(PredefModule, nme.copyArrayToImmutableIndexedSeq, List(elemtp), List(adaptedTree))
+              } else gen.mkWrapVarargsArray(adaptedTree, elemtp)
             }
           }
         }
@@ -299,13 +304,13 @@ abstract class UnCurry extends InfoTransform
               else sequenceToArray(tree)
             else
               if (tree.tpe.typeSymbol isSubClass SeqClass) tree
-              else arrayToSequence(tree, varargsElemType)
+              else arrayToSequence(tree, varargsElemType, copy = isNewCollections) // existing array, make a defensive copy
           }
           else {
             def mkArray = mkArrayValue(args drop (formals.length - 1), varargsElemType)
             if (javaStyleVarArgs) mkArray
             else if (args.isEmpty) gen.mkNil  // avoid needlessly double-wrapping an empty argument list
-            else arrayToSequence(mkArray, varargsElemType)
+            else arrayToSequence(mkArray, varargsElemType, copy = false) // fresh array, no need to copy
           }
 
         exitingUncurry {

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -435,7 +435,8 @@ trait Definitions extends api.StandardDefinitions {
     def elementType(container: Symbol, tp: Type): Type       = elementExtract(container, tp)
 
     // collections classes
-    private[this] lazy val isNewCollections = getClassIfDefined("scala.collection.IterableOnce") != NoSymbol
+    private[this] lazy val _isNewCollections = getClassIfDefined("scala.collection.IterableOnce") != NoSymbol
+    private[scala] def isNewCollections = _isNewCollections
     lazy val ConsClass              = requiredClass[scala.collection.immutable.::[_]]
     lazy val IteratorClass          = requiredClass[scala.collection.Iterator[_]]
     lazy val IterableClass          = requiredClass[scala.collection.Iterable[_]]

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -610,6 +610,8 @@ trait StdNames {
     val wrapUnitArray: NameType    = "wrapUnitArray"
     val genericWrapArray: NameType = "genericWrapArray"
 
+    val copyArrayToImmutableIndexedSeq: NameType = "copyArrayToImmutableIndexedSeq"
+
     // Compiler utilized names
 
     val AnnotatedType: NameType        = "AnnotatedType"

--- a/test/files/run/adding-growing-set.scala
+++ b/test/files/run/adding-growing-set.scala
@@ -5,7 +5,7 @@ object Test {
   def main(args: Array[String]): Unit = {
     val a = new Array[Long](1000000)
     (1 to 10000) foreach (i => a(i) = i)
-    val s = collection.mutable.Set(a: _*)
+    val s = collection.mutable.Set(collection.immutable.ArraySeq.unsafeWrapArray(a): _*)
     assert(s.sum > 0)
   }
 }

--- a/test/files/run/t11042.check
+++ b/test/files/run/t11042.check
@@ -1,0 +1,6 @@
+t11042.scala:6: warning: Passing an explicit array value to a Scala varargs method is deprecated (since 2.13.0) and will result in a defensive copy; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call
+  println(g(Array(1, 2, 3): _*))
+                 ^
+false
+true
+true

--- a/test/files/run/t11042.flags
+++ b/test/files/run/t11042.flags
@@ -1,0 +1,1 @@
+-deprecation

--- a/test/files/run/t11042.scala
+++ b/test/files/run/t11042.scala
@@ -1,0 +1,8 @@
+object Test extends App {
+  def f(xs: Array[Int]): Boolean = xs.isInstanceOf[scala.collection.immutable.Seq[_]]
+  def g(xs: Int*): Boolean = xs.isInstanceOf[scala.collection.immutable.Seq[_]]
+
+  println(f(Array(1, 2, 3)))
+  println(g(Array(1, 2, 3): _*))
+  println(g(1, 2, 3))
+}

--- a/test/files/run/t6611.check
+++ b/test/files/run/t6611.check
@@ -1,0 +1,1 @@
+warning: there were 10 deprecation warnings (since 2.13.0); re-run with -deprecation for details

--- a/test/files/run/t9567c.check
+++ b/test/files/run/t9567c.check
@@ -1,0 +1,1 @@
+warning: there were two deprecation warnings (since 2.13.0); re-run with -deprecation for details


### PR DESCRIPTION
This operation is deprecated and produces a deprecation warning similar
to the one for `Predef.copyArrayToImmutableIndexedSeq.` which serves the
same purpose for the non-varargs case.

Fixes https://github.com/scala/bug/issues/11024