### PR TITLE
incorrect endsWith implementation on Range #11328

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -609,15 +609,17 @@ private class RangeIterator(
   }
 
   override def drop(n: Int): Iterator[Int] = {
-    val longPos = _next.toLong + step * n
-    if (step > 0) {
-      _next = Math.min(lastElement, longPos).toInt
-      _hasNext = longPos <= lastElement
+    if (n > 0) {
+      val longPos = _next.toLong + step * n
+      if (step > 0) {
+        _next = Math.min(lastElement, longPos).toInt
+        _hasNext = longPos <= lastElement
+      }
+      else if (step < 0) {
+        _next = Math.max(lastElement, longPos).toInt
+        _hasNext = longPos >= lastElement
+      }
     }
-    else if (step < 0) {
-      _next = Math.max(lastElement, longPos).toInt
-      _hasNext = longPos >= lastElement
-    }
-    this
+      this
   }
 }

--- a/test/junit/scala/collection/immutable/RangeTest.scala
+++ b/test/junit/scala/collection/immutable/RangeTest.scala
@@ -89,4 +89,19 @@ class RangeTest {
     assertEquals(20, (20 to 1 by -1).min(Ordering.Int.reverse))
     assertEquals(1, (20 to 1 by -1).max(Ordering.Int.reverse))
   }
+
+  @Test
+  def testRangeEndsWith(): Unit = {
+    assertFalse((0 until 0).endsWith(List(-4, -3, -2, -1)))
+    assertTrue((-8 until -1).endsWith((-8 until -1).takeRight(1)))
+    assertTrue((0 until 0).endsWith(0 until 0))
+  }
+
+  @Test
+  def testRangeDrop(): Unit = {
+    assertTrue((0 until 0).iterator.drop(-4).toList.isEmpty)
+    assertEquals(4, (1 to 4).iterator.drop(-4).toList.size)
+  }
+
+
 }


### PR DESCRIPTION
I'm not sure if there is a further underlying cause with Seq.endsWith switching from GenSeq to Iterator in its implementation, but this tiny fix resolved the case indicated in the issue https://github.com/scala/bug/issues/11328 and some obvious examples I tried still worked fine. I'm curious if there are some additional cases I'm not accounting for, or if there is something deeper in the implementation that would need to be addressed. 

The issue seemed to only appear when `length - that.size` in `val i = iterator.drop(length - that.size)` was negative.

In any case, this is my first dive into the Scala codebase and it's a great learning experience! I appreciate the excellent contributor documentation.

Thanks!

### Test Results
```
[info] Test scala.collection.SeqTest.testEndsWith started
[info] Test scala.collection.SeqTest.hasCorrectIndexOfSlice started
[info] Test scala.collection.SeqTest.testLengthIs started
[info] Test scala.collection.SeqTest.hasCorrectLastIndexOfSlice started
[info] Test scala.collection.SeqTest.unionAlias started
[info] Test scala.collection.SeqTest.t9936$u0020indexWhere started
[info] Test scala.collection.SeqTest.hasCorrectIntersect started
[info] Test scala.collection.SeqTest.combinations started
[info] Test scala.collection.SeqTest.hasCorrectDiff started
[info] Test scala.collection.SeqTest.hasCorrectDistinct started
[info] Test scala.collection.SeqTest.hasCorrectDistinctBy started
[info] Test run finished: 0 failed, 0 ignored, 11 total, 0.006s
```

