### PR TITLE
Make TypeMap work when based on plain maps, delaying symbol cloning

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1562,7 +1562,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       */
     def substInfo(syms0: List[Symbol], syms1: List[Symbol]): this.type =
       if (syms0.isEmpty) this
-      else modifyInfo(_.substSym(syms0, syms1))
+      else modifyInfo(_.substSym(syms0, syms1, Some(this)))
 
     def setInfoOwnerAdjusted(info: Type): this.type = setInfo(info atOwner this)
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -742,9 +742,9 @@ trait Types
      * first, as otherwise symbols will immediately get rebound in typeRef to the old
      * symbol.
      */
-    def substSym(from: List[Symbol], to: List[Symbol]): Type =
+    def substSym(from: List[Symbol], to: List[Symbol], but: Option[Symbol] = None): Type =
       if ((from eq to) || from.isEmpty) this
-      else new SubstSymMap(from, to) apply this
+      else new SubstSymMap(from, to, but) apply this
 
     /** Substitute all occurrences of `ThisType(from)` in this type by `to`.
      *

--- a/test/files/pos/t10911.scala
+++ b/test/files/pos/t10911.scala
@@ -1,0 +1,15 @@
+object OfFor {top =>
+	trait Something
+	trait Tag[X]
+	trait Template[T] {
+		type Repr
+		trait Tag extends top.Tag[Repr]
+	}
+	type OfFor[T, _Repr] = Template[T] {
+		type Repr = _Repr
+	}
+
+	implicit def something[T : Tag]: Something = ???
+	implicit def hkTag[T, Repr[X]]: OfFor[T, Repr[T]]#Tag = ???
+	implicitly[Something]
+}

--- a/test/files/run/t2318.scala
+++ b/test/files/run/t2318.scala
@@ -5,6 +5,7 @@ import scala.language.{ reflectiveCalls }
 object Test {
   trait Bar { def bar: Unit }
 
+  val forcePreloadBoxedUnit = scala.runtime.BoxedUnit.UNIT //Avoid parasiting ClassCircularityError, at least in Windows
   object Mgr extends SecurityManager {
     override def checkPermission(perm: Permission) = perm match {
       case _: java.lang.RuntimePermission                                                   => ()


### PR DESCRIPTION
Fixes scala/bug#10911

Adressed also a regression with looping symbols being created once TypeMap was improved this way (pos/t1210a was failing, among a few others)