### PR TITLE
add test case for t9628

### DIFF
--- a/test/files/pos/t9628.scala
+++ b/test/files/pos/t9628.scala
@@ -1,0 +1,9 @@
+case class Foo(bar: String, foo: String)
+case class Bar(bar: String)
+
+object FooBar {
+  def crash(): Unit = {
+    val foo = Foo("foo", "bar").copy(foo = "foo")
+    val bar = Bar(foo.bar)
+  }
+}


### PR DESCRIPTION
close https://github.com/scala/bug/issues/9628

fixed since Scala 2.12

```
Welcome to Scala 2.11.12 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> case class Foo(bar: String, foo: String)
defined class Foo

scala> case class Bar(bar: String)
defined class Bar

scala>

scala> object FooBar {
     |   def crash(): Unit = {
     |     val foo = Foo("foo", "bar").copy(foo = "foo")
     |     val bar = Bar(foo.bar)
     |   }
     | }
ReplGlobal.abort: Unknown type: <error>, <error> [class scala.reflect.internal.Types$ErrorType$, class scala.reflect.internal.Types$ErrorType$] TypeRef? false
error:
  Unknown type: <error>, <error> [class scala.reflect.internal.Types$ErrorType$, class scala.reflect.internal.Types$ErrorType$] TypeRef? false
     while compiling: <console>
        during phase: icode
     library version: version 2.11.12
    compiler version: version 2.11.12
  reconstructed args:

  last tree to typer: TypeTree
       tree position: line 18 of <console>
            tree tpe: <notype>
              symbol: <none>
   symbol definition: <none> (a NoSymbol)
      symbol package: <none>
       symbol owners:
           call site: object iw$FooBar in package $line5 in package $line5

<Cannot read source file>
scala.reflect.internal.FatalError:
  Unknown type: <error>, <error> [class scala.reflect.internal.Types$ErrorType$, class scala.reflect.internal.Types$ErrorType$] TypeRef? false
     while compiling: <console>
        during phase: icode
     library version: version 2.11.12
    compiler version: version 2.11.12
  reconstructed args:

  last tree to typer: TypeTree
       tree position: line 18 of <console>
            tree tpe: <notype>
              symbol: <none>
   symbol definition: <none> (a NoSymbol)
      symbol package: <none>
       symbol owners:
           call site: object iw$FooBar in package $line5 in package $line5

<Cannot read source file>
	at scala.reflect.internal.Reporting$class.abort(Reporting.scala:59)
	at scala.tools.nsc.interpreter.IMain$$anon$1.scala$tools$nsc$interpreter$ReplGlobal$$super$abort(IMain.scala:254)
	at scala.tools.nsc.interpreter.ReplGlobal$class.abort(ReplGlobal.scala:20)
	at scala.tools.nsc.interpreter.IMain$$anon$1.abort(IMain.scala:254)
	at scala.tools.nsc.backend.icode.TypeKinds$class.toTypeKind(TypeKinds.scala:401)
	at scala.tools.nsc.backend.icode.ICodes.toTypeKind(ICodes.scala:19)
```

```
Welcome to Scala 2.12.6 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> case class Foo(bar: String, foo: String)
defined class Foo

scala> case class Bar(bar: String)
defined class Bar

scala>

scala> object FooBar {
     |   def crash(): Unit = {
     |     val foo = Foo("foo", "bar").copy(foo = "foo")
     |     val bar = Bar(foo.bar)
     |   }
     | }
defined object FooBar
```

```
Welcome to Scala 2.13.0-M4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> case class Foo(bar: String, foo: String)
defined class Foo

scala> case class Bar(bar: String)
defined class Bar

scala>

scala> object FooBar {
     |   def crash(): Unit = {
     |     val foo = Foo("foo", "bar").copy(foo = "foo")
     |     val bar = Bar(foo.bar)
     |   }
     | }
defined object FooBar
```