### PR TITLE
[nomerge] Small tweak: Avoid list allocation 

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -276,12 +276,12 @@ private[internal] trait GlbLubs {
         // the type constructor of the calculated lub instead.  This
         // is because lubbing type constructors tends to result in types
         // which have been applied to dummies or Nothing.
-        ts.map(_.typeParams.size).distinct match {
-          case x :: Nil if res.typeParams.size != x =>
-            logResult(s"Stripping type args from lub because $res is not consistent with $ts")(res.typeConstructor)
-          case _                                    =>
-            res
-        }
+        val rtps = res.typeParams.size
+        val hs = ts.head.typeParams.size
+        if (hs != rtps && ts.forall(_.typeParams.size == hs))
+          logResult(s"Stripping type args from lub because $res is not consistent with $ts")(res.typeConstructor)
+        else
+          res
       }
       finally {
         lubResults.clear()


### PR DESCRIPTION
Backport of https://github.com/scala/scala/pull/7655 to the 2.12 branch. Replaces https://github.com/scala/scala/pull/7845 Thanks to @som-snytt for finding this one out. 

A `map`, followed by a `distinct`, follow by a uniqueness-check, is equivalent to a forall that compares all tail to the head. This allows us to avoid allocating lists here.