### PR TITLE
Make Option extend IterableOnce

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,6 +122,17 @@ val mimaPrereleaseHandlingSettings = Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.util.Properties.versionFor"),
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.immutable.HashMap.updatedWith"),
     ProblemFilters.exclude[FinalClassProblem]("scala.collection.StringView"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.None$"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.Option"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.Some"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Option.knownSize"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Option.stepper"),
+    ProblemFilters.exclude[FinalMethodProblem]("scala.Option.isEmpty"),
+    ProblemFilters.exclude[FinalMethodProblem]("scala.Option.isDefined"),
+    ProblemFilters.exclude[FinalMethodProblem]("scala.Option.isEmpty"),
+    ProblemFilters.exclude[FinalMethodProblem]("scala.Option.isEmpty"),
+    ProblemFilters.exclude[DirectAbstractMethodProblem]("scala.Option.isEmpty"),
+    ProblemFilters.exclude[ReversedAbstractMethodProblem]("scala.Option.isEmpty"),
   ),
 )
 

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -143,7 +143,7 @@ object Option {
  *  @define undefinedorder
  */
 @SerialVersionUID(-114498752079829388L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
-sealed abstract class Option[+A] extends Product with Serializable {
+sealed abstract class Option[+A] extends IterableOnce[A] with Product with Serializable {
   self =>
 
   /** Returns true if the option is $none, false otherwise.
@@ -156,7 +156,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
    * }
    * }}}
    */
-  def isEmpty: Boolean
+  final def isEmpty: Boolean = this eq None
 
   /** Returns true if the option is an instance of $some, false otherwise.
    *
@@ -168,7 +168,9 @@ sealed abstract class Option[+A] extends Product with Serializable {
    * }
    * }}}
    */
-  def isDefined: Boolean = !isEmpty
+  final def isDefined: Boolean = !isEmpty
+
+  final def knownSize: Int = if (isEmpty) 0 else 1
 
   /** Returns the option's value.
    *
@@ -344,7 +346,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
    * }}}
    *  @note   Implemented here to avoid the implicit conversion to Iterable.
    */
-  final def nonEmpty = isDefined
+  final def nonEmpty: Boolean = isDefined
 
   /** Necessary to keep $option from being implicitly converted to
    *  [[scala.collection.Iterable]] in `for` comprehensions.
@@ -618,8 +620,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
  */
 @SerialVersionUID(1234815782226070388L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
 final case class Some[+A](value: A) extends Option[A] {
-  def isEmpty = false
-  def get = value
+  def get: A = value
 }
 
 
@@ -629,6 +630,5 @@ final case class Some[+A](value: A) extends Option[A] {
  */
 @SerialVersionUID(5066590221178148012L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
 case object None extends Option[Nothing] {
-  def isEmpty = true
-  def get = throw new NoSuchElementException("None.get")
+  def get: Nothing = throw new NoSuchElementException("None.get")
 }

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -18,6 +18,7 @@ object Option {
 
   /** An implicit conversion that converts an option to an iterable value
    */
+  @deprecated("use `option.toList` or `option.iterator` instead", "2.13.0")
   implicit def option2Iterable[A](xo: Option[A]): Iterable[A] =
     if (xo.isEmpty) Iterable.empty else Iterable.single(xo.get)
 

--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -999,7 +999,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     *  @param asIterable A function that converts elements of this array to rows - Iterables of type `B`.
     *  @return           An array obtained by concatenating rows of this array.
     */
-  def flatten[B](implicit asIterable: A => scala.collection.Iterable[B], m: ClassTag[B]): Array[B] = {
+  def flatten[B](implicit asIterable: A => IterableOnce[B], m: ClassTag[B]): Array[B] = {
     val b = ArrayBuilder.make[B]
     val len = xs.length
     var size = 0

--- a/test/files/presentation/doc/doc.scala
+++ b/test/files/presentation/doc/doc.scala
@@ -108,7 +108,7 @@ object Test extends InteractiveTest {
                 case Some(comment) =>
                   import comment._
                   def cnt(bodies: Iterable[Body]) = bodies.size
-                  val actual = cnt(example) + cnt(version) + cnt(since) + cnt(todo) + cnt(note) + cnt(see)
+                  val actual = cnt(example) + cnt(version.toList) + cnt(since.toList) + cnt(todo) + cnt(note) + cnt(see)
                   if (actual != i)
                     println(s"Got docComment with $actual tags instead of $i, file text:\n$newText")
               }

--- a/test/files/presentation/ide-t1000567/Runner.scala
+++ b/test/files/presentation/ide-t1000567/Runner.scala
@@ -5,8 +5,8 @@ import scala.tools.nsc.interactive.tests.InteractiveTest
 object Test extends InteractiveTest {
 
   override def runDefaultTests(): Unit = {
-    val a = sourceFiles.find(_.file.name == "a.scala").head
-    val b = sourceFiles.find(_.file.name == "b.scala").head
+    val a = sourceFiles.find(_.file.name == "a.scala").get
+    val b = sourceFiles.find(_.file.name == "b.scala").get
     askLoadedTyped(a).get
     askLoadedTyped(b).get
     super.runDefaultTests()

--- a/test/files/presentation/ide-t1000976/Test.scala
+++ b/test/files/presentation/ide-t1000976/Test.scala
@@ -10,7 +10,7 @@ object Test extends InteractiveTest {
   }
 
   private def loadSourceAndWaitUntilTypechecked(sourceName: String): SourceFile = {
-    val sourceFile = sourceFiles.find(_.file.name == sourceName).head
+    val sourceFile = sourceFiles.find(_.file.name == sourceName).get
     compiler.askToDoFirst(sourceFile)
     val res = new Response[Unit]
     compiler.askReload(List(sourceFile), res)

--- a/test/files/presentation/ide-t1001388/Test.scala
+++ b/test/files/presentation/ide-t1001388/Test.scala
@@ -9,7 +9,7 @@ object Test extends InteractiveTest {
   }
 
   private def loadSourceAndWaitUntilTypechecked(sourceName: String): SourceFile = {
-    val sourceFile = sourceFiles.find(_.file.name == sourceName).head
+    val sourceFile = sourceFiles.find(_.file.name == sourceName).get
     askLoadedTyped(sourceFile).get
     /* The response to `askLoadedType` may return before `interactive.Global.waitLoadedType`
      * fully executes. Because this test expects `waitLoadedType` is fully executed before

--- a/test/files/presentation/parse-invariants/Test.scala
+++ b/test/files/presentation/parse-invariants/Test.scala
@@ -6,7 +6,7 @@ object Test extends InteractiveTest {
 
   override def execute(): Unit = {
     def test(fileName: String): Unit = {
-      val sf = sourceFiles.find(_.file.name == fileName).head
+      val sf = sourceFiles.find(_.file.name == fileName).get
       noNewSymbols(sf)
       uniqueParseTree(sf)
       unattributedParseTree(sf)

--- a/test/files/presentation/private-case-class-members/Test.scala
+++ b/test/files/presentation/private-case-class-members/Test.scala
@@ -9,7 +9,7 @@ object Test extends InteractiveTest {
   }
 
   private def loadSourceAndWaitUntilTypechecked(sourceName: String): SourceFile = {
-    val sourceFile = sourceFiles.find(_.file.name == sourceName).head
+    val sourceFile = sourceFiles.find(_.file.name == sourceName).get
     compiler.askToDoFirst(sourceFile)
     val res = new Response[Unit]
     compiler.askReload(List(sourceFile), res)

--- a/test/files/presentation/t8085/Test.scala
+++ b/test/files/presentation/t8085/Test.scala
@@ -10,7 +10,7 @@ object Test extends InteractiveTest {
   }
 
   private def loadSourceAndWaitUntilTypechecked(sourceName: String): SourceFile = {
-    val sourceFile = sourceFiles.find(_.file.name == sourceName).head
+    val sourceFile = sourceFiles.find(_.file.name == sourceName).get
     askReload(List(sourceFile)).get
     askLoadedTyped(sourceFile).get
     sourceFile

--- a/test/files/presentation/t8085b/Test.scala
+++ b/test/files/presentation/t8085b/Test.scala
@@ -10,7 +10,7 @@ object Test extends InteractiveTest {
   }
 
   private def loadSourceAndWaitUntilTypechecked(sourceName: String): SourceFile = {
-    val sourceFile = sourceFiles.find(_.file.name == sourceName).head
+    val sourceFile = sourceFiles.find(_.file.name == sourceName).get
     askReload(List(sourceFile)).get
     askLoadedTyped(sourceFile).get
     sourceFile

--- a/test/files/presentation/t8934/Runner.scala
+++ b/test/files/presentation/t8934/Runner.scala
@@ -10,7 +10,7 @@ object Test extends InteractiveTest {
   }
 
   private def loadSourceAndWaitUntilTypechecked(sourceName: String): SourceFile = {
-    val sourceFile = sourceFiles.find(_.file.name == sourceName).head
+    val sourceFile = sourceFiles.find(_.file.name == sourceName).get
     askReload(List(sourceFile)).get
     askLoadedTyped(sourceFile).get
     sourceFile

--- a/test/files/run/icode-reader-dead-code.scala
+++ b/test/files/run/icode-reader-dead-code.scala
@@ -60,7 +60,7 @@ object Test extends DirectTest {
   def addDeadCode(): Unit = {
     val file = (testOutput / "p" / "A.class").path
     val cnode = readClass(file)
-    val method = cnode.methods.asScala.find(_.name == "f").head
+    val method = cnode.methods.asScala.find(_.name == "f").get
 
     AsmUtils.traceMethod(method)
 

--- a/test/files/run/noInlineUnknownIndy/Test.scala
+++ b/test/files/run/noInlineUnknownIndy/Test.scala
@@ -22,7 +22,7 @@ object Test extends DirectTest {
       "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;",
       /* itf = */ false)
     modifyClassFile(new File(testOutput.toFile, "A_1.class"))((cn: ClassNode) => {
-      val testMethod = cn.methods.iterator.asScala.find(_.name == "test").head
+      val testMethod = cn.methods.iterator.asScala.find(_.name == "test").get
       val indy = testMethod.instructions.iterator.asScala.collect({ case i: InvokeDynamicInsnNode => i }).next()
       indy.bsm = unknownBootstrapMethod
       cn

--- a/test/files/run/t3346e.scala
+++ b/test/files/run/t3346e.scala
@@ -36,13 +36,13 @@ class QuickSort[Coll](a: Coll) {
 class FilterMap[Repr](a: Repr) {
   def filterMap[A, B, That](f: A => Option[B])(implicit ev0: Repr => IterableOps[A, Iterable, _],
                                                bf: BuildFrom[Repr, B, That]): That = {
-    bf.fromSpecific(a)(a.flatMap(e => f(e).toSeq))
+    bf.fromSpecific(a)(a.flatMap(e => f(e)))
   }
 }
 
 class FilterMapFixed[A, Repr <% IterableOps[A, Iterable, _]](a: Repr) {
   def filterMap2[B, That](f: A => Option[B])(implicit bf: BuildFrom[Repr, B, That]): That = {
-    bf.fromSpecific(a)(a.flatMap(e => f(e).toSeq))
+    bf.fromSpecific(a)(a.flatMap(e => f(e)))
   }
 }
 

--- a/test/junit/scala/collection/MapTest.scala
+++ b/test/junit/scala/collection/MapTest.scala
@@ -53,4 +53,16 @@ class MapTest {
     val s1 = List(1) ++: m
     assertEquals(1 :: m.toList.sorted, (s1: Iterable[Any]).toList.sortBy({case (x: Int, _) => x; case x: Int => x}))
   }
+
+  @Test
+  def flatMapOption(): Unit = {
+    def f(p: (Int, Int)) = if (p._1 < p._2) Some(p._1, p._2) else None
+    val m = (1 to 10).zip(11 to 20).toMap
+    val m2 = m.flatMap(f)
+    (m2: Map[Int, Int]).head
+    val m3 = m.flatMap(p => Some(p))
+    (m3: Map[Int, Int]).head
+    val m4 = m.flatMap(_ => Some(3))
+    (m4: Iterable[Int]).head
+  }
 }


### PR DESCRIPTION
https://github.com/scala/bug/issues/11033

Option cannot be `Iterable` because we'd have to implement
```
protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]): C
```
