### PR TITLE
Remove unnecessary type parameter on `IterableOnce#stepper`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,6 +91,7 @@ val mimaPrereleaseHandlingSettings = Seq(
     // Drop after 2.13.0 is out, whence src/reflect/mima-filters/ takes over.
     ProblemFilters.exclude[Problem]("scala.reflect.internal.*"),
 
+
 // #8094    
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FutureConverters#CompletionStageOps.toScala"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FutureConverters#FutureOps.toJava"),
@@ -105,13 +106,16 @@ val mimaPrereleaseHandlingSettings = Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.javaapi.FutureConverters.asJava"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.javaapi.FutureConverters.asScala"),
 
+
 // #8096    
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet.this"),
-    
+
+
 // #8093    
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.IterableOnceOps.knownSize"),
     ProblemFilters.exclude[DirectAbstractMethodProblem]("scala.collection.IterableOnce.knownSize"),
-    
+
+
 // #8089 
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.MapView$Concat"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.collection.AbstractMapView.++"),
@@ -121,11 +125,17 @@ val mimaPrereleaseHandlingSettings = Seq(
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.MapView.+"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.collection.MapView.concat"),
 
+
 // #8104
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.RichFloat.isFinite$extension"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.RichDouble.isFinite$extension"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.RichFloat.isFinite"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.RichDouble.isFinite"),
+
+
+// #8083
+    ProblemFilters.exclude[FinalMethodProblem]("scala.jdk.Accumulator.stepper"),
+
 
   ),
 )

--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -121,7 +121,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
       else Iterator.empty.next()
   }
 
