### PR TITLE
TreeMap#keySet does no copying by only transferring inner Tree to TreeSet

### DIFF
--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -47,13 +47,15 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V])(implicit va
 
   def this()(implicit ordering: Ordering[K]) = this(null)(ordering)
 
-  private[this] def newMapOrSelf[V1 >: V](t: RB.Tree[K, V1]) = if(t eq tree) this else new TreeMap[K, V1](t)
+  private[this] def newMapOrSelf[V1 >: V](t: RB.Tree[K, V1]): TreeMap[K, V1] = if(t eq tree) this else new TreeMap[K, V1](t)
 
-  override def sortedMapFactory = TreeMap
+  override def sortedMapFactory: SortedMapFactory[TreeMap] = TreeMap
 
   def iterator: Iterator[(K, V)] = RB.iterator(tree)
 
   def keysIteratorFrom(start: K): Iterator[K] = RB.keysIterator(tree, Some(start))
+
+  override def keySet: TreeSet[K] = new TreeSet(tree)(ordering)
 
   def iteratorFrom(start: K): Iterator[(K, V)] = RB.iterator(tree, Some(start))
 

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -35,7 +35,7 @@ import immutable.{RedBlackTree => RB}
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
-final class TreeSet[A] private (private[immutable] val tree: RB.Tree[A, Null])(implicit val ordering: Ordering[A])
+final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[A, Any])(implicit val ordering: Ordering[A])
   extends AbstractSet[A]
     with SortedSet[A]
     with SortedSetOps[A, TreeSet, TreeSet[A]]
@@ -48,7 +48,7 @@ final class TreeSet[A] private (private[immutable] val tree: RB.Tree[A, Null])(i
 
   override def sortedIterableFactory = TreeSet
 
-  private[this] def newSetOrSelf(t: RB.Tree[A, Null]) = if(t eq tree) this else new TreeSet[A](t)
+  private[this] def newSetOrSelf(t: RB.Tree[A, Any]) = if(t eq tree) this else new TreeSet[A](t)
 
   override def size: Int = RB.count(tree)
 
@@ -213,7 +213,7 @@ object TreeSet extends SortedIterableFactory[TreeSet] {
     }
 
   def newBuilder[A](implicit ordering: Ordering[A]): Builder[A, TreeSet[A]] = new ReusableBuilder[A, TreeSet[A]] {
-    private[this] var tree: RB.Tree[A, Null] = null
+    private[this] var tree: RB.Tree[A, Any] = null
     def addOne(elem: A): this.type = { tree = RB.update(tree, elem, null, overwrite = false); this }
     override def addAll(xs: IterableOnce[A]): this.type = {
       xs match {


### PR DESCRIPTION
`TreeMap#keySet` currently will create a new Set which, when modified, will trigger a full deep copy of the map keys into a new Set.

Instead, we change TreeSet to have an underlying tree of type `Tree[A, Any]` rather than `Tree[A, Null]`, and simply ignore any values stored in the `Any`s. This essentially turns `TreeMap#keySet` into a no-op.

### Potential reasons not to allow this

* Since the values are not being "zeroed out", they will not be garbage collected. Though if this is a serious concern, maybe we could add a scaladoc explaining that if you want the values to be GC'd, do something like `treeMap.iterator.to(TreeSet)`


## Benchmarks!

* the following benchmarks benchmark the behaviour of:
  * `treeMap.keySet - existingValue`
  * `treeMap.keySet + newValue`
  * `treeMap.oldKeySet - existingValue`
  * `treeMap.oldKeySet + newValue`  
```
[info] Benchmark                      (size)  Mode  Cnt        Score        Error  Units
[info] MapBenchmark.keyset_excl            0  avgt    6       19.006 ±      2.532  ns/op
[info] MapBenchmark.keyset_excl           10  avgt    6       75.278 ±      9.936  ns/op
[info] MapBenchmark.keyset_excl         1000  avgt    6      179.175 ±     23.782  ns/op
[info] MapBenchmark.keyset_excl        10000  avgt    6      237.307 ±     23.803  ns/op
[info] MapBenchmark.keyset_excl       100000  avgt    6      298.336 ±     59.395  ns/op
[info] MapBenchmark.keyset_excl      1000000  avgt    6      370.251 ±     56.013  ns/op
[info] MapBenchmark.keyset_incl            0  avgt    6       22.552 ±      0.750  ns/op
[info] MapBenchmark.keyset_incl           10  avgt    6       35.853 ±      2.382  ns/op
[info] MapBenchmark.keyset_incl         1000  avgt    6       87.752 ±      6.868  ns/op
[info] MapBenchmark.keyset_incl        10000  avgt    6      114.505 ±      2.039  ns/op
[info] MapBenchmark.keyset_incl       100000  avgt    6      141.777 ±      2.068  ns/op
[info] MapBenchmark.keyset_incl      1000000  avgt    6      170.921 ±      2.001  ns/op
[info] MapBenchmark.old_keyset_excl        0  avgt    6       84.470 ±      3.612  ns/op
[info] MapBenchmark.old_keyset_excl       10  avgt    6      261.250 ±     13.085  ns/op
[info] MapBenchmark.old_keyset_excl     1000  avgt    6     7920.724 ±     51.274  ns/op
[info] MapBenchmark.old_keyset_excl    10000  avgt    6    97249.755 ±   1040.499  ns/op
[info] MapBenchmark.old_keyset_excl   100000  avgt    6  1053655.934 ±  20767.632  ns/op
[info] MapBenchmark.old_keyset_excl  1000000  avgt    6  9570122.164 ± 224791.632  ns/op
[info] MapBenchmark.old_keyset_incl        0  avgt    6       90.871 ±      2.222  ns/op
[info] MapBenchmark.old_keyset_incl       10  avgt    6      172.646 ±      2.270  ns/op
[info] MapBenchmark.old_keyset_incl     1000  avgt    6     7787.613 ±    279.998  ns/op
[info] MapBenchmark.old_keyset_incl    10000  avgt    6    96754.475 ±   3025.751  ns/op
[info] MapBenchmark.old_keyset_incl   100000  avgt    6  1162963.769 ±  35115.460  ns/op
[info] MapBenchmark.old_keyset_incl  1000000  avgt    6  9498622.033 ± 116221.941  ns/op
```