### PR TITLE
Changing s.c.i.Vector.iterator to return Iterator.empty on empty

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -86,10 +86,14 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
     if (s.depth > 1) s.gotoPos(startIndex, startIndex ^ focus)
   }
 
-  override def iterator: VectorIterator[A] = {
-    val s = new VectorIterator[A](startIndex, endIndex)
-    initIterator(s)
-    s
+  override def iterator: Iterator[A] = {
+    if(isEmpty)
+      Iterator.empty
+    else {
+      val s = new VectorIterator[A](startIndex, endIndex)
+      initIterator(s)
+      s
+    }
   }
 
   // Ideally, clients will inline calls to map all the way down, including the iterator/builder methods.

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -50,4 +50,10 @@ class VectorTest {
   }
 
   @Test def checkSearch: Unit = SeqTests.checkSearch(Vector(0 to 1000: _*), 15,  implicitly[Ordering[Int]])
+
+  @Test
+  def emptyIteratorReuse(): Unit = {
+    assertSame(Vector.empty.iterator, Vector.empty.iterator)
+    assertSame(Vector.empty.iterator, Vector(1).drop(1).iterator)
+  }
 }


### PR DESCRIPTION
This means changing the method to return Iterator iso VectorIterator.