### PR TITLE
override mutable.HashMap#updateWith and mutable.LinkedHashMap#updateWith for performance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,6 +124,7 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[FinalMethodProblem]("scala.collection.immutable.Stream.find"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.sys.process.BasicIO.connectNoOp"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.sys.process.BasicIO.connectToStdIn"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.HashTable.removeEntry0"),
   ),
 }
 

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -106,6 +106,57 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     }
   }
 
+  // Override updateWith for performance, so we can do the update while hashing
+  // the input key only once and performing one lookup into the hash table
+  override def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = {
+    if (getClass != classOf[HashMap[_, _]]) {
+      // subclasses of HashMap might customise `get` ...
+      super.updateWith(key)(remappingFunction)
+    } else {
+      val hash = computeHash(key)
+      val indexedHash = index(hash)
+
+      var foundNode: Node[K, V] = null
+      var previousNode: Node[K, V] = null
+      table(indexedHash) match {
+        case null =>
+        case nd =>
+          @tailrec
+          def findNode(prev: Node[K, V], nd: Node[K, V], k: K, h: Int): Unit = {
+            if (h == nd.hash && k == nd.key) {
+              previousNode = prev
+              foundNode = nd
+            }
+            else if ((nd.next eq null) || (nd.hash > h)) ()
+            else findNode(nd, nd.next, k, h)
+          }
+
+          findNode(null, nd, key, hash)
+      }
+
+      val previousValue = foundNode match {
+        case null => None
+        case nd => Some(nd.value)
+      }
+
+      val nextValue = remappingFunction(previousValue)
+
+      (previousValue, nextValue) match {
+        case (None, None) => // do nothing
+
+        case (Some(_), None) =>
+          if (previousNode != null) previousNode.next = foundNode.next
+          else table(indexedHash) = foundNode.next
+          contentSize -= 1
+
+        case (None, Some(value)) => put0(key, value, false, hash, indexedHash)
+
+        case (Some(_), Some(newValue)) => foundNode.value = newValue
+      }
+      nextValue
+    }
+  }
+
   override def subtractAll(xs: IterableOnce[K]): this.type = {
     if (size == 0) {
       return this

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -176,7 +176,11 @@ private[collection] /*abstract class*/ trait HashTable[A, B, Entry >: Null <: Ha
   /** Remove entry from table if present.
    */
   final def removeEntry(key: A) : Entry = {
-    val h = index(elemHashCode(key))
+    removeEntry0(key, index(elemHashCode(key)))
+  }
+  /** Remove entry from table if present.
+   */
+  private[collection] final def removeEntry0(key: A, h: Int) : Entry = {
     var e = table(h).asInstanceOf[Entry]
     if (e != null) {
       if (elemEquals(e.key, key)) {

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/LinkedHashMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/LinkedHashMapBenchmark.scala
@@ -1,10 +1,9 @@
 package scala.collection.mutable
 
+import java.util.concurrent.TimeUnit
+
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra._
-import org.openjdk.jmh.runner.IterationType
-import benchmark._
-import java.util.concurrent.TimeUnit
 
 @BenchmarkMode(Array(Mode.AverageTime))
 @Fork(2)
@@ -13,7 +12,7 @@ import java.util.concurrent.TimeUnit
 @Measurement(iterations = 10)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
-class HashMapBenchmark {
+class LinkedHashMapBenchmark {
   @Param(Array("10", "100", "1000"))
   var size: Int = _
   @Param(Array("true"))
@@ -35,54 +34,10 @@ class HashMapBenchmark {
     missingKeys = (size to 2 * size).toArray.map(_.toString)
   }
 
-  var map: collection.mutable.HashMap[Any, Any] = null
+  var map: collection.mutable.LinkedHashMap[Any, Any] = null
 
   @Setup(Level.Trial) def initialize = {
-    map = collection.mutable.HashMap(existingKeys.map(x => (x, x)) : _*)
-  }
-
-  @Benchmark def contains(bh: Blackhole): Unit = {
-    var i = 0;
-    while (i < size) {
-      bh.consume(map.contains(existingKeys(i)))
-      if (useMissingValues) {
-        bh.consume(map.contains(missingKeys(i)))
-      }
-      i += 1
-    }
-  }
-
-  @Benchmark def get(bh: Blackhole): Unit = {
-    var i = 0;
-    while (i < size) {
-      bh.consume(map.get(existingKeys(i)))
-      if (useMissingValues) {
-        bh.consume(map.get(missingKeys(i)))
-      }
-      i += 1
-    }
-  }
-
-  @Benchmark def getOrElse(bh: Blackhole): Unit = {
-    var i = 0;
-    while (i < size) {
-      bh.consume(map.getOrElse(existingKeys(i), ""))
-      if (useMissingValues) {
-        bh.consume(map.getOrElse(missingKeys(i), ""))
-      }
-      i += 1
-    }
-  }
-
-  @Benchmark def getOrElseUpdate(bh: Blackhole): Unit = {
-    var i = 0;
-    while (i < size) {
-      bh.consume(map.getOrElseUpdate(existingKeys(i), ""))
-      if (useMissingValues) {
-        bh.consume(map.getOrElse(missingKeys(i), ""))
-      }
-      i += 1
-    }
+    map = collection.mutable.LinkedHashMap(existingKeys.map(x => (x, x)) : _*)
   }
 
   @Benchmark def updateWith(bh: Blackhole): Unit = {

--- a/test/junit/scala/collection/mutable/HashMapTest.scala
+++ b/test/junit/scala/collection/mutable/HashMapTest.scala
@@ -113,19 +113,144 @@ class HashMapTest {
   @Test
   def testUpdateWith(): Unit = {
     val insertIfAbsent: Option[String] => Option[String] = _.orElse(Some("b"))
+
     val hashMap1 = mutable.HashMap(1 -> "a")
     assertEquals(hashMap1.updateWith(1)(insertIfAbsent), Some("a"))
     assertEquals(hashMap1, mutable.HashMap(1 -> "a"))
+
     val hashMap2 = mutable.HashMap(1 -> "a")
     assertEquals(hashMap2.updateWith(2)(insertIfAbsent), Some("b"))
     assertEquals(hashMap2, mutable.HashMap(1 -> "a", 2 -> "b"))
 
     val noneAnytime: Option[String] => Option[String] =  _ => None
+
     val hashMap3 = mutable.HashMap(1 -> "a")
     assertEquals(hashMap3.updateWith(1)(noneAnytime), None)
     assertEquals(hashMap3, mutable.HashMap())
+
     val hashMap4 = mutable.HashMap(1 -> "a")
     assertEquals(hashMap4.updateWith(2)(noneAnytime), None)
     assertEquals(hashMap4, mutable.HashMap(1 -> "a"))
+
+    val flip: Option[String] => Option[String] =  {
+      case None => Some("X")
+      case Some(x) => None}
+
+    val hashMap5 = mutable.HashMap(1 -> "a")
+    assertEquals(hashMap5.updateWith(1)(flip), None)
+    assertEquals(hashMap5, mutable.HashMap())
+
+    val hashMap6 = mutable.HashMap(1 -> "a")
+    assertEquals(hashMap6.updateWith(2)(flip), Some("X"))
+    assertEquals(hashMap6, mutable.HashMap(1 -> "a", 2 -> "X"))
+
+    val transform: Option[String] => Option[String] =  _.map(_ + "2")
+
+    val hashMap7 = mutable.HashMap(1 -> "a")
+    assertEquals(hashMap7.updateWith(1)(transform), Some("a2"))
+    assertEquals(hashMap7, mutable.HashMap(1 -> "a2"))
+
+    val hashMap8 = mutable.HashMap(1 -> "a")
+    assertEquals(hashMap8.updateWith(2)(transform), None)
+    assertEquals(hashMap8, mutable.HashMap(1 -> "a"))
+
+    val overwrite: Option[String] => Option[String] = _ => Some("X")
+
+    val hashMap9 = mutable.HashMap(1 -> "a")
+    assertEquals(hashMap9.updateWith(1)(overwrite), Some("X"))
+    assertEquals(hashMap9, mutable.HashMap(1 -> "X"))
+
+    val hashMap10 = mutable.HashMap(1 -> "a")
+    assertEquals(hashMap10.updateWith(2)(overwrite), Some("X"))
+    assertEquals(hashMap10, mutable.HashMap(1 -> "a", 2 -> "X"))
+
+
+    val hashMapMulti1 = mutable.HashMap(1 -> "a", 2 -> "b")
+    assertEquals(hashMapMulti1.updateWith(2)(noneAnytime), None)
+    assertEquals(hashMapMulti1, mutable.HashMap(1 -> "a"))
+
+    val hashMapMulti2 = mutable.HashMap(1 -> "a", 2 -> "b")
+    assertEquals(hashMapMulti2.updateWith(1)(noneAnytime), None)
+    assertEquals(hashMapMulti2, mutable.HashMap(2 -> "b"))
+
+    val hashMapMulti3 = mutable.HashMap(1 -> "a", 2 -> "b", 3 -> "c")
+    assertEquals(hashMapMulti3.updateWith(1)(noneAnytime), None)
+    assertEquals(hashMapMulti3, mutable.HashMap(2 -> "b", 3 -> "c"))
+
+    val hashMapMulti4 = mutable.HashMap(1 -> "a", 2 -> "b", 3 -> "c")
+    assertEquals(hashMapMulti4.updateWith(2)(noneAnytime), None)
+    assertEquals(hashMapMulti4, mutable.HashMap(1 -> "a", 3 -> "c"))
+
+    val hashMapMulti5 = mutable.HashMap(1 -> "a", 2 -> "b", 3 -> "c")
+    assertEquals(hashMapMulti5.updateWith(3)(noneAnytime), None)
+    assertEquals(hashMapMulti5, mutable.HashMap(1 -> "a", 2 -> "b"))
+
+
+    val hashMapCollide1 = mutable.HashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
+    assertEquals(hashMapCollide1.updateWith(0)(noneAnytime), None)
+    assertEquals(hashMapCollide1, mutable.HashMap((null: Any) -> "b", "" -> "c"))
+
+    val hashMapCollide2 = mutable.HashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
+    assertEquals(hashMapCollide2.updateWith((null: Any))(noneAnytime), None)
+    assertEquals(hashMapCollide2, mutable.HashMap(0 -> "a", "" -> "c"))
+
+    val hashMapCollide3 = mutable.HashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
+    assertEquals(hashMapCollide3.updateWith("")(noneAnytime), None)
+    assertEquals(hashMapCollide3, mutable.HashMap(0 -> "a", (null: Any) -> "b"))
+
+    val hashMapCollide4 = mutable.HashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
+    assertEquals(hashMapCollide4.updateWith(())(noneAnytime), None)
+    assertEquals(hashMapCollide4, mutable.HashMap(0 -> "a", (null: Any) -> "b", "" -> "c"))
+
+    val hashMapCollide5 = mutable.HashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
+    assertEquals(hashMapCollide5.updateWith(())(insertIfAbsent), Some("b"))
+    assertEquals(hashMapCollide5, mutable.HashMap(0 -> "a", (null: Any) -> "b", "" -> "c", () -> "b"))
+
+    val hashMapCollide6 = mutable.HashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
+    assertEquals(hashMapCollide6.updateWith("")(insertIfAbsent), Some("c"))
+    assertEquals(hashMapCollide6, mutable.HashMap(0 -> "a", (null: Any) -> "b", "" -> "c"))
+
+    val hashMapCollide7 = mutable.HashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
+    assertEquals(hashMapCollide7.updateWith("")(overwrite), Some("X"))
+    assertEquals(hashMapCollide7, mutable.HashMap(0 -> "a", (null: Any) -> "b", "" -> "X"))
+
+
+    var count = 0
+    val countingKey1 = new Object{
+      override def hashCode() = {
+        count += 1
+        super.hashCode()
+      }
+    }
+    val countingKey2 = new Object{
+      override def hashCode() = {
+        count += 1
+        super.hashCode()
+      }
+    }
+
+    val hashMapCount1 = mutable.HashMap(countingKey1 -> "a")
+    assertEquals(hashMapCount1.updateWith(countingKey1)(overwrite), Some("X"))
+    assertEquals(2, count) // once during hashtable construction, once during updateWith
+    assertEquals(hashMapCount1, mutable.HashMap(countingKey1 -> "X"))
+
+    count = 0
+    val hashMapCount2 = mutable.HashMap(countingKey1 -> "a")
+    assertEquals(hashMapCount2.updateWith(countingKey2)(overwrite), Some("X"))
+    assertEquals(2, count) // once during hashtable construction, once during updateWith
+    assertEquals(hashMapCount2, mutable.HashMap(countingKey1 -> "a", countingKey2 -> "X"))
+
+    count = 0
+    val hashMapCount3 = mutable.HashMap(countingKey1 -> "a")
+    assertEquals(hashMapCount3.updateWith(countingKey1)(transform), Some("a2"))
+    assertEquals(2, count) // once during hashtable construction, once during updateWith
+    assertEquals(hashMapCount3, mutable.HashMap(countingKey1 -> "a2"))
+
+    count = 0
+    val hashMapCount4 = mutable.HashMap(countingKey1 -> "a")
+    assertEquals(hashMapCount4.updateWith(countingKey2)(transform), None)
+    assertEquals(2, count) // once during hashtable construction, once during updateWith
+    assertEquals(hashMapCount4, mutable.HashMap(countingKey1 -> "a"))
+
   }
 }

--- a/test/junit/scala/collection/mutable/LinkedHashMapTest.scala
+++ b/test/junit/scala/collection/mutable/LinkedHashMapTest.scala
@@ -1,5 +1,6 @@
 package scala.collection.mutable
 
+import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.{ Assert, Test }
@@ -21,5 +22,149 @@ class LinkedHashMapTest {
     Assert.assertNotNull(lhm.lastItemRef)
     lhm.clear()
     Assert.assertNull(lhm.lastItemRef)
+  }
+
+  @Test
+  def testUpdateWith(): Unit = {
+    val insertIfAbsent: Option[String] => Option[String] = _.orElse(Some("b"))
+
+    val hashMap1 = mutable.LinkedHashMap(1 -> "a")
+    assertEquals(hashMap1.updateWith(1)(insertIfAbsent), Some("a"))
+    assertEquals(hashMap1, mutable.LinkedHashMap(1 -> "a"))
+
+    val hashMap2 = mutable.LinkedHashMap(1 -> "a")
+    assertEquals(hashMap2.updateWith(2)(insertIfAbsent), Some("b"))
+    assertEquals(hashMap2, mutable.LinkedHashMap(1 -> "a", 2 -> "b"))
+
+    val noneAnytime: Option[String] => Option[String] =  _ => None
+
+    val hashMap3 = mutable.LinkedHashMap(1 -> "a")
+    assertEquals(hashMap3.updateWith(1)(noneAnytime), None)
+    assertEquals(hashMap3, mutable.LinkedHashMap())
+
+    val hashMap4 = mutable.LinkedHashMap(1 -> "a")
+    assertEquals(hashMap4.updateWith(2)(noneAnytime), None)
+    assertEquals(hashMap4, mutable.LinkedHashMap(1 -> "a"))
+
+    val flip: Option[String] => Option[String] =  {
+      case None => Some("X")
+      case Some(x) => None}
+
+    val hashMap5 = mutable.LinkedHashMap(1 -> "a")
+    assertEquals(hashMap5.updateWith(1)(flip), None)
+    assertEquals(hashMap5, mutable.LinkedHashMap())
+
+    val hashMap6 = mutable.LinkedHashMap(1 -> "a")
+    assertEquals(hashMap6.updateWith(2)(flip), Some("X"))
+    assertEquals(hashMap6, mutable.LinkedHashMap(1 -> "a", 2 -> "X"))
+
+    val transform: Option[String] => Option[String] =  _.map(_ + "2")
+
+    val hashMap7 = mutable.LinkedHashMap(1 -> "a")
+    assertEquals(hashMap7.updateWith(1)(transform), Some("a2"))
+    assertEquals(hashMap7, mutable.LinkedHashMap(1 -> "a2"))
+
+    val hashMap8 = mutable.LinkedHashMap(1 -> "a")
+    assertEquals(hashMap8.updateWith(2)(transform), None)
+    assertEquals(hashMap8, mutable.LinkedHashMap(1 -> "a"))
+
+    val overwrite: Option[String] => Option[String] = _ => Some("X")
+
+    val hashMap9 = mutable.LinkedHashMap(1 -> "a")
+    assertEquals(hashMap9.updateWith(1)(overwrite), Some("X"))
+    assertEquals(hashMap9, mutable.LinkedHashMap(1 -> "X"))
+
+    val hashMap10 = mutable.LinkedHashMap(1 -> "a")
+    assertEquals(hashMap10.updateWith(2)(overwrite), Some("X"))
+    assertEquals(hashMap10, mutable.LinkedHashMap(1 -> "a", 2 -> "X"))
+
+
+    val hashMapMulti1 = mutable.LinkedHashMap(1 -> "a", 2 -> "b")
+    assertEquals(hashMapMulti1.updateWith(2)(noneAnytime), None)
+    assertEquals(hashMapMulti1, mutable.LinkedHashMap(1 -> "a"))
+
+    val hashMapMulti2 = mutable.LinkedHashMap(1 -> "a", 2 -> "b")
+    assertEquals(hashMapMulti2.updateWith(1)(noneAnytime), None)
+    assertEquals(hashMapMulti2, mutable.LinkedHashMap(2 -> "b"))
+
+    val hashMapMulti3 = mutable.LinkedHashMap(1 -> "a", 2 -> "b", 3 -> "c")
+    assertEquals(hashMapMulti3.updateWith(1)(noneAnytime), None)
+    assertEquals(hashMapMulti3, mutable.LinkedHashMap(2 -> "b", 3 -> "c"))
+
+    val hashMapMulti4 = mutable.LinkedHashMap(1 -> "a", 2 -> "b", 3 -> "c")
+    assertEquals(hashMapMulti4.updateWith(2)(noneAnytime), None)
+    assertEquals(hashMapMulti4, mutable.LinkedHashMap(1 -> "a", 3 -> "c"))
+
+    val hashMapMulti5 = mutable.LinkedHashMap(1 -> "a", 2 -> "b", 3 -> "c")
+    assertEquals(hashMapMulti5.updateWith(3)(noneAnytime), None)
+    assertEquals(hashMapMulti5, mutable.LinkedHashMap(1 -> "a", 2 -> "b"))
+
+
+    val hashMapCollide1 = mutable.LinkedHashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
+    assertEquals(hashMapCollide1.updateWith(0)(noneAnytime), None)
+    assertEquals(hashMapCollide1, mutable.LinkedHashMap((null: Any) -> "b", "" -> "c"))
+
+    val hashMapCollide2 = mutable.LinkedHashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
+    assertEquals(hashMapCollide2.updateWith((null: Any))(noneAnytime), None)
+    assertEquals(hashMapCollide2, mutable.LinkedHashMap(0 -> "a", "" -> "c"))
+
+    val hashMapCollide3 = mutable.LinkedHashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
+    assertEquals(hashMapCollide3.updateWith("")(noneAnytime), None)
+    assertEquals(hashMapCollide3, mutable.LinkedHashMap(0 -> "a", (null: Any) -> "b"))
+
+    val hashMapCollide4 = mutable.LinkedHashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
+    assertEquals(hashMapCollide4.updateWith(())(noneAnytime), None)
+    assertEquals(hashMapCollide4, mutable.LinkedHashMap(0 -> "a", (null: Any) -> "b", "" -> "c"))
+
+    val hashMapCollide5 = mutable.LinkedHashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
+    assertEquals(hashMapCollide5.updateWith(())(insertIfAbsent), Some("b"))
+    assertEquals(hashMapCollide5, mutable.LinkedHashMap(0 -> "a", (null: Any) -> "b", "" -> "c", () -> "b"))
+
+    val hashMapCollide6 = mutable.LinkedHashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
+    assertEquals(hashMapCollide6.updateWith("")(insertIfAbsent), Some("c"))
+    assertEquals(hashMapCollide6, mutable.LinkedHashMap(0 -> "a", (null: Any) -> "b", "" -> "c"))
+
+    val hashMapCollide7 = mutable.LinkedHashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
+    assertEquals(hashMapCollide7.updateWith("")(overwrite), Some("X"))
+    assertEquals(hashMapCollide7, mutable.LinkedHashMap(0 -> "a", (null: Any) -> "b", "" -> "X"))
+
+
+    var count = 0
+    val countingKey1 = new Object{
+      override def hashCode() = {
+        count += 1
+        super.hashCode()
+      }
+    }
+    val countingKey2 = new Object{
+      override def hashCode() = {
+        count += 1
+        super.hashCode()
+      }
+    }
+
+    val hashMapCount1 = mutable.LinkedHashMap(countingKey1 -> "a")
+    assertEquals(hashMapCount1.updateWith(countingKey1)(overwrite), Some("X"))
+    assertEquals(2, count) // once during hashtable construction, once during updateWith
+    assertEquals(hashMapCount1, mutable.LinkedHashMap(countingKey1 -> "X"))
+
+    count = 0
+    val hashMapCount2 = mutable.LinkedHashMap(countingKey1 -> "a")
+    assertEquals(hashMapCount2.updateWith(countingKey2)(overwrite), Some("X"))
+    assertEquals(2, count) // once during hashtable construction, once during updateWith
+    assertEquals(hashMapCount2, mutable.LinkedHashMap(countingKey1 -> "a", countingKey2 -> "X"))
+
+    count = 0
+    val hashMapCount3 = mutable.LinkedHashMap(countingKey1 -> "a")
+    assertEquals(hashMapCount3.updateWith(countingKey1)(transform), Some("a2"))
+    assertEquals(2, count) // once during hashtable construction, once during updateWith
+    assertEquals(hashMapCount3, mutable.LinkedHashMap(countingKey1 -> "a2"))
+
+    count = 0
+    val hashMapCount4 = mutable.LinkedHashMap(countingKey1 -> "a")
+    assertEquals(hashMapCount4.updateWith(countingKey2)(transform), None)
+    assertEquals(2, count) // once during hashtable construction, once during updateWith
+    assertEquals(hashMapCount4, mutable.LinkedHashMap(countingKey1 -> "a"))
+
   }
 }


### PR DESCRIPTION
mutable version of https://github.com/scala/scala/pull/8032

This allows us to only hash the input key and perform the hash table lookup once, rather than twice

Mostly code cribbed from the existing methods in `mutable.HashMap`, inlined and mangled so we can avoid performing the key-hashing and table-lookup more than once. Instead we store the `foundNode` and `previousNode` (either or both of which can be `null`) and mangle the `next` pointers to add things to the table/linked-list, remove things from the table/linked-list, or just update `Node.value` in place if there was already a previous value we are updating.

For `mutable.HashMap`, removals occur in-place and additions occur in the order defined by `put0`. For `mutable.LinkedHashMap`, removals occur in place and additions occur at the tail of the linked list.

I've added a pretty thorough test suite to `HashMapTests` and `LinkedHashMapTests` exercising this code in a variety of situations:

- Various transform functions
- Hash collisions
- Adding and removing from the start, middle, and end of the linked list
- Checking that `.hashCode` is only called once per `updateWith` call

Also added benchmarks, which show a measurable improvement to the performance of both operations:

```text
BEFORE

[info] Result "scala.collection.mutable.HashMapBenchmark.updateWith":
[info]   31181.097 ±(99.9%) 26909.915 ns/op [Average]
[info]   (min, avg, max) = (29481.979, 31181.097, 32132.847), stdev = 1475.023
[info]   CI (99.9%): [4271.182, 58091.012] (assumes normal distribution)
[info] # Run complete. Total time: 00:00:34
[info] Benchmark                    (size)  (stringsOnly)  (useMissingValues)  Mode  Cnt      Score       Error  Units
[info] HashMapBenchmark.updateWith      10          false                true  avgt    3    273.904 ±    14.262  ns/op
[info] HashMapBenchmark.updateWith     100          false                true  avgt    3   2623.131 ±   109.200  ns/op
[info] HashMapBenchmark.updateWith    1000          false                true  avgt    3  31181.097 ± 26909.915  ns/op

[info] Result "scala.collection.mutable.LinkedHashMapBenchmark.updateWith":
[info]   46182.148 ±(99.9%) 61228.785 ns/op [Average]
[info]   (min, avg, max) = (43733.960, 46182.148, 50007.889), stdev = 3356.156
[info]   CI (99.9%): [≈ 0, 107410.933] (assumes normal distribution)
[info] # Run complete. Total time: 00:00:34
[info] Benchmark                          (size)  (stringsOnly)  (useMissingValues)  Mode  Cnt      Score       Error  Units
[info] LinkedHashMapBenchmark.updateWith      10          false                true  avgt    3    373.098 ±   115.872  ns/op
[info] LinkedHashMapBenchmark.updateWith     100          false                true  avgt    3   3942.097 ±   404.435  ns/op
[info] LinkedHashMapBenchmark.updateWith    1000          false                true  avgt    3  46182.148 ± 61228.785  ns/op

AFTER

[info] Result "scala.collection.mutable.HashMapBenchmark.updateWith":
[info]   29130.178 ±(99.9%) 28853.438 ns/op [Average]
[info]   (min, avg, max) = (27308.944, 29130.178, 30157.602), stdev = 1581.554
[info]   CI (99.9%): [276.740, 57983.617] (assumes normal distribution)
[info] # Run complete. Total time: 00:00:34
[info] Benchmark                    (size)  (stringsOnly)  (useMissingValues)  Mode  Cnt      Score       Error  Units
[info] HashMapBenchmark.updateWith      10          false                true  avgt    3    257.002 ±    21.512  ns/op
[info] HashMapBenchmark.updateWith     100          false                true  avgt    3   2558.933 ±   347.473  ns/op
[info] HashMapBenchmark.updateWith    1000          false                true  avgt    3  29130.178 ± 28853.438  ns/op

[info] Result "scala.collection.mutable.LinkedHashMapBenchmark.updateWith":
[info]   37820.263 ±(99.9%) 27136.733 ns/op [Average]
[info]   (min, avg, max) = (36472.498, 37820.263, 39416.194), stdev = 1487.456
[info]   CI (99.9%): [10683.531, 64956.996] (assumes normal distribution)
[info] # Run complete. Total time: 00:00:34
[info] Benchmark                          (size)  (stringsOnly)  (useMissingValues)  Mode  Cnt      Score       Error  Units
[info] LinkedHashMapBenchmark.updateWith      10          false                true  avgt    3    284.379 ±     7.107  ns/op
[info] LinkedHashMapBenchmark.updateWith     100          false                true  avgt    3   3033.440 ±   180.528  ns/op
[info] LinkedHashMapBenchmark.updateWith    1000          false                true  avgt    3  37820.263 ± 27136.733  ns/op
```

It seems `LinkedHashMap` benefits more than `HashMap`, with a 24% reduction in time vs a 6% reduction in time per operation. I expect this improvement to be greater in real world scenarios where `.hashCode` of the keys is non-trivial.

Not sure if there's a way for us to reasonably share code between the two effectively-identical unit test suites, but for now it's all just copy-pasta