### PR TITLE
Avoid bad generic signatures when mixin forwarders tparams shadow

### DIFF
--- a/test/files/pos/t11525a/A.scala
+++ b/test/files/pos/t11525a/A.scala
@@ -1,0 +1,16 @@
+package example
+
+
+trait PartialFunction[-A, +B] extends Function1[A,B] { self =>
+  def isDefinedAt(x: A): Boolean
+  def compose[CLASH](k: PartialFunction[CLASH, A]): PartialFunction[CLASH, B] = null
+}
+
+trait Function1[-T1, +R] extends AnyRef { self =>
+  def apply(v1: T1): R
+  def compose[A](g: Function1[A, T1]): Function1[A , R] = null
+}
+
+abstract class AbstractPartialFunction[-T1, +CLASH] extends Function1[T1, CLASH] with PartialFunction[T1, CLASH] { self =>
+  def apply(x: T1): CLASH = ???
+}

--- a/test/files/pos/t11525a/Test.java
+++ b/test/files/pos/t11525a/Test.java
@@ -1,0 +1,5 @@
+public class Test {
+    class D extends example.AbstractPartialFunction<String, String> {
+        public boolean isDefinedAt(String s) { return false; }
+    };
+}

--- a/test/files/pos/t11525b/Test.java
+++ b/test/files/pos/t11525b/Test.java
@@ -1,0 +1,5 @@
+public class Test {
+    class D extends scala.runtime.AbstractPartialFunction<String, String> {
+        public boolean isDefinedAt(String s) { return false; }
+    };
+}


### PR DESCRIPTION
... referenced type parameters of an enclosing class.

Rename the type parameters of mixin forwarders when shadowing is detected.

Fixes scala/bug#11523