### PR TITLE
Size-restrict RangeTest lists

### DIFF
--- a/test/scalacheck/range.scala
+++ b/test/scalacheck/range.scala
@@ -231,11 +231,11 @@ abstract class RangeTest(kind: String) extends Properties("Range "+kind) {
   }
 
   property("tails") = forAll(myGen) { r =>
-    r.tails.toList == r.toList.tails.toList
+    (r.size < 1024) ==> { r.tails.toList == r.toList.tails.toList }
   }
 
   property("inits") = forAll(myGen) { r =>
-    r.inits.toList == r.toList.inits.toList
+    (r.size < 1024) ==> { r.inits.toList == r.toList.inits.toList }
   }
 
   property("reverse.toSet.equal") = forAll(myGen) { r =>


### PR DESCRIPTION
Since it's possible to generate reasonably large ranges with small steps, avoid converting to large lists.

```
Error Message

java.lang.OutOfMemoryError: GC overhead limit exceeded

Stacktrace

sbt.ForkMain$ForkError: java.lang.OutOfMemoryError: GC overhead limit exceeded
	at scala.collection.mutable.ListBuffer.addOne(ListBuffer.scala:108)
	at scala.collection.mutable.ListBuffer.addOne(ListBuffer.scala:40)
	at scala.collection.IterableOps.dropRight(Iterable.scala:479)
	at scala.collection.IterableOps.dropRight$(Iterable.scala:473)
	at scala.collection.AbstractIterable.dropRight(Iterable.scala:916)
	at scala.collection.IterableOps.init(Iterable.scala:532)
	at scala.collection.IterableOps.init$(Iterable.scala:530)
	at scala.collection.AbstractIterable.init(Iterable.scala:916)
	at scala.collection.IterableOps.$anonfun$inits$1(Iterable.scala:824)
	at scala.collection.IterableOps$$Lambda$2022/351307950.apply(Unknown Source)
	at scala.collection.Iterator$$anon$26.next(Iterator.scala:1016)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:585)
	at scala.collection.Iterator$ConcatIterator.hasNext(Iterator.scala:1091)
	at scala.collection.Iterator$$anon$9.hasNext(Iterator.scala:553)
	at scala.collection.mutable.Growable.addAll(Growable.scala:61)
	at scala.collection.mutable.Growable.addAll$(Growable.scala:59)
	at scala.collection.mutable.AbstractBuffer.addAll(Buffer.scala:227)
	at scala.collection.mutable.ListBuffer$.from(ListBuffer.scala:321)
	at scala.collection.immutable.List$.from(List.scala:607)
	at scala.collection.IterableOnceOps.toList(IterableOnce.scala:1200)
	at scala.collection.IterableOnceOps.toList$(IterableOnce.scala:1200)
	at scala.collection.AbstractIterator.toList(Iterator.scala:1195)
	at RangeTest.$anonfun$new$53(range.scala:238)
	at RangeTest.$anonfun$new$53$adapted(range.scala:237)
	at RangeTest$$Lambda$2019/1892412594.apply(Unknown Source)
	at org.scalacheck.Prop$.$anonfun$forAllShrink$2(Prop.scala:761)
	at org.scalacheck.Prop$$$Lambda$1711/439302017.apply(Unknown Source)
	at org.scalacheck.Prop$.secure(Prop.scala:471)
	at org.scalacheck.Prop$.result$1(Prop.scala:761)
	at org.scalacheck.Prop$.$anonfun$forAllShrink$1(Prop.scala:800)
	at org.scalacheck.Prop$$$Lambda$394/1213349904.apply(Unknown Source)
	at org.scalacheck.Prop$.$anonfun$apply$1(Prop.scala:307)
```
At https://scala-ci.typesafe.com/job/scala-2.13.x-validate-main/6424/testReport/(root)/NormalRangeTest/inits/