### PR TITLE
Defer the pattern matching phase until after refchecks

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -466,16 +466,6 @@ class Global(var currentSettings: Settings, reporter0: LegacyReporter)
     if (settings.YmacroAnnotations) new { val global: Global.this.type = Global.this } with Analyzer with MacroAnnotationNamers
     else new { val global: Global.this.type = Global.this } with Analyzer
 
-  // phaseName = "patmat"
-  object patmat extends {
-    val global: Global.this.type = Global.this
-    // patmat does not need to run before the superaccessors phase, because
-    // patmat never emits `this.x` where `x` is a ParamAccessor.
-    // (However, patmat does need to run before outer accessors generation).
-    val runsAfter = List("superaccessors")
-    val runsRightAfter = None
-  } with PatternMatching
-
   // phaseName = "superaccessors"
   object superAccessors extends {
     val global: Global.this.type = Global.this
@@ -487,7 +477,7 @@ class Global(var currentSettings: Settings, reporter0: LegacyReporter)
   // phaseName = "extmethods"
   object extensionMethods extends {
     val global: Global.this.type = Global.this
-    val runsAfter = List("patmat")
+    val runsAfter = List("superaccessors")
     val runsRightAfter = None
   } with ExtensionMethods
 
@@ -505,10 +495,20 @@ class Global(var currentSettings: Settings, reporter0: LegacyReporter)
     val runsRightAfter = None
   } with RefChecks
 
+  // phaseName = "patmat"
+  object patmat extends {
+    val global: Global.this.type = Global.this
+    // patmat does not need to run before the superaccessors phase, because
+    // patmat never emits `this.x` where `x` is a ParamAccessor.
+    // (However, patmat does need to run before outer accessors generation).
+    val runsAfter = List("refchecks")
+    val runsRightAfter = None
+  } with PatternMatching
+
   // phaseName = "uncurry"
   override object uncurry extends {
     val global: Global.this.type = Global.this
-    val runsAfter = List("refchecks")
+    val runsAfter = List("patmat")
     val runsRightAfter = None
   } with UnCurry
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1822,26 +1822,6 @@ abstract class RefChecks extends Transform {
               transform(pat)
             }
             treeCopy.CaseDef(tree, pat1, transform(guard), transform(body))
-          case LabelDef(_, _, _) if treeInfo.hasSynthCaseSymbol(result) =>
-            savingInPattern {
-              inPattern = true
-              deriveLabelDef(result)(transform)
-            }
-          case Apply(fun, args) if fun.symbol.isLabel && treeInfo.isSynthCaseSymbol(fun.symbol) =>
-            savingInPattern {
-              // scala/bug#7756 If we were in a translated pattern, we can now switch out of pattern mode, as the label apply signals
-              //         that we are in the user-supplied code in the case body.
-              //
-              //         Relies on the translation of:
-              //            (null: Any) match { case x: List[_] => x; x.reverse; case _ => }'
-              //         to:
-              //            <synthetic> val x2: List[_] = (x1.asInstanceOf[List[_]]: List[_]);
-              //                  matchEnd4({ x2; x2.reverse}) // case body is an argument to a label apply.
-              inPattern = false
-              super.transform(result)
-            }
-          case ValDef(_, _, _, _) if treeInfo.hasSynthCaseSymbol(result) =>
-            deriveValDef(result)(transform) // scala/bug#7716 Don't refcheck the tpt of the synthetic val that holds the selector.
           case _ =>
             result.transform(this)
         }

--- a/test/files/neg/t6446-additional.check
+++ b/test/files/neg/t6446-additional.check
@@ -5,10 +5,10 @@
 packageobjects   3  load package objects
          typer   4  the meat and potatoes: type the trees
 superaccessors   5  add super accessors in traits and nested classes
-        patmat   6  translate match expressions
-    extmethods   7  add extension methods for inline classes
-       pickler   8  serialize symbol tables
-     refchecks   9  reference/override checking, translate nested objects
+    extmethods   6  add extension methods for inline classes
+       pickler   7  serialize symbol tables
+     refchecks   8  reference/override checking, translate nested objects
+        patmat   9  translate match expressions
        uncurry  10  uncurry, translate function values to anonymous classes
         fields  11  synthesize accessors and fields, add bitmaps for lazy vals
      tailcalls  12  replace tail calls by jumps

--- a/test/files/neg/t6446-missing.check
+++ b/test/files/neg/t6446-missing.check
@@ -6,10 +6,10 @@ Error: unable to load class: t6446.Ploogin
 packageobjects   3  load package objects
          typer   4  the meat and potatoes: type the trees
 superaccessors   5  add super accessors in traits and nested classes
-        patmat   6  translate match expressions
-    extmethods   7  add extension methods for inline classes
-       pickler   8  serialize symbol tables
-     refchecks   9  reference/override checking, translate nested objects
+    extmethods   6  add extension methods for inline classes
+       pickler   7  serialize symbol tables
+     refchecks   8  reference/override checking, translate nested objects
+        patmat   9  translate match expressions
        uncurry  10  uncurry, translate function values to anonymous classes
         fields  11  synthesize accessors and fields, add bitmaps for lazy vals
      tailcalls  12  replace tail calls by jumps

