### PR TITLE
[#11114] Fix broken Buffer#patchInPlace

### DIFF
--- a/src/library/scala/collection/mutable/Buffer.scala
+++ b/src/library/scala/collection/mutable/Buffer.scala
@@ -199,7 +199,7 @@ trait IndexedBuffer[A] extends IndexedSeq[A]
       j += 1
     }
     if (j < patch.length) insertAll(i + j, patch.iterator.drop(j))
-    else if (j < replaced0) remove(i + j, replaced0 - j)
+    else if (j < replaced0) remove(i + j, math.min(replaced0 - j, length - i - j))
     this
   }
 }

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -315,4 +315,40 @@ class ArrayBufferTest {
     assertThrows[NoSuchElementException](new ArrayBuffer[Int].iterator.drop(1).next())
   }
 
+  @Test
+  def t11114_ArrayBufferPatch: Unit = {
+    {
+      def newBuf = ArrayBuffer(1, 2, 3, 4, 5)
+      assertEquals(ArrayBuffer(1, 2, 3, 10, 11), newBuf.patchInPlace(3, List(10, 11), 4))
+      assertEquals(ArrayBuffer(1, 2, 3, 10, 11), newBuf.patchInPlace(3, List(10, 11), 10))
+      assertEquals(ArrayBuffer(10, 11), newBuf.patchInPlace(0, List(10, 11), 10))
+      assertEquals(ArrayBuffer(1, 2, 3, 10, 11, 12), newBuf.patchInPlace(3, List(10, 11, 12), 4))
+    }
+
+    for {
+      size <- 0 to 10
+      patchSize <- 0 to 12
+      patch = 100 until (100 + patchSize)
+      from <- -1 to 11
+      replaced <- -1 to 13
+    } {
+      def createBuf = (0 until size).to(ArrayBuffer)
+
+      val fromPatch = createBuf.patch(from, patch, replaced)
+      val fromPatchInPlace = createBuf.patchInPlace(from, patch, replaced)
+
+      assert(fromPatch == fromPatchInPlace,
+        s"""Failed on:
+           |  size: $size
+           |  targetBuffer: $createBuf
+           |  from: $from
+           |  patch sequence: $patch
+           |  replaced: $replaced
+           |  patch returned: $fromPatch
+           |  patchInPlace returned: $fromPatchInPlace
+         """.stripMargin
+      )
+    }
+  }
+
 }


### PR DESCRIPTION
* Fixes the semantics of the implementation
* Adds unit tests to ensure equivalence of `patch` and `patchInPlace` on `ArrayBuffer`

Fixes scala/bug#11114