### PR TITLE
Avoid the call to BaseTypeSeq.toList in type Unification.

### DIFF
--- a/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
+++ b/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
@@ -130,6 +130,9 @@ trait BaseTypeSeqs {
     /** Return all evaluated types in this sequence as a list */
     def toList: List[Type] = elems.toList
 
+    /** Return an iterator over all evaluated types in this sequence */
+    def toIterator: Iterator[Type] = elems.iterator
+
     def copy(head: Type, offset: Int): BaseTypeSeq = {
       val arr = new Array[Type](elems.length + offset)
       java.lang.System.arraycopy(elems, 0, arr, offset, elems.length)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3326,7 +3326,7 @@ trait Types
             (tp.parents exists unifyFull) || (
               // @PP: Is it going to be faster to filter out the parents we just checked?
               // That's what's done here but I'm not sure it matters.
-              tp.baseTypeSeq.toList.tail filterNot (tp.parents contains _) exists unifyFull
+              tp.baseTypeSeq.toIterator.drop(1).exists(bt => !tp.parents.contains(bt) && unifyFull(bt))
             )
           )
         )


### PR DESCRIPTION
The method `toList` of the `BaseTypeSeq` class creates a list from the elements already in an array. In the Types unification, this method was called to create a list of types that was immediately filtered out and folded with an `exists`.

We avoid the call to `toList`, and instead perform a single iteration through the underlying array.