### PR TITLE
Optimizations for scala.collection.{immutable,mutable}.BitSet#diff

### DIFF
--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -311,4 +311,24 @@ object BitSetOps {
     else assert(w == 0L)
     newelems
   }
+
+  private[collection] def computeWordForFilter(pred: Int => Boolean, isFlipped: Boolean, oldWord: Long, wordIndex: Int): Long =
+    if (oldWord == 0L) 0L else {
+      var w = oldWord
+      val trailingZeroes = java.lang.Long.numberOfTrailingZeros(w)
+      var jmask = 1L << trailingZeroes
+      var j = wordIndex * BitSetOps.WordLength + trailingZeroes
+      val maxJ = (wordIndex + 1) * BitSetOps.WordLength - java.lang.Long.numberOfLeadingZeros(w)
+      while (j != maxJ) {
+        if ((w & jmask) != 0L) {
+          if (pred(j) == isFlipped) {
+            // j did not pass the filter here
+            w = w & ~jmask
+          }
+        }
+        jmask = jmask << 1
+        j += 1
+      }
+      w
+    }
 }

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -14,8 +14,6 @@ package scala
 package collection
 package immutable
 
-import java.io.{ObjectInputStream, ObjectOutputStream}
-
 import BitSetOps.{LogWL, updateArray}
 import mutable.Builder
 import scala.annotation.implicitNotFound
@@ -97,7 +95,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
       case _          => (newBuilder ++= it).result()
     }
 
-  def empty: BitSet = new BitSet1(0L)
+  final val empty: BitSet = new BitSet1(0L)
 
   def newBuilder: Builder[Int, BitSet] =
     mutable.BitSet.newBuilder.mapResult(bs => fromBitMaskNoCopy(bs.elems))
@@ -134,6 +132,22 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
       if (idx == 0) new BitSet1(w)
       else if (idx == 1) createSmall(elems, w)
       else fromBitMaskNoCopy(updateArray(Array(elems), idx, w))
