### PR TITLE
Remove scala.collection.AnyConstr

### DIFF
--- a/src/library/scala/collection/IndexedSeqView.scala
+++ b/src/library/scala/collection/IndexedSeqView.scala
@@ -40,7 +40,7 @@ object IndexedSeqView {
   }
 
   /** An `IndexedSeqOps` whose collection type and collection type constructor are unknown */
-  type SomeIndexedSeqOps[A] = IndexedSeqOps[A, AnyConstr, _]
+  type SomeIndexedSeqOps[A] = IndexedSeqOps[A, Any, _]
 
   @SerialVersionUID(3L)
   class Id[+A](underlying: SomeIndexedSeqOps[A])

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -827,7 +827,7 @@ object IterableOps {
     * These operations are implemented in terms of
     * [[scala.collection.IterableOps.sizeCompare(Int) `sizeCompare(Int)`]].
     */
-  final class SizeCompareOps private[collection](val it: IterableOps[_, AnyConstr, _]) extends AnyVal {
+  final class SizeCompareOps private[collection](val it: IterableOps[_, Any, _]) extends AnyVal {
     /** Tests if the size of the collection is less than some value. */
     @inline def <(size: Int): Boolean = it.sizeCompare(size) < 0
     /** Tests if the size of the collection is less than or equal to some value. */

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -73,7 +73,7 @@ trait Map[K, +V]
   */
 // Note: the upper bound constraint on CC is useful only to
 // erase CC to IterableOps instead of Object
-trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
+trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, Any, _], +C]
   extends IterableOps[(K, V), Iterable, C]
     with PartialFunction[K, V] {
 
@@ -310,7 +310,7 @@ object MapOps {
     *
     * @define coll map collection
     */
-  class WithFilter[K, +V, +IterableCC[_], +CC[_, _] <: IterableOps[_, AnyConstr, _]](
+  class WithFilter[K, +V, +IterableCC[_], +CC[_, _] <: IterableOps[_, Any, _]](
     self: MapOps[K, V, CC, _] with IterableOps[(K, V), IterableCC, _],
     p: ((K, V)) => Boolean
   ) extends IterableOps.WithFilter[(K, V), IterableCC](self, p) {

--- a/src/library/scala/collection/MapView.scala
+++ b/src/library/scala/collection/MapView.scala
@@ -31,7 +31,7 @@ trait MapView[K, +V]
 object MapView {
 
   /** An `IterableOps` whose collection type and collection type constructor are unknown */
-  type SomeIterableConstr[X, Y] = IterableOps[_, AnyConstr, _]
+  type SomeIterableConstr[X, Y] = IterableOps[_, Any, _]
   /** A `MapOps` whose collection type and collection type constructor are (mostly) unknown */
   type SomeMapOps[K, +V] = MapOps[K, V, SomeIterableConstr, _]
 

--- a/src/library/scala/collection/Searching.scala
+++ b/src/library/scala/collection/Searching.scala
@@ -23,7 +23,7 @@ object Searching {
   case class InsertionPoint(insertionPoint: Int) extends SearchResult
 
   @deprecated("Search methods are defined directly on SeqOps and do not require scala.collection.Searching any more", "2.13.0")
-  class SearchImpl[Repr, A](private val coll: SeqOps[A, AnyConstr, _]) extends AnyVal
+  class SearchImpl[Repr, A](private val coll: SeqOps[A, Any, _]) extends AnyVal
 
   @deprecated("Search methods are defined directly on SeqOps and do not require scala.collection.Searching any more", "2.13.0")
   implicit def search[Repr, A](coll: Repr)(implicit fr: IsSeqLike[Repr]): SearchImpl[Repr, fr.A] =

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -918,7 +918,7 @@ object SeqOps {
     * These operations are implemented in terms of
     * [[scala.collection.SeqOps.lengthCompare(Int) `lengthCompare(Int)`]].
     */
-  final class LengthCompareOps private[SeqOps](val seq: SeqOps[_, AnyConstr, _]) extends AnyVal {
+  final class LengthCompareOps private[SeqOps](val seq: SeqOps[_, Any, _]) extends AnyVal {
     /** Tests if the length of the collection is less than some value. */
     @inline def <(len: Int): Boolean = seq.lengthCompare(len) < 0
     /** Tests if the length of the collection is less than or equal to some value. */

--- a/src/library/scala/collection/SeqView.scala
+++ b/src/library/scala/collection/SeqView.scala
@@ -20,11 +20,11 @@ trait SeqView[+A] extends SeqOps[A, View, View[A]] with View[A] {
 object SeqView {
 
   /** A `SeqOps` whose collection type and collection type constructor are unknown */
-  type SomeSeqOps[+A] = SeqOps[A, AnyConstr, _]
+  type SomeSeqOps[+A] = SeqOps[A, Any, _]
 
   /** A view that doesn’t apply any transformation to an underlying sequence */
   @SerialVersionUID(3L)
-  class Id[+A](underlying: SeqOps[A, AnyConstr, _]) extends AbstractSeqView[A] {
+  class Id[+A](underlying: SeqOps[A, Any, _]) extends AbstractSeqView[A] {
     def apply(idx: Int): A = underlying.apply(idx)
     def length: Int = underlying.length
     def iterator: Iterator[A] = underlying.iterator

--- a/src/library/scala/collection/StrictOptimizedMapOps.scala
+++ b/src/library/scala/collection/StrictOptimizedMapOps.scala
@@ -10,7 +10,7 @@ import scala.language.higherKinds
   * @tparam CC Collection type constructor
   * @tparam C  Collection type
   */
-trait StrictOptimizedMapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
+trait StrictOptimizedMapOps[K, +V, +CC[_, _] <: IterableOps[_, Any, _], +C]
   extends MapOps[K, V, CC, C]
     with StrictOptimizedIterableOps[(K, V), Iterable, C] {
 

--- a/src/library/scala/collection/View.scala
+++ b/src/library/scala/collection/View.scala
@@ -134,7 +134,7 @@ object View extends IterableFactory[View] {
   }
 
   /** An `IterableOps` whose collection type and collection type constructor are unknown */
-  type SomeIterableOps[A] = IterableOps[A, AnyConstr, _]
+  type SomeIterableOps[A] = IterableOps[A, Any, _]
 
   /** A view that filters an underlying collection. */
   @SerialVersionUID(3L)

--- a/src/library/scala/collection/package.scala
+++ b/src/library/scala/collection/package.scala
@@ -41,13 +41,6 @@ package object collection {
   @deprecated("Gen* collection types have been removed", "2.13.0")
   val GenMap = Map
 
-  /** Needed to circumvent a difficulty between dotty and scalac concerning
-   *  the right top type for a type parameter of kind * -> *.
-   *  In Scalac, we can provide `Any`, as `Any` is kind-polymorphic. In dotty this is not allowed.
-   *  In dotty, we can provide `[X] => Any`. But Scalac does not know lambda syntax.
-   */
-  type AnyConstr[X] = Any
-
   /** An extractor used to head/tail deconstruct sequences. */
   object +: {
     /** Splits a sequence into head :+ tail.

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -9,7 +9,7 @@
 package scala
 package runtime
 
-import scala.collection.{ AbstractIterator, AnyConstr, SortedOps, StrictOptimizedIterableOps, StringOps, StringView, View }
+import scala.collection.{ AbstractIterator, SortedOps, StrictOptimizedIterableOps, StringOps, StringView, View }
 import scala.collection.generic.IsIterableLike
 import scala.collection.immutable.{ NumericRange, ArraySeq }
 import scala.collection.mutable.StringBuilder
@@ -198,7 +198,7 @@ object ScalaRunTime {
       // Don't want to a) traverse infinity or b) be overly helpful with peoples' custom
       // collections which may have useful toString methods - ticket #3710
       // or c) print AbstractFiles which are somehow also Iterable[AbstractFile]s.
-      case x: Iterable[_] => (!x.isInstanceOf[StrictOptimizedIterableOps[_, AnyConstr, _]]) || !isScalaClass(x) || isScalaCompilerClass(x) || isXmlNode(x.getClass) || isXmlMetaData(x.getClass)
+      case x: Iterable[_] => (!x.isInstanceOf[StrictOptimizedIterableOps[_, Any, _]]) || !isScalaClass(x) || isScalaCompilerClass(x) || isXmlNode(x.getClass) || isXmlMetaData(x.getClass)
       // Otherwise, nothing could possibly go wrong
       case _ => false
     }

--- a/test/files/run/t3346e.scala
+++ b/test/files/run/t3346e.scala
@@ -1,18 +1,18 @@
 import scala.language.implicitConversions
 import scala.math.Ordering
-import collection.{AnyConstr, BuildFrom, Iterable, IterableOps, SeqOps}
+import collection.{BuildFrom, Iterable, IterableOps, SeqOps}
 import collection.immutable.BitSet
 
 class QuickSort[Coll](a: Coll) {
   //should be able to sort only something with defined order (someting like a Seq)
-  def quickSort[T](implicit ev0: Coll => SeqOps[T, AnyConstr, Iterable[T]],
+  def quickSort[T](implicit ev0: Coll => SeqOps[T, Any, Iterable[T]],
                    bf: BuildFrom[Coll, T, Coll],
                    n: Ordering[T]): Coll = {
     quickSortAnything(ev0, bf, n)
   }
 
   //we can even sort a Set, if we really want to
-  def quickSortAnything[T](implicit ev0: Coll => IterableOps[T, AnyConstr, Iterable[T]],
+  def quickSortAnything[T](implicit ev0: Coll => IterableOps[T, Any, Iterable[T]],
                            bf: BuildFrom[Coll, T, Coll],
                            n: Ordering[T]): Coll = {
     import n._


### PR DESCRIPTION
This was added in collection-strawman for cross-compiling with Dotty.
Nowadays Dotty doesn’t have `AnyConstr` anymore so there’s no point in
moving it to `scala.AnyConstr` for compatibility.