### PR TITLE
Remove -Xmax-classfile-length; hard-code to 240

### DIFF
--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -99,7 +99,7 @@ object ScalaOptionParser {
   private val phases = List("all", "parser", "namer", "packageobjects", "typer", "patmat", "superaccessors", "extmethods", "pickler", "refchecks", "uncurry", "tailcalls", "specialize", "explicitouter", "erasure", "posterasure", "fields", "lambdalift", "constructors", "flatten", "mixin", "cleanup", "delambdafy", "icode", "jvm", "terminal")
   private val phaseSettings = List("-Xprint-icode", "-Ystop-after", "-Yskip", "-Yshow", "-Ystop-before", "-Ybrowse", "-Ylog", "-Ycheck", "-Xprint", "-Yvalidate-pos")
   private def multiStringSettingNames = List("-Xmacro-settings", "-Xplugin", "-Xplugin-disable", "-Xplugin-require", "-Ywarn-unused", "-opt-inline-from")
-  private def intSettingNames = List("-Xmax-classfile-name", "-Xelide-below", "-Ypatmat-exhaust-depth", "-Ypresentation-delay", "-Yrecursion")
+  private def intSettingNames = List("-Xelide-below", "-Ypatmat-exhaust-depth", "-Ypresentation-delay", "-Yrecursion")
   private def choiceSettingNames = Map[String, List[String]](
     "-YclasspathImpl" -> List("flat", "recursive"),
     "-Ydelambdafy" -> List("inline", "method"),

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -125,7 +125,6 @@ trait ScalaSettings extends AbsScalaSettings
   val logReflectiveCalls = BooleanSetting      ("-Xlog-reflective-calls", "Print a message when a reflective method call is generated")
   val logFreeTerms       = BooleanSetting      ("-Xlog-free-terms", "Print a message when reification creates a free term.")
   val logFreeTypes       = BooleanSetting      ("-Xlog-free-types", "Print a message when reification resorts to generating a free type.")
-  val maxClassfileName   = IntSetting          ("-Xmax-classfile-name", "Maximum filename length for generated classes", 255, Some((72, 255)), _ => None)
   val maxerrs            = IntSetting          ("-Xmaxerrs", "Maximum errors to print", 100, None, _ => None)
   val maxwarns           = IntSetting          ("-Xmaxwarns", "Maximum warnings to print", 100, None, _ => None)
   val Xmigration         = ScalaVersionSetting ("-Xmigration", "version", "Warn about constructs whose behavior may have changed since version.", initial = NoScalaVersion, default = Some(AnyScalaVersion))

--- a/src/manual/scala/man1/scalac.scala
+++ b/src/manual/scala/man1/scalac.scala
@@ -233,9 +233,6 @@ object scalac extends Command {
           CmdOption("Xmain-class", Argument("path")),
           "Class for manifest's Main-Class entry (only useful with -d <jar>)."),
         Definition(
-          CmdOption("Xmax-classfile-name", Argument("n")),
-          "Maximum filename length for generated classes."),
-        Definition(
           CmdOptionBound("Xmigration:", Argument("version")),
           "Warn about constructs whose behavior may have changed since" & Argument("version") & "."),
         Definition(

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -64,7 +64,6 @@ abstract class MutableSettings extends AbsSettings {
   def YstatisticsEnabled: Boolean = false
 
   def Yrecursion: IntSetting
-  def maxClassfileName: IntSetting
 
   def isScala211: Boolean
   def isScala212: Boolean

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -57,7 +57,6 @@ private[reflect] class Settings extends MutableSettings {
   val verbose           = new BooleanSetting(false)
 
   val Yrecursion        = new IntSetting(0)
-  val maxClassfileName  = new IntSetting(255)
   def isScala211        = true
   def isScala212        = true
   private[scala] def isScala213 = false

--- a/test/files/run/t8199.scala
+++ b/test/files/run/t8199.scala
@@ -39,7 +39,7 @@ object Test extends App {
     checkClassName(c.getName)
   }
   def checkClassName(name: String): Unit = {
-    val defaultMaxClassFileLength = 255
+    val defaultMaxClassFileLength = 240
     assert((name + ".class").length <= defaultMaxClassFileLength, name)
   }
 


### PR DESCRIPTION
This option allowed users to limit the size of classfile names
to fewer than 255 (previously the default) characters.

However, this means that classfiles made from a compiler with the
option are not compatible with classfiles made without it
(in either direction), since the compiler will flatten names of
classes with the current value of the setting, not whatever the
class was compiled with.

So, remove it and default to 240 (the limit in docker).

See also scala/bug#8199