### PR TITLE
Add immutable.IndexedSeqView and  stack-/heap-safe implementations

### DIFF
--- a/src/library/scala/collection/SeqView.scala
+++ b/src/library/scala/collection/SeqView.scala
@@ -24,7 +24,7 @@ object SeqView {
 
   /** A view that doesn’t apply any transformation to an underlying sequence */
   @SerialVersionUID(3L)
-  class Id[+A](underlying: SeqOps[A, AnyConstr, _]) extends AbstractSeqView[A] {
+  class Id[+A](underlying: SomeSeqOps[A]) extends AbstractSeqView[A] {
     def apply(idx: Int): A = underlying.apply(idx)
     def length: Int = underlying.length
     def iterator: Iterator[A] = underlying.iterator

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -1454,7 +1454,7 @@ final class StringOps(private val s: String) extends AnyVal {
   def permutations: Iterator[String] = new WrappedString(s).permutations.map(_.unwrap)
 }
 
-case class StringView(s: String) extends AbstractIndexedSeqView[Char] {
+case class StringView(s: String) extends immutable.AbstractIndexedSeqView[Char] {
   def length = s.length
   @throws[StringIndexOutOfBoundsException]
   def apply(n: Int) = s.charAt(n)

--- a/src/library/scala/collection/immutable/IndexedSeqView.scala
+++ b/src/library/scala/collection/immutable/IndexedSeqView.scala
@@ -1,0 +1,416 @@
+package scala.collection.immutable
+
+import scala.collection.{AnyConstr, SeqView, View}
+import scala.language.higherKinds
+
+/** An IndexedSeqView whose underlying collections are immutable */
+trait IndexedSeqView[+A] extends collection.IndexedSeqView[A] with IndexedSeqOps[A, View, View[A]] { self =>
+
+  override def view: IndexedSeqView[A] = this
+
+  def prependedBy[B >: A](prefix: IndexedSeq[B]): IndexedSeqView[B] = IndexedSeqView.prependedBy(this, prefix)
+  override def prepended[B >: A](elem: B): IndexedSeqView[B] = IndexedSeqView.prepended(this, elem)
+  override def take(n: Int): IndexedSeqView[A] = IndexedSeqView.take(this, n)
+  override def takeRight(n: Int): IndexedSeqView[A] = IndexedSeqView.takeRight(this, n)
+  override def drop(n: Int): IndexedSeqView[A] = IndexedSeqView.drop(this, n)
+  override def dropRight(n: Int): IndexedSeqView[A] = IndexedSeqView.dropRight(this, n)
+  override def map[B](f: A => B): IndexedSeqView[B] = IndexedSeqView.map[A, B](this, f)
+  override def reverse: IndexedSeqView[A] = IndexedSeqView.reverse(this)
+  override def slice(from: Int, until: Int): IndexedSeqView[A] = IndexedSeqView.slice(this, from, until)
+  override def appended[B >: A](elem: B): IndexedSeqView[B] = IndexedSeqView.appended(this, elem)
+  def appendedBy[B >: A](suffix: IndexedSeq[B]): IndexedSeqView[B] = IndexedSeqView.appendedAll(this, suffix)
+}
+
+object IndexedSeqView {
+
+  /** An `IndexedSeqOps` whose collection type and collection type constructor are unknown */
+  type SomeIndexedSeqOps[A] = IndexedSeqOps[A, AnyConstr, _]
+
+  def empty[A]: IndexedSeqView[A] = Empty
+
+  def single[A](elem: A): IndexedSeqView[A] = new Single(elem)
+
+  def id[A](underlying: SomeIndexedSeqOps[A]): IndexedSeqView[A] = new Id(underlying)
+
+  def previouslyEvaluated[A](underlying: Vector[A]): IndexedSeqView[A] =
+    if (underlying.isEmpty) Empty else new PreviouslyEvaluated(underlying)
+
+  def take[A](underlying: SomeIndexedSeqOps[A], n: Int): IndexedSeqView[A] = slice(underlying, 0, n)
+
+  def takeRight[A](underlying: SomeIndexedSeqOps[A], n: Int): IndexedSeqView[A] = {
+    val len = underlying.length
+    slice(underlying, len - n, len)
+  }
+
+  def drop[A](underlying: SomeIndexedSeqOps[A], n: Int): IndexedSeqView[A] = slice(underlying, n, underlying.length)
+
+  def dropRight[A](underlying: SomeIndexedSeqOps[A], n: Int): IndexedSeqView[A] =
+    slice(underlying, 0, underlying.length - n)
+
+  def reverse[A](underlying: SomeIndexedSeqOps[A]): IndexedSeqView[A] =
+    if (underlying.isEmpty) Empty else new Slice(Empty, underlying, 0, underlying.length, Empty, true, IndexedSeq.empty)
+
+  def slice[A](underlying: SomeIndexedSeqOps[A], from: Int, until: Int): IndexedSeqView[A] = {
+    val length = underlying.length
+    val _from = from.max(0)
+    val _until = until.max(_from).min(length)
+    if (_from >= _until) Empty
+    else new Slice(Empty, underlying, _from, _until, Empty, false, IndexedSeq.empty)
+  }
+
+
+  def map[A, B](underlying: SomeIndexedSeqOps[A], f: A => B): IndexedSeqView[B] = {
+    val len = underlying.length
+    if (len <= 0) Empty
+    else new Slice(Empty, underlying, 0, len, Empty, false, IndexedSeq(f.asInstanceOf[Any => Any]))
+  }
+
+  def appended[A](underlying: SomeIndexedSeqOps[A], elem: A): IndexedSeqView[A] = {
+    val len = underlying.length
+    val _single = single(elem)
+    if (len <= 0) _single else new Slice(Empty, underlying, 0, len, _single, false, IndexedSeq.empty)
+  }
+
+  def appendedAll[A](underlying: SomeIndexedSeqOps[A], suffix: IndexedSeq[A]): IndexedSeqView[A] = {
+    val suffixLen = suffix.length
+    val underlyingLen = underlying.length
+    if (suffixLen <= 0) {
+      if (underlyingLen <= 0) Empty else id(underlying)
+    } else if (underlyingLen <= 0) {
+      id(suffix)
+    } else {
+      new Slice[A, A](Empty, underlying, 0, underlyingLen, id(suffix), false, IndexedSeq.empty)
+    }
+  }
+
+  def prepended[A](underlying: SomeIndexedSeqOps[A], elem: A): IndexedSeqView[A] = {
+    val len = underlying.length
+    if (len <= 0) single(elem) else
+      new Slice[A, A](single(elem), underlying, 0, len, Empty, false, IndexedSeq.empty)
+  }
+  def prependedBy[A](underlying: SomeIndexedSeqOps[A], prefix: IndexedSeq[A]): IndexedSeqView[A] = {
+    val prefixLen = prefix.length
+    val underlyingLen = underlying.length
+    if (prefixLen <= 0) {
+      if (underlyingLen <= 0) Empty else id(underlying)
+    } else if (underlyingLen <= 0) {
+      id(prefix)
+    } else {
+      new Slice[A, A](id(prefix), underlying, 0, underlyingLen, Empty, false, IndexedSeq.empty)
+    }
+  }
+
+  @SerialVersionUID(3L)
+  private[scala] case object Empty extends AbstractIndexedSeqView[Nothing] {
+    override def iterator = Iterator.empty
+    override def apply(i: Int): Nothing = throw new IndexOutOfBoundsException(i.toString)
+    override def length = 0
+    override def prepended[B >: Nothing](elem: B) = single(elem)
+    override def take(n: Int) = this
+    override def takeRight(n: Int) = this
+    override def drop(n: Int) = this
+    override def dropRight(n: Int) = this
+    override def map[B](f: Nothing => B) = this
+    override def reverse = this
+    override def slice(from: Int, until: Int) = this
+    override def appended[B >: Nothing](elem: B) = single(elem)
+  }
+
+  @SerialVersionUID(3L)
+  private[scala] final class Single[+A](underlying: A) extends AbstractIndexedSeqView[A] {
+    override def apply(i: Int) = if (i == 0) underlying else throw new IndexOutOfBoundsException(i.toString)
+    override def length = 1
+    override def prepended[B >: A](elem: B) = new PreviouslyEvaluated(Vector(elem, underlying))
+    override def take(n: Int) = if (n <= 0) Empty else this
+    override def takeRight(n: Int) = take(n)
+    override def drop(n: Int) = if (n > 0) Empty else this
+    override def dropRight(n: Int) = drop(n)
+    override def map[B](f: A => B) = new Slice(Empty, this, 0, 1, Empty, false, IndexedSeq(f.asInstanceOf[Any => Any]))
+    override def reverse = this
+    override def slice(from: Int, until: Int) = if (from > 0 || until < 1) Empty else this
+    override def appended[B >: A](elem: B) = new PreviouslyEvaluated(Vector(underlying, elem))
+  }
+
+  /** In cases where a user constructs previously-evaluated elements, such as in the case of appending/prepending, etc,
+    * it makes to store these elements in our own data structure which can perform appropriate optimizations. Namely,
+    * storing repeated prepends/appends in a Vector rather than in the call stack.
+    *
+    * Note that we will not use this to represent a user-passed IndexedSeq, because it could potentially have much worse
+    * prepend/append performance.
+    *
+    * All other operations are still completely lazy though, in keeping with the idea of a view.
+    */
+  @SerialVersionUID(3L)
+  private[scala] final class PreviouslyEvaluated[+A](underlying: Vector[A]) extends AbstractIndexedSeqView[A] {
+    override def apply(i: Int) = underlying(i)
+    override def length = underlying.length
+    override def prepended[B >: A](elem: B) = new PreviouslyEvaluated(underlying.prepended(elem))
+    override def take(n: Int) = IndexedSeqView.take(underlying, n)
+    override def takeRight(n: Int) = IndexedSeqView.takeRight(underlying, n)
+    override def drop(n: Int) = IndexedSeqView.drop(underlying, n)
+    override def dropRight(n: Int) = IndexedSeqView.dropRight(underlying, n)
+    override def map[B](f: A => B) = IndexedSeqView.map(underlying, f)
+    override def reverse = IndexedSeqView.reverse(underlying)
+    override def slice(from: Int, until: Int) = IndexedSeqView.slice(underlying, from, until)
+    override def appended[B >: A](elem: B) = new PreviouslyEvaluated(underlying.appended(elem))
+  }
+
+  @SerialVersionUID(3L)
+  private[scala] final class Id[+A](underlying: SomeIndexedSeqOps[A])
+    extends SeqView.Id(underlying) with IndexedSeqView[A] {
+    override def prepended[B >: A](elem: B) = IndexedSeqView.prepended(underlying, elem)
+    override def take(n: Int) = IndexedSeqView.take(underlying, n)
+    override def takeRight(n: Int) = IndexedSeqView.takeRight(underlying, n)
+    override def drop(n: Int) = IndexedSeqView.drop(underlying, n)
+    override def dropRight(n: Int) = IndexedSeqView.dropRight(underlying, n)
+    override def map[B](f: A => B) = IndexedSeqView.map(underlying, f)
+    override def reverse = IndexedSeqView.reverse(underlying)
+    override def slice(from: Int, until: Int) = IndexedSeqView.slice(underlying, from, until)
+    override def appended[B >: A](elem: B) = IndexedSeqView.appended(underlying, elem)
+  }
+
+  /** A data structure that is the main implementation for [[IndexedSeqView]].
+    *
+    * The benefit of this data structure is that by tracking more information about the underlying data the view
+    * represents, it is able to more intelligently perform transformations by:
+    *   * avoiding wrapping layers, and in some cases even allocations:
+    *       Most transformations do not add additional wrapping but instead rearrange underlying data in a slice
+    *       of the same (or lower) depth
+    *   * discarding data when possible
+    *       When we are able to throw away data, such as during a .drop or .take transformation, we do so
+    *   * combining repeated map transformations into a heap data structure, which can be traversed stack-safely
+    *
+    * It works by tracking three separate component collections. These are:
+    *   underlying:
+    *     The main collection this is a slice of.
+    *     Offsets within the underlying collection are also maintained, these are `lo` and `hi`
+    *   prefix: The IndexedSeqView of elements which precedes `underlying`, usually obtained through prepending
+    *   suffix: The IndexedSeqView of elements which follows `underlying`, usually obtained through appending
+    *
+    * The overall picture is then:
+    *
+    * prefix                           underlying                          suffix
+    * [*******************************][     *********************        ][*******************************]
+    *                                  |----|lo
+    *                                  |--------------------------|hi
+    *
+    *
+    * Also tracked are:
+    *   isReversed:
+    *     a flag that tracks whether at read time, the elements should be read:
+    *       right to left (true)
+    *       left to right (false)
+    *
+    *     The flag will not be set, unless a previous `reverse` transformation has been applied
+    *
+    *   mapFunctions:
+    *     a queue of functions, possibly of different types, that are applied to each element
+    *     from left to right at read time. This is used as a stack-safe alternative to arbitrily
+    *     nested functions during repeated calls to .map(f) transformations.
+    *
+    * @param underlying The main sequence of elements over which this slice manages a view of. Will not typically be
+    *                   empty, but there is no breakage caused if it is empty
+    * @param prefix the elements which precede the elements in underlying
+    * @param from the offset from the left, of elements in underlying. This is the lowest index which is included
+    * @param until the offset from the left, of elements in underlying. This is the lowest index which is EXCLUDED
+    * @param suffix the elements which succeed the elements in underlying
+    * @param isReversed if true, then this slice is to be read right-to-left. Otherwise, left-to-right
+    * @param mapFunctions an IndexedSeq of functions which represent previous mapping transformations, to be applied
+    *                     left-to-right, when this view is strictly evaluated.
+    *
+    *                     Care is taken to ensure that the first input type of the first map function
+    *                     is of type `A`, and the last has output type `B`
+    *
+    * @tparam A the type of element in underlying
+    * @tparam B the type of element this is a view of, which are obtained by mapping elements of type `A` through
+    *           mapFunctions
+    */
+  @SerialVersionUID(3L)
+  private[scala] final class Slice[+A, +B](
+    prefix: IndexedSeqView[B],
+    underlying: SomeIndexedSeqOps[A],
+    from: Int,
+    until: Int,
+    suffix: IndexedSeqView[B],
+    isReversed: Boolean,
+    mapFunctions: IndexedSeq[Any => Any]) extends AbstractIndexedSeqView[B] {
+    /** The actual low underlying offset */
+    protected val lo = from max 0
+    /** The actual high underlying offset */
+    protected val hi = (until max 0) min underlying.length
+
+    /** Length of prefix */
+    protected val prefixLen = prefix.length
+    /** Length of underlying */
+    protected val len = (hi - lo) max 0
+    /** Length of suffix */
+    protected val suffixLen = suffix.length
+
+    override def length = prefixLen + len + suffixLen
+
+    @throws[IndexOutOfBoundsException]
+    def apply(i: Int): B = {
+      // the underlying index, after accounting for reversals
+      val j = if(isReversed) length - i - 1 else i
+      if (j < prefixLen) {
+        prefix(j)
+      } else if (j < prefixLen + len) {
+        mapFunctions.foldLeft(underlying(lo + (j - prefixLen)) : Any)((arg, f) => f(arg)).asInstanceOf[B]
+      } else {
+        val postIndex = j - prefixLen - len
+        if (postIndex < suffixLen) {
+          suffix(postIndex)
+        } else throw new IndexOutOfBoundsException(i.toString)
+      }
+    }
+
+    override def take(n: Int): IndexedSeqView[B] = dropRight(length - n)
+
+    override def takeRight(n: Int): IndexedSeqView[B] = drop(length - n)
+
+    override def drop(n: Int): IndexedSeqView[B] = {
+      val dropped = (n max 0) min length
+      if (dropped == 0) {
+        this
+      } else if (dropped >= length) {
+        Empty
+      } else if (isReversed) {
+        if (dropped <= suffixLen) {
+          new Slice(prefix, underlying, lo, hi, suffix.dropRight(dropped), isReversed, mapFunctions)
+        } else if (dropped <= suffixLen + len) {
+          val newHi = hi - (dropped - suffixLen)
+          if (newHi <= lo) {
+            prefix.reverse
+          } else {
+            new Slice(prefix, underlying, lo, newHi, Empty, isReversed, mapFunctions)
+          }
+        } else {
+          prefix.dropRight(dropped - suffixLen - len).reverse
+        }
+      } else {
+        if (dropped <= prefixLen) {
+          new Slice(prefix.drop(dropped), underlying, lo, hi, suffix, isReversed, mapFunctions)
+        } else if (dropped <= prefixLen + len) {
+          val newLo = lo + (dropped - prefixLen)
+          if (newLo >= hi) {
+            suffix
+          } else {
+            new Slice(Empty, underlying, newLo, hi, suffix, isReversed, mapFunctions)
+          }
+        } else {
+          suffix.drop(dropped - prefixLen - len)
+        }
+      }
+    }
+    override def dropRight(n: Int): IndexedSeqView[B] =
+      if (n <= 0) {
+        this
+      } else {
+        val dropped = n.max(0).min(length)
+        if (dropped >= length) Empty
+        else if (isReversed) {
+          if (dropped <= prefixLen) {
+            new Slice(prefix.drop(dropped), underlying, lo, hi, suffix, isReversed, mapFunctions)
+          } else if (dropped <= prefixLen + len) {
+            val newLo = lo + (dropped - prefixLen)
+            if (newLo >= hi) {
+              suffix.reverse
+            } else {
+              new Slice(Empty, underlying, newLo, hi, suffix, isReversed, mapFunctions)
+            }
+          } else {
+            suffix.drop(dropped - prefixLen - len).reverse
+          }
+        }
+        else if (dropped <= suffixLen) new Slice(prefix, underlying, lo, hi, suffix.dropRight(dropped), isReversed, mapFunctions)
+        else if (dropped <= suffixLen + len) {
+          val newHi = hi - dropped + suffixLen
+          if (newHi <= lo) {
+            prefix
+          } else {
+            new Slice(prefix, underlying, lo, newHi, Empty, isReversed, mapFunctions)
+          }
+        } else {
+          prefix.dropRight(dropped - suffixLen - len)
+        }
+      }
+
+    override def reverse: IndexedSeqView[B] = new Slice(prefix, underlying, lo, hi, suffix, !isReversed, mapFunctions)
+
+    override def slice(from: Int, until: Int): IndexedSeqView[B] = {
+      val _from = from.max(0).min(length)
+      val _until = until.max(0).min(length)
+      val newLen = (_until - _from).max(0)
+
+      if (newLen == 0) {
+        Empty
+      } else if (newLen >= length) {
+        this
+      } else if (isReversed) {
+        if (_from >= suffixLen) {
+          if (_from >= suffixLen + len) {
+            if (_from >= length) {
+              Empty
+            } else {
+              prefix.reverse.slice(_from - suffixLen - len, _until - suffixLen - len)
+            }
+          } else {
+            if (_until <= suffixLen + len) {
+              new Slice(Empty, underlying, hi - (_until - suffixLen), hi - (_from - suffixLen), Empty, isReversed, mapFunctions)
+            } else {
+              new Slice(prefix.takeRight(_until - (suffixLen + len)), underlying, lo, hi - (from - suffixLen), Empty, isReversed, mapFunctions)
+            }
+          }
+        } else {
+          if (_until <= suffixLen) {
+            suffix.reverse.slice(_from, _until)
+          } else if (_until <= suffixLen + len){
+            new Slice(Empty, underlying, hi - (_until - suffixLen), hi, suffix.dropRight(_from), isReversed, mapFunctions)
+          } else {
+            new Slice(prefix.takeRight(_until - suffixLen - len), underlying, lo, hi, suffix.take(suffixLen - _from), isReversed, mapFunctions)
+          }
+        }
+      } else {
+        if (_from >= prefixLen) {
+          if (_from >= prefixLen + len) {
+            if (_from >= length) {
+              Empty
+            } else {
+              suffix.slice(_from - prefixLen - len, _until - prefixLen - len)
+            }
+          } else {
+            if (_until <= prefixLen + len) {
+              new Slice(Empty, underlying, _from - prefixLen, _until - prefixLen, Empty, isReversed, mapFunctions)
+            } else {
+              new Slice(Empty, underlying, lo + _from - prefixLen , hi, suffix.take(_until - prefixLen - len), isReversed, mapFunctions)
+            }
+          }
+        } else {
+          if (_until <= prefixLen) {
+            prefix.slice(_from, _until)
+          } else if (_until <= prefixLen + len){
+            new Slice(prefix.drop(_from), underlying, lo, lo + _until - prefixLen, Empty, isReversed, mapFunctions)
+          } else {
+            new Slice(prefix.drop(_from), underlying, lo, hi, suffix.take(_until - prefixLen - len), isReversed, mapFunctions)
+          }
+        }
+      }
+    }
+
+    override def map[B0](f: B => B0): IndexedSeqView[B0] =
+      new Slice(prefix.map(f), underlying, lo, hi, suffix.map(f), isReversed, mapFunctions :+ f.asInstanceOf[Any => Any])
+
+    override def prepended[B0 >: B](elem: B0): IndexedSeqView[B0] =
+      if (isReversed) new Slice(prefix, underlying, lo, hi, suffix.appended(elem), isReversed, mapFunctions)
+      else new Slice(prefix.prepended(elem), underlying, lo, hi, suffix, isReversed, mapFunctions)
+
+    override def appended[B0 >: B](elem: B0): IndexedSeqView[B0] =
+      if (isReversed) new Slice(prefix.prepended(elem), underlying, lo, hi, suffix, isReversed, mapFunctions)
+      else new Slice(prefix, underlying, lo, hi, suffix.appended(elem), isReversed, mapFunctions)
+  }
+
+}
+
+/** Explicit instantiation of the `IndexedSeqView` trait to reduce class file size in subclasses. */
+@SerialVersionUID(3L)
+abstract class AbstractIndexedSeqView[+A] extends collection.AbstractIndexedSeqView[A] with IndexedSeqView[A]

--- a/src/library/scala/collection/immutable/Seq.scala
+++ b/src/library/scala/collection/immutable/Seq.scala
@@ -35,6 +35,8 @@ trait IndexedSeq[+A] extends Seq[A]
   final override def toIndexedSeq: IndexedSeq[A] = this
 
   override def iterableFactory: SeqFactory[IterableCC] = IndexedSeq
+
+  override def view: IndexedSeqView[A] = IndexedSeqView.id(this)
 }
 
 @SerialVersionUID(3L)

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -74,9 +74,12 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
   // Code paths that mutates `dirty` _must_ call `Statics.releaseFence()` before returning from
   // the public method.
   private[immutable] var dirty = false
+
   // While most JDKs would implicit add this fence because of >= 1 final field, the spec only mandates
   // it if all fields are final, so let's add this in explicitly.
   releaseFence()
+
+  override def view: IndexedSeqView[A] = IndexedSeqView.previouslyEvaluated(this)
 
   def length: Int = endIndex - startIndex
 

--- a/test/junit/scala/collection/immutable/HashSetTest.scala
+++ b/test/junit/scala/collection/immutable/HashSetTest.scala
@@ -1,6 +1,6 @@
 package scala.collection.immutable
 
-import org.junit.Assert.{assertEquals, assertSame}
+import org.junit.Assert.assertSame
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4

--- a/test/junit/scala/collection/immutable/IndexedSeqViewTest.scala
+++ b/test/junit/scala/collection/immutable/IndexedSeqViewTest.scala
@@ -1,0 +1,655 @@
+package scala.collection.immutable
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.annotation.tailrec
+import scala.collection.View
+import scala.collection.immutable.IndexedSeqView.Slice
+import scala.tools.testing.AssertUtil.assertThrows
+
+@RunWith(classOf[JUnit4])
+class IndexedSeqViewTest {
+  @Test
+  def foo: Unit = {
+    assertEquals(Seq(3, 4, 5), Vector(1, 2, 3, 4, 5).view.drop(2).toSeq)
+  }
+  @Test
+  def slice: Unit = {
+        assertEquals(Seq(), Vector().view.slice(0,0).toSeq)
+        assertEquals(Seq(), Vector().view.slice(2,4).toSeq)
+        assertEquals(Seq(), Vector(1,1,1).view.slice(2,2).toSeq)
+        assertEquals(Seq(1,1), Vector(1,1,1).view.slice(-2,2).toSeq)
+        assertEquals(Seq(3,4), Vector(1,2,3,4,5).view.slice(2,4).toSeq)
+  }
+
+  @Test
+  def reverse: Unit = {
+    assertEquals(Seq(), Vector().view.reverse.toSeq)
+    assertEquals(Seq(1), Vector(1).view.reverse.toSeq)
+    val a = Vector(2, 1)
+    val b = a.view
+    val c = b.reverse
+    val d = c.toSeq
+    assertEquals(Seq(1, 2), Vector(2, 1).view.reverse.toSeq)
+    assertEquals(Seq(1, 1), Vector(1, 1, 1).view.slice(-2, 2).toSeq)
+    assertEquals(Seq(3, 4), Vector(1, 2, 3, 4, 5).view.slice(2, 4).toSeq)
+  }
+
+}
+
+@RunWith(classOf[JUnit4])
+class IndexedSeqViewSliceTest {
+  // generates pairs of slices with their corresponding equivalent indexedSeq, to cross-check behavior
+  // The slices generated vary in, size of prefix, size of underlying collection, and size of suffix
+  val MaxPrefixLength = 10
+  val MaxUnderlyingLength = 10
+  val MaxSuffixLength = 10
+  val maxLength = MaxPrefixLength + MaxUnderlyingLength + MaxSuffixLength
+
+  val allSlices: Seq[(IndexedSeqView[Int], IndexedSeq[Int], (Int, Int, Int))] = {
+    val goingForward = for {
+      prefixLength <- 0 to MaxPrefixLength
+      underlyingLength <- 0 to MaxUnderlyingLength
+      suffixLength <- 0 to MaxSuffixLength
+    } yield {
+      val indexedSeq = 0 until (prefixLength + underlyingLength + suffixLength)
+
+      val slice = new Slice(
+        prefix = IndexedSeqView.id(0 until prefixLength),
+        underlying = (prefixLength until (prefixLength + underlyingLength)).view,
+        from = 0,
+        until = underlyingLength,
+        suffix = ((prefixLength + underlyingLength) until (prefixLength + underlyingLength + suffixLength)).view,
+        isReversed = false,
+        mapFunctions = IndexedSeq.empty
+      )
+
+      (slice, indexedSeq.toVector, (prefixLength, underlyingLength, suffixLength))
+    }
+
+    val reverse = goingForward.map {
+      case (slice, seq, sizes) => (slice.reverse, seq.reverse, sizes)
+    }
+
+    goingForward ++ reverse
+  }
+
+  @Test
+  def foo: Unit = {
+    assertEquals(Seq(3, 4, 5), Vector(1, 2, 3, 4, 5).view.drop(2).toSeq)
+  }
+  @Test
+  def slice: Unit = {
+    assertEquals(Seq(), Vector().view.slice(0,0).toSeq)
+    assertEquals(Seq(), Vector().view.slice(2,4).toSeq)
+    assertEquals(Seq(), Vector(1,1,1).view.slice(2,2).toSeq)
+    assertEquals(Seq(1,1), Vector(1,1,1).view.slice(-2,2).toSeq)
+    assertEquals(Seq(3,4), Vector(1,2,3,4,5).view.slice(2,4).toSeq)
+  }
+
+  @Test
+  def reverse: Unit = {
+    assertEquals(Seq(), Vector().view.reverse.toSeq)
+    assertEquals(Seq(1), Vector(1).view.reverse.toSeq)
+    val a = Vector(2, 1)
+    val b = a.view
+    val c = b.reverse
+    val d = c.toSeq
+    assertEquals(Seq(1, 2), Vector(2, 1).view.reverse.toSeq)
+    assertEquals(Seq(1, 1), Vector(1, 1, 1).view.slice(-2, 2).toSeq)
+    assertEquals(Seq(3, 4), Vector(1, 2, 3, 4, 5).view.slice(2, 4).toSeq)
+  }
+
+
+  @Test
+  def stackSafeTail: Unit = {
+    val coll = Vector.fill(12000)(0)
+
+    def makeStackedSlice(coll: IndexedSeq[Int], count: Int) = {
+      @tailrec
+      def makeSlicesOfView(view: View[Int], noOfSlices: Int): View[Int] =
+        if (noOfSlices == 0) view
+        else makeSlicesOfView(view.tail, noOfSlices - 1)
+
+      makeSlicesOfView(coll.view, count)
+    }
+
+    val slice = makeStackedSlice(coll, 10000)
+    assertEquals(slice.head, 0)
+  }
+
+  @Test
+  def stackSafe2: Unit = {
+
+    val NumStages = 12
+    val NumIterations = 100 * 1000 // hundred thousand
+
+    val seq = (0 until (NumIterations * NumStages)).view
+      .map(_ % NumStages)
+      .foldLeft((1 to 10).view) {
+        case (acc, 0) => acc.appended(-1)
+        case (acc, 1) => acc.take(10)
+        case (acc, 2) => acc.appended(-2)
+        case (acc, 3) => acc.dropRight(1)
+        case (acc, 4) => acc.reverse
+        case (acc, 5) => acc.reverse
+
+        case (acc, 6) => acc.slice(1, 9)
+        case (acc, 7) => acc.prepended(1).appended(10)
+
+        case (acc, 8) => acc.drop(5)
+        case (acc, 9) =>
+          acc.prepended(5).prepended(4).prepended(3).prepended(2).prepended(1)
+
+        case (acc, 10) => acc.takeRight(9).map(identity)
+        case (acc, 11) => acc.prepended(1)
+        case (acc, _)  => acc
+      }
+      .toSeq
+
+    assertEquals(1 to 10, seq)
+  }
+
+  @Test
+  def sliceExchaustive: Unit = {
+    for {
+      (slice, indexedSeq, sizes) <- allSlices
+      from <- -3 to maxLength + 3
+      until <- -3 to maxLength + 2
+      fromRange = indexedSeq.slice(from, until).toList
+      fromView = slice.slice(from, until).toSeq
+    } assert(fromRange == fromView,
+      s"""Failed on slice=${slice.toSeq}(sizes=$sizes),indexedSeq=$indexedSeq,from=$from,until=$until
+         |range: $fromRange
+         |view: $fromView
+     """.stripMargin)
+  }
+
+  @Test
+  def reverseExhaustive: Unit = {
+    for {
+      (slice, indexedSeq, _) <- allSlices
+      fromRange = indexedSeq.reverse
+      fromView = slice.reverse.toSeq
+    } {
+      assert(fromRange == fromView,
+        s"""Failed on slice=${slice.toSeq},indexedSeq=$indexedSeq
+           |range: $fromRange
+           |view: $fromView
+     """.stripMargin)
+      assert(slice.toSeq == slice.reverse.reverse.toSeq,
+        s"""Failed on slice=${slice.toSeq},indexedSeq=$indexedSeq
+           |range: $fromRange
+           |view: $fromView
+     """.stripMargin)
+    }
+  }
+
+  @Test
+  def takeExhaustive: Unit = {
+    for {
+      (slice, indexedSeq, _) <- allSlices
+      n <- -3 to maxLength + 3
+      fromRange = indexedSeq.take(n).toSeq
+      fromView = slice.take(n).toSeq
+    } assert(fromRange == fromView,
+      s"""Failed on slice=${slice.toSeq},indexedSeq=$indexedSeq,n=$n
+         |range: $fromRange
+         |view: $fromView
+     """.stripMargin)
+  }
+
+  @Test
+  def takeRightExhaustive: Unit = {
+    for {
+      (slice, indexedSeq, sizes) <- allSlices
+      n <- -3 to maxLength + 3
+      fromRange = indexedSeq.takeRight(n).toVector
+      fromView = slice.takeRight(n).toSeq
+    } assert(fromRange == fromView,
+      s"""Failed on slice=${slice.toSeq}(sizes=$sizes),indexedSeq=$indexedSeq,n=$n
+         |range: $fromRange
+         |view: $fromView
+     """.stripMargin)
+  }
+
+  @Test
+  def dropExhaustive: Unit = {
+    for {
+      (slice, indexedSeq, sizes) <- allSlices
+      n <- -3 to maxLength + 3
+      fromRange = indexedSeq.drop(n).toList
+      fromView = slice.drop(n).toSeq
+    } assert(fromRange == fromView,
+      s"""Failed on slice=${slice.toSeq}(sizes=$sizes),indexedSeq=$indexedSeq,n=$n
+         |range: $fromRange
+         |view: $fromView
+     """.stripMargin)
+  }
+
+  @Test
+  def dropRightExhaustive: Unit = {
+    for {
+      (slice, indexedSeq, sizes) <- allSlices
+      n <- -3 to maxLength + 3
+      fromRange = indexedSeq.dropRight(n).toList
+      fromView = slice.dropRight(n).toList
+    } assert(fromRange == fromView,
+      s"""Failed on slice=${slice.toSeq}(sizes=$sizes),indexedSeq=$indexedSeq,n=$n
+         |range: $fromRange
+         |view: $fromView
+     """.stripMargin)
+  }
+
+  @Test
+  def mapExhaustive: Unit = {
+    for {
+      (slice, indexedSeq, _) <-
+        // this test is a bit meaty, we can just sample 5%
+        allSlices
+          .zipWithIndex
+          .collect { case (elem, i) if i % 10 == 0 => elem}
+      depthOfMaps <- List(1, 10, 20000)
+      fromRange = indexedSeq.map(_ + depthOfMaps).toList
+      fromView = (1 to depthOfMaps).foldLeft(slice)((acc, _) => acc.map(_ + 1)).toSeq
+    } assert(fromRange == fromView,
+      s"""Failed on slice=${slice.toSeq},indexedSeq=$indexedSeq,depthOfMaps=$depthOfMaps
+         |range: $fromRange
+         |view: $fromView
+     """.stripMargin)
+  }
+
+  @Test
+  def prependedExhaustive: Unit = {
+    for {
+      (slice, indexedSeq, _) <- allSlices
+      fromSeq = indexedSeq.prepended(-100).toList
+      fromView = slice.prepended(-100).toList
+    } assert(fromSeq == fromView,
+      s"""Failed on slice=${slice.toSeq},indexedSeq=$indexedSeq
+         |range: $fromSeq
+         |view: $fromView
+     """.stripMargin)
+  }
+  @Test
+  def prependedAllExhaustive: Unit = {
+    // for indexedSeqs
+    for {
+      (slice, indexedSeq, _) <- allSlices
+      prependSize <- List(0, 1, 2, 10)
+      prefix = 0 until prependSize
+      fromSeq = indexedSeq.prependedAll(prefix).toList
+      fromView = slice.prependedBy(prefix).toList
+    } {
+      assert(fromSeq == fromView,
+        s"""Failed on slice=${slice.toSeq},indexedSeq=$indexedSeq
+           |range: $fromSeq
+           |view: $fromView
+     """.stripMargin)
+    }
+    // for iterables
+    for {
+      (slice, indexedSeq, _) <- allSlices
+      prefixSize <- List(0, 1, 2, 10)
+      prefix: Iterable[Int] = 0 until prefixSize : Iterable[Int]
+      fromSeq = indexedSeq.prependedAll(prefix).toList
+      fromView = slice.prependedAll(prefix).toList
+    } {
+      assert(fromSeq == fromView,
+        s"""Failed on slice=${slice.toSeq},indexedSeq=$indexedSeq
+           |range: $fromSeq
+           |view: $fromView
+     """.stripMargin)
+    }
+  }
+
+  @Test
+  def appendedExhaustive: Unit = {
+    for {
+      (slice, indexedSeq, _) <- allSlices
+      fromSeq = indexedSeq.appended(-100).toList
+      fromView = slice.appended(-100).toList
+    } assert(fromSeq == fromView,
+      s"""Failed on slice=${slice.toSeq},indexedSeq=$indexedSeq
+         |range: $fromSeq
+         |view: $fromView
+     """.stripMargin)
+  }
+
+  @Test
+  def appendedAllExhaustive: Unit = {
+    // for indexedSeqs
+    for {
+      (slice, indexedSeq, _) <- allSlices
+      suffixSize <- List(0, 1, 2, 10)
+      suffix = 0 until suffixSize
+      fromSeq = indexedSeq.prependedAll(suffix).toList
+      fromView = slice.prependedBy(suffix).toList
+    } {
+      assert(fromSeq == fromView,
+        s"""Failed on slice=${slice.toSeq},indexedSeq=$indexedSeq
+           |range: $fromSeq
+           |view: $fromView
+     """.stripMargin)
+    }
+    // for iterables
+    for {
+      (slice, indexedSeq, _) <- allSlices
+      suffixSize <- List(0, 1, 2, 10)
+      suffix: Iterable[Int] = 0 until suffixSize : Iterable[Int]
+      fromSeq = indexedSeq.appendedAll(suffix).toList
+      fromView = slice.appendedAll(suffix).toList
+    } {
+      assert(fromSeq == fromView,
+        s"""Failed on slice=${slice.toSeq},indexedSeq=$indexedSeq
+           |range: $fromSeq
+           |view: $fromView
+     """.stripMargin)
+    }
+  }
+
+  @Test
+  def stackSafeAppended: Unit = {
+    assertEquals(100001,
+      (1 to 100000).foldLeft(Vector(0).view)(_.appended(_)).length)
+  }
+  @Test
+  def stackSafeAppendedBy: Unit = {
+    val v = Vector(1)
+    assertEquals(100003,
+      (1 to 100000).map(_ => v).foldLeft(Vector(1,2,3).view)(_.appendedBy(_)).length)
+  }
+
+  @Test
+  def stackSafePrepend: Unit = {
+    assertEquals(100001,
+      (1 to 100000).foldLeft(Vector(0).view)(_.prepended(_)).length)
+  }
+  @Test
+  def stackSafePrependedBy: Unit = {
+    val v = Vector(1)
+    assertEquals(100003,
+      (1 to 100000).map(_ => v).foldLeft(Vector(1,2,3).view)(_.prependedBy(_)).length)
+  }
+
+  @Test
+  def mapMultipleTypesTest: Unit = {
+    assertEquals(List(10),
+      Vector(1).view
+        .map(_.toString)
+        .map(_.headOption)
+        .map(_.map(_.toString.toInt))
+        .map(_.map(_ * 10))
+        .map(_.getOrElse(5))
+        .toSeq)
+  }
+
+  @Test
+  def mapIsLazyUntilForced: Unit = {
+    for ((slice, _, _) <- allSlices) {
+      var canary = 0
+      val mapped = slice.map { _ => canary += 1; 1 }
+      assertEquals(0, canary)
+
+      val forced = mapped.toSeq
+      assertEquals(canary > 0, slice.nonEmpty)
+    }
+  }
+}
+
+@RunWith(classOf[JUnit4])
+class EmptyIndexedSeqViewTest {
+  val empty = IndexedSeqView.Empty
+  @Test
+  def apply: Unit = {
+    assertThrows[IndexOutOfBoundsException](empty(-1))
+    assertThrows[IndexOutOfBoundsException](empty(0))
+    assertThrows[IndexOutOfBoundsException](empty(1))
+  }
+  @Test
+  def length: Unit = {
+    assertEquals(0, empty.length)
+    assert(empty.isEmpty)
+    assert(!empty.nonEmpty)
+  }
+  @Test
+  def prepended: Unit = {
+    assertEquals(List(1), empty.prepended(1).toList)
+    assertEquals(List(1,2), empty.prepended(2).prepended(1).toList)
+  }
+  @Test
+  def take: Unit = {
+    assertEquals(empty.take(-1), empty)
+    assertEquals(empty.take(0), empty)
+    assertEquals(empty.take(1), empty)
+    assertEquals(empty.take(100), empty)
+  }
+  @Test
+  def takeRight: Unit = {
+    assertEquals(empty.takeRight(-1), empty)
+    assertEquals(empty.takeRight(0), empty)
+    assertEquals(empty.takeRight(1), empty)
+    assertEquals(empty.takeRight(100), empty)
+  }
+  @Test
+  def drop: Unit = {
+    assertEquals(empty.drop(-1), empty)
+    assertEquals(empty.drop(0), empty)
+    assertEquals(empty.drop(1), empty)
+    assertEquals(empty.drop(100), empty)
+  }
+  @Test
+  def dropRight: Unit = {
+    assertEquals(empty.dropRight(-1), empty)
+    assertEquals(empty.dropRight(0), empty)
+    assertEquals(empty.dropRight(1), empty)
+    assertEquals(empty.dropRight(100), empty)
+  }
+  @Test
+  def map: Unit = {
+    assertEquals(empty.map(_ => 1), empty)
+
+    var canary = 0
+    val mapped = empty.map { _ => canary += 1; 1 }
+    assertEquals(0, canary)
+    assertEquals(Nil, mapped.toList)
+    assertEquals(0, canary)
+  }
+  @Test
+  def reverse: Unit = {
+    assertEquals(empty.reverse, empty)
+  }
+  @Test
+  def slice: Unit = {
+    assertEquals(empty.slice(-1, -1), empty)
+    assertEquals(empty.slice(-1, 0), empty)
+    assertEquals(empty.slice(-1, 3), empty)
+    assertEquals(empty.slice(0, 3), empty)
+    assertEquals(empty.slice(3, 3), empty)
+  }
+  @Test
+  def appended: Unit = {
+    assertEquals(empty.appended(1).toList,List(1))
+    assertEquals(empty.appended(1).appended(2).toList,List(1, 2))
+  }
+}
+
+@RunWith(classOf[JUnit4])
+class SingleIndexedSeqViewTest {
+  val single = new IndexedSeqView.Single(1)
+  val empty = IndexedSeqView.Empty
+  @Test
+  def apply: Unit = {
+    assertThrows[IndexOutOfBoundsException](single(-1))
+    assertEquals(1, single(0))
+    assertThrows[IndexOutOfBoundsException](single(1))
+    assertThrows[IndexOutOfBoundsException](single(100))
+  }
+  @Test
+  def length: Unit = {
+    assertEquals(1, single.length)
+    assert(!single.isEmpty)
+    assert(single.nonEmpty)
+  }
+  @Test
+  def prepended: Unit = {
+    assertEquals(List(1,1), single.prepended(1).toList)
+    assertEquals(List(1,2,1), single.prepended(2).prepended(1).toList)
+  }
+  @Test
+  def take: Unit = {
+    assertEquals(single.take(-1), empty)
+    assertEquals(single.take(0), empty)
+    assertEquals(single.take(1), single)
+    assertEquals(single.take(100), single)
+  }
+  @Test
+  def takeRight: Unit = {
+    assertEquals(single.takeRight(-1), empty)
+    assertEquals(single.takeRight(0), empty)
+    assertEquals(single.takeRight(1), single)
+    assertEquals(single.takeRight(100), single)
+  }
+  @Test
+  def drop: Unit = {
+    assertEquals(single.drop(-1), single)
+    assertEquals(single.drop(0), single)
+    assertEquals(single.drop(1), empty)
+    assertEquals(single.drop(100), empty)
+  }
+  @Test
+  def dropRight: Unit = {
+    assertEquals(single.dropRight(-1), single)
+    assertEquals(single.dropRight(0), single)
+    assertEquals(single.dropRight(1), empty)
+    assertEquals(single.dropRight(100), empty)
+  }
+  @Test
+  def map: Unit = {
+    assertEquals(single.map(_ => 2).toList, List(2))
+
+    var canary = 0
+    val mapped = single.map { _ => canary += 1; 2 }
+    assertEquals(0, canary)
+    assertEquals(List(2), mapped.toList)
+    assertEquals(1, canary)
+  }
+  @Test
+  def reverse: Unit = {
+    assertEquals(single.reverse, single)
+  }
+  @Test
+  def slice: Unit = {
+    assertEquals(single.slice(-1, -1), empty)
+    assertEquals(single.slice(-1, 0), empty)
+    assertEquals(single.slice(-1, 3), single)
+    assertEquals(single.slice(0, 3), single)
+    assertEquals(single.slice(3, 3), empty)
+  }
+  @Test
+  def appended: Unit = {
+    assertEquals(single.appended(2).toList,List(1,2))
+    assertEquals(single.appended(2).appended(3).toList,List(1, 2, 3))
+  }
+}
+
+@RunWith(classOf[JUnit4])
+class PreviouslyEvaluatedIndexedSeqViewTest {
+  def make[A](elems: A*) = new IndexedSeqView.PreviouslyEvaluated(elems.toVector)
+
+  @Test
+  def apply: Unit = {
+    assertThrows[IndexOutOfBoundsException](make()(-1))
+    assertThrows[IndexOutOfBoundsException](make()(0))
+    assertThrows[IndexOutOfBoundsException](make()(1))
+
+    assertThrows[IndexOutOfBoundsException](make(1)(-1))
+    assertEquals(1, make(1)(0))
+    assertEquals(2, make(1, 2)(1))
+
+  }
+  @Test
+  def length: Unit = {
+    assertEquals(0, make().length)
+    assertEquals(4, make(1,1,1,1).length)
+  }
+  @Test
+  def prepended: Unit = {
+    assertEquals(List(1,1,2,3), make(1,2,3).prepended(1).toList)
+    assertEquals(List(1), make().prepended(1).toList)
+  }
+
+  @Test
+  def take: Unit = {
+    assert(make().take(-1).isEmpty)
+    assert(make().take(0).isEmpty)
+
+    assert(make(1).take(-1).isEmpty)
+    assert(make(1,2).take(0).isEmpty)
+
+    assertEquals(make(1).take(1).toList, List(1))
+    assertEquals(make(1,2).take(1).toList, List(1))
+    assertEquals(make(1,2).take(2).toList, List(1,2))
+  }
+  @Test
+  def takeRight: Unit = {
+    assertEquals(make().takeRight(1).toList, Nil)
+    assertEquals(make(1,2,3,4,5).takeRight(-1).toList, Nil)
+    assertEquals(make(1,2,3,4,5).takeRight(0).toList, Nil)
+    assertEquals(make(1,2,3,4,5).takeRight(1).toList, List(5))
+    assertEquals(make(1,2,3,4,5).takeRight(3).toList, List(3,4,5))
+  }
+  @Test
+  def drop: Unit = {
+    assertEquals(make().drop(1).toList, Nil)
+    assertEquals(make(1,2,3,4,5).drop(-1).toList, List(1,2,3,4,5))
+    assertEquals(make(1,2,3,4,5).drop(0).toList, List(1,2,3,4,5))
+    assertEquals(make(1,2,3,4,5).drop(1).toList, List(2,3,4,5))
+    assertEquals(make(1,2,3,4,5).drop(7).toList, Nil)
+
+  }
+  @Test
+  def dropRight: Unit = {
+    assertEquals(make().dropRight(1).toList, Nil)
+    assertEquals(make(1,2,3,4,5).dropRight(-1).toList, List(1,2,3,4,5))
+    assertEquals(make(1,2,3,4,5).dropRight(0).toList, List(1,2,3,4,5))
+    assertEquals(make(1,2,3,4,5).dropRight(1).toList, List(1,2,3,4))
+    assertEquals(make(1,2,3,4,5).dropRight(7).toList, Nil)
+  }
+  @Test
+  def map: Unit = {
+    assertEquals(make(1,2,3,4,5).map(_ => 2).toList, List(2,2,2,2,2))
+
+    var canary = 0
+    val mapped = make(1,2,3,4,5).map { _ => canary += 1; 2 }
+    assertEquals(0, canary)
+    assertEquals(List(2,2,2,2,2), mapped.toList)
+    assertEquals(5, canary)
+  }
+
+  @Test
+  def reverse: Unit = {
+    assertEquals(make().reverse.toSeq, Nil)
+    assertEquals(make(1).reverse.toSeq, List(1))
+    assertEquals(make(1,2,3).reverse.toSeq, List(3,2,1))
+  }
+  @Test
+  def slice: Unit = {
+    assertEquals(make(1).slice(-1, -1).toList, Nil)
+    assertEquals(make(1).slice(-1, 0).toList, Nil)
+    assertEquals(make(1).slice(-1, 3).toList, List(1))
+    assertEquals(make(1).slice(0, 3).toList, List(1))
+    assertEquals(make(1).slice(3, 3).toList, Nil)
+
+    assertEquals(make(1,2,3,4,5).slice(1, 3).toList, List(2,3))
+  }
+  @Test
+  def appended: Unit = {
+    assertEquals(make().appended(2).toList,List(2))
+    assertEquals(make(1).appended(2).toList,List(1,2))
+    assertEquals(make(1,2,3,2,1).appended(2).toList,List(1,2,3,2,1,2))
+  }
+}


### PR DESCRIPTION
## This description is out of date, see update posted below (kept this for context)

scala/bug#11066 scala/bug#11067 scala/bug#9069

This is a proposal to replace the existing implementations of `IndexedSeqView` with stack-safe and heap-safe alternatives. Under this proposal, the main class which performs most of the heavy lifting to implement `indexedSeqView` is a greatly expanded version of `IndexedSeqView.Slice`, which tries to perform as many optimizations as I've thought of, to avoid allocations and especially to avoid additional layers of wrapping. 

The implementing classes removed are:

* IndexedSeqView.Prepended
* IndexedSeqView.Take
* IndexedSeqView.TakeRight
* IndexedSeqView.Drop
* IndexedSeqView.DropRight
* IndexedSeqView.Map
* IndexedSeqView.Reverse

Their functionality as static factories for IndexedSeqViews have also been provided by methods on `IndexedSeqView`:

```scala

  def single[A](elem: A): IndexedSeqView[A] 
  def id[A](underlying: SomeIndexedSeqOps[A]): IndexedSeqView[A]
  def take[A](underlying: SomeIndexedSeqOps[A], n: Int): IndexedSeqView[A]
  def takeRight[A](underlying: SomeIndexedSeqOps[A], n: Int): IndexedSeqView[A]
  def drop[A](underlying: SomeIndexedSeqOps[A], n: Int): IndexedSeqView[A] 
  def dropRight[A](underlying: SomeIndexedSeqOps[A], n: Int): IndexedSeqView[A] 
  def reverse[A](underlying: SomeIndexedSeqOps[A]): IndexedSeqView[A] 
  def map[A, B](underlying: SomeIndexedSeqOps[A], f: A => B): IndexedSeqView[B] 
  def appended[A](underlying: SomeIndexedSeqOps[A], elem: A): IndexedSeqView[A] 
  def prepended[A](underlying: SomeIndexedSeqOps[A], elem: A): IndexedSeqView[A]
```

While 

* IndexedSeqView.Id

has been outfitted with some overrides, and the following classes are completely new

* IndexedSeqView.Empty
* IndexedSeqView.Single
* IndexedSeqView.PreviouslyEvaluated -- This sounds like it is an oxymoron, but what it represents is the result of multiple single-element appends/prepends on an already strictly loaded view, like `Single` or `Empty`, and continues to work as a View, not forcing other transformations like `map`, etc. This was actually a crucial step in getting stack safety from the appended/prepended methods of IndexedSeqView and in particular Slice.

## Regarding scala/bug#11066:

* This specializes the return type of `IndexedSeqView[A]#appended[B >: A](elem: B): View[B]` to `IndexedSeqView[A]#appended[B >: A](elem: B): IndexedSeqView[B]` but does nothing else


## Further work

* I think that similar optimizations could work on Views in general (not indexed), but have not tried to implement this yet.


@julienrf @szeiger 

 