### PR TITLE
Fix ArrayOps.sorted and add tests for ArraySeq sorting

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -478,7 +478,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     val len = xs.length
     def boxed = if(len < ArrayOps.MaxStableSortLength) {
       val a = xs.clone()
-      Sorting.stableSort(a)(ord.asInstanceOf[Ordering[A]])//Performed the sort on 'a' instead of 'xs'
+      Sorting.stableSort(a)(ord.asInstanceOf[Ordering[A]])
       a
     } else {
       val a = Array.copyAs[AnyRef](xs, len)(ClassTag.AnyRef)

--- a/test/files/run/ArrayOpsSortWithTest.scala
+++ b/test/files/run/ArrayOpsSortWithTest.scala
@@ -1,9 +1,0 @@
-object Test extends App {
-
-  val unsortedArray = Array[Int](1,-1,-100,0,100,99,91,10,91)
-  val sortedArray = unsortedArray.sortWith(_ < _)
-
-  assert(sortedArray.mkString(" ") == "-100 -1 0 1 10 91 91 99 100")
-  assert(unsortedArray.mkString(" ") == "1 -1 -100 0 100 99 91 10 91")
-
-}

--- a/test/junit/scala/collection/immutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/immutable/ArraySeqTest.scala
@@ -58,6 +58,13 @@ class ArraySeqTest {
   }
 
   @Test
+  def t11187(): Unit = {
+    assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sorted)
+    assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sortBy(identity))
+    assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sortWith(_ < _))
+  }
+
+  @Test
   def safeToArray(): Unit = {
     val a = ArraySeq(1,2,3)
     a.toArray.update(0, 100)

--- a/test/junit/scala/collection/mutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/mutable/ArraySeqTest.scala
@@ -13,7 +13,13 @@ class ArraySeqTest {
   @Test
   def t11187(): Unit = {
     assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sorted)
+    assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sortInPlace)
+    assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sortBy(identity))
+    assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sortInPlaceBy(identity))
+    assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sortWith(_ < _))
+    assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sortInPlaceWith(_ < _))
   }
+
   @Test
   def t10851(): Unit = {
     val s1 = ArraySeq.untagged(1,2,3)


### PR DESCRIPTION
These are the missing tests for https://github.com/scala/bug/issues/11187.
The other sort methods show no remaining instances of the bug but there
was an unrelated but uncovered by the tests.