### PR TITLE
Simplify List.flatMap

### DIFF
--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -259,29 +259,25 @@ sealed abstract class List[+A]
       h
     }
   }
+
   final override def flatMap[B](f: A => IterableOnce[B]): List[B] = {
-    if (this eq Nil) Nil else {
-      var rest = this
-      var found = false
-      var h: ::[B] = null
-      var t: ::[B] = null
-      while (rest ne Nil) {
-        f(rest.head).iterator.foreach { b =>
-          if (!found) {
-            h = new ::(b, Nil)
-            t = h
-            found = true
-          }
-          else {
-            val nx = new ::(b, Nil)
-            t.next = nx
-            t = nx
-          }
+    var rest = this
+    var h: ::[B] = null
+    var t: ::[B] = null
+    while (rest ne Nil) {
+      val it = f(rest.head).iterator
+      while (it.hasNext) {
+        val nx = new ::(it.next(), Nil)
+        if (t eq null) {
+          h = nx
+        } else {
+          t.next = nx
         }
-        rest = rest.tail
+        t = nx
       }
-      if (!found) Nil else {releaseFence(); h}
+      rest = rest.tail
     }
+    if (h eq null) Nil else {releaseFence(); h}
   }
 
   @inline final override def takeWhile(p: A => Boolean): List[A] = {


### PR DESCRIPTION
- remove unneeded boolean and a redundant case.
- rewrite inner loop to avoid foreach closure