### PR TITLE
Fix 11438, 11439 leaky abstraction / NPE patrol

### DIFF
--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -227,7 +227,7 @@ class ListBuffer[A]
       if(prev eq null) first = next else prev.next = next
       prev = next
     }
-    if(prev.next.isEmpty) last0 = prev
+    if ((prev ne null) && prev.next.isEmpty) last0 = prev
     prev
   }
 

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -68,6 +68,13 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   import ord._
 
   private class ResizableArrayAccess[A0] extends ArrayBuffer[A0] {
+    override def mapInPlace(f: A0 => A0): this.type = {
+      var i = 1 // see "we do not use array(0)" comment below (???)
+      val siz = size
+      while (i < siz) { this(i) = f(this(i)); i += 1 }
+      this
+    }
+
     def p_size0 = size0
     def p_size0_=(s: Int) = size0 = s
     def p_array = array
@@ -81,7 +88,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
 
   private val resarr = new ResizableArrayAccess[A]
 
-  resarr.p_size0 += 1                  // we do not use array(0)
+  resarr.p_size0 += 1                  // we do not use array(0) TODO: explain -- what is the first element even for?
   def length: Int = resarr.length - 1  // adjust length accordingly
   override def size: Int = length
   override def knownSize: Int = length

--- a/test/junit/scala/collection/mutable/ListBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ListBufferTest.scala
@@ -215,6 +215,7 @@ class ListBufferTest {
     testPatchInPlace(from = 2, replaced = 1, expectation = ListBuffer(0, 1, -3, -2, -1))
     testPatchInPlace(from = 10, replaced = 10, expectation = ListBuffer(0, 1, 2, -3, -2, -1))
     testPatchInPlace(from = 0, replaced = 100, expectation = ListBuffer(-3, -2, -1))
+    assertEquals(ListBuffer(), ListBuffer().patchInPlace(0, Nil, -1)) // scala/bug#11438
   }
 
   @Test

--- a/test/junit/scala/collection/mutable/PriorityQueueTest.scala
+++ b/test/junit/scala/collection/mutable/PriorityQueueTest.scala
@@ -28,7 +28,7 @@ class PriorityQueueTest {
     assert(pq.ord eq pq.reverse.reverse.ord)
   }
 
-  @Test
+  @Test /* Regression for https://github.com/scala/bug/issues/11439 */
   def emptyMapInPlace(): Unit = {
     val pq = mutable.PriorityQueue.empty[String].mapInPlace(_.toUpperCase) // used to crash because of the weird resarr implementation
     assert(pq.isEmpty)

--- a/test/junit/scala/collection/mutable/PriorityQueueTest.scala
+++ b/test/junit/scala/collection/mutable/PriorityQueueTest.scala
@@ -27,7 +27,13 @@ class PriorityQueueTest {
     val pq = new mutable.PriorityQueue[Nothing]()((_,_)=>42)
     assert(pq.ord eq pq.reverse.reverse.ord)
   }
-  
+
+  @Test
+  def emptyMapInPlace(): Unit = {
+    val pq = mutable.PriorityQueue.empty[String].mapInPlace(_.toUpperCase) // used to crash because of the weird resarr implementation
+    assert(pq.isEmpty)
+  }
+
   @Test
   def canSerialize(): Unit = {
     val outputStream = new ByteArrayOutputStream()


### PR DESCRIPTION
Fix scala/bug#11438
Fix scala/bug#11439