### PR TITLE
fix 11551. use == instead of equals in BitmapIndexedSetNode

### DIFF
--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -467,7 +467,7 @@ private final class BitmapIndexedSetNode[A](
       } else {
         val element0UnimprovedHash = getHash(index)
         val element0Hash = improve(element0UnimprovedHash)
-        if (originalHash == element0UnimprovedHash && element0.equals(element)) {
+        if (originalHash == element0UnimprovedHash && element0 == element) {
           return this
         } else {
           val subNodeNew = mergeTwoKeyValPairs(element0, element0UnimprovedHash, element0Hash, element, originalHash, elementHash, shift + BitPartitionSize)

--- a/test/junit/scala/collection/immutable/HashSetTest.scala
+++ b/test/junit/scala/collection/immutable/HashSetTest.scala
@@ -10,6 +10,14 @@ import scala.tools.testkit.AssertUtil._
 class HashSetTest {
 
   @Test
+  def t11551(): Unit = {
+    val x = Set[AnyVal](1L, (), 28028, -3.8661012E-17, -67)
+    val y = Set[AnyVal](1, 3.3897517E-23, ())
+    val z = x ++ y
+    assertEquals(6, z.size)
+  }
+
+  @Test
   def factoryReuse(): Unit = {
     assertSame(HashSet.empty, HashSet.empty)
     assertSame(HashSet.empty, HashSet())

--- a/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
@@ -376,4 +376,8 @@ object ImmutableChampHashSetProperties extends Properties("immutable.HashSet") {
     hs.removedAll(hs2)
     hs ?= clone
   }
+  property("t11551") = forAll { (x: HashSet[AnyVal], y: HashSet[AnyVal]) =>
+    val z = x ++ y
+    z.size ?= z.toList.toSet.size
+  }
 }


### PR DESCRIPTION
fix https://github.com/scala/bug/issues/11551