### PR TITLE
Exception handling in sys.process

### DIFF
--- a/src/library/scala/sys/process/BasicIO.scala
+++ b/src/library/scala/sys/process/BasicIO.scala
@@ -77,7 +77,7 @@ object BasicIO {
   }
 
   private[process] trait Uncloseable extends Closeable {
-    final override def close(): Unit = { }
+    final override def close(): Unit = ()
   }
   private[process] object Uncloseable {
     def apply(in: InputStream): InputStream      = new FilterInputStream(in) with Uncloseable { }

--- a/src/library/scala/sys/process/Process.scala
+++ b/src/library/scala/sys/process/Process.scala
@@ -176,7 +176,7 @@ trait ProcessCreation {
     */
   def cat(files: scala.collection.Seq[Source]): ProcessBuilder = {
     require(files.nonEmpty)
-    files map (_.cat) reduceLeft (_ #&& _)
+    files.map(_.cat).reduceLeft(_ #&& _)
   }
 }
 

--- a/src/library/scala/sys/process/ProcessBuilderImpl.scala
+++ b/src/library/scala/sys/process/ProcessBuilderImpl.scala
@@ -64,7 +64,7 @@ private[process] trait ProcessBuilderImpl {
           ok = true
         } finally success.put(ok)
       }
-      val t = Spawn(go(), io.daemonizeThreads)
+      val t = Spawn("ThreadProcess", io.daemonizeThreads)(go())
       new ThreadProcess(t, success)
     }
   }
@@ -86,11 +86,11 @@ private[process] trait ProcessBuilderImpl {
       import io._
 
       // spawn threads that process the input, output, and error streams using the functions defined in `io`
-      val inThread  = Spawn(writeInput(process.getOutputStream), daemon = true)
-      val outThread = Spawn(processOutput(process.getInputStream), daemonizeThreads)
+      val inThread  = Spawn("Simple-input", daemon = true)(writeInput(process.getOutputStream))
+      val outThread = Spawn("Simple-output", daemonizeThreads)(processOutput(process.getInputStream))
       val errorThread =
         if (p.redirectErrorStream) Nil
-        else List(Spawn(processError(process.getErrorStream), daemonizeThreads))
+        else List(Spawn("Simple-error", daemonizeThreads)(processError(process.getErrorStream)))
 
       new SimpleProcess(process, inThread, outThread :: errorThread)
     }
@@ -172,7 +172,7 @@ private[process] trait ProcessBuilderImpl {
       val lazilyListed = LazilyListed[String](nonZeroException, capacity)
       val process      = run(BasicIO(withInput, lazilyListed.process, log))
 
-      Spawn(lazilyListed done process.exitValue())
+      Spawn("LazyLines")(lazilyListed done process.exitValue())
       lazilyListed.lazyList
     }
 
@@ -185,7 +185,7 @@ private[process] trait ProcessBuilderImpl {
       val streamed = Streamed[String](nonZeroException, capacity)
       val process  = run(BasicIO(withInput, streamed.process, log))
 
-      Spawn(streamed done process.exitValue())
+      Spawn("LineStream")(streamed done process.exitValue())
       streamed.stream()
     }
 

--- a/src/library/scala/sys/process/ProcessImpl.scala
+++ b/src/library/scala/sys/process/ProcessImpl.scala
@@ -98,6 +98,14 @@ private[process] trait ProcessImpl {
       val thread = Spawn("CompoundProcess") {
         var value: Option[Int] = None
         try value = runAndExitValue()
+        catch {
+          case _: IndexOutOfBoundsException
+             | _: IOException
+             | _: NullPointerException
+             | _: SecurityException
+             | _: UnsupportedOperationException
+          => value = Some(-1)
+        }
         finally code.put(value)
       }
 
@@ -260,11 +268,5 @@ private[process] trait ProcessImpl {
     override def isAlive()   = thread.isAlive()
     override def exitValue() = if (success.get) 0 else 1   // thread.join()
     override def destroy()   = thread.interrupt()
-  }
-
-  private[process] object FailedProcess extends Process {
-    override def isAlive() = false
-    override def exitValue() = 1
-    override def destroy(): Unit = ()
   }
 }

