### PR TITLE
Improve usability of -Xprompt

### DIFF
--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -33,7 +33,7 @@ object VersionUtil {
       |    / __/ __// _ | / /  / _ |
       |  __\ \/ /__/ __ |/ /__/ __ |
       | /____/\___/_/ |_/____/_/ | |
-      |                          |/  %s""".stripMargin.linesIterator.drop(1).map(s => s"${ "%n" }${ s }").mkString,
+      |                          |/  %s""".stripMargin.linesIterator.mkString("%n"),
     resourceGenerators in Compile += generateVersionPropertiesFile.map(file => Seq(file)).taskValue,
     generateVersionPropertiesFile := generateVersionPropertiesFileImpl.value
   )

--- a/src/compiler/scala/tools/nsc/Driver.scala
+++ b/src/compiler/scala/tools/nsc/Driver.scala
@@ -14,8 +14,9 @@ package scala
 package tools.nsc
 
 import Properties.{versionMsg, residentPromptString}
-import scala.tools.nsc.reporters.Reporter
 import scala.reflect.internal.util.FakePos
+import scala.tools.nsc.reporters.Reporter
+import scala.tools.util.SystemExit
 
 abstract class Driver {
 
@@ -66,6 +67,7 @@ abstract class Driver {
         else
           doCompile(compiler)
       } catch {
+        case _: SystemExit => // user requested to bail
         case ex: Throwable =>
           compiler.reportThrowable(ex)
           ex match {

--- a/src/compiler/scala/tools/nsc/reporters/AbstractReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/AbstractReporter.scala
@@ -42,6 +42,5 @@ abstract class AbstractReporter extends Reporter with PositionFiltering {
   private def countAndDisplay(pos: Position, msg: String, severity: Severity): Unit = {
     severity.count += 1
     display(pos, msg, severity)
-    if (isPromptSet && severity != INFO) displayPrompt()
   }
 }

--- a/src/compiler/scala/tools/nsc/reporters/DisplayReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/DisplayReporter.scala
@@ -66,7 +66,7 @@ trait PrintReporter extends InternalReporter {
     writer.print("a)bort, s)tack, r)esume: ")
     writer.flush()
     if (reader != null) {
-      reader.read match {
+      Option(reader.readLine).flatMap(_.trim.headOption).getOrElse('r') match {
         case 'a' | 'A' =>
           new Throwable().printStackTrace(writer)
           throw SystemExit(1)
@@ -76,7 +76,7 @@ trait PrintReporter extends InternalReporter {
           writer.flush()
         case _ =>
       }
-    }
+    } else writer.println("r")
   }
 
   override def flush() = {


### PR DESCRIPTION
Discard rest of input line after prompt, handle `SystemExit` gracefully, `ConsoleReporter` is a `PrintReporter` so `AbstractReporter` should not double-prompt.

Fixes scala/bug#11332