### PR TITLE
add test case for t9818

### DIFF
--- a/test/files/pos/t9818.scala
+++ b/test/files/pos/t9818.scala
@@ -1,0 +1,17 @@
+trait A {
+  def g(x: Int = 0, y: Int = 1) = x + y
+
+  def x: Int = ???
+
+  def ref: A
+}
+
+trait B {
+  def f(a: Int, b: Int = 0) = a + b
+
+  def foo(in: A): Unit = {
+    import in._
+
+    ref.g(x = f(0))
+  }
+}


### PR DESCRIPTION
fixed since Scala 2.13.0-M3. close https://github.com/scala/bug/issues/9818

```
Welcome to Scala 2.13.0-M2 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> trait A {
     |   def g(x: Int = 0, y: Int = 1) = x + y
     |
     |   def x: Int = ???
     |
     |   def ref: A
     | }
defined trait A

scala> trait B {
     |   def f(a: Int, b: Int = 0) = a + b
     |
     |   def foo(in: A): Unit = {
     |     import in._
     |
     |     ref.g(x = f(0))
     |   }
     | }
java.lang.NullPointerException
	at scala.tools.nsc.typechecker.Typers$Typer.noExpectedType$1(Typers.scala:3585)
	at scala.tools.nsc.typechecker.Typers$Typer.handleMonomorphicCall$1(Typers.scala:3588)
	at scala.tools.nsc.typechecker.Typers$Typer.$anonfun$doTypedApply$33(Typers.scala:3617)
	at scala.tools.nsc.typechecker.Typers$Typer.doTypedApply(Typers.scala:3617)
	at scala.tools.nsc.typechecker.Typers$Typer.tryNamesDefaults$1(Typers.scala:3502)
	at scala.tools.nsc.typechecker.Typers$Typer.doTypedApply(Typers.scala:3574)
	at scala.tools.nsc.typechecker.Typers$Typer.tryNamesDefaults$1(Typers.scala:3560)
	at scala.tools.nsc.typechecker.Typers$Typer.doTypedApply(Typers.scala:3574)
	at scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typed1$25(Typers.scala:4642)
```

```
Welcome to Scala 2.13.0-M3 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> trait A {
     |   def g(x: Int = 0, y: Int = 1) = x + y
     |
     |   def x: Int = ???
     |
     |   def ref: A
     | }
defined trait A

scala> trait B {
     |   def f(a: Int, b: Int = 0) = a + b
     |
     |   def foo(in: A): Unit = {
     |     import in._
     |
     |     ref.g(x = f(0))
     |   }
     | }
defined trait B
```