### PR TITLE
Partest summation respects terse mode

### DIFF
--- a/src/compiler/scala/tools/nsc/reporters/Reporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/Reporter.scala
@@ -43,12 +43,25 @@ object Reporter {
   /** Adapt a reporter to legacy reporter API. Handle `info` by forwarding to `echo`. */
   class AdaptedReporter(val delegate: InternalReporter) extends Reporter with ForwardingReporter {
     override protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = delegate.echo(pos, msg)
+    private def other(severity: Severity): delegate.Severity = severity match {
+      case ERROR   => delegate.ERROR
+      case WARNING => delegate.WARNING
+      case _       => delegate.INFO
+    }
+    override def count(severity: Severity)      = delegate.count(other(severity))
+    override def resetCount(severity: Severity) = delegate.resetCount(other(severity))
+
+    override def errorCount   = delegate.errorCount
+    override def warningCount = delegate.warningCount
+    override def hasErrors    = delegate.hasErrors
+    override def hasWarnings  = delegate.hasWarnings
+
     override def toString() = s"AdaptedReporter($delegate)"
   }
   /** A marker trait for adapted reporters that respect maxerrs. */
   trait LimitedReporter { _: Reporter => }
   /** A legacy `Reporter` adapter that respects `-Xmaxerrs` and `-Xmaxwarns`.  */
-  class LimitingReporter(settings: Settings, protected val delegate: Reporter) extends Reporter with FilteringReporter with LimitedReporter {
+  class LimitingReporter(settings: Settings, delegate0: Reporter) extends AdaptedReporter(delegate0) with FilteringReporter with LimitedReporter {
     override protected def filter(pos: Position, msg: String, severity: Severity) =
       severity match {
         case ERROR   => errorCount   < settings.maxerrs.value

--- a/src/partest/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AbstractRunner.scala
@@ -304,7 +304,8 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
           case t: Throwable => throw new RuntimeException(s"Error running $testFile", t)
         }
       stopwatchDuration = Some(durationMs)
-      val more = reportTest(state, info, durationMs, diffOnFail = config.optShowDiff || onlyIndividualTests , logOnFail = config.optShowLog || onlyIndividualTests)
+      val verboseSummation = onlyIndividualTests && !terse
+      val more = reportTest(state, info, durationMs, diffOnFail = config.optShowDiff || verboseSummation , logOnFail = config.optShowLog || verboseSummation)
       runner.cleanup(state)
       if (more.isEmpty) state
       else {

--- a/src/reflect/scala/reflect/internal/Reporting.scala
+++ b/src/reflect/scala/reflect/internal/Reporting.scala
@@ -117,7 +117,7 @@ abstract class Reporter {
     }
 }
 
-/** A `Reporter` that forwards all methods to a delegate.
+/** A `Reporter` that forwards messages to a delegate.
  *
  *  Concrete subclasses must implement the abstract `delegate` member.
  */
@@ -143,21 +143,7 @@ trait ForwardingReporter extends Reporter {
   override def warning(pos: Position, msg: String) = delegate.warning(pos, msg)
   override def error(pos: Position, msg: String)   = delegate.error(pos, msg)
 
-  private def other(severity: Severity): delegate.Severity = severity match {
-    case ERROR   => delegate.ERROR
-    case WARNING => delegate.WARNING
-    case _       => delegate.INFO
-  }
-  override def count(severity: Severity)      = delegate.count(other(severity))
-  override def resetCount(severity: Severity) = delegate.resetCount(other(severity))
-
-  override def errorCount   = delegate.errorCount
-  override def warningCount = delegate.warningCount
-  override def hasErrors    = delegate.hasErrors
-  override def hasWarnings  = delegate.hasWarnings
-  override def reset()      = delegate.reset()
-  override def flush()      = delegate.flush()
-  override def finish()     = delegate.finish()
-  override def rerunWithDetails(setting: MutableSettings#Setting, name: String) =
-                              delegate.rerunWithDetails(setting, name)
+  override def reset()      = { super.reset() ; delegate.reset() }
+  override def flush()      = { super.flush() ; delegate.flush() }
+  override def finish()     = { super.finish() ; delegate.finish() }
 }

--- a/test/files/run/maxerrs.scala
+++ b/test/files/run/maxerrs.scala
@@ -23,7 +23,7 @@ object Test extends DirectTest {
 
   override def show(): Unit = {
     compile()
-    assert(store.infos.size == limit)
+    assert(store.infos.size == limit, s"${store.infos.size} should be $limit")
   }
   override def newSettings(args: List[String]) = {
     val s = super.newSettings(args)

--- a/test/junit/scala/tools/nsc/reporters/ConsoleReporterTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/ConsoleReporterTest.scala
@@ -159,7 +159,7 @@ class ConsoleReporterTest {
       settings.maxerrs.value  = 1
       settings.maxwarns.value = 1
 
-      new Reporter.LimitingReporter(settings, reporter)
+      new Reporter.LimitingReporter(settings, reporter) with CountingReporter
     }
 
     // pass one message
@@ -193,5 +193,26 @@ class ConsoleReporterTest {
     val reporter = new Reporter.LimitingReporter(new Settings, new StoreReporter)
     // test obsolete API, make sure it doesn't throw
     reporter.info(NoPosition, "goodbye, cruel world", force = false)
+  }
+
+  @Test
+  def adaptedReporterTest(): Unit = {
+    val reporter = createConsoleReporter("r", writerOut)
+    val adapted  = new Reporter.AdaptedReporter(reporter)
+
+    // pass one message
+    testHelper(msg = "Testing display")(adapted.echo(_, "Testing display"))
+    testHelper(msg = "Testing display", severity = "warning: ")(adapted.warning(_, "Testing display"))
+    testHelper(msg = "Testing display", severity = "error: ")(adapted.error(_, "Testing display"))
+
+    assertTrue(adapted.hasErrors)
+    assertEquals(1, adapted.errorCount)
+    assertTrue(adapted.hasWarnings)
+    assertEquals(1, adapted.warningCount)
+    adapted.reset()
+    assertFalse(adapted.hasErrors)
+    assertEquals(0, adapted.errorCount)
+    assertFalse(adapted.hasWarnings)
+    assertEquals(0, adapted.warningCount)
   }
 }


### PR DESCRIPTION
If I ask for `--terse`, I don't want the default `--show-diff` and `--show-log`, because that wouldn't be terse enough. IMHO. In particular, `--terse a.scala b.scala`, terse could have no other meaning.