### PR TITLE
Don't recurse without bound in outerPath

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -264,7 +264,11 @@ abstract class ExplicitOuter extends InfoTransform
     protected def outerPath(base: Tree, from: Symbol, to: Symbol): Tree = {
       //Console.println("outerPath from "+from+" to "+to+" at "+base+":"+base.tpe)
       if (from == to) base
-      else outerPath(outerSelect(base), from.outerClass, to)
+      else {
+        val outerSel = outerSelect(base)
+        if (outerSel.isEmpty) EmptyTree
+        else outerPath(outerSel, from.outerClass, to)
+      }
     }
 
 

--- a/test/files/pos/t10035.scala
+++ b/test/files/pos/t10035.scala
@@ -1,0 +1,11 @@
+trait Inner {
+  def f(): Outer
+}
+
+class Outer(o: Set[Inner]) {
+  def this() = this(Set(1).map{
+    case k => new Inner {
+      def f(): Outer = Outer.this
+    }
+  })
+}


### PR DESCRIPTION
`outerSelect` returns `EmptyTree` if it hits a `Symbol` with no outer accessor. `outerPath` doesn't check for this and will happily hand the returned `EmptyTree` back to outerSelect, and so on until stack overflow.
The fix is to check for an `EmptyTree` result and terminate.

Fixes scala/bug#10035.