### PR TITLE
Implement `take` and `slice` in VectorIterator

### DIFF
--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -181,4 +181,41 @@ class VectorTest {
     // test that type info is not lost
     val x: Vector[Char] = Vector[Char]().tapEach(f)
   }
+
+  @Test
+  def vectorIteratorTake(): Unit = {
+    val v = Vector.from(0 to 50)
+    for {
+      i <- -100 to 4000 by 40
+      j <- -100 to 4000 by 6
+    } {
+      val v2 = v.take(i)
+      assertArrayEquals(s"<${v2.length}>.take($j)", v2.toArray.take(j), v2.iterator.take(j).toArray)
+    }
+  }
+
+  @Test
+  def vectorIteratorDrop2(): Unit = {
+    val v = Vector.from(0 to 50)
+    for {
+      i <- -100 to 4000 by 40
+      j <- -100 to 4000 by 60
+    } {
+      val v2 = v.take(i)
+      assertArrayEquals(s"<${v2.length}>.drop($j)", v2.toArray.drop(j), v2.iterator.drop(j).toArray)
+    }
+  }
+
+  @Test
+  def vectorIteratorSlice(): Unit = {
+    val v = Vector.from(0 to 50)
+    for {
+      i <- -100 to 4000 by 40
+      j <- -100 to 4000 by 60
+      k <- -100 to 4000 by 60
+    } {
+      val v2 = v.take(i)
+      assertArrayEquals(s"<${v2.length}>.slice($j, $k)", v2.toArray.slice(j, k), v2.iterator.slice(j, k).toArray)
+    }
+  }
 }


### PR DESCRIPTION
...and fix the `drop` implementation which didn’t ensure that the
remaining size is reported as 0 when all remaining elements are dropped.

Fixes https://github.com/scala/bug/issues/9954