### PR TITLE
Link useful Option functions

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -67,8 +67,8 @@ object Option {
  *  - [[isDefined]] — True if not empty
  *  - [[isEmpty]] — True if empty
  *  - [[nonEmpty]] — True if not empty
- *  - [[orElse]] — Return default optional value if empty
- *  - [[getOrElse]] — Return default value if empty
+ *  - [[orElse]] — Evaluate and return alternate optional value if empty
+ *  - [[getOrElse]] — Evaluate and return alternate value if empty
  *  - [[get]] — Return value, throw exception if empty
  *  - [[fold]] —  Apply function on optional value, return default if empty
  *  - [[map]] — Apply a function on the optional value

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -63,6 +63,27 @@ object Option {
  *  This allows for sophisticated chaining of $option values without
  *  having to check for the existence of a value.
  *
+ * These are useful helper functions that exist for both $some and $none.
+ *  - [[isDefined]] — True if not empty
+ *  - [[isEmpty]] — True if empty
+ *  - [[nonEmpty]] — True if not empty
+ *  - [[orElse]] — Return default optional value if empty
+ *  - [[getOrElse]] — Return default value if empty
+ *  - [[get]] — Return value, throw exception if empty
+ *  - [[fold]] —  Apply function on optional value, return default if empty
+ *  - [[map]] — Apply a function on the optional value
+ *  - [[flatMap]] — Same as map but function must return an optional value
+ *  - [[foreach]] — Apply a procedure on option value
+ *  - [[collect]] — Apply partial pattern match on optional value
+ *  - [[filter]] — An optional value satisfies predicate
+ *  - [[filterNot]] — An optional value doesn't satisfy predicate
+ *  - [[exists]] — Apply predicate on optional value, or false if empty
+ *  - [[forall]] — Apply predicate on optional value, or true if empty
+ *  - [[contains]] — Checks if value equals optional value, or false if empty
+ *  - [[toList]] — Unary list of optional value, otherwise the empty list
+ *  - [[toRight]] — Sum type for optional value is "Right", otherwise default value is "Left"
+ *  - [[toLeft]] — Sum type for optional value is "Left", otherwise default value is "Right"
+ *
  *  A less-idiomatic way to use $option values is via pattern matching: {{{
  *  val nameMaybe = request getParameter "name"
  *  nameMaybe match {

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -63,7 +63,7 @@ object Option {
  *  This allows for sophisticated chaining of $option values without
  *  having to check for the existence of a value.
  *
- * These are useful helper functions that exist for both $some and $none.
+ * These are useful methods that exist for both $some and $none.
  *  - [[isDefined]] — True if not empty
  *  - [[isEmpty]] — True if empty
  *  - [[nonEmpty]] — True if not empty

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -81,8 +81,6 @@ object Option {
  *  - [[forall]] — Apply predicate on optional value, or true if empty
  *  - [[contains]] — Checks if value equals optional value, or false if empty
  *  - [[toList]] — Unary list of optional value, otherwise the empty list
- *  - [[toRight]] — Sum type for optional value is "Right", otherwise default value is "Left"
- *  - [[toLeft]] — Sum type for optional value is "Left", otherwise default value is "Right"
  *
  *  A less-idiomatic way to use $option values is via pattern matching: {{{
  *  val nameMaybe = request getParameter "name"


### PR DESCRIPTION
There are over 100 functions in the docs for `Option`.  This is mostly because it is compatible with `Iterable`.  However, there are only a few dozen useful ones.  It's hard for beginners to find them, though.

The top of the page could include code examples for each of those methods, but how about adding a list of links to the useful methods?

There was also a concern from @som-snytt in #7586 that the functions for `Option` should be favored over pattern matching.  