### PR TITLE
Add CollisionProofHashMap, a mutable HashMap that degrades to red-black trees in the worst case

### DIFF
--- a/src/library/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/src/library/scala/collection/mutable/CollisionProofHashMap.scala
@@ -1,0 +1,801 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection
+package mutable
+
+import scala.annotation.meta.{getter, setter}
+import scala.annotation.tailrec
+import scala.collection.generic.DefaultSerializationProxy
+import scala.collection.mutable
+import scala.runtime.Statics
+
+/** This class implements mutable maps using a hashtable with red-black trees in the buckets for good
+  * worst-case performance on hash collisions. An `Ordering` is required for the element type. Equality
+  * as determined by the `Ordering` has to be consistent with `equals` and `hashCode`. Universal equality
+  * of numeric types is not supported (similar to `AnyRefMap`).
+  *
+  * @author  Stefan Zeiger
+  * @since   2.13
+  * @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
+  * section on `Hash Tables` for more information.
+  *
+  * @define Coll `mutable.CollisionProofHashMap`
+  * @define coll mutable collision-proof hash map
+  * @define mayNotTerminateInf
+  * @define willNotTerminateInf
+  */
+final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double)(implicit ordering: Ordering[K])
+  extends AbstractMap[K, V]
+    with MapOps[K, V, Map, CollisionProofHashMap[K, V]] //--
+    with StrictOptimizedIterableOps[(K, V), Iterable, CollisionProofHashMap[K, V]]
+    with StrictOptimizedMapOps[K, V, Map, CollisionProofHashMap[K, V]] { //--
+
+  def this()(implicit ordering: Ordering[K]) = this(CollisionProofHashMap.defaultInitialCapacity, CollisionProofHashMap.defaultLoadFactor)(ordering)
+
+  import CollisionProofHashMap.Node
+  private[this] type RBNode = CollisionProofHashMap.RBNode[K, V]
+  private[this] type LLNode = CollisionProofHashMap.LLNode[K, V]
+
+  /** The actual hash table. */
+  private[this] var table: Array[Node] = new Array[Node](tableSizeFor(initialCapacity))
+
+  /** The next size value at which to resize (capacity * load factor). */
+  private[this] var threshold: Int = newThreshold(table.length)
+
+  private[this] var contentSize = 0
+
+  override def size: Int = contentSize
+
+  @`inline` private[this] final def computeHash(o: K): Int = {
+    val h = if(o.asInstanceOf[AnyRef] eq null) 0 else o.hashCode
+    h ^ (h >>> 16)
+  }
+
+  @`inline` private[this] final def index(hash: Int) = hash & (table.length - 1)
+
+  override def contains(key: K): Boolean = findNode(key) ne null
+
+  def get(key: K): Option[V] = findNode(key) match {
+    case null => None
+    case nd => Some(nd match {
+      case nd: LLNode => nd.value
+      case nd: RBNode => nd.value
+    })
+  }
+
+  @throws[NoSuchElementException]
+  override def apply(key: K): V = findNode(key) match {
+    case null => default(key)
+    case nd => nd match {
+      case nd: LLNode => nd.value
+      case nd: RBNode => nd.value
+    }
+  }
+
+  override def getOrElse[V1 >: V](key: K, default: => V1): V1 = {
+    val nd = findNode(key)
+    if (nd eq null) default else nd match {
+      case nd: LLNode => nd.value
+      case n => n.asInstanceOf[RBNode].value
+    }
+  }
+
+  @`inline` private[this] def findNode(elem: K): Node = {
+    val hash = computeHash(elem)
+    table(index(hash)) match {
+      case null => null
+      case n: LLNode => n.getNode(elem, hash)
+      case n => n.asInstanceOf[RBNode].getNode(elem, hash)
+    }
+  }
+
+  override def sizeHint(size: Int): Unit = {
+    val target = tableSizeFor(((size + 1).toDouble / loadFactor).toInt)
+    if(target > table.length) {
+      if(size == 0) reallocTable(target)
+      else growTable(target)
+    }
+  }
+
+  override def update(key: K, value: V): Unit = put0(key, value, false)
+
+  override def put(key: K, value: V): Option[V] = put0(key, value, true) match {
+    case null => None
+    case sm => sm
+  }
+
+  def addOne(elem: (K, V)): this.type = { put0(elem._1, elem._2, false); this }
+
+  @`inline` private[this] def put0(key: K, value: V, getOld: Boolean): Some[V] = {
+    if(contentSize + 1 >= threshold) growTable(table.length * 2)
+    val hash = computeHash(key)
+    val idx = index(hash)
+    put0(key, value, getOld, hash, idx)
+  }
+
+  private[this] def put0(key: K, value: V, getOld: Boolean, hash: Int, idx: Int): Some[V] = {
+    val res = table(idx) match {
+      case n: RBNode =>
+        insert(n, idx, key, hash, value)
+      case _old =>
+        val old: LLNode = _old.asInstanceOf[LLNode]
+        if(old eq null) {
+          table(idx) = new LLNode(key, hash, value, null)
+        } else {
+          var remaining = CollisionProofHashMap.treeifyThreshold
+          var prev: LLNode = null
+          var n = old
+          while((n ne null) && n.hash <= hash && remaining > 0) {
+            if(n.hash == hash && key == n.key) {
+              val old = n.value
+              n.value = value
+              return (if(getOld) Some(old) else null)
+            }
+            prev = n
+            n = n.next
+            remaining -= 1
+          }
+          if(remaining == 0) {
+            treeify(old, idx)
+            return put0(key, value, getOld, hash, idx)
+          }
+          if(prev eq null) table(idx) = new LLNode(key, hash, value, old)
+          else prev.next = new LLNode(key, hash, value, prev.next)
+        }
+        true
+    }
+    if(res) contentSize += 1
+    if(res) Some(null.asInstanceOf[V]) else null //TODO
+  }
+
+  private[this] def treeify(old: LLNode, idx: Int): Unit = {
+    table(idx) = CollisionProofHashMap.leaf(old.key, old.hash, old.value, red = false, null)
+    var n: LLNode = old.next
+    while(n ne null) {
+      val root = table(idx).asInstanceOf[RBNode]
+      insertIntoExisting(root, idx, n.key, n.hash, n.value, root)
+      n = n.next
+    }
+  }
+
+  override def addAll(xs: IterableOnce[(K, V)]): this.type = {
+    val k = xs.knownSize
+    if(k > 0) sizeHint(contentSize + k)
+    super.addAll(xs)
+  }
+
+  // returns the old value or Statics.pfMarker if not found
+  private[this] def remove0(elem: K) : Any = {
+    val hash = computeHash(elem)
+    var idx = index(hash)
+    table(idx) match {
+      case null => Statics.pfMarker
+      case t: RBNode =>
+        val v = delete(t, idx, elem, hash)
+        if(v.asInstanceOf[AnyRef] ne Statics.pfMarker) contentSize -= 1
+        v
+      case nd: LLNode if nd.hash == hash && nd.key == elem =>
+        // first element matches
+        table(idx) = nd.next
+        contentSize -= 1
+        nd.value
+      case nd: LLNode =>
+        // find an element that matches
+        var prev = nd
+        var next = nd.next
+        while((next ne null) && next.hash <= hash) {
+          if(next.hash == hash && next.key == elem) {
+            prev.next = next.next
+            contentSize -= 1
+            return next.value
+          }
+          prev = next
+          next = next.next
+        }
+        Statics.pfMarker
+    }
+  }
+
+  private[this] abstract class MapIterator[R] extends AbstractIterator[R] {
+    protected[this] def extract(node: LLNode): R
+    protected[this] def extract(node: RBNode): R
+
+    private[this] var i = 0
+    private[this] var node: Node = null
+    private[this] val len = table.length
+
+    def hasNext: Boolean = {
+      if(node ne null) true
+      else {
+        while(i < len) {
+          val n = table(i)
+          i += 1
+          n match {
+            case null =>
+            case n: RBNode =>
+              node = CollisionProofHashMap.minNodeNonNull(n)
+              return true
+            case n: LLNode =>
+              node = n
+              return true
+          }
+        }
+        false
+      }
+    }
+
+    def next(): R =
+      if(!hasNext) Iterator.empty.next()
+      else node match {
+        case n: RBNode =>
+          val r = extract(n)
+          node = CollisionProofHashMap.successor(n )
+          r
+        case n: LLNode =>
+          val r = extract(n)
+          node = n.next
+          r
+      }
+  }
+
+  override def keysIterator: Iterator[K] = new MapIterator[K] {
+    protected[this] def extract(node: LLNode) = node.key
+    protected[this] def extract(node: RBNode) = node.key
+  }
+
+  override def iterator: Iterator[(K, V)] = new MapIterator[(K, V)] {
+    protected[this] def extract(node: LLNode) = (node.key, node.value)
+    protected[this] def extract(node: RBNode) = (node.key, node.value)
+  }
+
+  private[this] def growTable(newlen: Int) = {
+    var oldlen = table.length
+    table = java.util.Arrays.copyOf(table, newlen)
+    threshold = newThreshold(table.length)
+    while(oldlen < newlen) {
+      var i = 0
+      while (i < oldlen) {
+        val old = table(i)
+        if(old ne null) splitBucket(old, i, i + oldlen, oldlen)
+        i += 1
+      }
+      oldlen *= 2
+    }
+  }
+
+  @`inline` private[this] def reallocTable(newlen: Int) = {
+    table = new Array(newlen)
+    threshold = newThreshold(table.length)
+  }
+
+  @`inline` private[this] def splitBucket(tree: Node, lowBucket: Int, highBucket: Int, mask: Int): Unit = tree match {
+    case t: LLNode => splitBucket(t, lowBucket, highBucket, mask)
+    case t: RBNode => splitBucket(t, lowBucket, highBucket, mask)
+  }
+
+  private[this] def splitBucket(list: LLNode, lowBucket: Int, highBucket: Int, mask: Int): Unit = {
+    val preLow: LLNode = new LLNode(null.asInstanceOf[K], 0, null.asInstanceOf[V], null)
+    val preHigh: LLNode = new LLNode(null.asInstanceOf[K], 0, null.asInstanceOf[V], null)
+    //preLow.next = null
+    //preHigh.next = null
+    var lastLow: LLNode = preLow
+    var lastHigh: LLNode = preHigh
+    var n = list
+    while(n ne null) {
+      val next = n.next
+      if((n.hash & mask) == 0) { // keep low
+        lastLow.next = n
+        lastLow = n
+      } else { // move to high
+        lastHigh.next = n
+        lastHigh = n
+      }
+      n = next
+    }
+    lastLow.next = null
+    if(list ne preLow.next) table(lowBucket) = preLow.next
+    if(preHigh.next ne null) {
+      table(highBucket) = preHigh.next
+      lastHigh.next = null
+    }
+  }
+
+  private[this] def splitBucket(tree: RBNode, lowBucket: Int, highBucket: Int, mask: Int): Unit = {
+    var lowCount, highCount = 0
+    tree.foreachNode((n: RBNode) => if((n.hash & mask) != 0) highCount += 1 else lowCount += 1)
+    if(highCount != 0) {
+      if(lowCount == 0) {
+        table(lowBucket) = null
+        table(highBucket) = tree
+      } else {
+        table(lowBucket) = fromNodes(new CollisionProofHashMap.RBNodesIterator(tree).filter(n => (n.hash & mask) == 0), lowCount)
+        table(highBucket) = fromNodes(new CollisionProofHashMap.RBNodesIterator(tree).filter(n => (n.hash & mask) != 0), highCount)
+      }
+    }
+  }
+
+  private[this] def tableSizeFor(capacity: Int) =
+    (Integer.highestOneBit((capacity-1).max(4))*2).min(1 << 30)
+
+  private[this] def newThreshold(size: Int) = (size.toDouble * loadFactor).toInt
+
+  override def clear(): Unit = {
+    java.util.Arrays.fill(table.asInstanceOf[Array[AnyRef]], null)
+    contentSize = 0
+  }
+
+  override def remove(key: K): Option[V] = {
+    val v = remove0(key)
+    if(v.asInstanceOf[AnyRef] eq Statics.pfMarker) None else Some(v.asInstanceOf[V])
+  }
+
+  def subtractOne(elem: K): this.type = { remove0(elem); this }
+
+  override def knownSize: Int = size
+
+  override def isEmpty: Boolean = size == 0
+
+  override def foreach[U](f: ((K, V)) => U): Unit = {
+    val len = table.length
+    var i = 0
+    while(i < len) {
+      val n = table(i)
+      if(n ne null) n match {
+        case n: LLNode => n.foreach(f)
+        case n: RBNode => n.foreach(f)
+      }
+      i += 1
+    }
+  }
+
+  protected[this] def writeReplace(): AnyRef = new DefaultSerializationProxy(new CollisionProofHashMap.DeserializationFactory[K, V](table.length, loadFactor, ordering), this)
+
+  override protected[this] def stringPrefix = "CollisionProofHashMap"
+
+  override def getOrElseUpdate(key: K, defaultValue: => V): V = {
+    val hash = computeHash(key)
+    val idx = index(hash)
+    table(idx) match {
+      case null => ()
+      case n: LLNode =>
+        val nd = n.getNode(key, hash)
+        if(nd != null) return nd.value
+      case n =>
+        val nd = n.asInstanceOf[RBNode].getNode(key, hash)
+        if(nd != null) return nd.value
+    }
+    val table0 = table
+    val default = defaultValue
+    if(contentSize + 1 >= threshold) growTable(table.length * 2)
+    // Avoid recomputing index if the `defaultValue()` or new element hasn't triggered a table resize.
+    val newIdx = if (table0 eq table) idx else index(hash)
+    put0(key, default, false, hash, newIdx)
+    default
+  }
+
+  ///////////////////// RedBlackTree code derived from mutable.RedBlackTree:
+
+  @`inline` private[this] def isRed(node: RBNode) = (node ne null) && node.red
+  @`inline` private[this] def isBlack(node: RBNode) = (node eq null) || !node.red
+
+  @`inline` private[this] def compare(key: K, hash: Int, node: LLNode): Int = {
+    val i = hash - node.hash
+    if(i != 0) i else ordering.compare(key, node.key)
+  }
+
+  @`inline` private[this] def compare(key: K, hash: Int, node: RBNode): Int = {
+    /*val i = hash - node.hash
+    if(i != 0) i else*/ ordering.compare(key, node.key)
+  }
+
+  // ---- insertion ----
+
+  @tailrec private[this] final def insertIntoExisting(_root: RBNode, bucket: Int, key: K, hash: Int, value: V, x: RBNode): Boolean = {
+    val cmp = compare(key, hash, x)
+    if(cmp == 0) {
+      x.value = value
+      false
+    } else {
+      val next = if(cmp < 0) x.left else x.right
+      if(next eq null) {
+        val z = CollisionProofHashMap.leaf(key, hash, value, red = true, x)
+        if (cmp < 0) x.left = z else x.right = z
+        table(bucket) = fixAfterInsert(_root, z)
+        return true
+      }
+      else insertIntoExisting(_root, bucket, key, hash, value, next)
+    }
+  }
+
+  private[this] final def insert(tree: RBNode, bucket: Int, key: K, hash: Int, value: V): Boolean = {
+    if(tree eq null) {
+      table(bucket) = CollisionProofHashMap.leaf(key, hash, value, red = false, null)
+      true
+    } else insertIntoExisting(tree, bucket, key, hash, value, tree)
+  }
+
+  private[this] def fixAfterInsert(_root: RBNode, node: RBNode): RBNode = {
+    var root = _root
+    var z = node
+    while (isRed(z.parent)) {
+      if (z.parent eq z.parent.parent.left) {
+        val y = z.parent.parent.right
+        if (isRed(y)) {
+          z.parent.red = false
+          y.red = false
+          z.parent.parent.red = true
+          z = z.parent.parent
+        } else {
+          if (z eq z.parent.right) {
+            z = z.parent
+            root = rotateLeft(root, z)
+          }
+          z.parent.red = false
+          z.parent.parent.red = true
+          root = rotateRight(root, z.parent.parent)
+        }
+      } else { // symmetric cases
+        val y = z.parent.parent.left
+        if (isRed(y)) {
+          z.parent.red = false
+          y.red = false
+          z.parent.parent.red = true
+          z = z.parent.parent
+        } else {
+          if (z eq z.parent.left) {
+            z = z.parent
+            root = rotateRight(root, z)
+          }
+          z.parent.red = false
+          z.parent.parent.red = true
+          root = rotateLeft(root, z.parent.parent)
+        }
+      }
+    }
+    root.red = false
+    root
+  }
+
+  // ---- deletion ----
+
+  // returns the old value or Statics.pfMarker if not found
+  private[this] def delete(_root: RBNode, bucket: Int, key: K, hash: Int): Any = {
+    var root = _root
+    val z = root.getNode(key, hash: Int)
+    if (z ne null) {
+      val oldValue = z.value
+      var y = z
+      var yIsRed = y.red
+      var x: RBNode = null
+      var xParent: RBNode = null
+
+      if (z.left eq null) {
+        x = z.right
+        root = transplant(root, z, z.right)
+        xParent = z.parent
+      }
+      else if (z.right eq null) {
+        x = z.left
+        root = transplant(root, z, z.left)
+        xParent = z.parent
+      }
+      else {
+        y = CollisionProofHashMap.minNodeNonNull(z.right)
+        yIsRed = y.red
+        x = y.right
+
+        if (y.parent eq z) xParent = y
+        else {
+          xParent = y.parent
+          root = transplant(root, y, y.right)
+          y.right = z.right
+          y.right.parent = y
+        }
+        root = transplant(root, z, y)
+        y.left = z.left
+        y.left.parent = y
+        y.red = z.red
+      }
+
+      if (!yIsRed) root = fixAfterDelete(root, x, xParent)
+      if(root ne _root) table(bucket) = root
+      oldValue
+    } else Statics.pfMarker
+  }
+
+  private[this] def fixAfterDelete(_root: RBNode, node: RBNode, parent: RBNode): RBNode = {
+    var root = _root
+    var x = node
+    var xParent = parent
+    while ((x ne root) && isBlack(x)) {
+      if (x eq xParent.left) {
+        var w = xParent.right
+        // assert(w ne null)
+
+        if (w.red) {
+          w.red = false
+          xParent.red = true
+          root = rotateLeft(root, xParent)
+          w = xParent.right
+        }
+        if (isBlack(w.left) && isBlack(w.right)) {
+          w.red = true
+          x = xParent
+        } else {
+          if (isBlack(w.right)) {
+            w.left.red = false
+            w.red = true
+            root = rotateRight(root, w)
+            w = xParent.right
+          }
+          w.red = xParent.red
+          xParent.red = false
+          w.right.red = false
+          root = rotateLeft(root, xParent)
+          x = root
+        }
+      } else { // symmetric cases
+        var w = xParent.left
+        // assert(w ne null)
+
+        if (w.red) {
+          w.red = false
+          xParent.red = true
+          root = rotateRight(root, xParent)
+          w = xParent.left
+        }
+        if (isBlack(w.right) && isBlack(w.left)) {
+          w.red = true
+          x = xParent
+        } else {
+          if (isBlack(w.left)) {
+            w.right.red = false
+            w.red = true
+            root = rotateLeft(root, w)
+            w = xParent.left
+          }
+          w.red = xParent.red
+          xParent.red = false
+          w.left.red = false
+          root = rotateRight(root, xParent)
+          x = root
+        }
+      }
+      xParent = x.parent
+    }
+    if (x ne null) x.red = false
+    root
+  }
+
+  // ---- helpers ----
+
+  @`inline` private[this] def rotateLeft(_root: RBNode, x: RBNode): RBNode = {
+    var root = _root
+    val y = x.right
+    x.right = y.left
+
+    val xp = x.parent
+    if (y.left ne null) y.left.parent = x
+    y.parent = xp
+
+    if (xp eq null) root = y
+    else if (x eq xp.left) xp.left = y
+    else xp.right = y
+
+    y.left = x
+    x.parent = y
+    root
+  }
+
+  @`inline` private[this] def rotateRight(_root: RBNode, x: RBNode): RBNode = {
+    var root = _root
+    val y = x.left
+    x.left = y.right
+
+    val xp = x.parent
+    if (y.right ne null) y.right.parent = x
+    y.parent = xp
+
+    if (xp eq null) root = y
+    else if (x eq xp.right) xp.right = y
+    else xp.left = y
+
+    y.right = x
+    x.parent = y
+    root
+  }
+
+  /**
+    * Transplant the node `from` to the place of node `to`. This is done by setting `from` as a child of `to`'s previous
+    * parent and setting `from`'s parent to the `to`'s previous parent. The children of `from` are left unchanged.
+    */
+  private[this] def transplant(_root: RBNode, to: RBNode, from: RBNode): RBNode = {
+    var root = _root
+    if (to.parent eq null) root = from
+    else if (to eq to.parent.left) to.parent.left = from
+    else to.parent.right = from
+    if (from ne null) from.parent = to.parent
+    root
+  }
+
+  // building
+
+  def fromNodes(xs: Iterator[Node], size: Int): RBNode = {
+    val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
+    def f(level: Int, size: Int): RBNode = size match {
+      case 0 => null
+      case 1 =>
+        val nn = xs.next()
+        val (key, hash, value) = nn match {
+          case nn: LLNode => (nn.key, nn.hash, nn.value)
+          case nn: RBNode => (nn.key, nn.hash, nn.value)
+        }
+        new RBNode(key, hash, value, level == maxUsedDepth && level != 1, null, null, null)
+      case n =>
+        val leftSize = (size-1)/2
+        val left = f(level+1, leftSize)
+        val nn = xs.next()
+        val right = f(level+1, size-1-leftSize)
+        val (key, hash, value) = nn match {
+          case nn: LLNode => (nn.key, nn.hash, nn.value)
+          case nn: RBNode => (nn.key, nn.hash, nn.value)
+        }
+        val n = new RBNode(key, hash, value, false, left, right, null)
+        if(left ne null) left.parent = n
+        right.parent = n
+        n
+    }
+    f(1, size)
+  }
+}
+
+/**
+  * $factoryInfo
+  * @define Coll `mutable.CollisionProofHashMap`
+  * @define coll mutable collision-proof hash map
+  */
+@SerialVersionUID(3L)
+object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
+
+  def from[K : Ordering, V](it: scala.collection.IterableOnce[(K, V)]): CollisionProofHashMap[K, V] = {
+    val k = it.knownSize
+    val cap = if(k > 0) ((k + 1).toDouble / defaultLoadFactor).toInt else defaultInitialCapacity
+    new CollisionProofHashMap[K, V](cap, defaultLoadFactor) ++= it
+  }
+
+  def empty[K : Ordering, V]: CollisionProofHashMap[K, V] = new CollisionProofHashMap[K, V]
+
+  def newBuilder[K : Ordering, V]: Builder[(K, V), CollisionProofHashMap[K, V]] = newBuilder(defaultInitialCapacity, defaultLoadFactor)
+
+  def newBuilder[K : Ordering, V](initialCapacity: Int, loadFactor: Double): Builder[(K, V), CollisionProofHashMap[K, V]] =
+    new GrowableBuilder[(K, V), CollisionProofHashMap[K, V]](new CollisionProofHashMap[K, V](initialCapacity, loadFactor)) {
+      override def sizeHint(size: Int) = elems.sizeHint(size)
+    }
+
+  /** The default load factor for the hash table */
+  final def defaultLoadFactor: Double = 0.75
+
+  /** The default initial capacity for the hash table */
+  final def defaultInitialCapacity: Int = 16
+
+  @SerialVersionUID(3L)
+  private final class DeserializationFactory[K, V](val tableLength: Int, val loadFactor: Double, val ordering: Ordering[K]) extends Factory[(K, V), CollisionProofHashMap[K, V]] with Serializable {
+    def fromSpecific(it: IterableOnce[(K, V)]): CollisionProofHashMap[K, V] = new CollisionProofHashMap[K, V](tableLength, loadFactor)(ordering) ++= it
+    def newBuilder: Builder[(K, V), CollisionProofHashMap[K, V]] = CollisionProofHashMap.newBuilder(tableLength, loadFactor)(ordering)
+  }
+
+  @`inline` private def compare[K, V](key: K, hash: Int, node: LLNode[K, V])(implicit ord: Ordering[K]): Int = {
+    val i = hash - node.hash
+    if(i != 0) i else ord.compare(key, node.key)
+  }
+
+  @`inline` private def compare[K, V](key: K, hash: Int, node: RBNode[K, V])(implicit ord: Ordering[K]): Int = {
+    /*val i = hash - node.hash
+    if(i != 0) i else*/ ord.compare(key, node.key)
+  }
+
+  private final val treeifyThreshold = 8
+
+  // Superclass for RBNode and LLNode to help the JIT with optimizing instance checks, but no shared common fields.
+  // Keeping calls monomorphic where possible and dispatching manually where needed is faster.
+  sealed abstract class Node
+
+  /////////////////////////// Red-Black Tree Node
+
+  final class RBNode[K, V](var key: K, var hash: Int, var value: V, var red: Boolean, var left: RBNode[K, V], var right: RBNode[K, V], var parent: RBNode[K, V]) extends Node {
+    override def toString: String = "RBNode(" + key + ", " + hash + ", " + value + ", " + red + ", " + left + ", " + right + ")"
+
+    @tailrec def getNode(k: K, h: Int)(implicit ord: Ordering[K]): RBNode[K, V] = {
+      val cmp = compare(k, h, this)
+      if (cmp < 0) {
+        if(left ne null) left.getNode(k, h) else null
+      } else if (cmp > 0) {
+        if(right ne null) right.getNode(k, h) else null
+      } else this
+    }
+
+    def foreach[U](f: ((K, V)) => U): Unit = {
+      if(left ne null) left.foreach(f)
+      f((key, value))
+      if(right ne null) right.foreach(f)
+    }
+
+    def foreachNode[U](f: RBNode[K, V] => U): Unit = {
+      if(left ne null) left.foreachNode(f)
+      f(this)
+      if(right ne null) right.foreachNode(f)
+    }
+  }
+
+  @`inline` private def leaf[A, B](key: A, hash: Int, value: B, red: Boolean, parent: RBNode[A, B]): RBNode[A, B] =
+    new RBNode(key, hash, value, red, null, null, parent)
+
+  @tailrec private def minNodeNonNull[A, B](node: RBNode[A, B]): RBNode[A, B] =
+    if (node.left eq null) node else minNodeNonNull(node.left)
+
+  /**
+    * Returns the node that follows `node` in an in-order tree traversal. If `node` has the maximum key (and is,
+    * therefore, the last node), this method returns `null`.
+    */
+  private def successor[A, B](node: RBNode[A, B]): RBNode[A, B] = {
+    if (node.right ne null) minNodeNonNull(node.right)
+    else {
+      var x = node
+      var y = x.parent
+      while ((y ne null) && (x eq y.right)) {
+        x = y
+        y = y.parent
+      }
+      y
+    }
+  }
+
+  private final class RBNodesIterator[A, B](tree: RBNode[A, B])(implicit ord: Ordering[A]) extends AbstractIterator[RBNode[A, B]] {
+    private[this] var nextNode: RBNode[A, B] = if(tree eq null) null else minNodeNonNull(tree)
+
+    def hasNext: Boolean = nextNode ne null
+
+    @throws[NoSuchElementException]
+    def next(): RBNode[A, B] = nextNode match {
+      case null => Iterator.empty.next()
+      case node =>
+        nextNode = successor(node)
+        node
+    }
+  }
+
+  /////////////////////////// Linked List Node
+
+  private final class LLNode[K, V](var key: K, var hash: Int, var value: V, var next: LLNode[K, V]) extends Node {
+    override def toString = s"LLNode($key, $value, $hash) -> $next"
+
+    private[this] def eq(a: Any, b: Any): Boolean =
+      if(a.asInstanceOf[AnyRef] eq null) b.asInstanceOf[AnyRef] eq null else a.asInstanceOf[AnyRef].equals(b)
+
+    @tailrec def getNode(k: K, h: Int)(implicit ord: Ordering[K]): LLNode[K, V] = {
+      if(h == hash && eq(k, key) /*ord.compare(k, key) == 0*/) this
+      else if((next eq null) || (hash > h)) null
+      else next.getNode(k, h)
+    }
+
+    @tailrec def foreach[U](f: ((K, V)) => U): Unit = {
+      f((key, value))
+      if(next ne null) next.foreach(f)
+    }
+
+    @tailrec def foreachNode[U](f: LLNode[K, V] => U): Unit = {
+      f(this)
+      if(next ne null) next.foreachNode(f)
+    }
+  }
+}

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/CollisionProofHashMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/CollisionProofHashMapBenchmark.scala
@@ -1,0 +1,205 @@
+package scala.collection.mutable
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+import org.openjdk.jmh.runner.IterationType
+import benchmark._
+import java.util.concurrent.TimeUnit
+import java.util.{ HashMap => JHashMap }
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class CollisionProofHashMapBenchmark {
+  @Param(Array(/*"0", "1", "10",*/ "100", "1000", "10000"))
+  var size: Int = _
+
+  class Collider(val x: String, val h: Int) extends Comparable[Collider] {
+    override def hashCode: Int = h
+    override def equals(o: Any): Boolean = o match {
+      case o: Collider => x == o.x
+      case _ => false
+    }
+    def compareTo(o: Collider): Int = x.compareTo(o.x)
+  }
+
+  implicit val colliderOrdering: Ordering[Collider] = Ordering.String.on[Collider](_.x)
+
+  var existingKeys: Array[String] = _
+  var existingKVs: ArrayBuffer[(String, String)] = _
+  var missingKeys: Array[String] = _
+  var oa1: CollisionProofHashMap[String, String] = _
+  var m1: HashMap[String, String] = _
+  var j1: JHashMap[String, String] = new JHashMap[String, String]
+  var colliders: Array[Collider] = _
+  var dos: Array[Collider] = _
+
+  @Setup(Level.Trial) def init: Unit = {
+    existingKeys = (0 until size).map(_.toString).toArray
+    existingKVs = ArrayBuffer.from(existingKeys.iterator.map(k => (k, k)))
+    missingKeys = (size until (2 * size.max(100))).toArray.map(_.toString)
+    oa1 = CollisionProofHashMap.from(existingKVs)
+    m1 = HashMap.from(existingKVs)
+    m1.foreach { case (k, v) => j1.put(k, v) }
+    colliders = existingKeys.map(k => new Collider(k, k.hashCode & 0x1111))
+    dos = existingKeys.map(k => new Collider(k, 42))
+  }
+
+  @Benchmark def oaFillRegular(bh: Blackhole): Unit = {
+    val h = new CollisionProofHashMap[String, String]
+    existingKeys.foreach(k => h.put(k, k))
+    bh.consume(h)
+  }
+
+  @Benchmark def oaFillColliding(bh: Blackhole): Unit = {
+    val h = new CollisionProofHashMap[Collider, Collider]
+    colliders.foreach(k => h.put(k, k))
+    bh.consume(h)
+  }
+
+  @Benchmark def oaFillDoS(bh: Blackhole): Unit = {
+    val h = new CollisionProofHashMap[Collider, Collider]
+    dos.foreach(k => h.put(k, k))
+    bh.consume(h)
+  }
+
+  @Benchmark def oaBuild(bh: Blackhole): Unit =
+    bh.consume(CollisionProofHashMap.from(existingKVs))
+
+  @Benchmark def oaIterateKeys(bh: Blackhole): Unit = {
+    val it = oa1.keysIterator
+    while(it.hasNext) bh.consume(it.next())
+  }
+
+  @Benchmark def oaIterateEntries(bh: Blackhole): Unit = {
+    val it = oa1.iterator
+    while(it.hasNext) bh.consume(it.next())
+  }
+
+  @Benchmark def oaGetExisting(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < size) {
+      bh.consume(oa1.apply(existingKeys(i)))
+      i += 1
+    }
+  }
+
+  @Benchmark def oaGetNone(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < size.max(100)) {
+      bh.consume(oa1.get(missingKeys(i)))
+      i += 1
+    }
+  }
+
+  @Benchmark def oaClearRemove(bh: Blackhole): Unit = {
+    val m = CollisionProofHashMap.from(oa1)
+    val it = oa1.keysIterator
+    while(it.hasNext) m.remove(it.next())
+    assert(m.isEmpty)
+    bh.consume(m)
+  }
+
+  @Benchmark def oaClearSubtractOne(bh: Blackhole): Unit = {
+    val m = CollisionProofHashMap.from(oa1)
+    val it = oa1.keysIterator
+    while(it.hasNext) m.subtractOne(it.next())
+    assert(m.isEmpty)
+    bh.consume(m)
+  }
+
+  @Benchmark def hmFillRegular(bh: Blackhole): Unit = {
+    val h = new HashMap[Any, Any]
+    existingKeys.foreach(k => h.put(k, k))
+    bh.consume(h)
+  }
+
+  @Benchmark def hmFillColliding(bh: Blackhole): Unit = {
+    val h = new HashMap[Any, Any]
+    colliders.foreach(k => h.put(k, k))
+    bh.consume(h)
+  }
+
+  @Benchmark def hmBuild(bh: Blackhole): Unit =
+    bh.consume(HashMap.from(existingKVs))
+
+  @Benchmark def hmIterateKeys(bh: Blackhole): Unit = {
+    val it = m1.keysIterator
+    while(it.hasNext) bh.consume(it.next())
+  }
+
+  @Benchmark def hmIterateEntries(bh: Blackhole): Unit = {
+    val it = m1.iterator
+    while(it.hasNext) bh.consume(it.next())
+  }
+
+  @Benchmark def hmGetExisting(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < size) {
+      bh.consume(m1.apply(existingKeys(i)))
+      i += 1
+    }
+  }
+
+  @Benchmark def hmGetNone(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < size.max(100)) {
+      bh.consume(m1.get(missingKeys(i)))
+      i += 1
+    }
+  }
+
+  @Benchmark def javaFillRegular(bh: Blackhole): Unit = {
+    val h = new JHashMap[Any, Any]
+    existingKeys.foreach(k => h.put(k, k))
+    bh.consume(h)
+  }
+
+  @Benchmark def javaFillColliding(bh: Blackhole): Unit = {
+    val h = new JHashMap[Any, Any]
+    colliders.foreach(k => h.put(k, k))
+    bh.consume(h)
+  }
+
+  @Benchmark def javaFillDoS(bh: Blackhole): Unit = {
+    val h = new JHashMap[Any, Any]
+    dos.foreach(k => h.put(k, k))
+    bh.consume(h)
+  }
+
+  @Benchmark def javaBuild(bh: Blackhole): Unit = {
+    val h = new JHashMap[Any, Any](((existingKeys.length+1).toDouble/0.75).toInt, 0.75f)
+    existingKeys.foreach(k => h.put(k, k))
+    bh.consume(h)
+  }
+
+  @Benchmark def javaIterateKeys(bh: Blackhole): Unit = {
+    val it = j1.keySet().iterator()
+    while(it.hasNext) bh.consume(it.next())
+  }
+
+  @Benchmark def javaIterateEntries(bh: Blackhole): Unit = {
+    val it = j1.entrySet().iterator()
+    while(it.hasNext) bh.consume(it.next())
+  }
+
+  @Benchmark def javaGetExisting(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < size) {
+      bh.consume(j1.get(existingKeys(i)))
+      i += 1
+    }
+  }
+
+  @Benchmark def javaGetNone(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < size.max(100)) {
+      bh.consume(j1.get(missingKeys(i)))
+      i += 1
+    }
+  }
+}

