### PR TITLE
Un-deprecate `option2Iterable` implicit conversion

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -16,9 +16,7 @@ object Option {
 
   import scala.language.implicitConversions
 
-  /** An implicit conversion that converts an option to an iterable value
-   */
-  @deprecated("use `option.toList` or `option.iterator` instead", "2.13.0")
+  /** An implicit conversion that converts an option to an iterable value */
   implicit def option2Iterable[A](xo: Option[A]): Iterable[A] =
     if (xo.isEmpty) Iterable.empty else Iterable.single(xo.get)
 


### PR DESCRIPTION
The selection of methods available on `Option` is not very consistent.
For example, there is `.toList`, but not `.to` or any of the other
standard conversion methods like `.toVector`, `.toSet`, etc. There are
likely other methods that are commonly used today, but only available
through `option2Iterable` (e.g., `mkString`).

It's too late for 2.13 to go over Option's API. Keeping
`option2Iterable` covers up some of the shortcomings, and it's the same
as in 2.12, therefore backwards compatible.