### PR TITLE
Make scala.collection.AnyConstr private

### DIFF
--- a/src/library/scala/collection/package.scala
+++ b/src/library/scala/collection/package.scala
@@ -46,7 +46,7 @@ package object collection {
    *  In Scalac, we can provide `Any`, as `Any` is kind-polymorphic. In dotty this is not allowed.
    *  In dotty, we can provide `[X] => Any`. But Scalac does not know lambda syntax.
    */
-  type AnyConstr[X] = Any
+  private[scala] type AnyConstr[X] = Any
 
   /** An extractor used to head/tail deconstruct sequences. */
   object +: {

--- a/test/files/run/t3346e.scala
+++ b/test/files/run/t3346e.scala
@@ -1,18 +1,18 @@
 import scala.language.implicitConversions
 import scala.math.Ordering
-import collection.{AnyConstr, BuildFrom, Iterable, IterableOps, SeqOps}
+import collection.{BuildFrom, Iterable, IterableOps, SeqOps}
 import collection.immutable.BitSet
 
 class QuickSort[Coll](a: Coll) {
   //should be able to sort only something with defined order (someting like a Seq)
-  def quickSort[T](implicit ev0: Coll => SeqOps[T, AnyConstr, Iterable[T]],
+  def quickSort[T](implicit ev0: Coll => SeqOps[T, Any, Iterable[T]],
                    bf: BuildFrom[Coll, T, Coll],
                    n: Ordering[T]): Coll = {
     quickSortAnything(ev0, bf, n)
   }
 
   //we can even sort a Set, if we really want to
-  def quickSortAnything[T](implicit ev0: Coll => IterableOps[T, AnyConstr, Iterable[T]],
+  def quickSortAnything[T](implicit ev0: Coll => IterableOps[T, Any, Iterable[T]],
                            bf: BuildFrom[Coll, T, Coll],
                            n: Ordering[T]): Coll = {
     import n._


### PR DESCRIPTION
It exists only for cross-compiling the library between Scala 2 and Dotty
and is not supposed to be used directly.