### PR TITLE
Quote terminal symbols in EBNF

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1998,8 +1998,8 @@ self =>
       }
 
       /** {{{
-       *  Pattern2    ::=  id  @ Pattern3
-       *                |  `_' @ Pattern3
+       *  Pattern2    ::=  id  `@' Pattern3
+       *                |  `_' `@' Pattern3
        *                |   Pattern3
        *  }}}
        */


### PR DESCRIPTION
When terminal symbols are symbols they are quoted
(e.g. `=>' in `typ` method).