### PR TITLE
Small performance tweak: avoid List.map when computing maximum over list.

### DIFF
--- a/src/reflect/scala/reflect/internal/Depth.scala
+++ b/src/reflect/scala/reflect/internal/Depth.scala
@@ -19,6 +19,8 @@ final class Depth private (val depth: Int) extends AnyVal with Ordered[Depth] {
   override def toString = s"Depth($depth)"
 }
 
+trait DepthFunction[A] { def apply(a: A): Depth }
+
 object Depth {
   // A don't care value for the depth parameter in lubs/glbs and related operations.
   // When passed this value, the recursion budget will be inferred from the shape of
@@ -38,7 +40,7 @@ object Depth {
     else new Depth(depth)
   }
 
-  def maximumBy[A](xs: List[A], ff: A => Depth): Depth = {
+  def maximumBy[A](xs: List[A])(ff: DepthFunction[A]): Depth = {
     def maxDepth(d: Depth, x: A) = d max ff(x)
     xs.foldLeft(Zero)(maxDepth)
   }

--- a/src/reflect/scala/reflect/internal/Depth.scala
+++ b/src/reflect/scala/reflect/internal/Depth.scala
@@ -41,7 +41,12 @@ object Depth {
   }
 
   def maximumBy[A](xs: List[A])(ff: DepthFunction[A]): Depth = {
-    def maxDepth(d: Depth, x: A) = d max ff(x)
-    xs.foldLeft(Zero)(maxDepth)
+    var ys: List[A] = xs
+    var mm: Depth = Zero
+    while (!ys.isEmpty){
+      mm = mm max ff(ys.head)
+      ys = ys.tail
+    }
+    mm
   }
 }

--- a/src/reflect/scala/reflect/internal/Depth.scala
+++ b/src/reflect/scala/reflect/internal/Depth.scala
@@ -37,4 +37,9 @@ object Depth {
     if (depth < AnyDepthValue) AnyDepth
     else new Depth(depth)
   }
+
+  def maximumBy[A](xs: List[A], ff: A => Depth): Depth = {
+    def maxDepth(d: Depth, x: A) = d max ff(x)
+    xs.foldLeft(Zero)(maxDepth)
+  }
 }

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4320,7 +4320,7 @@ trait Types
   /** The maximum allowable depth of lubs or glbs over types `ts`.
     */
   def lubDepth(ts: List[Type]): Depth = {
-    val td = typeDepth(ts)
+    val td = maxDepth(ts)
     val bd = baseTypeSeqDepth(ts)
     lubDepthAdjust(td, td max bd)
   }
@@ -4335,9 +4335,9 @@ trait Types
     else if (bd <= Depth(7)) td max (bd decr 2)
     else td.decr max (bd decr 3)
 
-  private def symTypeDepth(syms: List[Symbol]): Depth  = typeDepth(syms map (_.info))
-  private def typeDepth(tps: List[Type]): Depth        = maxDepth(tps)
-  private def baseTypeSeqDepth(tps: List[Type]): Depth = maxbaseTypeSeqDepth(tps)
+  private def infoTypeDepth(sym: Symbol): Depth = typeDepth(sym.info)
+  private def symTypeDepth(syms: List[Symbol]): Depth  = Depth.maximumBy(syms, infoTypeDepth)
+  private def baseTypeSeqDepth(tps: List[Type]): Depth = Depth.maximumBy(tps, (t: Type) => t.baseTypeSeqDepth)
 
   /** Is intersection of given types populated? That is,
    *  for all types tp1, tp2 in intersection
@@ -5115,8 +5115,8 @@ trait Types
 
   /** The maximum depth of type `tp` */
   def typeDepth(tp: Type): Depth = tp match {
-    case TypeRef(pre, sym, args)          => typeDepth(pre) max typeDepth(args).incr
-    case RefinedType(parents, decls)      => typeDepth(parents) max symTypeDepth(decls.toList).incr
+    case TypeRef(pre, sym, args)          => typeDepth(pre) max maxDepth(args).incr
+    case RefinedType(parents, decls)      => maxDepth(parents) max symTypeDepth(decls.toList).incr
     case TypeBounds(lo, hi)               => typeDepth(lo) max typeDepth(hi)
     case MethodType(paramtypes, result)   => typeDepth(result)
     case NullaryMethodType(result)        => typeDepth(result)
@@ -5130,20 +5130,8 @@ trait Types
   //    var d = 0
   //    for (tp <- tps) d = d max by(tp) //!!!OPT!!!
   //    d
-  private[scala] def maxDepth(tps: List[Type]): Depth = {
-    @tailrec def loop(tps: List[Type], acc: Depth): Depth = tps match {
-      case tp :: rest => loop(rest, acc max typeDepth(tp))
-      case _          => acc
-    }
-    loop(tps, Depth.Zero)
-  }
-  private[scala] def maxbaseTypeSeqDepth(tps: List[Type]): Depth = {
-    @tailrec def loop(tps: List[Type], acc: Depth): Depth = tps match {
-      case tp :: rest => loop(rest, acc max tp.baseTypeSeqDepth)
-      case _          => acc
-    }
-    loop(tps, Depth.Zero)
-  }
+  private[scala] def maxDepth(tps: List[Type]): Depth =
+    Depth.maximumBy(tps, typeDepth)
 
   @tailrec private def areTrivialTypes(tps: List[Type]): Boolean = tps match {
     case tp :: rest => tp.isTrivial && areTrivialTypes(rest)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4336,8 +4336,8 @@ trait Types
     else td.decr max (bd decr 3)
 
   private def infoTypeDepth(sym: Symbol): Depth = typeDepth(sym.info)
-  private def symTypeDepth(syms: List[Symbol]): Depth  = Depth.maximumBy(syms, infoTypeDepth)
-  private def baseTypeSeqDepth(tps: List[Type]): Depth = Depth.maximumBy(tps, (t: Type) => t.baseTypeSeqDepth)
+  private def symTypeDepth(syms: List[Symbol]): Depth  = Depth.maximumBy(syms)(infoTypeDepth)
+  private def baseTypeSeqDepth(tps: List[Type]): Depth = Depth.maximumBy(tps)((t: Type) => t.baseTypeSeqDepth)
 
   /** Is intersection of given types populated? That is,
    *  for all types tp1, tp2 in intersection
@@ -5125,13 +5125,8 @@ trait Types
     case _                                => Depth(1)
   }
 
-  //OPT replaced with tail recursive function to save on #closures
-  // was:
-  //    var d = 0
-  //    for (tp <- tps) d = d max by(tp) //!!!OPT!!!
-  //    d
   private[scala] def maxDepth(tps: List[Type]): Depth =
-    Depth.maximumBy(tps, typeDepth)
+    Depth.maximumBy(tps)(typeDepth)
 
   @tailrec private def areTrivialTypes(tps: List[Type]): Boolean = tps match {
     case tp :: rest => tp.isTrivial && areTrivialTypes(rest)


### PR DESCRIPTION
The `Types` trait uses a method to compute the depth of a type. For composite types, this is based on the the maximum depth of its components. In some cases, this was using a call to `List.map(_.info)`, which creates a temporary list of types that is discarded afterwards.

- We add a generic `Depth.maximumBy` method, that computes the maximum over a list in constant space. It takes a function from a generic type to `Depth`.  We replace the loops to compute maximums with calls to this method.
- We invoke this method using different lambda functions, which saves the need to create the auxiliary lists.

