### PR TITLE
Optimize RedBlackTree-based immutable collections

### DIFF
--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -572,6 +572,40 @@ private[collection] object RedBlackTree {
     override def nextResult(tree: Tree[A, B]) = tree.value
   }
 
+  /** Build a Tree suitable for a TreeSet from an ordered sequence of keys */
+  def fromOrderedKeys[A](xs: Iterator[A], size: Int): Tree[A, Null] = {
+    val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
+    def f(level: Int, size: Int): Tree[A, Null] = size match {
+      case 0 => null
+      case 1 => mkTree(level != maxUsedDepth || level == 1, xs.next(), null, null, null)
+      case n =>
+        val leftSize = (size-1)/2
+        val left = f(level+1, leftSize)
+        val x = xs.next()
+        val right = f(level+1, size-1-leftSize)
+        BlackTree(x, null, left, right)
+    }
+    f(1, size)
+  }
+
+  /** Build a Tree suitable for a TreeMap from an ordered sequence of key/value pairs */
+  def fromOrderedEntries[A, B](xs: Iterator[(A, B)], size: Int): Tree[A, B] = {
+    val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
+    def f(level: Int, size: Int): Tree[A, B] = size match {
+      case 0 => null
+      case 1 =>
+        val (k, v) = xs.next()
+        mkTree(level != maxUsedDepth || level == 1, k, v, null, null)
+      case n =>
+        val leftSize = (size-1)/2
+        val left = f(level+1, leftSize)
+        val (k, v) = xs.next()
+        val right = f(level+1, size-1-leftSize)
+        BlackTree(k, v, left, right)
+    }
+    f(1, size)
+  }
+
   // Bulk operations based on "Just Join for Parallel Ordered Sets" (https://www.cs.cmu.edu/~guyb/papers/BFS16.pdf)
   // We don't store the black height in the tree so we pass it down into the join methods and derive the black height
   // of child nodes from it. Where possible the black height is used directly instead of deriving the rank from it.

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -571,4 +571,132 @@ private[collection] object RedBlackTree {
   private[this] class ValuesIterator[A: Ordering, B](tree: Tree[A, B], focus: Option[A]) extends TreeIterator[A, B, B](tree, focus) {
     override def nextResult(tree: Tree[A, B]) = tree.value
   }
+
+  // Bulk operations based on "Just Join for Parallel Ordered Sets" (https://www.cs.cmu.edu/~guyb/papers/BFS16.pdf):
+
+  def union[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] = blacken(_union(t1, t2))
+
+  def intersect[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] = blacken(_intersect(t1, t2))
+
+  def difference[A, B](t1: Tree[A, B], t2: Tree[A, _])(implicit ordering: Ordering[A]): Tree[A, B] =
+    blacken(_difference(t1, t2.asInstanceOf[Tree[A, B]]))
+
+  private[this] def r[A, B](t: Tree[A, B]): Int = {
+    @tailrec def h(t: Tree[A, B], i: Int): Int =
+      if(t eq null) i+1 else if(isBlackTree(t)) h(t.left, i+1) else h(t.left, i)
+    if((t eq null) || isBlackTree(t)) 2*(h(t, 0)-1)
+    else 2*h(t, 0)-1
+  }
+
+  private[this] def rotateLeft[A, B](t: Tree[A, B]): Tree[A, B] =
+    mkTree(isBlackTree(t.right), t.right.key, t.right.value,
+      mkTree(isBlackTree(t), t.key, t.value, t.left, t.right.left),
+      t.right.right)
+
+  private[this] def rotateRight[A, B](t: Tree[A, B]): Tree[A, B] =
+    mkTree(isBlackTree(t.left), t.left.key, t.left.value,
+      t.left.left,
+      mkTree(isBlackTree(t), t.key, t.value, t.left.right, t.right))
+
+  private[this] def joinRightRB[A, B](tl: Tree[A, B], k: A, v: B, tr: Tree[A, B]): Tree[A, B] = {
+    if(r(tl) == (r(tr)/2)*2)
+      RedTree(k, v, tl, tr)
+    else {
+      val cc = isBlackTree(tl)
+      val rr = tl.right
+      val ttr = joinRightRB(rr, k, v, tr)
+      if(cc && isRedTree(ttr) && isRedTree(ttr.right)) {
+        val ttr2 = mkTree(isBlackTree(ttr), ttr.key, ttr.value, ttr.left, blacken(ttr.right))
+        val tt = mkTree(cc, tl.key, tl.value, tl.left, ttr2)
+        rotateLeft(tt)
+      } else mkTree(cc, tl.key, tl.value, tl.left, ttr)
+    }
+  }
+
+  private[this] def joinLeftRB[A, B](tl: Tree[A, B], k: A, v: B, tr: Tree[A, B]): Tree[A, B] = {
+    if(r(tr) == (r(tl)/2)*2)
+      RedTree(k, v, tl, tr)
+    else {
+      val cc = isBlackTree(tr)
+      val ll = tr.left
+      val ttl = joinLeftRB(tl, k, v, ll)
+      if(cc && isRedTree(ttl) && isRedTree(ttl.left)) {
+        val ttl2 = mkTree(isBlackTree(ttl), ttl.key, ttl.value, blacken(ttl.left), ttl.right)
+        val tt = mkTree(cc, tr.key, tr.value, ttl2, tr.right)
+        rotateRight(tt)
+      } else mkTree(cc, tr.key, tr.value, ttl, tr.right)
+    }
+  }
+
+  private[this] def join[A, B](tl: Tree[A, B], k: A, v: B, tr: Tree[A, B]): Tree[A, B] = {
+    val rtl = r(tl)
+    val rtr = r(tr)
+    if(rtl/2 > rtr/2) {
+      val tt = joinRightRB(tl, k, v, tr)
+      if(isRedTree(tt) && isRedTree(tt.right)) blacken(tt)
+      else tt
+    } else if(rtr/2 > rtl/2) {
+      val tt = joinLeftRB(tl, k, v, tr)
+      if(isRedTree(tt) && isRedTree(tt.left)) blacken(tt)
+      else tt
+    } else mkTree(!(isBlackTree(tl) && isBlackTree(tr)), k, v, tl, tr)
+  }
+
+  private[this] def split[A, B](t: Tree[A, B], k: A, v: B)(implicit ordering: Ordering[A]): (Tree[A, B], Boolean, Tree[A, B]) = {
+    if(t eq null) (null, false, null)
+    else {
+      val cmp = ordering.compare(k, t.key)
+      if(cmp == 0) (t.left, true, t.right)
+      else if(cmp < 0) {
+        val (ll, b, lr) = split(t.left, k, v)
+        (ll, b, join(lr, t.key, t.value, t.right))
+      } else {
+        val (rl, b, rr) = split(t.right, k, v)
+        (join(t.left, t.key, t.value, rl), b, rr)
+      }
+    }
+  }
+
+  private[this] def splitLast[A, B](t: Tree[A, B]): (Tree[A, B], A, B) =
+    if(t.right eq null) (t.left, t.key, t.value)
+    else {
+      val (tt, kk, vv) = splitLast(t.right)
+      (join(t.left, t.key, t.value, tt), kk, vv)
+    }
+
+  private[this] def join2[A, B](tl: Tree[A, B], tr: Tree[A, B]): Tree[A, B] =
+    if(tl eq null) tr
+    else {
+      val (ttl, k, v) = splitLast(tl)
+      join(ttl, k, v, tr)
+    }
+
+  private[this] def _union[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] =
+    if(t1 eq null) t2
+    else if(t2 eq null) t1
+    else {
+      val (l1, b, r1) = split(t1, t2.key, t2.value)
+      val tl = _union(l1, t2.left)
+      val tr = _union(r1, t2.right)
+      join(tl, t2.key, t2.value, tr)
+    }
+
+  private[this] def _intersect[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] =
+    if((t1 eq null) || (t2 eq null)) null
+    else {
+      val (l1, b, r1) = split(t1, t2.key, t2.value)
+      val tl = _intersect(l1, t2.left)
+      val tr = _intersect(r1, t2.right)
+      if(b) join(tl, t2.key, t2.value, tr)
+      else join2(tl, tr)
+    }
+
+  private[this] def _difference[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] =
+    if((t1 eq null) || (t2 eq null)) t1
+    else {
+      val (l1, b, r1) = split(t1, t2.key, t2.value)
+      val tl = _difference(l1, t2.left)
+      val tr = _difference(r1, t2.right)
+      join2(tl, tr)
+    }
 }

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -498,6 +498,55 @@ private[collection] object RedBlackTree {
     f(1, size)
   }
 
