### PR TITLE
Refcheck original of annotation

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1396,6 +1396,8 @@ abstract class RefChecks extends Transform {
         annots.foreach { ann =>
           checkTypeRef(ann.tpe, tree, skipBounds = false)
           checkTypeRefBounds(ann.tpe, tree)
+          if (ann.original != null && ann.original.hasExistingSymbol)
+            checkUndesiredProperties(ann.original.symbol, tree.pos)
         }
 
         annots

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1399,7 +1399,6 @@ abstract class RefChecks extends Transform {
           if (ann.original != null && ann.original.hasExistingSymbol)
             checkUndesiredProperties(ann.original.symbol, tree.pos)
         }
-
         annots
           .map(_.transformArgs(transformTrees))
           .groupBy(_.symbol)
@@ -1409,7 +1408,8 @@ abstract class RefChecks extends Transform {
 
       // assumes non-empty `anns`
       def groupRepeatableAnnotations(sym: Symbol, anns: List[AnnotationInfo]): List[AnnotationInfo] =
-        if (!sym.isJavaDefined) anns else anns match {
+        if (!sym.isJavaDefined) anns
+        else anns match {
           case single :: Nil => anns
           case multiple      =>
             sym.getAnnotation(AnnotationRepeatableAttr) match {
@@ -1426,7 +1426,6 @@ abstract class RefChecks extends Transform {
                     devWarning(s"@Repeatable $sym had no containing class")
                     multiple
                 }
-
               case None =>
                 reporter.error(tree.pos, s"$sym may not appear multiple times on ${tree.symbol}")
                 multiple
@@ -1461,7 +1460,6 @@ abstract class RefChecks extends Transform {
             if (sym.isTrait) warn("traits")
             else if (!sym.isSerializable) warn("non-serializable classes")
           }
-
         case tpt@TypeTree() =>
           if (tpt.original != null) {
             tpt.original foreach {
@@ -1470,7 +1468,6 @@ abstract class RefChecks extends Transform {
               case _ =>
             }
           }
-
           if (!inPattern)
             tree.setType(tree.tpe map {
               case AnnotatedType(anns, ul) =>

--- a/test/files/neg/t11012.check
+++ b/test/files/neg/t11012.check
@@ -1,0 +1,12 @@
+t11012.scala:8: warning: class A is deprecated: class!
+@A class C
+         ^
+t11012.scala:10: warning: constructor B in class B is deprecated: constructor!
+@B class D   // should warn
+         ^
+t11012.scala:13: warning: constructor B in class B is deprecated: constructor!
+  def foo = new B
+            ^
+error: No warnings can be incurred under -Xfatal-warnings.
+three warnings found
+one error found

--- a/test/files/neg/t11012.scala
+++ b/test/files/neg/t11012.scala
@@ -1,0 +1,14 @@
+// scalac: -Xfatal-warnings -deprecation
+import scala.annotation.StaticAnnotation
+
+@deprecated("class!", "") class A extends StaticAnnotation
+
+class B @deprecated("constructor!", "") extends StaticAnnotation
+
+@A class C
+
+@B class D   // should warn
+
+trait T {
+  def foo = new B
+}


### PR DESCRIPTION
Try to do minimal work by just checking for
undesirables.

It's a little weird that the caret is not on the problematic class.

"Minimal work."