### PR TITLE
Fix type inference involving wildcards

### DIFF
--- a/test/files/pos/t11558.scala
+++ b/test/files/pos/t11558.scala
@@ -1,3 +1,5 @@
 class Test {
-  java.util.stream.Stream.of(1,2,3).map(_.toString) // check that map's type param is inferred (should be String)
+  trait F1[A, B] { def apply(a: A): B }
+  trait S[T] { def map[R](f: F1[_ >: T, _ <: R]): S[R] }
+  (??? : S[Int]).map(_.toString) // check that map's type param is inferred (should be String)
 }

--- a/test/files/pos/t11558.scala
+++ b/test/files/pos/t11558.scala
@@ -1,0 +1,3 @@
+class Test {
+  java.util.stream.Stream.of(1,2,3).map(_.toString) // check that map's type param is inferred (should be String)
+}


### PR DESCRIPTION
Use == instead of =:= because we're looking for occurs, not equality.

When we were using =:= to detect occurrences of type params in bounds,
we'd accidentally unify too much (e.g. on wildcards / other type vars).

Discovered while looking into why this doesn't type check:
`java.util.stream.Stream.of(1,2,3).map(_.toString)`

I noticed that there was cross talk between the type params of java.util.Function during type inference.

This partially regressed in scala/scala#6492, but was actually wrong since the one with `*** empty log message ***`

Fix scala/bug#11558
Relates to scala/scala-dev#184