### PR TITLE
Add `scala.Try` as alias of `scala.util.Try` to `scala` package.

### DIFF
--- a/src/compiler/scala/reflect/macros/compiler/DefaultMacroCompiler.scala
+++ b/src/compiler/scala/reflect/macros/compiler/DefaultMacroCompiler.scala
@@ -51,8 +51,8 @@ abstract class DefaultMacroCompiler extends Resolvers
    */
   def resolveMacroImpl: Tree = {
     def tryCompile(compiler: MacroImplRefCompiler): scala.util.Try[Tree] = {
-      try { compiler.validateMacroImplRef(); scala.util.Success(compiler.macroImplRef) }
-      catch { case ex: MacroImplResolutionException => scala.util.Failure(ex) }
+      try { compiler.validateMacroImplRef(); scala.Try.Success(compiler.macroImplRef) }
+      catch { case ex: MacroImplResolutionException => scala.Try.Failure(ex) }
     }
     val vanillaImplRef = MacroImplRefCompiler(macroDdef.rhs.duplicate, isImplBundle = false)
     val (maybeBundleRef, methName, targs) = macroDdef.rhs.duplicate match {

--- a/src/compiler/scala/tools/nsc/plugins/Plugin.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugin.scala
@@ -13,16 +13,11 @@
 package scala.tools.nsc
 package plugins
 
-import scala.tools.nsc.io.Jar
 import scala.reflect.internal.util.ScalaClassLoader
-import scala.reflect.io.{Directory, File, Path}
-import java.io.InputStream
-import java.net.URL
-
-import scala.collection.JavaConverters._
+import scala.reflect.io.{File, Path}
 import scala.collection.mutable
 import scala.tools.nsc.classpath.FileBasedCache
-import scala.util.{Failure, Success, Try}
+import scala.Try.{Failure, Success}
 
 /** Information about a plugin loaded from a jar file.
  *

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -17,7 +17,7 @@ import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.util.control.{NonFatal, NoStackTrace}
-import scala.util.{Failure, Success, Try}
+import scala.Try.{Failure, Success}
 import scala.concurrent.duration._
 import scala.collection.BuildFrom
 import scala.collection.mutable.{Builder, ArrayBuffer}

--- a/src/library/scala/concurrent/Promise.scala
+++ b/src/library/scala/concurrent/Promise.scala
@@ -12,7 +12,7 @@
 
 package scala.concurrent
 
-import scala.util.{ Try, Success, Failure }
+import scala.Try.{Failure, Success}
 
 /** Promise is an object which can be completed with a value or failed
  *  with an exception.

--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -16,7 +16,7 @@ import Future.InternalCallbackExecutor
 import scala.concurrent.duration.Duration
 import scala.annotation.{ tailrec, switch }
 import scala.util.control.{ NonFatal, ControlThrowable }
-import scala.util.{ Try, Success, Failure }
+import scala.Try.{Failure, Success}
 import scala.runtime.NonLocalReturnControl
 import java.util.concurrent.locks.AbstractQueuedSynchronizer
 import java.util.concurrent.atomic.AtomicReference

--- a/src/library/scala/package.scala
+++ b/src/library/scala/package.scala
@@ -143,4 +143,6 @@ package object scala {
   type Right[+A, +B] = scala.util.Right[A, B]
   val Right = scala.util.Right
 
+  type Try[+T] = scala.util.Try[T]
+  val Try = scala.util.Try
 }

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -51,10 +51,10 @@ package util
  *
  *  Since `Either` defines the methods `map` and `flatMap`, it can also be used in for comprehensions:
  *  {{{
- *  val right1 = Right(1)   : Right[Double, Int] 
+ *  val right1 = Right(1)   : Right[Double, Int]
  *  val right2 = Right(2)
  *  val right3 = Right(3)
- *  val left23 = Left(23.0) : Left[Double, Int]  
+ *  val left23 = Left(23.0) : Left[Double, Int]
  *  val left42 = Left(42.0)
  *
  *  for {
@@ -370,7 +370,7 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
     * rl.flatten //Either[String, Int]: Left("flounder")
     * rr.flatten //Either[String, Int]: Right(7)
     * }}}
-    * 
+    *
     * Equivalent to `flatMap(id => id)`
     */
   def flatten[A1 >: A, B1](implicit ev: B <:< Either[A1, B1]): Either[A1, B1] = flatMap(ev)
@@ -430,8 +430,8 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
   }
 
   def toTry(implicit ev: A <:< Throwable): Try[B] = this match {
-    case Right(b) => Success(b)
-    case Left(a)  => Failure(a)
+    case Right(b) => Try.Success(b)
+    case Left(a)  => Try.Failure(a)
   }
 
   /** Returns `true` if this is a `Left`, `false` otherwise.
@@ -653,7 +653,7 @@ object Either {
       case x @ Left(a) if p(a) => Some(x.asInstanceOf[Either[A, B1]])
       case _                   => None
     }
-    
+
     /** Returns a `Seq` containing the `Left` value if it exists or an empty
      *  `Seq` if this is a `Right`.
      *
@@ -797,7 +797,7 @@ object Either {
       case Right(b) if p(b) => Some(Right(b))
       case _                => None
     }
-    
+
     /** Returns `None` if this is a `Left` or if the
      *  given predicate `p` does not hold for the right value,
      *  otherwise, returns a `Right`.
@@ -812,7 +812,7 @@ object Either {
       case r @ Right(b) if p(b) => Some(r.asInstanceOf[Either[A1, B]])
       case _                    => None
     }
-    
+
     /** Returns a `Seq` containing the `Right` value if
      *  it exists or an empty `Seq` if this is a `Left`.
      *

--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -20,7 +20,7 @@ import scala.util.control.NonFatal
  * The `Try` type represents a computation that may either result in an exception, or return a
  * successfully computed value. It's similar to, but semantically different from the [[scala.util.Either]] type.
  *
- * Instances of `Try[T]`, are either an instance of [[scala.util.Success]][T] or [[scala.util.Failure]][T].
+ * Instances of `Try[T]`, are either an instance of [[scala.util.Try.Success]][T] or [[scala.util.Try.Failure]][T].
  *
  * For example, `Try` can be used to perform division on a user-defined input, without the need to do explicit
  * exception-handling in all of the places that an exception might occur.
@@ -28,7 +28,7 @@ import scala.util.control.NonFatal
  * Example:
  * {{{
  *   import scala.io.StdIn
- *   import scala.util.{Try, Success, Failure}
+ *   import scala.Try.{Success, Failure}
  *
  *   def divide: Try[Int] = {
  *     val dividend = Try(StdIn.readLine("Enter an Int that you'd like to divide:\n").toInt)
@@ -61,6 +61,7 @@ import scala.util.control.NonFatal
  *
  * `Try` comes to the Scala standard library after years of use as an integral part of Twitter's stack.
  *
+ * @tparam T Type of the expected result value type.
  * @author based on Twitter's original implementation in com.twitter.util.
  * @since 2.10
  */
@@ -214,6 +215,11 @@ object Try {
       case NonFatal(e) => Failure(e)
     }
 
+  /**
+   * Class `Failure[+T]` represent a computation of `T` is failed with a [[Throwable]].
+   *
+   * @tparam T Type of the expected result value type.
+   */
   final case class Failure[+T](exception: Throwable) extends Try[T] {
     override def isFailure: Boolean = true
     override def isSuccess: Boolean = false
@@ -249,7 +255,11 @@ object Try {
     override def fold[U](fa: Throwable => U, fb: T => U): U = fa(exception)
   }
 
-
+  /**
+   * Class `Success[+T]` represent a computation of `T` is succeeded with a value of `T`.
+   *
+   * @tparam T Type of the expected result value type.
+   */
   final case class Success[+T](value: T) extends Try[T] {
     override def isFailure: Boolean = false
     override def isSuccess: Boolean = true

--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -213,73 +213,73 @@ object Try {
     try Success(r) catch {
       case NonFatal(e) => Failure(e)
     }
-}
 
-final case class Failure[+T](exception: Throwable) extends Try[T] {
-  override def isFailure: Boolean = true
-  override def isSuccess: Boolean = false
-  override def get: T = throw exception
-  override def getOrElse[U >: T](default: => U): U = default
-  override def orElse[U >: T](default: => Try[U]): Try[U] =
-    try default catch { case NonFatal(e) => Failure(e) }
-  override def flatMap[U](f: T => Try[U]): Try[U] = this.asInstanceOf[Try[U]]
-  override def flatten[U](implicit ev: T <:< Try[U]): Try[U] = this.asInstanceOf[Try[U]]
-  override def foreach[U](f: T => U): Unit = ()
-  override def transform[U](s: T => Try[U], f: Throwable => Try[U]): Try[U] =
-    try f(exception) catch { case NonFatal(e) => Failure(e) }
-  override def map[U](f: T => U): Try[U] = this.asInstanceOf[Try[U]]
-  override def collect[U](pf: PartialFunction[T, U]): Try[U] = this.asInstanceOf[Try[U]]
-  override def filter(p: T => Boolean): Try[T] = this
-  override def recover[U >: T](pf: PartialFunction[Throwable, U]): Try[U] = {
-    val marker = Statics.pfMarker
-    try {
-      val v = pf.applyOrElse(exception, (x: Throwable) => marker)
-      if (marker ne v.asInstanceOf[AnyRef]) Success(v.asInstanceOf[U]) else this
-    } catch { case NonFatal(e) => Failure(e) }
+  final case class Failure[+T](exception: Throwable) extends Try[T] {
+    override def isFailure: Boolean = true
+    override def isSuccess: Boolean = false
+    override def get: T = throw exception
+    override def getOrElse[U >: T](default: => U): U = default
+    override def orElse[U >: T](default: => Try[U]): Try[U] =
+      try default catch { case NonFatal(e) => Failure(e) }
+    override def flatMap[U](f: T => Try[U]): Try[U] = this.asInstanceOf[Try[U]]
+    override def flatten[U](implicit ev: T <:< Try[U]): Try[U] = this.asInstanceOf[Try[U]]
+    override def foreach[U](f: T => U): Unit = ()
+    override def transform[U](s: T => Try[U], f: Throwable => Try[U]): Try[U] =
+      try f(exception) catch { case NonFatal(e) => Failure(e) }
+    override def map[U](f: T => U): Try[U] = this.asInstanceOf[Try[U]]
+    override def collect[U](pf: PartialFunction[T, U]): Try[U] = this.asInstanceOf[Try[U]]
+    override def filter(p: T => Boolean): Try[T] = this
+    override def recover[U >: T](pf: PartialFunction[Throwable, U]): Try[U] = {
+      val marker = Statics.pfMarker
+      try {
+        val v = pf.applyOrElse(exception, (x: Throwable) => marker)
+        if (marker ne v.asInstanceOf[AnyRef]) Success(v.asInstanceOf[U]) else this
+      } catch { case NonFatal(e) => Failure(e) }
+    }
+    override def recoverWith[U >: T](pf: PartialFunction[Throwable, Try[U]]): Try[U] = {
+      val marker = Statics.pfMarker
+      try {
+        val v = pf.applyOrElse(exception, (x: Throwable) => marker)
+        if (marker ne v.asInstanceOf[AnyRef]) v.asInstanceOf[Try[U]] else this
+      } catch { case NonFatal(e) => Failure(e) }
+    }
+    override def failed: Try[Throwable] = Success(exception)
+    override def toOption: Option[T] = None
+    override def toEither: Either[Throwable, T] = Left(exception)
+    override def fold[U](fa: Throwable => U, fb: T => U): U = fa(exception)
   }
-  override def recoverWith[U >: T](pf: PartialFunction[Throwable, Try[U]]): Try[U] = {
-    val marker = Statics.pfMarker
-    try {
-      val v = pf.applyOrElse(exception, (x: Throwable) => marker)
-      if (marker ne v.asInstanceOf[AnyRef]) v.asInstanceOf[Try[U]] else this
-    } catch { case NonFatal(e) => Failure(e) }
-  }
-  override def failed: Try[Throwable] = Success(exception)
-  override def toOption: Option[T] = None
-  override def toEither: Either[Throwable, T] = Left(exception)
-  override def fold[U](fa: Throwable => U, fb: T => U): U = fa(exception)
-}
 
 
-final case class Success[+T](value: T) extends Try[T] {
-  override def isFailure: Boolean = false
-  override def isSuccess: Boolean = true
-  override def get = value
-  override def getOrElse[U >: T](default: => U): U = get
-  override def orElse[U >: T](default: => Try[U]): Try[U] = this
-  override def flatMap[U](f: T => Try[U]): Try[U] =
-    try f(value) catch { case NonFatal(e) => Failure(e) }
-  override def flatten[U](implicit ev: T <:< Try[U]): Try[U] = value
-  override def foreach[U](f: T => U): Unit = f(value)
-  override def transform[U](s: T => Try[U], f: Throwable => Try[U]): Try[U] = this flatMap s
-  override def map[U](f: T => U): Try[U] = Try[U](f(value))
-  override def collect[U](pf: PartialFunction[T, U]): Try[U] = {
-    val marker = Statics.pfMarker
-    try {
-      val v = pf.applyOrElse(value, ((x: T) => marker).asInstanceOf[Function[T, U]])
-      if (marker ne v.asInstanceOf[AnyRef]) Success(v)
-      else Failure(new NoSuchElementException("Predicate does not hold for " + value))
-    } catch { case NonFatal(e) => Failure(e) }
+  final case class Success[+T](value: T) extends Try[T] {
+    override def isFailure: Boolean = false
+    override def isSuccess: Boolean = true
+    override def get: T = value
+    override def getOrElse[U >: T](default: => U): U = get
+    override def orElse[U >: T](default: => Try[U]): Try[U] = this
+    override def flatMap[U](f: T => Try[U]): Try[U] =
+      try f(value) catch { case NonFatal(e) => Failure(e) }
+    override def flatten[U](implicit ev: T <:< Try[U]): Try[U] = value
+    override def foreach[U](f: T => U): Unit = f(value)
+    override def transform[U](s: T => Try[U], f: Throwable => Try[U]): Try[U] = this flatMap s
+    override def map[U](f: T => U): Try[U] = Try[U](f(value))
+    override def collect[U](pf: PartialFunction[T, U]): Try[U] = {
+      val marker = Statics.pfMarker
+      try {
+        val v = pf.applyOrElse(value, ((x: T) => marker).asInstanceOf[Function[T, U]])
+        if (marker ne v.asInstanceOf[AnyRef]) Success(v)
+        else Failure(new NoSuchElementException("Predicate does not hold for " + value))
+      } catch { case NonFatal(e) => Failure(e) }
+    }
+    override def filter(p: T => Boolean): Try[T] =
+      try {
+        if (p(value)) this else Failure(new NoSuchElementException("Predicate does not hold for " + value))
+      } catch { case NonFatal(e) => Failure(e) }
+    override def recover[U >: T](pf: PartialFunction[Throwable, U]): Try[U] = this
+    override def recoverWith[U >: T](pf: PartialFunction[Throwable, Try[U]]): Try[U] = this
+    override def failed: Try[Throwable] = Failure(new UnsupportedOperationException("Success.failed"))
+    override def toOption: Option[T] = Some(value)
+    override def toEither: Either[Throwable, T] = Right(value)
+    override def fold[U](fa: Throwable => U, fb: T => U): U =
+      try { fb(value) } catch { case NonFatal(e) => fa(e) }
   }
-  override def filter(p: T => Boolean): Try[T] =
-    try {
-      if (p(value)) this else Failure(new NoSuchElementException("Predicate does not hold for " + value))
-    } catch { case NonFatal(e) => Failure(e) }
-  override def recover[U >: T](pf: PartialFunction[Throwable, U]): Try[U] = this
-  override def recoverWith[U >: T](pf: PartialFunction[Throwable, Try[U]]): Try[U] = this
-  override def failed: Try[Throwable] = Failure(new UnsupportedOperationException("Success.failed"))
-  override def toOption: Option[T] = Some(value)
-  override def toEither: Either[Throwable, T] = Right(value)
-  override def fold[U](fa: Throwable => U, fb: T => U): U =
-    try { fb(value) } catch { case NonFatal(e) => fa(e) }
 }

--- a/src/library/scala/util/control/Exception.scala
+++ b/src/library/scala/util/control/Exception.scala
@@ -254,7 +254,7 @@ object Exception {
     /** Apply this catch logic to the supplied body, mapping the result
      * into `Try[T]` - `Failure` if an exception was caught, `Success(T)` otherwise.
      */
-    def withTry[U >: T](body: => U): scala.util.Try[U] = toTry(Success(body))
+    def withTry[U >: T](body: => U): scala.util.Try[U] = toTry(Try.Success(body))
 
     /** Create a `Catch` object with the same `isDefinedAt` logic as this one,
       * but with the supplied `apply` method replacing the current one. */
@@ -269,7 +269,7 @@ object Exception {
     /** Convenience methods. */
     def toOption: Catch[Option[T]] = withApply(_ => None)
     def toEither: Catch[Either[Throwable, T]] = withApply(Left(_))
-    def toTry: Catch[scala.util.Try[T]] = withApply(x => Failure(x))
+    def toTry: Catch[scala.util.Try[T]] = withApply(x => Try.Failure(x))
   }
 
   final val nothingCatcher: Catcher[Nothing]  = mkThrowableCatcher(_ => false, throw _)

--- a/src/library/scala/util/package.scala
+++ b/src/library/scala/util/package.scala
@@ -17,4 +17,14 @@ package object util {
    * Adds chaining methods `tap` and `pipe` to every type. See [[ChainingOps]].
    */
   object chaining extends ChainingSyntax
+
+  @deprecated("Use `Try.Failure` instead.", since = "2.13.0")
+  type Failure[+T] = scala.util.Try.Failure[T]
+  @deprecated("Use `Try.Failure` instead.", since = "2.13.0")
+  val Failure = scala.util.Try.Failure
+
+  @deprecated("Use `Try.Success` instead.", since = "2.13.0")
+  type Success[+T] = scala.util.Try.Success[T]
+  @deprecated("Use `Try.Success` instead.", since = "2.13.0")
+  val Success = scala.util.Try.Success
 }

--- a/src/partest/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AbstractRunner.scala
@@ -18,7 +18,7 @@ import utils.Properties._
 import scala.tools.nsc.Properties.{propOrFalse, setProp, versionMsg}
 import scala.collection.mutable
 import scala.reflect.internal.util.Collections.distinctBy
-import scala.util.{Try, Success, Failure}
+import scala.Try.{Failure, Success}
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.NANOSECONDS
@@ -86,7 +86,7 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
           bold(cyan(s"##### Log file '${info.logFile}' from failed test #####\n")),
           info.logFile.fileContents
         ) else Nil
-      val diffed = 
+      val diffed =
         if (diffOnFail) {
           val differ = bold(red("% ")) + "diff "
           state.transcript.find(_ startsWith differ) match {

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/JavapClass.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/JavapClass.scala
@@ -26,7 +26,7 @@ import scala.language.reflectiveCalls
 import scala.reflect.internal.util.ScalaClassLoader
 import scala.reflect.io.File
 import scala.util.Properties.{lineSeparator => EOL}
-import scala.util.{Failure, Success, Try}
+import scala.Try.{Failure, Success}
 import Javap._
 import scala.tools.nsc.interpreter.Repl
 

--- a/src/scalacheck/org/scalacheck/Arbitrary.scala
+++ b/src/scalacheck/org/scalacheck/Arbitrary.scala
@@ -11,7 +11,7 @@ package org.scalacheck
 
 import language.higherKinds
 import concurrent.Future
-import scala.util.{Failure, Success, Try}
+import scala.Try.{Failure, Success}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
 import util.Buildable

--- a/src/scalacheck/org/scalacheck/Cogen.scala
+++ b/src/scalacheck/org/scalacheck/Cogen.scala
@@ -12,7 +12,7 @@ package org.scalacheck
 import language.higherKinds
 import scala.annotation.tailrec
 import scala.collection.immutable.BitSet
-import scala.util.{Failure, Success, Try}
+import scala.Try.{Failure, Success}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import java.math.BigInteger
 import rng.Seed

--- a/src/scalacheck/org/scalacheck/commands/Commands.scala
+++ b/src/scalacheck/org/scalacheck/commands/Commands.scala
@@ -10,7 +10,7 @@
 package org.scalacheck.commands
 
 import org.scalacheck._
-import scala.util.{Try, Success, Failure}
+import scala.Try.{Failure, Success}
 
 /** An API for stateful testing in ScalaCheck.
  *

--- a/test/benchmarks/src/main/scala/scala/concurrent/FutureBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/concurrent/FutureBenchmark.scala
@@ -4,7 +4,7 @@ import scala.concurrent.duration._
 import java.util.concurrent.{ TimeUnit, Executor, Executors, ExecutorService, ForkJoinPool, CountDownLatch }
 import org.openjdk.jmh.infra.Blackhole
 import org.openjdk.jmh.annotations._
-import scala.util.{ Try, Success, Failure }
+import scala.Try.{Failure, Success}
 import scala.annotation.tailrec
 
 @State(Scope.Benchmark)
@@ -243,7 +243,7 @@ class ZipWithFutureBenchmark extends OpFutureBenchmark {
 
 class AndThenFutureBenchmark extends OpFutureBenchmark {
   private[this] final val effect: PartialFunction[Try[Result], Unit] = { case t: Try[Result] => () }
-  
+
   @tailrec private[this] final def next(i: Int, f: Future[Result])(implicit ec: ExecutionContext): Future[Result] =
       if (i > 0) { next(i - 1, f.andThen(effect)) } else { f }
 

--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -3,7 +3,7 @@ import scala.concurrent.duration._
 import scala.concurrent.duration.Duration.Inf
 import scala.collection._
 import scala.runtime.NonLocalReturnControl
-import scala.util.{Try,Success,Failure}
+import scala.Try.{Failure, Success}
 
 
 

--- a/test/files/jvm/future-spec/PromiseTests.scala
+++ b/test/files/jvm/future-spec/PromiseTests.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration._
 import scala.concurrent.duration.Duration.Inf
 import scala.collection._
 import scala.runtime.NonLocalReturnControl
-import scala.util.{Try,Success,Failure}
+import scala.Try.{Failure, Success}
 
 
 class PromiseTests extends MinimalScalaTest {

--- a/test/files/jvm/future-spec/TryTests.scala
+++ b/test/files/jvm/future-spec/TryTests.scala
@@ -3,7 +3,7 @@
 // It lives in the future-spec directory simply because it requires a specs-like
 // DSL which has already been minimally implemented for the future spec tests.
 
-import scala.util.{Try,Success,Failure}
+import scala.Try.{Failure, Success}
 
 class TryTests extends MinimalScalaTest {
   class MyException extends Exception

--- a/test/files/jvm/scala-concurrent-tck.scala
+++ b/test/files/jvm/scala-concurrent-tck.scala
@@ -8,7 +8,7 @@ import scala.concurrent.{
   Await,
   blocking
 }
-import scala.util.{ Try, Success, Failure }
+import scala.Try.{Failure, Success}
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration._
 import scala.reflect.{ classTag, ClassTag }
@@ -225,7 +225,7 @@ def testTransformFailure(): Unit = once {
   }
 
   def testTransformResultToFailure(): Unit = once {
-    done => 
+    done =>
       val e = new Exception("expected")
       Future("foo").transform {
         case Success(s) => Failure(e)
@@ -272,7 +272,7 @@ def testTransformFailure(): Unit = once {
   }
 
   def testTransformWithResultToFailure(): Unit = once {
-    done => 
+    done =>
       val e = new Exception("expected")
       Future("foo").transformWith {
         case Success(s) => Future(throw e)
@@ -848,7 +848,7 @@ class Exceptions extends TestBase {
 
 class GlobalExecutionContext extends TestBase {
   import ExecutionContext.Implicits._
-  
+
   def testNameOfGlobalECThreads(): Unit = once {
     done => Future({
         val expectedName = "scala-execution-context-global-"+ Thread.currentThread.getId

--- a/test/files/jvm/try-type-tests.scala
+++ b/test/files/jvm/try-type-tests.scala
@@ -1,4 +1,4 @@
-import scala.util.{Try, Success, Failure}
+import scala.Try.{Failure, Success}
 
 // tests the basic combinators on Try
 trait TryStandard {

--- a/test/files/neg/logImplicits.check
+++ b/test/files/neg/logImplicits.check
@@ -7,10 +7,10 @@ logImplicits.scala:9: applied implicit conversion from String("abc") to ?{def ma
 logImplicits.scala:17: inferred view from String("abc") to Int via C.this.convert: (p: "abc")Int
   math.max(122, x: Int)
                 ^
-logImplicits.scala:21: applied implicit conversion from Int(1) to ?{def ->: ?} = final implicit def ArrowAssoc[A](self: A): ArrowAssoc[A]
+logImplicits.scala:21: applied implicit conversion from Int(1) to ?{def ->: ?} = implicit def ArrowAssoc[A](self: A): ArrowAssoc[A]
   def f = (1 -> 2) + "c"
            ^
-logImplicits.scala:21: applied implicit conversion from (Int, Int) to ?{def +: ?} = final implicit def any2stringadd[A](self: A): any2stringadd[A]
+logImplicits.scala:21: applied implicit conversion from (Int, Int) to ?{def +: ?} = implicit def any2stringadd[A](self: A): any2stringadd[A]
   def f = (1 -> 2) + "c"
              ^
 logImplicits.scala:24: error: class Un needs to be abstract, since method unimplemented is not defined

--- a/test/files/neg/logImplicits.check
+++ b/test/files/neg/logImplicits.check
@@ -7,10 +7,10 @@ logImplicits.scala:9: applied implicit conversion from String("abc") to ?{def ma
 logImplicits.scala:17: inferred view from String("abc") to Int via C.this.convert: (p: "abc")Int
   math.max(122, x: Int)
                 ^
-logImplicits.scala:21: applied implicit conversion from Int(1) to ?{def ->: ?} = implicit def ArrowAssoc[A](self: A): ArrowAssoc[A]
+logImplicits.scala:21: applied implicit conversion from Int(1) to ?{def ->: ?} = final implicit def ArrowAssoc[A](self: A): ArrowAssoc[A]
   def f = (1 -> 2) + "c"
            ^
-logImplicits.scala:21: applied implicit conversion from (Int, Int) to ?{def +: ?} = implicit def any2stringadd[A](self: A): any2stringadd[A]
+logImplicits.scala:21: applied implicit conversion from (Int, Int) to ?{def +: ?} = final implicit def any2stringadd[A](self: A): any2stringadd[A]
   def f = (1 -> 2) + "c"
              ^
 logImplicits.scala:24: error: class Un needs to be abstract, since method unimplemented is not defined

--- a/test/files/run/t6188.scala
+++ b/test/files/run/t6188.scala
@@ -2,7 +2,7 @@
 //
 // scala/bug#6188 Optimizer incorrectly removes method invocations containing throw expressions
 
-import scala.util.Success
+import scala.Try.Success
 
 object Test {
  def main(args: Array[String]): Unit = {

--- a/test/files/run/t9174.check
+++ b/test/files/run/t9174.check
@@ -12,6 +12,7 @@ scala> def f3(b: Boolean) = if (b) LazyList.empty else LazyList.cons(1, LazyList
 f3: (b: Boolean)scala.collection.immutable.LazyList[Int]
 
 scala> def f4(b: Boolean) = if (b) Success(1) else Failure(new Exception(""))
+warning: there were two deprecation warnings (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 f4: (b: Boolean)scala.util.Try[Int]
 
 scala> :quit

--- a/test/junit/scala/collection/immutable/RangeConsistencyTest.scala
+++ b/test/junit/scala/collection/immutable/RangeConsistencyTest.scala
@@ -15,20 +15,20 @@ class RangeConsistencyTest {
     val num = implicitly[Integral[T]]
     import num._
     val one = num.one
-    
+
     if (!check(puff, fromInt(r.start))) return Nil
     val start = puff * fromInt(r.start)
     val sp1 = start + one
     val sn1 = start - one
-      
+
     if (!check(puff, fromInt(r.end))) return Nil
     val end = puff * fromInt(r.end)
     val ep1 = end + one
     val en1 = end - one
-    
+
     if (!check(stride, fromInt(r.step))) return Nil
     val step = stride * fromInt(r.step)
-    
+
     def NR(s: T, e: T, i: T) = {
       val delta = (bi(e) - bi(s)).abs - (if (r.isInclusive) 0 else 1)
       val n = if (r.length == 0) BigInt(0) else delta / bi(i).abs + 1
@@ -38,15 +38,15 @@ class RangeConsistencyTest {
       else {
         (n, Try(NumericRange(s,e,i).length))
       }
-    } 
-    
+    }
+
     List(NR(start, end, step)) :::
     (if (sn1 < start) List(NR(sn1, end, step)) else Nil) :::
     (if (start < sp1) List(NR(sp1, end, step)) else Nil) :::
     (if (en1 < end) List(NR(start, en1, step)) else Nil) :::
     (if (end < ep1) List(NR(start, ep1, step)) else Nil)
   }
-  
+
   // Motivated by scala/bug#4370: Wrong result for Long.MinValue to Long.MaxValue by Int.MaxValue
   @Test
   def rangeChurnTest(): Unit = {
@@ -61,10 +61,10 @@ class RangeConsistencyTest {
         case 3 => var x = rn.nextInt; while (x==0) x = rn.nextInt; x
       }
       val r = if (rn.nextBoolean) Range.inclusive(start, end, step) else Range(start, end, step)
-      
+
       try { r.length }
       catch { case iae: IllegalArgumentException => control.Breaks.break }
-      
+
       val lpuff = rn.nextInt(4) match {
         case 0 => 1L
         case 1 => rn.nextInt(11)+2L
@@ -78,19 +78,19 @@ class RangeConsistencyTest {
         case 3 => math.max(1L, math.abs(rn.nextLong))
       }
       val lr = r2nr[Long](
-        r, lpuff, lstride, 
+        r, lpuff, lstride,
         (a,b) => { val x = BigInt(a)*BigInt(b); x.isValidLong },
         x => BigInt(x)
       )
-      
+
       lr.foreach{ case (n,t) => assert(
         t match {
-          case Failure(_) => n > Int.MaxValue
-          case Success(m) => n == m
+          case scala.Try.Failure(_) => n > Int.MaxValue
+          case scala.Try.Success(m) => n == m
         },
         (r.start, r.end, r.step, r.isInclusive, lpuff, lstride, n, t)
       )}
-      
+
       val bipuff = rn.nextInt(3) match {
         case 0 => BigInt(1)
         case 1 => BigInt(rn.nextLong) + Long.MaxValue + 2
@@ -102,25 +102,25 @@ class RangeConsistencyTest {
         case 2 => BigInt("1" + "0"*(rn.nextInt(100)+1))
       }
       val bir = r2nr[BigInt](r, bipuff, bistride, (a,b) => true, identity)
-      
+
       bir.foreach{ case (n,t) => assert(
         t match {
-          case Failure(_) => n > Int.MaxValue
-          case Success(m) => n == m
+          case scala.Try.Failure(_) => n > Int.MaxValue
+          case scala.Try.Success(m) => n == m
         },
         (r.start, r.end, r.step, r.isInclusive, bipuff, bistride, n, t)
-      )}              
+      )}
     }}
   }
-  
+
   @Test
   def testSI4370(): Unit = { assert{
     Try((Long.MinValue to Long.MaxValue by Int.MaxValue).length) match {
-      case Failure(iae: IllegalArgumentException) => true
+      case scala.Try.Failure(iae: IllegalArgumentException) => true
       case _ => false
     }
   }}
-  
+
   @Test
   def testSI6736(): Unit = {
     // These operations on overfull ranges should all succeed.

--- a/test/junit/scala/concurrent/impl/DefaultPromiseTest.scala
+++ b/test/junit/scala/concurrent/impl/DefaultPromiseTest.scala
@@ -1,15 +1,16 @@
 package scala.concurrent.impl
 
-import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.CountDownLatch
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch}
+
 import org.junit.Assert._
-import org.junit.{ After, Before, Test }
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+
+import scala.Try.{Failure, Success}
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import scala.concurrent.impl.Promise.DefaultPromise
-import scala.util.{ Failure, Success, Try }
 import scala.util.control.NonFatal
 
 /** Tests for the private class DefaultPromise */

--- a/test/junit/scala/tools/nsc/util/StackTraceTest.scala
+++ b/test/junit/scala/tools/nsc/util/StackTraceTest.scala
@@ -2,11 +2,8 @@
 package scala.tools.nsc.util
 
 import scala.language.reflectiveCalls
-import scala.util._
-import PartialFunction.cond
-import Properties.isJavaAtLeast
+import scala.util.Properties.isJavaAtLeast
 
-import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -65,8 +62,8 @@ class StackTraceTest extends Expecting {
   // evaluating s should throw, p trims stack trace, t is the test of resulting trace string
   def probe(s: =>String)(p: StackTraceElement => Boolean)(t: String => Unit): Unit = {
     Try(s) recover { case e => e stackTracePrefixString p } match {
-      case Success(s) => t(s)
-      case Failure(e) => throw e
+      case Try.Success(s) => t(s)
+      case Try.Failure(e) => throw e
     }
   }
 

--- a/test/junit/scala/util/TryTest.scala
+++ b/test/junit/scala/util/TryTest.scala
@@ -17,13 +17,13 @@ class TryTest {
   @Test
   def withFilterSuccess(): Unit = {
     val success1 = for (x <- util.Try(1) if x >= 1) yield x
-    assertEquals(success1, util.Success(1))
+    assertEquals(success1, Try.Success(1))
   }
 
   @Test
   def withFilterFlatMap(): Unit = {
     val successFlatMap = for (x <- util.Try(1) if x >= 1; y <- util.Try(2) if x < y) yield x
-    assertEquals(successFlatMap, util.Success(1))
+    assertEquals(successFlatMap, Try.Success(1))
   }
 
   @Test

--- a/test/junit/scala/util/UsingTest.scala
+++ b/test/junit/scala/util/UsingTest.scala
@@ -230,7 +230,7 @@ class UsingTest {
 
   @Test
   def safeUsingMultipleResourcesPropagatesCorrectlySimple(): Unit = {
-    val scala.util.Failure(usingException) = for {
+    val scala.Try.Failure(usingException) = for {
       _ <- Using(new ExceptionResource)
       _ <- Using(new ErrorResource)
     } yield {
@@ -300,7 +300,7 @@ class UsingTest {
     val res = Using(new NoOpResource) { r =>
       r.identity("test")
     }
-    assertEquals(res, scala.util.Success("test"))
+    assertEquals(res, scala.Try.Success("test"))
   }
 
   /* using multiple resources close in the correct order */
@@ -358,7 +358,7 @@ class UsingTest {
     } yield {
       r1.identity(1) + r2.identity(1)
     }
-    assertEquals(res, scala.util.Success(2))
+    assertEquals(res, scala.Try.Success(2))
   }
 
   @Test
@@ -373,7 +373,7 @@ class UsingTest {
         r2.identity(1) +
         r3.identity(1)
     }
-    assertEquals(res, scala.util.Success(3))
+    assertEquals(res, scala.Try.Success(3))
   }
 
   /* misc */

--- a/test/scalacheck/CheckEither.scala
+++ b/test/scalacheck/CheckEither.scala
@@ -185,8 +185,8 @@ object CheckEitherTest extends Properties("Either") {
   }))
 
   val prop_try = forAll((e: Either[Throwable, Int]) => e.toTry == (e match {
-    case Left(a)  => util.Failure(a)
-    case Right(b) => util.Success(b)
+    case Left(a)  => Try.Failure(a)
+    case Right(b) => Try.Success(b)
   }))
 
   /** Hard to believe I'm "fixing" a test to reflect B before A ... */
@@ -226,7 +226,7 @@ object CheckEitherTest extends Properties("Either") {
       ("prop_Either_right", prop_Either_right),
       ("prop_Either_joinLeft", prop_Either_joinLeft),
       ("prop_Either_joinRight", prop_Either_joinRight),
-      ("prop_Either_reduce", prop_Either_reduce),      
+      ("prop_Either_reduce", prop_Either_reduce),
       ("prop_getOrElse", prop_getOrElse),
       ("prop_orElse", prop_orElse),
       ("prop_contains", prop_contains),

--- a/test/scalacheck/scala/collection/immutable/MapProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/MapProperties.scala
@@ -9,7 +9,6 @@ import org.scalacheck.Gen
 import org.scalacheck.commands.Commands
 
 import scala.collection.mutable
-import scala.util.{Success, Try}
 
 object MapProperties extends Properties("immutable.Map builder implementations"){
 
@@ -89,7 +88,7 @@ class MapBuilderStateProperties[K, V, ControlMap <: Map[K, V], M <: Map[K, V]](
   }
   case object Result extends Command {
     override type Result = M
-    override def postCondition(state: ControlMap, result: Try[Result]) = result == Success(state)
+    override def postCondition(state: ControlMap, result: Try[Result]) = result == Try.Success(state)
     override def run(sut: mutable.Builder[(K, V), M]) = sut.result()
     override def nextState(state: ControlMap) = state
     override def preCondition(state: ControlMap) = true

--- a/test/scalacheck/scala/collection/immutable/SeqProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/SeqProperties.scala
@@ -7,7 +7,6 @@ import org.scalacheck.Gen
 import org.scalacheck.commands.Commands
 
 import scala.collection.mutable
-import scala.util.{Success, Try}
 import org.scalacheck.Properties
 
 
@@ -73,7 +72,7 @@ class SeqBuilderStateProperties[A: Arbitrary, To <: Seq[A]](newBuilder: => mutab
   }
   case object Result extends Command {
     override type Result = State
-    override def postCondition(state: State, result: Try[Result]) = result.map(_.toVector) == Success(state.toVector)
+    override def postCondition(state: State, result: Try[Result]) = result.map(_.toVector) == Try.Success(state.toVector)
     override def run(sut: Sut) = sut.result().toVector
     override def nextState(state: State) = state
     override def preCondition(state: State) = true

--- a/test/scalacheck/scala/collection/immutable/SetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/SetProperties.scala
@@ -5,8 +5,6 @@ import org.scalacheck.{Arbitrary, Gen, Properties, Shrink}
 import org.scalacheck.commands.Commands
 
 import scala.collection.mutable
-import scala.util.{Success, Try}
-
 
 object SetProperties extends Properties("immutable.Set builder implementations"){
 

--- a/test/scalacheck/scala/collection/immutable/SetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/SetProperties.scala
@@ -68,7 +68,7 @@ class SetBuilderStateProperties[A, To <: Set[A]](newBuilder: => mutable.Builder[
   }
   case object Result extends Command {
     override type Result = State
-    override def postCondition(state: State, result: Try[Result]) = result == Success(state)
+    override def postCondition(state: State, result: Try[Result]) = result == Try.Success(state)
     override def run(sut: Sut) = sut.result()
     override def nextState(state: State) = state
     override def preCondition(state: State) = true

--- a/test/scalacheck/scala/collection/mutable/BuilderProperties.scala
+++ b/test/scalacheck/scala/collection/mutable/BuilderProperties.scala
@@ -12,7 +12,6 @@ import org.scalacheck.Gen
 import org.scalacheck.commands.Commands
 
 import scala.collection.mutable
-import scala.util.{Success, Try}
 
 /** Generic stateful property testing for builders
   *
@@ -74,7 +73,7 @@ class SeqBuilderStateProperties[A: Arbitrary, To <: Seq[A]](newBuilder: => mutab
   }
   case object Result extends Command {
     override type Result = To
-    override def postCondition(state: State, result: Try[Result]) = result == Success(state.reverse)
+    override def postCondition(state: State, result: Try[Result]) = result == Try.Success(state.reverse)
     override def run(sut: Sut) = sut.result()
     override def nextState(state: State) = state
     override def preCondition(state: State) = true


### PR DESCRIPTION
These classes deserve to be top level. And could help if we want to move some classes in `scala.util` to dedicated modules.
One concern is serialization stability....

refs:https://github.com/scala/bug/issues/11268
