### PR TITLE
Fix HKT unification bugs

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3473,6 +3473,7 @@ trait Types
      */
     protected final def sharesConstraints(other: Type): Boolean = other match {
       case other: TypeVar => constr == other.constr // scala/bug#8237 avoid cycles. Details in pos/t8237.scala
+      case PolyType(_, other: TypeVar) => constr == other.constr
       case _ => false
     }
     private[Types] def suspended_=(b: Boolean): Unit = _suspended = if (b) ConstantTrue else ConstantFalse

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -382,18 +382,14 @@ trait TypeComparers {
   def isHKSubType(tp1: Type, tp2: Type, depth: Depth): Boolean = {
 
     def isSubHKTypeVar(tp1: Type, tp2: Type) = (tp1, tp2) match {
-      case (tv1 @ TypeVar(_, _), tv2 @ TypeVar(_, _)) =>
-        reporter.warning(tv1.typeSymbol.pos,
-          sm"""|compiler bug: Unexpected code path: testing two type variables for subtype relation:
-               |  ${tv1} <:< ${tv2}
-               |Please report bug at https://github.com/scala/bug/issues
-            """.trim)
-        false
-      case (tp1, tv2 @ TypeVar(_, _)) =>
+      case (tv1: TypeVar, tv2: TypeVar) =>
+        devWarning(sm"Unexpected code path: testing two type variables for subtype relation: $tv1 <:< $tv2")
+        tv1 eq tv2
+      case (_, tv2: TypeVar) =>
         val ntp1 = tp1.normalize
         (tv2.params corresponds ntp1.typeParams)(methodHigherOrderTypeParamsSubVariance) &&
         { tv2.addLoBound(ntp1); true }
-      case (tv1 @ TypeVar(_, _), tp2) =>
+      case (tv1: TypeVar, _) =>
         val ntp2 = tp2.normalize
         (ntp2.typeParams corresponds tv1.params)(methodHigherOrderTypeParamsSubVariance) &&
         { tv1.addHiBound(ntp2); true }

--- a/test/files/pos/t11303.scala
+++ b/test/files/pos/t11303.scala
@@ -1,0 +1,19 @@
+// scalac: -Xfatal-warnings
+import scala.language.higherKinds
+
+object Test {
+  sealed trait Gadt[F[_], O, R]
+  final case class Output[F[_], O](values: List[O]) extends Gadt[F, O, Unit]
+
+  final case class Algebra[F[_], A]()
+  final case class Free[F[_], A](fa: F[A])
+
+  def values[F[_], O, R](gadt: Gadt[F, O, R]): List[O] =
+    gadt match { case o: Output[F, O] => o.values }
+
+  def free[F[_], A](f: Free[({ type G[x] = Algebra[F, x] })#G, A]): Algebra[F, A] = f.fa
+  def pure[F[_], A]: Free[({ type G[x] = Algebra[F, x] })#G, A] = Free(Algebra())
+
+  val vs = values(Output[Option, String](List("GADT")))
+  val a: Algebra[Option, Int] = free(pure)
+}


### PR DESCRIPTION
* Amend `TypeVar.sharesConstraints` to handle HKTs
* Demote `TypeVar <:< TypeVar` warning in `isSubHKTypeVar` to `devWarning`

    It's a valid code path because type inference substitutes
    type parameters with type variables both in formal parameter
    types and in actual argument types before checking conformance.

Fixes scala/bug#11303