### PR TITLE
Add another fast path to i.Hash{Map,Set}.equals

### DIFF
--- a/src/library/scala/collection/immutable/ChampHashMap.scala
+++ b/src/library/scala/collection/immutable/ChampHashMap.scala
@@ -1008,8 +1008,9 @@ private final class BitmapIndexedMapNode[K, +V](
         (this eq node) ||
           (this.nodeMap == node.nodeMap) &&
             (this.dataMap == node.dataMap) &&
-              java.util.Arrays.equals(this.originalHashes, node.originalHashes) &&
-                deepContentEquality(this.content, node.content, content.length)
+              (this.size == node.size) &&
+                java.util.Arrays.equals(this.originalHashes, node.originalHashes) &&
+                  deepContentEquality(this.content, node.content, content.length)
       case _ => false
     }
 

--- a/src/library/scala/collection/immutable/ChampHashSet.scala
+++ b/src/library/scala/collection/immutable/ChampHashSet.scala
@@ -581,8 +581,9 @@ private final class BitmapIndexedSetNode[A](
         (this eq node) ||
           (this.nodeMap == node.nodeMap) &&
             (this.dataMap == node.dataMap) &&
-            java.util.Arrays.equals(this.originalHashes, node.originalHashes) &&
-            deepContentEquality(this.content, node.content, content.length)
+              (this.size == node.size) &&
+                java.util.Arrays.equals(this.originalHashes, node.originalHashes) &&
+                   deepContentEquality(this.content, node.content, content.length)
       case _ => false
     }
 


### PR DESCRIPTION
We added the size field to the nodes recently. This can
be used to short circuit equals without descending into the
trie.