### PR TITLE
Try to drop symbol literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         script:
           - sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
           - STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
-          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
+          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info "junit/testOnly scala.lang.stringinterpol.SymbolsTest"
 
       # build the spec using jekyll
       - stage: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         script:
           - sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
           - STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
-          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info "junit/testOnly scala.lang.stringinterpol.SymbolsTest"
+          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
 
       # build the spec using jekyll
       - stage: build

--- a/scripts/jobs/validate/test
+++ b/scripts/jobs/validate/test
@@ -21,7 +21,7 @@ case $prDryRun in
        -warn \
        "setupValidateTest $prRepoUrl" \
        $testExtraArgs \
-       testAll
+       "junit/testOnly scala.lang.stringinterpol.SymbolsTest"
 
     ;;
 

--- a/scripts/jobs/validate/test
+++ b/scripts/jobs/validate/test
@@ -21,7 +21,7 @@ case $prDryRun in
        -warn \
        "setupValidateTest $prRepoUrl" \
        $testExtraArgs \
-       "junit/testOnly scala.lang.stringinterpol.SymbolsTest"
+       testAll
 
     ;;
 

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -690,7 +690,7 @@ self =>
 
     def isLiteralToken(token: Token) = token match {
       case CHARLIT | INTLIT | LONGLIT | FLOATLIT | DOUBLELIT |
-           STRINGLIT | INTERPOLATIONID | SYMBOLLIT | TRUE | FALSE | NULL => true
+           STRINGLIT | INTERPOLATIONID | TRUE | FALSE | NULL        => true
       case _                                                        => false
     }
     def isLiteral = isLiteralToken(in.token)
@@ -1302,7 +1302,6 @@ self =>
 
     /** {{{
      *  SimpleExpr    ::= literal
-     *                  | symbol
      *                  | null
      *  }}}
      */
@@ -1310,8 +1309,6 @@ self =>
       def finish(value: Any): Tree = try newLiteral(value) finally in.nextToken()
       if (in.token == INTERPOLATIONID)
         interpolatedString(inPattern = inPattern)
