### PR TITLE
LMF only builds bridges for SAMmy

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -115,7 +115,11 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
 
       val samBridges = logResultIf[List[Symbol]](s"will add SAM bridges for $fun", _.nonEmpty) {
         userSamCls.fold[List[Symbol]](Nil) {
-          _.info.findMembers(excludedFlags = 0L, requiredFlags = BRIDGE).toList
+          _.info.findMember(sam.name, excludedFlags = 0L, requiredFlags = BRIDGE, stableOnly = false) match {
+            case NoSymbol => Nil
+            case bridges if bridges.isOverloaded => bridges.alternatives
+            case bridge => bridge :: Nil
+          }
         }
       }
 

--- a/test/files/run/t11373/Fun0.java
+++ b/test/files/run/t11373/Fun0.java
@@ -1,0 +1,5 @@
+public interface Fun0 {
+    String ap();
+
+    default Fun0 test(Fun0 b) { return null; }
+}

--- a/test/files/run/t11373/Fun0Impl.java
+++ b/test/files/run/t11373/Fun0Impl.java
@@ -1,0 +1,3 @@
+public interface Fun0Impl extends Fun0 {
+    default Fun0Impl test(Fun0 b) { return null; }
+}

--- a/test/files/run/t11373/Test.scala
+++ b/test/files/run/t11373/Test.scala
@@ -1,0 +1,3 @@
+object Test extends App {
+  val f: Fun0Impl = () => null
+}


### PR DESCRIPTION
I think the intent in #6087 was to only consider bridges for the SAM method. Passing other bridge methods to LMF will result in a crash, as shown in scala/bug#11373


Fix scala/bug#11373