### PR TITLE
Remove usesMutableState from ScalaDocs

### DIFF
--- a/src/library/scala/collection/immutable/Iterable.scala
+++ b/src/library/scala/collection/immutable/Iterable.scala
@@ -18,17 +18,6 @@ import scala.collection.IterableFactory
   *
   * @tparam A the element type of the collection
   *
-  * @define usesMutableState
-  *
-  *   Note: Despite being an immutable collection, the implementation uses mutable state internally during
-  *   construction. These state changes are invisible in single-threaded code but can lead to race conditions
-  *   in some multi-threaded scenarios. The state of a new collection instance may not have been "published"
-  *   (in the sense of the Java Memory Model specification), so that an unsynchronized non-volatile read from
-  *   another thread may observe the object in an invalid state (see
-  *   [[https://github.com/scala/bug/issues/7838 scala/bug#7838]] for details). Note that such a read is not
-  *   guaranteed to ''ever'' see the written object at all, and should therefore not be used, regardless
-  *   of this issue. The easiest workaround is to exchange values between threads through a volatile var.
-  *
   * @define coll immutable collection
   * @define Coll `immutable.Iterable`
   */

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -32,8 +32,6 @@ import scala.runtime.Statics.releaseFence
   *  This class is optimal for last-in-first-out (LIFO), stack-like access patterns. If you need another access
   *  pattern, for example, random access or FIFO, consider using a collection more suited to this than `List`.
   *
-  *  $usesMutableState
-  *
   *  ==Performance==
   *  '''Time:''' `List` has `O(1)` prepend and head/tail access. Most other operations are `O(n)` on the number of elements in the list.
   *  This includes the index-based lookup of elements, `length`, `append` and `reverse`.

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -65,8 +65,6 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
  *  endian bit-mapped vector trie with a branching factor of 32.  Locality is very good, but not
  *  contiguous, which is good for very large sequences.
  *
- *  $usesMutableState
- *
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#vectors "Scala's Collection Library overview"]]
  *  section on `Vectors` for more information.
  *


### PR DESCRIPTION
Fixed by https://github.com/scala/scala/pull/6425

I came across the comment looking at the nightly API docs for 2.13.x and was a bit confused. I followed the link and it seems like this comment is no longer needed!