### PR TITLE
Avoid the parentSymbols method: less allocations.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -1123,7 +1123,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
      */
     def isAndroidParcelableClass(sym: Symbol) =
       (AndroidParcelableInterface != NoSymbol) &&
-      (sym.info.parents.exists( _.typeSymbol == AndroidParcelableInterface))
+      (sym.parentSymbolsIterator contains AndroidParcelableInterface)
 
     /*
      * must-single-thread

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -1123,7 +1123,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
      */
     def isAndroidParcelableClass(sym: Symbol) =
       (AndroidParcelableInterface != NoSymbol) &&
-      (sym.parentSymbols contains AndroidParcelableInterface)
+      (sym.info.parents.exists( _.typeSymbol == AndroidParcelableInterface))
 
     /*
      * must-single-thread

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -1213,7 +1213,7 @@ abstract class Erasure extends InfoTransform
           // class if `m` is defined in Java. This avoids the need for having the Java class as
           // a direct parent (scala-dev#143).
           if (qual.isInstanceOf[Super]) {
-            val qualSym = accessibleOwnerOrParentDefiningMember(sym, qual.tpe.typeSymbol.parentSymbols, context) match {
+            val qualSym = accessibleOwnerOrParentDefiningMember(sym, qual.tpe.typeSymbol.info.parents, context) match {
               case Some(p) => p
               case None =>
                 // There is no test for this warning, I have been unable to come up with an example that would trigger it.
@@ -1395,13 +1395,14 @@ abstract class Erasure extends InfoTransform
    * - For Java-defined members we prefer a direct parent over of the owner, even if the owner is
    *   accessible. This way the owner doesn't need to be added as a direct parent, see scala-dev#143.
    */
