### PR TITLE
Conditional is always boolean

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1453,6 +1453,11 @@ self =>
         in.nextToken()
         val r = expr()
         accept(RPAREN)
+        if (isWildcard(r))
+          placeholderParams.head.tpt match {
+            case tpt @ TypeTree() => tpt.setType(definitions.BooleanTpe)
+            case _                =>
+          }
         r
       } else {
         accept(LPAREN)

--- a/test/files/pos/ifunc.scala
+++ b/test/files/pos/ifunc.scala
@@ -1,0 +1,10 @@
+
+trait T {
+  val f = if (_) 42 else 17
+
+  val p = while (_) println    // weird
+
+  val q = do println while (_) // weird
+
+  val g = (b: () => Boolean) => while (b()) println    // less weird
+}


### PR DESCRIPTION
Syntactic support for `if (_)`, which
is a placeholder example in the spec.
Probably the code only occurs in REPL.