### PR TITLE
create trait collection.SeqMap

### DIFF
--- a/src/library/scala/collection/SeqMap.scala
+++ b/src/library/scala/collection/SeqMap.scala
@@ -10,12 +10,10 @@
  * additional information regarding copyright ownership.
  */
 
-package scala
-package collection
-package mutable
+package scala.collection
 
 /**
-  * A generic trait for ordered mutable maps. Concrete classes have to provide
+  * A generic trait for ordered maps. Concrete classes have to provide
   * functionality for the abstract methods in `SeqMap`.
   *
   * Note that when checking for equality [[SeqMap]] does not take into account
@@ -24,15 +22,15 @@ package mutable
   * @tparam K      the type of the keys contained in this linked map.
   * @tparam V      the type of the values associated with the keys in this linked map.
   *
-  * @author Matthew de Detrich
+  * @author Matthew de Detrich, Josh Lemer
   * @version 2.13
   * @since 2.13
-  * @define coll mutable Seq map
-  * @define Coll `mutable.SeqMap`
+  * @define coll immutable seq map
+  * @define Coll `immutable.SeqMap`
   */
 
-trait SeqMap[K, V] extends Map[K, V]
-  with collection.SeqMap[K, V]
+trait SeqMap[K, +V] extends Map[K, V]
   with MapOps[K, V, SeqMap, SeqMap[K, V]]
 
-object SeqMap extends MapFactory.Delegate[SeqMap](LinkedHashMap)
+object SeqMap extends MapFactory.Delegate[immutable.SeqMap](immutable.SeqMap)
+

--- a/src/library/scala/collection/immutable/SeqMap.scala
+++ b/src/library/scala/collection/immutable/SeqMap.scala
@@ -14,8 +14,6 @@ package scala
 package collection
 package immutable
 
-import java.io.{ObjectInputStream, ObjectOutputStream}
-
 import scala.collection.mutable.Builder
 
 /**
@@ -36,11 +34,13 @@ import scala.collection.mutable.Builder
   */
 
 trait SeqMap[K, +V]
-  extends AbstractMap[K, V]
+  extends Map[K, V]
+    with collection.SeqMap[K, V]
     with MapOps[K, V, SeqMap, SeqMap[K, V]]
 
+
 object SeqMap extends MapFactory[SeqMap] {
-  def empty[K, V]: SeqMap[K, V] = EmptyLinkedMap.asInstanceOf[SeqMap[K, V]]
+  def empty[K, V]: SeqMap[K, V] = EmptySeqMap.asInstanceOf[SeqMap[K, V]]
 
   def from[K, V](it: collection.IterableOnce[(K, V)]): SeqMap[K, V] =
     it match {
@@ -51,7 +51,7 @@ object SeqMap extends MapFactory[SeqMap] {
   def newBuilder[K, V]: Builder[(K, V), SeqMap[K, V]] = VectorMap.newBuilder
 
   @SerialVersionUID(3L)
-  private object EmptyLinkedMap extends SeqMap[Any, Nothing] with Serializable {
+  private object EmptySeqMap extends SeqMap[Any, Nothing] with Serializable {
     override def size: Int = 0
     override def knownSize: Int = 0
     override def apply(key: Any) = throw new NoSuchElementException("key not found: " + key)


### PR DESCRIPTION
closes scala/bug#11458

also:
* immutable/mutable.SeqMap extends Map, not AbstractMap, to be consistent with other collecitons like SortedMap.

