### PR TITLE
Optimize ListBuffer

### DIFF
--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -194,8 +194,21 @@ class ListBuffer[A]
   def update(idx: Int, elem: A): Unit = {
     ensureUnaliased()
     if (idx < 0 || idx >= len) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${len-1})")
-    val p = locate(idx)
-    setNext(p, elem :: getNext(p).tail)
+    if (idx == 0) {
+      val newElem = new :: (elem, first.tail)
+      if (last0 eq first) {
+        last0 = newElem
+      }
+      first = newElem
+    } else {
+      // `p` can not be `null` because the case where `idx == 0` is handled above
+      val p = locate(idx)
+      val newElem = new :: (elem, p.tail.tail)
+      if (last0 eq p.tail) {
+        last0 = newElem
+      }
+      p.asInstanceOf[::[A]].next = newElem
+    }
   }
 
   def insert(idx: Int, elem: A): Unit = {

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/ListBufferBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/ListBufferBenchmark.scala
@@ -1,0 +1,101 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.mutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 20)
+@Measurement(iterations = 20)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class ListBufferBenchmark {
+  @Param(Array(/*"0", "1",*/ "10", "100", "1000", "10000"))
+  var size: Int = _
+
+  var ref: ListBuffer[Int] = _
+
+  @Setup(Level.Trial) def init: Unit = {
+    ref = new ListBuffer
+    for(i <- 0 until size) ref += i
+  }
+
+  @Benchmark def filterInPlace(bh: Blackhole): Unit = {
+    val b = ref.clone()
+    b.filterInPlace(_ % 2 == 0)
+    bh.consume(b)
+  }
+
+  @Benchmark def update(bh: Blackhole): Unit = {
+    val b = ref.clone()
+    var i = 0
+    while(i < size) {
+      b.update(i, -1)
+      i += 2
+    }
+    bh.consume(b)
+  }
+
+  @Benchmark def remove1(bh: Blackhole): Unit = {
+    val b = ref.clone()
+    var i = 0
+    while(i < size/2) {
+      b.remove(i)
+      i += 2
+    }
+    bh.consume(b)
+  }
+
+  @Benchmark def remove2(bh: Blackhole): Unit = {
+    val b = ref.clone()
+    var i = 0
+    while(i < size/4) {
+      b.remove(i, 2)
+      i += 2
+    }
+    bh.consume(b)
+  }
+
+  @Benchmark def insert(bh: Blackhole): Unit = {
+    val b = ref.clone()
+    var i = 0
+    while(i < size) {
+      b.insert(i, 0)
+      i += 2
+    }
+    bh.consume(b)
+  }
+
+  @Benchmark def insertAll(bh: Blackhole): Unit = {
+    val b = ref.clone()
+    val seq = Seq(0,0)
+    var i = 0
+    while(i < size/2) {
+      b.insertAll(i, seq)
+      i += 4
+    }
+    bh.consume(b)
+  }
+
+  @Benchmark def flatMapInPlace1(bh: Blackhole): Unit = {
+    val b = ref.clone()
+    val seq = Seq(0,0)
+    b.flatMapInPlace { _ => seq }
+    bh.consume(b)
+  }
+}

--- a/test/junit/scala/collection/mutable/ListBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ListBufferTest.scala
@@ -216,4 +216,14 @@ class ListBufferTest {
     testPatchInPlace(from = 10, replaced = 10, expectation = ListBuffer(0, 1, 2, -3, -2, -1))
     testPatchInPlace(from = 0, replaced = 100, expectation = ListBuffer(-3, -2, -1))
   }
+
+  @Test
+  def testUpdate(): Unit = {
+    val b = ListBuffer.empty[String] += "a"
+    assertEquals(Seq("a"), b)
+    b.update(0, "a1")
+    assertEquals(Seq("a1"), b)
+    b += "b"
+    assertEquals(Seq("a1", "b"), b)
+  }
 }


### PR DESCRIPTION
Using @julienrf's original changes and test plus additional changes to remove `setNext` entirely.

Fixes https://github.com/scala/bug/issues/11409.

Benchmark results before:

