### PR TITLE
Process parses command

### DIFF
--- a/src/library/scala/sys/process/Parser.scala
+++ b/src/library/scala/sys/process/Parser.scala
@@ -1,0 +1,111 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.sys.process
+
+import scala.annotation.tailrec
+
+/** A simple enough command line parser.
+ */
+private[scala] object Parser {
+  private final val DQ = '"'
+  private final val SQ = '\''
+
+  /** Split the line into tokens separated by whitespace or quotes.
+   *
+   *  @return either an error message or reverse list of tokens
+   */
+  private def tokens(in: String) = {
+    import Character.isWhitespace
+    import java.lang.{StringBuilder => Builder}
+    import collection.mutable.ArrayBuffer
+
+    var accum: List[String] = Nil
+    var pos = 0
+    var start = 0
+    val qpos = new ArrayBuffer[Int](16)    // positions of paired quotes
+
+    def cur: Int  = if (done) -1 else in.charAt(pos)
+    def bump() = pos += 1
+    def done   = pos >= in.length
+
+    def skipToQuote(q: Int) = {
+      var escaped = false
+      def terminal = in.charAt(pos) match {
+        case _ if escaped => escaped = false ; false
+        case '\\'         => escaped = true ; false
+        case `q`          => true
+        case _            => false
+      }
+      while (!done && !terminal) pos += 1
+      !done
+    }
+    def skipToDelim(): Boolean =
+      cur match {
+        case q @ (DQ | SQ)        => { qpos += pos; bump(); skipToQuote(q) } && { qpos += pos; bump(); skipToDelim() }
+        case -1                   => true
+        case c if isWhitespace(c) => true
+        case _                    => bump(); skipToDelim()
+      }
+    def skipWhitespace() = while (isWhitespace(cur)) pos += 1
+    def copyText() = {
+      val buf = new Builder
+      var p = start
+      var i = 0
+      while (p < pos) {
+        if (i >= qpos.size) {
+          buf.append(in, p, pos)
+          p = pos
+        } else if (p == qpos(i)) {
+          buf.append(in, qpos(i)+1, qpos(i+1))
+          p = qpos(i+1)+1
+          i += 2
+        } else {
+          buf.append(in, p, qpos(i))
+          p = qpos(i)
+        }
+      }
+      buf.toString
+    }
+    def text() = {
+      val res =
+        if (qpos.isEmpty) in.substring(start, pos)
+        else if (qpos(0) == start && qpos(1) == pos) in.substring(start+1, pos-1)
+        else copyText()
+      qpos.clear()
+      res
+    }
+    def badquote = Left("Unmatched quote")
+
+    @tailrec def loop(): Either[String, List[String]] = {
+      skipWhitespace()
+      start = pos
+      if (done) Right(accum)
+      else if (!skipToDelim()) badquote
+      else {
+        accum = text() :: accum
+        loop()
+      }
+    }
+    loop()
+  }
+
+  class ParseException(msg: String) extends RuntimeException(msg)
+
+  def tokenize(line: String, errorFn: String => Unit): List[String] =
+    tokens(line) match {
+      case Right(args) => args.reverse
+      case Left(msg)   => errorFn(msg) ; Nil
+    }
+
+  def tokenize(line: String): List[String] = tokenize(line, x => throw new ParseException(x))
+}

--- a/src/library/scala/sys/process/Process.scala
+++ b/src/library/scala/sys/process/Process.scala
@@ -91,14 +91,8 @@ trait ProcessCreation {
     *
     * @example {{{ apply("java", params.get("cwd"), "CLASSPATH" -> "library.jar") }}}
     */
-  def apply(command: String, cwd: Option[File], extraEnv: (String, String)*): ProcessBuilder = {
-    apply(command.split("""\s+"""), cwd, extraEnv : _*)
-    // not smart to use this on windows, because CommandParser uses \ to escape ".
-    /*CommandParser.parse(command) match {
-      case Left(errorMsg) => error(errorMsg)
-      case Right((cmd, args)) => apply(cmd :: args, cwd, extraEnv : _*)
-    }*/
-  }
+  def apply(command: String, cwd: Option[File], extraEnv: (String, String)*): ProcessBuilder =
+    apply(Parser.tokenize(command), cwd, extraEnv: _*)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] with working dir optionally set to
     * `File` and extra environment variables.

--- a/test/junit/scala/sys/process/ParserTest.scala
+++ b/test/junit/scala/sys/process/ParserTest.scala
@@ -1,0 +1,45 @@
+package scala.sys.process
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import scala.tools.testing.AssertUtil.assertThrows
+
+@RunWith(classOf[JUnit4])
+class ParserTest {
+  import Parser.{tokenize, ParseException}
+
+  @Test
+  def parserTokenizes(): Unit = {
+    assertEquals(Nil, tokenize(""))
+    assertEquals(List("x"), tokenize("x"))
+    assertEquals(List("x"), tokenize(" x "))
+    assertEquals(List("x","y"), tokenize("x y"))
+    assertEquals(List("x","y","z"), tokenize("x y z"))
+  }
+  @Test
+  def parserTrims(): Unit = {
+    assertEquals(Nil, tokenize(" "))
+    assertEquals(List("x"), tokenize(" x "))
+    assertEquals(List("x"), tokenize("\nx\n"))
+    assertEquals(List("x","y","z"), tokenize(" x y z "))
+  }
+  @Test
+  def parserQuotes(): Unit = {
+    assertEquals(List("x"), tokenize("'x'"))
+    assertEquals(List("x"), tokenize(""""x""""))
+    assertEquals(List("x","y","z"), tokenize("x 'y' z"))
+    assertEquals(List("x"," y ","z"), tokenize("x ' y ' z"))
+    assertEquals(List("x","y","z"), tokenize("""x "y" z"""))
+    assertEquals(List("x"," y ","z"), tokenize("""x " y " z"""))
+    // interior quotes
+    assertEquals(List("x y z"), tokenize("x' y 'z"))   // was assertEquals(List("x'","y","'z"), tokenize("x' y 'z"))
+    assertEquals(List("x\ny\nz"), tokenize("x'\ny\n'z"))
+    assertEquals(List("x'y'z"), tokenize("""x"'y'"z"""))
+    assertEquals(List("abcxyz"), tokenize(""""abc"xyz"""))
+    // missing quotes
+    assertThrows[ParseException](tokenize(""""x"""))         // was assertEquals(List("\"x"), tokenize(""""x"""))
+    assertThrows[ParseException](tokenize("""x'"""))
+  }
+}


### PR DESCRIPTION
Pasted parser and test into `sys.process`.

Did not cope with comment about backslash on Windows.

Fixes scala/bug#7947