+  def transform[A, B, C](t: Tree[A, B], f: (A, B) => C): Tree[A, C] =
+    if(t eq null) null
+    else {
+      val k = t.key
+      val v = t.value
+      val l = t.left
+      val r = t.right
+      val l2 = transform(l, f)
+      val v2 = f(k, v)
+      val r2 = transform(r, f)
+      if((v2.asInstanceOf[AnyRef] eq v.asInstanceOf[AnyRef])
+          && (l2 eq l)
+          && (r2 eq r)) t.asInstanceOf[Tree[A, C]]
+      else mkTree(isBlackTree(t), k, v2, l2, r2)
+    }
+
+  def filterEntries[A, B](t: Tree[A, B], f: (A, B) => Boolean): Tree[A, B] = if(t eq null) null else {
+    def fk(t: Tree[A, B]): Tree[A, B] = {
+      val k = t.key
+      val v = t.value
+      val l = t.left
+      val r = t.right
+      val l2 = if(l eq null) null else fk(l)
+      val keep = f(k, v)
+      val r2 = if(r eq null) null else fk(r)
+      if(!keep) join2(l2, r2)
+      else if((l2 eq l) && (r2 eq r)) t
+      else join(l2, k, v, r2)
+    }
+    fk(t)
+  }
+
+  def filterKeys[A, B](t: Tree[A, B], f: A => Boolean): Tree[A, B] = if(t eq null) null else {
+    def fk(t: Tree[A, B]): Tree[A, B] = {
+      val k = t.key
+      val l = t.left
+      val r = t.right
+      val l2 = if(l eq null) null else fk(l)
+      val keep = f(k)
+      val r2 = if(r eq null) null else fk(r)
+      if(!keep) join2(l2, r2)
+      else if((l2 eq l) && (r2 eq r)) t
+      else join(l2, k, t.value, r2)
+    }
+    fk(t)
+  }
+
+
+
   // Bulk operations based on "Just Join for Parallel Ordered Sets" (https://www.cs.cmu.edu/~guyb/papers/BFS16.pdf)
   // We don't store the black height in the tree so we pass it down into the join methods and derive the black height
   // of child nodes from it. Where possible the black height is used directly instead of deriving the rank from it.

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -149,8 +149,8 @@ private[collection] object RedBlackTree {
 
   def isBlack(tree: Tree[_, _]) = (tree eq null) || isBlackTree(tree)
 
-  private[this] def isRedTree(tree: Tree[_, _]) = tree.isInstanceOf[RedTree[_, _]]
-  private[this] def isBlackTree(tree: Tree[_, _]) = tree.isInstanceOf[BlackTree[_, _]]
+  @`inline` private[this] def isRedTree(tree: Tree[_, _]) = tree.isInstanceOf[RedTree[_, _]]
+  @`inline` private[this] def isBlackTree(tree: Tree[_, _]) = tree.isInstanceOf[BlackTree[_, _]]
 
   private[this] def blacken[A, B](t: Tree[A, B]): Tree[A, B] = if (t eq null) null else t.black
 
@@ -497,12 +497,12 @@ private[collection] object RedBlackTree {
     override def hasNext: Boolean = lookahead ne null
 
     @throws[NoSuchElementException]
-    override def next(): R = lookahead match {
-      case null =>
-        throw new NoSuchElementException("next on empty iterator")
-      case tree =>
+    override def next(): R = {
+      val tree = lookahead
+      if(tree ne null) {
         lookahead = findLeftMostOrPopOnEmpty(goRight(tree))
         nextResult(tree)
+      } else Iterator.empty.next()
     }
 
     @tailrec
@@ -552,12 +552,12 @@ private[collection] object RedBlackTree {
       find(root)
     }
 
-    private[this] def goLeft(tree: Tree[A, B]) = {
+    @`inline` private[this] def goLeft(tree: Tree[A, B]) = {
       pushNext(tree)
       tree.left
     }
 
-    private[this] def goRight(tree: Tree[A, B]) = tree.right
+    @`inline` private[this] def goRight(tree: Tree[A, B]) = tree.right
   }
 
   private[this] class EntriesIterator[A: Ordering, B](tree: Tree[A, B], focus: Option[A]) extends TreeIterator[A, B, (A, B)](tree, focus) {

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -164,6 +164,15 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V])(implicit va
 
   override def span(p: ((K, V)) => Boolean): (TreeMap[K, V], TreeMap[K, V]) = splitAt(countWhile(p))
 
+  override def filter(f: ((K, V)) => Boolean): TreeMap[K, V] =
+    newMapOrSelf(RB.filterEntries[K, V](tree, (k, v) => f((k, v))))
+
+  override def transform[W](f: (K, V) => W): TreeMap[K, W] = {
+    val t2 = RB.transform[K, V, W](tree, f)
+    if(t2 eq tree) this.asInstanceOf[TreeMap[K, W]]
+    else new TreeMap(t2)
+  }
+
   override protected[this] def className = "TreeMap"
 }
 

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -124,9 +124,9 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V])(implicit va
     (greatest.key, greatest.value)
   }
 
