### PR TITLE
Ensure that lifted DelayedInit fields are non-final

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -503,6 +503,11 @@ abstract class LambdaLift extends InfoTransform {
             }
 
             treeCopy.ValDef(tree, mods, name, tpt1, factoryCall)
+          } else if(sym.enclClass.isSubClass(DelayedInitClass) && !mods.hasFlag(CAPTURED)) {
+            // Fields of DelayedInit bodies are initialized in a regular method, not in a static initializer,
+            // and must therefore not be final in bytecode (https://github.com/scala/bug/issues/11412)
+            sym.setFlag(MUTABLE)
+            tree
           } else tree
         case Return(Block(stats, value)) =>
           Block(stats, treeCopy.Return(tree, value)) setType tree.tpe setPos tree.pos


### PR DESCRIPTION
Usually fields inside of a class or object body are initialized in an initializer block, which is the correct way to initialize final fields, but when they occur in a `DelayedInit` body, the initialization code is put into a method instead. This is illegal according to https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-8.3.1.2. The fix is to emit these fields as non-final.

Fixes https://github.com/scala/bug/issues/11412