### PR TITLE
Start a new line for the +(s:String) method in GenerateAnyVals.

### DIFF
--- a/project/GenerateAnyVals.scala
+++ b/project/GenerateAnyVals.scala
@@ -147,7 +147,7 @@ import scala.language.implicitConversions"""
     def mkCoercions = numeric map (x => "def to%s: %s".format(x, x))
     def mkUnaryOps  = unaryOps map (x => "%s\n  def unary_%s : %s".format(x.doc, x.op, this opType I))
     def mkStringOps = List(
-      """@deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String"""
+      "@deprecated(\"Adding a number and a String is deprecated. Use the string interpolation `s\\\"$num$str\\\"`\", \"2.13.0\")\n  def +(x: String): String"
     )
     def mkShiftOps  = (
       for (op <- shiftOps ; arg <- List(I, L)) yield {

--- a/src/library/scala/Byte.scala
+++ b/src/library/scala/Byte.scala
@@ -46,7 +46,8 @@ final abstract class Byte private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Int
 
-  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0")
+  def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,

--- a/src/library/scala/Char.scala
+++ b/src/library/scala/Char.scala
@@ -46,7 +46,8 @@ final abstract class Char private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Int
 
-  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0")
+  def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,

--- a/src/library/scala/Double.scala
+++ b/src/library/scala/Double.scala
@@ -37,7 +37,8 @@ final abstract class Double private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Double
 
-  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0")
+  def +(x: String): String
 
   /** Returns `true` if this value is equal to x, `false` otherwise. */
   def ==(x: Byte): Boolean

--- a/src/library/scala/Float.scala
+++ b/src/library/scala/Float.scala
@@ -37,7 +37,8 @@ final abstract class Float private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Float
 
-  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0")
+  def +(x: String): String
 
   /** Returns `true` if this value is equal to x, `false` otherwise. */
   def ==(x: Byte): Boolean

--- a/src/library/scala/Int.scala
+++ b/src/library/scala/Int.scala
@@ -46,7 +46,8 @@ final abstract class Int private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Int
 
-  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0")
+  def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,

--- a/src/library/scala/Long.scala
+++ b/src/library/scala/Long.scala
@@ -46,7 +46,8 @@ final abstract class Long private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Long
 
-  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0")
+  def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,

--- a/src/library/scala/Short.scala
+++ b/src/library/scala/Short.scala
@@ -46,7 +46,8 @@ final abstract class Short private extends AnyVal {
   /** Returns the negation of this value. */
   def unary_- : Int
 
-  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0") def +(x: String): String
+  @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0")
+  def +(x: String): String
 
   /**
   * Returns this value bit-shifted left by the specified number of bits,


### PR DESCRIPTION
=lib Start a new line for the `+` method in GenerateAnyVals.

### Motivation:
The current generated `+` method is tailing with the `@deprecate` annotation,not nicely show up in IDE.

### Modification:
Change the GenerateAnyVals to start a new line for `+` method and regenerate the AnyVals.

### Result:
Now the `+` method of `Int` etc starts with a new line.

refs:https://github.com/scala/bug/issues/11267