### PR TITLE
Deprecate numeric conversions that lose precision

### DIFF
--- a/src/library/scala/Function0.scala
+++ b/src/library/scala/Function0.scala
@@ -11,7 +11,7 @@
  */
 
 // GENERATED CODE: DO NOT EDIT.
-// genprod generated these sources at: 2019-01-20T09:16:45.854Z
+// genprod generated these sources at: 2019-06-18T11:44:34.585Z
 
 package scala
 

--- a/src/library/scala/Int.scala
+++ b/src/library/scala/Int.scala
@@ -478,8 +478,9 @@ object Int extends AnyValCompanion {
   override def toString = "object scala.Int"
   /** Language mandated coercions from Int to "wider" types. */
   import scala.language.implicitConversions
-  implicit def int2long(x: Int): Long = x.toLong
+  @deprecated("Implicit conversion from Int to Float is dangerous because it loses precision. Write `.toFloat` instead.", "2.13.1")
   implicit def int2float(x: Int): Float = x.toFloat
+  implicit def int2long(x: Int): Long = x.toLong
   implicit def int2double(x: Int): Double = x.toDouble
 }
 

--- a/src/library/scala/Long.scala
+++ b/src/library/scala/Long.scala
@@ -475,7 +475,9 @@ object Long extends AnyValCompanion {
   override def toString = "object scala.Long"
   /** Language mandated coercions from Long to "wider" types. */
   import scala.language.implicitConversions
+  @deprecated("Implicit conversion from Long to Float is dangerous because it loses precision. Write `.toFloat` instead.", "2.13.1")
   implicit def long2float(x: Long): Float = x.toFloat
+  @deprecated("Implicit conversion from Long to Double is dangerous because it loses precision. Write `.toDouble` instead.", "2.13.1")
   implicit def long2double(x: Long): Double = x.toDouble
 }
 

--- a/test/files/neg/deprecated_widening.check
+++ b/test/files/neg/deprecated_widening.check
@@ -1,0 +1,21 @@
+deprecated_widening.scala:3: warning: Automatic conversion from Int to Float is deprecated (since 2.13.1) because it loses precision. Write `.toFloat` instead.
+    val i_f: Float = i  // deprecated
+                     ^
+deprecated_widening.scala:5: warning: Automatic conversion from Long to Float is deprecated (since 2.13.1) because it loses precision. Write `.toFloat` instead.
+    val l_f: Float = l  // deprecated
+                     ^
+deprecated_widening.scala:6: warning: Automatic conversion from Long to Double is deprecated (since 2.13.1) because it loses precision. Write `.toDouble` instead.
+    val l_d: Double = l // deprecated
+                      ^
+deprecated_widening.scala:10: warning: method int2float in object Int is deprecated (since 2.13.1): Implicit conversion from Int to Float is dangerous because it loses precision. Write `.toFloat` instead.
+    implicitly[Int => Float]   // deprecated
+              ^
+deprecated_widening.scala:12: warning: method long2float in object Long is deprecated (since 2.13.1): Implicit conversion from Long to Float is dangerous because it loses precision. Write `.toFloat` instead.
+    implicitly[Long => Float]  // deprecated
+              ^
+deprecated_widening.scala:13: warning: method long2double in object Long is deprecated (since 2.13.1): Implicit conversion from Long to Double is dangerous because it loses precision. Write `.toDouble` instead.
+    implicitly[Long => Double] // deprecated
+              ^
+error: No warnings can be incurred under -Werror.
+6 warnings found
+one error found

--- a/test/files/neg/deprecated_widening.flags
+++ b/test/files/neg/deprecated_widening.flags
@@ -1,0 +1,1 @@
+-deprecation -Xfatal-warnings

