### PR TITLE
Stricter refchecks: subclassing on traits does not imply suffixing for their linearisations [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -768,18 +768,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
              members) ++= decls
         }
       }
-      def forwarders(sdef: Tree): List[Tree] = sdef match {
-        case ClassDef(mods, name, tparams, _) if (parentToken == INTERFACE) =>
-          val tparams1: List[TypeDef] = tparams map (_.duplicate)
-          var rhs: Tree = Select(Ident(parentName.toTermName), name)
-          if (!tparams1.isEmpty) rhs = AppliedTypeTree(rhs, tparams1 map (tp => Ident(tp.name)))
-          List(TypeDef(Modifiers(Flags.PROTECTED), name, tparams1, rhs))
-        case _ =>
-          List()
-      }
-      val sdefs = statics.toList
-      val idefs = members.toList ::: (sdefs flatMap forwarders)
-      (sdefs, idefs)
+      (statics.toList, members.toList)
     }
     def annotationParents = Select(javaLangDot(nme.annotation), tpnme.Annotation) :: Nil
     def annotationDecl(mods: Modifiers): List[Tree] = {

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -464,7 +464,6 @@ abstract class Erasure extends InfoTransform
   class EnterBridges(unit: CompilationUnit, root: Symbol) {
 
     class BridgesCursor(root: Symbol) extends overridingPairs.Cursor(root) {
-      override def parents              = root.info.firstParent :: Nil
       // Varargs bridges may need generic bridges due to the non-repeated part of the signature of the involved methods.
       // The vararg bridge is generated during refchecks (probably to simplify override checking),
       // but then the resulting varargs "bridge" method may itself need an actual erasure bridge.

--- a/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
+++ b/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
@@ -127,6 +127,9 @@ trait TypeAdaptingTransformer { self: TreeDSL =>
       }
       if (pt =:= UnitTpe) {
         // See scala/bug#4731 for one example of how this occurs.
+        // TODO: that initial fix was quite symptomatic (the real problem was that it allowed an illegal override,
+        // which resulted in types being so out of whack that'd case something to unit where we shouldn't),
+        // so I'm not sure this case actually still arises.
         log("Attempted to cast to Unit: " + tree)
         tree.duplicate setType pt
       } else if (tree.tpe != null && tree.tpe.typeSymbol == ArrayClass && pt.typeSymbol == ArrayClass) {

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -31,7 +31,7 @@ trait Iterable[+A] extends IterableOnce[A] with IterableOps[A, Iterable, Iterabl
   final def toIterable: this.type = this
 
   //TODO scalac generates an override for this in AbstractMap; Making it final leads to a VerifyError
-  protected def coll: this.type = this
+  final protected def coll: this.type = this
 
   protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]): IterableCC[A] @uncheckedVariance = iterableFactory.from(coll)
   protected def newSpecificBuilder: Builder[A, IterableCC[A]] @uncheckedVariance = iterableFactory.newBuilder[A]

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -30,7 +30,6 @@ trait Iterable[+A] extends IterableOnce[A] with IterableOps[A, Iterable, Iterabl
   // The collection itself
   final def toIterable: this.type = this
 
-  //TODO scalac generates an override for this in AbstractMap; Making it final leads to a VerifyError
   final protected def coll: this.type = this
 
   protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]): IterableCC[A] @uncheckedVariance = iterableFactory.from(coll)

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -191,9 +191,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
 
   // Make `concat` an alias for `appendedAll` so that it benefits from performance
   // overrides of this method
-  // TODO https://github.com/scala/bug/issues/10853 Uncomment final
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  @`inline` /*final*/ override def concat[B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
+  @`inline` final override def concat[B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
 
  /** Produces a new sequence which contains all elements of this $coll and also all elements of
    *  a given sequence. `xs union ys`  is equivalent to `xs ++ ys`.

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -65,8 +65,7 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     *  @param elem the element to test for membership.
     *  @return  `true` if `elem` is contained in this set, `false` otherwise.
     */
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /*@`inline` final*/ def apply(elem: A): Boolean = this.contains(elem)
+  @`inline` final def apply(elem: A): Boolean = this.contains(elem)
 
   /** Tests whether this set is a subset of another set.
     *

--- a/src/library/scala/collection/StrictOptimizedIterableOps.scala
+++ b/src/library/scala/collection/StrictOptimizedIterableOps.scala
@@ -120,8 +120,8 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
-  override def concat[B >: A](suffix: IterableOnce[B]): CC[B] =
-    strictOptimizedConcat(suffix, iterableFactory.newBuilder[B])
+//  override def concat[B >: A](suffix: IterableOnce[B]): CC[B] =
+//    strictOptimizedConcat(suffix, iterableFactory.newBuilder[B])
 
   /**
     * @param that Elements to concatenate to this collection

--- a/src/library/scala/collection/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSeqOps.scala
@@ -64,10 +64,6 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
     b.result()
   }
 
-  // Must override here to ensure that `concat` is still an alias for `appendedAll` since it is overridden in `StrictOptimizedIterableOps`
-//  @deprecatedOverriding("Compatibility override", since="2.13.0")
-//  override def concat[B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
-
   override def padTo[B >: A](len: Int, elem: B): CC[B] = {
     val b = iterableFactory.newBuilder[B]
     val L = size

--- a/src/library/scala/collection/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSeqOps.scala
@@ -65,8 +65,8 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
   }
 
   // Must override here to ensure that `concat` is still an alias for `appendedAll` since it is overridden in `StrictOptimizedIterableOps`
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
-  override def concat[B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
+//  @deprecatedOverriding("Compatibility override", since="2.13.0")
+//  override def concat[B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
 
   override def padTo[B >: A](len: Int, elem: B): CC[B] = {
     val b = iterableFactory.newBuilder[B]

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -73,8 +73,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   def removed(key: K): C
 
   /** Alias for `remove` */
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /*@`inline` final*/ def - (key: K): C = removed(key)
+  @`inline` final def - (key: K): C = removed(key)
 
   @deprecated("Use -- with an explicit collection", "2.13.0")
   def - (key1: K, key2: K, keys: K*): C = removed(key1).removed(key2).removedAll(keys)
@@ -91,8 +90,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   def removedAll(keys: IterableOnce[K]): C = keys.iterator.foldLeft[C](coll)(_ - _)
 
   /** Alias for `removeAll` */
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /* @`inline` final */ override def -- (keys: IterableOnce[K]): C = removedAll(keys)
+  @`inline` final override def -- (keys: IterableOnce[K]): C = removedAll(keys)
 
   /** Creates a new map obtained by updating this map with a given key/value pair.
     *  @param    key the key

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -43,8 +43,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   def incl(elem: A): C
 
   /** Alias for `incl` */
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  override /*final*/ def + (elem: A): C = incl(elem) // like in collection.Set but not deprecated
+  override final def + (elem: A): C = incl(elem) // like in collection.Set but not deprecated
 
   /** Creates a new set with a given element removed from this set.
     *
@@ -55,8 +54,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   def excl(elem: A): C
 
   /** Alias for `excl` */
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /*@`inline` final*/ override def - (elem: A): C = excl(elem)
+  @`inline` final override def - (elem: A): C = excl(elem)
 
   def diff(that: collection.Set[A]): C =
     toIterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result + elem)
@@ -70,8 +68,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   def removedAll(that: IterableOnce[A]): C = that.iterator.foldLeft[C](coll)(_ - _)
 
   /** Alias for removeAll */
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  override /*final*/ def -- (that: IterableOnce[A]): C = removedAll(that)
+  override final def -- (that: IterableOnce[A]): C = removedAll(that)
 }
 
 trait StrictOptimizedSetOps[A, +CC[X], +C <: SetOps[A, CC, C]]

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -51,6 +51,8 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   protected[collection] var array: Array[AnyRef] = initialElements
   protected var size0 = initialSize
 
+  override def knownSize: Int = super[IndexedSeqOps].knownSize
+
   /** Ensure that the internal array has at least `n` cells. */
   protected def ensureSize(n: Int): Unit =
     array = RefArrayUtils.ensureSize(array, size0, n)

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -65,6 +65,8 @@ class ArrayDeque[A] protected (
 
   def this(initialSize: Int = ArrayDeque.DefaultInitialSize) = this(ArrayDeque.alloc(initialSize), start = 0, end = 0)
 
+  override def knownSize: Int = super[IndexedSeqOps].knownSize
+
   def apply(idx: Int) = {
     requireBounds(idx)
     _get(idx)

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -74,12 +74,10 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
   def result(): C = coll
 
   @deprecated("Use - or remove on an immutable Map", "2.13.0")
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /*final*/ def - (key: K): C = clone() -= key
+  final def - (key: K): C = clone() -= key
 
   @deprecated("Use -- or removeAll on an immutable Map", "2.13.0")
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /*final*/ def - (key1: K, key2: K, keys: K*): C = clone() -= key1 -= key2 --= keys
+  final def - (key1: K, key2: K, keys: K*): C = clone() -= key1 -= key2 --= keys
 
   /** Adds a new key/value pair to this map and optionally returns previously bound value.
     *  If the map already contains a

--- a/src/reflect/scala/reflect/internal/SymbolPairs.scala
+++ b/src/reflect/scala/reflect/internal/SymbolPairs.scala
@@ -37,13 +37,6 @@ abstract class SymbolPairs {
   val global: SymbolTable
   import global._
 
-  /** Are types tp1 and tp2 equivalent seen from the perspective
-   *  of `baseClass`? For instance List[Int] and Seq[Int] are =:=
-   *  when viewed from IterableClass.
-   */
-  def sameInBaseClass(baseClass: Symbol)(tp1: Type, tp2: Type) =
-    tp1.baseType(baseClass).typeSymbol == tp2.baseType(baseClass).typeSymbol
-
   final case class SymbolPair(base: Symbol, low: Symbol, high: Symbol) {
     private[this] val self  = base.thisType
 
@@ -113,33 +106,7 @@ abstract class SymbolPairs {
      */
     protected def matches(high: Symbol): Boolean
 
-    /** The parents and base classes of `base`.  Can be refined in subclasses.
-     */
-    protected def parents: List[Type] = base.info.parents
     protected def bases: List[Symbol] = base.info.baseClasses
-
-    /** An implementation of BitSets as arrays (maybe consider collection.BitSet
-     *  for that?) The main purpose of this is to implement
-     *  intersectionContainsElement efficiently.
-     */
-    private type BitSet = Array[Int]
-
-    /** A mapping from all base class indices to a bitset
-     *  which indicates whether parents are subclasses.
-     *
-     *   i \in subParents(j)   iff
-     *   exists p \in parents, b \in baseClasses:
-     *     i = index(p)
-     *     j = index(b)
-     *     p isSubClass b
-     *     p.baseType(b).typeSymbol == self.baseType(b).typeSymbol
-     */
-    private[this] val subParents = new Array[BitSet](size)
-
-    /** A map from baseclasses of <base> to ints, with smaller ints meaning lower in
-     *  linearization order. Symbols that are not baseclasses map to -1.
-     */
-    private[this] val index = new mutable.HashMap[Symbol, Int]().withDefaultValue(-1)
 
     /** The scope entries that have already been visited as highSymbol
      *  (but may have been excluded via hasCommonParentAsSubclass.)
@@ -187,59 +154,16 @@ abstract class SymbolPairs {
           }
         }
       }
-      var i = 0
-      for (bc <- bases) {
-        index(bc) = i
-        subParents(i) = new BitSet(size)
-        i += 1
-      }
-      for (p <- parents) {
-        val pIndex = index(p.typeSymbol)
-        if (pIndex >= 0)
-          for (bc <- p.baseClasses ; if sameInBaseClass(bc)(p, self)) {
-            val bcIndex = index(bc)
-            if (bcIndex >= 0)
-              include(subParents(bcIndex), pIndex)
-          }
-      }
+
       // first, deferred (this will need to change if we change lookup rules!)
       fillDecls(bases, deferred = true)
       // then, concrete.
       fillDecls(bases, deferred = false)
     }
 
-    private def include(bs: BitSet, n: Int): Unit = {
-      val nshifted = n >> 5
-      val nmask    = 1 << (n & 31)
-      bs(nshifted) |= nmask
-    }
-
-    /** Implements `bs1 * bs2 * {0..n} != 0`.
-     *  Used in hasCommonParentAsSubclass */
-    private def intersectionContainsElementLeq(bs1: BitSet, bs2: BitSet, n: Int): Boolean = {
-      val nshifted = n >> 5
-      val nmask = 1 << (n & 31)
-      var i = 0
-      while (i < nshifted) {
-        if ((bs1(i) & bs2(i)) != 0) return true
-        i += 1
-      }
-      (bs1(nshifted) & bs2(nshifted) & (nmask | nmask - 1)) != 0
-    }
-
-    /** Do `sym1` and `sym2` have a common subclass in `parents`?
-     *  In that case we do not follow their pairs.
-     */
-    private def hasCommonParentAsSubclass(sym1: Symbol, sym2: Symbol) = {
-      val index1 = index(sym1.owner)
-      (index1 >= 0) && {
-        val index2 = index(sym2.owner)
-        (index2 >= 0) && {
-          intersectionContainsElementLeq(
-            subParents(index1), subParents(index2), index1 min index2)
-        }
-      }
-    }
+    // We can only draw conclusions about linearisation from a non-trait parent; skip Object, being the top of the lattice.
+    private lazy val nonTraitParent: Symbol =
+      base.info.firstParent.typeSymbol.filter(sym => !sym.isTrait && sym != definitions.ObjectClass)
 
     @tailrec private def advanceNextEntry(): Unit = {
       if (nextEntry ne null) {
@@ -248,12 +172,14 @@ abstract class SymbolPairs {
           val high    = nextEntry.sym
           val isMatch = matches(high) && { visited addEntry nextEntry ; true } // side-effect visited on all matches
 
-          // skip nextEntry if a class in `parents` is a subclass of the
-          // owners of both low and high.
-          if (isMatch && !hasCommonParentAsSubclass(lowSymbol, high))
-            highSymbol = high
-          else
+          // Skip nextEntry if the (non-trait) class in `parents` is a subclass of the owners of both low and high.
+          // this means we'll come back to this entry when we consider `nonTraitParent`, and the linearisation order will be the same
+          // (this only works for non-trait classes, since subclassing on traits does not imply one's linearisation is contained in the other's)
+          // This is not just an optimization -- bridge generation relies on visiting each such class only once.
+          if (!isMatch || (nonTraitParent.isNonBottomSubClass(low.owner) && nonTraitParent.isNonBottomSubClass(high.owner)))
             advanceNextEntry()
+          else
+            highSymbol = high
         }
       }
     }

--- a/test/files/neg/abstract-class-2.check
+++ b/test/files/neg/abstract-class-2.check
@@ -1,4 +1,5 @@
-abstract-class-2.scala:11: error: object creation impossible, since method f in trait S2 of type (x: P2.this.p.S1)Int is not defined
+abstract-class-2.scala:11: error: object creation impossible. Missing implementation for:
+  def f(x: P2.this.p.S1): Int // inherited from trait S2
 (Note that P.this.p.S1 does not match P2.this.S1: their prefixes (i.e., enclosing instances) differ)
   object O2 extends S2 {
          ^

--- a/test/files/neg/abstract-class-error.check
+++ b/test/files/neg/abstract-class-error.check
@@ -1,4 +1,5 @@
-S.scala:1: error: class S needs to be abstract, since method g in class J of type (y: Int, z: java.util.List)Int is not defined
+S.scala:1: error: class S needs to be abstract. Missing implementation for:
+  def g(y: Int, z: java.util.List): Int // inherited from class J
 (Note that java.util.List does not match java.util.List[String]. To implement this raw type, use java.util.List[_])
 class S extends J {
       ^

--- a/test/files/neg/abstract-concrete-methods.check
+++ b/test/files/neg/abstract-concrete-methods.check
@@ -1,4 +1,5 @@
-abstract-concrete-methods.scala:7: error: class Outer2 needs to be abstract, since method score in trait Outer of type (i: Outer2#Inner)Double is not defined
+abstract-concrete-methods.scala:7: error: class Outer2 needs to be abstract. Missing implementation for:
+  def score(i: Outer2#Inner): Double // inherited from trait Outer
 (Note that This#Inner does not match Outer2#Inner: class Inner in class Outer2 is a subclass of trait Inner in trait Outer, but method parameter types must match exactly.)
 class Outer2 extends Outer[Outer2] {
       ^

--- a/test/files/neg/abstract-report.check
+++ b/test/files/neg/abstract-report.check
@@ -1,8 +1,5 @@
-abstract-report.scala:1: error: class Unimplemented needs to be abstract, since:
-it has 6 unimplemented members.
-/** As seen from class Unimplemented, the missing signatures are as follows.
- *  For convenience, these are usable as stub implementations.
- */
+abstract-report.scala:1: error: class Unimplemented needs to be abstract.
+Missing implementations for 6 members. Stub implementations follow:
   // Members declared in scala.collection.IterableOnce
   def iterator: Iterator[String] = ???
 

--- a/test/files/neg/abstract-report2.check
+++ b/test/files/neg/abstract-report2.check
@@ -1,8 +1,5 @@
-abstract-report2.scala:3: error: class Foo needs to be abstract, since:
-it has 13 unimplemented members.
-/** As seen from class Foo, the missing signatures are as follows.
- *  For convenience, these are usable as stub implementations.
- */
+abstract-report2.scala:3: error: class Foo needs to be abstract.
+Missing implementations for 13 members. Stub implementations follow:
   def add(x$1: Int): Boolean = ???
   def addAll(x$1: java.util.Collection[_ <: Int]): Boolean = ???
   def clear(): Unit = ???
@@ -19,11 +16,8 @@ it has 13 unimplemented members.
 
 class Foo extends Collection[Int]
       ^
-abstract-report2.scala:5: error: class Bar needs to be abstract, since:
-it has 13 unimplemented members.
-/** As seen from class Bar, the missing signatures are as follows.
- *  For convenience, these are usable as stub implementations.
- */
+abstract-report2.scala:5: error: class Bar needs to be abstract.
+Missing implementations for 13 members. Stub implementations follow:
   def add(x$1: List[_ <: String]): Boolean = ???
   def addAll(x$1: java.util.Collection[_ <: List[_ <: String]]): Boolean = ???
   def clear(): Unit = ???
@@ -40,11 +34,8 @@ it has 13 unimplemented members.
 
 class Bar extends Collection[List[_ <: String]]
       ^
-abstract-report2.scala:7: error: class Baz needs to be abstract, since:
-it has 13 unimplemented members.
-/** As seen from class Baz, the missing signatures are as follows.
- *  For convenience, these are usable as stub implementations.
- */
+abstract-report2.scala:7: error: class Baz needs to be abstract.
+Missing implementations for 13 members. Stub implementations follow:
   def add(x$1: T): Boolean = ???
   def addAll(x$1: java.util.Collection[_ <: T]): Boolean = ???
   def clear(): Unit = ???
@@ -61,11 +52,8 @@ it has 13 unimplemented members.
 
 class Baz[T] extends Collection[T]
       ^
-abstract-report2.scala:15: error: class Dingus needs to be abstract, since:
-it has 7 unimplemented members.
-/** As seen from class Dingus, the missing signatures are as follows.
- *  For convenience, these are usable as stub implementations.
- */
+abstract-report2.scala:15: error: class Dingus needs to be abstract.
+Missing implementations for 7 members. Stub implementations follow:
   // Members declared in scala.collection.IterableOnce
   def iterator: Iterator[(Set[Int], String)] = ???
 

--- a/test/files/neg/abstract-vars.check
+++ b/test/files/neg/abstract-vars.check
@@ -1,20 +1,25 @@
-abstract-vars.scala:5: error: class Fail1 needs to be abstract, since variable x is not defined
+abstract-vars.scala:5: error: class Fail1 needs to be abstract. Missing implementation for:
+  def x: Int
 (Note that variables need to be initialized to be defined)
 class Fail1 extends A {
       ^
-abstract-vars.scala:9: error: class Fail2 needs to be abstract, since variable x in class A of type Int is not defined
+abstract-vars.scala:9: error: class Fail2 needs to be abstract. Missing implementation for:
+  def x: Int // inherited from class A
 (Note that variables need to be initialized to be defined)
 class Fail2 extends A { }
       ^
-abstract-vars.scala:11: error: class Fail3 needs to be abstract, since variable x in class A of type Int is not defined
+abstract-vars.scala:11: error: class Fail3 needs to be abstract. Missing implementation for:
+  def x_=(x$1: Int): Unit // inherited from class A
 (Note that an abstract var requires a setter in addition to the getter)
 class Fail3 extends A {
       ^
-abstract-vars.scala:14: error: class Fail4 needs to be abstract, since variable x in class A of type Int is not defined
+abstract-vars.scala:14: error: class Fail4 needs to be abstract. Missing implementation for:
+  def x_=(x$1: Int): Unit // inherited from class A
 (Note that an abstract var requires a setter in addition to the getter)
 class Fail4 extends A {
       ^
-abstract-vars.scala:18: error: class Fail5 needs to be abstract, since variable x in class A of type Int is not defined
+abstract-vars.scala:18: error: class Fail5 needs to be abstract. Missing implementation for:
+  def x: Int // inherited from class A
 (Note that an abstract var requires a getter in addition to the setter)
 class Fail5 extends A {
       ^

--- a/test/files/neg/accesses.check
+++ b/test/files/neg/accesses.check
@@ -1,17 +1,21 @@
-accesses.scala:23: error: overriding method f2 in class A of type ()Unit;
-  method f2 has weaker access privileges; it should not be private
+accesses.scala:23: error: weaker access privileges in overriding
+private[package p2] def f2(): Unit (defined in class A)
+  override should not be private
   private def f2(): Unit = ()
               ^
-accesses.scala:24: error: overriding method f3 in class A of type ()Unit;
-  method f3 has weaker access privileges; it should be at least protected
+accesses.scala:24: error: weaker access privileges in overriding
+protected def f3(): Unit (defined in class A)
+  override should at least be protected
   private[p2] def f3(): Unit = ()
                   ^
-accesses.scala:25: error: overriding method f4 in class A of type ()Unit;
-  method f4 has weaker access privileges; it should be at least private[p1]
+accesses.scala:25: error: weaker access privileges in overriding
+private[package p1] def f4(): Unit (defined in class A)
+  override should at least be private[p1]
   private[p2] def f4(): Unit
                   ^
-accesses.scala:26: error: overriding method f5 in class A of type ()Unit;
-  method f5 has weaker access privileges; it should be at least protected[p1]
+accesses.scala:26: error: weaker access privileges in overriding
+protected[package p1] def f5(): Unit (defined in class A)
+  override should at least be protected[p1]
   protected[p2] def f5(): Unit
                     ^
 four errors found

--- a/test/files/neg/accesses2.check
+++ b/test/files/neg/accesses2.check
@@ -1,12 +1,15 @@
-accesses2.scala:6: error: overriding method f2 in class A of type ()Int;
-  method f2 has weaker access privileges; it should not be private
+accesses2.scala:6: error: weaker access privileges in overriding
+private[package p2] def f2(): Int (defined in class A)
+  override should not be private
     private def f2(): Int = 1
                 ^
-accesses2.scala:5: error: class B1 needs to be abstract, since method f2 in class A of type ()Int is not defined
+accesses2.scala:5: error: class B1 needs to be abstract. Missing implementation for:
+  private[package p2] def f2(): Int // inherited from class A
   class B1 extends A {
         ^
-accesses2.scala:9: error: overriding method f2 in class A of type ()Int;
-  method f2 has weaker access privileges; it should not be private
+accesses2.scala:9: error: weaker access privileges in overriding
+private[package p2] def f2(): Int (defined in class A)
+  override should not be private
     private def f2(): Int = 1
                 ^
 three errors found

--- a/test/files/neg/lazy-override.check
+++ b/test/files/neg/lazy-override.check
@@ -1,9 +1,9 @@
-lazy-override.scala:11: error: overriding value x in class A of type Int;
-  lazy value x cannot override a concrete non-lazy value
+lazy-override.scala:11: error: concrete non-lazy value cannot be overridden:
+val x: Int (defined in class A)
     override lazy val x: Int = { print("/*B.x*/"); 3 }
                       ^
-lazy-override.scala:13: error: overriding lazy value y in class A of type Int;
-  value y must be declared lazy to override a concrete lazy value
+lazy-override.scala:13: error: value must be lazy when overriding concrete lazy value:
+lazy val y: Int (defined in class A)
     override val y: Int = { print("/*B.y*/"); 3 }
                  ^
 two errors found

--- a/test/files/neg/logImplicits.check
+++ b/test/files/neg/logImplicits.check
@@ -13,7 +13,8 @@ logImplicits.scala:21: applied implicit conversion from Int(1) to ?{def ->: ?} =
 logImplicits.scala:21: applied implicit conversion from (Int, Int) to ?{def +: ?} = final implicit def any2stringadd[A](self: A): any2stringadd[A]
   def f = (1 -> 2) + "c"
              ^
-logImplicits.scala:24: error: class Un needs to be abstract, since method unimplemented is not defined
+logImplicits.scala:24: error: class Un needs to be abstract. Missing implementation for:
+  def unimplemented: Int
 class Un {
       ^
 one error found

--- a/test/files/neg/macro-override-macro-overrides-abstract-method-a.check
+++ b/test/files/neg/macro-override-macro-overrides-abstract-method-a.check
@@ -1,5 +1,5 @@
-Impls_Macros_1.scala:12: error: overriding method foo in trait Foo of type (x: Int)Int;
-  macro method foo cannot be used here - term macros cannot override abstract methods
+Impls_Macros_1.scala:12: error: macro cannot override abstract method:
+def foo(x: Int): Int (defined in trait Foo)
   def foo(x: Int): Int = macro Impls.impl
       ^
 one error found

--- a/test/files/neg/macro-override-macro-overrides-abstract-method-b.check
+++ b/test/files/neg/macro-override-macro-overrides-abstract-method-b.check
@@ -1,11 +1,11 @@
 Test_2.scala:3: error: <$anon: C with A> inherits conflicting members:
-  macro method t in trait C of type ()Unit and
-  method t in trait A of type ()Unit
+  macro override def t(): Unit (defined in trait C) and
+  def t(): Unit (defined in trait A)
   (note: this can be resolved by declaring an `override` in <$anon: C with A>.)
   val c2 = new C with A {}
                ^
-Test_2.scala:5: error: overriding macro method t in trait C of type ()Unit;
-  method t cannot be used here - only term macros can override term macros
+Test_2.scala:5: error: macro can only be overridden by another macro:
+macro override def t(): Unit (defined in trait C)
   val c4 = new C with A { override def t(): Unit = () }
                                        ^
 two errors found

--- a/test/files/neg/macro-override-method-overrides-macro.check
+++ b/test/files/neg/macro-override-method-overrides-macro.check
@@ -1,5 +1,5 @@
-Macros_Test_2.scala:8: error: overriding macro method foo in class B of type (x: String)Unit;
-  method foo cannot be used here - only term macros can override term macros
+Macros_Test_2.scala:8: error: macro can only be overridden by another macro:
+macro def foo(x: String): Unit (defined in class B)
   override def foo(x: String): Unit = println("fooDString")
                ^
 one error found

--- a/test/files/neg/names-defaults-neg-ref.check
+++ b/test/files/neg/names-defaults-neg-ref.check
@@ -9,8 +9,10 @@ names-defaults-neg-ref.scala:17: error: in class C, multiple overloaded alternat
 The members with defaults are defined in class C and class B.
 class C extends B {
       ^
-names-defaults-neg-ref.scala:21: error: overriding method bar$default$1 in class B of type => String;
-  method bar$default$1 has incompatible type
+names-defaults-neg-ref.scala:21: error: incompatible type in overriding
+def bar$default$1: String (defined in class B);
+ found   : => Int
+ required: => String
   def bar(i: Int = 129083) = i
           ^
 four errors found

--- a/test/files/neg/override-concrete-type.check
+++ b/test/files/neg/override-concrete-type.check
@@ -1,9 +1,12 @@
-override-concrete-type.scala:13: error: overriding type A1 in class Foo, which equals Something;
-  overriding concrete type alias type A1 is not allowed except when equivalent
+override-concrete-type.scala:13: error: incompatible type in overriding
+type A1 = Something (defined in class Foo)
+   (Equivalent type required when overriding a type alias.)
   override type A1 = Something with Serializable
                 ^
-override-concrete-type.scala:14: error: overriding type A2 in class Foo with bounds <: Something;
-  type A2 has incompatible type
+override-concrete-type.scala:14: error: incompatible type in overriding
+type A2 <: Something (defined in class Foo);
+ found   : Any
+ required:  <: Something
   override type A2 = Any
                 ^
 two errors found

--- a/test/files/neg/override-final-implicit.check
+++ b/test/files/neg/override-final-implicit.check
@@ -1,5 +1,5 @@
-override-final-implicit.scala:6: error: overriding method FooExtender in class Implicits of type (foo: String)Test.this.FooExtender;
-  method FooExtender cannot override final member
+override-final-implicit.scala:6: error: cannot override final member:
+final implicit def FooExtender(foo: String): Test.this.FooExtender (defined in class Implicits)
   override implicit def FooExtender(foo: String) = super.FooExtender(foo)
                         ^
 one error found

--- a/test/files/neg/override-object-flag.check
+++ b/test/files/neg/override-object-flag.check
@@ -1,5 +1,5 @@
-override-object-flag.scala:3: error: overriding object Foo in trait A;
-  object Foo cannot override final member
+override-object-flag.scala:3: error: cannot override final member:
+object Foo (defined in trait A)
 trait B extends A  { override object Foo }
                                      ^
 one error found

--- a/test/files/neg/override.check
+++ b/test/files/neg/override.check
@@ -1,5 +1,8 @@
-override.scala:9: error: overriding type T in trait A with bounds >: Int <: Int;
-  type T in trait B with bounds >: String <: String has incompatible type
+override.scala:9: error: incompatible type in overriding
+type T >: Int <: Int (defined in trait A)
+  with type T >: String <: String (defined in trait B);
+ found   :  >: String <: String
+ required:  >: Int <: Int
   lazy val x : A with B = {println(""); x}
                ^
 one error found

--- a/test/files/neg/raw-types-stubs.check
+++ b/test/files/neg/raw-types-stubs.check
@@ -1,8 +1,5 @@
-S_3.scala:1: error: class Sub needs to be abstract, since:
-it has 2 unimplemented members.
-/** As seen from class Sub, the missing signatures are as follows.
- *  For convenience, these are usable as stub implementations.
- */
+S_3.scala:1: error: class Sub needs to be abstract.
+Missing implementations for 2 members. Stub implementations follow:
   def raw(x$1: M_1[_ <: String]): Unit = ???
   def raw(x$1: Any): Unit = ???
 

--- a/test/files/neg/sd128.check
+++ b/test/files/neg/sd128.check
@@ -4,8 +4,13 @@ Test.scala:4: error: class C1 inherits conflicting members:
   (note: this can be resolved by declaring an `override` in class C1.)
 class C1 extends A with T // error
       ^
+Test.scala:5: error: cannot override a concrete member without a third member that's overridden by both (this rule is designed to prevent ``accidental overrides'')
+def f: Int (defined in trait T)
+  with <defaultmethod> def f(): Int (defined in trait A)
+class C2 extends T with A // error
+      ^
 Test.scala:14: error: `override` modifier required to override concrete member:
 <defaultmethod> def f(): Int (defined in trait A)
   def f() = 9999 // need override modifier
       ^
-two errors found
+three errors found

--- a/test/files/neg/sd128.check
+++ b/test/files/neg/sd128.check
@@ -4,14 +4,8 @@ Test.scala:4: error: class C1 inherits conflicting members:
   (note: this can be resolved by declaring an `override` in class C1.)
 class C1 extends A with T // error
       ^
-Test.scala:5: error: class C2 inherits conflicting members:
-  method f in trait T of type => Int and
-  method f in trait A of type ()Int
-  (note: this can be resolved by declaring an `override` in class C2.)
-class C2 extends T with A // error
-      ^
 Test.scala:14: error: overriding method f in trait A of type ()Int;
   method f needs `override` modifier
   def f() = 9999 // need override modifier
       ^
-three errors found
+two errors found

--- a/test/files/neg/sd128.check
+++ b/test/files/neg/sd128.check
@@ -1,11 +1,11 @@
 Test.scala:4: error: class C1 inherits conflicting members:
-  method f in trait A of type ()Int and
-  method f in trait T of type => Int
+  <defaultmethod> def f(): Int (defined in trait A) and
+  def f: Int (defined in trait T)
   (note: this can be resolved by declaring an `override` in class C1.)
 class C1 extends A with T // error
       ^
-Test.scala:14: error: overriding method f in trait A of type ()Int;
-  method f needs `override` modifier
+Test.scala:14: error: `override` modifier required to override concrete member:
+<defaultmethod> def f(): Int (defined in trait A)
   def f() = 9999 // need override modifier
       ^
 two errors found

--- a/test/files/neg/sip23-override.check
+++ b/test/files/neg/sip23-override.check
@@ -1,9 +1,13 @@
-sip23-override.scala:24: error: overriding value f2 in trait Overridden of type 4;
-  value f2 has incompatible type
+sip23-override.scala:24: error: incompatible type in overriding
+val f2: 4 (defined in trait Overridden);
+ found   : 5
+ required: 4
   override val f2: 5 = 5
                ^
-sip23-override.scala:28: error: overriding method f5 in trait Overridden of type => 4;
-  method f5 has incompatible type
+sip23-override.scala:28: error: incompatible type in overriding
+def f5: 4 (defined in trait Overridden);
+ found   : => 5
+ required: => 4
   override def f5: 5 = 5
                ^
 two errors found

--- a/test/files/neg/string-context-refchecked.check
+++ b/test/files/neg/string-context-refchecked.check
@@ -1,5 +1,5 @@
-string-context-refchecked.scala:3: error: overriding method foo in class C of type => Int;
-  method foo cannot override final member
+string-context-refchecked.scala:3: error: cannot override final member:
+final def foo: Int (defined in class C)
   s"foo${class D extends C { def foo = 2 }; new D}bar"
                                  ^
 one error found

--- a/test/files/neg/t0345.check
+++ b/test/files/neg/t0345.check
@@ -1,4 +1,5 @@
-t0345.scala:2: error: object creation impossible, since method cons in trait Lizt of type (a: Nothing)Unit is not defined
+t0345.scala:2: error: object creation impossible. Missing implementation for:
+  def cons(a: Nothing): Unit // inherited from trait Lizt
     val empty = new Lizt[Nothing] {
                     ^
 one error found

--- a/test/files/neg/t10260.check
+++ b/test/files/neg/t10260.check
@@ -1,16 +1,20 @@
-Test.scala:1: error: class IAImpl needs to be abstract, since method foo in trait IA of type (a: A)Unit is not defined
+Test.scala:1: error: class IAImpl needs to be abstract. Missing implementation for:
+  def foo(a: A): Unit // inherited from trait IA
 (Note that A does not match A[_]. To implement this raw type, use A[T] forSome { type T <: A[T] })
 class IAImpl extends IA { def foo(a: A[_]) = ??? }
       ^
-Test.scala:2: error: class IBImpl needs to be abstract, since method foo in trait IB of type (a: B)Unit is not defined
+Test.scala:2: error: class IBImpl needs to be abstract. Missing implementation for:
+  def foo(a: B): Unit // inherited from trait IB
 (Note that B does not match B[_, _]. To implement this raw type, use B[T,R] forSome { type T; type R <: java.util.List[_ >: T] })
 class IBImpl extends IB { def foo(a: B[_,_]) = ??? }
       ^
-Test.scala:3: error: class ICImpl needs to be abstract, since method foo in trait IC of type (a: Int, b: C, c: String)C is not defined
+Test.scala:3: error: class ICImpl needs to be abstract. Missing implementation for:
+  def foo(a: Int, b: C, c: String): C // inherited from trait IC
 (Note that C does not match C[_]. To implement this raw type, use C[_ <: String])
 class ICImpl extends IC { def foo(a: Int, b: C[_], c: String) = ??? }
       ^
-Test.scala:4: error: class IDImpl needs to be abstract, since method foo in trait ID of type (a: D)Unit is not defined
+Test.scala:4: error: class IDImpl needs to be abstract. Missing implementation for:
+  def foo(a: D): Unit // inherited from trait ID
 (Note that D does not match D[_ <: String]. To implement this raw type, use D[_])
 class IDImpl extends ID { def foo(a: D[_ <: String]) = ??? }
       ^

--- a/test/files/neg/t11136.check
+++ b/test/files/neg/t11136.check
@@ -1,5 +1,6 @@
-t11136.scala:12: error: overriding method c in trait SO of type (x: Int)Int;
-  method c in trait SOIO of type (x: Int)Int cannot override final member
+t11136.scala:12: error: cannot override final member:
+final override def c(x: Int): Int (defined in trait SO)
+  with override def c(x: Int): Int (defined in trait SOIO)
 class L extends AS with SOSO // error expected: c definined in SOIO overrides final method c in SO
       ^
 one error found

--- a/test/files/neg/t11136.check
+++ b/test/files/neg/t11136.check
@@ -1,0 +1,5 @@
+t11136.scala:12: error: overriding method c in trait SO of type (x: Int)Int;
+  method c in trait SOIO of type (x: Int)Int cannot override final member
+class L extends AS with SOSO // error expected: c definined in SOIO overrides final method c in SO
+      ^
+one error found

--- a/test/files/neg/t11136.scala
+++ b/test/files/neg/t11136.scala
@@ -1,0 +1,12 @@
+trait IO {
+  def c(x: Int): Int = ???
+}
+trait SO extends IO {
+  override final def c(x: Int): Int = ???
+}
+trait SOIO extends IO {
+  override def c(x: Int): Int = ???
+}
+trait SOSO extends SOIO with SO
+abstract class AS extends SO
+class L extends AS with SOSO // error expected: c definined in SOIO overrides final method c in SO

--- a/test/files/neg/t11136_was_t4731.check
+++ b/test/files/neg/t11136_was_t4731.check
@@ -1,0 +1,5 @@
+t11136_was_t4731.scala:11: error: overriding method foo in trait Trait1 of type (arg: java.util.Comparator[String])Unit;
+  method foo in trait Trait2 of type (arg: java.util.Comparator[String])Int has incompatible type
+class Class1 extends Trait2[String] { }
+      ^
+one error found

--- a/test/files/neg/t11136_was_t4731.check
+++ b/test/files/neg/t11136_was_t4731.check
@@ -1,5 +1,8 @@
-t11136_was_t4731.scala:11: error: overriding method foo in trait Trait1 of type (arg: java.util.Comparator[String])Unit;
-  method foo in trait Trait2 of type (arg: java.util.Comparator[String])Int has incompatible type
+t11136_was_t4731.scala:11: error: incompatible type in overriding
+def foo(arg: java.util.Comparator[String]): Unit (defined in trait Trait1)
+  with def foo(arg: java.util.Comparator[String]): Int (defined in trait Trait2);
+ found   : (arg: java.util.Comparator[String])Int
+ required: (arg: java.util.Comparator[String])Unit
 class Class1 extends Trait2[String] { }
       ^
 one error found

--- a/test/files/neg/t11136_was_t4731.scala
+++ b/test/files/neg/t11136_was_t4731.scala
@@ -1,5 +1,9 @@
 import java.util.Comparator
 
+/* This accidentally started as a pos/ test, with the initial fix addressing a crasher in the backend.
+The real problem is that `foo`'s return type is not refined covariantly, so the override should be ruled out.
+Refchecks was too eager in pruning the paits it considers, so this was never detected.
+*/
 trait Trait1[T] { def foo(arg: Comparator[T]): Unit }
 
 trait Trait2[T] extends Trait1[T] { def foo(arg: Comparator[String]): Int = 0 }

--- a/test/files/neg/t1163.check
+++ b/test/files/neg/t1163.check
@@ -1,7 +1,8 @@
-t1163.scala:2: error: overriding method foo in trait Sub of type => Sub;
-  method foo in trait Super of type => Super has incompatible type;
-  (note that method foo in trait Sub of type => Sub is abstract,
-  and is therefore overridden by concrete method foo in trait Super of type => Super)
+t1163.scala:2: error: incompatible type in overriding
+override def foo: Sub (defined in trait Sub)
+  with def foo: Super (defined in trait Super);
+  (note that override def foo: Sub (defined in trait Sub) is abstract,
+  and is therefore overridden by concrete def foo: Super (defined in trait Super))
 trait Sub extends Super { override def foo: Sub }
       ^
 one error found

--- a/test/files/neg/t1364.check
+++ b/test/files/neg/t1364.check
@@ -1,5 +1,7 @@
-t1364.scala:9: error: overriding type T in trait A with bounds <: AnyRef{type S[-U]};
-  type T has incompatible type
+t1364.scala:9: error: incompatible type in overriding
+type T <: AnyRef{type S[-U]} (defined in trait A);
+ found   : AnyRef{type S[U] = U}
+ required:  <: AnyRef{type S[-U]}
  type T = { type S[U] = U }
       ^
 one error found

--- a/test/files/neg/t1477.check
+++ b/test/files/neg/t1477.check
@@ -1,5 +1,5 @@
-t1477.scala:13: error: overriding type V in trait C with bounds <: Middle.this.D;
-  type V is a volatile type; cannot override a type with non-volatile upper bound
+t1477.scala:13: error: volatile type member cannot override type member with non-volatile upper bound:
+type V <: Middle.this.D (defined in trait C)
     type V <: (D with U)
          ^
 one error found

--- a/test/files/neg/t2066.check
+++ b/test/files/neg/t2066.check
@@ -1,21 +1,31 @@
-t2066.scala:6: error: overriding method f in trait A1 of type [T[_]]=> Unit;
-  method f has incompatible type
+t2066.scala:6: error: incompatible type in overriding
+def f[T[_]]: Unit (defined in trait A1);
+ found   : [T[+_]]=> Unit
+ required: [T[_]]=> Unit
   override def f[T[+_]] = ()
                ^
-t2066.scala:10: error: overriding method f in trait A1 of type [T[_]]=> Unit;
-  method f has incompatible type
+t2066.scala:10: error: incompatible type in overriding
+def f[T[_]]: Unit (defined in trait A1);
+ found   : [T[-_]]=> Unit
+ required: [T[_]]=> Unit
   override def f[T[-_]] = ()
                ^
-t2066.scala:23: error: overriding method f in trait A2 of type [T[+_]]=> Unit;
-  method f has incompatible type
+t2066.scala:23: error: incompatible type in overriding
+def f[T[+_]]: Unit (defined in trait A2);
+ found   : [T[-_]]=> Unit
+ required: [T[+_]]=> Unit
   override def f[T[-_]] = ()
                ^
-t2066.scala:45: error: overriding method f in trait A4 of type [T[X[+_]]]=> Unit;
-  method f has incompatible type
+t2066.scala:45: error: incompatible type in overriding
+def f[T[X[+_]]]: Unit (defined in trait A4);
+ found   : [T[X[_]]]=> Unit
+ required: [T[X[+_]]]=> Unit
   override def f[T[X[_]]] = ()
                ^
-t2066.scala:53: error: overriding method f in trait A5 of type [T[X[-_]]]=> Unit;
-  method f has incompatible type
+t2066.scala:53: error: incompatible type in overriding
+def f[T[X[-_]]]: Unit (defined in trait A5);
+ found   : [T[X[_]]]=> Unit
+ required: [T[X[-_]]]=> Unit
   override def f[T[X[_]]] = ()
                ^
 5 errors found

--- a/test/files/neg/t2066b.check
+++ b/test/files/neg/t2066b.check
@@ -1,5 +1,7 @@
-t2066b.scala:7: error: overriding method f in trait A of type [T[_]](x: T[Int])T[Any];
-  method f has incompatible type
+t2066b.scala:7: error: incompatible type in overriding
+def f[T[_]](x: T[Int]): T[Any] (defined in trait A);
+ found   : [T(in method f)(in method f)[+_]](x: T(in method f)(in method f)[Int])T(in method f)(in method f)[Any]
+ required: [T(in method f)(in method f)[_]](x: T(in method f)(in method f)[Int])T(in method f)(in method f)[Any]
 	 def f[T[+_]](x : T[Int]) : T[Any] = x
              ^
 one error found

--- a/test/files/neg/t2213.check
+++ b/test/files/neg/t2213.check
@@ -1,8 +1,5 @@
-t2213.scala:9: error: class C needs to be abstract, since:
-it has 4 unimplemented members.
-/** As seen from class C, the missing signatures are as follows.
- *  For convenience, these are usable as stub implementations.
- */
+t2213.scala:9: error: class C needs to be abstract.
+Missing implementations for 4 members. Stub implementations follow:
   def f: Int = ???
   def g: Int = ???
   val x: Int = ???
@@ -10,11 +7,8 @@ it has 4 unimplemented members.
 
 class C extends A {}
       ^
-t2213.scala:11: error: object creation impossible, since:
-it has 4 unimplemented members.
-/** As seen from object Q, the missing signatures are as follows.
- *  For convenience, these are usable as stub implementations.
- */
+t2213.scala:11: error: object creation impossible.
+Missing implementations for 4 members. Stub implementations follow:
   def f: Int = ???
   def g: Int = ???
   val x: Int = ???

--- a/test/files/neg/t2497.check
+++ b/test/files/neg/t2497.check
@@ -1,0 +1,6 @@
+t2497.scala:21: error: cannot override a concrete member without a third member that's overridden by both (this rule is designed to prevent ``accidental overrides'')
+def eval: Int (defined in class Foo)
+  with absoverride def eval: Int (defined in trait DebugNode)
+  (new Foo with DebugNode).eval
+       ^
+one error found

--- a/test/files/neg/t2497.scala
+++ b/test/files/neg/t2497.scala
@@ -1,0 +1,22 @@
+trait Node { def eval: Int }
+
+trait DebugNode extends Node {
+  abstract override def eval: Int = {
+    println("before")
+    val res = super.eval
+    println("res= "+res)
+    res
+  }
+}
+
+class Var extends Node { def eval = 42 }
+class Foo { def eval = 42 }
+
+class C {
+  // typechecks, correct
+  (new Var with DebugNode).eval
+
+  // should *not* typecheck but does!
+  // Foo.eval does not override Node.eval, but typechecker accepts this anyway
+  (new Foo with DebugNode).eval
+}

--- a/test/files/neg/t2497b.check
+++ b/test/files/neg/t2497b.check
@@ -1,0 +1,6 @@
+t2497b.scala:6: error: cannot override a concrete member without a third member that's overridden by both (this rule is designed to prevent ``accidental overrides'')
+def f: Int (defined in trait B)
+  with override def f: Int (defined in trait AAA)
+class C extends B with AAA
+      ^
+one error found

--- a/test/files/neg/t2497b.scala
+++ b/test/files/neg/t2497b.scala
@@ -1,0 +1,6 @@
+// from https://github.com/scala/scala/pull/7439#issuecomment-470101184
+trait A { def f: Int }
+trait AA extends A { def f = -1 }
+trait AAA extends A { override def f = 1 }
+trait B { def f = -1 }
+class C extends B with AAA

--- a/test/files/neg/t276.check
+++ b/test/files/neg/t276.check
@@ -1,5 +1,5 @@
-t276.scala:6: error: overriding type Bar in class Foo, which equals (Int, Int);
-  class Bar cannot be used here - classes can only override abstract types
+t276.scala:6: error: classes can only override abstract types; cannot override:
+type Bar = (Int, Int) (defined in class Foo)
   class Bar
         ^
 one error found

--- a/test/files/neg/t3854.check
+++ b/test/files/neg/t3854.check
@@ -1,4 +1,5 @@
-t3854.scala:1: error: class Bar needs to be abstract, since method foo in trait Foo of type [G[_]](implicit n: N[G,F])X[F] is not defined
+t3854.scala:1: error: class Bar needs to be abstract. Missing implementation for:
+  def foo[G[_]](implicit n: N[G,F]): X[F] // inherited from trait Foo
 (Note that N[G,F] does not match M[G])
 class Bar[F[_]] extends Foo[F] {
       ^

--- a/test/files/neg/t4137.check
+++ b/test/files/neg/t4137.check
@@ -1,9 +1,11 @@
-t4137.scala:9: error: overriding type EPC in trait A, which equals [X1]C[X1];
-  overriding concrete type alias type EPC is not allowed except when equivalent
+t4137.scala:9: error: incompatible type in overriding
+type EPC[X1] = C[X1] (defined in trait A)
+   (Equivalent type required when overriding a type alias.)
   override type EPC = C[T]
                 ^
-t4137.scala:10: error: overriding type EPC2 in trait A, which equals [X1]C[X1];
-  overriding concrete type alias type EPC2 is not allowed except when equivalent
+t4137.scala:10: error: incompatible type in overriding
+type EPC2[X1] = C[X1] (defined in trait A)
+   (Equivalent type required when overriding a type alias.)
   override type EPC2[X1 <: String] = C[X1]
                 ^
 two errors found

--- a/test/files/neg/t4431.check
+++ b/test/files/neg/t4431.check
@@ -1,4 +1,5 @@
-t4431.scala:5: error: class BB needs to be abstract, since there is a deferred declaration of method f which is not implemented in a subclass
+t4431.scala:5: error: class BB needs to be abstract. No implementation found in a subclass for deferred declaration
+def f(): Unit
   class BB extends B { def f (): Unit }
         ^
 t4431.scala:8: error: trait cannot redefine final method from class AnyRef

--- a/test/files/neg/t521.check
+++ b/test/files/neg/t521.check
@@ -1,15 +1,17 @@
-t521.scala:10: error: class PlainFile needs to be abstract, since method path in class AbstractFile of type => String is not defined
+t521.scala:10: error: class PlainFile needs to be abstract. Missing implementation for:
+  def path: String // inherited from class AbstractFile
 class PlainFile(val file : File) extends AbstractFile {}
       ^
-t521.scala:13: error: overriding value file in class PlainFile of type java.io.File;
-  value file needs `override` modifier
+t521.scala:13: error: `override` modifier required to override concrete member:
+val file: java.io.File (defined in class PlainFile)
 final class ZipArchive(val file : File, archive : ZipFile) extends PlainFile(file) {
                            ^
-t521.scala:13: error: class ZipArchive needs to be abstract, since method path in class AbstractFile of type => String is not defined
+t521.scala:13: error: class ZipArchive needs to be abstract. Missing implementation for:
+  def path: String // inherited from class AbstractFile
 final class ZipArchive(val file : File, archive : ZipFile) extends PlainFile(file) {
             ^
-t521.scala:15: error: overriding value path in class VirtualFile of type String;
-  method path needs to be a stable, immutable value
+t521.scala:15: error: stable, immutable value required to override:
+val path: String (defined in class VirtualFile)
     override def path = "";
                  ^
 four errors found

--- a/test/files/neg/t5358.check
+++ b/test/files/neg/t5358.check
@@ -1,6 +1,6 @@
 t5358.scala:3: error: class C inherits conflicting members:
-  method hi in trait A of type => String and
-  method hi in trait B of type => String
+  def hi: String (defined in trait A) and
+  def hi: String (defined in trait B)
   (note: this can be resolved by declaring an `override` in class C.)
 class C extends A with B
       ^

--- a/test/files/neg/t5429.check
+++ b/test/files/neg/t5429.check
@@ -1,49 +1,55 @@
-t5429.scala:20: error: overriding value value in class A of type Int;
-  object value needs `override` modifier
+t5429.scala:20: error: `override` modifier required to override concrete member:
+val value: Int (defined in class A)
   object value      // fail
          ^
-t5429.scala:21: error: overriding lazy value lazyvalue in class A of type Int;
-  object lazyvalue needs `override` modifier
+t5429.scala:21: error: `override` modifier required to override concrete member:
+lazy val lazyvalue: Int (defined in class A)
   object lazyvalue  // fail
          ^
-t5429.scala:22: error: overriding method nullary in class A of type => Int;
-  object nullary needs `override` modifier
+t5429.scala:22: error: `override` modifier required to override concrete member:
+def nullary: Int (defined in class A)
   object nullary    // fail
          ^
-t5429.scala:23: error: overriding method emptyArg in class A of type ()Int;
-  object emptyArg needs `override` modifier
+t5429.scala:23: error: `override` modifier required to override concrete member:
+def emptyArg(): Int (defined in class A)
   object emptyArg   // fail
          ^
-t5429.scala:27: error: overriding value value in class A0 of type Any;
-  object value needs `override` modifier
+t5429.scala:27: error: `override` modifier required to override concrete member:
+val value: Any (defined in class A0)
   object value      // fail
          ^
-t5429.scala:28: error: overriding lazy value lazyvalue in class A0 of type Any;
-  object lazyvalue needs `override` modifier
+t5429.scala:28: error: `override` modifier required to override concrete member:
+lazy val lazyvalue: Any (defined in class A0)
   object lazyvalue  // fail
          ^
-t5429.scala:29: error: overriding method nullary in class A0 of type => Any;
-  object nullary needs `override` modifier
+t5429.scala:29: error: `override` modifier required to override concrete member:
+def nullary: Any (defined in class A0)
   object nullary    // fail
          ^
-t5429.scala:30: error: overriding method emptyArg in class A0 of type ()Any;
-  object emptyArg needs `override` modifier
+t5429.scala:30: error: `override` modifier required to override concrete member:
+def emptyArg(): Any (defined in class A0)
   object emptyArg   // fail
          ^
-t5429.scala:35: error: overriding value value in class A of type Int;
-  object value has incompatible type
+t5429.scala:35: error: incompatible type in overriding
+val value: Int (defined in class A);
+ found   : C.this.value.type
+ required: Int
   override object value     // fail
                   ^
-t5429.scala:36: error: overriding lazy value lazyvalue in class A of type Int;
-  object lazyvalue must be declared lazy to override a concrete lazy value
+t5429.scala:36: error: value must be lazy when overriding concrete lazy value:
+lazy val lazyvalue: Int (defined in class A)
   override object lazyvalue // fail
                   ^
-t5429.scala:37: error: overriding method nullary in class A of type => Int;
-  object nullary has incompatible type
+t5429.scala:37: error: incompatible type in overriding
+def nullary: Int (defined in class A);
+ found   : C.this.nullary.type
+ required: => Int
   override object nullary   // fail
                   ^
-t5429.scala:38: error: overriding method emptyArg in class A of type ()Int;
-  object emptyArg has incompatible type
+t5429.scala:38: error: incompatible type in overriding
+def emptyArg(): Int (defined in class A);
+ found   : C.this.emptyArg.type
+ required: ()Int
   override object emptyArg  // fail
                   ^
 t5429.scala:39: error: object oneArg overrides nothing.
@@ -51,8 +57,8 @@ Note: the super classes of class C contain the following, non final members name
 def oneArg(x: String): Int
   override object oneArg    // fail
                   ^
-t5429.scala:43: error: overriding lazy value lazyvalue in class A0 of type Any;
-  object lazyvalue must be declared lazy to override a concrete lazy value
+t5429.scala:43: error: value must be lazy when overriding concrete lazy value:
+lazy val lazyvalue: Any (defined in class A0)
   override object lazyvalue // !!! this fails, but should succeed (lazy over lazy)
                   ^
 t5429.scala:46: error: object oneArg overrides nothing.
@@ -60,24 +66,24 @@ Note: the super classes of class C0 contain the following, non final members nam
 def oneArg(x: String): Any
   override object oneArg    // fail
                   ^
-t5429.scala:50: error: overriding value value in class A of type Int;
-  value value needs `override` modifier
+t5429.scala:50: error: `override` modifier required to override concrete member:
+val value: Int (defined in class A)
   val value = 0       // fail
       ^
-t5429.scala:51: error: overriding lazy value lazyvalue in class A of type Int;
-  value lazyvalue needs `override` modifier
+t5429.scala:51: error: `override` modifier required to override concrete member:
+lazy val lazyvalue: Int (defined in class A)
   val lazyvalue = 0   // fail
       ^
-t5429.scala:52: error: overriding method nullary in class A of type => Int;
-  value nullary needs `override` modifier
+t5429.scala:52: error: `override` modifier required to override concrete member:
+def nullary: Int (defined in class A)
   val nullary = 5     // fail
       ^
-t5429.scala:53: error: overriding method emptyArg in class A of type ()Int;
-  value emptyArg needs `override` modifier
+t5429.scala:53: error: `override` modifier required to override concrete member:
+def emptyArg(): Int (defined in class A)
   val emptyArg = 10   // fail
       ^
-t5429.scala:58: error: overriding lazy value lazyvalue in class A0 of type Any;
-  value lazyvalue must be declared lazy to override a concrete lazy value
+t5429.scala:58: error: value must be lazy when overriding concrete lazy value:
+lazy val lazyvalue: Any (defined in class A0)
   override val lazyvalue = 0  // fail (non-lazy)
                ^
 t5429.scala:61: error: value oneArg overrides nothing.
@@ -85,28 +91,28 @@ Note: the super classes of class D0 contain the following, non final members nam
 def oneArg(x: String): Any
   override val oneArg = 15    // fail
                ^
-t5429.scala:65: error: overriding value value in class A of type Int;
-  method value needs `override` modifier
+t5429.scala:65: error: `override` modifier required to override concrete member:
+val value: Int (defined in class A)
   def value = 0       // fail
       ^
-t5429.scala:66: error: overriding lazy value lazyvalue in class A of type Int;
-  method lazyvalue needs `override` modifier
+t5429.scala:66: error: `override` modifier required to override concrete member:
+lazy val lazyvalue: Int (defined in class A)
   def lazyvalue = 2   // fail
       ^
-t5429.scala:67: error: overriding method nullary in class A of type => Int;
-  method nullary needs `override` modifier
+t5429.scala:67: error: `override` modifier required to override concrete member:
+def nullary: Int (defined in class A)
   def nullary = 5     // fail
       ^
-t5429.scala:68: error: overriding method emptyArg in class A of type ()Int;
-  method emptyArg needs `override` modifier
+t5429.scala:68: error: `override` modifier required to override concrete member:
+def emptyArg(): Int (defined in class A)
   def emptyArg = 10   // fail
       ^
-t5429.scala:72: error: overriding value value in class A0 of type Any;
-  method value needs to be a stable, immutable value
+t5429.scala:72: error: stable, immutable value required to override:
+val value: Any (defined in class A0)
   override def value = 0      // fail
                ^
-t5429.scala:73: error: overriding lazy value lazyvalue in class A0 of type Any;
-  method lazyvalue needs to be a stable, immutable value
+t5429.scala:73: error: stable, immutable value required to override:
+lazy val lazyvalue: Any (defined in class A0)
   override def lazyvalue = 2  // fail
                ^
 t5429.scala:76: error: method oneArg overrides nothing.
@@ -114,24 +120,24 @@ Note: the super classes of class E0 contain the following, non final members nam
 def oneArg(x: String): Any
   override def oneArg = 15    // fail
                ^
-t5429.scala:80: error: overriding value value in class A of type Int;
-  lazy value value needs `override` modifier
+t5429.scala:80: error: `override` modifier required to override concrete member:
+val value: Int (defined in class A)
   lazy val value = 0       // fail
            ^
-t5429.scala:81: error: overriding lazy value lazyvalue in class A of type Int;
-  lazy value lazyvalue needs `override` modifier
+t5429.scala:81: error: `override` modifier required to override concrete member:
+lazy val lazyvalue: Int (defined in class A)
   lazy val lazyvalue = 2   // fail
            ^
-t5429.scala:82: error: overriding method nullary in class A of type => Int;
-  lazy value nullary needs `override` modifier
+t5429.scala:82: error: `override` modifier required to override concrete member:
+def nullary: Int (defined in class A)
   lazy val nullary = 5     // fail
            ^
-t5429.scala:83: error: overriding method emptyArg in class A of type ()Int;
-  lazy value emptyArg needs `override` modifier
+t5429.scala:83: error: `override` modifier required to override concrete member:
+def emptyArg(): Int (defined in class A)
   lazy val emptyArg = 10   // fail
            ^
-t5429.scala:87: error: overriding value value in class A0 of type Any;
-  lazy value value cannot override a concrete non-lazy value
+t5429.scala:87: error: concrete non-lazy value cannot be overridden:
+val value: Any (defined in class A0)
   override lazy val value = 0      // fail (strict over lazy)
                     ^
 t5429.scala:91: error: lazy value oneArg overrides nothing.

--- a/test/files/neg/t5687.check
+++ b/test/files/neg/t5687.check
@@ -1,8 +1,10 @@
 t5687.scala:4: error: type arguments [T] do not conform to class Template's type parameter bounds [T <: AnyRef]
   type Repr[T]<:Template[T]
                 ^
-t5687.scala:20: error: overriding type Repr in class Template with bounds[T] <: Template[T];
-  type Repr has incompatible type
+t5687.scala:20: error: incompatible type in overriding
+type Repr[T] <: Template[T] (defined in class Template);
+ found   : CurveTemplate[T(in class CurveTemplate)]
+ required: [T(in type Repr)] <: Template[T(in type Repr)]
   type Repr = CurveTemplate[T]
        ^
 two errors found

--- a/test/files/neg/t6013.check
+++ b/test/files/neg/t6013.check
@@ -1,7 +1,9 @@
-DerivedScala.scala:4: error: class C needs to be abstract, since there is a deferred declaration of method foo in class B of type => Int which is not implemented in a subclass
+DerivedScala.scala:4: error: class C needs to be abstract. No implementation found in a subclass for deferred declaration
+def foo: Int (defined in class B)
 class C extends B
       ^
-DerivedScala.scala:7: error: class DerivedScala needs to be abstract, since there is a deferred declaration of method foo in class Abstract of type ()Boolean which is not implemented in a subclass
+DerivedScala.scala:7: error: class DerivedScala needs to be abstract. No implementation found in a subclass for deferred declaration
+def foo(): Boolean (defined in class Abstract)
 class DerivedScala extends Abstract
       ^
 two errors found

--- a/test/files/neg/t630.check
+++ b/test/files/neg/t630.check
@@ -1,5 +1,7 @@
-t630.scala:20: error: overriding value foo in trait Bar of type Req2;
-  object foo has incompatible type
+t630.scala:20: error: incompatible type in overriding
+val foo: Req2 (defined in trait Bar);
+ found   : Test.foo.type
+ required: Req2
         object foo extends Req1
                ^
 one error found

--- a/test/files/neg/t708.check
+++ b/test/files/neg/t708.check
@@ -1,5 +1,7 @@
-t708.scala:8: error: overriding type S in trait X with bounds <: A.this.T;
-  type S has incompatible type
+t708.scala:8: error: incompatible type in overriding
+private[trait A] type S <: A.this.T (defined in trait X);
+ found   : Any
+ required:  <: A.this.T
     override private[A] type S = Any;
                              ^
 one error found

--- a/test/files/neg/t8143a.check
+++ b/test/files/neg/t8143a.check
@@ -1,5 +1,6 @@
-t8143a.scala:2: error: overriding method f in class Foo of type => Int;
-  method f has weaker access privileges; it should not be private
+t8143a.scala:2: error: weaker access privileges in overriding
+def f: Int (defined in class Foo)
+  override should not be private
 class Bar extends Foo { private def f = 10 }
                                     ^
 one error found

--- a/test/files/neg/t856.check
+++ b/test/files/neg/t856.check
@@ -1,8 +1,5 @@
-t856.scala:3: error: class ComplexRect needs to be abstract, since:
-it has 2 unimplemented members.
-/** As seen from class ComplexRect, the missing signatures are as follows.
- *  For convenience, these are usable as stub implementations.
- */
+t856.scala:3: error: class ComplexRect needs to be abstract.
+Missing implementations for 2 members. Stub implementations follow:
   // Members declared in scala.Equals
   def canEqual(that: Any): Boolean = ???
 

--- a/test/files/neg/t9138.check
+++ b/test/files/neg/t9138.check
@@ -1,15 +1,19 @@
-t9138.scala:9: error: class D needs to be abstract, since method f in class C of type (t: B)(s: String)B is not defined
+t9138.scala:9: error: class D needs to be abstract. Missing implementation for:
+  def f(t: B)(s: String): B // inherited from class C
 (Note that String does not match Int)
 class D extends C[B] {
       ^
-t9138.scala:19: error: object creation impossible, since method foo in trait Base of type (a: String)(b: Int)Nothing is not defined
+t9138.scala:19: error: object creation impossible. Missing implementation for:
+  def foo(a: String)(b: Int): Nothing // inherited from trait Base
 object Derived extends Base[String] {
        ^
-t9138.scala:29: error: class DDD needs to be abstract, since method f in class CCC of type (t: B, s: String)B is not defined
+t9138.scala:29: error: class DDD needs to be abstract. Missing implementation for:
+  def f(t: B, s: String): B // inherited from class CCC
 (Note that T does not match Int)
 class DDD extends CCC[B] {
       ^
-t9138.scala:43: error: object creation impossible, since method create in trait Model of type (conditionalParams: ImplementingParamTrait)(implicit d: Double)Int is not defined
+t9138.scala:43: error: object creation impossible. Missing implementation for:
+  def create(conditionalParams: ImplementingParamTrait)(implicit d: Double): Int // inherited from trait Model
 (overriding member must declare implicit parameter list)
 object Obj extends Model[ImplementingParamTrait] {
        ^

--- a/test/files/neg/tcpoly_variance.check
+++ b/test/files/neg/tcpoly_variance.check
@@ -1,5 +1,7 @@
-tcpoly_variance.scala:6: error: overriding method str in class A of type => m[Object];
-  method str has incompatible type
+tcpoly_variance.scala:6: error: incompatible type in overriding
+def str: m[Object] (defined in class A);
+ found   : => m[String]
+ required: => m[Object]
  override def str: m[String]  = sys.error("foo") // since x in m[x] is invariant, ! m[String] <: m[Object]
               ^
 one error found

--- a/test/files/neg/trait_fields_conflicts.check
+++ b/test/files/neg/trait_fields_conflicts.check
@@ -1,273 +1,273 @@
-trait_fields_conflicts.scala:5: error: overriding value x in trait Val of type Int;
-  value x needs `override` modifier
+trait_fields_conflicts.scala:5: error: `override` modifier required to override concrete member:
+val x: Int (defined in trait Val)
 trait ValForVal extends Val { val x: Int = 1 } // needs override
                                   ^
-trait_fields_conflicts.scala:6: error: overriding value x in trait Val of type Int;
-  variable x needs `override` modifier
+trait_fields_conflicts.scala:6: error: `override` modifier required to override concrete member:
+val x: Int (defined in trait Val)
 trait VarForVal extends Val { var x: Int = 1 } // needs override
                                   ^
-trait_fields_conflicts.scala:7: error: overriding value x in trait Val of type Int;
-  method x needs `override` modifier
+trait_fields_conflicts.scala:7: error: `override` modifier required to override concrete member:
+val x: Int (defined in trait Val)
 trait DefForVal extends Val { def x: Int = 1 } // needs override
                                   ^
-trait_fields_conflicts.scala:8: error: overriding variable x in trait Var of type Int;
-  value x needs `override` modifier
+trait_fields_conflicts.scala:8: error: `override` modifier required to override concrete member:
+def x: Int (defined in trait Var)
 trait ValForVar extends Var { val x: Int = 1 } // needs override
                                   ^
-trait_fields_conflicts.scala:9: error: overriding variable x in trait Var of type Int;
-  variable x needs `override` modifier
+trait_fields_conflicts.scala:9: error: `override` modifier required to override concrete member:
+def x: Int (defined in trait Var)
 trait VarForVar extends Var { var x: Int = 1 } // needs override
                                   ^
-trait_fields_conflicts.scala:10: error: overriding variable x in trait Var of type Int;
-  method x needs `override` modifier
+trait_fields_conflicts.scala:10: error: `override` modifier required to override concrete member:
+def x: Int (defined in trait Var)
 trait DefForVar extends Var { def x: Int = 1 } // needs override
                                   ^
-trait_fields_conflicts.scala:11: error: overriding lazy value x in trait Lazy of type Int;
-  value x needs `override` modifier
+trait_fields_conflicts.scala:11: error: `override` modifier required to override concrete member:
+lazy val x: Int (defined in trait Lazy)
 trait ValForLazy extends Lazy { val x: Int = 1 } // needs override
                                     ^
-trait_fields_conflicts.scala:12: error: overriding lazy value x in trait Lazy of type Int;
-  variable x needs `override` modifier
+trait_fields_conflicts.scala:12: error: `override` modifier required to override concrete member:
+lazy val x: Int (defined in trait Lazy)
 trait VarForLazy extends Lazy { var x: Int = 1 } // needs override
                                     ^
-trait_fields_conflicts.scala:13: error: overriding lazy value x in trait Lazy of type Int;
-  method x needs `override` modifier
+trait_fields_conflicts.scala:13: error: `override` modifier required to override concrete member:
+lazy val x: Int (defined in trait Lazy)
 trait DefForLazy extends Lazy { def x: Int = 1 } // needs override
                                     ^
-trait_fields_conflicts.scala:16: error: overriding value x in trait Val of type Int;
-  variable x needs to be a stable, immutable value
+trait_fields_conflicts.scala:16: error: stable, immutable value required to override:
+val x: Int (defined in trait Val)
 trait VarForValOvr extends Val { override var x: Int = 1 } // bad override
                                               ^
-trait_fields_conflicts.scala:17: error: overriding value x in trait Val of type Int;
-  method x needs to be a stable, immutable value
+trait_fields_conflicts.scala:17: error: stable, immutable value required to override:
+val x: Int (defined in trait Val)
 trait DefForValOvr extends Val { override def x: Int = 1 } // bad override
                                               ^
-trait_fields_conflicts.scala:18: error: overriding variable x in trait Var of type Int;
-  value x cannot override a mutable variable
+trait_fields_conflicts.scala:18: error: mutable variable cannot be overridden:
+def x: Int (defined in trait Var)
 trait ValForVarOvr extends Var { override val x: Int = 1 } // bad override -- unsound if used in path and var changes
                                               ^
-trait_fields_conflicts.scala:19: error: overriding variable x in trait Var of type Int;
-  variable x cannot override a mutable variable
+trait_fields_conflicts.scala:19: error: mutable variable cannot be overridden:
+def x: Int (defined in trait Var)
 trait VarForVarOvr extends Var { override var x: Int = 1 } // bad override -- why?
                                               ^
-trait_fields_conflicts.scala:20: error: overriding variable x in trait Var of type Int;
-  method x cannot override a mutable variable
+trait_fields_conflicts.scala:20: error: mutable variable cannot be overridden:
+def x: Int (defined in trait Var)
 trait DefForVarOvr extends Var { override def x: Int = 1 } // bad override -- why?
                                               ^
-trait_fields_conflicts.scala:21: error: overriding lazy value x in trait Lazy of type Int;
-  value x must be declared lazy to override a concrete lazy value
+trait_fields_conflicts.scala:21: error: value must be lazy when overriding concrete lazy value:
+lazy val x: Int (defined in trait Lazy)
 trait ValForLazyOvr extends Lazy { override val x: Int = 1 } // bad override -- why?
                                                 ^
-trait_fields_conflicts.scala:22: error: overriding lazy value x in trait Lazy of type Int;
-  variable x needs to be a stable, immutable value
+trait_fields_conflicts.scala:22: error: stable, immutable value required to override:
+lazy val x: Int (defined in trait Lazy)
 trait VarForLazyOvr extends Lazy { override var x: Int = 1 } // bad override -- why?
                                                 ^
-trait_fields_conflicts.scala:23: error: overriding lazy value x in trait Lazy of type Int;
-  method x needs to be a stable, immutable value
+trait_fields_conflicts.scala:23: error: stable, immutable value required to override:
+lazy val x: Int (defined in trait Lazy)
 trait DefForLazyOvr extends Lazy { override def x: Int = 1 } // bad override -- why?
                                                 ^
-trait_fields_conflicts.scala:25: error: overriding value x in trait Val of type Int;
-  value x needs `override` modifier
+trait_fields_conflicts.scala:25: error: `override` modifier required to override concrete member:
+val x: Int (defined in trait Val)
 class CValForVal extends Val { val x: Int = 1 } // needs override
                                    ^
-trait_fields_conflicts.scala:26: error: overriding value x in trait Val of type Int;
-  variable x needs `override` modifier
+trait_fields_conflicts.scala:26: error: `override` modifier required to override concrete member:
+val x: Int (defined in trait Val)
 class CVarForVal extends Val { var x: Int = 1 } // needs override
                                    ^
-trait_fields_conflicts.scala:27: error: overriding value x in trait Val of type Int;
-  method x needs `override` modifier
+trait_fields_conflicts.scala:27: error: `override` modifier required to override concrete member:
+val x: Int (defined in trait Val)
 class CDefForVal extends Val { def x: Int = 1 } // needs override
                                    ^
-trait_fields_conflicts.scala:28: error: overriding variable x in trait Var of type Int;
-  value x needs `override` modifier
+trait_fields_conflicts.scala:28: error: `override` modifier required to override concrete member:
+def x: Int (defined in trait Var)
 class CValForVar extends Var { val x: Int = 1 } // needs override
                                    ^
-trait_fields_conflicts.scala:29: error: overriding variable x in trait Var of type Int;
-  variable x needs `override` modifier
+trait_fields_conflicts.scala:29: error: `override` modifier required to override concrete member:
+def x: Int (defined in trait Var)
 class CVarForVar extends Var { var x: Int = 1 } // needs override
                                    ^
-trait_fields_conflicts.scala:30: error: overriding variable x in trait Var of type Int;
-  method x needs `override` modifier
+trait_fields_conflicts.scala:30: error: `override` modifier required to override concrete member:
+def x: Int (defined in trait Var)
 class CDefForVar extends Var { def x: Int = 1 } // needs override
                                    ^
-trait_fields_conflicts.scala:31: error: overriding lazy value x in trait Lazy of type Int;
-  value x needs `override` modifier
+trait_fields_conflicts.scala:31: error: `override` modifier required to override concrete member:
+lazy val x: Int (defined in trait Lazy)
 class CValForLazy extends Lazy { val x: Int = 1 } // needs override
                                      ^
-trait_fields_conflicts.scala:32: error: overriding lazy value x in trait Lazy of type Int;
-  variable x needs `override` modifier
+trait_fields_conflicts.scala:32: error: `override` modifier required to override concrete member:
+lazy val x: Int (defined in trait Lazy)
 class CVarForLazy extends Lazy { var x: Int = 1 } // needs override
                                      ^
-trait_fields_conflicts.scala:33: error: overriding lazy value x in trait Lazy of type Int;
-  method x needs `override` modifier
+trait_fields_conflicts.scala:33: error: `override` modifier required to override concrete member:
+lazy val x: Int (defined in trait Lazy)
 class CDefForLazy extends Lazy { def x: Int = 1 } // needs override
                                      ^
-trait_fields_conflicts.scala:36: error: overriding value x in trait Val of type Int;
-  variable x needs to be a stable, immutable value
+trait_fields_conflicts.scala:36: error: stable, immutable value required to override:
+val x: Int (defined in trait Val)
 class CVarForValOvr extends Val { override var x: Int = 1 } // bad override
                                                ^
-trait_fields_conflicts.scala:37: error: overriding value x in trait Val of type Int;
-  method x needs to be a stable, immutable value
+trait_fields_conflicts.scala:37: error: stable, immutable value required to override:
+val x: Int (defined in trait Val)
 class CDefForValOvr extends Val { override def x: Int = 1 } // bad override
                                                ^
-trait_fields_conflicts.scala:38: error: overriding variable x in trait Var of type Int;
-  value x cannot override a mutable variable
+trait_fields_conflicts.scala:38: error: mutable variable cannot be overridden:
+def x: Int (defined in trait Var)
 class CValForVarOvr extends Var { override val x: Int = 1 } // bad override -- unsound if used in path and var changes
                                                ^
-trait_fields_conflicts.scala:39: error: overriding variable x in trait Var of type Int;
-  variable x cannot override a mutable variable
+trait_fields_conflicts.scala:39: error: mutable variable cannot be overridden:
+def x: Int (defined in trait Var)
 class CVarForVarOvr extends Var { override var x: Int = 1 } // bad override -- why?
                                                ^
-trait_fields_conflicts.scala:40: error: overriding variable x in trait Var of type Int;
-  method x cannot override a mutable variable
+trait_fields_conflicts.scala:40: error: mutable variable cannot be overridden:
+def x: Int (defined in trait Var)
 class CDefForVarOvr extends Var { override def x: Int = 1 } // bad override -- why?
                                                ^
-trait_fields_conflicts.scala:41: error: overriding lazy value x in trait Lazy of type Int;
-  value x must be declared lazy to override a concrete lazy value
+trait_fields_conflicts.scala:41: error: value must be lazy when overriding concrete lazy value:
+lazy val x: Int (defined in trait Lazy)
 class CValForLazyOvr extends Lazy { override val x: Int = 1 } // bad override -- why?
                                                  ^
-trait_fields_conflicts.scala:42: error: overriding lazy value x in trait Lazy of type Int;
-  variable x needs to be a stable, immutable value
+trait_fields_conflicts.scala:42: error: stable, immutable value required to override:
+lazy val x: Int (defined in trait Lazy)
 class CVarForLazyOvr extends Lazy { override var x: Int = 1 } // bad override -- why?
                                                  ^
-trait_fields_conflicts.scala:43: error: overriding lazy value x in trait Lazy of type Int;
-  method x needs to be a stable, immutable value
+trait_fields_conflicts.scala:43: error: stable, immutable value required to override:
+lazy val x: Int (defined in trait Lazy)
 class CDefForLazyOvr extends Lazy { override def x: Int = 1 } // bad override -- why?
                                                  ^
-trait_fields_conflicts.scala:49: error: overriding value x in class CVal of type Int;
-  value x needs `override` modifier
+trait_fields_conflicts.scala:49: error: `override` modifier required to override concrete member:
+val x: Int (defined in class CVal)
 trait ValForCVal extends CVal { val x: Int = 1 } // needs override
                                     ^
-trait_fields_conflicts.scala:50: error: overriding value x in class CVal of type Int;
-  variable x needs `override` modifier
+trait_fields_conflicts.scala:50: error: `override` modifier required to override concrete member:
+val x: Int (defined in class CVal)
 trait VarForCVal extends CVal { var x: Int = 1 } // needs override
                                     ^
-trait_fields_conflicts.scala:51: error: overriding value x in class CVal of type Int;
-  method x needs `override` modifier
+trait_fields_conflicts.scala:51: error: `override` modifier required to override concrete member:
+val x: Int (defined in class CVal)
 trait DefForCVal extends CVal { def x: Int = 1 } // needs override
                                     ^
-trait_fields_conflicts.scala:52: error: overriding variable x in class CVar of type Int;
-  value x needs `override` modifier
+trait_fields_conflicts.scala:52: error: `override` modifier required to override concrete member:
+def x: Int (defined in class CVar)
 trait ValForCVar extends CVar { val x: Int = 1 } // needs override
                                     ^
-trait_fields_conflicts.scala:53: error: overriding variable x in class CVar of type Int;
-  variable x needs `override` modifier
+trait_fields_conflicts.scala:53: error: `override` modifier required to override concrete member:
+def x: Int (defined in class CVar)
 trait VarForCVar extends CVar { var x: Int = 1 } // needs override
                                     ^
-trait_fields_conflicts.scala:54: error: overriding variable x in class CVar of type Int;
-  method x needs `override` modifier
+trait_fields_conflicts.scala:54: error: `override` modifier required to override concrete member:
+def x: Int (defined in class CVar)
 trait DefForCVar extends CVar { def x: Int = 1 } // needs override
                                     ^
-trait_fields_conflicts.scala:55: error: overriding lazy value x in class CLazy of type Int;
-  value x needs `override` modifier
+trait_fields_conflicts.scala:55: error: `override` modifier required to override concrete member:
+lazy val x: Int (defined in class CLazy)
 trait ValForCLazy extends CLazy { val x: Int = 1 } // needs override
                                       ^
-trait_fields_conflicts.scala:56: error: overriding lazy value x in class CLazy of type Int;
-  variable x needs `override` modifier
+trait_fields_conflicts.scala:56: error: `override` modifier required to override concrete member:
+lazy val x: Int (defined in class CLazy)
 trait VarForCLazy extends CLazy { var x: Int = 1 } // needs override
                                       ^
-trait_fields_conflicts.scala:57: error: overriding lazy value x in class CLazy of type Int;
-  method x needs `override` modifier
+trait_fields_conflicts.scala:57: error: `override` modifier required to override concrete member:
+lazy val x: Int (defined in class CLazy)
 trait DefForCLazy extends CLazy { def x: Int = 1 } // needs override
                                       ^
-trait_fields_conflicts.scala:60: error: overriding value x in class CVal of type Int;
-  variable x needs to be a stable, immutable value
+trait_fields_conflicts.scala:60: error: stable, immutable value required to override:
+val x: Int (defined in class CVal)
 trait VarForCValOvr extends CVal { override var x: Int = 1 } // bad override
                                                 ^
-trait_fields_conflicts.scala:61: error: overriding value x in class CVal of type Int;
-  method x needs to be a stable, immutable value
+trait_fields_conflicts.scala:61: error: stable, immutable value required to override:
+val x: Int (defined in class CVal)
 trait DefForCValOvr extends CVal { override def x: Int = 1 } // bad override
                                                 ^
-trait_fields_conflicts.scala:62: error: overriding variable x in class CVar of type Int;
-  value x cannot override a mutable variable
+trait_fields_conflicts.scala:62: error: mutable variable cannot be overridden:
+def x: Int (defined in class CVar)
 trait ValForCVarOvr extends CVar { override val x: Int = 1 } // bad override -- unsound if used in path and var changes
                                                 ^
-trait_fields_conflicts.scala:63: error: overriding variable x in class CVar of type Int;
-  variable x cannot override a mutable variable
+trait_fields_conflicts.scala:63: error: mutable variable cannot be overridden:
+def x: Int (defined in class CVar)
 trait VarForCVarOvr extends CVar { override var x: Int = 1 } // bad override -- why?
                                                 ^
-trait_fields_conflicts.scala:64: error: overriding variable x in class CVar of type Int;
-  method x cannot override a mutable variable
+trait_fields_conflicts.scala:64: error: mutable variable cannot be overridden:
+def x: Int (defined in class CVar)
 trait DefForCVarOvr extends CVar { override def x: Int = 1 } // bad override -- why?
                                                 ^
-trait_fields_conflicts.scala:65: error: overriding lazy value x in class CLazy of type Int;
-  value x must be declared lazy to override a concrete lazy value
+trait_fields_conflicts.scala:65: error: value must be lazy when overriding concrete lazy value:
+lazy val x: Int (defined in class CLazy)
 trait ValForCLazyOvr extends CLazy { override val x: Int = 1 } // bad override -- why?
                                                   ^
-trait_fields_conflicts.scala:66: error: overriding lazy value x in class CLazy of type Int;
-  variable x needs to be a stable, immutable value
+trait_fields_conflicts.scala:66: error: stable, immutable value required to override:
+lazy val x: Int (defined in class CLazy)
 trait VarForCLazyOvr extends CLazy { override var x: Int = 1 } // bad override -- why?
                                                   ^
-trait_fields_conflicts.scala:67: error: overriding lazy value x in class CLazy of type Int;
-  method x needs to be a stable, immutable value
+trait_fields_conflicts.scala:67: error: stable, immutable value required to override:
+lazy val x: Int (defined in class CLazy)
 trait DefForCLazyOvr extends CLazy { override def x: Int = 1 } // bad override -- why?
                                                   ^
-trait_fields_conflicts.scala:69: error: overriding value x in class CVal of type Int;
-  value x needs `override` modifier
+trait_fields_conflicts.scala:69: error: `override` modifier required to override concrete member:
+val x: Int (defined in class CVal)
 class CValForCVal extends CVal { val x: Int = 1 } // needs override
                                      ^
-trait_fields_conflicts.scala:70: error: overriding value x in class CVal of type Int;
-  variable x needs `override` modifier
+trait_fields_conflicts.scala:70: error: `override` modifier required to override concrete member:
+val x: Int (defined in class CVal)
 class CVarForCVal extends CVal { var x: Int = 1 } // needs override
                                      ^
-trait_fields_conflicts.scala:71: error: overriding value x in class CVal of type Int;
-  method x needs `override` modifier
+trait_fields_conflicts.scala:71: error: `override` modifier required to override concrete member:
+val x: Int (defined in class CVal)
 class CDefForCVal extends CVal { def x: Int = 1 } // needs override
                                      ^
-trait_fields_conflicts.scala:72: error: overriding variable x in class CVar of type Int;
-  value x needs `override` modifier
+trait_fields_conflicts.scala:72: error: `override` modifier required to override concrete member:
+def x: Int (defined in class CVar)
 class CValForCVar extends CVar { val x: Int = 1 } // needs override
                                      ^
-trait_fields_conflicts.scala:73: error: overriding variable x in class CVar of type Int;
-  variable x needs `override` modifier
+trait_fields_conflicts.scala:73: error: `override` modifier required to override concrete member:
+def x: Int (defined in class CVar)
 class CVarForCVar extends CVar { var x: Int = 1 } // needs override
                                      ^
-trait_fields_conflicts.scala:74: error: overriding variable x in class CVar of type Int;
-  method x needs `override` modifier
+trait_fields_conflicts.scala:74: error: `override` modifier required to override concrete member:
+def x: Int (defined in class CVar)
 class CDefForCVar extends CVar { def x: Int = 1 } // needs override
                                      ^
-trait_fields_conflicts.scala:75: error: overriding lazy value x in class CLazy of type Int;
-  value x needs `override` modifier
+trait_fields_conflicts.scala:75: error: `override` modifier required to override concrete member:
+lazy val x: Int (defined in class CLazy)
 class CValForCLazy extends CLazy { val x: Int = 1 } // needs override
                                        ^
-trait_fields_conflicts.scala:76: error: overriding lazy value x in class CLazy of type Int;
-  variable x needs `override` modifier
+trait_fields_conflicts.scala:76: error: `override` modifier required to override concrete member:
+lazy val x: Int (defined in class CLazy)
 class CVarForCLazy extends CLazy { var x: Int = 1 } // needs override
                                        ^
-trait_fields_conflicts.scala:77: error: overriding lazy value x in class CLazy of type Int;
-  method x needs `override` modifier
+trait_fields_conflicts.scala:77: error: `override` modifier required to override concrete member:
+lazy val x: Int (defined in class CLazy)
 class CDefForCLazy extends CLazy { def x: Int = 1 } // needs override
                                        ^
-trait_fields_conflicts.scala:80: error: overriding value x in class CVal of type Int;
-  variable x needs to be a stable, immutable value
+trait_fields_conflicts.scala:80: error: stable, immutable value required to override:
+val x: Int (defined in class CVal)
 class CVarForCValOvr extends CVal { override var x: Int = 1 } // bad override
                                                  ^
-trait_fields_conflicts.scala:81: error: overriding value x in class CVal of type Int;
-  method x needs to be a stable, immutable value
+trait_fields_conflicts.scala:81: error: stable, immutable value required to override:
+val x: Int (defined in class CVal)
 class CDefForCValOvr extends CVal { override def x: Int = 1 } // bad override
                                                  ^
-trait_fields_conflicts.scala:82: error: overriding variable x in class CVar of type Int;
-  value x cannot override a mutable variable
+trait_fields_conflicts.scala:82: error: mutable variable cannot be overridden:
+def x: Int (defined in class CVar)
 class CValForCVarOvr extends CVar { override val x: Int = 1 } // bad override -- unsound if used in path and var changes
                                                  ^
-trait_fields_conflicts.scala:83: error: overriding variable x in class CVar of type Int;
-  variable x cannot override a mutable variable
+trait_fields_conflicts.scala:83: error: mutable variable cannot be overridden:
+def x: Int (defined in class CVar)
 class CVarForCVarOvr extends CVar { override var x: Int = 1 } // bad override -- why?
                                                  ^
-trait_fields_conflicts.scala:84: error: overriding variable x in class CVar of type Int;
-  method x cannot override a mutable variable
+trait_fields_conflicts.scala:84: error: mutable variable cannot be overridden:
+def x: Int (defined in class CVar)
 class CDefForCVarOvr extends CVar { override def x: Int = 1 } // bad override -- why?
                                                  ^
-trait_fields_conflicts.scala:85: error: overriding lazy value x in class CLazy of type Int;
-  value x must be declared lazy to override a concrete lazy value
+trait_fields_conflicts.scala:85: error: value must be lazy when overriding concrete lazy value:
+lazy val x: Int (defined in class CLazy)
 class CValForCLazyOvr extends CLazy { override val x: Int = 1 } // bad override -- why?
                                                    ^
-trait_fields_conflicts.scala:86: error: overriding lazy value x in class CLazy of type Int;
-  variable x needs to be a stable, immutable value
+trait_fields_conflicts.scala:86: error: stable, immutable value required to override:
+lazy val x: Int (defined in class CLazy)
 class CVarForCLazyOvr extends CLazy { override var x: Int = 1 } // bad override -- why?
                                                    ^
-trait_fields_conflicts.scala:87: error: overriding lazy value x in class CLazy of type Int;
-  method x needs to be a stable, immutable value
+trait_fields_conflicts.scala:87: error: stable, immutable value required to override:
+lazy val x: Int (defined in class CLazy)
 class CDefForCLazyOvr extends CLazy { override def x: Int = 1 } // bad override -- why?
                                                    ^
 68 errors found

--- a/test/files/neg/trait_fields_var_override.check
+++ b/test/files/neg/trait_fields_var_override.check
@@ -1,5 +1,5 @@
-trait_fields_var_override.scala:2: error: overriding variable end in trait SizeChangeEvent of type Int;
-  variable end cannot override a mutable variable
+trait_fields_var_override.scala:2: error: mutable variable cannot be overridden:
+protected def end: Int (defined in trait SizeChangeEvent)
 class BackedUpListIterator[E](override protected var end: Int) extends SizeChangeEvent
                                                      ^
 one error found

--- a/test/files/neg/volatile_no_override.check
+++ b/test/files/neg/volatile_no_override.check
@@ -1,5 +1,5 @@
-volatile_no_override.scala:13: error: overriding value x in class A of type Volatile.this.D;
-  value x has a volatile type; cannot override a member with non-volatile type
+volatile_no_override.scala:13: error: member with volatile type cannot override member with non-volatile type:
+val x: Volatile.this.D (defined in class A)
   val x: A with D = null
       ^
 one error found

--- a/test/files/pos/t11136/Maps.java
+++ b/test/files/pos/t11136/Maps.java
@@ -1,0 +1,14 @@
+interface Map<K, V> {
+    default V getOrDefault(Object key, V defaultValue) {
+        return null;
+    }
+}
+
+interface ConcurrentMap<K, V> extends Map<K, V> {
+    @Override
+    default V getOrDefault(Object key, V defaultValue) {
+        return null;
+    }
+}
+
+// class ConcurrentMapWrapper<K, V> implements Map<K, V>, ConcurrentMap<K, V> {  }

--- a/test/files/pos/t11136/Test.scala
+++ b/test/files/pos/t11136/Test.scala
@@ -1,0 +1,1 @@
+class ConcurrentMapWrapper[K, V] extends Map[K, V] with ConcurrentMap[K, V]

--- a/test/files/run/StubErrorTypeDef.check
+++ b/test/files/run/StubErrorTypeDef.check
@@ -1,5 +1,7 @@
-error: newSource1.scala:4: overriding type D in class B with bounds <: stuberrors.A;
-  type D has incompatible type
+error: newSource1.scala:4: incompatible type in overriding
+type D <: stuberrors.A (defined in class B);
+ found   : stuberrors.E
+ required:  <: stuberrors.A
       new B { type D = E }
                    ^
 error: newSource1.scala:4: Symbol 'type stuberrors.A' is missing from the classpath.

--- a/test/junit/scala/tools/nsc/typechecker/OverridingPairsTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/OverridingPairsTest.scala
@@ -1,0 +1,33 @@
+package scala.tools.nsc.typechecker
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+import scala.tools.testing.BytecodeTesting
+
+class OverridingPairsTest extends BytecodeTesting {
+  override def compilerArgs = "-Ystop-after:typer"
+
+  @Test
+  def overridingPairs_11136(): Unit = {
+    val code =
+      """package p1
+        |trait IO { def c(x: Int): Int = ??? }
+        |trait SO extends IO { override final def c(x: Int): Int = ??? }
+        |trait SOIO extends IO { override def c(x: Int): Int = ??? }
+        |trait SOSO extends SOIO with SO // interloper
+        |abstract class AS extends SO
+        |class L extends AS with SOSO
+      """.stripMargin
+    val run = compiler.newRun
+    run.compileSources(List(BytecodeTesting.makeSourceFile(code, "UnitTestSource.scala")))
+
+    val g = compiler.global
+    val C = g.rootMirror.getRequiredClass("p1.L")
+
+    val opcs = new g.overridingPairs.Cursor(C).iterator.filter(_.low.nameString == "c").map(c => (c.lowString, c.highString)).toList
+
+    assertEquals(List(("override def c(x: Int): Int in trait SOIO", "final override def c(x: Int): Int in trait SO"),
+                      ("override def c(x: Int): Int in trait SOIO", "def c(x: Int): Int in trait IO")), opcs)
+  }
+}


### PR DESCRIPTION
this is true for non-trait classes: the linearisation of a class C contains
as segments the linearisations of its (non-trait) super classes, so we can
just treat those at the lowest point in the hierarchy

this optimization breaks down when considering traits and their linearisations,
as shown in the tests

attempt to fix scala/bug#11136

TODO: 
  - [x] there's actually a second problem in refchecks that allows the neg test to compile currently
  - [x] consider including some of the refactoring i did in my overridingPairs branch
  - [X] check performance
  - [x] see if we can collapse similar warnings (mixing in the same traits will give the same error each time, but which one is canonical?)
  - [x] bytecode diff
  - [x] community build run on 2.12 backport: https://github.com/scala/scala/pull/7746
  - [ ] 2.13 community build run