### PR TITLE
use if-expressions instead of Boolean#&& and Boolean#|| in VectorMap#equals

### DIFF
--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -112,29 +112,32 @@ final class VectorMap[K, +V] private[immutable] (
   override def equals(that: Any): Boolean =
     that match {
       case map: Map[K, V] =>
-        (this eq map) ||
-          (this.size == map.size) && {
-            try {
-              var i = 0
-              val _size = size
-              while (i < _size) {
-                val k = fields(i)
+        if (this eq map) {
+          true
+        } else if (this.size == map.size) {
+          try {
+            var i = 0
+            val _size = size
+            while (i < _size) {
+              val k = fields(i)
 
-                map.get(k) match {
-                  case Some(value) =>
-                    if (!(value == underlying(k)._2)) {
-                      return false
-                    }
-                  case None =>
+              map.get(k) match {
+                case Some(value) =>
+                  if (!(value == underlying(k)._2)) {
                     return false
-                }
-                i += 1
+                  }
+                case None =>
+                  return false
               }
-              true
-            } catch {
-              case _: ClassCastException => false
+              i += 1
             }
+            true
+          } catch {
+            case _: ClassCastException => false
           }
+        } else {
+          false
+        }
       case _ => super.equals(that)
     }
 


### PR DESCRIPTION
workaround for https://github.com/scala/bug/issues/11127

[diff with whitespace ignored](
https://github.com/scala/scala/pull/7162/files?w=1)