### PR TITLE
re-STARR to fix semantic merge conflict around serialization

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -1,5 +1,5 @@
 # Scala version used for bootstrapping (see README.md)
-starr.version=2.13.0-M5
+starr.version=2.13.0-M5-6e0cba7
 
 # These are the versions of the modules that go with this release.
 # Artifact dependencies:


### PR DESCRIPTION
I'm having a bad time running (for instance) `run/lambda-serialization.scala`. The problem appears to be that the new proxy-based collection serialization is serializing members of the companion object, some of which are not serializable.

This seems to fix it.