### PR TITLE
[REJECTED] Use lightweight exception for Success.filter

### DIFF
--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -264,12 +264,12 @@ final case class Success[+T](value: T) extends Try[T] {
     try {
       val v = pf.applyOrElse(value, ((x: T) => marker).asInstanceOf[Function[T, U]])
       if (marker ne v.asInstanceOf[AnyRef]) Success(v)
-      else Failure(new NoSuchElementException("Predicate does not hold for " + value))
+      else Failure(new Success.UnsatisfiedPredicateException(value))
     } catch { case NonFatal(e) => Failure(e) }
   }
   override def filter(p: T => Boolean): Try[T] =
     try {
-      if (p(value)) this else Failure(new NoSuchElementException("Predicate does not hold for " + value))
+      if (p(value)) this else Failure(new Success.UnsatisfiedPredicateException(value))
     } catch { case NonFatal(e) => Failure(e) }
   override def recover[U >: T](pf: PartialFunction[Throwable, U]): Try[U] = this
   override def recoverWith[U >: T](pf: PartialFunction[Throwable, Try[U]]): Try[U] = this
@@ -278,4 +278,9 @@ final case class Success[+T](value: T) extends Try[T] {
   override def toEither: Either[Throwable, T] = Right(value)
   override def fold[U](fa: Throwable => U, fb: T => U): U =
     try { fb(value) } catch { case NonFatal(e) => fa(e) }
+
+}
+
+object Success {
+  class UnsatisfiedPredicateException[T] private[Success] (val value: T) extends RuntimeException("Predicate does not hold", null, false, false)
 }

--- a/test/files/jvm/try-type-tests.scala
+++ b/test/files/jvm/try-type-tests.scala
@@ -48,7 +48,7 @@ trait TryStandard {
     val n = t.filter(x => x < 0)
     n match {
       case Success(v) => assert(false)
-      case Failure(e: NoSuchElementException) => assert(true)
+      case Failure(e: Success.UnsatisfiedPredicateException[_]) => ()
       case _          => assert(false)
     }
   }

--- a/test/junit/scala/util/TryTest.scala
+++ b/test/junit/scala/util/TryTest.scala
@@ -10,26 +10,33 @@ import org.junit.Assert._
 class TryTest {
   @Test
   def withFilterFail(): Unit = {
-    val fail = for (x <- util.Try(1) if x > 1) yield x
-    assert(fail.isFailure)
+    val fail = for (x <- Try(1) if x > 1) yield x
+    assertTrue(fail.isFailure)
   }
 
   @Test
   def withFilterSuccess(): Unit = {
-    val success1 = for (x <- util.Try(1) if x >= 1) yield x
-    assertEquals(success1, util.Success(1))
+    val success1 = for (x <- Try(1) if x >= 1) yield x
+    assertEquals(Success(1), success1)
   }
 
   @Test
   def withFilterFlatMap(): Unit = {
-    val successFlatMap = for (x <- util.Try(1) if x >= 1; y <- util.Try(2) if x < y) yield x
-    assertEquals(successFlatMap, util.Success(1))
+    val successFlatMap = for (x <- Try(1) if x >= 1; y <- Try(2) if x < y) yield x
+    assertEquals(Success(1), successFlatMap)
   }
 
   @Test
   def withFilterForeach(): Unit = {
     var ok = false
-    for (x <- util.Try(1) if x == 1) ok = x == 1
-    assert(ok)
+    for (x <- Try(1) if x == 1) ok = x == 1
+    assertTrue(ok)
+  }
+
+  @Test
+  def filterIsCheap(): Unit = {
+    Try(1).filter(_ > 1) match {
+      case Failure(e: Success.UnsatisfiedPredicateException[_]) => assertEquals(0, e.getStackTrace.size)
+    }
   }
 }


### PR DESCRIPTION
Discussion at https://contributors.scala-lang.org/t/avoid-append-value-on-success-filter-if-the-predicate-doesn-t-hold/2104