### PR TITLE
override methods on WrappedString to use String methods

### DIFF
--- a/src/library/scala/collection/immutable/WrappedString.scala
+++ b/src/library/scala/collection/immutable/WrappedString.scala
@@ -38,6 +38,59 @@ final class WrappedString(private val self: String) extends AbstractSeq[Char] wi
   override def toString = self
   override def view: StringView = new StringView(self)
 
+  override def startsWith[B >: Char](that: IterableOnce[B], offset: Int = 0): Boolean =
+    that match {
+      case s: WrappedString => self.startsWith(s.self, offset)
+      case _                => super.startsWith(that, offset)
+    }
+
+  override def endsWith[B >: Char](that: collection.Iterable[B]): Boolean =
+    that match {
+      case s: WrappedString => self.endsWith(s.self)
+      case _                => super.endsWith(that)
+    }
+
+  override def indexOf[B >: Char](elem: B, from: Int = 0): Int = elem match {
+    case c: Char => self.indexOf(c, from)
+    case _       => super.indexOf(elem)
+  }
+
+  override def lastIndexOf[B >: Char](elem: B, end: Int = length - 1): Int =
+    elem match {
+      case c: Char => self.lastIndexOf(c, end)
+      case _       => super.lastIndexOf(elem, end)
+    }
+
+  override def indexOfSlice[B >: Char](that: collection.Seq[B], from: Int = 0): Int =
+    that match {
+      case s: WrappedString => self.indexOfSlice(s.self, from)
+      case _                => super.indexOfSlice(that, from)
+    }
+
+  override def lastIndexOfSlice[B >: Char](that: collection.Seq[B], end: Int = length - 1): Int =
+    that match {
+      case s: WrappedString => self.lastIndexOfSlice(s, end)
+      case _                => super.lastIndexOfSlice(that, end)
+    }
+
+  override def copyToArray[B >: Char](xs: Array[B], start: Int): Int =
+    copyToArray(xs, start, length)
+
+  override def copyToArray[B >: Char](xs: Array[B], start: Int, len: Int): Int =
+    (xs: Any) match {
+      case chs: Array[Char] =>
+        val copied = IterableOnce.elemsToCopyToArray(length, chs.length, start, len)
+        self.getChars(0, copied, chs, start)
+        copied
+      case _                => super.copyToArray(xs, start, len)
+    }
+
+  override def appendedAll[B >: Char](suffix: IterableOnce[B]): IndexedSeq[B] =
+    suffix match {
+      case s: WrappedString => new WrappedString(self concat s.self)
+      case _                => super.appendedAll(suffix)
+    }
+
   override protected[this] def className = "WrappedString"
 
   override def equals(other: Any): Boolean = other match {


### PR DESCRIPTION
`startsWith`, `endsWith`, `indexOf`, `lastIndexOf`, `indexOfSlice`, `lastIndexOf`, and `copyToArray` all have analoguous methods on i `jl.String`, which can be used if the types line up.