### PR TITLE
Deprecate scala.collection.mutable.MultiMap

### DIFF
--- a/src/library/scala/collection/mutable/MultiMap.scala
+++ b/src/library/scala/collection/mutable/MultiMap.scala
@@ -51,6 +51,7 @@ package scala.collection.mutable
   *  @define Coll `MultiMap`
   *  @since   1
   */
+@deprecated("Use a scala.collection.mutable.MultiDict in the scala-collection-contrib module", "2.13.0")
 trait MultiMap[K, V] extends Map[K, Set[V]] {
   /** Creates a new set.
     *

--- a/test/files/run/t2857.check
+++ b/test/files/run/t2857.check
@@ -1,2 +1,2 @@
-warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details
+warning: there were two deprecation warnings (since 2.13.0); re-run with -deprecation for details
 false


### PR DESCRIPTION
In the new Scala-Collection-Contrib module, there exists all three of:

* `scala.collection.MultiDict`
* `scala.collection.immutable.MultiDict`
* `scala.collection.mutable.MultiDict`

They probably even would have been called `MultiMap`, except that that would cause a name collision with the existing `mutable.MultiMap` in the standard library. 

And so, there is no longer a need for the singular `mutable.MultiMap` implementation in the core library. 

I'd actually prefer that these two data structures (`MultiMap`/`MultiDict` and `MultiSet`/`Bag`) would be included in core, since they are extremely useful to every day programming. Maybe that can be considered for a future release, but in the meantime we should probably avoid duplicating `MultiMap` here and there. 

Fixes https://github.com/scala/bug/issues/11504

For additional context: https://github.com/scala/scala-collection-contrib/issues/17