### PR TITLE
Fix the definition of SubType_refl

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1640,7 +1640,7 @@ trait Definitions extends api.StandardDefinitions {
       // Methods treated specially by implicit search
       lazy val Predef_conforms = getMemberIfDefined(PredefModule, nme.conforms)
       lazy val SubTypeModule   = requiredModule[scala.<:<[_,_]]
-      lazy val SubType_refl    = getMemberIfDefined(PredefModule, nme.refl)
+        lazy val SubType_refl  = getMemberMethod(SubTypeModule, nme.refl)
 
       lazy val Predef_classOf      = getMemberMethod(PredefModule, nme.classOf)
       lazy val Predef_implicitly   = getMemberMethod(PredefModule, nme.implicitly)


### PR DESCRIPTION
The previous definition looked into the wrong module, that didn't break
anything because it was using getMemberIfDefined and because this symbol
is only used to shortcut part of implicit search.