### PR TITLE
Exclude process test from windows

### DIFF
--- a/test/junit/scala/sys/process/ProcessTest.scala
+++ b/test/junit/scala/sys/process/ProcessTest.scala
@@ -83,7 +83,7 @@ class ProcessTest {
   }
 
   // a test for A && B where A fails and B is not started
-  @Test def t10823_short_circuit(): Unit = {
+  @Test def t10823_short_circuit(): Unit = testily {
     def createFile(prefix: String) = {
       val file = createTempFile(prefix, "tmp")
       Files.write(file, List(prefix).asJava, UTF_8)


### PR DESCRIPTION
Windows fails the attempt to delete the temp file.

Todo: check if the output isn't closed by the redirect facility in sys.process?

Fixes: scala/scala-dev#589
