### PR TITLE
Experimental support for outline type checking

### DIFF
--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -489,8 +489,12 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
         command.settings.Ymacroexpand.value = command.settings.MacroExpand.None
         val run1 = new compiler.Run()
         run1 compile files
-        registerPickleClassPath(command.settings.outputDirs.getSingleOutput.get.file.toPath, run1.symData)
         outlineTimer.stop()
+        log(f"scalac outline: done ${outlineTimer.durationMs}%.0f ms")
+        pickleExportTimer.start()
+        registerPickleClassPath(command.settings.outputDirs.getSingleOutput.get.file.toPath, run1.symData)
+        pickleExportTimer.stop()
+        log(f"scalac: exported pickles ${pickleExportTimer.durationMs}%.0f ms")
         reporter.finish()
         if (reporter.hasErrors) {
           log("scalac outline: failed")

--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -17,32 +17,28 @@ import java.lang.Thread.UncaughtExceptionHandler
 import java.nio.file.attribute.FileTime
 import java.nio.file.{Files, Path, Paths}
 import java.time.Instant
-import java.util.Collections
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.{Collections, Locale}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
-import javax.tools.ToolProvider
+import javax.tools.Diagnostic.Kind
+import javax.tools.{Diagnostic, DiagnosticListener, JavaFileObject, ToolProvider}
 
-import scala.collection.JavaConverters.asScalaIteratorConverter
+import scala.collection.JavaConverters._
 import scala.collection.{immutable, mutable, parallel}
 import scala.concurrent._
 import scala.concurrent.duration.Duration
 import scala.reflect.internal.pickling.PickleBuffer
-import scala.reflect.internal.util.FakePos
-import scala.reflect.io.RootPath
+import scala.reflect.internal.util.{BatchSourceFile, FakePos, Position}
+import scala.reflect.io.{PlainNioFile, RootPath}
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.reporters.{ConsoleReporter, Reporter}
 import scala.tools.nsc.util.ClassPath
 import scala.util.{Failure, Success, Try}
-import PipelineMain.{BuildStrategy, Pipeline, Traditional}
+import PipelineMain.{Pipeline, Traditional}
 
-class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy, argFiles: Seq[Path], useJars: Boolean) {
-  private val pickleCacheConfigured = System.getProperty("scala.pipeline.picklecache")
-  private val pickleCache: Path = {
-    if (pickleCacheConfigured == null) Files.createTempDirectory("scala.picklecache")
-    else {
-      Paths.get(pickleCacheConfigured)
-    }
-  }
+class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.PipelineSettings) {
+  import pipelineSettings._
+  private val pickleCache: Path = configuredPickleCache.getOrElse(Files.createTempDirectory("scala.picklecache"))
   private def cachePath(file: Path): Path = {
     val newExtension = if (useJars) ".jar" else ""
     changeExtension(pickleCache.resolve("./" + file).normalize(), newExtension)
@@ -120,7 +116,7 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
   }
 
 
-  def writeDotFile(dependsOn: mutable.LinkedHashMap[Task, List[Dependency]]): Unit = {
+  def writeDotFile(logDir: Path, dependsOn: mutable.LinkedHashMap[Task, List[Dependency]]): Unit = {
     val builder = new java.lang.StringBuilder()
     builder.append("digraph projects {\n")
     for ((p, deps) <- dependsOn) {
@@ -133,17 +129,16 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
       }
     }
     builder.append("}\n")
-    val path = Paths.get("projects.dot")
+    val path = logDir.resolve("projects.dot")
     Files.write(path, builder.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8))
-    println("Wrote project dependency graph to: " + path.toAbsolutePath)
+    reporter.echo("Wrote project dependency graph to: " + path.toAbsolutePath)
   }
 
   private case class Dependency(t: Task, isMacro: Boolean, isPlugin: Boolean)
 
   def process(): Boolean = {
-    println(s"parallelism = $parallelism, strategy = $strategy")
-
-    reporter = new ConsoleReporter(new Settings(scalacError))
+    reporter = createReporter(new Settings(scalacError))
+    reporter.echo(s"parallelism = $parallelism, strategy = $strategy")
 
     def commandFor(argFileArg: Path): Task = {
       val ss = new Settings(scalacError)
@@ -152,6 +147,8 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
     }
 
     val projects: List[Task] = argFiles.toList.map(commandFor)
+    if (reporter.hasErrors) return false
+
     val numProjects = projects.size
     val produces = mutable.LinkedHashMap[Path, Task]()
     for (p <- projects) {
@@ -168,26 +165,26 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
     val externalClassPath = projects.iterator.flatMap(_.classPath).filter(p => !produces.contains(p) && Files.exists(p)).toSet
 
     if (strategy != Traditional) {
-      val exportTimer = new Timer
-      exportTimer.start()
-      for (entry <- externalClassPath) {
-        val extracted = cachePath(entry)
-        val sourceTimeStamp = Files.getLastModifiedTime(entry)
-        if (Files.exists(extracted) && Files.getLastModifiedTime(extracted) == sourceTimeStamp) {
-          // println(s"Skipped export of pickles from $entry to $extracted (up to date)")
-        } else {
-          PickleExtractor.process(entry, extracted)
-          Files.setLastModifiedTime(extracted, sourceTimeStamp)
-          println(s"Exported pickles from $entry to $extracted")
-          Files.setLastModifiedTime(extracted, sourceTimeStamp)
+      if (stripExternalClassPath) {
+        val exportTimer = new Timer
+        exportTimer.start()
+        for (entry <- externalClassPath) {
+          val extracted = cachePath(entry)
+          val sourceTimeStamp = Files.getLastModifiedTime(entry)
+          if (Files.exists(extracted) && Files.getLastModifiedTime(extracted) == sourceTimeStamp) {
+            // println(s"Skipped export of pickles from $entry to $extracted (up to date)")
+          } else {
+            PickleExtractor.process(entry, extracted)
+            Files.setLastModifiedTime(extracted, sourceTimeStamp)
+            reporter.echo(s"Exported pickles from $entry to $extracted")
+            Files.setLastModifiedTime(extracted, sourceTimeStamp)
+          }
+          strippedAndExportedClassPath(entry) = extracted
         }
-        strippedAndExportedClassPath(entry) = extracted
+        exportTimer.stop()
+        reporter.echo(f"Exported external classpath in ${exportTimer.durationMs}%.0f ms")
       }
-      exportTimer.stop()
-      println(f"Exported external classpath in ${exportTimer.durationMs}%.0f ms")
     }
-
-    writeDotFile(dependsOn)
 
     val timer = new Timer
     timer.start()
@@ -197,9 +194,12 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
       val allFutures = projects.flatMap(_.futures)
       val count = allFutures.size
       val counter = new AtomicInteger(count)
+      val failed = new AtomicBoolean(false)
       val handler = (a: Try[_]) => a match {
         case f @ Failure(_) =>
-          done.complete(f)
+          if (failed.compareAndSet(false, true)) {
+            done.complete(f)
+          }
         case Success(_) =>
           val remaining = counter.decrementAndGet()
           if (remaining == 0) done.success(())
@@ -213,28 +213,28 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
       val allFutures: immutable.Seq[Future[_]] = projects.flatMap(_.futures)
       val numAllFutures = allFutures.size
       val awaitAllFutures: Future[_] = awaitAll(allFutures)
-      val numTasks = awaitAllFutures
       var lastNumCompleted = allFutures.count(_.isCompleted)
       while (true) try {
         Await.result(awaitAllFutures, Duration(60, "s"))
         timer.stop()
         val numCompleted = allFutures.count(_.isCompleted)
-        println(s"PROGRESS: $numCompleted / $numAllFutures")
+        reporter.echo(s"PROGRESS: $numCompleted / $numAllFutures")
         return
       } catch {
         case _: TimeoutException =>
           val numCompleted = allFutures.count(_.isCompleted)
           if (numCompleted == lastNumCompleted) {
-            println(s"STALLED: $numCompleted / $numAllFutures")
-            println("Outline/Scala/Javac")
+            reporter.echo(s"STALLED: $numCompleted / $numAllFutures")
+            reporter.echo("Outline/Scala/Javac")
             projects.map {
               p =>
                 def toX(b: Future[_]): String = b.value match { case None => "-"; case Some(Success(_)) => "x"; case Some(Failure(_)) => "!" }
                 val s = List(p.outlineDoneFuture, p.groupsDoneFuture, p.javaDoneFuture).map(toX).mkString(" ")
-                println(s + " " + p.label)
+                reporter.echo(s + " " + p.label)
             }
           } else {
-            println(s"PROGRESS: $numCompleted / $numAllFutures")
+            reporter.echo(s"PROGRESS: $numCompleted / $numAllFutures")
+            lastNumCompleted = numCompleted
           }
       }
     }
@@ -246,7 +246,7 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
             _ <- depsReady
             _ <- {
               val isLeaf = !dependedOn.contains(p)
-              if (isLeaf) {
+              if (isLeaf && useTraditionalForLeaf) {
                 p.outlineDone.complete(Success(()))
                 p.fullCompile()
               } else
@@ -274,16 +274,17 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
 
         if (parallelism == 1) {
           val criticalPath = projects.maxBy(_.regularCriticalPathMs)
-          println(f"Critical path: ${criticalPath.regularCriticalPathMs}%.0f ms. Wall Clock: ${timer.durationMs}%.0f ms")
+          reporter.echo(f"Critical path: ${criticalPath.regularCriticalPathMs}%.0f ms. Wall Clock: ${timer.durationMs}%.0f ms")
         } else
-          println(f" Wall Clock: ${timer.durationMs}%.0f ms")
+          reporter.echo(f" Wall Clock: ${timer.durationMs}%.0f ms")
       case Traditional =>
         projects.foreach { p =>
           val f1 = Future.traverse(dependsOn.getOrElse(p, Nil))(_.t.javaDone.future)
           val f2 = f1.flatMap { _ =>
             p.outlineDone.complete(Success(()))
             p.fullCompile()
-            Future.traverse(p.groups)(_.done.future).map(_ => p.javaCompile())
+            val eventualUnits: Future[List[Unit]] = Future.traverse(p.groups)(_.done.future)
+            eventualUnits.map(_ => p.javaCompile())
           }
           f2.onComplete { _ => p.compiler.close() }
         }
@@ -298,24 +299,28 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
         }
         if (parallelism == 1) {
           val maxFullCriticalPath: Double = projects.map(_.fullCriticalPathMs).max
-          println(f"Critical path: $maxFullCriticalPath%.0f ms. Wall Clock: ${timer.durationMs}%.0f ms")
+          reporter.echo(f"Critical path: $maxFullCriticalPath%.0f ms. Wall Clock: ${timer.durationMs}%.0f ms")
         } else {
-          println(f"Wall Clock: ${timer.durationMs}%.0f ms")
+          reporter.echo(f"Wall Clock: ${timer.durationMs}%.0f ms")
         }
     }
 
-    writeChromeTrace(projects)
+    logDir.foreach { dir =>
+      Files.createDirectories(dir)
+      writeDotFile(dir, dependsOn)
+      writeChromeTrace(dir, projects)
+    }
     deleteTempPickleCache()
     true
   }
 
   private def deleteTempPickleCache(): Unit = {
-    if (pickleCacheConfigured == null) {
+    if (configuredPickleCache.isEmpty) {
       AbstractFile.getDirectory(pickleCache.toFile).delete()
     }
   }
 
-  private def writeChromeTrace(projects: List[Task]) = {
+  private def writeChromeTrace(logDir: Path, projects: List[Task]) = {
     val trace = new java.lang.StringBuilder()
     trace.append("""{"traceEvents": [""")
     val sb = new mutable.StringBuilder(trace)
@@ -344,9 +349,9 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
 
     projects.iterator.flatMap(projectEvents).addString(sb, ",\n")
     trace.append("]}")
-    val traceFile = Paths.get(s"build-${label}.trace")
+    val traceFile = logDir.resolve(s"build-${label}.trace")
     Files.write(traceFile, trace.toString.getBytes())
-    println("Chrome trace written to " + traceFile.toAbsolutePath)
+    reporter.echo("Chrome trace written to " + traceFile.toAbsolutePath)
   }
 
   case class Group(files: List[String]) {
@@ -355,7 +360,7 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
   }
 
   private case class Task(argsFile: Path, command: CompilerCommand, files: List[String]) {
-    val label = argsFile.toString.replaceAll("target/", "").replaceAll("""(.*)/(.*).args""", "$1:$2")
+    val label = argsFile.toString.replaceAll(".*/target/", "").replaceAll("""(.*)/(.*).args""", "$1:$2")
     override def toString: String = argsFile.toString
     def outputDir: Path = command.settings.outputDirs.getSingleOutput.get.file.toPath.toAbsolutePath.normalize()
     private def expand(s: command.settings.PathSetting): List[Path] = {
@@ -380,8 +385,6 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
       dependency.t.outlineDone.future
 
 
-    val cacheMacro = java.lang.Boolean.getBoolean("scala.pipeline.cache.macro.classloader")
-    val cachePlugin = java.lang.Boolean.getBoolean("scala.pipeline.cache.plugin.classloader")
     if (cacheMacro)
       command.settings.YcacheMacroClassLoader.value = "always"
     if (cachePlugin)
@@ -391,6 +394,8 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
       command.settings.YpickleJava.value = true
     }
 
+    val groupSize = Integer.getInteger("scala.pipeline.group.size", 128)
+
     val groups: List[Group] = {
       val isScalaLibrary = files.exists(_.endsWith("Predef.scala"))
       if (isScalaLibrary) {
@@ -398,7 +403,7 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
       } else {
         command.settings.classpath.value = command.settings.outputDirs.getSingleOutput.get.toString + File.pathSeparator + command.settings.classpath.value
         val length = files.length
-        val groups = (length.toDouble / 128).toInt.max(1)
+        val groups = (length.toDouble / groupSize).toInt.max(1)
         files.grouped((length.toDouble / groups).ceil.toInt.max(1)).toList.map(Group(_))
       }
     }
@@ -438,8 +443,8 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
         throw t
     }
 
-
     def fullCompile(): Unit = {
+      command.settings.Youtline.value = false
       command.settings.stopAfter.value = Nil
       command.settings.Ymacroexpand.value = command.settings.MacroExpand.Normal
 
@@ -451,9 +456,14 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
             group.timer.start()
             val compiler2 = newCompiler(command.settings)
             try {
-              val run2 = new compiler2.Run()
-              run2 compile group.files
-              compiler2.reporter.finish()
+              try {
+                val run2 = new compiler2.Run()
+                run2 compile group.files
+                compiler2.reporter.finish()
+              } finally {
+                group.timer.stop()
+                log(f"scalac (${ix + 1}/$groupCount): done ${group.timer.durationMs}%.0f ms")
+              }
               if (compiler2.reporter.hasErrors) {
                 group.done.complete(Failure(new RuntimeException(label + ": compile failed: ")))
               } else {
@@ -461,9 +471,7 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
               }
             } finally {
               compiler2.close()
-              group.timer.stop()
             }
-            log(f"scalac (${ix + 1}/$groupCount): done ${group.timer.durationMs}%.0f ms")
           }
         }
       }
@@ -521,19 +529,40 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
         log("javac: start")
         javaTimer.start()
         javaDone.completeWith(Future {
-          val opts = java.util.Arrays.asList("-d", command.settings.outdir.value, "-cp", command.settings.outdir.value + File.pathSeparator + originalClassPath)
-          val compileTask = ToolProvider.getSystemJavaCompiler.getTask(null, null, null, opts, null, fileManager.getJavaFileObjects(javaSources.toArray: _*))
+          val opts: java.util.List[String] = java.util.Arrays.asList("-d", command.settings.outdir.value, "-cp", command.settings.outdir.value + File.pathSeparator + originalClassPath)
+          val compiler = ToolProvider.getSystemJavaCompiler
+          val listener = new DiagnosticListener[JavaFileObject] {
+            override def report(diagnostic: Diagnostic[_ <: JavaFileObject]): Unit = {
+              val msg = diagnostic.getMessage(Locale.getDefault)
+              val source: JavaFileObject = diagnostic.getSource
+              val path = Paths.get(source.toUri)
+              val sourceFile = new BatchSourceFile(new PlainNioFile(path))
+              val position = Position.range(sourceFile, diagnostic.getStartPosition.toInt, diagnostic.getPosition.toInt, diagnostic.getEndPosition.toInt)
+              diagnostic.getKind match {
+                case Kind.ERROR => reporter.error(position, msg)
+                case Kind.WARNING | Kind.MANDATORY_WARNING => reporter.warning(position, msg)
+                case Kind.NOTE => reporter.info(position, msg, true)
+                case Kind.OTHER => reporter.echo(position, msg)
+              }
+            }
+          }
+          val fileManager = ToolProvider.getSystemJavaCompiler.getStandardFileManager(null, null, null)
+          val compileTask = compiler.getTask(null, fileManager, listener, opts, null, fileManager.getJavaFileObjects(javaSources.toArray: _*))
           compileTask.setProcessors(Collections.emptyList())
-          compileTask.call()
-          javaTimer.stop()
-          log(f"javac: done ${javaTimer.durationMs}%.0f ms")
+          if (compileTask.call()) {
+            javaTimer.stop()
+            log(f"javac: done ${javaTimer.durationMs}%.0f ms ")
+          } else {
+            javaTimer.stop()
+            log(f"javac: error ${javaTimer.durationMs}%.0f ms ")
+          }
           ()
         })
       } else {
         javaDone.complete(Success(()))
       }
     }
-    def log(msg: String): Unit = println(this.label + ": " + msg)
+    def log(msg: String): Unit = reporter.echo(this.label + ": " + msg)
   }
 
   final class Timer() {
@@ -579,24 +608,39 @@ class PipelineMainClass(label: String, parallelism: Int, strategy: BuildStrategy
 object PipelineMain {
   sealed abstract class BuildStrategy
 
-  /** Begin compilation as soon as the pickler phase is complete on all dependencies. */
+  /** Transport pickles as an input to downstream compilation. */
   case object Pipeline extends BuildStrategy
 
   /** Emit class files before triggering downstream compilation */
   case object Traditional extends BuildStrategy
 
-  def main(args: Array[String]): Unit = {
+  case class PipelineSettings(label: String, parallelism: Int, strategy: BuildStrategy, useJars: Boolean,
+                              configuredPickleCache: Option[Path], cacheMacro: Boolean, cachePlugin: Boolean,
+                              stripExternalClassPath: Boolean, useTraditionalForLeaf: Boolean, logDir: Option[Path],
+                              createReporter: (Settings => Reporter))
+  def defaultSettings: PipelineSettings = {
     val strategies = List(Pipeline, Traditional)
     val strategy = strategies.find(_.productPrefix.equalsIgnoreCase(System.getProperty("scala.pipeline.strategy", "pipeline"))).get
     val parallelism = java.lang.Integer.getInteger("scala.pipeline.parallelism", parallel.availableProcessors)
     val useJars = java.lang.Boolean.getBoolean("scala.pipeline.use.jar")
+    val cacheMacro = java.lang.Boolean.getBoolean("scala.pipeline.cache.macro.classloader")
+    val cachePlugin = java.lang.Boolean.getBoolean("scala.pipeline.cache.plugin.classloader")
+    val stripExternalClassPath = java.lang.Boolean.getBoolean("scala.pipeline.strip.external.classpath")
+    val useTraditionalForLeaf = java.lang.Boolean.getBoolean("scala.pipeline.use.traditional.for.leaf")
+    val configuredPickleCache = Option(System.getProperty("scala.pipeline.picklecache")).map(Paths.get(_))
+    val logDir = Paths.get(".")
+    new PipelineSettings("1", parallelism, strategy, useJars, configuredPickleCache,
+      cacheMacro, cachePlugin, stripExternalClassPath, useTraditionalForLeaf, Some(logDir), new ConsoleReporter(_))
+  }
+
+  def main(args: Array[String]): Unit = {
     val argFiles: Seq[Path] = args match {
       case Array(path) if Files.isDirectory(Paths.get(path)) =>
         Files.walk(Paths.get(path)).iterator().asScala.filter(_.getFileName.toString.endsWith(".args")).toList
       case _ =>
         args.map(Paths.get(_))
     }
-    val main = new PipelineMainClass("1", parallelism, strategy, argFiles, useJars)
+    val main = new PipelineMainClass(argFiles, defaultSettings)
     val result = main.process()
     if (!result)
       System.exit(1)
@@ -608,10 +652,12 @@ object PipelineMain {
 //object PipelineMainTest {
 //  def main(args: Array[String]): Unit = {
 //    var i = 0
-//    val argsFiles = Files.walk(Paths.get("/code/guardian-frontend")).iterator().asScala.filter(_.getFileName.toString.endsWith(".args")).toList
-//    for (_ <- 1 to 2; n <- List(parallel.availableProcessors); strat <- List(Pipeline)) {
+////    val argsFiles = Files.walk(Paths.get("/code/guardian-frontend")).iterator().asScala.filter(_.getFileName.toString.endsWith(".args")).toList
+//    val argsFiles = List(Paths.get("/Users/jz/code/guardian-frontend/common/target/compile.args"))
+//    val useJars = java.lang.Boolean.getBoolean("scala.pipeline.use.jar")
+//    for (_ <- 1 to 20; n <- List(parallel.availableProcessors); strat <- List(OutlineTypePipeline)) {
 //      i += 1
-//      val main = new PipelineMainClass(strat + "-" + i, n, strat, argsFiles, useJars = false)
+//      val main = new PipelineMainClass(strat + "-" + i, n, strat, argsFiles, useJars)
 //      println(s"====== ITERATION $i=======")
 //      val result = main.process()
 //      if (!result)

--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -34,7 +34,7 @@ import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.reporters.{ConsoleReporter, Reporter}
 import scala.tools.nsc.util.ClassPath
 import scala.util.{Failure, Success, Try}
-import PipelineMain.{Pipeline, Traditional}
+import PipelineMain.{OutlineTypePipeline, Pipeline, Traditional}
 
 class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.PipelineSettings) {
   import pipelineSettings._
@@ -239,6 +239,43 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
       }
     }
     strategy match {
+      case OutlineTypePipeline =>
+        projects.foreach { p: Task =>
+          val depsReady = Future.traverse(dependsOn.getOrElse(p, Nil))(task => p.dependencyReadyFuture(task))
+          val f = for {
+            _ <- depsReady
+            _ <- {
+              p.outlineCompile()
+              p.outlineDone.future
+            }
+            _ <- {
+              p.fullCompile()
+              Future.traverse(p.groups)(_.done.future)
+            }
+          } yield {
+            p.javaCompile()
+          }
+          f.onComplete { _ => p.compiler.close() }
+        }
+
+        awaitDone()
+
+        for (p <- projects) {
+          val dependencies = dependsOn(p).map(_.t)
+
+          def maxByOrZero[A](as: List[A])(f: A => Double): Double = if (as.isEmpty) 0d else as.map(f).max
+
+          val maxOutlineCriticalPathMs = maxByOrZero(dependencies)(_.outlineCriticalPathMs)
+          p.outlineCriticalPathMs = maxOutlineCriticalPathMs + p.outlineTimer.durationMs
+          p.regularCriticalPathMs = maxOutlineCriticalPathMs + maxByOrZero(p.groups)(_.timer.durationMs)
+          p.fullCriticalPathMs = maxByOrZero(dependencies)(_.fullCriticalPathMs) + p.groups.map(_.timer.durationMs).sum
+        }
+
+        if (parallelism == 1) {
+          val criticalPath = projects.maxBy(_.regularCriticalPathMs)
+          reporter.echo(f"Critical path: ${criticalPath.regularCriticalPathMs}%.0f ms. Wall Clock: ${timer.durationMs}%.0f ms")
+        } else
+          reporter.echo(f" Wall Clock: ${timer.durationMs}%.0f ms")
       case Pipeline =>
         projects.foreach { p =>
           val depsReady = Future.traverse(dependsOn.getOrElse(p, Nil))(task => p.dependencyReadyFuture(task))
@@ -332,7 +369,7 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
     def projectEvents(p: Task): List[String] = {
       val events = List.newBuilder[String]
       if (p.outlineTimer.durationMicros > 0d) {
-        val desc = "parser-to-pickler"
+        val desc = if (strategy == OutlineTypePipeline) "outline-type" else "parser-to-pickler"
         events += durationEvent(p.label, desc, p.outlineTimer)
         events += durationEvent(p.label, "pickle-export", p.pickleExportTimer)
       }
@@ -398,7 +435,7 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
 
     val groups: List[Group] = {
       val isScalaLibrary = files.exists(_.endsWith("Predef.scala"))
-      if (isScalaLibrary) {
+      if (strategy != OutlineTypePipeline || isScalaLibrary) {
         Group(files) :: Nil
       } else {
         command.settings.classpath.value = command.settings.outputDirs.getSingleOutput.get.toString + File.pathSeparator + command.settings.classpath.value
@@ -441,6 +478,32 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
       case t: Throwable =>
         t.printStackTrace()
         throw t
+    }
+
+    def outlineCompile(): Unit = {
+      outlineTimer.start()
+      try {
+        log("scalac outline: start")
+        command.settings.Youtline.value = true
+        command.settings.stopAfter.value = List("pickler")
+        command.settings.Ymacroexpand.value = command.settings.MacroExpand.None
+        val run1 = new compiler.Run()
+        run1 compile files
+        registerPickleClassPath(command.settings.outputDirs.getSingleOutput.get.file.toPath, run1.symData)
+        outlineTimer.stop()
+        reporter.finish()
+        if (reporter.hasErrors) {
+          log("scalac outline: failed")
+          outlineDone.complete(Failure(new RuntimeException(label + ": compile failed: ")))
+        } else {
+          log(f"scalac outline: done ${outlineTimer.durationMs}%.0f ms")
+          outlineDone.complete(Success(()))
+        }
+      } catch {
+        case t: Throwable =>
+          t.printStackTrace()
+          outlineDone.complete(Failure(new RuntimeException(label + ": compile failed: ")))
+      }
     }
 
     def fullCompile(): Unit = {
@@ -608,6 +671,8 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
 object PipelineMain {
   sealed abstract class BuildStrategy
 
+  /** Outline type check sources to compute type signatures an input to downstream compilation. Compile sources (optionally */
+  case object OutlineTypePipeline extends BuildStrategy
   /** Transport pickles as an input to downstream compilation. */
   case object Pipeline extends BuildStrategy
 
@@ -619,7 +684,7 @@ object PipelineMain {
                               stripExternalClassPath: Boolean, useTraditionalForLeaf: Boolean, logDir: Option[Path],
                               createReporter: (Settings => Reporter))
   def defaultSettings: PipelineSettings = {
-    val strategies = List(Pipeline, Traditional)
+    val strategies = List(OutlineTypePipeline, Pipeline, Traditional)
     val strategy = strategies.find(_.productPrefix.equalsIgnoreCase(System.getProperty("scala.pipeline.strategy", "pipeline"))).get
     val parallelism = java.lang.Integer.getInteger("scala.pipeline.parallelism", parallel.availableProcessors)
     val useJars = java.lang.Boolean.getBoolean("scala.pipeline.use.jar")

--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -768,18 +768,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
              members) ++= decls
         }
       }
-      def forwarders(sdef: Tree): List[Tree] = sdef match {
-        case ClassDef(mods, name, tparams, _) if (parentToken == INTERFACE) =>
-          val tparams1: List[TypeDef] = tparams map (_.duplicate)
-          var rhs: Tree = Select(Ident(parentName.toTermName), name)
-          if (!tparams1.isEmpty) rhs = AppliedTypeTree(rhs, tparams1 map (tp => Ident(tp.name)))
-          List(TypeDef(Modifiers(Flags.PROTECTED), name, tparams1, rhs))
-        case _ =>
-          List()
-      }
-      val sdefs = statics.toList
-      val idefs = members.toList ::: (sdefs flatMap forwarders)
-      (sdefs, idefs)
+      (statics.toList, members.toList)
     }
     def annotationParents = List(
       gen.scalaAnnotationDot(tpnme.Annotation),

--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -112,11 +112,13 @@ trait Analyzer extends AnyRef
         try {
           val typer = newTyper(rootContext(unit))
           unit.body = typer.typed(unit.body)
-          for (workItem <- unit.toCheck) workItem()
-          if (settings.warnUnusedImport)
-            warnUnusedImports(unit)
-          if (settings.warnUnused.isSetByUser)
-            new checkUnused(typer).apply(unit)
+          if (!settings.Youtline.value) {
+            for (workItem <- unit.toCheck) workItem()
+            if (settings.warnUnusedImport)
+              warnUnusedImports(unit)
+            if (settings.warnUnused.isSetByUser)
+              new checkUnused(typer).apply(unit)
+          }
         }
         finally {
           unit.toCheck.clear()

--- a/test/files/pos/java-inherited-type-protobuf/Test.java
+++ b/test/files/pos/java-inherited-type-protobuf/Test.java
@@ -1,0 +1,39 @@
+package example;
+
+public class Test {
+    
+}
+
+class GeneratedMessage extends AbstractMessage {
+    GeneratedMessage(Builder<?> builder) {
+    }
+
+    public abstract static class Builder <BuilderType extends Builder>
+      extends AbstractMessage.Builder<BuilderType> {}
+}
+
+class AbstractMessage extends AbstractMessageLite
+                                      implements Message {
+  public static abstract class Builder<BuilderType extends Builder>
+      extends AbstractMessageLite.Builder<BuilderType>
+      implements Message.Builder {}
+}
+
+class AbstractMessageLite implements MessageLite {
+  public static abstract class Builder<BuilderType extends Builder>
+      implements MessageLite.Builder {
+    }
+
+}
+
+interface Message extends MessageLite, MessageOrBuilder {
+    static interface Builder extends MessageLite.Builder, MessageOrBuilder {}
+}
+
+interface MessageLite extends MessageLiteOrBuilder {
+  interface Builder extends MessageLiteOrBuilder, Cloneable {}
+}
+
+interface MessageLiteOrBuilder {}
+
+interface MessageOrBuilder extends MessageLiteOrBuilder {}

--- a/test/files/pos/java-inherited-type-protobuf/client.scala
+++ b/test/files/pos/java-inherited-type-protobuf/client.scala
@@ -1,0 +1,5 @@
+package example
+
+object Client {
+  new GeneratedMessage(null)
+}

--- a/test/junit/scala/tools/nsc/DeterminismTest.scala
+++ b/test/junit/scala/tools/nsc/DeterminismTest.scala
@@ -1,20 +1,18 @@
 package scala.tools.nsc
 
-import java.io.{File, OutputStreamWriter}
+import java.io.OutputStreamWriter
 import java.nio.charset.Charset
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
-import java.util
 
 import javax.tools.ToolProvider
 import org.junit.Test
 
-import scala.collection.JavaConverters.{asScalaIteratorConverter, seqAsJavaListConverter}
-import scala.collection.immutable
+import scala.collection.JavaConverters.seqAsJavaListConverter
 import scala.language.implicitConversions
 import scala.reflect.internal.util.{BatchSourceFile, SourceFile}
-import scala.reflect.io.PlainNioFile
 import scala.tools.nsc.reporters.StoreReporter
+import FileUtils._
 
 class DeterminismTest {
   @Test def testLambdaLift(): Unit = {
@@ -328,7 +326,7 @@ class DeterminismTest {
       val recompileOutput = Files.createTempDirectory("recompileOutput")
       copyRecursive(referenceOutput, recompileOutput)
       compile(recompileOutput, permutation)
-      assert(diff(referenceOutput, recompileOutput), s"Difference detected between recompiling $permutation Run:\njardiff -r $referenceOutput $recompileOutput\n")
+      assertDirectorySame(referenceOutput, recompileOutput, permutation.toString)
       deleteRecursive(recompileOutput)
     }
     deleteRecursive(referenceOutput)
@@ -336,30 +334,4 @@ class DeterminismTest {
   }
   def permutationsWithSubsets[A](as: List[A]): List[List[A]] =
     as.permutations.toList.flatMap(_.inits.filter(_.nonEmpty)).distinct
-
-  private def diff(dir1: Path, dir2: Path): Boolean = {
-    def allFiles(dir: Path) = Files.walk(dir).iterator().asScala.map(x => (dir.relativize(x), x)).toList.filter(_._2.getFileName.toString.endsWith(".class")).sortBy(_._1.toString)
-
-    val dir1Files = allFiles(dir1)
-    val dir2Files = allFiles(dir2)
-    val identical = dir1Files.corresponds(dir2Files) {
-      case ((rel1, file1), (rel2, file2)) =>
-        rel1 == rel2 && java.util.Arrays.equals(Files.readAllBytes(file1), Files.readAllBytes(file2))
-    }
-    identical
-  }
-  private def deleteRecursive(f: Path) = new PlainNioFile(f).delete()
-  private def copyRecursive(src: Path, dest: Path): Unit = {
-    class CopyVisitor(src: Path, dest: Path) extends SimpleFileVisitor[Path] {
-      override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult = {
-        Files.createDirectories(dest.resolve(src.relativize(dir)))
-        super.preVisitDirectory(dir, attrs)
-      }
-      override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
-        Files.copy(file, dest.resolve(src.relativize(file)))
-        super.visitFile(file, attrs)
-      }
-    }
-    Files.walkFileTree(src, new CopyVisitor(src, dest))
-  }
 }

--- a/test/junit/scala/tools/nsc/FileUtils.scala
+++ b/test/junit/scala/tools/nsc/FileUtils.scala
@@ -1,0 +1,39 @@
+package scala.tools.nsc
+
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+
+import scala.collection.JavaConverters.asScalaIteratorConverter
+import scala.reflect.io.PlainNioFile
+
+object FileUtils {
+  def assertDirectorySame(dir1: Path, dir2: Path, dir2Label: String): Unit = {
+    assert(FileUtils.diff(dir1, dir2), s"Difference detected between recompiling $dir2Label Run:\njardiff -r $dir1 $dir2\n")
+  }
+  def diff(dir1: Path, dir2: Path): Boolean = {
+    def allFiles(dir: Path) = Files.walk(dir).iterator().asScala.map(x => (dir.relativize(x), x)).toList.filter(_._2.getFileName.toString.endsWith(".class")).sortBy(_._1.toString)
+
+    val dir1Files = allFiles(dir1)
+    val dir2Files = allFiles(dir2)
+    val identical = dir1Files.corresponds(dir2Files) {
+      case ((rel1, file1), (rel2, file2)) =>
+        rel1 == rel2 && java.util.Arrays.equals(Files.readAllBytes(file1), Files.readAllBytes(file2))
+    }
+    identical
+  }
+
+  def deleteRecursive(f: Path) = new PlainNioFile(f).delete()
+  def copyRecursive(src: Path, dest: Path): Unit = {
+    class CopyVisitor(src: Path, dest: Path) extends SimpleFileVisitor[Path] {
+      override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        Files.createDirectories(dest.resolve(src.relativize(dir)))
+        super.preVisitDirectory(dir, attrs)
+      }
+      override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        Files.copy(file, dest.resolve(src.relativize(file)))
+        super.visitFile(file, attrs)
+      }
+    }
+    Files.walkFileTree(src, new CopyVisitor(src, dest))
+  }
+}

--- a/test/junit/scala/tools/nsc/PipelineMainTest.scala
+++ b/test/junit/scala/tools/nsc/PipelineMainTest.scala
@@ -80,6 +80,7 @@ class PipelineMainTest {
 
   private lazy val allBuilds = List(m1, b2, b3, b4, b5SuperAccessor)
 
+  // Build containing a macro definition and a reference to it from another internal subproject
   private lazy val m1: Build = {
     val build = new Build(projectsBase, "m1")
     val macroProject = build.project("p1")
@@ -106,6 +107,7 @@ class PipelineMainTest {
     build
   }
 
+  // Build containing a reference to the external macro from `b1`
   private lazy val b2: Build = {
     val build = new Build(projectsBase, "b1")
     val p1 = build.project("p1")
@@ -120,6 +122,9 @@ class PipelineMainTest {
     build
   }
 
+  // Build containing projects with mixed Java/Scala source files.
+  // PipelineMain pickles the API of jointly compiled .java files and
+  // places these on the classpath of downstream scalac invocations.
   private lazy val b3: Build = {
     val build = new Build(projectsBase, "b3")
     val p1 = build.project("p1")
@@ -156,6 +161,7 @@ class PipelineMainTest {
     build
   }
 
+  // External version of `b4.p2`.
   private lazy val b4: Build = {
     val build = new Build(projectsBase, "b4")
     val b3P1 = b3.project("p1")
@@ -178,6 +184,8 @@ class PipelineMainTest {
     build
   }
 
+  // Build containing motivating test case for special handling of `Super` AST nodes
+  // in outline typechecking implementation.
   private lazy val b5SuperAccessor: Build = {
     val build = new Build(projectsBase, "b5")
     val p1 = build.project("p1")

--- a/test/junit/scala/tools/nsc/PipelineMainTest.scala
+++ b/test/junit/scala/tools/nsc/PipelineMainTest.scala
@@ -1,0 +1,260 @@
+package scala.tools.nsc
+
+import java.io.{File, IOException}
+import java.nio.charset.Charset
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+
+import org.junit.{After, Before, Test}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import FileUtils._
+import scala.tools.nsc.PipelineMain._
+import scala.tools.nsc.reporters.{ConsoleReporter, StoreReporter}
+
+class PipelineMainTest {
+  private var base: Path = _
+
+  // Enables verbose output to console to help understand what the test is doing.
+  private val debug = false
+  private var deleteBaseAfterTest = true
+
+  @Before def before(): Unit = {
+    base = Files.createTempDirectory("pipelineBase")
+  }
+
+  @After def after(): Unit = {
+    if (base != null && !debug && deleteBaseAfterTest) {
+      deleteRecursive(base)
+    }
+  }
+
+  private def projectsBase = createDir(base, "projects")
+
+  @Test def pipelineMainBuildsSeparate(): Unit = {
+    check(allBuilds.map(_.projects))
+  }
+
+  @Test def pipelineMainBuildsCombined(): Unit = {
+    check(List(allBuilds.flatMap(_.projects)))
+  }
+
+  private val pipelineSettings = PipelineMain.defaultSettings.copy(
+    useJars = true,
+    parallelism = java.lang.Runtime.getRuntime.availableProcessors,
+    cacheMacro = true,
+    cachePlugin = true,
+    stripExternalClassPath = true,
+    useTraditionalForLeaf = true,
+    createReporter = ((s: Settings) => if (debug) new ConsoleReporter(s) else new StoreReporter())
+  )
+
+  private def check(projectss: List[List[Build#Project]], altStrategies: List[BuildStrategy] = List(Pipeline)): Unit = {
+    def build(strategy: BuildStrategy): Unit = {
+      for (projects <- projectss) {
+        val argsFiles = projects.map(_.argsFile(Nil))
+        val main = new PipelineMainClass(argsFiles, pipelineSettings.copy(strategy = strategy, logDir = Some(base.resolve(strategy.toString))))
+        assert(main.process())
+      }
+    }
+    build(Traditional)
+
+    val reference = snapshotClasses(Traditional)
+    clean()
+    for (strategy <- altStrategies) {
+      build(strategy)
+      val recompiled = snapshotClasses(strategy)
+      // Bytecode should be identical regardless of compilation strategy.
+      deleteBaseAfterTest = false
+      assertDirectorySame(reference, recompiled, strategy.toString)
+      deleteBaseAfterTest = true
+    }
+  }
+
+  private lazy val allBuilds = List(m1, b2, b3, b4)
+
+  private lazy val m1: Build = {
+    val build = new Build(projectsBase, "m1")
+    val macroProject = build.project("p1")
+    macroProject.withSource("m1/p1/Macro.scala")(
+      """
+        |package m1.p1
+        |import reflect.macros.blackbox.Context, language.experimental._
+        |object Macro {
+        |  def m: Unit = macro impl
+        |  def impl(c: Context): c.Tree = {
+        |    import c.universe._
+        |    q"()"
+        |  }
+        |}
+      """.stripMargin)
+    val internalMacroClient = build.project("internalMacroClient")
+    internalMacroClient.scalacOptions ++= List("-Ymacro-classpath", macroProject.out.toString)
+    internalMacroClient.classpath += macroProject.out
+    internalMacroClient.withSource("m2/p2/InternalClient.scala")(
+      """
+        |package m1.p2
+        |class InternalClient { m1.p1.Macro.m }
+      """.stripMargin)
+    build
+  }
+
+  private lazy val b2: Build = {
+    val build = new Build(projectsBase, "b1")
+    val p1 = build.project("p1")
+    val m1P1 = m1.project("p1")
+    p1.classpath += m1P1.out
+    p1.scalacOptions ++= List("-Ymacro-classpath", m1P1.out.toString)
+    p1.withSource("b1/p1/ExternalClient.scala")(
+      """
+        |package b2.p2
+        |class ExternalClient { m1.p1.Macro.m }
+      """.stripMargin)
+    build
+  }
+
+  private lazy val b3: Build = {
+    val build = new Build(projectsBase, "b3")
+    val p1 = build.project("p1")
+    p1.withSource("b3/p1/JavaDefined.java")(
+      """
+        |package b3.p1;
+        |public class JavaDefined<T> {
+        |  ScalaJoint<T> id(T t) { return new ScalaJoint<T>(); }
+        |}
+      """.stripMargin)
+    p1.withSource("b3/p1/ScalaJoint.scala")(
+      """
+        |package b3.p1
+        |class ScalaJoint[T] {
+        |  def foo: Unit = new JavaDefined[String]
+        |}
+      """.stripMargin)
+    val p2 = build.project("p2")
+    p2.classpath += p1.out
+    p2.withSource("b3/p2/JavaClient.java")(
+      """
+        |package b3.p2;
+        |public class JavaClient {
+        |  b3.p1.JavaDefined<String> test() { return null; }
+        |}
+      """.stripMargin)
+    p2.withSource("b3/p2/ScalaClient.scala")(
+      """
+        |package b3.p2
+        |class ScalaClient {
+        |  def test(): b3.p1.JavaDefined[String] = null;
+        |}
+      """.stripMargin)
+    build
+  }
+
+  private lazy val b4: Build = {
+    val build = new Build(projectsBase, "b4")
+    val b3P1 = b3.project("p1")
+    val p2 = build.project("p2")
+    p2.classpath += b3P1.out
+    p2.withSource("b4/p2/JavaClient.java")(
+      """
+        |package b4.p2;
+        |public class JavaClient {
+        |  b3.p1.JavaDefined<String> test() { return null; }
+        |}
+      """.stripMargin)
+    p2.withSource("b4/p2/ScalaClient.scala")(
+      """
+        |package b4.p2
+        |class ScalaClient {
+        |  def test(): b3.p1.JavaDefined[String] = null;
+        |}
+      """.stripMargin)
+    build
+  }
+
+  final class Build(base: Path, name: String) {
+
+    val buildBase = createDir(base, name)
+    val scalacOptions = mutable.ListBuffer[String]()
+    final class Project(val name: String) {
+      def fullName: String = Build.this.name + "." + name
+      val base = createDir(buildBase, name)
+      val out = createDir(base, "target")
+      val src = createDir(base, "src")
+      val scalacOptions = mutable.ListBuffer[String]()
+      scalacOptions += "-usejavacp"
+      val classpath = mutable.ListBuffer[Path]()
+      val sources = mutable.ListBuffer[Path]()
+      def withSource(relativePath: String)(code: String): this.type = {
+        val srcFile = src.resolve(relativePath)
+        Files.createDirectories(srcFile.getParent)
+        Files.write(srcFile, code.getBytes(Charset.defaultCharset()))
+        sources += srcFile
+        this
+      }
+      def argsFile(extraOpts: List[String]): Path = {
+        val cp = if (classpath.isEmpty) Nil else List("-cp", classpath.mkString(File.pathSeparator))
+        val printArgs = if (debug) List("-Xprint-args", "-") else Nil
+        val entries = List(
+          Build.this.scalacOptions.toList,
+          scalacOptions.toList,
+          extraOpts,
+          printArgs,
+          List("-d", out.toString) ::: cp ::: sources.toList.map(_.toString)
+        ).flatten
+        Files.write(out.resolve(fullName + ".args"), entries.asJava)
+      }
+    }
+    private val projectsMap = mutable.LinkedHashMap[String, Project]()
+    def projects: List[Project] = projectsMap.valuesIterator.toList
+    def project(name: String): Project = {
+      projectsMap.getOrElseUpdate(name, new Project(name))
+    }
+  }
+
+  private def clean(): Unit = {
+    class CleanVisitor() extends SimpleFileVisitor[Path] {
+      override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        if (dir.getFileName.toString == "target") {
+          deleteRecursive(dir)
+          Files.createDirectories(dir)
+          FileVisitResult.SKIP_SUBTREE
+        } else super.preVisitDirectory(dir, attrs)
+      }
+    }
+    Files.walkFileTree(projectsBase, new CleanVisitor())
+  }
+  private def snapshotClasses(strategy: BuildStrategy): Path = {
+    val src = projectsBase
+    val dest = createDir(base, strategy.toString + "/classes")
+    class CopyVisitor(src: Path, dest: Path) extends SimpleFileVisitor[Path] {
+      override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        Files.createDirectories(dest.resolve(src.relativize(dir)))
+        super.preVisitDirectory(dir, attrs)
+      }
+
+      override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
+        val destDir = dest.resolve(src.relativize(dir))
+        val listing = Files.list(destDir)
+        try {
+          if (!listing.iterator().hasNext)
+            Files.delete(destDir)
+        } finally {
+          listing.close()
+        }
+        super.postVisitDirectory(dir, exc)
+      }
+      override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        Files.copy(file, dest.resolve(src.relativize(file)))
+        super.visitFile(file, attrs)
+      }
+    }
+    Files.walkFileTree(src, new CopyVisitor(src, dest))
+    dest
+  }
+
+  private def createDir(dir: Path, s: String): Path = {
+    val subDir = dir.resolve(s)
+    Files.createDirectories(subDir)
+  }
+}


### PR DESCRIPTION
A new mode for `PipelineMain` that can shorten the critical path of a build and extract more parallelism from the post-typer compiler phases (at the cost of instantiating multiple instances of `Global`).

First, we compile all sources with `-Youtline -Ystop-after:pickler`. The first option disables typechecking of the RHS of definitions that have ascribed types.

The RHS is _not_ skipped when it contains a `super` call that might need a super accessor. (hat tip to @smarter for finding this corner case in dotty). Are there more like it that we haven't identified?

The pickles are then exported and made available to downstream compilation, as is also the case with the `strategy=Pipeline`. The sources for the current projects are then compiled in parallel in chunks, also using the exported pickles on the classpath.

Testing this out `guardian-frontend`. In the past I've experimented with the full multi-module build, but in this case I want to focus on the `common` project that is the bottleneck the build.

## Pipeline + Outline
```
$ mkdir -p /tmp/pickle-cache && ./build/pack/bin/scala -J-Dsun.reflect.inflationThreshold=0  -J-Xmx4G -Dscala.pipeline.cache.name.table=true -Dscalac.filebasedcache.defer.close.ms=30000 -Dscala.pipeline.picklecache=/tmp/pickle-cache -Dscala.pipeline.group.size=128  -Dscala.pipeline.strategy=outlinetypepipeline -Dscala.pipeline.strip.external.classpath=true -Dscala.pipeline.cache.macro.classloader=true -Dscala.pipeline.use.jar=true scala.tools.nsc.PipelineMainTest /Users/jz/code/guardian-frontend/common/target/compile.args
...
====== ITERATION 20=======
parallelism = 8, strategy = OutlineTypePipeline
Exported external classpath in 4 ms
Wrote project dependency graph to: /Users/jz/code/scala/projects.dot
/Users/jz/code/guardian-frontend/common:compile: scalac outline: start
/Users/jz/code/guardian-frontend/common:compile: scalac outline: done 1378 ms
/Users/jz/code/guardian-frontend/common:compile: scalac (1/4): start
/Users/jz/code/guardian-frontend/common:compile: scalac (2/4): start
/Users/jz/code/guardian-frontend/common:compile: scalac (4/4): start
/Users/jz/code/guardian-frontend/common:compile: scalac (3/4): start
/Users/jz/code/guardian-frontend/common:compile: scalac (4/4): done 1729 ms
/Users/jz/code/guardian-frontend/common:compile: scalac (3/4): done 1898 ms
/Users/jz/code/guardian-frontend/common:compile: scalac (1/4): done 3074 ms
/Users/jz/code/guardian-frontend/common:compile: scalac (2/4): done 4698 ms
PROGRESS: 6 / 6
 Wall Clock: 6077 ms
Chrome trace written to /Users/jz/code/scala/build-OutlineTypePipeline-20.trace
```

## Pipeline 

```
$ ... -Dscala.pipeline.strategy=pipeline ...
====== ITERATION 20=======
parallelism = 8, strategy = Pipeline
Exported external classpath in 4 ms
Wrote project dependency graph to: /Users/jz/code/scala/projects.dot
/Users/jz/code/guardian-frontend/common:compile: scalac: start
/Users/jz/code/guardian-frontend/common:compile: scalac outline: done 4232 ms
/Users/jz/code/guardian-frontend/common:compile: scalac: exported pickles 52 ms
/Users/jz/code/guardian-frontend/common:compile: scalac: done 4523 ms
PROGRESS: 3 / 3
 Wall Clock: 8807 ms
Chrome trace written to /Users/jz/code/scala/build-Pipeline-20.trace
```

## Traditional

```
$ ... -Dscala.pipeline.strategy=traditional ...
====== ITERATION 20=======
parallelism = 8, strategy = Traditional
Wrote project dependency graph to: /Users/jz/code/scala/projects.dot
/Users/jz/code/guardian-frontend/common:compile: scalac (1/1): start
/Users/jz/code/guardian-frontend/common:compile: scalac (1/1): done 9343 ms
PROGRESS: 3 / 3
Wall Clock: 9409 ms
Chrome trace written to /Users/jz/code/scala/build-Traditional-20.trace
```

## Summary

 - The main benefit of the new strategy here is reducing the "time-to-pickles" down to 1.4s (vs  9.3 for traditional vs 4.2 for non-outline pipeline)
 - The wall clock time is also reduced somewhat (6.1s vs 8.8s), which may be interesting in itself when enough cores are available. There will be rapidly diminishing returns as the chunk size gets too small, however, due to the current approach of using a Global instance per-chunk.

## Caveats

 - Incompatible with the non-local optimizations in the backend as .class files for symbols backed by exported pickles aren't available. This shouldn't be a big problem in "dev mode".
 - To get the most of out of the caching of macro classloaders, a hand crafted `-Ymacro-classpath` setting is needed with the macro implementation.

## Future work:

  - Name table sharing across concurrently running instances of the compiler: https://github.com/retronym/scala/pull/46
