### PR TITLE
Rename immutable `remove` and similar methods to `removed`

### DIFF
--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -168,7 +168,7 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   @`inline` final def &~ (that: Set[A]): C = this diff that
 
   @deprecated("Consider requiring an immutable Set", "2.13.0")
-  def -- (that: IterableOnce[A]): C = fromSpecific(coll.toSet.removeAll(that))
+  def -- (that: IterableOnce[A]): C = fromSpecific(coll.toSet.removedAll(that))
 
   @deprecated("Consider requiring an immutable Set or fall back to Set.diff", "2.13.0")
   def - (elem: A): C = diff(Set(elem))

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -104,7 +104,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     if (newRootNode ne rootNode) new HashMap(newRootNode) else this
   }
 
-  def remove(key: K): HashMap[K, V] = {
+  def removed(key: K): HashMap[K, V] = {
     val keyUnimprovedHash = key.##
     val keyHash = improve(keyUnimprovedHash)
     val newRootNode = rootNode.removed(key, keyUnimprovedHash, keyHash, 0)
@@ -155,10 +155,10 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
   def merged[V1 >: V](that: HashMap[K, V1])(mergef: MergeFunction[K, V1]): HashMap[K, V1] = {
     val thisKeys = this.keySet
     if(mergef eq null)
-      that.removeAll(thisKeys) ++ this
+      that.removedAll(thisKeys) ++ this
     else {
       val thatKeys = that.keySet
-      that.removeAll(thisKeys) ++ this.removeAll(thatKeys) ++ thisKeys.intersect(thatKeys).map { case k => mergef((k, this(k)), (k, that(k))) }
+      that.removedAll(thisKeys) ++ this.removedAll(thatKeys) ++ thisKeys.intersect(thatKeys).map { case k => mergef((k, this(k)), (k, that(k))) }
     }
   }
 
@@ -177,14 +177,14 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     super.filterImpl(pred, flipped)
   }
 
-  override def removeAll(keys: IterableOnce[K]): HashMap[K, V] = {
+  override def removedAll(keys: IterableOnce[K]): HashMap[K, V] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
     //
     // In particular, `removeAll` could be optimized to avoid reallocating the `HashMap` wrapper of the rootNode on each
     // element in `keys`, and potentially to take advantage of the structure of `keys`, if it happens to be a HashSet
     // which would allow us to skip hashing keys all together.
-    super.removeAll(keys)
+    super.removedAll(keys)
   }
 
   override def partition(p: ((K, V)) => Boolean): (HashMap[K, V], HashMap[K, V]) = {

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -119,10 +119,10 @@ final class HashSet[A] private[immutable] (val rootNode: SetNode[A])
     super.diff(that)
   }
 
-  override def removeAll(that: IterableOnce[A]): HashSet[A] = {
+  override def removedAll(that: IterableOnce[A]): HashSet[A] = {
     // This method has been preemptively overridden in order to ensure that an optimizing implementation may be included
     // in a minor release without breaking binary compatibility.
-    super.removeAll(that)
+    super.removedAll(that)
   }
 
   override def partition(p: A => Boolean): (HashSet[A], HashSet[A]) = {

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -357,7 +357,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil => IntMap.Tip(key, value)
   }
 
-  def remove (key: Int): IntMap[T] = this match {
+  def removed (key: Int): IntMap[T] = this match {
     case IntMap.Bin(prefix, mask, left, right) =>
       if (!hasMatch(key, prefix, mask)) this
       else if (zero(key, mask)) bin(prefix, mask, left - key, right)

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -62,7 +62,7 @@ sealed class ListMap[K, +V]
 
   def updated[B1 >: V](key: K, value: B1): ListMap[K, B1] = new Node[B1](key, value)
 
-  def remove(key: K): ListMap[K, V] = this
+  def removed(key: K): ListMap[K, V] = this
 
   def iterator: Iterator[(K, V)] = {
     var curr: ListMap[K, V] = this
@@ -131,7 +131,7 @@ sealed class ListMap[K, +V]
       new m.Node[V2](k, v)
     }
 
-    override def remove(k: K): ListMap[K, V1] = removeInternal(k, this, Nil)
+    override def removed(k: K): ListMap[K, V1] = removeInternal(k, this, Nil)
 
     @tailrec private[this] def removeInternal(k: K, cur: ListMap[K, V1], acc: List[ListMap[K, V1]]): ListMap[K, V1] =
       if (cur.isEmpty) acc.last

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -340,7 +340,7 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil => LongMap.Tip(key, value)
   }
 
-  def remove(key: Long): LongMap[T] = this match {
+  def removed(key: Long): LongMap[T] = this match {
     case LongMap.Bin(prefix, mask, left, right) =>
       if (!hasMatch(key, prefix, mask)) this
       else if (zero(key, mask)) bin(prefix, mask, left - key, right)

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -71,14 +71,14 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
     * @param key the key to be removed
     * @return a new map without a binding for ''key''
     */
-  def remove(key: K): C
+  def removed(key: K): C
 
   /** Alias for `remove` */
   @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /*@`inline` final*/ def - (key: K): C = remove(key)
+  /*@`inline` final*/ def - (key: K): C = removed(key)
 
   @deprecated("Use -- with an explicit collection", "2.13.0")
-  def - (key1: K, key2: K, keys: K*): C = remove(key1).remove(key2).removeAll(keys)
+  def - (key1: K, key2: K, keys: K*): C = removed(key1).removed(key2).removedAll(keys)
 
   /** Creates a new $coll from this $coll by removing all elements of another
     *  collection.
@@ -87,11 +87,11 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
     *  @return a new $coll that contains all elements of the current $coll
     *  except one less occurrence of each of the elements of `elems`.
     */
-  def removeAll(keys: IterableOnce[K]): C = keys.iterator.foldLeft[C](coll)(_ - _)
+  def removedAll(keys: IterableOnce[K]): C = keys.iterator.foldLeft[C](coll)(_ - _)
 
   /** Alias for `removeAll` */
   @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /* @`inline` final */ override def -- (keys: IterableOnce[K]): C = removeAll(keys)
+  /* @`inline` final */ override def -- (keys: IterableOnce[K]): C = removedAll(keys)
 
   /** Creates a new map obtained by updating this map with a given key/value pair.
     *  @param    key the key
@@ -165,7 +165,7 @@ object Map extends MapFactory[Map] {
     override def concat [V2 >: V](xs: collection.IterableOnce[(K, V2)]): WithDefault[K, V2] =
       new WithDefault(underlying.concat(xs), defaultValue)
 
-    def remove(key: K): WithDefault[K, V] = new WithDefault[K, V](underlying.remove(key), defaultValue)
+    def removed(key: K): WithDefault[K, V] = new WithDefault[K, V](underlying.removed(key), defaultValue)
 
     def updated[V1 >: V](key: K, value: V1): WithDefault[K, V1] =
       new WithDefault[K, V1](underlying.updated(key, value), defaultValue)
@@ -200,7 +200,7 @@ object Map extends MapFactory[Map] {
     override def getOrElse [V1](key: Any, default: => V1): V1 = default
     def iterator: Iterator[(Any, Nothing)] = Iterator.empty
     def updated [V1] (key: Any, value: V1): Map[Any, V1] = new Map1(key, value)
-    def remove(key: Any): Map[Any, Nothing] = this
+    def removed(key: Any): Map[Any, Nothing] = this
   }
 
   final class Map1[K, +V](key1: K, value1: V) extends AbstractMap[K, V] with StrictOptimizedIterableOps[(K, V), Iterable, Map[K, V]] {
@@ -219,7 +219,7 @@ object Map extends MapFactory[Map] {
     def updated[V1 >: V](key: K, value: V1): Map[K, V1] =
       if (key == key1) new Map1(key1, value)
       else new Map2(key1, value1, key, value)
-    def remove(key: K): Map[K, V] =
+    def removed(key: K): Map[K, V] =
       if (key == key1) Map.empty else this
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1))
@@ -271,7 +271,7 @@ object Map extends MapFactory[Map] {
       if (key == key1) new Map2(key1, value, key2, value2)
       else if (key == key2) new Map2(key1, value1, key2, value)
       else new Map3(key1, value1, key2, value2, key, value)
-    def remove(key: K): Map[K, V] =
+    def removed(key: K): Map[K, V] =
       if (key == key1) new Map1(key2, value2)
       else if (key == key2) new Map1(key1, value1)
       else this
@@ -330,7 +330,7 @@ object Map extends MapFactory[Map] {
       else if (key == key2) new Map3(key1, value1, key2, value, key3, value3)
       else if (key == key3) new Map3(key1, value1, key2, value2, key3, value)
       else new Map4(key1, value1, key2, value2, key3, value3, key, value)
-    def remove(key: K): Map[K, V] =
+    def removed(key: K): Map[K, V] =
       if (key == key1)      new Map2(key2, value2, key3, value3)
       else if (key == key2) new Map2(key1, value1, key3, value3)
       else if (key == key3) new Map2(key1, value1, key2, value2)
@@ -397,7 +397,7 @@ object Map extends MapFactory[Map] {
       else if (key == key3) new Map4(key1, value1, key2, value2, key3, value, key4, value4)
       else if (key == key4) new Map4(key1, value1, key2, value2, key3, value3, key4, value)
       else HashMap.empty[K, V1].updated(key1,value1).updated(key2, value2).updated(key3, value3).updated(key4, value4).updated(key, value)
-    def remove(key: K): Map[K, V] =
+    def removed(key: K): Map[K, V] =
       if (key == key1)      new Map3(key2, value2, key3, value3, key4, value4)
       else if (key == key2) new Map3(key1, value1, key3, value3, key4, value4)
       else if (key == key3) new Map3(key1, value1, key2, value2, key4, value4)

--- a/src/library/scala/collection/immutable/SeqMap.scala
+++ b/src/library/scala/collection/immutable/SeqMap.scala
@@ -60,7 +60,7 @@ object SeqMap extends MapFactory[SeqMap] {
     override def getOrElse [V1](key: Any, default: => V1): V1 = default
     def iterator: Iterator[(Any, Nothing)] = Iterator.empty
     def updated [V1] (key: Any, value: V1): SeqMap[Any, V1] = new SeqMap1(key, value)
-    def remove(key: Any): SeqMap[Any, Nothing] = this
+    def removed(key: Any): SeqMap[Any, Nothing] = this
   }
 
   @SerialVersionUID(3L)
@@ -77,7 +77,7 @@ object SeqMap extends MapFactory[SeqMap] {
     def updated[V1 >: V](key: K, value: V1): SeqMap[K, V1] =
       if (key == key1) new SeqMap1(key1, value)
       else new SeqMap2(key1, value1, key, value)
-    def remove(key: K): SeqMap[K, V] =
+    def removed(key: K): SeqMap[K, V] =
       if (key == key1) SeqMap.empty else this
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1))
@@ -106,7 +106,7 @@ object SeqMap extends MapFactory[SeqMap] {
       if (key == key1) new SeqMap2(key1, value, key2, value2)
       else if (key == key2) new SeqMap2(key1, value1, key2, value)
       else new SeqMap3(key1, value1, key2, value2, key, value)
-    def remove(key: K): SeqMap[K, V] =
+    def removed(key: K): SeqMap[K, V] =
       if (key == key1) new SeqMap1(key2, value2)
       else if (key == key2) new SeqMap1(key1, value1)
       else this
@@ -141,7 +141,7 @@ object SeqMap extends MapFactory[SeqMap] {
       else if (key == key2) new SeqMap3(key1, value1, key2, value, key3, value3)
       else if (key == key3) new SeqMap3(key1, value1, key2, value2, key3, value)
       else new SeqMap4(key1, value1, key2, value2, key3, value3, key, value)
-    def remove(key: K): SeqMap[K, V] =
+    def removed(key: K): SeqMap[K, V] =
       if (key == key1)      new SeqMap2(key2, value2, key3, value3)
       else if (key == key2) new SeqMap2(key1, value1, key3, value3)
       else if (key == key3) new SeqMap2(key1, value1, key2, value2)
@@ -193,7 +193,7 @@ object SeqMap extends MapFactory[SeqMap] {
           )
         new VectorMap(fields, underlying)
       }
-    def remove(key: K): SeqMap[K, V] =
+    def removed(key: K): SeqMap[K, V] =
       if (key == key1)      new SeqMap3(key2, value2, key3, value3, key4, value4)
       else if (key == key2) new SeqMap3(key1, value1, key3, value3, key4, value4)
       else if (key == key3) new SeqMap3(key1, value1, key2, value2, key4, value4)

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -75,11 +75,11 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     *  @param that the collection containing the elements to remove.
     *  @return a new $coll with the given elements removed, omitting duplicates.
     */
-  def removeAll(that: IterableOnce[A]): C = that.iterator.foldLeft[C](coll)(_ - _)
+  def removedAll(that: IterableOnce[A]): C = that.iterator.foldLeft[C](coll)(_ - _)
 
   /** Alias for removeAll */
   @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  override /*final*/ def -- (that: IterableOnce[A]): C = removeAll(that)
+  override /*final*/ def -- (that: IterableOnce[A]): C = removedAll(that)
 }
 
 /**

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -111,7 +111,7 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
     override def concat [V2 >: V](xs: collection.IterableOnce[(K, V2)]): WithDefault[K, V2] =
       new WithDefault( underlying.concat(xs) , defaultValue)
 
-    override def remove(key: K): WithDefault[K, V] = new WithDefault[K, V](underlying.remove(key), defaultValue)
+    override def removed(key: K): WithDefault[K, V] = new WithDefault[K, V](underlying.removed(key), defaultValue)
 
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -61,7 +61,7 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V])(implicit va
 
   def get(key: K): Option[V] = RB.get(tree, key)
 
-  def remove(key: K): TreeMap[K,V] =
+  def removed(key: K): TreeMap[K,V] =
     newMapOrSelf(RB.delete(tree, key))
 
   def updated[V1 >: V](key: K, value: V1): TreeMap[K, V1] =
@@ -81,10 +81,10 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V])(implicit va
         t
     })
 
-  override def removeAll(keys: IterableOnce[K]): TreeMap[K, V] = keys match {
+  override def removedAll(keys: IterableOnce[K]): TreeMap[K, V] = keys match {
     case ts: TreeSet[K] if ordering == ts.ordering =>
       newMapOrSelf(RB.difference(tree, ts.tree))
-    case _ => super.removeAll(keys)
+    case _ => super.removedAll(keys)
   }
 
   /** A new TreeMap with the entry added is returned,

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -153,10 +153,10 @@ final class TreeSet[A] private (private[immutable] val tree: RB.Tree[A, Null])(i
     newSetOrSelf(t)
   }
 
-  override def removeAll(that: IterableOnce[A]): TreeSet[A] = that match {
+  override def removedAll(that: IterableOnce[A]): TreeSet[A] = that match {
     case ts: TreeSet[A] if ordering == ts.ordering =>
       newSetOrSelf(RB.difference(tree, ts.tree))
-    case _ => super.removeAll(that)
+    case _ => super.removedAll(that)
   }
 
   override def intersect(that: collection.Set[A]): TreeSet[A] = that match {

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -119,7 +119,7 @@ final class VectorMap[K, +V] private (
     }
   }
 
-  def remove(key: K): VectorMap[K, V] = {
+  def removed(key: K): VectorMap[K, V] = {
     if (isEmpty) empty
     else {
       var fs = fields


### PR DESCRIPTION
This affects:
- `immutable.Map.remove`
- `immutable.Map.removeAll`
- `immutable.Set.removeAll`

None of these methods existed in 2.12 so there’s no need for deprecated
forwarders.

Fixes https://github.com/scala/bug/issues/11189