### PR TITLE
Don't specialize super accessors / Fix specialization in traits

### DIFF
--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -308,6 +308,11 @@ trait Printers extends api.Printers { self: SymbolTable =>
       if (qual.nonEmpty || (checkSymbol && tree.symbol != NoSymbol)) print(resultName + ".")
       print("super")
       if (mix.nonEmpty) print(s"[$mix]")
+      else if (settings.debug) tree.tpe match {
+        case st: SuperType => print(s"[${st.supertpe}]")
+        case tp: Type => print(s"[$tp]")
+        case _ =>
+      }
     }
 
     protected def printThis(tree: This, resultName: => String) = {

--- a/test/files/run/specialize-functional-interface/T.scala
+++ b/test/files/run/specialize-functional-interface/T.scala
@@ -1,0 +1,1 @@
+trait T[@specialized(Int) A] { def t(a: A): A }

--- a/test/files/run/specialize-functional-interface/Test_1.java
+++ b/test/files/run/specialize-functional-interface/Test_1.java
@@ -1,0 +1,8 @@
+class Test_1 {
+    public T<?> doubler() {
+        return new T$mcI$sp() {
+            public int t$mcI$sp(int i) { return i * 2; }
+            public Object t(Object i) { return (int) i * 2; }
+        };
+    }
+}

--- a/test/files/run/specialize-functional-interface/Test_2.scala
+++ b/test/files/run/specialize-functional-interface/Test_2.scala
@@ -1,0 +1,4 @@
+object Test extends App {
+  val result = new Test_1().doubler().asInstanceOf[T[Int]].t(1)
+  assert(result == 2)
+}

--- a/test/files/run/t10277.check
+++ b/test/files/run/t10277.check
@@ -1,0 +1,4 @@
+put$mcJ$sp
+fillRange$mcJ$sp
+fillRange$mcJ$sp$
+fillRange$mcJ$sp

--- a/test/files/run/t10277.scala
+++ b/test/files/run/t10277.scala
@@ -1,0 +1,28 @@
+trait Column {}
+
+trait TypedColumn[@specialized(Long, Double) T] extends Column {
+  def put(idx: Int, value: T): Unit
+
+  def fillRange(start: Int, len: Int, value: T): Unit = {
+    var idx = start
+    val end = start + len
+    while (idx < end) {
+      put(idx, value)
+      idx += 1
+    }
+  }
+}
+
+final class LongColumn extends TypedColumn[Long] {
+  override def put(idx: Int, value: Long): Unit = {
+    val frames = Thread.currentThread().getStackTrace.toList.drop(1).takeWhile(_.getMethodName != "main")
+    println(frames.map(_.getMethodName).mkString("\n"))
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val c = new LongColumn
+    c.fillRange(0, 1, 10L)
+  }
+}

--- a/test/files/run/t10277b.check
+++ b/test/files/run/t10277b.check
@@ -1,0 +1,4 @@
+g$mcI$sp
+g$mcI$sp$
+g$mcI$sp
+f$mcI$sp

--- a/test/files/run/t10277b.scala
+++ b/test/files/run/t10277b.scala
@@ -1,0 +1,20 @@
+trait A[@specialized(Int) T] {
+  def f(x: T): Unit
+}
+
+trait B[@specialized(Int) T] {
+  def g(x: T): Unit = {
+    val frames = Thread.currentThread().getStackTrace.toList.drop(1).takeWhile(_.getMethodName != "main")
+    println(frames.map(_.getMethodName).mkString("\n"))
+  }
+}
+
+class C[@specialized(Int) T] extends A[T] with B[T] {
+  def f(x: T): Unit = g(x)
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    new C[Int].f(0)
+  }
+}

--- a/test/files/specialized/t8431.scala
+++ b/test/files/specialized/t8431.scala
@@ -1,18 +1,16 @@
-import scala.{ specialized => spec }
-
-trait EqProductFoo[@spec(Int) A] {
-  def eqv(x0: A): Boolean = true
+trait Top[@specialized(Int) A] {
+  def foo(x: A): Boolean = true
 }
 
-trait OrderProductFoo[@spec(Int) A] extends EqProductFoo[A] {
-  override def eqv(x0: A): Boolean = super.eqv(x0)
+trait Mid[@specialized(Int) A] extends Top[A] {
+  override def foo(x: A): Boolean = super.foo(x)
 }
 
-class C extends OrderProductFoo[Int]
+class C extends Mid[Int]
 
 object Test {
   def main(args: Array[String]): Unit = {
     val c = new C
-    println(c.eqv(42))
+    println(c.foo(42))
   }
 }


### PR DESCRIPTION
(Hijacked by Adriaan.)

My hypothesis is that super call chains have to stick to methods with
the same name, because as soon as you invokevirtual another method,
your next invokevirtual will go all the way down to the dynamic type,
even though you were expecting to be in a supercall chain. Because
specialized methods are name mangled and often just delegate to the
non-specialized method, having specialized super accessors causes
problems. So, just don't do that!

We no longer emit specialized overloads of super accessors, unless
for the case tested by run/t4996.scala. Normally, we go into the
boxed world on a super call, and stay there until we hit our target.

Mixin's rebindSuper has to know about this too:

The specialized version `T$sp` of a trait `T` will have a super accessor
that has the same alias as the super accessor in trait `T`; we must
rebind super from the vantage point of the original trait `T`, not the
specialized `T$sp` (it's inserted in the base class seq late in the game
and doesn't count as a super class in the super-call scheme).

This also means rebindSuper won't rebind to specialized methods, unless
we're looking for the super of a specialized method (as that would
entail a name change during a super call chain).

Fixes scala/bug#10277
Fixes scala/bug#6265
Fixes scala/bug#8431

See 9733f56 and its commit message for an in-depth analysis