-  override def tail: TreeMap[K, V] = new TreeMap(RB.delete(tree, firstKey))
+  override def tail: TreeMap[K, V] = new TreeMap(RB.tail(tree))
 
-  override def init: TreeMap[K, V] = new TreeMap(RB.delete(tree, lastKey))
+  override def init: TreeMap[K, V] = new TreeMap(RB.init(tree))
 
   override def drop(n: Int): TreeMap[K, V] = {
     if (n <= 0) this
@@ -166,6 +166,11 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V])(implicit va
 
   override def filter(f: ((K, V)) => Boolean): TreeMap[K, V] =
     newMapOrSelf(RB.filterEntries[K, V](tree, (k, v) => f((k, v))))
+
+  override def partition(p: ((K, V)) => Boolean): (TreeMap[K, V], TreeMap[K, V]) = {
+    val (l, r) = RB.partitionEntries[K, V](tree, (k, v) => p((k, v)))
+    (newMapOrSelf(l), newMapOrSelf(r))
+  }
 
   override def transform[W](f: (K, V) => W): TreeMap[K, W] = {
     val t2 = RB.transform[K, V, W](tree, f)

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -46,9 +46,9 @@ final class TreeSet[A] private (private[immutable] val tree: RB.Tree[A, Null])(i
 
   override def last: A = RB.greatest(tree).key
 
-  override def tail: TreeSet[A] = new TreeSet(RB.delete(tree, firstKey))
+  override def tail: TreeSet[A] = new TreeSet(RB.tail(tree))
 
-  override def init: TreeSet[A] = new TreeSet(RB.delete(tree, lastKey))
+  override def init: TreeSet[A] = new TreeSet(RB.init(tree))
 
   override def drop(n: Int): TreeSet[A] = {
     if (n <= 0) this
@@ -141,6 +141,12 @@ final class TreeSet[A] private (private[immutable] val tree: RB.Tree[A, Null])(i
     newSetOrSelf(t)
   }
 
+  override def removeAll(that: IterableOnce[A]): TreeSet[A] = that match {
+    case ts: TreeSet[A] if ordering == ts.ordering =>
+      newSetOrSelf(RB.difference(tree, ts.tree))
+    case _ => super.removeAll(that)
+  }
+
   override def intersect(that: collection.Set[A]): TreeSet[A] = that match {
     case ts: TreeSet[A] if ordering == ts.ordering =>
       newSetOrSelf(RB.intersect(tree, ts.tree))
@@ -156,6 +162,11 @@ final class TreeSet[A] private (private[immutable] val tree: RB.Tree[A, Null])(i
   }
 
   override def filter(f: A => Boolean): TreeSet[A] = newSetOrSelf(RB.filterKeys(tree, f))
+
+  override def partition(p: A => Boolean): (TreeSet[A], TreeSet[A]) = {
+    val (l, r) = RB.partitionKeys(tree, p)
+    (newSetOrSelf(l), newSetOrSelf(r))
+  }
 
   override protected[this] def className = "TreeSet"
 }

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -155,6 +155,8 @@ final class TreeSet[A] private (private[immutable] val tree: RB.Tree[A, Null])(i
       super.diff(that)
   }
 
+  override def filter(f: A => Boolean): TreeSet[A] = newSetOrSelf(RB.filterKeys(tree, f))
+
   override protected[this] def className = "TreeSet"
 }
 

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -230,6 +230,8 @@ object Ordering extends LowPriorityOrderingImplicits {
     override def hashCode(): Int = outer.hashCode() * reverseSeed
   }
 
+  private final val IntReverse: Ordering[Int] = new Reverse(Ordering.Int)
+
   private final class IterableOrdering[CC[X] <: Iterable[X], T](private val ord: Ordering[T]) extends Ordering[CC[T]] {
     def compare(x: CC[T], y: CC[T]): Int = {
       val xe = x.iterator
@@ -327,6 +329,7 @@ object Ordering extends LowPriorityOrderingImplicits {
 
   trait IntOrdering extends Ordering[Int] {
     def compare(x: Int, y: Int) = java.lang.Integer.compare(x, y)
+    override def reverse: Ordering[Int] = Ordering.IntReverse
   }
   implicit object Int extends IntOrdering
 

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/RedBlackTreeBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/RedBlackTreeBenchmark.scala
@@ -10,8 +10,8 @@ import scala.util.Random
 @BenchmarkMode(Array(Mode.AverageTime))
 @Fork(2)
 @Threads(1)
-@Warmup(iterations = 30)
-@Measurement(iterations = 30)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
 class RedBlackTreeBenchmark {
@@ -26,6 +26,7 @@ class RedBlackTreeBenchmark {
   var set3: TreeSet[Int] = _
   var set4: TreeSet[Int] = _
   var perm: Array[Int] = _ // repeatably pseudo-random permutation
+  var map1: TreeMap[Int, Int] = _
 
   @Setup(Level.Trial) def init: Unit = {
     nums = 1 to size
@@ -38,6 +39,7 @@ class RedBlackTreeBenchmark {
     set2 = set1.take(size/4)
     set3 = set1.take(size*3/4)
     set4 = set1.drop(size/2)
+    map1 = TreeMap.from(nums.map(i => (i, i)))
   }
 
   @Benchmark
@@ -112,4 +114,28 @@ class RedBlackTreeBenchmark {
     for(i <- 0 to 10) res += s.drop(s.size*i/10).size
     bh.consume(res)
   }
+
+  @Benchmark
+  def filterKeep(bh: Blackhole): Unit =
+    bh.consume(set1.filter(_ => true))
+
+  @Benchmark
+  def filterDrop(bh: Blackhole): Unit =
+    bh.consume(set1.filter(_ => false))
+
+  @Benchmark
+  def filterPartial(bh: Blackhole): Unit =
+    bh.consume(set1.filter(i => i % 2 == 0))
+
+  @Benchmark
+  def transformNone(bh: Blackhole): Unit =
+    bh.consume(map1.transform((k, v) => v))
+
+  @Benchmark
+  def transformAll(bh: Blackhole): Unit =
+    bh.consume(map1.transform((k, v) => v+1))
+
+  @Benchmark
+  def transformHalf(bh: Blackhole): Unit =
+    bh.consume(map1.transform((k, v) => if(k % 2 == 0) v else v+1))
 }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/RedBlackTreeBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/RedBlackTreeBenchmark.scala
@@ -22,6 +22,9 @@ class RedBlackTreeBenchmark {
   var nums: Range = _
   val rnd = new Random(0)
   var set1: TreeSet[Int] = _
+  var set2: TreeSet[Int] = _
+  var set3: TreeSet[Int] = _
+  var set4: TreeSet[Int] = _
   var perm: Array[Int] = _ // repeatably pseudo-random permutation
 
   @Setup(Level.Trial) def init: Unit = {
@@ -32,6 +35,9 @@ class RedBlackTreeBenchmark {
     perm = Array.fill(size)(rem.remove(rnd.nextInt(rem.size)))
     assert(rem.size == 0)
     assert(perm.sum == nums.sum)
+    set2 = set1.take(size/4)
+    set3 = set1.take(size*3/4)
+    set4 = set1.drop(size/2)
   }
 
   @Benchmark
@@ -63,5 +69,15 @@ class RedBlackTreeBenchmark {
     var s = set1
     perm.foreach(i => s = s.excl(i))
     bh.consume(s)
+  }
+
+  @Benchmark
+  def union(bh: Blackhole): Unit = {
+    bh.consume(
+      set1.union(set1).size +
+      set2.union(set3).size +
+      set2.union(set4).size +
+      set4.union(set2).size
+    )
   }
 }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/RedBlackTreeBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/RedBlackTreeBenchmark.scala
@@ -128,6 +128,10 @@ class RedBlackTreeBenchmark {
     bh.consume(set1.filter(i => i % 2 == 0))
 
   @Benchmark
+  def partition(bh: Blackhole): Unit =
+    bh.consume(set1.partition(i => i % 2 == 0))
+
+  @Benchmark
   def transformNone(bh: Blackhole): Unit =
     bh.consume(map1.transform((k, v) => v))
 
@@ -138,4 +142,10 @@ class RedBlackTreeBenchmark {
   @Benchmark
   def transformHalf(bh: Blackhole): Unit =
     bh.consume(map1.transform((k, v) => if(k % 2 == 0) v else v+1))
+
+  @Benchmark
+  def tails(bh: Blackhole): Unit = {
+    val it = set1.tails
+    while(it.hasNext) bh.consume(it.next())
+  }
 }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/RedBlackTreeBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/RedBlackTreeBenchmark.scala
@@ -80,4 +80,36 @@ class RedBlackTreeBenchmark {
       set4.union(set2).size
     )
   }
+
+  @Benchmark
+  def range(bh: Blackhole): Unit = {
+    var s = set1
+    var res = 0
+    for(i <- 0 to 5; j <- 0 to 5) res += s.range(s.size*i/5, s.size*j/5).size
+    bh.consume(res)
+  }
+
+  @Benchmark
+  def slice(bh: Blackhole): Unit = {
+    var s = set1
+    var res = 0
+    for(i <- 0 to 5; j <- 0 to 5) res += s.slice(s.size*i/5, s.size*j/5).size
+    bh.consume(res)
+  }
+
+  @Benchmark
+  def take(bh: Blackhole): Unit = {
+    var s = set1
+    var res = 0
+    for(i <- 0 to 10) res += s.take(s.size*i/10).size
+    bh.consume(res)
+  }
+
+  @Benchmark
+  def drop(bh: Blackhole): Unit = {
+    var s = set1
+    var res = 0
+    for(i <- 0 to 10) res += s.drop(s.size*i/10).size
+    bh.consume(res)
+  }
 }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/RedBlackTreeBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/RedBlackTreeBenchmark.scala
@@ -1,0 +1,67 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+
+import scala.util.Random
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 30)
+@Measurement(iterations = 30)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class RedBlackTreeBenchmark {
+
+  @Param(Array("0", "1", "10", "100", "1000", "10000"))
+  var size: Int = _
+
+  var nums: Range = _
+  val rnd = new Random(0)
+  var set1: TreeSet[Int] = _
+  var perm: Array[Int] = _ // repeatably pseudo-random permutation
+
+  @Setup(Level.Trial) def init: Unit = {
+    nums = 1 to size
+    set1 = TreeSet.from(nums)
+    perm = new Array[Int](size)
+    val rem = scala.collection.mutable.ArrayBuffer.from(nums)
+    perm = Array.fill(size)(rem.remove(rnd.nextInt(rem.size)))
+    assert(rem.size == 0)
+    assert(perm.sum == nums.sum)
+  }
+
+  @Benchmark
+  def build(bh: Blackhole): Unit =
+    bh.consume(TreeSet.from(nums))
+
+  @Benchmark
+  def buildRandom(bh: Blackhole): Unit =
+    bh.consume(TreeSet.from(perm))
+
+  @Benchmark
+  def iterator(bh: Blackhole): Unit = {
+    val it = set1.iterator
+    var res = 0
+    while(it.hasNext)
+      res += it.next()
+    bh.consume(res)
+  }
+
+  @Benchmark
+  def foreach(bh: Blackhole): Unit = {
+    var i = 0
+    set1.foreach { x => i += x }
+    bh.consume(i)
+  }
+
+  @Benchmark
+  def drain(bh: Blackhole): Unit = {
+    var s = set1
+    perm.foreach(i => s = s.excl(i))
+    bh.consume(s)
+  }
+}

--- a/test/scalacheck/redblacktree.scala
+++ b/test/scalacheck/redblacktree.scala
@@ -222,6 +222,32 @@ object TestDrop extends RedBlackTreeTest("RedBlackTree.drop") {
   }
 }
 
+object TestTail extends RedBlackTreeTest("RedBlackTree.tail") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, 0)
+  override def modify(tree: Tree[String, Int], parm: ModifyParm): Tree[String, Int] =
+    if(tree eq null) null else tail(tree)
+
+  property("tail") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).drop(1).toList == iterator(newTree).toList
+  }
+}
+
+object TestInit extends RedBlackTreeTest("RedBlackTree.init") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, 0)
+  override def modify(tree: Tree[String, Int], parm: ModifyParm): Tree[String, Int] =
+    if(tree eq null) null else init(tree)
+
+  property("tail") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).toList.dropRight(1) == iterator(newTree).toList
+  }
+}
+
 object TestTake extends RedBlackTreeTest("RedBlackTree.take") {
   import RB._
 
@@ -348,6 +374,32 @@ object TestFilter extends RedBlackTreeTest("RedBlackTree.filterEntries") {
 
   property("filter") = forAll(genInput) { case (tree, parm, newTree) =>
     iterator(tree).filter(t => t._1.hashCode % 2 == 0).toList == iterator(newTree).toList
+  }
+}
+
+object TestPartitionLeft extends RedBlackTreeTest("RedBlackTree.partitionKeysLeft") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, 0)
+  override def modify(tree: Tree[String, Int], parm: ModifyParm): Tree[String, Int] =
+    partitionKeys[String, Int](tree, k => k.hashCode % 2 == 0)._1
+
+  property("partition") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).filter(t => t._1.hashCode % 2 == 0).toList == iterator(newTree).toList
+  }
+}
+
+object TestPartitionRight extends RedBlackTreeTest("RedBlackTree.partitionKeysRight") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, 0)
+  override def modify(tree: Tree[String, Int], parm: ModifyParm): Tree[String, Int] =
+    partitionKeys[String, Int](tree, k => k.hashCode % 2 == 0)._2
+
+  property("partition") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).filter(t => t._1.hashCode % 2 != 0).toList == iterator(newTree).toList
   }
 }
 

