### PR TITLE
Regression Test for Bug t10215

### DIFF
--- a/test/files/pos/t10215.scala
+++ b/test/files/pos/t10215.scala
@@ -1,0 +1,7 @@
+import language.higherKinds
+
+class One[F[_]](val f: F[One[F]]) extends AnyVal
+class Two[A]()
+object One {
+  val _ = new One[Two](new Two)
+}


### PR DESCRIPTION
Resolves https://github.com/scala/bug/issues/10215, which has been fixed, by adding a regression for it. 

Bug 10215 happened when mixing higuer-kind type parameters with value classes `AnyVal`. This bug has been fixed in branch 2.13, so we add the regressions for it.