### PR TITLE
Add type annotation to `scala.concurrent.duration.*`

### DIFF
--- a/src/library/scala/concurrent/duration/Deadline.scala
+++ b/src/library/scala/concurrent/duration/Deadline.scala
@@ -64,7 +64,7 @@ case class Deadline private (time: FiniteDuration) extends Ordered[Deadline] {
   /**
    * The natural ordering for deadline is determined by the natural order of the underlying (finite) duration.
    */
-  def compare(other: Deadline) = time compare other.time
+  def compare(other: Deadline): Int = time compare other.time
 }
 
 object Deadline {
@@ -79,7 +79,7 @@ object Deadline {
    * The natural ordering for deadline is determined by the natural order of the underlying (finite) duration.
    */
   implicit object DeadlineIsOrdered extends Ordering[Deadline] {
-    def compare(a: Deadline, b: Deadline) = a compare b
+    def compare(a: Deadline, b: Deadline): Int = a compare b
   }
 
 }

--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -20,7 +20,7 @@ object Duration {
    * Construct a Duration from the given length and unit. Observe that nanosecond precision may be lost if
    *
    *  - the unit is NANOSECONDS
-   *  - and the length has an absolute value greater than 2^53
+   *  - and the length has an absolute value greater than `2^53`
    *
    * Infinite inputs (and NaN) are converted into [[Duration.Inf]], [[Duration.MinusInf]] and [[Duration.Undefined]], respectively.
    *
@@ -173,17 +173,17 @@ object Duration {
    *
    * The particular comparison semantics mirror those of Double.NaN.
    *
-   * '''''Use `eq` when checking an input of a method against this value.'''''
+   * '''''Use [[eq]] when checking an input of a method against this value.'''''
    */
   val Undefined: Infinite = new Infinite {
     override def toString = "Duration.Undefined"
-    override def equals(other: Any) = false
+    override def equals(other: Any): Boolean  = false
     override def +(other: Duration): Duration = this
     override def -(other: Duration): Duration = this
     override def *(factor: Double): Duration  = this
     override def /(factor: Double): Duration  = this
     override def /(other: Duration): Double   = Double.NaN
-    def compare(other: Duration) = if (other eq this) 0 else 1
+    def compare(other: Duration): Int         = if (other eq this) 0 else 1
     def unary_- : Duration = this
     def toUnit(unit: TimeUnit): Double = Double.NaN
     private def readResolve(): AnyRef = Undefined      // Instructs deserialization to use this same instance
@@ -236,15 +236,15 @@ object Duration {
    * matching its semantics in arithmetic operations.
    */
   val Inf: Infinite = new Infinite  {
-    override def toString = "Duration.Inf"
-    def compare(other: Duration) = other match {
+    override def toString: String      = "Duration.Inf"
+    def compare(other: Duration): Int  = other match {
       case x if x eq Undefined => -1 // Undefined != Undefined
       case x if x eq this      => 0  // `case Inf` will include null checks in the byte code
       case _                   => 1
     }
-    def unary_- : Duration = MinusInf
+    def unary_- : Duration             = MinusInf
     def toUnit(unit: TimeUnit): Double = Double.PositiveInfinity
-    private def readResolve(): AnyRef = Inf            // Instructs deserialization to use this same instance
+    private def readResolve(): AnyRef  = Inf            // Instructs deserialization to use this same instance
   }
 
   /**
@@ -253,11 +253,11 @@ object Duration {
    * matching its semantics in arithmetic operations.
    */
   val MinusInf: Infinite = new Infinite {
-    override def toString = "Duration.MinusInf"
-    def compare(other: Duration) = if (other eq this) 0 else -1
+    override def toString: String      = "Duration.MinusInf"
+    def compare(other: Duration): Int  = if (other eq this) 0 else -1
     def unary_- : Duration = Inf
     def toUnit(unit: TimeUnit): Double = Double.NegativeInfinity
-    private def readResolve(): AnyRef = MinusInf    // Instructs deserialization to use this same instance
+    private def readResolve(): AnyRef  = MinusInf    // Instructs deserialization to use this same instance
   }
 
   // Java Factories
@@ -271,7 +271,7 @@ object Duration {
    * Construct a Duration from the given length and unit. Observe that nanosecond precision may be lost if
    *
    *  - the unit is NANOSECONDS
-   *  - and the length has an absolute value greater than 2^53
+   *  - and the length has an absolute value greater than `2^53`
    *
    * Infinite inputs (and NaN) are converted into [[Duration.Inf]], [[Duration.MinusInf]] and [[Duration.Undefined]], respectively.
    *
@@ -299,7 +299,7 @@ object Duration {
    * The natural ordering of durations matches the natural ordering for Double, including non-finite values.
    */
   implicit object DurationIsOrdered extends Ordering[Duration] {
-    def compare(a: Duration, b: Duration) = a compare b
+    def compare(a: Duration, b: Duration): Int = a compare b
   }
 }
 
@@ -368,7 +368,7 @@ object Duration {
  *
  * @define exc @throws IllegalArgumentException when invoked on a non-finite duration
  *
- * @define ovf @throws IllegalArgumentException in case of a finite overflow: the range of a finite duration is +-(2^63-1)ns, and no conversion to infinite durations takes place.
+ * @define ovf @throws IllegalArgumentException in case of a finite overflow: the range of a finite duration is `+-(2^63-1)`ns, and no conversion to infinite durations takes place.
  */
 sealed abstract class Duration extends Serializable with Ordered[Duration] {
   /**
@@ -494,41 +494,41 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
    *
    * $ovf
    */
-  def div(divisor: Double)    = this / divisor
+  def div(divisor: Double): Duration = this / divisor
   /**
    * Return the quotient of this and that duration as floating-point number. The semantics are
    * determined by Double as if calculating the quotient of the nanosecond lengths of both factors.
    */
-  def div(other: Duration)   = this / other
-  def gt(other: Duration)    = this > other
-  def gteq(other: Duration)  = this >= other
-  def lt(other: Duration)    = this < other
-  def lteq(other: Duration)  = this <= other
+  def div(other: Duration): Double   = this / other
+  def gt(other: Duration): Boolean   = this > other
+  def gteq(other: Duration): Boolean = this >= other
+  def lt(other: Duration): Boolean   = this < other
+  def lteq(other: Duration): Boolean = this <= other
   /**
    * Return the difference of that duration and this. When involving non-finite summands the semantics match those
    * of Double.
    *
    * $ovf
    */
-  def minus(other: Duration) = this - other
+  def minus(other: Duration): Duration = this - other
   /**
    * Return this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
    * of Double.
    *
    * $ovf
    */
-  def mul(factor: Double)    = this * factor
+  def mul(factor: Double): Duration    = this * factor
   /**
    * Negate this duration. The only two values which are mapped to themselves are [[Duration.Zero]] and [[Duration.Undefined]].
    */
-  def neg()                  = -this
+  def neg(): Duration                  = -this
   /**
    * Return the sum of that duration and this. When involving non-finite summands the semantics match those
    * of Double.
    *
    * $ovf
    */
-  def plus(other: Duration)  = this + other
+  def plus(other: Duration): Duration  = this + other
   /**
    * Return duration which is equal to this duration but with a coarsest Unit, or self in case it is already the coarsest Unit
    * <p/>
@@ -546,11 +546,11 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
 object FiniteDuration {
 
   implicit object FiniteDurationIsOrdered extends Ordering[FiniteDuration] {
-    def compare(a: FiniteDuration, b: FiniteDuration) = a compare b
+    def compare(a: FiniteDuration, b: FiniteDuration): Int = a compare b
   }
 
-  def apply(length: Long, unit: TimeUnit) = new FiniteDuration(length, unit)
-  def apply(length: Long, unit: String)   = new FiniteDuration(length, Duration.timeUnit(unit))
+  def apply(length: Long, unit: TimeUnit): FiniteDuration  = new FiniteDuration(length, unit)
+  def apply(length: Long, unit: String): FiniteDuration    = new FiniteDuration(length, Duration.timeUnit(unit))
 
   // limit on abs. value of durations in their units
   private final val max_ns = Long.MaxValue
@@ -564,7 +564,7 @@ object FiniteDuration {
 
 /**
  * This class represents a finite duration. Its addition and subtraction operators are overloaded to retain
- * this guarantee statically. The range of this class is limited to +-(2^63-1)ns, which is roughly 292 years.
+ * this guarantee statically. The range of this class is limited to `+-(2^63-1)`ns, which is roughly 292  years.
  */
 final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duration {
   import FiniteDuration._
@@ -588,24 +588,24 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
         -max_d <= v && v <= max_d
     }, "Duration is limited to +-(2^63-1)ns (ca. 292 years)")
 
-  def toNanos   = unit.toNanos(length)
-  def toMicros  = unit.toMicros(length)
-  def toMillis  = unit.toMillis(length)
-  def toSeconds = unit.toSeconds(length)
-  def toMinutes = unit.toMinutes(length)
-  def toHours   = unit.toHours(length)
-  def toDays    = unit.toDays(length)
-  def toUnit(u: TimeUnit) = toNanos.toDouble / NANOSECONDS.convert(1, u)
+  def toNanos: Long               = unit.toNanos(length)
+  def toMicros: Long              = unit.toMicros(length)
+  def toMillis: Long              = unit.toMillis(length)
+  def toSeconds: Long             = unit.toSeconds(length)
+  def toMinutes: Long             = unit.toMinutes(length)
+  def toHours: Long               = unit.toHours(length)
+  def toDays: Long                = unit.toDays(length)
+  def toUnit(u: TimeUnit): Double = toNanos.toDouble / NANOSECONDS.convert(1, u)
 
   /**
    * Construct a [[Deadline]] from this duration by adding it to the current instant `Deadline.now`.
    */
   def fromNow: Deadline = Deadline.now + this
 
-  private[this] def unitString = timeUnitName(unit) + ( if (length == 1) "" else "s" )
-  override def toString = "" + length + " " + unitString
+  private[this] def unitString  = timeUnitName(unit) + ( if (length == 1) "" else "s" )
+  override def toString: String     = "" + length + " " + unitString
 
-  def compare(other: Duration) = other match {
+  def compare(other: Duration): Int = other match {
     case x: FiniteDuration => toNanos compare x.toNanos
     case _                 => -(other compare this)
   }
@@ -622,22 +622,22 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
     new FiniteDuration(totalLength, commonUnit)
   }
 
-  def +(other: Duration) = other match {
+  def +(other: Duration): Duration = other match {
     case x: FiniteDuration => add(x.length, x.unit)
     case _                 => other
   }
-  def -(other: Duration) = other match {
+  def -(other: Duration): Duration = other match {
     case x: FiniteDuration => add(-x.length, x.unit)
     case _                 => -other
   }
 
-  def *(factor: Double) =
+  def *(factor: Double): Duration  =
     if (!factor.isInfinite) fromNanos(toNanos * factor)
     else if (JDouble.isNaN(factor)) Undefined
     else if ((factor > 0) ^ (this < Zero)) Inf
     else MinusInf
 
-  def /(divisor: Double) =
+  def /(divisor: Double): Duration =
     if (!divisor.isInfinite) fromNanos(toNanos / divisor)
     else if (JDouble.isNaN(divisor)) Undefined
     else Zero
@@ -651,12 +651,12 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
     else minusZero
 
   // overloaded methods taking FiniteDurations, so that you can calculate while statically staying finite
-  def +(other: FiniteDuration) = add(other.length, other.unit)
-  def -(other: FiniteDuration) = add(-other.length, other.unit)
-  def plus(other: FiniteDuration) = this + other
-  def minus(other: FiniteDuration) = this - other
-  def min(other: FiniteDuration) = if (this < other) this else other
-  def max(other: FiniteDuration) = if (this > other) this else other
+  def +(other: FiniteDuration): FiniteDuration     = add(other.length, other.unit)
+  def -(other: FiniteDuration): FiniteDuration     = add(-other.length, other.unit)
+  def plus(other: FiniteDuration): FiniteDuration  = this + other
+  def minus(other: FiniteDuration): FiniteDuration = this - other
+  def min(other: FiniteDuration): FiniteDuration   = if (this < other) this else other
+  def max(other: FiniteDuration): FiniteDuration   = if (this > other) this else other
 
   // overloaded methods taking Long so that you can calculate while statically staying finite
 
@@ -665,14 +665,14 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
    *
    * @throws ArithmeticException if the factor is 0
    */
-  def /(divisor: Long) = fromNanos(toNanos / divisor)
+  def /(divisor: Long): FiniteDuration = fromNanos(toNanos / divisor)
 
   /**
    * Return the product of this duration and the given integer factor.
    *
    * @throws IllegalArgumentException if the result would overflow the range of FiniteDuration
    */
-  def *(factor: Long) = new FiniteDuration(safeMul(length, factor), unit)
+  def *(factor: Long): FiniteDuration  = new FiniteDuration(safeMul(length, factor), unit)
 
   /*
    * This method avoids the use of Long division, which saves 95% of the time spent,
@@ -699,14 +699,14 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
    *
    * @throws ArithmeticException if the factor is 0
    */
-  def div(divisor: Long) = this / divisor
+  def div(divisor: Long): FiniteDuration = this / divisor
 
   /**
    * Return the product of this duration and the given integer factor.
    *
    * @throws IllegalArgumentException if the result would overflow the range of FiniteDuration
    */
-  def mul(factor: Long) = this * factor
+  def mul(factor: Long): FiniteDuration  = this * factor
 
   def unary_- = Duration(-length, unit)
 
@@ -714,7 +714,7 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
 
   final override def toCoarsest: FiniteDuration = {
     def loop(length: Long, unit: TimeUnit): FiniteDuration = {
-      def coarserOrThis(coarser: TimeUnit, divider: Int) =
+      def coarserOrThis(coarser: TimeUnit, divider: Int): FiniteDuration =
         if (length % divider == 0) loop(length / divider, coarser)
         else if (unit == this.unit) this
         else FiniteDuration(length, unit)
@@ -734,9 +734,9 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
     else loop(length, unit)
   }
 
-  override def equals(other: Any) = other match {
+  override def equals(other: Any): Boolean = other match {
     case x: FiniteDuration => toNanos == x.toNanos
     case _                 => super.equals(other)
   }
-  override def hashCode = toNanos.toInt
+  override def hashCode: Int = toNanos.toInt
 }

--- a/src/library/scala/concurrent/duration/DurationConversions.scala
+++ b/src/library/scala/concurrent/duration/DurationConversions.scala
@@ -19,59 +19,59 @@ import DurationConversions._
 trait DurationConversions extends Any {
   protected def durationIn(unit: TimeUnit): FiniteDuration
 
-  def nanoseconds  = durationIn(NANOSECONDS)
-  def nanos        = nanoseconds
-  def nanosecond   = nanoseconds
-  def nano         = nanoseconds
+  def nanoseconds: FiniteDuration  = durationIn(NANOSECONDS)
+  def nanos: FiniteDuration        = nanoseconds
+  def nanosecond: FiniteDuration   = nanoseconds
+  def nano: FiniteDuration         = nanoseconds
 
-  def microseconds = durationIn(MICROSECONDS)
-  def micros       = microseconds
-  def microsecond  = microseconds
-  def micro        = microseconds
+  def microseconds: FiniteDuration = durationIn(MICROSECONDS)
+  def micros: FiniteDuration       = microseconds
+  def microsecond: FiniteDuration  = microseconds
+  def micro: FiniteDuration        = microseconds
 
-  def milliseconds = durationIn(MILLISECONDS)
-  def millis       = milliseconds
-  def millisecond  = milliseconds
-  def milli        = milliseconds
+  def milliseconds: FiniteDuration = durationIn(MILLISECONDS)
+  def millis: FiniteDuration       = milliseconds
+  def millisecond: FiniteDuration  = milliseconds
+  def milli: FiniteDuration        = milliseconds
 
-  def seconds      = durationIn(SECONDS)
-  def second       = seconds
+  def seconds: FiniteDuration      = durationIn(SECONDS)
+  def second: FiniteDuration       = seconds
 
-  def minutes      = durationIn(MINUTES)
-  def minute       = minutes
+  def minutes: FiniteDuration      = durationIn(MINUTES)
+  def minute: FiniteDuration       = minutes
 
-  def hours        = durationIn(HOURS)
-  def hour         = hours
+  def hours: FiniteDuration        = durationIn(HOURS)
+  def hour: FiniteDuration         = hours
 
-  def days         = durationIn(DAYS)
-  def day          = days
+  def days: FiniteDuration         = durationIn(DAYS)
+  def day: FiniteDuration          = days
 
-  def nanoseconds[C](c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(nanoseconds)
-  def nanos[C](c: C)(implicit ev: Classifier[C]): ev.R = nanoseconds(c)
-  def nanosecond[C](c: C)(implicit ev: Classifier[C]): ev.R = nanoseconds(c)
-  def nano[C](c: C)(implicit ev: Classifier[C]): ev.R = nanoseconds(c)
+  def nanoseconds[C](c: C)(implicit ev: Classifier[C]): ev.R  = ev.convert(nanoseconds)
+  def nanos[C](c: C)(implicit ev: Classifier[C]): ev.R        = nanoseconds(c)
+  def nanosecond[C](c: C)(implicit ev: Classifier[C]): ev.R   = nanoseconds(c)
+  def nano[C](c: C)(implicit ev: Classifier[C]): ev.R         = nanoseconds(c)
 
   def microseconds[C](c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(microseconds)
-  def micros[C](c: C)(implicit ev: Classifier[C]): ev.R = microseconds(c)
-  def microsecond[C](c: C)(implicit ev: Classifier[C]): ev.R = microseconds(c)
-  def micro[C](c: C)(implicit ev: Classifier[C]): ev.R = microseconds(c)
+  def micros[C](c: C)(implicit ev: Classifier[C]): ev.R       = microseconds(c)
+  def microsecond[C](c: C)(implicit ev: Classifier[C]): ev.R  = microseconds(c)
+  def micro[C](c: C)(implicit ev: Classifier[C]): ev.R        = microseconds(c)
 
   def milliseconds[C](c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(milliseconds)
-  def millis[C](c: C)(implicit ev: Classifier[C]): ev.R = milliseconds(c)
-  def millisecond[C](c: C)(implicit ev: Classifier[C]): ev.R = milliseconds(c)
-  def milli[C](c: C)(implicit ev: Classifier[C]): ev.R = milliseconds(c)
+  def millis[C](c: C)(implicit ev: Classifier[C]): ev.R       = milliseconds(c)
+  def millisecond[C](c: C)(implicit ev: Classifier[C]): ev.R  = milliseconds(c)
+  def milli[C](c: C)(implicit ev: Classifier[C]): ev.R        = milliseconds(c)
 
-  def seconds[C](c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(seconds)
-  def second[C](c: C)(implicit ev: Classifier[C]): ev.R = seconds(c)
+  def seconds[C](c: C)(implicit ev: Classifier[C]): ev.R      = ev.convert(seconds)
+  def second[C](c: C)(implicit ev: Classifier[C]): ev.R       = seconds(c)
 
-  def minutes[C](c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(minutes)
-  def minute[C](c: C)(implicit ev: Classifier[C]): ev.R = minutes(c)
+  def minutes[C](c: C)(implicit ev: Classifier[C]): ev.R      = ev.convert(minutes)
+  def minute[C](c: C)(implicit ev: Classifier[C]): ev.R       = minutes(c)
 
-  def hours[C](c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(hours)
-  def hour[C](c: C)(implicit ev: Classifier[C]): ev.R = hours(c)
+  def hours[C](c: C)(implicit ev: Classifier[C]): ev.R        = ev.convert(hours)
+  def hour[C](c: C)(implicit ev: Classifier[C]): ev.R         = hours(c)
 
-  def days[C](c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(days)
-  def day[C](c: C)(implicit ev: Classifier[C]): ev.R = days(c)
+  def days[C](c: C)(implicit ev: Classifier[C]): ev.R         = ev.convert(days)
+  def day[C](c: C)(implicit ev: Classifier[C]): ev.R          = days(c)
 }
 
 /**
@@ -85,12 +85,12 @@ object DurationConversions {
 
   implicit object spanConvert extends Classifier[span.type] {
     type R = FiniteDuration
-    def convert(d: FiniteDuration) = d
+    def convert(d: FiniteDuration): FiniteDuration = d
   }
 
   implicit object fromNowConvert extends Classifier[fromNow.type] {
     type R = Deadline
-    def convert(d: FiniteDuration) = Deadline.now + d
+    def convert(d: FiniteDuration): Deadline = Deadline.now + d
   }
 
 }

--- a/src/library/scala/concurrent/duration/package.scala
+++ b/src/library/scala/concurrent/duration/package.scala
@@ -53,15 +53,15 @@ package object duration {
   implicit def durationToPair(d: Duration): (Long, TimeUnit)           = (d.length, d.unit)
 
   implicit final class DurationInt(private val n: Int) extends AnyVal with DurationConversions {
-    override protected def durationIn(unit: TimeUnit): FiniteDuration = Duration(n.toLong, unit)
+    override protected def durationIn(unit: TimeUnit): FiniteDuration  = Duration(n.toLong, unit)
   }
 
   implicit final class DurationLong(private val n: Long) extends AnyVal with DurationConversions {
-    override protected def durationIn(unit: TimeUnit): FiniteDuration = Duration(n, unit)
+    override protected def durationIn(unit: TimeUnit): FiniteDuration  = Duration(n, unit)
   }
 
   implicit final class DurationDouble(private val d: Double) extends AnyVal with DurationConversions {
-    override protected def durationIn(unit: TimeUnit): FiniteDuration =
+    override protected def durationIn(unit: TimeUnit): FiniteDuration  =
       Duration(d, unit) match {
         case f: FiniteDuration => f
         case _ => throw new IllegalArgumentException("Duration DSL not applicable to " + d)
@@ -72,16 +72,16 @@ package object duration {
    * Avoid reflection based invocation by using non-duck type
    */
   implicit final class IntMult(private val i: Int) extends AnyVal {
-    def *(d: Duration) = d * i.toDouble
-    def *(d: FiniteDuration) = d * i.toLong
+    def *(d: Duration): Duration             = d * i.toDouble
+    def *(d: FiniteDuration): FiniteDuration = d * i.toLong
   }
 
   implicit final class LongMult(private val i: Long) extends AnyVal {
-    def *(d: Duration) = d * i.toDouble
-    def *(d: FiniteDuration) = d * i.toLong
+    def *(d: Duration): Duration             = d * i.toDouble
+    def *(d: FiniteDuration): FiniteDuration = d * i.toLong
   }
 
   implicit final class DoubleMult(private val f: Double) extends AnyVal {
-    def *(d: Duration) = d * f.toDouble
+    def *(d: Duration): Duration             = d * f.toDouble
   }
 }


### PR DESCRIPTION
Motivation: The most of the time, when one is programming with Future or Promise, they will frequently encounter these classes, though add explicit type parameters seem some kind of verbose but it does help a lot, especially for newcomers.