### PR TITLE
Remove partest orphan files

### DIFF
--- a/test/files/instrumented/indy-symbol-literal.check
+++ b/test/files/instrumented/indy-symbol-literal.check
@@ -1,6 +1,0 @@
-indy-symbol-literal.scala:10: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
-      'foo.name
-           ^
-indy-symbol-literal.scala:6: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
-    'warmup
-    ^


### PR DESCRIPTION
There are still extra files after #7255.  

These shell commands help to find them.

```
$ find . -type f -name '*.flags'
         ! -exec sh -c 'test -f ${0%.flags}.scala -o -d ${0%.flags}/' {} \;
```

```
$ find . -type f -name '*.check'
         ! -exec sh -c 'test -f ${0%.check}.scala -o -d ${0%.check}/' {} \;
```

I wonder if they should be used as lint rules for partest suites, or could be added to partest itself.