### PR TITLE
[10765] TrieMaps handle null values, and TrieMapTest tests TrieMaps

### DIFF
--- a/src/library/scala/collection/concurrent/INodeBase.java
+++ b/src/library/scala/collection/concurrent/INodeBase.java
@@ -18,7 +18,9 @@ abstract class INodeBase<K, V> extends BasicNode {
     public static final AtomicReferenceFieldUpdater<INodeBase<?, ?>, MainNode<?, ?>> updater =
             AtomicReferenceFieldUpdater.newUpdater((Class<INodeBase<?, ?>>) (Class<?>) INodeBase.class, (Class<MainNode<?, ?>>) (Class<?>) MainNode.class, "mainnode");
 
-    public static final Object RESTART = new Object();
+    static final Object RESTART = new Object();
+
+    static final Object NO_SUCH_ELEMENT_SENTINEL = new Object();
 
     public volatile MainNode<K, V> mainnode = null;
 


### PR DESCRIPTION
closes scala/bug#10765 

This fixes TrieMaps so that they can handle null values.

### Reasons why TrieMaps were not able to support null values previously

`null`s were not able to be stored in `TrieMap`s previously because of two reasons
* `INode#rec_lookup(...): AnyRef` method returned `null` to indicate that there is no value associated with key `k`. However, if `null` is associated with `k`, then callers of this method would of course interpret this return value to mean that no value is associated with `k`.
* `INode#rec_remove(..., v: V, ...): Option[V]` interpreted `v == null` to mean "remove key `k` from the map, no matter what value is associated with it". Otherwise, the behaviour is "remove `k` only if its value is equal to `v`. 

### Summary of changes

* `INode#rec_lookup(...): AnyRef` method now returns a newly added, package-private sentinel value `INodeBase.NO_SUCH_ELEMENT_SENTINEL`, in the case that there is no value associated to `k`. This allows callers to distinguish missing values from null values.
* All callers of `rec_lookup` now check for `NO_SUCH_ELEMENT_SENTINEL` and convert the result to appropriate exception throws / `Option[V]` / etc
* `INode#rec_remove` has a new argument `removeAlways: Boolean`. When `removeAlways` is `true`, `(k, v)` will be removed regardless of what `v`'s value is. When `removeAlways` is false, `(k, v)` is removed only when `v` matches the passed value of `v`.

* `INode#rec_insertif`'s argument `cond: AnyRef` had three valid arguments:
```
null - don't care if the key was there; KEY_ABSENT - key wasn't there; KEY_PRESENT - key was there; other value `v` - key must be bound to `v`
```

It now has an explicitly named non-null value, `KEY_PRESENT_OR_ABSENT`, to represent the previous null condition. While this is not directly related to handling null values in TrieMaps, I thought it is good practice to not use `null` sentinel values because of the trouble it is causing us already in this issue.

* `TrieMap#lookup(k: K): V` has been deprecated, but maintains its previous behavior to not break existing code. That is, it returns `null` if `k` is not absent. However, it also will return `null` if the value associated with `k` was `null`. Users are now directed to:
```scala
  @deprecated("Use getOrElse(k, null) instead.", "2.13.0")
```

* Extensive unit tests for behavior with respect to null values.


