### PR TITLE
Micro-optimisation: avoid using List.flatten

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2353,10 +2353,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           StarWithDefaultError(meth)
 
         if (!isPastTyper) {
-          val allParams = meth.paramss.flatten
-          for (p <- allParams) {
+          for (pp <- meth.paramss ; p <- pp){
             for (n <- p.deprecatedParamName) {
-              if (allParams.exists(p1 => p != p1 && (p1.name == n || p1.deprecatedParamName.exists(_ == n))))
+              if (mexists(meth.paramss)(p1 => p != p1 && (p1.name == n || p1.deprecatedParamName.exists(_ == n))))
                 DeprecatedParamNameError(p, n)
             }
           }
@@ -4012,8 +4011,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             case _ =>
               reportAnnotationError(UnexpectedTreeAnnotationError(t, typedAnn))
           }
-
-          if (annType.typeSymbol == DeprecatedAttr && argss.flatten.size < 2)
+          if (annType.typeSymbol == DeprecatedAttr && sumSize(argss, 0) < 2)
             context.deprecationWarning(ann.pos, DeprecatedAttr, "@deprecated now takes two arguments; see the scaladoc.", "2.11.0")
 
           if ((typedAnn.tpe == null) || typedAnn.tpe.isErroneous) ErroneousAnnotation

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -331,6 +331,9 @@ trait Collections {
   /** Again avoiding calling length, but the lengthCompare interface is clunky.
     */
   final def hasLength(xs: List[_], len: Int) = xs.lengthCompare(len) == 0
+
+  @tailrec final def sumSize(xss: List[List[_]], acc: Int): Int =
+    if (xss.isEmpty) acc else sumSize(xss.tail, acc + xss.head.size)
 }
 
 object Collections extends Collections


### PR DESCRIPTION
The method `List.flatten`, which is applied to a list of lists of elements, results in a lot of allocations for the concatenation.

In this commit, we remove one use of a call to flatten in the Typers. A for loop on the flattened list is same as a for loop on the outer list and one on each inner list. An "exists" on the flattened list is
same as an outer exists of inner exists.