### PR TITLE
Split TypeMaps with Variance

### DIFF
--- a/src/compiler/scala/reflect/macros/compiler/Validators.scala
+++ b/src/compiler/scala/reflect/macros/compiler/Validators.scala
@@ -183,7 +183,7 @@ trait Validators {
           def apply(tp: Type): Type = tp match {
             case TypeRef(pre, sym, args) =>
               val pre1  = mapPrefix(pre)
-              val args1 = mapOverArgs(args, sym.typeParams)
+              val args1 = args mapConserve this
               if ((pre eq pre1) && (args eq args1)) tp
               else typeRef(pre1, sym, args1)
             case _ =>

--- a/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
@@ -91,7 +91,7 @@ abstract class Duplicators extends Analyzer {
           )
           if (sym1.exists) {
             debuglog(s"fixing $sym -> $sym1")
-            typeRef(NoPrefix, sym1, mapOverArgs(args, sym1.typeParams))
+            typeRef(NoPrefix, sym1, args mapConserve this)
           }
           else super.mapOver(tpe)
 
@@ -99,7 +99,7 @@ abstract class Duplicators extends Analyzer {
           val newsym = updateSym(sym)
           if (newsym ne sym) {
             debuglog("fixing " + sym + " -> " + newsym)
-            typeRef(mapOver(pre), newsym, mapOverArgs(args, newsym.typeParams))
+            typeRef(mapOver(pre), newsym, args mapConserve this)
           } else
             super.mapOver(tpe)
 

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -850,7 +850,7 @@ trait Infer extends Checkable {
             val e1 = existentialAbstraction(undef1, tpe1)
             val e2 = existentialAbstraction(undef2, tpe2)
 
-            val flip = new TypeMap(trackVariance = true) {
+            val flip = new VariancedTypeMap {
               def apply(tp: Type): Type = tp match {
                 case TypeRef(pre, sym, args) if variance > 0 && sym.typeParams.exists(_.isContravariant) =>
                   mapOver(TypeRef(pre, sym.flipped, args))

--- a/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
@@ -175,7 +175,7 @@ trait PatternTypers {
         case _         => wrapClassTagUnapply(treeTyped, extractor, tpe)
       }
     }
-    private class VariantToSkolemMap extends TypeMap(trackVariance = true) {
+    private class VariantToSkolemMap extends VariancedTypeMap {
       private val skolemBuffer = mutable.ListBuffer[TypeSymbol]()
 
       // !!! FIXME - skipping this when variance.isInvariant allows unsoundness, see scala/bug#5189

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1530,7 +1530,10 @@ trait Types
     }
     override def kind = "TypeBoundsType"
     override def mapOver(map: TypeMap): Type = {
-      val lo1 = map.flipped(map(lo))
+      val lo1 = map match {
+        case vtm: VariancedTypeMap => vtm.flipped(vtm(lo))
+        case _ => map(lo)
+      }
       val hi1 = map(hi)
       if ((lo1 eq lo) && (hi1 eq hi)) this
       else TypeBounds(lo1, hi1)
@@ -2344,17 +2347,16 @@ trait Types
   abstract case class TypeRef(pre: Type, sym: Symbol, args: List[Type]) extends UniqueType with TypeRefApi {
     override def mapOver(map: TypeMap): Type = {
       val pre1 = map(pre)
-      val args1 = (
-        if (map.trackVariance && args.nonEmpty && !map.variance.isInvariant) {
+      val args1 = map match {
+        case map: VariancedTypeMap if args.nonEmpty && ! map.variance.isInvariant =>
           val tparams = sym.typeParams
           if (tparams.isEmpty)
             args mapConserve map
           else
             map.mapOverArgs(args, tparams)
-        } else {
+        case _ =>
           args mapConserve map
-        }
-      )
+      }
       if ((pre1 eq pre) && (args1 eq args)) this
       else copyTypeRef(this, pre1, this.coevolveSym(pre1), args1)
     }
@@ -2874,7 +2876,10 @@ trait Types
 
     override def kind = "MethodType"
     override def mapOver(map: TypeMap): Type = {
-      val params1 = map.flipped(map.mapOver(params))
+      val params1 = map match {
+        case vtm: VariancedTypeMap => vtm.flipped(vtm.mapOver(params))
+        case _ => map.mapOver(params)
+      }
       val result1 = map(resultType)
       if ((params1 eq params) && (result1 eq resultType)) this
       else copyMethodType(this, params1, result1.substSym(params, params1))
@@ -2976,7 +2981,10 @@ trait Types
 
     override def kind = "PolyType"
     override def mapOver(map: TypeMap): Type = {
-      val tparams1 = map.flipped(map.mapOver(typeParams))
+      val tparams1 = map match {
+        case vtm: VariancedTypeMap => vtm.flipped(vtm.mapOver(typeParams))
+        case _ => map.mapOver(typeParams)
+      }
       val result1 = map(resultType)
       if ((tparams1 eq typeParams) && (result1 eq resultType)) this
       else PolyType(tparams1, result1.substSym(typeParams, tparams1))
@@ -3723,7 +3731,11 @@ trait Types
     }
     override def mapOver(map: TypeMap): Type = {
       if (constr.instValid) map(constr.inst)
-      else this.applyArgs(map.mapOverArgs(this.typeArgs, this.params))  //@M !args.isEmpty implies !typeParams.isEmpty
+      else map match {
+        case map: VariancedTypeMap =>
+          this.applyArgs(map.mapOverArgs(this.typeArgs, this.params)) //@M !args.isEmpty implies !typeParams.isEmpty
+        case _ => this.applyArgs(this.typeArgs mapConserve map)
+      }
     }
   }
 

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -63,7 +63,7 @@ trait Variances {
       && !escapedLocals(sym)
     )
 
-    private object ValidateVarianceMap extends TypeMap(trackVariance = true) {
+    private object ValidateVarianceMap extends VariancedTypeMap {
       private[this] var base: Symbol = _
 
       /** The variance of a symbol occurrence of `tvar` seen at the level of the definition of `base`.


### PR DESCRIPTION
Overrides #7309. We split `TypeMap` abstract class into a `VariancedTypeMap`. 

We noted that the `trackVariance` attribute of a type map was never changed, which suggests that it was a static element better expressed through a type than through a boolean field. Thus, we modify the TypeMap class Hierarchy, so that type maps that do need to track variance have their own specific  class `VariancedTypeMap`. We move the variance-handling methods, and branches of methods, there.