### PR TITLE
Remove concat, ++ and + overloads from MapView

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,6 +90,13 @@ val mimaPrereleaseHandlingSettings = Seq(
   mimaBinaryIssueFilters ++= Seq(
     // Drop after 2.13.0 is out, whence src/reflect/mima-filters/ takes over.
     ProblemFilters.exclude[Problem]("scala.reflect.internal.*"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.MapView$Concat"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.collection.AbstractMapView.++"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.AbstractMapView.+"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.collection.AbstractMapView.concat"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.collection.MapView.++"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.MapView.+"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.collection.MapView.concat")
   ),
 )
 

--- a/src/library/scala/collection/MapView.scala
+++ b/src/library/scala/collection/MapView.scala
@@ -23,12 +23,6 @@ trait MapView[K, +V]
 
   override def view: MapView[K, V] = this
 
-  def concat[V1 >: V](that: SomeMapOps[K, V1]): MapView[K, V1] = new MapView.Concat(this, that)
-
-  def ++[V1 >: V](that: SomeMapOps[K, V1]): MapView[K, V1] = concat(that)
-
-  override def +[V1 >: V](kv: (K, V1)): MapView[K, V1] = concat(new Map1(kv._1, kv._2))
-
   /** Filters this map by retaining only keys satisfying a predicate.
     *  @param  p   the predicate used to test keys
     *  @return an immutable map consisting only of those key value pairs of this map where the key satisfies
@@ -73,7 +67,6 @@ object MapView extends MapViewFactory {
     override def iterator: Iterator[Nothing] = Iterator.empty[Nothing]
     override def knownSize: Int = 0
     override def isEmpty: Boolean = true
-    override def concat[V1 >: Nothing](that: SomeMapOps[Any, V1]): MapView[Any, V1] = mapFactory.from(that)
     override def filterKeys(p: Any => Boolean): MapView[Any, Nothing] = this
     override def mapValues[W](f: Nothing => W): MapView[Any, Nothing] = this
     override def filter(pred: ((Any, Nothing)) => Boolean): MapView[Any, Nothing] = this
@@ -87,15 +80,6 @@ object MapView extends MapViewFactory {
     def iterator: Iterator[(K, V)] = underlying.iterator
     override def knownSize: Int = underlying.knownSize
     override def isEmpty: Boolean = underlying.isEmpty
-  }
-
-  @SerialVersionUID(3L)
-  class Concat[K, +V](left: SomeMapOps[K, V], right: SomeMapOps[K, V]) extends AbstractMapView[K, V] {
-    def get(key: K): Option[V] = right.get(key) match {
-      case s @ Some(_) => s
-      case _ => left.get(key)
-    }
-    def iterator: Iterator[(K, V)] = left.iterator.filter { case (k, _) => !right.contains(k) }.concat(right.iterator)
   }
 
   @SerialVersionUID(3L)


### PR DESCRIPTION
According to the [blog post about the Collections Rework](https://www.scala-lang.org/blog/2017/02/28/collections-rework.html), and I've heard it said quite a few times:

>Conceptually a `View` is now a reified operation over an `Iterator`.  

So from that, we should be able to codify this as roughly:

>A `View` transformation should be equivalent to the corresponding transformation on `Iterator`

e.g.
```scala
val iterable: Iterable[A] = ???
a.view.transform().toList == a.iterator.transform().toList
```
  
However, these `concat`/`++`/`+` method overloads on `MapView` violate this principle, by treating MapView more like a Map than like a View, in order to return a MapView rather than widening to generic View. The result is this:

```scala
scala> Map(1 -> 1).view.concat(Map(1 -> 2)).toList
res2: List[(Int, Int)] = List((1,2))

scala> Map(1 -> 1).iterator.concat(Map(1 -> 2)).toList
res3: List[(Int, Int)] = List((1,1), (1,2))
```


And, since it's a specialized overload, it returns different data depending on the static type of the argument or receiver:

```scala
scala> Map(1 -> 1).view.concat(Map(1 -> 2)).toList
res5: List[(Int, Int)] = List((1,2))

scala> Map(1 -> 1).view.concat(Map(1 -> 2) : Iterable[(Int, Int)]).toList
res6: List[(Int, Int)] = List((1,1), (1,2))

scala> (Map(1 -> 1) : Iterable[(Int, Int)]).view.concat(Map(1 -> 2)).toList
res7: List[(Int, Int)] = List((1,1), (1,2))
```

Which is pretty odd I reckon. 
