### PR TITLE
Add lastSuch method, use it to avoid List flatten.

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3017,7 +3017,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       res
     }
 
-    override def isVarargs: Boolean = definitions.isVarArgsList(paramss.flatten)
+    override def isVarargs: Boolean = definitions.isVarArgsList(lastSuch(paramss)(!_.isEmpty))
 
     override def returnType: Type = {
       def loop(tpe: Type): Type =

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -55,6 +55,17 @@ trait Collections {
   final def mforeach[A](xss: List[List[A]])(f: A => Unit) = xss foreach (_ foreach f)
   final def mforeach[A](xss: Traversable[Traversable[A]])(f: A => Unit) = xss foreach (_ foreach f)
 
+  final def lastSuch[A](xs: List[A])(pred: A => Boolean): Option[A] = {
+    var res: A = null.asInstanceOf[A]
+    var ys = xs
+    while (!ys.isEmpty){
+      if (pred(ys.head))
+        res = ys.head
+      ys = ys.tail
+    }
+    Option(res)
+  }
+
   /** A version of List#map, specialized for List, and optimized to avoid allocation if `as` is empty */
   final def mapList[A, B](as: List[A])(f: A => B): List[B] = if (as eq Nil) Nil else {
     val head = new ::[B](f(as.head), Nil)


### PR DESCRIPTION
We add to the Collections trait a function "lastSuch", which returns the right-most element of the list that meets a property. We use this method to replace a call to `List.flatten.last`.