### PR TITLE
RFC: Split TypeMaps with Variance

### DIFF
--- a/src/compiler/scala/reflect/macros/compiler/Validators.scala
+++ b/src/compiler/scala/reflect/macros/compiler/Validators.scala
@@ -171,7 +171,7 @@ trait Validators {
           def apply(tp: Type): Type = tp match {
             case TypeRef(pre, sym, args) =>
               val pre1  = mapPrefix(pre)
-              val args1 = mapOverArgs(args, sym.typeParams)
+              val args1 = args mapConserve this
               if ((pre eq pre1) && (args eq args1)) tp
               else typeRef(pre1, sym, args1)
             case _ =>

--- a/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
@@ -84,7 +84,7 @@ abstract class Duplicators extends Analyzer {
           )
           if (sym1.exists) {
             debuglog(s"fixing $sym -> $sym1")
-            typeRef(NoPrefix, sym1, mapOverArgs(args, sym1.typeParams))
+            typeRef(NoPrefix, sym1, args mapConserve this)
           }
           else super.mapOver(tpe)
 
@@ -92,7 +92,7 @@ abstract class Duplicators extends Analyzer {
           val newsym = updateSym(sym)
           if (newsym ne sym) {
             debuglog("fixing " + sym + " -> " + newsym)
-            typeRef(mapOver(pre), newsym, mapOverArgs(args, newsym.typeParams))
+            typeRef(mapOver(pre), newsym, args mapConserve this)
           } else
             super.mapOver(tpe)
 

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -843,7 +843,7 @@ trait Infer extends Checkable {
             val e1 = existentialAbstraction(undef1, tpe1)
             val e2 = existentialAbstraction(undef2, tpe2)
 
-            val flip = new TypeMap(trackVariance = true) {
+            val flip = new VariancedTypeMap {
               def apply(tp: Type): Type = tp match {
                 case TypeRef(pre, sym, args) if variance > 0 && sym.typeParams.exists(_.isContravariant) =>
                   mapOver(TypeRef(pre, sym.flipped, args))

--- a/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
@@ -168,7 +168,7 @@ trait PatternTypers {
         case _         => wrapClassTagUnapply(treeTyped, extractor, tpe)
       }
     }
-    private class VariantToSkolemMap extends TypeMap(trackVariance = true) {
+    private class VariantToSkolemMap extends VariancedTypeMap {
       private val skolemBuffer = mutable.ListBuffer[TypeSymbol]()
 
       // !!! FIXME - skipping this when variance.isInvariant allows unsoundness, see scala/bug#5189

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1524,7 +1524,7 @@ trait Types
     override def kind = "TypeBoundsType"
     override def mapOver(map: TypeMap): Type = {
       val lo1 = map match {
-        case VariancedTypeMap(vtm) => vtm.flipped(vtm(lo))
+        case vtm: VariancedTypeMap => vtm.flipped(vtm(lo))
         case _ => map(lo)
       }
       val hi1 = map(hi)
@@ -2341,7 +2341,7 @@ trait Types
     override def mapOver(map: TypeMap): Type = {
       val pre1 = map(pre)
       val args1 =  map match {
-        case _: VariancedTypeMap if args.nonEmpty && !map.asInstanceOf[VariancedTypeMap].variance.isInvariant =>
+        case vtm: VariancedTypeMap if args.nonEmpty && ! vtm.variance.isInvariant =>
           val tparams = sym.typeParams
           if (tparams.isEmpty)
             args mapConserve map
@@ -2870,7 +2870,7 @@ trait Types
     override def kind = "MethodType"
     override def mapOver(map: TypeMap): Type = {
       val params1 = map match {
-        case VariancedTypeMap(vtm) => vtm.flipped(vtm.mapOver(params))
+        case vtm: VariancedTypeMap => vtm.flipped(vtm.mapOver(params))
         case _ => map.mapOver(params)
       }
       val result1 = map(resultType)
@@ -2975,7 +2975,7 @@ trait Types
     override def kind = "PolyType"
     override def mapOver(map: TypeMap): Type = {
       val tparams1 = map match {
-        case VariancedTypeMap(vtm) => vtm.flipped(vtm.mapOver(typeParams))
+        case vtm: VariancedTypeMap => vtm.flipped(vtm.mapOver(typeParams))
         case _ => map.mapOver(typeParams)
       }
       val result1 = map(resultType)

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -56,7 +56,7 @@ trait Variances {
       && !escapedLocals(sym)
     )
 
-    private object ValidateVarianceMap extends TypeMap(trackVariance = true) {
+    private object ValidateVarianceMap extends VariancedTypeMap {
       private[this] var base: Symbol = _
 
       /** The variance of a symbol occurrence of `tvar` seen at the level of the definition of `base`.

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -183,7 +183,6 @@ private[internal] trait TypeMaps {
           tree1.shallowDuplicate.setType(tpe1)
       }
     }
-
   }
 
   abstract class VariancedTypeMap extends TypeMap {
@@ -217,11 +216,6 @@ private[internal] trait TypeMaps {
         this(info)
     }
 
-  }
-
-  object VariancedTypeMap {
-    def unapply(tm: TypeMap): Option[VariancedTypeMap] =
-      if (tm.isInstanceOf[VariancedTypeMap]) Some(tm.asInstanceOf[VariancedTypeMap]) else None
   }
 
   abstract class TypeTraverser extends TypeMap {

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -183,6 +183,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.dropSingletonType
     this.abstractTypesToBounds
     this.dropIllegalStarTypes
+    this.VariancedTypeMap
     this.wildcardExtrapolation
     this.IsDependentCollector
     this.ApproximateDependentMap

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -183,7 +183,6 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.dropSingletonType
     this.abstractTypesToBounds
     this.dropIllegalStarTypes
-    this.VariancedTypeMap
     this.wildcardExtrapolation
     this.IsDependentCollector
     this.ApproximateDependentMap


### PR DESCRIPTION
This PR introduces some "refactors" in the `TypeMap` hierarchy. We noted that the "trackVariance" attribute of a type map was never changed, which suggests it is a static element, more represented through types, than through a field. In particular, the changes are: 

- We remove from the `TypeMap` abstract class the `trackVariance` field, and all the methods that were specifically tied to that. 
- We introduce an abstract `VariancedTypeMap` class, for those `TypeMap`s that need to track variance. We add here the fields and methods we cut from `TypeMap`. 
- We add a companion object with an `unapply` method. We use it at several places in which, before, there was by default a called to the `flipped`. 

I have tested this changes with `partest`. Almost all of the tests pass ok, except for two. 
- One is related to the Java Universe of  `scala.reflect`, which now includes `VariancedTypeMap`. 
- The other one is [`test/files/neg/t0764.scala`](https://github.com/scala/scala/blob/2.13.x/test/files/neg/t0764.scala), for which the expectation is that it would not compile, but which it does in this branch. Interestingly, the comments by @adriaanm suggests that it should actually be a positive example, and that this branch may actually be fixing an old bug. The compilation for the larger file, `t0764b.scala`  does not change.

@adriaanm Could you please weigh in, as to whether being able to compile that file is either break or a bug-fix?