### PR TITLE
List: add specialised flatMap with Option

### DIFF
--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -284,6 +284,30 @@ sealed abstract class List[+A]
     }
   }
 
+  final def flatMap[B](f: A => Option[B]): List[B] = {
+    if (this eq Nil) Nil else {
+      var rest = this
+      var found = false
+      var h: ::[B] = null
+      var t: ::[B] = null
+      while (rest ne Nil) {
+        f(rest.head) match {
+          case Some(b) if ! found =>
+            h = new ::(b, Nil)
+            t = h
+            found = true
+          case Some(b) if found =>
+            val nx = new ::(b, Nil)
+            t.next = nx
+            t = nx
+          case None => // do nothing
+        }
+        rest = rest.tail
+      }
+      if (!found) Nil else {releaseFence(); h}
+    }
+  }
+
   @inline final override def takeWhile(p: A => Boolean): List[A] = {
     val b = new ListBuffer[A]
     var these = this


### PR DESCRIPTION
The general `flatMap` method of the `List` class takes any type that is an `IterableOnce`, and then uses its iterator to create a new list with the elements of that iterator. For most other types, the cost of creating an iterator is a relatively small overhead with respect to the size of the final List.

But not so for `Option`: since each `Option` is going to have at most one item, it follows that `FlatMap` is going to create as many `Iterator` objects as elements has the final list.

For this reason, we introduced a specialised `flatMap` method, which is like a copy of the general one, but avoids creating the Iterator.