### PR TITLE
Add documentation to AnyRef#wait and sync with doc-root in scala-test.

### DIFF
--- a/src/library-aux/scala/AnyRef.scala
+++ b/src/library-aux/scala/AnyRef.scala
@@ -122,6 +122,21 @@ trait AnyRef extends Any {
    *  @note   not specified by SLS as a member of AnyRef
    */
   final def wait (): Unit
+
+  /** Causes the current Thread to wait until another Thread invokes
+   * the notify() or notifyAll() methods, or a specified amount of time has elapsed.
+   *
+   * @param timeout the maximum time to wait in milliseconds.
+   * @param nanos   additional time, in nanoseconds range 0-999999.
+   * @note not specified by SLS as a member of AnyRef
+   */
   final def wait (timeout: Long, nanos: Int): Unit
+
+  /** Causes the current Thread to wait until another Thread invokes
+   * the notify() or notifyAll() methods, or a specified amount of time has elapsed.
+   *
+   * @param timeout the maximum time to wait in milliseconds.
+   * @note not specified by SLS as a member of AnyRef
+   */
   final def wait (timeout: Long): Unit
 }

--- a/test/scaladoc/resources/doc-root/Any.scala
+++ b/test/scaladoc/resources/doc-root/Any.scala
@@ -14,6 +14,25 @@ package scala
 
 /** Class `Any` is the root of the Scala class hierarchy.  Every class in a Scala
  *  execution environment inherits directly or indirectly from this class.
+ *
+ * Starting with Scala 2.10 it is possible to directly extend `Any` using ''universal traits''.
+ * A ''universal trait'' is a trait that extends `Any`, only has `def`s as members, and does no initialization.
+ *
+ * The main use case for universal traits is to allow basic inheritance of methods for [[scala.AnyVal value classes]].
+ * For example,
+ *
+ * {{{
+ *     trait Printable extends Any {
+ *       def print(): Unit = println(this)
+ *     }
+ *     class Wrapper(val underlying: Int) extends AnyVal with Printable
+ *
+ *     val w = new Wrapper(3)
+ *     w.print()
+ * }}}
+ *
+ * See the [[http://docs.scala-lang.org/overviews/core/value-classes.html Value Classes and Universal Traits]] for more
+ * details on the interplay of universal traits and value classes.
  */
 abstract class Any {
   /** Compares the receiver object (`this`) with the argument object (`that`) for equivalence.
@@ -23,7 +42,7 @@ abstract class Any {
    *  - It is reflexive: for any instance `x` of type `Any`, `x.equals(x)` should return `true`.
    *  - It is symmetric: for any instances `x` and `y` of type `Any`, `x.equals(y)` should return `true` if and
    *    only if `y.equals(x)` returns `true`.
-   *  - It is transitive: for any instances `x`, `y`, and `z` of type `AnyRef` if `x.equals(y)` returns `true` and
+   *  - It is transitive: for any instances `x`, `y`, and `z` of type `Any` if `x.equals(y)` returns `true` and
    *    `y.equals(z)` returns `true`, then `x.equals(z)` should return `true`.
    *
    *  If you override this method, you should verify that your implementation remains an equivalence relation.
@@ -62,7 +81,7 @@ abstract class Any {
    *
    *  @return a class object corresponding to the runtime type of the receiver.
    */
-  def getClass(): Class[_]
+  final def getClass(): Class[_] = sys.error("getClass")
 
   /** Test two objects for equality.
    *  The expression `x == that` is equivalent to `if (x eq null) that eq null else x.equals(that)`.
@@ -101,7 +120,7 @@ abstract class Any {
    *
    *  @return `true` if the receiver object is an instance of erasure of type `T0`; `false` otherwise.
    */
-  def isInstanceOf[T0]: Boolean = sys.error("isInstanceOf")
+  final def isInstanceOf[T0]: Boolean = sys.error("isInstanceOf")
 
   /** Cast the receiver object to be of type `T0`.
    *
@@ -114,5 +133,5 @@ abstract class Any {
    *  @throws ClassCastException if the receiver object is not an instance of the erasure of type `T0`.
    *  @return the receiver object.
    */
-  def asInstanceOf[T0]: T0 = sys.error("asInstanceOf")
+  final def asInstanceOf[T0]: T0 = sys.error("asInstanceOf")
 }

