### PR TITLE
Revert BigDecimal MathContext handling changes

### DIFF
--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -484,11 +484,11 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
 
   /** Addition of BigDecimals
    */
-  def +  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.add(that.bigDecimal, mc), mc)
+  def +  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal add that.bigDecimal, mc)
 
   /** Subtraction of BigDecimals
    */
-  def -  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.subtract(that.bigDecimal, mc), mc)
+  def -  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal subtract that.bigDecimal, mc)
 
   /** Multiplication of BigDecimals
    */
@@ -502,14 +502,14 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    *  divideToIntegralValue and the remainder.  The computation is exact: no rounding is applied.
    */
   def /% (that: BigDecimal): (BigDecimal, BigDecimal) = {
-    val qr = this.bigDecimal.divideAndRemainder(that.bigDecimal, mc)
+    val qr = this.bigDecimal.divideAndRemainder(that.bigDecimal)
     (new BigDecimal(qr(0), mc), new BigDecimal(qr(1), mc))
   }
 
   /** Divide to Integral value.
    */
   def quot (that: BigDecimal): BigDecimal =
-    new BigDecimal(this.bigDecimal.divideToIntegralValue(that.bigDecimal, mc), mc)
+    new BigDecimal(this.bigDecimal divideToIntegralValue that.bigDecimal, mc)
 
   /** Returns the minimum of this and that, or this if the two are equal
    */
@@ -527,11 +527,11 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
 
   /** Remainder after dividing this by that.
    */
-  def remainder (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.remainder(that.bigDecimal, mc), mc)
+  def remainder (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal remainder that.bigDecimal, mc)
 
   /** Remainder after dividing this by that.
    */
-  def % (that: BigDecimal): BigDecimal = this.remainder(that)
+  def % (that: BigDecimal): BigDecimal = this remainder that
 
   /** Returns a BigDecimal whose value is this ** n.
    */
@@ -539,7 +539,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
 
   /** Returns a BigDecimal whose value is the negation of this BigDecimal
    */
-  def unary_- : BigDecimal = new BigDecimal(this.bigDecimal.negate(mc), mc)
+  def unary_- : BigDecimal = new BigDecimal(this.bigDecimal.negate(), mc)
 
   /** Returns the absolute value of this BigDecimal
    */

--- a/test/junit/scala/collection/immutable/RangeTest.scala
+++ b/test/junit/scala/collection/immutable/RangeTest.scala
@@ -89,4 +89,9 @@ class RangeTest {
     assertEquals(20, (20 to 1 by -1).min(Ordering.Int.reverse))
     assertEquals(1, (20 to 1 by -1).max(Ordering.Int.reverse))
   }
+
+  @Test
+  def t11152: Unit = {
+    assertEquals(11, (BigDecimal(1) to BigDecimal(s"1.${"0" * 32}1") by BigDecimal(s"0.${"0" * 33}1")).toList.length)
+  }
 }

--- a/test/junit/scala/math/BigDecimalTest.scala
+++ b/test/junit/scala/math/BigDecimalTest.scala
@@ -4,7 +4,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
 import java.math.{BigDecimal => BD, MathContext => MC}
-import java.util.Formatter.BigDecimalLayoutForm
 
 /* Tests various maps by making sure they all agree on the same answers. */
 @RunWith(classOf[JUnit4])
@@ -258,29 +257,6 @@ class BigDecimalTest {
 
     testPrecision()
     testRounded()
-  }
-
-  // Motivated by scala/bug#10882: Operators for BigDecimal don't use value of mc (MathContext)
-  @Test
-  def testUsesMathContextInOperators(): Unit = {
-    def isAE[A](a: => A): Boolean = try { a; false } catch { case e: ArithmeticException => true }
-
-    val bd128 = BigDecimal("4.2e1000", MC.DECIMAL128)
-    assert(bd128 + 10 == bd128)
-    assert(bd128 - 10 == bd128)
-    assert(bd128 + BigDecimal("1e100", MC.UNLIMITED) == bd128)
-    assert(bd128 - BigDecimal("1e100", MC.UNLIMITED) == bd128)
-    assert(bd128.quot(BigDecimal("1e100", MC.UNLIMITED)) == BigDecimal("4.2e900", MC.DECIMAL128))
-    assert(isAE(bd128.quot(BigDecimal("1e100", MC.UNLIMITED) + 1)))
-    assert(isAE(bd128 % (BigDecimal("1e100", MC.UNLIMITED) + 1)))
-    assert(isAE(bd128 /% (BigDecimal("1e100", MC.UNLIMITED) + 1)))
-
-    val bdUnlimited = BigDecimal("4.2e1000", MC.UNLIMITED)
-    assert(bdUnlimited + 10 > bdUnlimited)
-    assert(bdUnlimited - 10 < bdUnlimited)
-    assert(bdUnlimited + BigDecimal("1e100", MC.DECIMAL128) > bdUnlimited)
-    assert(bdUnlimited - BigDecimal("1e100", MC.DECIMAL128) < bdUnlimited)
-    assert(bdUnlimited.quot(BigDecimal("1e100", MC.DECIMAL128)) == BigDecimal("4.2e900", MC.UNLIMITED))
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11152, supersedes https://github.com/scala/scala/pull/7236,
reverts https://github.com/scala/scala/pull/6884 ...and repeats https://github.com/scala/scala/commit/3a1332c451c8bd9b987ab3dbe775ef5a08360705