### PR TITLE
Return a more specific type in Random.shuffle

### DIFF
--- a/src/library/scala/collection/BuildFrom.scala
+++ b/src/library/scala/collection/BuildFrom.scala
@@ -13,10 +13,9 @@
 package scala.collection
 
 import scala.language.higherKinds
-
 import scala.collection.mutable.Builder
 import scala.annotation.implicitNotFound
-
+import scala.collection.immutable.WrappedString
 import scala.reflect.ClassTag
 
 /** Builds a collection of type `C` from elements of type `A` when a source collection of type `From` is available.
@@ -63,6 +62,12 @@ object BuildFrom extends BuildFromLowPriority1 {
     new BuildFrom[String, Char, String] {
       def fromSpecific(from: String)(it: IterableOnce[Char]): String = Factory.stringFactory.fromSpecific(it)
       def newBuilder(from: String): Builder[Char, String] = Factory.stringFactory.newBuilder
+    }
+
+  implicit val buildFromWrappedString: BuildFrom[WrappedString, Char, WrappedString] =
+    new BuildFrom[WrappedString, Char, WrappedString] {
+      def fromSpecific(from: WrappedString)(it: IterableOnce[Char]): WrappedString = WrappedString.fromSpecific(it)
+      def newBuilder(from: WrappedString): mutable.Builder[Char, WrappedString] = WrappedString.newBuilder
     }
 
   implicit def buildFromArray[A : ClassTag]: BuildFrom[Array[_], A, Array[A]] =

--- a/src/library/scala/util/Random.scala
+++ b/src/library/scala/util/Random.scala
@@ -215,7 +215,7 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
    *
    *  @return         the shuffled collection
    */
-  def shuffle[T, CC[X] <: IterableOnce[X]](xs: CC[T])(implicit bf: BuildFrom[CC[T], T, CC[T]]): CC[T] = {
+  def shuffle[T, C](xs: IterableOnce[T])(implicit bf: BuildFrom[xs.type, T, C]): C = {
     val buf = new ArrayBuffer[T] ++= xs
 
     def swap(i1: Int, i2: Int): Unit = {

--- a/test/junit/scala/util/RandomTest.scala
+++ b/test/junit/scala/util/RandomTest.scala
@@ -1,6 +1,8 @@
 package scala.util
 
-import org.junit.{ Assert, Test }
+import org.junit.{Assert, Test}
+
+import scala.collection.immutable.WrappedString
 
 class RandomTest {
   // Test for scala/bug#9059
@@ -11,5 +13,15 @@ class RandomTest {
     for (c <- items) {
       Assert.assertTrue(s"$c should be alphanumeric", isAlphaNum(c))
     }
+  }
+
+  // These tests check that the static type returned by `Random.shuffle` is as specific as possible
+  @Test def testShuffle: Unit = {
+    val s = Random.shuffle("bar")
+    val sT: WrappedString = s
+    val ws = Random.shuffle("bar".toSeq)
+    val wsT: WrappedString = ws
+    val lhm = Random.shuffle(collection.mutable.LinkedHashMap("foo" -> 1, "bar" -> 2))
+    val lhmT: collection.mutable.LinkedHashMap[String, Int] = lhm
   }
 }


### PR DESCRIPTION
Also add a missing BuildFrom[WrappedString] instance.

These changes make `Random.shuffle` work with `String`, `WrappedString`
and `SeqMap` collections.

Fixes scala/bug#11315