### PR TITLE
Improve VectorMap equals performance

### DIFF
--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -106,9 +106,30 @@ final class VectorMap[K, +V] private[immutable] (
   // Only care about content, not ordering for equality
   override def equals(that: Any): Boolean =
     that match {
-      case vmap: VectorMap[_, _] =>
-        underlying.size == vmap.underlying.size &&
-          underlying.mapValues(_._2).toMap == vmap.underlying.mapValues(_._2).toMap
+      case map: Map[K, V] =>
+        (this eq map) ||
+          (this.size == map.size) && {
+            try {
+              var i = 0
+              val _size = size
+              while (i < _size) {
+                val k = fields(i)
+
+                map.get(k) match {
+                  case Some(value) =>
+                    if (!(value == underlying(k)._2)) {
+                      return false
+                    }
+                  case None =>
+                    return false
+                }
+                i += 1
+              }
+              true
+            } catch {
+              case _: ClassCastException => false
+            }
+          }
       case _ => super.equals(that)
     }
 

--- a/test/scalacheck/VectorMap.scala
+++ b/test/scalacheck/VectorMap.scala
@@ -12,4 +12,19 @@ object VectorMapTest extends Properties("VectorMap") {
     val z = VectorMap(3 -> 4, 1 -> 2)
     x == y && y == z && x == z
   }
+
+  property("shuffle") = forAll { (m: Map[Int, Int]) =>
+    val asSeq = Seq.from(m)
+    val vm1 = VectorMap.from(asSeq)
+    val vm2 = VectorMap.from(scala.util.Random.shuffle(asSeq))
+    vm1 == vm2
+  }
+
+  property("notEqual") = forAll { (m1: Map[Int, Int], m2: Map[Int, Int]) =>
+    m1 != m2 ==> {
+      val vm1 = VectorMap.from(m1)
+      val vm2 = VectorMap.from(m2)
+      m1 != m2
+    }
+  }
 }


### PR DESCRIPTION
@Ichoran @joshlemer Here is the PR which improves the VectorMap equals performance. I mainly did the suggestions that @Ichoran provided.

@joshlemer Note that I don't think there is a valid general purpose sentinel value for maps in Scala (in context of short circuiting manually). I just used `return` instead, there shouldn't be a performance difference.

I also added more exhaustive equality property checks 