### PR TITLE
Add `isFinite`-method to RichDouble and RichFloat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,6 +107,12 @@ val mimaPrereleaseHandlingSettings = Seq(
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.MapView.+"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.collection.MapView.concat"),
 
+// #8104
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.RichFloat.isFinite$extension"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.RichDouble.isFinite$extension"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.RichFloat.isFinite"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.RichDouble.isFinite"),
+
   ),
 )
 

--- a/src/library/scala/runtime/RichDouble.scala
+++ b/src/library/scala/runtime/RichDouble.scala
@@ -38,6 +38,7 @@ final class RichDouble(val self: Double) extends AnyVal with FractionalProxy[Dou
 
   def isNaN: Boolean         = java.lang.Double.isNaN(self)
   def isInfinity: Boolean    = java.lang.Double.isInfinite(self)
+  def isFinite: Boolean      = java.lang.Double.isFinite(self)
   def isPosInfinity: Boolean = Double.PositiveInfinity == self
   def isNegInfinity: Boolean = Double.NegativeInfinity == self
 

--- a/src/library/scala/runtime/RichFloat.scala
+++ b/src/library/scala/runtime/RichFloat.scala
@@ -38,6 +38,7 @@ final class RichFloat(val self: Float) extends AnyVal with FractionalProxy[Float
 
   def isNaN: Boolean         = java.lang.Float.isNaN(self)
   def isInfinity: Boolean    = java.lang.Float.isInfinite(self)
+  def isFinite: Boolean      = java.lang.Float.isFinite(self)
   def isPosInfinity: Boolean = Float.PositiveInfinity == self
   def isNegInfinity: Boolean = Float.NegativeInfinity == self
 

--- a/test/files/presentation/infix-completion.check
+++ b/test/files/presentation/infix-completion.check
@@ -3,7 +3,7 @@ reload: Snippet.scala
 askTypeCompletion at Snippet.scala(1,34)
 ================================================================================
 [response] askTypeCompletion at (1,34)
-retrieved 202 members
+retrieved 203 members
 [inaccessible] protected def num: Fractional[Double]
 [inaccessible] protected def ord: Ordering[Double]
 [inaccessible] protected def unifiedPrimitiveEquals(x: Any): Boolean
@@ -130,6 +130,7 @@ def floor: Double
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def intValue(): Int
+def isFinite: Boolean
 def isInfinite(): Boolean
 def isInfinity: Boolean
 def isNaN(): Boolean

--- a/test/files/presentation/infix-completion2.check
+++ b/test/files/presentation/infix-completion2.check
@@ -3,7 +3,7 @@ reload: Snippet.scala
 askTypeCompletion at Snippet.scala(1,34)
 ================================================================================
 [response] askTypeCompletion at (1,34)
-retrieved 202 members
+retrieved 203 members
 [inaccessible] protected def num: Fractional[Double]
 [inaccessible] protected def ord: Ordering[Double]
 [inaccessible] protected def unifiedPrimitiveEquals(x: Any): Boolean
@@ -130,6 +130,7 @@ def floor: Double
 def formatted(fmtstr: String): String
 def hashCode(): Int
 def intValue(): Int
+def isFinite: Boolean
 def isInfinite(): Boolean
 def isInfinity: Boolean
 def isNaN(): Boolean


### PR DESCRIPTION
Basically this PR is https://github.com/scala/scala/pull/8063 made against the `2.13` branch with the addition of adding the method to RichFloat as well. Closes https://github.com/scala/bug/issues/11531.