### PR TITLE
Fix crasher regression with implicit classes and default params

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -231,6 +231,13 @@ trait MethodSynthesis {
       val methDef = factoryMeth(classDef.mods & AccessFlags | METHOD | IMPLICIT | SYNTHETIC, classDef.name.toTermName, classDef)
       val methSym = enterInScope(assignMemberSymbol(methDef))
       context.unit.synthetics(methSym) = methDef
+
+      treeInfo.firstConstructor(classDef.impl.body) match {
+        case primaryConstructor: DefDef =>
+          if (mexists(primaryConstructor.vparamss)(_.mods.hasDefault))
+            enterDefaultGetters(methSym, primaryConstructor, primaryConstructor.vparamss, primaryConstructor.tparams)
+        case _ =>
+      }
       methSym setInfo implicitFactoryMethodCompleter(methDef, classDef.symbol)
     }
 

--- a/test/files/run/implicit-class-implicit-param-with-default.check
+++ b/test/files/run/implicit-class-implicit-param-with-default.check
@@ -1,0 +1,5 @@
+default
+default
+default
+explicit
+explicit

--- a/test/files/run/implicit-class-implicit-param-with-default.scala
+++ b/test/files/run/implicit-class-implicit-param-with-default.scala
@@ -1,0 +1,11 @@
+object Test {
+  implicit class C(self: String)(implicit val foo: String = "default")
+
+  def main(args: Array[String]) {
+    println("".foo)
+    println(C("").foo)
+    println(new C("").foo)
+    println(C("")("explicit").foo)
+    println(new C("")("explicit").foo)
+  }
+}


### PR DESCRIPTION
Since the changes to make the compiler output deterministic, default getter
symbols must be entered eagerly before the trees are created. This happens
in `enterDefDef`, but that method is bypassed when entering the synthetic
symbol for an implicit class factory method.

This commit enters the default getter symbols in this case, as well,
avoiding a later crash.

Fixes scala/bug#11235