### PR TITLE
Infer function parameter types from partially eta-expanded methods (backport  #7316 and #7333)

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -438,11 +438,6 @@ trait ContextErrors {
         setError(fun)
       }
 
-      def WrongNumberOfParametersError(tree: Tree, argpts: List[Type]) = {
-        issueNormalTypeError(tree, "wrong number of parameters; expected = " + argpts.length)
-        setError(tree)
-      }
-
       def MissingParameterTypeError(fun: Tree, vparam: ValDef, pt: Type, withTupleAddendum: Boolean) = {
         def issue(what: String) = {
           val addendum: String = fun match {

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3080,13 +3080,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               if (!vd.tpt.isEmpty) Right(vd.tpt.tpe)
               else Left(args.indexWhere {
                 case Ident(name) => name == vd.name
-                case _           => false // TODO: i think we need to deal with widening conversions too??
+                case _           => false // TODO: this does not catch eta-expansion of an overloaded method that involves numeric widening scala/bug#9738 (and maybe similar patterns?)
               })
             }
 
           // If some of the vparams without type annotation was not applied to `meth`,
           // we're not going to learn enough from typing `meth` to determine them.
-          if (formalsFromApply.exists{ case Left(-1) => true case _ => false }) EmptyTree
+          if (formalsFromApply.contains(Left(-1))) EmptyTree
           else {
             // We're looking for a method (as indicated by FUNmode in the silent typed below),
             // so let's make sure our expected type is a MethodType (of the right arity, but we can't easily say more about the argument types)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2985,7 +2985,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case _                                       => (vparams map (if (pt == ErrorType) (_ => ErrorType) else (_ => NoType)), WildcardType)
         }
 
-      if (!FunctionSymbol.exists) MaxFunctionArityError(fun)
+      // After typer, no need for further checks, parameter type inference or PartialFunction synthesis.
+      if (isPastTyper) doTypedFunction(fun, resProto)
+      else if (!FunctionSymbol.exists) MaxFunctionArityError(fun)
       else if (argProtos.lengthCompare(numVparams) != 0) WrongNumberOfParametersError(fun, argProtos)
       else {
         val paramsMissingType = mutable.ArrayBuffer.empty[ValDef] //.sizeHint(numVparams) probably useless, since initial size is 16 and max fun arity is 22
@@ -3000,20 +3002,20 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           }
         }
 
-        val ptUnrollingEtaExpansion =
-          if (paramsMissingType.isEmpty || pt == ErrorType) null
-          else typedFunctionInferParamTypes(fun, mode, pt, argProtos, resProto)
+        if (paramsMissingType.nonEmpty && pt != ErrorType) {
+          // If we can resolve the missing parameter type by undoing eta-expansion and recursing, do that -- otherwise, report error and bail
+          typedFunctionUndoingEtaExpansion(fun, mode, pt, argProtos, resProto) orElse {
+            // we ran out of things to try, missing parameter types are an irrevocable error
+            var issuedMissingParameterTypeError = false
+            paramsMissingType.foreach { vparam =>
+              vparam.tpt setType ErrorType
+              MissingParameterTypeError(fun, vparam, pt, withTupleAddendum = !issuedMissingParameterTypeError)
+              issuedMissingParameterTypeError = true
+            }
 
-        if (ptUnrollingEtaExpansion ne null) typedFunction(fun, mode, ptUnrollingEtaExpansion)
-        else {
-          // we ran out of things to try, missing parameter types are an irrevocable error
-          var issuedMissingParameterTypeError = false
-          paramsMissingType.foreach { vparam =>
-            vparam.tpt setType ErrorType
-            MissingParameterTypeError(fun, vparam, pt, withTupleAddendum = !issuedMissingParameterTypeError)
-            issuedMissingParameterTypeError = true
+            doTypedFunction(fun, resProto) // TODO: why is it not enough to do setError(fun)?  (for test case, see neg/t8675b.scala)
           }
-
+        } else {
           fun.body match {
             // translate `x => x match { <cases> }` : PartialFunction to
             // `new PartialFunction { def applyOrElse(x, default) = x match { <cases> } def isDefinedAt(x) = ... }`
@@ -3027,25 +3029,33 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
               outerTyper.synthesizePartialFunction(p.name, p.pos, paramSynthetic = false, fun.body, mode, pt)
 
-            case _ =>
-              doTypedFunction(fun, resProto)
+            case _ => doTypedFunction(fun, resProto)
           }
         }
       }
     }
 
-    private def typedFunctionInferParamTypes(fun: Function, mode: Mode, pt: Type, argProtos: List[Type], resProto: Type) = {
+    /** Retry typedFunction when parameter types are missing, and they might be recovered from
+      * the method selection that was eta-expanded into `fun`.
+      *
+      * When typing `(a1: T1, ..., aN: TN) => m(a1,..., aN)`, where some Ti are not fully defined,
+      * type `m` directly (undoing eta-expansion of method m) to determine the argument types.
+      * We have to be careful to use the result of typing the method selection, as its tree
+      * may be rewritten.
+      *
+      * This tree is the result from one of:
+      *   - manual eta-expansion with named arguments (x => f(x));
+      *   - wildcard-style eta expansion (`m(_, _,)`);
+      *   - (I don't think it can result from etaExpand, because we know the argument types there.)
+      *
+      * Note that method values are a separate thing (`m _`): they have the idiosyncratic shape
+      * of `Typed(expr, Function(Nil, EmptyTree))`
+      *
+      * @return EmptyTree on failure, or a typed version of `fun` if we are successful
+      */
+    private def typedFunctionUndoingEtaExpansion(fun: Function, mode: Mode, pt: Type, argProtos: List[Type], resProto: Type) = {
       val vparams = fun.vparams
 
-      // If we're typing `(a1: T1, ..., aN: TN) => m(a1,..., aN)`, where some Ti are not fully defined,
-      // type `m` directly (undoing eta-expansion of method m) to determine the argument types.
-      // This tree is the result from one of:
-      //   - manual eta-expansion with named arguments (x => f(x));
-      //   - wildcard-style eta expansion (`m(_, _,)`);
-      //   - instantiateToMethodType adapting a tree of method type to a function type using etaExpand.
-      //
-      // Note that method values are a separate thing (`m _`): they have the idiosyncratic shape
-      // of `Typed(expr, Function(Nil, EmptyTree))`
       fun.body match {
         // we can compare arguments and parameters by name because there cannot be a binder between
         // the function's valdefs and the Apply's arguments
@@ -3054,26 +3064,28 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           // so let's make sure our expected type is a MethodType
           val methArgs = NoSymbol.newSyntheticValueParams(argProtos map { case NoType => WildcardType case tp => tp })
 
-          val result = silent(_.typed(meth, mode.forFunMode, MethodType(methArgs, resProto)))
-          // we can't have results with undetermined type params
-          val resultMono = result filter (_ => context.undetparams.isEmpty)
-          resultMono map { methTyped =>
-            val numVparams = vparams.length
-            // if context.undetparams is not empty, the method was polymorphic,
-            // so we need the missing arguments to infer its type. See #871
-            val funPt = normalize(methTyped.tpe) baseType FunctionClass(numVparams)
-            // println(s"typeUnEtaExpanded $meth : ${methTyped.tpe} --> normalized: $funPt")
+          silent(_.typed(meth, mode.forFunMode, MethodType(methArgs, resProto))).fold(EmptyTree: Tree){ methTyped =>
+            if (context.undetparams.isEmpty) {
+              val numVparams = vparams.length
+              // if context.undetparams is not empty, the method was polymorphic,
+              // so we need the missing arguments to infer its type. See #871
+              val funPt = normalize(methTyped.tpe) baseType FunctionClass(numVparams)
+              // println(s"typeUnEtaExpanded $meth : ${methTyped.tpe} --> normalized: $funPt")
 
-            // If we are sure this function type provides all the necessary info, so that we won't have
-            // any undetermined argument types, go ahead an recurse below (`typedFunction(fun, mode, ptUnrollingEtaExpansion)`)
-            // and rest assured we won't end up right back here (and keep recursing)
-            if (isFunctionType(funPt) && funPt.typeArgs.iterator.take(numVparams).forall(isFullyDefined)) funPt
-            else null
-          } orElse { _ => null }
-        case _                                                                                                           => null
+              // If we are sure this function type provides all the necessary info, so that we won't have
+              // any undetermined argument types, go ahead an recurse below (`typedFunction(fun, mode, ptUnrollingEtaExpansion)`)
+              // and rest assured we won't end up right back here (and keep recursing).
+              // Be careful to reuse methTyped -- it may have changed from meth (scala/bug#9745)!
+              if (isFunctionType(funPt) && funPt.typeArgs.iterator.take(numVparams).forall(isFullyDefined))
+                typedFunction(treeCopy.Function(fun, vparams, treeCopy.Apply(fun.body, methTyped, args)), mode, funPt)
+              else EmptyTree
+            } else EmptyTree
+          }
+        case _ => EmptyTree
       }
     }
 
+    // Assuming the expected number of parameters, which all have type annotations, do the happy path.
     private def doTypedFunction(fun: Function, bodyPt: Type) = {
       val vparams = fun.vparams
       val vparamSyms = vparams map { vparam =>
@@ -4651,6 +4663,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               return tryTypedApply(fun setType newtpe, args)
             }
           }
+          // TODO: case to recurse into Function?
           def treesInResult(tree: Tree): List[Tree] = tree :: (tree match {
             case Block(_, r)                        => treesInResult(r)
             case Match(_, cases)                    => cases

--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -142,9 +142,6 @@ names-defaults-neg.scala:138: error: not found: value get
 names-defaults-neg.scala:139: error: parameter 'a' is already specified at parameter position 1
   val taf3 = testAnnFun(b = _: String, a = get(8))
                                          ^
-names-defaults-neg.scala:140: error: missing parameter type for expanded function ((x$3: <error>) => testAnnFun(x$3, ((x$4) => b = x$4)))
-  val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
-                                               ^
 names-defaults-neg.scala:140: error: missing parameter type for expanded function ((x$4: <error>) => b = x$4)
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                       ^
@@ -188,4 +185,4 @@ names-defaults-neg.scala:184: error: reference to x is ambiguous; it is both a m
   class u18 { var x: Int = u.f(x = 1) }
                                  ^
 6 warnings found
-46 errors found
+45 errors found

--- a/test/files/neg/t9745.check
+++ b/test/files/neg/t9745.check
@@ -1,0 +1,19 @@
+t9745.scala:2: error: missing parameter type for expanded function ((x$1: <error>) => Seq({
+  <x: error>.<$plus$eq: error>(1);
+  42
+}).apply(x$1))
+  val func = Seq { x += 1; 42 } apply _
+                                      ^
+t9745.scala:8: error: missing parameter type
+  val g = x => f(y += 1)(x)
+          ^
+t9745.scala:14: error: missing parameter type
+  val g = x => f(x += 1)(x)
+          ^
+t9745.scala:19: error: missing parameter type
+  val g = (x, y) => f(42)(x, y)
+           ^
+t9745.scala:19: error: missing parameter type
+  val g = (x, y) => f(42)(x, y)
+              ^
+5 errors found

--- a/test/files/neg/t9745.scala
+++ b/test/files/neg/t9745.scala
@@ -1,0 +1,20 @@
+class C {
+  val func = Seq { x += 1; 42 } apply _
+}
+
+class D {
+  var i = 0
+  def f(n: Unit)(j: Int): Int = ???
+  val g = x => f(y += 1)(x)
+}
+
+class E {
+  var i = 0
+  def f(n: Unit)(j: Int): Int = ???
+  val g = x => f(x += 1)(x)
+}
+
+class Convo {
+  def f(i: Int)(z: Any): Int = ???
+  val g = (x, y) => f(42)(x, y)
+}

--- a/test/files/pos/eta_partial.scala
+++ b/test/files/pos/eta_partial.scala
@@ -1,0 +1,6 @@
+class Test {
+  def repeat(x: Int, y: String) = y * x
+  val sayAaah = repeat(_, "a") // partial eta-expansion recovers fun param types from method (place holder syntax)
+  val thrice = x => repeat(3, x) // partial eta-expansion recovers fun param types from method (explicit version)
+  val repeatFlip = (x, y) => repeat(y, x) // partial eta-expansion recovers fun param types from method (explicit version, two params)
+}

--- a/test/files/pos/t9745.scala
+++ b/test/files/pos/t9745.scala
@@ -1,0 +1,14 @@
+class C {
+  val func = Seq { var i = 0; i += 1; i } apply _
+}
+
+class D {
+  var i = 0
+  def f(n: Unit)(j: Int): Int = ???
+  val g = x => f(i += 1)(x)
+}
+
+class Convo {
+  def f(i: Int)(z: Any): Int = ???
+  val g = (x: Int, y: Int) => f(42)(x, y)
+}


### PR DESCRIPTION
Backport a fix for scala/bug#9745 (#7316) and improve type inference for partial eta-expansion (#7333)

This improves inference of function parameter types for partially eta-expanded methods (i.e., when only some arguments are omitted using `_`)

Example from the test, given `def repeat(x: Int, y: String) = y * x`, partial eta-expansion recovers fun param types from the definition of the selected method:
```
val sayAaah = repeat(_, "a") // place holder syntax
val thrice = x => repeat(3, x) // explicit version
val repeatFlip = (x, y) => repeat(y, x) // explicit version, two params
```