### PR TITLE
Emit detailed compiler trace under -Yprofile-trace

### DIFF
--- a/project/ScriptCommands.scala
+++ b/project/ScriptCommands.scala
@@ -109,11 +109,11 @@ object ScriptCommands {
     Project.setProject(session, newStructure, state)
   }
 
-  private[this] val enableOptimizer = Seq(
+  val enableOptimizer = Seq(
     scalacOptions in Compile in ThisBuild ++= Seq("-opt:l:inline", "-opt-inline-from:scala/**")
   )
 
-  private[this] val noDocs = Seq(
+  val noDocs = Seq(
     publishArtifact in (Compile, packageDoc) in ThisBuild := false
   )
 

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -446,8 +446,10 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
         currentRun.informUnitStarting(this, unit)
         val unit0 = currentUnit
         currentRun.currentUnit = unit
+        currentRun.profiler.beforeUnit(phase, unit.source.file)
         try apply(unit)
         finally {
+          currentRun.profiler.afterUnit(phase, unit.source.file)
           currentRun.currentUnit = unit0
           currentRun.advanceUnit()
         }
@@ -1110,6 +1112,9 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
 
   def newJavaUnitParser(unit: CompilationUnit): JavaUnitParser = new JavaUnitParser(unit)
 
+  override protected[scala] def currentRunProfilerBeforeCompletion(root: Symbol, associatedFile: AbstractFile): Unit = currentRun.profiler.beforeCompletion(root, associatedFile)
+  override protected[scala] def currentRunProfilerAfterCompletion(root: Symbol, associatedFile: AbstractFile): Unit = currentRun.profiler.afterCompletion(root, associatedFile)
+
   /** A Run is a single execution of the compiler on a set of units.
    */
   class Run extends RunContextApi with RunReporting with RunParsing {
@@ -1474,7 +1479,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     private final val GlobalPhaseName = "global (synthetic)"
     protected final val totalCompileTime = statistics.newTimer("#total compile time", GlobalPhaseName)
 
-    def compileUnits(units: List[CompilationUnit], fromPhase: Phase): Unit =  compileUnitsInternal(units,fromPhase)
+    def compileUnits(units: List[CompilationUnit], fromPhase: Phase): Unit = compileUnitsInternal(units,fromPhase)
     private def compileUnitsInternal(units: List[CompilationUnit], fromPhase: Phase) {
       units foreach addUnit
       reporter.reset()

--- a/src/compiler/scala/tools/nsc/profile/Profiler.scala
+++ b/src/compiler/scala/tools/nsc/profile/Profiler.scala
@@ -14,31 +14,41 @@ package scala.tools.nsc.profile
 
 import java.io.{FileWriter, PrintWriter}
 import java.lang.management.ManagementFactory
+import java.nio.file.{Files, Paths}
 import java.util.ServiceLoader
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+
 import javax.management.openmbean.CompositeData
 import javax.management.{Notification, NotificationEmitter, NotificationListener}
 
-import scala.tools.nsc.{Phase, Settings}
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.internal.util.ChromeTrace
+import scala.reflect.io.{AbstractFile, File}
+import scala.tools.nsc.{Global, Phase, Settings}
 
 object Profiler {
   def apply(settings: Settings):Profiler =
     if (!settings.YprofileEnabled) NoOpProfiler
     else {
-      val reporter = if(settings.YprofileDestination.isSetByUser)
-        new StreamProfileReporter(new PrintWriter(new FileWriter(settings.YprofileDestination.value, true)))
-      else ConsoleProfileReporter
+      val reporter = settings.YprofileDestination.value match {
+        case _ if !settings.YprofileDestination.isSetByUser => NoOpProfileReporter
+        case "-" => ConsoleProfileReporter
+        case path => new StreamProfileReporter(new PrintWriter(new FileWriter(path, true)))
+      }
       new RealProfiler(reporter, settings)
     }
 
-  private[profile] val emptySnap = ProfileSnap(0, "", 0, 0, 0, 0, 0, 0)
+  private[profile] val emptySnap = ProfileSnap(0, "", 0, 0, 0, 0, 0, 0, 0, 0)
 }
-case class GcEventData(pool:String, reportTimeNs: Long, gcStartMillis:Long, gcEndMillis:Long, name:String, action:String, cause:String, threads:Long)
+case class GcEventData(pool:String, reportTimeNs: Long, gcStartMillis:Long, gcEndMillis:Long, durationMillis: Long, name:String, action:String, cause:String, threads:Long) {
+  val endNanos = System.nanoTime()
+}
 
 case class ProfileSnap(threadId: Long, threadName: String, snapTimeNanos : Long,
-                         idleTimeNanos:Long, cpuTimeNanos: Long, userTimeNanos: Long,
-                         allocatedBytes:Long, heapBytes:Long) {
+                       idleTimeNanos:Long, cpuTimeNanos: Long, userTimeNanos: Long,
+                       allocatedBytes:Long, heapBytes:Long, totalClassesLoaded: Long, totalJITCompilationTime: Long) {
   def updateHeap(heapBytes:Long) = {
     copy(heapBytes = heapBytes)
   }
@@ -73,13 +83,29 @@ case class ProfileRange(start: ProfileSnap, end:ProfileSnap, phase:Phase, purpos
   def retainedHeapMB = toMegaBytes(end.heapBytes - start.heapBytes)
 }
 
-sealed trait Profiler {
+sealed abstract class Profiler {
 
   def finished(): Unit
 
   def beforePhase(phase: Phase): ProfileSnap
 
   def afterPhase(phase: Phase, profileBefore: ProfileSnap): Unit
+
+  def beforeUnit(phase: Phase, file: AbstractFile): Unit
+
+  def afterUnit(phase: Phase, file: AbstractFile): Unit
+
+  def beforeTypedImplDef(sym: Global#Symbol): Unit = ()
+  def afterTypedImplDef(sym: Global#Symbol): Unit = ()
+
+  def beforeImplicitSearch(pt: Global#Type): Unit = ()
+  def afterImplicitSearch(pt: Global#Type): Unit = ()
+
+  def beforeMacroExpansion(macroSym: Global#Symbol): Unit = ()
+  def afterMacroExpansion(macroSym: Global#Symbol): Unit = ()
+
+  def beforeCompletion(root: Global#Symbol, associatedFile: AbstractFile): Unit = ()
+  def afterCompletion(root: Global#Symbol, associatedFile: AbstractFile): Unit = ()
 }
 private [profile] object NoOpProfiler extends Profiler {
 
@@ -87,6 +113,8 @@ private [profile] object NoOpProfiler extends Profiler {
 
   override def afterPhase(phase: Phase, profileBefore: ProfileSnap): Unit = ()
 
+  override def beforeUnit(phase: Phase, file: AbstractFile): Unit = ()
+  override def afterUnit(phase: Phase, file: AbstractFile): Unit = ()
   override def finished(): Unit = ()
 }
 private [profile] object RealProfiler {
@@ -99,30 +127,12 @@ private [profile] object RealProfiler {
   val threadMx = ExtendedThreadMxBean.proxy
   if (threadMx.isThreadCpuTimeSupported) threadMx.setThreadCpuTimeEnabled(true)
   private val idGen = new AtomicInteger()
+
   lazy val allPlugins = ServiceLoader.load(classOf[ProfilerPlugin]).iterator().asScala.toList
-}
-
-private [profile] class RealProfiler(reporter : ProfileReporter, val settings: Settings) extends Profiler with NotificationListener {
-  def completeBackground(threadRange: ProfileRange): Unit = {
-    reporter.reportBackground(this, threadRange)
-  }
-
-  def outDir = settings.outputDirs.getSingleOutput.getOrElse(settings.outputDirs.outputs.head._2.file).toString
-
-  val id = RealProfiler.idGen.incrementAndGet()
-  RealProfiler.gcMx foreach {
-    case emitter: NotificationEmitter => emitter.addNotificationListener(this, null, null)
-    case gc => println(s"Cant connect gcListener to ${gc.getClass}")
-  }
-
-  val active = RealProfiler.allPlugins map (_.generate(this, settings))
-
-  private val mainThread = Thread.currentThread()
 
   private[profile] def snapThread( idleTimeNanos:Long): ProfileSnap = {
-    import RealProfiler._
     val current = Thread.currentThread()
-
+    val allocatedBytes = threadMx.getThreadAllocatedBytes(Thread.currentThread().getId)
     ProfileSnap(
       threadId = current.getId,
       threadName = current.getName,
@@ -130,11 +140,48 @@ private [profile] class RealProfiler(reporter : ProfileReporter, val settings: S
       idleTimeNanos = idleTimeNanos,
       cpuTimeNanos = threadMx.getCurrentThreadCpuTime,
       userTimeNanos = threadMx.getCurrentThreadUserTime,
-      allocatedBytes = threadMx.getThreadAllocatedBytes(Thread.currentThread().getId),
-      heapBytes = readHeapUsage()
+      allocatedBytes = allocatedBytes,
+      heapBytes = readHeapUsage(),
+      totalClassesLoaded = classLoaderMx.getTotalLoadedClassCount,
+      totalJITCompilationTime = compileMx.getTotalCompilationTime
     )
   }
   private def readHeapUsage() = RealProfiler.memoryMx.getHeapMemoryUsage.getUsed
+}
+
+private [profile] class RealProfiler(reporter : ProfileReporter, val settings: Settings) extends Profiler with NotificationListener {
+  private val mainThread = Thread.currentThread()
+  val id = RealProfiler.idGen.incrementAndGet()
+  object Category {
+    final val Run = "run"
+    final val Phase = "phase"
+    final val File = "file"
+    final val TypeCheck = "typecheck"
+    final val Implicit = "implicit"
+    final val Macro = "macro"
+    final val Completion = "completion"
+  }
+
+  private val chromeTrace = {
+    if (settings.YprofileTrace.isSetByUser)
+      new ChromeTrace(Paths.get(settings.YprofileTrace.value))
+    else null
+  }
+  if (chromeTrace != null)
+    chromeTrace.traceDurationEventStart(Category.Run, "scalac-" + id)
+
+  def completeBackground(threadRange: ProfileRange): Unit = {
+    reporter.reportBackground(this, threadRange)
+  }
+
+  def outDir = settings.outputDirs.getSingleOutput.getOrElse(settings.outputDirs.outputs.head._2.file).toString
+
+  RealProfiler.gcMx foreach {
+    case emitter: NotificationEmitter => emitter.addNotificationListener(this, null, null)
+    case gc => println(s"Cant connect gcListener to ${gc.getClass}")
+  }
+
+  val active = RealProfiler.allPlugins map (_.generate(this, settings))
 
   private def doGC: Unit = {
     System.gc()
@@ -151,8 +198,19 @@ private [profile] class RealProfiler(reporter : ProfileReporter, val settings: S
       case gc =>
     }
     reporter.close(this)
+    if (chromeTrace != null) {
+      for (gcEvent <- gcEvents) {
+        val durationNanos = TimeUnit.MILLISECONDS.toNanos(gcEvent.durationMillis)
+        val startNanos = gcEvent.endNanos - durationNanos
+        chromeTrace.traceDurationEvent(gcEvent.name, startNanos, durationNanos, GcThreadId)
+      }
+      chromeTrace.traceDurationEventEnd(Category.Run, "scalac-" + id)
+      chromeTrace.close()
+    }
   }
 
+  private val gcEvents = ArrayBuffer[GcEventData]()
+  private val GcThreadId = "GC"
 
   override def handleNotification(notification: Notification, handback: scala.Any): Unit = {
     import java.lang.{Long => jLong}
@@ -173,28 +231,17 @@ private [profile] class RealProfiler(reporter : ProfileReporter, val settings: S
         val startTime = info.get("startTime").asInstanceOf[jLong].longValue()
         val endTime = info.get("endTime").asInstanceOf[jLong].longValue()
         val threads = info.get("GcThreadCount").asInstanceOf[jInt].longValue()
-        reporter.reportGc(GcEventData("", reportNs, startTime, endTime, name, action, cause, threads))
+        val gcEvent = GcEventData("", reportNs, startTime, endTime, duration, name, action, cause, threads)
+        synchronized {
+          gcEvents += gcEvent
+        }
+        reporter.reportGc(gcEvent)
     }
-  }
-
-  override def afterPhase(phase: Phase, snapBefore: ProfileSnap): Unit = {
-    assert(mainThread eq Thread.currentThread())
-    val initialSnap = snapThread(0)
-    active foreach {_.afterPhase(phase)}
-    if (settings.YprofileExternalTool.containsPhase(phase)) {
-      println("Profile hook stop")
-      ExternalToolHook.after()
-    }
-    val finalSnap = if (settings.YprofileRunGcBetweenPhases.containsPhase(phase)) {
-      doGC
-      initialSnap.updateHeap(readHeapUsage())
-    } else initialSnap
-
-    reporter.reportForeground(this, ProfileRange(snapBefore, finalSnap, phase, "", 0, Thread.currentThread))
   }
 
   override def beforePhase(phase: Phase): ProfileSnap = {
     assert(mainThread eq Thread.currentThread())
+    if (chromeTrace != null) chromeTrace.traceDurationEventStart(Category.Phase, phase.name)
     if (settings.YprofileRunGcBetweenPhases.containsPhase(phase))
       doGC
     if (settings.YprofileExternalTool.containsPhase(phase)) {
@@ -202,9 +249,98 @@ private [profile] class RealProfiler(reporter : ProfileReporter, val settings: S
       ExternalToolHook.before()
     }
     active foreach {_.beforePhase(phase)}
-    snapThread(0)
+    RealProfiler.snapThread(0)
   }
 
+  override def afterPhase(phase: Phase, snapBefore: ProfileSnap): Unit = {
+    assert(mainThread eq Thread.currentThread())
+    val initialSnap = RealProfiler.snapThread(0)
+    active foreach {_.afterPhase(phase)}
+    if (settings.YprofileExternalTool.containsPhase(phase)) {
+      println("Profile hook stop")
+      ExternalToolHook.after()
+    }
+    val finalSnap = if (settings.YprofileRunGcBetweenPhases.containsPhase(phase)) {
+      doGC
+      initialSnap.updateHeap(RealProfiler.readHeapUsage())
+    } else initialSnap
+    if (chromeTrace != null) chromeTrace.traceDurationEventEnd(Category.Phase, phase.name)
+
+    reporter.reportForeground(this, ProfileRange(snapBefore, finalSnap, phase, "", 0, Thread.currentThread))
+  }
+
+  override def beforeUnit(phase: Phase, file: AbstractFile): Unit = {
+    assert(mainThread eq Thread.currentThread())
+    if (chromeTrace != null) chromeTrace.traceDurationEventStart(Category.File, file.name)
+  }
+
+  private var nextAfterUnitSnap: Long = System.nanoTime()
+
+  override def afterUnit(phase: Phase, file: AbstractFile): Unit = {
+    assert(mainThread eq Thread.currentThread())
+    if (chromeTrace != null) {
+      val now = System.nanoTime()
+      chromeTrace.traceDurationEventEnd(Category.File, file.name)
+      if (now > nextAfterUnitSnap) {
+        val initialSnap = RealProfiler.snapThread(0)
+        chromeTrace.traceCounterEvent("allocBytes", "allocBytes", initialSnap.allocatedBytes, processWide = false)
+        chromeTrace.traceCounterEvent("heapBytes", "heapBytes", initialSnap.heapBytes, processWide = true)
+        chromeTrace.traceCounterEvent("classesLoaded", "classesLoaded", initialSnap.totalClassesLoaded, processWide = true)
+        chromeTrace.traceCounterEvent("jitCompilationTime", "jitCompilationTime", initialSnap.totalJITCompilationTime, processWide = true)
+        chromeTrace.traceCounterEvent("userTime", "userTime", initialSnap.userTimeNanos, processWide = false)
+        chromeTrace.traceCounterEvent("cpuTime", "cpuTime", initialSnap.cpuTimeNanos, processWide = false)
+        chromeTrace.traceCounterEvent("idleTime", "idleTime", initialSnap.idleTimeNanos, processWide = false)
+        nextAfterUnitSnap = System.nanoTime() + 10 * 1000 * 1000
+      }
+    }
+  }
+
+  override def beforeTypedImplDef(sym: Global#Symbol): Unit = {
+    if (chromeTrace != null) chromeTrace.traceDurationEventStart(Category.TypeCheck, sym.rawname.toString)
+  }
+  override def afterTypedImplDef(sym: Global#Symbol): Unit = {
+    if (chromeTrace != null) chromeTrace.traceDurationEventEnd(Category.TypeCheck, sym.rawname.toString)
+  }
+
+  override def beforeImplicitSearch(pt: Global#Type): Unit = {
+    if (chromeTrace != null) chromeTrace.traceDurationEventStart(Category.Implicit, "?[" + pt.typeSymbol.rawname + "]", colour = "yellow")
+  }
+
+  override def afterImplicitSearch(pt: Global#Type): Unit = {
+    if (chromeTrace != null) chromeTrace.traceDurationEventEnd(Category.Implicit, "?[" + pt.typeSymbol.rawname + "]", colour = "yellow")
+  }
+
+  override def beforeMacroExpansion(macroSym: Global#Symbol): Unit = {
+    if (chromeTrace != null) chromeTrace.traceDurationEventStart(Category.Macro, "«" + macroSym.rawname + "»", colour = "olive")
+  }
+
+  override def afterMacroExpansion(macroSym: Global#Symbol): Unit = {
+    if (chromeTrace != null) chromeTrace.traceDurationEventEnd(Category.Macro, "«" + macroSym.rawname + "»", colour = "olive")
+  }
+
+  override def beforeCompletion(root: Global#Symbol, associatedFile: AbstractFile): Unit = {
+    if (chromeTrace != null) {
+      chromeTrace.traceDurationEventStart(Category.Completion, "↯", colour = "thread_state_sleeping")
+      chromeTrace.traceDurationEventStart(Category.File, associatedFile.name)
+      chromeTrace.traceDurationEventStart(Category.Completion, completionName(root, associatedFile))
+    }
+  }
+
+  override def afterCompletion(root: Global#Symbol, associatedFile: AbstractFile): Unit = {
+    if (chromeTrace != null) {
+      chromeTrace.traceDurationEventEnd(Category.Completion, completionName(root, associatedFile))
+      chromeTrace.traceDurationEventEnd(Category.File, associatedFile.name)
+      chromeTrace.traceDurationEventEnd(Category.Completion, "↯", colour = "thread_state_sleeping")
+    }
+  }
+
+  private def completionName(root: Global#Symbol, associatedFile: AbstractFile): String = {
+    if (root.hasPackageFlag || root.isTopLevel) root.javaBinaryNameString
+    else {
+      val enclosing = root.enclosingTopLevelClass
+      enclosing.javaBinaryNameString + "::" + root.rawname.toString
+    }
+  }
 }
 
 object EventType extends Enumeration {
@@ -228,24 +364,23 @@ sealed trait ProfileReporter {
 }
 
 object ConsoleProfileReporter extends ProfileReporter {
+  private val outWriter = new PrintWriter(Console.out)
+  private val delegate = new StreamProfileReporter(new PrintWriter(Console.out))
+  override def reportBackground(profiler: RealProfiler, threadRange: ProfileRange): Unit = delegate.reportBackground(profiler, threadRange)
+  override def reportForeground(profiler: RealProfiler, threadRange: ProfileRange): Unit = delegate.reportForeground(profiler, threadRange)
+  override def close(profiler: RealProfiler): Unit = outWriter.flush()
 
+  override def header(profiler: RealProfiler): Unit = delegate.header(profiler)
+  override def reportGc(data: GcEventData): Unit = delegate.reportGc(data)
+}
 
-  override def reportBackground(profiler: RealProfiler, threadRange: ProfileRange): Unit =
-  // TODO
-    ???
-  override def reportForeground(profiler: RealProfiler, threadRange: ProfileRange): Unit =
-  // TODO
-    ???
-
+object NoOpProfileReporter extends ProfileReporter {
+  override def reportBackground(profiler: RealProfiler, threadRange: ProfileRange): Unit = ()
+  override def reportForeground(profiler: RealProfiler, threadRange: ProfileRange): Unit = ()
   override def close(profiler: RealProfiler): Unit = ()
 
-  override def header(profiler: RealProfiler): Unit = {
-    println(s"Profiler start (${profiler.id}) ${profiler.outDir}")
-  }
-
-  override def reportGc(data: GcEventData): Unit = {
-    println(f"Profiler GC reported ${data.gcEndMillis - data.gcStartMillis}ms")
-  }
+  override def header(profiler: RealProfiler): Unit = ()
+  override def reportGc(data: GcEventData): Unit = ()
 }
 
 class StreamProfileReporter(out:PrintWriter) extends ProfileReporter {
@@ -271,10 +406,8 @@ class StreamProfileReporter(out:PrintWriter) extends ProfileReporter {
     out.println(s"${EventType.GC},$start,${data.reportTimeNs},${data.gcStartMillis}, ${data.gcEndMillis},${data.name},${data.action},${data.cause},${data.threads}")
   }
 
-
   override def close(profiler: RealProfiler): Unit = {
-    out.flush
-    out.close
+    out.flush()
+    out.close()
   }
 }
-

--- a/src/compiler/scala/tools/nsc/profile/ThreadPoolFactory.scala
+++ b/src/compiler/scala/tools/nsc/profile/ThreadPoolFactory.scala
@@ -98,9 +98,9 @@ object ThreadPoolFactory {
       val data = new ThreadProfileData
       localData.set(data)
 
-      val profileStart = profiler.snapThread(0)
+      val profileStart = RealProfiler.snapThread(0)
       try worker.run finally {
-        val snap = profiler.snapThread(data.idleNs)
+        val snap = RealProfiler.snapThread(data.idleNs)
         val threadRange = ProfileRange(profileStart, snap, phase, shortId, data.taskCount, Thread.currentThread())
         profiler.completeBackground(threadRange)
       }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -415,7 +415,9 @@ trait ScalaSettings extends AbsScalaSettings
   override def YhotStatisticsEnabled = YhotStatistics.value
 
   val YprofileEnabled = BooleanSetting("-Yprofile-enabled", "Enable profiling.")
-  val YprofileDestination = StringSetting("-Yprofile-destination", "file", "where to send profiling output - specify a file, default is to the console.", "").
+  val YprofileDestination = StringSetting("-Yprofile-destination", "file", "Profiling output - specify a file or `-` for console.", "").
+    withPostSetHook( _ => YprofileEnabled.value = true )
+  val YprofileTrace = StringSetting("-Yprofile-trace", "file", "Capture trace of compilation in Chrome Trace format", "profile.trace").
     withPostSetHook( _ => YprofileEnabled.value = true )
   val YprofileExternalTool = PhasesSetting("-Yprofile-external-tool", "Enable profiling for a phase using an external tool hook. Generally only useful for a single phase", "typer").
     withPostSetHook( _ => YprofileEnabled.value = true )

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -87,6 +87,15 @@ trait Implicits {
    *  @return                        A search result
    */
   def inferImplicit(tree: Tree, pt: Type, reportAmbiguous: Boolean, isView: Boolean, context: Context, saveAmbiguousDivergent: Boolean, pos: Position): SearchResult = {
+    currentRun.profiler.beforeImplicitSearch(pt)
+    try {
+      inferImplicit1(tree, pt, reportAmbiguous, isView, context, saveAmbiguousDivergent, pos)
+    } finally {
+      currentRun.profiler.afterImplicitSearch(pt)
+    }
+  }
+
+  private def inferImplicit1(tree: Tree, pt: Type, reportAmbiguous: Boolean, isView: Boolean, context: Context, saveAmbiguousDivergent: Boolean, pos: Position): SearchResult = {
     // Note that the isInvalidConversionTarget seems to make a lot more sense right here, before all the
     // work is performed, than at the point where it presently exists.
     val shouldPrint     = printTypings && !context.undetparams.isEmpty

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -770,7 +770,13 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
     // By default, use the current typer's fresh name creator in macros. The compiler option
     // allows people to opt in to the old behaviour of Scala 2.12, which used a global fresh creator.
     if (!settings.YmacroFresh.value) currentFreshNameCreator = typer.fresh
-    pluginsMacroExpand(typer, expandee, mode, pt)
+    val macroSym = expandee.symbol
+    currentRun.profiler.beforeMacroExpansion(macroSym)
+    try {
+      pluginsMacroExpand(typer, expandee, mode, pt)
+    } finally {
+      currentRun.profiler.afterMacroExpansion(macroSym)
+    }
   }
 
   /** Default implementation of `macroExpand`.

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.internal.{TreeGen => InternalTreeGen}
+import scala.reflect.io.AbstractFile
 
 abstract class SymbolTable extends macros.Universe
                               with Collections
@@ -493,6 +494,9 @@ abstract class SymbolTable extends macros.Universe
    * Adds the `sm` String interpolator to a [[scala.StringContext]].
    */
   implicit val StringContextStripMarginOps: StringContext => StringContextStripMarginOps = util.StringContextStripMarginOps
+
+  protected[scala] def currentRunProfilerBeforeCompletion(root: Symbol, associatedFile: AbstractFile): Unit = ()
+  protected[scala] def currentRunProfilerAfterCompletion(root: Symbol, associatedFile: AbstractFile): Unit = ()
 }
 
 trait SymbolTableStats {

--- a/src/reflect/scala/reflect/internal/util/ChromeTrace.scala
+++ b/src/reflect/scala/reflect/internal/util/ChromeTrace.scala
@@ -1,0 +1,189 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.reflect.internal.util
+
+import java.io.Closeable
+import java.lang.management.ManagementFactory
+import java.nio.file.{Files, Path}
+import java.util
+import java.util.concurrent.TimeUnit
+
+import scala.collection.mutable
+
+object ChromeTrace {
+
+  private object EventType {
+    final val Start = "B"
+    final val Instant = "I"
+    final val End = "E"
+    final val Complete = "X"
+
+    final val Counter = "C"
+
+    final val AsyncStart = "b"
+    final val AsyncInstant = "n"
+    final val AsyncEnd = "e"
+  }
+
+}
+
+/** Allows writing a subset of of https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#
+  * for use in Chrome's about://tracing or the tooling in https://www.google.com.au/search?q=catapult+tracing&oq=catapult+tracing+&aqs=chrome..69i57.3974j0j4&sourceid=chrome&ie=UTF-8 */
+final class ChromeTrace(f: Path) extends Closeable {
+  import ChromeTrace.EventType
+  private val traceWriter = FileUtils.newAsyncBufferedWriter(f)
+  private val context = mutable.ArrayStack[JsonContext](TopContext)
+  private val tidCache = new ThreadLocal[String]() {
+    override def initialValue(): String = Thread.currentThread().getId.formatted("%05d")
+  }
+  objStart()
+  fld("traceEvents")
+  context.push(ValueContext)
+  arrStart()
+  traceWriter.newLine()
+
+  private val pid = ManagementFactory.getRuntimeMXBean().getName().replaceAll("@.*", "")
+
+  override def close(): Unit = {
+    arrEnd()
+    objEnd()
+    context.pop()
+    tidCache.remove()
+    traceWriter.close()
+  }
+
+  def traceDurationEvent(name: String, startNanos: Long, durationNanos: Long, tid: String = this.tid(), pidSuffix: String = ""): Unit = {
+    val durationMicros = nanosToMicros(durationNanos)
+    val startMicros = nanosToMicros(startNanos)
+    objStart()
+    str("cat", "scalac")
+    str("name", name)
+    str("ph", EventType.Complete)
+    str("tid", tid)
+    writePid(pidSuffix)
+    lng("ts", startMicros)
+    lng("dur", durationMicros)
+    objEnd()
+    traceWriter.newLine()
+  }
+
+  private def writePid(pidSuffix: String) = {
+    if (pidSuffix == "")
+      str("pid", pid)
+    else
+      str2("pid", pid, "-", pidSuffix)
+  }
+
+  def traceCounterEvent(name: String, counterName: String, count: Long, processWide: Boolean): Unit = {
+    objStart()
+    str("cat", "scalac")
+    str("name", name)
+    str("ph", EventType.Counter)
+    str("tid", tid())
+    writePid(pidSuffix = if (processWide) "" else tid())
+    lng("ts", microTime())
+    fld("args")
+    objStart()
+    lng(counterName, count)
+    objEnd()
+    objEnd()
+    traceWriter.newLine()
+  }
+
+  def traceDurationEventStart(cat: String, name: String, colour: String = "", pidSuffix: String = tid()): Unit = traceDurationEventStartEnd(EventType.Start, cat, name, colour, pidSuffix)
+  def traceDurationEventEnd(cat: String, name: String, colour: String = "", pidSuffix: String = tid()): Unit = traceDurationEventStartEnd(EventType.End, cat, name, colour, pidSuffix)
+
+  private def traceDurationEventStartEnd(eventType: String, cat: String, name: String, colour: String, pidSuffix: String = ""): Unit = {
+    objStart()
+    str("cat", cat)
+    str("name", name)
+    str("ph", eventType)
+    writePid(pidSuffix)
+    str("tid", tid())
+    lng("ts", microTime())
+    if (colour != "") {
+      str("cname", colour)
+    }
+    objEnd()
+    traceWriter.newLine()
+  }
+
+  private def tid(): String = tidCache.get()
+
+  private def nanosToMicros(t: Long): Long = TimeUnit.NANOSECONDS.toMicros(t)
+
+  private def microTime(): Long = nanosToMicros(System.nanoTime())
+
+  sealed abstract class JsonContext
+  case class ArrayContext(var first: Boolean) extends JsonContext
+  case class ObjectContext(var first: Boolean) extends JsonContext
+  case object ValueContext extends JsonContext
+  case object TopContext extends JsonContext
+
+  private def str(name: String, value: String): Unit = {
+    fld(name)
+    traceWriter.write("\"")
+    traceWriter.write(value) // This assumes no escaping is needed
+    traceWriter.write("\"")
+  }
+  private def str2(name: String, value: String, valueContinued1: String, valueContinued2: String): Unit = {
+    fld(name)
+    traceWriter.write("\"")
+    traceWriter.write(value) // This assumes no escaping is needed
+    traceWriter.write(valueContinued1) // This assumes no escaping is needed
+    traceWriter.write(valueContinued2) // This assumes no escaping is needed
+    traceWriter.write("\"")
+  }
+  private def lng(name: String, value: Long): Unit = {
+    fld(name)
+    traceWriter.write(String.valueOf(value))
+    traceWriter.write("")
+  }
+  private def objStart(): Unit = {
+    context.top match {
+      case ac @ ArrayContext(first) =>
+        if (first) ac.first = false
+        else traceWriter.write(",")
+      case _ =>
+    }
+    context.push(ObjectContext(true))
+    traceWriter.write("{")
+  }
+  private def objEnd(): Unit = {
+    traceWriter.write("}")
+    context.pop()
+  }
+  private def arrStart(): Unit = {
+    traceWriter.write("[")
+    context.push(ArrayContext(true))
+  }
+  private def arrEnd(): Unit = {
+    traceWriter.write("]")
+    context.pop()
+  }
+
+  private def fld(name: String) = {
+    val topContext = context.top
+    topContext match {
+      case oc @ ObjectContext(first) =>
+        if (first) oc.first = false
+        else traceWriter.write(",")
+      case context =>
+        throw new IllegalStateException("Wrong context: " + context)
+    }
+    traceWriter.write("\"")
+    traceWriter.write(name)
+    traceWriter.write("\"")
+    traceWriter.write(":")
+  }
+}

--- a/src/reflect/scala/reflect/internal/util/FileUtils.scala
+++ b/src/reflect/scala/reflect/internal/util/FileUtils.scala
@@ -1,0 +1,199 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.reflect.internal.util
+
+import java.io.{BufferedWriter, IOException, OutputStreamWriter, Writer}
+import java.nio.CharBuffer
+import java.nio.charset.{Charset, CharsetEncoder, StandardCharsets}
+import java.nio.file.{Files, OpenOption, Path}
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.atomic.AtomicBoolean
+
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Promise}
+import scala.util.{Failure, Success}
+
+object FileUtils {
+  def newAsyncBufferedWriter(path: Path, charset: Charset = StandardCharsets.UTF_8, options: Array[OpenOption] = NO_OPTIONS, threadsafe: Boolean = false): LineWriter = {
+    val encoder: CharsetEncoder = charset.newEncoder
+    val writer = new OutputStreamWriter(Files.newOutputStream(path, options: _*), encoder)
+    newAsyncBufferedWriter(new BufferedWriter(writer), threadsafe)
+  }
+  def newAsyncBufferedWriter(underlying: Writer, threadsafe: Boolean): LineWriter = {
+    val async = new AsyncBufferedWriter(underlying)
+    if (threadsafe) new ThreadsafeWriter(async) else async
+  }
+  private val NO_OPTIONS = new Array[OpenOption](0)
+
+  sealed abstract class LineWriter extends Writer {
+    def newLine(): Unit
+  }
+  private class ThreadsafeWriter(val underlying: AsyncBufferedWriter) extends LineWriter {
+    lock = underlying
+    override def write(c: Int): Unit =
+      lock.synchronized (underlying.write(c))
+
+    override def write(cbuf: Array[Char]): Unit =
+      lock.synchronized (underlying.write(cbuf))
+
+    override def write(cbuf: Array[Char], off: Int, len: Int): Unit =
+      lock.synchronized (underlying.write(cbuf, off, len))
+
+    override def write(str: String): Unit =
+      lock.synchronized (underlying.write(str))
+
+    override def write(str: String, off: Int, len: Int): Unit =
+      lock.synchronized (underlying.write(str, off, len))
+
+    override def flush(): Unit =
+      lock.synchronized (underlying.flush())
+
+    override def close(): Unit =
+      lock.synchronized (underlying.close())
+
+    override def newLine(): Unit =
+      lock.synchronized (underlying.newLine())
+
+  }
+
+  private object AsyncBufferedWriter {
+    private val Close = CharBuffer.allocate(0)
+    private val Flush = CharBuffer.allocate(0)
+  }
+  private class AsyncBufferedWriter(val underlying: Writer, bufferSize : Int = 4096) extends LineWriter {
+    private var current: CharBuffer = allocate
+    override def write(c: Int): Unit = super.write(c)
+    private def flushAsync(): Unit = {
+      background.ensureProcessed(current)
+      current = allocate
+    }
+//    allocate or reuse a CharArray which is guaranteed to have a backing array
+    private def allocate: CharBuffer = {
+      val reused = background.reuseBuffer
+      if (reused eq null)      CharBuffer.allocate(bufferSize)
+      else {
+        //we don't care about race conditions
+        background.reuseBuffer = null
+        reused.clear()
+        reused
+      }
+    }
+
+    override def write(cbuf: Array[Char], initialOffset: Int, initialLength: Int): Unit = {
+      var offset = initialOffset
+      var length = initialLength
+      while (length > 0) {
+        val capacity = current.remaining()
+        if (length <= capacity) {
+          current.put(cbuf, offset, length)
+          length = 0
+        } else {
+          current.put(cbuf, offset, capacity)
+          flushAsync()
+          length -= capacity
+          offset += capacity
+        }
+      }
+    }
+
+    override def write(s: String,  initialOffset: Int, initialLength: Int): Unit = {
+      var offset = initialOffset
+      var length = initialLength
+      while (length > 0) {
+        val capacity = current.remaining()
+        if (length <= capacity) {
+          current.put(s, offset, offset + length)
+          length = 0
+        } else {
+          current.put(s, offset, offset + capacity)
+          flushAsync()
+          length -= capacity
+          offset += capacity
+        }
+      }
+    }
+
+    def newLine(): Unit = write(scala.util.Properties.lineSeparator)
+
+    /** slightly breaks the flush contract in that the flush is not complete when the method returns */
+    override def flush(): Unit = {
+      flushAsync()
+    }
+
+    override def close(): Unit = {
+      background.ensureProcessed(current)
+      background.ensureProcessed(AsyncBufferedWriter.Close)
+      current = null
+      Await.result(background.asyncStatus.future, Duration.Inf)
+      underlying.close()
+    }
+    private object background extends Runnable{
+
+      import scala.concurrent.ExecutionContext.Implicits.global
+
+      private val pending = new LinkedBlockingQueue[CharBuffer]
+      //a failure detected will case an Failure, Success indicates a close
+      val asyncStatus = Promise[Unit]()
+      private val scheduled = new AtomicBoolean
+      @volatile var reuseBuffer: CharBuffer = _
+
+      def ensureProcessed(buffer: CharBuffer): Unit = {
+        if (asyncStatus.isCompleted) {
+          asyncStatus.future.value.get match {
+            case Success(()) => throw new IllegalStateException("closed")
+            case Failure(t) => throw new IOException("async failure", t)
+          }
+        }
+
+        //order is essential - add to the queue before the CAS
+        pending.add(buffer)
+        if (scheduled.compareAndSet(false, true)) {
+          global.execute(background)
+        }
+      }
+
+      def run(): Unit = {
+        try {
+          while (!pending.isEmpty) {
+            val next = pending.poll()
+            if (next eq AsyncBufferedWriter.Flush) {
+              underlying.flush()
+            } else if (next eq AsyncBufferedWriter.Close) {
+              underlying.flush()
+              underlying.close()
+              asyncStatus.trySuccess(())
+            } else {
+              val array = next.array()
+              next.flip()
+              underlying.write(array, next.arrayOffset() + next.position(), next.limit())
+              reuseBuffer = next
+            }
+          }
+        } catch {
+          case t: Throwable =>
+            asyncStatus.tryFailure(t)
+            throw t
+        }
+        finally scheduled.set(false)
+
+        //we are not scheduled any more
+        //as a last check ensure that we didnt race with an addition to the queue
+        //order is essential - queue is checked before CAS
+        if ((!pending.isEmpty) && scheduled.compareAndSet(false, true)) {
+          global.execute(background)
+        }
+      }
+    }
+  }
+}

--- a/test/junit/scala/reflect/internal/util/FileUtilsTest.scala
+++ b/test/junit/scala/reflect/internal/util/FileUtilsTest.scala
@@ -1,0 +1,89 @@
+package scala.reflect.internal.util
+
+import java.io._
+
+import org.junit.Assert._
+import org.junit._
+
+class FileUtilsTest {
+
+  @Test def writeIsSame(): Unit = {
+    val fileTest = File.createTempFile("FileUtilsTest", "t1")
+    val fileExpected = File.createTempFile("FileUtilsTest", "t2")
+
+    val sTest = FileUtils.newAsyncBufferedWriter(new FileWriter(fileTest), false)
+    val sExpected = new BufferedWriter(new FileWriter(fileExpected))
+
+    def writeBoth(s:String, asChars: Boolean) = {
+      if (asChars) {
+        sTest.write(s.toCharArray)
+        sExpected.write(s.toCharArray)
+      } else {
+        sTest.write(s)
+        sExpected.write(s)
+      }
+    }
+
+    for (i <- 1 to 2000) {
+      writeBoth(s"line $i text;", true)
+      writeBoth(s"line $i chars", false)
+      sTest.newLine
+      sExpected.newLine
+    }
+    sTest.close()
+    sExpected.close()
+
+    assertEquals(fileExpected.length(),fileTest.length())
+
+    val expIn = new BufferedReader(new FileReader(fileExpected))
+    val testIn = new BufferedReader(new FileReader(fileTest))
+
+    var exp = expIn.readLine()
+    while (exp ne null) {
+      val actual = testIn.readLine()
+      assertEquals(exp, actual)
+      exp = expIn.readLine()
+    }
+    expIn.close()
+    testIn.close()
+    fileTest.delete()
+    fileExpected.delete()
+  }
+
+  @Test def showPerformance: Unit = {
+    //warmup
+    for (i <- 1 to 1000) {
+      writeIsSame()
+    }
+
+    val fileTest = File.createTempFile("FileUtilsTest", "t1")
+    val fileExpected = File.createTempFile("FileUtilsTest", "t2")
+
+    for (i <- 1 to 10) {
+      val sTest = FileUtils.newAsyncBufferedWriter(fileTest.toPath)
+      val sExpected = new BufferedWriter(new FileWriter(fileExpected))
+
+      val t1 = System.nanoTime()
+      List.tabulate(10000) {i =>
+        sTest.write(s"line $i text;")
+        sTest.newLine
+      }
+      val t2 = System.nanoTime()
+      sTest.close()
+      val t3 = System.nanoTime()
+      List.tabulate(10000) {i =>
+        sExpected.write(s"line $i text;")
+        sExpected.newLine
+      }
+      val t4 = System.nanoTime()
+      sExpected.close()
+
+      println(s"async    took ${t2 - t1} ns")
+      println(s"buffered took ${t4 - t3} ns")
+
+      fileTest.delete()
+      fileExpected.delete()
+    }
+  }
+
+}


### PR DESCRIPTION
Suitable for viewing directly in chrome://tracing, or post processing
with https://github.com/retronym/chrome-trace-to-flamegraph

Co-Authored-By: Mike Skells <mike.skells@talk21.com>

## Demo

Editing an SBT build to add these settings to each project.

```scala
def profileSettings = Seq(Compile, Test).map(config => scalacOptions in config := List("-Ycache-macro-class-loader:last-modified", "-Yprofile-trace")
```

Compiling the project will create:

```
$ find $PWD -name '*.trace' | xargs echo
/code/guardian-frontend/identity/target/compile.trace /code/guardian-frontend/identity/target/test.trace /code/guardian-frontend/archive/target/compile.trace /code/guardian-frontend/archive/target/test.trace /code/guardian-frontend/rss/target/compile.trace /code/guardian-frontend/admin/target/compile.trace /code/guardian-frontend/admin/target/test.trace /code/guardian-frontend/facia/target/compile.trace /code/guardian-frontend/facia/target/test.trace /code/guardian-frontend/sport/target/compile.trace /code/guardian-frontend/sport/target/test.trace /code/guardian-frontend/commercial/target/compile.trace /code/guardian-frontend/commercial/target/test.trace /code/guardian-frontend/common/target/compile.trace /code/guardian-frontend/common/target/test.trace /code/guardian-frontend/diagnostics/target/compile.trace /code/guardian-frontend/diagnostics/target/test.trace /code/guardian-frontend/applications/target/compile.trace /code/guardian-frontend/applications/target/test.trace /code/guardian-frontend/preview/target/compile.trace /code/guardian-frontend/preview/target/test.trace /code/guardian-frontend/article/target/compile.trace /code/guardian-frontend/article/target/test.trace /code/guardian-frontend/discussion/target/compile.trace /code/guardian-frontend/discussion/target/test.trace /code/guardian-frontend/facia-press/target/compile.trace /code/guardian-frontend/facia-press/target/test.trace /code/guardian-frontend/onward/target/compile.trace /code/guardian-frontend/onward/target/test.trace
```

These can be loaded individually into `chrome://tracing` in Chrome.

![image](https://user-images.githubusercontent.com/65551/47342538-52382200-d6e7-11e8-851f-9531da97322e.png)


Post process to aggregate, split events when GC occurs or when lazy type completion occurs

```
$ git clone https://github.com/retronym/chrome-trace-to-flamegraph; cd chrome-trace-to-flamegraph; sbt
...
sbt:chrome-trace-to-flamegraph> runMain io.github.retronym.chrometraceflame.ChromeTraceFlame /code/guardian-frontend/identity/target/compile.trace /code/guardian-frontend/identity/target/test.trace /code/guardian-frontend/archive/target/compile.trace /code/guardian-frontend/archive/target/test.trace /code/guardian-frontend/rss/target/compile.trace /code/guardian-frontend/admin/target/compile.trace /code/guardian-frontend/admin/target/test.trace /code/guardian-frontend/facia/target/compile.trace /code/guardian-frontend/facia/target/test.trace /code/guardian-frontend/sport/target/compile.trace /code/guardian-frontend/sport/target/test.trace /code/guardian-frontend/commercial/target/compile.trace /code/guardian-frontend/commercial/target/test.trace /code/guardian-frontend/common/target/compile.trace /code/guardian-frontend/common/target/test.trace /code/guardian-frontend/diagnostics/target/compile.trace /code/guardian-frontend/diagnostics/target/test.trace /code/guardian-frontend/applications/target/compile.trace /code/guardian-frontend/applications/target/test.trace /code/guardian-frontend/preview/target/compile.trace /code/guardian-frontend/preview/target/test.trace /code/guardian-frontend/article/target/compile.trace /code/guardian-frontend/article/target/test.trace /code/guardian-frontend/discussion/target/compile.trace /code/guardian-frontend/discussion/target/test.trace /code/guardian-frontend/facia-press/target/compile.trace /code/guardian-frontend/facia-press/target/test.trace /code/guardian-frontend/onward/target/compile.trace /code/guardian-frontend/onward/target/test.trace
[info] Running io.github.retronym.chrometraceflame.ChromeTraceFlame /code/guardian-frontend/identity/target/compile.trace /code/guardian-frontend/identity/target/test.trace /code/guardian-frontend/archive/target/compile.trace /code/guardian-frontend/archive/target/test.trace /code/guardian-frontend/rss/target/compile.trace /code/guardian-frontend/admin/target/compile.trace /code/guardian-frontend/admin/target/test.trace /code/guardian-frontend/facia/target/compile.trace /code/guardian-frontend/facia/target/test.trace /code/guardian-frontend/sport/target/compile.trace /code/guardian-frontend/sport/target/test.trace /code/guardian-frontend/commercial/target/compile.trace /code/guardian-frontend/commercial/target/test.trace /code/guardian-frontend/common/target/compile.trace /code/guardian-frontend/common/target/test.trace /code/guardian-frontend/diagnostics/target/compile.trace /code/guardian-frontend/diagnostics/target/test.trace /code/guardian-frontend/applications/target/compile.trace /code/guardian-frontend/applications/target/test.trace /code/guardian-frontend/preview/target/compile.trace /code/guardian-frontend/preview/target/test.trace /code/guardian-frontend/article/target/compile.trace /code/guardian-frontend/article/target/test.trace /code/guardian-frontend/discussion/target/compile.trace /code/guardian-frontend/discussion/target/test.trace /code/guardian-frontend/facia-press/target/compile.trace /code/guardian-frontend/facia-press/target/test.trace /code/guardian-frontend/onward/target/compile.trace /code/guardian-frontend/onward/target/test.trace
[success] Total time: 4 s, completed 23/10/2018 5:03:58 PM
sbt:chrome-trace-to-flamegraph> [info] shutting down server
/code/chrome-trace-to-flamegraph on master*

$ ls -la /tmp/combined.*
-rw-r--r--  1 jz  wheel   5998325 Oct 23 17:03 /tmp/combined.csv
-rw-r--r--  1 jz  wheel  37307335 Oct 23 17:03 /tmp/combined.trace
```

`combined.trace` can be viewed in `chrome:/tracing`.

![image](https://user-images.githubusercontent.com/65551/47342478-29b02800-d6e7-11e8-9392-98d5f54850f0.png)


Generate flame graphs.

```
$ cat /tmp/combined.csv | /code/FlameGraph/flamegraph.pl --minwidth 2 --width 2000 - > /tmp/combined.svg
$ cat /tmp/combined.csv | /code/FlameGraph/flamegraph.pl --minwidth 2 --width 2000 --reverse - > /tmp/combined-reverse.svg
```

## UPDATE

[speedscope.app](https://speedscope.app) can now import the `compile.trace` file directly and render both the trace view (what happens over time) and the flamegraph view.