### PR TITLE
Add a generic bootstrap method for future use

### DIFF
--- a/src/library/scala/runtime/Static.java
+++ b/src/library/scala/runtime/Static.java
@@ -1,0 +1,25 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.runtime;
+
+import java.lang.invoke.*;
+
+public final class Static {
+    private Static() {
+    }
+
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String invokedName, MethodType invokedType, MethodHandle handle, Object... args) throws Throwable {
+        Object value = handle.invokeWithArguments(args);
+        return new ConstantCallSite(MethodHandles.constant(invokedType.returnType(), value));
+    }
+}


### PR DESCRIPTION
I plan to use this in place of `SymbolLiteral.bootstrap` and
`StructuralCallSite.bootstrap`.

It will also support future use cases for per-callsite constants
built atop invokedynamic, such as `ClassTag`s or regular expressions.