### PR TITLE
Improve parsing of numeric separator and error messages

### DIFF
--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -347,10 +347,8 @@ Literal  ::=  [‘-’] integerLiteral
 ```ebnf
 integerLiteral  ::=  (decimalNumeral | hexNumeral)
                        [‘L’ | ‘l’]
-decimalNumeral  ::=  ‘0’ | nonZeroDigit {digit}
+decimalNumeral  ::=  digit {digit}
 hexNumeral      ::=  ‘0’ (‘x’ | ‘X’) hexDigit {hexDigit}
-digit           ::=  ‘0’ | nonZeroDigit
-nonZeroDigit    ::=  ‘1’ | … | ‘9’
 ```
 
 Values of type `Int` are all integer

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -44,10 +44,8 @@ id               ::=  plainid
 idrest           ::=  {letter | digit} [‘_’ op]
 
 integerLiteral   ::=  (decimalNumeral | hexNumeral) [‘L’ | ‘l’]
-decimalNumeral   ::=  ‘0’ | nonZeroDigit {digit}
+decimalNumeral   ::=  digit {digit}
 hexNumeral       ::=  ‘0’ (‘x’ | ‘X’) hexDigit {hexDigit}
-digit            ::=  ‘0’ | nonZeroDigit
-nonZeroDigit     ::=  ‘1’ | … | ‘9’
 
 floatingPointLiteral
                  ::=  digit {digit} ‘.’ digit {digit} [exponentPart] [floatType]

--- a/test/files/neg/literals.check
+++ b/test/files/neg/literals.check
@@ -1,4 +1,4 @@
-literals.scala:4: error: missing integer number
+literals.scala:4: error: invalid literal number
   def missingHex: Int    = { 0x }        // line 4: was: not reported, taken as zero
                              ^
 literals.scala:6: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
@@ -13,7 +13,7 @@ literals.scala:10: warning: Decimal integer literals should not have a leading z
 literals.scala:14: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
   def zeroOfNineDot: Int = { 09. }       // line 14: malformed integer, ident expected
                              ^
-literals.scala:22: error: missing integer number
+literals.scala:22: error: invalid literal number
   def missingHex: Int    = 0x            // line 22: was: not reported, taken as zero
                            ^
 literals.scala:26: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)

--- a/test/files/neg/t6124.check
+++ b/test/files/neg/t6124.check
@@ -1,28 +1,49 @@
-t6124.scala:3: error: trailing separator is not allowed
+t6124.scala:3: error: illegal separator
   def i: Int = 123_456_
                       ^
-t6124.scala:4: error: trailing separator is not allowed
+t6124.scala:4: error: illegal separator
   def j: Long = 123_456_L * 1000
                        ^
-t6124.scala:7: error: trailing separator is not allowed
+t6124.scala:7: error: illegal separator
   def f = 3_14_E-2
               ^
-t6124.scala:8: error: Invalid literal number
+t6124.scala:8: error: illegal separator
   def e = 3_14E-_2
-          ^
-t6124.scala:9: error: trailing separator is not allowed
+                ^
+t6124.scala:9: error: illegal separator
   def d = 3_14E-2_
                  ^
-t6124.scala:11: error: trailing separator is not allowed
+t6124.scala:11: error: illegal separator
   def p = 3.1_4_
                ^
-t6124.scala:12: error: trailing separator is not allowed
+t6124.scala:12: error: illegal separator
   def q = 3.1_4_d
                ^
-t6124.scala:13: error: trailing separator is not allowed
+t6124.scala:13: error: illegal separator
   def r = 3.1_4_dd
                ^
-t6124.scala:13: error: Invalid literal number
+t6124.scala:13: error: invalid literal number
   def r = 3.1_4_dd
           ^
-9 errors
+t6124.scala:14: error: illegal separator
+  def s = 3_.14
+           ^
+t6124.scala:18: error: illegal separator
+  def v = 0_x42
+           ^
+t6124.scala:18: error: invalid literal number
+  def v = 0_x42
+          ^
+t6124.scala:22: error: illegal separator
+  def x = 00_
+            ^
+t6124.scala:23: error: illegal separator
+  def y = 0_
+           ^
+t6124.scala:26: error: invalid literal number
+  def wtf = 0x    // see neg/literals.scala
+            ^
+t6124.scala:30: error: illegal separator
+  def `caret positions` = 0x___________
+                                      ^
+16 errors

--- a/test/files/neg/t6124.scala
+++ b/test/files/neg/t6124.scala
@@ -11,6 +11,22 @@ trait T {
   def p = 3.1_4_
   def q = 3.1_4_d
   def r = 3.1_4_dd
+  def s = 3_.14
+  def t = 3._14   // member selection
 
+  def u = 0x_42
+  def v = 0_x42
+
+  def `was: error: malformed double precision floating point number` = 0_1.1
+  def w = 0_1
+  def x = 00_
+  def y = 0_
   def z = 0
+
+  def wtf = 0x    // see neg/literals.scala
+}
+
+trait SyntaxInRecovery {
+  def `caret positions` = 0x___________
+  def `minimal cascade` = 0x_42 + 1
 }

--- a/test/files/neg/t877.check
+++ b/test/files/neg/t877.check
@@ -1,4 +1,4 @@
-t877.scala:3: error: Invalid literal number
+t877.scala:3: error: invalid literal number
 trait Foo extends A(22A, Bug!) {}
                     ^
 t877.scala:3: error: ')' expected but eof found.


### PR DESCRIPTION
Unlike Java and Dotty, Scala is OK with `0x_42` or `0b_1010` (coming soon).

In error messages, adjust caret position for leading zero.

Arguably, `0x_42` is easier to read than `0x42`.

Java is inconsistent in that underscore is allowed after octal prefix:
```
jshell> 0755
$1 ==> 493

jshell> 0_755
$2 ==> 493

jshell> 0x_42
|  Error:
|  illegal underscore
|  0x_42
|    ^
```