### PR TITLE
[SUPERSEDED] Unit companion is compileTimeOnly

### DIFF
--- a/project/GenerateAnyVals.scala
+++ b/project/GenerateAnyVals.scala
@@ -468,6 +468,9 @@ override def getClass(): Class[Boolean] = ???
     )
     def objectLines = interpolate(allCompanions).linesIterator.toList
 
+    private def nono = "`Unit` companion object is not allowed in source; instead, use `()` for the unit value"
+    override def mkObject = s"""@scala.annotation.compileTimeOnly("$nono")\n${super.mkObject}"""
+
     override def boxUnboxInterpolations = Map(
       "@boxRunTimeDoc@" -> "",
       "@unboxRunTimeDoc@" -> "",
@@ -495,7 +498,7 @@ object GenerateAnyVals {
 
     av.make() foreach { case (name, code ) =>
       val file = new java.io.File(outDir, name + ".scala")
-      sbt.IO.write(file, code, java.nio.charset.Charset.forName("UTF-8"), false)
+      sbt.IO.write(file, code, java.nio.charset.StandardCharsets.UTF_8, false)
     }
   }
 }

--- a/src/build/genprod.scala
+++ b/src/build/genprod.scala
@@ -119,8 +119,8 @@ object FunctionZero extends Function(0) {
 
 object FunctionOne extends Function(1) {
   override def classAnnotation    = "@annotation.implicitNotFound(msg = \"No implicit view available from ${T1} => ${R}.\")\n"
-  override def contravariantSpecs = "@specialized(scala.Int, scala.Long, scala.Float, scala.Double) "
-  override def covariantSpecs     = "@specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double) "
+  override def contravariantSpecs = "@specialized(Specializable.Arg) "
+  override def covariantSpecs     = "@specialized(Specializable.Return) "
 
   override def descriptiveComment = "  " + functionNTemplate.format("succ", "anonfun1",
 """
@@ -154,8 +154,8 @@ object FunctionOne extends Function(1) {
 }
 
 object FunctionTwo extends Function(2) {
-  override def contravariantSpecs = "@specialized(scala.Int, scala.Long, scala.Double) "
-  override def covariantSpecs = "@specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double) "
+  override def contravariantSpecs = "@specialized(Specializable.Args) "
+  override def covariantSpecs = "@specialized(Specializable.Return) "
 
   override def descriptiveComment = "  " + functionNTemplate.format("max", "anonfun2",
 """

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -115,6 +115,7 @@ abstract class RefChecks extends Transform {
 
     var localTyper: analyzer.Typer = typer
     var currentApplication: Tree = EmptyTree
+    var inAnnotation: Boolean = false
     var inPattern: Boolean = false
     @inline final def savingInPattern[A](body: => A): A = {
       val saved = inPattern
@@ -1283,7 +1284,7 @@ abstract class RefChecks extends Transform {
           reporter.warning(pos, s"${sym.fullLocationString} has changed semantics in version ${sym.migrationVersion.get}:\n${sym.migrationMessage.get}")
       }
       // See an explanation of compileTimeOnly in its scaladoc at scala.annotation.compileTimeOnly.
-      if (sym.isCompileTimeOnly && !currentOwner.ownerChain.exists(x => x.isCompileTimeOnly)) {
+      if (sym.isCompileTimeOnly && !inAnnotation && !currentOwner.ownerChain.exists(x => x.isCompileTimeOnly)) {
         def defaultMsg =
           sm"""Reference to ${sym.fullLocationString} should not have survived past type checking,
               |it should have been processed and eliminated during expansion of an enclosing macro."""
@@ -1427,11 +1428,14 @@ abstract class RefChecks extends Transform {
           if (ann.original != null && ann.original.hasExistingSymbol)
             checkUndesiredProperties(ann.original.symbol, tree.pos)
         }
-        annots
+        val saved = inAnnotation
+        inAnnotation = true
+        try annots
           .map(_.transformArgs(transformTrees))
           .groupBy(_.symbol)
           .flatMap((groupRepeatableAnnotations _).tupled)
           .toList
+        finally inAnnotation = saved
       }
 
       // assumes non-empty `anns`

--- a/src/library/scala/Function0.scala
+++ b/src/library/scala/Function0.scala
@@ -11,7 +11,7 @@
  */
 
 // GENERATED CODE: DO NOT EDIT.
-// genprod generated these sources at: Wed Jan 02 15:00:44 PST 2019
+// genprod generated these sources at: 2019-01-20T09:16:45.854Z
 
 package scala
 

--- a/src/library/scala/Function0.scala
+++ b/src/library/scala/Function0.scala
@@ -11,7 +11,7 @@
  */
 
 // GENERATED CODE: DO NOT EDIT.
-// genprod generated these sources at: 2019-01-14T03:08:31.937870Z
+// genprod generated these sources at: Wed Jan 02 15:00:44 PST 2019
 
 package scala
 

--- a/src/library/scala/Function1.scala
+++ b/src/library/scala/Function1.scala
@@ -34,7 +34,7 @@ package scala
  *  is that the latter can specify inputs which it will not handle.
  */
 @annotation.implicitNotFound(msg = "No implicit view available from ${T1} => ${R}.")
-trait Function1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double) +R] extends AnyRef { self =>
+trait Function1[@specialized(Specializable.Arg) -T1, @specialized(Specializable.Return) +R] extends AnyRef { self =>
   /** Apply the body of this function to the argument.
    *  @return   the result of function application.
    */

--- a/src/library/scala/Function2.scala
+++ b/src/library/scala/Function2.scala
@@ -31,7 +31,7 @@ package scala
  * }
  *  }}}
  */
-trait Function2[@specialized(scala.Int, scala.Long, scala.Double) -T1, @specialized(scala.Int, scala.Long, scala.Double) -T2, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double) +R] extends AnyRef { self =>
+trait Function2[@specialized(Specializable.Args) -T1, @specialized(Specializable.Args) -T2, @specialized(Specializable.Return) +R] extends AnyRef { self =>
   /** Apply the body of this function to the arguments.
    *  @return   the result of function application.
    */

--- a/src/library/scala/Specializable.scala
+++ b/src/library/scala/Specializable.scala
@@ -30,4 +30,9 @@ object Specializable {
   final val Integral:    Group[(Byte, Short, Int, Long, Char)] = null
   final val AllNumeric:  Group[(Byte, Short, Int, Long, Char, Float, Double)] = null
   final val BestOfBreed: Group[(Int, Double, Boolean, Unit, AnyRef)] = null
+  final val Unit:        Group[Tuple1[Unit]] = null
+
+  final val Arg:         Group[(Int, Long, Float, Double)] = null
+  final val Args:        Group[(Int, Long, Double)] = null
+  final val Return:      Group[(Int, Long, Float, Double, Boolean, Unit)] = null
 }

--- a/src/library/scala/Specializable.scala
+++ b/src/library/scala/Specializable.scala
@@ -19,15 +19,15 @@ trait Specializable
 
 object Specializable {
   // No type parameter in @specialized annotation.
-  trait SpecializedGroup { }
+  trait SpecializedGroup
 
   // Smuggle a list of types by way of a tuple upon which Group is parameterized.
-  class Group[T >: Null](value: T) extends SpecializedGroup { }
+  class Group[T >: Null](value: T) extends SpecializedGroup
 
-  final val Primitives  = new Group((Byte, Short, Int, Long, Char, Float, Double, Boolean, Unit))
-  final val Everything  = new Group((Byte, Short, Int, Long, Char, Float, Double, Boolean, Unit, AnyRef))
-  final val Bits32AndUp = new Group((Int, Long, Float, Double))
-  final val Integral    = new Group((Byte, Short, Int, Long, Char))
-  final val AllNumeric  = new Group((Byte, Short, Int, Long, Char, Float, Double))
-  final val BestOfBreed = new Group((Int, Double, Boolean, Unit, AnyRef))
+  final val Primitives:  Group[(Byte, Short, Int, Long, Char, Float, Double, Boolean, Unit)] = null
+  final val Everything:  Group[(Byte, Short, Int, Long, Char, Float, Double, Boolean, Unit, AnyRef)] = null
+  final val Bits32AndUp: Group[(Int, Long, Float, Double)] = null
+  final val Integral:    Group[(Byte, Short, Int, Long, Char)] = null
+  final val AllNumeric:  Group[(Byte, Short, Int, Long, Char, Float, Double)] = null
+  final val BestOfBreed: Group[(Int, Double, Boolean, Unit, AnyRef)] = null
 }

--- a/src/library/scala/Unit.scala
+++ b/src/library/scala/Unit.scala
@@ -27,7 +27,7 @@ final abstract class Unit private extends AnyVal {
   override def getClass(): Class[Unit] = ???
 }
 
-//@scala.annotation.compileTimeOnly("`Unit` companion object is not allowed in source; instead, use `()` for the unit value")
+@scala.annotation.compileTimeOnly("`Unit` companion object is not allowed in source; instead, use `()` for the unit value")
 object Unit extends AnyValCompanion {
 
   /** Transform a value type into a boxed reference type.

--- a/src/library/scala/Unit.scala
+++ b/src/library/scala/Unit.scala
@@ -27,6 +27,7 @@ final abstract class Unit private extends AnyVal {
   override def getClass(): Class[Unit] = ???
 }
 
+//@scala.annotation.compileTimeOnly("`Unit` companion object is not allowed in source; instead, use `()` for the unit value")
 object Unit extends AnyValCompanion {
 
   /** Transform a value type into a boxed reference type.

--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -118,7 +118,7 @@ object ArrayOps {
     def withFilter(q: A => Boolean): WithFilter[A] = new WithFilter[A](a => p(a) && q(a), xs)
   }
 
-  private final class ArrayIterator[@specialized(AnyRef, Int, Double, Long, Float, Char, Byte, Short, Boolean, Unit) A](xs: Array[A]) extends AbstractIterator[A] {
+  private final class ArrayIterator[@specialized(Specializable.Everything) A](xs: Array[A]) extends AbstractIterator[A] {
     private[this] var pos = 0
     private[this] val len = xs.length
     def hasNext: Boolean = pos < len
@@ -133,7 +133,7 @@ object ArrayOps {
     }
   }
 
-  private final class ReverseIterator[@specialized(AnyRef, Int, Double, Long, Float, Char, Byte, Short, Boolean, Unit) A](xs: Array[A]) extends AbstractIterator[A] {
+  private final class ReverseIterator[@specialized(Specializable.Everything) A](xs: Array[A]) extends AbstractIterator[A] {
     private[this] var pos = xs.length-1
     def hasNext: Boolean = pos >= 0
     def next(): A = try {
@@ -700,7 +700,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *           Returns `z` if this array is empty.
     */
   def foldLeft[B](z: B)(op: (B, A) => B): B = {
-    def f[@specialized(AnyRef, Int, Double, Long, Float, Char, Byte, Short, Boolean, Unit) T](xs: Array[T], op: (Any, Any) => Any, z: Any): Any = {
+    def f[@specialized(Specializable.Everything) T](xs: Array[T], op: (Any, Any) => Any, z: Any): Any = {
       val length = xs.length
       var v: Any = z
       var i = 0
@@ -806,7 +806,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *           Returns `z` if this array is empty.
     */
   def foldRight[B](z: B)(op: (A, B) => B): B = {
-    def f[@specialized(AnyRef, Int, Double, Long, Float, Char, Byte, Short, Boolean, Unit) T](xs: Array[T], op: (Any, Any) => Any, z: Any): Any = {
+    def f[@specialized(Specializable.Everything) T](xs: Array[T], op: (Any, Any) => Any, z: Any): Any = {
       var v = z
       var i = xs.length - 1
       while(i >= 0) {
@@ -841,7 +841,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *  @return        the result of applying the fold operator `op` between all the elements, or `z` if this array is empty.
     */
   def fold[A1 >: A](z: A1)(op: (A1, A1) => A1): A1 = {
-    def f[@specialized(AnyRef, Int, Double, Long, Float, Char, Byte, Short, Boolean, Unit) T](xs: Array[T], op: (Any, Any) => Any, z: Any): Any = {
+    def f[@specialized(Specializable.Everything) T](xs: Array[T], op: (Any, Any) => Any, z: Any): Any = {
       // Start with the last element and run the loop from 0 until length-1. It would be more logical to start with
       // the first element and loop from 1 until length but hotspot performs special optimizations for loops starting
       // at 0 which have a huge impact when the actual folding operation is fast.

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -91,7 +91,7 @@ sealed class NumericRange[T](
     else locationAfterN(idx)
   }
 
-  override def foreach[@specialized(Unit) U](f: T => U): Unit = {
+  override def foreach[@specialized(Specializable.Unit) U](f: T => U): Unit = {
     var count = 0
     var current = start
     while (count < length) {

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -171,7 +171,7 @@ sealed abstract class Range(
     else start + (step * idx)
   }
 
-  /*@`inline`*/ final override def foreach[@specialized(Unit) U](f: Int => U): Unit = {
+  /*@`inline`*/ final override def foreach[@specialized(Specializable.Unit) U](f: Int => U): Unit = {
     // Implementation chosen on the basis of favorable microbenchmarks
     // Note--initialization catches step == 0 so we don't need to here
     if (!isEmpty) {

--- a/src/library/scala/runtime/AbstractFunction1.scala
+++ b/src/library/scala/runtime/AbstractFunction1.scala
@@ -14,6 +14,6 @@
 
 package scala.runtime
 
-abstract class AbstractFunction1[@specialized(scala.Int, scala.Long, scala.Float, scala.Double) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double) +R] extends Function1[T1, R] {
+abstract class AbstractFunction1[@specialized(Specializable.Arg) -T1, @specialized(Specializable.Return) +R] extends Function1[T1, R] {
 
 }

--- a/src/library/scala/runtime/AbstractFunction2.scala
+++ b/src/library/scala/runtime/AbstractFunction2.scala
@@ -14,6 +14,6 @@
 
 package scala.runtime
 
-abstract class AbstractFunction2[@specialized(scala.Int, scala.Long, scala.Double) -T1, @specialized(scala.Int, scala.Long, scala.Double) -T2, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double) +R] extends Function2[T1, T2, R] {
+abstract class AbstractFunction2[@specialized(Specializable.Args) -T1, @specialized(Specializable.Args) -T2, @specialized(Specializable.Return) +R] extends Function2[T1, T2, R] {
 
 }

--- a/src/library/scala/runtime/AbstractPartialFunction.scala
+++ b/src/library/scala/runtime/AbstractPartialFunction.scala
@@ -27,7 +27,7 @@ package runtime
  *  @author  Pavel Pavlov
  *  @since   2.10
  */
-abstract class AbstractPartialFunction[@specialized(scala.Int, scala.Long, scala.Float, scala.Double) -T1, @specialized(scala.Unit, scala.Boolean, scala.Int, scala.Float, scala.Long, scala.Double) +R] extends Function1[T1, R] with PartialFunction[T1, R] { self =>
+abstract class AbstractPartialFunction[@specialized(Specializable.Arg) -T1, @specialized(Specializable.Return) +R] extends Function1[T1, R] with PartialFunction[T1, R] { self =>
   // this method must be overridden for better performance,
   // for backwards compatibility, fall back to the one inherited from PartialFunction
   // this assumes the old-school partial functions override the apply method, though

--- a/test/files/neg/macro-blackbox-fundep-materialization/Macros_1.scala
+++ b/test/files/neg/macro-blackbox-fundep-materialization/Macros_1.scala
@@ -24,7 +24,7 @@ object Iso {
     }
 
     def mkFrom() = {
-      if (fields.length == 0) Literal(Constant(Unit))
+      if (fields.length == 0) Literal(Constant(()))
       else Apply(Ident(newTermName("Tuple" + fields.length)), fields map (f => Select(Ident(newTermName("f")), newTermName(f.name.toString.trim))))
     }
 

--- a/test/files/neg/macro-bundle-whitebox-use-raw/Macros_1.scala
+++ b/test/files/neg/macro-bundle-whitebox-use-raw/Macros_1.scala
@@ -43,7 +43,7 @@ class FundepMaterializationBundle(val c: Context) {
     }
 
     def mkFrom() = {
-      if (fields.length == 0) Literal(Constant(Unit))
+      if (fields.length == 0) Literal(Constant(()))
       else Apply(Ident(newTermName("Tuple" + fields.length)), fields map (f => Select(Ident(newTermName("f")), newTermName(f.name.toString.trim))))
     }
 

--- a/test/files/neg/macro-bundle-whitebox-use-refined/Macros_1.scala
+++ b/test/files/neg/macro-bundle-whitebox-use-refined/Macros_1.scala
@@ -43,7 +43,7 @@ class FundepMaterializationBundle(val c: Context { type PrefixType = Nothing }) 
     }
 
     def mkFrom() = {
-      if (fields.length == 0) Literal(Constant(Unit))
+      if (fields.length == 0) Literal(Constant(()))
       else Apply(Ident(newTermName("Tuple" + fields.length)), fields map (f => Select(Ident(newTermName("f")), newTermName(f.name.toString.trim))))
     }
 

--- a/test/files/run/macro-bundle-whitebox-use-raw/Macros_1.scala
+++ b/test/files/run/macro-bundle-whitebox-use-raw/Macros_1.scala
@@ -43,7 +43,7 @@ class FundepMaterializationBundle(val c: Context) {
     }
 
     def mkFrom() = {
-      if (fields.length == 0) Literal(Constant(Unit))
+      if (fields.length == 0) Literal(Constant(()))
       else Apply(Ident(newTermName("Tuple" + fields.length)), fields map (f => Select(Ident(newTermName("f")), newTermName(f.name.toString.trim))))
     }
 

--- a/test/files/run/macro-bundle-whitebox-use-refined/Macros_1.scala
+++ b/test/files/run/macro-bundle-whitebox-use-refined/Macros_1.scala
@@ -43,7 +43,7 @@ class FundepMaterializationBundle(val c: Context) {
     }
 
     def mkFrom() = {
-      if (fields.length == 0) Literal(Constant(Unit))
+      if (fields.length == 0) Literal(Constant(()))
       else Apply(Ident(newTermName("Tuple" + fields.length)), fields map (f => Select(Ident(newTermName("f")), newTermName(f.name.toString.trim))))
     }
 

--- a/test/files/run/macro-whitebox-fundep-materialization/Macros_1.scala
+++ b/test/files/run/macro-whitebox-fundep-materialization/Macros_1.scala
@@ -24,7 +24,7 @@ object Iso {
     }
 
     def mkFrom() = {
-      if (fields.length == 0) Literal(Constant(Unit))
+      if (fields.length == 0) Literal(Constant(()))
       else Apply(Ident(newTermName("Tuple" + fields.length)), fields map (f => Select(Ident(newTermName("f")), newTermName(f.name.toString.trim))))
     }
 

--- a/test/junit/scala/lang/primitives/BoxUnboxTest.scala
+++ b/test/junit/scala/lang/primitives/BoxUnboxTest.scala
@@ -112,13 +112,30 @@ class BoxUnboxTest extends RunTesting {
 
     val b = runtime.BoxedUnit.UNIT
 
+    def boxing(x: Unit): runtime.BoxedUnit = {
+      val k = this.getClass.getClassLoader.loadClass("scala.Unit$")
+      val u = k.getDeclaredField("MODULE$").get(null)
+      k.getDeclaredMethods.find(_.getName == "box").get.invoke(u, x.asInstanceOf[Object]).asInstanceOf[runtime.BoxedUnit]
+    }
+    def unboxing(x: Object): Unit = {
+      val k = this.getClass.getClassLoader.loadClass("scala.Unit$")
+      val u = k.getDeclaredField("MODULE$").get(null)
+      k.getDeclaredMethods.find(_.getName == "unbox").get.invoke(u, x).asInstanceOf[Unit]
+    }
+
     assert(eff() == b); chk()
-    assert(Unit.box(eff()) == b); chk()
+    //assert(Unit.box(eff()) == b); chk()
+    assert(boxing(eff()) == b); chk()
     assert(().asInstanceOf[Object] == b)
 
-    Unit.unbox({eff(); b}); chk()
-    Unit.unbox({eff(); null}); chk()
-    assertThrows[ClassCastException](Unit.unbox({eff(); ""})); chk()
+    //Unit.unbox({eff(); b}); chk()
+    //Unit.unbox({eff(); null}); chk()
+    //assertThrows[ClassCastException](Unit.unbox({eff(); ""})); chk()
+    unboxing({eff(); b}); chk()
+    unboxing({eff(); null}); chk()
+    assertThrows[ClassCastException](
+      try unboxing({eff(); ""}) catch { case t: java.lang.reflect.InvocationTargetException => throw t.getCause }
+    ); chk()
 
     val n1 = null.asInstanceOf[Unit]
     assert(n1 == b)


### PR DESCRIPTION
Annotations get a dispensation for the ref check.

The `Group` mechanism for specialized only uses the type args, so avoid using `Unit` to define a value.

Forward ports https://github.com/scala/scala/pull/6490, which didn't cope with `Group` definitions.