### PR TITLE
fix some warnings

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -852,7 +852,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
         "serialVersionUID",
         "J",
         null, // no java-generic-signature
-        new java.lang.Long(id)
+        java.lang.Long.valueOf(id)
       ).visitEnd()
     }
   } // end of trait BCClassGen

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
@@ -104,7 +104,7 @@ abstract class BCodeIdiomatic {
         emit(Opcodes.ICONST_M1)
         emit(Opcodes.IXOR)
       } else if (bType == LONG) {
-        jmethod.visitLdcInsn(new java.lang.Long(-1))
+        jmethod.visitLdcInsn(java.lang.Long.valueOf(-1))
         jmethod.visitInsn(Opcodes.LXOR)
       } else {
         abort(s"Impossible to negate a $bType")
@@ -291,7 +291,7 @@ abstract class BCodeIdiomatic {
       } else if (cst >= java.lang.Short.MIN_VALUE && cst <= java.lang.Short.MAX_VALUE) {
         jmethod.visitIntInsn(Opcodes.SIPUSH, cst)
       } else {
-        jmethod.visitLdcInsn(new Integer(cst))
+        jmethod.visitLdcInsn(Integer.valueOf(cst))
       }
     }
 
@@ -300,7 +300,7 @@ abstract class BCodeIdiomatic {
       if (cst == 0L || cst == 1L) {
         emit(Opcodes.LCONST_0 + cst.asInstanceOf[Int])
       } else {
-        jmethod.visitLdcInsn(new java.lang.Long(cst))
+        jmethod.visitLdcInsn(java.lang.Long.valueOf(cst))
       }
     }
 
@@ -310,7 +310,7 @@ abstract class BCodeIdiomatic {
       if (bits == 0L || bits == 0x3f800000 || bits == 0x40000000) { // 0..2
         emit(Opcodes.FCONST_0 + cst.asInstanceOf[Int])
       } else {
-        jmethod.visitLdcInsn(new java.lang.Float(cst))
+        jmethod.visitLdcInsn(java.lang.Float.valueOf(cst))
       }
     }
 
@@ -320,7 +320,7 @@ abstract class BCodeIdiomatic {
       if (bits == 0L || bits == 0x3ff0000000000000L) { // +0.0d and 1.0d
         emit(Opcodes.DCONST_0 + cst.asInstanceOf[Int])
       } else {
-        jmethod.visitLdcInsn(new java.lang.Double(cst))
+        jmethod.visitLdcInsn(java.lang.Double.valueOf(cst))
       }
     }
 

--- a/src/interactive/scala/tools/nsc/interactive/Pickler.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Pickler.scala
@@ -237,11 +237,11 @@ object Pickler {
   /** A pickler the handles instances of classes that have an empty constructor.
    *  It represents than as `$new ( <name of class> )`.
    *  When unpickling, a new instance of the class is created using the empty
-   *  constructor of the class via `Class.forName(<name of class>).newInstance()`.
+   *  constructor of the class via `Class.forName(<name of class>).getConstructor().newInstance()`.
    */
   def javaInstancePickler[T <: AnyRef]: Pickler[T] =
     (stringPickler labelled "$new")
-      .wrapped { name => Class.forName(name).newInstance().asInstanceOf[T] } { _.getClass.getName }
+      .wrapped { name => Class.forName(name).getConstructor().newInstance().asInstanceOf[T] } { _.getClass.getName }
 
   /** A picklers that handles iterators. It pickles all values
    *  returned by an iterator separated by commas.

--- a/src/partest/scala/tools/partest/package.scala
+++ b/src/partest/scala/tools/partest/package.scala
@@ -99,7 +99,7 @@ package object partest {
      */
     def instantiate[A >: Null](name: String): A = (
       catching(classOf[ClassNotFoundException], classOf[SecurityException]) opt
-      (loader loadClass name).newInstance.asInstanceOf[A] orNull
+      (loader loadClass name).getConstructor().newInstance().asInstanceOf[A] orNull
     )
   }
 

--- a/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
@@ -46,7 +46,7 @@ trait ScalaClassLoader extends JClassLoader {
 
   /** Create an instance of a class with this classloader */
   def create(path: String): AnyRef =
-    tryToInitializeClass[AnyRef](path).map(_.newInstance()).orNull
+    tryToInitializeClass[AnyRef](path).map(_.getConstructor().newInstance()).orNull
 
   /** Create an instance with ctor args, or invoke errorFn before throwing. */
   def create[T <: AnyRef : ClassTag](path: String, errorFn: String => Unit)(args: AnyRef*): T = {

--- a/src/scaladoc/scala/tools/nsc/doc/DocFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/DocFactory.scala
@@ -115,7 +115,7 @@ class DocFactory(val reporter: Reporter, val settings: doc.Settings) { processor
         .map(_.newInstance(reporter))
         .getOrElse{
           reporter.warning(null, "Doclets should be created with the Reporter constructor, otherwise logging reporters will not be shared by the creating parent")
-          docletClass.newInstance()
+          docletClass.getConstructor().newInstance()
         }
         .asInstanceOf[Generator]
 


### PR DESCRIPTION
- avoid `java.lang.Class#newInstance`. deprecated since JDK9
  - https://docs.oracle.com/javase/9/docs/api/java/lang/Class.html#newInstance--
- avoid boxed primitive constructors. use `valueOf`
  - https://bugs.openjdk.java.net/browse/JDK-8176335 
  - https://docs.oracle.com/javase/9/docs/api/java/lang/Integer.html#Integer-int-