### PR TITLE
[11296] implement mutating VectorMapBuilder 

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -1341,6 +1341,7 @@ private[immutable] final class HashMapBuilder[K, V] extends Builder[(K, V), Hash
   import Node._
   import MapNode._
 
+
   private def newEmptyRootNode = new BitmapIndexedMapNode[K, V](0, 0, Array(), Array(), 0, 0)
 
   /** The last given out HashMap as a return value of `result()`, if any, otherwise null.
@@ -1352,6 +1353,13 @@ private[immutable] final class HashMapBuilder[K, V] extends Builder[(K, V), Hash
 
   /** The root node of the partially build hashmap */
   private var rootNode: MapNode[K, V] = newEmptyRootNode
+
+  private[immutable] def getOrElse[V0 >: V](key: K, value: V0): V0 =
+    if (rootNode.size == 0) value
+    else {
+      val originalHash = key.##
+      rootNode.getOrElse(key, originalHash, improve(originalHash), 0, value)
+    }
 
   /** Inserts element `elem` into array `as` at index `ix`, shifting right the trailing elems */
   private def insertElement(as: Array[Int], ix: Int, elem: Int): Array[Int] = {

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorMapBenchmark.scala
@@ -14,19 +14,20 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
 class VectorMapBenchmark {
-  @Param(Array("10", "100", "1000"))
+  @Param(Array("1", "10", "100", "1000", "1000000"))
   var size: Int = _
 
-  var values: Vector[Any] = _
+  var kvs: Iterable[(Int, Int)] = _
 
-  @Setup(Level.Trial) def initKeys(): Unit = {
-    values = (0 to size).map(i => (i % 4) match {
-      case 0 => i.toString
-      case 1 => i.toChar
-      case 2 => i.toDouble
-      case 3 => i.toInt
-    }).toVector
+  @Setup(Level.Trial)
+  def initKeys(): Unit = {
+    val unique = (0 to size).map(i => i -> i)
+    kvs = unique ++ unique
   }
 
-  @Benchmark def groupBy = values.groupBy(_.getClass)
+  @Benchmark
+  def builder(bh: Blackhole): Unit = {
+    val b = VectorMap.newBuilder[Int, Int]
+    bh.consume(b.addAll(kvs).result())
+  }
 }


### PR DESCRIPTION
This is a partial fix for https://github.com/scala/bug/issues/11296

## Summary:

* MapBuilderImpl and HashMapBuilder expose 
  * `def getOrElse[V0 >: V](key: K, value: V0): V0`
    * this method is used in `VectorMapBuilder`
  * `def addOne(key: K, value: V): this.type` 
    * also used in `VectorMapBuilder`
  * Both of these classes are `private[immutable]` so public api is not changed

* new `private[immutable]` VectorMapBuilder is implemented which delegates to an underlying VectorBuilder and MapBuilder, then builds the result on `result()` calls. After one result call is made, further additions to the VectorBuilder fall back to immutable updates. 

## Benchmarks

```

[info] # Run complete. Total time: 00:07:52
[info] Benchmark                       (size)  Mode  Cnt           Score           Error  Units
[info] VectorMapBenchmark.newBuilder        1  avgt   20         194.294 ±        48.158  ns/op
[info] VectorMapBenchmark.newBuilder       10  avgt   20        1310.853 ±        70.853  ns/op
[info] VectorMapBenchmark.newBuilder      100  avgt   20       17957.492 ±      3096.264  ns/op
[info] VectorMapBenchmark.newBuilder     1000  avgt   20      285058.415 ±     74489.514  ns/op
[info] VectorMapBenchmark.newBuilder  1000000  avgt   20   994031624.475 ±  35092489.752  ns/op
[info] VectorMapBenchmark.oldBuilder        1  avgt   20         508.492 ±         8.691  ns/op
[info] VectorMapBenchmark.oldBuilder       10  avgt   20        5405.426 ±      5472.874  ns/op
[info] VectorMapBenchmark.oldBuilder      100  avgt   20      419727.318 ±    378794.168  ns/op
[info] VectorMapBenchmark.oldBuilder     1000  avgt   20      560260.095 ±     50140.120  ns/op
[info] VectorMapBenchmark.oldBuilder  1000000  avgt   20  1822695595.250 ± 144192596.555  ns/op
```

### Benchmark TL;DR
Typically ~ 60% reduction in CPU time.