### PR TITLE
Add `final` modifier to annotations such as `native`,`specialized`,throws`,`volatile` etc.

### DIFF
--- a/src/library/scala/SerialVersionUID.scala
+++ b/src/library/scala/SerialVersionUID.scala
@@ -23,4 +23,4 @@ package scala
   * @see [[http://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html `java.io.Serializable`]]
   * @see [[Serializable]]
   */
-class SerialVersionUID(value: Long) extends scala.annotation.ConstantAnnotation
+final class SerialVersionUID(value: Long) extends scala.annotation.ConstantAnnotation

--- a/src/library/scala/annotation/showAsInfix.scala
+++ b/src/library/scala/annotation/showAsInfix.scala
@@ -36,4 +36,4 @@ package scala.annotation
   * @param enabled whether to show this type as an infix type operator.
   * @since 2.12.2
   */
-class showAsInfix(enabled: Boolean = true) extends annotation.StaticAnnotation
+final class showAsInfix(enabled: Boolean = true) extends annotation.StaticAnnotation

--- a/src/library/scala/annotation/strictfp.scala
+++ b/src/library/scala/annotation/strictfp.scala
@@ -18,4 +18,4 @@ package scala.annotation
  *  @author Paul Phillips
  *  @since 2.9
  */
-class strictfp extends scala.annotation.StaticAnnotation
+final class strictfp extends scala.annotation.StaticAnnotation

--- a/src/library/scala/annotation/unspecialized.scala
+++ b/src/library/scala/annotation/unspecialized.scala
@@ -18,4 +18,4 @@ package scala.annotation
  *
  *  @since 2.10
  */
-class unspecialized extends scala.annotation.StaticAnnotation
+final class unspecialized extends scala.annotation.StaticAnnotation

--- a/src/library/scala/beans/BeanProperty.scala
+++ b/src/library/scala/beans/BeanProperty.scala
@@ -27,4 +27,4 @@ package scala.beans
  *  use the `scala.beans.BooleanBeanProperty` annotation instead.
  */
 @scala.annotation.meta.field
-class BeanProperty extends scala.annotation.StaticAnnotation
+final class BeanProperty extends scala.annotation.StaticAnnotation

--- a/src/library/scala/beans/BooleanBeanProperty.scala
+++ b/src/library/scala/beans/BooleanBeanProperty.scala
@@ -17,4 +17,4 @@ package scala.beans
  *  named `isFieldName` instead of `getFieldName`.
  */
 @scala.annotation.meta.field
-class BooleanBeanProperty extends scala.annotation.StaticAnnotation
+final class BooleanBeanProperty extends scala.annotation.StaticAnnotation

--- a/src/library/scala/deprecated.scala
+++ b/src/library/scala/deprecated.scala
@@ -58,4 +58,4 @@ import scala.annotation.meta._
  *  @see    [[scala.deprecatedName]]
  */
 @getter @setter @beanGetter @beanSetter
-class deprecated(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation
+final class deprecated(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation

--- a/src/library/scala/deprecatedInheritance.scala
+++ b/src/library/scala/deprecatedInheritance.scala
@@ -48,4 +48,4 @@ import scala.annotation.meta._
  *  @see    [[scala.deprecatedName]]
  */
 @getter @setter @beanGetter @beanSetter
-class deprecatedInheritance(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation
+final class deprecatedInheritance(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation

--- a/src/library/scala/deprecatedName.scala
+++ b/src/library/scala/deprecatedName.scala
@@ -42,7 +42,7 @@ import scala.annotation.meta._
   *  @see    [[scala.deprecatedOverriding]]
   */
 @param
-class deprecatedName(name: String = "<none>", since: String = "") extends scala.annotation.StaticAnnotation {
+final class deprecatedName(name: String = "<none>", since: String = "") extends scala.annotation.StaticAnnotation {
   @deprecated("The parameter name should be a String, not a symbol.", "2.13.0") def this(name: Symbol, since: String) = this(name.name, since)
   @deprecated("The parameter name should be a String, not a symbol.", "2.13.0") def this(name: Symbol) = this(name.name, "")
 }

--- a/src/library/scala/deprecatedOverriding.scala
+++ b/src/library/scala/deprecatedOverriding.scala
@@ -49,4 +49,4 @@ import scala.annotation.meta._
  *  @see    [[scala.deprecatedName]]
  */
 @getter @setter @beanGetter @beanSetter
-class deprecatedOverriding(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation
+final class deprecatedOverriding(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation

--- a/src/library/scala/inline.scala
+++ b/src/library/scala/inline.scala
@@ -49,4 +49,4 @@ package scala
  *
  * @author Lex Spoon
  */
-class inline extends scala.annotation.StaticAnnotation
+final class inline extends scala.annotation.StaticAnnotation

--- a/src/library/scala/native.scala
+++ b/src/library/scala/native.scala
@@ -25,4 +25,4 @@ package scala
   *
   * @since 2.6
   */
-class native extends scala.annotation.StaticAnnotation {}
+final class native extends scala.annotation.StaticAnnotation {}

--- a/src/library/scala/noinline.scala
+++ b/src/library/scala/noinline.scala
@@ -47,4 +47,4 @@ package scala
  *
  * @author Lex Spoon
  */
-class noinline extends scala.annotation.StaticAnnotation
+final class noinline extends scala.annotation.StaticAnnotation

--- a/src/library/scala/reflect/macros/internal/macroImpl.scala
+++ b/src/library/scala/reflect/macros/internal/macroImpl.scala
@@ -27,4 +27,4 @@ package internal
  *  To lessen the weirdness we define this annotation as `private[scala]`.
  *  It will not prevent pickling, but it will prevent application developers (and scaladocs) from seeing the annotation.
  */
-private[scala] class macroImpl(val referenceToMacroImpl: Any) extends scala.annotation.StaticAnnotation
+private[scala] final class macroImpl(val referenceToMacroImpl: Any) extends scala.annotation.StaticAnnotation

--- a/src/library/scala/specialized.scala
+++ b/src/library/scala/specialized.scala
@@ -30,7 +30,7 @@ import Specializable._
  */
 // class tspecialized[T](group: Group[T]) extends scala.annotation.StaticAnnotation {
 
-class specialized(group: SpecializedGroup) extends scala.annotation.StaticAnnotation {
+final class specialized(group: SpecializedGroup) extends scala.annotation.StaticAnnotation {
   def this(types: Specializable*) = this(new Group(types.toList))
   def this() = this(Primitives)
 }

--- a/src/library/scala/throws.scala
+++ b/src/library/scala/throws.scala
@@ -26,6 +26,6 @@ package scala
  * @author  Nikolay Mihaylov
  * @since   2.1
  */
-class throws[T <: Throwable](cause: String = "") extends scala.annotation.StaticAnnotation {
+final class throws[T <: Throwable](cause: String = "") extends scala.annotation.StaticAnnotation {
   def this(clazz: Class[T]) = this("")
 }

--- a/src/library/scala/transient.scala
+++ b/src/library/scala/transient.scala
@@ -15,4 +15,4 @@ package scala
 import scala.annotation.meta._
 
 @field
-class transient extends scala.annotation.StaticAnnotation
+final class transient extends scala.annotation.StaticAnnotation

--- a/src/library/scala/unchecked.scala
+++ b/src/library/scala/unchecked.scala
@@ -37,4 +37,4 @@ package scala
  *
  *  @since 2.4
  */
-class unchecked extends scala.annotation.Annotation {}
+final class unchecked extends scala.annotation.Annotation {}

--- a/src/library/scala/volatile.scala
+++ b/src/library/scala/volatile.scala
@@ -15,4 +15,4 @@ package scala
 import scala.annotation.meta._
 
 @field
-class volatile extends scala.annotation.StaticAnnotation
+final class volatile extends scala.annotation.StaticAnnotation


### PR DESCRIPTION
=lib Add `final` modifier to annotations.

### Motivation:

The annotations such as `switch`,`strictfp`,`deprecated` and etc should be final.

### Modification:
Add `final` modifier to these annotations

### Result:
These annotations are final now and can't be inherited.

refs:https://github.com/scala/bug/issues/11266