### PR TITLE
Fix a typo in EBNF

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -3150,7 +3150,7 @@ self =>
      *  TopStatSeq ::= TopStat {semi TopStat}
      *  TopStat ::= Annotations Modifiers TmplDef
      *            | Packaging
-     *            | package object objectDef
+     *            | package object ObjectDef
      *            | Import
      *            |
      *  }}}


### PR DESCRIPTION
In comments nonterminal symbol start with an uppercase letter.