### PR TITLE
Vectors smaller than 32 allocate or reuse small arrays when possible

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -31,15 +31,49 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
 
   def from[E](it: collection.IterableOnce[E]): Vector[E] =
     it match {
+      case as: ArraySeq[E] if as.length <= 32 && as.unsafeArray.isInstanceOf[Array[AnyRef]] =>
+        if (as.isEmpty) NIL
+        else {
+          val v = new Vector(0, as.length, 0)
+          v.display0 = as.unsafeArray.asInstanceOf[Array[AnyRef]]
+          v.depth = 1
+          v
+        }
       case v: Vector[E] => v
-      case _ if it.knownSize == 0 => empty[E]
-      case _ => (newBuilder ++= it).result()
+      case _ =>
+        val knownSize = it.knownSize
+
+        if (knownSize == 0) empty[E]
+        else if (knownSize > 0 && knownSize <= 32) {
+          val display0 = new Array[AnyRef](knownSize)
+
+          var i = 0
+          val iterator = it.iterator
+          while (iterator.hasNext) {
+            display0(i) = iterator.next().asInstanceOf[AnyRef]
+            i += 1
+          }
+          val v = new Vector[E](0, knownSize, 0)
+          v.depth = 1
+          v.display0 = display0
+          v
+        } else {
+          (newBuilder ++= it).result()
+        }
     }
 
   def newBuilder[A]: ReusableBuilder[A, Vector[A]] = new VectorBuilder[A]
 
+  /** Creates a Vector of one element */
+  private def single[A](elem: A): Vector[A] = {
+    val s = new Vector[A](0, 1, 0)
+    s.depth = 1
+    s.display0 = Array[AnyRef](elem.asInstanceOf[AnyRef])
+    s
+  }
+
   @transient
