### PR TITLE
Detect CallerSensitive in Java 9+

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -120,7 +120,12 @@ object BytecodeUtils {
 
   def isNativeMethod(methodNode: MethodNode): Boolean = (methodNode.access & ACC_NATIVE) != 0
 
-  def hasCallerSensitiveAnnotation(methodNode: MethodNode): Boolean = methodNode.visibleAnnotations != null && methodNode.visibleAnnotations.asScala.exists(_.desc == "Lsun/reflect/CallerSensitive;")
+  // cross-jdk
+  def hasCallerSensitiveAnnotation(methodNode: MethodNode): Boolean =
+    methodNode.visibleAnnotations != null &&
+    methodNode.visibleAnnotations.stream.filter(ann =>
+      ann.desc == "Lsun/reflect/CallerSensitive;" || ann.desc == "Ljdk/internal/reflect/CallerSensitive;"
+    ).findFirst.isPresent
 
   def isFinalClass(classNode: ClassNode): Boolean = (classNode.access & ACC_FINAL) != 0
 


### PR DESCRIPTION
The annotation's package was changed in Java 9.
This fix is already in the 2.13.x branch:

https://github.com/scala/scala/pull/6889/files#diff-79df42960bfb7be4f216dd68c8d73e60R124

I am hoping that this will fix the following error
when using the `-release` option:

Class sun.reflect.CallerSensitive not found - continuing with a stub

I haven't verified that yet, however.