### PR TITLE
Deprecate unicode arrows `⇒`, `←` and `→`

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -628,8 +628,10 @@ trait Scanners extends ScannersCommon {
         case _ =>
           def fetchOther() = {
             if (ch == '\u21D2') {
+              deprecationWarning("The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.", "2.13.0")
               nextChar(); token = ARROW
             } else if (ch == '\u2190') {
+              deprecationWarning("The unicode arrow `←` is deprecated, use `<-` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.", "2.13.0")
               nextChar(); token = LARROW
             } else if (Character.isUnicodeIdentifierStart(ch)) {
               putChar(ch)

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -351,6 +351,7 @@ object Predef extends LowPriorityImplicits {
   /** @group implicit-classes-any */
   implicit final class ArrowAssoc[A](private val self: A) extends AnyVal {
     @inline def -> [B](y: B): (A, B) = (self, y)
+    @deprecated("Use `->` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.", "2.13.0")
     def →[B](y: B): (A, B) = ->(y)
   }
 

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -97,10 +97,10 @@ final class VectorMap[K, +V] private (
         key = null.asInstanceOf[K]
       } else {
         field(nextSlot) match {
-          case (-1, _) ⇒
+          case (-1, _) =>
             slot = fieldsLength
             key = null.asInstanceOf[K]
-          case (s, k) ⇒
+          case (s, k) =>
             slot = s
             key = k
         }
@@ -177,7 +177,7 @@ final class VectorMap[K, +V] private (
     fields
       .reverseIterator
       .find(!_.isInstanceOf[Tombstone])
-      .map { f ⇒
+      .map { f =>
         val last = f.asInstanceOf[K]
         (last, underlying(last)._2)
       }

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -164,7 +164,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   @deprecated("Use 'new GrowableBuilder(this).mapResult(f)' instead", "2.13.0")
   @deprecatedOverriding("ArrayBuffer[A] no longer extends Builder[A, ArrayBuffer[A]]", "2.13.0")
-  @inline def mapResult[NewTo](f: (ArrayBuffer[A]) ⇒ NewTo): Builder[A, NewTo] = new GrowableBuilder(this).mapResult(f)
+  @inline def mapResult[NewTo](f: (ArrayBuffer[A]) => NewTo): Builder[A, NewTo] = new GrowableBuilder(this).mapResult(f)
 
   override protected[this] def stringPrefix = "ArrayBuffer"
 

--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -576,14 +576,14 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
       /*
        * enforce the 2^63-1 ns limit, must be pos/neg symmetrical because of unary_-
        */
-      case NANOSECONDS  ⇒ bounded(max_ns)
-      case MICROSECONDS ⇒ bounded(max_µs)
-      case MILLISECONDS ⇒ bounded(max_ms)
-      case SECONDS      ⇒ bounded(max_s)
-      case MINUTES      ⇒ bounded(max_min)
-      case HOURS        ⇒ bounded(max_h)
-      case DAYS         ⇒ bounded(max_d)
-      case _ ⇒
+      case NANOSECONDS  => bounded(max_ns)
+      case MICROSECONDS => bounded(max_µs)
+      case MILLISECONDS => bounded(max_ms)
+      case SECONDS      => bounded(max_s)
+      case MINUTES      => bounded(max_min)
+      case HOURS        => bounded(max_h)
+      case DAYS         => bounded(max_d)
+      case _ =>
         val v = DAYS.convert(length, unit)
         -max_d <= v && v <= max_d
     }, "Duration is limited to +-(2^63-1)ns (ca. 292 years)")

--- a/src/reflect/scala/reflect/api/Symbols.scala
+++ b/src/reflect/scala/reflect/api/Symbols.scala
@@ -336,7 +336,7 @@ trait Symbols { self: Universe =>
      *
      *  This method always returns signatures in the most generic way possible, even if the underlying symbol is obtained from an
      *  instantiation of a generic type. For example, signature
-     *  of the method `def map[B](f: (A) ⇒ B): List[B]`, which refers to the type parameter `A` of the declaring class `List[A]`,
+     *  of the method `def map[B](f: (A) => B): List[B]`, which refers to the type parameter `A` of the declaring class `List[A]`,
      *  will always feature `A`, regardless of whether `map` is loaded from the `List[_]` or from `List[Int]`. To get a signature
      *  with type parameters appropriately instantiated, one should use `infoIn`.
      *

--- a/src/scaladoc/scala/tools/nsc/doc/base/MemberLookupBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/MemberLookupBase.scala
@@ -49,8 +49,8 @@ trait MemberLookupBase {
       | - [[scala.collection.immutable.List!.apply class List's apply method]] and
       | - [[scala.collection.immutable.List$.apply object List's apply method]]
       |Disambiguating overloaded members: If a term is overloaded, you can indicate the first part of its signature followed by *:
-      | - [[[scala.collection.immutable.List$.fill[A](Int)(⇒A):List[A]* Fill with a single parameter]]]
-      | - [[[scala.collection.immutable.List$.fill[A](Int,Int)(⇒A):List[List[A]]* Fill with a two parameters]]]
+      | - [[[scala.collection.immutable.List$.fill[A](Int)(=>A):List[A]* Fill with a single parameter]]]
+      | - [[[scala.collection.immutable.List$.fill[A](Int,Int)(=>A):List[List[A]]* Fill with a two parameters]]]
       |Notes:
       | - you can use any number of matching square brackets to avoid interference with the signature
       | - you can use \\. to escape dots in prefixes (don't forget to use * at the end to match the signature!)

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryTypeSupport.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryTypeSupport.scala
@@ -55,13 +55,13 @@ trait ModelFactoryTypeSupport {
           val args = tp.typeArgs
           nameBuffer append '('
           appendTypes0(args.init, ", ")
-          nameBuffer append ") ⇒ "
+          nameBuffer append ") => "
           appendType0(args.last)
         case tp: TypeRef if definitions.isScalaRepeatedParamType(tp) =>
           appendType0(tp.args.head)
           nameBuffer append '*'
         case tp: TypeRef if definitions.isByNameParamType(tp) =>
-          nameBuffer append "⇒ "
+          nameBuffer append "=> "
           appendType0(tp.args.head)
         case tp: TypeRef if definitions.isTupleTypeDirect(tp) =>
           val args = tp.typeArgs
@@ -195,7 +195,7 @@ trait ModelFactoryTypeSupport {
           }
         /* Eval-by-name types */
         case NullaryMethodType(result) =>
-          nameBuffer append '⇒'
+          nameBuffer append "=>"
           appendType0(result)
 
         /* Polymorphic types */

--- a/test/files/jvm/duration-tck.scala
+++ b/test/files/jvm/duration-tck.scala
@@ -130,7 +130,7 @@ object Test extends App {
 
 
   // test overflow protection
-  for (unit ← Seq(DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS, MICROSECONDS, NANOSECONDS)) {
+  for (unit <- Seq(DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS, MICROSECONDS, NANOSECONDS)) {
     val x = unit.convert(Long.MaxValue, NANOSECONDS)
     val dur = Duration(x, unit)
     val mdur = Duration(-x, unit)

--- a/test/files/jvm/future-spec/PromiseTests.scala
+++ b/test/files/jvm/future-spec/PromiseTests.scala
@@ -204,7 +204,7 @@ class PromiseTests extends MinimalScalaTest {
     "cast using mapTo" in {
       f {
         (future, result) =>
-        Await.result(future.mapTo[Boolean].recover({ case _: ClassCastException ⇒ false }), defaultTimeout) mustBe (false)
+        Await.result(future.mapTo[Boolean].recover({ case _: ClassCastException => false }), defaultTimeout) mustBe (false)
       }
     }
 
@@ -271,7 +271,7 @@ class PromiseTests extends MinimalScalaTest {
     "recover from exception" in {
       f {
         (future, message) =>
-        Await.result(future.recover({ case e if e.getMessage == message ⇒ "pigdog" }), defaultTimeout) mustBe ("pigdog")
+        Await.result(future.recover({ case e if e.getMessage == message => "pigdog" }), defaultTimeout) mustBe ("pigdog")
       }
     }
 

--- a/test/files/neg/t10474.check
+++ b/test/files/neg/t10474.check
@@ -1,5 +1,5 @@
 t10474.scala:8: error: stable identifier required, but Test.this.Foo found.
-    case Foo.Bar ⇒ true
+    case Foo.Bar => true
          ^
 t10474.scala:15: error: stable identifier required, but hrhino.this.Foo found.
   val Foo.Crash = ???

--- a/test/files/neg/t10474.scala
+++ b/test/files/neg/t10474.scala
@@ -5,8 +5,8 @@ object Test {
   object Bar
 
   def crash[A](): Boolean = Bar match {
-    case Foo.Bar ⇒ true
-    case _ ⇒ false
+    case Foo.Bar => true
+    case _ => false
   }
 }
 

--- a/test/files/neg/t10806.check
+++ b/test/files/neg/t10806.check
@@ -1,12 +1,12 @@
 t10806.scala:12: warning: unreachable code
-      case e: IllegalArgumentException ⇒ println(e.getMessage)
-                                                ^
+      case e: IllegalArgumentException => println(e.getMessage)
+                                                 ^
 t10806.scala:18: warning: unreachable code
-      case e: IllegalArgumentException ⇒ println(e.getMessage)
-                                                ^
+      case e: IllegalArgumentException => println(e.getMessage)
+                                                 ^
 t10806.scala:23: warning: unreachable code
-      case e: IllegalArgumentException ⇒ println(e.getMessage)
-                                                ^
+      case e: IllegalArgumentException => println(e.getMessage)
+                                                 ^
 error: No warnings can be incurred under -Xfatal-warnings.
 three warnings found
 one error found

--- a/test/files/neg/t10806.scala
+++ b/test/files/neg/t10806.scala
@@ -8,19 +8,19 @@ trait T {
   def f(): Unit = {
     // anything but simple type tests forced analysis
     try { 1 } catch {
-      case _: Exception ⇒ println("Something went wrong")
-      case e: IllegalArgumentException ⇒ println(e.getMessage)
-      case Nope ⇒ ???
+      case _: Exception => println("Something went wrong")
+      case e: IllegalArgumentException => println(e.getMessage)
+      case Nope => ???
     }
 
     try { 1 } catch {
-      case _: Exception ⇒ println("Something went wrong")
-      case e: IllegalArgumentException ⇒ println(e.getMessage)
+      case _: Exception => println("Something went wrong")
+      case e: IllegalArgumentException => println(e.getMessage)
     }
 
     (new IllegalArgumentException()) match {
-      case _: Exception ⇒ println("Something went very wrong")
-      case e: IllegalArgumentException ⇒ println(e.getMessage)
+      case _: Exception => println("Something went very wrong")
+      case e: IllegalArgumentException => println(e.getMessage)
     }
   }
 }

--- a/test/files/neg/unicode-arrows-deprecation.check
+++ b/test/files/neg/unicode-arrows-deprecation.check
@@ -1,0 +1,15 @@
+unicode-arrows-deprecation.scala:4: warning: The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.
+  val a: Int ⇒ Int = x ⇒ x
+             ^
+unicode-arrows-deprecation.scala:4: warning: The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.
+  val a: Int ⇒ Int = x ⇒ x
+                       ^
+unicode-arrows-deprecation.scala:6: warning: The unicode arrow `←` is deprecated, use `<-` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.
+  val b = for { x ← (1 to 10) } yield x
+                  ^
+unicode-arrows-deprecation.scala:8: warning: method → in class ArrowAssoc is deprecated (since 2.13.0): Use `->` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.
+  val c: (Int, Int) = 1 → 1
+                        ^
+error: No warnings can be incurred under -Xfatal-warnings.
+four warnings found
+one error found

--- a/test/files/neg/unicode-arrows-deprecation.scala
+++ b/test/files/neg/unicode-arrows-deprecation.scala
@@ -1,0 +1,9 @@
+// scalac: -deprecation -Xfatal-warnings
+//
+object Test {
+  val a: Int ⇒ Int = x ⇒ x
+
+  val b = for { x ← (1 to 10) } yield x
+
+  val c: (Int, Int) = 1 → 1
+}

--- a/test/files/run/repl-no-imports-no-predef.check
+++ b/test/files/run/repl-no-imports-no-predef.check
@@ -18,17 +18,10 @@ scala>
 scala> { import scala.Predef.ArrowAssoc; 1 -> 2 }
 res5: (Int, Int) = (1,2)
 
-scala> { import scala.Predef.ArrowAssoc; 1 → 2 }
-res6: (Int, Int) = (1,2)
-
 scala> 1 -> 2
          ^
        error: value -> is not a member of Int
        did you mean >>>?
-
-scala> 1 → 2
-         ^
-       error: value → is not a member of Int
 
 scala> 
 
@@ -36,7 +29,7 @@ scala> val answer = 42
 answer: Int = 42
 
 scala> { import scala.StringContext; s"answer: $answer" }
-res9: String = answer: 42
+res7: String = answer: 42
 
 scala> s"answer: $answer"
        ^
@@ -45,7 +38,7 @@ scala> s"answer: $answer"
 scala> 
 
 scala> "abc" + true
-res11: String = abctrue
+res9: String = abctrue
 
 scala> 
 
@@ -72,12 +65,12 @@ scala>
 scala> 2 ; 3
        ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-res13: Int = 3
+res11: Int = 3
 
 scala> { 2 ; 3 }
          ^
        warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
-res14: Int = 3
+res12: Int = 3
 
 scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
 bippy = {
@@ -95,56 +88,56 @@ bippy = {
 defined object Cow
 defined class Moo
 bippy: Int
-res15: Int = 105
+res13: Int = 105
 
 scala> 
 
 scala> object Bovine { var x: scala.List[_] = null } ; case class Ruminant(x: scala.Int) ; bippy * bippy * bippy
 defined object Bovine
 defined class Ruminant
-res16: Int = 216
+res14: Int = 216
 
 scala> Bovine.x = scala.List(Ruminant(5), Cow, new Moo)
 mutated Bovine.x
 
 scala> Bovine.x
-res17: List[Any] = List(Ruminant(5), Cow, Moooooo)
+res15: List[Any] = List(Ruminant(5), Cow, Moooooo)
 
 scala> 
 
 scala> (2)
-res18: Int = 2
+res16: Int = 2
 
 scala> (2 + 2)
-res19: Int = 4
+res17: Int = 4
 
 scala> ((2 + 2))
-res20: Int = 4
+res18: Int = 4
 
 scala>   ((2 + 2))
-res21: Int = 4
+res19: Int = 4
 
 scala>   (  (2 + 2))
-res22: Int = 4
+res20: Int = 4
 
 scala>   (  (2 + 2 )  )
-res23: Int = 4
+res21: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
        ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
                    ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-res24: Int = 5
+res22: Int = 5
 
 scala> (((2 + 2)), ((2 + 2)))
-res25: (Int, Int) = (4,4)
+res23: (Int, Int) = (4,4)
 
 scala> (((2 + 2)), ((2 + 2)), 2)
-res26: (Int, Int, Int) = (4,4,2)
+res24: (Int, Int, Int) = (4,4,2)
 
 scala> (((((2 + 2)), ((2 + 2)), 2).productIterator ++ scala.Iterator(3)).mkString)
-res27: String = 4423
+res25: String = 4423
 
 scala> 
 
@@ -153,27 +146,27 @@ scala> 55 ; ((2 + 2)) ; (1, 2, 3)
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
                 ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-res28: (Int, Int, Int) = (1,2,3)
+res26: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: scala.Int) => x + 1 ; () => ((5))
        ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
                            ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-res29: () => Int = <function0>
+res27: () => Int = <function0>
 
 scala> 
 
 scala> () => 5
-res30: () => Int = <function0>
+res28: () => Int = <function0>
 
 scala> 55 ; () => 5
        ^
        warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-res31: () => Int = <function0>
+res29: () => Int = <function0>
 
 scala> () => { class X ; new X }
-res32: () => AnyRef = <function0>
+res30: () => AnyRef = <function0>
 
 scala> 
 
@@ -181,12 +174,12 @@ scala> def foo(x: scala.Int)(y: scala.Int)(z: scala.Int) = x+y+z
 foo: (x: Int)(y: Int)(z: Int)Int
 
 scala> foo(5)(10)(15)+foo(5)(10)(15)
-res33: Int = 60
+res31: Int = 60
 
 scala> 
 
 scala> scala.List(1) ++ scala.List('a')
-res34: List[AnyVal] = List(1, a)
+res32: List[AnyVal] = List(1, a)
 
 scala> 
 
@@ -201,7 +194,7 @@ EOF
 defined class C
 
 scala> new C().c
-res35: Int = 42
+res33: Int = 42
 
 scala> :paste <| EOF
 // Entering paste mode (EOF to finish)
@@ -214,7 +207,7 @@ EOF
 defined class D
 
 scala> new D().d
-res36: Int = 42
+res34: Int = 42
 
 scala> 
 
@@ -255,7 +248,7 @@ scala> case class BippyBungus()
 defined class BippyBungus
 
 scala> x1 + x2 + x3
-res37: Int = 6
+res35: Int = 6
 
 scala> :reset
 Resetting interpreter state.
@@ -267,7 +260,6 @@ Forgetting this session history:
 "abc"
 (1, 2)
 { import scala.Predef.ArrowAssoc; 1 -> 2 }
-{ import scala.Predef.ArrowAssoc; 1 → 2 }
 val answer = 42
 { import scala.StringContext; s"answer: $answer" }
 "abc" + true

--- a/test/files/run/repl-no-imports-no-predef.scala
+++ b/test/files/run/repl-no-imports-no-predef.scala
@@ -17,9 +17,7 @@ object Test extends scala.tools.partest.ReplTest {
 (1, 2)
 
 { import scala.Predef.ArrowAssoc; 1 -> 2 }
-{ import scala.Predef.ArrowAssoc; 1 → 2 }
 1 -> 2
-1 → 2
 
 val answer = 42
 { import scala.StringContext; s"answer: $answer" }

--- a/test/files/run/t7240/Macros_1.scala
+++ b/test/files/run/t7240/Macros_1.scala
@@ -22,9 +22,9 @@ object Bakery {
 
       val tpeName = newTypeName(names.head)
       names.tail.reverse match {
-        case head :: tail ⇒
-          Select(tail.foldLeft[Tree](Ident(newTermName(head)))((tree, name) ⇒ Select(tree, newTermName(name))), tpeName)
-        case Nil ⇒
+        case head :: tail =>
+          Select(tail.foldLeft[Tree](Ident(newTermName(head)))((tree, name) => Select(tree, newTermName(name))), tpeName)
+        case Nil =>
           Ident(tpeName)
       }
     }

--- a/test/files/run/t8091.scala
+++ b/test/files/run/t8091.scala
@@ -1,4 +1,4 @@
 object Test extends App {
-  val result = "börk börk" flatMap (ch ⇒ if (ch > 127) f"&#x${ch}%04x;" else "" + ch)
+  val result = "börk börk" flatMap (ch => if (ch > 127) f"&#x${ch}%04x;" else "" + ch)
   println(result)
 }


### PR DESCRIPTION
Fixes scala/scala-dev#585
Fixes https://github.com/scala/bug/issues/11210