### PR TITLE
Leading import _root_ is always root package

### DIFF
--- a/spec/09-top-level-definitions.md
+++ b/spec/09-top-level-definitions.md
@@ -123,8 +123,14 @@ Like all other references, package references are relative. That is,
 a package reference starting in a name $p$ will be looked up in the
 closest enclosing scope that defines a member named $p$.
 
-The special predefined name `_root_` refers to the
-outermost root package which contains all top-level packages.
+If a package name is shadowed, it's possible to refer to its
+fully-qualified name by prefixing it with
+the special predefined name `_root_`, which refers to the
+outermost root package that contains all top-level packages.
+
+The name `_root_` has this special denotation only when
+used as the first element of a qualifier; it is an ordinary
+identifier otherwise.
 
 ###### Example
 Consider the following program:
@@ -134,11 +140,18 @@ package b {
   class B
 }
 
-package a.b {
-  class A {
-    val x = new _root_.b.B
+package a {
+  package b {
+    class A {
+      val x = new _root_.b.B
+    }
+    class C {
+      import _root_.b._
+      def y = new B
+    }
   }
 }
+
 ```
 
 Here, the reference `_root_.b.B` refers to class `B` in the

--- a/test/files/neg/t6217.check
+++ b/test/files/neg/t6217.check
@@ -1,0 +1,6 @@
+t6217.scala:11: warning: _root_ in root position of qualifier refers to the root package, not package _root_ in package p, which is in scope
+    import _root_.scala.Option
+           ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t6217.scala
+++ b/test/files/neg/t6217.scala
@@ -1,0 +1,22 @@
+// scalac: -Xfatal-warnings
+package p {
+  package _root_ {
+    package scala {
+      object Option
+    }
+  }
+}
+package p {
+  object Test {
+    import _root_.scala.Option
+    def f = Option(null)
+  }
+}
+
+// was:
+// test/files/neg/t6217.scala:12: error: p._root_.scala.Option.type does not take parameters
+/*
+t6217.scala:11: warning: ignoring relative package named _root_ in root position
+    import _root_.scala.Option
+               ^
+ */

--- a/test/files/neg/t6217b.check
+++ b/test/files/neg/t6217b.check
@@ -1,0 +1,6 @@
+t6217b.scala:5: warning: _root_ in root position of qualifier refers to the root package, not package _root_ in package p, which is in scope
+  import _root_.scala.Option
+         ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/t6217b.scala
+++ b/test/files/neg/t6217b.scala
@@ -1,0 +1,10 @@
+// scalac: -Xfatal-warnings
+package p
+package _root_
+object Test {
+  import _root_.scala.Option
+  def f = Option(null)
+}
+
+// was:
+// test/files/neg/t6217b.scala:5: error: object scala is not a member of package p._root_

--- a/test/files/neg/t6217c.check
+++ b/test/files/neg/t6217c.check
@@ -1,0 +1,18 @@
+t6217c.scala:18: warning: _root_ in root position of qualifier refers to the root package, not package _root_ in package a, which is in scope
+      val x = new _root_.b.B
+                  ^
+t6217c.scala:25: warning: _root_ in root position of qualifier refers to the root package, not package _root_ in package a, which is in scope
+      import _root_.b._
+             ^
+t6217c.scala:19: warning: _root_ in root position of qualifier refers to the root package, not package _root_ in package a, which is in scope
+      def k: _root_.b.B = (x: Any) match {
+             ^
+t6217c.scala:20: warning: _root_ in root position of qualifier refers to the root package, not package _root_ in package a, which is in scope
+        case b: _root_.b.B => b
+                ^
+t6217c.scala:38: warning: _root_ in root position in package definition does not refer to the root package, but to package _root_ in package a, which is in scope
+  package _root_.p {
+          ^
+error: No warnings can be incurred under -Xfatal-warnings.
+5 warnings found
+one error found

--- a/test/files/neg/t6217c.scala
+++ b/test/files/neg/t6217c.scala
@@ -1,0 +1,41 @@
+// scalac: -Xfatal-warnings
+package b {
+  class B
+}
+package object b {
+  def f: B = new a.b.A().x
+  def c = new a.b.C()
+  def g: B = c.y
+  def k: B = (new a.b.A().x: Any) match {
+    case b: _root_.b.B => b
+    case _ => ???
+  }
+}
+
+package a {
+  package b {
+    class A {
+      val x = new _root_.b.B
+      def k: _root_.b.B = (x: Any) match {
+        case b: _root_.b.B => b
+        case _ => ???
+      }
+    }
+    class C {
+      import _root_.b._
+      def y = new B
+      def z = a._root_.X
+      def v = a.b.p.Y
+      def w = a._root_.p.Y
+    } 
+  }
+  package b.p {
+    object Y
+  }
+  package _root_ {
+    object X
+  }
+  package _root_.p {
+    object Y
+  }
+}

--- a/test/files/pos/t6217.scala
+++ b/test/files/pos/t6217.scala
@@ -1,0 +1,16 @@
+// scalac: -Xfatal-warnings
+package p {
+  package _root_ {
+    package scala {
+      object Option {
+        def apply(b: Boolean) = if (b) "true" else "false"
+      }
+    }
+  }
+}
+package p {
+  object Test {
+    import p._root_.scala.Option
+    def f = Option(true)
+  }
+}


### PR DESCRIPTION
Warn if there is an alternative relative _root_,
and ignore it.

In any position other than the start of an import
clause, `_root_` remains an ordinary, if rather
homely, identifier.

Fixes scala/bug#6217