### PR TITLE
Don't give unhelpful unemptiness advice.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -30,6 +30,7 @@ Eugene Burmako <xeno.by@gmail.com> <burmako@epfl.ch>
 Eugene Vigdorchik <eugenevigdorchik@epfl.ch> <eugene.vigdorchik@gmail.com>
 François Garillot <francois@garillot.net>
 Geoff Reedy <geoff@programmer-monk.net> <gereedy@sandia.gov>
+Harrison Houghton <hora.rhino@gmail.com> <hhoughton@learningobjects.com>
 Ilya Sergei <ilyas@epfl.ch>
 Ingo Maier <ingo.maier@epfl.ch>
 Ingo Maier <ingo.maier@epfl.ch> <ingoem@gmail.com>

--- a/src/intellij/scala.ipr.SAMPLE
+++ b/src/intellij/scala.ipr.SAMPLE
@@ -18,7 +18,8 @@
   </component>
   <component name="InspectionProjectProfileManager">
     <profile version="1.0">
-      <option name="myName" value="Project Default" />
+      <option value="Project Default" name="myName"/>
+      <inspection_tool enabled_by_default="false" level="WARNING" enabled="false" class="EmptyCheck"/>
     </profile>
     <version value="1.0" />
   </component>


### PR DESCRIPTION
As we've recently learned, sometimes `!isEmpty` is simply better than `nonEmpty`, performance-wise. Thus, let IntelliJ not bring the yellow highlight of shame down upon us for using it.