### PR TITLE
RHS of var def is an expr

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2675,7 +2675,7 @@ self =>
         } else {
           accept(EQUALS)
           expr() match {
-            case x if !tp.isEmpty && newmods.isMutable && lhs.toList.forall(_.isInstanceOf[Ident]) && isWildcard(x) =>
+            case x if !tp.isEmpty && newmods.isMutable && lhs.forall(_.isInstanceOf[Ident]) && isWildcard(x) =>
               tp match {
                 case SingletonTypeTree(Literal(Constant(_))) =>
                   syntaxError(tp.pos, "default initialization prohibited for literal-typed vars", skipIt = false)

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2669,24 +2669,23 @@ self =>
       val lhs = commaSeparated(stripParens(noSeq.pattern2()))
       val tp = typedOpt()
       val rhs =
-        if (tp.isEmpty || in.token == EQUALS) {
-          accept(EQUALS)
-          if (!tp.isEmpty && newmods.isMutable &&
-              (lhs.toList forall (_.isInstanceOf[Ident])) && in.token == USCORE) {
-            in.nextToken()
-            tp match {
-              case SingletonTypeTree(Literal(Constant(_))) =>
-                syntaxError(tp.pos, "default initialization prohibited for literal-typed vars", skipIt = false)
-              case _ =>
-            }
-            newmods = newmods | Flags.DEFAULTINIT
-            EmptyTree
-          } else {
-            expr()
-          }
-        } else {
+        if (!tp.isEmpty && in.token != EQUALS) {
           newmods = newmods | Flags.DEFERRED
           EmptyTree
+        } else {
+          accept(EQUALS)
+          expr() match {
+            case x if !tp.isEmpty && newmods.isMutable && lhs.toList.forall(_.isInstanceOf[Ident]) && isWildcard(x) =>
+              tp match {
+                case SingletonTypeTree(Literal(Constant(_))) =>
+                  syntaxError(tp.pos, "default initialization prohibited for literal-typed vars", skipIt = false)
+                case _ =>
+              }
+              placeholderParams = placeholderParams.tail
+              newmods = newmods | Flags.DEFAULTINIT
+              EmptyTree
+            case x => x
+          }
         }
       def mkDefs(p: Tree, tp: Tree, rhs: Tree): List[Tree] = {
         val trees = {

--- a/test/files/pos/t11437.scala
+++ b/test/files/pos/t11437.scala
@@ -1,0 +1,6 @@
+
+trait T {
+  val adder0: Int => Int = _ + 3   // Works fine
+  var adder1: Int => Int = (_ + 3) // Works fine
+  var adder2: Int => Int = _ + 3   // was: Error
+}


### PR DESCRIPTION
Previously too much was assumed from leading underscore.

Fixes scala/bug#11437