### PR TITLE
Add Map.foreachEntry to avoid tupling penalty

### DIFF
--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -199,7 +199,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
   /** Apply `f` to each key/value pair for its side effects
    *  Note: [U] parameter needed to help scalac's type inference.
    */
-  def foreachKeyValue[U](f: (K, V) => U): Unit = {
+  def foreachEntry[U](f: (K, V) => U): Unit = {
     val it = iterator
     while (it.hasNext) {
       val next = it.next()

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -196,6 +196,17 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
     def next() = iter.next()._2
   }
 
+  /** Apply `f` to each key/value pair for its side effects
+   *  Note: [U] parameter needed to help scalac's type inference.
+   */
+  def foreachKeyValue[U](f: (K, V) => U): Unit = {
+    val it = iterator
+    while (it.hasNext) {
+      val next = it.next()
+      f(next._1, next._2)
+    }
+  }
+
   /** Filters this map by retaining only keys satisfying a predicate.
     *  @param  p   the predicate used to test keys
     *  @return an immutable map consisting only of those key value pairs of this map where the key satisfies

--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -353,7 +353,7 @@ private[collection] trait Wrappers {
       def next() = { val e = ui.next(); (e.getKey, e.getValue) }
     }
 
-    override def foreachKeyValue[U](f: (K, V) => U): Unit = {
+    override def foreachEntry[U](f: (K, V) => U): Unit = {
       val i = underlying.entrySet().iterator()
       while (i.hasNext) {
         val entry = i.next()

--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -353,6 +353,14 @@ private[collection] trait Wrappers {
       def next() = { val e = ui.next(); (e.getKey, e.getValue) }
     }
 
+    override def foreachKeyValue[U](f: (K, V) => U): Unit = {
+      val i = underlying.entrySet().iterator()
+      while (i.hasNext) {
+        val entry = i.next()
+        f(entry.getKey, entry.getValue)
+      }
+    }
+
     override def clear() = underlying.clear()
 
   }

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -136,7 +136,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
 
   override def foreach[U](f: ((K, V)) => U): Unit = rootNode.foreach(f)
 
-  override def foreachKeyValue[U](f: (K, V) => U): Unit = rootNode.foreachKeyValue(f)
+  override def foreachEntry[U](f: (K, V) => U): Unit = rootNode.foreachEntry(f)
 
   /** Applies a function to each key, value, and **original** hash value in this Map */
   @`inline` private[collection] def foreachWithHash(f: (K, V, Int) => Unit): Unit = rootNode.foreachWithHash(f)
@@ -333,7 +333,7 @@ private[immutable] sealed abstract class MapNode[K, +V] extends Node[MapNode[K, 
   def size: Int
 
   def foreach[U](f: ((K, V)) => U): Unit
-  def foreachKeyValue[U](f: (K, V) => U): Unit
+  def foreachEntry[U](f: (K, V) => U): Unit
 
   def foreachWithHash(f: (K, V, Int) => Unit): Unit
 
@@ -736,7 +736,7 @@ private final class BitmapIndexedMapNode[K, +V](
     }
   }
 
-  override def foreachKeyValue[U](f: (K, V) => U): Unit = {
+  override def foreachEntry[U](f: (K, V) => U): Unit = {
     val iN = payloadArity // arity doesn't change during this operation
     var i = 0
     while (i < iN) {
@@ -747,7 +747,7 @@ private final class BitmapIndexedMapNode[K, +V](
     val jN = nodeArity // arity doesn't change during this operation
     var j = 0
     while (j < jN) {
-      getNode(j).foreachKeyValue(f)
+      getNode(j).foreachEntry(f)
       j += 1
     }
   }
@@ -1372,7 +1372,7 @@ private final class HashCollisionMapNode[K, +V ](
 
   def foreach[U](f: ((K, V)) => U): Unit = content.foreach(f)
 
-  def foreachKeyValue[U](f: (K, V) => U): Unit = content.foreach { case (k, v) => f(k, v)}
+  def foreachEntry[U](f: (K, V) => U): Unit = content.foreach { case (k, v) => f(k, v)}
 
   override def foreachWithHash(f: (K, V, Int) => Unit): Unit = {
     val iter = content.iterator

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -136,6 +136,8 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
 
   override def foreach[U](f: ((K, V)) => U): Unit = rootNode.foreach(f)
 
+  override def foreachKeyValue[U](f: (K, V) => U): Unit = rootNode.foreachKeyValue(f)
+
   /** Applies a function to each key, value, and **original** hash value in this Map */
   @`inline` private[collection] def foreachWithHash(f: (K, V, Int) => Unit): Unit = rootNode.foreachWithHash(f)
 
@@ -331,6 +333,7 @@ private[immutable] sealed abstract class MapNode[K, +V] extends Node[MapNode[K, 
   def size: Int
 
   def foreach[U](f: ((K, V)) => U): Unit
+  def foreachKeyValue[U](f: (K, V) => U): Unit
 
   def foreachWithHash(f: (K, V, Int) => Unit): Unit
 
@@ -729,6 +732,22 @@ private final class BitmapIndexedMapNode[K, +V](
     var j = 0
     while (j < jN) {
       getNode(j).foreach(f)
+      j += 1
+    }
+  }
+
+  override def foreachKeyValue[U](f: (K, V) => U): Unit = {
+    val iN = payloadArity // arity doesn't change during this operation
+    var i = 0
+    while (i < iN) {
+      f(getKey(i), getValue(i))
+      i += 1
+    }
+
+    val jN = nodeArity // arity doesn't change during this operation
+    var j = 0
+    while (j < jN) {
+      getNode(j).foreachKeyValue(f)
       j += 1
     }
   }
@@ -1352,6 +1371,8 @@ private final class HashCollisionMapNode[K, +V ](
   override def getHash(index: Int): Int = originalHash
 
   def foreach[U](f: ((K, V)) => U): Unit = content.foreach(f)
+
+  def foreachKeyValue[U](f: (K, V) => U): Unit = content.foreach { case (k, v) => f(k, v)}
 
   override def foreachWithHash(f: (K, V, Int) => Unit): Unit = {
     val iter = content.iterator

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -224,8 +224,8 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil =>
   }
 
-  override def foreachKeyValue[U](f: (IntMapUtils.Int, T) => U): Unit = this match {
-    case IntMap.Bin(_, _, left, right) => { left.foreachKeyValue(f); right.foreachKeyValue(f) }
+  override def foreachEntry[U](f: (IntMapUtils.Int, T) => U): Unit = this match {
+    case IntMap.Bin(_, _, left, right) => { left.foreachEntry(f); right.foreachEntry(f) }
     case IntMap.Tip(key, value) => f(key, value)
     case IntMap.Nil =>
   }

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -224,6 +224,12 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil =>
   }
 
+  override def foreachKeyValue[U](f: (IntMapUtils.Int, T) => U): Unit = this match {
+    case IntMap.Bin(_, _, left, right) => { left.foreachKeyValue(f); right.foreachKeyValue(f) }
+    case IntMap.Tip(key, value) => f(key, value)
+    case IntMap.Nil =>
+  }
+
   override def keysIterator: Iterator[Int] = this match {
     case IntMap.Nil => Iterator.empty
     case _ => new IntMapKeyIterator(this)

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -219,8 +219,8 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil =>
   }
 
-  override final def foreachKeyValue[U](f: (Long, T) => U): Unit = this match {
-    case LongMap.Bin(_, _, left, right) => { left.foreachKeyValue(f); right.foreachKeyValue(f) }
+  override final def foreachEntry[U](f: (Long, T) => U): Unit = this match {
+    case LongMap.Bin(_, _, left, right) => { left.foreachEntry(f); right.foreachEntry(f) }
     case LongMap.Tip(key, value) => f(key, value)
     case LongMap.Nil =>
   }

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -219,6 +219,12 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil =>
   }
 
+  override final def foreachKeyValue[U](f: (Long, T) => U): Unit = this match {
+    case LongMap.Bin(_, _, left, right) => { left.foreachKeyValue(f); right.foreachKeyValue(f) }
+    case LongMap.Tip(key, value) => f(key, value)
+    case LongMap.Nil =>
+  }
+
   override def keysIterator: Iterator[Long] = this match {
     case LongMap.Nil => Iterator.empty
     case _ => new LongMapKeyIterator(this)

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -156,6 +156,14 @@ private[collection] object RedBlackTree {
     if (tree.right ne null) _foreachKey(tree.right, f)
   }
 
+  def foreachKeyValue[A, B, U](tree:Tree[A,B], f: (A, B) => U):Unit = if (tree ne null) _foreachKeyValue(tree,f)
+
+  private[this] def _foreachKeyValue[A, B, U](tree: Tree[A, B], f: (A, B) => U): Unit = {
+    if (tree.left ne null) _foreachKeyValue(tree.left, f)
+    f(tree.key, tree.value)
+    if (tree.right ne null) _foreachKeyValue(tree.right, f)
+  }
+
   def iterator[A: Ordering, B](tree: Tree[A, B], start: Option[A] = None): Iterator[(A, B)] = new EntriesIterator(tree, start)
   def keysIterator[A: Ordering](tree: Tree[A, _], start: Option[A] = None): Iterator[A] = new KeysIterator(tree, start)
   def valuesIterator[A: Ordering, B](tree: Tree[A, B], start: Option[A] = None): Iterator[B] = new ValuesIterator(tree, start)

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -156,12 +156,12 @@ private[collection] object RedBlackTree {
     if (tree.right ne null) _foreachKey(tree.right, f)
   }
 
-  def foreachKeyValue[A, B, U](tree:Tree[A,B], f: (A, B) => U):Unit = if (tree ne null) _foreachKeyValue(tree,f)
+  def foreachEntry[A, B, U](tree:Tree[A,B], f: (A, B) => U):Unit = if (tree ne null) _foreachEntry(tree,f)
 
-  private[this] def _foreachKeyValue[A, B, U](tree: Tree[A, B], f: (A, B) => U): Unit = {
-    if (tree.left ne null) _foreachKeyValue(tree.left, f)
+  private[this] def _foreachEntry[A, B, U](tree: Tree[A, B], f: (A, B) => U): Unit = {
+    if (tree.left ne null) _foreachEntry(tree.left, f)
     f(tree.key, tree.value)
-    if (tree.right ne null) _foreachKeyValue(tree.right, f)
+    if (tree.right ne null) _foreachEntry(tree.right, f)
   }
 
   def iterator[A: Ordering, B](tree: Tree[A, B], start: Option[A] = None): Iterator[(A, B)] = new EntriesIterator(tree, start)

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -117,7 +117,7 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V])(implicit va
   override def range(from: K, until: K): TreeMap[K,V] = newMapOrSelf(RB.range(tree, from, until))
 
   override def foreach[U](f: ((K, V)) => U): Unit = RB.foreach(tree, f)
-
+  override def foreachKeyValue[U](f: (K, V) => U): Unit = RB.foreachKeyValue(tree, f)
   override def size: Int = RB.count(tree)
   override def knownSize: Int = size
 

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -117,7 +117,7 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V])(implicit va
   override def range(from: K, until: K): TreeMap[K,V] = newMapOrSelf(RB.range(tree, from, until))
 
   override def foreach[U](f: ((K, V)) => U): Unit = RB.foreach(tree, f)
-  override def foreachKeyValue[U](f: (K, V) => U): Unit = RB.foreachKeyValue(tree, f)
+  override def foreachEntry[U](f: (K, V) => U): Unit = RB.foreachEntry(tree, f)
   override def size: Int = RB.count(tree)
   override def knownSize: Int = size
 

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -367,7 +367,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
     }
   }
 
-  override def foreachKeyValue[U](f: (K,V) => U): Unit = {
+  override def foreachEntry[U](f: (K,V) => U): Unit = {
     var i = 0
     var e = _size
     while (e > 0) {

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -367,6 +367,20 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
     }
   }
 
+  override def foreachKeyValue[U](f: (K,V) => U): Unit = {
+    var i = 0
+    var e = _size
+    while (e > 0) {
+      while(i < _hashes.length && { val h = _hashes(i); h+h == 0 && i < _hashes.length}) i += 1
+      if (i < _hashes.length) {
+        f(_keys(i).asInstanceOf[K], _values(i).asInstanceOf[V])
+        i += 1
+        e -= 1
+      }
+      else return
+    }
+  }
+
   override def clone(): AnyRefMap[K, V] = {
     val hz = java.util.Arrays.copyOf(_hashes, _hashes.length)
     val kz = java.util.Arrays.copyOf(_keys, _keys.length)

--- a/src/library/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/src/library/scala/collection/mutable/CollisionProofHashMap.scala
@@ -364,14 +364,14 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     }
   }
 
-  override def foreachKeyValue[U](f: (K, V) => U): Unit = {
+  override def foreachEntry[U](f: (K, V) => U): Unit = {
     val len = table.length
     var i = 0
     while(i < len) {
       val n = table(i)
       if(n ne null) n match {
-        case n: LLNode => n.foreachKeyValue(f)
-        case n: RBNode => n.foreachKeyValue(f)
+        case n: LLNode => n.foreachEntry(f)
+        case n: RBNode => n.foreachEntry(f)
       }
       i += 1
     }
@@ -749,10 +749,10 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
       if(right ne null) right.foreach(f)
     }
 
-    def foreachKeyValue[U](f: (K, V) => U): Unit = {
-      if(left ne null) left.foreachKeyValue(f)
+    def foreachEntry[U](f: (K, V) => U): Unit = {
+      if(left ne null) left.foreachEntry(f)
       f(key, value)
-      if(right ne null) right.foreachKeyValue(f)
+      if(right ne null) right.foreachEntry(f)
     }
 
     def foreachNode[U](f: RBNode[K, V] => U): Unit = {
@@ -818,9 +818,9 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
       if(next ne null) next.foreach(f)
     }
 
-    @tailrec def foreachKeyValue[U](f: (K, V) => U): Unit = {
+    @tailrec def foreachEntry[U](f: (K, V) => U): Unit = {
       f(key, value)
-      if(next ne null) next.foreachKeyValue(f)
+      if(next ne null) next.foreachEntry(f)
     }
 
     @tailrec def foreachNode[U](f: LLNode[K, V] => U): Unit = {

--- a/src/library/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/src/library/scala/collection/mutable/CollisionProofHashMap.scala
@@ -364,6 +364,19 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     }
   }
 
+  override def foreachKeyValue[U](f: (K, V) => U): Unit = {
+    val len = table.length
+    var i = 0
+    while(i < len) {
+      val n = table(i)
+      if(n ne null) n match {
+        case n: LLNode => n.foreachKeyValue(f)
+        case n: RBNode => n.foreachKeyValue(f)
+      }
+      i += 1
+    }
+  }
+
   protected[this] def writeReplace(): AnyRef = new DefaultSerializationProxy(new CollisionProofHashMap.DeserializationFactory[K, V](table.length, loadFactor, ordering), this)
 
   override protected[this] def stringPrefix = "CollisionProofHashMap"
@@ -736,6 +749,12 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
       if(right ne null) right.foreach(f)
     }
 
+    def foreachKeyValue[U](f: (K, V) => U): Unit = {
+      if(left ne null) left.foreachKeyValue(f)
+      f(key, value)
+      if(right ne null) right.foreachKeyValue(f)
+    }
+
     def foreachNode[U](f: RBNode[K, V] => U): Unit = {
       if(left ne null) left.foreachNode(f)
       f(this)
@@ -797,6 +816,11 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
     @tailrec def foreach[U](f: ((K, V)) => U): Unit = {
       f((key, value))
       if(next ne null) next.foreach(f)
+    }
+
+    @tailrec def foreachKeyValue[U](f: (K, V) => U): Unit = {
+      f(key, value)
+      if(next ne null) next.foreachKeyValue(f)
     }
 
     @tailrec def foreachNode[U](f: LLNode[K, V] => U): Unit = {

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -191,6 +191,14 @@ class LinkedHashMap[K, V]
     }
   }
 
+  override def foreachKeyValue[U](f: (K, V) => U): Unit = {
+    var cur = firstEntry
+    while (cur ne null) {
+      f(cur.key, cur.value)
+      cur = cur.later
+    }
+  }
+
   override def clear(): Unit = {
     table.clearTable()
     firstEntry = null

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -191,7 +191,7 @@ class LinkedHashMap[K, V]
     }
   }
 
-  override def foreachKeyValue[U](f: (K, V) => U): Unit = {
+  override def foreachEntry[U](f: (K, V) => U): Unit = {
     var cur = firstEntry
     while (cur ne null) {
       f(cur.key, cur.value)

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -439,6 +439,20 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
     }
   }
 
+  override def foreachKeyValue[U](f: (Long,V) => U): Unit = {
+    if ((extraKeys & 1) == 1) f(0L, zeroValue.asInstanceOf[V])
+    if ((extraKeys & 2) == 2) f(Long.MinValue, minValue.asInstanceOf[V])
+    var i,j = 0
+    while (i < _keys.length & j < _size) {
+      val k = _keys(i)
+      if (k != -k) {
+        j += 1
+        f(k, _values(i).asInstanceOf[V])
+      }
+      i += 1
+    }
+  }
+
   override def clone(): LongMap[V] = {
     val kz = java.util.Arrays.copyOf(_keys, _keys.length)
     val vz = java.util.Arrays.copyOf(_values,  _values.length)

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -439,7 +439,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
     }
   }
 
-  override def foreachKeyValue[U](f: (Long,V) => U): Unit = {
+  override def foreachEntry[U](f: (Long,V) => U): Unit = {
     if ((extraKeys & 1) == 1) f(0L, zeroValue.asInstanceOf[V])
     if ((extraKeys & 2) == 2) f(Long.MinValue, minValue.asInstanceOf[V])
     var i,j = 0

--- a/src/library/scala/collection/mutable/OpenHashMap.scala
+++ b/src/library/scala/collection/mutable/OpenHashMap.scala
@@ -282,7 +282,7 @@ class OpenHashMap[Key, Value](initialSize : Int)
       f((entry.key, entry.value.get))}
     )
   }
-  override def foreachKeyValue[U](f : (Key, Value) => U): Unit = {
+  override def foreachEntry[U](f : (Key, Value) => U): Unit = {
     val startModCount = modCount
     foreachUndeletedEntry(entry => {
       if (modCount != startModCount) throw new ConcurrentModificationException

--- a/src/library/scala/collection/mutable/OpenHashMap.scala
+++ b/src/library/scala/collection/mutable/OpenHashMap.scala
@@ -282,6 +282,13 @@ class OpenHashMap[Key, Value](initialSize : Int)
       f((entry.key, entry.value.get))}
     )
   }
+  override def foreachKeyValue[U](f : (Key, Value) => U): Unit = {
+    val startModCount = modCount
+    foreachUndeletedEntry(entry => {
+      if (modCount != startModCount) throw new ConcurrentModificationException
+      f(entry.key, entry.value.get)}
+    )
+  }
 
   private[this] def foreachUndeletedEntry(f : Entry => Unit): Unit = {
     table.foreach(entry => if (entry != null && entry.value != None) f(entry))

--- a/src/library/scala/collection/mutable/RedBlackTree.scala
+++ b/src/library/scala/collection/mutable/RedBlackTree.scala
@@ -456,7 +456,7 @@ private[collection] object RedBlackTree {
     if(r ne null) g(r)
   }
 
-  def foreachKeyValue[A, B, U](tree: Tree[A, B], f: (A, B) => U): Unit = {
+  def foreachEntry[A, B, U](tree: Tree[A, B], f: (A, B) => U): Unit = {
     def g(node: Node[A, B]): Unit = {
       val l = node.left
       if(l ne null) g(l)

--- a/src/library/scala/collection/mutable/RedBlackTree.scala
+++ b/src/library/scala/collection/mutable/RedBlackTree.scala
@@ -456,6 +456,18 @@ private[collection] object RedBlackTree {
     if(r ne null) g(r)
   }
 
+  def foreachKeyValue[A, B, U](tree: Tree[A, B], f: (A, B) => U): Unit = {
+    def g(node: Node[A, B]): Unit = {
+      val l = node.left
+      if(l ne null) g(l)
+      f(node.key, node.value)
+      val r = node.right
+      if(r ne null) g(r)
+    }
+    val r = tree.root
+    if(r ne null) g(r)
+  }
+
   def transform[A, B](tree: Tree[A, B], f: (A, B) => B): Unit = transformNode(tree.root, f)
 
   private[this] def transformNode[A, B, U](node: Node[A, B], f: (A, B) => B): Unit =

--- a/src/library/scala/collection/mutable/TreeMap.scala
+++ b/src/library/scala/collection/mutable/TreeMap.scala
@@ -103,6 +103,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   def rangeImpl(from: Option[K], until: Option[K]): TreeMap[K, V] = new TreeMapProjection(from, until)
 
   override def foreach[U](f: ((K, V)) => U): Unit = RB.foreach(tree, f)
+  override def foreachKeyValue[U](f: (K, V) => U): Unit = RB.foreachKeyValue(tree, f)
 
   override def size: Int = RB.size(tree)
   override def knownSize: Int = size

--- a/src/library/scala/collection/mutable/TreeMap.scala
+++ b/src/library/scala/collection/mutable/TreeMap.scala
@@ -103,7 +103,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   def rangeImpl(from: Option[K], until: Option[K]): TreeMap[K, V] = new TreeMapProjection(from, until)
 
   override def foreach[U](f: ((K, V)) => U): Unit = RB.foreach(tree, f)
-  override def foreachKeyValue[U](f: (K, V) => U): Unit = RB.foreachKeyValue(tree, f)
+  override def foreachEntry[U](f: (K, V) => U): Unit = RB.foreachEntry(tree, f)
 
   override def size: Int = RB.size(tree)
   override def knownSize: Int = size


### PR DESCRIPTION
And implement it where it makes sense.

Fixes scala/scala-dev#521 