### PR TITLE
Revert the change of making `deprecated` final.

### DIFF
--- a/src/library/scala/deprecated.scala
+++ b/src/library/scala/deprecated.scala
@@ -58,4 +58,5 @@ import scala.annotation.meta._
  *  @see    [[scala.deprecatedName]]
  */
 @getter @setter @beanGetter @beanSetter
-final class deprecated(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation
+@deprecatedInheritance(since = "2.13.0")
+class deprecated(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation


### PR DESCRIPTION
Cause there are some usages like `class unused extends deprecated("unused")` currently in the community, which need a clean migration path, defer this change to 2.14.

I suggest that we introduce a new annotation in 2.14 like this one:
```scala
class suppressWarnings(suppressed:Array[String]) extends scala.annotation.StaticAnnotation
```
and then it could be used as:
```scala
class unused extends suppressWarnings(suppressed = Array("unused"))
```

Another kind of thing is supporting annotation cascading. like :
```scala
@deprecated("unused")
class suppressUnusedWarnning extends scala.annotation.StaticAnnotation
```


refs:https://github.com/scala/bug/issues/11311