-  final def accessibleOwnerOrParentDefiningMember(member: Symbol, parents: List[Symbol], context: Context): Option[Symbol] = {
+  final def accessibleOwnerOrParentDefiningMember(member: Symbol, parents: List[Type], context: Context): Option[Symbol] = {
     def eraseAny(cls: Symbol) = if (cls == AnyClass || cls == AnyValClass) ObjectClass else cls
 
     if (member.isConstructor || !member.isJavaDefined) Some(eraseAny(member.owner))
     else parents.find { p =>
-      val e = eraseAny(p)
+      val e = eraseAny(p.typeSymbol)
       isJvmAccessible(e, context) && definesMemberAfterErasure(e, member)
+    } map { _.typeSymbol
     } orElse {
       val e = eraseAny(member.owner)
       if (isJvmAccessible(e, context)) Some(e) else None

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -1213,7 +1213,7 @@ abstract class Erasure extends InfoTransform
           // class if `m` is defined in Java. This avoids the need for having the Java class as
           // a direct parent (scala-dev#143).
           if (qual.isInstanceOf[Super]) {
-            val qualSym = accessibleOwnerOrParentDefiningMember(sym, qual.tpe.typeSymbol.info.parents, context) match {
+            val qualSym = accessibleOwnerOrParentDefiningMember(sym, qual.tpe.typeSymbol.parentSymbolsIterator, context) match {
               case Some(p) => p
               case None =>
                 // There is no test for this warning, I have been unable to come up with an example that would trigger it.
@@ -1395,14 +1395,13 @@ abstract class Erasure extends InfoTransform
    * - For Java-defined members we prefer a direct parent over of the owner, even if the owner is
    *   accessible. This way the owner doesn't need to be added as a direct parent, see scala-dev#143.
    */
-  final def accessibleOwnerOrParentDefiningMember(member: Symbol, parents: List[Type], context: Context): Option[Symbol] = {
+  final def accessibleOwnerOrParentDefiningMember(member: Symbol, parents: Iterator[Symbol], context: Context): Option[Symbol] = {
     def eraseAny(cls: Symbol) = if (cls == AnyClass || cls == AnyValClass) ObjectClass else cls
 
     if (member.isConstructor || !member.isJavaDefined) Some(eraseAny(member.owner))
     else parents.find { p =>
-      val e = eraseAny(p.typeSymbol)
+      val e = eraseAny(p)
       isJvmAccessible(e, context) && definesMemberAfterErasure(e, member)
-    } map { _.typeSymbol
     } orElse {
       val e = eraseAny(member.owner)
       if (isJvmAccessible(e, context)) Some(e) else None

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -225,7 +225,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL with AccessorSynthes
               def genForwarder(required: Boolean): Unit = {
                 val owner = member.owner
                 val isJavaInterface = owner.isJavaDefined && owner.isInterface
-                if (isJavaInterface && !clazz.parentSymbols.contains(owner)) {
+                if (isJavaInterface && !clazz.info.parents.exists(_.typeSymbol == owner)) {
                   if (required) {
                     val text = s"Unable to implement a mixin forwarder for $member in $clazz unless interface ${owner.name} is directly extended by $clazz."
                     reporter.error(clazz.pos, text)
@@ -302,7 +302,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL with AccessorSynthes
                 mixinMember.alias, mixinClass))
             case alias1 =>
               if (alias1.owner.isJavaDefined && alias1.owner.isInterface) {
-                if (!clazz.parentSymbols.contains(alias1.owner)) {
+                if (!clazz.info.parents.exists(_.typeSymbol eq alias1.owner)) {
                   val suggestedParent = exitingTyper(clazz.info.baseType(alias1.owner))
                   reporter.error(clazz.pos, s"Unable to implement a super accessor required by trait ${mixinClass.name} unless $suggestedParent is directly extended by $clazz.")
                 } else

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -225,7 +225,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL with AccessorSynthes
               def genForwarder(required: Boolean): Unit = {
                 val owner = member.owner
                 val isJavaInterface = owner.isJavaDefined && owner.isInterface
-                if (isJavaInterface && !clazz.info.parents.exists(_.typeSymbol == owner)) {
+                if (isJavaInterface && !clazz.parentSymbolsIterator.contains(owner)) {
                   if (required) {
                     val text = s"Unable to implement a mixin forwarder for $member in $clazz unless interface ${owner.name} is directly extended by $clazz."
                     reporter.error(clazz.pos, text)
@@ -302,7 +302,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL with AccessorSynthes
                 mixinMember.alias, mixinClass))
             case alias1 =>
               if (alias1.owner.isJavaDefined && alias1.owner.isInterface) {
-                if (!clazz.info.parents.exists(_.typeSymbol eq alias1.owner)) {
+                if (!clazz.parentSymbolsIterator.contains(alias1.owner)) {
                   val suggestedParent = exitingTyper(clazz.info.baseType(alias1.owner))
                   reporter.error(clazz.pos, s"Unable to implement a super accessor required by trait ${mixinClass.name} unless $suggestedParent is directly extended by $clazz.")
                 } else

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1453,7 +1453,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
 
   def illegalSpecializedInheritance(clazz: Symbol): Boolean = (
        clazz.isSpecialized
-    && originalClass(clazz).info.parents.exists(p => hasSpecializedParams(p.typeSymbol) && !p.typeSymbol.isTrait)
+    && originalClass(clazz).parentSymbolsIterator.exists(p => hasSpecializedParams(p) && !p.isTrait)
   )
 
   class SpecializationTransformer(unit: CompilationUnit) extends TypingTransformer(unit) {
@@ -1938,7 +1938,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
         }
       }
       if (hasSpecializedFields) {
-        val isSpecializedInstance = (sClass hasFlag SPECIALIZED) || sClass.info.parents.exists(_.typeSymbol hasFlag SPECIALIZED)
+        val isSpecializedInstance = (sClass hasFlag SPECIALIZED) || sClass.parentSymbolsIterator.exists(_ hasFlag SPECIALIZED)
         val sym = sClass.newMethod(nme.SPECIALIZED_INSTANCE, sClass.pos) setInfoAndEnter MethodType(Nil, BooleanTpe)
 
         mbrs += DefDef(sym, Literal(Constant(isSpecializedInstance)).setType(BooleanTpe)).setType(NoType)

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1453,7 +1453,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
 
   def illegalSpecializedInheritance(clazz: Symbol): Boolean = (
        clazz.isSpecialized
-    && originalClass(clazz).parentSymbols.exists(p => hasSpecializedParams(p) && !p.isTrait)
+    && originalClass(clazz).info.parents.exists(p => hasSpecializedParams(p.typeSymbol) && !p.typeSymbol.isTrait)
   )
 
   class SpecializationTransformer(unit: CompilationUnit) extends TypingTransformer(unit) {
@@ -1938,7 +1938,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
         }
       }
       if (hasSpecializedFields) {
-        val isSpecializedInstance = sClass :: sClass.parentSymbols exists (_ hasFlag SPECIALIZED)
+        val isSpecializedInstance = (sClass hasFlag SPECIALIZED) || sClass.info.parents.exists(_.typeSymbol hasFlag SPECIALIZED)
         val sym = sClass.newMethod(nme.SPECIALIZED_INSTANCE, sClass.pos) setInfoAndEnter MethodType(Nil, BooleanTpe)
 
         mbrs += DefDef(sym, Literal(Constant(isSpecializedInstance)).setType(BooleanTpe)).setType(NoType)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -394,11 +394,11 @@ abstract class RefChecks extends Transform {
             //Console.println(infoString(member) + " shadows1 " + infoString(other) " in " + clazz);//DEBUG
             return
           }
-          if (clazz.parentSymbols exists (p => subOther(p) && subMember(p) && deferredCheck)) {
+          if (clazz.info.parents exists (p => subOther(p.typeSymbol) && subMember(p.typeSymbol) && deferredCheck)) {
             //Console.println(infoString(member) + " shadows2 " + infoString(other) + " in " + clazz);//DEBUG
             return
           }
-          if (clazz.parentSymbols forall (p => subOther(p) == subMember(p))) {
+          if (clazz.info.parents forall (p => subOther(p.typeSymbol) == subMember(p.typeSymbol))) {
             //Console.println(infoString(member) + " shadows " + infoString(other) + " in " + clazz);//DEBUG
             return
           }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -394,11 +394,11 @@ abstract class RefChecks extends Transform {
             //Console.println(infoString(member) + " shadows1 " + infoString(other) " in " + clazz);//DEBUG
             return
           }
-          if (clazz.info.parents exists (p => subOther(p.typeSymbol) && subMember(p.typeSymbol) && deferredCheck)) {
+          if (clazz.parentSymbolsIterator exists (p => subOther(p) && subMember(p) && deferredCheck)) {
             //Console.println(infoString(member) + " shadows2 " + infoString(other) + " in " + clazz);//DEBUG
             return
           }
-          if (clazz.info.parents forall (p => subOther(p.typeSymbol) == subMember(p.typeSymbol))) {
+          if (clazz.parentSymbolsIterator forall (p => subOther(p) == subMember(p))) {
             //Console.println(infoString(member) + " shadows " + infoString(other) + " in " + clazz);//DEBUG
             return
           }

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -184,8 +184,8 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
           // There is no test left for this warning, as I have been unable to come up with an example that would trigger it.
           // For a `super.m` selection, there must be a direct parent from which `m` can be selected. This parent will be used
           // as receiver in the invokespecial call.
-          val receiverInBytecode = erasure.accessibleOwnerOrParentDefiningMember(sym, sup.tpe.typeSymbol.parentSymbols, localTyper.context.asInstanceOf[erasure.Context]).getOrElse(sym.owner)
-          if (!clazz.parentSymbols.contains(receiverInBytecode))
+          val receiverInBytecode = erasure.accessibleOwnerOrParentDefiningMember(sym, sup.tpe.typeSymbol.info.parents, localTyper.context.asInstanceOf[erasure.Context]).getOrElse(sym.owner)
+          if (!clazz.info.parents.exists(_.typeSymbol == receiverInBytecode))
             reporter.error(sel.pos, s"unable to emit super call unless interface ${owner.name} (which declares $sym) is directly extended by $clazz.")
         }
       }

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -184,8 +184,8 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
           // There is no test left for this warning, as I have been unable to come up with an example that would trigger it.
           // For a `super.m` selection, there must be a direct parent from which `m` can be selected. This parent will be used
           // as receiver in the invokespecial call.
-          val receiverInBytecode = erasure.accessibleOwnerOrParentDefiningMember(sym, sup.tpe.typeSymbol.info.parents, localTyper.context.asInstanceOf[erasure.Context]).getOrElse(sym.owner)
-          if (!clazz.info.parents.exists(_.typeSymbol == receiverInBytecode))
+          val receiverInBytecode = erasure.accessibleOwnerOrParentDefiningMember(sym, sup.tpe.typeSymbol.parentSymbolsIterator, localTyper.context.asInstanceOf[erasure.Context]).getOrElse(sym.owner)
+          if (!clazz.parentSymbolsIterator.contains(receiverInBytecode))
             reporter.error(sel.pos, s"unable to emit super call unless interface ${owner.name} (which declares $sym) is directly extended by $clazz.")
         }
       }

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -368,8 +368,7 @@ abstract class SymbolTable extends macros.Universe
       }
     }
     // enter decls of parent classes
-    for (px <- container.info.parents) {
-      val p = px.typeSymbol
+    for (p <- container.parentSymbolsIterator) {
       if (p != definitions.ObjectClass) {
         openPackageModule(p, dest)
       }

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -368,7 +368,8 @@ abstract class SymbolTable extends macros.Universe
       }
     }
     // enter decls of parent classes
-    for (p <- container.parentSymbols) {
+    for (px <- container.info.parents) {
+      val p = px.typeSymbol
       if (p != definitions.ObjectClass) {
         openPackageModule(p, dest)
       }

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2170,6 +2170,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def superClass: Symbol = if (info.parents.isEmpty) NoSymbol else info.parents.head.typeSymbol
     def parentSymbols: List[Symbol] = info.parents map (_.typeSymbol)
 
+    def parentSymbolsIterator: Iterator[Symbol] = info.parents.iterator.map(_.typeSymbol)
     /** The directly or indirectly inherited mixins of this class
      *  except for mixin classes inherited by the superclass. Mixin classes appear
      *  in linearization order.


### PR DESCRIPTION
The "Type" abstract class defines a method "parentSymbols" that is implemented by getting the list of parents of the type, and then performing a "map" to get each parent's type symbol. This map is allocating a list. Looking at the usages of this method, we confirmed that most of the calls to this method were followed by a "fold" on the list, such as an "contains", or a "find". In some cases, the list is not used at all.

To save allocations, we replace the calls to "parentSymbols" with the calls to its implementation, "info.parents", and replace the "contains" methods with "exists(_.typesymbol)". This is another example of merging a `map` into a `fold` using the fold laws.  