### PR TITLE
GrowableBuilder should forward its addAll method to its underlying growable

### DIFF
--- a/src/library/scala/collection/mutable/GrowableBuilder.scala
+++ b/src/library/scala/collection/mutable/GrowableBuilder.scala
@@ -34,4 +34,5 @@ class GrowableBuilder[Elem, To <: Growable[Elem]](protected val elems: To)
 
   def addOne(elem: Elem): this.type = { elems += elem; this }
 
+  override def addAll(xs: IterableOnce[Elem]): this.type = { elems.addAll(xs); this }
 }


### PR DESCRIPTION
Rather than iterating through elements one-by-one, it should forward calls to addAll, where there are likely optimized implementations. 