### PR TITLE
Uncurry of Java varargs respects Java's universal trait nescience

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1305,8 +1305,8 @@ trait Types
       case TypeBounds(_, _) => that <:< this
       case _                => lo <:< that && that <:< hi
     }
-    private def emptyLowerBound = typeIsNothing(lo) || lo.isWildcard
-    private def emptyUpperBound = typeIsAny(hi) || hi.isWildcard
+    def emptyLowerBound = typeIsNothing(lo) || lo.isWildcard
+    def emptyUpperBound = typeIsAny(hi) || hi.isWildcard
     def isEmptyBounds = emptyLowerBound && emptyUpperBound
 
     override def safeToString = scalaNotation(_.toString)
@@ -4661,10 +4661,6 @@ trait Types
     try { explainSwitch = true; op } finally { explainSwitch = s }
   }
 
-  def isUnboundedGeneric(tp: Type) = tp match {
-    case t @ TypeRef(_, sym, _) => sym.isAbstractType && !(t <:< AnyRefTpe)
-    case _                      => false
-  }
   def isBoundedGeneric(tp: Type) = tp match {
     case TypeRef(_, sym, _) if sym.isAbstractType => (tp <:< AnyRefTpe)
     case TypeRef(_, sym, _)                       => !isPrimitiveValueClass(sym)

--- a/src/reflect/scala/reflect/internal/transform/UnCurry.scala
+++ b/src/reflect/scala/reflect/internal/transform/UnCurry.scala
@@ -56,6 +56,12 @@ trait UnCurry {
   }
 
   object DesugaredParameterType {
+    def isUnboundedGeneric(tp: Type) = tp match {
+      case t @ TypeRef(_, sym, _) if sym.isAbstractType =>
+        sym.info.resultType.bounds.emptyUpperBound
+      case _                      => false
+    }
+
     def unapply(tpe: Type): Option[Type] = tpe match {
       case TypeRef(pre, ByNameParamClass, arg :: Nil) =>
         Some(functionType(List(), arg))

--- a/test/files/run/t11109/JaVarArgs.java
+++ b/test/files/run/t11109/JaVarArgs.java
@@ -1,0 +1,9 @@
+// filter: Note:
+package t11109;
+
+import java.io.*;
+
+public class JaVarArgs {
+    public <T extends Serializable> void serialize(T... ts) {}
+    public <T extends Universal> void universalize(T... ts) {}
+}

--- a/test/files/run/t11109/Test.scala
+++ b/test/files/run/t11109/Test.scala
@@ -1,0 +1,7 @@
+import t11109._
+
+object Test extends App {
+  val jva = new JaVarArgs
+  jva.serialize("asdf")
+  jva.universalize(Universal)
+}

--- a/test/files/run/t11109/Universal.scala
+++ b/test/files/run/t11109/Universal.scala
@@ -1,0 +1,4 @@
+package t11109
+
+trait Universal extends Any
+object Universal extends Universal


### PR DESCRIPTION
If `U` is a universal trait (i.e., one extending from `Any` rather than `AnyRef`), Java still sees it as a normal interface, and in a method with a generic varargs parameter `<T extends U>`, interprets that as declaring an array argument `U[]` after erasure. However, due to a pre-value-class implementation of `isUnboundedGeneric`, such a type parameter was considered unbounded, and therefore Scala considered its erasure to be `Object[]` instead. This causes a runtime `NoSuchMethodError`, of course.

I moved `isUnboundedGeneric` from `Types` into `UnCurry`, since that's the only place it was used, and its proximity to `isBoundedGeneric`, which is neither defined as nor synonymous with `!isUnboundedGeneric` appeared likely to cause confusion. (_That_ method is only used in `SpecialiseTypes`, but I didn't want to change an unrelated file.)

Running into this bug is probably penance for using Hibernate with Scala, but I promise I'm "just following orders".

Fixes scala/bug#11109.