### PR TITLE
Deprecate multi-arg infix notation under -Xsource:2.14

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -872,6 +872,10 @@ self =>
         case Parens(args) => mkNamed(args)
         case _            => right :: Nil
       }
+      def msg(what: String) = s"""multi-parameter infix notation is $what; use dot-and-parenthesis instead"""
+      if (settings.isScala214 && arguments.size > 1) {
+        deprecationWarning(right.pos.point, msg("deprecated"), "2.14.0")
+      }
       if (isExpr) {
         if (rightAssoc) {
           import symtab.Flags._

--- a/test/files/neg/infix-deprecation.check
+++ b/test/files/neg/infix-deprecation.check
@@ -1,0 +1,6 @@
+infix-deprecation.scala:5: warning: multi-parameter infix notation is deprecated; use dot-and-parenthesis instead
+  val im2 = scala.collection.immutable.Map("foo" -> 1) updated ("baz", 3) // not ok
+                                                               ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/infix-deprecation.scala
+++ b/test/files/neg/infix-deprecation.scala
@@ -1,0 +1,6 @@
+// scalac: -deprecation -Xfatal-warnings -Xsource:2.14
+
+object Test1 {
+  val im1 = scala.collection.immutable.Map("foo" -> 1).updated("bar", 2) // ok
+  val im2 = scala.collection.immutable.Map("foo" -> 1) updated ("baz", 3) // not ok
+}


### PR DESCRIPTION
Ref https://github.com/scala/scala-dev/issues/503
Ref https://github.com/lampepfl/dotty/pull/4311