### PR TITLE
JavaMirrors / MethodMetadata: avoid arrays

### DIFF
--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -206,6 +206,14 @@ trait Collections {
       index += 1
     }
   }
+  final def foreachWithIndex[A](it: Iterator[A])(f: (A, Int) => Unit){
+    var index = 0
+    while (it.hasNext) {
+      f(it.next, index)
+      index += 1
+    }
+  }
+
 
   // @inline
   final def findOrElse[A](xs: TraversableOnce[A])(p: A => Boolean)(orElse: => A): A = {


### PR DESCRIPTION
We improve the class `MethofMetadata`, to reduce the number of allocations it performs and the space it takes:

- We avoid the calls to `List.flatten`, since that usually allocates a list equal to the sum of the lengths.
- We avoid the `params` array, since this was only used as a basis from which to map into the other arrays `vcMetaData` and `isByName`.
- For the `isByName`, instead of using an `Array` of Booleans (which may have been boxed and therefore an array of Objects), we use a BitSet which can be more compact.