-  override def stepper[B >: Int, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[Int, S]): S with EfficientSplit = {
     val st = scala.collection.convert.impl.BitSetStepper.from(this)
     val r =
       if (shape.shape == StepperShape.IntShape) st

--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -37,13 +37,13 @@ trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self =>
 
   def iterator: Iterator[A] = view.iterator
 
-  override def stepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S with EfficientSplit = {
     import convert.impl._
     val s = shape.shape match {
       case StepperShape.IntShape    => new IntIndexedSeqStepper   (this.asInstanceOf[IndexedSeqOps[Int, AnyConstr, _]],    0, length)
       case StepperShape.LongShape   => new LongIndexedSeqStepper  (this.asInstanceOf[IndexedSeqOps[Long, AnyConstr, _]],   0, length)
       case StepperShape.DoubleShape => new DoubleIndexedSeqStepper(this.asInstanceOf[IndexedSeqOps[Double, AnyConstr, _]], 0, length)
-      case _                        => shape.parUnbox(new AnyIndexedSeqStepper[B](this, 0, length))
+      case _                        => shape.parUnbox(new AnyIndexedSeqStepper[A](this, 0, length))
     }
     s.asInstanceOf[S with EfficientSplit]
   }

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -63,13 +63,13 @@ trait IterableOnce[+A] extends Any {
     * allow creating parallel streams, whereas bare Steppers can be converted only to sequential
     * streams.
     */
-  def stepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S = {
+  def stepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S = {
     import convert.impl._
     val s = shape.shape match {
       case StepperShape.IntShape    => new IntIteratorStepper   (iterator.asInstanceOf[Iterator[Int]])
       case StepperShape.LongShape   => new LongIteratorStepper  (iterator.asInstanceOf[Iterator[Long]])
       case StepperShape.DoubleShape => new DoubleIteratorStepper(iterator.asInstanceOf[Iterator[Double]])
-      case _                        => shape.seqUnbox(new AnyIteratorStepper[B](iterator))
+      case _                        => shape.seqUnbox(new AnyIteratorStepper[A](iterator))
     }
     s.asInstanceOf[S]
   }

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -90,7 +90,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
   }
 
   /** Returns a [[Stepper]] for the values of this map. See method [[stepper]]. */
-  def valueStepper[V1 >: V, S <: Stepper[_]](implicit shape: StepperShape[V1, S]): S = {
+  def valueStepper[S <: Stepper[_]](implicit shape: StepperShape[V, S]): S = {
     import convert.impl._
     val s = shape.shape match {
       case StepperShape.IntShape    => new IntIteratorStepper   (valuesIterator.asInstanceOf[Iterator[Int]])

--- a/src/library/scala/collection/StepperShape.scala
+++ b/src/library/scala/collection/StepperShape.scala
@@ -19,7 +19,7 @@ import scala.collection.Stepper.EfficientSplit
 /** An implicit StepperShape instance is used in the [[IterableOnce.stepper]] to return a possibly
   * specialized Stepper `S` according to the element type `T`.
   */
-sealed trait StepperShape[T, S <: Stepper[_]] {
+sealed trait StepperShape[-T, S <: Stepper[_]] {
   /** Return the Int constant (as defined in the `StepperShape` companion object) for this `StepperShape`. */
   def shape: StepperShape.Shape
 

--- a/src/library/scala/collection/convert/StreamExtensions.scala
+++ b/src/library/scala/collection/convert/StreamExtensions.scala
@@ -39,7 +39,7 @@ trait StreamExtensions {
   }
 
   protected type IterableOnceWithEfficientStepper[A] = IterableOnce[A] {
-    def stepper[B >: A, S <: Stepper[_]](implicit shape : StepperShape[B, S]) : S with EfficientSplit
+    def stepper[S <: Stepper[_]](implicit shape : StepperShape[A, S]) : S with EfficientSplit
   }
 
   // Not `CC[X] <: IterableOnce[X]`, but `C` with an extra constraint, to support non-parametric classes like IntAccumulator
@@ -84,8 +84,8 @@ trait StreamExtensions {
 
   implicit class MapHasParKeyValueStream[K, V, CC[X, Y] <: collection.MapOps[X, Y, CC, _]](cc: CC[K, V]) {
     private type MapOpsWithEfficientKeyStepper[K, V] = collection.MapOps[K, V, CC, _] { def keyStepper[S <: Stepper[_]](implicit shape : StepperShape[K, S]) : S with EfficientSplit }
-    private type MapOpsWithEfficientValueStepper[K, V] = collection.MapOps[K, V, CC, _] { def valueStepper[V1 >: V, S <: Stepper[_]](implicit shape : StepperShape[V1, S]) : S with EfficientSplit }
-    private type MapOpsWithEfficientStepper[K, V] = collection.MapOps[K, V, CC, _] { def stepper[B >: (K, V), S <: Stepper[_]](implicit shape : StepperShape[B, S]) : S with EfficientSplit }
+    private type MapOpsWithEfficientValueStepper[K, V] = collection.MapOps[K, V, CC, _] { def valueStepper[S <: Stepper[_]](implicit shape : StepperShape[V, S]) : S with EfficientSplit }
+    private type MapOpsWithEfficientStepper[K, V] = collection.MapOps[K, V, CC, _] { def stepper[S <: Stepper[_]](implicit shape : StepperShape[(K, V), S]) : S with EfficientSplit }
 
     /** Create a parallel [[java.util.stream.Stream Java Stream]] for the keys of this map. If
       * the keys are primitive values, a corresponding specialized Stream is returned (e.g.,

--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -55,7 +55,7 @@ sealed abstract class ArraySeq[+A]
   protected def evidenceIterableFactory: ArraySeq.type = ArraySeq
   protected def iterableEvidence: ClassTag[A @uncheckedVariance] = elemTag.asInstanceOf[ClassTag[A]]
 
-  override def stepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S with EfficientSplit = {
     import scala.collection.convert.impl._
     val isRefShape = shape.shape == StepperShape.ReferenceShape
     val s = if (isRefShape) unsafeArray match {
@@ -70,7 +70,7 @@ sealed abstract class ArraySeq[+A]
       case a: Array[AnyRef]  => new ObjectArrayStepper(a, 0, a.length)
     } else {
       unsafeArray match {
-        case a: Array[AnyRef] => shape.parUnbox(new ObjectArrayStepper(a, 0, a.length).asInstanceOf[AnyStepper[B] with EfficientSplit])
+        case a: Array[AnyRef] => shape.parUnbox(new ObjectArrayStepper(a, 0, a.length).asInstanceOf[AnyStepper[A] with EfficientSplit])
         case a: Array[Int]    => new IntArrayStepper(a, 0, a.length)
         case a: Array[Long]   => new LongArrayStepper(a, 0, a.length)
         case a: Array[Double] => new DoubleArrayStepper(a, 0, a.length)

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -94,9 +94,9 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     else new MapKeyValueTupleReverseIterator[K, V](rootNode)
   }
 
-  override def stepper[B >: (K, V), S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit =
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[(K, V), S]): S with EfficientSplit =
     shape.
-      parUnbox(collection.convert.impl.AnyChampStepper.from[B, MapNode[K, V]](size, rootNode, (node, i) => node.getPayload(i)))
+      parUnbox(collection.convert.impl.AnyChampStepper.from[(K, V), MapNode[K, V]](size, rootNode, (node, i) => node.getPayload(i)))
 
   override def keyStepper[S <: Stepper[_]](implicit shape: StepperShape[K, S]): S with EfficientSplit = {
     import collection.convert.impl._
@@ -109,13 +109,13 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     s.asInstanceOf[S with EfficientSplit]
   }
 
-  override def valueStepper[B >: V, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override def valueStepper[S <: Stepper[_]](implicit shape: StepperShape[V, S]): S with EfficientSplit = {
     import collection.convert.impl._
     val s = shape.shape match {
       case StepperShape.IntShape    => IntChampStepper.from[   MapNode[K, V]](size, rootNode, (node, i) => node.getValue(i).asInstanceOf[Int])
       case StepperShape.LongShape   => LongChampStepper.from[  MapNode[K, V]](size, rootNode, (node, i) => node.getValue(i).asInstanceOf[Long])
       case StepperShape.DoubleShape => DoubleChampStepper.from[MapNode[K, V]](size, rootNode, (node, i) => node.getValue(i).asInstanceOf[Double])
-      case _         => shape.parUnbox(AnyChampStepper.from[B, MapNode[K, V]](size, rootNode, (node, i) => node.getValue(i)))
+      case _         => shape.parUnbox(AnyChampStepper.from[V, MapNode[K, V]](size, rootNode, (node, i) => node.getValue(i)))
     }
     s.asInstanceOf[S with EfficientSplit]
   }

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -62,13 +62,13 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
 
   protected[immutable] def reverseIterator: Iterator[A] = new SetReverseIterator[A](rootNode)
 
-  override def stepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S with EfficientSplit = {
     import convert.impl._
     val s = shape.shape match {
       case StepperShape.IntShape    => IntChampStepper.from[   SetNode[A]](size, rootNode, (node, i) => node.getPayload(i).asInstanceOf[Int])
       case StepperShape.LongShape   => LongChampStepper.from[  SetNode[A]](size, rootNode, (node, i) => node.getPayload(i).asInstanceOf[Long])
       case StepperShape.DoubleShape => DoubleChampStepper.from[SetNode[A]](size, rootNode, (node, i) => node.getPayload(i).asInstanceOf[Double])
-      case _         => shape.parUnbox(AnyChampStepper.from[B, SetNode[A]](size, rootNode, (node, i) => node.getPayload(i)))
+      case _         => shape.parUnbox(AnyChampStepper.from[A, SetNode[A]](size, rootNode, (node, i) => node.getPayload(i)))
     }
     s.asInstanceOf[S with EfficientSplit]
   }

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -54,13 +54,13 @@ sealed class NumericRange[T](
 
   override def iterator: Iterator[T] = new NumericRange.NumericRangeIterator(this, num)
 
-  override def stepper[B >: T, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[T, S]): S with EfficientSplit = {
     import scala.collection.convert._
     import impl._
     val s = shape.shape match {
       case StepperShape.IntShape    => new IntNumericRangeStepper   (this.asInstanceOf[NumericRange[Int]],    0, length)
       case StepperShape.LongShape   => new LongNumericRangeStepper  (this.asInstanceOf[NumericRange[Long]],   0, length)
-      case _         => shape.parUnbox(new AnyNumericRangeStepper[T](this, 0, length).asInstanceOf[AnyStepper[B] with EfficientSplit])
+      case _         => shape.parUnbox(new AnyNumericRangeStepper[T](this, 0, length).asInstanceOf[AnyStepper[T] with EfficientSplit])
     }
     s.asInstanceOf[S with EfficientSplit]
   }

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -70,7 +70,7 @@ sealed abstract class Range(
 
   final override def iterator: Iterator[Int] = new RangeIterator(start, step, lastElement, isEmpty)
 
-  override final def stepper[B >: Int, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override final def stepper[S <: Stepper[_]](implicit shape: StepperShape[Int, S]): S with EfficientSplit = {
     val st = new RangeStepper(start, step, 0, length)
     val r =
       if (shape.shape == StepperShape.IntShape) st

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -93,9 +93,9 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V])(implicit va
 
   override def valuesIteratorFrom(start: K): Iterator[V] = RB.valuesIterator(tree, Some(start))
 
-  override def stepper[B >: (K, V), S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit =
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[(K, V), S]): S with EfficientSplit =
     shape.parUnbox(
-      scala.collection.convert.impl.AnyBinaryTreeStepper.from[B, RB.Tree[K, V]](
+      scala.collection.convert.impl.AnyBinaryTreeStepper.from[(K, V), RB.Tree[K, V]](
         size, tree, _.left, _.right, x => (x.key, x.value)
       )
     )
@@ -112,14 +112,14 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V])(implicit va
     s.asInstanceOf[S with EfficientSplit]
   }
 
-  override def valueStepper[V1 >: V, S <: Stepper[_]](implicit shape: StepperShape[V1, S]): S with EfficientSplit = {
+  override def valueStepper[S <: Stepper[_]](implicit shape: StepperShape[V, S]): S with EfficientSplit = {
     import scala.collection.convert.impl._
     type T = RB.Tree[K, V]
     val s = shape.shape match {
       case StepperShape.IntShape    => IntBinaryTreeStepper.from[T]    (size, tree, _.left, _.right, _.value.asInstanceOf[Int])
       case StepperShape.LongShape   => LongBinaryTreeStepper.from[T]   (size, tree, _.left, _.right, _.value.asInstanceOf[Long])
       case StepperShape.DoubleShape => DoubleBinaryTreeStepper.from[T] (size, tree, _.left, _.right, _.value.asInstanceOf[Double])
-      case _         => shape.parUnbox(AnyBinaryTreeStepper.from[V1, T](size, tree, _.left, _.right, _.value.asInstanceOf[V1]))
+      case _         => shape.parUnbox(AnyBinaryTreeStepper.from[V, T] (size, tree, _.left, _.right, _.value.asInstanceOf[V]))
     }
     s.asInstanceOf[S with EfficientSplit]
   }

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -115,14 +115,14 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
 
   def iteratorFrom(start: A): Iterator[A] = RB.keysIterator(tree, Some(start))
 
-  override def stepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S with EfficientSplit = {
     import scala.collection.convert.impl._
     type T = RB.Tree[A, Any]
     val s = shape.shape match {
       case StepperShape.IntShape    => IntBinaryTreeStepper.from[T]   (size, tree, _.left, _.right, _.key.asInstanceOf[Int])
       case StepperShape.LongShape   => LongBinaryTreeStepper.from[T]  (size, tree, _.left, _.right, _.key.asInstanceOf[Long])
       case StepperShape.DoubleShape => DoubleBinaryTreeStepper.from[T](size, tree, _.left, _.right, _.key.asInstanceOf[Double])
-      case _         => shape.parUnbox(AnyBinaryTreeStepper.from[B, T](size, tree, _.left, _.right, _.key.asInstanceOf[B]))
+      case _         => shape.parUnbox(AnyBinaryTreeStepper.from[A, T](size, tree, _.left, _.right, _.key))
     }
     s.asInstanceOf[S with EfficientSplit]
   }

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -146,7 +146,7 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
     }
   }
 
-  override def stepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S with EfficientSplit = {
     import convert.impl._
     var depth = -1
     val displaySource: VectorPointer[A] =
@@ -163,7 +163,7 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
       case StepperShape.IntShape    => new IntVectorStepper   (startIndex, endIndex, depth, trunk)
       case StepperShape.LongShape   => new LongVectorStepper  (startIndex, endIndex, depth, trunk)
       case StepperShape.DoubleShape => new DoubleVectorStepper(startIndex, endIndex, depth, trunk)
-      case _         => shape.parUnbox(new AnyVectorStepper[B](startIndex, endIndex, depth, trunk))
+      case _         => shape.parUnbox(new AnyVectorStepper[A](startIndex, endIndex, depth, trunk))
     }
     s.asInstanceOf[S with EfficientSplit]
   }

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -120,11 +120,11 @@ final class VectorMap[K, +V] private (
   // No-Op overrides to allow for more efficient steppers in a minor release.
   // Refining the return type to `S with EfficientSplit` is binary compatible.
 
-  override def stepper[B >: (K, V), S <: Stepper[_]](implicit shape: StepperShape[B, S]): S = super.stepper(shape)
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[(K, V), S]): S = super.stepper(shape)
 
   override def keyStepper[S <: Stepper[_]](implicit shape: StepperShape[K, S]): S = super.keyStepper(shape)
 
-  override def valueStepper[V1 >: V, S <: Stepper[_]](implicit shape: StepperShape[V1, S]): S = super.valueStepper(shape)
+  override def valueStepper[S <: Stepper[_]](implicit shape: StepperShape[V, S]): S = super.valueStepper(shape)
 
 
   def removed(key: K): VectorMap[K, V] = {

--- a/src/library/scala/collection/immutable/WrappedString.scala
+++ b/src/library/scala/collection/immutable/WrappedString.scala
@@ -55,7 +55,7 @@ final class WrappedString(private val self: String) extends AbstractSeq[Char] wi
   override def toString = self
   override def view: StringView = new StringView(self)
 
-  override def stepper[B >: Char, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[Char, S]): S with EfficientSplit = {
     val st = new CharStringStepper(self, 0, self.length)
     val r =
       if (shape.shape == StepperShape.CharShape) st

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -53,9 +53,9 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   protected[collection] var array: Array[AnyRef] = initialElements
   protected var size0 = initialSize
 
-  override def stepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S with EfficientSplit = {
     import scala.collection.convert.impl._
-    shape.parUnbox(new ObjectArrayStepper(array, 0, length).asInstanceOf[AnyStepper[B] with EfficientSplit])
+    shape.parUnbox(new ObjectArrayStepper(array, 0, length).asInstanceOf[AnyStepper[A] with EfficientSplit])
   }
 
   override def knownSize: Int = super[IndexedSeqOps].knownSize

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -67,7 +67,7 @@ class ArrayDeque[A] protected (
   override def knownSize: Int = super[IndexedSeqOps].knownSize
 
   // No-Op override to allow for more efficient stepper in a minor release.
-  override def stepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = super.stepper(shape)
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S with EfficientSplit = super.stepper(shape)
 
   def apply(idx: Int) = {
     requireBounds(idx)

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -67,7 +67,7 @@ sealed abstract class ArraySeq[T]
     * or subtype of the element type. */
   def array: Array[_]
 
-  override def stepper[B >: T, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[T, S]): S with EfficientSplit = {
     import scala.collection.convert.impl._
     val isRefShape = shape.shape == StepperShape.ReferenceShape
     val s = if (isRefShape) array match {
@@ -82,7 +82,7 @@ sealed abstract class ArraySeq[T]
       case a: Array[AnyRef]  => new ObjectArrayStepper(a, 0, a.length)
     } else {
       array match {
-        case a: Array[AnyRef] => shape.parUnbox(new ObjectArrayStepper(a, 0, a.length).asInstanceOf[AnyStepper[B] with EfficientSplit])
+        case a: Array[AnyRef] => shape.parUnbox(new ObjectArrayStepper(a, 0, a.length).asInstanceOf[AnyStepper[T] with EfficientSplit])
         case a: Array[Int]    => new IntArrayStepper(a, 0, a.length)
         case a: Array[Long]   => new LongArrayStepper(a, 0, a.length)
         case a: Array[Double] => new DoubleArrayStepper(a, 0, a.length)

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -263,9 +263,9 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
       protected[this] def extract(nd: Node[K, V]) = nd
     }
 
-  override def stepper[B >: (K, V), S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit =
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[(K, V), S]): S with EfficientSplit =
     shape.
-      parUnbox(new convert.impl.AnyTableStepper[B, Node[K, V]](size, table, _.next, node => (node.key, node.value), 0, table.length)).
+      parUnbox(new convert.impl.AnyTableStepper[(K, V), Node[K, V]](size, table, _.next, node => (node.key, node.value), 0, table.length)).
       asInstanceOf[S with EfficientSplit]
 
   override def keyStepper[S <: Stepper[_]](implicit shape: StepperShape[K, S]): S with EfficientSplit = {
@@ -279,13 +279,13 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     s.asInstanceOf[S with EfficientSplit]
   }
 
-  override def valueStepper[B >: V, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override def valueStepper[S <: Stepper[_]](implicit shape: StepperShape[V, S]): S with EfficientSplit = {
     import convert.impl._
     val s = shape.shape match {
       case StepperShape.IntShape    => new IntTableStepper[Node[K, V]]   (size, table, _.next, _.value.asInstanceOf[Int],    0, table.length)
       case StepperShape.LongShape   => new LongTableStepper[Node[K, V]]  (size, table, _.next, _.value.asInstanceOf[Long],   0, table.length)
       case StepperShape.DoubleShape => new DoubleTableStepper[Node[K, V]](size, table, _.next, _.value.asInstanceOf[Double], 0, table.length)
-      case _         => shape.parUnbox(new AnyTableStepper[B, Node[K, V]](size, table, _.next, _.value.asInstanceOf[B],      0, table.length))
+      case _         => shape.parUnbox(new AnyTableStepper[V, Node[K, V]](size, table, _.next, _.value,                      0, table.length))
     }
     s.asInstanceOf[S with EfficientSplit]
   }

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -218,13 +218,13 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
     override protected[this] def extract(nd: Node[A]): Node[A] = nd
   }
 
-  override def stepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S with EfficientSplit = {
     import convert.impl._
     val s = shape.shape match {
       case StepperShape.IntShape    => new IntTableStepper[Node[A]]   (size, table, _.next, _.key.asInstanceOf[Int],    0, table.length)
       case StepperShape.LongShape   => new LongTableStepper[Node[A]]  (size, table, _.next, _.key.asInstanceOf[Long],   0, table.length)
       case StepperShape.DoubleShape => new DoubleTableStepper[Node[A]](size, table, _.next, _.key.asInstanceOf[Double], 0, table.length)
-      case _         => shape.parUnbox(new AnyTableStepper[B, Node[A]](size, table, _.next, _.key.asInstanceOf[B],      0, table.length))
+      case _         => shape.parUnbox(new AnyTableStepper[A, Node[A]](size, table, _.next, _.key,                      0, table.length))
     }
     s.asInstanceOf[S with EfficientSplit]
   }

--- a/src/library/scala/collection/mutable/TreeMap.scala
+++ b/src/library/scala/collection/mutable/TreeMap.scala
@@ -80,9 +80,9 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     else RB.valuesIterator(tree, Some(start))
   }
 
-  override def stepper[B >: (K, V), S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit =
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[(K, V), S]): S with EfficientSplit =
     shape.parUnbox(
-      scala.collection.convert.impl.AnyBinaryTreeStepper.from[B, RB.Node[K, V]](
+      scala.collection.convert.impl.AnyBinaryTreeStepper.from[(K, V), RB.Node[K, V]](
         size, tree.root, _.left, _.right, x => (x.key, x.value)
       )
     )
@@ -99,14 +99,14 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     s.asInstanceOf[S with EfficientSplit]
   }
 
-  override def valueStepper[V1 >: V, S <: Stepper[_]](implicit shape: StepperShape[V1, S]): S with EfficientSplit = {
+  override def valueStepper[S <: Stepper[_]](implicit shape: StepperShape[V, S]): S with EfficientSplit = {
     import scala.collection.convert.impl._
     type T = RB.Node[K, V]
     val s = shape.shape match {
       case StepperShape.IntShape    => IntBinaryTreeStepper.from[T]    (size, tree.root, _.left, _.right, _.value.asInstanceOf[Int])
       case StepperShape.LongShape   => LongBinaryTreeStepper.from[T]   (size, tree.root, _.left, _.right, _.value.asInstanceOf[Long])
       case StepperShape.DoubleShape => DoubleBinaryTreeStepper.from[T] (size, tree.root, _.left, _.right, _.value.asInstanceOf[Double])
-      case _         => shape.parUnbox(AnyBinaryTreeStepper.from[V1, T](size, tree.root, _.left, _.right, _.value.asInstanceOf[V1]))
+      case _         => shape.parUnbox(AnyBinaryTreeStepper.from[V, T] (size, tree.root, _.left, _.right, _.value))
     }
     s.asInstanceOf[S with EfficientSplit]
   }

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -55,14 +55,14 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
 
   def iteratorFrom(start: A): collection.Iterator[A] = RB.keysIterator(tree, Some(start))
 
-  override def stepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  override def stepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S with EfficientSplit = {
     import scala.collection.convert.impl._
     type T = RB.Node[A, Null]
     val s = shape.shape match {
       case StepperShape.IntShape    => IntBinaryTreeStepper.from[T]   (size, tree.root, _.left, _.right, _.key.asInstanceOf[Int])
       case StepperShape.LongShape   => LongBinaryTreeStepper.from[T]  (size, tree.root, _.left, _.right, _.key.asInstanceOf[Long])
       case StepperShape.DoubleShape => DoubleBinaryTreeStepper.from[T](size, tree.root, _.left, _.right, _.key.asInstanceOf[Double])
-      case _         => shape.parUnbox(AnyBinaryTreeStepper.from[B, T](size, tree.root, _.left, _.right, _.key.asInstanceOf[B]))
+      case _         => shape.parUnbox(AnyBinaryTreeStepper.from[A, T](size, tree.root, _.left, _.right, _.key))
     }
     s.asInstanceOf[S with EfficientSplit]
   }

--- a/src/library/scala/jdk/Accumulator.scala
+++ b/src/library/scala/jdk/Accumulator.scala
@@ -86,9 +86,9 @@ abstract class Accumulator[@specialized(Double, Int, Long) A, +CC[X] <: mutable.
     else 1 << 24
   }
 
-  protected def efficientStepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit
+  protected def efficientStepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S with EfficientSplit
 
-  final override def stepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit =
+  final override def stepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S with EfficientSplit =
     efficientStepper(shape)
 
   final override def length: Int =

--- a/src/library/scala/jdk/AnyAccumulator.scala
+++ b/src/library/scala/jdk/AnyAccumulator.scala
@@ -38,8 +38,8 @@ final class AnyAccumulator[A]
 
   override protected[this] def className: String = "AnyAccumulator"
 
-  def efficientStepper[B >: A, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit =
-    shape.parUnbox(new AnyAccumulatorStepper[B](this.asInstanceOf[AnyAccumulator[B]]))
+  def efficientStepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S with EfficientSplit =
+    shape.parUnbox(new AnyAccumulatorStepper[A](this.asInstanceOf[AnyAccumulator[A]]))
 
   private def expand(): Unit = {
     if (index > 0) {

--- a/src/library/scala/jdk/DoubleAccumulator.scala
+++ b/src/library/scala/jdk/DoubleAccumulator.scala
@@ -32,7 +32,7 @@ final class DoubleAccumulator
 
   override protected[this] def className: String = "DoubleAccumulator"
 
-  def efficientStepper[B >: Double, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  def efficientStepper[S <: Stepper[_]](implicit shape: StepperShape[Double, S]): S with EfficientSplit = {
     val st = new DoubleAccumulatorStepper(this)
     val r =
       if (shape.shape == StepperShape.DoubleShape) st

--- a/src/library/scala/jdk/IntAccumulator.scala
+++ b/src/library/scala/jdk/IntAccumulator.scala
@@ -32,7 +32,7 @@ final class IntAccumulator
 
   override protected[this] def className: String = "IntAccumulator"
 
-  def efficientStepper[B >: Int, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  def efficientStepper[S <: Stepper[_]](implicit shape: StepperShape[Int, S]): S with EfficientSplit = {
     val st = new IntAccumulatorStepper(this)
     val r =
       if (shape.shape == StepperShape.IntShape) st

--- a/src/library/scala/jdk/LongAccumulator.scala
+++ b/src/library/scala/jdk/LongAccumulator.scala
@@ -32,7 +32,7 @@ final class LongAccumulator
 
   override protected[this] def className: String = "LongAccumulator"
 
-  def efficientStepper[B >: Long, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+  def efficientStepper[S <: Stepper[_]](implicit shape: StepperShape[Long, S]): S with EfficientSplit = {
     val st = new LongAccumulatorStepper(this)
     val r =
       if (shape.shape == StepperShape.LongShape) st

--- a/test/junit/scala/jdk/StepperTest.scala
+++ b/test/junit/scala/jdk/StepperTest.scala
@@ -19,7 +19,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.collection.{AnyStepper, ClassTagIterableFactory, IntStepper, IterableFactory, MapFactory, SortedIterableFactory, SortedMapFactory, SpecificIterableFactory, Stepper, concurrent => cc, immutable => ci, mutable => cm}
+import scala.collection.{AnyStepper, ClassTagIterableFactory, IntStepper, IterableFactory, MapFactory, SortedIterableFactory, SortedMapFactory, SpecificIterableFactory, Stepper, StepperShape, concurrent => cc, immutable => ci, mutable => cm}
 import scala.jdk.StreamConverters._
 import scala.util.chaining._
 
@@ -275,5 +275,12 @@ class StepperTest {
       val codePoints = s.codePoints().toScala(List)
       testStepper(null, s.codePointStepper, codePoints, size, testElemOrder = true, orderedFlag = true)
     }
+  }
+
+  class MyIterableOnce extends IterableOnce[Int] {
+    private[this] val data = Array(1, 2, 3)
+    def iterator = data.iterator
+    override def knownSize = data.length
+    override def stepper[S <: Stepper[_]](implicit shape: StepperShape[Int, S]): S = data.stepper[S]
   }
 }

--- a/test/junit/scala/jdk/StreamConvertersTypingTest.scala
+++ b/test/junit/scala/jdk/StreamConvertersTypingTest.scala
@@ -348,8 +348,8 @@ class StreamConvertersTypingTest {
       val s3: IntStepper with EfficientSplit = ibs.stepper
       val s4: Stepper[Int] = ibs.stepper
       val s5: Stepper[Int] with EfficientSplit = ibs.stepper
-      val s6: AnyStepper[Int] = ibs.stepper[Int, AnyStepper[Int]]
-      val s7: AnyStepper[Int] with EfficientSplit = ibs.stepper[Int, AnyStepper[Int]]
+      val s6: AnyStepper[Int] = ibs.stepper[AnyStepper[Int]]
+      val s7: AnyStepper[Int] with EfficientSplit = ibs.stepper[AnyStepper[Int]]
       // val s8: Stepper[Any] = ibs.stepper  // no StepperShape instance
       // val s9: Stepper[Long] = ibs.stepper // no StepperShape instance
     }
@@ -376,8 +376,8 @@ class StreamConvertersTypingTest {
     val s3: IntStepper with EfficientSplit = r.stepper
     val s4: Stepper[Int] = r.stepper
     val s5: Stepper[Int] with EfficientSplit = r.stepper
-    val s6: AnyStepper[Int] = r.stepper[Int, AnyStepper[Int]]
-    val s7: AnyStepper[Int] with EfficientSplit = r.stepper[Int, AnyStepper[Int]]
+    val s6: AnyStepper[Int] = r.stepper[AnyStepper[Int]]
+    val s7: AnyStepper[Int] with EfficientSplit = r.stepper[AnyStepper[Int]]
     // val s8: Stepper[Any] = r.stepper  // no StepperShape instance
     // val s9: Stepper[Long] = r.stepper // no StepperShape instance
   }


### PR DESCRIPTION
This also requires a contravariant `StepperShape`. Without this change it is impossible to delegate easily (without casting) from such a `stepper` implementation to one without the extra type parameter (see `StepperTest`). It also makes the signatures less ugly.