### PR TITLE
[SUPERSEDED] Remove adaptation of 0-arg methods under -Xsource:3.0 and preserve infix unit value

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -868,6 +868,7 @@ self =>
       }
       def mkNamed(args: List[Tree]) = if (isExpr) args map treeInfo.assignmentToMaybeNamedArg else args
       val arguments = right match {
+        case Parens(Nil)  => Literal(Constant(())) :: Nil
         case Parens(args) => mkNamed(args)
         case _            => right :: Nil
       }

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -632,7 +632,7 @@ abstract class BTypes {
         // synchronization required to ensure the apply is finished
         // which populates info. ClassBType doesnt escape apart from via the map
         // and the object mutex is locked prior to insertion. See apply
-        this.synchronized()
+        this.synchronized {}
       assert(_info != null, s"ClassBType.info not yet assigned: $this")
       _info
     }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -106,7 +106,6 @@ trait ScalaSettings extends AbsScalaSettings
   def isScala214: Boolean = source.value >= version214
   private[this] val version300 = ScalaVersion("3.0.0")
   def isScala300: Boolean = source.value >= version300
-  def isScala3:   Boolean = isScala300
 
   /**
    * -X "Advanced" settings

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -106,7 +106,7 @@ trait ScalaSettings extends AbsScalaSettings
   def isScala214: Boolean = source.value >= version214
   private[this] val version300 = ScalaVersion("3.0.0")
   def isScala300: Boolean = source.value >= version300
-
+  def isScala3:   Boolean = isScala300
 
   /**
    * -X "Advanced" settings

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -259,7 +259,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
               // reflective method call machinery
               val invokeName  = MethodClass.tpe member nme.invoke_                                  // scala.reflect.Method.invoke(...)
               def cache       = REF(reflectiveMethodCache(ad.symbol.name.toString, paramTypes))     // cache Symbol
-              def lookup      = Apply(cache, List(qual1() GETCLASS()))                                // get Method object from cache
+              def lookup      = Apply(cache, List(qual1().GETCLASS()))                                // get Method object from cache
               def invokeArgs  = ArrayValue(TypeTree(ObjectTpe), params)                       // args for invocation
               def invocation  = (lookup DOT invokeName)(qual1(), invokeArgs)                        // .invoke(qual1, ...)
 
@@ -299,7 +299,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
              * so we have to generate both kinds of code.
              */
             def genArrayCallWithTest =
