### PR TITLE
Add Shrinking to ArrayBuffer

### DIFF
--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -358,4 +358,14 @@ class ArrayBufferTest {
     a.sortInPlace
     assertEquals(List(3,4,5), a)
   }
+
+  @Test def shrinkToSize: Unit = {
+    val b = ArrayBuffer(1,2,3)
+    assertEquals(8, b.array.length)
+    b ++= (1 to 1000)
+    assertEquals(1024, b.array.length)
+    b.remove(200, 803)
+    b.shrinkToSize()
+    assertEquals(256, b.array.length)
+  }
 }


### PR DESCRIPTION
Updated version of https://github.com/scala/scala/pull/7658

- Remove `RefArrayUtils.nullElems` (`Arrays.fill` does the same) and move the other methods into the `ArrayBuffer` companion objects with `private` visibility.

- Simplify the shrinking a bit and add support for shrinking down from `Int.MaxValue`.

- Add a unit test

- Fix `ArrayBuffer.from` to respect the minimum size. It still doesn't extend to the next power of 2 and I'm not sure if it should so I'll leave that open for now.