### PR TITLE
Superaccessors: merge several List method.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -157,8 +157,9 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
         if (mix == tpnme.EMPTY && !owner.isTrait) {
           // scala/bug#4989 Check if an intermediate class between `clazz` and `owner` redeclares the method as abstract.
           val intermediateClasses = clazz.info.baseClasses.tail.takeWhile(_ != owner)
-          intermediateClasses.map(sym.overridingSymbol).find(s => s.isDeferred && !s.isAbstractOverride && !s.owner.isTrait).foreach {
-            absSym =>
+          intermediateClasses.foreach { icls =>
+            val absSym = sym.overridingSymbol(icls)
+            if (absSym.isDeferred && !absSym.isAbstractOverride && !absSym.owner.isTrait)
               reporter.error(sel.pos, s"${sym.fullLocationString} cannot be directly accessed from $clazz because ${absSym.owner} redeclares it as abstract")
           }
         }


### PR DESCRIPTION
The modified code was performing a `map`, followed by a `find`, followed by a `foreach`. The first `map` was allocating an intermediate list that was immediately consumed. We use fusion to join those three operations in a single foreach, to traverse without extra list allocations.