### PR TITLE
Add `groupInto` to `Array` and `Seq`.

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -425,7 +425,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *  @tparam A2  the element type of the second resulting collection
     *  @param f    the 'split function' mapping the elements of this array to an [[scala.util.Either]]
     *
-    *  @return     a pair of arrays: the first one made of those values returned by `f` that were wrapped in [[scala.util.Left]], 
+    *  @return     a pair of arrays: the first one made of those values returned by `f` that were wrapped in [[scala.util.Left]],
     *              and the second one made of those wrapped in [[scala.util.Right]]. */
   def partitionMap[A1: ClassTag, A2: ClassTag](f: A => Either[A1, A2]): (Array[A1], Array[A2]) = {
     val res1 = ArrayBuilder.make[A1]
@@ -736,7 +736,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *  Example:
     *  {{{
     *    Array(1, 2, 3, 4).scanLeft(0)(_ + _) == Array(0, 1, 3, 6, 10)
-    *  }}}    
+    *  }}}
     *
     */
   def scanLeft[ B : ClassTag ](z: B)(op: (B, A) => B): Array[B] = {
@@ -749,7 +749,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
       i += 1
     }
     res(i) = v
-    res 
+    res
   }
 
   /** Computes a prefix scan of the elements of the array.
@@ -775,7 +775,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *  Example:
     *  {{{
     *    Array(4, 3, 2, 1).scanRight(0)(_ + _) == Array(10, 6, 3, 1, 0)
-    *  }}}    
+    *  }}}
     *
     */
   def scanRight[ B : ClassTag ](z: B)(op: (A, B) => B): Array[B] = {
@@ -788,7 +788,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
       res(i) = v
       i -= 1
     }
-    res 
+    res
   }
 
   /** Applies a binary operator to all elements of this array and a start value,
@@ -1349,17 +1349,11 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *               for which `f(x)` equals `k`.
     */
   def groupBy[K](f: A => K): immutable.Map[K, Array[A]] = {
-    val m = mutable.Map.empty[K, ArrayBuilder[A]]
-    val len = xs.length
-    var i = 0
-    while(i < len) {
-      val elem = xs(i)
-      val key = f(elem)
-      val bldr = m.getOrElseUpdate(key, ArrayBuilder.make[A])
-      bldr += elem
-      i += 1
-    }
-    m.view.mapValues(_.result()).toMap
+    groupInto(immutable.Map)(f)
+  }
+
+  def groupInto[K, MC[_, _]](mapFactory: MapFactory[MC])(f: A => K): MC[K, Array[A]] = {
+    mapFactory.groupFrom(view, f, ArrayBuilder.make[A])
   }
 
   /**

--- a/src/library/scala/collection/Factory.scala
+++ b/src/library/scala/collection/Factory.scala
@@ -13,10 +13,10 @@
 package scala
 package collection
 
-import scala.collection.immutable.NumericRange
-import scala.language.{higherKinds, implicitConversions}
-import scala.collection.mutable.Builder
 import scala.annotation.unchecked.uncheckedVariance
+import scala.collection.immutable.NumericRange
+import scala.collection.mutable.Builder
+import scala.language.{higherKinds, implicitConversions}
 import scala.reflect.ClassTag
 
 /**
@@ -388,6 +388,10 @@ trait MapFactory[+CC[_, _]] extends Serializable {
 
   def from[K, V](it: IterableOnce[(K, V)]): CC[K, V]
 
+  def groupFrom[A, K, C1](it: IterableOnce[A],
+                          f: A => K,
+                          builder: => Builder[A, C1]): CC[K, C1]
+
   def apply[K, V](elems: (K, V)*): CC[K, V] = from(elems)
 
   def newBuilder[K, V]: Builder[(K, V), CC[K, V]]
@@ -424,6 +428,12 @@ object MapFactory {
   class Delegate[C[_, _]](delegate: MapFactory[C]) extends MapFactory[C] {
     def from[K, V](it: IterableOnce[(K, V)]): C[K, V] = delegate.from(it)
     def empty[K, V]: C[K, V] = delegate.empty
+    def groupFrom[A, K, C1](it: IterableOnce[A],
+                            f: A => K,
+                            builder: => mutable.Builder[A, C1]): C[K, C1] = {
+      delegate.groupFrom(it, f, builder)
+    }
+
     def newBuilder[K, V]: Builder[(K, V), C[K, V]] = delegate.newBuilder
   }
 }

--- a/src/library/scala/collection/MapView.scala
+++ b/src/library/scala/collection/MapView.scala
@@ -76,6 +76,24 @@ object MapView {
     def newBuilder[X, Y]: Builder[(X, Y), View[(X, Y)]] = View.newBuilder[(X, Y)]
     def empty[X, Y]: View[(X, Y)] = View.empty
     def from[X, Y](it: IterableOnce[(X, Y)]): View[(X, Y)] = View.from(it)
+    def groupFrom[A, K1, C1](it: IterableOnce[A],
+                             f: A => K1,
+                             builder: => mutable.Builder[A, C1]): View[(K1, C1)] = {
+      val iterator = it.iterator
+      if (iterator.isEmpty) {
+        empty
+      } else {
+        val m = mutable.Map.empty[K1, Builder[A, C1]]
+        val it = iterator
+        while (it.hasNext) {
+          val elem = it.next()
+          val key = f(elem)
+          val bldr = m.getOrElseUpdate(key, builder)
+          bldr += elem
+        }
+        m.view.mapValues(_.result())
+      }
+    }
   }
 }
 

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -13,7 +13,6 @@
 package scala.collection
 
 import scala.collection.immutable.Range
-
 import scala.language.higherKinds
 import scala.util.hashing.MurmurHash3
 import Searching.{SearchResult, Found, InsertionPoint}
@@ -950,11 +949,11 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     * @return a `Found` value containing the index corresponding to the element in the
     *         sequence, or the `InsertionPoint` where the element would be inserted if
     *         the element is not in the sequence.
-    * 
+    *
     * @note if `to <= from`, the search space is empty, and an `InsertionPoint` at `from`
     *       is returned
     */
