### PR TITLE
Move the `trait Manifest` to the `package object reflect`.

### DIFF
--- a/src/library/scala/reflect/package.scala
+++ b/src/library/scala/reflect/package.scala
@@ -47,6 +47,56 @@ package object reflect {
   @deprecated("use scala.reflect.ClassTag instead", "2.10.0")
   val ClassManifest = ClassManifestFactory
 
+  /** A `Manifest[T]` is an opaque descriptor for type T.  Its supported use
+   *  is to give access to the erasure of the type as a `Class` instance, as
+   *  is necessary for the creation of native `Arrays` if the class is not
+   *  known at compile time.
+   *
+   *  The type-relation operators `<:<` and `=:=` should be considered
+   *  approximations only, as there are numerous aspects of type conformance
+   *  which are not yet adequately represented in manifests.
+   *
+   *  Example usages:
+   *  {{{
+   *    def arr[T] = new Array[T](0)                          // does not compile
+   *    def arr[T](implicit m: Manifest[T]) = new Array[T](0) // compiles
+   *    def arr[T: Manifest] = new Array[T](0)                // shorthand for the preceding
+   *
+   *    // Methods manifest and optManifest are in [[scala.Predef]].
+   *    def isApproxSubType[T: Manifest, U: Manifest] = manifest[T] <:< manifest[U]
+   *    isApproxSubType[List[String], List[AnyRef]] // true
+   *    isApproxSubType[List[String], List[Int]]    // false
+   *
+   *    def methods[T: Manifest] = manifest[T].runtimeClass.getMethods
+   *    def retType[T: Manifest](name: String) =
+   *      methods[T] find (_.getName == name) map (_.getGenericReturnType)
+   *
+   *    retType[Map[_, _]]("values")  // Some(scala.collection.Iterable<B>)
+   *  }}}
+   */
+  @scala.annotation.implicitNotFound(msg = "No Manifest available for ${T}.")
+  // TODO undeprecated until Scala reflection becomes non-experimental
+  // @deprecated("use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
+  trait Manifest[T] extends ClassManifest[T] with Equals {
+    override def typeArguments: List[Manifest[_]] = Nil
+
+    override def arrayManifest: Manifest[Array[T]] =
+      Manifest.classType[Array[T]](arrayClass[T](runtimeClass), this)
+
+    override def canEqual(that: Any): Boolean = that match {
+      case _: Manifest[_]   => true
+      case _                => false
+    }
+    /** Note: testing for erasure here is important, as it is many times
+     *  faster than <:< and rules out most comparisons.
+     */
+    override def equals(that: Any): Boolean = that match {
+      case m: Manifest[_] => (m canEqual this) && (this.runtimeClass == m.runtimeClass) && (this <:< m) && (m <:< this)
+      case _              => false
+    }
+    override def hashCode = this.runtimeClass.##
+  }
+
   /** The object `Manifest` defines factory methods for manifests.
    *  It is intended for use by the compiler and should not be used in client code.
    */

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -526,7 +526,7 @@ trait Definitions extends api.StandardDefinitions {
          def UniverseInternal = getMemberValue(UniverseClass, nme.internal)
 
     lazy val PartialManifestModule = requiredModule[scala.reflect.ClassManifestFactory.type]
-    lazy val FullManifestClass     = requiredClass[scala.reflect.Manifest[_]]
+    lazy val FullManifestClass     = getClassIfDefined("scala.reflect.Manifest").orElse(getMemberClass(ReflectPackage, newTypeName("Manifest"))) // first alternative necessary until next re-starr
     lazy val FullManifestModule    = requiredModule[scala.reflect.ManifestFactory.type]
     lazy val OptManifestClass      = requiredClass[scala.reflect.OptManifest[_]]
     lazy val NoManifest            = requiredModule[scala.reflect.NoManifest.type]

--- a/test/files/run/primitive-sigs-2-old.check
+++ b/test/files/run/primitive-sigs-2-old.check
@@ -1,7 +1,7 @@
 T<java.lang.Object>
 List(A, char, class java.lang.Object)
 a
-public <T> java.lang.Object Arr.arr4(java.lang.Object[],scala.reflect.Manifest<T>)
+public <T> java.lang.Object Arr.arr4(java.lang.Object[],scala.reflect.package$Manifest<T>)
 public float[] Arr.arr3(float[][])
 public scala.collection.immutable.List<java.lang.Character> Arr.arr2(java.lang.Character[])
 public scala.collection.immutable.List<java.lang.Object> Arr.arr1(int[])


### PR DESCRIPTION
There is already a `val Manifest` in the package object, so the trait of the same name should also be in the package object. Otherwise, in some weird circumstances, like somehow while building Scala.js in the community build (but only in the community build), we get a compile error saying that `Manifest` is already defined in the package object.

See also https://github.com/scala/community-builds/pull/829. Note that merging this PR will not *yet* be enough for Scala.js to compile, since it will have a cascading effect on Scala.js having to adapt its own copy of `Manifest.scala` to reflect the move.