--- a/test/scalacheck/redblacktree.scala
+++ b/test/scalacheck/redblacktree.scala
@@ -337,3 +337,29 @@ object TestDifference extends BulkTest("RedBlackTree.difference") {
   def treeOp(t1: Tree[String, Int], t2: Tree[String, Int]): Tree[String, Int] = difference(t1, t2)
   def setOp(s1: Set[(String, Int)], s2: Set[(String, Int)]): Set[(String, Int)] = s1.diff(s2)
 }
+
+object TestFilter extends RedBlackTreeTest("RedBlackTree.filterEntries") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, 0)
+  override def modify(tree: Tree[String, Int], parm: ModifyParm): Tree[String, Int] =
+    filterEntries[String, Int](tree, (k, _) => k.hashCode % 2 == 0)
+
+  property("filter") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).filter(t => t._1.hashCode % 2 == 0).toList == iterator(newTree).toList
+  }
+}
+
+object TestTransform extends RedBlackTreeTest("RedBlackTree.transform") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, count(tree))
+  override def modify(tree: Tree[String, Int], parm: ModifyParm): Tree[String, Int] =
+    transform[String, Int, Int](tree, (k, v) => if(v < parm) v else v+1)
+
+  property("transform") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).toList.map { case (k, v) => if(v < parm) (k, v) else (k, v+1) } == iterator(newTree).toList
+  }
+}


