### PR TITLE
Avoid CCE with no message

### DIFF
--- a/test/files/run/t6411a.javaopts
+++ b/test/files/run/t6411a.javaopts
@@ -1,0 +1,1 @@
+-XX:CompileCommand=exclude,scala/runtime/BoxesRunTime.unboxToInt

--- a/test/files/run/t6411a.scala
+++ b/test/files/run/t6411a.scala
@@ -1,3 +1,9 @@
+// filter: scala.runtime.BoxesRunTime.{1,2}unboxToInt
+//
+// noise from -XX:CompileCommand=exclude,scala/runtime/BoxesRunTime.unboxToInt
+// CompilerOracle: exclude scala/runtime/BoxesRunTime.unboxToInt
+// ### Excluding compile: static scala.runtime.BoxesRunTime::unboxToInt
+//
 import scala.reflect.runtime.universe._
 import scala.reflect.runtime.{currentMirror => cm}
 import scala.language.reflectiveCalls


### PR DESCRIPTION
This test relies on testing the message of a
ClassCastException, but if the method that throws
it is JIT-compiled, the message is null. This was
observed when an unrelated test was added to the
in-process suite which over-exercised the method
and caused it to be compiled.

Adding `.javaopts` causes the test to run out-of-
process, and the supplied option also turns off
compilation for the method in question.