### PR TITLE
add test case for t10090

### DIFF
--- a/test/files/neg/t10090.check
+++ b/test/files/neg/t10090.check
@@ -1,0 +1,7 @@
+t10090.scala:4: error: stable identifier required, but X.Y found.
+  (null: Any) match { case X.Y.Z() => }
+                             ^
+t10090.scala:6: error: stable identifier required, but X.Y found.
+  (null: Any) match { case X.Y.Z => }
+                             ^
+two errors found

--- a/test/files/neg/t10090.scala
+++ b/test/files/neg/t10090.scala
@@ -1,0 +1,7 @@
+object X { implicit class Y(self: String) }
+
+object T10090 {
+  (null: Any) match { case X.Y.Z() => }
+
+  (null: Any) match { case X.Y.Z => }
+}


### PR DESCRIPTION
fixed since Scala 2.12.5

close https://github.com/scala/bug/issues/10090

```
Welcome to Scala 2.12.3 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> object X { implicit class Y(self: String) }
defined object X

scala> (null: Any) match { case X.Y.Z() => }
java.lang.NullPointerException
	at scala.tools.nsc.transform.patmat.ScalacPatternExpanders$ScalacPatternExpander.applyMethodTypes(ScalacPatternExpanders.scala:65)
	at scala.tools.nsc.transform.patmat.ScalacPatternExpanders$ScalacPatternExpander.applyMethodTypes$(ScalacPatternExpanders.scala:64)
	at scala.tools.nsc.transform.patmat.ScalacPatternExpanders$alignPatterns$.applyMethodTypes(ScalacPatternExpanders.scala:97)
	at scala.tools.nsc.transform.patmat.ScalacPatternExpanders$alignPatterns$.apply(ScalacPatternExpanders.scala:136)
```

```
Welcome to Scala 2.12.4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> object X { implicit class Y(self: String) }
defined object X

scala> (null: Any) match { case X.Y.Z() => }
scala.MatchError: null
  ... 28 elided
```

```
Welcome to Scala 2.12.5 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> object X { implicit class Y(self: String) }
defined object X

scala> (null: Any) match { case X.Y.Z() => }
<console>:13: error: stable identifier required, but X.Y found.
       (null: Any) match { case X.Y.Z() => }
                                  ^
```

```
Welcome to Scala 2.13.0-M4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> object X { implicit class Y(self: String) }
defined object X

scala> (null: Any) match { case X.Y.Z() => }
                                  ^
       error: stable identifier required, but X.Y found.
```