### PR TITLE
[SUPERSEDED] Escalate or de-escalate deprecations

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -16,11 +16,10 @@ package nsc
 
 import scala.collection.mutable
 import scala.reflect.internal.util.StringOps.countElementsAsString
+import nsc.settings.{NoScalaVersion, ScalaVersion}
 
 /** Provides delegates to the reporter doing the actual work.
- * PerRunReporting implements per-Run stateful info tracking and reporting
- *
- * TODO: make reporting configurable
+ *  PerRunReporting implements per-Run stateful info tracking and reporting.
  */
 trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions with CompilationUnits with scala.reflect.internal.Symbols =>
   def settings: Settings
@@ -28,6 +27,59 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
   // not deprecated yet, but a method called "error" imported into
   // nearly every trait really must go.  For now using globalError.
   def error(msg: String) = globalError(msg)
+
+  object policy extends Enumeration {
+    val Silent, Info, Warn, Error = Value
+    case class Philter(pkg: String, esc: Value, isInfractor: Boolean, label: String, version: ScalaVersion, matcher: ScalaVersion => Boolean) {
+      def matches(sym: Symbol, since: String, infractor: String): Boolean = {
+        val (lib, v) = splitVersion(since)
+        (pkg.isEmpty || sym.fullName.startsWith(pkg)) &&
+        (label.isEmpty || label == lib) &&
+        ((version eq NoScalaVersion) || matcher(v))
+      }
+    }
+    val NoPhilter = Philter("", Silent, false, "", NoScalaVersion, _ => false)
+    val config: List[Philter] = {
+      val regex = raw"([+-]{0,2})(?:\s*([\w.']*))?(?:\s*since([<>=])([\w. -]+))?".r
+      object Maybes {
+        def unapplySeq(s: String): Option[Seq[String]] =
+          regex.unapplySeq(s).map(ss => ss.map { case null => "" case x => x })
+      }
+      def parse(s: String) =
+        s match {
+          case Maybes(esc,pkg,op,vers) =>
+            val infr = pkg.startsWith("'")
+            val name = if (infr) pkg.substring(1) else pkg
+            val warn = esc match { case "+" => Error case "-" => Info case "--" => Silent case "" => Warn
+              case _ => reporter.error(NoPosition, s"bad escalation '$esc'") ; Warn }
+            val (label, version) = splitVersion(vers)
+            Philter(name, warn, infr, label, version,
+              op match {
+                case "<" => x => version < x
+                case ">" => x => version > x
+                case "=" => x => version == x
+                case ""  => _ => false
+                case huh => reporter.error(NoPosition, s"bad operator '$huh'") ; _ => false
+              })
+          case _ =>
+            reporter.error(NoPosition, s"bad policy '$s'")
+            NoPhilter
+        }
+      settings.deprecationPolicy.value.map(parse)
+    }
+    private def splitVersion(since: String): (String, ScalaVersion) = {
+      if (since.contains(' ')) {
+        val i = since.lastIndexOf(' ')
+        val (a, b) = since.splitAt(i)
+        (a.trim, versionOf(b.trim))
+      } else
+        ("", versionOf(since))
+    }
+    private def versionOf(vstr: String) = ScalaVersion(vstr, x => reporter.error(NoPosition, s"bad version '$x'"))
+
+    def apply(pos: Position, sym: Symbol, msg: String, since: String, infractor: String): Value =
+      config.find(_.matches(sym, since, infractor)).map(_.esc).getOrElse(Warn)
+  }
 
   // a new instance of this class is created for every Run (access the current instance via `currentRun.reporting`)
   protected def PerRunReporting = new PerRunReporting
@@ -76,7 +128,7 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
     private val _allConditionalWarnings = List(_deprecationWarnings, _uncheckedWarnings, _featureWarnings, _inlinerWarnings)
 
     // TODO: remove in favor of the overload that takes a Symbol, give that argument a default (NoSymbol)
