### PR TITLE
Add regression test for bug 7891.

### DIFF
--- a/test/files/neg/t7891.check
+++ b/test/files/neg/t7891.check
@@ -1,0 +1,8 @@
+t7891.scala:2: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  def this(x: Any) { this() ; new Object { self } }
+                                           ^
+t7891.scala:2: error: Internal error: unable to find the outer accessor symbol of <$anon: Object>
+  def this(x: Any) { this() ; new Object { self } }
+                                  ^
+one warning found
+one error found

--- a/test/files/neg/t7891.scala
+++ b/test/files/neg/t7891.scala
@@ -1,0 +1,3 @@
+class B { self =>
+  def this(x: Any) { this() ; new Object { self } }
+}


### PR DESCRIPTION
Resolves https://github.com/scala/bug/issues/7891, by adding a regression test for the reduced example. 

Bug 7891 was a compiler crash, or stack overflow, produced by an infinite recursion in the `OuterPathTransformer.outerPath`. This bug has been fixed in Scala 2.13.x.