### PR TITLE
Deprecate universal Equiv in Scala 2.13

### DIFF
--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -42,6 +42,17 @@ trait Equiv[T] extends Any with Serializable {
 trait LowPriorityEquiv {
   self: Equiv.type =>
 
+  /**
+   * @deprecated since 2.13.0. This implicit universal `Equiv` instance allows accidentally
+   * comparing instances of types for which equality isn't well-defined or implemented.
+   * (For example, it does not make sense to compare two `Function1` instances.)
+   *
+   * Use `Equiv.universal` explicitly instead. If you really want an implicit univeral `Equiv` instance
+   * despite the potential problems, consider `implicit def universalEquiv[T]: Equiv[T] = universal[T]`.
+   */
+  @deprecated("Use explicit Equiv.universal instead. See Scaladoc entry for more information: " +
+    "https://www.scala-lang.org/api/2.13.0/scala/math/Equiv$.html#universalEquiv[T]:scala.math.Equiv[T]",
+    since = "2.13.0")
   implicit def universalEquiv[T] : Equiv[T] = universal[T]
 }
 
@@ -58,4 +69,6 @@ object Equiv extends LowPriorityEquiv {
     ((x, y) => implicitly[Equiv[S]].equiv(f(x), f(y)))
 
   @inline def apply[T: Equiv]: Equiv[T] = implicitly[Equiv[T]]
+
+  implicit def equivFromPartialOrdering[T](implicit ev: PartialOrdering[T]): Equiv[T] = ev
 }

--- a/src/library/scala/math/PartialOrdering.scala
+++ b/src/library/scala/math/PartialOrdering.scala
@@ -85,3 +85,9 @@ trait PartialOrdering[T] extends Equiv[T] {
     override def equiv(x: T, y: T) = outer.equiv(y, x)
   }
 }
+
+object PartialOrdering {
+  implicit def partialOrderingFromOrdering[T](implicit ev: Ordering[T]): PartialOrdering[T] = ev
+
+  @inline def apply[T](implicit ev: PartialOrdering[T]): PartialOrdering[T] = ev
+}

--- a/test/junit/scala/math/EquivTest.scala
+++ b/test/junit/scala/math/EquivTest.scala
@@ -1,0 +1,44 @@
+package scala.math
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class EquivTest {
+  import EquivTest._
+
+  @Test
+  def testOrderingToEquivResolution: Unit = {
+    implicit val o: Ordering[Box[Int]] = intBoxOrdering
+
+    assert(Equiv[Box[Int]] == intBoxOrdering)
+  }
+
+  @Test
+  def testPartialOrderingToEquivResolution: Unit = {
+    implicit val po: PartialOrdering[Box[Int]] = intBoxOrdering
+
+    assert(Equiv[Box[Int]] == intBoxOrdering)
+  }
+
+  @Test
+  def testOrderingAndPartialOrderingToEquivResolution: Unit = {
+    implicit val po: PartialOrdering[Box[Int]] = intBoxOrdering
+    implicit val o: Ordering[Box[Int]] = intBoxOrdering
+
+    assert(Equiv[Box[Int]] == intBoxOrdering)
+  }
+
+  @Test
+  def testUniversalEquivResolution: Unit = {
+    assert(Equiv[Box[Int]].equiv(Box(3), Box(1 + 2)))
+  }
+}
+
+object EquivTest {
+  final case class Box[A](value: A)
+
+  val intBoxOrdering: Ordering[Box[Int]] = Ordering.by(_.value)
+}

--- a/test/junit/scala/math/PartialOrderingTest.scala
+++ b/test/junit/scala/math/PartialOrderingTest.scala
@@ -1,0 +1,26 @@
+package scala.math
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class PartialOrderingTest {
+  import EquivTest._
+
+  @Test
+  def testOrderingToPartialOrderingResolution: Unit = {
+    implicit val o: Ordering[Box[Int]] = intBoxOrdering
+
+    assert(PartialOrdering[Box[Int]] == intBoxOrdering)
+  }
+
+  @Test
+  def testOrderingAndPartialOrderingToPartialOrderingResolution: Unit = {
+    implicit val po: PartialOrdering[Box[Int]] = intBoxOrdering
+    implicit val o: Ordering[Box[Int]] = intBoxOrdering
+
+    assert(PartialOrdering[Box[Int]] == intBoxOrdering)
+  }
+}


### PR DESCRIPTION
This is a replacement for #7187 (see discussion there).

This does the following things:

1. Deprecate universal Equiv instance.
2. Create an Ordering -> PartialOrdering conversion.
3. Create a PartialOrdering -> Equiv conversion at a higher priority
than the universal instance.
4. Add some unit tests that check that implicit resolution is working as
expected.

@NthPortal suggested the conversions as a simple way to have `Equiv`
instances that could be resolved without duplicating a lot of the work
that has been done for `Order` instances for basic types.