### PR TITLE
Update documentation of PriorityQueue

### DIFF
--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -15,6 +15,12 @@ import generic._
 /** This class implements priority queues using a heap.
  *  To prioritize elements of type A there must be an implicit
  *  Ordering[A] available at creation.
+ * 
+ *  If multiple elements have the same priority in the ordering of this
+ *  PriorityQueue, no guarantees are made regarding the order in which elements
+ *  are returned by `dequeue` or `dequeueAll`. In particular, that means this
+ *  class does not guarantee first in first out behaviour that may be
+ *  incorrectly inferred from the Queue part of the name of this class.
  *
  *  Only the `dequeue` and `dequeueAll` methods will return elements in priority
  *  order (while removing elements from the heap).  Standard collection methods


### PR DESCRIPTION
Makes it clear that despite the name Queue, PriorityQueue does not guarantee FIFO ordering

Closes (part of?) https://github.com/scala/bug/issues/11079 in that it clarifies the documentation.

Further action, like adding a separate FIFO priority queue, renaming this class to MinHeap or some variation thereof does not interfere with this PR.