### PR TITLE
Duplicators: avoid allocations in call to invalidateAll

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
@@ -174,7 +174,8 @@ abstract class Duplicators extends Analyzer {
 
           case DefDef(_, name, tparams, vparamss, _, rhs) =>
             // invalidate parameters
-            invalidateAll(tparams ::: vparamss.flatten)
+            invalidateAll(tparams)
+            vparamss foreach (x => invalidateAll(x))
             tree.symbol = NoSymbol
 
           case Function(vparams, _) =>


### PR DESCRIPTION
The method `invalidateAll` is just a foreach loop. In that case, rather than flattening the `vparamss` and pre-pending the `tparams`, which allocates a list that is just consumed, we run the call on
`tparams` and then use a foreach on the `vparamss`.