-      else if (in.token == SYMBOLLIT)
-        Apply(scalaDot(nme.Symbol), List(finish(in.strVal)))
       else finish(in.token match {
         case CHARLIT                => in.charVal
         case INTLIT                 => in.intVal(isNegated).toInt
@@ -2116,7 +2113,7 @@ self =>
             in.nextToken()
             atPos(start, start) { Ident(nme.WILDCARD) }
           case CHARLIT | INTLIT | LONGLIT | FLOATLIT | DOUBLELIT |
-               STRINGLIT | INTERPOLATIONID | SYMBOLLIT | TRUE | FALSE | NULL =>
+               STRINGLIT | INTERPOLATIONID | TRUE | FALSE | NULL   =>
             literal(inPattern = true)
           case LPAREN =>
             atPos(start)(makeParens(noSeq.patterns()))

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -562,7 +562,7 @@ trait Scanners extends ScannersCommon {
                     wholeLine.count(_ == '\'') > 1
                   case _ => false
                 }
-              if (token == SYMBOLLIT && offset == lastOffset) s"""$unclosed (or use " for string literal "$strVal")"""
+              if (token == IDENTIFIER && offset == lastOffset) s"""$unclosed (or use " for string literal "$strVal")"""
               else if (maybeMistakenQuote) s"""$unclosed (or use " not ' for string literal)"""
               else unclosed
             }
@@ -661,7 +661,7 @@ trait Scanners extends ScannersCommon {
 
     /** Can token end a statement? */
     def inLastOfStat(token: Token) = token match {
-      case CHARLIT | INTLIT | LONGLIT | FLOATLIT | DOUBLELIT | STRINGLIT | SYMBOLLIT |
+      case CHARLIT | INTLIT | LONGLIT | FLOATLIT | DOUBLELIT | STRINGLIT |
            IDENTIFIER | BACKQUOTED_IDENT | THIS | NULL | TRUE | FALSE | RETURN | USCORE |
            TYPE | XMLSTART | RPAREN | RBRACKET | RBRACE =>
         true
@@ -1093,7 +1093,7 @@ trait Scanners extends ScannersCommon {
     }
 
     /** Parse character literal if current character is followed by \',
-     *  or follow with given op and return a symbol literal token
+     *  or follow with given op and return an identifier token.
      */
     def charLitOr(op: () => Unit): Unit = {
       putChar(ch)
@@ -1104,7 +1104,7 @@ trait Scanners extends ScannersCommon {
         setStrVal()
       } else {
         op()
-        token = SYMBOLLIT
+        token = IDENTIFIER
         strVal = name.toString
       }
     }
@@ -1257,7 +1257,6 @@ trait Scanners extends ScannersCommon {
     case FLOATLIT => "float literal"
     case DOUBLELIT => "double literal"
     case STRINGLIT | STRINGPART | INTERPOLATIONID => "string literal"
-    case SYMBOLLIT => "symbol literal"
     case LPAREN => "'('"
     case RPAREN => "')'"
     case LBRACE => "'{'"

--- a/src/compiler/scala/tools/nsc/ast/parser/Tokens.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Tokens.scala
@@ -15,7 +15,6 @@ package ast.parser
 
 object Tokens extends CommonTokens {
   final val STRINGPART = 7 // a part of an interpolated string
-  final val SYMBOLLIT = 8
   final val INTERPOLATIONID = 9 // the lead identifier of an interpolated string
 
   def isLiteral(code: Int) = code >= CHARLIT && code <= INTERPOLATIONID

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -213,9 +213,6 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
   def                     srBoxesRunTimeRef         : ClassBType = _srBoxesRunTimeRef.get
   private[this] lazy val _srBoxesRunTimeRef         : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[scala.runtime.BoxesRunTime]))
 
-  def                     srSymbolLiteral           : ClassBType = _srSymbolLiteral.get
-  private[this] lazy val _srSymbolLiteral           : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[scala.runtime.SymbolLiteral]))
-
   def                     srStructuralCallSite      : ClassBType = _srStructuralCallSite.get
   private[this] lazy val _srStructuralCallSite      : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[scala.runtime.StructuralCallSite]))
 

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -138,8 +138,8 @@ case class StringContext(parts: String*) {
   object sym {
     def unapplySeq(s: Symbol): Option[Seq[String]] = {
       parts match {
-        case first +: Seq() if s.name == first => Some(Seq.empty[String])
-        case _                                 => None
+        case s.name +: Seq() => Some(Seq.empty[String])
+        case _               => None
       }
     }
   }

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -139,6 +139,10 @@ case class StringContext(parts: String*) {
     def unapplySeq(s: Symbol): Option[Seq[String]] = {
       parts match {
         case s.name +: Seq() => Some(Seq.empty[String])
+        case _ +: _ +: _     => // if parts.size > 1
+          throw new IllegalArgumentException(
+            "Variable interpolation not supported, use '$$' for '$'"
+          )
         case _               => None
       }
     }

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -117,6 +117,33 @@ case class StringContext(parts: String*) {
    */
   def raw(args: Any*): String = standardInterpolator(identity, args, parts)
 
+  /** Shorthand symbol constructor.
+   *
+   *  Here's an example of usage:
+   *  {{{
+   *    val abc = List(sym"a", sym"b", sym"c")
+   *    println(syms) // List('a, 'b, 'c)
+   *  }}}
+   *  This string-based shorthand, replaces the old built-in quote syntax:
+   *  {{{
+   *    val abc = List('a, 'b, 'c) // Quoted symbol literals dropped in 2.14
+   *  }}}
+   *
+   *  @param `str` The string to be converted to a symbol.
+   */
+  def sym(args: String*): Symbol = {
+    Symbol(standardInterpolator(processEscapes, args, parts))
+  }
+
+  object sym {
+    def unapplySeq(s: Symbol): Option[Seq[String]] = {
+      parts match {
+        case first +: Seq() if s.name == first => Some(Seq.empty[String])
+        case _                                 => None
+      }
+    }
+  }
+
   /** The formatted string interpolator.
    *
    *  It inserts its arguments between corresponding parts of the string context.

--- a/src/library/scala/Symbol.scala
+++ b/src/library/scala/Symbol.scala
@@ -14,12 +14,6 @@ package scala
 
 /** This class provides a simple way to get unique objects for equal strings.
  *  Since symbols are interned, they can be compared using reference equality.
- *  Instances of `Symbol` can be created easily with Scala's built-in quote
- *  mechanism.
- *
- *  For instance, the Scala term `'mysym` will
- *  invoke the constructor of the `Symbol` class in the following way:
- *  `Symbol("mysym")`.
  *
  *  @author  Martin Odersky, Iulian Dragos
  *  @since   1.7

--- a/test/files/jvm/manifests-new.scala
+++ b/test/files/jvm/manifests-new.scala
@@ -16,14 +16,14 @@ object Test1 extends TestUtil {
   print('a')
   print(1)
   print("abc")
-  print('abc)
+  print(sym"abc")
   println()
 
   print(List(()))
   print(List(true))
   print(List(1))
   print(List("abc"))
-  print(List('abc))
+  print(List(sym"abc"))
   println()
 
   //print(Array(()))  //Illegal class name "[V" in class file Test$
@@ -31,14 +31,14 @@ object Test1 extends TestUtil {
   print(Array('a'))
   print(Array(1))
   print(Array("abc"))
-  print(Array('abc))
+  print(Array(sym"abc"))
   println()
 
   print(((), ()))
   print((true, false))
   print((1, 2))
   print(("abc", "xyz"))
-  print(('abc, 'xyz))
+  print((sym"abc", sym"xyz"))
   println()
 
   print(Test)
@@ -62,12 +62,12 @@ object Test2 {
   println("true="+load[Boolean](dump(true)))
   println("a="+load[Char](dump('a')))
   println("1="+load[Int](dump(1)))
-  println("'abc="+load[scala.Symbol](dump('abc)))
+  println("'abc="+load[scala.Symbol](dump(sym"abc")))
   println()
 
   println("List(())="+load[List[Unit]](dump(List(()))))
   println("List(true)="+load[List[Boolean]](dump(List(true))))
-  println("List('abc)="+load[List[scala.Symbol]](dump(List('abc))))
+  println("List('abc)="+load[List[scala.Symbol]](dump(List(sym"abc"))))
   println()
 
   def loadArray[T](x: Array[Byte])(implicit t: reflect.ClassTag[Array[T]]) =

--- a/test/files/jvm/manifests-old.scala
+++ b/test/files/jvm/manifests-old.scala
@@ -14,14 +14,14 @@ object Test1 extends TestUtil {
   print('a')
   print(1)
   print("abc")
-  print('abc)
+  print(sym"abc")
   println()
 
   print(List(()))
   print(List(true))
   print(List(1))
   print(List("abc"))
-  print(List('abc))
+  print(List(sym"abc"))
   println()
 
   //print(Array(()))  //Illegal class name "[V" in class file Test$
@@ -29,14 +29,14 @@ object Test1 extends TestUtil {
   print(Array('a'))
   print(Array(1))
   print(Array("abc"))
-  print(Array('abc))
+  print(Array(sym"abc"))
   println()
 
   print(((), ()))
   print((true, false))
   print((1, 2))
   print(("abc", "xyz"))
-  print(('abc, 'xyz))
+  print((sym"abc", sym"xyz"))
   println()
 
   // Disabled: should these work? changing the inference for objects from
@@ -62,12 +62,12 @@ object Test2 {
   println("true="+load[Boolean](dump(true)))
   println("a="+load[Char](dump('a')))
   println("1="+load[Int](dump(1)))
-  println("'abc="+load[Symbol](dump('abc)))
+  println("'abc="+load[Symbol](dump(sym"abc")))
   println()
 
   println("List(())="+load[List[Unit]](dump(List(()))))
   println("List(true)="+load[List[Boolean]](dump(List(true))))
-  println("List('abc)="+load[List[Symbol]](dump(List('abc))))
+  println("List('abc)="+load[List[Symbol]](dump(List(sym"abc"))))
   println()
 
   def loadArray[T](x: Array[Byte])(implicit m: reflect.Manifest[Array[T]]) =

--- a/test/files/jvm/serialization-new.scala
+++ b/test/files/jvm/serialization-new.scala
@@ -150,7 +150,7 @@ object Test1_scala {
     check(r1, _r1)
 */
     // Symbol
-    val s1 = 'hello
+    val s1 = sym"hello"
     val _s1: Symbol = read(write(s1))
     println("s1 = " + s1)
     println("_s1 = " + _s1)
@@ -262,7 +262,7 @@ object Test2_immutable {
     check(ts1, _ts1)
 
     // Vector
-    val v1 = Vector('a, 'b, 'c)
+    val v1 = Vector(sym"a", sym"b", sym"c")
     val _v1: Vector[Symbol] = read(write(v1))
     check(v1, _v1)
   }

--- a/test/files/jvm/serialization.scala
+++ b/test/files/jvm/serialization.scala
@@ -150,7 +150,7 @@ object Test1_scala {
     check(r1, _r1)
 */
     // Symbol
-    val s1 = 'hello
+    val s1 = sym"hello"
     val _s1: Symbol = read(write(s1))
     println("s1 = " + s1)
     println("_s1 = " + _s1)
@@ -262,7 +262,7 @@ object Test2_immutable {
     check(ts1, _ts1)
 
     // Vector
-    val v1 = Vector('a, 'b, 'c)
+    val v1 = Vector(sym"a", sym"b", sym"c")
     val _v1: Vector[Symbol] = read(write(v1))
     check(v1, _v1)
   }

--- a/test/files/neg/checksensible.check
+++ b/test/files/neg/checksensible.check
@@ -78,7 +78,7 @@ checksensible.scala:53: warning: comparing values of types Int and Unit using `!
   (1 != println)
      ^
 checksensible.scala:54: warning: comparing values of types Int and Symbol using `!=' will always yield true
-  (1 != 'sym)
+  (1 != sym"sym")
      ^
 checksensible.scala:60: warning: comparing a fresh object using `==' will always yield false
   ((x: Int) => x + 1) == null

--- a/test/files/neg/checksensible.scala
+++ b/test/files/neg/checksensible.scala
@@ -51,7 +51,7 @@ class EqEqValTest {
   (scala.runtime.BoxedUnit.UNIT: java.io.Serializable) != () // shouldn't warn
 
   (1 != println)
-  (1 != 'sym)
+  (1 != sym"sym")
 }
 
 // 12 warnings

--- a/test/files/neg/names-defaults-neg.scala
+++ b/test/files/neg/names-defaults-neg.scala
@@ -100,9 +100,9 @@ object Test extends App {
   deprNam5(deprNam5Arg = null)
 
   // deprecated deprecatatedName constructors
-  def deprNam6(@deprecatedName('foo) deprNam6Arg: String) = 0
+  def deprNam6(@deprecatedName("foo") deprNam6Arg: String) = 0
   deprNam6(foo = null)
-  def deprNam7(@deprecatedName('bar, "2.12.0") deprNam7Arg: String) = 0
+  def deprNam7(@deprecatedName("bar", "2.12.0") deprNam7Arg: String) = 0
   deprNam7(bar = null)
 
   // t3818

--- a/test/files/neg/t7872b.check
+++ b/test/files/neg/t7872b.check
@@ -1,5 +1,5 @@
 t7872b.scala:8: error: contravariant type a occurs in covariant position in type [-a]List[a] of type l
-  def oops1 = down[({type l[-a] = List[a]})#l](List('whatever: Object)).head + "oops"
+  def oops1 = down[({type l[-a] = List[a]})#l](List(sym"whatever": Object)).head + "oops"
                           ^
 t7872b.scala:19: error: covariant type a occurs in contravariant position in type [+a]coinv.Stringer[a] of type l
   def oops2 = up[({type l[+a] = Stringer[a]})#l]("printed: " + _)

--- a/test/files/neg/t7872b.scala
+++ b/test/files/neg/t7872b.scala
@@ -5,7 +5,7 @@ object coinv {
   up(List("hi"))
  
   // should not compile; `l' is unsound
-  def oops1 = down[({type l[-a] = List[a]})#l](List('whatever: Object)).head + "oops"
+  def oops1 = down[({type l[-a] = List[a]})#l](List(sym"whatever": Object)).head + "oops"
   // scala> oops1
   // java.lang.ClassCastException: scala.Symbol cannot be cast to java.lang.String
   //         at com.nocandysw.coinv$.oops1(coinv.scala:12)

--- a/test/files/neg/t7872c.check
+++ b/test/files/neg/t7872c.check
@@ -1,11 +1,11 @@
 t7872c.scala:7: error: inferred kinds of the type arguments (List) do not conform to the expected kinds of the type parameters (type F).
 List's type parameters do not match type F's expected parameters:
 type A is covariant, but type _ is declared contravariant
-  down(List('whatever: Object))
+  down(List(sym"whatever": Object))
   ^
 t7872c.scala:7: error: type mismatch;
  found   : List[Object]
  required: F[Object]
-  down(List('whatever: Object))
+  down(List(sym"whatever": Object))
            ^
 two errors found

--- a/test/files/neg/t7872c.scala
+++ b/test/files/neg/t7872c.scala
@@ -4,5 +4,5 @@ object coinv {
  
   up(List("hi"))
   // [error] type A is covariant, but type _ is declared contravariant
-  down(List('whatever: Object))
+  down(List(sym"whatever": Object))
 }

--- a/test/files/pos/t389.scala
+++ b/test/files/pos/t389.scala
@@ -1,7 +1,7 @@
 object Test {
-  def a = 'a
-  def b = 'B
-  def c = '+
+  def a = sym"a"
+  def b = sym"B"
+  def c = sym"+"
   //def d = '`\n` //error: unclosed character literal
-  def e = '\u0041
+  def e = sym"\u0041"
 }

--- a/test/files/pos/t4812.scala
+++ b/test/files/pos/t4812.scala
@@ -1,4 +1,4 @@
 trait Test1 {
-  def m1(sym: Symbol = 'TestSym): Unit
+  def m1(sym: Symbol = sym"TestSym"): Unit
   def m2(s: String = "TestString"): Unit
 }

--- a/test/files/pos/t8664.scala
+++ b/test/files/pos/t8664.scala
@@ -1,4 +1,4 @@
 object Test extends App {
   Ordering[Symbol]
-  Seq('b, 'c, 'a).sorted
+  Seq(sym"b", sym"c", sym"a").sorted
 }

--- a/test/files/run/SymbolsTest.scala
+++ b/test/files/run/SymbolsTest.scala
@@ -2,46 +2,46 @@
 import scala.language.reflectiveCalls
 
 class Slazz {
-  val s1 = 'myFirstSymbol
-  val s2 = 'mySecondSymbol
-  def s3 = 'myThirdSymbol
+  val s1 = sym"myFirstSymbol"
+  val s2 = sym"mySecondSymbol"
+  def s3 = sym"myThirdSymbol"
   var s4: Symbol = null
 
-  s4 = 'myFourthSymbol
+  s4 = sym"myFourthSymbol"
 }
 
 class Base {
-  val basesymbol = 'symbase
+  val basesymbol = sym"symbase"
 }
 
 class Sub extends Base {
-  val subsymbol = 'symsub
+  val subsymbol = sym"symsub"
 }
 
 trait Signs {
-  val ind = 'indication
-  val trace = 'trace
+  val ind = sym"indication"
+  val trace = sym"trace"
 }
 
 trait Lazy1 {
   lazy val v1 = "lazy v1"
-  lazy val s1 = 'lazySymbol1
+  lazy val s1 = sym"lazySymbol1"
 }
 
 trait Lazy2 {
   lazy val v2 = "lazy v2"
-  lazy val s2 = 'lazySymbol2
+  lazy val s2 = sym"lazySymbol2"
 }
 
 trait Lazy3 {
   lazy val v3 = "lazy v3"
-  lazy val s3 = 'lazySymbol3
+  lazy val s3 = sym"lazySymbol3"
 }
 
 object SingletonOfLazyness {
-  lazy val lazysym = 'lazySymbol
-  lazy val another = 'another
-  lazy val lastone = 'lastone
+  lazy val lazysym = sym"lazySymbol"
+  lazy val another = sym"another"
+  lazy val lastone = sym"lastone"
 }
 
 /*
@@ -49,18 +49,18 @@ object SingletonOfLazyness {
  */
 object Test {
   class Inner {
-    val simba = 'smba
+    val simba = sym"smba"
     var mfs: Symbol = null
     mfs = Symbol("mfsa")
   }
 
   object InnerObject {
-    val o1 = 'aaa
-    val o2 = 'ddd
+    val o1 = sym"aaa"
+    val o2 = sym"ddd"
   }
 
-  def aSymbol = 'myFirstSymbol
-  val anotherSymbol = 'mySecondSymbol
+  def aSymbol = sym"myFirstSymbol"
+  val anotherSymbol = sym"mySecondSymbol"
 
   def main(args: Array[String]): Unit = {
     testLiterals
@@ -81,7 +81,7 @@ object Test {
     val scl = new Slazz
     assert(scl.s1 == aSymbol)
     assert(scl.s2 == anotherSymbol)
-    assert(scl.s3 == 'myThirdSymbol)
+    assert(scl.s3 == sym"myThirdSymbol")
     assert(scl.s4 == Symbol.apply("myFourthSymbol"))
     assert(scl.s1 == Symbol("myFirstSymbol"))
   }
@@ -92,59 +92,59 @@ object Test {
 
   def testInnerClasses: Unit = {
     val innerPower = new Inner
-    assert(innerPower.simba == 'smba)
-    assert(innerPower.mfs == 'mfsa)
+    assert(innerPower.simba == sym"smba")
+    assert(innerPower.mfs == sym"mfsa")
   }
 
   def testInnerObjects: Unit = {
-    assert(InnerObject.o1 == 'aaa)
-    assert(InnerObject.o2 == 'ddd)
+    assert(InnerObject.o1 == sym"aaa")
+    assert(InnerObject.o2 == sym"ddd")
   }
 
   def testWithHashMaps: Unit = {
     val map = new collection.mutable.HashMap[Symbol, Symbol]
-    map.put(InnerObject.o1, 'smba)
-    map.put(InnerObject.o2, 'mfsa)
+    map.put(InnerObject.o1, sym"smba")
+    map.put(InnerObject.o2, sym"mfsa")
     map.put(Symbol("WeirdKey" + 1), Symbol("Weird" + "Val" + 1))
-    assert(map('aaa) == 'smba)
-    assert(map('ddd) == 'mfsa)
-    assert(map('WeirdKey1) == Symbol("WeirdVal1"))
+    assert(map(sym"aaa") == sym"smba")
+    assert(map(sym"ddd") == sym"mfsa")
+    assert(map(sym"WeirdKey1") == Symbol("WeirdVal1"))
 
     map.clear
     for (i <- 0 until 100) map.put(Symbol("symKey" + i), Symbol("symVal" + i))
     assert(map(Symbol("symKey15")) == Symbol("symVal15"))
-    assert(map('symKey22) == 'symVal22)
-    assert(map('symKey73) == 'symVal73)
-    assert(map('symKey56) == 'symVal56)
-    assert(map('symKey91) == 'symVal91)
+    assert(map(sym"symKey22") == sym"symVal22")
+    assert(map(sym"symKey73") == sym"symVal73")
+    assert(map(sym"symKey56") == sym"symVal56")
+    assert(map(sym"symKey91") == sym"symVal91")
   }
 
   def testLists: Unit = {
     var lst: List[Symbol] = Nil
     for (i <- 0 until 100) lst ::= Symbol("lsym" + (99 - i))
-    assert(lst(0) == 'lsym0)
-    assert(lst(10) == 'lsym10)
-    assert(lst(30) == 'lsym30)
-    assert(lst(40) == 'lsym40)
-    assert(lst(65) == 'lsym65)
-    assert(lst(90) == 'lsym90)
+    assert(lst(0) == sym"lsym0")
+    assert(lst(10) == sym"lsym10")
+    assert(lst(30) == sym"lsym30")
+    assert(lst(40) == sym"lsym40")
+    assert(lst(65) == sym"lsym65")
+    assert(lst(90) == sym"lsym90")
   }
 
   def testAnonymous: Unit = { // TODO complaints classdef can't be found for some reason, runs fine in my case
     // val anon = () => {
-    //   val simba = 'smba
+    //   val simba = sym"smba"
     //   simba
     // }
     // val an2 = () => {
     //   object nested {
-    //     val m = 'mfsa
+    //     val m = sym"mfsa"
     //   }
     //   nested.m
     // }
     // val an3 = () => {
     //   object nested {
     //     val f = () => {
-    //       'layered
+    //       sym"layered"
     //     }
     //     def gets = f()
     //   }
@@ -153,91 +153,91 @@ object Test {
     // val inner = new Inner
     // assert(anon() == inner.simba)
     // assert(anon().toString == "'smba")
-    // assert(an2() == 'mfsa)
+    // assert(an2() == sym"mfsa")
     // assert(an3() == Symbol("layered" + ""))
   }
 
   def testNestedObject: Unit = {
     object nested {
-      def sign = 'sign
-      def insignia = 'insignia
+      def sign = sym"sign"
+      def insignia = sym"insignia"
     }
-    assert(nested.sign == 'sign)
-    assert(nested.insignia == 'insignia)
-    assert(('insignia).toString == "'insignia")
+    assert(nested.sign == sym"sign")
+    assert(nested.insignia == sym"insignia")
+    assert((sym"insignia").toString == "'insignia")
   }
 
   def testInheritance: Unit = {
     val base = new Base
     val sub = new Sub
-    assert(base.basesymbol == 'symbase)
-    assert(sub.subsymbol == 'symsub)
-    assert(sub.basesymbol == 'symbase)
+    assert(base.basesymbol == sym"symbase")
+    assert(sub.subsymbol == sym"symsub")
+    assert(sub.basesymbol == sym"symbase")
 
     val anon = new Sub {
-      def subsubsymbol = 'symsubsub
+      def subsubsymbol = sym"symsubsub"
     }
-    assert(anon.subsubsymbol == 'symsubsub)
-    assert(anon.subsymbol == 'symsub)
-    assert(anon.basesymbol == 'symbase)
+    assert(anon.subsubsymbol == sym"symsubsub")
+    assert(anon.subsymbol == sym"symsub")
+    assert(anon.basesymbol == sym"symbase")
 
     object nested extends Sub {
-      def objsymbol = 'symobj
+      def objsymbol = sym"symobj"
     }
-    assert(nested.objsymbol == 'symobj)
-    assert(nested.subsymbol == 'symsub)
-    assert(nested.basesymbol == 'symbase)
-    assert(('symbase).toString == "'symbase")
+    assert(nested.objsymbol == sym"symobj")
+    assert(nested.subsymbol == sym"symsub")
+    assert(nested.basesymbol == sym"symbase")
+    assert((sym"symbase").toString == "'symbase")
   }
 
   def testTraits: Unit = {
     val fromTrait = new AnyRef with Signs {
-      def traitsymbol = 'traitSymbol
+      def traitsymbol = sym"traitSymbol"
     }
 
-    assert(fromTrait.traitsymbol == 'traitSymbol)
-    assert(fromTrait.ind == 'indication)
-    assert(fromTrait.trace == 'trace)
-    assert(('trace).toString == "'trace")
+    assert(fromTrait.traitsymbol == sym"traitSymbol")
+    assert(fromTrait.ind == sym"indication")
+    assert(fromTrait.trace == sym"trace")
+    assert((sym"trace").toString == "'trace")
 
     trait Compl {
-      val s1 = 's1
-      def s2 = 's2
+      val s1 = sym"s1"
+      def s2 = sym"s2"
       object inner {
-        val s3 = 's3
-        val s4 = 's4
+        val s3 = sym"s3"
+        val s4 = sym"s4"
       }
     }
 
     val compl = new Sub with Signs with Compl
-    assert(compl.s1 == 's1)
-    assert(compl.s2 == 's2)
-    assert(compl.inner.s3 == 's3)
-    assert(compl.inner.s4 == 's4)
-    assert(compl.ind == 'indication)
-    assert(compl.trace == 'trace)
-    assert(compl.subsymbol == 'symsub)
-    assert(compl.basesymbol == 'symbase)
+    assert(compl.s1 == sym"s1")
+    assert(compl.s2 == sym"s2")
+    assert(compl.inner.s3 == sym"s3")
+    assert(compl.inner.s4 == sym"s4")
+    assert(compl.ind == sym"indication")
+    assert(compl.trace == sym"trace")
+    assert(compl.subsymbol == sym"symsub")
+    assert(compl.basesymbol == sym"symbase")
 
     object Local extends Signs with Compl {
-      val s5 = 's5
-      def s6 = 's6
+      val s5 = sym"s5"
+      def s6 = sym"s6"
       object inner2 {
-        val s7 = 's7
-        def s8 = 's8
+        val s7 = sym"s7"
+        def s8 = sym"s8"
       }
     }
-    assert(Local.s5 == 's5)
-    assert(Local.s6 == 's6)
-    assert(Local.inner2.s7 == 's7)
-    assert(Local.inner2.s8 == 's8)
-    assert(Local.inner.s3 == 's3)
-    assert(Local.inner.s4 == 's4)
-    assert(Local.s1 == 's1)
-    assert(Local.s2 == 's2)
-    assert(Local.trace == 'trace)
-    assert(Local.ind == 'indication)
-    assert(('s8).toString == "'s8")
+    assert(Local.s5 == sym"s5")
+    assert(Local.s6 == sym"s6")
+    assert(Local.inner2.s7 == sym"s7")
+    assert(Local.inner2.s8 == sym"s8")
+    assert(Local.inner.s3 == sym"s3")
+    assert(Local.inner.s4 == sym"s4")
+    assert(Local.s1 == sym"s1")
+    assert(Local.s2 == sym"s2")
+    assert(Local.trace == sym"trace")
+    assert(Local.ind == sym"indication")
+    assert((sym"s8").toString == "'s8")
   }
 
   def testLazyTraits: Unit = {
@@ -250,20 +250,20 @@ object Test {
     l3.v3
     assert((l1.s1).toString == "'lazySymbol1")
     assert(l2.s2 == Symbol("lazySymbol" + 2))
-    assert(l3.s3 == 'lazySymbol3)
+    assert(l3.s3 == sym"lazySymbol3")
   }
 
   def testLazyObjects: Unit = {
-    assert(SingletonOfLazyness.lazysym == 'lazySymbol)
+    assert(SingletonOfLazyness.lazysym == sym"lazySymbol")
     assert(SingletonOfLazyness.another == Symbol("ano" + "ther"))
     assert((SingletonOfLazyness.lastone).toString == "'lastone")
 
     object nested {
-      lazy val sym1 = 'snested1
-      lazy val sym2 = 'snested2
+      lazy val sym1 = sym"snested1"
+      lazy val sym2 = sym"snested2"
     }
 
-    assert(nested.sym1 == 'snested1)
+    assert(nested.sym1 == sym"snested1")
     assert(nested.sym2 == Symbol("snested" + "2"))
   }
 

--- a/test/files/run/arrays.scala
+++ b/test/files/run/arrays.scala
@@ -206,7 +206,7 @@ object Test {
   val a2: Int     = 0;
   val a3: Null  = null;
   val a4: String  = "a-z";
-  val a5: Symbol  = 'token;
+  val a5: Symbol  = sym"token";
   val a6: HashMap = new HashMap();
   val a7: TreeMap = scala.collection.immutable.TreeMap.empty[Int, Any];
   val a8: Strings = List("a", "z");

--- a/test/files/run/fors.scala
+++ b/test/files/run/fors.scala
@@ -6,7 +6,7 @@
 
 object Test extends App {
   val xs = List(1, 2, 3)
-  val ys = List('a, 'b, 'c)
+  val ys = List(sym"a", sym"b", sym"c")
 
   def it = 0 until 10
 

--- a/test/files/run/lisp.scala
+++ b/test/files/run/lisp.scala
@@ -303,17 +303,17 @@ object LispAny extends Lisp {
   def asBoolean(x: Data): Boolean = x != 0
 
   def normalize(x: Data): Data = x match {
-    case 'and :: x :: y :: Nil =>
-      normalize('if :: x :: y :: 0 :: Nil)
-    case 'or :: x :: y :: Nil =>
-      normalize('if :: x :: 1 :: y :: Nil)
-    case 'def :: (name :: args) :: body :: expr :: Nil =>
-      normalize('def :: name :: ('lambda :: args :: body :: Nil) :: expr :: Nil)
-    case 'cond :: ('else :: expr :: Nil) :: rest =>
+    case sym"and" :: x :: y :: Nil =>
+      normalize(sym"if" :: x :: y :: 0 :: Nil)
+    case sym"or" :: x :: y :: Nil =>
+      normalize(sym"if" :: x :: 1 :: y :: Nil)
+    case sym"def" :: (name :: args) :: body :: expr :: Nil =>
+      normalize(sym"def" :: name :: (sym"lambda" :: args :: body :: Nil) :: expr :: Nil)
+    case sym"cond" :: (sym"else" :: expr :: Nil) :: rest =>
         normalize(expr);
-    case 'cond :: (test :: expr :: Nil) :: rest =>
-	normalize('if :: test :: expr :: ('cond :: rest) :: Nil)
-    case 'cond :: 'else :: expr :: Nil =>
+    case sym"cond" :: (test :: expr :: Nil) :: rest =>
+	normalize(sym"if" :: test :: expr :: (sym"cond" :: rest) :: Nil)
+    case sym"cond" :: sym"else" :: expr :: Nil =>
       normalize(expr)
     case h :: t =>
       normalize(h) :: asList(normalize(t))
@@ -342,15 +342,15 @@ object LispAny extends Lisp {
   def eval1(x: Data, env: Environment): Data = x match {
     case Symbol(name) =>
       env lookup name
-    case 'def :: Symbol(name) :: y :: z :: Nil =>
+    case sym"def" :: Symbol(name) :: y :: z :: Nil =>
       eval(z, env.extendRec(name, (env1 => eval(y, env1))))
-    case 'val :: Symbol(name) :: y :: z :: Nil =>
+    case sym"val" :: Symbol(name) :: y :: z :: Nil =>
       eval(z, env.extend(name, eval(y, env)))
-    case 'lambda :: params :: y :: Nil =>
+    case sym"lambda" :: params :: y :: Nil =>
       mkLambda(params, y, env)
-    case 'if :: c :: y :: z :: Nil =>
+    case sym"if" :: c :: y :: z :: Nil =>
       if (asBoolean(eval(c, env))) eval(y, env) else eval(z, env)
-    case 'quote :: y :: Nil =>
+    case sym"quote" :: y :: Nil =>
       y
     case y :: z =>
       apply(eval(y, env), z map (x => eval(x, env)))

--- a/test/files/run/t10646.scala
+++ b/test/files/run/t10646.scala
@@ -7,7 +7,7 @@ object Test extends App {
   it.head
   it.last
 
-  val that = Array(A("baz"), A('fff))
+  val that = Array(A("baz"), A(sym"fff"))
   that.head
   that.last
 }

--- a/test/files/run/t4560.scala
+++ b/test/files/run/t4560.scala
@@ -18,7 +18,7 @@ trait B {
 
   def y = new { def f() = println("Success 1") }
   def fail() = {
-    println('Test)
+    println(sym"Test")
     y.f()
   }
 }
@@ -35,7 +35,7 @@ trait B2 {
 
   def y = new { def f() = println("Success 2") }
   def fail() = {
-    println('Test)
+    println(sym"Test")
     y.f()
   }
 }
@@ -50,7 +50,7 @@ trait B3 {
 
   def y = new { def f() = println("Success 3") }
   def fail() = {
-    println('Test)
+    println(sym"Test")
     y.f()
   }
 }

--- a/test/files/run/t4601.scala
+++ b/test/files/run/t4601.scala
@@ -4,7 +4,7 @@ trait B {
   self: A =>
 
   def test: Unit = {
-    println('blubber)
+    println(sym"blubber")
   }
 }
 

--- a/test/files/run/t4710.check
+++ b/test/files/run/t4710.check
@@ -1,5 +1,5 @@
 
-scala> def method : String = { implicit def f(s: Symbol) = "" ; 'symbol }
+scala> def method : String = { implicit def f(s: Symbol) = "" ; sym"symbol" }
 warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 method: String
 

--- a/test/files/run/t4710.scala
+++ b/test/files/run/t4710.scala
@@ -1,6 +1,6 @@
 import scala.tools.partest.ReplTest
 
 object Test extends ReplTest {
-  def code = """def method : String = { implicit def f(s: Symbol) = "" ; 'symbol }"""
+  def code = """def method : String = { implicit def f(s: Symbol) = "" ; sym"symbol" }"""
 }
 

--- a/test/files/run/t6549.check
+++ b/test/files/run/t6549.check
@@ -2,7 +2,7 @@
 scala> case class `X"`(var xxx: Any)
 defined class X$u0022
 
-scala> val m = Map(("": Any) -> `X"`("\""), ('s: Any) -> `X"`("\""))
+scala> val m = Map(("": Any) -> `X"`("\""), (sym"s": Any) -> `X"`("\""))
 m: scala.collection.immutable.Map[Any,X"] = Map("" -> X"("), 's -> X"("))
 
 scala> m("")
@@ -17,8 +17,8 @@ mutated m("").xxx
 scala> m("").xxx = "\""
 mutated m("").xxx
 
-scala> m('s).xxx = 's
-mutated m(scala.Symbol("s")).xxx
+scala> m(sym"s").xxx = sym"s"
+mutated m(StringContext("s").sym()).xxx
 
 scala> val `"` = 0
 ": Int = 0

--- a/test/files/run/t6549.scala
+++ b/test/files/run/t6549.scala
@@ -11,12 +11,12 @@ import scala.tools.partest.ReplTest
 object Test extends ReplTest {
   def code = """
     |case class `X"`(var xxx: Any)
-    |val m = Map(("": Any) -> `X"`("\""), ('s: Any) -> `X"`("\""))
+    |val m = Map(("": Any) -> `X"`("\""), (sym"s": Any) -> `X"`("\""))
     |m("")
     |m("").xxx
     |m("").xxx = 0
     |m("").xxx = "\""
-    |m('s).xxx = 's
+    |m(sym"s").xxx = sym"s"
     |val `"` = 0
   """.stripMargin
 }

--- a/test/files/run/t6632.scala
+++ b/test/files/run/t6632.scala
@@ -1,22 +1,22 @@
 object Test extends App {
   import collection.mutable.ListBuffer
 
-  def newLB = ListBuffer('a, 'b, 'c, 'd, 'e)
+  def newLB = ListBuffer(sym"a", sym"b", sym"c", sym"d", sym"e")
 
   def iiobe[A](f: => A) =
     try { f }
     catch { case ex: IndexOutOfBoundsException => println(ex) }
 
   val lb0 = newLB
-  iiobe( lb0.insert(-1, 'x) )
+  iiobe( lb0.insert(-1, sym"x") )
 
   val lb1 = newLB
-  iiobe( lb1.insertAll(-2, Array('x, 'y, 'z)) )
+  iiobe( lb1.insertAll(-2, Array(sym"x", sym"y", sym"z")) )
 
   val lb2 = newLB
-  iiobe( lb2.update(-3, 'u) )
+  iiobe( lb2.update(-3, sym"u") )
 
   val lb3 = newLB
-  iiobe( lb3.update(-1, 'u) )
-  iiobe( lb3.update(5, 'u) )
+  iiobe( lb3.update(-1, sym"u") )
+  iiobe( lb3.update(5, sym"u") )
 }

--- a/test/files/run/t6633.scala
+++ b/test/files/run/t6633.scala
@@ -1,12 +1,12 @@
 object Test extends App {
   import collection.mutable.ListBuffer
 
-  def newLB = ListBuffer('a, 'b, 'c, 'd, 'e)
+  def newLB = ListBuffer(sym"a", sym"b", sym"c", sym"d", sym"e")
 
   val lb0 = newLB
 
   try {
-    lb0.insert(9, 'x)
+    lb0.insert(9, sym"x")
   } catch {
     case ex: IndexOutOfBoundsException => println(ex)
   }
@@ -14,7 +14,7 @@ object Test extends App {
   val lb1 = newLB
 
   try {
-    lb1.insert(9, 'x)
+    lb1.insert(9, sym"x")
   } catch {
     case ex: IndexOutOfBoundsException =>
   }

--- a/test/files/run/t6634.scala
+++ b/test/files/run/t6634.scala
@@ -1,7 +1,7 @@
 import collection.mutable.ListBuffer
 
 object Test extends App {
-  def newLB = ListBuffer('a, 'b, 'c, 'd, 'e)
+  def newLB = ListBuffer(sym"a", sym"b", sym"c", sym"d", sym"e")
 
   val lb0 = newLB
   println("Trying lb0 ...")

--- a/test/files/run/t7974.check
+++ b/test/files/run/t7974.check
@@ -1,40 +1,61 @@
 
   // access flags 0x1
   public someSymbol1()Lscala/Symbol;
-    INVOKEDYNAMIC apply()Lscala/Symbol; [
-      // handle kind 0x6 : INVOKESTATIC
-      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
-      // arguments:
-      "Symbolic1"
-    ]
+    NEW scala/StringContext
+    DUP
+    GETSTATIC scala/runtime/ScalaRunTime$.MODULE$ : Lscala/runtime/ScalaRunTime$;
+    ICONST_1
+    ANEWARRAY java/lang/String
+    DUP
+    ICONST_0
+    LDC "Symbolic1"
+    AASTORE
+    INVOKEVIRTUAL scala/runtime/ScalaRunTime$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/immutable/ArraySeq;
+    INVOKESPECIAL scala/StringContext.<init> (Lscala/collection/immutable/Seq;)V
+    GETSTATIC scala/collection/immutable/Nil$.MODULE$ : Lscala/collection/immutable/Nil$;
+    INVOKEVIRTUAL scala/StringContext.sym (Lscala/collection/immutable/Seq;)Lscala/Symbol;
     ARETURN
-    MAXSTACK = 1
+    MAXSTACK = 7
     MAXLOCALS = 1
 
 
   // access flags 0x1
   public someSymbol2()Lscala/Symbol;
-    INVOKEDYNAMIC apply()Lscala/Symbol; [
-      // handle kind 0x6 : INVOKESTATIC
-      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
-      // arguments:
-      "Symbolic2"
-    ]
+    NEW scala/StringContext
+    DUP
+    GETSTATIC scala/runtime/ScalaRunTime$.MODULE$ : Lscala/runtime/ScalaRunTime$;
+    ICONST_1
+    ANEWARRAY java/lang/String
+    DUP
+    ICONST_0
+    LDC "Symbolic2"
+    AASTORE
+    INVOKEVIRTUAL scala/runtime/ScalaRunTime$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/immutable/ArraySeq;
+    INVOKESPECIAL scala/StringContext.<init> (Lscala/collection/immutable/Seq;)V
+    GETSTATIC scala/collection/immutable/Nil$.MODULE$ : Lscala/collection/immutable/Nil$;
+    INVOKEVIRTUAL scala/StringContext.sym (Lscala/collection/immutable/Seq;)Lscala/Symbol;
     ARETURN
-    MAXSTACK = 1
+    MAXSTACK = 7
     MAXLOCALS = 1
 
 
   // access flags 0x1
   public sameSymbol1()Lscala/Symbol;
-    INVOKEDYNAMIC apply()Lscala/Symbol; [
-      // handle kind 0x6 : INVOKESTATIC
-      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
-      // arguments:
-      "Symbolic1"
-    ]
+    NEW scala/StringContext
+    DUP
+    GETSTATIC scala/runtime/ScalaRunTime$.MODULE$ : Lscala/runtime/ScalaRunTime$;
+    ICONST_1
+    ANEWARRAY java/lang/String
+    DUP
+    ICONST_0
+    LDC "Symbolic1"
+    AASTORE
+    INVOKEVIRTUAL scala/runtime/ScalaRunTime$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/immutable/ArraySeq;
+    INVOKESPECIAL scala/StringContext.<init> (Lscala/collection/immutable/Seq;)V
+    GETSTATIC scala/collection/immutable/Nil$.MODULE$ : Lscala/collection/immutable/Nil$;
+    INVOKEVIRTUAL scala/StringContext.sym (Lscala/collection/immutable/Seq;)Lscala/Symbol;
     ARETURN
-    MAXSTACK = 1
+    MAXSTACK = 7
     MAXLOCALS = 1
 
 
@@ -52,14 +73,21 @@
     ALOAD 0
     INVOKESPECIAL java/lang/Object.<init> ()V
     ALOAD 0
-    INVOKEDYNAMIC apply()Lscala/Symbol; [
-      // handle kind 0x6 : INVOKESTATIC
-      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
-      // arguments:
-      "Symbolic3"
-    ]
+    NEW scala/StringContext
+    DUP
+    GETSTATIC scala/runtime/ScalaRunTime$.MODULE$ : Lscala/runtime/ScalaRunTime$;
+    ICONST_1
+    ANEWARRAY java/lang/String
+    DUP
+    ICONST_0
+    LDC "Symbolic3"
+    AASTORE
+    INVOKEVIRTUAL scala/runtime/ScalaRunTime$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/immutable/ArraySeq;
+    INVOKESPECIAL scala/StringContext.<init> (Lscala/collection/immutable/Seq;)V
+    GETSTATIC scala/collection/immutable/Nil$.MODULE$ : Lscala/collection/immutable/Nil$;
+    INVOKEVIRTUAL scala/StringContext.sym (Lscala/collection/immutable/Seq;)Lscala/Symbol;
     PUTFIELD Symbols.someSymbol3 : Lscala/Symbol;
     RETURN
-    MAXSTACK = 2
+    MAXSTACK = 8
     MAXLOCALS = 1
 

--- a/test/files/run/t7974/Symbols.scala
+++ b/test/files/run/t7974/Symbols.scala
@@ -1,6 +1,6 @@
 class Symbols {
-  def someSymbol1 = 'Symbolic1
-  def someSymbol2 = 'Symbolic2
-  def sameSymbol1 = 'Symbolic1
-  val someSymbol3 = 'Symbolic3
+  def someSymbol1 = sym"Symbolic1"
+  def someSymbol2 = sym"Symbolic2"
+  def sameSymbol1 = sym"Symbolic1"
+  val someSymbol3 = sym"Symbolic3"
 }

--- a/test/files/run/t8933/A_1.scala
+++ b/test/files/run/t8933/A_1.scala
@@ -2,5 +2,5 @@ class MotherClass
 
 trait MixinWithSymbol {
   self: MotherClass =>
-  def symbolFromTrait: Symbol = 'traitSymbol
+  def symbolFromTrait: Symbol = sym"traitSymbol"
 }

--- a/test/files/run/t8933/Test_2.scala
+++ b/test/files/run/t8933/Test_2.scala
@@ -1,5 +1,5 @@
 class MotherClass extends MixinWithSymbol {
-  val classSymbol = 'classSymbol
+  val classSymbol = sym"classSymbol"
 }
 
 object Test {

--- a/test/files/run/t8933b/A.scala
+++ b/test/files/run/t8933b/A.scala
@@ -1,4 +1,4 @@
 trait MixinWithSymbol {
   self: MotherClass =>
-  def symbolFromTrait: Any = 'traitSymbol
+  def symbolFromTrait: Any = sym"traitSymbol"
 }

--- a/test/files/run/t8933b/Test.scala
+++ b/test/files/run/t8933b/Test.scala
@@ -1,5 +1,5 @@
 class MotherClass extends MixinWithSymbol {
-  def foo = 'sym1
+  def foo = sym"sym1"
 }
 
 object Test {

--- a/test/junit/scala/lang/stringinterpol/StringContextTest.scala
+++ b/test/junit/scala/lang/stringinterpol/StringContextTest.scala
@@ -162,7 +162,7 @@ class StringContextTest {
       f"${s}%S"     -> "SCALA",
       f"${5}"       -> "5",
       f"${i}"       -> "42",
-      f"${'foo}"    -> "'foo",
+      f"${sym"foo"}"    -> "'foo",
 
       f"${Thread.State.NEW}" -> "NEW",
 

--- a/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
+++ b/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
@@ -29,7 +29,6 @@ class SymbolsTest {
   @Test
   def symbolInterpolationTest: Unit = {
     val foo = "bar"
-    assertEquals('bar, sym"$foo")
     assertEquals("'bar", sym"$foo".toString)
   }
 

--- a/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
+++ b/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
@@ -1,0 +1,64 @@
+package scala.lang.stringinterpol
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.language.implicitConversions
+
+@RunWith(classOf[JUnit4])
+class SymbolsTest {
+
+  @Test
+  def symbolTest: Unit = {
+    assertEquals("'foo", sym"foo".toString)
+  }
+
+  @Test
+  def emptySymbolTest: Unit = {
+    assertEquals("'", sym"".toString)
+  }
+
+  @Test
+  def symbolListTest: Unit = {
+    assertEquals("List('foo, 'bar, 'baz)", List(sym"foo", sym"bar", sym"baz").toString)
+    assertEquals("List('foo, 'bar, 'baz)", (sym"foo" :: sym"bar" :: sym"baz" :: Nil).toString)
+  }
+
+  @Test
+  def symbolInterpolation: Unit = {
+    val foo = "bar"
+    assertEquals("'bar", sym"$foo".toString)
+  }
+
+  @Test
+  def symbolPatternMatch: Unit = {
+    val bar = "foo"
+    sym"foo" match {
+      case sym""              => assertTrue(false)
+      case sym"$bar"          => assertTrue(false)
+      case sym"$foo"          => assertTrue(false)
+      case sym"${foo}"        => assertTrue(false)
+      case sym"bar"           => assertTrue(false)
+      case sym"foo$bar"       => assertTrue(false)
+      case sym"foo${bar}baz"  => assertTrue(false)
+      case sym"${foo}bar$baz" => assertTrue(false)
+      case sym"foo"           => assertTrue(true )
+      case _                  => assertTrue(false)
+    }
+  }
+
+  @Test
+  def symbolDeconstruct: Unit = {
+    val sym"foo" = sym"foo"
+    val Symbol(foo) = sym"foo"
+    assertEquals("foo", foo)
+  }
+
+  @Test(expected = classOf[MatchError])
+  def symbolMatchFailure: Unit = {
+    val sym"bar" = sym"foo"
+    assertTrue(false)
+  }
+}

--- a/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
+++ b/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
@@ -36,16 +36,16 @@ class SymbolsTest {
   def symbolPatternMatch: Unit = {
     val bar = "foo"
     sym"foo" match {
-      case sym""              => assertTrue(false)
-      case sym"$bar"          => assertTrue(false)
-      case sym"$foo"          => assertTrue(false)
-      case sym"${foo}"        => assertTrue(false)
-      case sym"bar"           => assertTrue(false)
-      case sym"foo$bar"       => assertTrue(false)
-      case sym"foo${bar}baz"  => assertTrue(false)
-      case sym"${foo}bar$baz" => assertTrue(false)
-      case sym"foo"           => assertTrue(true )
-      case _                  => assertTrue(false)
+      case sym""              => fail
+      case sym"$bar"          => fail
+      case sym"$foo"          => fail
+      case sym"${foo}"        => fail
+      case sym"bar"           => fail
+      case sym"foo$bar"       => fail
+      case sym"foo${bar}baz"  => fail
+      case sym"${foo}bar$baz" => fail
+      case sym"foo"           => return
+      case _                  => fail
     }
   }
 
@@ -59,6 +59,5 @@ class SymbolsTest {
   @Test(expected = classOf[MatchError])
   def symbolMatchFailure: Unit = {
     val sym"bar" = sym"foo"
-    assertTrue(false)
   }
 }

--- a/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
+++ b/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
@@ -27,37 +27,57 @@ class SymbolsTest {
   }
 
   @Test
-  def symbolInterpolation: Unit = {
+  def symbolInterpolationTest: Unit = {
     val foo = "bar"
+    assertEquals('bar, sym"$foo")
     assertEquals("'bar", sym"$foo".toString)
   }
 
   @Test
-  def symbolPatternMatch: Unit = {
+  def patternMatchTest: Unit = {
+    val foo = "foo"
+    sym"foo" match {
+      case sym""           => fail
+      case sym"$$foo"      => fail
+      case sym"$${foo}"    => fail
+      case sym"foo$${bar}" => fail
+      case sym"foo\n"      => fail
+      case sym"foo"        => return
+      case _               => fail
+    }
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def patternMatchDollarFail: Unit = {
     val bar = "foo"
     sym"foo" match {
-      case sym""              => fail
-      case sym"$bar"          => fail
-      case sym"$foo"          => fail
-      case sym"${foo}"        => fail
-      case sym"bar"           => fail
-      case sym"foo$bar"       => fail
-      case sym"foo${bar}baz"  => fail
-      case sym"${foo}bar$baz" => fail
-      case sym"foo"           => return
-      case _                  => fail
+      // Variable interpolation not supported, use '$$' for '$'
+      case sym"$bar" =>
+    }
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def patternMatchDollarBracesFail: Unit = {
+    val bar = "foo"
+    sym"foo" match {
+      // Variable interpolation not supported, use '$$' for '$'
+      case sym"${bar}" =>
     }
   }
 
   @Test
-  def symbolDeconstruct: Unit = {
+  def deconstructTest: Unit = {
     val sym"foo" = sym"foo"
-    val Symbol(foo) = sym"foo"
-    assertEquals("foo", foo)
   }
 
   @Test(expected = classOf[MatchError])
-  def symbolMatchFailure: Unit = {
+  def deconstructFail: Unit = {
     val sym"bar" = sym"foo"
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def deconstructDollarFail: Unit = {
+    // Variable interpolation not supported, use '$$' for '$'
+    val sym"$foo" = sym"foo"
   }
 }

--- a/test/junit/scala/lang/traits/BytecodeTest.scala
+++ b/test/junit/scala/lang/traits/BytecodeTest.scala
@@ -92,18 +92,18 @@ class BytecodeTest extends BytecodeTesting {
 
     val c = noForwardersCompiler.compileClasses(code).map(c => (c.name, c)).toMap
 
-    val noForwarder = List('C1, 'C2, 'C3, 'C4, 'C10, 'C11, 'C12, 'C13, 'C16, 'C17)
+    val noForwarder = List(sym"C1", sym"C2", sym"C3", sym"C4", sym"C10", sym"C11", sym"C12", sym"C13", sym"C16", sym"C17")
     for (cn <- noForwarder) assertEquals(getMethods(c(cn.name), "f"), Nil)
 
-    checkForwarder(c, 'C5, "T3")
-    checkForwarder(c, 'C6, "T4")
-    checkForwarder(c, 'C7, "T5")
-    checkForwarder(c, 'C8, "T4")
-    checkForwarder(c, 'C9, "T5")
-    checkForwarder(c, 'C14, "T4")
-    checkForwarder(c, 'C15, "T5")
+    checkForwarder(c, sym"C5", "T3")
+    checkForwarder(c, sym"C6", "T4")
+    checkForwarder(c, sym"C7", "T5")
+    checkForwarder(c, sym"C8", "T4")
+    checkForwarder(c, sym"C9", "T5")
+    checkForwarder(c, sym"C14", "T4")
+    checkForwarder(c, sym"C15", "T5")
     assertSameSummary(getMethod(c("C18"), "f"), List(BIPUSH, IRETURN))
-    checkForwarder(c, 'C19, "T7")
+    checkForwarder(c, sym"C19", "T7")
     assertSameCode(getMethod(c("C19"), "T7$$super$f"), List(VarOp(ALOAD, 0), Invoke(INVOKESPECIAL, "C18", "f", "()I", false), Op(IRETURN)))
     assertInvoke(getMethod(c("C20"), "clone"), "T8", "clone$") // mixin forwarder
   }
@@ -148,10 +148,10 @@ class BytecodeTest extends BytecodeTesting {
       """.stripMargin
     val c = noForwardersCompiler.compileClasses(code, List(j1, j2, j3, j4)).map(c => (c.name, c)).toMap
 
-    val noForwarder = List('K1, 'K2, 'K3, 'K4, 'K5, 'K6, 'K7, 'K8, 'K9, 'K10, 'K11)
+    val noForwarder = List(sym"K1", sym"K2", sym"K3", sym"K4", sym"K5", sym"K6", sym"K7", sym"K8", sym"K9", sym"K10", sym"K11")
     for (cn <- noForwarder) assertEquals(getMethods(c(cn.name), "f"), Nil)
 
-    checkForwarder(c, 'K12, "T2")
+    checkForwarder(c, sym"K12", "T2")
   }
 
   @Test

--- a/test/junit/scala/math/OrderingTest.scala
+++ b/test/junit/scala/math/OrderingTest.scala
@@ -205,7 +205,7 @@ class OrderingTest {
   /* Test for scala/bug#8664 */
   @Test
   def testSymbolOrdering(): Unit = {
-    assertEquals(Seq('b, 'c, 'a).sorted, Seq('a, 'b, 'c))
+    assertEquals(Seq(sym"b", sym"c", sym"a").sorted, Seq(sym"a", sym"b", sym"c"))
   }
 
   @Test

--- a/test/scalacheck/scala/reflect/quasiquotes/UnliftableProps.scala
+++ b/test/scalacheck/scala/reflect/quasiquotes/UnliftableProps.scala
@@ -73,8 +73,8 @@ object UnliftableProps extends QuasiquoteProperties("unliftable") {
   }
 
   property("unlift scala.symbol") = test {
-    val q"${s: scala.Symbol}" = q"'foo"
-    assert(s.isInstanceOf[scala.Symbol] && s == 'foo)
+    val q"${s: scala.Symbol}" = q"""sym"foo""""
+    assert(s.isInstanceOf[scala.Symbol] && s == sym"foo")
   }
 
   implicit def unliftList[T: Unliftable]: Unliftable[List[T]] = Unliftable {

--- a/test/scalacheck/scala/reflect/quasiquotes/UnliftableProps.scala
+++ b/test/scalacheck/scala/reflect/quasiquotes/UnliftableProps.scala
@@ -72,11 +72,6 @@ object UnliftableProps extends QuasiquoteProperties("unliftable") {
     assert(s.isInstanceOf[String] && s == "foo")
   }
 
-  property("unlift scala.symbol") = test {
-    val q"${s: scala.Symbol}" = q"""sym"foo""""
-    assert(s.isInstanceOf[scala.Symbol] && s == sym"foo")
-  }
-
   implicit def unliftList[T: Unliftable]: Unliftable[List[T]] = Unliftable {
     case q"scala.collection.immutable.List(..$args)" if args.forall { implicitly[Unliftable[T]].unapply(_).nonEmpty } =>
       val ut = implicitly[Unliftable[T]]


### PR DESCRIPTION
This is a demonstration of dropping symbol literals to answer at least two questions:

1) What does dropping symbol literals change or break?
2) How does a new syntax fair in the test suite?

For (2), this experiment is based upon the new `sym` syntax feature branch in the pull request #7495.

Proposal to deprecate symbol literals is https://github.com/scala/scala-dev/issues/459.