### PR TITLE
[#11159][do not merge] Prototype proposal to fix seqview and indexedSeqView operators

### DIFF
--- a/src/library/scala/collection/IndexedSeqView.scala
+++ b/src/library/scala/collection/IndexedSeqView.scala
@@ -23,6 +23,10 @@ trait IndexedSeqView[+A] extends IndexedSeqOps[A, View, View[A]] with SeqView[A]
   def concat[B >: A](suffix: IndexedSeqView.SomeIndexedSeqOps[B]): IndexedSeqView[B] = new IndexedSeqView.Concat(this, suffix)
   def appendedAll[B >: A](suffix: IndexedSeqView.SomeIndexedSeqOps[B]): IndexedSeqView[B] = new IndexedSeqView.Concat(this, suffix)
   def prependedAll[B >: A](prefix: IndexedSeqView.SomeIndexedSeqOps[B]): IndexedSeqView[B] = new IndexedSeqView.Concat(prefix, this)
+
+  override def +: [B >: A](elem: B): IndexedSeqView[B] = prepended(elem)
+  override def :+ [B >: A](elem: B): IndexedSeqView[B] = appended(elem)
+  def ++ [B >: A](suffix: IndexedSeqView.SomeIndexedSeqOps[B]): IndexedSeqView[B] = concat(suffix)
 }
 
 object IndexedSeqView {

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -705,7 +705,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   })
 
   /** Alias for `concat` */
-  @`inline` final def ++ [B >: A](suffix: IterableOnce[B]): CC[B] = concat(suffix)
+  def ++ [B >: A](suffix: IterableOnce[B]): CC[B] = concat(suffix)
 
   /** Returns a $coll formed from this $coll and another iterable collection
     *  by combining corresponding elements in pairs.

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -20,6 +20,11 @@ trait Seq[+A]
 
   override def iterableFactory: SeqFactory[IterableCC] = Seq
 
+  override final def +: [B >: A](elem: B): IterableCC[B] = prepended(elem)
+
+  override final def :+ [B >: A](elem: B): IterableCC[B] = appended(elem)
+
+
   /** Method called from equality methods, so that user-defined subclasses can
     *  refuse to be equal to other collections of the same kind.
     *  @param   that   The object with which this $coll should be compared
@@ -112,7 +117,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     * Note that :-ending operators are right associative (see example).
     * A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
     */
-  @`inline` final def +: [B >: A](elem: B): CC[B] = prepended(elem)
+  def +: [B >: A](elem: B): CC[B] = prepended(elem)
 
   /** A copy of this $coll with an element appended.
     *
@@ -142,7 +147,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     * Note that :-ending operators are right associative (see example).
     * A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
     */
-  @`inline` final def :+ [B >: A](elem: B): CC[B] = appended(elem)
+  def :+ [B >: A](elem: B): CC[B] = appended(elem)
 
   /** As with `:++`, returns a new collection containing the elements from the left operand followed by the
     *  elements from the right operand.

--- a/src/library/scala/collection/SeqView.scala
+++ b/src/library/scala/collection/SeqView.scala
@@ -15,6 +15,10 @@ trait SeqView[+A] extends SeqOps[A, View, View[A]] with View[A] {
   def concat[B >: A](suffix: SeqView.SomeSeqOps[B]): SeqView[B] = new SeqView.Concat(this, suffix)
   def appendedAll[B >: A](suffix: SeqView.SomeSeqOps[B]): SeqView[B] = new SeqView.Concat(this, suffix)
   def prependedAll[B >: A](prefix: SeqView.SomeSeqOps[B]): SeqView[B] = new SeqView.Concat(prefix, this)
+
+  override def +: [B >: A](elem: B): SeqView[B] = prepended(elem)
+  override def :+ [B >: A](elem: B): SeqView[B] = appended(elem)
+  def ++ [B >: A](suffix: SeqView.SomeSeqOps[B]): SeqView[B] = concat(suffix)
 }
 
 object SeqView {

--- a/src/library/scala/collection/immutable/Iterable.scala
+++ b/src/library/scala/collection/immutable/Iterable.scala
@@ -23,6 +23,8 @@ import scala.collection.IterableFactory
 trait Iterable[+A] extends collection.Iterable[A]
                       with collection.IterableOps[A, Iterable, Iterable[A]] {
 
+  override final def ++ [B >: A](suffix: IterableOnce[B]): IterableCC[B] = concat(suffix)
+
   override def iterableFactory: IterableFactory[IterableCC] = Iterable
 }
 

--- a/test/junit/scala/collection/IndexedSeqViewTest.scala
+++ b/test/junit/scala/collection/IndexedSeqViewTest.scala
@@ -1,0 +1,17 @@
+package scala.collection
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+
+@RunWith(classOf[JUnit4])
+class IndexedSeqViewTest {
+
+  @Test def t11159(): Unit = {
+    (1 +: 2 +: Vector().view) : IndexedSeqView[Int]
+    (Vector().view :+ 1 :+ 2) : IndexedSeqView[Int]
+    (Vector(1, 2).view ++ Vector(3, 4).view) : IndexedSeqView[Int]
+    (Vector(1, 2).view ++ List(3, 4).view) : SeqView[Int]
+    (List(1, 2).view ++ Vector(3, 4).view) : SeqView[Int]
+  }
+}

--- a/test/junit/scala/collection/SeqViewTest.scala
+++ b/test/junit/scala/collection/SeqViewTest.scala
@@ -1,0 +1,16 @@
+
+package scala.collection
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+
+@RunWith(classOf[JUnit4])
+class SeqViewTest {
+
+  @Test def t11159(): Unit = {
+    (1 +: 2 +: Nil.view) : SeqView[Int]
+    (Nil.view :+ 1 :+ 2) : SeqView[Int]
+    (List(1, 2).view ++ List(3, 4).view) : SeqView[Int]
+  }
+}


### PR DESCRIPTION
This is a prototype / strawman proposal to fix scala/bug#11159 

Is it okay to move the various ```@`inline` final def``` symbolic aliases into the `Collection` proper trait, rather than the `CollectionOps` trait? This would allow Views, SeqViews, and IndexedSeqViews to override the now-non-final symbolic operators in SeqOps.

Proof of the api are found in the junit tests, [here](https://github.com/scala/scala/pull/7286/files#diff-c236299738fe3a89e2b020e973942a02R8) and [here](https://github.com/scala/scala/pull/7286/files#diff-5ed8925325b54af8398af95187549155R9)