### PR TITLE
Optimize array iterators

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -104,24 +104,25 @@ object ArrayOps {
     def withFilter(q: A => Boolean): WithFilter[A] = new WithFilter[A](a => p(a) && q(a), xs)
   }
 
-  private class ArrayIterator[A](private[this] val xs: Array[A]) extends AbstractIterator[A] {
+  private final class ArrayIterator[@specialized(AnyRef, Int, Double, Long, Float, Char, Byte, Short, Boolean, Unit) A](xs: Array[A]) extends AbstractIterator[A] {
     private[this] var pos = 0
-    def hasNext: Boolean = pos < xs.length
+    private[this] val len = xs.length
+    def hasNext: Boolean = pos < len
     def next(): A = try {
       val r = xs(pos)
       pos += 1
       r
-    } catch { case _: ArrayIndexOutOfBoundsException => throw new NoSuchElementException }
+    } catch { case _: ArrayIndexOutOfBoundsException => Iterator.empty.next() }
   }
 
-  private class ReverseIterator[A](private[this] val xs: Array[A]) extends AbstractIterator[A] {
+  private final class ReverseIterator[@specialized(AnyRef, Int, Double, Long, Float, Char, Byte, Short, Boolean, Unit) A](xs: Array[A]) extends AbstractIterator[A] {
     private[this] var pos = xs.length-1
     def hasNext: Boolean = pos >= 0
     def next(): A = try {
       val r = xs(pos)
       pos -= 1
       r
-    } catch { case _: ArrayIndexOutOfBoundsException => throw new NoSuchElementException }
+    } catch { case _: ArrayIndexOutOfBoundsException => Iterator.empty.next() }
   }
 
   private class GroupedIterator[A](xs: Array[A], groupSize: Int) extends AbstractIterator[Array[A]] {
@@ -318,7 +319,20 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     slice(lo, xs.length)
   }
 
-  def iterator: Iterator[A] = new ArrayOps.ArrayIterator[A](xs)
+  def iterator: Iterator[A] =
+    ((xs: Any) match {
+      case xs: Array[AnyRef]  => new ArrayOps.ArrayIterator(xs)
+      case xs: Array[Int]     => new ArrayOps.ArrayIterator(xs)
+      case xs: Array[Double]  => new ArrayOps.ArrayIterator(xs)
+      case xs: Array[Long]    => new ArrayOps.ArrayIterator(xs)
+      case xs: Array[Float]   => new ArrayOps.ArrayIterator(xs)
+      case xs: Array[Char]    => new ArrayOps.ArrayIterator(xs)
+      case xs: Array[Byte]    => new ArrayOps.ArrayIterator(xs)
+      case xs: Array[Short]   => new ArrayOps.ArrayIterator(xs)
+      case xs: Array[Boolean] => new ArrayOps.ArrayIterator(xs)
+      case xs: Array[Unit]    => new ArrayOps.ArrayIterator(xs)
+      case null               => throw new NullPointerException
+    }).asInstanceOf[Iterator[A]]
 
   /** Partitions elements in fixed size arrays.
     *  @see [[scala.collection.Iterator]], method `grouped`
@@ -384,7 +398,20 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *
     *  @return  an iterator yielding the elements of this array in reversed order
     */
