### PR TITLE
fix #11122 Vector#prependedAll

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -204,18 +204,23 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
     import Vector.{Log2ConcatFaster, TinyAppendFaster}
     if (prefix.isEmpty) this
     else {
-      prefix.size match {
-        case n if n <= TinyAppendFaster || n < (this.size >>> Log2ConcatFaster) =>
-          var v: Vector[B] = this
-          val it = prefix.toIndexedSeq.reverseIterator
-          while (it.hasNext) v = it.next() +: v
-          v
-        case n if this.size < (n >>> Log2ConcatFaster) && prefix.isInstanceOf[Vector[_]] =>
-          var v = prefix.asInstanceOf[Vector[B]]
-          val it = this.iterator
-          while (it.hasNext) v = v :+ it.next()
-          v
-        case _ => super.prependedAll(prefix)
+      prefix match {
+        case prefix: collection.Iterable[B] =>
+          prefix.size match {
+            case n if n <= TinyAppendFaster || n < (this.size >>> Log2ConcatFaster) =>
+              var v: Vector[B] = this
+              val it = prefix.toIndexedSeq.reverseIterator
+              while (it.hasNext) v = it.next() +: v
+              v
+            case n if this.size < (n >>> Log2ConcatFaster) && prefix.isInstanceOf[Vector[_]] =>
+              var v = prefix.asInstanceOf[Vector[B]]
+              val it = this.iterator
+              while (it.hasNext) v = v :+ it.next()
+              v
+            case _ => super.prependedAll(prefix)
+          }
+        case _ =>
+          super.prependedAll(prefix)
       }
     }
   }

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -56,4 +56,10 @@ class VectorTest {
     assertSame(Vector.empty.iterator, Vector.empty.iterator)
     assertSame(Vector.empty.iterator, Vector(1).drop(1).iterator)
   }
+
+  @Test
+  def t11122_prependedAll_Iterator(): Unit = {
+    val i = Iterator.from(1).take(3)
+    assertEquals(Vector(1, 2, 3, 0), Vector(0).prependedAll(i))
+  }
 }


### PR DESCRIPTION
fix https://github.com/scala/bug/issues/11122

[diff without indent changes](https://github.com/scala/scala/pull/7153/files?w=1)