### PR TITLE
Optimisation: replace mapParamss with a foreachParamss

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -696,7 +696,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
         // resolved by the type checker. Later on, erasure re-typechecks everything and
         // chokes if it finds default parameters for specialized members, even though
         // they are never needed.
-        mapParamss(sym)(_ resetFlag DEFAULTPARAM)
+        foreachParamss(sym)(_ resetFlag DEFAULTPARAM)
         decls1 enter subst(fullEnv)(sym)
       }
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1357,9 +1357,9 @@ abstract class RefChecks extends Transform {
       }
 
       // types of the value parameters
-      mapParamss(member)(p => checkAccessibilityOfType(p.tpe))
+      foreachParamss(member)(p => checkAccessibilityOfType(p.tpe))
       // upper bounds of type parameters
-      member.typeParams.map(_.info.upperBound.widen) foreach checkAccessibilityOfType
+      member.typeParams.foreach(tp => checkAccessibilityOfType(tp.info.upperBound.widen))
     }
 
     private def checkByNameRightAssociativeDef(tree: DefDef) {

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -481,9 +481,10 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
         val code = DefDef(newAcc, {
           val (receiver :: _) :: tail = newAcc.paramss
           val base: Tree              = Select(Ident(receiver), sym)
-          val allParamTypes           = mapParamss(sym)(_.tpe)
-          val args = map2(tail, allParamTypes)((params, tpes) => map2(params, tpes)(makeArg(_, receiver, _)))
-          args.foldLeft(base)(Apply(_, _))
+          foldLeft2(tail, sym.info.paramss)(base){ (acc, params, pps) =>
+            val y = map2(params, pps)( (param, pp) =>  makeArg(param, receiver, pp.tpe))
+            Apply(acc, y)
+          }
         })
 
         debuglog("created protected accessor: " + code)

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3707,6 +3707,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
    */
   def mapParamss[T](sym: Symbol)(f: Symbol => T): List[List[T]] = mmap(sym.info.paramss)(f)
 
+  def foreachParamss(sym: Symbol)(f: Symbol => Unit): Unit = mforeach(sym.info.paramss)(f)
+
   def existingSymbols(syms: List[Symbol]): List[Symbol] =
     syms filter (s => (s ne null) && (s ne NoSymbol))
 


### PR DESCRIPTION
We complement the `mapParamss` function of the Symbols cake slice with a foreachParamss method, that performs a side-effectful action. We replace several uses of mapParamss with the `foreachParamss`, to avoid the extra allocations.

We also do other optimisations, such as merging a map followed by a `foldLeft` into the fold, and a `map` followed by a `foreach` into the `foreach` (which is another fold).