### PR TITLE
Cleanups around caching of classpath/classloaders

### DIFF
--- a/test/junit/scala/tools/nsc/GlobalCustomizeClassloaderTest.scala
+++ b/test/junit/scala/tools/nsc/GlobalCustomizeClassloaderTest.scala
@@ -17,7 +17,6 @@ class GlobalCustomizeClassloaderTest {
   // that properly closes them before one of the elements needs to be overwritten.
   @Test def test(): Unit = {
     val g = new Global(new Settings) {
-      override protected[scala] def findMacroClassLoader(): ClassLoader = getClass.getClassLoader
       override protected def findPluginClassLoader(classpath: Seq[Path]): ClassLoader = {
         val d = new VirtualDirectory("", None)
         val xml = d.fileNamed("scalac-plugin.xml")


### PR DESCRIPTION
Improve timer-based eviction of classloader caches

Cancel in-progress timer task on a cache hit. This avoids reducing the
effective deferred close delay when the old timer task fires and sees a ref
count of zero, even though the ref count has since been positive.

Remove unused, duplicated copy of findMacroClassLoader