### PR TITLE
Display warning on `equals` comparing non-references

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1137,10 +1137,41 @@ abstract class RefChecks extends Transform {
         else warnIfLubless()
       }
     }
+
+    private def checkSensibleAnyEquals(pos: Position, qual: Tree, name: Name, sym: Symbol, other: Tree) = {
+      def underlyingClass(tp: Type): Symbol = {
+        val sym = tp.widen.typeSymbol
+        if (sym.isAbstractType) underlyingClass(sym.info.upperBound)
+        else sym
+      }
+      val receiver = underlyingClass(qual.tpe)
+      val actual   = underlyingClass(other.tpe)
+      def typesString = normalizeAll(qual.tpe.widen)+" and "+normalizeAll(other.tpe.widen)
+      def nonSensiblyEquals() = {
+        reporter.warning(pos, s"comparing values of types $typesString using `${name.decode}` is unsafe due to cooperative equality; use `==` instead")
+      }
+      def isScalaNumber(s: Symbol) = s isSubClass ScalaNumberClass
+      def isJavaNumber(s: Symbol)  = s isSubClass JavaNumberClass
+      def isAnyNumber(s: Symbol)   = isScalaNumber(s) || isJavaNumber(s)
+      def isNumeric(s: Symbol)     = isNumericValueClass(unboxedValueClass(s)) || isAnyNumber(s)
+      def isReference(s: Symbol)   = (unboxedValueClass(s) isSubClass AnyRefClass) || (s isSubClass ObjectClass)
+      def isUnit(s: Symbol)        = unboxedValueClass(s) == UnitClass
+      def isNumOrNonRef(s: Symbol) = isNumeric(s) || (!isReference(s) && !isUnit(s))
+      if (isNumeric(receiver) && isNumOrNonRef(actual)) {
+        if (receiver == actual) ()
+        else nonSensiblyEquals()
+      }
+      else if ((sym == Any_equals || sym == Object_equals) && isNumOrNonRef(actual) && !isReference(receiver)) {
+        nonSensiblyEquals()
+      }
+    }
+
     /** Sensibility check examines flavors of equals. */
     def checkSensible(pos: Position, fn: Tree, args: List[Tree]) = fn match {
       case Select(qual, name @ (nme.EQ | nme.NE | nme.eq | nme.ne)) if args.length == 1 && isObjectOrAnyComparisonMethod(fn.symbol) && (!currentOwner.isSynthetic || currentOwner.isAnonymousFunction) =>
         checkSensibleEquals(pos, qual, name, fn.symbol, args.head)
+      case Select(qual, name @ nme.equals_) if args.length == 1 && (!currentOwner.isSynthetic || currentOwner.isAnonymousFunction) =>
+        checkSensibleAnyEquals(pos, qual, name, fn.symbol, args.head)
       case _ =>
     }
 

--- a/test/files/jvm/serialization-new.check
+++ b/test/files/jvm/serialization-new.check
@@ -1,3 +1,15 @@
+serialization-new.scala:24: warning: comparing values of types A and B using `equals` is unsafe due to cooperative equality; use `==` instead
+    println("x equals y: " + (x equals y) + ", y equals x: " + (y equals x))
+                                ^
+serialization-new.scala:24: warning: comparing values of types B and A using `equals` is unsafe due to cooperative equality; use `==` instead
+    println("x equals y: " + (x equals y) + ", y equals x: " + (y equals x))
+                                                                  ^
+serialization-new.scala:25: warning: comparing values of types A and B using `equals` is unsafe due to cooperative equality; use `==` instead
+    assert((x equals y) && (y equals x))
+              ^
+serialization-new.scala:25: warning: comparing values of types B and A using `equals` is unsafe due to cooperative equality; use `==` instead
+    assert((x equals y) && (y equals x))
+                              ^
 warning: 4 deprecations (since 2.13.0); re-run with -deprecation for details
 a1 = Array[1,2,3]
 _a1 = Array[1,2,3]

--- a/test/files/jvm/serialization.check
+++ b/test/files/jvm/serialization.check
@@ -1,3 +1,15 @@
+serialization.scala:24: warning: comparing values of types A and B using `equals` is unsafe due to cooperative equality; use `==` instead
+    println("x equals y: " + (x equals y) + ", y equals x: " + (y equals x))
+                                ^
+serialization.scala:24: warning: comparing values of types B and A using `equals` is unsafe due to cooperative equality; use `==` instead
+    println("x equals y: " + (x equals y) + ", y equals x: " + (y equals x))
+                                                                  ^
+serialization.scala:25: warning: comparing values of types A and B using `equals` is unsafe due to cooperative equality; use `==` instead
+    assert((x equals y) && (y equals x))
+              ^
+serialization.scala:25: warning: comparing values of types B and A using `equals` is unsafe due to cooperative equality; use `==` instead
+    assert((x equals y) && (y equals x))
+                              ^
 warning: 4 deprecations (since 2.13.0); re-run with -deprecation for details
 a1 = Array[1,2,3]
 _a1 = Array[1,2,3]

