### PR TITLE
Reset access boundary of companion module symbols

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -146,8 +146,14 @@ trait Namers extends MethodSynthesis {
     }
 
     def setPrivateWithin[T <: Symbol](tree: Tree, sym: T, mods: Modifiers): T =
-      if (sym.isPrivateLocal || !mods.hasAccessBoundary) sym
-      else sym setPrivateWithin typer.qualifyingClass(tree, mods.privateWithin, packageOK = true, immediate = false)
+      if (sym.isPrivateLocal) sym
+      else {
+        val qualClass = if (mods.hasAccessBoundary)
+          typer.qualifyingClass(tree, mods.privateWithin, packageOK = true, immediate = false)
+        else
+          NoSymbol
+        sym setPrivateWithin qualClass
+      }
 
     def setPrivateWithin(tree: MemberDef, sym: Symbol): Symbol =
       setPrivateWithin(tree, sym, tree.mods)

--- a/test/files/pos/t11273-case-class-access-boundary.scala
+++ b/test/files/pos/t11273-case-class-access-boundary.scala
@@ -1,0 +1,13 @@
+package p1 {
+  private[p1] case class Foo(a: Int)
+  object Foo {
+    def m = 1
+  }
+}
+
+package p2 {
+  class Test {
+    p1.Foo.m
+    p1.Foo(42)
+  }
+}


### PR DESCRIPTION
When a synthetic module symbol was created with `ensureCompanionObject`
during `enterClassDef`, _before_ an explicitly written companion module
that appears later in the list of statements, the module symbol initially
has the access boundary of the class (as copied by `caseModuleDef`).

When the module is later entered, this symbol is mutated to reflect
what is written in source code:

https://github.com/scala/scala/blob/bdfc43b3e0b3e34d76ee9bd248b6fb49f38e71eb/src/compiler/scala/tools/nsc/typechecker/Namers.scala#L467-L470

This code fails to remove the access boundary.

Fixes scala/bug#11273