### PR TITLE
HKT inference and GADT improvements

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3348,9 +3348,9 @@ trait Types
     _constr: TypeConstraint,
     override val params: List[Symbol]
   ) extends TypeVar(_origin, _constr) {
-
     require(params.nonEmpty, this)
-    override def isHigherKinded          = true
+    override def isHigherKinded: Boolean = true
+    override def typeParams: List[Symbol] = params
   }
 
   /** Precondition: `params.length == typeArgs.length > 0` (enforced structurally). */

--- a/test/files/pos/t10117.scala
+++ b/test/files/pos/t10117.scala
@@ -1,0 +1,11 @@
+import scala.language.higherKinds
+
+case class Const[A, B](value: A)
+sealed trait Foo[F[_], A]
+final case class Bar[F[_]]() extends Foo[F, Unit]
+
+object Test {
+  def f[F[_], A](foo: Foo[F, A]): Unit = foo match {
+    case Bar() => Const[Unit, F[Unit]](()).value
+  }
+}

--- a/test/files/pos/t10208.scala
+++ b/test/files/pos/t10208.scala
@@ -1,0 +1,17 @@
+import scala.language.higherKinds
+
+trait ~>[A[_], B[_]] {
+  def apply[I](fa: A[I]): B[I]
+}
+
+sealed trait GADTK[A[_], I]
+final case class MemberK[A[_]](i: Int) extends GADTK[A, Int]
+
+object Test {
+  def doesNotCompile[A[_]]: (({ type λ[α] = GADTK[A, α] })#λ ~> ({ type λ[α] = GADTK[A, α] })#λ) =
+    new (({ type λ[α] = GADTK[A, α] })#λ ~> ({ type λ[α] = GADTK[A, α] })#λ) {
+      def apply[I](v: GADTK[A, I]): GADTK[A, I] = v match {
+        case MemberK(i) => MemberK(i)
+      }
+    }
+}

--- a/test/files/pos/t10208b.scala
+++ b/test/files/pos/t10208b.scala
@@ -1,0 +1,22 @@
+import scala.language.higherKinds
+
+class Base[M[_]] { def mint: M[Int] = ??? }
+final case class Sub() extends Base[Option]
+
+object Test {
+  def test[M[_]](b: Base[M]): Option[Int] = {
+    bar: M[Any]
+    b match {
+      case Sub() =>
+        bar: M[Any] // incorrect error: M does not take type parameters
+        b.mint // GADT refinement: M = Option
+
+      // Fix: change GADT refinement for HK type params to assign M the type:
+      // [A]( >: Option[A] <: Option[A]),
+      // rather than:
+      // >: Option <: Option
+    }
+  }
+
+  def bar[N[_]]: N[Any] = ???
+}


### PR DESCRIPTION
Handle missing HKT cases in a few more places in the compiler:
 * in `HKTypeVar` override `typeParams`
 * in `isSubHKTypeVar` special-case `Any` and `Nothing` as kind-poly
 * in `instantiateTypeVar` handle refining of higher-kinded GADT bounds

Fixes scala/bug#10208
Fixes scala/bug#10117
Fixes scala/bug#10116
Supersedes #5744

Took tests from @retronym's branch