### PR TITLE
Change immutable and mutable bitset linearization

### DIFF
--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -31,11 +31,11 @@ import scala.annotation.implicitNotFound
 sealed abstract class BitSet
   extends AbstractSet[Int]
     with SortedSet[Int]
-    with collection.BitSet
     with SortedSetOps[Int, SortedSet, BitSet]
-    with collection.BitSetOps[BitSet]
     with StrictOptimizedIterableOps[Int, Set, BitSet]
-    with StrictOptimizedSortedSetOps[Int, SortedSet, BitSet] {
+    with StrictOptimizedSortedSetOps[Int, SortedSet, BitSet]
+    with collection.BitSet
+    with collection.BitSetOps[BitSet] {
 
   override def unsorted: Set[Int] = this
 

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -39,11 +39,11 @@ import scala.annotation.implicitNotFound
 class BitSet(protected[collection] final var elems: Array[Long])
   extends AbstractSet[Int]
     with SortedSet[Int]
-    with collection.BitSet
     with SortedSetOps[Int, SortedSet, BitSet]
-    with collection.BitSetOps[BitSet]
     with StrictOptimizedIterableOps[Int, Set, BitSet]
-    with StrictOptimizedSortedSetOps[Int, SortedSet, BitSet] {
+    with StrictOptimizedSortedSetOps[Int, SortedSet, BitSet]
+    with collection.BitSet
+    with collection.BitSetOps[BitSet] {
 
   def this(initSize: Int) = this(new Array[Long](math.max((initSize + 63) >> 6, 1)))
 


### PR DESCRIPTION
By moving `collection.BitSet` and `collection.BitSetOps` to the end of the extends clause, they inherit the bitset specific method implementations from `collection.BitSet` instead of the more generic implementations from `collection.StrictOptimizedIterableOps` and `collection.StrictOptimizedSortedSetOps`.