### PR TITLE
Make some alias methods final now that starr includes a fix for 10853

### DIFF
--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -188,11 +188,9 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   /** Alias for `appendedAll` */
   @`inline` final def :++ [B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
 
-  // Make `concat` an alias for `appendedAll` so that it benefits from performance
-  // overrides of this method
-  // TODO https://github.com/scala/bug/issues/10853 Uncomment final
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  @`inline` /*final*/ override def concat[B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
+  // Make `concat` an alias for `appendedAll` so that it benefits from performance overrides of this
+  // method. Cannot be `@inline final` because it's overridden in StrictOptimizedSeqOps.
+  override def concat[B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
 
  /** Produces a new sequence which contains all elements of this $coll and also all elements of
    *  a given sequence. `xs union ys`  is equivalent to `xs ++ ys`.

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -64,8 +64,7 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     *  @param elem the element to test for membership.
     *  @return  `true` if `elem` is contained in this set, `false` otherwise.
     */
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /*@`inline` final*/ def apply(elem: A): Boolean = this.contains(elem)
+  @`inline` final def apply(elem: A): Boolean = this.contains(elem)
 
   /** Tests whether this set is a subset of another set.
     *

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -74,8 +74,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   def removed(key: K): C
 
   /** Alias for `remove` */
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /*@`inline` final*/ def - (key: K): C = removed(key)
+  @`inline` final def - (key: K): C = removed(key)
 
   @deprecated("Use -- with an explicit collection", "2.13.0")
   def - (key1: K, key2: K, keys: K*): C = removed(key1).removed(key2).removedAll(keys)
@@ -90,8 +89,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   def removedAll(keys: IterableOnce[K]): C = keys.iterator.foldLeft[C](coll)(_ - _)
 
   /** Alias for `removeAll` */
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /* @`inline` final */ override def -- (keys: IterableOnce[K]): C = removedAll(keys)
+  @`inline` final override def -- (keys: IterableOnce[K]): C = removedAll(keys)
 
   /** Creates a new map obtained by updating this map with a given key/value pair.
     *  @param    key the key

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -44,8 +44,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   def incl(elem: A): C
 
   /** Alias for `incl` */
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  override /*final*/ def + (elem: A): C = incl(elem) // like in collection.Set but not deprecated
+  override final def + (elem: A): C = incl(elem) // like in collection.Set but not deprecated
 
   /** Creates a new set with a given element removed from this set.
     *
@@ -56,8 +55,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   def excl(elem: A): C
 
   /** Alias for `excl` */
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /*@`inline` final*/ override def - (elem: A): C = excl(elem)
+  @`inline` final override def - (elem: A): C = excl(elem)
 
   override def concat(that: collection.IterableOnce[A]): C = {
     var result: C = coll
@@ -78,8 +76,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   def removedAll(that: IterableOnce[A]): C = that.iterator.foldLeft[C](coll)(_ - _)
 
   /** Alias for removeAll */
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  override /*final*/ def -- (that: IterableOnce[A]): C = removedAll(that)
+  override final def -- (that: IterableOnce[A]): C = removedAll(that)
 }
 
 /**

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -74,12 +74,10 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
   def result(): C = coll
 
   @deprecated("Use - or remove on an immutable Map", "2.13.0")
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /*final*/ def - (key: K): C = clone() -= key
+  final def - (key: K): C = clone() -= key
 
   @deprecated("Use -- or removeAll on an immutable Map", "2.13.0")
-  @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
-  /*final*/ def - (key1: K, key2: K, keys: K*): C = clone() -= key1 -= key2 --= keys
+  final def - (key1: K, key2: K, keys: K*): C = clone() -= key1 -= key2 --= keys
 
   /** Adds a new key/value pair to this map and optionally returns previously bound value.
     *  If the map already contains a


### PR DESCRIPTION
scala/bug#10853 caused unnecessary bridge methods, which sometimes were
overriding final members. To work around this in the library, certain
methods were not marked final. Now that we're running with a starr
that include a fix, we can make those methods final.