### PR TITLE
Make s.c.i.ArraySeq#unsafeArray private[scala]

### DIFF
--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -51,7 +51,7 @@ sealed abstract class ArraySeq[+A]
     * the expected immutability. Its element type does not have to be equal to the element type of this ArraySeq.
     * A primitive ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an
     * array of a supertype or subtype of the element type. */
-  def unsafeArray: Array[_]
+  private[scala] def unsafeArray: Array[_]
 
   override protected def fromSpecific(coll: scala.collection.IterableOnce[A] @uncheckedVariance): ArraySeq[A] = ArraySeq.from(coll)(elemTag.asInstanceOf[ClassTag[A]])
 


### PR DESCRIPTION
Having `s.c.i.ArraySeq#unsafeArray` public violates
encapsulation, which means that an instance of
`s.c.i.ArraySeq` cannot safely be shared without defensively
copying it.

I'm not sure if there has been prior discussion about this, but if so, I'm not sure where that is. Whatever the decision, this MUST be addressed before RC1. I would personally prefer the method be `protected`, but there are three uses outside of `ArraySeq`, and changing them is a larger change to make right before the RC.

See also #7915.