### PR TITLE
immutable.SeqOps#sorted is lazy by default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,6 +107,19 @@ val mimaPrereleaseHandlingSettings = Seq(
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.MapView.+"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.collection.MapView.concat"),
 
+// #8100
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.SeqView.sorted"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.SeqView#Drop.sorted"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.SeqView#Take.sorted"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.SeqView#Prepended.sorted"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.SeqView#Map.sorted"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.SeqView#DropRight.sorted"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.SeqView#Appended.sorted"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.SeqView#TakeRight.sorted"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.SeqView#Concat.sorted"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.AbstractSeqView.sorted"),
+
+
   ),
 )
 

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -684,29 +684,11 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *
     *  @see [[scala.math.Ordering]]
     *
-    *  $willForceEvaluation
-    *
     *  @param  ord the ordering to be used to compare elements.
     *  @return     a $coll consisting of the elements of this $coll
     *              sorted according to the ordering `ord`.
     */
-  def sorted[B >: A](implicit ord: Ordering[B]): C = {
-    val len = this.length
-    val b = newSpecificBuilder
-    if (len == 1) b += head
-    else if (len > 1) {
-      b.sizeHint(len)
-      val arr = new Array[Any](len)
-      copyToArray(arr)
-      java.util.Arrays.sort(arr.asInstanceOf[Array[AnyRef]], ord.asInstanceOf[Ordering[AnyRef]])
-      var i = 0
-      while (i < len) {
-        b += arr(i).asInstanceOf[A]
-        i += 1
-      }
-    }
-    b.result()
-  }
+  def sorted[B >: A](implicit ord: Ordering[B]): C = fromSpecific(new SeqView.Sorted(this, ord))
 
   /** Sorts this $coll according to a comparison function.
     *  $willNotTerminateInf

--- a/src/library/scala/collection/SeqView.scala
+++ b/src/library/scala/collection/SeqView.scala
@@ -30,8 +30,6 @@ trait SeqView[+A] extends SeqOps[A, View, View[A]] with View[A] {
   def appendedAll[B >: A](suffix: SeqView.SomeSeqOps[B]): SeqView[B] = new SeqView.Concat(this, suffix)
   def prependedAll[B >: A](prefix: SeqView.SomeSeqOps[B]): SeqView[B] = new SeqView.Concat(prefix, this)
 
-  override def sorted[B >: A](implicit ord: Ordering[B]): SeqView[A] = new SeqView.Sorted(this, ord)
-
   @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix: String = "SeqView"
 }

--- a/src/library/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -77,4 +77,22 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
     b.result()
   }
 
+  override def sorted[B >: A](implicit ord: Ordering[B]): C = {
+    val len = this.length
+    val b = newSpecificBuilder
+    if (len == 1) b += head
+    else if (len > 1) {
+      b.sizeHint(len)
+      val arr = new Array[Any](len)
+      copyToArray(arr)
+      java.util.Arrays.sort(arr.asInstanceOf[Array[AnyRef]], ord.asInstanceOf[Ordering[AnyRef]])
+      var i = 0
+      while (i < len) {
+        b += arr(i).asInstanceOf[A]
+        i += 1
+      }
+    }
+    b.result()
+  }
+
 }

--- a/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
@@ -889,6 +889,24 @@ class LazyListLazinessTest {
     assertLazyAll(op)
     assertRepeatedlyLazy(op)
   }
+
+  @Test
+  def sorted_properlyLazy(): Unit = {
+    val sorted = lazyListOp { ll => ll.sorted }
+    val sortBy = lazyListOp { ll => ll.sortBy(identity) }
+    val sortWith = lazyListOp { ll => ll.sortWith(_ < _) }
+
+
+    assertLazyAll(sorted)
+    assertLazyAll(sortBy)
+    assertLazyAll(sortWith)
+//    assertRepeatedlyLazy(sorted)
+//    assertRepeatedlyLazy(sortBy)
+//    assertRepeatedlyLazy(sortWith)
+//    genericLazyOp_properlyLazy(_.sorted)
+  }
+
+
 }
 
 private object LazyListLazinessTest {

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -350,4 +350,9 @@ class LazyListTest {
     assertEquals(1 to 10, build(_ ++= LazyList.from(1).take(10)))
     assertEquals(1 to 10, build(_ ++= Iterator.from(1).take(10)))
   }
+
+  @Test
+  def sorted(): Unit = {
+    assertEquals(List(1,2,3), LazyList(2,1,3).sorted)
+  }
 }


### PR DESCRIPTION
The existing strict implementation has been moved to StrictOptimizedSeqOps.

This is a big win for simplicity and consistency (SeqView no longer needs to override the inherited strict implementation) as well as correctness (LazyList was previously strictly sorting its elements). 