### PR TITLE
Support scalac -release on JDK 12+

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
@@ -247,9 +247,11 @@ final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends Clas
   // e.g. "java.lang" -> Seq(/876/java/lang, /87/java/lang, /8/java/lang))
   private val packageIndex: scala.collection.Map[String, Seq[Path]] = {
     val index = collection.mutable.AnyRefMap[String, collection.mutable.ListBuffer[Path]]()
+    val isJava12OrHigher = scala.util.Properties.isJavaAtLeast("12")
     rootsForRelease.foreach(root => Files.walk(root).iterator().asScala.filter(Files.isDirectory(_)).foreach { p =>
-      if (p.getNameCount > 1) {
-        val packageDotted = p.subpath(1, p.getNameCount).toString.replace('/', '.')
+      val moduleNamePathElementCount = if (isJava12OrHigher) 1 else 0
+      if (p.getNameCount > root.getNameCount + moduleNamePathElementCount) {
+        val packageDotted = p.subpath(moduleNamePathElementCount + root.getNameCount, p.getNameCount).toString.replace('/', '.')
         index.getOrElseUpdate(packageDotted, new collection.mutable.ListBuffer) += p
       }
     })


### PR DESCRIPTION
The ct.sym file now contains the module name in the paths.

Fixes scala/bug#11403

## Manually tested:

### Hello world works:
```
$ for i in openjdk@1.9.0-4 openjdk@1.11.0 openjdk@1.12.0; do (jabba use $i; java -version; qscala -release 8 -e  'println("hello")'); done
openjdk version "9.0.4"
OpenJDK Runtime Environment (build 9.0.4+11)
OpenJDK 64-Bit Server VM (build 9.0.4+11, mixed mode)
hello
openjdk version "11" 2018-09-25
OpenJDK Runtime Environment 18.9 (build 11+28)
OpenJDK 64-Bit Server VM 18.9 (build 11+28, mixed mode)
hello
openjdk version "12" 2019-03-19
OpenJDK Runtime Environment (build 12+32)
OpenJDK 64-Bit Server VM (build 12+32, mixed mode, sharing)
hello
```

### Can't use JDK 9 API:

```
$ for i in openjdk@1.9.0-4 openjdk@1.11.0 openjdk@1.12.0; do (jabba use $i; java -version; qscala -release 8 -e  'java.util.List.of[String]("")'); done
openjdk version "9.0.4"
OpenJDK Runtime Environment (build 9.0.4+11)
OpenJDK 64-Bit Server VM (build 9.0.4+11, mixed mode)
/var/folders/tz/p8vd07wn7wxck3b9v54grlzw0000gp/T/scalacmd17028913264456597519.scala:1: error: value of is not a member of object java.util.List
java.util.List.of[String]("")
               ^
openjdk version "11" 2018-09-25
OpenJDK Runtime Environment 18.9 (build 11+28)
OpenJDK 64-Bit Server VM 18.9 (build 11+28, mixed mode)
/var/folders/tz/p8vd07wn7wxck3b9v54grlzw0000gp/T/scalacmd10102049886558546606.scala:1: error: value of is not a member of object java.util.List
java.util.List.of[String]("")
               ^
openjdk version "12" 2019-03-19
OpenJDK Runtime Environment (build 12+32)
OpenJDK 64-Bit Server VM (build 12+32, mixed mode, sharing)
/var/folders/tz/p8vd07wn7wxck3b9v54grlzw0000gp/T/scalacmd1941055367007427450.scala:1: error: value of is not a member of object java.util.List
java.util.List.of[String]("")
               ^
```
