### PR TITLE
Make the global EC a BatchedExecutor (performance)

### DIFF
--- a/src/library/scala/concurrent/Promise.scala
+++ b/src/library/scala/concurrent/Promise.scala
@@ -65,9 +65,9 @@ trait Promise[T] {
    *  @return   This promise
    */
    def completeWith(other: Future[T]): this.type = {
-    if (other ne this.future) { // this tryCompleteWith this doesn't make much sense
+    if (other ne this.future) // this tryCompleteWith this doesn't make much sense
       other.onComplete(this tryComplete _)(Future.InternalCallbackExecutor)
-    }
+
     this
   }
 

--- a/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
+++ b/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
@@ -15,7 +15,7 @@ package scala.concurrent.impl
 import java.util.concurrent.{ ForkJoinPool, ForkJoinWorkerThread, Callable, Executor, ExecutorService, ThreadFactory, TimeUnit }
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.Collection
-import scala.concurrent.{ BlockContext, ExecutionContext, CanAwait, ExecutionContextExecutor, ExecutionContextExecutorService }
+import scala.concurrent.{ BatchingExecutor, BlockContext, ExecutionContext, CanAwait, ExecutionContextExecutor, ExecutionContextExecutorService }
 import scala.annotation.tailrec
 
 
@@ -111,7 +111,8 @@ private[concurrent] object ExecutionContextImpl {
                                                  prefix = "scala-execution-context-global",
                                                  uncaught = (thread: Thread, cause: Throwable) => reporter(cause))
 
-    new ForkJoinPool(desiredParallelism, threadFactory, threadFactory.uncaught, true) with ExecutionContextExecutorService {
+    new ForkJoinPool(desiredParallelism, threadFactory, threadFactory.uncaught, true) with ExecutionContextExecutorService with BatchingExecutor {
+      final override def unbatchedExecute(runnable: Runnable): Unit = super[ForkJoinPool].execute(runnable)
       final override def reportFailure(cause: Throwable): Unit =
         getUncaughtExceptionHandler() match {
           case null =>

--- a/test/files/jvm/scala-concurrent-tck.scala
+++ b/test/files/jvm/scala-concurrent-tck.scala
@@ -81,9 +81,8 @@ class FutureCallbacks extends TestBase {
     done =>
       val f = Future[Unit] { throw cause }
       f onComplete {
-        case Success(_) => done(false)
         case Failure(e: ExecutionException) if e.getCause == cause => done(true)
-        case Failure(_) => done(false)
+        case _ => done(false)
       }
   }
 
@@ -744,8 +743,9 @@ class BlockContexts extends TestBase {
 
   // test BlockContext in our default ExecutionContext
   def testDefaultFJP(): Unit = {
+    val prevCurrent = BlockContext.current
     val bc = getBlockContext(BlockContext.current)
-    assert(bc.isInstanceOf[java.util.concurrent.ForkJoinWorkerThread])
+    assert(bc ne prevCurrent) // Should have been replaced by the EC.
   }
 
   // test BlockContext inside BlockContext.withBlockContext


### PR DESCRIPTION
This PR makes the global EC implement BatchingExecutor, which on benches for Future increases performance significantly for most combinators.

Numbers from my box using scala.concurrent.global:

```diff
- 2.13.x:
+ Proposed:
- [info] AndThenFutureBenchmark.post                    1.130 ±    0.018  ops/ms
+ [info] AndThenFutureBenchmark.post                    3.129 ±    0.072  ops/ms
- [info] AndThenFutureBenchmark.pre                     1.277 ±    0.007  ops/ms
+ [info] AndThenFutureBenchmark.pre                     5.189 ±    0.273  ops/ms
- [info] CallbackFutureBenchmark.post                   0.861 ±    0.006  ops/ms
+ [info] CallbackFutureBenchmark.post                   0.848 ±    0.020  ops/ms
- [info] CallbackFutureBenchmark.pre                    1.021 ±    0.005  ops/ms
+ [info] CallbackFutureBenchmark.pre                    0.865 ±    0.017  ops/ms
- [info] CompleteFutureBenchmark.failure              146.932 ±    3.913  ops/ms
+ [info] CompleteFutureBenchmark.failure              147.145 ±    2.424  ops/ms
- [info] CompleteFutureBenchmark.success              146.881 ±    6.264  ops/ms
+ [info] CompleteFutureBenchmark.success              146.884 ±    5.060  ops/ms
- [info] CompleteWithFutureBenchmark.failure           91.133 ±    2.887  ops/ms
+ [info] CompleteWithFutureBenchmark.failure          217.430 ±   13.574  ops/ms
- [info] CompleteWithFutureBenchmark.success           91.102 ±    1.259  ops/ms
+ [info] CompleteWithFutureBenchmark.success          218.909 ±    2.613  ops/ms
- [info] FilterFutureBenchmark.post                     1.264 ±    0.024  ops/ms
+ [info] FilterFutureBenchmark.post                     3.386 ±    0.117  ops/ms
- [info] FilterFutureBenchmark.pre                      1.409 ±    0.013  ops/ms
+ [info] FilterFutureBenchmark.pre                      6.096 ±    0.549  ops/ms
- [info] FirstCompletedOfFutureBenchmark.post           1.071 ±    0.025  ops/ms
+ [info] FirstCompletedOfFutureBenchmark.post           0.981 ±    0.016  ops/ms
- [info] FirstCompletedOfFutureBenchmark.pre            0.983 ±    0.026  ops/ms
+ [info] FirstCompletedOfFutureBenchmark.pre            0.980 ±    0.024  ops/ms
- [info] FlatMapFutureBenchmark.post                    1.052 ±    0.006  ops/ms
+ [info] FlatMapFutureBenchmark.post                    2.867 ±    0.088  ops/ms
- [info] FlatMapFutureBenchmark.pre                     1.072 ±    0.006  ops/ms
+ [info] FlatMapFutureBenchmark.pre                     3.223 ±    0.031  ops/ms
- [info] LoopFutureBenchmark.post                      93.598 ±    0.400  ops/ms
+ [info] LoopFutureBenchmark.post                      94.910 ±    1.875  ops/ms
- [info] LoopFutureBenchmark.pre                       94.261 ±    1.553  ops/ms
+ [info] LoopFutureBenchmark.pre                       95.783 ±    1.059  ops/ms
- [info] MapFutureBenchmark.post                        1.125 ±    0.041  ops/ms
+ [info] MapFutureBenchmark.post                        3.152 ±    0.033  ops/ms
- [info] MapFutureBenchmark.pre                         1.304 ±    0.011  ops/ms
+ [info] MapFutureBenchmark.pre                         5.204 ±    0.272  ops/ms
- [info] NoopFutureBenchmark.post                   42388.978 ±  648.515  ops/ms
+ [info] NoopFutureBenchmark.post                   41983.270 ±  797.985  ops/ms
- [info] NoopFutureBenchmark.pre                   224481.015 ± 3176.761  ops/ms
+ [info] NoopFutureBenchmark.pre                   224429.800 ± 5779.305  ops/ms
- [info] RecoverFutureBenchmark.post                    0.876 ±    0.033  ops/ms
+ [info] RecoverFutureBenchmark.post                    2.940 ±    0.045  ops/ms
- [info] RecoverFutureBenchmark.pre                     0.984 ±    0.002  ops/ms
+ [info] RecoverFutureBenchmark.pre                     5.099 ±    0.394  ops/ms
- [info] RecoverWithFutureBenchmark.post                1.083 ±    0.012  ops/ms
+ [info] RecoverWithFutureBenchmark.post                2.899 ±    0.050  ops/ms
- [info] RecoverWithFutureBenchmark.pre                 1.073 ±    0.011  ops/ms
+ [info] RecoverWithFutureBenchmark.pre                 5.895 ±    0.216  ops/ms
- [info] SequenceFutureBenchmark.post                   0.509 ±    0.006  ops/ms
+ [info] SequenceFutureBenchmark.post                   0.911 ±    0.006  ops/ms
- [info] SequenceFutureBenchmark.pre                    0.560 ±    0.009  ops/ms
+ [info] SequenceFutureBenchmark.pre                    0.941 ±    0.014  ops/ms
- [info] TransformFutureBenchmark.post                  1.165 ±    0.016  ops/ms
+ [info] TransformFutureBenchmark.post                  3.439 ±    0.050  ops/ms
- [info] TransformFutureBenchmark.pre                   1.385 ±    0.028  ops/ms
+ [info] TransformFutureBenchmark.pre                   3.993 ±    0.160  ops/ms
- [info] TransformWithFutureBenchmark.post              1.013 ±    0.014  ops/ms
+ [info] TransformWithFutureBenchmark.post              2.739 ±    0.047  ops/ms
- [info] TransformWithFutureBenchmark.pre               1.196 ±    0.010  ops/ms
+ [info] TransformWithFutureBenchmark.pre               3.865 ±    0.319  ops/ms
- [info] VariousFutureBenchmark.post                    0.168 ±    0.006  ops/ms
+ [info] VariousFutureBenchmark.post                    0.266 ±    0.009  ops/ms
- [info] VariousFutureBenchmark.pre                     0.192 ±    0.003  ops/ms
+ [info] VariousFutureBenchmark.pre                     0.518 ±    0.005  ops/ms
- [info] ZipWithFutureBenchmark.post                    0.589 ±    0.031  ops/ms
+ [info] ZipWithFutureBenchmark.post                    1.015 ±    0.015  ops/ms
- [info] ZipWithFutureBenchmark.pre                     0.571 ±    0.002  ops/ms
+ [info] ZipWithFutureBenchmark.pre                     1.186 ±    0.016  ops/ms
```

Note that all operations have not improved performance, but in reality, some of the benches are not typical end-user code.
