### PR TITLE
Make NextOfKin’s constructor private[Tombstone]

### DIFF
--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -205,7 +205,7 @@ object VectorMap extends MapFactory[VectorMap] {
     final case object Kinless extends Tombstone {
       override def toString = "⤞"
     }
-    final case class NextOfKin private (distance: Int) extends Tombstone {
+    final case class NextOfKin private[Tombstone] (distance: Int) extends Tombstone {
       override def toString = "⥅" + distance
     }
     def apply(distance: Int): Tombstone =


### PR DESCRIPTION
This change is required if we want to change the visibility
of the synthetic `apply` method in case classes companions to
match the visibility of their case class constructor.

See also discussion in lampepfl/dotty#5472.