### PR TITLE
Preemptively override VectorMap#concat and builder#addAll

### DIFF
--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -62,6 +62,8 @@ final class VectorMap[K, +V] private (
     }
   }
 
+  override def concat[V1 >: V](that: IterableOnce[(K, V1)]): VectorMap[K, V1] = super.concat(that)
+
   override def withDefault[V1 >: V](d: K => V1): Map[K, V1] =
     new Map.WithDefault(this, d)
 
@@ -263,4 +265,6 @@ private[immutable] final class VectorMapBuilder[K, V] extends mutable.Builder[(K
   }
 
   override def addOne(elem: (K, V)): this.type = addOne(elem._1, elem._2)
+
+  override def addAll(xs: IterableOnce[(K, V)]): this.type = super.addAll(xs)
 }


### PR DESCRIPTION
Due to the recently-merged https://github.com/scala/scala/pull/7588 , there's good reason to believe that we can get a lot of improvement out of concatenating VectorMaps and building them in bulk from other VectorMaps, since these can utilize the new faster VectorBuilder.

 

