### PR TITLE
Fix regression in import name comparison

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1533,7 +1533,7 @@ trait Contexts { self: Analyzer =>
       @inline def current = selectors.head
       while ((selectors ne Nil) && result == NoSymbol) {
         def sameName(name: Name, other: Name) = {
-          (name eq other) || (name ne null) && name.start == other.start
+          (name eq other) || (name ne null) && name.start == other.start && name.length == other.length
         }
         if (sameName(current.rename, name))
           result = qual.tpe.nonLocalMember( // new to address #2733: consider only non-local members for imports


### PR DESCRIPTION
```
scala> :power
Power mode enabled. :phase is at typer.
import scala.tools.nsc._, intp.global._, definitions._
Try :help or completions for vals._ and power._

scala> val t = TermName("abcdefghijklmnopqrstuvwxyz")
t: $r.intp.global.TermName = abcdefghijklmnopqrstuvwxyz

scala> t.subName(0, 25)
res0: $r.intp.global.TermName = abcdefghijklmnopqrstuvwxy

scala> res0.start
res1: Int = 474232

scala> t.start
res2: Int = 474232
```