### PR TITLE
[SUPERSEDED] Synthetic hashCode is applied

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -238,7 +238,7 @@ trait SyntheticMethods extends ast.TreeDSL {
      * def hashCode(): Int = this.underlying.hashCode
      */
     def hashCodeDerivedValueClassMethod: Tree = createMethod(nme.hashCode_, Nil, IntTpe) { m =>
-      Select(mkThisSelect(clazz.derivedValueClassUnbox), nme.hashCode_)
+      Apply(Select(mkThisSelect(clazz.derivedValueClassUnbox), nme.hashCode_), Nil)
     }
 
     /* The _1, _2, etc. methods to implement ProductN, disabled

--- a/test/files/pos/synthetic.scala
+++ b/test/files/pos/synthetic.scala
@@ -1,0 +1,5 @@
+// scalac: -deprecation -Xsource:2.14 -Werror
+//
+// Ensure synthetic hashCode compiles cleanly.
+
+case class C(c: Int) extends AnyVal


### PR DESCRIPTION
Previously, parens were inferred, but this emits
a warning under -Xsource:2.14.