### PR TITLE
Fix interactions between macros and by-name implicits

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -588,8 +588,7 @@ trait Implicits {
           new SearchResult(ref, EmptyTreeTypeSubstituter, Nil)
         else {
           val recursiveImplicit: Option[OpenImplicit] =
-            if(tree == EmptyTree) None
-            else context.openImplicits find {
+            context.openImplicits find {
               case oi @ OpenImplicit(info, tp, tree1) =>
                 (oi.isByName || isByNamePt) && oi.pt <:< pt
             }

--- a/test/files/pos/byname-implicits-31/Macros_1.scala
+++ b/test/files/pos/byname-implicits-31/Macros_1.scala
@@ -1,0 +1,63 @@
+import scala.language.experimental.macros
+
+import scala.reflect.macros.whitebox
+
+object util {
+  def lazily[T](implicit t: => T): T = t
+}
+
+abstract class Quux {
+  def ping: Ping
+  def pong: Pong
+}
+
+object Quux {
+  implicit def mkQuux: Quux = macro mkImpl
+
+  def mkImpl(c: whitebox.Context): c.Tree = {
+    import c.universe._
+
+    q"""
+      new Quux {
+         def ping = util.lazily[Ping]
+         def pong = util.lazily[Pong]
+      }
+    """
+  }
+}
+
+abstract class Ping {
+  def next: Quux
+}
+
+object Ping {
+  implicit def mkPing: Ping = macro mkImpl
+
+  def mkImpl(c: whitebox.Context): c.Tree = {
+    import c.universe._
+
+    q"""
+      new Ping {
+         def next = util.lazily[Quux]
+      }
+    """
+  }
+}
+
+abstract class Pong {
+  def next: Quux
+}
+
+object Pong {
+  implicit def mkPong: Pong = macro mkImpl
+
+  def mkImpl(c: whitebox.Context): c.Tree = {
+    import c.universe._
+
+    q"""
+      new Pong {
+         def next = util.lazily[Quux]
+      }
+    """
+  }
+}

--- a/test/files/pos/byname-implicits-31/Main_2.flags
+++ b/test/files/pos/byname-implicits-31/Main_2.flags
@@ -1,0 +1,1 @@
+-Ycheck:all

--- a/test/files/pos/byname-implicits-31/Main_2.scala
+++ b/test/files/pos/byname-implicits-31/Main_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  util.lazily[Ping]
+}

--- a/test/files/pos/byname-implicits-31/byname-implicits-29/Macros_1.scala
+++ b/test/files/pos/byname-implicits-31/byname-implicits-29/Macros_1.scala
@@ -1,0 +1,36 @@
+import scala.language.experimental.macros
+
+import scala.reflect.macros.whitebox
+
+object util {
+  def lazily[T](implicit t: => T): T = t
+}
+
+case class Rec[T](res: Rec[T])
+
+class Functor[F[_]]
+
+object Functor {
+  def apply[F[_]](implicit f: => Functor[F]): Functor[F] = f
+
+  implicit def hcons[F[_]](implicit ihc: IsHCons10[F]): Functor[F] = ???
+}
+
+trait IsHCons10[L[_]]
+
+object IsHCons10 {
+  implicit def apply[L[_]]: IsHCons10[L] = macro mkImpl[L]
+
+  def mkImpl[L[_]](c: whitebox.Context)
+    (implicit lTag: c.WeakTypeTag[L[_]]): c.Tree = {
+    import c.universe._
+
+    val tpe = lTag.tpe.etaExpand
+
+    q"""
+      new IsHCons10[$tpe] {
+        def foo = util.lazily[Functor[Rec]]
+      }
+    """
+  }
+}

--- a/test/files/pos/byname-implicits-31/byname-implicits-29/Main_2.flags
+++ b/test/files/pos/byname-implicits-31/byname-implicits-29/Main_2.flags
@@ -1,0 +1,1 @@
+-Ycheck:all

--- a/test/files/pos/byname-implicits-31/byname-implicits-29/Main_2.scala
+++ b/test/files/pos/byname-implicits-31/byname-implicits-29/Main_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  util.lazily[Functor[Rec]]
+}

--- a/test/files/pos/byname-implicits-32/Macros_1.scala
+++ b/test/files/pos/byname-implicits-32/Macros_1.scala
@@ -1,0 +1,70 @@
+import scala.language.experimental.macros
+
+import scala.reflect.macros.whitebox
+
+object util {
+  def lazily[T](implicit t: => T): T = t
+}
+
+abstract class Quux {
+  def ping: Ping
+  def pong: Pong
+}
+
+object Quux {
+  implicit def mkQuux: Quux = macro mkImpl
+
+  def mkImpl(c: whitebox.Context): c.Tree = {
+    import c.universe._
+
+    val ping = c.untypecheck(c.inferImplicitValue(appliedType(definitions.ByNameParamClass, weakTypeOf[Ping]), silent = false))
+    val pong = c.untypecheck(c.inferImplicitValue(appliedType(definitions.ByNameParamClass, weakTypeOf[Pong]), silent = false))
+
+    q"""
+      new Quux {
+         def ping = $ping
+         def pong = $pong
+      }
+    """
+  }
+}
+
+abstract class Ping {
+  def next: Quux
+}
+
+object Ping {
+  implicit def mkPing: Ping = macro mkImpl
+
+  def mkImpl(c: whitebox.Context): c.Tree = {
+    import c.universe._
+
+    val quux = c.untypecheck(c.inferImplicitValue(appliedType(definitions.ByNameParamClass, weakTypeOf[Quux]), silent = false))
+
+    q"""
+      new Ping {
+         def next = $quux
+      }
+    """
+  }
+}
+
+abstract class Pong {
+  def next: Quux
+}
+
+object Pong {
+  implicit def mkPong: Pong = macro mkImpl
+
+  def mkImpl(c: whitebox.Context): c.Tree = {
+    import c.universe._
+
+    val quux = c.untypecheck(c.inferImplicitValue(appliedType(definitions.ByNameParamClass, weakTypeOf[Quux]), silent = false))
+
+    q"""
+      new Pong {
+         def next = $quux
+      }
+    """
+  }
+}

--- a/test/files/pos/byname-implicits-32/Main_2.flags
+++ b/test/files/pos/byname-implicits-32/Main_2.flags
@@ -1,0 +1,1 @@
+-Ycheck:all

--- a/test/files/pos/byname-implicits-32/Main_2.scala
+++ b/test/files/pos/byname-implicits-32/Main_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  util.lazily[Ping]
+}

