### PR TITLE
Optimize ListMap.from(IterableOnce[(K, V)]) for LinkedHashmap,Map,MapView

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -216,8 +216,6 @@ object ListMap extends MapFactory[ListMap] {
 
   private object EmptyListMap extends ListMap[Any, Nothing]
 
-  def from_old[K, V](it: collection.IterableOnce[(K, V)]): ListMap[K, V] = (newBuilder[K, V] ++= it).result()
-
   def from[K, V](it: collection.IterableOnce[(K, V)]): ListMap[K, V] =
     it match {
       case lm: ListMap[K, V] => lm

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -65,7 +65,8 @@ class LinkedHashMap[K, V]
 
   override def mapFactory: MapFactory[LinkedHashMap] = LinkedHashMap
 
-  private[mutable] type Entry = LinkedHashMap.LinkedEntry[K, V]
+  private[collection] type Entry = LinkedHashMap.LinkedEntry[K, V]
+  private[collection] def _firstEntry: Entry = firstEntry
 
   @transient protected var firstEntry: Entry = null
   @transient protected var lastEntry: Entry = null

--- a/test/scalacheck/scala/collection/immutable/ListMapProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ListMapProperties.scala
@@ -1,0 +1,23 @@
+package scala.collection.immutable
+
+import org.scalacheck._
+import Prop._
+
+object ListMapProperties extends Properties("immutable.ListMap") {
+
+  type K = Int
+  type V = Int
+  type T = (K, V)
+
+  property("from(linkedHashMap) == from(linkedHashMap.toList)") = forAll { m: Map[K, V] =>
+    val lhm = m.to(collection.mutable.LinkedHashMap)
+    ListMap.from(lhm) ?= ListMap.from(lhm.toList)
+  }
+
+  property("from(map) == from(map.toList)") = forAll { m: Map[K, V] =>
+    ListMap.from(m) ?= ListMap.from(m.toList)
+  }
+  property("from(map.view) == from(map)") = forAll { m: Map[K, V] =>
+    ListMap.from(m.view) ?= ListMap.from(m)
+  }
+}


### PR DESCRIPTION
Reduces complexity of transforming these maps from `O(size ^ 2)` to `O(size)`. 

Also, 
* add property tests for `ListMap.from`
* duplicate these optimizations to ListMapBuilder


Benchmarks:
```
[info] Benchmark                                (size)  Mode  Cnt          Score         Error  Units
[info] ListMapBenchmark.from_HashMap_new             1  avgt   10         13.268 ±       2.715  ns/op
[info] ListMapBenchmark.from_HashMap_new            10  avgt   10         57.246 ±       1.015  ns/op
[info] ListMapBenchmark.from_HashMap_new           100  avgt   10        690.848 ±      14.525  ns/op
[info] ListMapBenchmark.from_HashMap_new          1000  avgt   10       6341.170 ±     156.812  ns/op
[info] ListMapBenchmark.from_HashMap_new         10000  avgt   10      69352.806 ±    1441.611  ns/op
[info] ListMapBenchmark.from_HashMap_old             1  avgt   10         44.170 ±       0.926  ns/op
[info] ListMapBenchmark.from_HashMap_old            10  avgt   10        165.546 ±       4.365  ns/op
[info] ListMapBenchmark.from_HashMap_old           100  avgt   10      11873.401 ±     294.169  ns/op
[info] ListMapBenchmark.from_HashMap_old          1000  avgt   10    1095358.773 ±   51243.349  ns/op
[info] ListMapBenchmark.from_HashMap_old         10000  avgt   10  151304507.743 ± 8374770.986  ns/op
[info] ListMapBenchmark.from_LinkedHashMap_new       1  avgt   10          9.746 ±       0.285  ns/op
[info] ListMapBenchmark.from_LinkedHashMap_new      10  avgt   10         42.072 ±       1.691  ns/op
[info] ListMapBenchmark.from_LinkedHashMap_new     100  avgt   10        363.437 ±       9.490  ns/op
[info] ListMapBenchmark.from_LinkedHashMap_new    1000  avgt   10       4772.085 ±     502.076  ns/op
[info] ListMapBenchmark.from_LinkedHashMap_new   10000  avgt   10      53050.899 ±    3309.646  ns/op
[info] ListMapBenchmark.from_LinkedHashMap_old       1  avgt   10         35.124 ±       0.810  ns/op
[info] ListMapBenchmark.from_LinkedHashMap_old      10  avgt   10        231.330 ±       3.672  ns/op
[info] ListMapBenchmark.from_LinkedHashMap_old     100  avgt   10      12143.676 ±     262.654  ns/op
[info] ListMapBenchmark.from_LinkedHashMap_old    1000  avgt   10    2933180.471 ±   57195.163  ns/op
[info] ListMapBenchmark.from_LinkedHashMap_old   10000  avgt   10  124750269.786 ± 1642278.070  ns/op
```

Benchmark code:
```scala
  @Param(Array("1", "10", "100", "1000", "10000"))//, "100000", "1000000"))
  var size: Int = _
  
  var lhm: mutable.LinkedHashMap[Int, Int] = _
  var hm: HashMap[Int, Int] = _

  @Setup(Level.Trial)
  def initKeys(): Unit = {
    lhm = (0 to size).map(i => i -> i).to(mutable.LinkedHashMap)
    hm = (0 to size).map(i => i -> i).to(HashMap)
  }

  @Benchmark
  def from_LinkedHashMap_new(bh: Blackhole): Unit = {
    bh.consume(ListMap.from(lhm))
  }
  @Benchmark
  def from_HashMap_new(bh: Blackhole): Unit = {
    bh.consume(ListMap.from(hm))
  }
  @Benchmark
  def from_LinkedHashMap_old(bh: Blackhole): Unit = {
    bh.consume(ListMap.from_old(lhm))
  }
  @Benchmark
  def from_HashMap_old(bh: Blackhole): Unit = {
    bh.consume(ListMap.from_old(hm))
  }
```

## TODO
- [x] Add more property tests for the ListMapBuilder