### PR TITLE
Fix non-termination with java strictfp

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -395,6 +395,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
             in.nextToken()
           case STRICTFP =>
             addAnnot(ScalaStrictFPAttr)
+            in.nextToken()
           case SYNCHRONIZED =>
             in.nextToken()
           case _ =>

--- a/test/files/jvm/strictfp/StrictFpJava.java
+++ b/test/files/jvm/strictfp/StrictFpJava.java
@@ -1,0 +1,5 @@
+strictfp class StrictFpJava {}
+
+class StrictFpJavaMethod {
+  strictfp void test() {}
+}

--- a/test/files/presentation/parse-invariants.check
+++ b/test/files/presentation/parse-invariants.check
@@ -1,3 +1,10 @@
+parseTree
+NoNewSymbolsEntered OK
+Unique OK
+Unattributed OK
+NeverModify OK
+AlwaysParseTree OK
+parseTree
 NoNewSymbolsEntered OK
 Unique OK
 Unattributed OK

--- a/test/files/presentation/parse-invariants/Test.scala
+++ b/test/files/presentation/parse-invariants/Test.scala
@@ -5,12 +5,16 @@ import scala.tools.nsc.interactive.Response
 object Test extends InteractiveTest {
 
   override def execute(): Unit = {
-    val sf = sourceFiles.find(_.file.name == "A.scala").head
-    noNewSymbols(sf)
-    uniqueParseTree(sf)
-    unattributedParseTree(sf)
-    neverModifyParseTree(sf)
-    shouldAlwaysReturnParseTree(sf)
+    def test(fileName: String): Unit = {
+      val sf = sourceFiles.find(_.file.name == fileName).head
+      noNewSymbols(sf)
+      uniqueParseTree(sf)
+      unattributedParseTree(sf)
+      neverModifyParseTree(sf)
+      shouldAlwaysReturnParseTree(sf)
+    }
+    test("A.scala")
+    test("A.java")
   }
 
   /**
@@ -19,6 +23,7 @@ object Test extends InteractiveTest {
   private def noNewSymbols(sf: SourceFile) {
     def nextId() = compiler.NoSymbol.newTermSymbol(compiler.TermName("dummy"), compiler.NoPosition, compiler.NoFlags).id
     val id = nextId()
+    println("parseTree")
     val tree = compiler.parseTree(sf)
     val id2 = nextId()
     if (id2 == id + 1) {

--- a/test/files/presentation/parse-invariants/src/a/A.java
+++ b/test/files/presentation/parse-invariants/src/a/A.java
@@ -1,0 +1,16 @@
+package syntax;
+
+class A {
+  transient volatile int x;
+  strictfp void test() {
+  }
+
+  native void nativeMethod()
+
+  synchronized void syncMethod() {}
+
+  void thrower() throws Throwable {}
+
+}
+
+strictfp class B {}


### PR DESCRIPTION
Also test that the Java parser doesn't force entry of new symbols
when it parses modifiers that it translates into symbol annotations.

Regressed in #7356