### PR TITLE
Allow negative initial size in ArrayBuffer

### DIFF
--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -48,7 +48,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   def this() = this(new Array[AnyRef](ArrayBuffer.DefaultInitialSize), 0)
 
-  def this(initialSize: Int) = this(new Array[AnyRef](initialSize), 0)
+  def this(initialSize: Int) = this(new Array[AnyRef](initialSize max 1), 0)
 
   protected[collection] var array: Array[AnyRef] = initialElements
   protected var size0 = initialSize

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -368,4 +368,7 @@ class ArrayBufferTest {
     b.trimToSize()
     assertEquals(256, b.array.length)
   }
+
+  @Test def t11482_allowNegativeInitialSize: Unit =
+    new ArrayBuffer(-1)
 }


### PR DESCRIPTION
Is it better than throwing an exception? I’m unconvinced. But at least
it’s compatible with 2.12.

Fixes https://github.com/scala/bug/issues/11482