-    def deprecationWarning(pos: Position, msg: String, since: String): Unit = _deprecationWarnings.warn(pos, msg, since)
+    def deprecationWarning(pos: Position, msg: String, since: String): Unit = deprecationWarning(pos, NoSymbol, msg, since)
     def uncheckedWarning(pos: Position, msg: String): Unit   = _uncheckedWarnings.warn(pos, msg)
     def featureWarning(pos: Position, msg: String): Unit     = _featureWarnings.warn(pos, msg)
     def inlinerWarning(pos: Position, msg: String): Unit     = _inlinerWarnings.warn(pos, msg)
@@ -88,8 +140,15 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
 
     def allConditionalWarnings = _allConditionalWarnings flatMap (_.warnings)
 
-    // behold! the symbol that caused the deprecation warning (may not be deprecated itself)
-    def deprecationWarning(pos: Position, sym: Symbol, msg: String, since: String): Unit = _deprecationWarnings.warn(pos, msg, since)
+    def deprecationWarning(pos: Position, sym: Symbol, msg: String, since: String): Unit = {
+      val infractor = ""
+      policy(pos, sym, msg, since, infractor) match {
+        case policy.Silent =>
+        case policy.Info   => reporter.echo(pos, s"$msg (since $since)")
+        case policy.Warn   => _deprecationWarnings.warn(pos, msg, since)
+        case policy.Error  => reporter.error(pos, s"$msg (since $since)")
+      }
+    }
     def deprecationWarning(pos: Position, sym: Symbol): Unit = {
       val version = sym.deprecationVersion.getOrElse("")
       val since   = if (version.isEmpty) version else s" (since $version)"

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -105,6 +105,30 @@ trait ScalaSettings extends AbsScalaSettings
   private[this] val version300 = ScalaVersion("3.0.0")
   def isScala300: Boolean = source.value >= version300
 
+  val deprecationPolicy  = MultiStringSetting("-deprecation-policy", "config", "Configure deprecation warnings.", helpText = Some(
+    """|Specify when to emit deprecation warnings and at which severity.
+       |
+       |To filter deprecations by version, use "since<1.0" for deprecations previous to "1.0",
+       |or "since=1.0" or "since>1.0" for at or after "1.0". Version strings must be parsable,
+       |otherwise only testing for equality is supported.
+       |
+       |To enable warnings in a package, list the package name.
+       |To escalate deprecations, prefix the package name with "+",
+       |or de-escalate by prefixing with "-".
+       |
+       |To enable warnings about symbols from a package, prefix the package name
+       |with a single quote.
+       |
+       |For example, "-deprecation-policy:since<1.5,com.acme.app,+com.acme.lib,-net.info,+'scala.collection"
+       |turns deprecated usages by "lib" into errors and also usages anywhere of deprecated collections.
+       |Warnings for "app" are enabled if "-deprecation" is not on, and "net.info" will not cause warnings.
+       |
+       |Package names can be followed by a condition: "-deprecation-policy:com.acme since<1.5",
+       |and a version string can include a library name: "-deprecation-policy:since<Acme Platform 1.5",
+       |where the library name must also match the deprecation since attribute.
+       |""".stripMargin
+    )) withAbbreviation "--deprecation-policy"
+
   /**
    * -X "Advanced" settings
    */

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -264,7 +264,7 @@ abstract class UnCurry extends InfoTransform
                 else gen.mkCastArray(tree, elemtp, pt)
 
               if(copy) {
-                currentRun.reporting.deprecationWarning(tree.pos, NoSymbol,
+                currentRun.reporting.deprecationWarning(tree.pos, localTyper.context.owner, NoSymbol,
                   "Passing an explicit array value to a Scala varargs method is deprecated (since 2.13.0) and will result in a defensive copy; "+
                     "Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call", "2.13.0")
                 gen.mkMethodCall(PredefModule, nme.copyArrayToImmutableIndexedSeq, List(elemtp), List(adaptedTree))

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternExpansion.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternExpansion.scala
@@ -221,7 +221,7 @@ trait PatternExpansion {
 
     private def err(msg: String) = context.error(fun.pos,msg)
     private def warn(msg: String) = context.warning(fun.pos,msg)
-    private def depr(msg: String, since: String) = currentRun.reporting.deprecationWarning(fun.pos, fun.symbol.owner, msg, since)
+    private def depr(msg: String, since: String) = currentRun.reporting.deprecationWarning(fun.pos, context.owner.asInstanceOf[PatternExpansion.this.global.Symbol], fun.symbol.owner, msg, since)
 
     private def warnPatternTupling() =
       if (effectivePatternArity(args) == 1 && tupleValuedUnapply) {

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -783,9 +783,9 @@ trait Contexts { self: Analyzer =>
 
 
     def deprecationWarning(pos: Position, sym: Symbol, msg: String, since: String): Unit =
-      currentRun.reporting.deprecationWarning(fixPosition(pos), sym, msg, since)
+      currentRun.reporting.deprecationWarning(fixPosition(pos), owner, sym, msg, since)
     def deprecationWarning(pos: Position, sym: Symbol): Unit =
-      currentRun.reporting.deprecationWarning(fixPosition(pos), sym) // TODO: allow this to escalate to an error, and implicit search will ignore deprecated implicits
+      currentRun.reporting.deprecationWarning(fixPosition(pos), owner, sym) // TODO: allow this to escalate to an error, and implicit search will ignore deprecated implicits
 
     def featureWarning(pos: Position, featureName: String, featureDesc: String, featureTrait: Symbol, construct: => String = "", required: Boolean): Unit =
       currentRun.reporting.featureWarning(fixPosition(pos), featureName, featureDesc, featureTrait, construct, required)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -552,7 +552,7 @@ abstract class RefChecks extends Transform {
             val since   = if (version.isEmpty) version else s" (since $version)"
             val message = other.deprecatedOverridingMessage map (msg => s": $msg") getOrElse ""
             val report  = s"overriding ${other.fullLocationString} is deprecated$since$message"
-            currentRun.reporting.deprecationWarning(member.pos, other, report, version)
+            currentRun.reporting.deprecationWarning(member.pos, member, other, report, version)
           }
         }
       }
@@ -1259,7 +1259,7 @@ abstract class RefChecks extends Transform {
       // If symbol is deprecated, and the point of reference is not enclosed
       // in either a deprecated member or a scala bridge method, issue a warning.
       if (sym.isDeprecated && !currentOwner.ownerChain.exists(x => x.isDeprecated))
-        currentRun.reporting.deprecationWarning(pos, sym)
+        currentRun.reporting.deprecationWarning(pos, currentOwner, sym)
 
       // Similar to deprecation: check if the symbol is marked with @migration
       // indicating it has changed semantics between versions.
@@ -1357,19 +1357,17 @@ abstract class RefChecks extends Transform {
 
     /** Check that a deprecated val or def does not override a
       * concrete, non-deprecated method.  If it does, then
-      * deprecation is meaningless.
+      * deprecation is meaningless. TODO: this error is not itself a deprecation. Is it lint?
       */
     private def checkDeprecatedOvers(tree: Tree): Unit = {
       val symbol = tree.symbol
       if (symbol.isDeprecated) {
-        val concrOvers =
-          symbol.allOverriddenSymbols.filter(sym =>
-            !sym.isDeprecated && !sym.isDeferred && !sym.hasDeprecatedOverridingAnnotation && !sym.enclClass.hasDeprecatedInheritanceAnnotation)
-        if(!concrOvers.isEmpty)
-          currentRun.reporting.deprecationWarning(
-            tree.pos,
-            symbol,
-            s"${symbol.toString} overrides concrete, non-deprecated symbol(s):    ${concrOvers.map(_.name.decode).mkString(", ")}", "")
+        val concrOvers = symbol.allOverriddenSymbols.filter(sym =>
+          !sym.isDeprecated && !sym.isDeferred && !sym.hasDeprecatedOverridingAnnotation && !sym.enclClass.hasDeprecatedInheritanceAnnotation
+        )
+        if (!concrOvers.isEmpty) currentRun.reporting.deprecationWarning(tree.pos, symbol, symbol,
+            s"${symbol.toString} overrides concrete, non-deprecated symbol(s):    ${concrOvers.map(_.name.decode).mkString(", ")}", ""
+        )
       }
     }
     private def isRepeatedParamArg(tree: Tree) = currentApplication match {

--- a/src/library/scala/deprecated.scala
+++ b/src/library/scala/deprecated.scala
@@ -59,4 +59,6 @@ import scala.annotation.meta._
  */
 @getter @setter @beanGetter @beanSetter
 @deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
-class deprecated(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation
+class deprecated(message: String = "", since: String = "", label: String = "") extends scala.annotation.StaticAnnotation
+
+final class deprecatedError(message: String, since: String, label: String) extends deprecated(message, since, label)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1264,6 +1264,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val BooleanBeanPropertyAttr    = requiredClass[scala.beans.BooleanBeanProperty]
     lazy val CompileTimeOnlyAttr        = getClassIfDefined("scala.annotation.compileTimeOnly")
     lazy val DeprecatedAttr             = requiredClass[scala.deprecated]
+    lazy val DeprecatedErrorAttr        = requiredClass[scala.deprecatedError]
     lazy val DeprecatedNameAttr         = requiredClass[scala.deprecatedName]
     lazy val DeprecatedInheritanceAttr  = requiredClass[scala.deprecatedInheritance]
     lazy val DeprecatedOverridingAttr   = requiredClass[scala.deprecatedOverriding]

--- a/src/reflect/scala/reflect/internal/Reporting.scala
+++ b/src/reflect/scala/reflect/internal/Reporting.scala
@@ -92,6 +92,7 @@ abstract class Reporter {
   def error(pos: Position, msg: String): Unit   = info0(pos, msg, ERROR, force = false)
 
   class Severity(val id: Int)(name: String) { var count: Int = 0 ; override def toString = name}
+  object SILENT  extends Severity(-1)("SILENT")
   object INFO    extends Severity(0)("INFO")
   object WARNING extends Severity(1)("WARNING")
   object ERROR   extends Severity(2)("ERROR")

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -910,6 +910,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isDeprecated           = hasAnnotation(DeprecatedAttr)
     def deprecationMessage     = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 0)
     def deprecationVersion     = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 1)
+    def deprecationLabel       = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 2)
     def deprecatedParamName    = getAnnotation(DeprecatedNameAttr) flatMap (ann => ann.symbolArg(0).orElse(ann.stringArg(0).map(newTermName)).orElse(Some(nme.NO_NAME)))
     def deprecatedParamVersion = getAnnotation(DeprecatedNameAttr) flatMap (_ stringArg 1)
     def hasDeprecatedInheritanceAnnotation

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -414,6 +414,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.BooleanBeanPropertyAttr
     definitions.CompileTimeOnlyAttr
     definitions.DeprecatedAttr
+    definitions.DeprecatedErrorAttr
     definitions.DeprecatedNameAttr
     definitions.DeprecatedInheritanceAttr
     definitions.DeprecatedOverridingAttr

--- a/src/repl-frontend/scala/tools/nsc/MainGenericRunner.scala
+++ b/src/repl-frontend/scala/tools/nsc/MainGenericRunner.scala
@@ -79,7 +79,7 @@ class MainGenericRunner {
         case _  =>
           // We start the repl when no arguments are given.
           // If user is agnostic about both -feature and -deprecation, turn them on.
-          if (settings.deprecation.isDefault && settings.feature.isDefault) {
+          if (List(settings.deprecation, settings.deprecationPolicy, settings.feature).forall(_.isDefault)) {
             settings.deprecation.value = true
             settings.feature.value = true
           }

--- a/test/files/neg/reportage.check
+++ b/test/files/neg/reportage.check
@@ -1,7 +1,10 @@
-reportage.scala:27: error: method x in object X is deprecated (since Policy 1.0): Badly done (since Policy 1.0)
+reportage.scala:33: error: method x in object X is deprecated (since Policy 1.0): Badly done (since Policy 1.0)
     def f = policy.test.X.x
                           ^
-reportage.scala:28: method y in object Y is deprecated (since Policy 1.0): Also pretty bad but salvageable (since Policy 1.0)
+reportage.scala:34: method y in object Y is deprecated (since Policy 1.0): Also pretty bad but salvageable (since Policy 1.0)
     def g = policy.reprieve.Y.y
                               ^
-one error found
+reportage.scala:47: error: method xxx in object XXX is deprecated (since Policy 1.0): So bad we made it a hard deprecation (since Policy 1.0)
+      XXX.xxx()
+          ^
+two errors found

--- a/test/files/neg/reportage.check
+++ b/test/files/neg/reportage.check
@@ -1,0 +1,7 @@
+reportage.scala:27: error: method x in object X is deprecated (since Policy 1.0): Badly done (since Policy 1.0)
+    def f = policy.test.X.x
+                          ^
+reportage.scala:28: method y in object Y is deprecated (since Policy 1.0): Also pretty bad but salvageable (since Policy 1.0)
+    def g = policy.reprieve.Y.y
+                              ^
+one error found

--- a/test/files/neg/reportage.scala
+++ b/test/files/neg/reportage.scala
@@ -1,0 +1,36 @@
+// scalac: --deprecation-policy:+policy.test,-policy.reprieve,'oldtrial
+//
+// also can match on since, but note annoying spaces
+// --deprecation-policy:+policy.test since=Policy 1.0,-policy.reprieve since<1.5,'oldtrial
+
+package policy.test {
+  object X {
+    @deprecated("Badly done", since="Policy 1.0")
+    def x = 42
+  }
+}
+package policy.reprieve {
+  object Y {
+    @deprecated("Also pretty bad but salvageable", since="Policy 1.0")
+    def y = 42
+  }
+}
+package policy.stale {
+  object Z {
+    @deprecated("Let it die", since="Policy 1.0")
+    def z = 42
+  }
+}
+
+package trial {
+  trait T {
+    def f = policy.test.X.x
+    def g = policy.reprieve.Y.y
+  }
+}
+package oldtrial {
+  trait T {
+    // TODO
+    def old = policy.stale.Z.z
+  }
+}

--- a/test/files/neg/reportage.scala
+++ b/test/files/neg/reportage.scala
@@ -21,6 +21,12 @@ package policy.stale {
     def z = 42
   }
 }
+package api.escalated {
+  object XXX {
+    @deprecatedError("So bad we made it a hard deprecation", since="Policy 1.0", label="escalated")
+    def xxx() = ???
+  }
+}
 
 package trial {
   trait T {
@@ -32,5 +38,13 @@ package oldtrial {
   trait T {
     // TODO
     def old = policy.stale.Z.z
+  }
+}
+package app {
+  import api.escalated._
+  object Main {
+    def main(args: Array[String]) = println {
+      XXX.xxx()
+    }
   }
 }


### PR DESCRIPTION
Taking up Adriaan's idea. Still rough and `from` mode isn't wired up. I was too lazy to fetch the original commit. Turning off edits at least until it's further along. More bright ideas welcome.

Slightly different syntax:
```
$ skalac --deprecation-policy:help
Specify when to emit deprecation warnings and at which severity.

To filter deprecations by version, use "since<1.0" for deprecations previous to "1.0",
or "since=1.0" or "since>1.0" for at or after "1.0". Version strings must be parsable,
otherwise only testing for equality is supported.

To enable warnings in a package, list the package name.
To escalate deprecations, prefix the package name with "+",
or de-escalate by prefixing with "-".

To enable warnings about symbols from a package, prefix the package name
with a single quote.

For example, "-deprecation-policy:since<1.5,com.acme.app,+com.acme.lib,-net.info,+'scala.collection"
turns deprecated usages by "lib" into errors and also usages anywhere of deprecated collections.
Warnings for "app" are enabled if "-deprecation" is not on, and "net.info" will not cause warnings.

Package names can be followed by a condition: "-deprecation-policy:com.acme since<1.5",
and a version string can include a library name: "-deprecation-policy:since<Acme Platform 1.5",
where the library name must also match the deprecation since attribute.
```
Also `--com.acme` for silent. I don't like `'com.acme` for `from` mode, and resisting `@`.