### PR TITLE
[backport] 11330: Port fix for byte array hash code

### DIFF
--- a/src/library/scala/util/hashing/MurmurHash3.scala
+++ b/src/library/scala/util/hashing/MurmurHash3.scala
@@ -210,14 +210,14 @@ object MurmurHash3 extends MurmurHash3 {
   final val setSeed         = "Set".hashCode
 
   def arrayHash[@specialized T](a: Array[T]): Int  = arrayHash(a, arraySeed)
-  def bytesHash(data: Array[Byte]): Int            = bytesHash(data, arraySeed)
+  def bytesHash(data: Array[Byte]): Int            = arrayHash(data, arraySeed)
   def orderedHash(xs: TraversableOnce[Any]): Int   = orderedHash(xs, symmetricSeed)
   def productHash(x: Product): Int                 = productHash(x, productSeed)
   def stringHash(x: String): Int                   = stringHash(x, stringSeed)
   def unorderedHash(xs: TraversableOnce[Any]): Int = unorderedHash(xs, traversableSeed)
 
   private[scala] def wrappedArrayHash[@specialized T](a: Array[T]): Int  = arrayHash(a, seqSeed)
-  private[scala] def wrappedBytesHash(data: Array[Byte]): Int            = bytesHash(data, seqSeed)
+  private[scala] def wrappedBytesHash(data: Array[Byte]): Int            = arrayHash(data, seqSeed)
 
   /** To offer some potential for optimization.
    */

--- a/test/junit/scala/collection/mutable/WrappedArrayTest.scala
+++ b/test/junit/scala/collection/mutable/WrappedArrayTest.scala
@@ -1,8 +1,11 @@
 package scala.collection.mutable
 
+import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
+
+import scala.collection.immutable
 
 @RunWith(classOf[JUnit4])
 class WrappedArrayTest {
@@ -15,5 +18,13 @@ class WrappedArrayTest {
     assertOfRef(Array(Double.box(65.0)), Array(Int.box(65)))
     assertOfRef(Array(Int.box(65)), Array(Char.box('A')))
     assertOfRef(Array(Char.box('A')), Array(Int.box(65)))
+  }
+
+  @Test
+  def byteArrayHashCodeEquality(): Unit = {
+    val x = immutable.Seq[Byte](10)
+    val y = Array[Byte](10).toSeq
+    assertEquals(x, y)
+    assertEquals(x.hashCode(), y.hashCode())
   }
 }


### PR DESCRIPTION
Issue https://github.com/scala/bug/issues/10690 fixed this issue for scala 2.13, and a similar fix has been implemented here. There are some additional changes over those in 10690, removing byte array hashing entirely. Hashing is now consistent in that it produces the same result regardless of the underlying numeric type, in so far as the numbers in question fit into the byte width of the type.