### PR TITLE
Regression test for Scala Bug 4043

### DIFF
--- a/test/files/pos/t4043.scala
+++ b/test/files/pos/t4043.scala
@@ -1,0 +1,10 @@
+import scala.language.higherKinds
+object t4043 {
+  trait GC[K[_ <: H0], H0]
+
+  trait PA[H1] {
+    type Apply[A <: H1] = Any
+  }
+
+  type a = GC[PA[Int]#Apply, Int]
+}


### PR DESCRIPTION
Closes https://github.com/scala/bug/issues/4043, which is already solved in Scala 2.13.x, by adding a regression. 

Bug 4043, originally reported by @retronym, involved computing a least upper bound between types used as arguments for a higher-kinded type parameters. This is still unsolved in Scala 2.12.8, but already works in Scala 2.13.x branch.