### PR TITLE
[SUPERSEDED] Werror and friends

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1228,18 +1228,17 @@ class Global(var currentSettings: Settings, reporter0: LegacyReporter)
       // doesn't select a unique phase, that might be surprising too.
       def checkPhaseSettings(including: Boolean, specs: Seq[String]*) = {
         def isRange(s: String) = s.forall(c => c.isDigit || c == '-')
-        def isSpecial(s: String) = (s == "all" || isRange(s))
-        val setting = new ss.PhasesSetting("fake","fake")
+        def isSpecial(s: String) = (s == "_" || isRange(s))
+        val tester = new ss.PhasesSetting("fake","fake")
         for (p <- specs.flatten.to(Set)) {
-          setting.value = List(p)
-          val count = (
-            if (including) first.iterator count (setting containsPhase _)
-            else phaseDescriptors count (setting contains _.phaseName)
-          )
+          tester.value = List(p)
+          val count =
+            if (including) first.iterator.count(tester.containsPhase(_))
+            else phaseDescriptors.count(pd => tester.contains(pd.phaseName))
           if (count == 0) warning(s"'$p' specifies no phase")
           if (count > 1 && !isSpecial(p)) warning(s"'$p' selects $count phases")
           if (!including && isSpecial(p)) globalError(s"-Yskip and -Ystop values must name phases: '$p'")
-          setting.clear()
+          tester.clear()
         }
       }
       // phases that are excluded; for historical reasons, these settings only select by phase name

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -134,7 +134,7 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
       // todo: migrationWarnings
 
       if (settings.fatalWarnings && reporter.hasWarnings)
-        reporter.error(NoPosition, "No warnings can be incurred under -Xfatal-warnings.")
+        reporter.error(NoPosition, "No warnings can be incurred under -Werror.")
     }
   }
 }

--- a/src/compiler/scala/tools/nsc/fsc/OfflineCompilerCommand.scala
+++ b/src/compiler/scala/tools/nsc/fsc/OfflineCompilerCommand.scala
@@ -46,8 +46,8 @@ class OfflineCompilerCommand(arguments: List[String], settings: FscSettings) ext
 
   override def cmdName = "fsc"
   override def usageMsg = (
-    createUsageMsg("where possible fsc", shouldExplain = false, x => x.isStandard && settings.isFscSpecific(x.name)) +
+    createUsageMsg("where possible fsc", explain = false)(x => x.isStandard && settings.isFscSpecific(x.name)) +
     "\n\nStandard scalac options also available:" +
-    createUsageMsg(x => x.isStandard && !settings.isFscSpecific(x.name))
+    optionsMessage(x => x.isStandard && !settings.isFscSpecific(x.name))
   )
 }

--- a/src/compiler/scala/tools/nsc/settings/AbsSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/AbsSettings.scala
@@ -121,13 +121,17 @@ trait AbsSettings extends scala.reflect.internal.settings.AbsSettings {
      */
     def tryToSetFromPropertyValue(s: String): Unit = tryToSet(s :: Nil)
 
-    /** These categorizations are so the help output shows -X and -P among
-     *  the standard options and -Y among the advanced options.
+    /** Standard options are shown on the `-help` output,
+     *  advanced on `-X`, private on `-Y`, warning on `-W`, verbose on `-V`.
+     *
+     *  The single char options themselves, including `-P`, are explained on `-help`.
+     *  Additionally, `-Werror` is on `-help` and `-Xlint` on `-W`.
      */
-    def isAdvanced   = name match { case "-Y" => true ; case "-X" => false ; case _  => name startsWith "-X" }
-    def isPrivate    = name match { case "-Y" => false ; case _  => name startsWith "-Y" }
-    def isStandard   = !isAdvanced && !isPrivate
-    def isForDebug   = name endsWith "-debug" // by convention, i.e. -Ytyper-debug
+    def isAdvanced   = name.startsWith("-X") && name != "-X"
+    def isPrivate    = name.startsWith("-Y") && name != "-Y"
+    def isVerbose    = name.startsWith("-V") && name != "-V"
+    def isWarning    = name match { case "-W" | "-Werror" => false ; case "-Xlint" => true ; case _  => name.startsWith("-W") }
+    def isStandard   = !isAdvanced && !isPrivate && !isWarning && !isVerbose
     def isDeprecated = deprecationMessage.isDefined
 
     def compare(that: Setting): Int = name compare that.name

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -888,9 +888,8 @@ class MutableSettings(val errorFn: String => Unit)
   }
 
   /** A setting represented by a list of strings which should be prefixes of
-   *  phase names. This is not checked here, however.  Alternatively the string
-   *  `"all"` can be used to represent all phases.
-   *  (the empty list, unless set)
+   *  phase names. This is not checked here, however.  Alternatively, underscore
+   *  can be used to indicate all phases.
    */
   class PhasesSetting private[nsc](
     name: String,
@@ -918,7 +917,7 @@ class MutableSettings(val errorFn: String => Unit)
       _names = numsAndStrs._2
       _v     = t
     }
