### PR TITLE
Restore the working directory of partest, junit to the project root

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -601,6 +601,8 @@ lazy val junit = project.in(file("test") / "junit")
   .settings(
     fork in Test := true,
     javaOptions in Test += "-Xss1M",
+    (forkOptions in Test) := (forkOptions in Test).value.withWorkingDirectory((baseDirectory in ThisBuild).value),
+    (forkOptions in Test in testOnly) := (forkOptions in Test in testOnly).value.withWorkingDirectory((baseDirectory in ThisBuild).value),
     libraryDependencies ++= Seq(junitDep, junitInterfaceDep, jolDep),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     unmanagedSourceDirectories in Compile := Nil,
@@ -724,6 +726,7 @@ lazy val test = project
     testFrameworks += new TestFramework("scala.tools.partest.sbt.Framework"),
     testOptions in IntegrationTest += Tests.Argument("-Dpartest.java_opts=-Xmx1024M -Xms64M"),
     testOptions in IntegrationTest += Tests.Argument("-Dpartest.scalac_opts=" + (scalacOptions in Compile).value.mkString(" ")),
+    (forkOptions in IntegrationTest) := (forkOptions in IntegrationTest).value.withWorkingDirectory((baseDirectory in ThisBuild).value),
     testOptions in IntegrationTest += {
       val cp = (dependencyClasspath in Test).value
       val baseDir = (baseDirectory in ThisBuild).value


### PR DESCRIPTION
We lost this in the SBT 1.x upgrade.


This restores the abilty to use paths relative to the checkout base in:

```
sbt> partest test/files/run/t1234.scala

sbt> junit/testOnly scala.SerializationStabilityTest -- -Doverwrite.source=test/junit/scala/SerializationStabilityTest.scala
```