### PR TITLE
WIP: Translate module loads to invokedynamic

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -949,12 +949,8 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
         mnode.visitVarInsn(asm.Opcodes.ALOAD, 0)
       } else {
         val mbt = symInfoTK(module).asClassBType
-        mnode.visitFieldInsn(
-          asm.Opcodes.GETSTATIC,
-          mbt.internalName /* + "$" */ ,
-          strMODULE_INSTANCE_FIELD,
-          mbt.descriptor // for nostalgics: typeToBType(module.tpe).descriptor
-        )
+        val moduleLoadDesc = MethodBType(Nil, mbt).descriptor
+        mnode.visitInvokeDynamicInsn("MODULE$", moduleLoadDesc, moduleLoadBootstrapHandle, mbt.toASMType)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -165,6 +165,9 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
   def                     jiSerializableRef         : ClassBType = _jiSerializableRef.get
   private[this] lazy val _jiSerializableRef         : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(JavaSerializableClass))     // java/io/Serializable
 
+  def                     jlClassRef                : ClassBType = _jlClassRef.get
+  private[this] lazy val _jlClassRef                : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(ClassClass))                // java/lang/Class
+
   def                     jlClassCastExceptionRef   : ClassBType = _jlClassCastExceptionRef.get
   private[this] lazy val _jlClassCastExceptionRef   : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(ClassCastExceptionClass))   // java/lang/ClassCastException
 
@@ -209,6 +212,9 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
 
   def                     srLambdaDeserialize       : ClassBType = _srLambdaDeserialize.get
   private[this] lazy val _srLambdaDeserialize       : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[scala.runtime.LambdaDeserialize]))
+
+  def                     srModuleLoad              : ClassBType = _srModuleLoad.get
+  private[this] lazy val _srModuleLoad              : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[scala.runtime.ModuleLoad]))
 
   def                     srBoxedUnitRef            : ClassBType = _srBoxedUnitRef.get
   private[this] lazy val _srBoxedUnitRef            : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[scala.runtime.BoxedUnit]))
@@ -399,6 +405,22 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
           coreBTypes.StringRef,
           coreBTypes.jliMethodTypeRef,
           ArrayBType(jliMethodHandleRef)
+        ),
+        coreBTypes.jliCallSiteRef
+      ).descriptor,
+      /* itf = */ coreBTypes.srLambdaDeserialize.isInterface.get)
+  }
+
+  def moduleLoadBootstrapHandle: Handle = _moduleLoadBootstrapHandle.get
+  private[this] lazy val _moduleLoadBootstrapHandle: LazyVar[Handle] = runLazy {
+    new Handle(Opcodes.H_INVOKESTATIC,
+      coreBTypes.srModuleLoad.internalName, sn.Bootstrap.toString,
+      MethodBType(
+        List(
+          coreBTypes.jliMethodHandlesLookupRef,
+          coreBTypes.StringRef,
+          coreBTypes.jliMethodTypeRef,
+          coreBTypes.jlClassRef
         ),
         coreBTypes.jliCallSiteRef
       ).descriptor,

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -293,7 +293,7 @@ abstract class BackendUtils extends PerRunInit {
   }
 
   def isModuleLoad(insn: AbstractInsnNode, moduleName: InternalName): Boolean = insn match {
-    case fi: FieldInsnNode => fi.getOpcode == GETSTATIC && fi.owner == moduleName && fi.name == "MODULE$" && fi.desc == ("L" + moduleName + ";")
+    case insn: InvokeDynamicInsnNode => insn.name == "MODULE$" && insn.desc == ("L" + moduleName + ";")
     case _ => false
   }
 

--- a/src/library/scala/runtime/ModuleLoad.java
+++ b/src/library/scala/runtime/ModuleLoad.java
@@ -1,0 +1,48 @@
+package scala.runtime;
+
+
+import java.lang.invoke.*;
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+import static java.lang.invoke.MethodHandles.*;
+import static java.lang.invoke.MethodType.methodType;
+
+public final class ModuleLoad {
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String invokedName,
+                                     MethodType invokedType, Class<?> moduleClass) throws Throwable {
+        MethodHandle getter = lookup.findStaticGetter(moduleClass, "MODULE$", moduleClass);
+        return new ModuleLoadCallSite(getter);
+    }
+
+    private static final class ModuleLoadCallSite extends MutableCallSite {
+        private MethodHandle getter;
+        private static final MethodHandle FALLBACK;
+
+        static {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            try {
+                FALLBACK =
+                        lookup.findVirtual(
+                                ModuleLoadCallSite.class, "fallback", methodType(MethodHandle.class));
+            } catch (NoSuchMethodException | IllegalAccessException e) {
+                throw new AssertionError(e);
+            }
+        }
+
+        ModuleLoadCallSite(MethodHandle getter) {
+            super(methodType(getter.type().returnType()));
+            this.getter = getter;
+            setTarget(foldArguments(exactInvoker(type()), FALLBACK.bindTo(this)));
+        }
+
+        private MethodHandle fallback() throws Throwable {
+            Object result = getter.invoke();
+            MethodHandle target = constant(getter.type().returnType(), result);
+            if (result != null) {
+                setTarget(target);
+            }
+            return target;
+        }
+    }
+}


### PR DESCRIPTION
Trialling out a proposed solution to scala/scala-dev#537

Module loads are translated to an indy which stabilizes
to a constant call site after a non-null value is witnessed.

```
$ mkdir -p /tmp/{old,new}; export code="object O { println() }; object Test { def main(args: Array[String]): Unit = O } "; qscalac -d /tmp/new <(echo $code); scalac-ref 2.13.x -d /tmp/old <(echo $code); jardiff /tmp/{old,new}
```
```diff
diff --git a/O$.class.asm b/O$.class.asm
index 6fcf1bd..bb58d08 100644
--- a/O$.class.asm
+++ b/O$.class.asm
@@ -2,6 +2,8 @@
 // access flags 0x31
 public final class O$ {

+  // access flags 0x19
+  public final static INNERCLASS java/lang/invoke/MethodHandles$Lookup java/lang/invoke/MethodHandles Lookup

   // access flags 0x9
   public static LO$; MODULE$
@@ -20,7 +22,12 @@
     INVOKESPECIAL java/lang/Object.<init> ()V
     ALOAD 0
     PUTSTATIC O$.MODULE$ : LO$;
-    GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
+    INVOKEDYNAMIC MODULE$()Lscala/Predef$; [
+      // handle kind 0x6 : INVOKESTATIC
+      scala/runtime/ModuleLoad.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/Class;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      scala.Predef$.class
+    ]
     INVOKEVIRTUAL scala/Predef$.println ()V
     RETURN
     MAXSTACK = 1
diff --git a/Test$.class.asm b/Test$.class.asm
index 7582ac9..51e39c3 100644
--- a/Test$.class.asm
+++ b/Test$.class.asm
@@ -2,6 +2,8 @@
 // access flags 0x31
 public final class Test$ {

+  // access flags 0x19
+  public final static INNERCLASS java/lang/invoke/MethodHandles$Lookup java/lang/invoke/MethodHandles Lookup

   // access flags 0x19
   public final static LTest$; MODULE$
@@ -27,7 +29,12 @@
   // access flags 0x1
   public main([Ljava/lang/String;)V
     // parameter final  args
-    GETSTATIC O$.MODULE$ : LO$;
+    INVOKEDYNAMIC MODULE$()LO$; [
+      // handle kind 0x6 : INVOKESTATIC
+      scala/runtime/ModuleLoad.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/Class;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      O$.class
+    ]
     POP
     RETURN
     MAXSTACK = 1
```