### PR TITLE
Prompt change during replay

### DIFF
--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -525,10 +525,15 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
   def replay(): Unit = {
     if (replayCommandStack.isEmpty)
       echo("Nothing to replay.")
-    else for (cmd <- replayCommands) {
-      echo("Replaying: " + cmd)  // flush because maybe cmd will have its own output
-      command(cmd)
-      echo("")
+    else {
+      val reprompt = "replay> "
+      intp.reporter.indenting(reprompt.length) {
+        for (cmd <- replayCommands) {
+          echo(s"$reprompt$cmd")
+          command(cmd)
+          echo("") // flush because maybe cmd will have its own output
+        }
+      }
     }
   }
   /** `reset` the interpreter in an attempt to start fresh.
@@ -856,7 +861,7 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
     result
   }
 
-  private val continueText   = {
+  private val continueText = {
     val text   = enversion(continueString)
     val margin = promptText.linesIterator.toList.last.length - text.length
     if (margin > 0) " " * margin + text else text

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
@@ -43,8 +43,16 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
     flush()
   }
 
+  private def indentDepth: Int = config.promptText.linesIterator.toList.last.length
+  private[this] var indentation: String = " " * indentDepth
+  def indenting(n: Int)(body: => Unit): Unit = {
+    val save = indentation
+    indentation = " " * n
+    try body finally indentation = save
+  }
+  private def indented(str: String) = str.linesIterator.mkString(indentation, "\n" + indentation, "")
+
   def colorOk: Boolean = config.colorOk
-  def indentDepth: Int = config.promptText.linesIterator.toList.last.length
   def isDebug: Boolean = config.isReplDebug
   def isTrace: Boolean = config.isReplTrace
 
@@ -151,9 +159,6 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
 
     printMessage(pos, prefix + msg)
   }
-
-  private val indentation = " " * indentDepth
-  private def indented(str: String) = str.linesIterator.mkString(indentation, "\n" + indentation, "")
 
   // indent errors, error message uses the caret to point at the line already on the screen instead of repeating it
   // TODO: can we splice the error into the code the user typed when multiple lines were entered?

--- a/src/repl/scala/tools/nsc/interpreter/Interface.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Interface.scala
@@ -238,6 +238,9 @@ trait ReplReporter extends Reporter {
     */
   def withoutUnwrapping(body: => Unit): Unit
 
+  /** Change indentation due to prompt. */
+  def indenting(n: Int)(body: => Unit): Unit
+
 
   /** Print result (Right --> success, Left --> error)
     */

--- a/test/files/run/repl-replay.check
+++ b/test/files/run/repl-replay.check
@@ -1,0 +1,12 @@
+
+scala> locally { val x = 42 ; "$x" }
+res0: String = $x
+
+scala> :replay -Xlint
+replay> locally { val x = 42 ; "$x" }
+                               ^
+        warning: possible missing interpolator: detected interpolated identifier `$x`
+res0: String = $x
+
+
+scala> :quit

--- a/test/files/run/repl-replay.scala
+++ b/test/files/run/repl-replay.scala
@@ -1,0 +1,9 @@
+
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def code = """
+    |locally { val x = 42 ; "$x" }
+    |:replay -Xlint
+  """.stripMargin.trim
+}


### PR DESCRIPTION
A little hokey, as described at https://github.com/scala/bug/issues/11309#issuecomment-447061149

```
$ skala -Yimports:java.lang,scala,mypredef.P 
Welcome to Scala 2.13.0 (OpenJDK 64-Bit Server VM 11.0.1)

scala> banner
res0: String = My Predef

scala> :replay -Yimports:java.lang,scala,mypredef.P -Yno-predef
replaying> banner
           ^
           error: not found: value banner


scala> 42
res1: Int = 42

scala> 42 toString
          ^
       error: postfix operator toString needs to be enabled
       by making the implicit value scala.language.postfixOps visible.
       This can be achieved by adding the import clause 'import scala.language.postfixOps'
       or by setting the compiler option -language:postfixOps.
       See the Scaladoc for value scala.language.postfixOps for a discussion
       why the feature needs to be explicitly enabled.
```