### PR TITLE
Don’t expose Map.WithDefault in return types

### DIFF
--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -41,7 +41,7 @@ trait Map[K, +V]
     *  @param d     the function mapping keys to values, used for non-present keys
     *  @return      a wrapper of the map with a default value
     */
-  def withDefault[V1 >: V](d: K => V1): Map.WithDefault[K, V1] = new Map.WithDefault[K, V1](this, d)
+  def withDefault[V1 >: V](d: K => V1): Map[K, V1] = new Map.WithDefault[K, V1](this, d)
 
   /** The same map with a given default value.
     *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
@@ -52,7 +52,7 @@ trait Map[K, +V]
     *  @param d     default value used for non-present keys
     *  @return      a wrapper of the map with a default value
     */
-  def withDefaultValue[V1 >: V](d: V1): Map.WithDefault[K, V1] = new Map.WithDefault[K, V1](this, _ => d)
+  def withDefaultValue[V1 >: V](d: V1): Map[K, V1] = new Map.WithDefault[K, V1](this, _ => d)
 }
 
 /** Base trait of immutable Maps implementations

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -36,7 +36,7 @@ trait SortedMap[K, +V]
     *  @param d     the function mapping keys to values, used for non-present keys
     *  @return      a wrapper of the map with a default value
     */
-  override def withDefault[V1 >: V](d: K => V1): SortedMap.WithDefault[K, V1] = new SortedMap.WithDefault[K, V1](this, d)
+  override def withDefault[V1 >: V](d: K => V1): SortedMap[K, V1] = new SortedMap.WithDefault[K, V1](this, d)
 
   /** The same map with a given default value.
     *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
@@ -47,7 +47,7 @@ trait SortedMap[K, +V]
     *  @param d     default value used for non-present keys
     *  @return      a wrapper of the map with a default value
     */
-  override def withDefaultValue[V1 >: V](d: V1): SortedMap.WithDefault[K, V1] = new SortedMap.WithDefault[K, V1](this, _ => d)
+  override def withDefaultValue[V1 >: V](d: V1): SortedMap[K, V1] = new SortedMap.WithDefault[K, V1](this, _ => d)
 }
 
 trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -62,10 +62,10 @@ final class VectorMap[K, +V] private (
     }
   }
 
-  override def withDefault[V1 >: V](d: K => V1): Map.WithDefault[K, V1] =
+  override def withDefault[V1 >: V](d: K => V1): Map[K, V1] =
     new Map.WithDefault(this, d)
 
-  override def withDefaultValue[V1 >: V](d: V1): Map.WithDefault[K, V1] =
+  override def withDefaultValue[V1 >: V](d: V1): Map[K, V1] =
     new Map.WithDefault[K, V1](this, _ => d)
 
   def get(key: K): Option[V] = underlying.get(key) match {

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -45,7 +45,7 @@ trait Map[K, V]
     *  @param d     the function mapping keys to values, used for non-present keys
     *  @return      a wrapper of the map with a default value
     */
-  def withDefault(d: K => V): Map.WithDefault[K, V] = new Map.WithDefault[K, V](this, d)
+  def withDefault(d: K => V): Map[K, V] = new Map.WithDefault[K, V](this, d)
 
   /** The same map with a given default value.
     *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
@@ -56,7 +56,7 @@ trait Map[K, V]
     *  @param d     default value used for non-present keys
     *  @return      a wrapper of the map with a default value
     */
-  def withDefaultValue(d: V): Map.WithDefault[K, V] = new Map.WithDefault[K, V](this, x => d)
+  def withDefaultValue(d: V): Map[K, V] = new Map.WithDefault[K, V](this, x => d)
 }
 
 /**
@@ -230,7 +230,7 @@ object Map extends MapFactory.Delegate[Map](HashMap) {
 
     def addOne(elem: (K, V)): WithDefault.this.type = { underlying.addOne(elem); this }
 
-    override def concat[V2 >: V](suffix: collection.IterableOnce[(K, V2)]): WithDefault[K, V2] =
+    override def concat[V2 >: V](suffix: collection.IterableOnce[(K, V2)]): Map[K, V2] =
       underlying.concat(suffix).withDefault(defaultValue)
 
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)

--- a/src/library/scala/collection/mutable/SortedMap.scala
+++ b/src/library/scala/collection/mutable/SortedMap.scala
@@ -37,7 +37,7 @@ trait SortedMap[K, V]
     *  @param d     the function mapping keys to values, used for non-present keys
     *  @return      a wrapper of the map with a default value
     */
