### PR TITLE
Wrap map result in Option instead of Some

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -154,7 +154,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
    *  @see foreach
    */
   @inline final def map[B](f: A => B): Option[B] =
-    if (isEmpty) None else Some(f(this.get))
+    if (isEmpty) None else Option(f(this.get))
 
   /** Returns the result of applying $f to this $option's
    *  value if the $option is nonempty.  Otherwise, evaluates


### PR DESCRIPTION
Map produces null pointer exception in following case

```scala
case class Name(firstName: String)

val name = Name("Neeraj")

Option(name).map(_.firstName).map(_.toLowerCase)

val nameNull = Name(null)

Option(nameNull).map(_.firstName).map(_.toLowerCase)  //Throws null pointer exception
```