### PR TITLE
[scala/bug#11010] Put back Coll for compatibility reasons

### DIFF
--- a/src/library/scala/collection/Factory.scala
+++ b/src/library/scala/collection/Factory.scala
@@ -387,7 +387,7 @@ trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
   */
 trait MapFactory[+CC[_, _]] extends Serializable {
   /** The type constructor of the collection that can be built by this factory */
-  @deprecated("Use directly CC[_, _] instead", "2.13")
+  @deprecated("Use CC[_, _] directly instead", "2.13")
   type Coll = CC[_, _]
 
   def empty[K, V]: CC[K, V]

--- a/src/library/scala/collection/Factory.scala
+++ b/src/library/scala/collection/Factory.scala
@@ -447,7 +447,7 @@ object MapFactory {
   */
 trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable {
   /** The type constructor of the collection that can be built by this factory */
-  @deprecated("Use directly CC[_] instead", "2.13")
+  @deprecated("Use CC[_] directly instead", "2.13")
   type Coll = CC[_]
 
   def from[E : Ev](it: IterableOnce[E]): CC[E]

--- a/src/library/scala/collection/Factory.scala
+++ b/src/library/scala/collection/Factory.scala
@@ -83,6 +83,9 @@ object Factory {
   * @define Coll `Iterable`
   */
 trait IterableFactory[+CC[_]] extends Serializable {
+  /** The type constructor of the collection that can be built by this factory */
+  @deprecated("Use directly CC[_] instead", "2.13")
+  type Coll = CC[_]
 
   /** Creates a target $coll from an existing source collection
     *
@@ -383,6 +386,9 @@ trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
   * @define Coll `Iterable`
   */
 trait MapFactory[+CC[_, _]] extends Serializable {
+  /** The type constructor of the collection that can be built by this factory */
+  @deprecated("Use directly CC[_, _] instead", "2.13")
+  type Coll = CC[_, _]
 
   def empty[K, V]: CC[K, V]
 
@@ -440,6 +446,9 @@ object MapFactory {
   * @define Coll `Iterable`
   */
 trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable {
+  /** The type constructor of the collection that can be built by this factory */
+  @deprecated("Use directly CC[_] instead", "2.13")
+  type Coll = CC[_]
 
   def from[E : Ev](it: IterableOnce[E]): CC[E]
 
@@ -720,6 +729,9 @@ trait StrictOptimizedClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extend
   * @define Coll `Iterable`
   */
 trait SortedMapFactory[+CC[_, _]] extends Serializable {
+  /** The type constructor of the collection that can be built by this factory */
+  @deprecated("Use directly CC[_, _] instead", "2.13")
+  type Coll = CC[_, _]
 
   def empty[K : Ordering, V]: CC[K, V]
 

--- a/src/library/scala/collection/Factory.scala
+++ b/src/library/scala/collection/Factory.scala
@@ -84,7 +84,7 @@ object Factory {
   */
 trait IterableFactory[+CC[_]] extends Serializable {
   /** The type constructor of the collection that can be built by this factory */
-  @deprecated("Use directly CC[_] instead", "2.13")
+  @deprecated("Use CC[_] directly instead", "2.13")
   type Coll = CC[_]
 
   /** Creates a target $coll from an existing source collection

--- a/src/library/scala/collection/Factory.scala
+++ b/src/library/scala/collection/Factory.scala
@@ -730,7 +730,7 @@ trait StrictOptimizedClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extend
   */
 trait SortedMapFactory[+CC[_, _]] extends Serializable {
   /** The type constructor of the collection that can be built by this factory */
-  @deprecated("Use directly CC[_, _] instead", "2.13")
+  @deprecated("Use CC[_, _] directly instead", "2.13")
   type Coll = CC[_, _]
 
   def empty[K : Ordering, V]: CC[K, V]


### PR DESCRIPTION
The collection API was refactored.
The internal type `Coll` was removed in new factories.

To avoid breaking compatibility, we put it back in new factories for sub-types.

See https://github.com/scala/bug/issues/11010