### PR TITLE
Regression tests for Bugs 9485, 9963, 8584.

### DIFF
--- a/test/files/neg/t9963.check
+++ b/test/files/neg/t9963.check
@@ -1,0 +1,4 @@
+t9963.scala:14: error: value withFilter is not a member of t9963.MySet[A]
+    j: A <- new MySet[A]() // must have a typecheck patmat here to trigger this bug
+            ^
+one error found

--- a/test/files/neg/t9963.scala
+++ b/test/files/neg/t9963.scala
@@ -1,0 +1,16 @@
+object t9963 {
+  class MyIterable[+A] {
+    def flatMap[B](f: A => MyIterable[B]): MyIterable[B] = ???
+    def map[B](f: A => B): MyIterable[B] = ???
+  }
+
+  class MySet[A] {
+    def map[B: Equiv](f: A => B): MySet[B] = ??? // must have an implicit typeclass here to trigger this bug
+    def filter(f: A => Boolean): MySet[A] = ???
+  }
+
+  def f[A] = for {
+    i <- new MyIterable[A]()
+    j: A <- new MySet[A]() // must have a typecheck patmat here to trigger this bug
+  } yield (i, j)
+}

--- a/test/files/pos/t8584.scala
+++ b/test/files/pos/t8584.scala
@@ -1,0 +1,19 @@
+trait A {
+  def x: Double
+  def y: Double
+
+  def thisA: A
+  def copy( x: Double = 0, y: Double = 0 ): A
+}
+
+class B( in: A ) {
+  import in._
+
+  def foo( a: Double, b: Double ) = a
+
+  def bar = thisA.copy(
+    x = foo(
+      b = 1,
+      a = 2 )
+  )
+}

--- a/test/files/pos/t9485.scala
+++ b/test/files/pos/t9485.scala
@@ -1,0 +1,17 @@
+trait Traversable[+A] {
+  def flatMap[B](f: A => Traversable[B]): Traversable[B] = ???
+}
+
+trait Iterable[+A] extends Traversable[A] {
+  def flatMap[B](f: A => Iterable[B]): Iterable[B] = ???
+}
+
+trait Seq[+A] extends Iterable[A] {
+  def flatMap[B](f: A => Seq[B]): Seq[B] = ???
+}
+
+object Test extends App {
+  val a: Seq[Int] = new Seq[Int] {}
+  val b: Iterable[Int] = new Iterable[Int] {}
+  a.flatMap(i => b)
+}


### PR DESCRIPTION
Closes https://github.com/scala/bug/issues/9485, which bug has already been fixed in branch 2.12.8.
Closes https://github.com/scala/bug/issues/9963, in the same way.
Closes https://github.com/scala/bug/issues/8584, also solved by version 2.12.7 and 2.12.8. 