### PR TITLE
Infer - Remove intermediate lists and functions.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -599,7 +599,7 @@ trait Implicits {
                 false
               } else {
                 val targs = solvedTypes(tvars, allUndetparams, allUndetparams map varianceInType(wildPt), upper = false, lubDepth(tpInstantiated :: wildPt :: Nil))
-                val AdjustedTypeArgs(okParams, okArgs) = adjustTypeArgs(allUndetparams, tvars, targs)
+                val (okParams, okArgs) = AdjustedTypeArgs.split(adjustTypeArgs(allUndetparams, tvars, targs))
                 val remainingUndet = allUndetparams diff okParams
                 val tpSubst = deriveTypeWithWildcards(remainingUndet)(tp.instantiateTypeParams(okParams, okArgs))
                 if(!matchesPt(tpSubst, wildPt, remainingUndet)) {
@@ -820,7 +820,7 @@ trait Implicits {
             // filter out failures from type inference, don't want to remove them from undetParams!
             // we must be conservative in leaving type params in undetparams
             // prototype == WildcardType: want to remove all inferred Nothings
-            val AdjustedTypeArgs(okParams, okArgs) = adjustTypeArgs(undetParams, tvars, targs)
+            val (okParams, okArgs) = AdjustedTypeArgs.split(adjustTypeArgs(undetParams, tvars, targs))
 
             val subst: TreeTypeSubstituter =
               if (okParams.isEmpty) EmptyTreeTypeSubstituter


### PR DESCRIPTION
The `Infer` file uses several functions to break up a result (a mutable map from symbols to types) into separate lists, of symbols matched or not matched to types (keys), and types they were matched to, etc. These functions are provided as "unapply" functions of some objects, to be used in a pattern-match fashion. The implementations of these functions were using some combinations of List operations like `collect`, `partition`, or `HashMap.map`, that were generating some intermediate lists or collections that are not used afterwards. 

This commit, removes those and reimplements each function as a `foreach` loop that builds those lists on mutable buffers. 