### PR TITLE
split out shared testing code into new subproject

### DIFF
--- a/src/intellij/compilerOptionsExporter.iml.SAMPLE
+++ b/src/intellij/compilerOptionsExporter.iml.SAMPLE
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
+  <component name="NewModuleRootManager">
     <output url="file://$MODULE_DIR$/../../build/quick/classes/compilerOptionsExporter" />
     <output-test url="file://$MODULE_DIR$/../../out/test/compilerOptionsExporter" />
     <exclude-output />

--- a/src/intellij/junit.iml.SAMPLE
+++ b/src/intellij/junit.iml.SAMPLE
@@ -17,6 +17,7 @@
     <orderEntry type="module" module-name="interactive" />
     <orderEntry type="module" module-name="scaladoc" />
     <orderEntry type="module" module-name="partest" />
+    <orderEntry type="module" module-name="testkit" />
     <orderEntry type="library" name="junit-deps" level="project" />
     <orderEntry type="library" name="starr" level="project" />
   </component>

--- a/src/intellij/partest.iml.SAMPLE
+++ b/src/intellij/partest.iml.SAMPLE
@@ -16,6 +16,7 @@
     <orderEntry type="module" module-name="scaladoc" />
     <orderEntry type="module" module-name="repl" />
     <orderEntry type="module" module-name="repl-frontend" />
+    <orderEntry type="module" module-name="testkit" />
     <orderEntry type="library" name="partest-deps" level="project" />
     <orderEntry type="library" name="starr" level="project" />
   </component>

--- a/src/intellij/scala.ipr.SAMPLE
+++ b/src/intellij/scala.ipr.SAMPLE
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
     <wildcardResourcePatterns>
@@ -188,6 +189,7 @@
       <module filepath="$PROJECT_DIR$/scaladoc.iml" fileurl="file://$PROJECT_DIR$/scaladoc.iml"/>
       <module filepath="$PROJECT_DIR$/scalap.iml" fileurl="file://$PROJECT_DIR$/scalap.iml"/>
       <module filepath="$PROJECT_DIR$/test.iml" fileurl="file://$PROJECT_DIR$/test.iml"/>
+      <module filepath="$PROJECT_DIR$/testkit.iml" fileurl="file://$PROJECT_DIR$/testkit.iml"/>
     </modules>
   </component>
   <component project-jdk-type="JavaSDK" project-jdk-name="1.8" default="true" languageLevel="JDK_1_8" version="2" name="ProjectRootManager">
@@ -205,262 +207,286 @@
   <component name="libraryTable">
     <library name="bench-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-6.2.0-scala-2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/pl.project13.scala/sbt-jmh-extras/jars/sbt-jmh-extras-0.3.3.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-core/jars/jmh-core-1.20.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/net.sf.jopt-simple/jopt-simple/jars/jopt-simple-4.6.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.commons/commons-math3/jars/commons-math3-3.2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-generator-bytecode/jars/jmh-generator-bytecode-1.20.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-generator-reflection/jars/jmh-generator-reflection-1.20.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-generator-asm/jars/jmh-generator-asm-1.20.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.ow2.asm/asm/jars/asm-5.0.3.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jol/jol-core/jars/jol-core-0.6.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-7.0.0-scala-1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/pl.project13.scala/sbt-jmh-extras/jars/sbt-jmh-extras-0.3.3.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-core/jars/jmh-core-1.20.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/net.sf.jopt-simple/jopt-simple/jars/jopt-simple-4.6.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.commons/commons-math3/jars/commons-math3-3.2.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-generator-bytecode/jars/jmh-generator-bytecode-1.20.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-generator-reflection/jars/jmh-generator-reflection-1.20.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-generator-asm/jars/jmh-generator-asm-1.20.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.ow2.asm/asm/jars/asm-5.0.3.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jol/jol-core/jars/jol-core-0.6.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="compiler-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-6.2.0-scala-2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-7.0.0-scala-1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="compilerOptionsExporter-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-6.2.0-scala-2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/com.fasterxml.jackson.core/jackson-core/bundles/jackson-core-2.9.5.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/com.fasterxml.jackson.core/jackson-annotations/bundles/jackson-annotations-2.9.5.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/com.fasterxml.jackson.core/jackson-databind/bundles/jackson-databind-2.9.5.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/bundles/jackson-dataformat-yaml-2.9.5.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.yaml/snakeyaml/bundles/snakeyaml-1.18.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-7.0.0-scala-1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.fasterxml.jackson.core/jackson-core/bundles/jackson-core-2.9.7.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.fasterxml.jackson.core/jackson-annotations/bundles/jackson-annotations-2.9.7.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.fasterxml.jackson.core/jackson-databind/bundles/jackson-databind-2.9.7.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/bundles/jackson-dataformat-yaml-2.9.7.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.yaml/snakeyaml/bundles/snakeyaml-1.23.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="interactive-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-6.2.0-scala-2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-7.0.0-scala-1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="junit-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-6.2.0-scala-2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/junit/junit/jars/junit-4.11.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.hamcrest/hamcrest-core/jars/hamcrest-core-1.3.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jol/jol-core/jars/jol-core-0.5.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/junit/junit/jars/junit-4.12.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.hamcrest/hamcrest-core/jars/hamcrest-core-1.3.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-7.0.0-scala-1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jol/jol-core/jars/jol-core-0.9.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="manual-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.13.0-M4.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.13.0-M5-1775dba.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="partest-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-6.2.0-scala-2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-7.0.0-scala-1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/junit/junit/jars/junit-4.12.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.hamcrest/hamcrest-core/jars/hamcrest-core-1.3.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="partest-javaagent-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-6.2.0-scala-2.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-7.0.0-scala-1.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="repl-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-6.2.0-scala-2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-7.0.0-scala-1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="repl-frontend-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-6.2.0-scala-2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-7.0.0-scala-1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="scala-build-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.pantsbuild/jarjar/jars/jarjar-1.6.5.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.ant/ant/jars/ant-1.9.9.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.ant/ant-launcher/jars/ant-launcher-1.9.9.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.ow2.asm/asm/jars/asm-6.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.ow2.asm/asm-commons/jars/asm-commons-6.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.ow2.asm/asm-tree/jars/asm-tree-6.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.maven/maven-plugin-api/jars/maven-plugin-api-3.3.9.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.maven/maven-model/jars/maven-model-3.3.9.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.codehaus.plexus/plexus-utils/jars/plexus-utils-3.0.22.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.commons/commons-lang3/jars/commons-lang3-3.4.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.maven/maven-artifact/jars/maven-artifact-3.3.9.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.eclipse.sisu/org.eclipse.sisu.plexus/eclipse-plugins/org.eclipse.sisu.plexus-0.3.2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/javax.enterprise/cdi-api/jars/cdi-api-1.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/javax.annotation/jsr250-api/jars/jsr250-api-1.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/javax.inject/javax.inject/jars/javax.inject-1.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.eclipse.sisu/org.eclipse.sisu.inject/eclipse-plugins/org.eclipse.sisu.inject-0.3.2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.codehaus.plexus/plexus-component-annotations/jars/plexus-component-annotations-1.5.5.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.codehaus.plexus/plexus-classworlds/bundles/plexus-classworlds-2.5.2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/biz.aQute.bnd/biz.aQute.bnd/jars/biz.aQute.bnd-2.4.1.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/scala_2.10/sbt_0.13/com.typesafe/sbt-mima-plugin/jars/sbt-mima-plugin-0.1.15.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/com.typesafe/mima-reporter_2.10/jars/mima-reporter_2.10-0.1.15.jar!/"/>
