### PR TITLE
Test defect for reflection of private fields

### DIFF
--- a/test/junit/scala/collection/mutable/OpenHashMapTest.scala
+++ b/test/junit/scala/collection/mutable/OpenHashMapTest.scala
@@ -15,8 +15,7 @@ class OpenHashMapTest {
     val m = OpenHashMap.empty[Int, Int]
 
     // Reflect to get the private `deleted` field's value, which should be zero.
-
-    /* TODO Doesn't work, due to scala/bug#9306.
+    // Was broken, see scala/bug#9306.
     import scala.reflect.runtime.{universe => ru}
 
     val mirror = ru.runtimeMirror(m.getClass.getClassLoader)
@@ -27,7 +26,7 @@ class OpenHashMapTest {
       .head.asTerm
 
     val fieldMirror = mirror.reflect(m).reflectField(termSym)
-		*/
+
     // Use Java reflection instead for now.
     val field =
       try {  // Name may or not be mangled, depending on what the compiler authors are doing.
@@ -43,7 +42,7 @@ class OpenHashMapTest {
     assertEquals(1, field.getInt(m))
 
     m.put(0, 0)  // Add an entry with the same key
-    // TODO assertEquals(0, fieldMirror.get.asInstanceOf[Int])
+    assertEquals(0, fieldMirror.get.asInstanceOf[Int])
     assertEquals(0, field.getInt(m))
   }
 

--- a/test/junit/scala/reflect/FieldAccessTest.scala
+++ b/test/junit/scala/reflect/FieldAccessTest.scala
@@ -16,10 +16,10 @@ class FieldAccessTest {
   @Test
   def testFieldAccess(): Unit = {
     import scala.reflect.runtime.{universe => ru}
-    val mirror = ru.runtimeMirror(getClass.getClassLoader)
+    import scala.reflect.runtime.currentMirror
     val obj = new TestClass
-    val objType = mirror.reflect(obj).symbol.toType
+    val objType = currentMirror.reflect(obj).symbol.toType
     val objFields = objType.members.collect { case ms: ru.MethodSymbol if ms.isGetter => ms }
-    assertEquals(123, mirror.reflect(obj).reflectField(objFields.head).get)
+    assertEquals(123, currentMirror.reflect(obj).reflectField(objFields.head).get)
   }
 }

--- a/test/junit/scala/reflect/FieldAccessTest.scala
+++ b/test/junit/scala/reflect/FieldAccessTest.scala
@@ -1,0 +1,25 @@
+package scala.reflect
+
+import org.junit.Assert._
+import org.junit.Ignore
+import org.junit.Test
+
+class FieldAccessTest {
+
+  class TestClass {
+    private val x = 123
+    // Uncommenting the following line would make the test fail
+    () => x
+  }
+
+  /** scala/bug#9306 */
+  @Test
+  def testFieldAccess(): Unit = {
+    import scala.reflect.runtime.{universe => ru}
+    val mirror = ru.runtimeMirror(getClass.getClassLoader)
+    val obj = new TestClass
+    val objType = mirror.reflect(obj).symbol.toType
+    val objFields = objType.members.collect { case ms: ru.MethodSymbol if ms.isGetter => ms }
+    assertEquals(123, mirror.reflect(obj).reflectField(objFields.head).get)
+  }
+}


### PR DESCRIPTION
Test case, `FieldAccessTest.testFieldAccess`, would throw the error:

```
scala.ScalaReflectionException: Scala field x isn't represented as a
  Java field, neither it has a Java accessor method note that private
  parameters of class constructors don't get mapped onto fields
  and/or accessors, unless they are used outside of their declaring
  constructors.
```

For `OpenHashMapTest.maintainsDeletedCount` test, `OpenHashMap.deleted` couldn't be updated with scala-reflect.

Fixes scala/bug#9306?