### PR TITLE
Improve message for infix nullary invocation

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -870,7 +870,7 @@ self =>
       }
       def mkNamed(args: List[Tree]) = if (isExpr) args map treeInfo.assignmentToMaybeNamedArg else args
       val arguments = right match {
-        case Parens(Nil)  => Literal(Constant(())) :: Nil
+        case Parens(Nil)  => literalUnit :: Nil
         case Parens(args) => mkNamed(args)
         case _            => right :: Nil
       }

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -595,7 +595,11 @@ trait ContextErrors {
             val excess = supplied - expected
             val target = treeSymTypeMsg(fun)
 
-            if (expected == 0) s"no arguments allowed for nullary $target"
+            if (expected == 0) args match {
+              case (c @ Literal(Constant(()))) :: Nil if c.hasAttachment[SyntheticUnitAttachment.type] =>
+                s"can't supply unit value with infix notation because nullary $target takes no arguments; use dotted invocation instead: ${show(treeCopy.Apply(tree, fun, Nil))}"
+              case _ => s"no arguments allowed for nullary $target"
+            }
             else if (excess < 3 && expected <= 5) s"too many arguments ($supplied) for $target"
             else if (expected > 10) s"$supplied arguments but expected $expected for $target"
             else {

--- a/test/files/neg/t8667.check
+++ b/test/files/neg/t8667.check
@@ -97,4 +97,10 @@ t8667.scala:33: error: 2 more arguments than can be applied to method f6: (i: In
 t8667.scala:34: error: 15 arguments but expected 12 for method f12: (i: Int, j: Int, k: Int, l: Int, m: Int, n: Int, o: Int, p: Int, q: Int, r: Int, s: Int, t: Int)Int
     f12(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
                                                ^
-33 errors found
+t8667.scala:42: error: can't supply unit value with infix notation because nullary method f0: ()Int takes no arguments; use dotted invocation instead: x.f0()
+    x f0 ()
+      ^
+t8667.scala:43: error: no arguments allowed for nullary method f0: ()Int
+    x.f0(())
+         ^
+35 errors found

--- a/test/files/neg/t8667.scala
+++ b/test/files/neg/t8667.scala
@@ -35,3 +35,16 @@ trait X {
     ()
   }
 }
+
+object app {
+  def test(): Unit = {
+    val x = null.asInstanceOf[X]
+    x f0 ()
+    x.f0(())
+  }
+  def workaround(): Unit = {
+    import language.postfixOps
+    val x = null.asInstanceOf[X]
+    x f0
+  }
+}


### PR DESCRIPTION
Detect that the unit value was reconstituted by
parser and realize that the user exploited
obsolete `x f ()` for nullary `f`.

Fixes scala/bug#11461