### PR TITLE
Reduce the overhead of macro expansion

### DIFF
--- a/src/compiler/scala/reflect/macros/runtime/JavaReflectionRuntimes.scala
+++ b/src/compiler/scala/reflect/macros/runtime/JavaReflectionRuntimes.scala
@@ -31,19 +31,25 @@ trait JavaReflectionRuntimes {
       // so every methName can resolve to at maximum one method
       val implMeth = implMeths getOrElse { throw new NoSuchMethodException(s"$className.$methName") }
       macroLogVerbose(s"successfully loaded macro impl as ($implClass, $implMeth)")
-      args => {
-        val implObj =
-          if (isBundle) {
-            def isMacroContext(clazz: Class[_]) = clazz == classOf[BlackboxContext] || clazz == classOf[WhiteboxContext]
-            def isBundleCtor(ctor: jConstructor[_]) = ctor.getParameterTypes match {
-              case Array(param) if isMacroContext(param) => true
-              case _ => false
-            }
-            val Array(bundleCtor) = implClass.getConstructors.filter(isBundleCtor)
-            bundleCtor.newInstance(args.c)
-          } else ReflectionUtils.staticSingletonInstance(implClass)
-        val implArgs = if (isBundle) args.others else args.c +: args.others
-        implMeth.invoke(implObj, implArgs.asInstanceOf[Seq[AnyRef]]: _*)
+      if (isBundle) {
+        def isMacroContext(clazz: Class[_]) = clazz == classOf[BlackboxContext] || clazz == classOf[WhiteboxContext]
+
+        def isBundleCtor(ctor: jConstructor[_]) = ctor.getParameterTypes match {
+          case Array(param) if isMacroContext(param) => true
+          case _ => false
+        }
+
+        val Array(bundleCtor) = implClass.getConstructors.filter(isBundleCtor)
+        args => {
+          val implObj = bundleCtor.newInstance(args.c)
+          implMeth.invoke(implObj, args.others.asInstanceOf[Seq[AnyRef]]: _*)
+        }
+      } else {
+        val implObj = ReflectionUtils.staticSingletonInstance(implClass)
+        args => {
+          val implArgs = args.c +: args.others
+          implMeth.invoke(implObj, implArgs.asInstanceOf[Seq[AnyRef]]: _*)
+        }
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -171,13 +171,6 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
       transformer.treeCopy.TypeTreeWithDeferredRefCheck(tree)
   }
 
-  object resetPos extends Traverser {
-    override def traverse(t: Tree) {
-      if (t != EmptyTree) t.setPos(NoPosition)
-      super.traverse(t)
-    }
-  }
-
   // Finally, no one uses resetAllAttrs anymore, so I'm removing it from the compiler.
   // Even though it's with great pleasure I'm doing that, I'll leave its body here to warn future generations about what happened in the past.
   //

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1300,7 +1300,7 @@ trait Contexts { self: Analyzer =>
           }
         }
         // optimization: don't write out package prefixes
-        finish(resetPos(imp1.qual.duplicate), impSym)
+        finish(duplicateAndResetPos.transform(imp1.qual), impSym)
       }
       else finish(EmptyTree, NoSymbol)
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -312,10 +312,14 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
     macroDef withAnnotation AnnotationInfo(MacroImplAnnotation.tpe, List(pickle), Nil)
   }
 
-  def loadMacroImplBinding(macroDef: Symbol): Option[MacroImplBinding] =
-    macroDef.getAnnotation(MacroImplAnnotation) collect {
-      case AnnotationInfo(_, List(pickle), _) => MacroImplBinding.unpickle(pickle)
-    }
+  def loadMacroImplBinding(macroDef: Symbol): Option[MacroImplBinding] = {
+    macroImplBindingCache.getOrElseUpdate(macroDef,
+      macroDef.getAnnotation(MacroImplAnnotation) collect {
+        case AnnotationInfo(_, List(pickle), _) => MacroImplBinding.unpickle(pickle)
+      }
+    )
+  }
+  private val macroImplBindingCache = perRunCaches.newAnyRefMap[Symbol, Option[MacroImplBinding]]()
 
   def isBlackbox(expandee: Tree): Boolean = isBlackbox(dissectApplied(expandee).core.symbol)
   def isBlackbox(macroDef: Symbol): Boolean = pluginsIsBlackbox(macroDef)
