### PR TITLE
Definitions - SymbolSet: avoid middle map list

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -162,10 +162,11 @@ trait Definitions extends api.StandardDefinitions {
     lazy val ScalaNumericValueClassesSet: SymbolSet = new SymbolSet(ScalaNumericValueClasses)
     final class SymbolSet(syms: List[Symbol]) {
       private[this] val ids: Array[Symbol] = syms.toArray
-      private[this] val commonOwner = syms.map(_.rawowner).distinct match {
-        case common :: Nil => common
-        case _ => null
-      }
+      private[this] val commonOwner =
+        if (syms.isEmpty) null else {
+          val hhOwner = syms.head.rawowner
+          if (syms.tail.forall(_.rawowner == hhOwner)) hhOwner else null
+        }
       final def contains(sym: Symbol): Boolean = {
         if (commonOwner != null && (commonOwner ne sym.rawowner))
           return false


### PR DESCRIPTION
The code to compute the `commonOwner` was using a List.map, that allocates a new list, followed by a `distinct` operation, that may generate a smaller one, followed by a singleton-list check.

We can achieve the same using a comparison between the head and all of the elements in the tail, at no extra List allocation cost.