### PR TITLE
Modify existentialAbstraction to avoid calls to contains.

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2695,7 +2695,9 @@ trait Types
   private final class ClassArgsTypeRef(pre: Type, sym: Symbol, args: List[Type]) extends ArgsTypeRef(pre, sym, args)
   private final class AliasNoArgsTypeRef(pre: Type, sym: Symbol) extends NoArgsTypeRef(pre, sym) with AliasTypeRef
   private final class AbstractNoArgsTypeRef(pre: Type, sym: Symbol) extends NoArgsTypeRef(pre, sym) with AbstractTypeRef
-  private final class ClassNoArgsTypeRef(pre: Type, sym: Symbol) extends NoArgsTypeRef(pre, sym)
+  private final class ClassNoArgsTypeRef(pre: Type, sym: Symbol) extends NoArgsTypeRef(pre, sym){
+    override def contains(sym: Symbol) = this.sym == sym || super.contains(sym)
+  }
 
   object TypeRef extends TypeRefExtractor {
     def apply(pre: Type, sym: Symbol, args: List[Type]): Type = unique({

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2696,7 +2696,7 @@ trait Types
   private final class AliasNoArgsTypeRef(pre: Type, sym: Symbol) extends NoArgsTypeRef(pre, sym) with AliasTypeRef
   private final class AbstractNoArgsTypeRef(pre: Type, sym: Symbol) extends NoArgsTypeRef(pre, sym) with AbstractTypeRef
   private final class ClassNoArgsTypeRef(pre: Type, sym: Symbol) extends NoArgsTypeRef(pre, sym){
-    override def contains(sym: Symbol) = this.sym == sym || super.contains(sym)
+    override def contains(sym0: Symbol): Boolean = (sym eq sym0) || pre.contains(sym0)
   }
 
   object TypeRef extends TypeRefExtractor {

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4132,7 +4132,8 @@ trait Types
       while (tparams1 != tparams0) {
         tparams0 = tparams1
         tparams1 = tparams filter { p =>
-          tparams1 exists { p1 => p1 == p || (p1.info contains p) }
+          tparams1.exists( (p1: Symbol) => p1 eq p) ||
+          tparams1.exists( p1 => p1.info contains p)
         }
       }
       newExistentialType(tparams1, tpe1)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4141,23 +4141,23 @@ trait Types
          * Each element in tparams goes from pending to border, and from border to closed
          * We separate border from closed to avoid recomputing `Type.contains` for same elements.
          */
-        val pending   = mutable.ListBuffer.empty[Symbol]
+        val pending = mutable.ListBuffer.empty[Symbol]
         var border  = mutable.ListBuffer.empty[Symbol]
         partitionInto(tparams, tpe.contains, border, pending)
         val closed    = mutable.ListBuffer.empty[Symbol]
-        var borderAux = mutable.ListBuffer.empty[Symbol]
+        var nextBorder = mutable.ListBuffer.empty[Symbol]
         while (border.nonEmpty) {
-          borderAux.clear
+          nextBorder.clear
           pending.filterInPlace { paramTodo =>
             !border.exists(_.info contains paramTodo) || {
-              borderAux += paramTodo;
+              nextBorder += paramTodo;
               false
             }
           }
           closed ++= border
           val swap = border
-          border = borderAux
-          borderAux = swap
+          border = nextBorder
+          nextBorder = swap
         }
         if (closed.length == tparams.length) tparams else closed.toList
     }

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -292,6 +292,15 @@ trait Collections {
     true
   }
 
+  final def partitionInto[A](xs: List[A], pred: A => Boolean, ayes: ListBuffer[A], nays: ListBuffer[A]): Unit = {
+    var ys = xs
+    while (!ys.isEmpty) {
+      val y = ys.head
+      if (pred(y)) ayes.addOne(y) else nays.addOne(y)
+      ys = ys.tail
+    }
+  }
+
   final def sequence[A](as: List[Option[A]]): Option[List[A]] = {
     if (as.exists (_.isEmpty)) None
     else Some(as.flatten)


### PR DESCRIPTION
The `existentialAbstraction` method performs a fix-point transitive closure loop, which at each iteration compares a list of "candidate" parameters with a list of "already marked", which is a subset of it.
The test includes both equality (same object) and a call to the `Type.contains` method, which would create a `ContainsCollector` object.

We modify the code, to move quick equality check before doing any call to `Type.contains`. This should avoid creating the `ContainsCollector` object, but would perform two list traversals in each loop.