### PR TITLE
Remove overridden productPrefix in case class equality test

### DIFF
--- a/test/files/run/caseClassEquality.scala
+++ b/test/files/run/caseClassEquality.scala
@@ -1,11 +1,7 @@
 object Test {
   abstract class A1
   case class C1(x: Int) extends A1
-  class C2(x: Int) extends C1(x) {
-    // this used to be a different prefix, not sure what it was testing
-    // (now, hashCode takes the prefix into account, so using the same as the super case class is the only way to maintain the assert on hashCode below)
-    override def productPrefix = "C1"
-  }
+  class C2(x: Int) extends C1(x)
   class C3(x: Int) extends C1(x) {
     override def canEqual(other: Any) = other.isInstanceOf[C3]
     override def equals(other: Any) = other match {


### PR DESCRIPTION
The override is not necessary, because the `productPrefix` is
inherited from the case class parent.

If this were not the case, it would mean violating the `equals` -
`hashCode` contract by default for classes extending case classes,
so I think the test is more meaningful without the override.

Follow up #7693