### PR TITLE
partest 1.1.9 (was 1.1.7)

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -22,6 +22,6 @@ scala.binary.version=2.12
 scala-xml.version.number=1.0.6
 scala-parser-combinators.version.number=1.0.7
 scala-swing.version.number=2.0.3
-partest.version.number=1.1.7
+partest.version.number=1.1.9
 scala-asm.version=6.2.0-scala-2
 jline.version=2.14.6


### PR DESCRIPTION
there aren't any real changes in this version. the context is
to test that we are able to publish Scala modules using sbt 1 now