### PR TITLE
Make non-abstract classes final in scala.runtime

### DIFF
--- a/src/library/scala/runtime/BooleanRef.java
+++ b/src/library/scala/runtime/BooleanRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class BooleanRef implements java.io.Serializable {
+public final class BooleanRef implements java.io.Serializable {
     private static final long serialVersionUID = -5730524563015615974L;
 
     public boolean elem;

--- a/src/library/scala/runtime/ByteRef.java
+++ b/src/library/scala/runtime/ByteRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class ByteRef implements java.io.Serializable {
+public final class ByteRef implements java.io.Serializable {
     private static final long serialVersionUID = -100666928446877072L;
 
     public byte elem;

--- a/src/library/scala/runtime/CharRef.java
+++ b/src/library/scala/runtime/CharRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class CharRef implements java.io.Serializable {
+public final class CharRef implements java.io.Serializable {
     private static final long serialVersionUID = 6537214938268005702L;
 
     public char elem;

--- a/src/library/scala/runtime/DoubleRef.java
+++ b/src/library/scala/runtime/DoubleRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class DoubleRef implements java.io.Serializable {
+public final class DoubleRef implements java.io.Serializable {
     private static final long serialVersionUID = 8304402127373655534L;
 
     public double elem;

--- a/src/library/scala/runtime/FloatRef.java
+++ b/src/library/scala/runtime/FloatRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class FloatRef implements java.io.Serializable {
+public final class FloatRef implements java.io.Serializable {
     private static final long serialVersionUID = -5793980990371366933L;
 
     public float elem;

--- a/src/library/scala/runtime/IntRef.java
+++ b/src/library/scala/runtime/IntRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class IntRef implements java.io.Serializable {
+public final class IntRef implements java.io.Serializable {
     private static final long serialVersionUID = 1488197132022872888L;
 
     public int elem;

--- a/src/library/scala/runtime/LongRef.java
+++ b/src/library/scala/runtime/LongRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class LongRef implements java.io.Serializable {
+public final class LongRef implements java.io.Serializable {
     private static final long serialVersionUID = -3567869820105829499L;
 
     public long elem;

--- a/src/library/scala/runtime/ObjectRef.java
+++ b/src/library/scala/runtime/ObjectRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class ObjectRef<T> implements java.io.Serializable {
+public final class ObjectRef<T> implements java.io.Serializable {
     private static final long serialVersionUID = -9055728157600312291L;
 
     public T elem;

--- a/src/library/scala/runtime/ShortRef.java
+++ b/src/library/scala/runtime/ShortRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class ShortRef implements java.io.Serializable {
+public final class ShortRef implements java.io.Serializable {
     private static final long serialVersionUID = 4218441291229072313L;
 
     public short elem;

--- a/src/library/scala/runtime/VolatileBooleanRef.java
+++ b/src/library/scala/runtime/VolatileBooleanRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class VolatileBooleanRef implements java.io.Serializable {
+public final class VolatileBooleanRef implements java.io.Serializable {
     private static final long serialVersionUID = -5730524563015615974L;
 
     volatile public boolean elem;

--- a/src/library/scala/runtime/VolatileByteRef.java
+++ b/src/library/scala/runtime/VolatileByteRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class VolatileByteRef implements java.io.Serializable {
+public final class VolatileByteRef implements java.io.Serializable {
     private static final long serialVersionUID = -100666928446877072L;
 
     volatile public byte elem;

--- a/src/library/scala/runtime/VolatileCharRef.java
+++ b/src/library/scala/runtime/VolatileCharRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class VolatileCharRef implements java.io.Serializable {
+public final class VolatileCharRef implements java.io.Serializable {
     private static final long serialVersionUID = 6537214938268005702L;
 
     volatile public char elem;

--- a/src/library/scala/runtime/VolatileDoubleRef.java
+++ b/src/library/scala/runtime/VolatileDoubleRef.java
@@ -12,7 +12,7 @@
 
 package scala.runtime;
 
-public class VolatileDoubleRef implements java.io.Serializable {
+public final class VolatileDoubleRef implements java.io.Serializable {
     private static final long serialVersionUID = 8304402127373655534L;
 
     volatile public double elem;

--- a/src/library/scala/runtime/VolatileFloatRef.java
+++ b/src/library/scala/runtime/VolatileFloatRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class VolatileFloatRef implements java.io.Serializable {
+public final class VolatileFloatRef implements java.io.Serializable {
     private static final long serialVersionUID = -5793980990371366933L;
 
     volatile public float elem;

--- a/src/library/scala/runtime/VolatileIntRef.java
+++ b/src/library/scala/runtime/VolatileIntRef.java
@@ -12,7 +12,7 @@
 
 package scala.runtime;
 
-public class VolatileIntRef implements java.io.Serializable {
+public final class VolatileIntRef implements java.io.Serializable {
     private static final long serialVersionUID = 1488197132022872888L;
 
     volatile public int elem;

--- a/src/library/scala/runtime/VolatileLongRef.java
+++ b/src/library/scala/runtime/VolatileLongRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class VolatileLongRef implements java.io.Serializable {
+public final class VolatileLongRef implements java.io.Serializable {
     private static final long serialVersionUID = -3567869820105829499L;
 
     volatile public long elem;

--- a/src/library/scala/runtime/VolatileObjectRef.java
+++ b/src/library/scala/runtime/VolatileObjectRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class VolatileObjectRef<T> implements java.io.Serializable {
+public final class VolatileObjectRef<T> implements java.io.Serializable {
     private static final long serialVersionUID = -9055728157600312291L;
 
     volatile public T elem;

--- a/src/library/scala/runtime/VolatileShortRef.java
+++ b/src/library/scala/runtime/VolatileShortRef.java
@@ -12,8 +12,7 @@
 
 package scala.runtime;
 
-
-public class VolatileShortRef implements java.io.Serializable {
+public final class VolatileShortRef implements java.io.Serializable {
     private static final long serialVersionUID = 4218441291229072313L;
 
     volatile public short elem;


### PR DESCRIPTION
Discovered with

    rg '^[^*/]*[^tl] class ' src/library/scala/runtime/

Fixes https://github.com/scala/scala-dev/issues/339