### PR TITLE
Make s.c.i.ArraySeq#unsafeArray protected

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
@@ -19,7 +19,6 @@ import scala.reflect.internal.Chars._
 import JavaTokens._
 import scala.annotation.{ switch, tailrec }
 import scala.language.implicitConversions
-import scala.collection.immutable.ArraySeq
 
 // Todo merge these better with Scanners
 trait JavaScanners extends ast.parser.ScannersCommon {
@@ -881,7 +880,7 @@ trait JavaScanners extends ast.parser.ScannersCommon {
   }
 
   class JavaUnitScanner(unit: CompilationUnit) extends JavaScanner {
-    in = new JavaCharArrayReader(new ArraySeq.ofChar(unit.source.content), !settings.nouescape.value, syntaxError)
+    in = new JavaCharArrayReader(unit.source.content, !settings.nouescape.value, syntaxError)
     init()
     def error(pos: Int, msg: String) = reporter.error(pos, msg)
     def incompleteInputError(pos: Int, msg: String) = currentRun.parsing.incompleteInputError(pos, msg)

--- a/src/compiler/scala/tools/nsc/util/JavaCharArrayReader.scala
+++ b/src/compiler/scala/tools/nsc/util/JavaCharArrayReader.scala
@@ -15,12 +15,11 @@ package tools.nsc
 package util
 
 import scala.reflect.internal.Chars._
-import scala.collection.immutable.ArraySeq
 
-class JavaCharArrayReader(buf: ArraySeq.ofChar, start: Int, /* startline: int, startcol: int, */
+class JavaCharArrayReader(buf: Array[Char], start: Int, /* startline: int, startcol: int, */
                       decodeUni: Boolean, error: String => Unit) extends Iterator[Char] with Cloneable {
 
-  def this(buf: ArraySeq.ofChar, decodeUni: Boolean, error: String => Unit) =
+  def this(buf: Array[Char], decodeUni: Boolean, error: String => Unit) =
     this(buf, 0, /* 1, 1, */ decodeUni, error)
 
   /** the line and column position of the current character
@@ -33,7 +32,7 @@ class JavaCharArrayReader(buf: ArraySeq.ofChar, start: Int, /* startline: int, s
   def hasNext = bp < buf.length
 
   def next(): Char = {
-    val buf = this.buf.unsafeArray
+    val buf = this.buf
     if(!hasNext) {
       ch = SU
       return SU  // there is an endless stream of SU's at the end

--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -51,7 +51,7 @@ sealed abstract class ArraySeq[+A]
     * the expected immutability. Its element type does not have to be equal to the element type of this ArraySeq.
     * A primitive ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an
     * array of a supertype or subtype of the element type. */
-  def unsafeArray: Array[_]
+  protected def unsafeArray: Array[_]
 
   override protected def fromSpecific(coll: scala.collection.IterableOnce[A] @uncheckedVariance): ArraySeq[A] = ArraySeq.from(coll)(elemTag.asInstanceOf[ClassTag[A]])
 

--- a/src/library/scala/runtime/LambdaDeserialize.scala
+++ b/src/library/scala/runtime/LambdaDeserialize.scala
@@ -33,10 +33,9 @@ final class LambdaDeserialize private (lookup: MethodHandles.Lookup, targetMetho
 }
 
 object LambdaDeserialize {
-  @varargs @throws[Throwable]
-  def bootstrap(lookup: MethodHandles.Lookup, invokedName: String, invokedType: MethodType, targetMethods: MethodHandle*): CallSite = {
-    val targetMethodsArray = targetMethods.asInstanceOf[immutable.ArraySeq[_]].unsafeArray.asInstanceOf[Array[MethodHandle]]
-    val exact = MethodHandleConstants.LAMBDA_DESERIALIZE_DESERIALIZE_LAMBDA.bindTo(new LambdaDeserialize(lookup, targetMethodsArray)).asType(invokedType)
+  @throws[Throwable]
+  def bootstrap(lookup: MethodHandles.Lookup, invokedName: String, invokedType: MethodType, targetMethods: Array[MethodHandle]): CallSite = {
+    val exact = MethodHandleConstants.LAMBDA_DESERIALIZE_DESERIALIZE_LAMBDA.bindTo(new LambdaDeserialize(lookup, targetMethods)).asType(invokedType)
     new ConstantCallSite(exact)
   }
 

--- a/test/junit/scala/collection/immutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/immutable/ArraySeqTest.scala
@@ -55,7 +55,9 @@ class ArraySeqTest {
   @Test
   def t10851(): Unit = {
     val s1 = ArraySeq.untagged(1,2,3)
-    assertTrue(s1.unsafeArray.getClass == classOf[Array[AnyRef]])
+    val unsafeArray = s1.getClass.getMethod("unsafeArray")
+    unsafeArray.setAccessible(true)
+    assertTrue(unsafeArray.invoke(s1).getClass == classOf[Array[AnyRef]])
   }
 
   @Test


### PR DESCRIPTION
Having `s.c.i.ArraySeq#unsafeArray` public violates
encapsulation, which means that an instance of
`s.c.i.ArraySeq` cannot safely be shared without defensively
copying it.

I'm not sure if there has been prior discussion about this, but if so, I'm not sure where that is. Whatever the decision, this MUST be addressed before RC1.

Alternative to #7914.