### PR TITLE
[SUPERSEDED] Take CR as line terminator in linesIterator

### DIFF
--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -588,7 +588,8 @@ final class StringOps(private val s: String) extends AnyVal {
     }
   }
 
-  @inline private[this] def isLineBreak(c: Char) = c == LF || c == FF
+  @`inline` private[this] def isLineBreak(c: Char) = c == CR || c == LF || c == FF
+  @`inline` private[this] def isLineBreak2(c0: Char, c: Char) = c0 == CR && c == LF
 
   /**
     *  Strip trailing line end character from this string if it has one.
@@ -600,17 +601,15 @@ final class StringOps(private val s: String) extends AnyVal {
     *  If a line feed character `LF` is preceded by a carriage return `CR`
     *  (`0x0D` hex), the `CR` character is also stripped (Windows convention).
     */
-  def stripLineEnd: String = {
-    val len = s.length
-    if (len == 0) s
-    else {
-      val last = apply(len - 1)
-      if (isLineBreak(last))
-        s.substring(0, if (last == LF && len >= 2 && apply(len - 2) == CR) len - 2 else len - 1)
-      else
-        s
-    }
-  }
+  def stripLineEnd: String =
+    if (!s.isEmpty) {
+      var i = s.length - 1
+      val last = apply(i)
+      if (isLineBreak(last)) {
+        if (i > 0 && isLineBreak2(apply(i - 1), last)) i -= 1
+        s.substring(0, i)
+      } else s
+    } else s
 
   /** Return all lines in this string in an iterator, including trailing
     *  line end characters.
@@ -623,16 +622,33 @@ final class StringOps(private val s: String) extends AnyVal {
     *  - `LF` - line feed   (`0x0A`)
     *  - `FF` - form feed   (`0x0C`)
     */