--- a/test/files/pos/byname-implicits-32/byname-implicits-30/Macros_1.scala
+++ b/test/files/pos/byname-implicits-32/byname-implicits-30/Macros_1.scala
@@ -1,0 +1,25 @@
+import scala.language.experimental.macros
+
+import scala.reflect.macros.whitebox
+
+object util {
+  def lazily[T](implicit t: => T): T = t
+}
+
+abstract class Rec {
+  def next: Rec
+}
+
+object Rec {
+  implicit def mkRec: Rec = macro mkImpl
+
+  def mkImpl(c: whitebox.Context): c.Tree = {
+    import c.universe._
+
+    q"""
+      new Rec {
+         def next = util.lazily[Rec]
+      }
+    """
+  }
+}

--- a/test/files/pos/byname-implicits-32/byname-implicits-30/Main_2.flags
+++ b/test/files/pos/byname-implicits-32/byname-implicits-30/Main_2.flags
@@ -1,0 +1,1 @@
+-Ycheck:all

--- a/test/files/pos/byname-implicits-32/byname-implicits-30/Main_2.scala
+++ b/test/files/pos/byname-implicits-32/byname-implicits-30/Main_2.scala
@@ -1,0 +1,3 @@
+object Test {
+  util.lazily[Rec]
+}

--- a/test/files/run/byname-implicits-30.scala
+++ b/test/files/run/byname-implicits-30.scala
@@ -1,0 +1,17 @@
+object Test {
+  class Loop[T, U](self0: => Loop[T, U], swap0: => Loop[U, T]) {
+    lazy val self: Loop[T, U] = self0
+    lazy val swap: Loop[U, T] = swap0
+  }
+
+  object Loop {
+    implicit def mkLoop[T, U](implicit tu: => Loop[T, U], ut: => Loop[U, T]): Loop[T, U] = new Loop(tu, ut)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val loop = implicitly[Loop[Int, String]]
+    assert(loop.self eq loop)
+    assert(loop.swap.self eq loop.swap)
+    assert(loop.swap.swap eq loop)
+  }
+}


### PR DESCRIPTION
While prototyping a version of shapeless which replaces `Lazy` with by-name implicits it emerged that implicit resolutions which involve both by-name implicits and implicit macros can produce dictionaries
which type check but which have broken owner chains.

This had been anticipated (see 5dd99093) but the ownership change performed there wasn't thoroughgoing enough.

In addition, an unnecessary check in `Implicits.scala`, excluding implicit expansion sites with empty trees when attempting to determine if an implicit resolution was recursive, meant that implicit macros, which
always have empty trees in this case, were never detected as recursive.

Finally, the implicit dictionary is now encoded as,
```scala
final class LazyDefns$n extends java.io.Serializable {
  final val rec$m ...
}
val lazyDefns$n = new LazyDefns$
lazyDefns$n.rec$m
```
rather than as an object, to eliminate the unecessary overhead of object lazy initialization and to allow serialzation in rare cases where the enclosing value is captured.

With this commit a `Lazy`-free shapeless build is possible.