### PR TITLE
TypeBounds: try to avoid creation of the type bounds.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5289,15 +5289,20 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             foreach2(args, tparams) { (arg, tparam) =>
               // note: can't use args1 in selector, because Binds got replaced
               val asym = arg.symbol
-              def abounds = asym.info.bounds
-              def tbounds = tparam.info.bounds
               def enhanceBounds(): Unit = {
-                val TypeBounds(lo0, hi0) = abounds
-                val TypeBounds(lo1, hi1) = tbounds.subst(tparams, argtypes)
+                val info0 = asym.info
+                val lo0 = info0.lowerBound
+                val hi0 = info0.upperBound
+                val tpinfo = tparam.info
+                val lo1 = tpinfo.lowerBound.subst(tparams, argtypes)
+                val hi1 = tpinfo.upperBound.subst(tparams, argtypes)
                 val lo = lub(List(lo0, lo1))
                 val hi = glb(List(hi0, hi1))
                 if (!(lo =:= lo0 && hi =:= hi0))
-                  asym setInfo logResult(s"Updating bounds of ${asym.fullLocationString} in $tree from '$abounds' to")(TypeBounds(lo, hi))
+                  asym setInfo logResult({
+                    val abounds = TypeBounds(lo0, hi0)
+                    s"Updating bounds of ${asym.fullLocationString} in $tree from '$abounds' to"
+                  })(TypeBounds(lo, hi))
               }
               if (asym != null && asym.isAbstractType) {
                 arg match {

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1322,8 +1322,8 @@ trait Types
       case TypeBounds(_, _) => that <:< this
       case _                => lo <:< that && that <:< hi
     }
-    def emptyLowerBound = typeIsNothing(lo) || lo.isWildcard
-    def emptyUpperBound = typeIsAny(hi) || hi.isWildcard
+    private[this] def emptyLowerBound = typeIsNothing(lo) || lo.isWildcard
+    private[this] def emptyUpperBound = typeIsAny(hi) || hi.isWildcard
     def isEmptyBounds = emptyLowerBound && emptyUpperBound
 
     override def safeToString = scalaNotation(_.toString)
@@ -3462,11 +3462,11 @@ trait Types
      *  bounds are exactly tp.
      */
     override def bounds: TypeBounds = underlying.bounds match {
-      case TypeBounds(_: this.type, _: this.type) => TypeBounds(this, this)
-      case oftp                                   => oftp
+      case bd @ TypeBounds(_: this.type, _: this.type) => bd
+      case oftp                                        => oftp
     }
-    override def lowerBound: Type = bounds.lo
-    override def upperBound: Type = bounds.hi
+    override def lowerBound: Type = underlying.lowerBound
+    override def upperBound: Type = underlying.upperBound
 
     // ** Replace formal type parameter symbols with actual type arguments. * /
     override def instantiateTypeParams(formals: List[Symbol], actuals: List[Type]) = {

--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -356,10 +356,10 @@ private[internal] trait GlbLubs {
               else if (symtypes.tail forall (symtypes.head =:= _))
                 proto.cloneSymbol(lubRefined.typeSymbol).setInfoOwnerAdjusted(symtypes.head)
               else {
-                def lubBounds(bnds: List[TypeBounds]): TypeBounds =
-                  TypeBounds(glb(bnds map (_.lo), depth.decr), lub(bnds map (_.hi), depth.decr))
+                val lo = glb(symtypes map (_.lowerBound), depth.decr)
+                val hi = lub(symtypes map (_.upperBound), depth.decr)
                 lubRefined.typeSymbol.newAbstractType(proto.name.toTypeName, proto.pos)
-                  .setInfoOwnerAdjusted(lubBounds(symtypes map (_.bounds)))
+                  .setInfoOwnerAdjusted(TypeBounds(lo, hi))
               }
             }
           }

--- a/src/reflect/scala/reflect/internal/transform/UnCurry.scala
+++ b/src/reflect/scala/reflect/internal/transform/UnCurry.scala
@@ -70,7 +70,8 @@ trait UnCurry {
   object DesugaredParameterType {
     def isUnboundedGeneric(tp: Type) = tp match {
       case t @ TypeRef(_, sym, _) if sym.isAbstractType =>
-        sym.info.resultType.bounds.emptyUpperBound
+        val hi = sym.info.resultType.upperBound
+        typeIsAny(hi) || hi.isWildcard
       case _                      => false
     }
 

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -542,13 +542,13 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
   private trait TypeBoundsImpl {
     def sym: Symbol
     def inTpl: TemplateImpl
-    def lo = sym.info.bounds match {
-      case TypeBounds(lo, hi) if lo.typeSymbol != NothingClass =>
+    def lo = sym.info.lowerBound match {
+      case lo if lo.typeSymbol != NothingClass =>
         Some(makeTypeInTemplateContext(appliedType(lo, sym.info.typeParams map {_.tpe}), inTpl, sym))
       case _ => None
     }
-    def hi = sym.info.bounds match {
-      case TypeBounds(lo, hi) if hi.typeSymbol != AnyClass =>
+    def hi = sym.info.upperBound match {
+      case hi if hi.typeSymbol != AnyClass =>
         Some(makeTypeInTemplateContext(appliedType(hi, sym.info.typeParams map {_.tpe}), inTpl, sym))
       case _ => None
     }

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryTypeSupport.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryTypeSupport.scala
@@ -240,7 +240,7 @@ trait ModelFactoryTypeSupport {
                 nameBuffer append "val "
                 nameBuffer append tpnme.dropSingletonName(sym.name)
                 nameBuffer append ": "
-                appendType0(dropSingletonType(sym.info.bounds.hi))
+                appendType0(dropSingletonType(sym.info.upperBound))
               } else {
                 if (sym.flagString != "") nameBuffer append (sym.flagString + " ")
                 if (sym.keyString != "") nameBuffer append (sym.keyString + " ")


### PR DESCRIPTION
The method "bounds" from the Type class hierarchy is usually implemented in terms of the "lowerBound" and "upperBound" methods. For this reason, it is most efficient to directly use the upper or lower bounds wherever possible, and avoid the TypeBounds object.