### PR TITLE
OverloadedArgProto's toWild also nukes undets

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3518,7 +3518,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
               mapWithIndex(args) { (arg, argIdx) =>
                 def typedArg0(tree: Tree, argIdxOrName: Either[Int, Name] = Left(argIdx)) = {
-                  typedArg(tree, amode, BYVALmode, OverloadedArgProto(argIdxOrName, pre, alts))
+                  typedArg(tree, amode, BYVALmode, OverloadedArgProto(argIdxOrName, pre, alts)(undetparams))
                 }
 
                 arg match {

--- a/test/files/pos/t11511.scala
+++ b/test/files/pos/t11511.scala
@@ -1,0 +1,12 @@
+object ORSet {
+  def empty[A]: ORSet[A] = ???
+}
+
+final class ORSet[A] {
+  def add(node: Long, element: A): ORSet[A] = ???
+  def add(node: Int, element: A): ORSet[A] = ???
+}
+
+class Test {
+  ORSet.empty.add(42, "A")
+}


### PR DESCRIPTION
Fix scala/bug#11511