### PR TITLE
fix IsIterableOnce scaladoc

### DIFF
--- a/src/library/scala/collection/generic/IsIterableOnce.scala
+++ b/src/library/scala/collection/generic/IsIterableOnce.scala
@@ -22,7 +22,7 @@ package generic
  *    class FilterMapImpl[Repr, I <: IsIterableOnce[Repr]](coll: Repr, it: I) {
  *      final def filterMap[B, That](f: it.A => Option[B])(implicit bf: BuildFrom[Repr, B, That]): That = {
  *        val b = bf.newBuilder(coll)
- *        for(e <- it(coll)) f(e) foreach (b +=)
+ *        for(e <- it(coll).iterator) f(e) foreach (b +=)
  *        b.result()
  *      }
  *    }


### PR DESCRIPTION
```
Welcome to Scala 2.13.0-pre-046937d (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> :paste
// Entering paste mode (ctrl-D to finish)

import scala.collection._, generic._

class FilterMapImpl[Repr, I <: IsIterableOnce[Repr]](coll: Repr, it: I) {
  final def filterMap[B, That](f: it.A => Option[B])(implicit bf: BuildFrom[Repr, B, That]): That = {
    val b = bf.newBuilder(coll)
    for(e <- it(coll)) f(e) foreach (b +=)
    b.result()
  }
}
implicit def filterMap[Repr](coll: Repr)(implicit it: IsIterableOnce[Repr]): FilterMapImpl[Repr, it.type] =
  new FilterMapImpl(coll, it)

List(1, 2, 3, 4, 5) filterMap (i => if(i % 2 == 0) Some(i) else None)

// Exiting paste mode, now interpreting.

           for(e <- it(coll)) f(e) foreach (b +=)
                      ^
On line 6: warning: method foreach in class IterableOnceExtensionMethods is deprecated (since 2.13.0): Use .iterator.foreach(...) instead
```