### PR TITLE
Submerge the Variance extractor function into the solve functions.

### DIFF
--- a/src/compiler/scala/reflect/macros/compiler/Validators.scala
+++ b/src/compiler/scala/reflect/macros/compiler/Validators.scala
@@ -72,7 +72,7 @@ trait Validators {
         checkMacroImplResultTypeMismatch(atpeToRtpe(aret), rret)
 
         val maxLubDepth = lubDepth(aparamss.flatten map (_.tpe)) max lubDepth(rparamss.flatten map (_.tpe))
-        val atargs = solvedTypes(atvars, atparams, atparams map varianceInType(aret), upper = false, maxLubDepth)
+        val atargs = solvedTypes(atvars, atparams, varianceInType(aret), upper = false, maxLubDepth)
         val boundsOk = typer.silent(_.infer.checkBounds(macroDdef, NoPrefix, NoSymbol, atparams, atargs, ""))
         boundsOk match {
           case SilentResultValue(true) => // do nothing, success

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -598,7 +598,7 @@ trait Implicits {
                 if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(matchesPtInstMismatch1)
                 false
               } else {
-                val targs = solvedTypes(tvars, allUndetparams, allUndetparams map varianceInType(wildPt), upper = false, lubDepth(tpInstantiated :: wildPt :: Nil))
+                val targs = solvedTypes(tvars, allUndetparams, varianceInType(wildPt), upper = false, lubDepth(tpInstantiated :: wildPt :: Nil))
                 val adjusted = adjustTypeArgs(allUndetparams, tvars, targs)
                 val tpSubst = deriveTypeWithWildcards(adjusted.undetParams)(tp.instantiateTypeParams(adjusted.okParams, adjusted.okArgs))
                 if(!matchesPt(tpSubst, wildPt, adjusted.undetParams)) {
@@ -796,7 +796,7 @@ trait Implicits {
             if (tvars.nonEmpty)
               typingLog("solve", ptLine("tvars" -> tvars, "tvars.constr" -> tvars.map(_.constr)))
 
-            val targs = solvedTypes(tvars, undetParams, undetParams map varianceInType(pt), upper = false, lubDepth(itree3.tpe :: pt :: Nil))
+            val targs = solvedTypes(tvars, undetParams, varianceInType(pt), upper = false, lubDepth(itree3.tpe :: pt :: Nil))
 
             // #2421: check that we correctly instantiated type parameters outside of the implicit tree:
             checkBounds(itree3, NoPrefix, NoSymbol, undetParams, targs, "inferred ")

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2930,10 +2930,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               // use function type subtyping, not method type subtyping (the latter is invariant in argument types)
               fun.tpe <:< functionType(samInfoWithTVars.paramTypes, samInfoWithTVars.finalResultType)
 
-              val variances = tparams map varianceInType(sam.info)
-
               // solve constraints tracked by tvars
-              val targs = solvedTypes(tvars, tparams, variances, upper = false, lubDepth(sam.info :: Nil))
+              val targs = solvedTypes(tvars, tparams, varianceInType(sam.info), upper = false, lubDepth(sam.info :: Nil))
 
               debuglog(s"sam infer: $pt --> ${appliedType(samTyCon, targs)} by ${fun.tpe} <:< $samInfoWithTVars --> $targs for $tparams")
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2871,7 +2871,7 @@ trait Types
       val tvars = quantifiedFresh map (tparam => TypeVar(tparam))
       val underlying1 = underlying.instantiateTypeParams(quantified, tvars) // fuse subst quantified -> quantifiedFresh -> tvars
       op(underlying1) && {
-        solve(tvars, quantifiedFresh, quantifiedFresh map (_ => Invariant), upper = false, depth) &&
+        solve(tvars, quantifiedFresh, (_ => Invariant), upper = false, depth) &&
         isWithinBounds(NoPrefix, NoSymbol, quantifiedFresh, tvars map (_.inst))
       }
     }

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -197,7 +197,7 @@ trait Collections {
     xss.isEmpty || xss.head.isEmpty && flattensToEmpty(xss.tail)
   }
 
-  final def foreachWithIndex[A, B](xs: List[A])(f: (A, Int) => Unit) {
+  final def foreachWithIndex[A](xs: List[A])(f: (A, Int) => Unit) {
     var index = 0
     var ys = xs
     while (!ys.isEmpty) {


### PR DESCRIPTION
In the `solvedTypes` and the `solve` functions, there is a third parameter to give the specific variances, in the context of the resolution, of each parameter which goes in the second parameter.
In fact, this `variances` list is always a `map` of a function, which is different in each call, on the second list of symbols.

We replace the third parameter from being the list of variances to being the function that is used to get that third list, and thus merge the application of that list in each step of the foreach. This has these benefits:

- We avoid allocating the list of variances, particularly for the case in which we are just using a constant function to Invariant.
- By using a `Variance.Extractor` instead of a `Function1`, as required by the `List.map` function, we can avoid allocations of Variance objects, and use instead the underlying integer value.

There could be a small performance prejudice: the double-nested loop of the solve method could compute the variances up to N times.