--- a/test/files/neg/t6446-show-phases.check
+++ b/test/files/neg/t6446-show-phases.check
@@ -5,10 +5,10 @@
 packageobjects   3  load package objects
          typer   4  the meat and potatoes: type the trees
 superaccessors   5  add super accessors in traits and nested classes
-        patmat   6  translate match expressions
-    extmethods   7  add extension methods for inline classes
-       pickler   8  serialize symbol tables
-     refchecks   9  reference/override checking, translate nested objects
+    extmethods   6  add extension methods for inline classes
+       pickler   7  serialize symbol tables
+     refchecks   8  reference/override checking, translate nested objects
+        patmat   9  translate match expressions
        uncurry  10  uncurry, translate function values to anonymous classes
         fields  11  synthesize accessors and fields, add bitmaps for lazy vals
      tailcalls  12  replace tail calls by jumps

--- a/test/files/neg/t7494-no-options.check
+++ b/test/files/neg/t7494-no-options.check
@@ -6,10 +6,10 @@ error: Error: ploogin takes no options
 packageobjects   3  load package objects
          typer   4  the meat and potatoes: type the trees
 superaccessors   5  add super accessors in traits and nested classes
-        patmat   6  translate match expressions
-    extmethods   7  add extension methods for inline classes
-       pickler   8  serialize symbol tables
-     refchecks   9  reference/override checking, translate nested objects
+    extmethods   6  add extension methods for inline classes
+       pickler   7  serialize symbol tables
+     refchecks   8  reference/override checking, translate nested objects
+        patmat   9  translate match expressions
        uncurry  10  uncurry, translate function values to anonymous classes
         fields  11  synthesize accessors and fields, add bitmaps for lazy vals
      tailcalls  12  replace tail calls by jumps

--- a/test/files/run/patmat-seq.check
+++ b/test/files/run/patmat-seq.check
@@ -15,7 +15,7 @@ package <empty> {
       B.super.<init>();
       ()
     };
