### PR TITLE
Include pipe operator '|>' in `ChainingOps`

### DIFF
--- a/src/library/scala/util/ChainingOps.scala
+++ b/src/library/scala/util/ChainingOps.scala
@@ -34,7 +34,7 @@ final class ChainingOps[A](private val self: A) extends AnyVal {
    *  @tparam U     the result type of the function `f`.
    *  @return       the original value `self`.
    */
-  @inline def tap[U](f: A => U): A = {
+  def tap[U](f: A => U): A = {
     f(self)
     self
   }
@@ -58,7 +58,7 @@ final class ChainingOps[A](private val self: A) extends AnyVal {
    *  @tparam B     the result type of the function `f`.
    *  @return       the result of applying `f` to the value.
    */
-  @inline def pipe[B](f: A => B): B = f(self)
+  def pipe[B](f: A => B): B = f(self)
 
 
   /** Applies function `f` to the value.
@@ -82,5 +82,5 @@ final class ChainingOps[A](private val self: A) extends AnyVal {
    *  @tparam B     the result type of the function `f`.
    *  @return       the result of applying `f` to the value.
    */
-  @inline def |>[B](f: A => B): B = pipe(f)
+  def |>[B](f: A => B): B = pipe(f)
 }

--- a/src/library/scala/util/ChainingOps.scala
+++ b/src/library/scala/util/ChainingOps.scala
@@ -19,7 +19,7 @@ trait ChainingSyntax {
 
 /** Adds chaining methods `tap`, `pipe` (aliased as `|>`) to every type.
  *
- * Note: these methods may have a small amount of overhead compared their expanded forms.
+ * Note: these methods may have a small amount of overhead compared to their expanded forms.
  */
 final class ChainingOps[A](private val self: A) extends AnyVal {
   /** Applies `f` to the value for its side effects, and returns the original value.

--- a/test/junit/scala/util/ChainingOpsTest.scala
+++ b/test/junit/scala/util/ChainingOpsTest.scala
@@ -23,12 +23,10 @@ class ChainingOpsTest extends RunTesting {
 
   @Test
   def testAnyPipe: Unit = {
-    val times6 = (_: Int) * 6
-    val result = (1 - 2 - 3)
-      .pipe(times6)
-      .pipe(scala.math.abs)
+    val plus3 = (_: Int) + 3
+    val result = (1 - 2) |> plus3 |> scala.math.abs
 
-    assertEquals(24, result)
+    assertEquals(2, result)
   }
 
   @Test(expected = classOf[ToolBoxError]) def testNoSelf: Unit =


### PR DESCRIPTION
This is in follow up to the excellent PR by @eed3si9n at https://github.com/scala/scala/pull/7007.

---

The operator is common throughout many programming languages and is a familiar syntax to many, especially those coming from Bash and F#.

I modified the test examples, so that the order of function application is completely unambiguous. *6 and math.abs in this particular case make it which way round the functions are applied, so I replaced it with a simplified test case that makes it clearer.

This is *the one* symbol that is good to have as a symbol. It is very special.

Inspired by @eed3si9n's comment here: https://github.com/scala/scala/pull/7007/files#r222332538

**Multi-line**:
What I especially enjoyed in F# days, and also love with Bash, is being able to multi-line it:
```
input
  |> foo
  |> bar
  |> baz
```
This would sadly yield a compile error but I'm sure such syntax could be added eventually.