### PR TITLE
Clarify Builder/ReusableBuilder semantics

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -18,7 +18,7 @@ import java.lang.System.arraycopy
 
 import scala.annotation.unchecked.{uncheckedVariance => uV}
 import scala.collection.Hashing.improve
-import scala.collection.mutable.Builder
+import scala.collection.mutable.{Builder, ReusableBuilder}
 import scala.collection.{Iterator, MapFactory, StrictOptimizedIterableOps, mutable}
 import scala.util.hashing.MurmurHash3
 import scala.runtime.Statics.releaseFence
@@ -1530,11 +1530,17 @@ object HashMap extends MapFactory[HashMap] {
       case _ => (newBuilder[K, V] ++= source).result()
     }
 
-  def newBuilder[K, V]: Builder[(K, V), HashMap[K, V]] = new HashMapBuilder[K, V]
+  /** Create a new Builder which can be reused after calling `result()` without an
+    * intermediate call to `clear()` in order to build multiple related results.
+    */
+  def newBuilder[K, V]: ReusableBuilder[(K, V), HashMap[K, V]] = new HashMapBuilder[K, V]
 }
 
 
-private[immutable] final class HashMapBuilder[K, V] extends Builder[(K, V), HashMap[K, V]] {
+/** A Builder for a HashMap.
+  * $multipleResults
+  */
+private[immutable] final class HashMapBuilder[K, V] extends ReusableBuilder[(K, V), HashMap[K, V]] {
   import Node._
   import MapNode._
 

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -14,7 +14,7 @@ package scala
 package collection
 package immutable
 
-import mutable.Builder
+import mutable.ReusableBuilder
 import Hashing.improve
 import java.lang.Integer.{bitCount, numberOfTrailingZeros}
 import java.lang.System.arraycopy
@@ -1187,10 +1187,16 @@ object HashSet extends IterableFactory[HashSet] {
       case _ => (newBuilder[A] ++= source).result()
     }
 
-  def newBuilder[A]: Builder[A, HashSet[A]] = new HashSetBuilder
+  /** Create a new Builder which can be reused after calling `result()` without an
+    * intermediate call to `clear()` in order to build multiple related results.
+    */
+  def newBuilder[A]: ReusableBuilder[A, HashSet[A]] = new HashSetBuilder
 }
 
-private[collection] final class HashSetBuilder[A] extends Builder[A, HashSet[A]] {
+/** Builder for HashSet.
+  * $multipleResults
+  */
+private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, HashSet[A]] {
   import Node._
   import SetNode._
 

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -16,7 +16,7 @@ package immutable
 
 import scala.annotation.tailrec
 
-import scala.collection.mutable.Builder
+import scala.collection.mutable.ReusableBuilder
 import scala.runtime.Statics.releaseFence
 
 /**
@@ -230,10 +230,13 @@ object ListMap extends MapFactory[ListMap] {
     * @tparam K the map key type
     * @tparam V the map value type
     */
-  def newBuilder[K, V]: Builder[(K, V), ListMap[K, V]] = new ListMapBuilder[K, V]
+  def newBuilder[K, V]: ReusableBuilder[(K, V), ListMap[K, V]] = new ListMapBuilder[K, V]
 }
 
-private[immutable] final class ListMapBuilder[K, V] extends mutable.Builder[(K, V), ListMap[K, V]] {
+/** Builder for ListMap.
+  * $multipleResults
+  */
+private[immutable] final class ListMapBuilder[K, V] extends mutable.ReusableBuilder[(K, V), ListMap[K, V]] {
   private[this] var isAliased: Boolean = false
   private[this] var underlying: ListMap[K, V] = ListMap.empty
 

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -18,7 +18,7 @@ import java.io.{ObjectInputStream, ObjectOutputStream}
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable.Map.Map4
-import scala.collection.mutable.Builder
+import scala.collection.mutable.{Builder, ReusableBuilder}
 import scala.language.higherKinds
 
 
@@ -447,7 +447,7 @@ object Map extends MapFactory[Map] {
 @SerialVersionUID(3L)
 abstract class AbstractMap[K, +V] extends scala.collection.AbstractMap[K, V] with Map[K, V]
 
-private[immutable] final class MapBuilderImpl[K, V] extends Builder[(K, V), Map[K, V]] {
+private[immutable] final class MapBuilderImpl[K, V] extends ReusableBuilder[(K, V), Map[K, V]] {
   private[this] var elems: Map[K, V] = Map.empty
   private[this] var switchedToHashMapBuilder: Boolean = false
   private[this] var hashMapBuilder: HashMapBuilder[K, V] = _

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -16,7 +16,7 @@ package immutable
 
 
 import scala.collection.immutable.Set.Set4
-import scala.collection.mutable.{Builder, ImmutableBuilder}
+import scala.collection.mutable.{Builder, ReusableBuilder, ImmutableBuilder}
 import scala.language.higherKinds
 
 
@@ -258,7 +258,10 @@ object Set extends IterableFactory[Set] {
 abstract class AbstractSet[A] extends scala.collection.AbstractSet[A] with Set[A]
 
 
-private final class SetBuilderImpl[A] extends Builder[A, Set[A]] {
+/** Builder for Set.
+  * $multipleResults
+  */
+private final class SetBuilderImpl[A] extends ReusableBuilder[A, Set[A]] {
   private[this] var elems: Set[A] = Set.empty
   private[this] var switchedToHashSetBuilder: Boolean = false
   private[this] var hashSetBuilder: HashSetBuilder[A] = _

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -216,7 +216,7 @@ object TreeMap extends SortedMapFactory[TreeMap] {
         new TreeMap[K, V](t)
     }
 
-  def newBuilder[K, V](implicit ordering: Ordering[K]): Builder[(K, V), TreeMap[K, V]] = new ReusableBuilder[(K, V), TreeMap[K, V]] {
+  def newBuilder[K, V](implicit ordering: Ordering[K]): ReusableBuilder[(K, V), TreeMap[K, V]] = new ReusableBuilder[(K, V), TreeMap[K, V]] {
     private[this] var tree: RB.Tree[K, V] = null
     def addOne(elem: (K, V)): this.type = { tree = RB.update(tree, elem._1, elem._2, overwrite = true); this }
     override def addAll(xs: IterableOnce[(K, V)]): this.type = {

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -211,7 +211,7 @@ object TreeSet extends SortedIterableFactory[TreeSet] {
         new TreeSet[E](t)
     }
 
-  def newBuilder[A](implicit ordering: Ordering[A]): Builder[A, TreeSet[A]] = new ReusableBuilder[A, TreeSet[A]] {
+  def newBuilder[A](implicit ordering: Ordering[A]): ReusableBuilder[A, TreeSet[A]] = new ReusableBuilder[A, TreeSet[A]] {
     private[this] var tree: RB.Tree[A, Any] = null
     def addOne(elem: A): this.type = { tree = RB.update(tree, elem, null, overwrite = false); this }
     override def addAll(xs: IterableOnce[A]): this.type = {

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -37,7 +37,7 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
       case _ => (newBuilder ++= it).result()
     }
 
-  def newBuilder[A]: Builder[A, Vector[A]] = new VectorBuilder[A]
+  def newBuilder[A]: ReusableBuilder[A, Vector[A]] = new VectorBuilder[A]
 
   private[immutable] val NIL = new Vector[Nothing](0, 0, 0)
 

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -496,7 +496,7 @@ object AnyRefMap {
   /** Creates a new `AnyRefMap` with zero or more key/value pairs. */
   def apply[K <: AnyRef, V](elems: (K, V)*): AnyRefMap[K, V] = buildFromIterableOnce(elems)
 
-  def newBuilder[K <: AnyRef, V]: Builder[(K, V), AnyRefMap[K, V]] = new AnyRefMapBuilder[K, V]
+  def newBuilder[K <: AnyRef, V]: ReusableBuilder[(K, V), AnyRefMap[K, V]] = new AnyRefMapBuilder[K, V]
 
   private def buildFromIterableOnce[K <: AnyRef, V](elems: IterableOnce[(K, V)]): AnyRefMap[K, V] = {
     var sz = elems.knownSize

--- a/src/library/scala/collection/mutable/Builder.scala
+++ b/src/library/scala/collection/mutable/Builder.scala
@@ -12,7 +12,14 @@
 
 package scala.collection.mutable
 
-/** Base trait for collection builders */
+/** Base trait for collection builders.
+  *
+  * After calling `result()` the behavior of a Builder (which is not also a [[scala.collection.mutable.ReusableBuilder]])
+  * is undefined. No further methods should be called. It is common for mutable collections to be their own non-reusable
+  * Builder, in which case `result()` simply returns `this`.
+  *
+  * @see [[scala.collection.mutable.ReusableBuilder]] for Builders which can be reused after calling `result()`
+  */
 trait Builder[-A, +To] extends Growable[A] { self =>
 
   /** Clears the contents of this builder.

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -609,7 +609,7 @@ object LongMap {
     case _ => buildFromIterableOnce(source)
   }
 
-  def newBuilder[V]: Builder[(Long, V), LongMap[V]] = new LongMapBuilder[V]
+  def newBuilder[V]: ReusableBuilder[(Long, V), LongMap[V]] = new LongMapBuilder[V]
 
   /** Creates a new `LongMap` from arrays of keys and values.
     *  Equivalent to but more efficient than `LongMap((keys zip values): _*)`.

--- a/src/library/scala/collection/mutable/ReusableBuilder.scala
+++ b/src/library/scala/collection/mutable/ReusableBuilder.scala
@@ -17,26 +17,30 @@ package mutable
 
 /** `ReusableBuilder` is a marker trait that indicates that a `Builder`
   *  can be reused to build more than one instance of a collection.  In
-  *  particular, calling `result` followed by `clear` will produce a
+  *  particular, calling `result()` followed by `clear()` will produce a
   *  collection and reset the builder to begin building a new collection
   *  of the same type.
   *
-  *  It is up to subclasses to implement this behavior, and to document any
-  *  other behavior that varies from standard `ReusableBuilder` usage
-  *  (e.g. operations being well-defined after a call to `result`, or allowing
-  *  multiple calls to result to obtain different snapshots of a collection under
-  *  construction).
+  *  In general no method other than `clear()` may be called after `result()`.
+  *  It is up to subclasses to implement and to document other allowed sequences
+  *  of operations (e.g. calling other methods after `result()` in order to obtain
+  *  different snapshots of a collection under construction).
   *
   *  @tparam  Elem  the type of elements that get added to the builder.
   *  @tparam  To    the type of collection that it produced.
   *
   *  @since 2.12
+  *
+  *  @define multipleResults
+  *
+  *     This Builder can be reused after calling `result()` without an
+  *     intermediate call to `clear()` in order to build multiple related results.
   */
 trait ReusableBuilder[-Elem, +To] extends Builder[Elem, To] {
   /** Clears the contents of this builder.
     *  After execution of this method, the builder will contain no elements.
     *
-    *  If executed immediately after a call to `result`, this allows a new
+    *  If executed immediately after a call to `result()`, this allows a new
     *  instance of the same type of collection to be built.
     */
   override def clear(): Unit    // Note: overriding for Scaladoc only!
@@ -44,7 +48,7 @@ trait ReusableBuilder[-Elem, +To] extends Builder[Elem, To] {
   /** Produces a collection from the added elements.
     *
     *  After a call to `result`, the behavior of all other methods is undefined
-    *  save for `clear`.  If `clear` is called, then the builder is reset and
+    *  save for `clear()`.  If `clear()` is called, then the builder is reset and
     *  may be used to build another instance.
     *
     *  @return a collection containing the elements added to this builder.

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -27,20 +27,22 @@ import scala.Predef.{ // unimport char-related implicit conversions to avoid tri
 }
 
 /** A builder for mutable sequence of characters.  This class provides an API
-  *  mostly compatible with `java.lang.StringBuilder`, except where there are
-  *  conflicts with the Scala collections API (such as the `reverse` method.)
+  * mostly compatible with `java.lang.StringBuilder`, except where there are
+  * conflicts with the Scala collections API (such as the `reverse` method.)
   *
-  *  @author Stephane Micheloud
-  *  @author Martin Odersky
-  *  @since   2.7
-  *  @define Coll `mutable.IndexedSeq`
-  *  @define coll string builder
-  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#stringbuilders "Scala's Collection Library overview"]]
-  *  section on `StringBuilders` for more information.
+  * $multipleResults
+  *
+  * @author Stephane Micheloud
+  * @author Martin Odersky
+  * @since   2.7
+  * @define Coll `mutable.IndexedSeq`
+  * @define coll string builder
+  * @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#stringbuilders "Scala's Collection Library overview"]]
+  * section on `StringBuilders` for more information.
   */
 @SerialVersionUID(3L)
 final class StringBuilder(val underlying: java.lang.StringBuilder) extends AbstractSeq[Char]
-  with Builder[Char, String]
+  with ReusableBuilder[Char, String]
   with IndexedSeq[Char]
   with IndexedSeqOps[Char, IndexedSeq, StringBuilder]
   with java.lang.CharSequence {

--- a/test/files/neg/t2031.check
+++ b/test/files/neg/t2031.check
@@ -1,5 +1,5 @@
 t2031.scala:8: error: polymorphic expression cannot be instantiated to expected type;
- found   : [A]scala.collection.mutable.Builder[A,scala.collection.immutable.TreeSet[A]]
+ found   : [A]scala.collection.mutable.ReusableBuilder[A,scala.collection.immutable.TreeSet[A]]
  required: Ordering[Int]
  res0.map(x => x)(TreeSet.newBuilder)
                           ^


### PR DESCRIPTION
Intended semantics:
- Builder behavior is undefined after `result()`
- ReusableBuilder allows `clear()` after `result()`
- Anything else is up to individual implementations

Changes summary:
- ReusableBuilder subclasses can use the $multipleResults doc template
  if they allow reuse without `clear()`
- Some builders that were already reusable now implement
  ReusableBuilder instead of Builder
- Some `newBuilder` methods now use ReusableBuilder as the return type
  to document that they always produce a reusable builder
- Added documentation to builders that allow reuse without `clear()`


Fixes https://github.com/scala/bug/issues/11160