### PR TITLE
Remove some abstract overrides

### DIFF
--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -82,11 +82,6 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   /** The length (number of elements) of the $coll. `size` is an alias for `length` in `Seq` collections. */
   def length: Int
 
-  /**
-    * @return This collection as a `Seq[A]`. This is equivalent to `to(Seq)` but might be faster.
-    */
-  def toSeq: immutable.Seq[A]
-
   /** A copy of the $coll with an element prepended.
     *
     * Also, the original $coll is not modified, so you will want to capture the result.

--- a/src/library/scala/reflect/ClassManifestDeprecatedApis.scala
+++ b/src/library/scala/reflect/ClassManifestDeprecatedApis.scala
@@ -94,9 +94,6 @@ trait ClassManifestDeprecatedApis[T] extends OptManifest[T] {
   def arrayManifest: ClassManifest[Array[T]] =
     ClassManifest.classType[Array[T]](arrayClass[T](runtimeClass), this)
 
-  override def newArray(len: Int): Array[T] =
-    java.lang.reflect.Array.newInstance(runtimeClass, len).asInstanceOf[Array[T]]
-
   @deprecated("use wrap.newArray instead", "2.10.0")
   def newArray2(len: Int): Array[Array[T]] =
     java.lang.reflect.Array.newInstance(arrayClass[T](runtimeClass), len)

--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -46,7 +46,8 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
   def wrap: ClassTag[Array[T]] = ClassTag[Array[T]](arrayClass(runtimeClass))
 
   /** Produces a new array with element type `T` and length `len` */
-  override def newArray(len: Int): Array[T]
+  def newArray(len: Int): Array[T] =
+    java.lang.reflect.Array.newInstance(runtimeClass, len).asInstanceOf[Array[T]]
 
   /** A ClassTag[T] can serve as an extractor that matches only objects of type T.
    *


### PR DESCRIPTION
If a concrete members is overridden by an abstract member, children must
provide an implementation in Dotty. See lampepfl/dotty#4770