### PR TITLE
[REVERTED] VectorBuilder shares structure of added Vector if the builder was empty, for better performance of Vector#concat

### DIFF
--- a/test/scalacheck/scala/collection/immutable/VectorBuilderProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/VectorBuilderProperties.scala
@@ -1,0 +1,99 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.immutable
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop._
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+
+object VectorBuilderProperties extends Properties("VectorBuilder") {
+
+  type Elem = Int
+
+  /** Wrapper for all the many parameters to our properties
+    *
+    * @param a first vector to add
+    * @param dropA number of elems to drop from `a` before adding
+    * @param dropRightA number of elems to dropRight from `a` before adding
+    * @param b second vector to add
+    * @param dropB number of elems to drop from `b` before adding
+    * @param dropRightB number of elems to dropRight from `b` before adding
+    * @param c first vector to add
+    * @param dropC number of elems to drop from `c` before adding
+    * @param dropRightC number of elems to dropRight from `c` before adding
+    */
+  case class AddAllTestCase(
+    a: Vector[Elem],
+    dropA: Int,
+    dropRightA: Int,
+    b: Vector[Elem],
+    dropB: Int,
+    dropRightB: Int,
+    c: Vector[Elem],
+    dropC: Int,
+    dropRightC: Int
+  )
+
+  implicit val arbAddAllTestCase: Arbitrary[AddAllTestCase] =
+    Arbitrary {
+      for {
+        a <- arbitrary[Vector[Elem]]
+        dropA <- Gen.choose(0, 500)
+        dropRightA <- Gen.choose(0, 500)
+        b <- arbitrary[Vector[Elem]]
+        dropB <- Gen.choose(0, 500)
+        dropRightB <- Gen.choose(0, 500)
+        c <- arbitrary[Vector[Elem]]
+        dropC <- Gen.choose(0, 500)
+        dropRightC <- Gen.choose(0, 500)
+      } yield AddAllTestCase(a, dropA, dropRightA, b, dropB, dropRightB, c, dropC, dropRightC)
+    }
+
+  property("addAll(a).addAll(b).addAll(c).result() == a ++ b ++ c") =
+    forAll { testCase: AddAllTestCase =>
+      val AddAllTestCase(a, dropA, dropRightA, b, dropB, dropRightB, c, dropC, dropRightC) = testCase
+
+      val actual: Seq[Elem] =
+        new VectorBuilder[Elem]
+          .addAll(a.drop(dropA).dropRight(dropRightA))
+          .addAll(b.drop(dropB).dropRight(dropRightB))
+          .addAll(c.drop(dropC).dropRight(dropRightC))
+          .result()
+
+      val expected =
+        a.toList.drop(dropA).dropRight(dropRightA) ++
+        b.toList.drop(dropB).dropRight(dropRightB) ++
+        c.toList.drop(dropC).dropRight(dropRightC)
+
+      actual ?= expected
+    }
+  property("addAll(a).addAll(b).addAll(c).size == (a ++ b ++ c).size") =
+    forAll { testCase: AddAllTestCase =>
+      val AddAllTestCase(a, dropA, dropRightA, b, dropB, dropRightB, c, dropC, dropRightC) = testCase
+
+      val actual: Int =
+        new VectorBuilder[Elem]
+          .addAll(a.drop(dropA).dropRight(dropRightA))
+          .addAll(b.drop(dropB).dropRight(dropRightB))
+          .addAll(c.drop(dropC).dropRight(dropRightC))
+          .size
+
+      val expected =
+        (a.toList.drop(dropA).dropRight(dropRightA) ++
+          b.toList.drop(dropB).dropRight(dropRightB) ++
+          c.toList.drop(dropC).dropRight(dropRightC)).length
+
+      actual ?= expected
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11329

Currently, when adding a Vector to a VectorBuilder via `builder.addAll(v)`, that builder will copy all elements into the new Vector. Instead we can share almost all structure with that passed Vector, if the builder was empty before adding the Vector.

This is important because this is the code-path hit by `Vector#concat(Iterable)` and so by doing this we greatly improve CPU time of the builder in these cases, reduce memory usage, and CPU time of the Vector#concat/appendedAll method.

## Benchmarks

#### Vector#concat

The benefit to Vector concat is large but not as large as the benefit to the builder. That is because there was already some logic inside Vector concat that would avoid copying all elements of the left vector, and instead prepend the elements of `this` to the vector on the right, one-by-one. Still, that trick does not work for non-Vector collections. 

```
[info] Benchmark                            (sizeLeft)  (sizeRight)  Mode  Cnt      Score     Error  Units
[info] VectorBenchmark.leftConcatRight_new           0          100  avgt    6      6.756 ±   0.579  ns/op
[info] VectorBenchmark.leftConcatRight_new           1          100  avgt    6     49.904 ±   1.709  ns/op
[info] VectorBenchmark.leftConcatRight_new          10          100  avgt    6    218.261 ±   7.919  ns/op
[info] VectorBenchmark.leftConcatRight_new         100          100  avgt    6    318.429 ±  18.978  ns/op
[info] VectorBenchmark.leftConcatRight_new        1000          100  avgt    6    262.965 ±  12.497  ns/op
[info] VectorBenchmark.leftConcatRight_new       10000          100  avgt    6    493.761 ±   8.534  ns/op
[info] VectorBenchmark.leftConcatRight_new      100000          100  avgt    6    644.133 ±  13.492  ns/op
[info] VectorBenchmark.leftConcatRight_new     1000000          100  avgt    6    637.583 ±  27.483  ns/op
[info] VectorBenchmark.leftConcatRight_new    10000000          100  avgt    6    839.363 ±  95.754  ns/op
[info] VectorBenchmark.leftConcatRight_old           0          100  avgt    6     15.956 ±   0.437  ns/op
[info] VectorBenchmark.leftConcatRight_old           1          100  avgt    6     62.119 ±   1.686  ns/op
[info] VectorBenchmark.leftConcatRight_old          10          100  avgt    6    224.170 ±   6.856  ns/op
[info] VectorBenchmark.leftConcatRight_old         100          100  avgt    6    324.611 ±  12.725  ns/op
[info] VectorBenchmark.leftConcatRight_old        1000          100  avgt    6   1218.946 ±  39.278  ns/op
[info] VectorBenchmark.leftConcatRight_old       10000          100  avgt    6  10124.572 ± 709.876  ns/op
[info] VectorBenchmark.leftConcatRight_old      100000          100  avgt    6  10329.658 ± 709.561  ns/op
[info] VectorBenchmark.leftConcatRight_old     1000000          100  avgt    6   9955.540 ± 716.100  ns/op
[info] VectorBenchmark.leftConcatRight_old    10000000          100  avgt    6  10465.319 ± 675.380  ns/op
```
#### VectorBuilder#addAll
benchmark's `new VectorBuilder[A].addAll(vec)`
```
[info] Benchmark                                (sizeLeft)  Mode  Cnt         Score         Error  Units
[info] VectorBenchmark.vectorBuilderAddAll_new           0  avgt    6        20.314 ±       1.864  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_new           1  avgt    6        37.637 ±       0.781  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_new          10  avgt    6        42.497 ±       1.103  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_new         100  avgt    6        49.754 ±       1.258  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_new        1000  avgt    6        46.884 ±       2.006  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_new       10000  avgt    6       264.986 ±      17.862  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_new      100000  avgt    6       404.341 ±       5.669  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_new     1000000  avgt    6       410.077 ±       8.319  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_new    10000000  avgt    6       564.855 ±      29.569  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_old           0  avgt    6        19.112 ±       0.352  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_old           1  avgt    6        38.005 ±       0.944  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_old          10  avgt    6        38.558 ±       0.867  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_old         100  avgt    6       145.642 ±       5.987  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_old        1000  avgt    6      1075.496 ±      23.117  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_old       10000  avgt    6     10699.170 ±     440.156  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_old      100000  avgt    6    164777.276 ±  184712.385  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_old     1000000  avgt    6   2180308.349 ±  502256.170  ns/op
[info] VectorBenchmark.vectorBuilderAddAll_old    10000000  avgt    6  38082222.389 ± 1357357.187  ns/op
```