### PR DESCRIPTION
- Some improved inlining in RedBlackTree
- Remove unnecessary `contains` check before deleting from TreeSet or TreeMap
- Avoid recreating wrapper objects when appending to and deleting from TreeSets and TreeMaps without a change
- Bulk building / appending without creating intermediate TreeSets or TreeMaps
- Building TreeSets and TreeMaps directly without a Builder
- Use null instead of () as dummy value in TreeSet

Here's some performance data from Java 8 with HotSpot on x64. Getting reliable results was not always easy. I ran the benchmarks with `bench/jmh:run -jvmArgs "-Xms128M -Xmx128M" scala.collection.immutable.RedBlackTreeBenchmark`. Giving it lots of memory led to unreliable data, with optimizations kicking in very late only when there was GC pressure, so you'd need  a huge number of warmup iterations.

Building from a source in the correct order and in random order, in 2.13.x:
```
[info] Benchmark                          (size)  Mode  Cnt        Score       Error  Units
[info] RedBlackTreeBenchmark.build             0  avgt   60       15.032 ±     0.084  ns/op
[info] RedBlackTreeBenchmark.build             1  avgt   60       24.781 ±     0.111  ns/op
[info] RedBlackTreeBenchmark.build            10  avgt   60      741.863 ±     4.457  ns/op
[info] RedBlackTreeBenchmark.build           100  avgt   60    11803.651 ±    68.646  ns/op
[info] RedBlackTreeBenchmark.build          1000  avgt   60   178889.209 ±   947.915  ns/op
[info] RedBlackTreeBenchmark.build         10000  avgt   60  2641918.688 ± 13482.549  ns/op
[info] RedBlackTreeBenchmark.buildRandom       0  avgt   60       27.135 ±     0.155  ns/op
[info] RedBlackTreeBenchmark.buildRandom       1  avgt   60       44.238 ±     0.583  ns/op
[info] RedBlackTreeBenchmark.buildRandom      10  avgt   60      706.818 ±    15.026  ns/op
[info] RedBlackTreeBenchmark.buildRandom     100  avgt   60    11097.576 ±    87.879  ns/op
[info] RedBlackTreeBenchmark.buildRandom    1000  avgt   60   242717.013 ±  1577.754  ns/op
[info] RedBlackTreeBenchmark.buildRandom   10000  avgt   60  3932147.592 ± 23255.622  ns/op
```

