### PR TITLE
consider annotations in wrappingPos

### DIFF
--- a/src/reflect/scala/reflect/internal/Positions.scala
+++ b/src/reflect/scala/reflect/internal/Positions.scala
@@ -54,12 +54,13 @@ trait Positions extends api.Positions { self: SymbolTable =>
       while (rest ne Nil) {
         val head = rest.head
         rest = rest.tail
-        // workaround for a MemberDef's position not wrapping its annotations (scala/bug#11060)
-        // TODO: should we change the range pos for a member def to actually wrap the annotations/modifiers?
-        head match {
-          case md: MemberDef => rest = md.mods.annotations ::: rest
-          case _ =>
-        }
+        
+        // TODO: a tree's range position should cover the positions of all trees it "includes" 
+        // (inclusion mostly refers to subtrees, but also other attributes reached through the tree, such as its annotations/modifiers);
+        // concretely, a MemberDef's position should cover its annotations (scala/bug#11060)
+        // Workaround, which explicitly includes annotations of traversed trees, can be removed when TODO above is resolved:
+        head match { case md: MemberDef => rest = md.mods.annotations ::: rest  case _ => }
+        
         val pos = head.pos
         if (pos.isRange) {
           min = Math.min(min, pos.start)

--- a/src/reflect/scala/reflect/internal/Positions.scala
+++ b/src/reflect/scala/reflect/internal/Positions.scala
@@ -54,6 +54,12 @@ trait Positions extends api.Positions { self: SymbolTable =>
       while (rest ne Nil) {
         val head = rest.head
         rest = rest.tail
+        // workaround for a MemberDef's position not wrapping its annotations (scala/bug#11060)
+        // TODO: should we change the range pos for a member def to actually wrap the annotations/modifiers?
+        head match {
+          case md: MemberDef => rest = md.mods.annotations ::: rest
+          case _ =>
+        }
         val pos = head.pos
         if (pos.isRange) {
           min = Math.min(min, pos.start)


### PR DESCRIPTION
Not sure whether we should set the MemberDef's position
to include its annotations in the first place, or whether
our locator should widen its gaze to the separate positions
of the annotations. See also Locator tree traverser

Fix scala/bug#11060
