### PR TITLE
Remove the bothNames method from the Name class.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -559,7 +559,8 @@ trait Namers extends MethodSynthesis {
       def checkSelector(s: ImportSelector) = {
         val ImportSelector(from, fromPos, to, _) = s
         def isValid(original: Name) =
-          original.bothNames forall (x => (base nonLocalMember x) == NoSymbol)
+          (base nonLocalMember original.toTermName) == NoSymbol &&
+            (base nonLocalMember original.toTypeName) == NoSymbol
 
         if (from != nme.WILDCARD && base != ErrorType) {
           if (isValid(from)) {

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -214,7 +214,6 @@ trait Names extends api.Names {
     def toTermName: TermName
     def toTypeName: TypeName
     def companionName: Name
-    def bothNames: List[Name] = List(toTermName, toTypeName)
 
     /** Return the subname with characters from from to to-1. */
     def subName(from: Int, to: Int): Name with ThisNameType

--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -244,7 +244,11 @@ trait MemberHandlers {
     def importedSymbols = individualSymbols ++ wildcardSymbols
 
     lazy val importableSymbolsWithRenames = {
-      val selectorRenameMap = individualSelectors.flatMap(x => x.name.bothNames zip x.rename.bothNames).toMap
+      val selectorRenameMap: mutable.HashMap[Name, Name] = mutable.HashMap.empty[Name, Name]
+      individualSelectors foreach { x =>
+        selectorRenameMap.put(x.name.toTermName, x.rename.toTermName)
+        selectorRenameMap.put(x.name.toTypeName, x.rename.toTypeName)
+      }
       importableTargetMembers flatMap (m => selectorRenameMap.get(m.name) map (m -> _))
     }
 


### PR DESCRIPTION
The `Name` class defined a `bothNames` method which always returned a list of two elements, the `termName` and the `typeName`, both publicly accessible. To avoid needless List allocations, we remove this method and replace any use of it by a direct call to the `termName` and `typeName` methods.

Along the way, we replace the creation of a potentially large List immediately fed into building an immutable map, of limited scope, by directly creating mutable map.