### PR TITLE
Quote terminal symbols in EBNF

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1651,7 +1651,7 @@ self =>
     def isTypedParam(t: Tree) = t.isInstanceOf[Typed]
 
     /** {{{
-     *  Expr ::= implicit Id => Expr
+     *  Expr ::= implicit Id `=>` Expr
      *  }}}
      */
 


### PR DESCRIPTION
When terminal symbols are symbols they are quoted
(e.g. `=>` in `typ` method).