### PR TITLE
Avoid the use of modifyInfo in maps, use foreach

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -175,7 +175,8 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
       // need to modify the bounds of the cloned type parameters, but we
       // don't want to substitute for the cloned type parameters themselves.
       val tparams = tparamsFromMethod ::: tparamsFromClass
-      GenPolyType(tparams map (_ modifyInfo fixtparam), fixres(resultType))
+      tparams foreach (_ modifyInfo fixtparam)
+      GenPolyType(tparams, fixres(resultType))
 
       // For reference, calling fix on the GenPolyType plays out like this:
       // error: scala.reflect.internal.Types$TypeError: type arguments [B#7344,A#6966]

--- a/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
@@ -266,7 +266,8 @@ trait PatternTypers {
       // tree1's remaining type-slack skolems will be deskolemized (to the method type parameter skolems)
       tree1 modifyType {
         case MethodType(ctorArgs, restpe) => // ctorArgs are actually in a covariant position, since this is the type of the subpatterns of the pattern represented by this Apply node
-          copyMethodType(tree1.tpe, ctorArgs map (_ modifyInfo extrapolate), extrapolate(restpe)) // no need to clone ctorArgs, this is OUR method type
+          ctorArgs foreach (_ modifyInfo extrapolate)
+          copyMethodType(tree1.tpe, ctorArgs, extrapolate(restpe)) // no need to clone ctorArgs, this is OUR method type
         case tp => tp
       }
     }

--- a/src/reflect/scala/reflect/internal/ExistentialsAndSkolems.scala
+++ b/src/reflect/scala/reflect/internal/ExistentialsAndSkolems.scala
@@ -110,7 +110,8 @@ trait ExistentialsAndSkolems {
     val typeParamTypes = typeParams map (_.tpeHK)
     def doSubst(info: Type) = info.subst(rawSyms, typeParamTypes)
 
-    creator(typeParams map (_ modifyInfo doSubst), doSubst(tp))
+    typeParams foreach (_ modifyInfo doSubst)
+    creator(typeParams, doSubst(tp))
   }
 
   /**

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3688,10 +3688,16 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
    *  @param    infoFn  the function to apply to the infos
    *  @return           the newly created, info-adjusted symbols
    */
-  def cloneSymbolsAndModify(syms: List[Symbol], infoFn: Type => Type): List[Symbol] =
-    mapList(cloneSymbols(syms))(_ modifyInfo infoFn)
-  def cloneSymbolsAtOwnerAndModify(syms: List[Symbol], owner: Symbol, infoFn: Type => Type): List[Symbol] =
-    mapList(cloneSymbolsAtOwner(syms, owner))(_ modifyInfo infoFn)
+  def cloneSymbolsAndModify(syms: List[Symbol], infoFn: Type => Type): List[Symbol] = {
+    val cloned = cloneSymbols(syms)
+    cloned foreach (_ modifyInfo infoFn)
+    cloned
+  }
+  def cloneSymbolsAtOwnerAndModify(syms: List[Symbol], owner: Symbol, infoFn: Type => Type): List[Symbol] = {
+    val cloned = cloneSymbolsAtOwner(syms, owner)
+    cloned foreach (_ modifyInfo infoFn)
+    cloned
+  }
 
   /** Functions which perform the standard clone/substituting on the given symbols and type,
    *  then call the creator function with the new symbols and type as arguments.


### PR DESCRIPTION
The modifyInfo method is a modification of a mutable field in place, so the returned value is the receiver object itself. However, in some places a `map` function is used to apply a modification to all types in a list, and that allocates an entire list which is identical to the input list.

In some places we have found this, we replace the map with a foreach.

_Note_ We could ideally just use a `mapList`, or a function that would just return the same function. Yet, IMHO, it's more readable to clearly separate functional from imperative code, even at the expense of a few more lines. Therefore, I would rather not use a functional idiom (`map`),  however optimised, for what is a non-functional action (mutate fields).