### PR TITLE
REPL tab completion: skip deprecated things until double-tab

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
@@ -163,9 +163,17 @@ trait PresentationCompilation { self: IMain =>
               case t: TypeMember if t.implicitlyAdded && t.viaView.info.params.head.info.bounds.isEmptyBounds => true
               case _ => false
             }
+            def isDeprecated(m: Member) = m match {
+              case tm: TypeMember if tm.viaView.isDeprecated || tm.viaView != NoSymbol && tm.viaView.owner.isDeprecated || !m.sym.exists =>
+                true
+              case _ =>
+                m.sym.isDeprecated ||
+                m.sym.hasGetter && m.sym.getterIn(m.sym.owner).isDeprecated
+            }
             (
               isUniversal && nme.isReplWrapperName(m.prefix.typeSymbol.name)
                 || isUniversal && tabCount == 0 && r.name.isEmpty
+                || isDeprecated(m) && tabCount == 0
                 || viaUniversalExtensionMethod && tabCount == 0 && r.name.isEmpty
               )
           }


### PR DESCRIPTION
motivation: it's a good change in general, I believe.

but also, this is motivated by all the new deprecations in 2.13. lots of people are trying out the new collections API; some of them will be doing it in the REPL; let's not confuse those people and make our API look bad by offering them deprecated completions

~~this is still a draft because although a lot of things work already, there are a couple commented-out test cases that fail that I'd like to attempt to fix as well (UPDATE: one of them was scala/bug#10152 rather than something I did wrong)~~

~~also I might still decide to target 2.12.x instead. I can't add `isDeprecated` to `api.Symbol` there, but that's nbd~~ nah