### PR TITLE
Fix scala/bug#10911, two ways

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -182,7 +182,12 @@ private[internal] trait TypeMaps {
         else AntiPolyType(pre1, args1)
       case tv@TypeVar(_, constr) =>
         if (constr.instValid) this(constr.inst)
-        else tv.applyArgs(mapOverArgs(tv.typeArgs, tv.params))  //@M !args.isEmpty implies !typeParams.isEmpty
+        else {
+          val args = tv.typeArgs
+          val args1 = mapOverArgs(args, tv.params) //@M !args.isEmpty implies !typeParams.isEmpty
+          if (args1 eq args) tv
+          else tv.applyArgs(args1)
+        }
       case AnnotatedType(annots, atp) =>
         val annots1 = mapOverAnnotations(annots)
         val atp1 = this(atp)

--- a/test/files/pos/t10911.scala
+++ b/test/files/pos/t10911.scala
@@ -1,0 +1,11 @@
+object Test {
+  trait Super[X]
+  trait Template[T] {
+    type Repr
+    trait Sub extends Super[Repr]
+  }
+
+  // create a compound type that has a type variable in the decls of one of its parents
+  implicit def reprTSub[T, Rpr[X]]: (Template[T]{type Repr = Rpr[T]})#Sub = ???
+  implicitly[Super[Any]] // bug is not really related to implicit search, but is hard to trigger without
+}


### PR DESCRIPTION
This was originally diagnosed and fixed by @NirvanaNrv in the innards of `TypeMap`. However, I'd rather fix the problem a bit closer to the source (the infinite recursion in computing a BTS of a `RefinedType` containing `TypeVar`s in its parents. The code didn't cover the case of applied type vars, which result in new instances for each application to type args.)