### PR TITLE
Restore StringContext#standardInterpolator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,6 +113,7 @@ val mimaPrereleaseHandlingSettings = Seq(
     ProblemFilters.exclude[Problem]("scala.collection.StepperShape.*"),
     ProblemFilters.exclude[Problem]("scala.jdk.*"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.concurrent.impl.FutureConvertersImpl#CF.*"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.StringContext.standardInterpolator"),
   ),
 )
 

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -154,6 +154,10 @@ case class StringContext(parts: String*) {
    */
   def raw(args: Any*): String = macro ??? // fasttracked to scala.tools.reflect.FastStringInterpolator::interpolateRaw
 
+  @deprecated("Use the static method StringContext.standardInterpolator instead of the instance method", "2.13.0")
+  def standardInterpolator(process: String => String, args: Seq[Any]): String =
+    StringContext.standardInterpolator(process, args, parts)
+
   /** The formatted string interpolator.
    *
    *  It inserts its arguments between corresponding parts of the string context.


### PR DESCRIPTION
I discovered this while upgrading Slick for 2.13. It fixes a regression and looks harmless enough that we should consider it for 2.13.0:

This uses to be a public method in 2.11 and 2.12 but was removed in
https://github.com/scala/scala/commit/12c0d2796040927af43b62194159c759ca3e2814#diff-648e8f7f409d844c3c99b2d5a0d0dfe5
and later restored as a method of the companion object without prior
deprecation.