### PR TITLE
Fix regression in HashMap#concat method 

### DIFF
--- a/src/library/scala/collection/immutable/ChampHashMap.scala
+++ b/src/library/scala/collection/immutable/ChampHashMap.scala
@@ -127,8 +127,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
           //
           // This is not necessary in the top level because the resulting hash in that case is already computed. It is
           // the hash of the right HashMap
-          val canReturnEarly = shift == 0
-          if (canReturnEarly && (left eq right)) {
+          if (shift == 0 && (left eq right)) {
             right
           } else left match {
             case leftBm: BitmapIndexedMapNode[K, V] =>
@@ -215,12 +214,6 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
                       leftNodeOnly |
                       rightNodeOnly |
                       dataToNodeMigrationTargets
-
-
-                  if (canReturnEarly && (newDataMap == (rightDataOnly | leftDataRightDataRightOverwrites)) && (newNodeMap == rightNodeOnly)) {
-                    // nothing from left will make it into the result -- return early
-                    return right
-                  }
 
                   val newDataSize = bitCount(newDataMap)
                   val newContentSize = (MapNode.TupleLength * newDataSize) + bitCount(newNodeMap)


### PR DESCRIPTION
We were too optimistically returning early, and not correctly handling the hashcode. 

Specifically, we should not return early where `leftDataRightDataRightOverwrites != 0`, because we still must visit that data, to subtract its hash from the final hash. 

https://github.com/scala/scala/pull/7288#issuecomment-425721963