### PR TITLE
Fix VectorMap `init`, and `tail` methods; and partially fix `remove`

### DIFF
--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -20,13 +20,12 @@ import scala.annotation.unchecked.{uncheckedVariance => uV}
   * @define Coll `immutable.VectorMap`
   */
 final class VectorMap[K, +V] private[immutable] (
-    private val fields: Vector[K],
-    private val underlying: Map[K, (Int, V)])
+    private[immutable] val fields: Vector[K],
+    private[immutable] val underlying: Map[K, (Int, V)])
     extends AbstractMap[K, V]
     with SeqMap[K, V]
     with MapOps[K, V, VectorMap, VectorMap[K, V]]
     with StrictOptimizedIterableOps[(K, V), Iterable, VectorMap[K, V]] {
-
   override protected[this] def className: String = "VectorMap"
 
   def updated[V1 >: V](key: K, value: V1): VectorMap[K, V1] = {
@@ -37,7 +36,7 @@ final class VectorMap[K, +V] private[immutable] (
       case None =>
         new VectorMap(
           fields :+ key,
-          underlying.updated(key, (fields.length + 1, value)))
+          underlying.updated(key, (fields.length, value)))
     }
   }
 

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -95,11 +95,11 @@ final class VectorMap[K, +V] private[immutable] (
   }
 
   override def tail: VectorMap[K, V] = {
-    new VectorMap(fields.tail, underlying.remove(fields.last))
+    new VectorMap(fields.tail, underlying.remove(fields.head))
   }
 
   override def init: VectorMap[K, V] = {
-    new VectorMap(fields.init, underlying.remove(fields.head))
+    new VectorMap(fields.init, underlying.remove(fields.last))
   }
 
   // Only care about content, not ordering for equality

--- a/test/scalacheck/scala/collection/immutable/VectorMapProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/VectorMapProperties.scala
@@ -1,0 +1,23 @@
+package scala.collection.immutable
+
+import org.scalacheck._
+import Arbitrary.arbitrary
+import Prop._
+import Gen._
+
+object VectorMapProperties extends Properties("immutable.VectorMap") {
+  property("internal underlying index match") = forAll { (m: Map[Int, Int]) =>
+    !m.isEmpty ==> {
+      val vm = VectorMap.from(m)
+      val last = vm.fields.last
+      vm.underlying(last)._1 == vm.size - 1
+    }
+  }
+
+  property("internal underlying and field length") = forAll { (m: Map[Int, Int]) => {
+      val vm = VectorMap.from(m)
+      vm.underlying.size == vm.fields.length
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11100, ended up being a silly fencepost error.

The only other significant change in this PR is the fact that `fields`/`underlying` are not fully private, I needed to do this in order to test the underlying implementation of `VectorMap`