### PR TITLE
add test case for t9371

### DIFF
--- a/test/files/pos/t9371.scala
+++ b/test/files/pos/t9371.scala
@@ -1,0 +1,21 @@
+import scala.annotation.tailrec
+
+object TestCase {
+
+  sealed trait Result[+A]
+
+  type Operation[A] = Int => Result[A]
+
+  case class Terminate[A](state: Int, value: A) extends Result[A]
+  case class Continue[A](state: Int, cont: Operation[A]) extends Result[A]
+
+  @tailrec
+  def runConversion[A](state: Int, op: Operation[A]): (Int, A) = {
+    op(state) match {
+      case Continue(s, c) =>
+        runConversion(s, c)
+      case Terminate(s, v) =>
+        (s, v)
+    }
+  }
+}


### PR DESCRIPTION
fix https://github.com/scala/bug/issues/9371

```
Welcome to Scala 2.13.0-M4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> import scala.annotation.tailrec
import scala.annotation.tailrec

scala> object TestCase {
     | 
     |   sealed trait Result[+A]
     | 
     |   type Operation[A] = Int => Result[A]
     | 
     |   case class Terminate[A](state: Int, value: A) extends Result[A]
     |   case class Continue[A](state: Int, cont: Operation[A]) extends Result[A]
     | 
     |   @tailrec
     |   def runConversion[A](state: Int, op: Operation[A]): (Int, A) = {
     |     op(state) match {
     |       case Continue(s, c) =>
     |         runConversion(s, c)
     |       case Terminate(s, v) =>
     |         (s, v)
     |     }
     |   }
     | }
defined object TestCase
```

```
Welcome to Scala 2.12.6 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> import scala.annotation.tailrec
import scala.annotation.tailrec

scala> object TestCase {
     | 
     |   sealed trait Result[+A]
     | 
     |   type Operation[A] = Int => Result[A]
     | 
     |   case class Terminate[A](state: Int, value: A) extends Result[A]
     |   case class Continue[A](state: Int, cont: Operation[A]) extends Result[A]
     | 
     |   @tailrec
     |   def runConversion[A](state: Int, op: Operation[A]): (Int, A) = {
     |     op(state) match {
     |       case Continue(s, c) =>
     |         runConversion(s, c)
     |       case Terminate(s, v) =>
     |         (s, v)
     |     }
     |   }
     | }
defined object TestCase
```

```
Welcome to Scala 2.11.12 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> import scala.annotation.tailrec
import scala.annotation.tailrec

scala> object TestCase {
     | 
     |   sealed trait Result[+A]
     | 
     |   type Operation[A] = Int => Result[A]
     | 
     |   case class Terminate[A](state: Int, value: A) extends Result[A]
     |   case class Continue[A](state: Int, cont: Operation[A]) extends Result[A]
     | 
     |   @tailrec
     |   def runConversion[A](state: Int, op: Operation[A]): (Int, A) = {
     |     op(state) match {
     |       case Continue(s, c) =>
     |         runConversion(s, c)
     |       case Terminate(s, v) =>
     |         (s, v)
     |     }
     |   }
     | }
<console>:23: error: could not optimize @tailrec annotated method runConversion: it contains a recursive call not in tail position
           op(state) match {
             ^
```