### PR TITLE
Update syntax summary to align with chapter text

### DIFF
--- a/spec/05-classes-and-objects.md
+++ b/spec/05-classes-and-objects.md
@@ -63,14 +63,15 @@ The _least proper supertype_ of a template is the class type or
 class types.
 
 The statement sequence $\mathit{stats}$ contains member definitions that
-define new members or overwrite members in the parent classes.  If the
-template forms part of an abstract class or trait definition, the
-statement part $\mathit{stats}$ may also contain declarations of abstract
-members. If the template forms part of a concrete class definition,
+define new members or override members in the parent classes.  If the
+template forms part of an abstract class or trait definition, then
+$\mathit{stats}$ may also contain declarations of abstract members.
+If the template forms part of a concrete class definition,
 $\mathit{stats}$ may still contain declarations of abstract type members, but
 not of abstract term members.  Furthermore, $\mathit{stats}$ may in any case
-also contain expressions; these are executed in the order they are
-given as part of the initialization of a template.
+also contain strictly evaluated expressions: these are executed in the order they are
+given as part of the initialization of a template, even if they appear in
+the definition of overridden members.
 
 The sequence of template statements may be prefixed with a formal
 parameter definition and an arrow, e.g. `$x$ =>`, or

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -11,8 +11,8 @@ The following descriptions of Scala tokens uses literal characters `‘c’` whe
 _Unicode escapes_ are used to represent the Unicode character with the given hexadecimal code:
 
 ```ebnf
-UnicodeEscape ::= ‘\’ ‘u’ {‘u’} hexDigit hexDigit hexDigit hexDigit
-hexDigit      ::= ‘0’ | … | ‘9’ | ‘A’ | … | ‘F’ | ‘a’ | … | ‘f’
+UnicodeEscape ::=  ‘\’ ‘u’ {‘u’} hexDigit hexDigit hexDigit hexDigit
+hexDigit      ::=  ‘0’ | … | ‘9’ | ‘A’ | … | ‘F’ | ‘a’ | … | ‘f’
 ```
 
 ## Lexical Syntax
