### PR TITLE
Speed up implicit resolution by avoiding allocations when traversing TypeRefs in core

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -482,7 +482,10 @@ trait Implicits {
       case AnnotatedType(annots, tp)          => core(tp)
       case ExistentialType(tparams, result)   => core(result).subst(tparams, tparams map (t => core(t.info.bounds.hi)))
       case PolyType(tparams, result)          => core(result).subst(tparams, tparams map (t => core(t.info.bounds.hi)))
-      case TypeRef(pre, sym, args)            => typeRef(pre, sym, args.map(core))
+      case TypeRef(pre, sym, args)            =>
+        val coreArgs = args.mapConserve(core)
+        if (coreArgs eq args) tp
+        else typeRef(pre, sym, coreArgs)
       case _                                  => tp
     }
 


### PR DESCRIPTION
As reported [here](https://github.com/scala/scala/pull/6580#issuecomment-411218556), #6530 causes a significant slowdown when performing implicit searches for large types: in the case of the "select from large hlist" [benchmark](https://github.com/scala/compiler-benchmark/blob/master/corpus/induction/latest/inductive-implicits-bench.scala) it roughly doubles the compile time.

This PR claws almost all of that back by avoiding allocations when traversing through TypeRefs.