### PR TITLE
Normalise APIs for Auto-Application removal

### DIFF
--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -232,7 +232,7 @@ object StringContext {
     val ai = args.iterator
     val bldr = new JLSBuilder(process(pi.next()))
     while (ai.hasNext) {
-      bldr append ai.next
+      bldr append ai.next()
       bldr append process(pi.next())
     }
     bldr.toString

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -1061,7 +1061,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     */
   final def mkString(start: String, sep: String, end: String): String =
     if (isEmpty) start + end
-    else addString(new StringBuilder(), start, sep, end).result
+    else addString(new StringBuilder(), start, sep, end).result()
 
   /** Displays all elements of this $coll in a string using a separator string.
     *
@@ -1116,10 +1116,10 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     if (start.length != 0) jsb.append(start)
     val it = iterator
     if (it.hasNext) {
-      jsb.append(it.next)
+      jsb.append(it.next())
       while (it.hasNext) {
         jsb.append(sep)
-        jsb.append(it.next)
+        jsb.append(it.next())
       }
     }
     if (end.length != 0) jsb.append(end)

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -1051,7 +1051,7 @@ final class StringOps(private val s: String) extends AnyVal {
   def indices: Range = Range(0, s.length)
 
   /** Iterator can be used only once */
-  def iterator(): Iterator[Char] = new StringIterator(s)
+  def iterator: Iterator[Char] = new StringIterator(s)
 
   /** Tests whether the string is not empty. */
   @`inline` def nonEmpty: Boolean = !s.isEmpty
@@ -1065,7 +1065,7 @@ final class StringOps(private val s: String) extends AnyVal {
     *
     *  @return  an iterator yielding the chars of this string in reversed order
     */
-  def reverseIterator(): Iterator[Char] = new ReverseIterator(s)
+  def reverseIterator: Iterator[Char] = new ReverseIterator(s)
 
   /** Creates a non-strict filter of this string.
     *

--- a/src/library/scala/collection/generic/IsIterableLike.scala
+++ b/src/library/scala/collection/generic/IsIterableLike.scala
@@ -115,8 +115,8 @@ object IsIterableLike {
         protected[this] def coll: String = s
         protected[this] def fromSpecificIterable(coll: Iterable[Char]): String = coll.mkString
         def iterableFactory: IterableFactory[Iterable] = Iterable
-        protected[this] def newSpecificBuilder(): mutable.Builder[Char, String] = new StringBuilder
-        def iterator(): Iterator[Char] = s.iterator()
+        protected[this] def newSpecificBuilder: mutable.Builder[Char, String] = new StringBuilder
+        def iterator: Iterator[Char] = s.iterator
       }
     }
 

--- a/src/library/scala/collection/generic/IsSeqLike.scala
+++ b/src/library/scala/collection/generic/IsSeqLike.scala
@@ -31,8 +31,8 @@ object IsSeqLike {
         protected[this] def coll: String = s
         protected[this] def fromSpecificIterable(coll: Iterable[Char]): String = coll.mkString
         def iterableFactory: IterableFactory[Seq] = Seq
-        protected[this] def newSpecificBuilder(): mutable.Builder[Char, String] = new StringBuilder
-        def iterator(): Iterator[Char] = s.iterator()
+        protected[this] def newSpecificBuilder: mutable.Builder[Char, String] = new StringBuilder
+        def iterator: Iterator[Char] = s.iterator
       }
     }
 

--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -227,7 +227,7 @@ abstract class Source extends Iterator[Char] with Closeable {
       }
     }
     def hasNext = iter.hasNext
-    def next = {
+    def next() = {
       sb.clear()
       while (getc()) { }
       sb.toString

--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -394,7 +394,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    *  with large exponents.
    */
   override def hashCode(): Int = {
-    if (computedHashCode == BigDecimal.hashCodeNotComputed) computeHashCode
+    if (computedHashCode == BigDecimal.hashCodeNotComputed) computeHashCode()
     computedHashCode
   }
 
@@ -466,7 +466,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
     catch { case _: ArithmeticException => false }
   }
 
-  def isWhole() = scale <= 0 || bigDecimal.stripTrailingZeros.scale <= 0
+  def isWhole = scale <= 0 || bigDecimal.stripTrailingZeros.scale <= 0
 
   def underlying = bigDecimal
 
@@ -547,11 +547,11 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    *   +1 if it is greater than 0,
    *   0  if it is equal to 0.
    */
-  def signum: Int = this.bigDecimal.signum()
+  def signum: Int = this.bigDecimal.signum
 
   /** Returns the precision of this `BigDecimal`.
    */
-  def precision: Int = this.bigDecimal.precision()
+  def precision: Int = this.bigDecimal.precision
 
   /** Returns a BigDecimal rounded according to the supplied MathContext settings, but
    *  preserving its own MathContext for future operations.
@@ -569,7 +569,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
 
   /** Returns the scale of this `BigDecimal`.
    */
-  def scale: Int = this.bigDecimal.scale()
+  def scale: Int = this.bigDecimal.scale
 
   /** Returns the size of an ulp, a unit in the last place, of this BigDecimal.
    */
@@ -697,20 +697,20 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
 
   /** Converts this `BigDecimal` to a scala.BigInt.
    */
-  def toBigInt(): BigInt = new BigInt(this.bigDecimal.toBigInteger())
+  def toBigInt: BigInt = new BigInt(this.bigDecimal.toBigInteger)
 
   /** Converts this `BigDecimal` to a scala.BigInt if it
    *  can be done losslessly, returning Some(BigInt) or None.
    */
-  def toBigIntExact(): Option[BigInt] =
-    if (isWhole()) {
-      try Some(new BigInt(this.bigDecimal.toBigIntegerExact()))
+  def toBigIntExact: Option[BigInt] =
+    if (isWhole) {
+      try Some(new BigInt(this.bigDecimal.toBigIntegerExact))
       catch { case _: ArithmeticException => None }
     }
     else None
 
   /** Returns the decimal String representation of this BigDecimal.
    */
-  override def toString(): String = this.bigDecimal.toString()
+  override def toString: String = this.bigDecimal.toString
 
 }

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -115,7 +115,7 @@ final class BigInt(val bigInteger: BigInteger)
 {
   /** Returns the hash code for this BigInt. */
   override def hashCode(): Int =
-    if (isValidLong) unifiedPrimitiveHashcode()
+    if (isValidLong) unifiedPrimitiveHashcode
     else bigInteger.##
 
   /** Compares this BigInt with the specified value for equality.

--- a/src/library/scala/math/ScalaNumericConversions.scala
+++ b/src/library/scala/math/ScalaNumericConversions.scala
@@ -13,7 +13,7 @@ package math
  *  extend ScalaNumber (which excludes value classes.)
  */
 trait ScalaNumericConversions extends ScalaNumber with ScalaNumericAnyConversions {
-  def underlying(): Object
+  def underlying: Object
 }
 
 /** Conversions which present a consistent conversion interface
@@ -21,50 +21,50 @@ trait ScalaNumericConversions extends ScalaNumber with ScalaNumericAnyConversion
  */
 trait ScalaNumericAnyConversions extends Any {
   /** @return `'''true'''` if this number has no decimal component, `'''false'''` otherwise. */
-  def isWhole(): Boolean
-  def underlying(): Any
+  def isWhole: Boolean
+  def underlying: Any
 
-  def byteValue(): Byte
-  def shortValue(): Short
-  def intValue(): Int
-  def longValue(): Long
-  def floatValue(): Float
-  def doubleValue(): Double
+  def byteValue: Byte
+  def shortValue: Short
+  def intValue: Int
+  def longValue: Long
+  def floatValue: Float
+  def doubleValue: Double
 
   /** Returns the value of this as a [[scala.Char]]. This may involve
     * rounding or truncation.
     */
-  def toChar = intValue().toChar
+  def toChar = intValue.toChar
 
   /** Returns the value of this as a [[scala.Byte]]. This may involve
     * rounding or truncation.
     */
-  def toByte = byteValue()
+  def toByte = byteValue
 
   /** Returns the value of this as a [[scala.Short]]. This may involve
     * rounding or truncation.
     */
-  def toShort = shortValue()
+  def toShort = shortValue
 
   /** Returns the value of this as an [[scala.Int]]. This may involve
     * rounding or truncation.
     */
-  def toInt = intValue()
+  def toInt = intValue
 
   /** Returns the value of this as a [[scala.Long]]. This may involve
     * rounding or truncation.
     */
-  def toLong = longValue()
+  def toLong = longValue
 
   /** Returns the value of this as a [[scala.Float]]. This may involve
     * rounding or truncation.
     */
-  def toFloat = floatValue()
+  def toFloat = floatValue
 
   /** Returns the value of this as a [[scala.Double]]. This may involve
     * rounding or truncation.
     */
-  def toDouble = doubleValue()
+  def toDouble = doubleValue
 
   /** Returns `true` iff this has a zero fractional part, and is within the
     * range of [[scala.Byte]] MinValue and MaxValue; otherwise returns `false`.
@@ -86,7 +86,7 @@ trait ScalaNumericAnyConversions extends Any {
     */
   def isValidChar  = isWhole && (toInt >= Char.MinValue && toInt <= Char.MaxValue)
 
-  protected def unifiedPrimitiveHashcode() = {
+  protected def unifiedPrimitiveHashcode = {
     val lv = toLong
     if (lv >= Int.MinValue && lv <= Int.MaxValue) lv.toInt
     else lv.##

--- a/src/library/scala/ref/Reference.scala
+++ b/src/library/scala/ref/Reference.scala
@@ -20,5 +20,5 @@ trait Reference[+T <: AnyRef] extends Function0[T] {
   override def toString = get.map(_.toString).getOrElse("<deleted>")
   def clear(): Unit
   def enqueue(): Boolean
-  def isEnqueued(): Boolean
+  def isEnqueued: Boolean
 }

--- a/src/library/scala/ref/ReferenceWrapper.scala
+++ b/src/library/scala/ref/ReferenceWrapper.scala
@@ -21,7 +21,7 @@ trait ReferenceWrapper[+T <: AnyRef] extends Reference[T] with Proxy {
     ret
   }
   def clear() = underlying.clear()
-  def enqueue = underlying.enqueue
+  def enqueue() = underlying.enqueue()
   def isEnqueued = underlying.isEnqueued
   def self = underlying
 }

--- a/src/library/scala/runtime/RichByte.scala
+++ b/src/library/scala/runtime/RichByte.scala
@@ -14,12 +14,12 @@ final class RichByte(val self: Byte) extends AnyVal with ScalaWholeNumberProxy[B
   protected def num = scala.math.Numeric.ByteIsIntegral
   protected def ord = scala.math.Ordering.Byte
 
-  override def doubleValue() = self.toDouble
-  override def floatValue()  = self.toFloat
-  override def longValue()   = self.toLong
-  override def intValue()    = self.toInt
-  override def byteValue()   = self
-  override def shortValue()  = self.toShort
+  override def doubleValue = self.toDouble
+  override def floatValue  = self.toFloat
+  override def longValue   = self.toLong
+  override def intValue    = self.toInt
+  override def byteValue   = self
+  override def shortValue  = self.toShort
 
   override def isValidByte   = true
 

--- a/src/library/scala/runtime/RichChar.scala
+++ b/src/library/scala/runtime/RichChar.scala
@@ -16,12 +16,12 @@ final class RichChar(val self: Char) extends AnyVal with IntegralProxy[Char] {
   protected def num = scala.math.Numeric.CharIsIntegral
   protected def ord = scala.math.Ordering.Char
 
-  override def doubleValue() = self.toDouble
-  override def floatValue()  = self.toFloat
-  override def longValue()   = self.toLong
-  override def intValue()    = self.toInt
-  override def byteValue()   = self.toByte
-  override def shortValue()  = self.toShort
+  override def doubleValue = self.toDouble
+  override def floatValue  = self.toFloat
+  override def longValue   = self.toLong
+  override def intValue    = self.toInt
+  override def byteValue   = self.toByte
+  override def shortValue  = self.toShort
 
   override def isValidChar   = true
 

--- a/src/library/scala/runtime/RichDouble.scala
+++ b/src/library/scala/runtime/RichDouble.scala
@@ -13,12 +13,12 @@ final class RichDouble(val self: Double) extends AnyVal with FractionalProxy[Dou
   protected def num: Fractional[Double] = scala.math.Numeric.DoubleIsFractional
   protected def ord: Ordering[Double]   = scala.math.Ordering.Double.TotalOrdering
 
-  override def doubleValue() = self
-  override def floatValue()  = self.toFloat
-  override def longValue()   = self.toLong
-  override def intValue()    = self.toInt
-  override def byteValue()   = self.toByte
-  override def shortValue()  = self.toShort
+  override def doubleValue = self
+  override def floatValue  = self.toFloat
+  override def longValue   = self.toLong
+  override def intValue    = self.toInt
+  override def byteValue   = self.toByte
+  override def shortValue  = self.toShort
 
   override def isWhole = {
     val l = self.toLong

--- a/src/library/scala/runtime/RichFloat.scala
+++ b/src/library/scala/runtime/RichFloat.scala
@@ -13,12 +13,12 @@ final class RichFloat(val self: Float) extends AnyVal with FractionalProxy[Float
   protected def num: Fractional[Float] = scala.math.Numeric.FloatIsFractional
   protected def ord: Ordering[Float]   = scala.math.Ordering.Float.TotalOrdering
 
-  override def doubleValue() = self.toDouble
-  override def floatValue()  = self
-  override def longValue()   = self.toLong
-  override def intValue()    = self.toInt
-  override def byteValue()   = self.toByte
-  override def shortValue()  = self.toShort
+  override def doubleValue = self.toDouble
+  override def floatValue  = self
+  override def longValue   = self.toLong
+  override def intValue    = self.toInt
+  override def byteValue   = self.toByte
+  override def shortValue  = self.toShort
 
   override def isWhole = {
     val l = self.toLong

--- a/src/library/scala/runtime/RichInt.scala
+++ b/src/library/scala/runtime/RichInt.scala
@@ -17,12 +17,12 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
   protected def num = scala.math.Numeric.IntIsIntegral
   protected def ord = scala.math.Ordering.Int
 
-  override def doubleValue() = self.toDouble
-  override def floatValue()  = self.toFloat
-  override def longValue()   = self.toLong
-  override def intValue()    = self
-  override def byteValue()   = self.toByte
-  override def shortValue()  = self.toShort
+  override def doubleValue = self.toDouble
+  override def floatValue  = self.toFloat
+  override def longValue   = self.toLong
+  override def intValue    = self
+  override def byteValue   = self.toByte
+  override def shortValue  = self.toShort
 
   /** Returns `'''true'''` if this number has no decimal component.
     * Always `'''true'''` for `RichInt`.

--- a/src/library/scala/runtime/RichLong.scala
+++ b/src/library/scala/runtime/RichLong.scala
@@ -13,12 +13,12 @@ final class RichLong(val self: Long) extends AnyVal with IntegralProxy[Long] {
   protected def num = scala.math.Numeric.LongIsIntegral
   protected def ord = scala.math.Ordering.Long
 
-  override def doubleValue() = self.toDouble
-  override def floatValue()  = self.toFloat
-  override def longValue()   = self
-  override def intValue()    = self.toInt
-  override def byteValue()   = self.toByte
-  override def shortValue()  = self.toShort
+  override def doubleValue = self.toDouble
+  override def floatValue  = self.toFloat
+  override def longValue   = self
+  override def intValue    = self.toInt
+  override def byteValue   = self.toByte
+  override def shortValue  = self.toShort
 
   override def isValidByte  = self.toByte.toLong == self
   override def isValidShort = self.toShort.toLong == self

--- a/src/library/scala/runtime/RichShort.scala
+++ b/src/library/scala/runtime/RichShort.scala
@@ -14,12 +14,12 @@ final class RichShort(val self: Short) extends AnyVal with ScalaWholeNumberProxy
   protected def num = scala.math.Numeric.ShortIsIntegral
   protected def ord = scala.math.Ordering.Short
 
-  override def doubleValue() = self.toDouble
-  override def floatValue()  = self.toFloat
-  override def longValue()   = self.toLong
-  override def intValue()    = self.toInt
-  override def byteValue()   = self.toByte
-  override def shortValue()  = self
+  override def doubleValue = self.toDouble
+  override def floatValue  = self.toFloat
+  override def longValue   = self.toLong
+  override def intValue    = self.toInt
+  override def byteValue   = self.toByte
+  override def shortValue  = self
 
   override def isValidShort  = true
 

--- a/src/library/scala/runtime/ScalaNumberProxy.scala
+++ b/src/library/scala/runtime/ScalaNumberProxy.scala
@@ -23,13 +23,13 @@ import Proxy.Typed
 trait ScalaNumberProxy[T] extends Any with ScalaNumericAnyConversions with Typed[T] with OrderedProxy[T] {
   protected implicit def num: Numeric[T]
 
-  def underlying()  = self.asInstanceOf[AnyRef]
-  def doubleValue() = num.toDouble(self)
-  def floatValue()  = num.toFloat(self)
-  def longValue()   = num.toLong(self)
-  def intValue()    = num.toInt(self)
-  def byteValue()   = intValue().toByte
-  def shortValue()  = intValue().toShort
+  def underlying  = self.asInstanceOf[AnyRef]
+  def doubleValue = num.toDouble(self)
+  def floatValue  = num.toFloat(self)
+  def longValue   = num.toLong(self)
+  def intValue    = num.toInt(self)
+  def byteValue   = intValue.toByte
+  def shortValue  = intValue.toShort
 
   /** Returns `'''this'''` if `'''this''' < that` or `that` otherwise. */
   def min(that: T): T = num.min(self, that)
@@ -41,7 +41,7 @@ trait ScalaNumberProxy[T] extends Any with ScalaNumericAnyConversions with Typed
   def signum          = num.signum(self)
 }
 trait ScalaWholeNumberProxy[T] extends Any with ScalaNumberProxy[T] {
-  def isWhole() = true
+  def isWhole = true
 }
 trait IntegralProxy[T] extends Any with ScalaWholeNumberProxy[T] with RangedProxy[T] {
   protected implicit def num: Integral[T]
@@ -55,7 +55,7 @@ trait IntegralProxy[T] extends Any with ScalaWholeNumberProxy[T] with RangedProx
 trait FractionalProxy[T] extends Any with ScalaNumberProxy[T] {
   protected implicit def num: Fractional[T]
 
-  def isWhole() = false
+  def isWhole = false
 }
 
 trait OrderedProxy[T] extends Any with Ordered[T] with Typed[T] {

--- a/src/library/scala/sys/BooleanProp.scala
+++ b/src/library/scala/sys/BooleanProp.scala
@@ -48,9 +48,13 @@ object BooleanProp {
     def set(newValue: String) = "" + value
     def setValue[T1 >: Boolean](newValue: T1): Boolean = value
     def get: String = "" + value
-    val clear, enable, disable, toggle = ()
     def option = if (isSet) Some(value) else None
     //def or[T1 >: Boolean](alt: => T1): T1 = if (value) true else alt
+
+    def clear() = ()
+    def enable() = ()
+    def disable() = ()
+    def toggle() = ()
 
     protected def zero = false
   }

--- a/src/library/scala/sys/ShutdownHookThread.scala
+++ b/src/library/scala/sys/ShutdownHookThread.scala
@@ -29,7 +29,7 @@ object ShutdownHookThread {
    *  given code.
    */
   def apply(body: => Unit): ShutdownHookThread = {
-    val t = new ShutdownHookThread(() => body, hookName)
+    val t = new ShutdownHookThread(() => body, hookName())
     Runtime.getRuntime addShutdownHook t
     t
   }

--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -393,7 +393,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
     val matchIterator = findAllIn(source)
     new AbstractIterator[Match] {
       def hasNext = matchIterator.hasNext
-      def next: Match = {
+      def next(): Match = {
         matchIterator.next()
         new Match(matchIterator.source, matchIterator.matcher, matchIterator.groupNames).force
       }
@@ -854,14 +854,14 @@ object Regex {
     /** Convert to an iterator that yields MatchData elements instead of Strings. */
     def matchData: Iterator[Match] = new AbstractIterator[Match] {
       def hasNext = self.hasNext
-      def next = { self.next(); new Match(source, matcher, groupNames).force }
+      def next() = { self.next(); new Match(source, matcher, groupNames).force }
     }
 
     /** Convert to an iterator that yields MatchData elements instead of Strings and has replacement support. */
     private[matching] def replacementData = new AbstractIterator[Match] with Replacement {
       def matcher = self.matcher
       def hasNext = self.hasNext
-      def next = { self.next(); new Match(source, matcher, groupNames).force }
+      def next() = { self.next(); new Match(source, matcher, groupNames).force }
     }
   }
 

--- a/test/files/pos/t6600.scala
+++ b/test/files/pos/t6600.scala
@@ -1,8 +1,8 @@
 final class Natural extends scala.math.ScalaNumber with scala.math.ScalaNumericConversions {
-  def intValue(): Int = 0
-  def longValue(): Long = 0L
-  def floatValue(): Float = 0.0F
-  def doubleValue(): Double = 0.0D
-  def isWhole(): Boolean = false
-  def underlying() = this
+  def intValue: Int = 0
+  def longValue: Long = 0L
+  def floatValue: Float = 0.0F
+  def doubleValue: Double = 0.0D
+  def isWhole: Boolean = false
+  def underlying = this
 }

--- a/test/files/presentation/infix-completion.check
+++ b/test/files/presentation/infix-completion.check
@@ -7,7 +7,7 @@ retrieved 202 members
 [inaccessible] protected def num: Fractional[Double]
 [inaccessible] protected def ord: Ordering[Double]
 [inaccessible] protected def unifiedPrimitiveEquals(x: Any): Boolean
-[inaccessible] protected def unifiedPrimitiveHashcode(): Int
+[inaccessible] protected def unifiedPrimitiveHashcode: Int
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def !=(x: Byte): Boolean
@@ -159,7 +159,7 @@ def toString(): String
 def unary_+: Int
 def unary_-: Int
 def unary_~: Int
-def underlying(): AnyRef
+def underlying: AnyRef
 def until(end: Int): scala.collection.immutable.Range
 def until(end: Int, step: Int): scala.collection.immutable.Range
 def until(end: Long): scala.collection.immutable.NumericRange.Exclusive[Long]
@@ -188,7 +188,7 @@ override def isValidByte: Boolean
 override def isValidChar: Boolean
 override def isValidInt: Boolean
 override def isValidShort: Boolean
-override def isWhole(): Boolean
+override def isWhole: Boolean
 override def max(that: Double): Double
 override def max(that: Float): Float
 override def max(that: Int): Int

--- a/test/files/presentation/infix-completion2.check
+++ b/test/files/presentation/infix-completion2.check
@@ -7,7 +7,7 @@ retrieved 202 members
 [inaccessible] protected def num: Fractional[Double]
 [inaccessible] protected def ord: Ordering[Double]
 [inaccessible] protected def unifiedPrimitiveEquals(x: Any): Boolean
-[inaccessible] protected def unifiedPrimitiveHashcode(): Int
+[inaccessible] protected def unifiedPrimitiveHashcode: Int
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def !=(x: Byte): Boolean
@@ -159,7 +159,7 @@ def toString(): String
 def unary_+: Int
 def unary_-: Int
 def unary_~: Int
-def underlying(): AnyRef
+def underlying: AnyRef
 def until(end: Int): scala.collection.immutable.Range
 def until(end: Int, step: Int): scala.collection.immutable.Range
 def until(end: Long): scala.collection.immutable.NumericRange.Exclusive[Long]
@@ -188,7 +188,7 @@ override def isValidByte: Boolean
 override def isValidChar: Boolean
 override def isValidInt: Boolean
 override def isValidShort: Boolean
-override def isWhole(): Boolean
+override def isWhole: Boolean
 override def max(that: Double): Double
 override def max(that: Float): Float
 override def max(that: Int): Int


### PR DESCRIPTION
Dotty does not support Auto-Application (an empty argument list `()` was
implicitly inserted when calling a nullary method without arguments).

See http://dotty.epfl.ch/docs/reference/dropped/auto-apply.html