### PR TITLE
Improve refcheck of missing method

### DIFF
--- a/test/files/neg/abstract-class-2.check
+++ b/test/files/neg/abstract-class-2.check
@@ -1,5 +1,5 @@
 abstract-class-2.scala:11: error: object creation impossible, since method f in trait S2 of type (x: P2.this.p.S1)Int is not defined
-(Note that P.this.p.S1 does not match P2.this.S1: their prefixes (i.e. enclosing instances) differ)
+(Note that P.this.p.S1 does not match P2.this.S1: their prefixes (i.e., enclosing instances) differ)
   object O2 extends S2 {
          ^
 one error found

--- a/test/files/neg/t9138.check
+++ b/test/files/neg/t9138.check
@@ -1,4 +1,5 @@
 t9138.scala:9: error: class D needs to be abstract, since method f in class C of type (t: B)(s: String)B is not defined
+(Note that String does not match Int)
 class D extends C[B] {
       ^
 t9138.scala:19: error: object creation impossible, since method foo in trait Base of type (a: String)(b: Int)Nothing is not defined
@@ -8,4 +9,8 @@ t9138.scala:29: error: class DDD needs to be abstract, since method f in class C
 (Note that T does not match Int)
 class DDD extends CCC[B] {
       ^
-three errors found
+t9138.scala:43: error: object creation impossible, since method create in trait Model of type (conditionalParams: ImplementingParamTrait)(implicit d: Double)Int is not defined
+(overriding member must declare implicit parameter list)
+object Obj extends Model[ImplementingParamTrait] {
+       ^
+four errors found

--- a/test/files/neg/t9138.scala
+++ b/test/files/neg/t9138.scala
@@ -29,3 +29,17 @@ abstract class CCC[T <: A] {
 class DDD extends CCC[B] {
   def f(b: Int, i: String) = b
 }
+
+// an additional example from the forum
+
+trait ParamTrait
+
+class ImplementingParamTrait extends ParamTrait
+
+trait Model[P <: ParamTrait] {
+  def create(conditionalParams: P)(implicit d: Double): Int
+}
+
+object Obj extends Model[ImplementingParamTrait] {
+  def create(conditionalParams: ImplementingParamTrait)(d: Double): Int = 5
+}


### PR DESCRIPTION
Improve type comparison and also check whether a member fails to override because of a missing implicit modifier.

Follow-up to scala/bug#9138