### PR TITLE
relax `flatten` methods to work with any =>, not just <:<

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -300,7 +300,7 @@ sealed abstract class Option[+A] extends Product with Serializable {
    *           also an $option.
    * @see flatMap
    */
-  def flatten[B](implicit ev: A <:< Option[B]): Option[B] =
+  def flatten[B](implicit ev: A => Option[B]): Option[B] =
     if (isEmpty) None else ev(this.get)
 
   /** Returns this $option if it is nonempty '''and''' applying the predicate $p to

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -264,7 +264,7 @@ trait Future[+T] extends Awaitable[T] {
    * @tparam S  the type of the returned `Future`
    * @group Transformations
    */
-  def flatten[S](implicit ev: T <:< Future[S]): Future[S] = flatMap(ev)(parasitic)
+  def flatten[S](implicit ev: T => Future[S]): Future[S] = flatMap(ev)(parasitic)
 
   /** Creates a new future by filtering the value of the current future with a predicate.
    *
@@ -598,7 +598,7 @@ object Future {
     override final def transformWith[S](f: Try[Nothing] => Future[S])(implicit executor: ExecutionContext): Future[S] = this
     override final def map[S](f: Nothing => S)(implicit executor: ExecutionContext): Future[S] = this
     override final def flatMap[S](f: Nothing => Future[S])(implicit executor: ExecutionContext): Future[S] = this
-    override final def flatten[S](implicit ev: Nothing <:< Future[S]): Future[S] = this
+    override final def flatten[S](implicit ev: Nothing => Future[S]): Future[S] = this
     override final def filter(p: Nothing => Boolean)(implicit executor: ExecutionContext): Future[Nothing] = this
     override final def collect[S](pf: PartialFunction[Nothing, S])(implicit executor: ExecutionContext): Future[S] = this
     override final def recover[U >: Nothing](pf: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): Future[U] = this

--- a/src/library/scala/typeConstraints.scala
+++ b/src/library/scala/typeConstraints.scala
@@ -39,11 +39,10 @@ import scala.annotation.implicitNotFound
   *            sealed trait Option[+A] {
   *              // def flatten[B, A <: Option[B]]: Option[B] = ...
   *              // won't work, since the A in flatten shadows the class-scoped A.
-  *              def flatten[B](implicit ev: A <:< Option[B]): Option[B]
-  *                = if(isEmpty) None else ev(get)
-  *              // Because (A <:< Option[B]) <: (A => Option[B]), ev can be called to turn the
-  *              // A from get into an Option[B], and because ev is implicit, that call can be
-  *              // left out and inserted automatically.
+  *
+  *              def flatten[B](implicit ev: A => Option[B]): Option[B] = if(isEmpty) None else ev(get)
+  *              // Because (A <:< Option[B]) <: (A => Option[B]), the compiler provides the `<:<`
+  *              // value when invoking `flatten`.
   *            }
   *           }}}
   *

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -371,7 +371,7 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
     *
     * Equivalent to `flatMap(id => id)`
     */
-  def flatten[A1 >: A, B1](implicit ev: B <:< Either[A1, B1]): Either[A1, B1] = flatMap(ev)
+  def flatten[A1 >: A, B1](implicit ev: B => Either[A1, B1]): Either[A1, B1] = flatMap(ev)
 
   /** The given function is applied if this is a `Right`.
    *

--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -164,7 +164,7 @@ sealed abstract class Try[+T] extends Product with Serializable {
    * Transforms a nested `Try`, ie, a `Try` of type `Try[Try[T]]`,
    * into an un-nested `Try`, ie, a `Try` of type `Try[T]`.
    */
-  def flatten[U](implicit ev: T <:< Try[U]): Try[U]
+  def flatten[U](implicit ev: T => Try[U]): Try[U]
 
   /**
    * Inverts this `Try`. If this is a `Failure`, returns its exception wrapped in a `Success`.
@@ -222,7 +222,7 @@ final case class Failure[+T](exception: Throwable) extends Try[T] {
   override def orElse[U >: T](default: => Try[U]): Try[U] =
     try default catch { case NonFatal(e) => Failure(e) }
   override def flatMap[U](f: T => Try[U]): Try[U] = this.asInstanceOf[Try[U]]
-  override def flatten[U](implicit ev: T <:< Try[U]): Try[U] = this.asInstanceOf[Try[U]]
+  override def flatten[U](implicit ev: T => Try[U]): Try[U] = this.asInstanceOf[Try[U]]
   override def foreach[U](f: T => U): Unit = ()
   override def transform[U](s: T => Try[U], f: Throwable => Try[U]): Try[U] =
     try f(exception) catch { case NonFatal(e) => Failure(e) }
@@ -258,7 +258,7 @@ final case class Success[+T](value: T) extends Try[T] {
   override def orElse[U >: T](default: => Try[U]): Try[U] = this
   override def flatMap[U](f: T => Try[U]): Try[U] =
     try f(value) catch { case NonFatal(e) => Failure(e) }
-  override def flatten[U](implicit ev: T <:< Try[U]): Try[U] = value
+  override def flatten[U](implicit ev: T => Try[U]): Try[U] = value
   override def foreach[U](f: T => U): Unit = f(value)
   override def transform[U](s: T => Try[U], f: Throwable => Try[U]): Try[U] = this flatMap s
   override def map[U](f: T => U): Try[U] = Try[U](f(value))


### PR DESCRIPTION
`IterableOps.flatten` also uses `=>`, not `<:<`, so this makes the `flatten`s more uniform (and general).

Just wanted to put it out there in case anyone feels strongly that this should go into 2.13.0. Otherwise it's for 2.14 :)