### PR TITLE
ListMapBuilder#addAll(Map) actually adds the map.

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -287,6 +287,7 @@ private[immutable] final class ListMapBuilder[K, V] extends mutable.Builder[(K, 
           newUnderlying = new ListMap.Node[K, V](next._1, next._2, newUnderlying)
         }
       }
+      underlying = newUnderlying
       this
 
     case _ => super.addAll(xs)

--- a/test/scalacheck/scala/collection/immutable/ListMapBuilderProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ListMapBuilderProperties.scala
@@ -1,0 +1,46 @@
+package scala.collection.immutable
+
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop._
+import org.scalacheck._
+import org.scalacheck.Gen._
+
+object ListMapBuilderProperties extends Properties("immutable.ListMapBuilder") {
+
+  type K = Int
+  type V = Int
+
+  sealed trait Transform
+
+  object Transform {
+    case class AddOne(kv: (K, V)) extends Transform
+    case class AddAllList(kvs: List[(K, V)]) extends Transform
+    case class AddAllMap(kvs: Map[K, V]) extends Transform
+    case object Clear extends Transform
+  }
+
+
+
+  val transformGen: Gen[List[Transform]] =
+    listOf(oneOf(
+      Arbitrary.arbitrary[(K, V)].map(Transform.AddOne),
+      Arbitrary.arbitrary[List[(K, V)]].map(Transform.AddAllList),
+      Arbitrary.arbitrary[Map[K, V]].map(Transform.AddAllMap),
+      const(Transform.Clear)
+    ))
+
+  def interpret(transforms: Seq[Transform], builder: () => collection.mutable.Builder[(K, V), Map[K, V]]): Map[K, V] =
+    transforms.foldLeft(builder()) {
+      case (b, Transform.AddOne(kv)) => b.addOne(kv)
+      case (b, Transform.AddAllList(kvs)) => b.addAll(kvs)
+      case (b, Transform.AddAllMap(kvs)) => b.addAll(kvs)
+      case (b, Transform.Clear) => b.clear(); b
+    }.result()
+
+
+  property("Multiple transforms on ListMapBuilder give same result as HashMapBuilder") =
+    forAll(transformGen) { transforms: Seq[Transform] =>
+      interpret(transforms, () => ListMap.newBuilder) ?= interpret(transforms, () => HashMap.newBuilder)
+  }
+
+}


### PR DESCRIPTION
This fixes a bug that I introduced in https://github.com/scala/scala/pull/7547 where the builder, when addAll'ing a `Map`, wasn't updating its underlying `ListMap`.

Now a property test is added to validate `ListMapBuilder#addAll(Map)` works identically to `HashMap.newBuilder.addAll(Map)` among other things. 