### PR TITLE
optimize s.c.i.HashSetBuilder 

### DIFF
--- a/src/library/scala/collection/immutable/ChampHashMap.scala
+++ b/src/library/scala/collection/immutable/ChampHashMap.scala
@@ -585,19 +585,15 @@ private final class BitmapIndexedMapNode[K, +V](
 
   override def copy(): BitmapIndexedMapNode[K, V] = {
     val contentClone = new Array[Any](content.length)
-    var i = 0
-    val dataIndices = bitCount(dataMap) * 2
-    while (i < dataIndices) {
-      contentClone(i) = content(i)
-      i += 1
-    }
+    val dataIndices = bitCount(dataMap) * TupleLength
+    Array.copy(content, 0, contentClone, 0, dataIndices)
+    var i = dataIndices
     while (i < content.length) {
       contentClone(i) = content(i).asInstanceOf[MapNode[K, V]].copy()
       i += 1
     }
     new BitmapIndexedMapNode[K, V](dataMap, nodeMap, contentClone, originalHashes.clone(), size)
   }
-
 }
 
 private final class HashCollisionMapNode[K, +V ](
@@ -987,7 +983,6 @@ private[immutable] final class HashMapBuilder[K, V] extends Builder[(K, V), Hash
 
   /** Copy elements to new mutable structure */
   private def copyElems(): Unit = {
-    aliased = null
     rootNode = rootNode.copy()
   }
 

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -400,12 +400,8 @@ object Map extends MapFactory[Map] {
       f((key1, value1)); f((key2, value2)); f((key3, value3)); f((key4, value4))
     }
 
-    private[immutable] def buildTo[V1 >: V](builder: HashMapBuilder[K, V1]): Unit = {
-      builder.addOne(key1, value1)
-      builder.addOne(key2, value2)
-      builder.addOne(key3, value3)
-      builder.addOne(key4, value4)
-    }
+    private[immutable] def buildTo[V1 >: V](builder: HashMapBuilder[K, V1]): builder.type =
+      builder.addOne(key1, value1).addOne(key2, value2).addOne(key3, value3).addOne(key4, value4)
   }
 
   // scalac generates a `readReplace` method to discard the deserialized state (see https://github.com/scala/bug/issues/10412).


### PR DESCRIPTION
This supercedes https://github.com/scala/scala/pull/7138, and is simply the porting of all the efforts made on the HashMapBuilder in https://github.com/scala/scala/pull/7118 into the HashSetBuilder