### PR TITLE
Added to the document about why it is 'unsafe'.

### DIFF
--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -193,7 +193,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   /**
    * Wrap an existing `Array` into an `ArraySeq` of the proper primitive specialization type
-   * without copying.
+   * without copying. Any changes to wrapped array will break the expected immutability.
    *
    * Note that an array containing boxed primitives can be wrapped in an `ArraySeq` without
    * copying. For example, `val a: Array[Any] = Array(1)` is an array of `Object` at runtime,


### PR DESCRIPTION
In Scala 2.13 or later, it is recommended to use the ArraySeq.unsafeWrapArray method explicitly to convert an Array to Seq without copying the elements. However, even though the method name is given 'unsafe', scaladoc does not describe the unsafe reason.

Since the scaladoc of the ArraySeq.unsafeArray method has notes on the returned array, I think it would be better to write similar notes to the ArraySeq.unsafeWrapArray method.