### PR TITLE
[no-merge] Update types when treating parts

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1599,16 +1599,15 @@ abstract class RefChecks extends Transform {
                 try {
                   val treated = lits.mapConserve { lit =>
                     val stringVal = lit.asInstanceOf[Literal].value.stringValue
-                    treeCopy.Literal(lit, Constant(StringContext.processEscapes(stringVal)))
+                    val k = Constant(StringContext.processEscapes(stringVal))
+                    treeCopy.Literal(lit, k).setType(ConstantType(k))
                   }
                   Some((treated, args))
                 } catch {
-                  case _: StringContext.InvalidEscapeException =>
-                    None
+                  case _: StringContext.InvalidEscapeException => None
                 }
               }
             case _ => None
-
           }
         } else None
       }

--- a/test/files/run/t11196.scala
+++ b/test/files/run/t11196.scala
@@ -1,0 +1,8 @@
+
+object Test extends App {
+  assert(s"a\tb" == "a\tb")
+  def f = () => s"a\tb"
+  assert(f() == "a\tb")
+  def g(x: => String) = x
+  assert(g(s"a\tb") == "a\tb")
+}


### PR DESCRIPTION
When string interpolation parts are pre-treated
for escapes, also update their constant types,
which is relied upon by later transforms.

Trivial backport of https://github.com/scala/scala/pull/7334