### PR TITLE
fix scala.reflect.api.Types scaladoc

### DIFF
--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -39,7 +39,7 @@ package api
  *  For example, to look up the `map` method of `List`, one can do:
  *
  *  {{{
- *     scala> typeOf[List[_]].member("map": TermName)
+ *     scala> typeOf[List[_]].member(TermName("map"))
  *     res1: reflect.runtime.universe.Symbol = method map
  *  }}}
  *


### PR DESCRIPTION
https://github.com/scala/scala/blob/v2.13.0-M5/src/reflect/scala/reflect/api/Names.scala#L36-L37

```
Welcome to Scala 2.13.0-M5 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> import scala.reflect.runtime.universe._
import scala.reflect.runtime.universe._

scala> typeOf[List[_]].member("map": TermName)
                              ^
       warning: method stringToTermName in trait Names is deprecated (since 2.11.0): use explicit `TermName(s)` instead
res0: reflect.runtime.universe.Symbol = method map

scala> typeOf[List[_]].member(TermName("map"))
res1: reflect.runtime.universe.Symbol = method map
```