### PR TITLE
Extractor methods must take a single argument.

### DIFF
--- a/spec/08-pattern-matching.md
+++ b/spec/08-pattern-matching.md
@@ -244,8 +244,8 @@ An extractor pattern cannot match the value `null`. The implementation
 ensures that the `unapply`/`unapplySeq` method is not applied to `null`.
 
 An `unapply` method in an object $x$ _matches_ the pattern
-$x(p_1 , \ldots , p_n)$ if it takes exactly one argument and one of
-the following applies:
+$x(p_1 , \ldots , p_n)$ if it has a single parameter (and, optionally, an
+implicit parameter list) and one of the following applies:
 
 * $n=0$ and `unapply`'s result type is `Boolean`. In this case
   the extractor pattern matches all values $v$ for which

--- a/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/PatternTypers.scala
@@ -89,13 +89,16 @@ trait PatternTypers {
         || member.isOverloaded // the whole overloading situation is over the rails
       )
 
+      // if we're already failing, no need to emit another error here
+      if (fun.tpe.isErroneous)
+        fun
       // Dueling test cases: pos/overloaded-unapply.scala, run/case-class-23.scala, pos/t5022.scala
       // A case class with 23+ params has no unapply method.
       // A case class constructor may be overloaded with unapply methods in the companion.
-      if (canElide && caseClass.isCase && !member.isOverloaded)
+      else if (canElide && caseClass.isCase && !member.isOverloaded)
         logResult(s"convertToCaseConstructor($fun, $caseClass, pt=$pt)")(convertToCaseConstructor(fun, caseClass, pt))
       else if (!reallyExists(member))
