### PR TITLE
fix StandardDefinitions.scala scaladoc

### DIFF
--- a/src/reflect/scala/reflect/api/StandardDefinitions.scala
+++ b/src/reflect/scala/reflect/api/StandardDefinitions.scala
@@ -131,10 +131,10 @@ trait StandardDefinitions {
      *  scala> val m = typeOf[C].member(TermName("m")).asMethod
      *  m: reflect.runtime.universe.MethodSymbol = method m
      *
-     *  scala> m.params(0)(0).info
+     *  scala> m.paramLists(0)(0).info
      *  res1: reflect.runtime.universe.Type = => scala.Int
      *
-     *  scala> showRaw(m.params(0)(0).info)
+     *  scala> showRaw(m.paramLists(0)(0).info)
      *  res2: String = TypeRef(
      *      ThisType(scala),
      *      scala.<byname>, // <-- ByNameParamClass
@@ -159,10 +159,10 @@ trait StandardDefinitions {
      *  scala> val m = typeOf[C].member(TermName("m")).asMethod
      *  m: reflect.runtime.universe.MethodSymbol = method m
      *
-     *  scala> m.params(0)(0).info
+     *  scala> m.paramLists(0)(0).info
      *  res1: reflect.runtime.universe.Type = <repeated...>[Object]
      *
-     *  scala> showRaw(m.params(0)(0).info)
+     *  scala> showRaw(m.paramLists(0)(0).info)
      *  res2: String = TypeRef(
      *      ThisType(scala),
      *      scala.<repeated...>, // <-- JavaRepeatedParamClass
@@ -184,10 +184,10 @@ trait StandardDefinitions {
      *  scala> val m = typeOf[C].member(TermName("m")).asMethod
      *  m: reflect.runtime.universe.MethodSymbol = method m
      *
-     *  scala> m.params(0)(0).info
+     *  scala> m.paramLists(0)(0).info
      *  res1: reflect.runtime.universe.Type = scala.Int*
      *
-     *  scala> showRaw(m.params(0)(0).info)
+     *  scala> showRaw(m.paramLists(0)(0).info)
      *  res2: String = TypeRef(
      *      ThisType(scala),
      *      scala.<repeated>, // <-- RepeatedParamClass


### PR DESCRIPTION
```
Welcome to Scala 2.13.0-M5 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> class C { def m(x: => Int) = ??? }
defined class C

scala> import scala.reflect.runtime.universe._
import scala.reflect.runtime.universe._

scala> val m = typeOf[C].member(TermName("m")).asMethod
m: reflect.runtime.universe.MethodSymbol = method m

scala> m.params(0)(0).info
         ^
       error: value params is not a member of reflect.runtime.universe.MethodSymbol

scala> m.paramLists(0)(0).info
res1: reflect.runtime.universe.Type = => Int

scala> showRaw(m.paramLists(0)(0).info)
res2: String = TypeRef(ThisType(scala), scala.<byname>, List(TypeRef(ThisType(scala), scala.Int, List())))
```