### PR TITLE
Display parsing warnings in REPL

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -1099,14 +1099,12 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
   def parse(line: String): Either[Result, (List[Tree], Position)] = {
     var isIncomplete = false
     currentRun.parsing.withIncompleteHandler((_, _) => isIncomplete = true) {
-      withoutWarnings {
-        reporter.reset()
-        val unit = newCompilationUnit(line, label)
-        val trees = newUnitParser(unit).parseStats()
-        if (reporter.hasErrors) Left(Error)
-        else if (isIncomplete) Left(Incomplete)
-        else Right((trees, unit.firstXmlPos))
-      }
+      reporter.reset()
+      val unit = newCompilationUnit(line, label)
+      val trees = newUnitParser(unit).parseStats()
+      if (reporter.hasErrors) Left(Error)
+      else if (isIncomplete) Left(Incomplete)
+      else Right((trees, unit.firstXmlPos))
     }
   }
 

--- a/test/files/run/repl-errors.check
+++ b/test/files/run/repl-errors.check
@@ -1,0 +1,11 @@
+
+scala> '\060'
+        ^
+       error: octal escape literals are unsupported: use \u0030 instead
+
+scala> def foo() { }
+                 ^
+       warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `foo`'s return type
+foo: ()Unit
+
+scala> :quit

--- a/test/files/run/repl-errors.scala
+++ b/test/files/run/repl-errors.scala
@@ -1,0 +1,10 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def extraSettings = "-deprecation"
+
+  def code = """
+'\060'
+def foo() { }
+  """.trim
+}


### PR DESCRIPTION
In https://github.com/scala/scala/pull/6325#issuecomment-441708672 @SethTisue  reported that procedure syntax deprecation warnings are not displayed on REPL.

```
% /usr/local/scala/scala-2.13.0-M5/bin/scala -deprecation        
Welcome to Scala 2.13.0-M5 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_192).
Type in expressions for evaluation. Or try :help.

scala> def foo() { }
foo: ()Unit
```

This is because warnings were filtered out by `withoutWarnings` in #5647 to fix scala/bug#10130.
On 2.13.x, it seems to work ok without the `withoutWarnings` filter during parse.