### PR TITLE
Rewrite List(a, b) to `new ::(a, new ::(b, Nil)`

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -31,7 +31,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
     private val newStaticMembers      = mutable.Buffer.empty[Tree]
     private val newStaticInits        = mutable.Buffer.empty[Tree]
     private val symbolsStoredAsStatic = mutable.Map.empty[String, Symbol]
-    private var transformListApplyLimit = 16
+    private var transformListApplyLimit = 8
     private def reducingTransformListApply[A](depth: Int)(body: => A): A = {
       val saved = transformListApplyLimit
       transformListApplyLimit -= depth

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -31,6 +31,13 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
     private val newStaticMembers      = mutable.Buffer.empty[Tree]
     private val newStaticInits        = mutable.Buffer.empty[Tree]
     private val symbolsStoredAsStatic = mutable.Map.empty[String, Symbol]
+    private var transformListApplyLimit = 16
+    private def reducingTransformListApply[A](depth: Int)(body: => A): A = {
+      val saved = transformListApplyLimit
+      transformListApplyLimit -= depth
+      try body
+      finally transformListApplyLimit = saved
+    }
     private def clearStatics() {
       newStaticMembers.clear()
       newStaticInits.clear()
@@ -471,6 +478,17 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
       case Apply(appMeth, List(elem0, Apply(wrapArrayMeth, List(rest @ ArrayValue(elemtpt, _)))))
       if wrapArrayMeth.symbol == Predef_wrapArray(elemtpt.tpe) && appMeth.symbol == ArrayModule_apply(elemtpt.tpe) =>
         super.transform(treeCopy.ArrayValue(rest, rest.elemtpt, elem0 :: rest.elems))
+
+      // List(a, b, c) ~> new ::(a, new ::(b, new ::(c, Nil)))
+      case Apply(appMeth, List(Apply(wrapArrayMeth, List(StripCast(rest @ ArrayValue(elemtpt, _))))))
+      if wrapArrayMeth.symbol == currentRun.runDefinitions.Predef_wrapRefArray && appMeth.symbol == List_apply && rest.elems.length < transformListApplyLimit =>
+        val consed = rest.elems.reverse.foldLeft(gen.mkAttributedRef(NilModule): Tree)(
+          (acc, elem) => New(ConsClass, elem, acc)
+        )
+        // Limiting extra stack frames consumed by generated code
+        reducingTransformListApply(rest.elems.length) {
+          super.transform(localTyper.typedPos(tree.pos)(consed))
+        }
 
       case _ =>
         super.transform(tree)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -435,6 +435,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val IteratorClass          = requiredClass[scala.collection.Iterator[_]]
     lazy val IterableClass          = requiredClass[scala.collection.Iterable[_]]
     lazy val ListClass              = requiredClass[scala.collection.immutable.List[_]]
+         def List_cons              = getMemberMethod(ListClass, nme.CONS)
     lazy val SeqClass               = requiredClass[scala.collection.Seq[_]]
     lazy val JavaStringBuilderClass = requiredClass[java.lang.StringBuilder]
     lazy val JavaStringBufferClass  = requiredClass[java.lang.StringBuffer]

--- a/test/files/run/list-apply-eval.scala
+++ b/test/files/run/list-apply-eval.scala
@@ -1,0 +1,15 @@
+object Test {
+  var counter = 0
+  def next = {
+    counter += 1
+    counter.toString
+  }
+  def main(args: Array[String]) {
+    //List.apply is subject to an optimisation in cleanup
+    //ensure that the arguments are evaluated in the currect order
+    // Rewritten to:
+    //      val myList: List = new collection.immutable.::(Test.this.next(), new collection.immutable.::(Test.this.next(), new collection.immutable.::(Test.this.next(), scala.collection.immutable.Nil)));
+    val myList = List(next, next, next)
+    assert(myList == List("1", "2", "3"), myList)
+  }
+}


### PR DESCRIPTION
Conservatively limits the extra stack frames consumed by the generated
program to 8.

Cherry picked from https://github.com/scala/scala/commit/cf8af0c429322bb7ea687a46c0fa1b47b794a29d