### PR TITLE
remove @author tags from (mainly) src/library

### DIFF
--- a/src/compiler/scala/reflect/reify/Reifier.scala
+++ b/src/compiler/scala/reflect/reify/Reifier.scala
@@ -20,7 +20,6 @@ import scala.reflect.reify.utils.Utils
 /** Given a tree or a type, generate a tree that when executed at runtime produces the original tree or type.
  *  See more info in the comments to `reify` in scala.reflect.api.Universe.
  *
- *  @author   Martin Odersky
  *  @since    2.10
  */
 abstract class Reifier extends States

--- a/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTest.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTest.scala
@@ -46,9 +46,6 @@ import scala.collection.mutable.ListBuffer
  *  framework will automatically pick it up.
  *
  *  @see   Check existing tests under test/files/presentation
- *
- *  @author Iulian Dragos
- *  @author Mirco Dotta
  */
 abstract class InteractiveTest
   extends AskParse

--- a/src/library/scala/App.scala
+++ b/src/library/scala/App.scala
@@ -36,7 +36,6 @@ import scala.collection.mutable.ListBuffer
  *
  *  Future versions of this trait will no longer extend `DelayedInit`.
  *
- *  @author  Martin Odersky
  *  @since   2.1
  */
 trait App extends DelayedInit {

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -31,7 +31,6 @@ import scala.runtime.ScalaRunTime.{array_apply, array_update}
  *  where the array objects `a`, `b` and `c` have respectively the values
  *  `Array(1, 2)`, `Array(0, 0)` and `Array(1, 2, 0, 0)`.
  *
- *  @author Martin Odersky
  *  @since  1.0
  */
 object Array {
@@ -609,7 +608,6 @@ object Array {
  *  by converting to `ArraySeq` first and invoking the variant of `reverse` that returns another
  *  `ArraySeq`.
  *
- *  @author Martin Odersky
  *  @since  1.0
  *  @see [[http://www.scala-lang.org/files/archive/spec/2.13/ Scala Language Specification]], for in-depth information on the transformations the Scala compiler makes on Arrays (Sections 6.6 and 6.15 respectively.)
  *  @see [[http://docs.scala-lang.org/sips/completed/scala-2-8-arrays.html "Scala 2.8 Arrays"]] the Scala Improvement Document detailing arrays since Scala 2.8.

--- a/src/library/scala/Console.scala
+++ b/src/library/scala/Console.scala
@@ -109,7 +109,6 @@ import scala.util.DynamicVariable
  *    <tr><td style="background-color:#000;color:#fff">First primes: Vector(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47)</td></tr>
  *  </table>
  *
- *  @author  Matthias Zenger
  *  @since   1.0
  *
  *  @groupname console-output Console Output

--- a/src/library/scala/DelayedInit.scala
+++ b/src/library/scala/DelayedInit.scala
@@ -45,7 +45,6 @@ package scala
  *
  *  @see "Delayed Initialization" subsection of the Scala Language Specification (section 5.1)
  *
- *  @author  Martin Odersky
  */
 @deprecated("DelayedInit semantics can be surprising. Support for `App` will continue. See the release notes for more details: https://github.com/scala/scala/releases/tag/v2.11.0", "2.11.0")
 trait DelayedInit {

--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -83,7 +83,6 @@ import scala.util.matching.Regex
  *
  *  @param initial The initial value from which to count the integers that
  *                 identifies values at run-time.
- *  @author  Matthias Zenger
  */
 @SerialVersionUID(8476000850333817230L)
 abstract class Enumeration (initial: Int) extends Serializable {

--- a/src/library/scala/Function.scala
+++ b/src/library/scala/Function.scala
@@ -14,7 +14,6 @@ package scala
 
 /** A module defining utility methods for higher-order functional programming.
  *
- *  @author  Martin Odersky
  *  @since   1.0
  */
 object Function {

--- a/src/library/scala/MatchError.scala
+++ b/src/library/scala/MatchError.scala
@@ -16,8 +16,6 @@ package scala
  *  object doesn't match any pattern of a pattern matching
  *  expression.
  *
- *  @author  Matthias Zenger
- *  @author  Martin Odersky
  *  @since   2.0
  */
 final class MatchError(@transient obj: Any) extends RuntimeException {

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -127,8 +127,6 @@ object Option {
  *  the implicit conversion tends to leave one with an Iterable in
  *  situations where one could have retained an Option.
  *
- *  @author  Martin Odersky
- *  @author  Matthias Zenger
  *  @since   1.1
  *  @define none `None`
  *  @define some [[scala.Some]]
@@ -616,7 +614,6 @@ sealed abstract class Option[+A] extends Product with Serializable {
 /** Class `Some[A]` represents existing values of type
  *  `A`.
  *
- *  @author  Martin Odersky
  *  @since   1.0
  */
 @SerialVersionUID(1234815782226070388L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
@@ -628,7 +625,6 @@ final case class Some[+A](value: A) extends Option[A] {
 
 /** This case object represents non-existent values.
  *
- *  @author  Martin Odersky
  *  @since   1.0
  */
 @SerialVersionUID(5066590221178148012L) // value computed by serialver for 2.11.2, annotation added in 2.11.4

--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -61,7 +61,6 @@ package scala
  *        | from optional [[Function]] | [[Function.UnliftOps#unlift]] or [[Function.unlift]] | [[Predef.identity]] | [[Function.UnliftOps#unlift]] |
  *        | from an extractor | `{ case extractor(x) => x }` | `extractor.unapply _` | [[Predef.identity]] |
  *
- *  @author  Martin Odersky, Pavel Pavlov, Adriaan Moors
  *  @since   1.0
  */
 trait PartialFunction[-A, +B] extends (A => B) { self =>
@@ -222,7 +221,6 @@ trait PartialFunction[-A, +B] extends (A => B) { self =>
  *  def onlyInt(v: Any): Option[Int] = condOpt(v) { case x: Int => x }
  *  }}}
  *
- *  @author  Paul Phillips
  *  @since   2.8
  */
 object PartialFunction {

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -507,7 +507,6 @@ object Predef extends LowPriorityImplicits {
 *  but that are partially overridden by higher-priority conversions in object
 *  `Predef`.
 *
-*  @author  Martin Odersky
 *  @since 2.8
 */
 // scala/bug#7335 Parents of Predef are defined in the same compilation unit to avoid

--- a/src/library/scala/Product.scala
+++ b/src/library/scala/Product.scala
@@ -17,7 +17,6 @@ package scala
  *  their subclasses [[scala.Tuple1]] through [[scala.Tuple22]].  In addition,
  *  all case classes implement `Product` with synthetically generated methods.
  *
- *  @author  Burak Emir
  *  @since   2.3
  */
 trait Product extends Any with Equals {

--- a/src/library/scala/Proxy.scala
+++ b/src/library/scala/Proxy.scala
@@ -23,7 +23,6 @@ package scala
  *  '''Note:''' forwarding methods in this way will most likely create
  *  an asymmetric equals method, which is not generally recommended.
  *
- *  @author  Matthias Zenger
  *  @since   1.0
  */
 @deprecated("Explicitly override hashCode, equals and toString instead.", "2.13.0")

--- a/src/library/scala/Symbol.scala
+++ b/src/library/scala/Symbol.scala
@@ -21,7 +21,6 @@ package scala
  *  invoke the constructor of the `Symbol` class in the following way:
  *  `Symbol("mysym")`.
  *
- *  @author  Martin Odersky, Iulian Dragos
  *  @since   1.7
  */
 final class Symbol private (val name: String) extends Serializable {

--- a/src/library/scala/UninitializedError.scala
+++ b/src/library/scala/UninitializedError.scala
@@ -14,7 +14,6 @@ package scala
 
 /** This class represents uninitialized variable/value errors.
  *
- *  @author  Martin Odersky
  *  @since   2.5
  */
 // TODO: remove in 2.14

--- a/src/library/scala/annotation/Annotation.scala
+++ b/src/library/scala/annotation/Annotation.scala
@@ -23,7 +23,6 @@ package scala.annotation
  * and therefore not visible in Java reflection. In order to achieve this, the annotation has to
  * be written in Java.
  *
- *  @author  Martin Odersky
  *  @since 2.4
  */
 abstract class Annotation

--- a/src/library/scala/annotation/ClassfileAnnotation.scala
+++ b/src/library/scala/annotation/ClassfileAnnotation.scala
@@ -16,7 +16,6 @@ package scala.annotation
  *  [[http://docs.oracle.com/javase/8/docs/technotes/guides/language/annotations.html Java annotations]]]
  *  in classfiles.
  *
- *  @author  Martin Odersky
  *  @since 2.4
  */
 @deprecated("Annotation classes need to be written in Java in order to be stored in classfiles in a Java-compatible manner", "2.13.0")

--- a/src/library/scala/annotation/StaticAnnotation.scala
+++ b/src/library/scala/annotation/StaticAnnotation.scala
@@ -20,7 +20,6 @@ package scala.annotation
  * and therefore not visible in Java reflection. In order to achieve this, the annotation has to
  * be written in Java.
  *
- *  @author  Martin Odersky
  *  @since   2.4
  */
 trait StaticAnnotation extends Annotation

--- a/src/library/scala/annotation/TypeConstraint.scala
+++ b/src/library/scala/annotation/TypeConstraint.scala
@@ -23,7 +23,6 @@ package scala.annotation
  *  applied.  A Scala compiler will drop such annotations in cases where it
  *  would rewrite a type constraint.
  *
- *  @author  Lex Spoon
  *  @since   2.6
  */
 trait TypeConstraint extends Annotation

--- a/src/library/scala/annotation/elidable.scala
+++ b/src/library/scala/annotation/elidable.scala
@@ -76,7 +76,6 @@ package scala.annotation
  *   }
  * }}}
  *
- *  @author   Paul Phillips
  *  @since    2.8
  */
 final class elidable(final val level: Int) extends scala.annotation.StaticAnnotation

--- a/src/library/scala/annotation/implicitAmbiguous.scala
+++ b/src/library/scala/annotation/implicitAmbiguous.scala
@@ -38,7 +38,6 @@ package scala.annotation
   * implicitly[Int =!= Int]
   * }}}
   *
-  * @author Brian McKenna
   * @since 2.12.0
   */
 @meta.getter

--- a/src/library/scala/annotation/implicitNotFound.scala
+++ b/src/library/scala/annotation/implicitNotFound.scala
@@ -53,7 +53,6 @@ package scala.annotation
  * </pre>
  *
  *
- * @author Adriaan Moors
  * @since 2.8.1
  */
 final class implicitNotFound(msg: String) extends scala.annotation.StaticAnnotation {}

--- a/src/library/scala/annotation/strictfp.scala
+++ b/src/library/scala/annotation/strictfp.scala
@@ -15,7 +15,6 @@ package scala.annotation
 /** If this annotation is present on a method or its enclosing class,
  *  the strictfp flag will be emitted.
  *
- *  @author Paul Phillips
  *  @since 2.9
  */
 @deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")

--- a/src/library/scala/annotation/switch.scala
+++ b/src/library/scala/annotation/switch.scala
@@ -30,7 +30,6 @@ package scala.annotation
  *  Note: for pattern matches with one or two cases, the compiler generates jump instructions.
  *  Annotating such a match with `@switch` does not issue any warning.
  *
- *  @author   Paul Phillips
  *  @since    2.8
  */
 final class switch extends scala.annotation.StaticAnnotation

--- a/src/library/scala/collection/BufferedIterator.scala
+++ b/src/library/scala/collection/BufferedIterator.scala
@@ -16,7 +16,6 @@ package scala.collection
 /** Buffered iterators are iterators which provide a method `head`
  *  that inspects the next element without discarding it.
  *
- *  @author  Martin Odersky
  *  @since   2.8
  */
 trait BufferedIterator[+A] extends Iterator[A] {

--- a/src/library/scala/collection/Factory.scala
+++ b/src/library/scala/collection/Factory.scala
@@ -76,7 +76,6 @@ object Factory {
   * @tparam CC Collection type constructor (e.g. `List`)
   * @define factoryInfo
   *   This object provides a set of operations to create $Coll values.
-  *   @author Martin Odersky
   *   @since 2.13
   *
   * @define coll collection
@@ -360,7 +359,6 @@ trait StrictOptimizedSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extends SeqFac
   * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
   * @define factoryInfo
   *   This object provides a set of operations to create $Coll values.
-  *   @author Martin Odersky
   *   @since  2.13
   *
   * @define coll collection
@@ -378,7 +376,6 @@ trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
 /**
   * @define factoryInfo
   *   This object provides a set of operations to create $Coll values.
-  *   @author Martin Odersky
   *   @since 2.13
   *
   * @define coll collection
@@ -717,7 +714,6 @@ trait StrictOptimizedClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extend
 /**
   * @define factoryInfo
   *   This object provides a set of operations to create $Coll values.
-  *   @author Martin Odersky
   *   @since 2.13
   *
   * @define coll collection

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -993,7 +993,6 @@ object SeqOps {
  /**  A KMP implementation, based on the undoubtedly reliable wikipedia entry.
    *  Note: I made this private to keep it from entering the API.  That can be reviewed.
    *
-   *  @author paulp, Rex Kerr
    *  @since  2.10
    *  @param  S       Sequence that may contain target
    *  @param  m0      First index of S to consider
@@ -1082,7 +1081,6 @@ object SeqOps {
 
   /** Make sure a target sequence has fast, correctly-ordered indexing for KMP.
    *
-   *  @author Rex Kerr
    *  @since  2.10
    *  @param  W    The target sequence
    *  @param  n0   The first element in the target sequence that we should use
@@ -1122,7 +1120,6 @@ object SeqOps {
 
  /** Make a jump table for KMP search.
    *
-   *  @author paulp, Rex Kerr
    *  @since  2.10
    *  @param  Wopt The target sequence
    *  @param  wlen Just in case we're only IndexedSeq and not IndexedSeqOptimized

--- a/src/library/scala/collection/SeqMap.scala
+++ b/src/library/scala/collection/SeqMap.scala
@@ -21,7 +21,6 @@ package scala.collection
   *
   * @tparam K      the type of the keys contained in this linked map.
   * @tparam V      the type of the values associated with the keys in this linked map.
-  * @author Matthew de Detrich, Josh Lemer
   * @version 2.13
   * @since 2.13
   * @define coll immutable seq map

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -114,7 +114,6 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     *
     *  $willForceEvaluation
     *
-    *  @author Eastsun
     */
   private class SubsetsItr(elms: IndexedSeq[A], len: Int) extends AbstractIterator[C] {
     private[this] val idxs = Array.range(0, len+1)

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -678,7 +678,6 @@ private[concurrent] case class RDCSS_Descriptor[K, V](old: INode[K, V], expected
   *
   *  For details, see: [[http://lampwww.epfl.ch/~prokopec/ctries-snapshot.pdf]]
   *
-  *  @author Aleksandar Prokopec
   *  @since 2.10
   */
 final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater[TrieMap[K, V], AnyRef], hashf: Hashing[K], ef: Equiv[K])

--- a/src/library/scala/collection/generic/IsIterableOnce.scala
+++ b/src/library/scala/collection/generic/IsIterableOnce.scala
@@ -37,8 +37,6 @@ package generic
  *    // == List(2, 4)
  * }}}
  *
- * @author Miles Sabin
- * @author J. Suereth
  * @since 2.10
  */
 trait IsIterableOnce[Repr] {

--- a/src/library/scala/collection/generic/Subtractable.scala
+++ b/src/library/scala/collection/generic/Subtractable.scala
@@ -23,7 +23,6 @@ import scala.collection.IterableOnce
   *
   *  @tparam   A    the type of the elements of the $coll.
   *  @tparam   Repr the type of the $coll itself
-  *  @author   Martin Odersky
   *  @version  2.8
   *  @since    2.8
   *  @define   coll collection

--- a/src/library/scala/collection/immutable/ChampCommon.scala
+++ b/src/library/scala/collection/immutable/ChampCommon.scala
@@ -103,8 +103,6 @@ private[collection] abstract class Node[T <: Node[T]] {
   * node before traversing sub-nodes (left to right).
   *
   * @tparam T the trie node type we are iterating over
-  *
-  * @author   Michael J. Steindorfer
   */
 private[immutable] abstract class ChampBaseIterator[T <: Node[T]] {
 
@@ -193,8 +191,6 @@ private[immutable] abstract class ChampBaseIterator[T <: Node[T]] {
   * iterator performs a depth-first post-order traversal, traversing sub-nodes (right to left).
   *
   * @tparam T the trie node type we are iterating over
-  *
-  * @author   Michael J. Steindorfer
   */
 private[immutable] abstract class ChampBaseReverseIterator[T <: Node[T]] {
 

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -31,7 +31,6 @@ import scala.util.hashing.MurmurHash3
   *  @tparam K      the type of the keys contained in this hash set.
   *  @tparam V      the type of the values associated with the keys in this hash map.
   *
-  *  @author  Michael J. Steindorfer
   *  @since   2.13
   *  @define Coll `immutable.HashMap`
   *  @define coll immutable champ hash map

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -29,7 +29,6 @@ import scala.util.hashing.MurmurHash3
   *
   *  @tparam A      the type of the elements contained in this hash set.
   *
-  *  @author  Michael J. Steindorfer
   *  @since   2.13
   *  @define Coll `immutable.HashSet`
   *  @define coll immutable champ hash set

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -21,7 +21,6 @@ import scala.annotation.tailrec
 import scala.annotation.unchecked.uncheckedVariance
 
 /** Utility class for integer maps.
-  *  @author David MacIver
   */
 private[immutable] object IntMapUtils extends BitOperations.Int {
   def branchMask(i: Int, j: Int) = highestOneBit(i ^ j)

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -67,7 +67,6 @@ import scala.runtime.Statics.releaseFence
   *        objects that rely on structural sharing), will be serialized and deserialized with multiple lists, one for
   *        each reference to it. I.e. structural sharing is lost after serialization/deserialization.
   *
-  *  @author  Martin Odersky and others
   *  @since   1.0
   *  @see  [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#lists "Scala's Collection Library overview"]]
   *  section on `Lists` for more information.

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -35,8 +35,6 @@ import scala.runtime.Statics.releaseFence
   * @tparam K the type of the keys contained in this list map
   * @tparam V the type of the values associated with the keys
   *
-  * @author Matthias Zenger
-  * @author Martin Odersky
   * @since 1
   * @define Coll ListMap
   * @define coll list map

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -34,7 +34,6 @@ import scala.collection.generic.DefaultSerializable
   *
   * @tparam A the type of the elements contained in this list set
   *
-  * @author Matthias Zenger
   * @since 1
   * @define Coll ListSet
   * @define coll list set

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -23,7 +23,6 @@ import scala.annotation.tailrec
 import scala.annotation.unchecked.uncheckedVariance
 
 /** Utility class for long maps.
-  *  @author David MacIver
   */
 private[immutable] object LongMapUtils extends BitOperations.Long {
   def branchMask(i: Long, j: Long) = highestOneBit(i ^ j)

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -30,7 +30,6 @@ import scala.collection.mutable.{Builder, ListBuffer}
   *  where a pivot is required, in which case, a cost of `O(n)` is incurred, where `n` is the number of elements in the queue. When this happens,
   *  `n` remove operations with `O(1)` cost are guaranteed. Removing an item is on average `O(1)`.
   *
-  *  @author  Erik Stenman
   *  @since   1
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable-queues "Scala's Collection Library overview"]]
   *  section on `Immutable Queues` for more information.

--- a/src/library/scala/collection/immutable/SeqMap.scala
+++ b/src/library/scala/collection/immutable/SeqMap.scala
@@ -27,7 +27,6 @@ import scala.collection.mutable.Builder
   * @tparam K      the type of the keys contained in this linked map.
   * @tparam V      the type of the values associated with the keys in this linked map.
   *
-  * @author Matthew de Detrich
   * @version 2.13
   * @since 2.13
   * @define coll immutable seq map

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -57,8 +57,6 @@ import scala.collection.mutable.ReusableBuilder
   *  @tparam V         the type of the values associated with the keys.
   *  @param ordering   the implicit ordering used to compare objects of type `A`.
   *
-  *  @author  Erik Stenman
-  *  @author  Matthias Zenger
   *  @since   1
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
   *  section on `Red-Black Trees` for more information.

--- a/src/library/scala/collection/immutable/TreeSeqMap.scala
+++ b/src/library/scala/collection/immutable/TreeSeqMap.scala
@@ -40,7 +40,6 @@ import scala.annotation.unchecked.uncheckedVariance
   *
   *  @tparam K the type of the keys contained in this map.
   *  @tparam V the type of the values associated with the keys in this map.
-  * @author Odd Möller
   * @version 2.13
   * @since 2.13
   * @define coll immutable tree seq map

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -25,7 +25,6 @@ import scala.collection.mutable.ReusableBuilder
   *  @tparam A         the type of the elements contained in this tree set
   *  @param ordering   the implicit ordering used to compare objects of type `A`
   *
-  *  @author  Martin Odersky
   *  @since   1
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
   *  section on `Red-Black Trees` for more information.

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -24,8 +24,6 @@ import scala.annotation.tailrec
   *  @tparam K      the type of the keys contained in this vector map.
   *  @tparam V      the type of the values associated with the keys in this vector map.
   *
-  * @author Matthew de Detrich
-  * @author Odd Möller
   * @version 2.13
   * @since 2.13
   * @define coll immutable vector map

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -24,8 +24,6 @@ import scala.collection.generic.DefaultSerializable
   *  access take constant time (amortized time). Prepends and removes are
   *  linear in the buffer size.
   *
-  *  @author  Matthias Zenger
-  *  @author  Martin Odersky
   *  @since   1
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array-buffers "Scala's Collection Library overview"]]
   *  section on `Array Buffers` for more information.

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -27,7 +27,6 @@ import scala.reflect.ClassTag
   *
   *  @note Subclasses ''must'' override the `ofArray` protected method to return a more specific type.
   *
-  *  @author  Pathikrit Bhowmick
   *  @since   2.13
   *
   *  @tparam A  the type of this ArrayDeque's elements.

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -26,7 +26,6 @@ import scala.util.hashing.MurmurHash3
   *
   *  @tparam T    type of the elements in this wrapped array.
   *
-  *  @author  Martin Odersky, Stephane Micheloud
   *  @since 2.8
   *  @define Coll `ArraySeq`
   *  @define coll wrapped array

--- a/src/library/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/src/library/scala/collection/mutable/CollisionProofHashMap.scala
@@ -25,7 +25,6 @@ import scala.runtime.Statics
   * as determined by the `Ordering` has to be consistent with `equals` and `hashCode`. Universal equality
   * of numeric types is not supported (similar to `AnyRefMap`).
   *
-  * @author  Stefan Zeiger
   * @since   2.13
   * @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
   * section on `Hash Tables` for more information.

--- a/src/library/scala/collection/mutable/GrowableBuilder.scala
+++ b/src/library/scala/collection/mutable/GrowableBuilder.scala
@@ -19,7 +19,6 @@ package collection.mutable
   *
   * GrowableBuilders can produce only a single instance of the collection they are growing.
   *
-  * @author Paul Phillips
   * @since 2.8
   *
   * @define Coll `GrowingBuilder`

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -19,7 +19,6 @@ import scala.collection.generic.DefaultSerializationProxy
 
 /** This class implements mutable maps using a hashtable.
   *
-  *  @author  Stefan Zeiger
   *  @since 1
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
   *  section on `Hash Tables` for more information.

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -19,7 +19,6 @@ import scala.collection.generic.DefaultSerializationProxy
 
 /** This class implements mutable sets using a hashtable.
   *
-  * @author  Stefan Zeiger
   * @since   1
   * @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
   * section on `Hash Tables` for more information.

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -33,8 +33,6 @@ import java.lang.Integer
  *  its size is automatically doubled. Both parameters may be changed by
  *  overriding the corresponding values in class `HashTable`.
  *
- *  @author  Matthias Zenger
- *  @author  Martin Odersky
  *  @since   1
  *
  *  @tparam A     type of the elements contained in this hash table.

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -21,9 +21,6 @@ import scala.collection.generic.DefaultSerializable
 /** This class implements mutable sets using a hashtable.
  *  The iterator and all traversal methods of this class visit elements in the order they were inserted.
  *
- *  @author  Matthias Zenger
- *  @author  Martin Odersky
- *  @author  Pavel Pavlov
  *  @since   1
  *
  *  @tparam A     the type of the elements contained in this set.

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -23,8 +23,6 @@ import scala.runtime.Statics.releaseFence
 /** A `Buffer` implementation backed by a list. It provides constant time
   *  prepend and append. Most other operations are linear.
   *
-  *  @author  Matthias Zenger
-  *  @author  Martin Odersky
   *  @since   1
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#list-buffers "Scala's Collection Library overview"]]
   *  section on `List Buffers` for more information.

--- a/src/library/scala/collection/mutable/MultiMap.scala
+++ b/src/library/scala/collection/mutable/MultiMap.scala
@@ -49,8 +49,6 @@ package scala.collection.mutable
   *
   *  @define coll multimap
   *  @define Coll `MultiMap`
-  *  @author  Matthias Zenger
-  *  @author  Martin Odersky
   *  @since   1
   */
 trait MultiMap[K, V] extends Map[K, Set[V]] {

--- a/src/library/scala/collection/mutable/OpenHashMap.scala
+++ b/src/library/scala/collection/mutable/OpenHashMap.scala
@@ -55,7 +55,6 @@ object OpenHashMap extends MapFactory[OpenHashMap] {
   *  @tparam Value        type of the values in this map.
   *  @param initialSize   the initial size of the internal hash table.
   *
-  *  @author David MacIver
   *  @since  2.7
   *
   *  @define Coll `OpenHashMap`

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -45,7 +45,6 @@ import scala.math.Ordering
   *  @tparam A    type of the elements in this priority queue.
   *  @param ord   implicit ordering used to compare the elements of type `A`.
   *
-  *  @author  Matthias Zenger
   *  @since   1
   *
   *  @define Coll PriorityQueue

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -19,8 +19,6 @@ import scala.collection.generic.DefaultSerializable
 /** `Queue` objects implement data structures that allow to
   *  insert and retrieve elements in a first-in-first-out (FIFO) manner.
   *
-  *  @author  Pathikrit Bhowmick
-  *
   *  @since   2.13
   *
   *  @define Coll `mutable.Queue`

--- a/src/library/scala/collection/mutable/RedBlackTree.scala
+++ b/src/library/scala/collection/mutable/RedBlackTree.scala
@@ -22,7 +22,6 @@ import java.lang.String
  *
  * The trees implemented in this object are *not* thread safe.
  *
- * @author Rui Gonçalves
  * @since 2.12
  */
 private[collection] object RedBlackTree {

--- a/src/library/scala/collection/mutable/SeqMap.scala
+++ b/src/library/scala/collection/mutable/SeqMap.scala
@@ -24,7 +24,6 @@ package mutable
   * @tparam K      the type of the keys contained in this linked map.
   * @tparam V      the type of the values associated with the keys in this linked map.
   *
-  * @author Matthew de Detrich
   * @version 2.13
   * @since 2.13
   * @define coll mutable Seq map

--- a/src/library/scala/collection/mutable/Shrinkable.scala
+++ b/src/library/scala/collection/mutable/Shrinkable.scala
@@ -18,7 +18,6 @@ import scala.annotation.tailrec
 /** This trait forms part of collections that can be reduced
   *  using a `-=` operator.
   *
-  *  @author   Martin Odersky
   *  @since   2.8
   *  @define coll shrinkable collection
   *  @define Coll `Shrinkable`

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -21,7 +21,6 @@ import scala.collection.{IterableFactoryDefaults, IterableOnce, SeqFactory, Stri
   *
   *  @tparam A    type of the elements contained in this stack.
   *
-  *  @author  Pathikrit Bhowmick
   *  @since   2.13
   *
   *  @define Coll `Stack`

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -32,8 +32,6 @@ import scala.Predef.{ // unimport char-related implicit conversions to avoid tri
   *
   * $multipleResults
   *
-  * @author Stephane Micheloud
-  * @author Martin Odersky
   * @since   2.7
   * @define Coll `mutable.IndexedSeq`
   * @define coll string builder

--- a/src/library/scala/collection/mutable/TreeMap.scala
+++ b/src/library/scala/collection/mutable/TreeMap.scala
@@ -26,7 +26,6 @@ import scala.collection.mutable.{RedBlackTree => RB}
   * @tparam K the type of the keys contained in this tree map.
   * @tparam V the type of the values associated with the keys.
   *
-  * @author Rui Gonçalves
   * @since 2.12
   *
   * @define Coll mutable.TreeMap

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -24,7 +24,6 @@ import scala.collection.{SortedIterableFactory, SortedSetFactoryDefaults, Steppe
   * @param ordering the implicit ordering used to compare objects of type `A`.
   * @tparam A the type of the keys contained in this tree set.
   *
-  * @author Rui Gonçalves
   * @since 2.10
   *
   * @define Coll mutable.TreeSet
@@ -190,7 +189,6 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
   * $factoryInfo
   * @define Coll `mutable.TreeSet`
   * @define coll mutable tree set
-  * @author Lucien Pereira
   */
 @SerialVersionUID(3L)
 object TreeSet extends SortedIterableFactory[TreeSet] {

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -44,7 +44,6 @@ import scala.collection.immutable.Nil
   *
   *  @define coll unrolled buffer
   *  @define Coll `UnrolledBuffer`
-  *  @author Aleksandar Prokopec
   *
   */
 @SerialVersionUID(3L)

--- a/src/library/scala/concurrent/Channel.scala
+++ b/src/library/scala/concurrent/Channel.scala
@@ -16,7 +16,6 @@ package scala.concurrent
  *  which are read by one or more reader threads.
  *
  *  @tparam A type of data exchanged
- *  @author  Martin Odersky
  */
 @deprecated("Use `java.util.concurrent.LinkedTransferQueue` instead.", since = "2.13.0")
 class Channel[A] {

--- a/src/library/scala/concurrent/DelayedLazyVal.scala
+++ b/src/library/scala/concurrent/DelayedLazyVal.scala
@@ -24,7 +24,6 @@ package scala.concurrent
  *  @param  f      the function to obtain the current value at any point in time
  *  @param  body   the computation to run to completion in another thread
  *
- *  @author  Paul Phillips
  *  @since 2.8
  */
 @deprecated("`DelayedLazyVal` Will be removed in Scala 2.14.0 release.", since = "2.13.0")

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -42,8 +42,6 @@ import scala.concurrent.ExecutionContext.parasitic
  *  }
  *  }}}
  *
- *  @author  Philipp Haller, Heather Miller, Aleksandar Prokopec, Viktor Klang
- *
  *  @see [[http://docs.scala-lang.org/overviews/core/futures.html Futures and Promises]]
  *
  *  @define multipleCallbacks

--- a/src/library/scala/concurrent/JavaConversions.scala
+++ b/src/library/scala/concurrent/JavaConversions.scala
@@ -17,8 +17,6 @@ import scala.language.implicitConversions
 
 /** The `JavaConversions` object provides implicit conversions supporting
  *  interoperability between Scala and Java concurrency classes.
- *
- *  @author Philipp Haller
  */
 @deprecated("Use the factory methods in `ExecutionContext` instead", "2.13.0")
 object JavaConversions {

--- a/src/library/scala/concurrent/SyncChannel.scala
+++ b/src/library/scala/concurrent/SyncChannel.scala
@@ -16,7 +16,6 @@ package scala.concurrent
  *  a reader and a writer thread. The writer thread is blocked until the
  *  data to be written has been read by a corresponding reader thread.
  *
- *  @author  Philipp Haller
  *  @since 2.0
  */
 @deprecated("Use `java.util.concurrent.Exchanger` instead.", since = "2.13.0")

--- a/src/library/scala/concurrent/SyncVar.scala
+++ b/src/library/scala/concurrent/SyncVar.scala
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeUnit
  *  All methods are synchronized.
  *
  *  @tparam A type of the contained value
- *  @author  Martin Odersky
  */
 @deprecated("Use `java.util.concurrent.LinkedBlockingQueue with capacity 1` instead.", since = "2.13.0")
 class SyncVar[A] {

--- a/src/library/scala/inline.scala
+++ b/src/library/scala/inline.scala
@@ -46,8 +46,6 @@ package scala
  * def t1 = f1(1) + f1(1): @noinline   // equivalent to (f1(1) + f1(1)): @noinline
  * def t2 = f1(1) + (f1(1): @noinline) // the second call to f1 is not inlined
  * }}}
- *
- * @author Lex Spoon
  */
 @deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
 class inline extends scala.annotation.StaticAnnotation

--- a/src/library/scala/io/BufferedSource.scala
+++ b/src/library/scala/io/BufferedSource.scala
@@ -19,8 +19,6 @@ import scala.collection.mutable.StringBuilder
 
 /** This object provides convenience methods to create an iterable
  *  representation of a source file.
- *
- *  @author  Burak Emir, Paul Phillips
  */
 class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val codec: Codec) extends Source {
   def this(inputStream: InputStream)(implicit codec: Codec) = this(inputStream, DefaultBufSize)(codec)

--- a/src/library/scala/io/Position.scala
+++ b/src/library/scala/io/Position.scala
@@ -35,7 +35,6 @@ package io
  *  {{{
  *  encode(line1,column1) <= encode(line2,column2)
  *  }}}
- *  @author Burak Emir (translated from work by Matthias Zenger and others)
  */
 @deprecated("this class will be removed", "2.10.0")
 private[scala] abstract class Position {

--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -19,8 +19,6 @@ import java.net.{ URI, URL }
 
 /** This object provides convenience methods to create an iterable
  *  representation of a source file.
- *
- *  @author  Burak Emir, Paul Phillips
  */
 object Source {
   val DefaultBufSize = 2048

--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -19,8 +19,6 @@ import java.math.{ MathContext, BigDecimal => BigDec }
 import scala.collection.immutable.NumericRange
 
 /**
- *  @author  Stephane Micheloud
- *  @author  Rex Kerr
  *  @since 2.7
  */
 object BigDecimal {
@@ -355,9 +353,6 @@ object BigDecimal {
  *  and powers.  The left-hand argument's `MathContext` always determines the
  *  degree of rounding, if any, and is the one propagated through arithmetic
  *  operations that do not apply rounding themselves.
- *
- *  @author  Stephane Micheloud
- *  @author  Rex Kerr
  */
 final class BigDecimal(val bigDecimal: BigDec, val mc: MathContext)
 extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[BigDecimal] {

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -17,7 +17,6 @@ import java.math.BigInteger
 import scala.language.implicitConversions
 
 /**
- *  @author  Martin Odersky
  *  @since 2.1
  */
 object BigInt {
@@ -108,9 +107,6 @@ object BigInt {
   implicit def javaBigInteger2bigInt(x: BigInteger): BigInt = apply(x)
 }
 
-/**
- *  @author  Martin Odersky
- */
 final class BigInt(val bigInteger: BigInteger)
   extends ScalaNumber
     with ScalaNumericConversions

--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -31,7 +31,6 @@ import scala.language.higherKinds
  *    1. transitive: if `equiv(x, y) == true` and `equiv(y, z) == true`, then
  *       `equiv(x, z) == true` for any `x`, `y`, and `z` of type `T`.
  *
- *  @author  Geoffrey Washburn, Paul Phillips
  *  @since 2.7
  */
 

--- a/src/library/scala/math/Ordered.scala
+++ b/src/library/scala/math/Ordered.scala
@@ -55,7 +55,6 @@ import scala.language.implicitConversions
  *  provide it yourself either when inheriting or instantiating.
  *
  *  @see [[scala.math.Ordering]], [[scala.math.PartiallyOrdered]]
- *  @author  Martin Odersky
  */
 trait Ordered[A] extends Any with java.lang.Comparable[A] {
 

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -65,7 +65,6 @@ import scala.language.{higherKinds, implicitConversions}
   * You can import scala.math.Ordering.Implicits to gain access to other
   * implicit orderings.
   *
-  * @author Geoffrey Washburn
   * @since 2.7
   * @see [[scala.math.Ordered]], [[scala.util.Sorting]]
   */

--- a/src/library/scala/math/PartialOrdering.scala
+++ b/src/library/scala/math/PartialOrdering.scala
@@ -37,7 +37,6 @@ package math
  *  exposed as the `equiv` method, inherited from the
  *  [[scala.math.Equiv Equiv]] trait.
  *
- *  @author  Geoffrey Washburn
  *  @since 2.7
  */
 

--- a/src/library/scala/math/PartiallyOrdered.scala
+++ b/src/library/scala/math/PartiallyOrdered.scala
@@ -14,8 +14,6 @@ package scala
 package math
 
 /** A class for partially ordered data.
- *
- *  @author  Martin Odersky
  */
 trait PartiallyOrdered[+A] extends Any {
 

--- a/src/library/scala/math/ScalaNumber.java
+++ b/src/library/scala/math/ScalaNumber.java
@@ -13,7 +13,6 @@
 package scala.math;
 
 /** A marker class for Number types introduced by Scala
- *  @author  Martin Odersky, Paul Phillips
  *  @version 2.8
  *  @since 2.8
  */

--- a/src/library/scala/noinline.scala
+++ b/src/library/scala/noinline.scala
@@ -44,7 +44,5 @@ package scala
  * def t1 = f1(1) + f1(1): @noinline   // equivalent to (f1(1) + f1(1)): @noinline
  * def t2 = f1(1) + (f1(1): @noinline) // the second call to f1 is not inlined
  * }}}
- *
- * @author Lex Spoon
  */
 final class noinline extends scala.annotation.StaticAnnotation

--- a/src/library/scala/ref/PhantomReference.scala
+++ b/src/library/scala/ref/PhantomReference.scala
@@ -12,16 +12,10 @@
 
 package scala.ref
 
-/**
- *  @author Sean McDirmid
- */
 class PhantomReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T]) extends ReferenceWrapper[T] {
   val underlying: java.lang.ref.PhantomReference[_ <: T] =
     new PhantomReferenceWithWrapper[T](value, queue, this)
 }
 
-/**
- *  @author Philipp Haller
- */
 private class PhantomReferenceWithWrapper[T <: AnyRef](value: T, queue: ReferenceQueue[T], val wrapper: PhantomReference[T])
   extends java.lang.ref.PhantomReference[T](value, queue.underlying.asInstanceOf[java.lang.ref.ReferenceQueue[T]]) with ReferenceWithWrapper[T]

--- a/src/library/scala/ref/Reference.scala
+++ b/src/library/scala/ref/Reference.scala
@@ -14,7 +14,6 @@ package scala.ref
 
 /**
  * @see `java.lang.ref.Reference`
- * @author Sean McDirmid
  */
 trait Reference[+T <: AnyRef] extends Function0[T] {
   /** return the underlying value */

--- a/src/library/scala/ref/ReferenceQueue.scala
+++ b/src/library/scala/ref/ReferenceQueue.scala
@@ -12,10 +12,6 @@
 
 package scala.ref
 
-/**
- *  @author Sean McDirmid
- *  @author Philipp Haller
- */
 class ReferenceQueue[+T <: AnyRef] {
 
   private[ref] val underlying: java.lang.ref.ReferenceQueue[_ <: T] = new java.lang.ref.ReferenceQueue[T]

--- a/src/library/scala/ref/ReferenceWrapper.scala
+++ b/src/library/scala/ref/ReferenceWrapper.scala
@@ -12,9 +12,6 @@
 
 package scala.ref
 
-/**
- *  @author Sean McDirmid
- */
 trait ReferenceWrapper[+T <: AnyRef] extends Reference[T] with Proxy {
   val underlying: java.lang.ref.Reference[_ <: T]
   override def get = Option(underlying.get)
@@ -29,9 +26,6 @@ trait ReferenceWrapper[+T <: AnyRef] extends Reference[T] with Proxy {
   def self = underlying
 }
 
-/**
- *  @author Philipp Haller
- */
 private trait ReferenceWithWrapper[T <: AnyRef] {
   val wrapper: ReferenceWrapper[T]
 }

--- a/src/library/scala/ref/SoftReference.scala
+++ b/src/library/scala/ref/SoftReference.scala
@@ -12,9 +12,6 @@
 
 package scala.ref
 
-/**
- *  @author Sean McDirmid
- */
 class SoftReference[+T <: AnyRef](value : T, queue : ReferenceQueue[T]) extends ReferenceWrapper[T] {
   def this(value : T) = this(value, null)
 
@@ -24,7 +21,6 @@ class SoftReference[+T <: AnyRef](value : T, queue : ReferenceQueue[T]) extends 
 
 /**
  *  A companion object that implements an extractor for `SoftReference` values
- *  @author Rebecca Claire Murphy
  */
 object SoftReference {
 
@@ -35,8 +31,5 @@ object SoftReference {
   def unapply[T <: AnyRef](sr: SoftReference[T]): Option[T] = Option(sr.underlying.get)
 }
 
-/**
- *  @author Philipp Haller
- */
 private class SoftReferenceWithWrapper[T <: AnyRef](value: T, queue: ReferenceQueue[T], val wrapper: SoftReference[T])
   extends java.lang.ref.SoftReference[T](value, if (queue == null) null else queue.underlying.asInstanceOf[java.lang.ref.ReferenceQueue[T]]) with ReferenceWithWrapper[T]

--- a/src/library/scala/ref/WeakReference.scala
+++ b/src/library/scala/ref/WeakReference.scala
@@ -16,7 +16,6 @@ package scala.ref
  *  A wrapper class for java.lang.ref.WeakReference
  *  The new functionality is (1) results are Option values, instead of using null.
  *  (2) There is an extractor that maps the weak reference itself into an option.
- *  @author Sean McDirmid
  */
 class WeakReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T]) extends ReferenceWrapper[T] {
   def this(value: T) = this(value, null)
@@ -34,8 +33,5 @@ object WeakReference {
   def unapply[T <: AnyRef](wr: WeakReference[T]): Option[T] = Option(wr.underlying.get)
 }
 
-/**
- *  @author Philipp Haller
- */
 private class WeakReferenceWithWrapper[T <: AnyRef](value: T, queue: ReferenceQueue[T], val wrapper: WeakReference[T])
   extends java.lang.ref.WeakReference[T](value, if (queue == null) null else queue.underlying.asInstanceOf[java.lang.ref.ReferenceQueue[T]]) with ReferenceWithWrapper[T]

--- a/src/library/scala/reflect/OptManifest.scala
+++ b/src/library/scala/reflect/OptManifest.scala
@@ -16,8 +16,6 @@ package reflect
 /** A `OptManifest[T]` is an optional [[scala.reflect.Manifest]].
  *
  *  It is either a `Manifest` or the value `NoManifest`.
- *
- *  @author Martin Odersky
  */
 // TODO undeprecated until Scala reflection becomes non-experimental
 // @deprecated("This notion doesn't have a corresponding concept in 2.10, because scala.reflect.runtime.universe.TypeTag can capture arbitrary types. Use type tags instead of manifests, and there will be no need in opt manifests.", "2.10.0")

--- a/src/library/scala/runtime/AbstractPartialFunction.scala
+++ b/src/library/scala/runtime/AbstractPartialFunction.scala
@@ -24,7 +24,6 @@ package runtime
  *
  *  This trait is used as a basis for implementation of all partial function literals.
  *
- *  @author  Pavel Pavlov
  *  @since   2.10
  */
 abstract class AbstractPartialFunction[@specialized(Specializable.Arg) -T1, @specialized(Specializable.Return) +R] extends Function1[T1, R] with PartialFunction[T1, R] { self =>

--- a/src/library/scala/runtime/BoxesRunTime.java
+++ b/src/library/scala/runtime/BoxesRunTime.java
@@ -24,9 +24,6 @@ import scala.math.ScalaNumber;
   *     be a boxed value.
   *   - Standard value operators for boxed number and quasi-number values.
   *
-  * @author  Gilles Dubochet
-  * @author  Martin Odersky
-  * @contributor Stepan Koltsov
   * @version 2.0 */
 public final class BoxesRunTime
 {

--- a/src/library/scala/runtime/ScalaNumberProxy.scala
+++ b/src/library/scala/runtime/ScalaNumberProxy.scala
@@ -21,7 +21,6 @@ import Proxy.Typed
 /** Base classes for the Rich* wrappers of the primitive types.
  *  As with all classes in scala.runtime.*, this is not a supported API.
  *
- *  @author Paul Phillips
  *  @since   2.9
  */
 trait ScalaNumberProxy[T] extends Any with ScalaNumericAnyConversions with Typed[T] with OrderedProxy[T] {

--- a/src/library/scala/sys/Prop.scala
+++ b/src/library/scala/sys/Prop.scala
@@ -19,7 +19,6 @@ package sys
  *
  *  See `scala.sys.SystemProperties` for an example usage.
  *
- *  @author Paul Phillips
  *  @since   2.9
  */
 trait Prop[+T] {

--- a/src/library/scala/sys/ShutdownHookThread.scala
+++ b/src/library/scala/sys/ShutdownHookThread.scala
@@ -16,7 +16,6 @@ package sys
 /** A minimal Thread wrapper to enhance shutdown hooks.  It knows
  *  how to unregister itself.
  *
- *  @author Paul Phillips
  *  @since   2.9
  */
 class ShutdownHookThread private (runnable: Runnable, name: String) extends Thread(runnable, name) {

--- a/src/library/scala/sys/SystemProperties.scala
+++ b/src/library/scala/sys/SystemProperties.scala
@@ -28,7 +28,6 @@ import scala.language.implicitConversions
  *  @define Coll `collection.mutable.Map`
  *  @define coll mutable map
  *
- *  @author Paul Phillips
  *  @since   2.9
  */
 class SystemProperties

--- a/src/library/scala/sys/package.scala
+++ b/src/library/scala/sys/package.scala
@@ -19,7 +19,6 @@ import scala.collection.JavaConverters._
  *  and altering core aspects of the virtual machine as well as the
  *  world outside of it.
  *
- *  @author Paul Phillips
  *  @since   2.9
  */
 package object sys {

--- a/src/library/scala/throws.scala
+++ b/src/library/scala/throws.scala
@@ -23,7 +23,6 @@ package scala
  * }
  * }}}
  *
- * @author  Nikolay Mihaylov
  * @since   2.1
  */
 final class throws[T <: Throwable](cause: String = "") extends scala.annotation.StaticAnnotation {

--- a/src/library/scala/util/DynamicVariable.scala
+++ b/src/library/scala/util/DynamicVariable.scala
@@ -38,7 +38,6 @@ import java.lang.InheritableThreadLocal
  *  from then on the bindings for the new thread
  *  are independent of those for the original thread.
  *
- *  @author  Lex Spoon
  *  @since   2.6
  */
 class DynamicVariable[T](init: T) {

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -117,7 +117,6 @@ package util
  *  // Left(42.0), but unexpectedly a `Either[Double,String]`
  *  }}}
  *
- *  @author <a href="mailto:research@workingmouse.com">Tony Morris</a>, Workingmouse
  *  @since 2.7
  */
 sealed abstract class Either[+A, +B] extends Product with Serializable {
@@ -454,8 +453,6 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
 }
 
 /** The left side of the disjoint union, as opposed to the [[scala.util.Right]] side.
- *
- *  @author <a href="mailto:research@workingmouse.com">Tony Morris</a>, Workingmouse
  */
 final case class Left[+A, +B](value: A) extends Either[A, B] {
   def isLeft  = true
@@ -473,8 +470,6 @@ final case class Left[+A, +B](value: A) extends Either[A, B] {
 }
 
 /** The right side of the disjoint union, as opposed to the [[scala.util.Left]] side.
- *
- *  @author <a href="mailto:research@workingmouse.com">Tony Morris</a>, Workingmouse
  */
 final case class Right[+A, +B](value: B) extends Either[A, B] {
   def isLeft  = false
@@ -526,7 +521,6 @@ object Either {
 
   /** Projects an `Either` into a `Left`.
    *
-   *  @author <a href="mailto:research@workingmouse.com">Tony Morris</a>, Workingmouse
    *  @see [[scala.util.Either#left]]
    */
   @deprecated("use `swap` instead", "2.13.0")
@@ -686,8 +680,6 @@ object Either {
    *  Because `Either` is already right-biased, this class is not normally needed.
    *  (It is retained in the library for now for easy cross-compilation between Scala
    *  2.11 and 2.12.)
-   *
-   *  @author <a href="mailto:research@workingmouse.com">Tony Morris</a>, Workingmouse
    */
   @deprecated("Either is now right-biased, calls to `right` should be removed", "2.13.0")
   final case class RightProjection[+A, +B](e: Either[A, B]) {

--- a/src/library/scala/util/Random.scala
+++ b/src/library/scala/util/Random.scala
@@ -19,10 +19,6 @@ import scala.collection.BuildFrom
 import scala.collection.immutable.{ List, LazyList }
 import scala.language.{implicitConversions, higherKinds}
 
-/**
- *  @author Stephane Micheloud
- *
- */
 class Random(val self: java.util.Random) extends AnyRef with Serializable {
   /** Creates a new random number generator using a single long seed. */
   def this(seed: Long) = this(new java.util.Random(seed))

--- a/src/library/scala/util/Sorting.scala
+++ b/src/library/scala/util/Sorting.scala
@@ -34,10 +34,6 @@ import scala.math.Ordering
   * Note also that high-performance non-default sorts for numeric types
   * are not provided.  If this is required, it is advisable to investigate
   * other libraries that cover this use case.
-  *
-  * @author  Ross Judson
-  * @author  Adriaan Moors
-  * @author  Rex Kerr
   */
 object Sorting {
   /** Sort an array of Doubles using `java.util.Arrays.sort`. */

--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -61,7 +61,6 @@ import scala.util.control.NonFatal
  *
  * `Try` comes to the Scala standard library after years of use as an integral part of Twitter's stack.
  *
- * @author based on Twitter's original implementation in com.twitter.util.
  * @since 2.10
  */
 sealed abstract class Try[+T] extends Product with Serializable {

--- a/src/library/scala/util/Using.scala
+++ b/src/library/scala/util/Using.scala
@@ -91,7 +91,6 @@ import scala.util.control.{ControlThrowable, NonFatal}
   *
   * @define suppressionBehavior See the main doc for [[Using `Using`]] for full details of
   *                             suppression behavior.
-  * @author NthPortal
   */
 object Using {
   /** Performs an operation using a resource, and then releases the resource,

--- a/src/library/scala/util/control/ControlThrowable.scala
+++ b/src/library/scala/util/control/ControlThrowable.scala
@@ -39,8 +39,6 @@ package scala.util.control
  *
  *  Instances of `ControlThrowable` should not normally have a cause.
  *  Legacy subclasses may set a cause using `initCause`.
- *
- *  @author Miles Sabin
  */
 abstract class ControlThrowable(message: String) extends Throwable(
   message, /*cause*/ null, /*enableSuppression=*/ false, /*writableStackTrace*/ false) {

--- a/src/library/scala/util/control/Exception.scala
+++ b/src/library/scala/util/control/Exception.scala
@@ -148,8 +148,6 @@ import scala.language.implicitConversions
  *  @groupdesc logic-container Containers for catch and finally behavior.
  *
  *  @define protectedExceptions `ControlThrowable` or `InterruptedException`
- *
- *  @author Paul Phillips
  */
 
 object Exception {

--- a/src/library/scala/util/control/NoStackTrace.scala
+++ b/src/library/scala/util/control/NoStackTrace.scala
@@ -20,7 +20,6 @@ package util.control
  *
  *  @note Since JDK 1.7, a similar effect can be achieved with `class Ex extends Throwable(..., writableStackTrace = false)`
  *
- *  @author   Paul Phillips
  *  @since    2.8
  */
 trait NoStackTrace extends Throwable {

--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -191,10 +191,6 @@ import java.util.regex.{ Pattern, Matcher }
  *
  *  @see [[java.util.regex.Pattern]]
  *
- *  @author  Thibaud Hottelier
- *  @author  Philipp Haller
- *  @author  Martin Odersky
- *
  *  @param pattern    The compiled pattern
  *  @param groupNames A mapping from names to indices in capture groups
  *

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -12,7 +12,6 @@
 
 /* NSC -- new Scala compiler
  * Copyright 2005-2013 LAMP/EPFL
- * @author  Martin Odersky
  */
 
 package scala

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -19,7 +19,6 @@ import scala.annotation.tailrec
 
 /** This class ...
  *
- *  @author Martin Odersky
  *  @version 1.0
  */
 abstract class TreeInfo {

--- a/src/reflect/scala/reflect/internal/pickling/PickleFormat.scala
+++ b/src/reflect/scala/reflect/internal/pickling/PickleFormat.scala
@@ -20,7 +20,6 @@ package pickling
  *  If you extend the format, be sure to increase the
  *  version minor number.
  *
- *  @author Martin Odersky
  *  @version 1.0
  */
 object PickleFormat {

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -26,9 +26,6 @@ import scala.collection.mutable.ListBuffer
 import scala.annotation.switch
 import scala.util.control.NonFatal
 
-/** @author Martin Odersky
- *  @version 1.0
- */
 abstract class UnPickler {
   val symbolTable: SymbolTable
   import symbolTable._

--- a/src/reflect/scala/reflect/internal/util/AbstractFileClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/AbstractFileClassLoader.scala
@@ -36,8 +36,6 @@ object AbstractFileClassLoader {
 }
 
 /** A class loader that loads files from a [[scala.reflect.io.AbstractFile]].
- *
- *  @author Lex Spoon
  */
 class AbstractFileClassLoader(val root: AbstractFile, parent: ClassLoader)
     extends ClassLoader(parent)

--- a/src/reflect/scala/reflect/internal/util/StringOps.scala
+++ b/src/reflect/scala/reflect/internal/util/StringOps.scala
@@ -19,8 +19,6 @@ import java.lang.System.{lineSeparator => EOL}
 
 /** This object provides utility methods to extract elements
  *  from Strings.
- *
- *  @author Martin Odersky
  *  @version 1.0
  */
 trait StringOps {

--- a/src/reflect/scala/reflect/io/AbstractFile.scala
+++ b/src/reflect/scala/reflect/io/AbstractFile.scala
@@ -26,7 +26,6 @@ import scala.collection.AbstractIterable
  *
  * ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  *
- * @author Philippe Altherr
  * @version 1.0, 23/03/2004
  */
 object AbstractFile {

--- a/src/reflect/scala/reflect/io/Directory.scala
+++ b/src/reflect/scala/reflect/io/Directory.scala
@@ -36,7 +36,6 @@ object Directory {
 
 /** An abstraction for directories.
  *
- *  @author  Paul Phillips
  *  @since   2.8
  *
  *  ''Note:  This is library is considered experimental and should not be used unless you know what you are doing.''

--- a/src/reflect/scala/reflect/io/File.scala
+++ b/src/reflect/scala/reflect/io/File.scala
@@ -42,7 +42,6 @@ object File {
  *  precedence if supplied.) If neither is available, the value
  *  of scala.io.Codec.default is used.
  *
- *  @author  Paul Phillips
  *  @since   2.8
  *
  *  ''Note:  This is library is considered experimental and should not be used unless you know what you are doing.''

--- a/src/reflect/scala/reflect/io/Path.scala
+++ b/src/reflect/scala/reflect/io/Path.scala
@@ -32,7 +32,6 @@ import scala.util.Random.alphanumeric
  *  Also available are createFile and createDirectory, which attempt
  *  to create the path in question.
  *
- *  @author  Paul Phillips
  *  @since   2.8
  *
  *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''

--- a/src/reflect/scala/reflect/io/Streamable.scala
+++ b/src/reflect/scala/reflect/io/Streamable.scala
@@ -24,7 +24,6 @@ import scala.annotation.tailrec
 
 /** Traits for objects which can be represented as Streams.
  *
- *  @author Paul Phillips
  *  @since  2.8
  *
  *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''

--- a/src/reflect/scala/reflect/io/VirtualDirectory.scala
+++ b/src/reflect/scala/reflect/io/VirtualDirectory.scala
@@ -19,8 +19,6 @@ import scala.collection.mutable
 /**
  * An in-memory directory.
  *
- * @author Lex Spoon
- *
  * ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
 class VirtualDirectory(val name: String, maybeContainer: Option[VirtualDirectory])

--- a/src/reflect/scala/reflect/io/VirtualFile.scala
+++ b/src/reflect/scala/reflect/io/VirtualFile.scala
@@ -18,7 +18,6 @@ import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, InputStream, Outpu
 
 /** This class implements an in-memory file.
  *
- *  @author  Philippe Altherr
  *  @version 1.0, 23/03/2004
  *
  *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''

--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -29,8 +29,6 @@ import scala.reflect.internal.JDK9Reflectors
  *  it is for performance: we come through here a lot on every run.  Be careful
  *  about changing it.
  *
- *  @author  Philippe Altherr (original version)
- *  @author  Paul Phillips (this one)
  *  @version 2.0,
  *
  *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -46,9 +46,6 @@ import scala.collection.JavaConverters._
   * There should be no direct dependency of this code on the compiler;
   * it should all go through the `intp` reference to the interpreter,
   * or maybe eventually even over the wire to a remote compiler.
-  *
-  * @author Moez A. Abdel-Gawad
-  * @author Lex Spoon
   */
 class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
             protected val out: PrintWriter = new PrintWriter(Console.out, true)) extends LoopCommands {

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -67,9 +67,6 @@ import scala.util.control.NonFatal
   *  behaves exactly as does compiled code, including running at full speed.
   *  The main weakness is that redefining classes and methods is not handled
   *  properly, because rebinding at the Java level is technically difficult.
-  *
-  *  @author Moez A. Abdel-Gawad
-  *  @author Lex Spoon
   */
 class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoader], compilerSettings: Settings, val reporter: ReplReporter)
   extends Repl with Imports with PresentationCompilation with Closeable {

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -338,7 +338,7 @@ trait EntityPage extends HtmlPage {
     val postamble =
       List(Div(id = "tooltip"),
            if (Set("epfl", "EPFL").contains(tpl.universe.settings.docfooter.value))
-             Div(id = "footer", elems = Txt("Scala programming documentation. Copyright (c) 2002-2019 ") :: A(href = "http://www.epfl.ch", target = "_top", elems = Txt("EPFL")) :: Txt(", with contributions from ") :: A(href = "http://www.lightbend.com", target = "_top", elems = Txt("Lightbend")) :: Txt("."))
+             Div(id = "footer", elems = Txt("Scala programming documentation. Copyright (c) 2002-2019 ") :: A(href = "http://www.epfl.ch", target = "_top", elems = Txt("EPFL")) :: Txt(" and ") :: A(href = "http://www.lightbend.com", target = "_top", elems = Txt("Lightbend")) :: Txt("."))
            else
              Div(id = "footer", elems = Txt(tpl.universe.settings.docfooter.value)))
 

--- a/test/instrumented/boxes.patch
+++ b/test/instrumented/boxes.patch
@@ -9,7 +9,7 @@
  package scala.runtime;
 
  import scala.math.ScalaNumber;
-@@ -47,37 +47,54 @@
+@@ -44,37 +44,54 @@
 
  /* BOXING ... BOXING ... BOXING ... BOXING ... BOXING ... BOXING ... BOXING ... BOXING */
 


### PR DESCRIPTION
I'm not pushing hard for this to be merged. I'm just suggesting it

why do it?
* the credits are bitrotted; most credits date back to very very early days; it's pretty random whether any given file has these credits at all, and if so, how much it still corresponds with any concept of "real" authorship
* authorship of the standard library is collective, code "ownership" is discouraged

and anyway, actual authorship information is available in the Git history.