### PR TITLE
Infer function parameter types from partially eta-expanded methods

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -440,11 +440,6 @@ trait ContextErrors {
         setError(fun)
       }
 
-      def WrongNumberOfParametersError(tree: Tree, argpts: List[Type]) = {
-        issueNormalTypeError(tree, "wrong number of parameters; expected = " + argpts.length)
-        setError(tree)
-      }
-
       def MissingParameterTypeError(fun: Tree, vparam: ValDef, pt: Type, withTupleAddendum: Boolean) = {
         def issue(what: String) = {
           val addendum: String = fun match {

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2864,6 +2864,45 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       case _ => false
     }
 
+    /**
+      * Deconstruct an expected function-ish type `pt` into `numVparams` argument prototypes and a result prototype.
+      *
+      * If the expected type `pt` does not denote a function-ish type with arity `numVparams`,
+      * still return the expected number of ErrorType/NoType argument protos, and WildcardType for the result.
+      *
+      * @param pt
+      * @param numVparams
+      * @return (argProtos, resProto) where argProtos.lengthCompare(numVparams) == 0
+      */
+    private def argsResProtosFromFun(pt: Type, numVparams: Int): (List[Type], Type) =
+      pt match {
+        case pt: OverloadedArgFunProto if pt.hofParamTypes.lengthCompare(numVparams) == 0 => (pt.hofParamTypes, WildcardType)
+        case _ =>
+          val FunctionSymbol = FunctionClass(numVparams)
+
+          // In case of any non-trivial type slack between `pt` and the built-in function types, we go the SAM route,
+          // as a subclass could have (crazily) implemented the apply method and introduced another abstract method
+          // to serve as the vehicle.
+          val ptNorm = pt.typeSymbol match {
+            case NoSymbol                              => NoType
+            case FunctionSymbol | PartialFunctionClass => pt
+            case _                                     =>
+              val sam = samOf(pt)
+              if (sam.exists && sam.info.params.lengthCompare(numVparams) == 0)
+                wildcardExtrapolation(methodToExpressionTp(pt memberInfo sam))
+              else pt // allow type slack (pos/6221)
+          }
+
+          ptNorm baseType FunctionSymbol match {
+            case TypeRef(_, _, args :+ res) => (args, res) // if it's a TypeRef, we know its symbol will be FunctionSymbol
+            case _                          => {
+              val dummyPt = if (pt == ErrorType) ErrorType else NoType
+              (List.fill(numVparams)(dummyPt), WildcardType) // dummyPt is in CBN position
+            }
+          }
+      }
+
+
     /** Type check a function literal.
      *
      * Based on the expected type pt, potentially synthesize an instance of
@@ -2873,78 +2912,56 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     private def typedFunction(fun: Function, mode: Mode, pt: Type): Tree = {
       val vparams = fun.vparams
       val numVparams = vparams.length
-      val FunctionSymbol =
-        if (numVparams > definitions.MaxFunctionArity) NoSymbol
-        else FunctionClass(numVparams)
-
-      // The Single Abstract Member of pt, unless pt is the built-in function type of the expected arity.
-      val sam =
-        pt.typeSymbol match {
-          case NoSymbol | FunctionSymbol | PartialFunctionClass => NoSymbol
-          case _                                                => samOf(pt)
-        }
-
-      val ptNorm = pt match {
-        case pt: ProtoType                                     => pt.asFunctionType
-        case _ if samMatchesFunctionBasedOnArity(sam, vparams) => samToFunctionType(pt, sam)
-        case _                                                 => pt
-      }
-
-      val (argProtos, resProto) =
-        ptNorm baseType FunctionSymbol match {
-          case TypeRef(_, FunctionSymbol, args :+ res) => (args, res)
-          case _                                       =>
-            val dummyPt = if (pt == ErrorType) ErrorType else NoType
-            (List.fill(numVparams)(dummyPt), WildcardType) // dummyPt is in CBN position
-        }
-
-      // After typer, no need for further checks, parameter type inference or PartialFunction synthesis.
-      if (isPastTyper) doTypedFunction(fun, resProto)
-      else if (!FunctionSymbol.exists) MaxFunctionArityError(fun, s", but ${numVparams} given")
-      else if (argProtos.lengthCompare(numVparams) != 0) WrongNumberOfParametersError(fun, argProtos)
+      if (numVparams > definitions.MaxFunctionArity) MaxFunctionArityError(fun, s", but ${numVparams} given")
       else {
-        val paramsMissingType = mutable.ArrayBuffer.empty[ValDef] //.sizeHint(numVparams) probably useless, since initial size is 16 and max fun arity is 22
+        val (argProtos, resProto) = argsResProtosFromFun(pt, numVparams)
 
-        // first, try to define param types from expected function's arg types if needed
-        foreach2(vparams, argProtos) { (vparam, argpt) =>
-          // TODO: do we need to exclude vparam.symbol.isError? (I don't think so,
-          // because I don't see how we could recurse after the `setError(vparam)` call below
-          if (vparam.tpt.isEmpty) {
-            if (isFullyDefined(argpt)) vparam.tpt setType argpt
-            else paramsMissingType += vparam
+        // After typer, no need for further checks, parameter type inference or PartialFunction synthesis.
+        if (isPastTyper) doTypedFunction(fun, resProto)
+        else {
+          val paramsMissingType = mutable.ArrayBuffer.empty[ValDef] //.sizeHint(numVparams) probably useless, since initial size is 16 and max fun arity is 22
 
-            if (!vparam.tpt.pos.isDefined) vparam.tpt setPos vparam.pos.focus
-          }
-        }
+          // first, try to define param types from expected function's arg types if needed
+          foreach2(vparams, argProtos) { (vparam, argpt) =>
+            // TODO: do we need to exclude vparam.symbol.isError? (I don't think so,
+            // because I don't see how we could recurse after the `setError(vparam)` call below
+            if (vparam.tpt.isEmpty) {
+              if (isFullyDefined(argpt)) vparam.tpt setType argpt
+              else paramsMissingType += vparam
 
-        if (paramsMissingType.nonEmpty && pt != ErrorType) {
-          // If we can resolve the missing parameter type by undoing eta-expansion and recursing, do that -- otherwise, report error and bail
-          typedFunctionUndoingEtaExpansion(fun, mode, pt, argProtos, resProto) orElse {
-            // we ran out of things to try, missing parameter types are an irrevocable error
-            var issuedMissingParameterTypeError = false
-            paramsMissingType.foreach { vparam =>
-              setError(vparam) //  see neg/t8675b.scala (we used to set vparam.tpt to ErrorType, but that isn't as effective)
-              MissingParameterTypeError(fun, vparam, pt, withTupleAddendum = !issuedMissingParameterTypeError)
-              issuedMissingParameterTypeError = true
+              if (!vparam.tpt.pos.isDefined) vparam.tpt setPos vparam.pos.focus
             }
-
-            setError(fun)
           }
-        } else {
-          fun.body match {
-            // translate `x => x match { <cases> }` : PartialFunction to
-            // `new PartialFunction { def applyOrElse(x, default) = x match { <cases> } def isDefinedAt(x) = ... }`
-            case Match(sel, cases) if (sel ne EmptyTree) && (pt.typeSymbol == PartialFunctionClass) =>
-              // go to outer context -- must discard the context that was created for the Function since we're discarding the function
-              // thus, its symbol, which serves as the current context.owner, is not the right owner
-              // you won't know you're using the wrong owner until lambda lift crashes (unless you know better than to use the wrong owner)
-              val outerTyper = newTyper(context.outer)
-              val p = vparams.head
-              if (p.tpt.tpe == null) p.tpt setType outerTyper.typedType(p.tpt).tpe
 
-              outerTyper.synthesizePartialFunction(p.name, p.pos, paramSynthetic = false, fun.body, mode, pt)
+          if (paramsMissingType.nonEmpty && pt != ErrorType) {
+            // If we can resolve the missing parameter type by undoing eta-expansion and recursing, do that -- otherwise, report error and bail
+            typedFunctionUndoingEtaExpansion(fun, mode, pt, argProtos, resProto) orElse {
+              // we ran out of things to try, missing parameter types are an irrevocable error
+              var issuedMissingParameterTypeError = false
+              paramsMissingType.foreach { vparam =>
+                setError(vparam) //  see neg/t8675b.scala (we used to set vparam.tpt to ErrorType, but that isn't as effective)
+                MissingParameterTypeError(fun, vparam, pt, withTupleAddendum = !issuedMissingParameterTypeError)
+                issuedMissingParameterTypeError = true
+              }
 
-            case _ => doTypedFunction(fun, resProto)
+              setError(fun)
+            }
+          } else {
+            fun.body match {
+              // translate `x => x match { <cases> }` : PartialFunction to
+              // `new PartialFunction { def applyOrElse(x, default) = x match { <cases> } def isDefinedAt(x) = ... }`
+              case Match(sel, cases) if (sel ne EmptyTree) && (pt.typeSymbol == PartialFunctionClass) =>
+                // go to outer context -- must discard the context that was created for the Function since we're discarding the function
+                // thus, its symbol, which serves as the current context.owner, is not the right owner
+                // you won't know you're using the wrong owner until lambda lift crashes (unless you know better than to use the wrong owner)
+                val outerTyper = newTyper(context.outer)
+                val p = vparams.head
+                if (p.tpt.tpe == null) p.tpt setType outerTyper.typedType(p.tpt).tpe
+
+                outerTyper.synthesizePartialFunction(p.name, p.pos, paramSynthetic = false, fun.body, mode, pt)
+
+              case _ => doTypedFunction(fun, resProto)
+            }
           }
         }
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3004,13 +3004,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               if (!vd.tpt.isEmpty) Right(vd.tpt.tpe)
               else Left(args.indexWhere {
                 case Ident(name) => name == vd.name
-                case _           => false // TODO: i think we need to deal with widening conversions too??
+                case _           => false // TODO: this does not catch eta-expansion of an overloaded method that involves numeric widening scala/bug#9738 (and maybe similar patterns?)
               })
             }
 
           // If some of the vparams without type annotation was not applied to `meth`,
           // we're not going to learn enough from typing `meth` to determine them.
-          if (formalsFromApply.exists{ case Left(-1) => true case _ => false }) EmptyTree
+          if (formalsFromApply.contains(Left(-1))) EmptyTree
           else {
             // We're looking for a method (as indicated by FUNmode in the silent typed below),
             // so let's make sure our expected type is a MethodType (of the right arity, but we can't easily say more about the argument types)

--- a/test/files/neg/names-defaults-neg-pu.check
+++ b/test/files/neg/names-defaults-neg-pu.check
@@ -139,8 +139,8 @@ names-defaults-neg-pu.scala:140: error: not found: value get
 names-defaults-neg-pu.scala:141: error: parameter 'a' is already specified at parameter position 1
   val taf3 = testAnnFun(b = _: String, a = get(8))
                                          ^
-names-defaults-neg-pu.scala:142: error: missing parameter type for expanded function ((<x$3: error>) => testAnnFun(x$3, ((x$4) => b = x$4)))
+names-defaults-neg-pu.scala:142: error: missing parameter type for expanded function ((<x$4: error>) => b = x$4)
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
-                                               ^
+                                                      ^
 5 warnings found
 33 errors found

--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -145,8 +145,8 @@ names-defaults-neg.scala:146: error: not found: value get
 names-defaults-neg.scala:147: error: parameter 'a' is already specified at parameter position 1
   val taf3 = testAnnFun(b = _: String, a = get(8))
                                          ^
-names-defaults-neg.scala:148: error: missing parameter type for expanded function ((<x$3: error>) => testAnnFun(x$3, ((x$4) => b = x$4)))
+names-defaults-neg.scala:148: error: missing parameter type for expanded function ((<x$4: error>) => b = x$4)
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
-                                               ^
+                                                      ^
 7 warnings found
 33 errors found

--- a/test/files/pos/eta_partial.scala
+++ b/test/files/pos/eta_partial.scala
@@ -1,0 +1,6 @@
+class Test {
+  def repeat(x: Int, y: String) = y * x
+  val sayAaah = repeat(_, "a") // partial eta-expansion recovers fun param types from method (place holder syntax)
+  val thrice = x => repeat(3, x) // partial eta-expansion recovers fun param types from method (explicit version)
+  val repeatFlip = (x, y) => repeat(y, x) // partial eta-expansion recovers fun param types from method (explicit version, two params)
+}


### PR DESCRIPTION
This improves inference of function parameter types for partially eta-expanded methods (i.e., when only some arguments are omitted using `_`)

Example from the test, given `def repeat(x: Int, y: String) = y * x`, partial eta-expansion recovers fun param types from the definition of the selected method:
```
val sayAaah = repeat(_, "a") // place holder syntax
val thrice = x => repeat(3, x) // explicit version
val repeatFlip = (x, y) => repeat(y, x) // explicit version, two params
```

Back ported to 2.12.8 as #7340
See https://github.com/lampepfl/dotty/issues/2570