### PR TITLE
s.c.i.Hash{Map,Set} concat/removedAll use shallow mutations

### DIFF
--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -33,14 +33,14 @@ import scala.runtime.Statics.releaseFence
   *  @define Coll `immutable.HashSet`
   *  @define coll immutable champ hash set
   */
-final class HashSet[A] private[immutable] (val rootNode: SetNode[A])
+final class HashSet[A] private[immutable](private[immutable] val rootNode: BitmapIndexedSetNode[A])
   extends AbstractSet[A]
     with StrictOptimizedSetOps[A, HashSet, HashSet[A]]
     with DefaultSerializable {
 
   releaseFence()
 
-  private[this] def newHashSetOrThis(newRootNode: SetNode[A]): HashSet[A] =
+  private[this] def newHashSetOrThis(newRootNode: BitmapIndexedSetNode[A]): HashSet[A] =
     if (rootNode eq newRootNode) this else new HashSet(newRootNode)
 
   override def iterableFactory: IterableFactory[HashSet] = HashSet
@@ -80,8 +80,58 @@ final class HashSet[A] private[immutable] (val rootNode: SetNode[A])
 
   override def concat(that: IterableOnce[A]): HashSet[A] =
     that match {
-      case hs: HashSet[A] => newHashSetOrThis(rootNode.concat(hs.rootNode, 0))
-      case _ => super.concat(that)
+      case hs: HashSet[A] =>
+        newHashSetOrThis(rootNode.concat(hs.rootNode, 0))
+      case hs: collection.mutable.HashSet[A] =>
+        val iter = hs.nodeIterator
+        var current = rootNode
+        while (iter.hasNext) {
+          val next = iter.next()
+          val originalHash = hs.unimproveHash(next.hash)
+          val improved = improve(originalHash)
+          current = current.updated(next.key, originalHash, improved, 0)
+
+          if (current ne rootNode) {
+            var shallowlyMutableNodeMap = Node.bitposFrom(Node.maskFrom(improved, 0))
+            while (iter.hasNext) {
+              val next = iter.next()
+              val originalHash = hs.unimproveHash(next.hash)
+              val improved = improve(originalHash)
+              shallowlyMutableNodeMap = current.updateWithShallowMutations(next.key, originalHash, improved, 0, shallowlyMutableNodeMap)
+            }
+            return new HashSet(current)
+          }
+        }
+        this
+      case _ =>
+        val iter = that.iterator
+        var current = rootNode
+        while (iter.hasNext) {
+          val element = iter.next()
+          val originalHash = element.##
+          val improved = improve(originalHash)
+          current = current.updated(element, originalHash, improved, 0)
+
+          if (current ne rootNode) {
+            // Note: We could have started with shallowlyMutableNodeMap = 0, however this way, in the case that
+            // the first changed key ended up in a subnode beneath root, we mark that root right away as being
+            // shallowly mutable.
+            //
+            // since `element` has just been inserted, and certainly caused a new root node to be created, we can say with
+            // certainty that it either caused a new subnode to be created underneath `current`, in which case we should
+            // carry on mutating that subnode, or it ended up as a child data pair of the root, in which case, no harm is
+            // done by including its bit position in the shallowlyMutableNodeMap anyways.
+            var shallowlyMutableNodeMap = Node.bitposFrom(Node.maskFrom(improved, 0))
+            while (iter.hasNext) {
+              val element = iter.next()
+              val originalHash = element.##
+              val improved = improve(originalHash)
+              shallowlyMutableNodeMap = current.updateWithShallowMutations(element, originalHash, improved, 0, shallowlyMutableNodeMap)
+            }
+            return new HashSet(current)
+          }
+        }
+        this
     }
 
   override def tail: HashSet[A] = this - head
@@ -131,6 +181,34 @@ final class HashSet[A] private[immutable] (val rootNode: SetNode[A])
             val newRootNode = rootNode.diff(hashSet.rootNode, 0)
             if (newRootNode.size == 0) HashSet.empty else newHashSetOrThis(rootNode.diff(hashSet.rootNode, 0))
           }
+        case hashSet: collection.mutable.HashSet[A] =>
+          val iter = hashSet.nodeIterator
+          var curr = rootNode
+          while (iter.hasNext) {
+            val next = iter.next()
+            val originalHash = hashSet.unimproveHash(next.hash)
+            val improved = improve(originalHash)
+            curr = curr.removed(next.key, originalHash, improved, 0)
+            if (curr ne rootNode) {
+              if (curr.size == 0) {
+                return HashSet.empty
+              }
+              while (iter.hasNext) {
+                val next = iter.next()
+                val originalHash = hashSet.unimproveHash(next.hash)
+                val improved = improve(originalHash)
+
+                curr.removeWithShallowMutations(next.key, originalHash, improved)
+
+                if (curr.size == 0) {
+                  return HashSet.empty
+                }
+              }
+              return new HashSet(curr)
+            }
+          }
+          this
+
         case other =>
           val thatKnownSize = other.knownSize
 
