### PR TITLE
Deprecation for thee, not for we

### DIFF
--- a/src/compiler/scala/tools/nsc/plugins/Plugin.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugin.scala
@@ -72,7 +72,7 @@ abstract class Plugin {
     true
   }
 
-  @deprecated("use Plugin#init instead", since="2.11.0")
+  @deprecatedOverriding("use Plugin#init instead", since="2.11.0")
   def processOptions(options: List[String], error: String => Unit): Unit = {
     if (!options.isEmpty) error(s"Error: $name takes no options")
   }

--- a/src/reflect/scala/reflect/internal/AnnotationCheckers.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationCheckers.scala
@@ -52,14 +52,14 @@ trait AnnotationCheckers {
      * Modify the type that has thus far been inferred for a tree. All this should
      * do is add annotations.
      */
-    @deprecated("create an AnalyzerPlugin and use pluginsTyped", "2.10.1")
+    @deprecatedOverriding("create an AnalyzerPlugin and use pluginsTyped", "2.10.1")
     def addAnnotations(tree: Tree, tpe: Type): Type = tpe
 
     /**
      * Decide whether this analyzer plugin can adapt a tree that has an annotated type to the
      * given type tp, taking into account the given mode (see method adapt in trait Typers).
      */
-    @deprecated("create an AnalyzerPlugin and use canAdaptAnnotations", "2.10.1")
+    @deprecatedOverriding("create an AnalyzerPlugin and use canAdaptAnnotations", "2.10.1")
     def canAdaptAnnotations(tree: Tree, mode: Mode, pt: Type): Boolean = false
 
     /**
@@ -69,7 +69,7 @@ trait AnnotationCheckers {
      * An implementation cannot rely on canAdaptAnnotations being called before. If the implementing
      * class cannot do the adapting, it should return the tree unchanged.
      */
-    @deprecated("create an AnalyzerPlugin and use adaptAnnotations", "2.10.1")
+    @deprecatedOverriding("create an AnalyzerPlugin and use adaptAnnotations", "2.10.1")
     def adaptAnnotations(tree: Tree, mode: Mode, pt: Type): Tree = tree
 
     /**
@@ -79,8 +79,9 @@ trait AnnotationCheckers {
      *
      * By default, this method simply returns the passed `default` type.
      */
-    @deprecated("Create an AnalyzerPlugin and use pluginsTypedReturn. Note: the 'tree' argument here is\n"+
-                "the 'expr' of a Return tree; 'pluginsTypedReturn' takes the Return tree itself as argument", "2.10.1")
+    @deprecatedOverriding(
+      "Create an AnalyzerPlugin and use pluginsTypedReturn. Note: the 'tree' argument here is\n"+
+      "the 'expr' of a Return tree; 'pluginsTypedReturn' takes the Return tree itself as argument", "2.10.1")
     def adaptTypeOfReturn(tree: Tree, pt: Type, default: => Type): Type = default
   }
 


### PR DESCRIPTION
I assume the hope was to discourage plugin writers from implementing those methods, not to admonish ourselves for continuing to support them. (Although perhaps we deserve it.)