### PR TITLE
Inline WeakReference get method

### DIFF
--- a/src/compiler/scala/tools/nsc/SubComponent.scala
+++ b/src/compiler/scala/tools/nsc/SubComponent.scala
@@ -63,10 +63,10 @@ abstract class SubComponent {
 
   /** The phase corresponding to this subcomponent in the current compiler run */
   def ownPhase: Phase = {
-    ownPhaseCache.get match {
-      case Some(phase) if ownPhaseRunId == global.currentRunId =>
-        phase
-      case _ =>
+    val cache = ownPhaseCache.underlying.get
+    if (cache != null && ownPhaseRunId == global.currentRunId)
+      cache
+    else {
         val phase = global.currentRun.phaseNamed(phaseName)
         ownPhaseCache = new WeakReference(phase)
         ownPhaseRunId = global.currentRunId


### PR DESCRIPTION
Resolves https://github.com/scala/scala-dev/issues/547

The `get` method from the `WeakReference` class uses the `Option.apply` method to avoid null references. This creates a "Some" object which was only read once, at the pattern match, and then discarded. This PR inlines the code from `WeakReference`, and avoids
creating that `Some` object.