### PR TITLE
Disallow repeated param except in method signature

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1019,7 +1019,7 @@ self =>
        *  Type ::= InfixType `=>' Type
        *         | `(' [`=>' Type] `)' `=>' Type
        *         | InfixType [ExistentialClause]
-       *  ExistentialClause ::= forSome `{' ExistentialDcl {semi ExistentialDcl}} `}'
+       *  ExistentialClause ::= forSome `{' ExistentialDcl {semi ExistentialDcl} `}'
        *  ExistentialDcl    ::= type TypeDcl | val ValDcl
        *  }}}
        */
@@ -2134,7 +2134,7 @@ self =>
     /** The implementation of the context sensitive methods for parsing outside of patterns. */
     object outPattern extends PatternContextSensitive {
       def argType(): Tree = typ()
-      def functionArgType(): Tree = paramType(useStartAsPosition = true)
+      def functionArgType(): Tree = paramType(repeatedParameterOK = false, useStartAsPosition = true)
     }
     /** The implementation for parsing inside of patterns at points where sequences are allowed. */
     object seqOK extends SeqContextSensitive {
@@ -2366,8 +2366,8 @@ self =>
      *  ParamType ::= Type | `=>' Type | Type `*'
      *  }}}
      */
-    def paramType(): Tree = paramType(useStartAsPosition = false)
-    def paramType(useStartAsPosition: Boolean): Tree = {
+    def paramType(): Tree = paramType(repeatedParameterOK = true, useStartAsPosition = false)
+    def paramType(repeatedParameterOK: Boolean, useStartAsPosition: Boolean): Tree = {
       val start = in.offset
       in.token match {
         case ARROW  =>
@@ -2377,7 +2377,8 @@ self =>
           val t = typ()
           if (isRawStar) {
             in.nextToken()
-            if (useStartAsPosition) atPos(start)(repeatedApplication(t))
+            if (!repeatedParameterOK) { syntaxError("repeated parameters are only allowed in method signatures; use Seq instead", skipIt = false) ; t }
+            else if (useStartAsPosition) atPos(start)(repeatedApplication(t))
             else atPos(t.pos.start, t.pos.point)(repeatedApplication(t))
           }
           else t

--- a/test/files/run/byname.scala
+++ b/test/files/run/byname.scala
@@ -44,8 +44,8 @@ test("all", 5, testAll(1, 2, 22, 23))
 val testAllR = testAll _
 test("all r", 7, testAllR(2, 3, Seq(34, 35)))
 
-val testAllS: (Int, =>Int, Int*) => Int = testAll _
-test("all s", 8, testAllS(1, 5, 78, 89))
+val testAllS: (Int, =>Int, Seq[Int]) => Int = testAll _
+test("all s", 8, testAllS(1, 5, Seq(78, 89)))
 
 // test currying
 
@@ -65,10 +65,8 @@ test("cvv", 3, testCVV(1, 2)("", 8))
 val testCVVR = testCVV _
 test("cvv r", 3, testCVVR(Seq(1))("", Seq(8, 9)))
 
-val testCVVRS: (String, Int*) => Int = testCVV(2, 3)
-test("cvv rs", 4, testCVVRS("", 5, 6))
+val testCVVRS: (String, Seq[Int]) => Int = testCVV(2, 3)
+test("cvv rs", 4, testCVVRS("", Seq(5, 6)))
 
 println("$")
-
-// vim: set ts=4 sw=4 et:
 }

--- a/test/files/run/reify_magicsymbols.check
+++ b/test/files/run/reify_magicsymbols.check
@@ -9,5 +9,4 @@ List[AnyRef]
 List[Null]
 List[Nothing]
 AnyRef{def foo(x: Int): Int}
-Int* => Unit
 (=> Int) => Unit

--- a/test/files/run/reify_magicsymbols.scala
+++ b/test/files/run/reify_magicsymbols.scala
@@ -12,6 +12,6 @@ object Test extends App {
   println(typeOf[List[Null]])
   println(typeOf[List[Nothing]])
   println(typeOf[{def foo(x: Int): Int}])
-  println(typeOf[(Int*) => Unit])
+  //println(typeOf[(Int*) => Unit])
   println(typeOf[(=> Int) => Unit])
 }

--- a/test/files/run/t5610.scala
+++ b/test/files/run/t5610.scala
@@ -17,8 +17,8 @@ object Test {
     fun3(1)()
     fun4(1)()
 
-    val f: (String, Int*) => Unit = m(2, 3)
-    f("", 5, 6)
+    val f: (String, Seq[Int]) => Unit = m(2, 3)
+    f("", Seq(5, 6))
   }
 
   def foo(s: => String)(dummy: Int) = () => println(s)


### PR DESCRIPTION
In the old days, eta expansion would preserve
repeatedness of parameters. Instead, disallow
`T*` except for methods and constructors.

In function types, it should be expressed with
`Seq`, including for the expected type of an
eta expansion.

Originally at https://github.com/scala/scala/pull/6107

Fixes scala/bug#8923