### PR TITLE
Add .isFinite to RichDouble(_)

### DIFF
--- a/src/library/scala/runtime/RichDouble.scala
+++ b/src/library/scala/runtime/RichDouble.scala
@@ -39,6 +39,7 @@ final class RichDouble(val self: Double) extends AnyVal with FractionalProxy[Dou
 
   def isNaN: Boolean         = java.lang.Double.isNaN(self)
   def isInfinity: Boolean    = java.lang.Double.isInfinite(self)
+  def isFinite: Boolean      = java.lang.Double.isFinite(self)
   def isPosInfinity: Boolean = Double.PositiveInfinity == self
   def isNegInfinity: Boolean = Double.NegativeInfinity == self
 

--- a/test/files/presentation/infix-completion.check
+++ b/test/files/presentation/infix-completion.check
@@ -3,7 +3,7 @@ reload: Snippet.scala
 askTypeCompletion at Snippet.scala(1,34)
 ================================================================================
 [response] askTypeCompletion at (1,34)
-retrieved 211 members
+retrieved 212 members
 [inaccessible] protected def integralNum: math.Numeric.DoubleAsIfIntegral.type
 [inaccessible] protected def num: math.Numeric.DoubleIsFractional.type
 [inaccessible] protected def ord: math.Ordering.Double.type
@@ -131,6 +131,7 @@ def floor: Double
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def intValue(): Int
+def isFinite: Boolean
 def isInfinite(): Boolean
 def isInfinity: Boolean
 def isNaN(): Boolean

--- a/test/files/presentation/infix-completion2.check
+++ b/test/files/presentation/infix-completion2.check
@@ -3,7 +3,7 @@ reload: Snippet.scala
 askTypeCompletion at Snippet.scala(1,34)
 ================================================================================
 [response] askTypeCompletion at (1,34)
-retrieved 211 members
+retrieved 212 members
 [inaccessible] protected def integralNum: math.Numeric.DoubleAsIfIntegral.type
 [inaccessible] protected def num: math.Numeric.DoubleIsFractional.type
 [inaccessible] protected def ord: math.Ordering.Double.type
@@ -131,6 +131,7 @@ def floor: Double
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def intValue(): Int
+def isFinite: Boolean
 def isInfinite(): Boolean
 def isInfinity: Boolean
 def isNaN(): Boolean


### PR DESCRIPTION
Fixes scala/bug#11531. Rationale for this PR is outlined there.

Full text search for `RichDouble` and `isInfinity` didn't reveal any spec documents or unit tests, hence there are no additions in this regard.

Merging into `2.12.x` to address both `.12` and `.13`.

This is my first contribution. I have signed the Scala CLA. If there are any worries, let me know.