### PR TITLE
Avoid NPE during global initialization under -verbose/-Ylogcp

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1713,7 +1713,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
 
   def createJavadoc    = false
 
-  final val closeableRegistry: CloseableRegistry = new CloseableRegistry
+  final lazy val closeableRegistry: CloseableRegistry = new CloseableRegistry
 
   def close(): Unit = {
     perRunCaches.clearAll()


### PR DESCRIPTION
```
$ git clone wheaties/TwoTails
```

```
sbt:root> ; ++2.12.9-bin-88ed07f-SNAPSHOT! ; Test/compile

[error] java.lang.NullPointerException
[error]     at scala.tools.nsc.classpath.FileBasedCache.getOrCreate(ZipAndJarFileLookupFactory.scala:269)
[error]     at scala.tools.nsc.classpath.ZipAndJarFileLookupFactory.create(ZipAndJarFileLookupFactory.scala:44)
[error]     at scala.tools.nsc.classpath.ZipAndJarFileLookupFactory.create$(ZipAndJarFileLookupFactory.scala:37)
[error]     at scala.tools.nsc.classpath.ZipAndJarClassPathFactory$.create(ZipAndJarFileLookupFactory.scala:55)
[error]     at scala.tools.nsc.classpath.ClassPathFactory$.newClassPath(ClassPathFactory.scala:85)
[error]     at scala.tools.nsc.classpath.ClassPathFactory.newClassPath(ClassPathFactory.scala:29)
[error]     at scala.tools.nsc.classpath.ClassPathFactory.$anonfun$classesInPathImpl$3(ClassPathFactory.scala:69)
[error]     at scala.tools.nsc.classpath.ClassPathFactory.$anonfun$classesInPathImpl$1(ClassPathFactory.scala:65)
[error]     at scala.tools.nsc.classpath.ClassPathFactory.classesInPathImpl(ClassPathFactory.scala:64)
[error]     at scala.tools.nsc.classpath.ClassPathFactory.classesInPath(ClassPathFactory.scala:55)
[error]     at scala.tools.util.PathResolver$Calculated$.basis(PathResolver.scala:260)
[error]     at scala.tools.util.PathResolver$Calculated$.containers$lzycompute(PathResolver.scala:272)
[error]     at scala.tools.util.PathResolver$Calculated$.containers(PathResolver.scala:272)
[error]     at scala.tools.util.PathResolver.containers(PathResolver.scala:288)
[error]     at scala.tools.util.PathResolver.computeResult(PathResolver.scala:310)
[error]     at scala.tools.util.PathResolver.result(PathResolver.scala:293)
[error]     at scala.tools.nsc.backend.JavaPlatform.classPath(JavaPlatform.scala:30)
[error]     at scala.tools.nsc.backend.JavaPlatform.classPath$(JavaPlatform.scala:29)
[error]     at scala.tools.nsc.Global$GlobalPlatform.classPath(Global.scala:127)
[error]     at scala.tools.nsc.Global.classPath(Global.scala:138)
[error]     at scala.tools.nsc.Global.<init>(Global.scala:364)
[error]     at xsbt.CallbackGlobal.<init>(CallbackGlobal.scala:21)
[error]     at xsbt.ZincCompiler.<init>(CallbackGlobal.scala:60)
[error]     at xsbt.CachedCompilerCompat.newCompiler(Compat.scala:31)
[error]     at xsbt.CachedCompilerCompat.newCompiler$(Compat.scala:30)
[error]     at xsbt.CachedCompiler0.newCompiler(CompilerInterface.scala:55)
[error]     at xsbt.CachedCompiler0.<init>(CompilerInterface.scala:84)
[error]     at xsbt.CompilerInterface.newCompiler(CompilerInterface.scala:22)
```