### PR TITLE
Align the ArrayOps#copyToArray methods and IterableOnce#copyToArray methods

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -183,7 +183,7 @@ object ArrayOps {
   *
   *  @tparam A   type of the elements contained in this array.
   */
-final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
+final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
   @`inline` private[this] implicit def elemTag: ClassTag[A] = ClassTag(xs.getClass.getComponentType)
 
@@ -702,7 +702,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *  Example:
     *  {{{
     *    Array(1, 2, 3, 4).scanLeft(0)(_ + _) == Array(0, 1, 3, 6, 10)
-    *  }}}    
+    *  }}}
     *
     */
   def scanLeft[ B : ClassTag ](z: B)(op: (B, A) => B): Array[B] = {
@@ -715,7 +715,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
       i += 1
     }
     res(i) = v
-    res 
+    res
   }
 
   /** Computes a prefix scan of the elements of the array.
@@ -741,7 +741,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     *  Example:
     *  {{{
     *    Array(4, 3, 2, 1).scanRight(0)(_ + _) == Array(10, 6, 3, 1, 0)
-    *  }}}    
+    *  }}}
     *
     */
   def scanRight[ B : ClassTag ](z: B)(op: (A, B) => B): Array[B] = {
@@ -754,7 +754,7 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
       res(i) = v
       i -= 1
     }
-    res 
+    res
   }
 
   /** Applies a binary operator to all elements of this array and a start value,
@@ -1366,19 +1366,40 @@ final class ArrayOps[A](val xs: Array[A]) extends AnyVal {
     immutable.ArraySeq.unsafeWrapArray(Array.copyOf(xs, xs.length))
 
   /** Copy elements of this array to another array.
-    *  Fills the given array `dest` starting at index `start` with at most `len` values.
-    *  Copying will stop once either the all elements of this array have been copied,
+    *  Fills the given array `xs` starting at index 0.
+    *  Copying will stop once either all the elements of this array have been copied,
+    *  or the end of the array is reached.
+    *
+    *  @param  xs   the array to fill.
+    *  @tparam B      the type of the elements of the array.
+    */
+  def copyToArray[B >: A](xs: Array[B]): Int = copyToArray(xs, 0)
+
+  /** Copy elements of this array to another array.
+    *  Fills the given array `xs` starting at index `start`.
+    *  Copying will stop once either all the elements of this array have been copied,
+    *  or the end of the array is reached.
+    *
+    *  @param  xs   the array to fill.
+    *  @param  start  the starting index within the destination array.
+    *  @tparam B      the type of the elements of the array.
+    */
+  def copyToArray[B >: A](xs: Array[B], start: Int): Int = copyToArray(xs, start, Int.MaxValue)
+
+  /** Copy elements of this array to another array.
+    *  Fills the given array `xs` starting at index `start` with at most `len` values.
+    *  Copying will stop once either all the elements of this array have been copied,
     *  or the end of the array is reached, or `len` elements have been copied.
     *
-    *  @param  dest   the array to fill.
-    *  @param  start  the starting index.
+    *  @param  xs   the array to fill.
+    *  @param  start  the starting index within the destination array.
     *  @param  len    the maximal number of elements to copy.
     *  @tparam B      the type of the elements of the array.
     */
