### PR TITLE
Adds regression test for Bug 9451

### DIFF
--- a/test/files/pos/t9451.scala
+++ b/test/files/pos/t9451.scala
@@ -1,0 +1,10 @@
+import scala.language.higherKinds
+object t9451 {
+  implicit def impl[I[_]]: {
+    type F[X] = { type Self = I[X] }
+  } = new {
+    type F[X] = { type Self = I[X] }
+  }
+
+  implicitly[{type F[X] = { type Self = Iterable[X] }}]
+}


### PR DESCRIPTION
Resolves https://github.com/scala/bug/issues/9451, by adding the regression test for that bug. This bug has already been solved in Scala 2.13.x. 