### PR TITLE
Override List.last

### DIFF
--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -132,6 +132,8 @@ sealed abstract class List[+A]
     these
   }
 
+  override final def isEmpty: Boolean = this eq Nil
+
   override def prepended[B >: A](elem: B): List[B] = elem :: this
 
   // When calling prependAll with another list `prefix`, avoid copying `this`
@@ -591,13 +593,11 @@ sealed abstract class List[+A]
 final case class :: [+A](override val head: A, private[scala] var next: List[A @uncheckedVariance]) // sound because `next` is used only locally
   extends List[A] {
   releaseFence()
-  override def isEmpty: Boolean = false
   override def headOption: Some[A] = Some(head)
   override def tail: List[A] = next
 }
 
 case object Nil extends List[Nothing] {
-  override def isEmpty: Boolean = true
   override def head: Nothing = throw new NoSuchElementException("head of empty list")
   override def headOption: None.type = None
   override def tail: Nothing = throw new UnsupportedOperationException("tail of empty list")

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -395,6 +395,19 @@ sealed abstract class List[+A]
     None
   }
 
+  override def last: A = {
+    if (isEmpty) throw new NoSuchElementException("List.last")
+    else {
+      var these = this
+      var scout = tail
+      while (!scout.isEmpty) {
+        these = scout
+        scout = scout.tail
+      }
+      these.head
+    }
+  }
+
   override def corresponds[B](that: collection.Seq[B])(p: (A, B) => Boolean): Boolean = that match {
     case that: LinearSeq[B] =>
       var i = this

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1978,7 +1978,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         var alts0: List[Symbol] = alternatives
         var alts1: List[Symbol] = Nil
 
-        while (alts0.nonEmpty) {
+        while (!alts0.isEmpty) {
           if (cond(alts0.head))
             alts1 ::= alts0.head
           else

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2396,7 +2396,7 @@ trait Types
     override def mapOver(map: TypeMap): Type = {
       val pre1 = map(pre)
       val args1 = map match {
-        case map: VariancedTypeMap if args.nonEmpty && ! map.variance.isInvariant =>
+        case map: VariancedTypeMap if !args.isEmpty && ! map.variance.isInvariant =>
           val tparams = sym.typeParams
           if (tparams.isEmpty)
             args mapConserve map


### PR DESCRIPTION
Recent profiles of the compiler shows that a few tenths of a percent of execution time
is spent in nonEmpty, which is an interface method that might not be fully inlinable
by HotSpot.

The cost isn't much, but it really should be 0%, so let's just remove the use of `nonEmpty`
from a hotspot in the compiler and override List.last to avoid this and to avoid virtual
calls to `.head` / `.tail`