### PR TITLE
Delay filtering accessor/field annotations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -151,6 +151,7 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
   cleanFiles += (classDirectory in Compile).value,
   cleanFiles += (target in Compile in doc).value,
   fork in run := true,
+  connectInput in run := true,
   //scalacOptions in Compile += "-Xlint:-nullary-override,-inaccessible,-nonlocal-return,_",
   //scalacOptions ++= Seq("-Xmaxerrs", "5", "-Xmaxwarns", "5"),
   scalacOptions in Compile in doc ++= Seq(

--- a/src/compiler/scala/reflect/reify/phases/Reshape.scala
+++ b/src/compiler/scala/reflect/reify/phases/Reshape.scala
@@ -243,7 +243,7 @@ trait Reshape {
       }
 
       def extractOriginal: PartialFunction[Tree, Tree] = { case Apply(Select(New(tpt), _), _) => tpt }
-      assert(extractOriginal.isDefinedAt(ann.original), showRaw(ann.original))
+      assert(extractOriginal.isDefinedAt(ann.original), s"$ann has unexpected original ${showRaw(ann.original)}" )
       New(TypeTree(ann.atp) setOriginal extractOriginal(ann.original), List(args))
     }
 
@@ -278,7 +278,10 @@ trait Reshape {
             var flags1 = flags & ~LOCAL
             if (!ddef.symbol.isPrivate) flags1 = flags1 & ~PRIVATE
             val privateWithin1 = ddef.mods.privateWithin
-            val annotations1 = accessors(vdef).foldLeft(annotations)((curr, acc) => curr ++ (acc.symbol.annotations map toPreTyperAnnotation))
+            val annotations1 =
+              accessors(vdef).foldLeft(annotations){ (curr, acc) =>
+                curr ++ (acc.symbol.annotations.filterNot(_ == UnmappableAnnotation ).map(toPreTyperAnnotation))
+              }
             Modifiers(flags1, privateWithin1, annotations1) setPositions mods.positions
           } else {
             mods

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2016,6 +2016,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       } else typedModifiers(vdef.mods)
 
       sym.annotations.map(_.completeInfo())
+      sym.filterAnnotations(_ != UnmappableAnnotation)
+
       val tpt1 = checkNoEscaping.privates(this, sym, typedType(vdef.tpt))
       checkNonCyclic(vdef, tpt1)
 
@@ -2242,6 +2244,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       warnTypeParameterShadow(tparams1, meth)
 
       meth.annotations.map(_.completeInfo())
+      // we only have to move annotations around for accessors -- see annotSig as used by AccessorTypeCompleter and ValTypeCompleter
+      if (meth.isAccessor) meth.filterAnnotations(_ != UnmappableAnnotation)
+
 
       for (vparams1 <- vparamss1; vparam1 <- vparams1 dropRight 1)
         if (isRepeatedParamType(vparam1.symbol.tpe))

--- a/test/files/pos/t10497.scala
+++ b/test/files/pos/t10497.scala
@@ -1,0 +1,6 @@
+// also works with subsets of {@annotation.meta.field @annotation.meta.getter @annotation.meta.setter}
+class baz(out: Foo => Int)
+
+class Foo {
+  @baz(out = _.value) val value: Int = 5
+}

--- a/test/files/run/reify_ann5.check
+++ b/test/files/run/reify_ann5.check
@@ -16,7 +16,7 @@
       C.super.<init>();
       ()
     };
-    @inline @scala.annotation.meta.beanGetter def getX(): Int = C.this.x
+    @inline @scala.annotation.meta.beanGetter @<notype> def getX(): Int = C.this.x
   };
   ()
 }


### PR DESCRIPTION
Avoid cycles by doing the filtering during LazyAnnotationInfo
completion, which maps the suppressed annotation to an
UnmappableAnnotation, which is then suppressed during type checking
(in selected locations -- should generalize this if we use
filtering for other purposes).

Fix scala/bug#10497