### PR TITLE
Make TreeSeqMap the default immutable SeqMap 

### DIFF
--- a/src/library/scala/collection/immutable/SeqMap.scala
+++ b/src/library/scala/collection/immutable/SeqMap.scala
@@ -51,7 +51,7 @@ object SeqMap extends MapFactory[SeqMap] {
       case _ => (newBuilder[K, V] ++= it).result()
     }
 
-  def newBuilder[K, V]: Builder[(K, V), SeqMap[K, V]] = VectorMap.newBuilder
+  def newBuilder[K, V]: Builder[(K, V), SeqMap[K, V]] = TreeSeqMap.newBuilder
 
   @SerialVersionUID(3L)
   private object EmptySeqMap extends SeqMap[Any, Nothing] with Serializable {

--- a/test/junit/scala/collection/FactoriesTest.scala
+++ b/test/junit/scala/collection/FactoriesTest.scala
@@ -281,8 +281,8 @@ class FactoriesTest {
     assert(Iterable().isInstanceOf[List[_]], "Iterable.apply should delegate to List.apply")
     assert(Iterable(1,2,3).isInstanceOf[List[_]], "Iterable.apply should delegate to List.apply")
 
-    assert(im.SeqMap().isInstanceOf[im.VectorMap[_, _]], "immutable.SeqMap.apply should delegate to VectorMap.apply")
-    assert(im.SeqMap(1 -> 2, 3 -> 4, 5 -> 6).isInstanceOf[im.VectorMap[_, _]], "immutable.SeqMap.apply should delegate to VectorMap.apply")
+    assert(im.SeqMap().isInstanceOf[im.TreeSeqMap[_, _]], "immutable.SeqMap.apply should delegate to TreeSeqMap.apply")
+    assert(im.SeqMap(1 -> 2, 3 -> 4, 5 -> 6).isInstanceOf[im.TreeSeqMap[_, _]], "immutable.SeqMap.apply should delegate to TreeSeqMap.apply")
 
     assert(Map().isInstanceOf[im.Map[_, _]], "Map.apply should delegate to immutable.Map.apply")
     assert(Map(1 -> 2, 3 -> 4, 5 -> 6).isInstanceOf[im.Map[_, _]], "Map.apply should delegate to immutable.Map.apply")


### PR DESCRIPTION
This relates to the discussion in PR #7146 starting from https://github.com/scala/scala/pull/7146#issuecomment-448465230.