### PR TITLE
immutable.Set.newBuilder uses the new SetBuilderImpl

### DIFF
--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -102,10 +102,7 @@ object Set extends IterableFactory[Set] {
       case _                       => (newBuilder[E] ++= it).result()
     }
 
-  def newBuilder[A]: Builder[A, Set[A]] =
-    new ImmutableBuilder[A, Set[A]](empty) {
-      def addOne(elem: A): this.type = { elems = elems + elem; this }
-    }
+  def newBuilder[A]: Builder[A, Set[A]] = new SetBuilderImpl[A]
 
   /** An optimized representation for immutable empty sets */
   private object EmptySet extends AbstractSet[Any] {


### PR DESCRIPTION
It seems that while the SetBuilderImpl was implemented, it never got hooked up to `immutable.Set.newBuilder` 😅 