### PR TITLE
provide map, flatMap, collect, concat that return CollisionProofHashMap

### DIFF
--- a/test/junit/scala/collection/mutable/CollisionProofHashMapTest.scala
+++ b/test/junit/scala/collection/mutable/CollisionProofHashMapTest.scala
@@ -102,4 +102,34 @@ class CollisionProofHashMapTest {
     assertEquals(m4(2), "3")
     assertEquals(m4(100), "101")
   }
+  @Test
+  def testPreserveType: Unit = {
+    val m1 = mutable.CollisionProofHashMap(1 -> "a", 2 -> "b")
+    val m2 = (m1 map { case (k, v) => k -> (v + "!") }).addOne(3 -> "c")
+    assertEquals(m2(3), "c")
+
+    val m3 = (m1 flatMap { case (k, v) => List(k -> (v + "!"), -k -> (v + "!")) }).addOne(3 -> "c")
+    assertEquals(m3(3), "c")
+
+    val m4 = (m1 collect { case (k, v) if k == 1 => k -> (v + "!") }).addOne(3 -> "c")
+    assertEquals(m4(3), "c")
+
+    val m5 = (m1 concat List(4 -> "d")).addOne(3 -> "c")
+    assertEquals(m5(3), "c")
+
+    val m6 = (m1 ++ List(4 -> "d")).addOne(3 -> "c")
+    assertEquals(m6(3), "c")
+
+    // deprecated
+    val m7 = (m1 + (4 -> "d")).addOne(3 -> "c")
+    assertEquals(m7(3), "c")
+
+    // deprecated
+    val m8 = (m1 + (4 -> "d", 5 -> "e")).addOne(3 -> "c")
+    assertEquals(m8(3), "c")
+
+    // deprecated
+    val m9 = (m1.updated(4, "d")).addOne(3 -> "c")
+    assertEquals(m9(3), "c")
+  }
 }


### PR DESCRIPTION
Fixes scala/bug#11449

```scala
scala> import scala.collection.mutable
import scala.collection.mutable

scala> val m1 = mutable.CollisionProofHashMap(1 -> "a", 2 -> "b")
m1: scala.collection.mutable.CollisionProofHashMap[Int,String] = CollisionProofHashMap(1 -> a, 2 -> b)

scala> val m2 = (m1 map { case (k, v) => k -> (v + "!") }).addOne(3 -> "c")
m2: scala.collection.mutable.CollisionProofHashMap[Int,String] = CollisionProofHashMap(1 -> a!, 2 -> b!, 3 -> c)

scala> val m3 = (m1 flatMap { case (k, v) => List(k -> (v + "!"), -k -> (v + "!")) }).addOne(3 -> "c")
m3: scala.collection.mutable.CollisionProofHashMap[Int,String] = CollisionProofHashMap(-1 -> a!, -2 -> b!, 1 -> a!, 2 -> b!, 3 -> c)

scala> val m4 = (m1 collect { case (k, v) if k == 1 => k -> (v + "!") }).addOne(3 -> "c")
m4: scala.collection.mutable.CollisionProofHashMap[Int,String] = CollisionProofHashMap(1 -> a!, 3 -> c)

scala> val m5 = (m1 concat List(4 -> "d")).addOne(3 -> "c")
m5: scala.collection.mutable.CollisionProofHashMap[Int,String] = CollisionProofHashMap(1 -> a, 2 -> b, 3 -> c, 4 -> d)

scala> val m6 = (m1 ++ List(4 -> "d")).addOne(3 -> "c")
m6: scala.collection.mutable.CollisionProofHashMap[Int,String] = CollisionProofHashMap(1 -> a, 2 -> b, 3 -> c, 4 -> d)

scala> val m7 = (m1 + (4 -> "d")).addOne(3 -> "c")
                    ^
       warning: method + in class CollisionProofHashMap is deprecated (since 2.13.0): Consider requiring an immutable Map or fall back to Map.concat
m7: scala.collection.mutable.CollisionProofHashMap[Int,String] = CollisionProofHashMap(1 -> a, 2 -> b, 3 -> c, 4 -> d)

scala> val m8 = (m1 + (4 -> "d", 5 -> "e")).addOne(3 -> "c")
                    ^
       warning: method + in class CollisionProofHashMap is deprecated (since 2.13.0): Use ++ with an explicit collection argument instead of + with varargs
m8: scala.collection.mutable.CollisionProofHashMap[Int,String] = CollisionProofHashMap(1 -> a, 2 -> b, 3 -> c, 4 -> d, 5 -> e)

scala> val m9 = (m1.updated(4, "d")).addOne(3 -> "c")
                    ^
       warning: method updated in trait MapOps is deprecated (since 2.13.0): Use m.clone().addOne((k,v)) instead of m.updated(k, v)
m9: scala.collection.mutable.Map[Int,String] = CollisionProofHashMap(1 -> a, 2 -> b, 3 -> c, 4 -> d)
```