### PR TITLE
Avoid intermittent "cannot create classes.bak" SBT error.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -164,7 +164,7 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
     "-doc-source-url", s"https://github.com/scala/scala/tree/${versionProperties.value.githubTree}€{FILE_PATH}.scala#L1"
   ),
   //maxErrors := 10,
-  incOptions := (incOptions in LocalProject("root")).value,
+  setIncOptions,
   apiURL := Some(url("http://www.scala-lang.org/api/" + versionProperties.value.mavenVersion + "/")),
   pomIncludeRepository := { _ => false },
   pomExtra := {
@@ -944,10 +944,7 @@ lazy val root: Project = (project in file("."))
         throw new RuntimeException
       }
     },
-    incOptions := {
-      incOptions.value
-        .withRecompileOnMacroDef(Some(Boolean box false).asJava) // macros in library+reflect are hard-wired to implementations with `FastTrack`.
-    }
+    setIncOptions
   )
   .aggregate(library, reflect, compiler, compilerOptionsExporter, interactive, repl, replFrontend,
     scaladoc, scalap, partest, junit, scalaDist).settings(
@@ -955,6 +952,11 @@ lazy val root: Project = (project in file("."))
     onLoadMessage := """|*** Welcome to the sbt build definition for Scala! ***
       |Check README.md for more information.""".stripMargin
   )
+
+def setIncOptions = incOptions := {
+  incOptions.value
+    .withRecompileOnMacroDef(Some(Boolean box false).asJava) // macros in library+reflect are hard-wired to implementations with `FastTrack`.
+}
 
 // The following subprojects' binaries are required for building "pack":
 lazy val distDependencies = Seq(replFrontend, compiler, library, reflect, scalap, scaladoc)


### PR DESCRIPTION
Our subprojects were sharing the `incOptions` value from the root
project, which includes the class backup directory derived from
the root project's `crossTarget` setting.

Instead, we should share the code to modify the `incOptions`.

Before:

```
sbt:root> show library/incOptions
[info] IncOptions(transitiveStep: 3, recompileAllFraction: 0.5, relationsDebug: false, apiDebug: false, apiDiffContextSize: 5, apiDumpDirectory: Optional.empty, classfileManagerType: Optional[TransactionalManagerType(backupDirectory: /Users/jz/code/scala/target/scala-2.13.0-M5/classes.bak, logger: sbt.util.Logger$$anon$2@c7ba58d)], useCustomizedFileManager: false, recompileOnMacroDef: Optional[false], useOptimizedSealed: false, storeApis: true, enabled: true, extra: {}, logRecompileOnMacro: true, externalHooks: xsbti.compile.DefaultExternalHooks@2d579733, ignoredScalacOptions: [Ljava.lang.String;@282c2bbd)
```

After:
```
sbt:root> show library/incOptions
[info] IncOptions(transitiveStep: 3, recompileAllFraction: 0.5, relationsDebug: false, apiDebug: false, apiDiffContextSize: 5, apiDumpDirectory: Optional.empty, classfileManagerType: Optional[TransactionalManagerType(backupDirectory: /Users/jz/code/scala/target/library/classes.bak, logger: sbt.util.Logger$$anon$2@c7ba58d)], useCustomizedFileManager: false, recompileOnMacroDef: Optional[false], useOptimizedSealed: false, storeApis: true, enabled: true, extra: {}, logRecompileOnMacro: true, externalHooks: xsbti.compile.DefaultExternalHooks@5e425ceb, ignoredScalacOptions: [Ljava.lang.String;@26af3265)
```