-  def reverseIterator: Iterator[A] = new ArrayOps.ReverseIterator[A](xs)
+  def reverseIterator: Iterator[A] =
+    ((xs: Any) match {
+      case xs: Array[AnyRef]  => new ArrayOps.ReverseIterator(xs)
+      case xs: Array[Int]     => new ArrayOps.ReverseIterator(xs)
+      case xs: Array[Double]  => new ArrayOps.ReverseIterator(xs)
+      case xs: Array[Long]    => new ArrayOps.ReverseIterator(xs)
+      case xs: Array[Float]   => new ArrayOps.ReverseIterator(xs)
+      case xs: Array[Char]    => new ArrayOps.ReverseIterator(xs)
+      case xs: Array[Byte]    => new ArrayOps.ReverseIterator(xs)
+      case xs: Array[Short]   => new ArrayOps.ReverseIterator(xs)
+      case xs: Array[Boolean] => new ArrayOps.ReverseIterator(xs)
+      case xs: Array[Unit]    => new ArrayOps.ReverseIterator(xs)
+      case null               => throw new NullPointerException
+    }).asInstanceOf[Iterator[A]]
 
   /** Selects all elements of this array which satisfy a predicate.
     *

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayIteratorBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayIteratorBenchmark.scala
@@ -1,0 +1,47 @@
+package scala.collection.mutable
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 4, time = 4, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+class ArrayIteratorBenchmarks {
+
+  @Param(Array(
+    "0",
+    "100",
+    /*"200",
+    "300",
+    "400",
+    "500",
+    "600",
+    "700",
+    "800",
+    "900",*/
+    "1000",
+    "10000",
+    "100000",
+    "1000000",
+    "10000000",
+    "100000000",
+  ))
+  var valueCount: Int = _
+
+  var values: Array[Int] = _
+
+  @Setup
+  def setValues(): Unit = {
+    val random: util.Random = new util.Random(0)
+    values = Array.fill(valueCount)(random.nextInt())
+  }
+
+  @Benchmark
+  def arrayIterator(blackhole: Blackhole): Unit = {
+    val i = values.iterator
+    while (i.hasNext) blackhole.consume(i.next())
+  }
+}


### PR DESCRIPTION
Their performance had regressed since 2.12. Now they are consistently
faster than the 2.12 implementation.

Fixes https://github.com/scala/bug/issues/11118

Before:

```
[info] Benchmark                              (valueCount)   Mode  Cnt           Score          Error  Units
[info] ArrayIteratorBenchmarks.arrayIterator             0  thrpt    5  1062464845.202 ± 24904701.044  ops/s
[info] ArrayIteratorBenchmarks.arrayIterator           100  thrpt    5     1478433.436 ±    39484.575  ops/s
[info] ArrayIteratorBenchmarks.arrayIterator          1000  thrpt    5      148765.505 ±     2190.330  ops/s
[info] ArrayIteratorBenchmarks.arrayIterator         10000  thrpt    5       14901.314 ±      364.297  ops/s
[info] ArrayIteratorBenchmarks.arrayIterator        100000  thrpt    5        1459.279 ±       72.760  ops/s
[info] ArrayIteratorBenchmarks.arrayIterator       1000000  thrpt    5         144.065 ±        4.327  ops/s
[info] ArrayIteratorBenchmarks.arrayIterator      10000000  thrpt    5          14.385 ±        0.800  ops/s
[info] ArrayIteratorBenchmarks.arrayIterator     100000000  thrpt    5           1.452 ±        0.052  ops/s
```

After:

```
[info] Benchmark                              (valueCount)   Mode  Cnt           Score          Error  Units
[info] ArrayIteratorBenchmarks.arrayIterator             0  thrpt    5  1053249647.465 ± 33697918.043  ops/s
[info] ArrayIteratorBenchmarks.arrayIterator           100  thrpt    5     1589050.782 ±    64432.883  ops/s
[info] ArrayIteratorBenchmarks.arrayIterator          1000  thrpt    5      157945.945 ±     3639.108  ops/s
[info] ArrayIteratorBenchmarks.arrayIterator         10000  thrpt    5       17558.844 ±      719.517  ops/s
[info] ArrayIteratorBenchmarks.arrayIterator        100000  thrpt    5        1837.055 ±       70.482  ops/s
[info] ArrayIteratorBenchmarks.arrayIterator       1000000  thrpt    5         185.288 ±        9.067  ops/s
[info] ArrayIteratorBenchmarks.arrayIterator      10000000  thrpt    5          18.194 ±        0.893  ops/s
[info] ArrayIteratorBenchmarks.arrayIterator     100000000  thrpt    5           1.831 ±        0.042  ops/s
```