### PR TITLE
When parsing a Scaladoc table do not consume non-table content

### DIFF
--- a/test/scaladoc/resources/tables.scala
+++ b/test/scaladoc/resources/tables.scala
@@ -67,6 +67,15 @@ package scala.test.scaladoc.tables {
     */
   trait TrailingCellsEmpty
 
+  /**
+    * ||Header 1|Header 2|
+    * |---|---|---|
+    * |||Fig|
+    * ||Cherry||
+    * |Walnut|||
+    */
+  trait LeadingCellsEmpty
+
   // Headers
 
   /**
@@ -164,20 +173,8 @@ package scala.test.scaladoc.tables {
     */
   trait CellMarkerEscapeEscapesOnlyMarker
 
-  // Known suboptimal behaviour. Candidates for improving later.
-
   /**
-    * ||Header 1|Header 2|
-    * |---|---|---|
-    * |||Fig|
-    * ||Cherry||
-    * |Walnut|||
-    */
-  trait LeadingCellsEmpty
-
-  // Should not lose r2c1 or warn
-  /**
-    * |Unstarted|
+    * |Unstarted Row|
     * |-|
     * |r1c1|
     * r2c1|
@@ -191,16 +188,25 @@ package scala.test.scaladoc.tables {
     * |-|
     * |Accidental
     * newline|
-    * |~FIN~|
     *
     */
   trait SplitCellContent
 
   /**
+    * |Split|
+    * |-|
+    * |Accidental
+    * newline|
+    * |~FIN~|
+    *
+    */
+  trait SplitInternalCellContent
+
+  /**
     * |Hill Dweller|
     * |---|
     * |Ant|
-    * Ants are cool.
+    * Ants are cool
     * |Hive Dweller|
     * |---|
     * |Bee|
@@ -208,7 +214,11 @@ package scala.test.scaladoc.tables {
     */
   trait MixedContentUnspaced
 
-  // Should parse to table with a header, defaulted delimiter and no rows.
+  // Known suboptimal behaviour. Candidates for improving later.
+
+  // Because table rows must not have leading whitespace this
+  // should parse to a table with a header, defaulted delimiter and no rows
+  // while the ignored content is parsed as non-table content.
   /**
     * |Leading|
     *  |-|

--- a/test/scaladoc/run/tables-warnings.check
+++ b/test/scaladoc/run/tables-warnings.check
@@ -1,7 +1,4 @@
-newSource:3: warning: unclosed table row
-  /**
-  ^
-newSource:9: warning: missing trailing cell marker
+newSource:9: warning: Fixing missing delimiter row
   /**
   ^
 newSource:19: warning: Fixing invalid column alignment: ::-

--- a/test/scaladoc/run/tables.check
+++ b/test/scaladoc/run/tables.check
@@ -4,10 +4,13 @@ newSource:36: warning: Dropping 1 excess table delimiter cells from row.
 newSource:36: warning: Dropping 1 excess table data cells from row.
   /**
   ^
-newSource:179: warning: no additional content on same line after table
+newSource:176: warning: Fixing missing delimiter row
   /**
   ^
-newSource:179: warning: Fixing missing delimiter row
+newSource:195: warning: Fixing missing delimiter row
+  /**
+  ^
+newSource:222: warning: Fixing missing delimiter row
   /**
   ^
 Done.


### PR DESCRIPTION
Fixes two issues by reducing greediness of Scaladoc table parsing,

- Content appearing directly after table ends is not lost in the call to `blockEnded("table")`
- Cell content breaking over more than one line is not parsed

By looking further ahead and ensuring the next line of content is a valid table row both these issues are avoided and subsequent parsing is simplified because the rows being parsing have a known structure.

This approach preserves the fast failing check on existence of a new table row via the same quick check on the next char as the previous non-regex approach.

Scaladoc tables are a subset of GFM tables. One restriction over GFM is the requirement for table rows to start and end with the | character with no leading/trailing whitespace. The test for leading whitespace not being ignored is turned on and confirms the restriction is active.


## Example Scaladoc
http://janekdb.github.io/scala/PR-7347/scala/test/scaladoc/tables/code/index.html

This page contains the unit test tables with the table markdown duplicated into a code block,

![image](https://user-images.githubusercontent.com/1123855/47214820-a614d500-d38e-11e8-8d74-fe343d40b25b.png)

In the above 1 is the rendered content resulting from 2 the Scaladoc markdown. This particular example shows that non-table rows are not processed by the table parsing code as desired. This matches the restrictions give on the [Scaladoc tables post](https://www.scala-lang.org/blog/2018/10/04/scaladoc-tables.html).

Another example of markdown that include non-table markdown is [MissingInitialCellMark](http://janekdb.github.io/scala/PR-7347/scala/test/scaladoc/tables/code/MissingInitialCellMark.html)

![image](https://user-images.githubusercontent.com/1123855/47215102-b7aaac80-d38f-11e8-8988-a40b9d3ec2db.png)

Line `r2c1|` is not a table row because it does not start with a leading | so table parsing stops before that line.

With this approach all the text entered by the user get displayed even when it is not part of the table.
