### PR TITLE
Fix the definition of `ClassDef`

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2892,7 +2892,7 @@ self =>
     }
 
     /** {{{
-     *  ClassDef ::= Id [TypeParamClause] {Annotation}
+     *  ClassDef ::= Id [TypeParamClause] ConstrAnnotations
      *               [AccessModifier] ClassParamClauses RequiresTypeOpt ClassTemplateOpt
      *  TraitDef ::= Id [TypeParamClause] RequiresTypeOpt TraitTemplateOpt
      *  }}}


### PR DESCRIPTION
`classDef` calls not `annotations` but `constructorAnnotations`.