### PR TITLE
override mutable.LinkedHashMap#updateWith for performance

### DIFF
--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -179,7 +179,8 @@ class LinkedHashMap[K, V]
       else Iterator.empty.next()
   }
 
-
+  // Override updateWith for performance, so we can do the update while hashing
+  // the input key only once and performing one lookup into the hash table
   override def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = {
     val keyHash = table.elemHashCode(key)
     val keyIndex = table.index(keyHash)

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -202,8 +202,6 @@ class LinkedHashMap[K, V]
 
       case (None, Some(value)) =>
         table.addEntry0(table.createNewEntry(key, value), keyIndex)
-        val e = table.findOrAddEntry(key, value)
-        if (e ne null) e.value = value
 
       case (Some(_), Some(value)) =>
         entry.value = value


### PR DESCRIPTION
Sister PR to https://github.com/scala/scala/pull/8073 and https://github.com/scala/scala/pull/8032, except for `mutable.LinkedHashMap` instead. Most of https://github.com/scala/scala/pull/8073 's PR description applies to this too