### PR TITLE
prepare to remove UninitializedError

### DIFF
--- a/src/library/scala/UninitializedError.scala
+++ b/src/library/scala/UninitializedError.scala
@@ -15,4 +15,6 @@ package scala
  *  @author  Martin Odersky
  *  @since   2.5
  */
+// TODO: remove in 2.14
+@deprecated("will be removed in a future release", since = "2.12.7")
 final class UninitializedError extends RuntimeException("uninitialized value")


### PR DESCRIPTION
It doesn't have any Scala-specific semantics and is unlikely to be worth more than a custom exception type to anyone currently using it.

If there's some reason to keep it around that I'm missing, please let me know.