### PR TITLE
Put @implicitAmbiguous annotation on the getter, not the field

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
@@ -95,9 +95,9 @@ trait PatternTypers {
       else if (isOkay)
         fun
       else if (isEmptyType == NoType)
-        CaseClassConstructorError(fun, s"an unapply result must have a member `def isEmpty: Boolean")
+        CaseClassConstructorError(fun, s"an unapply result must have a member `def isEmpty: Boolean`")
       else
-        CaseClassConstructorError(fun, s"an unapply result must have a member `def isEmpty: Boolean (found: def isEmpty: $isEmptyType)")
+        CaseClassConstructorError(fun, s"an unapply result must have a member `def isEmpty: Boolean` (found: `def isEmpty: $isEmptyType`)")
     }
 
     def typedArgsForFormals(args: List[Tree], formals: List[Type], mode: Mode): List[Tree] = {

--- a/src/library/scala/annotation/implicitAmbiguous.scala
+++ b/src/library/scala/annotation/implicitAmbiguous.scala
@@ -29,4 +29,5 @@ package scala.annotation
   * @author Brian McKenna
   * @since 2.12.0
   */
+@meta.getter
 final class implicitAmbiguous(msg: String) extends scala.annotation.StaticAnnotation

--- a/test/files/neg/implicit-ambiguous-val.check
+++ b/test/files/neg/implicit-ambiguous-val.check
@@ -1,0 +1,4 @@
+implicit-ambiguous-val.scala:16: error: unexpected string
+  meh("")
+     ^
+one error found

--- a/test/files/neg/implicit-ambiguous-val.scala
+++ b/test/files/neg/implicit-ambiguous-val.scala
@@ -1,0 +1,17 @@
+sealed trait NotString[T]
+
+object NotString extends NotString0 {
+  @annotation.implicitAmbiguous("unexpected string")
+  implicit val stringAmb_1: NotString[String] = null
+  implicit val stringAmb_2: NotString[String] = null
+}
+sealed abstract class NotString0 {
+  implicit def notString[T]: NotString[T] = null
+}
+
+object Test {
+  def meh[T: NotString](t: T) = ()
+
+  meh(12)
+  meh("")
+}

--- a/test/files/neg/t7850.check
+++ b/test/files/neg/t7850.check
@@ -1,7 +1,7 @@
-t7850.scala:11: error: an unapply result must have a member `def isEmpty: Boolean (found: def isEmpty: Casey)
+t7850.scala:11: error: an unapply result must have a member `def isEmpty: Boolean` (found: `def isEmpty: Casey`)
     val Casey(x1) = new Casey(1)
         ^
-t7850.scala:12: error: an unapply result must have a member `def isEmpty: Boolean
+t7850.scala:12: error: an unapply result must have a member `def isEmpty: Boolean`
     val Dingy(x2) = new Dingy(1)
         ^
 two errors found


### PR DESCRIPTION
Because that's where the compiler checks.

Also fix a dangling backtick.

Fixes scala/bug#11228