### PR TITLE
VectorBuilder#addAll and VectorIterator#copyToArray/addAll use System.arraycopy

### DIFF
--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorBenchmark.scala
@@ -1,0 +1,28 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.infra.Blackhole
+
+import org.openjdk.jmh.annotations._
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class VectorBenchmark {
+  @Param(Array("0", "10", "1000", "1000000"))
+  var size: Int = _
+  var vec: Vector[AnyRef] = _
+  val array = Array.fill(1000000)(new AnyRef)
+
+  @Setup(Level.Trial) def initKeys(): Unit = {
+    vec = Vector.fill(size)(new AnyRef)
+  }
+  @Benchmark def concat(bh: Blackhole): Any = {
+    bh.consume(vec.copyToArray(array, 0, size))
+  }
+}

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -64,6 +64,18 @@ class VectorTest {
   }
 
   @Test
+  def concat: Unit = {
+    assertEquals((1 to 100).toVector, (1 to 7).toVector concat (8 to 100).toVector)
+  }
+
+  @Test
+  def copyToArray: Unit = {
+    val array = Array.fill(100)(2)
+    Vector.fill(100)(1).copyToArray(array, 0, 100)
+    assertEquals(array.toSeq, Seq.fill(100)(1))
+  }
+
+  @Test
   def vectorIteratorDrop(): Unit = {
     val underlying = Vector(0 to 10010: _*)
 


### PR DESCRIPTION
This optimizes VectorBuilder#addAll and VectorIterator#copyToArray to use System.arraycopy rather than copying one-by-one, resulting in a pretty large improvement, if my benchmarks are valid:

```scala
  @Param(Array("0", "10", "1000", "1000000"))
  var size: Int = _
  var first: Vector[Int] = _
  var second: Vector[Int] = _

  @Setup(Level.Trial) def initKeys(): Unit = {
    first = (0 until size).toVector
    second = (0 until size).toVector
  }

  @Benchmark def concat(bh: Blackhole): Any = {
    bh.consume(first ++ second)
  }
```

```
With Optimization:

[info] Benchmark                (size)  Mode  Cnt         Score        Error  Units

[info] VectorBenchmark.concat        0  avgt   20       48.523 ±      1.596  ns/op
[info] VectorBenchmark.concat       10  avgt   20       65.017 ±      1.183  ns/op
[info] VectorBenchmark.concat     1000  avgt   20     2424.475 ±    108.181  ns/op
[info] VectorBenchmark.concat  1000000  avgt   20  6774195.422 ± 147708.690  ns/op


2.13.x

[info] Benchmark                (size)  Mode  Cnt         Score         Error  Units

[info] Benchmark                (size)  Mode  Cnt        Score        Error  Units
[info] VectorBenchmark.concat        0  avgt   20       51.239 ±      5.362  ns/op
[info] VectorBenchmark.concat       10  avgt   20      102.522 ±     23.212  ns/op
[info] VectorBenchmark.concat     1000  avgt   20     5844.086 ±    435.703  ns/op
[info] VectorBenchmark.concat  1000000  avgt   20  9860384.444 ± 165811.511  ns/op
```