### PR TITLE
Deprecated reduce in order to be symmetric to the fold API

### DIFF
--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -669,6 +669,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *  @return         The result of applying reduce operator `op` between all the elements if the $coll is nonempty.
     *  @throws UnsupportedOperationException if this $coll is empty.
     */
+  @deprecated("Use reduceLeft instead", "2.13.0")
   def reduce[B >: A](op: (B, B) => B): B = reduceLeft(op)
 
   /** Reduces the elements of this $coll, if any, using the specified

--- a/test/files/run/t8428.scala
+++ b/test/files/run/t8428.scala
@@ -1,6 +1,6 @@
 object Test extends App {
   val xs = List.tabulate(4)(List(_))
-  val i = xs.map(_.iterator).reduce { (a,b) =>
+  val i = xs.map(_.iterator).reduceLeft { (a,b) =>
     a.hasNext
     a ++ b
   }


### PR DESCRIPTION
This PR deprecates `IterableOnce.reduce` in order to be 'in sync' with `fold`.

See [this discussion](https://twitter.com/julienrf/status/1087663655200669701).