### PR TITLE
traverse does not take an IterableOnce of Futures

### DIFF
--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -836,8 +836,8 @@ object Future {
    * @tparam A        the type of the value inside the Futures in the `IterableOnce`
    * @tparam B        the type of the value of the returned `Future`
    * @tparam M        the type of the `IterableOnce` of Futures
-   * @param in        the `IterableOnce` to be mapped to an `IterableOnce` of Futures to be sequenced into a Future of `IterableOnce`
-   * @param fn        the function to apply to the `IterableOnce` to produce an `IterableOnce` of Futures
+   * @param in        the `IterableOnce` to be mapped over with the provided function to produce an `IterableOnce` of Futures that is then sequenced into a Future of `IterableOnce`
+   * @param fn        the function to be mapped over the `IterableOnce` to produce an `IterableOnce` of Futures
    * @return          the `Future` of the `IterableOnce` of results
    */
   final def traverse[A, B, M[X] <: IterableOnce[X]](in: M[A])(fn: A => Future[B])(implicit bf: BuildFrom[M[A], B, M[B]], executor: ExecutionContext): Future[M[B]] =

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -836,8 +836,8 @@ object Future {
    * @tparam A        the type of the value inside the Futures in the `IterableOnce`
    * @tparam B        the type of the value of the returned `Future`
    * @tparam M        the type of the `IterableOnce` of Futures
-   * @param in        the `IterableOnce` of Futures which will be sequenced
-   * @param fn        the function to apply to the `IterableOnce` of Futures to produce the results
+   * @param in        the `IterableOnce` to be mapped to an `IterableOnce` of Futures to be sequenced into a Future of `IterableOnce`
+   * @param fn        the function to apply to the `IterableOnce` to produce an `IterableOnce` of Futures
    * @return          the `Future` of the `IterableOnce` of results
    */
   final def traverse[A, B, M[X] <: IterableOnce[X]](in: M[A])(fn: A => Future[B])(implicit bf: BuildFrom[M[A], B, M[B]], executor: ExecutionContext): Future[M[B]] =

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -833,12 +833,12 @@ object Future {
    *  {{{
    *    val myFutureList = Future.traverse(myList)(x => Future(myFunc(x)))
    *  }}}
-   * @tparam A        the type of the value inside the Futures in the `IterableOnce`
+   * @tparam A        the type of the value inside the Futures in the collection
    * @tparam B        the type of the value of the returned `Future`
-   * @tparam M        the type of the `IterableOnce` of Futures
-   * @param in        the `IterableOnce` to be mapped over with the provided function to produce an `IterableOnce` of Futures that is then sequenced into a Future of `IterableOnce`
-   * @param fn        the function to be mapped over the `IterableOnce` to produce an `IterableOnce` of Futures
-   * @return          the `Future` of the `IterableOnce` of results
+   * @tparam M        the type of the collection of Futures
+   * @param in        the collection to be mapped over with the provided function to produce a collection of Futures that is then sequenced into a Future collection
+   * @param fn        the function to be mapped over the collection to produce a collection of Futures
+   * @return          the `Future` of the collection of results
    */
   final def traverse[A, B, M[X] <: IterableOnce[X]](in: M[A])(fn: A => Future[B])(implicit bf: BuildFrom[M[A], B, M[B]], executor: ExecutionContext): Future[M[B]] =
     in.iterator.foldLeft(successful(bf.newBuilder(in))) {


### PR DESCRIPTION
Hello, I just want to draw your attention to the fact that the current description of the 'in' parameter seems incorrect. The most obvious  symptom of this is the fact that the description is identical to that of the 'in' parameter of the sequence method, but while the 'in' parameter of sequence is an `IterableOnce` of Futures, the 'in' parameter of traverse is not an `IterableOnce` of Futures, rather, its elements will be mapped to Futures by invoking the function that is the 'fn' parameter. I am not suggesting that my changes be made verbatim, you'll certainly do a much better job of figuring out an 'appropriate' way of correcting the description (e.g. one consistent with the rest of the Scaladoc).

I appreciate that it is not easy to write this kind of description.

Thanks.