### PR TITLE
Widen mutable.BitSet operations to accept any collection.BitSet, not just mutable

### DIFF
--- a/test/benchmarks/src/main/scala/scala/collection/mutable/BitSetBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/BitSetBenchmark.scala
@@ -1,0 +1,40 @@
+package scala.collection.mutable
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+import java.util.concurrent.TimeUnit
+
+import scala.collection.mutable
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 6)
+@Measurement(iterations = 6)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class BitSetBenchmark {
+  @Param(Array("0", "3", "5", "10", "1000", "1000000"))
+  var size: Int = _
+
+  val bitSet = (1 to 1000).to(mutable.BitSet)
+
+  var bs: mutable.BitSet = _
+
+  var range: Range = _
+
+  val clones: Array[mutable.BitSet] = new Array(100)
+
+  @Setup(Level.Iteration) def initializeRange(): Unit = {
+    range = (10 to (10 + size))
+  }
+  @Setup(Level.Invocation) def initializeClones(): Unit = {
+    (0 until 100) foreach (i => clones(i) = bitSet.clone())
+  }
+
+  @Benchmark def addAll(bh: Blackhole): Unit = {
+    clones.foreach{ c =>
+      bh consume c.addAll(range)
+    }
+  }
+}

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -118,4 +118,10 @@ class BitSetTest {
     assert(BitSet().diff(a) == BitSet())
     assert(BitSet().diff(BitSet()) == BitSet())
   }
+
+  @Test def buildFromRange(): Unit = {
+    import scala.util.chaining._
+    assert((1 to 1000).to(BitSet) == BitSet().tap(bs => (1 to 1000).foreach(bs.addOne)))
+
+  }
 }


### PR DESCRIPTION
I saw no reason these methods should be restricted to only accepting mutable BitSets.
Also, replaced for expressions and Range objects with while loops. 

Also, this includes an optimized implementation of `mutable.BitSet#addAll(IterableOnce[Int])` where if  the argument is a non-negative `Range` with a step of `+/- 1`, we simply fill in all the ones from position `range.min` to `range.max`. Benchmarks below 

Note there's a big jump in cpu time at size `1000000`, this is because the BitSets are initialized to size `1000`, meaning that in the case of `1000000` an array resizing must be performed.
```
[info] Benchmark                   (size)  Mode  Cnt          Score          Error  Units
[info] BitSetBenchmark.newAddAll        0  avgt    6       3526.876 ±      189.692  ns/op
[info] BitSetBenchmark.newAddAll        3  avgt    6       3432.946 ±      105.355  ns/op
[info] BitSetBenchmark.newAddAll        5  avgt    6       3451.243 ±      205.785  ns/op
[info] BitSetBenchmark.newAddAll       10  avgt    6       3448.004 ±       91.350  ns/op
[info] BitSetBenchmark.newAddAll     1000  avgt    6       3836.286 ±       59.384  ns/op
[info] BitSetBenchmark.newAddAll  1000000  avgt    6     870262.127 ±    28773.114  ns/op
[info] BitSetBenchmark.oldAddAll        0  avgt    6       3577.063 ±       47.795  ns/op
[info] BitSetBenchmark.oldAddAll        3  avgt    6       4801.710 ±      355.115  ns/op
[info] BitSetBenchmark.oldAddAll        5  avgt    6       5516.834 ±      161.252  ns/op
[info] BitSetBenchmark.oldAddAll       10  avgt    6       7083.424 ±      118.083  ns/op
[info] BitSetBenchmark.oldAddAll     1000  avgt    6     673910.034 ±    12110.355  ns/op
[info] BitSetBenchmark.oldAddAll  1000000  avgt    6  547244039.917 ± 11428012.641  ns/op
```

benchmark code is included in this PR.

---------

- [x] Remove `oldAddAll`