### PR TITLE
Adding Implicit Conversion Import Into Enum Doc

### DIFF
--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -62,6 +62,7 @@ import scala.util.matching.Regex
  *     def surfaceGravity: Double = Planet.G * mass / (radius * radius)
  *     def surfaceWeight(otherMass: Double): Double = otherMass * surfaceGravity
  *   }
+ *   import scala.language.implicitConversions
  *   implicit def valueToPlanetVal(x: Value): Val = x.asInstanceOf[Val]
  *
  *   val G: Double = 6.67300E-11


### PR DESCRIPTION
Enum API doc, when copy pasted in Scala REPL, gave this warning. Fixing the warning.
<img width="1316" alt="screenshot 2018-12-01 at 6 59 39 pm" src="https://user-images.githubusercontent.com/10391044/49328715-491a5a80-f59b-11e8-8a8c-bb3385ba6ded.png">
