### PR TITLE
[#11315] WrappedString directly extends IndexedSeq

### DIFF
--- a/src/library/scala/collection/immutable/WrappedString.scala
+++ b/src/library/scala/collection/immutable/WrappedString.scala
@@ -29,7 +29,7 @@ import mutable.{Builder, StringBuilder}
   *  @define Coll `WrappedString`
   *  @define coll wrapped string
   */
-final class WrappedString(private val self: String) extends AbstractSeq[Char] with IndexedSeq[Char]
+final class WrappedString(private val self: String) extends IndexedSeq[Char]
   with IndexedSeqOps[Char, IndexedSeq, WrappedString] {
 
   def apply(i: Int): Char = self.charAt(i)

--- a/test/junit/scala/util/RandomTest.scala
+++ b/test/junit/scala/util/RandomTest.scala
@@ -1,6 +1,8 @@
 package scala.util
 
-import org.junit.{ Assert, Test }
+import org.junit.{Assert, Test}
+
+import scala.tools.testing.AssertUtil._
 
 class RandomTest {
   // Test for scala/bug#9059
@@ -11,5 +13,10 @@ class RandomTest {
     for (c <- items) {
       Assert.assertTrue(s"$c should be alphanumeric", isAlphaNum(c))
     }
+  }
+
+  @Test def test11315: Unit = {
+    // test for scala/bug#11315
+    assertSameElements(Random.shuffle("hello".toSeq).sorted, "hello".toSeq.sorted)
   }
 }


### PR DESCRIPTION
Fixes scala/bug#11315 by directly extending `IndexedSeq[Char]` rather than `AbstractSeq[Char] with IndexedSeq[Char]`

It's a better approach than https://github.com/scala/scala/pull/7534 I reckon