-  def search[B >: A](elem: B, from: Int, to: Int) (implicit ord: Ordering[B]): SearchResult = 
+  def search[B >: A](elem: B, from: Int, to: Int) (implicit ord: Ordering[B]): SearchResult =
     linearSearch(view.slice(from, to), elem, math.max(0, from))(ord)
 
   private[this] def linearSearch[B >: A](c: View[A], elem: B, offset: Int)

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -14,8 +14,6 @@ package scala
 package collection
 package immutable
 
-import java.io.{ObjectInputStream, ObjectOutputStream}
-
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable.Map.Map4
 import scala.collection.mutable.{Builder, ReusableBuilder}
@@ -218,6 +216,31 @@ object Map extends MapFactory[Map] {
       case m: Map[K, V] => m
       case _ => (newBuilder[K, V] ++= it).result()
     }
+
+  def groupFrom[A, K, C1](it: IterableOnce[A],
+                          f: A => K,
+                          builder: => mutable.Builder[A, C1]): Map[K, C1] = {
+    val iterator = it.iterator
+    if (iterator.isEmpty) {
+      empty
+    } else {
+      val m = mutable.Map.empty[K, Builder[A, C1]]
+      val it = iterator
+      while (it.hasNext) {
+        val elem = it.next()
+        val key = f(elem)
+        val bldr = m.getOrElseUpdate(key, builder)
+        bldr += elem
+      }
+      var result = empty[K, C1]
+      val mapIt = m.iterator
+      while (mapIt.hasNext) {
+        val (k, v) = mapIt.next()
+        result = result.updated(k, v.result())
+      }
+      result
+    }
+  }
 
   def newBuilder[K, V]: Builder[(K, V), Map[K, V]] = new MapBuilderImpl
 

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -340,6 +340,31 @@ object HashMap extends MapFactory[HashMap] {
     new HashMap[K, V](cap, defaultLoadFactor).addAll(it)
   }
 
