### PR TITLE
GlbLubs: Small performance Tweak.

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -66,20 +66,20 @@ private[internal] trait GlbLubs {
     *  @return List of symbol pairs holding the recursive type
     *    parameter and the parameter which references it.
     */
-  def findRecursiveBounds(ts: List[Type]): List[(Symbol, Symbol)] = {
+  def findRecursiveBounds(ts: List[Type]): List[Symbol] = {
     if (ts.isEmpty) Nil
     else {
       val sym = ts.head.typeSymbol
       require(ts.tail forall (_.typeSymbol == sym), ts)
       for (p <- sym.typeParams ; in <- sym.typeParams ; if in.info.bounds contains p) yield
-        p -> in
+        in
     }
   }
 
   // only called when strictInference
   private def willViolateRecursiveBounds(tp: Type, ts: List[Type], tsElimSub: List[Type]) = {
     val typeSym     = ts.head.typeSymbol // we're uniform, the `.head` is as good as any.
-    def fbounds     = findRecursiveBounds(ts) map (_._2)
+    def fbounds     = findRecursiveBounds(ts)
     def isRecursive = typeSym.typeParams exists fbounds.contains
 
     isRecursive && (transposeSafe(tsElimSub map (_.normalize.typeArgs)) match {
@@ -87,9 +87,9 @@ private[internal] trait GlbLubs {
         val mergedTypeArgs = (tp match { case et: ExistentialType => et.underlying; case _ => tp}).typeArgs
         exists3(typeSym.typeParams, mergedTypeArgs, arggsTransposed) {
           (param, arg, lubbedArgs) =>
-            val isExistential = arg.typeSymbol.isExistentiallyBound
-            val isInFBound    = fbounds contains param
-            val wasLubbed     = !lubbedArgs.exists(_ =:= arg)
+            def isExistential = arg.typeSymbol.isExistentiallyBound
+            def isInFBound    = fbounds contains param
+            def wasLubbed     = !lubbedArgs.exists(_ =:= arg)
             (!isExistential && isInFBound && wasLubbed)
         }
       case None => false


### PR DESCRIPTION
The function `findRecursiveBounds` was building a list of pairs,
but in the only called that list was mapped to second elements.
We modify the function to directly return the second elements.

We change some `val` by `def` in the `exists3` block, so as to
allow for short-circuiting expensive comutations.