### PR TITLE
fix StringOpsTest.scala for JDK 9 or higher

### DIFF
--- a/test/junit/scala/collection/StringOpsTest.scala
+++ b/test/junit/scala/collection/StringOpsTest.scala
@@ -58,7 +58,7 @@ class StringOpsTest {
     check(string = "", start = 1, array = Array(), copied = 0, after = Array())
     check(string = "", start = -1, array = Array(), copied = 0, after = Array())
 
-    assertThrows[ArrayIndexOutOfBoundsException](check(string = "abcd", start = -13, array = Array('x', 'y'), copied = 0, after = Array('x', 'y')))
+    assertThrows[IndexOutOfBoundsException](check(string = "abcd", start = -13, array = Array('x', 'y'), copied = 0, after = Array('x', 'y')))
     check(string = "abcd", start = 0, array = Array('x', 'y'), copied = 2, after = Array('a', 'b'))
     check(string = "abcd", start = 1, array = Array('x', 'y'), copied = 1, after = Array('x', 'a'))
     check(string = "abcd", start = 2, array = Array('x', 'y'), copied = 0, after = Array('x', 'y'))


### PR DESCRIPTION
`String#getChars` throws `StringIndexOutOfBoundsException` instead of `ArrayIndexOutOfBoundsException` since JDK 9

```
Welcome to Scala 2.12.6 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> "abcd".getChars(0, 4, Array('x', 'y'), -13)
java.lang.ArrayIndexOutOfBoundsException
  at java.lang.String.getChars(String.java:826)
  ... 28 elided
```

```
Welcome to Scala 2.12.6 (Java HotSpot(TM) 64-Bit Server VM, Java 11).
Type in expressions for evaluation. Or try :help.

scala> "abcd".getChars(0, 4, Array('x', 'y'), -13)
java.lang.StringIndexOutOfBoundsException: offset -13, count 4, length 2
  at java.base/java.lang.String.checkBoundsOffCount(String.java:3304)
  at java.base/java.lang.String.getChars(String.java:855)
  ... 28 elided
```

```
Welcome to Scala 2.12.6 (Java HotSpot(TM) 64-Bit Server VM, Java 9.0.4).
Type in expressions for evaluation. Or try :help.

scala> "abcd".getChars(0, 4, Array('x', 'y'), -13)
java.lang.StringIndexOutOfBoundsException: offset -13, count 4, length 2
  at java.base/java.lang.String.checkBoundsOffCount(String.java:3101)
  at java.base/java.lang.String.getChars(String.java:866)
  ... 28 elided
```