### PR TITLE
Allow escaping Scaladoc table cell delimiter

### DIFF
--- a/test/scaladoc/resources/tables.scala
+++ b/test/scaladoc/resources/tables.scala
@@ -144,15 +144,14 @@ package scala.test.scaladoc.tables {
     */
   trait ParagraphEnd
 
-  // Known suboptimal behaviour. Candidates for improving later.
-
   /**
-    * |First \|Header|
-    * |---|---|
-    * |\|Content 1|
-    * |C\|ontent 2|
-    * |Content\| 3|
-    * |Content \|4|
+    * |First \|Header|Second\| Header|Third\|Head\er|
+    * |:---:|:---|-:|
+    * |a\|b|cd|ef|
+    * |\|Content 1|||
+    * |C\|ontent 2|||
+    * |Content\| 3|||
+    * |Content  \|4|\|\||\|\|\|\||
     * |Content 5\||
     */
   trait CellMarkerEscaped
@@ -161,8 +160,11 @@ package scala.test.scaladoc.tables {
     * |Domain|Symbol|Operation|Extra|
     * |---|:---:|---|---|
     * |Bitwise| \| |Or||
+    * |Strange|\|\\||???|\N|
     */
-  trait CellMarkerEscapedTwice
+  trait CellMarkerEscapeEscapesOnlyMarker
+
+  // Known suboptimal behaviour. Candidates for improving later.
 
   /**
     * ||Header 1|Header 2|

--- a/test/scaladoc/run/tables.check
+++ b/test/scaladoc/run/tables.check
@@ -4,13 +4,10 @@ newSource:36: warning: Dropping 1 excess table delimiter cells from row.
 newSource:36: warning: Dropping 1 excess table data cells from row.
   /**
   ^
-newSource:160: warning: Dropping 1 excess table data cells from row.
+newSource:179: warning: no additional content on same line after table
   /**
   ^
-newSource:177: warning: no additional content on same line after table
-  /**
-  ^
-newSource:177: warning: Fixing missing delimiter row
+newSource:179: warning: Fixing missing delimiter row
   /**
   ^
 Done.

--- a/test/scaladoc/run/tables.scala
+++ b/test/scaladoc/run/tables.scala
@@ -245,37 +245,37 @@ object Test extends ScaladocModelTest {
       assertBodiesEquals(expected, comment.body)
     }
 
+    withComment("CellMarkerEscaped") { comment =>
+      val header = r("First |Header", "Second| Header", "Third|Head\\er")
+      val colOpts = ColumnOptionCenter :: ColumnOptionLeft :: ColumnOptionRight :: Nil
+
+      val row1 = r("a|b", "cd", "ef")
+      val row2 = r("|Content 1", "", "")
+      val row3 = r("C|ontent 2", "", "")
+      val row4 = r("Content| 3", "", "")
+      val row5 = r("Content  |4", "||", "||||")
+      val row6 = Row(Cell(List(Paragraph(Text("Content 5|")))) :: Cell(Nil) :: Cell(Nil) :: Nil)
+
+      val rows = row1 :: row2 :: row3 :: row4 :: row5 :: row6 :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
+    withComment("CellMarkerEscapeEscapesOnlyMarker") { comment =>
+      val header = r("Domain", "Symbol", "Operation", "Extra")
+      val colOpts = ColumnOptionLeft :: ColumnOptionCenter :: ColumnOptionLeft :: ColumnOptionLeft :: Nil
+
+      val row1 = r("Bitwise", " | ", "Or", "")
+      val row2 = r("Strange", raw"|\|", "???", raw"\N")
+
+      val rows = row1 :: row2 :: Nil
+      assertTableEquals(Table(header, colOpts, rows), comment.body)
+    }
+
     /* Deferred Enhancements.
      *
      * When these improvements are made corresponding test updates to any new or
      * changed error messages and parsed content and would be included.
      */
-
-    // Deferred pipe escape functionality.
-    withComment("CellMarkerEscaped") { comment =>
-      val header = r("First \\", "Header")
-      val colOpts = ColumnOptionLeft :: ColumnOptionLeft :: Nil
-
-      val row1 = r("\\", "Content 1")
-      val row2 = r("C\\", "ontent 2")
-      val row3 = r("Content\\", " 3")
-      val row4 = r("Content \\", "4")
-      val row5 = Row(Cell(List(Paragraph(Text("Content 5\\")))) :: Cell(Nil) :: Nil)
-
-      val rows = row1 :: row2 :: row3 :: row4 :: row5 :: Nil
-      assertTableEquals(Table(header, colOpts, rows), comment.body)
-    }
-
-    // Deferred pipe escape functionality.
-    withComment("CellMarkerEscapedTwice") { comment =>
-      val header = r("Domain", "Symbol", "Operation", "Extra")
-      val colOpts = ColumnOptionLeft :: ColumnOptionCenter :: ColumnOptionLeft :: ColumnOptionLeft :: Nil
-
-      val row = r("Bitwise", " \\", " ", "Or")
-
-      val rows = row :: Nil
-      assertTableEquals(Table(header, colOpts, rows), comment.body)
-    }
 
     withComment("MissingInitialCellMark") { comment =>
 


### PR DESCRIPTION
Interpret `\|` as content instead of cell delimiter following the GitHub
Flavored Markdown Table Extension spec.

For example this markdown defines a 2 column table,

```
    | Purpose | Command |
    | ------- | ------- |
    | Count instances | cut -f2 data.tsv \| sort \| uniq -c |
```
```
    ┌──────────────────┬───────────────────────────────────┐
    │ Purpose          │ Command                           │
    ├──────────────────┼───────────────────────────────────┤
    │ Count instances  │ cut -f2 data.tsv | sort | uniq -c │
    └──────────────────┴───────────────────────────────────┘
```

Fixes scala/bug#11161