-        <root url="jar://$USER_HOME$/.sbt/boot/scala-2.10.7/lib/scala-library.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/com.typesafe/mima-core_2.10/jars/mima-core_2.10-0.1.15.jar!/"/>
-        <root url="jar://$USER_HOME$/.sbt/boot/scala-2.10.7/lib/scala-compiler.jar!/"/>
-        <root url="jar://$USER_HOME$/.sbt/boot/scala-2.10.7/lib/scala-reflect.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/com.typesafe/config/bundles/config-1.0.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.eclipse.jgit/org.eclipse.jgit/jars/org.eclipse.jgit-4.6.0.201612231935-r.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/com.jcraft/jsch/jars/jsch-0.1.53.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.javaewah/JavaEWAH/bundles/JavaEWAH-1.1.6.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.httpcomponents/httpclient/jars/httpclient-4.3.6.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.httpcomponents/httpcore/jars/httpcore-4.3.3.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/commons-logging/commons-logging/jars/commons-logging-1.1.3.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/commons-codec/commons-codec/jars/commons-codec-1.6.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.slf4j/slf4j-nop/jars/slf4j-nop-1.7.23.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.slf4j/slf4j-api/jars/slf4j-api-1.7.23.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/scala_2.10/sbt_0.13/pl.project13.scala/sbt-jmh/jars/sbt-jmh-0.3.3.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/pl.project13.scala/sbt-jmh-extras/jars/sbt-jmh-extras-0.3.3.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-core/jars/jmh-core-1.20.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/net.sf.jopt-simple/jopt-simple/jars/jopt-simple-4.6.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.commons/commons-math3/jars/commons-math3-3.2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-generator-bytecode/jars/jmh-generator-bytecode-1.20.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-generator-reflection/jars/jmh-generator-reflection-1.20.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-generator-asm/jars/jmh-generator-asm-1.20.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/sbt/jars/sbt-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/main/jars/main-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/actions/jars/actions-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/classpath/jars/classpath-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/interface/jars/interface-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/io/jars/io-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/control/jars/control-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/launcher-interface/jars/launcher-interface-1.0.1.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/completion/jars/completion-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/collections/jars/collections-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.5.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/api/jars/api-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/classfile/jars/classfile-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/logging/jars/logging-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/process/jars/process-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/compiler-integration/jars/compiler-integration-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/incremental-compiler/jars/incremental-compiler-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/relation/jars/relation-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/compile/jars/compile-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/persist/jars/persist-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-tools.sbinary/sbinary_2.10/jars/sbinary_2.10-0.4.2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/compiler-ivy-integration/jars/compiler-ivy-integration-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/ivy/jars/ivy-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/cross/jars/cross-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt.ivy/ivy/jars/ivy-2.3.0-sbt-b18f59ea3bc914a297bb6f1a4f7fb0ace399e310.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/serialization_2.10/jars/serialization_2.10-0.1.2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-pickling_2.10/jars/scala-pickling_2.10-0.10.1.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scalamacros/quasiquotes_2.10/jars/quasiquotes_2.10-2.0.1.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.json4s/json4s-core_2.10/jars/json4s-core_2.10-3.2.10.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.json4s/json4s-ast_2.10/jars/json4s-ast_2.10-3.2.10.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/com.thoughtworks.paranamer/paranamer/jars/paranamer-2.6.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.spire-math/jawn-parser_2.10/jars/jawn-parser_2.10-0.6.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.spire-math/json4s-support_2.10/jars/json4s-support_2.10-0.6.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/run/jars/run-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/task-system/jars/task-system-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/tasks/jars/tasks-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/tracking/jars/tracking-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/cache/jars/cache-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/testing/jars/testing-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-agent/jars/test-agent-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/main-settings/jars/main-settings-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/apply-macro/jars/apply-macro-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/command/jars/command-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/template-resolver/jars/template-resolver-0.1.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/logic/jars/logic-0.13.17.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/compiler-interface/jars/compiler-interface-0.13.17.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.commons/commons-lang3/jars/commons-lang3-3.3.2.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/biz.aQute.bnd/biz.aQute.bnd/jars/biz.aQute.bnd-2.4.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/scala_2.12/sbt_1.0/com.typesafe/sbt-mima-plugin/jars/sbt-mima-plugin-0.1.18.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.typesafe/mima-reporter_2.12/jars/mima-reporter_2.12-0.1.18.jar!/" />
+        <root url="jar://$USER_HOME$/.sbt/boot/scala-2.12.7/lib/scala-library.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.typesafe/mima-core_2.12/jars/mima-core_2.12-0.1.18.jar!/" />
+        <root url="jar://$USER_HOME$/.sbt/boot/scala-2.12.7/lib/scala-compiler.jar!/" />
+        <root url="jar://$USER_HOME$/.sbt/boot/scala-2.12.7/lib/scala-reflect.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12/bundles/scala-xml_2.12-1.0.6.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/scala_2.12/sbt_1.0/com.dwijnand/sbt-compat/jars/sbt-compat-1.0.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.eclipse.jgit/org.eclipse.jgit/jars/org.eclipse.jgit-4.6.0.201612231935-r.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.javaewah/JavaEWAH/bundles/JavaEWAH-1.1.6.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.httpcomponents/httpclient/jars/httpclient-4.3.6.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.httpcomponents/httpcore/jars/httpcore-4.3.3.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/commons-logging/commons-logging/jars/commons-logging-1.1.3.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/commons-codec/commons-codec/jars/commons-codec-1.6.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.slf4j/slf4j-nop/jars/slf4j-nop-1.7.23.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/scala_2.12/sbt_1.0/pl.project13.scala/sbt-jmh/jars/sbt-jmh-0.3.3.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/pl.project13.scala/sbt-jmh-extras/jars/sbt-jmh-extras-0.3.3.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-core/jars/jmh-core-1.20.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/net.sf.jopt-simple/jopt-simple/jars/jopt-simple-4.6.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.commons/commons-math3/jars/commons-math3-3.2.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-generator-bytecode/jars/jmh-generator-bytecode-1.20.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-generator-reflection/jars/jmh-generator-reflection-1.20.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jmh/jmh-generator-asm/jars/jmh-generator-asm-1.20.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.ow2.asm/asm/jars/asm-5.0.3.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/scala_2.12/sbt_1.0/de.heikoseeberger/sbt-header/jars/sbt-header-5.0.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/sbt/jars/sbt-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/main_2.12/jars/main_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/logic_2.12/jars/logic_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/collections_2.12/jars/collections_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.eed3si9n/sjson-new-scalajson_2.12/jars/sjson-new-scalajson_2.12-0.8.2.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.eed3si9n/sjson-new-core_2.12/jars/sjson-new-core_2.12-0.8.2.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.eed3si9n/shaded-scalajson_2.12/jars/shaded-scalajson_2.12-1.0.0-M4.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.spire-math/jawn-parser_2.12/jars/jawn-parser_2.12-0.10.4.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/util-position_2.12/jars/util-position_2.12-1.2.4.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/util-relation_2.12/jars/util-relation_2.12-1.2.4.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/actions_2.12/jars/actions_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/completion_2.12/jars/completion_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/io_2.12/jars/io_2.12-1.2.2.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.swoval/apple-file-events/jars/apple-file-events-1.3.2.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/net.java.dev.jna/jna/jars/jna-4.5.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/net.java.dev.jna/jna-platform/jars/jna-platform-4.5.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/util-control_2.12/jars/util-control_2.12-1.2.4.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/run_2.12/jars/run_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/util-logging_2.12/jars/util-logging_2.12-1.2.4.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/util-interface/jars/util-interface-1.2.4.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.logging.log4j/log4j-api/jars/log4j-api-2.11.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.logging.log4j/log4j-core/jars/log4j-core-2.11.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.lmax/disruptor/jars/disruptor-3.4.2.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/zinc-classpath_2.12/jars/zinc-classpath_2.12-1.2.5.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/compiler-interface/jars/compiler-interface-1.2.5.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/launcher-interface/jars/launcher-interface-1.0.4.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/task-system_2.12/jars/task-system_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/tasks_2.12/jars/tasks_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/util-cache_2.12/jars/util-cache_2.12-1.2.4.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.eed3si9n/sjson-new-murmurhash_2.12/jars/sjson-new-murmurhash_2.12-0.8.2.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/testing_2.12/jars/testing_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-agent/jars/test-agent-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/util-tracking_2.12/jars/util-tracking_2.12-1.2.4.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/zinc-apiinfo_2.12/jars/zinc-apiinfo_2.12-1.2.5.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/compiler-bridge_2.12/jars/compiler-bridge_2.12-1.2.5.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/zinc-classfile_2.12/jars/zinc-classfile_2.12-1.2.5.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/librarymanagement-core_2.12/jars/librarymanagement-core_2.12-1.2.4.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.jcraft/jsch/jars/jsch-0.1.54.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.eed3si9n/gigahorse-okhttp_2.12/jars/gigahorse-okhttp_2.12-0.3.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.eed3si9n/gigahorse-core_2.12/jars/gigahorse-core_2.12-0.3.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.typesafe/ssl-config-core_2.12/bundles/ssl-config-core_2.12-0.2.2.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.typesafe/config/bundles/config-1.2.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.reactivestreams/reactive-streams/jars/reactive-streams-1.0.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.slf4j/slf4j-api/jars/slf4j-api-1.7.25.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.squareup.okhttp3/okhttp/jars/okhttp-3.7.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.squareup.okio/okio/jars/okio-1.12.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.squareup.okhttp3/okhttp-urlconnection/jars/okhttp-urlconnection-3.7.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/zinc-ivy-integration_2.12/jars/zinc-ivy-integration_2.12-1.2.5.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/zinc-compile-core_2.12/jars/zinc-compile-core_2.12-1.2.5.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/bundles/scala-parser-combinators_2.12-1.0.5.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/zinc_2.12/jars/zinc_2.12-1.2.5.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/zinc-core_2.12/jars/zinc-core_2.12-1.2.5.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/zinc-persist_2.12/jars/zinc-persist_2.12-1.2.5.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.trueaccord.scalapb/scalapb-runtime_2.12/jars/scalapb-runtime_2.12-0.6.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.trueaccord.lenses/lenses_2.12/jars/lenses_2.12-0.4.12.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.lihaoyi/fastparse_2.12/jars/fastparse_2.12-0.4.2.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.lihaoyi/fastparse-utils_2.12/jars/fastparse-utils_2.12-0.4.2.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.lihaoyi/sourcecode_2.12/jars/sourcecode_2.12-0.1.3.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.google.protobuf/protobuf-java/bundles/protobuf-java-3.3.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/sbinary_2.12/jars/sbinary_2.12-0.5.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/main-settings_2.12/jars/main-settings_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/command_2.12/jars/command_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/protocol_2.12/jars/protocol_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt.ipcsocket/ipcsocket/jars/ipcsocket-1.0.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/template-resolver/jars/template-resolver-0.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/core-macros_2.12/jars/core-macros_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/scripted-sbt-redux_2.12/jars/scripted-sbt-redux_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/util-scripted_2.12/jars/util-scripted_2.12-1.2.4.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/scripted-plugin_2.12/jars/scripted-plugin_2.12-1.2.8.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.logging.log4j/log4j-slf4j-impl/jars/log4j-slf4j-impl-2.11.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.github.cb372/scalacache-caffeine_2.12/jars/scalacache-caffeine_2.12-0.20.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.github.cb372/scalacache-core_2.12/jars/scalacache-core_2.12-0.20.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.github.ben-manes.caffeine/caffeine/jars/caffeine-2.5.6.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/librarymanagement-ivy_2.12/jars/librarymanagement-ivy_2.12-1.2.4.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt.ivy/ivy/jars/ivy-2.3.0-sbt-cb9cc189e9f3af519f9f102e6c5d446488ff6832.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/zinc-compile_2.12/jars/zinc-compile_2.12-1.2.5.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="scalacheck-src-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="scalacheck-test-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-6.2.0-scala-2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-7.0.0-scala-1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="scaladoc-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-6.2.0-scala-2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-7.0.0-scala-1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="scalap-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-6.2.0-scala-2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-7.0.0-scala-1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
     </library>
