### PR TITLE
Increase suppression granularity in Using.resource

### DIFF
--- a/test/junit/scala/util/UsingTest.scala
+++ b/test/junit/scala/util/UsingTest.scala
@@ -14,164 +14,259 @@ class UsingTest {
 
   /* raw `Using.resource` that doesn't use `Try` */
 
-  @Test
-  def usingResourceThatThrowsException(): Unit = {
-    val exception = use(new ExceptionResource, new UsingException(_))
-    assertThrowableClass[UsingException](exception)
-    assertSingleSuppressed[ClosingException](exception)
+  private def genericResourceThrowing[CloseT <: Throwable: ClassTag](resource: => CustomResource[CloseT],
+                                                                     onLinkage: SuppressionBehavior,
+                                                                     onInterruption: SuppressionBehavior,
+                                                                     onControl: SuppressionBehavior,
+                                                                     onException: SuppressionBehavior): Unit = {
+    def check[UseT <: Throwable: ClassTag](t: String => UseT,
+                                           behavior: SuppressionBehavior,
+                                           allowsSuppression: Boolean): Unit = {
+      val ex = use(resource, t)
+      if (behavior == IsSuppressed) {
+        assertThrowableClass[UseT](ex)
+        if (allowsSuppression) assertSingleSuppressed[CloseT](ex)
+        else assertNoSuppressed(ex)
+      } else {
+        assertThrowableClass[CloseT](ex)
+        if (behavior == AcceptsSuppressed) assertSingleSuppressed[UseT](ex)
+        else assertNoSuppressed(ex)
+      }
+    }
 
-    val error = use(new ExceptionResource, new Error(_))
-    assertThrowableClass[Error](error)
-    assertSingleSuppressed[ClosingException](error)
-
-    val fatal = use(new ExceptionResource, new OutOfMemoryError(_))
-    assertThrowableClass[OutOfMemoryError](fatal)
-    assertSingleSuppressed[ClosingException](fatal)
-
-    val control = use(new ExceptionResource, new UsingMarker(_))
-    assertThrowableClass[UsingMarker](control)
-    assertNoSuppressed(control)
+    check(new UsingVMError(_), behavior = IsSuppressed, allowsSuppression = true)
+    check(new UsingLinkageError(_), onLinkage, allowsSuppression = true)
+    check(_ => new UsingInterruption, onInterruption, allowsSuppression = true)
+    check(new UsingControl(_), onControl, allowsSuppression = false)
+    check(new UsingError(_), onException, allowsSuppression = true)
+    check(new UsingException(_), onException, allowsSuppression = true)
   }
 
   @Test
-  def usingResourceThatThrowsError(): Unit = {
-    val exception = use(new ErrorResource, new UsingException(_))
-    assertThrowableClass[UsingException](exception)
-    assertSingleSuppressed[ClosingError](exception)
-
-    val error = use(new ErrorResource, new Error(_))
-    assertThrowableClass[Error](error)
-    assertSingleSuppressed[ClosingError](error)
-
-    val fatal = use(new ErrorResource, new OutOfMemoryError(_))
-    assertThrowableClass[OutOfMemoryError](fatal)
-    assertSingleSuppressed[ClosingError](fatal)
-
-    val control = use(new ErrorResource, new UsingMarker(_))
-    assertThrowableClass[UsingMarker](control)
-    assertNoSuppressed(control)
+  def resourceThrowingVMError(): Unit = {
+    genericResourceThrowing(
+      new VMErrorResource,
+      onLinkage = AcceptsSuppressed,
+      onInterruption = AcceptsSuppressed,
+      onControl = AcceptsSuppressed,
+      onException = AcceptsSuppressed)
   }
 
   @Test
-  def usingResourceThatThrowsFatal(): Unit = {
-    val exception = use(new FatalResource, new UsingException(_))
-    assertThrowableClass[StackOverflowError](exception)
-    assertSingleSuppressed[UsingException](exception)
-
-    val error = use(new FatalResource, new Error(_))
-    assertThrowableClass[StackOverflowError](error)
-    assertSingleSuppressed[Error](error)
-
-    val fatal = use(new FatalResource, new OutOfMemoryError(_))
-    assertThrowableClass[OutOfMemoryError](fatal)
-    assertSingleSuppressed[StackOverflowError](fatal)
-
-    val control = use(new FatalResource, new UsingMarker(_))
-    assertThrowableClass[UsingMarker](control)
-    assertNoSuppressed(control)
+  def resourceThrowingLinkageError(): Unit = {
+    genericResourceThrowing(
+      new LinkageResource,
+      onLinkage = IsSuppressed,
+      onInterruption = AcceptsSuppressed,
+      onControl = AcceptsSuppressed,
+      onException = AcceptsSuppressed)
   }
 
   @Test
-  def usingResourceThatThrowsControlThrowable(): Unit = {
-    val exception = use(new MarkerResource, new UsingException(_))
-    assertThrowableClass[ClosingMarker](exception)
-    assertNoSuppressed(exception)
-
-    val error = use(new MarkerResource, new Error(_))
-    assertThrowableClass[ClosingMarker](error)
-    assertNoSuppressed(error)
-
-    val fatal = use(new MarkerResource, new OutOfMemoryError(_))
-    assertThrowableClass[OutOfMemoryError](fatal)
-    assertSingleSuppressed[ClosingMarker](fatal)
-
-    val control = use(new MarkerResource, new UsingMarker(_))
-    assertThrowableClass[UsingMarker](control)
-    assertNoSuppressed(control)
-  }
-
-  /* safe `Using` that returns `Try` */
-
-  @Test
-  def safeUsingResourceThatThrowsException(): Unit = {
-    val exception = UseWrapped(new ExceptionResource, new UsingException(_))
-    assertThrowableClass[UsingException](exception)
-    assertSingleSuppressed[ClosingException](exception)
-
-    val error = UseWrapped(new ExceptionResource, new Error(_))
-    assertThrowableClass[Error](error)
-    assertSingleSuppressed[ClosingException](error)
-
-    val fatal = UseWrapped.catching(new ExceptionResource, new OutOfMemoryError(_))
-    assertThrowableClass[OutOfMemoryError](fatal)
-    assertSingleSuppressed[ClosingException](fatal)
-
-    val control = UseWrapped.catching(new ExceptionResource, new UsingMarker(_))
-    assertThrowableClass[UsingMarker](control)
-    assertNoSuppressed(control)
+  def resourceThrowingInterruption(): Unit = {
+    genericResourceThrowing(
+      new InterruptionResource,
+      onLinkage = IsSuppressed,
+      onInterruption = IsSuppressed,
+      onControl = AcceptsSuppressed,
+      onException = AcceptsSuppressed)
   }
 
   @Test
-  def safeUsingResourceThatThrowsError(): Unit = {
-    val exception = UseWrapped(new ErrorResource, new UsingException(_))
-    assertThrowableClass[UsingException](exception)
-    assertSingleSuppressed[ClosingError](exception)
-
-    val error = UseWrapped(new ErrorResource, new Error(_))
-    assertThrowableClass[Error](error)
-    assertSingleSuppressed[ClosingError](error)
-
-    val fatal = UseWrapped.catching(new ErrorResource, new OutOfMemoryError(_))
-    assertThrowableClass[OutOfMemoryError](fatal)
-    assertSingleSuppressed[ClosingError](fatal)
-
-    val control = UseWrapped.catching(new ErrorResource, new UsingMarker(_))
-    assertThrowableClass[UsingMarker](control)
-    assertNoSuppressed(control)
+  def resourceThrowingControl(): Unit = {
+    genericResourceThrowing(
+      new ControlResource,
+      onLinkage = IsSuppressed,
+      onInterruption = IsSuppressed,
+      onControl = IsSuppressed,
+      onException = IgnoresSuppressed)
   }
 
   @Test
-  def safeUsingResourceThatThrowsFatal(): Unit = {
-    val exception = UseWrapped.catching(new FatalResource, new UsingException(_))
-    assertThrowableClass[StackOverflowError](exception)
-    assertSingleSuppressed[UsingException](exception)
-
-    val error = UseWrapped.catching(new FatalResource, new Error(_))
-    assertThrowableClass[StackOverflowError](error)
-    assertSingleSuppressed[Error](error)
-
-    val fatal = UseWrapped.catching(new FatalResource, new OutOfMemoryError(_))
-    assertThrowableClass[OutOfMemoryError](fatal)
-    assertSingleSuppressed[StackOverflowError](fatal)
-
-    val control = UseWrapped.catching(new FatalResource, new UsingMarker(_))
-    assertThrowableClass[UsingMarker](control)
-    assertNoSuppressed(control)
+  def resourceThrowingError(): Unit = {
+    genericResourceThrowing(
+      new ErrorResource,
+      onLinkage = IsSuppressed,
+      onInterruption = IsSuppressed,
+      onControl = IsSuppressed,
+      onException = IsSuppressed)
   }
 
   @Test
-  def safeUsingResourceThatThrowsControlThrowable(): Unit = {
-    val exception = UseWrapped.catching(new MarkerResource, new UsingException(_))
-    assertThrowableClass[ClosingMarker](exception)
-    assertNoSuppressed(exception)
+  def resourceThrowingException(): Unit = {
+    genericResourceThrowing(
+      new ExceptionResource,
+      onLinkage = IsSuppressed,
+      onInterruption = IsSuppressed,
+      onControl = IsSuppressed,
+      onException = IsSuppressed)
+  }
 
-    val error = UseWrapped.catching(new MarkerResource, new Error(_))
-    assertThrowableClass[ClosingMarker](error)
-    assertNoSuppressed(error)
+  /* `Using` that returns `Try` */
 
-    val fatal = UseWrapped.catching(new MarkerResource, new OutOfMemoryError(_))
-    assertThrowableClass[OutOfMemoryError](fatal)
-    assertSingleSuppressed[ClosingMarker](fatal)
+  private def genericUsingThrowing[CloseT <: Throwable: ClassTag](resource: => CustomResource[CloseT],
+                                                                  onLinkage: SuppressionBehavior,
+                                                                  onInterruption: SuppressionBehavior,
+                                                                  onControl: SuppressionBehavior,
+                                                                  onException: SuppressionBehavior): Unit = {
+    def check[UseT <: Throwable: ClassTag](t: String => UseT,
+                                           behavior: SuppressionBehavior,
+                                           allowsSuppression: Boolean,
+                                           yieldsTry: Boolean): Unit = {
+      val ex = if (yieldsTry) UseWrapped(resource, t) else UseWrapped.catching(resource, t)
+      if (behavior == IsSuppressed) {
+        assertThrowableClass[UseT](ex)
+        if (allowsSuppression) assertSingleSuppressed[CloseT](ex)
+        else assertNoSuppressed(ex)
+      } else {
+        assertThrowableClass[CloseT](ex)
+        if (behavior == AcceptsSuppressed) assertSingleSuppressed[UseT](ex)
+        else assertNoSuppressed(ex)
+      }
+    }
 
-    val control = UseWrapped.catching(new MarkerResource, new UsingMarker(_))
-    assertThrowableClass[UsingMarker](control)
-    assertNoSuppressed(control)
+    check(new UsingVMError(_), behavior = IsSuppressed, allowsSuppression = true, yieldsTry = false)
+    check(new UsingLinkageError(_), onLinkage, allowsSuppression = true, yieldsTry = false)
+    check(_ => new UsingInterruption, onInterruption, allowsSuppression = true, yieldsTry = false)
+    check(new UsingControl(_), onControl, allowsSuppression = false, yieldsTry = false)
+    check(new UsingError(_), onException, allowsSuppression = true, yieldsTry = onException == IsSuppressed)
+    check(new UsingException(_), onException, allowsSuppression = true, yieldsTry = onException == IsSuppressed)
+  }
+
+  @Test
+  def usingThrowingVMError(): Unit = {
+    genericUsingThrowing(
+      new VMErrorResource,
+      onLinkage = AcceptsSuppressed,
+      onInterruption = AcceptsSuppressed,
+      onControl = AcceptsSuppressed,
+      onException = AcceptsSuppressed)
+  }
+
+  @Test
+  def usingThrowingLinkageError(): Unit = {
+    genericUsingThrowing(
+      new LinkageResource,
+      onLinkage = IsSuppressed,
+      onInterruption = AcceptsSuppressed,
+      onControl = AcceptsSuppressed,
+      onException = AcceptsSuppressed)
+  }
+
+  @Test
+  def usingThrowingInterruption(): Unit = {
+    genericUsingThrowing(
+      new InterruptionResource,
+      onLinkage = IsSuppressed,
+      onInterruption = IsSuppressed,
+      onControl = AcceptsSuppressed,
+      onException = AcceptsSuppressed)
+  }
+
+  @Test
+  def usingThrowingControl(): Unit = {
+    genericUsingThrowing(
+      new ControlResource,
+      onLinkage = IsSuppressed,
+      onInterruption = IsSuppressed,
+      onControl = IsSuppressed,
+      onException = IgnoresSuppressed)
+  }
+
+  @Test
+  def usingThrowingError(): Unit = {
+    genericUsingThrowing(
+      new ErrorResource,
+      onLinkage = IsSuppressed,
+      onInterruption = IsSuppressed,
+      onControl = IsSuppressed,
+      onException = IsSuppressed)
+  }
+
+  @Test
+  def usingThrowingException(): Unit = {
+    genericUsingThrowing(
+      new ExceptionResource,
+      onLinkage = IsSuppressed,
+      onInterruption = IsSuppressed,
+      onControl = IsSuppressed,
+      onException = IsSuppressed)
   }
 
   /* nested resource usage returns the correct exception */
 
+  private def checkMultiplePropagatesCorrectlySimple(usingException: Throwable): Unit = {
+    /*
+    UsingException
+     |- ClosingError
+     |- ClosingException
+     */
+    assertThrowableClass[UsingException](usingException)
+    val suppressed = usingException.getSuppressed
+    assertEquals(suppressed.length, 2)
+    val closingError = suppressed(0)
+    val closingException = suppressed(1)
+    assertThrowableClass[ClosingError](closingError)
+    assertThrowableClass[ClosingException](closingException)
+  }
+
+  private def checkMultiplePropagatesCorrectlyComplex(vmError: Throwable): Unit = {
+    /*
+    ClosingVMError
+     |- UsingException
+     |   |- ClosingError
+     |- ClosingException
+     */
+    assertThrowableClass[ClosingVMError](vmError)
+    val firstLevelSuppressed = vmError.getSuppressed
+    assertEquals(firstLevelSuppressed.length, 2)
+    val usingException = firstLevelSuppressed(0)
+    val closingException = firstLevelSuppressed(1)
+    assertThrowableClass[UsingException](usingException)
+    assertThrowableClass[ClosingException](closingException)
+    assertSingleSuppressed[ClosingError](usingException)
+  }
+
+  private def checkMultiplePropagatesCorrectlyExtremelyComplex(vmError: Throwable): Unit = {
+    /*
+    ClosingVMError
+     |- ClosingLinkageError
+     |   |- ClosingInterruption
+     |   |   |- UsingException
+     |   |   |   |- ClosingError
+     |   |   |- ClosingException
+     |   |- ClosingError
+     |   |- ClosingControl
+     |- ClosingException
+     */
+    assertThrowableClass[ClosingVMError](vmError)
+
+    val firstLevelSuppressed = vmError.getSuppressed
+    assertEquals(firstLevelSuppressed.length, 2)
+    val closingLinkage = firstLevelSuppressed(0)
+    val closingException1 = firstLevelSuppressed(1)
+    assertThrowableClass[ClosingLinkageError](closingLinkage)
+    assertThrowableClass[ClosingException](closingException1)
+    assertNoSuppressed(closingException1)
+
+    val secondLevelSuppressed = closingLinkage.getSuppressed
+    assertEquals(secondLevelSuppressed.length, 3)
+    val closingInterruption = secondLevelSuppressed(0)
+    val closingError2 = secondLevelSuppressed(1)
+    val closingControl = secondLevelSuppressed(2)
+    assertNoSuppressed(closingError2)
+    assertNoSuppressed(closingControl)
+
+    val thirdLevelSuppressed = closingInterruption.getSuppressed
+    assertEquals(thirdLevelSuppressed.length, 2)
+    val usingException = thirdLevelSuppressed(0)
+    val closingException2 = thirdLevelSuppressed(1)
+    assertSingleSuppressed[ClosingError](usingException)
+    assertNoSuppressed(closingException2)
+  }
+
   @Test
-  def usingMultipleResourcesPropagatesCorrectlySimple(): Unit = {
+  def resourceMultiplePropagatesCorrectlySimple(): Unit = {
     val usingException = catchThrowable {
       Using.resource(new ExceptionResource) { _ =>
         Using.resource(new ErrorResource) { _ =>
@@ -183,25 +278,14 @@ class UsingTest {
     // uncomment to debug actual suppression nesting
     //usingException.printStackTrace()
 
-    /*
-    UsingException
-     |- ClosingError
-     |- ClosingException
-     */
-    assertThrowableClass[UsingException](usingException)
-    val suppressed = usingException.getSuppressed
-    assertEquals(suppressed.length, 2)
-    val closingError = suppressed(0)
-    val closingException = suppressed(1)
-    assertThrowableClass[ClosingError](closingError)
-    assertThrowableClass[ClosingException](closingException)
+    checkMultiplePropagatesCorrectlySimple(usingException)
   }
 
   @Test
-  def usingMultipleResourcesPropagatesCorrectlyComplex(): Unit = {
-    val fatal = catchThrowable {
+  def resourceMultiplePropagatesCorrectlyComplex(): Unit = {
+    val vmError = catchThrowable {
       Using.resource(new ExceptionResource) { _ =>
-        Using.resource(new FatalResource) { _ =>
+        Using.resource(new VMErrorResource) { _ =>
           Using.resource(new ErrorResource) { _ =>
             throw new UsingException("nested `Using.resource`")
           }
@@ -210,26 +294,41 @@ class UsingTest {
     }
 
     // uncomment to debug actual suppression nesting
-    //fatal.printStackTrace()
+    //vmError.printStackTrace()
 
-    /*
-    StackOverflowError
-     |- UsingException
-     |   |- ClosingError
-     |- ClosingException
-     */
-    assertThrowableClass[StackOverflowError](fatal)
-    val firstLevelSuppressed = fatal.getSuppressed
-    assertEquals(firstLevelSuppressed.length, 2)
-    val usingException = firstLevelSuppressed(0)
-    val closingException = firstLevelSuppressed(1)
-    assertThrowableClass[UsingException](usingException)
-    assertThrowableClass[ClosingException](closingException)
-    assertSingleSuppressed[ClosingError](usingException)
+    checkMultiplePropagatesCorrectlyComplex(vmError)
   }
 
   @Test
-  def safeUsingMultipleResourcesPropagatesCorrectlySimple(): Unit = {
+  def resourceMultiplePropagatesCorrectlyExtremelyComplex(): Unit = {
+    val vmError = catchThrowable {
+      Using.resource(new ExceptionResource) { _ =>
+        Using.resource(new VMErrorResource) { _ =>
+          Using.resource(new ControlResource) { _ =>
+            Using.resource(new ErrorResource) { _ =>
+              Using.resource(new LinkageResource) { _ =>
+                Using.resource(new ExceptionResource) { _ =>
+                  Using.resource(new InterruptionResource) { _ =>
+                    Using.resource(new ErrorResource) { _ =>
+                      throw new UsingException("nested `Using.resource`")
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // uncomment to debug actual suppression nesting
+    //vmError.printStackTrace()
+
+    checkMultiplePropagatesCorrectlyExtremelyComplex(vmError)
+  }
+
+  @Test
+  def usingMultipleResourcesPropagatesCorrectlySimple(): Unit = {
     val scala.util.Failure(usingException) = for {
       _ <- Using(new ExceptionResource)
       _ <- Using(new ErrorResource)
@@ -240,26 +339,15 @@ class UsingTest {
     // uncomment to debug actual suppression nesting
     //usingException.printStackTrace()
 
-    /*
-    UsingException
-     |- ClosingError
-     |- ClosingException
-     */
-    assertThrowableClass[UsingException](usingException)
-    val suppressed = usingException.getSuppressed
-    assertEquals(suppressed.length, 2)
-    val closingError = suppressed(0)
-    val closingException = suppressed(1)
-    assertThrowableClass[ClosingError](closingError)
-    assertThrowableClass[ClosingException](closingException)
+    checkMultiplePropagatesCorrectlySimple(usingException)
   }
 
   @Test
-  def safeUsingMultipleResourcesPropagatesCorrectlyComplex(): Unit = {
-    val fatal = catchThrowable {
+  def usingMultipleResourcesPropagatesCorrectlyComplex(): Unit = {
+    val vmError = catchThrowable {
       for {
         _ <- Using(new ExceptionResource)
-        _ <- Using(new FatalResource)
+        _ <- Using(new VMErrorResource)
         _ <- Using(new ErrorResource)
       } yield {
         throw new UsingException("nested `Using`")
@@ -267,28 +355,38 @@ class UsingTest {
     }
 
     // uncomment to debug actual suppression nesting
-    //fatal.printStackTrace()
+    //vmError.printStackTrace()
 
-    /*
-    StackOverflowError
-     |- UsingException
-     |   |- ClosingError
-     |- ClosingException
-     */
-    assertThrowableClass[StackOverflowError](fatal)
-    val firstLevelSuppressed = fatal.getSuppressed
-    assertEquals(firstLevelSuppressed.length, 2)
-    val usingException = firstLevelSuppressed(0)
-    val closingException = firstLevelSuppressed(1)
-    assertThrowableClass[UsingException](usingException)
-    assertThrowableClass[ClosingException](closingException)
-    assertSingleSuppressed[ClosingError](usingException)
+    checkMultiplePropagatesCorrectlyComplex(vmError)
+  }
+
+  @Test
+  def usingMultiplePropagatesCorrectlyExtremelyComplex(): Unit = {
+    val vmError = catchThrowable {
+      for {
+        _ <- Using(new ExceptionResource)
+        _ <- Using(new VMErrorResource)
+        _ <- Using(new ControlResource)
+        _ <- Using(new ErrorResource)
+        _ <- Using(new LinkageResource)
+        _ <- Using(new ExceptionResource)
+        _ <- Using(new InterruptionResource)
+        _ <- Using(new ErrorResource)
+      } yield {
+        throw new UsingException("nested `Using`")
+      }
+    }
+
+    // uncomment to debug actual suppression nesting
+    //vmError.printStackTrace()
+
+    checkMultiplePropagatesCorrectlyExtremelyComplex(vmError)
   }
 
   /* works when throwing no exceptions */
 
   @Test
-  def usingResourceWithNoThrow(): Unit = {
+  def resourceWithNoThrow(): Unit = {
     val res = Using.resource(new NoOpResource) { r =>
       r.identity("test")
     }
@@ -296,7 +394,7 @@ class UsingTest {
   }
 
   @Test
-  def safeUsingResourceWithNoThrow(): Unit = {
+  def usingWithNoThrow(): Unit = {
     val res = Using(new NoOpResource) { r =>
       r.identity("test")
     }
@@ -306,7 +404,7 @@ class UsingTest {
   /* using multiple resources close in the correct order */
 
   @Test
-  def using2Resources(): Unit = {
+  def resources2(): Unit = {
     val group = new ResourceGroup
     val res = Using.resources(
       group.newResource(),
@@ -318,7 +416,7 @@ class UsingTest {
   }
 
   @Test
-  def using3Resources(): Unit = {
+  def resources3(): Unit = {
     val group = new ResourceGroup
     val res = Using.resources(
       group.newResource(),
@@ -333,7 +431,7 @@ class UsingTest {
   }
 
   @Test
-  def using4Resources(): Unit = {
+  def resources4(): Unit = {
     val group = new ResourceGroup
     val res = Using.resources(
       group.newResource(),
@@ -350,7 +448,7 @@ class UsingTest {
   }
 
   @Test
-  def safeUsing2Resources(): Unit = {
+  def using2(): Unit = {
     val group = new ResourceGroup
     val res = for {
       r1 <- Using(group.newResource())
@@ -362,7 +460,7 @@ class UsingTest {
   }
 
   @Test
-  def safeUsing3Resources(): Unit = {
+  def using3(): Unit = {
     val group = new ResourceGroup
     val res = for {
       r1 <- Using(group.newResource())
@@ -370,40 +468,63 @@ class UsingTest {
       r3 <- Using(group.newResource())
     } yield {
       r1.identity(1) +
-        r2.identity(1) +
-        r3.identity(1)
+      r2.identity(1) +
+      r3.identity(1)
     }
     assertEquals(res, scala.util.Success(3))
+  }
+
+  @Test
+  def using4(): Unit = {
+    val group = new ResourceGroup
+    val res = for {
+      r1 <- Using(group.newResource())
+      r2 <- Using(group.newResource())
+      r3 <- Using(group.newResource())
+      r4 <- Using(group.newResource())
+    } yield {
+      r1.identity(1) +
+      r2.identity(1) +
+      r3.identity(1) +
+      r4.identity(1)
+    }
+    assertEquals(res, scala.util.Success(4))
   }
 
   /* misc */
 
   @Test
-  def usingDisallowsNull(): Unit = {
+  def resourceDisallowsNull(): Unit = {
     val npe = catchThrowable(Using.resource(null: AutoCloseable)(_ => "test"))
     assertThrowableClass[NullPointerException](npe)
   }
 
   @Test
-  def safeUsingDisallowsNull(): Unit = {
+  def usingDisallowsNull(): Unit = {
     val npe = Using(null: AutoCloseable)(_ => "test").failed.get
     assertThrowableClass[NullPointerException](npe)
   }
 
   @Test
-  def safeUsingCatchesOpeningException(): Unit = {
+  def usingCatchesOpeningException(): Unit = {
     val ex = Using({ throw new RuntimeException }: AutoCloseable)(_ => "test").failed.get
     assertThrowableClass[RuntimeException](ex)
   }
 }
 
 object UsingTest {
-  final class ClosingException(message: String) extends Exception(message)
-  final class UsingException(message: String) extends Exception(message)
+  final class ClosingVMError(message: String) extends VirtualMachineError(message)
+  final class UsingVMError(message: String) extends VirtualMachineError(message)
+  final class ClosingLinkageError(message: String) extends LinkageError(message)
+  final class UsingLinkageError(message: String) extends LinkageError(message)
+  type ClosingInterruption = InterruptedException
+  type UsingInterruption = ThreadDeath
+  final class ClosingControl(message: String) extends ControlThrowable(message)
+  final class UsingControl(message: String) extends ControlThrowable(message)
   final class ClosingError(message: String) extends Error(message)
   final class UsingError(message: String) extends Error(message)
-  final class ClosingMarker(message: String) extends ControlThrowable(message)
-  final class UsingMarker(message: String) extends ControlThrowable(message)
+  final class ClosingException(message: String) extends Exception(message)
+  final class UsingException(message: String) extends Exception(message)
 
   abstract class BaseResource extends AutoCloseable {
     final def identity[A](a: A): A = a
@@ -413,14 +534,24 @@ object UsingTest {
     override def close(): Unit = ()
   }
 
-  abstract class CustomResource(t: String => Throwable) extends BaseResource {
+  abstract class CustomResource[T <: Throwable](t: String => T) extends BaseResource {
     override final def close(): Unit = throw t("closing " + getClass.getSimpleName)
   }
 
-  final class ExceptionResource extends CustomResource(new ClosingException(_))
+  final class VMErrorResource extends CustomResource(new ClosingVMError(_))
+  final class LinkageResource extends CustomResource(new ClosingLinkageError(_))
+  final class InterruptionResource extends CustomResource(new ClosingInterruption(_))
+  final class ControlResource extends CustomResource(new ClosingControl(_))
   final class ErrorResource extends CustomResource(new ClosingError(_))
-  final class FatalResource extends CustomResource(new StackOverflowError(_))
-  final class MarkerResource extends CustomResource(new ClosingMarker(_))
+  final class ExceptionResource extends CustomResource(new ClosingException(_))
+
+  sealed trait SuppressionBehavior
+  /** is added as a suppressed exception to the other exception, and the other exception is thrown */
+  case object IsSuppressed extends SuppressionBehavior
+  /** is thrown, and the other exception is added to this as suppressed */
+  case object AcceptsSuppressed extends SuppressionBehavior
+  /** is thrown, and the other exception is ignored */
+  case object IgnoresSuppressed extends SuppressionBehavior
 
   def assertThrowableClass[T <: Throwable: ClassTag](t: Throwable): Unit = {
     assertEquals(s"Caught [${t.getMessage}]", implicitly[ClassTag[T]].runtimeClass, t.getClass)


### PR DESCRIPTION
Use granular hierarchy for exception suppression in `Using.resource`.

The motivation for this PR is that it seemed odd to me that a `NonLocalReturnControl` should be thrown in preference to a `VirtualMachineError`.