### PR TITLE
Introduce Unit.void[A](x: A): Unit

### DIFF
--- a/src/library/scala/Unit.scala
+++ b/src/library/scala/Unit.scala
@@ -28,7 +28,7 @@ final abstract class Unit private extends AnyVal {
 }
 
 object Unit extends AnyValCompanion {
-  def void[A](x: A): Unit = ()
+  final def void[A](x: A): Unit = ()
 
   /** Transform a value type into a boxed reference type.
    *

--- a/src/library/scala/Unit.scala
+++ b/src/library/scala/Unit.scala
@@ -28,6 +28,7 @@ final abstract class Unit private extends AnyVal {
 }
 
 object Unit extends AnyValCompanion {
+  def void[A](x: A): Unit = ()
 
   /** Transform a value type into a boxed reference type.
    *

--- a/test/junit/scala/UnitTest.scala
+++ b/test/junit/scala/UnitTest.scala
@@ -1,0 +1,8 @@
+package scala
+
+import org.junit.Assert._
+import org.junit.Test
+
+final class UnitTest {
+  @Test def testVoid: Unit = Unit.void(1)
+}

--- a/test/junit/scala/UnitTest.scala
+++ b/test/junit/scala/UnitTest.scala
@@ -4,5 +4,5 @@ import org.junit.Assert._
 import org.junit.Test
 
 final class UnitTest {
-  @Test def testVoid: Unit = Unit.void(1)
+  @Test def testVoid(): Unit = assertTrue(().getClass == Unit.void(1).getClass)
 }


### PR DESCRIPTION
This is useful when you want to explicitly discard a value, without
having to val it and force your expression to be a block.

Ideally, this would be defined on the Unit type rather than the Unit
companion object, but I couldn't figure out the backend changes
necessary to get it to handle that...

Possible alternative names: discard, drop, forget, unit, ...

TODO:
- [ ] Finalise the name
- [ ] Finalise the location
- [x] Fix the test so it absolutely tests

Review (and help wanted) by @lrytz or @adriaanm, kindly.