### PR TITLE
[SUPERSEDED] Lint pattern in vardefs

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -391,4 +391,6 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
   }
 
   override def isPatVarWarnable = settings.warnUnusedPatVars
+
+  override def isVarDefWarnable = settings.lintValPatterns
 }

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -107,6 +107,7 @@ trait Warnings {
     val NonlocalReturn         = LintWarning("nonlocal-return",           "A return statement used an exception for flow control.")
     val ImplicitNotFound       = LintWarning("implicit-not-found",        "Check @implicitNotFound and @implicitAmbiguous messages.")
     val Serial                 = LintWarning("serial",                    "@SerialVersionUID on traits and non-serializable classes.")
+    val ValPattern             = LintWarning("valpattern",                "Enable pattern checks in val definitions.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
   }
@@ -131,6 +132,7 @@ trait Warnings {
   def warnNonlocalReturn         = lint contains NonlocalReturn
   def lintImplicitNotFound       = lint contains ImplicitNotFound
   def warnSerialization          = lint contains Serial
+  def lintValPatterns            = lint contains ValPattern
 
   // The Xlint warning group.
   val lint = MultiChoiceSetting(

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -769,7 +769,8 @@ abstract class TreeGen {
       //                  ...
       //                  val/var x_N = t$._N
 
-      val rhsUnchecked = mkUnchecked(rhs)
+      val linting = isVarDefWarnable
+      val rhsUnchecked = if (linting) rhs else mkUnchecked(rhs)
 
       // TODO: clean this up -- there is too much information packed into mkPatDef's `pat` argument
       // when it's a simple identifier (case Some((name, tpt)) -- above),
@@ -958,6 +959,9 @@ abstract class TreeGen {
 
   /** Can be overridden to depend on settings.warnUnusedPatvars. */
   def isPatVarWarnable: Boolean = true
+
+  /** Can be overridden to depend on settings.lintValPatterns. */
+  def isVarDefWarnable: Boolean = false
 
   /** Not in for comprehensions, whether to warn unused pat vars depends on flag. */
   object patvarTransformer       extends PatvarTransformer(forFor = false)

--- a/test/files/neg/t5898.check
+++ b/test/files/neg/t5898.check
@@ -1,0 +1,11 @@
+t5898.scala:9: warning: match may not be exhaustive.
+It would fail on the following input: C(_)
+  def f() = t match { case x: D => ??? }
+            ^
+t5898.scala:10: warning: match may not be exhaustive.
+It would fail on the following input: C(_)
+  val D(x) = t
+             ^
+error: No warnings can be incurred under -Xfatal-warnings.
+two warnings found
+one error found

--- a/test/files/neg/t5898.scala
+++ b/test/files/neg/t5898.scala
@@ -1,0 +1,12 @@
+// scalac: -Xlint:valpattern -Xfatal-warnings
+//
+sealed trait T
+case class C(i: Int) extends T
+case class D(i: Int) extends T
+
+trait Test {
+  def t: T = C(42)
+  def f() = t match { case x: D => ??? }
+  val D(x) = t
+  val D(y) = (null: Any)
+}


### PR DESCRIPTION
Under `-Xlint`, don't emit the RHS of pat var defs
as `@unchecked`.

Mitigates https://github.com/scala/bug/issues/5898