### PR TITLE
Bump timeout in future-spec

### DIFF
--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -30,7 +30,7 @@ class FutureTests extends MinimalScalaTest {
     t
   }
 
-  val defaultTimeout = 5 seconds
+  val defaultTimeout = Test.DefaultTimeout
 
   /* future specification */
 

--- a/test/files/jvm/future-spec/main.scala
+++ b/test/files/jvm/future-spec/main.scala
@@ -9,6 +9,8 @@ import java.util.concurrent.{ TimeoutException, CountDownLatch, TimeUnit }
 
 object Test {
 
+  val DefaultTimeout = Duration(60, TimeUnit.SECONDS)
+
   def main(args: Array[String]): Unit = {
     (new FutureTests).check()
     (new PromiseTests).check()
@@ -86,7 +88,7 @@ trait MinimalScalaTest extends Output with Features {
 
 
 object TestLatch {
-  val DefaultTimeout = Duration(5, TimeUnit.SECONDS)
+  val DefaultTimeout = Test.DefaultTimeout
 
   def apply(count: Int = 1) = new TestLatch(count)
 }


### PR DESCRIPTION
From five to sixty seconds.

No test seems to time out intentionally.

Addresses https://github.com/scala/scala/pull/7758#issuecomment-464606870 which appears to show that side effects aren't always seen.