### PR TITLE
Restrict DummyImplicit creation

### DIFF
--- a/src/library/scala/DummyImplicit.scala
+++ b/src/library/scala/DummyImplicit.scala
@@ -13,9 +13,9 @@
 package scala
 
 /** A type for which there is always an implicit value. */
-class DummyImplicit
+final class DummyImplicit private ()
 
 object DummyImplicit {
   /** An implicit value yielding a `DummyImplicit`. */
-  implicit def dummyImplicit: DummyImplicit = new DummyImplicit
+  implicit val dummyImplicit: DummyImplicit = new DummyImplicit
 }


### PR DESCRIPTION
Restrict DummyImplicit creation

- Make the implicit a val to avoid allocating instances for no reason.
- Make the class itself final with a private constructor to guarantee
  that there is only one instance (the compiler could take this into
  account to shortcut implicit search).