### PR TITLE
add first element of empty queue to out list / return explicit empty queue

### DIFF
--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -141,7 +141,10 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
     *
     *  @param  iter        an iterable object
     */
-  def enqueueAll[B >: A](iter: scala.collection.Iterable[B]) = new Queue(iter.toList reverse_::: in, out)
+  def enqueueAll[B >: A](iter: scala.collection.Iterable[B]) =
+    if (isEmpty) new Queue(in, iter.toList ::: out)
+    else  new Queue(iter.toList reverse_::: in, out)
+
 
   /** Returns a tuple with the first element in the queue,
     *  and a new queue with this element removed.

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -118,7 +118,9 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
     *
     *  @param  elem        the element to insert
     */
-  def enqueue[B >: A](elem: B): Queue[B] = new Queue(elem :: in, out)
+  def enqueue[B >: A](elem: B): Queue[B] =
+    if (isEmpty) new Queue(Nil, out :+ elem)
+    else new Queue(elem :: in, out)
 
   /** Creates a new queue with all elements provided by an `Iterable` object
     *  added at the end of the old queue.
@@ -148,7 +150,10 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
     *  @return the first element of the queue.
     */
   def dequeue: (A, Queue[A]) = out match {
-    case Nil if !in.isEmpty => val rev = in.reverse ; (rev.head, new Queue(Nil, rev.tail))
+    case Nil if !in.isEmpty => in match {
+      case x :: Nil => (x, new Queue(Nil, Nil))
+      case _ => val rev = in.reverse ; (rev.head, new Queue(Nil, rev.tail))
+    }
     case x :: xs            => (x, new Queue(in, xs))
     case _                  => throw new NoSuchElementException("dequeue on empty queue")
   }

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -142,7 +142,7 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
     *  @param  iter        an iterable object
     */
   def enqueueAll[B >: A](iter: scala.collection.Iterable[B]) =
-    if (isEmpty) new Queue(in, iter.toList ::: out)
+    if (isEmpty) new Queue(Nil, iter.toList)
     else  new Queue(iter.toList reverse_::: in, out)
 
 


### PR DESCRIPTION
…ue if last element is dequeued

This is response to the request of optimization found here: https://github.com/scala/bug/issues/11396?fbclid=IwAR1IOb9kbA447CCGeH7UdIzW8S76xt99fcMAp9qNFXBMuyUbYzaA3FpgjlE

"immutable.Queue's methods should be optimised so that when dequeueing elements, it does not leave out empty (unless in is also empty), and when enqueueing elements, it puts at least one element in out if both in and out are empty (although once you're checking, might as well put everything in out)."