### PR TITLE
Rationalize subclasses of Name

### DIFF
--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -38,7 +38,7 @@ trait Names extends api.Names {
   private val nameLock: Object = new Object
 
   /** Memory to store all names sequentially. */
-  var chrs: Array[Char] = new Array[Char](NAME_SIZE)
+  var chrs: Array[Char] = new Array[Char](NAME_SIZE) // TODO this ought to be private
   private var nc = 0
 
   /** Hashtable for finding term names quickly. */
@@ -470,7 +470,9 @@ trait Names extends api.Names {
     def debugString = { val s = decode ; if (isTypeName) s + "!" else s }
 
     override final def toString: String = if (cachedString == null) new String(chrs, index, len) else cachedString
-
+    final def appendTo(buffer: java.lang.StringBuffer, start: Int, length: Int): Unit = {
+      buffer.append(chrs, this.start + start, length)
+    }
   }
 
   implicit def AnyNameOps(name: Name): NameOps[Name]          = new NameOps(name)

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1310,11 +1310,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         if (sym.isRoot || sym.isRootPackage || sym == NoSymbol || sym.owner.isEffectiveRoot) {
           val capacity = size + nSize
           b = new java.lang.StringBuffer(capacity)
-          b.append(chrs, symName.start, nSize)
+          symName.appendTo(b, 0, nSize)
         } else {
           loop(size + nSize + 1, sym.effectiveOwner.enclClass)
           b.append(separator)
-          b.append(chrs, symName.start, nSize)
+          symName.appendTo(b, 0, nSize)
         }
       }
       loop(suffix.length(), this)

--- a/test/files/run/reflection-names.check
+++ b/test/files/run/reflection-names.check
@@ -1,4 +1,4 @@
 (java.lang.String,bc)
-(scala.reflect.internal.Names$TermName_R,bc)
-(scala.reflect.internal.Names$TypeName_R,bc)
-(scala.reflect.internal.Names$TypeName_R,bc)
+(scala.reflect.internal.Names$TermName,bc)
+(scala.reflect.internal.Names$TypeName,bc)
+(scala.reflect.internal.Names$TypeName,bc)


### PR DESCRIPTION
Due to alignment, TermName_R (which doesn't cache the provided string
for toString) takes up just as much space as TermName_S.

The code ends up somewhat easier to read with by just encoding the
difference with the a nullable field.