### PR TITLE
Lazy implementations of takeRight and dropRight

### DIFF
--- a/src/library/scala/collection/IndexedSeqView.scala
+++ b/src/library/scala/collection/IndexedSeqView.scala
@@ -133,27 +133,16 @@ object IndexedSeqView {
     extends SeqView.Take(underlying, n) with IndexedSeqView[A]
 
   @SerialVersionUID(3L)
-  class TakeRight[A](underlying: SomeIndexedSeqOps[A], n: Int) extends AbstractIndexedSeqView[A] {
-    private[this] val delta = (underlying.size - (n max 0)) max 0
-    def length = underlying.size - delta
-    @throws[IndexOutOfBoundsException]
-    def apply(i: Int) = underlying.apply(i + delta)
-  }
+  class TakeRight[A](underlying: SomeIndexedSeqOps[A], n: Int)
+    extends SeqView.TakeRight(underlying, n) with IndexedSeqView[A]
 
   @SerialVersionUID(3L)
-  class Drop[A](underlying: SomeIndexedSeqOps[A], n: Int) extends View.Drop[A](underlying, n) with IndexedSeqView[A] {
-    def length = (underlying.size - normN) max 0
-    @throws[IndexOutOfBoundsException]
-    def apply(i: Int) = underlying.apply(i + normN)
-  }
+  class Drop[A](underlying: SomeIndexedSeqOps[A], n: Int)
+    extends SeqView.Drop[A](underlying, n) with IndexedSeqView[A]
 
   @SerialVersionUID(3L)
-  class DropRight[A](underlying: SomeIndexedSeqOps[A], n: Int) extends AbstractIndexedSeqView[A] {
-    private[this] val len = (underlying.size - (n max 0)) max 0
-    def length = len
-    @throws[IndexOutOfBoundsException]
-    def apply(i: Int) = underlying.apply(i)
-  }
+  class DropRight[A](underlying: SomeIndexedSeqOps[A], n: Int)
+    extends SeqView.DropRight[A](underlying, n) with IndexedSeqView[A]
 
   @SerialVersionUID(3L)
   class Map[A, B](underlying: SomeIndexedSeqOps[A], f: A => B)

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -434,43 +434,38 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
 
   def take(n: Int): C = fromSpecific(new View.Take(this, n))
 
-  /** A collection containing the last `n` elements of this collection.
-    * $willForceEvaluation
+  /** Selects the last ''n'' elements.
+    *  $orderDependent
+    *  @param  n    the number of elements to take from this $coll.
+    *  @return a $coll consisting only of the last `n` elements of this $coll,
+    *          or else the whole $coll, if it has less than `n` elements.
+    *          If `n` is negative, returns an empty $coll.
+    *  @note    Reuse: $consumesAndProducesIterator
     */
-  def takeRight(n: Int): C = {
-    val b = newSpecificBuilder
-    b.sizeHintBounded(n, toIterable)
-    val lead = iterator drop n
-    val it = iterator
-    while (lead.hasNext) {
-      lead.next()
-      it.next()
-    }
-    while (it.hasNext) b += it.next()
-    b.result()
-  }
+  def takeRight(n: Int): C = fromSpecific(new View.TakeRight(this, n))
 
+  /** Takes longest prefix of elements that satisfy a predicate.
+    *  $orderDependent
+    *  @param   p  The predicate used to test elements.
+    *  @return  the longest prefix of this $coll whose elements all satisfy
+    *           the predicate `p`.
+    *  @note    Reuse: $consumesAndProducesIterator
+    */
   def takeWhile(p: A => Boolean): C = fromSpecific(new View.TakeWhile(this, p))
 
   def span(p: A => Boolean): (C, C) = (takeWhile(p), dropWhile(p))
 
   def drop(n: Int): C = fromSpecific(new View.Drop(this, n))
 
-  /** The rest of the collection without its `n` last elements. For
-    *  linear, immutable collections this should avoid making a copy.
-    *  $willForceEvaluation
+  /** Selects all elements except last ''n'' ones.
+    *  $orderDependent
+    *  @param  n    the number of elements to drop from this $coll.
+    *  @return a $coll consisting of all elements of this $coll except the last `n` ones, or else the
+    *          empty $coll, if this $coll has less than `n` elements.
+    *          If `n` is negative, don't drop any elements.
+    *  @note    Reuse: $consumesAndProducesIterator
     */
-  def dropRight(n: Int): C = {
-    val b = newSpecificBuilder
-    if (n >= 0) b.sizeHint(toIterable, delta = -n)
-    val lead = iterator drop n
-    val it = iterator
-    while (lead.hasNext) {
-      b += it.next()
-      lead.next()
-    }
-    b.result()
-  }
+  def dropRight(n: Int): C = fromSpecific(new View.DropRight(this, n))
 
   def dropWhile(p: A => Boolean): C = fromSpecific(new View.DropWhile(this, p))
 

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -295,7 +295,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     */
   def filterNot(pred: A => Boolean): C
 
-  /** Selects first ''n'' elements.
+  /** Selects the first ''n'' elements.
     *  $orderDependent
     *  @param  n    the number of elements to take from this $coll.
     *  @return a $coll consisting only of the first `n` elements of this $coll,

--- a/src/library/scala/collection/SeqView.scala
+++ b/src/library/scala/collection/SeqView.scala
@@ -23,6 +23,9 @@ trait SeqView[+A] extends SeqOps[A, View, View[A]] with View[A] {
   override def prepended[B >: A](elem: B): SeqView[B] = new SeqView.Prepended(elem, this)
   override def reverse: SeqView[A] = new SeqView.Reverse(this)
   override def take(n: Int): SeqView[A] = new SeqView.Take(this, n)
+  override def drop(n: Int): SeqView[A] = new SeqView.Drop(this, n)
+  override def takeRight(n: Int): SeqView[A] = new SeqView.TakeRight(this, n)
+  override def dropRight(n: Int): SeqView[A] = new SeqView.DropRight(this, n)
 
   def concat[B >: A](suffix: SeqView.SomeSeqOps[B]): SeqView[B] = new SeqView.Concat(this, suffix)
   def appendedAll[B >: A](suffix: SeqView.SomeSeqOps[B]): SeqView[B] = new SeqView.Concat(this, suffix)
@@ -85,6 +88,29 @@ object SeqView {
       throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${if (underlying.knownSize >= 0) knownSize - 1 else "unknown"})")
     }
     def length: Int = underlying.length min normN
+  }
+
+  @SerialVersionUID(3L)
+  class TakeRight[+A](underlying: SomeSeqOps[A], n: Int) extends View.TakeRight(underlying, n) with SeqView[A] {
+    private[this] val delta = (underlying.size - (n max 0)) max 0
+    def length = underlying.size - delta
+    @throws[IndexOutOfBoundsException]
+    def apply(i: Int) = underlying.apply(i + delta)
+  }
+
+  @SerialVersionUID(3L)
+  class Drop[A](underlying: SomeSeqOps[A], n: Int) extends View.Drop[A](underlying, n) with SeqView[A] {
+    def length = (underlying.size - normN) max 0
+    @throws[IndexOutOfBoundsException]
+    def apply(i: Int) = underlying.apply(i + normN)
+  }
+
+  @SerialVersionUID(3L)
+  class DropRight[A](underlying: SomeSeqOps[A], n: Int) extends View.DropRight[A](underlying, n) with SeqView[A] {
+    private[this] val len = (underlying.size - (n max 0)) max 0
+    def length = len
+    @throws[IndexOutOfBoundsException]
+    def apply(i: Int) = underlying.apply(i)
   }
 }
 

--- a/src/library/scala/collection/StrictOptimizedIterableOps.scala
+++ b/src/library/scala/collection/StrictOptimizedIterableOps.scala
@@ -255,4 +255,35 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     coll
   }
 
+  /** A collection containing the last `n` elements of this collection.
+    * $willForceEvaluation
+    */
+  override def takeRight(n: Int): C = {
+    val b = newSpecificBuilder
+    b.sizeHintBounded(n, toIterable)
+    val lead = iterator drop n
+    val it = iterator
+    while (lead.hasNext) {
+      lead.next()
+      it.next()
+    }
+    while (it.hasNext) b += it.next()
+    b.result()
+  }
+
+  /** The rest of the collection without its `n` last elements. For
+    *  linear, immutable collections this should avoid making a copy.
+    *  $willForceEvaluation
+    */
+  override def dropRight(n: Int): C = {
+    val b = newSpecificBuilder
+    if (n >= 0) b.sizeHint(toIterable, delta = -n)
+    val lead = iterator drop n
+    val it = iterator
+    while (lead.hasNext) {
+      b += it.next()
+      lead.next()
+    }
+    b.result()
+  }
 }

