### PR TITLE
Move sbt dispensation to reporting

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1463,7 +1463,6 @@ class Global(var currentSettings: Settings, reporter0: LegacyReporter)
       units foreach addUnit
       reporter.reset()
       warnDeprecatedAndConflictingSettings()
-      checkGoldenUnits(units)
       globalPhase = fromPhase
 
       val timePhases = statistics.areStatisticsLocallyEnabled
@@ -1549,16 +1548,6 @@ class Global(var currentSettings: Settings, reporter0: LegacyReporter)
 
       // Clear any sets or maps created via perRunCaches.
       perRunCaches.clearAll()
-    }
-
-    // special dispensations for golden units
-    def checkGoldenUnits(units: List[CompilationUnit]): Unit = {
-      units match {
-        case u :: Nil if u.source.file.path.endsWith("xsbt/Compat.scala") =>
-          val ss = settings
-          ss.language.enable(ss.languageFeatures.postfixOps)
-        case _ =>
-      }
     }
 
     /** Compile list of abstract files. */

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -113,8 +113,12 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
       reportedFeature += featureTrait
 
       val msg = s"$featureDesc $req be enabled\nby making the implicit value $fqname visible.$explain" replace ("#", construct)
-      if (required) reporter.error(pos, msg)
-      else featureWarning(pos, msg)
+      // don't error on postfix in pre-0.13.18 xsbt/Compat.scala
+      def isSbtCompat =
+        (featureName == "postfixOps" && pos.source.path.endsWith("/xsbt/Compat.scala") && Thread.currentThread.getStackTrace.exists(_.getClassName.startsWith("sbt.")))
+      if (required && !isSbtCompat) {
+        reporter.error(pos, msg)
+      } else featureWarning(pos, msg)
     }
 
     /** Has any macro expansion used a fallback during this run? */


### PR DESCRIPTION
Avoid postfixOps feature error when compiling
sbt's Compat.scala file.

Required to support sbt < 0.13.18 with scalac 2.13.x.