### PR TITLE
Deprecate Option.apply

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
+++ b/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
@@ -367,7 +367,7 @@ abstract class NodePrinters {
 
   def printUnit(unit: CompilationUnit): Unit = {
     print("// Scala source: " + unit.source + "\n")
-    println(Option(unit.body) map (x => nodeToString(x) + "\n") getOrElse "<null>")
+    println(Option.whenNonNull(unit.body) map (x => nodeToString(x) + "\n") getOrElse "<null>")
   }
 
   def printAll(): Unit = {

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -42,7 +42,7 @@ abstract class BTypes {
    * name. The method assumes that every class type that appears in the bytecode exists in the map
    */
   def cachedClassBType(internalName: InternalName): Option[ClassBType] =
-    Option(cachedClassBTypeOrNull(internalName))
+    Option.whenNonNull(cachedClassBTypeOrNull(internalName))
 
   def cachedClassBTypeOrNull(internalName: InternalName): ClassBType =
     classBTypeCache.map.get(internalName)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
@@ -130,7 +130,7 @@ abstract class BTypesFromClassfile {
             classBTypeFromParsedClassfile(classNode.outerClass)
           }
         val staticFlag = (innerEntry.access & Opcodes.ACC_STATIC) != 0
-        NestedInfo(enclosingClass, Option(innerEntry.outerName), Option(innerEntry.innerName), staticFlag)
+        NestedInfo(enclosingClass, Option.whenNonNull(innerEntry.outerName), Option.whenNonNull(innerEntry.innerName), staticFlag)
     }
 
     val inlineInfo = inlineInfoFromClassfile(classNode)

--- a/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
@@ -193,7 +193,7 @@ private[jvm] object GeneratedClassHandler {
       javaExecutor.shutdownNow()
     }
 
-    def tryStealing: Option[Runnable] = Option(javaExecutor.getQueue.poll())
+    def tryStealing: Option[Runnable] = Option.whenNonNull(javaExecutor.getQueue.poll())
   }
 
 }

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -163,13 +163,13 @@ object BytecodeUtils {
 
   @tailrec def nextExecutableInstruction(insn: AbstractInsnNode, alsoKeep: AbstractInsnNode => Boolean = Set()): Option[AbstractInsnNode] = {
     val next = insn.getNext
-    if (next == null || isExecutable(next) || alsoKeep(next)) Option(next)
+    if (next == null || isExecutable(next) || alsoKeep(next)) Option.whenNonNull(next)
     else nextExecutableInstruction(next, alsoKeep)
   }
 
   @tailrec def nextExecutableInstructionOrLabel(insn: AbstractInsnNode): Option[AbstractInsnNode] = {
     val next = insn.getNext
-    if (next == null || isExecutable(next) || next.isInstanceOf[LabelNode]) Option(next)
+    if (next == null || isExecutable(next) || next.isInstanceOf[LabelNode]) Option.whenNonNull(next)
     else nextExecutableInstructionOrLabel(next)
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/InlinerHeuristics.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/InlinerHeuristics.scala
@@ -203,7 +203,7 @@ abstract class InlinerHeuristics extends PerRunInit {
               val what = if (callee.annotatedInline) "callee" else "callsite"
               s"the $what is annotated `@inline`"
             } else {
-              val paramNames = Option(callee.callee.parameters).map(_.asScala.map(_.name).toVector)
+              val paramNames = Option.whenNonNull(callee.callee.parameters).map(_.asScala.map(_.name).toVector)
               def param(i: Int) = {
                 def syn = s"<param $i>"
                 paramNames.fold(syn)(v => v.applyOrElse(i, (_: Int) => syn))

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
@@ -421,7 +421,7 @@ abstract class LocalOpt {
 
       // When running nullness optimizations the method may still have unreachable code. Analyzer
       // frames of unreachable instructions are `null`.
-      def frameAt(insn: AbstractInsnNode): Option[Frame[NullnessValue]] = Option(nullnessAnalyzer.frameAt(insn))
+      def frameAt(insn: AbstractInsnNode): Option[Frame[NullnessValue]] = Option.whenNonNull(nullnessAnalyzer.frameAt(insn))
 
       def nullness(insn: AbstractInsnNode, slot: Int): Option[NullnessValue] = {
         frameAt(insn).map(_.getValue(slot))

--- a/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
@@ -34,7 +34,7 @@ class ClassPathFactory(settings: Settings) {
   def sourcesInPath(path: String): List[ClassPath] =
     for {
       file <- expandPath(path, expandStar = false)
-      dir <- Option(AbstractFile getDirectory file)
+      dir <- Option.whenNonNull(AbstractFile getDirectory file)
     } yield createSourcePath(dir)
 
 
@@ -46,7 +46,7 @@ class ClassPathFactory(settings: Settings) {
     for {
       dir <- expandPath(path, expandStar = false)
       name <- expandDir(dir)
-      entry <- Option(AbstractFile.getDirectory(name))
+      entry <- Option.whenNonNull(AbstractFile.getDirectory(name))
     } yield newClassPath(entry)
 
   def classesInExpandedPath(path: String): IndexedSeq[ClassPath] =
@@ -64,7 +64,7 @@ class ClassPathFactory(settings: Settings) {
       file <- expandPath(path, expand)
       dir <- {
         def asImage = if (file.endsWith(".jimage")) Some(AbstractFile.getFile(file)) else None
-        Option(AbstractFile.getDirectory(file)).orElse(asImage)
+        Option.whenNonNull(AbstractFile.getDirectory(file)).orElse(asImage)
       }
     } yield newClassPath(dir)
 

--- a/src/compiler/scala/tools/nsc/classpath/VirtualDirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/VirtualDirectoryClassPath.scala
@@ -25,7 +25,7 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
 
   protected def emptyFiles: Array[AbstractFile] = Array.empty
   protected def getSubDir(packageDirName: String): Option[AbstractFile] =
-    Option(AbstractFileClassLoader.lookupPath(dir)(packageDirName.split('/'), directory = true))
+    Option.whenNonNull(AbstractFileClassLoader.lookupPath(dir)(packageDirName.split('/'), directory = true))
   protected def listChildren(dir: AbstractFile, filter: Option[AbstractFile => Boolean] = None): Array[F] = filter match {
     case Some(f) => dir.iterator.filter(f).toArray
     case _ => dir.toArray
@@ -42,7 +42,7 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
 
   def findClassFile(className: String): Option[AbstractFile] = {
     val relativePath = FileUtils.dirPath(className) + ".class"
-    Option(AbstractFileClassLoader.lookupPath(dir)(relativePath split '/', directory = false))
+    Option.whenNonNull(AbstractFileClassLoader.lookupPath(dir)(relativePath split '/', directory = false))
   }
 
   private[nsc] def classes(inPackage: String): Seq[ClassFileEntry] = files(inPackage)

--- a/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
@@ -52,7 +52,7 @@ trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPa
   protected def file(inPackage: String, name: String): Option[FileEntryType] =
     for {
       dirEntry <- findDirEntry(inPackage)
-      entry <- Option(dirEntry.lookupName(name, directory = false))
+      entry <- Option.whenNonNull(dirEntry.lookupName(name, directory = false))
       if isRequiredFileType(entry)
     } yield createFileEntry(entry)
 

--- a/src/compiler/scala/tools/nsc/fsc/CompileClient.scala
+++ b/src/compiler/scala/tools/nsc/fsc/CompileClient.scala
@@ -46,7 +46,7 @@ class StandardCompileClient extends HasCompileSocket with CompileOutputCommon {
     info(fscArgs.mkString("[Transformed arguments: ", " ", "]"))
     info(vmArgs.mkString("[VM arguments: ", " ", "]"))
 
-    val socket = Option(settings.server.value).filter(_.nonEmpty)
+    val socket = Option.whenNonNull(settings.server.value).filter(_.nonEmpty)
                  .map(compileSocket.getSocket)
                  .getOrElse(
       compileSocket.getOrCreateSocket(vmArgs.mkString(" "), !shutdown, settings.port.value)

--- a/src/compiler/scala/tools/nsc/io/Jar.scala
+++ b/src/compiler/scala/tools/nsc/io/Jar.scala
@@ -46,7 +46,7 @@ class Jar(file: File) extends AbstractIterable[JarEntry] {
   def this(jfile: JFile) = this(File(jfile))
   def this(path: String) = this(File(path))
 
-  lazy val manifest = withJarInput(s => Option(s.getManifest))
+  lazy val manifest = withJarInput(s => Option.whenNonNull(s.getManifest))
 
   def mainClass     = manifest map (f => f(Name.MAIN_CLASS))
   /** The manifest-defined classpath String if available. */

--- a/src/compiler/scala/tools/nsc/settings/AbsSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/AbsSettings.scala
@@ -52,7 +52,7 @@ trait AbsSettings extends scala.reflect.internal.settings.AbsSettings {
   def checkDependencies =
     visibleSettings filterNot (_.isDefault) forall (setting => setting.dependencies forall {
       case (dep, value) =>
-        (Option(dep.value) exists (_.toString == value)) || {
+        (Option.whenNonNull(dep.value) exists (_.toString == value)) || {
           errorFn("incomplete option %s (requires %s)".format(setting.name, dep.name))
           false
         }

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -204,7 +204,7 @@ class MutableSettings(val errorFn: String => Unit)
   * and `boot.class.path`.  These resources should contain the application
   * and boot classpaths in the same form as would be passed on the command line.*/
   def embeddedDefaults(loader: ClassLoader): Unit = {
-    explicitParentLoader = Option(loader) // for the Interpreter parentClassLoader
+    explicitParentLoader = Option.whenNonNull(loader) // for the Interpreter parentClassLoader
     getClasspath("app", loader) foreach { classpath.value = _ }
     getClasspath("boot", loader) foreach { bootclasspath append _ }
   }
@@ -215,7 +215,7 @@ class MutableSettings(val errorFn: String => Unit)
   /** Retrieves the contents of resource "${id}.class.path" from `loader`
   * (wrapped in Some) or None if the resource does not exist.*/
   private def getClasspath(id: String, loader: ClassLoader): Option[String] =
-    Option(loader).flatMap(ld => Option(ld.getResource(id + ".class.path"))).map { cp =>
+    Option.whenNonNull(loader).flatMap(ld => Option.whenNonNull(ld.getResource(id + ".class.path"))).map { cp =>
        Source.fromURL(cp).mkString
     }
 

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -37,7 +37,7 @@ trait ScalaSettings extends AbsScalaSettings
    *  defaults to the value of CLASSPATH env var if it is set, as in Java,
    *  or else to `"."` for the current user directory.
    */
-  protected def defaultClasspath = Option(System.getenv("CLASSPATH")).getOrElse(".")
+  protected def defaultClasspath = Option.whenNonNull(System.getenv("CLASSPATH")).getOrElse(".")
 
   /** Enabled under -Xfuture. */
   protected def futureSettings = List[BooleanSetting]()
@@ -93,7 +93,7 @@ trait ScalaSettings extends AbsScalaSettings
       // TODO validate release <= java.specification.version
     }
   } withAbbreviation "--release"
-  def releaseValue: Option[String] = Option(release.value).filter(_ != "")
+  def releaseValue: Option[String] = Option.whenNonNull(release.value).filter(_ != "")
 
   /*
    * The previous "-source" option is intended to be used mainly

--- a/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
@@ -307,7 +307,7 @@ trait Solving extends Logic {
       object ToDisjunction {
         def unapply(f: Prop): Option[Array[Clause]] = f match {
           case Or(fv)         =>
-            val cl = fv.foldLeft(Option(clause())) {
+            val cl = fv.foldLeft(Option.whenNonNull(clause())) {
               case (Some(clause), ToLiteral(lit)) =>
                 Some(clause + lit)
               case (_, _)                         =>
@@ -328,7 +328,7 @@ trait Solving extends Logic {
         def unapply(f: Prop): Option[Solvable] = f match {
           case ToDisjunction(clauses) => Some(Solvable(clauses, symbolMapping) )
           case And(fv)                =>
-            val clauses = fv.foldLeft(Option(mutable.ArrayBuffer[Clause]())) {
+            val clauses = fv.foldLeft(Some(mutable.ArrayBuffer[Clause]()): Option[ArrayBuffer[Clause]]) {
               case (Some(cnf), ToDisjunction(clauses)) =>
                 Some(cnf ++= clauses)
               case (_, _)                              =>

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1608,7 +1608,7 @@ trait Namers extends MethodSynthesis {
       private val module = companionSymbolOf(meth.owner, context)
       if (initCompanionModule) module.initialize
       private val cda: Option[ConstructorDefaultsAttachment] = module.attachments.get[ConstructorDefaultsAttachment]
-      private val moduleNamer = cda.flatMap(x => Option(x.companionModuleClassNamer))
+      private val moduleNamer = cda.flatMap(x => Option.whenNonNull(x.companionModuleClassNamer))
 
       def createAndEnter(f: Symbol => Symbol): Unit = {
         val default = f(module.moduleClass)
@@ -1995,7 +1995,7 @@ trait Namers extends MethodSynthesis {
     val tree: Tree
     override def forceDirectSuperclasses: Unit = {
       tree.foreach {
-        case dt: DefTree => global.withPropagateCyclicReferences(Option(dt.symbol).map(_.maybeInitialize))
+        case dt: DefTree => global.withPropagateCyclicReferences(Option.whenNonNull(dt.symbol).map(_.maybeInitialize))
         case _ =>
       }
     }

--- a/src/compiler/scala/tools/reflect/FormatInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FormatInterpolator.scala
@@ -227,7 +227,7 @@ abstract class FormatInterpolator {
     def argc: Int
 
     import SpecifierGroups.{ Value => SpecGroup, _ }
-    private def maybeStr(g: SpecGroup) = Option(m group g.id)
+    private def maybeStr(g: SpecGroup) = Option.whenNonNull(m group g.id)
     private def maybeInt(g: SpecGroup) = maybeStr(g) map (_.toInt)
     val index: Option[Int]     = maybeInt(Index)
     val flags: Option[String]  = maybeStr(Flags)
@@ -310,8 +310,8 @@ abstract class FormatInterpolator {
           badCC(s"illegal conversion character '$cc'")
           null
       }
-      Option(m group CC.id) map (cc => cv(cc(0))) match {
-        case Some(x) => Option(x) filter (_.verify)
+      Option.whenNonNull(m group CC.id) map (cc => cv(cc(0))) match {
+        case Some(x) => Option.whenNonNull(x) filter (_.verify)
         case None    =>
           badCC(s"Missing conversion operator in '${m.matched}'; $literalHelp")
           None

--- a/src/compilerOptionsExporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
+++ b/src/compilerOptionsExporter/scala/tools/nsc/ScalaCompilerOptionsExporter.scala
@@ -89,7 +89,7 @@ object ScalaCompilerOptionsExporter {
       } yield {
         Choice(
           choice,
-          description = Option(d).map(markdownifyBackquote).map(dehtmlfy).filter(_.nonEmpty),
+          description = Option.whenNonNull(d).map(markdownifyBackquote).map(dehtmlfy).filter(_.nonEmpty),
           deprecated = Some("EXPLAIN_ALTERNATIVE").filter(_ => d.toLowerCase.contains("deprecated"))
         )
       }
@@ -104,12 +104,12 @@ object ScalaCompilerOptionsExporter {
             Schema(_type="Int", default = Some(i.default), min = i.range.map(_._1), max = i.range.map(_._2))
           case c: settings.ChoiceSetting =>
             val choices = mergeChoice(c.choices, c.choicesHelp)
-            Schema(_type="Choice", arg = Some(c.helpArg).map(dehtmlfy), default = Option(c.default), choices = choices)
+            Schema(_type="Choice", arg = Some(c.helpArg).map(dehtmlfy), default = Option.whenNonNull(c.default), choices = choices)
           case mc: settings.MultiChoiceSetting[_] =>
             val choices = mergeChoice(mc.choices, mc.descriptions)
             Schema(_type="Choice", multiple = Some(true), arg = Some(mc.helpArg).map(dehtmlfy), choices = choices)
           case ps: settings.PhasesSetting =>
-            Schema(_type="Phases", default = Option(ps.default))
+            Schema(_type="Phases", default = Option.whenNonNull(ps.default))
           case px: settings.PrefixSetting =>
             Schema(_type="Prefix")
           case sv: settings.ScalaVersionSetting =>

--- a/src/interactive/scala/tools/nsc/interactive/tests/core/TestSettings.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/core/TestSettings.scala
@@ -22,7 +22,7 @@ private[tests] trait TestSettings {
   protected val outDir = Path(System.getProperty("partest.cwd", "."))
 
   /** The base directory for this test, usually a subdirectory of "test/files/presentation/" */
-  protected val baseDir = Option(System.getProperty("partest.testname")).map(outDir / _).getOrElse(Path("."))
+  protected val baseDir = Option.whenNonNull(System.getProperty("partest.testname")).map(outDir / _).getOrElse(Path("."))
 
   /** Where source files are placed. */
   protected val sourceDir = "src"

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -26,8 +26,19 @@ object Option {
    *
    *  @param  x the value
    *  @return   Some(value) if value != null, None if value == null
+   *  @deprecated if you intend to filter out null, use [[whenNonNull]] instead,
+   *              as its meaning is clearer; otherwise use [[Some.apply Some]]
    */
-  def apply[A](x: A): Option[A] = if (x == null) None else Some(x)
+  @deprecated("Use `whenNonNull` or `Some.apply` instead", since = "2.13.0")
+  @inline def apply[A](x: A): Option[A] = whenNonNull(x)
+
+  /** An Option factory which creates Some(x) if the argument is not null,
+    *  and None if it is null.
+    *
+    *  @param  a the value
+    *  @return   Some(value) if value != null, None if value == null
+    */
+  def whenNonNull[A](a: A): Option[A] = if (a == null) None else Some(a)
 
   /** An Option factory which returns `None` in a manner consistent with
    *  the collections hierarchy.
@@ -308,7 +319,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
    *  If either of the two options is empty, $none is returned.
    *
    *  @example {{{
-   *  // Returns Option(("foo", "bar")) because both options are nonempty.
+   *  // Returns Some(("foo", "bar")) because both options are nonempty.
    *  Some("foo") zip Some("bar")
    *
    *  // Returns None because `that` option is empty.

--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -333,11 +333,11 @@ private[collection] trait Wrappers {
     def addOne(kv: (K, V)): this.type = { underlying.put(kv._1, kv._2); this }
     def subtractOne(key: K): this.type = { underlying remove key; this }
 
-    override def put(k: K, v: V): Option[V] = Option(underlying.put(k, v))
+    override def put(k: K, v: V): Option[V] = Option.whenNonNull(underlying.put(k, v))
 
     override def update(k: K, v: V): Unit = { underlying.put(k, v) }
 
-    override def remove(k: K): Option[V] = Option(underlying remove k)
+    override def remove(k: K): Option[V] = Option.whenNonNull(underlying remove k)
 
     def iterator: Iterator[(K, V)] = new AbstractIterator[(K, V)] {
       val ui = underlying.entrySet.iterator
@@ -397,17 +397,17 @@ private[collection] trait Wrappers {
     extends AbstractJMapWrapper[K, V]
       with concurrent.Map[K, V] {
 
-    override def get(k: K) = Option(underlying get k)
+    override def get(k: K) = Option.whenNonNull(underlying get k)
 
     override def isEmpty: Boolean = underlying.isEmpty
     override def knownSize: Int = if (underlying.isEmpty) 0 else super.knownSize
     override def empty = new JConcurrentMapWrapper(new juc.ConcurrentHashMap[K, V])
 
-    def putIfAbsent(k: K, v: V): Option[V] = Option(underlying.putIfAbsent(k, v))
+    def putIfAbsent(k: K, v: V): Option[V] = Option.whenNonNull(underlying.putIfAbsent(k, v))
 
     def remove(k: K, v: V): Boolean = underlying.remove(k, v)
 
-    def replace(k: K, v: V): Option[V] = Option(underlying.replace(k, v))
+    def replace(k: K, v: V): Option[V] = Option.whenNonNull(underlying.replace(k, v))
 
     def replace(k: K, oldvalue: V, newvalue: V): Boolean =
       underlying.replace(k, oldvalue, newvalue)
@@ -447,16 +447,16 @@ private[collection] trait Wrappers {
     override def isEmpty: Boolean = underlying.isEmpty
     override def knownSize: Int = if (underlying.isEmpty) 0 else super.knownSize
 
-    def get(k: K) = Option(underlying get k)
+    def get(k: K) = Option.whenNonNull(underlying get k)
 
     def addOne(kv: (K, V)): this.type = { underlying.put(kv._1, kv._2); this }
     def subtractOne(key: K): this.type = { underlying remove key; this }
 
-    override def put(k: K, v: V): Option[V] = Option(underlying.put(k, v))
+    override def put(k: K, v: V): Option[V] = Option.whenNonNull(underlying.put(k, v))
 
     override def update(k: K, v: V): Unit = { underlying.put(k, v) }
 
-    override def remove(k: K): Option[V] = Option(underlying remove k)
+    override def remove(k: K): Option[V] = Option.whenNonNull(underlying remove k)
     def iterator = enumerationAsScalaIterator(underlying.keys) map (k => (k, underlying get k))
 
     override def clear() = iterator.foreach(entry => underlying.remove(entry._1))

--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -232,7 +232,7 @@ private[concurrent] final object Promise {
 
     override final def isCompleted: Boolean = value0 ne null
 
-    override final def value: Option[Try[T]] = Option(value0)
+    override final def value: Option[Try[T]] = Option.whenNonNull(value0)
 
     @tailrec // returns null if not completed
     private final def value0: Try[T] = {

--- a/src/library/scala/ref/ReferenceWrapper.scala
+++ b/src/library/scala/ref/ReferenceWrapper.scala
@@ -17,7 +17,7 @@ package scala.ref
  */
 trait ReferenceWrapper[+T <: AnyRef] extends Reference[T] with Proxy {
   val underlying: java.lang.ref.Reference[_ <: T]
-  override def get = Option(underlying.get)
+  override def get = Option.whenNonNull(underlying.get)
   def apply() = {
     val ret = underlying.get
     if (ret eq null) throw new NoSuchElementException

--- a/src/library/scala/ref/SoftReference.scala
+++ b/src/library/scala/ref/SoftReference.scala
@@ -32,7 +32,7 @@ object SoftReference {
   def apply[T <: AnyRef](value: T) = new SoftReference(value)
 
   /** Optionally returns the referenced value, or `None` if that value no longer exists */
-  def unapply[T <: AnyRef](sr: SoftReference[T]): Option[T] = Option(sr.underlying.get)
+  def unapply[T <: AnyRef](sr: SoftReference[T]): Option[T] = Option.whenNonNull(sr.underlying.get)
 }
 
 /**

--- a/src/library/scala/ref/WeakReference.scala
+++ b/src/library/scala/ref/WeakReference.scala
@@ -31,7 +31,7 @@ object WeakReference {
   def apply[T <: AnyRef](value: T) = new WeakReference(value)
 
   /** Optionally returns the referenced value, or `None` if that value no longer exists */
-  def unapply[T <: AnyRef](wr: WeakReference[T]): Option[T] = Option(wr.underlying.get)
+  def unapply[T <: AnyRef](wr: WeakReference[T]): Option[T] = Option.whenNonNull(wr.underlying.get)
 }
 
 /**

--- a/src/library/scala/reflect/ClassManifestDeprecatedApis.scala
+++ b/src/library/scala/reflect/ClassManifestDeprecatedApis.scala
@@ -28,7 +28,7 @@ trait ClassManifestDeprecatedApis[T] extends OptManifest[T] {
     def loop(left: Set[jClass[_]], seen: Set[jClass[_]]): Boolean = {
       left.nonEmpty && {
         val next = left.head
-        val supers = next.getInterfaces.toSet ++ Option(next.getSuperclass)
+        val supers = next.getInterfaces.toSet ++ Option.whenNonNull(next.getSuperclass)
         supers(sup) || {
           val xs = left ++ supers filterNot seen
           loop(xs - next, seen + next)

--- a/src/library/scala/sys/SystemProperties.scala
+++ b/src/library/scala/sys/SystemProperties.scala
@@ -48,7 +48,7 @@ extends mutable.AbstractMap[String, String] {
   ) getOrElse Iterator.empty
 
   def get(key: String) =
-    wrapAccess(Option(System.getProperty(key))) flatMap (x => x)
+    wrapAccess(Option.whenNonNull(System.getProperty(key))) flatMap (x => x)
   override def contains(key: String) =
     wrapAccess(super.contains(key)) exists (x => x)
 

--- a/src/library/scala/sys/package.scala
+++ b/src/library/scala/sys/package.scala
@@ -58,7 +58,7 @@ package object sys {
   def props: SystemProperties = new SystemProperties
 
   // TODO: consider whether layering a Map on top of Java's properties is really needed -- we could simply provide:
-  //  def prop(p: String) = Option(System.getProperty(p))
+  //  def prop(p: String) = Option.whenNonNull(System.getProperty(p))
 
   /** An immutable Map representing the current system environment.
    *

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -52,23 +52,23 @@ private[scala] trait PropertiesTrait {
 
   def propIsSet(name: String)                   = System.getProperty(name) != null
   def propIsSetTo(name: String, value: String)  = propOrNull(name) == value
-  def propOrElse(name: String, alt: => String)     = Option(System.getProperty(name)).getOrElse(alt)
+  def propOrElse(name: String, alt: => String)     = Option.whenNonNull(System.getProperty(name)).getOrElse(alt)
   def propOrEmpty(name: String)                 = propOrElse(name, "")
   def propOrNull(name: String)                  = propOrElse(name, null)
-  def propOrNone(name: String)                  = Option(propOrNull(name))
+  def propOrNone(name: String)                  = Option.whenNonNull(propOrNull(name))
   def propOrFalse(name: String)                 = propOrNone(name) exists (x => List("yes", "on", "true") contains x.toLowerCase)
   def setProp(name: String, value: String)      = System.setProperty(name, value)
   def clearProp(name: String)                   = System.clearProperty(name)
 
-  def envOrElse(name: String, alt: => String)      = Option(System getenv name) getOrElse alt
-  def envOrNone(name: String)                   = Option(System getenv name)
+  def envOrElse(name: String, alt: => String)      = Option.whenNonNull(System getenv name) getOrElse alt
+  def envOrNone(name: String)                   = Option.whenNonNull(System getenv name)
 
   def envOrSome(name: String, alt: => Option[String])       = envOrNone(name) orElse alt
 
   // for values based on propFilename, falling back to System properties
   def scalaPropOrElse(name: String, alt: => String): String = scalaPropOrNone(name).getOrElse(alt)
   def scalaPropOrEmpty(name: String): String             = scalaPropOrElse(name, "")
-  def scalaPropOrNone(name: String): Option[String]      = Option(scalaProps.getProperty(name)).orElse(propOrNone("scala." + name))
+  def scalaPropOrNone(name: String): Option[String]      = Option.whenNonNull(scalaProps.getProperty(name)).orElse(propOrNone("scala." + name))
 
   /** The numeric portion of the runtime Scala version, if this is a final
    *  release.  If for instance the versionString says "version 2.9.0.final",

--- a/src/partest/scala/tools/partest/ASMConverters.scala
+++ b/src/partest/scala/tools/partest/ASMConverters.scala
@@ -162,11 +162,11 @@ object ASMConverters {
     private def convertMethodHandle(h: asm.Handle): MethodHandle = MethodHandle(h.getTag, h.getOwner, h.getName, h.getDesc, h.isInterface)
 
     private def convertHandlers(method: t.MethodNode): List[ExceptionHandler] = {
-      method.tryCatchBlocks.iterator.asScala.map(h => ExceptionHandler(applyLabel(h.start), applyLabel(h.end), applyLabel(h.handler), Option(h.`type`))).toList
+      method.tryCatchBlocks.iterator.asScala.map(h => ExceptionHandler(applyLabel(h.start), applyLabel(h.end), applyLabel(h.handler), Option.whenNonNull(h.`type`))).toList
     }
 
     private def convertLocalVars(method: t.MethodNode): List[LocalVariable] = {
-      method.localVariables.iterator.asScala.map(v => LocalVariable(v.name, v.desc, Option(v.signature), applyLabel(v.start), applyLabel(v.end), v.index)).toList
+      method.localVariables.iterator.asScala.map(v => LocalVariable(v.name, v.desc, Option.whenNonNull(v.signature), applyLabel(v.start), applyLabel(v.end), v.index)).toList
     }
   }
 

--- a/src/partest/scala/tools/partest/sbt/SBTRunner.scala
+++ b/src/partest/scala/tools/partest/sbt/SBTRunner.scala
@@ -25,7 +25,7 @@ class SBTRunner(config: RunnerSpec.Config,
                 srcDir: String, testClassLoader: URLClassLoader, javaCmd: File, javacCmd: File,
                 scalacArgs: Array[String], args: Array[String]) extends AbstractRunner(
   config,
-  config.optSourcePath orElse Option(srcDir) getOrElse PartestDefaults.sourcePath,
+  config.optSourcePath orElse Option.whenNonNull(srcDir) getOrElse PartestDefaults.sourcePath,
   new FileManager(testClassLoader = testClassLoader)
 ) {
 
@@ -62,8 +62,8 @@ class SBTRunner(config: RunnerSpec.Config,
     else l.mkString(" ")
   }
 
-  override val javaCmdPath = Option(javaCmd).map(_.getAbsolutePath) getOrElse PartestDefaults.javaCmd
-  override val javacCmdPath = Option(javacCmd).map(_.getAbsolutePath) getOrElse PartestDefaults.javacCmd
+  override val javaCmdPath = Option.whenNonNull(javaCmd).map(_.getAbsolutePath) getOrElse PartestDefaults.javaCmd
+  override val javacCmdPath = Option.whenNonNull(javacCmd).map(_.getAbsolutePath) getOrElse PartestDefaults.javacCmd
   override val scalacExtraArgs = scalacArgs.toIndexedSeq
 
   override def onFinishTest(testFile: File, result: TestState, durationMs: Long): TestState = {

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -430,7 +430,7 @@ abstract class SymbolTable extends macros.Universe
 
     def clearAll() = {
       debuglog("Clearing " + (caches.size + javaCaches.size) + " caches.")
-      caches foreach (ref => Option(ref.get).foreach(_.clear))
+      caches foreach (ref => Option.whenNonNull(ref.get).foreach(_.clear))
       caches = caches.filterNot(_.get == null)
 
       javaCaches foreach (_.clear)

--- a/src/reflect/scala/reflect/internal/util/JavaClearable.scala
+++ b/src/reflect/scala/reflect/internal/util/JavaClearable.scala
@@ -22,10 +22,10 @@ object JavaClearable {
   def forMap[T <: JMap[_,_]](data: T): JavaClearable[T] = new JavaClearableMap(new WeakReference(data))
 
   private final class JavaClearableMap[T <: JMap[_,_]](dataRef:WeakReference[T]) extends JavaClearable(dataRef) {
-    override def clear: Unit = Option(dataRef.get) foreach (_.clear())
+    override def clear: Unit = Option.whenNonNull(dataRef.get) foreach (_.clear())
   }
   private final class JavaClearableCollection[T <: JCollection[_]](dataRef:WeakReference[T]) extends JavaClearable(dataRef) {
-    override def clear: Unit = Option(dataRef.get) foreach (_.clear())
+    override def clear: Unit = Option.whenNonNull(dataRef.get) foreach (_.clear())
   }
 }
 sealed abstract class JavaClearable[T <: AnyRef] protected (protected val dataRef: WeakReference[T]) extends Clearable {

--- a/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
@@ -163,7 +163,7 @@ object ScalaClassLoader {
 
   /** Finding what jar a clazz or instance came from */
   def originOfClass(x: Class[_]): Option[URL] =
-    Option(x.getProtectionDomain.getCodeSource) flatMap (x => Option(x.getLocation))
+    Option.whenNonNull(x.getProtectionDomain.getCodeSource) flatMap (x => Option.whenNonNull(x.getLocation))
 
   private[this] val bootClassLoader: ClassLoader = {
     if (!util.Properties.isJavaAtLeast("9")) null

--- a/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
+++ b/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
@@ -74,7 +74,7 @@ final class WeakHashSet[A <: AnyRef](val initialCapacity: Int, val loadFactor: D
 
   private[this] def computeThreshold: Int = (table.size * loadFactor).ceil.toInt
 
-  def get(elem: A): Option[A] = Option(findEntry(elem))
+  def get(elem: A): Option[A] = Option.whenNonNull(findEntry(elem))
 
   /**
    * find the bucket associated with an element's hash code

--- a/src/reflect/scala/reflect/io/VirtualDirectory.scala
+++ b/src/reflect/scala/reflect/io/VirtualDirectory.scala
@@ -63,14 +63,14 @@ extends AbstractFile {
     (files get name filter (_.isDirectory == directory)).orNull
 
   override def fileNamed(name: String): AbstractFile =
-    Option(lookupName(name, directory = false)) getOrElse {
+    Option.whenNonNull(lookupName(name, directory = false)) getOrElse {
       val newFile = new VirtualFile(name, path+'/'+name)
       files(name) = newFile
       newFile
     }
 
   override def subdirectoryNamed(name: String): AbstractFile =
-    Option(lookupName(name, directory = true)) getOrElse {
+    Option.whenNonNull(lookupName(name, directory = true)) getOrElse {
       val dir = new VirtualDirectory(name, Some(this))
       files(name) = dir
       dir

--- a/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
+++ b/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
@@ -92,7 +92,7 @@ object ReflectionUtils {
   }
 
   class EnclosedIn[T](enclosure: jClass[_] => T) {
-    def unapply(jclazz: jClass[_]): Option[T] = Option(enclosure(jclazz))
+    def unapply(jclazz: jClass[_]): Option[T] = Option.whenNonNull(enclosure(jclazz))
   }
 
   object EnclosedInMethod extends EnclosedIn(_.getEnclosingMethod)

--- a/src/reflect/scala/reflect/runtime/TwoWayCache.scala
+++ b/src/reflect/scala/reflect/runtime/TwoWayCache.scala
@@ -38,7 +38,7 @@ private[runtime] class TwoWayCache[J, S] {
   private object SomeRef {
     def unapply[T](optRef: Option[WeakReference[T]]): Option[T] =
       if (optRef.nonEmpty) {
-        Option(optRef.get.get)
+        Option.whenNonNull(optRef.get.get)
       } else None
   }
 

--- a/src/reflect/scala/reflect/runtime/TwoWayCaches.scala
+++ b/src/reflect/scala/reflect/runtime/TwoWayCaches.scala
@@ -38,7 +38,7 @@ private[runtime] trait TwoWayCaches { self: SymbolTable =>
     private object SomeRef {
       def unapply[T](optRef: Option[WeakReference[T]]): Option[T] =
         if (optRef.nonEmpty) {
-          Option(optRef.get.get)
+          Option.whenNonNull(optRef.get.get)
         } else None
     }
 

--- a/src/repl-frontend/scala/tools/nsc/Interpreter.scala
+++ b/src/repl-frontend/scala/tools/nsc/Interpreter.scala
@@ -50,7 +50,7 @@ class InterpreterLoop {
   def interpreter_= (interpreter: Interpreter) = {
     val config = interpreter.config
     compilerSettings = config._1 match { case null => interpreterSettings case cs => cs }
-    parentClassLoader = Option(config._2)
+    parentClassLoader = Option.whenNonNull(config._2)
   }
 
   @volatile private var intp: Repl = _

--- a/src/repl-frontend/scala/tools/nsc/interpreter/jline/FileBackedHistory.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/jline/FileBackedHistory.scala
@@ -40,7 +40,7 @@ trait FileBackedHistory extends JLineHistory with PersistentHistory {
     val fs = FileSystems.getDefault
 
     // This would really have been sufficient for our property getting infrastructure
-    def prop(p: String) = Option(System.getProperty(p))
+    def prop(p: String) = Option.whenNonNull(System.getProperty(p))
 
     (prop("scala.shell.histfile").map(fs.getPath(_)).map{ p => if (!Files.exists(p)) secure(p); p } orElse
       prop("user.home").map(n => fs.getPath(n + s"${fs.getSeparator}${FileBackedHistory.defaultFileName}")).map(secure)

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -234,7 +234,7 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
     def complete(buffer: String, cursor: Int): CompletionResult =
       buffer.substring(0, cursor) match {
         case emptyWord(s)        => listed(cursor, Directory.Current)
-        case directorily(s)      => listed(cursor, Option(Path(s)))
+        case directorily(s)      => listed(cursor, Option.whenNonNull(Path(s)))
         case trailingWord(s) =>
           val f = File(s)
           val (i, maybes) =
@@ -818,7 +818,7 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
           case x :: Nil => x
           case _        => echo("usage: :paste [-raw] file | < EOF") ; return result
         }
-        (raw0, Option(file0), Option(margin0))
+        (raw0, Option.whenNonNull(file0), Option.whenNonNull(margin0))
       }
     val code = (file, margin) match {
       case (Some(name), None) =>

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/InteractiveReader.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/InteractiveReader.scala
@@ -82,7 +82,7 @@ class SplashLoop(in: InteractiveReader, prompt: String) extends Runnable {
         }
       }
     finally {
-      try result.put(Option(input))
+      try result.put(Option.whenNonNull(input))
       catch { case ie: InterruptedException =>  } // we may have been interrupted because the interpreter reported an error
     }
   }

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/LoopCommands.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/LoopCommands.scala
@@ -174,7 +174,7 @@ trait LoopCommands {
     val default = Result(keepRunning = true, None)
 
     // "keep running, and record this line"
-    def recording(line: String) = Result(keepRunning = true, Option(line))
+    def recording(line: String) = Result(keepRunning = true, Option.whenNonNull(line))
 
     // most commands do not want to micromanage the Result, but they might want
     // to print something to the console, so we accommodate Unit and String returns.

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Scripted.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Scripted.scala
@@ -60,7 +60,7 @@ class Scripted(@BeanProperty val factory: ScriptEngineFactory, settings: Setting
     val ctx = compileContext
     val terms = for {
       scope <- ctx.getScopes.asScala
-      binding <- Option(ctx.getBindings(scope)) map (_.asScala) getOrElse Nil
+      binding <- Option.whenNonNull(ctx.getBindings(scope)) map (_.asScala) getOrElse Nil
       key = binding._1
     } yield key
     Set.from(terms)

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -251,7 +251,7 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
     // might be null if we're on the boot classpath
     parentClassLoaderOverride.
       orElse(settings.explicitParentLoader).
-      orElse(Option(replClass.getClassLoader())).
+      orElse(Option.whenNonNull(replClass.getClassLoader())).
       getOrElse(ClassLoader.getSystemClassLoader)
   }
 
@@ -1022,7 +1022,7 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
       }
       loop(null, top, rest)
     }
-    Option(symbolOfTerm(id)).filter(_.exists).flatMap(s => Trying(value(originalPath(s))).toOption.flatten)
+    Option.whenNonNull(symbolOfTerm(id)).filter(_.exists).flatMap(s => Trying(value(originalPath(s))).toOption.flatten)
   }
 
   /** It's a bit of a shotgun approach, but for now we will gain in

--- a/src/scalacheck/org/scalacheck/util/CmdLineParser.scala
+++ b/src/scalacheck/org/scalacheck/util/CmdLineParser.scala
@@ -73,7 +73,7 @@ private[scalacheck] trait CmdLineParser {
         case Some(o: IntOpt) => getInt(a2).map(v => parse(as, om.set(o -> v), us))
         case Some(o: FloatOpt) => getFloat(a2).map(v => parse(as, om.set(o -> v), us))
         case Some(o: StrOpt) => getStr(a2).map(v => parse(as, om.set(o -> v), us))
-        case Some(o: OpStrOpt) => getStr(a2).map(v => parse(as, om.set(o -> Option(v)), us))
+        case Some(o: OpStrOpt) => getStr(a2).map(v => parse(as, om.set(o -> Option.whenNonNull(v)), us))
         case _ => None
       }).getOrElse(parse(a2::as, om, us :+ a1))
     }

--- a/src/scaladoc/scala/tools/nsc/doc/model/MemberLookup.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/MemberLookup.scala
@@ -58,7 +58,7 @@ trait MemberLookup extends base.MemberLookupBase {
         sym.info.member(newTermName("package"))
       else sym
     def classpathEntryFor(s: Symbol): Option[String] = {
-      Option(s.associatedFile).flatMap(_.underlyingSource).map { src =>
+      Option.whenNonNull(s.associatedFile).flatMap(_.underlyingSource).map { src =>
         val path = src.canonicalPath
         if(path.endsWith(".class")) { // Individual class file -> Classpath entry is root dir
           val nesting = s.ownerChain.count(_.hasPackageFlag)

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -458,7 +458,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     def groupSearch[T](extractor: Comment => Option[T]): Option[T] = {
       val comments = comment +: linearizationTemplates.collect { case dtpl: DocTemplateImpl => dtpl.comment }
       comments.flatten.map(extractor).flatten.headOption orElse {
-        Option(inTpl) flatMap (_.groupSearch(extractor))
+        Option.whenNonNull(inTpl) flatMap (_.groupSearch(extractor))
       }
     }
 
@@ -492,7 +492,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
       val inRealTpl = (
         conversion.flatMap(conv => nonRootTemplate(conv.toType.typeSymbol))
           orElse nonRootTemplate(sym.owner)
-          orElse Option(inTpl))
+          orElse Option.whenNonNull(inTpl))
 
       inRealTpl flatMap (tpl => thisFactory.comment(commentCarryingSymbol(sym), tpl, tpl))
     }

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/OpenHashMapRunner.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/OpenHashMapRunner.scala
@@ -34,13 +34,13 @@ object OpenHashMapRunner extends JmhRunner {
     def size: String = r.getParams.getParam("size")
 
     /** Return the operation counts. Not every test tracks this. */
-    def operations = Option(r.getSecondaryResults.get("operations"))
+    def operations = Option.whenNonNull(r.getSecondaryResults.get("operations"))
 
     /** Return the number of map entries. */
     def entries = r.getSecondaryResults.get("mapEntries")
 
     /** Return the memory usage. Only defined if memory usage was measured. */
-    def memory = Option(r.getSecondaryResults.get("memory"))
+    def memory = Option.whenNonNull(r.getSecondaryResults.get("memory"))
   }
 
   /** Return the statistics of the given result as a string. */

--- a/test/files/jvm/scala-concurrent-tck.scala
+++ b/test/files/jvm/scala-concurrent-tck.scala
@@ -23,7 +23,7 @@ trait TestBase {
     body(new Done {
       def apply(proof: => Boolean): Unit = q offer Try(proof)
     })
-    assert(Option(q.poll(2000, TimeUnit.MILLISECONDS)).map(_.get).getOrElse(false))
+    assert(Option.whenNonNull(q.poll(2000, TimeUnit.MILLISECONDS)).map(_.get).getOrElse(false))
     // Check that we don't get more than one completion
     assert(q.poll(50, TimeUnit.MILLISECONDS) eq null)
   }

--- a/test/files/neg/infix-op-positions.check
+++ b/test/files/neg/infix-op-positions.check
@@ -1,7 +1,7 @@
-infix-op-positions.scala:2: error: value -! is not a member of Option[Int]
-  Option(1) -! "test" // left associative operator
-            ^
-infix-op-positions.scala:3: error: value -!: is not a member of Option[Int]
-  "test" -!: Option(1) // right associative operators
+infix-op-positions.scala:2: error: value -! is not a member of Some[Int]
+  Some(1) -! "test" // left associative operator
+          ^
+infix-op-positions.scala:3: error: value -!: is not a member of Some[Int]
+  "test" -!: Some(1) // right associative operators
          ^
 two errors found

--- a/test/files/neg/infix-op-positions.scala
+++ b/test/files/neg/infix-op-positions.scala
@@ -1,4 +1,4 @@
 object Test {
-  Option(1) -! "test" // left associative operator
-  "test" -!: Option(1) // right associative operators
+  Some(1) -! "test" // left associative operator
+  "test" -!: Some(1) // right associative operators
 }

--- a/test/files/neg/t563.check
+++ b/test/files/neg/t563.check
@@ -1,4 +1,4 @@
 t563.scala:6: error: missing parameter type
-            map(n,ptr => Option(ptr.get));
+            map(n,ptr => Option.whenNonNull(ptr.get));
                   ^
 one error found

--- a/test/files/neg/t563.scala
+++ b/test/files/neg/t563.scala
@@ -3,5 +3,5 @@ object Test {
 
     def split(sn : Iterable[List[Option[Int]]]) : Unit =
         for (n <- sn)
-            map(n,ptr => Option(ptr.get));
+            map(n,ptr => Option.whenNonNull(ptr.get));
 }

--- a/test/files/neg/t6567.check
+++ b/test/files/neg/t6567.check
@@ -1,9 +1,9 @@
-t6567.scala:10: warning: Suspicious application of an implicit view (Test.this.a2b) in the argument to Option.apply.
-  Option[B](a)
-           ^
-t6567.scala:12: warning: Suspicious application of an implicit view (Test.this.a2b) in the argument to Option.apply.
-  val b: Option[B] = Option(a)
-                           ^
+t6567.scala:10: warning: Suspicious application of an implicit view (Test.this.a2b) in the argument to Option.whenNonNull.
+  Option.whenNonNull[B](a)
+                       ^
+t6567.scala:12: warning: Suspicious application of an implicit view (Test.this.a2b) in the argument to Option.whenNonNull.
+  val b: Option[B] = Option.whenNonNull(a)
+                                       ^
 warning: there was one feature warning; re-run with -feature for details
 error: No warnings can be incurred under -Xfatal-warnings.
 three warnings found

--- a/test/files/neg/t6567.scala
+++ b/test/files/neg/t6567.scala
@@ -7,7 +7,7 @@ object Test {
   val a: A = null
   implicit def a2b(a: A) = new B
 
-  Option[B](a)
+  Option.whenNonNull[B](a)
 
-  val b: Option[B] = Option(a)
+  val b: Option[B] = Option.whenNonNull(a)
 }

--- a/test/files/neg/t6663.scala
+++ b/test/files/neg/t6663.scala
@@ -1,8 +1,8 @@
 import language.dynamics
 
 class C(v: Any) extends Dynamic {
-  def selectDynamic[T](n: String): Option[T] = Option(v.asInstanceOf[T])
-  def applyDynamic[T](n: String)(): Option[T] = Option(v.asInstanceOf[T])
+  def selectDynamic[T](n: String): Option[T] = Option.whenNonNull(v.asInstanceOf[T])
+  def applyDynamic[T](n: String)(): Option[T] = Option.whenNonNull(v.asInstanceOf[T])
 }
 
 object Test extends App {

--- a/test/files/neg/t7473.check
+++ b/test/files/neg/t7473.check
@@ -1,7 +1,7 @@
 t7473.scala:6: error: '<-' expected but '=' found.
-  (for (x = Option(i); if x == j) yield 42) toList
+  (for (x = Some(i); if x == j) yield 42) toList
           ^
 t7473.scala:6: error: illegal start of simple expression
-  (for (x = Option(i); if x == j) yield 42) toList
-                     ^
+  (for (x = Some(i); if x == j) yield 42) toList
+                   ^
 two errors found

--- a/test/files/neg/t7473.scala
+++ b/test/files/neg/t7473.scala
@@ -1,7 +1,7 @@
 
 object Foo {
   val i,j = 3
-  //for (x = Option(i); if x == j) yield 42  //t7473.scala:4: error: '<-' expected but '=' found.
+  //for (x = Some(i); if x == j) yield 42  //t7473.scala:4: error: '<-' expected but '=' found.
   // evil postfix!
-  (for (x = Option(i); if x == j) yield 42) toList
+  (for (x = Some(i); if x == j) yield 42) toList
 }

--- a/test/files/neg/warn-unused-patvars.scala
+++ b/test/files/neg/warn-unused-patvars.scala
@@ -39,14 +39,14 @@ trait Boundings {
 
 trait Forever {
   def f = {
-    val t = Option((17, 42))
+    val t = Some((17, 42))
     for {
       ns <- t
       (i, j) = ns                        // no warn
     } yield (i + j)
   }
   def g = {
-    val t = Option((17, 42))
+    val t = Some((17, 42))
     for {
       ns <- t
       (i, j) = ns                        // no warn

--- a/test/files/neg/warn-unused-privates.scala
+++ b/test/files/neg/warn-unused-privates.scala
@@ -180,14 +180,14 @@ trait Boundings {
 
 trait Forever {
   def f = {
-    val t = Option((17, 42))
+    val t = Some((17, 42))
     for {
       ns <- t
       (i, j) = ns                        // no warn
     } yield (i + j)
   }
   def g = {
-    val t = Option((17, 42))
+    val t = Some((17, 42))
     for {
       ns <- t
       (i, j) = ns                        // no warn
@@ -207,7 +207,7 @@ trait CaseyKasem {
   }
 }
 trait CaseyAtTheBat {
-  def f = Option(42) match {
+  def f = Option.whenNonNull(42) match {
     case Some(x) if x < 25 => "no warn"
     case Some(y @ _) if toString.nonEmpty => "no warn"
     case Some(z) => "warn"

--- a/test/files/pos/prune-poly-view.scala
+++ b/test/files/pos/prune-poly-view.scala
@@ -24,7 +24,7 @@ object Test2 {
 }
 
 object Test3 {
-  implicit def toOption[T](v: T): Option[T] = Option(v)
+  implicit def toOption[T](v: T): Option[T] = Option.whenNonNull(v)
   val a: Int = 123
   val b: Option[Long] = a // Works under 2.12.6 but not with the implicit-poly-prune-2.12.x PR
 }

--- a/test/files/pos/t10722.scala
+++ b/test/files/pos/t10722.scala
@@ -9,5 +9,5 @@ object Test {
   def flop[F[_], G <: F[String]](f: F[String], g: G) = ???
 
   flip(Tails("scala"): Coin[Int, String], Heads(50))
-  flop(Option("scala"), None)
+  flop(Some("scala"): Option[String], None)
 }

--- a/test/files/pos/t10740.scala
+++ b/test/files/pos/t10740.scala
@@ -3,7 +3,7 @@ object Test {
   def diff1[A](i: Inv[A], j: Inv[_ <: A]) = 1
   def diff2[A](i: Inv[_ >: A], j: Inv[A]) = 2
   def diff3[A](i: Inv[_ >: A], j: Inv[_ <: A]) = 3
-  val i = Inv(Option(42))
+  val i = Inv(Option.whenNonNull(42))
   val j = Inv(Some(42))
   diff1(i, j)
   diff2(i, j)

--- a/test/files/pos/t10763.scala
+++ b/test/files/pos/t10763.scala
@@ -6,5 +6,5 @@ class Test {
 
     for (refute@1 <- xs) {}
   }
-  def f() = for (Some(i: Int) <- List(Option(42))) println(i)
+  def f() = for (Some(i: Int) <- List(Some(42))) println(i)
 }

--- a/test/files/pos/t5542.scala
+++ b/test/files/pos/t5542.scala
@@ -1,5 +1,5 @@
 // scalac: -Xfatal-warnings -unchecked
 //
 class Test {
-  Option(3) match { case Some(n) => n; case None => 0 }
+  Option.whenNonNull(3) match { case Some(n) => n; case None => 0 }
 }

--- a/test/files/pos/t5720-ownerous.scala
+++ b/test/files/pos/t5720-ownerous.scala
@@ -25,10 +25,10 @@ class C {
   val m = M("foo")()
 
   // reported
-  //def model = Option(M("foo")()).getOrElse(M("bar")()).copy(currentUser = "")()
+  //def model = Option.whenNonNull(M("foo")()).getOrElse(M("bar")()).copy(currentUser = "")()
 
   // the bug
-  def model = Option(m).getOrElse(M("bar")()).copy("baz")("empty")
+  def model = Option.whenNonNull(m).getOrElse(M("bar")()).copy("baz")("empty")
 
   // style points for this version
   def modish = ((null: Option[M]) getOrElse new M()()).copy()("empty")
@@ -36,7 +36,7 @@ class C {
   // various simplifications are too simple
   case class N(currentUser: String = "anon")
   val n = N("fun")
-  def nudel = Option(n).getOrElse(N()).copy()
+  def nudel = Option.whenNonNull(n).getOrElse(N()).copy()
 }
 
 object Test {

--- a/test/files/pos/t8793.scala
+++ b/test/files/pos/t8793.scala
@@ -5,11 +5,11 @@ trait F[A]
 class G(val a: F[_], val b: F[_])
  
 object G {
-  def unapply(g: G) = Option((g.a, g.b))
+  def unapply(g: G) = Some((g.a, g.b))
 }
  
 object H {
   def unapply(g: G) = g match {
-    case G(a, _) => Option(a)
+    case G(a, _) => Option.whenNonNull(a)
   }
 }

--- a/test/files/run/macro-system-properties.check
+++ b/test/files/run/macro-system-properties.check
@@ -4,7 +4,7 @@ import scala.language.experimental._
 import scala.reflect.macros.blackbox.Context
 
 scala>     object GrabContext {
-      def lastContext = Option(System.getProperties.get("lastContext").asInstanceOf[reflect.macros.runtime.Context])
+      def lastContext = Option.whenNonNull(System.getProperties.get("lastContext").asInstanceOf[reflect.macros.runtime.Context])
       // System.properties lets you stash true globals (unlike statics which are classloader scoped)
       def impl(c: Context)() = { import c.universe._; System.getProperties.put("lastContext", c); c.Expr[Unit](q"()") }
       def grab(): Unit = macro impl

--- a/test/files/run/macro-system-properties.scala
+++ b/test/files/run/macro-system-properties.scala
@@ -5,7 +5,7 @@ object Test extends ReplTest {
   def code = """
     import scala.language.experimental._, scala.reflect.macros.blackbox.Context
     object GrabContext {
-      def lastContext = Option(System.getProperties.get("lastContext").asInstanceOf[reflect.macros.runtime.Context])
+      def lastContext = Option.whenNonNull(System.getProperties.get("lastContext").asInstanceOf[reflect.macros.runtime.Context])
       // System.properties lets you stash true globals (unlike statics which are classloader scoped)
       def impl(c: Context)() = { import c.universe._; System.getProperties.put("lastContext", c); c.Expr[Unit](q"()") }
       def grab(): Unit = macro impl

--- a/test/files/run/programmatic-main.scala
+++ b/test/files/run/programmatic-main.scala
@@ -4,7 +4,7 @@ import scala.tools.nsc._
 import io.Path
 
 object Test {
-  val cwd = Option(System.getProperty("partest.cwd")) getOrElse "."
+  val cwd = Option.whenNonNull(System.getProperty("partest.cwd")) getOrElse "."
   val basedir = Path(cwd).parent / "lib" path
   val baseargs = Array("-usejavacp", "-bootclasspath", basedir + "/scala-library.jar", "-cp", basedir + "/scala-compiler.jar")
 

--- a/test/files/run/t3346e.scala
+++ b/test/files/run/t3346e.scala
@@ -69,7 +69,7 @@ object Test extends App {
   println("qwe".filterMap((c: Char) => Some(c)))
   println(Array(2, 0).filterMap((c: Int) => Some(c.toInt)).toList)
   println(Seq(2, 0).filterMap((c: Int) => if (c < 2) Some(s"$c!") else None))
-  def test(i:Int) = Option(i)
+  def test(i:Int) = Some(i)
   println(BitSet(2,0).filterMap(test))
 
   println(toFM2("qwe").filterMap2(c => Some(c)))

--- a/test/files/run/t4283/ScalaBipp.scala
+++ b/test/files/run/t4283/ScalaBipp.scala
@@ -1,5 +1,5 @@
 package test
 
 class ScalaBipp extends AbstractFoo {
-  def make: Option[ScalaBipp] = Option(this)
+  def make: Option[ScalaBipp] = Some(this)
 }

--- a/test/files/run/t4283b/ScalaBipp.scala
+++ b/test/files/run/t4283b/ScalaBipp.scala
@@ -1,5 +1,5 @@
 package test
 
 class ScalaBipp extends AbstractFoo {
-  def make: Option[ScalaBipp] = Option(this)
+  def make: Option[ScalaBipp] = Some(this)
 }

--- a/test/files/run/t6064.scala
+++ b/test/files/run/t6064.scala
@@ -1,9 +1,9 @@
 object Test extends App {
-  assert(Option(42) contains 42)
+  assert(Option.whenNonNull(42) contains 42)
   assert(Some(42) contains 42)
-  assert(Option(BigInt(42)) contains 42)
-  assert(Option(42) contains BigInt(42))
+  assert(Some(BigInt(42)) contains 42)
+  assert(Some(42) contains BigInt(42))
   assert(!(None contains 42))
   assert(Some(null) contains null)
-  assert(!(Option(null) contains null))
+  assert(!(Option.whenNonNull(null) contains null))
 }

--- a/test/files/run/t6663.scala
+++ b/test/files/run/t6663.scala
@@ -3,8 +3,8 @@
 import language.dynamics
 
 class C(v: Any) extends Dynamic {
-  def selectDynamic[T](n: String): Option[T] = Option(v.asInstanceOf[T])
-  def applyDynamic[T](n: String)(): Option[T] = Option(v.asInstanceOf[T])
+  def selectDynamic[T](n: String): Option[T] = Option.whenNonNull(v.asInstanceOf[T])
+  def applyDynamic[T](n: String)(): Option[T] = Option.whenNonNull(v.asInstanceOf[T])
 }
 
 object Test extends App {

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -285,7 +285,7 @@ class IterableTest {
     import scala.collection.{mutable => m, immutable => i}
     assertEquals(true, Some(1).hasDefiniteSize)
     assertEquals(true, None.hasDefiniteSize)
-    assertEquals(true, Option(1).hasDefiniteSize)
+    assertEquals(true, Option.whenNonNull(1).hasDefiniteSize)
     assertEquals(true, Array(1).hasDefiniteSize)
     assertEquals(true, "a".hasDefiniteSize)
     assertEquals(true, c.BitSet(1).hasDefiniteSize)

--- a/test/junit/scala/lang/primitives/BoxUnboxTest.scala
+++ b/test/junit/scala/lang/primitives/BoxUnboxTest.scala
@@ -93,7 +93,7 @@ class BoxUnboxTest extends RunTesting {
 
   @Test
   def boxUnboxBoolean(): Unit = {
-    val n1 = Option(null.asInstanceOf[Boolean])
+    val n1 = Option.whenNonNull(null.asInstanceOf[Boolean])
     assertEquals(n1, Some(false))
   }
 

--- a/test/junit/scala/tools/nsc/interpreter/ScriptedTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/ScriptedTest.scala
@@ -83,7 +83,7 @@ class ScriptedTest {
       |  s = scala.io.StdIn.readLine()
       |  val out = if ((i & 1) == 0) Console.out else Console.err
       |  i += 1
-      |  Option(s) foreach out.println
+      |  Option.whenNonNull(s) foreach out.println
       |} while (s != null)""".stripMargin
 
     ctx.setWriter(out)


### PR DESCRIPTION
Deprecate `Option.apply` and replace with `Option.whenNonNull`.

Inspired by a comment from @sjrd [here](https://contributors.scala-lang.org/t/sip-suggestion-add-and-syntactic-sugar-for-more-convenient-option-t-usage/2413/9), as well as other discussions elsewhere.