### PR TITLE
[bug#11515] Fix View#toString impl

### DIFF
--- a/src/library/scala/collection/View.scala
+++ b/src/library/scala/collection/View.scala
@@ -34,7 +34,7 @@ trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] with Itera
 
   override def empty: scala.collection.View[A] = iterableFactory.empty
 
-  override def toString: String  = stringPrefix + "(<not computed>)"
+  override def toString: String  = className + "(<not computed>)"
 
   @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix: String = "View"

--- a/test/junit/scala/collection/IndexedSeqViewTest.scala
+++ b/test/junit/scala/collection/IndexedSeqViewTest.scala
@@ -6,9 +6,9 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(classOf[JUnit4])
-class SeqViewTest {
+class IndexedSeqViewTest {
   @Test
   def _toString(): Unit = {
-    assertEquals("SeqView(<not computed>)", Seq(1, 2, 3).view.toString)
+    assertEquals("IndexedSeqView(<not computed>)", IndexedSeq(1, 2, 3).view.toString)
   }
 }

--- a/test/junit/scala/collection/MapViewTest.scala
+++ b/test/junit/scala/collection/MapViewTest.scala
@@ -1,0 +1,14 @@
+package scala.collection
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class MapViewTest {
+  @Test
+  def _toString(): Unit = {
+    assertEquals("MapView(<not computed>)", Map(1 -> 2).view.toString)
+  }
+}

--- a/test/junit/scala/collection/ViewTest.scala
+++ b/test/junit/scala/collection/ViewTest.scala
@@ -107,8 +107,14 @@ class ViewTest {
     checkThrows(ll.toList)
   }
 
-  def t10103: Unit = {
+  @Test
+  def t10103(): Unit = {
     val ints: IndexedSeq[Int] = Vector(1, 2, 3, 4)
     ints.view(1, 3): scala.collection.IndexedSeqView[Int]
+  }
+
+  @Test
+  def _toString(): Unit = {
+    assertEquals("View(<not computed>)", View(1, 2, 3).toString)
   }
 }


### PR DESCRIPTION
Fix `View#toString` implementation so that subclasses
can override `className` and still change the string
representation. Since by default `className`
forwards to `stringPrefix`, it will still behave correctly
for old/migratory implementations, but will now also support
"correct" implementations as well.

Followup to #8029.

Fixes scala/bug#11515 *for real this time*.