### PR TITLE
Optimize ListBuffer.addAll

### DIFF
--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -114,11 +114,21 @@ class ListBuffer[A]
     this
   }
 
-  // Overridden for performance (to avoid virtual call to addOne
+  // Overridden for performance
   override final def addAll(xs: IterableOnce[A]): this.type = {
     val it = xs.iterator
-    while (it.hasNext) {
-      addOne(it.next())
+    if (it.hasNext) {
+      ensureUnaliased()
+      val last1 = new ::[A](it.next(), Nil)
+      if (len == 0) first = last1 else last0.next = last1
+      last0 = last1
+      len += 1
+      while (it.hasNext) {
+        val last1 = new ::[A](it.next(), Nil)
+        last0.next = last1
+        last0 = last1
+        len += 1
+      }
     }
     this
   }

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -105,12 +105,21 @@ class ListBuffer[A]
     aliased = false
   }
 
-  def addOne(elem: A): this.type = {
+  final def addOne(elem: A): this.type = {
     ensureUnaliased()
     val last1 = new ::[A](elem, Nil)
     if (len == 0) first = last1 else last0.next = last1
     last0 = last1
     len += 1
+    this
+  }
+
+  // Overridden for performance (to avoid virtual call to addOne
+  override final def addAll(xs: IterableOnce[A]): this.type = {
+    val it = xs.iterator
+    while (it.hasNext) {
+      addOne(it.next())
+    }
     this
   }
 

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/BuilderBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/BuilderBenchmark.scala
@@ -1,0 +1,55 @@
+package scala.collection.mutable
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+import org.openjdk.jmh.runner.IterationType
+import benchmark._
+import java.util.concurrent.TimeUnit
+import java.util.{ HashSet => JHashSet }
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 20)
+@Measurement(iterations = 20)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class BuilderBenchmark {
+
+  import collection.mutable
+
+  var listBuffer: mutable.ListBuffer[String] = _
+  var arrayBuffer: mutable.ArrayBuffer[String] = _
+  var queue: mutable.Queue[String] = _
+  var sinks: Array[mutable.Buffer[String]] = _
+  var source1: collection.Seq[String] = _
+  var source2: collection.Seq[String] = _
+  var source3: collection.Seq[String] = _
+  var sources: Array[collection.Seq[String]] = _
+
+  @Setup(Level.Iteration) def init: Unit = {
+    listBuffer = new mutable.ListBuffer
+    arrayBuffer = new mutable.ArrayBuffer
+    queue = new collection.mutable.Queue
+    source1 = (1 to 1000).map(_.toString).toList
+    source2 = (1 to 1000).map(_.toString).toArray[String]
+    source3 = (1 to 1000).map(_.toString).toVector
+    sources = scala.util.Random.shuffle(List.fill(10)(List(source1, source2, source2, source3)).flatten).toArray
+    sinks = Array[Buffer[String]](listBuffer, arrayBuffer, listBuffer, queue, listBuffer, arrayBuffer, listBuffer, listBuffer)
+  }
+
+  @Benchmark def addAllPolymorphic(bh: Blackhole): Unit = {
+    var i, j = 0
+    val sources = this.sources
+    val sinks = this.sinks
+    while (i < sinks.length) {
+      sinks(i).clear()
+      while (j < sources.length) {
+        sinks(i).addAll(sources(j))
+        j += 1
+      }
+      bh.consume(sinks(i))
+      i += 1
+    }
+  }
+}


### PR DESCRIPTION
The benchmark is a bit convoluted to make it hard for JIT to inline
through the megamorphic call.

I was motivated to look into this area when 2.13.x compiler profiles
showed a measurable amount of virtual call overhead in `Buffer.addAll`.

Before:

```
[info] # Run complete. Total time: 00:02:32
[info] Benchmark                           Mode  Cnt       Score      Error  Units
[info] BuilderBenchmark.addAllPolymorphic  avgt   60  868902.815 ± 6016.016  ns/op
```

After:

```
[info] BuilderBenchmark.addAllPolymorphic  avgt   60  624145.797 ± 4292.346  ns/op
```

After second commit:

```
[info] BuilderBenchmark.addAllPolymorphic  avgt   40  580774.689 ± 6331.147  ns/op
```