### PR TITLE
Rename type params in mixin forwarder signatures if they shadow

### DIFF
--- a/test/files/pos/t11523/A_1.scala
+++ b/test/files/pos/t11523/A_1.scala
@@ -1,0 +1,7 @@
+trait T[A, B] {
+  def m[R]: T[R, B] = null
+}
+
+// gets a mixin forwarder `def m[R]: T[R<method-tparam>, R<class-tparam>]
+// so the type parameter in the mixin forwarder is renamed
+class C[X, R] extends T[X, R]

--- a/test/files/pos/t11523/Test_2.java
+++ b/test/files/pos/t11523/Test_2.java
@@ -1,0 +1,1 @@
+public class Test_2 extends C<String, String> { }

--- a/test/junit/scala/lang/traits/BytecodeTest.scala
+++ b/test/junit/scala/lang/traits/BytecodeTest.scala
@@ -25,6 +25,16 @@ class BytecodeTest extends BytecodeTesting {
   }
 
   @Test
+  def t11523(): Unit = {
+    val code =
+      """trait T[A, B] { def m[R]: T[R, B] = null }
+        |class C[X, R] extends T[X, R]
+      """.stripMargin
+    val List(c, t) = compileClasses(code)
+    assertEquals("<R$M:Ljava/lang/Object;>()LT<TR$M;TR;>;", getAsmMethod(c, "m").signature)
+  }
+
+  @Test
   def t10853(): Unit = {
     val code =
       """trait F[T1, R] { def apply(funArg: T1): R }


### PR DESCRIPTION
Type params in mixin forwarders can shadow type parameters of the
containing class, in which case the generic signature can become
invalid.

Fix this by renaming the mixin forwarder's type param in this case.

Fixes https://github.com/scala/bug/issues/11523