### PR TITLE
[test] Break partest pos check files [don't merge]

### DIFF
--- a/test/files/pos/constant-warning.check
+++ b/test/files/pos/constant-warning.check
@@ -2,3 +2,5 @@ constant-warning.scala:2: warning: Evaluation of a constant expression results i
   val fails = 1 + 2 / (3 - 2 - 1)
                     ^
 one warning found
+
+some text that doesn't actually appear in the output

--- a/test/files/pos/t8001.check
+++ b/test/files/pos/t8001.check
@@ -1,0 +1,1 @@
+some text that doesn't actually appear in the output


### PR DESCRIPTION
I have been running into problems where partest doesn't verify the output for `partest pos`, so I'm checking if that's just a local problem or not. 