### PR TITLE
Make scala.util.Using.Releasable be an alias to java.lang.AutoCloseable

### DIFF
--- a/src/library/scala/util/Using.scala
+++ b/src/library/scala/util/Using.scala
@@ -379,7 +379,9 @@ object Using {
 
   object Releasable {
     /** An implicit `Releasable` for [[java.lang.AutoCloseable `AutoCloseable`s]]. */
-    implicit val autoCloseableIsReleasable: Releasable[AutoCloseable] = (resource: AutoCloseable) => resource.close()
+    implicit object AutoCloseableIsReleasable extends Releasable[AutoCloseable] {
+      def release(resource: AutoCloseable): Unit = resource.close()
+    }
   }
 
 }


### PR DESCRIPTION
We don't gain anything by providing an extra indirection layer.
AutoCloseable has 1-to-1 the same functionality and intent as
newly added scala.util.Using.Releasable.