With this change (avoiding the unnecessary intermediate `TreeSet` objects):
```
[info] RedBlackTreeBenchmark.build             0  avgt   60        6.529 ±     0.036  ns/op
[info] RedBlackTreeBenchmark.build             1  avgt   60       11.644 ±     0.126  ns/op
[info] RedBlackTreeBenchmark.build            10  avgt   60      398.927 ±     2.394  ns/op
[info] RedBlackTreeBenchmark.build           100  avgt   60     8533.978 ±    50.420  ns/op
[info] RedBlackTreeBenchmark.build          1000  avgt   60   164994.754 ±  1869.387  ns/op
[info] RedBlackTreeBenchmark.build         10000  avgt   60  2253731.587 ± 11218.765  ns/op
[info] RedBlackTreeBenchmark.buildRandom       0  avgt   60       25.479 ±     0.160  ns/op
[info] RedBlackTreeBenchmark.buildRandom       1  avgt   60       32.923 ±     0.642  ns/op
[info] RedBlackTreeBenchmark.buildRandom      10  avgt   60      346.081 ±     2.612  ns/op
[info] RedBlackTreeBenchmark.buildRandom     100  avgt   60     8221.890 ±    43.662  ns/op
[info] RedBlackTreeBenchmark.buildRandom    1000  avgt   60   209767.283 ±  1639.279  ns/op
[info] RedBlackTreeBenchmark.buildRandom   10000  avgt   60  3668358.135 ± 51228.253  ns/op
```

