### PR TITLE
Avoid creating lists in Implicits - eligible

### DIFF
--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -215,8 +215,10 @@ trait Collections {
   final def mapFrom[A, A1 >: A, B](xs: List[A])(f: A => B): Map[A1, B] = {
     Map[A1, B](xs map (x => (x, f(x))): _*)
   }
-  final def linkedMapFrom[A, A1 >: A, B](xs: List[A])(f: A => B): mutable.LinkedHashMap[A1, B] = {
-    mutable.LinkedHashMap[A1, B](xs map (x => (x, f(x))): _*)
+  final def linkedMapFrom[A, A1 >: A, B](xs: Iterator[A])(f: A => B): mutable.LinkedHashMap[A1, B] = {
+    val res = mutable.LinkedHashMap.empty[A1, B]
+    xs.foreach(x => res +=  x -> f(x) )
+    res
   }
 
   final def mapWithIndex[A, B](xs: List[A])(f: (A, Int) => B): List[B] = {

--- a/test/files/neg/divergent-implicit.check
+++ b/test/files/neg/divergent-implicit.check
@@ -4,7 +4,7 @@ divergent-implicit.scala:4: error: type mismatch;
   val x1: String = 1
                    ^
 divergent-implicit.scala:5: error: diverging implicit expansion for type Int => String
-starting with method $conforms in object Predef
+starting with method cast in object Test1
   val x2: String = cast[Int, String](1)
                                     ^
 divergent-implicit.scala:14: error: type mismatch;

--- a/test/files/neg/t2316.check
+++ b/test/files/neg/t2316.check
@@ -1,6 +1,6 @@
 t2316.scala:28: error: ambiguous implicit values:
- both method T1FromT3 in object T1 of type (implicit t3: test.T3)test.T1
- and method T1FromT2 in object T1 of type (implicit t2: test.T2)test.T1
+ both method T1FromT2 in object T1 of type (implicit t2: test.T2)test.T1
+ and method T1FromT3 in object T1 of type (implicit t3: test.T3)test.T1
  match expected type test.T1
       val t1 = requireT1
                ^


### PR DESCRIPTION
We add some small optimisations to the Implicit sections, so as to reduce memory consumption by avoiding creating extra Cons objects.

- We change the type of the eligible list of ImplicitInfo solutions, from a linked list to an ArrayList.
- We avoid using the `List.flatMap` and `List.filter` operations, and instead we use `foreach` to avoid extra memory consumption. (save for iterators)
- In the `rankImplicits`, we replace the use of the list with the use of iterators. This makes `filterNot` into a constant operation.


Note: I noticed this change when looking at @retronym PR #7757 