### PR TITLE
Fix inference bug involving nullary methods

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1197,7 +1197,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     }
 
     def instantiate(tree: Tree, mode: Mode, pt: Type): Tree = {
-      inferExprInstance(tree, context.extractUndetparams(), pt)
+      inferExprInstance(tree, context.extractUndetparams(), pt, useWeaklyCompatible = true)
       adapt(tree, mode, pt)
     }
     /** If the expected type is Unit: try instantiating type arguments

--- a/test/files/neg/t9093.check
+++ b/test/files/neg/t9093.check
@@ -1,6 +1,6 @@
-t9093.scala:3: error: polymorphic expression cannot be instantiated to expected type;
- found   : [C](f: C)Null
- required: Unit
+t9093.scala:3: error: missing argument list for method apply2 in object Main
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `apply2 _` or `apply2(_)(_)` instead of `apply2`.
   val x: Unit = apply2(0)/*(0)*/
                       ^
 one error found

--- a/test/files/pos/t11052.scala
+++ b/test/files/pos/t11052.scala
@@ -1,0 +1,8 @@
+object Test {
+  val x: Byte = Iterator.empty.next
+    // error: polymorphic expression cannot be instantiated to expected type;
+    // found   : [T]()T
+    // required: Byte
+    // val x: Byte = Iterator.empty.next
+    //                              ^
+}


### PR DESCRIPTION
I don't know what this change does exactly but it seems to fix the
problem ¯\\\_(ツ)\_/¯

Fixes scala/bug#11052: we don't need to change the result type of
Iterator#empty to get inference working like it did in 2.12.