### PR TITLE
Bad main messaging [ci:last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -254,15 +254,16 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
     /*
      * must-single-thread
      */
-    def apply(sym: Symbol, csymCompUnit: CompilationUnit): Boolean = sym.hasModuleFlag && {
-      def warnBadMain(msg: String, pos: Position): Unit = reporter.warning(pos,
+    def apply(sym: Symbol, csymCompUnit: CompilationUnit, mainClass: Option[String]): Boolean = sym.hasModuleFlag && {
+      val warn = mainClass.fold(true)(_ == sym.fullNameString)
+      def warnBadMain(msg: String, pos: Position): Unit = if (warn) reporter.warning(pos,
         s"""|not a valid main method for ${sym.fullName('.')},
             |  because $msg.
             |  To define an entry point, please define the main method as:
             |    def main(args: Array[String]): Unit
             |""".stripMargin
       )
-      def warnNoForwarder(msg: String, hasExact: Boolean, mainly: Type) = reporter.warning(sym.pos,
+      def warnNoForwarder(msg: String, hasExact: Boolean, mainly: Type) = if (warn) reporter.warning(sym.pos,
         s"""|${sym.name.decoded} has a ${if (hasExact) "valid " else ""}main method${if (mainly != NoType) " "+mainly else ""},
             |  but ${sym.fullName('.')} will not have an entry point on the JVM.
             |  Reason: $msg, which means no static forwarder can be generated.

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -13,6 +13,8 @@ import scala.tools.asm.ClassWriter
 import scala.tools.nsc.backend.jvm.BCodeHelpers.ScalaSigBytes
 import scala.tools.nsc.reporters.NoReporter
 
+import PartialFunction.cond
+
 /*
  *  Traits encapsulating functionality to convert Scala AST Trees into ASM ClassNodes.
  *
@@ -247,8 +249,8 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
     /*
      * must-single-thread
      */
-    def apply(sym: Symbol, csymCompUnit: CompilationUnit): Boolean = {
-      def fail(msg: String, pos: Position = sym.pos) = {
+    def apply(sym: Symbol, csymCompUnit: CompilationUnit): Boolean = sym.hasModuleFlag && {
+      def fail(msg: String, pos: Position): Unit = {
         reporter.warning(sym.pos,
           sym.name +
           s" has a main method with parameter type Array[String], but ${sym.fullName('.')} will not be a runnable program.\n  Reason: $msg"
@@ -257,52 +259,50 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
           //   not sure what the jvm allows here
           // + "  You can still run the program by calling it as " + sym.javaSimpleName + " instead."
         )
-        false
       }
-      def failNoForwarder(msg: String) = {
-        fail(s"$msg, which means no static forwarder can be generated.\n")
-      }
-      val possibles = if (sym.hasModuleFlag) (sym.tpe nonPrivateMember nme.main).alternatives else Nil
-      val hasApproximate = possibles exists { m =>
-        m.info match {
-          case MethodType(p :: Nil, _) => p.tpe.typeSymbol == definitions.ArrayClass
-          case _                       => false
-        }
-      }
-      // At this point it's a module with a main-looking method, so either succeed or warn that it isn't.
-      hasApproximate && {
-        // Before erasure so we can identify generic mains.
-        enteringErasure {
-          val companion     = sym.linkedClassOfClass
+      def failNoForwarder(msg: String) = fail(s"$msg, which means no static forwarder can be generated.\n", sym.pos)
+      val possibles = (sym.tpe nonPrivateMember nme.main).alternatives
+      val hasApproximate = possibles.exists(m => cond(m.info) { case MethodType(p :: Nil, _) => p.tpe.typeSymbol == definitions.ArrayClass })
 
-          if (definitions.hasJavaMainMethod(companion))
-            failNoForwarder("companion contains its own main method")
+      // Before erasure so we can identify generic mains.
+      def check(): Boolean = enteringErasure {
+        val companion = sym.linkedClassOfClass
+        val hasExact  = possibles.exists(definitions.isJavaMainMethod)
+
+        val companionAdvice =
+          if (companion.isTrait)
+            Some("companion is a trait")
+          else if (definitions.hasJavaMainMethod(companion))
+            Some("companion contains its own main method")
           else if (companion.tpe.member(nme.main) != NoSymbol)
             // this is only because forwarders aren't smart enough yet
-            failNoForwarder("companion contains its own main method (implementation restriction: no main is allowed, regardless of signature)")
-          else if (companion.isTrait)
-            failNoForwarder("companion is a trait")
-          // Now either succeed, or issue some additional warnings for things which look like
-          // attempts to be java main methods.
-        else (possibles exists definitions.isJavaMainMethod) || {
-            possibles exists { m =>
-              m.info match {
-                case PolyType(_, _) =>
-                  fail("main methods cannot be generic.")
-                case MethodType(params, res) =>
-                  if (res.typeSymbol :: params exists (_.isAbstractType))
-                    fail("main methods cannot refer to type parameters or abstract types.", m.pos)
-                  else
-                    definitions.isJavaMainMethod(m) || fail("main method must have exact signature (Array[String])Unit", m.pos)
-                case tp =>
-                  fail(s"don't know what this is: $tp", m.pos)
-              }
+            Some("companion contains its own main method (implementation restriction: no main is allowed, regardless of signature)")
+          else
+            None
+
+        // some additional warnings for things which look like attempts to be java main methods.
+        val mainAdvice =
+          if (hasExact) Nil
+          else possibles.map { m =>
+            m.info match {
+              case PolyType(_, _) =>
+                ("main methods cannot be generic.", m.pos)
+              case MethodType(params, res) if res.typeSymbol :: params exists (_.isAbstractType) =>
+                ("main methods cannot refer to type parameters or abstract types.", m.pos)
+              case MethodType(_, _) =>
+                ("main method must have exact signature (Array[String])Unit", m.pos)
+              case tp =>
+                (s"don't know what this is: $tp", m.pos)
             }
           }
-        }
-      }
-    }
 
+        companionAdvice.foreach(failNoForwarder)
+        if (companionAdvice.isEmpty) mainAdvice.foreach { case (msg, pos) => fail(msg, pos) }
+        companionAdvice.isEmpty && mainAdvice.isEmpty
+      }
+      // At this point it's a module with a main-looking method, so either succeed or warn that it isn't.
+      hasApproximate && check()
+    }
   }
 
   /*

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -377,7 +377,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
     }
 
     override def transform(tree: Tree): Tree = tree match {
-      case _: ClassDef if genBCode.codeGen.CodeGenImpl.isJavaEntryPoint(tree.symbol, currentUnit) =>
+      case _: ClassDef if genBCode.codeGen.CodeGenImpl.isJavaEntryPoint(tree.symbol, currentUnit, settings.mainClass.valueSetByUser.map(_.toString)) =>
         // collecting symbols for entry points here (as opposed to GenBCode where they are used)
         // has the advantage of saving an additional pass over all ClassDefs.
         entryPoints += tree.symbol

--- a/test/files/neg/main1.check
+++ b/test/files/neg/main1.check
@@ -23,19 +23,19 @@ main1.scala:41: warning: Foo has a main method with parameter type Array[String]
 
   object Foo extends Foo {  // Overrides main from the class
          ^
-main1.scala:52: warning: Main has a main method with parameter type Array[String], but p6.Main will not be a runnable program.
+main1.scala:53: warning: Main has a main method with parameter type Array[String], but p6.Main will not be a runnable program.
   Reason: main method must have exact signature (Array[String])Unit
-  object Main {
-         ^
+    def main(args: Array[Int]) = ()
+        ^
 main1.scala:59: warning: Main has a main method with parameter type Array[String], but p7.Main will not be a runnable program.
   Reason: companion is a trait, which means no static forwarder can be generated.
 
   object Main {
          ^
-main1.scala:59: warning: Main has a main method with parameter type Array[String], but p7.Main will not be a runnable program.
+main1.scala:60: warning: Main has a main method with parameter type Array[String], but p7.Main will not be a runnable program.
   Reason: main method must have exact signature (Array[String])Unit
-  object Main {
-         ^
+    def main(args: Array[Int]) = ()
+        ^
 error: No warnings can be incurred under -Xfatal-warnings.
 8 warnings found
 one error found

--- a/test/files/neg/main1.check
+++ b/test/files/neg/main1.check
@@ -32,6 +32,10 @@ main1.scala:59: warning: Main has a main method with parameter type Array[String
 
   object Main {
          ^
+main1.scala:59: warning: Main has a main method with parameter type Array[String], but p7.Main will not be a runnable program.
+  Reason: main method must have exact signature (Array[String])Unit
+  object Main {
+         ^
 error: No warnings can be incurred under -Xfatal-warnings.
-7 warnings found
+8 warnings found
 one error found

--- a/test/files/neg/main1.check
+++ b/test/files/neg/main1.check
@@ -23,6 +23,10 @@ main1.scala:41: warning: Foo has a main method with parameter type Array[String]
 
   object Foo extends Foo {  // Overrides main from the class
          ^
+main1.scala:52: warning: Main has a main method with parameter type Array[String], but p6.Main will not be a runnable program.
+  Reason: main method must have exact signature (Array[String])Unit
+  object Main {
+         ^
 error: No warnings can be incurred under -Xfatal-warnings.
-5 warnings found
+6 warnings found
 one error found

--- a/test/files/neg/main1.check
+++ b/test/files/neg/main1.check
@@ -27,6 +27,11 @@ main1.scala:52: warning: Main has a main method with parameter type Array[String
   Reason: main method must have exact signature (Array[String])Unit
   object Main {
          ^
+main1.scala:59: warning: Main has a main method with parameter type Array[String], but p7.Main will not be a runnable program.
+  Reason: companion is a trait, which means no static forwarder can be generated.
+
+  object Main {
+         ^
 error: No warnings can be incurred under -Xfatal-warnings.
-6 warnings found
+7 warnings found
 one error found

--- a/test/files/neg/main1.check
+++ b/test/files/neg/main1.check
@@ -1,41 +1,73 @@
-main1.scala:5: warning: Foo has a main method with parameter type Array[String], but foo1.Foo will not be a runnable program.
+main1.scala:5: warning: Foo has a valid main method (args: Array[String])Unit,
+  but foo1.Foo will not have an entry point on the JVM.
   Reason: companion is a trait, which means no static forwarder can be generated.
 
   object Foo {  // companion is trait
          ^
-main1.scala:12: warning: Foo has a main method with parameter type Array[String], but foo2.Foo will not be a runnable program.
+main1.scala:12: warning: Foo has a valid main method (args: Array[String])Unit,
+  but foo2.Foo will not have an entry point on the JVM.
   Reason: companion contains its own main method, which means no static forwarder can be generated.
 
   object Foo {  // companion has its own main
          ^
-main1.scala:24: warning: Foo has a main method with parameter type Array[String], but foo3.Foo will not be a runnable program.
+main1.scala:24: warning: Foo has a valid main method (args: Array[String])Unit,
+  but foo3.Foo will not have an entry point on the JVM.
   Reason: companion contains its own main method (implementation restriction: no main is allowed, regardless of signature), which means no static forwarder can be generated.
 
   object Foo {  // Companion contains main, but not an interfering main.
          ^
-main1.scala:33: warning: Foo has a main method with parameter type Array[String], but foo4.Foo will not be a runnable program.
+main1.scala:33: warning: Foo has a valid main method (args: Array[String])Unit,
+  but foo4.Foo will not have an entry point on the JVM.
   Reason: companion contains its own main method, which means no static forwarder can be generated.
 
   object Foo extends Foo {  // Inherits main from the class
          ^
-main1.scala:41: warning: Foo has a main method with parameter type Array[String], but foo5.Foo will not be a runnable program.
+main1.scala:41: warning: Foo has a valid main method (args: Array[String])Unit,
+  but foo5.Foo will not have an entry point on the JVM.
   Reason: companion contains its own main method, which means no static forwarder can be generated.
 
   object Foo extends Foo {  // Overrides main from the class
          ^
-main1.scala:53: warning: Main has a main method with parameter type Array[String], but p6.Main will not be a runnable program.
-  Reason: main method must have exact signature (Array[String])Unit
+main1.scala:53: warning: not a valid main method for p6.Main,
+  because main methods must have the exact signature (Array[String])Unit.
+  To define an entry point, please define the main method as:
+    def main(args: Array[String]): Unit
+
     def main(args: Array[Int]) = ()
         ^
-main1.scala:59: warning: Main has a main method with parameter type Array[String], but p7.Main will not be a runnable program.
+main1.scala:59: warning: Main has a main method (args: Array[Int])Unit,
+  but p7.Main will not have an entry point on the JVM.
   Reason: companion is a trait, which means no static forwarder can be generated.
 
   object Main {
          ^
-main1.scala:60: warning: Main has a main method with parameter type Array[String], but p7.Main will not be a runnable program.
-  Reason: main method must have exact signature (Array[String])Unit
+main1.scala:60: warning: not a valid main method for p7.Main,
+  because main methods must have the exact signature (Array[String])Unit.
+  To define an entry point, please define the main method as:
+    def main(args: Array[String]): Unit
+
+    def main(args: Array[Int]) = ()
+        ^
+main1.scala:66: warning: Main has a main method,
+  but p8.Main will not have an entry point on the JVM.
+  Reason: companion is a trait, which means no static forwarder can be generated.
+
+  object Main {
+         ^
+main1.scala:68: warning: not a valid main method for p8.Main,
+  because main methods must have the exact signature (Array[String])Unit.
+  To define an entry point, please define the main method as:
+    def main(args: Array[String]): Unit
+
+    def main(args: Array[Double]) = ()
+        ^
+main1.scala:67: warning: not a valid main method for p8.Main,
+  because main methods must have the exact signature (Array[String])Unit.
+  To define an entry point, please define the main method as:
+    def main(args: Array[String]): Unit
+
     def main(args: Array[Int]) = ()
         ^
 error: No warnings can be incurred under -Xfatal-warnings.
-8 warnings found
+11 warnings found
 one error found

--- a/test/files/neg/main1.scala
+++ b/test/files/neg/main1.scala
@@ -53,3 +53,10 @@ package p6 {
     def main(args: Array[Int]) = ()
   }
 }
+
+package p7 {
+  trait Main
+  object Main {
+    def main(args: Array[Int]) = ()
+  }
+}

--- a/test/files/neg/main1.scala
+++ b/test/files/neg/main1.scala
@@ -45,3 +45,11 @@ package foo5 {
     def main(args: Array[String]): Unit = ()
   }
 }
+
+// extended messaging
+
+package p6 {
+  object Main {
+    def main(args: Array[Int]) = ()
+  }
+}

--- a/test/files/neg/main1.scala
+++ b/test/files/neg/main1.scala
@@ -60,3 +60,11 @@ package p7 {
     def main(args: Array[Int]) = ()
   }
 }
+
+package p8 {
+  trait Main
+  object Main {
+    def main(args: Array[Int]) = ()
+    def main(args: Array[Double]) = ()
+  }
+}

--- a/test/files/neg/main2.check
+++ b/test/files/neg/main2.check
@@ -1,0 +1,9 @@
+main2.scala:7: warning: X has a valid main method (args: Array[String])Unit,
+  but p.X will not have an entry point on the JVM.
+  Reason: companion is a trait, which means no static forwarder can be generated.
+
+  object X {
+         ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/main2.scala
+++ b/test/files/neg/main2.scala
@@ -1,0 +1,19 @@
+// scalac: -Xfatal-warnings -Xmain-class p.X
+//
+
+// emit a warning
+
+package p {
+  object X {
+    def main(args: Array[String]): Unit = ()
+  }
+  trait X
+}
+
+// no warn because not the designated main
+
+package q {
+  object Main {
+    def main(args: Array[Int]) = ()
+  }
+}

--- a/test/files/neg/t3692-new.check
+++ b/test/files/neg/t3692-new.check
@@ -10,10 +10,10 @@ t3692-new.scala:18: warning: non-variable type argument Int in type pattern scal
 t3692-new.scala:17: warning: unreachable code
       case m1: Map[Int, V] => new java.util.HashMap[Integer, V]
                               ^
-t3692-new.scala:6: warning: Tester has a main method with parameter type Array[String], but Tester will not be a runnable program.
+t3692-new.scala:7: warning: Tester has a main method with parameter type Array[String], but Tester will not be a runnable program.
   Reason: main method must have exact signature (Array[String])Unit
-object Tester {
-       ^
+  def main(args: Array[String]) = {
+      ^
 error: No warnings can be incurred under -Xfatal-warnings.
 5 warnings found
 one error found

--- a/test/files/neg/t3692-new.check
+++ b/test/files/neg/t3692-new.check
@@ -1,19 +1,15 @@
-t3692-new.scala:16: warning: non-variable type argument Int in type pattern scala.collection.immutable.Map[Int,Int] (the underlying of Map[Int,Int]) is unchecked since it is eliminated by erasure
+t3692-new.scala:17: warning: non-variable type argument Int in type pattern scala.collection.immutable.Map[Int,Int] (the underlying of Map[Int,Int]) is unchecked since it is eliminated by erasure
       case m0: Map[Int, Int] => new java.util.HashMap[Integer, Integer]
                ^
-t3692-new.scala:17: warning: non-variable type argument Int in type pattern scala.collection.immutable.Map[Int,V] (the underlying of Map[Int,V]) is unchecked since it is eliminated by erasure
+t3692-new.scala:18: warning: non-variable type argument Int in type pattern scala.collection.immutable.Map[Int,V] (the underlying of Map[Int,V]) is unchecked since it is eliminated by erasure
       case m1: Map[Int, V] => new java.util.HashMap[Integer, V]
                ^
-t3692-new.scala:18: warning: non-variable type argument Int in type pattern scala.collection.immutable.Map[T,Int] (the underlying of Map[T,Int]) is unchecked since it is eliminated by erasure
+t3692-new.scala:19: warning: non-variable type argument Int in type pattern scala.collection.immutable.Map[T,Int] (the underlying of Map[T,Int]) is unchecked since it is eliminated by erasure
       case m2: Map[T, Int] => new java.util.HashMap[T, Integer]
                ^
-t3692-new.scala:17: warning: unreachable code
+t3692-new.scala:18: warning: unreachable code
       case m1: Map[Int, V] => new java.util.HashMap[Integer, V]
                               ^
-t3692-new.scala:7: warning: Tester has a main method with parameter type Array[String], but Tester will not be a runnable program.
-  Reason: main method must have exact signature (Array[String])Unit
-  def main(args: Array[String]) = {
-      ^
 error: No warnings can be incurred under -Xfatal-warnings.
-5 warnings found
+four warnings found
 one error found

--- a/test/files/neg/t3692-new.scala
+++ b/test/files/neg/t3692-new.scala
@@ -7,6 +7,7 @@ object Tester {
   def main(args: Array[String]) = {
     val map = Map("John" -> 1, "Josh" -> 2)
     new Tester().toJavaMap(map)
+    ()
   }
 }
 

--- a/test/files/neg/t4749.check
+++ b/test/files/neg/t4749.check
@@ -1,32 +1,47 @@
-t4749.scala:5: warning: Fail1 has a main method with parameter type Array[String], but bippy.Fail1 will not be a runnable program.
-  Reason: main method must have exact signature (Array[String])Unit
+t4749.scala:5: warning: not a valid main method for bippy.Fail1,
+  because main methods must have the exact signature (Array[String])Unit.
+  To define an entry point, please define the main method as:
+    def main(args: Array[String]): Unit
+
     def main(args: Array[String]): Any = ()
         ^
-t4749.scala:9: warning: Fail2 has a main method with parameter type Array[String], but bippy.Fail2 will not be a runnable program.
-  Reason: main methods cannot be generic.
+t4749.scala:9: warning: not a valid main method for bippy.Fail2,
+  because main methods cannot be generic.
+  To define an entry point, please define the main method as:
+    def main(args: Array[String]): Unit
+
     def main[T](args: Array[String]): T = null.asInstanceOf[T]
         ^
-t4749.scala:13: warning: Fail3 has a main method with parameter type Array[String], but bippy.Fail3 will not be a runnable program.
-  Reason: main methods cannot refer to type parameters or abstract types.
+t4749.scala:13: warning: not a valid main method for bippy.Fail3,
+  because main methods cannot refer to type parameters or abstract types.
+  To define an entry point, please define the main method as:
+    def main(args: Array[String]): Unit
+
     def main(args: Array[String]): T = null.asInstanceOf[T]
         ^
-t4749.scala:18: warning: Fail4 has a main method with parameter type Array[String], but bippy.Fail4 will not be a runnable program.
+t4749.scala:18: warning: Fail4 has a valid main method (args: Array[String])Unit,
+  but bippy.Fail4 will not have an entry point on the JVM.
   Reason: companion is a trait, which means no static forwarder can be generated.
 
   object Fail4 {
          ^
-t4749.scala:23: warning: Fail5 has a main method with parameter type Array[String], but bippy.Fail5 will not be a runnable program.
+t4749.scala:23: warning: Fail5 has a valid main method (args: Array[String])Unit,
+  but bippy.Fail5 will not have an entry point on the JVM.
   Reason: companion contains its own main method, which means no static forwarder can be generated.
 
   object Fail5 extends Fail5 { }
          ^
-t4749.scala:28: warning: Fail6 has a main method with parameter type Array[String], but bippy.Fail6 will not be a runnable program.
+t4749.scala:28: warning: Fail6 has a valid main method (args: Array[String])Unit,
+  but bippy.Fail6 will not have an entry point on the JVM.
   Reason: companion contains its own main method (implementation restriction: no main is allowed, regardless of signature), which means no static forwarder can be generated.
 
   object Fail6 {
          ^
-t4749.scala:44: warning: Win3 has a main method with parameter type Array[String], but bippy.Win3 will not be a runnable program.
-  Reason: main method must have exact signature (Array[String])Unit
+t4749.scala:44: warning: not a valid main method for bippy.Win3,
+  because main methods must have the exact signature (Array[String])Unit.
+  To define an entry point, please define the main method as:
+    def main(args: Array[String]): Unit
+
   object Win3 extends WinBippy[Unit] { }
          ^
 error: No warnings can be incurred under -Xfatal-warnings.

--- a/test/files/neg/t4749.check
+++ b/test/files/neg/t4749.check
@@ -1,15 +1,15 @@
-t4749.scala:4: warning: Fail1 has a main method with parameter type Array[String], but bippy.Fail1 will not be a runnable program.
+t4749.scala:5: warning: Fail1 has a main method with parameter type Array[String], but bippy.Fail1 will not be a runnable program.
   Reason: main method must have exact signature (Array[String])Unit
-  object Fail1 {
-         ^
-t4749.scala:8: warning: Fail2 has a main method with parameter type Array[String], but bippy.Fail2 will not be a runnable program.
+    def main(args: Array[String]): Any = ()
+        ^
+t4749.scala:9: warning: Fail2 has a main method with parameter type Array[String], but bippy.Fail2 will not be a runnable program.
   Reason: main methods cannot be generic.
-  object Fail2 {
-         ^
-t4749.scala:15: warning: Fail3 has a main method with parameter type Array[String], but bippy.Fail3 will not be a runnable program.
+    def main[T](args: Array[String]): T = null.asInstanceOf[T]
+        ^
+t4749.scala:13: warning: Fail3 has a main method with parameter type Array[String], but bippy.Fail3 will not be a runnable program.
   Reason: main methods cannot refer to type parameters or abstract types.
-  object Fail3 extends Bippy[Unit] { }
-         ^
+    def main(args: Array[String]): T = null.asInstanceOf[T]
+        ^
 t4749.scala:18: warning: Fail4 has a main method with parameter type Array[String], but bippy.Fail4 will not be a runnable program.
   Reason: companion is a trait, which means no static forwarder can be generated.
 


### PR DESCRIPTION
Emit warnings for bad companions and bad main signatures.

It's not obvious that fixing either class of problem has priority.

Another idea was to make it contingent on `-Xmain-class`, since it makes sense to warn only for that class; so setting it is a way to disable the messaging.