### PR TITLE
Fix deprecation warning for Position

### DIFF
--- a/src/compiler/scala/tools/nsc/util/package.scala
+++ b/src/compiler/scala/tools/nsc/util/package.scala
@@ -116,8 +116,8 @@ package object util {
 
   lazy val trace = new SimpleTracer(System.out)
 
-  // These four deprecated since 2.10.0 are still used in (at least)
-  // the sbt 0.12.4 compiler interface.
+  // These four deprecated since 2.10.0 are still used in
+  // the sbt 0.13 compiler interface.
   @deprecated("Moved to scala.reflect.internal.util.Position", "2.10.0")
   type Position = scala.reflect.internal.util.Position
   @deprecated("Moved to scala.reflect.internal.util.NoPosition", "2.10.0")

--- a/test/scalacheck/scala/tools/nsc/scaladoc/CommentFactoryTest.scala
+++ b/test/scalacheck/scala/tools/nsc/scaladoc/CommentFactoryTest.scala
@@ -27,13 +27,13 @@ class Factory(val g: Global, val s: doc.Settings)
   }
 
   def getComment(s: String): Comment =
-    parse(s, "", scala.tools.nsc.util.NoPosition, null)
+    parse(s, "", scala.reflect.internal.util.NoPosition, null)
 
   def parseComment(s: String): Option[Inline] =
     strip(getComment(s))
 
   def createBody(s: String) =
-    parse(s, "", scala.tools.nsc.util.NoPosition, null).body
+    parse(s, "", scala.reflect.internal.util.NoPosition, null).body
 }
 
 object CommentFactoryTest extends Properties("CommentFactory") {


### PR DESCRIPTION
Update comment that it still exists in sbt 0.13 per discussion in #8028.