### PR TITLE
Override LinkedHash{Map,Set}.{last,lastOption,head,headOption} for performance

### DIFF
--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -94,6 +94,22 @@ class LinkedHashMap[K, V]
 
     }
 
+  override def last: (K, V) = 
+    if (size > 0) (lastEntry.key, lastEntry.value) 
+    else throw new java.util.NoSuchElementException("Cannot call .last on empty LinkedHashMap")
+      
+  override def lastOption: Option[(K, V)] = 
+    if (size > 0) Some((lastEntry.key, lastEntry.value))
+    else None
+
+  override def head: (K, V) = 
+    if (size > 0) (firstEntry.key, firstEntry.value) 
+    else throw new java.util.NoSuchElementException("Cannot call .head on empty LinkedHashMap")
+      
+  override def headOption: Option[(K, V)] = 
+    if (size > 0) Some((firstEntry.key, firstEntry.value))
+    else None
+      
   override def empty = LinkedHashMap.empty[K, V]
   override def size = table.tableSize
   override def knownSize: Int = size

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -66,6 +66,22 @@ class LinkedHashSet[A]
       }
     }
 
+  override def last: A =
+    if (size > 0) lastEntry.key
+    else throw new java.util.NoSuchElementException("Cannot call .last on empty LinkedHashSet")
+      
+  override def lastOption: Option[A] =
+    if (size > 0) Some(lastEntry.key)
+    else None
+
+  override def head: A =
+    if (size > 0) firstEntry.key
+    else throw new java.util.NoSuchElementException("Cannot call .head on empty LinkedHashSet")
+      
+  override def headOption: Option[A] =
+    if (size > 0) Some(firstEntry.key)
+    else None
+
   override def size: Int = table.tableSize
   override def knownSize: Int = size
   override def isEmpty: Boolean = size == 0


### PR DESCRIPTION
This avoids creating unnecessary iterators in head/headOption, but more importantly also does so in last/lastOption and turns those two methods from O(n) to O(1)