### PR TITLE
Optimize HashMap#filter,filterNot,removeAll, HashSet#filter,filterNot,removeAll,diff by using structural sharing.

### DIFF
--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -14,7 +14,6 @@ package scala
 package collection
 package immutable
 
-import java.io.{ObjectInputStream, ObjectOutputStream}
 
 import scala.collection.immutable.Set.Set4
 import scala.collection.mutable.{Builder, ImmutableBuilder}

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/SetBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/SetBenchmark.scala
@@ -20,7 +20,7 @@ class SetBenchmark {
   @Setup(Level.Trial) def initKeys(): Unit = {
     base = Set("a", "b", "c", "d")
   }
-  
+
   // immutable map is implemented as EmptySet -> Set1 -> Set2 -> Set3 -> Set4 -> HashSet
   // add an extra entry to Set4 causes a lot of work, benchmark the transition
   @Benchmark def set4AddElement(bh: Blackhole): Unit = {

--- a/test/junit/scala/collection/SetMapConsistencyTest.scala
+++ b/test/junit/scala/collection/SetMapConsistencyTest.scala
@@ -251,7 +251,7 @@ class SetMapConsistencyTest {
           }
           case _ => None
         }
-        throw new Exception(s"Disagreement after ${what.result} between ${map1.title} and ${map2.title} because ${map1.keys.map(map2 has _).mkString(",")} ${map2.keys.map(map1 has _).mkString(",")} at step $i:\n$map1\n$map2\n$temp")
+        throw new Exception(s"Disagreement after ${what.result()} between ${map1.title} and ${map2.title} because ${map1.keys.map(map2 has _).mkString(",")} ${map2.keys.map(map1 has _).mkString(",")} at step $i:\n$map1\n$map2\n$temp")
       }
       what ++= " (%d) ".format(i)
       if (rn.nextInt(10)==0) {

--- a/test/junit/scala/collection/immutable/HashSetTest.scala
+++ b/test/junit/scala/collection/immutable/HashSetTest.scala
@@ -4,6 +4,7 @@ import org.junit.Assert.{assertEquals, assertSame}
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import scala.tools.testing.AssertUtil._
 
 @RunWith(classOf[JUnit4])
 class HashSetTest {
@@ -14,5 +15,19 @@ class HashSetTest {
     assertSame(HashSet.empty, HashSet())
     val m = HashSet("a")
     assertSame(m, HashSet.from(m))
+  }
+
+  @Test
+  def earlyReturnWhenRemoveAllIterator(): Unit = {
+    val xs = (1 to 10).to(HashSet)
+    def iter(n: Int) = (1 to n).iterator.concat(new Iterator[Int] {
+      override def hasNext = true
+      override def next() = throw new RuntimeException("This iterator should not be evaluated")
+    })
+
+    assertSame(HashSet.empty, xs.removedAll(iter(10)))
+    assertSame(HashSet.empty, xs.removedAll(iter(100)))
+    assertThrows[RuntimeException](xs.removedAll(iter(9)))
+    assertThrows[RuntimeException](xs.removedAll(iter(1)))
   }
 }

--- a/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
@@ -51,7 +51,7 @@ object ImmutableChampHashSetProperties extends Properties("immutable.ChampHashSe
   }
 
   property("containsAfterInsert") = forAll { (inputValues: HashSet[K]) =>
-    var testSet = HashSet.empty[K] ++ inputValues
+    val testSet = HashSet.empty[K] ++ inputValues
     inputValues.forall(testSet.contains)
   }
 
@@ -290,5 +290,11 @@ object ImmutableChampHashSetProperties extends Properties("immutable.ChampHashSe
   property("(xs - elem) == xs.toList.filterNot(_ == elem).toSet") = forAll { (xs: Set[K], elem: K) =>
     (xs - elem) == xs.toList.filterNot(_ == elem).toSet
   }
-
+  property("(xs + elem) == (xs.toList :+ elem).toSet") = forAll { (xs: Set[K], elem: K) =>
+    (xs + elem) == (xs.toList :+ elem).toSet
+  }
+  property("xs -- range == xs -- range.toSet") = forAll { (xs: Set[Int], rangeMax: Int) =>
+    val range = 1 to (rangeMax % 10000)
+    xs -- range == xs -- range.toSet
+  }
 }


### PR DESCRIPTION
This PR includes:


## `s.c.i.HashMap`

* Optimized implementation filterImpl (and therefor, filter, filterNot)
* Optimized implementation for removeAll (and therefor --)

## `s.c.i.HashSet`

* Optimized implementation filterImpl (and therefor, filter, filterNot)
* Optimized implementation for removeAll (and therefor --)
	* includes extra-fast paths for `s.c.i.Range`, `s.c.Set`
* Optimized implementation for diff (required by removeAll)
* Combined private[this] method `BitmapIndexedSetNode#newNodeFrom` which allows partially shared implementation between `diff` and `filter`

## Notes

* change in semantics:
	* when calling `removeAll(Iterator[a])`, we will stop consuming the iterator as soon as we know that the result will be empty. that is, we call `next()` one-by-one, removing elements each time from the map/set. after each element removal, we check if the resulting structure is empty. if so, we do an early return, immediately returning `HashMap.empty`/`HashSet.empty`

## Ideas for future PR's💡 
  * perhaps a package-private method could be exposed on `scala.collection.mutable.HashSet` (note, **mutable**) to allow to check for `contains(elem: A, hashCode: Int)`. This would allow cooperation when intersecting/diffing immutable and mutable HashSets. 
