### PR TITLE
Use the correct Ordering in SortedSet#{min,max}

### DIFF
--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -75,13 +75,13 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
     if (isEmpty) throw new UnsupportedOperationException("empty.min")
     else if (ord == ordering) head
     else if (ord isReverseOf ordering) last
-    else super.min
+    else super.min[B] // need the type annotation for it to infer the correct implicit
 
   override def max[B >: A](implicit ord: Ordering[B]): A =
     if (isEmpty) throw new UnsupportedOperationException("empty.max")
     else if (ord == ordering) last
     else if (ord isReverseOf ordering) head
-    else super.max
+    else super.max[B] // need the type annotation for it to infer the correct implicit
 
   def rangeTo(to: A): C = {
     val i = rangeFrom(to).iterator

--- a/test/junit/scala/collection/SortedSetTest.scala
+++ b/test/junit/scala/collection/SortedSetTest.scala
@@ -58,7 +58,9 @@ class SortedSetTest {
 
   @Test
   def min_max_differentOrdering(): Unit = {
-    val set = SortedSet(1, 2, 3)(Ordering[Int].reverse)
+    implicit val forward: Ordering[Int] = (x, y) => Ordering.Int.compare(x, y)
+
+    val set = SortedSet(1, 2, 3)(Ordering.Int.reverse)
     assertEquals(1, set.min)
     assertEquals(3, set.max)
     assertEquals(3, set.min(set.ordering))

--- a/test/junit/scala/collection/SortedSetTest.scala
+++ b/test/junit/scala/collection/SortedSetTest.scala
@@ -55,6 +55,15 @@ class SortedSetTest {
       assert(count > 10)
     }
   }
+
+  @Test
+  def min_max_differentOrdering(): Unit = {
+    val set = SortedSet(1, 2, 3)(Ordering[Int].reverse)
+    assertEquals(1, set.min)
+    assertEquals(3, set.max)
+    assertEquals(3, set.min(set.ordering))
+    assertEquals(1, set.max(set.ordering))
+  }
 }
 
 private object SortedSetTest {


### PR DESCRIPTION
Fixes scala/bug#11507