--- a/test/scaladoc/resources/doc-root/AnyRef.scala
+++ b/test/scaladoc/resources/doc-root/AnyRef.scala
@@ -80,8 +80,8 @@ trait AnyRef extends Any {
    *  @param    that  the object to compare against this object for equality.
    *  @return         `true` if the receiver object is equivalent to the argument; `false` otherwise.
    */
-  final def ==(that: AnyRef): Boolean =
-    if (this eq null) that eq null
+  final def ==(that: Any): Boolean =
+    if (this eq null) that.asInstanceOf[AnyRef] eq null
     else this equals that
 
   /** Create a copy of the receiver object.
@@ -104,33 +104,39 @@ trait AnyRef extends Any {
    */
   protected def finalize(): Unit
 
-  /** A representation that corresponds to the dynamic class of the receiver object.
-   *
-   *  The nature of the representation is platform dependent.
-   *
-   *  @note   not specified by SLS as a member of AnyRef
-   *  @return a representation that corresponds to the dynamic class of the receiver object.
-   */
-  def getClass(): Class[_]
-
   /** Wakes up a single thread that is waiting on the receiver object's monitor.
    *
    *  @note   not specified by SLS as a member of AnyRef
    */
-  def notify(): Unit
+  final def notify(): Unit
 
   /** Wakes up all threads that are waiting on the receiver object's monitor.
    *
    *  @note   not specified by SLS as a member of AnyRef
    */
-  def notifyAll(): Unit
+  final def notifyAll(): Unit
 
   /** Causes the current Thread to wait until another Thread invokes
    *  the notify() or notifyAll() methods.
    *
    *  @note   not specified by SLS as a member of AnyRef
    */
-  def wait (): Unit
-  def wait (timeout: Long, nanos: Int): Unit
-  def wait (timeout: Long): Unit
+  final def wait (): Unit
+
+  /** Causes the current Thread to wait until another Thread invokes
+   * the notify() or notifyAll() methods, or a specified amount of time has elapsed.
+   *
+   * @param timeout the maximum time to wait in milliseconds.
+   * @param nanos   additional time, in nanoseconds range 0-999999.
+   * @note not specified by SLS as a member of AnyRef
+   */
+  final def wait (timeout: Long, nanos: Int): Unit
+
+  /** Causes the current Thread to wait until another Thread invokes
+   * the notify() or notifyAll() methods, or a specified amount of time has elapsed.
+   *
+   * @param timeout the maximum time to wait in milliseconds.
+   * @note not specified by SLS as a member of AnyRef
+   */
+  final def wait (timeout: Long): Unit
 }

--- a/test/scaladoc/resources/doc-root/Singleton.scala
+++ b/test/scaladoc/resources/doc-root/Singleton.scala
@@ -1,0 +1,59 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+
+/** `Singleton` is used by the compiler as a supertype for singleton types. This includes literal types,
+  * as they are also singleton types.
+  *
+  * {{{
+  * scala> object A { val x = 42 }
+  * defined object A
+  *
+  * scala> implicitly[A.type <:< Singleton]
+  * res12: A.type <:< Singleton = generalized constraint
+  *
+  * scala> implicitly[A.x.type <:< Singleton]
+  * res13: A.x.type <:< Singleton = generalized constraint
+  *
+  * scala> implicitly[42 <:< Singleton]
+  * res14: 42 <:< Singleton = generalized constraint
+  *
+  * scala> implicitly[Int <:< Singleton]
+  * ^
+  * error: Cannot prove that Int <:< Singleton.
+  * }}}
+  *
+  * `Singleton` has a special meaning when it appears as an upper bound on a formal type
+  * parameter. Normally, type inference in Scala widens singleton types to the underlying
+  * non-singleton type. When a type parameter has an explicit upper bound of `Singleton`,
+  * the compiler infers a singleton type.
+  *
+  * {{{
+  * scala> def check42[T](x: T)(implicit ev: T =:= 42): T = x
+  * check42: [T](x: T)(implicit ev: T =:= 42)T
+  *
+  * scala> val x1 = check42(42)
+  * ^
+  * error: Cannot prove that Int =:= 42.
+  *
+  * scala> def singleCheck42[T <: Singleton](x: T)(implicit ev: T =:= 42): T = x
+  * singleCheck42: [T <: Singleton](x: T)(implicit ev: T =:= 42)T
+  *
+  * scala> val x2 = singleCheck42(42)
+  * x2: Int = 42
+  * }}}
+  *
+  * See also [[https://docs.scala-lang.org/sips/42.type.html SIP-23 about Literal-based Singleton Types]].
+  */
+final trait Singleton extends Any


### PR DESCRIPTION
The docs of library-aux are not right, parameter names are missing.
refs:https://contributors.scala-lang.org/t/scaladocs-about-liburary-aux-is-broken/2582