### PR TITLE
Fix ArrayOps#startsWith throwing IndexOutOfBoundsException

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -1318,12 +1318,13 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *         index `offset`, otherwise `false`.
     */
   def startsWith[B >: A](that: Array[B], offset: Int): Boolean = {
+    val safeOffset = offset.max(0)
     val thatl = that.length
-    if(thatl > xs.length-offset) thatl == 0
+    if(thatl > xs.length-safeOffset) thatl == 0
     else {
       var i = 0
       while(i < thatl) {
-        if(xs(i+offset) != that(i)) return false
+        if(xs(i+safeOffset) != that(i)) return false
         i += 1
       }
       true

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -79,6 +79,8 @@ class ArrayOpsTest {
     assertEquals(l0.startsWith(l0, 1), a0.startsWith(a0, 1))
     assertEquals(l0.startsWith(l1, 0), a0.startsWith(a1, 0))
     assertEquals(l0.startsWith(l1, 1), a0.startsWith(a1, 1))
+    assertEquals(l0.startsWith(l1, -1), a0.startsWith(a1, -1))
+    assertEquals(l0.startsWith(l1, Int.MinValue), a0.startsWith(a1, Int.MinValue))
   }
 
   @Test


### PR DESCRIPTION
Addresses https://github.com/scala/bug/issues/11023

ArrayOps#startsWith throws ArrayIndexOutOfBoundsException when negative offset given.
It is incosistent with SeqOpts#startsWith, which treats negative offset as `0` virtually (`iterator drop offset`).

https://github.com/scala/scala/blob/86de18e326c5ccd5d9e3319e111f3a21973bae13/src/library/scala/collection/Seq.scala#L243-L251
