### PR TITLE
Add cached hash code to each node in CHAMP structures

### DIFF
--- a/src/library/scala/collection/immutable/ChampCommon.scala
+++ b/src/library/scala/collection/immutable/ChampCommon.scala
@@ -63,6 +63,8 @@ private[immutable] abstract class Node[T <: Node[T]] {
 
   def sizePredicate: Int
 
+  def cachedJavaKeySetHashCode: Int
+
   protected final def removeElement(as: Array[Int], ix: Int): Array[Int] = {
     if (ix < 0) throw new ArrayIndexOutOfBoundsException
     if (ix > as.length - 1) throw new ArrayIndexOutOfBoundsException

--- a/test/junit/scala/collection/immutable/ChampMapSmokeTest.scala
+++ b/test/junit/scala/collection/immutable/ChampMapSmokeTest.scala
@@ -177,18 +177,8 @@ class ChampMapSmokeTest {
   private def assertSameEqHash(expected: HashMap[Any, Any], actual: HashMap[Any, Any]) = {
     assertEquals(List.from(actual).size, actual.size)
     assertEquals(expected.size, actual.size)
-    assertEquals(cachedJavaKeySetHashCode(expected), cachedJavaKeySetHashCode(actual))
+    assertEquals(expected.rootNode.cachedJavaKeySetHashCode, actual.rootNode.cachedJavaKeySetHashCode)
     assertEquals(expected.hashCode(), actual.hashCode())
-  }
-
-  lazy val (mirror, field) = {
-    import scala.reflect.runtime.{universe=>ru}
-    val mirror = ru.runtimeMirror(classOf[HashMap[_,_]].getClassLoader)
-    val field = ru.typeOf[HashMap[_,_]].decl(ru.TermName("cachedJavaKeySetHashCode")).asTerm
-    (mirror, field)
-  }
-  def cachedJavaKeySetHashCode(map:  HashMap[Any, Any]) = {
-    mirror.reflect(map).reflectField(field).get
   }
 
   private def value(i: Int) = new String("" + i)
@@ -208,7 +198,7 @@ class ChampMapSmokeTest {
     var map1 = map
     for (c <- cs) {
       map1 = map1.updated(c, value(c.i))
-      assertEquals(cachedJavaKeySetHashCode(map), cachedJavaKeySetHashCode(map1))
+      assertEquals(map.rootNode.cachedJavaKeySetHashCode, map1.rootNode.cachedJavaKeySetHashCode)
       if (c.i % 41 == 0)
         assertEquals(map, map1)
     }

--- a/test/junit/scala/collection/immutable/ChampSetSmokeTest.scala
+++ b/test/junit/scala/collection/immutable/ChampSetSmokeTest.scala
@@ -230,7 +230,6 @@ class ChampSetSmokeTest extends DecorateAsJava with DecorateAsScala {
   private def assertSameEqHash(expected: HashSet[Any], actual: HashSet[Any]) = {
     assertEquals(List.from(actual).size, actual.size)
     assertEquals(expected.size, actual.size)
-    assertEquals(expected.cachedJavaHashCode, actual.cachedJavaHashCode)
     assertEquals(expected.hashCode(), actual.hashCode())
   }
 
@@ -250,7 +249,7 @@ class ChampSetSmokeTest extends DecorateAsJava with DecorateAsScala {
     var set1 = set
     for (c <- cs) {
       set1 = set1 + c
-      assertEquals(set.cachedJavaHashCode, set1.cachedJavaHashCode)
+      assertEquals(set.rootNode.cachedJavaKeySetHashCode, set1.rootNode.cachedJavaKeySetHashCode)
       if (c.i % 41 == 0)
         assertEquals(set, set1)
     }

--- a/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
@@ -245,10 +245,10 @@ object ImmutableChampHashSetProperties extends Properties("immutable.ChampHashSe
     val b = HashSet.newBuilder[K].addAll(seq)
     b.result == b.addAll(seq).result()
   }
-  property("(xs ++ ys).toMap == xs.toMap ++ ys.toMap") = forAll { (xs: Seq[K],ys: Seq[K]) =>
+  property("(xs ++ ys).toSet == xs.toSet ++ ys.toSet") = forAll { (xs: Seq[K],ys: Seq[K]) =>
     (xs ++ ys).toSet == xs.toSet ++ ys.toSet
   }
-  property("HashMapBuilder produces the same Map as MapBuilder") = forAll { (xs: Seq[K]) =>
+  property("HashSetBuilder produces the same Set as SetBuilder") = forAll { (xs: Seq[K]) =>
     HashSet.newBuilder[K].addAll(xs).result() == HashSet.newBuilder[K].addAll(xs).result()
   }
   property("HashSetBuilder does not mutate after releasing") = forAll { (xs: Seq[K], ys: Seq[K], single: K, addSingleFirst: Boolean) =>
@@ -281,6 +281,14 @@ object ImmutableChampHashSetProperties extends Properties("immutable.ChampHashSe
     val mb = Set.newBuilder[K].addAll(xs)
     val hmb = Set.newBuilder[K].addAll(xs)
     (mb.result() eq mb.result()) && (hmb.result() eq hmb.result())
+  }
+
+  property("xs.toList.toSet == xs") = forAll { xs: Set[K] =>
+    xs.toList.toSet == xs
+  }
+
+  property("(xs - elem) == xs.toList.filterNot(_ == elem).toSet") = forAll { (xs: Set[K], elem: K) =>
+    (xs - elem) == xs.toList.filterNot(_ == elem).toSet
   }
 
 }


### PR DESCRIPTION
Left to do
- [x] Add these changes to HashSet
- [x] Move any formerly inlined methods (like `concat`) into the `{Map,Set}Node` trait. 
- [x] Take advantage of the cached hash codes to achieve greater structural sharing in `concat`