### PR TITLE
 Compile the stdlib with Dotty as part of the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
           - buildLocker
           - buildQuick
           - triggerScalaDist
+          - sbt -Dscala.build.compileWithDotty=true library/compile
 
       # pull request validation (w/ mini-bootstrap)
       - stage: build
@@ -42,6 +43,7 @@ jobs:
           - sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
           - STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
           - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
+          - sbt -Dscala.build.compileWithDotty=true library/compile
 
       # build the spec using jekyll
       - stage: build

--- a/build.sbt
+++ b/build.sbt
@@ -98,7 +98,12 @@ ThisBuild / headerLicense  := Some(HeaderLicense.Custom(
 // to be locked down sometime around the time of 2.13.0-RC1
 Global / mimaReferenceVersion := None
 
-Global / scalaVersion      := versionProps("starr.version")
+Global / scalaVersion      := {
+  if (DottySupport.compileWithDotty)
+    DottySupport.dottyVersion
+  else
+    versionProps("starr.version")
+}
 
 lazy val instanceSettings = Seq[Setting[_]](
   // we don't cross build Scala itself
@@ -200,7 +205,12 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
   // Don't log process output (e.g. of forked `compiler/runMain ...Main`), just pass it
   // directly to stdout
   outputStrategy in run := Some(StdoutOutput)
-) ++ removePomDependencies ++ setForkedWorkingDirectory
+) ++ removePomDependencies ++ setForkedWorkingDirectory ++ (
+  if (DottySupport.compileWithDotty)
+    DottySupport.commonSettings
+  else
+    Seq()
+)
 
 /** Extra post-processing for the published POM files. These are needed to create POMs that
   * are equivalent to the ones from the old Ant build. In the long term this should be removed and
@@ -364,6 +374,12 @@ lazy val library = configureAsSubproject(project)
     mimaCheckDirection := "both"
   )
   .settings(filterDocSources("*.scala" -- regexFileFilter(".*/scala/runtime/.*")))
+  .settings(
+    if (DottySupport.compileWithDotty)
+      DottySupport.librarySettings
+    else
+      Seq()
+  )
 
 lazy val reflect = configureAsSubproject(project)
   .settings(generatePropertiesFileSettings)

--- a/project/DottySupport.scala
+++ b/project/DottySupport.scala
@@ -1,0 +1,114 @@
+package scala.build
+
+import sbt._
+import sbt.Keys._
+
+import sbt.librarymanagement.{
+  ivy, DependencyResolution, ScalaModuleInfo, UpdateConfiguration, UnresolvedWarningConfiguration
+}
+
+/** Settings needed to compile with Dotty,
+ *  Only active when sbt is started with `sbt -Dscala.build.compileWithDotty=true`
+ *  This is currently only used to check that the standard library compiles with
+ *  Dotty in .travis.yml.
+ */
+object DottySupport {
+  val dottyVersion = "0.14.0-bin-20190226-afc03c9-NIGHTLY"
+  val compileWithDotty: Boolean =
+    Option(System.getProperty("scala.build.compileWithDotty")).map(_.toBoolean).getOrElse(false)
+  lazy val commonSettings = Seq(
+    scalacOptions ++= Seq(
+      "-Ynew-collections", // Make Dotty aware of the 2.13 collections
+      "-language:implicitConversions" // Avoid a million warnings
+    )
+  )
+  lazy val librarySettings = Seq(
+    // Needed to compile dotty-library together with scala-library
+    compileOrder := CompileOrder.Mixed,
+
+    // Some files shouldn't be compiled
+    excludeFilter in unmanagedSources ~= (old =>
+      old ||
+      "AnyVal.scala" ||
+      "language.scala"  // Replaced by scalaShadowing/language.scala from dotty-library
+    ),
+
+    // Add the sources of dotty-library to the current project to compile the
+    // complete standard library of Dotty in one go.
+    // Adapted from similar code in the scala-js build.
+    sourceGenerators in Compile += Def.task {
+      object DottyLibrarySourceFilter extends FileFilter {
+        def accept(file: File): Boolean = {
+          val name = file.name
+          val path = file.getCanonicalPath
+          file.isFile &&
+          (path.endsWith(".scala") || path.endsWith(".java")) &&
+          !file.getCanonicalPath.contains("src-non-bootstrapped") &&
+          // Copies of files already present in the scala-library present until
+          // Dotty switches to 2.13.
+          !path.endsWith("scala/runtime/ModuleSerializationProxy.java") &&
+          !path.endsWith("scala/ValueOf.scala") &&
+          // Corresponding files have been copied in this repo
+          !path.contains("scalaShadowing")
+        }
+      }
+
+      val s = streams.value
+      val cacheDir = s.cacheDirectory
+      val trgDir = (sourceManaged in Compile).value / "dotty-library-src"
+
+      val dottyLibrarySourceJar = fetchSourceJarOf(
+        dependencyResolution.value,
+        scalaModuleInfo.value,
+        updateConfiguration.value,
+        (unresolvedWarningConfiguration in update).value,
+        streams.value.log,
+        scalaOrganization.value %% "dotty-library" % scalaVersion.value)
+
+      FileFunction.cached(cacheDir / s"fetchDottyLibrarySource",
+        FilesInfo.lastModified, FilesInfo.exists) { dependencies =>
+        s.log.info(s"Unpacking dotty-library sources to $trgDir...")
+        if (trgDir.exists)
+          IO.delete(trgDir)
+        IO.createDirectory(trgDir)
+        IO.unzip(dottyLibrarySourceJar, trgDir)
+
+        (trgDir ** DottyLibrarySourceFilter).get.toSet
+      } (Set(dottyLibrarySourceJar)).toSeq
+    }.taskValue
+  )
+
+  /** Fetch source jar for `moduleID` */
+  def fetchSourceJarOf(
+    dependencyRes: DependencyResolution,
+    scalaInfo: Option[ScalaModuleInfo],
+    updateConfig: UpdateConfiguration,
+    warningConfig: UnresolvedWarningConfiguration,
+    log: Logger,
+    moduleID: ModuleID): File = {
+    val sourceClassifiersConfig = sbt.librarymanagement.GetClassifiersConfiguration(
+      sbt.librarymanagement.GetClassifiersModule(
+        moduleID,
+        scalaInfo,
+        Vector(moduleID),
+        Vector(Configurations.Default) ++ Configurations.default,
+        Vector("sources")
+      ),
+      Vector.empty,
+      updateConfig.withArtifactFilter(
+        librarymanagement.ArtifactTypeFilter.allow(Artifact.DefaultSourceTypes)
+      ),
+      Artifact.DefaultSourceTypes.toVector,
+      Vector.empty
+    )
+
+    dependencyRes.updateClassifiers(sourceClassifiersConfig, warningConfig, Vector.empty, log) match {
+      case Right(report) =>
+        val Vector(jar) = report.allFiles
+        jar
+      case _ =>
+        throw new MessageOnlyException(
+          s"Couldn't retrieve `$moduleID`.")
+    }
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -34,3 +34,9 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3")
 scalaVersion := "2.12.7"
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
+
+// See DottySupport.scala
+if (Option(System.getProperty("scala.build.compileWithDotty")).map(_.toBoolean).getOrElse(false))
+  Seq(addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.3.0"))
+else
+  Seq()

--- a/src/library/scala/deprecatedInheritance.scala
+++ b/src/library/scala/deprecatedInheritance.scala
@@ -48,5 +48,4 @@ import scala.annotation.meta._
  *  @see    [[scala.deprecatedName]]
  */
 @getter @setter @beanGetter @beanSetter
-@deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0") // ironically
-class deprecatedInheritance(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation
+final class deprecatedInheritance(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation


### PR DESCRIPTION
As suggested by @adriaanm at some point.

When sbt is started with `-Dscala.build.compileWithDotty=true`, Dotty
will be used as the STARR (this is toggled by a property to avoid any
interference between sbt-dotty and the regular build). Using this,
we add compilation of the standard library using Dotty to the CI,
to make sure it's never unintentionally broken.