### PR TITLE
Fix transitive equality on VectorMap

### DIFF
--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -106,7 +106,8 @@ final class VectorMap[K, +V] private[immutable] (
   // Only care about content, not ordering for equality
   override def equals(that: Any): Boolean =
     that match {
-      case vmap: VectorMap[_, _] => underlying == vmap.underlying
+      case vmap: VectorMap[_, _] =>
+        underlying.mapValues(_._2).toMap == vmap.underlying.mapValues(_._2).toMap
       case _ => super.equals(that)
     }
 

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -107,7 +107,8 @@ final class VectorMap[K, +V] private[immutable] (
   override def equals(that: Any): Boolean =
     that match {
       case vmap: VectorMap[_, _] =>
-        underlying.mapValues(_._2).toMap == vmap.underlying.mapValues(_._2).toMap
+        underlying.size == vmap.underlying.size &&
+          underlying.mapValues(_._2).toMap == vmap.underlying.mapValues(_._2).toMap
       case _ => super.equals(that)
     }
 

--- a/test/scalacheck/SeqMap.scala
+++ b/test/scalacheck/SeqMap.scala
@@ -7,7 +7,7 @@ import Gen._
 
 import scala.collection.mutable.ListBuffer
 
-object SeqMapTest extends Properties("LinkedMap") {
+object SeqMapTest extends Properties("SeqMap") {
 
   property("ordering") = forAll { (m: Map[Int, Int]) =>
     val list = m.toList

--- a/test/scalacheck/VectorMap.scala
+++ b/test/scalacheck/VectorMap.scala
@@ -1,0 +1,15 @@
+import scala.collection.immutable.VectorMap
+
+import org.scalacheck._
+import Arbitrary.arbitrary
+import Prop._
+import Gen._
+
+object VectorMapTest extends Properties("VectorMap") {
+  property("transitive test") = {
+    val x = VectorMap(1 -> 2, 3 -> 4)
+    val y = Map(1 -> 2, 3 -> 4)
+    val z = VectorMap(3 -> 4, 1 -> 2)
+    x == y && y == z && x == z
+  }
+}


### PR DESCRIPTION
This PR fixes https://github.com/scala/bug/issues/11080. Note that there may be a more performant solution but its important to get it correct first