```
[info] Benchmark                          (size)  Mode  Cnt          Score        Error  Units
[info] ListBufferBenchmark.filterInPlace      10  avgt   40        213.993 ±      9.279  ns/op
[info] ListBufferBenchmark.filterInPlace     100  avgt   40       6450.232 ±     30.698  ns/op
[info] ListBufferBenchmark.filterInPlace    1000  avgt   40     474254.604 ±   2457.770  ns/op
[info] ListBufferBenchmark.filterInPlace   10000  avgt   40   48242626.449 ± 365999.583  ns/op

[info] Benchmark                          (size)  Mode  Cnt          Score        Error  Units
[info] ListBufferBenchmark.update             10  avgt   40        237.333 ±      1.558  ns/op
[info] ListBufferBenchmark.update            100  avgt   40      11242.957 ±    121.830  ns/op
[info] ListBufferBenchmark.update           1000  avgt   40    1014819.707 ±   6490.569  ns/op
[info] ListBufferBenchmark.update          10000  avgt   40  104045879.343 ± 926308.554  ns/op

[info] Benchmark                   (size)  Mode  Cnt         Score        Error  Units
[info] ListBufferBenchmark.remove      10  avgt   40       188.239 ±      1.896  ns/op
[info] ListBufferBenchmark.remove     100  avgt   40      5783.076 ±     60.811  ns/op
[info] ListBufferBenchmark.remove    1000  avgt   40    426347.708 ±   4614.753  ns/op
[info] ListBufferBenchmark.remove   10000  avgt   40  44286211.782 ± 463694.285  ns/op

[info] Benchmark                   (size)  Mode  Cnt          Score         Error  Units
[info] ListBufferBenchmark.insert      10  avgt   40        275.363 ±       1.642  ns/op
[info] ListBufferBenchmark.insert     100  avgt   40      13608.938 ±      70.850  ns/op
[info] ListBufferBenchmark.insert    1000  avgt   40    1176737.215 ±    6898.737  ns/op
[info] ListBufferBenchmark.insert   10000  avgt   40  120546230.250 ± 1234946.402  ns/op

[info] Benchmark                    (size)  Mode  Cnt         Score        Error  Units
[info] ListBufferBenchmark.remove2      10  avgt   40       161.647 ±      1.301  ns/op
[info] ListBufferBenchmark.remove2     100  avgt   40      3568.217 ±     25.806  ns/op
[info] ListBufferBenchmark.remove2    1000  avgt   40    212074.870 ±   1217.360  ns/op
[info] ListBufferBenchmark.remove2   10000  avgt   40  21939020.101 ± 340284.128  ns/op

[info] Benchmark                      (size)  Mode  Cnt         Score        Error  Units
[info] ListBufferBenchmark.insertAll      10  avgt   40       301.374 ±      4.595  ns/op
[info] ListBufferBenchmark.insertAll     100  avgt   40      6848.488 ±     68.203  ns/op
[info] ListBufferBenchmark.insertAll    1000  avgt   40    479121.460 ±   3525.902  ns/op
[info] ListBufferBenchmark.insertAll   10000  avgt   40  48535212.551 ± 296195.253  ns/op

[info] Benchmark                            (size)  Mode  Cnt          Score         Error  Units
[info] ListBufferBenchmark.flatMapInPlace1      10  avgt   40        539.689 ±       4.809  ns/op
[info] ListBufferBenchmark.flatMapInPlace1     100  avgt   40      14084.171 ±     123.299  ns/op
[info] ListBufferBenchmark.flatMapInPlace1    1000  avgt   40    1006238.031 ±   10873.037  ns/op
[info] ListBufferBenchmark.flatMapInPlace1   10000  avgt   40  106487833.014 ± 1503451.673  ns/op
```

And after:

```
[info] Benchmark                          (size)  Mode  Cnt       Score     Error  Units
[info] ListBufferBenchmark.filterInPlace      10  avgt   40     187.115 ±   6.792  ns/op
[info] ListBufferBenchmark.filterInPlace     100  avgt   40    1740.251 ±  11.474  ns/op
[info] ListBufferBenchmark.filterInPlace    1000  avgt   40   17332.799 ±  91.070  ns/op
[info] ListBufferBenchmark.filterInPlace   10000  avgt   40  184835.603 ± 946.904  ns/op

[info] Benchmark                   (size)  Mode  Cnt         Score        Error  Units
[info] ListBufferBenchmark.update      10  avgt   40       196.233 ±      1.723  ns/op
[info] ListBufferBenchmark.update     100  avgt   40      5635.758 ±     25.738  ns/op
[info] ListBufferBenchmark.update    1000  avgt   40    470021.878 ±   2142.272  ns/op
[info] ListBufferBenchmark.update   10000  avgt   40  51798443.609 ± 404453.530  ns/op

[info] Benchmark                   (size)  Mode  Cnt         Score       Error  Units
[info] ListBufferBenchmark.remove      10  avgt   40       161.749 ±     1.718  ns/op
[info] ListBufferBenchmark.remove     100  avgt   40      2327.625 ±    33.012  ns/op
[info] ListBufferBenchmark.remove    1000  avgt   40    119450.990 ±  1148.015  ns/op
[info] ListBufferBenchmark.remove   10000  avgt   40  12956024.234 ± 74460.580  ns/op

[info] Benchmark                   (size)  Mode  Cnt         Score        Error  Units
[info] ListBufferBenchmark.insert      10  avgt   40       206.190 ±      1.380  ns/op
[info] ListBufferBenchmark.insert     100  avgt   40      5738.010 ±     28.709  ns/op
[info] ListBufferBenchmark.insert    1000  avgt   40    462003.825 ±   2419.041  ns/op
[info] ListBufferBenchmark.insert   10000  avgt   40  46510470.764 ± 335619.221  ns/op

[info] Benchmark                    (size)  Mode  Cnt        Score       Error  Units
[info] ListBufferBenchmark.remove2      10  avgt   40      152.818 ±     2.882  ns/op
[info] ListBufferBenchmark.remove2     100  avgt   40     1607.830 ±    14.286  ns/op
[info] ListBufferBenchmark.remove2    1000  avgt   40    34250.733 ±   489.042  ns/op
[info] ListBufferBenchmark.remove2   10000  avgt   40  3358515.268 ± 61505.290  ns/op

[info] Benchmark                      (size)  Mode  Cnt        Score       Error  Units
[info] ListBufferBenchmark.insertAll      10  avgt   40      276.493 ±    22.115  ns/op
[info] ListBufferBenchmark.insertAll     100  avgt   40     2349.570 ±    39.848  ns/op
[info] ListBufferBenchmark.insertAll    1000  avgt   40    66445.281 ±   788.143  ns/op
[info] ListBufferBenchmark.insertAll   10000  avgt   40  6514060.224 ± 45505.897  ns/op

[info] Benchmark                            (size)  Mode  Cnt         Score         Error  Units
[info] ListBufferBenchmark.flatMapInPlace1      10  avgt   40       476.809 ±      10.699  ns/op
[info] ListBufferBenchmark.flatMapInPlace1     100  avgt   40      3872.255 ±      33.894  ns/op
[info] ListBufferBenchmark.flatMapInPlace1    1000  avgt   40     40460.048 ±     300.383  ns/op
[info] ListBufferBenchmark.flatMapInPlace1   10000  avgt   40    339746.912 ±   11564.126  ns/op
```
