### PR TITLE
Add, move, and tidy up scaladoc variables around collections

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -863,7 +863,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     b.result()
   }
 
-  /** Finds the first element of the $coll for which the given partial function is defined, and applies the
+  /** Finds the first element of the array for which the given partial function is defined, and applies the
     * partial function to it. */
   def collectFirst[B](f: PartialFunction[A, B]): Option[B] = {
     var i = 0
@@ -929,7 +929,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *
     *  @param that     the iterable providing the second half of each result pair
     *  @param thisElem the element to be used to fill up the result if this array is shorter than `that`.
-    *  @param thatElem the element to be used to fill up the result if `that` is shorter than this $coll.
+    *  @param thatElem the element to be used to fill up the result if `that` is shorter than this array.
     *  @return        a new array containing pairs consisting of corresponding elements of this array and `that`.
     *                 The length of the returned array is the maximum of the lengths of this array and `that`.
     *                 If this array is shorter than `that`, `thisElem` values are used to pad the result.

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -11,24 +11,6 @@ import scala.collection.mutable.StringBuilder
   * A template trait for collections which can be traversed either once only
   * or one or more times.
   *
-  * @define orderDependent
-  *
-  *    Note: might return different results for different runs, unless the underlying collection type is ordered.
-  * @define orderDependentFold
-  *
-  *    Note: might return different results for different runs, unless the
-  *    underlying collection type is ordered or the operator is associative
-  *    and commutative.
-  * @define mayNotTerminateInf
-  *
-  *    Note: may not terminate for infinite-sized collections.
-  * @define willNotTerminateInf
-  *
-  *    Note: will not terminate for infinite-sized collections.
-  *
-  * @define willForceEvaluation
-  *    Note: Even when applied to a view or a lazy collection it will always force the elements.
-  *
   * @define coll collection
   */
 trait IterableOnce[+A] extends Any {
@@ -231,6 +213,41 @@ object IterableOnce {
 /** This implementation trait can be mixed into an `IterableOnce` to get the basic methods that are shared between
   * `Iterator` and `Iterable`. The `IterableOnce` must support multiple calls to `iterator` but may or may not
   * return the same `Iterator` every time.
+  *
+  * @define orderDependent
+  *
+  *              Note: might return different results for different runs, unless the underlying collection type is ordered.
+  * @define orderDependentFold
+  *
+  *              Note: might return different results for different runs, unless the
+  *              underlying collection type is ordered or the operator is associative
+  *              and commutative.
+  * @define mayNotTerminateInf
+  *
+  *              Note: may not terminate for infinite-sized collections.
+  * @define willNotTerminateInf
+  *
+  *              Note: will not terminate for infinite-sized collections.
+  * @define willForceEvaluation
+  *              Note: Even when applied to a view or a lazy collection it will always force the elements.
+  * @define consumesIterator
+  *              After calling this method, one should discard the iterator it was called
+  * on. Using it is undefined and subject to change.
+  * @define consumesAndProducesIterator
+  *              After calling this method, one should discard the iterator it was called
+  *              on, and use only the iterator that was returned. Using the old iterator
+  *              is undefined, subject to change, and may result in changes to the new
+  *              iterator as well.
+  * @define consumesOneAndProducesTwoIterators
+  *              After calling this method, one should discard the iterator it was called
+  *              on, and use only the iterators that were returned. Using the old iterator
+  *              is undefined, subject to change, and may result in changes to the new
+  *              iterators as well.
+  * @define undefinedorder
+  *              The order in which operations are performed on elements is unspecified
+  *              and may be nondeterministic.
+  * @define coll collection
+  *
   */
 trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
 
@@ -746,7 +763,6 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *
     *  $willNotTerminateInf
     */
-
   def copyToArray[B >: A](xs: Array[B], start: Int): Int = {
     val xsLen = xs.length
     val it = iterator

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -37,42 +37,29 @@ import scala.runtime.Statics
   * }
   * }}}
   *
-  * @define consumesIterator
-  * After calling this method, one should discard the iterator it was called
-  * on. Using it is undefined and subject to change.
-  *
-  *  @define willNotTerminateInf
-  *  Note: will not terminate for infinite iterators.
-  *  @define mayNotTerminateInf
+  * @define mayNotTerminateInf
   *  Note: may not terminate for infinite iterators.
