### PR TITLE
Promote stats flag to setting

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -434,11 +434,10 @@ trait ScalaSettings extends AbsScalaSettings
 
   val YoptLogInline = StringSetting("-Yopt-log-inline", "package/Class.method", "Print a summary of inliner activity; `_` to print all, prefix match to select.", "")
 
-  val Ystatistics = PhasesSetting("-Ystatistics", "Print compiler statistics for specific phases", "parser,typer,patmat,erasure,cleanup,jvm")
-  override def YstatisticsEnabled = Ystatistics.value.nonEmpty
+  val Ystatistics = PhasesSetting("-Ystatistics", "Print compiler statistics for specific phases", "parser,typer,patmat,erasure,cleanup,jvm").withPostSetHook(s => YstatisticsEnabled.value = s.value.nonEmpty)
+  val YstatisticsEnabled = BooleanSetting("-Ystatistics-enabled", "Internal setting, indicating that statistics are enabled for some phase.").internalOnly()
 
-  val YhotStatistics = BooleanSetting("-Yhot-statistics-enabled", s"Enable `${Ystatistics.name}` to print hot statistics.")
-  override def YhotStatisticsEnabled = YhotStatistics.value
+  val YhotStatisticsEnabled = BooleanSetting("-Yhot-statistics", s"Enable `${Ystatistics.name}` to also print hot statistics.")
 
   val YprofileEnabled = BooleanSetting("-Yprofile-enabled", "Enable profiling.")
   val YprofileDestination = StringSetting("-Yprofile-destination", "file", "where to send profiling output - specify a file, default is to the console.", "").

--- a/src/reflect/scala/reflect/internal/settings/AbsSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/AbsSettings.scala
@@ -14,18 +14,17 @@ package scala
 package reflect.internal
 package settings
 
-/** A Settings abstraction boiled out of the original highly mutable Settings
- *  class with the intention of creating an ImmutableSettings which can be used
- *  interchangeably.   Except of course without the mutants.
+/** Abstract settings, which is refined for `reflect` and `nsc`.
  */
-
 trait AbsSettings {
-  type Setting <: AbsSettingValue      // Fix to the concrete Setting type
 
+  /** Subclasses should further constrain Setting. */
+  type Setting <: AbsSettingValue
+
+  /** A setting is a value which may have been specified by the user. */
   trait AbsSettingValue {
     type T <: Any
     def value: T
     def isDefault: Boolean
   }
 }
-

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -58,10 +58,8 @@ abstract class MutableSettings extends AbsSettings {
   def uniqid: BooleanSetting
   def verbose: BooleanSetting
 
-  // Define them returning a `Boolean` to avoid breaking bincompat change
-  // TODO: Add these fields typed as `BooleanSetting` for 2.13.x
-  def YhotStatisticsEnabled: Boolean = false
-  def YstatisticsEnabled: Boolean = false
+  def YhotStatisticsEnabled: BooleanSetting
+  def YstatisticsEnabled: BooleanSetting
 
   def Yrecursion: IntSetting
   def maxClassfileName: IntSetting

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -56,6 +56,9 @@ private[reflect] class Settings extends MutableSettings {
   val uniqid            = new BooleanSetting(false)
   val verbose           = new BooleanSetting(false)
 
+  val YhotStatisticsEnabled = new BooleanSetting(false)
+  val YstatisticsEnabled    = new BooleanSetting(false)
+
   val Yrecursion        = new IntSetting(0)
   val maxClassfileName  = new IntSetting(255)
   def isScala211        = true


### PR DESCRIPTION
Eliminates a to do comment.

It's easy to hate on the reflect library, and the settings mechanism, and especially the settings rube goldberg machine as abstracted by reflect.

I'm not sure but maybe reflect should have a simpler interface for flags which doesn't mess with settings; the compiler could just forward `def flag = setting.value`, which is simpler than the current rigmarole.