### PR TITLE
Small Corrections to mutable.PriorityQueue

### DIFF
--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -248,7 +248,10 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   /** Removes all elements from the queue. After this operation is completed,
     *  the queue will be empty.
     */
-  def clear(): Unit = { resarr.p_size0 = 1 }
+  def clear(): Unit = {
+    resarr.clear()
+    resarr.p_size0 = 1
+  }
 
   /** Returns an iterator which yields all the elements.
     *
@@ -271,7 +274,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     *
     *  @return   the reversed priority queue.
     */
-  def reverse = {
+  def reverse: PriorityQueue[A] = {
     val revq = new PriorityQueue[A]()(ord.reverse)
     // copy the existing data into the new array backwards
     // this won't put it exactly into the correct order,


### PR DESCRIPTION
There was a memory leak in the clear method of `PriorityQueue,` by which when the `clear` method was called, references to contained objects were not _nullified_ (thus keeping non-contained objects).
This was noted in https://github.com/scala/bug/issues/9757, which was partially solved by #9776, but not completely. We fix that leak, by setting every array position to `null`, although that raises the complexity of the `clear` method from constant-time to linear time.

Thus, this Resolves https://github.com/scala/bug/issues/9757. 

We also add a type annotation for the `reverse` public method.