### PR TITLE
fix BigInt#isWhole

### DIFF
--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -168,7 +168,7 @@ final class BigInt(val bigInteger: BigInteger)
     (shifted.signum != 0) && !(shifted equals BigInt.minusOne)
   }
 
-  def isWhole() = true
+  def isWhole = true
   def underlying = bigInteger
 
   /** Compares this BigInt with the specified BigInt for equality.


### PR DESCRIPTION
https://github.com/scala/scala/commit/f5c102e72fbd835bf66377879bdb8be20d882da1

```
[warn] scala/src/library/scala/math/BigInt.scala:171: non-nullary method overrides nullary method
[warn]   def isWhole() = true
[warn]       ^
```