### PR TITLE
Add array shrinking operation to the ArrayBuffer 

### DIFF
--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -247,7 +247,6 @@ object RefArrayUtils {
       throw new Exception(s"Collections can not have a negative size")
     if (n == Int.MaxValue)
       throw new Exception(s"Collections can not have more than ${Int.MaxValue} elements")
-    // Use a Long to prevent overflows
     var newLength: Int = array.length
     while (newLength >= n && newLength >= 8)
       newLength = newLength / 2


### PR DESCRIPTION
The ArrayBuffer already had the logic to grow and expand an array into another twice the size, when adding a new element to a full array.

This PR adds a complementary shrink operation, that replaces the array by a smaller one when the number of occupied positions in the array falls below a fourth fraction of the size of the array.

This was motivated by a [comment](https://github.com/scala/scala/pull/7628#issuecomment-453545756) by @SethTisue, regarding the PriorityQueue class which is itself backed by a resizable array. 