### PR TITLE
Specialize attachments for common case of zero or one attachments.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -481,6 +481,13 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.macros.Attachments.removeElement"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.macros.Attachments.addElement"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.macros.Attachments.containsElement"),
+    // https://github.com/scala/scala/pull/7960: these only cause problems if someone is implausibly extending Attachments somehow
+    ProblemFilters.exclude[DirectAbstractMethodProblem]("scala.reflect.macros.Attachments.all"),
+    ProblemFilters.exclude[ReversedAbstractMethodProblem]("scala.reflect.macros.Attachments.all"),
+    ProblemFilters.exclude[DirectAbstractMethodProblem]("scala.reflect.macros.Attachments.isEmpty"),
+    ProblemFilters.exclude[ReversedAbstractMethodProblem]("scala.reflect.macros.Attachments.isEmpty"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.reflect.macros.EmptyAttachments"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.reflect.macros.SingleAttachment"),
 
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.Settings.async"),
 

--- a/src/reflect/scala/reflect/internal/util/Position.scala
+++ b/src/reflect/scala/reflect/internal/util/Position.scala
@@ -16,7 +16,7 @@ package internal
 package util
 
 /** @inheritdoc */
-class Position extends scala.reflect.api.Position with InternalPositionImpl with DeprecatedPosition {
+class Position extends macros.EmptyAttachments with api.Position with InternalPositionImpl with DeprecatedPosition {
   type Pos = Position
   def pos: Position = this
   def withPos(newPos: Position): macros.Attachments { type Pos = Position.this.Pos } = newPos

--- a/src/reflect/scala/reflect/macros/Attachments.scala
+++ b/src/reflect/scala/reflect/macros/Attachments.scala
@@ -14,6 +14,8 @@ package scala
 package reflect
 package macros
 
+import reflect.internal.util.Position
+
 /**
  * <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>
  *
@@ -35,7 +37,7 @@ package macros
 abstract class Attachments { self =>
 
   /** The position type of this attachment */
-  type Pos >: Null
+  type Pos >: Null // <: api.Position
 
   /** The underlying position */
   def pos: Pos
@@ -44,7 +46,7 @@ abstract class Attachments { self =>
   def withPos(newPos: Pos): Attachments { type Pos = self.Pos }
 
   /** The underlying payload with the guarantee that no two elements have the same type. */
-  def all: Set[Any] = Set.empty
+  def all: Set[Any]
 
   private def matchesTag[T: ClassTag]: (Any => Boolean) = {
     // OPT: avoid lambda allocation for each call to `remove`, etc.
@@ -71,6 +73,7 @@ abstract class Attachments { self =>
     else {
       val newAll = all filterNot matchesTag[T]
       if (newAll.isEmpty) pos.asInstanceOf[Attachments { type Pos = self.Pos }]
+      else if (newAll.size == 1) new SingleAttachment[Pos](pos, newAll.head)
       else new NonemptyAttachments[Pos](this.pos, newAll)
     }
   }
@@ -81,10 +84,11 @@ abstract class Attachments { self =>
     else if (newAll.isEmpty) pos.asInstanceOf[Attachments { type Pos = self.Pos }]
     else new NonemptyAttachments[Pos](this.pos, newAll)
   }
+
   /** Creates a copy of this attachment with the given element added. */
   final def addElement[T](attachment: T): Attachments { type Pos = self.Pos } = {
     val newAll = all + attachment
-    if (newAll eq all) this
+    if (newAll eq all) this // i.e., this was the same attachment as before
     else new NonemptyAttachments[Pos](this.pos, newAll)
   }
 
@@ -93,13 +97,37 @@ abstract class Attachments { self =>
     all.contains(element)
   }
 
-  def isEmpty: Boolean = true
+  def isEmpty: Boolean
 }
 
 private object Attachments {
   private val matchesTagCache = new ClassValue[Function1[Any, Boolean]] {
     override def computeValue(cls: Class[_]): Function[Any, Boolean] = cls.isInstance(_)
   }
+}
+
+private[reflect] abstract class EmptyAttachments extends Attachments { self: Position =>
+  final override def all: Set[Any] = Set.empty
+  final override def get[T: ClassTag]: Option[T] = None
+  final override def contains[T: ClassTag]: Boolean = false
+  final override def update[T: ClassTag](newAtt: T): Attachments { type Pos = self.Pos } =
+    new SingleAttachment[Pos](pos, newAtt)
+  final override def remove[T: ClassTag]: Attachments { type Pos = self.Pos } = this
+  final override def isEmpty: Boolean = true
+}
+
+private final class SingleAttachment[P >: Null](override val pos: P, val att: Any) extends Attachments {
+  type Pos = P
+  def withPos(newPos: Pos) = new SingleAttachment[Pos](newPos, att)
+  override def isEmpty: Boolean = false
+  override def all = Set.empty[Any] + att
+  override def contains[T](implicit tt: ClassTag[T]) = tt.runtimeClass.isInstance(att)
+  override def get[T](implicit tt: ClassTag[T]) = if (contains(tt)) Some(att.asInstanceOf[T]) else None
+  override def update[T](newAtt: T)(implicit tt: ClassTag[T]) =
+    if (contains(tt)) new SingleAttachment[P](pos, newAtt)
+    else new NonemptyAttachments[P](pos, Set.empty[Any] + att + newAtt)
+  override def remove[T](implicit tt: ClassTag[T]) =
+    if (contains(tt)) pos.asInstanceOf[Attachments { type Pos = P }] else this
 }
 
 // scala/bug#7018: This used to be an inner class of `Attachments`, but that led to a memory leak in the

--- a/test/junit/scala/reflect/macros/AttachmentsTest.scala
+++ b/test/junit/scala/reflect/macros/AttachmentsTest.scala
@@ -1,0 +1,65 @@
+package scala.reflect.macros
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.reflect.internal.util._
+
+@RunWith(classOf[JUnit4])
+class AttachmentsTest {
+  def emptyAtt: Attachments = NoPosition
+
+  @Test def testAttachments = {
+    var atts = emptyAtt
+
+    assert(atts.isEmpty)
+    assert(atts.all.isEmpty)
+
+    atts = atts update Foo(0)
+    assert(!atts.isEmpty)
+    assert(atts.all == Set(Foo(0)))
+    assert(atts.contains[Foo])
+    assert(atts.get[Foo] == Some(Foo(0)))
+
+    atts = atts.remove[Bar]
+    assert(!atts.isEmpty)
+    assert(atts.all == Set(Foo(0)))
+    assert(atts.contains[Foo])
+    assert(atts.get[Foo] == Some(Foo(0)))
+
+    object theBar extends Bar
+    atts = atts.update(theBar)
+    assert(!atts.isEmpty)
+    assert(atts.all == Set(Foo(0), theBar))
+    assert(atts.get[Foo] == Some(Foo(0)))
+    assert(atts.get[Bar] == Some(theBar))
+    assert(atts.get[theBar.type] == Some(theBar))
+
+    atts = atts.update(new Baz)
+    assert(!atts.isEmpty)
+    assert(!(atts.all contains Foo(0)))
+    assert(atts.all.exists(_.isInstanceOf[Baz]))
+    assert(atts.get[Baz].isDefined)
+    assert(atts.get[Foo].isEmpty)
+    assert(atts.get[Bar].isDefined)
+
+    atts = atts.update("foo")
+    atts = atts.update(Zzy)
+    assert(!atts.isEmpty)
+    assert(atts.all.size == 4, atts.toString)
+    assert(atts.contains[String])
+    assert(atts.contains[Zzy.type])
+    assert(atts.contains[Baz])
+    assert(atts.contains[theBar.type])
+
+    atts = atts.remove[Zzy.type].remove[String]
+    assert(atts.all.size == 2)
+  }
+
+}
+
+case class Foo(i: Int) extends Baz
+class Bar
+class Baz
+object Zzy


### PR DESCRIPTION
Some cheap statistics around attachments shows that around 1.1% of trees/symbols receive attachments, and less than a tenth of a percent receive multiple. Therefore, add a specialized class to hold a position and a single attachment.

cc @mkeskells 

I saw an (admittedly-shaky) 0.3-0.5% improvement on the scalap corpus from this. My nice computer has died, so that's on my decade-old desktop, for whatever it's worth.