### PR TITLE
Remove leftover words from scaladoc of uncheckedVariance

### DIFF
--- a/src/library/scala/annotation/unchecked/uncheckedVariance.scala
+++ b/src/library/scala/annotation/unchecked/uncheckedVariance.scala
@@ -12,8 +12,7 @@
 
 package scala.annotation.unchecked
 
-/** An annotation for type arguments for which one wants to suppress variance checking
- *  types are volatile.
+/** An annotation for type arguments for which one wants to suppress variance checking.
  *
  *  @since 2.7
  */


### PR DESCRIPTION
Just a minor fix of documentation.

Looks like a leftover from copy-paste of `uncheckedStable`.