-  *  @define preservesIterator
+  * @define preservesIterator
   *  The iterator remains valid for further use whatever result is returned.
-  *  @define consumesIterator
+  * @define consumesIterator
   *  After calling this method, one should discard the iterator it was called
   *  on. Using it is undefined and subject to change.
-  *  @define consumesAndProducesIterator
+  * @define consumesAndProducesIterator
   *  After calling this method, one should discard the iterator it was called
   *  on, and use only the iterator that was returned. Using the old iterator
   *  is undefined, subject to change, and may result in changes to the new
   *  iterator as well.
-  *  @define consumesTwoAndProducesOneIterator
+  * @define consumesTwoAndProducesOneIterator
   *  After calling this method, one should discard the iterator it was called
   *  on, as well as the one passed as a parameter, and use only the iterator
   *  that was returned. Using the old iterators is undefined, subject to change,
   *  and may result in changes to the new iterator as well.
-  *  @define consumesOneAndProducesTwoIterators
+  * @define consumesOneAndProducesTwoIterators
   *  After calling this method, one should discard the iterator it was called
   *  on, and use only the iterators that were returned. Using the old iterator
   *  is undefined, subject to change, and may result in changes to the new
   *  iterators as well.
-  *  @define consumesTwoIterators
-  *  After calling this method, one should discard the iterator it was called
-  *  on, as well as the one passed as parameter. Using the old iterators is
-  *  undefined and subject to change.
-  *  @define undefinedorder
-  *  The order in which operations are performed on elements is unspecified
-  *  and may be nondeterministic.
-  *  @define coll iterator
+  * @define coll iterator
   */
 trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Iterator[A]] { self =>
 

--- a/src/library/scala/collection/LazyZipOps.scala
+++ b/src/library/scala/collection/LazyZipOps.scala
@@ -2,7 +2,13 @@ package scala.collection
 
 import scala.language.implicitConversions
 
-/** Decorator representing lazily zipped pairs. */
+/** Decorator representing lazily zipped pairs.
+  *
+  * @define coll pair
+  * @define willNotTerminateInf
+  *
+  *              Note: will not terminate for infinite-sized collections.
+  */
 final class LazyZip2[+El1, +El2, C1] private[collection](src: C1, coll1: Iterable[El1], coll2: Iterable[El2]) {
 
   /** Zips `that` iterable collection with an existing `LazyZip2`. The elements in each collection are
@@ -113,7 +119,13 @@ object LazyZip2 {
 }
 
 
-/** Decorator representing lazily zipped triples. */
+/** Decorator representing lazily zipped triples.
+  *
+  * @define coll triple
+  * @define willNotTerminateInf
+  *
+  *              Note: will not terminate for infinite-sized collections.
+  */
 final class LazyZip3[+El1, +El2, +El3, C1] private[collection](src: C1,
                                                                coll1: Iterable[El1],
                                                                coll2: Iterable[El2],
@@ -237,7 +249,13 @@ object LazyZip3 {
 
 
 
-/** Decorator representing lazily zipped 4-tuples. */
+/** Decorator representing lazily zipped 4-tuples.
+  *
+  * @define coll tuple
+  * @define willNotTerminateInf
+  *
+  *              Note: will not terminate for infinite-sized collections.
+  */
 final class LazyZip4[+El1, +El2, +El3, +El4, C1] private[collection](src: C1,
                                                                      coll1: Iterable[El1],
                                                                      coll2: Iterable[El2],

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -64,11 +64,11 @@ object StringOps {
       }
     }
 
-    /** Builds a new collection by applying a function to all chars of this filtered String.
+    /** Builds a new collection by applying a function to all chars of this filtered string.
       *
       *  @param f      the function to apply to each char.
       *  @return       a new collection resulting from applying the given function
-      *                `f` to each char of this String and collecting the results.
+      *                `f` to each char of this string and collecting the results.
       */
     def map[B](f: Char => B): immutable.IndexedSeq[B] = {
       val len = s.length
@@ -83,11 +83,11 @@ object StringOps {
       b.result()
     }
 
-    /** Builds a new String by applying a function to all chars of this filtered String.
+    /** Builds a new string by applying a function to all chars of this filtered string.
       *
       *  @param f      the function to apply to each char.
-      *  @return       a new String resulting from applying the given function
-      *                `f` to each char of this String and collecting the results.
+      *  @return       a new string resulting from applying the given function
+      *                `f` to each char of this string and collecting the results.
       */
     def map(f: Char => Char): String = {
       val len = s.length
@@ -101,12 +101,12 @@ object StringOps {
       sb.toString
     }
 
-    /** Builds a new collection by applying a function to all chars of this filtered String
+    /** Builds a new collection by applying a function to all chars of this filtered string
       * and using the elements of the resulting collections.
       *
       *  @param f      the function to apply to each char.
       *  @return       a new collection resulting from applying the given collection-valued function
-      *                `f` to each char of this String and concatenating the results.
+      *                `f` to each char of this string and concatenating the results.
       */
     def flatMap[B](f: Char => IterableOnce[B]): immutable.IndexedSeq[B] = {
       val len = s.length
@@ -120,12 +120,12 @@ object StringOps {
       b.result()
     }
 
-    /** Builds a new String by applying a function to all chars of this filtered String
+    /** Builds a new string by applying a function to all chars of this filtered string
       * and using the elements of the resulting Strings.
       *
       *  @param f      the function to apply to each char.
-      *  @return       a new String resulting from applying the given string-valued function
-      *                `f` to each char of this String and concatenating the results.
+      *  @return       a new string resulting from applying the given string-valued function
+      *                `f` to each char of this string and concatenating the results.
       */
     def flatMap(f: Char => String): String = {
       val len = s.length
@@ -158,11 +158,11 @@ final class StringOps(private val s: String) extends AnyVal {
 
   def lengthCompare(len: Int): Int = Integer.compare(s.length, len)
 
-  /** Builds a new collection by applying a function to all chars of this String.
+  /** Builds a new collection by applying a function to all chars of this string.
     *
     *  @param f      the function to apply to each char.
     *  @return       a new collection resulting from applying the given function
-    *                `f` to each char of this String and collecting the results.
+    *                `f` to each char of this string and collecting the results.
     */
   def map[B](f: Char => B): immutable.IndexedSeq[B] = {
     val len = s.length
@@ -175,11 +175,11 @@ final class StringOps(private val s: String) extends AnyVal {
     new ArraySeq.ofRef(dst).asInstanceOf[immutable.IndexedSeq[B]]
   }
 
-  /** Builds a new String by applying a function to all chars of this String.
+  /** Builds a new string by applying a function to all chars of this string.
     *
     *  @param f      the function to apply to each char.
-    *  @return       a new String resulting from applying the given function
-    *                `f` to each char of this String and collecting the results.
+    *  @return       a new string resulting from applying the given function
+    *                `f` to each char of this string and collecting the results.
     */
   def map(f: Char => Char): String = {
     val len = s.length
@@ -192,12 +192,12 @@ final class StringOps(private val s: String) extends AnyVal {
     new String(dst)
   }
 
-  /** Builds a new collection by applying a function to all chars of this String
+  /** Builds a new collection by applying a function to all chars of this string
     * and using the elements of the resulting collections.
     *
     *  @param f      the function to apply to each char.
     *  @return       a new collection resulting from applying the given collection-valued function
-    *                `f` to each char of this String and concatenating the results.
+    *                `f` to each char of this string and concatenating the results.
     */
   def flatMap[B](f: Char => IterableOnce[B]): immutable.IndexedSeq[B] = {
     val len = s.length
@@ -210,12 +210,12 @@ final class StringOps(private val s: String) extends AnyVal {
     b.result()
   }
 
-  /** Builds a new String by applying a function to all chars of this String
-    * and using the elements of the resulting Strings.
+  /** Builds a new string by applying a function to all chars of this string
+    * and using the elements of the resulting strings.
     *
     *  @param f      the function to apply to each char.
-    *  @return       a new String resulting from applying the given string-valued function
-    *                `f` to each char of this String and concatenating the results.
+    *  @return       a new string resulting from applying the given string-valued function
+    *                `f` to each char of this string and concatenating the results.
     */
   def flatMap(f: Char => String): String = {
     val len = s.length
@@ -228,12 +228,12 @@ final class StringOps(private val s: String) extends AnyVal {
     sb.toString
   }
 
-  /** Returns a new collection containing the chars from this String followed by the elements from the
+  /** Returns a new collection containing the chars from this string followed by the elements from the
     * right hand operand.
     *
     *  @param suffix the collection to append.
     *  @return       a new collection which contains all chars
-    *                of this String followed by all elements of `suffix`.
+    *                of this string followed by all elements of `suffix`.
     */
   def concat[B >: Char](suffix: IterableOnce[B]): immutable.IndexedSeq[B] = {
     val b = immutable.IndexedSeq.newBuilder[B]
@@ -244,12 +244,12 @@ final class StringOps(private val s: String) extends AnyVal {
     b.result()
   }
 
-  /** Returns a new String containing the chars from this String followed by the chars from the
+  /** Returns a new string containing the chars from this string followed by the chars from the
     * right hand operand.
     *
     *  @param suffix the collection to append.
-    *  @return       a new String which contains all chars
-    *                of this String followed by all chars of `suffix`.
+    *  @return       a new string which contains all chars
+    *                of this string followed by all chars of `suffix`.
     */
   def concat(suffix: IterableOnce[Char]): String = {
     val k = suffix.knownSize
@@ -259,12 +259,12 @@ final class StringOps(private val s: String) extends AnyVal {
     sb.toString
   }
 
-  /** Returns a new String containing the chars from this String followed by the chars from the
+  /** Returns a new string containing the chars from this string followed by the chars from the
     * right hand operand.
     *
-    *  @param suffix the String to append.
-    *  @return       a new String which contains all chars
-    *                of this String followed by all chars of `suffix`.
+    *  @param suffix the string to append.
+    *  @return       a new string which contains all chars
+    *                of this string followed by all chars of `suffix`.
     */
   @`inline` def concat(suffix: String): String = s + suffix
 
@@ -282,7 +282,7 @@ final class StringOps(private val s: String) extends AnyVal {
     *  @param  len   the target length
     *  @param  elem  the padding value
     *  @return a collection consisting of
-    *          this String followed by the minimal number of occurrences of `elem` so
+    *          this string followed by the minimal number of occurrences of `elem` so
     *          that the resulting collection has a length of at least `len`.
     */
   def padTo[B >: Char](len: Int, elem: B): immutable.IndexedSeq[B]  = {
@@ -300,13 +300,13 @@ final class StringOps(private val s: String) extends AnyVal {
     }
   }
 
-  /** Returns a String with a char appended until a given target length is reached.
+  /** Returns a string with a char appended until a given target length is reached.
     *
     *  @param   len   the target length
     *  @param   elem  the padding value
-    *  @return a String consisting of
-    *          this String followed by the minimal number of occurrences of `elem` so
-    *          that the resulting String has a length of at least `len`.
+    *  @return a string consisting of
+    *          this string followed by the minimal number of occurrences of `elem` so
+    *          that the resulting string has a length of at least `len`.
     */
   def padTo(len: Int, elem: Char): String = {
     val sLen = s.length
@@ -324,7 +324,7 @@ final class StringOps(private val s: String) extends AnyVal {
     }
   }
 
-  /** A copy of the String with an element prepended */
+  /** A copy of the string with an element prepended */
   def prepended[B >: Char](elem: B): immutable.IndexedSeq[B] = {
     val b = immutable.IndexedSeq.newBuilder[B]
     b.sizeHint(s.length + 1)
@@ -336,14 +336,14 @@ final class StringOps(private val s: String) extends AnyVal {
   /** Alias for `prepended` */
   @`inline` def +: [B >: Char] (elem: B): immutable.IndexedSeq[B] = prepended(elem)
 
-  /** A copy of the String with an char prepended */
+  /** A copy of the string with an char prepended */
   def prepended(c: Char): String =
     new JStringBuilder(s.length + 1).append(c).append(s).toString
 
   /** Alias for `prepended` */
   @`inline` def +: (c: Char): String = prepended(c)
 
-  /** A copy of the String with all elements from a collection prepended */
+  /** A copy of the string with all elements from a collection prepended */
   def prependedAll[B >: Char](prefix: IterableOnce[B]): immutable.IndexedSeq[B] = {
     val b = immutable.IndexedSeq.newBuilder[B]
     val k = prefix.knownSize
@@ -356,13 +356,13 @@ final class StringOps(private val s: String) extends AnyVal {
   /** Alias for `prependedAll` */
   @`inline` def ++: [B >: Char] (prefix: IterableOnce[B]): immutable.IndexedSeq[B] = prependedAll(prefix)
 
-  /** A copy of the String with another String prepended */
+  /** A copy of the string with another string prepended */
   def prependedAll(prefix: String): String = prefix + s
 
   /** Alias for `prependedAll` */
   @`inline` def ++: (prefix: String): String = prependedAll(prefix)
 
-  /** A copy of the String with an element appended */
+  /** A copy of the string with an element appended */
   def appended[B >: Char](elem: B): immutable.IndexedSeq[B] = {
     val b = immutable.IndexedSeq.newBuilder[B]
     b.sizeHint(s.length + 1)
@@ -374,14 +374,14 @@ final class StringOps(private val s: String) extends AnyVal {
   /** Alias for `appended` */
   @`inline` def :+ [B >: Char](elem: B): immutable.IndexedSeq[B] = appended(elem)
 
-  /** A copy of the String with an element appended */
+  /** A copy of the string with an element appended */
   def appended(c: Char): String =
     new JStringBuilder(s.length + 1).append(s).append(c).toString
 
   /** Alias for `appended` */
   @`inline` def :+ (c: Char): String = appended(c)
 
-  /** A copy of the String with all elements from a collection appended */
+  /** A copy of the string with all elements from a collection appended */
   @`inline` def appendedAll[B >: Char](suffix: IterableOnce[B]): immutable.IndexedSeq[B] =
     concat(suffix)
 
@@ -389,22 +389,22 @@ final class StringOps(private val s: String) extends AnyVal {
   @`inline` def :++ [B >: Char](suffix: IterableOnce[B]): immutable.IndexedSeq[B] =
     concat(suffix)
 
-  /** A copy of the String with another String appended */
+  /** A copy of the string with another string appended */
   @`inline` def appendedAll(suffix: String): String = s + suffix
 
   /** Alias for `appendedAll` */
   @`inline` def :++ (suffix: String): String = s + suffix
 
-  /** Produces a new collection where a slice of characters in this String is replaced by another collection.
+  /** Produces a new collection where a slice of characters in this string is replaced by another collection.
     *
     * Patching at negative indices is the same as patching starting at 0.
-    * Patching at indices at or larger than the length of the original String appends the patch to the end.
+    * Patching at indices at or larger than the length of the original string appends the patch to the end.
     * If more values are replaced than actually exist, the excess is ignored.
     *
     *  @param  from     the index of the first replaced char
     *  @param  other    the replacement collection
-    *  @param  replaced the number of chars to drop in the original String
-    *  @return          a new collection consisting of all chars of this String
+    *  @param  replaced the number of chars to drop in the original string
+    *  @return          a new collection consisting of all chars of this string
     *                   except that `replaced` chars starting from `from` are replaced
     *                   by `other`.
     */
@@ -423,32 +423,32 @@ final class StringOps(private val s: String) extends AnyVal {
     b.result()
   }
 
-  /** Produces a new collection where a slice of characters in this String is replaced by another collection.
+  /** Produces a new collection where a slice of characters in this string is replaced by another collection.
     *
     * Patching at negative indices is the same as patching starting at 0.
-    * Patching at indices at or larger than the length of the original String appends the patch to the end.
+    * Patching at indices at or larger than the length of the original string appends the patch to the end.
     * If more values are replaced than actually exist, the excess is ignored.
     *
     *  @param  from     the index of the first replaced char
     *  @param  other    the replacement string
-    *  @param  replaced the number of chars to drop in the original String
-    *  @return          a new string consisting of all chars of this String
+    *  @param  replaced the number of chars to drop in the original string
+    *  @return          a new string consisting of all chars of this string
     *                   except that `replaced` chars starting from `from` are replaced
     *                   by `other`.
     */
   def patch(from: Int, other: IterableOnce[Char], replaced: Int): String =
     patch(from, other.iterator.mkString, replaced)
 
-  /** Produces a new String where a slice of characters in this String is replaced by another String.
+  /** Produces a new string where a slice of characters in this string is replaced by another string.
     *
     * Patching at negative indices is the same as patching starting at 0.
-    * Patching at indices at or larger than the length of the original String appends the patch to the end.
+    * Patching at indices at or larger than the length of the original string appends the patch to the end.
     * If more values are replaced than actually exist, the excess is ignored.
     *
     *  @param  from     the index of the first replaced char
-    *  @param  other    the replacement String
-    *  @param  replaced the number of chars to drop in the original String
-    *  @return          a new String consisting of all chars of this String
+    *  @param  other    the replacement string
+    *  @param  replaced the number of chars to drop in the original string
+    *  @return          a new string consisting of all chars of this string
     *                   except that `replaced` chars starting from `from` are replaced
     *                   by `other`.
     */
@@ -475,10 +475,10 @@ final class StringOps(private val s: String) extends AnyVal {
     sb.toString
   }
 
-  /** Tests whether this String contains the given character.
+  /** Tests whether this string contains the given character.
     *
     *  @param elem  the character to test.
-    *  @return     `true` if this String has an element that is equal (as
+    *  @return     `true` if this string has an element that is equal (as
     *              determined by `==`) to `elem`, `false` otherwise.
     */
   def contains(elem: Char): Boolean = s.indexOf(elem) >= 0
@@ -507,7 +507,7 @@ final class StringOps(private val s: String) extends AnyVal {
     if (sep.isEmpty || s.length < 2) s
     else mkString("", sep, "")
 
-  /** Returns this String */
+  /** Returns this string */
   @inline final def mkString: String = s
 
   /** Appends this string to a string builder. */
@@ -545,11 +545,11 @@ final class StringOps(private val s: String) extends AnyVal {
     *    from <= indexOf(x) < until
     *  }}}
     *
-    *  @param from   the lowest index to include from this $coll.
-    *  @param until  the lowest index to EXCLUDE from this $coll.
+    *  @param from   the lowest index to include from this string.
+    *  @param until  the lowest index to EXCLUDE from this string.
     *  @return  a string containing the elements greater than or equal to
     *           index `from` extending up to (but not including) index `until`
-    *           of this $coll.
+    *           of this string.
     */
   def slice(from: Int, until: Int): String = {
     val start = from max 0
@@ -1079,7 +1079,7 @@ final class StringOps(private val s: String) extends AnyVal {
     *        and `withFilter` operations.
     *
     *  @param p   the predicate used to test elements.
-    *  @return    an object of class `StringOps.WithFilter`, which supports
+    *  @return    an object of class `stringOps.WithFilter`, which supports
     *             `map`, `flatMap`, `foreach`, and `withFilter` operations.
     *             All these operations apply to those chars of this string
     *             which satisfy the predicate `p`.
@@ -1098,7 +1098,7 @@ final class StringOps(private val s: String) extends AnyVal {
   /** The rest of the string without its `n` first chars. */
   def drop(n: Int): String = slice(min(n, s.length), s.length)
 
-  /** An string containing the last `n` chars of this string. */
+  /** A string containing the last `n` chars of this string. */
   def takeRight(n: Int): String = drop(s.length - max(n, 0))
 
   /** The rest of the string without its `n` last chars. */


### PR DESCRIPTION
Partially fixes scala/collection-strawman#510:
- fixes doc generation errors in IterableOnceOps (and several others)
- does not address differences in IterableOps vs IterableOnceOps (future PR)

Mostly fixes scala/bug#10969:
- Addresses unbound references in the listed files and others
- Does not address any issues caused by the referenced bug scala/bug#9785

A couple questions I'd like some specific feedback on:
- StringOps defines a `$coll` variable but does not use that very much. Is it worth expanding the use of this variable or removing it entirely? This class does not rely much on inherited docs, nor are these docs inherited elsewhere.
- In StringOps, I adjusted all the docs to consistently capitalize `String`. Should ArrayOps do a similar thing for `Array`? 