### PR TITLE
Apply consistent rules for key & value identities to maps and sets

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -577,7 +577,7 @@ private final class BitmapIndexedMapNode[K, +V](
 
     // copy 'src' and set 1 element(s) at position 'idx'
     arraycopy(src, 0, dst, 0, src.length)
-    dst(idx) = newKey
+    //dst(idx) = newKey
     dst(idx + 1) = newValue
     new BitmapIndexedMapNode[K, V1](dataMap, nodeMap, dst, originalHashes, size, cachedJavaKeySetHashCode)
   }
@@ -1428,7 +1428,7 @@ private[immutable] final class HashMapBuilder[K, V] extends Builder[(K, V), Hash
   private def setValue[V1 >: V](bm: BitmapIndexedMapNode[K, V], bitpos: Int, newKey: K, newValue: V1): Unit = {
     val dataIx = bm.dataIndex(bitpos)
     val idx = TupleLength * dataIx
-    bm.content(idx) = newKey
+    //bm.content(idx) = newKey
     bm.content(idx + 1) = newValue
   }
 

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -298,7 +298,8 @@ private final class BitmapIndexedSetNode[A](
         val element0UnimprovedHash = getHash(index)
         val element0Hash = improve(element0UnimprovedHash)
         if (element0.equals(element)) {
-          return copyAndSetValue(bitpos, element, originalHash, elementHash)
+          return this
+          //return copyAndSetValue(bitpos, element, originalHash, elementHash)
         } else {
           val subNodeNew = mergeTwoKeyValPairs(element0, element0UnimprovedHash, element0Hash, element, originalHash, elementHash, shift + BitPartitionSize)
           return copyAndMigrateFromInlineToNode(bitpos, element0Hash, subNodeNew)

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -127,15 +127,15 @@ sealed class ListMap[K, +V]
       else containsInternal(cur.next, k)
 
     override def updated[V2 >: V1](k: K, v: V2): ListMap[K, V2] = {
-      val m = this - k
-      new m.Node[V2](k, v)
+      val (m, k0) = removeInternal(k, this, Nil)
+      new m.Node[V2](k0, v)
     }
 
-    override def removed(k: K): ListMap[K, V1] = removeInternal(k, this, Nil)
+    override def removed(k: K): ListMap[K, V1] = removeInternal(k, this, Nil)._1
 
-    @tailrec private[this] def removeInternal(k: K, cur: ListMap[K, V1], acc: List[ListMap[K, V1]]): ListMap[K, V1] =
-      if (cur.isEmpty) acc.last
-      else if (k == cur.key) acc.foldLeft(cur.next) { (t, h) => new t.Node(h.key, h.value) }
+    @tailrec private[this] def removeInternal(k: K, cur: ListMap[K, V1], acc: List[ListMap[K, V1]]): (ListMap[K, V1], K) =
+      if (cur.isEmpty) (acc.last, k)
+      else if (k == cur.key) (acc.foldLeft(cur.next) { (t, h) => new t.Node(h.key, h.value) }, cur.key)
       else removeInternal(k, cur.next, cur :: acc)
 
     override protected def next: ListMap[K, V1] = ListMap.this

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -200,7 +200,7 @@ private[collection] object RedBlackTree {
     val cmp = ordering.compare(k, tree.key)
     if (cmp < 0) balanceLeft(isBlackTree(tree), tree.key, tree.value, upd(tree.left, k, v, overwrite), tree.right)
     else if (cmp > 0) balanceRight(isBlackTree(tree), tree.key, tree.value, tree.left, upd(tree.right, k, v, overwrite))
-    else if (overwrite || k != tree.key) mkTree(isBlackTree(tree), k, v, tree.left, tree.right)
+    else if (overwrite || k != tree.key) mkTree(isBlackTree(tree), tree.key, v, tree.left, tree.right)
     else tree
   }
   private[this] def updNth[A, B, B1 >: B](tree: Tree[A, B], idx: Int, k: A, v: B1, overwrite: Boolean): Tree[A, B1] = if (tree eq null) {

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -129,7 +129,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
     e | MissingBit
   }
 
-  private def seekEntryOrOpen(h: Int, k: AnyRef): Int = {
+  @`inline` private def seekEntryOrOpen(h: Int, k: AnyRef): Int = {
     var e = h & mask
     var x = 0
     var g = 0
@@ -251,12 +251,11 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
 
   override def put(key: K, value: V): Option[V] = {
     val h = hashOf(key)
-    val k = key
-    val i = seekEntryOrOpen(h, k)
+    val i = seekEntryOrOpen(h, key)
     if (i < 0) {
       val j = i & IndexMask
       _hashes(j) = h
-      _keys(j) = k
+      _keys(j) = key
       _values(j) = value.asInstanceOf[AnyRef]
       _size += 1
       if ((i & VacantBit) != 0) _vacant -= 1
@@ -266,7 +265,6 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
     else {
       val ans = Some(_values(i).asInstanceOf[V])
       _hashes(i) = h
-      _keys(i) = k
       _values(i) = value.asInstanceOf[AnyRef]
       ans
     }
@@ -278,12 +276,11 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
    */
   override def update(key: K, value: V): Unit = {
     val h = hashOf(key)
-    val k = key
-    val i = seekEntryOrOpen(h, k)
+    val i = seekEntryOrOpen(h, key)
     if (i < 0) {
       val j = i & IndexMask
       _hashes(j) = h
-      _keys(j) = k
+      _keys(j) = key
       _values(j) = value.asInstanceOf[AnyRef]
       _size += 1
       if ((i & VacantBit) != 0) _vacant -= 1
@@ -291,7 +288,6 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
     }
     else {
       _hashes(i) = h
-      _keys(i) = k
       _values(i) = value.asInstanceOf[AnyRef]
     }
   }

--- a/src/library/scala/collection/mutable/ListMap.scala
+++ b/src/library/scala/collection/mutable/ListMap.scala
@@ -43,14 +43,18 @@ class ListMap[K, V]
   def get(key: K): Option[V] = elems find (_._1 == key) map (_._2)
   def iterator: Iterator[(K, V)] = elems.iterator
 
-  final override def addOne(kv: (K, V)) = { elems = remove(kv._1, elems, List()); elems = kv :: elems; siz += 1; this }
+  final override def addOne(kv: (K, V)) = {
+    val (e, key0) = remove(kv._1, elems, List())
+    elems = (key0, kv._2) :: e
+    siz += 1; this
+  }
 
-  final override def subtractOne(key: K) = { elems = remove(key, elems, List()); this }
+  final override def subtractOne(key: K) = { elems = remove(key, elems, List())._1; this }
 
   @tailrec
-  private def remove(key: K, elems: List[(K, V)], acc: List[(K, V)]): List[(K, V)] = {
-    if (elems.isEmpty) acc
-    else if (elems.head._1 == key) { siz -= 1; acc ::: elems.tail }
+  private def remove(key: K, elems: List[(K, V)], acc: List[(K, V)]): (List[(K, V)], K) = {
+    if (elems.isEmpty) (acc, key)
+    else if (elems.head._1 == key) { siz -= 1; (acc ::: elems.tail, elems.head._1) }
     else remove(key, elems.tail, elems.head :: acc)
   }
 

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/AnyRefMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/AnyRefMapBenchmark.scala
@@ -1,0 +1,81 @@
+package scala.collection.mutable
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+import org.openjdk.jmh.runner.IterationType
+import benchmark._
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class AnyRefMapBenchmark {
+  @Param(Array("10", "100", "1000"))
+  var size: Int = _
+  @Param(Array("true"))
+  var useMissingValues = true
+
+  var existingKeys: Array[String] = _
+  var missingKeys: Array[String] = _
+  var map: collection.mutable.AnyRefMap[String, String] = null
+
+  @Setup(Level.Trial) def initialize: Unit = {
+    existingKeys = (0 to size).map(_.toString).toArray
+    missingKeys = (size to 2 * size).toArray.map(_.toString)
+    map = collection.mutable.AnyRefMap(existingKeys.map(x => (x, x)) : _*)
+  }
+
+  @Benchmark def contains(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < size) {
+      bh.consume(map.contains(existingKeys(i)))
+      if (useMissingValues) {
+        bh.consume(map.contains(missingKeys(i)))
+      }
+      i += 1
+    }
+  }
+
+  @Benchmark def get(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < size) {
+      bh.consume(map.get(existingKeys(i)))
+      if (useMissingValues) {
+        bh.consume(map.get(missingKeys(i)))
+      }
+      i += 1
+    }
+  }
+
+  @Benchmark def getOrElse(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < size) {
+      bh.consume(map.getOrElse(existingKeys(i), ""))
+      if (useMissingValues) {
+        bh.consume(map.getOrElse(missingKeys(i), ""))
+      }
+      i += 1
+    }
+  }
+
+  @Benchmark def getOrElseUpdate(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < size) {
+      bh.consume(map.getOrElseUpdate(existingKeys(i), ""))
+      if (useMissingValues) {
+        bh.consume(map.getOrElse(missingKeys(i), ""))
+      }
+      i += 1
+    }
+  }
+
+  @Benchmark def fill(bh: Blackhole): Unit = {
+    val h = new AnyRefMap[String, String]
+    existingKeys.foreach(k => h.put(k, k))
+    bh.consume(h)
+  }
+}

--- a/test/junit/scala/collection/SetMapRulesTest.scala
+++ b/test/junit/scala/collection/SetMapRulesTest.scala
@@ -1,0 +1,271 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+import org.junit.Assert._
+import scala.collection
+import scala.collection.{mutable, immutable, concurrent}
+
+/**
+  * Test that various set and map implementation conform to the following rules:
+  *
+  * 1. Unless explicitly noted otherwise, containment and equality for key elements (i.e. set elements and map keys) refers to the `equals` / `hashCode` contract.
+  * 2. Immutable updates of mutable collections *must* always return a unique copy without observable structural sharing, even when the collection is unchanged or the result is empty.
+  * 3. Immutable updates of immutable collections *should* use structural sharing and avoid copying.
+  * 4. When updating a collection (immutably or in place), key element identities already in the source collection (i.e. the receiver of a method call) *must* always be preferred over new key elements which are equal but have different identities.
+  * 5. When transforming a collection (immutably or in place) into a new collection (e.g. `map`, `flatMap`, `collect`), only the transformation results are used. Existing key elements *must not* be preserved.
+  * 6. Map values *must* always be updated (i.e. a new value wins over an existing value with a different identity)
+  * 7. In immutable maps structural sharing *must not* be done for non-identical values; equality of map values is irrelevant.
+  *
+  * 1 is indirectly tested by using the `Value` instances as keys in all tests. 3 cannot be tested directly. The other
+  * rules have explicit tests.
+  */
+@RunWith(classOf[JUnit4])
+class SetMapRulesTest {
+
+  class Value private (val id: Int, extra: Int) {
+    override def hashCode: Int = id
+    override def equals(o: Any): Boolean = o match {
+      case v: Value => id == v.id
+      case _ => false
+    }
+    override def toString: String = s"$id.$extra"
+    def + (i: Int): Value = Value(id, extra + i)
+    def toTuple: (Int, Int) = (id, extra)
+  }
+  object Value {
+    private[this] val cache = new mutable.HashMap[(Int, Int), Value]
+    def apply(id: Int, extra: Int): Value = cache.get((id, extra)) match {
+      case Some(v) => v
+      case None =>
+        val v = new Value(id, extra)
+        cache.put((id, extra), v)
+        v
+    }
+  }
+
+  implicit val valueOrdering: Ordering[Value] = Ordering.Int.on(_.id)
+
+  val mapdata: Seq[Seq[(Value, Value)]] = 1.to(20).map(n => (Value(n, 1), Value(100+n, 1))).inits.toSeq.reverse
+  val setdata: Seq[Seq[Value]] = 1.to(20).map(n => Value(n, 1)).inits.toSeq.reverse
+
+  private def checkUnique[T <: mutable.Iterable[_]](gen: () => T, op: String)(f: T => T): Unit = {
+    val v1 = gen()
+    val v2 = f(v1)
+    assertNotSame(s"$op should be a different object", v1, v2)
+  }
+
+  private def checkPreservesKeyIdentities[T <: collection.Map[Value, Value]](gen: () => T, op: String)(f: T => T): Unit = {
+    val v1 = gen()
+    val keys1 = v1.keysIterator.map(_.toTuple).toSet
+    val v2 = f(v1)
+    val keys2 = v2.keysIterator.map(_.toTuple).toSet
+    assertTrue(s"$op should preserve key identities (all of $keys1 should be in $keys2)", keys1.forall(k => keys2.contains(k)))
+  }
+
+  private def checkPreservesIdentities[T <: collection.Iterable[Value]](gen: () => T, op: String)(f: T => T): Unit = {
+    val v1 = gen()
+    val keys1 = v1.iterator.map(_.toTuple).toSet
+    val v2 = f(v1)
+    val keys2 = v2.iterator.map(_.toTuple).toSet
+    assertTrue(s"$op should preserve key identities (all of $keys1 should be in $keys2)", keys1.forall(k => keys2.contains(k)))
+  }
+
+  private def checkDiscardsKeyIdentities[T <: collection.Map[Value, Value]](gen: () => T, op: String)(f: T => T): Unit = {
+    val v1 = gen()
+    val keys1 = v1.keysIterator.map(_.toTuple).toSet
+    val v2 = f(v1)
+    val keys2 = v2.keysIterator.map(_.toTuple).toSet
+    assertTrue(s"$op should discard key identities (none of $keys1 should be in $keys2)", keys1.forall(k => !keys2.contains(k)))
+  }
+
+  private def checkDiscardsIdentities[T <: collection.Iterable[Value]](gen: () => T, op: String)(f: T => T): Unit = {
+    val v1 = gen()
+    val keys1 = v1.iterator.map(_.toTuple).toSet
+    val v2 = f(v1)
+    val keys2 = v2.iterator.map(_.toTuple).toSet
+    assertTrue(s"$op should discard key identities (none of $keys1 should be in $keys2)", keys1.forall(k => !keys2.contains(k)))
+  }
+
+  private def checkAllValuesUpdated[T <: collection.Map[Value, Value]](gen: () => T, op: String)(f: T => T): Unit = {
+    val v1 = gen()
+    val values1 = v1.valuesIterator.map(_.toTuple).toSet
+    val v2 = f(v1)
+    val values2 = v2.valuesIterator.map(_.toTuple).toSet
+    assertTrue(s"$op should update values (none of $values1 should be in $values2)", values1.forall(k => !values2.contains(k)))
+  }
+
+  private def checkNoSharedValues[T <: immutable.Map[Value, Value]](gen: () => T, op: String)(f: T => T): Unit = {
+    val v1 = gen()
+    val entries1a = v1.iterator.map { case (k, v) => (k.toTuple, v.toTuple) }.toSet
+    val v2 = f(v1)
+    val entries1b = v1.iterator.map { case (k, v) => (k.toTuple, v.toTuple) }.toSet
+    val entries2 = v2.iterator.map { case (k, v) => (k.toTuple, v.toTuple) }.toSet
+    assertEquals(s"$op should preserve original values ($entries1a should be equal to $entries1b)", entries1a, entries1b)
+  }
+
+  private def checkMap(gen: () => collection.Map[Value, Value]): Unit = {
+    checkPreservesKeyIdentities(gen, "concat (identical value)")(_.concat(Seq((Value(1,2), Value(101,1)))))
+    checkPreservesKeyIdentities(gen, "concat (equal value)")(_.concat(Seq((Value(1,2), Value(101,2)))))
+    checkDiscardsKeyIdentities(gen, "map")(_.map { case (k, v) => (k + 1, v)})
+    checkDiscardsKeyIdentities(gen, "flatMap")(_.flatMap { case (k, v) => Seq((k + 1, v))})
+  }
+
+  private def checkMutableMap(gen: () => mutable.Map[Value, Value]): Unit = {
+    checkMap(gen)
+    checkUnique(gen, "map")(_.map { case (k, v) => (k, v + 1) })
+    checkUnique(gen, "map (identity)")(_.map(identity))
+    checkUnique(gen, "filter (keep all)")(_.filter(_ => true))
+    checkUnique(gen, "filter (drop all)")(_.filter(_ => false))
+    checkUnique(gen, "flatMap")(_.flatMap(x => Iterable(x)))
+    checkUnique(gen, "flatMap (to empty)")(_.flatMap(x => Nil))
+    checkPreservesKeyIdentities(gen, "addOne")(_.addOne((Value(1,2), Value(101,2))))
+    checkPreservesKeyIdentities(gen, "addAll")(_.addAll(Seq((Value(1,2), Value(101,2)))))
+    checkPreservesKeyIdentities(gen, "update") { c => c.update(Value(1,2), Value(101,2)); c }
+    checkPreservesKeyIdentities(gen, "put") { c => c.put(Value(1,2), Value(101,2)); c }
+    checkAllValuesUpdated(gen, "addOne (identical key)") { c => c.addOne((Value(1,1), Value(101,2))).filter(_._1.id == 1) }
+    checkAllValuesUpdated(gen, "addOne (equal key)") { c => c.addOne((Value(1,2), Value(101,2))).filter(_._1.id == 1) }
+    checkAllValuesUpdated(gen, "addAll (identical key)") { c => c.addAll(Seq((Value(1,1), Value(101,2)))).filter(_._1.id == 1) }
+    checkAllValuesUpdated(gen, "addAll (equal key)") { c => c.addAll(Seq((Value(1,2), Value(101,2)))).filter(_._1.id == 1) }
+    checkAllValuesUpdated(gen, "update (identical key)") { c => c.update(Value(1,1), Value(101,2)); c.filter(_._1.id == 1) }
+    checkAllValuesUpdated(gen, "update (equal key)") { c => c.update(Value(1,2), Value(101,2)); c.filter(_._1.id == 1) }
+    checkAllValuesUpdated(gen, "put (identical key)") { c => c.put(Value(1,1), Value(101,2)); c.filter(_._1.id == 1) }
+    checkAllValuesUpdated(gen, "put (equal key)") { c => c.put(Value(1,2), Value(101,2)); c.filter(_._1.id == 1) }
+  }
+
+  private def checkImmutableMap(gen: () => immutable.Map[Value, Value]): Unit = {
+    checkMap(gen)
+    checkPreservesKeyIdentities(gen, "updated (identical value)")(_.updated(Value(1,2), Value(101,1)))
+    checkPreservesKeyIdentities(gen, "updated (equal value)")(_.updated(Value(1,2), Value(101,2)))
+    checkPreservesKeyIdentities(gen, "+ (identical value)")(_.+((Value(1,2), Value(101,1))))
+    checkPreservesKeyIdentities(gen, "+ (equal value)")(_.+((Value(1,2), Value(101,2))))
+    checkAllValuesUpdated(gen, "updated (identical key)")(_.updated(Value(1,1), Value(101,2)).filter(_._1.id == 1))
+    checkAllValuesUpdated(gen, "updated (equal key)")(_.updated(Value(1,2), Value(101,2)).filter(_._1.id == 1))
+    checkAllValuesUpdated(gen, "+ (identical key)")(_.+((Value(1,1), Value(101,2))).filter(_._1.id == 1))
+    checkAllValuesUpdated(gen, "+ (equal key)")(_.+((Value(1,2), Value(101,2))).filter(_._1.id == 1))
+    checkAllValuesUpdated(gen, "concat (identical key)")(_.concat(Seq((Value(1,1), Value(101,2)))).filter(_._1.id == 1))
+    checkAllValuesUpdated(gen, "concat (equal key)")(_.concat(Seq((Value(1,2), Value(101,2)))).filter(_._1.id == 1))
+    checkNoSharedValues(gen, "updated")(_.updated(Value(1,1), Value(101,2)))
+    checkNoSharedValues(gen, "+")(_.+((Value(1,1), Value(101,2))))
+    checkNoSharedValues(gen, "concat")(_.concat(Seq((Value(1,1), Value(101,2)))))
+    checkNoSharedValues(gen, "map")(_.map { case (k, v) => (k, v + 1)})
+    checkNoSharedValues(gen, "flatMap")(_.flatMap { case (k, v) => Seq((k, v + 1))})
+  }
+
+  private def checkSet(gen: () => collection.Set[Value]): Unit = {
+    checkDiscardsIdentities(gen, "map")(_.map(_ + 1))
+    checkDiscardsIdentities(gen, "flatMap")(_.flatMap(k => Seq(k + 1)))
+  }
+
+  private def checkMutableSet(gen: () => mutable.Set[Value]): Unit = {
+    checkSet(gen)
+    checkUnique(gen, "map (identity)")(_.map(identity))
+    checkUnique(gen, "filter (keep all)")(_.filter(_ => true))
+    checkUnique(gen, "filter (drop all)")(_.filter(_ => false))
+    checkUnique(gen, "flatMap")(_.flatMap(x => Iterable(x)))
+    checkUnique(gen, "flatMap (to empty)")(_.flatMap(x => Nil))
+    checkPreservesIdentities(gen, "add") { c => c.add(Value(1,2)); c }
+    checkPreservesIdentities(gen, "addOne")(_.addOne(Value(1,2)))
+    checkPreservesIdentities(gen, "addAll")(_.addAll(Seq(Value(1,2))))
+    checkPreservesIdentities(gen, "update") { c => c.update(Value(1,2), true); c }
+  }
+
+  private def checkImmutableSet(gen: () => immutable.Set[Value]): Unit = {
+    checkSet(gen)
+    checkPreservesIdentities(gen, "incl")(_.incl(Value(1,2)))
+    checkPreservesIdentities(gen, "concat")(_.concat(Seq(Value(1,2))))
+  }
+
+  // Immutable maps
+
+  @Test def testImmutableMap: Unit =
+    mapdata.foreach(d => checkImmutableMap(() => immutable.Map.from(d)))
+
+  @Test def testImmutableListMap: Unit =
+    mapdata.foreach(d => checkImmutableMap(() => immutable.ListMap.from(d)))
+
+  @Test def testImmutableVectorMap: Unit =
+    mapdata.foreach(d => checkImmutableMap(() => immutable.VectorMap.from(d)))
+
+  @Test def testImmutableTreeMap: Unit =
+    mapdata.foreach(d => checkImmutableMap(() => immutable.TreeMap.from(d)))
+
+  @Test def testImmutableHashMap: Unit =
+    mapdata.foreach(d => checkImmutableMap(() => immutable.HashMap.from(d)))
+
+  // Mutable maps
+
+  @Test def testMutableMap: Unit =
+    mapdata.foreach(d => checkMutableMap(() => mutable.Map.from(d)))
+
+  @Test def testMutableHashMap: Unit =
+    mapdata.foreach(d => checkMutableMap(() => mutable.HashMap.from(d)))
+
+  @Test def testMutableOpenHashMap: Unit =
+    mapdata.foreach(d => checkMutableMap(() => mutable.OpenHashMap.from(d)))
+
+  @Test def testMutableAnyRefMap: Unit =
+    mapdata.foreach(d => checkMutableMap(() => mutable.AnyRefMap.from(d)))
+
+  @Test def testMutableTreeMap: Unit =
+    mapdata.foreach(d => checkMutableMap(() => mutable.TreeMap.from(d)))
+
+  @Test def testMutableLinkedHashMap: Unit =
+    mapdata.foreach(d => checkMutableMap(() => mutable.LinkedHashMap.from(d)))
+
+  @Test def testMutableSeqMap: Unit =
+    mapdata.foreach(d => checkMutableMap(() => mutable.SeqMap.from(d)))
+
+  @Test def testMutableListMap: Unit =
+    mapdata.foreach(d => checkMutableMap(() => mutable.ListMap.from(d)))
+
+  @Test def testConcurrentTrieMap: Unit =
+    mapdata.foreach(d => checkMutableMap(() => concurrent.TrieMap.from(d)))
+
+  @Test def testJavaHashMap: Unit =
+    mapdata.foreach(d => checkMutableMap(() => JavaConverters.mapAsScalaMap(new java.util.HashMap[Value, Value]).addAll(d)))
+
+  // Immutable sets
+
+  @Test def testImmutableSet: Unit =
+    setdata.foreach(d => checkImmutableSet(() => immutable.Set.from(d)))
+
+  @Test def testImmutableHashSet: Unit =
+    setdata.foreach(d => checkImmutableSet(() => immutable.HashSet.from(d)))
+
+  @Test def testImmutableListSet: Unit =
+    setdata.foreach(d => checkImmutableSet(() => immutable.ListSet.from(d)))
+
+  @Test def testImmutableTreeSet: Unit =
+    setdata.foreach(d => checkImmutableSet(() => immutable.TreeSet.from(d)))
+
+  // Mutable sets
+
+  @Test def testMutableSet: Unit =
+    setdata.foreach(d => checkMutableSet(() => mutable.Set.from(d)))
+
+  @Test def testMutableHashSet: Unit =
+    setdata.foreach(d => checkMutableSet(() => mutable.HashSet.from(d)))
+
+  @Test def testMutableLinkedHashSet: Unit =
+    setdata.foreach(d => checkMutableSet(() => mutable.LinkedHashSet.from(d)))
+
+  @Test def testMutableTreeSet: Unit =
+    setdata.foreach(d => checkMutableSet(() => mutable.TreeSet.from(d)))
+
+  @Test def testJavaHashSet: Unit =
+    setdata.foreach(d => checkMutableSet(() => JavaConverters.asScalaSet(new java.util.HashSet[Value]).addAll(d)))
+}


### PR DESCRIPTION
The rules are listed in `SetMapRulesTest`. All collections changes
are necessary to comply with rule 3 (key identity). The other rules
were not violated by any of the tested collections.

Fixes https://github.com/scala/bug/issues/10415

There may be more elegant or efficient ways to fix some of the collections but I wanted to get this out before the weekend for some feedback. I fixed the following collections:

-  `immutable.HashMap` and `immutable.HashSet` may be slightly faster now
- ` mutable.ListMap`, ` mutable.AnyRefMap` and immutable.ListMap could be slightly slower
-  `concurrent.TrieMap` and  immutable.TreeMap should not show any effects on performance

Someone should look over the changes I made to `TrieMap` and `AnyRefMap` because I am not very familiar with these. The rest was quite straight-forward.