### PR TITLE
Extend varargs empty sequence optimisation.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -485,6 +485,11 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
       case Apply(appMeth, elem0 :: Apply(wrapArrayMeth, (rest @ ArrayValue(elemtpt, _)) :: Nil) :: Nil)
       if wrapArrayMeth.symbol == wrapVarargsArrayMethod(elemtpt.tpe) && appMeth.symbol == ArrayModule_apply(elemtpt.tpe) =>
         treeCopy.ArrayValue(rest, rest.elemtpt, elem0 :: rest.elems).transform(this)
+      case Apply(appMeth, elem :: (nil: RefTree) :: Nil)
+      if nil.symbol == NilModule && appMeth.symbol == ArrayModule_apply(elem.tpe.widen) && treeInfo.isExprSafeToInline(nil) =>
+        localTyper.typedPos(elem.pos) {
+          ArrayValue(TypeTree(elem.tpe), elem :: Nil)
+        } transform this
 
       // List(a, b, c) ~> new ::(a, new ::(b, new ::(c, Nil)))
       case Apply(appMeth @ Select(qual, _), List(Apply(wrapArrayMeth, List(StripCast(rest @ ArrayValue(elemtpt, _))))))

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -479,14 +479,14 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
       // with just `ArrayValue(...).$asInstanceOf[...]`
       //
       // See scala/bug#6611; we must *only* do this for literal vararg arrays.
-      case Apply(appMeth, Apply(wrapRefArrayMeth, (arg @ StripCast(ArrayValue(_, _))) :: Nil) :: _ :: Nil)
-      if wrapRefArrayMeth.symbol == currentRun.runDefinitions.wrapVarargsRefArrayMethod && appMeth.symbol == ArrayModule_genericApply =>
+      case Apply(appMeth @ Select(appMethQual, _), Apply(wrapRefArrayMeth, (arg @ StripCast(ArrayValue(_, _))) :: Nil) :: _ :: Nil)
+      if wrapRefArrayMeth.symbol == currentRun.runDefinitions.wrapVarargsRefArrayMethod && appMeth.symbol == ArrayModule_genericApply && treeInfo.isQualifierSafeToElide(appMethQual) =>
         arg.transform(this)
-      case Apply(appMeth, elem0 :: Apply(wrapArrayMeth, (rest @ ArrayValue(elemtpt, _)) :: Nil) :: Nil)
-      if wrapArrayMeth.symbol == wrapVarargsArrayMethod(elemtpt.tpe) && appMeth.symbol == ArrayModule_apply(elemtpt.tpe) =>
+      case Apply(appMeth @ Select(appMethQual, _), elem0 :: Apply(wrapArrayMeth, (rest @ ArrayValue(elemtpt, _)) :: Nil) :: Nil)
+      if wrapArrayMeth.symbol == wrapVarargsArrayMethod(elemtpt.tpe) && appMeth.symbol == ArrayModule_apply(elemtpt.tpe) && treeInfo.isQualifierSafeToElide(appMethQual) =>
         treeCopy.ArrayValue(rest, rest.elemtpt, elem0 :: rest.elems).transform(this)
-      case Apply(appMeth, elem :: (nil: RefTree) :: Nil)
-      if nil.symbol == NilModule && appMeth.symbol == ArrayModule_apply(elem.tpe.widen) && treeInfo.isExprSafeToInline(nil) =>
+      case Apply(appMeth @ Select(appMethQual, _), elem :: (nil: RefTree) :: Nil)
+      if nil.symbol == NilModule && appMeth.symbol == ArrayModule_apply(elem.tpe.widen) && treeInfo.isExprSafeToInline(nil) && treeInfo.isQualifierSafeToElide(appMethQual) =>
         localTyper.typedPos(elem.pos) {
           ArrayValue(TypeTree(elem.tpe), elem :: Nil)
         } transform this

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -320,8 +320,10 @@ abstract class UnCurry extends InfoTransform
           }
           else {
             def mkArray = mkArrayValue(args drop (params.length - 1), varargsElemType)
+            // if args.length < params.length the repeated argument is empty
+            def emptyVarargs = compareLengths(args, params) < 0
             if (javaStyleVarArgs) mkArray
-            else if (args.isEmpty) gen.mkNil  // avoid needlessly double-wrapping an empty argument list
+            else if (emptyVarargs) gen.mkNil  // avoid needlessly double-wrapping an empty argument list
             else arrayToSequence(mkArray, varargsElemType, copy = false) // fresh array, no need to copy
           }
 

--- a/test/junit/scala/tools/nsc/transform/UncurryTest.scala
+++ b/test/junit/scala/tools/nsc/transform/UncurryTest.scala
@@ -1,0 +1,33 @@
+package scala.tools.nsc
+package transform
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testkit.BytecodeTesting
+
+@RunWith(classOf[JUnit4])
+class UncurryTest {
+  import BytecodeTesting._
+
+  @Test def emptyVarargsDoesNotAllocate(): Unit = {
+    val code =
+      """
+        |def test0 = va0()
+        |def test1 = va0(0)
+        |def test2 = va1(0)
+        |def test3 = va1(0, 0)
+        |def va0(elems: Int*): Int = ???
+        |def va1(first: Int, rest: Int*): Int = ???
+        |
+      """.stripMargin
+    val compiler = newCompiler()
+    val List(test0, test1, test2, test3, va0, va1) = compiler.compileMethods(code)
+    assertDoesNotInvoke(test0, "wrapIntArray")
+    assertInvoke(test1, "scala/runtime/ScalaRunTime$", "wrapIntArray")
+    assertDoesNotInvoke(test2, "wrapIntArray")
+    assertInvoke(test3, "scala/runtime/ScalaRunTime$", "wrapIntArray")
+  }
+
+}


### PR DESCRIPTION
There was code to ensure that
```scala
def va(is: Int*) = is.sum
va()
```
to pass `Nil` to `va` rather than allocating and wrapping a new emptyarray. This commit makes that optimisation work even if there are other formal parameters in the varargs method:
```scala
def va2(i: Int, is: Int*) = i * is.sum
```

Fixes rorygraves/scalac_perf#21.