### PR TITLE
Add smart constructors for scala.concurrent.duration.Duration

### DIFF
--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -8,7 +8,8 @@
 
 package scala.concurrent.duration
 
-import java.lang.{ Double => JDouble, Long => JLong }
+import java.lang.{Double => JDouble, Long => JLong}
+import java.util.concurrent.TimeUnit
 
 object Duration {
 
@@ -127,6 +128,41 @@ object Duration {
     else
       fromNanos(nanos.round)
   }
+
+  /**
+    * Construct a finite duration from the given number of days.
+    */
+  def ofDays(days: Long): FiniteDuration = Duration(days, TimeUnit.DAYS)
+
+  /**
+    * Construct a finite duration from the given number of hours.
+    */
+  def ofHours(hours: Long): FiniteDuration = Duration(hours, TimeUnit.HOURS)
+
+  /**
+    * Construct a finite duration from the given number of minutes.
+    */
+  def ofMinutes(minutes: Long): FiniteDuration = Duration(minutes, TimeUnit.MINUTES)
+
+  /**
+    * Construct a finite duration from the given number of seconds.
+    */
+  def ofSeconds(seconds: Long): FiniteDuration = Duration(seconds, TimeUnit.SECONDS)
+
+  /**
+    * Construct a finite duration from the given number of milliseconds.
+    */
+  def ofMillis(millis: Long): FiniteDuration = Duration(millis, TimeUnit.MILLISECONDS)
+
+  /**
+    * Construct a finite duration from the given number of microseconds.
+    */
+  def ofMicros(micros: Long): FiniteDuration = Duration(micros, TimeUnit.MICROSECONDS)
+
+  /**
+    * Construct a finite duration from the given number of nanos.
+    */
+  def ofNanos(nanos: Long): FiniteDuration = Duration(nanos, TimeUnit.NANOSECONDS)
 
   private[this] final val  µs_per_ns = 1000L
   private[this] final val  ms_per_ns =  µs_per_ns * 1000


### PR DESCRIPTION
This is purely a convenience suggestion, here is my motivation:

I often end up in my editor in a state like this:

```
Await.result(someFuture, ???)
```

Most of the time, I want a duration of a few seconds and currently I have three choices:

1) go to the import section and manually import `scala.concurrent.duration._`
2) write `Duration(10, TimeUnit.SECONDS)`
3) use `Duration.fromNanos(...)`

Alternative 1) is very annoying on a daliy basis, 2) is not very elegant and 3) is bad because I have to convert seconds to nanos.

To improve the situation I added several smart constructors to `scala.concurrent.duration.Duration` that provide the same convenience for other `TimeUnit`s as already exists via `fromNanos`.

So in the end the example from above can be written as:

```
Await.result(someFuture, Duration.fromSeconds(10))
```