### PR TITLE
Resolve Bug 10896, of a Stack Overflow Error involving higher kinds.

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2238,7 +2238,13 @@ trait Types
 
     // beta-reduce, but don't do partial application -- cycles have been checked in typeRef
     override protected def normalizeImpl =
-      if (typeParamsMatchArgs) betaReduce.normalize
+      if (typeParamsMatchArgs){
+        val br = betaReduce
+        if (br ne this)
+          br.normalize
+        else
+          throw new MalformedType(pre, sym.nameString)
+      }
       else if (isHigherKinded) super.normalizeImpl
       else {
         // if we are overriding a type alias in an erroneous way, don't just

--- a/test/files/neg/t10896.check
+++ b/test/files/neg/t10896.check
@@ -1,0 +1,4 @@
+t10896.scala:3: error: malformed type: t10896.type#S
+ type F[A] = S[S]
+      ^
+one error found

--- a/test/files/neg/t10896.scala
+++ b/test/files/neg/t10896.scala
@@ -1,0 +1,4 @@
+object t10896 {
+ type S[A[_]] = A[A[Int]]
+ type F[A] = S[S]
+}


### PR DESCRIPTION
This Pull Request resolves https://github.com/scala/bug/issues/10896.

The bug was caused by a set of mutually recursive calls between methods `normalize`, `normalizeImpl`, and `betaReduce`, which are declared, defined, and overridden at several places of the `Types` class hierarchy, but none of which was modifying the actual `Type` object they act upon. This resulted in an infinite recursion, leading to a StackOverflow Error. To mitigate this: 

- We add the code example from the bug report as a negative example in the Scala repo. 
- We add a quick fix, to check if the call to `betaReduce` modifies the object. If not, we throw a generic `MalformedType ` error.

This is a Quick & Dirty fix for the reported bug, but it may not be general enough. In Dotty, it uses a more general solution by means of Kind-Checking, but bringing that to Scala may exceed the scope of a bug. 