### PR TITLE
Create optimized s.c.i.HashSetBuilder and "Smart Builder"

### DIFF
--- a/src/library/scala/collection/immutable/ChampCommon.scala
+++ b/src/library/scala/collection/immutable/ChampCommon.scala
@@ -51,19 +51,37 @@ private[immutable] abstract class Node[T <: Node[T]] {
 
   def sizePredicate: Int
 
-  protected final def removeElement[A: ClassTag](as: Array[A], ix: Int): Array[A] = {
+  protected final def removeElement(as: Array[Int], ix: Int): Array[Int] = {
     if (ix < 0) throw new ArrayIndexOutOfBoundsException
     if (ix > as.length - 1) throw new ArrayIndexOutOfBoundsException
-    val result = new Array[A](as.length - 1)
+    val result = new Array[Int](as.length - 1)
     arraycopy(as, 0, result, 0, ix)
     arraycopy(as, ix + 1, result, ix, as.length - ix - 1)
     result
   }
 
-  protected final def insertElement[A: ClassTag](as: Array[A], ix: Int, elem: A): Array[A] = {
+  protected final def removeAnyElement(as: Array[Any], ix: Int): Array[Any] = {
+    if (ix < 0) throw new ArrayIndexOutOfBoundsException
+    if (ix > as.length - 1) throw new ArrayIndexOutOfBoundsException
+    val result = new Array[Any](as.length - 1)
+    arraycopy(as, 0, result, 0, ix)
+    arraycopy(as, ix + 1, result, ix, as.length - ix - 1)
+    result
+  }
+
+  protected final def insertElement(as: Array[Int], ix: Int, elem: Int): Array[Int] = {
     if (ix < 0) throw new ArrayIndexOutOfBoundsException
     if (ix > as.length) throw new ArrayIndexOutOfBoundsException
-    val result = new Array[A](as.length + 1)
+    val result = new Array[Int](as.length + 1)
+    arraycopy(as, 0, result, 0, ix)
+    result(ix) = elem
+    arraycopy(as, ix, result, ix + 1, as.length - ix)
+    result
+  }
+  protected final def insertAnyElement(as: Array[Any], ix: Int, elem: Int): Array[Any] = {
+    if (ix < 0) throw new ArrayIndexOutOfBoundsException
+    if (ix > as.length) throw new ArrayIndexOutOfBoundsException
+    val result = new Array[Any](as.length + 1)
     arraycopy(as, 0, result, 0, ix)
     result(ix) = elem
     arraycopy(as, ix, result, ix + 1, as.length - ix)

--- a/src/library/scala/collection/immutable/ChampCommon.scala
+++ b/src/library/scala/collection/immutable/ChampCommon.scala
@@ -5,6 +5,8 @@ import java.lang.Integer.bitCount
 import java.lang.Math.ceil
 import java.lang.System.arraycopy
 
+import scala.reflect.ClassTag
+
 private[immutable] final object Node {
 
   final val HashCodeLength = 32
@@ -49,19 +51,19 @@ private[immutable] abstract class Node[T <: Node[T]] {
 
   def sizePredicate: Int
 
-  protected final def removeElement(as: Array[Int], ix: Int): Array[Int] = {
+  protected final def removeElement[A: ClassTag](as: Array[A], ix: Int): Array[A] = {
     if (ix < 0) throw new ArrayIndexOutOfBoundsException
     if (ix > as.length - 1) throw new ArrayIndexOutOfBoundsException
-    val result = new Array[Int](as.length - 1)
+    val result = new Array[A](as.length - 1)
     arraycopy(as, 0, result, 0, ix)
     arraycopy(as, ix + 1, result, ix, as.length - ix - 1)
     result
   }
 
-  protected final def insertElement(as: Array[Int], ix: Int, elem: Int): Array[Int] = {
+  protected final def insertElement[A: ClassTag](as: Array[A], ix: Int, elem: A): Array[A] = {
     if (ix < 0) throw new ArrayIndexOutOfBoundsException
     if (ix > as.length) throw new ArrayIndexOutOfBoundsException
-    val result = new Array[Int](as.length + 1)
+    val result = new Array[A](as.length + 1)
     arraycopy(as, 0, result, 0, ix)
     result(ix) = elem
     arraycopy(as, ix, result, ix + 1, as.length - ix)

--- a/src/library/scala/collection/immutable/ChampHashMap.scala
+++ b/src/library/scala/collection/immutable/ChampHashMap.scala
@@ -7,7 +7,6 @@ import java.lang.System.arraycopy
 
 import scala.annotation.unchecked.{uncheckedVariance => uV}
 import scala.collection.Hashing.improve
-import scala.collection.immutable.Map.Map4
 import scala.collection.mutable.Builder
 import scala.collection.{Iterator, MapFactory, StrictOptimizedIterableOps, StrictOptimizedMapOps}
 import scala.util.hashing.MurmurHash3
@@ -644,8 +643,8 @@ private final class HashCollisionMapNode[K, +V](
       this
     } else {
       val index = contentKeys.indexOf(key)
-      val newContentKeys = removeElement(contentKeys, index)
-      val newContentValues = removeElement(contentValues, index)
+      val newContentKeys = removeAnyElement(contentKeys, index)
+      val newContentValues = removeAnyElement(contentValues, index)
 
       // assert(newContentKeys.length == contentKeys.length - 1)
 

--- a/src/library/scala/collection/immutable/ChampHashMap.scala
+++ b/src/library/scala/collection/immutable/ChampHashMap.scala
@@ -1088,9 +1088,6 @@ final class HashMapBuilder[K, V] extends Builder[(K, V), HashMap[K, V]] {
             }
         }
         addAllRec(hm.rootNode)
-
-      case map4: Map4[K, V] =>
-        map4
       case other =>
         val it = other.iterator
         while(it.hasNext) addOne(it.next())

--- a/src/library/scala/collection/immutable/ChampHashMap.scala
+++ b/src/library/scala/collection/immutable/ChampHashMap.scala
@@ -1042,7 +1042,9 @@ final class HashMapBuilder[K, V] extends Builder[(K, V), HashMap[K, V]] {
 
   override def clear(): Unit = {
     aliased = false
-    rootNode = new BitmapIndexedMapNode[K, V](0, 0, Array(), Array(), 0)
+    if (rootNode.size > 0) {
+      rootNode = new BitmapIndexedMapNode[K, V](0, 0, Array(), Array(), 0)
+    }
     hash = 0
   }
 }

--- a/src/library/scala/collection/immutable/ChampHashMap.scala
+++ b/src/library/scala/collection/immutable/ChampHashMap.scala
@@ -1099,7 +1099,7 @@ final class HashMapBuilder[K, V] extends Builder[(K, V), HashMap[K, V]] {
   override def clear(): Unit = {
     aliased = false
     if (rootNode.size > 0) {
-      rootNode = new BitmapIndexedMapNode[K, V](0, 0, Array(), Array(), 0)
+      rootNode = newEmptyRootNode
     }
     hash = 0
   }

--- a/src/library/scala/collection/immutable/ChampHashMap.scala
+++ b/src/library/scala/collection/immutable/ChampHashMap.scala
@@ -1099,6 +1099,7 @@ final class HashMapBuilder[K, V] extends Builder[(K, V), HashMap[K, V]] {
   override def clear(): Unit = {
     aliased = false
     if (rootNode.size > 0) {
+      // if rootNode is empty, we will not have given it away anyways, we instead give out the reused Map.empty
       rootNode = new BitmapIndexedMapNode[K, V](0, 0, Array(), Array(), 0)
     }
     hash = 0

--- a/src/library/scala/collection/immutable/ChampHashSet.scala
+++ b/src/library/scala/collection/immutable/ChampHashSet.scala
@@ -952,7 +952,7 @@ private[collection] final class HashSetBuilder[A] extends Builder[A, HashSet[A]]
     aliased = false
     if (rootNode.size > 0) {
       // if rootNode is empty, we will not have given it away anyways, we instead give out the reused Set.empty
-      rootNode = new BitmapIndexedSetNode[A](0, 0, Array(), Array(), 0)
+      rootNode = newEmptyRootNode
     }
     hash = 0
   }

--- a/src/library/scala/collection/immutable/ChampHashSet.scala
+++ b/src/library/scala/collection/immutable/ChampHashSet.scala
@@ -9,8 +9,8 @@ import Hashing.improve
 import java.lang.Integer.{bitCount, numberOfTrailingZeros}
 import java.lang.System.arraycopy
 
+import scala.collection.immutable.Set.Set4
 import scala.util.hashing.MurmurHash3
-
 import scala.runtime.Statics.releaseFence
 
 /** This class implements immutable sets using a Compressed Hash-Array Mapped Prefix-tree.
@@ -952,4 +952,5 @@ private[collection] final class HashSetBuilder[A] extends Builder[A, HashSet[A]]
 
   private[collection] def size: Int = rootNode.size
 }
+
 

--- a/src/library/scala/collection/immutable/ChampHashSet.scala
+++ b/src/library/scala/collection/immutable/ChampHashSet.scala
@@ -72,6 +72,13 @@ final class HashSet[A] private[immutable] (val rootNode: SetNode[A], val cachedJ
     else this
   }
 
+  override def concat(that: IterableOnce[A]): HashSet[A] = {
+    val builder = iterableFactory.newBuilder[A]
+    builder ++= this
+    builder ++= that
+    builder.result()
+  }
+
   override def tail: HashSet[A] = this - head
 
   override def init: HashSet[A] = this - last

--- a/src/library/scala/collection/immutable/ChampHashSet.scala
+++ b/src/library/scala/collection/immutable/ChampHashSet.scala
@@ -779,7 +779,7 @@ private[collection] final class HashSetBuilder[A] extends Builder[A, HashSet[A]]
     bm.content(idx) = elem
   }
 
-  def updated(setNode: SetNode[A], element: A, originalHash: Int, elementHash: Int, shift: Int): SetNode[A] = {
+  def update(setNode: SetNode[A], element: A, originalHash: Int, elementHash: Int, shift: Int): SetNode[A] = {
     setNode match {
       case bm: BitmapIndexedSetNode[A] =>
         val mask = maskFrom(elementHash, shift)
@@ -826,10 +826,11 @@ private[collection] final class HashSetBuilder[A] extends Builder[A, HashSet[A]]
 
 
   /** Inserts the this key/value only if the key is not present in the map already */
-  private def updateIfNotExists(mapNode: MapNode[K, V], key: K, value: V, originalHash: Int, keyHash: Int, shift: Int): Unit = {
-    mapNode match {
-      case bm: BitmapIndexedMapNode[K, V] =>
-        val mask = maskFrom(keyHash, shift)
+//  private def updateIfNotExists(setNode: SetNode[A], element: A, originalHash: Int, elementHash: Int, shift: Int) = {
+  private def updateIfNotExists(setNode: SetNode[A], element: A, originalHash: Int, keyHash: Int, shift: Int): Unit = {
+    setNode match {
+      case bm: BitmapIndexedSetNode[A] =>
+        val mask = maskFrom(elementHash, shift)
         val bitpos = bitposFrom(mask)
         if ((bm.dataMap & bitpos) != 0) {
           val index = indexFrom(bm.dataMap, mask, bitpos)

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -6,7 +6,7 @@ import java.io.{ObjectInputStream, ObjectOutputStream}
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable.Map.Map4
-import scala.collection.mutable.{Builder, ImmutableBuilder}
+import scala.collection.mutable.Builder
 import scala.language.higherKinds
 
 
@@ -181,10 +181,7 @@ object Map extends MapFactory[Map] {
       case _ => (newBuilder[K, V] ++= it).result()
     }
 
-  def newBuilder[K, V]: Builder[(K, V), Map[K, V]] =
-    new ImmutableBuilder[(K, V), Map[K, V]](empty) {
-      def addOne(elem: (K, V)): this.type = { elems = elems + elem; this }
-    }
+  def newBuilder[K, V]: Builder[(K, V), Map[K, V]] = new MapBuilderImpl
 
   private object EmptyMap extends AbstractMap[Any, Nothing] {
     override def size: Int = 0

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -410,3 +410,4 @@ object Map extends MapFactory[Map] {
 /** Explicit instantiation of the `Map` trait to reduce class file size in subclasses. */
 @SerialVersionUID(3L)
 abstract class AbstractMap[K, +V] extends scala.collection.AbstractMap[K, V] with Map[K, V]
+

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -5,6 +5,7 @@ package immutable
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
 import scala.annotation.unchecked.uncheckedVariance
+import scala.collection.immutable.Map.Map4
 import scala.collection.mutable.{Builder, ImmutableBuilder}
 import scala.language.higherKinds
 
@@ -335,7 +336,16 @@ object Map extends MapFactory[Map] {
     }
   }
 
-  final class Map4[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V, key4: K, value4: V) extends AbstractMap[K, V] with StrictOptimizedIterableOps[(K, V), Iterable, Map[K, V]] {
+  final class Map4[K, +V](
+    private[collection] val key1: K,
+    private[collection] val value1: V,
+    private[collection] val key2: K,
+    private[collection] val value2: V,
+    private[collection] val key3: K,
+    private[collection] val value3: V,
+    private[collection] val key4: K,
+    private[collection] val value4: V) extends AbstractMap[K, V] with StrictOptimizedIterableOps[(K, V), Iterable, Map[K, V]] {
+
     override def size: Int = 4
     override def knownSize: Int = 4
     override def isEmpty: Boolean = false
@@ -411,3 +421,46 @@ object Map extends MapFactory[Map] {
 @SerialVersionUID(3L)
 abstract class AbstractMap[K, +V] extends scala.collection.AbstractMap[K, V] with Map[K, V]
 
+private[collection] final class MapBuilderImpl[K, V] extends Builder[(K, V), Map[K, V]] {
+  private[this] var elems: Map[K, V] = Map.empty
+  private[this] var hashMapBuilder: HashMapBuilder[K, V] = null
+
+  override def clear(): Unit = {
+    elems = Map.empty
+    if (hashMapBuilder != null) {
+      hashMapBuilder.clear()
+    }
+  }
+
+  override def result(): Map[K, V] = {
+    if (hashMapBuilder == null || hashMapBuilder.size == 0) {
+      elems
+    } else if (elems.size == 4) {
+      val map4 = elems.asInstanceOf[Map4[K, V]]
+
+      hashMapBuilder.addOneIfNotExists(map4.key1, map4.value1)
+      hashMapBuilder.addOneIfNotExists(map4.key2, map4.value2)
+      hashMapBuilder.addOneIfNotExists(map4.key3, map4.value3)
+      hashMapBuilder.addOneIfNotExists(map4.key4, map4.value4)
+
+      hashMapBuilder.result()
+    } else {
+      // should never happen...
+      elems.foreach { case (k, v) => hashMapBuilder.addOneIfNotExists(k, v) }
+      hashMapBuilder.result()
+    }
+  }
+  override def addOne(elem: (K, V)) = {
+    if (elems.size < 4) {
+      elems = elems + elem
+    } else {
+      if (hashMapBuilder == null) {
+        hashMapBuilder = new HashMapBuilder
+      }
+
+      hashMapBuilder.addOne(elem)
+    }
+
+    this
+  }
+}

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashMapBenchmark.scala
@@ -37,40 +37,61 @@ class HashMapBenchmark {
 
   var map: collection.immutable.Map[Any, Any] = null
 
+  var map2: collection.immutable.Map[Any, Any] = null
+
   @Setup(Level.Trial) def initialize = {
     map = collection.immutable.Map(existingKeys.map(x => (x, x)) : _*)
+    map2 = collection.immutable.Map(existingKeys.splitAt(10)._1.map(x => (x, (x, x))) ++ missingKeys.map(x => (x, x)) : _*)
   }
 
-  @Benchmark def contains(bh: Blackhole): Unit = {
-    var i = 0;
-    while (i < size) {
-      bh.consume(map.contains(existingKeys(i)))
-      if (useMissingValues) {
-        bh.consume(map.contains(missingKeys(i)))
+    @Benchmark def concat(bh: Blackhole): Unit = {
+      var i = 0
+      while (i < size) {
+        bh.consume(map concat map2)
+        i += 1
       }
-      i += 1
     }
-  }
 
-  @Benchmark def get(bh: Blackhole): Unit = {
-    var i = 0;
-    while (i < size) {
-      bh.consume(map.get(existingKeys(i)))
-      if (useMissingValues) {
-        bh.consume(map.get(missingKeys(i)))
-      }
-      i += 1
-    }
-  }
-
-  @Benchmark def getOrElse(bh: Blackhole): Unit = {
-    var i = 0;
-    while (i < size) {
-      bh.consume(map.getOrElse(existingKeys(i), ""))
-      if (useMissingValues) {
-        bh.consume(map.getOrElse(missingKeys(i), ""))
-      }
-      i += 1
-    }
-  }
+//  @Benchmark def contains(bh: Blackhole): Unit = {
+//    var i = 0
+//    while (i < size) {
+//      bh.consume(map.contains(existingKeys(i)))
+//      if (useMissingValues) {
+//        bh.consume(map.contains(missingKeys(i)))
+//      }
+//      i += 1
+//    }
+//  }
+//
+//  @Benchmark def get(bh: Blackhole): Unit = {
+//    var i = 0
+//    while (i < size) {
+//      bh.consume(map.get(existingKeys(i)))
+//      if (useMissingValues) {
+//        bh.consume(map.get(missingKeys(i)))
+//      }
+//      i += 1
+//    }
+//  }
+//
+//  @Benchmark def getOrElse(bh: Blackhole): Unit = {
+//    var i = 0
+//    while (i < size) {
+//      bh.consume(map.getOrElse(existingKeys(i), ""))
+//      if (useMissingValues) {
+//        bh.consume(map.getOrElse(missingKeys(i), ""))
+//      }
+//      i += 1
+//    }
+//  }
+//  @Benchmark def updated(bh: Blackhole): Unit = {
+//    var i = 0
+//    while (i < size) {
+//      bh.consume(map.updated(existingKeys(i), ""))
+//      if (useMissingValues) {
+//        bh.consume(map.updated(missingKeys(i), ""))
+//      }
+//      i += 1
+//    }
+//  }
 }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashMapBenchmark.scala
@@ -44,54 +44,54 @@ class HashMapBenchmark {
     map2 = collection.immutable.Map(existingKeys.splitAt(10)._1.map(x => (x, (x, x))) ++ missingKeys.map(x => (x, x)) : _*)
   }
 
-    @Benchmark def concat(bh: Blackhole): Unit = {
-      var i = 0
-      while (i < size) {
-        bh.consume(map concat map2)
-        i += 1
-      }
+  @Benchmark def concat(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < size) {
+      bh.consume(map concat map2)
+      i += 1
     }
+  }
 
-//  @Benchmark def contains(bh: Blackhole): Unit = {
-//    var i = 0
-//    while (i < size) {
-//      bh.consume(map.contains(existingKeys(i)))
-//      if (useMissingValues) {
-//        bh.consume(map.contains(missingKeys(i)))
-//      }
-//      i += 1
-//    }
-//  }
-//
-//  @Benchmark def get(bh: Blackhole): Unit = {
-//    var i = 0
-//    while (i < size) {
-//      bh.consume(map.get(existingKeys(i)))
-//      if (useMissingValues) {
-//        bh.consume(map.get(missingKeys(i)))
-//      }
-//      i += 1
-//    }
-//  }
-//
-//  @Benchmark def getOrElse(bh: Blackhole): Unit = {
-//    var i = 0
-//    while (i < size) {
-//      bh.consume(map.getOrElse(existingKeys(i), ""))
-//      if (useMissingValues) {
-//        bh.consume(map.getOrElse(missingKeys(i), ""))
-//      }
-//      i += 1
-//    }
-//  }
-//  @Benchmark def updated(bh: Blackhole): Unit = {
-//    var i = 0
-//    while (i < size) {
-//      bh.consume(map.updated(existingKeys(i), ""))
-//      if (useMissingValues) {
-//        bh.consume(map.updated(missingKeys(i), ""))
-//      }
-//      i += 1
-//    }
-//  }
+  @Benchmark def contains(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < size) {
+      bh.consume(map.contains(existingKeys(i)))
+      if (useMissingValues) {
+        bh.consume(map.contains(missingKeys(i)))
+      }
+      i += 1
+    }
+  }
+
+  @Benchmark def get(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < size) {
+      bh.consume(map.get(existingKeys(i)))
+      if (useMissingValues) {
+        bh.consume(map.get(missingKeys(i)))
+      }
+      i += 1
+    }
+  }
+
+  @Benchmark def getOrElse(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < size) {
+      bh.consume(map.getOrElse(existingKeys(i), ""))
+      if (useMissingValues) {
+        bh.consume(map.getOrElse(missingKeys(i), ""))
+      }
+      i += 1
+    }
+  }
+  @Benchmark def updated(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < size) {
+      bh.consume(map.updated(existingKeys(i), ""))
+      if (useMissingValues) {
+        bh.consume(map.updated(missingKeys(i), ""))
+      }
+      i += 1
+    }
+  }
 }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/SetBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/SetBenchmark.scala
@@ -5,6 +5,8 @@ import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra._
 
+import scala.collection.mutable
+
 @BenchmarkMode(Array(Mode.AverageTime))
 @Fork(2)
 @Threads(1)
@@ -16,37 +18,103 @@ class SetBenchmark {
   @Param(Array("10", "100", "1000", "10000"))
   var size: Int = _
 
-  var base: Set[String] = _
+//  var base: Set[String] = _
 
   var existingKeys: Array[Any] = _
   var missingKeys: Array[Any] = _
+  var allSameHash: Array[Any] = _
   var set1: collection.immutable.Set[Any] = _
   var set2: collection.immutable.Set[Any] = _
 
   @Setup(Level.Trial) def initKeys(): Unit = {
-    base = Set("a", "b", "c", "d")
+//    base = Set("a", "b", "c", "d")
 
-    existingKeys = (0 to size).map(i => (i % 4) match {
-      case 0 => i.toString
-      case 1 => i.toChar
-      case 2 => i.toDouble
-      case 3 => i.toInt
-    }).toArray
-    missingKeys = (size to 2 * size).toArray.map(_.toString)
+    existingKeys = (0 to size)
+      .map(i =>
+        (i % 4) match {
+          case 0 => i.toString
+          case 1 => i.toChar
+          case 2 => i.toDouble
+          case 3 => i.toInt
+      })
+      .toArray
+//    missingKeys = (size to 2 * size).toArray.map(_.toString)
+
+    allSameHash = (1 to size)
+      .map(_ =>
+        new AnyRef {
+          override def hashCode() = 12345
+      })
+      .toArray
+
   }
-  
+
   // immutable map is implemented as EmptySet -> Set1 -> Set2 -> Set3 -> Set4 -> HashSet
   // add an extra entry to Set4 causes a lot of work, benchmark the transition
-//  @Benchmark def set4AddElement(bh: Blackhole): Unit = {
-//    bh.consume(base + "e")
+  //  @Benchmark def set4AddElement(bh: Blackhole): Unit = {
+  //    bh.consume(base + "e")
+  //  }
+//
+//  @Setup(Level.Trial) def initialize = {
+//    set1 = existingKeys.toSet
+//    set2 = (existingKeys.splitAt(10)._1 ++ missingKeys).toSet
 //  }
 
-  @Setup(Level.Trial) def initialize = {
-    set1 = existingKeys.toSet
-    set2 = (existingKeys.splitAt(10)._1 ++ missingKeys).toSet
+  @Benchmark def hashsetBuilder_allNewElems(bh: Blackhole): Unit = {
+    val b = HashSet.newBuilder[Any]
+    b ++= existingKeys
+    bh.consume(b.result())
+  }
+  @Benchmark def hashsetBuilder_allElemsAndThenRepeat(bh: Blackhole): Unit = {
+    val b = HashSet.newBuilder[Any]
+    b ++= existingKeys
+    b ++= existingKeys
+    bh.consume(b.result())
+  }
+  @Benchmark def hashsetBuilder_allSameHash(bh: Blackhole): Unit = {
+    val b = HashSet.newBuilder[Any]
+    b ++= allSameHash
+    bh.consume(b.result())
   }
 
-  @Benchmark def concat(bh: Blackhole): Unit = {
-    bh.consume(set1 ++ set2)
+  def newImmutableBuilder = new mutable.ImmutableBuilder(Set.empty[Any]) {
+    override def addOne(elem: Any) = { elems += elem; this }
   }
+
+  @Benchmark def immutableBuilder_allNewElems(bh: Blackhole): Unit = {
+    val b = newImmutableBuilder
+    b ++= existingKeys
+    bh.consume(b.result())
+  }
+  @Benchmark def immutableBuilder_allElemsAndThenRepeat(bh: Blackhole): Unit = {
+    val b = newImmutableBuilder
+    b ++= existingKeys
+    b ++= existingKeys
+    bh.consume(b.result())
+  }
+  @Benchmark def immutableBuilder_allSameHash(bh: Blackhole): Unit = {
+    val b = newImmutableBuilder
+    b ++= allSameHash
+    bh.consume(b.result())
+  }
+
+
+  @Benchmark def smartBuilder_allNewElems(bh: Blackhole): Unit = {
+    val b = new SetBuilderImpl[Any]
+    b ++= existingKeys
+    bh.consume(b.result())
+  }
+  @Benchmark def smartBuilder_allElemsAndThenRepeat(bh: Blackhole): Unit = {
+    val b = new SetBuilderImpl[Any]
+    b ++= existingKeys
+    b ++= existingKeys
+    bh.consume(b.result())
+  }
+  @Benchmark def smartBuilder_allSameHash(bh: Blackhole): Unit = {
+    val b = new SetBuilderImpl[Any]
+    b ++= allSameHash
+    bh.consume(b.result())
+  }
+
+
 }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/SetBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/SetBenchmark.scala
@@ -13,17 +13,40 @@ import org.openjdk.jmh.infra._
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
 class SetBenchmark {
+  @Param(Array("10", "100", "1000", "10000"))
+  var size: Int = _
 
   var base: Set[String] = _
 
+  var existingKeys: Array[Any] = _
+  var missingKeys: Array[Any] = _
+  var set1: collection.immutable.Set[Any] = _
+  var set2: collection.immutable.Set[Any] = _
 
   @Setup(Level.Trial) def initKeys(): Unit = {
     base = Set("a", "b", "c", "d")
+
+    existingKeys = (0 to size).map(i => (i % 4) match {
+      case 0 => i.toString
+      case 1 => i.toChar
+      case 2 => i.toDouble
+      case 3 => i.toInt
+    }).toArray
+    missingKeys = (size to 2 * size).toArray.map(_.toString)
   }
   
   // immutable map is implemented as EmptySet -> Set1 -> Set2 -> Set3 -> Set4 -> HashSet
   // add an extra entry to Set4 causes a lot of work, benchmark the transition
-  @Benchmark def set4AddElement(bh: Blackhole): Unit = {
-    bh.consume(base + "e")
+//  @Benchmark def set4AddElement(bh: Blackhole): Unit = {
+//    bh.consume(base + "e")
+//  }
+
+  @Setup(Level.Trial) def initialize = {
+    set1 = existingKeys.toSet
+    set2 = (existingKeys.splitAt(10)._1 ++ missingKeys).toSet
+  }
+
+  @Benchmark def concat(bh: Blackhole): Unit = {
+    bh.consume(set1 ++ set2)
   }
 }

--- a/test/junit/scala/collection/SetMapConsistencyTest.scala
+++ b/test/junit/scala/collection/SetMapConsistencyTest.scala
@@ -462,7 +462,15 @@ class SetMapConsistencyTest {
     val rn = new scala.util.Random(42)
     def mhm: M = { val m = new cm.HashMap[Int, Boolean]; m ++= manyKVs; m }
     def mohm: M = { val m = new cm.OpenHashMap[Int, Boolean]; m ++= manyKVs; m }
-    def ihm: M = ci.HashMap.empty[Int, Boolean] ++ manyKVs
+    def ihm: M = {
+      val d = manyKVs.distinctBy(_._1)
+      val result = ci.HashMap.empty[Int, Boolean] ++ manyKVs
+      val s = result.size
+      val rV = result.toVector
+      val anyMissed = manyKVs.map(_._1).forall(result.contains)
+      val missed = manyKVs.filterNot(kv => result.contains(kv._1))
+      result
+    }
     val densities = List(0, 0.05, 0.2, 0.5, 0.8, 0.95, 1)
     def repeat = rn.nextInt(100) < 33
     def pick(m: M, density: Double) = m.keys.filter(_ => rn.nextDouble < density).toSet
@@ -473,7 +481,11 @@ class SetMapConsistencyTest {
           val density = densities(rn.nextInt(densities.length))
           val keep = pick(ms.head, density)
           ms = ms.map(_.filter(keep contains _._1))
-          if (!ms.sliding(2).forall(s => s(0) == s(1))) return false
+          if (!ms.sliding(2).forall{s =>
+            val result = s(0) == s(1)
+            result
+          })
+            return false
         } while (repeat)
       }
       true

--- a/test/junit/scala/collection/immutable/ChampMapSmokeTest.scala
+++ b/test/junit/scala/collection/immutable/ChampMapSmokeTest.scala
@@ -207,7 +207,8 @@ class ChampMapSmokeTest {
       map = map.updated(c, value(c.i))
     var map1 = map
     for (c <- cs) {
-      map1 = map1.updated(c, value(c.i))
+      val v = value(c.i)
+      map1 = map1.updated(c, v)
       assertEquals(cachedJavaKeySetHashCode(map), cachedJavaKeySetHashCode(map1))
       if (c.i % 41 == 0)
         assertEquals(map, map1)

--- a/test/junit/scala/collection/immutable/HashMapTest.scala
+++ b/test/junit/scala/collection/immutable/HashMapTest.scala
@@ -112,4 +112,39 @@ class HashMapTest {
     val expected = OldHashMap(A(0) -> 1, A(1) -> 1)
     assertEquals(merged, expected)
   }
+
+  @Test
+  def builder: Unit = {
+
+    val hm = HashMap(1 -> 1)
+
+    val hm2 = hm updated (1, 1)
+
+    val hmb = new HashMapBuilder[Int, String]
+
+    hmb.addOne(1 -> "hello")
+    hmb.addOne(2 -> "again")
+
+    hmb.addAll(Seq(
+      1 -> "hh",
+      6 -> "66",
+      1 -> "hhhhhhhh",
+      -5 -> ""
+    ))
+
+    assertEquals(Map( 1 -> "hello", 2 -> "again",    1 -> "hh", 6 -> "66", 1 -> "hhhhhhhh", -5 -> ""), hmb.result())
+
+  }
+}
+
+@RunWith(classOf[JUnit4])
+class HashMapBuilderTest {
+
+  @Test
+  def foo: Unit = {
+
+    val b = new HashMapBuilder[Int, String]
+
+  }
+
 }


### PR DESCRIPTION
This is a follow up to (and depends on) https://github.com/scala/scala/pull/7118

This ports the same optimization strategies made in that PR to HashSets. Here are the benchmarks:

# Benchmark

## Definition of terms:

* `hashsetBuilder` this is a benchmark that tests the new highly optimized `HashSetBuilder`
* `immutableBuilder` this is a benchmark that tests the status quo immutable "build by immutable append" builder
* `smartBuilder` this is a benchmark that tests the new "smart builder" (`SetBuilderImpl`) which uses `Set.{Empty,1,2,3,4}` for small sets, and then falls back to the `HashetBuilder` when n >= 5 
* `allElemsAndThenRepeat` this bench inserts `size` different elements, and then inserts the same `size` elements again, each one on the second insert is therefor a duplicate
* `allNewElems` this bench inserts `size` different unique elements
* `allSameHash` this bench inserts `size` different elements which all contain the same hash, and therefor all end up in the same `HashSetCollisionNode`

## Results

```
[info] Benchmark                                            (size)  Mode  Cnt          Score          Error  Units

## All Elems And then Repeat

[info] SetBenchmark.hashsetBuilder_allElemsAndThenRepeat         4  avgt   20        461.120 ±      174.441  ns/op
[info] SetBenchmark.hashsetBuilder_allElemsAndThenRepeat        10  avgt   20        923.064 ±      118.984  ns/op
[info] SetBenchmark.hashsetBuilder_allElemsAndThenRepeat       100  avgt   20      11766.627 ±     1321.132  ns/op
[info] SetBenchmark.hashsetBuilder_allElemsAndThenRepeat      1000  avgt   20     159571.073 ±     4211.029  ns/op
[info] SetBenchmark.hashsetBuilder_allElemsAndThenRepeat     10000  avgt   20    1871995.227 ±   104160.554  ns/op

[info] SetBenchmark.immutableBuilder_allElemsAndThenRepeat       4  avgt   20        178.842 ±        2.621  ns/op
[info] SetBenchmark.immutableBuilder_allElemsAndThenRepeat      10  avgt   20       1366.083 ±      114.302  ns/op
[info] SetBenchmark.immutableBuilder_allElemsAndThenRepeat     100  avgt   20      13732.907 ±      324.712  ns/op
[info] SetBenchmark.immutableBuilder_allElemsAndThenRepeat    1000  avgt   20     228701.967 ±    25629.324  ns/op
[info] SetBenchmark.immutableBuilder_allElemsAndThenRepeat   10000  avgt   20    2648201.750 ±   161944.262  ns/op

[info] SetBenchmark.smartBuilder_allElemsAndThenRepeat           4  avgt   20        451.313 ±       58.208  ns/op
[info] SetBenchmark.smartBuilder_allElemsAndThenRepeat          10  avgt   20       1008.728 ±       10.587  ns/op
[info] SetBenchmark.smartBuilder_allElemsAndThenRepeat         100  avgt   20      13194.197 ±     6260.655  ns/op
[info] SetBenchmark.smartBuilder_allElemsAndThenRepeat        1000  avgt   20     244450.988 ±   182873.459  ns/op
[info] SetBenchmark.smartBuilder_allElemsAndThenRepeat       10000  avgt   20    2359102.407 ±   424972.757  ns/op

======================================================================================================

## All New Elems

[info] SetBenchmark.hashsetBuilder_allNewElems                   4  avgt   20        227.666 ±.      10.203  ns/op
[info] SetBenchmark.hashsetBuilder_allNewElems                  10  avgt   20        770.831 ±      116.286  ns/op
[info] SetBenchmark.hashsetBuilder_allNewElems                 100  avgt   20       9122.488 ±      687.308  ns/op
[info] SetBenchmark.hashsetBuilder_allNewElems                1000  avgt   20     163210.290 ±    38650.265  ns/op
[info] SetBenchmark.hashsetBuilder_allNewElems               10000  avgt   20    1486824.212 ±    92824.013  ns/op

[info] SetBenchmark.immutableBuilder_allNewElems                 4  avgt   20         98.542 ±        3.967  ns/op
[info] SetBenchmark.immutableBuilder_allNewElems                10  avgt   20        975.557 ±       50.507  ns/op
[info] SetBenchmark.immutableBuilder_allNewElems               100  avgt   20      11825.366 ±      375.397  ns/op
[info] SetBenchmark.immutableBuilder_allNewElems              1000  avgt   20     267016.390 ±   155772.082  ns/op
[info] SetBenchmark.immutableBuilder_allNewElems             10000  avgt   20    1917628.161 ±    48746.446  ns/op

[info] SetBenchmark.smartBuilder_allNewElems                     4  avgt   20        121.177 ±       17.690  ns/op
[info] SetBenchmark.smartBuilder_allNewElems                    10  avgt   20       1434.406 ±      933.942  ns/op
[info] SetBenchmark.smartBuilder_allNewElems                   100  avgt   20       9296.645 ±     1434.086  ns/op
[info] SetBenchmark.smartBuilder_allNewElems                  1000  avgt   20     154395.698 ±    39509.936  ns/op
[info] SetBenchmark.smartBuilder_allNewElems                 10000  avgt   20    1717090.984 ±   326901.032  ns/op

======================================================================================================

## All Same Hash


[info] SetBenchmark.hashsetBuilder_allSameHash                   4  avgt   20        873.658 ±      103.922  ns/op
[info] SetBenchmark.hashsetBuilder_allSameHash                  10  avgt   20       1354.255 ±       77.125  ns/op
[info] SetBenchmark.hashsetBuilder_allSameHash                 100  avgt   20      11714.884 ±      284.126  ns/op
[info] SetBenchmark.hashsetBuilder_allSameHash                1000  avgt   20     442027.875 ±    26044.298  ns/op
[info] SetBenchmark.hashsetBuilder_allSameHash               10000  avgt   20   45572338.624 ± 11576225.319  ns/op

[info] SetBenchmark.immutableBuilder_allSameHash                 4  avgt   20        115.165 ±       45.761  ns/op
[info] SetBenchmark.immutableBuilder_allSameHash                10  avgt   20       2438.225 ±      555.489  ns/op
[info] SetBenchmark.immutableBuilder_allSameHash               100  avgt   20      24954.463 ±     3065.362  ns/op
[info] SetBenchmark.immutableBuilder_allSameHash              1000  avgt   20    1838116.768 ±   193481.067  ns/op
[info] SetBenchmark.immutableBuilder_allSameHash             10000  avgt   20  165434443.783 ±  2579894.522  ns/op

[info] SetBenchmark.smartBuilder_allSameHash                     4  avgt   20        100.144 ±        6.086  ns/op
[info] SetBenchmark.smartBuilder_allSameHash                    10  avgt   20       1517.489 ±      208.193  ns/op
[info] SetBenchmark.smartBuilder_allSameHash                   100  avgt   20      12727.658 ±      736.618  ns/op
[info] SetBenchmark.smartBuilder_allSameHash                  1000  avgt   20     448956.518 ±     5946.428  ns/op
[info] SetBenchmark.smartBuilder_allSameHash                 10000  avgt   20   41187438.767 ±  1543454.321  ns/op
```