### PR TITLE
Fix rvm in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt
+    - $HOME/.rvm/
 
 stages:
   - name: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,14 @@ jobs:
 
       # build the spec using jekyll
       - stage: build
-        rvm: 2.2
-        install: bundle install
+        language: ruby
+        install:
+          - rvm install 2.2
+          - rvm use 2.2
+          - rvm info
+          - ruby -v
+          - bundler --version
+          - bundle install
         script:
         - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then (cd admin && ./init.sh); fi'
         - bundle exec jekyll build -s spec/ -d build/spec


### PR DESCRIPTION
For some reason, the Ruby job failed on a documentation change PR I have for 2.12.  I thought it would be ephemeral, but it happened again.  I took a look at trying to reproduce it, but in the process learned that the declaration for `rvm` to be "2.2" was probably being ignored.  It seems you need to add a
"language: ruby" declaration to the Travis configuration file for it to work.  It already has "language: scala" and Travis doesn't support multiple languages, so it seems manual installation of a ruby version with `rvm` is necessary.

I've added diagnostic commands for ruby to help avoid this problem in the future.

We'll see if the spec still builds with Ruby 2.2.  The evidence suggested it was being built in 2.4.1.