### PR TITLE
Adds Regression for Scala Bug 8583

### DIFF
--- a/test/files/pos/t8583.flags
+++ b/test/files/pos/t8583.flags
@@ -1,0 +1,1 @@
+-language:implicitConversions

--- a/test/files/pos/t8583.scala
+++ b/test/files/pos/t8583.scala
@@ -1,0 +1,11 @@
+class t8583 {
+
+  case class A( value: Double ) {
+    def *( o: A ) = A( value * o.value )
+  }
+
+  implicit def doubleToA( d: Double ) = A( d )
+  implicit def listToA( in: List[A] ): A = in.head
+
+  val result: A = List( A( 1 ) ) map { 2.0 * _ } //this line causes the compiler to crash
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/8583

That bug was reporting a `NullPointerException` when compiling a code example with implicit conversions. This error had transformed into a `MatchError` in the later versions of Scala 2.12 and early milestones of 2.13, and it has already been solved at Milestone 4 of version 2.13.

This commit adds the example code from that test, to test for regressions.