### PR TITLE
Don't re-apply type maps to info of unchanged symbols

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -189,7 +189,7 @@ private[internal] trait TypeMaps {
       // throw new Error("mapOver inapplicable for " + tp);
     }
 
-    def withVariance[T](v: Variance)(body: => T): T = {
+    @inline final def withVariance[T](v: Variance)(body: => T): T = {
       val saved = variance
       variance = v
       try body finally variance = saved
@@ -199,7 +199,7 @@ private[internal] trait TypeMaps {
       try body
       finally if (trackVariance) variance = variance.flip
     }
-    protected def mapOverArgs(args: List[Type], tparams: List[Symbol]): List[Type] = (
+    protected final def mapOverArgs(args: List[Type], tparams: List[Symbol]): List[Type] = (
       if (trackVariance)
         map2Conserve(args, tparams)((arg, tparam) => withVariance(variance * tparam.variance)(this(arg)))
       else
@@ -218,13 +218,13 @@ private[internal] trait TypeMaps {
     /** The index of the first symbol in `origSyms` which would have its info
       * transformed by this type map.
       */
-    protected def firstChangedSymbol(origSyms: List[Symbol]): Int = {
+    private def firstChangedSymbol(origSyms: List[Symbol]): Int = {
       @tailrec def loop(i: Int, syms: List[Symbol]): Int = syms match {
-        case Nil     => -1
         case x :: xs =>
           val info = x.info
           if (applyToSymbolInfo(x, info) eq info) loop(i+1, xs)
           else i
+        case Nil => -1
       }
       loop(0, origSyms)
     }


### PR DESCRIPTION
The fast path in `mapOver` would avoid cloning symbols if the map had no effect on any of their infos. However, if a symbol with a changed info was found, it would use `cloneSymbolsAndModify` to apply itself to a fresh clone of those symbols, with the result that it would re-apply itself to the infos of symbols clone from symbols that were unchanged.

This avoids that.

In library/reflect/compiler, this avoids 51358 _direct_ repeated calls to `TypeMap#apply`. Since those may go off and do more work, it's more than that. (This was collected by adding a new statistics counter. I took it away since I'm not sure if the overhead is worth it. I can put it back.)

Have some (inconclusive?) [numbers](https://gist.github.com/hrhino/d5b2b4b55d0f06c95fd592f698a16afa). (They look good, but the reduced number of calls to `apply` is (IMO) a better indication of the improvement.)

cc @mkeskells @rorygraves 