### PR TITLE
GlbLubs: avoid using map to decide boolean property of list.

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -276,12 +276,10 @@ private[internal] trait GlbLubs {
         // the type constructor of the calculated lub instead.  This
         // is because lubbing type constructors tends to result in types
         // which have been applied to dummies or Nothing.
-        ts.map(_.typeParams.size).distinct match {
-          case x :: Nil if res.typeParams.size != x =>
-            logResult(s"Stripping type args from lub because $res is not consistent with $ts")(res.typeConstructor)
-          case _                                    =>
-            res
-        }
+        val hs = ts.head.typeParams.size
+        if (hs != res.typeParams.size && ts.tail.forall(t => hasLength(t.typeParams, hs)))
+          logResult(s"Stripping type args from lub because $res is not consistent with $ts")(res.typeConstructor)
+        else res
       }
       finally {
         lubResults.clear()


### PR DESCRIPTION
In this code of `GlbLubs`, there is a call to `map`, to extract for each type in the list the number of type parameters it has. This allocates a list of Integer.  However, from the code after the `map` it is clear that the only relevant information wanted is whether or not all types in the input list have the same number of type parameters, and whether that number is equal to the number of type parameters in the result type.

This information can be obtained by using a forall clause, to check if all the elements in the list tail have as many tparams as the head.