### PR TITLE
Add missing bridge with self types

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4542,6 +4542,7 @@ trait Types
     case SingleType(pre, sym)  => !(sym hasFlag PACKAGE) && isEligibleForPrefixUnification(pre)
     case tv@TypeVar(_, constr) => !tv.instValid || isEligibleForPrefixUnification(constr.inst)
     case RefinedType(_, _)     => true
+    case ThisType(sym)         => sym.hasSelfType
     case _                     => false
   }
 

--- a/test/files/run/t10477.scala
+++ b/test/files/run/t10477.scala
@@ -1,0 +1,31 @@
+abstract class BasicBackend {
+  type F
+  val f: F
+}
+
+class DistributedBackend extends BasicBackend {
+  type F = FImpl
+  val f: F = new FImpl
+  class FImpl
+}
+
+trait BasicProfile {
+  type Backend <: BasicBackend
+  val backend: Backend
+  trait SimpleQL {
+    val f: backend.F = backend.f
+  }
+}
+
+trait DistributedProfile extends BasicProfile { _: DistributedDriver =>
+  type Backend = DistributedBackend
+  val backend: Backend = new DistributedBackend
+  class SimpleQlImpl extends SimpleQL
+  new SimpleQlImpl
+}
+
+class DistributedDriver extends DistributedProfile
+
+object Test extends App {
+  new DistributedDriver()
+}


### PR DESCRIPTION
Since a ThisType always widens to a RefinedType,
one might argue it was simply a missing case in
`isEligibleForPrefixUnification`.

Fix scala/bug#10477