### PR TITLE
Eliminate LaTeX-style quotations from compiler output and comments (round 2)

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -623,7 +623,7 @@ self =>
 
     /** {{{
      *  semi = nl {nl} | `;`
-     *  nl  = `\n' // where allowed
+     *  nl  = `\n` // where allowed
      *  }}}
      */
     def acceptStatSep(): Unit = in.token match {
@@ -2915,8 +2915,8 @@ self =>
           classContextBounds = contextBoundBuf.toList
           val tstart = (in.offset :: classContextBounds.map(_.pos.start)).min
           if (!classContextBounds.isEmpty && mods.isTrait) {
-            val viewBoundsExist = if (settings.isScala214) "" else " nor view bounds `<% ...'"
-              syntaxError(s"traits cannot have type parameters with context bounds `: ...'$viewBoundsExist", skipIt = false)
+            val viewBoundsExist = if (settings.isScala214) "" else " nor view bounds `<% ...`"
+              syntaxError(s"traits cannot have type parameters with context bounds `: ...`$viewBoundsExist", skipIt = false)
             classContextBounds = List()
           }
           val constrAnnots = if (!mods.isTrait) constructorAnnotations() else Nil

--- a/test/files/neg/t882.check
+++ b/test/files/neg/t882.check
@@ -1,4 +1,4 @@
-t882.scala:2: error: traits cannot have type parameters with context bounds `: ...' nor view bounds `<% ...'
+t882.scala:2: error: traits cannot have type parameters with context bounds `: ...` nor view bounds `<% ...`
 trait SortedSet[A <% Ordered[A]] {
                                  ^
 one error found


### PR DESCRIPTION
Follow-up of #7583. Seems to have missed 1 or 2 occurrences in Parsers.scala.