### PR TITLE
s.c.m.Buffer#patchInPlace accepts iterableOnce rather than s.c.Seq

### DIFF
--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -125,7 +125,7 @@ private[collection] trait Wrappers {
       }
       this
     }
-    def patchInPlace(from: Int, patch: scala.collection.Seq[A], replaced: Int): this.type = {
+    def patchInPlace(from: Int, patch: scala.collection.IterableOnce[A], replaced: Int): this.type = {
       remove(from, replaced)
       insertAll(from, patch)
       this

--- a/src/library/scala/collection/mutable/Buffer.scala
+++ b/src/library/scala/collection/mutable/Buffer.scala
@@ -116,7 +116,7 @@ trait Buffer[A]
     remove(length - norm, norm)
   }
 
-  def patchInPlace(from: Int, patch: scala.collection.Seq[A], replaced: Int): this.type
+  def patchInPlace(from: Int, patch: scala.collection.IterableOnce[A], replaced: Int): this.type
 
   // +=, ++=, clear inherited from Growable
   // Per remark of @ichoran, we should preferably not have these:
@@ -189,16 +189,16 @@ trait IndexedBuffer[A] extends IndexedSeq[A]
     if (i == j) this else takeInPlace(j)
   }
 
-  def patchInPlace(from: Int, patch: scala.collection.Seq[A], replaced: Int): this.type = {
+  def patchInPlace(from: Int, patch: scala.collection.IterableOnce[A], replaced: Int): this.type = {
     val replaced0 = math.min(math.max(replaced, 0), length)
     val i = math.min(math.max(from, 0), length)
     var j = 0
-    val n = math.min(patch.length, replaced0)
-    while (j < n && i + j < length) {
-      update(i + j, patch(j))
+    val iter = patch.iterator
+    while (iter.hasNext && j < replaced0 && i + j < length) {
+      update(i + j, iter.next())
       j += 1
     }
-    if (j < patch.length) insertAll(i + j, patch.iterator.drop(j))
+    if (iter.hasNext) insertAll(i + j, iter)
     else if (j < replaced0) remove(i + j, math.min(replaced0 - j, length - i - j))
     this
   }

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -270,7 +270,7 @@ class ListBuffer[A]
     this
   }
 
-  def patchInPlace(from: Int, patch: collection.Seq[A], replaced: Int): this.type = {
+  def patchInPlace(from: Int, patch: collection.IterableOnce[A], replaced: Int): this.type = {
     val i = math.min(math.max(from, 0), length)
     val n = math.min(math.max(replaced, 0), length)
     ensureUnaliased()

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -193,7 +193,7 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
     this
   }
 
-  def patchInPlace(from: Int, patch: scala.collection.Seq[T], replaced: Int): this.type = {
+  def patchInPlace(from: Int, patch: collection.IterableOnce[T], replaced: Int): this.type = {
     remove(from, replaced)
     insertAll(from, patch)
     this

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -328,21 +328,22 @@ class ArrayBufferTest {
     for {
       size <- 0 to 10
       patchSize <- 0 to 12
-      patch = 100 until (100 + patchSize)
+      patchRange = 100 until (100 + patchSize)
+      patch <- Seq(() => patchRange.toVector, () => patchRange.iterator)
       from <- -1 to 11
       replaced <- -1 to 13
     } {
       def createBuf = (0 until size).to(ArrayBuffer)
 
-      val fromPatch = createBuf.patch(from, patch, replaced)
-      val fromPatchInPlace = createBuf.patchInPlace(from, patch, replaced)
+      val fromPatch = createBuf.patch(from, patch(), replaced)
+      val fromPatchInPlace = createBuf.patchInPlace(from, patch(), replaced)
 
       assert(fromPatch == fromPatchInPlace,
         s"""Failed on:
            |  size: $size
            |  targetBuffer: $createBuf
            |  from: $from
-           |  patch sequence: $patch
+           |  patch sequence: ${patch()} (${patch().toVector})
            |  replaced: $replaced
            |  patch returned: $fromPatch
            |  patchInPlace returned: $fromPatchInPlace


### PR DESCRIPTION
This is a follow-up to (and is dependent upon) https://github.com/scala/scala/pull/7155  
  
This changes `scala.collection.mutable.Buffer`'s `patchInPlace` method to accept `patch: IterableOnce[A]` rather than `collection.Seq[A]`, in order to be exactly equivalent to the immutable method `def patch[B >: A](from: Int, other: IterableOnce[B], replaced: Int): CC[B]` inherited from `scala.collection.Seq[A]`