### PR TITLE
Try to drop symbol literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
         script:
           - sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
           - STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
-          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
+          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info "junit/testOnly scala.lang.stringinterpol.SymbolsTest"
 
       # build the spec using jekyll
       - stage: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
         script:
           - sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
           - STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
-          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info "junit/testOnly scala.lang.stringinterpol.SymbolsTest"
+          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
 
       # build the spec using jekyll
       - stage: build

--- a/build.sbt
+++ b/build.sbt
@@ -125,7 +125,7 @@ headerLicense in ThisBuild  := Some(HeaderLicense.Custom(
      |""".stripMargin
 ))
 
-mimaReferenceVersion in Global := Some("2.12.0")
+mimaReferenceVersion in Global := None
 
 scalaVersion in Global         := versionProps("starr.version")
 

--- a/scripts/jobs/validate/test
+++ b/scripts/jobs/validate/test
@@ -21,7 +21,7 @@ case $prDryRun in
        --warn \
        "setupValidateTest $prRepoUrl" \
        $testExtraArgs \
-       "junit/testOnly scala.lang.stringinterpol.SymbolsTest"
+       testAll
 
     ;;
 

--- a/scripts/jobs/validate/test
+++ b/scripts/jobs/validate/test
@@ -21,7 +21,7 @@ case $prDryRun in
        --warn \
        "setupValidateTest $prRepoUrl" \
        $testExtraArgs \
-       testAll
+       "junit/testOnly scala.lang.stringinterpol.SymbolsTest"
 
     ;;
 

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -690,7 +690,7 @@ self =>
 
     def isLiteralToken(token: Token) = token match {
       case CHARLIT | INTLIT | LONGLIT | FLOATLIT | DOUBLELIT |
-           STRINGLIT | INTERPOLATIONID | SYMBOLLIT | TRUE | FALSE | NULL => true
+           STRINGLIT | INTERPOLATIONID | TRUE | FALSE | NULL        => true
       case _                                                        => false
     }
     def isLiteral = isLiteralToken(in.token)
@@ -1269,15 +1269,12 @@ self =>
 
     /** {{{
      *  SimpleExpr    ::= literal
-     *                  | symbol
      *                  | null
      *  }}}
      */
     def literal(isNegated: Boolean = false, inPattern: Boolean = false, start: Offset = in.offset): Tree = atPos(start) {
       def finish(value: Any): Tree = try newLiteral(value) finally in.nextToken()
-      if (in.token == SYMBOLLIT)
-        Apply(scalaDot(nme.Symbol), List(finish(in.strVal)))
-      else if (in.token == INTERPOLATIONID)
+      if (in.token == INTERPOLATIONID)
         interpolatedString(inPattern = inPattern)
       else finish(in.token match {
         case CHARLIT                => in.charVal
@@ -2082,7 +2079,7 @@ self =>
             in.nextToken()
             atPos(start, start) { Ident(nme.WILDCARD) }
           case CHARLIT | INTLIT | LONGLIT | FLOATLIT | DOUBLELIT |
-               STRINGLIT | INTERPOLATIONID | SYMBOLLIT | TRUE | FALSE | NULL =>
+               STRINGLIT | INTERPOLATIONID | TRUE | FALSE | NULL   =>
             literal(inPattern = true)
           case LPAREN =>
             atPos(start)(makeParens(noSeq.patterns()))

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -562,7 +562,7 @@ trait Scanners extends ScannersCommon {
                     wholeLine.count(_ == '\'') > 1
                   case _ => false
                 }
-              if (token == SYMBOLLIT && offset == lastOffset) s"""$unclosed (or use " for string literal "$strVal")"""
+              if (token == IDENTIFIER && offset == lastOffset) s"""$unclosed (or use " for string literal "$strVal")"""
               else if (maybeMistakenQuote) s"""$unclosed (or use " not ' for string literal)"""
               else unclosed
             }
@@ -661,7 +661,7 @@ trait Scanners extends ScannersCommon {
 
     /** Can token end a statement? */
     def inLastOfStat(token: Token) = token match {
-      case CHARLIT | INTLIT | LONGLIT | FLOATLIT | DOUBLELIT | STRINGLIT | SYMBOLLIT |
+      case CHARLIT | INTLIT | LONGLIT | FLOATLIT | DOUBLELIT | STRINGLIT |
            IDENTIFIER | BACKQUOTED_IDENT | THIS | NULL | TRUE | FALSE | RETURN | USCORE |
            TYPE | XMLSTART | RPAREN | RBRACKET | RBRACE =>
         true
@@ -1097,7 +1097,7 @@ trait Scanners extends ScannersCommon {
     }
 
     /** Parse character literal if current character is followed by \',
-     *  or follow with given op and return a symbol literal token
+     *  or follow with given op and return an identifier token.
      */
     def charLitOr(op: () => Unit): Unit = {
       putChar(ch)
@@ -1108,7 +1108,7 @@ trait Scanners extends ScannersCommon {
         setStrVal()
       } else {
         op()
-        token = SYMBOLLIT
+        token = IDENTIFIER
         strVal = name.toString
       }
     }
@@ -1261,7 +1261,6 @@ trait Scanners extends ScannersCommon {
     case FLOATLIT => "float literal"
     case DOUBLELIT => "double literal"
     case STRINGLIT | STRINGPART | INTERPOLATIONID => "string literal"
-    case SYMBOLLIT => "symbol literal"
     case LPAREN => "'('"
     case RPAREN => "')'"
     case LBRACE => "'{'"

--- a/src/compiler/scala/tools/nsc/ast/parser/Tokens.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Tokens.scala
@@ -15,7 +15,6 @@ package ast.parser
 
 object Tokens extends CommonTokens {
   final val STRINGPART = 7 // a part of an interpolated string
-  final val SYMBOLLIT = 8
   final val INTERPOLATIONID = 9 // the lead identifier of an interpolated string
 
   def isLiteral(code: Int) = code >= CHARLIT && code <= INTERPOLATIONID

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -216,9 +216,6 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
   def                     srBoxesRunTimeRef         : ClassBType = _srBoxesRunTimeRef.get
   private[this] lazy val _srBoxesRunTimeRef         : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[scala.runtime.BoxesRunTime]))
 
-  def                     srSymbolLiteral           : ClassBType = _srSymbolLiteral.get
-  private[this] lazy val _srSymbolLiteral           : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[scala.runtime.SymbolLiteral]))
-
   def                     srStructuralCallSite      : ClassBType = _srStructuralCallSite.get
   private[this] lazy val _srStructuralCallSite      : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[scala.runtime.StructuralCallSite]))
 

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -347,7 +347,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
  *  @since   1.0
  */
 @SerialVersionUID(1234815782226070388L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
-final case class Some[+A](@deprecatedName('x, "2.12.0") value: A) extends Option[A] {
+final case class Some[+A](@deprecatedName(Symbol("x"), "2.12.0") value: A) extends Option[A] {
   def isEmpty = false
   def get = value
 

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -158,6 +158,10 @@ case class StringContext(parts: String*) {
     def unapplySeq(s: Symbol): Option[Seq[String]] = {
       parts match {
         case s.name +: Seq() => Some(Seq.empty[String])
+        case _ +: _ +: _     => // if parts.size > 1
+          throw new IllegalArgumentException(
+            "Variable interpolation not supported, use '$$' for '$'"
+          )
         case _               => None
       }
     }

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -136,6 +136,33 @@ case class StringContext(parts: String*) {
     bldr.toString
   }
 
+  /** Shorthand symbol constructor.
+   *
+   *  Here's an example of usage:
+   *  {{{
+   *    val abc = List(sym"a", sym"b", sym"c")
+   *    println(syms) // List('a, 'b, 'c)
+   *  }}}
+   *  This string-based shorthand, replaces the old built-in quote syntax:
+   *  {{{
+   *    val abc = List('a, 'b, 'c) // Quoted symbol literals dropped in 2.14
+   *  }}}
+   *
+   *  @param `str` The string to be converted to a symbol.
+   */
+  def sym(args: String*): Symbol = {
+    Symbol(standardInterpolator(processEscapes, args, parts))
+  }
+
+  object sym {
+    def unapplySeq(s: Symbol): Option[Seq[String]] = {
+      parts match {
+        case first +: Seq() if s.name == first => Some(Seq.empty[String])
+        case _                                 => None
+      }
+    }
+  }
+
   /** The formatted string interpolator.
    *
    *  It inserts its arguments between corresponding parts of the string context.

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -151,7 +151,7 @@ case class StringContext(parts: String*) {
    *  @param `str` The string to be converted to a symbol.
    */
   def sym(args: String*): Symbol = {
-    Symbol(standardInterpolator(processEscapes, args, parts))
+    Symbol(standardInterpolator(processEscapes, args))
   }
 
   object sym {
@@ -214,7 +214,7 @@ object StringContext {
    *  @param  str   The offending string
    *  @param  index   The index of the offending backslash character in `str`.
    */
-  class InvalidEscapeException(str: String, @deprecatedName('idx) val index: Int) extends IllegalArgumentException(
+  class InvalidEscapeException(str: String, @deprecatedName(Symbol("idx")) val index: Int) extends IllegalArgumentException(
     s"""invalid escape ${
       require(index >= 0 && index < str.length)
       val ok = """[\b, \t, \n, \f, \r, \\, \", \']"""

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -157,8 +157,8 @@ case class StringContext(parts: String*) {
   object sym {
     def unapplySeq(s: Symbol): Option[Seq[String]] = {
       parts match {
-        case first +: Seq() if s.name == first => Some(Seq.empty[String])
-        case _                                 => None
+        case s.name +: Seq() => Some(Seq.empty[String])
+        case _               => None
       }
     }
   }

--- a/src/library/scala/Symbol.scala
+++ b/src/library/scala/Symbol.scala
@@ -14,12 +14,6 @@ package scala
 
 /** This class provides a simple way to get unique objects for equal strings.
  *  Since symbols are interned, they can be compared using reference equality.
- *  Instances of `Symbol` can be created easily with Scala's built-in quote
- *  mechanism.
- *
- *  For instance, the Scala term `'mysym` will
- *  invoke the constructor of the `Symbol` class in the following way:
- *  `Symbol("mysym")`.
  *
  *  @author  Martin Odersky, Iulian Dragos
  *  @since   1.7

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -454,7 +454,7 @@ trait GenTraversableOnce[+A] extends Any {
    *  @return        `true` if this $coll is empty or the given predicate `p`
    *                 holds for all elements of this $coll, otherwise `false`.
    */
-  def forall(@deprecatedName('pred) p: A => Boolean): Boolean
+  def forall(@deprecatedName(Symbol("pred")) p: A => Boolean): Boolean
 
   /** Tests whether a predicate holds for at least one element of this $coll.
    *
@@ -463,7 +463,7 @@ trait GenTraversableOnce[+A] extends Any {
    *  @param   p     the predicate used to test elements.
    *  @return        `true` if the given predicate `p` is satisfied by at least one element of this $coll, otherwise `false`
    */
-  def exists(@deprecatedName('pred) p: A => Boolean): Boolean
+  def exists(@deprecatedName(Symbol("pred")) p: A => Boolean): Boolean
 
   /** Finds the first element of the $coll satisfying a predicate, if any.
    *
@@ -474,7 +474,7 @@ trait GenTraversableOnce[+A] extends Any {
    *  @return        an option value containing the first element in the $coll
    *                 that satisfies `p`, or `None` if none exists.
    */
-  def find(@deprecatedName('pred) p: A => Boolean): Option[A]
+  def find(@deprecatedName(Symbol("pred")) p: A => Boolean): Option[A]
 
   /** Copies the elements of this $coll to an array.
    *  Fills the given array `xs` with values of this $coll.

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -119,7 +119,7 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
   }
 
   override /*TraversableLike*/
-  def foldLeft[B](z: B)(@deprecatedName('f) op: (B, A) => B): B = {
+  def foldLeft[B](z: B)(@deprecatedName(Symbol("f")) op: (B, A) => B): B = {
     var acc = z
     var these = this
     while (!these.isEmpty) {
@@ -130,12 +130,12 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
   }
 
   override /*IterableLike*/
-  def foldRight[B](z: B)(@deprecatedName('f) op: (A, B) => B): B =
+  def foldRight[B](z: B)(@deprecatedName(Symbol("f")) op: (A, B) => B): B =
     if (this.isEmpty) z
     else op(head, tail.foldRight(z)(op))
 
   override /*TraversableLike*/
-  def reduceLeft[B >: A](@deprecatedName('f) op: (B, A) => B): B =
+  def reduceLeft[B >: A](@deprecatedName(Symbol("f")) op: (B, A) => B): B =
     if (isEmpty) throw new UnsupportedOperationException("empty.reduceLeft")
     else tail.foldLeft[B](head)(op)
 

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -96,13 +96,13 @@ object Set extends ImmutableSetFactory[Set] {
     override def foreach[U](f: A => U): Unit = {
       f(elem1)
     }
-    override def exists(@deprecatedName('f) p: A => Boolean): Boolean = {
+    override def exists(@deprecatedName(Symbol("f")) p: A => Boolean): Boolean = {
       p(elem1)
     }
-    override def forall(@deprecatedName('f) p: A => Boolean): Boolean = {
+    override def forall(@deprecatedName(Symbol("f")) p: A => Boolean): Boolean = {
       p(elem1)
     }
-    override def find(@deprecatedName('f) p: A => Boolean): Option[A] = {
+    override def find(@deprecatedName(Symbol("f")) p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)
       else None
     }
@@ -131,13 +131,13 @@ object Set extends ImmutableSetFactory[Set] {
     override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2)
     }
-    override def exists(@deprecatedName('f) p: A => Boolean): Boolean = {
+    override def exists(@deprecatedName(Symbol("f")) p: A => Boolean): Boolean = {
       p(elem1) || p(elem2)
     }
-    override def forall(@deprecatedName('f) p: A => Boolean): Boolean = {
+    override def forall(@deprecatedName(Symbol("f")) p: A => Boolean): Boolean = {
       p(elem1) && p(elem2)
     }
-    override def find(@deprecatedName('f) p: A => Boolean): Option[A] = {
+    override def find(@deprecatedName(Symbol("f")) p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)
       else if (p(elem2)) Some(elem2)
       else None
@@ -168,13 +168,13 @@ object Set extends ImmutableSetFactory[Set] {
     override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2); f(elem3)
     }
-    override def exists(@deprecatedName('f) p: A => Boolean): Boolean = {
+    override def exists(@deprecatedName(Symbol("f")) p: A => Boolean): Boolean = {
       p(elem1) || p(elem2) || p(elem3)
     }
-    override def forall(@deprecatedName('f) p: A => Boolean): Boolean = {
+    override def forall(@deprecatedName(Symbol("f")) p: A => Boolean): Boolean = {
       p(elem1) && p(elem2) && p(elem3)
     }
-    override def find(@deprecatedName('f) p: A => Boolean): Option[A] = {
+    override def find(@deprecatedName(Symbol("f")) p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)
       else if (p(elem2)) Some(elem2)
       else if (p(elem3)) Some(elem3)
@@ -207,13 +207,13 @@ object Set extends ImmutableSetFactory[Set] {
     override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2); f(elem3); f(elem4)
     }
-    override def exists(@deprecatedName('f) p: A => Boolean): Boolean = {
+    override def exists(@deprecatedName(Symbol("f")) p: A => Boolean): Boolean = {
       p(elem1) || p(elem2) || p(elem3) || p(elem4)
     }
-    override def forall(@deprecatedName('f) p: A => Boolean): Boolean = {
+    override def forall(@deprecatedName(Symbol("f")) p: A => Boolean): Boolean = {
       p(elem1) && p(elem2) && p(elem3) && p(elem4)
     }
-    override def find(@deprecatedName('f) p: A => Boolean): Option[A] = {
+    override def find(@deprecatedName(Symbol("f")) p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)
       else if (p(elem2)) Some(elem2)
       else if (p(elem3)) Some(elem3)

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -525,7 +525,7 @@ self: ParIterableLike[T, Repr, Sequential] =>
    *  @param p       a predicate used to test elements
    *  @return        true if `p` holds for all elements, false otherwise
    */
-  def forall(@deprecatedName('pred) p: T => Boolean): Boolean = {
+  def forall(@deprecatedName(Symbol("pred")) p: T => Boolean): Boolean = {
     tasksupport.executeAndWaitResult(new Forall(p, splitter assign new DefaultSignalling with VolatileAbort))
   }
 
@@ -536,7 +536,7 @@ self: ParIterableLike[T, Repr, Sequential] =>
    *  @param p       a predicate used to test elements
    *  @return        true if `p` holds for some element, false otherwise
    */
-  def exists(@deprecatedName('pred) p: T => Boolean): Boolean = {
+  def exists(@deprecatedName(Symbol("pred")) p: T => Boolean): Boolean = {
     tasksupport.executeAndWaitResult(new Exists(p, splitter assign new DefaultSignalling with VolatileAbort))
   }
 
@@ -551,7 +551,7 @@ self: ParIterableLike[T, Repr, Sequential] =>
    *  @param p        predicate used to test the elements
    *  @return         an option value with the element if such an element exists, or `None` otherwise
    */
-  def find(@deprecatedName('pred) p: T => Boolean): Option[T] = {
+  def find(@deprecatedName(Symbol("pred")) p: T => Boolean): Option[T] = {
     tasksupport.executeAndWaitResult(new Find(p, splitter assign new DefaultSignalling with VolatileAbort))
   }
 

--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -81,7 +81,7 @@ trait ExecutionContext {
    *
    *  @param cause  the cause of the failure
    */
-  def reportFailure(@deprecatedName('t) cause: Throwable): Unit
+  def reportFailure(@deprecatedName(Symbol("t")) cause: Throwable): Unit
 
   /** Prepares for the execution of a task. Returns the prepared
      *  execution context. The recommended implementation of

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -142,7 +142,7 @@ trait Future[+T] extends Awaitable[T] {
    * @group Callbacks
    */
   @deprecated("use `onComplete` or `failed.foreach` instead (keep in mind that they take total rather than partial functions)", "2.12.0")
-  def onFailure[U](@deprecatedName('callback) pf: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): Unit = onComplete {
+  def onFailure[U](@deprecatedName(Symbol("callback")) pf: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): Unit = onComplete {
     case Failure(t) =>
       pf.applyOrElse[Throwable, Any](t, Predef.identity[Throwable]) // Exploiting the cached function to avoid MatchError
     case _ =>
@@ -164,7 +164,7 @@ trait Future[+T] extends Awaitable[T] {
    * @param f     the function to be executed when this `Future` completes
    * @group Callbacks
    */
-  def onComplete[U](@deprecatedName('func) f: Try[T] => U)(implicit executor: ExecutionContext): Unit
+  def onComplete[U](@deprecatedName(Symbol("func")) f: Try[T] => U)(implicit executor: ExecutionContext): Unit
 
 
   /* Miscellaneous */
@@ -336,7 +336,7 @@ trait Future[+T] extends Awaitable[T] {
    * @return    a `Future` which will hold the successful result of this `Future` if it matches the predicate or a `NoSuchElementException`
    * @group Transformations
    */
-  def filter(@deprecatedName('pred) p: T => Boolean)(implicit executor: ExecutionContext): Future[T] =
+  def filter(@deprecatedName(Symbol("pred")) p: T => Boolean)(implicit executor: ExecutionContext): Future[T] =
     map { r => if (p(r)) r else throw new NoSuchElementException("Future.filter predicate is not satisfied") }
 
   /** Used by for-comprehensions.
@@ -654,7 +654,7 @@ object Future {
   *  @param executor  the execution context on which the future is run
   *  @return          the `Future` holding the result of the computation
   */
-  def apply[T](body: =>T)(implicit @deprecatedName('execctx) executor: ExecutionContext): Future[T] =
+  def apply[T](body: =>T)(implicit @deprecatedName(Symbol("execctx")) executor: ExecutionContext): Future[T] =
     unit.map(_ => body)
 
   /** Simple version of `Future.traverse`. Asynchronously and non-blockingly transforms a `TraversableOnce[Future[A]]`
@@ -699,7 +699,7 @@ object Future {
    * @return          the `Future` holding the optional result of the search
    */
   @deprecated("use the overloaded version of this method that takes a scala.collection.immutable.Iterable instead", "2.12.0")
-  def find[T](@deprecatedName('futurestravonce) futures: TraversableOnce[Future[T]])(@deprecatedName('predicate) p: T => Boolean)(implicit executor: ExecutionContext): Future[Option[T]] = {
+  def find[T](@deprecatedName(Symbol("futurestravonce")) futures: TraversableOnce[Future[T]])(@deprecatedName(Symbol("predicate")) p: T => Boolean)(implicit executor: ExecutionContext): Future[Option[T]] = {
     val futuresBuffer = futures.toBuffer
     if (futuresBuffer.isEmpty) successful[Option[T]](None)
     else {
@@ -786,7 +786,7 @@ object Future {
    * @return         the `Future` holding the result of the fold
    */
   @deprecated("use Future.foldLeft instead", "2.12.0")
-  def fold[T, R](futures: TraversableOnce[Future[T]])(zero: R)(@deprecatedName('foldFun) op: (R, T) => R)(implicit executor: ExecutionContext): Future[R] = {
+  def fold[T, R](futures: TraversableOnce[Future[T]])(zero: R)(@deprecatedName(Symbol("foldFun")) op: (R, T) => R)(implicit executor: ExecutionContext): Future[R] = {
     if (futures.isEmpty) successful(zero)
     else sequence(futures).map(_.foldLeft(zero)(op))
   }

--- a/src/library/scala/concurrent/Promise.scala
+++ b/src/library/scala/concurrent/Promise.scala
@@ -83,7 +83,7 @@ trait Promise[T] {
    *
    *  $promiseCompletion
    */
-  def success(@deprecatedName('v) value: T): this.type = complete(Success(value))
+  def success(@deprecatedName(Symbol("v")) value: T): this.type = complete(Success(value))
 
   /** Tries to complete the promise with a value.
    *
@@ -101,7 +101,7 @@ trait Promise[T] {
    *
    *  $promiseCompletion
    */
-  def failure(@deprecatedName('t) cause: Throwable): this.type = complete(Failure(cause))
+  def failure(@deprecatedName(Symbol("t")) cause: Throwable): this.type = complete(Failure(cause))
 
   /** Tries to complete the promise with an exception.
    *
@@ -109,7 +109,7 @@ trait Promise[T] {
    *
    *  @return    If the promise has already been completed returns `false`, or `true` otherwise.
    */
-  def tryFailure(@deprecatedName('t) cause: Throwable): Boolean = tryComplete(Failure(cause))
+  def tryFailure(@deprecatedName(Symbol("t")) cause: Throwable): Boolean = tryComplete(Failure(cause))
 }
 
 object Promise {

--- a/src/library/scala/concurrent/package.scala
+++ b/src/library/scala/concurrent/package.scala
@@ -121,7 +121,7 @@ package object concurrent {
    */
   @deprecated("use `Future { ... }` instead", "2.11.0")
   // removal planned for 2.13.0
-  def future[T](body: =>T)(implicit @deprecatedName('execctx) executor: ExecutionContext): Future[T] = Future[T](body)
+  def future[T](body: =>T)(implicit @deprecatedName(Symbol("execctx")) executor: ExecutionContext): Future[T] = Future[T](body)
 
   /** Creates a promise object which can be completed with a value or an exception.
    *

--- a/src/library/scala/runtime/Tuple2Zipped.scala
+++ b/src/library/scala/runtime/Tuple2Zipped.scala
@@ -89,7 +89,7 @@ final class Tuple2Zipped[El1, Repr1, El2, Repr2](val colls: (TraversableLike[El1
     (b1.result(), b2.result())
   }
 
-  def exists(@deprecatedName('f) p: (El1, El2) => Boolean): Boolean = {
+  def exists(@deprecatedName(Symbol("f")) p: (El1, El2) => Boolean): Boolean = {
     val elems2 = coll2.iterator
 
     for (el1 <- coll1) {
@@ -102,7 +102,7 @@ final class Tuple2Zipped[El1, Repr1, El2, Repr2](val colls: (TraversableLike[El1
     false
   }
 
-  def forall(@deprecatedName('f) p: (El1, El2) => Boolean): Boolean =
+  def forall(@deprecatedName(Symbol("f")) p: (El1, El2) => Boolean): Boolean =
     !exists((x, y) => !p(x, y))
 
   def foreach[U](f: (El1, El2) => U): Unit = {

--- a/src/library/scala/runtime/Tuple3Zipped.scala
+++ b/src/library/scala/runtime/Tuple3Zipped.scala
@@ -98,7 +98,7 @@ final class Tuple3Zipped[El1, Repr1, El2, Repr2, El3, Repr3](val colls: (Travers
     result
   }
 
-  def exists(@deprecatedName('f) p: (El1, El2, El3) => Boolean): Boolean = {
+  def exists(@deprecatedName(Symbol("f")) p: (El1, El2, El3) => Boolean): Boolean = {
     val elems2 = coll2.iterator
     val elems3 = coll3.iterator
 
@@ -112,7 +112,7 @@ final class Tuple3Zipped[El1, Repr1, El2, Repr2, El3, Repr3](val colls: (Travers
     false
   }
 
-  def forall(@deprecatedName('f) p: (El1, El2, El3) => Boolean): Boolean =
+  def forall(@deprecatedName(Symbol("f")) p: (El1, El2, El3) => Boolean): Boolean =
     !exists((x, y, z) => !p(x, y, z))
 
   def foreach[U](f: (El1, El2, El3) => U): Unit = {

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -424,7 +424,7 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
  *
  *  @author <a href="mailto:research@workingmouse.com">Tony Morris</a>, Workingmouse
  */
-final case class Left[+A, +B](@deprecatedName('a, "2.12.0") value: A) extends Either[A, B] {
+final case class Left[+A, +B](@deprecatedName(Symbol("a"), "2.12.0") value: A) extends Either[A, B] {
   def isLeft  = true
   def isRight = false
 
@@ -435,7 +435,7 @@ final case class Left[+A, +B](@deprecatedName('a, "2.12.0") value: A) extends Ei
  *
  *  @author <a href="mailto:research@workingmouse.com">Tony Morris</a>, Workingmouse
  */
-final case class Right[+A, +B](@deprecatedName('b, "2.12.0") value: B) extends Either[A, B] {
+final case class Right[+A, +B](@deprecatedName(Symbol("b"), "2.12.0") value: B) extends Either[A, B] {
   def isLeft  = false
   def isRight = true
 
@@ -530,7 +530,7 @@ object Either {
      *  Right(12).left.forall(_ > 10) // true
      *  }}}
      */
-    def forall(@deprecatedName('f) p: A => Boolean): Boolean = e match {
+    def forall(@deprecatedName(Symbol("f")) p: A => Boolean): Boolean = e match {
       case Left(a) => p(a)
       case _       => true
     }
@@ -544,7 +544,7 @@ object Either {
      *  Right(12).left.exists(_ > 10) // false
      *  }}}
      */
-    def exists(@deprecatedName('f) p: A => Boolean): Boolean = e match {
+    def exists(@deprecatedName(Symbol("f")) p: A => Boolean): Boolean = e match {
       case Left(a) => p(a)
       case _       => false
     }
@@ -688,7 +688,7 @@ object Either {
      *  Left(12).right.exists(_ > 10)   // false
      *  }}}
      */
-    def exists(@deprecatedName('f) p: B => Boolean): Boolean = e match {
+    def exists(@deprecatedName(Symbol("f")) p: B => Boolean): Boolean = e match {
       case Right(b) => p(b)
       case _        => false
     }

--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -148,13 +148,13 @@ sealed abstract class Try[+T] extends Product with Serializable {
    * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
    * This is like `flatMap` for the exception.
    */
-  def recoverWith[U >: T](@deprecatedName('f) pf: PartialFunction[Throwable, Try[U]]): Try[U]
+  def recoverWith[U >: T](@deprecatedName(Symbol("f")) pf: PartialFunction[Throwable, Try[U]]): Try[U]
 
   /**
    * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
    * This is like map for the exception.
    */
-  def recover[U >: T](@deprecatedName('f) pf: PartialFunction[Throwable, U]): Try[U]
+  def recover[U >: T](@deprecatedName(Symbol("f")) pf: PartialFunction[Throwable, U]): Try[U]
 
   /**
    * Returns `None` if this is a `Failure` or a `Some` containing the value if this is a `Success`.
@@ -230,9 +230,9 @@ final case class Failure[+T](exception: Throwable) extends Try[T] {
   override def map[U](f: T => U): Try[U] = this.asInstanceOf[Try[U]]
   override def collect[U](pf: PartialFunction[T, U]): Try[U] = this.asInstanceOf[Try[U]]
   override def filter(p: T => Boolean): Try[T] = this
-  override def recover[U >: T](@deprecatedName('rescueException) pf: PartialFunction[Throwable, U]): Try[U] =
+  override def recover[U >: T](@deprecatedName(Symbol("rescueException")) pf: PartialFunction[Throwable, U]): Try[U] =
     try { if (pf isDefinedAt exception) Success(pf(exception)) else this } catch { case NonFatal(e) => Failure(e) }
-  override def recoverWith[U >: T](@deprecatedName('f) pf: PartialFunction[Throwable, Try[U]]): Try[U] =
+  override def recoverWith[U >: T](@deprecatedName(Symbol("f")) pf: PartialFunction[Throwable, Try[U]]): Try[U] =
     try { if (pf isDefinedAt exception) pf(exception) else this } catch { case NonFatal(e) => Failure(e) }
   override def failed: Try[Throwable] = Success(exception)
   override def toOption: Option[T] = None
@@ -262,8 +262,8 @@ final case class Success[+T](value: T) extends Try[T] {
     try {
       if (p(value)) this else Failure(new NoSuchElementException("Predicate does not hold for " + value))
     } catch { case NonFatal(e) => Failure(e) }
-  override def recover[U >: T](@deprecatedName('rescueException) pf: PartialFunction[Throwable, U]): Try[U] = this
-  override def recoverWith[U >: T](@deprecatedName('f) pf: PartialFunction[Throwable, Try[U]]): Try[U] = this
+  override def recover[U >: T](@deprecatedName(Symbol("rescueException")) pf: PartialFunction[Throwable, U]): Try[U] = this
+  override def recoverWith[U >: T](@deprecatedName(Symbol("f")) pf: PartialFunction[Throwable, Try[U]]): Try[U] = this
   override def failed: Try[Throwable] = Failure(new UnsupportedOperationException("Success.failed"))
   override def toOption: Option[T] = Some(value)
   override def toEither: Either[Throwable, T] = Right(value)

--- a/test/files/instrumented/indy-symbol-literal.scala
+++ b/test/files/instrumented/indy-symbol-literal.scala
@@ -3,11 +3,11 @@ import scala.tools.partest.instrumented.Instrumentation._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    'warmup
+    Symbol("warmup")
     startProfiling()
     var i = 0;
     while (i < 2) {
-      'foo.name
+      Symbol("foo").name
       i += 1
     }
     stopProfiling()

--- a/test/files/jvm/manifests-new.scala
+++ b/test/files/jvm/manifests-new.scala
@@ -15,14 +15,14 @@ object Test1 extends TestUtil {
   print('a')
   print(1)
   print("abc")
-  print('abc)
+  print(sym"abc")
   println()
 
   print(List(()))
   print(List(true))
   print(List(1))
   print(List("abc"))
-  print(List('abc))
+  print(List(sym"abc"))
   println()
 
   //print(Array(()))  //Illegal class name "[V" in class file Test$
@@ -30,14 +30,14 @@ object Test1 extends TestUtil {
   print(Array('a'))
   print(Array(1))
   print(Array("abc"))
-  print(Array('abc))
+  print(Array(sym"abc"))
   println()
 
   print(((), ()))
   print((true, false))
   print((1, 2))
   print(("abc", "xyz"))
-  print(('abc, 'xyz))
+  print((sym"abc", sym"xyz"))
   println()
 
   print(Test)
@@ -61,12 +61,12 @@ object Test2 {
   println("true="+load[Boolean](dump(true)))
   println("a="+load[Char](dump('a')))
   println("1="+load[Int](dump(1)))
-  println("'abc="+load[scala.Symbol](dump('abc)))
+  println("'abc="+load[scala.Symbol](dump(sym"abc")))
   println()
 
   println("List(())="+load[List[Unit]](dump(List(()))))
   println("List(true)="+load[List[Boolean]](dump(List(true))))
-  println("List('abc)="+load[List[scala.Symbol]](dump(List('abc))))
+  println("List('abc)="+load[List[scala.Symbol]](dump(List(sym"abc"))))
   println()
 
   def loadArray[T](x: Array[Byte])(implicit t: reflect.ClassTag[Array[T]]) =

--- a/test/files/jvm/manifests-old.scala
+++ b/test/files/jvm/manifests-old.scala
@@ -12,14 +12,14 @@ object Test1 extends TestUtil {
   print('a')
   print(1)
   print("abc")
-  print('abc)
+  print(sym"abc")
   println()
 
   print(List(()))
   print(List(true))
   print(List(1))
   print(List("abc"))
-  print(List('abc))
+  print(List(sym"abc"))
   println()
 
   //print(Array(()))  //Illegal class name "[V" in class file Test$
@@ -27,14 +27,14 @@ object Test1 extends TestUtil {
   print(Array('a'))
   print(Array(1))
   print(Array("abc"))
-  print(Array('abc))
+  print(Array(sym"abc"))
   println()
 
   print(((), ()))
   print((true, false))
   print((1, 2))
   print(("abc", "xyz"))
-  print(('abc, 'xyz))
+  print((sym"abc", sym"xyz"))
   println()
 
   // Disabled: should these work? changing the inference for objects from
@@ -60,12 +60,12 @@ object Test2 {
   println("true="+load[Boolean](dump(true)))
   println("a="+load[Char](dump('a')))
   println("1="+load[Int](dump(1)))
-  println("'abc="+load[Symbol](dump('abc)))
+  println("'abc="+load[Symbol](dump(sym"abc")))
   println()
 
   println("List(())="+load[List[Unit]](dump(List(()))))
   println("List(true)="+load[List[Boolean]](dump(List(true))))
-  println("List('abc)="+load[List[Symbol]](dump(List('abc))))
+  println("List('abc)="+load[List[Symbol]](dump(List(sym"abc"))))
   println()
 
   def loadArray[T](x: Array[Byte])(implicit m: reflect.Manifest[Array[T]]) =

--- a/test/files/jvm/serialization-new.scala
+++ b/test/files/jvm/serialization-new.scala
@@ -150,7 +150,7 @@ object Test1_scala {
     check(r1, _r1)
 */
     // Symbol
-    val s1 = 'hello
+    val s1 = sym"hello"
     val _s1: Symbol = read(write(s1))
     println("s1 = " + s1)
     println("_s1 = " + _s1)
@@ -267,7 +267,7 @@ object Test2_immutable {
     check(ts1, _ts1)
 
     // Vector
-    val v1 = Vector('a, 'b, 'c)
+    val v1 = Vector(sym"a", sym"b", sym"c")
     val _v1: Vector[Symbol] = read(write(v1))
     check(v1, _v1)
   }

--- a/test/files/jvm/serialization.scala
+++ b/test/files/jvm/serialization.scala
@@ -150,7 +150,7 @@ object Test1_scala {
     check(r1, _r1)
 */
     // Symbol
-    val s1 = 'hello
+    val s1 = sym"hello"
     val _s1: Symbol = read(write(s1))
     println("s1 = " + s1)
     println("_s1 = " + _s1)
@@ -267,7 +267,7 @@ object Test2_immutable {
     check(ts1, _ts1)
 
     // Vector
-    val v1 = Vector('a, 'b, 'c)
+    val v1 = Vector(sym"a", sym"b", sym"c")
     val _v1: Vector[Symbol] = read(write(v1))
     check(v1, _v1)
   }

--- a/test/files/neg/checksensible.check
+++ b/test/files/neg/checksensible.check
@@ -77,7 +77,7 @@ checksensible.scala:51: warning: comparing values of types Int and Unit using `!
   (1 != println)
      ^
 checksensible.scala:52: warning: comparing values of types Int and Symbol using `!=' will always yield true
-  (1 != 'sym)
+  (1 != sym"sym")
      ^
 checksensible.scala:58: warning: comparing a fresh object using `==' will always yield false
   ((x: Int) => x + 1) == null

--- a/test/files/neg/checksensible.scala
+++ b/test/files/neg/checksensible.scala
@@ -49,7 +49,7 @@ class EqEqValTest {
   (scala.runtime.BoxedUnit.UNIT: java.io.Serializable) != () // shouldn't warn
 
   (1 != println)
-  (1 != 'sym)
+  (1 != sym"sym")
 }
 
 // 12 warnings

--- a/test/files/neg/names-defaults-neg-warn.scala
+++ b/test/files/neg/names-defaults-neg-warn.scala
@@ -1,9 +1,9 @@
 object Test extends App {
   object deprNam2 {
-    def f(@deprecatedName('s) x: String) = 1
+    def f(@deprecatedName(Symbol("s")) x: String) = 1
     def f(s: Object) = 2
 
-    def g(@deprecatedName('x) s: Object) = 3
+    def g(@deprecatedName(Symbol("x")) s: Object) = 3
     def g(s: String) = 4
   }
 

--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -107,11 +107,11 @@ names-defaults-neg.scala:86: error: module extending its companion class cannot 
     object C extends C()
                      ^
 names-defaults-neg.scala:90: error: deprecated parameter name x has to be distinct from any other parameter name (deprecated or not).
-  def deprNam1(x: Int, @deprecatedName('x) y: String) = 0
-                                           ^
+  def deprNam1(x: Int, @deprecatedName(Symbol("x")) y: String) = 0
+                                                    ^
 names-defaults-neg.scala:91: error: deprecated parameter name a has to be distinct from any other parameter name (deprecated or not).
-  def deprNam2(a: String)(@deprecatedName('a) b: Int) = 1
-                                              ^
+  def deprNam2(a: String)(@deprecatedName(Symbol("a")) b: Int) = 1
+                                                       ^
 names-defaults-neg.scala:93: warning: the parameter name y is deprecated: use b instead
   deprNam3(y = 10, b = 2)
              ^

--- a/test/files/neg/names-defaults-neg.scala
+++ b/test/files/neg/names-defaults-neg.scala
@@ -87,12 +87,12 @@ object Test extends App {
   }
 
   // deprecated names
-  def deprNam1(x: Int, @deprecatedName('x) y: String) = 0
-  def deprNam2(a: String)(@deprecatedName('a) b: Int) = 1
-  def deprNam3(@deprecatedName('x) a: Int, @deprecatedName('y) b: Int) = a + b
+  def deprNam1(x: Int, @deprecatedName(Symbol("x")) y: String) = 0
+  def deprNam2(a: String)(@deprecatedName(Symbol("a")) b: Int) = 1
+  def deprNam3(@deprecatedName(Symbol("x")) a: Int, @deprecatedName(Symbol("y")) b: Int) = a + b
   deprNam3(y = 10, b = 2)
 
-  def deprNam4(@deprecatedName('deprNam4Arg) deprNam4Arg: String) = 0
+  def deprNam4(@deprecatedName(Symbol("deprNam4Arg")) deprNam4Arg: String) = 0
   deprNam4(deprNam4Arg = null)
   def deprNam5(@deprecatedName deprNam5Arg: String) = 0
   deprNam5(deprNam5Arg = null)

--- a/test/files/neg/t7872b.check
+++ b/test/files/neg/t7872b.check
@@ -1,5 +1,5 @@
 t7872b.scala:8: error: contravariant type a occurs in covariant position in type [-a]List[a] of type l
-  def oops1 = down[({type l[-a] = List[a]})#l](List('whatever: Object)).head + "oops"
+  def oops1 = down[({type l[-a] = List[a]})#l](List(sym"whatever": Object)).head + "oops"
                           ^
 t7872b.scala:19: error: covariant type a occurs in contravariant position in type [+a]coinv.Stringer[a] of type l
   def oops2 = up[({type l[+a] = Stringer[a]})#l]("printed: " + _)

--- a/test/files/neg/t7872b.scala
+++ b/test/files/neg/t7872b.scala
@@ -5,7 +5,7 @@ object coinv {
   up(List("hi"))
  
   // should not compile; `l' is unsound
-  def oops1 = down[({type l[-a] = List[a]})#l](List('whatever: Object)).head + "oops"
+  def oops1 = down[({type l[-a] = List[a]})#l](List(sym"whatever": Object)).head + "oops"
   // scala> oops1
   // java.lang.ClassCastException: scala.Symbol cannot be cast to java.lang.String
   //         at com.nocandysw.coinv$.oops1(coinv.scala:12)

--- a/test/files/neg/t7872c.check
+++ b/test/files/neg/t7872c.check
@@ -1,11 +1,11 @@
 t7872c.scala:7: error: inferred kinds of the type arguments (List) do not conform to the expected kinds of the type parameters (type F).
 List's type parameters do not match type F's expected parameters:
 type A is covariant, but type _ is declared contravariant
-  down(List('whatever: Object))
+  down(List(sym"whatever": Object))
   ^
 t7872c.scala:7: error: type mismatch;
  found   : List[Object]
  required: F[Object]
-  down(List('whatever: Object))
+  down(List(sym"whatever": Object))
            ^
 two errors found

--- a/test/files/neg/t7872c.scala
+++ b/test/files/neg/t7872c.scala
@@ -4,5 +4,5 @@ object coinv {
  
   up(List("hi"))
   // [error] type A is covariant, but type _ is declared contravariant
-  down(List('whatever: Object))
+  down(List(sym"whatever": Object))
 }

--- a/test/files/pos/t389.scala
+++ b/test/files/pos/t389.scala
@@ -1,7 +1,7 @@
 object Test {
-  def a = 'a
-  def b = 'B
-  def c = '+
+  def a = sym"a"
+  def b = sym"B"
+  def c = sym"+"
   //def d = '`\n` //error: unclosed character literal
-  def e = '\u0041
+  def e = sym"\u0041"
 }

--- a/test/files/pos/t4812.scala
+++ b/test/files/pos/t4812.scala
@@ -1,4 +1,4 @@
 trait Test1 {
-  def m1(sym: Symbol = 'TestSym)
+  def m1(sym: Symbol = sym"TestSym")
   def m2(s: String = "TestString")
 }

--- a/test/files/run/SymbolsTest.scala
+++ b/test/files/run/SymbolsTest.scala
@@ -2,46 +2,46 @@
 import scala.language.reflectiveCalls
 
 class Slazz {
-  val s1 = 'myFirstSymbol
-  val s2 = 'mySecondSymbol
-  def s3 = 'myThirdSymbol
+  val s1 = sym"myFirstSymbol"
+  val s2 = sym"mySecondSymbol"
+  def s3 = sym"myThirdSymbol"
   var s4: Symbol = null
 
-  s4 = 'myFourthSymbol
+  s4 = sym"myFourthSymbol"
 }
 
 class Base {
-  val basesymbol = 'symbase
+  val basesymbol = sym"symbase"
 }
 
 class Sub extends Base {
-  val subsymbol = 'symsub
+  val subsymbol = sym"symsub"
 }
 
 trait Signs {
-  val ind = 'indication
-  val trace = 'trace
+  val ind = sym"indication"
+  val trace = sym"trace"
 }
 
 trait Lazy1 {
   lazy val v1 = "lazy v1"
-  lazy val s1 = 'lazySymbol1
+  lazy val s1 = sym"lazySymbol1"
 }
 
 trait Lazy2 {
   lazy val v2 = "lazy v2"
-  lazy val s2 = 'lazySymbol2
+  lazy val s2 = sym"lazySymbol2"
 }
 
 trait Lazy3 {
   lazy val v3 = "lazy v3"
-  lazy val s3 = 'lazySymbol3
+  lazy val s3 = sym"lazySymbol3"
 }
 
 object SingletonOfLazyness {
-  lazy val lazysym = 'lazySymbol
-  lazy val another = 'another
-  lazy val lastone = 'lastone
+  lazy val lazysym = sym"lazySymbol"
+  lazy val another = sym"another"
+  lazy val lastone = sym"lastone"
 }
 
 /*
@@ -49,18 +49,18 @@ object SingletonOfLazyness {
  */
 object Test {
   class Inner {
-    val simba = 'smba
+    val simba = sym"smba"
     var mfs: Symbol = null
     mfs = Symbol("mfsa")
   }
 
   object InnerObject {
-    val o1 = 'aaa
-    val o2 = 'ddd
+    val o1 = sym"aaa"
+    val o2 = sym"ddd"
   }
 
-  def aSymbol = 'myFirstSymbol
-  val anotherSymbol = 'mySecondSymbol
+  def aSymbol = sym"myFirstSymbol"
+  val anotherSymbol = sym"mySecondSymbol"
 
   def main(args: Array[String]) {
     testLiterals
@@ -81,7 +81,7 @@ object Test {
     val scl = new Slazz
     assert(scl.s1 == aSymbol)
     assert(scl.s2 == anotherSymbol)
-    assert(scl.s3 == 'myThirdSymbol)
+    assert(scl.s3 == sym"myThirdSymbol")
     assert(scl.s4 == Symbol.apply("myFourthSymbol"))
     assert(scl.s1 == Symbol("myFirstSymbol"))
   }
@@ -92,59 +92,59 @@ object Test {
 
   def testInnerClasses {
     val innerPower = new Inner
-    assert(innerPower.simba == 'smba)
-    assert(innerPower.mfs == 'mfsa)
+    assert(innerPower.simba == sym"smba")
+    assert(innerPower.mfs == sym"mfsa")
   }
 
   def testInnerObjects {
-    assert(InnerObject.o1 == 'aaa)
-    assert(InnerObject.o2 == 'ddd)
+    assert(InnerObject.o1 == sym"aaa")
+    assert(InnerObject.o2 == sym"ddd")
   }
 
   def testWithHashMaps {
     val map = new collection.mutable.HashMap[Symbol, Symbol]
-    map.put(InnerObject.o1, 'smba)
-    map.put(InnerObject.o2, 'mfsa)
+    map.put(InnerObject.o1, sym"smba")
+    map.put(InnerObject.o2, sym"mfsa")
     map.put(Symbol("WeirdKey" + 1), Symbol("Weird" + "Val" + 1))
-    assert(map('aaa) == 'smba)
-    assert(map('ddd) == 'mfsa)
-    assert(map('WeirdKey1) == Symbol("WeirdVal1"))
+    assert(map(sym"aaa") == sym"smba")
+    assert(map(sym"ddd") == sym"mfsa")
+    assert(map(sym"WeirdKey1") == Symbol("WeirdVal1"))
 
     map.clear
     for (i <- 0 until 100) map.put(Symbol("symKey" + i), Symbol("symVal" + i))
     assert(map(Symbol("symKey15")) == Symbol("symVal15"))
-    assert(map('symKey22) == 'symVal22)
-    assert(map('symKey73) == 'symVal73)
-    assert(map('symKey56) == 'symVal56)
-    assert(map('symKey91) == 'symVal91)
+    assert(map(sym"symKey22") == sym"symVal22")
+    assert(map(sym"symKey73") == sym"symVal73")
+    assert(map(sym"symKey56") == sym"symVal56")
+    assert(map(sym"symKey91") == sym"symVal91")
   }
 
   def testLists {
     var lst: List[Symbol] = Nil
     for (i <- 0 until 100) lst ::= Symbol("lsym" + (99 - i))
-    assert(lst(0) == 'lsym0)
-    assert(lst(10) == 'lsym10)
-    assert(lst(30) == 'lsym30)
-    assert(lst(40) == 'lsym40)
-    assert(lst(65) == 'lsym65)
-    assert(lst(90) == 'lsym90)
+    assert(lst(0) == sym"lsym0")
+    assert(lst(10) == sym"lsym10")
+    assert(lst(30) == sym"lsym30")
+    assert(lst(40) == sym"lsym40")
+    assert(lst(65) == sym"lsym65")
+    assert(lst(90) == sym"lsym90")
   }
 
   def testAnonymous { // TODO complaints classdef can't be found for some reason, runs fine in my case
     // val anon = () => {
-    //   val simba = 'smba
+    //   val simba = sym"smba"
     //   simba
     // }
     // val an2 = () => {
     //   object nested {
-    //     val m = 'mfsa
+    //     val m = sym"mfsa"
     //   }
     //   nested.m
     // }
     // val an3 = () => {
     //   object nested {
     //     val f = () => {
-    //       'layered
+    //       sym"layered"
     //     }
     //     def gets = f()
     //   }
@@ -153,91 +153,91 @@ object Test {
     // val inner = new Inner
     // assert(anon() == inner.simba)
     // assert(anon().toString == "'smba")
-    // assert(an2() == 'mfsa)
+    // assert(an2() == sym"mfsa")
     // assert(an3() == Symbol("layered" + ""))
   }
 
   def testNestedObject {
     object nested {
-      def sign = 'sign
-      def insignia = 'insignia
+      def sign = sym"sign"
+      def insignia = sym"insignia"
     }
-    assert(nested.sign == 'sign)
-    assert(nested.insignia == 'insignia)
-    assert(('insignia).toString == "'insignia")
+    assert(nested.sign == sym"sign")
+    assert(nested.insignia == sym"insignia")
+    assert((sym"insignia").toString == "'insignia")
   }
 
   def testInheritance {
     val base = new Base
     val sub = new Sub
-    assert(base.basesymbol == 'symbase)
-    assert(sub.subsymbol == 'symsub)
-    assert(sub.basesymbol == 'symbase)
+    assert(base.basesymbol == sym"symbase")
+    assert(sub.subsymbol == sym"symsub")
+    assert(sub.basesymbol == sym"symbase")
 
     val anon = new Sub {
-      def subsubsymbol = 'symsubsub
+      def subsubsymbol = sym"symsubsub"
     }
-    assert(anon.subsubsymbol == 'symsubsub)
-    assert(anon.subsymbol == 'symsub)
-    assert(anon.basesymbol == 'symbase)
+    assert(anon.subsubsymbol == sym"symsubsub")
+    assert(anon.subsymbol == sym"symsub")
+    assert(anon.basesymbol == sym"symbase")
 
     object nested extends Sub {
-      def objsymbol = 'symobj
+      def objsymbol = sym"symobj"
     }
-    assert(nested.objsymbol == 'symobj)
-    assert(nested.subsymbol == 'symsub)
-    assert(nested.basesymbol == 'symbase)
-    assert(('symbase).toString == "'symbase")
+    assert(nested.objsymbol == sym"symobj")
+    assert(nested.subsymbol == sym"symsub")
+    assert(nested.basesymbol == sym"symbase")
+    assert((sym"symbase").toString == "'symbase")
   }
 
   def testTraits {
     val fromTrait = new AnyRef with Signs {
-      def traitsymbol = 'traitSymbol
+      def traitsymbol = sym"traitSymbol"
     }
 
-    assert(fromTrait.traitsymbol == 'traitSymbol)
-    assert(fromTrait.ind == 'indication)
-    assert(fromTrait.trace == 'trace)
-    assert(('trace).toString == "'trace")
+    assert(fromTrait.traitsymbol == sym"traitSymbol")
+    assert(fromTrait.ind == sym"indication")
+    assert(fromTrait.trace == sym"trace")
+    assert((sym"trace").toString == "'trace")
 
     trait Compl {
-      val s1 = 's1
-      def s2 = 's2
+      val s1 = sym"s1"
+      def s2 = sym"s2"
       object inner {
-        val s3 = 's3
-        val s4 = 's4
+        val s3 = sym"s3"
+        val s4 = sym"s4"
       }
     }
 
     val compl = new Sub with Signs with Compl
-    assert(compl.s1 == 's1)
-    assert(compl.s2 == 's2)
-    assert(compl.inner.s3 == 's3)
-    assert(compl.inner.s4 == 's4)
-    assert(compl.ind == 'indication)
-    assert(compl.trace == 'trace)
-    assert(compl.subsymbol == 'symsub)
-    assert(compl.basesymbol == 'symbase)
+    assert(compl.s1 == sym"s1")
+    assert(compl.s2 == sym"s2")
+    assert(compl.inner.s3 == sym"s3")
+    assert(compl.inner.s4 == sym"s4")
+    assert(compl.ind == sym"indication")
+    assert(compl.trace == sym"trace")
+    assert(compl.subsymbol == sym"symsub")
+    assert(compl.basesymbol == sym"symbase")
 
     object Local extends Signs with Compl {
-      val s5 = 's5
-      def s6 = 's6
+      val s5 = sym"s5"
+      def s6 = sym"s6"
       object inner2 {
-        val s7 = 's7
-        def s8 = 's8
+        val s7 = sym"s7"
+        def s8 = sym"s8"
       }
     }
-    assert(Local.s5 == 's5)
-    assert(Local.s6 == 's6)
-    assert(Local.inner2.s7 == 's7)
-    assert(Local.inner2.s8 == 's8)
-    assert(Local.inner.s3 == 's3)
-    assert(Local.inner.s4 == 's4)
-    assert(Local.s1 == 's1)
-    assert(Local.s2 == 's2)
-    assert(Local.trace == 'trace)
-    assert(Local.ind == 'indication)
-    assert(('s8).toString == "'s8")
+    assert(Local.s5 == sym"s5")
+    assert(Local.s6 == sym"s6")
+    assert(Local.inner2.s7 == sym"s7")
+    assert(Local.inner2.s8 == sym"s8")
+    assert(Local.inner.s3 == sym"s3")
+    assert(Local.inner.s4 == sym"s4")
+    assert(Local.s1 == sym"s1")
+    assert(Local.s2 == sym"s2")
+    assert(Local.trace == sym"trace")
+    assert(Local.ind == sym"indication")
+    assert((sym"s8").toString == "'s8")
   }
 
   def testLazyTraits {
@@ -250,20 +250,20 @@ object Test {
     l3.v3
     assert((l1.s1).toString == "'lazySymbol1")
     assert(l2.s2 == Symbol("lazySymbol" + 2))
-    assert(l3.s3 == 'lazySymbol3)
+    assert(l3.s3 == sym"lazySymbol3")
   }
 
   def testLazyObjects {
-    assert(SingletonOfLazyness.lazysym == 'lazySymbol)
+    assert(SingletonOfLazyness.lazysym == sym"lazySymbol")
     assert(SingletonOfLazyness.another == Symbol("ano" + "ther"))
     assert((SingletonOfLazyness.lastone).toString == "'lastone")
 
     object nested {
-      lazy val sym1 = 'snested1
-      lazy val sym2 = 'snested2
+      lazy val sym1 = sym"snested1"
+      lazy val sym2 = sym"snested2"
     }
 
-    assert(nested.sym1 == 'snested1)
+    assert(nested.sym1 == sym"snested1")
     assert(nested.sym2 == Symbol("snested" + "2"))
   }
 

--- a/test/files/run/arrays.scala
+++ b/test/files/run/arrays.scala
@@ -206,7 +206,7 @@ object Test {
   val a2: Int     = 0;
   val a3: Null  = null;
   val a4: String  = "a-z";
-  val a5: Symbol  = 'token;
+  val a5: Symbol  = sym"token";
   val a6: HashMap = new HashMap();
   val a7: TreeMap = scala.collection.immutable.TreeMap.empty[Int, Any];
   val a8: Strings = List("a", "z");

--- a/test/files/run/fors.scala
+++ b/test/files/run/fors.scala
@@ -6,7 +6,7 @@
 
 object Test extends App {
   val xs = List(1, 2, 3)
-  val ys = List('a, 'b, 'c)
+  val ys = List(sym"a", sym"b", sym"c")
 
   def it = 0 until 10
 

--- a/test/files/run/lisp.scala
+++ b/test/files/run/lisp.scala
@@ -303,17 +303,17 @@ object LispAny extends Lisp {
   def asBoolean(x: Data): Boolean = x != 0
 
   def normalize(x: Data): Data = x match {
-    case 'and :: x :: y :: Nil =>
-      normalize('if :: x :: y :: 0 :: Nil)
-    case 'or :: x :: y :: Nil =>
-      normalize('if :: x :: 1 :: y :: Nil)
-    case 'def :: (name :: args) :: body :: expr :: Nil =>
-      normalize('def :: name :: ('lambda :: args :: body :: Nil) :: expr :: Nil)
-    case 'cond :: ('else :: expr :: Nil) :: rest =>
+    case sym"and" :: x :: y :: Nil =>
+      normalize(sym"if" :: x :: y :: 0 :: Nil)
+    case sym"or" :: x :: y :: Nil =>
+      normalize(sym"if" :: x :: 1 :: y :: Nil)
+    case sym"def" :: (name :: args) :: body :: expr :: Nil =>
+      normalize(sym"def" :: name :: (sym"lambda" :: args :: body :: Nil) :: expr :: Nil)
+    case sym"cond" :: (sym"else" :: expr :: Nil) :: rest =>
         normalize(expr);
-    case 'cond :: (test :: expr :: Nil) :: rest =>
-	normalize('if :: test :: expr :: ('cond :: rest) :: Nil)
-    case 'cond :: 'else :: expr :: Nil =>
+    case sym"cond" :: (test :: expr :: Nil) :: rest =>
+	normalize(sym"if" :: test :: expr :: (sym"cond" :: rest) :: Nil)
+    case sym"cond" :: sym"else" :: expr :: Nil =>
       normalize(expr)
     case h :: t =>
       normalize(h) :: asList(normalize(t))
@@ -342,15 +342,15 @@ object LispAny extends Lisp {
   def eval1(x: Data, env: Environment): Data = x match {
     case Symbol(name) =>
       env lookup name
-    case 'def :: Symbol(name) :: y :: z :: Nil =>
+    case sym"def" :: Symbol(name) :: y :: z :: Nil =>
       eval(z, env.extendRec(name, (env1 => eval(y, env1))))
-    case 'val :: Symbol(name) :: y :: z :: Nil =>
+    case sym"val" :: Symbol(name) :: y :: z :: Nil =>
       eval(z, env.extend(name, eval(y, env)))
-    case 'lambda :: params :: y :: Nil =>
+    case sym"lambda" :: params :: y :: Nil =>
       mkLambda(params, y, env)
-    case 'if :: c :: y :: z :: Nil =>
+    case sym"if" :: c :: y :: z :: Nil =>
       if (asBoolean(eval(c, env))) eval(y, env) else eval(z, env)
-    case 'quote :: y :: Nil =>
+    case sym"quote" :: y :: Nil =>
       y
     case y :: z =>
       apply(eval(y, env), z map (x => eval(x, env)))

--- a/test/files/run/names-defaults.scala
+++ b/test/files/run/names-defaults.scala
@@ -355,15 +355,15 @@ object Test extends App {
   (new DBLAH())
 
   // deprecated names
-  def deprNam1(@deprecatedName('x) a: Int, @deprecatedName('y) b: Int) = a + b
+  def deprNam1(@deprecatedName(Symbol("x")) a: Int, @deprecatedName(Symbol("y")) b: Int) = a + b
   deprNam1(y = 10, a = 1)
   deprNam1(b = 2, x = 10)
 
   object deprNam2 {
-    def f(@deprecatedName('s) x: String) = 1
+    def f(@deprecatedName(Symbol("s")) x: String) = 1
     def f(s: Object) = 2
 
-    def g(@deprecatedName('x) s: Object) = 3
+    def g(@deprecatedName(Symbol("x")) s: Object) = 3
     def g(s: String) = 4
   }
   println(deprNam2.f(s = "dlf"))

--- a/test/files/run/t10646.scala
+++ b/test/files/run/t10646.scala
@@ -7,7 +7,7 @@ object Test extends App {
   it.head
   it.last
 
-  val that = Array(A("baz"), A('fff))
+  val that = Array(A("baz"), A(sym"fff"))
   that.head
   that.last
 }

--- a/test/files/run/t4560.scala
+++ b/test/files/run/t4560.scala
@@ -18,7 +18,7 @@ trait B {
 
   def y = new { def f() = println("Success 1") }
   def fail() = {
-    println('Test)
+    println(sym"Test")
     y.f()
   }
 }
@@ -35,7 +35,7 @@ trait B2 {
 
   def y = new { def f() = println("Success 2") }
   def fail() = {
-    println('Test)
+    println(sym"Test")
     y.f()
   }
 }
@@ -50,7 +50,7 @@ trait B3 {
 
   def y = new { def f() = println("Success 3") }
   def fail() = {
-    println('Test)
+    println(sym"Test")
     y.f()
   }
 }

--- a/test/files/run/t4601.scala
+++ b/test/files/run/t4601.scala
@@ -4,7 +4,7 @@ trait B {
   self: A =>
 
   def test {
-    println('blubber)
+    println(sym"blubber")
   }
 }
 

--- a/test/files/run/t4710.check
+++ b/test/files/run/t4710.check
@@ -1,5 +1,5 @@
 
-scala> def method : String = { implicit def f(s: Symbol) = "" ; 'symbol }
+scala> def method : String = { implicit def f(s: Symbol) = "" ; sym"symbol" }
 warning: there was one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 method: String
 

--- a/test/files/run/t4710.scala
+++ b/test/files/run/t4710.scala
@@ -1,6 +1,6 @@
 import scala.tools.partest.ReplTest
 
 object Test extends ReplTest {
-  def code = """def method : String = { implicit def f(s: Symbol) = "" ; 'symbol }"""
+  def code = """def method : String = { implicit def f(s: Symbol) = "" ; sym"symbol" }"""
 }
 

--- a/test/files/run/t6549.check
+++ b/test/files/run/t6549.check
@@ -2,7 +2,7 @@
 scala> case class `X"`(var xxx: Any)
 defined class X$u0022
 
-scala> val m = Map(("": Any) -> `X"`("\""), ('s: Any) -> `X"`("\""))
+scala> val m = Map(("": Any) -> `X"`("\""), (sym"s": Any) -> `X"`("\""))
 m: scala.collection.immutable.Map[Any,X"] = Map("" -> X"("), 's -> X"("))
 
 scala> m("")
@@ -17,8 +17,8 @@ m("").xxx: Any = 0
 scala> m("").xxx = "\""
 m("").xxx: Any = "
 
-scala> m('s).xxx = 's
-m(scala.Symbol("s")).xxx: Any = 's
+scala> m(sym"s").xxx = sym"s"
+m(StringContext("s").sym()).xxx: Any = 's
 
 scala> val `"` = 0
 ": Int = 0

--- a/test/files/run/t6549.scala
+++ b/test/files/run/t6549.scala
@@ -11,12 +11,12 @@ import scala.tools.partest.ReplTest
 object Test extends ReplTest {
   def code = """
     |case class `X"`(var xxx: Any)
-    |val m = Map(("": Any) -> `X"`("\""), ('s: Any) -> `X"`("\""))
+    |val m = Map(("": Any) -> `X"`("\""), (sym"s": Any) -> `X"`("\""))
     |m("")
     |m("").xxx
     |m("").xxx = 0
     |m("").xxx = "\""
-    |m('s).xxx = 's
+    |m(sym"s").xxx = sym"s"
     |val `"` = 0
   """.stripMargin
 }

--- a/test/files/run/t6632.scala
+++ b/test/files/run/t6632.scala
@@ -1,22 +1,22 @@
 object Test extends App {
   import collection.mutable.ListBuffer
 
-  def newLB = ListBuffer('a, 'b, 'c, 'd, 'e)
+  def newLB = ListBuffer(sym"a", sym"b", sym"c", sym"d", sym"e")
 
   def iiobe[A](f: => A) =
     try { f }
     catch { case ex: IndexOutOfBoundsException => println(ex) }
 
   val lb0 = newLB
-  iiobe( lb0.insert(-1, 'x) )
+  iiobe( lb0.insert(-1, sym"x") )
 
   val lb1 = newLB
-  iiobe( lb1.insertAll(-2, Array('x, 'y, 'z)) )
+  iiobe( lb1.insertAll(-2, Array(sym"x", sym"y", sym"z")) )
 
   val lb2 = newLB
-  iiobe( lb2.update(-3, 'u) )
+  iiobe( lb2.update(-3, sym"u") )
 
   val lb3 = newLB
-  iiobe( lb3.updated(-1, 'u) )
-  iiobe( lb3.updated(5, 'u) )
+  iiobe( lb3.update(-1, sym"u") )
+  iiobe( lb3.update(5, sym"u") )
 }

--- a/test/files/run/t6633.scala
+++ b/test/files/run/t6633.scala
@@ -1,12 +1,12 @@
 object Test extends App {
   import collection.mutable.ListBuffer
 
-  def newLB = ListBuffer('a, 'b, 'c, 'd, 'e)
+  def newLB = ListBuffer(sym"a", sym"b", sym"c", sym"d", sym"e")
 
   val lb0 = newLB
 
   try {
-    lb0.insert(9, 'x)
+    lb0.insert(9, sym"x")
   } catch {
     case ex: IndexOutOfBoundsException => println(ex)
   }
@@ -14,7 +14,7 @@ object Test extends App {
   val lb1 = newLB
 
   try {
-    lb1.insert(9, 'x)
+    lb1.insert(9, sym"x")
   } catch {
     case ex: IndexOutOfBoundsException =>
   }

--- a/test/files/run/t6634.scala
+++ b/test/files/run/t6634.scala
@@ -1,7 +1,7 @@
 import collection.mutable.ListBuffer
 
 object Test extends App {
-  def newLB = ListBuffer('a, 'b, 'c, 'd, 'e)
+  def newLB = ListBuffer(sym"a", sym"b", sym"c", sym"d", sym"e")
 
   val lb0 = newLB
   println("Trying lb0 ...")

--- a/test/files/run/t7974.check
+++ b/test/files/run/t7974.check
@@ -1,40 +1,64 @@
 
   // access flags 0x1
   public someSymbol1()Lscala/Symbol;
-    INVOKEDYNAMIC apply()Lscala/Symbol; [
-      // handle kind 0x6 : INVOKESTATIC
-      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
-      // arguments:
-      "Symbolic1"
-    ]
+    NEW scala/StringContext
+    DUP
+    GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
+    ICONST_1
+    ANEWARRAY java/lang/String
+    DUP
+    ICONST_0
+    LDC "Symbolic1"
+    AASTORE
+    CHECKCAST [Ljava/lang/Object;
+    INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
+    INVOKESPECIAL scala/StringContext.<init> (Lscala/collection/Seq;)V
+    GETSTATIC scala/collection/immutable/Nil$.MODULE$ : Lscala/collection/immutable/Nil$;
+    INVOKEVIRTUAL scala/StringContext.sym (Lscala/collection/Seq;)Lscala/Symbol;
     ARETURN
-    MAXSTACK = 1
+    MAXSTACK = 7
     MAXLOCALS = 1
 
 
   // access flags 0x1
   public someSymbol2()Lscala/Symbol;
-    INVOKEDYNAMIC apply()Lscala/Symbol; [
-      // handle kind 0x6 : INVOKESTATIC
-      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
-      // arguments:
-      "Symbolic2"
-    ]
+    NEW scala/StringContext
+    DUP
+    GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
+    ICONST_1
+    ANEWARRAY java/lang/String
+    DUP
+    ICONST_0
+    LDC "Symbolic2"
+    AASTORE
+    CHECKCAST [Ljava/lang/Object;
+    INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
+    INVOKESPECIAL scala/StringContext.<init> (Lscala/collection/Seq;)V
+    GETSTATIC scala/collection/immutable/Nil$.MODULE$ : Lscala/collection/immutable/Nil$;
+    INVOKEVIRTUAL scala/StringContext.sym (Lscala/collection/Seq;)Lscala/Symbol;
     ARETURN
-    MAXSTACK = 1
+    MAXSTACK = 7
     MAXLOCALS = 1
 
 
   // access flags 0x1
   public sameSymbol1()Lscala/Symbol;
-    INVOKEDYNAMIC apply()Lscala/Symbol; [
-      // handle kind 0x6 : INVOKESTATIC
-      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
-      // arguments:
-      "Symbolic1"
-    ]
+    NEW scala/StringContext
+    DUP
+    GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
+    ICONST_1
+    ANEWARRAY java/lang/String
+    DUP
+    ICONST_0
+    LDC "Symbolic1"
+    AASTORE
+    CHECKCAST [Ljava/lang/Object;
+    INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
+    INVOKESPECIAL scala/StringContext.<init> (Lscala/collection/Seq;)V
+    GETSTATIC scala/collection/immutable/Nil$.MODULE$ : Lscala/collection/immutable/Nil$;
+    INVOKEVIRTUAL scala/StringContext.sym (Lscala/collection/Seq;)Lscala/Symbol;
     ARETURN
-    MAXSTACK = 1
+    MAXSTACK = 7
     MAXLOCALS = 1
 
 
@@ -52,14 +76,22 @@
     ALOAD 0
     INVOKESPECIAL java/lang/Object.<init> ()V
     ALOAD 0
-    INVOKEDYNAMIC apply()Lscala/Symbol; [
-      // handle kind 0x6 : INVOKESTATIC
-      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
-      // arguments:
-      "Symbolic3"
-    ]
+    NEW scala/StringContext
+    DUP
+    GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
+    ICONST_1
+    ANEWARRAY java/lang/String
+    DUP
+    ICONST_0
+    LDC "Symbolic3"
+    AASTORE
+    CHECKCAST [Ljava/lang/Object;
+    INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
+    INVOKESPECIAL scala/StringContext.<init> (Lscala/collection/Seq;)V
+    GETSTATIC scala/collection/immutable/Nil$.MODULE$ : Lscala/collection/immutable/Nil$;
+    INVOKEVIRTUAL scala/StringContext.sym (Lscala/collection/Seq;)Lscala/Symbol;
     PUTFIELD Symbols.someSymbol3 : Lscala/Symbol;
     RETURN
-    MAXSTACK = 2
+    MAXSTACK = 8
     MAXLOCALS = 1
 

--- a/test/files/run/t7974/Symbols.scala
+++ b/test/files/run/t7974/Symbols.scala
@@ -1,6 +1,6 @@
 class Symbols {
-  def someSymbol1 = 'Symbolic1
-  def someSymbol2 = 'Symbolic2
-  def sameSymbol1 = 'Symbolic1
-  val someSymbol3 = 'Symbolic3
+  def someSymbol1 = sym"Symbolic1"
+  def someSymbol2 = sym"Symbolic2"
+  def sameSymbol1 = sym"Symbolic1"
+  val someSymbol3 = sym"Symbolic3"
 }

--- a/test/files/run/t8933/A_1.scala
+++ b/test/files/run/t8933/A_1.scala
@@ -2,5 +2,5 @@ class MotherClass
 
 trait MixinWithSymbol {
   self: MotherClass =>
-  def symbolFromTrait: Symbol = 'traitSymbol
+  def symbolFromTrait: Symbol = sym"traitSymbol"
 }

--- a/test/files/run/t8933/Test_2.scala
+++ b/test/files/run/t8933/Test_2.scala
@@ -1,5 +1,5 @@
 class MotherClass extends MixinWithSymbol {
-  val classSymbol = 'classSymbol
+  val classSymbol = sym"classSymbol"
 }
 
 object Test {

--- a/test/files/run/t8933b/A.scala
+++ b/test/files/run/t8933b/A.scala
@@ -1,4 +1,4 @@
 trait MixinWithSymbol {
   self: MotherClass =>
-  def symbolFromTrait: Any = 'traitSymbol
+  def symbolFromTrait: Any = sym"traitSymbol"
 }

--- a/test/files/run/t8933b/Test.scala
+++ b/test/files/run/t8933b/Test.scala
@@ -1,5 +1,5 @@
 class MotherClass extends MixinWithSymbol {
-  def foo = 'sym1
+  def foo = sym"sym1"
 }
 
 object Test {

--- a/test/junit/scala/lang/stringinterpol/StringContextTest.scala
+++ b/test/junit/scala/lang/stringinterpol/StringContextTest.scala
@@ -172,7 +172,7 @@ class StringContextTest {
       f"${s}%S"     -> "SCALA",
       f"${5}"       -> "5",
       f"${i}"       -> "42",
-      f"${'foo}"    -> "'foo",
+      f"${sym"foo"}"    -> "'foo",
 
       f"${Thread.State.NEW}" -> "NEW",
 

--- a/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
+++ b/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
@@ -29,7 +29,6 @@ class SymbolsTest {
   @Test
   def symbolInterpolationTest: Unit = {
     val foo = "bar"
-    assertEquals('bar, sym"$foo")
     assertEquals("'bar", sym"$foo".toString)
   }
 

--- a/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
+++ b/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
@@ -1,0 +1,64 @@
+package scala.lang.stringinterpol
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.language.implicitConversions
+
+@RunWith(classOf[JUnit4])
+class SymbolsTest {
+
+  @Test
+  def symbolTest: Unit = {
+    assertEquals("'foo", sym"foo".toString)
+  }
+
+  @Test
+  def emptySymbolTest: Unit = {
+    assertEquals("'", sym"".toString)
+  }
+
+  @Test
+  def symbolListTest: Unit = {
+    assertEquals("List('foo, 'bar, 'baz)", List(sym"foo", sym"bar", sym"baz").toString)
+    assertEquals("List('foo, 'bar, 'baz)", (sym"foo" :: sym"bar" :: sym"baz" :: Nil).toString)
+  }
+
+  @Test
+  def symbolInterpolation: Unit = {
+    val foo = "bar"
+    assertEquals("'bar", sym"$foo".toString)
+  }
+
+  @Test
+  def symbolPatternMatch: Unit = {
+    val bar = "foo"
+    sym"foo" match {
+      case sym""              => assertTrue(false)
+      case sym"$bar"          => assertTrue(false)
+      case sym"$foo"          => assertTrue(false)
+      case sym"${foo}"        => assertTrue(false)
+      case sym"bar"           => assertTrue(false)
+      case sym"foo$bar"       => assertTrue(false)
+      case sym"foo${bar}baz"  => assertTrue(false)
+      case sym"${foo}bar$baz" => assertTrue(false)
+      case sym"foo"           => assertTrue(true )
+      case _                  => assertTrue(false)
+    }
+  }
+
+  @Test
+  def symbolDeconstruct: Unit = {
+    val sym"foo" = sym"foo"
+    val Symbol(foo) = sym"foo"
+    assertEquals("foo", foo)
+  }
+
+  @Test(expected = classOf[MatchError])
+  def symbolMatchFailure: Unit = {
+    val sym"bar" = sym"foo"
+    assertTrue(false)
+  }
+}

--- a/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
+++ b/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
@@ -36,16 +36,16 @@ class SymbolsTest {
   def symbolPatternMatch: Unit = {
     val bar = "foo"
     sym"foo" match {
-      case sym""              => assertTrue(false)
-      case sym"$bar"          => assertTrue(false)
-      case sym"$foo"          => assertTrue(false)
-      case sym"${foo}"        => assertTrue(false)
-      case sym"bar"           => assertTrue(false)
-      case sym"foo$bar"       => assertTrue(false)
-      case sym"foo${bar}baz"  => assertTrue(false)
-      case sym"${foo}bar$baz" => assertTrue(false)
-      case sym"foo"           => assertTrue(true )
-      case _                  => assertTrue(false)
+      case sym""              => fail
+      case sym"$bar"          => fail
+      case sym"$foo"          => fail
+      case sym"${foo}"        => fail
+      case sym"bar"           => fail
+      case sym"foo$bar"       => fail
+      case sym"foo${bar}baz"  => fail
+      case sym"${foo}bar$baz" => fail
+      case sym"foo"           => return
+      case _                  => fail
     }
   }
 
@@ -59,6 +59,5 @@ class SymbolsTest {
   @Test(expected = classOf[MatchError])
   def symbolMatchFailure: Unit = {
     val sym"bar" = sym"foo"
-    assertTrue(false)
   }
 }

--- a/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
+++ b/test/junit/scala/lang/stringinterpol/SymbolsTest.scala
@@ -27,37 +27,57 @@ class SymbolsTest {
   }
 
   @Test
-  def symbolInterpolation: Unit = {
+  def symbolInterpolationTest: Unit = {
     val foo = "bar"
+    assertEquals('bar, sym"$foo")
     assertEquals("'bar", sym"$foo".toString)
   }
 
   @Test
-  def symbolPatternMatch: Unit = {
+  def patternMatchTest: Unit = {
+    val foo = "foo"
+    sym"foo" match {
+      case sym""           => fail
+      case sym"$$foo"      => fail
+      case sym"$${foo}"    => fail
+      case sym"foo$${bar}" => fail
+      case sym"foo\n"      => fail
+      case sym"foo"        => return
+      case _               => fail
+    }
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def patternMatchDollarFail: Unit = {
     val bar = "foo"
     sym"foo" match {
-      case sym""              => fail
-      case sym"$bar"          => fail
-      case sym"$foo"          => fail
-      case sym"${foo}"        => fail
-      case sym"bar"           => fail
-      case sym"foo$bar"       => fail
-      case sym"foo${bar}baz"  => fail
-      case sym"${foo}bar$baz" => fail
-      case sym"foo"           => return
-      case _                  => fail
+      // Variable interpolation not supported, use '$$' for '$'
+      case sym"$bar" =>
+    }
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def patternMatchDollarBracesFail: Unit = {
+    val bar = "foo"
+    sym"foo" match {
+      // Variable interpolation not supported, use '$$' for '$'
+      case sym"${bar}" =>
     }
   }
 
   @Test
-  def symbolDeconstruct: Unit = {
+  def deconstructTest: Unit = {
     val sym"foo" = sym"foo"
-    val Symbol(foo) = sym"foo"
-    assertEquals("foo", foo)
   }
 
   @Test(expected = classOf[MatchError])
-  def symbolMatchFailure: Unit = {
+  def deconstructFail: Unit = {
     val sym"bar" = sym"foo"
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def deconstructDollarFail: Unit = {
+    // Variable interpolation not supported, use '$$' for '$'
+    val sym"$foo" = sym"foo"
   }
 }

--- a/test/junit/scala/lang/traits/BytecodeTest.scala
+++ b/test/junit/scala/lang/traits/BytecodeTest.scala
@@ -77,18 +77,18 @@ class BytecodeTest extends BytecodeTesting {
 
     val c = noForwardersCompiler.compileClasses(code).map(c => (c.name, c)).toMap
 
-    val noForwarder = List('C1, 'C2, 'C3, 'C4, 'C10, 'C11, 'C12, 'C13, 'C16, 'C17)
+    val noForwarder = List(sym"C1", sym"C2", sym"C3", sym"C4", sym"C10", sym"C11", sym"C12", sym"C13", sym"C16", sym"C17")
     for (cn <- noForwarder) assertEquals(getMethods(c(cn.name), "f"), Nil)
 
-    checkForwarder(c, 'C5, "T3")
-    checkForwarder(c, 'C6, "T4")
-    checkForwarder(c, 'C7, "T5")
-    checkForwarder(c, 'C8, "T4")
-    checkForwarder(c, 'C9, "T5")
-    checkForwarder(c, 'C14, "T4")
-    checkForwarder(c, 'C15, "T5")
+    checkForwarder(c, sym"C5", "T3")
+    checkForwarder(c, sym"C6", "T4")
+    checkForwarder(c, sym"C7", "T5")
+    checkForwarder(c, sym"C8", "T4")
+    checkForwarder(c, sym"C9", "T5")
+    checkForwarder(c, sym"C14", "T4")
+    checkForwarder(c, sym"C15", "T5")
     assertSameSummary(getMethod(c("C18"), "f"), List(BIPUSH, IRETURN))
-    checkForwarder(c, 'C19, "T7")
+    checkForwarder(c, sym"C19", "T7")
     assertSameCode(getMethod(c("C19"), "T7$$super$f"), List(VarOp(ALOAD, 0), Invoke(INVOKESPECIAL, "C18", "f", "()I", false), Op(IRETURN)))
     assertInvoke(getMethod(c("C20"), "clone"), "T8", "clone$") // mixin forwarder
   }
@@ -133,10 +133,10 @@ class BytecodeTest extends BytecodeTesting {
       """.stripMargin
     val c = noForwardersCompiler.compileClasses(code, List(j1, j2, j3, j4)).map(c => (c.name, c)).toMap
 
-    val noForwarder = List('K1, 'K2, 'K3, 'K4, 'K5, 'K6, 'K7, 'K8, 'K9, 'K10, 'K11)
+    val noForwarder = List(sym"K1", sym"K2", sym"K3", sym"K4", sym"K5", sym"K6", sym"K7", sym"K8", sym"K9", sym"K10", sym"K11")
     for (cn <- noForwarder) assertEquals(getMethods(c(cn.name), "f"), Nil)
 
-    checkForwarder(c, 'K12, "T2")
+    checkForwarder(c, sym"K12", "T2")
   }
 
   @Test

--- a/test/scalacheck/scala/reflect/quasiquotes/UnliftableProps.scala
+++ b/test/scalacheck/scala/reflect/quasiquotes/UnliftableProps.scala
@@ -72,11 +72,6 @@ object UnliftableProps extends QuasiquoteProperties("unliftable") {
     assert(s.isInstanceOf[String] && s == "foo")
   }
 
-  property("unlift scala.symbol") = test {
-    val q"${s: scala.Symbol}" = q"'foo"
-    assert(s.isInstanceOf[scala.Symbol] && s == 'foo)
-  }
-
   implicit def unliftList[T: Unliftable]: Unliftable[List[T]] = Unliftable {
     case q"scala.collection.immutable.List(..$args)" if args.forall { implicitly[Unliftable[T]].unapply(_).nonEmpty } =>
       val ut = implicitly[Unliftable[T]]


### PR DESCRIPTION
After some investigation, it seems that studying #7495 against the community build is better served in 2.12, since a lot of projects are still working on supporting 2.13.  This backports dropping symbol literals to 2.12.  This should produce 2.12 artifacts of the compiler the community build can use.

Previously, #7499.