### PR TITLE
Remove redundant `final` flag on objects

### DIFF
--- a/src/library/scala/collection/StringParsers.scala
+++ b/src/library/scala/collection/StringParsers.scala
@@ -17,7 +17,7 @@ import scala.annotation.tailrec
 
 /** A module containing the implementations of parsers from strings to numeric types, and boolean
  */
-final private[scala] object StringParsers {
+private[scala] object StringParsers {
 
   //compile-time constant helpers
 

--- a/src/library/scala/collection/immutable/ChampCommon.scala
+++ b/src/library/scala/collection/immutable/ChampCommon.scala
@@ -17,7 +17,7 @@ import java.lang.Integer.bitCount
 import java.lang.Math.ceil
 import java.lang.System.arraycopy
 
-private[immutable] final object Node {
+private[immutable] object Node {
 
   final val HashCodeLength = 32
 

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -242,7 +242,7 @@ final class HashSet[A] private[immutable] (val rootNode: SetNode[A])
   }
 }
 
-private[immutable] final object SetNode {
+private[immutable] object SetNode {
 
   private final val EmptySetNode = new BitmapIndexedSetNode(0, 0, Array.empty, Array.empty, 0, 0)
 

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -204,7 +204,7 @@ final class VectorMap[K, +V] private (
 object VectorMap extends MapFactory[VectorMap] {
   private[VectorMap] sealed trait Tombstone
   private[VectorMap] object Tombstone {
-    final case object Kinless extends Tombstone {
+    case object Kinless extends Tombstone {
       override def toString = "⤞"
     }
     final case class NextOfKin private[Tombstone] (distance: Int) extends Tombstone {

--- a/src/library/scala/concurrent/BlockContext.scala
+++ b/src/library/scala/concurrent/BlockContext.scala
@@ -58,7 +58,7 @@ trait BlockContext {
 }
 
 object BlockContext {
-  private[this] final object DefaultBlockContext extends BlockContext {
+  private[this] object DefaultBlockContext extends BlockContext {
     override final def blockOn[T](thunk: =>T)(implicit permission: CanAwait): T = thunk
   }
 

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -565,7 +565,7 @@ object Future {
 
   /** A Future which is never completed.
    */
-  final object never extends Future[Nothing] {
+  object never extends Future[Nothing] {
 
     private[this] final val notGoingToHappen = new CountDownLatch(1)
 
@@ -866,7 +866,7 @@ object Future {
   // by just not ever using it itself. scala.concurrent
   // doesn't need to create defaultExecutionContext as
   // a side effect.
-  private[concurrent] final object InternalCallbackExecutor extends ExecutionContext with java.util.concurrent.Executor with BatchingExecutor {
+  private[concurrent] object InternalCallbackExecutor extends ExecutionContext with java.util.concurrent.Executor with BatchingExecutor {
     override protected final def unbatchedExecute(r: Runnable): Unit = r.run()
     override final def reportFailure(t: Throwable): Unit =
       ExecutionContext.defaultReporter(new IllegalStateException("problem in scala.concurrent internal callback", t))

--- a/src/library/scala/concurrent/Promise.scala
+++ b/src/library/scala/concurrent/Promise.scala
@@ -113,7 +113,7 @@ trait Promise[T] {
   def tryFailure(cause: Throwable): Boolean = tryComplete(Failure(cause))
 }
 
-final object Promise {
+object Promise {
   /** Creates a promise object which can be completed with a value.
    *
    *  @tparam T       the type of the value in the promise

--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -45,7 +45,7 @@ private[impl] final class CompletionLatch[T] extends AbstractQueuedSynchronizer 
   }
 }
 
-private[concurrent] final object Promise {
+private[concurrent] object Promise {
     /**
      * Link represents a completion dependency between 2 DefaultPromises.
      * As the DefaultPromise referred to by a Link can itself be linked to another promise


### PR DESCRIPTION
Dotty now warns about them.