@@ -139,21 +217,7 @@ final class HashSet[A] private[immutable] (val rootNode: SetNode[A])
           } else if (thatKnownSize <= size) {
             /* this branch intentionally includes the case of thatKnownSize == -1. We know that HashSets are quite fast at look-up, so
             we're likely to be the faster of the two at that. */
-            val iter = other.iterator
-            var curr = rootNode
-            while(iter.hasNext) {
-              // TODO: add mutable.hashSet#contains(elem, hashCode)
-              // in order to avoid rehashing elements
-              val next = iter.next()
-              val originalHash = next.##
-              val improved = improve(originalHash)
-              curr = curr.removed(next, originalHash, improved, 0)
-              if (curr.size <= 0) {
-                return HashSet.empty
-              }
-            }
-
-            newHashSetOrThis(curr)
+            removedAllWithShallowMutations(other)
           } else {
             // TODO: Develop more sophisticated heuristic for which branch to take
             filterNot(other.contains)
@@ -161,6 +225,41 @@ final class HashSet[A] private[immutable] (val rootNode: SetNode[A])
       }
 
     }
+  }
+
+  /** Immutably removes all elements of `that` from this HashSet
+    *
+    * Mutation is used internally, but only on root SetNodes which this method itself creates.
+    *
+    * That is, this method is safe to call on published sets because it does not mutate `this`
+    */
+  private[this] def removedAllWithShallowMutations(that: IterableOnce[A]): HashSet[A] = {
+    val iter = that.iterator
+    var curr = rootNode
+    while (iter.hasNext) {
+      val next = iter.next()
+      val originalHash = next.##
+      val improved = improve(originalHash)
+      curr = curr.removed(next, originalHash, improved, 0)
+      if (curr ne rootNode) {
+        if (curr.size == 0) {
+          return HashSet.empty
+        }
+        while (iter.hasNext) {
+          val next = iter.next()
+          val originalHash = next.##
+          val improved = improve(originalHash)
+
+          curr.removeWithShallowMutations(next, originalHash, improved)
+
+          if (curr.size == 0) {
+            return HashSet.empty
+          }
+        }
+        return new HashSet(curr)
+      }
+    }
+    this
   }
 
   override def removedAll(that: IterableOnce[A]): HashSet[A] = that match {
@@ -172,18 +271,7 @@ final class HashSet[A] private[immutable] (val rootNode: SetNode[A])
       }
 
     case _ =>
