### PR TITLE
Don't forget to mapOver TypeVar.typeArgs

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3729,14 +3729,18 @@ trait Types
         TypeVar(origin, constr.cloneInternal, typeArgs, params)
       )
     }
-    override def mapOver(map: TypeMap): Type = {
-      if (constr.instValid) map(constr.inst)
-      else map match {
+
+    override def mapOver(map: TypeMap): Type =
+      if (constr.instValid) {
+        // ideally TypeVar.inst should handle this,
+        // but it would have to be disentangled from TypeVar.constr.inst
+        map(appliedType(constr.inst, typeArgs))
+      } else map match {
         case map: VariancedTypeMap =>
-          this.applyArgs(map.mapOverArgs(this.typeArgs, this.params)) //@M !args.isEmpty implies !typeParams.isEmpty
-        case _ => this.applyArgs(this.typeArgs mapConserve map)
+          //@M !args.isEmpty implies !typeParams.isEmpty
+          applyArgs(map.mapOverArgs(typeArgs, params))
+        case _ => applyArgs(typeArgs mapConserve map)
       }
-    }
   }
 
   /** A type carrying some annotations. Created by the typechecker

--- a/test/files/pos/t11169.scala
+++ b/test/files/pos/t11169.scala
@@ -1,0 +1,27 @@
+import scala.language.higherKinds
+
+object Test {
+  trait HKT[F[_]]
+
+  trait A1[S[_]] {      type T } // HKT param
+  trait A2 { type S   ; type T } // non-HKT member
+  trait A3 { type S[_]; type T } // HKT member
+
+  // "Aux"-style aliases for fixing member types: "ST" fixes S and T, "T" fixes just T (where applicable)
+  object A1 { type ST[ S[_], _T] = A1[S] {                    type T = _T }                                  }
+  object A2 { type ST[_S   , _T] = A2    { type S    = _S   ; type T = _T }; type T[_T] = A2 { type T = _T } }
+  object A3 { type ST[_S[_], _T] = A3    { type S[U] = _S[U]; type T = _T }; type T[_T] = A3 { type T = _T } }
+
+  // HKT derivations for aliases above, always with wildcard `T` in rightmost position, for partial unification
+  implicit def a1[S[_]]: HKT[({ type F[x] = A1.ST[S, x] })#F] = ???
+  implicit def a2[S   ]: HKT[({ type F[x] = A2.ST[S, x] })#F] = ???
+  implicit def a3[S[_]]: HKT[({ type F[x] = A3.ST[S, x] })#F] = ???
+  implicit def a2t     : HKT[A2. T      ] = ???
+  implicit def a3t     : HKT[A3. T      ] = ???
+
+  implicitly[HKT[({ type F[x] = A1.ST[List, x] })#F]] // HKT-param
+  implicitly[HKT[({ type F[x] = A2.ST[Char, x] })#F]] // non-HKT member
+  implicitly[HKT[({ type F[x] = A3.ST[List, x] })#F]] // HKT-member
+  implicitly[HKT[A2.T]]
+  implicitly[HKT[A3.T]]
+}


### PR DESCRIPTION
Ideally `TypeVar.typeArgs` should be handled by `TypeVar.inst` as
opposed to `TypeVar.constr.inst` but the two are used interchangeably
throughout the compiler and it seems impossible to disentangle them.

Fixes scala/bug#11169