### PR TITLE
[EXPERIMENT] Improve escape hatch for filter in generator

### DIFF
--- a/test/files/pos/t900-workaround.scala
+++ b/test/files/pos/t900-workaround.scala
@@ -1,0 +1,20 @@
+
+trait T {
+  val xs = Seq(Some(1), None)
+
+  def f() = for (x @ (_x: Some[_]) <- xs) yield x
+
+  def g() = for (x @ (_: Some[_]) <- xs) yield x
+}
+
+/*
+ * The second form was not translated to a partial function:
+  val res1 = xs.withFilter(((check$ifrefutable$1) => check$ifrefutable$1: @scala.unchecked match {
+    case (x @ (_: Some[(_ @ <empty>)])) => true
+    case _ => false
+  })).map(((x: Some[(_ @ <empty>)]) => x))
+ *
+ *        error: type mismatch;
+ *         found   : Some[_] => Some[Any]
+ *         required: Option[Int] => ?
+ */


### PR DESCRIPTION
Allow `for (x @ (_: T) <- ts)` workaround using
underscore as shown. Because the rewrite happens
after patterns are transformed, it was taken as
a straight typed pattern.