+
+
+    override def diff(other: collection.Set[Int]): BitSet = other match {
+      case bs: collection.BitSet => bs.nwords match {
+        case 0 => this
+        case _ =>
+          val newElems = elems & ~bs.word(0)
+          if (newElems == 0L) empty else new BitSet1(newElems)
+      }
+      case _ => super.diff(other)
+    }
+
+    override def filterImpl(pred: Int => Boolean, isFlipped: Boolean): BitSet = {
+      val _elems = BitSetOps.computeWordForFilter(pred, isFlipped, elems, 0)
+      if (_elems == 0L) empty else new BitSet1(_elems)
+    }
   }
 
   class BitSet2(val elems0: Long, elems1: Long) extends BitSet {
@@ -143,12 +157,171 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
       if (idx == 0) new BitSet2(w, elems1)
       else if (idx == 1) createSmall(elems0, w)
       else fromBitMaskNoCopy(updateArray(Array(elems0, elems1), idx, w))
+
+
+    override def diff(other: collection.Set[Int]): BitSet = other match {
+      case bs: collection.BitSet => bs.nwords match {
+        case 0 => this
+        case 1 =>
+          new BitSet2(elems0 & ~bs.word(0), elems1)
+        case _ =>
+          val _elems0 = elems0 & ~bs.word(0)
+          val _elems1 = elems1 & ~bs.word(1)
+
+          if (_elems1 == 0L) {
+            if (_elems0 == 0L) {
+              empty
+            } else {
+              new BitSet1(_elems0)
+            }
+          } else {
+            new BitSet2(_elems0, _elems1)
+          }
+      }
+      case _ => super.diff(other)
+    }
+
+    override def filterImpl(pred: Int => Boolean, isFlipped: Boolean): BitSet = {
+      val _elems0 = BitSetOps.computeWordForFilter(pred, isFlipped, elems0, 0)
+      val _elems1 = BitSetOps.computeWordForFilter(pred, isFlipped, elems1, 0)
+
+      if (_elems1 == 0L) {
+        if (_elems0 == 0L) {
+          empty
+        }
+        new BitSet1(_elems0)
+      }
+      new BitSet2(_elems0, _elems1)
+    }
   }
 
   class BitSetN(val elems: Array[Long]) extends BitSet {
     protected[collection] def nwords = elems.length
+
     protected[collection] def word(idx: Int) = if (idx < nwords) elems(idx) else 0L
+
     protected[collection] def updateWord(idx: Int, w: Long): BitSet = fromBitMaskNoCopy(updateArray(elems, idx, w))
+
+    override def diff(that: collection.Set[Int]): BitSet = that match {
+      case bs: collection.BitSet =>
+        /*
+          * Algorithm:
+          *
+          * We iterate, word-by-word, backwards from the shortest of the two bitsets (this, or bs) i.e. the one with
+          * the fewer words. Two extra concerns for optimization are described below.
+          *
+          * Array Shrinking:
+          * If `this` is not longer than `bs`, then since we must iterate through the full array of words,
+          * we can track the new highest index word which is non-zero, at little additional cost. At the end, the new
+          * Array[Long] allocated for the returned BitSet will only be of size `maxNonZeroIndex + 1`
+          *
+          * Tracking Changes:
+          * If the two sets are disjoint, then we can return `this`. Therefor, until at least one change is detected,
+          * we check each word for if it has changed from its corresponding word in `this`. Once a single change is
+          * detected, we stop checking because the cost of the new Array must be paid anyways.
+          */
+
+        val bsnwords = bs.nwords
+        val thisnwords = nwords
+        if (bsnwords >= thisnwords) {
+          // here, we may have opportunity to shrink the size of the array
+          // so, track the highest index which is non-zero. That ( + 1 ) will be our new array length
+          var i = thisnwords - 1
+          var currentWord = 0L
+          // if there are never any changes, we can return `this` at the end
+          var anyChanges = false
+          while (i >= 0 && currentWord == 0L) {
+            val oldWord = word(i)
+            currentWord = oldWord & ~bs.word(i)
+            anyChanges ||= currentWord != oldWord
+            i -= 1
+          }
+          if (i < 0) {
+            // all indices >= 0 have had result 0, so the bitset is empty
+            empty
+          } else {
+            val minimumNonZeroIndex: Int = i + 1
+            while (!anyChanges && i >= 0) {
+              val oldWord = word(i)
+              currentWord = oldWord & ~bs.word(i)
+              anyChanges ||= currentWord != oldWord
+              i -= 1
+            }
+            if (anyChanges) {
+              val newArray = elems.take(minimumNonZeroIndex + 1)
+              newArray(i + 1) = currentWord
+              while (i >= 0) {
+                newArray(i) = word(i) & ~bs.word(i)
+                i -= 1
+              }
+              fromBitMaskNoCopy(newArray)
+            } else {
+              this
+            }
+          }
+        } else {
+          var i = bsnwords - 1
+          var anyChanges = false
+          var currentWord = 0L
+          while (i >= 0 && !anyChanges) {
+            val oldWord = word(i)
+            currentWord = oldWord & ~bs.word(i)
+            anyChanges ||= currentWord != oldWord
+            i -= 1
+          }
+          if (anyChanges) {
+            val newElems = elems.clone()
+            newElems(i + 1) = currentWord
+            while (i >= 0) {
+              newElems(i) = word(i) & ~bs.word(i)
+              i -= 1
+            }
+            fromBitMaskNoCopy(newElems)
+          } else {
+            this
+          }
+        }
+      case _ => super.diff(that)
+    }
+
+
+    override def filterImpl(pred: Int => Boolean, isFlipped: Boolean): BitSet = {
+      // here, we may have opportunity to shrink the size of the array
+      // so, track the highest index which is non-zero. That ( + 1 ) will be our new array length
+      var i = nwords - 1
+      var currentWord = 0L
+      // if there are never any changes, we can return `this` at the end
+      var anyChanges = false
+      while (i >= 0 && currentWord == 0L) {
+        val oldWord = word(i)
+        currentWord = BitSetOps.computeWordForFilter(pred, isFlipped, oldWord, i)
+        anyChanges ||= currentWord != oldWord
+        i -= 1
+      }
+      if (i < 0) {
+        // all indices >= 0 have had result 0, so the bitset is empty
+        if (currentWord == 0) empty else fromBitMaskNoCopy(Array(currentWord))
+      } else {
+        val minimumNonZeroIndex: Int = i + 1
+        while (!anyChanges && i >= 0) {
+          val oldWord = word(i)
+          currentWord = BitSetOps.computeWordForFilter(pred, isFlipped, oldWord, i)
+          anyChanges ||= currentWord != oldWord
+          i -= 1
+        }
+        if (anyChanges) {
+          val newArray = elems.take(minimumNonZeroIndex + 1)
+          newArray(i + 1) = currentWord
+          while (i >= 0) {
+            newArray(i) = BitSetOps.computeWordForFilter(pred, isFlipped, word(i), i)
+            i -= 1
+          }
+          fromBitMaskNoCopy(newArray)
+        } else {
+          this
+        }
+      }
+    }
   }
 
   @SerialVersionUID(3L)

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -248,13 +248,25 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
               i -= 1
             }
             if (anyChanges) {
-              val newArray = elems.take(minimumNonZeroIndex + 1)
-              newArray(i + 1) = currentWord
-              while (i >= 0) {
-                newArray(i) = word(i) & ~bs.word(i)
-                i -= 1
+              if (minimumNonZeroIndex >= 0) {
+                if (minimumNonZeroIndex >= 1) {
+                  if (minimumNonZeroIndex >= 2) {
+                    val newArray = elems.take(minimumNonZeroIndex + 1)
+                    newArray(i + 1) = currentWord
+                    while (i >= 0) {
+                      newArray(i) = word(i) & ~bs.word(i)
+                      i -= 1
+                    }
+                    fromBitMaskNoCopy(newArray)
+                  } else {
+                    new BitSet2(word(0) & ~bs.word(0), currentWord)
+                  }
+                } else {
+                  new BitSet1(currentWord)
+                }
+              } else {
+                empty
               }
-              fromBitMaskNoCopy(newArray)
             } else {
               this
             }

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -248,24 +248,20 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
               i -= 1
             }
             if (anyChanges) {
-              if (minimumNonZeroIndex >= 0) {
-                if (minimumNonZeroIndex >= 1) {
-                  if (minimumNonZeroIndex >= 2) {
-                    val newArray = elems.take(minimumNonZeroIndex + 1)
-                    newArray(i + 1) = currentWord
-                    while (i >= 0) {
-                      newArray(i) = word(i) & ~bs.word(i)
-                      i -= 1
-                    }
-                    fromBitMaskNoCopy(newArray)
-                  } else {
-                    new BitSet2(word(0) & ~bs.word(0), currentWord)
-                  }
-                } else {
-                  new BitSet1(currentWord)
-                }
-              } else {
+              if (minimumNonZeroIndex == -1) {
                 empty
+              } else if (minimumNonZeroIndex == 0) {
+                new BitSet1(currentWord)
+              } else if (minimumNonZeroIndex == 1) {
+                new BitSet2(word(0) & ~bs.word(0), currentWord)
+              } else {
+                val newArray = elems.take(minimumNonZeroIndex + 1)
+                newArray(i + 1) = currentWord
+                while (i >= 0) {
+                  newArray(i) = word(i) & ~bs.word(i)
+                  i -= 1
+                }
+                fromBitMaskNoCopy(newArray)
               }
             } else {
               this
@@ -322,13 +318,21 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
           i -= 1
         }
         if (anyChanges) {
-          val newArray = elems.take(minimumNonZeroIndex + 1)
-          newArray(i + 1) = currentWord
-          while (i >= 0) {
-            newArray(i) = BitSetOps.computeWordForFilter(pred, isFlipped, word(i), i)
-            i -= 1
+          if (minimumNonZeroIndex == -1) {
+            empty
+          } else if (minimumNonZeroIndex == 0) {
+            new BitSet1(currentWord)
+          } else if (minimumNonZeroIndex == 1) {
+            new BitSet2(BitSetOps.computeWordForFilter(pred, isFlipped, word(0), 0), currentWord)
+          } else {
+            val newArray = elems.take(minimumNonZeroIndex + 1)
+            newArray(i + 1) = currentWord
+            while (i >= 0) {
+              newArray(i) = BitSetOps.computeWordForFilter(pred, isFlipped, word(i), i)
+              i -= 1
+            }
+            fromBitMaskNoCopy(newArray)
           }
-          fromBitMaskNoCopy(newArray)
         } else {
           this
         }

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -249,6 +249,16 @@ class BitSet(protected[collection] final var elems: Array[Long])
       fromBitMaskNoCopy(newArray)
     }
   }
