### PR TITLE
Fix ignoring of a function in StringOps.WithFilter's map

### DIFF
--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -107,7 +107,7 @@ object StringOps {
       var i = 0
       while (i < len) {
         val x = s.charAt(i)
-        if(p(x)) sb.append(x)
+        if(p(x)) sb.append(f(x))
         i += 1
       }
       sb.toString

--- a/test/junit/scala/collection/StringOpsTest.scala
+++ b/test/junit/scala/collection/StringOpsTest.scala
@@ -93,4 +93,8 @@ class StringOpsTest {
     assertEquals("", "a" * 0)
     assertEquals("", "a" * -1)
   }
+
+  @Test def withFilterAndThenMap(): Unit = {
+    assertEquals("hello".withFilter(_ != 'e').map(_.toUpper), "HLLO")
+  }
 }


### PR DESCRIPTION
According to [this conversation](https://users.scala-lang.org/t/some-questions-about-for-if-yield/3444), `map` of `StringOps.WithFilter` ignores given function. This PR fixes it and adds a simple test for this particular case.