### PR TITLE
HashMap uses structural sharing to achieve sub-linear concatenation

### DIFF
--- a/src/library/scala/collection/immutable/ChampCommon.scala
+++ b/src/library/scala/collection/immutable/ChampCommon.scala
@@ -21,6 +21,8 @@ private[immutable] final object Node {
 
   final val SizeMoreThanOne = 2
 
+  final val BranchingFactor = 1 << BitPartitionSize
+
   final def maskFrom(hash: Int, shift: Int): Int = (hash >>> shift) & BitPartitionMask
 
   final def bitposFrom(mask: Int): Int = 1 << mask

--- a/test/scalacheck/scala/collection/immutable/ImmutableChampHashMapProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ImmutableChampHashMapProperties.scala
@@ -6,8 +6,8 @@ import org.scalacheck._
 
 object ImmutableChampHashMapProperties extends Properties("immutable.HashMap") {
 
-  type K = String
-  type V = String
+  type K = Int
+  type V = Int
   type T = (K, V)
 
   //  override def overrideParameters(p: org.scalacheck.Test.Parameters) =


### PR DESCRIPTION
Also depends on #7118 in order to use mutability of the MapNodes.  
If this goes through, I will gladly do the same for HashSets. 