-  def linesWithSeparators: Iterator[String] = new AbstractIterator[String] {
+  def linesWithSeparators: Iterator[String] = linesSeparated(stripped = false)
+
+  /** Lines in this string, where a line is terminated by
+   *  `"\n"`, `"\r"`, `"\r\n"`, `"\f"`, or the end of the string.
+   *  A line may be empty. Line terminators are removed.
+   */
+  def linesIterator: Iterator[String] = linesSeparated(stripped = true)
+
+  // if `stripped`, exclude the line separators
+  private def linesSeparated(stripped: Boolean): Iterator[String] = new AbstractIterator[String] {
+    def hasNext: Boolean = !done
+    def next(): String = if (done) Iterator.empty.next() else advance()
+
     private[this] val len = s.length
     private[this] var index = 0
-    def hasNext: Boolean = index < len
-    def next(): String = {
-      if (index >= len) Iterator.empty.next()
+    @`inline` private def done = index >= len
+    private def advance(): String = {
       val start = index
-      while (index < len && !isLineBreak(apply(index))) index += 1
-      index += 1
-      s.substring(start, index min len)
+      while (!done && !isLineBreak(apply(index))) index += 1
+      var end   = index
+      if (!done) {
+        val c = apply(index)
+        index += 1
+        if (!done && isLineBreak2(c, apply(index))) index += 1
+        if (!stripped) end = index
+      }
+      s.substring(start, end)
     }
   }
 
@@ -640,16 +656,8 @@ final class StringOps(private val s: String) extends AnyVal {
     *  end characters; i.e., apply `.stripLineEnd` to all lines
     *  returned by `linesWithSeparators`.
     */
-  def linesIterator: Iterator[String] =
-    linesWithSeparators map (_.stripLineEnd)
-
-  /** Return all lines in this string in an iterator, excluding trailing line
-    *  end characters; i.e., apply `.stripLineEnd` to all lines
-    *  returned by `linesWithSeparators`.
-    */
-  @deprecated("Use .linesIterator, because JDK 11 adds a `lines` method on String", "2.13.0")
-  def lines: Iterator[String] =
-    linesWithSeparators map (_.stripLineEnd)
+  @deprecated("Use `linesIterator`, because JDK 11 adds a `lines` method on String", "2.13.0")
+  def lines: Iterator[String] = linesIterator
 
   /** Returns this string with first character converted to upper case.
     * If the first character of the string is capitalized, it is returned unchanged.
@@ -693,10 +701,10 @@ final class StringOps(private val s: String) extends AnyVal {
       val len = line.length
       var index = 0
       while (index < len && line.charAt(index) <= ' ') index += 1
-      sb.append {
+      val stripped =
         if (index < len && line.charAt(index) == marginChar) line.substring(index + 1)
         else line
-      }
+      sb.append(stripped)
     }
     sb.toString
   }

--- a/test/junit/scala/collection/immutable/StringLikeTest.scala
+++ b/test/junit/scala/collection/immutable/StringLikeTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil
+import scala.tools.testing.AssertUtil._
 import scala.util.Random
 
 /* Test for scala/bug#8988 */
@@ -23,7 +23,7 @@ class StringLikeTest {
       // make sure we can match a literal character done by Java's split
       val jSplit = jString.split("\\Q" + c.toString + "\\E")
       val sSplit = s.split(c)
-      AssertUtil.assertSameElements(jSplit, sSplit, s"Not same result as Java split for char $c in string $s")
+      assertSameElements(jSplit, sSplit, s"Not same result as Java split for char $c in string $s")
     }
   }
 
@@ -34,12 +34,12 @@ class StringLikeTest {
     val surrogatepair = List(high, low).mkString
     val twopairs = surrogatepair + "_" + surrogatepair
     
-    AssertUtil.assertSameElements("abcd".split('d'), Array("abc")) // not Array("abc", "")
-    AssertUtil.assertSameElements("abccc".split('c'), Array("ab")) // not Array("ab", "", "", "")
-    AssertUtil.assertSameElements("xxx".split('x'), Array[String]()) // not Array("", "", "", "")
-    AssertUtil.assertSameElements("".split('x'), Array("")) // not Array()
-    AssertUtil.assertSameElements("--ch--omp--".split("-"), Array("", "", "ch", "", "omp")) // All the cases!
-    AssertUtil.assertSameElements(twopairs.split(high), Array(twopairs)) //don't split on characters that are half a surrogate pair
+    assertSameElements("abcd".split('d'), Array("abc")) // not Array("abc", "")
+    assertSameElements("abccc".split('c'), Array("ab")) // not Array("ab", "", "", "")
+    assertSameElements("xxx".split('x'), Array[String]()) // not Array("", "", "", "")
+    assertSameElements("".split('x'), Array("")) // not Array()
+    assertSameElements("--ch--omp--".split("-"), Array("", "", "ch", "", "omp")) // All the cases!
+    assertSameElements(twopairs.split(high), Array(twopairs)) //don't split on characters that are half a surrogate pair
   }
 
   /* Test for scala/bug#9767 */
@@ -49,26 +49,59 @@ class StringLikeTest {
     val sOk  = "2"
     val sNull:String = null
 
-    AssertUtil.assertThrows[java.lang.NumberFormatException](sOne.toInt)
-    AssertUtil.assertThrows[java.lang.NumberFormatException](sOne.toLong)
-    AssertUtil.assertThrows[java.lang.NumberFormatException](sOne.toShort)
-    AssertUtil.assertThrows[java.lang.NumberFormatException](sOne.toByte)
-    assertTrue("trim toDouble", sOne.toDouble == 1.0d)
-    assertTrue("trim toFloat", sOne.toFloat == 1.0f)
+    assertThrows[java.lang.NumberFormatException](sOne.toInt)
+    assertThrows[java.lang.NumberFormatException](sOne.toLong)
+    assertThrows[java.lang.NumberFormatException](sOne.toShort)
+    assertThrows[java.lang.NumberFormatException](sOne.toByte)
+    assertEquals("trim toDouble", 1.0d, sOne.toDouble, 0.1d)
+    assertEquals("trim toDouble", 1.0d, sOne.toDouble, 0.1d)
+    assertEquals("trim toFloat", 1.0f, sOne.toFloat, 0.1f)
 
-    assertTrue("no trim toInt", sOk.toInt == 2)
-    assertTrue("no trim toLong", sOk.toLong == 2L)
-    assertTrue("no trim toShort", sOk.toShort == 2.toShort)
-    assertTrue("no trim toByte", sOk.toByte == 2.toByte)
-    assertTrue("no trim toDouble", sOk.toDouble == 2.0d)
-    assertTrue("no trim toFloat", sOk.toFloat == 2.0f)
+    assertEquals("no trim toInt", 2, sOk.toInt)
+    assertEquals("no trim toLong", 2L, sOk.toLong)
+    assertEquals("no trim toShort",  2.toShort, sOk.toShort)
+    assertEquals("no trim toByte", 2.toByte, sOk.toByte)
+    assertEquals("no trim toDouble", 2.0d, sOk.toDouble, 0.1d)
+    assertEquals("no trim toFloat", 2.0f, sOk.toFloat, 0.1f)
 
-    AssertUtil.assertThrows[java.lang.NumberFormatException](sNull.toInt, {s => s == "null"})
-    AssertUtil.assertThrows[java.lang.NumberFormatException](sNull.toLong, {s => s == "null"})
-    AssertUtil.assertThrows[java.lang.NumberFormatException](sNull.toShort, {s => s == "null"})
-    AssertUtil.assertThrows[java.lang.NumberFormatException](sNull.toByte, {s => s == "null"})
+    assertThrows[java.lang.NumberFormatException](sNull.toInt, {s => s == "null"})
+    assertThrows[java.lang.NumberFormatException](sNull.toLong, {s => s == "null"})
+    assertThrows[java.lang.NumberFormatException](sNull.toShort, {s => s == "null"})
+    assertThrows[java.lang.NumberFormatException](sNull.toByte, {s => s == "null"})
 
-    AssertUtil.assertThrows[java.lang.NullPointerException](sNull.toDouble)
-    AssertUtil.assertThrows[java.lang.NullPointerException](sNull.toFloat)
+    assertThrows[java.lang.NullPointerException](sNull.toDouble)
+    assertThrows[java.lang.NullPointerException](sNull.toFloat)
+  }
+
+  @Test
+  def `line split on CR`(): Unit = {
+    assertEquals(2, "abc\r\ndef".linesIterator.size)
+    assertEquals(2, "abc\rdef".linesIterator.size)
+  }
+
+  @Test
+  def `line split on NL, FF`(): Unit = {
+    assertEquals(2, "abc\ndef".linesIterator.size)
+    assertEquals(2, "abc\fdef".linesIterator.size)
+    assertEquals(2, "abc\ndef\n".linesIterator.size)
+
+    // status quo
+    assertEquals(3, "abc\n\fdef".linesIterator.size)
+    assertEquals(4, "abc\n\f\ndef".linesIterator.size)
+    //assertEquals(2, "abc\n\fdef".linesIterator.size)
+    //assertEquals(3, "abc\n\f\ndef".linesIterator.size)
+    //
+
+    assertSameElements(List("abc", "def"), "abc\ndef".linesIterator)
+  }
+
+  @Test
+  def `strip line endings`(): Unit = {
+    assertEquals("abc", "abc".stripLineEnd)
+    assertEquals("abc", "abc\n".stripLineEnd)
+    assertEquals("abc\n", "abc\n\n".stripLineEnd)
+    assertEquals("abc", "abc\r\n".stripLineEnd)
+    assertEquals("abc\r\n", "abc\r\n\f".stripLineEnd)
+    assertEquals("abc", "abc\f".stripLineEnd)
   }
 }

--- a/test/scalacheck/scala/collection/StringOpsProps.scala
+++ b/test/scalacheck/scala/collection/StringOpsProps.scala
@@ -1,0 +1,32 @@
+
+package scala.collection
+
+import java.io.{BufferedReader, StringReader}
+
+import org.scalacheck.{Gen, Properties}, Gen.{oneOf, listOf}
+import org.scalacheck.Prop._
+
+import JavaConverters._
+
+object StringOpsTest extends Properties("StringOps") {
+
+  val lineChar: Gen[Char] = oneOf('X', '\r', '\n')
+
+  val line = listOf(lineChar).map(_.mkString)
+
+  property("linesIterator tracks BufferedReader.lines") = forAll(line) { s =>
+    val r = new BufferedReader(new StringReader(s))
+
+    s.linesIterator.sameElements(r.lines.iterator.asScala)
+  }
+
+  property("linesIterator returns stripped lines") = forAll(line) { s =>
+    s.linesIterator.sameElements(s.linesWithSeparators.map(_.stripLineEnd))
+  }
+
+  property("when string contains a terminator, WithSeparators is longer") = forAll(line) { s =>
+    val hasEOL = s.exists(c => c == '\r' || c == '\n')
+    if (hasEOL) s.linesIterator.map(_.length).sum < s.linesWithSeparators.map(_.length).sum
+    else s.linesIterator.map(_.length).sum == s.linesWithSeparators.map(_.length).sum
+  }
+}


### PR DESCRIPTION
Lines can end in CR, CRNL, NL or FF.

The FF convention does not receive much attention; the compiler also takes FF.

Possibly, NL-FF should count as one line and not two; that is, the special handling would be only that FF not trailing a normal line terminator would also terminate.

swing at scala/bug#11241