### PR TITLE
Optimize Constant.{equals,hashCode}

### DIFF
--- a/src/reflect/scala/reflect/internal/Constants.scala
+++ b/src/reflect/scala/reflect/internal/Constants.scala
@@ -83,7 +83,28 @@ trait Constants extends api.Constants {
     // !!! In what circumstance could `equalHashValue == that.equalHashValue && tag != that.tag` be true?
     override def equals(other: Any): Boolean = other match {
       case that: Constant =>
-        this.tag == that.tag && equalHashValue == that.equalHashValue
+        this.tag == that.tag && {
+          //
+          // Consider two `NaN`s to be identical, despite non-equality
+          // Consider -0d to be distinct from 0d, despite equality
+          //
+          // We use the raw versions (i.e. `floatToRawIntBits` rather than `floatToIntBits`)
+          // to avoid treating different encodings of `NaN` as the same constant.
+          // You probably can't express different `NaN` varieties as compile time
+          // constants in regular Scala code, but it is conceivable that you could
+          // conjure them with a macro.
+          //
+          this.tag match {
+            case NullTag =>
+              true
+            case FloatTag =>
+              floatToRawIntBits(value.asInstanceOf[Float]) == floatToRawIntBits(that.value.asInstanceOf[Float])
+            case DoubleTag =>
+              doubleToRawLongBits(value.asInstanceOf[Double]) == doubleToRawLongBits(that.value.asInstanceOf[Double])
+            case _ =>
+              this.value.equals(that.value)
+          }
+        }
       case _ => false
     }
 
@@ -243,28 +264,19 @@ trait Constants extends api.Constants {
     def typeValue: Type     = value.asInstanceOf[Type]
     def symbolValue: Symbol = value.asInstanceOf[Symbol]
 
-    /**
-     * Consider two `NaN`s to be identical, despite non-equality
-     * Consider -0d to be distinct from 0d, despite equality
-     *
-     * We use the raw versions (i.e. `floatToRawIntBits` rather than `floatToIntBits`)
-     * to avoid treating different encodings of `NaN` as the same constant.
-     * You probably can't express different `NaN` varieties as compile time
-     * constants in regular Scala code, but it is conceivable that you could
-     * conjure them with a macro.
-     */
-    private def equalHashValue: Any = value match {
-      case f: Float  => floatToRawIntBits(f)
-      case d: Double => doubleToRawLongBits(d)
-      case v         => v
-    }
-
     override def hashCode: Int = {
       import scala.util.hashing.MurmurHash3._
       val seed = 17
       var h = seed
       h = mix(h, tag.##) // include tag in the hash, otherwise 0, 0d, 0L, 0f collide.
-      h = mix(h, equalHashValue.##)
+      val valueHash = tag match {
+        case NullTag => 0
+        // We could just use value.hashCode here, at the cost of a collition between different NaNs
+        case FloatTag => java.lang.Integer.hashCode(floatToRawIntBits(value.asInstanceOf[Float]))
+        case DoubleTag => java.lang.Long.hashCode(doubleToRawLongBits(value.asInstanceOf[Double]))
+        case _ => value.hashCode()
+      }
+      h = mix(h, valueHash)
       finalizeHash(h, length = 2)
     }
   }


### PR DESCRIPTION
- Avoid boxing of the raw bits of double/floats before using them
   in equals/hashcode
 - Avoid cooperative equality by directly calling .equals / .hashCode
   for other values.

Fixes scala/scala-dev#542