--- a/test/junit/scala/collection/mutable/CollisionProofHashMapTest.scala
+++ b/test/junit/scala/collection/mutable/CollisionProofHashMapTest.scala
@@ -1,0 +1,105 @@
+package scala.collection
+package mutable
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class CollisionProofHashMapTest {
+
+  @Test
+  def getOrElseUpdate_mutationInCallback(): Unit = {
+    val hm = new mutable.CollisionProofHashMap[String, String]()
+    // add enough elements to resize the hash table in the callback
+    def add() = 1 to 100000 foreach (i => hm(i.toString) = "callback")
+    hm.getOrElseUpdate("0", {
+      add()
+      ""
+    })
+    assertEquals(Some(""), hm.get("0"))
+  }
+
+  @Test
+  def getOrElseUpdate_evalOnce(): Unit = {
+    var i = 0
+    val hm = new mutable.CollisionProofHashMap[Int, Int]()
+    hm.getOrElseUpdate(0, {i += 1; i})
+    assertEquals(1, hm(0))
+  }
+
+  @Test
+  def getOrElseUpdate_noEval(): Unit = {
+    val hm = new mutable.CollisionProofHashMap[Int, Int]()
+    hm.put(0, 0)
+    hm.getOrElseUpdate(0, throw new AssertionError())
+  }
+
+  def getOrElseUpdate_keyIdempotence(): Unit = {
+    val map = mutable.CollisionProofHashMap[String, String]()
+
+    val key = "key"
+    map.getOrElseUpdate(key, {
+      map.getOrElseUpdate(key, "value1")
+      "value2"
+    })
+
+    assertEquals(List((key, "value2")), map.toList)
+  }
+
+  @Test
+  def testWithDefaultValue: Unit = {
+    val m1 = mutable.CollisionProofHashMap(1 -> "a", 2 -> "b")
+    val m2 = m1.withDefaultValue("")
+
+    assertEquals(m2(1), "a")
+    assertEquals(m2(3), "")
+
+    m2 += (3 -> "c")
+    assertEquals(m2(3), "c")
+    assertEquals(m2(4), "")
+
+    m2 ++= List(4 -> "d", 5 -> "e", 6 -> "f")
+    assertEquals(m2(3), "c")
+    assertEquals(m2(4), "d")
+    assertEquals(m2(5), "e")
+    assertEquals(m2(6), "f")
+    assertEquals(m2(7), "")
+
+    m2 --= List(3, 4, 5)
+    assertEquals(m2(3), "")
+    assertEquals(m2(4), "")
+    assertEquals(m2(5), "")
+    assertEquals(m2(6), "f")
+    assertEquals(m2(7), "")
+
+    val m3 = m2 ++ List(3 -> "333")
+    assertEquals(m2(3), "")
+    assertEquals(m3(3), "333")
+  }
+  @Test
+  def testWithDefault: Unit = {
+    val m1 = mutable.CollisionProofHashMap(1 -> "a", 2 -> "b")
+
+    val m2: mutable.Map[Int, String] = m1.withDefault(i => (i + 1).toString)
+    m2.update(1, "aa")
+    m2.update(100, "bb")
+    m2.addAll(List(500 -> "c", 501 -> "c"))
+
+    assertEquals(m2(1), "aa")
+    assertEquals(m2(2), "b")
+    assertEquals(m2(3), "4")
+    assertEquals(m2(4), "5")
+    assertEquals(m2(500), "c")
+    assertEquals(m2(501), "c")
+    assertEquals(m2(502), "503")
+
+    val m3: mutable.Map[Int, String] = m2 - 1
+    assertEquals(m3(1), "2")
+
+    val m4: mutable.Map[Int, String] = m3 -- List(2, 100)
+    assertEquals(m4(2), "3")
+    assertEquals(m4(100), "101")
+  }
+}


