### PR TITLE
Add some missing View features

### DIFF
--- a/src/library/scala/collection/SeqView.scala
+++ b/src/library/scala/collection/SeqView.scala
@@ -7,11 +7,14 @@ trait SeqView[+A] extends SeqOps[A, View, View[A]] with View[A] {
   override def view: SeqView[A] = this
 
   override def map[B](f: A => B): SeqView[B] = new SeqView.Map(this, f)
-
+  override def appended[B >: A](elem: B): SeqView[B] = new SeqView.Appended(this, elem)
   override def prepended[B >: A](elem: B): SeqView[B] = new SeqView.Prepended(elem, this)
-
+  override def reverse: SeqView[A] = new SeqView.Reverse(this)
   override def take(n: Int): SeqView[A] = new SeqView.Take(this, n)
 
+  def concat[B >: A](suffix: SeqView.SomeSeqOps[B]): SeqView[B] = new SeqView.Concat(this, suffix)
+  def appendedAll[B >: A](suffix: SeqView.SomeSeqOps[B]): SeqView[B] = new SeqView.Concat(this, suffix)
+  def prependedAll[B >: A](prefix: SeqView.SomeSeqOps[B]): SeqView[B] = new SeqView.Concat(prefix, this)
 }
 
 object SeqView {
@@ -20,6 +23,7 @@ object SeqView {
   type SomeSeqOps[+A] = SeqOps[A, AnyConstr, _]
 
   /** A view that doesn’t apply any transformation to an underlying sequence */
+  @SerialVersionUID(3L)
   class Id[+A](underlying: SeqOps[A, AnyConstr, _]) extends AbstractSeqView[A] {
     def apply(idx: Int): A = underlying.apply(idx)
     def length: Int = underlying.length
@@ -27,16 +31,41 @@ object SeqView {
     override def knownSize: Int = underlying.knownSize
   }
 
+  @SerialVersionUID(3L)
   class Map[+A, +B](underlying: SomeSeqOps[A], f: A => B) extends View.Map[A, B](underlying, f) with SeqView[B] {
     def apply(idx: Int): B = f(underlying(idx))
     def length: Int = underlying.length
   }
 
+  @SerialVersionUID(3L)
+  class Appended[+A](underlying: SomeSeqOps[A], elem: A) extends View.Appended(underlying, elem) with SeqView[A] {
+    def apply(idx: Int): A = if (idx == underlying.length) elem else underlying(idx)
+    def length: Int = underlying.length + 1
+  }
+
+  @SerialVersionUID(3L)
   class Prepended[+A](elem: A, underlying: SomeSeqOps[A]) extends View.Prepended(elem, underlying) with SeqView[A] {
     def apply(idx: Int): A = if (idx == 0) elem else underlying(idx - 1)
     def length: Int = underlying.length + 1
   }
 
+  @SerialVersionUID(3L)
+  class Concat[A](prefix: SomeSeqOps[A], suffix: SomeSeqOps[A]) extends View.Concat[A](prefix, suffix) with SeqView[A] {
+    def apply(idx: Int): A = {
+      val l = prefix.length
+      if (idx < l) prefix(idx) else suffix(idx - l)
+    }
+    def length: Int = prefix.length + suffix.length
+  }
+
+  @SerialVersionUID(3L)
+  class Reverse[A](underlying: SomeSeqOps[A]) extends AbstractSeqView[A] {
+    def apply(i: Int) = underlying.apply(size - 1 - i)
+    def length = underlying.size
+    override def iterator: Iterator[A] = underlying.reverseIterator
+  }
+
+  @SerialVersionUID(3L)
   class Take[+A](underlying: SomeSeqOps[A], n: Int) extends View.Take(underlying, n) with SeqView[A] {
     def apply(idx: Int): A = if (idx < n) underlying(idx) else throw new IndexOutOfBoundsException(idx.toString)
     def length: Int = underlying.length min normN

--- a/src/library/scala/collection/View.scala
+++ b/src/library/scala/collection/View.scala
@@ -365,7 +365,7 @@ object View extends IterableFactory[View] {
 
   /** A view that appends an element to its elements */
   @SerialVersionUID(3L)
-  class Appended[A](underlying: SomeIterableOps[A], elem: A) extends AbstractView[A] {
+  class Appended[+A](underlying: SomeIterableOps[A], elem: A) extends AbstractView[A] {
     def iterator: Iterator[A] = new Concat(underlying, new View.Single(elem)).iterator
     override def knownSize: Int = {
       val size = underlying.knownSize

--- a/test/junit/scala/collection/ViewTest.scala
+++ b/test/junit/scala/collection/ViewTest.scala
@@ -24,10 +24,28 @@ class ViewTest {
 
   @Test
   def seqView(): Unit = {
-    val xs = List(1, 2, 3).view
-    assertEquals(List(3, 2, 1), xs.reverse.to(List))
-    assertEquals(2, xs(1))
-//    assertEquals(xs, xs.reverse.reverse.to(List)) doesn’t compile
+    val xs = List(1, 2, 3)
+    assertEquals(xs.reverse, xs.view.reverse.toSeq)
+    assertEquals(2, xs.view(1))
+    val v1 = xs.view.reverse.reverse
+    val v1t: SeqView[Int] = v1
+    assertEquals(xs, v1t.toSeq)
+    val v2 = xs.view.concat(xs)
+    val v2t: SeqView[Int] = v2
+    assertEquals(xs.concat(xs), v2t.toSeq)
+  }
+
+  @Test
+  def indexedSeqView(): Unit = {
+    val xs = Vector(1, 2, 3)
+    assertEquals(xs.reverse, xs.view.reverse.toSeq)
+    assertEquals(2, xs.view(1))
+    val v1 = xs.view.reverse.reverse
+    val v1t: IndexedSeqView[Int] = v1
+    assertEquals(xs, v1t.toSeq)
+    val v2 = xs.view.concat(xs)
+    val v2t: IndexedSeqView[Int] = v2
+    assertEquals(xs.concat(xs), v2t.toSeq)
   }
 
   @Test


### PR DESCRIPTION
- Add `SeqView.Reverse`
- Base the existing `IndexedSeqView.Reverse` on it
- Override `SeqView#reverse` and `IndexedSeqView#reverse`

- Add `SeqView.Appended`, `IndexedSeqView.Appended` and matching
  overrides in `SeqView` and `IndexedSeqView` similar to the already
  existing `Prepended` implementation

- Add `SeqView.Concat` and `IndexedSeqView.Concat`
- Override `concat`, `appendedAll` and `prependedAll` in `SeqView` and
  `IndexedSeqView` using the new `Concat` implementations

- Add missing `@SerialVersionUID` annotations in `SeqView`

Fixes https://github.com/scala/bug/issues/11066