### PR TITLE
LinearSeq extension problem solved

### DIFF
--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -37,7 +37,7 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeq
 
   def iterator: Iterator[A] =
     if (knownSize == 0) Iterator.empty
-    else new LinearSeqIterator[A](toSeq)
+    else new LinearSeqIterator[A](this)
 
   def length: Int = {
     var these = coll
@@ -216,9 +216,9 @@ trait StrictOptimizedLinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]
 /** A specialized Iterator for LinearSeqs that is lazy enough for Stream and LazyList. This is accomplished by not
   * evaluating the tail after returning the current head.
   */
-private[collection] final class LinearSeqIterator[A](coll: Seq[A]) extends AbstractIterator[A] {
+private[collection] final class LinearSeqIterator[A](coll: LinearSeqOps[A, LinearSeq, LinearSeq[A]]) extends AbstractIterator[A] {
   // A call-by-need cell
-  private[this] final class LazyCell(st: => Seq[A]) { lazy val v = st }
+  private[this] final class LazyCell(st: => LinearSeqOps[A, LinearSeq, LinearSeq[A]]) { lazy val v = st }
 
   private[this] var these: LazyCell = new LazyCell(coll)
 

--- a/test/junit/scala/collection/LinearSeqTest.scala
+++ b/test/junit/scala/collection/LinearSeqTest.scala
@@ -1,0 +1,22 @@
+package scala.collection
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class LinearSeqTest {
+  // Tests regression on issue 11262
+  @Test def extensionIteratorTest: Unit = {
+    class ConstantLinearSeq[A](len: Int, elt: A) extends scala.collection.LinearSeq[A] {
+      override val isEmpty: Boolean = len == 0
+      override val head = elt
+      override lazy val tail = if(len > 0) new ConstantLinearSeq(len - 1, elt) else throw new Exception("tail of empty Seq")
+    }
+
+    val x = new ConstantLinearSeq(4, 7)
+
+    val it = x.iterator // The main thing we want to test is that this does not throw an exception
+    assert(it.hasNext == true) // Call it at least once so that it won't be optimized away
+  }
+}


### PR DESCRIPTION
When extending a LinearSeq, calling iterator resulted in an
infinite loop causing a StackOverflowError.

Fixes scala/bug#11262