-              IF ((qual1() GETCLASS()) DOT nme.isArray) THEN genArrayCall ELSE genDefaultCall
+              IF (qual1().GETCLASS() DOT nme.isArray) THEN genArrayCall ELSE genDefaultCall
 
             localTyper typed (
               if (isMaybeBoxed && isJavaValueMethod) genValueCallWithTest

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchCodeGen.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchCodeGen.scala
@@ -155,7 +155,7 @@ trait MatchCodeGen extends Interface {
         // res: T
         // returns MatchMonad[T]
         def one(res: Tree): Tree = matchEnd APPLY (res) // a jump to a case label is special-cased in typedApply
-        protected def zero: Tree = nextCase APPLY ()
+        protected def zero: Tree = nextCase.APPLY()
 
         // prev: MatchMonad[T]
         // b: T

--- a/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
@@ -72,13 +72,13 @@ trait Adaptations {
           || t.symbol.name == nme.NE
         )
       }
-      @inline def msg(what: String): String = s"adaptation of an empty argument list by appending () is $what"
+      @inline def msg(what: String): String = s"adaptation of an empty argument list by inserting () $what"
       @inline def noAdaptation = {
-        context.error(t.pos, adaptWarningMessage(msg("unsupported"), showAdaptation = false))
+        context.error(t.pos, adaptWarningMessage(msg("has been removed"), showAdaptation = false))
         false // drop adaptation
       }
       @inline def deprecatedAdaptation = {
-        val text = s"${msg("deprecated")}: ${
+        val text = s"${msg("is deprecated")}: ${
           if (isLeakyTarget) "leaky (Object-receiving) target makes this especially dangerous"
           else "this is unlikely to be what you want"
         }"

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1207,7 +1207,7 @@ trait Implicits {
      */
     def searchImplicit(implicitInfoss: Infoss, isLocalToCallsite: Boolean): SearchResult =
       if (implicitInfoss.forall(_.isEmpty)) SearchFailure
-      else new ImplicitComputation(implicitInfoss, isLocalToCallsite) findBest()
+      else new ImplicitComputation(implicitInfoss, isLocalToCallsite).findBest()
 
     /** Produce an implicit info map, i.e. a map from the class symbols C of all parts of this type to
      *  the implicit infos in the companion objects of these class symbols C.

--- a/test/files/jvm/future-spec.check
+++ b/test/files/jvm/future-spec.check
@@ -1,3 +1,1 @@
-warning: there was one deprecation warning (since 2.11.0)
-warning: there were 5 deprecation warnings (since 2.13.0)
-warning: there were 6 deprecation warnings in total; re-run with -deprecation for details
+warning: there were 5 deprecation warnings (since 2.13.0); re-run with -deprecation for details

--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -41,8 +41,7 @@ class FutureTests extends MinimalScalaTest {
       val ms = new concurrent.TrieMap[Throwable, Unit]
       implicit val ec = scala.concurrent.ExecutionContext.fromExecutor(new java.util.concurrent.ForkJoinPool(), {
         t =>
-        val u = ()
-        ms += (t -> u)
+        ms += (t -> ())
       })
 
       class ThrowableTest(m: String) extends Throwable(m)

--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -1,3 +1,5 @@
+/* scalac: -Xsource:3.0 */
+
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.concurrent.duration.Duration.Inf
@@ -39,7 +41,8 @@ class FutureTests extends MinimalScalaTest {
       val ms = new concurrent.TrieMap[Throwable, Unit]
       implicit val ec = scala.concurrent.ExecutionContext.fromExecutor(new java.util.concurrent.ForkJoinPool(), {
         t =>
-        ms += (t -> ())
+        val u = ()
+        ms += (t -> u)
       })
 
       class ThrowableTest(m: String) extends Throwable(m)

--- a/test/files/neg/checksensible.check
+++ b/test/files/neg/checksensible.check
@@ -1,21 +1,3 @@
-checksensible.scala:47: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
-        signature: Any.==(x$1: Any): Boolean
-  given arguments: <none>
- after adaptation: Any.==((): Unit)
-  () == ()
-     ^
-checksensible.scala:50: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
-        signature: Object.!=(x$1: Any): Boolean
-  given arguments: <none>
- after adaptation: Object.!=((): Unit)
-  scala.runtime.BoxedUnit.UNIT != ()
-                               ^
-checksensible.scala:51: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
-        signature: Any.!=(x$1: Any): Boolean
-  given arguments: <none>
- after adaptation: Any.!=((): Unit)
-  (scala.runtime.BoxedUnit.UNIT: java.io.Serializable) != () // shouldn't warn
-                                                       ^
 checksensible.scala:15: warning: comparing a fresh object using `eq` will always yield false
   (new AnyRef) eq (new AnyRef)
                ^
@@ -116,5 +98,5 @@ checksensible.scala:97: warning: comparing values of types Unit and Int using `!
     while ((c = in.read) != -1)
                          ^
 error: No warnings can be incurred under -Xfatal-warnings.
-36 warnings found
+33 warnings found
 one error found

--- a/test/files/neg/checksensible.check
+++ b/test/files/neg/checksensible.check
@@ -1,17 +1,16 @@
-#partest java8
-checksensible.scala:47: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
+checksensible.scala:47: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
         signature: Any.==(x$1: Any): Boolean
   given arguments: <none>
  after adaptation: Any.==((): Unit)
   () == ()
      ^
-checksensible.scala:50: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
+checksensible.scala:50: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
         signature: Object.!=(x$1: Any): Boolean
   given arguments: <none>
  after adaptation: Object.!=((): Unit)
   scala.runtime.BoxedUnit.UNIT != ()
                                ^
-checksensible.scala:51: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
+checksensible.scala:51: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
         signature: Any.!=(x$1: Any): Boolean
   given arguments: <none>
  after adaptation: Any.!=((): Unit)
@@ -118,137 +117,4 @@ checksensible.scala:97: warning: comparing values of types Unit and Int using `!
                          ^
 error: No warnings can be incurred under -Xfatal-warnings.
 36 warnings found
-one error found
-#partest !java8
-checksensible.scala:47: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
-        signature: Any.==(x$1: Any): Boolean
-  given arguments: <none>
- after adaptation: Any.==((): Unit)
-  () == ()
-     ^
-checksensible.scala:50: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
-        signature: Object.!=(x$1: Any): Boolean
-  given arguments: <none>
- after adaptation: Object.!=((): Unit)
-  scala.runtime.BoxedUnit.UNIT != ()
-                               ^
-checksensible.scala:51: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
-        signature: Any.!=(x$1: Any): Boolean
-  given arguments: <none>
- after adaptation: Any.!=((): Unit)
-  (scala.runtime.BoxedUnit.UNIT: java.io.Serializable) != () // shouldn't warn
-                                                       ^
-checksensible.scala:15: warning: comparing a fresh object using `eq` will always yield false
-  (new AnyRef) eq (new AnyRef)
-               ^
-checksensible.scala:16: warning: comparing a fresh object using `ne` will always yield true
-  (new AnyRef) ne (new AnyRef)
-               ^
-checksensible.scala:17: warning: comparing a fresh object using `eq` will always yield false
-  Shmoopie eq (new AnyRef)
-           ^
-checksensible.scala:18: warning: comparing a fresh object using `eq` will always yield false
-  (Shmoopie: AnyRef) eq (new AnyRef)
-                     ^
-checksensible.scala:19: warning: comparing a fresh object using `eq` will always yield false
-  (new AnyRef) eq Shmoopie
-               ^
-checksensible.scala:20: warning: comparing a fresh object using `eq` will always yield false
-  (new AnyRef) eq null
-               ^
-checksensible.scala:21: warning: comparing a fresh object using `eq` will always yield false
-  null eq new AnyRef
-       ^
-checksensible.scala:28: warning: comparing values of types Unit and Int using `==` will always yield false
-  (c = 1) == 0
-          ^
-checksensible.scala:29: warning: comparing values of types Integer and Unit using `==` will always yield false
-  0 == (c = 1)
-    ^
-checksensible.scala:31: warning: comparing values of types Int and String using `==` will always yield false
-  1 == "abc"
-    ^
-checksensible.scala:35: warning: comparing values of types Some[Int] and Int using `==` will always yield false
-  Some(1) == 1      // as above
-          ^
-checksensible.scala:37: warning: constructor Boolean in class Boolean is deprecated: see corresponding Javadoc for more information.
-  true == new java.lang.Boolean(true) // none of these should warn except for deprecated API
-          ^
-checksensible.scala:38: warning: constructor Boolean in class Boolean is deprecated: see corresponding Javadoc for more information.
-  new java.lang.Boolean(true) == true
-  ^
-checksensible.scala:40: warning: comparing a fresh object using `==` will always yield false
-  new AnyRef == 1
-             ^
-checksensible.scala:42: warning: constructor Integer in class Integer is deprecated: see corresponding Javadoc for more information.
-  1 == (new java.lang.Integer(1)) // ...something like this
-        ^
-checksensible.scala:43: warning: comparing values of types Int and Boolean using `==` will always yield false
-  1 == (new java.lang.Boolean(true))
-    ^
-checksensible.scala:43: warning: constructor Boolean in class Boolean is deprecated: see corresponding Javadoc for more information.
-  1 == (new java.lang.Boolean(true))
-        ^
-checksensible.scala:45: warning: comparing values of types Int and Boolean using `!=` will always yield true
-  1 != true
-    ^
-checksensible.scala:46: warning: comparing values of types Unit and Boolean using `==` will always yield false
-  () == true
-     ^
-checksensible.scala:47: warning: comparing values of types Unit and Unit using `==` will always yield true
-  () == ()
-     ^
-checksensible.scala:48: warning: comparing values of types Unit and Unit using `==` will always yield true
-  () == println
-     ^
-checksensible.scala:49: warning: comparing values of types Unit and scala.runtime.BoxedUnit using `==` will always yield true
-  () == scala.runtime.BoxedUnit.UNIT // these should warn for always being true/false
-     ^
-checksensible.scala:50: warning: comparing values of types scala.runtime.BoxedUnit and Unit using `!=` will always yield false
-  scala.runtime.BoxedUnit.UNIT != ()
-                               ^
-checksensible.scala:53: warning: comparing values of types Int and Unit using `!=` will always yield true
-  (1 != println)
-     ^
-checksensible.scala:54: warning: comparing values of types Int and Symbol using `!=` will always yield true
-  (1 != 'sym)
-     ^
-checksensible.scala:60: warning: comparing a fresh object using `==` will always yield false
-  ((x: Int) => x + 1) == null
-                      ^
-checksensible.scala:61: warning: comparing a fresh object using `==` will always yield false
-  Bep == ((_: Int) + 1)
-      ^
-checksensible.scala:63: warning: comparing a fresh object using `==` will always yield false
-  new Object == new Object
-             ^
-checksensible.scala:64: warning: comparing a fresh object using `==` will always yield false
-  new Object == "abc"
-             ^
-checksensible.scala:65: warning: comparing a fresh object using `!=` will always yield true
-  new Exception() != new Exception()
-                  ^
-checksensible.scala:68: warning: comparing values of types Int and Null using `==` will always yield false
-  if (foo.length == null) "plante" else "plante pas"
-                 ^
-checksensible.scala:73: warning: comparing values of types Bip and Bop using `==` will always yield false
-  (x1 == x2)
-      ^
-checksensible.scala:83: warning: comparing values of types EqEqRefTest.this.C3 and EqEqRefTest.this.Z1 using `==` will always yield false
-  c3 == z1
-     ^
-checksensible.scala:84: warning: comparing values of types EqEqRefTest.this.Z1 and EqEqRefTest.this.C3 using `==` will always yield false
-  z1 == c3
-     ^
-checksensible.scala:85: warning: comparing values of types EqEqRefTest.this.Z1 and EqEqRefTest.this.C3 using `!=` will always yield true
-  z1 != c3
-     ^
-checksensible.scala:86: warning: comparing values of types EqEqRefTest.this.C3 and String using `!=` will always yield true
-  c3 != "abc"
-     ^
-checksensible.scala:97: warning: comparing values of types Unit and Int using `!=` will always yield true
-    while ((c = in.read) != -1)
-                         ^
-error: No warnings can be incurred under -Xfatal-warnings.
-40 warnings found
 one error found

--- a/test/files/neg/t4851.check
+++ b/test/files/neg/t4851.check
@@ -1,10 +1,10 @@
-S.scala:4: warning: adaptation of an empty argument list by appending () is deprecated: leaky (Object-receiving) target makes this especially dangerous
+S.scala:4: warning: adaptation of an empty argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous
         signature: J(x: Any): J
   given arguments: <none>
  after adaptation: new J((): Unit)
   val x1 = new J
            ^
-S.scala:5: warning: adaptation of an empty argument list by appending () is deprecated: leaky (Object-receiving) target makes this especially dangerous
+S.scala:5: warning: adaptation of an empty argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous
         signature: J(x: Any): J
   given arguments: <none>
  after adaptation: new J((): Unit)
@@ -28,13 +28,13 @@ S.scala:9: warning: adapted the argument list to the expected 3-tuple: add addit
  after adaptation: new Some((1, 2, 3): (Int, Int, Int))
   val y2 = new Some(1, 2, 3)
            ^
-S.scala:11: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
+S.scala:11: warning: adaptation of an empty argument list by inserting () is deprecated: this is unlikely to be what you want
         signature: J2(x: T): J2[T]
   given arguments: <none>
  after adaptation: new J2((): Unit)
   val z1 = new J2
            ^
-S.scala:12: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
+S.scala:12: warning: adaptation of an empty argument list by inserting () is deprecated: this is unlikely to be what you want
         signature: J2(x: T): J2[T]
   given arguments: <none>
  after adaptation: new J2((): Unit)

--- a/test/files/neg/t4851.check
+++ b/test/files/neg/t4851.check
@@ -1,46 +1,46 @@
-S.scala:4: warning: Adaptation of argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous.
+S.scala:4: warning: adaptation of an empty argument list by appending () is deprecated: leaky (Object-receiving) target makes this especially dangerous
         signature: J(x: Any): J
   given arguments: <none>
  after adaptation: new J((): Unit)
   val x1 = new J
            ^
-S.scala:5: warning: Adaptation of argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous.
+S.scala:5: warning: adaptation of an empty argument list by appending () is deprecated: leaky (Object-receiving) target makes this especially dangerous
         signature: J(x: Any): J
   given arguments: <none>
  after adaptation: new J((): Unit)
   val x2 = new J()
            ^
-S.scala:6: warning: Adapting argument list by creating a 5-tuple: this may not be what you want.
+S.scala:6: warning: adapted the argument list to the expected 5-tuple: add additional parens instead
         signature: J(x: Any): J
   given arguments: 1, 2, 3, 4, 5
  after adaptation: new J((1, 2, 3, 4, 5): (Int, Int, Int, Int, Int))
   val x3 = new J(1, 2, 3, 4, 5)
            ^
-S.scala:8: warning: Adapting argument list by creating a 3-tuple: this may not be what you want.
+S.scala:8: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Some.apply[A](value: A): Some[A]
   given arguments: 1, 2, 3
  after adaptation: Some((1, 2, 3): (Int, Int, Int))
   val y1 = Some(1, 2, 3)
                ^
-S.scala:9: warning: Adapting argument list by creating a 3-tuple: this may not be what you want.
+S.scala:9: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Some(value: A): Some[A]
   given arguments: 1, 2, 3
  after adaptation: new Some((1, 2, 3): (Int, Int, Int))
   val y2 = new Some(1, 2, 3)
            ^
-S.scala:11: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
+S.scala:11: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
         signature: J2(x: T): J2[T]
   given arguments: <none>
  after adaptation: new J2((): Unit)
   val z1 = new J2
            ^
-S.scala:12: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
+S.scala:12: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
         signature: J2(x: T): J2[T]
   given arguments: <none>
  after adaptation: new J2((): Unit)
   val z2 = new J2()
            ^
-S.scala:16: warning: Adapting argument list by creating a 3-tuple: this may not be what you want.
+S.scala:16: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Test.anyId(a: Any): Any
   given arguments: 1, 2, 3
  after adaptation: Test.anyId((1, 2, 3): (Int, Int, Int))

--- a/test/files/neg/t8035-deprecated.check
+++ b/test/files/neg/t8035-deprecated.check
@@ -1,16 +1,16 @@
-t8035-deprecated.scala:4: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
+t8035-deprecated.scala:4: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
         signature: SetOps.apply(elem: A): Boolean
   given arguments: <none>
  after adaptation: SetOps((): Unit)
   List(1,2,3).toSet()
                    ^
-t8035-deprecated.scala:7: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
+t8035-deprecated.scala:7: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
         signature: A(x: T): Foo.A[T]
   given arguments: <none>
  after adaptation: new A((): Unit)
   new A
   ^
-t8035-deprecated.scala:11: warning: Adaptation of argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous.
+t8035-deprecated.scala:11: warning: adaptation of an empty argument list by appending () is deprecated: leaky (Object-receiving) target makes this especially dangerous
         signature: Format.format(x$1: Any): String
   given arguments: <none>
  after adaptation: Format.format((): Unit)

--- a/test/files/neg/t8035-deprecated.check
+++ b/test/files/neg/t8035-deprecated.check
@@ -1,16 +1,16 @@
-t8035-deprecated.scala:4: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
+t8035-deprecated.scala:4: warning: adaptation of an empty argument list by inserting () is deprecated: this is unlikely to be what you want
         signature: SetOps.apply(elem: A): Boolean
   given arguments: <none>
  after adaptation: SetOps((): Unit)
   List(1,2,3).toSet()
                    ^
-t8035-deprecated.scala:7: warning: adaptation of an empty argument list by appending () is deprecated: this is unlikely to be what you want
+t8035-deprecated.scala:7: warning: adaptation of an empty argument list by inserting () is deprecated: this is unlikely to be what you want
         signature: A(x: T): Foo.A[T]
   given arguments: <none>
  after adaptation: new A((): Unit)
   new A
   ^
-t8035-deprecated.scala:11: warning: adaptation of an empty argument list by appending () is deprecated: leaky (Object-receiving) target makes this especially dangerous
+t8035-deprecated.scala:11: warning: adaptation of an empty argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous
         signature: Format.format(x$1: Any): String
   given arguments: <none>
  after adaptation: Format.format((): Unit)

--- a/test/files/neg/t8035-removed.check
+++ b/test/files/neg/t8035-removed.check
@@ -1,14 +1,14 @@
-t8035-removed.scala:4: error: adaptation of an empty argument list by appending () is unsupported
+t8035-removed.scala:4: error: adaptation of an empty argument list by inserting () has been removed
         signature: SetOps.apply(elem: A): Boolean
   given arguments: <none>
   List(1,2,3).toSet()
                    ^
-t8035-removed.scala:7: error: adaptation of an empty argument list by appending () is unsupported
+t8035-removed.scala:7: error: adaptation of an empty argument list by inserting () has been removed
         signature: A(x: T): Foo.A[T]
   given arguments: <none>
   new A
   ^
-t8035-removed.scala:11: error: adaptation of an empty argument list by appending () is unsupported
+t8035-removed.scala:11: error: adaptation of an empty argument list by inserting () has been removed
         signature: Format.format(x$1: Any): String
   given arguments: <none>
   sdf.format()

--- a/test/files/neg/t8035-removed.check
+++ b/test/files/neg/t8035-removed.check
@@ -1,14 +1,14 @@
-t8035-removed.scala:4: error: Adaptation of argument list by inserting () has been removed.
+t8035-removed.scala:4: error: adaptation of an empty argument list by appending () is unsupported
         signature: SetOps.apply(elem: A): Boolean
   given arguments: <none>
   List(1,2,3).toSet()
                    ^
-t8035-removed.scala:7: error: Adaptation of argument list by inserting () has been removed.
+t8035-removed.scala:7: error: adaptation of an empty argument list by appending () is unsupported
         signature: A(x: T): Foo.A[T]
   given arguments: <none>
   new A
   ^
-t8035-removed.scala:11: error: Adaptation of argument list by inserting () has been removed.
+t8035-removed.scala:11: error: adaptation of an empty argument list by appending () is unsupported
         signature: Format.format(x$1: Any): String
   given arguments: <none>
   sdf.format()

--- a/test/files/neg/t8417.check
+++ b/test/files/neg/t8417.check
@@ -1,10 +1,10 @@
-t8417.scala:7: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
+t8417.scala:7: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: T.f(x: Any)(y: Any): String
   given arguments: "hello", "world"
  after adaptation: T.f(("hello", "world"): (String, String))
   def g = f("hello", "world")("holy", "moly")
            ^
-t8417.scala:7: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
+t8417.scala:7: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: T.f(x: Any)(y: Any): String
   given arguments: "holy", "moly"
  after adaptation: T.f(("holy", "moly"): (String, String))

--- a/test/files/neg/t8525.check
+++ b/test/files/neg/t8525.check
@@ -1,4 +1,4 @@
-t8525.scala:9: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
+t8525.scala:9: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
  after adaptation: X.f((3, 4): (Int, Int))

--- a/test/files/neg/t8610.check
+++ b/test/files/neg/t8610.check
@@ -1,7 +1,7 @@
 t8610.scala:7: warning: possible missing interpolator: detected interpolated identifier `$name`
   def x = "Hi, $name"   // missing interp
           ^
-t8610.scala:9: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
+t8610.scala:9: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
  after adaptation: X.f((3, 4): (Int, Int))

--- a/test/files/pos/t5413.scala
+++ b/test/files/pos/t5413.scala
@@ -1,9 +1,11 @@
+/* scalac: -Xsource:3.0 */
+
 object Fail {
   def nom (guard : => Boolean) (something : => Unit): Unit = { }
   def main(args: Array[String]): Unit = {
     nom {
       val i = 0
       (i != 3)
-    }()
+    }(())
   }
 }

--- a/test/files/run/macro-range.flags
+++ b/test/files/run/macro-range.flags
@@ -1,1 +1,1 @@
--language:experimental.macros
+-language:experimental.macros -Xsource:3.0

--- a/test/files/run/macro-range/Common_1.scala
+++ b/test/files/run/macro-range/Common_1.scala
@@ -40,7 +40,7 @@ abstract class Utils {
   }
   def makeWhile(lname: TermName, cond: Tree, body: Tree): Tree = {
     val continu = Apply(Ident(lname), Nil)
-    val rhs = If(cond, Block(List(body), continu), Literal(Constant()))
+    val rhs = If(cond, Block(List(body), continu), Literal(Constant(())))
     LabelDef(lname, Nil, rhs)
   }
   def makeBinop(left: Tree, op: String, right: Tree): Tree =

--- a/test/files/run/runtime.scala
+++ b/test/files/run/runtime.scala
@@ -65,7 +65,7 @@ object Test1Test {
     // {System.out.print(12); java.lang}.System.out.println();
     // {System.out.print(13); java.lang.System}.out.println();
     {Console.print(14); Console}.println;
-    {Console.print(15); (() => Console.println):(() => Unit)} apply ();
+    {Console.print(15); (() => Console.println):(() => Unit)}.apply();
     {Console.print(16); Console.println};
 
     {Console.print(20)}; test1.bar.System.out.println();
@@ -73,7 +73,7 @@ object Test1Test {
     // {System.out.print(22); test1.bar}.System.out.println();
     {Console.print(23); test1.bar.System}.out.println();
     {Console.print(24); test1.bar.System.out}.println();
-    {Console.print(25); test1.bar.System.out.println _ : (() => Unit)} apply ();
+    {Console.print(25); test1.bar.System.out.println _ : (() => Unit)}.apply();
     {Console.print(26); test1.bar.System.out.println()};
   }
 

--- a/test/files/run/t576.check
+++ b/test/files/run/t576.check
@@ -1,4 +1,3 @@
-warning: there was one deprecation warning (since 2.11.0); re-run with -deprecation for details
 1
 2
 3

--- a/test/files/run/t576.scala
+++ b/test/files/run/t576.scala
@@ -1,3 +1,5 @@
+/* -Xsource:3.0 */
+
 import scala.language.reflectiveCalls
 
 class A {
@@ -35,7 +37,10 @@ object Test {
 
     assert(x1 == x1)
     assert(x1 != x2)
-    assert(x1 != ())
+
+    // This is a workaround for x1 != (())
+    val unit = ()
+    assert(x1 != unit)
     assert(x2 != x1)
 
     assert(x3 == x3)

--- a/test/files/run/t576.scala
+++ b/test/files/run/t576.scala
@@ -38,9 +38,7 @@ object Test {
     assert(x1 == x1)
     assert(x1 != x2)
 
-    // This is a workaround for x1 != (())
-    val unit = ()
-    assert(x1 != unit)
+    assert(x1 != ())
     assert(x2 != x1)
 
     assert(x3 == x3)

--- a/test/files/run/t6863.check
+++ b/test/files/run/t6863.check
@@ -1,11 +1,12 @@
-t6863.scala:38: warning: comparing values of types Unit and Unit using `==` will always yield true
+t6863.scala:41: warning: comparing values of types Unit and Unit using `==` will always yield true
     assert({ () => x}.apply == ())
                             ^
-t6863.scala:42: warning: comparing values of types Unit and Unit using `==` will always yield true
+t6863.scala:45: warning: comparing values of types Unit and Unit using `==` will always yield true
     assert({ () => x}.apply == ())
                             ^
-t6863.scala:46: warning: comparing values of types Unit and Unit using `==` will always yield true
+t6863.scala:49: warning: comparing values of types Unit and Unit using `==` will always yield true
     assert({ () => x}.apply == ())
                             ^
-t6863.scala:59: warning: comparing values of types Unit and Unit using `==` will always yield true
+t6863.scala:62: warning: comparing values of types Unit and Unit using `==` will always yield true
     assert({ () => x }.apply == ())
+                             ^

--- a/test/files/run/t6863.check
+++ b/test/files/run/t6863.check
@@ -9,5 +9,3 @@ t6863.scala:46: warning: comparing values of types Unit and Unit using `==` will
                             ^
 t6863.scala:59: warning: comparing values of types Unit and Unit using `==` will always yield true
     assert({ () => x }.apply == ())
-                             ^
-warning: there were four deprecation warnings (since 2.11.0); re-run with -deprecation for details

--- a/test/files/run/t6863.scala
+++ b/test/files/run/t6863.scala
@@ -1,5 +1,10 @@
+/* scalac: -Xsource:3.0 */
+
 /** Make sure that when a variable is captured its initialization expression is handled properly */
 object Test {
+  // This is a workaround for x == (())
+  val u = ()
+
   def lazyVal() = {
   	// internally lazy vals become vars which are initialized with "_", so they need to be tested just like vars do
   	lazy val x = "42"
@@ -35,15 +40,15 @@ object Test {
   def assign() = {
     var y = 1
     var x = y = 42
-    assert({ () => x}.apply == ())
+    assert({ () => x}.apply == u)
   }
   def valDef() = {
     var x = {val y = 42}
-    assert({ () => x}.apply == ())
+    assert({ () => x}.apply == u)
   }
   def `return`(): String = {
     var x = if (true) return "42" else ()
-    assert({ () => x}.apply == ())
+    assert({ () => x}.apply == u)
     "42"
   }
   def tryFinally() = {
@@ -56,7 +61,7 @@ object Test {
   }
   def `if`() = {
   	var x = if (true) ()
-    assert({ () => x }.apply == ())
+    assert({ () => x }.apply == u)
   }
   def ifElse() = {
     var x = if(true) "42" else "43"

--- a/test/files/run/t6863.scala
+++ b/test/files/run/t6863.scala
@@ -2,12 +2,10 @@
 
 /** Make sure that when a variable is captured its initialization expression is handled properly */
 object Test {
-  // This is a workaround for x == (())
-  val u = ()
 
   def lazyVal() = {
-  	// internally lazy vals become vars which are initialized with "_", so they need to be tested just like vars do
-  	lazy val x = "42"
+    // internally lazy vals become vars which are initialized with "_", so they need to be tested just like vars do
+    lazy val x = "42"
     assert({ () => x }.apply == "42")
   }
   def ident() = {
@@ -29,7 +27,7 @@ object Test {
     assert({ () => x }.apply == "42")
   }
   def select() = {
-    object Foo{val bar = "42"}
+    object Foo { val bar = "42" }
     var x = Foo.bar
     assert({ () => x }.apply == "42")
   }
@@ -40,15 +38,15 @@ object Test {
   def assign() = {
     var y = 1
     var x = y = 42
-    assert({ () => x}.apply == u)
+    assert({ () => x}.apply == ())
   }
   def valDef() = {
-    var x = {val y = 42}
-    assert({ () => x}.apply == u)
+    var x = { val y = 42 }
+    assert({ () => x}.apply == ())
   }
   def `return`(): String = {
     var x = if (true) return "42" else ()
-    assert({ () => x}.apply == u)
+    assert({ () => x}.apply == ())
     "42"
   }
   def tryFinally() = {
@@ -60,16 +58,16 @@ object Test {
     assert({ () => x }.apply == "42")
   }
   def `if`() = {
-  	var x = if (true) ()
-    assert({ () => x }.apply == u)
+    var x = if (true) ()
+    assert({ () => x }.apply == ())
   }
   def ifElse() = {
-    var x = if(true) "42" else "43"
+    var x = if (true) "42" else "43"
     assert({ () => x }.apply == "42")
   }
   def matchCase() = {
     var x = 100 match {
-       case 100 => "42"
+      case 100 => "42"
       case _ => "43"
     }
     assert({ () => x }.apply == "42")
@@ -90,13 +88,13 @@ object Test {
   def nested() = {
     var x = {
       val y = 42
-        if(true) try "42" catch {case _: Throwable => "43"}
-        else "44"
+      if (true) try "42" catch { case _: Throwable => "43" }
+      else "44"
     }
     assert({ () => x }.apply == "42")
   }
   def main(args: Array[String]): Unit = {
-  	lazyVal()
+    lazyVal()
     ident()
     apply()
     literal()
@@ -116,4 +114,3 @@ object Test {
     nested()
   }
 }
-

--- a/test/files/run/t6935.check
+++ b/test/files/run/t6935.check
@@ -1,1 +1,0 @@
-warning: there was one deprecation warning (since 2.11.0); re-run with -deprecation for details

--- a/test/files/run/t6935.scala
+++ b/test/files/run/t6935.scala
@@ -1,3 +1,5 @@
+/* scalac: -Xsource:3.0 */
+
 object Test {
 
   def main(args: Array[String]): Unit = {
@@ -8,7 +10,9 @@ object Test {
     out.close()
     val buf = bytes.toByteArray
     val in = new ObjectInputStream(new ByteArrayInputStream(buf))
-    val unit = in.readObject()
-    assert(unit == ())
+    val actual = in.readObject()
+    // This is a workaround for actual == (())
+    val unit = ()
+    assert(actual == unit)
   }
 }

--- a/test/files/run/t6935.scala
+++ b/test/files/run/t6935.scala
@@ -11,8 +11,6 @@ object Test {
     val buf = bytes.toByteArray
     val in = new ObjectInputStream(new ByteArrayInputStream(buf))
     val actual = in.readObject()
-    // This is a workaround for actual == (())
-    val unit = ()
-    assert(actual == unit)
+    assert(actual == ())
   }
 }

--- a/test/files/run/t8610.check
+++ b/test/files/run/t8610.check
@@ -1,4 +1,4 @@
-t8610.scala:8: warning: Adapting argument list by creating a 2-tuple: this may not be what you want.
+t8610.scala:8: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
  after adaptation: X.f((3, 4): (Int, Int))

--- a/test/junit/scala/lang/stringinterpol/StringContextTest.scala
+++ b/test/junit/scala/lang/stringinterpol/StringContextTest.scala
@@ -72,7 +72,7 @@ class StringContextTest {
 
   // verifying that the standard interpolators can be supplanted
   @Test def antiHijack_?() = {
-    object AllYourStringsAreBelongToMe { case class StringContext(args: Any*) { def s(args: Any) = "!!!!" } }
+    object AllYourStringsAreBelongToMe { case class StringContext(args: Any*) { def s(args: Any*) = "!!!!" } }
     import AllYourStringsAreBelongToMe._
     //assertEquals("????", s"????")
     assertEquals("!!!!", s"????") // OK to hijack core interpolator ids


### PR DESCRIPTION
Commits not reordered or squashed.

Besides updating check files, attempts to preserve unit value in

```
"" + ()
```
which currently warns because it takes the empty parens as an empty arg list instead of unit value.

The spec is clear that "several args in parens" are taken as an arg list, not empty parens.