### PR TITLE
Optimize s.c.i.HashMap builder 

### DIFF
--- a/src/library/scala/collection/immutable/ChampCommon.scala
+++ b/src/library/scala/collection/immutable/ChampCommon.scala
@@ -58,10 +58,28 @@ private[immutable] abstract class Node[T <: Node[T]] {
     result
   }
 
+  protected final def removeAnyElement(as: Array[Any], ix: Int): Array[Any] = {
+    if (ix < 0) throw new ArrayIndexOutOfBoundsException
+    if (ix > as.length - 1) throw new ArrayIndexOutOfBoundsException
+    val result = new Array[Any](as.length - 1)
+    arraycopy(as, 0, result, 0, ix)
+    arraycopy(as, ix + 1, result, ix, as.length - ix - 1)
+    result
+  }
+
   protected final def insertElement(as: Array[Int], ix: Int, elem: Int): Array[Int] = {
     if (ix < 0) throw new ArrayIndexOutOfBoundsException
     if (ix > as.length) throw new ArrayIndexOutOfBoundsException
     val result = new Array[Int](as.length + 1)
+    arraycopy(as, 0, result, 0, ix)
+    result(ix) = elem
+    arraycopy(as, ix, result, ix + 1, as.length - ix)
+    result
+  }
+  protected final def insertAnyElement(as: Array[Any], ix: Int, elem: Int): Array[Any] = {
+    if (ix < 0) throw new ArrayIndexOutOfBoundsException
+    if (ix > as.length) throw new ArrayIndexOutOfBoundsException
+    val result = new Array[Any](as.length + 1)
     arraycopy(as, 0, result, 0, ix)
     result(ix) = elem
     arraycopy(as, ix, result, ix + 1, as.length - ix)

--- a/src/library/scala/collection/immutable/ChampHashMap.scala
+++ b/src/library/scala/collection/immutable/ChampHashMap.scala
@@ -306,8 +306,9 @@ private final class BitmapIndexedMapNode[K, +V](
 
     if ((dataMap & bitpos) != 0) {
       val index = indexFrom(dataMap, mask, bitpos)
-      val key0 = this.getKey(index)
-      if (key0 == key) {
+      val key0 = getKey(index)
+      val key0UnimprovedHash = getHash(index)
+      if (key0UnimprovedHash == originalHash && key0 == key) {
         val value0 = this.getValue(index)
         return (
           if ((key0.asInstanceOf[AnyRef] eq key.asInstanceOf[AnyRef]) && (value0.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]))
@@ -316,7 +317,6 @@ private final class BitmapIndexedMapNode[K, +V](
         )
       } else {
         val value0 = this.getValue(index)
-        val key0UnimprovedHash = key0.##
         val key0Hash = improve(key0UnimprovedHash)
 
         val subNodeNew = mergeTwoKeyValPairs(key0, value0, key0UnimprovedHash, key0Hash, key, value, originalHash, keyHash, shift + BitPartitionSize)
@@ -943,17 +943,16 @@ private[immutable] final class HashMapBuilder[K, V] extends Builder[(K, V), Hash
         if ((bm.dataMap & bitpos) != 0) {
           val index = indexFrom(bm.dataMap, mask, bitpos)
           val key0 = bm.getKey(index)
+          val key0UnimprovedHash = bm.getHash(index)
 
-          if (key0 == key) {
+          if (key0UnimprovedHash == originalHash && key0 == key) {
             val value0 = mapNode.getValue(index)
             if (!((key0.asInstanceOf[AnyRef] eq key.asInstanceOf[AnyRef]) &&
               (value0.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]))) {
               setValue(bm, bitpos, key, value)
             }
           } else {
-
             val value0 = bm.getValue(index)
-            val key0UnimprovedHash = key0.##
             val key0Hash = improve(key0UnimprovedHash)
 
             val subNodeNew: MapNode[K, V] =

--- a/src/library/scala/collection/immutable/ChampHashMap.scala
+++ b/src/library/scala/collection/immutable/ChampHashMap.scala
@@ -946,11 +946,7 @@ private[immutable] final class HashMapBuilder[K, V] extends Builder[(K, V), Hash
           val key0UnimprovedHash = bm.getHash(index)
 
           if (key0UnimprovedHash == originalHash && key0 == key) {
-            val value0 = mapNode.getValue(index)
-            if (!((key0.asInstanceOf[AnyRef] eq key.asInstanceOf[AnyRef]) &&
-              (value0.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]))) {
-              setValue(bm, bitpos, key, value)
-            }
+            setValue(bm, bitpos, key, value)
           } else {
             val value0 = bm.getValue(index)
             val key0Hash = improve(key0UnimprovedHash)

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -5,7 +5,8 @@ package immutable
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.mutable.{Builder, ImmutableBuilder}
+import scala.collection.immutable.Map.Map4
+import scala.collection.mutable.Builder
 import scala.language.higherKinds
 
 
@@ -180,10 +181,7 @@ object Map extends MapFactory[Map] {
       case _ => (newBuilder[K, V] ++= it).result()
     }
 
-  def newBuilder[K, V]: Builder[(K, V), Map[K, V]] =
-    new ImmutableBuilder[(K, V), Map[K, V]](empty) {
-      def addOne(elem: (K, V)): this.type = { elems = elems + elem; this }
-    }
+  def newBuilder[K, V]: Builder[(K, V), Map[K, V]] = new MapBuilderImpl
 
   private object EmptyMap extends AbstractMap[Any, Nothing] {
     override def size: Int = 0
@@ -335,7 +333,16 @@ object Map extends MapFactory[Map] {
     }
   }
 
-  final class Map4[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V, key4: K, value4: V) extends AbstractMap[K, V] with StrictOptimizedIterableOps[(K, V), Iterable, Map[K, V]] {
+  final class Map4[K, +V](
+    private[collection] val key1: K,
+    private[collection] val value1: V,
+    private[collection] val key2: K,
+    private[collection] val value2: V,
+    private[collection] val key3: K,
+    private[collection] val value3: V,
+    private[collection] val key4: K,
+    private[collection] val value4: V) extends AbstractMap[K, V] with StrictOptimizedIterableOps[(K, V), Iterable, Map[K, V]] {
+
     override def size: Int = 4
     override def knownSize: Int = 4
     override def isEmpty: Boolean = false
@@ -410,3 +417,47 @@ object Map extends MapFactory[Map] {
 /** Explicit instantiation of the `Map` trait to reduce class file size in subclasses. */
 @SerialVersionUID(3L)
 abstract class AbstractMap[K, +V] extends scala.collection.AbstractMap[K, V] with Map[K, V]
+
+private[collection] final class MapBuilderImpl[K, V] extends Builder[(K, V), Map[K, V]] {
+  private[this] var elems: Map[K, V] = Map.empty
+  private[this] var hashMapBuilder: HashMapBuilder[K, V] = _
+
+  override def clear(): Unit = {
+    elems = Map.empty
+    if (hashMapBuilder != null) {
+      hashMapBuilder.clear()
+    }
+  }
+
+  override def result(): Map[K, V] = {
+    if (hashMapBuilder == null || hashMapBuilder.size == 0) {
+      elems
+    } else if (elems.size == 4) {
+      val map4 = elems.asInstanceOf[Map4[K, V]]
+
+      hashMapBuilder.addOneIfNotExists(map4.key1, map4.value1)
+      hashMapBuilder.addOneIfNotExists(map4.key2, map4.value2)
+      hashMapBuilder.addOneIfNotExists(map4.key3, map4.value3)
+      hashMapBuilder.addOneIfNotExists(map4.key4, map4.value4)
+
+      hashMapBuilder.result()
+    } else {
+      // should never happen...
+      elems.foreach { case (k, v) => hashMapBuilder.addOneIfNotExists(k, v) }
+      hashMapBuilder.result()
+    }
+  }
+  override def addOne(elem: (K, V)) = {
+    if (elems.size < 4) {
+      elems = elems + elem
+    } else {
+      if (hashMapBuilder == null) {
+        hashMapBuilder = new HashMapBuilder
+      }
+
+      hashMapBuilder.addOne(elem)
+    }
+
+    this
+  }
+}

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashMapBenchmark.scala
@@ -37,12 +37,19 @@ class HashMapBenchmark {
 
   var map: collection.immutable.Map[Any, Any] = null
 
+  var map2: collection.immutable.Map[Any, Any] = null
+
   @Setup(Level.Trial) def initialize = {
     map = collection.immutable.Map(existingKeys.map(x => (x, x)) : _*)
+    map2 = collection.immutable.Map(existingKeys.splitAt(10)._1.map(x => (x, (x, x))) ++ missingKeys.map(x => (x, x)) : _*)
+  }
+
+  @Benchmark def concat(bh: Blackhole): Unit = {
+    bh.consume(map concat map2)
   }
 
   @Benchmark def contains(bh: Blackhole): Unit = {
-    var i = 0;
+    var i = 0
     while (i < size) {
       bh.consume(map.contains(existingKeys(i)))
       if (useMissingValues) {
@@ -53,7 +60,7 @@ class HashMapBenchmark {
   }
 
   @Benchmark def get(bh: Blackhole): Unit = {
-    var i = 0;
+    var i = 0
     while (i < size) {
       bh.consume(map.get(existingKeys(i)))
       if (useMissingValues) {
@@ -64,11 +71,21 @@ class HashMapBenchmark {
   }
 
   @Benchmark def getOrElse(bh: Blackhole): Unit = {
-    var i = 0;
+    var i = 0
     while (i < size) {
       bh.consume(map.getOrElse(existingKeys(i), ""))
       if (useMissingValues) {
         bh.consume(map.getOrElse(missingKeys(i), ""))
+      }
+      i += 1
+    }
+  }
+  @Benchmark def updated(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < size) {
+      bh.consume(map.updated(existingKeys(i), ""))
+      if (useMissingValues) {
+        bh.consume(map.updated(missingKeys(i), ""))
       }
       i += 1
     }

--- a/test/junit/scala/collection/immutable/HashMapTest.scala
+++ b/test/junit/scala/collection/immutable/HashMapTest.scala
@@ -113,3 +113,4 @@ class HashMapTest {
     assertEquals(merged, expected)
   }
 }
+


### PR DESCRIPTION
Improve performance of immutable.{Map,(Champ)HashMap} builders

* Build up the Trie mutably within the builder, rather than relying on
`immutable.HashMap.updated` that requires copies of the path of
nodes from root to the insertion point (and of the `ChampHashMap`
instance itself.)

* A further optimization is possible when adding an entire
`HashMap` to the builder: we can avoid recomputing the hashes.

* Because the champ nodes now have vars rather than vals, we need to
explicitly use `releaseFence` at the conclusion of their constructor
and after the builder publishes a mutated node in a result to ensure
that the results can be safely shared to other threads without other
synchronization.

* The builder keeps track of whether `result()` has been called, and
ensures that the subsequent additions are _not_ reflected in the
built collection.

* The builder for `immutable.Map` still returns `Map{1,2,3,4}` for small
resulting collections, but otherwise delegates to `HashMapBuilder`
to build up the rest of the collection.

Followup work will make the same changes to `HashSet`, apply
similar optimizations to map merging and set union, etc.

Here are some benchmarks
```
[info] Benchmark                                                          (size)  (stringsOnly)  (useMissingValues)  Mode  Cnt       Score       Error   Units
[info] HashMapBenchmark.buildMapHashMap                                       10          false                true  avgt   20    1951.702 ±   593.702   ns/op
[info] HashMapBenchmark.buildMapHashMap:·gc.alloc.rate                        10          false                true  avgt   20    1126.445 ±   226.404  MB/sec
[info] HashMapBenchmark.buildMapHashMap:·gc.alloc.rate.norm                   10          false                true  avgt   20    3204.004 ±    32.072    B/op
[info] HashMapBenchmark.buildMapHashMap:·gc.churn.PS_Eden_Space               10          false                true  avgt   20    1129.798 ±   224.233  MB/sec
[info] HashMapBenchmark.buildMapHashMap:·gc.churn.PS_Eden_Space.norm          10          false                true  avgt   20    3218.978 ±    94.791    B/op
[info] HashMapBenchmark.buildMapHashMap:·gc.churn.PS_Survivor_Space           10          false                true  avgt   20       0.105 ±     0.036  MB/sec
[info] HashMapBenchmark.buildMapHashMap:·gc.churn.PS_Survivor_Space.norm      10          false                true  avgt   20       0.297 ±     0.073    B/op
[info] HashMapBenchmark.buildMapHashMap:·gc.count                             10          false                true  avgt   20     254.000              counts
[info] HashMapBenchmark.buildMapHashMap:·gc.time                              10          false                true  avgt   20     165.000                  ms
[info] HashMapBenchmark.buildMapHashMap                                      100          false                true  avgt   20   19627.993 ±  1077.523   ns/op
[info] HashMapBenchmark.buildMapHashMap:·gc.alloc.rate                       100          false                true  avgt   20    1083.941 ±    59.880  MB/sec
[info] HashMapBenchmark.buildMapHashMap:·gc.alloc.rate.norm                  100          false                true  avgt   20   33384.032 ±     0.063    B/op
[info] HashMapBenchmark.buildMapHashMap:·gc.churn.PS_Eden_Space              100          false                true  avgt   20    1077.024 ±    58.008  MB/sec
[info] HashMapBenchmark.buildMapHashMap:·gc.churn.PS_Eden_Space.norm         100          false                true  avgt   20   33194.524 ±  1016.788    B/op
[info] HashMapBenchmark.buildMapHashMap:·gc.churn.PS_Survivor_Space          100          false                true  avgt   20       0.093 ±     0.036  MB/sec
[info] HashMapBenchmark.buildMapHashMap:·gc.churn.PS_Survivor_Space.norm     100          false                true  avgt   20       2.907 ±     1.153    B/op
[info] HashMapBenchmark.buildMapHashMap:·gc.count                            100          false                true  avgt   20     308.000              counts
[info] HashMapBenchmark.buildMapHashMap:·gc.time                             100          false                true  avgt   20     180.000                  ms
[info] HashMapBenchmark.buildMapHashMap                                     1000          false                true  avgt   20  324747.300 ± 54596.109   ns/op
[info] HashMapBenchmark.buildMapHashMap:·gc.alloc.rate                      1000          false                true  avgt   20     876.906 ±    93.334  MB/sec
[info] HashMapBenchmark.buildMapHashMap:·gc.alloc.rate.norm                 1000          false                true  avgt   20  438732.513 ±  7472.990    B/op
[info] HashMapBenchmark.buildMapHashMap:·gc.churn.PS_Eden_Space             1000          false                true  avgt   20     881.497 ±   101.118  MB/sec
[info] HashMapBenchmark.buildMapHashMap:·gc.churn.PS_Eden_Space.norm        1000          false                true  avgt   20  440682.138 ± 18493.464    B/op
[info] HashMapBenchmark.buildMapHashMap:·gc.churn.PS_Survivor_Space         1000          false                true  avgt   20       0.062 ±     0.027  MB/sec
[info] HashMapBenchmark.buildMapHashMap:·gc.churn.PS_Survivor_Space.norm    1000          false                true  avgt   20      31.869 ±    14.535    B/op
[info] HashMapBenchmark.buildMapHashMap:·gc.count                           1000          false                true  avgt   20     273.000              counts
[info] HashMapBenchmark.buildMapHashMap:·gc.time                            1000          false                true  avgt   20     171.000                  ms
[info] HashMapBenchmark.buildMapNew                                           10          false                true  avgt   20    1881.001 ±   107.424   ns/op
[info] HashMapBenchmark.buildMapNew:·gc.alloc.rate                            10          false                true  avgt   20    1142.764 ±    59.821  MB/sec
[info] HashMapBenchmark.buildMapNew:·gc.alloc.rate.norm                       10          false                true  avgt   20    3372.003 ±    32.073    B/op
[info] HashMapBenchmark.buildMapNew:·gc.churn.PS_Eden_Space                   10          false                true  avgt   20    1148.765 ±    73.060  MB/sec
[info] HashMapBenchmark.buildMapNew:·gc.churn.PS_Eden_Space.norm              10          false                true  avgt   20    3389.432 ±   129.289    B/op
[info] HashMapBenchmark.buildMapNew:·gc.churn.PS_Survivor_Space               10          false                true  avgt   20       0.116 ±     0.031  MB/sec
[info] HashMapBenchmark.buildMapNew:·gc.churn.PS_Survivor_Space.norm          10          false                true  avgt   20       0.345 ±     0.098    B/op
[info] HashMapBenchmark.buildMapNew:·gc.count                                 10          false                true  avgt   20     302.000              counts
[info] HashMapBenchmark.buildMapNew:·gc.time                                  10          false                true  avgt   20     189.000                  ms
[info] HashMapBenchmark.buildMapNew                                          100          false                true  avgt   20   21286.490 ±  3746.258   ns/op
[info] HashMapBenchmark.buildMapNew:·gc.alloc.rate                           100          false                true  avgt   20    1046.092 ±   129.660  MB/sec
[info] HashMapBenchmark.buildMapNew:·gc.alloc.rate.norm                      100          false                true  avgt   20   34140.033 ±   523.857    B/op
[info] HashMapBenchmark.buildMapNew:·gc.churn.PS_Eden_Space                  100          false                true  avgt   20    1047.725 ±   124.149  MB/sec
[info] HashMapBenchmark.buildMapNew:·gc.churn.PS_Eden_Space.norm             100          false                true  avgt   20   34288.417 ±  1556.271    B/op
[info] HashMapBenchmark.buildMapNew:·gc.churn.PS_Survivor_Space              100          false                true  avgt   20       0.083 ±     0.030  MB/sec
[info] HashMapBenchmark.buildMapNew:·gc.churn.PS_Survivor_Space.norm         100          false                true  avgt   20       2.702 ±     0.919    B/op
[info] HashMapBenchmark.buildMapNew:·gc.count                                100          false                true  avgt   20     292.000              counts
[info] HashMapBenchmark.buildMapNew:·gc.time                                 100          false                true  avgt   20     176.000                  ms
[info] HashMapBenchmark.buildMapNew                                         1000          false                true  avgt   20  349762.891 ± 41296.354   ns/op
[info] HashMapBenchmark.buildMapNew:·gc.alloc.rate                          1000          false                true  avgt   20     793.985 ±    84.506  MB/sec
[info] HashMapBenchmark.buildMapNew:·gc.alloc.rate.norm                     1000          false                true  avgt   20  430512.558 ±     1.086    B/op
[info] HashMapBenchmark.buildMapNew:·gc.churn.PS_Eden_Space                 1000          false                true  avgt   20     794.083 ±    89.928  MB/sec
[info] HashMapBenchmark.buildMapNew:·gc.churn.PS_Eden_Space.norm            1000          false                true  avgt   20  430664.192 ± 18367.155    B/op
[info] HashMapBenchmark.buildMapNew:·gc.churn.PS_Survivor_Space             1000          false                true  avgt   20       0.080 ±     0.034  MB/sec
[info] HashMapBenchmark.buildMapNew:·gc.churn.PS_Survivor_Space.norm        1000          false                true  avgt   20      44.501 ±    19.874    B/op
[info] HashMapBenchmark.buildMapNew:·gc.count                               1000          false                true  avgt   20     239.000              counts
[info] HashMapBenchmark.buildMapNew:·gc.time                                1000          false                true  avgt   20     160.000                  ms
[info] HashMapBenchmark.buildMapOld                                           10          false                true  avgt   20    2071.745 ±    61.394   ns/op
[info] HashMapBenchmark.buildMapOld:·gc.alloc.rate                            10          false                true  avgt   20    1401.500 ±    40.315  MB/sec
[info] HashMapBenchmark.buildMapOld:·gc.alloc.rate.norm                       10          false                true  avgt   20    4568.004 ±     0.007    B/op
[info] HashMapBenchmark.buildMapOld:·gc.churn.PS_Eden_Space                   10          false                true  avgt   20    1393.642 ±    82.045  MB/sec
[info] HashMapBenchmark.buildMapOld:·gc.churn.PS_Eden_Space.norm              10          false                true  avgt   20    4541.095 ±   214.839    B/op
[info] HashMapBenchmark.buildMapOld:·gc.churn.PS_Survivor_Space               10          false                true  avgt   20       0.096 ±     0.031  MB/sec
[info] HashMapBenchmark.buildMapOld:·gc.churn.PS_Survivor_Space.norm          10          false                true  avgt   20       0.314 ±     0.100    B/op
[info] HashMapBenchmark.buildMapOld:·gc.count                                 10          false                true  avgt   20     270.000              counts
[info] HashMapBenchmark.buildMapOld:·gc.time                                  10          false                true  avgt   20     175.000                  ms
[info] HashMapBenchmark.buildMapOld                                          100          false                true  avgt   20   24004.461 ±  5799.477   ns/op
[info] HashMapBenchmark.buildMapOld:·gc.alloc.rate                           100          false                true  avgt   20    1944.073 ±   272.469  MB/sec
[info] HashMapBenchmark.buildMapOld:·gc.alloc.rate.norm                      100          false                true  avgt   20   70460.038 ±   523.855    B/op
[info] HashMapBenchmark.buildMapOld:·gc.churn.PS_Eden_Space                  100          false                true  avgt   20    1942.113 ±   288.716  MB/sec
[info] HashMapBenchmark.buildMapOld:·gc.churn.PS_Eden_Space.norm             100          false                true  avgt   20   70294.376 ±  2725.173    B/op
[info] HashMapBenchmark.buildMapOld:·gc.churn.PS_Survivor_Space              100          false                true  avgt   20       0.105 ±     0.030  MB/sec
[info] HashMapBenchmark.buildMapOld:·gc.churn.PS_Survivor_Space.norm         100          false                true  avgt   20       3.784 ±     0.938    B/op
[info] HashMapBenchmark.buildMapOld:·gc.count                                100          false                true  avgt   20     305.000              counts
[info] HashMapBenchmark.buildMapOld:·gc.time                                 100          false                true  avgt   20     179.000                  ms
[info] HashMapBenchmark.buildMapOld                                         1000          false                true  avgt   20  351007.553 ± 13521.110   ns/op
[info] HashMapBenchmark.buildMapOld:·gc.alloc.rate                          1000          false                true  avgt   20    1801.661 ±    61.878  MB/sec
[info] HashMapBenchmark.buildMapOld:·gc.alloc.rate.norm                     1000          false                true  avgt   20  994816.585 ±     1.158    B/op
[info] HashMapBenchmark.buildMapOld:·gc.churn.PS_Eden_Space                 1000          false                true  avgt   20    1796.874 ±    75.349  MB/sec
[info] HashMapBenchmark.buildMapOld:·gc.churn.PS_Eden_Space.norm            1000          false                true  avgt   20  992284.009 ± 26410.210    B/op
[info] HashMapBenchmark.buildMapOld:·gc.churn.PS_Survivor_Space             1000          false                true  avgt   20       0.062 ±     0.023  MB/sec
[info] HashMapBenchmark.buildMapOld:·gc.churn.PS_Survivor_Space.norm        1000          false                true  avgt   20      34.544 ±    12.769    B/op
[info] HashMapBenchmark.buildMapOld:·gc.count                               1000          false                true  avgt   20     315.000              counts
[info] HashMapBenchmark.buildMapOld:·gc.time                                1000          false                true  avgt   20     179.000                  ms
```

Which run from the following code
```scala
  var keyValues: Array[(Any, Any)] = _
  var keyValues2: Array[(Any, Any)] = _
  
  @Setup(Level.Trial) def initKeys(): Unit = {
    keyValues = (1 to size).map(i => i.toString -> i).toArray
    keyValues2 = (size to 2 * size).map(i => i.toString -> i).toArray
  }

  def build(b: mutable.Builder[(Any, Any), Map[Any, Any]]): Map[Any, Any] = {
    var i = 0
    while (i < keyValues.length) {
      b.addOne(keyValues(i))
      i += 1
    }
    i = 0
    while (i < keyValues.length) {
      b.addOne(keyValues(i))
      i += 1
    }
    i = 0
    while (i < keyValues2.length) {
      b.addOne(keyValues2(i))
      i += 1
    }
    b.result()
  }
  
  def newImmutableBuilder() = new mutable.ImmutableBuilder[(Any, Any), Map[Any, Any]](Map.empty) {
    override def addOne(elem: (Any, Any)) = {
      elems = elems.updated(elem._1, elem._2)
      this
    }
  }
  @Benchmark def buildMapNew(bh: Blackhole): Unit = bh.consume(build(Map.newBuilder))
  @Benchmark def buildMapOld(bh: Blackhole): Unit = bh.consume(build(newImmutableBuilder()))
  @Benchmark def buildMapHashMap(bh: Blackhole): Unit = bh.consume(build(HashMap.newBuilder))
```
