### PR TITLE
Align generator with valdef

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -931,7 +931,8 @@ be implemented in different ways for different carrier types.
 
 The translation scheme is as follows.  In a first step, every
 generator `$p$ <- $e$`, where $p$ is not [irrefutable](08-pattern-matching.html#patterns)
-for the type of $e$ is replaced by
+for the type of $e$, and $p$ is some pattern other than a simple name
+or a name followed by a colon and a type, is replaced by
 
 ```scala
 $p$ <- $e$.withFilter { case $p$ => true; case _ => false }


### PR DESCRIPTION
Irrefutability does not cover `for (X <- e)`
because `X` is not a "varid".

Transplant the words used for value definitions.