### PR TITLE
Remove backwards compatibility from extension methods

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -36,39 +36,6 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
   def newTransformer(unit: CompilationUnit): Transformer =
     new Extender(unit)
 
-  /** Generate stream of possible names for the extension version of given instance method `imeth`.
-   *  If the method is not overloaded, this stream consists of just "extension$imeth".
-   *  If the method is overloaded, the stream has as first element "extensionX$imeth", where X is the
-   *  index of imeth in the sequence of overloaded alternatives with the same name. This choice will
-   *  always be picked as the name of the generated extension method.
-   *  After this first choice, all other possible indices in the range of 0 until the number
-   *  of overloaded alternatives are returned. The secondary choices are used to find a matching method
-   *  in `extensionMethod` if the first name has the wrong type. We thereby gain a level of insensitivity
-   *  of how overloaded types are ordered between phases and picklings.
-   */
-  // TODO 2.13.1 Remove the $N variants, just return the one and only name.
-  private def extensionNames(imeth: Symbol): Stream[Name] = {
-    val decl = imeth.owner.info.decl(imeth.name)
-
-    // Bridge generation is done at phase `erasure`, but new scopes are only generated
-    // for the phase after that. So bridges are visible in earlier phases.
-    //
-    // `info.member(imeth.name)` filters these out, but we need to use `decl`
-    // to restrict ourselves to members defined in the current class, so we
-    // must do the filtering here.
-    val declTypeNoBridge = decl.filter(sym => !sym.isBridge).tpe
-
-    declTypeNoBridge match {
-      case OverloadedType(_, alts) =>
-        val index = alts indexOf imeth
-        assert(index >= 0, alts+" does not contain "+imeth)
-        def altName(index: Int) = extensionName(imeth.name).append(index.toString)
-        extensionName(imeth.name) #:: ((0 until alts.length).toStream map altName)
-      case tpe =>
-        assert(tpe != NoType, imeth.name+" not found in "+imeth.owner+"'s decls: "+imeth.owner.info.decls)
-        Stream(extensionName(imeth.name))
-    }
-  }
   private def extensionName(name: Name): TermName = {
     name.append("$extension").toTermName
   }
@@ -81,7 +48,7 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
   /** Return the extension method that corresponds to given instance method `meth`. */
   def extensionMethod(imeth: Symbol): Symbol = enteringPhase(currentRun.refchecksPhase) {
     val companionInfo = companionModuleForce(imeth.owner).info
-    val candidates = extensionNames(imeth).map(companionInfo.decl(_)).filter(_.exists).flatMap(_.alternatives)
+    val candidates = companionInfo.decl(extensionName(imeth.name)).alternatives
     val matching = candidates filter (alt => normalize(alt.tpe, imeth.owner) matches imeth.tpe)
     assert(matching.nonEmpty,
       sm"""|no extension method found for:
@@ -94,9 +61,7 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
            |
            | Candidates (signatures normalized):
            |
-           | ${candidates.map(c => c.name+":"+normalize(c.tpe, imeth.owner)).mkString("\n")}
-           |
-           | Eligible Names: ${extensionNames(imeth).mkString(",")}" """)
+           | ${candidates.map(c => c.name+":"+normalize(c.tpe, imeth.owner)).mkString("\n")}" """)
     matching.head
   }
 

--- a/versions.properties
+++ b/versions.properties
@@ -1,5 +1,5 @@
 # Scala version used for bootstrapping (see README.md)
-starr.version=2.13.0-M5-1775dba
+starr.version=2.13.0-M5-5eef812
 
 # These are the versions of the modules that go with this release.
 # Artifact dependencies:


### PR DESCRIPTION
Follow up for #7896

Using new STARR 2.13.0-M5-5eef812 (built by https://travis-ci.org/scala/scala/jobs/510944441#L462
using `export SCALA_VER_BASE=2.13.0 SCALA_VER_SUFFIX=-M5-5eef812` as "before_install:" -- see https://github.com/scala/scala-dev/blob/scala-dev/.github/ISSUE_TEMPLATE/release.md)
