### PR TITLE
Check template stats for wildcards.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -3183,10 +3183,10 @@ self =>
      *  }}}
      * @param isPre specifies whether in early initializer (true) or not (false)
      */
-    def templateStatSeq(isPre : Boolean): (ValDef, List[Tree]) = checkNoEscapingPlaceholders {
+    def templateStatSeq(isPre : Boolean): (ValDef, List[Tree]) = {
       var self: ValDef = noSelfType
       var firstOpt: Option[Tree] = None
-      if (isExprIntro) {
+      if (isExprIntro) checkNoEscapingPlaceholders {
         in.flushDoc
         val first = expr(InTemplate) // @S: first statement is potentially converted so cannot be stubbed.
         if (in.token == ARROW) {
@@ -3219,7 +3219,7 @@ self =>
      *                     |
      *  }}}
      */
-    def templateStats(): List[Tree] = statSeq(templateStat)
+    def templateStats(): List[Tree] = checkNoEscapingPlaceholders { statSeq(templateStat) }
     def templateStat: PartialFunction[Token, List[Tree]] = {
       case IMPORT =>
         in.flushDoc

--- a/test/files/run/t11064.check
+++ b/test/files/run/t11064.check
@@ -1,0 +1,16 @@
+
+scala> // should say "unbound wildcard type" not "not found: type _$1"
+
+scala>  type T = _
+                 ^
+       error: unbound wildcard type
+
+scala>  class C extends _
+                        ^
+       error: unbound wildcard type
+
+scala>  trait F[x <: _]
+                     ^
+       error: unbound wildcard type
+
+scala> :quit

--- a/test/files/run/t11064.scala
+++ b/test/files/run/t11064.scala
@@ -1,0 +1,9 @@
+object Test extends tools.partest.ReplTest {
+  override def code =
+    """
+    | // should say "unbound wildcard type" not "not found: type _$1"
+    | type T = _
+    | class C extends _
+    | trait F[x <: _]
+    """.stripMargin
+}


### PR DESCRIPTION
Not just if they're in a seq thereof.

2.13 repl passes lines directly to `templateStats`; wrapper comes later.

Fixes scala/bug#11064.