### PR TITLE
Enumeration ValueOrdering is implicitly available

### DIFF
--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -266,7 +266,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
   }
 
   /** An ordering by id for values of this set */
-  object ValueOrdering extends Ordering[Value] {
+  implicit object ValueOrdering extends Ordering[Value] {
     def compare(x: Value, y: Value): Int = x compare y
   }
 

--- a/test/junit/scala/EnumerationTest.scala
+++ b/test/junit/scala/EnumerationTest.scala
@@ -19,4 +19,11 @@ class EnumerationTest {
     val s4 = A.values.flatMap(x => Set(x))
     assertEquals(Set.empty, (s4: A.ValueSet))
   }
+
+  @Test def implicitOrderingIsSameAsEnumerationOrdering: Unit = {
+    object MyEnum extends Enumeration {
+      val a, b, c = Value
+    }
+    assertSame(Ordering[MyEnum.Value], MyEnum.ValueOrdering)
+  }
 }


### PR DESCRIPTION
Currently, even though `Enumeration`s admit an ordering via `Enumeration#ValueOrdering`, this value ordering will not be picked up implicitly. Instead, when asked for, a low-priority conversion kicks in, from `scala.math.LowPriorityOrderingImplicits`:
```scala
type AsComparable[A] = A => Comparable[A]

implicit def ordered[A](implicit asComparable: AsComparable[A]): Ordering[A] = new Ordering[A] {
  def compare(x: A, y: A): Int = asComparable(x).compareTo(y)
}
```

The consequences of this are that SortedSet/SortedMap optimizations cannot be applied, because they can only be applied if orderings are the same.

