### PR TITLE
Fixed bug #11306. Added Junit test to ListMapTest

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -127,11 +127,21 @@ sealed class ListMap[K, +V]
       else containsInternal(cur.next, k)
 
     override def updated[V2 >: V1](k: K, v: V2): ListMap[K, V2] = {
-      val m = this - k
-      new m.Node[V2](k, v)
+      replaceInternal(k, v, this, Nil)
     }
 
-    override def remove(k: K): ListMap[K, V1] = removeInternal(k, this, Nil)
+    @tailrec private[this] def replaceInternal[V2 >: V1](k: K, v : V2, cur: ListMap[K, V2], acc: List[ListMap[K, V2]]): ListMap[K, V2] =
+      if (cur.isEmpty) new this.Node(k,v)
+      else if (k == cur.key) {
+        val nextNode : ListMap[K, V2] = cur.next
+        val updatedCurrentNode : ListMap[K, V2] = new nextNode.Node(k,v)
+        acc.foldLeft(updatedCurrentNode) { (t, h) => new t.Node(h.key, h.value) }
+      }
+      else replaceInternal(k, v, cur.next, cur :: acc)
+
+    override def remove(k: K): ListMap[K, V1] = {
+      removeInternal(k, this, Nil)
+    }
 
     @tailrec private[this] def removeInternal(k: K, cur: ListMap[K, V1], acc: List[ListMap[K, V1]]): ListMap[K, V1] =
       if (cur.isEmpty) acc.last

--- a/test/junit/scala/collection/immutable/ListMapTest.scala
+++ b/test/junit/scala/collection/immutable/ListMapTest.scala
@@ -14,10 +14,14 @@ class ListMapTest {
     assertEquals(ListMap(2 -> 2, 3 -> 3, 4 -> 4, 5 -> 5), m.tail)
   }
 
+  /*
+  Modifying this test to make up for the fix (bug #11306)
+  where updating existing key retains its position
+   */
   @Test
   def hasCorrectBuilder(): Unit = {
     val m = ListMap("a" -> "1", "b" -> "2", "c" -> "3", "b" -> "2.2", "d" -> "4")
-    assertEquals(List("a" -> "1", "c" -> "3", "b" -> "2.2", "d" -> "4"), m.toList)
+    assertEquals(List("a" -> "1","b" -> "2.2", "c" -> "3",  "d" -> "4"), m.toList)
   }
 
   @Test
@@ -50,5 +54,16 @@ class ListMapTest {
   def keysShouldPreserveOrderAsInserted: Unit = {
     val m = ListMap("a" -> "1", "b" -> "2", "c" -> "3", "d" -> "4", "e" -> "5")
     assertEquals(List("A", "B", "C", "D", "E"), m.keys.map(_.toUpperCase).toList)
+  }
+
+  @Test
+  def updatingExistingKeyShouldRetainItsPosition : Unit = {
+    val m = ListMap(1 -> 100, 2 -> 200, 3 -> 500, 10 -> 455)
+    val newNode1 = (2 -> 2343)
+    val result1 = m + newNode1
+    assertEquals(result1, ListMap(1 -> 100, newNode1, 3 -> 500, 10 -> 455))
+    val newNode2 = (1 -> 101)
+    val result2 = result1 + newNode2
+    assertEquals(result2, ListMap(1 -> 101, newNode1, 3 -> 500, 10 -> 455))
   }
 }


### PR DESCRIPTION
I have fixed the bug where in the position of the node in listmap is retained if a new node with an existing key is added. 
I can see that the pull request https://github.com/scala/scala/pull/7547 has fixed this issue. But I still think that my change is better (IMHO) as does it in 3 lines as compared to the above pull request which has done it an elaborate way. I have only added a method called 

> replaceInternal

I would request the reviewers to look at the difference in both the fixes and accept the right one.

Fixed scala/bug#11306