### PR TITLE
Provide a simple string matcher as the dual of the simple string interpolator

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1387,9 +1387,10 @@ trait Definitions extends api.StandardDefinitions {
       }
     }
     def getMemberMethod(owner: Symbol, name: Name): TermSymbol = {
+      def miss = fatalMissingSymbol(owner, name, "method")
       getMember(owner, name.toTermName) match {
-        case x: TermSymbol => x
-        case _             => fatalMissingSymbol(owner, name, "method")
+        case x: TermSymbol => x.filter(_.isMethod).orElse(miss).asInstanceOf[TermSymbol]
+        case _             => miss
       }
     }
 


### PR DESCRIPTION
Examples:

```scala
val s"Hello, $name" = "Hello, James"
println(name)  // "James"
```

```scala
val s"$greeting, $name" = "Hello, James"
println(greeting)  // "Hello"
println(name)  // "James"
```

```scala
val TimeSplitter = "([0-9]+)[.:]([0-9]+)".r
val s"The time is ${TimeSplitter(hours, mins)}" = "The time is 10.50"
println(hours) // 10
println(mins) // 50
```

This is slightly random, but I think it fits very well as a counterpart
to the existing `s"..."` interpolator, has a very simple definition, has
lived in the ammonite-ops library as the `r` interpolator for a long
time, and I have generally found it very useful.

It supports simple globbing matches, without any fancy regex
group-matching or whatever. This is a nice fit for the simple semantics
of the existing `s` interpolator.

One subtlety is that in the case of ambiguity, the implementation gives
the characters to later matches rather than earlier matches:

```scala
scala> val s"$a-$b-$c-$d" = "1-2-3-4-5-6-7-8-9"
a: String = 1
b: String = 2
c: String = 3
d: String = 4-5-6-7-8-9
```

This is somewhat arbitrary. This is for simple matches; for anything
complex or ambiguous, you can use a full regex.

Fancier regex matching, e.g. using regex-syntax in the literal parts of the string or regex capturing groups to the bound variables, is out of scope for this PR. Maybe it can be done separately, but even if it does appear I think there's value in a simple matcher that people can use without worrying about needing to escape their `.`s and other regex special-characters.

Notably, this *cannot* be implemented in user-land right now as an extension method on `StringContext`, because the presence of the `s` method stops the extension method from being picked up.

What do people think? If it seems plausible that we could get this into the standard library, I'll be happy to add a few unit tests and do whatever polish is necessary.