### PR TITLE
add test case for t10533

### DIFF
--- a/test/files/pos/t10533.scala
+++ b/test/files/pos/t10533.scala
@@ -1,0 +1,5 @@
+object Foo {
+  val b @ Bar(_) = Bar(1)(2)(3)
+}
+
+case class Bar(a: Int)(b: Int)(c: Int)


### PR DESCRIPTION
fixed since Scala 2.12.5. close https://github.com/scala/bug/issues/10533

```
Welcome to Scala 2.12.4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> case class Bar(a: Int)(b: Int)(c: Int)
defined class Bar

scala> val b @ Bar(_) = Bar(1)(2)(3)
scala.ScalaReflectionException: value b is not a method
	at scala.reflect.api.Symbols$SymbolApi.asMethod(Symbols.scala:228)
	at scala.reflect.api.Symbols$SymbolApi.asMethod$(Symbols.scala:222)
	at scala.reflect.internal.Symbols$SymbolContextApiImpl.asMethod(Symbols.scala:94)
	at scala.tools.nsc.typechecker.ContextErrors$TyperContextErrors$TyperErrorGen$.MissingArgsForMethodTpeError(ContextErrors.scala:669)
	at scala.tools.nsc.typechecker.Typers$Typer.cantAdapt$1(Typers.scala:895)
	at scala.tools.nsc.typechecker.Typers$Typer.instantiateToMethodType$1(Typers.scala:939)
	at scala.tools.nsc.typechecker.Typers$Typer.adapt(Typers.scala:1212)
	at scala.tools.nsc.typechecker.Typers$Typer.runTyper$1(Typers.scala:5598)
```

```
Welcome to Scala 2.12.5 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> case class Bar(a: Int)(b: Int)(c: Int)
defined class Bar

scala> val b @ Bar(_) = Bar(1)(2)(3)
b: Bar = Bar(1)
```