### PR TITLE
Add pattern matches to doc for Option

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -135,14 +135,38 @@ sealed abstract class Option[+A] extends Product with Serializable {
   self =>
 
   /** Returns true if the option is $none, false otherwise.
+   *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(_) => false
+   *   case None    => true
+   * }
+   * }}}
    */
   def isEmpty: Boolean
 
   /** Returns true if the option is an instance of $some, false otherwise.
+   *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(_) => true
+   *   case None    => false
+   * }
+   * }}}
    */
   def isDefined: Boolean = !isEmpty
 
   /** Returns the option's value.
+   *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) => x
+   *   case None    => throw new Exception
+   * }
+   * }}}
    *  @note The option must be nonempty.
    *  @throws java.util.NoSuchElementException if the option is empty.
    */
@@ -151,6 +175,14 @@ sealed abstract class Option[+A] extends Product with Serializable {
   /** Returns the option's value if the option is nonempty, otherwise
    * return the result of evaluating `default`.
    *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) => x
+   *   case None    => default
+   * }
+   * }}}
+   *
    *  @param default  the default expression.
    */
   @inline final def getOrElse[B >: A](default: => B): B =
@@ -158,8 +190,17 @@ sealed abstract class Option[+A] extends Product with Serializable {
 
   /** Returns the option's value if it is nonempty,
    * or `null` if it is empty.
+   *
    * Although the use of null is discouraged, code written to use
    * $option must often interface with code that expects and returns nulls.
+   *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) => x
+   *   case None    => null
+   * }
+   * }}}
    * @example {{{
    * val initialText: Option[String] = getInitialText
    * val textField = new JComponent(initialText.orNull,20)
@@ -171,6 +212,13 @@ sealed abstract class Option[+A] extends Product with Serializable {
    * value if this $option is nonempty.
    * Otherwise return $none.
    *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) => Some(f(x))
+   *   case None    => None
+   * }
+   * }}}
    *  @note This is similar to `flatMap` except here,
    *  $f does not need to wrap its result in an $option.
    *
@@ -185,8 +233,17 @@ sealed abstract class Option[+A] extends Product with Serializable {
    *  value if the $option is nonempty.  Otherwise, evaluates
    *  expression `ifEmpty`.
    *
-   *  @note This is equivalent to `$option map f getOrElse ifEmpty`.
-   *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) => f(x)
+   *   case None    => ifEmpty
+   * }
+   * }}}
+   * This is also equivalent to:
+   * {{{
+   * option map f getOrElse ifEmpty
+   * }}}
    *  @param  ifEmpty the expression to evaluate if empty.
    *  @param  f       the function to apply if nonempty.
    */
@@ -199,6 +256,13 @@ sealed abstract class Option[+A] extends Product with Serializable {
    * Slightly different from `map` in that $f is expected to
    * return an $option (which could be $none).
    *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) => f(x)
+   *   case None    => None
+   * }
+   * }}}
    *  @param  f   the function to apply
    *  @see map
    *  @see foreach