-    def unapplySeq(a: Int): Some[scala.collection.immutable.ArraySeq[Int]] = scala.Some.apply[scala.collection.immutable.ArraySeq[Int]](scala.collection.immutable.ArraySeq.apply[Int](1, 2, 3)((ClassTag.Int: scala.reflect.ClassTag[Int])))
+    def unapplySeq(a: Int): Some[scala.collection.immutable.ArraySeq[Int]] = new Some[scala.collection.immutable.ArraySeq[Int]](scala.collection.immutable.ArraySeq.apply[Int](1, 2, 3)((ClassTag.Int: scala.reflect.ClassTag[Int])))
   };
   class Foo[T] extends scala.AnyRef {
     def <init>(): Foo[T] = {
@@ -41,7 +41,7 @@ package <empty> {
       D.super.<init>();
       ()
     };
-    def unapplySeq[T](a: Int): Some[Foo[T]] = scala.Some.apply[Foo[T]](new Foo[T]())
+    def unapplySeq[T](a: Int): Some[Foo[T]] = new Some[Foo[T]](new Foo[T]())
   };
   object E extends scala.AnyRef {
     def <init>(): E.type = {
@@ -55,7 +55,7 @@ package <empty> {
       F.super.<init>();
       ()
     };
-    def unapplySeq(a: Int): Some[String] = scala.Some.apply[String]("123")
+    def unapplySeq(a: Int): Some[String] = new Some[String]("123")
   };
   class T extends scala.AnyRef {
     def <init>(): T = {
@@ -80,7 +80,7 @@ package <empty> {
           {
             val x: Int = o20.get.apply(0);
             val y: Int = o20.get.apply(1);
-            matchEnd15(scala.Tuple2.apply[Int, Int](x, y))
+            matchEnd15(new (Int, Int)(x, y))
           }
         else
           case19()
@@ -91,7 +91,7 @@ package <empty> {
           {
             val x: Int = o22.get.apply(0);
             val xs: Seq[Int] = o22.get.drop(1);
-            matchEnd15(scala.Tuple2.apply[Int, Seq[Int]](x, xs))
+            matchEnd15(new (Int, Seq[Int])(x, xs))
           }
         else
           case21()
@@ -112,7 +112,7 @@ package <empty> {
           {
             val x: Int = o26.get.apply(0);
             val y: Int = o26.get.apply(1);
-            matchEnd15(scala.Tuple2.apply[Int, Int](x, y))
+            matchEnd15(new (Int, Int)(x, y))
           }
         else
           case25()
@@ -123,7 +123,7 @@ package <empty> {
           {
             val x: Int = o28.get.apply(0);
             val xs: Seq[Int] = o28.get.drop(1);
-            matchEnd15(scala.Tuple2.apply[Int, Seq[Int]](x, xs))
+            matchEnd15(new (Int, Seq[Int])(x, xs))
           }
         else
           case27()
@@ -144,7 +144,7 @@ package <empty> {
           {
             val x: Int = o32.get.apply(0);
             val y: Int = o32.get.apply(1);
-            matchEnd15(scala.Tuple2.apply[Int, Int](x, y))
+            matchEnd15(new (Int, Int)(x, y))
           }
         else
           case31()
@@ -155,7 +155,7 @@ package <empty> {
           {
             val x: Int = o34.get.apply(0);
             val xs: Seq[Int] = o34.get.drop(1);
-            matchEnd15(scala.Tuple2.apply[Int, Seq[Int]](x, xs))
+            matchEnd15(new (Int, Seq[Int])(x, xs))
           }
         else
           case33()
@@ -176,7 +176,7 @@ package <empty> {
           {
             val x: Nothing = o38.get.apply(0);
             val y: Nothing = o38.get.apply(1);
-            matchEnd15(scala.Tuple2.apply[Nothing, Nothing](x, y))
+            matchEnd15(new (Nothing, Nothing)(x, y))
           }
         else
           case37()
@@ -187,7 +187,7 @@ package <empty> {
           {
             val x: Nothing = o40.get.apply(0);
             val xs: Seq[Nothing] = o40.get.drop(1);
-            matchEnd15(scala.Tuple2.apply[Nothing, Seq[Nothing]](x, xs))
+            matchEnd15(new (Nothing, Seq[Nothing])(x, xs))
           }
         else
           case39()

--- a/test/files/run/programmatic-main.check
+++ b/test/files/run/programmatic-main.check
@@ -5,10 +5,10 @@
 packageobjects   3  load package objects
          typer   4  the meat and potatoes: type the trees
 superaccessors   5  add super accessors in traits and nested classes
-        patmat   6  translate match expressions
-    extmethods   7  add extension methods for inline classes
-       pickler   8  serialize symbol tables
-     refchecks   9  reference/override checking, translate nested objects
+    extmethods   6  add extension methods for inline classes
+       pickler   7  serialize symbol tables
+     refchecks   8  reference/override checking, translate nested objects
+        patmat   9  translate match expressions
        uncurry  10  uncurry, translate function values to anonymous classes
         fields  11  synthesize accessors and fields, add bitmaps for lazy vals
      tailcalls  12  replace tail calls by jumps

--- a/test/files/run/t1434.check
+++ b/test/files/run/t1434.check
@@ -1,3 +1,0 @@
-t1434.scala:7: warning: comparing values of types Null and Null using `!=' will always yield false
-    case a: A[_] if(a.op != null) => "with op"
-                         ^

--- a/test/files/run/t1434.check
+++ b/test/files/run/t1434.check
@@ -1,0 +1,3 @@
+t1434.scala:7: warning: comparing values of types Null and Null using `!=' will always yield false
+    case a: A[_] if(a.op != null) => "with op"
+                         ^

--- a/test/files/run/t1434.scala
+++ b/test/files/run/t1434.scala
@@ -1,5 +1,5 @@
 object Test {
-  class A[T] { val op = null }
+  class A[T] { val op: AnyRef = null }
   class B extends A[Any]
   class C extends B
 

--- a/test/files/run/t6288.check
+++ b/test/files/run/t6288.check
@@ -5,7 +5,7 @@
       [106][106][106]Case3.super.<init>();
       [13]()
     };
-    [21]def unapply([29]z: [32]<type: [32]scala.Any>): [21]Option[Int] = [56][52][52]scala.Some.apply[[52]Int]([57]-1);
+    [21]def unapply([29]z: [32]<type: [32]scala.Any>): [21]Option[Int] = [56][52][52]new [52]Some[Int]([57]-1);
     [64]{
       [64]case <synthetic> val x1: [64]String = [64]"";
       [64]case5(){
@@ -89,7 +89,7 @@
       [417][417][417]Case6.super.<init>();
       [326]()
     };
-    [334]def unapply([342]z: [345]<type: [345]scala.Int>): [334]Option[Int] = [369][365][365]scala.Some.apply[[365]Int]([370]-1);
+    [334]def unapply([342]z: [345]<type: [345]scala.Int>): [334]Option[Int] = [369][365][365]new [365]Some[Int]([370]-1);
     [377]{
       [377]case <synthetic> val x1: [377]Int = [377]0;
       [377]case5()[396]{


### PR DESCRIPTION
Continuing from #6552.

The motivation is run the pickler phase earlier, as its intermediate
output can be used as an input to downstream compilation in a
[pipelined build](https://github.com/retronym/scala/pull/27#issuecomment-424193195) architecture.

TODO:
 - [x] Simplify (and review) `refchecks`. e.g. we can no longer hit https://github.com/scala/scala/blob/8bfc74557d68fd9aa94c807fd635e04189c69159/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala#L1833
