### PR TITLE
Separate compilation of inferred type constructors should not crash asSeenFrom (nor cause spurious recompilation)

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -96,15 +96,16 @@ abstract class Pickler extends SubComponent {
     private def isRootSym(sym: Symbol) =
       sym.name.toTermName == rootName && sym.owner == rootOwner
 
-    /** Returns usually symbol's owner, but picks classfile root instead
-     *  for existentially bound variables that have a non-local owner.
-     *  Question: Should this be done for refinement class symbols as well?
-     *
-     *  Note: tree pickling also finds its way here; e.g. in scala/bug#7501 the pickling
-     *  of trees in annotation arguments considers the parameter symbol of a method
-     *  called in such a tree as "local". The condition `sym.isValueParameter` was
-     *  added to fix that bug, but there may be a better way.
-     */
+    /** Usually `sym.owner`, except when `sym` is pickle-local, while `sym.owner` is not.
+      *
+      * In the latter case, the alternative owner is the pickle root,
+      * or a non-class owner of root (so that term-owned parameters remain term-owned).
+      *
+      * Note: tree pickling also finds its way here; e.g. in scala/bug#7501 the pickling
+      * of trees in annotation arguments considers the parameter symbol of a method
+      * called in such a tree as "local". The condition `sym.isValueParameter` was
+      * added to fix that bug, but there may be a better way.
+      */
     private def localizedOwner(sym: Symbol) =
       if (isLocalToPickle(sym) && !isRootSym(sym) && !isLocalToPickle(sym.owner))
         // don't use a class as the localized owner for type parameters that are not owned by a class: those are not instantiated by asSeenFrom

--- a/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
@@ -224,9 +224,25 @@ trait PatternTypers {
      */
     private def convertToCaseConstructor(tree: Tree, caseClass: Symbol, ptIn: Type): Tree = {
       val variantToSkolem     = new VariantToSkolemMap
-      val caseClassType       = tree.tpe.prefix memberType caseClass
-      val caseConstructorType = caseClassType memberType caseClass.primaryConstructor
-      val tree1               = TypeTree(caseConstructorType) setOriginal tree
+
+      //  `caseClassType` is the prefix from which we're seeing the constructor info, so it must be kind *.
+      // Need the `initialize` call to make sure we see any type params.
+      val caseClassType       = caseClass.initialize.tpe_*.asSeenFrom(tree.tpe.prefix, caseClass.owner)
+      assert(!caseClassType.isHigherKinded, s"Unexpected type constructor $caseClassType")
+
+      // If the case class is polymorphic, need to capture those type params in the type that we relativize using asSeenFrom,
+      // as they may also be sensitive to the prefix (see test/files/pos/t11103.scala).
+      // Note that undetParams may thus be different from caseClass.typeParams.
+      // (For a monomorphic case class, GenPolyType will not create/destruct a PolyType.)
+      val (undetparams, caseConstructorType) =
+        GenPolyType.unapply {
+          val ctorUnderClassTypeParams = GenPolyType(caseClass.typeParams, caseClass.primaryConstructor.info)
+          ctorUnderClassTypeParams.asSeenFrom(caseClassType, caseClass)
+        }.get
+
+      // println(s"convertToCaseConstructor(${tree.tpe}, $caseClass, $ptIn) // $caseClassType // ${caseConstructorType.typeParams.map(_.info)}")
+
+      val tree1 = TypeTree(caseConstructorType) setOriginal tree
 
       // have to open up the existential and put the skolems in scope
       // can't simply package up pt in an ExistentialType, because that takes us back to square one (List[_ <: T] == List[T] due to covariance)
@@ -237,7 +253,7 @@ trait PatternTypers {
       // as instantiateTypeVar's bounds would end up there
       val ctorContext = context.makeNewScope(tree, context.owner)
       freeVars foreach ctorContext.scope.enter
-      newTyper(ctorContext).infer.inferConstructorInstance(tree1, caseClass.typeParams, ptSafe)
+      newTyper(ctorContext).infer.inferConstructorInstance(tree1, undetparams, ptSafe)
 
       // simplify types without losing safety,
       // so that we get rid of unnecessary type slack, and so that error messages don't unnecessarily refer to skolems

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4049,23 +4049,11 @@ trait Types
 
   /** A creator and extractor for type parameterizations that strips empty type parameter lists.
    *  Use this factory method to indicate the type has kind * (it's a polymorphic value)
-   *  until we start tracking explicit kinds equivalent to typeFun (except that the latter requires tparams nonEmpty).
-   *
-   *  PP to AM: I've co-opted this for where I know tparams may well be empty, and
-   *  expecting to get back `tpe` in such cases.  Re being "forgiving" below,
-   *  can we instead say this is the canonical creator for polyTypes which
-   *  may or may not be poly? (It filched the standard "canonical creator" name.)
    */
   object GenPolyType {
-    def apply(tparams: List[Symbol], tpe: Type): Type = {
-      tpe match {
-        case MethodType(_, _) =>
-          assert(tparams forall (_.isInvariant), "Trying to create a method with variant type parameters: " + ((tparams, tpe)))
-        case _                =>
-      }
-      if (tparams.nonEmpty) typeFun(tparams, tpe)
-      else tpe // it's okay to be forgiving here
-    }
+    def apply(tparams: List[Symbol], tpe: Type): Type =
+      if (tparams.isEmpty) tpe else PolyType(tparams, tpe)
+
     def unapply(tpe: Type): Option[(List[Symbol], Type)] = tpe match {
       case PolyType(tparams, restpe) => Some((tparams, restpe))
       case _                         => Some((Nil, tpe))

--- a/test/files/neg/hk-typevar-unification.check
+++ b/test/files/neg/hk-typevar-unification.check
@@ -1,6 +1,6 @@
 hk-typevar-unification.scala:16: error: inferred kinds of the type arguments ([_ <: B]Foo[_]) do not conform to the expected kinds of the type parameters (type F).
 [_ <: B]Foo[_]'s type parameters do not match type F's expected parameters:
-type _ (in class Foo)'s bounds <: B are stricter than type _'s declared bounds >: Nothing <: Any
+type _'s bounds <: B are stricter than type _'s declared bounds >: Nothing <: Any
   f(tcFoo)
   ^
 hk-typevar-unification.scala:16: error: type mismatch;
@@ -10,8 +10,8 @@ hk-typevar-unification.scala:16: error: type mismatch;
     ^
 hk-typevar-unification.scala:19: error: inferred kinds of the type arguments ([_ <: B]Foo[_]) do not conform to the expected kinds of the type parameters (type F).
 [_ <: B]Foo[_]'s type parameters do not match type F's expected parameters:
-type _ (in class Foo) is invariant, but type _ is declared covariant
-type _ (in class Foo)'s bounds <: B are stricter than type _'s declared bounds >: Nothing <: Any
+type _ is invariant, but type _ is declared covariant
+type _'s bounds <: B are stricter than type _'s declared bounds >: Nothing <: Any
   g(tcFoo)
   ^
 hk-typevar-unification.scala:19: error: type mismatch;

--- a/test/files/pos/t10762/t10762_1.scala
+++ b/test/files/pos/t10762/t10762_1.scala
@@ -1,0 +1,12 @@
+import language.higherKinds
+
+trait Tycon[A]
+trait MatcherFactory1X[TC1[_]]
+trait Matcher[T]{
+  class X {
+        def be = {
+      def inferTycon[TC1[_]](other: MatcherFactory1X[TC1]): MatcherFactory1X[TC1] = ???
+          inferTycon(??? : MatcherFactory1X[Tycon])
+        }
+  }
+}

--- a/test/files/pos/t10762/t10762_2.scala
+++ b/test/files/pos/t10762/t10762_2.scala
@@ -1,0 +1,4 @@
+object Test {
+  val m: Matcher[_] = ???
+  val tpinfer = (new m.X).be
+}

--- a/test/files/pos/t11103.scala
+++ b/test/files/pos/t11103.scala
@@ -1,0 +1,12 @@
+trait Outer[O] {
+  case class C[T <: O](x: T, y: Outer.this.type)
+}
+
+object Foo extends Outer[String]
+
+class Tst {
+  val c = new Foo.C("a", Foo)
+  c match {
+    case Foo.C(a, o) => a
+  }
+}


### PR DESCRIPTION
While trying to fix scala/bug#10762, I stumbled on scala/bug#11103, which we'll try/have to fix first. 

When you drill down to the info of a member of a polymorphic class, you should remember to push down the type params of the class by re-wrapping the info of the member in a PolyType, so that, then when you relativize the info of the member relative to the class and its corresponding prefix (used as its this type, which should thus have kind *), you also rewrite the info of the type params, which may be affected as illustrated by the test case pos/t11103.scala.

A similar problem arose in etaExpand. Use the rewritten type parameters in typeNew.

Dotty has a neat solution through denotations, we need to take care...
 
The real problem we're trying to solve is spurious recompilation and ASF crashes due to eta expansion reusing the class owning the type params as the owner for the binders in the resulting PolyType. 

Changing the owner of the binders used for eta-expansion, weirdly revealed a problem with typing annotations, where, I assume, reuse of the class type params hid the missing logic for dealing with polymorphic annotation classes and the undetparams that arise of typing their instantiation.


H/T @retronym for spotting the dodgy `tree.tpe.prefix memberType caseClass`. As no good deed goes unpunished, also review by –.

Fixes scala/bug#11103
Fixes scala/bug#10762