### PR TITLE
Add destroyForcibly method to scala.sys.process 

### DIFF
--- a/src/library/scala/sys/process/Process.scala
+++ b/src/library/scala/sys/process/Process.scala
@@ -40,6 +40,11 @@ trait Process {
   def exitValue(): Int
   /** Destroys this process. */
   def destroy(): Unit
+  /** Destroy this process forcibly. Requires overriding in some scenario depending on type of process. */
+  def destroyForcibly(): Process = {
+    destroy()
+    this
+  }
 }
 
 /** Methods for constructing simple commands that can then be combined. */


### PR DESCRIPTION
For scala/bug#10106

@SethTisue , in that thread, you mentioned about deriving sys.process to be a "module". What's your proposed strategy on for the requirement of the module?