### PR TITLE
Rework -Xprint-args to continue compiler and allow file output

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilerCommand.scala
+++ b/src/compiler/scala/tools/nsc/CompilerCommand.scala
@@ -100,13 +100,8 @@ class CompilerCommand(arguments: List[String], val settings: Settings) {
       if (debug) "\n" + global.phaseFlagDescriptions else ""
     )
     else if (genPhaseGraph.isSetByUser) {
-      val components = global.phaseNames  // global.phaseDescriptors // one initializes
+      val components = global.phaseNames // global.phaseDescriptors // one initializes
       s"Phase graph of ${components.size} components output to ${genPhaseGraph.value}*.dot."
-    } else if (printArgs.value) {
-      s"""
-         |${recreateArgs.mkString("\n")}
-         |${files.mkString("\n")}
-        """.stripMargin
     }
     else allSettings.filter(_.isHelping).map(_.help).mkString("\n\n")
   }

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1426,11 +1426,27 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     /** Caching member symbols that are def-s in Definitions because they might change from Run to Run. */
     val runDefinitions: definitions.RunDefinitions = new definitions.RunDefinitions
 
+    private def printArgs(sources: List[SourceFile]): Unit = {
+      if (settings.printArgs.isSetByUser) {
+        val argsFile = (settings.recreateArgs ::: sources.map(_.file.absolute.toString())).mkString("", "\n", "\n")
+        settings.printArgs.value match {
+          case "-" =>
+            reporter.echo(argsFile)
+          case pathString =>
+            import java.nio.file._
+            val path = Paths.get(pathString)
+            Files.write(path, argsFile.getBytes(Charset.forName("UTF-8")))
+            reporter.echo("Compiler arguments written to: " + path)
+        }
+      }
+    }
+
     /** Compile list of source files,
      *  unless there is a problem already,
      *  such as a plugin was passed a bad option.
      */
     def compileSources(sources: List[SourceFile]): Unit = if (!reporter.hasErrors) {
+      printArgs(sources)
 
       def checkDeprecations() = {
         warnDeprecatedAndConflictingSettings()

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -37,7 +37,7 @@ trait ScalaSettings extends AbsScalaSettings
   protected def futureSettings = List[BooleanSetting]()
 
   /** If any of these settings is enabled, the compiler should print a message and exit.  */
-  def infoSettings = List[Setting](version, help, Xhelp, Yhelp, showPlugins, showPhases, genPhaseGraph, printArgs)
+  def infoSettings = List[Setting](version, help, Xhelp, Yhelp, showPlugins, showPhases, genPhaseGraph)
 
   /** Is an info setting set? Any -option:help? */
   def isInfo = infoSettings.exists(_.isSetByUser) || allSettings.exists(_.isHelping)
@@ -132,7 +132,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Xprint             = PhasesSetting       ("-Xprint", "Print out program after")
   val Xprintpos          = BooleanSetting      ("-Xprint-pos", "Print tree positions, as offsets.")
   val printtypes         = BooleanSetting      ("-Xprint-types", "Print tree types (debugging option).")
-  val printArgs          = BooleanSetting      ("-Xprint-args", "Print all compiler arguments and exit.")
+  val printArgs          = StringSetting       ("-Xprint-args", "file", "Print all compiler arguments to the specified location. Use - to echo to the reporter.", "-")
   val prompt             = BooleanSetting      ("-Xprompt", "Display a prompt after each error (debugging option).")
   val resident           = BooleanSetting      ("-Xresident", "Compiler stays resident: read source filenames from standard input.")
   val script             = StringSetting       ("-Xscript", "object", "Treat the source file as a script and wrap it in a main method.", "")


### PR DESCRIPTION
```
$ qscalac -X 2>&1 | grep -i print-args
  -Xprint-args <file>              Print all compiler arguments to the specified location. Use - to echo to the reporter.

$ qscalac -cp /tmp -Xprint-args -Xprint:jvm sandbox/test.scala
Compiler arguments written to: -Xprint:jvm
sandbox/test.scala:1: error: object apache is not a member of package org
class Test { println(org.apache.commons.io.IOUtils.EOF) }
                         ^
one error found

$ qscalac -cp /tmp -Xprint-args /tmp/compiler.args -Xprint:jvm sandbox/test.scala
Compiler arguments written to: /tmp/compiler.args
sandbox/test.scala:1: error: object apache is not a member of package org
class Test { println(org.apache.commons.io.IOUtils.EOF) }
                         ^
one error found

$ cat /tmp/compiler.args
-Xprint-args
/tmp/compiler.args
-Xprint:jvm
-classpath
/tmp
/Users/jz/code/scala/sandbox/test.scala

$ qscalac -cp /tmp -Xprint-args - -Xprint:jvm sandbox/test.scala
-Xprint:jvm
-classpath
/tmp
/Users/jz/code/scala/sandbox/test.scala
sandbox/test.scala:1: error: object apache is not a member of package org
class Test { println(org.apache.commons.io.IOUtils.EOF) }
                         ^
one error found
```