--- a/test/files/neg/checksensible.check
+++ b/test/files/neg/checksensible.check
@@ -1,4 +1,3 @@
-#partest java8
 checksensible.scala:54: warning: symbol literal is deprecated; use Symbol("sym") instead
   (1 != 'sym)
         ^
@@ -101,124 +100,21 @@ checksensible.scala:86: warning: comparing values of types EqEqRefTest.this.C3 a
 checksensible.scala:97: warning: comparing values of types Unit and Int using `!=` will always yield true
     while ((c = in.read) != -1)
                          ^
+checksensible.scala:105: warning: comparing values of types Long and Int using `equals` is unsafe due to cooperative equality; use `==` instead
+  1L equals 1
+     ^
+checksensible.scala:112: warning: comparing values of types Any and Int using `equals` is unsafe due to cooperative equality; use `==` instead
+  (1L: Any) equals 1
+            ^
+checksensible.scala:113: warning: comparing values of types AnyVal and Int using `equals` is unsafe due to cooperative equality; use `==` instead
+  (1L: AnyVal) equals 1
+               ^
+checksensible.scala:114: warning: comparing values of types AnyVal and AnyVal using `equals` is unsafe due to cooperative equality; use `==` instead
+  (1L: AnyVal) equals (1: AnyVal)
+               ^
+checksensible.scala:117: warning: comparing values of types A and Int using `equals` is unsafe due to cooperative equality; use `==` instead
+  def foo[A](a: A) = a.equals(1)
+                             ^
 error: No warnings can be incurred under -Werror.
-34 warnings
-1 error
-#partest !java8
-checksensible.scala:54: warning: symbol literal is deprecated; use Symbol("sym") instead
-  (1 != 'sym)
-        ^
-checksensible.scala:15: warning: comparing a fresh object using `eq` will always yield false
-  (new AnyRef) eq (new AnyRef)
-               ^
-checksensible.scala:16: warning: comparing a fresh object using `ne` will always yield true
-  (new AnyRef) ne (new AnyRef)
-               ^
-checksensible.scala:17: warning: comparing a fresh object using `eq` will always yield false
-  Shmoopie eq (new AnyRef)
-           ^
-checksensible.scala:18: warning: comparing a fresh object using `eq` will always yield false
-  (Shmoopie: AnyRef) eq (new AnyRef)
-                     ^
-checksensible.scala:19: warning: comparing a fresh object using `eq` will always yield false
-  (new AnyRef) eq Shmoopie
-               ^
-checksensible.scala:20: warning: comparing a fresh object using `eq` will always yield false
-  (new AnyRef) eq null
-               ^
-checksensible.scala:21: warning: comparing a fresh object using `eq` will always yield false
-  null eq new AnyRef
-       ^
-checksensible.scala:28: warning: comparing values of types Unit and Int using `==` will always yield false
-  (c = 1) == 0
-          ^
-checksensible.scala:29: warning: comparing values of types Integer and Unit using `==` will always yield false
-  0 == (c = 1)
-    ^
-checksensible.scala:31: warning: comparing values of types Int and String using `==` will always yield false
-  1 == "abc"
-    ^
-checksensible.scala:35: warning: comparing values of types Some[Int] and Int using `==` will always yield false
-  Some(1) == 1      // as above
-          ^
-checksensible.scala:37: warning: constructor Boolean in class Boolean is deprecated: see corresponding Javadoc for more information.
-  true == new java.lang.Boolean(true) // none of these should warn except for deprecated API
-          ^
-checksensible.scala:38: warning: constructor Boolean in class Boolean is deprecated: see corresponding Javadoc for more information.
-  new java.lang.Boolean(true) == true
-  ^
-checksensible.scala:40: warning: comparing a fresh object using `==` will always yield false
-  new AnyRef == 1
-             ^
-checksensible.scala:42: warning: constructor Integer in class Integer is deprecated: see corresponding Javadoc for more information.
-  1 == (new java.lang.Integer(1)) // ...something like this
-        ^
-checksensible.scala:43: warning: comparing values of types Int and Boolean using `==` will always yield false
-  1 == (new java.lang.Boolean(true))
-    ^
-checksensible.scala:43: warning: constructor Boolean in class Boolean is deprecated: see corresponding Javadoc for more information.
-  1 == (new java.lang.Boolean(true))
-        ^
-checksensible.scala:45: warning: comparing values of types Int and Boolean using `!=` will always yield true
-  1 != true
-    ^
-checksensible.scala:46: warning: comparing values of types Unit and Boolean using `==` will always yield false
-  () == true
-     ^
-checksensible.scala:47: warning: comparing values of types Unit and Unit using `==` will always yield true
-  () == ()
-     ^
-checksensible.scala:48: warning: comparing values of types Unit and Unit using `==` will always yield true
-  () == println()
-     ^
-checksensible.scala:49: warning: comparing values of types Unit and scala.runtime.BoxedUnit using `==` will always yield true
-  () == scala.runtime.BoxedUnit.UNIT // these should warn for always being true/false
-     ^
-checksensible.scala:50: warning: comparing values of types scala.runtime.BoxedUnit and Unit using `!=` will always yield false
-  scala.runtime.BoxedUnit.UNIT != ()
-                               ^
-checksensible.scala:53: warning: comparing values of types Int and Unit using `!=` will always yield true
-  (1 != println())
-     ^
-checksensible.scala:54: warning: comparing values of types Int and Symbol using `!=` will always yield true
-  (1 != 'sym)
-     ^
-checksensible.scala:60: warning: comparing a fresh object using `==` will always yield false
-  ((x: Int) => x + 1) == null
-                      ^
-checksensible.scala:61: warning: comparing a fresh object using `==` will always yield false
-  Bep == ((_: Int) + 1)
-      ^
-checksensible.scala:63: warning: comparing a fresh object using `==` will always yield false
-  new Object == new Object
-             ^
-checksensible.scala:64: warning: comparing a fresh object using `==` will always yield false
-  new Object == "abc"
-             ^
-checksensible.scala:65: warning: comparing a fresh object using `!=` will always yield true
-  new Exception() != new Exception()
-                  ^
-checksensible.scala:68: warning: comparing values of types Int and Null using `==` will always yield false
-  if (foo.length == null) "plante" else "plante pas"
-                 ^
-checksensible.scala:73: warning: comparing values of types Bip and Bop using `==` will always yield false
-  (x1 == x2)
-      ^
-checksensible.scala:83: warning: comparing values of types EqEqRefTest.this.C3 and EqEqRefTest.this.Z1 using `==` will always yield false
-  c3 == z1
-     ^
-checksensible.scala:84: warning: comparing values of types EqEqRefTest.this.Z1 and EqEqRefTest.this.C3 using `==` will always yield false
-  z1 == c3
-     ^
-checksensible.scala:85: warning: comparing values of types EqEqRefTest.this.Z1 and EqEqRefTest.this.C3 using `!=` will always yield true
-  z1 != c3
-     ^
-checksensible.scala:86: warning: comparing values of types EqEqRefTest.this.C3 and String using `!=` will always yield true
-  c3 != "abc"
-     ^
-checksensible.scala:97: warning: comparing values of types Unit and Int using `!=` will always yield true
-    while ((c = in.read) != -1)
-                         ^
-error: No warnings can be incurred under -Werror.
-38 warnings
+39 warnings
 1 error

--- a/test/files/neg/checksensible.scala
+++ b/test/files/neg/checksensible.scala
@@ -100,3 +100,21 @@ class EqEqRefTest {
     in.close
   }
 }
+
+class AnyEqualsTest {
+  1L equals 1
+  // ok, because it's between the same numeric types
+  1 equals 1
+  // ok
+  1L equals "string"
+  // ok
+  1L.equals(())
+  (1L: Any) equals 1
+  (1L: AnyVal) equals 1
+  (1L: AnyVal) equals (1: AnyVal)
+  // ok
+  "string" equals 1
+  def foo[A](a: A) = a.equals(1)
+  // ok
+  def bar[A <: AnyRef](a: A) = a.equals(1)
+}


### PR DESCRIPTION
Ref https://github.com/scala/bug/issues/11551
Ref https://twitter.com/not_xuwei_k/status/1135374786593468416

Scala 2.13.1 or Dotty allows you to write the following expression:

```scala
1 equals 1L
```

or generically as:

```scala
scala> def check[A](a1: A, a2: A): Boolean = a1.equals(a2)
def check[A](a1: A, a2: A): Boolean
```

## problem

This looks seemingly innocuous but it's actually not "safe" because of cooperative equality.

```scala
scala> 1 equals 1L
val res0: Boolean = false

scala> check(1L, 1)
val res1: Boolean = false
```

## what this changes

This PR extends "sensible check" to `equals`, to warn against using it as opposed to `==`:

```scala
[info] Running (fork) scala.tools.nsc.MainGenericRunner -usejavacp
Welcome to Scala 2.13.0-pre-db58db9 (OpenJDK 64-Bit Server VM, Java 1.8.0_232).
Type in expressions for evaluation. Or try :help.

scala> def check[A](a1: A, a2: A): Boolean = a1.equals(a2)
                                                      ^
       warning: comparing values of types A and A using `equals` is unsafe due to cooperative equality; use `==` instead
check: [A](a1: A, a2: A)Boolean
```

/cc @xuwei-k 