-  private[immutable] val NIL = new Vector[Nothing](0, 0, 0)
+  private val NIL = new Vector[Nothing](0, 0, 0)
 
   private val defaultApplyPreferredMaxLength: Int =
     try System.getProperty("scala.collection.immutable.Vector.defaultApplyPreferredMaxLength",
@@ -349,145 +383,158 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
   }
 
   override def prepended[B >: A](value: B): Vector[B] = {
-    val result = if (endIndex != startIndex) {
-      val blockIndex = (startIndex - 1) & ~31
-      val lo = (startIndex - 1) & 31
-
-      if (startIndex != blockIndex + 32) {
-        val s = new Vector(startIndex - 1, endIndex, blockIndex)
-        s.initFrom(this)
-        s.dirty = dirty
-        s.gotoPosWritable(focus, blockIndex, focus ^ blockIndex)
-        s.display0(lo) = value.asInstanceOf[AnyRef]
+    val thisLength = length
+    val result =
+      if (depth == 1 && thisLength < 32) {
+        val s = new Vector(0, thisLength + 1, 0)
+        s.depth = 1
+        val newDisplay0 = new Array[AnyRef](thisLength + 1)
+        System.arraycopy(display0, startIndex, newDisplay0, 1, thisLength)
+        newDisplay0(0) = value.asInstanceOf[AnyRef]
+        s.display0 = newDisplay0
         s
-      } else {
+      } else if (thisLength > 0) {
+        val blockIndex = (startIndex - 1) & ~31
+        val lo = (startIndex - 1) & 31
 
-        val freeSpace = (1 << (5 * depth)) - endIndex           // free space at the right given the current tree-structure depth
-        val shift = freeSpace & ~((1 << (5 * (depth - 1))) - 1) // number of elements by which we'll shift right (only move at top level)
-        val shiftBlocks = freeSpace >>> (5 * (depth - 1))       // number of top-level blocks
-
-        if (shift != 0) {
-          // case A: we can shift right on the top level
-          if (depth > 1) {
-            val newBlockIndex = blockIndex + shift
-            val newFocus = focus + shift
-
-            val s = new Vector(startIndex - 1 + shift, endIndex + shift, newBlockIndex)
-            s.initFrom(this)
-            s.dirty = dirty
-            s.shiftTopLevel(0, shiftBlocks) // shift right by n blocks
-            s.gotoFreshPosWritable(newFocus, newBlockIndex, newFocus ^ newBlockIndex) // maybe create pos; prepare for writing
-            s.display0(lo) = value.asInstanceOf[AnyRef]
-            s
-          } else {
-            val newBlockIndex = blockIndex + 32
-            val newFocus = focus
-
-            val s = new Vector(startIndex - 1 + shift, endIndex + shift, newBlockIndex)
-            s.initFrom(this)
-            s.dirty = dirty
-            s.shiftTopLevel(0, shiftBlocks) // shift right by n elements
-            s.gotoPosWritable(newFocus, newBlockIndex, newFocus ^ newBlockIndex) // prepare for writing
-            s.display0(shift - 1) = value.asInstanceOf[AnyRef]
-            s
-          }
-        } else if (blockIndex < 0) {
-          // case B: we need to move the whole structure
-          val move = (1 << (5 * (depth + 1))) - (1 << (5 * depth))
-          val newBlockIndex = blockIndex + move
-          val newFocus = focus + move
-
-          val s = new Vector(startIndex - 1 + move, endIndex + move, newBlockIndex)
+        if (startIndex != blockIndex + 32) {
+          val s = new Vector(startIndex - 1, endIndex, blockIndex)
           s.initFrom(this)
           s.dirty = dirty
-          s.gotoFreshPosWritable(newFocus, newBlockIndex, newFocus ^ newBlockIndex) // could optimize: we know it will create a whole branch
+          s.gotoPosWritable(focus, blockIndex, focus ^ blockIndex)
           s.display0(lo) = value.asInstanceOf[AnyRef]
           s
         } else {
-          val newBlockIndex = blockIndex
-          val newFocus = focus
 
-          val s = new Vector(startIndex - 1, endIndex, newBlockIndex)
-          s.initFrom(this)
-          s.dirty = dirty
-          s.gotoFreshPosWritable(newFocus, newBlockIndex, newFocus ^ newBlockIndex)
-          s.display0(lo) = value.asInstanceOf[AnyRef]
-          s
+          val freeSpace = (1 << (5 * depth)) - endIndex           // free space at the right given the current tree-structure depth
+          val shift = freeSpace & ~((1 << (5 * (depth - 1))) - 1) // number of elements by which we'll shift right (only move at top level)
+          val shiftBlocks = freeSpace >>> (5 * (depth - 1))       // number of top-level blocks
+
+          if (shift != 0) {
+            // case A: we can shift right on the top level
+            if (depth > 1) {
+              val newBlockIndex = blockIndex + shift
+              val newFocus = focus + shift
+
+              val s = new Vector(startIndex - 1 + shift, endIndex + shift, newBlockIndex)
+              s.initFrom(this)
+              s.dirty = dirty
+              s.shiftTopLevel(0, shiftBlocks) // shift right by n blocks
+              s.gotoFreshPosWritable(newFocus, newBlockIndex, newFocus ^ newBlockIndex) // maybe create pos; prepare for writing
+              s.display0(lo) = value.asInstanceOf[AnyRef]
+              s
+            } else {
+              val newBlockIndex = blockIndex + 32
+              val newFocus = focus
+
+              val s = new Vector(startIndex - 1 + shift, endIndex + shift, newBlockIndex)
+              s.initFrom(this)
+              s.dirty = dirty
+              s.shiftTopLevel(0, shiftBlocks) // shift right by n elements
+              s.gotoPosWritable(newFocus, newBlockIndex, newFocus ^ newBlockIndex) // prepare for writing
+              s.display0(shift - 1) = value.asInstanceOf[AnyRef]
+              s
+            }
+          } else if (blockIndex < 0) {
+            // case B: we need to move the whole structure
+            val move = (1 << (5 * (depth + 1))) - (1 << (5 * depth))
+            val newBlockIndex = blockIndex + move
+            val newFocus = focus + move
+
+            val s = new Vector(startIndex - 1 + move, endIndex + move, newBlockIndex)
+            s.initFrom(this)
+            s.dirty = dirty
+            s.gotoFreshPosWritable(newFocus, newBlockIndex, newFocus ^ newBlockIndex) // could optimize: we know it will create a whole branch
+            s.display0(lo) = value.asInstanceOf[AnyRef]
+            s
+          } else {
+            val newBlockIndex = blockIndex
+            val newFocus = focus
+
+            val s = new Vector(startIndex - 1, endIndex, newBlockIndex)
+            s.initFrom(this)
+            s.dirty = dirty
+            s.gotoFreshPosWritable(newFocus, newBlockIndex, newFocus ^ newBlockIndex)
+            s.display0(lo) = value.asInstanceOf[AnyRef]
+            s
+          }
         }
-      }
-    } else {
-      // empty vector, just insert single element at the back
-      val elems = new Array[AnyRef](32)
-      elems(31) = value.asInstanceOf[AnyRef]
-      val s = new Vector(31, 32, 0)
-      s.depth = 1
-      s.display0 = elems
-      s
-    }
+      } else Vector.single(value)
+
     releaseFence()
     result
   }
 
   override def appended[B >: A](value: B): Vector[B] = {
-    val result = if (endIndex != startIndex) {
-      val blockIndex = endIndex & ~31 // round down to nearest 32
-      val lo = endIndex & 31 // remainder of blockIndex / 32
-
-      if (endIndex != blockIndex) {
-        val s = new Vector(startIndex, endIndex + 1, blockIndex)
-        s.initFrom(this)
-        s.dirty = dirty
-        s.gotoPosWritable(focus, blockIndex, focus ^ blockIndex)
-        s.display0(lo) = value.asInstanceOf[AnyRef]
+    val thisLength = length
+    val result =
+      if (depth == 1 && thisLength < 32) {
+        val s = new Vector(0, thisLength + 1, 0)
+        s.depth = 1
+        val newDisplay0 = new Array[AnyRef](thisLength + 1)
+        System.arraycopy(display0, startIndex, newDisplay0, 0, thisLength)
+        newDisplay0(thisLength) = value.asInstanceOf[AnyRef]
+        s.display0 = newDisplay0
         s
-      } else {
-        val shift = startIndex & ~((1 << (5 * (depth - 1))) - 1)
-        val shiftBlocks = startIndex >>> (5 * (depth - 1))
+      } else if (thisLength > 0) {
+        val blockIndex = endIndex & ~31 // round down to nearest 32
+        val lo = endIndex & 31 // remainder of blockIndex / 32
 
-        if (shift != 0) {
-          if (depth > 1) {
-            val newBlockIndex = blockIndex - shift
-            val newFocus = focus - shift
+        if (endIndex != blockIndex) {
+          val s = new Vector(startIndex, endIndex + 1, blockIndex)
+          s.initFrom(this)
+          s.dirty = dirty
+          s.gotoPosWritable(focus, blockIndex, focus ^ blockIndex)
+          s.display0(lo) = value.asInstanceOf[AnyRef]
+          s
+        } else {
+          val shift = startIndex & ~((1 << (5 * (depth - 1))) - 1)
+          val shiftBlocks = startIndex >>> (5 * (depth - 1))
 
-            val s = new Vector(startIndex - shift, endIndex + 1 - shift, newBlockIndex)
+          if (shift != 0) {
+            if (depth > 1) {
+              val newBlockIndex = blockIndex - shift
+              val newFocus = focus - shift
+
+              val s = new Vector(startIndex - shift, endIndex + 1 - shift, newBlockIndex)
+              s.initFrom(this)
+              s.dirty = dirty
+              s.shiftTopLevel(shiftBlocks, 0) // shift left by n blocks
+              s.gotoFreshPosWritable(newFocus, newBlockIndex, newFocus ^ newBlockIndex)
+              s.display0(lo) = value.asInstanceOf[AnyRef]
+              s
+            } else {
+              val newBlockIndex = blockIndex - 32
+              val newFocus = focus
+
+              val s = new Vector(startIndex - shift, endIndex + 1 - shift, newBlockIndex)
+              s.initFrom(this)
+              s.dirty = dirty
+              s.shiftTopLevel(shiftBlocks, 0) // shift right by n elements
+              s.gotoPosWritable(newFocus, newBlockIndex, newFocus ^ newBlockIndex)
+
+              if (s.display0.length < 32 - shift - 1) {
+                val newDisplay0 = new Array[AnyRef](32 - shift - 1)
+                s.display0.copyToArray(newDisplay0)
+                s.display0 = newDisplay0
+              }
+              s.display0(32 - shift) = value.asInstanceOf[AnyRef]
+              s
+            }
+          } else {
+            val newBlockIndex = blockIndex
+            val newFocus = focus
+
+            val s = new Vector(startIndex, endIndex + 1, newBlockIndex)
             s.initFrom(this)
             s.dirty = dirty
-            s.shiftTopLevel(shiftBlocks, 0) // shift left by n blocks
             s.gotoFreshPosWritable(newFocus, newBlockIndex, newFocus ^ newBlockIndex)
             s.display0(lo) = value.asInstanceOf[AnyRef]
             s
-          } else {
-            val newBlockIndex = blockIndex - 32
-            val newFocus = focus
-
-            val s = new Vector(startIndex - shift, endIndex + 1 - shift, newBlockIndex)
-            s.initFrom(this)
-            s.dirty = dirty
-            s.shiftTopLevel(shiftBlocks, 0) // shift right by n elements
-            s.gotoPosWritable(newFocus, newBlockIndex, newFocus ^ newBlockIndex)
-            s.display0(32 - shift) = value.asInstanceOf[AnyRef]
-            s
           }
-        } else {
-          val newBlockIndex = blockIndex
-          val newFocus = focus
-
-          val s = new Vector(startIndex, endIndex + 1, newBlockIndex)
-          s.initFrom(this)
-          s.dirty = dirty
-          s.gotoFreshPosWritable(newFocus, newBlockIndex, newFocus ^ newBlockIndex)
-          s.display0(lo) = value.asInstanceOf[AnyRef]
-          s
         }
-      }
-    } else {
-      val elems = new Array[AnyRef](32)
-      elems(0) = value.asInstanceOf[AnyRef]
-      val s = new Vector(0, 1, 0)
-      s.depth = 1
-      s.display0 = elems
-      s
-    }
+      } else Vector.single(value)
+
     releaseFence()
     result
   }

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -37,6 +37,7 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
           val v = new Vector(0, as.length, 0)
           v.display0 = as.unsafeArray.asInstanceOf[Array[AnyRef]]
           v.depth = 1
+          releaseFence()
           v
         }
       case v: Vector[E] => v
@@ -56,6 +57,7 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
           val v = new Vector[E](0, knownSize, 0)
           v.depth = 1
           v.display0 = display0
+          releaseFence()
           v
         } else {
           (newBuilder ++= it).result()
@@ -64,7 +66,7 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
 
   def newBuilder[A]: ReusableBuilder[A, Vector[A]] = new VectorBuilder[A]
 
-  /** Creates a Vector of one element */
+  /** Creates a Vector of one element. Not safe for publication, the caller is responsible for `releaseFence` */
   private def single[A](elem: A): Vector[A] = {
     val s = new Vector[A](0, 1, 0)
     s.depth = 1


### PR DESCRIPTION
One critique often made against Vectors is that small Vectors consume a lot of memory (See Li Haoyi's post [here](http://www.lihaoyi.com/post/BenchmarkingScalaCollections.html#memory-use-of-immutable-collections) ). Previous to this PR, Vectors of sizes in range [1, 31] would always round up and allocate an Array of size 32. Now, when creating a Vector with known size < 32, only exactly that size of an Array is allocated.

As well, when creating from varargs of `AnyRef`s (`collection.immutable.ArraySeq[T <: AnyRef]`) of size <= 32, we reuse the underlying `Array[AnyRef]`.

Performance of creating a Vector from varargs is greatly improved, for both AnyRef and AnyVal types.

### Benchmarks

Code:
```scala
@Benchmark def apply5String(bh: Blackhole): Unit = {
  bh.consume(Vector("1", "2", "3", "4", "5"))
}
@Benchmark def apply5Int(bh: Blackhole): Unit = {
  bh.consume(Vector(1,2,3,4,5))
}
@Benchmark def apply5StringOld(bh: Blackhole): Unit = {
  bh.consume(Vector.applyOld("1", "2", "3", "4", "5"))
}
@Benchmark def apply5IntOld(bh: Blackhole): Unit = {
  bh.consume(Vector.applyOld(1,2,3,4,5))
}
```

GC-profiled benchmark:
```
[info] Benchmark                                                         Mode  Cnt     Score     Error   Units
[info] VectorBenchmark.apply5Int                                         avgt   10    37.862 ±   0.941   ns/op
[info] VectorBenchmark.apply5Int:·gc.alloc.rate                          avgt   10  3223.910 ±  77.807  MB/sec
[info] VectorBenchmark.apply5Int:·gc.alloc.rate.norm                     avgt   10   192.000 ±   0.001    B/op
[info] VectorBenchmark.apply5Int:·gc.churn.PS_Eden_Space                 avgt   10  3222.198 ± 273.634  MB/sec
[info] VectorBenchmark.apply5Int:·gc.churn.PS_Eden_Space.norm            avgt   10   191.965 ±  17.591    B/op
[info] VectorBenchmark.apply5Int:·gc.churn.PS_Survivor_Space             avgt   10     0.110 ±   0.071  MB/sec
[info] VectorBenchmark.apply5Int:·gc.churn.PS_Survivor_Space.norm        avgt   10     0.007 ±   0.004    B/op
[info] VectorBenchmark.apply5Int:·gc.count                               avgt   10   106.000            counts
[info] VectorBenchmark.apply5Int:·gc.time                                avgt   10    83.000                ms
[info] VectorBenchmark.apply5IntOld                                      avgt   10    73.371 ±   0.792   ns/op
[info] VectorBenchmark.apply5IntOld:·gc.alloc.rate                       avgt   10  2979.859 ±  32.103  MB/sec
[info] VectorBenchmark.apply5IntOld:·gc.alloc.rate.norm                  avgt   10   344.000 ±   0.001    B/op
[info] VectorBenchmark.apply5IntOld:·gc.churn.PS_Eden_Space              avgt   10  2984.372 ± 249.212  MB/sec
[info] VectorBenchmark.apply5IntOld:·gc.churn.PS_Eden_Space.norm         avgt   10   344.551 ±  29.454    B/op
[info] VectorBenchmark.apply5IntOld:·gc.churn.PS_Survivor_Space          avgt   10     0.100 ±   0.061  MB/sec
[info] VectorBenchmark.apply5IntOld:·gc.churn.PS_Survivor_Space.norm     avgt   10     0.012 ±   0.007    B/op
[info] VectorBenchmark.apply5IntOld:·gc.count                            avgt   10   106.000            counts
[info] VectorBenchmark.apply5IntOld:·gc.time                             avgt   10    80.000                ms
[info] VectorBenchmark.apply5String                                      avgt   10    10.452 ±   0.080   ns/op
[info] VectorBenchmark.apply5String:·gc.alloc.rate                       avgt   10  5835.117 ±  45.558  MB/sec
[info] VectorBenchmark.apply5String:·gc.alloc.rate.norm                  avgt   10    96.000 ±   0.001    B/op
[info] VectorBenchmark.apply5String:·gc.churn.PS_Eden_Space              avgt   10  5730.019 ± 452.277  MB/sec
[info] VectorBenchmark.apply5String:·gc.churn.PS_Eden_Space.norm         avgt   10    94.270 ±   7.385    B/op
[info] VectorBenchmark.apply5String:·gc.churn.PS_Survivor_Space          avgt   10     0.104 ±   0.049  MB/sec
[info] VectorBenchmark.apply5String:·gc.churn.PS_Survivor_Space.norm     avgt   10     0.002 ±   0.001    B/op
[info] VectorBenchmark.apply5String:·gc.count                            avgt   10   112.000            counts
[info] VectorBenchmark.apply5String:·gc.time                             avgt   10    91.000                ms
[info] VectorBenchmark.apply5StringOld                                   avgt   10    71.918 ±   1.024   ns/op
[info] VectorBenchmark.apply5StringOld:·gc.alloc.rate                    avgt   10  3110.849 ±  44.149  MB/sec
[info] VectorBenchmark.apply5StringOld:·gc.alloc.rate.norm               avgt   10   352.000 ±   0.001    B/op
[info] VectorBenchmark.apply5StringOld:·gc.churn.PS_Eden_Space           avgt   10  3125.554 ± 234.281  MB/sec
[info] VectorBenchmark.apply5StringOld:·gc.churn.PS_Eden_Space.norm      avgt   10   353.583 ±  23.029    B/op
[info] VectorBenchmark.apply5StringOld:·gc.churn.PS_Survivor_Space       avgt   10     0.100 ±   0.063  MB/sec
[info] VectorBenchmark.apply5StringOld:·gc.churn.PS_Survivor_Space.norm  avgt   10     0.011 ±   0.007    B/op
[info] VectorBenchmark.apply5StringOld:·gc.count                         avgt   10   119.000            counts
[info] VectorBenchmark.apply5StringOld:·gc.time                          avgt   10    88.000                ms
```

Edit:
Some benchmark for `Vector.from(ArrayBuffer)`

```scala
  val ab = collection.mutable.ArrayBuffer(1,2,3,4,5)
  @Benchmark def from5Old(bh: Blackhole): Unit = {
    bh.consume(Vector.fromOld(ab))
  }
  @Benchmark def from5(bh: Blackhole): Unit = {
    bh.consume(Vector.from(ab))
  }
```

```
[info] Benchmark                                                  Mode  Cnt     Score     Error   Units
[info] VectorBenchmark.from5                                      avgt   10    39.882 ±   0.785   ns/op
[info] VectorBenchmark.from5:·gc.alloc.rate                       avgt   10  2295.068 ±  46.150  MB/sec
[info] VectorBenchmark.from5:·gc.alloc.rate.norm                  avgt   10   144.000 ±   0.001    B/op
[info] VectorBenchmark.from5:·gc.churn.PS_Eden_Space              avgt   10  2325.590 ± 232.257  MB/sec
[info] VectorBenchmark.from5:·gc.churn.PS_Eden_Space.norm         avgt   10   145.898 ±  13.829    B/op
[info] VectorBenchmark.from5:·gc.churn.PS_Survivor_Space          avgt   10     0.106 ±   0.052  MB/sec
[info] VectorBenchmark.from5:·gc.churn.PS_Survivor_Space.norm     avgt   10     0.007 ±   0.003    B/op
[info] VectorBenchmark.from5:·gc.count                            avgt   10   104.000            counts
[info] VectorBenchmark.from5:·gc.time                             avgt   10    94.000                ms
[info] VectorBenchmark.from5Old                                   avgt   10    68.592 ±   1.548   ns/op
[info] VectorBenchmark.from5Old:·gc.alloc.rate                    avgt   10  2743.165 ±  61.659  MB/sec
[info] VectorBenchmark.from5Old:·gc.alloc.rate.norm               avgt   10   296.000 ±   0.001    B/op
[info] VectorBenchmark.from5Old:·gc.churn.PS_Eden_Space           avgt   10  2717.767 ± 422.149  MB/sec
[info] VectorBenchmark.from5Old:·gc.churn.PS_Eden_Space.norm      avgt   10   293.202 ±  44.510    B/op
[info] VectorBenchmark.from5Old:·gc.churn.PS_Survivor_Space       avgt   10     0.090 ±   0.052  MB/sec
[info] VectorBenchmark.from5Old:·gc.churn.PS_Survivor_Space.norm  avgt   10     0.010 ±   0.005    B/op
[info] VectorBenchmark.from5Old:·gc.count                         avgt   10    86.000            counts
[info] VectorBenchmark.from5Old:·gc.time                          avgt   10    79.000                ms
```