### PR TITLE
Rename partitionWith to partitionMap, and improve doc

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -407,6 +407,40 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     (res1.result(), res2.result())
   }
 
+  /** Applies a function `f` to each element of the array and returns a pair of arrays: the first one
+    *  made of those values returned by `f` that were wrapped in [[scala.util.Left]], and the second
+    *  one made of those wrapped in [[scala.util.Right]].
+    *
+    *  Example:
+    *  {{{
+    *    val xs = Array(1, "one", 2, "two", 3, "three") partitionMap {
+    *     case i: Int => Left(i)
+    *     case s: String => Right(s)
+    *    }
+    *    // xs == (Array(1, 2, 3),
+    *    //        Array(one, two, three))
+    *  }}}
+    *
+    *  @tparam A1  the element type of the first resulting collection
+    *  @tparam A2  the element type of the second resulting collection
+    *  @param f    the 'split function' mapping the elements of this array to an [[scala.util.Either]]
+    *
+    *  @return     a pair of arrays: the first one made of those values returned by `f` that were wrapped in [[scala.util.Left]], 
+    *              and the second one made of those wrapped in [[scala.util.Right]]. */
+  def partitionMap[A1: ClassTag, A2: ClassTag](f: A => Either[A1, A2]): (Array[A1], Array[A2]) = {
+    val res1 = ArrayBuilder.make[A1]
+    val res2 = ArrayBuilder.make[A2]
+    var i = 0
+    while(i < xs.length) {
+      f(xs(i)) match {
+        case Left(x) => res1 += x
+        case Right(x) => res2 += x
+      }
+      i += 1
+    }
+    (res1.result(), res2.result())
+  }
+
   /** Returns a new array with the elements in reversed order. */
   @inline def reverse: Array[A] = {
     val len = xs.length

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -16,7 +16,7 @@ package collection
 import scala.language.{higherKinds, implicitConversions}
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.mutable.Builder
-import scala.collection.View.{LeftPartitionedWith, RightPartitionedWith}
+import scala.collection.View.{LeftPartitionMapped, RightPartitionMapped}
 import scala.collection.generic.DefaultSerializationProxy
 
 /** Base trait for generic collections.
@@ -668,12 +668,13 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   def collect[B](pf: PartialFunction[A, B]): CC[B] =
     iterableFactory.from(new View.Collect(this, pf))
 
-  /** A pair of ${coll}s, first, consisting of the values that are produced by `f` applied to this $coll elements contained in [[scala.util.Left]] and, second,
-    *  all the values contained in [[scala.util.Right]].
+  /** Applies a function `f` to each element of the $coll and returns a pair of ${coll}s: the first one
+    *  made of those values returned by `f` that were wrapped in [[scala.util.Left]], and the second
+    *  one made of those wrapped in [[scala.util.Right]].
     *
     *  Example:
     *  {{{
-    *    val xs = $Coll(1, "one", 2, "two", 3, "three") partitionWith {
+    *    val xs = $Coll(1, "one", 2, "two", 3, "three") partitionMap {
     *     case i: Int => Left(i)
     *     case s: String => Right(s)
     *    }
@@ -681,16 +682,16 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     *    //        $Coll(one, two, three))
     *  }}}
     *
-    *  @tparam A1         element type of the first resulting collection
-    *  @tparam A2         element type of the second resulting collection
-    *  @param f          split function that map the element of the $coll into an [[scala.util.Either]][A1, A2]
+    *  @tparam A1  the element type of the first resulting collection
+    *  @tparam A2  the element type of the second resulting collection
+    *  @param f    the 'split function' mapping the elements of this $coll to an [[scala.util.Either]]
     *
-    *  @return           a pair of ${coll}s, first, consisting of the values that are produced by `f` applied to this $coll
-    *               elements contained in [[scala.util.Left]] and, second, all the values contained in [[scala.util.Right]].
+    *  @return     a pair of ${coll}s: the first one made of those values returned by `f` that were wrapped in [[scala.util.Left]], 
+    *              and the second one made of those wrapped in [[scala.util.Right]].
     */
-  def partitionWith[A1, A2](f: A => Either[A1, A2]): (CC[A1], CC[A2]) = {
-    val left: View[A1] = new LeftPartitionedWith(this, f)
-    val right: View[A2] = new RightPartitionedWith(this, f)
+  def partitionMap[A1, A2](f: A => Either[A1, A2]): (CC[A1], CC[A2]) = {
+    val left: View[A1] = new LeftPartitionMapped(this, f)
+    val right: View[A2] = new RightPartitionMapped(this, f)
     (iterableFactory.from(left), iterableFactory.from(right))
   }
 

--- a/src/library/scala/collection/StrictOptimizedIterableOps.scala
+++ b/src/library/scala/collection/StrictOptimizedIterableOps.scala
@@ -236,8 +236,8 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
-  // Optimized, push-based version of `partitionWith`
-  override def partitionWith[A1, A2](f: A => Either[A1, A2]): (CC[A1], CC[A2]) = {
+  // Optimized, push-based version of `partitionMap`
+  override def partitionMap[A1, A2](f: A => Either[A1, A2]): (CC[A1], CC[A2]) = {
     val l = iterableFactory.newBuilder[A1]
     val r = iterableFactory.newBuilder[A2]
     foreach { x =>

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -1309,6 +1309,36 @@ final class StringOps(private val s: String) extends AnyVal {
     (res1.toString, res2.toString)
   }
 
+  /** Applies a function `f` to each character of the string and returns a pair of strings: the first one
+    *  made of those characters returned by `f` that were wrapped in [[scala.util.Left]], and the second
+    *  one made of those wrapped in [[scala.util.Right]].
+    *
+    *  Example:
+    *  {{{
+    *    val xs = "1one2two3three" partitionMap { c =>
+    *      if (c > 'a') Left(c) else Right(c)
+    *    }
+    *    // xs == ("onetwothree", "123")
+    *  }}}
+    *
+    *  @param f    the 'split function' mapping the elements of this string to an [[scala.util.Either]]
+    *
+    *  @return     a pair of strings: the first one made of those characters returned by `f` that were wrapped in [[scala.util.Left]], 
+    *              and the second one made of those wrapped in [[scala.util.Right]]. */
+  def partitionMap(f: Char => Either[Char,Char]): (String, String) = {
+    val res1, res2 = new JStringBuilder
+    var i = 0
+    val len = s.length
+    while(i < len) {
+      f(s.charAt(i)) match {
+        case Left(c) => res1.append(c)
+        case Right(c) => res2.append(c)
+      }
+      i += 1
+    }
+    (res1.toString, res2.toString)
+  }
+
   /** Analogous to `zip` except that the elements in each collection are not consumed until a strict operation is
     * invoked on the returned `LazyZip2` decorator.
     *

--- a/src/library/scala/collection/View.scala
+++ b/src/library/scala/collection/View.scala
@@ -164,7 +164,7 @@ object View extends IterableFactory[View] {
   }
 
   @SerialVersionUID(3L)
-  class LeftPartitionedWith[A, A1, A2](underlying: SomeIterableOps[A], f: A => Either[A1, A2]) extends AbstractView[A1] {
+  class LeftPartitionMapped[A, A1, A2](underlying: SomeIterableOps[A], f: A => Either[A1, A2]) extends AbstractView[A1] {
     def iterator = new AbstractIterator[A1] {
       private[this] val self = underlying.iterator
       private[this] var hd: A1 = _
@@ -188,7 +188,7 @@ object View extends IterableFactory[View] {
   }
 
   @SerialVersionUID(3L)
-  class RightPartitionedWith[A, A1, A2](underlying: SomeIterableOps[A], f: A => Either[A1, A2]) extends AbstractView[A2] {
+  class RightPartitionMapped[A, A1, A2](underlying: SomeIterableOps[A], f: A => Either[A1, A2]) extends AbstractView[A2] {
       def iterator = new AbstractIterator[A2] {
         private[this] val self = underlying.iterator
         private[this] var hd: A2 = _

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -354,7 +354,7 @@ final class LazyList[+A] private(private[this] var lazyState: () => LazyList.Sta
 
   override def partition(p: A => Boolean): (LazyList[A], LazyList[A]) = (filter(p), filterNot(p))
 
-  override def partitionWith[A1, A2](f: A => Either[A1, A2]): (LazyList[A1], LazyList[A2]) = {
+  override def partitionMap[A1, A2](f: A => Either[A1, A2]): (LazyList[A1], LazyList[A2]) = {
     val (left, right) = map(f).partition(_.isLeft)
     (left.map(_.asInstanceOf[Left[A1, _]].value), right.map(_.asInstanceOf[Right[_, A2]].value))
   }

--- a/test/junit/scala/collection/BuildFromTest.scala
+++ b/test/junit/scala/collection/BuildFromTest.scala
@@ -105,7 +105,7 @@ class BuildFromTest {
     builder.result()
   }
 
-  def partitionWith[A, B, C, ToL, ToR](coll: Iterable[A])(f: A => Either[B, C])
+  def partitionMap[A, B, C, ToL, ToR](coll: Iterable[A])(f: A => Either[B, C])
               (implicit bfLeft:  BuildFrom[coll.type, B, ToL], bfRight: BuildFrom[coll.type, C, ToR]): (ToL, ToR) = {
     val left = bfLeft.newBuilder(coll)
     val right = bfRight.newBuilder(coll)
@@ -135,14 +135,14 @@ class BuildFromTest {
   }
 
   @Test
-  def partitionWithTest: Unit = {
+  def partitionMapTest: Unit = {
     val xs1 = immutable.List(1, 2, 3)
-    val (xs2, xs3) = partitionWith(xs1)(x => if (x % 2 == 0) Left(x) else Right(x.toString))
+    val (xs2, xs3) = partitionMap(xs1)(x => if (x % 2 == 0) Left(x) else Right(x.toString))
     val xs4: immutable.List[Int] = xs2
     val xs5: immutable.List[String] = xs3
 
     val xs6 = immutable.TreeMap((1, "1"), (2, "2"))
-    val (xs7, xs8) = partitionWith(xs6) { case (k, v) => Left[(String, Int), (Int, Boolean)]((v, k)) }
+    val (xs7, xs8) = partitionMap(xs6) { case (k, v) => Left[(String, Int), (Int, Boolean)]((v, k)) }
     val xs9: immutable.TreeMap[String, Int] = xs7
     val xs10: immutable.TreeMap[Int, Boolean] = xs8
   }

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -270,8 +270,8 @@ class IterableTest {
   }
 
   @Test
-  def partitionWith: Unit = {
-    val (left, right) = Seq(1, "1", 2, "2", 3, "3", 4, "4", 5, "5").partitionWith {
+  def partitionMap: Unit = {
+    val (left, right) = Seq(1, "1", 2, "2", 3, "3", 4, "4", 5, "5").partitionMap {
       case i: Int => Left(i)
       case s: String => Right(s)
     }

--- a/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
@@ -133,7 +133,7 @@ class LazyListLazinessTest {
 
   @Test
   def partitionWith_properlyLazy(): Unit = {
-    val partition = lazyListOp(_.partitionWith(i => if (i % 2 == 0) Left(i) else Right(i)))
+    val partition = lazyListOp(_.partitionMap(i => if (i % 2 == 0) Left(i) else Right(i)))
     val op1 = partition.andThen(_._1)
     val op2 = partition.andThen(_._2)
     val d = DropProfile(dropCount = 1, repeatedDrops = true)


### PR DESCRIPTION
See: https://github.com/scala/collection-strawman/issues/235

Rationale: the "with" suffix is woefully uninformative. Almost any method `foo` that takes parameters could be called `fooWith`. There are a couple of projects in the community where this method was called `partitionWith`, but I think it was more an artifact of the "naming is hard" problem. The standard library should strive not to perpetuate poor name choices.

On the other hand, `partitionMap` describes well what this method does: it is partitioning + mapping. Similarly,`flatMap` is flattening + mapping, and `groupMap` is grouping + mapping, so this would be consistent with other methods in the collections library.