### PR TITLE
-Ywarn-unused:privates doesn't warn on unused locals

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -653,8 +653,9 @@ trait TypeDiagnostics {
       unusedPrivates.traverse(body)
 
       if (settings.warnUnusedLocals || settings.warnUnusedPrivates) {
+        def shouldWarnOn(sym: Symbol) = if (sym.isPrivate) settings.warnUnusedPrivates else settings.warnUnusedLocals
         val valAdvice = "is never updated: consider using immutable val"
-        for (defn: DefTree <- unusedPrivates.unusedTerms) {
+        def termWarning(defn: SymTree): Unit = {
           val sym = defn.symbol
           val pos = (
             if (defn.pos.isDefined) defn.pos
@@ -663,7 +664,7 @@ trait TypeDiagnostics {
               case sym: TermSymbol => sym.referenced.pos
               case _               => NoPosition
             }
-            )
+          )
           val why = if (sym.isPrivate) "private" else "local"
           var cond = "is never used"
           val what = (
@@ -682,19 +683,19 @@ trait TypeDiagnostics {
             else if (sym.isMethod) s"method ${sym.name.decoded}"
             else if (sym.isModule) s"object ${sym.name.decoded}"
             else "term"
-            )
+          )
           typer.context.warning(pos, s"$why $what in ${sym.owner} $cond")
         }
+        def typeWarning(defn: SymTree): Unit = {
+          val why = if (defn.symbol.isPrivate) "private" else "local"
+          typer.context.warning(defn.pos, s"$why ${defn.symbol.fullLocationString} is never used")
+        }
+
+        for (defn <- unusedPrivates.unusedTerms if shouldWarnOn(defn.symbol)) { termWarning(defn) }
+        for (defn <- unusedPrivates.unusedTypes if shouldWarnOn(defn.symbol)) { typeWarning(defn) }
+
         for (v <- unusedPrivates.unsetVars) {
           typer.context.warning(v.pos, s"local var ${v.name} in ${v.owner} ${valAdvice}")
-        }
-        for (t <- unusedPrivates.unusedTypes) {
-          val sym = t.symbol
-          val wrn = if (sym.isPrivate) settings.warnUnusedPrivates else settings.warnUnusedLocals
-          if (wrn) {
-            val why = if (sym.isPrivate) "private" else "local"
-            typer.context.warning(t.pos, s"$why ${sym.fullLocationString} is never used")
-          }
         }
       }
       if (settings.warnUnusedPatVars) {

--- a/test/files/neg/warn-unused-locals.check
+++ b/test/files/neg/warn-unused-locals.check
@@ -1,0 +1,24 @@
+warn-unused-locals.scala:7: warning: local var x in method f0 is never used
+    var x = 1 // warn
+        ^
+warn-unused-locals.scala:14: warning: local val b in method f1 is never used
+    val b = new Outer // warn
+        ^
+warn-unused-locals.scala:25: warning: local object HiObject in method l1 is never used
+    object HiObject { def f = this } // warn
+           ^
+warn-unused-locals.scala:26: warning: local class Hi is never used
+    class Hi { // warn
+          ^
+warn-unused-locals.scala:30: warning: local class DingDongDoobie is never used
+    class DingDongDoobie // warn
+          ^
+warn-unused-locals.scala:33: warning: local type OtherThing is never used
+    type OtherThing = String // warn
+         ^
+warn-unused-locals.scala:18: warning: local var x in method f2 is never updated: consider using immutable val
+    var x = 100 // warn about it being a var
+        ^
+error: No warnings can be incurred under -Xfatal-warnings.
+7 warnings found
+one error found

--- a/test/files/neg/warn-unused-locals.flags
+++ b/test/files/neg/warn-unused-locals.flags
@@ -1,0 +1,1 @@
+-Ywarn-unused:locals -Xfatal-warnings

--- a/test/files/neg/warn-unused-locals.scala
+++ b/test/files/neg/warn-unused-locals.scala
@@ -1,0 +1,36 @@
+class Outer {
+  class Inner
+}
+
+trait Locals {
+  def f0 = {
+    var x = 1 // warn
+    var y = 2 // no warn
+    y = 3
+    y + y
+  }
+  def f1 = {
+    val a = new Outer // no warn
+    val b = new Outer // warn
+    new a.Inner
+  }
+  def f2 = {
+    var x = 100 // warn about it being a var
+    x
+  }
+}
+
+object Types {
+  def l1() = {
+    object HiObject { def f = this } // warn
+    class Hi { // warn
+      def f1: Hi = new Hi
+      def f2(x: Hi) = x
+    }
+    class DingDongDoobie // warn
+    class Bippy // no warn
+    type Something = Bippy // no warn
+    type OtherThing = String // warn
+    (new Bippy): Something
+  }
+}

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -40,18 +40,9 @@ warn-unused-privates.scala:70: warning: private default argument in trait Defaul
 warn-unused-privates.scala:70: warning: private default argument in trait DefaultArgs is never used
   private def bippy(x1: Int, x2: Int = 10, x3: Int = 15): Int = x1 + x2 + x3
                                            ^
-warn-unused-privates.scala:86: warning: local var x in method f0 is never used
-    var x = 1 // warn
-        ^
-warn-unused-privates.scala:93: warning: local val b in method f1 is never used
-    val b = new Outer // warn
-        ^
 warn-unused-privates.scala:103: warning: private object Dongo in object Types is never used
   private object Dongo { def f = this } // warn
                  ^
-warn-unused-privates.scala:113: warning: local object HiObject in method l1 is never used
-    object HiObject { def f = this } // warn
-           ^
 warn-unused-privates.scala:136: warning: private method x_= in class OtherNames is never used
   private def x_=(i: Int): Unit = ()
               ^
@@ -61,60 +52,21 @@ warn-unused-privates.scala:137: warning: private method x in class OtherNames is
 warn-unused-privates.scala:138: warning: private method y_= in class OtherNames is never used
   private def y_=(i: Int): Unit = ()
               ^
-warn-unused-privates.scala:97: warning: local var x in method f2 is never updated: consider using immutable val
-    var x = 100 // warn about it being a var
-        ^
 warn-unused-privates.scala:104: warning: private class Bar1 in object Types is never used
   private class Bar1 // warn
                 ^
 warn-unused-privates.scala:106: warning: private type Alias1 in object Types is never used
   private type Alias1 = String // warn
                ^
-warn-unused-privates.scala:114: warning: local class Hi is never used
-    class Hi { // warn
-          ^
-warn-unused-privates.scala:118: warning: local class DingDongDoobie is never used
-    class DingDongDoobie // warn
-          ^
-warn-unused-privates.scala:121: warning: local type OtherThing is never used
-    type OtherThing = String // warn
-         ^
 warn-unused-privates.scala:216: warning: private class for your eyes only in object not even using companion privates is never used
   private implicit class `for your eyes only`(i: Int) {  // warn
                          ^
 warn-unused-privates.scala:232: warning: private class D in class nonprivate alias is enclosing is never used
   private class D extends C2   // warn
                 ^
-warn-unused-privates.scala:153: warning: pattern var x in method f is never used; `x@_' suppresses this warning
-    val C(x, y, Some(z)) = c              // warn
-          ^
-warn-unused-privates.scala:153: warning: pattern var y in method f is never used; `y@_' suppresses this warning
-    val C(x, y, Some(z)) = c              // warn
-             ^
-warn-unused-privates.scala:153: warning: pattern var z in method f is never used; `z@_' suppresses this warning
-    val C(x, y, Some(z)) = c              // warn
-                     ^
-warn-unused-privates.scala:161: warning: pattern var z in method h is never used; `z@_' suppresses this warning
-    val C(x @ _, y @ _, z @ Some(_)) = c  // warn for z?
-                        ^
-warn-unused-privates.scala:166: warning: pattern var x in method v is never used; `x@_' suppresses this warning
-    val D(x) = d                          // warn
-         ^
-warn-unused-privates.scala:201: warning: pattern var z in method f is never used; `z@_' suppresses this warning
-    case z => "warn"
-         ^
-warn-unused-privates.scala:208: warning: pattern var z in method f is never used; `z@_' suppresses this warning
-    case Some(z) => "warn"
-              ^
-warn-unused-privates.scala:20: warning: parameter value msg0 in class B3 is never used
-class B3(msg0: String) extends A("msg")
-         ^
-warn-unused-privates.scala:136: warning: parameter value i in method x_= is never used
-  private def x_=(i: Int): Unit = ()
-                  ^
-warn-unused-privates.scala:138: warning: parameter value i in method y_= is never used
-  private def y_=(i: Int): Unit = ()
-                  ^
+warn-unused-privates.scala:97: warning: local var x in method f2 is never updated: consider using immutable val
+    var x = 100 // warn about it being a var
+        ^
 error: No warnings can be incurred under -Xfatal-warnings.
-39 warnings found
+23 warnings found
 one error found

--- a/test/files/neg/warn-unused-privates.flags
+++ b/test/files/neg/warn-unused-privates.flags
@@ -1,1 +1,1 @@
--Ywarn-unused -Xfatal-warnings
+-Ywarn-unused:privates -Xfatal-warnings


### PR DESCRIPTION
Narrow the eponymous test case to privates warnings only (there are similarly-named partests for the other warnable cases).