### PR TITLE
Improve performance of some ArrayOps methods

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -844,15 +844,24 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *  @return       a new aray resulting from applying the given function
     *                `f` to each element of this array and collecting the results.
     */
-  def map[B : ClassTag](f: A => B): Array[B] = {
-    val l = xs.length
-    val res = new Array[B](l)
-    var i = 0
-    while (i < l) {
-      res(i) = f(xs(i))
-      i = i + 1
+  def map[B](f: A => B)(implicit ct: ClassTag[B]): Array[B] = {
+    val len = xs.length
+    val ys = new Array[B](len)
+    if(len > 0) {
+      var i = 0
+      (xs: Any) match {
+        case xs: Array[AnyRef]  => while (i < len) { ys(i) = f(xs(i).asInstanceOf[A]); i = i+1 }
+        case xs: Array[Int]     => while (i < len) { ys(i) = f(xs(i).asInstanceOf[A]); i = i+1 }
+        case xs: Array[Double]  => while (i < len) { ys(i) = f(xs(i).asInstanceOf[A]); i = i+1 }
+        case xs: Array[Long]    => while (i < len) { ys(i) = f(xs(i).asInstanceOf[A]); i = i+1 }
+        case xs: Array[Float]   => while (i < len) { ys(i) = f(xs(i).asInstanceOf[A]); i = i+1 }
+        case xs: Array[Char]    => while (i < len) { ys(i) = f(xs(i).asInstanceOf[A]); i = i+1 }
+        case xs: Array[Byte]    => while (i < len) { ys(i) = f(xs(i).asInstanceOf[A]); i = i+1 }
+        case xs: Array[Short]   => while (i < len) { ys(i) = f(xs(i).asInstanceOf[A]); i = i+1 }
+        case xs: Array[Boolean] => while (i < len) { ys(i) = f(xs(i).asInstanceOf[A]); i = i+1 }
+      }
     }
-    res
+    ys
   }
 
   def mapInPlace(f: A => A): Array[A] = {
@@ -872,7 +881,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *  @return       a new array resulting from applying the given collection-valued function
     *                `f` to each element of this array and concatenating the results.
     */
-  def flatMap[B: ClassTag](f: A => IterableOnce[B]): Array[B] = {
+  def flatMap[B : ClassTag](f: A => IterableOnce[B]): Array[B] = {
     val b = ArrayBuilder.make[B]
     var i = 0
     while(i < xs.length) {
@@ -894,13 +903,25 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     */
   def flatten[B](implicit asIterable: A => scala.collection.Iterable[B], m: ClassTag[B]): Array[B] = {
     val b = ArrayBuilder.make[B]
-    val sizes = map {
-      case is: IndexedSeq[_] => is.size
-      case _ => 0
+    val len = xs.length
+    var size = 0
+    var i = 0
+    while(i < len) {
+      xs(i) match {
+        case it: IterableOnce[_] =>
+          val k = it.knownSize
+          if(k > 0) size += k
+        case a: Array[_] => size += a.length
+        case _ =>
+      }
+      i += 1
     }
-    b.sizeHint(new ArrayOps(sizes).fold(0)(_ + _))
-    for (xs <- this)
-      b ++= asIterable(xs)
+    if(size > 0) b.sizeHint(size)
+    i = 0
+    while(i < len) {
+      b ++= asIterable(xs(i))
+      i += 1
+    }
     b.result()
   }
 
@@ -1227,9 +1248,16 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
   def foreach[U](f: A => U): Unit = {
     val len = xs.length
     var i = 0
-    while(i < len) {
-      f(xs(i))
-      i += 1
+    (xs: Any) match {
+      case xs: Array[AnyRef]  => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Int]     => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Double]  => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Long]    => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Float]   => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Char]    => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Byte]    => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Short]   => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Boolean] => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
     }
   }
 

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayOpsBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayOpsBenchmark.scala
@@ -23,14 +23,42 @@ class ArrayOpsBenchmark {
   var strings: List[String] = _
   var integersA: Array[Int] = _
   var stringsA: Array[String] = _
-
+  var intIntA: Array[Array[Int]] = _
 
   @Setup(Level.Trial) def initNumbers: Unit = {
     integers = (1 to size).toList
     strings = integers.map(_.toString)
     integersA = integers.toArray
     stringsA = strings.toArray
+    intIntA = integersA.map { x => integersA }
   }
+
+  @Benchmark def foreachInt(bh: Blackhole): Unit = {
+    var i = 0
+    integersA.foreach { x => i += x }
+    bh.consume(i)
+  }
+
+  @Benchmark def foreachString(bh: Blackhole): Unit = {
+    var i = 0
+    stringsA.foreach { x => i += x.length }
+    bh.consume(i)
+  }
+
+  @Benchmark def flattenInt(bh: Blackhole): Unit =
+    bh.consume(intIntA.flatten)
+
+  @Benchmark def mapIntInt(bh: Blackhole): Unit =
+    bh.consume(integersA.map(x => 0))
+
+  @Benchmark def mapIntString(bh: Blackhole): Unit =
+    bh.consume(integersA.map(x => ""))
+
+  @Benchmark def mapStringString(bh: Blackhole): Unit =
+    bh.consume(stringsA.map(x => ""))
+
+  @Benchmark def mapStringInt(bh: Blackhole): Unit =
+    bh.consume(stringsA.map(x => 0))
 
   @Benchmark def appendInteger(bh: Blackhole): Unit = {
     var arr = Array.empty[Int]

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -1886,19 +1886,19 @@ class InlinerTest extends BytecodeTesting {
       """.stripMargin
     val c = compileClass(code)
     assertSameSummary(getMethod(c, "t1"), List(
-      ALOAD, ARRAYLENGTH, ISTORE, ILOAD, NEWARRAY, ASTORE, ICONST_0, ISTORE, // init new array, loop counter
-      -1 /*11*/, ILOAD, ILOAD, IF_ICMPGE /*30*/, // loop condition
+      ALOAD, ARRAYLENGTH, ISTORE, ILOAD, NEWARRAY, ASTORE, ILOAD, ICONST_0, IF_ICMPLE /*39*/, ICONST_0, ISTORE, // init new array, loop counter
+      -1 /*14*/, ILOAD, ILOAD, IF_ICMPGE /*39*/, // loop condition
       ALOAD, ILOAD, IALOAD, ICONST_1, IADD, ISTORE, // compute element
       ALOAD, ILOAD, ILOAD, IASTORE, // store element
-      ILOAD, ICONST_1, IADD, ISTORE, GOTO /*11*/, // increase counter, jump
-      -1 /*30*/, ALOAD, ARETURN)
+      ILOAD, ICONST_1, IADD, ISTORE, GOTO /*14*/, // increase counter, jump
+      -1 /*39*/, ALOAD, ARETURN)
     )
     assertSameSummary(getMethod(c, "t2"), List(
-      ALOAD, ARRAYLENGTH, ISTORE, ILOAD, ANEWARRAY, ASTORE, ICONST_0, ISTORE, // init new array, loop counter
-      -1 /*14*/, ILOAD, ILOAD, IF_ICMPGE /*37*/, // loop condition
+      ALOAD, ARRAYLENGTH, ISTORE, ILOAD, ANEWARRAY, ASTORE, ILOAD, ICONST_0, IF_ICMPLE /*38*/, ICONST_0, ISTORE, // init new array, loop counter
+      -1 /*15*/, ILOAD, ILOAD, IF_ICMPGE /*38*/, // loop condition
       ALOAD, ILOAD, AALOAD, "trim", ASTORE, ALOAD, ILOAD, ALOAD, AASTORE, // compute and store element
-      ILOAD, ICONST_1, IADD, ISTORE, GOTO /*14*/, // increase counter, jump
-      -1 /*37*/, ALOAD, ARETURN)
+      ILOAD, ICONST_1, IADD, ISTORE, GOTO /*15*/, // increase counter, jump
+      -1 /*38*/, ALOAD, ARETURN)
     )
   }
 


### PR DESCRIPTION
- `map` is specialized on the source array type. Specializing on the
  target type does not have any measurable effect. Recognizing
  specialized function types to avoid boxing had a large negative
  effect. `flatMap` did not benefit from a similar treatment.
- `flatten` uses a more efficient way to estimate the target size and
  also takes nested arrays into account.
- `foreach` is specialized on the array type for much better performance
  with primitive arrays.

Here's some performance data:

`map` shows big improvements for larger primitive arrays, no changes for others:
```
[info] Benchmark                             (size)  Mode  Cnt     Score    Error  Units
[info] ArrayOpsBenchmark.mapIntIntNew             0  avgt    5    25.071 ±  1.371  ns/op
[info] ArrayOpsBenchmark.mapIntIntNew             1  avgt    5    20.556 ±  1.233  ns/op
[info] ArrayOpsBenchmark.mapIntIntNew            10  avgt    5    25.190 ±  1.484  ns/op
[info] ArrayOpsBenchmark.mapIntIntNew           100  avgt    5    53.542 ±  2.540  ns/op
[info] ArrayOpsBenchmark.mapIntIntNew          1000  avgt    5   405.494 ±  8.233  ns/op
[info] ArrayOpsBenchmark.mapIntIntOld             0  avgt    5    25.748 ±  1.355  ns/op
[info] ArrayOpsBenchmark.mapIntIntOld             1  avgt    5    20.295 ±  1.313  ns/op
[info] ArrayOpsBenchmark.mapIntIntOld            10  avgt    5    30.944 ±  0.714  ns/op
[info] ArrayOpsBenchmark.mapIntIntOld           100  avgt    5   132.725 ±  6.855  ns/op
[info] ArrayOpsBenchmark.mapIntIntOld          1000  avgt    5  1137.030 ± 32.654  ns/op
[info] ArrayOpsBenchmark.mapIntStringNew          0  avgt    5    34.563 ±  0.904  ns/op
[info] ArrayOpsBenchmark.mapIntStringNew          1  avgt    5    32.070 ±  1.272  ns/op
[info] ArrayOpsBenchmark.mapIntStringNew         10  avgt    5    41.398 ±  1.705  ns/op
[info] ArrayOpsBenchmark.mapIntStringNew        100  avgt    5   121.130 ±  1.667  ns/op
[info] ArrayOpsBenchmark.mapIntStringNew       1000  avgt    5   983.286 ± 29.651  ns/op
[info] ArrayOpsBenchmark.mapIntStringOld          0  avgt    5    34.448 ±  0.441  ns/op
[info] ArrayOpsBenchmark.mapIntStringOld          1  avgt    5    31.787 ±  0.185  ns/op
[info] ArrayOpsBenchmark.mapIntStringOld         10  avgt    5    49.799 ±  1.761  ns/op
[info] ArrayOpsBenchmark.mapIntStringOld        100  avgt    5   212.175 ±  8.807  ns/op
[info] ArrayOpsBenchmark.mapIntStringOld       1000  avgt    5  1511.642 ± 94.519  ns/op
[info] ArrayOpsBenchmark.mapStringIntNew          0  avgt    5    25.013 ±  1.099  ns/op
[info] ArrayOpsBenchmark.mapStringIntNew          1  avgt    5    21.002 ±  0.392  ns/op
[info] ArrayOpsBenchmark.mapStringIntNew         10  avgt    5    23.068 ±  1.279  ns/op
[info] ArrayOpsBenchmark.mapStringIntNew        100  avgt    5    53.668 ±  2.897  ns/op
[info] ArrayOpsBenchmark.mapStringIntNew       1000  avgt    5   401.520 ± 21.021  ns/op
[info] ArrayOpsBenchmark.mapStringIntOld          0  avgt    5    24.889 ±  0.880  ns/op
[info] ArrayOpsBenchmark.mapStringIntOld          1  avgt    5    21.867 ±  0.505  ns/op
[info] ArrayOpsBenchmark.mapStringIntOld         10  avgt    5    24.117 ±  0.784  ns/op
[info] ArrayOpsBenchmark.mapStringIntOld        100  avgt    5    54.455 ±  4.601  ns/op
[info] ArrayOpsBenchmark.mapStringIntOld       1000  avgt    5   412.629 ± 25.483  ns/op
[info] ArrayOpsBenchmark.mapStringStringNew       0  avgt    5    35.171 ±  1.641  ns/op
[info] ArrayOpsBenchmark.mapStringStringNew       1  avgt    5    32.194 ±  0.560  ns/op
[info] ArrayOpsBenchmark.mapStringStringNew      10  avgt    5    41.073 ±  0.679  ns/op
[info] ArrayOpsBenchmark.mapStringStringNew     100  avgt    5   121.382 ±  5.912  ns/op
[info] ArrayOpsBenchmark.mapStringStringNew    1000  avgt    5   991.019 ± 67.719  ns/op
[info] ArrayOpsBenchmark.mapStringStringOld       0  avgt    5    35.031 ±  1.856  ns/op
[info] ArrayOpsBenchmark.mapStringStringOld       1  avgt    5    32.891 ±  0.402  ns/op
[info] ArrayOpsBenchmark.mapStringStringOld      10  avgt    5    40.808 ±  2.417  ns/op
[info] ArrayOpsBenchmark.mapStringStringOld     100  avgt    5   114.096 ±  5.302  ns/op
[info] ArrayOpsBenchmark.mapStringStringOld    1000  avgt    5   992.567 ± 61.525  ns/op
```

`flatten` shows huge improvements for an `Array[Array[_]]` (there is still a significant improvement just from the more efficient size calculation by itself but the larger part comes from taking nested arrays into account):
```
[info] Benchmark                        (size)  Mode  Cnt        Score        Error  Units
[info] ArrayOpsBenchmark.flattenIntNew       0  avgt    5       27.203 ±      0.994  ns/op
[info] ArrayOpsBenchmark.flattenIntNew       1  avgt    5       56.914 ±      1.349  ns/op
[info] ArrayOpsBenchmark.flattenIntNew      10  avgt    5      164.321 ±     11.637  ns/op
[info] ArrayOpsBenchmark.flattenIntNew     100  avgt    5     4702.348 ±     99.674  ns/op
[info] ArrayOpsBenchmark.flattenIntNew    1000  avgt    5   728406.319 ±  55499.579  ns/op
[info] ArrayOpsBenchmark.flattenIntOld       0  avgt    5       48.357 ±      2.966  ns/op
[info] ArrayOpsBenchmark.flattenIntOld       1  avgt    5       93.496 ±      4.586  ns/op
[info] ArrayOpsBenchmark.flattenIntOld      10  avgt    5      476.141 ±     18.808  ns/op
[info] ArrayOpsBenchmark.flattenIntOld     100  avgt    5    20390.761 ±    183.365  ns/op
[info] ArrayOpsBenchmark.flattenIntOld    1000  avgt    5  2536749.218 ± 110570.121  ns/op
```

`foreach` shows huge improvements for primitive arrays, no change for object arrays:
```
[info] Benchmark                           (size)  Mode  Cnt     Score    Error  Units
[info] ArrayOpsBenchmark.foreachIntNew          0  avgt    5     3.363 ±  0.055  ns/op
[info] ArrayOpsBenchmark.foreachIntNew          1  avgt    5     4.153 ±  0.191  ns/op
[info] ArrayOpsBenchmark.foreachIntNew         10  avgt    5     7.738 ±  0.637  ns/op
[info] ArrayOpsBenchmark.foreachIntNew        100  avgt    5    32.361 ±  1.185  ns/op
[info] ArrayOpsBenchmark.foreachIntNew       1000  avgt    5   325.033 ± 13.255  ns/op
[info] ArrayOpsBenchmark.foreachIntOld          0  avgt    5     3.320 ±  0.110  ns/op
[info] ArrayOpsBenchmark.foreachIntOld          1  avgt    5     4.775 ±  0.131  ns/op
[info] ArrayOpsBenchmark.foreachIntOld         10  avgt    5    16.258 ±  0.261  ns/op
[info] ArrayOpsBenchmark.foreachIntOld        100  avgt    5   110.588 ±  4.885  ns/op
[info] ArrayOpsBenchmark.foreachIntOld       1000  avgt    5  2560.176 ± 71.902  ns/op
[info] ArrayOpsBenchmark.foreachStringNew       0  avgt    5     3.340 ±  0.234  ns/op
[info] ArrayOpsBenchmark.foreachStringNew       1  avgt    5     4.494 ±  0.090  ns/op
[info] ArrayOpsBenchmark.foreachStringNew      10  avgt    5    11.324 ±  0.212  ns/op
[info] ArrayOpsBenchmark.foreachStringNew     100  avgt    5    67.151 ±  1.572  ns/op
[info] ArrayOpsBenchmark.foreachStringNew    1000  avgt    5  1220.985 ± 29.322  ns/op
[info] ArrayOpsBenchmark.foreachStringOld       0  avgt    5     3.288 ±  0.305  ns/op
[info] ArrayOpsBenchmark.foreachStringOld       1  avgt    5     4.443 ±  0.310  ns/op
[info] ArrayOpsBenchmark.foreachStringOld      10  avgt    5    11.205 ±  0.208  ns/op
[info] ArrayOpsBenchmark.foreachStringOld     100  avgt    5    67.801 ±  1.442  ns/op
[info] ArrayOpsBenchmark.foreachStringOld    1000  avgt    5  1203.988 ± 30.366  ns/op
```