### PR TITLE
align spec on which identifiers are taken as variable patters vs constant patterns with implementation

### DIFF
--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -34,8 +34,8 @@ classes (Unicode general category given in parentheses):
 
 1. Whitespace characters. `\u0020 | \u0009 | \u000D | \u000A`.
 1. Letters, which include lower case letters (`Ll`), upper case letters (`Lu`),
-   titlecase letters (`Lt`), other letters (`Lo`), letter numerals (`Nl`) and the
-   two characters `\u0024 ‘$’` and `\u005F ‘_’`.
+   titlecase letters (`Lt`), other letters (`Lo`), modifier letters (`Ml`), 
+   letter numerals (`Nl`) and the two characters `\u0024 ‘$’` and `\u005F ‘_’`.
 1. Digits `‘0’ | … | ‘9’`.
 1. Parentheses `‘(’ | ‘)’ | ‘[’ | ‘]’ | ‘{’ | ‘}’ `.
 1. Delimiter characters ``‘`’ | ‘'’ | ‘"’ | ‘.’ | ‘;’ | ‘,’ ``.
@@ -82,8 +82,10 @@ decomposes into the three identifiers `big_bob`, `++=`, and
 The rules for pattern matching further distinguish between
 _variable identifiers_, which start with a lower case letter, and
 _constant identifiers_, which do not. For this purpose,
-underscore `‘_‘` is taken as lower case, and the ‘\$’ character
-is taken as upper case.
+all letters in unicode category Lo (lowercase letter), and all letters that 
+that have contributory property Other_Lowercase that are not in
+category Nl (letter numerals) are taken as lower case, as well as
+underscore `‘_‘`.
 
 The ‘\$’ character is reserved for compiler-synthesized identifiers.
 User programs should not define identifiers which contain ‘\$’ characters.

--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -80,12 +80,30 @@ decomposes into the three identifiers `big_bob`, `++=`, and
 `def`.
 
 The rules for pattern matching further distinguish between
-_variable identifiers_, which start with a lower case letter, and
-_constant identifiers_, which do not. For this purpose,
-all letters in unicode category Lo (lowercase letter), and all letters that 
-that have contributory property Other_Lowercase that are not in
-category Nl (letter numerals) are taken as lower case, as well as
-underscore `‘_‘`.
+_variable identifiers_, which start with a lower case letter
+or `_`, and _constant identifiers_, which do not.
+
+For this purpose, lower case letter don't only include a-z,
+but also all characters in Unicode category Ll (lowercase letter),
+as well as all letters that have contributory property
+Other_Lowercase, except characters in category Nl (letter numerals)
+which are never taken as lower case.
+
+The following are examples of variable identifiers:
+
+> ```scala
+>     x         maxIndex   p2p   empty_?
+>     `yield`   αρετη      _y    dot_product_*
+>     __system  _MAX_LEN_
+>     ªpple     ʰelper
+> ```
+
+Some examples of constant identifiers are
+
+> ```scala
+>     +    Object  $reserved  ǅul    ǂnûm
+>     ⅰ_ⅲ  Ⅰ_Ⅲ     ↁelerious  ǃqhàà  ʹthatsaletter
+> ```
 
 The ‘\$’ character is reserved for compiler-synthesized identifiers.
 User programs should not define identifiers which contain ‘\$’ characters.

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -23,7 +23,7 @@ The lexical syntax of Scala is given by the following grammar in EBNF form:
 whiteSpace       ::=  ‘\u0020’ | ‘\u0009’ | ‘\u000D’ | ‘\u000A’
 lower            ::=  ‘a’ | … | ‘z’ | ‘_’ // and any character in Unicode category Ll, and and any character in Lo or Ml that has contributory property Other_Lowercase
 upper            ::=  ‘A’ | … | ‘Z’ | ‘\$’ // and any character in Unicode category Lu, Lt or Nl, and any character in Lo and Ml that don't have contributory property Other_Lowercase
-letter           ::=  upper | lower // and Unicode categories Lo, Lt, Nl
+letter           ::=  upper | lower
 digit            ::=  ‘0’ | … | ‘9’
 paren            ::=  ‘(’ | ‘)’ | ‘[’ | ‘]’ | ‘{’ | ‘}’
 delim            ::=  ‘`’ | ‘'’ | ‘"’ | ‘.’ | ‘;’ | ‘,’

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -21,8 +21,8 @@ The lexical syntax of Scala is given by the following grammar in EBNF form:
 
 ```ebnf
 whiteSpace       ::=  ‘\u0020’ | ‘\u0009’ | ‘\u000D’ | ‘\u000A’
-upper            ::=  ‘A’ | … | ‘Z’ | ‘\$’ | ‘_’  // and Unicode category Lu
-lower            ::=  ‘a’ | … | ‘z’ // and Unicode category Ll
+lower            ::=  ‘a’ | … | ‘z’ | ‘_’ // and any character in Unicode category Ll, and and any character in Lo or Ml that has contributory property Other_Lowercase
+upper            ::=  ‘A’ | … | ‘Z’ | ‘\$’ // and any character in Unicode category Lu, Lt or Nl, and any character in Lo and Ml that don't have contributory property Other_Lowercase
 letter           ::=  upper | lower // and Unicode categories Lo, Lt, Nl
 digit            ::=  ‘0’ | … | ‘9’
 paren            ::=  ‘(’ | ‘)’ | ‘[’ | ‘]’ | ‘{’ | ‘}’

--- a/test/files/run/identifierCase.check
+++ b/test/files/run/identifierCase.check
@@ -1,0 +1,10 @@
+identifierCase.scala:22: warning: patterns after a variable pattern cannot match (SLS 8.1.1)
+      case ªpple         => "not so constant"
+           ^
+identifierCase.scala:23: warning: unreachable code due to variable pattern 'ªpple' on line 22
+      case ʰelper        => "unreachable"
+                            ^
+identifierCase.scala:23: warning: unreachable code
+      case ʰelper        => "unreachable"
+                            ^
+not so constant

--- a/test/files/run/identifierCase.scala
+++ b/test/files/run/identifierCase.scala
@@ -1,0 +1,42 @@
+object Test {
+
+  val $reserved      = "$reserved"
+  val ǅul            = "ǅul"
+  val ǂnûm           = "ǂnûm"
+  val ⅰ_ⅲ            = "ⅰ_ⅲ"
+  val Ⅰ_Ⅲ            = "Ⅰ_Ⅲ"
+  val ↁelerious      = "ↁelerious"
+  val ǃqhàà          = "ǃqhàà"
+  val ʹthatsaletter  = "ʹthatsaletter"
+
+  def main(args: Array[String]): Unit = {
+    val s = "foo" match {
+      case $reserved     => "constant"
+      case ǅul           => "constant"
+      case ǂnûm          => "constant"
+      case ⅰ_ⅲ           => "constant"
+      case Ⅰ_Ⅲ           => "constant"
+      case ↁelerious     => "constant"
+      case ǃqhàà         => "constant"
+      case ʹthatsaletter => "constant"
+      case ªpple         => "not so constant"
+      case ʰelper        => "unreachable"
+    }
+    println(s)
+  }
+
+  //all non-op characters can follow a "normal" leading letter
+  //if any of the second characters below weren't letters or numbers, this wouldn't compile
+  //they are not numbers since they are used as leading characters above
+
+  val a$reserved      = "a$"
+  val aǅul            = "aǅul"
+  val aǂnûm           = "aǂnûm"
+  val aⅰ_ⅲ            = "aⅰ_ⅲ"
+  val aⅠ_Ⅲ            = "aⅠ_Ⅲ"
+  val aↁelerious      = "aↁelerious"
+  val aǃqhàà          = "aǃqhàà"
+  val aʹthatsaletter  = "aʹthatsaletter"
+  val anªpple         = "anªpple"
+  val aʰelper         = "aʰelper"
+}


### PR DESCRIPTION
The implementation checks if it's lower case with _.isLetter && _.isLower

_.isLetter excludes Nl but includes Ml

A different solution could be to align the implementation more closely to the spec (drop the .isLetter check to include Nl lower case letters), which would make the spec a bit more regular, but would mean a change in behaviour (and possibly breaking peoples code if they start their identifiers with lower case roman numeral unicode for some reason for relatively little benefit.)