-  def copyToArray[B >: A](dest: Array[B], start: Int, len: Int = Int.MaxValue): Int = {
-    val copied = IterableOnce.elemsToCopyToArray(xs.length, dest.length, start, len)
+  def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {
+    val copied = IterableOnce.elemsToCopyToArray(this.xs.length, xs.length, start, len)
     if (copied > 0) {
-      Array.copy(xs, 0, dest, start, copied)
+      Array.copy(this.xs, 0, xs, start, copied)
     }
     copied
   }

--- a/test/scalacheck/scala/collection/mutable/ArrayOpsProperties.scala
+++ b/test/scalacheck/scala/collection/mutable/ArrayOpsProperties.scala
@@ -1,0 +1,112 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.mutable
+
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop._
+import org.scalacheck._
+
+object ArrayOpsProperties extends Properties("ArrayOps") {
+  type E = Int
+
+  private def showArray[A](array: Array[A]): String = array.mkString("Array(", ",", ")")
+
+  property("left.copyToArray(right) == min(left.length, right.length)") = forAll{ (left: Array[E], right: Array[E]) =>
+    val returned = left.copyToArray(right)
+    s"left.length: ${left.length}, right.length: ${right.length}" |:
+      (returned ?= math.min(left.length, right.length))
+  }
+
+  property("left.copyToArray(right, start) returns min of (left.length, right.length - start)") =
+    forAll(Arbitrary.arbitrary[Array[E]], Arbitrary.arbitrary[Array[E]], Gen.chooseNum[Int](0, 10000)) {
+      (left: Array[E], right: Array[E], start: Int) =>
+        val returned = left.copyToArray(right, start)
+        s"left.length: ${left.length}, right.length: ${right.length}" |:
+          (returned ?= (left.length min (right.length - start).max(0)))
+    }
+
+  property("left.copyToArray(right, start, len) returns min of (left.length, right.length - start, len)") =
+    forAll(Arbitrary.arbitrary[Array[E]], Arbitrary.arbitrary[Array[E]], Gen.chooseNum[Int](0, 10000), Gen.chooseNum[Int](0, 10000)) {
+      (left: Array[E], right: Array[E], start: Int, len: Int) =>
+        val returned = left.copyToArray(right, start, len)
+        s"left.length: ${left.length}, right.length: ${right.length}" |:
+          (returned ?= (left.length min (right.length - start).max(0) min len.max(0)))
+    }
+
+
+  property("left.copyToArray(right) copies min(left.length, right.length) to right") = forAll{ (left: Array[E], right: Array[E]) =>
+
+    left.copyToArray(right)
+
+    val prefix = left.take(left.length min right.length)
+
+    s"left: ${showArray(left)}, right: ${showArray(right)}" |: (Prop(left.startsWith(prefix)) && right.startsWith(prefix))
+  }
+
+  property("left.copyToArray(right, start) copies min of (left.length, right.length - start) to right") =
+    forAll(Arbitrary.arbitrary[Array[E]], Arbitrary.arbitrary[Array[E]], Gen.chooseNum[Int](0, 10000)) {
+      (left: Array[E], right: Array[E], start: Int) =>
+        left.copyToArray(right, start)
+
+        val prefix = left.take(left.length min (right.length - start).max(0))
+
+        s"left: ${showArray(left)}, right: ${showArray(right)}, prefix: ${showArray(prefix)}" |:
+          (Prop(left.startsWith(prefix)) && right.drop(start).startsWith(prefix))
+    }
+
+  property("left.copyToArray(right, start, len) copies min of (left.length, right.length - start, len) to right") =
+    forAll(
+      Arbitrary.arbitrary[Array[E]],
+      Arbitrary.arbitrary[Array[E]],
+      Gen.chooseNum[Int](0, 10000),
+      Gen.chooseNum[Int](0, 10000)) {
+      (left: Array[E], right: Array[E], start: Int, len) =>
+        left.copyToArray(right, start)
+
+        val prefix = left.take(left.length min (right.length - start).max(0) min len.max(0))
+
+        s"left: ${showArray(left)}, right: ${showArray(right)}, prefix: ${showArray(prefix)}" |:
+          (Prop(left.startsWith(prefix)) && right.drop(start).startsWith(prefix))
+    }
+
+  property("left.copyToArray(right) does not modify left") = forAll{ (left: Array[E], right: Array[E]) =>
+    val beforeSeq = left.toList
+    left.copyToArray(right)
+    val afterSeq = left.toList
+    s"before: $beforeSeq, after: $afterSeq" |: (afterSeq ?= beforeSeq)
+  }
+
+  property("left.copyToArray(right, start) does not modify left") =
+    forAll(Arbitrary.arbitrary[Array[E]], Arbitrary.arbitrary[Array[E]], Gen.chooseNum[Int](0, 10000)) {
+      (left: Array[E], right: Array[E], start: Int) =>
+        val beforeSeq = left.toList
+        left.copyToArray(right, start)
+        val afterSeq = left.toList
+        s"before: $beforeSeq, after: $afterSeq" |: (afterSeq ?= beforeSeq)
+    }
+  property("left.copyToArray(right, start, len) does not modify left") =
+    forAll(
+      Arbitrary.arbitrary[Array[E]],
+      Arbitrary.arbitrary[Array[E]],
+      Gen.chooseNum[Int](0, 10000),
+      Gen.chooseNum[Int](0, 10000)
+    ) {
+      (left: Array[E], right: Array[E], start: Int, len: Int) =>
+        val beforeSeq = left.toList
+        left.copyToArray(right, start, len)
+        val afterSeq = left.toList
+        s"before: $beforeSeq, after: $afterSeq" |: (afterSeq ?= beforeSeq)
+    }
+
+}
+


### PR DESCRIPTION
Currently, `IterableOnce[A]` has defined the following methods:
```scala
  def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int 
  def copyToArray[B >: A](xs: Array[B], start: Int): Int 
  def copyToArray[B >: A](xs: Array[B]): Int
```
while `ArrayOps[A]` has defined:
```scala
 def copyToArray[B >: A](dest: Array[B], start: Int, len: Int = Int.MaxValue): Int
```

* This PR changes ArrayOps to conform to IterableOnce's methods, so that means changing `dest` to `xs`, replacing the default param `len` with two different methods (one with, one without `len`) and the addition of the basic `copyToArray[B >: A](xs: Array[B]): Int` method

* This also brings ArrayOps in line with 2.12.x branch: https://www.scala-lang.org/api/2.12.8/scala/collection/mutable/ArrayOps.html#copyToArray(xs:Array[A],start:Int,len:Int):Unit

* In order to use the name `xs` for the method argument, `ArrayOps#xs` had to be renamed to `as` (`a` chosen because the type param is `A`).

* Added scalacheck property tests for all three variants of `ArrayOps#copyToArray`

* Fixed minor grammatical mistakes, and add more specificity, in ArrayOps#copyToArray scaladocs
  * `    *  @param  start  the starting index` -> `... within the destination array.`
  * `Copying will stop once either the all elements of this` -> `Copying will stop once either all the elements of this


EDIT: Added regression label because this could be called a regression of ArrayOps from 2.12.