### PR TITLE
Add ++: overload that return Map

### DIFF
--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -309,6 +309,10 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
   def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] =
     mapFactory.from(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
 
+  @deprecated("Use xs ++ ys instead of ys ++: xs for xs of type Iterable", "2.13.0")
+  def ++: [V1 >: V](prefix: IterableOnce[(K,V1)]): CC[K,V1] =
+    mapFactory.from(new View.Concat(this.toIterable, prefix.iterator.to(Iterable)))
+
   @deprecated("Consider requiring an immutable Map.", "2.13.0")
   @`inline` def -- (keys: IterableOnce[K]): C = {
     lazy val keysSet = keys.toSet

--- a/test/junit/scala/collection/MapTest.scala
+++ b/test/junit/scala/collection/MapTest.scala
@@ -37,4 +37,13 @@ class MapTest {
     assert(Map(1 -> 1, 2 -> 2).mkString("foo [", ", ", "] bar").toString ==
       "foo [1 -> 1, 2 -> 2] bar")
   }
+
+  @Test def t11188(): Unit = {
+    import scala.collection.immutable.ListMap
+
+    val m = ListMap(1 -> "one")
+    val mm = Map(2 -> "two") ++: m
+    assert(mm.isInstanceOf[ListMap[Int,String]])
+    assertEquals(mm.mkString("[", ", ", "]"), "[1 -> one, 2 -> two]")
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11188

After this PR,
```
Welcome to Scala 2.13.0-20181005-084508-ba97010 (OpenJDK 64-Bit Server VM, Java 11).
Type in expressions for evaluation. Or try :help.

scala> val m = Map(3 -> "wishes")
m: scala.collection.immutable.Map[Int,String] = Map(3 -> wishes)

scala> m ++: m
         ^
       warning: method ++: in trait MapOps is deprecated (since 2.13.0): Use xs ++ ys instead of ys ++: xs for xs of type Iterable
res0: scala.collection.immutable.Map[Int,String] = Map(3 -> wishes)
```
I tried to override the deprecated `Iterable#++:`, but can not figure out what is the appropriate return type.`
```scala
trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
  extends IterableOps[(K, V), Iterable, C]
    with PartialFunction[K, V] {
    ...
    override def ++:[B >: (K,V)](that: IterableOnce[B]): HERE = ...
                                                         ^^^^
```
If someone give me a guidance, I will update.