### PR TITLE
Small optimisations to lubList

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1933,7 +1933,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      *  inheritance graph (i.e. subclass.isLess(superclass) always holds).
      *  the ordering is given by: (_.isType, -_.baseTypeSeq.length) for type symbols, followed by `id`.
      */
-    final def isLess(that: Symbol): Boolean = {
+    final def isLess(that: Symbol): Boolean = (this ne that)  && {
       def baseTypeSeqLength(sym: Symbol) =
         if (sym.isAbstractType) 1 + sym.info.upperBound.baseTypeSeq.length
         else sym.info.baseTypeSeq.length

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -13,6 +13,7 @@
 package scala
 package reflect.internal.util
 
+import scala.reflect.ClassTag
 import scala.collection.{immutable, mutable}
 import scala.annotation.tailrec
 import mutable.ListBuffer
@@ -335,6 +336,28 @@ trait Collections {
         res
       }
     }
+
+  final def mapToArray[A, B: ClassTag](xs: List[A])(f: A => B): Array[B] = {
+    val arr = new Array[B](xs.length)
+    var ix = 0
+    var ys = xs
+    while (ix < arr.length){
+      arr(ix) = f(ys.head)
+      ix += 1
+      ys = ys.tail
+    }
+    arr
+  }
+
+  final def mapFromArray[A, B](arr: Array[A])(f: A => B): List[B] = {
+    var ix = arr.length
+    var xs: List[B] = Nil
+    while (ix > 0){
+      ix -= 1
+      xs = f(arr(ix)) :: xs
+    }
+    xs
+  }
 
   // "Opt" suffix or traverse clashes with the various traversers' traverses
   final def sequenceOpt[A](as: List[Option[A]]): Option[List[A]] = traverseOpt(as)(identity)

--- a/test/benchmarks/src/main/scala/reflect/internal/LubBenchmark.scala
+++ b/test/benchmarks/src/main/scala/reflect/internal/LubBenchmark.scala
@@ -1,0 +1,52 @@
+package scala.reflect.internal
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+import org.openjdk.jmh.runner.IterationType
+import benchmark._
+import java.util.concurrent.TimeUnit
+
+import scala.reflect.internal.util.BatchSourceFile
+
+@BenchmarkMode(Array(org.openjdk.jmh.annotations.Mode.SampleTime))
+@Fork(4)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class LubBenchmark {
+  import scala.tools.nsc._
+  var g: Global = _
+  var ts: List[Global#Type] = _
+
+  trait A1 ; trait A2 ; trait A3 extends A1 ; trait A4 extends A2 ; trait A5 ; trait A6 ; trait A7 ; trait A8 extends A7
+
+  trait Odd extends A1 with A3 with A5 with A7
+  trait Even extends A2 with A3 with A6 with A8
+  trait Low extends A1 with A2 with A3 with A4
+  trait High extends A5 with A6 with A7 with A8
+  trait All extends A1 with A2 with A3 with A4 with A5 with A6 with A7 with A8
+  class B1 extends A1 with A2
+  class B2 extends A7 with A8
+  class B3 extends B2 with Low
+  class B4 extends B1 with High
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    val settings = new Settings()
+    settings.usejavacp.value = true
+    val global = new Global(settings)
+    g = global
+    val run = new global.Run()
+    import language.existentials
+    val tp = global.typeOf[((A1, A2, A3, A4), (Odd, Even, High, Low), (B1, B2, B3, B4) )]
+    ts = tp.typeArgs
+  }
+
+  @Benchmark def measure(bh: Blackhole): Any = {
+    val global = g
+    import global._
+    lub(ts.asInstanceOf[List[Type]])
+  }
+}


### PR DESCRIPTION
The `lubList` method computes the lub of a list of types by extracting the `baseTypeSeq` of each one, and iteratively looking for the common elements in those lists.

Before this commit, the program would transform each `baseTypeSeq` into a list, and then build a list of those lists. The algorithm would iteratively re-create that outer list. This gave a lot of allocations.

This commit replaces the use of a lists of lists with an array of the `BaseTypeSeq` object themselves. To keep the position of each list, it uses an array of indices. This may also help memory locality.