### PR TITLE
Generalize MapOps signature for keyStream / valueStream extension methods

### DIFF
--- a/src/library/scala/collection/convert/StreamExtensions.scala
+++ b/src/library/scala/collection/convert/StreamExtensions.scala
@@ -38,12 +38,12 @@ trait StreamExtensions {
       s.fromStepper(cc.stepper, par = false)
   }
 
-  protected type IterableOnceWithEfficientStepper[A] = IterableOnce[A] {
-    def stepper[S <: Stepper[_]](implicit shape : StepperShape[A, S]) : S with EfficientSplit
-  }
-
   // Not `CC[X] <: IterableOnce[X]`, but `C` with an extra constraint, to support non-parametric classes like IntAccumulator
   implicit class IterableNonGenericHasParStream[A, C <: IterableOnce[_]](c: C)(implicit ev: C <:< IterableOnce[A]) {
+    private type IterableOnceWithEfficientStepper = IterableOnce[A] {
+      def stepper[S <: Stepper[_]](implicit shape : StepperShape[A, S]) : S with EfficientSplit
+    }
+
     /** Create a parallel [[java.util.stream.Stream Java Stream]] for this collection. If the
       * collection contains primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
@@ -52,13 +52,13 @@ trait StreamExtensions {
         s: StreamShape[A, S, St],
         st: StepperShape[A, St],
         @implicitNotFound("`parStream` can only be called on collections where `stepper` returns a `Stepper with EfficientSplit`")
-        isEfficient: C <:< IterableOnceWithEfficientStepper[A]): S =
+        isEfficient: C <:< IterableOnceWithEfficientStepper): S =
       s.fromStepper(ev(c).stepper, par = true)
   }
 
   // maps
 
-  implicit class MapHasSeqKeyValueStream[K, V, CC[X, Y] <: collection.MapOps[X, Y, CC, _]](cc: CC[K, V]) {
+  implicit class MapHasSeqKeyValueStream[K, V, CC[X, Y] <: collection.MapOps[X, Y, collection.Map, _]](cc: CC[K, V]) {
     /** Create a sequential [[java.util.stream.Stream Java Stream]] for the keys of this map. If
       * the keys are primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
@@ -82,10 +82,10 @@ trait StreamExtensions {
   }
 
 
-  implicit class MapHasParKeyValueStream[K, V, CC[X, Y] <: collection.MapOps[X, Y, CC, _]](cc: CC[K, V]) {
-    private type MapOpsWithEfficientKeyStepper[K, V] = collection.MapOps[K, V, CC, _] { def keyStepper[S <: Stepper[_]](implicit shape : StepperShape[K, S]) : S with EfficientSplit }
-    private type MapOpsWithEfficientValueStepper[K, V] = collection.MapOps[K, V, CC, _] { def valueStepper[S <: Stepper[_]](implicit shape : StepperShape[V, S]) : S with EfficientSplit }
-    private type MapOpsWithEfficientStepper[K, V] = collection.MapOps[K, V, CC, _] { def stepper[S <: Stepper[_]](implicit shape : StepperShape[(K, V), S]) : S with EfficientSplit }
+  implicit class MapHasParKeyValueStream[K, V, CC[X, Y] <: collection.MapOps[X, Y, collection.Map, _]](cc: CC[K, V]) {
+    private type MapOpsWithEfficientKeyStepper = collection.MapOps[K, V, collection.Map, _] { def keyStepper[S <: Stepper[_]](implicit shape : StepperShape[K, S]) : S with EfficientSplit }
+    private type MapOpsWithEfficientValueStepper = collection.MapOps[K, V, collection.Map, _] { def valueStepper[S <: Stepper[_]](implicit shape : StepperShape[V, S]) : S with EfficientSplit }
+    private type MapOpsWithEfficientStepper = collection.MapOps[K, V, collection.Map, _] { def stepper[S <: Stepper[_]](implicit shape : StepperShape[(K, V), S]) : S with EfficientSplit }
 
     /** Create a parallel [[java.util.stream.Stream Java Stream]] for the keys of this map. If
       * the keys are primitive values, a corresponding specialized Stream is returned (e.g.,
@@ -95,7 +95,7 @@ trait StreamExtensions {
         s: StreamShape[K, S, St],
         st: StepperShape[K, St],
         @implicitNotFound("parKeyStream can only be called on maps where `keyStepper` returns a `Stepper with EfficientSplit`")
-        isEfficient: CC[K, V] <:< MapOpsWithEfficientKeyStepper[K, V]): S =
+        isEfficient: CC[K, V] <:< MapOpsWithEfficientKeyStepper): S =
       s.fromStepper(cc.keyStepper, par = true)
 
     /** Create a parallel [[java.util.stream.Stream Java Stream]] for the values of this map. If
@@ -106,7 +106,7 @@ trait StreamExtensions {
         s: StreamShape[V, S, St],
         st: StepperShape[V, St],
         @implicitNotFound("parValueStream can only be called on maps where `valueStepper` returns a `Stepper with EfficientSplit`")
-        isEfficient: CC[K, V] <:< MapOpsWithEfficientValueStepper[K, V]): S =
+        isEfficient: CC[K, V] <:< MapOpsWithEfficientValueStepper): S =
       s.fromStepper(cc.valueStepper, par = true)
 
     // The asJavaParStream extension method for IterableOnce doesn't apply because its `CC` takes a single type parameter, whereas the one here takes two
@@ -117,7 +117,7 @@ trait StreamExtensions {
         s: StreamShape[(K, V), S, St],
         st: StepperShape[(K, V), St],
         @implicitNotFound("parStream can only be called on maps where `stepper` returns a `Stepper with EfficientSplit`")
-        isEfficient: CC[K, V] <:< MapOpsWithEfficientStepper[K, V]): S =
+        isEfficient: CC[K, V] <:< MapOpsWithEfficientStepper): S =
       s.fromStepper(cc.stepper, par = true)
   }
 

--- a/test/junit/scala/jdk/StreamConvertersTypingTest.scala
+++ b/test/junit/scala/jdk/StreamConvertersTypingTest.scala
@@ -35,9 +35,9 @@ class StreamConvertersTypingTest {
     // the elements in insertion order.
 
     val m1 = Map(1 -> "a")
-    val m2 = mutable.LinkedHashMap('c' -> 35f)
+    val m2 = mutable.TreeMap('c' -> 35f)
     val s1 = Set("3", "4")
-    val s2 = mutable.LinkedHashSet('a', 'b')
+    val s2 = mutable.TreeSet('a', 'b')
 
 
     val m1ks = m1.keyStepper
@@ -45,9 +45,9 @@ class StreamConvertersTypingTest {
     val m1vs = m1.valueStepper
     (m1vs: AnyStepper[String] /*with EfficientSubstep*/).nextStep()
     val m2ks = m2.keyStepper
