### PR TITLE
[REJECTED] Enable discard unit value in infix expr

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -870,7 +870,7 @@ self =>
       }
       def mkNamed(args: List[Tree]) = if (isExpr) args map treeInfo.assignmentToMaybeNamedArg else args
       val arguments = right match {
-        case Parens(Nil)  => Literal(Constant(())) :: Nil
+        case Parens(Nil)  => literalUnit :: Nil
         case Parens(args) => mkNamed(args)
         case _            => right :: Nil
       }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -260,6 +260,7 @@ trait ScalaSettings extends AbsScalaSettings
   val YjarCompressionLevel = IntSetting("-Yjar-compression-level", "compression level to use when writing jar files",
     Deflater.DEFAULT_COMPRESSION, Some((Deflater.DEFAULT_COMPRESSION,Deflater.BEST_COMPRESSION)), (x: String) => None)
   val YpickleJava = BooleanSetting("-Ypickle-java", "Pickler phase should compute pickles for .java defined symbols for use by build tools").internalOnly()
+  val YunitDiscard = BooleanSetting("-Yunit-discard", "Enable adapting unit value used as infix operand to invocation of zero-arg method")
 
   sealed abstract class CachePolicy(val name: String, val help: String)
   object CachePolicy {

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3576,7 +3576,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
            * This is the last thing which is tried (after default arguments).
            */
           def tryTupleApply: Tree =
-            if (phase.erasedTypes || !eligibleForTupleConversion(paramTypes, argslen)) EmptyTree
+            if (phase.erasedTypes) EmptyTree
+            else if (settings.YunitDiscard && params.isEmpty && argslen == 1 && args.head.hasAttachment[SyntheticUnitAttachment.type])
+              doTypedApply(tree, fun, Nil, mode, pt)
+            else if (!eligibleForTupleConversion(paramTypes, argslen)) EmptyTree
             else {
               val tupleArgs = List(atPos(tree.pos.makeTransparent)(gen.mkTuple(args)))
               // expected one argument, but got 0 or >1 ==>  try applying to tuple

--- a/test/files/pos/unit-discard.scala
+++ b/test/files/pos/unit-discard.scala
@@ -1,0 +1,9 @@
+// scalac: -Yunit-discard
+
+trait T {
+  def f() = 42
+}
+trait U {
+  def t: T = ???
+  def g: Int = t f ()
+}

--- a/test/files/run/t11475.scala
+++ b/test/files/run/t11475.scala
@@ -1,0 +1,6 @@
+// scalac: -Yunit-discard
+object Test {
+  def f(xs: Any*) = xs.size
+  def g = Test f ()
+  def main(args: Array[String]) = assert(g == 1)
+}


### PR DESCRIPTION
`-Yunit-discard` to discard the operand
in infix `x op ()`. This enables a certain
DSL style, but it only supports methods
that take no parameters, not repeating
parameters.