### PR TITLE
Restore deprecated bothnames method.

### DIFF
--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -214,6 +214,8 @@ trait Names extends api.Names {
     def toTermName: TermName
     def toTypeName: TypeName
     def companionName: Name
+    @deprecated("Use either toTermName or toTypeName", "2.12.9")
+    def bothNames: List[Name] = List(toTermName, toTypeName)
 
     /** Return the subname with characters from from to to-1. */
     def subName(from: Int, to: Int): Name with ThisNameType


### PR DESCRIPTION
We restore the method bothNames, with the deprecated annotation, to prevent existing compiler plugins from falling into a binary crash.

Follows comments from #7810 

**Question**: would we want to keep this as a deprecation through 2.13?