### PR TITLE
Deprecate BitSet implementation classes

### DIFF
--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -125,6 +125,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
     else new BitSetN(elems)
   }
 
+  @deprecated("Implementation classes of BitSet should not be accessed directly", "2.13.0")
   class BitSet1(val elems: Long) extends BitSet {
     protected[collection] def nwords = 1
     protected[collection] def word(idx: Int) = if (idx == 0) elems else 0L
@@ -150,7 +151,8 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
     }
   }
 
-  class BitSet2(val elems0: Long, elems1: Long) extends BitSet {
+  @deprecated("Implementation classes of BitSet should not be accessed directly", "2.13.0")
+  class BitSet2(val elems0: Long, val elems1: Long) extends BitSet {
     protected[collection] def nwords = 2
     protected[collection] def word(idx: Int) = if (idx == 0) elems0 else if (idx == 1) elems1 else 0L
     protected[collection] def updateWord(idx: Int, w: Long): BitSet =
@@ -195,6 +197,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
     }
   }
 
+  @deprecated("Implementation classes of BitSet should not be accessed directly", "2.13.0")
   class BitSetN(val elems: Array[Long]) extends BitSet {
     protected[collection] def nwords = elems.length
 


### PR DESCRIPTION
Also make BitSet.BitSet2.elems1 a val for consistency (which doesn’t
really matter if we make it private anyway)

Fixes https://github.com/scala/bug/issues/10677