### PR TITLE
Suspend type vars using same scheme as skolem separation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,6 +125,11 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.sys.process.BasicIO.connectNoOp"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.sys.process.BasicIO.connectToStdIn"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.HashTable.removeEntry0"),
+    // #7978
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedTypes.typeVarSuspensionLevel"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedTypes.typeVarSuspensionLevel_="),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUniverse.typeVarSuspensionLevel"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUniverse.typeVarSuspensionLevel_="),
   ),
 }
 

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -363,19 +363,6 @@ trait Collections {
     }
   }
 
-  final def bitSetByPredicate[A](xs: List[A])(pred: A => Boolean): mutable.BitSet = {
-    val bs = new mutable.BitSet()
-    var ys = xs
-    var i: Int = 0
-    while (! ys.isEmpty){
-      if (pred(ys.head))
-        bs.add(i)
-      ys = ys.tail
-      i += 1
-    }
-    bs
-  }
-
   final def transposeSafe[A](ass: List[List[A]]): Option[List[List[A]]] = try {
     Some(ass.transpose)
   } catch {

--- a/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
@@ -56,6 +56,10 @@ private[reflect] trait SynchronizedTypes extends internal.Types { self: SymbolTa
   override def skolemizationLevel = _skolemizationLevel.get
   override def skolemizationLevel_=(value: Int) = _skolemizationLevel.set(value)
 
+  private lazy val _typeVarSuspensionLevel = mkThreadLocalStorage(0)
+  override def typeVarSuspensionLevel = _typeVarSuspensionLevel.get
+  override def typeVarSuspensionLevel_=(value: Int) = _typeVarSuspensionLevel.set(value)
+
   private lazy val _undoLog = mkThreadLocalStorage(new UndoLog)
   override def undoLog = _undoLog.get
 


### PR DESCRIPTION
Based on an idea by @retronym while working on a fix for scala/bug#11480. Still not sure how to fix that bug, but this already seems like a nice cleanup / performance win (?)

