### PR TITLE
upgrade MiMa to 0.1.18 (was 0.1.15)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ buildInfoKeys := Seq[BuildInfoKey](buildClasspath)
 
 buildInfoPackage := "scalabuild"
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.15")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")
 
 libraryDependencies ++= Seq(
   "org.eclipse.jgit" % "org.eclipse.jgit" % "4.6.0.201612231935-r",


### PR DESCRIPTION
motivation: older versions are incompatible with sbt-whitesource
(reference: https://github.com/lightbend/migration-manager/releases/tag/0.1.18)

it would be nice to further upgrade to a newer version like 0.2.0 or
0.3.0, but for now I just want to resolve the incompatibility with
minimum fuss.