### PR TITLE
Add fields sorting (primitives first) in case class equals

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -188,7 +188,9 @@ trait SyntheticMethods extends ast.TreeDSL {
 
       val otherName = freshTermName(clazz.name + "$")(freshNameCreatorFor(context))
       val otherSym  = eqmeth.newValue(otherName, eqmeth.pos, SYNTHETIC) setInfo clazz.tpe
-      val pairwise  = accessors collect {
+      //compare primitive fields first, slow equality checks of non-primitive fields can be skipped when primitives differ
+      val accessorsParts = accessors.partition(x => isPrimitiveValueType(x.info.resultType))
+      val pairwise  = (accessorsParts._1 ++ accessorsParts._2) collect {
         case acc if usefulEquality(acc) =>
           fn(Select(mkThis, acc), acc.tpe member nme.EQ, Select(Ident(otherSym), acc))
       }

--- a/test/files/run/case_class_equals_fields_sort.scala
+++ b/test/files/run/case_class_equals_fields_sort.scala
@@ -1,0 +1,9 @@
+object Test {
+    def main(args: Array[String]): Unit = {
+        class X { override def equals(x: Any) = throw new Exception("shouldn't be called") }
+        case class C(x: X, i: Int)
+        val x = new X
+
+        C(x, 1) == C(x, 2)
+    }
+}


### PR DESCRIPTION
Currently
```scala
case class X(a: Seq[Int], b: String, c: Boolean)
```
generates the following:
```scala
...
override def equals(x: Any) = ref_check || type_check && {
  val y = x.asInstanceOf[X]
  a == y.a && b == y.b && c == y.c && y.canEqual(this)
}
...
```
For cases like
```scala
X(Seq(1, 2, 3), "abcd", true) == X(Seq(1, 2, 3), "abcd", false)
```
it can be improved by reordering field checks:
```scala
c == y.c && a == y.a && b == y.b && y.canEqual(this)
```