### PR TITLE
Replace `tail.nonEmpty` with `sizeIs > 1` as sources might be `Nil`

### DIFF
--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -437,7 +437,7 @@ class Runner(val testInfo: TestInfo, val suiteRunner: AbstractRunner) {
 
   /** Grouped files in group order, and lex order within each group. */
   def groupedFiles(sources: List[File]): List[List[File]] = (
-    if (sources.tail.nonEmpty) {
+    if (sources.sizeIs > 1) {
       val grouped = sources groupBy (_.group)
       grouped.keys.toList.sorted map (k => grouped(k) sortBy (_.getName))
     }


### PR DESCRIPTION
fixes https://github.com/scala/bug/issues/8000