### PR TITLE
Refactor adjustTypeArgs, giving its result record a name

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -599,9 +599,9 @@ trait Implicits {
                 false
               } else {
                 val targs = solvedTypes(tvars, allUndetparams, allUndetparams map varianceInType(wildPt), upper = false, lubDepth(tpInstantiated :: wildPt :: Nil))
-                val AdjustedTypeArgs(okParams, okArgs) = adjustTypeArgs(allUndetparams, tvars, targs)
-                val remainingUndet = allUndetparams diff okParams
-                val tpSubst = deriveTypeWithWildcards(remainingUndet)(tp.instantiateTypeParams(okParams, okArgs))
+                val adjusted = adjustTypeArgs(allUndetparams, tvars, targs)
+                val remainingUndet = allUndetparams diff adjusted.okParams
+                val tpSubst = deriveTypeWithWildcards(remainingUndet)(tp.instantiateTypeParams(adjusted.okParams, adjusted.okArgs))
                 if(!matchesPt(tpSubst, wildPt, remainingUndet)) {
                   if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(matchesPtInstMismatch2)
                   false
@@ -820,7 +820,8 @@ trait Implicits {
             // filter out failures from type inference, don't want to remove them from undetParams!
             // we must be conservative in leaving type params in undetparams
             // prototype == WildcardType: want to remove all inferred Nothings
-            val AdjustedTypeArgs(okParams, okArgs) = adjustTypeArgs(undetParams, tvars, targs)
+            val adjusted = adjustTypeArgs(undetParams, tvars, targs)
+            import adjusted.{okParams, okArgs}
 
             val subst: TreeTypeSubstituter =
               if (okParams.isEmpty) EmptyTreeTypeSubstituter

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -600,9 +600,8 @@ trait Implicits {
               } else {
                 val targs = solvedTypes(tvars, allUndetparams, allUndetparams map varianceInType(wildPt), upper = false, lubDepth(tpInstantiated :: wildPt :: Nil))
                 val adjusted = adjustTypeArgs(allUndetparams, tvars, targs)
-                val remainingUndet = allUndetparams diff adjusted.okParams
-                val tpSubst = deriveTypeWithWildcards(remainingUndet)(tp.instantiateTypeParams(adjusted.okParams, adjusted.okArgs))
-                if(!matchesPt(tpSubst, wildPt, remainingUndet)) {
+                val tpSubst = deriveTypeWithWildcards(adjusted.undetParams)(tp.instantiateTypeParams(adjusted.okParams, adjusted.okArgs))
+                if(!matchesPt(tpSubst, wildPt, adjusted.undetParams)) {
                   if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(matchesPtInstMismatch2)
                   false
                 } else true

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -476,7 +476,7 @@ trait Infer extends Checkable {
         }
       }
 
-      new AdjustedTypeArgs(tparams, okParams.toList, okArgs.toList, undetParams.toList, allArgs.toList)
+      AdjustedTypeArgs(okParams.toList, okArgs.toList, undetParams.toList, allArgs.toList)
     }
 
     /** Return inferred type arguments, given type parameters, formal parameters,
@@ -952,13 +952,13 @@ trait Infer extends Checkable {
      *  `fn(args)`, given prototype `pt`.
      *
      *  @param fn          fn: the function that needs to be instantiated.
-     *  @param undetparams the parameters that need to be determined
+     *  @param undetParams the parameters that need to be determined
      *  @param args        the actual arguments supplied in the call.
      *  @param pt0         the expected type of the function application
      *  @return            The type parameters that remain uninstantiated,
      *                     and that thus have not been substituted.
      */
-    def inferMethodInstance(fn: Tree, undetparams: List[Symbol],
+    def inferMethodInstance(fn: Tree, undetParams: List[Symbol],
                             args: List[Tree], pt0: Type): List[Symbol] = fn.tpe match {
       case mt @ MethodType(params0, _) =>
         try {
@@ -967,15 +967,15 @@ trait Infer extends Checkable {
           val argtpes = tupleIfNecessary(formals, args map (x => elimAnonymousClass(x.tpe.deconst)))
           val restpe  = fn.tpe.resultType(argtpes)
 
-          val adjusted = methTypeArgs(fn, undetparams, formals, restpe, argtpes, pt)
-          import adjusted.{okParams, okArgs, allArgs, undetParams}
+          val adjusted = methTypeArgs(fn, undetParams, formals, restpe, argtpes, pt)
+          import adjusted.{okParams, okArgs, allArgs}
 
-          if (checkBounds(fn, NoPrefix, NoSymbol, undetparams, allArgs, "inferred ")) {
+          if (checkBounds(fn, NoPrefix, NoSymbol, undetParams, allArgs, "inferred ")) {
             val treeSubst = new TreeTypeSubstituter(okParams, okArgs)
             treeSubst traverseTrees fn :: args
             notifyUndetparamsInferred(okParams, okArgs)
 
-            undetParams match {
+            adjusted.undetParams match {
               case Nil  => Nil
               case xs   =>
                 // #3890
@@ -1438,5 +1438,5 @@ trait Infer extends Checkable {
     }
   }
 
-  case class AdjustedTypeArgs(tparams: List[Symbol], okParams: List[Symbol], okArgs: List[Type], undetParams: List[Symbol], allArgs: List[Type])
+  final case class AdjustedTypeArgs(okParams: List[Symbol], okArgs: List[Type], undetParams: List[Symbol], allArgs: List[Type])
 }


### PR DESCRIPTION
The performance angle is directly building the lists we end up needing, rather than building an `LinkedHashMap` and deriving the lists from that.