-    <library type="Scala" name="starr">
+    <library name="starr" type="Scala">
       <properties>
-        <option value="Scala_2_12" name="languageLevel"/>
         <compiler-classpath>
-          <root url="file://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.13.0-M4.jar"/>
-          <root url="file://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.13.0-M4.jar"/>
-          <root url="file://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-reflect/jars/scala-reflect-2.13.0-M4.jar"/>
-          <root url="file://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar"/>
+          <root url="file://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.13.0-M5-1775dba.jar" />
+          <root url="file://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.13.0-M5-1775dba.jar" />
+          <root url="file://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-reflect/jars/scala-reflect-2.13.0-M5-1775dba.jar" />
+          <root url="file://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar" />
         </compiler-classpath>
       </properties>
-      <CLASSES/>
-      <JAVADOC/>
-      <SOURCES/>
+      <CLASSES />
+      <JAVADOC />
+      <SOURCES />
     </library>
     <library name="test-deps">
       <CLASSES>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-6.2.0-scala-2.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.scala-sha-bootstrap.test.files.lib/annotations/jars/annotations-02fe2ed93766323a13f22c7a7e2ecdcd84259b6c.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.scala-sha-bootstrap.test.files.lib/enums/jars/enums-981392dbd1f727b152cd1c908c5fce60ad9d07f7.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.scala-sha-bootstrap.test.files.lib/genericNest/jars/genericNest-b1ec8a095cec4902b3609d74d274c04365c59c04.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.scala-sha-bootstrap.test.files.lib/jsoup-1.3.1/jars/jsoup-1.3.1-346d3dff4088839d6b4d163efa2892124039d216.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.scala-sha-bootstrap.test.files.lib/macro210/jars/macro210-3794ec22d9b27f2b179bd34e9b46db771b934ec3.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.scala-sha-bootstrap.test.files.lib/methvsfield/jars/methvsfield-be8454d5e7751b063ade201c225dcedefd252775.jar!/"/>
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.scala-sha-bootstrap.test.files.lib/nest/jars/nest-cd33e0a0ea249eb42363a2f8ba531186345ff68c.jar!/"/>
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-7.0.0-scala-1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/junit/junit/jars/junit-4.12.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.hamcrest/hamcrest-core/jars/hamcrest-core-1.3.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.scala-sha-bootstrap.test.files.lib/annotations/jars/annotations-02fe2ed93766323a13f22c7a7e2ecdcd84259b6c.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.scala-sha-bootstrap.test.files.lib/enums/jars/enums-981392dbd1f727b152cd1c908c5fce60ad9d07f7.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.scala-sha-bootstrap.test.files.lib/genericNest/jars/genericNest-b1ec8a095cec4902b3609d74d274c04365c59c04.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.scala-sha-bootstrap.test.files.lib/jsoup-1.3.1/jars/jsoup-1.3.1-346d3dff4088839d6b4d163efa2892124039d216.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.scala-sha-bootstrap.test.files.lib/macro210/jars/macro210-3794ec22d9b27f2b179bd34e9b46db771b934ec3.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.scala-sha-bootstrap.test.files.lib/methvsfield/jars/methvsfield-be8454d5e7751b063ade201c225dcedefd252775.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.scala-sha-bootstrap.test.files.lib/nest/jars/nest-cd33e0a0ea249eb42363a2f8ba531186345ff68c.jar!/" />
       </CLASSES>
