### PR TITLE
Adds regression tests for Scala Bug 9061

### DIFF
--- a/test/files/pos/t9061.scala
+++ b/test/files/pos/t9061.scala
@@ -1,0 +1,30 @@
+object original {
+  trait Bar[T] {
+    val value: T
+  }
+
+  object Bar {
+    def apply[T](t: => T): Bar[T] = new Bar[T] {
+      val value = t
+    }
+  }
+
+  trait Foo[A] { def foo(a: A): Unit }
+  object Foo {
+    implicit val intFoo = new Foo[Int] { def foo(x: Int) = () }
+  }
+
+  object Demo {
+    Bar[Foo[Int]]({
+      object Blah {
+        lazy val blah: Foo[Int] = Foo.intFoo
+      }
+      Blah.blah
+    }).value.foo _
+  }
+}
+
+class Reduced {
+  def byName(a: => Any) = ???
+  byName({ object Blah; Blah }).toString _
+}


### PR DESCRIPTION
Closes https://github.com/scala/bug/issues/9061

This bug has been fixed by some change incorporated to the 2.13.x branch. The code of both example (the long one from the description and the short one introduced by @retronym) now compile fine. 

_Edit_ I have also tested them on the 2.12.x branch, and they still fail in there. 
