### PR TITLE
Optimize s.c.m.Set#filterInPlace implementations

### DIFF
--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -187,8 +187,11 @@ private[collection] trait Wrappers {
     }
     override def remove(elem: AnyRef) =
       try underlying.remove(elem.asInstanceOf[A])
-      catch { case ex: ClassCastException => false }
-    override def clear() = underlying.clear()
+      catch { case _: ClassCastException => false }
+
+    override def clear(): Unit = {
+      underlying.clear()
+    }
   }
 
   @SerialVersionUID(3L)
@@ -197,7 +200,7 @@ private[collection] trait Wrappers {
     override def size = underlying.size
     override def isEmpty: Boolean = underlying.isEmpty
     override def knownSize: Int = if (underlying.isEmpty) 0 else super.knownSize
-    def iterator = underlying.iterator.asScala
+    def iterator: Iterator[A] = underlying.iterator.asScala
 
     def contains(elem: A): Boolean = underlying.contains(elem)
 
@@ -205,15 +208,20 @@ private[collection] trait Wrappers {
     def subtractOne(elem: A): this.type = { underlying remove elem; this }
 
     override def remove(elem: A): Boolean = underlying remove elem
-    override def clear() = underlying.clear()
+    override def clear(): Unit = underlying.clear()
 
-    override def empty = JSetWrapper(new ju.HashSet[A])
+    override def empty: mutable.Set[A] = JSetWrapper(new ju.HashSet[A])
     // Note: Clone cannot just call underlying.clone because in Java, only specific collections
     // expose clone methods.  Generically, they're protected.
-    override def clone() =
+    override def clone(): mutable.Set[A] =
       new JSetWrapper[A](new ju.LinkedHashSet[A](underlying))
 
-    override def iterableFactory = mutable.HashSet
+    override def iterableFactory: IterableFactory[mutable.Set] = mutable.HashSet
+
+    override def filterInPlace(p: A => Boolean): this.type = {
+      if (underlying.size() > 0) underlying.removeIf(!p(_))
+      this
+    }
   }
 
   @SerialVersionUID(3L)

--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -222,6 +222,7 @@ private[collection] trait Wrappers {
       if (underlying.size() > 0) underlying.removeIf(!p(_))
       this
     }
+    def superFilterInPlace(p: A => Boolean): this.type = super.filterInPlace(p)
   }
 
   @SerialVersionUID(3L)

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -13,7 +13,6 @@
 package scala.collection
 package mutable
 
-import scala.annotation.meta.{getter, setter}
 import scala.annotation.tailrec
 import scala.collection.generic.DefaultSerializationProxy
 
@@ -201,6 +200,40 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
         oldlen *= 2
       }
     }
+  }
+
+  override def filterInPlace(p: A => Boolean): this.type = {
+    if (nonEmpty) {
+      var bucket = 0
+
+      while (bucket < table.length) {
+        var head = table(bucket)
+
+        while ((head ne null) && !p(head.key)) {
+          head = head.next
+          contentSize -= 1
+        }
+
+        if (head ne null) {
+          var prev = head
+          var next = head.next
+
+          while (next ne null) {
+            if (p(next.key)) {
+              prev = next
+            } else {
+              prev.next = next.next
+              contentSize -= 1
+            }
+            next = next.next
+          }
+        }
+
+        table(bucket) = head
+        bucket += 1
+      }
+    }
+    this
   }
 
   /*

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -202,6 +202,8 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
     }
   }
 
+  def superFilterInPlace(p: A => Boolean): this.type = super.filterInPlace(p)
+
   override def filterInPlace(p: A => Boolean): this.type = {
     if (nonEmpty) {
       var bucket = 0

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -131,6 +131,14 @@ private[mutable] abstract class HashTable[A, B, Entry >: Null <: HashEntry[A, En
     foreachEntry(writeEntry)
   }
 
+  /** Get the entry at a given index, or null if none exist */
+  final def apply(index: Int): Entry = table(index).asInstanceOf[Entry]
+
+  /** Set the entry at bucket `index` to `entry` */
+  final def update(index: Int, entry: Entry): Unit = {
+    table(index) = entry
+  }
+
   /** Find entry with given key in table, null if not found.
    */
   final def findEntry(key: A): Entry =

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -94,6 +94,7 @@ class LinkedHashSet[A]
       true
     }
   }
