### PR TITLE
[backport] Use Java rules for member lookup in .java sources

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -554,7 +554,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
      *  @return modified tree and new prefix type
      */
     private def makeAccessible(tree: Tree, sym: Symbol, pre: Type, site: Tree): (Tree, Type) =
-      if (context.isInPackageObject(sym, pre.typeSymbol)) {
+      if (!unit.isJava && context.isInPackageObject(sym, pre.typeSymbol)) {
         if (pre.typeSymbol == ScalaPackageClass && sym.isTerm) {
           // short cut some aliases. It seems pattern matching needs this
           // to notice exhaustiveness and to generate good code when
@@ -671,16 +671,16 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       }
     }
 
-    /** The member with given name of given qualifier tree */
-    def member(qual: Tree, name: Name) = {
+    /** The member with given name of given qualifier type */
+    def member(qual: Type, name: Name): Symbol = {
       def callSiteWithinClass(clazz: Symbol) = context.enclClass.owner hasTransOwner clazz
-      val includeLocals = qual.tpe match {
+      val includeLocals = qual match {
         case ThisType(clazz) if callSiteWithinClass(clazz)                => true
         case SuperType(clazz, _) if callSiteWithinClass(clazz.typeSymbol) => true
         case _                                                            => phase.next.erasedTypes
       }
-      if (includeLocals) qual.tpe member name
-      else qual.tpe nonLocalMember name
+      if (includeLocals) qual member name
+      else qual nonLocalMember name
     }
 
     def silent[T](op: Typer => T,
@@ -1160,7 +1160,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       def vanillaAdapt(tree: Tree) = {
         def applyPossible = {
-          def applyMeth = member(adaptToName(tree, nme.apply), nme.apply)
+          def applyMeth = member(adaptToName(tree, nme.apply).tpe, nme.apply)
           def hasPolymorphicApply = applyMeth.alternatives exists (_.tpe.typeParams.nonEmpty)
           def hasMonomorphicApply = applyMeth.alternatives exists (_.tpe.paramSectionCount > 0)
 
@@ -1364,7 +1364,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
      *  If no conversion is found, return `qual` unchanged.
      */
     def adaptToName(qual: Tree, name: Name) =
-      if (member(qual, name) != NoSymbol) qual
+      if (member(qual.tpe, name) != NoSymbol) qual
       else adaptToMember(qual, HasMember(name))
 
     private def validateNoCaseAncestor(clazz: Symbol) = {
@@ -3380,6 +3380,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         if (!context.owner.isPackageClass)
           checkNoDoubleDefs(scope)
 
+        // Note that Java units don't have synthetics, but there's no point in making a special case (for performance or correctness),
+        // as we only type check Java units when running Scaladoc on Java sources.
         addSynthetics(stats1, scope)
       }
     }
@@ -5009,11 +5011,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       // For Java, instance and static members are in the same scope, but we put the static ones in the companion object
       // so, when we can't find a member in the class scope, check the companion
-      def inCompanionForJavaStatic(pre: Type, cls: Symbol, name: Name): Symbol =
-        if (!(context.unit.isJava && cls.isClass && !cls.isModuleClass)) NoSymbol else {
-          val companion = companionSymbolOf(cls, context)
-          if (!companion.exists) NoSymbol
-          else member(gen.mkAttributedRef(pre, companion), name) // assert(res.isStatic, s"inCompanionForJavaStatic($pre, $cls, $name) = $res ${res.debugFlagString}")
+      def inCompanionForJavaStatic(cls: Symbol, name: Name): Symbol =
+        if (!(context.unit.isJava && cls.isClass)) NoSymbol else {
+          context.javaFindMember(cls.typeOfThis, name, _ => true)._2
         }
 
       /* Attribute a selection where `tree` is `qual.name`.
@@ -5032,7 +5032,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             wrapErrors(t, (_.typed1(t, mode, pt)))
           }
 
-          val sym = tree.symbol orElse member(qual, name) orElse inCompanionForJavaStatic(qual.tpe.prefix, qual.symbol, name)
+          val sym = tree.symbol orElse member(qual.tpe, name) orElse inCompanionForJavaStatic(qual.symbol, name)
           if ((sym eq NoSymbol) && name != nme.CONSTRUCTOR && mode.inAny(EXPRmode | PATTERNmode)) {
             // symbol not found? --> try to convert implicitly to a type that does have the required
             // member.  Added `| PATTERNmode` to allow enrichment in patterns (so we can add e.g., an
@@ -5149,7 +5149,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           if (name.isTypeName) {
             val qualTyped = typedTypeSelectionQualifier(tree.qualifier, WildcardType)
             val qualStableOrError =
-              if (qualTyped.isErrorTyped || treeInfo.admitsTypeSelection(qualTyped)) qualTyped
+              if (qualTyped.isErrorTyped || unit.isJava || treeInfo.admitsTypeSelection(qualTyped)) qualTyped
               else UnstableTreeError(qualTyped)
             typedSelect(tree, qualStableOrError, name)
           } else {
@@ -5203,6 +5203,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         }
           // ignore current variable scope in patterns to enforce linearity
         val startContext = if (mode.typingPatternOrTypePat) context.outer else context
+
+        def asTypeName = if (mode.inAll(MonoQualifierModes) && unit.isJava && name.isTermName) {
+          startContext.lookupSymbol(name.toTypeName, qualifies).symbol
+        } else NoSymbol
+
         val nameLookup   = tree.symbol match {
           case NoSymbol   => startContext.lookupSymbol(name, qualifies)
           case sym        => LookupSucceeded(EmptyTree, sym)
@@ -5212,7 +5217,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case LookupAmbiguous(msg)         => issue(AmbiguousIdentError(tree, name, msg))
           case LookupInaccessible(sym, msg) => issue(AccessError(tree, sym, context, msg))
           case LookupNotFound               =>
-            inEmptyPackage orElse lookupInRoot(name) match {
+            asTypeName orElse inEmptyPackage orElse lookupInRoot(name) match {
               case NoSymbol => issue(SymbolNotFoundError(tree, name, context.owner, startContext))
               case sym      => typed1(tree setSymbol sym, mode, pt)
                 }

--- a/test/files/pos/java-inherited-type/Client.scala
+++ b/test/files/pos/java-inherited-type/Client.scala
@@ -1,0 +1,19 @@
+object Client {
+  def test= {
+    Test.Outer.Nested.sig
+    Test.Outer.Nested.sig1
+    Test.Outer.Nested.sig2
+    val o = new Test.Outer
+    new o.Nested1().sig
+    new o.Nested1().sig1
+    new o.Nested1().sig2
+  }
+
+  def test1 = {
+    val t = new Test
+    val o = new t.Outer1
+    new o.Nested1().sig
+    new o.Nested1().sig1
+    new o.Nested1().sig2
+  }
+}

--- a/test/files/pos/java-inherited-type/Test.java
+++ b/test/files/pos/java-inherited-type/Test.java
@@ -1,0 +1,30 @@
+public class Test {
+  static class OuterBase implements OuterBaseInterface {
+    static class StaticInner {}
+    class Inner {}
+  }
+  interface OuterBaseInterface {
+    interface InnerFromInterface {}
+  }
+  public static class Outer extends OuterBase {
+    public static class Nested {
+      public static P<StaticInner, Inner, InnerFromInterface> sig; // was: "type StaticInner", "not found: type Inner", "not found: type InnerFromInterface"
+      public static P<Outer.StaticInner, Outer.Inner, Outer.InnerFromInterface> sig1; // was: "type StaticInner is not a member of Test.Outer"
+      public static P<OuterBase.StaticInner, OuterBase.Inner, OuterBaseInterface.InnerFromInterface> sig2;
+
+    }
+    public class Nested1 {
+      public P<StaticInner, Inner, InnerFromInterface> sig; // was: "not found: type StaticInner"
+      public P<Outer.StaticInner, Outer.Inner, Outer.InnerFromInterface> sig1; // was: "type StaticInner is not a member of Test.Outer"
+      public P<OuterBase.StaticInner, OuterBase.Inner, OuterBaseInterface.InnerFromInterface> sig2;
+    }
+  }
+  public class Outer1 extends OuterBase {
+    public class Nested1 {
+      public P<StaticInner, Inner, InnerFromInterface> sig; // was: "not found: type StaticInner"
+      public P<Outer.StaticInner, Outer.Inner, Outer.InnerFromInterface> sig1; // was: "type StaticInner is not a member of Test.Outer"
+      public P<OuterBase.StaticInner, OuterBase.Inner, OuterBaseInterface.InnerFromInterface> sig2;
+    }
+  }
+  public static class P<A, B, C>{}
+}

--- a/test/files/pos/java-inherited-type1/J.java
+++ b/test/files/pos/java-inherited-type1/J.java
@@ -1,0 +1,9 @@
+class J extends S {
+  // These references all work in Javac because `object O { class I }` erases to `O$I`
+
+  void select1(S1.Inner1 i) { new S1.Inner1(); }
+  void ident(Inner i) {}
+
+  void ident1(Inner1 i) {}
+  void select(S.Inner i) { new S.Inner(); }
+}

--- a/test/files/pos/java-inherited-type1/S.scala
+++ b/test/files/pos/java-inherited-type1/S.scala
@@ -1,0 +1,9 @@
+class S extends S1
+object S {
+  class Inner
+}
+
+class S1
+object S1 {
+  class Inner1
+}

--- a/test/files/pos/java-inherited-type1/Test.scala
+++ b/test/files/pos/java-inherited-type1/Test.scala
@@ -1,0 +1,8 @@
+object Test {
+  val j = new J
+  // force completion of these signatures
+  j.ident(null);
+  j.ident1(null);
+  j.select(null);
+  j.select1(null);
+}

--- a/test/files/run/t10490-2.check
+++ b/test/files/run/t10490-2.check
@@ -1,0 +1,1 @@
+Foo$Bar was instantiated!

--- a/test/files/run/t10490-2/JavaClass.java
+++ b/test/files/run/t10490-2/JavaClass.java
@@ -1,0 +1,4 @@
+public class JavaClass {
+    // This is defined in ScalaClass
+    public static final Foo.Bar bar = new Foo.Bar();
+}

--- a/test/files/run/t10490-2/ScalaClass.scala
+++ b/test/files/run/t10490-2/ScalaClass.scala
@@ -1,0 +1,18 @@
+/* Similar to t10490 -- but defines `Foo` in the object.
+ * Placing this test within t10490 makes it work without a fix, that's why it's independent.
+ * Note that this was already working, we add it to make sure we don't regress
+ */
+
+class Foo
+object Foo {
+  class Bar {
+    override def toString: String = "Foo$Bar was instantiated!"
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    // JavaClass is the user of the Scala defined classes
+    println(JavaClass.bar)
+  }
+}

--- a/test/files/run/t10490.check
+++ b/test/files/run/t10490.check
@@ -1,0 +1,1 @@
+Foo$Bar was instantiated!

--- a/test/files/run/t10490/JavaClass.java
+++ b/test/files/run/t10490/JavaClass.java
@@ -1,0 +1,4 @@
+public class JavaClass {
+    // This is defined in ScalaClass
+    public static final Foo.Bar bar = (new Foo()).new Bar();
+}

--- a/test/files/run/t10490/ScalaClass.scala
+++ b/test/files/run/t10490/ScalaClass.scala
@@ -1,0 +1,13 @@
+class Foo {
+  class Bar {
+    override def toString: String = "Foo$Bar was instantiated!"
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    // JavaClass is the user of the Scala defined classes
+    println(JavaClass.bar)
+    //println(JavaClass.baz)
+  }
+}


### PR DESCRIPTION
- Inherited type declarations are in scope in Java code
 - For static innner classes, we need to check in the companion
module of each base classes.
 - Incorporate and accomodate test case from #6053
 - Tests to java code referring to module-class owned classes via companion class prefix

 Backport of scala/scala#7671