### PR TITLE
Remove implicit universal Equiv instance for Scala 2.13

### DIFF
--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -35,13 +35,7 @@ trait Equiv[T] extends Any with Serializable {
   def equiv(x: T, y: T): Boolean
 }
 
-trait LowPriorityEquiv {
-  self: Equiv.type =>
-
-  implicit def universalEquiv[T] : Equiv[T] = universal[T]
-}
-
-object Equiv extends LowPriorityEquiv {
+object Equiv {
   def reference[T <: AnyRef]: Equiv[T] = { _ eq _ }
   def universal[T]: Equiv[T] = { _ == _ }
   def fromComparator[T](cmp: Comparator[T]): Equiv[T] = {

--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -29,13 +29,21 @@ import java.util.Comparator
  *  @since 2.7
  */
 
+sealed trait LowPriorityEquiv2 { self: Equiv.type =>
+  implicit def equivFromPartialOrdering[A](implicit ev: PartialOrdering[A]): Equiv[A] = ev
+}
+
+sealed trait LowPriorityEquiv1 extends LowPriorityEquiv2 { self: Equiv.type =>
+  implicit def equivFromOrdering[A](implicit ev: Ordering[A]): Equiv[A] = ev
+}
+
 trait Equiv[T] extends Any with Serializable {
   /** Returns `true` iff `x` is equivalent to `y`.
    */
   def equiv(x: T, y: T): Boolean
 }
 
-object Equiv {
+object Equiv extends LowPriorityEquiv1 {
   def reference[T <: AnyRef]: Equiv[T] = { _ eq _ }
   def universal[T]: Equiv[T] = { _ == _ }
   def fromComparator[T](cmp: Comparator[T]): Equiv[T] = {

--- a/test/junit/scala/math/EquivTest.scala
+++ b/test/junit/scala/math/EquivTest.scala
@@ -1,0 +1,39 @@
+package scala.math
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class EquivTest {
+  import EquivTest._
+  
+  @Test
+  def testOrderingToEquivResolution: Unit = {
+    implicit val o: Ordering[Box[Int]] = intBoxOrdering
+
+    assert(Equiv[Box[Int]].equiv(Box(3), Box(1 + 2)))
+  }
+
+  @Test
+  def testPartialOrderingToEquivResolution: Unit = {
+    implicit val po: PartialOrdering[Box[Int]] = intBoxOrdering
+
+    assert(Equiv[Box[Int]].equiv(Box(3), Box(1 + 2)))
+  }
+
+  @Test
+  def testOrderingAndPartialOrderingToEquivResolution: Unit = {
+    implicit val po: PartialOrdering[Box[Int]] = intBoxOrdering
+    implicit val o: Ordering[Box[Int]] = intBoxOrdering
+
+    assert(Equiv[Box[Int]].equiv(Box(3), Box(1 + 2)))
+  }
+}
+
+object EquivTest {
+  final case class Box[A](value: A)
+
+  val intBoxOrdering: Ordering[Box[Int]] = Ordering.by(_.value)
+}


### PR DESCRIPTION
Based on discussion [here](https://github.com/scala/scala/pull/7164).

I didn't seem to have to change any tests for this, so either it was
untested or I'm missing something.