### PR TITLE
Remove use of List.map in the "varianceInTypes" function.

### DIFF
--- a/src/reflect/scala/reflect/internal/Variance.scala
+++ b/src/reflect/scala/reflect/internal/Variance.scala
@@ -14,6 +14,7 @@ package scala
 package reflect
 package internal
 
+import scala.annotation.tailrec
 import Variance._
 
 /** Variances form a lattice:
@@ -86,12 +87,26 @@ object Variance {
     def > (other: Int) = v.flags > other
   }
 
-  def fold(variances: List[Variance]): Variance = (
-    if (variances.isEmpty) Bivariant
-    else variances reduceLeft (_ & _)
-  )
   val Bivariant     = new Variance(2)
   val Covariant     = new Variance(1)
   val Contravariant = new Variance(-1)
   val Invariant     = new Variance(0)
+
+  trait Extractor[A]     { def apply(x: A): Variance }
+  trait Extractor2[A, B] { def apply(x: A, y: B): Variance }
+
+  def foldExtract[A](as: List[A])(f: Extractor[A]): Variance = {
+    @tailrec def loop(xs: List[A], acc: Variance): Variance =
+      if (acc.isInvariant || xs.isEmpty) acc
+      else loop(xs.tail, acc & f(xs.head))
+    loop(as, Bivariant)
+  }
+
+  def foldExtract2[A, B](as: List[A], bs: List[B])(f: Extractor2[A, B]): Variance = {
+    @tailrec def loop(xs: List[A], ys: List[B], acc: Variance): Variance =
+      if (acc.isInvariant || xs.isEmpty || ys.isEmpty) acc
+      else loop(xs.tail, ys.tail, acc & f(xs.head, ys.head))
+    loop(as, bs, Bivariant)
+  }
+
 }


### PR DESCRIPTION
The function `varianceInTypes`, used to calculate the variance of a certain type parameter inside a large type, was using several calls to `List.map` function, which has a linear number of allocations.
However, these lists were immediately folded into a single Variance result.

Using fold fusion, we remove the intermediate mapped lists. 
