### PR TITLE
Fix the EBNF of BlockStat

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1270,7 +1270,7 @@ include at least the expressions of the following forms:
 
 ```ebnf
 BlockStat    ::=  Import
-               |  {Annotation} [‘implicit’ | ‘lazy’] Def
+               |  {Annotation} [‘implicit’] [‘lazy’] Def
                |  {Annotation} {LocalModifier} TmplDef
                |  Expr1
                |

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -174,7 +174,7 @@ grammar:
                       |  ‘{’ Block ‘}’
   Block             ::=  BlockStat {semi BlockStat} [ResultExpr]
   BlockStat         ::=  Import
-                      |  {Annotation} [‘implicit’ | ‘lazy’] Def
+                      |  {Annotation} [‘implicit’] [‘lazy’] Def
                       |  {Annotation} {LocalModifier} TmplDef
                       |  Expr1
                       |


### PR DESCRIPTION
This is valid syntax:

```
object Main extends App {
  def a(op: => Unit): Unit = ()

  a {
    implicit lazy val i = 1
    lazy implicit val j = 2
    implicit val k = 3
    lazy val l = 4
  }
}
```