### PR TITLE
Add regression test for Bug 6962

### DIFF
--- a/test/files/neg/t6962.check
+++ b/test/files/neg/t6962.check
@@ -1,0 +1,4 @@
+t6962.scala:5: error: Bar is not an enclosing class
+  protected[Bar] def crashes(withDefaultParam: Boolean = true): Int = 42
+                     ^
+one error found

--- a/test/files/neg/t6962.scala
+++ b/test/files/neg/t6962.scala
@@ -1,0 +1,6 @@
+trait t6962 {
+  def sth() = {
+    crashes()
+  }
+  protected[Bar] def crashes(withDefaultParam: Boolean = true): Int = 42
+}


### PR DESCRIPTION
Fixes (marks as resolved) bug https://github.com/scala/bug/issues/6962, which involves the use of wrong package or class scope for a scope-private annotation.

The test file contains the example code from the first message of that ticket, with some changes.