### PR TITLE
Add shrinking to ArrayBuffer, take 3

### DIFF
--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -15,6 +15,7 @@ package collection
 package mutable
 
 import scala.collection.generic.DefaultSerializable
+import java.util.Arrays
 
 /** An implementation of the `Buffer` class using an array to
   *  represent the assembled sequence internally. Append, update and random
@@ -44,7 +45,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     with StrictOptimizedSeqOps[A, ArrayBuffer, ArrayBuffer[A]]
     with DefaultSerializable {
 
-  def this() = this(new Array[AnyRef](16), 0)
+  def this() = this(new Array[AnyRef](ArrayBuffer.minimalBufferSize), 0)
 
   def this(initialSize: Int) = this(new Array[AnyRef](initialSize), 0)
 
@@ -55,16 +56,21 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   /** Ensure that the internal array has at least `n` cells. */
   protected def ensureSize(n: Int): Unit =
-    array = RefArrayUtils.ensureSize(array, size0, n)
+    array = ArrayBuffer.ensureSize(array, size0, n)
 
   def sizeHint(size: Int): Unit =
     if(size > length && size >= 1) ensureSize(size)
 
   /** Reduce length to `n`, nulling out all dropped elements */
   private def reduceToSize(n: Int): Unit = {
-    RefArrayUtils.nullElems(array, n, size0)
+    Arrays.fill(array, n, size0, null)
     size0 = n
   }
+
+  /** Trims the ArrayBuffer to an appropriate size for the current number of elements (rounding up to the next
+    * natural size), which may replace the array by a shorter one. This allows releasing some unused memory. */
+  def trimToSize(): Unit =
+    array = ArrayBuffer.reduceSize(array, size0)
 
   @inline private def checkWithinBounds(lo: Int, hi: Int) = {
     if (lo < 0) throw new IndexOutOfBoundsException(s"$lo is out of bounds (min 0, max ${size0-1})")
@@ -208,14 +214,16 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
 
   // Avoid reallocation of buffer if length is known.
-  def from[B](coll: collection.IterableOnce[B]): ArrayBuffer[B] =
-    if (coll.knownSize >= 0) {
-      val array = new Array[AnyRef](coll.knownSize)
+  def from[B](coll: collection.IterableOnce[B]): ArrayBuffer[B] = {
+    val k = coll.knownSize
+    if (k >= 0) {
+      val array = new Array[AnyRef](k max minimalBufferSize)
       val it = coll.iterator
-      for (i <- 0 until array.length) array(i) = it.next().asInstanceOf[AnyRef]
-      new ArrayBuffer[B](array, array.length)
+      for (i <- 0 until k) array(i) = it.next().asInstanceOf[AnyRef]
+      new ArrayBuffer[B](array, k)
     }
     else new ArrayBuffer[B] ++= coll
+  }
 
   def newBuilder[A]: Builder[A, ArrayBuffer[A]] =
     new GrowableBuilder[A, ArrayBuffer[A]](empty) {
@@ -223,22 +231,34 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
     }
 
   def empty[A]: ArrayBuffer[A] = new ArrayBuffer[A]()
-}
 
-final class ArrayBufferView[A](val array: Array[AnyRef], val length: Int) extends AbstractIndexedSeqView[A] {
-  @throws[ArrayIndexOutOfBoundsException]
-  def apply(n: Int) = if (n < length) array(n).asInstanceOf[A] else throw new IndexOutOfBoundsException(s"$n is out of bounds (min 0, max ${length - 1})")
-  override protected[this] def className = "ArrayBufferView"
-}
+  // We chose 8 as a good size for the minimum array
+  private final val minimalBufferSize = 8
 
-/** An object used internally by collections backed by an extensible Array[AnyRef] */
-object RefArrayUtils {
+  /**
+    * Reduce the `array` buffer size down to either a power of 2
+    * or Int.MaxValue while keeping first `n` elements.
+    */
+  private def reduceSize(array: Array[AnyRef], n: Int): Array[AnyRef] = {
+    var newSize: Long = array.length
+    if (newSize == Int.MaxValue) {
+      newSize += 1 // ensure that newSize is a power of 2
+    }
+    val minLength = minimalBufferSize max n
+    while (newSize / 2 >= minLength) newSize /= 2
+    if (newSize != array.length && newSize < Int.MaxValue) {
+      val newArray: Array[AnyRef] = new Array(newSize.toInt)
+      Array.copy(array, 0, newArray, 0, n)
+      newArray
+    }
+    else array
+  }
 
-  def ensureSize(array: Array[AnyRef], end: Int, n: Int): Array[AnyRef] = {
+  private def ensureSize(array: Array[AnyRef], end: Int, n: Int): Array[AnyRef] = {
     // Use a Long to prevent overflows
     val arrayLength: Long = array.length
     def growArray = {
-      var newSize: Long = math.max(arrayLength * 2, 8)
+      var newSize: Long = math.max(arrayLength * 2, minimalBufferSize)
       while (n > newSize)
         newSize = newSize * 2
       // Clamp newSize to Int.MaxValue
@@ -253,16 +273,10 @@ object RefArrayUtils {
     }
     if (n <= arrayLength) array else growArray
   }
+}
 
-  /** Remove elements of this array at indices after `sz`.
-   */
-  def nullElems(array: Array[AnyRef], start: Int, end: Int): Unit = {
-    // Maybe use `fill` instead?
-    var i = start
-    while (i < end) {
-      array(i) = null
-      i += 1
-    }
-  }
-
+final class ArrayBufferView[A](val array: Array[AnyRef], val length: Int) extends AbstractIndexedSeqView[A] {
+  @throws[ArrayIndexOutOfBoundsException]
+  def apply(n: Int) = if (n < length) array(n).asInstanceOf[A] else throw new IndexOutOfBoundsException(s"$n is out of bounds (min 0, max ${length - 1})")
+  override protected[this] def className = "ArrayBufferView"
 }

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -358,4 +358,14 @@ class ArrayBufferTest {
     a.sortInPlace
     assertEquals(List(3,4,5), a)
   }
+
+  @Test def trimToSize: Unit = {
+    val b = ArrayBuffer(1,2,3)
+    assertEquals(8, b.array.length)
+    b ++= (1 to 1000)
+    assertEquals(1024, b.array.length)
+    b.remove(200, 803)
+    b.trimToSize()
+    assertEquals(256, b.array.length)
+  }
 }

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -361,7 +361,7 @@ class ArrayBufferTest {
 
   @Test def trimToSize: Unit = {
     val b = ArrayBuffer(1,2,3)
-    assertEquals(8, b.array.length)
+    assertEquals(16, b.array.length)
     b ++= (1 to 1000)
     assertEquals(1024, b.array.length)
     b.remove(200, 803)


### PR DESCRIPTION
This is an updated version of #7893 / #7658, addressing my own review comments.

- Changes the name from `def shrinkToSize()` to `def trimToSize()` following https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html#trimToSize--
- Fixes minor whitespaces.
- Fixes handling of buffer size near `Int.MaxValue`

### commit comment

The ArrayBuffer already had the logic to grow and expand an array into
another twice the size, when adding a new element to a full array.

This PR adds a complementary `trimToSize` method, that can shrink
the array and replace it with a smaller one, if the number of occupied
positions in the array falls below a fraction of its length.

Following suggestions in code review, we keep this as a separate
method that a programmer has to invoke directly, and not as part of
other operations.