### PR TITLE
Avoid using List.zip in the SpecializeTypes unification

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1189,13 +1189,13 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
 
   private def unify(tp1: List[Type], tp2: List[Type], env: TypeEnv, strict: Boolean): TypeEnv = {
     if (tp1.isEmpty || tp2.isEmpty) env
-    else (tp1 zip tp2).foldLeft(env) { (env, args) =>
-      if (!strict) unify(args._1, args._2, env, strict)
+    else foldLeft2(tp1, tp2)(env) { (env, arg1, arg2) =>
+      if (!strict) unify(arg1, arg2, env, strict)
       else {
-        val nenv = unify(args._1, args._2, emptyEnv, strict)
+        val nenv = unify(arg1, arg2, emptyEnv, strict)
         if (env.keySet.intersect(nenv.keySet).isEmpty) env ++ nenv
         else {
-          debuglog(s"could not unify: u(${args._1}, ${args._2}) yields $nenv, env: $env")
+          debuglog(s"could not unify: u($arg1, $arg2) yields $nenv, env: $env")
           unifyError(tp1, tp2)
         }
       }

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -158,6 +158,19 @@ trait Collections {
     if (lb eq null) Nil else lb.result
   }
 
+  // compare to foldLeft[A, B](xs)
+  final def foldLeft2[A1, A2, B](xs1: List[A1], xs2: List[A2])(z0: B)(f: (B, A1, A2) => B): B = {
+    var ys1 = xs1
+    var ys2 = xs2
+    var res = z0
+    while (!ys1.isEmpty && !ys2.isEmpty) {
+      res = f(res, ys1.head, ys2.head)
+      ys1 = ys1.tail
+      ys2 = ys2.tail
+    }
+    res
+  }
+
   final def flatCollect[A, B](elems: List[A])(pf: PartialFunction[A, Traversable[B]]): List[B] = {
     val lb = new ListBuffer[B]
     for (x <- elems ; if pf isDefinedAt x)


### PR DESCRIPTION
The code in the unify section of SpecializeTypes had a call to `List.zip`, which was followed by a process to foldLeft that list of pairs (by unifying the elements of each pair). This is allocating a linear number of Cons `::` and Tuple2 objects.

We introduce in the Collections class a new method, `foldLeft2`, to fold over two lists without extra allocations. We use it to replace the call to `zip`.