### PR TITLE
Clarify what Null is a subtype of.

### DIFF
--- a/spec/03-types.md
+++ b/spec/03-types.md
@@ -829,7 +829,7 @@ The conformance relation $(<:)$ is the smallest transitive relation that satisfi
 - Conformance includes equivalence. If $T \equiv U$ then $T <: U$.
 - For every value type $T$, `scala.Nothing <: $T$ <: scala.Any`.
 - For every type constructor $T$ (with any number of type parameters), `scala.Nothing <: $T$ <: scala.Any`.
-- For every class type $T$ such that `$T$ <: scala.AnyRef` one has `scala.Null <: $T$`.
+- For every value type $T$, `scala.Null <: $T$` unless `$T$ <: scala.AnyVal`.
 - A type variable or abstract type $t$ conforms to its upper bound and
   its lower bound conforms to $t$.
 - A class type or parameterized type conforms to any of its base-types.

--- a/src/library-aux/scala/Null.scala
+++ b/src/library-aux/scala/Null.scala
@@ -13,9 +13,12 @@
 package scala
 
 /** `Null` is - together with [[scala.Nothing]] - at the bottom of the Scala type hierarchy.
- *
- *  `Null` is a subtype of all reference types; its only instance is the `null` reference.
- *  Since `Null` is not a subtype of value types, `null` is not a member of any such type.  For instance,
- *  it is not possible to assign `null` to a variable of type [[scala.Int]].
- */
+  *
+  * `Null` is the type of the `null` literal. It is a subtype of every type
+  * except those of value classes. Value classes are subclasses of [[AnyVal]], which includes
+  * primitive types such as [[Int]], [[Boolean]], and user-defined value classes.
+  *
+  * Since `Null` is not a subtype of value types, `null` is not a member of any such type.
+  * For instance, it is not possible to assign `null` to a variable of type [[scala.Int]].
+  */
 sealed trait Null


### PR DESCRIPTION
To wit, any non-value-class class type, and non-class value types so declared, but certainly not value-class types.

Okay, okay, that's not what I've made it say. Hopefully this is clearer.

Fixes scala/bug#11479.