### PR TITLE
Publicise PlainNioFile and implement underlyingSource

### DIFF
--- a/src/reflect/scala/reflect/io/PlainFile.scala
+++ b/src/reflect/scala/reflect/io/PlainFile.scala
@@ -101,7 +101,7 @@ class PlainFile(val givenPath: Path) extends AbstractFile {
     new PlainFile(givenPath / name)
 }
 
-private[scala] class PlainNioFile(nioPath: java.nio.file.Path) extends AbstractFile {
+final class PlainNioFile(val nioPath: java.nio.file.Path) extends AbstractFile {
   import java.nio.file._
 
   assert(nioPath ne null)
@@ -115,7 +115,29 @@ private[scala] class PlainNioFile(nioPath: java.nio.file.Path) extends AbstractF
 
   override lazy val canonicalPath = super.canonicalPath
 
-  override def underlyingSource  = Some(this)
+  override def underlyingSource  = {
+    val fileSystem = nioPath.getFileSystem
+    fileSystem.provider().getScheme match {
+      case "jar" =>
+        val fileStores = fileSystem.getFileStores.iterator()
+        if (fileStores.hasNext) {
+          val jarPath = fileStores.next().name
+          try {
+            Some(new PlainNioFile(Paths.get(jarPath.stripSuffix(fileSystem.getSeparator))))
+          } catch {
+            case _: InvalidPathException =>
+              None
+          }
+        } else None
+      case "jrt" =>
+        if (nioPath.getNameCount > 2 && nioPath.startsWith("/modules")) {
+          // TODO limit this to OpenJDK based JVMs?
+          val moduleName = nioPath.getName(1)
+          Some(new PlainNioFile(Paths.get(System.getProperty("java.home"), "jmods", moduleName.toString + ".jmod")))
+        } else None
+      case _ => None
+    }
+  }
 
   private val fpath = nioPath.toAbsolutePath.toString
 


### PR DESCRIPTION
```
$ ./build/quick/bin/scala
Welcome to Scala 2.13.0-20190221-140355-c0a7682 (OpenJDK 64-Bit Server VM, Java 11).
Type in expressions for evaluation. Or try :help.

scala> :power

scala> val path = symbolOf[java.lang.String].associatedFile
path: scala.reflect.io.AbstractFile = /modules/java.base/java/lang/String.class

scala> .underlyingSource
res0: Option[scala.reflect.io.AbstractFile] = Some(/Users/jz/.jabba/jdk/openjdk@1.11.0/Contents/Home/jmods/java.base.jmod)

scala> .get.exists
res1: Boolean = true
res0: Boolean = true
```

```
$ ./build/quick/bin/scala -release 8
Welcome to Scala 2.13.0-20190221-140355-c0a7682 (OpenJDK 64-Bit Server VM, Java 11).
Type in expressions for evaluation. Or try :help.

scala> :power

scala> val path = symbolOf[java.lang.String].associatedFile
path: scala.reflect.io.AbstractFile = /8/java/lang/String.sig

scala> .underlyingSource
res3: Option[scala.reflect.io.AbstractFile] = Some(/Users/jz/.jabba/jdk/openjdk@1.11.0/Contents/Home/lib/ct.sym)

scala> .get.exists
res4: Boolean = true
```

References https://github.com/sbt/zinc/issues/609
