### PR TITLE
Override some collections methods in Range to use optimised implementations

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -108,8 +108,10 @@ sealed abstract class Range(
   /** The last element of this range.  This method will return the correct value
     *  even if there are too many elements to iterate over.
     */
-  final override def last: Int = if (isEmpty) Nil.head else lastElement
-  final override def head: Int = if (isEmpty) Nil.head else start
+  final override def last: Int =
+    if (isEmpty) throw Range.emptyRangeError("last") else lastElement
+  final override def head: Int =
+    if (isEmpty) throw Range.emptyRangeError("head") else start
 
   /** Creates a new range containing all the elements of this range except the last one.
     *
@@ -117,12 +119,8 @@ sealed abstract class Range(
     *
     *  @return  a new range consisting of all the elements of this range except the last one.
     */
-  final override def init: Range = {
-    if (isEmpty)
-      Nil.init
-
-    dropRight(1)
-  }
+  final override def init: Range =
+    if (isEmpty) throw Range.emptyRangeError("init") else dropRight(1)
 
   /** Creates a new range containing all the elements of this range except the first one.
     *
@@ -131,8 +129,7 @@ sealed abstract class Range(
     *  @return  a new range consisting of all the elements of this range except the first one.
     */
   final override def tail: Range = {
-    if (isEmpty)
-      Nil.tail
+    if (isEmpty) throw Range.emptyRangeError("tail")
     if (numRangeElements == 1) newEmptyRange(end)
     else if(isInclusive) new Range.Inclusive(start + step, end, step)
     else new Range.Exclusive(start + step, end, step)
@@ -581,6 +578,8 @@ object Range {
     def inclusive(start: Int, end: Int, step: Int) = NumericRange.inclusive(start, end, step)
   }
 
+  private def emptyRangeError(what: String): Throwable =
+    new NoSuchElementException(what + " on empty Range")
 }
 
 /**

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -14,8 +14,6 @@ package scala
 package collection.immutable
 
 import collection.{AbstractIterator, Iterator}
-import java.lang.String
-
 import scala.util.hashing.MurmurHash3
 
 /** The `Range` class represents integer values in range
@@ -169,7 +167,7 @@ sealed abstract class Range(
     else start + (step * idx)
   }
 
-  /*@`inline`*/ final override def foreach[@specialized(Specializable.Unit) U](f: Int => U): Unit = {
+  /*@`inline`*/ final override def foreach[@specialized(Unit) U](f: Int => U): Unit = {
     // Implementation chosen on the basis of favorable microbenchmarks
     // Note--initialization catches step == 0 so we don't need to here
     if (!isEmpty) {
@@ -180,6 +178,38 @@ sealed abstract class Range(
         i += step
       }
     }
+  }
+
+  override final def indexOf[@specialized(Int) B >: Int](elem: B, from: Int = 0): Int =
+    elem match {
+      case i: Int =>
+        val pos = posOf(i)
+        if (pos >= from) pos else -1
+      case _ => super.indexOf(elem, from)
+    }
+
+  override final def lastIndexOf[@specialized(Int) B >: Int](elem: B, end: Int = length - 1): Int =
+    elem match {
+      case i: Int =>
+        val pos = posOf(i)
+        if (pos <= end) pos else -1
+      case _ => super.lastIndexOf(elem, end)
+    }
+
+  private[this] def posOf(i: Int): Int =
+    if (contains(i)) (i - start) / step else -1
+
+  override def sameElements[B >: Int](that: IterableOnce[B]): Boolean = that match {
+    case other: Range =>
+      (this.length : @annotation.switch) match {
+        case 0 => other.isEmpty
+        case 1 => other.length == 1 && this.start == other.start
+        case n => other.length == n && (
+          (this.start == other.start)
+            && (this.step == other.step)
+        )
+      }
+    case _ => super.sameElements(that)
   }
 
   /** Creates a new range containing the first `n` elements of this range.
@@ -335,6 +365,11 @@ sealed abstract class Range(
       if (x < end || x > start) false
       else (step == -1) || (((x - start) % step) == 0)
     }
+  }
+  /* Seq#contains has a type parameter so the optimised contains above doesn't override it */
+  override final def contains[B >: Int](elem: B): Boolean = elem match {
+    case i: Int => this.contains(i)
+    case _      => super.contains(elem)
   }
 
   final override def sum[B >: Int](implicit num: Numeric[B]): Int = {

--- a/src/library/scala/collection/immutable/WrappedString.scala
+++ b/src/library/scala/collection/immutable/WrappedString.scala
@@ -14,6 +14,7 @@ package scala.collection
 package immutable
 
 import mutable.{Builder, StringBuilder}
+import scala.Predef.{ wrapString => _ }  // unimport to avoid triggering accidentally
 
 /**
   *  This class serves as a wrapper augmenting `String`s with all the operations
@@ -75,18 +76,6 @@ final class WrappedString(private val self: String) extends AbstractSeq[Char] wi
       case _       => super.lastIndexOf(elem, end)
     }
 
-  override def indexOfSlice[B >: Char](that: collection.Seq[B], from: Int = 0): Int =
-    that match {
-      case s: WrappedString => self.indexOfSlice(s.self, from)
-      case _                => super.indexOfSlice(that, from)
-    }
-
-  override def lastIndexOfSlice[B >: Char](that: collection.Seq[B], end: Int = length - 1): Int =
-    that match {
-      case s: WrappedString => self.lastIndexOfSlice(s, end)
-      case _                => super.lastIndexOfSlice(that, end)
-    }
-
   override def copyToArray[B >: Char](xs: Array[B], start: Int): Int =
     copyToArray(xs, start, length)
 
@@ -104,6 +93,11 @@ final class WrappedString(private val self: String) extends AbstractSeq[Char] wi
       case s: WrappedString => new WrappedString(self concat s.self)
       case _                => super.appendedAll(suffix)
     }
+
+  override def sameElements[B >: Char](o: IterableOnce[B]) = o match {
+    case s: WrappedString => self == s.self
+    case _                => super.sameElements(o)
+  }
 
   override protected[this] def className = "WrappedString"
 

--- a/test/junit/scala/collection/immutable/RangeTest.scala
+++ b/test/junit/scala/collection/immutable/RangeTest.scala
@@ -103,5 +103,10 @@ class RangeTest {
     assertEquals(4, (1 to 4).iterator.drop(-4).toList.size)
   }
 
+  @Test
+  def `startsWith should not throw an exception when out of range`(): Unit = {
+    assertTrue((1 to 5).startsWith(Nil, 7))
+    assertFalse((1 to 5).startsWith(1 to 1, 8))
+  }
 
 }

--- a/test/scalacheck/scala/collection/immutable/RangeProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/RangeProperties.scala
@@ -1,0 +1,76 @@
+package scala
+package collection.immutable
+
+import org.scalacheck._
+
+class RangeProperties extends Properties("immutable.Range") {
+  import Prop._
+  import RangeProperties._
+
+  property("indexOf") = forAll { (r: Range, i: Int) =>
+    r.indexOf(i) == r.toVector.indexOf(i)
+  }
+
+  property("indexOf with start") = forAll { (r: Range, start: Int, i: Int) =>
+    r.indexOf(i, start) == r.toVector.indexOf(i, start)
+  }
+
+  property("lastIndexOf") = forAll { (r: Range, i: Int) =>
+    r.lastIndexOf(i) == r.toVector.lastIndexOf(i)
+  }
+
+  property("lastIndexOf with end") = forAll { (r: Range, end: Int, i: Int) =>
+    r.lastIndexOf(i, end) == r.toVector.lastIndexOf(i, end)
+  }
+
+  property("sorted") = forAll { (r: Range) =>
+    r.sorted.toVector == r.toVector.sorted
+  }
+
+  property("sorted backwards") = forAll { (r: Range) =>
+    r.sorted(Ordering.Int.reverse).toVector == r.toVector.sorted(Ordering.Int.reverse)
+  }
+
+  property("sameElements") = forAll { (r: Range, s: Range) =>
+    r.sameElements(s) == r.toVector.sameElements(s.toVector)
+  }
+
+  property("sameElements reflexive") = forAll { (r: Range) =>
+    r sameElements r
+  }
+
+  property("sameElements neg init") = forAll { (r: Range) =>
+    !r.isEmpty ==> !r.sameElements(r.init)
+  }
+
+  property("sameElements neg tail") = forAll { (r: Range) =>
+    !r.isEmpty ==> !r.sameElements(r.tail)
+  }
+
+  property("sameElements neg empty/non-empty") = forAll { (r1: Range, r2: Range) =>
+    (r1.isEmpty != r2.isEmpty) ==> !r1.sameElements(r2)
+  }
+
+  property("sameElements with different clusivity") = forAll { (r: Range) =>
+    !r.isEmpty ==> {
+      val oneFurther = if (r.step > 0) 1 else -1
+      if (r.isInclusive) r.sameElements(r.start until (r.end + oneFurther) by r.step)
+      else r.sameElements(r.start to (r.end - oneFurther) by r.step)
+    }
+  }
+
+}
+
+object RangeProperties {
+  final val MinInt = -128
+  final val MaxInt = 127
+
+  implicit val arbitraryRange: Arbitrary[Range] = Arbitrary(for {
+    start <- Gen.choose(MinInt, MaxInt)
+    step  <- Gen.choose(MinInt, MaxInt) filter (_ != 0)
+    end   <- Gen.choose(MinInt, MaxInt)
+    incl  <- Gen.oneOf(true, false)
+    r      = (if (incl) start to end else start until end) by step
+  } yield r)
+
+}

--- a/test/scalacheck/scala/collection/immutable/WrappedStringProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/WrappedStringProperties.scala
@@ -1,0 +1,72 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.immutable
+
+import org.scalacheck._
+
+class WrappedStringProperties extends Properties("immutable.WrappedString") {
+  import Prop._
+  import WrappedStringProperties._
+
+  property("indexOf") = forAll { (s: WrappedString, c: Char) =>
+    s.indexOf(c) == s.toString.indexOf(c)
+  }
+
+  property("indexOf with start") = forAll { (s: WrappedString, start: Int, c: Char) =>
+    start < s.size ==> (s.indexOf(c, start) == s.toString.indexOf(c, start))
+  }
+
+  property("indexOf") = forAll { (s: WrappedString, c: Char) =>
+    s.lastIndexOf(c) == s.toString.lastIndexOf(c)
+  }
+
+  property("indexOf with end") = forAll { (s: WrappedString, end: Int, c: Char) =>
+    end < s.size ==> (s.lastIndexOf(c, end) == s.toString.lastIndexOf(c, end))
+  }
+
+  property("sameElements") = forAll { (s: WrappedString, o: WrappedString) =>
+    s.sameElements(o) == (s.toString == o.toString)
+  }
+
+  property("sameElements reflexive") = forAll { (s: WrappedString) =>
+    s sameElements s
+  }
+
+  property("sameElements neg init") = forAll { (s: WrappedString) =>
+    !s.isEmpty ==> !s.sameElements(s.init)
+  }
+
+  property("sameElements neg tail") = forAll { (s: WrappedString) =>
+    !s.isEmpty ==> !s.sameElements(s.tail)
+  }
+
+  property("sameElements neg sizes") = forAll { (s: WrappedString, o: WrappedString) =>
+    (s.size != o.size) ==> !s.sameElements(o)
+  }
+
+}
+
+object WrappedStringProperties {
+
+  implicit val arbitraryWrappedString: Arbitrary[WrappedString] = Arbitrary {
+    for {
+      isAlpha <- Gen.oneOf(false, true)
+      charGen  = if (isAlpha) Gen.alphaChar else Arbitrary.arbChar.arbitrary
+      size    <- Gen.chooseNum(0, 4)
+      chars   <- Gen.listOfN(size, charGen)
+    } yield wrapString(new String(chars.toArray))
+  }
+
+  implicit val arbitraryChar: Arbitrary[Char] = Arbitrary(Gen.alphaNumChar)
+
+}


### PR DESCRIPTION
- `indexOf` and `lastIndexOf` are calculable in constant time
- `sorted` on a `Range`, if it uses the default `Int` ordering, is a no-op
- `sameElements` can be calculated by comparing `start`/`step`/`last`, if the
  other collection is also a `Range` 

cc @mkeskells 