### PR TITLE
Bug 4612 is already fixed. Add Regression test case.

### DIFF
--- a/test/files/neg/t4612.check
+++ b/test/files/neg/t4612.check
@@ -1,0 +1,6 @@
+t4612.scala:13: error: type mismatch;
+ found   : t4612.this.Bob
+ required: _1
+      def foo = new Bob
+                ^
+one error found

--- a/test/files/neg/t4612.scala
+++ b/test/files/neg/t4612.scala
@@ -1,0 +1,16 @@
+class t4612 {
+
+  trait Ann[A] {
+    def foo: A
+  }
+
+  class Bob extends Ann[Bob] {
+    def foo = new Bob
+
+    trait Cris extends Ann[Cris] {
+      self: Bob =>
+
+      def foo = new Bob
+    }
+  }
+}


### PR DESCRIPTION
Closes https://github.com/scala/bug/issues/4612. 

The Scala Bug 4612 reported a compiler crash error when compiling a (renamed) piece of code, that combined class-trait nesting, inheritance, type parameters, and a self-type annotation. 

I have tested this code in the current Scala 2.12, by using the console Paste-mode. It no longer crashes, but instead gives a type error message (which I think expected).
```
<console>:22: error: type mismatch;
 found   : CyclicReferenceCompilerBug.this.Class
 required: _1
             def foo = new Class
```

I have also checked it against the branch of `2.13.x`, using the `scala` command within the `sbt` build, and pasting the code. It gives thoe same result. 