Deleting all elements in random order in 2.13.x:
```
[info] RedBlackTreeBenchmark.drain             0  avgt   60        4.347 ±     0.032  ns/op
[info] RedBlackTreeBenchmark.drain             1  avgt   60       13.908 ±     0.078  ns/op
[info] RedBlackTreeBenchmark.drain            10  avgt   60      563.643 ±     3.989  ns/op
[info] RedBlackTreeBenchmark.drain           100  avgt   60    10659.737 ±    69.129  ns/op
[info] RedBlackTreeBenchmark.drain          1000  avgt   60   284227.686 ±  2179.154  ns/op
[info] RedBlackTreeBenchmark.drain         10000  avgt   60  4932893.507 ± 34018.351  ns/op
```

With this change (benefiting mostly from not performing the unnecessary `contains` checks):
```
[info] RedBlackTreeBenchmark.drain             0  avgt   60        4.334 ±     0.030  ns/op
[info] RedBlackTreeBenchmark.drain             1  avgt   60       13.726 ±     0.082  ns/op
[info] RedBlackTreeBenchmark.drain            10  avgt   60      486.583 ±     2.400  ns/op
[info] RedBlackTreeBenchmark.drain           100  avgt   60     9553.461 ±    54.927  ns/op
[info] RedBlackTreeBenchmark.drain          1000  avgt   60   220971.471 ±  1502.734  ns/op
[info] RedBlackTreeBenchmark.drain         10000  avgt   60  4115382.806 ± 27286.882  ns/op
```

