### PR TITLE
Remove deprecated fields from compiler

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilationUnits.scala
+++ b/src/compiler/scala/tools/nsc/CompilationUnits.scala
@@ -149,9 +149,6 @@ trait CompilationUnits { global: Global =>
     @deprecated("Call global.currentRun.reporting.uncheckedWarning directly instead.", "2.11.2")
     final def uncheckedWarning(pos: Position, msg: String): Unit   = currentRun.reporting.uncheckedWarning(pos, msg)
 
-    @deprecated("This method will be removed. It does nothing.", "2.11.2")
-    final def comment(pos: Position, msg: String): Unit = {}
-
     /** Is this about a .java source file? */
     val isJava = source.file.name.endsWith(".java")
 

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -314,8 +314,6 @@ class Global(var currentSettings: Settings, reporter0: LegacyReporter)
       log(msg)
   }
 
-  @deprecated("Renamed to reportThrowable", "2.10.1")
-  def logThrowable(t: Throwable): Unit = reportThrowable(t)
   def reportThrowable(t: Throwable): Unit = globalError(throwableAsString(t))
   override def throwableAsString(t: Throwable) = util.stackTraceString(t)
 

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -57,14 +57,6 @@ trait Implicits {
   def inferImplicitByTypeSilent(pt: Type, context: Context, pos: Position = NoPosition): SearchResult =
     inferImplicit(EmptyTree, pt, reportAmbiguous = false, isView = false, context, saveAmbiguousDivergent = false, pos)
 
-  @deprecated("Unused in scalac", "2.12.0-M4")
-  def inferImplicit(tree: Tree, pt: Type, reportAmbiguous: Boolean, isView: Boolean, context: Context): SearchResult =
-    inferImplicit(tree, pt, reportAmbiguous, isView, context, saveAmbiguousDivergent = true, tree.pos)
-
-  @deprecated("Unused in scalac", "2.12.0-M4")
-  def inferImplicit(tree: Tree, pt: Type, reportAmbiguous: Boolean, isView: Boolean, context: Context, saveAmbiguousDivergent: Boolean): SearchResult =
-    inferImplicit(tree, pt, reportAmbiguous, isView, context, saveAmbiguousDivergent, tree.pos)
-
   /** Search for an implicit value. Consider using one of the convenience methods above. This one has many boolean levers.
    *
    * See the comment on `result` at the end of class `ImplicitSearch` for more info how the search is conducted.


### PR DESCRIPTION
These seemed like low risk things to trim. I am not an expert.