### PR TITLE
Deprecate implicit universal Equiv instance

### DIFF
--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -35,9 +35,11 @@ trait Equiv[T] extends Any with Serializable {
   def equiv(x: T, y: T): Boolean
 }
 
+@deprecated("This only existed for the implicit universalEquiv. Use the explicit Equiv.universal instead.", "2.13.0")
 trait LowPriorityEquiv {
   self: Equiv.type =>
 
+  @deprecated("This being implicit was error-prone. Use the explicit Equiv.universal instead.", "2.13.0")
   implicit def universalEquiv[T] : Equiv[T] = universal[T]
 }
 


### PR DESCRIPTION
One of the benefits of type class-based equality is that the compiler
can enforce that you only check equality on types for which it is
meaningful (as opposed to universal equality such as Java's `equals`
that will allow you to compare any two objects even if it's a
meaningless comparison due to a typo).

Having an implicit universal `Equiv` instance throws away this benefit.
With this instance in scope (and it always is, since it's in the
companion object), the compiler will happily let you compare two `Any`
instances, two `Function1` instances, etc, even though doing so is
probably a mistake. Also, even if you have defined a well-behaved
`Equiv` instance for your type, if you forget to import it, the
universal instance will jump in to take its place without the compiler
warning you.

[Here](https://twitter.com/jvican/status/1034529059911426048?s=19) is a recent tweet from @jvican on the subject.

This also came up in a [discussion](https://github.com/typelevel/cats/issues/2455) in the Cats
repo that I started recently about what it would take for Cats to start
using `Equiv`/`PartialOrdering`/`Ordering` from the standard library
instead of having its own version of these type classes. I'm a bit
hesitant to link to that conversation here, since it goes well beyond
the scope of this PR, but it is relevant.

If desired, I'll happily change this to a PR to remove this instance
altogether for Scala 2.13, but I wasn't sure whether it was too late to
introduce that change.