### PR TITLE
fix XSS vulnerability in scaladoc search by escaping the input parameter

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -532,6 +532,7 @@ function searchAll() {
     scheduler.clear("search"); // clear previous search
     maxJobs = 1; // clear previous max
     var searchStr = $("#textfilter input").attr("value").trim() || '';
+    searchStr = escape(searchStr);
 
     if (searchStr === '') {
         $("div#search-results").hide();

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -532,7 +532,6 @@ function searchAll() {
     scheduler.clear("search"); // clear previous search
     maxJobs = 1; // clear previous max
     var searchStr = $("#textfilter input").attr("value").trim() || '';
-    searchStr = escape(searchStr);
 
     if (searchStr === '') {
         $("div#search-results").hide();
@@ -563,9 +562,12 @@ function searchAll() {
     entityResults.appendChild(entityH1);
 
     $("div#results-content")
-        .prepend("<span class='search-text'>"
-                +"  Showing results for <span class='query-str'>\"" + searchStr + "\"</span>"
-                +"</span>");
+      .prepend(
+          $("<span>")
+              .addClass("search-text")
+              .append(document.createTextNode("  Showing results for "))
+              .append($("<span>").addClass("query-str").text(searchStr))
+      );
 
     var regExp = compilePattern(searchStr);
 

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -561,13 +561,12 @@ function searchAll() {
     entityH1.innerHTML = "Entity results";
     entityResults.appendChild(entityH1);
 
-    $("div#results-content")
-      .prepend(
-          $("<span>")
-              .addClass("search-text")
-              .append(document.createTextNode("  Showing results for "))
-              .append($("<span>").addClass("query-str").text(searchStr))
-      );
+    $("div#results-content").prepend(
+        $("<span>")
+            .addClass("search-text")
+            .append(document.createTextNode("  Showing results for "))
+            .append($("<span>").addClass("query-str").text(searchStr))
+    );
 
     var regExp = compilePattern(searchStr);
 


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11513

To trigger the XSS vulnerability, simply paste this into the search bar, e.g. on https://www.scala-lang.org/api/2.12.8/:
```
"\><img/src='1'onerror=alert(777111)>{{7*7}}
```

All credit for finding the vulnerability goes to Yeasir Arafat:
skylinearafat@gmail.com
https://www.facebook.com/skylinearafat.arafat

n.b. I've targeted 2.12.x because according to https://github.com/scala/scala/blob/2.13.x/CONTRIBUTING.md this will be merged into 2.13.x 'in time'. 