### PR TITLE
ControlThrowable never suppresses

### DIFF
--- a/src/compiler/scala/reflect/macros/runtime/AbortMacroException.scala
+++ b/src/compiler/scala/reflect/macros/runtime/AbortMacroException.scala
@@ -16,4 +16,4 @@ package runtime
 import scala.reflect.internal.util.Position
 import scala.util.control.ControlThrowable
 
-class AbortMacroException(val pos: Position, val msg: String) extends Throwable(msg) with ControlThrowable
+class AbortMacroException(val pos: Position, val msg: String) extends ControlThrowable(msg)

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -17,7 +17,7 @@ import scala.reflect.internal.util.StringOps.{ countElementsAsString, countAsStr
 import java.lang.System.{lineSeparator => EOL}
 import scala.reflect.runtime.ReflectionUtils
 import scala.reflect.macros.runtime.AbortMacroException
-import scala.util.control.NonFatal
+import scala.util.control.{ControlThrowable, NonFatal}
 import scala.tools.nsc.util.stackTraceString
 import scala.reflect.io.NoAbstractFile
 import scala.reflect.internal.util.NoSourceFile
@@ -826,7 +826,7 @@ trait ContextErrors {
       }
 
 
-      case object MacroExpansionException extends Exception with scala.util.control.ControlThrowable
+      case object MacroExpansionException extends ControlThrowable
 
       protected def macroExpansionError(expandee: Tree, msg: String, pos: Position = NoPosition) = {
         def msgForLog = if (msg != null && (msg contains "exception during macro expansion")) msg.split(EOL).drop(1).headOption.getOrElse("?") else msg

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -124,7 +124,7 @@ trait Infer extends Checkable {
    */
   def freshVar(tparam: Symbol): TypeVar = TypeVar(tparam)
 
-  class NoInstance(msg: String) extends Throwable(msg) with ControlThrowable { }
+  class NoInstance(msg: String) extends ControlThrowable(msg)
   private class DeferredNoInstance(getmsg: () => String) extends NoInstance("") {
     override def getMessage(): String = getmsg()
   }

--- a/src/compiler/scala/tools/util/SystemExit.scala
+++ b/src/compiler/scala/tools/util/SystemExit.scala
@@ -20,4 +20,4 @@ import scala.util.control.ControlThrowable
   *
   * @param code the exit code
   */
-final case class SystemExit(code: Int) extends Throwable(s"exit code $code") with ControlThrowable
+final case class SystemExit(code: Int) extends ControlThrowable(s"exit code $code")

--- a/src/library/scala/util/Using.scala
+++ b/src/library/scala/util/Using.scala
@@ -14,7 +14,7 @@ package scala.util
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import scala.util.control.{ControlThrowable, NonFatal}
+import scala.util.control.NonFatal
 
 /** A utility for performing automatic resource management. It can be used to perform an
   * operation using resources, after which it will release the resources, in reverse order
@@ -148,10 +148,8 @@ object Using {
   def resource[R: Resource, A](resource: R)(body: R => A): A = {
     if (resource == null) throw new NullPointerException("null resource")
 
-    @inline def safeAddSuppressed(t: Throwable, suppressed: Throwable): Unit = {
-      // don't `addSuppressed` to something which is a `ControlThrowable`
-      if (!t.isInstanceOf[ControlThrowable]) t.addSuppressed(suppressed)
-    }
+    @inline def safeAddSuppressed(t: Throwable, suppressed: Throwable): Unit =
+      t.addSuppressed(suppressed)  // a no-op for ControlThrowable
 
     var primary: Throwable = null
     try {

--- a/src/library/scala/util/control/ControlThrowable.scala
+++ b/src/library/scala/util/control/ControlThrowable.scala
@@ -10,30 +10,43 @@
  * additional information regarding copyright ownership.
  */
 
-package scala
-package util.control
+package scala.util.control
 
-/** A marker trait indicating that the `Throwable` it is mixed into is
- *  intended for flow control.
+/** A parent class for throwable objects intended for flow control.
  *
- *  Note that `Throwable` subclasses which extend this trait may extend any
- *  other `Throwable` subclass (eg. `RuntimeException`) and are not required
- *  to extend `Throwable` directly.
+ *  Instances of `ControlThrowable` should not normally be caught.
  *
- *  Instances of `Throwable` subclasses marked in this way should not normally
- *  be caught. Where catch-all behaviour is required `ControlThrowable`
- *  should be propagated, for example:
+ *  As a convenience, `NonFatal` does not match `ControlThrowable`.
+ *
  *  {{{
- *  import scala.util.control.ControlThrowable
+ *  import scala.util.control.{Breaks, NonFatal}, Breaks.{break, breakable}
  *
- *  try {
- *    // Body might throw arbitrarily
- *  } catch {
- *    case c: ControlThrowable => throw c // propagate
- *    case t: Exception        => log(t)  // log and suppress
+ *  breakable {
+ *    for (v <- values) {
+ *      try {
+ *        if (p(v)) break
+ *        else ???
+ *      } catch {
+ *        case NonFatal(t) => log(t)  // can't catch a break
+ *      }
+ *    }
  *  }
  *  }}}
  *
+ *  Suppression is disabled, because flow control should not suppress
+ *  an exceptional condition.
+ *
+ *  Instances of `ControlThrowable` should not normally have either
+ *  a cause or a writable stack trace.
+ *
+ *  Legacy subclasses may make the stack trace writable by using
+ *  the appropriate constructor. A cause may be set using `initCause`.
+ *
  *  @author Miles Sabin
  */
-trait ControlThrowable extends Throwable with NoStackTrace
+abstract class ControlThrowable private[this] (message: String, cause: Throwable, writableStackTrace: Boolean) extends Throwable(message, cause, /*enableSuppression=*/ false, writableStackTrace) {
+  def this() = this(message = null, cause = null, writableStackTrace = false)
+  def this(message: String) = this(message = message, cause = null, writableStackTrace = false)
+  @deprecated("Writable stack trace is provided only for compatibility", since = "2.13.0")
+  protected def this(message: String, writableStackTrace: true) = this(message = message, cause = null, writableStackTrace = writableStackTrace)
+}

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -5064,8 +5064,8 @@ trait Types
     if (settings.debug) printStackTrace()
   }
 
-  class NoCommonType(tps: List[Type]) extends Throwable(
-    "lub/glb of incompatible types: " + tps.mkString("", " and ", "")) with ControlThrowable
+  class NoCommonType(tps: List[Type]) extends ControlThrowable(
+    "lub/glb of incompatible types: " + tps.mkString("", " and ", ""))
 
   /** A throwable signalling a malformed type */
   class MalformedType(msg: String) extends TypeError(msg) {

--- a/test/files/jvm/non-fatal-tests.scala
+++ b/test/files/jvm/non-fatal-tests.scala
@@ -16,7 +16,7 @@ trait NonFatalTests {
           new OutOfMemoryError,
           new LinkageError,
           new VirtualMachineError {},
-          new Throwable with scala.util.control.ControlThrowable)
+          new scala.util.control.ControlThrowable {})
 
 	def testFatalsUsingApply(): Unit = {
 	   fatals foreach { t => assert(NonFatal(t) == false) }

--- a/test/junit/scala/tools/testing/AssertThrowsTest.scala
+++ b/test/junit/scala/tools/testing/AssertThrowsTest.scala
@@ -5,7 +5,7 @@ import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import AssertUtil.assertThrows
+import AssertUtil.{assertThrown, assertThrows}
 
 @RunWith(classOf[JUnit4])
 class AssertThrowsTest {
@@ -40,4 +40,28 @@ class AssertThrowsTest {
     }
     fail("assertThrows should error if the tested expression does not throw anything")
   }
+
+  @Test
+  def helpful(): Unit =
+    try {
+      assertThrown[Foo]((foo: Foo) => false)(throw new Foo)
+    } catch {
+      case ae: AssertionError =>
+        assertEquals(1, ae.getSuppressed.length)
+        assertEquals("Exception failed check: scala.tools.testing.AssertThrowsTest$Foo", ae.getMessage)
+        assertEquals(classOf[Foo], ae.getSuppressed.head.getClass)
+      case t: Throwable => fail("Expected an AssertionError: $t")
+    }
+
+  @Test
+  def discriminating(): Unit =
+    try {
+      assertThrown[Foo]((foo: Foo) => true)(throw new Bar)
+    } catch {
+      case ae: AssertionError =>
+        assertEquals(1, ae.getSuppressed.length)
+        assertEquals("Exception not a scala.tools.testing.AssertThrowsTest$Foo: scala.tools.testing.AssertThrowsTest$Bar", ae.getMessage)
+        assertEquals(classOf[Bar], ae.getSuppressed.head.getClass)
+      case t: Throwable => fail("Expected an AssertionError: $t")
+    }
 }

--- a/test/junit/scala/tools/testing/AssertUtil.scala
+++ b/test/junit/scala/tools/testing/AssertUtil.scala
@@ -54,6 +54,16 @@ object AssertUtil {
     }
   }
 
+  def assertThrown[T <: Throwable: ClassTag](checker: T => Boolean)(body: => Any): Unit =
+    try {
+      body
+      fail("Expression did not throw!")
+    } catch {
+      case e: T if checker(e) => ()
+      case other: T => val ae = new AssertionError(s"Exception failed check: $other") ; ae.addSuppressed(other) ; throw ae
+      case other => val ae = new AssertionError(s"Exception not a ${implicitly[ClassTag[T]]}: $other") ; ae.addSuppressed(other) ; throw ae
+    }
+
   /** JUnit-style assertion for `IterableLike.sameElements`.
    */
   def assertSameElements[A, B >: A](expected: Iterable[A], actual: Iterable[B], message: String = ""): Unit =

--- a/test/junit/scala/util/UsingTest.scala
+++ b/test/junit/scala/util/UsingTest.scala
@@ -402,8 +402,8 @@ object UsingTest {
   final class UsingException(message: String) extends Exception(message)
   final class ClosingError(message: String) extends Error(message)
   final class UsingError(message: String) extends Error(message)
-  final class ClosingMarker(message: String) extends Throwable(message) with ControlThrowable
-  final class UsingMarker(message: String) extends Throwable(message) with ControlThrowable
+  final class ClosingMarker(message: String) extends ControlThrowable(message)
+  final class UsingMarker(message: String) extends ControlThrowable(message)
 
   abstract class BaseResource extends AutoCloseable {
     final def identity[A](a: A): A = a
@@ -423,17 +423,17 @@ object UsingTest {
   final class MarkerResource extends CustomResource(new ClosingMarker(_))
 
   def assertThrowableClass[T <: Throwable: ClassTag](t: Throwable): Unit = {
-    assertEquals(t.getClass, implicitly[ClassTag[T]].runtimeClass)
+    assertEquals(s"Caught [${t.getMessage}]", implicitly[ClassTag[T]].runtimeClass, t.getClass)
   }
 
   def assertSingleSuppressed[T <: Throwable: ClassTag](t: Throwable): Unit = {
     val suppressed = t.getSuppressed
-    assertEquals(suppressed.length, 1)
+    assertEquals(1, suppressed.length)
     assertThrowableClass[T](suppressed(0))
   }
 
   def assertNoSuppressed(t: Throwable): Unit = {
-    assertEquals(t.getSuppressed.length, 0)
+    assertEquals(0, t.getSuppressed.length)
   }
 
   def catchThrowable(thunk: => Any): Throwable = {

--- a/test/junit/scala/util/control/ControlThrowableTest.scala
+++ b/test/junit/scala/util/control/ControlThrowableTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.util.control
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+import org.junit.Assert._
+import scala.tools.testing.AssertUtil._
+
+@RunWith(classOf[JUnit4])
+@deprecated("Test me, don't judge me", since = "forever")
+class ControlThrowableTest {
+
+  class MyCtl extends ControlThrowable
+
+  @deprecated("Test me, don't use me", since = "forever")
+  class LegacyCtl extends ControlThrowable("legacy", true)
+
+  @Test
+  def stackless(): Unit = assertThrown[MyCtl]((my: MyCtl) => my.getStackTrace.isEmpty)(throw new MyCtl)
+
+  @Test
+  def fatal(): Unit =
+    new MyCtl match {
+      case NonFatal(_) => fail("ControlThrowable was NonFatal")
+      case _ => ()
+    }
+
+  @Test
+  def nonsuppressant(): Unit =
+    assertThrown((my: MyCtl) => my.getSuppressed.isEmpty) {
+      val e = new MyCtl
+      e.addSuppressed(new java.io.IOException)
+      throw e
+    }
+
+  @Test
+  def stackful(): Unit =
+    assertThrown[LegacyCtl]((legacy: LegacyCtl) => !legacy.getStackTrace.isEmpty) {
+      throw new LegacyCtl
+    }
+}


### PR DESCRIPTION
Make ControlThrowable a class with suppression and stack trace disabled.

This change would affect anyone mixing the trait into a custom Error or checked exception.