### PR TITLE
[Backport] Hashmap fix to Scala 2.11

### DIFF
--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -73,10 +73,18 @@ extends AbstractMap[A, B]
   }
 
   override def getOrElseUpdate(key: A, defaultValue: => B): B = {
-    val i = index(elemHashCode(key))
+    val hash = elemHashCode(key)
+    val i = index(hash)
     val entry = findEntry(key, i)
     if (entry != null) entry.value
-    else addEntry(createNewEntry(key, defaultValue), i)
+    else {
+      val table0 = table
+      val default = defaultValue
+      // Avoid recomputing index if the `defaultValue()` hasn't triggered
+      // a table resize.
+      val newEntryIndex = if (table0 eq table) i else index(hash)
+      addEntry(createNewEntry(key, default), newEntryIndex)
+    }
   }
 
   /* inlined HashTable.findEntry0 to preserve its visibility */

--- a/test/junit/scala/collection/mutable/HashMapTest.scala
+++ b/test/junit/scala/collection/mutable/HashMapTest.scala
@@ -1,0 +1,38 @@
+package scala.collection
+package mutable
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class HashMapTest {
+
+  @Test
+  def getOrElseUpdate_mutationInCallback() {
+    val hm = new mutable.HashMap[String, String]()
+    // add enough elements to resize the hash table in the callback
+    def add() = 1 to 100000 foreach (i => hm(i.toString) = "callback")
+    hm.getOrElseUpdate("0", {
+      add()
+      ""
+    })
+    assertEquals(Some(""), hm.get("0"))
+  }
+
+  @Test
+  def getOrElseUpdate_evalOnce(): Unit = {
+    var i = 0
+    val hm = new mutable.HashMap[Int, Int]()
+    hm.getOrElseUpdate(0, {i += 1; i})
+    assertEquals(1, hm(0))
+  }
+
+  @Test
+  def getOrElseUpdate_noEval(): Unit = {
+    val hm = new mutable.HashMap[Int, Int]()
+    hm.put(0, 0)
+    hm.getOrElseUpdate(0, throw new AssertionError())
+  }
+}


### PR DESCRIPTION
In Scala 2.12.2, a bug was noticed by @retronym where the index of the hashmap could become stale if a resize is triggered (See https://github.com/scala/scala/commit/19742418eea6571c725c5f3c13bf8d84acf91f4b). This bug was fixed. However, at the moment, we are unable to migrate over to Scala 2.12 as our versions of Spark and SBT are incompatible with Scala 2.12. Therefore, we were wondering if you could backport this bug fix to a scala 2.11 version.