### PR TITLE
[ROUNDLY REJECTED] Pre-SIP: Take omitted Unit for procedure syntax

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2611,13 +2611,13 @@ self =>
         syntaxError("lazy not allowed here. Only vals can be lazy", skipIt = false)
       in.token match {
         case VAL =>
-          patDefOrDcl(pos, mods withPosition(VAL, tokenRange(in)))
+          patDefOrDcl(pos, mods.withPosition(VAL, tokenRange(in)))
         case VAR =>
-          patDefOrDcl(pos, (mods | Flags.MUTABLE) withPosition (VAR, tokenRange(in)))
+          patDefOrDcl(pos, (mods | Flags.MUTABLE).withPosition(VAR, tokenRange(in)))
         case DEF =>
-          List(funDefOrDcl(pos, mods withPosition(DEF, tokenRange(in))))
+          List(funDefOrDcl(pos, mods.withPosition(DEF, tokenRange(in))))
         case TYPE =>
-          List(typeDefOrDcl(pos, mods withPosition(TYPE, tokenRange(in))))
+          List(typeDefOrDcl(pos, mods.withPosition(TYPE, tokenRange(in))))
         case _ =>
           List(tmplDef(pos, mods))
       }

--- a/test/files/neg/ur-ass.check
+++ b/test/files/neg/ur-ass.check
@@ -1,0 +1,18 @@
+ur-ass.scala:22: warning: discarded non-Unit value
+  def h() := { println("I don't care (I love it)") ; 42 }
+                                                     ^
+ur-ass.scala:22: warning: a pure expression does nothing in statement position
+  def h() := { println("I don't care (I love it)") ; 42 }
+                                                     ^
+ur-ass.scala:22: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
+  def h() := { println("I don't care (I love it)") ; 42 }
+                                                     ^
+ur-ass.scala:25: warning: discarded non-Unit value
+  def fail(): Unit = 42
+                     ^
+ur-ass.scala:25: warning: a pure expression does nothing in statement position
+  def fail(): Unit = 42
+                     ^
+error: No warnings can be incurred under -Xfatal-warnings.
+5 warnings found
+one error found

--- a/test/files/neg/ur-ass.scala
+++ b/test/files/neg/ur-ass.scala
@@ -1,0 +1,40 @@
+
+// scalac: -Ywarn-value-discard -Xfatal-warnings
+
+// Ur-assignment operator := looks like omitted Unit syntax,
+// which replaces procedure syntax.
+//
+// This is "safe" because the extra colon signals
+// that inferred Unit is required.
+//
+// That also means that "value discard" is ignored when warning is enabled.
+
+import language.experimental.macros
+
+trait T {
+  // omitted Unit
+  def f(): = println("hello, brave new world")
+
+  // omitted Unit with no space, using Ur-assignment operator
+  def g() := println("hello, brave new world")
+
+  // error on warning, Unit is explicit
+  def h() := { println("I don't care (I love it)") ; 42 }
+
+  // error on warning, Unit is explicit, old style
+  def fail(): Unit = 42
+
+  // ordinary inferred result type
+  def whatever() = 42
+
+  // should still be happy
+  def m() := macro M.m
+}
+
+object M {
+  import scala.reflect.macros.blackbox.Context
+  def m(c: Context)() = {
+    import c.universe._
+    Literal(Constant(()))
+  }
+}


### PR DESCRIPTION

    The weakness of procedure syntax was that
    it is easy to accidentally leave out an
    equals sign, especially as a beginner.
    
    The strength of procedure syntax was that
    it was a strong visual signal for an
    experienced eye that the method is Unit-valued.
    
    This commit takes an omitted result type
    as explicit Unit: `def f(): = ()`.
    
    The extra colon over an inferred result type
    means that it is not an easy beginner trap,
    but it is also pithy and easy to spot for
    experienced eyes.
    
    For aesthetics, also accept `:=` for this
    idiom, since an identifier is not otherwise
    valid in this position.
    
    This identifier was once proposed as
    the Ur-assignment operator, so this syntax
    has the added benefit of triggering one's
    spidey sense, or Speyside sense, depending
    on the time of day. It is also familiar
    from sbt in a different usage.