### PR TITLE
[11049] Fixes scala/bug#11049

### DIFF
--- a/src/library/scala/collection/IndexedSeqView.scala
+++ b/src/library/scala/collection/IndexedSeqView.scala
@@ -26,13 +26,12 @@ object IndexedSeqView {
     private[this] var current = 0
     override def knownSize: Int = self.size - current
     def hasNext = current < self.size
-    def next(): A = try {
-      val r = self.apply(current)
-      current += 1
-      r
-    } catch {
-      case _: IndexOutOfBoundsException => throw new NoSuchElementException("last of empty iterator")
-    }
+    def next(): A =
+      if (hasNext) {
+        val r = self.apply(current)
+        current += 1
+        r
+      } else Iterator.empty.next()
   }
 
   /** An `IndexedSeqOps` whose collection type and collection type constructor are unknown */

--- a/src/library/scala/collection/IndexedSeqView.scala
+++ b/src/library/scala/collection/IndexedSeqView.scala
@@ -26,10 +26,12 @@ object IndexedSeqView {
     private[this] var current = 0
     override def knownSize: Int = self.size - current
     def hasNext = current < self.size
-    def next(): A = {
+    def next(): A = try {
       val r = self.apply(current)
       current += 1
       r
+    } catch {
+      case _: IndexOutOfBoundsException => throw new NoSuchElementException("last of empty iterator")
     }
   }
 

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -210,7 +210,7 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
 
 final class ArrayBufferView[A](val array: Array[AnyRef], val length: Int) extends AbstractIndexedSeqView[A] {
   @throws[ArrayIndexOutOfBoundsException]
-  def apply(n: Int) = array(n).asInstanceOf[A]
+  def apply(n: Int) = if (n < length) array(n).asInstanceOf[A] else throw new IndexOutOfBoundsException(n.toString)
   override protected[this] def className = "ArrayBufferView"
 }
 

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -247,15 +247,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     *
     *  @return  an iterator over all the elements.
     */
-  override def iterator: Iterator[A] = new AbstractIterator[A] {
-    private[this] var i = 1
-    def hasNext: Boolean = i < resarr.p_size0
-    def next(): A = {
-      val n = resarr.p_array(i)
-      i += 1
-      toA(n)
-    }
-  }
+  override def iterator: Iterator[A] = resarr.iterator.drop(1)
 
   /** Returns the reverse of this priority queue. The new priority queue has
     *  the same elements as the original, but the opposite ordering.

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -5,7 +5,9 @@ import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert.assertEquals
 
+
 import scala.tools.testing.AssertUtil
+import scala.tools.testing.AssertUtil.assertThrows
 
 /* Test for scala/bug#9043 */
 @RunWith(classOf[JUnit4])
@@ -307,4 +309,10 @@ class ArrayBufferTest {
 
     assertEquals(builder.result(), "4,3,2,1")
   }
+
+  @Test
+  def emptyIteratorDropOneMustBeEmpty: Unit = {
+    assertThrows[NoSuchElementException](new ArrayBuffer[Int].iterator.drop(1).next())
+  }
+
 }

--- a/test/junit/scala/collection/mutable/PriorityQueueTest.scala
+++ b/test/junit/scala/collection/mutable/PriorityQueueTest.scala
@@ -9,8 +9,6 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, 
 
 import scala.tools.testing.AssertUtil.assertThrows
 
-
-
 @RunWith(classOf[JUnit4])
 /* Test for scala/bug#7568  */
 class PriorityQueueTest {
@@ -49,6 +47,7 @@ class PriorityQueueTest {
   }
   @Test
   def lastOfEmptyThrowsException(): Unit = {
+    assert(List(1,2,3,4,5).contains(collection.mutable.PriorityQueue[Int](1,2,3,4,5).last))
     assertThrows[NoSuchElementException](collection.mutable.PriorityQueue[Int]().last)
   }
 }

--- a/test/junit/scala/collection/mutable/PriorityQueueTest.scala
+++ b/test/junit/scala/collection/mutable/PriorityQueueTest.scala
@@ -3,8 +3,13 @@ package scala.collection.mutable
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
+
 import scala.collection.mutable
-import java.io.{ObjectInputStream, ByteArrayInputStream, ByteArrayOutputStream, ObjectOutputStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+
+import scala.tools.testing.AssertUtil.assertThrows
+
+
 
 @RunWith(classOf[JUnit4])
 /* Test for scala/bug#7568  */
@@ -41,5 +46,9 @@ class PriorityQueueTest {
     val deserializedPriorityQueue = objectInputStream.readObject().asInstanceOf[PriorityQueue[Int]]
     //correct sequencing is also tested here:
     assert(deserializedPriorityQueue.dequeueAll == elements.sorted.reverse)
+  }
+  @Test
+  def lastOfEmptyThrowsException(): Unit = {
+    assertThrows[NoSuchElementException](collection.mutable.PriorityQueue[Int]().last)
   }
 }


### PR DESCRIPTION
This Fixes scala/bug#11049 as well as the more general issue with ArrayBuffers, which is the following:

```scala
new ArrayBuffer[Int].iterator.next // returns 0
```

Now, this will throw a `NoSuchElementException`