### PR TITLE
Recommend string interpolation instead of toString

### DIFF
--- a/project/GenerateAnyVals.scala
+++ b/project/GenerateAnyVals.scala
@@ -147,7 +147,7 @@ import scala.language.implicitConversions"""
     def mkCoercions = numeric map (x => "def to%s: %s".format(x, x))
     def mkUnaryOps  = unaryOps map (x => "%s\n  def unary_%s : %s".format(x.doc, x.op, this opType I))
     def mkStringOps = List(
-      """@deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String"""
+      """@deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String"""
     )
     def mkShiftOps  = (
       for (op <- shiftOps ; arg <- List(I, L)) yield {

--- a/project/GenerateAnyVals.scala
+++ b/project/GenerateAnyVals.scala
@@ -147,7 +147,7 @@ import scala.language.implicitConversions"""
     def mkCoercions = numeric map (x => "def to%s: %s".format(x, x))
     def mkUnaryOps  = unaryOps map (x => "%s\n  def unary_%s : %s".format(x.doc, x.op, this opType I))
     def mkStringOps = List(
-      """@deprecated("Adding a number and a String is deprecated. Convert the number to a String with `toString` first to call +", "2.13.0") def +(x: String): String"""
+      """@deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String"""
     )
     def mkShiftOps  = (
       for (op <- shiftOps ; arg <- List(I, L)) yield {

--- a/src/library/scala/Byte.scala
+++ b/src/library/scala/Byte.scala
@@ -42,7 +42,7 @@ final abstract class Byte private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Int
 
-  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,

--- a/src/library/scala/Byte.scala
+++ b/src/library/scala/Byte.scala
@@ -42,7 +42,7 @@ final abstract class Byte private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Int
 
-  @deprecated("Adding a number and a String is deprecated. Convert the number to a String with `toString` first to call +", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,

--- a/src/library/scala/Char.scala
+++ b/src/library/scala/Char.scala
@@ -42,7 +42,7 @@ final abstract class Char private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Int
 
-  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,

--- a/src/library/scala/Char.scala
+++ b/src/library/scala/Char.scala
@@ -42,7 +42,7 @@ final abstract class Char private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Int
 
-  @deprecated("Adding a number and a String is deprecated. Convert the number to a String with `toString` first to call +", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,

--- a/src/library/scala/Double.scala
+++ b/src/library/scala/Double.scala
@@ -33,7 +33,7 @@ final abstract class Double private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Double
 
-  @deprecated("Adding a number and a String is deprecated. Convert the number to a String with `toString` first to call +", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String
 
   /** Returns `true` if this value is equal to x, `false` otherwise. */
   def ==(x: Byte): Boolean

--- a/src/library/scala/Double.scala
+++ b/src/library/scala/Double.scala
@@ -33,7 +33,7 @@ final abstract class Double private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Double
 
-  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String
 
   /** Returns `true` if this value is equal to x, `false` otherwise. */
   def ==(x: Byte): Boolean

--- a/src/library/scala/Float.scala
+++ b/src/library/scala/Float.scala
@@ -33,7 +33,7 @@ final abstract class Float private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Float
 
-  @deprecated("Adding a number and a String is deprecated. Convert the number to a String with `toString` first to call +", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String
 
   /** Returns `true` if this value is equal to x, `false` otherwise. */
   def ==(x: Byte): Boolean

--- a/src/library/scala/Float.scala
+++ b/src/library/scala/Float.scala
@@ -33,7 +33,7 @@ final abstract class Float private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Float
 
-  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String
 
   /** Returns `true` if this value is equal to x, `false` otherwise. */
   def ==(x: Byte): Boolean

--- a/src/library/scala/Int.scala
+++ b/src/library/scala/Int.scala
@@ -42,7 +42,7 @@ final abstract class Int private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Int
 
-  @deprecated("Adding a number and a String is deprecated. Convert the number to a String with `toString` first to call +", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,

--- a/src/library/scala/Int.scala
+++ b/src/library/scala/Int.scala
@@ -42,7 +42,7 @@ final abstract class Int private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Int
 
-  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,

--- a/src/library/scala/Long.scala
+++ b/src/library/scala/Long.scala
@@ -42,7 +42,7 @@ final abstract class Long private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Long
 
-  @deprecated("Adding a number and a String is deprecated. Convert the number to a String with `toString` first to call +", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,

--- a/src/library/scala/Long.scala
+++ b/src/library/scala/Long.scala
@@ -42,7 +42,7 @@ final abstract class Long private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Long
 
-  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,

--- a/src/library/scala/Short.scala
+++ b/src/library/scala/Short.scala
@@ -42,7 +42,7 @@ final abstract class Short private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Int
 
-  @deprecated("Adding a number and a String is deprecated. Convert the number to a String with `toString` first to call +", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,

--- a/src/library/scala/Short.scala
+++ b/src/library/scala/Short.scala
@@ -42,7 +42,7 @@ final abstract class Short private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Int
 
-  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"${num}{$str}\"`", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,

--- a/test/files/neg/numeric-add-string-warning.check
+++ b/test/files/neg/numeric-add-string-warning.check
@@ -1,4 +1,4 @@
-numeric-add-string-warning.scala:4: warning: method + in class Int is deprecated (since 2.13.0): Adding a number and a String is deprecated. Convert the number to a String with `toString` first to call +
+numeric-add-string-warning.scala:4: warning: method + in class Int is deprecated (since 2.13.0): Adding a number and a String is deprecated. Use the string interpolation `s"${num}{$str}"`
   val x = 4 + "2"
             ^
 error: No warnings can be incurred under -Xfatal-warnings.

--- a/test/files/neg/numeric-add-string-warning.check
+++ b/test/files/neg/numeric-add-string-warning.check
@@ -1,4 +1,4 @@
-numeric-add-string-warning.scala:4: warning: method + in class Int is deprecated (since 2.13.0): Adding a number and a String is deprecated. Use the string interpolation `s"${num}{$str}"`
+numeric-add-string-warning.scala:4: warning: method + in class Int is deprecated (since 2.13.0): Adding a number and a String is deprecated. Use the string interpolation `s"$num$str"`
   val x = 4 + "2"
             ^
 error: No warnings can be incurred under -Xfatal-warnings.


### PR DESCRIPTION
Adresses https://github.com/scala/bug/issues/11025#issuecomment-405497800

`s""` interpolator is optimized since 2.12.5 (https://github.com/scala/scala/pull/6093), as mentioned in https://github.com/scala/bug/issues/11025#issuecomment-405336747, 