### PR TITLE
HashMap#keySet#incl,excl,filter,filterNot do not copy data. HashMap/Set#filterImpl optimized in maps of depth 1

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -54,6 +54,26 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
 
   override def isEmpty: Boolean = rootNode.size == 0
 
+  override def keySet: Set[K] = if (size == 0) Set.empty else new KeySet
+
+  private final class KeySet extends ImmutableKeySet {
+
+    private[this] def newKeySetOrThis(newHashMap: HashMap[K, _]): Set[K] =
+      if (newHashMap eq HashMap.this) this else newHashMap.keySet
+    private[this] def newKeySetOrThis(newRootNode: BitmapIndexedMapNode[K, _]): Set[K] =
+      if (newRootNode eq rootNode) this else new HashMap(newRootNode).keySet
+
+    override def incl(elem: K): Set[K] = {
+      val originalHash = elem.##
+      val improvedHash = improve(originalHash)
+      val newNode = rootNode.updated(elem, null, originalHash, improvedHash, 0, replaceValue = false)
+      newKeySetOrThis(newNode)
+    }
+    override def excl(elem: K): Set[K] = newKeySetOrThis(HashMap.this - elem)
+    override def filter(pred: K => Boolean): Set[K] = newKeySetOrThis(HashMap.this.filter(kv => pred(kv._1)))
+    override def filterNot(pred: K => Boolean): Set[K] = newKeySetOrThis(HashMap.this.filterNot(kv => pred(kv._1)))
+  }
+
   def iterator: Iterator[(K, V)] = {
     if (isEmpty) Iterator.empty
     else new MapKeyValueTupleIterator[K, V](rootNode)
@@ -102,7 +122,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
 
   def updated[V1 >: V](key: K, value: V1): HashMap[K, V1] = {
     val keyUnimprovedHash = key.##
-    newHashMapOrThis(rootNode.updated(key, value, keyUnimprovedHash, improve(keyUnimprovedHash), 0))
+    newHashMapOrThis(rootNode.updated(key, value, keyUnimprovedHash, improve(keyUnimprovedHash), 0, replaceValue = true))
   }
 
   def removed(key: K): HashMap[K, V] = {
@@ -119,7 +139,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
         val next = iter.next()
         val originalHash = hm.unimproveHash(next.hash)
         val improved = improve(originalHash)
-        current = current.updated(next.key, next.value, originalHash, improved, 0)
+        current = current.updated(next.key, next.value, originalHash, improved, 0, replaceValue = true)
 
         if (current ne rootNode) {
           var shallowlyMutableNodeMap = Node.bitposFrom(Node.maskFrom(improved, 0))
@@ -140,7 +160,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
         val (key, value) = iter.next()
         val originalHash = key.##
         val improved = improve(originalHash)
-        current = current.updated(key, value, originalHash, improved, 0).asInstanceOf[BitmapIndexedMapNode[K, V]]
+        current = current.updated(key, value, originalHash, improved, 0, replaceValue = true)
 
         if (current ne rootNode) {
           // Note: We could have started with shallowlyMutableNodeMap = 0, however this way, in the case that
@@ -211,9 +231,9 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
           val (mergedK, mergedV) = mergef(payload, thatPayload)
           val mergedOriginalHash = mergedK.##
           val mergedImprovedHash = improve(mergedOriginalHash)
-          new HashMap(that.rootNode.updated(mergedK, mergedV, mergedOriginalHash, mergedImprovedHash, 0))
+          new HashMap(that.rootNode.updated(mergedK, mergedV, mergedOriginalHash, mergedImprovedHash, 0, replaceValue = true))
         } else {
-          new HashMap(that.rootNode.updated(k, v, originalHash, improved, 0))
+          new HashMap(that.rootNode.updated(k, v, originalHash, improved, 0, replaceValue = true))
         }
       } else if (that.size == 0) {
         val thatPayload@(k, v) = rootNode.getPayload(0)
@@ -225,9 +245,9 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
           val (mergedK, mergedV) = mergef(payload, thatPayload)
           val mergedOriginalHash = mergedK.##
           val mergedImprovedHash = improve(mergedOriginalHash)
-          new HashMap(rootNode.updated(mergedK, mergedV, mergedOriginalHash, mergedImprovedHash, 0))
+          new HashMap(rootNode.updated(mergedK, mergedV, mergedOriginalHash, mergedImprovedHash, 0, replaceValue = true))
         } else {
-          new HashMap(rootNode.updated(k, v, thatOriginalHash, thatImproved, 0))
+          new HashMap(rootNode.updated(k, v, thatOriginalHash, thatImproved, 0, replaceValue = true))
         }
       } else {
         val builder = new HashMapBuilder[K, V1]
@@ -393,7 +413,20 @@ private[immutable] sealed abstract class MapNode[K, +V] extends Node[MapNode[K, 
 
   def containsKey(key: K, originalHash: Int, hash: Int, shift: Int): Boolean
 
-  def updated[V1 >: V](key: K, value: V1, originalHash: Int, hash: Int, shift: Int): MapNode[K, V1]
+  /** Returns a MapNode with the passed key-value assignment added
+    *
+    * @param key the key to add to the MapNode
+    * @param value the value to associate with `key`
+    * @param originalHash the original hash of `key`
+    * @param hash the improved hash of `key`
+    * @param shift the shift of the node (distanceFromRoot * BitPartitionSize)
+    * @param replaceValue if true, then the value currently associated to `key` will be replaced with the passed value
+    *                     argument.
+    *                     if false, then the key will be inserted if not already present, however if the key is present
+    *                     then the passed value will not replace the current value. That is, if `false`, then this
+    *                     method has `update if not exists` semantics.
+    */
+  def updated[V1 >: V](key: K, value: V1, originalHash: Int, hash: Int, shift: Int, replaceValue: Boolean): MapNode[K, V1]
 
   def removed[V1 >: V](key: K, originalHash: Int, hash: Int, shift: Int): MapNode[K, V1]
 
@@ -570,7 +603,7 @@ private final class BitmapIndexedMapNode[K, +V](
   }
 
 
-  def updated[V1 >: V](key: K, value: V1, originalHash: Int, keyHash: Int, shift: Int): BitmapIndexedMapNode[K, V1] = {
+  def updated[V1 >: V](key: K, value: V1, originalHash: Int, keyHash: Int, shift: Int, replaceValue: Boolean): BitmapIndexedMapNode[K, V1] = {
     val mask = maskFrom(keyHash, shift)
     val bitpos = bitposFrom(mask)
 
@@ -579,10 +612,12 @@ private final class BitmapIndexedMapNode[K, +V](
       val key0 = getKey(index)
       val key0UnimprovedHash = getHash(index)
       if (key0UnimprovedHash == originalHash && key0 == key) {
-        val value0 = this.getValue(index)
-        if ((key0.asInstanceOf[AnyRef] eq key.asInstanceOf[AnyRef]) && (value0.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]))
-          this
-        else copyAndSetValue(bitpos, key, value)
+        if (replaceValue) {
+          val value0 = this.getValue(index)
+          if ((key0.asInstanceOf[AnyRef] eq key.asInstanceOf[AnyRef]) && (value0.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]))
+            this
+          else copyAndSetValue(bitpos, key, value)
+        } else this
       } else {
         val value0 = this.getValue(index)
         val key0Hash = improve(key0UnimprovedHash)
@@ -593,7 +628,7 @@ private final class BitmapIndexedMapNode[K, +V](
     } else if ((nodeMap & bitpos) != 0) {
       val index = indexFrom(nodeMap, mask, bitpos)
       val subNode = this.getNode(index)
-      val subNodeNew = subNode.updated(key, value, originalHash, keyHash, shift + BitPartitionSize)
+      val subNodeNew = subNode.updated(key, value, originalHash, keyHash, shift + BitPartitionSize, replaceValue)
 
       if (subNodeNew eq subNode) this else copyAndSetNode(bitpos, subNode, subNodeNew)
     } else copyAndInsertValue(bitpos, key, originalHash, keyHash, value)
@@ -656,7 +691,7 @@ private final class BitmapIndexedMapNode[K, +V](
           subNodeBm.updateWithShallowMutations(key, value, originalHash, keyHash, shift + BitPartitionSize, 0)
           subNodeBm
         case _ =>
-          val result = subNode.updated(key, value, originalHash, keyHash, shift + BitPartitionSize)
+          val result = subNode.updated(key, value, originalHash, keyHash, shift + BitPartitionSize, replaceValue = true)
           if (result ne subNode) {
             returnMutableNodeMap |= bitpos
           }
@@ -1180,7 +1215,7 @@ private final class BitmapIndexedMapNode[K, +V](
       else if (bm.size == 0 || (bm eq this)) return this
       else if (bm.size == 1) {
         val originalHash = bm.getHash(0)
-        return this.updated(bm.getKey(0), bm.getValue(0), originalHash, improve(originalHash), shift)
+        return this.updated(bm.getKey(0), bm.getValue(0), originalHash, improve(originalHash), shift, replaceValue = true)
       }
       // if we go through the merge and the result does not differ from `bm`, we can just return `bm`, to improve sharing
       // So, `anyChangesMadeSoFar` will be set to `true` as soon as we encounter a difference between the
@@ -1318,12 +1353,7 @@ private final class BitmapIndexedMapNode[K, +V](
               val leftOriginalHash = getHash(leftDataIdx)
               val leftImproved = improve(leftOriginalHash)
 
-              // TODO: Implement MapNode#updatedIfNotContains
-              val updated = if (n.containsKey(leftKey, leftOriginalHash, leftImproved, nextShift)) {
-                n
-              } else {
-                n.updated(leftKey, leftValue, leftOriginalHash, leftImproved, nextShift)
-              }
+              val updated = n.updated(leftKey, leftValue, leftOriginalHash, leftImproved, nextShift, replaceValue = false)
 
               if (updated ne n) {
                 anyChangesMadeSoFar = true
@@ -1348,7 +1378,8 @@ private final class BitmapIndexedMapNode[K, +V](
                 value = bm.getValue(rightDataIdx),
                 originalHash = bm.getHash(rightDataIdx),
                 hash = improve(rightOriginalHash),
-                shift = nextShift
+                shift = nextShift,
+                replaceValue = true
               )
             }
 
@@ -1463,8 +1494,81 @@ private final class BitmapIndexedMapNode[K, +V](
   }
 
   override def filterImpl(pred: ((K, V)) => Boolean, flipped: Boolean): BitmapIndexedMapNode[K, V] = {
-    if (size == 0) this else if (size == 1) {
+    if (size == 0) this
+    else if (size == 1) {
       if (pred(getPayload(0)) != flipped) this else MapNode.empty
+    } else if (nodeMap == 0) {
+      // Performance optimization for nodes of depth 1:
+      //
+      // this node has no "node" children, all children are inlined data elems, therefor logic is significantly simpler
+      // approach:
+      //   * traverse the content array, accumulating in `newDataMap: Int` any bit positions of keys which pass the filter
+      //   * (bitCount(newDataMap) * TupleLength) tells us the new content array and originalHashes array size, so now perform allocations
+      //   * traverse the content array once more, placing each passing element (according to `newDatamap`) in the new content and originalHashes arrays
+      //
+      // note:
+      //   * this optimization significantly improves performance of not only small trees, but also larger trees, since
+      //     even non-root nodes are affected by this improvement, and large trees will consist of many nodes as
+      //     descendants
+      //
+      val minimumIndex: Int = Integer.numberOfTrailingZeros(dataMap)
+      val maximumIndex: Int = Node.BranchingFactor - Integer.numberOfLeadingZeros(dataMap)
+
+      var newDataMap = 0
+      var newCachedHashCode = 0
+      var dataIndex = 0
+
+      var i = minimumIndex
+
+      while(i < maximumIndex) {
+        val bitpos = bitposFrom(i)
+
+        if ((bitpos & dataMap) != 0) {
+          val payload = getPayload(dataIndex)
+          val passed = pred(payload) != flipped
+
+          if (passed) {
+            newDataMap |= bitpos
+            newCachedHashCode += improve(getHash(dataIndex))
+          }
+
+          dataIndex += 1
+        }
+
+        i += 1
+      }
+
+      if (newDataMap == 0) {
+        MapNode.empty
+      } else if (newDataMap == dataMap) {
+        this
+      } else {
+        val newSize = Integer.bitCount(newDataMap)
+        val newContent = new Array[Any](newSize * TupleLength)
+        val newOriginalHashCodes = new Array[Int](newSize)
+        val newMaximumIndex: Int = Node.BranchingFactor - Integer.numberOfLeadingZeros(newDataMap)
+
+        var j = Integer.numberOfTrailingZeros(newDataMap)
+
+        var newDataIndex = 0
+
+
+        while (j < newMaximumIndex) {
+          val bitpos = bitposFrom(j)
+          if ((bitpos & newDataMap) != 0) {
+            val oldIndex = indexFrom(dataMap, bitpos)
+            newContent(newDataIndex * TupleLength) = content(oldIndex * TupleLength)
+            newContent(newDataIndex * TupleLength + 1) = content(oldIndex * TupleLength + 1)
+            newOriginalHashCodes(newDataIndex) = originalHashes(oldIndex)
+            newDataIndex += 1
+          }
+          j += 1
+        }
+
+        new BitmapIndexedMapNode(newDataMap, 0, newContent, newOriginalHashCodes, newSize, newCachedHashCode)
+      }
+
+
     } else {
       val allMap = dataMap | nodeMap
       val minimumIndex: Int = Integer.numberOfTrailingZeros(allMap)
@@ -1663,14 +1767,17 @@ private final class HashCollisionMapNode[K, +V ](
       index >= 0 && (content(index)._2.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef])
     }
 
-  def updated[V1 >: V](key: K, value: V1, originalHash: Int, hash: Int, shift: Int): MapNode[K, V1] = {
+  def updated[V1 >: V](key: K, value: V1, originalHash: Int, hash: Int, shift: Int, replaceValue: Boolean): MapNode[K, V1] = {
     val index = indexOf(key)
     if (index >= 0) {
-
-      if (content(index)._2.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) {
-        this
+      if (replaceValue) {
+        if (content(index)._2.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) {
+          this
+        } else {
+          new HashCollisionMapNode[K, V1](originalHash, hash, content.updated[(K, V1)](index, (key, value)))
+        }
       } else {
-        new HashCollisionMapNode[K, V1](originalHash, hash, content.updated[(K, V1)](index, (key, value)))
+        this
       }
     } else {
       new HashCollisionMapNode[K, V1](originalHash, hash, content.appended[(K, V1)]((key, value)))

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -16,7 +16,7 @@ package immutable
 
 
 import scala.collection.immutable.Set.Set4
-import scala.collection.mutable.{Builder, ReusableBuilder, ImmutableBuilder}
+import scala.collection.mutable.{Builder, ReusableBuilder}
 import scala.language.higherKinds
 
 
@@ -112,6 +112,13 @@ object Set extends IterableFactory[Set] {
     override def size: Int = 0
     override def isEmpty = true
     override def knownSize: Int = size
+    override def filter(pred: Any => Boolean): Set[Any] = this
+    override def filterNot(pred: Any => Boolean): Set[Any] = this
+    override def removedAll(that: IterableOnce[Any]): Set[Any] = this
+    override def diff(that: collection.Set[Any]): Set[Any] = this
+    override def subsetOf(that: collection.Set[Any]): Boolean = true
+    override def intersect(that: collection.Set[Any]): Set[Any] = this
+    override def view: View[Any] = View.empty
     def contains(elem: Any): Boolean = false
     def incl(elem: Any): Set[Any] = new Set1(elem)
     def excl(elem: Any): Set[Any] = this

--- a/test/scalacheck/scala/collection/immutable/ImmutableChampHashMapProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ImmutableChampHashMapProperties.scala
@@ -78,7 +78,7 @@ object ImmutableChampHashMapProperties extends Properties("HashMap") {
   }
 
   property("(xs ++ ys).toMap == xs.toMap ++ ys.toMap") = forAll { (xs: Seq[(K, V)],ys: Seq[(K, V)]) =>
-    (xs ++ ys).toMap == xs.toMap ++ ys.toMap
+    (xs ++ ys).toMap ?= xs.toMap ++ ys.toMap
   }
 
   property("HashMapBuilder produces the same Map as MapBuilder") = forAll { (xs: Seq[(K, V)]) =>
@@ -289,4 +289,29 @@ object ImmutableChampHashMapProperties extends Properties("HashMap") {
     (hm ?= clone).label("hm is unmutated") &&
       ((mhs : collection.Set[K]) ?= hs).label("mhs is unmutated")
   }
+
+  property("xs.keySet + k == xs.map(_._1).to(Set) + k") = forAll { (hm: HashMap[K, V], k: K) =>
+    (hm.keySet + k) ?= (hm.map((kv: (K, V)) => kv._1).to(Set) + k)
+  }
+  property("xs.keySet - k == xs.map(_._1).to(Set) - k") = forAll { (hm: HashMap[K, V], k: K) =>
+    (hm.keySet - k) ?= (hm.map((kv: (K, V)) => kv._1).to(Set) - k)
+  }
+  property("xs.keySet removedAll ys == xs.map(_._1).to(Set) removedAll ys") = forAll { (hm: HashMap[K, V], ys: List[K]) =>
+    (hm.keySet.removedAll(ys) ?= hm.map((kv: (K, V)) => kv._1).to(Set).removedAll(ys)).label("RemovedAll(List)") &&
+      (hm.keySet.removedAll(ys.toSet) ?= hm.map((kv: (K, V)) => kv._1).to(Set).removedAll(ys)).label("RemovedAll(Set)")
+  }
+  property("xs.keySet filter p == xs.map(_._1).to(Set) filter p") = forAll { (hm: HashMap[K, V], p: (K => Boolean)) =>
+    hm.keySet.filter(p) ?= hm.to(List).map(_._1).to(Set).filter(p)
+  }
+
+  property("xs.keySet filterNot p == xs.map(_._1).to(Set) filterNot p") = forAll { (hm: HashMap[K, V], p: (K => Boolean)) =>
+    hm.keySet.filterNot(p) ?= hm.to(List).map(_._1).to(Set).filterNot(p)
+  }
+  property("xs.keySet ks == xs.map(_._1).to(Set) concat ks") = forAll { (hm: HashMap[K, V], ks: List[K]) =>
+    hm.keySet.concat(ks) ?= hm.to(List).map(_._1).to(Set).concat(ks)
+  }
+  property("xs.keySet diff ks == xs.map(_._1).to(Set) diff ks") = forAll { (hm: HashMap[K, V], ks: Set[K]) =>
+    hm.keySet.diff(ks) ?= hm.to(List).map(_._1).to(Set).diff(ks)
+  }
+
 }

--- a/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
@@ -325,6 +325,14 @@ object ImmutableChampHashSetProperties extends Properties("immutable.HashSet") {
     val actual: collection.Set[Int] = left -- right
     actual ?= expected
   }
+  property("(xs.filter(p) == xs.toList.filter(p).toSet") = forAll { xs: HashSet[Int] =>
+    val isEven = (i: Int) => i % 2 == 0
+    xs.toList.filter(isEven).toSet =? xs.filter(isEven)
+  }
+  property("(xs.filterNot(p) == xs.toList.filterNot(p).toSet") = forAll { xs: HashSet[Int] =>
+    val isEven = (i: Int) => i % 2 == 0
+    xs.toList.filterNot(isEven).toSet =? xs.filterNot(isEven)
+  }
 
   property("xs ++ list == list.foldLeft(xs)(_ + _)") = forAll { (xs: HashSet[Int], list: List[Int]) =>
     xs.concat(list) ?= list.foldLeft(xs)(_ + _)


### PR DESCRIPTION
Currently, `hashMap.keySet + newKey` will build and entirely new HashSet by adding each key from the map one-at-a-time, then add the new key.

Now, that keySet will simply immutably add `newKey -> null` to its underlying HashMap, and take the result's keySet.

Also, currently  `hashMap.keySet - newKey` does the same thing and then removes the new key. Now, we simply remove `newKey` from the underlying hashMap, and take that hashMap's `keySet`.

Edit:
Also implemented are methods removedAll,filter,filterNot,concat,diff.

### Benchmarks

```
[info] Benchmark                                (size)  Mode  Cnt          Score           Error  Units
[info] HashMapKeySetBenchmark.keyset_incl            0  avgt    6         28.103 ±         7.391  ns/op
[info] HashMapKeySetBenchmark.keyset_incl          100  avgt    6       2725.440 ±      1954.695  ns/op
[info] HashMapKeySetBenchmark.keyset_incl         1000  avgt    6      23617.398 ±     18553.029  ns/op
[info] HashMapKeySetBenchmark.keyset_incl        10000  avgt    6     228002.995 ±    139458.098  ns/op
[info] HashMapKeySetBenchmark.keyset_incl       100000  avgt    6    2924653.831 ±    751618.407  ns/op
[info] HashMapKeySetBenchmark.keyset_incl      1000000  avgt    6   33419223.947 ±  10151878.949  ns/op
[info] HashMapKeySetBenchmark.old_keyset_incl        0  avgt    6        177.658 ±        73.742  ns/op
[info] HashMapKeySetBenchmark.old_keyset_incl      100  avgt    6      26941.945 ±     13063.225  ns/op
[info] HashMapKeySetBenchmark.old_keyset_incl     1000  avgt    6     786708.786 ±    678236.136  ns/op
[info] HashMapKeySetBenchmark.old_keyset_incl    10000  avgt    6    5212476.176 ±   5973245.366  ns/op
[info] HashMapKeySetBenchmark.old_keyset_incl   100000  avgt    6   43123377.800 ±   9370534.805  ns/op
[info] HashMapKeySetBenchmark.old_keyset_incl  1000000  avgt    6  942625538.167 ± 394808816.417  ns/op


[info] Benchmark                                (size)  Mode  Cnt          Score          Error  Units
[info] HashMapKeySetBenchmark.keyset_excl            0  avgt    6          8.559 ±        2.751  ns/op
[info] HashMapKeySetBenchmark.keyset_excl          100  avgt    6        260.350 ±       93.318  ns/op
[info] HashMapKeySetBenchmark.keyset_excl         1000  avgt    6        254.287 ±       81.839  ns/op
[info] HashMapKeySetBenchmark.keyset_excl        10000  avgt    6        364.297 ±      159.606  ns/op
[info] HashMapKeySetBenchmark.keyset_excl       100000  avgt    6        541.303 ±      172.968  ns/op
[info] HashMapKeySetBenchmark.keyset_excl      1000000  avgt    6        349.217 ±      125.918  ns/op
[info] HashMapKeySetBenchmark.old_keyset_excl        0  avgt    6         30.162 ±        8.496  ns/op
[info] HashMapKeySetBenchmark.old_keyset_excl      100  avgt    6      30977.529 ±    23339.266  ns/op
[info] HashMapKeySetBenchmark.old_keyset_excl     1000  avgt    6     402904.727 ±   137605.331  ns/op
[info] HashMapKeySetBenchmark.old_keyset_excl    10000  avgt    6    3823408.058 ±   336888.592  ns/op
[info] HashMapKeySetBenchmark.old_keyset_excl   100000  avgt    6   46202949.029 ± 19961053.077  ns/op
[info] HashMapKeySetBenchmark.old_keyset_excl  1000000  avgt    6  582186487.833 ± 82206718.437  ns/op
```


### :bulb: ideas

### TODO

- [x] Remove `HashMap#oldKeySet` used for benchmarking

~- [ ] Benchmark methods removedAll,filter,filterNot,concat,diff,partition to prove they also enjoy performance benefits from the approach.~