### PR TITLE
Add sym shorthand for Symbol

### DIFF
--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -154,6 +154,37 @@ case class StringContext(parts: String*) {
    */
   def raw(args: Any*): String = standardInterpolator(identity, args, parts)
 
+  /** Shorthand symbol constructor.
+   *
+   *  Here's an example of usage:
+   *  {{{
+   *    val abc = List(sym"a", sym"b", sym"c")
+   *    println(syms) // List('a, 'b, 'c)
+   *  }}}
+   *  This string-based shorthand, replaces the old built-in quote syntax:
+   *  {{{
+   *    val abc = List('a, 'b, 'c) // Symbol literals were deprecated in 2.13
+   *  }}}
+   *
+   *  @param `str` The string to be converted to a symbol.
+   */
+  def sym(args: String*): Symbol = {
+    Symbol(standardInterpolator(processEscapes, args, parts))
+  }
+
+  object sym {
+    def unapplySeq(s: Symbol): Option[Seq[String]] = {
+      parts match {
+        case s.name +: Seq() => Some(Seq.empty[String])
+        case _ +: _ +: _     => // if parts.size > 1
+          throw new IllegalArgumentException(
+            "Variable interpolation not supported, use '$$' for '$'"
+          )
+        case _               => None
+      }
+    }
+  }
+
   /** The formatted string interpolator.
    *
    *  It inserts its arguments between corresponding parts of the string context.

--- a/src/library/scala/Symbol.scala
+++ b/src/library/scala/Symbol.scala
@@ -14,13 +14,14 @@ package scala
 
 /** This class provides a simple way to get unique objects for equal strings.
  *  Since symbols are interned, they can be compared using reference equality.
- *  Instances of `Symbol` can be created easily with Scala's built-in quote
- *  mechanism.
  *
- *  For instance, the Scala term `'mysym` will
- *  invoke the constructor of the `Symbol` class in the following way:
- *  `Symbol("mysym")`.
+ *  Instances of `Symbol` can be created with
+ *  the `sym` string interpolator:
+ *  {{{
+ *  val s = sym"mysym"
+ *  }}}
  *
+ *  @see     [[scala.StringContext.sym]]
  *  @author  Martin Odersky, Iulian Dragos
  *  @since   1.7
  */

--- a/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
+++ b/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
@@ -1,0 +1,83 @@
+package scala.lang.stringinterpol
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.language.implicitConversions
+
+@RunWith(classOf[JUnit4])
+class SymbolsTest {
+
+  @Test
+  def symbolTest: Unit = {
+    assertEquals("'foo", sym"foo".toString)
+  }
+
+  @Test
+  def emptySymbolTest: Unit = {
+    assertEquals("'", sym"".toString)
+  }
+
+  @Test
+  def symbolListTest: Unit = {
+    assertEquals("List('foo, 'bar, 'baz)", List(sym"foo", sym"bar", sym"baz").toString)
+    assertEquals("List('foo, 'bar, 'baz)", (sym"foo" :: sym"bar" :: sym"baz" :: Nil).toString)
+  }
+
+  @Test
+  def symbolInterpolationTest: Unit = {
+    val foo = "bar"
+    assertEquals('bar, sym"$foo")
+    assertEquals("'bar", sym"$foo".toString)
+  }
+
+  @Test
+  def patternMatchTest: Unit = {
+    val foo = "foo"
+    sym"foo" match {
+      case sym""           => fail
+      case sym"$$foo"      => fail
+      case sym"$${foo}"    => fail
+      case sym"foo$${bar}" => fail
+      case sym"foo\n"      => fail
+      case sym"foo"        => return
+      case _               => fail
+    }
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def patternMatchDollarFail: Unit = {
+    val bar = "foo"
+    sym"foo" match {
+      // Variable interpolation not supported, use '$$' for '$'
+      case sym"$bar" =>
+    }
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def patternMatchDollarBracesFail: Unit = {
+    val bar = "foo"
+    sym"foo" match {
+      // Variable interpolation not supported, use '$$' for '$'
+      case sym"${bar}" =>
+    }
+  }
+
+  @Test
+  def deconstructTest: Unit = {
+    val sym"foo" = sym"foo"
+  }
+
+  @Test(expected = classOf[MatchError])
+  def deconstructFail: Unit = {
+    val sym"bar" = sym"foo"
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def deconstructDollarFail: Unit = {
+    // Variable interpolation not supported, use '$$' for '$'
+    val sym"$foo" = sym"foo"
+  }
+}


### PR DESCRIPTION
**UPDATE:** this was reverted by #7917 

In https://github.com/scala/scala-dev/issues/459, there was a suggestion to provide a string variant to replace the symbol quote syntax:

```scala
book should have (
  sym"title" ("Programming in Scala"),
  sym"author" (List("Odersky", "Spoon", "Venners")),
  sym"pubYear" (2008)
)
```

This is a work-in-progress for discussion on providing an alternative so quote syntax can be deprecated.  As implemented with `StringContext`, it supports interpolation as well.

~~I've disabled the test suite so that only the new test runs.~~