### PR DESCRIPTION
Here's a first working version of a mutable `OrderAwareHashMap`. It could use some more polishing and there may be room for additional performance optimizations.

There's also a limitation in the design at the moment: We have no abstraction to represent a `Map` that requires an `Ordering` other than `SortedMap`, but this is *not* a `SortedMap`. We need something like `SortedMap` with all the same methods (that take an extra `Ordering`) and then `SortedMap` can be a subclass of it. It's not terribly important for this mutable version because there is no need to abstract over it (since it's the only one of its kind) and it doesn't pose a problem for the mutating methods, but an immutable version will require this additional abstraction.

------

The implementation is based on my new HashMap. Hash buckets use linked
lists ordered by hashcode by default. When a bucket gets too big due to
hash collisions it is converted into a red-black tree based on an
implicit Ordering for the keys. This is similar to java.util.HashMap
except we are using an Ordering instead of requiring the key type to
implement Comparable.

Equality semantics are determined by the Ordering, which has to be
consistent with the key’s hashCode.

------

Here are some benchmark results comparing the new `scala.collection.mutable.HashMap` ("hm"), `java.util.HashMap` ("java") and `OrderAwareHashMap` ("oa"):

```
[info] Benchmark                                      (size)  Mode  Cnt         Score        Error  Units
[info] OrderAwareHashMapBenchmark.hmBuild                100  avgt   20      1278.382 ±      8.998  ns/op
[info] OrderAwareHashMapBenchmark.hmBuild               1000  avgt   20     14432.822 ±    132.735  ns/op
[info] OrderAwareHashMapBenchmark.hmBuild              10000  avgt   20    151727.174 ±   1066.466  ns/op
[info] OrderAwareHashMapBenchmark.hmFillColliding        100  avgt   20      7658.501 ±     77.745  ns/op
[info] OrderAwareHashMapBenchmark.hmFillColliding       1000  avgt   20    529964.492 ±   4271.993  ns/op
[info] OrderAwareHashMapBenchmark.hmFillColliding      10000  avgt   20  28287147.289 ± 668258.012  ns/op
[info] OrderAwareHashMapBenchmark.hmFillRegular          100  avgt   20      2203.677 ±     22.506  ns/op
[info] OrderAwareHashMapBenchmark.hmFillRegular         1000  avgt   20     20344.985 ±    294.703  ns/op
[info] OrderAwareHashMapBenchmark.hmFillRegular        10000  avgt   20    232439.374 ±   6201.773  ns/op
[info] OrderAwareHashMapBenchmark.hmGetExisting          100  avgt   20       781.545 ±      6.442  ns/op
[info] OrderAwareHashMapBenchmark.hmGetExisting         1000  avgt   20      8905.764 ±     71.248  ns/op
[info] OrderAwareHashMapBenchmark.hmGetExisting        10000  avgt   20    104811.034 ±   5294.304  ns/op
[info] OrderAwareHashMapBenchmark.hmGetNone              100  avgt   20       726.723 ±     52.499  ns/op
[info] OrderAwareHashMapBenchmark.hmGetNone             1000  avgt   20      8283.629 ±    224.081  ns/op
[info] OrderAwareHashMapBenchmark.hmGetNone            10000  avgt   20    122303.024 ±   4705.909  ns/op
[info] OrderAwareHashMapBenchmark.hmIterateEntries       100  avgt   20      1052.933 ±     38.532  ns/op
[info] OrderAwareHashMapBenchmark.hmIterateEntries      1000  avgt   20     11403.256 ±    134.154  ns/op
[info] OrderAwareHashMapBenchmark.hmIterateEntries     10000  avgt   20    117159.529 ±   2443.455  ns/op
[info] OrderAwareHashMapBenchmark.hmIterateKeys          100  avgt   20       732.929 ±      9.441  ns/op
[info] OrderAwareHashMapBenchmark.hmIterateKeys         1000  avgt   20      8651.052 ±    142.330  ns/op
[info] OrderAwareHashMapBenchmark.hmIterateKeys        10000  avgt   20     87809.306 ±    836.859  ns/op
[info] OrderAwareHashMapBenchmark.javaBuild              100  avgt   20      1064.255 ±     23.366  ns/op
[info] OrderAwareHashMapBenchmark.javaBuild             1000  avgt   20     11196.882 ±     58.611  ns/op
[info] OrderAwareHashMapBenchmark.javaBuild            10000  avgt   20    143506.719 ±  19448.291  ns/op
[info] OrderAwareHashMapBenchmark.javaFillColliding      100  avgt   20     12671.089 ±    244.150  ns/op
[info] OrderAwareHashMapBenchmark.javaFillColliding     1000  avgt   20    254598.450 ±   2771.674  ns/op
[info] OrderAwareHashMapBenchmark.javaFillColliding    10000  avgt   20   4147371.899 ±  95794.889  ns/op
[info] OrderAwareHashMapBenchmark.javaFillDoS            100  avgt   20     18455.807 ±   1458.840  ns/op
[info] OrderAwareHashMapBenchmark.javaFillDoS           1000  avgt   20    317349.231 ±   5974.337  ns/op
[info] OrderAwareHashMapBenchmark.javaFillDoS          10000  avgt   20   3931170.230 ± 291880.463  ns/op
[info] OrderAwareHashMapBenchmark.javaFillRegular        100  avgt   20      1895.835 ±     12.992  ns/op
[info] OrderAwareHashMapBenchmark.javaFillRegular       1000  avgt   20     19282.599 ±    199.564  ns/op
[info] OrderAwareHashMapBenchmark.javaFillRegular      10000  avgt   20    254465.350 ±   2953.456  ns/op
[info] OrderAwareHashMapBenchmark.javaGetExisting        100  avgt   20       933.256 ±     10.986  ns/op
[info] OrderAwareHashMapBenchmark.javaGetExisting       1000  avgt   20     10032.797 ±     95.663  ns/op
[info] OrderAwareHashMapBenchmark.javaGetExisting      10000  avgt   20    116287.184 ±   1580.840  ns/op
[info] OrderAwareHashMapBenchmark.javaGetNone            100  avgt   20       748.969 ±     12.333  ns/op
[info] OrderAwareHashMapBenchmark.javaGetNone           1000  avgt   20      8660.554 ±    115.736  ns/op
[info] OrderAwareHashMapBenchmark.javaGetNone          10000  avgt   20    124993.543 ±   4842.760  ns/op
[info] OrderAwareHashMapBenchmark.javaIterateEntries     100  avgt   20       646.117 ±      9.328  ns/op
[info] OrderAwareHashMapBenchmark.javaIterateEntries    1000  avgt   20      7053.389 ±     49.033  ns/op
[info] OrderAwareHashMapBenchmark.javaIterateEntries   10000  avgt   20     91628.388 ±   1493.768  ns/op
[info] OrderAwareHashMapBenchmark.javaIterateKeys        100  avgt   20       660.341 ±      9.498  ns/op
[info] OrderAwareHashMapBenchmark.javaIterateKeys       1000  avgt   20      7221.019 ±    120.893  ns/op
[info] OrderAwareHashMapBenchmark.javaIterateKeys      10000  avgt   20     88045.309 ±   1060.025  ns/op
[info] OrderAwareHashMapBenchmark.oaBuild                100  avgt   20      1478.120 ±     11.852  ns/op
[info] OrderAwareHashMapBenchmark.oaBuild               1000  avgt   20     14882.973 ±    128.385  ns/op
[info] OrderAwareHashMapBenchmark.oaBuild              10000  avgt   20    162302.955 ±   1962.691  ns/op
[info] OrderAwareHashMapBenchmark.oaFillColliding        100  avgt   20      8687.708 ±     68.726  ns/op
[info] OrderAwareHashMapBenchmark.oaFillColliding       1000  avgt   20    194464.736 ±   2540.554  ns/op
[info] OrderAwareHashMapBenchmark.oaFillColliding      10000  avgt   20   2713781.773 ±  37586.106  ns/op
[info] OrderAwareHashMapBenchmark.oaFillDoS              100  avgt   20     12770.699 ±    123.557  ns/op
[info] OrderAwareHashMapBenchmark.oaFillDoS             1000  avgt   20    247698.804 ±   4469.197  ns/op
[info] OrderAwareHashMapBenchmark.oaFillDoS            10000  avgt   20   3452773.773 ±  68316.753  ns/op
[info] OrderAwareHashMapBenchmark.oaFillRegular          100  avgt   20      3511.814 ±     40.394  ns/op
[info] OrderAwareHashMapBenchmark.oaFillRegular         1000  avgt   20     30937.939 ±    341.542  ns/op
[info] OrderAwareHashMapBenchmark.oaFillRegular        10000  avgt   20    303128.611 ±   3761.797  ns/op
[info] OrderAwareHashMapBenchmark.oaGetExisting          100  avgt   20       901.374 ±     56.706  ns/op
[info] OrderAwareHashMapBenchmark.oaGetExisting         1000  avgt   20      9397.086 ±    169.353  ns/op
[info] OrderAwareHashMapBenchmark.oaGetExisting        10000  avgt   20    101547.858 ±   1534.589  ns/op
[info] OrderAwareHashMapBenchmark.oaGetNone              100  avgt   20       725.748 ±     22.510  ns/op
[info] OrderAwareHashMapBenchmark.oaGetNone             1000  avgt   20      8458.053 ±    542.173  ns/op
[info] OrderAwareHashMapBenchmark.oaGetNone            10000  avgt   20    119077.530 ±   2957.570  ns/op
[info] OrderAwareHashMapBenchmark.oaIterateEntries       100  avgt   20      1267.887 ±     15.472  ns/op
[info] OrderAwareHashMapBenchmark.oaIterateEntries      1000  avgt   20     12647.641 ±    194.028  ns/op
[info] OrderAwareHashMapBenchmark.oaIterateEntries     10000  avgt   20    146443.705 ±   8787.324  ns/op
[info] OrderAwareHashMapBenchmark.oaIterateKeys          100  avgt   20       765.175 ±     17.808  ns/op
[info] OrderAwareHashMapBenchmark.oaIterateKeys         1000  avgt   20      7667.263 ±    100.420  ns/op
[info] OrderAwareHashMapBenchmark.oaIterateKeys        10000  avgt   20     90741.446 ±   1834.352  ns/op
```