### PR TITLE
Small performance tweak: Replace a list of booleans by a mutable BitSet.

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4848,11 +4848,20 @@ trait Types
   // sides of a subtyping/equality judgement, which can lead to recursive types
   // being constructed. See pos/t0851 for a situation where this happens.
   @inline final def suspendingTypeVars[T](tvs: List[TypeVar])(op: => T): T = {
-    val saved = tvs map (_.suspended)
+    val saved = bitSetByPredicate(tvs)(_.suspended)
     tvs foreach (_.suspended = true)
 
     try op
-    finally foreach2(tvs, saved)(_.suspended = _)
+    finally {
+      var index = 0
+      var sss = tvs
+      while (sss != Nil) {
+        val tv = sss.head
+        tv.suspended = saved(index)
+        index += 1
+        sss = sss.tail
+      }
+    }
   }
 
   final def stripExistentialsAndTypeVars(ts: List[Type], expandLazyBaseType: Boolean = false): (List[Type], List[Symbol]) = {

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -301,6 +301,19 @@ trait Collections {
     }
   }
 
+  final def bitSetByPredicate[A](xs: List[A])(pred: A => Boolean): mutable.BitSet = {
+    val bs = new mutable.BitSet()
+    var ys = xs
+    var i: Int = 0
+    while (! ys.isEmpty){
+      if (pred(ys.head))
+        bs.add(i)
+      ys = ys.tail
+      i += 1
+    }
+    bs
+  }
+
   final def sequence[A](as: List[Option[A]]): Option[List[A]] = {
     if (as.exists (_.isEmpty)) None
     else Some(as.flatten)


### PR DESCRIPTION
Replace linked list of Booleans with Bitset. 

The method `suspendingTypeVars` is used to wrap an operations inside a block that _suspends_ a set of type variables, by setting the `suspended` boolean state variable to true. After the operation is completed, the previous `suspended` states are restored. To do this, it stores the value of `suspended` for each type variable in the list. 

The previous code was using a `List.map`, which for a list of N variables would create `N` cons (`::`) objects and `N` objects of type Boolean. Using a `BitSet`, that should reduce it to an object of type `BitSet` containing 1 array of length `N / 64`.  