### PR TITLE
Define Either.orElse.

### DIFF
--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -285,6 +285,19 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
     case _        => or
   }
 
+  /** Returns this `Right` or the given argument if this is a `Left`.
+   *
+   *  {{{
+   *  Right(1) orElse Left(2) // Right(1)
+   *  Left(1) orElse Left(2)  // Left(2)
+   *  Left(1) orElse Left(2) orElse Right(3) // Right(3)
+   *  }}}
+   */
+  def orElse[A1 >: A, B1 >: B](or: => Either[A1, B1]): Either[A1, B1] = this match {
+    case Right(_) => this
+    case _        => or
+  }
+
   /** Returns `true` if this is a `Right` and its value is equal to `elem` (as determined by `==`),
    *  returns `false` otherwise.
    *

--- a/test/scalacheck/CheckEither.scala
+++ b/test/scalacheck/CheckEither.scala
@@ -137,6 +137,11 @@ object CheckEitherTest extends Properties("Either") {
     case Right(b) => b
   }))
 
+  val prop_orElse = forAll((e: Either[Int, Int], or: Either[Int, Int]) => e.orElse(or) == (e match {
+    case Left(_) => or
+    case Right(_) => e
+  }))
+
   val prop_contains = forAll((e: Either[Int, Int], n: Int) =>
     e.contains(n) == (e.isRight && e.right.get == n))
 
@@ -223,6 +228,7 @@ object CheckEitherTest extends Properties("Either") {
       ("prop_Either_joinRight", prop_Either_joinRight),
       ("prop_Either_reduce", prop_Either_reduce),      
       ("prop_getOrElse", prop_getOrElse),
+      ("prop_orElse", prop_orElse),
       ("prop_contains", prop_contains),
       ("prop_forall", prop_forall),
       ("prop_exists", prop_exists),


### PR DESCRIPTION
Chaining optional values together with `orElse` to indicate a preferential order is a common pattern in code bases I have worked in. I would like to be able to do the same with right-biased `Either`, or frankly even with right/left projections.

```scala
def op1: Either[Failure, Success] = ???
def op2: Either[Failure, Success] = ???
def op3: Either[Failure, Success] = ???

op1 orElse op2 orElse op3
```