### PR TITLE
Remove s.c.i.Node#sizePredicate

### DIFF
--- a/src/library/scala/collection/immutable/ChampCommon.scala
+++ b/src/library/scala/collection/immutable/ChampCommon.scala
@@ -27,12 +27,6 @@ private[immutable] object Node {
 
   final val MaxDepth = ceil(HashCodeLength.toDouble / BitPartitionSize).toInt
 
-  final val SizeEmpty = 0
-
-  final val SizeOne = 1
-
-  final val SizeMoreThanOne = 2
-
   final val BranchingFactor = 1 << BitPartitionSize
 
   final def maskFrom(hash: Int, shift: Int): Int = (hash >>> shift) & BitPartitionMask
@@ -60,8 +54,6 @@ private[immutable] abstract class Node[T <: Node[T]] {
   def getPayload(index: Int): Any
 
   def getHash(index: Int): Int
-
-  def sizePredicate: Int
 
   def cachedJavaKeySetHashCode: Int
 

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -273,8 +273,6 @@ private[immutable] sealed abstract class SetNode[A] extends Node[SetNode[A]] {
 
   def getPayload(index: Int): A
 
-  def sizePredicate: Int
-
   def size: Int
 
   def foreach[U](f: A => U): Unit
@@ -413,19 +411,22 @@ private final class BitmapIndexedSetNode[A](
       val subNodeNew = subNode.removed(element, originalHash, elementHash, shift + BitPartitionSize)
       // assert(subNodeNew.sizePredicate != SizeEmpty, "Sub-node must have at least one element.")
 
-      if (subNodeNew eq subNode) return this
-      subNodeNew.sizePredicate match {
-        case SizeOne =>
-          if (this.payloadArity == 0 && this.nodeArity == 1) { // escalate (singleton or empty) result
-            return subNodeNew
-          }
-          else { // inline value (move to front)
-            return copyAndMigrateFromNodeToInline(bitpos, elementHash, subNode, subNodeNew)
-          }
+      // cache just in case subNodeNew is a hashCollision node, in which in which case a little arithmetic is avoided
+      // in Vector#length
+      val subNodeNewSize = subNodeNew.size
 
-        case SizeMoreThanOne =>
-          // modify current node (set replacement node)
-          return copyAndSetNode(bitpos, subNode, subNodeNew)
+      if (subNodeNewSize == 1) {
+        if (this.size == subNode.size) {
+          // subNode is the only child (no other data or node children of `this` exist)
+          // escalate (singleton or empty) result
+          return subNodeNew
+        } else {
+          // inline value (move to front)
+          return copyAndMigrateFromNodeToInline(bitpos, elementHash, subNode, subNodeNew)
+        }
+      } else if (subNodeNewSize > 1) {
+        // modify current node (set replacement node)
+        return copyAndSetNode(bitpos, subNode, subNodeNew)
       }
     }
 
@@ -460,13 +461,6 @@ private final class BitmapIndexedSetNode[A](
       }
     }
   }
-
-  def sizePredicate: Int =
-    if (nodeArity == 0) payloadArity match {
-      case 0 => SizeEmpty
-      case 1 => SizeOne
-      case _ => SizeMoreThanOne
-    } else SizeMoreThanOne
 
   def hasPayload: Boolean = dataMap != 0
 
@@ -1065,8 +1059,6 @@ private final class HashCollisionSetNode[A](val originalHash: Int, val hash: Int
   def getPayload(index: Int): A = content(index)
 
   override def getHash(index: Int): Int = originalHash
-
-  def sizePredicate: Int = SizeMoreThanOne
 
   def size: Int = content.length
 


### PR DESCRIPTION
Since `Node#sizePredicate: Int` was written, nodes have been modified to cache their sizes, so I don't think there's any longer a reason to keep around size predicate logic for deciding whether a node's size is {0, 1, >1}, which is probably even more costly than looking at the member `var size: Int` because it involves doing bit counting. 


