### PR TITLE
fix t9400 test with JDK9+

### DIFF
--- a/test/files/run/t9400.scala
+++ b/test/files/run/t9400.scala
@@ -1,6 +1,9 @@
 
 class Deprecation extends Deprecated {
   final val annotationType = classOf[Deprecated]
+
+  def forRemoval(): Boolean = false
+  def since(): String = ""
 }
 
 class Suppression extends SuppressWarnings {


### PR DESCRIPTION
```
t9400.scala:2: error: class Deprecation needs to be abstract, since:
it has 2 unimplemented members.
/** As seen from class Deprecation, the missing signatures are as follows.
 *  For convenience, these are usable as stub implementations.
 */
  def forRemoval(): Boolean = ???
  def since(): String = ???

class Deprecation extends Deprecated {
      ^
one error found
```