### PR TITLE
Partially apply BuildFrom to Factory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,6 +133,13 @@ val mimaPrereleaseHandlingSettings = Seq(
     ProblemFilters.exclude[FinalMethodProblem]("scala.Option.isEmpty"),
     ProblemFilters.exclude[DirectAbstractMethodProblem]("scala.Option.isEmpty"),
     ProblemFilters.exclude[ReversedAbstractMethodProblem]("scala.Option.isEmpty"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.SortedMapFactory#SortedMapFactoryToBuildFrom.toFactory"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.BuildFrom.toFactory"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.EvidenceIterableFactory#EvidenceIterableFactoryToBuildFrom.toFactory"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.IntMap#ToBuildFrom.toFactory"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.LongMap#ToBuildFrom.toFactory"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.AnyRefMap#ToBuildFrom.toFactory"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.LongMap#ToBuildFrom.toFactory"),
   ),
 )
 

--- a/src/library/scala/collection/BuildFrom.scala
+++ b/src/library/scala/collection/BuildFrom.scala
@@ -26,7 +26,7 @@ import scala.reflect.ClassTag
   * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
   */
 @implicitNotFound(msg = "Cannot construct a collection of type ${C} with elements of type ${A} based on a collection of type ${From}.")
-trait BuildFrom[-From, -A, +C] extends Any {
+trait BuildFrom[-From, -A, +C] extends Any { self =>
   def fromSpecific(from: From)(it: IterableOnce[A]): C
 
   /** Get a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
@@ -35,6 +35,12 @@ trait BuildFrom[-From, -A, +C] extends Any {
 
   @deprecated("Use newBuilder() instead of apply()", "2.13.0")
   @`inline` def apply(from: From): Builder[A, C] = newBuilder(from)
+
+  /** Partially apply a BuildFrom to a Factory */
+  def toFactory(from: From): Factory[A, C] = new Factory[A, C] {
+    def fromSpecific(it: IterableOnce[A]): C = self.fromSpecific(from)(it)
+    def newBuilder: Builder[A, C] = self.newBuilder(from)
+  }
 }
 
 object BuildFrom extends BuildFromLowPriority1 {

--- a/test/junit/scala/collection/BuildFromTest.scala
+++ b/test/junit/scala/collection/BuildFromTest.scala
@@ -148,6 +148,14 @@ class BuildFromTest {
     val xs10: immutable.TreeMap[Int, Boolean] = xs8
   }
 
+  @Test
+  def buildFromToFactory: Unit = {
+    val bf = implicitly[BuildFrom[Iterable[Int], Int, Iterable[Int]]]
+    val f = bf.toFactory(Set.empty[Int])
+    val bs = f.fromSpecific(Iterator(1, 2, 3))
+    bs.asInstanceOf[Set[Int]]
+  }
+
   implicitly[BuildFrom[String, Char, String]]
   implicitly[BuildFrom[Array[Int], Char, Array[Char]]]
   implicitly[BuildFrom[BitSet, Int, BitSet]]


### PR DESCRIPTION
Fixes https://github.com/scala/scala-collection-compat/issues/196

With all the stuff still going into RC2, I thought I'd throw this forgotten method into the queue for consideration as well. I noticed that this obvious method was missing while trying to make Slick compile on RC1.