### PR TITLE
Optimize TypeMaps used for TypeVar.unrelatable & isRelatable

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3686,8 +3686,9 @@ trait Types
       registerBound(HasTypeMember(sym.name.toTypeName, tp), isLowerBound = false)
     }
 
-    private def unrelatable(tp: Type): List[TypeSkolem] = tp.collect {
-      case TypeRef(_, ts: TypeSkolem, _) if ts.level > level => ts
+    private def unrelatable(tp: Type): List[TypeSkolem] = {
+      UnrelatableCollector.barLevel = level
+      UnrelatableCollector.collect(tp)
     }
 
 
@@ -3695,10 +3696,10 @@ trait Types
       *  This is not the case if `tp` contains type skolems whose
       *  skolemization level is higher than the level of this variable.
       */
-    def isRelatable(tp: Type) = tp.find {
-      case TypeRef(_, ts: TypeSkolem, _) => ts.level > level
-      case _ => false
-    }.isEmpty
+    def isRelatable(tp: Type): Boolean = {
+      IsRelatableCollector.barLevel = level
+      IsRelatableCollector.collect(tp)
+    }
 
     override def normalize: Type = (
       if (instValid) inst

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -201,6 +201,8 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.typeVarToOriginMap
     this.ErroneousCollector
     this.adaptToNewRunMap
+    this.UnrelatableCollector
+    this.IsRelatableCollector
     this.SubTypePair
     this.SymbolKind
     this.NoSymbol


### PR DESCRIPTION
Also optimize `CollectTypeCollector` to use `ListBuffer` instead of `List.reverse`.

Split out of #7985 