### PR TITLE
Use array stepper in ArraySeq, ArrayBuffer. Add some empty stepper overrides.

### DIFF
--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -77,6 +77,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
 
   override def view: MapView[K, V] = new MapView.Id(this)
 
+  /** Returns a [[Stepper]] for the keys of this map. See method [[stepper]]. */
   def keyStepper[S <: Stepper[_]](implicit shape: StepperShape[K, S]): S = {
     import convert.impl._
     val s = shape.shape match {
@@ -88,6 +89,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
     s.asInstanceOf[S]
   }
 
+  /** Returns a [[Stepper]] for the values of this map. See method [[stepper]]. */
   def valueStepper[V1 >: V, S <: Stepper[_]](implicit shape: StepperShape[V1, S]): S = {
     import convert.impl._
     val s = shape.shape match {

--- a/src/library/scala/collection/StepperShape.scala
+++ b/src/library/scala/collection/StepperShape.scala
@@ -108,7 +108,7 @@ trait StepperShapeLowPriority2 {
 
   protected val anyStepperShapePrototype: StepperShape[AnyRef, Stepper[AnyRef]] = new StepperShape[AnyRef, Stepper[AnyRef]] {
     def shape = StepperShape.ReferenceShape
-    def seqUnbox(st: AnyStepper[AnyRef]): AnyStepper[AnyRef] = st
-    def parUnbox(st: AnyStepper[AnyRef] with EfficientSplit): AnyStepper[AnyRef] with EfficientSplit = st
+    def seqUnbox(st: AnyStepper[AnyRef]): Stepper[AnyRef] = st
+    def parUnbox(st: AnyStepper[AnyRef] with EfficientSplit): Stepper[AnyRef] with EfficientSplit = st
   }
 }

--- a/src/library/scala/collection/convert/StreamExtensions.scala
+++ b/src/library/scala/collection/convert/StreamExtensions.scala
@@ -128,8 +128,13 @@ trait StreamExtensions {
       * stepper yields primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
-    def asJavaSeqStream[S <: BaseStream[_, _], St <: Stepper[_]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S =
-      s.fromStepper(stepper.asInstanceOf[St], par = false)
+    def asJavaSeqStream[S <: BaseStream[_, _], St <: Stepper[_]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S = {
+      val sStepper = stepper match {
+        case as: AnyStepper[A] => st.seqUnbox(as)
+        case _ => stepper.asInstanceOf[St]
+      }
+      s.fromStepper(sStepper, par = false)
+    }
   }
 
   implicit class StepperHasParStream[A](stepper: Stepper[A] with EfficientSplit) {
@@ -137,8 +142,13 @@ trait StreamExtensions {
       * stepper yields primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
-    def asJavaParStream[S <: BaseStream[_, _], St <: Stepper[_]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S =
-      s.fromStepper(stepper.asInstanceOf[St], par = true)
+    def asJavaParStream[S <: BaseStream[_, _], St <: Stepper[_]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S = {
+      val sStepper = stepper match {
+        case as: AnyStepper[A] => st.parUnbox(as)
+        case _ => stepper.asInstanceOf[St]
+      }
+      s.fromStepper(sStepper, par = true)
+    }
   }
 
   // arrays

--- a/src/library/scala/collection/convert/StreamExtensions.scala
+++ b/src/library/scala/collection/convert/StreamExtensions.scala
@@ -144,7 +144,7 @@ trait StreamExtensions {
       */
     def asJavaParStream[S <: BaseStream[_, _], St <: Stepper[_]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S = {
       val sStepper = stepper match {
-        case as: AnyStepper[A] => st.parUnbox(as)
+        case as: AnyStepper[A] with EfficientSplit => st.parUnbox(as)
         case _ => stepper.asInstanceOf[St]
       }
       s.fromStepper(sStepper, par = true)

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -15,8 +15,6 @@ package collection
 package immutable
 
 import scala.annotation.tailrec
-import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.mutable
 
 /** This class implements immutable maps using a vector/map-based data structure, which preserves insertion order.
   *
@@ -120,6 +118,16 @@ final class VectorMap[K, +V] private (
       result
     }
   }
+
+  // No-Op overrides to allow for more efficient steppers in a minor release.
+  // Refining the return type to `S with EfficientSplit` is binary compatible.
+
+  override def stepper[B >: (K, V), S <: Stepper[_]](implicit shape: StepperShape[B, S]): S = super.stepper(shape)
+
+  override def keyStepper[S <: Stepper[_]](implicit shape: StepperShape[K, S]): S = super.keyStepper(shape)
+
+  override def valueStepper[V1 >: V, S <: Stepper[_]](implicit shape: StepperShape[V1, S]): S = super.valueStepper(shape)
+
 
   def removed(key: K): VectorMap[K, V] = {
     if (isEmpty) empty

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -14,8 +14,10 @@ package scala
 package collection
 package mutable
 
-import scala.collection.generic.DefaultSerializable
 import java.util.Arrays
+
+import scala.collection.Stepper.EfficientSplit
+import scala.collection.generic.DefaultSerializable
 
 /** An implementation of the `Buffer` class using an array to
   *  represent the assembled sequence internally. Append, update and random
@@ -52,6 +54,11 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   protected[collection] var array: Array[AnyRef] = initialElements
   protected var size0 = initialSize
+
+  override def stepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+    import scala.collection.convert.impl._
+    shape.parUnbox(new ObjectArrayStepper(array, 0, length).asInstanceOf[AnyStepper[B] with EfficientSplit])
+  }
 
   override def knownSize: Int = super[IndexedSeqOps].knownSize
 

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -16,6 +16,7 @@ package mutable
 
 import java.util.NoSuchElementException
 
+import scala.collection.Stepper.EfficientSplit
 import scala.collection.generic.DefaultSerializable
 import scala.reflect.ClassTag
 
@@ -65,6 +66,9 @@ class ArrayDeque[A] protected (
   def this(initialSize: Int = ArrayDeque.DefaultInitialSize) = this(ArrayDeque.alloc(initialSize), start = 0, end = 0)
 
   override def knownSize: Int = super[IndexedSeqOps].knownSize
+
+  // No-Op override to allow for more efficient stepper in a minor release.
+  override def stepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = super.stepper(shape)
 
   def apply(idx: Int) = {
     requireBounds(idx)

--- a/test/junit/scala/jdk/StreamConvertersTypingTest.scala
+++ b/test/junit/scala/jdk/StreamConvertersTypingTest.scala
@@ -24,6 +24,8 @@ import scala.collection._
 
 @RunWith(classOf[JUnit4])
 class StreamConvertersTypingTest {
+  def anyStepper[T](c: IterableOnce[T]): AnyStepper[T] = c.stepper
+
   @Test
   def keyValueSteppers(): Unit = {
     import scala.jdk.StreamConverters.Ops._
@@ -461,4 +463,103 @@ class StreamConvertersTypingTest {
     (s: AnyStepper[Int]).asJavaSeqStream.count()
     s.asJavaParStream.count()
   }
+
+  @Test
+  def arraySeqStepper(): Unit = {
+    import collection.{mutable => m, immutable => i}
+    import scala.jdk.StreamConverters.Ops._
+
+    val sa = Array("", "")
+    val ia = Array(1, 2, 3)
+    val bia = Array[Any](1, 2, 3); assertEquals(classOf[Array[AnyRef]], bia.getClass)
+    val ba = Array(true, false)
+    val bba = Array[Any](true, false); assertEquals(classOf[Array[AnyRef]], bba.getClass)
+
+    val sams = m.ArraySeq.make(sa)
+    val iams = m.ArraySeq.make(ia)
+    val biams = m.ArraySeq.make(bia).asInstanceOf[m.ArraySeq[Int]]
+    val bams = m.ArraySeq.make(ba)
+    val bbams = m.ArraySeq.make(bba).asInstanceOf[m.ArraySeq[Boolean]]
+
+    val sais = i.ArraySeq.unsafeWrapArray(sa)
+    val iais = i.ArraySeq.unsafeWrapArray(ia)
+    val biais = i.ArraySeq.unsafeWrapArray(bia).asInstanceOf[i.ArraySeq[Int]]
+    val bais = i.ArraySeq.unsafeWrapArray(ba)
+    val bbais = i.ArraySeq.unsafeWrapArray(bba).asInstanceOf[i.ArraySeq[Boolean]]
+
+    val samsS = sams.stepper
+    (samsS: AnyStepper[String] with EfficientSplit).asJavaParStream.count()
+    val samsAS = anyStepper(sams)
+    (samsAS: AnyStepper[String]).asJavaSeqStream.count()
+
+    val iamsS = iams.stepper
+    (iamsS: IntStepper with EfficientSplit).asJavaParStream.count()
+    val iamsAS = anyStepper(iams)
+    (iamsAS: AnyStepper[Int]).asJavaSeqStream.count()
+
+    val biamsS = biams.stepper
+    (biamsS: IntStepper with EfficientSplit).asJavaParStream.count()
+    val biamsAS = anyStepper(biams)
+    (biamsAS: AnyStepper[Int]).asJavaSeqStream.count()
+
+    val bamsS = bams.stepper
+    (bamsS: AnyStepper[Boolean] with EfficientSplit).asJavaParStream.count()
+    val bamsAS = anyStepper(bams)
+    (bamsAS: AnyStepper[Boolean]).asJavaSeqStream.count()
+
+    val bbamsS = bbams.stepper
+    (bbamsS: AnyStepper[Boolean] with EfficientSplit).asJavaParStream.count()
+    val bbamsAS = anyStepper(bbams)
+    (bbamsAS: AnyStepper[Boolean]).asJavaSeqStream.count()
+
+
+    val saisS = sais.stepper
+    (saisS: AnyStepper[String] with EfficientSplit).asJavaParStream.count()
+    val saisAS = anyStepper(sais)
+    (saisAS: AnyStepper[String]).asJavaSeqStream.count()
+
+    val iaisS = iais.stepper
+    (iaisS: IntStepper with EfficientSplit).asJavaParStream.count()
+    val iaisAS = anyStepper(iais)
+    (iaisAS: AnyStepper[Int]).asJavaSeqStream.count()
+
+    val biaisS = biais.stepper
+    (biaisS: IntStepper with EfficientSplit).asJavaParStream.count()
+    val biaisAS = anyStepper(biais)
+    (biaisAS: AnyStepper[Int]).asJavaSeqStream.count()
+
+    val baisS = bais.stepper
+    (baisS: AnyStepper[Boolean] with EfficientSplit).asJavaParStream.count()
+    val baisAS = anyStepper(bais)
+    (baisAS: AnyStepper[Boolean]).asJavaSeqStream.count()
+
+    val bbaisS = bbais.stepper
+    (bbaisS: AnyStepper[Boolean] with EfficientSplit).asJavaParStream.count()
+    val bbaisAS = anyStepper(bbais)
+    (bbaisAS: AnyStepper[Boolean]).asJavaSeqStream.count()
+  }
+
+  @Test
+  def arrayBufferStepper(): Unit = {
+    import collection.{mutable => m, immutable => i}
+    import scala.jdk.StreamConverters.Ops._
+
+    val sb = m.ArrayBuffer.from(Array("", ""))
+    val ib = m.ArrayBuffer.from(Array(1, 2))
+    val bb = m.ArrayBuffer.from(Array(true, false))
+
+    val sbS = sb.stepper
+    (sbS: AnyStepper[String] with EfficientSplit).asJavaParStream.count()
+    val sbAS = anyStepper(sb)
+    (sbAS: AnyStepper[String]).asJavaSeqStream.count()
+
+    val ibS = ib.stepper
+    (ibS: IntStepper with EfficientSplit).asJavaParStream.count()
+    val ibAS = anyStepper(ib)
+    (ibAS: AnyStepper[Int]).asJavaSeqStream.count()
+
+    val bbS = bb.stepper
+    (bbS: AnyStepper[Boolean] with EfficientSplit).asJavaParStream.count()
+    val bbAS = anyStepper(bb)
+    (bbAS: AnyStepper[Boolean]).asJavaSeqStream.count()  }
 }

--- a/test/junit/scala/jdk/StreamConvertersTypingTest.scala
+++ b/test/junit/scala/jdk/StreamConvertersTypingTest.scala
@@ -447,4 +447,18 @@ class StreamConvertersTypingTest {
       (saps: Stream[String]).count()
     }
   }
+
+  @Test
+  def anyStepperOfPrimitiveAsStream(): Unit = {
+    import scala.jdk.StreamConverters.Ops._
+    val s = new AnyStepper[Int] with EfficientSplit {
+      override def trySplit(): AnyStepper[Int] = null
+      override def hasStep: Boolean = false
+      override def nextStep(): Int = ???
+      override def estimateSize: Long = Long.MaxValue
+      override def characteristics: Int = 0
+    }
+    (s: AnyStepper[Int]).asJavaSeqStream.count()
+    s.asJavaParStream.count()
+  }
 }


### PR DESCRIPTION
 Use ArrayStepper for ArrayBuffer, ArraySeq 

Override `stepper` in VectorMap, ArrayDeque. This allows providing a more efficient implementation in a binary compatible fashion.

Fix a bug in the `Stepper.asJava{Seq|Par}Stream` extension method.

Fixes https://github.com/scala/bug/issues/11483, fixes https://github.com/scala/bug/issues/11492