### PR TITLE
Improve chaining operators

### DIFF
--- a/src/library/scala/util/ChainingOps.scala
+++ b/src/library/scala/util/ChainingOps.scala
@@ -14,7 +14,7 @@ package scala
 package util
 
 trait ChainingSyntax {
-  implicit final def scalaUtilChainingOps[A](a: A): ChainingOps[A] = new ChainingOps(a)
+  @`inline` implicit final def scalaUtilChainingOps[A](a: A): ChainingOps[A] = new ChainingOps(a)
 }
 
 /** Adds chaining methods `tap` and `pipe` to every type.


### PR DESCRIPTION
This PR does 2 things:
- Make scalaUtilChainingOps inline
- <s>Add |> as an alias for pipe</s>

I humbly request that this gets considered before 2.13.0 (@SethTisue ?). I also sincerely apologize for not submitting sooner.

If the demonic symbolic alias is too controversial, I can drop it (for now).

However the first part is necessary IMHO.
e.g. 
```
class Foo { def foo = 1 pipe (_ + 2) } // with: -opt:l:inline -opt-inline-from:**
```
Before this PR:
```
  public int foo();
    Code:
       0: getstatic     #30                 // Field scala/util/ChainingOps$.MODULE$:Lscala/util/ChainingOps$;
       3: pop
       4: getstatic     #33                 // Field scala/util/package$chaining$.MODULE$:Lscala/util/package$chaining$;
       7: iconst_1
       8: invokestatic  #39                 // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
      11: invokestatic  #45                 // InterfaceMethod scala/util/ChainingSyntax.scalaUtilChainingOps$:(Lscala/util/ChainingSyntax;Ljava/lang/Object;)Ljava/lang/Object;
      14: invokestatic  #51                 // Method scala/runtime/BoxesRunTime.unboxToInt:(Ljava/lang/Object;)I
      17: iconst_2
      18: iadd
      19: ireturn
```

After this PR:
```
  public int foo();
    Code:
       0: getstatic     #30                 // Field scala/util/ChainingOps$.MODULE$:Lscala/util/ChainingOps$;
       3: pop
       4: getstatic     #33                 // Field scala/util/package$chaining$.MODULE$:Lscala/util/package$chaining$;
       7: pop
       8: iconst_1
       9: iconst_2
      10: iadd
      11: ireturn
```