### PR TITLE
Make contains accept subtypes of A

### DIFF
--- a/src/compiler/scala/tools/cmd/Opt.scala
+++ b/src/compiler/scala/tools/cmd/Opt.scala
@@ -81,7 +81,7 @@ object Opt {
 
     def choiceOf[T: FromString](choices: T*) = {
       --^[T] map { arg =>
-        if (choices contains arg) arg
+        if (choices containsAny arg) arg
         else failOption(arg.toString, "not a valid choice from " + choices)
       }
     }

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -3076,7 +3076,7 @@ self =>
 
       atPos(tstart1) {
         // Exclude only the 9 primitives plus AnyVal.
-        if (inScalaRootPackage && ScalaValueClassNames.contains(name))
+        if (inScalaRootPackage && ScalaValueClassNames.containsAny(name))
           Template(parents, self, anyvalConstructor :: body)
         else
           gen.mkTemplate(gen.mkParents(mods, parents, parentPos),

--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -163,7 +163,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
     }
 
     def skipTo(tokens: Int*): Unit = {
-      while (!(tokens contains in.token) && in.token != EOF) {
+      while (!(tokens containsAny in.token) && in.token != EOF) {
         if (in.token == LBRACE) { skipAhead(); accept(RBRACE) }
         else if (in.token == LPAREN) { skipAhead(); accept(RPAREN) }
         else in.nextToken()

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -271,7 +271,7 @@ abstract class ExplicitOuter extends InfoTransform
     /** The stack of class symbols in which a call to this() or to the super
       * constructor, or early definition is active
       */
-    protected def isUnderConstruction(clazz: Symbol) = selfOrSuperCalls contains clazz
+    protected def isUnderConstruction(clazz: Symbol) = selfOrSuperCalls containsAny clazz
     protected val selfOrSuperCalls = collection.mutable.Stack[Symbol]()
 
     override def transform(tree: Tree): Tree = {

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -314,7 +314,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
   def isSpecializedIn(sym: Symbol, site: Type) =
     specializedTypeVars(sym) exists { tvar =>
       val concretes = concreteTypes(tvar)
-      (concretes contains AnyRefClass) || (concretes contains site.memberType(tvar))
+      (concretes containsAny AnyRefClass) || (concretes contains site.memberType(tvar))
     }
 
 
@@ -408,7 +408,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     else
       specializedOn(sym).map(s => specializesClass(s).tpe).sorted
 
-    if (isBoundedGeneric(sym.tpe) && (types contains AnyRefClass))
+    if (isBoundedGeneric(sym.tpe) && (types containsAny AnyRefClass))
       reporter.warning(sym.pos, sym + " is always a subtype of " + AnyRefTpe + ".")
 
     types
@@ -987,7 +987,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
         if (stvars.nonEmpty)
           debuglog("specialized %s on %s".format(sym.fullLocationString, stvars.map(_.name).mkString(", ")))
 
-        val tps1 = if (sym.isConstructor) tps filter (sym.info.paramTypes contains _) else tps
+        val tps1 = if (sym.isConstructor) tps filter (sym.info.paramTypes containsAny _) else tps
         val tps2 = tps1 filter stvars
         if (!sym.isDeferred)
           addConcreteSpecMethod(sym)

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1428,7 +1428,7 @@ trait Implicits {
 
       /* Creates a tree that calls the factory method called constructor in object scala.reflect.Manifest */
       def manifestFactoryCall(constructor: String, tparg: Type, args: Tree*): Tree =
-        if (args contains EmptyTree) EmptyTree
+        if (args containsAny EmptyTree) EmptyTree
         else typedPos(tree.pos.focus) {
           val mani = gen.mkManifestFactoryCall(full, constructor, tparg, args.toList)
           if (settings.debug) println("generated manifest: "+mani) // DEBUG

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1552,7 +1552,7 @@ trait Namers extends MethodSynthesis {
                     // TODO: this is a very brittle approach; I sincerely hope that Denys's research into hygiene
                     //       will open the doors to a much better way of doing this kind of stuff
                     val tparamNames = defTparams map { case TypeDef(_, name, _, _) => name }
-                    val eraseAllMentionsOfTparams = new TypeTreeSubstituter(tparamNames contains _)
+                    val eraseAllMentionsOfTparams = new TypeTreeSubstituter(tparamNames containsAny _)
                     eraseAllMentionsOfTparams(rvparam.tpt match {
                       // default getter for by-name params
                       case AppliedTypeTree(_, List(arg)) if sym.hasFlag(BYNAMEPARAM) => arg

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -389,6 +389,10 @@ object Predef extends LowPriorityImplicits {
   /** @group conversions-string */
   @inline implicit def augmentString(x: String): StringOps = new StringOps(x)
 
+  @inline implicit def scalaSeqToInvariantSeqOps[A, CC[_]](seq: CC[A])
+    (implicit ev: CC[A] <:< Seq[A]): collection.InvariantSeqOps[A, CC] =
+    new collection.InvariantSeqOps(seq)
+
   // printing -----------------------------------------------------------
 
   /** Prints an object to `out` using its `toString` method.

--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -101,7 +101,7 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeq
     false
   }
 
-  override def contains[A1 >: A](elem: A1): Boolean = {
+  override def containsAny(elem: Any): Boolean = {
     var these: LinearSeq[A] = coll
     while (!these.isEmpty) {
       if (these.head == elem) return true

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -471,7 +471,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
    *  @return     `true` if this $coll has an element that is equal (as
    *              determined by `==`) to `elem`, `false` otherwise.
    */
-  def contains[A1 >: A](elem: A1): Boolean = exists (_ == elem)
+  def containsAny(elem: Any): Boolean = exists (_ == elem)
 
   @deprecated("Use .reverseIterator.map(f).to(...) instead of .reverseMap(f)", "2.13.0")
   def reverseMap[B](f: A => B): CC[B] = iterableFactory.from(new View.Map(View.fromIteratorProvider(() => reverseIterator), f))
@@ -1100,3 +1100,14 @@ object SeqOps {
 /** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses. */
 @SerialVersionUID(3L)
 abstract class AbstractSeq[+A] extends AbstractIterable[A] with Seq[A]
+
+final class InvariantSeqOps[A, CC[_]](seq: CC[A])(implicit ev: CC[A] <:< Seq[A]) {
+  /** Tests whether this $seq contains a given value as an element.
+   *  $mayNotTerminateInf
+   *
+   *  @param elem  the element to test.
+   *  @return     `true` if this $seq has an element that is equal (as
+   *              determined by `==`) to `elem`, `false` otherwise.
+   */
+  def contains(elem: A): Boolean = seq.containsAny(elem)
+}

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -367,7 +367,7 @@ sealed abstract class List[+A]
     false
   }
 
-  override final def contains[A1 >: A](elem: A1): Boolean = {
+  override final def containsAny(elem: Any): Boolean = {
     var these: List[A] = this
     while (!these.isEmpty) {
       if (these.head == elem) return true

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -149,7 +149,7 @@ sealed class NumericRange[T](
   def containsTyped(x: T): Boolean =
     isWithinBoundaries(x) && (((x - start) % step) == zero)
 
-  override def contains[A1 >: T](x: A1): Boolean =
+  override def containsAny(x: Any): Boolean =
     try containsTyped(x.asInstanceOf[T])
     catch { case _: ClassCastException => false }
 

--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -331,7 +331,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
         }
 
         val stripTags=List(inheritDiagramTag, contentDiagramTag, SimpleTagKey("template"), SimpleTagKey("documentable"))
-        val tagsWithoutDiagram = tags.filterNot(pair => stripTags.contains(pair._1))
+        val tagsWithoutDiagram = tags.filterNot(pair => stripTags.containsAny(pair._1))
 
         val bodyTags: mutable.Map[TagKey, List[Body]] =
           tagsWithoutDiagram.view.mapValues(_.map(parseWikiAtSymbol(_, pos, site))).to(mutable.Map)

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/diagram/DotDiagramGenerator.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/diagram/DotDiagramGenerator.scala
@@ -146,7 +146,7 @@ class DotDiagramGenerator(settings: doc.Settings) extends DiagramGenerator {
         else if (node.isTypeNode) " type"
 
       val cls =
-        if (node.isImplicitNode && incomingImplicits.contains(node)) "implicit-incoming" + baseClass
+        if (node.isImplicitNode && incomingImplicits.containsAny(node)) "implicit-incoming" + baseClass
         else if (node.isImplicitNode) "implicit-outgoing" + baseClass
         else if (node.isThisNode) "this" + baseClass
         else if (node.isOutsideNode) "outside" + baseClass

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
@@ -104,8 +104,8 @@ trait ModelFactoryImplicitSupport {
         .getOrElse(Nil)
 
       conversions = conversions filterNot { conv: ImplicitConversionImpl =>
-        hiddenConversions.contains(conv.conversionShortName) ||
-        hiddenConversions.contains(conv.conversionQualifiedName)
+        hiddenConversions.containsAny(conv.conversionShortName) ||
+        hiddenConversions.containsAny(conv.conversionQualifiedName)
       }
 
       // Filter out non-sensical conversions from value types

--- a/src/scaladoc/scala/tools/nsc/doc/model/diagram/DiagramFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/diagram/DiagramFactory.scala
@@ -126,7 +126,7 @@ trait DiagramFactory extends DiagramDirectiveParser {
               member.parentTypes map {
                 case (template, tpe) => template
               } filter {
-                nodesAll.contains(_)
+                nodesAll.containsAny(_)
               }
           }
         }

--- a/test/files/neg/seq-contains.check
+++ b/test/files/neg/seq-contains.check
@@ -1,0 +1,11 @@
+seq-contains.scala:2: error: type mismatch;
+ found   : String("wat")
+ required: Int
+  val x = Seq(1, 2, 3).contains("wat")
+                                ^
+seq-contains.scala:3: error: type mismatch;
+ found   : Option[String]
+ required: String
+  val l = List("foo").contains(Option("foo"))
+                                     ^
+two errors found

--- a/test/files/neg/seq-contains.scala
+++ b/test/files/neg/seq-contains.scala
@@ -1,0 +1,5 @@
+object Test {
+  val x = Seq(1, 2, 3).contains("wat")
+  val l = List("foo").contains(Option("foo"))
+  val y = Seq(Option(1)).contains(None) // this is ok
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/10831

This renames existing covariant `contains` method as `containsAny`
and introduces an invariant `contains` as an extension method.