@@ -906,33 +910,33 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
   var hasPendingMacroExpansions = false // JZ this is never reset to false. What is its purpose? Should it not be stored in Context?
   def typerShouldExpandDeferredMacros: Boolean = hasPendingMacroExpansions && !delayed.isEmpty
   private val forced = perRunCaches.newWeakSet[Tree]
-  private val delayed = perRunCaches.newWeakMap[Tree, scala.collection.mutable.Set[Int]]()
-  private def isDelayed(expandee: Tree) = delayed contains expandee
+  private val delayed = perRunCaches.newWeakMap[Tree, scala.collection.mutable.Set[Symbol]]()
+  private def isDelayed(expandee: Tree) = !delayed.isEmpty && (delayed contains expandee)
   def clearDelayed(): Unit = delayed.clear()
-  private def calculateUndetparams(expandee: Tree): scala.collection.mutable.Set[Int] =
-    if (forced(expandee)) scala.collection.mutable.Set[Int]()
+  private def calculateUndetparams(expandee: Tree): scala.collection.mutable.Set[Symbol] =
+    if (forced(expandee)) scala.collection.mutable.Set[Symbol]()
     else delayed.getOrElse(expandee, {
       val calculated = scala.collection.mutable.Set[Symbol]()
       expandee foreach (sub => {
-        def traverse(sym: Symbol) = if (sym != null && (undetparams contains sym.id)) calculated += sym
+        def traverse(sym: Symbol) = if (sym != null && (undetparams contains sym)) calculated += sym
         if (sub.symbol != null) traverse(sub.symbol)
         if (sub.tpe != null) sub.tpe foreach (sub => traverse(sub.typeSymbol))
       })
       macroLogVerbose("calculateUndetparams: %s".format(calculated))
-      calculated map (_.id)
+      calculated
     })
