### PR TITLE
Allow suppressing value-discard warning via type ascription to `Unit`

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
@@ -197,6 +197,9 @@ trait StdAttachments {
    */
   case class OriginalTreeAttachment(original: Tree)
 
+  /** Marks a Typed tree with Unit tpt. */
+  case object TypedExpectingUnitAttachment
+
   case class StabilizingDefinitions(vdefs: List[ValDef])
   private[this] val StabilizingDefinitionsTag: reflect.ClassTag[StabilizingDefinitions] = reflect.classTag[StabilizingDefinitions]
 

--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -497,7 +497,7 @@ trait Types {
     def sym: Symbol
   }
   /** The `SuperType` type is not directly written, but arises when `C.super` is used
-   *  as a prefix in a `TypeRef` or `SingleType`. It's internal presentation is
+   *  as a prefix in a `TypeRef` or `SingleType`. Its internal presentation is
    *  {{{
    *     SuperType(thistpe, supertpe)
    *  }}}
@@ -514,7 +514,7 @@ trait Types {
    */
   val SuperType: SuperTypeExtractor
 
-  /** An extractor class to create and pattern match with syntax `SingleType(thistpe, supertpe)`
+  /** An extractor class to create and pattern match with syntax `SuperType(thistpe, supertpe)`
    *  @group Extractors
    */
   abstract class SuperTypeExtractor {

--- a/test/files/neg/t9847.check
+++ b/test/files/neg/t9847.check
@@ -4,9 +4,6 @@ t9847.scala:6: warning: discarded non-Unit value
 t9847.scala:6: warning: a pure expression does nothing in statement position
   def f(): Unit = 42
                   ^
-t9847.scala:7: warning: a pure expression does nothing in statement position
-  def g = (42: Unit)
-           ^
 t9847.scala:9: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
     1
     ^
@@ -38,5 +35,5 @@ t9847.scala:24: warning: a pure expression does nothing in statement position; m
   class D { 42 ; 17 }
                  ^
 error: No warnings can be incurred under -Xfatal-warnings.
-13 warnings found
+12 warnings found
 one error found

--- a/test/files/neg/t9847.check
+++ b/test/files/neg/t9847.check
@@ -4,9 +4,6 @@ t9847.scala:6: warning: discarded non-Unit value
 t9847.scala:6: warning: a pure expression does nothing in statement position
   def f(): Unit = 42
                   ^
-t9847.scala:7: warning: discarded non-Unit value
-  def g = (42: Unit)
-           ^
 t9847.scala:7: warning: a pure expression does nothing in statement position
   def g = (42: Unit)
            ^
@@ -41,5 +38,5 @@ t9847.scala:24: warning: a pure expression does nothing in statement position; m
   class D { 42 ; 17 }
                  ^
 error: No warnings can be incurred under -Xfatal-warnings.
-14 warnings found
+13 warnings found
 one error found

--- a/test/files/neg/value-discard.check
+++ b/test/files/neg/value-discard.check
@@ -1,6 +1,12 @@
 value-discard.scala:6: warning: discarded non-Unit value
     mutable.Set[String]().remove("")   // expected to warn
                                 ^
+value-discard.scala:13: warning: discarded non-Unit value
+  def subtract(): Unit = mutable.Set.empty[String].subtractOne("")     // warn
+                                                              ^
+value-discard.scala:17: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+    ""                         // warn
+    ^
 error: No warnings can be incurred under -Xfatal-warnings.
-one warning found
+three warnings found
 one error found

--- a/test/files/neg/value-discard.check
+++ b/test/files/neg/value-discard.check
@@ -1,0 +1,6 @@
+value-discard.scala:6: warning: discarded non-Unit value
+    mutable.Set[String]().remove("")   // expected to warn
+                                ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/value-discard.scala
+++ b/test/files/neg/value-discard.scala
@@ -7,6 +7,15 @@ final class UnusedTest {
   }
 
   def removeAscribed(): Unit = {
-    mutable.Set[String]().remove(""): Unit
+    mutable.Set[String]().remove(""): Unit    // no warn
+  }
+
+  def subtract(): Unit = mutable.Set.empty[String].subtractOne("")     // warn
+
+  def warnings(): Unit = {
+    val s: mutable.Set[String] = mutable.Set.empty[String]
+    ""                         // warn
+    "": Unit                   // no warn
+    s.subtractOne("")          // no warn
   }
 }

--- a/test/files/neg/value-discard.scala
+++ b/test/files/neg/value-discard.scala
@@ -1,0 +1,12 @@
+// scalac: -Ywarn-value-discard -Xfatal-warnings
+final class UnusedTest {
+  import scala.collection.mutable
+
+  def remove(): Unit = {
+    mutable.Set[String]().remove("")   // expected to warn
+  }
+
+  def removeAscribed(): Unit = {
+    mutable.Set[String]().remove(""): Unit
+  }
+}


### PR DESCRIPTION
Extend `(e: Unit)` to mean no-warn for both value discard and expression in statement position warnings.
