### PR TITLE
Improve REPL completion for class names and constructors

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1567,7 +1567,7 @@ trait Contexts { self: Analyzer =>
     private def transformImport(selectors: List[ImportSelector], sym: Symbol): List[Symbol] = selectors match {
       case List() => List()
       case List(ImportSelector(nme.WILDCARD, _, _, _)) => List(sym)
-      case ImportSelector(from, _, to, _) :: _ if from == sym.name =>
+      case ImportSelector(from, _, to, _) :: _ if from == (if (from.isTermName) sym.name.toTermName else sym.name.toTypeName) =>
         if (to == nme.WILDCARD) List()
         else List(sym.cloneSymbol(sym.owner, sym.rawflags, to))
       case _ :: rest => transformImport(rest, sym)

--- a/src/interactive/scala/tools/nsc/interactive/CompilerControl.scala
+++ b/src/interactive/scala/tools/nsc/interactive/CompilerControl.scala
@@ -281,7 +281,7 @@ trait CompilerControl { self: Global =>
     val tpe: Type
     val accessible: Boolean
     def implicitlyAdded = false
-    def symNameDropLocal: Name = sym.name.dropLocal
+    def symNameDropLocal: Name = if (sym.name.isTermName) sym.name.dropLocal else sym.name
 
     private def accessible_s = if (accessible) "" else "[inaccessible] "
     def forceInfoString = {

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
@@ -12,11 +12,11 @@
 
 package scala.tools.nsc.interpreter
 
-import scala.reflect.internal.util.RangePosition
+import scala.reflect.internal.util.{Position, RangePosition}
 import scala.reflect.io.AbstractFile
 import scala.tools.nsc.backend.JavaPlatform
 import scala.tools.nsc.util.ClassPath
-import scala.tools.nsc.{interactive, CloseableRegistry, Settings}
+import scala.tools.nsc.{CloseableRegistry, Settings, interactive}
 import scala.tools.nsc.reporters.StoreReporter
 import scala.tools.nsc.classpath._
 
@@ -98,10 +98,13 @@ trait PresentationCompilation {
     import compiler.CompletionResult
 
     def completionsAt(cursor: Int): CompletionResult = {
-      val pos = unit.source.position(preambleLength + cursor)
-      compiler.completionsAt(pos)
+      compiler.completionsAt(positionOf(cursor))
     }
-    def typedTreeAt(code: String, selectionStart: Int, selectionEnd: Int): compiler.Tree = {
+
+    def positionOf(cursor: Int): Position =
+      unit.source.position(preambleLength + cursor)
+
+    def typedTreeAt(selectionStart: Int, selectionEnd: Int): compiler.Tree = {
       val start = selectionStart + preambleLength
       val end   = selectionEnd + preambleLength
       val pos   = new RangePosition(unit.source, start, start, end)

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilerCompleter.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilerCompleter.scala
@@ -12,7 +12,7 @@
 
 package scala.tools.nsc.interpreter
 
-import scala.reflect.internal.util.StringOps
+import scala.reflect.internal.util.{RangePosition, StringOps}
 import scala.tools.nsc.interpreter.Completion.Candidates
 import scala.util.control.NonFatal
 
@@ -57,17 +57,17 @@ class PresentationCompilerCompleter(intp: IMain) extends Completion {
       Candidates(cursor, "" :: printed :: Nil)
     }
     def typeAt(result: Result, start: Int, end: Int) = {
-      val tpString = result.compiler.exitingTyper(result.typedTreeAt(buf, start, end).tpe.toString)
+      val tpString = result.compiler.exitingTyper(result.typedTreeAt(start, end).tpe.toString)
       Candidates(cursor, "" :: tpString :: Nil)
     }
     def candidates(result: Result): Candidates = {
       import result.compiler._
       import CompletionResult._
-      def defStringCandidates(matching: List[Member], name: Name): Candidates = {
+      def defStringCandidates(matching: List[Member], name: Name, isNew: Boolean): Candidates = {
         val defStrings = for {
           member <- matching
           if member.symNameDropLocal == name
-          sym <- member.sym.alternatives
+          sym <- if (member.sym.isClass && isNew) member.sym.info.decl(nme.CONSTRUCTOR).alternatives else member.sym.alternatives
           sugared = sym.sugaredSymbolOrSelf
         } yield {
             val tp = member.prefix memberType sym
@@ -94,8 +94,25 @@ class PresentationCompilerCompleter(intp: IMain) extends Completion {
           val matching = r.matchingResults().filterNot(shouldHide)
           val tabAfterCommonPrefixCompletion = lastCommonPrefixCompletion.contains(buf.substring(0, cursor)) && matching.exists(_.symNameDropLocal == r.name)
           val doubleTab = tabCount > 0 && matching.forall(_.symNameDropLocal == r.name)
-          if (tabAfterCommonPrefixCompletion || doubleTab) defStringCandidates(matching, r.name)
-          else if (matching.isEmpty) {
+          if (tabAfterCommonPrefixCompletion || doubleTab) {
+            val offset = result.preambleLength
+            val pos1 = result.positionOf(cursor)
+            import result.compiler._
+            val locator = new Locator(pos1)
+            val tree = locator locateIn result.unit.body
+            var isNew = false
+            new TreeStackTraverser {
+              override def traverse(t: Tree): Unit = {
+                if (t eq tree) {
+                  isNew = path.dropWhile { case _: Select | _: Annotated => true; case _ => false}.headOption match {
+                    case Some(_: New) => true
+                    case _ => false
+                  }
+                } else super.traverse(t)
+              }
+            }.traverse(result.unit.body)
+            defStringCandidates(matching, r.name, isNew)
+          } else if (matching.isEmpty) {
             // Lenient matching based on camel case and on eliding JavaBean "get" / "is" boilerplate
             val camelMatches: List[Member] = r.matchingResults(CompletionResult.camelMatch(_)).filterNot(shouldHide)
             val memberCompletions = camelMatches.map(_.symNameDropLocal.decoded).distinct.sorted

--- a/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
@@ -177,6 +177,17 @@ class CompletionTest {
   }
 
   @Test
+  def defStringConstructor(): Unit = {
+    val intp = newIMain()
+    val completer = new PresentationCompilerCompleter(intp)
+    checkExact(completer, "class Shazam(i: Int); new Shaza")("Shazam")
+    checkExact(completer, "class Shazam(i: Int); new Shazam")(EmptyString, "def <init>(i: Int): Shazam")
+
+    checkExact(completer, "class Shazam(i: Int) { def this(x: String) = this(0) }; new Shaza")("Shazam")
+    checkExact(completer, "class Shazam(i: Int) { def this(x: String) = this(0) }; new Shazam")(EmptyString, "def <init>(i: Int): Shazam", "def <init>(x: String): Shazam")
+  }
+
+  @Test
   def treePrint(): Unit = {
     val intp = newIMain()
     val completer = new PresentationCompilerCompleter(intp)

--- a/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
@@ -203,6 +203,16 @@ class CompletionTest {
   }
 
   @Test
+  def constructor(): Unit = {
+    val intp = newIMain()
+    val completer = new PresentationCompilerCompleter(intp)
+    checkExact(completer, "class Shazam{}; new Shaz")("Shazam")
+
+    intp.interpret("class Shazam {}")
+    checkExact(completer, "new Shaz")("Shazam")
+  }
+
+  @Test
   def performanceOfLenientMatch(): Unit = {
     val intp = newIMain()
     val completer = new PresentationCompilerCompleter(intp)


### PR DESCRIPTION
```
Welcome to Scala 2.12.9-20190308-043616-e9bd65d (OpenJDK 64-Bit Server VM, Java 1.8.0-adoptopenjdk).
Type in expressions for evaluation. Or try :help.

scala> class Shazam(i :Int) { def this(s: String)(i: Int) = this(0) }
defined class Shazam

scala> new Sh
Shazam   Short

scala> new Shazam
   def <init>(i: Int): Shazam   def <init>(s: String)(i: Int): Shazam

scala> new Shazam
```