### PR TITLE
Collection hashCode performance improvements

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -16,6 +16,8 @@ package collection.immutable
 import collection.{AbstractIterator, Iterator}
 import java.lang.String
 
+import scala.util.hashing.MurmurHash3
+
 /** The `Range` class represents integer values in range
   *  ''[start;end)'' with non-zero step value `step`.
   *  It's a special case of an indexed sequence.
@@ -417,7 +419,9 @@ sealed abstract class Range(
       super.equals(other)
   }
 
-  /* Note: hashCode can't be overridden without breaking Seq's equals contract. */
+  final override def hashCode: Int =
+    if(length >= 2) MurmurHash3.rangeHash(start, step, lastElement)
+    else super.hashCode
 
   final override def toString: String = {
     val preposition = if (isInclusive) "to" else "until"

--- a/test/benchmarks/src/main/scala/scala/util/hashing/MurmurHash3Benchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/util/hashing/MurmurHash3Benchmark.scala
@@ -1,0 +1,159 @@
+package scala.util.hashing
+
+import java.util.concurrent.TimeUnit
+import scala.collection.immutable.ArraySeq
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class MurmurHash3Benchmark {
+
+  @Param(Array("0", "1", "2", "3", "10", "100", "1000", "10000"))
+  var size: Int = _
+  var ordered: Array[Int] = _
+  var mixed1: Array[Int] = _
+  var mixed2: Array[Int] = _
+  var orderedL: List[Int] = _
+  var mixed1L: List[Int] = _
+  var mixed2L: List[Int] = _
+  var orderedI: IndexedSeq[Int] = _
+  var mixed1I: IndexedSeq[Int] = _
+  var mixed2I: IndexedSeq[Int] = _
+  var range: Range = _
+
+  @Setup(Level.Trial) def initNumbers: Unit = {
+    range = (1 to size)
+    ordered = Array.iterate(1, size)(_ + 1)
+    mixed1 = Array.copyOf(ordered, ordered.length)
+    mixed2 = Array.copyOf(ordered, ordered.length)
+    if(size > 1) {
+      swap(mixed1, 0, 1)
+      swap(mixed2, mixed2.length-1, mixed2.length-2)
+    }
+    orderedL = ordered.toList
+    mixed1L = mixed1.toList
+    mixed2L = mixed2.toList
+    orderedI = ArraySeq.from(ordered)
+    mixed1I = ArraySeq.from(mixed1)
+    mixed2I = ArraySeq.from(mixed2)
+  }
+
+  def swap(a: Array[Int], i1: Int, i2: Int): Unit = {
+    val tmp = a(i1)
+    a(i1) = a(i2)
+    a(i2) = tmp
+  }
+
+  @Benchmark def rangeHash(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.rangeHash(1, 1, size, MurmurHash3.seqSeed))
+
+
+  @Benchmark def oldArrayHashOrdered(bh: Blackhole): Unit =
+    bh.consume(OldMurmurHash3.oldArrayHash(ordered, MurmurHash3.seqSeed))
+
+  @Benchmark def rangeOptimizedArrayHashOrdered(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.arrayHash(ordered, MurmurHash3.seqSeed))
+
+  @Benchmark def rangeOptimizedArrayHashMixed1(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.arrayHash(mixed1, MurmurHash3.seqSeed))
+
+  @Benchmark def rangeOptimizedArrayHashMixed2(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.arrayHash(mixed2, MurmurHash3.seqSeed))
+
+  @Benchmark def oldOrderedHashListOrdered(bh: Blackhole): Unit =
+    bh.consume(OldMurmurHash3.oldOrderedHash(orderedL, MurmurHash3.seqSeed))
+
+  @Benchmark def rangeOptimizedOrderedHashListOrdered(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.orderedHash(orderedL, MurmurHash3.seqSeed))
+
+  @Benchmark def rangeOptimizedOrderedHashListMixed1(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.orderedHash(mixed1L, MurmurHash3.seqSeed))
+
+  @Benchmark def rangeOptimizedOrderedHashListMixed2(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.orderedHash(mixed2L, MurmurHash3.seqSeed))
+
+
+  @Benchmark def oldOrderedHashIndexedOrdered(bh: Blackhole): Unit =
+    bh.consume(OldMurmurHash3.oldOrderedHash(orderedI, MurmurHash3.seqSeed))
+
+  @Benchmark def rangeOptimizedOrderedHashIndexedOrdered(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.orderedHash(orderedI, MurmurHash3.seqSeed))
+
+  @Benchmark def rangeOptimizedOrderedHashIndexedMixed1(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.orderedHash(mixed1I, MurmurHash3.seqSeed))
+
+  @Benchmark def rangeOptimizedOrderedHashIndexedMixed2(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.orderedHash(mixed2I, MurmurHash3.seqSeed))
+
+
+  @Benchmark def rangeOptimizedIndexedHashOrdered(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.indexedSeqHash(orderedI, MurmurHash3.seqSeed))
+
+  @Benchmark def rangeOptimizedIndexedHashMixed1(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.indexedSeqHash(mixed1I, MurmurHash3.seqSeed))
+
+  @Benchmark def rangeOptimizedIndexedHashMixed2(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.indexedSeqHash(mixed2I, MurmurHash3.seqSeed))
+
+
+  @Benchmark def oldListHashOrdered(bh: Blackhole): Unit =
+    bh.consume(OldMurmurHash3.oldListHash(orderedL, MurmurHash3.seqSeed))
+
+  @Benchmark def rangeOptimizedListHashOrdered(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.listHash(orderedL, MurmurHash3.seqSeed))
+
+  @Benchmark def rangeOptimizedListHashMixed1(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.listHash(mixed1L, MurmurHash3.seqSeed))
+
+  @Benchmark def rangeOptimizedListHashMixed2(bh: Blackhole): Unit =
+    bh.consume(MurmurHash3.listHash(mixed2L, MurmurHash3.seqSeed))
+}
+
+object OldMurmurHash3 {
+  import MurmurHash3._
+
+  /** Compute a hash that depends on the order of its arguments.
+    */
+  final def oldOrderedHash(xs: IterableOnce[Any], seed: Int): Int = {
+    var n = 0
+    var h = seed
+    xs.iterator foreach { x =>
+      h = mix(h, x.##)
+      n += 1
+    }
+    finalizeHash(h, n)
+  }
+
+  /** Compute the hash of an array.
+    */
+  final def oldArrayHash[@specialized T](a: Array[T], seed: Int): Int = {
+    var h = seed
+    var i = 0
+    while (i < a.length) {
+      h = mix(h, a(i).##)
+      i += 1
+    }
+    finalizeHash(h, a.length)
+  }
+
+  final def oldListHash(xs: scala.collection.immutable.List[_], seed: Int): Int = {
+    var n = 0
+    var h = seed
+    var elems = xs
+    while (!elems.isEmpty) {
+      val head = elems.head
+      val tail = elems.tail
+      h = mix(h, head.##)
+      n += 1
+      elems = tail
+    }
+    finalizeHash(h, n)
+  }
+}

--- a/test/junit/scala/util/hashing/MurmurHash3Test.scala
+++ b/test/junit/scala/util/hashing/MurmurHash3Test.scala
@@ -1,0 +1,60 @@
+package scala.util.hashing
+
+import scala.collection.immutable.ArraySeq
+import org.junit.Assert._
+import org.junit.Test
+
+class MurmurHash3Test {
+
+  def check(h: Int, a: Array[Int]): Unit = {
+    assertEquals(h, ArraySeq.unsafeWrapArray(a).hashCode)
+    assertEquals(h, MurmurHash3.arrayHash(a, MurmurHash3.seqSeed))
+    assertEquals(h, MurmurHash3.listHash(a.toList, MurmurHash3.seqSeed))
+    assertEquals(h, MurmurHash3.orderedHash(a.toList, MurmurHash3.seqSeed))
+  }
+
+  def swap(a: Array[Int], i1: Int, i2: Int): Unit = {
+    val tmp = a(i1)
+    a(i1) = a(i2)
+    a(i2) = tmp
+  }
+
+  @Test
+  def testRangeConsistency: Unit = for(size <- Seq(0, 1, 2, 3, 4, 10, 100)) {
+    val range = (1 to size)
+    val ordered = Array.iterate(1, size)(_ + 1)
+    assertEquals(range, ArraySeq.unsafeWrapArray(ordered))
+    check(range.hashCode, ordered)
+  }
+
+  @Test
+  def testNonRangeConsistency: Unit = for(size <- Seq(2, 3, 4, 10, 100)) {
+    val range = (1 to size)
+    val ordered = Array.iterate(1, size)(_ + 1)
+    val mixed1 = Array.copyOf(ordered, ordered.length)
+    val mixed2 = Array.copyOf(ordered, ordered.length)
+    swap(mixed1, 0, 1)
+    swap(mixed2, mixed2.length-1, mixed2.length-2)
+    check(ArraySeq.unsafeWrapArray(mixed1).hashCode, mixed1)
+    check(ArraySeq.unsafeWrapArray(mixed2).hashCode, mixed2)
+  }
+
+  @Test
+  def testRangeAlignment: Unit = {
+    // 2 elements: end is normalized
+    val r1 = 1 to 3 by 2
+    val r2 = 1 to 4 by 2
+    assertEquals(r1, r2)
+    assertEquals(r1.hashCode, r2.hashCode)
+    // > 2 elements: end is normalized
+    val r3 = 1 to 9 by 2
+    val r4 = 1 to 10 by 2
+    assertEquals(r3, r4)
+    assertEquals(r3.hashCode, r4.hashCode)
+    // 1 element: end and step are ignored
+    val r5 = 1 to 1 by 2
+    val r6 = 1 to 5 by 17
+    assertEquals(r5, r6)
+    assertEquals(r5.hashCode, r6.hashCode)
+  }
+}


### PR DESCRIPTION
- Use constant-time hashes for Range. Ranges of less than 2 elements
  still use the standard Seq hash. Other Ranges compute the hash
  directly from start, step and end without iterating through all
  elements.

- In order to keep Range hashes consistent with other Seq hashes we
  recognize Seqs where the elements’ hashes change sequentially with a
  fixed step and produce a Range hash instead of a regular Seq hash
  for these. The performance impact is mixed and relatively small.
  On Java 8 HotSpot x64 there are some slowdowns for smallish Seqs
  (but not < 2 elements because these are treated specially) and
  speedups for larger Seqs (which is counter-intuitive because the
  new algorithm is strictly more complex than the old one; it is still
  faster because HotSpot performed loop unrolling for the old algorithm
  which had a negative performance impact). The Range optimization is
  applied to arrayHash, orderedHash and listHash.

- Add (range-optimized) IndexedSeq hashing. Unlike what earlier comments
  in our MurmurHash3 implementation claim, there now is a significant
  performance boost from a specialized implementation.

/cc @pnf 

Here's a full benchmark run without the `IndexedSeq` optimizations:

```
[info] Benchmark                                              (size)  Mode  Cnt      Score      Error  Units
[info] MurmurHash3Benchmark.oldArrayHashOrdered                    0  avgt   20      4.766 ±    0.114  ns/op
[info] MurmurHash3Benchmark.oldArrayHashOrdered                    1  avgt   20      7.683 ±    0.171  ns/op
[info] MurmurHash3Benchmark.oldArrayHashOrdered                    2  avgt   20      9.591 ±    0.201  ns/op
[info] MurmurHash3Benchmark.oldArrayHashOrdered                    3  avgt   20     10.862 ±    0.214  ns/op
[info] MurmurHash3Benchmark.oldArrayHashOrdered                   10  avgt   20     22.588 ±    0.351  ns/op
[info] MurmurHash3Benchmark.oldArrayHashOrdered                  100  avgt   20    197.064 ±    2.166  ns/op
[info] MurmurHash3Benchmark.oldArrayHashOrdered                 1000  avgt   20   2103.802 ±   28.463  ns/op
[info] MurmurHash3Benchmark.oldArrayHashOrdered                10000  avgt   20  21378.506 ±  335.843  ns/op
[info] MurmurHash3Benchmark.oldListHashOrdered                     0  avgt   20      4.583 ±    0.365  ns/op
[info] MurmurHash3Benchmark.oldListHashOrdered                     1  avgt   20      8.794 ±    0.104  ns/op
[info] MurmurHash3Benchmark.oldListHashOrdered                     2  avgt   20     12.617 ±    0.135  ns/op
[info] MurmurHash3Benchmark.oldListHashOrdered                     3  avgt   20     14.956 ±    0.199  ns/op
[info] MurmurHash3Benchmark.oldListHashOrdered                    10  avgt   20     36.975 ±    0.402  ns/op
[info] MurmurHash3Benchmark.oldListHashOrdered                   100  avgt   20    305.132 ±    4.119  ns/op
[info] MurmurHash3Benchmark.oldListHashOrdered                  1000  avgt   20   2934.705 ±   41.807  ns/op
[info] MurmurHash3Benchmark.oldListHashOrdered                 10000  avgt   20  29357.418 ±  243.042  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashOrdered                  0  avgt   20      8.871 ±    0.294  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashOrdered                  1  avgt   20     15.960 ±    0.235  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashOrdered                  2  avgt   20     27.215 ±    0.373  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashOrdered                  3  avgt   20     35.660 ±    0.858  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashOrdered                 10  avgt   20     94.874 ±    1.504  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashOrdered                100  avgt   20    921.109 ±   21.339  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashOrdered               1000  avgt   20   9254.958 ±  120.631  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashOrdered              10000  avgt   20  92146.909 ± 1397.921  ns/op
[info] MurmurHash3Benchmark.rangeHash                              0  avgt   20      8.070 ±    0.329  ns/op
[info] MurmurHash3Benchmark.rangeHash                              1  avgt   20      7.770 ±    0.072  ns/op
[info] MurmurHash3Benchmark.rangeHash                              2  avgt   20      7.821 ±    0.108  ns/op
[info] MurmurHash3Benchmark.rangeHash                              3  avgt   20      7.780 ±    0.099  ns/op
[info] MurmurHash3Benchmark.rangeHash                             10  avgt   20      7.853 ±    0.127  ns/op
[info] MurmurHash3Benchmark.rangeHash                            100  avgt   20      7.806 ±    0.087  ns/op
[info] MurmurHash3Benchmark.rangeHash                           1000  avgt   20      7.675 ±    0.243  ns/op
[info] MurmurHash3Benchmark.rangeHash                          10000  avgt   20      7.503 ±    0.103  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1          0  avgt   20      4.808 ±    0.077  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1          1  avgt   20      7.330 ±    0.129  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1          2  avgt   20     10.928 ±    0.171  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1          3  avgt   20     11.406 ±    0.268  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1         10  avgt   20     22.662 ±    0.251  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1        100  avgt   20    199.573 ±    2.649  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1       1000  avgt   20   2095.051 ±   27.376  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1      10000  avgt   20  21226.062 ±  282.746  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2          0  avgt   20      4.806 ±    0.070  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2          1  avgt   20      7.335 ±    0.098  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2          2  avgt   20     10.956 ±    0.129  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2          3  avgt   20     11.257 ±    0.135  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2         10  avgt   20     24.134 ±    0.351  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2        100  avgt   20    192.812 ±    4.138  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2       1000  avgt   20   1854.044 ±   30.974  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2      10000  avgt   20  18535.794 ±  227.588  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered         0  avgt   20      4.924 ±    0.083  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered         1  avgt   20      7.300 ±    0.059  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered         2  avgt   20     11.315 ±    0.185  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered         3  avgt   20     12.675 ±    0.472  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered        10  avgt   20     24.923 ±    0.321  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered       100  avgt   20    189.875 ±    2.612  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered      1000  avgt   20   1844.843 ±   18.641  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered     10000  avgt   20  18762.374 ±  236.343  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed1           0  avgt   20      4.364 ±    0.056  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed1           1  avgt   20      9.274 ±    0.136  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed1           2  avgt   20     16.256 ±    0.236  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed1           3  avgt   20     18.545 ±    0.216  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed1          10  avgt   20     47.798 ±    0.542  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed1         100  avgt   20    341.948 ±    5.100  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed1        1000  avgt   20   3216.831 ±   42.486  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed1       10000  avgt   20  32054.327 ±  395.534  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed2           0  avgt   20      4.362 ±    0.049  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed2           1  avgt   20      9.310 ±    0.150  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed2           2  avgt   20     16.178 ±    0.301  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed2           3  avgt   20     18.669 ±    0.326  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed2          10  avgt   20     47.033 ±    0.618  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed2         100  avgt   20    338.261 ±    5.645  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed2        1000  avgt   20   3416.425 ±   56.577  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashMixed2       10000  avgt   20  32040.805 ±  564.557  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashOrdered          0  avgt   20      4.306 ±    0.077  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashOrdered          1  avgt   20      9.205 ±    0.093  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashOrdered          2  avgt   20     16.359 ±    0.230  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashOrdered          3  avgt   20     21.200 ±    0.451  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashOrdered         10  avgt   20     48.405 ±    0.808  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashOrdered        100  avgt   20    345.697 ±    5.619  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashOrdered       1000  avgt   20   3312.353 ±   46.730  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedListHashOrdered      10000  avgt   20  31130.434 ±  429.699  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed1        0  avgt   20     19.946 ±    0.201  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed1        1  avgt   20     29.845 ±    0.400  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed1        2  avgt   20     44.786 ±    0.693  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed1        3  avgt   20     49.877 ±    0.663  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed1       10  avgt   20    112.911 ±    2.222  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed1      100  avgt   20    961.552 ±   17.077  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed1     1000  avgt   20   9377.366 ±  126.620  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed1    10000  avgt   20  92066.418 ± 2607.347  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed2        0  avgt   20     19.466 ±    0.440  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed2        1  avgt   20     28.894 ±    0.348  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed2        2  avgt   20     43.234 ±    0.524  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed2        3  avgt   20     47.874 ±    0.616  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed2       10  avgt   20    109.906 ±    2.372  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed2      100  avgt   20    920.379 ±   11.051  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed2     1000  avgt   20   9133.441 ±  154.972  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashMixed2    10000  avgt   20  91156.502 ± 1256.069  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashOrdered       0  avgt   20     19.365 ±    0.272  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashOrdered       1  avgt   20     28.740 ±    0.337  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashOrdered       2  avgt   20     43.736 ±    2.251  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashOrdered       3  avgt   20     56.564 ±    5.880  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashOrdered      10  avgt   20    119.910 ±    2.254  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashOrdered     100  avgt   20    956.385 ±   27.940  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashOrdered    1000  avgt   20   9141.034 ±  139.801  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashOrdered   10000  avgt   20  91790.572 ± 1229.346  ns/op
```

Looking only at Array hashing from an earlier benchmark run. This is the method we started with:

```
[info] MurmurHash3Benchmark.oldArrayHashOrdered                  0  avgt   20      4.770 ±   0.264  ns/op
[info] MurmurHash3Benchmark.oldArrayHashOrdered                  1  avgt   20      7.669 ±   0.125  ns/op
[info] MurmurHash3Benchmark.oldArrayHashOrdered                  2  avgt   20      9.673 ±   0.126  ns/op
[info] MurmurHash3Benchmark.oldArrayHashOrdered                  3  avgt   20     10.777 ±   0.185  ns/op
[info] MurmurHash3Benchmark.oldArrayHashOrdered                 10  avgt   20     22.471 ±   0.310  ns/op
[info] MurmurHash3Benchmark.oldArrayHashOrdered                100  avgt   20    195.470 ±   2.468  ns/op
[info] MurmurHash3Benchmark.oldArrayHashOrdered               1000  avgt   20   2092.634 ±  32.907  ns/op
[info] MurmurHash3Benchmark.oldArrayHashOrdered              10000  avgt   20  20974.062 ± 227.221  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1        0  avgt   20      4.871 ±   0.089  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1        1  avgt   20      7.204 ±   0.162  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1        2  avgt   20     11.214 ±   0.151  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1        3  avgt   20     11.307 ±   0.195  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1       10  avgt   20     22.204 ±   0.345  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1      100  avgt   20    196.264 ±   2.131  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1     1000  avgt   20   2081.643 ±  27.508  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed1    10000  avgt   20  21133.974 ± 218.761  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2        0  avgt   20      4.816 ±   0.073  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2        1  avgt   20      7.216 ±   0.104  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2        2  avgt   20     10.842 ±   0.117  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2        3  avgt   20     11.189 ±   0.114  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2       10  avgt   20     23.946 ±   1.247  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2      100  avgt   20    187.109 ±   2.299  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2     1000  avgt   20   1816.470 ±  22.179  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashMixed2    10000  avgt   20  18222.006 ± 206.935  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered       0  avgt   20      4.785 ±   0.067  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered       1  avgt   20      7.219 ±   0.096  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered       2  avgt   20     10.767 ±   0.333  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered       3  avgt   20     12.057 ±   0.276  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered      10  avgt   20     24.467 ±   0.696  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered     100  avgt   20    189.314 ±   3.318  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered    1000  avgt   20   1808.171 ±  28.840  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedArrayHashOrdered   10000  avgt   20  18243.981 ± 316.244  ns/op
```

And here's the new range-optimized `indexedSeqHash` vs the old `orderedHash`:

```
[info] Benchmark                                                     (size)  Mode  Cnt       Score       Error  Units
[info] MurmurHash3Benchmark.oldOrderedHashIndexedOrdered                  0  avgt   20      24.588 ±     0.251  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashIndexedOrdered                  1  avgt   20      40.172 ±     0.596  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashIndexedOrdered                  2  avgt   20      56.306 ±     0.834  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashIndexedOrdered                  3  avgt   20      72.232 ±     0.668  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashIndexedOrdered                 10  avgt   20     181.092 ±     2.014  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashIndexedOrdered                100  avgt   20     393.088 ±     5.167  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashIndexedOrdered               1000  avgt   20    9933.940 ±    86.177  ns/op
[info] MurmurHash3Benchmark.oldOrderedHashIndexedOrdered              10000  avgt   20  167985.951 ± 35574.693  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed1               0  avgt   20       5.644 ±     0.092  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed1               1  avgt   20       8.673 ±     0.117  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed1               2  avgt   20      14.739 ±     2.036  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed1               3  avgt   20      15.704 ±     1.692  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed1              10  avgt   20      27.555 ±     0.290  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed1             100  avgt   20     203.227 ±     2.759  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed1            1000  avgt   20    4513.190 ±    60.270  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed1           10000  avgt   20   37923.481 ±   474.004  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed2               0  avgt   20       5.632 ±     0.086  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed2               1  avgt   20       8.994 ±     0.384  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed2               2  avgt   20      13.153 ±     0.202  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed2               3  avgt   20      14.593 ±     0.177  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed2              10  avgt   20      28.561 ±     0.253  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed2             100  avgt   20     227.804 ±     2.814  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed2            1000  avgt   20    5490.555 ±   109.540  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashMixed2           10000  avgt   20   44285.149 ±   904.101  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashOrdered              0  avgt   20       5.696 ±     0.180  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashOrdered              1  avgt   20       8.790 ±     0.094  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashOrdered              2  avgt   20      13.402 ±     0.361  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashOrdered              3  avgt   20      15.755 ±     0.404  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashOrdered             10  avgt   20      30.878 ±     1.783  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashOrdered            100  avgt   20     230.209 ±     4.743  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashOrdered           1000  avgt   20    5347.704 ±    76.944  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedIndexedHashOrdered          10000  avgt   20   50813.890 ±   605.234  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed1        0  avgt   20      35.492 ±     0.514  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed1        1  avgt   20      30.531 ±     0.257  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed1        2  avgt   20      36.939 ±     0.508  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed1        3  avgt   20      36.057 ±     0.257  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed1       10  avgt   20      56.351 ±     0.647  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed1      100  avgt   20     336.290 ±     4.927  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed1     1000  avgt   20    9936.769 ±   131.861  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed1    10000  avgt   20  100285.056 ±  1552.665  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed2        0  avgt   20      35.753 ±     0.553  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed2        1  avgt   20      31.010 ±     0.748  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed2        2  avgt   20      36.827 ±     0.824  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed2        3  avgt   20      36.452 ±     0.443  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed2       10  avgt   20      57.640 ±     0.810  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed2      100  avgt   20     352.868 ±     8.634  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed2     1000  avgt   20   10204.176 ±   178.471  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedMixed2    10000  avgt   20  103142.856 ±  1223.103  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedOrdered       0  avgt   20      35.917 ±     0.485  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedOrdered       1  avgt   20      30.488 ±     0.376  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedOrdered       2  avgt   20      36.842 ±     0.482  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedOrdered       3  avgt   20      39.613 ±     0.442  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedOrdered      10  avgt   20      62.243 ±     0.814  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedOrdered     100  avgt   20     371.507 ±     4.134  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedOrdered    1000  avgt   20   10432.483 ±   246.626  ns/op
[info] MurmurHash3Benchmark.rangeOptimizedOrderedHashIndexedOrdered   10000  avgt   20  105692.600 ±  1361.435  ns/op
```
