### PR TITLE
t10729 annotation usage should extend annotation and Seq won't slay compiler

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -442,6 +442,10 @@ trait ContextErrors {
         setError(tree)
       }
 
+      def DoesNotExtendAnnotation(tree: Tree, sym: Symbol) = {
+        NormalTypeError(tree, s"$sym does not extend ${AnnotationClass.fullName}")
+      }
+
       def DoesNotConformToSelfTypeError(tree: Tree, sym: Symbol, tpe0: Type) = {
         issueNormalTypeError(tree, sym + " cannot be instantiated because it does not conform to its self-type " + tpe0)
         setError(tree)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3923,8 +3923,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       // begin typedAnnotation
       val treeInfo.Applied(fun0, targs, argss) = ann
-      if (fun0.isErroneous)
-        return finish(ErroneousAnnotation)
+      if (fun0.isErroneous) return finish(ErroneousAnnotation)
       val typedFun0 = typed(fun0, mode.forFunMode)
       val typedFunPart = (
         // If there are dummy type arguments in typeFun part, it suggests we
@@ -3935,10 +3934,24 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         else
           typedFun0
       )
+      if (typedFunPart.isErroneous) return finish(ErroneousAnnotation)
+
       val treeInfo.Applied(typedFun @ Select(New(annTpt), _), _, _) = typedFunPart
       val annType = annTpt.tpe // for a polymorphic annotation class, this type will have unbound type params (see context.undetparams)
       val annTypeSym = annType.typeSymbol
       val isJava = annType != null && annTypeSym.isJavaDefined
+
+      typedFun0 match {
+        case Select(New(a), _) =>
+
+          val typedFun0ExtendsAnn = a.tpe.dealiasWiden.typeSymbol.isJavaAnnotation || a.tpe <:< AnnotationClass.tpe
+
+          if (!typedFun0ExtendsAnn){
+            reportAnnotationError(DoesNotExtendAnnotation(typedFun0, a.tpe.typeSymbol.initialize))
+            return finish(ErroneousAnnotation)
+          }
+        case _ =>
+      }
 
       @inline def constantly = {
         // Arguments of Java annotations and ConstantAnnotations are checked to be constants and
@@ -4722,8 +4735,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         val tp = tpt1.tpe
         val sym = tp.typeSymbol.initialize
+
         if ((sym.isAbstractType || sym.hasAbstractFlag)
-            && !(sym.isJavaAnnotation && context.inAnnotation))
+          && !(sym.isJavaAnnotation && context.inAnnotation))
           IsAbstractError(tree, sym)
         else if (isPrimitiveValueClass(sym)) {
           NotAMemberError(tpt, TypeTree(tp), nme.CONSTRUCTOR, startingIdentContext)

--- a/test/files/neg/t10729.check
+++ b/test/files/neg/t10729.check
@@ -1,0 +1,20 @@
+AbstractAnnotation.scala:6: error: class AbstractAnnotation is abstract; cannot be instantiated
+  1: @AbstractAnnotation
+      ^
+ArrayAsAnnotation.scala:2: error: class Array does not extend scala.annotation.Annotation
+  1: @Array(10)
+      ^
+SeqAsAnnotation.scala:2: error: trait Seq is abstract; cannot be instantiated
+  1: @Seq(10)
+      ^
+Switch.scala:1: warning: imported `switch` is permanently hidden by definition of class switch
+import annotation.switch
+                  ^
+Switch.scala:4: error: class switch does not extend scala.annotation.Annotation
+  def test(x: Int) = (x: @switch) match {
+                          ^
+TraitAnnotation.scala:6: error: trait TraitAnnotation is abstract; cannot be instantiated
+  1: @TraitAnnotation
+      ^
+one warning found
+5 errors found

--- a/test/files/neg/t10729/AbstractAnnotation.scala
+++ b/test/files/neg/t10729/AbstractAnnotation.scala
@@ -1,0 +1,7 @@
+import scala.annotation.Annotation
+
+abstract class AbstractAnnotation() extends Annotation {}
+
+object AbstractAnnotationFail {
+  1: @AbstractAnnotation
+}

--- a/test/files/neg/t10729/ArrayAsAnnotation.scala
+++ b/test/files/neg/t10729/ArrayAsAnnotation.scala
@@ -1,0 +1,3 @@
+object ArrayAsAnnotation {
+  1: @Array(10)
+}

--- a/test/files/neg/t10729/SeqAsAnnotation.scala
+++ b/test/files/neg/t10729/SeqAsAnnotation.scala
@@ -1,0 +1,3 @@
+object SeqAsAnnotation {
+  1: @Seq(10)
+}

--- a/test/files/neg/t10729/Switch.scala
+++ b/test/files/neg/t10729/Switch.scala
@@ -1,0 +1,7 @@
+import annotation.switch
+
+class switch {
+  def test(x: Int) = (x: @switch) match {
+    case 1 | 2 | 3 => ()
+  }
+}

--- a/test/files/neg/t10729/TraitAnnotation.scala
+++ b/test/files/neg/t10729/TraitAnnotation.scala
@@ -1,0 +1,7 @@
+import scala.annotation.Annotation
+
+trait TraitAnnotation extends Annotation {}
+
+object TraitAnnotationFail {
+  1: @TraitAnnotation
+}

--- a/test/files/pos/t10497.scala
+++ b/test/files/pos/t10497.scala
@@ -1,5 +1,7 @@
+import scala.annotation._
+
 // also works with subsets of {@annotation.meta.field @annotation.meta.getter @annotation.meta.setter}
-class baz(out: Foo => Int)
+class baz(out: Foo => Int) extends StaticAnnotation
 
 class Foo {
   @baz(out = _.value) val value: Int = 5


### PR DESCRIPTION
Issue: https://github.com/scala/bug/issues/10729

The linked issue says `1: Array(10)` should slay the compiler but it seems like that doesn't anymore after talking to @hrhino. Instead, I got some an error about an unexpected tree. However `1: Seq(10)` did slay.

This fix gives a more descriptive error for the Array case and prevents a slay for the Seq case.

Fixes scala/bug#11428