### PR TITLE
Add delegating override to s.c.i.StrictOptimizedSeqOps

### DIFF
--- a/src/library/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -77,4 +77,6 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
     b.result()
   }
 
+  override def sorted[B >: A](implicit ord: Ordering[B]): C = super.sorted(ord)
+
 }


### PR DESCRIPTION
This is minimum viable work necessary to allow https://github.com/scala/scala/pull/8100 (or similar) work through 2.13.x.

