### PR TITLE
Deprecate multi-parameter symbolic method declarations

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2794,6 +2794,14 @@ self =>
             }
             expr()
           }
+        def symbolicMethodMsg(what: String) =
+          s"multi-parameter symbolic method is $what: instead, change the parameters into a tuple or use a non-symbolic name"
+        def checkMultiParameterSymbolicMethod(): Unit =
+          if (vparamss.size == 1 && vparamss.head.size > 1 && name.isSymbolicName) {
+            if (currentRun.isScala214) syntaxError(nameOffset, symbolicMethodMsg("unsupported"))
+            else deprecationWarning(nameOffset, symbolicMethodMsg("deprecated"), "2.13.0")
+          }
+        checkMultiParameterSymbolicMethod()
         DefDef(newmods, name.toTermName, tparams, vparamss, restype, rhs)
       }
       signalParseProgress(result.pos)

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -431,6 +431,12 @@ trait Names extends api.Names {
       newTermName(cs, 0, len)
     }
 
+    /** This name does NOT start with an underscore or a Unicode identifier letter */
+    final def isSymbolicName: Boolean = {
+      val c = decode.head
+      (c != '_') && !Character.isUnicodeIdentifierStart(c)
+    }
+
     /* TODO - reconcile/fix that encode returns a Name but
      *  decode returns a String.
      */

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2425,7 +2425,7 @@ trait Types
       hasLength(args, 2) &&
         sym.getAnnotation(ShowAsInfixAnnotationClass)
          .map(_ booleanArg 0 getOrElse true)
-         .getOrElse(!Character.isUnicodeIdentifierStart(sym.decodedName.head))
+         .getOrElse(sym.name.isSymbolicName)
 
     private[Types] def invalidateTypeRefCaches(): Unit = {
       parentsCache = null

--- a/test/files/neg/symbolic-ops-deprecation.check
+++ b/test/files/neg/symbolic-ops-deprecation.check
@@ -1,0 +1,6 @@
+symbolic-ops-deprecation.scala:4: warning: multi-parameter symbolic method is deprecated: instead, change the parameters into a tuple or use a non-symbolic name
+  def +=(a: Int, b: Int): Foo
+      ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/symbolic-ops-deprecation.scala
+++ b/test/files/neg/symbolic-ops-deprecation.scala
@@ -1,0 +1,5 @@
+// scalac: -deprecation -Xfatal-warnings
+//
+abstract class Foo {
+  def +=(a: Int, b: Int): Foo
+}

--- a/test/files/neg/symbolic-ops-removal.check
+++ b/test/files/neg/symbolic-ops-removal.check
@@ -1,0 +1,4 @@
+symbolic-ops-removal.scala:4: error: multi-parameter symbolic method is unsupported: instead, change the parameters into a tuple or use a non-symbolic name
+  def +=(a: Int, b: Int): Foo
+      ^
+one error found

--- a/test/files/neg/symbolic-ops-removal.scala
+++ b/test/files/neg/symbolic-ops-removal.scala
@@ -1,0 +1,5 @@
+// scalac: -Xsource:2.14
+//
+abstract class Foo {
+  def +=(a: Int, b: Int): Foo
+}

--- a/test/files/run/t5565.check
+++ b/test/files/run/t5565.check
@@ -1,0 +1,1 @@
+warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details


### PR DESCRIPTION
Ref https://github.com/scala/scala-dev/issues/503

As a preparatory step towards deprecating multi-parameter infix notation, this will deprecate the declaration of symbolic method so the library authors can either mark symbolic multi-param methods as `@deprecated` in their library or migrate to something else.

```
symbolic-ops-deprecation.scala:4: warning: multi-parameter symbolic method is deprecated: instead, change the parameters into a tuple or use a non-symbolic name
  def +=(a: Int, b: Int): Foo
      ^
```

See also https://github.com/scala/scala/pull/7795