### PR TITLE
correct jansi version in intellij setup

### DIFF
--- a/src/intellij/scala.ipr.SAMPLE
+++ b/src/intellij/scala.ipr.SAMPLE
@@ -363,7 +363,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/completion/jars/completion-0.13.18.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/collections/jars/collections-0.13.18.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.13.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.fusesource.jansi/jansi/jars/jansi-1.11.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.fusesource.jansi/jansi/jars/jansi-1.12.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/api/jars/api-0.13.18.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/classfile/jars/classfile-0.13.18.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/logging/jars/logging-0.13.18.jar!/" />


### PR DESCRIPTION
I'm not sure the jansi entry ought to be here at all,
since the jline 1.14.6 jar embeds it shaded, but all
the weird jline stuff in our build.sbt makes me unsure.

but anyway, I happened to notice that the version number was wrong, as
per https://github.com/jline/jline2/blob/jline-2.14.6/pom.xml#L122 ,
having it right can't be bad