--- a/test/files/neg/deprecated_widening.scala
+++ b/test/files/neg/deprecated_widening.scala
@@ -1,0 +1,15 @@
+object Test {
+  def foo(i: Int, l: Long): Unit = {
+    val i_f: Float = i  // deprecated
+    val i_d: Double = i // OK
+    val l_f: Float = l  // deprecated
+    val l_d: Double = l // deprecated
+  }
+
+  def imp: Unit = {
+    implicitly[Int => Float]   // deprecated
+    implicitly[Int => Double]  // OK
+    implicitly[Long => Float]  // deprecated
+    implicitly[Long => Double] // deprecated
+  }
+}

--- a/test/files/neg/t8450.check
+++ b/test/files/neg/t8450.check
@@ -1,6 +1,6 @@
 t8450.scala:7: warning: implicit numeric widening
-  def elapsed: Foo = (System.nanoTime - 100L).foo
-                                      ^
+  def elapsed: Foo = (System.nanoTime.toInt - 100).foo
+                                            ^
 error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t8450.scala
+++ b/test/files/neg/t8450.scala
@@ -4,11 +4,11 @@ trait Foo
 
 class WarnWidening {
   implicit class FooDouble(d: Double) { def foo = new Foo {} }
-  def elapsed: Foo = (System.nanoTime - 100L).foo
+  def elapsed: Foo = (System.nanoTime.toInt - 100).foo
 }
 
 class NoWarnWidening {
-  implicit class FooLong(l: Long) { def foo = new Foo {} }
+  implicit class FooInt(i: Int) { def foo = new Foo {} }
   implicit class FooDouble(d: Double) { def foo = new Foo {} }
-  def elapsed: Foo = (System.nanoTime - 100L).foo
+  def elapsed: Foo = (System.nanoTime.toInt - 100).foo
 }

--- a/test/files/run/arrays.scala
+++ b/test/files/run/arrays.scala
@@ -293,7 +293,7 @@ object Test {
   def fcheck(xs: Array[Float  ]): Unit = {
     check(xs.length == 3, xs.length, 3);
     check(xs(0) == f0, xs(0), f0);
-    check(xs(1) == f1, xs(1), f1: Float); // !!! : Float
+    check(xs(1) == f1, xs(1), f1.toFloat); // !!! : Float
     check(xs(2) == f2, xs(2), f2);
   }
 
@@ -363,7 +363,7 @@ object Test {
   val carray: Array[Char   ] = Array(c0, c1, c2);
   val iarray: Array[Int    ] = Array(i0, i1, i2);
   val larray: Array[Long   ] = Array(l0, l1, l2);
-  val farray: Array[Float  ] = Array(f0, f1, f2);
+  val farray: Array[Float  ] = Array(f0, f1.toFloat, f2);
   val darray: Array[Double ] = Array(d0, d1, d2);
   val rarray: Array[AnyRef ] = Array(r0, r1, r2, r4, r4, r5);
   val oarray: Array[Object ] = Array(o0, o1, o2, o4, o4, o5);

--- a/test/files/run/hashCodeStatics.scala
+++ b/test/files/run/hashCodeStatics.scala
@@ -7,10 +7,10 @@ object Test
 
   def allSame[T](xs: List[T]) = assert(xs.distinct.size == 1, "failed: " + xs)
 
-  def mkNumbers(x: Int): List[Number] =
-    List(x.toByte, x.toShort, x, x.toLong, x.toFloat, x.toDouble)
+  def mkNumbers(x: Int): List[Any] =
+    List[Any](x.toByte, x.toShort, x, x.toLong, x.toFloat, x.toDouble)
 
-  def testLDF(x: Long) = allSame(List[Number](x, x.toDouble, x.toFloat) map anyHash)
+  def testLDF(x: Long) = allSame(List[Any](x, x.toDouble, x.toFloat) map anyHash)
 
   def main(args: Array[String]): Unit = {
     List(Byte.MinValue, -1, 0, 1, Byte.MaxValue) foreach { n =>


### PR DESCRIPTION
Int to Float, Long to Float and Long to Double are dangerous conversions
and should never be done automatically.