### PR TITLE
More precise inference for overloaded methods when arguments types align

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1434,9 +1434,13 @@ If there is precisely one alternative in $\mathscr{B}$, that alternative is chos
 
 Otherwise, let $S_1 , \ldots , S_m$ be the list of types obtained by typing each argument as follows.
 
-Normally, an argument is typed without an expected type, except when trying to propagate more type
-information to aid inference of higher-order function parameter types, as explained next. The intuition is
-that all arguments must be of a function-like type (`PartialFunction`, `FunctionN` or some equivalent [SAM type](#sam-conversion)),
+Normally, an argument is typed without an expected type, except when
+all alternatives explicitly specify the same parameter type for this argument (a missing parameter type,
+due to e.g. arity differences, is taken as `NoType`, thus resorting to no expected type),
+or when trying to propagate more type information to aid inference of higher-order function parameter types, as explained next.
+
+The intuition for higher-order function parameter type inference is that all arguments must be of a function-like type
+(`PartialFunction`, `FunctionN` or some equivalent [SAM type](#sam-conversion)),
 which in turn must define the same set of higher-order argument types, so that they can safely be used as
 the expected type of a given argument of the overloaded method, without unduly ruling out any alternatives.
 The intent is not to steer overloading resolution, but to preserve enough type information to steer type

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1320,6 +1320,8 @@ trait Implicits {
             getParts(t)
           case PolyType(_, t) =>
             getParts(t)
+          // not needed, a view's expected type is normalized in typer by normalizeProtoForView:
+          // case proto: OverloadedArgProto => getParts(proto.underlying)
           case _ =>
         }
       }
@@ -1567,6 +1569,8 @@ trait Implicits {
         case TypeRef(_, sym, _) if sym.isAbstractType =>
           materializeImplicit(pt.dealias.lowerBound) // #3977: use pt.dealias, not pt (if pt is a type alias, pt.lowerBound == pt)
         case pt @ TypeRef(pre, sym, arg :: Nil) =>
+          // TODO: is there any way in which an OverloadedArgProto could sneak into one of these special expected types for implicit search?
+          // As the outer expected type, it's normalized in typer by normalizeProtoForView
           sym match {
             case sym if ManifestSymbols(sym) => manifestOfType(arg, sym)
             case sym if TagSymbols(sym) => tagOfType(pre, arg, sym)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2893,8 +2893,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       */
     private def argsResProtosFromFun(pt: Type, numVparams: Int): (List[Type], Type) =
       pt match {
-        case pt: OverloadedArgFunProto if pt.hofParamTypes.lengthCompare(numVparams) == 0 => (pt.hofParamTypes, WildcardType)
-        case _ =>
+        case pt: OverloadedArgProto if pt.hofParamTypes.lengthCompare(numVparams) == 0 => (pt.hofParamTypes, WildcardType)
+        case _                                                                         =>
           val FunctionSymbol = FunctionClass(numVparams)
 
           // In case of any non-trivial type slack between `pt` and the built-in function types, we go the SAM route,
@@ -3418,8 +3418,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               val amode = forArgMode(fun, mode)
 
               mapWithIndex(args) { (arg, argIdx) =>
-                def typedArg0(tree: Tree) = {
-                  val argTyped = typedArg(tree, amode, BYVALmode, OverloadedArgFunProto(argIdx, pre, alts))
+                def typedArg0(tree: Tree, argIdxOrName: Either[Int, Name] = Left(argIdx)) = {
+                  val argTyped = typedArg(tree, amode, BYVALmode, OverloadedArgProto(argIdxOrName, pre, alts))
                   (argTyped, argTyped.tpe.deconst)
                 }
 
@@ -3431,7 +3431,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                   case NamedArg(lhs@Ident(name), rhs) =>
                     // named args: only type the righthand sides ("unknown identifier" errors otherwise)
                     // the assign is untyped; that's ok because we call doTypedApply
-                    typedArg0(rhs) match {
+                    typedArg0(rhs, Right(name)) match {
                       case (rhsTyped, tp) => (treeCopy.NamedArg(arg, lhs, rhsTyped), NamedType(name, tp))
                     }
                   case treeInfo.WildcardStarArg(_) =>

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -737,8 +737,8 @@ trait Definitions extends api.StandardDefinitions {
     // @requires pt.typeSymbol == PartialFunctionClass
     def partialFunctionArgResTypeFromProto(pt: Type): (Type, Type) =
       pt match {
-        case oap: OverloadedArgFunProto => (oap.hofParamTypes.head, WildcardType)
-        case _                          =>
+        case oap: OverloadedArgProto => (oap.hofParamTypes.head, WildcardType)
+        case _                       =>
           val arg :: res :: Nil = pt.baseType(PartialFunctionClass).typeArgs
           (arg, res)
       }

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1178,7 +1178,7 @@ trait Types
   abstract class ProtoType extends Type {
     def toBounds: TypeBounds = TypeBounds.empty
 
-    override final def isWildcard = true
+    override def isWildcard = true
     override def members = ErrorType.decls
 
     // tp <:< this prototype?
@@ -1199,7 +1199,8 @@ trait Types
     def toVariantType: Type = NoType
   }
 
-  /** Help infer parameter types for function arguments to overloaded methods.
+  /** Lazily compute expected types for arguments to overloaded methods.
+    * Primarily to improve parameter type inference for higher-order overloaded methods.
     *
     * Normally, overload resolution types the arguments to the alternatives without an expected type.
     * However, typing function literals and eta-expansion are driven by the expected type:
@@ -1208,22 +1209,30 @@ trait Types
     *
     * Now that the collections are full of overloaded HO methods, we should try harder to type check them nicely.
     *
-    * To avoid breaking existing code, we only provide an expected type (for each argument position) when:
+    * (This paragraph is conceptually true, but not a spec.) To avoid breaking existing code,
+    * we only provide an expected type (for each argument position) when:
     *   - there is at least one FunctionN type expected by one of the overloads:
     *     in this case, the expected type is a FunctionN[Ti, ?], where Ti are the argument types (they must all be =:=),
     *     and the expected result type is elided using a wildcard.
     *     This does not exclude any overloads that expect a SAM, because they conform to a function type through SAM conversion
     *   - OR: all overloads expect a SAM type of the same class, but with potentially varying result types (argument types must be =:=)
+    *   - OR: all expected types collapse to the same type (by =:=, pushing down method type params to arguments types)
     *
-    * We allow polymorphic cases, as long as the types parameters are instantiated by the AntiPolyType prefix.
+    * We allow polymorphic cases, taking account any instantiation by the AntiPolyType prefix.
+    * Constructors of polymorphic classes are not supported (type param occurrences use fresh symbols, hard to relate to class's type params).
     *
     * In all other cases, the old behavior is maintained: Wildcard is expected.
     */
-  final case class OverloadedArgFunProto(argIdx: Int, pre: Type, alternatives: List[Symbol]) extends ProtoType with SimpleTypeProxy {
+  final case class OverloadedArgProto(argIdx: Either[Int, Name], pre: Type, alternatives: List[Symbol]) extends ProtoType with SimpleTypeProxy {
     override def safeToString: String = underlying.safeToString
-    override def kind = "OverloadedArgFunProto"
+    override def kind = "OverloadedArgProto"
 
-    override def underlying: Type = functionArgsProto
+    override def underlying: Type = protoTp
+
+    // If underlying is not wildcard, we may have constrained a first-try-typing too much,
+    // so, when `!isWildcard` implicit search will try again with no expected type at all.
+    // See e.g., adaptToArguments's code paths that depend on `isWildcard`
+    override def isWildcard = underlying.isWildcard
 
     // Always match if we couldn't collapse the expected types contributed for this argument by the alternatives.
     // TODO: could we just match all function-ish types as an optimization? We previously used WildcardType
@@ -1247,12 +1256,12 @@ trait Types
     override def mapOver(map: TypeMap): Type = {
       val pre1 = pre.mapOver(map)
       val alts1 = map.mapOver(alternatives)
-      if ((pre ne pre1) || (alternatives ne alts1)) OverloadedArgFunProto(argIdx, pre1, alts1)
+      if ((pre ne pre1) || (alternatives ne alts1)) OverloadedArgProto(argIdx, pre1, alts1)
       else this
     }
 
     // TODO
-    // override def registerTypeEquality(tp: Type): Boolean = functionArgsProto =:= tp
+    // override def registerTypeEquality(tp: Type): Boolean = protoTp =:= tp
 
 
     // TODO: use =:=, but `!(typeOf[String with AnyRef] =:= typeOf[String])` (https://github.com/scala/scala-dev/issues/530)
@@ -1262,18 +1271,25 @@ trait Types
       def unapply(params: List[Symbol]): Option[Type] = {
         lazy val lastParamTp = params.last.tpe
 
+        val argIdxMapped = argIdx match {
+          case Left(idx) => idx
+          case Right(name) => params.indexWhere(p => p.name == name && !p.isSynthetic)
+        }
+
         // if we're asking for the last argument, or past, and it happens to be a repeated param -- strip the vararg marker and return the type
-        if (params.nonEmpty && params.lengthCompare(argIdx + 1) <= 0 && isRepeatedParamType(lastParamTp)) {
+        if (params.nonEmpty && params.lengthCompare(argIdxMapped + 1) <= 0 && isRepeatedParamType(lastParamTp)) {
           Some(lastParamTp.dealiasWiden.typeArgs.head)
-        } else if (params.isDefinedAt(argIdx)) {
-          Some(params(argIdx).tpe)
+        } else if (params.isDefinedAt(argIdxMapped)) {
+          Some(dropByName(params(argIdxMapped).tpe))
         } else None
       }
     }
 
 
     private def toWild(tp: Type): Type = tp match {
-      case PolyType(tparams, tp) => new SubstWildcardMap(tparams).apply(tp)
+      case PolyType(tparams, tp) =>
+        // we don't want bounded wildcards showing up for an f-bounded type param... no need for precision anyway
+        new SubstTypeMap(tparams, tparams map (_ => WildcardType)).apply(tp)
       case tp                    => tp
     }
 
@@ -1284,15 +1300,23 @@ trait Types
         alternatives map { alt =>
           // Use memberType so that a pre: AntiPolyType can instantiate its type params
           pre.memberType(alt) match {
-            case PolyType(tparams, MethodType(ParamAtIdx(paramTp), res)) => PolyType(tparams, paramTp.asSeenFrom(pre, alt.owner))
-            case MethodType(ParamAtIdx(paramTp), res)                    => paramTp.asSeenFrom(pre, alt.owner)
-            case _                                                       => NoType
+            case PolyType(tparams, MethodType(ParamAtIdx(paramTp), res))       => PolyType(tparams, paramTp.asSeenFrom(pre, alt.owner))
+            case MethodType(ParamAtIdx(paramTp), res)
+              if !(alt.isConstructor && alt.owner.info.isInstanceOf[PolyType]) => paramTp.asSeenFrom(pre, alt.owner)
+            // this is just too ugly, but the type params are out of whack and thus toWild won't catch them unless we rewrite as follows:
+            // if (alt.isConstructor && alt.owner.info.isInstanceOf[PolyType]) {
+            //   PolyType(alt.owner.info.typeParams.map(_.tpe.asSeenFrom(pre, alt.owner).typeSymbol), paramTp.asSeenFrom(pre, alt.owner))
+            // } else paramTp.asSeenFrom(pre, alt.owner)
+            case _ => NoType
           }
         }
 
+
+      // altParamTps.contains(NoType) implies sameTypesFolded.contains(NoType)
+      // so, if one alternative did not contribute an argument type, we'll not collapse this column
       altParamTps.foldLeft(Nil: List[Type]) {
-        case (acc, NoType | WildcardType) => acc
-        case (acc, tp)                    => if (acc.exists(same(tp, _))) acc else tp :: acc
+        case (acc, WildcardType) => acc
+        case (acc, tp)           => if (acc.exists(same(tp, _))) acc else tp :: acc
       }
     }
 
@@ -1301,7 +1325,7 @@ trait Types
 
     // Try to collapse all expected argument types (already distinct by =:=) into a single expected type,
     // so that we can use it to as the expected type to drive parameter type inference for a function literal argument.
-    private lazy val functionArgsProto = {
+    private lazy val protoTp = {
       val ABORT = (NoType, false, false)
 
       // we also consider any function-ish type equal as long as the argument types are
@@ -1323,15 +1347,22 @@ trait Types
 
       if ((sameHoArgTypesFolded eq WildcardType) || (sameHoArgTypesFolded eq NoType)) WildcardType
       else functionOrPfOrSamArgTypes(toWild(sameHoArgTypesFolded)) match {
-        case Nil     => WildcardType // TODO: can we retain some of this?
+        case Nil     =>
+          // Ok, it's not a function proto, but we did collapse to only one type -- why not use that as our expected type?
+          // we exclude constructors because a polymorphic class's type params are not represented as part of the constructor method's type, and thus toWild won't work
+          sameTypesFolded match {
+            case onlyType :: Nil =>
+              //              println(s"collapsed argument types at index $argIdx to ${toWild(onlyType)} for ${alternatives map (alt => (alt, pre memberType alt))} ")
+              toWild(onlyType)
+            case _               => WildcardType
+          }
         case hofArgs =>
           if (partialFun) appliedType(PartialFunctionClass, hofArgs :+ WildcardType)
           else if (regularFun) functionType(hofArgs, WildcardType)
-          // if we saw a variety of SAMs, can't collapse them -- what if they were accidental sams and we're not going to supply a function literal?
+               // if we saw a variety of SAMs, can't collapse them -- what if they were accidental sams and we're not going to supply a function literal?
           else if (sameTypesFolded.lengthCompare(1) == 0) toWild(sameTypesFolded.head)
           else WildcardType
       }
-
     }
   }
 

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -155,7 +155,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.ErrorType
     this.WildcardType
     this.BoundedWildcardType
-    this.OverloadedArgFunProto
+    this.OverloadedArgProto
     this.NoType
     this.NoPrefix
     this.ThisType

--- a/test/files/pos/overload_proto_accisam.scala
+++ b/test/files/pos/overload_proto_accisam.scala
@@ -1,4 +1,4 @@
-// TODO make independent of java.io.OutputStream, but obvious way does not capture the bug (see didInferSamType and OverloadedArgFunProto)
+// TODO make independent of java.io.OutputStream, but obvious way does not capture the bug (see didInferSamType and OverloadedArgProto)
 class Test {
   def overloadedAccidentalSam(a: java.io.OutputStream, b: String) = ???
   def overloadedAccidentalSam(a: java.io.OutputStream, b: Any)= ???

--- a/test/files/pos/t11015.scala
+++ b/test/files/pos/t11015.scala
@@ -1,0 +1,8 @@
+class Foo[A]
+
+class Test {
+  def append(a: Foo[String]): Unit = ()
+  def append(a: Foo[String], as: Int*): Unit = ()
+
+  append(new Foo)
+}

--- a/test/files/pos/t11015.scala
+++ b/test/files/pos/t11015.scala
@@ -1,8 +1,19 @@
 class Foo[A]
 
+object ParserInput { implicit def apply(string: String): ParserInput = ??? }
+trait ParserInput
+
+// overloaded with default arg
+class JsonParser(input: ParserInput, settings: String = null) { def this(input: ParserInput) = this(input, null) }
+
 class Test {
   def append(a: Foo[String]): Unit = ()
   def append(a: Foo[String], as: Int*): Unit = ()
 
   append(new Foo)
+
+  // needs implicit conversion from companion of expected type
+  // the problem was that getParts in implicits did not consider OverloadedArgProto's underlying type;
+  // the implemented solution is to normalize the expected type of a view before calling inferView
+  new JsonParser("""{"key":1}{"key":2}""")
 }


### PR DESCRIPTION
Normally, an argument supplied to an application of an overloaded method
is typed without an expected type. We can constrain type inference more
when we have only one candidate expected type between all alternatives.

So, this adds an exception when all alternatives explicitly specify the
same parameter type for an argument (a missing parameter type, due to e.g.
arity differences, is taken as `NoType`, thus resorting to no expected type).

Also improve a few corner cases with implicits (views), call-by-name arguments, named arguments.

Note that this also aligns us a bit better with dotty, where constraints are solved lazily, 
while being pushed through overload resolution, so that this more precise kind of type inference
falls out "naturally" :-)

Fix scala/bug#11015

@SethTisue let's see how much of the community build I broke :-)