### PR TITLE
Add doc for Option.apply factory

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -73,6 +73,19 @@ object Option {
  *  }
  *  }}}
  *
+ * Interacting with code that can occasionally return null can be
+ * safely wrapped in $option to become $none and $some otherwise. {{{
+ * val abc = new java.util.HashMap[Int, String]
+ * abc.put(1, "A")
+ * bMaybe = Option(abc.get(2))
+ * bMaybe match {
+ *   case Some(b) =>
+ *     println(s"Found $b")
+ *   case None =>
+ *     println("Not found")
+ * }
+ * }}}
+ *
  *  @note Many of the methods in here are duplicative with those
  *  in the Traversable hierarchy, but they are duplicated for a reason:
  *  the implicit conversion tends to leave one with an Iterable in


### PR DESCRIPTION
It seemed like an oversight to not document the null-checking companion object in the top-level docs for `Option`.

I decided to use `HashMap` in the example:

```scala
val abc = new java.util.HashMap[Int, String]
abc.put(1, "A")
bMaybe = Option(abc.get(2))
bMaybe match {
  case Some(b) =>
    println(s"Found $b")
  case None =>
    println("Not found")
}
```
I've added it to the class, since most companion objects in the library don't seem to have top-level documentation:

https://www.scala-lang.org/api/2.12.7/scala/Option$.html

Noticed this deficiency while looking at #7336.