### PR TITLE
Performance: use disjunction instead of list concatenation

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -560,9 +560,12 @@ trait Infer extends Checkable {
       // explicitly anywhere amongst the formal, argument, result, or expected type.
       // ...or lower bound of a type param, since they're asking for it.
       def canWarnAboutAny = {
-        val loBounds = tparams map (_.info.lowerBound)
-        def containsAny(t: Type) = (t contains AnyClass) || (t contains AnyValClass) || (t contains ObjectClass)
-        val hasAny = pt :: restpe :: formals ::: argtpes ::: loBounds exists (_.dealiasWidenChain exists containsAny)
+        val coll = new ContainsAnyCollector(List(AnyClass, AnyValClass, ObjectClass))
+        def containsAny(t: Type) = t.dealiasWidenChain.exists(coll.collect)
+        val hasAny = containsAny(pt) || containsAny(restpe) ||
+          formals.exists(containsAny) ||
+          argtpes.exists(containsAny) ||
+          tparams.exists(x => containsAny(x.info.lowerBound))
         !hasAny
       }
       if (settings.warnInferAny && context.reportErrors && !fn.isEmpty && canWarnAboutAny) {


### PR DESCRIPTION
Some performance tweaks in the code of canWarnAboutAny.
- Instead of a disjunction of three calls to `Type.contains`, each of which would create a ContainsCollector and run a full run of the tree, we create a single ContainsAnyCollector to be used in all calls, and perform a single run of the type-tree for each type.
- Instead of using a single exists on a concatenation of lists, we use a disjunctions of several calls to exists.
- We merge the `map` to get the lowerBound, and to perform the call to `dealiasWidenChain`.