### PR TITLE
Bug 9151: Add Example case.

### DIFF
--- a/test/files/pos/t9151.scala
+++ b/test/files/pos/t9151.scala
@@ -1,0 +1,15 @@
+class t9151 {
+  abstract class Foo extends Ordered[Foo]
+
+  val seq: Seq[Int] = null
+  val set: Set[Int] = null
+  val map: Map[Int, Int] = null
+  val values: Map[Int, Set[Foo]] = null
+
+  map ++ set.map(_ -> "")
+
+  values ++ seq.groupBy(_ / 2).toSeq.map({
+    case (key, group) =>
+      key -> (values(key) ++ group.map(_ => ""))
+  })
+}


### PR DESCRIPTION
Concerning [Bug 9151](https://github.com/scala/bug/issues/9151)

Bug 9151 concerns a small example program that made the compiler to run out of memory. This commit adds the code in question, originally added by @ochafik. When running the code locally on the latest 2.13.x, the code successfully compiles, albeit it takes me about 8 seconds to do so.