### PR TITLE
Reinstate 2.13.x condition for log side effects

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -106,8 +106,9 @@ trait ContextErrors {
     def issueTypeError(err: AbsTypeError)(implicit context: Context) { context.issue(err) }
 
     def typeErrorMsg(context: Context, found: Type, req: Type) =
-      if (context.openImplicits.nonEmpty && !settings.XlogImplicits.value)
-         // OPT: avoid error string creation for errors that won't see the light of day
+      if (context.openImplicits.nonEmpty && !settings.XlogImplicits.value && settings.isScala213)
+         // OPT: avoid error string creation for errors that won't see the light of day, but predicate
+        //       this on -Xsource:2.13 for bug compatibility with https://github.com/scala/scala/pull/7147#issuecomment-418233611
         "type mismatch"
       else "type mismatch" + foundReqMsg(found, req)
   }

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1018,7 +1018,7 @@ trait Implicits {
             if(wildPtNotInstantiable || matchesPtInst(firstPending))
               typedImplicit(firstPending, ptChecked = true, isLocalToCallsite)
             else SearchFailure
-          if (typedFirstPending.isFailure)
+          if (typedFirstPending.isFailure && settings.isScala213)
             undoLog.undoTo(mark) // Don't accumulate constraints from typechecking or type error message creation for failed candidates
 
           // Pass the errors to `DivergentImplicitRecovery` so that it can note


### PR DESCRIPTION
This reinstates the conditionalization of the suppression of logging side effects that was removed in 0a8e00cb1872e1c032c5f57a447743d27790ba2e.

I've confirmed locally that with this in place eff compiles on 2.12.x.