### PR TITLE
Optimize directory based classpath

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
@@ -5,13 +5,15 @@ package scala.tools.nsc.classpath
 
 import java.io.File
 import java.net.URL
-import java.nio.file.{FileSystems, Files}
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileSystems, FileVisitOption, Files}
 import java.util
 
 import scala.reflect.io.{AbstractFile, PlainFile, PlainNioFile}
 import scala.tools.nsc.util.{ClassPath, ClassRepresentation}
 import FileUtils._
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
 import scala.reflect.internal.JDK9Reflectors
 import scala.tools.nsc.classpath.PackageNameUtils.{packageContains, separatePkgAndClassNames}
 
@@ -23,19 +25,31 @@ import scala.tools.nsc.classpath.PackageNameUtils.{packageContains, separatePkgA
  * It abstracts over the file representation to work with both JFile and AbstractFile.
  */
 trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
+  // Within this file, we sort by file name for stable order of directory entries in package scope.
+  // This gives stable results ordering of base type sequences for unrelated classes
+  // with the same base type depth.
+  //
+  // Notably, this will stably infer`Product with Serializable`
+  // as the type of `case class C(); case class D(); List(C(), D()).head`, rather than the opposite order.
+  // On Mac, the HFS performs this sorting transparently, but on Linux the order is unspecified.
+  //
+  // Note this behaviour can be enabled in javac with `javac -XDsortfiles`, but that's only
+  // intended to improve determinism of the compiler for compiler hackers.
+
+
   type F
 
   val dir: F
 
   protected def emptyFiles: Array[F] // avoids reifying ClassTag[F]
   protected def getSubDir(dirName: String): Option[F]
-  protected def listChildren(dir: F, filter: Option[F => Boolean] = None): Array[F]
+  protected def listChildren(dir: F)(f: (F, BasicFileAttributes) => Boolean): (Array[F], Array[F])
   protected def getName(f: F): String
   protected def toAbstractFile(f: F): AbstractFile
-  protected def isPackage(f: F): Boolean
+  protected def isPackage(f: F, attrs: BasicFileAttributes): Boolean
 
   protected def createFileEntry(file: AbstractFile): FileEntryType
-  protected def isMatchingFile(f: F): Boolean
+  protected def isMatchingFile(f: F, attrs: BasicFileAttributes): Boolean
 
   private def getDirectory(forPackage: String): Option[F] = {
     if (forPackage == ClassPath.RootPackage) {
@@ -49,39 +63,42 @@ trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
 
   private[nsc] def packages(inPackage: String): Seq[PackageEntry] = {
     val dirForPackage = getDirectory(inPackage)
-    val nestedDirs: Array[F] = dirForPackage match {
-      case None => emptyFiles
-      case Some(directory) => listChildren(directory, Some(isPackage))
+    dirForPackage match {
+      case None => Nil
+      case Some(directory) =>
+        val prefix = PackageNameUtils.packagePrefix(inPackage)
+        val (listing, files) = listChildren(directory) { (childFile, attrs) => isPackage(childFile, attrs)}
+        assert(files.isEmpty, files.toList)
+        val array = listing.map(f => PackageEntryImpl(prefix + getName(f)))
+        collection.immutable.ArraySeq.unsafeWrapArray(array)
     }
-    val prefix = PackageNameUtils.packagePrefix(inPackage)
-    nestedDirs.map(f => PackageEntryImpl(prefix + getName(f)))
   }
 
   protected def files(inPackage: String): Seq[FileEntryType] = {
     val dirForPackage = getDirectory(inPackage)
-    val files: Array[F] = dirForPackage match {
-      case None => emptyFiles
-      case Some(directory) => listChildren(directory, Some(isMatchingFile))
+    dirForPackage match {
+      case None => Nil
+      case Some(directory) =>
+        val (dirs, listing) = listChildren(directory) { (childFile, attrs) => isMatchingFile(childFile, attrs) }
+        assert(dirs.isEmpty, dirs.toList)
+        listing.iterator.map(f => createFileEntry(toAbstractFile(f))).toVector
     }
-    files.iterator.map(f => createFileEntry(toAbstractFile(f))).toSeq
   }
 
   private[nsc] def list(inPackage: String): ClassPathEntries = {
     val dirForPackage = getDirectory(inPackage)
-    val files: Array[F] = dirForPackage match {
-      case None => emptyFiles
-      case Some(directory) => listChildren(directory)
+    dirForPackage match {
+      case None => ClassPathEntries.empty
+      case Some(directory) =>
+        val packagePrefix = PackageNameUtils.packagePrefix(inPackage)
+        val (dirs, files) = listChildren(directory) {
+          (childFile, attrs) => isPackage(childFile, attrs) || isMatchingFile(childFile, attrs)
+        }
+        ClassPathEntries(
+          dirs.map(f => PackageEntryImpl(packagePrefix + getName(f))),
+          ArrayBuffer.from(files.view.map(f => createFileEntry(toAbstractFile(f))))
+        )
     }
-    val packagePrefix = PackageNameUtils.packagePrefix(inPackage)
-    val packageBuf = collection.mutable.ArrayBuffer.empty[PackageEntry]
-    val fileBuf = collection.mutable.ArrayBuffer.empty[FileEntryType]
-    for (file <- files) {
-      if (isPackage(file))
-        packageBuf += PackageEntryImpl(packagePrefix + getName(file))
-      else if (isMatchingFile(file))
-        fileBuf += createFileEntry(toAbstractFile(file))
-    }
-    ClassPathEntries(packageBuf, fileBuf)
   }
 }
 
@@ -94,28 +111,32 @@ trait JFileDirectoryLookup[FileEntryType <: ClassRepresentation] extends Directo
     if (packageDir.exists && packageDir.isDirectory && packageDir.canRead) Some(packageDir)
     else None
   }
-  protected def listChildren(dir: File, filter: Option[File => Boolean]): Array[File] = {
-    val listing = filter match {
-      case Some(f) => dir.listFiles(mkFileFilter(f))
-      case None => dir.listFiles()
-    }
 
-    // Sort by file name for stable order of directory .class entries in package scope.
-    // This gives stable results ordering of base type sequences for unrelated classes
-    // with the same base type depth.
-    //
-    // Notably, this will stably infer`Product with Serializable`
-    // as the type of `case class C(); case class D(); List(C(), D()).head`, rather than the opposite order.
-    // On Mac, the HFS performs this sorting transparently, but on Linux the order is unspecified.
-    //
-    // Note this behaviour can be enabled in javac with `javac -XDsortfiles`, but that's only
-    // intended to improve determinism of the compiler for compiler hackers.
-    util.Arrays.sort(listing, (o1: File, o2: File) => o1.getName.compareTo(o2.getName))
-    listing
+  override protected def listChildren(dir: File)(f: (File, BasicFileAttributes) => Boolean): (Array[File], Array[File]) = {
+    import java.nio.file._
+    val files = new collection.mutable.ArrayBuilder.ofRef[File]()
+    val dirs = new collection.mutable.ArrayBuilder.ofRef[File]()
+    val visitor = new SimpleFileVisitor[Path]() {
+      override def visitFile(childFile: Path, attrs: attribute.BasicFileAttributes): FileVisitResult = {
+        if (dir != childFile && f(childFile.toFile, attrs)) {
+          if (attrs.isDirectory) dirs += childFile.toFile
+          else files += childFile.toFile
+        }
+        FileVisitResult.CONTINUE
+      }
+    }
+    // OPT: Prefer walkFileTree to File#listFiles, especially on Windows: https://bugs.openjdk.java.net/browse/JDK-8008469
+    Files.walkFileTree(dir.toPath, util.EnumSet.of(FileVisitOption.FOLLOW_LINKS), 1, visitor)
+    val filesListing = files.result()
+    val dirsListing = dirs.result()
+    util.Arrays.sort(filesListing, (o1: File, o2: File) => o1.getName.compareTo(o2.getName))
+    util.Arrays.sort(dirsListing, (o1: File, o2: File) => o1.getName.compareTo(o2.getName))
+    (dirsListing, filesListing)
   }
+
   protected def getName(f: File): String = f.getName
   protected def toAbstractFile(f: File): AbstractFile = new PlainFile(new scala.reflect.io.File(f))
-  protected def isPackage(f: File): Boolean = f.isPackage
+  protected def isPackage(f: File, attrs: BasicFileAttributes): Boolean = attrs.isDirectory && mayBeValidPackage(f.getName)
 
   assert(dir != null, "Directory file in DirectoryFileLookup cannot be null")
 
@@ -291,7 +312,7 @@ case class DirectoryClassPath(dir: File) extends JFileDirectoryLookup[ClassFileE
   }
 
   protected def createFileEntry(file: AbstractFile): ClassFileEntryImpl = ClassFileEntryImpl(file)
-  protected def isMatchingFile(f: File): Boolean = f.isClass
+  protected def isMatchingFile(f: File, attrs: BasicFileAttributes): Boolean = attrs.isRegularFile && endsClass(f.getName)
 
   private[nsc] def classes(inPackage: String): Seq[ClassFileEntry] = files(inPackage)
 }
@@ -300,7 +321,7 @@ case class DirectorySourcePath(dir: File) extends JFileDirectoryLookup[SourceFil
   def asSourcePathString: String = asClassPathString
 
   protected def createFileEntry(file: AbstractFile): SourceFileEntryImpl = SourceFileEntryImpl(file)
-  protected def isMatchingFile(f: File): Boolean = endsScalaOrJava(f.getName)
+  protected def isMatchingFile(f: File, attrs: BasicFileAttributes): Boolean = endsScalaOrJava(f.getName)
 
   override def findClass(className: String): Option[ClassRepresentation] = findSourceFile(className) map SourceFileEntryImpl
 

--- a/src/reflect/scala/reflect/io/AbstractFile.scala
+++ b/src/reflect/scala/reflect/io/AbstractFile.scala
@@ -11,6 +11,7 @@ package io
 import java.io.{BufferedOutputStream, ByteArrayOutputStream, IOException, InputStream, OutputStream}
 import java.io.{File => JFile}
 import java.net.URL
+import java.nio.file.attribute.{BasicFileAttributes, FileTime}
 
 import scala.collection.AbstractIterable
 
@@ -259,6 +260,22 @@ abstract class AbstractFile extends AbstractIterable[AbstractFile] {
     assert (isDirectory, "Tried to find '%s' in '%s' but it is not a directory".format(name, path))
     fileOrSubdirectoryNamed(name, isDir = true)
   }
+
+  final def asNioBasicFileAttributes: BasicFileAttributes = new BasicFileAttributes {
+    override def lastModifiedTime(): FileTime = FileTime.fromMillis(lastModified)
+    override def lastAccessTime(): FileTime = unsupported()
+    override def creationTime(): FileTime = unsupported()
+    override def isRegularFile: Boolean = !isDirectory
+    override def isDirectory: Boolean = isDirectory
+    override def isSymbolicLink: Boolean = unsupported()
+    override def isOther: Boolean = false
+    override def size(): Long = AbstractFile.this.sizeOption match {
+      case Some(size) => size.toLong
+      case None => unsupported()
+    }
+    override def fileKey(): AnyRef = unsupported()
+  }
+
 
   protected def unsupported(): Nothing = unsupported(null)
   protected def unsupported(msg: String): Nothing = throw new UnsupportedOperationException(msg)


### PR DESCRIPTION
- Use walkFileTree rather than listFiles to avoid the need for subsequent
   system calls to check for `isDirectory`.
 - Avoid temporary collection creation.