### PR TITLE
Make xml pos consistent with scanner after resume

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
@@ -69,12 +69,18 @@ trait MarkupParsers {
       else reportSyntaxError(msg)
 
     var input : CharArrayReader = _
+
     def lookahead(): BufferedIterator[Char] =
       (input.buf drop input.charOffset).iterator.buffered
 
     import parser.{ symbXMLBuilder => handle, o2p, r2p }
 
-    def curOffset : Int = input.charOffset - 1
+    // consistent with scanner.nextToken in CRNL handling,
+    // but curOffset does not report correct position for last token (compare lastOffset)
+    def curOffset: Int = {
+      val res = input.charOffset - 1
+      if (res > 0 && input.buf(res) == '\n' && input.buf(res-1) == '\r') res - 1 else res
+    }
     var tmppos : Position = NoPosition
     def ch = input.ch
     /** this method assign the next character to ch and advances in input */
@@ -358,12 +364,13 @@ trait MarkupParsers {
 
     /** Use a lookahead parser to run speculative body, and return the first char afterward. */
     private def charComingAfter(body: => Unit): Char = {
+      val saved = input
       try {
         input = input.lookaheadReader
         body
         ch
       }
-      finally input = parser.in
+      finally input = saved
     }
 
     /** xLiteral = element { element }
@@ -376,7 +383,6 @@ trait MarkupParsers {
 
         val ts = new ArrayBuffer[Tree]
         val start = curOffset
-        tmppos = o2p(curOffset)    // Iuli: added this line, as it seems content_LT uses tmppos when creating trees
         content_LT(ts)
 
         // parse more XML?

--- a/test/junit/scala/tools/nsc/parser/ParserTest.scala
+++ b/test/junit/scala/tools/nsc/parser/ParserTest.scala
@@ -1,0 +1,32 @@
+package scala.tools.nsc.parser
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.BytecodeTesting
+
+@RunWith(classOf[JUnit4])
+class ParserTest extends BytecodeTesting{
+  override def compilerArgs: String = "-Ystop-after:parser -Yvalidate-pos:parser -Yrangepos"
+  @Test
+  def crlfRangePositionXml_t10321(): Unit = {
+    val code =
+      """
+        |object Test {
+        |  Nil.map { _ =>
+        |    <X />
+        |    <Y />
+        |  }
+        |}
+      """.stripMargin
+    val crlfCode = code.linesIterator.map(_ + "\r\n").mkString
+    val lfCode = code.linesIterator.map(_ + "\n").mkString
+    assert(crlfCode != lfCode)
+    import compiler._, global._
+    val run = new Run
+    run.compileSources(newSourceFile(lfCode) :: Nil)
+    assert(!reporter.hasErrors)
+    run.compileSources(newSourceFile(crlfCode) :: Nil)
+  }
+}


### PR DESCRIPTION
XML parser uses current offset to compute end of
token offset, which is wrong. This commit makes
sure at least to back up to the CR of a line
ending so that the position is contained by the
position used by scanner after scanner.resume.
nextToken adjusts the position of the line ending.

Fixes scala/bug#10321