### PR TITLE
Infer: replace List reverse by ListBuffer

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -346,10 +346,12 @@ trait Infer extends Checkable {
      *  by existentially bound variables.
      */
     def makeFullyDefined(tp: Type): Type = {
-      var tparams: List[Symbol] = Nil
+      var tparams_ : ListBuffer[Symbol] = null
+      def tparams: ListBuffer[Symbol] = { if (tparams_ == null) tparams_ = ListBuffer.empty ; tparams_ }
+      def tparamsList: List[Symbol] = if (tparams_ == null) Nil else tparams_.toList
       def addTypeParam(bounds: TypeBounds): Type = {
         val tparam = context.owner.newExistential(newTypeName("_"+tparams.size), context.tree.pos.focus) setInfo bounds
-        tparams ::= tparam
+        tparams += tparam
         tparam.tpe
       }
       val tp1 = tp map {
@@ -358,7 +360,7 @@ trait Infer extends Checkable {
         case t                           => t
       }
       if (tp eq tp1) tp
-      else existentialAbstraction(tparams.reverse, tp1)
+      else existentialAbstraction(tparamsList, tp1)
     }
     def ensureFullyDefined(tp: Type): Type = if (isFullyDefined(tp)) tp else makeFullyDefined(tp)
 

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -512,6 +512,10 @@ trait StdNames {
     /** The name of a setter for protected symbols. Used for inherited Java fields. */
     def protSetterName(name: Name): TermName = newTermName(PROTECTED_SET_PREFIX + name)
 
+    private[this] val existentialNames = (0 to 22).map(existentialName0)
+    private def existentialName0(i: Int) = newTypeName("_" + i)
+    final def existentialName(i: Int): TypeName = if (i < existentialNames.length) existentialNames(i) else existentialName0(i)
+
     final val Nil: NameType                 = "Nil"
     final val Predef: NameType              = "Predef"
 


### PR DESCRIPTION
In the `makeFullyDefined` method of the Infer file, instead of building a List by appending each element and then reversing the list, which builds (allocates) 2 lists, we now use a ListBuffer
and append in the right order, so we only allocate one list.