### PR TITLE
Adapt to selection of polymorphic method

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -655,8 +655,11 @@ trait Implicits {
      (ptarg weak_<:< tparg) && {
        ptres match {
          case HasMethodMatching(name, argtpes, restpe) =>
-           (tpres.member(name) filter (m =>
-             isApplicableSafe(undet, m.tpe, argtpes, restpe))) != NoSymbol
+           tpres.member(name).filter { m =>
+             val memberTp = tpres memberType m
+//             println(s"$m : ${m.info} in $tpres: $memberTp")
+             isApplicableSafe(undet, memberTp, argtpes, restpe) // undet ++ m.owner.typeParams
+           } != NoSymbol
          case _ =>
            tpres <:< ptres
        }

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1033,7 +1033,10 @@ trait Infer extends Checkable {
                 enhanceBounds(okparams, okargs, xs1)
                 xs1
             }
-          } else Nil
+          } else {
+            // when we can't meet our bounds, we won't instantiate and all undetparams should remain undetermined
+            undetparams
+          }
         }
         catch ifNoInstance { msg =>
           NoMethodInstanceError(fn, args, msg); List()

--- a/test/files/neg/adapt_to_poly.check
+++ b/test/files/neg/adapt_to_poly.check
@@ -1,0 +1,6 @@
+adapt_to_poly.scala:3: error: type mismatch;
+ found   : Int => Iterable[Int]
+ required: Int => scala.collection.IterableOnce[String]
+  Option(1).flatMap[String](f) // don't drop explicitly provided args during adapt
+                            ^
+one error found

--- a/test/files/neg/adapt_to_poly.scala
+++ b/test/files/neg/adapt_to_poly.scala
@@ -1,0 +1,4 @@
+class Test {
+  val f: Int => Iterable[Int] = x => List(x)
+  Option(1).flatMap[String](f) // don't drop explicitly provided args during adapt
+}

--- a/test/files/pos/adapt_to_poly.scala
+++ b/test/files/pos/adapt_to_poly.scala
@@ -1,0 +1,24 @@
+trait Iterable[+T]
+
+trait O[T] {
+  def flatMap[U](f: T => O[U]): O[U] = ???
+  def foo[U <: String](t: U) = "C#foo"
+}
+class MapOptionFlatMapIterable[A](o: O[A]) {
+  def flatMap[B](f: A => Iterable[B]): Iterable[B] = ???
+  def foo(x: Any) = "D#foo"
+}
+
+// Monomorphic version worked before the fix:
+// trait O[T] { def flatMap(f: T => O[Int]): O[Int] = ??? }
+// class MapOptionFlatMapIterable[A](o: O[A]) { def flatMap(f: A => Iterable[Int]): Iterable[Int] = ??? }
+
+class Test {
+  implicit def mofmi[A](oo: O[A]): MapOptionFlatMapIterable[A] = new MapOptionFlatMapIterable[A](oo)
+
+  val f: Int => Iterable[Int] = ???
+
+  (??? : O[Int]).flatMap(f)
+
+  (??? : O[Int]).foo(0)
+}


### PR DESCRIPTION
Joint work with @szeiger.

The spec says:

> In a selection `e.m(args)` with `e` of type `T`, if the selector
> `m` denotes some member(s) of `T`, but none of these members is
> applicable to the arguments `args`.

> In this case a view `v` is searched which is applicable to `e`
> and whose result contains a method `m` which is applicable to `args`.
> The search proceeds as in the case of implicit parameters, where
> the implicit scope is the one of `T`.  If such a view is found, the
> selection `e.m` is converted to `v(e).m(args)`.

The problem was that the failing selection would actually look like
`e.m[T]`, where we need to strip the `[T]` so that the adapted expression
`v(e).m'` can infer the appropriate type params (most likely different
from `[T]`).

See scala/bug#3674
Fix https://github.com/scala/bug/issues/11232