### PR TITLE
Better heap-safety for iterative algorithms on lazy data types

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -1317,6 +1317,10 @@ abstract class Erasure extends InfoTransform
           }
           fun
 
+        case tree @ Typed(expr, tt @ TypeTree()) if tt.tpe.hasAnnotation(definitions.DropthisClass) =>
+          expr.updateAttachment(DropThisAttachment)
+          tree
+
         case _ =>
           tree
       }

--- a/src/library/scala/annotation/dropthis.scala
+++ b/src/library/scala/annotation/dropthis.scala
@@ -1,0 +1,23 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+
+/** This annotation can be used when referencing `this` in a method to indicate that there are no further references
+  * to `this` later. The compiler will generate code to allow `this` to be garbage-collected.
+  *
+  * It is an error to use this annotation on anything other than a direct reference to the directly enclosing
+  * class (`this`) or to require further references at a later point in the method.
+  *
+  * @since 2.13.1
+  */
+final class dropthis extends scala.annotation.StaticAnnotation

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1249,6 +1249,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val AnnotationRepeatableAttr      = requiredClass[java.lang.annotation.Repeatable]
 
     // Annotations
+    lazy val DropthisClass              = requiredClass[scala.annotation.dropthis]
     lazy val ElidableMethodClass        = requiredClass[scala.annotation.elidable]
     lazy val ImplicitNotFoundClass      = requiredClass[scala.annotation.implicitNotFound]
     lazy val ImplicitAmbiguousClass     = getClassIfDefined("scala.annotation.implicitAmbiguous")

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -121,4 +121,6 @@ trait StdAttachments {
   class QualTypeSymAttachment(val sym: Symbol)
 
   case object ConstructorNeedsFence extends PlainAttachment
+
+  case object DropThisAttachment extends PlainAttachment
 }

--- a/test/files/run/dropthis.check
+++ b/test/files/run/dropthis.check
@@ -1,0 +1,6 @@
+foreach1
+GC success - List deallocated
+foreach2
+List not deallocated
+foreach3
+GC success - List deallocated

--- a/test/files/run/dropthis.scala
+++ b/test/files/run/dropthis.scala
@@ -1,0 +1,75 @@
+import scala.annotation.{tailrec, dropthis}
+
+abstract class LList[+T] {
+
+  // Tail recursive
+  @tailrec final def foreach1(g: T => Unit): Unit = {
+    if(this != LNil) {
+      val l2 = this.asInstanceOf[LCons[T]]
+      g(l2.head)
+      l2.tail.foreach1(g)
+    }
+  }
+
+  // Iterative
+  def foreach2(g: T => Unit): Unit = {
+    var l = this
+    while(l != LNil) {
+      val l2 = l.asInstanceOf[LCons[T]]
+      g(l2.head)
+      l = l2.tail
+    }
+  }
+
+  // Iterative with @dropthis
+  def foreach3(g: T => Unit): Unit = {
+    var l = this: @dropthis
+    while(l != LNil) {
+      val l2 = l.asInstanceOf[LCons[T]]
+      g(l2.head)
+      l = l2.tail
+    }
+  }
+}
+
+final object LNil extends LList[Nothing]
+
+final class LCons[T](val head: T, _tail: () => LList[T]) extends LList[T] { def tail = _tail() }
+
+object Test extends App {
+  import scala.util.{Try, Success, Failure}
+  import scala.ref.WeakReference
+  case object GCSuccess extends RuntimeException
+
+  def mk(i: Int): LList[Int] = i match {
+    case 0 => LNil
+    case i => new LCons[Int](i, () => mk(i-1))
+  }
+
+  def assertDealloc(op: (=> LList[Int], Int => Unit) => Any): Unit = {
+    var ll = mk(200)
+    val ref = WeakReference(ll)
+
+    def step(n: Int): Unit = {
+      ll = null
+      System.gc()
+      Thread.sleep(10)
+      if(ref.get.isEmpty) throw GCSuccess
+    }
+
+    Try { op(ref(), step) } match {
+      case Failure(GCSuccess) => println("GC success - List deallocated")
+      case Failure(t) => throw t
+      case Success(_) => println("List not deallocated")
+    }
+  }
+
+  println("foreach1")
+  assertDealloc(_.foreach1(_))
+
+  println("foreach2")
+  assertDealloc(_.foreach2(_))
+
+  println("foreach3")
+  assertDealloc(_.foreach3(_))
+}


### PR DESCRIPTION
This is an idea I explored after seeing https://github.com/scala/scala/pull/7916.  Some gitter discussion at https://gitter.im/scala/contributors?at=5cb6f1596a84d76ed8a99167.

What I implemented so far is an annotation `@dropthis` that can be applied to an expression `this` in a method in order to drop the reference (after pushing it onto the stack) so it can be garbage-collected. This allows writing iterative algorithms (see the `foreach3` test case) that do not keep an unnecessary reference to the original receiver of the method, which is currently impossible in Scala.

So far this is a simple proof of concept. There are no checks for incorrect use of the annotation. If you put it on any non-`this` expression, it is ignored. If you use it and try to dereference `this` afterwards, you get an NPE. The next obvious step is to add these checks. The easiest way to do the flow analysis would probably be right in the backend at the ASM level but then you would get different semantics when running with a non-JVM backend, so we should do it earlier.

Furthermore, in cases where `this` gets aliased to a `var` with the same type (like in `foreach2`) it should be possible to perform this optimization without the need for an explicit annotation. We could reuse slot 0 in the LVT (which holds the receiver) for the var. In other cases (e.g. using an `Iterator` instead of manually traversing a linked list) the type may not match, so this is not an option. We don't want to null out the receiver unnecessarily in all methods, either. In these cases you would still have to use the annotation.

There is currently no optimization for aliasing of local variables or reuse of LVT slots in the backend. Every local variable gets a separate slot and everything is scoped to its full static scope.

- [ ] Perform flow analysis for illegal use of `@dropthis`
- [ ] Guard against using `@dropthis` on non-`this` expressions
- [ ] Detect aliasing of `this` into a `var` and reuse slot 0
- [ ] Share other LVT slots between non-overlapping variables of compatible types
- [ ] Reduce the scope of local variables from their static scope to the actual one
- [ ] Null out slot 0 in all forwarders and bridge methods for `@dropthis`-annotated methods