### PR TITLE
save a couple of allocations when adding an annotation

### DIFF
--- a/src/reflect/scala/reflect/internal/AnnotationInfos.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationInfos.scala
@@ -59,7 +59,7 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
 
     def removeAnnotation(cls: Symbol): Self = filterAnnotations(ann => !(ann matches cls))
 
-    final def withAnnotation(annot: AnnotationInfo): Self = withAnnotations(List(annot))
+    def withAnnotation(annot: AnnotationInfo): Self
 
     @tailrec private
     def dropOtherAnnotations(anns: List[AnnotationInfo], cls: Symbol): List[AnnotationInfo] = anns match {

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1873,6 +1873,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def withAnnotations(annots: List[AnnotationInfo]): this.type =
       setAnnotations(annots ::: annotations)
 
+    def withAnnotation(anno: AnnotationInfo): this.type =
+      setAnnotations(anno :: annotations)
+
     def withoutAnnotations: this.type =
       setAnnotations(Nil)
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1061,6 +1061,7 @@ trait Types
     def filterAnnotations(p: AnnotationInfo => Boolean): Type = this
     def setAnnotations(annots: List[AnnotationInfo]): Type  = annotatedType(annots, this)
     def withAnnotations(annots: List[AnnotationInfo]): Type = annotatedType(annots, this)
+    def withAnnotation(anno: AnnotationInfo): Type = withAnnotations(List(anno))
 
     /** The kind of this type; used for debugging */
     def kind: String = "unknown type of class "+getClass()
@@ -3780,6 +3781,9 @@ trait Types
     override def withAnnotations(annots: List[AnnotationInfo]): Type =
       if (annots.isEmpty) this
       else copy(annots ::: this.annotations)
+
+    override def withAnnotation(anno: AnnotationInfo): Type =
+      copy(anno :: this.annotations)
 
     /** Remove any annotations from this type.
      *  TODO - is it allowed to nest AnnotatedTypes? If not then let's enforce


### PR DESCRIPTION
sometimes we can just add to the head of a list directly

In my envoronment we are very annotation heavy, but I doubt this will make any measurable difference to most use cases