### PR TITLE
Fixed bug #11306. Added a junit test and modified the test 'hasCorrec…

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -127,9 +127,17 @@ sealed class ListMap[K, +V]
       else containsInternal(cur.next, k)
 
     override def updated[V2 >: V1](k: K, v: V2): ListMap[K, V2] = {
-      val (m, k0) = removeInternal(k, this, Nil)
-      new m.Node[V2](k0, v)
+      replaceInternal(k, v, this, Nil)
     }
+
+    @tailrec private[this] def replaceInternal[V2 >: V1](k: K, v : V2, cur: ListMap[K, V2], acc: List[ListMap[K, V2]]): ListMap[K, V2] =
+      if (cur.isEmpty) new this.Node(k,v)
+      else if (k == cur.key) {
+        val nextNode : ListMap[K, V2] = cur.next
+        val updatedCurrentNode : ListMap[K, V2] = new nextNode.Node(cur.key,v)
+        acc.foldLeft(updatedCurrentNode) { (t, h) => new t.Node(h.key, h.value) }
+      }
+      else replaceInternal(k, v, cur.next, cur :: acc)
 
     override def removed(k: K): ListMap[K, V1] = removeInternal(k, this, Nil)._1
 

--- a/test/junit/scala/collection/immutable/ListMapTest.scala
+++ b/test/junit/scala/collection/immutable/ListMapTest.scala
@@ -14,10 +14,15 @@ class ListMapTest {
     assertEquals(ListMap(2 -> 2, 3 -> 3, 4 -> 4, 5 -> 5), m.tail)
   }
 
+  /*
+  Modifying this test as part of bug fix (bug #11306)
+  where updating existing key retains its position
+  */
+
   @Test
   def hasCorrectBuilder(): Unit = {
     val m = ListMap("a" -> "1", "b" -> "2", "c" -> "3", "b" -> "2.2", "d" -> "4")
-    assertEquals(List("a" -> "1", "c" -> "3", "b" -> "2.2", "d" -> "4"), m.toList)
+    assertEquals(List("a" -> "1","b" -> "2.2", "c" -> "3",  "d" -> "4"), m.toList)
   }
 
   @Test
@@ -51,4 +56,16 @@ class ListMapTest {
     val m = ListMap("a" -> "1", "b" -> "2", "c" -> "3", "d" -> "4", "e" -> "5")
     assertEquals(List("A", "B", "C", "D", "E"), m.keys.map(_.toUpperCase).toList)
   }
+
+  @Test
+  def updatingExistingKeyShouldRetainItsPosition : Unit = {
+    val m = ListMap(1 -> 100, 2 -> 200, 3 -> 500, 10 -> 455)
+    val newNode1 = (2 -> 2343)
+    val result1 = m + newNode1
+    assertEquals(result1, ListMap(1 -> 100, newNode1, 3 -> 500, 10 -> 455))
+    val newNode2 = (1 -> 101)
+    val result2 = result1 + newNode2
+    assertEquals(result2, ListMap(1 -> 101, newNode1, 3 -> 500, 10 -> 455))
+  }
+
 }


### PR DESCRIPTION
…tBuilder' as part of this bug fix. Please have a look at this closed PR for more details https://github.com/scala/scala/pull/7556