### PR TITLE
depend on junit from partest, not vice versa. and reduce warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -633,6 +633,7 @@ lazy val junit = project.in(file("test") / "junit")
     javaOptions in Test += "-Xss1M",
     (forkOptions in Test) := (forkOptions in Test).value.withWorkingDirectory((baseDirectory in ThisBuild).value),
     (forkOptions in Test in testOnly) := (forkOptions in Test in testOnly).value.withWorkingDirectory((baseDirectory in ThisBuild).value),
+    scalacOptions += "-feature",
     libraryDependencies ++= Seq(junitDep, junitInterfaceDep, jolDep),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     unmanagedSourceDirectories in Compile := Nil,

--- a/build.sbt
+++ b/build.sbt
@@ -318,7 +318,7 @@ def regexFileFilter(s: String): FileFilter = new FileFilter {
 
 def setForkedWorkingDirectory: Seq[Setting[_]] = {
   // When we fork subprocesses, use the base directory as the working directory.
-  // This“ enables `sbt> partest test/files/run/t1.scala` or `sbt> scalac sandbox/test.scala`
+  // This enables `sbt> partest test/files/run/t1.scala` or `sbt> scalac sandbox/test.scala`
   val setting = (forkOptions in Compile) := (forkOptions in Compile).value.withWorkingDirectory((baseDirectory in ThisBuild).value)
   setting ++ inTask(run)(setting)
 }
@@ -543,7 +543,7 @@ lazy val scalap = configureAsSubproject(project)
   .dependsOn(compiler)
 
 lazy val partest = configureAsSubproject(project)
-  .dependsOn(library, reflect, compiler, scalap, replFrontend, scaladoc)
+  .dependsOn(library, reflect, compiler, scalap, scaladoc, junit % "compile->test")
   .settings(Osgi.settings)
   .settings(AutomaticModuleName.settings("scala.partest"))
   .settings(
@@ -622,7 +622,7 @@ lazy val bench = project.in(file("test") / "benchmarks")
 
 
 lazy val junit = project.in(file("test") / "junit")
-  .dependsOn(library, reflect, compiler, partest, scaladoc)
+  .dependsOn(library, reflect, compiler, replFrontend, scaladoc)
   .settings(clearSourceAndResourceDirectories)
   .settings(commonSettings)
   //.settings(scalacOptions in Compile += "-Xlint:-nullary-unit,-adapted-args")

--- a/src/partest/scala/tools/partest/BytecodeTest.scala
+++ b/src/partest/scala/tools/partest/BytecodeTest.scala
@@ -16,7 +16,7 @@ import scala.collection.JavaConverters._
 import scala.tools.asm.{ClassReader, ClassWriter}
 import scala.tools.asm.tree._
 import java.io.{InputStream, File => JFile}
-
+import scala.tools.testing.ASMConverters
 import AsmNode._
 import scala.tools.nsc.CloseableRegistry
 

--- a/test/files/jvm/t7253/test.scala
+++ b/test/files/jvm/t7253/test.scala
@@ -1,4 +1,5 @@
-import scala.tools.partest.{BytecodeTest, ASMConverters}
+import scala.tools.partest.BytecodeTest
+import scala.tools.testing.ASMConverters
 
 import scala.tools.nsc.util.JavaClassPath
 import java.io.InputStream

--- a/test/files/run/BoxUnboxTest.check
+++ b/test/files/run/BoxUnboxTest.check
@@ -1,0 +1,21 @@
+BoxUnboxTest.scala:55: warning: comparing values of types Int and Null using `==` will always yield false
+    val n6 = null.asInstanceOf[Int] == null
+                                    ^
+BoxUnboxTest.scala:59: warning: comparing values of types Int and Null using `!=` will always yield true
+    val n8 = null.asInstanceOf[Int] != null
+                                    ^
+BoxUnboxTest.scala:65: warning: comparing values of types Int and Null using `==` will always yield false
+    val n10 = mp.get(0) == null                    // scala/bug#602
+                        ^
+BoxUnboxTest.scala:114: warning: comparing values of types Unit and scala.runtime.BoxedUnit using `==` will always yield true
+    assert(eff() == b); chk()
+                 ^
+BoxUnboxTest.scala:116: warning: comparing values of types scala.runtime.BoxedUnit and scala.runtime.BoxedUnit using `==` will always yield true
+    assert(boxing(eff()) == b); chk()
+                         ^
+BoxUnboxTest.scala:129: warning: comparing values of types Unit and scala.runtime.BoxedUnit using `==` will always yield true
+    assert(n1 == b)
+              ^
+BoxUnboxTest.scala:131: warning: comparing values of types Unit and scala.runtime.BoxedUnit using `==` will always yield true
+    val n2 = null.asInstanceOf[Unit] == b
+                                     ^

--- a/test/files/run/BoxUnboxTest.scala
+++ b/test/files/run/BoxUnboxTest.scala
@@ -1,24 +1,19 @@
-package scala.lang.primitives
-
 import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import scala.tools.testing.AssertUtil._
 
-import scala.tools.testing.RunTesting
+class VCI(val x: Int) extends AnyVal { override def toString = "" + x }
 
-object BoxUnboxTest {
-  class VCI(val x: Int) extends AnyVal { override def toString = "" + x }
-}
+object Test {
 
-@RunWith(classOf[JUnit4])
-class BoxUnboxTest extends RunTesting {
-  import runner._
+  def main(args: Array[String]): Unit = {
+    boxUnboxInt()
+    numericConversions()
+    boxUnboxBoolean()
+    boxUnboxUnit()
+    t9671()
+  }
 
-  @Test
   def boxUnboxInt(): Unit = {
-    import scala.tools.testing.AssertUtil._
-    import org.junit.Assert._
 
     def genericNull[T] = null.asInstanceOf[T] // allowed, see scala/bug#4437, point 2
 
@@ -78,10 +73,7 @@ class BoxUnboxTest extends RunTesting {
     assertEquals(n12, 0)
   }
 
-  @Test
   def numericConversions(): Unit = {
-    import scala.tools.testing.AssertUtil._
-    import org.junit.Assert._
 
     val i1 = 1L.asInstanceOf[Int]
     assertEquals(i1, 1)
@@ -91,20 +83,16 @@ class BoxUnboxTest extends RunTesting {
     }
   }
 
-  @Test
   def boxUnboxBoolean(): Unit = {
     val n1 = Option(null.asInstanceOf[Boolean])
     assertEquals(n1, Some(false))
   }
 
-  @Test
   def boxUnboxUnit(): Unit = {
     // should not use assertEquals in this test: it takes two Object parameters. normally, Unit does
     // not conform to Object, but for Java-defined methods scalac makes an exception and treats them
     // as Any. passing a Unit as Any makes the compiler go through another layer of boxing, so it
     // can hide some bugs (where we actually have a null, but the compiler makes it a ()).
-    import scala.tools.testing.AssertUtil._
-    import org.junit.Assert._
 
     var v = 0
     def eff() = { v = 1 }
@@ -148,9 +136,7 @@ class BoxUnboxTest extends RunTesting {
     assertEquals(n3, "()")
   }
 
-  @Test
   def t9671(): Unit = {
-    import scala.lang.primitives.BoxUnboxTest.VCI
 
     def f1(a: Any) = "" + a
     def f2(a: AnyVal) = "" + a

--- a/test/files/run/WeakHashSetTest.scala
+++ b/test/files/run/WeakHashSetTest.scala
@@ -22,13 +22,13 @@ object Test {
 // it uses the package private "diagnostics" method
 package scala.reflect.internal.util {
 
-  object WeakHashSetTest {
-    // a class guaranteed to provide hash collisions
-    case class Collider(x : String) extends Comparable[Collider] with Serializable {
-      override def hashCode = 0
-      def compareTo(y : Collider) = this.x compareTo y.x
-    }
+  // a class guaranteed to provide hash collisions
+  case class Collider(x : String) extends Comparable[Collider] with Serializable {
+    override def hashCode = 0
+    def compareTo(y : Collider) = this.x compareTo y.x
+  }
 
+  object WeakHashSetTest {
     // basic emptiness check
     def checkEmpty: Unit = {
       val hs = new WeakHashSet[String]()

--- a/test/files/run/bcodeInlinerMixed/Test_2.scala
+++ b/test/files/run/bcodeInlinerMixed/Test_2.scala
@@ -1,4 +1,5 @@
-import scala.tools.partest.{BytecodeTest, ASMConverters}
+import scala.tools.partest.BytecodeTest
+import scala.tools.testing.ASMConverters
 import ASMConverters._
 
 class D {

--- a/test/files/run/junitForwarders/C_1.scala
+++ b/test/files/run/junitForwarders/C_1.scala
@@ -1,5 +1,5 @@
 trait T {
-  @org.junit.Test def foo = 0
+  @org.junitlike.Test def foo = 0
 }
 
 class C extends T
@@ -9,7 +9,7 @@ object Test extends App {
     val s = c.getDeclaredMethods.sortBy(_.getName).map(m => s"${m.getName} - ${m.getDeclaredAnnotations.mkString(", ")}").mkString(";")
     assert(s == e, s"found: $s\nexpected: $e")
   }
-  check(classOf[C], "foo - @org.junit.Test()")
+  check(classOf[C], "foo - @org.junitlike.Test()")
   // scala/scala-dev#213, scala/scala#5570: `foo$` should not have the @Test annotation
-  check(classOf[T], "$init$ - ;foo - @org.junit.Test();foo$ - ")
+  check(classOf[T], "$init$ - ;foo - @org.junitlike.Test();foo$ - ")
 }

--- a/test/files/run/junitForwarders/Test.java
+++ b/test/files/run/junitForwarders/Test.java
@@ -1,4 +1,4 @@
-package org.junit;
+package org.junitlike;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/test/files/run/t8601-closure-elim.scala
+++ b/test/files/run/t8601-closure-elim.scala
@@ -1,7 +1,7 @@
 // scalac: -Ydelambdafy:method -opt:l:inline -opt-inline-from:**
 //
 import scala.tools.partest.BytecodeTest
-import scala.tools.partest.ASMConverters.instructionsFromMethod
+import scala.tools.testing.ASMConverters.instructionsFromMethod
 import scala.tools.asm
 import scala.tools.asm.util._
 import scala.collection.JavaConverters._

--- a/test/files/run/t9403/Test_2.scala
+++ b/test/files/run/t9403/Test_2.scala
@@ -1,7 +1,7 @@
 import p.C
 import scala.tools.asm.Opcodes
 import scala.tools.partest.BytecodeTest
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 
 
 object Test extends BytecodeTest {

--- a/test/junit/scala/collection/BuildFromTest.scala
+++ b/test/junit/scala/collection/BuildFromTest.scala
@@ -4,6 +4,7 @@ import org.junit.Test
 
 import scala.collection.mutable.Builder
 import scala.math.Ordering
+import language.higherKinds
 
 class BuildFromTest {
 

--- a/test/junit/scala/collection/SetMapConsistencyTest.scala
+++ b/test/junit/scala/collection/SetMapConsistencyTest.scala
@@ -506,7 +506,7 @@ class SetMapConsistencyTest {
       else None
     }
     assert(f() match {
-      case Some((a,b)) if (a==null || b==null) => false
+      case Some((null, _)) => false
       case _ => true
     })
   }

--- a/test/junit/scala/collection/immutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/immutable/ArraySeqTest.scala
@@ -12,6 +12,7 @@ class ArraySeqTest {
   @Test
   def slice(): Unit = {
 
+    import language.implicitConversions
     implicit def array2ArraySeq[T](array: Array[T]): ArraySeq[T] =
       ArraySeq.unsafeWrapArray(array)
 

--- a/test/junit/scala/lang/annotations/BytecodeTest.scala
+++ b/test/junit/scala/lang/annotations/BytecodeTest.scala
@@ -7,7 +7,7 @@ import org.junit.runners.JUnit4
 
 import scala.collection.JavaConverters._
 import scala.tools.nsc.backend.jvm.AsmUtils
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/lang/traits/BytecodeTest.scala
+++ b/test/junit/scala/lang/traits/BytecodeTest.scala
@@ -9,7 +9,7 @@ import scala.collection.JavaConverters._
 import scala.tools.asm.Opcodes
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree.ClassNode
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/reflect/FieldAccessTest.scala
+++ b/test/junit/scala/reflect/FieldAccessTest.scala
@@ -8,18 +8,17 @@ class FieldAccessTest {
 
   class TestClass {
     private val x = 123
-    // Uncommenting the following line would make the test fail
-    () => x
+    def fn = () => x
   }
 
   /** scala/bug#9306 */
   @Test
   def testFieldAccess(): Unit = {
-    import scala.reflect.runtime.{universe => ru}
+    import scala.reflect.runtime.universe._
     import scala.reflect.runtime.currentMirror
     val obj = new TestClass
     val objType = currentMirror.reflect(obj).symbol.toType
-    val objFields = objType.members.collect { case ms: ru.MethodSymbol if ms.isGetter => ms }
+    val objFields = objType.members.collect { case ms: MethodSymbol if ms.isGetter => ms }
     assertEquals(123, currentMirror.reflect(obj).reflectField(objFields.head).get)
   }
 }

--- a/test/junit/scala/reflect/internal/Infer.scala
+++ b/test/junit/scala/reflect/internal/Infer.scala
@@ -7,6 +7,7 @@ import org.junit.runners.JUnit4
 import scala.collection.mutable
 import scala.tools.nsc.settings.ScalaVersion
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
+import language.higherKinds
 
 import scala.tools.testing.BytecodeTesting
 

--- a/test/junit/scala/reflect/internal/TypesTest.scala
+++ b/test/junit/scala/reflect/internal/TypesTest.scala
@@ -7,6 +7,7 @@ import org.junit.runners.JUnit4
 import scala.collection.mutable
 import scala.tools.nsc.settings.ScalaVersion
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
+import language.higherKinds
 
 @RunWith(classOf[JUnit4])
 class TypesTest {

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 import scala.collection.JavaConverters._

--- a/test/junit/scala/tools/nsc/backend/jvm/DirectCompileTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/DirectCompileTest.scala
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/IndySammyTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/IndySammyTest.scala
@@ -8,7 +8,7 @@ import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
 import scala.tools.nsc.reporters.StoreReporter
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
@@ -5,7 +5,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/StringConcatTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/StringConcatTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerTest.scala
@@ -10,7 +10,7 @@ import org.junit.runners.JUnit4
 import scala.tools.asm.Opcodes
 import scala.tools.asm.tree.AbstractInsnNode
 import scala.tools.nsc.backend.jvm.AsmUtils._
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BoxUnboxTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BoxUnboxTest.scala
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/CompactLocalVariablesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/CompactLocalVariablesTest.scala
@@ -7,7 +7,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting._
 import scala.tools.testing.ClearAfterClass
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/EmptyExceptionHandlersTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/EmptyExceptionHandlersTest.scala
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/EmptyLabelsAndLineNumbersTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/EmptyLabelsAndLineNumbersTest.scala
@@ -8,8 +8,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.partest.ASMConverters
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.AssertUtil._
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -12,7 +12,7 @@ import scala.reflect.internal.util.JavaClearable
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree._
 import scala.tools.nsc.backend.jvm.BackendReporting._
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
@@ -11,7 +11,7 @@ import scala.collection.JavaConverters._
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree.ClassNode
 import scala.tools.nsc.backend.jvm.AsmUtils._
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/SimplifyJumpsTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/SimplifyJumpsTest.scala
@@ -8,8 +8,8 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.partest.ASMConverters
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/UnreachableCodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/UnreachableCodeTest.scala
@@ -9,7 +9,7 @@ import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree.ClassNode
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.AssertUtil._
 import scala.tools.testing.BytecodeTesting._
 import scala.tools.testing.ClearAfterClass

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/UnusedLocalVariablesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/UnusedLocalVariablesTest.scala
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.collection.JavaConverters._
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/tools/nsc/transform/MixinTest.scala
+++ b/test/junit/scala/tools/nsc/transform/MixinTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.partest.ASMConverters.LineNumber
+import scala.tools.testing.ASMConverters.LineNumber
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/tools/testing/ASMConverters.scala
+++ b/test/junit/scala/tools/testing/ASMConverters.scala
@@ -10,7 +10,7 @@
  * additional information regarding copyright ownership.
  */
 
-package scala.tools.partest
+package scala.tools.testing
 
 import scala.collection.JavaConverters._
 import scala.tools.asm

--- a/test/junit/scala/tools/testing/BytecodeTesting.scala
+++ b/test/junit/scala/tools/testing/BytecodeTesting.scala
@@ -17,7 +17,7 @@ import scala.tools.nsc.backend.jvm.opt.BytecodeUtils
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.reporters.StoreReporter
 import scala.tools.nsc.{Global, Settings}
-import scala.tools.partest.ASMConverters._
+import scala.tools.testing.ASMConverters._
 
 trait BytecodeTesting extends ClearAfterClass {
   /**


### PR DESCRIPTION
three commits:
* first commit reverses the dependency relationship between our `junit` and `partest` subprojects
* second commit converts an example test from JUnit to partest
* third commit reduces build-time noise in the `junit` subproject

the unifying theme here is warning elimination. the second commit converts some warnings from build noise to something that actually gets tested. the first commit started as just something the second commit needed, but then it turned out to be the nicest part.