### PR TITLE
Annotation `unused` to suppress warnings

### DIFF
--- a/src/library/scala/annotation/unused.scala
+++ b/src/library/scala/annotation/unused.scala
@@ -1,0 +1,26 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+
+/** Mark an element unused for a given context.
+ *
+ *  Unused warnings are suppressed for elements known to be unused.
+ *
+ *  For example, a method parameter may be marked `@unused`
+ *  because the method is designed to be overridden by
+ *  an implementation that does use the parameter.
+ */
+@meta.getter @meta.setter
+class unused(message: String) extends StaticAnnotation {
+  def this() = this("")
+}

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1281,6 +1281,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val UncheckedClass             = requiredClass[scala.unchecked]
     lazy val UncheckedBoundsClass       = getClassIfDefined("scala.reflect.internal.annotations.uncheckedBounds")
     lazy val UnspecializedClass         = requiredClass[scala.annotation.unspecialized]
+    lazy val UnusedClass                = requiredClass[scala.annotation.unused]
     lazy val VolatileAttr               = requiredClass[scala.volatile]
     lazy val FunctionalInterfaceClass   = requiredClass[java.lang.FunctionalInterface]
 

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -429,6 +429,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.UncheckedClass
     definitions.UncheckedBoundsClass
     definitions.UnspecializedClass
+    definitions.UnusedClass
     definitions.VolatileAttr
     definitions.FunctionalInterfaceClass
     definitions.BeanGetterTargetClass

--- a/test/files/neg/t10790.check
+++ b/test/files/neg/t10790.check
@@ -1,0 +1,12 @@
+t10790.scala:13: warning: private val y in class X is never used
+  private val Some(y) = Option(42) // warn
+                  ^
+t10790.scala:10: warning: private class C in class X is never used
+  private class C                  // warn
+                ^
+t10790.scala:8: warning: parameter value x in method control is never used
+  def control(x: Int) = 42         // warn to verify control
+              ^
+error: No warnings can be incurred under -Xfatal-warnings.
+three warnings found
+one error found

--- a/test/files/neg/t10790.scala
+++ b/test/files/neg/t10790.scala
@@ -1,0 +1,21 @@
+// scalac: -Xfatal-warnings -Ywarn-unused
+
+import annotation.unused
+
+class X {
+  def f(@unused x: Int) = 42       // no warn
+
+  def control(x: Int) = 42         // warn to verify control
+
+  private class C                  // warn
+  @unused private class D          // no warn
+
+  private val Some(y) = Option(42) // warn
+  @unused private val Some(z) = Option(42) // no warn
+
+  @unused("not updated") private var i = 42       // no warn
+  def g = i
+
+  @unused("not read") private var j = 42       // no warn
+  def update() = j = 17
+}


### PR DESCRIPTION
Equivalent of `SuppressWarnings("unused")`.

Fixes scala/bug#10790