### PR TITLE
Use a java static to throw IndexOutOfBoundsException

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -84,10 +84,19 @@ trait MethodSynthesis {
     def forwardMethod(original: Symbol, newMethod: Symbol)(transformArgs: List[Tree] => List[Tree]): Tree =
       createMethod(original)(m => gen.mkMethodCall(newMethod, transformArgs(m.paramss.head map Ident)))
 
-    def createSwitchMethod(name: Name, range: Seq[Int], returnType: Type)(f: Int => Tree) = {
+    def createSwitchMethod(name: Name, range: Seq[Int], returnType: Type)(f: Int => Tree): Tree = {
+      def dflt(arg: Tree) = currentRun.runDefinitions.RuntimeStatics_ioobe match {
+        case NoSymbol =>
+          // Support running the compiler with an older library on the classpath
+          Throw(IndexOutOfBoundsExceptionClass.tpe_*, fn(arg, nme.toString_))
+        case ioobeSym =>
+          val ioobeTypeApply = TypeApply(gen.mkAttributedRef(ioobeSym), List(TypeTree(returnType)))
+          Apply(ioobeTypeApply, List(arg))
+      }
+
       createMethod(name, List(IntTpe), returnType) { m =>
         val arg0    = Ident(m.firstParam)
-        val default = DEFAULT ==> Throw(IndexOutOfBoundsExceptionClass.tpe_*, fn(arg0, nme.toString_))
+        val default = DEFAULT ==> dflt(arg0)
         val cases   = range.map(num => CASE(LIT(num)) ==> f(num)).toList :+ default
 
         Match(arg0, cases)

--- a/src/library/scala/runtime/Statics.java
+++ b/src/library/scala/runtime/Statics.java
@@ -186,4 +186,14 @@ public final class Statics {
           return found;
       }
   }
+
+  /**
+   * Just throws an exception.
+   * Used by the synthetic `productElement` and `productElementName` methods in case classes.
+   * Delegating the exception-throwing to this function reduces the bytecode size of the case class.
+   */
+  public static final <T> T ioobe(int n) throws IndexOutOfBoundsException {
+    throw new IndexOutOfBoundsException(String.valueOf(n));
+  }
+
 }

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1649,6 +1649,8 @@ trait Definitions extends api.StandardDefinitions {
       lazy val arrayClassMethod       = getMemberMethod(ScalaRunTimeModule, nme.arrayClass)
       lazy val wrapVarargsRefArrayMethod = getMemberMethod(getWrapVarargsArrayModule, nme.wrapRefArray)
 
+      lazy val RuntimeStatics_ioobe = getMemberMethod(RuntimeStaticsModule, nme.ioobe)
+
       lazy val GroupOfSpecializable = getMemberClass(SpecializableModule, tpnme.Group)
 
       lazy val WeakTypeTagClass = TypeTagsClass.map(sym => getMemberClass(sym, tpnme.WeakTypeTag))

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -739,6 +739,7 @@ trait StdNames {
     val initialized : NameType         = "initialized"
     val internal: NameType             = "internal"
     val inlinedEquals: NameType        = "inlinedEquals"
+    val ioobe : NameType               = "ioobe"
     val isArray: NameType              = "isArray"
     val isDefinedAt: NameType          = "isDefinedAt"
     val isEmpty: NameType              = "isEmpty"

--- a/test/files/run/idempotency-case-classes.check
+++ b/test/files/run/idempotency-case-classes.check
@@ -18,15 +18,15 @@ C(2,3)
     <synthetic> def productElement(x$1: Int): Any = x$1 match {
       case 0 => C.this.x
       case 1 => C.this.y
-      case _ => throw new IndexOutOfBoundsException(x$1.toString())
-    };
-    override <synthetic> def productElementName(x$1: Int): String = x$1 match {
-      case 0 => "x"
-      case 1 => "y"
-      case _ => throw new IndexOutOfBoundsException(x$1.toString())
+      case _ => scala.runtime.Statics.ioobe[Any](x$1)
     };
     override <synthetic> def productIterator: Iterator[Any] = scala.runtime.ScalaRunTime.typedProductIterator[Any](C.this);
     <synthetic> def canEqual(x$1: Any): Boolean = x$1.$isInstanceOf[C]();
+    override <synthetic> def productElementName(x$1: Int): String = x$1 match {
+      case 0 => "x"
+      case 1 => "y"
+      case _ => scala.runtime.Statics.ioobe[String](x$1)
+    };
     override <synthetic> def hashCode(): Int = {
       <synthetic> var acc: Int = -889275714;
       acc = scala.runtime.Statics.mix(acc, x);

--- a/test/files/run/productElementName-oob.check
+++ b/test/files/run/productElementName-oob.check
@@ -1,0 +1,11 @@
+java.lang.IndexOutOfBoundsException: 99
+scala.runtime.Statics.ioobe
+CaseClass.productElementName
+Test$.delayedEndpoint$Test$1
+Test$delayedInit$body.apply
+
+java.lang.IndexOutOfBoundsException: 99
+scala.Product.productElementName
+scala.Product.productElementName$
+CaseObject$.productElementName
+Test$.delayedEndpoint$Test$1

--- a/test/files/run/productElementName-oob.scala
+++ b/test/files/run/productElementName-oob.scala
@@ -1,0 +1,25 @@
+case class CaseClass(a: String, b: Int)
+case object CaseObject
+
+object Test extends App {
+
+  try {
+    CaseClass("foo", 123).productElementName(99)
+  } catch {
+    case e: IndexOutOfBoundsException =>
+      println(e)
+      e.getStackTrace.take(4).foreach(s => println(s.toString.takeWhile(_ != '(')))
+  }
+
+  println()
+
+  try {
+    CaseObject.productElementName(99)
+  } catch {
+    case e: IndexOutOfBoundsException =>
+      println(e)
+      e.getStackTrace.take(4).foreach(s => println(s.toString.takeWhile(_ != '(')))
+  }
+
+}
+

--- a/test/files/scalap/caseClass.check
+++ b/test/files/scalap/caseClass.check
@@ -6,9 +6,9 @@ case class CaseClass[A <: scala.Seq[scala.Int]](i: A, s: scala.Predef.String) ex
   override def productPrefix: java.lang.String = { /* compiled code */ }
   def productArity: scala.Int = { /* compiled code */ }
   def productElement(x$1: scala.Int): scala.Any = { /* compiled code */ }
-  override def productElementName(x$1: scala.Int): java.lang.String = { /* compiled code */ }
   override def productIterator: scala.collection.Iterator[scala.Any] = { /* compiled code */ }
   def canEqual(x$1: scala.Any): scala.Boolean = { /* compiled code */ }
+  override def productElementName(x$1: scala.Int): java.lang.String = { /* compiled code */ }
   override def hashCode(): scala.Int = { /* compiled code */ }
   override def toString(): java.lang.String = { /* compiled code */ }
   override def equals(x$1: scala.Any): scala.Boolean = { /* compiled code */ }

--- a/test/files/scalap/caseObject.check
+++ b/test/files/scalap/caseObject.check
@@ -3,7 +3,6 @@ case object CaseObject extends scala.AnyRef with scala.Product with scala.Serial
   override def productPrefix: java.lang.String = { /* compiled code */ }
   def productArity: scala.Int = { /* compiled code */ }
   def productElement(x$1: scala.Int): scala.Any = { /* compiled code */ }
-  override def productElementName(x$1: scala.Int): java.lang.String = { /* compiled code */ }
   override def productIterator: scala.collection.Iterator[scala.Any] = { /* compiled code */ }
   def canEqual(x$1: scala.Any): scala.Boolean = { /* compiled code */ }
   override def hashCode(): scala.Int = { /* compiled code */ }


### PR DESCRIPTION
Follow-up to #6972.

As suggested by @retronym, this reduces the bytecode fixed cost of the synthetic `productElement` and `productElementName` implementations in case classes.

Measured the difference using a simple case class:

```
case class FiveFields(a: Int, b: Int, c: Int, d: Int, e: Int)
```

Before (`2.13.0-pre-b739165`):

```
-rw-r--r--  1 chris  staff  2207 Aug 16 11:11 FiveFields$.class
-rw-r--r--  1 chris  staff  6291 Aug 16 11:11 FiveFields.class
```

After:

```
-rw-r--r--  1 chris  staff  2207 Aug 16 22:54 FiveFields$.class
-rw-r--r--  1 chris  staff  6186 Aug 16 22:54 FiveFields.class
```

So a saving of 105 bytes.

The new bytecode looks like this:

```
  public java.lang.String productElementName(int);
    Code:
       0: iload_1
       1: istore_2
       2: iload_2
       3: tableswitch   { // 0 to 4
                     0: 36
                     1: 41
                     2: 46
                     3: 51
                     4: 56
               default: 61
          }
      36: ldc           #104                // String a
      38: goto          71
      41: ldc           #105                // String b
      43: goto          71
      46: ldc           #106                // String c
      48: goto          71
      51: ldc           #107                // String d
      53: goto          71
      56: ldc           #108                // String e
      58: goto          71
      61: iload_1
      62: invokestatic  #101                // Method scala/runtime/Statics.ioobe:(I)Ljava/lang/Object;
      65: checkcast     #110                // class java/lang/String
      68: goto          71
      71: areturn
```

If we care about saving another 3 bytes, we could make the `ioobe` return `String` instead of having it generic. That happens to work because it's only called in these two places (`productElement`, which returns `Any`, and `productElementName`, which returns `String`) but it seems a bit naughty.

Also removed the synthetic `productElementName` for case objects. A bridge method is generated instead, but it's slightly smaller than the synthetic so we save about 16 bytes on case objects.