### PR TITLE
Optimize scala.collection.BitSet's min and max methods

### DIFF
--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -140,6 +140,62 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
 
   override def isEmpty: Boolean = 0 until nwords forall (i => word(i) == 0)
 
+  override def max[B >: Int](implicit ord: Ordering[B]): Int =
+    if (Ordering.Int eq ord) {
+      var i = nwords - 1
+      var currentWord = 0L
+      while(i >= 0) {
+        currentWord = word(i)
+        if (currentWord != 0L) {
+          return ((i + 1) * WordLength) - java.lang.Long.numberOfLeadingZeros(currentWord) - 1
+        }
+        i -= 1
+      }
+      throw new UnsupportedOperationException("empty.max")
+    } else if (Ordering.Int.reverse eq ord) {
+      val thisnwords = nwords
+      var i = 0
+      var currentWord = 0L
+      while(i < thisnwords) {
+        currentWord = word(i)
+        if (currentWord != 0L) {
+          return java.lang.Long.numberOfTrailingZeros(currentWord) + (i * WordLength)
+        }
+        i += 1
+      }
+      throw new UnsupportedOperationException("empty.max")
+    } else {
+      super.max(ord)
+    }
+
+  override def min[B >: Int](implicit ord: Ordering[B]): Int =
+    if (Ordering.Int eq ord) {
+      val thisnwords = nwords
+      var i = 0
+      var currentWord = 0L
+      while(i < thisnwords) {
+        currentWord = word(i)
+        if (currentWord != 0L) {
+          return java.lang.Long.numberOfTrailingZeros(currentWord) + (i * WordLength)
+        }
+        i += 1
+      }
+      throw new UnsupportedOperationException("empty.min")
+    } else if (Ordering.Int.reverse eq ord) {
+      var i = nwords - 1
+      var currentWord = 0L
+      while(i >= 0) {
+        currentWord = word(i)
+        if (currentWord != 0L) {
+          return ((i + 1) * WordLength) - java.lang.Long.numberOfLeadingZeros(currentWord) - 1
+        }
+        i -= 1
+      }
+      throw new UnsupportedOperationException("empty.min")
+    } else {
+      super.min(ord)
+    }
+
   override def foreach[U](f: Int => U): Unit = {
     /* NOTE: while loops are significantly faster as of 2.11 and
        one major use case of bitsets is performance. Also, there

--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -140,61 +140,41 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
 
   override def isEmpty: Boolean = 0 until nwords forall (i => word(i) == 0)
 
-  override def max[B >: Int](implicit ord: Ordering[B]): Int =
-    if (Ordering.Int eq ord) {
-      var i = nwords - 1
-      var currentWord = 0L
-      while(i >= 0) {
-        currentWord = word(i)
-        if (currentWord != 0L) {
-          return ((i + 1) * WordLength) - java.lang.Long.numberOfLeadingZeros(currentWord) - 1
-        }
-        i -= 1
+  @inline private[this] def smallestInt: Int = {
+    val thisnwords = nwords
+    var i = 0
+    while(i < thisnwords) {
+      val currentWord = word(i)
+      if (currentWord != 0L) {
+        return java.lang.Long.numberOfTrailingZeros(currentWord) + (i * WordLength)
       }
-      throw new UnsupportedOperationException("empty.max")
-    } else if (Ordering.Int.reverse eq ord) {
-      val thisnwords = nwords
-      var i = 0
-      var currentWord = 0L
-      while(i < thisnwords) {
-        currentWord = word(i)
-        if (currentWord != 0L) {
-          return java.lang.Long.numberOfTrailingZeros(currentWord) + (i * WordLength)
-        }
-        i += 1
-      }
-      throw new UnsupportedOperationException("empty.max")
-    } else {
-      super.max(ord)
+      i += 1
     }
+    throw new UnsupportedOperationException("empty.smallestInt")
+  }
+
+  @inline private[this] def largestInt: Int = {
+    var i = nwords - 1
+    while(i >= 0) {
+      val currentWord = word(i)
+      if (currentWord != 0L) {
+        return ((i + 1) * WordLength) - java.lang.Long.numberOfLeadingZeros(currentWord) - 1
+      }
+      i -= 1
+    }
+    throw new UnsupportedOperationException("empty.largestInt")
+  }
+
+  override def max[B >: Int](implicit ord: Ordering[B]): Int =
+    if (Ordering.Int eq ord) largestInt
+    else if (Ordering.Int.reverse eq ord) smallestInt
+    else super.max(ord)
+
 
   override def min[B >: Int](implicit ord: Ordering[B]): Int =
-    if (Ordering.Int eq ord) {
-      val thisnwords = nwords
-      var i = 0
-      var currentWord = 0L
-      while(i < thisnwords) {
-        currentWord = word(i)
-        if (currentWord != 0L) {
-          return java.lang.Long.numberOfTrailingZeros(currentWord) + (i * WordLength)
-        }
-        i += 1
-      }
-      throw new UnsupportedOperationException("empty.min")
-    } else if (Ordering.Int.reverse eq ord) {
-      var i = nwords - 1
-      var currentWord = 0L
-      while(i >= 0) {
-        currentWord = word(i)
-        if (currentWord != 0L) {
-          return ((i + 1) * WordLength) - java.lang.Long.numberOfLeadingZeros(currentWord) - 1
-        }
-        i -= 1
-      }
-      throw new UnsupportedOperationException("empty.min")
-    } else {
-      super.min(ord)
-    }
+    if (Ordering.Int eq ord) smallestInt
+    else if (Ordering.Int.reverse eq ord) largestInt
+    else super.min(ord)
 
   override def foreach[U](f: Int => U): Unit = {
     /* NOTE: while loops are significantly faster as of 2.11 and

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -234,7 +234,7 @@ object Ordering extends LowPriorityOrderingImplicits {
     override def hashCode(): Int = outer.hashCode() * reverseSeed
   }
 
-  private final val IntReverse: Ordering[Int] = new Reverse(Ordering.Int)
+  final val IntReverse: Ordering[Int] = new Reverse(Ordering.Int)
 
   private final class IterableOrdering[CC[X] <: Iterable[X], T](private val ord: Ordering[T]) extends Ordering[CC[T]] {
     def compare(x: CC[T], y: CC[T]): Int = {

--- a/test/scalacheck/scala/collection/immutable/BitSetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/BitSetProperties.scala
@@ -1,0 +1,33 @@
+package scala.collection.immutable
+import org.scalacheck._
+import org.scalacheck.Prop._
+import org.scalacheck.Prop.BooleanOperators
+import Gen._
+object BitSetProperties extends Properties("immutable.BitSet") {
+  override def overrideParameters(p: Test.Parameters): Test.Parameters =
+    p.withMinSuccessfulTests(500)
+      .withInitialSeed(42L)
+  // the top of the range shouldn't be too high, else we may not get enough overlap
+  implicit val arbitraryBitSet: Arbitrary[BitSet] = Arbitrary(
+    oneOf(
+      const(BitSet()),
+      oneOf(0 to 100).map(i => BitSet(i)),
+      listOfN(200, oneOf(0 to 10000)).map(_.to(BitSet))
+    )
+  )
+
+  property("min") = forAll { (bs: BitSet) =>
+    bs.nonEmpty ==> (bs.min ?= bs.toList.min)
+  }
+  property("min reverse") = forAll { (bs: BitSet) =>
+    bs.nonEmpty ==> (bs.min(Ordering.Int.reverse) ?= bs.toList.min(Ordering.Int.reverse))
+  }
+
+  property("max") = forAll { (bs: BitSet) =>
+    bs.nonEmpty ==> (bs.max ?= bs.toList.max)
+  }
+
+  property("max reverse") = forAll { (bs: BitSet) =>
+    bs.nonEmpty ==> (bs.max(Ordering.Int.reverse) ?= bs.toList.max(Ordering.Int.reverse))
+  }
+}


### PR DESCRIPTION
This specializes Bitset's methods:
* `def min(implicit ord: Ordering[Int]): Int`
* `def max(implicit ord: Ordring[Int]): Int` 

for the special case where `ord eq Ordering.Int` or `ord eq Ordering.Int.reverse`, by simply returning either the first or last int in the BitSet, avoiding a slow call to `reduceLeft`.

The performance gain is really great! However there is a some really glitchy thing going on maybe with the JIT. For BitSets of size 10million, every once in a while it will take thousands of times longer than at other times. It is still much much faster than the current implementation, but look at these benchmarks:

```
[info] Benchmark                 (size)  Mode  Cnt           Score           Error  Units
[info] BitSetBenchmark.newMax         1  avgt    6          24.718 ±         3.129  ns/op
[info] BitSetBenchmark.newMax      1000  avgt    6          33.748 ±         6.846  ns/op
[info] BitSetBenchmark.newMax  10000000  avgt    6          31.969 ±         2.037  ns/op
[info] BitSetBenchmark.oldMax         1  avgt    6         611.872 ±        35.562  ns/op
[info] BitSetBenchmark.oldMax      1000  avgt    6       67575.187 ±     29794.376  ns/op
[info] BitSetBenchmark.oldMax  10000000  avgt    6  1097735514.333 ± 284511227.381  ns/op
```

but sometimes:
```
[info] Benchmark                 (size)  Mode  Cnt          Score          Error  Units
[info] BitSetBenchmark.newMax         1  avgt    6         23.650 ±        0.513  ns/op
[info] BitSetBenchmark.newMax      1000  avgt    6         34.298 ±       15.535  ns/op
[info] BitSetBenchmark.newMax  10000000  avgt    6     807648.297 ±  1237980.119  ns/op
[info] BitSetBenchmark.oldMax         1  avgt    6        631.019 ±       17.239  ns/op
[info] BitSetBenchmark.oldMax      1000  avgt    6      59758.812 ±    13041.835  ns/op
[info] BitSetBenchmark.oldMax  10000000  avgt    6  918539719.917 ± 21715814.275  ns/op
```

These benchmarks are run with ord = Ordering.Int, so the code path for `Ordering.Int.reverse` is not taken. I have found that if I throw excption on the first line of that code path (by placing a `???`), then the performance goes back to normal. I think something weird is going on where maybe the wrong branch is being predicted and then backtracked or something. Not sure how to debug it..