### PR TITLE
Fix the build so setupPublishCore enables the optimizer again

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -157,7 +157,7 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
     // END: Copy/pasted from SBT
   },
   fork in run := true,
-  scalacOptions += "-Xlint:-nullary-override,-inaccessible,_",
+  scalacOptions in Compile += "-Xlint:-nullary-override,-inaccessible,_",
   //scalacOptions ++= Seq("-Xmaxerrs", "5", "-Xmaxwarns", "5"),
   scalacOptions in Compile in doc ++= Seq(
     "-doc-footer", "epfl",
@@ -606,7 +606,7 @@ lazy val junit = project.in(file("test") / "junit")
   .dependsOn(library, reflect, compiler, partest, scaladoc)
   .settings(clearSourceAndResourceDirectories)
   .settings(commonSettings)
-  .settings(scalacOptions += "-Xlint:-nullary-unit,-adapted-args")
+  .settings(scalacOptions in Compile += "-Xlint:-nullary-unit,-adapted-args")
   .settings(disableDocs)
   .settings(disablePublishing)
   .settings(
@@ -714,7 +714,7 @@ lazy val test = project
   .disablePlugins(plugins.JUnitXmlReportPlugin)
   .configs(IntegrationTest)
   .settings(commonSettings)
-  .settings(scalacOptions -= "-Xlint:-nullary-override,-inaccessible,_")
+  .settings(scalacOptions in Compile -= "-Xlint:-nullary-override,-inaccessible,_")
   .settings(disableDocs)
   .settings(disablePublishing)
   .settings(Defaults.itSettings)


### PR DESCRIPTION
Regressed in #6964

Before:

```
$ sbt setupPublishCore 'show library/scalacOptions' 'show reflect/scalacOptions' 'show compiler/test:scalacOptions' 'show test/scalacOptions'
[info] Loading global plugins from /Users/jz/.sbt/0.13/plugins
[info] Loading project definition from /Users/jz/code/scala/project/project
[info] Loading project definition from /Users/jz/code/scala/project
[info] Resolving key references (11393 settings) ...
[info] *** Welcome to the sbt build definition for Scala! ***
[info] Check README.md for more information.
[info] *** Welcome to the sbt build definition for Scala! ***
[info] Check README.md for more information.
[info] * -Xlint:-nullary-override,-inaccessible,_
[success] Total time: 0 s, completed 02/08/2018 12:33:38 PM
[info] * -Xlint:-nullary-override,-inaccessible,_
[success] Total time: 0 s, completed 02/08/2018 12:33:38 PM
[info] * -Xlint:-nullary-override,-inaccessible,_
[success] Total time: 0 s, completed 02/08/2018 12:33:38 PM
[info] *
[success] Total time: 0 s, completed 02/08/2018 12:33:38 PM
```

After:

```
$ sbt setupPublishCore 'show library/scalacOptions' 'show reflect/scalacOptions' 'show compiler/test:scalacOptions' 'show test/scalacOptions'
[info] Loading global plugins from /Users/jz/.sbt/0.13/plugins
[info] Loading project definition from /Users/jz/code/scala/project/project
[info] Loading project definition from /Users/jz/code/scala/project
[info] Resolving key references (11393 settings) ...
[info] *** Welcome to the sbt build definition for Scala! ***
[info] Check README.md for more information.
[info] *** Welcome to the sbt build definition for Scala! ***
[info] Check README.md for more information.
[info] * -opt:l:inline
[info] * -opt-inline-from:scala/**
[info] * -Xlint:-nullary-override,-inaccessible,_
[info] * -sourcepath
[info] * /Users/jz/code/scala/src/library
[success] Total time: 0 s, completed 02/08/2018 12:31:18 PM
[info] * -opt:l:inline
[info] * -opt-inline-from:scala/**
[info] * -Xlint:-nullary-override,-inaccessible,_
[success] Total time: 0 s, completed 02/08/2018 12:31:18 PM
[info] * -opt:l:inline
[info] * -opt-inline-from:scala/**
[info] * -Xlint:-nullary-override,-inaccessible,_
[success] Total time: 0 s, completed 02/08/2018 12:31:18 PM
[info] * -opt:l:inline
[info] * -opt-inline-from:scala/**
[success] Total time: 0 s, completed 02/08/2018 12:31:18 PM
```