### PR TITLE
Deprecate -Xfuture

### DIFF
--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -82,7 +82,7 @@ object ScalaOptionParser {
   }
 
   // TODO retrieve this data programmatically, ala https://github.com/scala/scala-tool-support/blob/master/bash-completion/src/main/scala/BashCompletion.scala
-  private def booleanSettingNames = List("-X", "-Xcheckinit", "-Xdev", "-Xdisable-assertions", "-Xexperimental", "-Xfatal-warnings", "-Xfuture", "-Xlog-free-terms", "-Xlog-free-types", "-Xlog-implicit-conversions", "-Xlog-implicits", "-Xlog-reflective-calls",
+  private def booleanSettingNames = List("-X", "-Xcheckinit", "-Xdev", "-Xdisable-assertions", "-Xexperimental", "-Xfatal-warnings", "-Xlog-free-terms", "-Xlog-free-types", "-Xlog-implicit-conversions", "-Xlog-implicits", "-Xlog-reflective-calls",
     "-Xno-forwarders", "-Xno-patmat-analysis", "-Xno-uescape", "-Xnojline", "-Xprint-pos", "-Xprint-types", "-Xprompt", "-Xresident", "-Xshow-phases", "-Xverify", "-Y",
     "-Ybreak-cycles", "-Ydebug", "-Ycompact-trees", "-YdisableFlatCpCaching", "-Ydoc-debug",
     "-Yide-debug",

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -39,9 +39,6 @@ trait ScalaSettings extends AbsScalaSettings
    */
   protected def defaultClasspath = Option(System.getenv("CLASSPATH")).getOrElse(".")
 
-  /** Enabled under -Xfuture. */
-  protected def futureSettings = List[BooleanSetting]()
-
   /** If any of these settings is enabled, the compiler should print a message and exit.  */
   def infoSettings = List[Setting](version, help, Xhelp, Yhelp, showPlugins, showPhases, genPhaseGraph, printArgs)
 
@@ -461,7 +458,7 @@ trait ScalaSettings extends AbsScalaSettings
 
   /** Groups of Settings.
    */
-  val future        = BooleanSetting("-Xfuture", "Turn on future language features.") enablingIfNotSetByUser futureSettings
+  val future        = BooleanSetting("-Xfuture", "Deprecated. The future is now.").withDeprecationMessage("Use -Xsource instead.")
   val optimise      = BooleanSetting("-optimise", "Compiler flag for the optimizer in Scala 2.11")
     .withAbbreviation("-optimize")
     .withDeprecationMessage("In 2.12, -optimise enables -opt:l:inline -opt-inline-from:**. Check -opt:help for using the Scala 2.12 optimizer.")

--- a/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
@@ -74,21 +74,21 @@ trait Adaptations {
       }
 
       if (args.isEmpty) {
-        if (settings.future)
+        if (settings.isScala300) {
           context.error(t.pos, adaptWarningMessage("Adaptation of argument list by inserting () has been removed.", showAdaptation = false))
-        else {
+          false // drop adaptation
+        } else {
           val msg = "Adaptation of argument list by inserting () is deprecated: " + (
           if (isLeakyTarget) "leaky (Object-receiving) target makes this especially dangerous."
           else "this is unlikely to be what you want.")
           context.deprecationWarning(t.pos, t.symbol, adaptWarningMessage(msg), "2.11.0")
+          true // keep adaptation
         }
-      } else if (settings.warnAdaptedArgs)
-        context.warning(t.pos, adaptWarningMessage(
-          s"Adapting argument list by creating a ${args.size}-tuple: this may not be what you want.")
-        )
-
-      // return `true` if the adaptation should be kept
-      !(args.isEmpty && settings.future)
+      } else {
+        if (settings.warnAdaptedArgs)
+          context.warning(t.pos, adaptWarningMessage(s"Adapting argument list by creating a ${args.size}-tuple: this may not be what you want."))
+        true // keep adaptation
+      }
     }
   }
 }

--- a/src/manual/scala/man1/scalac.scala
+++ b/src/manual/scala/man1/scalac.scala
@@ -206,9 +206,6 @@ object scalac extends Command {
           CmdOption("Xfull-lubs"),
           "Retain pre 2.10 behavior of less aggressive truncation of least upper bounds."),
         Definition(
-          CmdOption("Xfuture"),
-          "Turn on future language features."),
-        Definition(
           CmdOption("Xgenerate-phase-graph", Argument("file")),
           "Generate the phase graphs (outputs .dot files) to fileX.dot."),
         Definition(

--- a/test/files/neg/t7294.scala
+++ b/test/files/neg/t7294.scala
@@ -1,5 +1,5 @@
 object Test {
-  // Treat TupleN as final under -Xfuture for the for the purposes
-  // of the "fruitless type test" warning.
+  // TupleN is final now, so we get a
+  // "fruitless type test" warning.
   (1, 2) match { case Seq() => 0; case _ => 1 }
 }

--- a/test/files/neg/t8035-removed.scala
+++ b/test/files/neg/t8035-removed.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfuture
+// scalac: -Xsource:3.0
 //
 object Foo {
   List(1,2,3).toSet()

--- a/test/files/run/t1503.scala
+++ b/test/files/run/t1503.scala
@@ -5,7 +5,7 @@ object Whatever {
 object Test extends App {
   // this should make it abundantly clear Any is the best return type we can guarantee
   def matchWhatever(x: Any): Any = x match { case n @ Whatever => n }
-  // until 2.13, when left to its own devices, and not under -Xfuture, the return type used to be Whatever.type
+  // until 2.13 the return type used to be Whatever.type
   // now it is Any
   def matchWhateverCCE(x: Any) = x match { case n @ Whatever => n }
 

--- a/test/junit/scala/util/TryTest.scala
+++ b/test/junit/scala/util/TryTest.scala
@@ -5,7 +5,7 @@ import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert._
 
-/* Test Try's withFilter method, which was added along with the -Xfuture fix for scala/bug#6455  */
+/* Test Try's withFilter method, which was added along with the fix for scala/bug#6455  */
 @RunWith(classOf[JUnit4])
 class TryTest {
   @Test


### PR DESCRIPTION
Deprecates but doesn't remove the command-line option.

Close https://github.com/scala/scala-dev/issues/471
Fix https://github.com/scala/bug/issues/8361