### PR TITLE
add methods to Left and Right for upcasting the other type parameter

### DIFF
--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -441,6 +441,15 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
 final case class Left[+A, +B](value: A) extends Either[A, B] {
   def isLeft  = true
   def isRight = false
+
+  /**
+    * Upcasts this `Left[A, B]` to `Either[A, B1]`
+    * {{{
+    *   Left(1).up[String] // Either[Int, String]
+    * }}}
+    */
+  def up[B1 >: B]: Either[A, B1] = this
+
 }
 
 /** The right side of the disjoint union, as opposed to the [[scala.util.Left]] side.
@@ -450,6 +459,15 @@ final case class Left[+A, +B](value: A) extends Either[A, B] {
 final case class Right[+A, +B](value: B) extends Either[A, B] {
   def isLeft  = false
   def isRight = true
+
+  /**
+    * Upcasts this `Right[A, B]` to `Either[A1, B]`
+    * {{{
+    *   Right("1").up[Int] // Either[Int, String]
+    * }}}
+    */
+  def up[A1 >: A]: Either[A1, B] = this
+
 }
 
 object Either {

--- a/test/junit/scala/util/EitherTest.scala
+++ b/test/junit/scala/util/EitherTest.scala
@@ -1,6 +1,7 @@
 package scala.util
 
-import org.junit.{ Assert, Test }
+import org.junit.Assert._
+import org.junit.Test
 
 class EitherTest {
 
@@ -13,9 +14,34 @@ class EitherTest {
     val flatrl: Either[String, Int] = rl.flatten
     val flatrr: Either[String, Int] = rr.flatten
 
-    Assert.assertEquals(Left("pancake"), flatl)
-    Assert.assertEquals(Left("flounder"), flatrl)
-    Assert.assertEquals(Right(7), flatrr)
-    
+    assertEquals(Left("pancake"), flatl)
+    assertEquals(Left("flounder"), flatrl)
+    assertEquals(Right(7), flatrr)
+  }
+
+  @Test
+  def testLeftUp: Unit = {
+
+    def rightSumOrLeftEmpty(l: List[Int]) =
+      l.foldLeft(Left("empty").up[Int]) {
+        case (Left(_), i) => Right(i)
+        case (Right(s), i) => Right(s + i)
+      }
+
+    assertEquals(rightSumOrLeftEmpty(List(1, 2, 3)), Right(6))
+    assertEquals(rightSumOrLeftEmpty(Nil), Left("empty"))
+  }
+
+  @Test
+  def testRightUp: Unit = {
+
+    def leftSumOrRightEmpty(l: List[Int]) =
+      l.foldLeft(Right("empty").up[Int]) {
+        case (Right(_), i) => Left(i)
+        case (Left(s), i) => Left(s + i)
+      }
+
+    assertEquals(leftSumOrRightEmpty(List(1, 2, 3)), Left(6))
+    assertEquals(leftSumOrRightEmpty(Nil), Right("empty"))
   }
 }


### PR DESCRIPTION
This is another implementation of #6328 and #6329 
based on suggestion by @lrytz  

motivation: `Left` and `Right` constructors are typed as `Left` and `Right` respectively, but sometimes we want something like `Option.empty` which returns `None` but typed as `Option`.

The test represents a code that would not compile if plain `Left`/`Right` constructors are used

@SethTisue @lrytz please check it again, thanks!

**EDIT:** updated in #7080 to name the methods `withLeft` and `withRight`