### PR TITLE
Define `reflect.Manifest` as an `object` rather than a `val`.

### DIFF
--- a/src/library/scala/reflect/Manifest.scala
+++ b/src/library/scala/reflect/Manifest.scala
@@ -65,6 +65,82 @@ trait Manifest[T] extends ClassManifest[T] with Equals {
   override def hashCode = this.runtimeClass.##
 }
 
+/** The object `Manifest` defines factory methods for manifests.
+ *  It is intended for use by the compiler and should not be used in client code.
+ */
+// TODO undeprecated until Scala reflection becomes non-experimental
+// @deprecated("use scala.reflect.ClassTag (to capture erasures), scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
+object Manifest {
+  /* Forward all the public members of ManifestFactory, since this object used
+   * to be a `private val Manifest = ManifestFactory` in the package object. It
+   * was moved here because it needs to be in the same file as `trait Manifest`
+   * defined above.
+   */
+
+  def valueManifests: List[AnyValManifest[_]] =
+    ManifestFactory.valueManifests
+
+  val Byte: ManifestFactory.ByteManifest = ManifestFactory.Byte
+  val Short: ManifestFactory.ShortManifest = ManifestFactory.Short
+  val Char: ManifestFactory.CharManifest = ManifestFactory.Char
+  val Int: ManifestFactory.IntManifest = ManifestFactory.Int
+  val Long: ManifestFactory.LongManifest = ManifestFactory.Long
+  val Float: ManifestFactory.FloatManifest = ManifestFactory.Float
+  val Double: ManifestFactory.DoubleManifest = ManifestFactory.Double
+  val Boolean: ManifestFactory.BooleanManifest = ManifestFactory.Boolean
+  val Unit: ManifestFactory.UnitManifest = ManifestFactory.Unit
+
+  val Any: Manifest[scala.Any] = ManifestFactory.Any
+  val Object: Manifest[java.lang.Object] = ManifestFactory.Object
+  val AnyRef: Manifest[scala.AnyRef] = ManifestFactory.AnyRef
+  val AnyVal: Manifest[scala.AnyVal] = ManifestFactory.AnyVal
+  val Null: Manifest[scala.Null] = ManifestFactory.Null
+  val Nothing: Manifest[scala.Nothing] = ManifestFactory.Nothing
+
+  /** Manifest for the singleton type `value.type`. */
+  def singleType[T <: AnyRef](value: AnyRef): Manifest[T] =
+    ManifestFactory.singleType[T](value)
+
+  /** Manifest for the class type `clazz[args]`, where `clazz` is
+    * a top-level or static class.
+    * @note This no-prefix, no-arguments case is separate because we
+    *       it's called from ScalaRunTime.boxArray itself. If we
+    *       pass varargs as arrays into this, we get an infinitely recursive call
+    *       to boxArray. (Besides, having a separate case is more efficient)
+    */
+  def classType[T](clazz: Predef.Class[_]): Manifest[T] =
+    ManifestFactory.classType[T](clazz)
+
+  /** Manifest for the class type `clazz`, where `clazz` is
+    * a top-level or static class and args are its type arguments. */
+  def classType[T](clazz: Predef.Class[T], arg1: Manifest[_], args: Manifest[_]*): Manifest[T] =
+    ManifestFactory.classType[T](clazz, arg1, args: _*)
+
+  /** Manifest for the class type `clazz[args]`, where `clazz` is
+    * a class with non-package prefix type `prefix` and type arguments `args`.
+    */
+  def classType[T](prefix: Manifest[_], clazz: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
+    ManifestFactory.classType[T](prefix, clazz, args: _*)
+
+  def arrayType[T](arg: Manifest[_]): Manifest[Array[T]] =
+    ManifestFactory.arrayType[T](arg)
+
+  /** Manifest for the abstract type `prefix # name`. `upperBound` is not
+    * strictly necessary as it could be obtained by reflection. It was
+    * added so that erasure can be calculated without reflection. */
+  def abstractType[T](prefix: Manifest[_], name: String, upperBound: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
+    ManifestFactory.abstractType[T](prefix, name, upperBound, args: _*)
+
+  /** Manifest for the unknown type `_ >: L <: U` in an existential. */
+  def wildcardType[T](lowerBound: Manifest[_], upperBound: Manifest[_]): Manifest[T] =
+    ManifestFactory.wildcardType[T](lowerBound, upperBound)
+
+  /** Manifest for the intersection type `parents_0 with ... with parents_n`. */
+  def intersectionType[T](parents: Manifest[_]*): Manifest[T] =
+    ManifestFactory.intersectionType[T](parents: _*)
+
+}
+
 // TODO undeprecated until Scala reflection becomes non-experimental
 // @deprecated("use type tags and manually check the corresponding class or type instead", "2.10.0")
 @SerialVersionUID(1L)

--- a/src/library/scala/reflect/package.scala
+++ b/src/library/scala/reflect/package.scala
@@ -47,13 +47,6 @@ package object reflect {
   @deprecated("use scala.reflect.ClassTag instead", "2.10.0")
   val ClassManifest = ClassManifestFactory
 
-  /** The object `Manifest` defines factory methods for manifests.
-   *  It is intended for use by the compiler and should not be used in client code.
-   */
-  // TODO undeprecated until Scala reflection becomes non-experimental
-  // @deprecated("use scala.reflect.ClassTag (to capture erasures), scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
-  val Manifest = ManifestFactory
-
   def classTag[T](implicit ctag: ClassTag[T]) = ctag
 
   /** Make a java reflection object accessible, if it is not already


### PR DESCRIPTION
Yet another approach, alternative to #7642 and #7643.

Since there is a `trait Manifest`, the term of the same name should be in the same file. Otherwise, in some weird circumstances, like somehow while building Scala.js in the community build (but only in the community build), we get a compile error saying that `Manifest` is already defined in the package object.

Since we cannot define a top-level `val`, we declare it as an `object` instead. This means that we have to explicitly forward all the public members of `ManifestFactory` in `Manifest`.

This is meant as a small incremental fix that does not impact the compiler (since its codegen refers to `ManifestFactory`). Longer term, we should make the codegen use the `object Manifest` instead, and eventually retire `ManifestFactory`.