### PR TITLE
Iterator.flatMap clears reference early

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -557,8 +557,10 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
   def flatMap[B](f: A => IterableOnce[B]): Iterator[B] = new AbstractIterator[B] {
     private[this] var myCurrent: Iterator[B] = Iterator.empty
     private def current = {
-      while (!myCurrent.hasNext && self.hasNext)
+      while (!myCurrent.hasNext && self.hasNext) {
+        myCurrent = null   // clear the stale reference before advancing
         myCurrent = f(self.next()).iterator
+      }
       myCurrent
     }
     def hasNext = current.hasNext


### PR DESCRIPTION
Don't hold onto reference to previous
iterator when producing the next. This
matters especially for iterators that
hold references to the underlying iterable.

Fixes scala/bug#11272