### PR TITLE
Preemptively override s.c.i.HashMap#updatedWith 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,6 +119,7 @@ val mimaPrereleaseHandlingSettings = Seq(
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.mutable.BitSet.fromSpecific"),
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.mutable.BitSet.empty"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.util.PropertiesTrait.versionFor"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.immutable.HashMap.updatedWith"),
   ),
 )
 

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -152,6 +152,10 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     newHashMapOrThis(rootNode.updated(key, value, keyUnimprovedHash, improve(keyUnimprovedHash), 0, replaceValue = true))
   }
 
+  // preemptively overridden in anticipation of performance optimizations
+  override def updatedWith[V1 >: V](key: K)(remappingFunction: Option[V] => Option[V1]): HashMap[K, V1] =
+    super.updatedWith[V1](key)(remappingFunction)
+
   def removed(key: K): HashMap[K, V] = {
     val keyUnimprovedHash = key.##
     newHashMapOrThis(rootNode.removed(key, keyUnimprovedHash, improve(keyUnimprovedHash), 0))


### PR DESCRIPTION
This is in anticipation of future performance optimizations which will target 2.13.1, which currently can be found [here](https://github.com/scala/scala/pull/8032)