-      <JAVADOC/>
-      <SOURCES/>
+      <JAVADOC />
+      <SOURCES />
+    </library>
+    <library name="testkit-deps">
+      <CLASSES>
+        <root url="jar://$USER_HOME$/.ivy2/cache/junit/junit/jars/junit-4.12.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-7.0.0-scala-1.jar!/" />
+      </CLASSES>
+      <JAVADOC />
+      <SOURCES />
     </library>
   </component>
 </project>

--- a/src/intellij/testkit.iml.SAMPLE
+++ b/src/intellij/testkit.iml.SAMPLE
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <output url="file://$MODULE_DIR$/../../build/quick/classes/testkit" />
+    <output-test url="file://$MODULE_DIR$/../../out/test/testkit" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../testkit">
+      <sourceFolder url="file://$MODULE_DIR$/../testkit" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="library" />
+    <orderEntry type="library" name="testkit-deps" level="project" />
+    <orderEntry type="library" name="starr" level="project" />
+  </component>
+</module>

--- a/src/partest/scala/tools/partest/BytecodeTest.scala
+++ b/src/partest/scala/tools/partest/BytecodeTest.scala
@@ -16,7 +16,7 @@ import scala.collection.JavaConverters._
 import scala.tools.asm.{ClassReader, ClassWriter}
 import scala.tools.asm.tree._
 import java.io.{InputStream, File => JFile}
-import scala.tools.testing.ASMConverters
+import scala.tools.testkit.ASMConverters
 import AsmNode._
 import scala.tools.nsc.CloseableRegistry
 

--- a/src/testkit/scala/tools/testkit/ASMConverters.scala
+++ b/src/testkit/scala/tools/testkit/ASMConverters.scala
@@ -10,7 +10,7 @@
  * additional information regarding copyright ownership.
  */
 
-package scala.tools.testing
+package scala.tools.testkit
 
 import scala.collection.JavaConverters._
 import scala.tools.asm

--- a/src/testkit/scala/tools/testkit/AllocationTest.scala
+++ b/src/testkit/scala/tools/testkit/AllocationTest.scala
@@ -1,4 +1,4 @@
-package scala.util
+package scala.tools.testkit
 
 import java.lang.management.ManagementFactory
 

--- a/src/testkit/scala/tools/testkit/TempDir.scala
+++ b/src/testkit/scala/tools/testkit/TempDir.scala
@@ -1,4 +1,4 @@
-package scala.tools.testing
+package scala.tools.testkit
 
 import java.io.{IOException, File}
 

--- a/test/files/jvm/javaReflection/Test.scala
+++ b/test/files/jvm/javaReflection/Test.scala
@@ -50,15 +50,9 @@ getSimpleName / getCanonicalName / isAnonymousClass / isLocalClass / isSynthetic
     will change some day).
 */
 
