### PR TITLE
remove "special deprecation policy for 2.12" now that it's passé

### DIFF
--- a/src/library/scala/deprecated.scala
+++ b/src/library/scala/deprecated.scala
@@ -41,16 +41,9 @@ import scala.annotation.meta._
  *  A deprecated element of the Scala language or a definition in the Scala standard library will
  *  be preserved at least for the current major version.
  *
- *  This means that an element deprecated in some 2.12.x release will be preserved in
- *  all 2.12.x releases, but may be removed in 2.13. (A deprecated element
- *  might be kept longer to ease migration. Developers should not rely on this.)
- *
- *  '''Special deprecation policy for Scala 2.12'''<br>
- *  The Scala team has decided to enact a special deprecation policy for Scala 2.12:<br/>
- *
- *  As an upgrade from 2.11 to 2.12 also requires upgrading from Java 6 to Java 8,
- *  deprecated elements will not normally be removed in this release, to ease migration
- *  and cross-building.
+ *  This means that an element deprecated in some 2.13.x release will be preserved in
+ *  all 2.13.x releases, but may be removed in 2.14. (A deprecated element
+ *  might be kept longer to ease migration, but developers should not rely on this.)
  *
  *  @see    The official documentation on [[http://www.scala-lang.org/news/2.11.0/#binary-compatibility binary compatibility]].
  *  @param  message the message to print during compilation if the definition is accessed


### PR DESCRIPTION
(also make the example use 2.13, because why not.)