### PR TITLE
adds Either.collectLefts/collectRights

### DIFF
--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -507,6 +507,34 @@ object Either {
   def cond[A, B](test: Boolean, right: => B, left: => A): Either[A, B] =
     if (test) Right(right) else Left(left)
 
+  /**
+   * Retrieves Left values for several Either values
+   *  {{{
+   *  case class Person(firstName: String, lastName: String, age: Int)
+   *
+   *  def validateAge(intValue: Int): Either[String, Int] = ??? 
+   *  def validateFirstName(stringValue: String): Either[String, String] = ???
+   *  def validateLastName(stringValue: String): Either[String, String] = ???
+   *
+   *  val errors: Seq[String] = Either.collectLefts(
+   *   validateFirstName("john"),
+   *   validateLastName("doe"),
+   *   validateAge(40)
+   *  )
+   *  if (errors.isEmpty) ???// use for comprehension here to build a Person 
+   *  else ??? // handle errors here
+   *  }}}
+   */
+  def collectLefts[A](eithers: Either[A, _]*): Seq[A] = eithers.collect { 
+    case Left(a) => a
+  }
+
+  /** Retrieves Right values for several Either values
+   */
+  def collectRights[B](eithers : Either[_, B]*) : Seq[B]=  eithers.collect {
+    case Right(b) => b
+  }
+
   /** Allows use of a `merge` method to extract values from Either instances
    *  regardless of whether they are Left or Right.
    *

--- a/test/junit/scala/util/EitherTest.scala
+++ b/test/junit/scala/util/EitherTest.scala
@@ -44,4 +44,65 @@ class EitherTest {
     assertEquals(leftSumOrRightEmpty(List(1, 2, 3)), Left(6))
     assertEquals(leftSumOrRightEmpty(Nil), Right("empty"))
   }
+
+  @Test
+  def testCollectLeftsWithNoLeft: Unit = {
+    val e1 = Right(1)
+    val e2 = Right(2)
+    val e3 = Right(3)
+
+    assertEquals(Either.collectLefts(e1,e2,e3), Nil)
+  }
+
+  @Test
+  def testCollectLeftsWithSomeLefts: Unit = {
+    val e1 = Right(1)
+    val e2 = Left("nan")
+    val e3 = Left("nan2")
+
+    assertEquals(Either.collectLefts(e1,e2,e3), Seq("nan", "nan2"))
+  }
+
+  @Test
+  def testCollectLeftsWithSomeLeftsWithMixedRightTypes: Unit = {
+    val e1 = Right(1)
+    val e2 = Right("2")
+    val e3 = Left("nan")
+
+    assertEquals(Either.collectLefts(e1, e2, e3), Seq("nan"))
+  }
+
+  @Test
+  def testCollectLeftsWithSomeLeftsWithErrorTrait: Unit = {
+    sealed trait Error
+    case class NumericError(message: String) extends Error
+    case class OtherError(message: String) extends Error
+
+    val e1 = Right(1)
+    val e2 = Left(NumericError("nan"))
+    val e3 = Left(OtherError("foo"))
+
+    val lefts: Seq[Error] = Either.collectLefts(e1,e2,e3)
+    assertEquals(lefts, Seq(NumericError("nan"), OtherError("foo")))
+  }
+
+  @Test
+  def testCollectRightsWithNoRight: Unit = {
+    val e1 = Left(1)
+    val e2 = Left(2)
+    val e3 = Left(3)
+
+    assertEquals(Either.collectRights(e1,e2,e3), Nil)
+  }
+
+  @Test
+  def testCollectRightsWithSomeRights: Unit = {
+    val e0 = Left("nan")
+    val e1 = Right(1)
+    val e2 = Right(2)
+    val e3 = Left("nan bis")
+    val e4 = Right(3)
+
+    assertEquals(Either.collectRights(e0, e1, e2, e3, e4), Seq(1, 2, 3))
+  }  
 }


### PR DESCRIPTION
New version of the PR #7512 after rebasing the code, as discussed with @julienrf 

This small util methods would allow to use Either for multiple values validation, to avoid for comprehension fail-fast behavior and accumulate errors (without relying on more complex things like cats Validated).
It's easy to implement by hand but I believe this kind of thing is often used and boring to copy/paste each time, so I think it would be nice to have it in std lib :)

Usual use case would be :

```scala
case class Person(firstName: String, lastName: String, age: Int)

sealed trait Error
case class NumericError(message: String) extends Error
case class OtherError(message: String) extends Error

def validateAge(intValue: Int): Either[NumericError, Int] = ??? 
def validateFirstName(stringValue: String): Either[OtherError, String] = ???
def validateLastName(stringValue: String): Either[OtherError, String] = ???

val errors: Seq[Error] = Either.collectLefts(
  validateFirstName("john"),
  validateLastName("doe"),
  validateAge(40)
)

if (errors.isEmpty) ???// use for comprehension here to build a Person 
else ??? // handle errors here
```

`collectRights` symmetric method is provided for convenience.