### PR TITLE
Add Map#updateWith to modify a map based on current value

### DIFF
--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -105,6 +105,29 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   def updated[V1 >: V](key: K, value: V1): CC[K, V1]
 
   /**
+   * Update a mapping for the specified key and its current optionally-mapped value
+   * (`Some` if there is current mapping, `None` if not).
+   *
+   * If the remapping function returns `Some(v)`, the mapping is updated with the new value `v`.
+   * If the remapping function returns `None`, the mapping is removed (or remains absent if initially absent).
+   * If the function itself throws an exception, the exception is rethrown, and the current mapping is left unchanged.
+   *
+   * @param key the key value
+   * @param remappingFunction a partial function that receives current optionally-mapped value and return a new mapping
+   * @return A new map with the updated mapping with the key
+   * @since 2.13.0
+   */
+  def updatedWith[V1 >: V](key: K)(remappingFunction: Option[V] => Option[V1]): CC[K,V1] = {
+    val previousValue = this.get(key)
+    val nextValue = remappingFunction(previousValue)
+    (previousValue, nextValue) match {
+      case (None, None) => this.asInstanceOf[CC[K,V1]]
+      case (Some(_), None) => this.remove(key).asInstanceOf[CC[K,V1]]
+      case (_, Some(v)) => this.updated(key, v)
+    }
+  }
+
+  /**
     * Alias for `updated`
     *
     * @param kv the key/value pair.

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -106,6 +106,30 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
     */
   def update(key: K, value: V): Unit = { coll += ((key, value)) }
 
+  /**
+   * Update a mapping for the specified key and its current optionally-mapped value
+   * (`Some` if there is current mapping, `None` if not).
+   *
+   * If the remapping function returns `Some(v)`, the mapping is updated with the new value `v`.
+   * If the remapping function returns `None`, the mapping is removed (or remains absent if initially absent).
+   * If the function itself throws an exception, the exception is rethrown, and the current mapping is left unchanged.
+   *
+   * @param key the key value
+   * @param remappingFunction a partial function that receives current optionally-mapped value and return a new mapping
+   * @return the new value associated with the specified key
+   * @since 2.13.0
+   */
+  def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = {
+    val previousValue = this.get(key)
+    val nextValue = remappingFunction(previousValue)
+    (previousValue, nextValue) match {
+      case (None, None) => // do nothing
+      case (Some(_), None) => this.remove(key)
+      case (_, Some(v)) => this.update(key,v)
+    }
+    nextValue
+  }
+
   /** If given key is already in this map, returns associated value.
    *
    *  Otherwise, computes value from given expression `op`, stores with key

--- a/test/junit/scala/collection/concurrent/TrieMapTest.scala
+++ b/test/junit/scala/collection/concurrent/TrieMapTest.scala
@@ -639,4 +639,23 @@ class TrieMapTest {
     check(newTrieMap - null, null, None, "new value", Set("a" -> null, "c" -> "c"))
     check(newTrieMap - null, null, None, null, Set("a" -> null, "c" -> "c"))
   }
+
+  @Test
+  def testUpdateWith(): Unit = {
+    val insertIfAbsent: Option[String] => Option[String] = _.orElse(Some("b"))
+    val hashMap1 = TrieMap(1 -> "a")
+    assertEquals(hashMap1.updateWith(1)(insertIfAbsent), Some("a"))
+    assertEquals(hashMap1, TrieMap(1 -> "a"))
+    val hashMap2 = TrieMap(1 -> "a")
+    assertEquals(hashMap2.updateWith(2)(insertIfAbsent), Some("b"))
+    assertEquals(hashMap2, TrieMap(1 -> "a", 2 -> "b"))
+
+    val noneAnytime: Option[String] => Option[String] = _ => None
+    val hashMap3 = TrieMap(1 -> "a")
+    assertEquals(hashMap3.updateWith(1)(noneAnytime), None)
+    assertEquals(hashMap3, TrieMap())
+    val hashMap4 = TrieMap(1 -> "a")
+    assertEquals(hashMap4.updateWith(2)(noneAnytime), None)
+    assertEquals(hashMap4, TrieMap(1 -> "a"))
+  }
 }

--- a/test/junit/scala/collection/immutable/HashMapTest.scala
+++ b/test/junit/scala/collection/immutable/HashMapTest.scala
@@ -120,5 +120,17 @@ class HashMapTest {
 
     assert(hashMap.transform((_, v) => v) eq hashMap)
   }
+  @Test
+  def testUpdatedWith(): Unit = {
+    val hashMap = HashMap(1 -> "a")
+
+    val insertIfAbesent: Option[String] => Option[String] = _.orElse(Some("b"))
+    assertEquals(hashMap.updatedWith(1)(insertIfAbesent), HashMap(1 -> "a"))
+    assertEquals(hashMap.updatedWith(2)(insertIfAbesent), HashMap(1 -> "a", 2 -> "b"))
+
+    val noneAnytime: Option[String] => Option[String] = _ => None
+    assertEquals(hashMap.updatedWith(1)(noneAnytime), HashMap())
+    assertEquals(hashMap.updatedWith(2)(noneAnytime), HashMap(1 -> "a"))
+  }
 }
 

--- a/test/junit/scala/collection/mutable/HashMapTest.scala
+++ b/test/junit/scala/collection/mutable/HashMapTest.scala
@@ -110,4 +110,22 @@ class HashMapTest {
     assertEquals(m4(2), "3")
     assertEquals(m4(100), "101")
   }
+  @Test
+  def testUpdateWith(): Unit = {
+    val insertIfAbsent: Option[String] => Option[String] = _.orElse(Some("b"))
+    val hashMap1 = mutable.HashMap(1 -> "a")
+    assertEquals(hashMap1.updateWith(1)(insertIfAbsent), Some("a"))
+    assertEquals(hashMap1, mutable.HashMap(1 -> "a"))
+    val hashMap2 = mutable.HashMap(1 -> "a")
+    assertEquals(hashMap2.updateWith(2)(insertIfAbsent), Some("b"))
+    assertEquals(hashMap2, mutable.HashMap(1 -> "a", 2 -> "b"))
+
+    val noneAnytime: Option[String] => Option[String] =  _ => None
+    val hashMap3 = mutable.HashMap(1 -> "a")
+    assertEquals(hashMap3.updateWith(1)(noneAnytime), None)
+    assertEquals(hashMap3, mutable.HashMap())
+    val hashMap4 = mutable.HashMap(1 -> "a")
+    assertEquals(hashMap4.updateWith(2)(noneAnytime), None)
+    assertEquals(hashMap4, mutable.HashMap(1 -> "a"))
+  }
 }


### PR DESCRIPTION
Addresses https://github.com/scala/bug/issues/11185 by adding the following methods that is analogus to [` java.util.Map.compute`](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#compute-K-java.util.function.BiFunction-)

| - | <del>compute</del><br>updateWith | <del>computed</del><br>updatedWith |
|--|--|--|
| Added to | mutable.Map<br>concurrent.Map| immutable.Map|
| Return value | New value `Option[V]` | Updated `Map[K,V]`|