### PR TITLE
Significant performance improvements to Futures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,7 @@
 /project/project/target/
 /project/project/project/target/
 /test/macro-annot/target/
+/test/files/target/
+/test/target/
 /build-sbt/
 local.sbt

--- a/src/library/scala/concurrent/BatchingExecutor.scala
+++ b/src/library/scala/concurrent/BatchingExecutor.scala
@@ -50,6 +50,38 @@ private[concurrent] object BatchingExecutorStatics {
  * on the outer task completing.
  * This executor may run tasks in any order, including LIFO order.
  * There are no ordering guarantees.
+ *
+ * WARNING: Only use *EITHER* `submitAsyncBatched` OR `submitSyncBatched`!!
+ *
+ * When you implement this trait for async executors like thread pools,
+ * you're going to need to implement it something like the following:
+ *
+ * {{{
+ *  final override def submitAsync(runnable: Runnable): Unit =
+ *    super[SuperClass].execute(runnable) // To prevent reentrancy into `execute`
+ *
+ *  final override def execute(runnable: Runnable): Unit =
+ *    if (runnable.isInstanceOf[Batchable]) // Or other logic
+ *      submitAsyncBatched(runnable)
+ *    else
+ *      submitAsync(runnable)
+ *
+ *  final override def reportFailure(cause: Throwable): Unit = …
+ *  }}}
+ *
+ *  And if you want to implement if for a sync, trampolining, executor you're
+ *  going to implement it something like this:
+ *
+ * {{{
+ *  final override def submitAsync(runnable: Runnable): Unit = ()
+ *
+ *  final override def execute(runnable: Runnable): Unit =
+ *    submitSyncBatched(runnable) // You typically will want to batch everything
+ *
+ *  final override def reportFailure(cause: Throwable): Unit =
+ *    ExecutionContext.defaultReporter(cause) // Or choose something more fitting
+ * }}}
+ *
  */
 private[concurrent] trait BatchingExecutor extends Executor {
   private[this] final val _tasksLocal = new ThreadLocal[AnyRef]()
@@ -59,33 +91,7 @@ private[concurrent] trait BatchingExecutor extends Executor {
    * In order to conserve allocations, the first element in the batch is stored "unboxed" in
    * the `first` field. Subsequent Runnables are stored in the array called `other`.
   */
-  private[this] final class Batch(private[this] final val resubmitOnBlock: Boolean) extends Runnable with BlockContext with (BlockContext => Throwable) {
-    private[this] final var parentBlockContext: BlockContext = BatchingExecutorStatics.MissingParentBlockContext
-    private[this] final var first: Runnable = _
-    private[this] final var size: Int = _
-    private[this] final var other: Array[Runnable] = BatchingExecutorStatics.emptyBatchArray
-
-    def this(r: Runnable, resubmitOnBlock: Boolean) = {
-      this(resubmitOnBlock)
-      first = r
-      size = 1
-    }
-
-    private def this(first: Runnable, other: Array[Runnable], size: Int, resubmitOnBlock: Boolean) = {
-      this(resubmitOnBlock)
-      this.first = first
-      this.other = other
-      this.size = size
-    }
-
-    private[this] final def cloneAndClear(): Batch = {
-      val newBatch = new Batch(first, other, size, resubmitOnBlock)
-      this.first = null
-      this.parentBlockContext = BatchingExecutorStatics.MissingParentBlockContext
-      this.other = BatchingExecutorStatics.emptyBatchArray
-      this.size = 0
-      newBatch
-    }
+  private[this] sealed abstract class AbstractBatch protected (protected final var first: Runnable, protected final var other: Array[Runnable], protected final var size: Int) {
 
     private[this] final def ensureCapacity(curSize: Int): Array[Runnable] = {
       val curOther = this.other
@@ -111,61 +117,63 @@ private[concurrent] trait BatchingExecutor extends Executor {
       this.size = sz + 1
     }
 
-    private[this] final def runNext(): Boolean =
+    @tailrec protected final def runAll(): Unit = // TODO: Impose max limit of number of items (fairness)
       (this.size: @switch) match {
-        case 0 => false
+        case 0 =>
         case 1 =>
           val next = this.first
           this.first = null
           this.size = 0
           next.run()
-          this.size > 0// Could have changed during next.run()
+          runAll()
         case sz =>
           val o = this.other
           val next = o(sz - 2)
           o(sz - 2) = null
           this.size = sz - 1// Important to update prior to `r.run()`
           next.run()
-          this.size > 0// Could have changed during next.run()
+          runAll()
         }
 
-    // This method runs in the delegate ExecutionContext's thread
-    override final def run(): Unit = {
-      _tasksLocal.set(this)
-
-      val failure = // Only install the block context if we can resubmit on blocking
-        if (resubmitOnBlock) BlockContext.usingBlockContext(this)(this)
-        else runWithoutResubmit(runUntilFailureOrDone())
-
-      _tasksLocal.set(BatchingExecutorStatics.marker)
-      if (failure != null)
-        throw handleRunFailure(failure)
-    }
-
-    override final def apply(prevBlockContext: BlockContext): Throwable = {
-      parentBlockContext = prevBlockContext
-      val failure = runUntilFailureOrDone()
-      parentBlockContext = BatchingExecutorStatics.MissingParentBlockContext
-      failure
-    }
-
-    @tailrec private[this] final def runWithoutResubmit(failure: Throwable): Throwable =
-      if (failure != null && (failure.isInstanceOf[InterruptedException] || NonFatal(failure))) {
-        reportFailure(failure)
-        runWithoutResubmit(runUntilFailureOrDone())
-      } else failure
-
-    private[this] final def runUntilFailureOrDone(): Throwable =
+    protected final def runUntilFailureOrDone(): Throwable =
       try {
-        while(runNext()) {}
-
+        runAll()
         null
       } catch {
         case t: Throwable => t
       }
+  }
 
-    private[this] final def handleRunFailure(cause: Throwable): Throwable =
-      if (resubmitOnBlock && size > 0) {
+  private[this] final class AsyncBatch private(_first: Runnable, _other: Array[Runnable], _size: Int) extends AbstractBatch(_first, _other, _size) with Runnable with BlockContext with (BlockContext => Throwable) {
+    private[this] final var parentBlockContext: BlockContext = BatchingExecutorStatics.MissingParentBlockContext
+
+    final def this(runnable: Runnable) = this(runnable, BatchingExecutorStatics.emptyBatchArray, 1)
+
+    override final def run(): Unit = {
+      _tasksLocal.set(this) // This is later cleared in `apply` or `runWithoutResubmit`
+
+      val f = resubmit(BlockContext.usingBlockContext(this)(this))
+
+      if (f != null)
+        throw f
+    }
+
+    /* LOGIC FOR ASYNCHRONOUS BATCHES */
+    override final def apply(prevBlockContext: BlockContext): Throwable = {
+      parentBlockContext = prevBlockContext
+      val failure = runUntilFailureOrDone()
+      parentBlockContext = BatchingExecutorStatics.MissingParentBlockContext
+      _tasksLocal.remove()
+      failure
+    }
+
+    /* Attempts to resubmit this Batch to the underlying ExecutionContext,
+     * this only happens for Batches where `resubmitOnBlock` is `true`.
+     * Only attempt to resubmit when there are `Runnables` left to process.
+     * Note that `cause` can be `null`.
+     */
+    private[this] final def resubmit(cause: Throwable): Throwable =
+      if (this.size > 0) {
         try { submitAsync(this); cause } catch {
           case inner: Throwable =>
             if (NonFatal(inner)) {
@@ -174,50 +182,70 @@ private[concurrent] trait BatchingExecutor extends Executor {
               e
             } else inner
         }
-      } else cause
+      } else cause // TODO: consider if NonFatals should simply be `reportFailure`:ed rather than rethrown
 
-    override def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
+    private[this] final def cloneAndClear(): AsyncBatch = {
+      val newBatch = new AsyncBatch(first, other, size)
+      this.first = null
+      this.parentBlockContext = BatchingExecutorStatics.MissingParentBlockContext
+      this.other = BatchingExecutorStatics.emptyBatchArray
+      this.size = 0
+      newBatch
+    }
+
+    override final def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
       val pbc = parentBlockContext // Store this for later since `cloneAndClear()` will reset it
 
-      if(size > 0) // If we know there will be blocking, we don't want to keep tasks queued up because it could deadlock.
+      if(this.size > 0) // If we know there will be blocking, we don't want to keep tasks queued up because it could deadlock.
         submitAsync(cloneAndClear()) // If this throws then we have bigger problems
 
       pbc.blockOn(thunk) // Now delegate the blocking to the previous BC
     }
   }
 
-  /** Schedules the `runnable` to be executed—will only be used if `isAsync` returns `true`.
+  private[this] final class SyncBatch(runnable: Runnable) extends AbstractBatch(runnable, BatchingExecutorStatics.emptyBatchArray, 1) with Runnable {
+    @tailrec private[this] final def runWithoutResubmit(failure: Throwable): Throwable =
+      if (failure != null && (failure.isInstanceOf[InterruptedException] || NonFatal(failure))) {
+        reportFailure(failure)
+        runWithoutResubmit(runUntilFailureOrDone())
+      } else {
+        _tasksLocal.set(BatchingExecutorStatics.marker)
+        failure
+      }
+
+    override final def run(): Unit = {
+      _tasksLocal.set(this) // This is later cleared in `runWithoutResubmit`
+
+      val f = runWithoutResubmit(runUntilFailureOrDone())
+
+      if (f != null)
+        throw f
+    }
+  }
+
+  /** SHOULD throw a NullPointerException when `runnable` is null
   */
   protected def submitAsync(runnable: Runnable): Unit
 
-  /** Returns whether this `Executor` runs on the calling thread or if it `submitAsync` will execute its `Runnable`:s asynchronously.
-  */
-  protected def isAsync: Boolean = true
-
-  /** Must return `false` when `runnable` is `null`
-  */
-  protected def batchable(runnable: Runnable): Boolean = runnable.isInstanceOf[Batchable]
-
   /** Reports that an asynchronous computation failed.
+   *  See `ExecutionContext.reportFailure(throwable: Throwable)`
   */
   protected def reportFailure(throwable: Throwable): Unit
 
-  override final def execute(runnable: Runnable): Unit = {
+  protected final def submitAsyncBatched(runnable: Runnable): Unit = {
+    val b = _tasksLocal.get
+    if (b.isInstanceOf[AsyncBatch]) b.asInstanceOf[AsyncBatch].push(runnable)
+    else submitAsync(new AsyncBatch(runnable))
+  }
+
+  protected final def submitSyncBatched(runnable: Runnable): Unit = {
     Objects.requireNonNull(runnable, "runnable is null")
-    if (isAsync) {
-      if (batchable(runnable)) {
-        val b = _tasksLocal.get
-        if (b.isInstanceOf[Batch]) b.asInstanceOf[Batch].push(runnable)
-        else submitAsync(new Batch(runnable, resubmitOnBlock = true))
-      } else submitAsync(runnable)
-    } else {
-      val b = _tasksLocal.get
-      if (b.isInstanceOf[Batch]) b.asInstanceOf[Batch].push(runnable)
-      else if (b == null) {                             // If there is null in _tasksLocal, set a marker and run, inflate the Batch only if needed
-        _tasksLocal.set(BatchingExecutorStatics.marker) // Set a marker to indicate that we are submitting synchronously
-        runnable.run()                                  // If we observe a non-null task which isn't a batch here, then allocate a batch
-        _tasksLocal.remove()                            // Since we are executing synchronously, we can clear this at the end of execution
-      } else new Batch(runnable, resubmitOnBlock = false).run()
-    }
+    val b = _tasksLocal.get
+    if (b.isInstanceOf[SyncBatch]) b.asInstanceOf[SyncBatch].push(runnable)
+    else if (b == null) {                             // If there is null in _tasksLocal, set a marker and run, inflate the Batch only if needed
+      _tasksLocal.set(BatchingExecutorStatics.marker) // Set a marker to indicate that we are submitting synchronously
+      runnable.run()                                  // If we observe a non-null task which isn't a batch here, then allocate a batch
+      _tasksLocal.remove()                            // Since we are executing synchronously, we can clear this at the end of execution
+    } else new SyncBatch(runnable).run()
   }
 }

--- a/src/library/scala/concurrent/BatchingExecutor.scala
+++ b/src/library/scala/concurrent/BatchingExecutor.scala
@@ -213,7 +213,7 @@ private[concurrent] trait BatchingExecutor extends Executor {
       Objects.requireNonNull(runnable, "runnable is null")
       val b = _tasksLocal.get
       if (b.isInstanceOf[Batch]) b.asInstanceOf[Batch].push(runnable)
-      else if (b != null) {
+      else if (b == null) {                             // If there is null in _tasksLocal, set a marker and run, inflate the Batch only if needed
         _tasksLocal.set(BatchingExecutorStatics.marker) // Set a marker to indicate that we are submitting synchronously
         runnable.run()                                  // If we observe a non-null task which isn't a batch here, then allocate a batch
         _tasksLocal.remove()                            // Since we are executing synchronously, we can clear this at the end of execution

--- a/src/library/scala/concurrent/BatchingExecutor.scala
+++ b/src/library/scala/concurrent/BatchingExecutor.scala
@@ -15,7 +15,7 @@ package scala.concurrent
 import java.util.concurrent.Executor
 import java.util.Objects
 import scala.util.control.NonFatal
-import scala.annotation.tailrec
+import scala.annotation.{switch, tailrec}
 
 /**
  * Marker trait to indicate that a Runnable is Batchable by BatchingExecutors
@@ -24,7 +24,7 @@ trait Batchable {
   self: Runnable =>
 }
 
-private[concurrent] final object BatchingExecutorStatics {
+private[concurrent] object BatchingExecutorStatics {
   final val emptyBatchArray: Array[Runnable] = new Array[Runnable](0)
   final val marker = ""
   final object MissingParentBlockContext extends BlockContext {
@@ -111,21 +111,23 @@ private[concurrent] trait BatchingExecutor extends Executor {
       this.size = sz + 1
     }
 
-    final def pop(): Runnable = {
-      val sz = this.size
-      if (sz < 2) {
-        val ret = this.first
-        this.first = null
-        this.size = 0
-        ret
-      } else {
-        val o = this.other
-        val ret = o(sz - 2)
-        o(sz - 2) = null
-        this.size = sz - 1
-        ret
-      }
-    }
+    private[this] final def runNext(): Boolean =
+      (this.size: @switch) match {
+        case 0 => false
+        case 1 =>
+          val next = this.first
+          this.first = null
+          this.size = 0
+          next.run()
+          this.size > 0// Could have changed during next.run()
+        case sz =>
+          val o = this.other
+          val next = o(sz - 2)
+          o(sz - 2) = null
+          this.size = sz - 1// Important to update prior to `r.run()`
+          next.run()
+          this.size > 0// Could have changed during next.run()
+        }
 
     // This method runs in the delegate ExecutionContext's thread
     override final def run(): Unit = {
@@ -135,7 +137,7 @@ private[concurrent] trait BatchingExecutor extends Executor {
         if (resubmitOnBlock) BlockContext.usingBlockContext(this)(this)
         else runWithoutResubmit(runUntilFailureOrDone())
 
-      _tasksLocal.remove()
+      _tasksLocal.set(BatchingExecutorStatics.marker)
       if (failure != null)
         throw handleRunFailure(failure)
     }
@@ -155,8 +157,7 @@ private[concurrent] trait BatchingExecutor extends Executor {
 
     private[this] final def runUntilFailureOrDone(): Throwable =
       try {
-        while(size > 0)
-          pop().run()
+        while(runNext()) {}
 
         null
       } catch {
@@ -201,16 +202,15 @@ private[concurrent] trait BatchingExecutor extends Executor {
   */
   protected def reportFailure(throwable: Throwable): Unit
 
-  override final def execute(runnable: Runnable): Unit =
+  override final def execute(runnable: Runnable): Unit = {
+    Objects.requireNonNull(runnable, "runnable is null")
     if (isAsync) {
       if (batchable(runnable)) {
-        // We don't check if `runnable` is null here because if it is, it will be sent to `submitAsync` which will check that in the implementation(s)
         val b = _tasksLocal.get
         if (b.isInstanceOf[Batch]) b.asInstanceOf[Batch].push(runnable)
         else submitAsync(new Batch(runnable, resubmitOnBlock = true))
       } else submitAsync(runnable)
     } else {
-      Objects.requireNonNull(runnable, "runnable is null")
       val b = _tasksLocal.get
       if (b.isInstanceOf[Batch]) b.asInstanceOf[Batch].push(runnable)
       else if (b == null) {                             // If there is null in _tasksLocal, set a marker and run, inflate the Batch only if needed
@@ -219,4 +219,5 @@ private[concurrent] trait BatchingExecutor extends Executor {
         _tasksLocal.remove()                            // Since we are executing synchronously, we can clear this at the end of execution
       } else new Batch(runnable, resubmitOnBlock = false).run()
     }
+  }
 }

--- a/src/library/scala/concurrent/BlockContext.scala
+++ b/src/library/scala/concurrent/BlockContext.scala
@@ -88,11 +88,10 @@ object BlockContext {
    **/
   final def withBlockContext[T](blockContext: BlockContext)(body: => T): T = {
     val old = contextLocal.get // can be null
-    try {
+    if (old eq blockContext) body
+    else {
       contextLocal.set(blockContext)
-      body
-    } finally {
-      contextLocal.set(old)
+      try body finally contextLocal.set(old)
     }
   }
 
@@ -102,7 +101,10 @@ object BlockContext {
    **/
   final def usingBlockContext[I, T](blockContext: BlockContext)(f: BlockContext => T): T = {
     val old = contextLocal.get // can be null
-    contextLocal.set(blockContext)
-    try f(prefer(old)) finally contextLocal.set(old)
+    if (old eq blockContext) f(prefer(old))
+    else {
+      contextLocal.set(blockContext)
+      try f(prefer(old)) finally contextLocal.set(old)
+    }
   }
 }

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -13,7 +13,7 @@
 package scala.concurrent
 
 import scala.language.higherKinds
-import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.util.control.{NonFatal, NoStackTrace}

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -868,7 +868,7 @@ object Future {
   // a side effect.
   private[concurrent] object InternalCallbackExecutor extends ExecutionContextExecutor with BatchingExecutor {
     override final def submitAsync(runnable: Runnable): Unit = reportFailure(null) // Cannot submit async
-    override final def isAsync = false
+    final override def execute(runnable: Runnable): Unit = submitSyncBatched(runnable)
     override final def reportFailure(t: Throwable): Unit =
       ExecutionContext.defaultReporter(new IllegalStateException("problem in scala.concurrent internal callback", t))
   }

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -867,7 +867,7 @@ object Future {
   // doesn't need to create defaultExecutionContext as
   // a side effect.
   private[concurrent] object InternalCallbackExecutor extends ExecutionContextExecutor with BatchingExecutor {
-    override final def submitAsync(runnable: Runnable): Unit = reportFailure(null) // Cannot submit async
+    override final def submitForExecution(runnable: Runnable): Unit = runnable.run()
     final override def execute(runnable: Runnable): Unit = submitSyncBatched(runnable)
     override final def reportFailure(t: Throwable): Unit =
       ExecutionContext.defaultReporter(new IllegalStateException("problem in scala.concurrent internal callback", t))

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -416,7 +416,7 @@ trait Future[+T] extends Awaitable[T] {
    * @group Transformations
    */
   def zipWith[U, R](that: Future[U])(f: (T, U) => R)(implicit executor: ExecutionContext): Future[R] =
-    flatMap(r1 => that.map(r2 => f(r1, r2)))
+    flatMap(r1 => that.map(r2 => f(r1, r2)))(if (executor.isInstanceOf[BatchingExecutor]) executor else internalExecutor)
 
   /** Creates a new future which holds the result of this future if it was completed successfully, or, if not,
    *  the result of the `that` future if `that` is completed successfully.
@@ -692,7 +692,7 @@ object Future {
   final def sequence[A, CC[X] <: IterableOnce[X], To](in: CC[Future[A]])(implicit bf: BuildFrom[CC[Future[A]], A, To], executor: ExecutionContext): Future[To] =
     in.iterator.foldLeft(successful(bf.newBuilder(in))) {
       (fr, fa) => fr.zipWith(fa)(Future.addToBuilderFun)
-    }.map(_.result())(InternalCallbackExecutor)
+    }.map(_.result())(if (executor.isInstanceOf[BatchingExecutor]) executor else InternalCallbackExecutor)
 
   /** Asynchronously and non-blockingly returns a new `Future` to the result of the first future
    *  in the list that is completed. This means no matter if it is completed as a success or as a failure.
@@ -844,7 +844,7 @@ object Future {
   final def traverse[A, B, M[X] <: IterableOnce[X]](in: M[A])(fn: A => Future[B])(implicit bf: BuildFrom[M[A], B, M[B]], executor: ExecutionContext): Future[M[B]] =
     in.iterator.foldLeft(successful(bf.newBuilder(in))) {
       (fr, a) => fr.zipWith(fn(a))(Future.addToBuilderFun)
-    }.map(_.result())(InternalCallbackExecutor)
+    }.map(_.result())(if (executor.isInstanceOf[BatchingExecutor]) executor else InternalCallbackExecutor)
 
 
   // This is used to run callbacks which are internal
@@ -866,8 +866,9 @@ object Future {
   // by just not ever using it itself. scala.concurrent
   // doesn't need to create defaultExecutionContext as
   // a side effect.
-  private[concurrent] object InternalCallbackExecutor extends ExecutionContext with java.util.concurrent.Executor with BatchingExecutor {
-    override protected final def unbatchedExecute(r: Runnable): Unit = r.run()
+  private[concurrent] object InternalCallbackExecutor extends ExecutionContextExecutor with BatchingExecutor {
+    override final def submitAsync(runnable: Runnable): Unit = reportFailure(null) // Cannot submit async
+    override final def isAsync = false
     override final def reportFailure(t: Throwable): Unit =
       ExecutionContext.defaultReporter(new IllegalStateException("problem in scala.concurrent internal callback", t))
   }

--- a/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
+++ b/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
@@ -101,13 +101,13 @@ private[concurrent] object ExecutionContextImpl {
                                                  uncaught = (thread: Thread, cause: Throwable) => reporter(cause))
 
     new ForkJoinPool(desiredParallelism, threadFactory, threadFactory.uncaught, true) with ExecutionContextExecutorService with BatchingExecutor {
-      final override def submitAsync(runnable: Runnable): Unit = super[ForkJoinPool].execute(runnable)
+      final override def submitForExecution(runnable: Runnable): Unit = super[ForkJoinPool].execute(runnable)
 
       final override def execute(runnable: Runnable): Unit =
         if ((!runnable.isInstanceOf[Promise.Transformation[_,_]] || runnable.asInstanceOf[Promise.Transformation[_,_]].benefitsFromBatching) && runnable.isInstanceOf[Batchable])
           submitAsyncBatched(runnable)
         else
-          submitAsync(runnable)
+          submitForExecution(runnable)
 
       final override def reportFailure(cause: Throwable): Unit =
         getUncaughtExceptionHandler() match {

--- a/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
+++ b/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
@@ -12,10 +12,9 @@
 
 package scala.concurrent.impl
 
-import java.util.concurrent.{ ForkJoinPool, ForkJoinWorkerThread, Callable, Executor, ExecutorService, ThreadFactory, TimeUnit }
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{ Semaphore, ForkJoinPool, ForkJoinWorkerThread, Callable, Executor, ExecutorService, ThreadFactory, TimeUnit }
 import java.util.Collection
-import scala.concurrent.{ BatchingExecutor, BlockContext, ExecutionContext, CanAwait, ExecutionContextExecutor, ExecutionContextExecutorService }
+import scala.concurrent.{ Batchable, BatchingExecutor, BlockContext, ExecutionContext, CanAwait, ExecutionContextExecutor, ExecutionContextExecutorService }
 import scala.annotation.tailrec
 
 
@@ -36,17 +35,7 @@ private[concurrent] object ExecutionContextImpl {
     require(prefix ne null, "DefaultThreadFactory.prefix must be non null")
     require(maxBlockers >= 0, "DefaultThreadFactory.maxBlockers must be greater-or-equal-to 0")
 
-    private final val currentNumberOfBlockers = new AtomicInteger(0)
-
-    @tailrec private final def newBlocker(): Boolean = currentNumberOfBlockers.get() match {
-      case `maxBlockers` | Int.`MaxValue` => false
-      case other => currentNumberOfBlockers.compareAndSet(other, other + 1) || newBlocker()
-    }
-
-    @tailrec private final def freeBlocker(): Boolean = currentNumberOfBlockers.get() match {
-      case 0 => false
-      case other => currentNumberOfBlockers.compareAndSet(other, other - 1) || freeBlocker()
-    }
+    private final val blockerPermits = new Semaphore(maxBlockers)
 
     def wire[T <: Thread](thread: T): T = {
       thread.setDaemon(daemonic)
@@ -61,7 +50,7 @@ private[concurrent] object ExecutionContextImpl {
       wire(new ForkJoinWorkerThread(fjp) with BlockContext {
         private[this] final var isBlocked: Boolean = false // This is only ever read & written if this thread is the current thread
         final override def blockOn[T](thunk: =>T)(implicit permission: CanAwait): T =
-          if ((Thread.currentThread eq this) && !isBlocked && newBlocker()) {
+          if ((Thread.currentThread eq this) && !isBlocked && blockerPermits.tryAcquire()) {
             try {
               val b: ForkJoinPool.ManagedBlocker with (() => T) =
                 new ForkJoinPool.ManagedBlocker with (() => T) {
@@ -84,7 +73,7 @@ private[concurrent] object ExecutionContextImpl {
               b()
             } finally {
               isBlocked = false
-              freeBlocker()
+              blockerPermits.release()
             }
           } else thunk // Unmanaged blocking
       })
@@ -112,7 +101,11 @@ private[concurrent] object ExecutionContextImpl {
                                                  uncaught = (thread: Thread, cause: Throwable) => reporter(cause))
 
     new ForkJoinPool(desiredParallelism, threadFactory, threadFactory.uncaught, true) with ExecutionContextExecutorService with BatchingExecutor {
-      final override def unbatchedExecute(runnable: Runnable): Unit = super[ForkJoinPool].execute(runnable)
+      final override def submitAsync(runnable: Runnable): Unit = super[ForkJoinPool].execute(runnable)
+      final override def isAsync = true
+      final override def batchable(runnable: Runnable): Boolean =
+          if (runnable.isInstanceOf[Promise.Transformation[_,_]]) runnable.asInstanceOf[Promise.Transformation[_,_]].benefitsFromBatching
+          else super.batchable(runnable)
       final override def reportFailure(cause: Throwable): Unit =
         getUncaughtExceptionHandler() match {
           case null =>

--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -21,6 +21,7 @@ import scala.runtime.NonLocalReturnControl
 import java.util.concurrent.locks.AbstractQueuedSynchronizer
 import java.util.concurrent.atomic.{ AtomicReference, AtomicBoolean }
 import java.util.Objects.requireNonNull
+import java.io.{ NotSerializableException, IOException, ObjectInputStream, ObjectOutputStream }
 
 /**
   * Latch used to implement waiting on a DefaultPromise's result.
@@ -331,6 +332,15 @@ private[concurrent] object Promise {
         next.unlink(resolved)
       } else tryComplete0(state, resolved)
     }
+
+    @throws[IOException]
+    private def writeObject(out: ObjectOutputStream): Unit =
+      throw new NotSerializableException("Promises and Futures cannot be serialized")
+
+    @throws[IOException]
+    @throws[ClassNotFoundException]
+    private def readObject(in: ObjectInputStream): Unit =
+      throw new NotSerializableException("Promises and Futures cannot be deserialized")
   }
 
   // Constant byte tags for unpacking transformation function inputs or outputs

--- a/src/library/scala/concurrent/package.scala
+++ b/src/library/scala/concurrent/package.scala
@@ -121,7 +121,7 @@ package object concurrent {
    *  @throws InterruptedException in the case that a wait within the blocking `body` was interrupted
    */
   @throws(classOf[Exception])
-  def blocking[T](body: =>T): T = BlockContext.current.blockOn(body)(scala.concurrent.AwaitPermission)
+  final def blocking[T](body: =>T): T = BlockContext.current.blockOn(body)(scala.concurrent.AwaitPermission)
 }
 
 package concurrent {
@@ -169,7 +169,7 @@ package concurrent {
      */
     @throws(classOf[TimeoutException])
     @throws(classOf[InterruptedException])
-    def ready[T](awaitable: Awaitable[T], atMost: Duration): awaitable.type =
+    final def ready[T](awaitable: Awaitable[T], atMost: Duration): awaitable.type =
       blocking(awaitable.ready(atMost)(AwaitPermission))
 
     /**
@@ -193,7 +193,7 @@ package concurrent {
      * @throws IllegalArgumentException if `atMost` is [[scala.concurrent.duration.Duration.Undefined Duration.Undefined]]
      */
     @throws(classOf[Exception])
-    def result[T](awaitable: Awaitable[T], atMost: Duration): T =
+    final def result[T](awaitable: Awaitable[T], atMost: Duration): T =
       blocking(awaitable.result(atMost)(AwaitPermission))
   }
 }

--- a/test/benchmarks/src/main/scala/scala/concurrent/FutureBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/concurrent/FutureBenchmark.scala
@@ -36,24 +36,24 @@ abstract class AbstractBaseFutureBenchmark {
     executionContext = pool match {
       case "fjp" =>
         val fjp = new ForkJoinPool(threads) with ExecutionContext with BatchingExecutor {
-          final override def submitAsync(runnable: Runnable): Unit = super[ForkJoinPool].execute(runnable)
+          final override def submitForExecution(runnable: Runnable): Unit = super[ForkJoinPool].execute(runnable)
           final override def execute(runnable: Runnable): Unit =
             if ((!runnable.isInstanceOf[impl.Promise.Transformation[_,_]] || runnable.asInstanceOf[impl.Promise.Transformation[_,_]].benefitsFromBatching) && runnable.isInstanceOf[Batchable])
               submitAsyncBatched(runnable)
             else
-              submitAsync(runnable)
+              submitForExecution(runnable)
           override final def reportFailure(t: Throwable) = t.printStackTrace(System.err)
         }
         executorService = fjp // we want to close this
         fjp
       case "fix" =>
         val fix = new ThreadPoolExecutor(threads, threads, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue[Runnable]()) with ExecutionContext with BatchingExecutor {
-          final override def submitAsync(runnable: Runnable): Unit = super[ThreadPoolExecutor].execute(runnable)
+          final override def submitForExecution(runnable: Runnable): Unit = super[ThreadPoolExecutor].execute(runnable)
           final override def execute(runnable: Runnable): Unit =
             if ((!runnable.isInstanceOf[impl.Promise.Transformation[_,_]] || runnable.asInstanceOf[impl.Promise.Transformation[_,_]].benefitsFromBatching) && runnable.isInstanceOf[Batchable])
               submitAsyncBatched(runnable)
             else
-              submitAsync(runnable)
+              submitForExecution(runnable)
           override final def reportFailure(t: Throwable) = t.printStackTrace(System.err)
         }
         executorService = fix // we want to close this

--- a/test/benchmarks/src/main/scala/scala/concurrent/FutureBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/concurrent/FutureBenchmark.scala
@@ -1,7 +1,7 @@
 package scala.concurrent
 
 import scala.concurrent.duration._
-import java.util.concurrent.{ TimeUnit, Executor, Executors, ExecutorService, ForkJoinPool, CountDownLatch }
+import java.util.concurrent.{ TimeUnit, Executor, ThreadPoolExecutor, ExecutorService, ForkJoinPool, CountDownLatch, LinkedBlockingQueue }
 import org.openjdk.jmh.infra.Blackhole
 import org.openjdk.jmh.annotations._
 import scala.util.{ Try, Success, Failure }
@@ -33,13 +33,27 @@ abstract class AbstractBaseFutureBenchmark {
 
   @Setup(Level.Trial)
   def startup: Unit = {
-    val e = pool match {
+    executionContext = pool match {
       case "fjp" =>
-        val fjp = new ForkJoinPool(threads)
+        val fjp = new ForkJoinPool(threads) with ExecutionContext with BatchingExecutor {
+          final override def submitAsync(runnable: Runnable): Unit = super[ForkJoinPool].execute(runnable)
+          final override def isAsync = true
+          final override def batchable(runnable: Runnable): Boolean =
+            if (runnable.isInstanceOf[impl.Promise.Transformation[_,_]]) runnable.asInstanceOf[impl.Promise.Transformation[_,_]].benefitsFromBatching
+            else super.batchable(runnable)
+          override final def reportFailure(t: Throwable) = t.printStackTrace(System.err)
+        }
         executorService = fjp // we want to close this
         fjp
       case "fix" =>
-        val fix = Executors.newFixedThreadPool(threads)
+        val fix = new ThreadPoolExecutor(threads, threads, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue[Runnable]()) with ExecutionContext with BatchingExecutor {
+          final override def submitAsync(runnable: Runnable): Unit = super[ThreadPoolExecutor].execute(runnable)
+          final override def isAsync = true
+          final override def batchable(runnable: Runnable): Boolean =
+            if (runnable.isInstanceOf[impl.Promise.Transformation[_,_]]) runnable.asInstanceOf[impl.Promise.Transformation[_,_]].benefitsFromBatching
+            else super.batchable(runnable)
+          override final def reportFailure(t: Throwable) = t.printStackTrace(System.err)
+        }
         executorService = fix // we want to close this
         fix
       case "gbl" =>
@@ -49,18 +63,8 @@ abstract class AbstractBaseFutureBenchmark {
         System.setProperty("scala.concurrent.context.maxThreads", threads.toString)
         ExecutionContext.global
       case "fie" =>
-        scala.concurrent.Future.InternalCallbackExecutor.asInstanceOf[Executor]
+        scala.concurrent.Future.InternalCallbackExecutor
     }
-
-    executionContext =
-      if (e.isInstanceOf[ExecutionContext]) e.asInstanceOf[ExecutionContext]
-      else { // TODO: may want to extend this in the implementations directly
-        new ExecutionContext with BatchingExecutor {
-          private[this] final val g = e
-          override final def unbatchedExecute(r: Runnable) = g.execute(r)
-          override final def reportFailure(t: Throwable) = t.printStackTrace(System.err)
-        }
-      }
   }
 
   @TearDown(Level.Trial)
@@ -84,11 +88,8 @@ abstract class OpFutureBenchmark extends AbstractBaseFutureBenchmark {
 
   final val pre_f_p: Promise[Result] = Promise.fromTry(aFailure)
 
-  @inline protected final def await[T](a: Future[T]): Boolean = {
-    val v = a.value
-    val r = if (v eq None) Await.ready(a, timeout).value else v
-    r.get.getClass eq classOf[Success[T]]
-  }
+  @inline protected final def await[T](a: Future[T]): Boolean =
+    (a.value ne None) || (Await.ready(a, timeout) eq a)
 }
 
 class NoopFutureBenchmark extends OpFutureBenchmark {

--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -78,6 +78,25 @@ class FutureTests extends MinimalScalaTest {
   }
 
   "Futures" should {
+
+    "not be serializable" in {
+
+      def verifyNonSerializabilityFor(p: Future[_]): Unit = {
+        import java.io._
+        val out = new ObjectOutputStream(new ByteArrayOutputStream())
+        intercept[NotSerializableException] {
+          out.writeObject(p)
+        }
+      }
+      verifyNonSerializabilityFor(Await.ready(Future.unit.map(_ => ())(ExecutionContext.global), defaultTimeout))
+      verifyNonSerializabilityFor(Future.unit)
+      verifyNonSerializabilityFor(Future.failed(new NullPointerException))
+      verifyNonSerializabilityFor(Future.successful("test"))
+      verifyNonSerializabilityFor(Future.fromTry(Success("test")))
+      verifyNonSerializabilityFor(Future.fromTry(Failure(new NullPointerException)))
+      verifyNonSerializabilityFor(Future.never)
+    }
+
     "have proper toString representations" in {
       import ExecutionContext.Implicits.global
       val s = 5

--- a/test/files/jvm/future-spec/PromiseTests.scala
+++ b/test/files/jvm/future-spec/PromiseTests.scala
@@ -131,6 +131,23 @@ class PromiseTests extends MinimalScalaTest {
     futureWithResult(_(future, result))
   }
 
+  "A Promise should not be serializable" should {
+
+    def verifyNonSerializabilityFor(p: Promise[_]): Unit = {
+      import java.io._
+      val out = new ObjectOutputStream(new ByteArrayOutputStream())
+      intercept[NotSerializableException] {
+        out.writeObject(p)
+      }.getMessage mustBe "Promises and Futures cannot be serialized"
+    }
+
+    verifyNonSerializabilityFor(Promise[Unit]())
+    verifyNonSerializabilityFor(Promise.failed(new NullPointerException))
+    verifyNonSerializabilityFor(Promise.successful("test"))
+    verifyNonSerializabilityFor(Promise.fromTry(Success("test")))
+    verifyNonSerializabilityFor(Promise.fromTry(Failure(new NullPointerException)))
+  }
+
   def futureWithResult(f: ((Future[Any], Any) => Unit) => Unit): Unit = {
 
     "be completed" in { f((future, _) => future.isCompleted mustBe (true)) }


### PR DESCRIPTION
  * Improvements to Batching Executor by separating async vs sync
  * Performance improvements to installation of BlockContext
  * Reusing EC if Batchable for some of the Future utilities
  * Using Semaphore instead of bespoke permit counter
  * Switching to batching only select Transformations which benefit
  * Updating the FutureBenchmark to accommodate incompatibilities