+
+  override def filterInPlace(p: Int => Boolean): this.type = {
+    val thisnwords = nwords
+    var i = 0
+    while (i < thisnwords) {
+      elems(i) = BitSetOps.computeWordForFilter(p, isFlipped = false, elems(i), i)
+      i += 1
+    }
+    this
+  }
 }
 
 @SerialVersionUID(3L)

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/BitSetBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/BitSetBenchmark.scala
@@ -1,0 +1,36 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.util.Random
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 6)
+@Measurement(iterations = 6)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class BitSetBenchmark {
+  @Param(Array("1", "1000", "10000000"))
+  var sizeLeft: Int = _
+
+  var percentageFull: Double = 0.3
+
+  var bitSet: BitSet = _
+  var arg: BitSet = _
+
+  @Setup(Level.Iteration) def initNumbers: Unit = {
+    bitSet = (0 to sizeLeft).filter(_ => Random.nextDouble() <= percentageFull).to(BitSet)
+  }
+
+  @Benchmark
+  def filter(bh: Blackhole): Unit = {
+    (1 to 10) foreach { _ =>
+      bh.consume(bitSet.filter(_ % 2 == 0))
+    }
+  }
+}

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -3,6 +3,9 @@ package scala.collection.mutable
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.junit.Assert._
+
+import scala.tools.testing.AssertUtil._
 
 @RunWith(classOf[JUnit4])
 class BitSetTest {
@@ -108,7 +111,7 @@ class BitSetTest {
   @Test def diff(): Unit = {
     val a = BitSet(1, 2, 3)
     val b = BitSet(2, 4, 6)
-    assert(a.diff(b) == BitSet(1, 3))
+    assertEquals(BitSet(1, 3), a.diff(b))
     assert(b.diff(a) == BitSet(4, 6))
     assert(a.diff(BitSet(4, 6)) == BitSet(1, 2, 3))
     assert(a.diff(BitSet()) == BitSet(1, 2, 3))

--- a/test/scalacheck/scala/collection/mutable/BitSetProperties.scala
+++ b/test/scalacheck/scala/collection/mutable/BitSetProperties.scala
@@ -30,4 +30,8 @@ object BitSetProperties extends Properties("mutable.BitSet") {
   property("filterNot") = forAll { (bs: BitSet) =>
     bs.filterNot(_ % 2 == 0) ?= bs.toList.filterNot(_ % 2 == 0).to(BitSet)
   }
+  property("filterInPlace") = forAll { (bs: BitSet) =>
+    val list = bs.toList
+    bs.filterInPlace(_ % 2 == 0) ?= list.filter(_ % 2 == 0).to(BitSet)
+  }
 }

--- a/test/scalacheck/scala/collection/mutable/BitSetProperties.scala
+++ b/test/scalacheck/scala/collection/mutable/BitSetProperties.scala
@@ -1,12 +1,12 @@
-package scala.collection.immutable
+package scala.collection.mutable
 
 import org.scalacheck._
 import org.scalacheck.Prop._
 import Gen._
-object BitSetProperties extends Properties("immutable.BitSet") {
+object BitSetProperties extends Properties("mutable.BitSet") {
 
   override def overrideParameters(p: Test.Parameters): Test.Parameters =
-    p.withMinSuccessfulTests(500)
+    p.withMinSuccessfulTests(1000)
       .withInitialSeed(42L)
 
   // the top of the range shouldn't be too high, else we may not get enough overlap
@@ -18,28 +18,12 @@ object BitSetProperties extends Properties("immutable.BitSet") {
     )
   )
 
-  property("min") = forAll { (bs: BitSet) =>
-    bs.nonEmpty ==> (bs.min ?= bs.toList.min)
-  }
-  property("min reverse") = forAll { (bs: BitSet) =>
-    bs.nonEmpty ==> (bs.min(Ordering.Int.reverse) ?= bs.toList.min(Ordering.Int.reverse))
-  }
-
-  property("max") = forAll { (bs: BitSet) =>
-    bs.nonEmpty ==> (bs.max ?= bs.toList.max)
-  }
-
-  property("max reverse") = forAll { (bs: BitSet) =>
-    bs.nonEmpty ==> (bs.max(Ordering.Int.reverse) ?= bs.toList.max(Ordering.Int.reverse))
-  }
-
-  property("diff bitSet") = forAll { (left: BitSet, right: BitSet) =>
+  property("diff") = forAll { (left: BitSet, right: BitSet) =>
     (left.diff(right): Set[Int]) ?= left.to(HashSet).diff(right.to(HashSet))
   }
   property("diff hashSet") = forAll { (left: BitSet, right: BitSet) =>
-    (left.diff(right.to(HashSet)) : Set[Int]) ?= left.to(HashSet).diff(right.to(HashSet))
+    (left.diff(right.to(HashSet)): Set[Int]) ?= left.to(HashSet).diff(right.to(HashSet))
   }
-
   property("filter") = forAll { (bs: BitSet) =>
     bs.filter(_ % 2 == 0) ?= bs.toList.filter(_ % 2 == 0).to(BitSet)
   }


### PR DESCRIPTION
Summary of changes:

- `immutable.BitSet.empty` is now a `final val` rather than a `def`

- `immutable.{BitSet1, BitSet2}` have hand-crafted implementations of `diff` 

- `immutable.BitSetN` and `mutable.BitSet`s implementations of `diff` has been optimized to reduce allocation through two optimizations:
  - the inner `Array[Long]`s are traversed in reverse, and the method takes note of the first result word which is non-zero. The index of this word will be the maximum index in the resulting BitSet, and and so an Array of exactly the right size can be allocated once. This avoids allocating too big of an array, and also avoids building a new BitSet from empty, which would repeatedly double its array until it has enough capacity.
  - in the case of `immutable.BitSetN`, the implementation of `diff` will return `this` if there are no changes made in the Set. It does this by tracking whether or not any result word has differed from its original word, and it avoids allocating an array entirely if it gets all the way to the beginning of the BitSet without seeing any changes. 

- `mutable.BitSet`'s method `&~= (BitSet): BitSet` no longer ensures it is as big as its argument, no need to since we're only removing elements. Also the method's use of `Range` and `for` has been replaced with `while`

- both `mutable.BitSet` and `immutable.BitSet{1,2,N}` have new and optimized implementations of filter which perform similar optimizations. Benchmarks below!



## Benchmarks
Here are some benchmarks. The way to interpret them are:
* method under test: `left.diff(right)`
* percentageFull: the approximate percent of bits in both `left` and `right` which are set to `1`
* leftSize: the approximate max int contained in the `left` BitSet (may be significantly lower for the case of percentageFull = 0.01, since many Int's are not present)
* rightSize: same as leftSize, but for right.

Note I only did some quick benchmarks (1 fork, 6 warmup, 6 normal iterations) because there are a lot of combinations.

### Summary of results

Most configurations of parameters yield an improvement of ~3-10x

```

[info] Benchmark                (percentageFull)  (sizeLeft)  (sizeRight)  Mode  Cnt        Score         Error  Units
[info] BitSetBenchmark.newDiff              0.01           1            1  avgt    6       31.208 ±       8.739  ns/op
[info] BitSetBenchmark.newDiff              0.01           1         1000  avgt    6       45.754 ±      52.256  ns/op
[info] BitSetBenchmark.newDiff              0.01           1     10000000  avgt    6       35.929 ±       4.026  ns/op
[info] BitSetBenchmark.newDiff              0.01        1000            1  avgt    6       57.548 ±      38.719  ns/op
[info] BitSetBenchmark.newDiff              0.01        1000         1000  avgt    6      246.341 ±     556.715  ns/op
[info] BitSetBenchmark.newDiff              0.01        1000     10000000  avgt    6      219.376 ±     325.516  ns/op
[info] BitSetBenchmark.newDiff              0.01    10000000            1  avgt    6       52.386 ±      21.380  ns/op
[info] BitSetBenchmark.newDiff              0.01    10000000         1000  avgt    6      163.745 ±      49.906  ns/op
[info] BitSetBenchmark.newDiff              0.01    10000000     10000000  avgt    6  4097497.984 ±  737797.615  ns/op
[info] BitSetBenchmark.newDiff               0.3           1            1  avgt    6       36.079 ±      30.826  ns/op
[info] BitSetBenchmark.newDiff               0.3           1         1000  avgt    6       44.654 ±      13.963  ns/op
[info] BitSetBenchmark.newDiff               0.3           1     10000000  avgt    6       40.285 ±      12.105  ns/op
[info] BitSetBenchmark.newDiff               0.3        1000            1  avgt    6       98.747 ±     246.763  ns/op
[info] BitSetBenchmark.newDiff               0.3        1000         1000  avgt    6      280.314 ±       9.058  ns/op
[info] BitSetBenchmark.newDiff               0.3        1000     10000000  avgt    6      294.016 ±      72.456  ns/op
[info] BitSetBenchmark.newDiff               0.3    10000000            1  avgt    6   682123.637 ± 2963731.741  ns/op
[info] BitSetBenchmark.newDiff               0.3    10000000         1000  avgt    6  1979937.589 ±  130511.341  ns/op
[info] BitSetBenchmark.newDiff               0.3    10000000     10000000  avgt    6  3340775.918 ±  621110.908  ns/op
[info] BitSetBenchmark.newDiff               0.9           1            1  avgt    6       40.548 ±      38.187  ns/op
[info] BitSetBenchmark.newDiff               0.9           1         1000  avgt    6       40.362 ±      12.110  ns/op
[info] BitSetBenchmark.newDiff               0.9           1     10000000  avgt    6       36.276 ±      20.626  ns/op
[info] BitSetBenchmark.newDiff               0.9        1000            1  avgt    6      167.517 ±       1.397  ns/op
[info] BitSetBenchmark.newDiff               0.9        1000         1000  avgt    6      279.044 ±       6.620  ns/op
[info] BitSetBenchmark.newDiff               0.9        1000     10000000  avgt    6      284.226 ±      19.683  ns/op
[info] BitSetBenchmark.newDiff               0.9    10000000            1  avgt    6  2067804.998 ±  216944.640  ns/op
[info] BitSetBenchmark.newDiff               0.9    10000000         1000  avgt    6  1933810.397 ±  303777.991  ns/op
[info] BitSetBenchmark.newDiff               0.9    10000000     10000000  avgt    6  4975641.773 ± 4786001.431  ns/op
[info] BitSetBenchmark.newDiff               1.0           1            1  avgt    6       28.446 ±       4.065  ns/op
[info] BitSetBenchmark.newDiff               1.0           1         1000  avgt    6       38.800 ±      26.688  ns/op
[info] BitSetBenchmark.newDiff               1.0           1     10000000  avgt    6       34.487 ±       1.586  ns/op
[info] BitSetBenchmark.newDiff               1.0        1000            1  avgt    6      169.287 ±       3.249  ns/op
[info] BitSetBenchmark.newDiff               1.0        1000         1000  avgt    6      145.236 ±       0.743  ns/op
[info] BitSetBenchmark.newDiff               1.0        1000     10000000  avgt    6      146.821 ±       9.846  ns/op
[info] BitSetBenchmark.newDiff               1.0    10000000            1  avgt    6  2132533.344 ±  318796.881  ns/op
[info] BitSetBenchmark.newDiff               1.0    10000000         1000  avgt    6  2209938.828 ± 1484112.686  ns/op
[info] BitSetBenchmark.newDiff               1.0    10000000     10000000  avgt    6  2777661.491 ± 2940784.395  ns/op
[info] BitSetBenchmark.oldDiff              0.01           1            1  avgt    6      737.497 ±     856.767  ns/op
[info] BitSetBenchmark.oldDiff              0.01           1         1000  avgt    6      470.978 ±     148.842  ns/op
[info] BitSetBenchmark.oldDiff              0.01           1     10000000  avgt    6      431.590 ±       4.583  ns/op
[info] BitSetBenchmark.oldDiff              0.01        1000            1  avgt    6      694.960 ±      92.029  ns/op
[info] BitSetBenchmark.oldDiff              0.01        1000         1000  avgt    6      748.125 ±      12.566  ns/op
[info] BitSetBenchmark.oldDiff              0.01        1000     10000000  avgt    6      740.510 ±      10.169  ns/op
[info] BitSetBenchmark.oldDiff              0.01    10000000            1  avgt    6  5826771.627 ± 9064974.433  ns/op
[info] BitSetBenchmark.oldDiff              0.01    10000000         1000  avgt    6  6146382.193 ± 3875187.812  ns/op
[info] BitSetBenchmark.oldDiff              0.01    10000000     10000000  avgt    6  4580814.501 ± 2271609.579  ns/op
[info] BitSetBenchmark.oldDiff               0.3           1            1  avgt    6      423.621 ±       5.445  ns/op
[info] BitSetBenchmark.oldDiff               0.3           1         1000  avgt    6      433.577 ±       9.308  ns/op
[info] BitSetBenchmark.oldDiff               0.3           1     10000000  avgt    6      438.545 ±      31.578  ns/op
[info] BitSetBenchmark.oldDiff               0.3        1000            1  avgt    6      705.773 ±       9.507  ns/op
[info] BitSetBenchmark.oldDiff               0.3        1000         1000  avgt    6      743.735 ±      19.361  ns/op
[info] BitSetBenchmark.oldDiff               0.3        1000     10000000  avgt    6      764.688 ±      65.624  ns/op
[info] BitSetBenchmark.oldDiff               0.3    10000000            1  avgt    6  4417984.005 ± 1421879.462  ns/op
[info] BitSetBenchmark.oldDiff               0.3    10000000         1000  avgt    6  5127837.605 ±  834225.922  ns/op
[info] BitSetBenchmark.oldDiff               0.3    10000000     10000000  avgt    6  4711617.779 ± 2122533.210  ns/op
[info] BitSetBenchmark.oldDiff               0.9           1            1  avgt    6      426.939 ±       4.010  ns/op
[info] BitSetBenchmark.oldDiff               0.9           1         1000  avgt    6      432.011 ±       7.210  ns/op
[info] BitSetBenchmark.oldDiff               0.9           1     10000000  avgt    6      449.853 ±      69.014  ns/op
[info] BitSetBenchmark.oldDiff               0.9        1000            1  avgt    6      700.642 ±      12.765  ns/op
[info] BitSetBenchmark.oldDiff               0.9        1000         1000  avgt    6      741.179 ±      13.959  ns/op
[info] BitSetBenchmark.oldDiff               0.9        1000     10000000  avgt    6      770.903 ±      92.481  ns/op
[info] BitSetBenchmark.oldDiff               0.9    10000000            1  avgt    6  4340131.776 ± 1543854.072  ns/op
[info] BitSetBenchmark.oldDiff               0.9    10000000         1000  avgt    6  5059978.525 ±  545622.610  ns/op
[info] BitSetBenchmark.oldDiff               0.9    10000000     10000000  avgt    6  6337590.481 ± 9985141.843  ns/op
[info] BitSetBenchmark.oldDiff               1.0           1            1  avgt    6      423.524 ±       6.959  ns/op
[info] BitSetBenchmark.oldDiff               1.0           1         1000  avgt    6      430.071 ±       5.685  ns/op
[info] BitSetBenchmark.oldDiff               1.0           1     10000000  avgt    6      444.353 ±      38.419  ns/op
[info] BitSetBenchmark.oldDiff               1.0        1000            1  avgt    6      700.939 ±      19.550  ns/op
[info] BitSetBenchmark.oldDiff               1.0        1000         1000  avgt    6      765.482 ±      16.529  ns/op
[info] BitSetBenchmark.oldDiff               1.0        1000     10000000  avgt    6      754.800 ±      48.719  ns/op
[info] BitSetBenchmark.oldDiff               1.0    10000000            1  avgt    6  4355270.499 ± 1758132.946  ns/op
[info] BitSetBenchmark.oldDiff               1.0    10000000         1000  avgt    6  4854703.397 ± 2019329.042  ns/op
[info] BitSetBenchmark.oldDiff               1.0    10000000     10000000  avgt    6  4781573.211 ± 2910313.306  ns/op
```

## Benchmarks for filter
~ 50% - 70% improvement 
```
[info] Benchmark                  (sizeLeft)  Mode  Cnt          Score           Error  Units
[info] BitSetBenchmark.newFilter           1  avgt    6        105.774 ±        52.917  ns/op
[info] BitSetBenchmark.newFilter        1000  avgt    6       8796.433 ±      3451.048  ns/op
[info] BitSetBenchmark.newFilter    10000000  avgt    6  299675411.708 ±  13775556.597  ns/op
[info] BitSetBenchmark.oldFilter           1  avgt    6        620.988 ±       184.030  ns/op
[info] BitSetBenchmark.oldFilter        1000  avgt    6      37135.108 ±      5199.098  ns/op
[info] BitSetBenchmark.oldFilter    10000000  avgt    6  870425992.333 ± 363293650.619  ns/op
```