### PR TITLE
Optimize checkAccessible for super constructor calls

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -282,8 +282,11 @@ trait Infer extends Checkable {
             catch { case ex: MalformedType => malformed(ex, pre memberType underlyingSymbol(sym)) }
           )
           tree setSymbol sym1 setType (
-            pre match {
-              case _: SuperType => owntype map (tp => if (tp eq pre) site.symbol.thisType else tp)
+          pre match {
+              case _: SuperType =>
+                val result = owntype map ((tp: Type) => if (tp eq pre) site.symbol.thisType else tp)
+                if (result ne owntype) assert(!sym.isConstructor || owntype.isInstanceOf[OverloadedType], (sym, owntype, result))
+                result
               case _            => owntype
             }
           )

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -284,9 +284,8 @@ trait Infer extends Checkable {
           tree setSymbol sym1 setType (
           pre match {
               case _: SuperType =>
-                val result = owntype map ((tp: Type) => if (tp eq pre) site.symbol.thisType else tp)
-                if (result ne owntype) assert(!sym.isConstructor || owntype.isInstanceOf[OverloadedType], (sym, owntype, result))
-                result
+                if (!sym.isConstructor && !owntype.isInstanceOf[OverloadedType]) owntype // OPT: avoid lambda allocation and Type.map
+                else owntype map ((tp: Type) => if (tp eq pre) site.symbol.thisType else tp)
               case _            => owntype
             }
           )

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -282,11 +282,11 @@ trait Infer extends Checkable {
             catch { case ex: MalformedType => malformed(ex, pre memberType underlyingSymbol(sym)) }
           )
           tree setSymbol sym1 setType (
-          pre match {
-              case _: SuperType =>
-                if (!sym.isConstructor && !owntype.isInstanceOf[OverloadedType]) owntype // OPT: avoid lambda allocation and Type.map
-                else owntype map ((tp: Type) => if (tp eq pre) site.symbol.thisType else tp)
-              case _            => owntype
+            pre match {
+              // OPT: avoid lambda allocation and Type.map for super constructor calls
+              case _: SuperType if !sym.isConstructor && !owntype.isInstanceOf[OverloadedType] =>
+                owntype map ((tp: Type) => if (tp eq pre) site.symbol.thisType else tp)
+              case _ => owntype
             }
           )
       }


### PR DESCRIPTION
Allocation of this lambda accounted for 6% of lambda allocation in the compiler.