### PR TITLE
Replace Map[A,B] with Map[K,V]

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -160,7 +160,7 @@ object Predef extends LowPriorityImplicits {
   type Function[-A, +B] = Function1[A, B]
 
   /**  @group aliases */
-  type Map[A, +B] = immutable.Map[A, B]
+  type Map[K, +V] = immutable.Map[K, V]
   /**  @group aliases */
   type Set[A]     = immutable.Set[A]
   /**  @group aliases */

--- a/src/library/scala/collection/concurrent/Map.scala
+++ b/src/library/scala/collection/concurrent/Map.scala
@@ -22,8 +22,8 @@ package collection.concurrent
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#concurrent_maps "Scala's Collection Library overview"]]
   *  section on `Concurrent Maps` for more information.
   *
-  *  @tparam A  the key type of the map
-  *  @tparam B  the value type of the map
+  *  @tparam K  the key type of the map
+  *  @tparam V  the value type of the map
   *
   *  @define Coll `concurrent.Map`
   *  @define coll concurrent map
@@ -37,7 +37,7 @@ package collection.concurrent
   *  @define atomicop
   *  This is an atomic operation.
   */
-trait Map[A, B] extends scala.collection.mutable.Map[A, B] {
+trait Map[K, V] extends scala.collection.mutable.Map[K, V] {
 
   /**
     * Associates the given key with a given value, unless the key was already
@@ -51,7 +51,7 @@ trait Map[A, B] extends scala.collection.mutable.Map[A, B] {
     *            associated with the specified key, or `None` if there was no
     *            mapping for the specified key
     */
-  def putIfAbsent(k: A, v: B): Option[B]
+  def putIfAbsent(k: K, v: V): Option[V]
 
   /**
     * Removes the entry for the specified key if it's currently mapped to the
@@ -64,7 +64,7 @@ trait Map[A, B] extends scala.collection.mutable.Map[A, B] {
     *            the removal is to take place
     * @return    `true` if the removal took place, `false` otherwise
     */
-  def remove(k: A, v: B): Boolean
+  def remove(k: K, v: V): Boolean
 
   /**
     * Replaces the entry for the given key only if it was previously mapped to
@@ -78,7 +78,7 @@ trait Map[A, B] extends scala.collection.mutable.Map[A, B] {
     * @param newvalue  value to be associated with the specified key
     * @return          `true` if the entry was replaced, `false` otherwise
     */
-  def replace(k: A, oldvalue: B, newvalue: B): Boolean
+  def replace(k: K, oldvalue: V, newvalue: V): Boolean
 
   /**
     * Replaces the entry for the given key only if it was previously mapped
@@ -90,9 +90,9 @@ trait Map[A, B] extends scala.collection.mutable.Map[A, B] {
     * @param v   value to be associated with the specified key
     * @return    `Some(v)` if the given key was previously mapped to some value `v`, or `None` otherwise
     */
-  def replace(k: A, v: B): Option[B]
+  def replace(k: K, v: V): Option[V]
 
-  override def getOrElseUpdate(key: A, op: =>B): B = get(key) match {
+  override def getOrElseUpdate(key: K, op: =>V): V = get(key) match {
     case Some(v) => v
     case None =>
       val v = op

--- a/src/library/scala/collection/convert/AsJavaConverters.scala
+++ b/src/library/scala/collection/convert/AsJavaConverters.scala
@@ -200,9 +200,9 @@ trait AsJavaConverters {
    * @param m The Scala mutable `Map` to be converted.
    * @return  A Java `Map` view of the argument.
    */
-  def mutableMapAsJavaMap[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = m match {
+  def mutableMapAsJavaMap[K, V](m: mutable.Map[K, V]): ju.Map[K, V] = m match {
     case null                         => null
-    case w: JMapWrapper[A @uc, B @uc] => w.underlying
+    case w: JMapWrapper[K @uc, V @uc] => w.underlying
     case _                            => new MutableMapWrapper(m)
   }
 
@@ -220,7 +220,7 @@ trait AsJavaConverters {
    * @param m The Scala `Map` to be converted.
    * @return  A Java `Dictionary` view of the argument.
    */
-  def asJavaDictionary[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = m match {
+  def asJavaDictionary[K, V](m: mutable.Map[K, V]): ju.Dictionary[K, V] = m match {
     case null                         => null
     case JDictionaryWrapper(wrapped)  => wrapped
     case _                            => new DictionaryWrapper(m)
@@ -239,9 +239,9 @@ trait AsJavaConverters {
    * @param m The Scala `Map` to be converted.
    * @return  A Java `Map` view of the argument.
    */
-  def mapAsJavaMap[A, B](m: Map[A, B]): ju.Map[A, B] = m match {
+  def mapAsJavaMap[K, V](m: Map[K, V]): ju.Map[K, V] = m match {
     case null                         => null
-    case w: JMapWrapper[A @uc, B @uc] => w.underlying
+    case w: JMapWrapper[K @uc, V @uc] => w.underlying
     case _                            => new MapWrapper(m)
   }
 
@@ -259,7 +259,7 @@ trait AsJavaConverters {
    * @param m The Scala `concurrent.Map` to be converted.
    * @return  A Java `ConcurrentMap` view of the argument.
    */
-  def mapAsJavaConcurrentMap[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = m match {
+  def mapAsJavaConcurrentMap[K, V](m: concurrent.Map[K, V]): juc.ConcurrentMap[K, V] = m match {
     case null                           => null
     case JConcurrentMapWrapper(wrapped) => wrapped
     case _                              => new ConcurrentMapWrapper(m)

--- a/src/library/scala/collection/convert/DecorateAsJava.scala
+++ b/src/library/scala/collection/convert/DecorateAsJava.scala
@@ -87,27 +87,27 @@ trait DecorateAsJava extends AsJavaConverters {
    * Adds an `asJava` method that implicitly converts a Scala mutable `Map` to a Java `Map`.
    * @see [[mutableMapAsJavaMap]]
    */
-  implicit def mutableMapAsJavaMapConverter[A, B](m : mutable.Map[A, B]): AsJava[ju.Map[A, B]] =
+  implicit def mutableMapAsJavaMapConverter[K, V](m : mutable.Map[K, V]): AsJava[ju.Map[K, V]] =
     new AsJava(mutableMapAsJavaMap(m))
 
   /**
    * Adds an `asJavaDictionary` method that implicitly converts a Scala mutable `Map` to a Java `Dictionary`.
    * @see [[asJavaDictionary]]
    */
-  implicit def asJavaDictionaryConverter[A, B](m : mutable.Map[A, B]): AsJavaDictionary[A, B] =
+  implicit def asJavaDictionaryConverter[K, V](m : mutable.Map[K, V]): AsJavaDictionary[K, V] =
     new AsJavaDictionary(m)
 
   /**
    * Adds an `asJava` method that implicitly converts a Scala `Map` to a Java `Map`.
    * @see [[mapAsJavaMap]]
    */
-  implicit def mapAsJavaMapConverter[A, B](m : Map[A, B]): AsJava[ju.Map[A, B]] =
+  implicit def mapAsJavaMapConverter[K, V](m : Map[K, V]): AsJava[ju.Map[K, V]] =
     new AsJava(mapAsJavaMap(m))
 
   /**
    * Adds an `asJava` method that implicitly converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
    * @see [[mapAsJavaConcurrentMap]].
    */
-  implicit def mapAsJavaConcurrentMapConverter[A, B](m: concurrent.Map[A, B]): AsJava[juc.ConcurrentMap[A, B]] =
+  implicit def mapAsJavaConcurrentMapConverter[K, V](m: concurrent.Map[K, V]): AsJava[juc.ConcurrentMap[K, V]] =
     new AsJava(mapAsJavaConcurrentMap(m))
 }

--- a/src/library/scala/collection/convert/DecorateAsScala.scala
+++ b/src/library/scala/collection/convert/DecorateAsScala.scala
@@ -66,21 +66,21 @@ trait DecorateAsScala extends AsScalaConverters {
    * Adds an `asScala` method that implicitly converts a Java `Map` to a Scala mutable `Map`.
    * @see [[mapAsScalaMap]]
    */
-  implicit def mapAsScalaMapConverter[A, B](m : ju.Map[A, B]): AsScala[mutable.Map[A, B]] =
+  implicit def mapAsScalaMapConverter[K, V](m : ju.Map[K, V]): AsScala[mutable.Map[K, V]] =
     new AsScala(mapAsScalaMap(m))
 
   /**
    * Adds an `asScala` method that implicitly converts a Java `ConcurrentMap` to a Scala mutable `concurrent.Map`.
    * @see [[mapAsScalaConcurrentMap]]
    */
-  implicit def mapAsScalaConcurrentMapConverter[A, B](m: juc.ConcurrentMap[A, B]): AsScala[concurrent.Map[A, B]] =
+  implicit def mapAsScalaConcurrentMapConverter[K, V](m: juc.ConcurrentMap[K, V]): AsScala[concurrent.Map[K, V]] =
     new AsScala(mapAsScalaConcurrentMap(m))
 
   /**
    * Adds an `asScala` method that implicitly converts a Java `Dictionary` to a Scala mutable `Map`.
    * @see [[dictionaryAsScalaMap]]
    */
-  implicit def dictionaryAsScalaMapConverter[A, B](p: ju.Dictionary[A, B]): AsScala[mutable.Map[A, B]] =
+  implicit def dictionaryAsScalaMapConverter[K, V](p: ju.Dictionary[K, V]): AsScala[mutable.Map[K, V]] =
     new AsScala(dictionaryAsScalaMap(p))
 
   /**

--- a/src/library/scala/collection/convert/Decorators.scala
+++ b/src/library/scala/collection/convert/Decorators.scala
@@ -42,8 +42,8 @@ private[collection] object Decorators {
   }
 
   /** Generic class containing the `asJavaDictionary` converter method */
-  class AsJavaDictionary[A, B](m : mutable.Map[A, B]) {
+  class AsJavaDictionary[K, V](m : mutable.Map[K, V]) {
     /** Converts a Scala `Map` to a Java `Dictionary` */
-    def asJavaDictionary: ju.Dictionary[A, B] = JavaConverters.asJavaDictionary(m)
+    def asJavaDictionary: ju.Dictionary[K, V] = JavaConverters.asJavaDictionary(m)
   }
 }

--- a/src/library/scala/collection/convert/ImplicitConversions.scala
+++ b/src/library/scala/collection/convert/ImplicitConversions.scala
@@ -54,17 +54,17 @@ trait ToScalaImplicits {
   /** Implicitly converts a Java `Map` to a Scala mutable `Map`.
    *  @see [[AsScalaConverters.mapAsScalaMap]]
    */
-  implicit def `map AsScala`[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = mapAsScalaMap(m)
+  implicit def `map AsScala`[K, V](m: ju.Map[K, V]): mutable.Map[K, V] = mapAsScalaMap(m)
 
   /** Implicitly converts a Java `ConcurrentMap` to a Scala mutable `ConcurrentMap`.
    *  @see [[AsScalaConverters.mapAsScalaConcurrentMap]]
    */
-  implicit def `map AsScalaConcurrentMap`[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = mapAsScalaConcurrentMap(m)
+  implicit def `map AsScalaConcurrentMap`[K, V](m: juc.ConcurrentMap[K, V]): concurrent.Map[K, V] = mapAsScalaConcurrentMap(m)
 
   /** Implicitly converts a Java `Dictionary` to a Scala mutable `Map`.
    *  @see [[AsScalaConverters.dictionaryAsScalaMap]]
    */
-  implicit def `dictionary AsScalaMap`[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = dictionaryAsScalaMap(p)
+  implicit def `dictionary AsScalaMap`[K, V](p: ju.Dictionary[K, V]): mutable.Map[K, V] = dictionaryAsScalaMap(p)
 
   /** Implicitly converts a Java `Properties` to a Scala `mutable Map[String, String]`.
    *  @see [[AsScalaConverters.propertiesAsScalaMap]]
@@ -122,22 +122,22 @@ trait ToJavaImplicits {
   /** Implicitly converts a Scala mutable `Map` to a Java `Map`.
    *  @see [[AsJavaConverters.mutableMapAsJavaMap]]
    */
-  implicit def `mutableMap AsJavaMap`[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = mutableMapAsJavaMap(m)
+  implicit def `mutableMap AsJavaMap`[K, V](m: mutable.Map[K, V]): ju.Map[K, V] = mutableMapAsJavaMap(m)
 
   /** Implicitly converts a Scala mutable `Map` to a Java `Dictionary`.
    *  @see [[AsJavaConverters.asJavaDictionary]]
    */
-  implicit def `dictionary asJava`[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = asJavaDictionary(m)
+  implicit def `dictionary asJava`[K, V](m: mutable.Map[K, V]): ju.Dictionary[K, V] = asJavaDictionary(m)
 
   /** Implicitly converts a Scala `Map` to a Java `Map`.
    *  @see [[AsJavaConverters.mapAsJavaMap]]
    */
-  implicit def `map AsJavaMap`[A, B](m: Map[A, B]): ju.Map[A, B] = mapAsJavaMap(m)
+  implicit def `map AsJavaMap`[K, V](m: Map[K, V]): ju.Map[K, V] = mapAsJavaMap(m)
 
   /** Implicitly converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
    *  @see [[AsJavaConverters.mapAsJavaConcurrentMap]]
    */
-  implicit def `map AsJavaConcurrentMap`[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = mapAsJavaConcurrentMap(m)
+  implicit def `map AsJavaConcurrentMap`[K, V](m: concurrent.Map[K, V]): juc.ConcurrentMap[K, V] = mapAsJavaConcurrentMap(m)
 }
 
 /**

--- a/src/library/scala/collection/convert/WrapAsJava.scala
+++ b/src/library/scala/collection/convert/WrapAsJava.scala
@@ -32,10 +32,10 @@ trait WrapAsJava extends LowPriorityWrapAsJava {
   implicit def `deprecated seqAsJavaList`[A](seq: Seq[A]): ju.List[A] = seqAsJavaList(seq)
   implicit def `deprecated mutableSetAsJavaSet`[A](s: mutable.Set[A]): ju.Set[A] = mutableSetAsJavaSet(s)
   implicit def `deprecated setAsJavaSet`[A](s: Set[A]): ju.Set[A] = setAsJavaSet(s)
-  implicit def `deprecated mutableMapAsJavaMap`[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = mutableMapAsJavaMap(m)
-  implicit def `deprecated asJavaDictionary`[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = asJavaDictionary(m)
-  implicit def `deprecated mapAsJavaMap`[A, B](m: Map[A, B]): ju.Map[A, B] = mapAsJavaMap(m)
-  implicit def `deprecated mapAsJavaConcurrentMap`[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = mapAsJavaConcurrentMap(m)
+  implicit def `deprecated mutableMapAsJavaMap`[K, V](m: mutable.Map[K, V]): ju.Map[K, V] = mutableMapAsJavaMap(m)
+  implicit def `deprecated asJavaDictionary`[K, V](m: mutable.Map[K, V]): ju.Dictionary[K, V] = asJavaDictionary(m)
+  implicit def `deprecated mapAsJavaMap`[K, V](m: Map[K, V]): ju.Map[K, V] = mapAsJavaMap(m)
+  implicit def `deprecated mapAsJavaConcurrentMap`[K, V](m: concurrent.Map[K, V]): juc.ConcurrentMap[K, V] = mapAsJavaConcurrentMap(m)
 }
 
 private[convert] trait LowPriorityWrapAsJava {
@@ -223,9 +223,9 @@ private[convert] trait LowPriorityWrapAsJava {
    * @param m The Map to be converted.
    * @return A Java Map view of the argument.
    */
-  implicit def mutableMapAsJavaMap[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = m match {
+  implicit def mutableMapAsJavaMap[K, V](m: mutable.Map[K, V]): ju.Map[K, V] = m match {
     case null                         => null
-    case w: JMapWrapper[A @uc, B @uc] => w.underlying
+    case w: JMapWrapper[K @uc, V @uc] => w.underlying
     case _                            => new MutableMapWrapper(m)
   }
 
@@ -243,7 +243,7 @@ private[convert] trait LowPriorityWrapAsJava {
    * @param m The `Map` to be converted.
    * @return A Java `Dictionary` view of the argument.
    */
-  implicit def asJavaDictionary[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = m match {
+  implicit def asJavaDictionary[K, V](m: mutable.Map[K, V]): ju.Dictionary[K, V] = m match {
     case null                         => null
     case JDictionaryWrapper(wrapped)  => wrapped
     case _                            => new DictionaryWrapper(m)
@@ -263,9 +263,9 @@ private[convert] trait LowPriorityWrapAsJava {
    * @param m The `Map` to be converted.
    * @return A Java `Map` view of the argument.
    */
-  implicit def mapAsJavaMap[A, B](m: Map[A, B]): ju.Map[A, B] = m match {
+  implicit def mapAsJavaMap[K, V](m: Map[K, V]): ju.Map[K, V] = m match {
     case null                         => null
-    case w: JMapWrapper[A @uc, B @uc] => w.underlying
+    case w: JMapWrapper[K @uc, V @uc] => w.underlying
     case _                            => new MapWrapper(m)
   }
 
@@ -284,7 +284,7 @@ private[convert] trait LowPriorityWrapAsJava {
    * @param m The Scala `concurrent.Map` to be converted.
    * @return A Java `ConcurrentMap` view of the argument.
    */
-  implicit def mapAsJavaConcurrentMap[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = m match {
+  implicit def mapAsJavaConcurrentMap[K, V](m: concurrent.Map[K, V]): juc.ConcurrentMap[K, V] = m match {
     case null                           => null
     case JConcurrentMapWrapper(wrapped) => wrapped
     case _                              => new ConcurrentMapWrapper(m)

--- a/src/library/scala/collection/convert/WrapAsScala.scala
+++ b/src/library/scala/collection/convert/WrapAsScala.scala
@@ -28,9 +28,9 @@ trait WrapAsScala extends LowPriorityWrapAsScala {
   implicit def `deprecated collectionAsScalaIterable`[A](i: ju.Collection[A]): Iterable[A] = collectionAsScalaIterable(i)
   implicit def `deprecated asScalaBuffer`[A](l: ju.List[A]): mutable.Buffer[A] = asScalaBuffer(l)
   implicit def `deprecated asScalaSet`[A](s: ju.Set[A]): mutable.Set[A] = asScalaSet(s)
-  implicit def `deprecated mapAsScalaMap`[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = mapAsScalaMap(m)
-  implicit def `deprecated mapAsScalaConcurrentMap`[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = mapAsScalaConcurrentMap(m)
-  implicit def `deprecated dictionaryAsScalaMap`[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = dictionaryAsScalaMap(p)
+  implicit def `deprecated mapAsScalaMap`[K, V](m: ju.Map[K, V]): mutable.Map[K, V] = mapAsScalaMap(m)
+  implicit def `deprecated mapAsScalaConcurrentMap`[K, V](m: juc.ConcurrentMap[K, V]): concurrent.Map[K, V] = mapAsScalaConcurrentMap(m)
+  implicit def `deprecated dictionaryAsScalaMap`[K, V](p: ju.Dictionary[K, V]): mutable.Map[K, V] = dictionaryAsScalaMap(p)
   implicit def `deprecated propertiesAsScalaMap`(p: ju.Properties): mutable.Map[String, String] = propertiesAsScalaMap(p)
 }
 
@@ -171,7 +171,7 @@ private[convert] trait LowPriorityWrapAsScala {
    * @param m The Map to be converted.
    * @return A Scala mutable Map view of the argument.
    */
-  implicit def mapAsScalaMap[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = m match {
+  implicit def mapAsScalaMap[K, V](m: ju.Map[K, V]): mutable.Map[K, V] = m match {
     case null                       => null
     case MutableMapWrapper(wrapped) => wrapped
     case _                          => new JMapWrapper(m)
@@ -190,7 +190,7 @@ private[convert] trait LowPriorityWrapAsScala {
    * @param m The ConcurrentMap to be converted.
    * @return A Scala mutable ConcurrentMap view of the argument.
    */
-  implicit def mapAsScalaConcurrentMap[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = m match {
+  implicit def mapAsScalaConcurrentMap[K, V](m: juc.ConcurrentMap[K, V]): concurrent.Map[K, V] = m match {
     case null                             => null
     case cmw: ConcurrentMapWrapper[_, _]  => cmw.underlying
     case _                                => new JConcurrentMapWrapper(m)
@@ -207,7 +207,7 @@ private[convert] trait LowPriorityWrapAsScala {
    * @param p The Dictionary to be converted.
    * @return  A Scala mutable Map view of the argument.
    */
-  implicit def dictionaryAsScalaMap[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = p match {
+  implicit def dictionaryAsScalaMap[K, V](p: ju.Dictionary[K, V]): mutable.Map[K, V] = p match {
     case null                       => null
     case DictionaryWrapper(wrapped) => wrapped
     case _                          => new JDictionaryWrapper(p)

--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -217,34 +217,34 @@ private[collection] trait Wrappers {
   }
 
   @SerialVersionUID(3L)
-  class MapWrapper[A, B](underlying: Map[A, B]) extends ju.AbstractMap[A, B] with Serializable { self =>
+  class MapWrapper[K, V](underlying: Map[K, V]) extends ju.AbstractMap[K, V] with Serializable { self =>
     override def size = underlying.size
 
-    override def get(key: AnyRef): B = try {
-      underlying get key.asInstanceOf[A] match {
-        case None => null.asInstanceOf[B]
+    override def get(key: AnyRef): V = try {
+      underlying get key.asInstanceOf[K] match {
+        case None => null.asInstanceOf[V]
         case Some(v) => v
       }
     } catch {
-      case ex: ClassCastException => null.asInstanceOf[B]
+      case ex: ClassCastException => null.asInstanceOf[V]
     }
 
-    override def entrySet: ju.Set[ju.Map.Entry[A, B]] = new ju.AbstractSet[ju.Map.Entry[A, B]] {
+    override def entrySet: ju.Set[ju.Map.Entry[K, V]] = new ju.AbstractSet[ju.Map.Entry[K, V]] {
       def size = self.size
 
-      def iterator = new ju.Iterator[ju.Map.Entry[A, B]] {
+      def iterator = new ju.Iterator[ju.Map.Entry[K, V]] {
         val ui = underlying.iterator
-        var prev : Option[A] = None
+        var prev : Option[K] = None
 
         def hasNext = ui.hasNext
 
         def next() = {
           val (k, v) = ui.next()
           prev = Some(k)
-          new ju.Map.Entry[A, B] {
+          new ju.Map.Entry[K, V] {
             def getKey = k
             def getValue = v
-            def setValue(v1 : B) = self.put(k, v1)
+            def setValue(v1 : V) = self.put(k, v1)
             
             // It's important that this implementation conform to the contract
             // specified in the javadocs of java.util.Map.Entry.hashCode
@@ -283,26 +283,26 @@ private[collection] trait Wrappers {
       // Note: Subclass of collection.Map with specific key type may redirect generic
       // contains to specific contains, which will throw a ClassCastException if the
       // wrong type is passed. This is why we need a type cast to A inside a try/catch.
-      underlying.contains(key.asInstanceOf[A])
+      underlying.contains(key.asInstanceOf[K])
     } catch {
       case ex: ClassCastException => false
     }
   }
 
   @SerialVersionUID(3L)
-  case class MutableMapWrapper[A, B](underlying: mutable.Map[A, B]) extends MapWrapper[A, B](underlying) {
-    override def put(k: A, v: B) = underlying.put(k, v) match {
+  case class MutableMapWrapper[K, V](underlying: mutable.Map[K, V]) extends MapWrapper[K, V](underlying) {
+    override def put(k: K, v: V) = underlying.put(k, v) match {
       case Some(v1) => v1
-      case None => null.asInstanceOf[B]
+      case None => null.asInstanceOf[V]
     }
 
-    override def remove(k: AnyRef): B = try {
-      underlying remove k.asInstanceOf[A] match {
-        case None => null.asInstanceOf[B]
+    override def remove(k: AnyRef): V = try {
+      underlying remove k.asInstanceOf[K] match {
+        case None => null.asInstanceOf[V]
         case Some(v) => v
       }
     } catch {
-      case ex: ClassCastException => null.asInstanceOf[B]
+      case ex: ClassCastException => null.asInstanceOf[V]
     }
 
     override def clear() = underlying.clear()
@@ -357,35 +357,35 @@ private[collection] trait Wrappers {
     * atomic `get` when `null` values may be present.
     */
   @SerialVersionUID(3L)
-  class JMapWrapper[A, B](val underlying : ju.Map[A, B])
-    extends AbstractJMapWrapper[A, B] {
+  class JMapWrapper[K, V](val underlying : ju.Map[K, V])
+    extends AbstractJMapWrapper[K, V] {
 
     override def isEmpty: Boolean = underlying.isEmpty
     override def knownSize: Int = if (underlying.isEmpty) 0 else super.knownSize
-    override def empty = new JMapWrapper(new ju.HashMap[A, B])
+    override def empty = new JMapWrapper(new ju.HashMap[K, V])
   }
 
   @SerialVersionUID(3L)
-  class ConcurrentMapWrapper[A, B](override val underlying: concurrent.Map[A, B]) extends MutableMapWrapper[A, B](underlying) with juc.ConcurrentMap[A, B] {
+  class ConcurrentMapWrapper[K, V](override val underlying: concurrent.Map[K, V]) extends MutableMapWrapper[K, V](underlying) with juc.ConcurrentMap[K, V] {
 
-    override def putIfAbsent(k: A, v: B) = underlying.putIfAbsent(k, v) match {
+    override def putIfAbsent(k: K, v: V) = underlying.putIfAbsent(k, v) match {
       case Some(v) => v
-      case None => null.asInstanceOf[B]
+      case None => null.asInstanceOf[V]
     }
 
     override def remove(k: AnyRef, v: AnyRef) = try {
-      underlying.remove(k.asInstanceOf[A], v.asInstanceOf[B])
+      underlying.remove(k.asInstanceOf[K], v.asInstanceOf[V])
     } catch {
       case ex: ClassCastException =>
         false
     }
 
-    override def replace(k: A, v: B): B = underlying.replace(k, v) match {
+    override def replace(k: K, v: V): V = underlying.replace(k, v) match {
       case Some(v) => v
-      case None => null.asInstanceOf[B]
+      case None => null.asInstanceOf[V]
     }
 
-    override def replace(k: A, oldval: B, newval: B) = underlying.replace(k, oldval, newval)
+    override def replace(k: K, oldval: V, newval: V) = underlying.replace(k, oldval, newval)
   }
 
   /** Wraps a concurrent Java map as a Scala one.  Single-element concurrent
@@ -393,70 +393,70 @@ private[collection] trait Wrappers {
     * are not guaranteed to be atomic.
     */
   @SerialVersionUID(3L)
-  case class JConcurrentMapWrapper[A, B](underlying: juc.ConcurrentMap[A, B])
-    extends AbstractJMapWrapper[A, B]
-      with concurrent.Map[A, B] {
+  case class JConcurrentMapWrapper[K, V](underlying: juc.ConcurrentMap[K, V])
+    extends AbstractJMapWrapper[K, V]
+      with concurrent.Map[K, V] {
 
-    override def get(k: A) = Option(underlying get k)
+    override def get(k: K) = Option(underlying get k)
 
     override def isEmpty: Boolean = underlying.isEmpty
     override def knownSize: Int = if (underlying.isEmpty) 0 else super.knownSize
-    override def empty = new JConcurrentMapWrapper(new juc.ConcurrentHashMap[A, B])
+    override def empty = new JConcurrentMapWrapper(new juc.ConcurrentHashMap[K, V])
 
-    def putIfAbsent(k: A, v: B): Option[B] = Option(underlying.putIfAbsent(k, v))
+    def putIfAbsent(k: K, v: V): Option[V] = Option(underlying.putIfAbsent(k, v))
 
-    def remove(k: A, v: B): Boolean = underlying.remove(k, v)
+    def remove(k: K, v: V): Boolean = underlying.remove(k, v)
 
-    def replace(k: A, v: B): Option[B] = Option(underlying.replace(k, v))
+    def replace(k: K, v: V): Option[V] = Option(underlying.replace(k, v))
 
-    def replace(k: A, oldvalue: B, newvalue: B): Boolean =
+    def replace(k: K, oldvalue: V, newvalue: V): Boolean =
       underlying.replace(k, oldvalue, newvalue)
   }
 
   @SerialVersionUID(3L)
-  case class DictionaryWrapper[A, B](underlying: mutable.Map[A, B]) extends ju.Dictionary[A, B] {
+  case class DictionaryWrapper[K, V](underlying: mutable.Map[K, V]) extends ju.Dictionary[K, V] {
     def size: Int = underlying.size
     def isEmpty: Boolean = underlying.isEmpty
-    def keys: ju.Enumeration[A] = asJavaEnumeration(underlying.keysIterator)
-    def elements: ju.Enumeration[B] = asJavaEnumeration(underlying.valuesIterator)
+    def keys: ju.Enumeration[K] = asJavaEnumeration(underlying.keysIterator)
+    def elements: ju.Enumeration[V] = asJavaEnumeration(underlying.valuesIterator)
     def get(key: AnyRef) = try {
-      underlying get key.asInstanceOf[A] match {
-        case None => null.asInstanceOf[B]
+      underlying get key.asInstanceOf[K] match {
+        case None => null.asInstanceOf[V]
         case Some(v) => v
       }
     } catch {
-      case ex: ClassCastException => null.asInstanceOf[B]
+      case ex: ClassCastException => null.asInstanceOf[V]
     }
-    def put(key: A, value: B): B = underlying.put(key, value) match {
+    def put(key: K, value: V): V = underlying.put(key, value) match {
       case Some(v) => v
-      case None => null.asInstanceOf[B]
+      case None => null.asInstanceOf[V]
     }
     override def remove(key: AnyRef) = try {
-      underlying remove key.asInstanceOf[A] match {
-        case None => null.asInstanceOf[B]
+      underlying remove key.asInstanceOf[K] match {
+        case None => null.asInstanceOf[V]
         case Some(v) => v
       }
     } catch {
-      case ex: ClassCastException => null.asInstanceOf[B]
+      case ex: ClassCastException => null.asInstanceOf[V]
     }
   }
 
   @SerialVersionUID(3L)
-  case class JDictionaryWrapper[A, B](underlying: ju.Dictionary[A, B]) extends mutable.AbstractMap[A, B] {
+  case class JDictionaryWrapper[K, V](underlying: ju.Dictionary[K, V]) extends mutable.AbstractMap[K, V] {
     override def size: Int = underlying.size
     override def isEmpty: Boolean = underlying.isEmpty
     override def knownSize: Int = if (underlying.isEmpty) 0 else super.knownSize
 
-    def get(k: A) = Option(underlying get k)
+    def get(k: K) = Option(underlying get k)
 
-    def addOne(kv: (A, B)): this.type = { underlying.put(kv._1, kv._2); this }
-    def subtractOne(key: A): this.type = { underlying remove key; this }
+    def addOne(kv: (K, V)): this.type = { underlying.put(kv._1, kv._2); this }
+    def subtractOne(key: K): this.type = { underlying remove key; this }
 
-    override def put(k: A, v: B): Option[B] = Option(underlying.put(k, v))
+    override def put(k: K, v: V): Option[V] = Option(underlying.put(k, v))
 
-    override def update(k: A, v: B): Unit = { underlying.put(k, v) }
+    override def update(k: K, v: V): Unit = { underlying.put(k, v) }
 
-    override def remove(k: A): Option[B] = Option(underlying remove k)
+    override def remove(k: K): Option[V] = Option(underlying remove k)
     def iterator = enumerationAsScalaIterator(underlying.keys) map (k => (k, underlying get k))
 
     override def clear() = iterator.foreach(entry => underlying.remove(entry._1))

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -22,7 +22,7 @@ package mutable
 @SerialVersionUID(3L)
 object LinkedHashMap extends MapFactory[LinkedHashMap] {
 
-  def empty[A, B] = new LinkedHashMap[A, B]
+  def empty[K, V] = new LinkedHashMap[K, V]
 
   def from[K, V](it: collection.IterableOnce[(K, V)]) =
     it match {

--- a/src/library/scala/collection/mutable/MultiMap.scala
+++ b/src/library/scala/collection/mutable/MultiMap.scala
@@ -15,8 +15,8 @@ package scala.collection.mutable
 
 /** A trait for mutable maps with multiple values assigned to a key.
   *
-  *  This class is typically used as a mixin. It turns maps which map `A`
-  *  to `Set[B]` objects into multimaps that map `A` to `B` objects.
+  *  This class is typically used as a mixin. It turns maps which map `K`
+  *  to `Set[V]` objects into multimaps that map `K` to `V` objects.
   *
   *  @example {{{
   *  // first import all necessary types from package `collection.mutable`
@@ -53,16 +53,16 @@ package scala.collection.mutable
   *  @author  Martin Odersky
   *  @since   1
   */
-trait MultiMap[A, B] extends Map[A, Set[B]] {
+trait MultiMap[K, V] extends Map[K, Set[V]] {
   /** Creates a new set.
     *
     *  Classes that use this trait as a mixin can override this method
     *  to have the desired implementation of sets assigned to new keys.
     *  By default this is `HashSet`.
     *
-    *  @return An empty set of values of type `B`.
+    *  @return An empty set of values of type `V`.
     */
-  protected def makeSet: Set[B] = new HashSet[B]
+  protected def makeSet: Set[V] = new HashSet[V]
 
   /** Assigns the specified `value` to a specified `key`.  If the key
     *  already has a binding to equal to `value`, nothing is changed;
@@ -72,7 +72,7 @@ trait MultiMap[A, B] extends Map[A, Set[B]] {
     *  @param value  The value to bind to the key.
     *  @return       A reference to this multimap.
     */
-  def addBinding(key: A, value: B): this.type = {
+  def addBinding(key: K, value: V): this.type = {
     get(key) match {
       case None =>
         val set = makeSet
@@ -94,7 +94,7 @@ trait MultiMap[A, B] extends Map[A, Set[B]] {
     *  @param value   The value to remove.
     *  @return        A reference to this multimap.
     */
-  def removeBinding(key: A, value: B): this.type = {
+  def removeBinding(key: K, value: V): this.type = {
     get(key) match {
       case None =>
       case Some(set) =>
@@ -110,7 +110,7 @@ trait MultiMap[A, B] extends Map[A, Set[B]] {
     *  @param p     The predicate which a value assigned to the key must satisfy.
     *  @return      A boolean if such a binding exists
     */
-  def entryExists(key: A, p: B => Boolean): Boolean = get(key) match {
+  def entryExists(key: K, p: V => Boolean): Boolean = get(key) match {
     case None => false
     case Some(set) => set exists p
   }

--- a/src/library/scala/collection/mutable/WeakHashMap.scala
+++ b/src/library/scala/collection/mutable/WeakHashMap.scala
@@ -20,8 +20,8 @@ import convert.Wrappers._
  *  removed from this map when the key is no longer (strongly) referenced. This class wraps
  *  `java.util.WeakHashMap`.
  *
- *  @tparam A      type of keys contained in this map
- *  @tparam B      type of values associated with the keys
+ *  @tparam K      type of keys contained in this map
+ *  @tparam V      type of values associated with the keys
  *
  *  @since 2.8
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#weak-hash-maps "Scala's Collection Library overview"]]
@@ -32,9 +32,9 @@ import convert.Wrappers._
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
-class WeakHashMap[A, B] extends JMapWrapper[A, B](new java.util.WeakHashMap)
-    with JMapWrapperLike[A, B, WeakHashMap, WeakHashMap[A, B]] {
-  override def empty = new WeakHashMap[A, B]
+class WeakHashMap[K, V] extends JMapWrapper[K, V](new java.util.WeakHashMap)
+    with JMapWrapperLike[K, V, WeakHashMap, WeakHashMap[K, V]] {
+  override def empty = new WeakHashMap[K, V]
   override def mapFactory: MapFactory[WeakHashMap] = WeakHashMap
   override protected[this] def stringPrefix = "WeakHashMap"
 }

--- a/src/library/scala/reflect/ClassManifestDeprecatedApis.scala
+++ b/src/library/scala/reflect/ClassManifestDeprecatedApis.scala
@@ -63,8 +63,8 @@ trait ClassManifestDeprecatedApis[T] extends OptManifest[T] {
     //   List[String] <: AnyRef
     //   Map[Int, Int] <: Iterable[(Int, Int)]
     //
-    // Given the manifest for Map[A, B] how do I determine that a
-    // supertype has single type argument (A, B) ? I don't see how we
+    // Given the manifest for Map[K, V] how do I determine that a
+    // supertype has single type argument (K, V) ? I don't see how we
     // can say whether X <:< Y when type arguments are involved except
     // when the erasure is the same, even before considering variance.
     !cannotMatch && {

--- a/test/files/neg/found-req-variance.check
+++ b/test/files/neg/found-req-variance.check
@@ -178,7 +178,7 @@ You may wish to define T2 as +T2 instead. (SLS 4.5)
 found-req-variance.scala:105: error: type mismatch;
  found   : scala.collection.immutable.Map[AnyRef,String]
  required: Map[String,String]
-Note: AnyRef >: String, but trait Map is invariant in type A.
+Note: AnyRef >: String, but trait Map is invariant in type K.
 You may wish to investigate a wildcard type such as `_ >: String`. (SLS 3.2.10)
   def g2 = Set[Map[String, String]]() + Map[AnyRef, String]()
                                                            ^


### PR DESCRIPTION
Accomplished by searching for 'Map[A' (and 'MapOps[A',
which yielded no results). This method may have
missed some instances.

View.Map[A,B] and similar were skipped, because they
refer to mapping operations, not map collections.

I did not change test files, as none of them are part of any
public API.