### PR TITLE
Deprecate universal Equiv instance

### DIFF
--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -39,12 +39,12 @@ trait LowPriorityEquiv {
   self: Equiv.type =>
 
   /**
-   * @deprecated since 2.12.7. An implicit universal Equiv instance allows code to compile when it
-   * is comparing instances of types for which equality isn't well-defined or implemented (for
-   * example, comparing two Function1 instances doesn't generally provide a meaningful result). Use
-   * Equiv.universal explicitly instead. If you really want an implicit univeral Equiv intance
-   * despite the potential problems, you can write a method such as `implicit def universalEquiv[T]:
-   * Equiv[T] = universal[T]`
+   * @deprecated since 2.12.7. This implicit universal `Equiv` instance allows accidentally
+   * comparing instances of types for which equality isn't well-defined or implemented.
+   * (For example, it does not make sense to compare two `Function1` instances.)
+   *
+   * Use `Equiv.universal` explicitly instead. If you really want an implicit univeral `Equiv` instance
+   * despite the potential problems, consider `implicit def universalEquiv[T]: Equiv[T] = universal[T]`.
    */
   @deprecated("Use explicit Equiv.universal instead. See Scaladoc entry for more information: " +
     "https://www.scala-lang.org/api/2.12.7/scala/math/Equiv$.html#universalEquiv[T]:scala.math.Equiv[T]",

--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -38,6 +38,15 @@ trait Equiv[T] extends Any with Serializable {
 trait LowPriorityEquiv {
   self: Equiv.type =>
 
+  /**
+   * @deprecated since 2.12.7. An implicit universal Equiv instance allows code to compile when it
+   * is comparing instances of types for which equality isn't well-defined or implemented (for
+   * example, comparing two Function1 instances doesn't generally provide a meaningful result). Use
+   * Equiv.universal explicitly instead. If you really want an implicit univeral Equiv intance
+   * despite the potential problems, you can write a method such as `implicit def universalEquiv[T]:
+   * Equiv[T] = universal[T]`
+   */
+  @deprecated("Use explicit Equiv.universal instead. See Scaladoc entry for more information.", "2.12.7")
   implicit def universalEquiv[T] : Equiv[T] = universal[T]
 }
 

--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -46,7 +46,9 @@ trait LowPriorityEquiv {
    * despite the potential problems, you can write a method such as `implicit def universalEquiv[T]:
    * Equiv[T] = universal[T]`
    */
-  @deprecated("Use explicit Equiv.universal instead. See Scaladoc entry for more information.", "2.12.7")
+  @deprecated("Use explicit Equiv.universal instead. See Scaladoc entry for more information: " +
+    "https://www.scala-lang.org/api/2.12.7/scala/math/Equiv$.html#universalEquiv[T]:scala.math.Equiv[T]",
+    since = "2.12.7")
   implicit def universalEquiv[T] : Equiv[T] = universal[T]
 }
 


### PR DESCRIPTION
This targets the 2.12 branch. See discussion [here](https://github.com/scala/scala/pull/7164).