### PR TITLE
[11050] ArrayDeque correctly resets with new Array when inserting and resize is necessary

### DIFF
--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -138,6 +138,7 @@ class ArrayDeque[A] protected (
         copySliceToArray(srcStart = 0, dest = array2, destStart = 0, maxItems = idx)
         array2(idx) = elem.asInstanceOf[AnyRef]
         copySliceToArray(srcStart = idx, dest = array2, destStart = idx + 1, maxItems = n)
+        reset(array = array2, start = 0, end = finalLength)
       } else if (n <= idx * 2) {
         var i = n - 1
         while(i >= idx) {

--- a/test/junit/scala/collection/mutable/ArrayDequeTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayDequeTest.scala
@@ -71,4 +71,11 @@ class ArrayDequeTest {
     val target = Array[Int]()
     assertEquals(0, collection.mutable.ArrayDeque(1, 2).copyToArray(target, 1, 0))
   }
+
+  @Test
+  def insertsWhenResizeIsNeeded: Unit = {
+    val arrayDeque = ArrayDeque.from(Array.range(0, 15))
+    arrayDeque.insert(1, -1)
+    assertEquals(ArrayDeque(0, -1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), arrayDeque)
+  }
 }

--- a/test/junit/scala/collection/mutable/QueueTest.scala
+++ b/test/junit/scala/collection/mutable/QueueTest.scala
@@ -33,6 +33,13 @@ class QueueTest {
   @Test
   def copyToArrayOutOfBounds: Unit = {
     val target = Array[Int]()
-    assertEquals(0, mutable.Queue(1,2).copyToArray(target, 1, 0))
+    assertEquals(0, mutable.Queue(1, 2).copyToArray(target, 1, 0))
+  }
+
+  @Test
+  def insertsWhenResizeIsNeeded: Unit = {
+    val q = Queue.from(Array.range(0, 15))
+    q.insert(1, -1)
+    assertEquals(Queue(0, -1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), q)
   }
 }

--- a/test/junit/scala/collection/mutable/StackTest.scala
+++ b/test/junit/scala/collection/mutable/StackTest.scala
@@ -15,4 +15,11 @@ class StackTest {
     val s2: Stack[Int] = s1.reverse
     assertEquals("Stack", s2.collectionClassName)
   }
+
+  @Test
+  def insertsWhenResizeIsNeeded: Unit = {
+    val stack = Stack.from(Array.range(0, 15))
+    stack.insert(1, -1)
+    assertEquals(Stack(0, -1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), stack)
+  }
 }


### PR DESCRIPTION
 Fixes scala/bug#11050