### PR TITLE
Make SortedSetOps#ordering not implicit

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -951,9 +951,9 @@ trait SortedSetFactoryDefaults[+A,
     +WithFilterCC[x] <: IterableOps[x, WithFilterCC, WithFilterCC[x]] with Set[x]] extends SortedSetOps[A @uncheckedVariance, CC, CC[A @uncheckedVariance]] {
   self: IterableOps[A, WithFilterCC, _] =>
 
-  override protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]): CC[A @uncheckedVariance]    = sortedIterableFactory.from(coll)
-  override protected def newSpecificBuilder: mutable.Builder[A @uncheckedVariance, CC[A @uncheckedVariance]] = sortedIterableFactory.newBuilder[A]
-  override def empty: CC[A @uncheckedVariance] = sortedIterableFactory.empty
+  override protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]): CC[A @uncheckedVariance]    = sortedIterableFactory.from(coll)(ordering)
+  override protected def newSpecificBuilder: mutable.Builder[A @uncheckedVariance, CC[A @uncheckedVariance]] = sortedIterableFactory.newBuilder[A](ordering)
+  override def empty: CC[A @uncheckedVariance] = sortedIterableFactory.empty(ordering)
 
   override def withFilter(p: A => Boolean): SortedSetOps.WithFilter[A, WithFilterCC, CC] =
     new SortedSetOps.WithFilter[A, WithFilterCC, CC](this, p)
@@ -1001,9 +1001,9 @@ trait SortedMapFactoryDefaults[K, +V,
     +UnsortedCC[x, y] <: Map[x, y]] extends SortedMapOps[K, V, CC, CC[K, V @uncheckedVariance]] with MapOps[K, V, UnsortedCC, CC[K, V @uncheckedVariance]] {
   self: IterableOps[(K, V), WithFilterCC, _] =>
 
-  override def empty: CC[K, V @uncheckedVariance] = sortedMapFactory.empty
-  override protected def fromSpecific(coll: IterableOnce[(K, V @uncheckedVariance)]): CC[K, V @uncheckedVariance] = sortedMapFactory.from(coll)
-  override protected def newSpecificBuilder: mutable.Builder[(K, V @uncheckedVariance), CC[K, V @uncheckedVariance]] = sortedMapFactory.newBuilder[K, V]
+  override def empty: CC[K, V @uncheckedVariance] = sortedMapFactory.empty(ordering)
+  override protected def fromSpecific(coll: IterableOnce[(K, V @uncheckedVariance)]): CC[K, V @uncheckedVariance] = sortedMapFactory.from(coll)(ordering)
+  override protected def newSpecificBuilder: mutable.Builder[(K, V @uncheckedVariance), CC[K, V @uncheckedVariance]] = sortedMapFactory.newBuilder[K, V](ordering)
 
   override def withFilter(p: ((K, V)) => Boolean): collection.SortedMapOps.WithFilter[K, V, WithFilterCC, UnsortedCC, CC] =
     new collection.SortedMapOps.WithFilter[K, V, WithFilterCC, UnsortedCC, CC](this, p)

--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -162,16 +162,16 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
   override def concat[V2 >: V](suffix: IterableOnce[(K, V2)]): CC[K, V2] = sortedMapFactory.from(suffix match {
     case it: Iterable[(K, V2)] => new View.Concat(toIterable, it)
     case _ => iterator.concat(suffix.iterator)
-  })
+  })(ordering)
 
   /** Alias for `concat` */
   @`inline` override final def ++ [V2 >: V](xs: IterableOnce[(K, V2)]): CC[K, V2] = concat(xs)
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
-  override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = sortedMapFactory.from(new View.Appended(toIterable, kv))
+  override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = sortedMapFactory.from(new View.Appended(toIterable, kv))(ordering)
 
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
-  override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = sortedMapFactory.from(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
+  override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = sortedMapFactory.from(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))(ordering)
 
   // TODO Also override mapValues
 }

--- a/src/library/scala/collection/SortedOps.scala
+++ b/src/library/scala/collection/SortedOps.scala
@@ -16,7 +16,7 @@ package scala.collection
 /** Base trait for sorted collections */
 trait SortedOps[A, +C] {
 
-  implicit def ordering: Ordering[A]
+  def ordering: Ordering[A]
 
   /** Returns the first key of the collection. */
   def firstKey: A

--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -75,13 +75,13 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
     if (isEmpty) throw new UnsupportedOperationException("empty.min")
     else if (ord == ordering) head
     else if (ord isReverseOf ordering) last
-    else super.min
+    else super.min[B] // need the type annotation for it to infer the correct implicit
 
   override def max[B >: A](implicit ord: Ordering[B]): A =
     if (isEmpty) throw new UnsupportedOperationException("empty.max")
     else if (ord == ordering) last
     else if (ord isReverseOf ordering) head
-    else super.max
+    else super.max[B] // need the type annotation for it to infer the correct implicit
 
   def rangeTo(to: A): C = {
     val i = rangeFrom(to).iterator

--- a/src/library/scala/collection/StrictOptimizedSortedMapOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSortedMapOps.scala
@@ -33,7 +33,7 @@ trait StrictOptimizedSortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOp
     strictOptimizedFlatMap(sortedMapFactory.newBuilder, f)
 
   override def concat[V2 >: V](xs: IterableOnce[(K, V2)]): CC[K, V2] =
-    strictOptimizedConcat(xs, sortedMapFactory.newBuilder)
+    strictOptimizedConcat(xs, sortedMapFactory.newBuilder(ordering))
 
   override def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
     strictOptimizedCollect(sortedMapFactory.newBuilder, pf)

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -117,7 +117,7 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _]
       case (_, Some(v)) => this.updated(key, v)
     }
   }
-  override def transform[W](f: (K, V) => W): CC[K, W] = map({ case (k, v) => (k, f(k, v)) })
+  override def transform[W](f: (K, V) => W): CC[K, W] = map({ case (k, v) => (k, f(k, v)) })(ordering)
 }
 
 trait StrictOptimizedSortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]

--- a/test/junit/scala/collection/SortedSetTest.scala
+++ b/test/junit/scala/collection/SortedSetTest.scala
@@ -55,6 +55,17 @@ class SortedSetTest {
       assert(count > 10)
     }
   }
+
+  @Test
+  def min_max_differentOrdering(): Unit = {
+    implicit val forward: Ordering[Int] = (x, y) => Ordering.Int.compare(x, y)
+
+    val set = SortedSet(1, 2, 3)(Ordering.Int.reverse)
+    assertEquals(1, set.min)
+    assertEquals(3, set.max)
+    assertEquals(3, set.min(set.ordering))
+    assertEquals(1, set.max(set.ordering))
+  }
 }
 
 private object SortedSetTest {


### PR DESCRIPTION
On top of (and including) https://github.com/scala/scala/pull/8011 as a more comprehensive solution to https://github.com/scala/bug/issues/11507