-  override def withDefault(d: K => V): SortedMap.WithDefault[K, V] = new SortedMap.WithDefault[K, V](this, d)
+  override def withDefault(d: K => V): SortedMap[K, V] = new SortedMap.WithDefault[K, V](this, d)
 
   /** The same map with a given default value.
     * Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
@@ -48,7 +48,7 @@ trait SortedMap[K, V]
     * @param d default value used for non-present keys
     * @return a wrapper of the map with a default value
     */
-  override def withDefaultValue(d: V): SortedMap.WithDefault[K, V] = new SortedMap.WithDefault[K, V](this, _ => d)
+  override def withDefaultValue(d: V): SortedMap[K, V] = new SortedMap.WithDefault[K, V](this, _ => d)
 }
 
 trait SortedMapOps[K, V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
@@ -89,7 +89,7 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
     override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 
-    override def concat[V2 >: V](suffix: collection.IterableOnce[(K, V2)]): WithDefault[K, V2] =
+    override def concat[V2 >: V](suffix: collection.IterableOnce[(K, V2)]): SortedMap[K, V2] =
       underlying.concat(suffix).withDefault(defaultValue)
 
     override protected def fromSpecific(coll: scala.collection.IterableOnce[(K, V)]): WithDefault[K, V] =

--- a/test/junit/scala/collection/immutable/HashMapTest.scala
+++ b/test/junit/scala/collection/immutable/HashMapTest.scala
@@ -76,7 +76,7 @@ class HashMapTest {
   def testWithDefault: Unit = {
     val m1 = HashMap(1 -> "a", 2 -> "b")
 
-    val m2: Map.WithDefault[Int, String] =
+    val m2: Map[Int, String] =
       m1.withDefault(i => (i + 1).toString)
         .updated(1, "aa")
         .updated(100, "bb")
@@ -90,10 +90,10 @@ class HashMapTest {
     assertEquals(m2(501), "c")
     assertEquals(m2(502), "503")
 
-    val m3: Map.WithDefault[Int, String] = m2 - 1
+    val m3: Map[Int, String] = m2 - 1
     assertEquals(m3(1), "2")
 
-    val m4: Map.WithDefault[Int, String] = m3 -- List(2, 100)
+    val m4: Map[Int, String] = m3 -- List(2, 100)
     assertEquals(m4(2), "3")
     assertEquals(m4(100), "101")
   }

--- a/test/junit/scala/collection/immutable/SortedMapTest.scala
+++ b/test/junit/scala/collection/immutable/SortedMapTest.scala
@@ -9,7 +9,7 @@ import org.junit.runners.JUnit4
 class SortedMapTest {
   @Test
   def testWithDefaultValueReturnsSortedMapWithDeaultValue(): Unit = {
-    val tree: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
+    val tree: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
       .withDefault(defaultValueFunction)
 
     assertEquals("3 is not present in this map", tree(3))
@@ -17,7 +17,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedAfterAnElementIsAddedToUnderlyingMap(): Unit = {
-    val tree: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two")).withDefault(defaultValueFunction)
+    val tree: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two")).withDefault(defaultValueFunction)
     val newTree = tree + (3 -> "Three")
 
     assertEquals("5 is not present in this map", newTree(5))
@@ -25,7 +25,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedAfterCreatingEmptyMapFromUnderlyingSortedMap(): Unit = {
-    val emptyMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
+    val emptyMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
       .withDefault(defaultValueFunction)
       .empty
 
@@ -34,7 +34,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedAfterRangeOperationOnSortedMap(): Unit = {
-    val rangedProjectOfTreeMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
+    val rangedProjectOfTreeMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
       .withDefault(defaultValueFunction)
       .range(1, 3) // range `to` parameter is not inclusive
 
@@ -43,7 +43,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedAfterAnElementFromUnderlyingMapIsRemoved(): Unit = {
-    val originalTreeMap : SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
+    val originalTreeMap : SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
       .withDefault(defaultValueFunction)
 
     val newTreeMap = originalTreeMap - 3
@@ -54,7 +54,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsLostWhenNewSortedMapIsCreatedFromIterablesInOperationsLikeFlatMap(): Unit = {
-    val originalMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
+    val originalMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
       .withDefault(defaultValueFunction)
 
     val newTreeMap: SortedMap[String, Int] = originalMap.flatMap((kv: (Int, String)) => TreeMap(kv._2 -> kv._1))
@@ -71,7 +71,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedWhenNewSortedMapIsCreatedFromSpecificIterableInOperationsLikeFilter(): Unit = {
-    val evenNumbers: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 4 -> "Four", 5 -> "Five"))
+    val evenNumbers: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 4 -> "Four", 5 -> "Five"))
       .withDefault(defaultValueFunction)
       .filter((kv: (Int, String)) => kv._1 % 2 == 0)
 
@@ -80,7 +80,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedWhenNewSpecificBuilderIsCreatedFromSortedMapInOperationsLikeGroupBy(): Unit = {
-    val numbers: Map[String, SortedMap.WithDefault[Int, String]] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 4 -> "Four", 5 -> "Five"))
+    val numbers: Map[String, SortedMap[Int, String]] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 4 -> "Four", 5 -> "Five"))
       .withDefault(defaultValueFunction)
       .groupBy((kv: (Int, String)) => if (kv._1 % 2 == 0) "even" else "odd")
 
@@ -90,7 +90,7 @@ class SortedMapTest {
 
   @Test
   def testDefaulValueIsPersistedWhenNewMapIterableIsConcatenatedToOriginalMap(): Unit = {
-    val originaMap: SortedMap.WithDefault[Int, String] = TreeMap(1 -> "One", 2 -> "Two")
+    val originaMap: SortedMap[Int, String] = TreeMap(1 -> "One", 2 -> "Two")
       .withDefaultValue("element missing")
     val newMap: SortedMap[Int, String] = originaMap ++ Map(3 -> "Three")
 
@@ -117,7 +117,7 @@ class SortedMapTest {
   def testWithDefault: Unit = {
     val m1 = SortedMap(1 -> "a", 2 -> "b")
 
-    val m2: Map.WithDefault[Int, String] =
+    val m2: Map[Int, String] =
       m1.withDefault(i => (i + 1).toString)
         .updated(1, "aa")
         .updated(100, "bb")
@@ -131,10 +131,10 @@ class SortedMapTest {
     assertEquals(m2(501), "c")
     assertEquals(m2(502), "503")
 
-    val m3: Map.WithDefault[Int, String] = m2 - 1
+    val m3: Map[Int, String] = m2 - 1
     assertEquals(m3(1), "2")
 
-    val m4: Map.WithDefault[Int, String] = m3 -- List(2, 100)
+    val m4: Map[Int, String] = m3 -- List(2, 100)
     assertEquals(m4(2), "3")
     assertEquals(m4(100), "101")
   }

--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -34,7 +34,7 @@ class TreeMapTest {
   def testWithDefault: Unit = {
     val m1 = TreeMap(1 -> "a", 2 -> "b")
 
-    val m2: Map.WithDefault[Int, String] =
+    val m2: Map[Int, String] =
       m1.withDefault(i => (i + 1).toString)
         .updated(1, "aa")
         .updated(100, "bb")
@@ -48,10 +48,10 @@ class TreeMapTest {
     assertEquals(m2(501), "c")
     assertEquals(m2(502), "503")
 
-    val m3: Map.WithDefault[Int, String] = m2 - 1
+    val m3: Map[Int, String] = m2 - 1
     assertEquals(m3(1), "2")
 
-    val m4: Map.WithDefault[Int, String] = m3 -- List(2, 100)
+    val m4: Map[Int, String] = m3 -- List(2, 100)
     assertEquals(m4(2), "3")
     assertEquals(m4(100), "101")
   }

--- a/test/junit/scala/collection/mutable/HashMapTest.scala
+++ b/test/junit/scala/collection/mutable/HashMapTest.scala
@@ -90,7 +90,7 @@ class HashMapTest {
   def testWithDefault: Unit = {
     val m1 = mutable.HashMap(1 -> "a", 2 -> "b")
 
-    val m2: mutable.Map.WithDefault[Int, String] = m1.withDefault(i => (i + 1).toString)
+    val m2: mutable.Map[Int, String] = m1.withDefault(i => (i + 1).toString)
     m2.update(1, "aa")
     m2.update(100, "bb")
     m2.addAll(List(500 -> "c", 501 -> "c"))
@@ -103,10 +103,10 @@ class HashMapTest {
     assertEquals(m2(501), "c")
     assertEquals(m2(502), "503")
 
-    val m3: mutable.Map.WithDefault[Int, String] = m2 - 1
+    val m3: mutable.Map[Int, String] = m2 - 1
     assertEquals(m3(1), "2")
 
-    val m4: mutable.Map.WithDefault[Int, String] = m3 -- List(2, 100)
+    val m4: mutable.Map[Int, String] = m3 -- List(2, 100)
     assertEquals(m4(2), "3")
     assertEquals(m4(100), "101")
   }

--- a/test/junit/scala/collection/mutable/SortedMapTest.scala
+++ b/test/junit/scala/collection/mutable/SortedMapTest.scala
@@ -14,7 +14,7 @@ import scala.{Option, Unit}
 class SortedMapTest {
   @Test
   def testWithDefaultValueReturnsSortedMapWithDefaultValue(): Unit = {
-    val tree: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
+    val tree: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
       .withDefault(defaultValueFunction)
 
     assertEquals("3 is not present in this map", tree(3))
@@ -22,7 +22,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedAfterAnElementIsAddedToUnderlyingMap(): Unit = {
-    val tree: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
+    val tree: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
       .withDefault(defaultValueFunction)
 
     tree.addOne(3 -> "Three")
@@ -32,7 +32,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedAfterCreatingEmptyMapFromUnderlyingSortedMap(): Unit = {
-    val originalMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
+    val originalMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
       .withDefault(defaultValueFunction)
 
     val emptyMapWithDefault = originalMap.empty
@@ -42,7 +42,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedAfterRangeOperationOnSortedMap(): Unit = {
-    val rangedProjectOfTreeMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
+    val rangedProjectOfTreeMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
       .withDefault(defaultValueFunction)
       .range(1, 3) // range `to` parameter is not inclusive
 
@@ -51,7 +51,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedAfterAnElementFromUnderlyingMapIsRemoved(): Unit = {
-    val originalTreeMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
+    val originalTreeMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 3 -> "Three"))
       .withDefault(defaultValueFunction)
 
     originalTreeMap.remove(3)
@@ -62,7 +62,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsLostWhenNewSortedMapIsCreatedFromIterablesInOperationsLikeFlatMap(): Unit = {
-    val originalMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
+    val originalMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
       .withDefault(defaultValueFunction)
 
     val newTreeMap: SortedMap[String, Int] = originalMap.flatMap((kv: (Int, String)) => TreeMap(kv._2 -> kv._1))
@@ -79,7 +79,7 @@ class SortedMapTest {
 
   @Test
   def testDefaultValueIsPersistedWhenNewSortedMapIsCreatedFromSpecificIterableInOperationsLikeFilter(): Unit = {
-    val evenNumbers: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 4 -> "Four", 5 -> "Five"))
+    val evenNumbers: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two", 4 -> "Four", 5 -> "Five"))
       .withDefault(defaultValueFunction)
       .filter((kv: (Int, String)) => kv._1 % 2 == 0)
 
@@ -88,7 +88,7 @@ class SortedMapTest {
 
   @Test
   def testDefaulValueIsNotPersistedWhenNewMapIterableIsConcatenatedToOriginalMutableMap(): Unit = {
-    val originaMap: SortedMap.WithDefault[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
+    val originaMap: SortedMap[Int, String] = SortedMap.from(Map(1 -> "One", 2 -> "Two"))
       .withDefaultValue("element missing")
 
     val newMap: SortedMap[Int, String] = originaMap ++ SortedMap.from(Map(3 -> "Three")).withDefaultValue("foobar")
@@ -140,7 +140,7 @@ class SortedMapTest {
   def testWithDefault: Unit = {
     val m1 = mutable.SortedMap(1 -> "a", 2 -> "b")
 
-    val m2: mutable.Map.WithDefault[Int, String] = m1.withDefault(i => (i + 1).toString)
+    val m2: mutable.Map[Int, String] = m1.withDefault(i => (i + 1).toString)
     m2.update(1, "aa")
     m2.update(100, "bb")
     m2.addAll(List(500 -> "c", 501 -> "c"))
@@ -153,10 +153,10 @@ class SortedMapTest {
     assertEquals(m2(501), "c")
     assertEquals(m2(502), "503")
 
-    val m3: mutable.Map.WithDefault[Int, String] = m2 - 1
+    val m3: mutable.Map[Int, String] = m2 - 1
     assertEquals(m3(1), "2")
 
-    val m4: mutable.Map.WithDefault[Int, String] = m3 -- List(2, 100)
+    val m4: mutable.Map[Int, String] = m3 -- List(2, 100)
     assertEquals(m4(2), "3")
     assertEquals(m4(100), "101")
   }


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11314