### PR TITLE
fix performance regression in mutable.HashMap#getOrElseUpdate

### DIFF
--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -87,7 +87,7 @@ extends AbstractMap[A, B]
       // Repeat search
       // because evaluation of `default` can bring entry with `key`
       val secondEntry = findEntry(key, newEntryIndex)
-      if (secondEntry == null) addEntry0(e, newEntryIndex)
+      if (secondEntry == null) addEntry(e, newEntryIndex)
       else secondEntry.value = default
       default
     }


### PR DESCRIPTION
the change in question originated in https://github.com/scala/collection-strawman/pull/484. it was correct at the time because `HashTable#addEntry0` has a threshold check

but then when the  change was backported to 2.12.x in https://github.com/scala/scala/pull/6828, the `HashTable#addEntry0`call was replaced with a call to `HashMap#addEntry0`, which doesn't check the threshold. so if the table is only ever updated using `getOrElseUpdate`, the table's load factor would just keep climbing, resulting in poor performance

this was caught by my Project Euler solutions :-)