### PR TITLE
Optimize attachment lookup and prefix stabilizer addition

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5759,13 +5759,15 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       // Extract and insert stabilizing ValDefs (if any) which might have been
       // introduced during the typing of the original expression.
-      def insertStabilizer(tree: Tree, original: Tree): Tree =
-        stabilizingDefinitions(original) match {
+      def insertStabilizer(tree: Tree, original: Tree): Tree = {
+        if (phase.erasedTypes) tree
+        else stabilizingDefinitions(original) match {
           case Nil => tree
           case vdefs =>
             removeStabilizingDefinitions(tree)
             Block(vdefs.reverse, tree) setType tree.tpe setPos tree.pos
         }
+      }
 
       // Trees not allowed during pattern mode.
       def typedOutsidePatternMode(tree: Tree): Tree = tree match {

--- a/src/reflect/scala/reflect/macros/Attachments.scala
+++ b/src/reflect/scala/reflect/macros/Attachments.scala
@@ -50,8 +50,14 @@ abstract class Attachments { self =>
     classTag[T].runtimeClass.isInstance(datum)
 
   /** An underlying payload of the given class type `T`. */
-  def get[T: ClassTag]: Option[T] =
-    (all find matchesTag[T]).asInstanceOf[Option[T]]
+  def get[T: ClassTag]: Option[T] = {
+    val it = all.iterator
+    while (it.hasNext) { // OPT: hotspot, hand roll `Set.find`.
+      val datum = it.next()
+      if (matchesTag[T](datum)) return Some(datum.asInstanceOf[T])
+    }
+    None
+  }
 
   /** Check underlying payload contains an instance of type `T`. */
   def contains[T: ClassTag]: Boolean =


### PR DESCRIPTION
- Avoid a lambda in the hot method Attachments.get
 - Short circuit the prefix stabilizer logic in the erasure typechecker.