### PR TITLE
Stop overriding stringPrefix

### DIFF
--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -95,7 +95,7 @@ sealed abstract class ArraySeq[T]
     s.asInstanceOf[S with EfficientSplit]
   }
 
-  override protected[this] def stringPrefix = "ArraySeq"
+  override protected[this] def className = "ArraySeq"
 
   /** Clones this object, including the underlying Array. */
   override def clone(): ArraySeq[T] = ArraySeq.make(array.clone()).asInstanceOf[ArraySeq[T]]

--- a/src/library/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/src/library/scala/collection/mutable/CollisionProofHashMap.scala
@@ -386,7 +386,7 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
 
   protected[this] def writeReplace(): AnyRef = new DefaultSerializationProxy(new CollisionProofHashMap.DeserializationFactory[K, V](table.length, loadFactor, ordering), this)
 
-  override protected[this] def stringPrefix = "CollisionProofHashMap"
+  override protected[this] def className = "CollisionProofHashMap"
 
   override def getOrElseUpdate(key: K, defaultValue: => V): V = {
     val hash = computeHash(key)

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -361,7 +361,7 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
 
   protected[this] def writeReplace(): AnyRef = new DefaultSerializationProxy(new HashSet.DeserializationFactory[A](table.length, loadFactor), this)
 
-  override protected[this] def stringPrefix = "HashSet"
+  override protected[this] def className = "HashSet"
 }
 
 /**


### PR DESCRIPTION
Stop overriding `stringPrefix` in sealed or final collections,
and override `className` instead.