-      val iter = that.iterator
-      var curr = rootNode
-      while (iter.hasNext) {
-        val next = iter.next()
-        val originalHash = next.##
-        val improved = improve(originalHash)
-        curr = curr.removed(next, originalHash, improved, 0)
-        if (curr.size <= 0) {
-          return HashSet.empty
-        }
-      }
-      newHashSetOrThis(curr)
+      removedAllWithShallowMutations(that)
   }
 
   override def partition(p: A => Boolean): (HashSet[A], HashSet[A]) = {
@@ -252,8 +340,7 @@ private[immutable] object SetNode {
 
   private final val EmptySetNode = new BitmapIndexedSetNode(0, 0, Array.empty, Array.empty, 0, 0)
 
-  def empty[A]: SetNode[A] =
-    EmptySetNode.asInstanceOf[SetNode[A]]
+  def empty[A]: BitmapIndexedSetNode[A] = EmptySetNode.asInstanceOf[BitmapIndexedSetNode[A]]
 
   final val TupleLength = 1
 
@@ -329,7 +416,7 @@ private final class BitmapIndexedSetNode[A](
   }
   */
 
-  def getPayload(index: Int): A = content(TupleLength * index).asInstanceOf[A]
+  def getPayload(index: Int): A = content(index).asInstanceOf[A]
 
   override def getHash(index: Int): Int = originalHashes(index)
 
@@ -352,7 +439,7 @@ private final class BitmapIndexedSetNode[A](
     false
   }
 
-  def updated(element: A, originalHash: Int, elementHash: Int, shift: Int): SetNode[A] = {
+  def updated(element: A, originalHash: Int, elementHash: Int, shift: Int): BitmapIndexedSetNode[A] = {
     val mask = maskFrom(elementHash, shift)
     val bitpos = bitposFrom(mask)
 
@@ -373,7 +460,6 @@ private final class BitmapIndexedSetNode[A](
         }
       }
     }
-
     if ((nodeMap & bitpos) != 0) {
       val index = indexFrom(nodeMap, mask, bitpos)
       val subNode = this.getNode(index)
@@ -388,8 +474,90 @@ private final class BitmapIndexedSetNode[A](
 
     copyAndInsertValue(bitpos, element, originalHash, elementHash)
   }
+  /** A variant of `updated` which performs shallow mutations on the root (`this`), and if possible, on immediately
+    * descendant child nodes (only one level beneath `this`)
+    *
+    * The caller should pass a bitmap of child nodes of this node, which this method may mutate.
+    * If this method may mutate a child node, then if the updated value is located in that child node, it will
+    * be shallowly mutated (its children will not be mutated).
+    *
+    * If instead this method may not mutate the child node in which the to-be-updated value is located, then
+    * that child will be updated immutably, but the result will be mutably re-inserted as a child of this node.
+    *
+    * @param key the key to update
+    * @param originalHash key.##
+    * @param keyHash the improved hash
+    * @param shallowlyMutableNodeMap bitmap of child nodes of this node, which can be shallowly mutated
+    *                                during the call to this method
+    *
+    * @return Int which is the bitwise OR of shallowlyMutableNodeMap and any freshly created nodes, which will be
+    *         available for mutations in subsequent calls.
+    */
+  def updateWithShallowMutations(element: A, originalHash: Int, elementHash: Int, shift: Int, shallowlyMutableNodeMap: Int): Int = {
+    val mask = maskFrom(elementHash, shift)
+    val bitpos = bitposFrom(mask)
 
-  def removed(element: A, originalHash: Int, elementHash: Int, shift: Int): SetNode[A] = {
+    if ((dataMap & bitpos) != 0) {
+      val index = indexFrom(dataMap, mask, bitpos)
+      val element0 = getPayload(index)
+      val element0UnimprovedHash = getHash(index)
+      if (element0UnimprovedHash == originalHash && element0 == element) {
+        shallowlyMutableNodeMap
+      } else {
+        val element0Hash = improve(element0UnimprovedHash)
+        val subNodeNew = mergeTwoKeyValPairs(element0, element0UnimprovedHash, element0Hash, element, originalHash, elementHash, shift + BitPartitionSize)
+        migrateFromInlineToNodeInPlace(bitpos, element0Hash, subNodeNew)
+        shallowlyMutableNodeMap | bitpos
+      }
+    } else if ((nodeMap & bitpos) != 0) {
+      val index = indexFrom(nodeMap, mask, bitpos)
+      val subNode = this.getNode(index)
+      val subNodeSize = subNode.size
+      val subNodeCachedJavaKeySetHashCode = subNode.cachedJavaKeySetHashCode
+
+      var returnNodeMap = shallowlyMutableNodeMap
+
+      val subNodeNew: SetNode[A] = subNode match {
+        case subNodeBm: BitmapIndexedSetNode[A] if (bitpos & shallowlyMutableNodeMap) != 0 =>
+          subNodeBm.updateWithShallowMutations(element, originalHash, elementHash, shift + BitPartitionSize, 0)
+          subNodeBm
+        case _ =>
+          val subNodeNew = subNode.updated(element, originalHash, elementHash, shift + BitPartitionSize)
+          if (subNodeNew ne subNode) {
+            returnNodeMap |= bitpos
+          }
+          subNodeNew
+      }
+
+      this.content(this.content.length - 1 - this.nodeIndex(bitpos)) = subNodeNew
+      this.size = this.size - subNodeSize + subNodeNew.size
+      this.cachedJavaKeySetHashCode = this.cachedJavaKeySetHashCode - subNodeCachedJavaKeySetHashCode + subNodeNew.cachedJavaKeySetHashCode
+      returnNodeMap
+    } else {
+      val dataIx = dataIndex(bitpos)
+      val idx = dataIx
+
+      val src = this.content
+      val dst = new Array[Any](src.length + TupleLength)
+
+      // copy 'src' and insert 2 element(s) at position 'idx'
+      arraycopy(src, 0, dst, 0, idx)
+      dst(idx) = element
+      arraycopy(src, idx, dst, idx + TupleLength, src.length - idx)
+
+      val dstHashes = insertElement(originalHashes, dataIx, originalHash)
+
+      this.dataMap |= bitpos
+      this.content = dst
+      this.originalHashes = dstHashes
+      this.size += 1
+      this.cachedJavaKeySetHashCode += elementHash
+      shallowlyMutableNodeMap
+    }
+  }
+
+
+  def removed(element: A, originalHash: Int, elementHash: Int, shift: Int): BitmapIndexedSetNode[A] = {
     val mask = maskFrom(elementHash, shift)
     val bitpos = bitposFrom(mask)
 
@@ -418,7 +586,8 @@ private final class BitmapIndexedSetNode[A](
       val subNode = this.getNode(index)
 
       val subNodeNew = subNode.removed(element, originalHash, elementHash, shift + BitPartitionSize)
-      // assert(subNodeNew.size != 0, "Sub-node must have at least one element.")
+
+      if (subNodeNew eq subNode) return this
 
       // cache just in case subNodeNew is a hashCollision node, in which in which case a little arithmetic is avoided
       // in Vector#length
@@ -428,7 +597,7 @@ private final class BitmapIndexedSetNode[A](
         if (this.size == subNode.size) {
           // subNode is the only child (no other data or node children of `this` exist)
           // escalate (singleton or empty) result
-          return subNodeNew
+          return subNodeNew.asInstanceOf[BitmapIndexedSetNode[A]]
         } else {
           // inline value (move to front)
           return copyAndMigrateFromNodeToInline(bitpos, elementHash, subNode, subNodeNew)
@@ -440,6 +609,96 @@ private final class BitmapIndexedSetNode[A](
     }
 
     this
+  }
+  /** Variant of `removed` which will perform mutation on only the top-level node (`this`), rather than return a new
+    * node
+    *
+    * Should only be called on root nodes, because shift is assumed to be 0
+    *
+    * @param element the element to remove
+    * @param originalHash the original hash of `element`
+    * @param elementHash the improved hash of `element`
+    */
+  def removeWithShallowMutations(element: A, originalHash: Int, elementHash: Int): this.type = {
+    val mask = maskFrom(elementHash, 0)
+    val bitpos = bitposFrom(mask)
+
+    if ((dataMap & bitpos) != 0) {
+      val index = indexFrom(dataMap, mask, bitpos)
+      val element0 = this.getPayload(index)
+
+      if (element0 == element) {
+        if (this.payloadArity == 2 && this.nodeArity == 0) {
+          val newDataMap = dataMap ^ bitpos
+          if (index == 0) {
+            val newContent = Array[Any](getPayload(1))
+            val newOriginalHashes = Array(originalHashes(1))
+            val newCachedJavaKeySetHashCode = improve(getHash(1))
+            this.content = newContent
+            this.originalHashes = newOriginalHashes
+            this.cachedJavaKeySetHashCode = newCachedJavaKeySetHashCode
+          } else {
+            val newContent = Array[Any](getPayload(0))
+            val newOriginalHashes = Array(originalHashes(0))
+            val newCachedJavaKeySetHashCode = improve(getHash(0))
+            this.content = newContent
+            this.originalHashes = newOriginalHashes
+            this.cachedJavaKeySetHashCode = newCachedJavaKeySetHashCode
+          }
+          this.dataMap = newDataMap
+          this.nodeMap = 0
+          this.size = 1
+          this
+        }
+        else {
+          val dataIx = dataIndex(bitpos)
+          val idx = TupleLength * dataIx
+
+          val src = this.content
+          val dst = new Array[Any](src.length - TupleLength)
+
+          arraycopy(src, 0, dst, 0, idx)
+          arraycopy(src, idx + TupleLength, dst, idx, src.length - idx - TupleLength)
+
+          val dstHashes = removeElement(originalHashes, dataIx)
+
+          this.dataMap = this.dataMap ^ bitpos
+          this.content = dst
+          this.originalHashes = dstHashes
+          this.size -= 1
+          this.cachedJavaKeySetHashCode -= elementHash
+          this
+        }
+      } else this
+    } else if ((nodeMap & bitpos) != 0) {
+      val index = indexFrom(nodeMap, mask, bitpos)
+      val subNode = this.getNode(index)
+
+      val subNodeNew = subNode.removed(element, originalHash, elementHash, BitPartitionSize).asInstanceOf[BitmapIndexedSetNode[A]]
+
+      if (subNodeNew eq subNode) return this
+
+      if (subNodeNew.size == 1) {
+        if (this.payloadArity == 0 && this.nodeArity == 1) {
+          this.dataMap = subNodeNew.dataMap
+          this.nodeMap = subNodeNew.nodeMap
+          this.content = subNodeNew.content
+          this.originalHashes = subNodeNew.originalHashes
+          this.size = subNodeNew.size
+          this.cachedJavaKeySetHashCode = subNodeNew.cachedJavaKeySetHashCode
+          this
+        } else {
+          migrateFromNodeToInlineInPlace(bitpos, originalHash, elementHash, subNode, subNodeNew)
+          this
+        }
+      } else {
+        // size must be > 1
+        this.content(this.content.length - 1 - this.nodeIndex(bitpos)) = subNodeNew
+        this.size -= 1
+        this.cachedJavaKeySetHashCode = this.cachedJavaKeySetHashCode - subNode.cachedJavaKeySetHashCode + subNodeNew.cachedJavaKeySetHashCode
+        this
+      }
+    } else this
   }
 
   def mergeTwoKeyValPairs(key0: A, originalKeyHash0: Int, keyHash0: Int, key1: A, originalKeyHash1: Int, keyHash1: Int, shift: Int): SetNode[A] = {
@@ -570,6 +829,33 @@ private final class BitmapIndexedSetNode[A](
       cachedJavaKeySetHashCode = cachedJavaKeySetHashCode - elementHash + node.cachedJavaKeySetHashCode
     )
   }
+  /** Variant of `copyAndMigrateFromInlineToNode` which mutates `this` rather than returning a new node.
+    *
+    * Note: This method will mutate `this`, and will mutate `this.content`
+    *
+    * Mutation of `this.content` will occur as an optimization not possible in maps. Since TupleLength == 1 for sets,
+    * content array size does not change during inline <-> node migrations. Therefor, since we are updating in-place,
+    * we reuse this.content by shifting data/nodes around, rather than allocating a new array.
+    *
+    * @param bitpos the bit position of the data to migrate to node
+    * @param keyHash the improved hash of the element currently at `bitpos`
+    * @param node the node to place at `bitpos`
+    */
+  def migrateFromInlineToNodeInPlace(bitpos: Int, keyHash: Int, node: SetNode[A]): this.type = {
+    val dataIx = dataIndex(bitpos)
+    val idxOld = TupleLength * dataIx
+    val idxNew = this.content.length - TupleLength - nodeIndex(bitpos)
+
+    arraycopy(content, idxOld + TupleLength, content, idxOld, idxNew - idxOld)
+    content(idxNew) = node
+
+    this.dataMap = this.dataMap ^ bitpos
+    this.nodeMap = this.nodeMap | bitpos
+    this.originalHashes = removeElement(originalHashes, dataIx)
+    this.size = this.size - 1 + node.size
+    this.cachedJavaKeySetHashCode = this.cachedJavaKeySetHashCode - keyHash + node.cachedJavaKeySetHashCode
+    this
+  }
 
   def copyAndMigrateFromNodeToInline(bitpos: Int, elementHash: Int, oldNode: SetNode[A], node: SetNode[A]) = {
     val idxOld = this.content.length - 1 - nodeIndex(bitpos)
@@ -596,6 +882,34 @@ private final class BitmapIndexedSetNode[A](
       size = size - oldNode.size + 1,
       cachedJavaKeySetHashCode = cachedJavaKeySetHashCode - oldNode.cachedJavaKeySetHashCode + node.cachedJavaKeySetHashCode
     )
+  }
+
+  /** Variant of `copyAndMigrateFromNodeToInline` which mutates `this` rather than returning a new node.
+    *
+    * Note: This method will mutate `this`, and will mutate `this.content`
+    *
+    * Mutation of `this.content` will occur as an optimization not possible in maps. Since TupleLength == 1 for sets,
+    * content array size does not change during inline <-> node migrations. Therefor, since we are updating in-place,
+    * we reuse this.content by shifting data/nodes around, rather than allocating a new array.
+    *
+    * @param bitpos the bit position of the node to migrate inline
+    * @param oldNode the node currently stored at position `bitpos`
+    * @param node the node containing the single element to migrate inline
+    */
+  def migrateFromNodeToInlineInPlace(bitpos: Int, originalHash: Int, elementHash: Int, oldNode: SetNode[A], node: SetNode[A]): Unit = {
+    val idxOld = this.content.length - 1 - nodeIndex(bitpos)
+    val dataIxNew = dataIndex(bitpos)
+    val element = node.getPayload(0)
+    arraycopy(content, dataIxNew, content, dataIxNew + 1, idxOld - dataIxNew)
+    content(dataIxNew) = element
+    val hash = node.getHash(0)
+    val dstHashes = insertElement(originalHashes, dataIxNew, hash)
+
+    this.dataMap = this.dataMap | bitpos
+    this.nodeMap = this.nodeMap ^ bitpos
+    this.originalHashes = dstHashes
+    this.size = this.size - oldNode.size + 1
+    this.cachedJavaKeySetHashCode = this.cachedJavaKeySetHashCode - oldNode.cachedJavaKeySetHashCode + node.cachedJavaKeySetHashCode
   }
 
   def foreach[U](f: A => U): Unit = {
@@ -660,7 +974,7 @@ private final class BitmapIndexedSetNode[A](
       isValidSubset
   }
 
-  override def filterImpl(pred: A => Boolean, flipped: Boolean): SetNode[A] = {
+  override def filterImpl(pred: A => Boolean, flipped: Boolean): BitmapIndexedSetNode[A] = {
     if (size == 0) this
     else if (size == 1) {
       if (pred(getPayload(0)) != flipped) this else SetNode.empty
@@ -765,7 +1079,7 @@ private final class BitmapIndexedSetNode[A](
     }
   }
 
-  override def diff(that: SetNode[A], shift: Int): SetNode[A] = that match {
+  override def diff(that: SetNode[A], shift: Int): BitmapIndexedSetNode[A] = that match {
     case bm: BitmapIndexedSetNode[A] =>
       if (size == 0) this
       else if (size == 1) {
@@ -877,16 +1191,10 @@ private final class BitmapIndexedSetNode[A](
           newCachedHashCode = newCachedHashCode
         )
       }
-    case hashCollisionSetNode: HashCollisionSetNode[A] =>
+    case _: HashCollisionSetNode[A] =>
       // this branch should never happen, because HashCollisionSetNodes and BitMapIndexedSetNodes do not occur at the
       // same depth
-      var curr: SetNode[A] = this
-      val iter = hashCollisionSetNode.content.iterator
-      while(curr.size > 0 && iter.hasNext) {
-        val next = iter.next()
-        curr = curr.removed(next, hashCollisionSetNode.originalHash, hashCollisionSetNode.hash, shift)
-      }
-      curr
+      throw new RuntimeException("BitmapIndexedSetNode diff HashCollisionSetNode")
   }
 
   /** Utility method only for use in `diff` and `filterImpl`
@@ -918,7 +1226,7 @@ private final class BitmapIndexedSetNode[A](
     nodesToMigrateToData: mutable.Queue[SetNode[A]],
     mapOfNewNodes: Int,
     newNodes: mutable.Queue[SetNode[A]],
-    newCachedHashCode: Int): SetNode[A] = {
+    newCachedHashCode: Int): BitmapIndexedSetNode[A] = {
     if (newSize == 0) {
       SetNode.empty
     } else if (newSize == size) {
@@ -1023,9 +1331,9 @@ private final class BitmapIndexedSetNode[A](
     new BitmapIndexedSetNode[A](dataMap, nodeMap, contentClone, originalHashes.clone(), size, cachedJavaKeySetHashCode)
   }
 
-  override def concat(that: SetNode[A], shift: Int): SetNode[A] = that match {
+  override def concat(that: SetNode[A], shift: Int): BitmapIndexedSetNode[A] = that match {
     case bm: BitmapIndexedSetNode[A] =>
-      if (size == 0) return that
+      if (size == 0) return bm
       else if (bm.size == 0 || (bm eq this)) return this
       else if (bm.size == 1) {
         val originalHash = bm.getHash(0)
@@ -1522,9 +1830,6 @@ private final class SetHashIterator[A](rootNode: SetNode[A])
 @SerialVersionUID(3L)
 object HashSet extends IterableFactory[HashSet] {
 
-  private[HashSet] def apply[A](rootNode: SetNode[A], cachedJavaHashCode: Int) =
-    new HashSet[A](rootNode)
-
   @transient
   private final val EmptySet = new HashSet(SetNode.empty)
 
@@ -1561,7 +1866,7 @@ private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, Has
   private def isAliased: Boolean = aliased != null
 
   /** The root node of the partially build hashmap */
-  private var rootNode: SetNode[A] = newEmptyRootNode
+  private var rootNode: BitmapIndexedSetNode[A] = newEmptyRootNode
 
   /** Inserts element `elem` into array `as` at index `ix`, shifting right the trailing elems */
   private def insertElement(as: Array[Int], ix: Int, elem: Int): Array[Int] = {
@@ -1596,43 +1901,6 @@ private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, Has
     bm.cachedJavaKeySetHashCode += keyHash
   }
 
-  /** Removes element at index `ix` from array `as`, shifting the trailing elements right */
-  private def removeElement(as: Array[Int], ix: Int): Array[Int] = {
-    if (ix < 0) throw new ArrayIndexOutOfBoundsException
-    if (ix > as.length - 1) throw new ArrayIndexOutOfBoundsException
-    val result = new Array[Int](as.length - 1)
-    arraycopy(as, 0, result, 0, ix)
-    arraycopy(as, ix + 1, result, ix, as.length - ix - 1)
-    result
-  }
-
-  /** Mutates `bm` to replace inline data at bit position `bitpos` with node `node` */
-  private def migrateFromInlineToNode(bm: BitmapIndexedSetNode[A], elementHash: Int, bitpos: Int, node: SetNode[A]): Unit = {
-    val dataIx = bm.dataIndex(bitpos)
-    val idxOld = TupleLength * dataIx
-    val idxNew = bm.content.length - TupleLength - bm.nodeIndex(bitpos)
-
-    val src = bm.content
-    val dst = new Array[Any](src.length - TupleLength + 1)
-
-    // copy 'src' and remove 2 element(s) at position 'idxOld' and
-    // insert 1 element(s) at position 'idxNew'
-    // assert(idxOld <= idxNew)
-    arraycopy(src, 0, dst, 0, idxOld)
-    arraycopy(src, idxOld + TupleLength, dst, idxOld, idxNew - idxOld)
-    dst(idxNew) = node
-    arraycopy(src, idxNew + TupleLength, dst, idxNew + 1, src.length - idxNew - TupleLength)
-
-    val dstHashes = removeElement(bm.originalHashes, dataIx)
-
-    bm.dataMap ^= bitpos
-    bm.nodeMap |= bitpos
-    bm.content = dst
-    bm.originalHashes = dstHashes
-    bm.size = bm.size - 1 + node.size
-    bm.cachedJavaKeySetHashCode = bm.cachedJavaKeySetHashCode - elementHash + node.cachedJavaKeySetHashCode
-  }
-
   /** Mutates `bm` to replace inline data at bit position `bitpos` with updated key/value */
   private def setValue[A1 >: A](bm: BitmapIndexedSetNode[A], bitpos: Int, elem: A): Unit = {
     val dataIx = bm.dataIndex(bitpos)
@@ -1656,7 +1924,7 @@ private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, Has
           } else {
             val element0Hash = improve(element0UnimprovedHash)
             val subNodeNew = bm.mergeTwoKeyValPairs(element0, element0UnimprovedHash, element0Hash, element, originalHash, elementHash, shift + BitPartitionSize)
-            migrateFromInlineToNode(bm, element0Hash, bitpos, subNodeNew)
+            bm.migrateFromInlineToNodeInPlace(bitpos, element0Hash, subNodeNew)
           }
         } else if ((bm.nodeMap & bitpos) != 0) {
           val index = indexFrom(bm.nodeMap, mask, bitpos)
@@ -1712,7 +1980,7 @@ private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, Has
     ensureUnaliased()
     xs match {
       case hm: HashSet[A] =>
-        new ChampBaseIterator(hm.rootNode) {
+        new ChampBaseIterator[SetNode[A]](hm.rootNode) {
           while(hasNext) {
             val originalHash = currentValueNode.getHash(currentValueCursor)
             update(

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -49,6 +49,9 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
 
   override def size: Int = contentSize
 
+  /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash*/
+  @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
+
   /** Computes the improved hash of an original (`any.##`) hash. */
   private[this] def improveHash(originalHash: Int): Int = {
     // Improve the hash by xoring the high 16 bits into the low 16 bits just in case entropy is skewed towards the

--- a/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
@@ -4,7 +4,7 @@ import org.scalacheck.Arbitrary._
 import org.scalacheck.Prop._
 import org.scalacheck._
 
-object ImmutableChampHashSetProperties extends Properties("immutable.ChampHashSet") {
+object ImmutableChampHashSetProperties extends Properties("immutable.HashSet") {
 
   type K = Int
 
@@ -319,10 +319,53 @@ object ImmutableChampHashSetProperties extends Properties("immutable.ChampHashSe
     val actual: collection.Set[Int] = left -- right.to(collection.mutable.HashSet)
     actual ?= expected
   }
+
   property("removedAll(Vector)") = forAll { (left: HashSet[Int], right: Vector[Int]) =>
     val expected: collection.Set[Int] = left.filter(!right.contains(_))
     val actual: collection.Set[Int] = left -- right
     actual ?= expected
   }
 
+  property("xs ++ list == list.foldLeft(xs)(_ + _)") = forAll { (xs: HashSet[Int], list: List[Int]) =>
+    xs.concat(list) ?= list.foldLeft(xs)(_ + _)
+  }
+
+
+  property("hs.concat(list) does not mutate hs") = forAll { (hs: HashSet[K], l: List[K]) =>
+    val asList = hs.toList
+    val clone = hs.to(List).to(HashSet)
+    hs.concat(l)
+    hs ?= clone
+  }
+  property("hs.concat(mutable.HashSet) does not mutate hs or the mutable.HashSet") = forAll { (hs: HashSet[K], l: List[K]) =>
+    val mhs: collection.Set[K] = l.to(collection.mutable.HashSet)
+    val clone = hs.to(List).to(HashSet)
+    hs.concat(mhs)
+    hs ?= clone
+  }
+  property("hs.concat(mutable.HashSet)") = forAll { (hs: HashSet[K], l: List[K]) =>
+    val mhs: collection.Set[K] = l.to(collection.mutable.HashSet)
+    hs.concat(mhs) ?= mhs.foldLeft(hs)(_ + _)
+  }
+
+  property("hs.union(hashSet) does not mutate hs") = forAll { (hs: HashSet[K], hs2: HashSet[K]) =>
+    val clone = hs.to(List).to(HashSet)
+    hs.union(hs2)
+    hs ?= clone
+  }
+  property("hs.removedAll(list) does not mutate hs") = forAll { (hs: HashSet[K], l: List[K]) =>
+    val clone = hs.to(List).to(HashSet)
+    hs.removedAll(l)
+    hs ?= clone
+  }
+  property("hs.diff(hashSet) does not mutate hs") = forAll { (hs: HashSet[K], hs2: HashSet[K]) =>
+    val clone = hs.to(List).to(HashSet)
+    hs.diff(hs2)
+    hs ?= clone
+  }
+  property("hs.removedAll(hashSet) does not mutate hs") = forAll { (hs: HashSet[K], hs2: HashSet[K]) =>
+    val clone = hs.to(List).to(HashSet)
+    hs.removedAll(hs2)
+    hs ?= clone
+  }
 }


### PR DESCRIPTION
## Summary

### TL;DR

* immutable HashMaps and HashSets are tree structures
* When performing `concat` on them, previously we would immutably add the argument's elements to the Map/Set, one at a time, allocating a new node for each node on the path to the changed key
* Now, we use mutation when performing further changes, once a new node has been created at the root level, or at the level immediately below the root.
* Same thing for `removedAll`, except that method only performs the trick on the root level, not the level beneath root.
* `HashMap#concat`'s performance is improved enormously, `HashSet#concat`, `HashMap#removedAll`, `HashSet#removedAll` less so, but still noticably. See benchmarks below.


### Longer explanation

When adding multiple elements to a HashMap/HashSet, we typically do something like
```scala
val iter = collection.iterator
var currentNode = rootNode
while(iter.hasNext) {
  currentNode = currentNode.updated(iter.next())
}
return new HashMap(currentNode)
```
However, this PR exploits the fact that when calculating an updated rootNode for a HashMap, if the returned node is not reference-equal to the existing node, then it must be a newly created node, and therefor has not been returned to users yet, and is therefor safe to mutate in further updates. That is, the root node is able to be mutated, but not necessarily are any of its children.

So the above becomes

```scala
      val iter = that.iterator
      var current = rootNode.asInstanceOf[BitmapIndexedMapNode[K, V1]]
      while (iter.hasNext) {
        val (key, value) = iter.next()
        val originalHash = key.##
        val improved = improve(originalHash)
        current = current.updated(key, value, originalHash, improved, 0).asInstanceOf[BitmapIndexedMapNode[K, V]]

        if (current ne rootNode) {
          while (iter.hasNext) {
            val (key, value) = iter.next()
            val originalHash = key.##
            val improved = improve(originalHash)
            // new special-purpose `update` implementation which can/will mutate only root node.
            current.updateWithShallowMutations(key, value, originalHash, improved, 0)
          }
          return new HashMap(current)
        }
      }
      this
```


We then take this process one level deeper. the calling method `HashMap#concat` can cooperate with the mutating method to keep track of which immediate node-children of the root have so far been newly created. These are tracked in a bitmap called `shallowlyMutableNodeMap: Int`. This is fed into the `updateWithShallowMutations` method. Any `1` bits in that bitmap give the method permission to mutate the node at that position. 

The `updateWithShallowMutations` will return an updated bitmap including any newly created child nodes. Then in subsequent calls to that method, those newly-created nodes will be able to be mutated. 

So the final algorithm looks like:
```scala
      val iter = that.iterator
      var current = rootNode.asInstanceOf[BitmapIndexedMapNode[K, V1]]
      while (iter.hasNext) {
        val (key, value) = iter.next()
        val originalHash = key.##
        val improved = improve(originalHash)
        current = current.updated(key, value, originalHash, improved, 0).asInstanceOf[BitmapIndexedMapNode[K, V]]

        if (current ne rootNode) {
          assert(current.content ne rootNode.asInstanceOf[BitmapIndexedMapNode[K, V]].content)
          var shallowlyMutableNodeMap = 0
          while (iter.hasNext) {
            val (key, value) = iter.next()
            val originalHash = key.##
            val improved = improve(originalHash)
            shallowlyMutableNodeMap = current.updateWithShallowMutations(key, value, originalHash, improved, 0, shallowlyMutableNodeMap)
          }
          return new HashMap(current)
        }
      }
```

Why only two levels deep? Because it's pretty easy to keep track of a single `Int` bitmap, but any further would require allocating an `Array[Int](32)` which is not as clearly a win.

## Benchmarks

(removed because they were outdated. see below)

## Other changes:

* To avoid lots of casting to `BitMapIndexedMapNode[K, V]`, `HashMap#rootNode` has been refined to `BitMapIndexedMapNode[K, V]`. It always was that type at runtime, but now it is statically known.

## TODO

- [x] Perform same optimizations for HashMap#removedAll
- [x] Perform same optimizations for HashSet#concat
- [x] Perform same optimizations for HashSet#removedAll
- [x] Special tests to ensure previously exposed nodes are not mutated due to programming errors?
- [x] Extensive scaladocs on all added/changed methods  
- [x] Benchmark operations on HashSet
