### PR TITLE
ZipArchive isJarOrZip

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/FileUtils.scala
+++ b/src/compiler/scala/tools/nsc/classpath/FileUtils.scala
@@ -15,7 +15,7 @@ package scala.tools.nsc.classpath
 import java.io.{File => JFile, FileFilter}
 import java.net.URL
 import scala.reflect.internal.FatalError
-import scala.reflect.io.AbstractFile
+import scala.reflect.io.{AbstractFile, ZipArchive}
 
 /**
  * Common methods related to Java files and abstract files used in the context of classpath
@@ -29,7 +29,7 @@ object FileUtils {
     def isScalaOrJavaSource: Boolean = !file.isDirectory && (file.hasExtension("scala") || file.hasExtension("java"))
 
     // TODO do we need to check also other files using ZipMagicNumber like in scala.tools.nsc.io.Jar.isJarOrZip?
-    def isJarOrZip: Boolean = file.hasExtension("jar") || file.hasExtension("zip")
+    def isJarOrZip: Boolean = file.hasExtension("jar") || file.hasExtension("zip") || file.isInstanceOf[ZipArchive]
 
     /**
      * Safe method returning a sequence containing one URL representing this file, when underlying file exists,


### PR DESCRIPTION
This addresses the case where ManifestResources doesn't know it's a jar because it doesn't understand its URL. That symptom is the hypothetical case reported on the ticket, loading from launch4j wrapped app, but that is untested.

Fixes scala/bug#10488