### PR TITLE
Also deprecate backing field symbols.

### DIFF
--- a/src/library/scala/deprecated.scala
+++ b/src/library/scala/deprecated.scala
@@ -64,5 +64,5 @@ import scala.annotation.meta._
  *  @see    [[scala.deprecatedOverriding]]
  *  @see    [[scala.deprecatedName]]
  */
-@getter @setter @beanGetter @beanSetter
+@getter @setter @beanGetter @beanSetter @field
 class deprecated(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation

--- a/test/files/pos/t11538.flags
+++ b/test/files/pos/t11538.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -deprecation -stop:refchecks

--- a/test/files/pos/t11538.scala
+++ b/test/files/pos/t11538.scala
@@ -1,0 +1,13 @@
+package t11538
+
+@deprecated("not for you", since = "just now")
+class Abhorrent
+
+object Bizzle {
+  @deprecated("use mipple instead", since = "recently")
+  val wibble: Abhorrent = mipple
+  @deprecated("use wobble instead", since = "recently")
+  def mipple: Abhorrent = wobble
+  @deprecated("use wibble instead", since = "recently")
+  var wobble: Abhorrent = wibble
+}


### PR DESCRIPTION
Compiling
```scala
@deprecated val foo: T = some.deprecated(call)
```
yielded
```scala
private[this] val `foo `: T = some.deprecated(call)
@deprecated <accessor> def foo: T = this.`foo `
```

where the `@deprecated` has been slapped on the def (where it'll incur deprecation warnings on callers) but not on the val (where it'll suppress deprecation warnings on the body).

Just copy the annotation across.

Fixes scala/bug#11538 in an expedient manner.

Golly, I hope this works.