### PR TITLE
Decrement depth in subtype check withTypeVars

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -359,7 +359,7 @@ private[internal] trait GlbLubs {
             // In theory this should not be necessary, but higher-order type
             // parameters are not handled correctly.
             val ok = ts forall { t =>
-              isSubType(t, lubRefined, depth) || {
+              isSubType(t, lubRefined, depth.decr) || {
                 if (settings.debug || printLubs) {
                   Console.println(
                     "Malformed lub: " + lubRefined + "\n" +

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -3,7 +3,7 @@ package reflect
 package internal
 package tpe
 
-import scala.collection.{ mutable }
+import scala.collection.mutable
 import util.TriState
 import scala.annotation.tailrec
 import scala.reflect.internal.util.StatisticsStatics

--- a/test/files/pos/t7612.scala
+++ b/test/files/pos/t7612.scala
@@ -1,0 +1,18 @@
+object Test {
+  trait Fili[A]
+  trait Kili[M] {
+    def fili: Fili[M]
+  }
+
+  trait A extends Kili[A] {
+    def fili: Fili[A]
+  }
+
+  trait Ori[M] extends Kili[M] {
+    val ori: Fili[M]
+    def fili: ori.type
+  }
+  trait B extends Ori[B]
+
+  def foo(a: A, b: B) = if (true) a else b
+}


### PR DESCRIPTION
Fixes scala/bug#7612

The LUB becomes `Kili[_ >: A with B <: Kili[_ >: A with B <: Object]]`.
That makes sense to me.