### PR TITLE
deprecatedError + restricted annotation

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -97,6 +97,13 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
       deprecationWarning(pos, sym, s"$sym${sym.locationString} is deprecated$since$message", version)
     }
 
+    def deprecationError(pos: Position, sym: Symbol): Unit = {
+      val version = sym.deprecationVersion.getOrElse("")
+      val since   = if (version.isEmpty) version else s" (since $version)"
+      val message = sym.deprecationMessage match { case Some(msg) => s": $msg"        case _ => "" }
+      reporter.error(pos, s"$sym${sym.locationString} is unsupported$since$message")
+    }
+
     private[this] var reportedFeature = Set[Symbol]()
     def featureWarning(pos: Position, featureName: String, featureDesc: String, featureTrait: Symbol, construct: => String = "", required: Boolean): Unit = {
       val req     = if (required) "needs to" else "should"

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1256,12 +1256,13 @@ abstract class RefChecks extends Transform {
     // warnings after the first, but I think it'd be better if we didn't have to
     // arbitrarily choose one as more important than the other.
     private def checkUndesiredProperties(sym: Symbol, pos: Position): Unit = {
+      if (sym.isRestricted && !currentOwner.ownerChain.exists(x => x.isRestricted))
+        currentRun.reporting.handleRestriction(pos, sym)
+
       // If symbol is deprecated, and the point of reference is not enclosed
       // in either a deprecated member or a scala bridge method, issue a warning.
-      if (sym.isDeprecated && !currentOwner.ownerChain.exists(x => x.isDeprecated)) {
-        if (sym.isDeprecatedError) currentRun.reporting.deprecationError(pos, sym)
-        else currentRun.reporting.deprecationWarning(pos, sym)
-      }
+      if (sym.isDeprecated && !currentOwner.ownerChain.exists(x => x.isDeprecated))
+        currentRun.reporting.deprecationWarning(pos, sym)
 
       // Similar to deprecation: check if the symbol is marked with @migration
       // indicating it has changed semantics between versions.

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1258,8 +1258,10 @@ abstract class RefChecks extends Transform {
     private def checkUndesiredProperties(sym: Symbol, pos: Position): Unit = {
       // If symbol is deprecated, and the point of reference is not enclosed
       // in either a deprecated member or a scala bridge method, issue a warning.
-      if (sym.isDeprecated && !currentOwner.ownerChain.exists(x => x.isDeprecated))
-        currentRun.reporting.deprecationWarning(pos, sym)
+      if (sym.isDeprecated && !currentOwner.ownerChain.exists(x => x.isDeprecated)) {
+        if (sym.isDeprecatedError) currentRun.reporting.deprecationError(pos, sym)
+        else currentRun.reporting.deprecationWarning(pos, sym)
+      }
 
       // Similar to deprecation: check if the symbol is marked with @migration
       // indicating it has changed semantics between versions.

--- a/src/library/scala/annotation/restricted.scala
+++ b/src/library/scala/annotation/restricted.scala
@@ -1,0 +1,61 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+
+import scala.annotation.meta._
+
+object RestrictedSeverity {
+  final val info    = "info"
+  final val warning = "warning"
+  final val error   = "error"
+  final val none    = "none"
+}
+
+object RestrictedLabel {
+  final val deprecated   = "deprecated"
+  final val internalOnly = "internalOnly"
+  final val apiMayChange = "apiMayChange"
+}
+
+/**
+ * An annotation to denote the API status.
+ *
+ * @param  message the advisory to print during compilation
+ * @param  since   a string identifying the first version in which the restriction is applied
+ * @param  label   a string identifying the categorization of the restriction
+ * @param  defaultSeverity the default severity of the restriction when the annotee is referenced
+ * @since  2.13.0
+ * @see    [[scala.annotation.deprecatedError]]
+ * @see    [[scala.annotation.RestrictedSeverity]]
+ * @see    [[scala.annotation.RestrictedLabel]]
+ */
+@getter @setter @beanGetter @beanSetter @companionClass @companionMethod
+sealed class restricted(
+  message: String,
+  since: String,
+  label: String,
+  defaultSeverity: String = RestrictedSeverity.warning) extends scala.annotation.StaticAnnotation
+
+/** An annotation that designates that an annottee should no longer be used.
+ *
+ *  This can be used as a next step to deprecation. Instead of removing
+ *  the methods, this can be used to display a more helpful migration message.
+ *
+ *  @param  message the error message to print during compilation if a reference remains in code
+ *  @param  since   a string identifying the first version in which the definition was deprecated
+ *  @since  2.13.0
+ *  @see    [[scala.deprecated]]
+ */
+@getter @setter @beanGetter @beanSetter
+final class deprecatedError(message: String, since: String) extends
+  restricted(message, since, RestrictedLabel.deprecated, RestrictedSeverity.error)

--- a/src/library/scala/deprecated.scala
+++ b/src/library/scala/deprecated.scala
@@ -56,7 +56,21 @@ import scala.annotation.meta._
  *  @see    [[scala.deprecatedInheritance]]
  *  @see    [[scala.deprecatedOverriding]]
  *  @see    [[scala.deprecatedName]]
+ *  @see    [[scala.deprecatedError]]
  */
 @getter @setter @beanGetter @beanSetter
-@deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
+@deprecatedInheritance("Scheduled for being sealed in 2.14", "2.13.0")
 class deprecated(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation
+
+/** An annotation that designates that an annottee should no longer be used.
+ *
+ *  This can be used as a next step to deprecation. Instead of removing
+ *  the methods, this can be used to display a more helpful migration message.
+ *
+ *  @param  message the error message to print during compilation if a reference remains in code
+ *  @param  since   a string identifying the first version in which the definition was deprecated
+ *  @since  2.13.0
+ *  @see    [[scala.deprecated]]
+ */
+@getter @setter @beanGetter @beanSetter
+final class deprecatedError(message: String, since: String) extends deprecated(message, since)

--- a/src/library/scala/deprecated.scala
+++ b/src/library/scala/deprecated.scala
@@ -59,18 +59,5 @@ import scala.annotation.meta._
  *  @see    [[scala.deprecatedError]]
  */
 @getter @setter @beanGetter @beanSetter
-@deprecatedInheritance("Scheduled for being sealed in 2.14", "2.13.0")
+@deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
 class deprecated(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation
-
-/** An annotation that designates that an annottee should no longer be used.
- *
- *  This can be used as a next step to deprecation. Instead of removing
- *  the methods, this can be used to display a more helpful migration message.
- *
- *  @param  message the error message to print during compilation if a reference remains in code
- *  @param  since   a string identifying the first version in which the definition was deprecated
- *  @since  2.13.0
- *  @see    [[scala.deprecated]]
- */
-@getter @setter @beanGetter @beanSetter
-final class deprecatedError(message: String, since: String) extends deprecated(message, since)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1267,6 +1267,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val DeprecatedNameAttr         = requiredClass[scala.deprecatedName]
     lazy val DeprecatedInheritanceAttr  = requiredClass[scala.deprecatedInheritance]
     lazy val DeprecatedOverridingAttr   = requiredClass[scala.deprecatedOverriding]
+    lazy val DeprecatedErrorAttr        = getClassIfDefined("scala.deprecatedError")
     lazy val NativeAttr                 = requiredClass[scala.native]
     lazy val ScalaInlineClass           = requiredClass[scala.inline]
     lazy val ScalaNoInlineClass         = requiredClass[scala.noinline]

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1267,7 +1267,8 @@ trait Definitions extends api.StandardDefinitions {
     lazy val DeprecatedNameAttr         = requiredClass[scala.deprecatedName]
     lazy val DeprecatedInheritanceAttr  = requiredClass[scala.deprecatedInheritance]
     lazy val DeprecatedOverridingAttr   = requiredClass[scala.deprecatedOverriding]
-    lazy val DeprecatedErrorAttr        = getClassIfDefined("scala.deprecatedError")
+    lazy val DeprecatedErrorAttr        = getClassIfDefined("scala.annotation.deprecatedError")
+    lazy val RestrictedAttr             = getClassIfDefined("scala.annotation.restricted")
     lazy val NativeAttr                 = requiredClass[scala.native]
     lazy val ScalaInlineClass           = requiredClass[scala.inline]
     lazy val ScalaNoInlineClass         = requiredClass[scala.noinline]

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -908,7 +908,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isStrictFP: Boolean    = !isDeferred && (hasAnnotation(ScalaStrictFPAttr) || originalOwner.isStrictFP)
     def isSerializable         = info.baseClasses.exists(_ == SerializableClass)
     def isDeprecated           = hasAnnotation(DeprecatedAttr)
-    def isDeprecatedError      = hasAnnotation(DeprecatedErrorAttr)
     def deprecationMessage     = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 0)
     def deprecationVersion     = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 1)
     def deprecatedParamName    = getAnnotation(DeprecatedNameAttr) flatMap (ann => ann.symbolArg(0).orElse(ann.stringArg(0).map(newTermName)).orElse(Some(nme.NO_NAME)))
@@ -925,6 +924,13 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
                                = getAnnotation(DeprecatedOverridingAttr) flatMap (_ stringArg 0)
     def deprecatedOverridingVersion
                                = getAnnotation(DeprecatedOverridingAttr) flatMap (_ stringArg 1)
+    def isRestricted           = hasAnnotation(RestrictedAttr)
+    def restrictionMessage     = getAnnotation(RestrictedAttr) flatMap (_ stringArg 0)
+    def restrictionVersion     = getAnnotation(RestrictedAttr) flatMap (_ stringArg 1)
+    def restrictionLabel       = getAnnotation(RestrictedAttr) flatMap (_ stringArg 2)
+    def restrictionDefaultSeverity
+                               = getAnnotation(RestrictedAttr) flatMap (_ stringArg 3)
+    def isDeprecatedError      = hasAnnotation(DeprecatedErrorAttr)
 
     // !!! when annotation arguments are not literal strings, but any sort of
     // assembly of strings, there is a fair chance they will turn up here not as

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -908,6 +908,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isStrictFP: Boolean    = !isDeferred && (hasAnnotation(ScalaStrictFPAttr) || originalOwner.isStrictFP)
     def isSerializable         = info.baseClasses.exists(_ == SerializableClass)
     def isDeprecated           = hasAnnotation(DeprecatedAttr)
+    def isDeprecatedError      = hasAnnotation(DeprecatedErrorAttr)
     def deprecationMessage     = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 0)
     def deprecationVersion     = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 1)
     def deprecatedParamName    = getAnnotation(DeprecatedNameAttr) flatMap (ann => ann.symbolArg(0).orElse(ann.stringArg(0).map(newTermName)).orElse(Some(nme.NO_NAME)))

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -417,6 +417,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.DeprecatedNameAttr
     definitions.DeprecatedInheritanceAttr
     definitions.DeprecatedOverridingAttr
+    definitions.DeprecatedErrorAttr
     definitions.NativeAttr
     definitions.ScalaInlineClass
     definitions.ScalaNoInlineClass

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -418,6 +418,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.DeprecatedInheritanceAttr
     definitions.DeprecatedOverridingAttr
     definitions.DeprecatedErrorAttr
+    definitions.RestrictedAttr
     definitions.NativeAttr
     definitions.ScalaInlineClass
     definitions.ScalaNoInlineClass

--- a/test/files/neg/report-apiMayChange-error.check
+++ b/test/files/neg/report-apiMayChange-error.check
@@ -1,0 +1,4 @@
+report-apiMayChange-error.scala:16: error: method FooDSL in object syntax is unsupported (since foo-lib 1.0): foo DSL is incubating
+  "bar" should "something"
+  ^
+one error found

--- a/test/files/neg/report-apiMayChange-error.scala
+++ b/test/files/neg/report-apiMayChange-error.scala
@@ -1,0 +1,17 @@
+// scalac: -Wconfig apiMayChange:foo.*:error
+
+import scala.annotation.{ restricted, RestrictedLabel }
+
+package foo {
+  object syntax {
+    @restricted("foo DSL is incubating", since = "foo-lib 1.0", label = RestrictedLabel.apiMayChange)
+    implicit class FooDSL(s: String) {
+      def should(o: String): Unit = ()
+    }
+  }
+}
+
+object Test1 {
+  import foo.syntax._
+  "bar" should "something"
+}

--- a/test/files/neg/report-apiMayChange.check
+++ b/test/files/neg/report-apiMayChange.check
@@ -1,0 +1,6 @@
+report-apiMayChange.scala:16: warning: method FooDSL in object syntax is restricted (since foo-lib 1.0): foo DSL is incubating
+  "bar" should "something"
+  ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/report-apiMayChange.scala
+++ b/test/files/neg/report-apiMayChange.scala
@@ -1,0 +1,17 @@
+// scalac: -Xfatal-warnings
+
+import scala.annotation.{ restricted, RestrictedLabel }
+
+package foo {
+  object syntax {
+    @restricted("foo DSL is incubating", since = "foo-lib 1.0", label = RestrictedLabel.apiMayChange)
+    implicit class FooDSL(s: String) {
+      def should(o: String): Unit = ()
+    }
+  }
+}
+
+object Test1 {
+  import foo.syntax._
+  "bar" should "something"
+}

--- a/test/files/neg/report-deprecated-error.check
+++ b/test/files/neg/report-deprecated-error.check
@@ -1,4 +1,4 @@
-report-deprecated-error.scala:10: error: method <<= in object syntax is unsupported (since foo-lib 1.0): use := syntax instead
+report-deprecated-error.scala:12: error: method <<= in object syntax is unsupported (since foo-lib 1.0): use := syntax instead
   <<=()
   ^
 one error found

--- a/test/files/neg/report-deprecated-error.check
+++ b/test/files/neg/report-deprecated-error.check
@@ -1,0 +1,4 @@
+report-deprecated-error.scala:10: error: method <<= in object syntax is unsupported (since foo-lib 1.0): use := syntax instead
+  <<=()
+  ^
+one error found

--- a/test/files/neg/report-deprecated-error.scala
+++ b/test/files/neg/report-deprecated-error.scala
@@ -1,3 +1,5 @@
+import scala.annotation.deprecatedError
+
 package foo {
   object syntax {
     @deprecatedError("use := syntax instead", since="foo-lib 1.0")

--- a/test/files/neg/report-deprecated-error.scala
+++ b/test/files/neg/report-deprecated-error.scala
@@ -1,0 +1,11 @@
+package foo {
+  object syntax {
+    @deprecatedError("use := syntax instead", since="foo-lib 1.0")
+    def <<=() = ???
+  }
+}
+
+object Test1 {
+  import foo.syntax._
+  <<=()
+}


### PR DESCRIPTION
This implements `restricted` annotation as a generic form of `deprecated` annotation. `restricted` takes `label` and `defaultSeverity` parameter.

The user can configure how the usages of restricted API are handled by passing in `-Wconfig` config expressions.

A warning config expression may be `<label>`, `<label>:<severity>`, or `<label>:<prefix>:<severity>`

`<label>` is a String passed into `@restricted`.
`<severity>` must be one of "error", "warning", "info", or "none": default: warning.
`<prefix>` denotes the prefix of the restricted API. For example, `"foo.*"` will denote
that this config would apply only to calls under foo package/object.
Note: "*" is simply ignored.

The following configuration would escalate apiMayChange restriction to an error:
```
-Wconfig apiMayChange:foo.*:error
```
