### PR TITLE
[WIP] Add cache-able ControlThrowables [ci: last-only]

### DIFF
--- a/src/library/scala/util/control/Breaks.scala
+++ b/src/library/scala/util/control/Breaks.scala
@@ -91,4 +91,4 @@ class Breaks {
  */
 object Breaks extends Breaks
 
-private class BreakControl extends ControlThrowable
+private class BreakControl extends ControlThrowable.Cached

--- a/src/library/scala/util/control/Breaks.scala
+++ b/src/library/scala/util/control/Breaks.scala
@@ -91,4 +91,4 @@ class Breaks {
  */
 object Breaks extends Breaks
 
-private class BreakControl extends ControlThrowable.Cached
+private class BreakControl extends ControlThrowable.Cacheable

--- a/src/library/scala/util/control/ControlThrowable.scala
+++ b/src/library/scala/util/control/ControlThrowable.scala
@@ -35,31 +35,31 @@ package util.control
 trait ControlThrowable extends Throwable with NoStackTrace
 
 object ControlThrowable {
-  sealed trait CachedBase extends ControlThrowable {
+  sealed trait CacheableBase extends ControlThrowable {
     override def fillInStackTrace(): Throwable = this
   }
 
   class Cacheable(message: String)
     extends Throwable(message, null, false, false)
-    with CachedBase {
+    with CacheableBase {
     def this() = this(null)
   }
 
   class CacheableError(message: String)
     extends Error(message, null, false, false)
-    with CachedBase {
+    with CacheableBase {
     def this() = this(null)
   }
 
   class CacheableException(message: String)
     extends Exception(message, null, false, false)
-    with CachedBase {
+    with CacheableBase {
     def this() = this(null)
   }
 
   class CacheableRuntimeException(message: String)
     extends RuntimeException(message, null, false, false)
-    with CachedBase {
+    with CacheableBase {
     def this() = this(null)
   }
 }

--- a/src/library/scala/util/control/ControlThrowable.scala
+++ b/src/library/scala/util/control/ControlThrowable.scala
@@ -33,3 +33,33 @@ package util.control
  *  @author Miles Sabin
  */
 trait ControlThrowable extends Throwable with NoStackTrace
+
+object ControlThrowable {
+  sealed trait CachedBase extends Throwable with ControlThrowable {
+    override def fillInStackTrace(): Throwable = super[Throwable].fillInStackTrace()
+  }
+
+  class Cached(message: String)
+    extends Throwable(message, null, false, false)
+    with CachedBase {
+    def this() = this(null)
+  }
+
+  class CachedError(message: String)
+    extends Error(message, null, false, false)
+    with CachedBase {
+    def this() = this(null)
+  }
+
+  class CachedException(message: String)
+    extends Exception(message, null, false, false)
+    with CachedBase {
+    def this() = this(null)
+  }
+
+  class CachedRuntimeException(message: String)
+    extends RuntimeException(message, null, false, false)
+    with CachedBase {
+    def this() = this(null)
+  }
+}

--- a/src/library/scala/util/control/ControlThrowable.scala
+++ b/src/library/scala/util/control/ControlThrowable.scala
@@ -35,29 +35,29 @@ package util.control
 trait ControlThrowable extends Throwable with NoStackTrace
 
 object ControlThrowable {
-  sealed trait CachedBase extends Throwable with ControlThrowable {
-    override def fillInStackTrace(): Throwable = super[Throwable].fillInStackTrace()
+  sealed trait CachedBase extends ControlThrowable {
+    override def fillInStackTrace(): Throwable = this
   }
 
-  class Cached(message: String)
+  class Cacheable(message: String)
     extends Throwable(message, null, false, false)
     with CachedBase {
     def this() = this(null)
   }
 
-  class CachedError(message: String)
+  class CacheableError(message: String)
     extends Error(message, null, false, false)
     with CachedBase {
     def this() = this(null)
   }
 
-  class CachedException(message: String)
+  class CacheableException(message: String)
     extends Exception(message, null, false, false)
     with CachedBase {
     def this() = this(null)
   }
 
-  class CachedRuntimeException(message: String)
+  class CacheableRuntimeException(message: String)
     extends RuntimeException(message, null, false, false)
     with CachedBase {
     def this() = this(null)


### PR DESCRIPTION
Add subclasses of `ControlThrowable` which strictly disable stack trace
writing and exception suppression.

This has implications for Java's try-with-resources and `scala.util.Using`,
both of which suppress exceptions.

Fixes scala/bug#11116