### PR TITLE
remove some lower bounds in ArrayOps

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -492,12 +492,11 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
   /** Finds index of first occurrence of some value in this array after or at some start index.
     *
     *  @param   elem   the element value to search for.
-    *  @tparam  B      the type of the element `elem`.
     *  @param   from   the start index
     *  @return  the index `>= from` of the first element of this array that is equal (as determined by `==`)
     *           to `elem`, or `-1`, if none exists.
     */
-  def indexOf[B >: A](elem: B, from: Int = 0): Int = {
+  def indexOf(elem: A, from: Int = 0): Int = {
     var i = from
     while(i < xs.length) {
       if(elem == xs(i)) return i
@@ -526,11 +525,10 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *
     *  @param   elem   the element value to search for.
     *  @param   end    the end index.
-    *  @tparam  B      the type of the element `elem`.
     *  @return  the index `<= end` of the last element of this array that is equal (as determined by `==`)
     *           to `elem`, or `-1`, if none exists.
     */
-  def lastIndexOf[B >: A](elem: B, end: Int = xs.length - 1): Int = {
+  def lastIndexOf(elem: A, end: Int = xs.length - 1): Int = {
     var i = min(end, xs.length-1)
     while(i >= 0) {
       if(elem == xs(i)) return i
@@ -1030,7 +1028,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *  @return     `true` if this array has an element that is equal (as
     *              determined by `==`) to `elem`, `false` otherwise.
     */
-  def contains[A1 >: A](elem: A1): Boolean = exists (_ == elem)
+  def contains(elem: A): Boolean = exists (_ == elem)
 
   /** Returns a copy of this array with patched values.
     * Patching at negative indices is the same as patching starting at 0.

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
@@ -150,7 +150,7 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
   // TODO: the console could be empty due to external changes (also, :reset? -- see unfortunate example in jvm/interpeter (plusOne))
   def printMessage(posIn: Position, msg: String): Unit = {
     if ((posIn eq null) || (posIn.source eq NoSourceFile)) printMessage(msg)
-    else if (posIn.source.file.name == "<console>" && posIn.line == 1 && posIn.source.content.indexOf("\n") == -1) {
+    else if (posIn.source.file.name == "<console>" && posIn.line == 1) {
       // If there's only one line of input, and it's already printed on the console (as indicated by the position's source file name),
       // reuse that line in our error output, and suppress the line number (since we know it's `1`)
       // NOTE: see e.g. test/files/run/repl-colon-type.scala, where the error refers to a line that's not on the screen


### PR DESCRIPTION
We can remove lower bounds in ArrayOps because ArrayOps is invariant and not collection.

ref https://github.com/scala/bug/issues/10831 