### PR TITLE
Clean up StrictOptimizedOps traits

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -342,7 +342,6 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   @deprecated("Use .view.slice(from, until) instead of .view(from, until)", "2.13.0")
   @`inline` final def view(from: Int, until: Int): View[A] = view.slice(from, until)
 
-  //TODO Can there be a useful lazy implementation of this method? Otherwise mark it as being always strict
   /** Transposes this $coll of iterable collections into
     *  a $coll of ${coll}s.
     *
@@ -526,7 +525,9 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     drop(1)
   }
 
-  /** The initial part of the collection without its last element. */
+  /** The initial part of the collection without its last element.
+    * $willForceEvaluation
+    */
   def init: C = {
     if (isEmpty) throw new UnsupportedOperationException
     dropRight(1)
@@ -612,6 +613,8 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     *   def occurrences[A](as: Seq[A]): Map[A, Int] =
     *     as.groupMapReduce(identity)(_ => 1)(_ + _)
     * }}}
+    *
+    * $willForceEvaluation
     */
   def groupMapReduce[K, B](key: A => K)(f: A => B)(reduce: (B, B) => B): immutable.Map[K, B] = {
     val m = mutable.Map.empty[K, B]
@@ -646,6 +649,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     *  The head of the collection is the last cumulative result.
     *  $willNotTerminateInf
     *  $orderDependent
+    *  $willForceEvaluation
     *
     *  Example:
     *  {{{
@@ -817,6 +821,8 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   /** Iterates over the inits of this $coll. The first value will be this
     *  $coll and the final one will be an empty $coll, with the intervening
     *  values the results of successive applications of `init`.
+    *
+    *  $willForceEvaluation
     *
     *  @return  an iterator over all the inits of this $coll
     *  @example  `List(1,2,3).inits = Iterator(List(1,2,3), List(1,2), List(1), Nil)`

--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -224,7 +224,7 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeq
     Iterator.iterate(coll)(_.tail).takeWhile(_.nonEmpty) ++ Iterator.single(newSpecificBuilder.result())
 }
 
-trait StrictOptimizedLinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with StrictOptimizedLinearSeqOps[A, CC, C]] extends LinearSeqOps[A, CC, C] with StrictOptimizedSeqOps[A, CC, C] {
+trait StrictOptimizedLinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with StrictOptimizedLinearSeqOps[A, CC, C]] extends Any with LinearSeqOps[A, CC, C] with StrictOptimizedSeqOps[A, CC, C] {
   // A more efficient iterator implementation than the default LinearSeqIterator
   override def iterator: Iterator[A] = new AbstractIterator[A] {
     private[this] var current: Iterable[A] = toIterable

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -225,6 +225,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   /** Returns new $coll with elements in reversed order.
    *
    *  $willNotTerminateInf
+   *  $willForceEvaluation
    *
    *  @return A new $coll with all elements of this $coll in reversed order.
    */
@@ -681,6 +682,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Sorts this $coll according to a comparison function.
     *  $willNotTerminateInf
+    *  $willForceEvaluation
     *
     *  The sort is stable. That is, elements that are equal (as determined by
     *  `lt`) appear in the same order in the sorted sequence as in the original.
@@ -700,6 +702,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   /** Sorts this $coll according to the Ordering which results from transforming
     * an implicitly given Ordering with a transformation function.
     * $willNotTerminateInf
+    * $willForceEvaluation
     *
     * The sort is stable. That is, elements that are equal (as determined by
     * `ord.compare`) appear in the same order in the sorted sequence as in the original.
@@ -724,6 +727,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   def sortBy[B](f: A => B)(implicit ord: Ordering[B]): C = sorted(ord on f)
 
   /** Produces the range of all indices of this sequence.
+    * $willForceEvaluation
     *
     *  @return  a `Range` value from `0` to one less than the length of this $coll.
     */

--- a/src/library/scala/collection/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSeqOps.scala
@@ -20,8 +20,8 @@ import scala.language.higherKinds
   */
 trait StrictOptimizedSeqOps [+A, +CC[_], +C]
   extends Any
-    with StrictOptimizedIterableOps[A, CC, C]
-    with SeqOps[A, CC, C] {
+    with SeqOps[A, CC, C]
+    with StrictOptimizedIterableOps[A, CC, C] {
 
   override def distinctBy[B](f: A => B): C = {
     val builder = newSpecificBuilder

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -30,7 +30,6 @@ sealed abstract class BitSet
   extends AbstractSet[Int]
     with SortedSet[Int]
     with SortedSetOps[Int, SortedSet, BitSet]
-    with StrictOptimizedIterableOps[Int, Set, BitSet]
     with StrictOptimizedSortedSetOps[Int, SortedSet, BitSet]
     with collection.BitSet
     with collection.BitSetOps[BitSet] {

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -19,7 +19,7 @@ import java.lang.System.arraycopy
 import scala.annotation.unchecked.{uncheckedVariance => uV}
 import scala.collection.Hashing.improve
 import scala.collection.mutable.Builder
-import scala.collection.{Iterator, MapFactory, StrictOptimizedIterableOps, StrictOptimizedMapOps, mutable}
+import scala.collection.{Iterator, MapFactory, StrictOptimizedIterableOps, mutable}
 import scala.util.hashing.MurmurHash3
 import scala.runtime.Statics.releaseFence
 
@@ -37,8 +37,6 @@ import scala.runtime.Statics.releaseFence
 
 final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: MapNode[K, V])
   extends AbstractMap[K, V]
-    with MapOps[K, V, HashMap, HashMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), Iterable, HashMap[K, V]]
     with StrictOptimizedMapOps[K, V, HashMap, HashMap[K, V]] {
 
   def this() = this(MapNode.empty)

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -34,8 +34,7 @@ import scala.runtime.Statics.releaseFence
   */
 final class HashSet[A] private[immutable] (val rootNode: SetNode[A])
   extends AbstractSet[A]
-    with SetOps[A, HashSet, HashSet[A]]
-    with StrictOptimizedIterableOps[A, HashSet, HashSet[A]] {
+    with StrictOptimizedSetOps[A, HashSet, HashSet[A]] {
 
   releaseFence()
 

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -180,8 +180,7 @@ import IntMap._
   *  @define willNotTerminateInf
   */
 sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
-  with MapOps[Int, T, Map, IntMap[T]]
-  with StrictOptimizedIterableOps[(Int, T), Iterable, IntMap[T]] {
+  with StrictOptimizedMapOps[Int, T, Map, IntMap[T]] {
 
   override protected def fromSpecific(coll: scala.collection.IterableOnce[(Int, T) @uncheckedVariance]): IntMap[T] =
     intMapFrom[T](coll)

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -45,8 +45,6 @@ import scala.runtime.Statics.releaseFence
 sealed class ListMap[K, +V]
   extends AbstractMap[K, V]
     with SeqMap[K, V]
-    with MapOps[K, V, ListMap, ListMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), Iterable, ListMap[K, V]]
     with StrictOptimizedMapOps[K, V, ListMap, ListMap[K, V]] {
 
   override def mapFactory: MapFactory[ListMap] = ListMap

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -42,8 +42,7 @@ import scala.annotation.tailrec
   */
 sealed class ListSet[A]
   extends AbstractSet[A]
-    with SetOps[A, ListSet, ListSet[A]]
-    with StrictOptimizedIterableOps[A, ListSet, ListSet[A]] {
+    with StrictOptimizedSetOps[A, ListSet, ListSet[A]] {
 
   override protected[this] def className: String = "ListSet"
 

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -176,8 +176,7 @@ private[immutable] class LongMapKeyIterator[V](it: LongMap[V]) extends LongMapIt
   *  @define willNotTerminateInf
   */
 sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
-  with MapOps[Long, T, Map, LongMap[T]]
-  with StrictOptimizedIterableOps[(Long, T), Iterable, LongMap[T]] {
+  with StrictOptimizedMapOps[Long, T, Map, LongMap[T]] {
 
   override protected def fromSpecific(coll: scala.collection.IterableOnce[(Long, T)] @uncheckedVariance): LongMap[T] = {
     //TODO should this be the default implementation of this method in StrictOptimizedIterableOps?

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -83,6 +83,8 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   /** Creates a new $coll from this $coll by removing all elements of another
     *  collection.
     *
+    *  $willForceEvaluation
+    *
     *  @param keys   the collection containing the removed elements.
     *  @return a new $coll that contains all elements of the current $coll
     *  except one less occurrence of each of the elements of `elems`.
@@ -143,13 +145,6 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
     */
   def transform[W](f: (K, V) => W): CC[K, W] = map { case (k, v) => (k, f(k, v)) }
 
-  override def concat [V1 >: V](that: collection.IterableOnce[(K, V1)]): CC[K, V1] = {
-    var result: CC[K, V1] = coll
-    val it = that.iterator
-    while (it.hasNext) result = result + it.next()
-    result
-  }
-
   override def keySet: Set[K] = new ImmutableKeySet
 
   /** The implementation class of the set returned by `keySet` */
@@ -159,6 +154,20 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   }
 
 }
+
+trait StrictOptimizedMapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
+  extends MapOps[K, V, CC, C]
+    with collection.StrictOptimizedMapOps[K, V, CC, C]
+    with StrictOptimizedIterableOps[(K, V), Iterable, C] {
+
+  override def concat [V1 >: V](that: collection.IterableOnce[(K, V1)]): CC[K, V1] = {
+    var result: CC[K, V1] = coll
+    val it = that.iterator
+    while (it.hasNext) result = result + it.next()
+    result
+  }
+}
+
 
 /**
   * $factoryInfo

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -58,13 +58,6 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
   /*@`inline` final*/ override def - (elem: A): C = excl(elem)
 
-  override def concat(that: collection.IterableOnce[A]): C = {
-    var result: C = coll
-    val it = that.iterator
-    while (it.hasNext) result = result + it.next()
-    result
-  }
-
   def diff(that: collection.Set[A]): C =
     toIterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result + elem)
 
@@ -79,6 +72,19 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   /** Alias for removeAll */
   @deprecatedOverriding("This method should be final, but is not due to scala/bug#10853", "2.13.0")
   override /*final*/ def -- (that: IterableOnce[A]): C = removedAll(that)
+}
+
+trait StrictOptimizedSetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
+  extends SetOps[A, CC, C]
+    with collection.StrictOptimizedSetOps[A, CC, C]
+    with StrictOptimizedIterableOps[A, CC, C] {
+
+  override def concat(that: collection.IterableOnce[A]): C = {
+    var result: C = coll
+    val it = that.iterator
+    while (it.hasNext) result = result + it.next()
+    result
+  }
 }
 
 /**

--- a/src/library/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -20,8 +20,10 @@ import scala.language.higherKinds
   * Trait that overrides operations to take advantage of strict builders.
   */
 trait StrictOptimizedSeqOps[+A, +CC[_], +C]
-  extends SeqOps[A, CC, C]
-    with collection.StrictOptimizedSeqOps[A, CC, C] {
+  extends Any
+    with SeqOps[A, CC, C]
+    with collection.StrictOptimizedSeqOps[A, CC, C]
+    with StrictOptimizedIterableOps[A, CC, C] {
 
   override def distinctBy[B](f: A => B): C = {
     if (lengthCompare(1) <= 0) coll

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -40,9 +40,6 @@ import scala.collection.mutable.{Builder, ReusableBuilder}
 final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V])(implicit val ordering: Ordering[K])
   extends AbstractMap[K, V]
     with SortedMap[K, V]
-    with SortedMapOps[K, V, TreeMap, TreeMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), Iterable, TreeMap[K, V]]
-    with StrictOptimizedMapOps[K, V, Map, TreeMap[K, V]]
     with StrictOptimizedSortedMapOps[K, V, TreeMap, TreeMap[K, V]] {
 
   def this()(implicit ordering: Ordering[K]) = this(null)(ordering)

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -39,7 +39,6 @@ final class TreeSet[A] private (private[immutable] val tree: RB.Tree[A, Null])(i
   extends AbstractSet[A]
     with SortedSet[A]
     with SortedSetOps[A, TreeSet, TreeSet[A]]
-    with StrictOptimizedIterableOps[A, Set, TreeSet[A]]
     with StrictOptimizedSortedSetOps[A, TreeSet, TreeSet[A]] {
 
   if (ordering eq null) throw new NullPointerException("ordering must not be null")

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -36,8 +36,7 @@ final class VectorMap[K, +V] private (
     private[immutable] val underlying: Map[K, (Int, V)], dummy: Boolean)
   extends AbstractMap[K, V]
     with SeqMap[K, V]
-    with MapOps[K, V, VectorMap, VectorMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), Iterable, VectorMap[K, V]] {
+    with StrictOptimizedMapOps[K, V, VectorMap, VectorMap[K, V]] {
 
   import VectorMap._
 


### PR DESCRIPTION
- If a method can be implemented in a lazy way, a strict implementation
  always goes into a StrictOptimizedOps trait, not the regular Ops
  trait.
- All strict concrete collection types extend the appropriate
  StrictOptimizedOps traits.
- Ops traits subclassing is done consistently along 3 axes:
  - For collection kind X <: Y: XOps extends YOps (including
    StrictOptimized Xs and Ys)
  - i.FooOps extends c.FooOps (including StrictOptimized Foos)
  - x.StrictOptimizedFooOps extends x.FooOps
- No empty StrictOptimizedOps traits are added. In these cases the
  concrete classes still extend the 3 supertraits directly.

Fixes https://github.com/scala/bug/issues/10940