-    override def value = if (v contains "all") List("all") else super.value // i.e., v
+    override def value = if (v contains "_") List("_") else super.value // i.e., v
     private def numericValues = _numbs
     private def stringValues  = _names
     private def phaseIdTest(i: Int): Boolean = numericValues exists (_ match {
@@ -942,14 +941,14 @@ class MutableSettings(val errorFn: String => Unit)
     def clear(): Unit = (v = Nil)
 
     // we slightly abuse the usual meaning of "contains" here by returning
-    // true if our phase list contains "all", regardless of the incoming argument
+    // true if our phase list contains "_", regardless of the incoming argument
     def contains(phName: String)     = doAllPhases || containsName(phName)
     def containsName(phName: String) = stringValues exists (phName startsWith _)
     def containsId(phaseId: Int)     = phaseIdTest(phaseId)
     def containsPhase(ph: Phase)     = contains(ph.name) || containsId(ph.id)
 
-    def doAllPhases = stringValues contains "all"
-    def unparse: List[String] = value map (name + ":" + _)
+    def doAllPhases = stringValues.contains("_")
+    def unparse: List[String] = value.map(v => s"$name:$v")
 
     withHelpSyntax(
       if (default == "") name + ":<phases>"

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -19,12 +19,14 @@ package settings
 trait Warnings {
   self: MutableSettings =>
 
+  val Whelp         = BooleanSetting("-W", "Print a synopsis of warning options.")
+
   // Warning semantics.
-  val fatalWarnings = BooleanSetting("-Xfatal-warnings", "Fail the compilation if there are any warnings.")
+  val fatalWarnings = BooleanSetting("-Werror", "Fail the compilation if there are any warnings.") withAbbreviation "-Xfatal-warnings"
 
   // Non-lint warnings. -- TODO turn into MultiChoiceEnumeration
   val warnMacros           = ChoiceSetting(
-    name    = "-Ywarn-macros",
+    name    = "-Wmacros",
     helpArg = "mode",
     descr   = "Enable lint warnings on macro expansions.",
     choices = List("none", "before", "after", "both"),
@@ -35,10 +37,10 @@ trait Warnings {
       "Only inspect expanded trees when generating unused symbol warnings.",
       "Inspect both user-written code and expanded trees when generating unused symbol warnings."
     )
-  )
-  val warnDeadCode         = BooleanSetting("-Ywarn-dead-code", "Warn when dead code is identified.")
-  val warnValueDiscard     = BooleanSetting("-Ywarn-value-discard", "Warn when non-Unit expression results are unused.")
-  val warnNumericWiden     = BooleanSetting("-Ywarn-numeric-widen", "Warn when numerics are widened.")
+  ) withAbbreviation "-Ywarn-macros"
+  val warnDeadCode         = BooleanSetting("-Wdead-code", "Warn when dead code is identified.") withAbbreviation "-Ywarn-dead-code"
+  val warnValueDiscard     = BooleanSetting("-Wvalue-discard", "Warn when non-Unit expression results are unused.") withAbbreviation "-Ywarn-value-discard"
+  val warnNumericWiden     = BooleanSetting("-Wnumeric-widen", "Warn when numerics are widened.") withAbbreviation "-Ywarn-numeric-widen"
 
   object UnusedWarnings extends MultiChoiceEnumeration {
     val Imports   = Choice("imports",   "Warn if an import selector is not referenced.")
@@ -53,12 +55,12 @@ trait Warnings {
 
   // The -Ywarn-unused warning group.
   val warnUnused = MultiChoiceSetting(
-    name    = "-Ywarn-unused",
+    name    = "-Wunused",
     helpArg = "warning",
     descr   = "Enable or disable specific `unused' warnings",
     domain  = UnusedWarnings,
     default = Some(List("_"))
-  )
+  ) withAbbreviation "-Ywarn-unused"
 
   def warnUnusedImport    = warnUnused contains UnusedWarnings.Imports
   def warnUnusedPatVars   = warnUnused contains UnusedWarnings.PatVars
@@ -68,9 +70,9 @@ trait Warnings {
   def warnUnusedExplicits = warnUnused contains UnusedWarnings.Explicits
   def warnUnusedImplicits = warnUnused contains UnusedWarnings.Implicits
 
-  val warnExtraImplicit   = BooleanSetting("-Ywarn-extra-implicit", "Warn when more than one implicit parameter section is defined.")
+  val warnExtraImplicit   = BooleanSetting("-Wextra-implicit", "Warn when more than one implicit parameter section is defined.") withAbbreviation "-Ywarn-extra-implicit"
 
-  val warnSelfImplicit    = BooleanSetting("-Ywarn-self-implicit", "Warn when an implicit resolves to an enclosing self-definition.")
+  val warnSelfImplicit    = BooleanSetting("-Wself-implicit", "Warn when an implicit resolves to an enclosing self-definition.") withAbbreviation "-Ywarn-self-implicit"
 
   // Experimental lint warnings that are turned off, but which could be turned on programmatically.
   // They are not activated by -Xlint and can't be enabled on the command line because they are not

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -49,7 +49,7 @@ trait Warnings {
     val Locals    = Choice("locals",    "Warn if a local definition is unused.")
     val Explicits = Choice("explicits", "Warn if an explicit parameter is unused.")
     val Implicits = Choice("implicits", "Warn if an implicit parameter is unused.")
-    val Params    = Choice("params",    "Enable -Ywarn-unused:explicits,implicits.", expandsTo = List(Explicits, Implicits))
+    val Params    = Choice("params",    "Enable -Wunused:explicits,implicits.", expandsTo = List(Explicits, Implicits))
     val Linted    = Choice("linted",    "-Xlint:unused.", expandsTo = List(Imports, Privates, Locals, Implicits))
   }
 

--- a/src/scaladoc/scala/tools/nsc/ScalaDoc.scala
+++ b/src/scaladoc/scala/tools/nsc/ScalaDoc.scala
@@ -92,9 +92,9 @@ object ScalaDoc extends ScalaDoc {
   class Command(arguments: List[String], settings: doc.Settings) extends CompilerCommand(arguments, settings) {
     override def cmdName = "scaladoc"
     override def usageMsg = (
-      createUsageMsg("where possible scaladoc", shouldExplain = false, x => x.isStandard && settings.isScaladocSpecific(x.name)) +
+      createUsageMsg("where possible scaladoc", explain = false)(x => x.isStandard && settings.isScaladocSpecific(x.name)) +
       "\n\nStandard scalac options also available:" +
-      createUsageMsg(x => x.isStandard && !settings.isScaladocSpecific(x.name))
+      optionsMessage(x => x.isStandard && !settings.isScaladocSpecific(x.name))
     )
   }
 

--- a/test/files/neg/abstract-inaccessible.check
+++ b/test/files/neg/abstract-inaccessible.check
@@ -10,6 +10,6 @@ abstract-inaccessible.scala:9: warning: method overrideMeAlso in trait YourTrait
 Classes which cannot access Bippy may be unable to override overrideMeAlso.
     def overrideMeAlso(x: Map[Int, Set[Bippy]]) = x.keys.head
         ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/aladdin1055.check
+++ b/test/files/neg/aladdin1055.check
@@ -2,6 +2,6 @@ Test_1.scala:3: warning: match may not be exhaustive.
 It would fail on the following input: (_ : this.<local child>)
   def foo(t: A.T) = t match {
                     ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/case-collision-multifile.check
+++ b/test/files/neg/case-collision-multifile.check
@@ -2,6 +2,6 @@ two.scala:1: warning: Generated class hotDog differs only in case from HotDog (d
   Such classes will overwrite one another on case-insensitive filesystems.
 class hotDog
       ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/case-collision.check
+++ b/test/files/neg/case-collision.check
@@ -22,6 +22,6 @@ case-collision.scala:16: warning: Generated class foo.wackO differs only in case
   Such classes will overwrite one another on case-insensitive filesystems.
 object wackO
        ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 6 warnings found
 one error found

--- a/test/files/neg/catch-all.check
+++ b/test/files/neg/catch-all.check
@@ -7,6 +7,6 @@ catch-all.scala:6: warning: This catches all Throwables. If this is really inten
 catch-all.scala:8: warning: This catches all Throwables. If this is really intended, use `case x : Throwable` to clear this warning.
   try { "warn" } catch { case _: RuntimeException => ; case x => }
                                                             ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/check-dead.check
+++ b/test/files/neg/check-dead.check
@@ -10,6 +10,6 @@ check-dead.scala:30: warning: dead code following this construct
 check-dead.scala:34: warning: dead code following this construct
     throw new Exception // should warn
     ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/checksensible.check
+++ b/test/files/neg/checksensible.check
@@ -116,7 +116,7 @@ checksensible.scala:86: warning: comparing values of types EqEqRefTest.this.C3 a
 checksensible.scala:97: warning: comparing values of types Unit and Int using `!=' will always yield true
     while ((c = in.read) != -1)
                          ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 36 warnings found
 one error found
 #partest !java8
@@ -249,6 +249,6 @@ checksensible.scala:86: warning: comparing values of types EqEqRefTest.this.C3 a
 checksensible.scala:97: warning: comparing values of types Unit and Int using `!=' will always yield true
     while ((c = in.read) != -1)
                          ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 40 warnings found
 one error found

--- a/test/files/neg/classmanifests_new_deprecations.check
+++ b/test/files/neg/classmanifests_new_deprecations.check
@@ -10,6 +10,6 @@ classmanifests_new_deprecations.scala:6: warning: type ClassManifest in package 
 classmanifests_new_deprecations.scala:8: warning: type ClassManifest in package reflect is deprecated (since 2.10.0): use scala.reflect.ClassTag instead
   type RCM[T] = scala.reflect.ClassManifest[T]
                               ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/constant-warning.check
+++ b/test/files/neg/constant-warning.check
@@ -1,6 +1,6 @@
 constant-warning.scala:3: warning: Evaluation of a constant expression results in an arithmetic error: / by zero
   val fails = 1 + 2 / (3 - 2 - 1)
                     ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/constructor-init-order.check
+++ b/test/files/neg/constructor-init-order.check
@@ -4,6 +4,6 @@ constructor-init-order.scala:9: warning: Reference to uninitialized value baz
 constructor-init-order.scala:19: warning: Reference to uninitialized variable baz
   var bar1         = baz     // warn
                      ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/delayed-init-ref.check
+++ b/test/files/neg/delayed-init-ref.check
@@ -10,6 +10,6 @@ trait Before extends DelayedInit {
 delayed-init-ref.scala:42: warning: Selecting value foo from trait UserContext, which extends scala.DelayedInit, is likely to yield an uninitialized value
     println({locally(()); this}.foo)  // warn (spurious, but we can't discriminate)
                                 ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/deprecated-experimental.check
+++ b/test/files/neg/deprecated-experimental.check
@@ -1,6 +1,0 @@
-warning: -Xexperimental is deprecated: In 2.13 all options previously enabled by -Xexperimental are enabled by default or removed.
-deprecated-experimental.scala:3: error: expected class or object definition
-wibble
-^
-one warning found
-one error found

--- a/test/files/neg/deprecated-experimental.scala
+++ b/test/files/neg/deprecated-experimental.scala
@@ -1,3 +1,0 @@
-// scalac: -deprecation -Xexperimental
-//
-wibble

--- a/test/files/neg/deprecated-options.check
+++ b/test/files/neg/deprecated-options.check
@@ -1,0 +1,7 @@
+warning: -target is deprecated: -target:jvm-1.7 is deprecated, forcing use of jvm-1.8
+warning: -Xfuture is deprecated: Not used since 2.13.
+warning: -optimize is deprecated: Since 2.12, enables -opt:l:inline -opt-inline-from:**. See -opt:help.
+warning: -Xexperimental is deprecated: Not used since 2.13.
+error: No warnings can be incurred under -Xfatal-warnings.
+four warnings found
+one error found

--- a/test/files/neg/deprecated-options.check
+++ b/test/files/neg/deprecated-options.check
@@ -2,6 +2,6 @@ warning: -target is deprecated: -target:jvm-1.7 is deprecated, forcing use of jv
 warning: -Xfuture is deprecated: Not used since 2.13.
 warning: -optimize is deprecated: Since 2.12, enables -opt:l:inline -opt-inline-from:**. See -opt:help.
 warning: -Xexperimental is deprecated: Not used since 2.13.
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/deprecated-options.scala
+++ b/test/files/neg/deprecated-options.scala
@@ -1,0 +1,4 @@
+//
+// scalac: -Werror -deprecation -optimise -Xexperimental -Xfuture -target:jvm-1.7
+//
+// Deprecated options are announced before compilation.

--- a/test/files/neg/deprecated-target.check
+++ b/test/files/neg/deprecated-target.check
@@ -1,4 +1,0 @@
-warning: -target is deprecated: -target:jvm-1.7 is deprecated, forcing use of jvm-1.8
-error: No warnings can be incurred under -Xfatal-warnings.
-one warning found
-one error found

--- a/test/files/neg/deprecated-target.scala
+++ b/test/files/neg/deprecated-target.scala
@@ -1,3 +1,0 @@
-// scalac: -target:jvm-1.7 -deprecation -Xfatal-warnings
-//
-class C

--- a/test/files/neg/exhausting.check
+++ b/test/files/neg/exhausting.check
@@ -22,6 +22,6 @@ exhausting.scala:58: warning: match may not be exhaustive.
 It would fail on the following inputs: (Bar1, Bar2), (Bar1, Bar3), (Bar2, Bar1), (Bar2, Bar2)
   def fail5[T](xx: (Foo[T], Foo[T])) = xx match {
                                        ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 6 warnings found
 one error found

--- a/test/files/neg/forgot-interpolator.check
+++ b/test/files/neg/forgot-interpolator.check
@@ -22,6 +22,6 @@ forgot-interpolator.scala:91: warning: possible missing interpolator: detected i
 forgot-interpolator.scala:92: warning: possible missing interpolator: detected interpolated identifier `$calico`
     def f4 = "I also salute $calico" // warn 9
              ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 8 warnings found
 one error found

--- a/test/files/neg/implicit-ambiguous-invalid.check
+++ b/test/files/neg/implicit-ambiguous-invalid.check
@@ -2,6 +2,6 @@ implicit-ambiguous-invalid.scala:7: warning: Invalid implicitAmbiguous message f
 The type parameter B referenced in the message of the @implicitAmbiguous annotation is not defined by method neqAmbig1.
   implicit def neqAmbig1[A] : A =!= A = null
                ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/implicit-any2stringadd-warning.check
+++ b/test/files/neg/implicit-any2stringadd-warning.check
@@ -1,6 +1,6 @@
 implicit-any2stringadd-warning.scala:4: warning: method any2stringadd in object Predef is deprecated (since 2.13.0): Implicit injection of + is deprecated. Convert to String to call +
   true + "what"
   ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/implicitly-self.check
+++ b/test/files/neg/implicitly-self.check
@@ -10,6 +10,6 @@ implicitly-self.scala:10: warning: Implicit resolves to enclosing value t
 implicitly-self.scala:13: warning: Implicit resolves to enclosing object tcString
   implicit object tcString extends TC[String] { def ix = implicitly[TC[String]].ix + 1 }
                                                                    ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/inlineIndyLambdaPrivate.check
+++ b/test/files/neg/inlineIndyLambdaPrivate.check
@@ -11,6 +11,6 @@ The callee A_1::test()Ljava/lang/String; contains the instruction INVOKEDYNAMIC 
 that would cause an IllegalAccessError when inlined into class Test.
   def foo = A_1.test
                 ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/iterable-ordering.check
+++ b/test/files/neg/iterable-ordering.check
@@ -1,6 +1,6 @@
 iterable-ordering.scala:2: warning: method Iterable in object Ordering is deprecated (since 2.13.0): Iterables are not guaranteed to have a consistent order; if using a type with a consistent order (e.g. Seq), use its Ordering (found in the Ordering.Implicits object)
   val o = Ordering[Iterable[Int]]
                   ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/main1.check
+++ b/test/files/neg/main1.check
@@ -68,6 +68,6 @@ main1.scala:67: warning: not a valid main method for p8.Main,
 
     def main(args: Array[Int]) = ()
         ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 11 warnings found
 one error found

--- a/test/files/neg/main2.check
+++ b/test/files/neg/main2.check
@@ -4,6 +4,6 @@ main2.scala:7: warning: X has a valid main method (args: Array[String])Unit,
 
   object X {
          ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/maxwarns.check
+++ b/test/files/neg/maxwarns.check
@@ -7,6 +7,6 @@ maxwarns.scala:16: warning: method x in object X is deprecated (since forever): 
 maxwarns.scala:18: warning: method x in object X is deprecated (since forever): just to annoy people
   def c = x
           ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 5 warnings found
 one error found

--- a/test/files/neg/newpat_unreachable.check
+++ b/test/files/neg/newpat_unreachable.check
@@ -30,6 +30,6 @@ newpat_unreachable.scala:26: warning: unreachable code due to variable pattern '
 newpat_unreachable.scala:25: warning: unreachable code
           case c => 2
                     ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 9 warnings found
 one error found

--- a/test/files/neg/nonlocal-warning.check
+++ b/test/files/neg/nonlocal-warning.check
@@ -4,6 +4,6 @@ nonlocal-warning.scala:6: warning: This catches all Throwables. If this is reall
 nonlocal-warning.scala:4: warning: catch block may intercept non-local return from method foo
   def foo(l: List[Int]): Int = {
                                ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/nonsense_eq_refine.check
+++ b/test/files/neg/nonsense_eq_refine.check
@@ -4,6 +4,6 @@ nonsense_eq_refine.scala:6: warning: E and String are unrelated: they will most 
 nonsense_eq_refine.scala:9: warning: SE and String are unrelated: they will most likely never compare equal
   if (se == "") ??? // types are still unrelated
          ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/nullary-override.check
+++ b/test/files/neg/nullary-override.check
@@ -1,6 +1,6 @@
 nullary-override.scala:4: warning: non-nullary method overrides nullary method
 class B extends A { override def x(): Int = 4 }
                                  ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/numeric-add-string-warning.check
+++ b/test/files/neg/numeric-add-string-warning.check
@@ -1,6 +1,6 @@
 numeric-add-string-warning.scala:4: warning: method + in class Int is deprecated (since 2.13.0): Adding a number and a String is deprecated. Use the string interpolation `s"$num$str"`
   val x = 4 + "2"
             ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/optimiseDeprecated.check
+++ b/test/files/neg/optimiseDeprecated.check
@@ -1,4 +1,0 @@
-warning: -optimise is deprecated: In 2.12, -optimise enables -opt:l:inline -opt-inline-from:**. Check -opt:help for using the Scala 2.12 optimizer.
-error: No warnings can be incurred under -Xfatal-warnings.
-one warning found
-one error found

--- a/test/files/neg/optimiseDeprecated.scala
+++ b/test/files/neg/optimiseDeprecated.scala
@@ -1,3 +1,0 @@
-// scalac: -optimise -deprecation -Xfatal-warnings
-//
-class C

--- a/test/files/neg/outer-ref-checks.check
+++ b/test/files/neg/outer-ref-checks.check
@@ -19,6 +19,6 @@ outer-ref-checks.scala:48: warning: The outer reference in this type test cannot
 outer-ref-checks.scala:58: warning: The outer reference in this type test cannot be checked at run time.
     case _: (Inner @uncheckedVariance) => // unchecked warning
           ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 7 warnings found
 one error found

--- a/test/files/neg/overloaded-implicit.check
+++ b/test/files/neg/overloaded-implicit.check
@@ -5,6 +5,6 @@ overloaded-implicit.scala:5: warning: parameterized overloaded implicit methods 
   implicit def imp1[T](x: Set[T]): Map[T, T] = Map()
                ^
 warning: there were four feature warnings; re-run with -feature for details
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/pat_unreachable.check
+++ b/test/files/neg/pat_unreachable.check
@@ -12,6 +12,6 @@ pat_unreachable.scala:26: warning: unreachable code due to variable pattern 'b' 
 pat_unreachable.scala:25: warning: unreachable code
     case c => println("matched c")
                      ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/patmat-classtag-compound.check
+++ b/test/files/neg/patmat-classtag-compound.check
@@ -1,6 +1,6 @@
 patmat-classtag-compound.scala:14: warning: abstract type pattern A is unchecked since it is eliminated by erasure
     case b: A with Bar => true
             ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/patmatexhaust.check
+++ b/test/files/neg/patmatexhaust.check
@@ -37,6 +37,6 @@ patmatexhaust.scala:128: warning: match may not be exhaustive.
 It would fail on the following input: C1()
     def ma10(x: C) = x match { // not exhaustive: C1 is not abstract.
                      ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 10 warnings found
 one error found

--- a/test/files/neg/permanent-blindness.check
+++ b/test/files/neg/permanent-blindness.check
@@ -7,6 +7,6 @@ permanent-blindness.scala:12: warning: imported `Bop' is permanently hidden by d
 permanent-blindness.scala:12: warning: imported `Dingus' is permanently hidden by definition of object Dingus in package bar
   import foo.{ Bippy, Bop, Dingus }
                            ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/procedure-deprecation.check
+++ b/test/files/neg/procedure-deprecation.check
@@ -10,6 +10,6 @@ procedure-deprecation.scala:6: warning: procedure syntax is deprecated: instead,
 procedure-deprecation.scala:7: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type
   def boz(i: Int, l: Long) {}
                            ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/sealed-final-neg.check
+++ b/test/files/neg/sealed-final-neg.check
@@ -6,6 +6,6 @@ sealed-final-neg.scala:39: warning: neg2/Foo::bar(I)I is annotated @inline but c
 The method is not final and may be overridden.
     def f = Foo.mkFoo() bar 10
                         ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/sealed-java-enums.check
+++ b/test/files/neg/sealed-java-enums.check
@@ -2,6 +2,6 @@ sealed-java-enums.scala:7: warning: match may not be exhaustive.
 It would fail on the following inputs: BLOCKED, TERMINATED, TIMED_WAITING
   def f(state: State) = state match {
                         ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/sip23-uninitialized-1.check
+++ b/test/files/neg/sip23-uninitialized-1.check
@@ -1,6 +1,6 @@
 sip23-uninitialized-1.scala:4: warning: value f1 in object Test does nothing other than call itself recursively
   val f1: 1 = f1   // warning: recursive
               ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/sip23-uninitialized-3.check
+++ b/test/files/neg/sip23-uninitialized-3.check
@@ -1,6 +1,6 @@
 sip23-uninitialized-3.scala:4: warning: variable f3 in object Test does nothing other than call itself recursively
   var f3: 1 = f3   // warning: recursive
               ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/stmt-expr-discard.check
+++ b/test/files/neg/stmt-expr-discard.check
@@ -4,6 +4,6 @@ stmt-expr-discard.scala:5: warning: a pure expression does nothing in statement 
 stmt-expr-discard.scala:6: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
     - 4
     ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/switch.check
+++ b/test/files/neg/switch.check
@@ -4,6 +4,6 @@ switch.scala:40: warning: could not emit switch for @switch annotated match
 switch.scala:47: warning: could not emit switch for @switch annotated match
   def fail3(c: Char) = (c: @unchecked @switch) match {
                                        ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/t10270.check
+++ b/test/files/neg/t10270.check
@@ -1,6 +1,6 @@
 Main_2.scala:5: warning: Unused import
     import Implicits._
                      ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t10296-after.check
+++ b/test/files/neg/t10296-after.check
@@ -1,6 +1,6 @@
 Unused_2.scala:7: warning: private method g in object Unused is never used
   private def g(): Int = 17
               ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t10296-both.check
+++ b/test/files/neg/t10296-both.check
@@ -4,6 +4,6 @@ Unused_2.scala:8: warning: private method k in object Unused is never used
 Unused_2.scala:7: warning: private method g in object Unused is never used
   private def g(): Int = 17
               ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/t10296-warn.check
+++ b/test/files/neg/t10296-warn.check
@@ -1,6 +1,6 @@
 Unused_2.scala:9: warning: private method unusedMacro in object Unused is never used
   private def unusedMacro(): Unit = macro UnusedMacro.usedMacroImpl
               ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t10511.check
+++ b/test/files/neg/t10511.check
@@ -7,6 +7,6 @@ t10511.scala:4: warning: object DeprecatedDoubleOrdering in object Ordering is d
 t10511.scala:7: warning: object DeprecatedDoubleOrdering in object Ordering is deprecated (since 2.13.0): There are multiple ways to order Doubles (Ordering.Double.TotalOrdering, Ordering.Double.IeeeOrdering). Specify one by using a local import, assigning an implicit val, or passing it explicitly. See the documentation for details.
   list.sorted
        ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/t10806.check
+++ b/test/files/neg/t10806.check
@@ -7,6 +7,6 @@ t10806.scala:18: warning: unreachable code
 t10806.scala:23: warning: unreachable code
       case e: IllegalArgumentException ⇒ println(e.getMessage)
                                                 ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/t10820-warn.check
+++ b/test/files/neg/t10820-warn.check
@@ -1,6 +1,6 @@
 t10820-warn.scala:13: warning: return statement uses an exception to pass control to the caller of the enclosing named method result
   def result: Option[Int] = Try(0/0).recoverWith { case _ => return Some(-1) }.toOption
                                                              ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t11012.check
+++ b/test/files/neg/t11012.check
@@ -7,6 +7,6 @@ t11012.scala:10: warning: constructor B in class B is deprecated: constructor!
 t11012.scala:13: warning: constructor B in class B is deprecated: constructor!
   def foo = new B
             ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/t1909-object.check
+++ b/test/files/neg/t1909-object.check
@@ -1,6 +1,6 @@
 t1909-object.scala:6: warning: !!! scala/bug#1909 Unable to STATICally lift object InnerTrouble$2, which is defined in the self- or super-constructor call of class Kaboom. A VerifyError is likely.
       object InnerTrouble
              ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t2442.check
+++ b/test/files/neg/t2442.check
@@ -6,6 +6,6 @@ t2442.scala:11: warning: match may not be exhaustive.
 It would fail on the following input: BLUE
   def g(e: MySecondEnum) = e match {
                            ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/t2462b.check
+++ b/test/files/neg/t2462b.check
@@ -15,6 +15,6 @@ The type parameters XX, ZZ, Nix referenced in the message of the @implicitNotFou
     def m[S](implicit @implicitNotFound("${X} ${Y} ${ Z } ${R} ${S} -- ${XX} ${ZZ} ${ Nix }") i: Int) = ???
                                                                                               ^
 warning: there were two feature warnings; re-run with -feature for details
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 5 warnings found
 one error found

--- a/test/files/neg/t2796.check
+++ b/test/files/neg/t2796.check
@@ -13,6 +13,6 @@ class C1 extends {
 t2796.scala:10: warning: Implementation restriction: early definitions in traits are not initialized before the super class is initialized.
   val abstractVal = "T1.abstractVal" // warn
       ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 5 warnings found
 one error found

--- a/test/files/neg/t284.check
+++ b/test/files/neg/t284.check
@@ -1,6 +1,6 @@
 t284.scala:4: warning: Detected apparent refinement of Unit; are you missing an '=' sign?
   def f1(a: T): Unit { }
                      ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t3098.check
+++ b/test/files/neg/t3098.check
@@ -2,6 +2,6 @@ b.scala:3: warning: match may not be exhaustive.
 It would fail on the following input: (_ : C)
   def f = (null: T) match {
                ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t3683a.check
+++ b/test/files/neg/t3683a.check
@@ -2,6 +2,6 @@ t3683a.scala:16: warning: match may not be exhaustive.
 It would fail on the following input: XX()
     w match {
     ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t3692-new.check
+++ b/test/files/neg/t3692-new.check
@@ -10,6 +10,6 @@ t3692-new.scala:19: warning: non-variable type argument Int in type pattern scal
 t3692-new.scala:18: warning: unreachable code
       case m1: Map[Int, V] => new java.util.HashMap[Integer, V]
                               ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/t4302.check
+++ b/test/files/neg/t4302.check
@@ -1,6 +1,6 @@
 t4302.scala:4: warning: abstract type T is unchecked since it is eliminated by erasure
   def hasMatch[T](x: AnyRef) = x.isInstanceOf[T]
                                              ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t4440.check
+++ b/test/files/neg/t4440.check
@@ -10,6 +10,6 @@ t4440.scala:18: warning: The outer reference in this type test cannot be checked
 t4440.scala:19: warning: The outer reference in this type test cannot be checked at run time.
     case _: b.Inner => println("b") // this is the case we want
           ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/t4691_exhaust_extractor.check
+++ b/test/files/neg/t4691_exhaust_extractor.check
@@ -10,6 +10,6 @@ t4691_exhaust_extractor.scala:31: warning: match may not be exhaustive.
 It would fail on the following input: Bar3()
   def f3(x: Foo) = x match {
                    ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/t4749.check
+++ b/test/files/neg/t4749.check
@@ -44,6 +44,6 @@ t4749.scala:44: warning: not a valid main method for bippy.Win3,
 
   object Win3 extends WinBippy[Unit] { }
          ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 7 warnings found
 one error found

--- a/test/files/neg/t4762.check
+++ b/test/files/neg/t4762.check
@@ -4,6 +4,6 @@ t4762.scala:17: warning: private[this] value x in class B shadows mutable x inhe
 t4762.scala:50: warning: private[this] value x in class Derived shadows mutable x inherited from class Base.  Changes to x will not be visible within class Derived - you may want to give them distinct names.
   class Derived( x : Int ) extends Base( x ) { override def toString = x.toString }
                                                                        ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/t4851.check
+++ b/test/files/neg/t4851.check
@@ -46,6 +46,6 @@ S.scala:16: warning: Adapting argument list by creating a 3-tuple: this may not 
  after adaptation: Test.anyId((1, 2, 3): (Int, Int, Int))
   val w1 = anyId(1, 2 ,3)
                 ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 8 warnings found
 one error found

--- a/test/files/neg/t5426.check
+++ b/test/files/neg/t5426.check
@@ -10,6 +10,6 @@ t5426.scala:10: warning: comparing values of types Int and Some[Int] using `==' 
 t5426.scala:11: warning: comparing values of types Some[Int] and Int using `==' will always yield false
   (x2 == x1)
       ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/t5440.check
+++ b/test/files/neg/t5440.check
@@ -2,6 +2,6 @@ t5440.scala:5: warning: match may not be exhaustive.
 It would fail on the following inputs: (List(_), Nil), (Nil, List(_))
     (list1, list2) match {
     ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t5663-badwarneq.check
+++ b/test/files/neg/t5663-badwarneq.check
@@ -37,6 +37,6 @@ t5663-badwarneq.scala:83: warning: comparing values of types ValueClass3 and Val
 t5663-badwarneq.scala:84: warning: comparing values of types ValueClass3 and Int using `==' will always yield false
     println(ValueClass3(5) == 5) // bad
                            ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 13 warnings found
 one error found

--- a/test/files/neg/t5675.check
+++ b/test/files/neg/t5675.check
@@ -1,4 +1,4 @@
 warning: there was one feature warning; re-run with -feature for details
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t5691.check
+++ b/test/files/neg/t5691.check
@@ -19,6 +19,6 @@ t5691.scala:22: warning: type parameter List defined in type M shadows type List
 t5691.scala:23: warning: type parameter List defined in type M shadows type List defined in package object scala. You may want to rename your type parameter, or possibly remove it.
   def foo[N[M[List[_]]]] = ???
               ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 7 warnings found
 one error found

--- a/test/files/neg/t5762.check
+++ b/test/files/neg/t5762.check
@@ -10,6 +10,6 @@ t5762.scala:22: warning: non-variable type argument D[Int] in type pattern D[D[I
 t5762.scala:23: warning: non-variable type argument D[String] in type pattern D[D[String]] is unchecked since it is eliminated by erasure
     case _: D[D[String]]          => 2
             ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/t5830.check
+++ b/test/files/neg/t5830.check
@@ -4,6 +4,6 @@ t5830.scala:8: warning: unreachable code
 t5830.scala:6: warning: could not emit switch for @switch annotated match
   def unreachable(ch: Char) = (ch: @switch) match {
                                     ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/t6011.check
+++ b/test/files/neg/t6011.check
@@ -7,6 +7,6 @@ t6011.scala:12: warning: unreachable code
 t6011.scala:10: warning: could not emit switch for @switch annotated match
   def f2(ch: Char): Any = (ch: @annotation.switch) match {
                                 ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/t6048.check
+++ b/test/files/neg/t6048.check
@@ -13,6 +13,6 @@ t6048.scala:16: warning: unreachable code due to variable pattern on line 15
 t6048.scala:16: warning: unreachable code
     case 5 if true  => x // unreachable
                        ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 5 warnings found
 one error found

--- a/test/files/neg/t6120.check
+++ b/test/files/neg/t6120.check
@@ -15,6 +15,6 @@ t6120.scala:15: warning: method bippy in class BooleanOps has changed semantics 
 Used to return 5
   def g = true.bippy
                ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 5 warnings found
 one error found

--- a/test/files/neg/t6162-inheritance.check
+++ b/test/files/neg/t6162-inheritance.check
@@ -7,6 +7,6 @@ object SubT extends T
 usage.scala:8: warning: inheritance from trait S in package t6126 is deprecated
   new S {
       ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/t6162-overriding.check
+++ b/test/files/neg/t6162-overriding.check
@@ -4,6 +4,6 @@ t6162-overriding.scala:16: warning: overriding method bar in class Bar is deprec
 t6162-overriding.scala:17: warning: overriding method baz in class Bar is deprecated
   override def baz = 43
                ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/t6217.check
+++ b/test/files/neg/t6217.check
@@ -1,6 +1,6 @@
 t6217.scala:11: warning: _root_ in root position of qualifier refers to the root package, not package _root_ in package p, which is in scope
     import _root_.scala.Option
            ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t6217b.check
+++ b/test/files/neg/t6217b.check
@@ -1,6 +1,6 @@
 t6217b.scala:5: warning: _root_ in root position of qualifier refers to the root package, not package _root_ in package p, which is in scope
   import _root_.scala.Option
          ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t6217c.check
+++ b/test/files/neg/t6217c.check
@@ -13,6 +13,6 @@ t6217c.scala:20: warning: _root_ in root position of qualifier refers to the roo
 t6217c.scala:38: warning: _root_ in root position in package definition does not refer to the root package, but to package _root_ in package a, which is in scope
   package _root_.p {
           ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 5 warnings found
 one error found

--- a/test/files/neg/t6264.check
+++ b/test/files/neg/t6264.check
@@ -1,6 +1,6 @@
 t6264.scala:5: warning: non-variable type argument Tuple1[_] in type Tuple2[_, Tuple1[_]] is unchecked since it is eliminated by erasure
     x.isInstanceOf[Tuple2[_, Tuple1[_]]]
                   ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t6276.check
+++ b/test/files/neg/t6276.check
@@ -16,6 +16,6 @@ t6276.scala:15: warning: method a does nothing other than call itself recursivel
 t6276.scala:24: warning: method a does nothing other than call itself recursively
       def a = a // warn
               ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 6 warnings found
 one error found

--- a/test/files/neg/t6567.check
+++ b/test/files/neg/t6567.check
@@ -5,6 +5,6 @@ t6567.scala:12: warning: Suspicious application of an implicit view (Test.this.a
   val b: Option[B] = Option(a)
                            ^
 warning: there was one feature warning; re-run with -feature for details
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/t6582_exhaust_big.check
+++ b/test/files/neg/t6582_exhaust_big.check
@@ -2,6 +2,6 @@ t6582_exhaust_big.scala:29: warning: match may not be exhaustive.
 It would fail on the following input: Z11()
   def foo(z: Z) = z match {
                   ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t6595.check
+++ b/test/files/neg/t6595.check
@@ -1,6 +1,6 @@
 t6595.scala:5: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
 class Foo extends {
                   ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t6675.check
+++ b/test/files/neg/t6675.check
@@ -1,6 +1,6 @@
 t6675.scala:12: warning: object X expects 3 patterns to hold (Int, Int, Int) but crushing into 3-tuple to fit single pattern (scala/bug#6675)
   "" match { case X(b) => b } // should warn under -Xlint. Not an error because of scala/bug#6111
                   ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t6902.check
+++ b/test/files/neg/t6902.check
@@ -7,6 +7,6 @@ t6902.scala:11: warning: unreachable code
 t6902.scala:23: warning: unreachable code
     case 1 => 3 // crash
               ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/t7014.check
+++ b/test/files/neg/t7014.check
@@ -1,5 +1,5 @@
 warning: While parsing annotations in t7014-neg.obj/t7014/ThreadSafetyLevel_1.class, could not find COMPLETELY_THREADSAFE in enum ThreadSafetyLevel_1.
 This is likely due to an implementation restriction: an annotation argument cannot refer to a member of the annotated class (scala/bug#7014).
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t7020.check
+++ b/test/files/neg/t7020.check
@@ -14,6 +14,6 @@ t7020.scala:26: warning: match may not be exhaustive.
 It would fail on the following inputs: List((x: Int forSome x not in (1, 2, 4, 5, 6, 7))), List((x: Int forSome x not in (1, 2, 4, 5, 6, 7)), _), List(1, _), List(2, _), List(4, _), List(5, _), List(6, _), List(7, _), List(_, _)
   List(5) match {
       ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/t7110.check
+++ b/test/files/neg/t7110.check
@@ -1,6 +1,6 @@
 t7110.scala:4: warning: A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
   try { ??? } // warn
   ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t7171.check
+++ b/test/files/neg/t7171.check
@@ -4,6 +4,6 @@ t7171.scala:4: warning: The outer reference in this type test cannot be checked 
 t7171.scala:11: warning: The outer reference in this type test cannot be checked at run time.
     case _: A => true; case _ => false
           ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/t7171b.check
+++ b/test/files/neg/t7171b.check
@@ -7,6 +7,6 @@ t7171b.scala:10: warning: The outer reference in this type test cannot be checke
 t7171b.scala:15: warning: The outer reference in this type test cannot be checked at run time.
     case _: A => true; case _ => false
           ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/t7285.check
+++ b/test/files/neg/t7285.check
@@ -10,6 +10,6 @@ t7285.scala:53: warning: match may not be exhaustive.
 It would fail on the following input: (Up, Down)
     (d1, d2) match {
     ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/t7290.check
+++ b/test/files/neg/t7290.check
@@ -7,6 +7,6 @@ t7290.scala:7: warning: Pattern contains duplicate alternatives: 2, 3
 t7290.scala:8: warning: Pattern contains duplicate alternatives: 4
     case 4 | (_ @ 4) => 0
          ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/t7369.check
+++ b/test/files/neg/t7369.check
@@ -10,6 +10,6 @@ t7369.scala:33: warning: unreachable code
 t7369.scala:42: warning: unreachable code
     case Tuple1(null) => // unreachable
                       ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/t7623.check
+++ b/test/files/neg/t7623.check
@@ -10,6 +10,6 @@ t7623.scala:13: warning: A repeated case parameter or extracted sequence is not 
 t7623.scala:15: warning: Sequence wildcard (_*) does not align with repeated case parameter or extracted sequence; the result may be unexpected.
   def h = C("") match { case C(s, t, u @ _*) => }    // warn
                              ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/t7669.check
+++ b/test/files/neg/t7669.check
@@ -2,6 +2,6 @@ t7669.scala:11: warning: match may not be exhaustive.
 It would fail on the following input: NotHandled(_)
   def exhausto(expr: Expr): Unit = expr match {
                                    ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t7721.check
+++ b/test/files/neg/t7721.check
@@ -22,6 +22,6 @@ t7721.scala:49: warning: abstract type pattern B.this.Foo is unchecked since it 
 t7721.scala:49: warning: abstract type pattern B.this.Bar is unchecked since it is eliminated by erasure
     case x: Foo with Bar with Concrete => x.bippy + x.barry + x.dingo + x.conco + x.bongo
             ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 8 warnings found
 one error found

--- a/test/files/neg/t7756b.check
+++ b/test/files/neg/t7756b.check
@@ -1,6 +1,6 @@
 t7756b.scala:5: warning: comparing values of types Int and String using `==' will always yield false
     case _ => 0 == ""
                 ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t7783.check
+++ b/test/files/neg/t7783.check
@@ -13,6 +13,6 @@ t7783.scala:15: warning: type D in object O is deprecated:
 t7783.scala:16: warning: type D in object O is deprecated:
   locally(null.asInstanceOf[O.D])
                               ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 5 warnings found
 one error found

--- a/test/files/neg/t7848-interp-warn.check
+++ b/test/files/neg/t7848-interp-warn.check
@@ -22,6 +22,6 @@ t7848-interp-warn.scala:36: warning: possible missing interpolator: detected an 
 t7848-interp-warn.scala:38: warning: possible missing interpolator: detected an interpolated expression
   def z = "${ baz * 3}"                                       // warn, no expr parsing
           ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 8 warnings found
 one error found

--- a/test/files/neg/t7860.check
+++ b/test/files/neg/t7860.check
@@ -4,6 +4,6 @@ t7860.scala:7: warning: private class for your eyes only in object Test is never
 t7860.scala:33: warning: private class C in object Test3 is never used
   private implicit class C(val i: Int) extends AnyVal {       // warn
                          ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/t7984.check
+++ b/test/files/neg/t7984.check
@@ -1,6 +1,6 @@
 t7984.scala:6: warning: non-variable type argument Int in type pattern List[Int] (the underlying of Test.this.ListInt) is unchecked since it is eliminated by erasure
     case is: ListInt => is.head
              ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t8015-ffb.check
+++ b/test/files/neg/t8015-ffb.check
@@ -1,6 +1,6 @@
 t8015-ffb.scala:12: warning: side-effecting nullary methods are discouraged: suggest defining as `def w()` instead
   def w = { x\u000c() }       // ^L is colored blue on this screen, hardly visible
       ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t8035-deprecated.check
+++ b/test/files/neg/t8035-deprecated.check
@@ -16,6 +16,6 @@ t8035-deprecated.scala:11: warning: Adaptation of argument list by inserting () 
  after adaptation: Format.format((): Unit)
   sdf.format()
             ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/t8265.check
+++ b/test/files/neg/t8265.check
@@ -1,6 +1,6 @@
 t8265.scala:3: warning: Construct depends on unsound variance analysis and will not compile in scala 2.11 and beyond
 class Foo[+CC[X]] { type Coll = CC[_] }
                          ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t8417.check
+++ b/test/files/neg/t8417.check
@@ -10,6 +10,6 @@ t8417.scala:7: warning: Adapting argument list by creating a 2-tuple: this may n
  after adaptation: T.f(("holy", "moly"): (String, String))
   def g = f("hello", "world")("holy", "moly")
                              ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/t8430.check
+++ b/test/files/neg/t8430.check
@@ -22,6 +22,6 @@ t8430.scala:22: warning: match may not be exhaustive.
 It would fail on the following inputs: LetC, LetF, LetL(BooleanLit), LetL(IntLit), LetL(UnitLit), LetP
   val f5 = (tree: Tree) => tree match {case LetL(CharLit) => ??? }
                            ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 6 warnings found
 one error found

--- a/test/files/neg/t8450.check
+++ b/test/files/neg/t8450.check
@@ -1,6 +1,6 @@
 t8450.scala:7: warning: implicit numeric widening
   def elapsed: Foo = (System.nanoTime - 100L).foo
                                       ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t8525.check
+++ b/test/files/neg/t8525.check
@@ -10,6 +10,6 @@ t8525.scala:11: warning: private[this] value name in class X shadows mutable nam
 t8525.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
   def u: Unit = ()      // unitarian universalist
       ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/t8597.check
+++ b/test/files/neg/t8597.check
@@ -16,6 +16,6 @@ t8597.scala:20: warning: abstract type T in type pattern Array[T] is unchecked s
 t8597.scala:28: warning: non-variable type argument String in type pattern Array[Array[List[String]]] is unchecked since it is eliminated by erasure
   def warnArrayErasure2   = (null: Any) match {case Some(_: Array[Array[List[String]]]) => } // warn
                                                             ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 6 warnings found
 one error found

--- a/test/files/neg/t8597b.check
+++ b/test/files/neg/t8597b.check
@@ -1,6 +1,6 @@
 t8597b.scala:20: warning: non-variable type argument T in type pattern Some[T] is unchecked since it is eliminated by erasure
         case _: Some[T] => // warn
                 ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t8610-arg.check
+++ b/test/files/neg/t8610-arg.check
@@ -1,6 +1,6 @@
 t8610-arg.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
   def u: Unit = ()      // unitarian universalist
       ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t8610.check
+++ b/test/files/neg/t8610.check
@@ -13,6 +13,6 @@ t8610.scala:11: warning: private[this] value name in class X shadows mutable nam
 t8610.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
   def u: Unit = ()      // unitarian universalist
       ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/t8685.check
+++ b/test/files/neg/t8685.check
@@ -43,6 +43,6 @@ t8685.scala:54: warning: object F in object Extra is deprecated (since now): Ext
 t8685.scala:55: warning: class K in object J is deprecated (since now): Inner K is depr
   def l = new J.K(42)
                 ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 15 warnings found
 one error found

--- a/test/files/neg/t8700a.check
+++ b/test/files/neg/t8700a.check
@@ -6,6 +6,6 @@ Bar.scala:6: warning: match may not be exhaustive.
 It would fail on the following input: B
   def bar2(foo: Baz) = foo match {
                        ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/t8700b.check
+++ b/test/files/neg/t8700b.check
@@ -6,6 +6,6 @@ Bar_2.scala:6: warning: match may not be exhaustive.
 It would fail on the following input: B
   def bar2(foo: Baz_1) = foo match {
                          ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/t8731.check
+++ b/test/files/neg/t8731.check
@@ -1,6 +1,6 @@
 t8731.scala:12: warning: could not emit switch for @switch annotated match
   def g(x: Int) = (x: @annotation.switch) match {
                        ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t8736-c.check
+++ b/test/files/neg/t8736-c.check
@@ -6,6 +6,6 @@ See the Scaladoc for value scala.language.higherKinds for a discussion
 why the feature should be explicitly enabled.
   def hk[M[_]] = ???
          ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t9127.check
+++ b/test/files/neg/t9127.check
@@ -7,6 +7,6 @@ t9127.scala:7: warning: possible missing interpolator: detected an interpolated 
 t9127.scala:8: warning: possible missing interpolator: detected interpolated identifier `$s`
   val v = "a$s b"
           ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/t9398.check
+++ b/test/files/neg/t9398.check
@@ -2,6 +2,6 @@ match.scala:3: warning: match may not be exhaustive.
 It would fail on the following input: CC(B2)
   def test(c: CC): Unit = c match {
                           ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t9636.check
+++ b/test/files/neg/t9636.check
@@ -1,6 +1,6 @@
 t9636.scala:13: warning: a type was inferred to be `AnyVal`; this may indicate a programming error.
     if (signature.sameElements(Array(0x1F, 0x8B))) {
                   ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/t9675.check
+++ b/test/files/neg/t9675.check
@@ -22,6 +22,6 @@ t9675.scala:22: warning: comparing values of types Test.A and String using `!=' 
 t9675.scala:24: warning: comparing values of types Test.A and String using `!=' will always yield true
     List(A("x")).foreach((item: A) => item != "x")
                                            ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 8 warnings found
 one error found

--- a/test/files/neg/t9847.check
+++ b/test/files/neg/t9847.check
@@ -40,6 +40,6 @@ t9847.scala:24: warning: a pure expression does nothing in statement position; m
 t9847.scala:24: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
   class D { 42 ; 17 }
                  ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 14 warnings found
 one error found

--- a/test/files/neg/t9953.check
+++ b/test/files/neg/t9953.check
@@ -1,6 +1,6 @@
 t9953.scala:12: warning: Object and X are unrelated: they will never compare equal
   def b = y == x   // warn
             ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/trait_fields_deprecated_overriding.check
+++ b/test/files/neg/trait_fields_deprecated_overriding.check
@@ -1,6 +1,6 @@
 trait_fields_deprecated_overriding.scala:10: warning: overriding value x in trait DeprecatedOverriding is deprecated
   override val x = 2
                ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/unchecked-abstract.check
+++ b/test/files/neg/unchecked-abstract.check
@@ -34,6 +34,6 @@ unchecked-abstract.scala:45: warning: abstract type L in type Covariant[M.this.L
 unchecked-abstract.scala:50: warning: abstract type L in type Covariant[M.this.L] is unchecked since it is eliminated by erasure
     /*   warn */ println(x.isInstanceOf[Covariant[L]])
                                        ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 12 warnings found
 one error found

--- a/test/files/neg/unchecked-knowable.check
+++ b/test/files/neg/unchecked-knowable.check
@@ -4,6 +4,6 @@ unchecked-knowable.scala:20: warning: fruitless type test: a value of type Bippy
 unchecked-knowable.scala:21: warning: fruitless type test: a value of type Bippy cannot also be a B1
   /*   warn */ (new Bippy).isInstanceOf[B1]
                                        ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/unchecked-refinement.check
+++ b/test/files/neg/unchecked-refinement.check
@@ -11,6 +11,6 @@ unchecked-refinement.scala:26: warning: a pattern match on a refinement type is 
     /* nowarn - todo */ case x: AnyRef { def size: Int } if b  => x.size   // this could/should do a static conformance test and not warn
                                 ^
 warning: there was one feature warning; re-run with -feature for details
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 5 warnings found
 one error found

--- a/test/files/neg/unchecked-suppress.check
+++ b/test/files/neg/unchecked-suppress.check
@@ -7,6 +7,6 @@ unchecked-suppress.scala:7: warning: non-variable type argument String in type p
 unchecked-suppress.scala:9: warning: non-variable type argument Int in type pattern (Int, Int) => Int is unchecked since it is eliminated by erasure
     case f: ((Int, Int) => Int)                    =>           // unchecked
                         ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/unchecked.check
+++ b/test/files/neg/unchecked.check
@@ -16,6 +16,6 @@ unchecked.scala:52: warning: non-variable type argument String in type pattern T
 unchecked.scala:57: warning: non-variable type argument Array[T] in type pattern Test.Exp[Array[T]] is unchecked since it is eliminated by erasure
     case ArrayApply(x: Exp[Array[T]], _, _) => x // unchecked
                        ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 6 warnings found
 one error found

--- a/test/files/neg/unchecked2.check
+++ b/test/files/neg/unchecked2.check
@@ -40,6 +40,6 @@ unchecked2.scala:21: warning: non-variable type argument (String, Double) in typ
 unchecked2.scala:22: warning: non-variable type argument String => Double in type Option[String => Double] is unchecked since it is eliminated by erasure
   /*   warn */ (Some(123): Any).isInstanceOf[Option[String => Double]]
                                             ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 14 warnings found
 one error found

--- a/test/files/neg/unchecked3.check
+++ b/test/files/neg/unchecked3.check
@@ -37,6 +37,6 @@ unchecked3.scala:77: warning: abstract type A in type pattern scala.collection.i
 unchecked3.scala:64: warning: unreachable code
     /*   warn */ case _: Array[List[Array[String]]] => ()
                                                        ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 13 warnings found
 one error found

--- a/test/files/neg/unit-returns-value.check
+++ b/test/files/neg/unit-returns-value.check
@@ -10,6 +10,6 @@ unit-returns-value.scala:24: warning: a pure expression does nothing in statemen
 unit-returns-value.scala:25: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
     i2 // warn
     ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/unreachablechar.check
+++ b/test/files/neg/unreachablechar.check
@@ -7,6 +7,6 @@ unreachablechar.scala:7: warning: unreachable code due to variable pattern on li
 unreachablechar.scala:7: warning: unreachable code
     case 'f' => println("not stuff?");
                        ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/view-bounds-deprecation.check
+++ b/test/files/neg/view-bounds-deprecation.check
@@ -6,6 +6,6 @@ view-bounds-deprecation.scala:5: warning: view bounds are deprecated; use an imp
   example: instead of `def f[A <% Int](a: A)` use `def f[A](a: A)(implicit ev: A => Int)`
   def g[C, B <: C, A <% B : Numeric](a: A) = null
                      ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/virtpatmat_exhaust_big.check
+++ b/test/files/neg/virtpatmat_exhaust_big.check
@@ -2,6 +2,6 @@ virtpatmat_exhaust_big.scala:29: warning: match may not be exhaustive.
 It would fail on the following input: Z11()
   def foo(z: Z) = z match {
                   ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/virtpatmat_exhaust_compound.check
+++ b/test/files/neg/virtpatmat_exhaust_compound.check
@@ -10,6 +10,6 @@ virtpatmat_exhaust_compound.scala:24: warning: match may not be exhaustive.
 It would fail on the following input: O2
   def t2(a: Product with Base { def foo: Int }) = a match {
                                                   ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 three warnings found
 one error found

--- a/test/files/neg/virtpatmat_reach_null.check
+++ b/test/files/neg/virtpatmat_reach_null.check
@@ -1,6 +1,6 @@
 virtpatmat_reach_null.scala:15: warning: unreachable code
       case _                              =>  // unreachable
                                           ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/virtpatmat_reach_sealed_unsealed.check
+++ b/test/files/neg/virtpatmat_reach_sealed_unsealed.check
@@ -11,6 +11,6 @@ virtpatmat_reach_sealed_unsealed.scala:21: warning: unreachable code
 virtpatmat_reach_sealed_unsealed.scala:22: warning: unreachable code
   (true: Boolean) match { case true => case false =>  case _: Any => } // exhaustive, last case is unreachable
                                                                   ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 four warnings found
 one error found

--- a/test/files/neg/virtpatmat_unreach_select.check
+++ b/test/files/neg/virtpatmat_unreach_select.check
@@ -1,6 +1,6 @@
 virtpatmat_unreach_select.scala:12: warning: unreachable code
     case WARNING.id => // unreachable
                     ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/warn-inferred-any.check
+++ b/test/files/neg/warn-inferred-any.check
@@ -13,6 +13,6 @@ warn-inferred-any.scala:27: warning: a type was inferred to be `Any`; this may i
 warn-inferred-any.scala:37: warning: a type was inferred to be `Object`; this may indicate a programming error.
   cs.contains(new C2) // warns
      ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 5 warnings found
 one error found

--- a/test/files/neg/warn-unused-implicits.check
+++ b/test/files/neg/warn-unused-implicits.check
@@ -4,6 +4,6 @@ warn-unused-implicits.scala:13: warning: parameter value s in method f is never 
 warn-unused-implicits.scala:33: warning: parameter value s in method i is never used
   def i(implicit s: String, t: Int) = t           // yes, warn
                  ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 two warnings found
 one error found

--- a/test/files/neg/warn-unused-params.check
+++ b/test/files/neg/warn-unused-params.check
@@ -28,6 +28,6 @@ warn-unused-params.scala:89: warning: parameter value i in anonymous function is
 warn-unused-params.scala:95: warning: parameter value i in anonymous function is never used
   def g = for (i <- List(1)) yield 42    // warn map.(i => 42)
                ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 10 warnings found
 one error found

--- a/test/files/neg/warn-unused-patvars.check
+++ b/test/files/neg/warn-unused-patvars.check
@@ -1,6 +1,6 @@
 warn-unused-patvars.scala:11: warning: private val x in trait Boundings is never used
   private val x = 42                      // warn, sanity check
               ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 one warning found
 one error found

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -118,6 +118,6 @@ warn-unused-privates.scala:141: warning: parameter value i in method x_= is neve
 warn-unused-privates.scala:143: warning: parameter value i in method y_= is never used
   private def y_=(i: Int): Unit = ()
                   ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 40 warnings found
 one error found

--- a/test/files/neg/warn-useless-svuid.check
+++ b/test/files/neg/warn-useless-svuid.check
@@ -13,6 +13,6 @@ trait U extends scala.Serializable
 warn-useless-svuid.scala:25: warning: @SerialVersionUID has no effect on traits
 trait V extends java.io.Serializable
       ^
-error: No warnings can be incurred under -Xfatal-warnings.
+error: No warnings can be incurred under -Werror.
 5 warnings found
 one error found

--- a/test/scaladoc/run/t6812.check
+++ b/test/scaladoc/run/t6812.check
@@ -1,2 +1,1 @@
-warning: -Ymacro-no-expand is deprecated: Use -Ymacro-expand:none
 Done.

--- a/test/scaladoc/run/t6812.scala
+++ b/test/scaladoc/run/t6812.scala
@@ -19,6 +19,6 @@ object Test extends ScaladocModelTest {
   """
 
   def scaladocSettings = ""
-  override def extraSettings = super.extraSettings + " -Ymacro-no-expand -deprecation"
+  override def extraSettings = super.extraSettings + " -Ymacro-expand:none -deprecation"
   def testModel(root: Package) = ()
 }


### PR DESCRIPTION
Add standard option `-Werror` alias for `-Xfatal-warnings`.
As with javac, it appears on the `-help` output.

Rename `-Ywarn-foo-bar` as `-Wfoo-bar`, with the previous
name as a abbreviation or alias.

`-W` shows warnings, including all the `-Xlint` and `-Wunused`.

As suggested on https://github.com/scala/scala-dev/issues/430