### PR TITLE
[11440] ArrayDeque.empty#sliding(1) returns empty iterator

### DIFF
--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -483,9 +483,13 @@ class ArrayDeque[A] protected (
 
   override def sliding(window: Int, step: Int): Iterator[IterableCC[A]] = {
     require(window > 0 && step > 0, s"window=$window and step=$step, but both must be positive")
-    val lag = if (window > step) window - step else 0
-    if (length <= window) Iterator.single(slice(0, length))
-    else Iterator.range(start = 0, end = length - lag, step = step).map(i => slice(i, i + window))
+    length match {
+      case 0 => Iterator.empty
+      case n if n <= window => Iterator.single(slice(0, length))
+      case n =>
+        val lag = if (window > step) window - step else 0
+        Iterator.range(start = 0, end = n - lag, step = step).map(i => slice(i, i + window))
+    }
   }
 
   override def grouped(n: Int): Iterator[IterableCC[A]] = sliding(n, n)

--- a/test/junit/scala/collection/mutable/ArrayDequeTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayDequeTest.scala
@@ -104,18 +104,17 @@ class ArrayDequeTest {
 object ArrayDequeTest {
 
   // tests scala/bug#11047
-  def genericSlidingTest(factory: SeqFactory[ArrayDeque], collectionName: String): Unit =
+  def genericSlidingTest(factory: SeqFactory[ArrayDeque], collectionName: String): Unit = {
     for {
-      i <- 1 to 40
+      i <- 0 to 40
 
       range = 0 until i
-      iterable = collection.Iterable.from(range)
       other = factory.from(range)
 
       j <- 1 to 40
       k <- 1 to 40
 
-      iterableSliding = iterable.sliding(j,k).to(Seq)
+      iterableSliding = range.sliding(j, k).to(Seq)
       otherSliding = other.sliding(j, k).to(Seq)
     }
       assert(iterableSliding == otherSliding,
@@ -124,4 +123,8 @@ object ArrayDequeTest {
            |$collectionName yielded: $otherSliding
        """.stripMargin
       )
+
+    // scala/bug#11440
+    assertEquals(0, factory.empty[Int].sliding(1).size)
+  }
 }


### PR DESCRIPTION
Fixes scala/bug#11440