### PR TITLE
add test case for t10590

### DIFF
--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -106,4 +106,10 @@ class ArrayOpsTest {
     val target = Array[Int]()
     assertEquals(0, Array(1,2).copyToArray(target, 1, 0))
   }
+
+  @Test
+  def t10590_ArrayNothingHeadOption: Unit = {
+    val a: Array[Nothing] = Array.empty
+    assertEquals(None, a.headOption)
+  }
 }


### PR DESCRIPTION
close https://github.com/scala/bug/issues/10590


```
Welcome to Scala 2.13.0-M3 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> (Array.empty: Array[Nothing]).headOption
                                     ^
       error: value headOption is not a member of Array[Nothing]
```

```
Welcome to Scala 2.13.0-M4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> (Array.empty: Array[Nothing]).headOption
                   ^
       warning: method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated (since 2.13.0): Implicit conversions from Array to immutable.IndexedSeq are implemented by copying; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call
res0: Option[Nothing] = None
```