### PR TITLE
Optimize ArrayOps and ArraySeq sorting

### DIFF
--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -7,6 +7,7 @@ import scala.collection.mutable.{ArrayBuffer, ArrayBuilder, Builder, ArraySeq =>
 import scala.collection.{ArrayOps, ClassTagSeqFactory, SeqFactory, StrictOptimizedClassTagSeqFactory}
 import scala.collection.IterableOnce
 import scala.annotation.unchecked.uncheckedVariance
+import scala.util.Sorting
 import scala.util.hashing.MurmurHash3
 import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime
@@ -147,6 +148,14 @@ sealed abstract class ArraySeq[+A]
   override protected[this] def writeReplace(): AnyRef = this
 
   override protected final def applyPreferredMaxLength: Int = Int.MaxValue
+
+  override def sorted[B >: A](implicit ord: Ordering[B]): ArraySeq[A] =
+    if(unsafeArray.length <= 1) this
+    else {
+      val a = Array.copyAs[AnyRef](unsafeArray, length)(ClassTag.AnyRef)
+      Arrays.sort(a, ord.asInstanceOf[Ordering[AnyRef]])
+      new ArraySeq.ofRef[AnyRef](a).asInstanceOf[ArraySeq[A]]
+    }
 }
 
 /**
@@ -231,6 +240,14 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
           that.unsafeArray.asInstanceOf[Array[AnyRef]])
       case _ => super.equals(that)
     }
+    override def sorted[B >: T](implicit ord: Ordering[B]): ArraySeq.ofRef[T] = {
+      if(unsafeArray.length <= 1) this
+      else {
+        val a = unsafeArray.clone()
+        Arrays.sort(a, ord.asInstanceOf[Ordering[T]])
+        new ArraySeq.ofRef(a)
+      }
+    }
   }
 
   @SerialVersionUID(3L)
@@ -244,6 +261,13 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofByte => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    override def sorted[B >: Byte](implicit ord: Ordering[B]): ArraySeq[Byte] =
+      if(length <= 1) this
+      else if(ord eq Ordering.Byte) {
+        val a = unsafeArray.clone()
+        Arrays.sort(a)
+        new ArraySeq.ofByte(a)
+      } else super.sorted[B]
   }
 
   @SerialVersionUID(3L)
@@ -257,6 +281,13 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofShort => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    override def sorted[B >: Short](implicit ord: Ordering[B]): ArraySeq[Short] =
+      if(length <= 1) this
+      else if(ord eq Ordering.Short) {
+        val a = unsafeArray.clone()
+        Arrays.sort(a)
+        new ArraySeq.ofShort(a)
+      } else super.sorted[B]
   }
 
   @SerialVersionUID(3L)
@@ -270,6 +301,13 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofChar => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    override def sorted[B >: Char](implicit ord: Ordering[B]): ArraySeq[Char] =
+      if(length <= 1) this
+      else if(ord eq Ordering.Char) {
+        val a = unsafeArray.clone()
+        Arrays.sort(a)
+        new ArraySeq.ofChar(a)
+      } else super.sorted[B]
 
     override def addString(sb: StringBuilder, start: String, sep: String, end: String): StringBuilder =
       (new MutableArraySeq.ofChar(unsafeArray)).addString(sb, start, sep, end)
@@ -286,6 +324,13 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofInt => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    override def sorted[B >: Int](implicit ord: Ordering[B]): ArraySeq[Int] =
+      if(length <= 1) this
+      else if(ord eq Ordering.Int) {
+        val a = unsafeArray.clone()
+        Arrays.sort(a)
+        new ArraySeq.ofInt(a)
+      } else super.sorted[B]
   }
 
   @SerialVersionUID(3L)
@@ -299,6 +344,13 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofLong => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    override def sorted[B >: Long](implicit ord: Ordering[B]): ArraySeq[Long] =
+      if(length <= 1) this
+      else if(ord eq Ordering.Long) {
+        val a = unsafeArray.clone()
+        Arrays.sort(a)
+        new ArraySeq.ofLong(a)
+      } else super.sorted[B]
   }
 
   @SerialVersionUID(3L)
@@ -338,6 +390,13 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofBoolean => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    override def sorted[B >: Boolean](implicit ord: Ordering[B]): ArraySeq[Boolean] =
+      if(length <= 1) this
+      else if(ord eq Ordering.Boolean) {
+        val a = unsafeArray.clone()
+        Sorting.stableSort(a)
+        new ArraySeq.ofBoolean(a)
+      } else super.sorted[B]
   }
 
   @SerialVersionUID(3L)

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -78,6 +78,9 @@ sealed abstract class ArraySeq[T]
       super.equals(other)
   }
 
+  override def sorted[B >: T](implicit ord: Ordering[B]): ArraySeq[T] =
+    ArraySeq.make(array.asInstanceOf[Array[Any]].sorted(ord.asInstanceOf[Ordering[Any]])).asInstanceOf[ArraySeq[T]]
+
   override def sortInPlace[B >: T]()(implicit ord: Ordering[B]): this.type = {
     if (length > 1) scala.util.Sorting.stableSort(array.asInstanceOf[Array[B]])
     this

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/ArraySeqBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/ArraySeqBenchmark.scala
@@ -1,0 +1,71 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+import java.util.Arrays
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.reflect.ClassTag
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class ArraySeqBenchmark {
+
+  @Param(Array("0", "1", "10", "1000", "10000"))
+  var size: Int = _
+  var integersS: ArraySeq[Int] = _
+  var stringsS: ArraySeq[String] = _
+
+  @Setup(Level.Trial) def initNumbers: Unit = {
+    val integers = (1 to size).toList
+    val strings = integers.map(_.toString)
+    integersS = ArraySeq.unsafeWrapArray(integers.toArray)
+    stringsS = ArraySeq.unsafeWrapArray(strings.toArray)
+  }
+
+  @Benchmark def sortedStringOld(bh: Blackhole): Unit =
+    bh.consume(oldSorted(stringsS))
+
+  @Benchmark def sortedIntOld(bh: Blackhole): Unit =
+    bh.consume(oldSorted(integersS))
+
+  @Benchmark def sortedIntCustomOld(bh: Blackhole): Unit =
+    bh.consume(oldSorted(integersS)(Ordering.Int.reverse, implicitly))
+
+  @Benchmark def sortedStringNew(bh: Blackhole): Unit =
+    bh.consume(stringsS.sorted)
+
+  @Benchmark def sortedIntNew(bh: Blackhole): Unit =
+    bh.consume(integersS.sorted)
+
+  @Benchmark def sortedIntCustomNew(bh: Blackhole): Unit =
+    bh.consume(integersS.sorted(Ordering.Int.reverse))
+
+  private[this] def oldSorted[A](seq: ArraySeq[A])(implicit ord: Ordering[A], tag: ClassTag[A]): ArraySeq[A] = {
+    val len = seq.length
+    val b = ArraySeq.newBuilder[A](tag)
+    if (len == 1) b ++= seq.toIterable
+    else if (len > 1) {
+      b.sizeHint(len)
+      val arr = new Array[AnyRef](len)
+      var i = 0
+      for (x <- seq) {
+        arr(i) = x.asInstanceOf[AnyRef]
+        i += 1
+      }
+      java.util.Arrays.sort(arr, ord.asInstanceOf[Ordering[Object]])
+      i = 0
+      while (i < arr.length) {
+        b += arr(i).asInstanceOf[A]
+        i += 1
+      }
+    }
+    b.result()
+  }
+}

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayOpsBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayOpsBenchmark.scala
@@ -1,9 +1,12 @@
 package scala.collection.mutable
 
 import java.util.concurrent.TimeUnit
+import java.util.Arrays
 
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
+
+import scala.reflect.ClassTag
 
 @BenchmarkMode(Array(Mode.AverageTime))
 @Fork(2)
@@ -14,17 +17,19 @@ import org.openjdk.jmh.infra.Blackhole
 @State(Scope.Benchmark)
 class ArrayOpsBenchmark {
 
-  @Param(Array("10", "1000", "10000"))
+  @Param(Array("0", "1", "10", "1000", "10000"))
   var size: Int = _
   var integers: List[Int] = _
   var strings: List[String] = _
   var integersA: Array[Int] = _
+  var stringsA: Array[String] = _
 
 
   @Setup(Level.Trial) def initNumbers: Unit = {
     integers = (1 to size).toList
     strings = integers.map(_.toString)
     integersA = integers.toArray
+    stringsA = strings.toArray
   }
 
   @Benchmark def appendInteger(bh: Blackhole): Unit = {
@@ -65,5 +70,50 @@ class ArrayOpsBenchmark {
 
   @Benchmark def foldSum(bh: Blackhole): Unit = {
     bh.consume(integersA.fold(0){ (a,b) => a + b })
+  }
+
+  @Benchmark def sortedStringOld(bh: Blackhole): Unit =
+    bh.consume(oldSorted(stringsA))
+
+  @Benchmark def sortedIntOld(bh: Blackhole): Unit =
+    bh.consume(oldSorted(integersA))
+
+  @Benchmark def sortedIntCustomOld(bh: Blackhole): Unit =
+    bh.consume(oldSorted(integersA)(Ordering.Int.reverse))
+
+  @Benchmark def sortedStringNew(bh: Blackhole): Unit =
+    bh.consume(stringsA.sorted)
+
+  @Benchmark def sortedIntNew(bh: Blackhole): Unit =
+    bh.consume(integersA.sorted)
+
+  @Benchmark def sortedIntCustomNew(bh: Blackhole): Unit =
+    bh.consume(integersA.sorted(Ordering.Int.reverse))
+
+  def oldSorted[A, B >: A](xs: Array[A])(implicit ord: Ordering[B]): Array[A] = {
+    implicit def ct = ClassTag[A](xs.getClass.getComponentType)
+    val len = xs.length
+    if(xs.getClass.getComponentType.isPrimitive && len > 1) {
+      // need to copy into a boxed representation to use Java's Arrays.sort
+      val a = new Array[AnyRef](len)
+      var i = 0
+      while(i < len) {
+        a(i) = xs(i).asInstanceOf[AnyRef]
+        i += 1
+      }
+      Arrays.sort(a, ord.asInstanceOf[Ordering[AnyRef]])
+      val res = new Array[A](len)
+      i = 0
+      while(i < len) {
+        res(i) = a(i).asInstanceOf[A]
+        i += 1
+      }
+      res
+    } else {
+      val copy = xs.slice(0, len)
+      if(len > 1)
+        Arrays.sort(copy.asInstanceOf[Array[AnyRef]], ord.asInstanceOf[Ordering[AnyRef]])
+      copy
+    }
   }
 }


### PR DESCRIPTION
- Return the original collection (for immutable.ArraySeq) or a straight
  clone for length <= 1.
- Use Java’s native array sorting methods when sorting primitive arrays
  with the default Ordering.
- Copy primitive arrays into a boxed representation for sorting with a
  non-default Ordering using Java’s native array sorting. ArrayOps
  copies the result back into an unboxed array, immutable.ArraySeq wraps
  the boxed array directly. Both are much faster than Scala’s custom
  in-place sorting implementation.

Supersedes https://github.com/scala/scala/pull/6952, with additional optimizations.

Sorting an object array: No change. This was already as good as we can make it (going straight to Java's native implementation)
```
[info] Benchmark                             (size)  Mode  Cnt       Score      Error  Units
[info] ArrayOpsBenchmark.sortedStringOld          0  avgt   20      17.869 ±     0.199  ns/op
[info] ArrayOpsBenchmark.sortedStringOld          1  avgt   20      11.085 ±     0.114  ns/op
[info] ArrayOpsBenchmark.sortedStringOld         10  avgt   20      72.536 ±     7.423  ns/op
[info] ArrayOpsBenchmark.sortedStringOld        100  avgt   20    1767.907 ±    17.200  ns/op
[info] ArrayOpsBenchmark.sortedStringOld       1000  avgt   20   15965.566 ±   189.701  ns/op
[info] ArrayOpsBenchmark.sortedStringOld      10000  avgt   20  173831.775 ±  1899.360  ns/op

[info] ArrayOpsBenchmark.sortedStringNew          0  avgt   20      11.756 ±     0.390  ns/op
[info] ArrayOpsBenchmark.sortedStringNew          1  avgt   20      11.795 ±     0.136  ns/op
[info] ArrayOpsBenchmark.sortedStringNew         10  avgt   20      61.396 ±     0.807  ns/op
[info] ArrayOpsBenchmark.sortedStringNew        100  avgt   20    1770.621 ±    18.740  ns/op
[info] ArrayOpsBenchmark.sortedStringNew       1000  avgt   20   15657.061 ±   273.989  ns/op
[info] ArrayOpsBenchmark.sortedStringNew      10000  avgt   20  177713.819 ±  2154.167  ns/op
```

Sorting a primitive Int array with the default Ordering: Massive improvement from using Java's default sorting implementation:
```
[info] Benchmark                             (size)  Mode  Cnt       Score      Error  Units
[info] ArrayOpsBenchmark.sortedIntOld             0  avgt   20       8.815 ±     0.112  ns/op
[info] ArrayOpsBenchmark.sortedIntOld             1  avgt   20      11.028 ±     0.127  ns/op
[info] ArrayOpsBenchmark.sortedIntOld            10  avgt   20     100.229 ±     1.508  ns/op
[info] ArrayOpsBenchmark.sortedIntOld           100  avgt   20     659.618 ±     9.881  ns/op
[info] ArrayOpsBenchmark.sortedIntOld          1000  avgt   20    7318.415 ±   118.356  ns/op
[info] ArrayOpsBenchmark.sortedIntOld         10000  avgt   20   67797.645 ±  7449.328  ns/op

[info] ArrayOpsBenchmark.sortedIntNew             0  avgt   20      12.112 ±     0.188  ns/op
[info] ArrayOpsBenchmark.sortedIntNew             1  avgt   20      12.613 ±     0.195  ns/op
[info] ArrayOpsBenchmark.sortedIntNew            10  avgt   20      23.998 ±     0.267  ns/op
[info] ArrayOpsBenchmark.sortedIntNew           100  avgt   20     163.730 ±     1.849  ns/op
[info] ArrayOpsBenchmark.sortedIntNew          1000  avgt   20     864.012 ±     6.645  ns/op
[info] ArrayOpsBenchmark.sortedIntNew         10000  avgt   20    8147.550 ±    76.269  ns/op
```

Sorting a primitive Int array with a non-standard Ordering: Some optimizations but still using the same approach (copying to Object array, native sorting on that, copying back to primitive array) for array sizes > 300, using Scala's `stableSort` for in-place sorting a non-boxed copy for smaller arrays. `stableSort` wins for small array sizes but gets much slower for large arrays. Using it for large arrays might still be worthwhile to conserve memory.
```
[info] Benchmark                             (size)  Mode  Cnt       Score      Error  Units
[info] ArrayOpsBenchmark.sortedIntCustomOld       0  avgt   20       8.860 ±     0.086  ns/op
[info] ArrayOpsBenchmark.sortedIntCustomOld       1  avgt   20      11.153 ±     0.170  ns/op
[info] ArrayOpsBenchmark.sortedIntCustomOld      10  avgt   20     118.920 ±     1.734  ns/op
[info] ArrayOpsBenchmark.sortedIntCustomOld     100  avgt   20     799.530 ±    12.280  ns/op
[info] ArrayOpsBenchmark.sortedIntCustomOld    1000  avgt   20    8316.845 ±   524.701  ns/op
[info] ArrayOpsBenchmark.sortedIntCustomOld   10000  avgt   20   78325.358 ± 11240.512  ns/op

[info] ArrayOpsBenchmark.sortedIntCustomNew       0  avgt   20      14.334 ±     0.191  ns/op
[info] ArrayOpsBenchmark.sortedIntCustomNew       1  avgt   20      15.397 ±     0.581  ns/op
[info] ArrayOpsBenchmark.sortedIntCustomNew      10  avgt   20      47.800 ±     0.541  ns/op
[info] ArrayOpsBenchmark.sortedIntCustomNew     100  avgt   20     413.847 ±     4.284  ns/op
[info] ArrayOpsBenchmark.sortedIntCustomNew    1000  avgt   20    7292.830 ±    98.039  ns/op
[info] ArrayOpsBenchmark.sortedIntCustomNew   10000  avgt   20   72178.150 ±   884.447  ns/op
```

Sorting an `immutable.ArraySeq` with an object array: Big improvement from switching to the optimized array-based sorting instead of falling back to `Seq.sorted`:
```
[info] Benchmark                             (size)  Mode  Cnt       Score      Error  Units
[info] ArraySeqBenchmark.sortedStringOld          0  avgt   20      78.909 ±    1.173  ns/op
[info] ArraySeqBenchmark.sortedStringOld          1  avgt   20      94.850 ±    1.378  ns/op
[info] ArraySeqBenchmark.sortedStringOld         10  avgt   20     275.603 ±    2.217  ns/op
[info] ArraySeqBenchmark.sortedStringOld       1000  avgt   20   27189.362 ±  385.714  ns/op
[info] ArraySeqBenchmark.sortedStringOld      10000  avgt   20  294803.358 ± 5900.791  ns/op

[info] ArraySeqBenchmark.sortedStringNew          0  avgt   20       4.132 ±    0.071  ns/op
[info] ArraySeqBenchmark.sortedStringNew          1  avgt   20       4.128 ±    0.081  ns/op
[info] ArraySeqBenchmark.sortedStringNew         10  avgt   20      76.546 ±    0.899  ns/op
[info] ArraySeqBenchmark.sortedStringNew       1000  avgt   20   15775.443 ±  280.497  ns/op
[info] ArraySeqBenchmark.sortedStringNew      10000  avgt   20  176467.342 ± 2382.472  ns/op
```

Sorting an `immutable.ArraySeq` with a primitive Int array using the default Ordering: Massive improvement from using the primitive sorting implementation:
```
[info] Benchmark                             (size)  Mode  Cnt       Score      Error  Units
[info] ArraySeqBenchmark.sortedIntOld             0  avgt   20      66.731 ±    0.696  ns/op
[info] ArraySeqBenchmark.sortedIntOld             1  avgt   20      87.330 ±    4.183  ns/op
[info] ArraySeqBenchmark.sortedIntOld            10  avgt   20     238.544 ±    3.121  ns/op
[info] ArraySeqBenchmark.sortedIntOld          1000  avgt   20   20181.852 ±  262.960  ns/op
[info] ArraySeqBenchmark.sortedIntOld         10000  avgt   20  200233.699 ± 6651.001  ns/op

[info] ArraySeqBenchmark.sortedIntNew             0  avgt   20       4.177 ±    0.072  ns/op
[info] ArraySeqBenchmark.sortedIntNew             1  avgt   20       4.106 ±    0.054  ns/op
[info] ArraySeqBenchmark.sortedIntNew            10  avgt   20      22.479 ±    0.353  ns/op
[info] ArraySeqBenchmark.sortedIntNew          1000  avgt   20     864.245 ±    9.363  ns/op
[info] ArraySeqBenchmark.sortedIntNew         10000  avgt   20    8170.523 ±   75.056  ns/op
```

Sorting an `immutable.ArraySeq` with a primitive Int array using a non-default Ordering: Huge improvement from using the native sorting implementation on a boxed copy (without having to copy back in the end):
```
[info] Benchmark                             (size)  Mode  Cnt       Score      Error  Units
[info] ArraySeqBenchmark.sortedIntCustomOld       0  avgt   20      66.308 ±    0.614  ns/op
[info] ArraySeqBenchmark.sortedIntCustomOld       1  avgt   20      85.573 ±    0.879  ns/op
[info] ArraySeqBenchmark.sortedIntCustomOld      10  avgt   20     250.266 ±    2.141  ns/op
[info] ArraySeqBenchmark.sortedIntCustomOld    1000  avgt   20   21887.620 ±  270.656  ns/op
[info] ArraySeqBenchmark.sortedIntCustomOld   10000  avgt   20  207129.814 ± 6570.452  ns/op

[info] ArraySeqBenchmark.sortedIntCustomNew       0  avgt   20       4.121 ±    0.060  ns/op
[info] ArraySeqBenchmark.sortedIntCustomNew       1  avgt   20       4.106 ±    0.062  ns/op
[info] ArraySeqBenchmark.sortedIntCustomNew      10  avgt   20      86.280 ±    0.798  ns/op
[info] ArraySeqBenchmark.sortedIntCustomNew    1000  avgt   20    6697.837 ± 1439.887  ns/op
[info] ArraySeqBenchmark.sortedIntCustomNew   10000  avgt   20   80970.927 ± 1028.936  ns/op
```
