### PR TITLE
Avoid javax.annotation.Resource in test

### DIFF
--- a/test/files/neg/t9529.check
+++ b/test/files/neg/t9529.check
@@ -1,4 +1,4 @@
-t9529.scala:7: error: Java annotation Resource may not appear multiple times on class TooMany
+t9529.scala:7: error: Java annotation Deprecated may not appear multiple times on class TooMany
 class TooMany
       ^
 one error found

--- a/test/files/neg/t9529.scala
+++ b/test/files/neg/t9529.scala
@@ -2,6 +2,6 @@
 @deprecated("bar", "")
 class `scala ftw`
 
-@javax.annotation.Resource(name = "baz")
-@javax.annotation.Resource(name = "quux")
+@java.lang.Deprecated
+@java.lang.Deprecated
 class TooMany

--- a/test/files/run/t9529.check
+++ b/test/files/run/t9529.check
@@ -1,5 +1,5 @@
 A: List()
-B: List(@javax.annotation.Resource(shareable=true, lookup=, name=B, description=, authenticationType=CONTAINER, type=class java.lang.Object, mappedName=))
+B: List(@java.lang.Deprecated())
 C: List(@anns.Ann_0(name=C, value=see))
 D: List(@anns.Ann_0$Container(value=[@anns.Ann_0(name=D, value=dee), @anns.Ann_0(name=D, value=dye)]))
 

--- a/test/files/run/t9529/Test_1.scala
+++ b/test/files/run/t9529/Test_1.scala
@@ -2,7 +2,7 @@ import java.lang.reflect._
 import anns._
 
 class A
-@javax.annotation.Resource(name = "B") class B
+@java.lang.Deprecated class B
 @Ann_0(name = "C", value = "see") class C
 @Ann_0(name = "D", value = "dee") @Ann_0(name = "D", value = "dye") class D
 


### PR DESCRIPTION
`javax.xml.ws.annotation` module deprecated since JDK9

https://docs.oracle.com/javase/10/docs/api/java.xml.ws.annotation-summary.html