### PR TITLE
REPL summarizes warnings

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -85,6 +85,9 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
 
     def allConditionalWarnings = _allConditionalWarnings flatMap (_.warnings)
 
+    // useful in REPL because line parsing doesn't entail a new Run
+    def clearAllConditionalWarnings() = _allConditionalWarnings.foreach(_.warnings.clear())
+
     // behold! the symbol that caused the deprecation warning (may not be deprecated itself)
     def deprecationWarning(pos: Position, sym: Symbol, msg: String, since: String): Unit = _deprecationWarnings.warn(pos, msg, since)
     def deprecationWarning(pos: Position, sym: Symbol): Unit = {

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
@@ -78,7 +78,6 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
         withoutTruncating { printMessage(error) }
     }
 
-
   // whether to print anything
   var totalSilence: Boolean = false
   def suppressOutput[T](operation: => T): T = {

--- a/test/files/run/reify_newimpl_23.check
+++ b/test/files/run/reify_newimpl_23.check
@@ -8,7 +8,7 @@ import scala.tools.reflect.ToolBox
 scala> import scala.tools.reflect.Eval
 import scala.tools.reflect.Eval
 
-scala> def foo[T]{
+scala> def foo[T] = {
   val code = reify {
     List[T]()
   }

--- a/test/files/run/reify_newimpl_23.scala
+++ b/test/files/run/reify_newimpl_23.scala
@@ -6,7 +6,7 @@ object Test extends ReplTest {
 import scala.reflect.runtime.universe._
 import scala.tools.reflect.ToolBox
 import scala.tools.reflect.Eval
-def foo[T]{
+def foo[T] = {
   val code = reify {
     List[T]()
   }

--- a/test/files/run/reify_newimpl_26.check
+++ b/test/files/run/reify_newimpl_26.check
@@ -1,5 +1,5 @@
 
-scala> def foo[T]{
+scala> def foo[T] = {
   import scala.reflect.runtime.universe._
   val tt = implicitly[WeakTypeTag[List[T]]]
   println(tt)

--- a/test/files/run/reify_newimpl_26.scala
+++ b/test/files/run/reify_newimpl_26.scala
@@ -3,7 +3,7 @@ import scala.tools.partest.ReplTest
 object Test extends ReplTest {
   override def extraSettings = "-Xlog-free-types"
   def code = """
-def foo[T]{
+def foo[T] = {
   import scala.reflect.runtime.universe._
   val tt = implicitly[WeakTypeTag[List[T]]]
   println(tt)

--- a/test/files/run/repl-paste-2.check
+++ b/test/files/run/repl-paste-2.check
@@ -30,6 +30,7 @@ res10: Int = 12
 // Replaying 8 commands from transcript.
 
 scala> 999l
+warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 val res0: Long = 999
 
 scala> val res5 = { 123 }

--- a/test/files/run/t11402.check
+++ b/test/files/run/t11402.check
@@ -1,0 +1,12 @@
+
+scala> def f = {
+  val x = 'abc
+         val x = 'abc
+                 ^
+On line 2: warning: symbol literal is deprecated; use Symbol("abc") instead
+  val y = x.toString
+  y
+}
+def f: String
+
+scala> :quit

--- a/test/files/run/t11402.scala
+++ b/test/files/run/t11402.scala
@@ -1,0 +1,14 @@
+
+import scala.tools.nsc.Settings
+import scala.tools.partest.ReplTest
+import scala.util.chaining._
+
+object Test extends ReplTest {
+  override def transformSettings(ss: Settings) = ss.tap(_.deprecation.value = true)
+  override def code =
+    """|def f = {
+       |  val x = 'abc
+       |  val y = x.toString
+       |  y
+       |}""".stripMargin
+}

--- a/test/files/run/t4710.check
+++ b/test/files/run/t4710.check
@@ -1,5 +1,6 @@
 
 scala> def method : String = { implicit def f(s: Symbol) = "" ; 'symbol }
+warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 warning: 1 feature warning; for details, enable `:setting -feature' or `:replay -feature'
 def method: String
 

--- a/test/files/run/t6549.check
+++ b/test/files/run/t6549.check
@@ -3,6 +3,7 @@ scala> case class `X"`(var xxx: Any)
 class X$u0022
 
 scala> val m = Map(("": Any) -> `X"`("\""), ('s: Any) -> `X"`("\""))
+warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 val m: scala.collection.immutable.Map[Any,X"] = Map("" -> X"("), 's -> X"("))
 
 scala> m("")
@@ -18,6 +19,7 @@ scala> m("").xxx = "\""
 // mutated m("").xxx
 
 scala> m('s).xxx = 's
+warning: 2 deprecations (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 // mutated m(scala.Symbol("s")).xxx
 
 scala> val `"` = 0


### PR DESCRIPTION
Emit the summary "there were deprecations" after
successful parse.

Tweaks https://github.com/scala/scala/pull/7482

Previously, fatal warning trumped incomplete input, so switch that around. Previously:
```
Welcome to Scala 2.13.0-20190213-233114-f1c1d62 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_144).
Type in expressions for evaluation. Or try :help.

scala> def f() = { 'abc
                   ^
       warning: symbol literal is deprecated; use sym"abc" instead
error: No warnings can be incurred under -Xfatal-warnings.
```
Wait for complete input to issue summary.

Summary, `-deprecation`, `-Xfatal-warnings`:
```
$ skala -feature

     ________ ___   / /  ___
    / __/ __// _ | / /  / _ |
  __\ \/ /__/ __ |/ /__/ __ |
 /____/\___/_/ |_/____/_/ | |
                          |/  version 2.13.0-20190213-233114-f1c1d62

scala> 'abc
warning: there was one deprecation warning (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
res0: Symbol = 'abc

scala> trait T { def f() }
warning: there was one deprecation warning (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
defined trait T

scala> :replay -deprecation
replay> 'abc
        ^
        warning: symbol literal is deprecated; use sym"abc" instead
res0: Symbol = 'abc

replay> trait T { def f() }
                         ^
        warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `f`'s return type
defined trait T


scala> :replay -Xsource:2.14
replay> 'abc
        ^
        error: symbol literal is unsupported; use sym"abc" instead

replay> trait T { def f() }
                         ^
        error: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `f`'s return type


scala> :quit
```

Fixes scala/bug#11402