### PR TITLE
Avoid using List flatMap within normalizeImpl

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -18,7 +18,7 @@ import java.util.Objects
 
 import scala.collection.{immutable, mutable}
 import scala.ref.WeakReference
-import mutable.ListBuffer
+import mutable.{ListBuffer, LinkedHashSet}
 import Flags._
 import scala.util.control.ControlThrowable
 import scala.annotation.tailrec
@@ -1632,21 +1632,17 @@ trait Types
     private def normalizeImpl = {
       // TODO see comments around def intersectionType and def merge
       // scala/bug#8575 The dealias is needed here to keep subtyping transitive, example in run/t8575b.scala
-      val flattened: List[Type] = {
-        @inline
-        def dealiasRefinement(tp: Type) = if (tp.dealias.isInstanceOf[RefinedType]) tp.dealias else tp
-        val buf: ListBuffer[Type] = ListBuffer.empty[Type]
-        def loop(tp: Type): Unit = dealiasRefinement(tp) match {
-          case RefinedType(parents, ds) if ds.isEmpty => parents.foreach(loop)
-          case tp => if (buf contains tp) () else buf += tp
-        }
-        parents foreach loop
-        buf.toList
+      val flattened: LinkedHashSet[Type] = LinkedHashSet.empty[Type]
+      def dealiasRefinement(tp: Type) = if (tp.dealias.isInstanceOf[RefinedType]) tp.dealias else tp
+      def loop(tp: Type): Unit = dealiasRefinement(tp) match {
+        case RefinedType(parents, ds) if ds.isEmpty => parents.foreach(loop)
+        case tp => flattened.add(tp)
       }
-      if (decls.isEmpty && hasLength(flattened, 1)) {
+      parents foreach loop
+      if (decls.isEmpty && flattened.size == 1) {
         flattened.head
-      } else if (flattened != parents) {
-        refinedType(flattened, if (typeSymbol eq NoSymbol) NoSymbol else typeSymbol.owner, decls, NoPosition)
+      } else if (!flattened.sameElements(parents)) {
+        refinedType(flattened.toList, if (typeSymbol eq NoSymbol) NoSymbol else typeSymbol.owner, decls, NoPosition)
       } else if (isHigherKinded) {
         etaExpand
       } else super.normalize


### PR DESCRIPTION
The normalizeImpl was using a `flatten` method for flattening out the list of parents of a refined type. This `flatten` method combined a list map with a list flatMap and a recursive loop, which could give a
lot of list allocations discarded.

We replace the code by a simple `foreach` loop that uses a mutable list buffer. To further avoid the call to the "distinct" method, we also check for repeated elements before insertion.