### PR TITLE
Make concat an alias to appendedAll again.

### DIFF
--- a/src/library/scala/collection/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSeqOps.scala
@@ -64,6 +64,9 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
     b.result()
   }
 
+  // Must override here to ensure that `concat` is still an alias for `appendedAll` since it is overridden in `StrictOptimizedIterableOps`
+  override def concat[B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
+
   override def padTo[B >: A](len: Int, elem: B): CC[B] = {
     val b = iterableFactory.newBuilder[B]
     val L = size


### PR DESCRIPTION
This ensures that any inheritors overriding `appendedAll` (e.g. `immutable.List`) will also use that overridden implementation when called via `concat` (before this change the `concat` implementation inherited from `collection.StrictOptimizedIterableOps` would be inherited instead).