### PR TITLE
Distinguish backquote underscore as variable name

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5204,7 +5204,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             inEmptyPackage orElse lookupInRoot(name) match {
               case NoSymbol => issue(SymbolNotFoundError(tree, name, context.owner, startContext))
               case sym      => typed1(tree setSymbol sym, mode, pt)
-                }
+            }
           case LookupSucceeded(qual, sym)   =>
             (// this -> Foo.this
             if (sym.isThisSym)
@@ -5231,8 +5231,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       def typedIdentOrWildcard(tree: Ident) = {
         val name = tree.name
         if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(typedIdentCount)
-        if ((name == nme.WILDCARD && mode.typingPatternNotConstructor) ||
-            (name == tpnme.WILDCARD && mode.inTypeMode))
+        if (!tree.isBackquoted &&
+            ((name == nme.WILDCARD && mode.typingPatternNotConstructor) ||
+             (name == tpnme.WILDCARD && mode.inTypeMode)))
           tree setType makeFullyDefined(pt)
         else
           typedIdent(tree, name)

--- a/test/files/neg/t11374.check
+++ b/test/files/neg/t11374.check
@@ -1,0 +1,4 @@
+t11374.scala:8: error: _ is already defined as value _
+  val `_` = 17   // not ok
+      ^
+one error found

--- a/test/files/neg/t11374.scala
+++ b/test/files/neg/t11374.scala
@@ -1,0 +1,9 @@
+
+class C {
+  val `_` = 42   // ok
+}
+
+class D {
+  val `_` = 42
+  val `_` = 17   // not ok
+}

--- a/test/files/neg/t11374b.check
+++ b/test/files/neg/t11374b.check
@@ -1,0 +1,7 @@
+t11374b.scala:3: error: not found: value _
+  val Some(`_`) = Option(42)  // was crashola
+           ^
+t11374b.scala:6: error: not found: value _
+    val Some(`_`) = Option(42)  // was crashola
+             ^
+two errors found

--- a/test/files/neg/t11374b.scala
+++ b/test/files/neg/t11374b.scala
@@ -1,0 +1,8 @@
+
+class C {
+  val Some(`_`) = Option(42)  // was crashola
+
+  def f(): Unit = {
+    val Some(`_`) = Option(42)  // was crashola
+  }
+}

--- a/test/files/neg/t7691.scala
+++ b/test/files/neg/t7691.scala
@@ -30,3 +30,7 @@ object Test {
     val _ = 17        // was error
   }
 }
+
+class C {
+  val `_` = 42        // was crashola, see t11374
+}

--- a/test/files/pos/t11374.scala
+++ b/test/files/pos/t11374.scala
@@ -1,0 +1,5 @@
+
+class C {
+  val `_` = 42
+  val Some(`_`) = Option(42)
+}


### PR DESCRIPTION
A previous fix not to take `val _ = e` as defining a variable
or member named underscore did not consider backquoted underscore.
Now backquoted underscore is taken as introducing the variable.
This turns on recognizing the pattern tree during parser.

Fixes scala/bug#11374