### PR TITLE
WIP a method with MethodType(Nil, _) may be a getter

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4891,6 +4891,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case Ident(_) =>
             mkAssign(qual)
 
+          // a getter that had a MethodType(Nil, _) (due to java interop...)
+          case Apply(sel, Nil) => convertToAssignment(fun, sel, name, args)
+
           case Select(qualqual, vname) =>
             gen.evalOnce(qualqual, context.owner, fresh) { qq =>
               val qq1 = qq()

--- a/test/files/pos/t11158/CharSeqJava_1.java
+++ b/test/files/pos/t11158/CharSeqJava_1.java
@@ -1,0 +1,3 @@
+interface CharSeqJava {
+  int length();
+}

--- a/test/files/pos/t11158/test_2.scala
+++ b/test/files/pos/t11158/test_2.scala
@@ -1,0 +1,15 @@
+// interface CharSeqJava { int length(); }
+
+trait CharSeqScala { def length: Int }
+
+class A extends CharSeqScala with CharSeqJava {
+  // since there's a matching java-defined method, we convert the NullaryMethodType we would normally assign to this symbol to a MethodType(Nil, _)....
+  // so we can override toString more easily :roll-eyes:
+  def length: Int = 1
+  def length_=(value: Int): Unit = {}
+}
+
+class Test {
+  (new A).length = 1
+  (new A).length += 1
+}


### PR DESCRIPTION
if it inherited the empty argument list from a java-defined method

Fix for scala/bug#11158