### PR TITLE
Clean up `ControlThrowable`.

### DIFF
--- a/src/library/scala/util/control/ControlThrowable.scala
+++ b/src/library/scala/util/control/ControlThrowable.scala
@@ -34,19 +34,16 @@ package scala.util.control
  *  }}}
  *
  *  Suppression is disabled, because flow control should not suppress
- *  an exceptional condition.
+ *  an exceptional condition. Stack traces are also disabled, allowing
+ *  instances of `ControlThrowable` to be safely reused.
  *
- *  Instances of `ControlThrowable` should not normally have either
- *  a cause or a writable stack trace.
- *
- *  Legacy subclasses may make the stack trace writable by using
- *  the appropriate constructor. A cause may be set using `initCause`.
+ *  Instances of `ControlThrowable` should not normally have a cause.
+ *  Legacy subclasses may set a cause using `initCause`.
  *
  *  @author Miles Sabin
  */
-abstract class ControlThrowable private[this] (message: String, cause: Throwable, writableStackTrace: Boolean) extends Throwable(message, cause, /*enableSuppression=*/ false, writableStackTrace) {
-  def this() = this(message = null, cause = null, writableStackTrace = false)
-  def this(message: String) = this(message = message, cause = null, writableStackTrace = false)
-  @deprecated("Writable stack trace is provided only for compatibility", since = "2.13.0")
-  protected def this(message: String, writableStackTrace: true) = this(message = message, cause = null, writableStackTrace = writableStackTrace)
+abstract class ControlThrowable(message: String) extends Throwable(
+  message, /*cause*/ null, /*enableSuppression=*/ false, /*writableStackTrace*/ false) {
+
+  def this() = this(message = null)
 }

--- a/test/junit/scala/util/control/ControlThrowableTest.scala
+++ b/test/junit/scala/util/control/ControlThrowableTest.scala
@@ -24,9 +24,6 @@ class ControlThrowableTest {
 
   class MyCtl extends ControlThrowable
 
-  @deprecated("Test me, don't use me", since = "forever")
-  class LegacyCtl extends ControlThrowable("legacy", true)
-
   @Test
   def stackless(): Unit = assertThrown[MyCtl]((my: MyCtl) => my.getStackTrace.isEmpty)(throw new MyCtl)
 
@@ -43,11 +40,5 @@ class ControlThrowableTest {
       val e = new MyCtl
       e.addSuppressed(new java.io.IOException)
       throw e
-    }
-
-  @Test
-  def stackful(): Unit =
-    assertThrown[LegacyCtl]((legacy: LegacyCtl) => !legacy.getStackTrace.isEmpty) {
-      throw new LegacyCtl
     }
 }


### PR DESCRIPTION
In bd368a7e336b99d299681c96415fde75b025a92a, `ControlThrowable` received a legacy deprecated constructor to allow enabling writable stack traces, because it was deemed necessary not to break Scala.js. However, Scala.js found a more fundamental way to keep functioning, without this legacy constructor, in https://github.com/scala-js/scala-js/commit/03faf11c670ed0c8eb973e792a771a91c265c320

Therefore, this commit removes that legacy constructor.

Basically cleaning up my own mess ;)