### PR TITLE
Hand crafted equality implementation in HashTable.elemEquals

### DIFF
--- a/test/junit/scala/collection/mutable/HashMapTest.scala
+++ b/test/junit/scala/collection/mutable/HashMapTest.scala
@@ -48,4 +48,17 @@ class HashMapTest {
 
     assertEquals(List((key, "value2")), map.toList)
   }
+
+  @Test def nullKey(): Unit = {
+    assert(Int.box(0).## == null.##)
+    val m1 = collection.mutable.HashMap[Any, Any]()
+    m1.put(0, 0)
+    assert(!m1.contains(null))
+    assert(m1.contains(0))
+
+    val m2 = collection.mutable.HashMap[Any, Any]()
+    m2.put(null, null)
+    assert(m2.contains(null))
+    assert(!m2.contains(0))
+  }
 }


### PR DESCRIPTION
The preceding commit to optimize Statics.anyHash doesn't
quite claw back the performance regression in HashMap.contains
between 2.11.11 and 2.12.0.

This commit gains back a little ground by adding a fast path
for keys with identical classes.

This commit was originally part of https://github.com/scala/scala/pull/7265

In that PR, it improved the benchmark from `33488.598 ± 174.012  ns/op` to `31533.114 ± 320.620  ns/op`. The improvement is worthwhile, but we need a bit more time than was allowed by the 2.12.7 deadline to make sure it is strictly a win.