### PR TITLE
Use <:< for Option.unzip

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -345,7 +345,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
     *  @return       a pair of Options, containing, respectively, the first and second half
     *                of the element pair of this Option.
     */
-  final def unzip[A1, A2](implicit asPair: A => (A1, A2)): (Option[A1], Option[A2]) = {
+  final def unzip[A1, A2](implicit asPair: A <:< (A1, A2)): (Option[A1], Option[A2]) = {
     if (isEmpty)
       (None, None)
     else {
@@ -364,7 +364,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
     *  @return         a triple of Options, containing, respectively, the first, second, and third
     *                  elements from the element triple of this Option.
     */
-  final def unzip3[A1, A2, A3](implicit asTriple: A => (A1, A2, A3)): (Option[A1], Option[A2], Option[A3]) = {
+  final def unzip3[A1, A2, A3](implicit asTriple: A <:< (A1, A2, A3)): (Option[A1], Option[A2], Option[A3]) = {
     if (isEmpty)
       (None, None, None)
     else {


### PR DESCRIPTION
Currently, `Option.unzip` uses `asPair: A => (A, A)`.

The type checking error it produces is:

    scala> Some(42).unzip
                    ^
    error: No implicit view available from Int => (A1, A2).

It should be `asPair: A <:< (A, A)`, and give the error:

    scala> Some(42).unzip
                    ^
    error: Cannot prove that Int <:< (A1, A2).

The `<:<` symbol is cryptic, but the error overall is much better than one that confusingly mentions "views".  This also makes `unzip` consistent with the rest of `Option` library which uses `<:<`, see `orNull` and `flatten`.