### PR TITLE
Repair efficiency of product based part of hash code in MurmurHash3.unorderedHash for collections with size > 30

### DIFF
--- a/src/library/scala/util/hashing/MurmurHash3.scala
+++ b/src/library/scala/util/hashing/MurmurHash3.scala
@@ -96,7 +96,7 @@ private[hashing] class MurmurHash3 {
       val h = x.##
       a += h
       b ^= h
-      if (h != 0) c *= h
+      c *= h | 1
       n += 1
     }
     var h = seed

--- a/test/junit/scala/collection/immutable/ChampMapSmokeTest.scala
+++ b/test/junit/scala/collection/immutable/ChampMapSmokeTest.scala
@@ -254,6 +254,6 @@ class ChampMapSmokeTest {
   }
 
   @Test def hashCodeCheck(): Unit = {
-    assertEquals(359703249, collection.immutable.HashMap(1 -> 2).hashCode())
+    assertEquals(892962596, collection.immutable.HashMap(1 -> 2).hashCode())
   }
 }


### PR DESCRIPTION
Should fix https://github.com/scala/bug/issues/10840