### PR TITLE
Change Predef.$conforms type from A <:< A to A => A 

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1006,7 +1006,7 @@ trait Implicits {
 
       private def isIneligible(info: ImplicitInfo) = (
            info.isCyclicOrErroneous
-        || isView && (info.sym eq Predef_conforms) // as an implicit conversion, Predef.$conforms is a no-op, so exclude it
+        || isView && ((info.sym eq Predef_conforms) || (info.sym eq SubType_refl)) // as implicit conversions, Predef.$conforms and <:<.refl are no-op, so exclude them
         || (!context.macrosEnabled && info.sym.isTermMacro)
       )
 

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -77,10 +77,6 @@ import scala.annotation.meta.companionMethod
  * @groupprio console-output 30
  * @groupdesc console-output These methods provide output via the console.
  *
- * @groupname type-constraints Type Constraints
- * @groupprio type-constraints 40
- * @groupdesc type-constraints These entities allows constraints between types to be stipulated.
- *
  * @groupname aliases Aliases
  * @groupprio aliases 50
  * @groupdesc aliases These aliases bring selected immutable types into scope without any imports.
@@ -489,17 +485,13 @@ object Predef extends LowPriorityImplicits {
   /** @group conversions-java-to-anyval */
   implicit def Boolean2boolean(x: java.lang.Boolean): Boolean = x.asInstanceOf[Boolean]
 
-  // Type Constraints --------------------------------------------------------------
-
-  /** `A <: A` for all `A` (subtyping is reflexive). This also provides implicit views `A => B`
-   *  when `A <: B`, because `(A <:< A) <: (A <:< B) <: (A => B)`.
-   *
-   *  @group type-constraints
+  /** An implicit of type `A => A` is available for all `A` because it can always
+   *  be implemented using the identity function. This also means that an
+   *  implicit of type `A => B` is always available when `A <: B`, because
+   *  `(A => A) <: (A => B)`.
    */
   // $ to avoid accidental shadowing (e.g. scala/bug#7788)
-  // ideally implicit def $conforms[A]: A => A, with a <:< implicit in the companion
-  // but $conforms is a bit too magic for that
-  implicit def $conforms[A]: A <:< A = =:=.refl
+  implicit def $conforms[A]: A => A = <:<.refl
 }
 
 /** The `LowPriorityImplicits` class provides implicit values that

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1635,8 +1635,12 @@ trait Definitions extends api.StandardDefinitions {
         TypeTagClass     -> materializeTypeTag
       )
       lazy val TagSymbols = TagMaterializers.keySet
-      lazy val Predef_conforms     = (getMemberIfDefined(PredefModule, nme.conforms)
-                               orElse getMemberMethod(PredefModule, TermName("conforms"))) // TODO: predicate on -Xsource:2.10 (for now, needed for transition from M8 -> RC1)
+
+      // Methods treated specially by implicit search
+      lazy val Predef_conforms = getMemberIfDefined(PredefModule, nme.conforms)
+      lazy val SubTypeModule   = requiredModule[scala.<:<[_,_]]
+      lazy val SubType_refl    = getMemberIfDefined(PredefModule, nme.refl)
+
       lazy val Predef_classOf      = getMemberMethod(PredefModule, nme.classOf)
       lazy val Predef_implicitly   = getMemberMethod(PredefModule, nme.implicitly)
       lazy val Predef_???          = DefinitionsClass.this.Predef_???

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -788,6 +788,7 @@ trait StdNames {
     val raw_ : NameType                = "raw"
     val readResolve: NameType          = "readResolve"
     val releaseFence: NameType         = "releaseFence"
+    val refl: NameType                 = "refl"
     val reify : NameType               = "reify"
     val reificationSupport : NameType  = "reificationSupport"
     val rootMirror : NameType          = "rootMirror"


### PR DESCRIPTION
As suggested in the comment above $conforms

<hr>

This PR depends on https://github.com/scala/scala/pull/7350, only the last commit is new.