### PR TITLE
Define unzip and unzip3 for Option

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -323,6 +323,43 @@ sealed abstract class Option[+A] extends Product with Serializable {
   final def zip[A1 >: A, B](that: Option[B]): Option[(A1, B)] =
     if (isEmpty || that.isEmpty) None else Some((this.get, that.get))
 
+  /** Converts an Option of a pair into an Option of the first element and an Option of the second element.
+    *
+    *  @tparam A1    the type of the first half of the element pair
+    *  @tparam A2    the type of the second half of the element pair
+    *  @param asPair an implicit conversion which asserts that the element type
+    *                of this Option is a pair.
+    *  @return       a pair of Options, containing, respectively, the first and second half
+    *                of the element pair of this Option.
+    */
+  final def unzip[A1, A2](implicit asPair: A => (A1, A2)): (Option[A1], Option[A2]) = {
+    if (isEmpty)
+      (None, None)
+    else {
+      val e = asPair(this.get)
+      (Some(e._1), Some(e._2))
+    }
+  }
+
+  /** Converts an Option of a triple into three Options, one containing the element from each position of the triple.
+    *
+    *  @tparam A1      the type of the first of three elements in the triple
+    *  @tparam A2      the type of the second of three elements in the triple
+    *  @tparam A3      the type of the third of three elements in the triple
+    *  @param asTriple an implicit conversion which asserts that the element type
+    *                  of this Option is a triple.
+    *  @return         a triple of Options, containing, respectively, the first, second, and third
+    *                  elements from the element triple of this Option.
+    */
+  final def unzip3[A1, A2, A3](implicit asTriple: A => (A1, A2, A3)): (Option[A1], Option[A2], Option[A3]) = {
+    if (isEmpty)
+      (None, None, None)
+    else {
+      val e = asTriple(this.get)
+      (Some(e._1), Some(e._2), Some(e._3))
+    }
+  }
+
   /** Returns a singleton iterator returning the $option's value
    * if it is nonempty, or an empty iterator if the option is empty.
    */

--- a/test/junit/scala/OptionTest.scala
+++ b/test/junit/scala/OptionTest.scala
@@ -11,6 +11,14 @@ class OptionTest extends RunTesting {
   @Test def testNoneZipSome: Unit = assertEquals(None zip Some("bar"), None)
   @Test def testNoneZipNone: Unit = assertEquals(None zip None, None)
 
+  @Test def testSomeUnzipToSomePair: Unit = assertEquals(Some(("foo", "bar")).unzip, (Some("foo"), Some("bar")))
+  @Test def testSomeUnzipToSomeNone: Unit = assertEquals(Some(("foo", null)).unzip, (Some("foo"), Some(null)))
+  @Test def testNoneUnzipToNonePair: Unit = assertEquals(None.unzip, (None, None))
+
+  @Test def testSomeUnzip3ToSomeTriple: Unit = assertEquals(Some(("foo", "bar", "z")).unzip3, (Some("foo"), Some("bar"), Some("z")))
+  @Test def testSomeUnzip3ToSomeNone: Unit = assertEquals(Some(("foo", null, null)).unzip3, (Some("foo"), Some(null), Some(null)))
+  @Test def testNoneUnzip3ToNoneTriple: Unit = assertEquals(None.unzip3, (None, None, None))
+
   import runner._
   import scala.tools.reflect.{ ToolBoxError => E }
 


### PR DESCRIPTION
Fix scala/bug#11222

@SethTisue Re-created for commit rebase.
Previous PR: [Define unzip and unzip3 for Option](https://github.com/scala/scala/pull/7359)

Related issue: scala/bug#8394
Related PR: [scala/pull/6491](https://github.com/scala/scala/pull/6491)

