### PR TITLE
Ignore two unchecked warnings.

### DIFF
--- a/src/library/scala/jdk/javaapi/FutureConverters.scala
+++ b/src/library/scala/jdk/javaapi/FutureConverters.scala
@@ -47,7 +47,8 @@ object FutureConverters {
   def toJava[T](f: Future[T]): CompletionStage[T] = {
     f match {
       case p: P[T] => p.wrapped
-      case c: CompletionStage[T] => c
+      // in theory not safe (could be `class C extends Future[A] with CompletionStage[B]`):
+      case c: CompletionStage[T @unchecked] => c
       case _ =>
         val cf = new CF[T](f)
         f.onComplete(cf)(ExecutionContext.parasitic)
@@ -67,7 +68,8 @@ object FutureConverters {
   def toScala[T](cs: CompletionStage[T]): Future[T] = {
     cs match {
       case cf: CF[T] => cf.wrapped
-      case f: Future[T] => f
+      // in theory not safe (could be `class C extends Future[A] with CompletionStage[B]`):
+      case f: Future[T @unchecked] => f
       case _ =>
         val p = new P[T](cs)
         cs whenComplete p


### PR DESCRIPTION
The warnings are actually legitimate. Since `Future[T]` and `CompletionStage[T]` are unrelated, we could have a subclass

    class C extends Future[A] with CompletionStage[B]

which would expose the unsoundness that the compiler warns about. However, I assume that this was a known theoretical issue, and this commit ignores the warning.

Those two cases were added in https://github.com/scala/scala/commit/65be78d9c8b7c8f95cc565d2b32c5fc9cc98de19.