### PR TITLE
Add Regression test for Scala Bug 7131

### DIFF
--- a/test/files/neg/t7131.check
+++ b/test/files/neg/t7131.check
@@ -1,0 +1,7 @@
+t7131.scala:21: error: type mismatch;
+ found   : Iterable[U]
+ required: That
+ Note: implicit method convertToSimpleMappable is not applicable here because it comes after the application point and it lacks an explicit result type
+        x.value.map(f)
+                   ^
+one error found

--- a/test/files/neg/t7131.flags
+++ b/test/files/neg/t7131.flags
@@ -1,0 +1,1 @@
+-language:higherKinds -language:reflectiveCalls -language:implicitConversions

--- a/test/files/neg/t7131.scala
+++ b/test/files/neg/t7131.scala
@@ -1,0 +1,93 @@
+import collection.generic.CanBuildFrom
+
+// leaving out the observable part
+trait ObservableValue[-T] {
+  def value: T
+}
+
+object ObservableValue {
+
+  //this works as is
+  implicit class SimpleMappable[T](x: ObservableValue[T]) {
+    def map[U](f: T => U) = new ObservableValue[U] {
+      def value = f(x.value)
+    }
+  }
+
+  class TraversableMappable[T, Container[X] <: Traversable[X]](x: ObservableValue[Container[T]]) {
+
+    def map[U, That](f: T => U)(implicit bf: CanBuildFrom[Traversable[T], U, That]): ObservableValue[That] = new ObservableValue[That] {
+      def value: That = {
+        x.value.map(f)
+      }
+    }
+
+  }
+
+  //for some reason using an implicit class does not work
+  implicit def convertToTraversableMappable[T, Container[X] <: Traversable[X]](x: ObservableValue[Container[T]]) =
+    new TraversableMappable(x)
+
+  type HasMap[T, That[_]] = {
+    def map[U](f: T => U): That[U]
+  }
+
+  class NestedMappable[T, Container[X] <: HasMap[X, Container]](x: ObservableValue[Container[T]]) {
+
+    def map[U](f: T => U): ObservableValue[Container[U]] = new ObservableValue[Container[U]] {
+      def value: Container[U] = x.value.map(f)
+    }
+  }
+
+  //for some reason using an implicit class does not work
+  implicit def convertToSimpleMappable[T, Container[X] <: ObservableValue.HasMap[X, Container]](x: ObservableValue[Container[T]]) =
+    new NestedMappable(x)
+
+}
+
+object Main extends App {
+
+  class TestCase extends ObservableValue[Int] {
+    var value: Int = 0
+  }
+
+  val x = new TestCase
+
+  val r = x.map(_ + 1)
+
+  println(r.value) //1
+
+  x.value = 42
+
+  println(r.value) //43
+
+
+  class TestCase1 extends ObservableValue[Option[Int]] {
+    var value: Option[Int] = None
+  }
+
+  val x1 = new TestCase1
+
+  val r1 = x1 map ((x: Int) => x + 1)
+
+  println(r1.value) //None
+
+  x1.value = Some(3)
+
+  println(r1.value) //Some(4)
+
+  class TestCase2 extends ObservableValue[List[Int]] {
+    var value: List[Int] = List()
+  }
+
+  val y = new TestCase2
+
+  val q = y map (_ + 1)
+
+  println(q.value) //List()
+
+  y.value = List(3, 4)
+
+  println(q.value) //List(4, 5)
+
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/7131, in so far as the compiler no longer crashes. 

The program in `t7131.scala` caused the compiler to crash with StackOverflow This has been solved before version 2.13.x and 2.12.7, and the compiler no longer crashes. In This PR adds the program in question, to watch for regressions. We add the compile error generated in the current version. 

Although the compiler no longer crashes, the output is different between versions 2.13.x and 2.12.7. In the latter, it reports one error, on the definition of the `ObservableValue` trait: 
```
t7131.scala:5: error: contravariant type T occurs in covariant position in type => T of method value
  def value: T
```
Instead, current version 2.13.x misses that error, and instead reports the error noted in the `t7131.check` file. This may indicate another compiler bug, since the variance error above should also be reported. Interestingly, when writing that trait into the REPL, the 2.13.x does reject it. 

```
Welcome to Scala 2.13.0-20181116-133635-1f76b24 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_172).

scala> trait Ann[- X]{ def value: X}
                           ^
       error: contravariant type X occurs in covariant position in type => X of method value
```