### PR TITLE
Un-deprecate linesIterator (for JDK 11 friendliness)

### DIFF
--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -125,7 +125,7 @@ self =>
   /** Return all lines in this string in an iterator, excluding trailing line
    *  end characters; i.e., apply `.stripLineEnd` to all lines
    *  returned by `linesWithSeparators`.
-   */
+   */ // TODO: deprecate on 2.13 to avoid conflict on Java 11, which introduces `String::lines` (this is why `linesIterator` has been un-deprecated)
   def lines: Iterator[String] =
     linesWithSeparators map (line => new WrappedString(line).stripLineEnd)
 
@@ -133,7 +133,6 @@ self =>
    *  end characters; i.e., apply `.stripLineEnd` to all lines
    *  returned by `linesWithSeparators`.
    */
-  @deprecated("use `lines` instead","2.11.0")
   def linesIterator: Iterator[String] =
     linesWithSeparators map (line => new WrappedString(line).stripLineEnd)
 

--- a/test/files/run/repl-inline.check
+++ b/test/files/run/repl-inline.check
@@ -1,4 +1,3 @@
-warning: there was one deprecation warning (since 2.11.0); re-run with -deprecation for details
 callerOfCaller: String
 g: String
 h: String


### PR DESCRIPTION
Java 11 introduces the `lines` method on `String`, which means we should
probably avoid using that name, and go back to `linesIterator`.

To allow compiling with -Xfatal-warnings on Java 11, we have no choice
on 2.12 but to un-deprecate this method (well, you could also use `-release 8`, 
assuming you don't want to use any Java APIs beyond that). 

Probably shouldn't immediately deprecate `lines`, since most users will be 
running on Java 8, and are thus not affected by this. Perhaps 2.13 is the 
right time frame for switching around the deprecation.