### PR TITLE
Bring back deprecated Symbol.isLocal method

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1036,6 +1036,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     /** Is this symbol owned by a package? */
     final def isTopLevel = owner.isPackageClass
 
+    // shim for sbt's compiler interface
+    /** Is this symbol defined in a block? */
+    @deprecated("use isLocalToBlock instead", "2.11.0")
+    final def isLocal: Boolean = owner.isTerm
+
     /** Is this symbol defined in a block? */
     final def isLocalToBlock: Boolean = owner.isTerm
 


### PR DESCRIPTION
It's used by the compiler bridge.

This should hopefully fix scala/scala-dev#602