### PR TITLE
Fix ListMap#keys not returning ordered iterable

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -19,7 +19,7 @@ import scala.collection.mutable.{Builder, ImmutableBuilder}
 
 /**
   * This class implements immutable maps using a list-based data structure. List map iterators and
-  * traversal methods visit key-value pairs in the order whey were first inserted.
+  * traversal methods visit key-value pairs in the order they were first inserted.
   *
   * Entries are stored internally in reversed insertion order, which means the newest key is at the
   * head of the list. As such, methods such as `head` and `tail` are O(n), while `last` and `init`

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -63,11 +63,21 @@ sealed class ListMap[K, +V]
   def iterator: Iterator[(K, V)] = {
     var curr: ListMap[K, V] = this
     var res: List[(K, V)] = Nil
-    while (!curr.isEmpty) {
+    while (curr.nonEmpty) {
       res = (curr.key, curr.value) :: res
       curr = curr.next
     }
     res.iterator
+  }
+
+  override def keys: Iterable[K] = {
+    var curr: ListMap[K, V] = this
+    var res: List[K] = Nil
+    while (curr.nonEmpty) {
+      res = curr.key :: res
+      curr = curr.next
+    }
+    res
   }
 
   protected def key: K = throw new NoSuchElementException("key of empty map")

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -9,7 +9,7 @@ import scala.annotation.tailrec
 
 /**
   * This class implements immutable sets using a list-based data structure. List set iterators and
-  * traversal methods visit elements in the order whey were first inserted.
+  * traversal methods visit elements in the order they were first inserted.
   *
   * Elements are stored internally in reversed insertion order, which means the newest element is at
   * the head of the list. As such, methods such as `head` and `tail` are O(n), while `last` and

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -140,7 +140,7 @@ final class VectorMap[K, +V] private[immutable] (
 
   override def foreach[U](f: ((K, V)) => U): Unit = iterator.foreach(f)
 
-  override def keys: Iterable[K] = fields.toIterable
+  override def keys: Iterable[K] = fields
 
   override def values: Iterable[V] = new Iterable[V] {
     override def iterator: Iterator[V] = fields.iterator.map(underlying(_)._2)

--- a/test/junit/scala/collection/immutable/ListMapTest.scala
+++ b/test/junit/scala/collection/immutable/ListMapTest.scala
@@ -45,4 +45,10 @@ class ListMapTest {
     val m = ListMap(1 -> 1, 2 -> 2, 3 -> 3, 5 -> 5, 4 -> 4)
     assertEquals(List(1 -> 1, 2 -> 2, 3 -> 3, 5 -> 5, 4 -> 4), m.iterator.toList)
   }
+
+  @Test
+  def keysShouldPreserveOrderAsInserted: Unit = {
+    val m = ListMap("a" -> "1", "b" -> "2", "c" -> "3", "d" -> "4", "e" -> "5")
+    assertEquals(List("A", "B", "C", "D", "E"), m.keys.map(_.toUpperCase).toList)
+  }
 }


### PR DESCRIPTION
Addresses https://github.com/scala/bug/issues/9594.

Looks like ListMap#iterator and ListSet#iterator is already fixed.

