### PR TITLE
Revert "GlbLubs polyTypeMatch: No matrix no transpose"

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -564,18 +564,12 @@ private[internal] trait GlbLubs {
     val ntps: List[PolyType]   = ptHead :: ptRest.map(normalizeIter)
 
     val tparams1: List[Symbol] = {
-      val substSymMaps: Array[SubstSymMap] = new Array[SubstSymMap](ptRest.length)
-      foreachWithIndex(ntps.tail) { (ntp, ix) =>
+      def unifyBounds(ntp: PolyType): List[Type] = {
         val tparams1 = ntp.typeParams
-        if (! ((tparams1 eq tparamsHead) || tparams1.isEmpty))
-          substSymMaps(ix) = new SubstSymMap(tparams1, tparamsHead)
+        tparams1 map (tparam => tparam.info.substSym(tparams1, tparamsHead))
       }
-      mapWithIndex(tparamsHead){ (tparam, ix) =>
-        val bounds = mapWithIndex(ntps.tail){ (ntp, ix) =>
-          val binfo = ntp.typeParams(ix).info
-          val ssm = substSymMaps(ix)
-          if (ssm == null) binfo else ssm.apply(binfo)
-        }
+      val boundsTts : List[List[Type]] = ntps.tail.map(unifyBounds).transpose
+      map2(tparamsHead, boundsTts){ (tparam, bounds) =>
         tparam.cloneSymbol.setInfo(infoBoundTop(tparam.info :: bounds, depth))
       }
     }


### PR DESCRIPTION
Reverts scala/scala#7897

it broke scaladoc on scalaz in the community build 

```
[scalaz] java.lang.IndexOutOfBoundsException: 1
[scalaz] 	at scala.collection.LinearSeqOps.apply(LinearSeq.scala:114)
[scalaz] 	at scala.collection.LinearSeqOps.apply$(LinearSeq.scala:111)
[scalaz] 	at scala.reflect.internal.tpe.GlbLubs.$anonfun$polyTypeMatch$4(GlbLubs.scala:575)
[scalaz] 	at scala.reflect.internal.tpe.GlbLubs.lub0$1(GlbLubs.scala:574)
[scalaz] 	at scala.reflect.internal.tpe.GlbLubs.lub(GlbLubs.scala:382)
[scalaz] 	at scala.reflect.internal.tpe.GlbLubs.lub$(GlbLubs.scala:263)
```

(from https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/1866/consoleText)