### PR TITLE
Separate TypeFold from TypeMap

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -222,7 +222,34 @@ private[internal] trait TypeMaps {
         withVariance(Invariant)(this(info))
       else
         this(info)
+  }
+
+  abstract class TypeFolder extends (Type => Unit) {
+    /** Map this function over given type */
+    def apply(tp: Type): Unit // = if (tp ne null) tp.foldOver(this)
+
+    /** Map this function over given type */
+    def foldOver(syms: List[Symbol]): Unit = syms.foreach( sym => apply(sym.info) )
+
+    def foldOver(scope: Scope): Unit = {
+      val elems = scope.toList
+      val elems1 = foldOver(elems)
     }
+
+    def foldOverAnnotations(annots: List[AnnotationInfo]): Unit =
+      annots foreach foldOver
+
+    def foldOver(annot: AnnotationInfo): Unit = {
+      val AnnotationInfo(atp, args, assocs) = annot
+      atp.foldOver(this)
+      foldOverAnnotArgs(args)
+    }
+
+    def foldOverAnnotArgs(args: List[Tree]): Unit =
+      args foreach foldOver
+
+    def foldOver(tree: Tree): Unit = apply(tree.tpe)
+  }
 
   abstract class TypeTraverser extends TypeMap {
     def traverse(tp: Type): Unit
@@ -234,11 +261,11 @@ private[internal] trait TypeMaps {
     def clear(): Unit
   }
 
-  abstract class TypeCollector[T](initial: T) extends TypeTraverser {
+  abstract class TypeCollector[T](initial: T) extends TypeFolder {
     var result: T = _
     def collect(tp: Type) = {
       result = initial
-      traverse(tp)
+      apply(tp)
       result
     }
   }
@@ -290,7 +317,7 @@ private[internal] trait TypeMaps {
     private def countOccs(tp: Type) = {
       tp foreach {
         case TypeRef(_, sym, _) =>
-          if (tparams contains sym)
+          if (occurCount contains sym)
             occurCount(sym) += 1
         case _ => ()
       }
@@ -841,10 +868,9 @@ private[internal] trait TypeMaps {
 
   // dependent method types
   object IsDependentCollector extends TypeCollector(false) {
-    def traverse(tp: Type): Unit = {
+    def apply(tp: Type): Unit =
       if (tp.isImmediatelyDependent) result = true
-      else if (!result) tp.dealias.mapOver(this)
-    }
+      else if (!result) tp.dealias.foldOver(this)
   }
 
   object ApproximateDependentMap extends TypeMap {
@@ -994,7 +1020,7 @@ private[internal] trait TypeMaps {
 
     protected def pred(sym: Symbol): Boolean
 
-    def traverse(tp: Type): Unit = {
+    def apply(tp: Type): Unit =
       if (!result) {
         tp match {
           case _: ExistentialType =>
@@ -1003,24 +1029,23 @@ private[internal] trait TypeMaps {
             //
             // We can just map over the components and wait until we see the underlying type before we call
             // normalize.
-            tp.mapOver(this)
+            tp.foldOver(this)
           case TypeRef(_, sym1, _) if pred(sym1) => result = true // catch aliases before normalization
           case _ =>
             tp.normalize match {
               case TypeRef(_, sym1, _) if pred(sym1) => result = true
               case refined: RefinedType =>
-                tp.prefix.mapOver(this) // Assumption is that tp was a TypeRef prior to normalization so we should
+                tp.prefix.foldOver(this) // Assumption is that tp was a TypeRef prior to normalization so we should
                                         // mapOver its prefix
-                refined.mapOver(this)
+                refined.foldOver(this)
               case SingleType(_, sym1) if pred(sym1) => result = true
-              case _ => tp.mapOver(this)
+              case _ => tp.foldOver(this)
             }
         }
       }
-    }
 
     private[this] def inTree(t: Tree): Boolean = {
-      if (pred(t.symbol)) result = true else traverse(t.tpe)
+      if (pred(t.symbol)) result = true else apply(t.tpe)
       result
     }
 
@@ -1032,10 +1057,9 @@ private[internal] trait TypeMaps {
       }
     }
 
-    override def mapOver(arg: Tree) = {
+    override def foldOver(arg: Tree): Unit = {
       if (! result)
         findInTree.collect(arg)
-      arg
     }
   }
 
@@ -1054,9 +1078,9 @@ private[internal] trait TypeMaps {
   class FilterTypeCollector(p: Type => Boolean) extends TypeCollector[List[Type]](Nil) {
     override def collect(tp: Type) = super.collect(tp).reverse
 
-    def traverse(tp: Type): Unit = {
+    override def apply(tp: Type): Unit = {
       if (p(tp)) result ::= tp
-      tp.mapOver(this)
+      tp.foldOver(this)
     }
   }
 
@@ -1064,9 +1088,9 @@ private[internal] trait TypeMaps {
   class CollectTypeCollector[T](pf: PartialFunction[Type, T]) extends TypeCollector[List[T]](Nil) {
     override def collect(tp: Type) = super.collect(tp).reverse
 
-    def traverse(tp: Type): Unit = {
+    override def apply(tp: Type): Unit = {
       if (pf.isDefinedAt(tp)) result ::= pf(tp)
-      tp.mapOver(this)
+      tp.foldOver(this)
     }
   }
 
@@ -1079,17 +1103,17 @@ private[internal] trait TypeMaps {
 
   /** A map to implement the `filter` method. */
   class FindTypeCollector(p: Type => Boolean) extends TypeCollector[Option[Type]](None) {
-    def traverse(tp: Type): Unit =
+    def apply(tp: Type): Unit =
       if (result.isEmpty)
-        if (p(tp)) result = Some(tp) else tp.mapOver(this)
+        if (p(tp)) result = Some(tp) else tp.foldOver(this)
   }
 
   object ErroneousCollector extends TypeCollector(false) {
-    def traverse(tp: Type): Unit = {
+    def apply(tp: Type): Unit =
       if (!result) {
-        if (tp.isError) result = true else tp.mapOver(this)
+        result = tp.isError
+        if (!result) tp.foldOver(this)
       }
-    }
   }
 
   object adaptToNewRunMap extends TypeMap {

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -256,11 +256,6 @@ private[internal] trait TypeMaps {
     def apply(tp: Type): Type = { traverse(tp); tp }
   }
 
-  abstract class TypeTraverserWithResult[T] extends TypeTraverser {
-    def result: T
-    def clear(): Unit
-  }
-
   abstract class TypeCollector[T](initial: T) extends TypeFolder {
     var result: T = _
     def collect(tp: Type) = {


### PR DESCRIPTION
Refactoring: separate type-transforming `TypeMap` from type-querying `TypeFold`.

The typer phase performs operations on type expression trees following a GOF Visitor-like pattern, with a family of visitor objects (called collectors or traversals), each specialised to a particular query or transformation, are passed through the nodes of the Type tree. Currently, all those visitors are  based on the `TypeMap` ADT, which is a subtype of `Type => Type`, i.e., a transformation. 

However, many visitors do not transform the type, but merely query it, i.e, extract information from the  type without modifying it. These include the `Contains-`, `FindType-`, `FilterType-`, `Erroneous-`, `NeedsSig-`, and `IsDependent-` Collectors, amongst others. However, they are all represented and handled as TypeMaps, which adds to confusion and may create unneeded objects.

We add a separate type for these queries, called `TypeFold`, to represent operations that traverse the tree but do not modify it. To do this, we need to incorporate into the `Type` trait a method
`foldOver`, which takes a `TypeFold` and passes it through, similar to the `mapOver` for TypeMap.