### PR TITLE
[11054] Add lower priority BuildFrom[IterableOnce[_], A, IterableOnce[A]]

### DIFF
--- a/src/library/scala/collection/BuildFrom.scala
+++ b/src/library/scala/collection/BuildFrom.scala
@@ -82,7 +82,7 @@ trait BuildFromLowPriority1 extends BuildFromLowPriority2 {
   }
 }
 
-trait BuildFromLowPriority2 {
+trait BuildFromLowPriority2 extends BuildFromLowPriority3 {
   /** Build the source collection type from an IterableOps */
   implicit def buildFromIterableOps[CC[X] <: Iterable[X] with IterableOps[X, CC, _], A0, A]: BuildFrom[CC[A0], A, CC[A]] = new BuildFrom[CC[A0], A, CC[A]] {
     //TODO: Reuse a prototype instance
@@ -92,6 +92,13 @@ trait BuildFromLowPriority2 {
 
   implicit def buildFromIterator[A]: BuildFrom[Iterator[_], A, Iterator[A]] = new BuildFrom[Iterator[_], A, Iterator[A]] {
     def newBuilder(from: Iterator[_]): mutable.Builder[A, Iterator[A]] = Iterator.newBuilder
-    def fromSpecific(from: Iterator[_])(it: IterableOnce[A]): Iterator[A] = Iterator.from(it)
+    override def fromSpecific(from: Iterator[_])(it: IterableOnce[A]) = it.iterator
+  }
+}
+
+trait BuildFromLowPriority3 {
+  implicit def buildFromIterableOnce[A]: BuildFrom[IterableOnce[_], A, IterableOnce[A]] = new BuildFrom[IterableOnce[_], A, IterableOnce[A]] {
+    def newBuilder(from: IterableOnce[_]): mutable.Builder[A, IterableOnce[A]] = Iterator.newBuilder
+    override def fromSpecific(from: IterableOnce[_])(it: IterableOnce[A]) = it.iterator
   }
 }

--- a/test/junit/scala/collection/IterableOnceTest.scala
+++ b/test/junit/scala/collection/IterableOnceTest.scala
@@ -1,0 +1,31 @@
+package scala.collection
+
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.language.higherKinds
+import org.junit.Assert.assertEquals
+
+import scala.concurrent.Await
+
+
+
+@RunWith(classOf[JUnit4])
+class IterableOnceTest {
+
+  // tests scala/bug#11054
+  @Test
+  def buildFromIterableOnceToIterableOnce: Unit = {
+    import scala.concurrent.{ExecutionContext, Future}
+    import scala.concurrent.duration._
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(_.run())
+
+    val iterableOnce: IterableOnce[Future[Char]] = Iterator('a', 'b', 'c').map(Future.successful)
+    val result = Future.sequence(iterableOnce)
+    assertEquals(Seq('a','b','c'), Await.result(result, 10.millis).iterator.to(Seq))
+  }
+
+}
+


### PR DESCRIPTION
* Fixes scala/bug#11054
* Adds a `BuildFromLowPriority3` to avoid implicit search conflicts between `buildFromIterableOnce` and `buildFromIterator`