### PR TITLE
Deprecate `scala.ref`,and use `java.lang.ref.*` directly.

### DIFF
--- a/src/compiler/scala/tools/nsc/SubComponent.scala
+++ b/src/compiler/scala/tools/nsc/SubComponent.scala
@@ -12,7 +12,7 @@
 
 package scala.tools.nsc
 
-import scala.ref.WeakReference
+import java.lang.ref.WeakReference
 
 /** An nsc sub-component.
  *
@@ -62,7 +62,7 @@ abstract class SubComponent {
   /** The phase factory */
   def newPhase(prev: Phase): Phase
 
-  private var ownPhaseCache: WeakReference[Phase] = new WeakReference(null)
+  private var ownPhaseCache: WeakReference[Phase] = new WeakReference[Phase](null)
   private var ownPhaseRunId = global.NoRunId
 
   @inline final def beforeOwnPhase[T](op: => T) = global.enteringPhase(ownPhase)(op)
@@ -70,7 +70,7 @@ abstract class SubComponent {
 
   /** The phase corresponding to this subcomponent in the current compiler run */
   def ownPhase: Phase = {
-    val cache = ownPhaseCache.underlying.get
+    val cache = ownPhaseCache.get
     if (cache != null && ownPhaseRunId == global.currentRunId)
       cache
     else {

--- a/src/library/scala/ref/PhantomReference.scala
+++ b/src/library/scala/ref/PhantomReference.scala
@@ -15,6 +15,7 @@ package scala.ref
 /**
  *  @author Sean McDirmid
  */
+@deprecated("Use `java.lang.ref.PhantomReference` instead.", since = "2.13.0")
 class PhantomReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T]) extends ReferenceWrapper[T] {
   val underlying: java.lang.ref.PhantomReference[_ <: T] =
     new PhantomReferenceWithWrapper[T](value, queue, this)

--- a/src/library/scala/ref/Reference.scala
+++ b/src/library/scala/ref/Reference.scala
@@ -16,7 +16,8 @@ package scala.ref
  * @see `java.lang.ref.Reference`
  * @author Sean McDirmid
  */
-trait Reference[+T <: AnyRef] extends Function0[T] {
+@deprecated("Use `java.lang.ref.Reference` instead.", since = "2.13.0")
+trait Reference[+T <: AnyRef] extends (() => T) {
   /** return the underlying value */
   def apply(): T
   /** return `Some` underlying if it hasn't been collected, otherwise `None` */

--- a/src/library/scala/ref/ReferenceQueue.scala
+++ b/src/library/scala/ref/ReferenceQueue.scala
@@ -16,6 +16,7 @@ package scala.ref
  *  @author Sean McDirmid
  *  @author Philipp Haller
  */
+@deprecated("Use `java.lang.ref.ReferenceQueue` instead.", since = "2.13.0")
 class ReferenceQueue[+T <: AnyRef] {
 
   private[ref] val underlying: java.lang.ref.ReferenceQueue[_ <: T] = new java.lang.ref.ReferenceQueue[T]

--- a/src/library/scala/ref/ReferenceWrapper.scala
+++ b/src/library/scala/ref/ReferenceWrapper.scala
@@ -15,18 +15,19 @@ package scala.ref
 /**
  *  @author Sean McDirmid
  */
+@deprecated("Will be removed in Scala 2.14.0.", since = "2.13.0")
 trait ReferenceWrapper[+T <: AnyRef] extends Reference[T] with Proxy {
   val underlying: java.lang.ref.Reference[_ <: T]
   override def get = Option(underlying.get)
-  def apply() = {
+  def apply(): T = {
     val ret = underlying.get
     if (ret eq null) throw new NoSuchElementException
     ret
   }
-  def clear() = underlying.clear()
-  def enqueue() = underlying.enqueue()
-  def isEnqueued = underlying.isEnqueued
-  def self = underlying
+  def clear(): Unit = underlying.clear()
+  def enqueue(): Boolean = underlying.enqueue()
+  def isEnqueued: Boolean = underlying.isEnqueued
+  def self: java.lang.ref.Reference[_ <: T] = underlying
 }
 
 /**

--- a/src/library/scala/ref/SoftReference.scala
+++ b/src/library/scala/ref/SoftReference.scala
@@ -15,6 +15,7 @@ package scala.ref
 /**
  *  @author Sean McDirmid
  */
+@deprecated("Use `java.lang.ref.SoftReference` instead.", since = "2.13.0")
 class SoftReference[+T <: AnyRef](value : T, queue : ReferenceQueue[T]) extends ReferenceWrapper[T] {
   def this(value : T) = this(value, null)
 
@@ -26,10 +27,11 @@ class SoftReference[+T <: AnyRef](value : T, queue : ReferenceQueue[T]) extends 
  *  A companion object that implements an extractor for `SoftReference` values
  *  @author Rebecca Claire Murphy
  */
+@deprecated("Use `java.lang.ref.SoftReference` instead.", since = "2.13.0")
 object SoftReference {
 
   /** Creates a `SoftReference` pointing to `value` */
-  def apply[T <: AnyRef](value: T) = new SoftReference(value)
+  def apply[T <: AnyRef](value: T): SoftReference[T] = new SoftReference(value)
 
   /** Optionally returns the referenced value, or `None` if that value no longer exists */
   def unapply[T <: AnyRef](sr: SoftReference[T]): Option[T] = Option(sr.underlying.get)

--- a/src/library/scala/ref/WeakReference.scala
+++ b/src/library/scala/ref/WeakReference.scala
@@ -14,10 +14,12 @@ package scala.ref
 
 /**
  *  A wrapper class for java.lang.ref.WeakReference
- *  The new functionality is (1) results are Option values, instead of using null.
+ *  The new functionality is:
+ *  (1) results are Option values, instead of using null.
  *  (2) There is an extractor that maps the weak reference itself into an option.
  *  @author Sean McDirmid
  */
+@deprecated("Use `java.lang.ref.WeakReference` instead.", since = "2.13.0")
 class WeakReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T]) extends ReferenceWrapper[T] {
   def this(value: T) = this(value, null)
   val underlying: java.lang.ref.WeakReference[_ <: T] =
@@ -25,10 +27,11 @@ class WeakReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T]) extends Re
 }
 
 /** An extractor for weak reference values */
+@deprecated("Use `java.lang.ref.WeakReference` instead.", since = "2.13.0")
 object WeakReference {
 
   /** Creates a weak reference pointing to `value` */
-  def apply[T <: AnyRef](value: T) = new WeakReference(value)
+  def apply[T <: AnyRef](value: T): WeakReference[T] = new WeakReference(value)
 
   /** Optionally returns the referenced value, or `None` if that value no longer exists */
   def unapply[T <: AnyRef](wr: WeakReference[T]): Option[T] = Option(wr.underlying.get)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -14,10 +14,10 @@ package scala
 package reflect
 package internal
 
+import java.lang.ref.WeakReference
 import java.util.Objects
 
 import scala.collection.{immutable, mutable}
-import scala.ref.WeakReference
 import mutable.ListBuffer
 import Flags._
 import scala.util.control.ControlThrowable
@@ -1615,9 +1615,11 @@ trait Types
 
       intersectionWitness get parents match {
         case Some(ref) =>
-          ref.get match {
-            case Some(w) => if (w eq this) op1 else op2(w)
-            case None => updateCache()
+          val w = ref.get
+          if (w ne null) {
+            if (w eq this) op1 else op2(w)
+          } else {
+            updateCache()
           }
         case None => updateCache()
       }

--- a/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
@@ -15,8 +15,7 @@ package reflect
 package runtime
 
 import scala.collection.mutable
-import java.lang.ref.{WeakReference => jWeakRef}
-import scala.ref.{WeakReference => sWeakRef}
+import java.lang.ref.WeakReference
 import scala.reflect.internal.Depth
 
 /** This trait overrides methods in reflect.internal, bracketing
@@ -30,7 +29,7 @@ private[reflect] trait SynchronizedTypes extends internal.Types { self: SymbolTa
   // we can keep this lock fine-grained, because super.unique just updates the cache
   // and, in particular, doesn't call any reflection APIs which makes deadlocks impossible
   private lazy val uniqueLock = new Object
-  private[this] val uniques = mutable.WeakHashMap[Type, jWeakRef[Type]]()
+  private[this] val uniques = mutable.WeakHashMap[Type, WeakReference[Type]]()
   override def unique[T <: Type](tp: T): T = uniqueLock.synchronized {
     // we need to have weak uniques for runtime reflection
     // because unlike the normal compiler universe, reflective universe isn't organized in runs
@@ -44,7 +43,7 @@ private[reflect] trait SynchronizedTypes extends internal.Types { self: SymbolTa
       val result = if (inCache.isDefined) inCache.get.get else null
       if (result ne null) result.asInstanceOf[T]
       else {
-        uniques(tp) = new jWeakRef(tp)
+        uniques(tp) = new WeakReference(tp)
         tp
       }
     } else {
@@ -59,7 +58,7 @@ private[reflect] trait SynchronizedTypes extends internal.Types { self: SymbolTa
   private lazy val _undoLog = mkThreadLocalStorage(new UndoLog)
   override def undoLog = _undoLog.get
 
-  private lazy val _intersectionWitness = mkThreadLocalStorage(perRunCaches.newWeakMap[List[Type], sWeakRef[Type]]())
+  private lazy val _intersectionWitness = mkThreadLocalStorage(perRunCaches.newWeakMap[List[Type], WeakReference[Type]]())
   override def intersectionWitness = _intersectionWitness.get
 
   private lazy val _subsametypeRecursions = mkThreadLocalStorage(0)

--- a/test/junit/scala/collection/immutable/ListTest.scala
+++ b/test/junit/scala/collection/immutable/ListTest.scala
@@ -1,11 +1,11 @@
 package scala.collection.immutable
 
+import java.lang.ref.WeakReference
+
 import org.junit.Assert.assertSame
 import org.junit.{Assert, Test}
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-
-import scala.ref.WeakReference
 
 @RunWith(classOf[JUnit4])
 class ListTest {
@@ -20,7 +20,7 @@ class ListTest {
 
     do {
       val list = List.fill(10000)(num)
-      val ref = WeakReference(list)
+      val ref = new WeakReference(list)
 
       val i = list.iterator
 
@@ -29,7 +29,7 @@ class ListTest {
       emptyIterators = (i, ref) +: emptyIterators
 
       num+=1
-    } while (emptyIterators.forall(_._2.get.isDefined) && num<1000)
+    } while (emptyIterators.forall(_._2.get ne null) && num<1000)
 
     // check something is result to protect from JIT optimizations
     for ((i, _) <- emptyIterators) {
@@ -38,14 +38,14 @@ class ListTest {
 
     // await gc up to ~5 seconds
     var forceLoops = 50
-    while (emptyIterators.forall(_._2.get.isDefined) && forceLoops>0) {
+    while (emptyIterators.forall(_._2.get ne null) && forceLoops>0) {
       System.gc()
       Thread.sleep(100)
       forceLoops -= 1
     }
 
     // real assertion
-    Assert.assertTrue(emptyIterators.exists(_._2.get.isEmpty))
+    Assert.assertTrue(emptyIterators.exists(_._2.get eq null))
   }
 
   @Test


### PR DESCRIPTION
I think we can live with `java.lang.ref`'s verbose.