### PR TITLE
bug fix #11270. Overrode distinctBy to detect cycles and help termina…

### DIFF
--- a/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
@@ -554,21 +554,27 @@ class LazyListLazinessTest {
     assertKnownEmptyYieldsKnownEmpty(op)
   }
 
-  @Test
-  def distinct_properlyLazy(): Unit = {
-    val op = lazyListOp(_.distinct)
-    assertRepeatedlyFullyLazy(op)
-    assertLazyNextStateWhenHeadEvaluated(op)
-    assertKnownEmptyYieldsKnownEmpty(op)
-  }
-
-  @Test
-  def distinctBy_properlyLazy(): Unit = {
-    val op = lazyListOp(_.distinctBy(identity))
-    assertRepeatedlyFullyLazy(op)
-    assertLazyNextStateWhenHeadEvaluated(op)
-    assertKnownEmptyYieldsKnownEmpty(op)
-  }
+  /**
+    * Removing distinct and distinctBy tests.
+    * As part of bug fix #11270
+    * To know whether a lazy list is circular or not, we will have to have the state evaluated (using the classic 1x, 2x iterator)
+    * and there by making it non-lazy
+    */
+  //  @Test
+//  def distinct_properlyLazy(): Unit = {
+//    val op = lazyListOp(_.distinct)
+//    assertRepeatedlyFullyLazy(op)
+//    assertLazyNextStateWhenHeadEvaluated(op)
+//    assertKnownEmptyYieldsKnownEmpty(op)
+//  }
+//
+//  @Test
+//  def distinctBy_properlyLazy(): Unit = {
+//    val op = lazyListOp(_.distinctBy(identity))
+//    assertRepeatedlyFullyLazy(op)
+//    assertLazyNextStateWhenHeadEvaluated(op)
+//    assertKnownEmptyYieldsKnownEmpty(op)
+//  }
 
   @Test
   def startsWith_properlyLazy(): Unit = {

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -380,4 +380,17 @@ class LazyListTest {
     check(LazyList.from(Vector(1, 2, 3, 4, 5)))
     check(LazyList.tabulate(5)(_ + 1))
   }
+
+  @Test
+  def testDistinctCircularLazyList : Unit = {
+    lazy val ring : LazyList[Int] = 1 #:: 2 #:: 3 #:: 4 #:: 5#:: ring
+    assertEquals(ring.distinct.toList, List(1,2,3,4,5))
+
+    lazy val ring1 : LazyList[Int] = 1 #:: 2 #:: 3 #:: 4 #:: 5#:: ring1
+    val distinctByFunc : Int => Int = {i : Int => if(i == 4) 3 else i}
+    assertEquals(ring1.distinctBy(distinctByFunc), List(1,2,3,5))
+
+    lazy val nonRing : LazyList[Int] = 1 #:: 2 #:: 3 #:: 4 #:: 5#:: LazyList(2,6) //added as part of regression to test non circular lazyList
+    assertEquals(nonRing.distinct, List(1,2,3,4,5,6))
+  }
 }


### PR DESCRIPTION
…te. Removed lazyness test for distinctBy and distinct as checking if the list is cyclic cannot be lazy