### PR TITLE
Refine type returned by SortedMap#updatedWith

### DIFF
--- a/test/junit/scala/collection/immutable/SortedMapTest.scala
+++ b/test/junit/scala/collection/immutable/SortedMapTest.scala
@@ -138,4 +138,11 @@ class SortedMapTest {
     assertEquals(m4(2), "3")
     assertEquals(m4(100), "101")
   }
+
+  @Test def updatedWithReturnsSortedMap: Unit = {
+    val m1 = SortedMap(1 -> "a")
+    val m2 = m1.updatedWith(2) { case Some(v) => Some(v.toUpperCase) case None => Some("DEFAULT") }
+    val m3: SortedMap[Int, String] = m2 // check the type returned by `updatedWith`
+    assertEquals(SortedMap(1 -> "a", 2 -> "DEFAULT"), m3)
+  }
 }


### PR DESCRIPTION
Just like we do for `updated`.

Example of motivating use case: https://github.com/scala/scala-collection-contrib/pull/15/files#diff-ecdb036a4a3e0b0d1951d49df66779b0R32