-import scala.tools.nsc.settings.ScalaVersion
-import scala.util.Properties.javaSpecVersion
+import scala.tools.testkit.AssertUtil.assert8
 
 object Test {
-
-  def assert8(b: => Boolean, msg: => Any) = {
-    if (ScalaVersion(javaSpecVersion) == ScalaVersion("1.8")) assert(b, msg)
-    else if (!b) println(s"assert not $msg")
-  }
 
   def tr[T](m: => T): String = try {
     val r = m

--- a/test/files/jvm/t7253/test.scala
+++ b/test/files/jvm/t7253/test.scala
@@ -1,5 +1,5 @@
 import scala.tools.partest.BytecodeTest
-import scala.tools.testing.ASMConverters
+import scala.tools.testkit.ASMConverters
 
 import scala.tools.nsc.util.JavaClassPath
 import java.io.InputStream

--- a/test/files/run/BoxUnboxTest.scala
+++ b/test/files/run/BoxUnboxTest.scala
@@ -1,5 +1,5 @@
 import org.junit.Assert._
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 class VCI(val x: Int) extends AnyVal { override def toString = "" + x }
 

--- a/test/files/run/bcodeInlinerMixed/Test_2.scala
+++ b/test/files/run/bcodeInlinerMixed/Test_2.scala
@@ -1,5 +1,5 @@
 import scala.tools.partest.BytecodeTest
-import scala.tools.testing.ASMConverters
+import scala.tools.testkit.ASMConverters
 import ASMConverters._
 
 class D {

--- a/test/files/run/t8601-closure-elim.scala
+++ b/test/files/run/t8601-closure-elim.scala
@@ -1,7 +1,7 @@
 // scalac: -Ydelambdafy:method -opt:l:inline -opt-inline-from:**
 //
 import scala.tools.partest.BytecodeTest
-import scala.tools.testing.ASMConverters.instructionsFromMethod
+import scala.tools.testkit.ASMConverters.instructionsFromMethod
 import scala.tools.asm
 import scala.tools.asm.util._
 import scala.collection.JavaConverters._

--- a/test/files/run/t9403/Test_2.scala
+++ b/test/files/run/t9403/Test_2.scala
@@ -1,7 +1,7 @@
 import p.C
 import scala.tools.asm.Opcodes
 import scala.tools.partest.BytecodeTest
-import scala.tools.testing.ASMConverters._
+import scala.tools.testkit.ASMConverters._
 
 
 object Test extends BytecodeTest {

--- a/test/junit/scala/OptionTest.scala
+++ b/test/junit/scala/OptionTest.scala
@@ -3,7 +3,7 @@ package scala
 import org.junit.Assert._
 import org.junit.Test
 
-import scala.tools.testing.RunTesting
+import scala.tools.testkit.RunTesting
 
 class OptionTest extends RunTesting {
   @Test def testSomeZipSome: Unit = assertEquals(Some("foo") zip Some("bar"), Some(("foo", "bar")))

--- a/test/junit/scala/StringTest.scala
+++ b/test/junit/scala/StringTest.scala
@@ -1,7 +1,7 @@
 package scala
 
 import scala.tools.reflect.ToolBoxError
-import scala.tools.testing.RunTesting
+import scala.tools.testkit.RunTesting
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -6,7 +6,7 @@ import org.junit.runners.JUnit4
 
 import scala.collection.immutable.{ArraySeq, List, Range, Vector}
 import scala.language.higherKinds
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 import org.junit.Assert.assertEquals
 
 @RunWith(classOf[JUnit4])

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 import Seq.empty
 

--- a/test/junit/scala/collection/SetMapConsistencyTest.scala
+++ b/test/junit/scala/collection/SetMapConsistencyTest.scala
@@ -535,7 +535,7 @@ class SetMapConsistencyTest {
 
   @Test
   def test_SI8727(): Unit = {
-    import scala.tools.testing.AssertUtil._
+    import scala.tools.testkit.AssertUtil._
     type NSEE = NoSuchElementException
     val map = Map(0 -> "zero", 1 -> "one")
     val m = map.view.filterKeys(i => if (map contains i) true else throw new NSEE).toMap

--- a/test/junit/scala/collection/StringOpsTest.scala
+++ b/test/junit/scala/collection/StringOpsTest.scala
@@ -4,7 +4,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Assert.assertEquals
-import scala.tools.testing.AssertUtil.assertThrows
+import scala.tools.testkit.AssertUtil.assertThrows
 
 
 @RunWith(classOf[JUnit4])

--- a/test/junit/scala/collection/StringParsersTest.scala
+++ b/test/junit/scala/collection/StringParsersTest.scala
@@ -4,7 +4,7 @@ import org.junit.{Assert, Test}
 import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 import scala.util.Try
 
 @RunWith(classOf[JUnit4])

--- a/test/junit/scala/collection/concurrent/TrieMapTest.scala
+++ b/test/junit/scala/collection/concurrent/TrieMapTest.scala
@@ -4,7 +4,7 @@ import org.junit.Test
 import org.junit.Assert.assertEquals
 
 import scala.util.hashing.Hashing
-import scala.tools.testing.AssertUtil.assertThrows
+import scala.tools.testkit.AssertUtil.assertThrows
 
 class TrieMapTest {
 

--- a/test/junit/scala/collection/immutable/HashSetTest.scala
+++ b/test/junit/scala/collection/immutable/HashSetTest.scala
@@ -4,7 +4,7 @@ import org.junit.Assert.{assertEquals, assertSame}
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 @RunWith(classOf[JUnit4])
 class HashSetTest {

--- a/test/junit/scala/collection/immutable/IndexedSeqTest.scala
+++ b/test/junit/scala/collection/immutable/IndexedSeqTest.scala
@@ -5,8 +5,8 @@ import Assert._
 
 import scala.collection.Seq.empty
 import scala.language.postfixOps
-import scala.tools.testing.AssertUtil._
-import scala.util.AllocationTest
+import scala.tools.testkit.AssertUtil._
+import scala.tools.testkit.AllocationTest
 
 class IndexedSeqTest extends AllocationTest {
 

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -8,7 +8,7 @@ import org.junit.Assert._
 
 import scala.collection.mutable.{Builder, ListBuffer}
 import scala.ref.WeakReference
-import scala.tools.testing.AssertUtil
+import scala.tools.testkit.AssertUtil
 import scala.util.Try
 
 @RunWith(classOf[JUnit4])

--- a/test/junit/scala/collection/immutable/RangeTest.scala
+++ b/test/junit/scala/collection/immutable/RangeTest.scala
@@ -3,7 +3,7 @@ package scala.collection.immutable
 import org.junit.{Assert, Test}
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import scala.tools.testing.AssertUtil
+import scala.tools.testkit.AssertUtil
 
 @RunWith(classOf[JUnit4])
 class RangeTest {

--- a/test/junit/scala/collection/immutable/StringLikeTest.scala
+++ b/test/junit/scala/collection/immutable/StringLikeTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 import scala.util.Random
 
 /* Test for scala/bug#8988 */

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -6,8 +6,8 @@ import org.junit.Test
 import org.junit.Assert.assertEquals
 
 
-import scala.tools.testing.AssertUtil
-import scala.tools.testing.AssertUtil.assertThrows
+import scala.tools.testkit.AssertUtil
+import scala.tools.testkit.AssertUtil.assertThrows
 
 /* Test for scala/bug#9043 */
 @RunWith(classOf[JUnit4])

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -5,7 +5,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Assert._
 
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 @RunWith(classOf[JUnit4])
 class BitSetTest {

--- a/test/junit/scala/collection/mutable/PriorityQueueTest.scala
+++ b/test/junit/scala/collection/mutable/PriorityQueueTest.scala
@@ -7,7 +7,7 @@ import org.junit.Test
 import scala.collection.mutable
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 
-import scala.tools.testing.AssertUtil.assertThrows
+import scala.tools.testkit.AssertUtil.assertThrows
 
 @RunWith(classOf[JUnit4])
 /* Test for scala/bug#7568  */

--- a/test/junit/scala/collection/mutable/StringBuilderTest.scala
+++ b/test/junit/scala/collection/mutable/StringBuilderTest.scala
@@ -5,7 +5,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
 
-import scala.tools.testing.AssertUtil
+import scala.tools.testkit.AssertUtil
 
 @RunWith(classOf[JUnit4])
 class StringBuilderTest {

--- a/test/junit/scala/concurrent/FutureTest.scala
+++ b/test/junit/scala/concurrent/FutureTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 import scala.util.Try
 
 import java.util.concurrent.CountDownLatch

--- a/test/junit/scala/io/SourceTest.scala
+++ b/test/junit/scala/io/SourceTest.scala
@@ -6,7 +6,7 @@ import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 import java.io.{ Console => _, _ }
 

--- a/test/junit/scala/lang/annotations/BytecodeTest.scala
+++ b/test/junit/scala/lang/annotations/BytecodeTest.scala
@@ -7,9 +7,9 @@ import org.junit.runners.JUnit4
 
 import scala.collection.JavaConverters._
 import scala.tools.nsc.backend.jvm.AsmUtils
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class BytecodeTest extends BytecodeTesting {

--- a/test/junit/scala/lang/annotations/RunTest.scala
+++ b/test/junit/scala/lang/annotations/RunTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.RunTesting
+import scala.tools.testkit.RunTesting
 
 @RunWith(classOf[JUnit4])
 class RunTest extends RunTesting {
@@ -14,7 +14,7 @@ class RunTest extends RunTesting {
   @Test
   def annotationInfoNotErased(): Unit = {
     val code =
-      """import scala.tools.testing.Resource
+      """import scala.tools.testkit.Resource
         |import scala.annotation.meta.getter
         |class C {
         |  type Rg = Resource @getter

--- a/test/junit/scala/lang/primitives/NaNTest.scala
+++ b/test/junit/scala/lang/primitives/NaNTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.RunTesting
+import scala.tools.testkit.RunTesting
 
 @RunWith(classOf[JUnit4])
 class NaNTest extends RunTesting {

--- a/test/junit/scala/lang/stringinterpol/StringContextTest.scala
+++ b/test/junit/scala/lang/stringinterpol/StringContextTest.scala
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.language.implicitConversions
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 object StringContextTestUtils {
   private val decimalSeparator: Char = new DecimalFormat().getDecimalFormatSymbols().getDecimalSeparator()

--- a/test/junit/scala/lang/traits/BytecodeTest.scala
+++ b/test/junit/scala/lang/traits/BytecodeTest.scala
@@ -9,9 +9,9 @@ import scala.collection.JavaConverters._
 import scala.tools.asm.Opcodes
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree.ClassNode
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class BytecodeTest extends BytecodeTesting {

--- a/test/junit/scala/lang/traits/RunTest.scala
+++ b/test/junit/scala/lang/traits/RunTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.RunTesting
+import scala.tools.testkit.RunTesting
 
 @RunWith(classOf[JUnit4])
 class RunTest extends RunTesting {

--- a/test/junit/scala/reflect/ClassOfTest.scala
+++ b/test/junit/scala/reflect/ClassOfTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.RunTesting
+import scala.tools.testkit.RunTesting
 
 object ClassOfTest {
   class VC(val x: Any) extends AnyVal
@@ -71,7 +71,7 @@ class ClassOfTest extends RunTesting {
   @Test
   def t9702(): Unit = {
     val code =
-      """import scala.tools.testing.Resource
+      """import scala.tools.testkit.Resource
         |import scala.reflect.ClassOfTest.VC
         |class C {
         |  type aList[K] = List[K]

--- a/test/junit/scala/reflect/ClassTagTest.scala
+++ b/test/junit/scala/reflect/ClassTagTest.scala
@@ -5,7 +5,7 @@ import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 class Misc
 

--- a/test/junit/scala/reflect/QTest.scala
+++ b/test/junit/scala/reflect/QTest.scala
@@ -6,7 +6,7 @@ import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 @RunWith(classOf[JUnit4])
 class QTest {

--- a/test/junit/scala/reflect/internal/Infer.scala
+++ b/test/junit/scala/reflect/internal/Infer.scala
@@ -9,7 +9,7 @@ import scala.tools.nsc.settings.ScalaVersion
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
 import language.higherKinds
 
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 @RunWith(classOf[JUnit4])
 class InferTest extends BytecodeTesting {

--- a/test/junit/scala/reflect/internal/LongNamesTest.scala
+++ b/test/junit/scala/reflect/internal/LongNamesTest.scala
@@ -4,7 +4,7 @@ import org.junit._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.VirtualCompiler
+import scala.tools.testkit.VirtualCompiler
 import scala.language.reflectiveCalls
 
 @RunWith(classOf[JUnit4])

--- a/test/junit/scala/reflect/internal/NamesTest.scala
+++ b/test/junit/scala/reflect/internal/NamesTest.scala
@@ -1,6 +1,6 @@
 package scala.reflect.internal
 
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test

--- a/test/junit/scala/reflect/internal/PositionsTest.scala
+++ b/test/junit/scala/reflect/internal/PositionsTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 import scala.reflect.internal.util.NoSourceFile
 import scala.tools.nsc.reporters.StoreReporter
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
-import scala.tools.testing.AssertUtil
+import scala.tools.testkit.AssertUtil
 
 class PositionsTest {
 

--- a/test/junit/scala/reflect/internal/ScopeTest.scala
+++ b/test/junit/scala/reflect/internal/ScopeTest.scala
@@ -7,7 +7,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil.assertThrows
+import scala.tools.testkit.AssertUtil.assertThrows
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
 
 @RunWith(classOf[JUnit4])

--- a/test/junit/scala/reflect/internal/util/SourceFileTest.scala
+++ b/test/junit/scala/reflect/internal/util/SourceFileTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 @RunWith(classOf[JUnit4])
 class SourceFileTest {

--- a/test/junit/scala/reflect/io/AbstractFileTest.scala
+++ b/test/junit/scala/reflect/io/AbstractFileTest.scala
@@ -6,7 +6,7 @@ import org.junit.{Assert, Test}
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.TempDir
+import scala.tools.testkit.TempDir
 
 @RunWith(classOf[JUnit4])
 class AbstractFileTest {

--- a/test/junit/scala/sys/process/ParserTest.scala
+++ b/test/junit/scala/sys/process/ParserTest.scala
@@ -4,7 +4,7 @@ import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import scala.tools.testing.AssertUtil.assertThrows
+import scala.tools.testkit.AssertUtil.assertThrows
 
 @RunWith(classOf[JUnit4])
 class ParserTest {

--- a/test/junit/scala/sys/process/PipedProcessTest.scala
+++ b/test/junit/scala/sys/process/PipedProcessTest.scala
@@ -11,8 +11,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.control.Exception.ignoring
 import org.junit.Assert._
 
-import scala.tools.testing.AssertUtil.{readyOrNot, waitForIt}
-import scala.tools.testing.TestDuration
+import scala.tools.testkit.AssertUtil.{readyOrNot, waitForIt}
+import scala.tools.testkit.TestDuration
 
 @RunWith(classOf[JUnit4])
 class PipedProcessTest {

--- a/test/junit/scala/sys/process/ProcessBuilderTest.scala
+++ b/test/junit/scala/sys/process/ProcessBuilderTest.scala
@@ -4,7 +4,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert._
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 @RunWith(classOf[JUnit4])
 class ProcessBuilderTest {

--- a/test/junit/scala/tools/cmd/CommandLineParserTest.scala
+++ b/test/junit/scala/tools/cmd/CommandLineParserTest.scala
@@ -4,7 +4,7 @@ import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import scala.tools.testing.AssertUtil.assertThrows
+import scala.tools.testkit.AssertUtil.assertThrows
 
 @RunWith(classOf[JUnit4])
 class CommandLineParserTest {

--- a/test/junit/scala/tools/nsc/backend/jvm/BTypesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BTypesTest.scala
@@ -8,7 +8,7 @@ import org.junit.runners.JUnit4
 
 import scala.collection.mutable
 import scala.tools.asm.Opcodes
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 @RunWith(classOf[JUnit4])
 class BTypesTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -6,9 +6,9 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnit4])

--- a/test/junit/scala/tools/nsc/backend/jvm/DefaultMethodTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/DefaultMethodTest.scala
@@ -8,8 +8,8 @@ import scala.collection.JavaConverters._
 import scala.reflect.internal.Flags
 import scala.tools.asm.Opcodes
 import scala.tools.asm.tree.ClassNode
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 class DefaultMethodTest extends BytecodeTesting {
   import compiler._

--- a/test/junit/scala/tools/nsc/backend/jvm/DirectCompileTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/DirectCompileTest.scala
@@ -6,9 +6,9 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class DirectCompileTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/GenericSignaturesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/GenericSignaturesTest.scala
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.collection.JavaConverters._
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 @RunWith(classOf[JUnit4])
 class GenericSignaturesTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/IndyLambdaTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/IndyLambdaTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import scala.collection.JavaConverters._
 import scala.tools.asm.Handle
 import scala.tools.asm.tree.InvokeDynamicInsnNode
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 class IndyLambdaTest extends BytecodeTesting {
   import compiler._

--- a/test/junit/scala/tools/nsc/backend/jvm/IndySammyTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/IndySammyTest.scala
@@ -8,9 +8,9 @@ import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
 import scala.tools.nsc.reporters.StoreReporter
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 
 @RunWith(classOf[JUnit4])

--- a/test/junit/scala/tools/nsc/backend/jvm/InnerClassAttributeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/InnerClassAttributeTest.scala
@@ -7,8 +7,8 @@ import org.junit.runners.JUnit4
 
 import scala.collection.JavaConverters._
 import scala.tools.asm.Opcodes._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InnerClassAttributeTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
@@ -5,9 +5,9 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class OptimizedBytecodeTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/StringConcatTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/StringConcatTest.scala
@@ -6,9 +6,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class StringConcatTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
@@ -12,8 +12,8 @@ import scala.tools.asm.tree.MethodNode
 import scala.tools.nsc.backend.jvm.AsmUtils._
 import scala.tools.nsc.backend.jvm.BTypes._
 import scala.tools.nsc.backend.jvm.opt.BytecodeUtils._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class NullnessAnalyzerTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerTest.scala
@@ -10,9 +10,9 @@ import org.junit.runners.JUnit4
 import scala.tools.asm.Opcodes
 import scala.tools.asm.tree.AbstractInsnNode
 import scala.tools.nsc.backend.jvm.AsmUtils._
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class ProdConsAnalyzerTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/TypeFlowAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/TypeFlowAnalyzerTest.scala
@@ -10,8 +10,8 @@ import org.junit.runners.JUnit4
 import scala.tools.asm.Type
 import scala.tools.asm.tree.analysis.BasicValue
 import scala.tools.nsc.backend.jvm.analysis.TypeFlowInterpreter.{AaloadValue, LMFValue, ParamValue}
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class TypeFlowAnalyzerTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/AnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/AnalyzerTest.scala
@@ -10,8 +10,8 @@ import org.junit.runners.JUnit4
 import scala.tools.asm.tree.analysis._
 import scala.tools.nsc.backend.jvm.analysis.{AliasingAnalyzer, AliasingFrame}
 import scala.tools.nsc.backend.jvm.opt.BytecodeUtils._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class AnalyzerTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable
 import scala.tools.asm.Opcodes._
 import scala.tools.nsc.backend.jvm.BTypes.InternalName
 import scala.tools.nsc.backend.jvm.BackendReporting._
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 @RunWith(classOf[JUnit4])
 class BTypesFromClassfileTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BoxUnboxTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BoxUnboxTest.scala
@@ -8,9 +8,9 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 /**
   * Tests for boxing/unboxing optimizations.

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
@@ -13,9 +13,9 @@ import scala.reflect.internal.util.JavaClearable
 import scala.tools.asm.tree._
 import scala.tools.nsc.backend.jvm.BackendReporting._
 import scala.tools.nsc.reporters.StoreReporter
-import scala.tools.testing.AssertUtil._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.AssertUtil._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class CallGraphTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
@@ -7,9 +7,9 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class ClosureOptimizerTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/CompactLocalVariablesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/CompactLocalVariablesTest.scala
@@ -7,9 +7,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting._
-import scala.tools.testing.ClearAfterClass
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting._
+import scala.tools.testkit.ClearAfterClass
 
 @RunWith(classOf[JUnit4])
 class CompactLocalVariablesTest extends ClearAfterClass {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/EmptyExceptionHandlersTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/EmptyExceptionHandlersTest.scala
@@ -8,9 +8,9 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 
 @RunWith(classOf[JUnit4])

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/EmptyLabelsAndLineNumbersTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/EmptyLabelsAndLineNumbersTest.scala
@@ -8,9 +8,9 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.AssertUtil._
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.AssertUtil._
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class EmptyLabelsAndLineNumbersTest {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
@@ -11,7 +11,7 @@ import scala.collection.JavaConverters._
 import scala.reflect.internal.util.JavaClearable
 import scala.tools.nsc.backend.jvm.BTypes.MethodInlineInfo
 import scala.tools.nsc.backend.jvm.BackendReporting._
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 @RunWith(classOf[JUnit4])
 class InlineInfoTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineSourceMatcherTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineSourceMatcherTest.scala
@@ -8,8 +8,8 @@ import org.junit.runners.JUnit4
 import scala.tools.nsc.backend.jvm.BTypes.InternalName
 import scala.tools.nsc.backend.jvm.opt.InlineSourceMatcherTest._
 import scala.tools.nsc.backend.jvm.opt.InlinerHeuristics._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InlineSourceMatcherTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
@@ -6,8 +6,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InlineWarningTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerIllegalAccessTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerIllegalAccessTest.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConverters._
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree._
 import scala.tools.nsc.backend.jvm.AsmUtils._
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 @RunWith(classOf[JUnit4])
 class InlinerIllegalAccessTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InlinerSeparateCompilationTest {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -12,9 +12,9 @@ import scala.reflect.internal.util.JavaClearable
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree._
 import scala.tools.nsc.backend.jvm.BackendReporting._
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InlinerTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
@@ -11,9 +11,9 @@ import scala.collection.JavaConverters._
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree.ClassNode
 import scala.tools.nsc.backend.jvm.AsmUtils._
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class MethodLevelOptsTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ScalaInlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ScalaInlineInfoTest.scala
@@ -10,8 +10,8 @@ import org.junit.runners.JUnit4
 import scala.collection.JavaConverters._
 import scala.tools.asm.tree.ClassNode
 import scala.tools.nsc.backend.jvm.BTypes.{InlineInfo, MethodInlineInfo}
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class ScalaInlineInfoTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/SimplifyJumpsTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/SimplifyJumpsTest.scala
@@ -8,9 +8,9 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
-import scala.tools.testing.ASMConverters
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class SimplifyJumpsTest {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/UnreachableCodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/UnreachableCodeTest.scala
@@ -9,10 +9,10 @@ import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree.ClassNode
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.AssertUtil._
-import scala.tools.testing.BytecodeTesting._
-import scala.tools.testing.ClearAfterClass
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.AssertUtil._
+import scala.tools.testkit.BytecodeTesting._
+import scala.tools.testkit.ClearAfterClass
 
 @RunWith(classOf[JUnit4])
 class UnreachableCodeTest extends ClearAfterClass {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/UnusedLocalVariablesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/UnusedLocalVariablesTest.scala
@@ -8,9 +8,9 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.collection.JavaConverters._
-import scala.tools.testing.ASMConverters._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class UnusedLocalVariablesTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/classpath/MultiReleaseJarTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/MultiReleaseJarTest.scala
@@ -8,7 +8,7 @@ import java.util.jar.Attributes.Name
 import org.junit.{Assert, Test}
 
 import scala.tools.nsc.{Global, Settings}
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 import scala.util.Properties
 
 class MultiReleaseJarTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/doc/html/HtmlDocletTest.scala
+++ b/test/junit/scala/tools/nsc/doc/html/HtmlDocletTest.scala
@@ -5,7 +5,7 @@ import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 @RunWith(classOf[JUnit4])
 class HtmlDocletTest {

--- a/test/junit/scala/tools/nsc/interpreter/ScriptedTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/ScriptedTest.scala
@@ -2,7 +2,7 @@ package scala.tools.nsc
 package interpreter
 
 import org.junit._, Assert._, runner.RunWith, runners.JUnit4
-import scala.tools.testing.AssertUtil.assertThrows
+import scala.tools.testkit.AssertUtil.assertThrows
 
 @RunWith(classOf[JUnit4])
 class ScriptedTest {

--- a/test/junit/scala/tools/nsc/parser/ParserTest.scala
+++ b/test/junit/scala/tools/nsc/parser/ParserTest.scala
@@ -4,7 +4,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 @RunWith(classOf[JUnit4])
 class ParserTest extends BytecodeTesting{

--- a/test/junit/scala/tools/nsc/settings/ScalaVersionTest.scala
+++ b/test/junit/scala/tools/nsc/settings/ScalaVersionTest.scala
@@ -5,7 +5,7 @@ import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import scala.tools.testing.AssertUtil.assertThrows
+import scala.tools.testkit.AssertUtil.assertThrows
 
 @RunWith(classOf[JUnit4])
 class ScalaVersionTest {

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -5,7 +5,7 @@ import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import scala.tools.testing.AssertUtil.assertThrows
+import scala.tools.testkit.AssertUtil.assertThrows
 
 @RunWith(classOf[JUnit4])
 class SettingsTest {

--- a/test/junit/scala/tools/nsc/symtab/CannotHaveAttrsTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/CannotHaveAttrsTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil.assertThrows
+import scala.tools.testkit.AssertUtil.assertThrows
 import scala.reflect.internal.util.OffsetPosition
 
 @RunWith(classOf[JUnit4])

--- a/test/junit/scala/tools/nsc/symtab/FlagsTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/FlagsTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 @RunWith(classOf[JUnit4])
 class FlagsTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/symtab/FreshNameExtractorTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/FreshNameExtractorTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil.assertThrows
+import scala.tools.testkit.AssertUtil.assertThrows
 import scala.reflect.internal.util.FreshNameCreator
 
 @RunWith(classOf[JUnit4])

--- a/test/junit/scala/tools/nsc/symtab/StdNamesTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/StdNamesTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 @RunWith(classOf[JUnit4])
 class StdNamesTest {

--- a/test/junit/scala/tools/nsc/symtab/classfile/PicklerTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/classfile/PicklerTest.scala
@@ -7,7 +7,7 @@ import org.junit.runners.JUnit4
 import scala.reflect.io.VirtualDirectory
 import scala.tools.nsc.Global
 import scala.tools.nsc.classpath.{AggregateClassPath, VirtualDirectoryClassPath}
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 @RunWith(classOf[JUnit4])
 class PicklerTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/transform/ErasureTest.scala
+++ b/test/junit/scala/tools/nsc/transform/ErasureTest.scala
@@ -4,8 +4,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting.{assertNoInvoke, getMethod}
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting.{assertNoInvoke, getMethod}
 
 class ErasureTest extends BytecodeTesting {
   object symbolTable extends SymbolTableForUnitTesting

--- a/test/junit/scala/tools/nsc/transform/MixinTest.scala
+++ b/test/junit/scala/tools/nsc/transform/MixinTest.scala
@@ -6,9 +6,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.ASMConverters.LineNumber
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.ASMConverters.LineNumber
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class MixinTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/transform/ReleaseFenceTest.scala
+++ b/test/junit/scala/tools/nsc/transform/ReleaseFenceTest.scala
@@ -4,8 +4,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class ReleaseFenceTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/transform/delambdafy/DelambdafyTest.scala
+++ b/test/junit/scala/tools/nsc/transform/delambdafy/DelambdafyTest.scala
@@ -7,8 +7,8 @@ import org.junit.runners.JUnit4
 
 import scala.reflect.io.Path.jfile2path
 import scala.tools.nsc.io.AbstractFile
-import scala.tools.testing.BytecodeTesting._
-import scala.tools.testing.TempDir
+import scala.tools.testkit.BytecodeTesting._
+import scala.tools.testkit.TempDir
 
 @RunWith(classOf[JUnit4])
 class DelambdafyTest {

--- a/test/junit/scala/tools/nsc/transform/patmat/PatmatBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/transform/patmat/PatmatBytecodeTest.scala
@@ -7,8 +7,8 @@ import org.junit.runners.JUnit4
 
 import scala.tools.asm.Opcodes._
 import scala.tools.nsc.backend.jvm.AsmUtils._
-import scala.tools.testing.BytecodeTesting
-import scala.tools.testing.BytecodeTesting._
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class PatmatBytecodeTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/typechecker/Implicits.scala
+++ b/test/junit/scala/tools/nsc/typechecker/Implicits.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 @RunWith(classOf[JUnit4])
 class ImplicitsTests extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/typechecker/Infer.scala
+++ b/test/junit/scala/tools/nsc/typechecker/Infer.scala
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.nsc.settings.ScalaVersion
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 class A
 class B extends A

--- a/test/junit/scala/tools/nsc/typechecker/NamerTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/NamerTest.scala
@@ -4,7 +4,7 @@ import org.junit.{Assert, Test}
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 @RunWith(classOf[JUnit4])
 class NamerTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/typechecker/ParamAliasTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/ParamAliasTest.scala
@@ -8,7 +8,7 @@ import scala.reflect.io.VirtualDirectory
 import scala.tools.nsc.Global
 import scala.tools.nsc.classpath.{AggregateClassPath, VirtualDirectoryClassPath}
 import scala.tools.nsc.reporters.StoreReporter
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 @RunWith(classOf[JUnit4])
 class ParamAliasTest extends BytecodeTesting {

--- a/test/junit/scala/tools/nsc/typechecker/TypedTreeTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/TypedTreeTest.scala
@@ -3,7 +3,7 @@ package scala.tools.nsc.typechecker
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-import scala.tools.testing.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting
 
 class TypedTreeTest extends BytecodeTesting {
   override def compilerArgs = "-Ystop-after:typer"

--- a/test/junit/scala/tools/testing/AssertThrowsTest.scala
+++ b/test/junit/scala/tools/testing/AssertThrowsTest.scala
@@ -1,5 +1,4 @@
-package scala.tools
-package testing
+package scala.tools.testkit
 
 import org.junit.Assert._
 import org.junit.Test
@@ -48,7 +47,7 @@ class AssertThrowsTest {
     } catch {
       case ae: AssertionError =>
         assertEquals(1, ae.getSuppressed.length)
-        assertEquals("Exception failed check: scala.tools.testing.AssertThrowsTest$Foo", ae.getMessage)
+        assertEquals("Exception failed check: scala.tools.testkit.AssertThrowsTest$Foo", ae.getMessage)
         assertEquals(classOf[Foo], ae.getSuppressed.head.getClass)
       case t: Throwable => fail("Expected an AssertionError: $t")
     }
@@ -60,7 +59,7 @@ class AssertThrowsTest {
     } catch {
       case ae: AssertionError =>
         assertEquals(1, ae.getSuppressed.length)
-        assertEquals("Exception not a scala.tools.testing.AssertThrowsTest$Foo: scala.tools.testing.AssertThrowsTest$Bar", ae.getMessage)
+        assertEquals("Exception not a scala.tools.testkit.AssertThrowsTest$Foo: scala.tools.testkit.AssertThrowsTest$Bar", ae.getMessage)
         assertEquals(classOf[Bar], ae.getSuppressed.head.getClass)
       case t: Throwable => fail("Expected an AssertionError: $t")
     }

--- a/test/junit/scala/tools/testing/AssertUtilTest.scala
+++ b/test/junit/scala/tools/testing/AssertUtilTest.scala
@@ -1,5 +1,4 @@
-package scala.tools
-package testing
+package scala.tools.testkit
 
 import org.junit.Assert._
 import org.junit.Test

--- a/test/junit/scala/tools/testing/BytecodeTesting.scala
+++ b/test/junit/scala/tools/testing/BytecodeTesting.scala
@@ -1,4 +1,4 @@
-package scala.tools.testing
+package scala.tools.testkit
 
 import junit.framework.AssertionFailedError
 import org.junit.Assert._
@@ -17,7 +17,7 @@ import scala.tools.nsc.backend.jvm.opt.BytecodeUtils
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.reporters.StoreReporter
 import scala.tools.nsc.{Global, Settings}
-import scala.tools.testing.ASMConverters._
+import scala.tools.testkit.ASMConverters._
 
 trait BytecodeTesting extends ClearAfterClass {
   /**

--- a/test/junit/scala/tools/testing/ClearAfterClass.java
+++ b/test/junit/scala/tools/testing/ClearAfterClass.java
@@ -1,4 +1,4 @@
-package scala.tools.testing;
+package scala.tools.testkit;
 
 import org.junit.ClassRule;
 import org.junit.rules.TestRule;

--- a/test/junit/scala/tools/testing/Resource.java
+++ b/test/junit/scala/tools/testing/Resource.java
@@ -1,5 +1,5 @@
 
-package scala.tools.testing;
+package scala.tools.testkit;
 
 import java.lang.annotation.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;

--- a/test/junit/scala/tools/testing/RunTesting.scala
+++ b/test/junit/scala/tools/testing/RunTesting.scala
@@ -1,4 +1,4 @@
-package scala.tools.testing
+package scala.tools.testkit
 
 import scala.reflect.runtime._
 import scala.tools.reflect.ToolBox

--- a/test/junit/scala/tools/testing/VirtualCompilerTesting.scala
+++ b/test/junit/scala/tools/testing/VirtualCompilerTesting.scala
@@ -1,6 +1,4 @@
-package scala
-package tools
-package testing
+package scala.tools.testkit
 
 import java.io.OutputStreamWriter
 import java.net.URI

--- a/test/junit/scala/util/ChainingOpsTest.scala
+++ b/test/junit/scala/util/ChainingOpsTest.scala
@@ -4,7 +4,7 @@ import org.junit.Assert._
 import org.junit.Test
 
 import scala.tools.reflect.ToolBoxError
-import scala.tools.testing.RunTesting
+import scala.tools.testkit.RunTesting
 
 class ChainingOpsTest extends RunTesting {
   import scala.util.chaining._

--- a/test/junit/scala/util/RandomUtilTest.scala
+++ b/test/junit/scala/util/RandomUtilTest.scala
@@ -1,7 +1,7 @@
 package scala.util
 
 import org.junit.{Assert, Test}
-import tools.testing.AssertUtil.assertThrows
+import scala.tools.testkit.AssertUtil.assertThrows
 
 class RandomUtilTest {
   @Test def testBetween: Unit = {

--- a/test/junit/scala/util/SpecVersionTest.scala
+++ b/test/junit/scala/util/SpecVersionTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 /** The java version property uses the spec version
  *  and must work for legacy "major.minor" and plain version_number,

--- a/test/junit/scala/util/control/ControlThrowableTest.scala
+++ b/test/junit/scala/util/control/ControlThrowableTest.scala
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert._
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 @RunWith(classOf[JUnit4])
 @deprecated("Test me, don't judge me", since = "forever")

--- a/test/junit/scala/util/matching/RegexTest.scala
+++ b/test/junit/scala/util/matching/RegexTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testing.AssertUtil._
+import scala.tools.testkit.AssertUtil._
 
 @RunWith(classOf[JUnit4])
 class RegexTest {


### PR DESCRIPTION
sequel to #7817

this is needed in order to avoid using "compile->test" which
we can't replicate in the IntelliJ project (we don't think)

it's better this way anyway, the partest->junit dependency was
unnecessarily thick, this replaces it with a thin dependency. I had
strongly considered doing this anyway as part of #7817