### PR TITLE
Fixes scala/bug#11059. Replcaed UnsupportedOperationException with NoSuchElementException

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -144,7 +144,7 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
   }
 
   override def head: A = {
-    if (isEmpty) throw new UnsupportedOperationException("empty.head")
+    if (isEmpty) throw new NoSuchElementException("empty.head")
     apply(0)
   }
 


### PR DESCRIPTION
Considering docs as a source of truth. I have replaced UnsupportedOperationException with NoSuchElementException when a given vector is empty