### PR TITLE
override Range#map

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -123,6 +123,11 @@ sealed abstract class Range(
     else new Range.Exclusive(start + step, end, step)
   }
 
+  override def map[B](f: Int => B): IndexedSeq[B] = {
+    validateMaxLength()
+    super.map(f)
+  }
+
   final protected def copy(start: Int = start, end: Int = end, step: Int = step, isInclusive: Boolean = isInclusive): Range =
     if(isInclusive) new Range.Inclusive(start, end, step) else new Range.Exclusive(start, end, step)
 

--- a/test/junit/scala/collection/immutable/RangeTest.scala
+++ b/test/junit/scala/collection/immutable/RangeTest.scala
@@ -56,4 +56,9 @@ class RangeTest {
 
     assertEquals(10, it.next)
   }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def largeRangeMap(): Unit = {
+    Int.MinValue to Int.MaxValue map identity
+  }
 }


### PR DESCRIPTION
```
Welcome to Scala 2.13.0-M5 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> Int.MinValue to Int.MaxValue map identity
java.lang.OutOfMemoryError: GC overhead limit exceeded
  at java.lang.Integer.valueOf(Integer.java:832)
  at scala.runtime.BoxesRunTime.boxToInteger(BoxesRunTime.java:65)
  at .$anonfun$res0$1(<console>:1)
  at $$Lambda$892/95964948.apply$mcII$sp(Unknown Source)
  at scala.runtime.java8.JFunction1$mcII$sp.apply(JFunction1$mcII$sp.java:12)
  at scala.collection.StrictOptimizedIterableOps.map(StrictOptimizedIterableOps.scala:88)
  at scala.collection.StrictOptimizedIterableOps.map$(StrictOptimizedIterableOps.scala:75)
  at scala.collection.immutable.Range.map(Range.scala:45)
  ... 24 elided
```

```
Welcome to Scala 2.12.6 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> Int.MinValue to Int.MaxValue map identity
java.lang.IllegalArgumentException: -2147483648 to 2147483647 by 1: seqs cannot contain more than Int.MaxValue elements.
  at scala.collection.immutable.Range.fail(Range.scala:138)
  at scala.collection.immutable.Range.length(Range.scala:135)
  at scala.collection.immutable.Range.size(Range.scala:134)
  at scala.collection.IndexedSeqLike.sizeHintIfCheap(IndexedSeqLike.scala:96)
  at scala.collection.IndexedSeqLike.sizeHintIfCheap$(IndexedSeqLike.scala:96)
  at scala.collection.immutable.Range.sizeHintIfCheap(Range.scala:60)
  at scala.collection.mutable.Builder.sizeHint(Builder.scala:77)
  at scala.collection.mutable.Builder.sizeHint$(Builder.scala:76)
  at scala.collection.immutable.VectorBuilder.sizeHint(Vector.scala:635)
  at scala.collection.TraversableLike.builder$1(TraversableLike.scala:230)
  at scala.collection.TraversableLike.map(TraversableLike.scala:233)
  at scala.collection.TraversableLike.map$(TraversableLike.scala:227)
  at scala.collection.AbstractTraversable.map(Traversable.scala:104)
  ... 28 elided
```