### PR TITLE
Avoid a virtual call for Phase.erasedTypes

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -62,7 +62,7 @@ abstract class GenBCode extends SubComponent {
   class BCodePhase(prev: Phase) extends StdPhase(prev) {
     override def description = "Generate bytecode from ASTs using the ASM library"
 
-    override val erasedTypes = true
+    erasedTypes = true
 
     def apply(unit: CompilationUnit): Unit = codeGen.genUnit(unit)
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -62,8 +62,6 @@ abstract class GenBCode extends SubComponent {
   class BCodePhase(prev: Phase) extends StdPhase(prev) {
     override def description = "Generate bytecode from ASTs using the ASM library"
 
-    erasedTypes = true
-
     def apply(unit: CompilationUnit): Unit = codeGen.genUnit(unit)
 
     override def run(): Unit = {

--- a/src/reflect/scala/reflect/internal/Phase.scala
+++ b/src/reflect/scala/reflect/internal/Phase.scala
@@ -41,8 +41,9 @@ abstract class Phase(val prev: Phase) {
   def checkable: Boolean = true
 
   // NOTE: sbt injects its own phases which extend this class, and not GlobalPhase, so we must implement this logic here
-  private val _erasedTypes = ((prev ne null) && (prev ne NoPhase)) && (prev.name == "erasure" || prev.erasedTypes)
-  def erasedTypes: Boolean = _erasedTypes // overridden in back-end
+  private var _erasedTypes = ((prev ne null) && (prev ne NoPhase)) && (prev.name == "erasure" || prev.erasedTypes)
+  protected def erasedTypes_=(value: Boolean): Unit = {_erasedTypes = value}
+  final def erasedTypes: Boolean = _erasedTypes // overridden in back-end
   final val flatClasses: Boolean   = ((prev ne null) && (prev ne NoPhase)) && (prev.name == "flatten"    || prev.flatClasses)
   final val specialized: Boolean   = ((prev ne null) && (prev ne NoPhase)) && (prev.name == "specialize" || prev.specialized)
   final val refChecked: Boolean    = ((prev ne null) && (prev ne NoPhase)) && (prev.name == "refchecks"  || prev.refChecked)

--- a/src/reflect/scala/reflect/internal/Phase.scala
+++ b/src/reflect/scala/reflect/internal/Phase.scala
@@ -41,9 +41,7 @@ abstract class Phase(val prev: Phase) {
   def checkable: Boolean = true
 
   // NOTE: sbt injects its own phases which extend this class, and not GlobalPhase, so we must implement this logic here
-  private var _erasedTypes = ((prev ne null) && (prev ne NoPhase)) && (prev.name == "erasure" || prev.erasedTypes)
-  protected def erasedTypes_=(value: Boolean): Unit = {_erasedTypes = value}
-  final def erasedTypes: Boolean = _erasedTypes // overridden in back-end
+  final val erasedTypes: Boolean   = ((prev ne null) && (prev ne NoPhase)) && (prev.name == "erasure"    || prev.erasedTypes)
   final val flatClasses: Boolean   = ((prev ne null) && (prev ne NoPhase)) && (prev.name == "flatten"    || prev.flatClasses)
   final val specialized: Boolean   = ((prev ne null) && (prev ne NoPhase)) && (prev.name == "specialize" || prev.specialized)
   final val refChecked: Boolean    = ((prev ne null) && (prev ne NoPhase)) && (prev.name == "refchecks"  || prev.refChecked)


### PR DESCRIPTION
I can't quite untangle the history to know why things are setup
this way (maybe it goes back to the MSIL backend?).

But with this small refactor we can avoid the virtual call
overhead.