### PR TITLE
Treat WildcardType as kind-polymorphic

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -406,8 +406,8 @@ trait TypeComparers {
         isSub2(tp1.normalize, tp2.normalize)  // @M! normalize reduces higher-kinded case to PolyType's
 
     def isSub2(ntp1: Type, ntp2: Type) = (ntp1, ntp2) match {
-      case (TypeRef(_, AnyClass, _), _)                                     => false                    // avoid some warnings when Nothing/Any are on the other side
-      case (_, TypeRef(_, NothingClass, _))                                 => false
+      case (TypeRef(_, AnyClass, _), _) | (_, TypeRef(_, NothingClass, _))  => false                    // avoid some warnings when Nothing/Any are on the other side
+      case (WildcardType, _) | (_, WildcardType)                            => true                     // treat `?` as kind-polymorphic
       case (pt1: PolyType, pt2: PolyType)                                   => isPolySubType(pt1, pt2)  // @assume both .isHigherKinded (both normalized to PolyType)
       case (_: PolyType, MethodType(ps, _)) if ps exists (_.tpe.isWildcard) => false                    // don't warn on HasMethodMatching on right hand side
       case _                                                                =>                          // @assume !(both .isHigherKinded) thus cannot be subtypes

--- a/test/files/pos/t11239.scala
+++ b/test/files/pos/t11239.scala
@@ -1,0 +1,6 @@
+import scala.language.higherKinds
+
+trait Request[F[_]]
+trait Context { type F[_] }
+final case class AuthedRequest[F[_], A](authInfo: A, req: Request[F])
+final case class HttpRequestContext[C <: Context, Ctx](request: AuthedRequest[C#F, Ctx], context: Ctx)


### PR DESCRIPTION
Necessary due to the special treatment of `?` in `normalize`.

Fixes scala/bug#11239