### PR TITLE
Try to existentially abstract unrelatable skolems only once

### DIFF
--- a/test/files/pos/t11474/Outer_1.java
+++ b/test/files/pos/t11474/Outer_1.java
@@ -1,0 +1,19 @@
+public class Outer_1 {
+    public interface BaseBuilder { }
+    public abstract static class Container<B> { }
+    public abstract static class Builder<M extends Container<B>, B extends Builder<M, B>> implements BaseBuilder { }
+    public abstract static class Builder1<T extends Builder1<T>> extends Builder { }
+    public abstract class Builder2 extends Builder1<Builder2> { }
+
+    interface MyBase {
+        BaseBuilder newBuilder();
+    }
+
+    public static abstract class M1 implements MyBase  {
+        public Builder2 newBuilder() { return null; }
+    }
+
+    public static abstract class M2 implements MyBase {
+        public Builder newBuilder() { return null; }
+    }
+}

--- a/test/files/pos/t11474/Test_2.scala
+++ b/test/files/pos/t11474/Test_2.scala
@@ -1,0 +1,3 @@
+object Test_2 {
+  Seq(new Outer_1.M2 {}, new Outer_1.M1 {})
+}


### PR DESCRIPTION
Fixes a stack overflow error when the resulting existential is F-bounded

fixes scala/bug#11474