### PR TITLE
Remove extra List allocations in the newFindMemberScope.

### DIFF
--- a/src/library/scala/collection/BitSetLike.scala
+++ b/src/library/scala/collection/BitSetLike.scala
@@ -216,6 +216,19 @@ trait BitSetLike[+This <: BitSetLike[This] with SortedSet[Int]] extends SortedSe
     throw new NoSuchElementException("Empty BitSet")
   }
 
+  /** Returns the first positive integer not in the BitSet
+   */
+  def nonHead: Int = {
+    val n = nwords
+    var i = 0
+    while (i < n) {
+      val wi = word(i)
+      if (wi != -1L) return WordLength*i + java.lang.Long.numberOfTrailingZeros(~wi)
+      i += 1
+    }
+    return WordLength * nwords
+  }
+
   override def last: Int = {
     var i = nwords - 1
     while (i >= 0) {

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -189,6 +189,13 @@ class BitSet(protected final var elems: Array[Long]) extends AbstractSet[Int]
 object BitSet extends BitSetFactory[BitSet] {
   def empty: BitSet = new BitSet
 
+  /** Creates a BitSet fit to contain at least the number given of elements. */
+  def ofSize(size: Int): BitSet = new BitSet(new Array[Long]({
+    val quot = (size >> 6)
+    val mod = (size & 0x3F)
+    if (mod == 0) quot else quot + 1
+  }))
+
   /** A growing builder for mutable Sets. */
   def newBuilder: Builder[Int, BitSet] = new GrowingBuilder[Int, BitSet](empty)
 


### PR DESCRIPTION
In the internal.Scopes file, there is a special anonymous subclass of
Scope that is created for the `findMember` method.
The special feature of this Scope is that it overrides the `sorted`
methods, as detailed in the comment attached to the file.

The existing definition entailed the use of the methods map, groupBy,
flatMap, and reverse methods from the `List` class.
Although relatively simply (barely three lines) this definition could
cause a lot of allocations as the `members` list grew.

We replace that code (actually leave it commented for documentation)
by an array-based implementation.

- We use an array as buffer, which we start filling group by group, where for each group we get all elements with same owner.
- We use a `BitSet`, whose size is logarithmic to that of the `members` list, for marking which positions of the members list already in.
- We add a special method in the `BitSet`, to get the first non-negative number *not* in the Bitset.
- We add a special factory method in the `BitSet` companion object, to get a bites already prepared to fit a maximum number of items. 