### PR TITLE
[backport] Scaladoc: Add -doc-canonical-base-url to set a canonical URL

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -225,6 +225,13 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
     "Prevents parsing and inclusion of comments from java sources."
   )
 
+  val docCanonicalBaseUrl = StringSetting (
+    "-doc-canonical-base-url",
+    "url",
+    s"A base URL to use as prefix and add `canonical` URLs to all pages. The canonical URL may be used by search engines to choose the URL that you want people to see in search results. If unset no canonical URLs are generated.",
+    ""
+  )
+
   // For improved help output.
   def scaladocSpecific = Set[Settings#Setting](
     docformat, doctitle, docfooter, docversion, docUncompilable, docsourceurl, docgenerator, docRootContent, useStupidTypes,

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -48,6 +48,14 @@ trait EntityPage extends HtmlPage {
 
   def headers =
     <xml:group>
+      { val canonicalSetting = universe.settings.docCanonicalBaseUrl
+        if (canonicalSetting.isSetByUser) {
+          val canonicalUrl =
+          if (canonicalSetting.value.endsWith("/")) canonicalSetting.value
+            else canonicalSetting.value + "/"
+          <link href={ canonicalUrl + Page.relativeLinkTo(List("."), path) } rel="canonical"/>
+        } else NodeSeq.Empty
+      }
       <link href={ relativeLinkTo{List("index.css", "lib")} }  media="screen" type="text/css" rel="stylesheet"/>
       <link href={ relativeLinkTo{List("template.css", "lib")} } media="screen" type="text/css" rel="stylesheet"/>
       <link href={ relativeLinkTo{List("diagrams.css", "lib")} } media="screen" type="text/css" rel="stylesheet" id="diagrams-css" />

--- a/test/scaladoc/resources/canonical.scala
+++ b/test/scaladoc/resources/canonical.scala
@@ -1,0 +1,15 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package p
+
+class Canonical

--- a/test/scaladoc/run/canonical-unset.check
+++ b/test/scaladoc/run/canonical-unset.check
@@ -1,0 +1,2 @@
+As expected, no canonical URL found.
+Done.

--- a/test/scaladoc/run/canonical-unset.scala
+++ b/test/scaladoc/run/canonical-unset.scala
@@ -1,0 +1,43 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+import scala.tools.nsc.{ScalaDocReporter, doc, io}
+import scala.tools.nsc.doc.DocFactory
+import scala.tools.nsc.doc.model._
+import scala.tools.nsc.reporters.ConsoleReporter
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+
+  override def resourceFile: String = "test/scaladoc/resources/canonical.scala"
+
+  def destinationDir = "target/canonical-unset"
+
+  override def scaladocSettings =
+    s"-d ${destinationDir}"
+
+  override def code = ""
+
+  def testModel(rootPackage: Package): Unit = {
+    val dir = new java.io.File(destinationDir)
+    dir.mkdirs()
+    newDocFactory.document(List(resourceFile))
+    val Pattern = """<link href="([^"]*)" rel="canonical" />""".r
+    val s = io.File(s"${dir.getAbsolutePath}/p/Canonical.html").slurp()
+    Pattern.findFirstIn(s) match {
+      case Some(s) =>
+        println(s)
+      case _ =>
+        println("As expected, no canonical URL found.")
+    }
+  }
+}

--- a/test/scaladoc/run/canonical.check
+++ b/test/scaladoc/run/canonical.check
@@ -1,0 +1,2 @@
+<link href="https://www.scala-lang.org/files/archive/nightly/2.13.x/api/2.13.x/p/Canonical.html" rel="canonical" />
+Done.

--- a/test/scaladoc/run/canonical.scala
+++ b/test/scaladoc/run/canonical.scala
@@ -1,0 +1,44 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+import scala.tools.nsc.{ScalaDocReporter, doc, io}
+import scala.tools.nsc.doc.DocFactory
+import scala.tools.nsc.doc.model._
+import scala.tools.nsc.reporters.ConsoleReporter
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+
+  override def resourceFile: String = "test/scaladoc/resources/canonical.scala"
+
+  def destinationDir = "target/canonical"
+
+  override def scaladocSettings =
+    s"-doc-canonical-base-url https://www.scala-lang.org/files/archive/nightly/2.13.x/api/2.13.x/ -d $destinationDir"
+
+  override def code = ""
+
+  def testModel(rootPackage: Package): Unit = {
+    val dir = new java.io.File(destinationDir)
+    dir.mkdirs()
+    newDocFactory.document(List(resourceFile))
+    val Pattern = """<link href="([^"]*)" rel="canonical" />""".r
+    val s = io.File(s"${dir.getAbsolutePath}/p/Canonical.html").slurp()
+    Pattern.findFirstIn(s) match {
+      case Some(s) =>
+        println(s)
+      case _ =>
+        println("No canonical URL found.")
+        println(s.substring(0, Math.min(1000, s.length)))
+    }
+  }
+}


### PR DESCRIPTION
Backport of #7834 

Introduces a new command line flag for Scaladoc to configure a base URL for generation of canonical URLs on all pages.
Canonical URLs intend to help search engines to identify the most relevant/recent version of a page when several versions are available.

References
[Google Support: Consolidate duplicate URLs](https://support.google.com/webmasters/answer/139066?hl=en)
[Blog: Google’s Algorithms Can Ignore Rel Canonical When URLs Contain Different Content.](https://www.gsqi.com/marketing-blog/google-ignore-rel-canonical-different-content/)

Fixes https://github.com/scala/bug/issues/10640