### PR TITLE
Add Numeric#sign: T as a replacement of Numeric#signum: Int

### DIFF
--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -147,14 +147,14 @@ sealed class NumericRange[T](
   //   (Integral <: Ordering). This can happen for custom Integral types.
   // - The Ordering is the default Ordering of a well-known Integral type.
     if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
-      if (num.signum(step) > zero) head
+      if (num.sign(step) > zero) head
       else last
     } else super.min(ord)
 
   override def max[T1 >: T](implicit ord: Ordering[T1]): T =
   // See comment for fast path in min().
     if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
-      if (num.signum(step) > zero) last
+      if (num.sign(step) > zero) last
       else head
     } else super.max(ord)
 
@@ -308,8 +308,8 @@ object NumericRange {
         if (num.gt(t, limit)) throw new IllegalArgumentException("More than Int.MaxValue elements.")
         else t
       // If the range crosses zero, it might overflow when subtracted
-      val startside = num.signum(start)
-      val endside = num.signum(end)
+      val startside = num.sign(start)
+      val endside = num.sign(end)
       num.toInt{
         if (num.gteq(num.times(startside, endside), zero)) {
           // We're sure we can subtract these numbers.

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -147,14 +147,14 @@ sealed class NumericRange[T](
   //   (Integral <: Ordering). This can happen for custom Integral types.
   // - The Ordering is the default Ordering of a well-known Integral type.
     if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
-      if (num.signum(step) > 0) head
+      if (num.signum(step) > zero) head
       else last
     } else super.min(ord)
 
   override def max[T1 >: T](implicit ord: Ordering[T1]): T =
   // See comment for fast path in min().
     if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
-      if (num.signum(step) > 0) last
+      if (num.signum(step) > zero) last
       else head
     } else super.max(ord)
 
@@ -311,7 +311,7 @@ object NumericRange {
       val startside = num.signum(start)
       val endside = num.signum(end)
       num.toInt{
-        if (startside*endside >= 0) {
+        if (num.gteq(num.times(startside, endside), zero)) {
           // We're sure we can subtract these numbers.
           // Note that we do not use .rem because of different conventions for Long and BigInt
           val diff = num.minus(end, start)

--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -550,7 +550,14 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    *   +1 if it is greater than 0,
    *   0  if it is equal to 0.
    */
-  def signum: Int = this.bigDecimal.signum
+  def signum: Int = this.bigDecimal.signum()
+
+  /** Returns the sign of this BigDecimal;
+   *   -1 if it is less than 0,
+   *   +1 if it is greater than 0,
+   *   0  if it is equal to 0.
+   */
+  def sign: BigDecimal = signum
 
   /** Returns the precision of this `BigDecimal`.
    */

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -280,6 +280,13 @@ final class BigInt(val bigInteger: BigInteger)
    */
   def signum: Int = this.bigInteger.signum()
 
+  /** Returns the sign of this BigInt;
+   *   -1 if it is less than 0,
+   *   +1 if it is greater than 0,
+   *   0  if it is equal to 0.
+   */
+  def sign: BigInt = signum
+
   /** Returns the bitwise complement of this BigInt
    */
   def unary_~ : BigInt = new BigInt(this.bigInteger.not())

--- a/src/library/scala/math/Numeric.scala
+++ b/src/library/scala/math/Numeric.scala
@@ -64,6 +64,7 @@ object Numeric {
     def toLong(x: Int): Long = x.toLong
     def toFloat(x: Int): Float = x.toFloat
     def toDouble(x: Int): Double = x.toDouble
+    override def signum(x: Int): Int = math.signum(x)
   }
   implicit object IntIsIntegral extends IntIsIntegral with Ordering.IntOrdering
 
@@ -80,6 +81,8 @@ object Numeric {
     def toLong(x: Short): Long = x.toLong
     def toFloat(x: Short): Float = x.toFloat
     def toDouble(x: Short): Double = x.toDouble
+    // delegate to math.signum(Int)
+    override def signum(x: Short): Short = math.signum(x.toInt).toShort
   }
   implicit object ShortIsIntegral extends ShortIsIntegral with Ordering.ShortOrdering
 
@@ -96,6 +99,8 @@ object Numeric {
     def toLong(x: Byte): Long = x.toLong
     def toFloat(x: Byte): Float = x.toFloat
     def toDouble(x: Byte): Double = x.toDouble
+    // delegate to math.signum(Int)
+    override def signum(x: Byte): Byte = math.signum(x.toInt).toByte
   }
   implicit object ByteIsIntegral extends ByteIsIntegral with Ordering.ByteOrdering
 
@@ -112,6 +117,8 @@ object Numeric {
     def toLong(x: Char): Long = x.toLong
     def toFloat(x: Char): Float = x.toFloat
     def toDouble(x: Char): Double = x.toDouble
+    // delegate to math.signum(Int)
+    override def signum(x: Char): Char = math.signum(x.toInt).toChar
   }
   implicit object CharIsIntegral extends CharIsIntegral with Ordering.CharOrdering
 
@@ -128,6 +135,7 @@ object Numeric {
     def toLong(x: Long): Long = x
     def toFloat(x: Long): Float = x.toFloat
     def toDouble(x: Long): Double = x.toDouble
+    override def signum(x: Long): Long = math.signum(x)
   }
   implicit object LongIsIntegral extends LongIsIntegral with Ordering.LongOrdering
 
@@ -145,6 +153,7 @@ object Numeric {
     def div(x: Float, y: Float): Float = x / y
     // logic in Numeric base trait mishandles abs(-0.0f)
     override def abs(x: Float): Float = math.abs(x)
+    override def signum(x: Float): Float = math.signum(x)
   }
   implicit object FloatIsFractional extends FloatIsFractional with Ordering.Float.IeeeOrdering
 
@@ -162,6 +171,7 @@ object Numeric {
     def div(x: Double, y: Double): Double = x / y
     // logic in Numeric base trait mishandles abs(-0.0)
     override def abs(x: Double): Double = math.abs(x)
+    override def signum(x: Double): Double = math.signum(x)
   }
   implicit object DoubleIsFractional extends DoubleIsFractional with Ordering.Double.IeeeOrdering
 
@@ -208,10 +218,10 @@ trait Numeric[T] extends Ordering[T] {
   def one = fromInt(1)
 
   def abs(x: T): T = if (lt(x, zero)) negate(x) else x
-  def signum(x: T): Int =
-    if (lt(x, zero)) -1
-    else if (gt(x, zero)) 1
-    else 0
+  def signum(x: T): T =
+    if (lt(x, zero)) negate(one)
+    else if (gt(x, zero)) one
+    else zero
 
   class NumericOps(lhs: T) {
     def +(rhs: T) = plus(lhs, rhs)
@@ -219,7 +229,7 @@ trait Numeric[T] extends Ordering[T] {
     def *(rhs: T) = times(lhs, rhs)
     def unary_- = negate(lhs)
     def abs: T = Numeric.this.abs(lhs)
-    def signum: Int = Numeric.this.signum(lhs)
+    def signum: T = Numeric.this.signum(lhs)
     def toInt: Int = Numeric.this.toInt(lhs)
     def toLong: Long = Numeric.this.toLong(lhs)
     def toFloat: Float = Numeric.this.toFloat(lhs)

--- a/src/library/scala/math/Numeric.scala
+++ b/src/library/scala/math/Numeric.scala
@@ -81,7 +81,6 @@ object Numeric {
     def toLong(x: Short): Long = x.toLong
     def toFloat(x: Short): Float = x.toFloat
     def toDouble(x: Short): Double = x.toDouble
-    // delegate to math.signum(Int)
     override def signum(x: Short): Short = math.signum(x.toInt).toShort
   }
   implicit object ShortIsIntegral extends ShortIsIntegral with Ordering.ShortOrdering
@@ -99,7 +98,6 @@ object Numeric {
     def toLong(x: Byte): Long = x.toLong
     def toFloat(x: Byte): Float = x.toFloat
     def toDouble(x: Byte): Double = x.toDouble
-    // delegate to math.signum(Int)
     override def signum(x: Byte): Byte = math.signum(x.toInt).toByte
   }
   implicit object ByteIsIntegral extends ByteIsIntegral with Ordering.ByteOrdering
@@ -117,7 +115,6 @@ object Numeric {
     def toLong(x: Char): Long = x.toLong
     def toFloat(x: Char): Float = x.toFloat
     def toDouble(x: Char): Double = x.toDouble
-    // delegate to math.signum(Int)
     override def signum(x: Char): Char = math.signum(x.toInt).toChar
   }
   implicit object CharIsIntegral extends CharIsIntegral with Ordering.CharOrdering

--- a/src/library/scala/math/Numeric.scala
+++ b/src/library/scala/math/Numeric.scala
@@ -65,6 +65,7 @@ object Numeric {
     def toFloat(x: Int): Float = x.toFloat
     def toDouble(x: Int): Double = x.toDouble
     override def signum(x: Int): Int = math.signum(x)
+    override def sign(x: Int): Int = math.signum(x)
   }
   implicit object IntIsIntegral extends IntIsIntegral with Ordering.IntOrdering
 
@@ -81,7 +82,8 @@ object Numeric {
     def toLong(x: Short): Long = x.toLong
     def toFloat(x: Short): Float = x.toFloat
     def toDouble(x: Short): Double = x.toDouble
-    override def signum(x: Short): Short = math.signum(x.toInt).toShort
+    override def signum(x: Short): Int = math.signum(x.toInt)
+    override def sign(x: Short): Short = math.signum(x.toInt).toShort
   }
   implicit object ShortIsIntegral extends ShortIsIntegral with Ordering.ShortOrdering
 
@@ -98,7 +100,8 @@ object Numeric {
     def toLong(x: Byte): Long = x.toLong
     def toFloat(x: Byte): Float = x.toFloat
     def toDouble(x: Byte): Double = x.toDouble
-    override def signum(x: Byte): Byte = math.signum(x.toInt).toByte
+    override def signum(x: Byte): Int = math.signum(x.toInt)
+    override def sign(x: Byte): Byte = math.signum(x.toInt).toByte
   }
   implicit object ByteIsIntegral extends ByteIsIntegral with Ordering.ByteOrdering
 
@@ -115,7 +118,8 @@ object Numeric {
     def toLong(x: Char): Long = x.toLong
     def toFloat(x: Char): Float = x.toFloat
     def toDouble(x: Char): Double = x.toDouble
-    override def signum(x: Char): Char = math.signum(x.toInt).toChar
+    override def signum(x: Char): Int = math.signum(x.toInt)
+    override def sign(x: Char): Char = math.signum(x.toInt).toChar
   }
   implicit object CharIsIntegral extends CharIsIntegral with Ordering.CharOrdering
 
@@ -132,7 +136,8 @@ object Numeric {
     def toLong(x: Long): Long = x
     def toFloat(x: Long): Float = x.toFloat
     def toDouble(x: Long): Double = x.toDouble
-    override def signum(x: Long): Long = math.signum(x)
+    override def signum(x: Long): Int = math.signum(x).toInt
+    override def sign(x: Long): Long = math.signum(x)
   }
   implicit object LongIsIntegral extends LongIsIntegral with Ordering.LongOrdering
 
@@ -150,7 +155,8 @@ object Numeric {
     def div(x: Float, y: Float): Float = x / y
     // logic in Numeric base trait mishandles abs(-0.0f)
     override def abs(x: Float): Float = math.abs(x)
-    override def signum(x: Float): Float = math.signum(x)
+    // logic in Numeric base trait mishandles sign(-0.0f) and sign(Float.NaN)
+    override def sign(x: Float): Float = math.signum(x)
   }
   implicit object FloatIsFractional extends FloatIsFractional with Ordering.Float.IeeeOrdering
 
@@ -168,7 +174,8 @@ object Numeric {
     def div(x: Double, y: Double): Double = x / y
     // logic in Numeric base trait mishandles abs(-0.0)
     override def abs(x: Double): Double = math.abs(x)
-    override def signum(x: Double): Double = math.signum(x)
+    // logic in Numeric base trait mishandles sign(-0.0) and sign(Double.NaN)
+    override def sign(x: Double): Double = math.signum(x)
   }
   implicit object DoubleIsFractional extends DoubleIsFractional with Ordering.Double.IeeeOrdering
 
@@ -215,7 +222,12 @@ trait Numeric[T] extends Ordering[T] {
   def one = fromInt(1)
 
   def abs(x: T): T = if (lt(x, zero)) negate(x) else x
-  def signum(x: T): T =
+
+  @deprecated("use `sign` method instead", since = "2.13.0") def signum(x: T): Int =
+    if (lt(x, zero)) -1
+    else if (gt(x, zero)) 1
+    else 0
+  def sign(x: T): T =
     if (lt(x, zero)) negate(one)
     else if (gt(x, zero)) one
     else zero
@@ -226,7 +238,8 @@ trait Numeric[T] extends Ordering[T] {
     def *(rhs: T) = times(lhs, rhs)
     def unary_- = negate(lhs)
     def abs: T = Numeric.this.abs(lhs)
-    def signum: T = Numeric.this.signum(lhs)
+    @deprecated("use `sign` method instead", since = "2.13.0") def signum: Int = Numeric.this.signum(lhs)
+    def sign: T = Numeric.this.sign(lhs)
     def toInt: Int = Numeric.this.toInt(lhs)
     def toLong: Long = Numeric.this.toLong(lhs)
     def toFloat: Float = Numeric.this.toFloat(lhs)

--- a/src/library/scala/runtime/RichByte.scala
+++ b/src/library/scala/runtime/RichByte.scala
@@ -30,5 +30,4 @@ final class RichByte(val self: Byte) extends AnyVal with ScalaWholeNumberProxy[B
   override def abs: Byte             = math.abs(self).toByte
   override def max(that: Byte): Byte = math.max(self, that).toByte
   override def min(that: Byte): Byte = math.min(self, that).toByte
-  override def signum: Int           = math.signum(self.toInt)
 }

--- a/src/library/scala/runtime/RichChar.scala
+++ b/src/library/scala/runtime/RichChar.scala
@@ -32,7 +32,6 @@ final class RichChar(val self: Char) extends AnyVal with IntegralProxy[Char] {
   override def abs: Char             = self
   override def max(that: Char): Char = math.max(self.toInt, that.toInt).toChar
   override def min(that: Char): Char = math.min(self.toInt, that.toInt).toChar
-  override def signum: Int           = math.signum(self.toInt)
 
   def asDigit: Int                      = Character.digit(self, Character.MAX_RADIX)
 

--- a/src/library/scala/runtime/RichDouble.scala
+++ b/src/library/scala/runtime/RichDouble.scala
@@ -44,7 +44,6 @@ final class RichDouble(val self: Double) extends AnyVal with FractionalProxy[Dou
   override def abs: Double               = math.abs(self)
   override def max(that: Double): Double = math.max(self, that)
   override def min(that: Double): Double = math.min(self, that)
-  override def signum: Int               = math.signum(self).toInt  // !!! NaN
 
   def round: Long   = math.round(self)
   def ceil: Double  = math.ceil(self)

--- a/src/library/scala/runtime/RichDouble.scala
+++ b/src/library/scala/runtime/RichDouble.scala
@@ -44,6 +44,7 @@ final class RichDouble(val self: Double) extends AnyVal with FractionalProxy[Dou
   override def abs: Double               = math.abs(self)
   override def max(that: Double): Double = math.max(self, that)
   override def min(that: Double): Double = math.min(self, that)
+  @deprecated("signum does not handle -0.0 or Double.NaN; use `sign` method instead", since = "2.13.0") override def signum: Int = num.signum(self)
 
   def round: Long   = math.round(self)
   def ceil: Double  = math.ceil(self)

--- a/src/library/scala/runtime/RichFloat.scala
+++ b/src/library/scala/runtime/RichFloat.scala
@@ -44,6 +44,7 @@ final class RichFloat(val self: Float) extends AnyVal with FractionalProxy[Float
   override def abs: Float              = math.abs(self)
   override def max(that: Float): Float = math.max(self, that)
   override def min(that: Float): Float = math.min(self, that)
+  @deprecated("signum does not handle -0.0f or Float.NaN; use `sign` method instead", since = "2.13.0") override def signum: Int = num.signum(self)
 
   def round: Int   = math.round(self)
   def ceil: Float  = math.ceil(self.toDouble).toFloat

--- a/src/library/scala/runtime/RichFloat.scala
+++ b/src/library/scala/runtime/RichFloat.scala
@@ -44,7 +44,6 @@ final class RichFloat(val self: Float) extends AnyVal with FractionalProxy[Float
   override def abs: Float              = math.abs(self)
   override def max(that: Float): Float = math.max(self, that)
   override def min(that: Float): Float = math.min(self, that)
-  override def signum: Int             = math.signum(self).toInt  // !!! NaN
 
   def round: Int   = math.round(self)
   def ceil: Float  = math.ceil(self.toDouble).toFloat

--- a/src/library/scala/runtime/RichInt.scala
+++ b/src/library/scala/runtime/RichInt.scala
@@ -39,7 +39,6 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
   override def abs: Int            = math.abs(self)
   override def max(that: Int): Int = math.max(self, that)
   override def min(that: Int): Int = math.min(self, that)
-  override def signum: Int         = math.signum(self)
 
   /** There is no reason to round an `Int`, but this method is provided to avoid accidental loss of precision from a detour through `Float`. */
   @deprecated("this is an integer type; there is no reason to round it.  Perhaps you meant to call this on a floating-point value?", "2.11.0")

--- a/src/library/scala/runtime/RichLong.scala
+++ b/src/library/scala/runtime/RichLong.scala
@@ -35,7 +35,6 @@ final class RichLong(val self: Long) extends AnyVal with IntegralProxy[Long] {
   override def abs: Long             = math.abs(self)
   override def max(that: Long): Long = math.max(self, that)
   override def min(that: Long): Long = math.min(self, that)
-  override def signum: Int           = math.signum(self).toInt
 
   /** There is no reason to round a `Long`, but this method is provided to avoid accidental conversion to `Int` through `Float`. */
   @deprecated("this is an integer type; there is no reason to round it.  Perhaps you meant to call this on a floating-point value?", "2.11.0")

--- a/src/library/scala/runtime/RichShort.scala
+++ b/src/library/scala/runtime/RichShort.scala
@@ -30,5 +30,4 @@ final class RichShort(val self: Short) extends AnyVal with ScalaWholeNumberProxy
   override def abs: Short              = math.abs(self.toInt).toShort
   override def max(that: Short): Short = math.max(self.toInt, that.toInt).toShort
   override def min(that: Short): Short = math.min(self.toInt, that.toInt).toShort
-  override def signum: Int             = math.signum(self.toInt)
 }

--- a/src/library/scala/runtime/ScalaNumberProxy.scala
+++ b/src/library/scala/runtime/ScalaNumberProxy.scala
@@ -40,8 +40,15 @@ trait ScalaNumberProxy[T] extends Any with ScalaNumericAnyConversions with Typed
   def max(that: T): T = num.max(self, that)
   /** Returns the absolute value of `'''this'''`. */
   def abs             = num.abs(self)
+  /**
+   * Returns the sign of `'''this'''`.
+   * zero if the argument is zero, -zero if the argument is -zero,
+   * one if the argument is greater than zero, -one if the argument is less than zero,
+   * and NaN if the argument is NaN where applicable.
+   */
+  def sign: T         = num.sign(self)
   /** Returns the signum of `'''this'''`. */
-  def signum: T       = num.signum(self)
+  @deprecated("use `sign` method instead", since = "2.13.0") def signum: Int = num.signum(self)
 }
 trait ScalaWholeNumberProxy[T] extends Any with ScalaNumberProxy[T] {
   def isWhole = true

--- a/src/library/scala/runtime/ScalaNumberProxy.scala
+++ b/src/library/scala/runtime/ScalaNumberProxy.scala
@@ -41,7 +41,7 @@ trait ScalaNumberProxy[T] extends Any with ScalaNumericAnyConversions with Typed
   /** Returns the absolute value of `'''this'''`. */
   def abs             = num.abs(self)
   /** Returns the signum of `'''this'''`. */
-  def signum          = num.signum(self)
+  def signum: T       = num.signum(self)
 }
 trait ScalaWholeNumberProxy[T] extends Any with ScalaNumberProxy[T] {
   def isWhole = true

--- a/test/files/presentation/infix-completion.check
+++ b/test/files/presentation/infix-completion.check
@@ -3,7 +3,7 @@ reload: Snippet.scala
 askTypeCompletion at Snippet.scala(1,34)
 ================================================================================
 [response] askTypeCompletion at (1,34)
-retrieved 201 members
+retrieved 202 members
 [inaccessible] protected def num: Fractional[Double]
 [inaccessible] protected def ord: Ordering[Double]
 [inaccessible] protected def unifiedPrimitiveEquals(x: Any): Boolean
@@ -139,7 +139,7 @@ def isValidLong: Boolean
 def longValue(): Long
 def round: Long
 def shortValue(): Short
-def signum: Double
+def sign: Double
 def to(end: Int): scala.collection.immutable.Range.Inclusive
 def to(end: Int, step: Int): scala.collection.immutable.Range.Inclusive
 def to(end: Long): scala.collection.immutable.NumericRange.Inclusive[Long]
@@ -197,5 +197,6 @@ override def min(that: Double): Double
 override def min(that: Float): Float
 override def min(that: Int): Int
 override def min(that: Long): Long
+override def signum: Int
 private[this] val self: Double
 ================================================================================

--- a/test/files/presentation/infix-completion.check
+++ b/test/files/presentation/infix-completion.check
@@ -139,6 +139,7 @@ def isValidLong: Boolean
 def longValue(): Long
 def round: Long
 def shortValue(): Short
+def signum: Double
 def to(end: Int): scala.collection.immutable.Range.Inclusive
 def to(end: Int, step: Int): scala.collection.immutable.Range.Inclusive
 def to(end: Long): scala.collection.immutable.NumericRange.Inclusive[Long]
@@ -196,6 +197,5 @@ override def min(that: Double): Double
 override def min(that: Float): Float
 override def min(that: Int): Int
 override def min(that: Long): Long
-override def signum: Int
 private[this] val self: Double
 ================================================================================

--- a/test/files/presentation/infix-completion2.check
+++ b/test/files/presentation/infix-completion2.check
@@ -3,7 +3,7 @@ reload: Snippet.scala
 askTypeCompletion at Snippet.scala(1,34)
 ================================================================================
 [response] askTypeCompletion at (1,34)
-retrieved 201 members
+retrieved 202 members
 [inaccessible] protected def num: Fractional[Double]
 [inaccessible] protected def ord: Ordering[Double]
 [inaccessible] protected def unifiedPrimitiveEquals(x: Any): Boolean
@@ -139,7 +139,7 @@ def isValidLong: Boolean
 def longValue(): Long
 def round: Long
 def shortValue(): Short
-def signum: Double
+def sign: Double
 def to(end: Int): scala.collection.immutable.Range.Inclusive
 def to(end: Int, step: Int): scala.collection.immutable.Range.Inclusive
 def to(end: Long): scala.collection.immutable.NumericRange.Inclusive[Long]
@@ -197,5 +197,6 @@ override def min(that: Double): Double
 override def min(that: Float): Float
 override def min(that: Int): Int
 override def min(that: Long): Long
+override def signum: Int
 private[this] val self: Double
 ================================================================================

--- a/test/files/presentation/infix-completion2.check
+++ b/test/files/presentation/infix-completion2.check
@@ -139,6 +139,7 @@ def isValidLong: Boolean
 def longValue(): Long
 def round: Long
 def shortValue(): Short
+def signum: Double
 def to(end: Int): scala.collection.immutable.Range.Inclusive
 def to(end: Int, step: Int): scala.collection.immutable.Range.Inclusive
 def to(end: Long): scala.collection.immutable.NumericRange.Inclusive[Long]
@@ -196,6 +197,5 @@ override def min(that: Double): Double
 override def min(that: Float): Float
 override def min(that: Int): Int
 override def min(that: Long): Long
-override def signum: Int
 private[this] val self: Double
 ================================================================================

--- a/test/junit/scala/math/DoubleTest.scala
+++ b/test/junit/scala/math/DoubleTest.scala
@@ -1,0 +1,16 @@
+package scala.math
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class DoubleTest {
+
+  /* Test for scala/bug#11386 */
+  @Test
+  def tesDoubleSignumNaN: Unit = {
+    assertTrue(Double.NaN.signum.isNaN)
+  }
+}

--- a/test/junit/scala/math/DoubleTest.scala
+++ b/test/junit/scala/math/DoubleTest.scala
@@ -10,7 +10,13 @@ class DoubleTest {
 
   /* Test for scala/bug#11386 */
   @Test
-  def tesDoubleSignumNaN: Unit = {
+  def tesDoubleSignum: Unit = {
     assertTrue(Double.NaN.signum.isNaN)
+    assertEquals("1.0", Double.MaxValue.signum.toString)
+    assertEquals("1.0", Double.PositiveInfinity.signum.toString)
+    assertEquals("-1.0", Double.MinValue.signum.toString)
+    assertEquals("-1.0", Double.NegativeInfinity.signum.toString)
+    assertEquals("0.0", 0.0.signum.toString)
+    assertEquals("-0.0", -0.0.signum.toString)
   }
 }

--- a/test/junit/scala/math/DoubleTest.scala
+++ b/test/junit/scala/math/DoubleTest.scala
@@ -1,5 +1,6 @@
 package scala.math
 
+import java.lang.Double.doubleToLongBits
 import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -10,13 +11,24 @@ class DoubleTest {
 
   /* Test for scala/bug#11386 */
   @Test
+  def tesDoubleSign: Unit = {
+    assertTrue(Double.NaN.sign.isNaN)
+    assertEquals(doubleToLongBits(1.0), doubleToLongBits(Double.MaxValue.sign))
+    assertEquals(doubleToLongBits(1.0), doubleToLongBits(Double.PositiveInfinity.sign))
+    assertEquals(doubleToLongBits(-1.0), doubleToLongBits(Double.MinValue.sign))
+    assertEquals(doubleToLongBits(-1.0), doubleToLongBits(Double.NegativeInfinity.sign))
+    assertEquals(doubleToLongBits(0.0), doubleToLongBits(0.0.sign))
+    assertEquals(doubleToLongBits(-0.0), doubleToLongBits(-0.0.sign))
+  }
+
+  @Test
   def tesDoubleSignum: Unit = {
-    assertTrue(Double.NaN.signum.isNaN)
-    assertEquals("1.0", Double.MaxValue.signum.toString)
-    assertEquals("1.0", Double.PositiveInfinity.signum.toString)
-    assertEquals("-1.0", Double.MinValue.signum.toString)
-    assertEquals("-1.0", Double.NegativeInfinity.signum.toString)
-    assertEquals("0.0", 0.0.signum.toString)
-    assertEquals("-0.0", -0.0.signum.toString)
+    assertEquals(0, Double.NaN.signum)
+    assertEquals(1, Double.MaxValue.signum)
+    assertEquals(1, Double.PositiveInfinity.signum)
+    assertEquals(-1, Double.MinValue.signum)
+    assertEquals(-1, Double.NegativeInfinity.signum)
+    assertEquals(0, 0.0.signum)
+    assertEquals(0, -0.0.signum)
   }
 }


### PR DESCRIPTION
Fixes scala/bug#11386
See also https://github.com/scala/scala/pull/7748

`Numeric#signum` currently returns Int, which does not handle NaN as reported in scala/bug#11386. Current behavior is inconsistent with Java's `java.lang.Math.signum(Double)`, which returns NaN for Nan, zero for zero, 1.0 for positive, -1.0 for negative. Interestingly, this is also inconsistent with `scala.math.signum(Double)`, which forwards to `java.lang.Math.signum(Double)`!

This changes `Numeric#signum` to return T. For `Int`, `Long`, `Float`, and `Double`, `Numeric#signum` will forward to `scala.math.signum(...)` of the corresponding types. For `Short`, `Byte`, and `Char` it will use `scala.math.signum(Int)` similar to the way `max` is implemented in `RichShort`.

```scala
Welcome to Scala 2.13.0-20190313-035618-c447d5a (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_171).
Type in expressions for evaluation. Or try :help.

scala> Double.NaN.signum
                  ^
       warning: method signum in class RichDouble is deprecated (since 2.13.0): signum does not handle -0.0 or Double.NaN; use `sign` method instead
res0: Int = 0

scala> Double.NaN.sign
res1: Double = NaN

scala> scala.math.signum(Double.NaN)
res2: Double = NaN
```
