### PR TITLE
Introduce @ApiMayChange/@DoNotInherit/@InternalApi

### DIFF
--- a/src/library/scala/annotation/ApiMayChange.java
+++ b/src/library/scala/annotation/ApiMayChange.java
@@ -1,0 +1,39 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks APIs that are meant to evolve towards becoming stable APIs, but are not stable APIs yet.
+ *
+ * Evolving interfaces MAY change from one patch release to another (i.e. 2.4.10 to 2.4.11) without up-front notice.
+ * A best-effort approach is taken to not cause more breakage than really necessary, and usual deprecation techniques
+ * are utilised while evolving these APIs, however there is NO strong guarantee regarding the source or binary
+ * compatibility of APIs marked using this annotation.
+ * <p/>
+ * It MAY also change when promoting the API to stable, for example such changes may include removal of deprecated
+ * methods that were introduced during the evolution and final refactoring that were deferred because they would
+ * have introduced to much breaking changes during the evolution phase.
+ * <p/>
+ * Promoting the API to stable MAY happen in a patch release.
+ * <p/>
+ * It is encouraged to document in ScalaDoc how exactly this API is expected to evolve.
+ *
+ * @since 2.13.0
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS) // to be accessible by MiMa
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.TYPE, ElementType.PACKAGE})
+public @interface ApiMayChange {
+}

--- a/src/library/scala/annotation/DoNotInherit.java
+++ b/src/library/scala/annotation/DoNotInherit.java
@@ -1,0 +1,33 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks APIs that are designed under an closed-world assumption for and are NOT meant to be extended by user-code.
+ * It is fine to extend these classes within the library itself however.
+ * <p/>
+ * This is most useful for binary compatibility purposes when a set of classes and interfaces assume a "closed world"
+ * between them, and gain the ability to add methods to the interfaces without breaking binary compatibility for
+ * users of this code. Specifically this assumption may be understood intuitively: as all classes that implement this
+ * interface are in this compilation unit / artifact, it is impossible to obtain a "old" class with a "new" interface,
+ * as they are part of the same dependency.
+ *
+ * @since 2.13.0
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS) // to be accessible by MiMa
+@Target({ElementType.TYPE})
+public @interface DoNotInherit {
+}

--- a/src/library/scala/annotation/InternalApi.java
+++ b/src/library/scala/annotation/InternalApi.java
@@ -1,0 +1,34 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks APIs that are considered internal to the library and may change at any point in time without any warning.
+ * <p/>
+ * For example, this annotation should be used when the Scala {@code private[foo]} access restriction is used,
+ * as Java has no way of representing this package restricted access and such methods and classes are represented
+ * as {@code public} in byte-code.
+ * <p/>
+ * If a method/class annotated with this method has a javadoc/scaladoc comment, the first line MUST include
+ * {@code INTERNAL API} in order to be easily identifiable from generated documentation. Additional information
+ * may be put on the same line as the INTERNAL API comment in order to clarify further.
+ *
+ * @since 2.13.0
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS) // to be accessible by MiMa
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.TYPE, ElementType.PACKAGE})
+public @interface InternalApi {
+}


### PR DESCRIPTION
Uplifted from akka.annotation.

By having these in the standard library we can make use of them throughout the ecosystem and do things like build tools (like MiMa) upon their usage.

~~Note `StaticAnnotation` states:~~

> ~~Annotation classes defined in Scala are not stored in classfiles in a Java-compatible manner~~

~~and `ClassfileAnnotation` is (freshly) deprecated~~

> ~~Annotation classes need to be written in Java in order to be stored in classfiles in a Java-compatible manner~~

~~so I'm concerned that these might not be seen in MiMa (trivially).~~

Also, I retained the original name, with their upper-case, for Java users.

Finally I put these in the annotation package, as it seemed sensible (and mirrored Akka's original decision).

TODO:
- [x] Verify these would work with MiMa
- [ ] Finalise the name casing choice
- [ ] Finalise the package choice

Review (and help wanted) by @lrytz or @adriaanm, kindly.