### PR TITLE
Resource management for macro/plugin classloaders, classpath JARs

### DIFF
--- a/src/compiler/scala/reflect/macros/runtime/MacroRuntimes.scala
+++ b/src/compiler/scala/reflect/macros/runtime/MacroRuntimes.scala
@@ -54,23 +54,8 @@ trait MacroRuntimes extends JavaReflectionRuntimes {
   /** Macro classloader that is used to resolve and run macro implementations.
    *  Loads classes from from -cp (aka the library classpath).
    *  Is also capable of detecting REPL and reusing its classloader.
-   *
-   *  When -Xmacro-jit is enabled, we sometimes fallback to on-the-fly compilation of macro implementations,
-   *  which compiles implementations into a virtual directory (very much like REPL does) and then conjures
-   *  a classloader mapped to that virtual directory.
    */
-  private lazy val defaultMacroClassloaderCache = {
-    def attemptClose(loader: ClassLoader): Unit = {
-      if (!scala.tools.nsc.typechecker.Macros.macroClassLoadersCache.owns(loader)) {
-        loader match {
-          case u: URLClassLoader => debuglog("Closing macro runtime classloader"); u.close()
-          case afcl: AbstractFileClassLoader => attemptClose(afcl.getParent)
-          case _ => ???
-        }
-      }
-    }
-    perRunCaches.newGeneric(findMacroClassLoader, attemptClose _)
-  }
+  private lazy val defaultMacroClassloaderCache: () => ClassLoader = perRunCaches.newGeneric(findMacroClassLoader())
   def defaultMacroClassloader: ClassLoader = defaultMacroClassloaderCache()
 
   /** Abstracts away resolution of macro runtimes.

--- a/src/compiler/scala/reflect/macros/runtime/MacroRuntimes.scala
+++ b/src/compiler/scala/reflect/macros/runtime/MacroRuntimes.scala
@@ -60,10 +60,14 @@ trait MacroRuntimes extends JavaReflectionRuntimes {
    *  a classloader mapped to that virtual directory.
    */
   private lazy val defaultMacroClassloaderCache = {
-    def attemptClose(loader: ClassLoader): Unit = loader match {
-      case u: URLClassLoader => debuglog("Closing macro runtime classloader"); u.close()
-      case afcl: AbstractFileClassLoader => attemptClose(afcl.getParent)
-      case _ => ???
+    def attemptClose(loader: ClassLoader): Unit = {
+      if (!scala.tools.nsc.typechecker.Macros.macroClassLoadersCache.owns(loader)) {
+        loader match {
+          case u: URLClassLoader => debuglog("Closing macro runtime classloader"); u.close()
+          case afcl: AbstractFileClassLoader => attemptClose(afcl.getParent)
+          case _ => ???
+        }
+      }
     }
     perRunCaches.newGeneric(findMacroClassLoader, attemptClose _)
   }

--- a/src/compiler/scala/tools/nsc/CloseableRegistry.scala
+++ b/src/compiler/scala/tools/nsc/CloseableRegistry.scala
@@ -1,0 +1,34 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.nsc
+
+import scala.util.control.NonFatal
+
+/** Registry for resources to close when `Global` is closed */
+final class CloseableRegistry {
+  private[this] var closeables: List[java.io.Closeable] = Nil
+  final def registerClosable(c: java.io.Closeable): Unit = {
+    closeables ::= c
+  }
+
+  def close(): Unit = {
+    for (c <- closeables) {
+      try {
+        c.close()
+      } catch {
+        case NonFatal(_) =>
+      }
+    }
+    closeables = Nil
+  }
+}

--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -16,7 +16,14 @@ import java.net.URL
 import scala.tools.util.PathResolver
 
 class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
-  lazy val classpathURLs: Seq[URL] = new PathResolver(this).resultAsURLs
+  lazy val classpathURLs: Seq[URL] = {
+    val registry = new CloseableRegistry
+    try {
+      new PathResolver(this, new CloseableRegistry).resultAsURLs
+    } finally {
+      registry.close()
+    }
+  }
 
   val howtorun =
     ChoiceSetting(

--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -19,7 +19,7 @@ class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
   lazy val classpathURLs: Seq[URL] = {
     val registry = new CloseableRegistry
     try {
-      new PathResolver(this, new CloseableRegistry).resultAsURLs
+      new PathResolver(this, registry).resultAsURLs
     } finally {
       registry.close()
     }

--- a/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
+++ b/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
@@ -27,7 +27,7 @@ trait JavaPlatform extends Platform {
   private[nsc] var currentClassPath: Option[ClassPath] = None
 
   private[nsc] def classPath: ClassPath = {
-    if (currentClassPath.isEmpty) currentClassPath = Some(new PathResolver(settings).result)
+    if (currentClassPath.isEmpty) currentClassPath = Some(new PathResolver(settings, global.closeableRegistry).result)
     currentClassPath.get
   }
 

--- a/src/compiler/scala/tools/nsc/classpath/AggregateClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/AggregateClassPath.scala
@@ -65,7 +65,6 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
   override def asClassPathStrings: Seq[String] = aggregates.map(_.asClassPathString).distinct
 
   override def asSourcePathString: String = ClassPath.join(aggregates map (_.asSourcePathString): _*)
-
   override private[nsc] def packages(inPackage: String): Seq[PackageEntry] = {
     val aggregatedPackages = aggregates.flatMap(_.packages(inPackage)).distinct
     aggregatedPackages

--- a/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
@@ -14,7 +14,7 @@ package scala.tools.nsc.classpath
 
 import scala.reflect.io.{AbstractFile, VirtualDirectory}
 import scala.reflect.io.Path.string2path
-import scala.tools.nsc.Settings
+import scala.tools.nsc.{CloseableRegistry, Settings}
 import FileUtils.AbstractFileOps
 import scala.tools.nsc.util.ClassPath
 
@@ -22,11 +22,11 @@ import scala.tools.nsc.util.ClassPath
  * Provides factory methods for classpath. When creating classpath instances for a given path,
  * it uses proper type of classpath depending on a types of particular files containing sources or classes.
  */
-class ClassPathFactory(settings: Settings) {
+class ClassPathFactory(settings: Settings, closeableRegistry: CloseableRegistry) {
   /**
     * Create a new classpath based on the abstract file.
     */
-  def newClassPath(file: AbstractFile): ClassPath = ClassPathFactory.newClassPath(file, settings)
+  def newClassPath(file: AbstractFile): ClassPath = ClassPathFactory.newClassPath(file, settings, closeableRegistry)
 
   /**
     * Creators for sub classpaths which preserve this context.
@@ -70,7 +70,7 @@ class ClassPathFactory(settings: Settings) {
 
   private def createSourcePath(file: AbstractFile): ClassPath =
     if (file.isJarOrZip)
-      ZipAndJarSourcePathFactory.create(file, settings)
+      ZipAndJarSourcePathFactory.create(file, settings, closeableRegistry)
     else if (file.isDirectory)
       DirectorySourcePath(file.file)
     else
@@ -78,11 +78,11 @@ class ClassPathFactory(settings: Settings) {
 }
 
 object ClassPathFactory {
-  def newClassPath(file: AbstractFile, settings: Settings): ClassPath = file match {
+  def newClassPath(file: AbstractFile, settings: Settings, closeableRegistry: CloseableRegistry): ClassPath = file match {
     case vd: VirtualDirectory => VirtualDirectoryClassPath(vd)
     case _ =>
       if (file.isJarOrZip)
-        ZipAndJarClassPathFactory.create(file, settings)
+        ZipAndJarClassPathFactory.create(file, settings, closeableRegistry)
       else if (file.isDirectory)
         DirectoryClassPath(file.file)
       else

--- a/src/compiler/scala/tools/nsc/classpath/VirtualDirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/VirtualDirectoryClassPath.scala
@@ -37,7 +37,6 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
   // mimic the behavior of the old nsc.util.DirectoryClassPath
   def asURLs: Seq[URL] = Seq(new URL(dir.name))
   def asClassPathStrings: Seq[String] = Seq(dir.path)
-
   override def findClass(className: String): Option[ClassRepresentation] = findClassFile(className) map ClassFileEntryImpl
 
   def findClassFile(className: String): Option[AbstractFile] = {

--- a/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
@@ -190,6 +190,7 @@ final class FileBasedCache[T] {
   import java.nio.file.Path
   private case class Stamp(lastModified: FileTime, fileKey: Object)
   private val cache = collection.mutable.Map.empty[Seq[Path], (Seq[Stamp], T)]
+  def owns(t: T): Boolean = cache.valuesIterator.exists(_._2.asInstanceOf[AnyRef] eq t.asInstanceOf[AnyRef])
 
   def getOrCreate(paths: Seq[Path], create: () => T): T = cache.synchronized {
     val stamps = paths.map { path =>

--- a/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
@@ -190,7 +190,6 @@ final class FileBasedCache[T] {
   import java.nio.file.Path
   private case class Stamp(lastModified: FileTime, fileKey: Object)
   private val cache = collection.mutable.Map.empty[Seq[Path], (Seq[Stamp], T)]
-  def owns(t: T): Boolean = cache.valuesIterator.exists(_._2.asInstanceOf[AnyRef] eq t.asInstanceOf[AnyRef])
 
   def getOrCreate(paths: Seq[Path], create: () => T): T = cache.synchronized {
     val stamps = paths.map { path =>

--- a/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
@@ -244,6 +244,11 @@ final class FileBasedCache[T] {
 }
 
 object FileBasedCache {
+  // The tension here is that too long a delay could lead to an error (on Windows) with an inability
+  // to overwrite the JAR. To short a delay and the entry could be evicted before a subsequent
+  // sub-project compilation is able to get a cache hit. A more comprehensive solution would be to
+  // involve build tools in the policy: they could close entries with refcount of zero when that
+  // entry's JAR is about to be overwritten.
   private val deferCloseMs = Integer.getInteger("scalac.filebasedcache.defer.close.ms", 1000)
   private val timer: Option[Timer] = {
     if (deferCloseMs > 0)

--- a/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
@@ -12,8 +12,9 @@
 
 package scala.tools.nsc.classpath
 
-import java.io.File
+import java.io.{Closeable, File}
 import java.net.URL
+
 import scala.reflect.io.AbstractFile
 import scala.reflect.io.FileZipArchive
 import FileUtils.AbstractFileOps
@@ -24,7 +25,7 @@ import scala.tools.nsc.util.{ClassPath, ClassRepresentation}
  * It provides common logic for classes handling class and source files.
  * It's aware of things like e.g. META-INF directory which is correctly skipped.
  */
-trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
+trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPath with Closeable {
   val zipFile: File
   def release: Option[String]
 
@@ -32,8 +33,8 @@ trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPa
 
   override def asURLs: Seq[URL] = Seq(zipFile.toURI.toURL)
   override def asClassPathStrings: Seq[String] = Seq(zipFile.getPath)
-
   private val archive = new FileZipArchive(zipFile, release)
+  override def close(): Unit = archive.close()
 
   override private[nsc] def packages(inPackage: String): Seq[PackageEntry] = {
     val prefix = PackageNameUtils.packagePrefix(inPackage)

--- a/src/compiler/scala/tools/nsc/plugins/Plugin.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugin.scala
@@ -95,26 +95,7 @@ object Plugin {
 
   private val PluginXML = "scalac-plugin.xml"
 
-  private val pluginClassLoadersCache = new FileBasedCache[ScalaClassLoader]()
-
-  /** Create a class loader with the specified locations plus
-   *  the loader that loaded the Scala compiler.
-   *
-   *  If the class loader has already been created before and the
-   *  file stamps are the same, the previous loader is returned to
-   *  mitigate the cost of dynamic classloading as it has been
-   *  measured in https://github.com/scala/scala-dev/issues/458.
-   */
-  def loaderFor(locations: Seq[Path], disableCache: Boolean): ScalaClassLoader = {
-    def newLoader = () => {
-      val compilerLoader = classOf[Plugin].getClassLoader
-      val urls = locations map (_.toURL)
-      ScalaClassLoader fromURLs (urls, compilerLoader)
-    }
-
-    if (disableCache || locations.exists(!Jar.isJarOrZip(_))) newLoader()
-    else pluginClassLoadersCache.getOrCreate(locations.map(_.jfile.toPath()), newLoader)
-  }
+  private[nsc] val pluginClassLoadersCache = new FileBasedCache[ScalaClassLoader.URLClassLoader]()
 
   /** Try to load a plugin description from the specified location.
    */

--- a/src/compiler/scala/tools/nsc/plugins/Plugin.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugin.scala
@@ -97,20 +97,6 @@ object Plugin {
 
   private[nsc] val pluginClassLoadersCache = new FileBasedCache[ScalaClassLoader.URLClassLoader]()
 
-  /** Try to load a plugin description from the specified location.
-   */
-  private def loadDescriptionFromJar(jarp: Path): Try[PluginDescription] = {
-    // XXX Return to this once we have more ARM support
-    def read(is: Option[InputStream]) = is match {
-      case None     => throw new PluginLoadException(jarp.path, s"Missing $PluginXML in $jarp")
-      case Some(is) => PluginDescription.fromXML(is)
-    }
-    Try(new Jar(jarp.jfile).withEntryStream(PluginXML)(read))
-  }
-
-  private def loadDescriptionFromFile(f: Path): Try[PluginDescription] =
-    Try(PluginDescription.fromXML(new java.io.FileInputStream(f.jfile)))
-
   type AnyClass = Class[_]
 
   /** Use a class loader to load the plugin class.

--- a/src/compiler/scala/tools/nsc/plugins/Plugins.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugins.scala
@@ -164,13 +164,13 @@ trait Plugins { global: Global =>
         // TODO if the only null is jrt:// we can still cache
         // TODO filter out classpath elements pointing to non-existing files before we get here, that's another source of null
         analyzer.macroLogVerbose(s"macro classloader: caching is disabled because `AbstractFile.getURL` returned `null` for ${hasNullURL.map(_._1).mkString(", ")}.")
-        newLoader()
+        perRunCaches.recordClassloader(newLoader())
       } else {
         val locations = urlsAndFiles.map(t => Path(t._2.file))
         val nonJarZips = locations.filterNot(Jar.isJarOrZip(_))
         if (nonJarZips.nonEmpty) {
           analyzer.macroLogVerbose(s"macro classloader: caching is disabled because the following paths are not supported: ${nonJarZips.mkString(",")}.")
-          newLoader()
+          perRunCaches.recordClassloader(newLoader())
         } else {
           Macros.macroClassLoadersCache.getOrCreate(locations.map(_.jfile.toPath()), newLoader)
         }

--- a/src/compiler/scala/tools/nsc/plugins/Plugins.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugins.scala
@@ -37,7 +37,7 @@ trait Plugins { global: Global =>
       def injectDefault(s: String) = if (s.isEmpty) Defaults.scalaPluginPath else s
       asPath(settings.pluginsDir.value) map injectDefault map Path.apply
     }
-    val maybes = Plugin.loadAllFrom(paths, dirs, settings.disable.value, settings.YcachePluginClassLoader.value == settings.CachePolicy.None.name)
+    val maybes = Plugin.loadAllFrom(paths, dirs, settings.disable.value, findPluginClassLoader(_))
     val (goods, errors) = maybes partition (_.isSuccess)
     // Explicit parameterization of recover to avoid -Xlint warning about inferred Any
     errors foreach (_.recover[Any] {
@@ -51,6 +51,10 @@ trait Plugins { global: Global =>
     // is to register annotation checkers during object construction, so
     // creating multiple plugin instances will leave behind stale checkers.
     classes map (Plugin.instantiate(_, this))
+  }
+
+  protected def findPluginClassLoader(classpath: Seq[Path]): ClassLoader = {
+    Plugin.loaderFor(classpath, settings.YcachePluginClassLoader.value == settings.CachePolicy.None.name)
   }
 
   protected lazy val roughPluginsList: List[Plugin] = loadRoughPluginsList()

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -265,7 +265,7 @@ trait ScalaSettings extends AbsScalaSettings
   val YcachePluginClassLoader  = CachePolicy.setting("plugin", "compiler plugins")
   val YcacheMacroClassLoader   = CachePolicy.setting("macro", "macros")
 
-  val YmacroClasspath = PathSetting       ("-Ymacro-classpath", "The classpath used to reflectively load macro implementations", "")
+  val YmacroClasspath = PathSetting       ("-Ymacro-classpath", "The classpath used to reflectively load macro implementations, default is the compilation classpath.", "")
 
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -265,6 +265,8 @@ trait ScalaSettings extends AbsScalaSettings
   val YcachePluginClassLoader  = CachePolicy.setting("plugin", "compiler plugins")
   val YcacheMacroClassLoader   = CachePolicy.setting("macro", "macros")
 
+  val YmacroClasspath = PathSetting       ("-Ymacro-classpath", "The classpath used to reflectively load macro implementations", "")
+
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")
 

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -67,51 +67,6 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
 
   def globalSettings = global.settings
 
-  /** Obtains a `ClassLoader` instance used for macro expansion.
-   *
-   *  By default a new `ScalaClassLoader` is created using the classpath
-   *  from global and the classloader of self as parent.
-   *
-   *  Mirrors with runtime definitions (e.g. Repl) need to adjust this method.
-   */
-  protected def findMacroClassLoader(): ClassLoader = {
-    val classpath: Seq[URL] = if (settings.YmacroClasspath.isSetByUser) {
-      for {
-        file <- scala.tools.nsc.util.ClassPath.expandPath(settings.YmacroClasspath.value, true)
-        af <- Option(AbstractFile getDirectory file)
-      } yield af.file.toURI.toURL
-    } else global.classPath.asURLs
-    def newLoader = () => {
-      macroLogVerbose("macro classloader: initializing from -cp: %s".format(classpath))
-      ScalaClassLoader.fromURLs(classpath, self.getClass.getClassLoader)
-    }
-
-    val disableCache = settings.YcacheMacroClassLoader.value == settings.CachePolicy.None.name
-    if (disableCache) newLoader()
-    else {
-      import scala.tools.nsc.io.Jar
-      import scala.reflect.io.{AbstractFile, Path}
-
-      val urlsAndFiles = classpath.map(u => u -> AbstractFile.getURL(u))
-      val hasNullURL = urlsAndFiles.filter(_._2 eq null)
-      if (hasNullURL.nonEmpty) {
-        // TODO if the only null is jrt:// we can still cache
-        // TODO filter out classpath elements pointing to non-existing files before we get here, that's another source of null
-        macroLogVerbose(s"macro classloader: caching is disabled because `AbstractFile.getURL` returned `null` for ${hasNullURL.map(_._1).mkString(", ")}.")
-        newLoader()
-      } else {
-        val locations = urlsAndFiles.map(t => Path(t._2.file))
-        val nonJarZips = locations.filterNot(Jar.isJarOrZip(_))
-        if (nonJarZips.nonEmpty) {
-          macroLogVerbose(s"macro classloader: caching is disabled because the following paths are not supported: ${nonJarZips.mkString(",")}.")
-          newLoader()
-        } else {
-          Macros.macroClassLoadersCache.getOrCreate(locations.map(_.jfile.toPath()), newLoader)
-        }
-      }
-    }
-  }
-
   /** `MacroImplBinding` and its companion module are responsible for
    *  serialization/deserialization of macro def -> impl bindings.
    *

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -898,8 +898,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
 
 object Macros {
   final val macroClassLoadersCache =
-    new scala.tools.nsc.classpath.FileBasedCache[ScalaClassLoader]()
-
+    new scala.tools.nsc.classpath.FileBasedCache[ScalaClassLoader.URLClassLoader]()
 }
 
 trait MacrosStats {

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -67,9 +67,6 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
 
   def globalSettings = global.settings
 
-  private final val macroClassLoadersCache =
-    new scala.tools.nsc.classpath.FileBasedCache[ScalaClassLoader]()
-
   /** Obtains a `ClassLoader` instance used for macro expansion.
    *
    *  By default a new `ScalaClassLoader` is created using the classpath
@@ -109,7 +106,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
           macroLogVerbose(s"macro classloader: caching is disabled because the following paths are not supported: ${nonJarZips.mkString(",")}.")
           newLoader()
         } else {
-          macroClassLoadersCache.getOrCreate(locations.map(_.jfile.toPath()), newLoader)
+          Macros.macroClassLoadersCache.getOrCreate(locations.map(_.jfile.toPath()), newLoader)
         }
       }
     }
@@ -942,6 +939,12 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
           tree
       })
     }.transform(expandee)
+}
+
+object Macros {
+  final val macroClassLoadersCache =
+    new scala.tools.nsc.classpath.FileBasedCache[ScalaClassLoader]()
+
 }
 
 trait MacrosStats {

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -13,8 +13,6 @@
 package scala.tools.nsc
 package util
 
-import java.io.Closeable
-
 import io.{AbstractFile, Directory, File, Jar}
 import java.net.MalformedURLException
 import java.net.URL

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -13,6 +13,8 @@
 package scala.tools.nsc
 package util
 
+import java.io.Closeable
+
 import io.{AbstractFile, Directory, File, Jar}
 import java.net.MalformedURLException
 import java.net.URL

--- a/src/compiler/scala/tools/reflect/ReflectGlobal.scala
+++ b/src/compiler/scala/tools/reflect/ReflectGlobal.scala
@@ -32,7 +32,7 @@ class ReflectGlobal(currentSettings: Settings, reporter: Reporter, override val 
     */
   override protected[scala] def findMacroClassLoader(): ClassLoader = {
     val classpath = classPath.asURLs
-    ScalaClassLoader.fromURLs(classpath, rootClassLoader)
+    perRunCaches.recordClassloader(ScalaClassLoader.fromURLs(classpath, rootClassLoader))
   }
 
   override def transformedType(sym: Symbol) =

--- a/src/compiler/scala/tools/reflect/ReflectGlobal.scala
+++ b/src/compiler/scala/tools/reflect/ReflectGlobal.scala
@@ -25,18 +25,14 @@ import scala.tools.nsc.typechecker.Analyzer
 class ReflectGlobal(currentSettings: Settings, reporter: Reporter, override val rootClassLoader: ClassLoader)
   extends Global(currentSettings, reporter) with scala.tools.reflect.ReflectSetup with scala.reflect.runtime.SymbolTable {
 
-  override lazy val analyzer = new {
-    val global: ReflectGlobal.this.type = ReflectGlobal.this
-  } with Analyzer {
-    /** Obtains the classLoader used for runtime macro expansion.
-     *
-     *  Macro expansion can use everything available in [[global.classPath]] or [[rootClassLoader]].
-     *  The [[rootClassLoader]] is used to obtain runtime defined macros.
-     */
-    override protected def findMacroClassLoader(): ClassLoader = {
-      val classpath = global.classPath.asURLs
-      ScalaClassLoader.fromURLs(classpath, rootClassLoader)
-    }
+  /** Obtains the classLoader used for runtime macro expansion.
+    *
+    *  Macro expansion can use everything available in `global.classPath` or `rootClassLoader`.
+    *  The `rootClassLoader` is used to obtain runtime defined macros.
+    */
+  override protected[scala] def findMacroClassLoader(): ClassLoader = {
+    val classpath = classPath.asURLs
+    ScalaClassLoader.fromURLs(classpath, rootClassLoader)
   }
 
   override def transformedType(sym: Symbol) =

--- a/src/compiler/scala/tools/reflect/ReflectMain.scala
+++ b/src/compiler/scala/tools/reflect/ReflectMain.scala
@@ -14,15 +14,13 @@ package scala.tools
 package reflect
 
 import scala.reflect.internal.util.ScalaClassLoader
-import scala.tools.nsc.Driver
-import scala.tools.nsc.Global
-import scala.tools.nsc.Settings
+import scala.tools.nsc.{Driver, Global, CloseableRegistry, Settings}
 import scala.tools.util.PathResolver
 
 object ReflectMain extends Driver {
 
   private def classloaderFromSettings(settings: Settings) = {
-    val classPathURLs = new PathResolver(settings).resultAsURLs
+    val classPathURLs = new PathResolver(settings, new CloseableRegistry).resultAsURLs
     ScalaClassLoader.fromURLs(classPathURLs, getClass.getClassLoader)
   }
 

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -15,8 +15,9 @@ package tools
 package util
 
 import java.net.URL
+
 import scala.tools.reflect.WrappedProperties.AccessControl
-import scala.tools.nsc.Settings
+import scala.tools.nsc.{CloseableRegistry, Settings}
 import scala.tools.nsc.util.ClassPath
 import scala.reflect.io.{Directory, File, Path}
 import PartialFunction.condOpt
@@ -189,19 +190,24 @@ object PathResolver {
     } else {
       val settings = new Settings()
       val rest = settings.processArguments(args.toList, processAll = false)._2
-      val pr = new PathResolver(settings)
-      println("COMMAND: 'scala %s'".format(args.mkString(" ")))
-      println("RESIDUAL: 'scala %s'\n".format(rest.mkString(" ")))
+      val registry = new CloseableRegistry
+      try {
+        val pr = new PathResolver(settings, registry)
+        println("COMMAND: 'scala %s'".format(args.mkString(" ")))
+        println("RESIDUAL: 'scala %s'\n".format(rest.mkString(" ")))
 
-      pr.result match {
-        case cp: AggregateClassPath =>
-          println(s"ClassPath has ${cp.aggregates.size} entries and results in:\n${cp.asClassPathStrings}")
+        pr.result match {
+          case cp: AggregateClassPath =>
+            println(s"ClassPath has ${cp.aggregates.size} entries and results in:\n${cp.asClassPathStrings}")
+        }
+      } finally {
+        registry.close()
       }
     }
 }
 
-final class PathResolver(settings: Settings) {
-  private val classPathFactory = new ClassPathFactory(settings)
+final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistry) {
+  private val classPathFactory = new ClassPathFactory(settings, closeableRegistry)
 
   import PathResolver.{ AsLines, Defaults, ppcp }
 
@@ -250,7 +256,7 @@ final class PathResolver(settings: Settings) {
 
     // Assemble the elements!
     def basis = List[Iterable[ClassPath]](
-      JrtClassPath.apply(settings.releaseValue),    // 0. The Java 9 classpath (backed by the jrt:/ virtual system, if available)
+      jrt,                                          // 0. The Java 9+ classpath (backed by the ct.sym or jrt:/ virtual system, if available)
       classesInPath(javaBootClassPath),             // 1. The Java bootstrap class path.
       contentsOfDirsInPath(javaExtDirs),            // 2. The Java extension class path.
       classesInExpandedPath(javaUserClassPath),     // 3. The Java application class path.
@@ -260,6 +266,8 @@ final class PathResolver(settings: Settings) {
       classesInManifest(useManifestClassPath),      // 8. The Manifest class path.
       sourcesInPath(sourcePath)                     // 7. The Scala source path.
     )
+
+    private def jrt: Option[ClassPath] = JrtClassPath.apply(settings.releaseValue, closeableRegistry)
 
     lazy val containers = basis.flatten.distinct
 

--- a/src/partest/scala/tools/partest/BytecodeTest.scala
+++ b/src/partest/scala/tools/partest/BytecodeTest.scala
@@ -18,6 +18,7 @@ import scala.tools.asm.tree._
 import java.io.{InputStream, File => JFile}
 
 import AsmNode._
+import scala.tools.nsc.CloseableRegistry
 
 /**
  * Provides utilities for inspecting bytecode using ASM library.
@@ -144,7 +145,7 @@ abstract class BytecodeTest {
     import scala.tools.nsc.Settings
     // logic inspired by scala.tools.util.PathResolver implementation
     // `Settings` is used to check YdisableFlatCpCaching in ZipArchiveFlatClassPath
-    val factory = new ClassPathFactory(new Settings())
+    val factory = new ClassPathFactory(new Settings(), new CloseableRegistry)
     val containers = factory.classesInExpandedPath(sys.props("partest.output") + java.io.File.pathSeparator + Defaults.javaUserClassPath)
     new AggregateClassPath(containers)
   }

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -14,6 +14,8 @@ package scala
 package reflect
 package internal
 
+import java.net.URLClassLoader
+
 import scala.annotation.elidable
 import scala.collection.mutable
 import util._
@@ -413,6 +415,22 @@ abstract class SymbolTable extends macros.Universe
           caches ::= new WeakReference(cache)
       }
       cache
+    }
+
+    /** Closes the provided classloader at the conclusion of this Run */
+    final def recordClassloader(loader: ClassLoader): ClassLoader = {
+      def attemptClose(loader: ClassLoader): Unit = {
+        loader match {
+          case u: URLClassLoader => debuglog("Closing classloader " + u); u.close()
+          case _ =>
+        }
+      }
+      caches ::= new WeakReference((new Clearable {
+        def clear(): Unit = {
+          attemptClose(loader)
+        }
+      }))
+      loader
     }
 
     /**

--- a/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
@@ -138,7 +138,6 @@ object ScalaClassLoader {
       extends JURLClassLoader(urls.toArray, parent)
          with ScalaClassLoader
          with HasClassPath {
-
     private[this] var classloaderURLs: Seq[URL] = urls
     def classPathURLs: Seq[URL] = classloaderURLs
 

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
@@ -15,7 +15,7 @@ package scala.tools.nsc.interpreter
 import scala.reflect.internal.util.{Position, RangePosition, StringOps}
 import scala.tools.nsc.backend.JavaPlatform
 import scala.tools.nsc.util.ClassPath
-import scala.tools.nsc.{Settings, interactive}
+import scala.tools.nsc.{CloseableRegistry, Settings, interactive}
 import scala.tools.nsc.reporters.StoreReporter
 import scala.tools.nsc.classpath._
 import scala.tools.nsc.interpreter.Results.{Error, Result}
@@ -62,10 +62,6 @@ trait PresentationCompilation { self: IMain =>
     * You may downcast the `reporter` to `StoreReporter` to access type errors.
     */
   def newPresentationCompiler(): interactive.Global = {
-    def mergedFlatClasspath = {
-      val replOutClasspath = ClassPathFactory.newClassPath(replOutput.dir, settings)
-      AggregateClassPath(replOutClasspath :: global.platform.classPath :: Nil)
-    }
     def copySettings: Settings = {
       val s = new Settings(_ => () /* ignores "bad option -nc" errors, etc */)
       s.processArguments(global.settings.recreateArgs, processAll = false)
@@ -74,6 +70,11 @@ trait PresentationCompilation { self: IMain =>
     }
     val storeReporter: StoreReporter = new StoreReporter
     val interactiveGlobal = new interactive.Global(copySettings, storeReporter) { self =>
+      def mergedFlatClasspath = {
+        val replOutClasspath = ClassPathFactory.newClassPath(replOutput.dir, settings, closeableRegistry)
+        AggregateClassPath(replOutClasspath :: global.platform.classPath :: Nil)
+      }
+
       override lazy val platform: ThisPlatform = {
         new JavaPlatform {
           lazy val global: self.type = self

--- a/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -37,7 +37,7 @@ trait ReplGlobal extends Global {
       case None => base
       case Some(out) =>
         // Make bytecode of previous lines available to the inliner
-        val replOutClasspath = ClassPathFactory.newClassPath(settings.outputDirs.getSingleOutput.get, settings)
+        val replOutClasspath = ClassPathFactory.newClassPath(settings.outputDirs.getSingleOutput.get, settings, closeableRegistry)
         AggregateClassPath.createAggregate(platform.classPath, replOutClasspath)
     }
   }

--- a/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -25,16 +25,11 @@ trait ReplGlobal extends Global {
     super.abort(msg)
   }
 
-  override lazy val analyzer = new {
-    val global: ReplGlobal.this.type = ReplGlobal.this
-  } with Analyzer {
-
-    override protected def findMacroClassLoader(): ClassLoader = {
-      val loader = super.findMacroClassLoader
-      macroLogVerbose("macro classloader: initializing from a REPL classloader: %s".format(global.classPath.asURLs))
-      val virtualDirectory = globalSettings.outputDirs.getSingleOutput.get
-      new util.AbstractFileClassLoader(virtualDirectory, loader) {}
-    }
+  override protected[scala] def findMacroClassLoader(): ClassLoader = {
+    val loader = super.findMacroClassLoader
+    analyzer.macroLogVerbose("macro classloader: initializing from a REPL classloader: %s".format(classPath.asURLs))
+    val virtualDirectory = analyzer.globalSettings.outputDirs.getSingleOutput.get
+    new util.AbstractFileClassLoader(virtualDirectory, loader) {}
   }
 
   override def optimizerClassPath(base: ClassPath): ClassPath = {

--- a/test/junit/scala/tools/nsc/GlobalCustomizeClassloaderTest.scala
+++ b/test/junit/scala/tools/nsc/GlobalCustomizeClassloaderTest.scala
@@ -48,6 +48,7 @@ class GlobalCustomizeClassloaderTest {
       case Typed(Literal(Constant(s: String)), _) => Assert.assertEquals(SampleMacro.data, s)
       case _ => Assert.fail()
     }
+    g.close()
   }
 }
 

--- a/test/junit/scala/tools/nsc/GlobalCustomizeClassloaderTest.scala
+++ b/test/junit/scala/tools/nsc/GlobalCustomizeClassloaderTest.scala
@@ -1,0 +1,71 @@
+package scala.tools.nsc
+
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.reflect.internal.util.{AbstractFileClassLoader, NoSourceFile}
+import scala.reflect.io.{Path, VirtualDirectory}
+import scala.tools.nsc.plugins.{Plugin, PluginComponent}
+
+@RunWith(classOf[JUnit4])
+class GlobalCustomizeClassloaderTest {
+  // Demonstrate extension points to customise creation of the classloaders used to load compiler
+  // plugins and macro implementations.
+  //
+  // A use case could be for a build tool to take control of caching of these classloaders in a way
+  // that properly closes them before one of the elements needs to be overwritten.
+  @Test def test(): Unit = {
+    val g = new Global(new Settings) {
+      override protected[scala] def findMacroClassLoader(): ClassLoader = getClass.getClassLoader
+      override protected def findPluginClassLoader(classpath: Seq[Path]): ClassLoader = {
+        val d = new VirtualDirectory("", None)
+        val xml = d.fileNamed("scalac-plugin.xml")
+        val out = xml.bufferedOutput
+        out.write(
+          s"""<plugin>
+            |<name>sample-plugin</name>
+            |<classname>${classOf[SamplePlugin].getName}</classname>
+            |</plugin>
+            |""".stripMargin.getBytes())
+        out.close()
+        new AbstractFileClassLoader(d, getClass.getClassLoader)
+      }
+    }
+    g.settings.usejavacp.value = true
+    g.settings.plugin.value = List("sample")
+    new g.Run
+    assert(g.settings.log.value == List("typer"))
+
+    val unit = new g.CompilationUnit(NoSourceFile)
+    val context = g.analyzer.rootContext(unit)
+    val typer = g.analyzer.newTyper(context)
+    import g._
+    SampleMacro.data = "in this classloader"
+    val typed = typer.typed(q"scala.tools.nsc.SampleMacro.m")
+    assert(!reporter.hasErrors)
+    typed match {
+      case Typed(Literal(Constant(s: String)), _) => Assert.assertEquals(SampleMacro.data, s)
+      case _ => Assert.fail()
+    }
+  }
+}
+
+object SampleMacro {
+  var data: String = _
+  import language.experimental.macros
+  import scala.reflect.macros.blackbox.Context
+  def m: String = macro impl
+  def impl(c: Context): c.Tree = c.universe.Literal(c.universe.Constant(data))
+}
+
+class SamplePlugin(val global: Global) extends Plugin {
+  override val name: String = "sample"
+  override val description: String = "sample"
+  override val components: List[PluginComponent] = Nil
+  override def init(options: List[String], error: String => Unit): Boolean = {
+    val result = super.init(options, error)
+    global.settings.log.value = List("typer")
+    result
+  }
+}

--- a/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
@@ -8,7 +8,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.nsc.Settings
+import scala.tools.nsc.{CloseableRegistry, Settings}
 import scala.tools.nsc.backend.jvm.AsmUtils
 import scala.tools.nsc.util.ClassPath
 import scala.tools.util.PathResolver
@@ -19,14 +19,15 @@ class JrtClassPathTest {
   @Test def lookupJavaClasses(): Unit = {
     val specVersion = scala.util.Properties.javaSpecVersion
     // Run the test using the JDK8 or 9 provider for rt.jar depending on the platform the test is running on.
+    val closeableRegistry = new CloseableRegistry
     val cp: ClassPath =
       if (specVersion == "" || specVersion == "1.8") {
         val settings = new Settings()
-        val resolver = new PathResolver(settings)
-        val elements = new ClassPathFactory(settings).classesInPath(resolver.Calculated.javaBootClassPath)
+        val resolver = new PathResolver(settings, closeableRegistry)
+        val elements = new ClassPathFactory(settings, closeableRegistry).classesInPath(resolver.Calculated.javaBootClassPath)
         AggregateClassPath(elements)
       }
-      else JrtClassPath(None).get
+      else JrtClassPath(None, closeableRegistry).get
 
     assertEquals(Nil, cp.classes(""))
     assertTrue(cp.packages("java").toString, cp.packages("java").exists(_.name == "java.lang"))
@@ -37,5 +38,7 @@ class JrtClassPathTest {
     assertTrue(cp.list("java.lang").classesAndSources.exists(_.name == "Object"))
     assertTrue(cp.findClass("java.lang.Object").isDefined)
     assertTrue(cp.findClassFile("java.lang.Object").isDefined)
+
+    closeableRegistry.close()
   }
 }

--- a/test/junit/scala/tools/nsc/classpath/PathResolverBaseTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/PathResolverBaseTest.scala
@@ -4,13 +4,15 @@
 package scala.tools.nsc.classpath
 
 import java.io.File
+
 import org.junit.Assert._
 import org.junit._
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+
 import scala.tools.nsc.util.ClassPath
-import scala.tools.nsc.Settings
+import scala.tools.nsc.{CloseableRegistry, Settings}
 import scala.tools.util.PathResolver
 
 @RunWith(classOf[JUnit4])
@@ -57,7 +59,7 @@ class PathResolverBaseTest {
   def deleteTempDir: Unit = tempDir.delete()
 
   private def createFlatClassPath(settings: Settings) =
-    new PathResolver(settings).result
+    new PathResolver(settings, new CloseableRegistry).result
 
   @Test
   def testEntriesFromListOperationAgainstSeparateMethods: Unit = {

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
@@ -36,7 +36,7 @@ class SymbolTableForUnitTesting extends SymbolTable {
 
     def platformPhases: List[SubComponent] = Nil
 
-    private[nsc] lazy val classPath: ClassPath = new PathResolver(settings).result
+    private[nsc] lazy val classPath: ClassPath = new PathResolver(settings, new CloseableRegistry).result
 
     def isMaybeBoxed(sym: Symbol): Boolean = ???
     def needCompile(bin: AbstractFile, src: AbstractFile): Boolean = ???


### PR DESCRIPTION
Global now has a close() method, which closes any classloaders
and open JARs created for compiler plugins, macros, and the
classpath.

When these aren't owned by Global (because caching is turned on),
this reference counts are decremented on Global.close.

When the reference count for a resource reaches zero, it is queued
for close after a short (and configurable) delay.

Also introduces a setting to provide a restricted classpath for
the macro classloader, which can improve the hit ratio when
-Ycache-macro-classloader.