### PR TITLE
Revert "Disable parallelism in the scalacheck suite"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -661,9 +661,6 @@ lazy val scalacheck = project.in(file("test") / "scalacheck")
     testOptions in Test += Tests.Argument(TestFramework("org.scalacheck.LazyFramework"), "-verbosity", "2"),
     unmanagedSourceDirectories in Compile := Nil,
     unmanagedSourceDirectories in Test := List(baseDirectory.value)
-  ).settings(
-    // Workaround for https://github.com/sbt/sbt/pull/3985
-    List(Keys.test, Keys.testOnly).map(task => parallelExecution in task := false) : _*
   )
 
 lazy val osgiTestFelix = osgiTestProject(


### PR DESCRIPTION
This reverts commit a6873a2ebe168b14b7742c3030a481c62cc589b9.

reverts PR #6377

This workaround was needed on our 2.12.x branch which remains on sbt
0.13.x, but here on 2.13.x we're on sbt 1 and so this isn't supposed
to be necessary anymore.