### PR TITLE
Deal with numeric but singleton typed numeric fields 

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
@@ -292,7 +292,7 @@ trait AccessorSynthesis extends Transform with ast.TreeDSL {
 
         // The lazy accessor delegates to the compute method if needed, otherwise just accesses the var (it was initialized previously)
         // `if ((bitmap&n & MASK) == 0) this.l$compute() else l$`
-        val accessorRhs = If(needsInit, Apply(Select(thisRef, slowPathSym), Nil), selectVar)
+        val accessorRhs = fields.castHack(If(needsInit, Apply(Select(thisRef, slowPathSym), Nil), selectVar), lazyVar.info)
 
         afterOwnPhase { // so that we can assign to vals
           Thicket(List((DefDef(slowPathSym, slowPathRhs)), DefDef(lazyAccessor, accessorRhs)) map typedPos(lazyAccessor.pos.focus))

--- a/test/files/pos/chaining.scala
+++ b/test/files/pos/chaining.scala
@@ -1,0 +1,4 @@
+object Test {
+  case class Foo[A](self: A) { def bar: self.type = self }
+  lazy val result = Foo(1).bar
+}


### PR DESCRIPTION
Following on from scala/scala#5536 this commit adds another `fields.castHack` in `AccessorSynthesis#expandLazyClassMember` to deal with numeric but singleton typed numeric fields which would otherwise be widened by `numericLub`.

Fixes scala/bug#11071.