### PR TITLE
Emit bridge method forwarders with BRIDGE flag

### DIFF
--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -16,6 +16,42 @@ class BytecodeTest extends BytecodeTesting {
   import compiler._
 
   @Test
+  def bridgeFlag(): Unit = {
+    val code =
+      """ A { def f: Object = null }
+        |object B extends A { override def f: String = "b" }
+      """.stripMargin
+    for (base <- List("trait", "class")) {
+      val List(a, bMirror, bModule) = compileClasses(base + code)
+      assertEquals("B", bMirror.name)
+      assertEquals(List("f()Ljava/lang/Object;0x49", "f()Ljava/lang/String;0x9"),
+        bMirror.methods.asScala
+          .filter(_.name == "f")
+          .map(m => m.name + m.desc + "0x" + Integer.toHexString(m.access)).toList.sorted)
+    }
+  }
+
+  @Test
+  def varArg(): Unit = {
+    val code =
+      """ A { @annotation.varargs def f(i: Int*): Object = null }
+        |object B extends A { @annotation.varargs override def f(i: Int*): String = "b" }
+      """.stripMargin
+    for (base <- List("trait", "class")) {
+      val List(a, bMirror, bModule) = compileClasses(base + code)
+      assertEquals("B", bMirror.name)
+      assertEquals(List(
+        "f(Lscala/collection/Seq;)Ljava/lang/Object;0x49",
+        "f(Lscala/collection/Seq;)Ljava/lang/String;0x9",
+        "f([I)Ljava/lang/Object;0xc9",
+        "f([I)Ljava/lang/String;0x89"),
+        bMirror.methods.asScala
+          .filter(_.name == "f")
+          .map(m => m.name + m.desc + "0x" + Integer.toHexString(m.access)).toList.sorted)
+    }
+  }
+
+  @Test
   def t6288bJumpPosition(): Unit = {
     val code =
       """object Case3 {                                 // 01


### PR DESCRIPTION
Fixes scala/bug#11061
Ref scala/bug#10812

On 2.13.x branch #6531 removed the forwarder for bridge methods. I would like to do same in 2.12.x since Java 11-ea started to find them ambiguous as seen in akka/akka#25449 / scala/bug#11061.

The problem statement in scala/bug#10812 was:

> Luckily, javac picks one of the two (the more specific), but IntelliJ seems to complain.

The situation has changed in Java 11-ea, which @chbatey reported in akka/akka#25449 / scala/bug#11061:

```
[error] /private/tmp/override-in-jdk11/src/main/java/example/Test.java:9:1: reference to get is ambiguous
[error]   both method get(akka.actor.ActorSystem) in example.TestKitExtension and method get(akka.actor.ActorSystem) in example.TestKitExtension match
[error]     TestKitExtension.get(a);
```

This shows that Java 11-ea thinks the forwarder to be ambiguous.

To keep binary compatibility, I am still emitting the forwarder for bridge methods, but with `ACC_BRIDGE` flag. I've locally built this backport and tested it in the repro build https://github.com/eed3si9n/override-in-jdk11.

#### 2.12.6 on Java 11-ea:

```
sbt:akka-jdk11> compile
[info] Compiling 2 Scala sources and 1 Java source to /Users/eed3si9n/work/quicktest/override-in-jdk11/target/scala-2.12/classes ...
[info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.6. Compiling...
[info]   Compilation completed in 6.463s.
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by sbt.internal.inc.javac.DiagnosticsReporter$PositionImpl$ (file:/Users/eed3si9n/.sbt/boot/scala-2.12.6/org.scala-sbt/sbt/1.2.1/zinc-compile-core_2.12-1.2.1.jar) to field com.sun.tools.javac.api.ClientCodeWrapper$DiagnosticSourceUnwrapper.d
WARNING: Please consider reporting this to the maintainers of sbt.internal.inc.javac.DiagnosticsReporter$PositionImpl$
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
[error] /Users/eed3si9n/work/quicktest/override-in-jdk11/src/main/java/example/Test.java:8:1: reference to get is ambiguous
[error]   both method get(akka.actor.ActorSystem) in example.TestKitExtension and method get(akka.actor.ActorSystem) in example.TestKitExtension match
[error]     TestKitExtension.get(a);
[error] (Compile / compileIncremental) javac returned non-zero exit code
```

#### 2.12.7-bin-LOCAL20180810b (added BRIDGE flag to one of them)

```
sbt:akka-jdk11> compile
[info] Compiling 2 Scala sources and 1 Java source to /Users/eed3si9n/work/quicktest/override-in-jdk11/target/scala-2.12/classes ...
[info] Done compiling.
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.protobuf.UnsafeUtil (file:/Users/eed3si9n/.sbt/boot/scala-2.12.6/org.scala-sbt/sbt/1.2.1/protobuf-java-3.3.1.jar) to field java.nio.Buffer.address
WARNING: Please consider reporting this to the maintainers of com.google.protobuf.UnsafeUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
[success] Total time: 6 s, completed Aug 10, 2018, 10:38:19 PM
```

javap:

```java
  public static akka.testkit.TestKitSettings get(akka.actor.ActorSystem);
    descriptor: (Lakka/actor/ActorSystem;)Lakka/testkit/TestKitSettings;
    flags: (0x0009) ACC_PUBLIC, ACC_STATIC

  public static akka.actor.Extension get(akka.actor.ActorSystem);
    descriptor: (Lakka/actor/ActorSystem;)Lakka/actor/Extension;
    flags: (0x0049) ACC_PUBLIC, ACC_STATIC, ACC_BRIDGE
```
