### PR TITLE
Add unapply method for scala.Symbol

### DIFF
--- a/src/library/scala/Symbol.scala
+++ b/src/library/scala/Symbol.scala
@@ -39,6 +39,7 @@ object Symbol extends UniquenessCache[String, Symbol] {
   override def apply(name: String): Symbol = super.apply(name)
   protected def valueFromKey(name: String): Symbol = new Symbol(name)
   protected def keyFromValue(sym: Symbol): Option[String] = Some(sym.name)
+  def unapply(sym: Symbol): Some[String] = Some(sym.name)
 }
 
 /** This is private so it won't appear in the library API, but


### PR DESCRIPTION
We'd like to deprecate Symbol literals for 3.0 (and maybe 2.14?). To do so, we
need a rewrite rule that can replace symbol literals. For expressions, this is
simply

    'x  -->  Symbol("x")

With the `unapply` in this commit, we can use the same rewrite for patterns.