### PR TITLE
Fix regression in switch pattern translation

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -65,7 +65,13 @@ trait PatternMatching extends Transform
           // Keep 2.12 behaviour of using wildcard expected type, recomputing the LUB, then throwing it away for the continuations plugins
           // but for the rest of us pass in top as the expected type to avoid waste.
           val pt = if (origTp <:< definitions.AnyTpe) definitions.AnyTpe else WildcardType
-          localTyper.typed(translated, pt) setType origTp
+          localTyper.typed(translated, pt) match {
+            case b @ Block(stats, m: Match) =>
+              b.setType(origTp)
+              m.setType(origTp)
+              b
+            case tree => tree setType origTp
+          }
         } catch {
           case x: (Types#TypeError) =>
             // TODO: this should never happen; error should've been reported during type checking

--- a/test/files/run/patmat-origtp-switch.check
+++ b/test/files/run/patmat-origtp-switch.check
@@ -11,7 +11,7 @@ package <empty>{<empty>.type} {
         case 0{Int(0)} => a{A}
         case 1{Int(1)} => b{A with C}
         case _{Int} => throw new MatchError{MatchError}{(obj: Any)MatchError}(x1{Int}){MatchError}{Nothing}
-      }{Any}
+      }{A}
     }{A}
   }
 }

--- a/test/files/run/patmat-origtp-switch.check
+++ b/test/files/run/patmat-origtp-switch.check
@@ -1,0 +1,18 @@
+[[syntax trees at end of                    patmat]] // newSource1.scala
+package <empty>{<empty>.type} {
+  class C extends scala.AnyRef {
+    def <init>(): C = {
+      C.super{C.super.type}.<init>{()Object}(){Object};
+      (){Unit}
+    }{Unit};
+    def foo[A](a: A, b: A with C, i: Int): A = {
+      case <synthetic> val x1: Int = i{Int};
+      x1{Int} match {
+        case 0{Int(0)} => a{A}
+        case 1{Int(1)} => b{A with C}
+        case _{Int} => throw new MatchError{MatchError}{(obj: Any)MatchError}(x1{Int}){MatchError}{Nothing}
+      }{Any}
+    }{A}
+  }
+}
+

--- a/test/files/run/patmat-origtp-switch.scala
+++ b/test/files/run/patmat-origtp-switch.scala
@@ -1,0 +1,21 @@
+import scala.tools.partest._
+import java.io.{Console => _, _}
+
+object Test extends DirectTest {
+
+  override def extraSettings: String = "-usejavacp -Xprint:patmat -Xprint-types -d " + testOutput.path
+
+  override def code = """class C {
+    def foo[A](a: A, b: A with C, i: Int) = i match {
+      case 0 => a
+      case 1 => b
+    }
+  }
+  """
+
+  override def show(): Unit = {
+    Console.withErr(System.out) {
+      compile()
+    }
+  }
+}


### PR DESCRIPTION
The performance optimization in #6607 assumed that a translated match would
always be a `Match` node itself, but it can also be a `{ synthetic val x1 =
...; x1 match { .. } }` block.