### PR TITLE
Rework unification of Object and Any in Java/Scala interop

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -270,7 +270,7 @@ trait Infer extends Checkable {
      * Note: pre is not refchecked -- moreover, refchecking the resulting tree may not refcheck pre,
      *       since pre may not occur in its type (callers should wrap the result in a TypeTreeWithDeferredRefCheck)
      */
-    def checkAccessible(tree: Tree, sym: Symbol, pre: Type, site: Tree): Tree = {
+    def checkAccessible(tree: Tree, sym: Symbol, pre: Type, site: Tree, isJava: Boolean): Tree = {
       def malformed(ex: MalformedType, instance: Type): Type = {
         val what    = if (ex.msg contains "malformed type") "is malformed" else s"contains a ${ex.msg}"
         val message = s"\n because its instance type $instance $what"
@@ -302,7 +302,9 @@ trait Infer extends Checkable {
               // OPT: avoid lambda allocation and Type.map for super constructor calls
               case _: SuperType if !sym.isConstructor && !owntype.isInstanceOf[OverloadedType] =>
                 owntype map ((tp: Type) => if (tp eq pre) site.symbol.thisType else tp)
-              case _ => owntype
+              case _ =>
+                if ((owntype eq ObjectTpe) && isJava) ObjectTpeJava
+                else owntype
             }
           )
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1273,12 +1273,12 @@ trait Namers extends MethodSynthesis {
 
     // make a java method type if meth.isJavaDefined
     private def methodTypeFor(meth: Symbol, vparamSymss: List[List[Symbol]], restpe: Type) = {
-      def makeJavaMethodType(vparams: List[Symbol], restpe: Type) = {
-        vparams foreach (p => p setInfo objToAny(p.tpe))
-        JavaMethodType(vparams, restpe)
+      def makeMethodType(vparams: List[Symbol], restpe: Type) = {
+        vparams foreach (p => p setInfo p.tpe)
+        MethodType(vparams, restpe)
       }
       if (vparamSymss.isEmpty) NullaryMethodType(restpe)
-      else if (meth.isJavaDefined) vparamSymss.foldRight(restpe)(makeJavaMethodType)
+      else if (meth.isJavaDefined) vparamSymss.foldRight(restpe)(makeMethodType)
       else vparamSymss.foldRight(restpe)(MethodType(_, _))
     }
 
@@ -1755,7 +1755,7 @@ trait Namers extends MethodSynthesis {
         case TypeBounds(lt, rt) if (lt.isError || rt.isError) =>
           TypeBounds.empty
         case tp @ TypeBounds(lt, rt) if (tdef.symbol hasFlag JAVA) =>
-          TypeBounds(lt, objToAny(rt))
+          TypeBounds(lt, rt)
         case tp =>
           tp
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -588,9 +588,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             case SelectFromTypeTree(_, name) => SelectFromTypeTree(qual, name)
           }
         }
-        (checkAccessible(tree1, sym, qual.tpe, qual), qual.tpe)
+        (checkAccessible(tree1, sym, qual.tpe, qual, unit.isJava), qual.tpe)
       } else {
-        (checkAccessible(tree, sym, pre, site), pre)
+        (checkAccessible(tree, sym, pre, site, unit.isJava), pre)
       }
 
     /** Post-process an identifier or selection node, performing the following:

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -41,7 +41,7 @@ trait Definitions extends api.StandardDefinitions {
   private def newMethod(owner: Symbol, name: TermName, formals: List[Type], restpe: Type, flags: Long): MethodSymbol = {
     val msym   = owner.newMethod(name.encode, NoPosition, flags)
     val params = msym.newSyntheticValueParams(formals)
-    val info = if (owner.isJavaDefined) JavaMethodType(params, restpe) else MethodType(params, restpe)
+    val info = MethodType(params, restpe)
     msym.setInfo(info).markAllCompleted
   }
   private def enterNewMethod(owner: Symbol, name: TermName, formals: List[Type], restpe: Type, flags: Long = 0L): MethodSymbol =
@@ -293,6 +293,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val NothingTpe      = NothingClass.tpe
     lazy val NullTpe         = NullClass.tpe
     lazy val ObjectTpe       = ObjectClass.tpe
+    lazy val ObjectTpeJava   = mkObjectTpeJava
     lazy val SerializableTpe = SerializableClass.tpe
     lazy val StringTpe       = StringClass.tpe
     lazy val ThrowableTpe    = ThrowableClass.tpe
@@ -447,7 +448,7 @@ trait Definitions extends api.StandardDefinitions {
      // We don't need to deal with JavaRepeatedParamClass here, as `repeatedToSeq` is only called in the patmat translation for Scala sources.
     def repeatedToSeq(tp: Type): Type                        = elementTransform(RepeatedParamClass, tp)(seqType) orElse tp
     def seqToRepeated(tp: Type): Type                        = elementTransform(SeqClass, tp)(scalaRepeatedType) orElse tp
-    def isReferenceArray(tp: Type)                           = elementTest(ArrayClass, tp)(_ <:< AnyRefTpe)
+    def isReferenceArray(tp: Type)                           = elementTest(ArrayClass, tp)(elemtp => elemtp <:< AnyRefTpe || (elemtp eq ObjectTpeJava))
     def isArrayOfSymbol(tp: Type, elem: Symbol)              = elementTest(ArrayClass, tp)(_.typeSymbol == elem)
     def elementType(container: Symbol, tp: Type): Type       = elementExtract(container, tp)
 

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -149,8 +149,9 @@ trait TypeComparers {
     && (tp1.normalize =:= tp2.normalize)
   )
   private def isSameTypeRef(tr1: TypeRef, tr2: TypeRef) = (
-       equalSymsAndPrefixes(tr1.sym, tr1.pre, tr2.sym, tr2.pre)
-    && (isSameHKTypes(tr1, tr2) || isSameTypes(tr1.args, tr2.args))
+    if ((((tr1 eq ObjectTpeJava) && (tr2.sym eq AnyClass)) || (tr2 eq ObjectTpeJava) && (tr1.sym eq AnyClass)))
+      true
+    else equalSymsAndPrefixes(tr1.sym, tr1.pre, tr2.sym, tr2.pre) && (isSameHKTypes(tr1, tr2) || isSameTypes(tr1.args, tr2.args))
   )
 
   private def isSameSingletonType(tp1: SingletonType, tp2: SingletonType): Boolean = {
@@ -459,7 +460,7 @@ trait TypeComparers {
             // These typerefs are pattern matched up and down far more
             // than is necessary.
             val sym1 = tr1.sym
-            val sym2 = tr2.sym
+            val sym2 = if (!phase.erasedTypes && (tr2 eq ObjectTpeJava)) AnyClass else tr2.sym
             val pre1 = tr1.pre
             val pre2 = tr2.pre
             (((if (sym1 eq sym2) phase.erasedTypes || sym1.owner.hasPackageFlag || isSubType(pre1, pre2, depth)
@@ -557,7 +558,7 @@ trait TypeComparers {
             val res2 = mt2.resultType
             (sameLength(params1, params2) &&
               mt1.isImplicit == mt2.isImplicit &&
-              matchingParams(params1, params2, mt1.isJava, mt2.isJava) &&
+              matchingParams(params1, params2) &&
               isSubType(res1.substSym(params1, params2), res2, depth))
           // TODO: if mt1.params.isEmpty, consider NullaryMethodType?
           case _ =>

--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -72,7 +72,7 @@ trait Erasure {
    *  e.g. with "tagged types" like Array[Int] with T.
    */
   def unboundedGenericArrayLevel(tp: Type): Int = tp match {
-    case GenericArray(level, core) if !(core <:< AnyRefTpe) => level
+    case GenericArray(level, core) if !(core <:< AnyRefTpe || core.upperBound == ObjectTpeJava) => level
     case RefinedType(ps, _) if ps.nonEmpty                  => logResult(s"Unbounded generic level for $tp is")(unboundedGenericArrayLevel(intersectionDominator(ps)))
     case _                                                  => 0
   }

--- a/src/reflect/scala/reflect/internal/transform/UnCurry.scala
+++ b/src/reflect/scala/reflect/internal/transform/UnCurry.scala
@@ -76,7 +76,7 @@ trait UnCurry {
       case TypeRef(pre, RepeatedParamClass, arg :: Nil) =>
         Some(seqType(arg))
       case TypeRef(pre, JavaRepeatedParamClass, arg :: Nil) =>
-        Some(arrayType(if (isUnboundedGeneric(arg)) ObjectTpe else arg))
+        Some(arrayType(if (isUnboundedGeneric(arg)) ObjectTpeJava else arg))
       case _ =>
         None
       }

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -677,7 +677,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
     private class TypeParamCompleter(jtvar: jTypeVariable[_ <: GenericDeclaration]) extends LazyType with FlagAgnosticCompleter {
       override def load(sym: Symbol) = complete(sym)
       override def complete(sym: Symbol) = {
-        sym setInfo TypeBounds.upper(glb(jtvar.getBounds.toList map typeToScala map objToAny))
+        sym setInfo TypeBounds.upper(glb(jtvar.getBounds.toList map typeToScala))
         markAllCompleted(sym)
       }
     }
@@ -1084,7 +1084,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
           val tparam = owner.newExistential(newTypeName("T$" + tparams.length))
             .setInfo(TypeBounds(
               lub(jwild.getLowerBounds.toList map typeToScala),
-              glb(jwild.getUpperBounds.toList map typeToScala map objToAny)))
+              glb(jwild.getUpperBounds.toList map typeToScala)))
           tparams += tparam
           typeRef(NoPrefix, tparam, List())
         case _ =>
@@ -1102,7 +1102,10 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
           arrayType(typeToScala(jclazz.getComponentType))
         else {
           val clazz = classToScala(jclazz)
-          rawToExistential(typeRef(clazz.owner.thisType, clazz, List()))
+          rawToExistential(typeRef(clazz.owner.thisType, clazz, List())) match {
+            case ObjectTpe => ObjectTpeJava
+            case tp => tp
+          }
         }
       case japplied: ParameterizedType =>
         // http://stackoverflow.com/questions/5767122/parameterizedtype-getrawtype-returns-j-l-r-type-not-class
@@ -1112,7 +1115,11 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
         val (args, bounds) = targsToScala(pre.typeSymbol, args0.toList)
         newExistentialType(bounds, typeRef(pre, sym, args))
       case jarr: GenericArrayType =>
-        arrayType(typeToScala(jarr.getGenericComponentType))
+        var elemtp = typeToScala(jarr.getGenericComponentType)
+        if (elemtp.typeSymbol.isAbstractType && elemtp.upperBound =:= ObjectTpe) {
+          elemtp = intersectionType(List(elemtp, ObjectTpe))
+        }
+        arrayType(elemtp)
       case jtvar: jTypeVariable[_] =>
         val tparam = typeParamToScala(jtvar)
         typeRef(NoPrefix, tparam, List())
@@ -1219,7 +1226,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
             if (param.isNamePresent) TermName(param.getName)
             else nme.syntheticParamName(ix + 1)
           meth.owner.newValueParameter(name, meth.pos)
-            .setInfo(objToAny(typeToScala(param.getParameterizedType)))
+            .setInfo(typeToScala(param.getParameterizedType))
             .setFlag(if (param.isNamePresent) 0 else SYNTHETIC)
       }
     }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -231,6 +231,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.NothingTpe
     definitions.NullTpe
     definitions.ObjectTpe
