### PR TITLE
Add `identity` function to `scala.Function`.

### DIFF
--- a/src/library/scala/Function.scala
+++ b/src/library/scala/Function.scala
@@ -28,6 +28,15 @@ object Function {
   /** The constant function */
   def const[T, U](x: T)(y: U): T = x
 
+  /**
+   * Returns a function that always returns its input argument as result.
+   * Which could be used as a function argument passed to `map` or `flatMap` methods.
+   * Learn more from [[https://en.wikipedia.org/wiki/Identity_function Identity_function]]
+   * @tparam T the type of the input and output value of the function
+   * @return a function that always returns its input argument as result.
+   */
+  def identity[T]: T => T = t => t
+
   /** Turns a function `A => Option[B]` into a `PartialFunction[A, B]`.
    *
    *  '''Important note''': this transformation implies the original function

--- a/test/junit/scala/FunctionTest.scala
+++ b/test/junit/scala/FunctionTest.scala
@@ -1,0 +1,26 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import org.junit.{Assert, Test}
+
+class FunctionTest {
+
+  @Test
+  def `testFunction#identity`(): Unit = {
+    val input: Int = 1
+    val result = Function.identity[Int].apply(input)
+    Assert.assertEquals(input, result)
+    Assert.assertTrue(result.getClass == classOf[Int])
+  }
+}


### PR DESCRIPTION
Now, Scala has what's Java has too.