### PR TITLE
Don't try to issue type mismatch errors for erroneous anon classes

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1035,7 +1035,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         val boundOrSkolems = if (canIgnoreMismatch) bound ++ pt.skolemsExceptMethodTypeParams else Nil
         boundOrSkolems match {
-          case Nil => AdaptTypeError(tree, tree.tpe, pt) ; setError(tree)
+          case Nil => AdaptTypeError(tree, tree.tpe, pt)
           case _   => logResult(msg)(adapt(tree, mode, deriveTypeWithWildcards(boundOrSkolems)(pt)))
         }
       }

--- a/test/files/neg/t10003.check
+++ b/test/files/neg/t10003.check
@@ -1,0 +1,4 @@
+t10003.scala:4: error: illegal cyclic reference involving type List
+    new Functor[a] { type List[t] = List[t] }
+                                    ^
+one error found

--- a/test/files/neg/t10003.scala
+++ b/test/files/neg/t10003.scala
@@ -1,0 +1,5 @@
+trait Functor[a] { type MyType[a] }
+object Functor {
+  def listFunctor[a]: Functor[a] { type MyType[x] = List[x] } =
+    new Functor[a] { type List[t] = List[t] }
+}

--- a/test/files/neg/t10015.check
+++ b/test/files/neg/t10015.check
@@ -1,0 +1,7 @@
+t10015.scala:3: error: not found: type Baz
+  f (new Baz { def g })
+         ^
+t10015.scala:3: error: only traits and abstract classes can have declared but undefined members
+  f (new Baz { def g })
+                   ^
+two errors found

--- a/test/files/neg/t10015.scala
+++ b/test/files/neg/t10015.scala
@@ -1,0 +1,4 @@
+class Bar {
+  def f (x : { def g }) {}
+  f (new Baz { def g })
+}

