### PR TITLE
Deprecate `Channel`,`SyncChannel`,`SyncVar` and `DelayedLazyVal`

### DIFF
--- a/src/library/scala/concurrent/Channel.scala
+++ b/src/library/scala/concurrent/Channel.scala
@@ -18,10 +18,11 @@ package scala.concurrent
  *  @tparam A type of data exchanged
  *  @author  Martin Odersky
  */
+@deprecated("Use `java.util.concurrent.LinkedTransferQueue` instead.", since = "Scala 2.13.0")
 class Channel[A] {
   private class LinkedList {
     var elem: A = _
-    var next: LinkedList = null
+    var next: LinkedList = _
   }
   private[this] var written = new LinkedList    // FIFO queue, realized through
   private[this] var lastWritten = written       // aliasing of a linked list
@@ -32,7 +33,7 @@ class Channel[A] {
    *
    * @param x object to enqueue to this channel
    */
-  def write(x: A) = synchronized {
+  def write(x: A): Unit = synchronized {
     lastWritten.elem = x
     lastWritten.next = new LinkedList
     lastWritten = lastWritten.next

--- a/src/library/scala/concurrent/DelayedLazyVal.scala
+++ b/src/library/scala/concurrent/DelayedLazyVal.scala
@@ -27,6 +27,7 @@ package scala.concurrent
  *  @author  Paul Phillips
  *  @since 2.8
  */
+@deprecated("`DelayedLazyVal` Will be removed in Scala 2.14.0 release.", since = "Scala 2.13.0")
 class DelayedLazyVal[T](f: () => T, body: => Unit)(implicit exec: ExecutionContext){
   @volatile private[this] var _isDone = false
   private[this] lazy val complete = f()
@@ -35,7 +36,7 @@ class DelayedLazyVal[T](f: () => T, body: => Unit)(implicit exec: ExecutionConte
    *
    *  @return true if the computation is complete.
    */
-  def isDone = _isDone
+  def isDone: Boolean = _isDone
 
   /** The current result of f(), or the final result if complete.
    *
@@ -43,5 +44,7 @@ class DelayedLazyVal[T](f: () => T, body: => Unit)(implicit exec: ExecutionConte
    */
   def apply(): T = if (isDone) complete else f()
 
-  exec.execute(new Runnable { def run = { body; _isDone = true } })
+  exec.execute(() => {
+    body; _isDone = true
+  })
 }

--- a/src/library/scala/concurrent/SyncChannel.scala
+++ b/src/library/scala/concurrent/SyncChannel.scala
@@ -19,6 +19,7 @@ package scala.concurrent
  *  @author  Philipp Haller
  *  @since 2.0
  */
+@deprecated("Use `java.util.concurrent.Exchanger` instead.", since = "Scala 2.13.0")
 class SyncChannel[A] {
 
   private[this] var pendingWrites = List[(A, SyncVar[Boolean])]()
@@ -30,7 +31,7 @@ class SyncChannel[A] {
 
     this.synchronized {
       // check whether there is a reader waiting
-      if (!pendingReads.isEmpty) {
+      if (pendingReads.nonEmpty) {
         val readReq  = pendingReads.head
         pendingReads = pendingReads.tail
 
@@ -55,7 +56,7 @@ class SyncChannel[A] {
 
     this.synchronized {
       // check whether there is a writer waiting
-      if (!pendingWrites.isEmpty) {
+      if (pendingWrites.nonEmpty) {
         // read data
         val (data, writeReq) = pendingWrites.head
         pendingWrites = pendingWrites.tail

--- a/src/library/scala/concurrent/SyncVar.scala
+++ b/src/library/scala/concurrent/SyncVar.scala
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit
  *  @tparam A type of the contained value
  *  @author  Martin Odersky
  */
+@deprecated("Use `java.util.concurrent.LinkedBlockingQueue with capacity 1` instead.", since = "Scala 2.13.0")
 class SyncVar[A] {
   private[this] var isDefined: Boolean = false
   private[this] var value: A = _

--- a/src/library/scala/sys/process/package.scala
+++ b/src/library/scala/sys/process/package.scala
@@ -232,6 +232,7 @@ package scala.sys {
       type JProcess               = java.lang.Process
       type JProcessBuilder        = java.lang.ProcessBuilder
       type OutputStream           = java.io.OutputStream
+      @deprecated("Use `java.util.concurrent.SynchronousQueue` instead.", since = "Scala 2.13.0")
       type SyncVar[T]             = scala.concurrent.SyncVar[T]
       type URL                    = java.net.URL
 

--- a/test/files/jvm/sync-var.check
+++ b/test/files/jvm/sync-var.check
@@ -1,1 +1,2 @@
+warning: there was one deprecation warning (since Scala 2.13.0); re-run with -deprecation for details
 50005000 50005000 true

--- a/test/files/jvm/sync-var.scala
+++ b/test/files/jvm/sync-var.scala
@@ -1,4 +1,3 @@
-import java.util.concurrent._
 import java.util.concurrent.atomic._
 
 object Test { def main(args: Array[String]): Unit = {


### PR DESCRIPTION
There are many great concurrent libraries out there, so we could deprecate these.
And I think the `io` and `process` pacakges could live out of the Scala core library too.