### PR TITLE
Allow sorting of array slices

### DIFF
--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -189,7 +189,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     * @return modified input $coll sorted according to the ordering `ord`.
     */
   override def sortInPlace[B >: A]()(implicit ord: Ordering[B]): this.type = {
-    if (length > 1) scala.util.Sorting.stableSort(array.asInstanceOf[Array[B]])
+    if (length > 1) scala.util.Sorting.stableSort(array.asInstanceOf[Array[B]], 0, length)
     this
   }
 }

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -352,5 +352,10 @@ class ArrayBufferTest {
     }
   }
 
-
+  @Test def t11417_sortInPlace: Unit = {
+    val a = ArrayBuffer(5,4,3,2,1)
+    a.trimEnd(2)
+    a.sortInPlace
+    assertEquals(List(3,4,5), a)
+  }
 }


### PR DESCRIPTION
…and use it to fix https://github.com/scala/bug/issues/11417

Java already supports this and so do our primitive implementations in
`scala.util.Sorting` but the top-level methods there didn’t expose the
necessary API to callers.