+  def groupFrom[A, K, C1](it: IterableOnce[A],
+                          f: A => K,
+                          builder: => mutable.Builder[A, C1]): mutable.HashMap[K, C1] = {
+    val iterator = it.iterator
+    if (iterator.isEmpty) {
+      empty
+    } else {
+      val m = mutable.HashMap.empty[K, Builder[A, C1]]
+      val it = iterator
+      while (it.hasNext) {
+        val elem = it.next()
+        val key = f(elem)
+        val bldr = m.getOrElseUpdate(key, builder)
+        bldr += elem
+      }
+      val result = empty[K, C1]
+      val mapIt = m.iterator
+      while (mapIt.hasNext) {
+        val (k, v) = mapIt.next()
+        result.update(k, v.result())
+      }
+      result
+    }
+  }
+
   def newBuilder[K, V]: Builder[(K, V), HashMap[K, V]] = newBuilder(defaultInitialCapacity, defaultLoadFactor)
 
   def newBuilder[K, V](initialCapacity: Int, loadFactor: Double): Builder[(K, V), HashMap[K, V]] =

--- a/src/library/scala/collection/mutable/ListMap.scala
+++ b/src/library/scala/collection/mutable/ListMap.scala
@@ -75,5 +75,30 @@ class ListMap[K, V]
 object ListMap extends MapFactory[ListMap] {
   def empty[K, V]: ListMap[K, V] = new ListMap[K, V]
   def from[K, V](it: IterableOnce[(K, V)]): ListMap[K,V] = Growable.from(empty[K, V], it)
+  def groupFrom[A, K, C1](it: IterableOnce[A],
+                          f: A => K,
+                          builder: => mutable.Builder[A, C1]): ListMap[K, C1] = {
+    val iterator = it.iterator
+    if (iterator.isEmpty) {
+      empty
+    } else {
+      val m = mutable.SeqMap.empty[K, Builder[A, C1]]
+      val it = iterator
+      while (it.hasNext) {
+        val elem = it.next()
+        val key = f(elem)
+        val bldr = m.getOrElseUpdate(key, builder)
+        bldr += elem
+      }
+      val result = empty[K, C1]
+      val mapIt = m.iterator
+      while (mapIt.hasNext) {
+        val (k, v) = mapIt.next()
+        result.update(k, v.result())
+      }
+      result
+    }
+  }
+
   def newBuilder[K, V]: Builder[(K, V), ListMap[K,V]] = new GrowableBuilder(empty[K, V])
 }

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -5,6 +5,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.collection.immutable.SeqMap
+
 @RunWith(classOf[JUnit4])
 class ArrayOpsTest {
 
@@ -107,5 +109,21 @@ class ArrayOpsTest {
   def copyToArrayOutOfBoundsTest: Unit = {
     val target = Array[Int]()
     assertEquals(0, Array(1,2).copyToArray(target, 1, 0))
+  }
+
+  @Test
+  def groupIntoSeqMap(): Unit = {
+    val array = Array.tabulate(100)(identity)
+    val keys = array.groupInto(SeqMap)(a => a % 10).keys.toArray
+    assertEquals(keys(0), 0)
+    assertEquals(keys(1), 1)
+    assertEquals(keys(2), 2)
+    assertEquals(keys(3), 3)
+    assertEquals(keys(4), 4)
+    assertEquals(keys(5), 5)
+    assertEquals(keys(6), 6)
+    assertEquals(keys(7), 7)
+    assertEquals(keys(8), 8)
+    assertEquals(keys(9), 9)
   }
 }

--- a/test/junit/scala/collection/SeqTest.scala
+++ b/test/junit/scala/collection/SeqTest.scala
@@ -1,9 +1,11 @@
 package scala.collection
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import org.junit.Assert._
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.collection.immutable.SeqMap
 
 @RunWith(classOf[JUnit4])
 class SeqTest {
@@ -89,5 +91,20 @@ class SeqTest {
     assert(s.lengthIs >= 2)
     assert(s.lengthIs > 2)
     assert(s.lengthIs != 2)
+  }
+
+  @Test
+  def groupIntoSeqMap(): Unit = {
+    val keys = Seq.range(0, 100).groupInto(SeqMap)(a => a % 10).keys.toArray
+    assertEquals(keys(0), 0)
+    assertEquals(keys(1), 1)
+    assertEquals(keys(2), 2)
+    assertEquals(keys(3), 3)
+    assertEquals(keys(4), 4)
+    assertEquals(keys(5), 5)
+    assertEquals(keys(6), 6)
+    assertEquals(keys(7), 7)
+    assertEquals(keys(8), 8)
+    assertEquals(keys(9), 9)
   }
 }


### PR DESCRIPTION
For keeping their original ordering.

refs:https://github.com/scala/bug/issues/11276

cc @hrhino 