### PR TITLE
Don't compactify Java inner class names.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
+++ b/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
@@ -26,7 +26,7 @@ trait JavaPlatform extends Platform {
 
   private[nsc] var currentClassPath: Option[ClassPath] = None
 
-  private[nsc] def classPath: ClassPath = {
+  protected[nsc] def classPath: ClassPath = {
     if (currentClassPath.isEmpty) currentClassPath = Some(new PathResolver(settings).result)
     currentClassPath.get
   }

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1270,7 +1270,7 @@ trait Definitions extends api.StandardDefinitions {
       getMemberIfDefined(owner, name) orElse {
         if (phase.flatClasses && name.isTypeName && !owner.isPackageObjectOrClass) {
           val pkg = owner.owner
-          val flatname = tpnme.flattenedName(owner.name, name)
+          val flatname = tpnme.flattenedName(owner, name)
           getMember(pkg, flatname)
         }
         else fatalMissingSymbol(owner, name)

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -96,8 +96,10 @@ trait StdNames {
     protected val stringToTypeName = null
     protected implicit def createNameType(name: String): NameType
 
-    def flattenedName(segments: Name*): NameType =
-      compactify(segments mkString NAME_JOIN_STRING)
+    def flattenedName(owner: Symbol, name: Name): NameType = {
+      val flat = owner.name.toString + NAME_JOIN_STRING + name.toString
+      if (owner.isJava) flat else compactify(flat) // scala/bug#11277
+    }
 
     // TODO: what is the purpose of all this duplication!?!?!
     // I made these constants because we cannot change them without bumping our major version anyway.

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2959,7 +2959,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def name: TermName = {
       if (!isMethod && needsFlatClasses) {
         if (flatname eq null)
-          flatname = nme.flattenedName(rawowner.name, rawname)
+          flatname = nme.flattenedName(rawowner, rawname)
 
         flatname
       }
@@ -3380,7 +3380,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def name: TypeName = {
       if (needsFlatClasses) {
         if (flatname eq null)
-          flatname = tpnme.flattenedName(rawowner.name, rawname)
+          flatname = tpnme.flattenedName(rawowner, rawname)
 
         flatname
       }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -17,7 +17,7 @@ package runtime
 trait JavaUniverseForce { self: runtime.JavaUniverse  =>
   def force() {
     Literal(Constant(42)).duplicate
-    nme.flattenedName()
+    nme.flattenedName(NoSymbol, nme.NO_NAME)
     nme.raw
     WeakTypeTag
     TypeTag

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
@@ -78,7 +78,7 @@ trait PresentationCompilation {
       override lazy val platform: ThisPlatform = {
         new JavaPlatform {
           lazy val global: self.type = self
-          override private[nsc] lazy val classPath: ClassPath = mergedFlatClasspath
+          override lazy val classPath: ClassPath = mergedFlatClasspath
         }
       }
     }

--- a/test/files/run/t6240-universe-code-gen.scala
+++ b/test/files/run/t6240-universe-code-gen.scala
@@ -44,7 +44,7 @@ object Test extends App {
         |trait JavaUniverseForce { self: runtime.JavaUniverse  =>
         |  def force() {
         |    Literal(Constant(42)).duplicate
-        |    nme.flattenedName()
+        |    nme.flattenedName(NoSymbol, nme.NO_NAME)
         |    nme.raw
         |    WeakTypeTag
         |    TypeTag

--- a/test/junit/scala/reflect/internal/LongNamesTest.scala
+++ b/test/junit/scala/reflect/internal/LongNamesTest.scala
@@ -1,0 +1,43 @@
+package scala.reflect.internal
+
+import org.junit._
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.VirtualCompiler
+import scala.language.reflectiveCalls
+
+@RunWith(classOf[JUnit4])
+class LongNamesTest {
+
+  @Test def t11227: Unit = {
+    val compiler = new VirtualCompiler
+
+    val longClassName = (0 to 512).map(_ => 'X').mkString
+
+    val javaCode =
+      s"""package pkg;
+         |
+         |public class Outer {
+         |    public static class $longClassName {}
+         |}
+     """.stripMargin
+
+    val scalaCode =
+      s"""package pkg
+         |
+         |class Test {
+         |  def test = new Outer.$longClassName().getClass.getName
+         |}
+     """.stripMargin
+
+    compiler.compileJava("Outer.java" -> javaCode)
+
+    compiler.compileScala("Test.scala" -> scalaCode)
+
+    val testClass = compiler.classloader.loadClass("pkg.Test")
+
+    val output = testClass.newInstance().asInstanceOf[{ def test(): String }].test()
+    Assert.assertEquals(s"pkg.Outer$$$longClassName", output)
+  }
+}

--- a/test/junit/scala/tools/testing/VirtualCompilerTesting.scala
+++ b/test/junit/scala/tools/testing/VirtualCompilerTesting.scala
@@ -1,0 +1,116 @@
+package scala
+package tools
+package testing
+
+import java.io.OutputStreamWriter
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+
+import javax.tools._
+
+import scala.collection.JavaConverters._
+import scala.reflect.internal.util.AbstractFileClassLoader
+import scala.reflect.io.{AbstractFile, VirtualDirectory}
+import scala.tools.nsc.classpath.{AggregateClassPath, VirtualDirectoryClassPath}
+import scala.tools.nsc.{Global, Settings}
+
+/** Utilities for testing with javac/scalac without using the actual filesystem,
+  * presumably because one doesn't wish to deal with platform idiosyncracies.
+  */
+class VirtualCompiler {
+  /** A java compiler instance that we can use. */
+  lazy val javac = ToolProvider.getSystemJavaCompiler
+
+  /** The directory in which are placed classfiles. */
+  lazy val output = new VirtualDirectory("out", maybeContainer = None)
+
+  /** A javac file manager that places classfiles in `output`. */
+  lazy val fileManager: JavaFileManager = {
+    val dflt = javac.getStandardFileManager(null, Locale.ENGLISH, StandardCharsets.UTF_8)
+    new VirtualFileManager(output, dflt)
+  }
+
+  /** A scala compiler. */
+  lazy val scalac: Global = {
+    val settings = new Settings()
+    settings.usejavacp.value = true
+    settings.outputDirs setSingleOutput output
+    new Global(settings) {
+      override lazy val platform = new super.GlobalPlatform() {
+        override val classPath = AggregateClassPath(List(
+          super.classPath,
+          VirtualDirectoryClassPath(output),
+        ))
+      }
+    }
+  }
+
+  def compileJava(sources: (String, String)*): Unit = {
+    val sourcefiles = sources.map {
+      case (filename, content) =>
+        new InMemorySourcefile(new URI("vc:/" + filename), content)
+    }
+    val writer = new OutputStreamWriter(System.out)
+    assert {
+      javac
+        .getTask(writer, fileManager, null, null, null, sourcefiles.asJava)
+        .call()
+    }
+  }
+
+  def compileScala(sources: (String, String)*): Unit = {
+    val run = new scalac.Run()
+    val units = sources.map {
+      case (filename, content) => scalac.newCompilationUnit(content, filename)
+    }
+    run.compileUnits(units.toList, run.parserPhase)
+  }
+
+  def classloader: ClassLoader =
+    new AbstractFileClassLoader(output, getClass.getClassLoader)
+}
+
+final class VirtualFileManager(dir: VirtualDirectory, del: StandardJavaFileManager)
+    extends ForwardingJavaFileManager[StandardJavaFileManager](del) {
+  import JavaFileManager.Location
+  import JavaFileObject.Kind
+
+  override def getJavaFileForOutput(
+    loc: Location,
+    clasz: String,
+    kind: Kind,
+    sibling: FileObject,
+  ): JavaFileObject = {
+    assert(loc == StandardLocation.CLASS_OUTPUT, loc)
+    assert(kind == Kind.CLASS, kind)
+    val (file, uri) = mkFile(clasz)
+    new SimpleJavaFileObject(uri, Kind.CLASS) {
+      override def openOutputStream() = file.output
+    }
+  }
+
+  override def getJavaFileForInput(loc: Location, clasz: String, kind: Kind): JavaFileObject = {
+    if (loc == StandardLocation.CLASS_PATH) {
+      assert(kind == Kind.CLASS, kind)
+      val (file, uri) = mkFile(clasz)
+      new SimpleJavaFileObject(uri, Kind.CLASS) {
+        override def openInputStream() = file.input
+      }
+    } else super.getJavaFileForInput(loc, clasz, kind)
+  }
+
+  private def mkFile(clasz: String): (AbstractFile, URI) = {
+    val parts = clasz.split('.')
+    val pkg = parts.init.foldLeft[AbstractFile](dir)(_ subdirectoryNamed _)
+    val file = pkg.fileNamed(parts.last + ".class")
+    val uri = new URI("vc:/" + parts.mkString("/") + ".class")
+    (file, uri)
+  }
+}
+
+
+final class InMemorySourcefile(uri: URI, contents: String)
+    extends SimpleJavaFileObject(uri, JavaFileObject.Kind.SOURCE) {
+  override def getCharContent(ignoreEncodingErrors: Boolean) = contents
+}


### PR DESCRIPTION
The Java compiler won't, and neither should we.

Includes a virtual-directory-backed compiler agglomeration so that the test can possibly run and pass on Windows.

Fixes scala/bug#11277.