+    definitions.ObjectTpeJava
     definitions.SerializableTpe
     definitions.StringTpe
     definitions.ThrowableTpe

--- a/test/files/neg/abstract-class-error.check
+++ b/test/files/neg/abstract-class-error.check
@@ -1,6 +1,6 @@
 S.scala:1: error: class S needs to be abstract. Missing implementation for:
   def g(y: Int, z: java.util.List): Int // inherited from class J
-(Note that java.util.List does not match java.util.List[String]. To implement this raw type, use java.util.List[_])
+(Note that java.util.List does not match java.util.List[String]. To implement this raw type, use java.util.List[_ <: Object])
 class S extends J {
       ^
 one error found

--- a/test/files/neg/abstract-report2.check
+++ b/test/files/neg/abstract-report2.check
@@ -3,15 +3,15 @@ Missing implementations for 13 members. Stub implementations follow:
   def add(x$1: Int): Boolean = ???
   def addAll(x$1: java.util.Collection[_ <: Int]): Boolean = ???
   def clear(): Unit = ???
-  def contains(x$1: Any): Boolean = ???
+  def contains(x$1: Object): Boolean = ???
   def containsAll(x$1: java.util.Collection[_]): Boolean = ???
   def isEmpty(): Boolean = ???
   def iterator(): java.util.Iterator[Int] = ???
-  def remove(x$1: Any): Boolean = ???
+  def remove(x$1: Object): Boolean = ???
   def removeAll(x$1: java.util.Collection[_]): Boolean = ???
   def retainAll(x$1: java.util.Collection[_]): Boolean = ???
   def size(): Int = ???
-  def toArray[T](x$1: Array[T with Object]): Array[T with Object] = ???
+  def toArray[T <: Object](x$1: Array[T with Object]): Array[T with Object] = ???
   def toArray(): Array[Object] = ???
 
 class Foo extends Collection[Int]
@@ -21,15 +21,15 @@ Missing implementations for 13 members. Stub implementations follow:
   def add(x$1: List[_ <: String]): Boolean = ???
   def addAll(x$1: java.util.Collection[_ <: List[_ <: String]]): Boolean = ???
   def clear(): Unit = ???
-  def contains(x$1: Any): Boolean = ???
+  def contains(x$1: Object): Boolean = ???
   def containsAll(x$1: java.util.Collection[_]): Boolean = ???
   def isEmpty(): Boolean = ???
   def iterator(): java.util.Iterator[List[_ <: String]] = ???
-  def remove(x$1: Any): Boolean = ???
+  def remove(x$1: Object): Boolean = ???
   def removeAll(x$1: java.util.Collection[_]): Boolean = ???
   def retainAll(x$1: java.util.Collection[_]): Boolean = ???
   def size(): Int = ???
-  def toArray[T](x$1: Array[T with Object]): Array[T with Object] = ???
+  def toArray[T <: Object](x$1: Array[T with Object]): Array[T with Object] = ???
   def toArray(): Array[Object] = ???
 
 class Bar extends Collection[List[_ <: String]]
@@ -39,15 +39,15 @@ Missing implementations for 13 members. Stub implementations follow:
   def add(x$1: T): Boolean = ???
   def addAll(x$1: java.util.Collection[_ <: T]): Boolean = ???
   def clear(): Unit = ???
-  def contains(x$1: Any): Boolean = ???
+  def contains(x$1: Object): Boolean = ???
   def containsAll(x$1: java.util.Collection[_]): Boolean = ???
   def isEmpty(): Boolean = ???
   def iterator(): java.util.Iterator[T] = ???
-  def remove(x$1: Any): Boolean = ???
+  def remove(x$1: Object): Boolean = ???
   def removeAll(x$1: java.util.Collection[_]): Boolean = ???
   def retainAll(x$1: java.util.Collection[_]): Boolean = ???
   def size(): Int = ???
-  def toArray[T](x$1: Array[T with Object]): Array[T with Object] = ???
+  def toArray[T <: Object](x$1: Array[T with Object]): Array[T with Object] = ???
   def toArray(): Array[Object] = ???
 
 class Baz[T] extends Collection[T]

--- a/test/files/neg/raw-types-stubs.check
+++ b/test/files/neg/raw-types-stubs.check
@@ -1,7 +1,7 @@
 S_3.scala:1: error: class Sub needs to be abstract.
 Missing implementations for 2 members. Stub implementations follow:
   def raw(x$1: M_1[_ <: String]): Unit = ???
-  def raw(x$1: Any): Unit = ???
+  def raw(x$1: Object): Unit = ???
 
 class Sub extends Raw_2 { }
       ^

--- a/test/files/neg/t4851.check
+++ b/test/files/neg/t4851.check
@@ -1,17 +1,17 @@
 S.scala:4: warning: adaptation of an empty argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous
-        signature: J(x: Any): J
+        signature: J(x: Object): J
   given arguments: <none>
  after adaptation: new J((): Unit)
   val x1 = new J
            ^
 S.scala:5: warning: adaptation of an empty argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous
-        signature: J(x: Any): J
+        signature: J(x: Object): J
   given arguments: <none>
  after adaptation: new J((): Unit)
   val x2 = new J()
            ^
 S.scala:6: warning: adapted the argument list to the expected 5-tuple: add additional parens instead
-        signature: J(x: Any): J
+        signature: J(x: Object): J
   given arguments: 1, 2, 3, 4, 5
  after adaptation: new J((1, 2, 3, 4, 5): (Int, Int, Int, Int, Int))
   val x3 = new J(1, 2, 3, 4, 5)

--- a/test/files/neg/t8035-deprecated.check
+++ b/test/files/neg/t8035-deprecated.check
@@ -11,7 +11,7 @@ t8035-deprecated.scala:7: warning: adaptation of an empty argument list by inser
   new A
   ^
 t8035-deprecated.scala:11: warning: adaptation of an empty argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous
-        signature: Format.format(x$1: Any): String
+        signature: Format.format(x$1: Object): String
   given arguments: <none>
  after adaptation: Format.format((): Unit)
   sdf.format()

--- a/test/files/neg/t8035-removed.check
+++ b/test/files/neg/t8035-removed.check
@@ -9,7 +9,7 @@ t8035-removed.scala:7: error: adaptation of an empty argument list by inserting 
   new A
   ^
 t8035-removed.scala:11: error: adaptation of an empty argument list by inserting () has been removed
-        signature: Format.format(x$1: Any): String
+        signature: Format.format(x$1: Object): String
   given arguments: <none>
   sdf.format()
             ^

--- a/test/files/pos/java-object-any-unification-1/J_1.java
+++ b/test/files/pos/java-object-any-unification-1/J_1.java
@@ -1,0 +1,16 @@
+package p1;
+
+public class J_1 {
+    public static class Map<A, B> {}
+
+    public static class A<K, V> {
+        public synchronized void putAll(Map<? extends K, ? extends V> t) {            
+        }
+    }
+
+    public static class B extends A<Object, Object> {
+        @Override
+        public synchronized void putAll(Map<?, ?> t) {
+        }
+    }
+}

--- a/test/files/pos/java-object-any-unification-1/Test_2.scala
+++ b/test/files/pos/java-object-any-unification-1/Test_2.scala
@@ -1,0 +1,5 @@
+object Test {
+  def test(b: p1.J_1.B) = {
+    b.putAll(null)
+  }
+}

--- a/test/files/pos/java-object-any-unification-2/J.java
+++ b/test/files/pos/java-object-any-unification-2/J.java
@@ -1,0 +1,16 @@
+package p1;
+
+public class J {
+    public static class Map<A, B> {}
+
+    public static class A<K, V> {
+        public synchronized void putAll(Map<? extends K, ? extends V> t) {            
+        }
+    }
+
+    public static class B extends A<Object, Object> {
+        @Override
+        public synchronized void putAll(Map<?, ?> t) {
+        }
+    }
+}

--- a/test/files/pos/java-object-any-unification-2/Test.scala
+++ b/test/files/pos/java-object-any-unification-2/Test.scala
@@ -1,0 +1,5 @@
+object Test {
+  def test(b: p1.J.B) = {
+    b.putAll(null)
+  }
+}

--- a/test/files/pos/t11469/Generic.java
+++ b/test/files/pos/t11469/Generic.java
@@ -1,0 +1,4 @@
+package jkson;
+
+abstract class Erased { public abstract Object foo(); }
+public abstract class Generic<T> extends Erased { public T foo() { return null; } }

--- a/test/files/pos/t11469/test.scala
+++ b/test/files/pos/t11469/test.scala
@@ -1,0 +1,4 @@
+import jkson.Generic
+
+abstract class ScalaGen[T] extends Generic[T]
+abstract class ScalaMono extends Generic[Product] 

--- a/test/files/pos/t11469_2/Test_1.java
+++ b/test/files/pos/t11469_2/Test_1.java
@@ -1,0 +1,11 @@
+import java.util.Optional;
+
+public class Test_1 {
+  public abstract static class A<T> {
+    public void m(Optional<? extends T> a) { }
+  }
+  public abstract static class B extends A<Object> {
+    @Override
+    public void m(Optional<?> a) { }
+  }
+}

--- a/test/files/pos/t11469_2/Test_2.scala
+++ b/test/files/pos/t11469_2/Test_2.scala
@@ -1,0 +1,11 @@
+class A {
+  new Test_1.B() { }
+
+  new Test_1.B() {
+    override def m(a: java.util.Optional[_ <: Object]): Unit = { }
+  }
+
+  new Test_1.B() {
+    override def m(a: java.util.Optional[_]): Unit = { }
+  }
+}

--- a/test/files/presentation/callcc-interpreter.check
+++ b/test/files/presentation/callcc-interpreter.check
@@ -25,7 +25,7 @@ def ensuring(cond: Boolean): callccInterpreter.type
 def ensuring(cond: Boolean, msg: => Any): callccInterpreter.type
 def ensuring(cond: callccInterpreter.type => Boolean): callccInterpreter.type
 def ensuring(cond: callccInterpreter.type => Boolean, msg: => Any): callccInterpreter.type
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def id[A]: A => A

--- a/test/files/presentation/completion-implicit-chained.check
+++ b/test/files/presentation/completion-implicit-chained.check
@@ -6,7 +6,7 @@ askTypeCompletion at Completions.scala(11,16)
 retrieved 22 members
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def hashCode(): Int
 def map(x: Int => Int)(implicit a: DummyImplicit): test.O.type
 def toString(): String

--- a/test/files/presentation/ide-bug-1000349.check
+++ b/test/files/presentation/ide-bug-1000349.check
@@ -10,7 +10,7 @@ def ensuring(cond: Boolean): Foo
 def ensuring(cond: Boolean, msg: => Any): Foo
 def ensuring(cond: Foo => Boolean): Foo
 def ensuring(cond: Foo => Boolean, msg: => Any): Foo
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def foo: Foo
 def formatted(fmtstr: String): String
 def hashCode(): Int

--- a/test/files/presentation/ide-bug-1000475.check
+++ b/test/files/presentation/ide-bug-1000475.check
@@ -12,7 +12,7 @@ def ensuring(cond: Boolean): Object
 def ensuring(cond: Boolean, msg: => Any): Object
 def ensuring(cond: Object => Boolean): Object
 def ensuring(cond: Object => Boolean, msg: => Any): Object
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def toString(): String
@@ -44,7 +44,7 @@ def ensuring(cond: Boolean): Object
 def ensuring(cond: Boolean, msg: => Any): Object
 def ensuring(cond: Object => Boolean): Object
 def ensuring(cond: Object => Boolean, msg: => Any): Object
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def toString(): String
@@ -76,7 +76,7 @@ def ensuring(cond: Boolean): Object
 def ensuring(cond: Boolean, msg: => Any): Object
 def ensuring(cond: Object => Boolean): Object
 def ensuring(cond: Object => Boolean, msg: => Any): Object
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def toString(): String

--- a/test/files/presentation/ide-bug-1000531.check
+++ b/test/files/presentation/ide-bug-1000531.check
@@ -12,7 +12,7 @@ def ensuring(cond: Boolean): other.TestIterator[Nothing]
 def ensuring(cond: Boolean, msg: => Any): other.TestIterator[Nothing]
 def ensuring(cond: other.TestIterator[Nothing] => Boolean): other.TestIterator[Nothing]
 def ensuring(cond: other.TestIterator[Nothing] => Boolean, msg: => Any): other.TestIterator[Nothing]
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def formatted(fmtstr: String): String
 def hasNext: Boolean
 def hashCode(): Int

--- a/test/files/presentation/implicit-member.check
+++ b/test/files/presentation/implicit-member.check
@@ -10,7 +10,7 @@ def ensuring(cond: Boolean): Implicit.type
 def ensuring(cond: Boolean, msg: => Any): Implicit.type
 def ensuring(cond: Implicit.type => Boolean): Implicit.type
 def ensuring(cond: Implicit.type => Boolean, msg: => Any): Implicit.type
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def toString(): String

--- a/test/files/presentation/ping-pong.check
+++ b/test/files/presentation/ping-pong.check
@@ -13,7 +13,7 @@ def ensuring(cond: Boolean): Pong
 def ensuring(cond: Boolean, msg: => Any): Pong
 def ensuring(cond: Pong => Boolean): Pong
 def ensuring(cond: Pong => Boolean, msg: => Any): Pong
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def poke(): Unit
@@ -47,7 +47,7 @@ def ensuring(cond: Boolean): Ping
 def ensuring(cond: Boolean, msg: => Any): Ping
 def ensuring(cond: Ping => Boolean): Ping
 def ensuring(cond: Ping => Boolean, msg: => Any): Ping
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def loop: Unit

--- a/test/files/presentation/t5708.check
+++ b/test/files/presentation/t5708.check
@@ -16,7 +16,7 @@ def ensuring(cond: Boolean): test.Compat.type
 def ensuring(cond: Boolean, msg: => Any): test.Compat.type
 def ensuring(cond: test.Compat.type => Boolean): test.Compat.type
 def ensuring(cond: test.Compat.type => Boolean, msg: => Any): test.Compat.type
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def toString(): String

--- a/test/files/presentation/visibility.check
+++ b/test/files/presentation/visibility.check
@@ -11,7 +11,7 @@ def ensuring(cond: Boolean): accessibility.Foo
 def ensuring(cond: Boolean, msg: => Any): accessibility.Foo
 def ensuring(cond: accessibility.Foo => Boolean): accessibility.Foo
 def ensuring(cond: accessibility.Foo => Boolean, msg: => Any): accessibility.Foo
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def secretPublic(): Unit
@@ -48,7 +48,7 @@ def ensuring(cond: Boolean): accessibility.Foo
 def ensuring(cond: Boolean, msg: => Any): accessibility.Foo
 def ensuring(cond: accessibility.Foo => Boolean): accessibility.Foo
 def ensuring(cond: accessibility.Foo => Boolean, msg: => Any): accessibility.Foo
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def secretPublic(): Unit
@@ -86,7 +86,7 @@ def ensuring(cond: Boolean): accessibility.AccessibilityChecks
 def ensuring(cond: Boolean, msg: => Any): accessibility.AccessibilityChecks
 def ensuring(cond: accessibility.AccessibilityChecks => Boolean): accessibility.AccessibilityChecks
 def ensuring(cond: accessibility.AccessibilityChecks => Boolean, msg: => Any): accessibility.AccessibilityChecks
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def secretPublic(): Unit
@@ -128,7 +128,7 @@ def ensuring(cond: Boolean): accessibility.Foo
 def ensuring(cond: Boolean, msg: => Any): accessibility.Foo
 def ensuring(cond: accessibility.Foo => Boolean): accessibility.Foo
 def ensuring(cond: accessibility.Foo => Boolean, msg: => Any): accessibility.Foo
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def secretPublic(): Unit
@@ -167,7 +167,7 @@ def ensuring(cond: Boolean): accessibility.Foo
 def ensuring(cond: Boolean, msg: => Any): accessibility.Foo
 def ensuring(cond: accessibility.Foo => Boolean): accessibility.Foo
 def ensuring(cond: accessibility.Foo => Boolean, msg: => Any): accessibility.Foo
-def equals(x$1: Any): Boolean
+def equals(x$1: Object): Boolean
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def secretPublic(): Unit

--- a/test/files/run/reflection-magicsymbols-invoke.check
+++ b/test/files/run/reflection-magicsymbols-invoke.check
@@ -7,7 +7,7 @@ method ##: ()Int
 method ==: (x$1: Any)Boolean
 method asInstanceOf: [T0]=> T0
 method equals: (x$1: Any)Boolean
-method getClass: ()Class[_]
+method getClass: ()Class[_ <: Object]
 method hashCode: ()Int
 method isInstanceOf: [T0]=> Boolean
 method toString: ()String
@@ -43,9 +43,9 @@ method ==: (x$1: Any)Boolean
 method asInstanceOf: [T0]=> T0
 method clone: ()Object
 method eq: (x$1: AnyRef)Boolean
-method equals: (x$1: Any)Boolean
+method equals: (x$1: Object)Boolean
 method finalize: ()Unit
-method getClass: ()Class[_]
+method getClass: ()Class[_ <: Object]
 method hashCode: ()Int
 method isInstanceOf: [T0]=> Boolean
 method ne: (x$1: AnyRef)Boolean
@@ -89,9 +89,9 @@ method apply: (i: Int)T
 method asInstanceOf: [T0]=> T0
 method clone: ()Array[T]
 method eq: (x$1: AnyRef)Boolean
-method equals: (x$1: Any)Boolean
+method equals: (x$1: Object)Boolean
 method finalize: ()Unit
-method getClass: ()Class[_]
+method getClass: ()Class[_ <: Object]
 method hashCode: ()Int
 method isInstanceOf: [T0]=> Boolean
 method length: => Int

--- a/test/files/run/t5072.check
+++ b/test/files/run/t5072.check
@@ -3,6 +3,6 @@ scala> class C
 defined class C
 
 scala> Thread.currentThread.getContextClassLoader.loadClass(classOf[C].getName)
-res0: Class[_] = class C
+res0: Class[_ <: Object] = class C
 
 scala> :quit


### PR DESCRIPTION
References to `j.l.Object` from Java sources or classfiles use
`definitions.ObjectTpeJava`, which behaves like `ObjectTpe` but is
slackened to `AnyTpe` during `=:=` and `<:<` when this can help yield
positive results.

This subsumes two prior mechanisms (usages of `obj2Any` and
`MethodType.isJava`)

Fixes scala/bug#10418
Fixes scala/bug#11469