### PR TITLE
Prefer Type.foreach to Type.filter

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -549,7 +549,7 @@ trait TypeDiagnostics {
         }
 
         if (t.tpe ne null) {
-          for (tp <- t.tpe if !treeTypes(tp)) {
+          for (tp <- t.tpe) if (!treeTypes(tp)) {
             // Include references to private/local aliases (which might otherwise refer to an enclosing class)
             val isAlias = {
               val td = tp.typeSymbolDirect


### PR DESCRIPTION
The latter creates temporary lists in FilterTypeCollector, which was showing as
an allocation hotspot for builds with `-Ywarn-unused` enabled.