### PR TITLE
Scaladoc treats annotations more like classes.

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/Page.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/Page.scala
@@ -115,7 +115,6 @@ abstract class Page {
   def kindToString(mbr: MemberEntity) =
     mbr match {
       case c: Class => if (c.isCaseClass) "case class" else "class"
-      case c: AnnotationClass => if (c.isCaseClass) "case class" else "class"
       case _: Trait => "trait"
       case _: Package => "package"
       case _: Object => "object"

--- a/src/scaladoc/scala/tools/nsc/doc/model/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/Entity.scala
@@ -349,8 +349,8 @@ trait Object extends MemberTemplateEntity {
 }
 
 /** An annotation template. Any class which extends `scala.annotation.Annotation` */
-trait AnnotationClass extends MemberTemplateEntity {
-  def kind = "annotation"
+trait AnnotationClass extends Class {
+  override def kind = "annotation"
 }
 
 /** A package template. A package is in the universe if it is declared as a package object, or if it

--- a/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
+++ b/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
@@ -599,6 +599,10 @@ object HtmlFactoryTest extends Properties("HtmlFactory") {
 
   }
 
+  property("show constructor method for annotations") = {
+    checkTemplate("t11390.scala", "A.html") { (_, s) => s.contains("<h3>Instance Constructors</h3>") }
+  }
+
   property("scala/bug#9599 Multiple @todo formatted with comma on separate line") = {
     checkTemplate("t9599.scala", "X.html") { (_, s) => s.contains("""<span class="cmt"><p>todo1</p></span><span class="cmt"><p>todo2</p></span><span class="cmt"><p>todo3</p></span>""") }
   }

--- a/test/scaladoc/resources/t11390.scala
+++ b/test/scaladoc/resources/t11390.scala
@@ -1,0 +1,1 @@
+class A(x: Int = 0) extends annotation.Annotation


### PR DESCRIPTION
Because they are.

Fixes scala/bug#11390.