### PR TITLE
Fix for Bug 10344

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2703,8 +2703,8 @@ trait Types
     }
     private def customToString = sym match {
       case RepeatedParamClass | JavaRepeatedParamClass => args.head.toString + "*"
-      case ByNameParamClass   => "=> " + args.head
-      case _                  =>
+      case ByNameParamClass if args.nonEmpty => "=> " + args.head
+      case _ =>
         if (isFunctionTypeDirect(this)) {
           // Aesthetics: printing Function1 as T => R rather than (T) => R
           // ...but only if it's not a tuple, so ((T1, T2)) => R is distinguishable

--- a/test/files/pos/t10344.flags
+++ b/test/files/pos/t10344.flags
@@ -1,0 +1,1 @@
+-Xprint:typer -language:higherKinds

--- a/test/files/pos/t10344.scala
+++ b/test/files/pos/t10344.scala
@@ -1,0 +1,5 @@
+object t10344 {
+  def unwrap[F[_]](f: F[Unit] => Unit): Unit = ()
+  val f: (=> Unit) => Unit = { _ => () }
+  unwrap(f)
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/10344. Adds regression test, and a one-line patch for it.

To be precise, it just puts a patch to avoid hitting the exception. However, this does not solve the root cause, as to whether the field `args: List[Type]` from the following class should be allowed to be empty: 
```Scala
  abstract case class TypeRef(pre: Type, sym: Symbol, args: List[Type]) extends UniqueType with TypeRefApi {
```

_Edit_: ok, it is allowed to be empty. According to a comment above the `TypeRef` class, 
>  a higher-kinded type is represented as a TypeRef with sym.typeParams.nonEmpty, but args.isEmpty


