### PR TITLE
[nomerge] Backport performance changes from the 2.13 branch

### DIFF
--- a/src/compiler/scala/tools/nsc/SubComponent.scala
+++ b/src/compiler/scala/tools/nsc/SubComponent.scala
@@ -70,10 +70,10 @@ abstract class SubComponent {
 
   /** The phase corresponding to this subcomponent in the current compiler run */
   def ownPhase: Phase = {
-    ownPhaseCache.get match {
-      case Some(phase) if ownPhaseRunId == global.currentRunId =>
-        phase
-      case _ =>
+    val cache = ownPhaseCache.underlying.get
+    if (cache != null && ownPhaseRunId == global.currentRunId)
+      cache
+    else {
         val phase = global.currentRun.phaseNamed(phaseName)
         ownPhaseCache = new WeakReference(phase)
         ownPhaseRunId = global.currentRunId

--- a/src/reflect/scala/reflect/internal/Depth.scala
+++ b/src/reflect/scala/reflect/internal/Depth.scala
@@ -31,6 +31,8 @@ final class Depth private (val depth: Int) extends AnyVal with Ordered[Depth] {
   override def toString = s"Depth($depth)"
 }
 
+trait DepthFunction[A] { def apply(a: A): Depth }
+
 object Depth {
   // A don't care value for the depth parameter in lubs/glbs and related operations.
   // When passed this value, the recursion budget will be inferred from the shape of
@@ -48,5 +50,15 @@ object Depth {
   @inline final def apply(depth: Int): Depth = {
     if (depth < AnyDepthValue) AnyDepth
     else new Depth(depth)
+  }
+
+  def maximumBy[A](xs: List[A])(ff: DepthFunction[A]): Depth = {
+    var ys: List[A] = xs
+    var mm: Depth = Zero
+    while (!ys.isEmpty){
+      mm = mm max ff(ys.head)
+      ys = ys.tail
+    }
+    mm
   }
 }

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4591,10 +4591,10 @@ trait Types
               NoType  // something is wrong: an array without a type arg.
             }
             else {
-              val args = argss map (_.head)
-              if (args.tail forall (_ =:= args.head)) typeRef(pre, sym, List(args.head))
-              else if (args exists (arg => isPrimitiveValueClass(arg.typeSymbol))) ObjectTpe
-              else typeRef(pre, sym, List(lub(args)))
+              val argH = argss.head.head
+              if (argss.tail forall (_.head =:= argH)) typeRef(pre, sym, List(argH))
+              else if (argss exists (args => isPrimitiveValueClass(args.head.typeSymbol))) ObjectTpe
+              else typeRef(pre, sym, List(lub(argss.map(_.head))))
             }
           }
           else transposeSafe(argss) match {

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3028,8 +3028,6 @@ trait Types
   ) extends TypeVar(_origin, _constr) {
     require(params.nonEmpty && sameLength(params, typeArgs), this)
     override def safeToString: String = super.safeToString + typeArgs.map(_.safeToString).mkString("[", ", ", "]")
-    override def setInst(tp: Type): this.type =
-      super.setInst(if (isSubArgs(typeArgs, tp.typeArgs, params, Depth.AnyDepth)) tp.typeConstructor else NoType)
   }
 
   trait UntouchableTypeVar extends TypeVar {

--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -277,12 +277,12 @@ private[internal] trait GlbLubs {
         // the type constructor of the calculated lub instead.  This
         // is because lubbing type constructors tends to result in types
         // which have been applied to dummies or Nothing.
-        ts.map(_.typeParams.size).distinct match {
-          case x :: Nil if res.typeParams.size != x =>
-            logResult(s"Stripping type args from lub because $res is not consistent with $ts")(res.typeConstructor)
-          case _                                    =>
-            res
-        }
+        val rtps = res.typeParams.size
+        val hs = ts.head.typeParams.size
+        if (hs != rtps && ts.forall(_.typeParams.size == hs))
+          logResult(s"Stripping type args from lub because $res is not consistent with $ts")(res.typeConstructor)
+        else
+          res
       }
       finally {
         lubResults.clear()

--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -113,7 +113,8 @@ private[internal] trait GlbLubs {
     var lubListDepth = Depth.Zero
     // This catches some recursive situations which would otherwise
     // befuddle us, e.g. pos/hklub0.scala
-    def isHotForTs(xs: List[Type]) = ts exists (_.typeParams == xs.map(_.typeSymbol))
+    def isHotForT(tyPar: Symbol, x: Type): Boolean = tyPar eq x.typeSymbol
+    def isHotForTs(xs: List[Type]) = ts.exists(_.typeParams.corresponds(xs)(isHotForT(_,_)))
 
     def elimHigherOrderTypeParam(tp: Type) = tp match {
       case TypeRef(_, _, args) if args.nonEmpty && isHotForTs(args) =>

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -408,15 +408,13 @@ private[internal] trait TypeMaps {
       val tp1 = mapOver(tp)
       if (variance.isInvariant) tp1
       else tp1 match {
-        case TypeRef(pre, sym, args) if tparams contains sym =>
+        case TypeRef(pre, sym, args) if tparams.contains(sym) && occurCount(sym) == 1 =>
           val repl = if (variance.isPositive) dropSingletonType(tp1.upperBound) else tp1.lowerBound
-          val count = occurCount(sym)
-          val containsTypeParam = tparams exists (repl contains _)
           def msg = {
             val word = if (variance.isPositive) "upper" else "lower"
             s"Widened lone occurrence of $tp1 inside existential to $word bound"
           }
-          if (!repl.typeSymbol.isBottomClass && count == 1 && !containsTypeParam)
+          if (!repl.typeSymbol.isBottomClass && !tparams.exists(repl.contains))
             debuglogResult(msg)(repl)
           else
             tp1

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -350,6 +350,24 @@ trait Collections {
       Some(result.toList)
     }
 
+  final def bitSetByPredicate[A](xs: List[A])(pred: A => Boolean): mutable.BitSet = {
+    val bs = new mutable.BitSet()
+    var ys = xs
+    var i: Int = 0
+    while (! ys.isEmpty){
+      if (pred(ys.head))
+        bs.add(i)
+      ys = ys.tail
+      i += 1
+    }
+    bs
+  }
+
+  final def sequence[A](as: List[Option[A]]): Option[List[A]] = {
+    if (as.exists (_.isEmpty)) None
+    else Some(as.flatten)
+  }
+
   final def transposeSafe[A](ass: List[List[A]]): Option[List[List[A]]] = try {
     Some(ass.transpose)
   } catch {


### PR DESCRIPTION
- https://github.com/scala/scala/pull/7211 Inline WeakReference get method
- https://github.com/scala/scala/pull/7228 Replace a list of booleans by a mutable BitSet
- https://github.com/scala/scala/pull/7233 Avoid List.map when computing maximum over list.
- https://github.com/scala/scala/pull/7258 Bring test forward.
- https://github.com/scala/scala/pull/7292 Avoid `map` list in `mergePrefixAndArgs`
- https://github.com/scala/scala/pull/7592 Avoid zipping params-typevars in `AppliedTypeVar` (by @joroKr21 )
- https://github.com/scala/scala/pull/7655: In `GlbLubs`, replace a `map` with a `distinct` by a singleton match with a `forall` over the tail of the list to compares with the head.  
- https://github.com/scala/scala/pull/7789, together with its appendix https://github.com/scala/scala/pull/7793: fold a `map` into the exists, the list creation with a disjunction, and extract a list of top types.

**NOTE** Some of these PRs are those that I made directly to `2.13.x`, unaware that they could also be targeted first to the `2.12.x` branch. However, are there any other PRs that I may add? Is there a method for recognising those? 

**NOTE** Of these performance changes, the only that I have some small doubt is the 7592, since it modifies the constructor class of the `AppliedTypeVar` class. However, this is an internal class. Would that be a problem?