### PR TITLE
Don't reject views with result types which are TypeVars

### DIFF
--- a/test/files/pos/t11174.scala
+++ b/test/files/pos/t11174.scala
@@ -1,0 +1,18 @@
+trait CtorType[P]
+class Props[P] extends CtorType[P] {
+  def foo(props: P): P = ???
+}
+
+object Generic {
+  implicit def toComponentCtor[CT[p] <: CtorType[p]](c: ComponentSimple[CT]): CT[Int] = ???
+
+  trait ComponentSimple[CT[p] <: CtorType[p]]
+}
+
+object Test {
+  import Generic._
+
+  val c: ComponentSimple[Props] = ???
+  toComponentCtor(c).foo(23)
+  c.foo(23)
+}

--- a/test/files/pos/t11174b.scala
+++ b/test/files/pos/t11174b.scala
@@ -10,23 +10,3 @@ object Test {
   val from: From = ???
   from.foo(23)
 }
-
-/*
-class From {
-  type To[T]
-}
-
-class FromSub extends From {
-  class To[T] {
-    def foo(t: T): T = t
-  }
-}
-
-object Test {
-  implicit def conv[T](x: From): x.To[T] = ???
-
-  val from: FromSub = ???
-  conv(from).foo(23)
-  //from.foo(23)
-}
-*/

--- a/test/files/pos/t11174b.scala
+++ b/test/files/pos/t11174b.scala
@@ -1,0 +1,32 @@
+class From {
+  class To[T] {
+    def foo(t: T): T = t
+  }
+}
+
+object Test {
+  implicit def conv[T](x: From): x.To[T] = ???
+
+  val from: From = ???
+  from.foo(23)
+}
+
+/*
+class From {
+  type To[T]
+}
+
+class FromSub extends From {
+  class To[T] {
+    def foo(t: T): T = t
+  }
+}
+
+object Test {
+  implicit def conv[T](x: From): x.To[T] = ???
+
+  val from: FromSub = ???
+  conv(from).foo(23)
+  //from.foo(23)
+}
+*/

--- a/test/files/pos/t11174c.scala
+++ b/test/files/pos/t11174c.scala
@@ -1,0 +1,18 @@
+trait CtorType
+class Props extends CtorType {
+  def foo(props: Int): Int = ???
+}
+
+object Generic {
+  implicit def toComponentCtor[CT <: CtorType](c: ComponentSimple[CT]): CT = ???
+
+  trait ComponentSimple[CT <: CtorType]
+}
+
+object Test {
+  import Generic._
+
+  val c: ComponentSimple[Props] = ???
+  toComponentCtor(c).foo(23)
+  c.foo(23)
+}


### PR DESCRIPTION
On the `matchesPtInst` fast path views are pruned without first being applied. This can result in a false negative in `HasMethodMatching` if the view has a result type which is a not fully instantiated `TypeVar`. The fix is to fall back to the slow path in that case.

Fixes scala/bug#11174.