### PR TITLE
Add synchronous ("parasitic") ExecutionContext

### DIFF
--- a/src/library/scala/concurrent/Promise.scala
+++ b/src/library/scala/concurrent/Promise.scala
@@ -66,7 +66,7 @@ trait Promise[T] {
    */
    def completeWith(other: Future[T]): this.type = {
     if (other ne this.future) // this tryCompleteWith this doesn't make much sense
-      other.onComplete(this tryComplete _)(Future.InternalCallbackExecutor)
+      other.onComplete(this tryComplete _)(ExecutionContext.parasitic)
 
     this
   }

--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -447,7 +447,7 @@ private[concurrent] object Promise {
               fun(v)
               null
             case Xform_recover       =>
-              resolve(v.recover(fun.asInstanceOf[PartialFunction[Throwable, F]])) //recover F=:=T
+              if (v.isInstanceOf[Failure[F]]) resolve(v.recover(fun.asInstanceOf[PartialFunction[Throwable, F]])) else v //recover F=:=T
             case Xform_recoverWith   =>
               if (v.isInstanceOf[Failure[F]]) {
                 val f = fun.asInstanceOf[PartialFunction[Throwable, Future[T]]].applyOrElse(v.asInstanceOf[Failure[F]].exception, Future.recoverWithFailed)

--- a/test/benchmarks/src/main/scala/scala/concurrent/FutureBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/concurrent/FutureBenchmark.scala
@@ -15,7 +15,7 @@ import scala.annotation.tailrec
 @Fork(value = 1, jvmArgsAppend = Array("-Xmx1G", "-Xms1G", "-server", "-XX:+AggressiveOpts", "-XX:+UseCompressedOops", "-XX:+AlwaysPreTouch", "-XX:+UseCondCardMark"))
 @Threads(value = 1)
 abstract class AbstractBaseFutureBenchmark {
-  // fjp = ForkJoinPool, fix = FixedThreadPool, fie = FutureInternalExecutor, gbl = GlobalEC
+  // fjp = ForkJoinPool, fix = FixedThreadPool, fie = parasiticEC, gbl = GlobalEC
   @Param(Array[String]("fjp", "fix", "fie", "gbl"))
   final var pool: String = _
 
@@ -65,7 +65,7 @@ abstract class AbstractBaseFutureBenchmark {
         System.setProperty("scala.concurrent.context.maxThreads", threads.toString)
         ExecutionContext.global
       case "fie" =>
-        scala.concurrent.Future.InternalCallbackExecutor
+        scala.concurrent.ExecutionContext.parasitic
     }
   }
 

--- a/test/files/jvm/future-spec.check
+++ b/test/files/jvm/future-spec.check
@@ -1,1 +1,3 @@
 warning: there were 5 deprecation warnings (since 2.13.0); re-run with -deprecation for details
+FutureTests$$anon$2: do not rethrow
+FutureTests$$anon$3: expected

--- a/test/files/neg/t8849.check
+++ b/test/files/neg/t8849.check
@@ -1,5 +1,5 @@
 t8849.scala:8: error: ambiguous implicit values:
- both lazy value global in object Implicits of type => scala.concurrent.ExecutionContext
+ both method global in object Implicits of type => scala.concurrent.ExecutionContext
  and value dummy of type scala.concurrent.ExecutionContext
  match expected type scala.concurrent.ExecutionContext
     require(implicitly[ExecutionContext] eq dummy)


### PR DESCRIPTION
A synchronous, trampolining, ExecutionContext has been used for a long time *within* the Future implementation to run controlled logic as cheaply as possible.

I believe that there is a significant number of use-cases where it makes sense, for efficiency, to execute logic synchronously in a safe(-ish) way without having users to implement the logic for that ExecutionContext themselves—it is tricky to implement to say the least.

It is important to remember that `ExecutionContext` should be supplied via an implicit parameter, so that the caller can decide where logic should be executed. The use of `ExecutionContext.parasitic` means that logic may end up running on Threads/Pools that were not designed or intended to run specified logic. For instance, you may end up running CPU-bound logic on an IO-designed pool or vice versa. So use of `parasitic` is only advisable when it really makes sense. There is also a real risk of hitting StackOverflowErrors for certain patterns of nested invocations where a deep call chain ends up in the `parasitic` executor, leading to even more stack usage in the subsequent execution. Currently the `parasitic` ExecutionContext will allow a nested sequence of invocations at max 16, this may be changed in the future if it is discovered to cause problems.