### PR TITLE
Bug t10156: add test files and mark as resolved

### DIFF
--- a/test/files/neg/t10156.check
+++ b/test/files/neg/t10156.check
@@ -1,0 +1,4 @@
+t10156.scala:4: error: could not find implicit value for parameter a: t10156.A
+  val z = x _
+          ^
+one error found

--- a/test/files/neg/t10156.scala
+++ b/test/files/neg/t10156.scala
@@ -1,0 +1,5 @@
+object t10156 {
+  trait A
+  def x(implicit a: A) = a
+  val z = x _
+}


### PR DESCRIPTION
This Pull Request concerns bug https://github.com/scala/bug/issues/10156. It simply adds the test files to the `partest` collection. I have run these files on the current `2.12.x` branch head, using the `partest test/files/neg/t10156.scala`, and the compilation gives an error. 

Therefore, this resolves https://github.com/scala/bug/issues/10156