+  def superFilterInPlace(p: A => Boolean): this.type = super.filterInPlace(p)
 
   override def filterInPlace(p: A => Boolean): this.type = {
     if (size > 0) {

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -78,15 +78,17 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     *             are removed.
     */
   def filterInPlace(p: A => Boolean): this.type = {
-    val array = this.toArray[Any] // scala/bug#7269 toArray avoids ConcurrentModificationException
-    val arrayLength = array.length
-    var i = 0
-    while (i < arrayLength) {
-      val elem = array(i).asInstanceOf[A]
-      if (!p(elem)) {
-        this -= elem
+    if (nonEmpty) {
+      val array = this.toArray[Any] // scala/bug#7269 toArray avoids ConcurrentModificationException
+      val arrayLength = array.length
+      var i = 0
+      while (i < arrayLength) {
+        val elem = array(i).asInstanceOf[A]
+        if (!p(elem)) {
+          this -= elem
+        }
+        i += 1
       }
-      i += 1
     }
     this
   }

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -78,8 +78,16 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     *             are removed.
     */
   def filterInPlace(p: A => Boolean): this.type = {
-    for (elem <- this.toList) // scala/bug#7269 toList avoids ConcurrentModificationException
-      if (!p(elem)) this -= elem
+    val array = this.toArray[Any] // scala/bug#7269 toArray avoids ConcurrentModificationException
+    val arrayLength = array.length
+    var i = 0
+    while (i < arrayLength) {
+      val elem = array(i).asInstanceOf[A]
+      if (!p(elem)) {
+        this -= elem
+      }
+      i += 1
+    }
     this
   }
 

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -13,9 +13,8 @@
 package scala
 package collection.mutable
 
-import collection.{SortedIterableFactory, StrictOptimizedIterableOps, StrictOptimizedSortedSetOps}
+import collection.{SortedIterableFactory, StrictOptimizedIterableOps, StrictOptimizedSortedSetOps, mutable}
 import collection.mutable.{RedBlackTree => RB}
-
 import java.lang.String
 
 /**
@@ -87,6 +86,18 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
   override def maxBefore(key: A): Option[A] = RB.maxKeyBefore(tree, key)
 
   override def foreach[U](f: A => U): Unit = RB.foreachKey(tree, f)
+
+  override def filterImpl(pred: A => Boolean, isFlipped: Boolean): mutable.TreeSet[A] = {
+    // This method has been preemptively overridden to allow an optimized implementation to be written without breaking
+    // binary compatibility throughout the 2.13.X releases
+    super.filterImpl(pred, isFlipped)
+  }
+
+  override def filterInPlace(p: A => Boolean): this.type = {
+    // This method has been preemptively overridden to allow an optimized implementation to be written without breaking
+    // binary compatibility throughout the 2.13.X releases
+    super.filterInPlace(p)
+  }
 
 
   /**

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/SetBenchmark2.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/SetBenchmark2.scala
@@ -1,0 +1,17 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.mutable
+
+class SetBenchmark2 {
+
+}

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/SetBenchmark2.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/SetBenchmark2.scala
@@ -1,17 +1,62 @@
-/*
- * Scala (https://www.scala-lang.org)
- *
- * Copyright EPFL and Lightbend, Inc.
- *
- * Licensed under Apache License 2.0
- * (http://www.apache.org/licenses/LICENSE-2.0).
- *
- * See the NOTICE file distributed with this work for
- * additional information regarding copyright ownership.
- */
-
 package scala.collection.mutable
 
-class SetBenchmark2 {
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+import org.openjdk.jmh.runner.IterationType
+import benchmark._
+import java.util.concurrent.TimeUnit
+import java.util.{HashSet => JHashSet}
 
+import scala.collection.convert.Wrappers
+import scala.collection.convert.Wrappers.JSetWrapper
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class SetBenchmark2 {
+  @Param(Array("0", "1", "10", "100", "1000", "10000", "100000", "1000000"))
+  var size: Int = _
+//  @Param(Array("HashSet"))//, "LinkedHashSet", "JSetWrapper"))
+//  var setType: String = _
+
+  var hashSet: HashSet[Int] = _
+  var lhs: LinkedHashSet[Int] = _
+  var jsw: JSetWrapper[Int] = _
+
+  val pred: Int => Boolean = (i: Int) => i % 2 == 0
+
+  @Setup(Level.Invocation) def init: Unit = {
+    val elems = (0 until size)
+    hashSet = elems.to(collection.mutable.HashSet)
+    lhs = elems.to(collection.mutable.LinkedHashSet)
+    val jSet = new JHashSet[Int]()
+    elems.foreach(jSet.add)
+    jsw =JSetWrapper(jSet)
+  }
+
+//  @Benchmark def filterInPlace_new(bh: Blackhole): Unit = {
+//    bh.consume(set.filterInPlace(pred))
+//  }
+  @Benchmark def HashSet_super_filterInPlace(bh: Blackhole): Unit = {
+    bh.consume(hashSet.superFilterInPlace(pred))
+  }
+  @Benchmark def HashSet_filterInPlace(bh: Blackhole): Unit = {
+    bh.consume(hashSet.filterInPlace(pred))
+  }
+  @Benchmark def LinkedHashSet_super_filterInPlace(bh: Blackhole): Unit = {
+    bh.consume(lhs.superFilterInPlace(pred))
+  }
+  @Benchmark def LinkedHashSet_filterInPlace(bh: Blackhole): Unit = {
+    bh.consume(lhs.filterInPlace(pred))
+  }
+  @Benchmark def JSetWrapper_super_filterInPlace(bh: Blackhole): Unit = {
+    bh.consume(jsw.superFilterInPlace(pred))
+  }
+  @Benchmark def JSetWrapper_filterInPlace(bh: Blackhole): Unit = {
+    bh.consume(jsw.filterInPlace(pred))
+  }
 }

--- a/test/junit/scala/collection/mutable/LinkedHashSetTest.scala
+++ b/test/junit/scala/collection/mutable/LinkedHashSetTest.scala
@@ -12,6 +12,19 @@ class LinkedHashSetTest {
   class TestClass extends mutable.LinkedHashSet[String] {
     def lastItemRef = lastEntry
   }
+
+  @Test
+  def foo: Unit = {
+    def go(n: Int): Unit = {
+      val lhs = (1 to n).to(LinkedHashSet)
+
+      print(lhs.getTable.table.count(_ eq null))
+      print(" ")
+      println(lhs.getTable.table.count(_ ne null))
+    }
+
+    List(1, 10, 100, 1000, 10000, 100000, 1000000, 10000000).foreach(go)
+  }
   
   @Test
   def testClear: Unit = {

--- a/test/scalacheck/scala/collection/convert/WrapperProperties.scala
+++ b/test/scalacheck/scala/collection/convert/WrapperProperties.scala
@@ -1,0 +1,44 @@
+package scala.collection.convert
+import java.util
+import java.util.function.Predicate
+
+import org.scalacheck._
+import org.scalacheck.Prop._
+
+import scala.collection.immutable
+
+object WrapperProperties extends Properties("Wrappers") {
+  override def overrideParameters(p: Test.Parameters): Test.Parameters = p.withInitialSeed(42L)
+
+  property("JSetWrapper#filterInPlace(p)") = forAll { hs: immutable.HashSet[Int] =>
+    val p = (i: Int) => i % 2 == 0
+    val expected: collection.Set[Int] = hs.filter(p)
+    val actual: collection.Set[Int] = {
+      val jset = new util.HashSet[Int]()
+      hs.foreach(jset.add)
+      Wrappers.JSetWrapper(jset)
+    }.filterInPlace(p)
+    actual ?= expected
+  }
+  property("MutableSetWrapper#filterInPlace(p)") = forAll { hs: immutable.HashSet[Int] =>
+    val p = (i: Int) => i % 2 == 0
+
+    val expected: (util.Set[Int], Boolean) = {
+      val jset = new util.HashSet[Int]
+      hs.foreach(jset.add)
+      (jset, jset.removeIf(new Predicate[Int] {
+        override def test(t: Int): Boolean = !p(t)
+      }))
+    }
+
+    val actual: (util.Set[Int], Boolean) = {
+      val jset = Wrappers.MutableSetWrapper(hs.to(collection.mutable.Set))
+      (jset, jset.removeIf(new Predicate[Int] {
+        override def test(t: Int): Boolean = !p(t)
+      }))
+    }
+
+    actual ?= expected
+  }
+
+}

--- a/test/scalacheck/scala/collection/mutable/HashSetProperties.scala
+++ b/test/scalacheck/scala/collection/mutable/HashSetProperties.scala
@@ -1,0 +1,15 @@
+package scala.collection.mutable
+import org.scalacheck._
+import org.scalacheck.Prop._
+import scala.collection.immutable
+object HashSetProperties extends Properties("mutable.HashSet") {
+  override def overrideParameters(p: Test.Parameters): Test.Parameters =
+      p.withInitialSeed(42L)
+
+  property("filterInPlace(p)") = forAll { hs: immutable.HashSet[Int] =>
+    val p = (i: Int) => i % 2 == 0
+    val expected: collection.Set[Int] = hs.filter(p)
+    val actual: collection.Set[Int] = hs.to(HashSet).filterInPlace(p)
+    actual ?= expected
+  }
+}

--- a/test/scalacheck/scala/collection/mutable/LinkedHashMapProperties.scala
+++ b/test/scalacheck/scala/collection/mutable/LinkedHashMapProperties.scala
@@ -1,0 +1,15 @@
+package scala.collection.mutable
+import org.scalacheck._
+import org.scalacheck.Prop._
+import scala.collection.immutable
+object LinkedHashMapProperties extends Properties("mutable.LinkedHashMap") {
+  override def overrideParameters(p: Test.Parameters): Test.Parameters =
+    p.withInitialSeed(42L)
+
+  property("filterInPlace(p)") = forAll { v: Vector[(Int, Int)] =>
+    val p = (i: Int, j: Int) => (i + j) % 2 == 0
+    val expected: collection.Map[Int, Int] = v.to(immutable.HashMap).filter(p.tupled)
+    val actual: collection.Map[Int, Int] = v.to(LinkedHashMap).filterInPlace(p)
+    actual ?= expected
+  }
+}

--- a/test/scalacheck/scala/collection/mutable/LinkedHashSetProperties.scala
+++ b/test/scalacheck/scala/collection/mutable/LinkedHashSetProperties.scala
@@ -1,0 +1,15 @@
+package scala.collection.mutable
+import org.scalacheck._
+import org.scalacheck.Prop._
+import scala.collection.immutable
+object LinkedHashSetProperties extends Properties("mutable.LinkedHashSet") {
+  override def overrideParameters(p: Test.Parameters): Test.Parameters =
+    p.withInitialSeed(42L)
+
+  property("filterInPlace(p)") = forAll { v: Vector[Int] =>
+    val p = (i: Int) => i % 2 == 0
+    val expected: collection.Set[Int] = v.to(immutable.HashSet).filter(p)
+    val actual: collection.Set[Int] = v.to(LinkedHashSet).filterInPlace(p)
+    (actual ?= expected) && expected.subsetOf(actual)
+  }
+}


### PR DESCRIPTION
inlcuding:
* s.c.m.HashSet
* s.c.m.LinkedHashSet
* JSetWrapper forwards to underlying.removeIf
* ~forward MutableJsetWrapper#removeIf to underlying.filterInPlace~
* Add preemptive overrides for mutable.TreeSet#filterInPlace and filterImpl
* s.c.m.LinkedHashMap

## TODO

- [x] Create some good benchmarks to confirm that this actually is beneficial


## Benchmarks

* Turned out that it's slower to forward JSetWrapper#removeIf to underlying.filterInPlace
* Everything else is ~40% faster or so, ~except for very large (1million+) sized LinkedHashMaps. I'm not sure why at large sizes the old beats the new one, something to look into. Still, probably worth it for the great speedups at smaller sizes I'd say~. Fixed it, now it's faster at all sizes (benchmarks appended below)


```
Set Benchmarks

HashSet

[info] Benchmark                              (size)  Mode  Cnt         Score         Error  Units
[info] SetBenchmark.hashSetFilterInPlaceNew        0  avgt    6        20.642 ±       0.570  ns/op
[info] SetBenchmark.hashSetFilterInPlaceNew        1  avgt    6        37.340 ±       0.517  ns/op
[info] SetBenchmark.hashSetFilterInPlaceNew       10  avgt    6        74.699 ±       1.608  ns/op
[info] SetBenchmark.hashSetFilterInPlaceNew      100  avgt    6       719.398 ±      28.625  ns/op
[info] SetBenchmark.hashSetFilterInPlaceNew     1000  avgt    6      6081.337 ±     916.343  ns/op
[info] SetBenchmark.hashSetFilterInPlaceNew  1000000  avgt    6  10756491.709 ± 6216937.005  ns/op
[info] SetBenchmark.hashSetFilterInPlaceOld        0  avgt    6        22.983 ±       0.787  ns/op
[info] SetBenchmark.hashSetFilterInPlaceOld        1  avgt    6        58.709 ±       1.616  ns/op
[info] SetBenchmark.hashSetFilterInPlaceOld       10  avgt    6       200.766 ±       5.058  ns/op
[info] SetBenchmark.hashSetFilterInPlaceOld      100  avgt    6      1314.876 ±      19.072  ns/op
[info] SetBenchmark.hashSetFilterInPlaceOld     1000  avgt    6     10476.401 ±     167.688  ns/op
[info] SetBenchmark.hashSetFilterInPlaceOld  1000000  avgt    6  16159382.390 ± 3181990.396  ns/op

LinkedHashSet

[info] Benchmark                          (size)  Mode  Cnt         Score          Error  Units
[info] SetBenchmark.lhsFilterInPlaceNew        0  avgt    6        21.562 ±        0.163  ns/op
[info] SetBenchmark.lhsFilterInPlaceNew        1  avgt    6        40.113 ±        2.406  ns/op
[info] SetBenchmark.lhsFilterInPlaceNew       10  avgt    6        80.435 ±        2.422  ns/op
[info] SetBenchmark.lhsFilterInPlaceNew      100  avgt    6       618.553 ±       10.477  ns/op
[info] SetBenchmark.lhsFilterInPlaceNew     1000  avgt    6     14805.856 ±      374.524  ns/op
[info] SetBenchmark.lhsFilterInPlaceNew  1000000  avgt    6  79483415.292 ±  2776669.384  ns/op
[info] SetBenchmark.lhsFilterInPlaceOld        0  avgt    6        21.479 ±        0.104  ns/op
[info] SetBenchmark.lhsFilterInPlaceOld        1  avgt    6       119.541 ±        9.858  ns/op
[info] SetBenchmark.lhsFilterInPlaceOld       10  avgt    6       235.250 ±        7.125  ns/op
[info] SetBenchmark.lhsFilterInPlaceOld      100  avgt    6      2136.341 ±       66.079  ns/op
[info] SetBenchmark.lhsFilterInPlaceOld     1000  avgt    6     17373.401 ±      193.661  ns/op
[info] SetBenchmark.lhsFilterInPlaceOld  1000000  avgt    6  61029471.158 ± 25085732.002  ns/op

JSetWrapper

[info] Benchmark                                  (size)  Mode  Cnt         Score         Error  Units
[info] SetBenchmark.jsetWrapperFilterInPlaceNew        0  avgt    6        23.334 ±       0.279  ns/op
[info] SetBenchmark.jsetWrapperFilterInPlaceNew        1  avgt    6        43.792 ±       0.612  ns/op
[info] SetBenchmark.jsetWrapperFilterInPlaceNew       10  avgt    6       107.306 ±       4.030  ns/op
[info] SetBenchmark.jsetWrapperFilterInPlaceNew      100  avgt    6       932.517 ±      11.078  ns/op
[info] SetBenchmark.jsetWrapperFilterInPlaceNew     1000  avgt    6      7812.614 ±     159.583  ns/op
[info] SetBenchmark.jsetWrapperFilterInPlaceNew  1000000  avgt    6  10011237.971 ±  268929.575  ns/op
[info] SetBenchmark.jsetWrapperFilterInPlaceOld        0  avgt    6        24.300 ±       0.213  ns/op
[info] SetBenchmark.jsetWrapperFilterInPlaceOld        1  avgt    6        79.599 ±       2.664  ns/op
[info] SetBenchmark.jsetWrapperFilterInPlaceOld       10  avgt    6       285.031 ±      16.937  ns/op
[info] SetBenchmark.jsetWrapperFilterInPlaceOld      100  avgt    6      1938.743 ±      18.156  ns/op
[info] SetBenchmark.jsetWrapperFilterInPlaceOld     1000  avgt    6     20505.604 ±     520.052  ns/op
[info] SetBenchmark.jsetWrapperFilterInPlaceOld  1000000  avgt    6  21605549.296 ± 5291256.367  ns/op


SetWrapper

// !!! The below benchmarks determined the old implementation was faster, so that change has been reverted!

[info] Benchmark                                   (size)  Mode  Cnt         Score         Error  Units
[info] SetBenchmark.mutableSetWrapperRemoveIfNew        0  avgt    6        21.505 ±       0.308  ns/op
[info] SetBenchmark.mutableSetWrapperRemoveIfNew        1  avgt    6        51.029 ±       0.893  ns/op
[info] SetBenchmark.mutableSetWrapperRemoveIfNew       10  avgt    6       134.889 ±       1.601  ns/op
[info] SetBenchmark.mutableSetWrapperRemoveIfNew      100  avgt    6      1353.354 ±      27.763  ns/op
[info] SetBenchmark.mutableSetWrapperRemoveIfNew     1000  avgt    6     15635.084 ±    9842.301  ns/op
[info] SetBenchmark.mutableSetWrapperRemoveIfNew  1000000  avgt    6  11980124.763 ± 2516868.853  ns/op
[info] SetBenchmark.mutableSetWrapperRemoveIfOld        0  avgt    6        33.541 ±       2.788  ns/op
[info] SetBenchmark.mutableSetWrapperRemoveIfOld        1  avgt    6        41.562 ±       1.162  ns/op
[info] SetBenchmark.mutableSetWrapperRemoveIfOld       10  avgt    6       108.295 ±       3.015  ns/op
[info] SetBenchmark.mutableSetWrapperRemoveIfOld      100  avgt    6       881.835 ±      44.200  ns/op
[info] SetBenchmark.mutableSetWrapperRemoveIfOld     1000  avgt    6      7853.866 ±     175.839  ns/op
[info] SetBenchmark.mutableSetWrapperRemoveIfOld  1000000  avgt    6   9396194.135 ±  575615.688  ns/op

```

```
LinkedHashSet

[info] Benchmark                          (size)  Mode  Cnt          Score          Error  Units
[info] SetBenchmark.lhsFilterInPlaceNew        0  avgt    6         21.896 ±        0.513  ns/op
[info] SetBenchmark.lhsFilterInPlaceNew        1  avgt    6         35.793 ±        0.313  ns/op
[info] SetBenchmark.lhsFilterInPlaceNew       10  avgt    6         74.467 ±        2.220  ns/op
[info] SetBenchmark.lhsFilterInPlaceNew      100  avgt    6        545.094 ±       19.071  ns/op
[info] SetBenchmark.lhsFilterInPlaceNew     1000  avgt    6       9972.029 ±      308.070  ns/op
[info] SetBenchmark.lhsFilterInPlaceNew  1000000  avgt    6   58538950.667 ±  3206886.603  ns/op
[info] SetBenchmark.lhsFilterInPlaceNew  2000000  avgt    6  120526442.167 ±  8950859.500  ns/op
[info] SetBenchmark.lhsFilterInPlaceOld        0  avgt    6         22.343 ±        0.899  ns/op
[info] SetBenchmark.lhsFilterInPlaceOld        1  avgt    6        113.013 ±        4.684  ns/op
[info] SetBenchmark.lhsFilterInPlaceOld       10  avgt    6        227.760 ±        6.784  ns/op
[info] SetBenchmark.lhsFilterInPlaceOld      100  avgt    6       1878.171 ±       70.605  ns/op
[info] SetBenchmark.lhsFilterInPlaceOld     1000  avgt    6      17791.455 ±     1588.061  ns/op
[info] SetBenchmark.lhsFilterInPlaceOld  1000000  avgt    6   63002982.083 ± 21877377.837  ns/op
[info] SetBenchmark.lhsFilterInPlaceOld  2000000  avgt    6  151673581.250 ± 85351947.209  ns/op
```