### PR TITLE
Quick fix for VectorMap#remove

### DIFF
--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -64,7 +64,13 @@ final class VectorMap[K, +V] private[immutable] (
   def remove(key: K): VectorMap[K, V] = {
     underlying.get(key) match {
       case Some((index, _)) =>
-        new VectorMap(fields.patch(index, Nil, 1), underlying - key)
+        val finalUnderlying = (underlying - key).map{ case (k, (currentIndex,v)) =>
+          if (currentIndex > index)
+            (k, (currentIndex - 1, v))
+          else
+            (k, (currentIndex, v))
+        }
+        new VectorMap(fields.patch(index, Nil, 1), finalUnderlying)
       case _ =>
         this
     }

--- a/test/scalacheck/scala/collection/immutable/VectorMapProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/VectorMapProperties.scala
@@ -20,4 +20,14 @@ object VectorMapProperties extends Properties("immutable.VectorMap") {
     }
   }
 
+  property("internal underlying has consistent index") = forAll { (m: Map[Int, Int]) =>
+    m.size >= 3 ==> {
+      val v = Vector.from(m)
+      val random = v(new scala.util.Random().nextInt(v.size))
+      val vm = VectorMap.from(v)
+      val removed = vm - random._1
+      removed.underlying.toList.map{case (k, v) => v._1}.sorted.sliding(2).forall(x => x(1) - x(0) == 1 )
+    }
+  }
+
 }


### PR DESCRIPTION
This PR is a very quick fix for the issues presented in https://github.com/scala/bug/issues/11100. I may need a travis push on PR before I can validate this with the collection laws

A more complete and performant solution will be provided later, it just requires a lot more work because its non trivial.

There is also a property check to make sure the index is consistent (the test fails without the fix)