### PR TITLE
Try any expression

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -11,7 +11,7 @@ Expr         ::=  (Bindings | id | ‘_’) ‘=>’ Expr
                |  Expr1
 Expr1        ::=  ‘if’ ‘(’ Expr ‘)’ {nl} Expr [[semi] ‘else’ Expr]
                |  ‘while’ ‘(’ Expr ‘)’ {nl} Expr
-               |  ‘try’ (‘{’ Block ‘}’ | Expr) [‘catch’ ‘{’ CaseClauses ‘}’] [‘finally’ Expr]
+               |  ‘try’ Expr [‘catch’ Expr] [‘finally’ Expr]
                |  ‘do’ Expr [semi] ‘while’ ‘(’ Expr ‘)’
                |  ‘for’ (‘(’ Enumerators ‘)’ | ‘{’ Enumerators ‘}’) {nl} [‘yield’] Expr
                |  ‘throw’ Expr
@@ -1104,8 +1104,7 @@ is `scala.Nothing`.
 ## Try Expressions
 
 ```ebnf
-Expr1 ::=  ‘try’ (‘{’ Block ‘}’ | Expr) [‘catch’ ‘{’ CaseClauses ‘}’]
-           [‘finally’ Expr]
+Expr1 ::=  ‘try’ Expr [‘catch’ Expr] [‘finally’ Expr]
 ```
 
 A _try expression_ is of the form `try { $b$ } catch $h$`

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -143,7 +143,7 @@ grammar:
                       |  Expr1
   Expr1             ::=  ‘if’ ‘(’ Expr ‘)’ {nl} Expr [[semi] ‘else’ Expr]
                       |  ‘while’ ‘(’ Expr ‘)’ {nl} Expr
-                      |  ‘try’ (‘{’ Block ‘}’ | Expr) [‘catch’ ‘{’ CaseClauses ‘}’] [‘finally’ Expr]
+                      |  ‘try’ Expr [‘catch’ Expr] [‘finally’ Expr]
                       |  ‘do’ Expr [semi] ‘while’ ‘(’ Expr ‘)’
                       |  ‘for’ (‘(’ Enumerators ‘)’ | ‘{’ Enumerators ‘}’) {nl} [‘yield’] Expr
                       |  ‘throw’ Expr

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1515,11 +1515,7 @@ self =>
         parseIf
       case TRY =>
         def parseTry = atPos(in.skipToken()) {
-          val body = in.token match {
-            case LBRACE => inBracesOrUnit(block())
-            case LPAREN => inParensOrUnit(expr())
-            case _ => expr()
-          }
+          val body = expr()
           def catchFromExpr() = List(makeCatchFromExpr(expr()))
           val catches: List[CaseDef] =
             if (in.token != CATCH) Nil
@@ -1532,8 +1528,8 @@ self =>
               }
             }
           val finalizer = in.token match {
-            case FINALLY => in.nextToken(); expr()
-            case _ => EmptyTree
+            case FINALLY => in.nextToken() ; expr()
+            case _       => EmptyTree
           }
           Try(body, catches, finalizer)
         }

--- a/test/files/neg/t5887.check
+++ b/test/files/neg/t5887.check
@@ -1,0 +1,13 @@
+t5887.scala:8: warning: A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
+  def g = try 42
+          ^
+t5887.scala:10: error: missing parameter type for expanded function
+The argument types of an anonymous function must be fully known. (SLS 8.5)
+Expected type was: ?
+  def h = List("x") map (s => try { case _ => 7 })
+                                  ^
+t5887.scala:10: warning: A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
+  def h = List("x") map (s => try { case _ => 7 })
+                              ^
+two warnings found
+one error found

--- a/test/files/neg/t5887.scala
+++ b/test/files/neg/t5887.scala
@@ -1,0 +1,11 @@
+
+trait TheOldCollegeTry {
+
+  // was: value isDefinedAt is not a member of Int
+  // now: required: PartialFunction[Throwable,?]
+  //def f = try ??? catch 22
+
+  def g = try 42
+
+  def h = List("x") map (s => try { case _ => 7 })
+}

--- a/test/files/pos/t5887.scala
+++ b/test/files/pos/t5887.scala
@@ -1,0 +1,26 @@
+
+trait TheOldCollegeTry {
+  def f = try (1) + 1 finally ()
+
+  def g = try { 1 } + 1 finally ()
+
+  type H[A] = PartialFunction[Throwable, A]
+
+  val myh: H[Int] = { case _: NullPointerException => ??? ; case t => 42 }
+  def h = try ??? catch myh finally ()
+
+  // a little weird
+  def pf: H[Nothing] = try { case _: Throwable => ??? } finally ()
+
+  // but not weirder than
+  def tf = try (t: Throwable) => throw t finally ()
+
+  // old jedi mind trick
+//badcatch.scala:14: error: recursive value catchExpr1 needs type
+//    try {} catch catchExpr1
+//                 ^
+  def badcatch = {
+    def catchExpr1: PartialFunction[Throwable, Any] = ???
+    try {} catch catchExpr1
+  }
+}


### PR DESCRIPTION
Previously, parsing `try` was special-cased for expressions
beginning with paren or brace. Perhaps that was to avoid odd
sights such as `try (1,2,3)` or `try { case _ => }`, but it
also broke `try { 1 } + 1 finally ()`.

This commit takes an arbitrary expression to `try`.

This is just the parser change for `try` from https://github.com/scala/scala/pull/4400

Fixes scala/bug#5887