### PR TITLE
By-name implicits: Align detection of implicit recursion with the SIP

### DIFF
--- a/test/files/run/byname-implicits-29.scala
+++ b/test/files/run/byname-implicits-29.scala
@@ -1,0 +1,16 @@
+object Test {
+  class Foo(val bar: Bar)
+  class Bar(baz0: => Baz) {
+    lazy val baz = baz0
+  }
+  class Baz(val foo: Foo)
+
+  implicit def foo(implicit bar: Bar): Foo = new Foo(bar)
+  implicit def bar(implicit baz: => Baz): Bar = new Bar(baz)
+  implicit def baz(implicit foo: Foo): Baz = new Baz(foo)
+
+  def main(args: Array[String]): Unit = {
+    val foo = implicitly[Foo]
+    assert(foo.bar.baz.foo eq foo)
+  }
+}


### PR DESCRIPTION
The by-name implicits SIP specifies that a recursive occurrence of an implicit should tie the knot if there is at least one by-name parameter between the outermost and the innermost occurrence.

Prior to this commit the implementation required that either the innermost or the outermost occurrence must be by-name.

This commit brings the implementation into line with the SIP.