### PR TITLE
[11296] Implement mutating ListMapBuilder 

### DIFF
--- a/test/benchmarks/src/main/scala/scala/collection/immutable/ListMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/ListMapBenchmark.scala
@@ -1,0 +1,33 @@
+package scala.collection.immutable
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+import org.openjdk.jmh.runner.IterationType
+import benchmark._
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class ListMapBenchmark {
+  @Param(Array("1", "10", "100", "1000"))
+  var size: Int = _
+
+  var kvs: Iterable[(Int, Int)] = _
+
+  @Setup(Level.Trial)
+  def initKeys(): Unit = {
+    val unique = (0 to size).map(i => i -> i)
+    kvs = unique ++ unique
+  }
+
+  @Benchmark
+  def builder(bh: Blackhole): Unit = {
+    val b = new ListMapBuilder[Int, Int]
+    bh.consume(b.addAll(kvs).result())
+  }
+}


### PR DESCRIPTION
This is the second and final partial fix for scala/bug#11296

ListMaps are mutated as they are built, benchmarks below. 


## Benchmarks
```
[info] Benchmark                    (size)  Mode  Cnt         Score         Error  Units
[info] ListMapBenchmark.newBuilder       1  avgt   20        39.667 ±       3.548  ns/op
[info] ListMapBenchmark.newBuilder      10  avgt   20       687.855 ±     293.956  ns/op
[info] ListMapBenchmark.newBuilder     100  avgt   20    122789.268 ±  114902.192  ns/op
[info] ListMapBenchmark.newBuilder    1000  avgt   20   3292728.169 ±  169544.260  ns/op
[info] ListMapBenchmark.oldBuilder       1  avgt   20        78.175 ±       6.529  ns/op
[info] ListMapBenchmark.oldBuilder      10  avgt   20      3329.603 ±    1347.668  ns/op
[info] ListMapBenchmark.oldBuilder     100  avgt   20    176572.369 ±   40241.754  ns/op
[info] ListMapBenchmark.oldBuilder    1000  avgt   20  17078789.985 ± 1746390.128  ns/op
```