### PR TITLE
Improve performance of HashMaps, Any.##

### DIFF
--- a/src/library/scala/runtime/Statics.java
+++ b/src/library/scala/runtime/Statics.java
@@ -103,12 +103,20 @@ public final class Statics {
     if (x == null)
       return 0;
 
+    if (x instanceof java.lang.Number) {
+      return anyHashNumber((java.lang.Number) x);
+    }
+
+    return x.hashCode();
+  }
+
+  private static int anyHashNumber(Number x) {
     if (x instanceof java.lang.Long)
       return longHash(((java.lang.Long)x).longValue());
-
+  
     if (x instanceof java.lang.Double)
       return doubleHash(((java.lang.Double)x).doubleValue());
-
+  
     if (x instanceof java.lang.Float)
       return floatHash(((java.lang.Float)x).floatValue());
 


### PR DESCRIPTION
Fixes scala/bug#11171

Using the benchmark in that ticket:

```
$ (for V in 2.11.11 2.12.6 2.12.7-bin-2d7eaf7-SNAPSHOT 2.12.7-bin-642e034-SNAPSHOT; do echo "SCALA=$V"; sbt "++$V" "jmh:run -w 1 -r 1 MutableHashMapBenchmark.contains -psize=1000  -f2 "; done) | egrep 'SCALA=|MutableHashMapBenchmark.*ns/op'
SCALA=2.11.11
[info] MutableHashMapBenchmark.contains    1000          false                true  avgt   20  29863.646 ± 199.904  ns/op
SCALA=2.12.6
[info] MutableHashMapBenchmark.contains    1000          false                true  avgt   20  40008.217 ± 849.133  ns/op
SCALA=2.12.7-bin-2d7eaf7-SNAPSHOT
[info] MutableHashMapBenchmark.contains    1000          false                true  avgt   20  33488.598 ± 174.012  ns/op
SCALA=2.12.7-bin-642e034-SNAPSHOT
[info] MutableHashMapBenchmark.contains    1000          false                true  avgt   20  31533.114 ± 320.620  ns/op

$ (for V in 2.12.7-bin-642e034-SNAPSHOT; do echo "SCALA=$V"; sbt "++$V" "jmh:run -w 1 -r 1 MutableHashMapBenchmark.contains -psize=1000  -f2 -jvmArgs -XX:MaxInlineLevel=15"; done) | egrep 'SCALA=|MutableHashMapBenchmark.*ns/op'
SCALA=2.12.7-bin-642e034-SNAPSHOT
[info] MutableHashMapBenchmark.contains    1000          false                true  avgt   20  31064.080 ± 270.190  ns/op
```