### PR TITLE
Avoid invalid range positions for XML sequences with CRLF line endings

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
@@ -66,7 +66,7 @@ trait MarkupParsers {
 
     import parser.{ symbXMLBuilder => handle, o2p, r2p }
 
-    def curOffset : Int = input.charOffset - 1
+    def curOffset : Int = input.curOffset
     var tmppos : Position = NoPosition
     def ch = input.ch
     /** this method assign the next character to ch and advances in input */

--- a/src/compiler/scala/tools/nsc/util/CharArrayReader.scala
+++ b/src/compiler/scala/tools/nsc/util/CharArrayReader.scala
@@ -7,6 +7,7 @@ package scala.tools.nsc
 package util
 
 import scala.reflect.internal.Chars._
+import scala.tools.nsc.ast.parser.Scanners
 
 trait CharArrayReaderData {
   /** the last read character */
@@ -14,6 +15,12 @@ trait CharArrayReaderData {
 
   /** The offset one past the last read character */
   var charOffset: Int = 0
+
+  /** the offset of the character following the token preceding this one */
+  final def curOffset: Int = this match {
+    case td: Scanners#TokenData => td.lastOffset
+    case _ => charOffset - 1
+  }
 
   /** The start offset of the current line */
   var lineStartOffset: Int = 0

--- a/test/junit/scala/tools/nsc/parser/ParserTest.scala
+++ b/test/junit/scala/tools/nsc/parser/ParserTest.scala
@@ -1,0 +1,32 @@
+package scala.tools.nsc.parser
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.BytecodeTesting
+
+@RunWith(classOf[JUnit4])
+class ParserTest extends BytecodeTesting{
+  override def compilerArgs: String = "-Ystop-after:parser -Yvalidate-pos:parser -Yrangepos"
+  @Test
+  def crlfRangePositionXml_t10321(): Unit = {
+    val code =
+      """
+        |object Test {
+        |  Nil.map { _ =>
+        |    <X />
+        |    <Y />
+        |  }
+        |}
+      """.stripMargin
+    val crlfCode = code.replaceAllLiterally("\n", "\r\n")
+    val lfCode = code
+    assert(crlfCode != lfCode)
+    import compiler._, global._
+    val run = new Run
+    run.compileSources(newSourceFile(lfCode) :: Nil)
+    assert(!reporter.hasErrors)
+    run.compileSources(newSourceFile(crlfCode) :: Nil)
+  }
+}


### PR DESCRIPTION
Fixes scala/bug#10321