### PR TITLE
Revert the implicit dummy params added for Dotty

### DIFF
--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -234,7 +234,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
     coll.fromBitMaskNoCopy(a)
   }
 
-  override def concat(other: collection.IterableOnce[Int])(implicit dummy: DummyImplicit): C = other match {
+  override def concat(other: collection.IterableOnce[Int]): C = other match {
     case otherBitset: BitSet =>
       val len = coll.nwords max otherBitset.nwords
       val words = new Array[Long](len)

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -311,12 +311,8 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
     fromSpecific(this.view.filterKeys(k => !keysSet.contains(k)))
   }
 
-  // The implicit dummy parameter is necessary to avoid erased signature clashes
-  // between this `++:` and the overload overriden below.
-  // Note that these clashes only happen in Dotty because it adds mixin
-  // forwarders before erasure unlike Scala 2.
   @deprecated("Use ++ instead of ++: for collections of type Iterable", "2.13.0")
-  def ++: [V1 >: V](that: IterableOnce[(K,V1)])(implicit dummy: DummyImplicit): CC[K,V1] = {
+  def ++: [V1 >: V](that: IterableOnce[(K,V1)]): CC[K,V1] = {
     val thatIterable: Iterable[(K, V1)] = that match {
       case that: Iterable[(K, V1)] => that
       case that => View.from(that)

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -177,10 +177,6 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   @deprecated("Use &- with an explicit collection argument instead of - with varargs", "2.13.0")
   def - (elem1: A, elem2: A, elems: A*): C = diff(elems.toSet + elem1 + elem2)
 
-  // The implicit dummy parameter is necessary to avoid erased signature clashes
-  // between this `concat` and the polymorphic one defined in `IterableOps`.
-  // Note that these clashes only happen in Dotty because it adds mixin
-  // forwarders before erasure unlike Scala 2.
   /** Creates a new $coll by adding all elements contained in another collection to this $coll, omitting duplicates.
     *
     * This method takes a collection of elements and adds all elements, omitting duplicates, into $coll.
@@ -194,7 +190,7 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     *  @param that     the collection containing the elements to add.
     *  @return a new $coll with the given elements added, omitting duplicates.
     */
-  def concat(that: collection.IterableOnce[A])(implicit dummy: DummyImplicit): C = fromSpecific(that match {
+  def concat(that: collection.IterableOnce[A]): C = fromSpecific(that match {
     case that: collection.Iterable[A] => new View.Concat(toIterable, that)
     case _ => iterator.concat(that.iterator)
   })
@@ -206,7 +202,7 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   def + (elem1: A, elem2: A, elems: A*): C = fromSpecific(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
 
   /** Alias for `concat` */
-  @`inline` final def ++ (that: collection.IterableOnce[A])(implicit dummy: DummyImplicit): C = concat(that)
+  @`inline` final def ++ (that: collection.IterableOnce[A]): C = concat(that)
 
   /** Computes the union between of set and another set.
     *

--- a/src/library/scala/collection/StrictOptimizedSetOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSetOps.scala
@@ -23,7 +23,7 @@ trait StrictOptimizedSetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   extends SetOps[A, CC, C]
     with StrictOptimizedIterableOps[A, CC, C] {
 
-  override def concat(that: IterableOnce[A])(implicit dummy: DummyImplicit): C =
+  override def concat(that: IterableOnce[A]): C =
     strictOptimizedConcat(that, newSpecificBuilder)
 
 }

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -78,7 +78,7 @@ final class HashSet[A] private[immutable] (val rootNode: SetNode[A])
     newHashSetOrThis(newRootNode)
   }
 
-  override def concat(that: IterableOnce[A])(implicit dummy: DummyImplicit): HashSet[A] =
+  override def concat(that: IterableOnce[A]): HashSet[A] =
     that match {
       case hs: HashSet[A] => newHashSetOrThis(rootNode.concat(hs.rootNode, 0))
       case _ => super.concat(that)

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -79,7 +79,7 @@ trait StrictOptimizedSetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     with collection.StrictOptimizedSetOps[A, CC, C]
     with StrictOptimizedIterableOps[A, CC, C] {
 
-  override def concat(that: collection.IterableOnce[A])(implicit dummy: DummyImplicit): C = {
+  override def concat(that: collection.IterableOnce[A]): C = {
     var result: C = coll
     val it = that.iterator
     while (it.hasNext) result = result + it.next()

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -141,7 +141,7 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
   def excl(elem: A): TreeSet[A] =
     newSetOrSelf(RB.delete(tree, elem))
 
-  override def concat(that: collection.IterableOnce[A])(implicit dummy: DummyImplicit): TreeSet[A] = {
+  override def concat(that: collection.IterableOnce[A]): TreeSet[A] = {
     val t = that match {
       case ts: TreeSet[A] if ordering == ts.ordering =>
         RB.union(tree, ts.tree)

--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -160,13 +160,13 @@ object ExecutionContext {
    *
    * Any `NonFatal` or `InterruptedException`s will be reported to the `defaultReporter`.
    */
-  final object parasitic extends ExecutionContextExecutor with BatchingExecutor {
+  object parasitic extends ExecutionContextExecutor with BatchingExecutor {
     override final def submitForExecution(runnable: Runnable): Unit = runnable.run()
     override final def execute(runnable: Runnable): Unit = submitSyncBatched(runnable)
     override final def reportFailure(t: Throwable): Unit = defaultReporter(t)
   }
 
-  final object Implicits {
+  object Implicits {
     /**
      * The implicit global `ExecutionContext`. Import `global` when you want to provide the global
      * `ExecutionContext` implicitly.


### PR DESCRIPTION
Since https://github.com/lampepfl/dotty/pull/6079, Dotty generates mixin
forwarders after erasure just like Scala 2, so they don't cause extra
name clashes, therefore we can revert
43663326a8191250c78aaabb89898410372a21b9 and
e3ef6573a55cb6e7ecf80ee6ebd312876f7f12df.