### PR TITLE
Add regression test for bug 4889.

### DIFF
--- a/test/files/neg/t4889.check
+++ b/test/files/neg/t4889.check
@@ -1,0 +1,4 @@
+t4889.scala:19: error: could not find implicit value for parameter ma1: t4889.MatrixAdder[Int,[S]t4889.SparseMatrix[S]]
+  m1.foo
+     ^
+one error found

--- a/test/files/neg/t4889.scala
+++ b/test/files/neg/t4889.scala
@@ -1,0 +1,21 @@
+object t4889 {
+
+  import scala.language.higherKinds
+  trait Matrix[S, +Repr[s] <: Matrix[s, Repr]] {
+    def foo[R[S] >: Repr[S]](implicit ma1: MatrixAdder[S, R]) {}
+  }
+
+  trait SparseMatrix[S] extends Matrix[S, SparseMatrix]
+
+  trait MatrixAdder[S, -R[_]] {
+    def addTo(m: R[S]): Unit
+  }
+
+  implicit def adderImplicit[S, R[s] <: Matrix[s, R]] = new MatrixAdder[S, R] {
+    def addTo(m: R[S]) = { }
+  }
+
+  val m1 = new SparseMatrix[Int] { }
+  m1.foo
+
+}


### PR DESCRIPTION
Partially _Resolves_ https://github.com/scala/bug/issues/4889

Bug 4889 reported a compiler _crash_, with an Stack Overflow error, when trying to compile the program attached here. I have checked that version 2.12.7 of the Scala (REPL) still crashes when trying to compile this program. This compiler _crash_ has been solved in branch `2.13.x`.

However, the compiler _rejects_ the program, since in the call to `foo` (the crash point) it fails to find a value for the implicit parameter. 