--- a/test/files/neg/t10803.check
+++ b/test/files/neg/t10803.check
@@ -1,0 +1,10 @@
+t10803.scala:4: error: not found: type CocartesianMonoidalCategory
+  val sum: CocartesianMonoidalCategory[F] {
+           ^
+t10803.scala:18: error: not found: type CCC
+    } = new SymmetricDistributiveCategory[Function1] with CCC[Function1] { self =>
+                                                          ^
+t10803.scala:20: error: not found: type CocartesianMonoidalCategory
+      val sum = new CocartesianMonoidalCategory[F] {}
+                    ^
+three errors found

--- a/test/files/neg/t10803.scala
+++ b/test/files/neg/t10803.scala
@@ -1,0 +1,23 @@
+import scala.language.higherKinds
+
+trait DistributiveCategory[F[_, _]] { self =>
+  val sum: CocartesianMonoidalCategory[F] {
+    type Unit = self.Zero
+  }
+}
+
+object DistributiveCategory {
+  trait SymmetricDistributiveCategory[F[_, _]]
+
+  object instances {
+    type Void
+    type Dummy
+
+    implicit val function1: SymmetricDistributiveCategory[Function1] {
+      type Obj[A]
+    } = new SymmetricDistributiveCategory[Function1] with CCC[Function1] { self =>
+      type Zero
+      val sum = new CocartesianMonoidalCategory[F] {}
+    }
+  }
+}

--- a/test/files/neg/t11337.check
+++ b/test/files/neg/t11337.check
@@ -1,0 +1,4 @@
+t11337.scala:3: error: trait Foo takes type parameters
+  val foo: Foo[Any] { type Bar = Any } = new Foo { def baz(): Any = () }
+                                             ^
+one error found

--- a/test/files/neg/t11337.scala
+++ b/test/files/neg/t11337.scala
@@ -1,0 +1,4 @@
+trait Foo[T]
+object Foo {
+  val foo: Foo[Any] { type Bar = Any } = new Foo { def baz(): Any = () }
+}

--- a/test/files/neg/t1472.check
+++ b/test/files/neg/t1472.check
@@ -1,0 +1,7 @@
+t1472.scala:7: error: illegal cyclic reference involving type Utmp
+    val a : (SA { type U = Utmp })
+                           ^
+t1472.scala:12: error: illegal cyclic reference involving type U
+    type Ttmp = this.a.type#T
+                     ^
+two errors found

--- a/test/files/neg/t1472.scala
+++ b/test/files/neg/t1472.scala
@@ -1,0 +1,16 @@
+object Test extends App {
+  type SA = { type U; type T; val f : T => (U, T) }
+  type SB = { type U; type T; val g : T => (U, T) }
+
+  type S = { type Utmp = this.b.type#U
+    type Ttmp = this.a.type#T
+    val a : (SA { type U = Utmp })
+    val b : (SB { type T = Ttmp }) }
+
+  val AB : S = new { self =>
+    type Utmp = this.b.type#U
+    type Ttmp = this.a.type#T
+    val a : (SA { type U = self.type#Utmp }) = null
+    val b : (SB { type T = self.type#Ttmp }) = null
+  }
+}

--- a/test/files/neg/t9361.check
+++ b/test/files/neg/t9361.check
@@ -3,9 +3,4 @@ t9361.scala:4: error: type mismatch;
  required: Nothing[]
     new Foo { def tc = null.asInstanceOf[Tc[_]] }
                                         ^
-t9361.scala:4: error: type mismatch;
- found   : Foo[Nothing]
- required: Foo[Tc]{type T = Nothing}
-    new Foo { def tc = null.asInstanceOf[Tc[_]] }
-    ^
-two errors found
+one error found

--- a/test/files/neg/t9960.check
+++ b/test/files/neg/t9960.check
@@ -1,0 +1,4 @@
+t9960.scala:27: error: could not find implicit value for parameter m: NNN.Aux[NNN.Reader,NNN.FxAppend[NNN.Fx1[NNN.Task],NNN.Fx2[NNN.Validate,NNN.Reader]],U]
+      val hhhh: Eff[Fx2[Task, Validate], Unit] = runReader(gggg)
+                                                          ^
+one error found

--- a/test/files/neg/t9960.scala
+++ b/test/files/neg/t9960.scala
@@ -1,0 +1,30 @@
+import scala.language.higherKinds
+
+object NNN {
+  class Validate[A]
+  class Task[A]
+  class Fx2[M[_], N[_]]
+  class Fx1[M[_]]
+  class Eff[R, A]
+  class Reader[A]
+  final case class FxAppend[L, R](left: L, right: R)
+  trait Member[T[_], R]{
+    type Out
+  }
+
+  type Aux[T[_], R, U] = Member[T, R] { type Out = U }
+
+  implicit def Member3L[T[_], L[_],  R[_]]: Aux[T, FxAppend[Fx1[T], Fx2[L, R]], Fx2[L, R]] =
+    new Member[T, FxAppend[Fx1[T], Fx2[L,  R]]] { outer =>
+      type Out = Fx2[L,  R]
+    }
+
+  object TheTest {
+    def runReader[R, U, B](r: Eff[R, B])(implicit m: Aux[Reader, R, U]): Eff[U, B] = ???
+
+    def helper(): Unit = {
+      val gggg: Eff[FxAppend[Fx1[Task], Fx2[Validate, Reader]], Unit] = ???
+      val hhhh: Eff[Fx2[Task, Validate], Unit] = runReader(gggg)
+    }
+  }
+}


### PR DESCRIPTION
Errors will be issued at the anonymous class definition site.
It would be fruitless and maybe even misleading to issue a type
mismatch error. What is even the type of an erroneous definition?

Fixes scala/bug#11337
Fixes scala/bug#10803
Fixes scala/bug#10015
Fixes scala/bug#10003
Fixes scala/bug#9960
Fixes scala/bug#1472