### PR TITLE
Inline from classpath: list all lambda methods in `$deserializeLambda$`

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -15,15 +15,15 @@ package backend.jvm
 package opt
 
 import scala.annotation.{switch, tailrec}
-import scala.reflect.internal.util.Collections._
-import scala.tools.asm.commons.CodeSizeEvaluator
-import scala.tools.asm.tree.analysis._
-import scala.tools.asm.{Label, Type}
-import scala.tools.asm.Opcodes._
-import scala.tools.asm.tree._
-import GenBCode._
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.reflect.internal.util.Collections._
+import scala.tools.asm.Opcodes._
+import scala.tools.asm.commons.CodeSizeEvaluator
+import scala.tools.asm.tree._
+import scala.tools.asm.tree.analysis._
+import scala.tools.asm.{Label, Type}
+import scala.tools.nsc.backend.jvm.GenBCode._
 import scala.tools.nsc.backend.jvm.analysis.InstructionStackEffect
 
 object BytecodeUtils {
@@ -317,18 +317,6 @@ object BytecodeUtils {
 
     (roughUpperBound(caller) + roughUpperBound(callee) > maxMethodSizeAfterInline) &&
       (maxSize(caller) + maxSize(callee) > maxMethodSizeAfterInline)
-  }
-
-  def removeLineNumberNodes(classNode: ClassNode): Unit = {
-    for (m <- classNode.methods.asScala) removeLineNumberNodes(m.instructions)
-  }
-
-  def removeLineNumberNodes(instructions: InsnList): Unit = {
-    val iter = instructions.iterator
-    while (iter.hasNext) iter.next() match {
-      case _: LineNumberNode => iter.remove()
-      case _ =>
-    }
   }
 
   def cloneLabels(methodNode: MethodNode): Map[LabelNode, LabelNode] = {

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
@@ -337,6 +337,14 @@ abstract class ClosureOptimizer {
     // drop the closure from the stack
     ownerMethod.instructions.insertBefore(invocation, new InsnNode(POP))
 
+    val isNew = lambdaBodyHandle.getTag == H_NEWINVOKESPECIAL
+
+    if (isNew) {
+      val insns = ownerMethod.instructions
+      insns.insertBefore(invocation, new TypeInsnNode(NEW, lambdaBodyHandle.getOwner))
+      insns.insertBefore(invocation, new InsnNode(DUP))
+    }
+
     // load captured values and arguments
     insertLoadOps(invocation, ownerMethod, localsForCapturedValues)
     insertLoadOps(invocation, ownerMethod, argumentLocalsList)
@@ -344,7 +352,7 @@ abstract class ClosureOptimizer {
     // update maxStack
     // One slot per value is correct for long / double, see comment in the `analysis` package object.
     val numCapturedValues = localsForCapturedValues.locals.length
-    val invocationStackHeight = stackHeight + numCapturedValues - 1 // -1 because the closure is gone
+    val invocationStackHeight = stackHeight + numCapturedValues - 1 + (if (isNew) 2 else 0) // -1 because the closure is gone
     if (invocationStackHeight > ownerMethod.maxStack)
       ownerMethod.maxStack = invocationStackHeight
 
@@ -354,30 +362,28 @@ abstract class ClosureOptimizer {
       case H_INVOKESTATIC     => INVOKESTATIC
       case H_INVOKESPECIAL    => INVOKESPECIAL
       case H_INVOKEINTERFACE  => INVOKEINTERFACE
-      case H_NEWINVOKESPECIAL =>
-        val insns = ownerMethod.instructions
-        insns.insertBefore(invocation, new TypeInsnNode(NEW, lambdaBodyHandle.getOwner))
-        insns.insertBefore(invocation, new InsnNode(DUP))
-        INVOKESPECIAL
+      case H_NEWINVOKESPECIAL => INVOKESPECIAL
     }
     val bodyInvocation = new MethodInsnNode(bodyOpcode, lambdaBodyHandle.getOwner, lambdaBodyHandle.getName, lambdaBodyHandle.getDesc, lambdaBodyHandle.isInterface)
     ownerMethod.instructions.insertBefore(invocation, bodyInvocation)
 
-    val bodyReturnType = Type.getReturnType(lambdaBodyHandle.getDesc)
-    val invocationReturnType = Type.getReturnType(invocation.desc)
-    if (isPrimitiveType(invocationReturnType) && bodyReturnType.getDescriptor == ObjectRef.descriptor) {
-      val op =
-        if (invocationReturnType.getSort == Type.VOID) getPop(1)
-        else getScalaUnbox(invocationReturnType)
-      ownerMethod.instructions.insertBefore(invocation, op)
-    } else if (isPrimitiveType(bodyReturnType) && invocationReturnType.getDescriptor == ObjectRef.descriptor) {
-      val op =
-        if (bodyReturnType.getSort == Type.VOID) getBoxedUnit
-        else getScalaBox(bodyReturnType)
-      ownerMethod.instructions.insertBefore(invocation, op)
-    } else {
-      // see comment of that method
-      fixLoadedNothingOrNullValue(bodyReturnType, bodyInvocation, ownerMethod, bTypes)
+    if (!isNew) {
+      val bodyReturnType = Type.getReturnType(lambdaBodyHandle.getDesc)
+      val invocationReturnType = Type.getReturnType(invocation.desc)
+      if (isPrimitiveType(invocationReturnType) && bodyReturnType.getDescriptor == ObjectRef.descriptor) {
+        val op =
+          if (invocationReturnType.getSort == Type.VOID) getPop(1)
+          else getScalaUnbox(invocationReturnType)
+        ownerMethod.instructions.insertBefore(invocation, op)
+      } else if (isPrimitiveType(bodyReturnType) && invocationReturnType.getDescriptor == ObjectRef.descriptor) {
+        val op =
+          if (bodyReturnType.getSort == Type.VOID) getBoxedUnit
+          else getScalaBox(bodyReturnType)
+        ownerMethod.instructions.insertBefore(invocation, op)
+      } else {
+        // see comment of that method
+        fixLoadedNothingOrNullValue(bodyReturnType, bodyInvocation, ownerMethod, bTypes)
+      }
     }
 
     ownerMethod.instructions.remove(invocation)

--- a/test/files/run/indyLambdaKinds.check
+++ b/test/files/run/indyLambdaKinds.check
@@ -1,0 +1,50 @@
+Inlining into Main$.main
+ inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 121 ins, after: 138 ins.
+ inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 138 ins, after: 155 ins.
+ inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 155 ins, after: 172 ins.
+ inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 172 ins, after: 189 ins.
+ inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 189 ins, after: 206 ins.
+ inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 206 ins, after: 223 ins.
+ inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 223 ins, after: 240 ins.
+ inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 240 ins, after: 257 ins.
+ inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 257 ins, after: 274 ins.
+ inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 274 ins, after: 291 ins.
+ inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 291 ins, after: 308 ins.
+ inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 308 ins, after: 325 ins.
+ inlined A_1.m1 (the callee is a small trivial method). Before: 325 ins, after: 341 ins.
+ inlined A_1.m1 (the callee is a small trivial method). Before: 341 ins, after: 357 ins.
+ inlined A_1.m1 (the callee is a small trivial method). Before: 357 ins, after: 373 ins.
+ inlined A_1.m1 (the callee is a small trivial method). Before: 373 ins, after: 389 ins.
+Inlining into Main$.t1a: inlined A_1.a (the callsite is annotated `@inline`). Before: 7 ins, after: 16 ins.
+Inlining into Main$.t2a: inlined A_1.b (the callsite is annotated `@inline`). Before: 7 ins, after: 16 ins.
+Inlining into Main$.t3a: inlined A_1.c (the callsite is annotated `@inline`). Before: 7 ins, after: 16 ins.
+Inlining into Main$.t4a: failed A_1.d (the callsite is annotated `@inline`). A_1::d(Ljava/lang/String;)Ljava/util/function/BiFunction; is annotated @inline but could not be inlined: The callee A_1::d(Ljava/lang/String;)Ljava/util/function/BiFunction; contains the instruction INVOKEDYNAMIC apply(Ljava/lang/String;)Ljava/util/function/BiFunction; [       // handle kind 0x6 : INVOKESTATIC       java/lang/invoke/LambdaMetafactory.metafactory(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;       // arguments:       (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;,        // handle kind 0x6 : INVOKESTATIC       A_1.lambda$d$0(Ljava/lang/String;LA_1;Ljava/lang/String;)Ljava/lang/String;,        (LA_1;Ljava/lang/String;)Ljava/lang/String;     ] that would cause an IllegalAccessError when inlined into class Main$.
+Inlining into Main$.t4b: failed A_1.d (the callsite is annotated `@inline`). A_1::d(Ljava/lang/String;)Ljava/util/function/BiFunction; is annotated @inline but could not be inlined: The callee A_1::d(Ljava/lang/String;)Ljava/util/function/BiFunction; contains the instruction INVOKEDYNAMIC apply(Ljava/lang/String;)Ljava/util/function/BiFunction; [       // handle kind 0x6 : INVOKESTATIC       java/lang/invoke/LambdaMetafactory.metafactory(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;       // arguments:       (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;,        // handle kind 0x6 : INVOKESTATIC       A_1.lambda$d$0(Ljava/lang/String;LA_1;Ljava/lang/String;)Ljava/lang/String;,        (LA_1;Ljava/lang/String;)Ljava/lang/String;     ] that would cause an IllegalAccessError when inlined into class Main$.
+Inlining into Main$.t5a: failed A_1.e (the callsite is annotated `@inline`). A_1::e(Ljava/lang/String;)Ljava/util/function/Function; is annotated @inline but could not be inlined: The callee A_1::e(Ljava/lang/String;)Ljava/util/function/Function; contains the instruction INVOKEDYNAMIC apply(Ljava/lang/String;)Ljava/util/function/Function; [       // handle kind 0x6 : INVOKESTATIC       java/lang/invoke/LambdaMetafactory.metafactory(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;       // arguments:       (Ljava/lang/Object;)Ljava/lang/Object;,        // handle kind 0x6 : INVOKESTATIC       A_1.lambda$e$1(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;,        (Ljava/lang/String;)Ljava/lang/String;     ] that would cause an IllegalAccessError when inlined into class Main$.
+Inlining into Main$.t5b: failed A_1.e (the callsite is annotated `@inline`). A_1::e(Ljava/lang/String;)Ljava/util/function/Function; is annotated @inline but could not be inlined: The callee A_1::e(Ljava/lang/String;)Ljava/util/function/Function; contains the instruction INVOKEDYNAMIC apply(Ljava/lang/String;)Ljava/util/function/Function; [       // handle kind 0x6 : INVOKESTATIC       java/lang/invoke/LambdaMetafactory.metafactory(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;       // arguments:       (Ljava/lang/Object;)Ljava/lang/Object;,        // handle kind 0x6 : INVOKESTATIC       A_1.lambda$e$1(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;,        (Ljava/lang/String;)Ljava/lang/String;     ] that would cause an IllegalAccessError when inlined into class Main$.
+Inlining into Main$.t6a: failed A_1.f (the callsite is annotated `@inline`). A_1::f(Ljava/lang/String;)Ljava/util/function/Function; is annotated @inline but could not be inlined: The callee A_1::f(Ljava/lang/String;)Ljava/util/function/Function; contains the instruction INVOKEDYNAMIC apply(Ljava/lang/String;)Ljava/util/function/Function; [       // handle kind 0x6 : INVOKESTATIC       java/lang/invoke/LambdaMetafactory.metafactory(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;       // arguments:       (Ljava/lang/Object;)Ljava/lang/Object;,        // handle kind 0x6 : INVOKESTATIC       A_1.lambda$f$2(Ljava/lang/String;Ljava/lang/String;)LA_1;,        (Ljava/lang/String;)LA_1;     ] that would cause an IllegalAccessError when inlined into class Main$.
+Inlining into Main$.t6b: failed A_1.f (the callsite is annotated `@inline`). A_1::f(Ljava/lang/String;)Ljava/util/function/Function; is annotated @inline but could not be inlined: The callee A_1::f(Ljava/lang/String;)Ljava/util/function/Function; contains the instruction INVOKEDYNAMIC apply(Ljava/lang/String;)Ljava/util/function/Function; [       // handle kind 0x6 : INVOKESTATIC       java/lang/invoke/LambdaMetafactory.metafactory(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;       // arguments:       (Ljava/lang/Object;)Ljava/lang/Object;,        // handle kind 0x6 : INVOKESTATIC       A_1.lambda$f$2(Ljava/lang/String;Ljava/lang/String;)LA_1;,        (Ljava/lang/String;)LA_1;     ] that would cause an IllegalAccessError when inlined into class Main$.
+Inlining into Main$.t1b
+ inlined A_1.a (the callsite is annotated `@inline`). Before: 11 ins, after: 20 ins.
+ rewrote invocations of closure allocated in Main$.t1b with body m1: INVOKEINTERFACE java/util/function/BiFunction.apply (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; (itf)
+ inlined A_1.m1 (the callee is a small trivial method). Before: 27 ins, after: 34 ins.
+Inlining into Main$.t2b
+ inlined A_1.b (the callsite is annotated `@inline`). Before: 10 ins, after: 19 ins.
+ rewrote invocations of closure allocated in Main$.t2b with body m2: INVOKEINTERFACE java/util/function/Function.apply (Ljava/lang/Object;)Ljava/lang/Object; (itf)
+ inlined A_1.m2 (the callee is a small trivial method). Before: 23 ins, after: 29 ins.
+Inlining into Main$.t3b
+ inlined A_1.c (the callsite is annotated `@inline`). Before: 10 ins, after: 19 ins.
+ rewrote invocations of closure allocated in Main$.t3b with body <init>: INVOKEINTERFACE java/util/function/Function.apply (Ljava/lang/Object;)Ljava/lang/Object; (itf)
+warning: there were 6 inliner warnings; re-run enabling -opt-warnings for details, or try -help
+m1
+m1
+m2
+m2
+m1
+m1
+m1
+m1
+m2
+m2
+m1
+m1

--- a/test/files/run/indyLambdaKinds/A_1.java
+++ b/test/files/run/indyLambdaKinds/A_1.java
@@ -1,0 +1,16 @@
+import java.util.function.*;
+import java.lang.annotation.Annotation;
+
+public class A_1 {
+  public final String m1(String x) { return "m1"; }
+  public final static String m2(String x) { return "m2"; }
+  public A_1(String x) { }
+
+  public final BiFunction<A_1, String, String> a() { return A_1::m1; }
+  public final Function<String, String> b() { return A_1::m2; }
+  public final Function<String, A_1> c() { return A_1::new; }
+
+  public final BiFunction<A_1, String, String> d(String x) { return (a, s) -> a.m1(s + x); }
+  public final Function<String, String> e(String x) { return s -> A_1.m2(s + x); }
+  public final Function<String, A_1> f(String x) { return s -> new A_1(s + x); }
+}

--- a/test/files/run/indyLambdaKinds/Test_2.scala
+++ b/test/files/run/indyLambdaKinds/Test_2.scala
@@ -1,0 +1,55 @@
+import tools.partest.DirectTest
+import reflect.internal.util._
+
+object Test extends DirectTest {
+
+  override def extraSettings: String = s"-usejavacp -cp ${testOutput.path} -opt:l:inline -opt-inline-from:** -Yopt-log-inline _ -d ${testOutput.path}"
+
+  override def code = """object Main {
+  @noinline def t1a(a: A_1) = a.a(): @inline
+  @noinline def t1b(a: A_1) = (a.a(): @inline).apply(a, "")
+
+  @noinline def t2a(a: A_1) = a.b(): @inline
+  @noinline def t2b(a: A_1) = (a.b(): @inline).apply("")
+
+  @noinline def t3a(a: A_1) = a.c(): @inline
+  @noinline def t3b(a: A_1) = (a.c(): @inline).apply("")
+
+  @noinline def t4a(a: A_1) = a.d(""): @inline
+  @noinline def t4b(a: A_1) = (a.d(""): @inline).apply(a, "")
+
+  @noinline def t5a(a: A_1) = a.e(""): @inline
+  @noinline def t5b(a: A_1) = (a.e(""): @inline).apply("")
+
+  @noinline def t6a(a: A_1) = a.f(""): @inline
+  @noinline def t6b(a: A_1) = (a.f(""): @inline).apply("")
+
+  def main(args: Array[String]): Unit = {
+    val a = new A_1("")
+
+    println(t1a(a).apply(a, ""))
+    println(t1b(a))
+
+    println(t2a(a).apply(""))
+    println(t2b(a))
+
+    println(t3a(a).apply("").m1(""))
+    println(t3b(a).m1(""))
+
+    println(t4a(a).apply(a, ""))
+    println(t4b(a))
+
+    println(t5a(a).apply(""))
+    println(t5b(a))
+
+    println(t6a(a).apply("").m1(""))
+    println(t6b(a).m1(""))
+  }
+}"""
+
+  override def show(): Unit = {
+    compile()
+    ScalaClassLoader(getClass.getClassLoader) run ("Main", Nil)
+
+  }
+}

--- a/test/files/run/t11255.flags
+++ b/test/files/run/t11255.flags
@@ -1,0 +1,1 @@
+-opt:l:inline -opt-inline-from:**

--- a/test/files/run/t11255/A_1.scala
+++ b/test/files/run/t11255/A_1.scala
@@ -1,0 +1,4 @@
+class K(val f: Int => Int) extends Serializable
+class A {
+  @inline final def f = new K(x => x + 1)
+}

--- a/test/files/run/t11255/Test_2.scala
+++ b/test/files/run/t11255/Test_2.scala
@@ -1,0 +1,14 @@
+object Test {
+  def serializeDeserialize(obj: Object): Object = {
+    import java.io._
+    val buffer = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(obj)
+    val in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray))
+    in.readObject
+  }
+
+  def main(args: Array[String]): Unit = {
+    assert(serializeDeserialize((new A).f).asInstanceOf[K].f(10) == 11)
+  }
+}


### PR DESCRIPTION
When inlining an IndyLambda from the classpath, ensure that the lambda
impl method is listed in the class's `$deserializeLambda$`.

Fixes scala/bug#11255.