### PR TITLE
add lampepfl org to CoC notice

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,7 @@
-all repositories in the [scala](https://github.com/scala) and [scalacenter](https://github.com/scalacenter) organizations are covered by the Scala Code of Conduct: https://scala-lang.org/conduct/
+all repositories in these organizations:
+
+* [scala](https://github.com/scala)
+* [scalacenter](https://github.com/scalacenter)
+* [lampepfl](https://github.com/lampepfl)
+
+are covered by the Scala Code of Conduct: https://scala-lang.org/conduct/


### PR DESCRIPTION
a comparable change was already approved at
https://github.com/scala/scala-lang/pull/983 so this is
just following up on that here, too