### PR TITLE
[backport] upgrade to ASM 7

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/PostProcessor.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/PostProcessor.scala
@@ -73,15 +73,11 @@ abstract class PostProcessor extends PerRunInit {
       setInnerClasses(classNode)
       serializeClass(classNode)
     } catch {
-      case e: java.lang.RuntimeException if e.getMessage != null && (e.getMessage contains "too large!") =>
-        backendReporting.error(NoPosition,
-          s"Could not write class ${internalName} because it exceeds JVM code size limits. ${e.getMessage}")
-        null
       case ex: InterruptedException => throw ex
       case ex: Throwable =>
         // TODO fail fast rather than continuing to write the rest of the class files?
         if (frontendAccess.compilerSettings.debug) ex.printStackTrace()
-        backendReporting.error(NoPosition, s"Error while emitting ${internalName}\n${ex.getMessage}")
+        backendReporting.error(NoPosition, s"Error while emitting $internalName\n${ex.getMessage}")
         null
     }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerImpl.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerImpl.scala
@@ -464,16 +464,16 @@ case class ParameterProducer(local: Int)                                        
 case class UninitializedLocalProducer(local: Int)                                       extends InitialProducer
 case class ExceptionProducer[V <: Value](handlerLabel: LabelNode, handlerStackTop: Int) extends InitialProducer
 
-class InitialProducerSourceInterpreter extends SourceInterpreter(scala.tools.asm.Opcodes.ASM7_EXPERIMENTAL) {
+class InitialProducerSourceInterpreter extends SourceInterpreter(scala.tools.asm.Opcodes.ASM7) {
   override def newParameterValue(isInstanceMethod: Boolean, local: Int, tp: Type): SourceValue = {
     new SourceValue(tp.getSize, ParameterProducer(local))
   }
 
-  override def newEmptyNonParameterLocalValue(local: Int): SourceValue = {
+  override def newEmptyValue(local: Int): SourceValue = {
     new SourceValue(1, UninitializedLocalProducer(local))
   }
 
-  override def newExceptionValue(tryCatchBlockNode: TryCatchBlockNode, handlerFrame: Frame[_ <: Value], exceptionType: Type): SourceValue = {
+  override def newExceptionValue(tryCatchBlockNode: TryCatchBlockNode, handlerFrame: Frame[SourceValue], exceptionType: Type): SourceValue = {
     val handlerStackTop = handlerFrame.stackTop + 1 // +1 because this value is about to be pushed onto `handlerFrame`.
     new SourceValue(1, ExceptionProducer(tryCatchBlockNode.handler, handlerStackTop))
   }

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/TypeFlowInterpreter.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/TypeFlowInterpreter.scala
@@ -17,7 +17,7 @@ package analysis
 import scala.tools.asm.Type
 import scala.tools.asm.tree.analysis.{BasicValue, BasicInterpreter}
 
-abstract class TypeFlowInterpreter extends BasicInterpreter(scala.tools.asm.Opcodes.ASM7_EXPERIMENTAL) {
+abstract class TypeFlowInterpreter extends BasicInterpreter(scala.tools.asm.Opcodes.ASM7) {
   override def newValue(tp: Type) = {
     if (tp == null) super.newValue(tp)
     else if (isRef(tp)) new BasicValue(tp)

--- a/test/files/run/large_class.check
+++ b/test/files/run/large_class.check
@@ -1,1 +1,2 @@
-error: Could not write class BigEnoughToFail because it exceeds JVM code size limits. Class file too large!
+error: Error while emitting BigEnoughToFail
+Class too large: BigEnoughToFail

--- a/test/files/run/large_code.check
+++ b/test/files/run/large_code.check
@@ -1,1 +1,2 @@
-error: Could not write class BigEnoughToFail because it exceeds JVM code size limits. Method tooLong's code too large!
+error: Error while emitting BigEnoughToFail
+Method too large: BigEnoughToFail.tooLong ()V

--- a/versions.properties
+++ b/versions.properties
@@ -23,5 +23,5 @@ scala-xml.version.number=1.0.6
 scala-parser-combinators.version.number=1.0.7
 scala-swing.version.number=2.0.3
 partest.version.number=1.1.9
-scala-asm.version=6.2.0-scala-2
+scala-asm.version=7.0.0-scala-1
 jline.version=2.14.6


### PR DESCRIPTION
2.12.x backport of #7384

goal: improve compatibility with JDK 12, as per [scala/community-builds#864](https://github.com/scala/community-builds/issues/864) and [scala/bug#11372](https://github.com/scala/bug/issues/11372)

fixes scala/bug#11372