--- a/test/scalacheck/scala/collection/IteratorProperties.scala
+++ b/test/scalacheck/scala/collection/IteratorProperties.scala
@@ -1,0 +1,47 @@
+package scala.collection
+
+import org.scalacheck.{Arbitrary, Gen, Properties, Prop}
+import org.scalacheck.Prop.{forAll, BooleanOperators, all}
+
+object IteratorProperties extends Properties("Iterator") {
+
+  val smallInteger = Gen.choose(0,50)
+
+  class SimpleIterable[A](underlying: Iterable[A]) extends Iterable[A] {
+    def iterator: Iterator[A] = {
+      val it = underlying.iterator
+      new Iterator[A] {
+        override def hasNext: Boolean = it.hasNext
+        override def next(): A = it.next()
+      }
+    }
+  }
+
+  property("take") = check(_ take _)
+  property("takeRight") = check((it, n) => it match {
+    case it: Iterable[Int] => it.takeRight(n)
+    case it: Iterator[Int] => View.takeRightIterator(it, n)
+  })
+  property("drop") = check(_ drop _)
+  property("dropRight") = check((it, n) => it match {
+    case it: Iterable[Int] => it.dropRight(n)
+    case it: Iterator[Int] => View.dropRightIterator(it, n)
+  })
+
+  def check(f: (IterableOnceOps[Int, IterableOnce, IterableOnce[Int]], Int) => IterableOnce[Int]): Prop = forAll(Arbitrary.arbitrary[Seq[Int]], smallInteger) { (s: Seq[Int], n: Int) =>
+    val indexed = s.toIndexedSeq // IndexedSeqs and their Iterators have a knownSize
+    val simple = new SimpleIterable(s) // SimpleIterable and its Iterator don't
+    val stream = LazyList.from(s) // Lazy
+    val indexed1 = f(indexed, n).toSeq
+    val indexed2 = f(indexed.iterator, n).toSeq
+    val simple1 = f(simple, n).toSeq
+    val simple2 = f(simple.iterator, n).toSeq
+    val stream1 = f(stream, n).toSeq
+    val stream2 = f(stream.iterator, n).toSeq
+    (indexed1 == indexed2) :| s"indexed: $indexed1 != $indexed2" &&
+      (simple1 == simple2) :| s"simple: $simple1 != $simple2" &&
+      (stream1 == stream2) :| s"stream: $stream1 != $stream2" &&
+      (simple1 == indexed2) :| s"simple vs indexed: $simple1 != $indexed2" &&
+      (stream1 == indexed2) :| s"stream vs indexed: $stream1 != $indexed2"
+  }
+}


### PR DESCRIPTION
- Add these methods to IterableOnceOps
- Implement them in Iterator (with the necessary amount of caching but
  no more than that)
- Move the existing strict implementations from IterableOps to
  StrictOptimizedIterableOps
- Add View.(TakeRight|DropRight) based on Iterator
- Move IndexedSeqView implementations of TakeRight, Drop and DropRight
  up to SeqView
- Add new overrides in IndexedSeqView

Fixes https://github.com/scala/bug/issues/11275