### PR TITLE
REPL checks for fatal parse warnings

### DIFF
--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
@@ -17,7 +17,7 @@ import java.io.PrintWriter
 import scala.reflect.internal.util.{NoSourceFile, Position, StringOps}
 import scala.tools.nsc.{ConsoleWriter, NewLinePrintWriter, Settings}
 import scala.tools.nsc.interpreter.{Naming, ReplReporter, ReplRequest}
-import scala.tools.nsc.reporters.AbstractReporter
+import scala.tools.nsc.reporters.{AbstractReporter, DisplayReporter}
 
 
 object ReplReporterImpl {
@@ -160,7 +160,8 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
   // (should also comment out the error to keep multi-line copy/pastable)
   // TODO: multiple errors are not very intuitive (should the second error for same line repeat the line?)
   // TODO: the console could be empty due to external changes (also, :reset? -- see unfortunate example in jvm/interpeter (plusOne))
-  def printMessage(posIn: Position, msg: String): Unit = {
+  def printMessage(posIn: Position, msg0: String): Unit = {
+    val msg = DisplayReporter.explanation(msg0)
     if ((posIn eq null) || (posIn.source eq NoSourceFile)) printMessage(msg)
     else if (posIn.source.file.name == "<console>" && posIn.line == 1) {
       // If there's only one line of input, and it's already printed on the console (as indicated by the position's source file name),

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -1103,6 +1103,10 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
       val unit = newCompilationUnit(line, label)
       val trees = newUnitParser(unit).parseStats()
       if (reporter.hasErrors) Left(Error)
+      else if (reporter.hasWarnings && settings.fatalWarnings) {
+        currentRun.reporting.summarizeErrors()
+        Left(Error)
+      }
       else if (isIncomplete) Left(Incomplete)
       else Right((trees, unit.firstXmlPos))
     }


### PR DESCRIPTION
Previously, user input was re-parsed embedded in a template.
Also strip the marker for extended explanations.

```
scala> List(1) map (42 +) ; List(1) map (42 +)
                       ^
       error: postfix operator + needs to be enabled
       by making the implicit value scala.language.postfixOps visible.
       This can be achieved by adding the import clause 'import
scala.language.postfixOps'
       or by setting the compiler option -language:postfixOps.
       See the Scaladoc for value scala.language.postfixOps for a
discussion
       why the feature needs to be explicitly enabled.
                                            ^
       error: postfix operator + needs to be enabled
       by making the implicit value scala.language.postfixOps visible.

scala> def f() { }
               ^
       warning: procedure syntax is deprecated: instead, add `: Unit =`
to explicitly declare `f`'s return type
error: No warnings can be incurred under -Xfatal-warnings.

scala>
```
Fixes scala/bug#11278