--- a/src/library/scala/sys/process/package.scala
+++ b/src/library/scala/sys/process/package.scala
@@ -231,7 +231,6 @@ package scala.sys {
       type InputStream            = java.io.InputStream
       type JProcess               = java.lang.Process
       type JProcessBuilder        = java.lang.ProcessBuilder
-      type LinkedBlockingQueue[T] = java.util.concurrent.LinkedBlockingQueue[T]
       type OutputStream           = java.io.OutputStream
       type SyncVar[T]             = scala.concurrent.SyncVar[T]
       type URL                    = java.net.URL

--- a/test/files/run/t6488.javaopts
+++ b/test/files/run/t6488.javaopts
@@ -1,0 +1,1 @@
+-Dforked.test=yes.please

--- a/test/files/run/t6488.scala
+++ b/test/files/run/t6488.scala
@@ -5,6 +5,7 @@ import java.io.{File, IOException}, File.pathSeparator
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit._
 import java.util.concurrent.atomic._
+import scala.reflect.io.Path
 
 object Test {
   /*
@@ -29,25 +30,35 @@ object Test {
       test()          // args(0) == "jvm"
   }
 
-  // fork the data spewer, wait for input, then destroy the process
-  def test(): Unit = {
-    val f = new File(javaHome, "bin").listFiles.sorted filter (_.getName startsWith "java") find (_.canExecute) getOrElse {
+  def java(): File =
+    new File(javaHome, "bin").listFiles.sorted.filter(f => Path(f).stripExtension == "java").find(_.canExecute).getOrElse {
       // todo signal test runner that test is skipped
       new File("/bin/ls")  // innocuous
     }
+
+  // fork the data spewer, wait for input, then destroy the process
+  def test(): Unit = {
     //Process(f.getAbsolutePath).run(ProcessLogger { _ => () }).destroy
     val reading = new CountDownLatch(1)
     val count   = new AtomicInteger
     def counted = count.get
-    val outdir  = s"$userDir/test/files/run/t6488-run.obj"
-    val command = s"${f.getAbsolutePath} -classpath ${javaClassPath}${pathSeparator}${outdir} Test data"
+    // when run in-process, outdir is not absolute path; also, outdir is not listable for some reason.
+    //val outdir  = s"$userDir/test/files/run/${System.getProperty("partest.output")}"
+    val outdir  = System.getProperty("partest.output")
+    val command = java().getAbsolutePath ::
+                  "Test" ::
+                  "data" ::
+                  Nil
+                  // re-adding outdir to classpath only required for in-process exec, which is broken
+                  //"-classpath" ::
+                  //s"${javaClassPath}${pathSeparator}${outdir}" ::
     Try {
-      Process(command.split(" ").toSeq) run ProcessLogger { (s: String) =>
+      Process(command).run(ProcessLogger { (s: String) =>
         //Console println s"[[$s]]"     // java help
         count.getAndIncrement
         reading.countDown
         Thread.`yield`()
-      }
+      })
     } foreach { (p: Process) =>
       val ok = reading.await(10, SECONDS)
       if (!ok) Console println "Timed out waiting for process output!"

--- a/test/files/run/t6488.scala
+++ b/test/files/run/t6488.scala
@@ -1,7 +1,7 @@
 import scala.sys.process._
 import scala.util.Try
-import scala.util.Properties.{ javaHome, javaClassPath }
-import java.io.{ File, IOException }
+import scala.util.Properties.{javaHome, javaClassPath, userDir}
+import java.io.{File, IOException}, File.pathSeparator
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit._
 import java.util.concurrent.atomic._
@@ -39,9 +39,10 @@ object Test {
     val reading = new CountDownLatch(1)
     val count   = new AtomicInteger
     def counted = count.get
-    val command = s"${f.getAbsolutePath} -classpath ${javaClassPath} Test data"
+    val outdir  = s"$userDir/test/files/run/t6488-run.obj"
+    val command = s"${f.getAbsolutePath} -classpath ${javaClassPath}${pathSeparator}${outdir} Test data"
     Try {
-      Process(command) run ProcessLogger { (s: String) =>
+      Process(command.split(" ").toSeq) run ProcessLogger { (s: String) =>
         //Console println s"[[$s]]"     // java help
         count.getAndIncrement
         reading.countDown

--- a/test/junit/scala/sys/process/PipedProcessTest.scala
+++ b/test/junit/scala/sys/process/PipedProcessTest.scala
@@ -154,11 +154,7 @@ class PipeSourceSinkTest {
   }
 
   class PipeSink extends Process.PipeSink("TestPipeSink") {
-    def ensureRunloopStarted() = {
-      while (sink.size() > 0) {
-        Thread.sleep(1)
-      }
-    }
+    def ensureRunloopStarted() = while (sink.isSet) Thread.sleep(10L)
     def isReleased = {
       val field = classOf[Process.PipeSink].getDeclaredField("pipe")
       field.setAccessible(true)
@@ -168,11 +164,7 @@ class PipeSourceSinkTest {
   }
 
   class PipeSource extends Process.PipeSource("TestPipeSource") {
-    def ensureRunloopStarted() = {
-      while (source.size() > 0) {
-        Thread.sleep(1)
-      }
-    }
+    def ensureRunloopStarted() = while (source.isSet) Thread.sleep(10L)
     def isReleased = {
       val field = classOf[Process.PipeSource].getDeclaredField("pipe")
       field.setAccessible(true)
@@ -250,9 +242,9 @@ class PipeSourceSinkTest {
       sink.release()
     }
     Await.result(f, TestDuration.Standard)
-    assert(in.closed == true)
-    assert(source.isReleased == true)
-    assert(sink.isReleased == true)
+    assertTrue(in.closed)
+    assertTrue(source.isReleased)
+    assertTrue(sink.isReleased)
   }
 
   // PipeSource and PipeSink must release resources when interrupted during copy streams

--- a/test/junit/scala/sys/process/ProcessBuilderTest.scala
+++ b/test/junit/scala/sys/process/ProcessBuilderTest.scala
@@ -3,6 +3,8 @@ package scala.sys.process
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
+import org.junit.Assert._
+import scala.tools.testing.AssertUtil._
 
 @RunWith(classOf[JUnit4])
 class ProcessBuilderTest {
@@ -10,8 +12,14 @@ class ProcessBuilderTest {
   @Test
   def t8406: Unit = {
     import java.io.ByteArrayInputStream
+    import java.nio.charset.StandardCharsets.UTF_8
     import scala.util.Try
-    assert(Try(("does-not-exist" #< new ByteArrayInputStream("foo".getBytes("utf-8"))).lazyLines).isSuccess)
-    assert(Try(("does-not-exist" #< new ByteArrayInputStream("foo".getBytes("utf-8"))).lazyLines.toList).isFailure)
+
+    assertZeroNetThreads {
+      val p = Try(("does-not-exist" #< new ByteArrayInputStream("foo".getBytes(UTF_8))).lazyLines)
+      assertTrue(p.isSuccess)
+      val q = p.map(_.toList)
+      assertTrue("Expected realizing bad command to fail.", q.isFailure)
+    }
   }
 }

--- a/test/junit/scala/tools/testing/AssertUtil.scala
+++ b/test/junit/scala/tools/testing/AssertUtil.scala
@@ -11,7 +11,7 @@ import scala.collection.mutable
 import scala.tools.nsc.settings.ScalaVersion
 import scala.util.Properties.javaSpecVersion
 import java.lang.ref._
-import java.lang.reflect._
+import java.lang.reflect.{Array => _, _}
 import java.util.IdentityHashMap
 
 /** This module contains additional higher-level assert statements
@@ -97,4 +97,30 @@ object AssertUtil {
   def assert8(b: => Boolean, msg: => Any) =
     if (ScalaVersion(javaSpecVersion) == version8) assert(b, msg)
     else if (!b) println(s"assert not $msg")
+
+
+  /** Assert no new threads, with some margin for arbitrary threads to exit. */
+  def assertZeroNetThreads(body: => Unit): Unit = {
+    val beforeCount = Thread.activeCount
+    val beforeThreads = new Array[Thread](beforeCount)
+    assertEquals("Spurious early thread creation.", beforeCount, Thread.enumerate(beforeThreads))
+
+    body
+
+    val afterCount = {
+      var n = 1
+      while (Thread.activeCount > beforeCount && n < 5) {
+        //println("Wait for quiescence")
+        Thread.sleep(250L * n)
+        n += 1
+      }
+      Thread.activeCount
+    }
+    val afterThreads = new Array[Thread](afterCount)
+    assertEquals("Spurious late thread creation.", afterCount, Thread.enumerate(afterThreads))
+    val staleThreads = afterThreads.toList.diff(beforeThreads)
+    //staleThreads.headOption.foreach(_.getStackTrace.foreach(println))
+    assertEquals(staleThreads.mkString("There are stale threads: ",",",""), beforeCount, afterCount)
+    assertTrue(staleThreads.mkString("There are stale threads: ",",",""), staleThreads.isEmpty)
+  }
 }


### PR DESCRIPTION
    Handle bad process start and lazily
    
    Improve handling of failure of a process
    to start. In a `CompoundProcess`, catch
    exceptions and set a special exit value.
    For `lazyLines`, also supply a value so
    that requesting thread doesn't hang.
    
    It would be nicer to stow the exception
    and rethrow instead of using special
    integers.
    
    Test for stale thread.

Fixes https://github.com/scala/scala-dev/issues/566