### PR TITLE
Overload ++: in MapOps to return a Map

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -827,7 +827,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     (it ++ Iterator.single(Iterable.empty)).map(fromSpecific)
   }
 
-  @deprecated("Use xs ++ ys instead of ys ++: xs for xs of type Iterable", "2.13.0")
+  @deprecated("Use ++ instead of ++: for collections of type Iterable", "2.13.0")
   def ++:[B >: A](that: IterableOnce[B]): IterableCC[B] =
     (iterableFactory.from(that).asInstanceOf[Iterable[B]] ++ coll.asInstanceOf[Iterable[B]]).asInstanceOf[IterableCC[B]]
     // These casts are needed because C and CC do not have the proper constraints.

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -314,6 +314,19 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
     lazy val keysSet = keys.toSet
     fromSpecific(this.view.filterKeys(k => !keysSet.contains(k)))
   }
+
+  @deprecated("Use ++ instead of ++: for collections of type Iterable", "2.13.0")
+  def ++: [V1 >: V](that: IterableOnce[(K,V1)]): CC[K,V1] = {
+    val thatIterable: Iterable[(K, V1)] = that match {
+      case that: Iterable[(K, V1)] => that
+      case that => View.from(that)
+    }
+    mapFactory.from(new View.Concat(toIterable, thatIterable))
+  }
+
+  // explicit override for correct disambiguation with the new overload above
+  @deprecated("Use ++ instead of ++: for collections of type Iterable", "2.13.0")
+  override def ++:[B >: (K, V)](that: IterableOnce[B]): IterableCC[B] = super.++:[B](that)
 }
 
 object MapOps {

--- a/test/junit/scala/collection/MapTest.scala
+++ b/test/junit/scala/collection/MapTest.scala
@@ -37,4 +37,12 @@ class MapTest {
     assert(Map(1 -> 1, 2 -> 2).mkString("foo [", ", ", "] bar").toString ==
       "foo [1 -> 1, 2 -> 2] bar")
   }
+
+  @Test def t11188(): Unit = {
+    import scala.collection.immutable.ListMap
+    val m = ListMap(1 -> "one")
+    val mm = Map(2 -> "two") ++: m
+    assert(mm.isInstanceOf[ListMap[Int,String]])
+    assertEquals(mm.mkString("[", ", ", "]"), "[1 -> one, 2 -> two]")
+  }
 }


### PR DESCRIPTION
Picking up @exoego's work from https://github.com/scala/scala/pull/7324 after coming to the realization that an overload is indeed the best we can do.

I added a disambiguating override for the inherited method and changed
the confusing deprecation message.

Fixes https://github.com/scala/bug/issues/11188