### PR TITLE
remove VectorMap#keyIterator. use keysIterator

### DIFF
--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -192,11 +192,10 @@ final class VectorMap[K, +V] private (
     new VectorMap(fields.dropRight(size - 1 - slot + 1), underlying - key, false)
   }
 
-  def keyIterator: Iterator[K] = iterator.map(_._1)
-  override def keys: Vector[K] = keyIterator.toVector
+  override def keys: Vector[K] = keysIterator.toVector
 
   override def values: Iterable[V] = new Iterable[V] {
-    override def iterator: Iterator[V] = keyIterator.map(underlying(_)._2)
+    override def iterator: Iterator[V] = keysIterator.map(underlying(_)._2)
   }
 }
 


### PR DESCRIPTION
I think keyIterator is not necessary. We can use `MapOps#keysIterator`

https://github.com/scala/scala/blob/a84ce5bbc96d7eacd395e559237922d6feae4be0/src/library/scala/collection/Map.scala#L183-L191