### PR TITLE
Performance tweak: short-cut TypeMap traversals for Contains

### DIFF
--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1767,8 +1767,7 @@ trait Trees extends api.Trees {
     var result: Option[Tree] = None
     override def traverse(t: Tree): Unit = {
       if (result.isEmpty) {
-        if (p(t)) result = Some(t)
-        t.traverse(this)
+        if (p(t)) result = Some(t) else t.traverse(this)
       }
     }
   }


### PR DESCRIPTION
The `contains` and `find` operations, only need to find the first element that is equal / satisfies the property, and end immediately. They do not modify the type at all, so no full visit is needed. Therefore: 

- We modify the implementations of these methods, to avoid traversals where possible.
- We modify the `FindTreeTraverser` to incorporate the same kind of short-cut.
- We modify our `ContainsTypeTraverser` to use a `FindTreeTraverser`, instead of calling `Tree.foreach` (which created one traverser every time).
