### PR TITLE
Make inferred packedType-s determistic in bytecode

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4063,8 +4063,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           while (o != owner && o != NoSymbol && !o.hasPackageFlag) o = o.owner
           o == owner && !isVisibleParameter(sym)
         }
-      var localSyms = immutable.Set[Symbol]()
-      var boundSyms = immutable.Set[Symbol]()
+      val localSyms = mutable.LinkedHashSet[Symbol]()
+      val boundSyms = mutable.LinkedHashSet[Symbol]()
       def isLocal(sym: Symbol): Boolean =
         if (sym == NoSymbol || sym.isRefinementClass || sym.isLocalDummy) false
         else if (owner == NoSymbol) tree exists (defines(_, sym))

--- a/test/junit/scala/tools/nsc/DeterminismTest.scala
+++ b/test/junit/scala/tools/nsc/DeterminismTest.scala
@@ -263,6 +263,19 @@ class DeterminismTest {
     test(List(javaAnnots) :: code :: Nil)
   }
 
+  @Test def testPackedType(): Unit = {
+    def code = List[SourceFile](
+      source("a.scala",
+        """
+          | class C {
+          |   def foo = { object A; object B; object C; object D; object E; object F; def foo[A](a: A) = (a, a); foo((A, B, C, D, E))}
+          | }
+          |
+      """.stripMargin)
+    )
+    test(List(code))
+  }
+
   def source(name: String, code: String): SourceFile = new BatchSourceFile(name, code)
   private def test(groups: List[List[SourceFile]]): Unit = {
     val referenceOutput = Files.createTempDirectory("reference")


### PR DESCRIPTION
Prior to this patch, the enclosed test failed with:

```
--- a/C.class.scalap
+++ b/C.class.scalap
@@ -1,4 +1,4 @@
 class C extends scala.AnyRef {
   def this() = { /* compiled code */ }
-  def foo: scala.Tuple2[scala.Tuple5[A.type, B.type, C.type, D.type, E.type], scala.Tuple5[A.type, B.type, C.type, D.type, E.type]] forSome {type C.type <: scala.AnyRef with scala.Singleton; type E.type <: scala.AnyRef with scala.Singleton; type D.type <: scala.AnyRef with scala.Singleton; type A.type <: scala.AnyRef with scala.Singleton; type B.type <: scala.AnyRef with scala.Singleton} = { /* compiled code */ }
+  def foo: scala.Tuple2[scala.Tuple5[A.type, B.type, C.type, D.type, E.type], scala.Tuple5[A.type, B.type, C.type, D.type, E.type]] forSome {type C.type <: scala.AnyRef with scala.Singleton; type B.type <: scala.AnyRef with scala.Singleton; type E.type <: scala.AnyRef with scala.Singleton; type A.type <: scala.AnyRef with scala.Singleton; type D.type <: scala.AnyRef with scala.Singleton} = { /* compiled code */ }
 }
 ```