### PR TITLE
Add lazyZip to ArrayOps and StringOps

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -903,6 +903,25 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     b.result()
   }
 
+  /** Analogous to `zip` except that the elements in each collection are not consumed until a strict operation is
+    * invoked on the returned `LazyZip2` decorator.
+    *
+    * Calls to `lazyZip` can be chained to support higher arities (up to 4) without incurring the expense of
+    * constructing and deconstructing intermediary tuples.
+    *
+    * {{{
+    *    val xs = List(1, 2, 3)
+    *    val res = (xs lazyZip xs lazyZip xs lazyZip xs).map((a, b, c, d) => a + b + c + d)
+    *    // res == List(4, 8, 12)
+    * }}}
+    *
+    * @param that the iterable providing the second element of each eventual pair
+    * @tparam B   the type of the second element in each eventual pair
+    * @return a decorator `LazyZip2` that allows strict operations to be performed on the lazily evaluated pairs
+    *         or chained calls to `lazyZip`. Implicit conversion to `Iterable[(A, B)]` is also supported.
+    */
+  def lazyZip[B](that: Iterable[B]): LazyZip2[A, B, Array[A]] = new LazyZip2(xs, immutable.ArraySeq.unsafeWrapArray(xs), that)
+
   /** Returns an array formed from this array and another iterable collection
     *  by combining corresponding elements in pairs.
     *  If one of the two collections is shorter than the other,

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -81,6 +81,25 @@ trait Iterable[+A] extends IterableOnce[A] with IterableOps[A, Iterable, Iterabl
     *            by all elements separated by commas and enclosed in parentheses.
     */
   override def toString = mkString(className + "(", ", ", ")")
+
+  /** Analogous to `zip` except that the elements in each collection are not consumed until a strict operation is
+    * invoked on the returned `LazyZip2` decorator.
+    *
+    * Calls to `lazyZip` can be chained to support higher arities (up to 4) without incurring the expense of
+    * constructing and deconstructing intermediary tuples.
+    *
+    * {{{
+    *    val xs = List(1, 2, 3)
+    *    val res = (xs lazyZip xs lazyZip xs lazyZip xs).map((a, b, c, d) => a + b + c + d)
+    *    // res == List(4, 8, 12)
+    * }}}
+    *
+    * @param that the iterable providing the second element of each eventual pair
+    * @tparam B   the type of the second element in each eventual pair
+    * @return a decorator `LazyZip2` that allows strict operations to be performed on the lazily evaluated pairs
+    *         or chained calls to `lazyZip`. Implicit conversion to `Iterable[(A, B)]` is also supported.
+    */
+  def lazyZip[B](that: Iterable[B]): LazyZip2[A, B, this.type] = new LazyZip2(this, this, that)
 }
 
 /** Base trait for Iterable operations
@@ -846,9 +865,7 @@ object IterableOps {
 }
 
 @SerialVersionUID(3L)
-object Iterable extends IterableFactory.Delegate[Iterable](immutable.Iterable) {
-  implicit def toLazyZipOps[A, CC[X] <: Iterable[X]](that: CC[A]): LazyZipOps[A, CC[A]] = new LazyZipOps(that)
-}
+object Iterable extends IterableFactory.Delegate[Iterable](immutable.Iterable)
 
 /** Explicit instantiation of the `Iterable` trait to reduce class file size in subclasses. */
 @SerialVersionUID(3L)

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -330,8 +330,6 @@ object MapOps {
   */
 @SerialVersionUID(3L)
 object Map extends MapFactory.Delegate[Map](immutable.Map) {
-  implicit def toLazyZipOps[K, V, CC[X, Y] <: Iterable[(X, Y)]](that: CC[K, V]): LazyZipOps[(K, V), CC[K, V]] = new LazyZipOps(that)
-
   private val DefaultSentinel: AnyRef = new AnyRef
 }
 

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -1289,6 +1289,25 @@ final class StringOps(private val s: String) extends AnyVal {
     (res1.toString, res2.toString)
   }
 
+  /** Analogous to `zip` except that the elements in each collection are not consumed until a strict operation is
+    * invoked on the returned `LazyZip2` decorator.
+    *
+    * Calls to `lazyZip` can be chained to support higher arities (up to 4) without incurring the expense of
+    * constructing and deconstructing intermediary tuples.
+    *
+    * {{{
+    *    val xs = List(1, 2, 3)
+    *    val res = (xs lazyZip xs lazyZip xs lazyZip xs).map((a, b, c, d) => a + b + c + d)
+    *    // res == List(4, 8, 12)
+    * }}}
+    *
+    * @param that the iterable providing the second element of each eventual pair
+    * @tparam B   the type of the second element in each eventual pair
+    * @return a decorator `LazyZip2` that allows strict operations to be performed on the lazily evaluated pairs
+    *         or chained calls to `lazyZip`. Implicit conversion to `Iterable[(A, B)]` is also supported.
+    */
+  def lazyZip[B](that: Iterable[B]): LazyZip2[Char, B, String] = new LazyZip2(s, new WrappedString(s), that)
+
 
   /* ************************************************************************************************************
      The remaining methods are provided for completeness but they delegate to WrappedString implementations which

--- a/test/junit/scala/collection/LazyZipOpsTest.scala
+++ b/test/junit/scala/collection/LazyZipOpsTest.scala
@@ -257,4 +257,21 @@ class LazyZipOpsTest {
 
     assertEquals(Map(1 -> (1, 1, "a", "foo"), 2 -> (2, 2, "b", "bar")), res)
   }
+
+  @Test
+  def lazyZipArray: Unit = {
+    val a = Array(1,2,3).lazyZip(List(4,5,6)).map(_ + _)
+    val at: Array[Int] = a
+    assertArrayEquals(Array(5, 7, 9), at)
+  }
+
+  @Test
+  def lazyZipString: Unit = {
+    val v = "abc".lazyZip(List(1,2,3)).map((a, b) => a.toInt + b.toInt)
+    val vt: IndexedSeq[Int] = v
+    assertEquals(Vector(98, 100, 102), vt)
+    val s = "abc".lazyZip(List(1,2,3)).map((a, b) => (a.toInt + b.toInt).toChar)
+    val st: String = s
+    assertEquals("bdf", st)
+  }
 }


### PR DESCRIPTION
- Also simplify the definition of lazyZip for collections. There is no
  need for extension methods and LazyZipOps. lazyZip can be defined
  as a regular method.
- This alone makes it available for Array and String types but we want
  to get back an Array or String (if applicable) so we still need
  separate definitions in ArrayOps and StringOps.

Fixes https://github.com/scala/bug/issues/11063