### PR TITLE
Return correct array in ArrayOps.sorted.boxed

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -583,7 +583,6 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
       val a = Array.copyAs[AnyRef](xs, len)(ClassTag.AnyRef)
       Arrays.sort(a, ord.asInstanceOf[Ordering[AnyRef]])
       Array.copyAs[A](a, len)
-      a
     }
     if(len <= 1) xs.clone()
     else ((xs: Array[_]) match {

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -108,4 +108,10 @@ class ArrayOpsTest {
     val target = Array[Int]()
     assertEquals(0, Array(1,2).copyToArray(target, 1, 0))
   }
+
+  @Test
+  def t11499(): Unit = {
+    val a: Array[Byte] = new Array[Byte](1000).sortWith { _ < _ }
+    assertEquals(0, a(0))
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11499