### PR TITLE
BitmapIndexedMap/SetNode use Array#clone rather than manually copying content.

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -1072,12 +1072,11 @@ private final class BitmapIndexedMapNode[K, +V](
   }
 
   override def copy(): BitmapIndexedMapNode[K, V] = {
-    val contentClone = new Array[Any](content.length)
-    val dataIndices = bitCount(dataMap) * TupleLength
-    Array.copy(content, 0, contentClone, 0, dataIndices)
-    var i = dataIndices
-    while (i < content.length) {
-      contentClone(i) = content(i).asInstanceOf[MapNode[K, V]].copy()
+    val contentClone = content.clone()
+    val contentLength = contentClone.length
+    var i = bitCount(dataMap) * TupleLength
+    while (i < contentLength) {
+      contentClone(i) = contentClone(i).asInstanceOf[MapNode[K, V]].copy()
       i += 1
     }
     new BitmapIndexedMapNode[K, V](dataMap, nodeMap, contentClone, originalHashes.clone(), size, cachedJavaKeySetHashCode)

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -1004,12 +1004,11 @@ private final class BitmapIndexedSetNode[A](
     throw new UnsupportedOperationException("Trie nodes do not support hashing.")
 
   override def copy(): BitmapIndexedSetNode[A] = {
-    val contentClone = new Array[Any](content.length)
-    val dataIndices = bitCount(dataMap)
-    Array.copy(content, 0, contentClone, 0, dataIndices)
-    var i = dataIndices
-    while (i < content.length) {
-      contentClone(i) = content(i).asInstanceOf[SetNode[A]].copy()
+    val contentClone = content.clone()
+    val contentLength = contentClone.length
+    var i = bitCount(dataMap)
+    while (i < contentLength) {
+      contentClone(i) = contentClone(i).asInstanceOf[SetNode[A]].copy()
       i += 1
     }
     new BitmapIndexedSetNode[A](dataMap, nodeMap, contentClone, originalHashes.clone(), size, cachedJavaKeySetHashCode)


### PR DESCRIPTION
This improves performance of MapNode/SetNode#copy by quite a lot:

Below is a bench mark of `hashMap.rootNode.copy()` for various size of hashmap:

The benchmark code:

```scala

  var size: Int = _

  var hm: HashMap[Int, Int] = _

  @Setup(Level.Trial) def init(): Unit = {
    hm = (0 until size).map(_ -> 0).to(HashMap)
  }

   @Benchmark def copyElems(bh: Blackhole): Unit = {
    bh.consume{
      hm.rootNode.copy()
    }
  }

```

```
[info] # Run complete. Total time: 00:16:57
[info] Benchmark                        (size)  Mode  Cnt          Score         Error  Units
[info] HashMapBenchmark.copyElems_new        1  avgt   20         18.659 ±       0.261  ns/op
[info] HashMapBenchmark.copyElems_new        2  avgt   20         19.122 ±       0.114  ns/op
[info] HashMapBenchmark.copyElems_new        4  avgt   20         19.997 ±       0.464  ns/op
[info] HashMapBenchmark.copyElems_new        8  avgt   20         21.319 ±       0.501  ns/op
[info] HashMapBenchmark.copyElems_new       16  avgt   20         24.754 ±       0.364  ns/op
[info] HashMapBenchmark.copyElems_new       32  avgt   20        157.978 ±       0.901  ns/op
[info] HashMapBenchmark.copyElems_new       64  avgt   20        463.743 ±       4.058  ns/op
[info] HashMapBenchmark.copyElems_new      128  avgt   20        795.381 ±      17.054  ns/op
[info] HashMapBenchmark.copyElems_new      256  avgt   20       1295.282 ±       9.688  ns/op
[info] HashMapBenchmark.copyElems_new      512  avgt   20       2873.338 ±      79.958  ns/op
[info] HashMapBenchmark.copyElems_new     1024  avgt   20       7101.017 ±      90.400  ns/op
[info] HashMapBenchmark.copyElems_new     2048  avgt   20      17503.954 ±     217.401  ns/op
[info] HashMapBenchmark.copyElems_new     4096  avgt   20      33588.154 ±     268.578  ns/op
[info] HashMapBenchmark.copyElems_new     8192  avgt   20      57631.705 ±     488.770  ns/op
[info] HashMapBenchmark.copyElems_new    16384  avgt   20     120688.275 ±    1693.875  ns/op
[info] HashMapBenchmark.copyElems_new    32768  avgt   20     292481.710 ±    5856.160  ns/op
[info] HashMapBenchmark.copyElems_new    65536  avgt   20     719479.144 ±   16264.662  ns/op
[info] HashMapBenchmark.copyElems_new   131072  avgt   20    1613750.033 ±   33522.811  ns/op
[info] HashMapBenchmark.copyElems_new   262144  avgt   20    3611468.184 ±  124717.623  ns/op
[info] HashMapBenchmark.copyElems_new   524288  avgt   20    8783963.592 ±   69390.072  ns/op
[info] HashMapBenchmark.copyElems_new  1048576  avgt   20   16543834.577 ±  350817.912  ns/op
[info] HashMapBenchmark.copyElems_new  2097152  avgt   20   42205574.029 ±  516778.857  ns/op
[info] HashMapBenchmark.copyElems_new  4194304  avgt   20   93639257.114 ± 1168843.848  ns/op
[info] HashMapBenchmark.copyElems_new  8388608  avgt   20  147060438.379 ± 4959131.610  ns/op
```


```
[info] # Run complete. Total time: 00:17:45
[info] Benchmark                        (size)  Mode  Cnt          Score         Error  Units
[info] HashMapBenchmark.copyElems_old        1  avgt   20         32.244 ±       0.292  ns/op
[info] HashMapBenchmark.copyElems_old        2  avgt   20         32.613 ±       0.172  ns/op
[info] HashMapBenchmark.copyElems_old        4  avgt   20         33.517 ±       0.277  ns/op
[info] HashMapBenchmark.copyElems_old        8  avgt   20         33.673 ±       0.202  ns/op
[info] HashMapBenchmark.copyElems_old       16  avgt   20         37.358 ±       0.264  ns/op
[info] HashMapBenchmark.copyElems_old       32  avgt   20        271.275 ±       1.794  ns/op
[info] HashMapBenchmark.copyElems_old       64  avgt   20        806.847 ±       5.697  ns/op
[info] HashMapBenchmark.copyElems_old      128  avgt   20       1352.905 ±      36.802  ns/op
[info] HashMapBenchmark.copyElems_old      256  avgt   20       2206.602 ±      12.736  ns/op
[info] HashMapBenchmark.copyElems_old      512  avgt   20       4551.882 ±      72.987  ns/op
[info] HashMapBenchmark.copyElems_old     1024  avgt   20      11568.642 ±     171.903  ns/op
[info] HashMapBenchmark.copyElems_old     2048  avgt   20      27285.720 ±     178.391  ns/op
[info] HashMapBenchmark.copyElems_old     4096  avgt   20      51749.211 ±     239.596  ns/op
[info] HashMapBenchmark.copyElems_old     8192  avgt   20      85266.663 ±     661.074  ns/op
[info] HashMapBenchmark.copyElems_old    16384  avgt   20     184803.115 ±    1267.878  ns/op
[info] HashMapBenchmark.copyElems_old    32768  avgt   20     442262.479 ±    3079.178  ns/op
[info] HashMapBenchmark.copyElems_old    65536  avgt   20    1032738.550 ±   11238.429  ns/op
[info] HashMapBenchmark.copyElems_old   131072  avgt   20    2086561.402 ±   37217.579  ns/op
[info] HashMapBenchmark.copyElems_old   262144  avgt   20    5621774.342 ±  957624.190  ns/op
[info] HashMapBenchmark.copyElems_old   524288  avgt   20   11068290.301 ± 1075031.423  ns/op
[info] HashMapBenchmark.copyElems_old  1048576  avgt   20   20813090.598 ±  328521.384  ns/op
[info] HashMapBenchmark.copyElems_old  2097152  avgt   20   52016085.933 ±  477976.115  ns/op
[info] HashMapBenchmark.copyElems_old  4194304  avgt   20  115192223.744 ± 1584955.840  ns/op
[info] HashMapBenchmark.copyElems_old  8388608  avgt   20  173770367.383 ± 3551311.058  ns/op
```