### PR TITLE
Adds tap and pipe methods (available via `import scala.util.chaining._`)

### DIFF
--- a/src/library/scala/util/ChainingOps.scala
+++ b/src/library/scala/util/ChainingOps.scala
@@ -33,6 +33,9 @@ final class ChainingOps[A](val self: A) extends AnyVal {
    *    // i == 24
    *    }}}
    *
+   * Note: `(1 - 2 - 3).pipe(times6)` may have a small amount of overhead at
+   * runtime compared to the equivalent  `{ val temp = 1 - 2 - 3; times6(temp) }`.
+   *
    *  @param f      the function to apply to the value.
    *  @tparam B     the result type of the function `f`.
    *  @return       a new value resulting from applying the given function

--- a/src/library/scala/util/ChainingOps.scala
+++ b/src/library/scala/util/ChainingOps.scala
@@ -1,0 +1,42 @@
+package scala
+package util
+
+trait ChainingSyntax {
+  implicit final def scalaUtilChainingOps[A](a: A): ChainingOps[A] = new ChainingOps(a)
+}
+
+/** Adds chaining methods `tap` and `pipe` to every type.
+ */
+final class ChainingOps[A](val self: A) extends AnyVal {
+  /** Applies `f` to the value for its side effects, and returns the original value.
+   *
+   *    {{{
+   *    val xs = List(1, 2, 3)
+   *               .tap(ys => println("debug " + ys.toString))
+   *    // xs == List(1, 2, 3)
+   *    }}}
+   *
+   *  @param f      the function to apply to the value.
+   *  @tparam U     the result type of the function `f`.
+   *  @return       the original value `self`.
+   */
+  def tap[U](f: A => U): self.type = {
+    f(self)
+    self
+  }
+
+  /** Converts the value by applying the function `f`.
+   *
+   *    {{{
+   *    val times6 = (_: Int) * 6
+   *    val i = (1 - 2 - 3).pipe(times6).pipe(scala.math.abs)
+   *    // i == 24
+   *    }}}
+   *
+   *  @param f      the function to apply to the value.
+   *  @tparam B     the result type of the function `f`.
+   *  @return       a new value resulting from applying the given function
+   *                `f` to this value.
+   */
+  def pipe[B](f: A => B): B = f(self)
+}

--- a/src/library/scala/util/package.scala
+++ b/src/library/scala/util/package.scala
@@ -4,5 +4,5 @@ package object util {
   /**
    * Adds chaining methods `tap` and `pipe` to every type. See [[ChainingOps]].
    */
-  object chainingOps extends ChainingSyntax
+  object chaining extends ChainingSyntax
 }

--- a/src/library/scala/util/package.scala
+++ b/src/library/scala/util/package.scala
@@ -1,0 +1,8 @@
+package scala
+
+package object util {
+  /**
+   * Adds chaining methods `tap` and `pipe` to every type. See [[ChainingOps]].
+   */
+  object chainingOps extends ChainingSyntax
+}

--- a/test/junit/scala/util/ChainingOpsTest.scala
+++ b/test/junit/scala/util/ChainingOpsTest.scala
@@ -4,7 +4,7 @@ import org.junit.Assert._
 import org.junit.Test
 
 class ChainingOpsTest {
-  import scala.util.chainingOps._
+  import scala.util.chaining._
 
   @Test
   def testAnyTap: Unit = {

--- a/test/junit/scala/util/ChainingOpsTest.scala
+++ b/test/junit/scala/util/ChainingOpsTest.scala
@@ -1,0 +1,28 @@
+package scala.util
+
+import org.junit.Assert._
+import org.junit.Test
+
+class ChainingOpsTest {
+  import scala.util.chainingOps._
+
+  @Test
+  def testAnyTap: Unit = {
+    var x: Int = 0
+    val result = List(1, 2, 3)
+      .tap(xs => x = xs.head)
+
+    assertEquals(1, x)
+    assertEquals(List(1, 2, 3), result)
+  }
+
+  @Test
+  def testAnyPipe: Unit = {
+    val times6 = (_: Int) * 6
+    val result = (1 - 2 - 3)
+      .pipe(times6)
+      .pipe(scala.math.abs)
+
+    assertEquals(24, result)
+  }
+}


### PR DESCRIPTION
This implements opt-in extension methods, on all types, called `tap` and `pipe`:

```scala
scala> import scala.util.chaining._
import scala.util.chaining._

scala> val xs = List(1, 2, 3).tap(ys => println("debug " + ys.toString))
debug List(1, 2, 3)
xs: List[Int] = List(1, 2, 3)

scala> val times6 = (_: Int) * 6
times6: Int => Int = $$Lambda$1727/1479800269@10fbbdb

scala> (1 + 2 + 3).pipe(times6)
res0: Int = 36

scala> (1 - 2 - 3).pipe(times6).pipe(scala.math.abs)
res1: Int = 24
```

Fixes https://github.com/scala/bug/issues/5324
This is a resend of https://github.com/scala/scala/pull/6767 without the macro commits.