-  private val undetparams = perRunCaches.newSet[Int]()
+  private val undetparams = perRunCaches.newSet[Symbol]()
   def notifyUndetparamsAdded(newUndets: List[Symbol]): Unit = {
-    undetparams ++= newUndets map (_.id)
+    undetparams ++= newUndets
     if (macroDebugVerbose) newUndets foreach (sym => println("undetParam added: %s".format(sym)))
   }
   def notifyUndetparamsInferred(undetNoMore: List[Symbol], inferreds: List[Type]): Unit = {
-    undetparams --= undetNoMore map (_.id)
+    undetparams --= undetNoMore
     if (macroDebugVerbose) (undetNoMore zip inferreds) foreach { case (sym, tpe) => println("undetParam inferred: %s as %s".format(sym, tpe))}
     if (!delayed.isEmpty)
       delayed.toList foreach {
         case (expandee, undetparams) if !undetparams.isEmpty =>
-          undetparams --= undetNoMore map (_.id)
+          undetparams --= undetNoMore
           if (undetparams.isEmpty) {
             hasPendingMacroExpansions = true
             macroLogVerbose(s"macro expansion is pending: $expandee")

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -822,7 +822,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
           def validateResultingTree(expanded: Tree) = {
             macroLogVerbose("original:")
             macroLogLite("" + expanded + "\n" + showRaw(expanded))
-            val freeSyms = expanded.freeTerms ++ expanded.freeTypes
+            val freeSyms = expanded.freeSyms
             freeSyms foreach (sym => MacroFreeSymbolError(expandee, sym))
             // Macros might have spliced arguments with range positions into non-compliant
             // locations, notably, under a tree without a range position. Or, they might

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -512,8 +512,8 @@ trait Definitions extends api.StandardDefinitions {
     lazy val ReflectPackage              = requiredModule[scala.reflect.`package`.type]
     lazy val ReflectApiPackage           = getPackageObjectIfDefined("scala.reflect.api") // defined in scala-reflect.jar, so we need to be careful
     lazy val ReflectRuntimePackage       = getPackageObjectIfDefined("scala.reflect.runtime") // defined in scala-reflect.jar, so we need to be careful
-         def ReflectRuntimeUniverse      = ReflectRuntimePackage.map(sym => getMemberValue(sym, nme.universe))
-         def ReflectRuntimeCurrentMirror = ReflectRuntimePackage.map(sym => getMemberMethod(sym, nme.currentMirror))
+         def ReflectRuntimeUniverse      = ReflectRuntimePackage.map(sym => getDeclValue(sym, nme.universe))
+         def ReflectRuntimeCurrentMirror = ReflectRuntimePackage.map(sym => getDeclMethod(sym, nme.currentMirror))
 
     lazy val UniverseClass    = getClassIfDefined("scala.reflect.api.Universe") // defined in scala-reflect.jar, so we need to be careful
          def UniverseInternal = getMemberValue(UniverseClass, nme.internal)
@@ -536,6 +536,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val TypeTagsClass          = getClassIfDefined("scala.reflect.api.TypeTags") // defined in scala-reflect.jar, so we need to be careful
 
     lazy val ApiUniverseClass      = getClassIfDefined("scala.reflect.api.Universe") // defined in scala-reflect.jar, so we need to be careful
+    lazy val ApiQuasiquotesClass   = getClassIfDefined("scala.reflect.api.Quasiquotes") // defined in scala-reflect.jar, so we need to be careful
     lazy val JavaUniverseClass     = getClassIfDefined("scala.reflect.api.JavaUniverse") // defined in scala-reflect.jar, so we need to be careful
 
     lazy val MirrorClass           = getClassIfDefined("scala.reflect.api.Mirror") // defined in scala-reflect.jar, so we need to be careful
@@ -560,10 +561,10 @@ trait Definitions extends api.StandardDefinitions {
 
     // scala/bug#8392 a reflection universe on classpath may not have
     // quasiquotes, if e.g. crosstyping with -Xsource on
-    lazy val QuasiquoteClass             = if (ApiUniverseClass != NoSymbol) getMemberIfDefined(ApiUniverseClass, tpnme.Quasiquote) else NoSymbol
-    lazy val QuasiquoteClass_api         = if (QuasiquoteClass != NoSymbol) getMember(QuasiquoteClass, tpnme.api) else NoSymbol
-    lazy val QuasiquoteClass_api_apply   = if (QuasiquoteClass_api != NoSymbol) getMember(QuasiquoteClass_api, nme.apply) else NoSymbol
-    lazy val QuasiquoteClass_api_unapply = if (QuasiquoteClass_api != NoSymbol) getMember(QuasiquoteClass_api, nme.unapply) else NoSymbol
+    lazy val QuasiquoteClass             = if (ApiUniverseClass != NoSymbol) ApiQuasiquotesClass.info.decl(tpnme.Quasiquote) else NoSymbol
+    lazy val QuasiquoteClass_api         = if (QuasiquoteClass != NoSymbol) QuasiquoteClass.info.decl(tpnme.api) else NoSymbol
+    lazy val QuasiquoteClass_api_apply   = if (QuasiquoteClass_api != NoSymbol) getDeclMethod(QuasiquoteClass_api, nme.apply) else NoSymbol
+    lazy val QuasiquoteClass_api_unapply = if (QuasiquoteClass_api != NoSymbol) getDeclMethod(QuasiquoteClass_api, nme.unapply) else NoSymbol
 
     lazy val ScalaSignatureAnnotation = requiredClass[scala.reflect.ScalaSignature]
     lazy val ScalaLongSignatureAnnotation = requiredClass[scala.reflect.ScalaLongSignature]
@@ -1308,6 +1309,18 @@ trait Definitions extends api.StandardDefinitions {
         case _             => fatalMissingSymbol(owner, name, "method")
       }
     }
+    def getDeclMethod(owner: Symbol, name: Name): TermSymbol = {
+      getDecl(owner, name.toTermName) match {
+        case x: TermSymbol => x
+        case _             => fatalMissingSymbol(owner, name, "method")
+      }
+    }
+    def getDeclValue(owner: Symbol, name: Name): TermSymbol = {
+      getDecl(owner, name.toTermName) match {
+        case x: TermSymbol => x
+        case _             => fatalMissingSymbol(owner, name, "declared value")
+      }
+    }
 
     private lazy val erasurePhase = findPhaseWithName("erasure")
     def getMemberIfDefined(owner: Symbol, name: Name): Symbol =
@@ -1574,7 +1587,7 @@ trait Definitions extends api.StandardDefinitions {
       lazy val HigherKindsFeature         = getLanguageFeature("higherKinds")
       lazy val ExistentialsFeature        = getLanguageFeature("existentials")
 
-      lazy val ApiUniverseReify = ApiUniverseClass.map(sym => getMemberMethod(sym, nme.reify))
+      lazy val ApiUniverseReify = ApiUniverseClass.map(sym => getDeclIfDefined(sym, nme.reify))
 
       lazy val ReflectRuntimeUniverse      = DefinitionsClass.this.ReflectRuntimeUniverse
       lazy val ReflectRuntimeCurrentMirror = DefinitionsClass.this.ReflectRuntimeCurrentMirror

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1710,6 +1710,14 @@ trait Trees extends api.Trees {
       t1
     }
   }
+  object duplicateAndResetPos extends Transformer {
+    override val treeCopy = newStrictTreeCopier
+    override def transform(t: Tree) = {
+      val t1 = super.transform(t)
+      if (t1 ne EmptyTree) t1.setPos(NoPosition)
+      t1
+    }
+  }
   trait TreeStackTraverser extends Traverser {
     import collection.mutable
     val path: mutable.Stack[Tree] = mutable.Stack()

--- a/src/reflect/scala/reflect/macros/Attachments.scala
+++ b/src/reflect/scala/reflect/macros/Attachments.scala
@@ -65,9 +65,12 @@ abstract class Attachments { self =>
 
   /** Creates a copy of this attachment with the payload of the given class type `T` removed. */
   def remove[T: ClassTag]: Attachments { type Pos = self.Pos } = {
-    val newAll = all filterNot matchesTag[T]
-    if (newAll.isEmpty) pos.asInstanceOf[Attachments { type Pos = self.Pos }]
-    else new NonemptyAttachments[Pos](this.pos, newAll)
+    if (!all.exists(matchesTag[T])) this // OPT immutable.Set.filter doesn't structurally share on 2.12 collections.
+    else {
+      val newAll = all filterNot matchesTag[T]
+      if (newAll.isEmpty) pos.asInstanceOf[Attachments { type Pos = self.Pos }]
+      else new NonemptyAttachments[Pos](this.pos, newAll)
+    }
   }
 
   def isEmpty: Boolean = true

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -120,6 +120,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.pendingSuperCall
     this.emptyValDef
     this.EmptyTreeTypeSubstituter
+    this.duplicateAndResetPos
     this.UnmappableAnnotArg
     this.LiteralAnnotArg
     this.ArrayAnnotArg

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -326,6 +326,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.ClassTagClass
     definitions.TypeTagsClass
     definitions.ApiUniverseClass
+    definitions.ApiQuasiquotesClass
     definitions.JavaUniverseClass
     definitions.MirrorClass
     definitions.TypeCreatorClass


### PR DESCRIPTION
  - Cache processing of the macro impl annotations
  - Force fewer infos when initializing macro FastTrack
  - Optimize macro context creation with laziness and fewer temp lists
  - Fuse traversal to collect free terms and types in macro expansion
  - Avoid doing Java reflection lookkups on each expansion

The motivation was improving the performance of compiling ScalaTest
suites which materialize the source position with a simple macro
on every assert.

Details: https://github.com/scalatest/scalatest/issues/1418#issuecomment-495543079