-    (m2ks: IntStepper /*with EfficientSplit*/).nextStep()
+    (m2ks: IntStepper with EfficientSplit).nextStep()
     val m2vs = m2.valueStepper
-    (m2vs: DoubleStepper /*with EfficientSplit*/).nextStep()
+    (m2vs: DoubleStepper with EfficientSplit).nextStep()
 
     val m1sps = m1.asJavaSeqStream
     (m1sps: Stream[(Int, String)]).count()
@@ -56,9 +56,9 @@ class StreamConvertersTypingTest {
     val m1svs = m1.asJavaSeqValueStream
     (m1svs: Stream[String]).count()
 
-    // val m1pps = m1.parStream // Not available
-    // val m1pks = m1.parKeyStream // Not available
-    // val m1pvs = m1.parValueStream // Not available
+//    val m1pps = m1.asJavaParStream // Not available, no efficient stepper
+//    val m1pks = m1.asJavaParKeyStream // Not available, no efficient key stepper
+//    val m1pvs = m1.asJavaParValueStream // Not available, no efficient value stepper
 
     val m2sps = m2.asJavaSeqStream
     (m2sps: Stream[(Char, Float)]).count()
@@ -67,21 +67,21 @@ class StreamConvertersTypingTest {
     val m2svs = m2.asJavaSeqValueStream
     (m2svs: DoubleStream).count()
 
-//    val m2pps = m2.asJavaParStream
-//    (m2pps: Stream[(Char, Float)]).count()
-//    val m2pks = m2.asJavaParKeyStream
-//    (m2pks: IntStream).sum()
-//    val m2pvs = m2.asJavaParValueStream
-//    (m2pvs: DoubleStream).count()
+    val m2pps = m2.asJavaParStream
+    (m2pps: Stream[(Char, Float)]).count()
+    val m2pks = m2.asJavaParKeyStream
+    (m2pks: IntStream).sum()
+    val m2pvs = m2.asJavaParValueStream
+    (m2pvs: DoubleStream).count()
 
     val s1sps = s1.asJavaSeqStream
     (s1sps: Stream[String]).count()
-//    val s1pps = s1.parStream
+//    val s1pps = s1.asJavaParStream
 
     val s2sps = s2.asJavaSeqStream
     (s2sps: IntStream).count()
-//    val s2pps = s2.asJavaParStream
-//    (s2pps: IntStream).count()
+    val s2pps = s2.asJavaParStream
+    (s2pps: IntStream).count()
   }
 
   @Test


### PR DESCRIPTION
A sorted map `CC` extends `MapOps[_, _, Map, _]`, not
`MapOps[_, _, CC, _]`, so the extension methods were not available.

Plus some small cleanups.