### PR TITLE
StrictOptimizedIterableOps#strictOptimizedConcat forwards original collections to builders, not iterators

### DIFF
--- a/src/library/scala/collection/StrictOptimizedIterableOps.scala
+++ b/src/library/scala/collection/StrictOptimizedIterableOps.scala
@@ -131,10 +131,8 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     * @return The resulting collection
     */
   @inline protected[this] final def strictOptimizedConcat[B >: A, C2](that: IterableOnce[B], b: mutable.Builder[B, C2]): C2 = {
-    val it1 = iterator
-    val it2 = that.iterator
-    b ++= it1
-    b ++= it2
+    b ++= this
+    b ++= that
     b.result()
   }
 


### PR DESCRIPTION
The Builder itself is the one in the position to know whether or not an iterator should be created or not. For instance, a BitSets and HashMaps etc do not create iterators, and would be much slower if they did. 