### PR TITLE
Bug Fix #11240. Now Array, Seq, ArraySeq sortWith return the sorted a…

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -478,7 +478,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     val len = xs.length
     def boxed = if(len < ArrayOps.MaxStableSortLength) {
       val a = xs.clone()
-      Sorting.stableSort(xs)(ord.asInstanceOf[Ordering[A]])
+      Sorting.stableSort(a)(ord.asInstanceOf[Ordering[A]])//Performed the sort on 'a' instead of 'xs'
       a
     } else {
       val a = Array.copyAs[AnyRef](xs, len)(ClassTag.AnyRef)

--- a/test/files/run/ArrayOpsSortWithTest.scala
+++ b/test/files/run/ArrayOpsSortWithTest.scala
@@ -1,0 +1,9 @@
+object Test extends App {
+
+  val unsortedArray = Array[Int](1,-1,-100,0,100,99,91,10,91)
+  val sortedArray = unsortedArray.sortWith(_ < _)
+
+  assert(sortedArray.mkString(" ") == "-100 -1 0 1 10 91 91 99 100")
+  assert(unsortedArray.mkString(" ") == "1 -1 -100 0 100 99 91 10 91")
+
+}


### PR DESCRIPTION
…rray instead of the old array.

scala/bug#11240