### PR TITLE
Add Regression test for Bug t10228

### DIFF
--- a/test/files/neg/t10228.check
+++ b/test/files/neg/t10228.check
@@ -1,0 +1,4 @@
+t10228.scala:9: error: malformed type: A#Type
+  def g[A <: Fili[A]]: Unit = implicitly[A <:< A#Type]
+                                                 ^
+one error found

--- a/test/files/neg/t10228.scala
+++ b/test/files/neg/t10228.scala
@@ -1,0 +1,10 @@
+object t10228 {
+  trait Data { self =>
+    type Type >: self.type <: Data
+  }
+  trait DataF[P <: Data, A <: DataF[P, A]] extends Data { type Type = P#Type }
+
+  type Fili[A <: Data] = DataF[A, A]
+
+  def g[A <: Fili[A]]: Unit = implicitly[A <:< A#Type]
+}


### PR DESCRIPTION
Resolves https://github.com/scala/bug/issues/10228.

This Bug was still crashing the compiler with Stack Overflow (infinite recursion in the typer) in the version 2.12.7, but it has been solved on the current `2.13.x` branch version. 
