### PR TITLE
Sleep longer to overcome shutdown hook concurrency

### DIFF
--- a/test/files/run/shutdownhooks.scala
+++ b/test/files/run/shutdownhooks.scala
@@ -1,6 +1,8 @@
 object Test {
   scala.sys.addShutdownHook {
-    Thread.sleep(1000)
+    // sleep is added here so main#shutdown happens before this hook.
+    // Thread.sleep(1000) was not enough acoording to https://github.com/scala/bug/issues/11536
+    Thread.sleep(3000)
     println("Test#shutdown.")
   }
 


### PR DESCRIPTION
Fixes scala/bug#11536

https://docs.oracle.com/javase/8/docs/api/java/lang/Runtime.html#addShutdownHook-java.lang.Thread-

> When the virtual machine begins its shutdown sequence it will start all registered shutdown hooks in some unspecified order and let them run concurrently