### PR TITLE
[#11314] Override + in Map.WithDefault and SortedMap.WithDefault

### DIFF
--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -299,6 +299,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
     iterator.map { case (k, v) => s"$k -> $v" }.addString(sb, start, sep, end)
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat.", "2.13.0")
+  @deprecatedOverriding("Override the updated method instead", "2.13.0")
   def + [V1 >: V](kv: (K, V1)): CC[K, V1] =
     mapFactory.from(new View.Appended(toIterable, kv))
 

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -192,6 +192,8 @@ object Map extends MapFactory[Map] {
     def updated[V1 >: V](key: K, value: V1): WithDefault[K, V1] =
       new WithDefault[K, V1](underlying.updated(key, value), defaultValue)
 
+    override def + [V1 >: V](kv: (K, V1)): WithDefault[K, V1] = updated(kv._1, kv._2)
+
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 
     override protected def fromSpecific(coll: collection.IterableOnce[(K, V)] @uncheckedVariance): WithDefault[K, V] =

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -71,7 +71,7 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _]
 
     // We override these methods to fix their return type (which would be `Map` otherwise)
     def updated[V1 >: V](key: K, value: V1): CC[K, V1]
-    @`inline` final override def +[V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
+    override def +[V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
 
     override def concat[V2 >: V](xs: collection.IterableOnce[(K, V2)]): CC[K, V2] = {
         var result: CC[K, V2] = coll
@@ -107,6 +107,8 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
     override def updated[V1 >: V](key: K, value: V1): WithDefault[K, V1] =
       new WithDefault[K, V1](underlying.updated(key, value), defaultValue)
+
+    override def + [V1 >: V](kv: (K, V1)): WithDefault[K, V1] = updated(kv._1, kv._2)
 
     override def concat [V2 >: V](xs: collection.IterableOnce[(K, V2)]): WithDefault[K, V2] =
       new WithDefault( underlying.concat(xs) , defaultValue)

--- a/test/junit/scala/collection/immutable/MapTest.scala
+++ b/test/junit/scala/collection/immutable/MapTest.scala
@@ -1,0 +1,15 @@
+package scala.collection.immutable
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+
+@RunWith(classOf[JUnit4])
+class MapTest {
+
+  // Test if compile, see https://github.com/scala/bug/issues/11314
+  @Test
+  def test(): Unit = {
+    var m = Map("foo" -> "bar").withDefaultValue("baz")
+    m += "a" -> "b"
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11314
It has to remove final annotation on + method in SortedMapOps but overriding MapOps.+ is now deprecated.

poke @julienrf