### PR TITLE
Spec update: empty application precedes eta expansion

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1396,15 +1396,15 @@ type $T$ by evaluating the expression to which $m$ is bound.
 If the method takes only implicit parameters, implicit
 arguments are passed following the rules [here](07-implicits.html#implicit-parameters).
 
-###### Eta Expansion
-Otherwise, if the method is not a constructor,
-and the expected type $\mathit{pt}$ is a function type
-$(\mathit{Ts}') \Rightarrow T'$, [eta-expansion](#eta-expansion)
-is performed on the expression $e$.
-
 ###### Empty Application
 Otherwise, if $e$ has method type $()T$, it is implicitly applied to the empty
 argument list, yielding $e()$.
+
+###### Eta Expansion
+Otherwise, if the method is not a constructor,
+and the expected type $\mathit{pt}$ is a function type (potentially after sam conversion)
+$(\mathit{Ts}') \Rightarrow T'$, [eta-expansion](#eta-expansion)
+is performed on the expression $e$.
 
 ### Overloading Resolution
 


### PR DESCRIPTION
Follow up for #6475

Fix https://github.com/scala/bug/issues/7187