### PR TITLE
Only compare org, name and rev when finding ASM dep for packageBin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -425,7 +425,7 @@ lazy val compiler = configureAsSubproject(project)
     // (with strings) to deal with mutual recursion
     products in Compile in packageBin :=
       (products in Compile in packageBin).value ++
-        Seq((dependencyClasspath in Compile).value.find(_.get(moduleID.key) == Some(asmDep)).get.data) ++
+        Seq((dependencyClasspath in Compile).value.find(_.get(moduleID.key).map(id => (id.organization, id.name, id.revision)).contains((asmDep.organization, asmDep.name, asmDep.revision))).get.data) ++
         (products in Compile in packageBin in LocalProject("interactive")).value ++
         (products in Compile in packageBin in LocalProject("scaladoc")).value ++
         (products in Compile in packageBin in LocalProject("repl")).value ++


### PR DESCRIPTION
This avoids problems with the module ids not being equal when using the `scala` command in SBT while also using Coursier for dependency resolution. This fix only compares the relevant organization-name-revision part of the module to find the dependency (the module ids of the dependencies contain extra information when resolved via Coursier which makes no module id equal to the `asmDep` causing a `None.get`exception when starting the REPL via `scala` from inside SBT).