### PR TITLE
Optimized s.c.i.HashSet[A]#concat(s.c.i.HashSet[A]) implementation

### DIFF
--- a/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
@@ -1,15 +1,15 @@
 package scala.collection.immutable
 
 import org.scalacheck.Arbitrary._
-import org.scalacheck.Prop.forAll
+import org.scalacheck.Prop._
 import org.scalacheck._
 
 object ImmutableChampHashSetProperties extends Properties("immutable.ChampHashSet") {
 
   type K = Int
 
-//  override def overrideParameters(p: org.scalacheck.Test.Parameters) =
-//    p.withMinSuccessfulTests(1000)
+  override def overrideParameters(p: org.scalacheck.Test.Parameters) =
+    p.withMinSuccessfulTests(100)
 
   private def doSubtract(one: HashSet[K], two: HashSet[K]) = {
     one.foldLeft(HashSet.empty[K])((result, elem) => if (two contains elem) result else result + elem)
@@ -101,7 +101,7 @@ object ImmutableChampHashSetProperties extends Properties("immutable.ChampHashSe
     val intersectNative = oneWithShared.intersect(twoWithShared)
     val intersectDefault = doIntersect(oneWithShared, twoWithShared)
 
-    intersectDefault == intersectNative
+    intersectDefault =? intersectNative
   }
 
   property("intersectIdentityMostlyReference") = forAll { (input: HashSet[K], key: K) =>
@@ -246,10 +246,10 @@ object ImmutableChampHashSetProperties extends Properties("immutable.ChampHashSe
     b.result == b.addAll(seq).result()
   }
   property("(xs ++ ys).toSet == xs.toSet ++ ys.toSet") = forAll { (xs: Seq[K],ys: Seq[K]) =>
-    (xs ++ ys).toSet == xs.toSet ++ ys.toSet
+    (xs ++ ys).toSet =? xs.toSet ++ ys.toSet
   }
   property("HashSetBuilder produces the same Set as SetBuilder") = forAll { (xs: Seq[K]) =>
-    HashSet.newBuilder[K].addAll(xs).result() == HashSet.newBuilder[K].addAll(xs).result()
+    HashSet.newBuilder[K].addAll(xs).result() =? HashSet.newBuilder[K].addAll(xs).result()
   }
   property("HashSetBuilder does not mutate after releasing") = forAll { (xs: Seq[K], ys: Seq[K], single: K, addSingleFirst: Boolean) =>
     val b = HashSet.newBuilder[K].addAll(xs)
@@ -262,7 +262,7 @@ object ImmutableChampHashSetProperties extends Properties("immutable.ChampHashSe
       b.addAll(ys)
       b.addOne(single)
     }
-    (b.result().size >= hashSetA.size) && hashSetA == cloneOfA
+    Prop(b.result().size >= hashSetA.size) && ((hashSetA: Set[K]) ?= (cloneOfA: Set[K]))
   }
   property("Set does not mutate after releasing") = forAll { (xs: Seq[K], ys: Seq[K], single: K, addSingleFirst: Boolean) =>
     val b = Set.newBuilder[K].addAll(xs)


### PR DESCRIPTION
Related to / fixes https://github.com/scala/bug/issues/11128#issuecomment-454415157

This ports the implementation of `s.c.i.HashMap#concat` to `s.c.i.HashSet`s.

The one major difference is that when it comes to Sets, when there is a collision in the keys, the left is to be preferred over the right, so this implementation has extra optimizations for returning SetNodes from the left whenever possible rather than returning SetNodes from the right. 

In Maps it's the opposite because when keys collide, it is the value on the right that overwrites that of the left. In Sets, this complication isn't there and we're free to take left keys. In fact, the contract requires that key identities in the left/receiver set are the ones that are preserved.

This difference manifests itself in opposite logic for `BitmapIndexedSetNode#concat`'s `var anyChangesMadeSoFar: Boolean`, which for Maps tracks if the result is different from `right`. In Sets it tracks if the result is different from `left`/`this`. 

There is also a bitmap `Int` used in the concatenation process called `leftDataRightDataLeftOverwrites` which tracks the bit positions of data from the left which collide (according to `==`) with data nodes on the right, and in these cases of course the left data is passed through. In maps, this is called `leftDataRightDataRightOverwrites` and works the opposite way.

Extra Changes:
* HashMap#concat(SomethingOtherThanHashMap) calls `super.concat` rather than implementing it again.
* BitmapIndexedHashNode compares cached originalHashes of elements before calling potentially expensive `==` 
* HashMap concat and HashSet concat have extra optimized paths for cases where left or right are 0 or 1 elements.