-        CaseClassConstructorError(fun, s"${fun.symbol} is not a case class, nor does it have an unapply/unapplySeq member")
+        CaseClassConstructorError(fun, s"${fun.symbol} is not a case class, nor does it have a valid unapply/unapplySeq member")
       else if (isOkay)
         fun
       else if (isEmptyType == NoType)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -269,14 +269,6 @@ trait Definitions extends api.StandardDefinitions {
 
     def isUnitType(tp: Type) = tp.typeSymbol == UnitClass && tp.annotations.isEmpty
 
-    def hasMultipleNonImplicitParamLists(member: Symbol): Boolean = hasMultipleNonImplicitParamLists(member.info)
-    @tailrec
-    final def hasMultipleNonImplicitParamLists(info: Type): Boolean = info match {
-      case PolyType(_, restpe)                                   => hasMultipleNonImplicitParamLists(restpe)
-      case MethodType(_, MethodType(p :: _, _)) if !p.isImplicit => true
-      case _                                                     => false
-    }
-
     private def fixupAsAnyTrait(tpe: Type): Type = tpe match {
       case ClassInfoType(parents, decls, clazz) =>
         if (parents.head.typeSymbol == AnyClass) tpe

--- a/test/files/neg/t0418.check
+++ b/test/files/neg/t0418.check
@@ -1,4 +1,0 @@
-t0418.scala:2: error: not found: value Foo12340771
-  null match { case Foo12340771.Bar(x) => x }
-                    ^
-one error found

--- a/test/files/neg/t0418.scala
+++ b/test/files/neg/t0418.scala
@@ -1,3 +1,0 @@
-object Test {
-  null match { case Foo12340771.Bar(x) => x }
-}

--- a/test/files/neg/t11446.check
+++ b/test/files/neg/t11446.check
@@ -1,0 +1,29 @@
+t11446.scala:29: error: object A is not a case class, nor does it have a valid unapply/unapplySeq member
+Note: def unapply(s: String, strict: Boolean): Option[Int] exists in object A, but it cannot be used as an extractor as it has more than one (non-implicit) parameter
+  "a" match { case A(i) => i }
+                   ^
+t11446.scala:30: error: object B is not a case class, nor does it have a valid unapply/unapplySeq member
+Note: def unapply(s: String)(u: Int): Option[Int] exists in object B, but it cannot be used as an extractor due to its second non-implicit parameter list
+  "b" match { case B(i) => i }
+                   ^
+t11446.scala:31: error: object C is not a case class, nor does it have a valid unapply/unapplySeq member
+Note: def unapply(s: String, i: Int): Option[Int] exists in object C, but it cannot be used as an extractor as it has more than one (non-implicit) parameter
+  "c" match { case C(i) => i }
+                   ^
+t11446.scala:32: error: object D is not a case class, nor does it have a valid unapply/unapplySeq member
+Note: def unapply(): Option[Int] exists in object D, but it cannot be used as an extractor: an unapply method must accept a single argument
+  "d" match { case D(i) => i }
+                   ^
+t11446.scala:33: error: object E is not a case class, nor does it have a valid unapply/unapplySeq member
+Note: def unapply: Option[Int] exists in object E, but it cannot be used as an extractor: an unapply method must accept a single argument
+  "e" match { case E(i) => i }
+                   ^
+t11446.scala:34: error: object F is not a case class, nor does it have a valid unapply/unapplySeq member
+Note: val unapply: Option[Int] exists in object F, but it cannot be used as an extractor: an unapply method must accept a single argument
+  "f" match { case F(i) => i }
+                   ^
+t11446.scala:35: error: object F is not a case class, nor does it have a valid unapply/unapplySeq member
+Note: val unapply: Option[Int] exists in object F, but it cannot be used as an extractor: an unapply method must accept a single argument
+  "g" match { case F(i) => i }
+                   ^
+7 errors found

--- a/test/files/neg/t11446.scala
+++ b/test/files/neg/t11446.scala
@@ -1,0 +1,36 @@
+package t11446
+
+object A {
+  def unapply(s: String, strict: Boolean = false) =
+    if (s == "") None else Some(s.length)
+}
+object B {
+  def unapply(s: String)(u: Int) =
+    if (s == "") None else Some(u)
+}
+object C {
+  def unapply(s: String, i: Int) =
+    if (s == "") None else Some(i)
+}
+object D {
+  def unapply(): Option[Int] = Some(1)
+}
+object E {
+  def unapply: Option[Int] = Some(1)
+}
+object F {
+  val unapply: Option[Int] = Some(1)
+}
+object G {
+  def unapply(va: String*): Option[String] = va.headOption
+}
+
+object Test {
+  "a" match { case A(i) => i }
+  "b" match { case B(i) => i }
+  "c" match { case C(i) => i }
+  "d" match { case D(i) => i }
+  "e" match { case E(i) => i }
+  "f" match { case F(i) => i }
+  "g" match { case F(i) => i }
+}

--- a/test/files/neg/t4425.check
+++ b/test/files/neg/t4425.check
@@ -1,12 +1,12 @@
-t4425.scala:3: error: object X is not a case class, nor does it have an unapply/unapplySeq member
+t4425.scala:3: error: object X is not a case class, nor does it have a valid unapply/unapplySeq member
 Note: def unapply(x: Int)(y: Option[Int]): None.type exists in object X, but it cannot be used as an extractor due to its second non-implicit parameter list
   42 match { case _ X _ => () }
                     ^
-t4425.scala:8: error: object X is not a case class, nor does it have an unapply/unapplySeq member
+t4425.scala:8: error: object X is not a case class, nor does it have a valid unapply/unapplySeq member
 Note: def unapply(x: Int)(y: Int): Some[(Int, Int)] exists in object X, but it cannot be used as an extractor due to its second non-implicit parameter list
   42 match { case _ X _ => () }
                     ^
-t4425.scala:13: error: object X is not a case class, nor does it have an unapply/unapplySeq member
+t4425.scala:13: error: object X is not a case class, nor does it have a valid unapply/unapplySeq member
 Note: def unapply(x: String)(y: String): Some[(Int, Int)] exists in object X, but it cannot be used as an extractor due to its second non-implicit parameter list
   "" match { case _ X _ => () }
                     ^

--- a/test/files/neg/t4425b.check
+++ b/test/files/neg/t4425b.check
@@ -1,24 +1,24 @@
-t4425b.scala:5: error: object X is not a case class, nor does it have an unapply/unapplySeq member
+t4425b.scala:5: error: object X is not a case class, nor does it have a valid unapply/unapplySeq member
 Note: def unapply(x: String)(y: String): Nothing exists in object X, but it cannot be used as an extractor due to its second non-implicit parameter list
     println(      "" match { case _ X _   => "ok" ; case _ => "fail" })
                                     ^
-t4425b.scala:6: error: object X is not a case class, nor does it have an unapply/unapplySeq member
+t4425b.scala:6: error: object X is not a case class, nor does it have a valid unapply/unapplySeq member
 Note: def unapply(x: String)(y: String): Nothing exists in object X, but it cannot be used as an extractor due to its second non-implicit parameter list
     println((X: Any) match { case _ X _   => "ok" ; case _ => "fail" })
                                     ^
-t4425b.scala:7: error: object X is not a case class, nor does it have an unapply/unapplySeq member
+t4425b.scala:7: error: object X is not a case class, nor does it have a valid unapply/unapplySeq member
 Note: def unapply(x: String)(y: String): Nothing exists in object X, but it cannot be used as an extractor due to its second non-implicit parameter list
     println(      "" match { case X(_)    => "ok" ; case _ => "fail" })
                                   ^
-t4425b.scala:8: error: object X is not a case class, nor does it have an unapply/unapplySeq member
+t4425b.scala:8: error: object X is not a case class, nor does it have a valid unapply/unapplySeq member
 Note: def unapply(x: String)(y: String): Nothing exists in object X, but it cannot be used as an extractor due to its second non-implicit parameter list
     println((X: Any) match { case X(_)    => "ok" ; case _ => "fail" })
                                   ^
-t4425b.scala:9: error: object X is not a case class, nor does it have an unapply/unapplySeq member
+t4425b.scala:9: error: object X is not a case class, nor does it have a valid unapply/unapplySeq member
 Note: def unapply(x: String)(y: String): Nothing exists in object X, but it cannot be used as an extractor due to its second non-implicit parameter list
     println(      "" match { case X(_, _) => "ok" ; case _ => "fail" })
                                   ^
-t4425b.scala:10: error: object X is not a case class, nor does it have an unapply/unapplySeq member
+t4425b.scala:10: error: object X is not a case class, nor does it have a valid unapply/unapplySeq member
 Note: def unapply(x: String)(y: String): Nothing exists in object X, but it cannot be used as an extractor due to its second non-implicit parameter list
     println((X: Any) match { case X(_, _) => "ok" ; case _ => "fail" })
                                   ^

--- a/test/files/neg/t5078.check
+++ b/test/files/neg/t5078.check
@@ -1,13 +1,9 @@
-t5078.scala:7: error: an unapply method must accept a single argument.
+t5078.scala:7: error: object Foo is not a case class, nor does it have a valid unapply/unapplySeq member
+Note: def unapply: Option[Int] exists in object Foo, but it cannot be used as an extractor: an unapply method must accept a single argument
     val Foo(x1) = 1
         ^
-t5078.scala:7: error: recursive value x1 needs type
-    val Foo(x1) = 1
-           ^
-t5078.scala:8: error: an unapply method must accept a single argument.
+t5078.scala:8: error: object Foo2 is not a case class, nor does it have a valid unapply/unapplySeq member
+Note: def unapply(): Option[Int] exists in object Foo2, but it cannot be used as an extractor: an unapply method must accept a single argument
     val Foo2(y2) = 2
         ^
-t5078.scala:8: error: recursive value y2 needs type
-    val Foo2(y2) = 2
-            ^
-four errors found
+two errors found


### PR DESCRIPTION
According to the spec, defaults don't cut it.

Also tweak the error messaging, and clarify the spec.

Fixes scala/bug#11446.