### PR TITLE
mutable and immutable HashMaps and HashSets cooperate in addAll/subtractAll/concat/removedAll by sharing hashcodes

### DIFF
--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -94,6 +94,13 @@ final class HashSet[A] private[immutable] (val rootNode: SetNode[A])
 
   override def foreach[U](f: A => U): Unit = rootNode.foreach(f)
 
+  /** Applies a function f to each element, and its corresponding **original** hash, in this Set */
+  @`inline` private[collection] def foreachWithHash(f: (A, Int) => Unit): Unit = rootNode.foreachWithHash(f)
+
+  /** Applies a function f to each element, and its corresponding **original** hash, in this Set
+    * Stops iterating the first time that f returns `false`.*/
+  @`inline` private[collection] def foreachWithHashWhile(f: (A, Int) => Boolean): Unit = rootNode.foreachWithHashWhile(f)
+
   def subsetOf(that: Set[A]): Boolean = if (that.isEmpty) true else that match {
     case set: HashSet[A] => rootNode.subsetOf(set.rootNode, 0)
     case _ => super.subsetOf(that)
@@ -286,6 +293,9 @@ private[immutable] sealed abstract class SetNode[A] extends Node[SetNode[A]] {
 
   def concat(that: SetNode[A], shift: Int): SetNode[A]
 
+  def foreachWithHash(f: (A, Int) => Unit): Unit
+
+  def foreachWithHashWhile(f: (A, Int) => Boolean): Boolean
 }
 
 private final class BitmapIndexedSetNode[A](
@@ -589,14 +599,16 @@ private final class BitmapIndexedSetNode[A](
   }
 
   def foreach[U](f: A => U): Unit = {
+    val thisPayloadArity = payloadArity
     var i = 0
-    while (i < payloadArity) {
+    while (i < thisPayloadArity) {
       f(getPayload(i))
       i += 1
     }
 
+    val thisNodeArity = nodeArity
     var j = 0
-    while (j < nodeArity) {
+    while (j < thisNodeArity) {
       getNode(j).foreach(f)
       j += 1
     }
@@ -1276,6 +1288,40 @@ private final class BitmapIndexedSetNode[A](
       // should never happen -- hash collisions are never at the same level as bitmapIndexedSetNodes
       throw new UnsupportedOperationException("Cannot concatenate a HashCollisionSetNode with a BitmapIndexedSetNode")
   }
+
+  override def foreachWithHash(f: (A, Int) => Unit): Unit = {
+    val iN = payloadArity // arity doesn't change during this operation
+    var i = 0
+    while (i < iN) {
+      f(getPayload(i), getHash(i))
+      i += 1
+    }
+
+    val jN = nodeArity // arity doesn't change during this operation
+    var j = 0
+    while (j < jN) {
+      getNode(j).foreachWithHash(f)
+      j += 1
+    }
+  }
+
+  override def foreachWithHashWhile(f: (A, Int) => Boolean): Boolean = {
+    val thisPayloadArity = payloadArity
+    var pass = true
+    var i = 0
+    while (i < thisPayloadArity && pass) {
+      pass &&= f(getPayload(i), getHash(i))
+      i += 1
+    }
+
+    val thisNodeArity = nodeArity
+    var j = 0
+    while (j < thisNodeArity && pass) {
+      pass &&= getNode(j).foreachWithHashWhile(f)
+      j += 1
+    }
+    pass
+  }
 }
 
 private final class HashCollisionSetNode[A](val originalHash: Int, val hash: Int, var content: Vector[A]) extends SetNode[A] {
@@ -1399,6 +1445,24 @@ private final class HashCollisionSetNode[A](val originalHash: Int, val hash: Int
     case _: BitmapIndexedSetNode[A] =>
       // should never happen -- hash collisions are never at the same level as bitmapIndexedSetNodes
       throw new UnsupportedOperationException("Cannot concatenate a HashCollisionSetNode with a BitmapIndexedSetNode")
+  }
+
+  override def foreachWithHash(f: (A, Int) => Unit): Unit = {
+    val iter = content.iterator
+    while (iter.hasNext) {
+      val next = iter.next()
+      f(next.asInstanceOf[A], originalHash)
+    }
+  }
+
+  override def foreachWithHashWhile(f: (A, Int) => Boolean): Boolean = {
+    var stillGoing = true
+    val iter = content.iterator
+    while (iter.hasNext && stillGoing) {
+      val next = iter.next()
+      stillGoing &&= f(next.asInstanceOf[A], originalHash)
+    }
+    stillGoing
   }
 }
 

--- a/test/scalacheck/scala/collection/immutable/BitSetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/BitSetProperties.scala
@@ -3,6 +3,7 @@ package scala.collection.immutable
 import org.scalacheck._
 import org.scalacheck.Prop._
 import Gen._
+
 object BitSetProperties extends Properties("immutable.BitSet") {
 
   override def overrideParameters(p: Test.Parameters): Test.Parameters =

--- a/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
@@ -9,7 +9,7 @@ object ImmutableChampHashSetProperties extends Properties("immutable.ChampHashSe
   type K = Int
 
   override def overrideParameters(p: org.scalacheck.Test.Parameters) =
-    p.withMinSuccessfulTests(100)
+    p.withMinSuccessfulTests(100).withInitialSeed(42L)
 
   private def doSubtract(one: HashSet[K], two: HashSet[K]) = {
     one.foldLeft(HashSet.empty[K])((result, elem) => if (two contains elem) result else result + elem)
@@ -290,6 +290,7 @@ object ImmutableChampHashSetProperties extends Properties("immutable.ChampHashSe
   property("(xs - elem) == xs.toList.filterNot(_ == elem).toSet") = forAll { (xs: Set[K], elem: K) =>
     (xs - elem) == xs.toList.filterNot(_ == elem).toSet
   }
+
   property("(xs + elem) == (xs.toList :+ elem).toSet") = forAll { (xs: Set[K], elem: K) =>
     (xs + elem) == (xs.toList :+ elem).toSet
   }
@@ -297,4 +298,31 @@ object ImmutableChampHashSetProperties extends Properties("immutable.ChampHashSe
     val range = 1 to (rangeMax % 10000)
     xs -- range == xs -- range.toSet
   }
+
+  property("concat(mutable.HashSet)") = forAll { (left: HashSet[Int], right: HashSet[Int]) =>
+    val expected: collection.Set[Int] = left concat right
+    val actual: collection.Set[Int] = left.concat(right.to(collection.mutable.HashSet))
+    actual ?= expected
+  }
+  property("concat(Vector)") = forAll { (left: HashSet[Int], right: Vector[Int]) =>
+    val expected: collection.Set[Int] = left.iterableFactory.newBuilder[Int].addAll(left).addAll(right).result()
+    val actual: collection.Set[Int] = left.concat(right)
+    actual ?= expected
+  }
+  property("removedAll(HashSet)") = forAll { (left: HashSet[Int], right: HashSet[Int]) =>
+    val expected: collection.Set[Int] = left.filter(!right.contains(_))
+    val actual: collection.Set[Int] = left -- right
+    actual ?= expected
+  }
+  property("removedAll(mutable.HashSet)") = forAll { (left: HashSet[Int], right: HashSet[Int]) =>
+    val expected: collection.Set[Int] = left -- right
+    val actual: collection.Set[Int] = left -- right.to(collection.mutable.HashSet)
+    actual ?= expected
+  }
+  property("removedAll(Vector)") = forAll { (left: HashSet[Int], right: Vector[Int]) =>
+    val expected: collection.Set[Int] = left.filter(!right.contains(_))
+    val actual: collection.Set[Int] = left -- right
+    actual ?= expected
+  }
+
 }

--- a/test/scalacheck/scala/collection/mutable/HashMapProperties.scala
+++ b/test/scalacheck/scala/collection/mutable/HashMapProperties.scala
@@ -1,0 +1,45 @@
+package scala.collection.mutable
+
+import org.scalacheck._
+import org.scalacheck.Prop._
+
+import scala.collection.immutable
+
+object HashMapProperties extends Properties("mutable.HashMap") {
+
+  override def overrideParameters(p: Test.Parameters): Test.Parameters =
+    p.withMinSuccessfulTests(500)
+      .withInitialSeed(42L)
+
+  property("addAll(immutable.HashMap)") = forAll { (left: immutable.HashMap[Int, Int], right: immutable.HashMap[Int, Int]) =>
+    val expected: collection.Map[Int, Int] = left concat right
+    val actual: collection.Map[Int, Int] = left.to(HashMap).addAll(right)
+
+    actual ?= expected
+  }
+  property("addAll(mutable.HashMap)") = forAll { (left: immutable.HashMap[Int, Int], right: immutable.HashMap[Int, Int]) =>
+    val expected: collection.Map[Int, Int] = left concat right
+    val actual: collection.Map[Int, Int] = left.to(HashMap).addAll(right.to(HashMap.mapFactory))
+    actual ?= expected
+  }
+  property("addAll(Vector)") = forAll { (left: immutable.HashMap[Int, Int], right: Vector[(Int, Int)]) =>
+    val expected: collection.Map[Int, Int] = left concat right
+    val actual: collection.Map[Int, Int] = left.to(HashMap).addAll(right)
+    actual ?= expected
+  }
+  property("subtractAll(immutable.HashSet)") = forAll { (left: immutable.HashMap[Int, Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Map[Int, Int] = left -- right
+    val actual: collection.Map[Int, Int] = left.to(HashMap).subtractAll(right.to(HashSet))
+    actual ?= expected
+  }
+  property("subtractAll(mutable.HashSet)") = forAll { (left: immutable.HashMap[Int, Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Map[Int, Int] = left -- right
+    val actual: collection.Map[Int, Int] = left.to(HashMap).subtractAll(right.to(HashSet))
+    actual ?= expected
+  }
+  property("subtractAll(Vector)") = forAll { (left: immutable.HashMap[Int, Int], right: Vector[Int]) =>
+    val expected: collection.Map[Int, Int] = left -- right
+    val actual: collection.Map[Int, Int] = left.to(HashMap).subtractAll(right.to(Vector))
+    actual ?= expected
+  }
+}

--- a/test/scalacheck/scala/collection/mutable/HashSetProperties.scala
+++ b/test/scalacheck/scala/collection/mutable/HashSetProperties.scala
@@ -4,8 +4,6 @@ import org.scalacheck.Prop._
 import scala.collection.immutable
 
 object HashSetProperties extends Properties("mutable.HashSet") {
-  override def overrideParameters(p: Test.Parameters): Test.Parameters =
-    p.withInitialSeed(42L)
 
   property("filterInPlace(p)") = forAll { (hs: immutable.HashSet[Int], p: Int => Boolean) =>
     val expected: collection.Set[Int] = hs.filter(p)
@@ -19,5 +17,35 @@ object HashSetProperties extends Properties("mutable.HashSet") {
   property("filterInPlace(_ => false)") = forAll { hs: immutable.HashSet[Int] =>
     val actual: collection.Set[Int] = hs.to(HashSet).filterInPlace(_ => false)
     actual ?= Set.empty
+  }
+  property("addAll(immutable.HashSet)") = forAll { (left: immutable.HashSet[Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Set[Int] = left union right
+    val actual: collection.Set[Int] = left.to(HashSet).addAll(right)
+    actual ?= expected
+  }
+  property("addAll(mutable.HashSet)") = forAll { (left: immutable.HashSet[Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Set[Int] = left union right
+    val actual: collection.Set[Int] = left.to(HashSet).addAll(right.to(HashSet))
+    actual ?= expected
+  }
+  property("addAll(Vector)") = forAll { (left: immutable.HashSet[Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Set[Int] = left union right
+    val actual: collection.Set[Int] = left.to(HashSet).addAll(right.to(Vector))
+    actual ?= expected
+  }
+  property("subtractAll(immutable.HashSet)") = forAll { (left: immutable.HashSet[Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Set[Int] = left diff right
+    val actual: collection.Set[Int] = left.to(HashSet).subtractAll(right)
+    actual ?= expected
+  }
+  property("subtractAll(immutable.HashSet)") = forAll { (left: immutable.HashSet[Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Set[Int] = left diff right
+    val actual: collection.Set[Int] = left.to(HashSet).subtractAll(right.to(HashSet))
+    actual ?= expected
+  }
+  property("subtractAll(immutable.Vector)") = forAll { (left: immutable.HashSet[Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Set[Int] = left diff right
+    val actual: collection.Set[Int] = left.to(HashSet).subtractAll(right.to(Vector))
+    actual ?= expected
   }
 }


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11265

## Summary

### mutable.HashMap.addAll:
* when addAll'ing a mutable.HashMap, we create an `Iterator[Node[K, V]]` of the HashMap being added. From each node, we extract that key's hashcode, and feed it to a newly created method `put0` which allows for a hash Int to be passed in rather than computing it itself.
* when addAll'ing an immutable.HashMap, we call a new `private[collection]` method on hashMaps `foreachWithHash(f: (K, V, Int) => Unit): Unit` which applies `f` on each key-value-hash. Inside the lambda passed to this method, we also use the same new `put0` method

### mutable.HashSet.addAll:
* Same optimizations as above -- iterate through nodes when addAll'ing a mutable.HashSet, and call `immutable.HashSet.foreachWithHash` on immutable.HashSets

### mutable.HasMap.subtractAll
* when subtractAll'ing a mutable.HashSet, we create an `Iterator[Node[K]]` of the HashSet being added. From each node, we extract that key's hashcode, and feed it to a newly created `remove0` method, which allows the hash of the key to be passed in rather than computing it itself. After each key removal, we re-check to return early if `this` is now empty.
* when subtractAll'ing a `immutable.HashSet`, we call a newly created method on immutable HashSets `private[collection] def foreachWithHashWhile(f: (A, Int) => Boolean): Unit` (we can change the name haha) which applies f to each pair of (element, hashcode) it contains, until the function returns `false` at which point it stops. When calling this method, the boolean returned checks if `this` is empty. 

### mutable.HashSet.subtractAll
* Same optimizations as on HashMaps -- iterate through `mutable.HashSet.Node[A]`s when argument is a mutable HashSet. And when it is immutable, make a call to `immutable.HashSet.foreachWithHashWhile`, removing each element from `this` until empty or finished. 

### immutable.HashMap
* concat and HashMapBuilder.addAll take advantage of the same optimizations. This involves returning the mutable.HashMap hashcodes from their previous form ("improved") to original form, so that the immutable.HashMap can use the original hashcode. 

## Some Benchmarks

See HashMapBenchmark3 below

Quite good improvement, 30% or so on addAll, 50% or so, on subtractAll

```
[info] # Run complete. Total time: 00:06:19
[info] Benchmark                          (size)  Mode  Cnt           Score           Error  Units
[info] HashMapBenchmark3.addAll               10  avgt   10        1151.968 ±        55.506  ns/op
[info] HashMapBenchmark3.addAll              100  avgt   10        9338.862 ±      2409.561  ns/op
[info] HashMapBenchmark3.addAll             1000  avgt   10      182708.824 ±      1904.357  ns/op
[info] HashMapBenchmark3.addAll          1000000  avgt   10   463755799.767 ±  28729248.655  ns/op
[info] HashMapBenchmark3.oldAddAll            10  avgt   10        1406.127 ±        23.099  ns/op
[info] HashMapBenchmark3.oldAddAll           100  avgt   10       11094.094 ±       248.424  ns/op
[info] HashMapBenchmark3.oldAddAll          1000  avgt   10      217807.595 ±      6408.993  ns/op
[info] HashMapBenchmark3.oldAddAll       1000000  avgt   10  1059055684.800 ±  41515704.745  ns/op
[info] HashMapBenchmark3.oldSubtractAll       10  avgt   10         876.393 ±        23.448  ns/op
[info] HashMapBenchmark3.oldSubtractAll      100  avgt   10        6262.782 ±       120.999  ns/op
[info] HashMapBenchmark3.oldSubtractAll     1000  avgt   10      139785.435 ±      1623.414  ns/op
[info] HashMapBenchmark3.oldSubtractAll  1000000  avgt   10   616976152.100 ± 730354286.524  ns/op
[info] HashMapBenchmark3.subtractAll          10  avgt   10         513.716 ±        22.922  ns/op
[info] HashMapBenchmark3.subtractAll         100  avgt   10        3530.142 ±        77.625  ns/op
[info] HashMapBenchmark3.subtractAll        1000  avgt   10       87042.418 ±      2953.543  ns/op
[info] HashMapBenchmark3.subtractAll     1000000  avgt   10   255272035.070 ±   7723771.309  ns/op
```


TODO:

- [x] Document these newly created methods

- [x] Write unit- and property-tests

- [x] Apply these optimizations to mutable.HashSet