### PR TITLE
Add "@tailrec" annotation to these definitions.

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -843,6 +843,7 @@ trait Definitions extends api.StandardDefinitions {
      *  This makes it like 1000x easier to see the overall logic
      *  of the method.
      */
+    @tailrec
     def isStable(tp: Type): Boolean = tp match {
       case _: SingletonType                             => true
       case NoPrefix                                     => true

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2973,6 +2973,7 @@ trait Types
 
   /** A creator for existential types which flattens nested existentials.
    */
+  @tailrec
   def newExistentialType(quantified: List[Symbol], underlying: Type): Type =
     if (quantified.isEmpty) underlying
     else underlying match {


### PR DESCRIPTION
These functions are found to be tail-recursive, so we add the `@tailrec` annotation to avoid stack usage.