@@ -212,6 +276,13 @@ sealed abstract class Option[+A] extends Product with Serializable {
   /** Returns this $option if it is nonempty '''and''' applying the predicate $p to
    * this $option's value returns true. Otherwise, return $none.
    *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) if p(x) => Some(x)
+   *   case _               => None
+   * }
+   * }}}
    *  @param  p   the predicate used for testing.
    */
   @inline final def filter(p: A => Boolean): Option[A] =
@@ -220,12 +291,27 @@ sealed abstract class Option[+A] extends Product with Serializable {
   /** Returns this $option if it is nonempty '''and''' applying the predicate $p to
    * this $option's value returns false. Otherwise, return $none.
    *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) if !p(x) => Some(x)
+   *   case _                => None
+   * }
+   * }}}
    *  @param  p   the predicate used for testing.
    */
   @inline final def filterNot(p: A => Boolean): Option[A] =
     if (isEmpty || !p(this.get)) this else None
 
   /** Returns false if the option is $none, true otherwise.
+   *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(_) => true
+   *   case None    => false
+   * }
+   * }}}
    *  @note   Implemented here to avoid the implicit conversion to Iterable.
    */
   final def nonEmpty = isDefined
@@ -248,6 +334,13 @@ sealed abstract class Option[+A] extends Product with Serializable {
 
   /** Tests whether the option contains a given value as an element.
    *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) => x == elem
+   *   case None    => false
+   * }
+   * }}}
    *  @example {{{
    *  // Returns true because Some instance contains string "something" which equals "something".
    *  Some("something") contains "something"
@@ -270,6 +363,13 @@ sealed abstract class Option[+A] extends Product with Serializable {
    * $p returns true when applied to this $option's value.
    * Otherwise, returns false.
    *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) => p(x)
+   *   case None    => false
+   * }
+   * }}}
    *  @param  p   the predicate to test
    */
   @inline final def exists(p: A => Boolean): Boolean =
@@ -278,6 +378,13 @@ sealed abstract class Option[+A] extends Product with Serializable {
   /** Returns true if this option is empty '''or''' the predicate
    * $p returns true when applied to this $option's value.
    *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) => p(x)
+   *   case None    => true
+   * }
+   * }}}
    *  @param  p   the predicate to test
    */
   @inline final def forall(p: A => Boolean): Boolean = isEmpty || p(this.get)
@@ -285,6 +392,13 @@ sealed abstract class Option[+A] extends Product with Serializable {
   /** Apply the given procedure $f to the option's value,
    *  if it is nonempty. Otherwise, do nothing.
    *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) => f(x)
+   *   case None    => ()
+   * }
+   * }}}
    *  @param  f   the procedure to apply.
    *  @see map
    *  @see flatMap
@@ -319,6 +433,14 @@ sealed abstract class Option[+A] extends Product with Serializable {
 
   /** Returns this $option if it is nonempty,
    *  otherwise return the result of evaluating `alternative`.
+   *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) => Some(x)
+   *   case None    => alternative
+   * }
+   * }}}
    *  @param alternative the alternative expression.
    */
   @inline final def orElse[B >: A](alternative: => Option[B]): Option[B] =
@@ -332,6 +454,14 @@ sealed abstract class Option[+A] extends Product with Serializable {
 
   /** Returns a singleton list containing the $option's value
    * if it is nonempty, or the empty list if the $option is empty.
+   *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) => List(x)
+   *   case None    => Nil
+   * }
+   * }}}
    */
   def toList: List[A] =
     if (isEmpty) List() else new ::(this.get, Nil)
@@ -341,6 +471,13 @@ sealed abstract class Option[+A] extends Product with Serializable {
    * a [[scala.util.Right]] containing this $option's value if
    * this is nonempty.
    *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) => Right(x)
+   *   case None    => Left(left)
+   * }
+   * }}}
    * @param left the expression to evaluate and return if this is empty
    * @see toLeft
    */
@@ -352,6 +489,13 @@ sealed abstract class Option[+A] extends Product with Serializable {
    * a [[scala.util.Left]] containing this $option's value
    * if this $option is nonempty.
    *
+   * This is equivalent to:
+   * {{{
+   * option match {
+   *   case Some(x) => Left(x)
+   *   case None    => Right(right)
+   * }
+   * }}}
    * @param right the expression to evaluate and return if this is empty
    * @see toRight
    */

--- a/test/scalacheck/scala/OptionTest.scala
+++ b/test/scalacheck/scala/OptionTest.scala
@@ -1,0 +1,284 @@
+package scala
+
+import org.scalacheck.Prop
+import org.scalacheck.Properties
+import org.scalacheck.Prop.AnyOperators
+
+/**
+ * Property tests for code in [[scala.Option]]'s documentation.
+ */
+object OptionTest extends Properties("scala.Option") {
+
+  property("map") = {
+    Prop.forAll { (option: Option[Int], i: Int) =>
+      val f: Function1[Int,Int] = (_ => i)
+      option.map(f(_)) ?= {
+        option match {
+          case Some(x) => Some(f(x))
+          case None    => None
+        }
+      }
+    }
+  }
+
+  property("flatMap") = {
+    Prop.forAll { (option: Option[Int], i: Int) =>
+      val f: Function1[Int,Option[Int]] = (_ => Some(i))
+      option.flatMap(f(_)) ?= {
+        option match {
+          case Some(x) => f(x)
+          case None    => None
+        }
+      }
+    }
+  }
+
+  property("foreach") = {
+    Prop.forAll { (option: Option[Int], unit: Unit) =>
+      val proc: Function1[Int,Unit] = (_ => unit)
+      option.foreach(proc(_)) ?= {
+        option match {
+          case Some(x) => proc(x)
+          case None    => ()
+        }
+      }
+    }
+  }
+
+  property("fold") = {
+    Prop.forAll { (option: Option[Int], i: Int, y: Int) =>
+      val f: Function1[Int,Int] = (_ => i)
+      option.fold(y)(f(_)) ?= {
+        option match {
+          case Some(x) => f(x)
+          case None    => y
+        }
+      }
+    }
+  }
+
+  property("foldLeft") = {
+    Prop.forAll { (option: Option[Int], i: Int, y: Int) =>
+      val f: Function2[Int,Int,Int] = ((_, _) => i)
+      option.foldLeft(y)(f(_, _)) ?= {
+        option match {
+          case Some(x) => f(y, x)
+          case None    => y
+        }
+      }
+    }
+  }
+
+  property("foldRight") = {
+    Prop.forAll { (option: Option[Int], i: Int, y: Int) =>
+      val f: Function2[Int,Int,Int] = ((_, _) => i)
+      option.foldRight(y)(f(_, _)) ?= {
+        option match {
+          case Some(x) => f(x, y)
+          case None    => y
+        }
+      }
+    }
+  }
+
+  property("collect") = {
+    Prop.forAll { (option: Option[Int], i: Int) =>
+      val pf: PartialFunction[Int,Int] = {
+        case x if x > 0 => i
+      }
+      option.collect(pf) ?= {
+        option match {
+          case Some(x) if pf.isDefinedAt(x) => Some(pf(x))
+          case _                            => None
+        }
+      }
+    }
+  }
+
+  property("isDefined") = {
+    Prop.forAll { option: Option[Int] =>
+      option.isDefined ?= {
+        option match {
+          case Some(_) => true
+          case None    => false
+        }
+      }
+    }
+  }
+
+  property("isEmpty") = {
+    Prop.forAll { option: Option[Int] =>
+      option.isEmpty ?= {
+        option match {
+          case Some(_) => false
+          case None    => true
+        }
+      }
+    }
+  }
+
+  property("nonEmpty") = {
+    Prop.forAll { option: Option[Int] =>
+      option.nonEmpty ?= {
+        option match {
+          case Some(_) => true
+          case None    => false
+        }
+      }
+    }
+  }
+
+  property("orElse") = {
+    Prop.forAll { (option: Option[Int], y: Option[Int]) =>
+      option.orElse(y) ?= {
+        option match {
+          case Some(x) => Some(x)
+          case None    => y
+        }
+      }
+    }
+  }
+
+  property("getOrElse") = {
+    Prop.forAll { (option: Option[Int], y: Int) =>
+      option.getOrElse(y) ?= {
+        option match {
+          case Some(x) => x
+          case None    => y
+        }
+      }
+    }
+  }
+
+  property("get") = {
+    Prop.forAll { (option: Option[Int]) =>
+      Prop.iff[Option[Int]](option, {
+        case Some(x) =>
+          option.get ?= {
+            option match {
+              case Some(x) => x
+              case None    => throw new Exception
+            }
+          }
+        case None =>
+          Prop.throws(classOf[Exception]) {
+            option.get
+          }
+      })
+    }
+  }
+
+  property("orNull") = {
+    Prop.forAll { (option: Option[String]) =>
+      option.orNull ?= {
+        option match {
+          case Some(s) => s
+          case None    => null
+        }
+      }
+    }
+  }
+
+  property("filter") = {
+    Prop.forAll { (option: Option[Int], bool: Boolean) =>
+      val pred: Function1[Int,Boolean] = (_ => bool)
+      option.filter(pred(_)) ?= {
+        option match {
+          case Some(x) if pred(x) => Some(x)
+          case _                  => None
+        }
+      }
+    }
+  }
+
+  property("filterNot") = {
+    Prop.forAll { (option: Option[Int], bool: Boolean) =>
+      val pred: Function1[Int,Boolean] = (_ => bool)
+      option.filterNot(pred(_)) ?= {
+        option match {
+          case Some(x) if !pred(x) => Some(x)
+          case _                   => None
+        }
+      }
+    }
+  }
+
+  property("exists") = {
+    Prop.forAll { (option: Option[Int], bool: Boolean) =>
+      val pred: Function1[Int,Boolean] = (_ => bool)
+      option.exists(pred(_)) ?= {
+        option match {
+          case Some(x) => pred(x)
+          case None    => false
+        }
+      }
+    }
+  }
+
+  property("forall") = {
+    Prop.forAll { (option: Option[Int], bool: Boolean) =>
+      val pred: Function1[Int,Boolean] = (_ => bool)
+      option.forall(pred(_)) ?= {
+        option match {
+          case Some(x) => pred(x)
+          case None    => true
+        }
+      }
+    }
+  }
+
+  property("contains") = {
+    Prop.forAll { (option: Option[Int], y: Int) =>
+      option.contains(y) ?= {
+        option match {
+          case Some(x) => x == y
+          case None    => false
+        }
+      }
+    }
+  }
+
+  property("size") = {
+    Prop.forAll { option: Option[Int] =>
+      option.size ?= {
+        option match {
+          case Some(x) => 1
+          case None    => 0
+        }
+      }
+    }
+  }
+
+  property("toList") = {
+    Prop.forAll { option: Option[Int] =>
+      option.toList ?= {
+        option match {
+          case Some(x) => List(x)
+          case None    => Nil
+        }
+      }
+    }
+  }
+
+  property("toRight") = {
+    Prop.forAll { (option: Option[Int], i: Int) =>
+      option.toRight(i) ?= {
+        option match {
+          case Some(x) => scala.util.Right(x)
+          case None    => scala.util.Left(i)
+        }
+      }
+    }
+  }
+
+  property("toLeft") = {
+    Prop.forAll { (option: Option[Int], i: Int) =>
+      option.toLeft(i) ?= {
+        option match {
+          case Some(x) => scala.util.Left(x)
+          case None    => scala.util.Right(i)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I've added the pattern match to the doc for many of the `Option` methods.   I've included a suite of tests that I wrote to check my work.

The `Option` data type has been stable in Scala for many years, now.  Its documentation could use getting filled out to be more useful.  It's a commonly used part of the standard library, and it gets a lot of exposure from beginners.

I've built the docs locally and posted them on my Github pages for review:

https://ashawley.github.io/scala/2.12.8/library/scala/Option.html

Here's the current version for comparison:

https://www.scala-lang.org/api/2.12.8/scala/Option.html

PS. I've targeted this change to 2.12.  I figured when 2.12 gets bulk merged on to 2.13, again, I'd work on documenting zip and zip3 -- among other changes in 2.13.
