### PR TITLE
fix Iterable#partition scaladoc

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -411,7 +411,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     *  all elements that do not. Interesting because it splits a collection in two.
     *
     *  The default implementation provided here needs to traverse the collection twice.
-    *  Strict collections have an overridden version of `partition` in `Buildable`,
+    *  Strict collections have an overridden version of `partition` in `StrictOptimizedIterableOps`,
     *  which requires only a single traversal.
     */
   def partition(p: A => Boolean): (C, C) = {


### PR DESCRIPTION
`Buildable` no longer exists

- https://github.com/scala/scala/commit/0dbd5977b9e70384f8821deb120b4078e38e4d67#diff-e325090939d0c05b24284230016c77e7L259
- https://github.com/scala/scala/blob/c6fc4e717490402ff2502737df3e36f331cbd9d7/src/library/scala/collection/StrictOptimizedIterableOps.scala#L19-L24