### PR TITLE
Fix invisible dead link in Scaladoc

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
@@ -260,9 +260,9 @@ abstract class HtmlPage extends Page { thisPage =>
     val Trait, Class, Type, Object, Package = Value
   }
 
-  def permalink(template: Entity, isSelf: Boolean = true): Elem =
+  def permalink(template: Entity): Elem =
     <span class="permalink">
-      <a href={ memberToUrl(template, isSelf) } title="Permalink">
+      <a href={ memberToUrl(template) } title="Permalink">
         <i class="material-icons">&#xE157;</i>
       </a>
     </span>
@@ -297,16 +297,15 @@ abstract class HtmlPage extends Page { thisPage =>
       }
     }</span>
 
-  private def memberToUrl(template: Entity, isSelf: Boolean = true): String = {
+  private def memberToUrl(template: Entity): String = {
     val (signature: Option[String], containingTemplate: TemplateEntity) = template match {
-      case dte: DocTemplateEntity if (!isSelf) => (Some(dte.signature), dte.inTemplate)
       case dte: DocTemplateEntity => (None, dte)
       case me: MemberEntity => (Some(me.signature), me.inTemplate)
       case tpl => (None, tpl)
     }
 
     val templatePath = templateToPath(containingTemplate)
-    val url = "../" * (templatePath.size - 1) + templatePath.reverse.mkString("/")
+    val url = "../" * (thisPage.path.size - 1) + templatePath.reverse.mkString("/")
     url + signature.map("#" + _).getOrElse("")
   }
 }

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -987,7 +987,7 @@ trait EntityPage extends HtmlPage {
       </xml:group>
     mbr match {
       case dte: DocTemplateEntity if !isSelf =>
-        permalink(dte, isSelf) ++ { inside(hasLinks = true, nameLink = relativeLinkTo(dte)) }
+        permalink(dte) ++ { inside(hasLinks = true, nameLink = relativeLinkTo(dte)) }
       case _ if isSelf =>
         <h4 id="signature" class="signature">{ inside(hasLinks = true) }</h4>
       case _ =>

--- a/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
+++ b/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
@@ -749,8 +749,8 @@ object HtmlFactoryTest extends Properties("HtmlFactory") {
 
     property("scala/bug#8144: Members' permalink - inner package") = check("some/pack/index.html") { node =>
       ("type link" |: node.assertTypeLink("../../some/pack/index.html")) &&
-        ("member: SomeType (object)" |: node.assertValuesLink("some.pack.SomeType", "../../some/pack/index.html#SomeType")) &&
-        ("member: SomeType (class)" |: node.assertMemberLink("types")("some.pack.SomeType", "../../some/pack/index.html#SomeTypeextendsAnyRef"))
+        ("member: SomeType (object)" |: node.assertValuesLink("some.pack.SomeType", "../../some/pack/SomeType$.html")) &&
+        ("member: SomeType (class)" |: node.assertMemberLink("types")("some.pack.SomeType", "../../some/pack/SomeType.html"))
     }
 
     property("scala/bug#8144: Members' permalink - companion object") = check("some/pack/SomeType$.html") { node =>


### PR DESCRIPTION
Fixes scala/bug#11300

### before

scaladoc was producing `<a href="../scala/index.html#annotation" title="Permalink">` from `scala.collection` package page.

### after

scaladoc will produce `<a href="../../scala/annotation/index.html" title="Permalink">` from `scala.collection` package page.