Performance of iteration via `iterator` and `foreach` is unchanged.

I spent the better part of a week on this and the resulting set of changes is rather small. There's a lot more that I tried that didn't work:

- Removing `null` trees and using a proper `empty` tree object doesn't give you any real advantage. The way the red-black tree algorithms work you have to treat the empty tree specially in almost all cases so you may as well check for null. And even if you add an `empty` tree you'll still want to check for that by comparing it with `eq empty` because this is much faster than an `isEmpty` method on the tree itself.

- Removing polymorphic dispatch of `Tree` methods by making `Tree` final is promising. You have to encode the color somehow if it's not encoded in the class anymore. Adding an extra field is not a good option. The basic `Tree` type has a size of 32 bytes with no wasted space, just like the original `RedTree` and `BlackTree` types. Adding an extra field would increase the memory footprint by 25% (assuming 64-bit alignment), so I used the (otherwise unused) sign bit of the `count` field for the color:
  ```scala
    final class Tree[A, +B](
      @(`inline` @getter) final val key: A,
      @(`inline` @getter) final val value: B,
      @(`inline` @getter) final val left: Tree[A, B],
      @(`inline` @getter) final val right: Tree[A, B],
      @(`inline` @getter) final val _count: Int) // negative for black trees, positive for red trees
  ```
  This works rather well in *some* cases:
  ```
  [info] RedBlackTreeBenchmark.buildRandom       0  avgt   16       24.148 ±     0.250  ns/op
  [info] RedBlackTreeBenchmark.buildRandom       1  avgt   16       37.722 ±     0.615  ns/op
  [info] RedBlackTreeBenchmark.buildRandom      10  avgt   16      378.835 ±     7.607  ns/op
  [info] RedBlackTreeBenchmark.buildRandom     100  avgt   16     7688.842 ±    93.652  ns/op
  [info] RedBlackTreeBenchmark.buildRandom    1000  avgt   16   186845.275 ±  3112.246  ns/op
  [info] RedBlackTreeBenchmark.buildRandom   10000  avgt   16  3210497.905 ± 50008.618  ns/op
  ```
  Other benchmarks, in particular for iteration, showed decreased performance. Looking back now at the results I got when I did these tests, it's possible that they were skewed by the late optimization without limiting the heap size. I'll do another proper test run tonight. Maybe this encoding is better after all.

- Inlining some of the small methods in `TreeIterator`. This looks like an obvious win but it's not. Letting HotSpot take care of inlining is actually better in this case.

- Iteration instead of tail recursion in `foreach`. We can't enforce tail recursion (marking the method `@tailrec` is not an option because it is also used in non-tail position) but scalac still generates better code for the tail recursion than for an explicit loop.

- Using a Java implementation of the tree classes. The Scala version with the ``@(`inline` @getter)`` annotations is clunky, but so is Java. Performance is exactly the same.