### PR TITLE
[2.12.x] Type-annotate & fully qualify ExecutionContext in its implicitNotFound message

### DIFF
--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -68,7 +68,7 @@ If your application does not define an ExecutionContext elsewhere,
 consider using Scala's global ExecutionContext by defining
 the following:
 
-implicit val ec = ExecutionContext.global""")
+implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global""")
 trait ExecutionContext {
 
   /** Runs a block of code on this execution context.


### PR DESCRIPTION
Not type annotating an implicit val is only safe in method-local vals,
which isn't necessarily where this val will end up, so let's err on the
side of caution.  And for the same reason, let's fully-qualify the
names.

I'm targetting this to the 2.12.x branch as that's the latest stable
series, but let me know if I should rebase/retarget to 2.13.x instead.