### PR TITLE
Fix inserting at length-1 in `ArrayDeque#insertAll`

### DIFF
--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -165,7 +165,7 @@ class ArrayDeque[A] protected (
     val n = length
     if (idx == 0) {
       prependAll(elems)
-    } else if (idx == n - 1) {
+    } else if (idx == n) {
       addAll(elems)
     } else {
       // Get both an iterator and the length of the source (by copying the source to an IndexedSeq if needed)

--- a/test/junit/scala/collection/mutable/ArrayDequeTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayDequeTest.scala
@@ -78,4 +78,20 @@ class ArrayDequeTest {
     arrayDeque.insert(1, -1)
     assertEquals(ArrayDeque(0, -1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), arrayDeque)
   }
+
+  @Test
+  def insertAll: Unit = {
+    var a = ArrayDeque(0, 1)
+    a.insertAll(1, Seq(2))
+    assertEquals(ArrayDeque(0, 2, 1), a)
+    a = ArrayDeque(0, 1)
+    a.insertAll(2, Seq(2))
+    assertEquals(ArrayDeque(0, 1, 2), a)
+    var q = Queue(0, 1)
+    q.patchInPlace(1, Seq(2), 0)
+    assertEquals(Queue(0, 2, 1), q)
+    q = Queue(0, 1)
+    q.patchInPlace(2, Seq(2), 0)
+    assertEquals(Queue(0, 1, 2), q)
+  }
 }


### PR DESCRIPTION
Inserting with `insertAll` just before the last element would actually
insert after the last element.

Fixes https://github.com/scala/bug/issues/11046