### PR TITLE
Cache materialized TypeTags

### DIFF
--- a/src/reflect/mima-filters/2.12.0.forwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.forwards.excludes
@@ -32,3 +32,8 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.URLZipArchi
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.FileZipArchive.close")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ManifestResources.close")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive.close")
+
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaMirrors#JavaMirror.typeTag")
+ProblemFilters.exclude[MissingClassProblem]("scala.reflect.runtime.JavaMirrors$JavaMirror$typeTagCache$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.TypeTags.TypeTagImpl")
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.Universe.TypeTagImpl")

--- a/test/files/run/typetags_caching.scala
+++ b/test/files/run/typetags_caching.scala
@@ -1,0 +1,15 @@
+object Test {
+
+  def materializeTag = reflect.runtime.universe.typeTag[Option[String]]
+
+  def materializeTagBinder[T: reflect.runtime.universe.TypeTag] = reflect.runtime.universe.typeTag[Option[T]]
+
+  def main(args: Array[String]): Unit = {
+    val tag1 = materializeTag
+    val tag2 = materializeTag
+    assert(tag1 eq tag2) // materialized TypeTags are now cached
+    assert(tag1.tpe eq tag2.tpe) // TypeTags themselves have always cached the created Type in a lazy val.
+
+    assert(materializeTagBinder[String] ne materializeTagBinder[Object]) // type creators that splice bound types aren't cacheable.
+  }
+}


### PR DESCRIPTION
Type tags summoned with `universe.typeTag` or an implicit search are
expanded thusly:

```scala
object Test {

  def materializeTag = reflect.runtime.universe.typeTag[Option[String]]

  def main(args: Array[String]): Unit = {
    val tag1 = materializeTag
    val tag2 = materializeTag
    println(tag1 eq tag2)
  }
}
```

```scala
    def materializeTag: reflect.runtime.universe.TypeTag[Option[String]] = scala.reflect.runtime.`package`.universe.typeTag[Option[String]](({
      val $u: reflect.runtime.universe.type = scala.this.reflect.runtime.`package`.universe;
      val $m: $u.Mirror = scala.this.reflect.runtime.`package`.universe.runtimeMirror(this.getClass().getClassLoader());
      $u.TypeTag.apply[Option[String]]($m, {
        final class $typecreator1 extends TypeCreator {
          def <init>(): $typecreator1 = {
            $typecreator1.super.<init>();
            ()
          };
          def apply[U <: scala.reflect.api.Universe with Singleton]($m$untyped: scala.reflect.api.Mirror[U]): U#Type = {
            val $u: U = $m$untyped.universe;
            val $m: $u.Mirror = $m$untyped.asInstanceOf[$u.Mirror];
            $u.internal.reificationSupport.TypeRef($u.internal.reificationSupport.ThisType($m.staticPackage("scala").asModule.moduleClass), $m.staticClass("scala.Option"), scala.collection.immutable.List.apply[$u.Type]($u.internal.reificationSupport.TypeRef($u.internal.reificationSupport.SingleType($m.staticPackage("scala").asModule.moduleClass.asType.toTypeConstructor, $m.staticModule("scala.Predef")), $u.internal.reificationSupport.selectType($m.staticModule("scala.Predef").asModule.moduleClass, "String"), scala.collection.immutable.Nil)))
          }
        };
        new $typecreator1()
      })
    }: reflect.runtime.universe.TypeTag[Option[String]]));
```

A new TypeTag is created time `def materializeTag` is called above; the program prints `false`.

This commit introduces a cache, keyed by the synthetic `$typecreator1`, and hosted in the `JavaMirror`.
We know that the `apply` method is a pure, so the caching is sound.

Using `ClassValue` means that we're not introducing a classloader leak.

We are extending the lifetime of the `TypeTag` and contained type itself, which represents a small
risk to existing applications, so I've included an opt-out System property.