### PR TITLE
Add benchmark of for-loops

### DIFF
--- a/test/benchmarks/src/main/scala/scala/ArrayBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/ArrayBenchmark.scala
@@ -1,0 +1,134 @@
+package scala
+
+import java.util.concurrent.TimeUnit
+
+import scala.util.Random
+
+import org.openjdk.jmh.annotations._
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+class ArrayBenchmark {
+
+  // From #1338: Optimize simple for loops
+
+  @Param(Array("10", "100", "1000"))
+  var loopSize: Int = _
+  var doubles: Array[Array[Double]] = _
+
+  @Setup(Level.Trial) def initArrays: Unit = {
+    // doubles = Array.ofDim[Double](loopSize,loopSize)
+    // doubles = Array.tabulate(loopSize, loopSize)((i,_) => i.toDouble)
+    doubles = Array.tabulate(loopSize, loopSize) { (_, _) =>
+      scala.math.sqrt(Random.nextDouble)
+    }
+  }
+
+  @Benchmark 
+  def matMulUsingIteratorsBench(): Unit = {
+    matMulUsingIterators(doubles, doubles, doubles)
+  }
+
+  def matMulUsingIterators(
+    a: Array[Array[Double]],
+    b: Array[Array[Double]],
+    c: Array[Array[Double]]
+  ): Unit = {
+
+    val b_j = new Array[Double](b.length)
+
+    for (j <- 0 until b(0).length) {
+      for (k <- 0 until b.length) {
+        b_j(k) = b(k)(j)
+      }
+      for (i <- 0 until a.length) {
+        val c_i = c(i)
+        val a_i = a(i)
+        var s = 0.0d;
+        for (k <- 0 until b.length) {
+          s += a_i(k) * b_j(k)
+        }
+        c_i(j) = s
+      }
+    }
+  }
+
+  @Benchmark 
+  def matMulUsingRangesBench(): Unit = {
+    matMulUsingRanges(doubles, doubles, doubles)
+  }
+
+  def matMulUsingRanges(
+    a: Array[Array[Double]],
+    b: Array[Array[Double]],
+    c: Array[Array[Double]]
+  ) : Unit = {
+
+    val jRange = 0 until b(0).length;
+    val kRange = 0 until b.length;
+    val iRange = 0 until a.length;
+
+    val b_j = new Array[Double](b.length)
+
+    for (j <- jRange) {
+      for (k <- kRange) {
+        b_j(k) = b(k)(j)
+      }
+      for (i <- iRange) {
+        val c_i = c(i);
+        val a_i = a(i);
+        var s = 0.0d;
+        for (k <- kRange) {
+          s += a_i(k) * b_j(k)
+        }
+        c_i(j) = s
+      }
+    }
+  }
+
+  @Benchmark
+  def matMulUsingWhileLoopBench(): Unit = {
+    matMulUsingWhileLoop(doubles, doubles, doubles)
+  }
+
+  def matMulUsingWhileLoop(
+    a: Array[Array[Double]],
+    b: Array[Array[Double]],
+    c: Array[Array[Double]]
+  ): Unit = {
+
+    val m = a.length;
+    val p = b(0).length;
+    val n = b.length;
+
+    val b_j = new Array[Double](b.length);
+
+    var i = 0; var j = 0; var k = 0;
+    while (j < p) {
+      k = 0
+      while (k < n) {
+        b_j(k) = b(k)(j);
+        k += 1
+      }
+      i = 0
+      while (i < m) {
+        val c_i = c(i);
+        val a_i = a(i);
+        var s = 0.0d;
+        k = 0;
+        while (k < n) {
+          s += a_i(k) * b_j(k);
+          k += 1
+        }
+        c_i(j) = s;
+        i += 1
+      }
+      j += 1;
+    }
+  }
+}


### PR DESCRIPTION
Matrix multiplication code is copied from a bug report submitted by David Biesack in Sep-2008.  Now that 2.13 has a benchmark suite, this is easier to investigate.

Fixes https://github.com/scala/bug/issues/1338.  If you don't want this new benchmark, there are no hard feelings if you reject it.

The original complaint was about performance being 14x slower over a while-loop:

```
Iterators   2,807,815,301 ns
Ranges      2,789,958,191 ns
While loop    190,778,574 ns
```

This performance problem was seen as a barrier to adoption of Scala.  Ten years later, this can probably be put to rest, given Scala's greater popularity and with performance optimizations made in the language.  

The matrix multiplication would seem to perform much better.  

```
Benchmark             (size)  Mode  Cnt       Score      Error  Units
matMulUsingIterators      10  avgt   20        3.53 ±      2.2  us/op
matMulUsingRanges         10  avgt   20        4.46 ±      2.6  us/op
matMulUsingWhileLoop      10  avgt   20        1.68 ±      0.6  us/op
matMulUsingIterators     100  avgt   20     4547.97 ±   2524.4  us/op
matMulUsingRanges        100  avgt   20     3015.85 ±   1227.4  us/op
matMulUsingWhileLoop     100  avgt   20     2529.83 ±    832.1  us/op
matMulUsingIterators    1000  avgt   20  2405979.16 ± 655423.9  us/op
matMulUsingRanges       1000  avgt   20  2139198.80 ± 302942.9  us/op
matMulUsingWhileLoop    1000  avgt   20  2537273.35 ± 705309.7  us/op
```

*The benchmark output is in units of microseconds.