@@ -27,18 +27,20 @@ letter           ::=  upper | lower // and Unicode categories Lo, Lt, Nl
 digit            ::=  ‘0’ | … | ‘9’
 paren            ::=  ‘(’ | ‘)’ | ‘[’ | ‘]’ | ‘{’ | ‘}’
 delim            ::=  ‘`’ | ‘'’ | ‘"’ | ‘.’ | ‘;’ | ‘,’
-opchar           ::= // printableChar not matched by (whiteSpace | upper | lower |
-                     // letter | digit | paren | delim | opchar | Unicode_Sm | Unicode_So)
-printableChar    ::= // all characters in [\u0020, \u007F] inclusive
-charEscapeSeq    ::= ‘\’ (‘b’ | ‘t’ | ‘n’ | ‘f’ | ‘r’ | ‘"’ | ‘'’ | ‘\’)
+opchar           ::=  // printableChar not matched by (whiteSpace | upper | lower |
+                      // letter | digit | paren | delim | opchar | Unicode_Sm | Unicode_So)
+printableChar    ::=  // all characters in [\u0020, \u007F] inclusive
+charEscapeSeq    ::=  ‘\’ (‘b’ | ‘t’ | ‘n’ | ‘f’ | ‘r’ | ‘"’ | ‘'’ | ‘\’)
 
 op               ::=  opchar {opchar}
 varid            ::=  lower idrest
+boundvarid       ::=  varid
+                   |  ‘`’ varid ‘`’
 plainid          ::=  upper idrest
-                 |  varid
-                 |  op
+                   |  varid
+                   |  op
 id               ::=  plainid
-                 |  ‘`’ { charNoBackQuoteOrNewline | UnicodeEscape | charEscapeSeq } ‘`’
+                   |  ‘`’ { charNoBackQuoteOrNewline | UnicodeEscape | charEscapeSeq } ‘`’
 idrest           ::=  {letter | digit} [‘_’ op]
 
 integerLiteral   ::=  (decimalNumeral | hexNumeral) [‘L’ | ‘l’]
@@ -49,9 +51,9 @@ nonZeroDigit     ::=  ‘1’ | … | ‘9’
 
 floatingPointLiteral
                  ::=  digit {digit} ‘.’ digit {digit} [exponentPart] [floatType]
-                 |  ‘.’ digit {digit} [exponentPart] [floatType]
-                 |  digit {digit} exponentPart [floatType]
-                 |  digit {digit} [exponentPart] floatType
+                   |  ‘.’ digit {digit} [exponentPart] [floatType]
+                   |  digit {digit} exponentPart [floatType]
+                   |  digit {digit} [exponentPart] floatType
 exponentPart     ::=  (‘E’ | ‘e’) [‘+’ | ‘-’] digit {digit}
 floatType        ::=  ‘F’ | ‘f’ | ‘D’ | ‘d’
 
@@ -60,25 +62,25 @@ booleanLiteral   ::=  ‘true’ | ‘false’
 characterLiteral ::=  ‘'’ (charNoQuoteOrNewline | UnicodeEscape | charEscapeSeq) ‘'’
 
 stringLiteral    ::=  ‘"’ {stringElement} ‘"’
-                 |  ‘"""’ multiLineChars ‘"""’
+                   |  ‘"""’ multiLineChars ‘"""’
 stringElement    ::=  charNoDoubleQuoteOrNewline
-                 |  UnicodeEscape
-                 |  charEscapeSeq
+                   |  UnicodeEscape
+                   |  charEscapeSeq
 multiLineChars   ::=  {[‘"’] [‘"’] charNoDoubleQuote} {‘"’}
 
 interpolatedString 
-                 ::= alphaid ‘"’ {printableChar \ (‘"’ | ‘\$’) | escape} ‘"’ 
-                 |  alphaid ‘"""’ {[‘"’] [‘"’] char \ (‘"’ | ‘\$’) | escape} {‘"’} ‘"""’
-escape           ::= ‘\$\$’ 
-                 | ‘\$’ id 
-                 | ‘\$’ BlockExpr
-alphaid          ::= upper idrest
-                 |  varid
+                 ::=  alphaid ‘"’ {printableChar \ (‘"’ | ‘\$’) | escape} ‘"’ 
+                   |  alphaid ‘"""’ {[‘"’] [‘"’] char \ (‘"’ | ‘\$’) | escape} {‘"’} ‘"""’
+escape           ::=  ‘\$\$’ 
+                   |  ‘\$’ id 
+                   |  ‘\$’ BlockExpr
+alphaid          ::=  upper idrest
+                   |  varid
 
 symbolLiteral    ::=  ‘'’ plainid
 
 comment          ::=  ‘/*’ “any sequence of characters; nested comments are allowed” ‘*/’
-                 |  ‘//’ “any sequence of characters up to end of line”
+                   |  ‘//’ “any sequence of characters up to end of line”
 
 nl               ::=  $\mathit{“new line character”}$
 semi             ::=  ‘;’ |  nl {nl}
@@ -189,10 +191,10 @@ grammar:
   Guard             ::=  ‘if’ PostfixExpr
 
   Pattern           ::=  Pattern1 { ‘|’ Pattern1 }
-  Pattern1          ::=  varid ‘:’ TypePat
+  Pattern1          ::=  boundvarid ‘:’ TypePat
                       |  ‘_’ ‘:’ TypePat
                       |  Pattern2
-  Pattern2          ::=  varid [‘@’ Pattern3]
+  Pattern2          ::=  id [‘@’ Pattern3]
                       |  Pattern3
   Pattern3          ::=  SimplePattern
                       |  SimplePattern { id [nl] SimplePattern }
@@ -201,7 +203,7 @@ grammar:
                       |  Literal
                       |  StableId
                       |  StableId ‘(’ [Patterns] ‘)’
-                      |  StableId ‘(’ [Patterns ‘,’] [varid ‘@’] ‘_’ ‘*’ ‘)’
+                      |  StableId ‘(’ [Patterns ‘,’] [id ‘@’] ‘_’ ‘*’ ‘)’
                       |  ‘(’ [Patterns] ‘)’
                       |  XmlPattern
   Patterns          ::=  Pattern [‘,’ Patterns]
@@ -296,7 +298,7 @@ grammar:
   ClassParents      ::=  Constr {‘with’ AnnotType}
   TraitParents      ::=  AnnotType {‘with’ AnnotType}
   Constr            ::=  AnnotType {ArgumentExprs}
-  EarlyDefs         ::= ‘{’ [EarlyDef {semi EarlyDef}] ‘}’ ‘with’
+  EarlyDefs         ::=  ‘{’ [EarlyDef {semi EarlyDef}] ‘}’ ‘with’
   EarlyDef          ::=  {Annotation [nl]} {Modifier} PatVarDef
 
   ConstrExpr        ::=  SelfInvocation


### PR DESCRIPTION
Follow-up to https://github.com/scala/scala/pull/4935

I guess there was going to be a tool for this, ScalaSpecFix.