### PR TITLE
ClassPathFactory and PathResolver constructors: restore source compat and bincompat

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
@@ -22,7 +22,11 @@ import scala.tools.nsc.util.ClassPath
  * Provides factory methods for classpath. When creating classpath instances for a given path,
  * it uses proper type of classpath depending on a types of particular files containing sources or classes.
  */
-class ClassPathFactory(settings: Settings, closeableRegistry: CloseableRegistry) {
+class ClassPathFactory(settings: Settings, closeableRegistry: CloseableRegistry = new CloseableRegistry) {
+
+  @deprecated("for bincompat in 2.12.x series", "2.12.9")  // TODO remove from 2.13.x
+  def this(settings: Settings) = this(settings, new CloseableRegistry)
+
   /**
     * Create a new classpath based on the abstract file.
     */
@@ -78,7 +82,10 @@ class ClassPathFactory(settings: Settings, closeableRegistry: CloseableRegistry)
 }
 
 object ClassPathFactory {
-  def newClassPath(file: AbstractFile, settings: Settings, closeableRegistry: CloseableRegistry): ClassPath = file match {
+  @deprecated("for bincompat in 2.12.x series", "2.12.9")  // TODO remove from 2.13.x
+  def newClassPath(file: AbstractFile, settings: Settings): ClassPath =
+    newClassPath(file, settings, new CloseableRegistry)
+  def newClassPath(file: AbstractFile, settings: Settings, closeableRegistry: CloseableRegistry = new CloseableRegistry): ClassPath = file match {
     case vd: VirtualDirectory => VirtualDirectoryClassPath(vd)
     case _ =>
       if (file.isJarOrZip)

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -206,7 +206,11 @@ object PathResolver {
     }
 }
 
-final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistry) {
+final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistry = new CloseableRegistry) {
+
+  @deprecated("for bincompat in 2.12.x series", "2.12.9")  // TODO remove from 2.13.x
+  def this(settings: Settings) = this(settings, new CloseableRegistry)
+
   private val classPathFactory = new ClassPathFactory(settings, closeableRegistry)
 
   import PathResolver.{ AsLines, Defaults, ppcp }


### PR DESCRIPTION
small followup to #7712. the community build found that a couple of
projects (mima, classpath-shrinker) were using the old constructors. since
it's easy to do, let's keep both source compat (with the default
argument) and bincompat (with the extra constructor, which we can
toss for 2.13)

review by @retronym, is this a bad idea? idk what this code even does, I'm
just making the changes mechanically.

I've marked the extra constructors for removal in 2.13.x, should
the default arguments also be marked with the same TODO, or should
it stay going forward?