### PR TITLE
Promote -deprecation to -Xlint:deprecation

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -93,7 +93,7 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
     def deprecationWarning(pos: Position, sym: Symbol): Unit = {
       val version = sym.deprecationVersion.getOrElse("")
       val since   = if (version.isEmpty) version else s" (since $version)"
-      val message = sym.deprecationMessage match { case Some(msg) => s": $msg"        case _ => "" }
+      val message = sym.deprecationMessage.map(": " + _).getOrElse("")
       deprecationWarning(pos, sym, s"$sym${sym.locationString} is deprecated$since$message", version)
     }
 

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -111,6 +111,7 @@ trait Warnings {
     val ValPattern             = LintWarning("valpattern",                "Enable pattern checks in val definitions.")
     val EtaZero                = LintWarning("eta-zero",                  "Warn on eta-expansion (rather than auto-application) of zero-ary method.")
     val EtaSam                 = LintWarning("eta-sam",                   "Warn on eta-expansion to meet a Java-defined functional interface that is not explicitly annotated with @FunctionalInterface.")
+    val Deprecation            = LintWarning("deprecation",               "Enable linted deprecations.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
   }
@@ -138,6 +139,7 @@ trait Warnings {
   def lintValPatterns            = lint contains ValPattern
   def warnEtaZero                = lint contains EtaZero
   def warnEtaSam                 = lint contains EtaSam
+  def lintDeprecation            = lint contains Deprecation
 
   // The Xlint warning group.
   val lint = MultiChoiceSetting(
@@ -149,6 +151,7 @@ trait Warnings {
   ).withPostSetHook { s =>
     if (s contains Unused) warnUnused.enable(UnusedWarnings.Linted)
     else warnUnused.disable(UnusedWarnings.Linted)
+    if (s.contains(Deprecation)) deprecation.value = true
   }
 
   // Backward compatibility.

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1603,7 +1603,7 @@ abstract class RefChecks extends Transform {
         // on Unit, in which case we had better let it slide.
         val isOk = (
              sym.isGetter
-          || (sym.name containsName nme.DEFAULT_GETTER_STRING)
+          || sym.isDefaultGetter
           || sym.allOverriddenSymbols.exists(over => !(over.tpe.resultType =:= sym.tpe.resultType))
         )
         if (!isOk)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2372,7 +2372,7 @@ trait Types
     override def isShowAsInfixType: Boolean =
       hasLength(args, 2) &&
         sym.getAnnotation(ShowAsInfixAnnotationClass)
-         .map(_ booleanArg 0 getOrElse true)
+         .map(_.booleanArg(0).getOrElse(true))
          .getOrElse(!Character.isUnicodeIdentifierStart(sym.decodedName.head))
 
     private[Types] def invalidateTypeRefCaches(): Unit = {

--- a/test/files/neg/deprecated.check
+++ b/test/files/neg/deprecated.check
@@ -1,0 +1,27 @@
+deprecated.scala:5: warning: Specify both message and version: @deprecated("message", since = "1.0")
+  @deprecated def f = ???
+   ^
+deprecated.scala:9: warning: Specify both message and version: @deprecated("message", since = "1.0")
+  @deprecated("Don't use it."/*, forRemoval=true*/) def stale = ???
+   ^
+deprecated.scala:21: warning: method f in trait T is deprecated
+  t.f
+    ^
+deprecated.scala:22: warning: method g in trait T is deprecated (since 1.0): Don't use it.
+  t.g
+    ^
+deprecated.scala:23: warning: method stale in trait T is deprecated: Don't use it.
+  t.stale
+    ^
+deprecated.scala:24: warning: method gross in trait T is deprecated (since 1.0): Don't use it.
+  t.gross
+    ^
+deprecated.scala:26: warning: method innie in trait T is deprecated (since 1.0): Don't use it.
+  t.innie   // warn because API will be removed
+    ^
+deprecated.scala:27: warning: method keeper in trait T is deprecated (since 1.0): Prefer toString instead.
+  t.keeper  // don't warn because it's an inlined forwarder? maybe just warn.
+    ^
+error: No warnings can be incurred under -Xfatal-warnings.
+8 warnings found
+one error found

--- a/test/files/neg/deprecated.scala
+++ b/test/files/neg/deprecated.scala
@@ -1,0 +1,28 @@
+// scalac: -Xlint:deprecation -Xfatal-warnings -opt:inline -opt-inline-from:<sources>
+//
+
+trait T {
+  @deprecated def f = ???
+
+  @deprecated("Don't use it.", since="1.0") def g = ???
+
+  @deprecated("Don't use it."/*, forRemoval=true*/) def stale = ???
+
+  @deprecated("Don't use it.", since="1.0"/*, forRemoval=true*/) def gross = ???
+
+  @deprecated("Don't use it.", since="1.0"/*, forRemoval=true*/) @inline def innie = ???
+
+  @deprecated("Prefer toString instead.", since="1.0"/*, forRemoval=false*/) @inline def keeper = toString()
+}
+
+object Main {
+  def t: T = ???
+
+  t.f
+  t.g
+  t.stale
+  t.gross
+
+  t.innie   // warn because API will be removed
+  t.keeper  // don't warn because it's an inlined forwarder? maybe just warn.
+}


### PR DESCRIPTION
Promote `-deprecation` to `-Xlint:deprecation`, and demote complaining about missing `since` to lint.

(Setting the lint option also enables ordinary `-deprecation`; the lint is a superset.)

Was: Adopt `forRemoval` flag for `deprecated`.