### PR TITLE
BitSet#partition uses filter and &~ 

### DIFF
--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -291,6 +291,11 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
   def flatMap(f: Int => IterableOnce[Int]): C = fromSpecific(new View.FlatMap(toIterable, f))
 
   def collect(pf: PartialFunction[Int, Int]): C = fromSpecific(super[SortedSetOps].collect(pf).toIterable)
+
+  override def partition(p: Int => Boolean): (C, C) = {
+    val left = filter(p)
+    (left, this &~ left)
+  }
 }
 
 object BitSetOps {

--- a/test/scalacheck/scala/collection/immutable/BitSetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/BitSetProperties.scala
@@ -46,4 +46,10 @@ object BitSetProperties extends Properties("immutable.BitSet") {
   property("filterNot") = forAll { (bs: BitSet) =>
     bs.filterNot(_ % 2 == 0) ?= bs.toList.filterNot(_ % 2 == 0).to(BitSet)
   }
+
+  property("partition") = forAll { (bs: BitSet) =>
+    val p = (i: Int) => i % 2 == 0
+    val (left, right) = bs.partition(p)
+    (left ?= bs.filter(p)) && (right ?= bs.filterNot(p))
+  }
 }

--- a/test/scalacheck/scala/collection/mutable/BitSetProperties.scala
+++ b/test/scalacheck/scala/collection/mutable/BitSetProperties.scala
@@ -34,4 +34,9 @@ object BitSetProperties extends Properties("mutable.BitSet") {
     val list = bs.toList
     bs.filterInPlace(_ % 2 == 0) ?= list.filter(_ % 2 == 0).to(BitSet)
   }
+  property("partition") = forAll { (bs: BitSet) =>
+    val p = (i: Int) => i % 2 == 0
+    val (left, right) = bs.partition(p)
+    (left ?= bs.filter(p)) && (right ?= bs.filterNot(p))
+  }
 }


### PR DESCRIPTION
This should be a lot more efficient than going through and building new bitsets from the ground up with 2 View.Filter instances and everything. 