### PR TITLE
Add deprecated members `++:` and `repr` to `Iterable`

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -166,6 +166,9 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     */
   protected def coll: C
 
+  @deprecated("Use coll instead of repr in a collection implementation, use the collection value itself from the outside", "2.13.0")
+  final def repr: C = coll
+
   /**
     * Defines how to turn a given `Iterable[A]` into a collection of type `C`.
     *
@@ -809,6 +812,12 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     val it = Iterator.iterate(toIterable)(f).takeWhile(x => !x.isEmpty)
     (it ++ Iterator.single(Iterable.empty)).map(fromSpecific)
   }
+
+  @deprecated("Use xs ++ ys instead of ys ++: xs for xs of type Iterable", "2.13.0")
+  def ++:[B >: A](that: IterableOnce[B]): IterableCC[B] =
+    (iterableFactory.from(that).asInstanceOf[Iterable[B]] ++ coll.asInstanceOf[Iterable[B]]).asInstanceOf[IterableCC[B]]
+    // These casts are needed because C and CC do not have the proper constraints.
+    // Adding those constraints would require a lot of boilerplate in many classes.
 }
 
 object IterableOps {

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -162,7 +162,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   })
 
   /** Alias for `prependedAll` */
-  @`inline` final def ++: [B >: A](prefix: IterableOnce[B]): CC[B] = prependedAll(prefix)
+  @`inline` override final def ++: [B >: A](prefix: IterableOnce[B]): CC[B] = prependedAll(prefix)
 
   /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
     *  right hand operand. The element type of the $coll is the most specific superclass encompassing

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -40,6 +40,9 @@ class IterableTest {
     assertEquals(Seq(1,2,3,4,5,6), Seq(1,2,3).concat(Seq(4,5,6)))
     assertEquals(Seq(1,2,3,4,5,6), Seq(1,2,3).concat(Iterator(4,5,6)))
     assertEquals(Seq(1,2,3,4,5,6), Seq.from(Iterator(1,2,3).concat(Iterator(4,5,6))))
+
+    assertEquals(Iterable(1,2,3), Iterable(1) ++: Iterable(2,3))
+    assertEquals(Iterable(1,2,3), Iterator(1) ++: Iterable(2,3))
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/10974