### PR TITLE
Fixes for Dotty compatibility

### DIFF
--- a/project/DottySupport.scala
+++ b/project/DottySupport.scala
@@ -13,7 +13,7 @@ import sbt.librarymanagement.{
  *  Dotty in .travis.yml.
  */
 object DottySupport {
-  val dottyVersion = "0.14.0-bin-20190226-afc03c9-NIGHTLY"
+  val dottyVersion = "0.14.0-bin-20190320-b213f24-NIGHTLY"
   val compileWithDotty: Boolean =
     Option(System.getProperty("scala.build.compileWithDotty")).map(_.toBoolean).getOrElse(false)
   lazy val commonSettings = Seq(

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -530,7 +530,6 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     private[this] var nextElementDefined: Boolean = false
     private[this] var nextElement: A = _
 
-    @tailrec
     def hasNext: Boolean = nextElementDefined || (self.hasNext && {
       val a = self.next()
       if (traversedValues.add(f(a))) {

--- a/src/library/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/src/library/scala/collection/mutable/CollisionProofHashMap.scala
@@ -15,6 +15,7 @@ package mutable
 
 import scala.annotation.meta.{getter, setter}
 import scala.annotation.tailrec
+import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.generic.DefaultSerializationProxy
 import scala.collection.mutable
 import scala.runtime.Statics
@@ -62,6 +63,11 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
   }
 
   @`inline` private[this] final def index(hash: Int) = hash & (table.length - 1)
+
+  override protected def fromSpecific(coll: IterableOnce[(K, V)] @uncheckedVariance): CollisionProofHashMap[K, V] @uncheckedVariance = CollisionProofHashMap.from(coll)
+  override protected def newSpecificBuilder: Builder[(K, V), CollisionProofHashMap[K, V]] @uncheckedVariance = CollisionProofHashMap.newBuilder[K, V]
+
+  override def empty: CollisionProofHashMap[K, V] = new CollisionProofHashMap[K, V]
 
   override def contains(key: K): Boolean = findNode(key) ne null
 

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -194,7 +194,7 @@ object TreeSet extends SortedIterableFactory[TreeSet] {
         new TreeSet[E](RB.fromOrderedKeys(ss.iterator, ss.size))
       case r: Range if (ordering eq Ordering.Int) || (ordering eq Ordering.Int.reverse) =>
         val it = if((ordering eq Ordering.Int) == (r.step > 0)) r.iterator else r.reverseIterator
-        new TreeSet[E](RB.fromOrderedKeys(it, r.size))
+        new TreeSet[E](RB.fromOrderedKeys(it.asInstanceOf[Iterator[E]], r.size))
       case _ =>
         val t: RB.Tree[E, Null] = RB.Tree.empty
         val i = it.iterator


### PR DESCRIPTION
- `CollisionProofHashMap` was missing overrides for `fromSpecific` and
  `newSpecificBuilder`
- `TreeSet.from` exploited a GADT unsoundness in scalac