### PR TITLE
Add lower type bound to AsComparable

### DIFF
--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -202,7 +202,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
 
 trait LowPriorityOrderingImplicits {
 
-  type AsComparable[A] = A => Comparable[A]
+  type AsComparable[A] = A => Comparable[_ >: A]
 
   /** This would conflict with all the nice implicit Orderings
    *  available, but thanks to the magic of prioritized implicits

--- a/test/junit/scala/math/OrderingTest.scala
+++ b/test/junit/scala/math/OrderingTest.scala
@@ -267,4 +267,14 @@ class OrderingTest {
     check(Ordering[Seq[Int]])
     check(Ordering[SortedSet[Int]])
   }
+
+  /* Test for scala/bug#11284 */
+  @Test
+  def supertypeOrdering(): Unit = {
+    val before = java.time.LocalDate.of(2004, 1, 20)
+    val now = java.time.LocalDate.now()
+    val later = java.time.LocalDate.now().plusWeeks(1)
+
+    assertEquals(Seq(before, now, later), Seq(now, later, before).sorted)
+  }
 }


### PR DESCRIPTION
Now every type which is comparable to itself or to a supertype of itself should have an Ordering.

closes https://github.com/scala/bug/issues/11284