### PR TITLE
Use invokedynamic to statically cache materialized class tags (initially disabled by default)

### DIFF
--- a/src/compiler/scala/reflect/reify/Taggers.scala
+++ b/src/compiler/scala/reflect/reify/Taggers.scala
@@ -44,7 +44,7 @@ abstract class Taggers {
     val tagModule = ClassTagModule
     materializeTag(EmptyTree, tpe, tagModule, {
       val erasure = c.reifyRuntimeClass(tpe, concrete = true)
-      val canUseIndy = erasure.isInstanceOf[Literal] && settings.YclassTagInvokeDynamic.value && Static_bootstrap != NoSymbol && !tpe.typeSymbol.isPrimitiveValueClass
+      val canUseIndy = erasure.isInstanceOf[Literal] && Static_bootstrap != NoSymbol && !tpe.typeSymbol.isPrimitiveValueClass
       if (canUseIndy) {
         // Emit an invokedynamic which will cache this context-independent classtag
         val resultType = appliedType(ClassTagClass, tpe :: Nil)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -132,7 +132,13 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
   }
 
   def bootstrapMethodArg(t: Constant, pos: Position): AnyRef = t match {
-    case Constant(mt: Type) => methodBTypeFromMethodType(transformedType(mt), isConstructor = false).toASMType
+    case Constant(tp: Type) =>
+      tp match {
+        case (_: NullaryMethodType | _: MethodType) =>
+          methodBTypeFromMethodType(transformedType(tp), isConstructor = false).toASMType
+        case _ =>
+          typeToBType(transformedType(tp)).toASMType
+      }
     case c @ Constant(sym: Symbol) => staticHandleFromSymbol(sym)
     case c @ Constant(value: String) => value
     case c @ Constant(value) if c.isNonUnitAnyVal => c.value.asInstanceOf[AnyRef]

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -213,12 +213,6 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
   def                     srBoxesRunTimeRef         : ClassBType = _srBoxesRunTimeRef.get
   private[this] lazy val _srBoxesRunTimeRef         : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[scala.runtime.BoxesRunTime]))
 
-  def                     srSymbolLiteral           : ClassBType = _srSymbolLiteral.get
-  private[this] lazy val _srSymbolLiteral           : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[scala.runtime.SymbolLiteral]))
-
-  def                     srStructuralCallSite      : ClassBType = _srStructuralCallSite.get
-  private[this] lazy val _srStructuralCallSite      : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[scala.runtime.StructuralCallSite]))
-
   def                     srLambdaDeserialize       : ClassBType = _srLambdaDeserialize.get
   private[this] lazy val _srLambdaDeserialize       : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[scala.runtime.LambdaDeserialize]))
 

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -257,7 +257,6 @@ trait ScalaSettings extends AbsScalaSettings
   val YdisableFlatCpCaching  = BooleanSetting    ("-YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
   val YcachePluginClassLoader  = CachePolicy.setting("plugin", "compiler plugins")
   val YcacheMacroClassLoader   = CachePolicy.setting("macro", "macros")
-  val YclassTagInvokeDynamic = BooleanSetting("-Yclass-tag-invoke-dynamic", "Cache class tags at call-sites using invokedynamic")
 
   val YmacroClasspath = PathSetting       ("-Ymacro-classpath", "The classpath used to reflectively load macro implementations, default is the compilation classpath.", "")
 

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -257,6 +257,7 @@ trait ScalaSettings extends AbsScalaSettings
   val YdisableFlatCpCaching  = BooleanSetting    ("-YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
   val YcachePluginClassLoader  = CachePolicy.setting("plugin", "compiler plugins")
   val YcacheMacroClassLoader   = CachePolicy.setting("macro", "macros")
+  val YclassTagInvokeDynamic = BooleanSetting("-Yclass-tag-invoke-dynamic", "Cache class tags at call-sites using invokedynamic")
 
   val YmacroClasspath = PathSetting       ("-Ymacro-classpath", "The classpath used to reflectively load macro implementations, default is the compilation classpath.", "")
 

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -1293,7 +1293,8 @@ abstract class Erasure extends InfoTransform
 
             treeCopy.Literal(cleanLiteral, Constant(erased))
           } else cleanLiteral
-
+        case ApplyDynamic(qual, (lit @ Literal(Constant(bootstrapMethodRef: Symbol))) :: args) =>
+          treeCopy.ApplyDynamic(tree, transform(qual), lit :: transformTrees(args))
         case ClassDef(_,_,_,_) =>
           debuglog("defs of " + tree.symbol + " = " + tree.symbol.info.decls)
           copyClassDef(tree)(tparams = Nil)
@@ -1349,8 +1350,8 @@ abstract class Erasure extends InfoTransform
 
               try super.transform(tree1).clearType()
               finally tpt setType specialErasure(tree1.symbol)(tree1.symbol.tpe).resultType
-            case ApplyDynamic(qual, Literal(Constant(bootstrapMethodRef: Symbol)) :: _) =>
-              tree
+            case ApplyDynamic(qual, (lit @ Literal(Constant(bootstrapMethodRef: Symbol))) :: args) =>
+              treeCopy.ApplyDynamic(tree, transform(qual), lit :: args).modifyType(scalaErasure(_))
             case _: Apply if tree1 ne tree =>
               /* some Apply trees get replaced (in `preEraseApply`) with one of
                * their subtrees, which needs to be `preErase`d in its entirety,

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5600,7 +5600,6 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       }
 
       def typedApplyDynamic(tree: ApplyDynamic) = {
-        assert(phase.erasedTypes)
         val qual1 = typed(tree.qual, AnyRefTpe)
         val args1 = tree.args mapConserve (arg => typed(arg, AnyRefTpe))
         treeCopy.ApplyDynamic(tree, qual1, args1) setType AnyRefTpe

--- a/src/library/scala/runtime/ClassTag.java
+++ b/src/library/scala/runtime/ClassTag.java
@@ -1,0 +1,49 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.runtime;
+
+import java.lang.invoke.*;
+
+public final class ClassTag {
+    private ClassTag() {
+    }
+
+    private static final MethodHandle CLASSTAG_APPLY;
+    private static final Class<?> CLASSTAG_CLASS;
+
+    static {
+        CLASSTAG_CLASS = lookupClass();
+        CLASSTAG_APPLY = lookupHandle();
+    }
+
+    private static Class<?> lookupClass() {
+        try {
+            return Class.forName("scala.reflect.ClassTag");
+        } catch (ClassNotFoundException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static MethodHandle lookupHandle() {
+        try {
+            return MethodHandles.lookup().findStatic(CLASSTAG_CLASS, "apply", MethodType.methodType(CLASSTAG_CLASS, Class.class));
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String invokedName, MethodType invokedType, Class<?> value) throws Throwable {
+        Object tagValue = CLASSTAG_APPLY.invokeWithArguments(value);
+        return new ConstantCallSite(MethodHandles.constant(CLASSTAG_CLASS, tagValue));
+    }
+}

--- a/src/library/scala/runtime/Static.java
+++ b/src/library/scala/runtime/Static.java
@@ -1,0 +1,25 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.runtime;
+
+import java.lang.invoke.*;
+
+public final class Static {
+    private Static() {
+    }
+
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String invokedName, MethodType invokedType, MethodHandle handle, Object... args) throws Throwable {
+        Object value = handle.invokeWithArguments(args);
+        return new ConstantCallSite(MethodHandles.constant(invokedType.returnType(), value));
+    }
+}

--- a/src/library/scala/runtime/StructuralCallSite.scala
+++ b/src/library/scala/runtime/StructuralCallSite.scala
@@ -39,6 +39,8 @@ final class StructuralCallSite private (callType: MethodType) {
 }
 
 object StructuralCallSite {
+  def apply(callType: MethodType) = new StructuralCallSite(callType)
+
   def bootstrap(lookup: MethodHandles.Lookup, invokedName: String, invokedType: MethodType, reflectiveCallType: MethodType): CallSite = {
     val structuralCallSite = new StructuralCallSite(reflectiveCallType)
     new ConstantCallSite(MethodHandles.constant(classOf[StructuralCallSite], structuralCallSite))

--- a/src/library/scala/runtime/SymbolLiteral.java
+++ b/src/library/scala/runtime/SymbolLiteral.java
@@ -18,9 +18,7 @@ public final class SymbolLiteral {
     private SymbolLiteral() {
     }
 
-    public static CallSite bootstrap(MethodHandles.Lookup lookup, String invokedName,
-                                     MethodType invokedType,
-                                     String value) throws Throwable {
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String invokedName, MethodType invokedType, String value) throws Throwable {
         ClassLoader classLoader = lookup.lookupClass().getClassLoader();
         MethodType type = MethodType.fromMethodDescriptorString("(Ljava/lang/String;)Lscala/Symbol;", classLoader);
         Class<?> symbolClass = Class.forName("scala.Symbol", false, classLoader);

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -499,15 +499,13 @@ trait Definitions extends api.StandardDefinitions {
       def methodCache_find          = getMemberMethod(MethodCacheClass, nme.find_)
       def methodCache_add           = getMemberMethod(MethodCacheClass, nme.add_)
     lazy val StructuralCallSite     = getClassIfDefined("scala.runtime.StructuralCallSite")
-      def StructuralCallSite_bootstrap = getMemberMethod(StructuralCallSite.linkedClassOfClass, sn.Bootstrap)
-    // Marker for invokedynamic runtime.StructuralCall.bootstrap
-    lazy val StructuralCallSite_dummy = NoSymbol.newMethodSymbol(nme.apply).setInfo(NullaryMethodType(StructuralCallSite.tpe))
       def StructuralCallSite_find              = getMemberIfDefined(StructuralCallSite, nme.find_)
       def StructuralCallSite_add               = getMemberIfDefined(StructuralCallSite, nme.add_)
       def StructuralCallSite_getParameterTypes = getMemberIfDefined(StructuralCallSite, nme.parameterTypes)
     lazy val SymbolLiteral        = getClassIfDefined("scala.runtime.SymbolLiteral")
-      def SymbolLiteral_bootstrap = getMemberIfDefined(SymbolLiteral.linkedClassOfClass, sn.Bootstrap)
-      def SymbolLiteral_dummy     = NoSymbol.newMethodSymbol(nme.apply).setInfo(NullaryMethodType(SymbolModule.companionClass.tpe))
+    lazy val Static        = getClassIfDefined("scala.runtime.Static")
+      def Static_bootstrap = getMemberIfDefined(Static.linkedClassOfClass, sn.Bootstrap)
+      def Static_dummy(tpe: Type)    = NoSymbol.newTermSymbol(nme.apply).setInfo(NullaryMethodType(tpe))
 
     // XML
     lazy val ScalaXmlTopScope = getModuleIfDefined("scala.xml.TopScope")

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -308,8 +308,8 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.EmptyMethodCacheClass
     definitions.MethodCacheClass
     definitions.StructuralCallSite
-    definitions.StructuralCallSite_dummy
     definitions.SymbolLiteral
+    definitions.Static
     definitions.ScalaXmlTopScope
     definitions.ScalaXmlPackage
     definitions.ReflectPackage

--- a/test/files/run/class-tag-indy.scala
+++ b/test/files/run/class-tag-indy.scala
@@ -1,5 +1,3 @@
-// scalac: -Yclass-tag-invoke-dynamic
-//
 import reflect.ClassTag
 
 object Test {

--- a/test/files/run/class-tag-indy.scala
+++ b/test/files/run/class-tag-indy.scala
@@ -1,0 +1,18 @@
+// scalac: -Yclass-tag-invoke-dynamic
+//
+import reflect.ClassTag
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    // check that the invokedynamic bootstrap caches the classtag 
+    // from the first invocation of `cache`.
+    assert(cache eq cache)
+    assert(dontCache ne dontCache)
+  }
+
+  def cache = implicitly[ClassTag[SomeClass]]
+
+  def dontCache[A: ClassTag] = implicitly[ClassTag[Array[A]]]
+}
+
+class SomeClass

--- a/test/files/run/t7974.check
+++ b/test/files/run/t7974.check
@@ -4,8 +4,10 @@ warning: there were four deprecation warnings (since 2.13.0); re-run with -depre
   public someSymbol1()Lscala/Symbol;
     INVOKEDYNAMIC apply()Lscala/Symbol; [
       // handle kind 0x6 : INVOKESTATIC
-      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      scala/runtime/Static.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;
       // arguments:
+      // handle kind 0x6 : INVOKESTATIC
+      scala/Symbol.apply(Ljava/lang/String;)Lscala/Symbol;, 
       "Symbolic1"
     ]
     ARETURN
@@ -17,8 +19,10 @@ warning: there were four deprecation warnings (since 2.13.0); re-run with -depre
   public someSymbol2()Lscala/Symbol;
     INVOKEDYNAMIC apply()Lscala/Symbol; [
       // handle kind 0x6 : INVOKESTATIC
-      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      scala/runtime/Static.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;
       // arguments:
+      // handle kind 0x6 : INVOKESTATIC
+      scala/Symbol.apply(Ljava/lang/String;)Lscala/Symbol;, 
       "Symbolic2"
     ]
     ARETURN
@@ -30,8 +34,10 @@ warning: there were four deprecation warnings (since 2.13.0); re-run with -depre
   public sameSymbol1()Lscala/Symbol;
     INVOKEDYNAMIC apply()Lscala/Symbol; [
       // handle kind 0x6 : INVOKESTATIC
-      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      scala/runtime/Static.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;
       // arguments:
+      // handle kind 0x6 : INVOKESTATIC
+      scala/Symbol.apply(Ljava/lang/String;)Lscala/Symbol;, 
       "Symbolic1"
     ]
     ARETURN
@@ -55,8 +61,10 @@ warning: there were four deprecation warnings (since 2.13.0); re-run with -depre
     ALOAD 0
     INVOKEDYNAMIC apply()Lscala/Symbol; [
       // handle kind 0x6 : INVOKESTATIC
-      scala/runtime/SymbolLiteral.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      scala/runtime/Static.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;
       // arguments:
+      // handle kind 0x6 : INVOKESTATIC
+      scala/Symbol.apply(Ljava/lang/String;)Lscala/Symbol;, 
       "Symbolic3"
     ]
     PUTFIELD Symbols.someSymbol3 : Lscala/Symbol;


### PR DESCRIPTION
During compiler profiling, I've found cases where the repeated allocation 
of `s.r.ClassTags` (a wrapper over j.l.Class) contributed to allocation 
pressure.

This commit introduces a static cache at the materialization site using
invokedynamic. This is analagous to the way we cache Symbol literals.