### PR TITLE
fix NegativeArraySizeException `StringOps#*`

### DIFF
--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -563,13 +563,17 @@ final class StringOps(private val s: String) extends AnyVal {
   /** Return the current string concatenated `n` times.
     */
   def *(n: Int): String = {
-    val sb = new JStringBuilder(s.length * n)
-    var i = 0
-    while (i < n) {
-      sb.append(s)
-      i += 1
+    if (n <= 0) {
+      ""
+    } else {
+      val sb = new JStringBuilder(s.length * n)
+      var i = 0
+      while (i < n) {
+        sb.append(s)
+        i += 1
+      }
+      sb.toString
     }
-    sb.toString
   }
 
   @inline private[this] def isLineBreak(c: Char) = c == LF || c == FF

--- a/test/junit/scala/collection/StringOpsTest.scala
+++ b/test/junit/scala/collection/StringOpsTest.scala
@@ -1,5 +1,6 @@
 package scala.collection
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -23,5 +24,11 @@ class StringOpsTest {
 
   @Test def toArray(): Unit = {
     assert("".toArray[Any].length == 0) // should not throw
+  }
+
+  @Test def *(): Unit = {
+    assertEquals("aaa", "a" * 3)
+    assertEquals("", "a" * 0)
+    assertEquals("", "a" * -1)
   }
 }


### PR DESCRIPTION
```
Welcome to Scala 2.12.6 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> "a" * -1
res0: String = ""
```

```
Welcome to Scala 2.13.0-M4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> "a" * -1
java.lang.NegativeArraySizeException
  at java.lang.AbstractStringBuilder.<init>(AbstractStringBuilder.java:68)
  at java.lang.StringBuilder.<init>(StringBuilder.java:101)
  at scala.collection.StringOps$.$times$extension(StringOps.scala:555)
  ... 30 elided
```