### PR TITLE
`x @ _*` bound variables are now `scala.Seq`; name-based pattern matching changes to enable this

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchCodeGen.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchCodeGen.scala
@@ -73,18 +73,7 @@ trait MatchCodeGen extends Interface {
       def fun(arg: Symbol, body: Tree): Tree     = Function(List(ValDef(arg)), body)
       def tupleSel(binder: Symbol)(i: Int): Tree = (REF(binder) DOT nme.productAccessorName(i)) // make tree that accesses the i'th component of the tuple referenced by binder
       def index(tgt: Tree)(i: Int): Tree         = tgt APPLY (LIT(i))
-
-      // Right now this blindly calls drop on the result of the unapplySeq
-      // unless it verifiably has no drop method (this is the case in particular
-      // with Array.) You should not actually have to write a method called drop
-      // for name-based matching, but this was an expedient route for the basics.
-      def drop(tgt: Tree)(n: Int): Tree = {
-        def callDirect   = fn(tgt, nme.drop, LIT(n))
-        def callRuntime  = Apply(REF(currentRun.runDefinitions.traversableDropMethod), tgt :: LIT(n) :: Nil)
-        def needsRuntime = (tgt.tpe ne null) && (elementTypeFromDrop(tgt.tpe) == NoType)
-
-        if (needsRuntime) callRuntime else callDirect
-      }
+      def drop(tgt: Tree)(n: Int): Tree          = fn(tgt, nme.drop, LIT(n))
 
       // NOTE: checker must be the target of the ==, that's the patmat semantics for ya
       def _equals(checker: Tree, binder: Symbol): Tree = checker MEMBER_== REF(binder)

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -520,8 +520,16 @@ object Array {
    *  @param x the selector value
    *  @return  sequence wrapped in a [[scala.Some]], if `x` is an Array, otherwise `None`
    */
-  def unapplySeq[T](x: Array[T]): Option[IndexedSeq[T]] =
-    Some(ArraySeq.unsafeWrapArray[T](x))
+  def unapplySeq[T](x: Array[T]): UnapplySeqWrapper[T] = new UnapplySeqWrapper(x)
+
+  final class UnapplySeqWrapper[T](private val a: Array[T]) extends AnyVal {
+    def isEmpty: Boolean = false
+    def get: UnapplySeqWrapper[T] = this
+    def lengthCompare(len: Int): Int = a.lengthCompare(len)
+    def apply(i: Int): T = a(i)
+    def drop(n: Int): scala.Seq[T] = ArraySeq.unsafeWrapArray(a.drop(n)) // clones the array, also if n == 0
+    def toSeq: scala.Seq[T] = a.toSeq // clones the array
+  }
 }
 
 /** Arrays are mutable, indexed collections of values. `Array[T]` is Scala's representation

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -928,9 +928,7 @@ trait Definitions extends api.StandardDefinitions {
     // For name-based pattern matching, derive the "element type" (type argument of Option/Seq)
     // from the relevant part of the signature of various members (get/head/apply/drop)
     def elementTypeFromGet(tp: Type)   = typeArgOfBaseTypeOr(tp, OptionClass)(resultOfMatchingMethod(tp, nme.get)())
-    def elementTypeFromHead(tp: Type)  = typeArgOfBaseTypeOr(tp, SeqClass)(resultOfMatchingMethod(tp, nme.head)())
     def elementTypeFromApply(tp: Type) = typeArgOfBaseTypeOr(tp, SeqClass)(resultOfMatchingMethod(tp, nme.apply)(IntTpe))
-    def elementTypeFromDrop(tp: Type)  = typeArgOfBaseTypeOr(tp, SeqClass)(resultOfMatchingMethod(tp, nme.drop)(IntTpe))
     def resultOfIsEmpty(tp: Type)      = resultOfMatchingMethod(tp, nme.isEmpty)()
 
     // scala/bug#8128 Still using the type argument of the base type at Seq/Option if this is an old-style (2.10 compatible)
@@ -1544,7 +1542,6 @@ trait Definitions extends api.StandardDefinitions {
       lazy val arrayCloneMethod       = getMemberMethod(ScalaRunTimeModule, nme.array_clone)
       lazy val ensureAccessibleMethod = getMemberMethod(ScalaRunTimeModule, nme.ensureAccessible)
       lazy val arrayClassMethod       = getMemberMethod(ScalaRunTimeModule, nme.arrayClass)
-      lazy val traversableDropMethod  = getMemberMethod(ScalaRunTimeModule, nme.drop)
       lazy val wrapVarargsRefArrayMethod = getMemberMethod(getWrapVarargsArrayModule, nme.wrapRefArray)
 
       lazy val GroupOfSpecializable = getMemberClass(SpecializableModule, tpnme.Group)

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -805,6 +805,7 @@ trait StdNames {
     val toArray: NameType              = "toArray"
     val toList: NameType               = "toList"
     val toObjectArray : NameType       = "toObjectArray"
+    val toSeq: NameType                = "toSeq"
     val toStats: NameType              = "toStats"
     val TopScope: NameType             = "TopScope"
     val toString_ : NameType           = "toString"

--- a/test/files/neg/patmat-seq-neg.check
+++ b/test/files/neg/patmat-seq-neg.check
@@ -1,0 +1,15 @@
+patmat-seq-neg.scala:15: error: error during expansion of this match (this is a scalac bug).
+The underlying error was: type mismatch;
+ found   : scala.collection.mutable.ArrayBuffer[Int]
+ required: Seq[Int]
+  def t3: Any = 2 match {
+                  ^
+patmat-seq-neg.scala:18: error: error during expansion of this match (this is a scalac bug).
+The underlying error was: value toSeq is not a member of Array[Int]
+  def t4: Any = 2 match {
+                  ^
+patmat-seq-neg.scala:24: error: error during expansion of this match (this is a scalac bug).
+The underlying error was: value drop is not a member of Array[Int]
+  def t6: Any = 2 match {
+                  ^
+three errors found

--- a/test/files/neg/patmat-seq-neg.scala
+++ b/test/files/neg/patmat-seq-neg.scala
@@ -1,0 +1,27 @@
+object A {
+  def unapplySeq(a: Int) = Some(collection.mutable.ArrayBuffer(1,2,3))
+}
+object B {
+  def unapplySeq(a: Int) = Some(Array(1,2,3))
+}
+
+class T {
+  def t1: Any = 2 match {
+    case A(xs@_*) => xs // ok
+  }
+  def t2: Any = 2 match {
+    case A(x, y) => (x, y) // ok
+  }
+  def t3: Any = 2 match {
+    case A(x, xs@_*) => (x, xs) // type error with call to drop. found: ArrayBuffer, required: Seq.
+  }
+  def t4: Any = 2 match {
+    case B(xs@_*) => xs // error: toSeq is not a member of Array. no ArrayOps because adaptToMember is disabled after typer.
+  }
+  def t5: Any = 2 match {
+    case B(x, y) => (x, y) // ok
+  }
+  def t6: Any = 2 match {
+    case B(x, xs@_*) => (x, xs) // error: drop is not a member of Array
+  }
+}

--- a/test/files/run/macro-expand-unapply-a/Impls_Macros_1.scala
+++ b/test/files/run/macro-expand-unapply-a/Impls_Macros_1.scala
@@ -1,7 +1,7 @@
 import scala.reflect.macros.whitebox.Context
 
 object Helper {
-  def unapplySeq[T](x: List[T]): Option[Seq[T]] = List.unapplySeq[T](x)
+  def unapplySeq[T](x: List[T]): Option[Seq[T]] = Some(x)
 }
 
 object Macros {

--- a/test/files/run/patmat-seq.check
+++ b/test/files/run/patmat-seq.check
@@ -1,0 +1,405 @@
+newSource1.scala:35: warning: unreachable code
+    case B(x, y)       => (x, y)
+                          ^
+[[syntax trees at end of                    patmat]] // newSource1.scala
+package <empty> {
+  object A extends scala.AnyRef {
+    def <init>(): A.type = {
+      A.super.<init>();
+      ()
+    };
+    def unapplySeq(a: Int): collection.SeqFactory.UnapplySeqWrapper[Int] = new collection.SeqFactory.UnapplySeqWrapper[Int](scala.collection.mutable.ArrayBuffer.apply[Int](1, 2, 3))
+  };
+  object B extends scala.AnyRef {
+    def <init>(): B.type = {
+      B.super.<init>();
+      ()
+    };
+    def unapplySeq(a: Int): Some[scala.collection.immutable.ArraySeq[Int]] = scala.Some.apply[scala.collection.immutable.ArraySeq[Int]](scala.collection.immutable.ArraySeq.apply[Int](1, 2, 3)((ClassTag.Int: scala.reflect.ClassTag[Int])))
+  };
+  class Foo[T] extends scala.AnyRef {
+    def <init>(): Foo[T] = {
+      Foo.super.<init>();
+      ()
+    };
+    def isEmpty: Boolean = false;
+    def get: Foo[T] = this;
+    def apply(i: Int): T = scala.Predef.???;
+    def length: Int = 2;
+    def drop(n: Int): Seq[T] = scala.Predef.???;
+    def toSeq: Seq[T] = scala.Predef.???
+  };
+  object C extends scala.AnyRef {
+    def <init>(): C.type = {
+      C.super.<init>();
+      ()
+    };
+    def unapplySeq(a: Int): Foo[Int] = new Foo[Int]()
+  };
+  object D extends scala.AnyRef {
+    def <init>(): D.type = {
+      D.super.<init>();
+      ()
+    };
+    def unapplySeq[T](a: Int): Some[Foo[T]] = scala.Some.apply[Foo[T]](new Foo[T]())
+  };
+  object E extends scala.AnyRef {
+    def <init>(): E.type = {
+      E.super.<init>();
+      ()
+    };
+    def unapplySeq(a: Int): Array.UnapplySeqWrapper[Int] = new Array.UnapplySeqWrapper[Int](scala.Array.apply(1, 2, 3))
+  };
+  object F extends scala.AnyRef {
+    def <init>(): F.type = {
+      F.super.<init>();
+      ()
+    };
+    def unapplySeq(a: Int): Some[String] = scala.Some.apply[String]("123")
+  };
+  class T extends scala.AnyRef {
+    def <init>(): T = {
+      T.super.<init>();
+      ()
+    };
+    def t: Any = {
+      case <synthetic> val x1: Int = 2;
+      case16(){
+        <synthetic> val o18: collection.SeqFactory.UnapplySeqWrapper[Int] = A.unapplySeq(x1);
+        if (o18.isEmpty.unary_!)
+          {
+            val xs: Seq[Int] = o18.get.toSeq;
+            matchEnd15(xs)
+          }
+        else
+          case17()
+      };
+      case17(){
+        <synthetic> val o20: collection.SeqFactory.UnapplySeqWrapper[Int] = A.unapplySeq(x1);
+        if (o20.isEmpty.unary_!.&&(o20.get.!=(null).&&(o20.get.lengthCompare(2).==(0))))
+          {
+            val x: Int = o20.get.apply(0);
+            val y: Int = o20.get.apply(1);
+            matchEnd15(scala.Tuple2.apply[Int, Int](x, y))
+          }
+        else
+          case19()
+      };
+      case19(){
+        <synthetic> val o22: collection.SeqFactory.UnapplySeqWrapper[Int] = A.unapplySeq(x1);
+        if (o22.isEmpty.unary_!.&&(o22.get.!=(null).&&(o22.get.lengthCompare(1).>=(0))))
+          {
+            val x: Int = o22.get.apply(0);
+            val xs: Seq[Int] = o22.get.drop(1);
+            matchEnd15(scala.Tuple2.apply[Int, Seq[Int]](x, xs))
+          }
+        else
+          case21()
+      };
+      case21(){
+        <synthetic> val o24: Some[scala.collection.immutable.ArraySeq[Int]] = B.unapplySeq(x1);
+        if (o24.isEmpty.unary_!)
+          {
+            val xs: Seq[Int] = o24.get;
+            matchEnd15(xs)
+          }
+        else
+          case23()
+      };
+      case23(){
+        <synthetic> val o26: Some[scala.collection.immutable.ArraySeq[Int]] = B.unapplySeq(x1);
+        if (o26.isEmpty.unary_!.&&(o26.get.!=(null).&&(o26.get.lengthCompare(2).==(0))))
+          {
+            val x: Int = o26.get.apply(0);
+            val y: Int = o26.get.apply(1);
+            matchEnd15(scala.Tuple2.apply[Int, Int](x, y))
+          }
+        else
+          case25()
+      };
+      case25(){
+        <synthetic> val o28: Some[scala.collection.immutable.ArraySeq[Int]] = B.unapplySeq(x1);
+        if (o28.isEmpty.unary_!.&&(o28.get.!=(null).&&(o28.get.lengthCompare(1).>=(0))))
+          {
+            val x: Int = o28.get.apply(0);
+            val xs: Seq[Int] = o28.get.drop(1);
+            matchEnd15(scala.Tuple2.apply[Int, Seq[Int]](x, xs))
+          }
+        else
+          case27()
+      };
+      case27(){
+        <synthetic> val o30: Foo[Int] = C.unapplySeq(x1);
+        if (o30.isEmpty.unary_!)
+          {
+            val xs: Seq[Int] = o30.get.toSeq;
+            matchEnd15(xs)
+          }
+        else
+          case29()
+      };
+      case29(){
+        <synthetic> val o32: Foo[Int] = C.unapplySeq(x1);
+        if (o32.isEmpty.unary_!.&&(o32.get.!=(null).&&(scala.math.`package`.signum(o32.get.length.-(2)).==(0))))
+          {
+            val x: Int = o32.get.apply(0);
+            val y: Int = o32.get.apply(1);
+            matchEnd15(scala.Tuple2.apply[Int, Int](x, y))
+          }
+        else
+          case31()
+      };
+      case31(){
+        <synthetic> val o34: Foo[Int] = C.unapplySeq(x1);
+        if (o34.isEmpty.unary_!.&&(o34.get.!=(null).&&(scala.math.`package`.signum(o34.get.length.-(1)).>=(0))))
+          {
+            val x: Int = o34.get.apply(0);
+            val xs: Seq[Int] = o34.get.drop(1);
+            matchEnd15(scala.Tuple2.apply[Int, Seq[Int]](x, xs))
+          }
+        else
+          case33()
+      };
+      case33(){
+        <synthetic> val o36: Some[Foo[Nothing]] = D.unapplySeq[Nothing](x1);
+        if (o36.isEmpty.unary_!)
+          {
+            val xs: Seq[Nothing] = o36.get.toSeq;
+            matchEnd15(xs)
+          }
+        else
+          case35()
+      };
+      case35(){
+        <synthetic> val o38: Some[Foo[Nothing]] = D.unapplySeq[Nothing](x1);
+        if (o38.isEmpty.unary_!.&&(o38.get.!=(null).&&(scala.math.`package`.signum(o38.get.length.-(2)).==(0))))
+          {
+            val x: Nothing = o38.get.apply(0);
+            val y: Nothing = o38.get.apply(1);
+            matchEnd15(scala.Tuple2.apply[Nothing, Nothing](x, y))
+          }
+        else
+          case37()
+      };
+      case37(){
+        <synthetic> val o40: Some[Foo[Nothing]] = D.unapplySeq[Nothing](x1);
+        if (o40.isEmpty.unary_!.&&(o40.get.!=(null).&&(scala.math.`package`.signum(o40.get.length.-(1)).>=(0))))
+          {
+            val x: Nothing = o40.get.apply(0);
+            val xs: Seq[Nothing] = o40.get.drop(1);
+            matchEnd15(scala.Tuple2.apply[Nothing, Seq[Nothing]](x, xs))
+          }
+        else
+          case39()
+      };
+      case39(){
+        matchEnd15(throw new MatchError(x1))
+      };
+      matchEnd15(x: Any){
+        x
+      }
+    }
+  }
+}
+
+[[syntax trees at end of               posterasure]] // newSource1.scala
+package <empty> {
+  object A extends Object {
+    def <init>(): A.type = {
+      A.super.<init>();
+      ()
+    };
+    def unapplySeq(a: Int): scala.collection.SeqOps = scala.collection.mutable.ArrayBuffer.apply(scala.runtime.ScalaRunTime.wrapIntArray(Array[Int]{1, 2, 3})).$asInstanceOf[scala.collection.SeqOps]()
+  };
+  object B extends Object {
+    def <init>(): B.type = {
+      B.super.<init>();
+      ()
+    };
+    def unapplySeq(a: Int): Some = new Some(scala.collection.immutable.ArraySeq.apply(scala.runtime.ScalaRunTime.wrapIntArray(Array[Int]{1, 2, 3}), (ClassTag.Int(): scala.reflect.ClassTag)))
+  };
+  class Foo extends Object {
+    def <init>(): Foo = {
+      Foo.super.<init>();
+      ()
+    };
+    def isEmpty(): Boolean = false;
+    def get(): Foo = this;
+    def apply(i: Int): Object = scala.Predef.???();
+    def length(): Int = 2;
+    def drop(n: Int): Seq = scala.Predef.???();
+    def toSeq(): Seq = scala.Predef.???()
+  };
+  object C extends Object {
+    def <init>(): C.type = {
+      C.super.<init>();
+      ()
+    };
+    def unapplySeq(a: Int): Foo = new Foo()
+  };
+  object D extends Object {
+    def <init>(): D.type = {
+      D.super.<init>();
+      ()
+    };
+    def unapplySeq(a: Int): Some = new Some(new Foo())
+  };
+  object E extends Object {
+    def <init>(): E.type = {
+      E.super.<init>();
+      ()
+    };
+    def unapplySeq(a: Int): Object = scala.Array.apply(1, scala.runtime.ScalaRunTime.wrapIntArray(Array[Int]{2, 3}))
+  };
+  object F extends Object {
+    def <init>(): F.type = {
+      F.super.<init>();
+      ()
+    };
+    def unapplySeq(a: Int): Some = new Some("123")
+  };
+  class T extends Object {
+    def <init>(): T = {
+      T.super.<init>();
+      ()
+    };
+    def t(): Object = {
+      case <synthetic> val x1: Int = 2;
+      case16(){
+        <synthetic> val o18: scala.collection.SeqOps = A.unapplySeq(x1);
+        if (scala.collection.SeqFactory.UnapplySeqWrapper.isEmpty$extension(o18).unary_!())
+          {
+            val xs: Seq = scala.collection.SeqFactory.UnapplySeqWrapper.toSeq$extension(scala.collection.SeqFactory.UnapplySeqWrapper.get$extension(o18));
+            matchEnd15(xs)
+          }
+        else
+          case17()
+      };
+      case17(){
+        <synthetic> val o20: scala.collection.SeqOps = A.unapplySeq(x1);
+        if (scala.collection.SeqFactory.UnapplySeqWrapper.isEmpty$extension(o20).unary_!().&&(new collection.SeqFactory.UnapplySeqWrapper(scala.collection.SeqFactory.UnapplySeqWrapper.get$extension(o20)).!=(null).&&(scala.collection.SeqFactory.UnapplySeqWrapper.lengthCompare$extension(scala.collection.SeqFactory.UnapplySeqWrapper.get$extension(o20), 2).==(0))))
+          {
+            val x: Int = unbox(scala.collection.SeqFactory.UnapplySeqWrapper.apply$extension(scala.collection.SeqFactory.UnapplySeqWrapper.get$extension(o20), 0));
+            val y: Int = unbox(scala.collection.SeqFactory.UnapplySeqWrapper.apply$extension(scala.collection.SeqFactory.UnapplySeqWrapper.get$extension(o20), 1));
+            matchEnd15(new Tuple2$mcII$sp(x, y))
+          }
+        else
+          case19()
+      };
+      case19(){
+        <synthetic> val o22: scala.collection.SeqOps = A.unapplySeq(x1);
+        if (scala.collection.SeqFactory.UnapplySeqWrapper.isEmpty$extension(o22).unary_!().&&(new collection.SeqFactory.UnapplySeqWrapper(scala.collection.SeqFactory.UnapplySeqWrapper.get$extension(o22)).!=(null).&&(scala.collection.SeqFactory.UnapplySeqWrapper.lengthCompare$extension(scala.collection.SeqFactory.UnapplySeqWrapper.get$extension(o22), 1).>=(0))))
+          {
+            val x: Int = unbox(scala.collection.SeqFactory.UnapplySeqWrapper.apply$extension(scala.collection.SeqFactory.UnapplySeqWrapper.get$extension(o22), 0));
+            val xs: Seq = scala.collection.SeqFactory.UnapplySeqWrapper.drop$extension(scala.collection.SeqFactory.UnapplySeqWrapper.get$extension(o22), 1);
+            matchEnd15(new Tuple2(scala.Int.box(x), xs))
+          }
+        else
+          case21()
+      };
+      case21(){
+        <synthetic> val o24: Some = B.unapplySeq(x1);
+        if (o24.isEmpty().unary_!())
+          {
+            val xs: Seq = o24.get().$asInstanceOf[Seq]();
+            matchEnd15(xs)
+          }
+        else
+          case23()
+      };
+      case23(){
+        <synthetic> val o26: Some = B.unapplySeq(x1);
+        if (o26.isEmpty().unary_!().&&(o26.get().!=(null).&&(o26.get().$asInstanceOf[collection.IndexedSeqOps]().lengthCompare(2).==(0))))
+          {
+            val x: Int = unbox(o26.get().$asInstanceOf[collection.immutable.ArraySeq]().apply(0));
+            val y: Int = unbox(o26.get().$asInstanceOf[collection.immutable.ArraySeq]().apply(1));
+            matchEnd15(new Tuple2$mcII$sp(x, y))
+          }
+        else
+          case25()
+      };
+      case25(){
+        <synthetic> val o28: Some = B.unapplySeq(x1);
+        if (o28.isEmpty().unary_!().&&(o28.get().!=(null).&&(o28.get().$asInstanceOf[collection.IndexedSeqOps]().lengthCompare(1).>=(0))))
+          {
+            val x: Int = unbox(o28.get().$asInstanceOf[collection.immutable.ArraySeq]().apply(0));
+            val xs: Seq = o28.get().$asInstanceOf[collection.immutable.ArraySeq]().drop(1);
+            matchEnd15(new Tuple2(scala.Int.box(x), xs))
+          }
+        else
+          case27()
+      };
+      case27(){
+        <synthetic> val o30: Foo = C.unapplySeq(x1);
+        if (o30.isEmpty().unary_!())
+          {
+            val xs: Seq = o30.get().toSeq();
+            matchEnd15(xs)
+          }
+        else
+          case29()
+      };
+      case29(){
+        <synthetic> val o32: Foo = C.unapplySeq(x1);
+        if (o32.isEmpty().unary_!().&&(o32.get().!=(null).&&(scala.math.`package`.signum(o32.get().length().-(2)).==(0))))
+          {
+            val x: Int = unbox(o32.get().apply(0));
+            val y: Int = unbox(o32.get().apply(1));
+            matchEnd15(new Tuple2$mcII$sp(x, y))
+          }
+        else
+          case31()
+      };
+      case31(){
+        <synthetic> val o34: Foo = C.unapplySeq(x1);
+        if (o34.isEmpty().unary_!().&&(o34.get().!=(null).&&(scala.math.`package`.signum(o34.get().length().-(1)).>=(0))))
+          {
+            val x: Int = unbox(o34.get().apply(0));
+            val xs: Seq = o34.get().drop(1);
+            matchEnd15(new Tuple2(scala.Int.box(x), xs))
+          }
+        else
+          case33()
+      };
+      case33(){
+        <synthetic> val o36: Some = D.unapplySeq(x1);
+        if (o36.isEmpty().unary_!())
+          {
+            val xs: Seq = o36.get().$asInstanceOf[Foo]().toSeq();
+            matchEnd15(xs)
+          }
+        else
+          case35()
+      };
+      case35(){
+        <synthetic> val o38: Some = D.unapplySeq(x1);
+        if (o38.isEmpty().unary_!().&&(o38.get().!=(null).&&(scala.math.`package`.signum(o38.get().$asInstanceOf[Foo]().length().-(2)).==(0))))
+          {
+            val x: Nothing = o38.get().$asInstanceOf[Foo]().apply(0).$asInstanceOf[Nothing]();
+            val y: Nothing = o38.get().$asInstanceOf[Foo]().apply(1).$asInstanceOf[Nothing]();
+            matchEnd15(new Tuple2(x, y))
+          }
+        else
+          case37()
+      };
+      case37(){
+        <synthetic> val o40: Some = D.unapplySeq(x1);
+        if (o40.isEmpty().unary_!().&&(o40.get().!=(null).&&(scala.math.`package`.signum(o40.get().$asInstanceOf[Foo]().length().-(1)).>=(0))))
+          {
+            val x: Nothing = o40.get().$asInstanceOf[Foo]().apply(0).$asInstanceOf[Nothing]();
+            val xs: Seq = o40.get().$asInstanceOf[Foo]().drop(1);
+            matchEnd15(new Tuple2(x, xs))
+          }
+        else
+          case39()
+      };
+      case39(){
+        matchEnd15(throw new MatchError(scala.Int.box(x1)))
+      };
+      matchEnd15(x: Object){
+        x
+      }
+    }
+  }
+}
+

--- a/test/files/run/patmat-seq.scala
+++ b/test/files/run/patmat-seq.scala
@@ -1,0 +1,60 @@
+import scala.tools.partest._
+import java.io.{Console => _, _}
+
+object Test extends DirectTest {
+
+  override def extraSettings: String = "-usejavacp -Xprint:patmat,posterasure -Ystop-after:posterasure"
+
+  override def code =
+    """object A {
+      |  def unapplySeq(a: Int) = new collection.SeqFactory.UnapplySeqWrapper(collection.mutable.ArrayBuffer(1,2,3))
+      |}
+      |object B {
+      |  // this works: Some and immutable collections support the required interface.
+      |  // in reqality, immutable collections also use the UnapplySeqWrapper value class, which is eliminated by erasure
+      |  def unapplySeq(a: Int) = Some(collection.immutable.ArraySeq(1,2,3))
+      |}
+      |class Foo[T] {
+      |  def isEmpty = false
+      |  def get = this
+      |  def apply(i: Int): T = ???
+      |  def length = 2 // if there's no lengthCompare, the translation uses length
+      |  def drop(n: Int): Seq[T] = ???
+      |  def toSeq: Seq[T] = ???
+      |}
+      |object C {
+      |  def unapplySeq(a: Int) = new Foo[Int]
+      |}
+      |object D {
+      |  def unapplySeq[T](a: Int) = Some(new Foo[T])
+      |}
+      |object E {
+      |  def unapplySeq(a: Int) = new Array.UnapplySeqWrapper(Array(1,2,3))
+      |}
+      |object F {
+      |  def unapplySeq(a: Int) = Some("123")
+      |}
+      |class T {
+      |  def t: Any = 2 match {
+      |    case A(xs @ _*)    => xs      // wrapper.get.toSeq
+      |    case A(x, y)       => (x, y)  // wrapper.get.apply(0/1)
+      |    case A(x, xs @ _*) => (x, xs) // wrapper.get.drop(1)
+      |    case B(xs @ _*)    => xs
+      |    case B(x, y)       => (x, y)
+      |    case B(x, xs @ _*) => (x, xs)
+      |    case C(xs @ _*)    => xs
+      |    case C(x, y)       => (x, y)
+      |    case C(x, xs @ _*) => (x, xs)
+      |    case D(xs @ _*)    => xs
+      |    case D(x, y)       => (x, y)
+      |    case D(x, xs @ _*) => (x, xs)
+      |  }
+      |}
+    """.stripMargin
+
+  override def show(): Unit = {
+    Console.withErr(System.out) {
+      compile()
+    }
+  }
+}

--- a/test/files/run/string-extractor.scala
+++ b/test/files/run/string-extractor.scala
@@ -6,20 +6,22 @@ final class StringExtract(val s: String) extends AnyVal {
   def apply(idx: Int): Char       = s charAt idx
   def head: Char                  = s charAt 0
   def tail: String                = s drop 1
-  def drop(n: Int): StringExtract = new StringExtract(s drop n)
+  def drop(n: Int): Seq[Char]     = toSeq.drop(n)
+  def toSeq: Seq[Char]            = s.toSeq
 
   override def toString = s
 }
 
 final class ThreeStringExtract(val s: String) extends AnyVal {
-  def isEmpty                                      = (s eq null) || (s == "")
-  def get: (List[Int], Double, ThreeStringExtract) = ((s.length :: Nil, s.length.toDouble, this))
-  def length                                       = s.length
-  def lengthCompare(n: Int)                        = s.length compare n
-  def apply(idx: Int): Char                        = s charAt idx
-  def head: Char                                   = s charAt 0
-  def tail: String                                 = s drop 1
-  def drop(n: Int): ThreeStringExtract             = new ThreeStringExtract(s drop n)
+  def isEmpty                             = (s eq null) || (s == "")
+  def get: (List[Int], Double, Seq[Char]) = ((s.length :: Nil, s.length.toDouble, toSeq))
+  def length                              = s.length
+  def lengthCompare(n: Int)               = s.length compare n
+  def apply(idx: Int): Char               = s charAt idx
+  def head: Char                          = s charAt 0
+  def tail: String                        = s drop 1
+  def drop(n: Int): Seq[Char]             = toSeq.drop(n)
+  def toSeq: Seq[Char]                    = s.toSeq
 
   override def toString = s
 }

--- a/test/files/run/value-class-extractor-seq.check
+++ b/test/files/run/value-class-extractor-seq.check
@@ -1,3 +1,3 @@
 Bip(1, 2, 3)
-Bip(1, 2, c @ Array(3, 4, 5): _*)
+Bip(1, 2, c @ ArraySeq(3, 4, 5): _*)
 class [I

--- a/test/files/run/value-class-extractor-seq.scala
+++ b/test/files/run/value-class-extractor-seq.scala
@@ -2,7 +2,7 @@ import scala.runtime.ScalaRunTime.stringOf
 
 final class ArrayOpt[T](val xs: Array[T]) extends AnyVal {
   def isEmpty = xs == null
-  def get = xs
+  def get = new scala.Array.UnapplySeqWrapper(xs)
 }
 
 object Bip {


### PR DESCRIPTION
With name-based pattern matching, unapplySeq can return any type that
has an `isEmpty` and `get` methods. The object returned by `get` needs
to have `apply`, `length` or `lengthCompare` and `drop` methods.

This PR changes the type of `x @ _*` bound variables to `scala.Seq`. To support
that change, the object returned by `unapplySeq.get` is converted by
calling `.toSeq` or `drop(n)`.

This means there are two changes in the interface for name-based pattern
matching:
  - the object needs to define a `toSeq` method
  - the `drop` method needs to return a `scala.Seq`

The `unapplySeq` method defined in `collection.SeqFactory` now returns
a value class wrapper that delegates to the collection. `toSeq` no
longer exposes mutable collections.

`Array.unapplySeq` uses a similar value class wrapper.

Fixes scala/bug#11040