### PR TITLE
Better index checking in Seq.updated:

### DIFF
--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -891,9 +891,16 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *  @param  elem   the replacing element
     *  @tparam B        the element type of the returned $coll.
     *  @return a new $coll which is a copy of this $coll with the element at position `index` replaced by `elem`.
-    *  @throws IndexOutOfBoundsException if `index` does not satisfy `0 <= index < length`.
+    *  @throws IndexOutOfBoundsException if `index` does not satisfy `0 <= index < length`. In case of a
+    *                                    lazy collection this exception may be thrown at a later time or not at
+    *                                    all (if the end of the collection is never evaluated).
     */
-  def updated[B >: A](index: Int, elem: B): CC[B] = iterableFactory.from(new View.Updated(this, index, elem))
+  def updated[B >: A](index: Int, elem: B): CC[B] = {
+    if(index < 0) throw new IndexOutOfBoundsException(index.toString)
+    val k = knownSize
+    if(k >= 0 && index >= k) throw new IndexOutOfBoundsException(index.toString)
+    iterableFactory.from(new View.Updated(this, index, elem))
+  }
 
   protected[collection] def occCounts[B](sq: Seq[B]): mutable.Map[B, Int] = {
     val occ = new mutable.HashMap[B, Int] { override def default(k: B) = 0 }

--- a/src/library/scala/collection/View.scala
+++ b/src/library/scala/collection/View.scala
@@ -364,7 +364,10 @@ object View extends IterableFactory[View] {
         i += 1
         value
       }
-      def hasNext: Boolean = it.hasNext
+      def hasNext: Boolean =
+        if(it.hasNext) true
+        else if(index >= i) throw new IndexOutOfBoundsException(index.toString)
+        else false
     }
     override def knownSize: Int = underlying.knownSize
     override def isEmpty: Boolean = iterator.isEmpty

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -676,16 +676,15 @@ final class LazyList[+A] private(private[this] var lazyState: () => LazyList.Sta
   // overridden just in case a lazy implementation is developed at some point
   override def transpose[B](implicit asIterable: A => collection.Iterable[B]): LazyList[LazyList[B]] = super.transpose
 
-  override def updated[B >: A](index: Int, elem: B): LazyList[B] = {
-    if (index < 0 || lengthIs <= index) throw new IndexOutOfBoundsException(s"$index")
-    updatedImpl(index, elem)
-  }
+  override def updated[B >: A](index: Int, elem: B): LazyList[B] =
+    if (index < 0) throw new IndexOutOfBoundsException(s"$index")
+    else updatedImpl(index, elem, index)
 
-  // index is already known to be in bounds
-  private def updatedImpl[B >: A](index: Int, elem: B): LazyList[B] = {
+  private def updatedImpl[B >: A](index: Int, elem: B, startIndex: Int): LazyList[B] = {
     newLL {
       if (index <= 0) sCons(elem, tail)
-      else sCons(head, tail.updatedImpl(index - 1, elem))
+      else if (tail.isEmpty) throw new IndexOutOfBoundsException(startIndex.toString)
+      else sCons(head, tail.updatedImpl(index - 1, elem, startIndex))
     }
   }
 

--- a/test/junit/scala/collection/ViewTest.scala
+++ b/test/junit/scala/collection/ViewTest.scala
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import language.postfixOps
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
 @RunWith(classOf[JUnit4])
 class ViewTest {
@@ -89,4 +89,21 @@ class ViewTest {
     assertEquals(lb, Seq(1, 10, -1, 2, 10, -1, 3, 10, -1))
   }
 
+  @Test
+  def updated: Unit = {
+    def checkThrows[U](f: => U) = try { f; assertTrue(false) } catch { case _: IndexOutOfBoundsException => }
+    // View.Updated can update the last element but not the one after:
+    val v1 = new View.Updated(0 until 5, 4, 0)
+    val v2 = new View.Updated(0 until 5, 5, 0)
+    assertEquals(List(0,1,2,3,0), v1.toList)
+    checkThrows(v2.toList)
+    // Seq.updated throws immediately for strict collections:
+    checkThrows(ArrayBuffer.from(0 until 5).updated(5, 0))
+    checkThrows(ArrayBuffer.from(0 until 5).updated(-1, 0))
+    // Negative indices result in an immediate exception even for lazy collections:
+    checkThrows(LazyList.from(0 until 5).updated(-1, 0))
+    // `updated` does not force a LazyList but forcing it afterwards will check the index:
+    val ll = LazyList.from(0 until 5).updated(5, 0)
+    checkThrows(ll.toList)
+  }
 }


### PR DESCRIPTION
- Lazy collections are allowed to delay index checks
- The default implementation now checks the index (against < 0
  immediately and against the collection length when iterating through
  View.Updated)
- Delayed check in LazyList

Fixes https://github.com/scala/bug/issues/11219