### PR TITLE
Accept underscore as numeric literal separator

### DIFF
--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -333,13 +333,15 @@ digit           ::=  ‘0’ | nonZeroDigit
 nonZeroDigit    ::=  ‘1’ | … | ‘9’
 ```
 
-Integer literals are usually of type `Int`, or of type
-`Long` when followed by a `L` or
-`l` suffix. Values of type `Int` are all integer
+Values of type `Int` are all integer
 numbers between $-2\^{31}$ and $2\^{31}-1$, inclusive.  Values of
 type `Long` are all integer numbers between $-2\^{63}$ and
 $2\^{63}-1$, inclusive. A compile-time error occurs if an integer literal
 denotes a number outside these ranges.
+
+Integer literals are usually of type `Int`, or of type
+`Long` when followed by a `L` or `l` suffix.
+(Lowercase `l` is deprecated for reasons of legibility.)
 
 However, if the expected type [_pt_](06-expressions.html#expression-typing) of a literal
 in an expression is either `Byte`, `Short`, or `Char`
@@ -353,8 +355,11 @@ is _pt_. The numeric ranges given by these types are:
 |`Short`         | $-2\^{15}$ to $2\^{15}-1$|
 |`Char`          | $0$ to $2\^{16}-1$       |
 
+The digits of a numeric literal may be separated by
+arbitrarily many underscores for purposes of legibility.
+
 > ```scala
-> 0          21          0xFFFFFFFF       -42L
+> 0           21_000      0x7F        -42L        0xFFFF_FFFF
 > ```
 
 ### Floating Point Literals

--- a/test/files/neg/t6124.check
+++ b/test/files/neg/t6124.check
@@ -1,0 +1,28 @@
+t6124.scala:3: error: trailing separator is not allowed
+  def i: Int = 123_456_
+                      ^
+t6124.scala:4: error: trailing separator is not allowed
+  def j: Long = 123_456_L * 1000
+                       ^
+t6124.scala:7: error: trailing separator is not allowed
+  def f = 3_14_E-2
+              ^
+t6124.scala:8: error: Invalid literal number
+  def e = 3_14E-_2
+          ^
+t6124.scala:9: error: trailing separator is not allowed
+  def d = 3_14E-2_
+                 ^
+t6124.scala:11: error: trailing separator is not allowed
+  def p = 3.1_4_
+               ^
+t6124.scala:12: error: trailing separator is not allowed
+  def q = 3.1_4_d
+               ^
+t6124.scala:13: error: trailing separator is not allowed
+  def r = 3.1_4_dd
+               ^
+t6124.scala:13: error: Invalid literal number
+  def r = 3.1_4_dd
+          ^
+9 errors found

--- a/test/files/neg/t6124.scala
+++ b/test/files/neg/t6124.scala
@@ -1,0 +1,16 @@
+
+trait T {
+  def i: Int = 123_456_
+  def j: Long = 123_456_L * 1000
+  //def k = 123'455'
+
+  def f = 3_14_E-2
+  def e = 3_14E-_2
+  def d = 3_14E-2_
+
+  def p = 3.1_4_
+  def q = 3.1_4_d
+  def r = 3.1_4_dd
+
+  def z = 0
+}

--- a/test/files/pos/t6124.scala
+++ b/test/files/pos/t6124.scala
@@ -1,0 +1,11 @@
+
+trait T {
+  def i: Int = 1_024
+  def j: Long = 1_024L * 1_024
+  //def k = 1'024
+
+  def f = 3_14e-2
+  def d = 3_14E-2_1
+
+  def z = 0
+}

--- a/test/files/run/literals-parsing.check
+++ b/test/files/run/literals-parsing.check
@@ -1,0 +1,14 @@
+[[syntax trees at end of                    parser]] // newSource1.scala
+[0:161]package [0:0]<empty> {
+  [0:161]abstract trait T extends [8:161][161]scala.AnyRef {
+    [8]def $init$() = [8]{
+      [8]()
+    };
+    [16:34]def i: [23:26]Int = [29:34]1024;
+    [41:69]def j: [48:52]Long = [55:69][55:63][55:61]1024L.$times([64:69]1024);
+    [99:114]def f = [107:114]3.14;
+    [121:138]def d = [129:138]3.14E-19;
+    [146:155]def z = [154:155]0
+  }
+}
+

--- a/test/files/run/literals-parsing.scala
+++ b/test/files/run/literals-parsing.scala
@@ -1,0 +1,27 @@
+import scala.tools.partest.DirectTest
+
+object Test extends DirectTest {
+
+  override def extraSettings: String =
+    s"-usejavacp -Xprint-pos -Xprint:parser -Yrangepos -Ystop-after:parser -d ${testOutput.path} -cp ${testOutput.path}"
+
+  // test/files/pos/t6124.scala
+  override def code = """
+    trait T {
+      def i: Int = 1_024
+      def j: Long = 1_024L * 1_024
+      //def k = 1'024
+
+      def f = 3_14e-2
+      def d = 3_14E-2_1
+
+      def z = 0
+    }
+  """.trim
+
+  override def show(): Unit = Console.withErr(System.out) {
+    compile()
+  }
+}
+
+// support classes here, as needed


### PR DESCRIPTION
`000123`, `000_123`, `000'123`, `3_14e-0_2`.