### PR TITLE
Dedup stringPrefix deprecation message

### DIFF
--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -36,7 +36,6 @@ trait BitSet extends SortedSet[Int] with BitSetOps[BitSet] {
   override protected def fromSpecific(coll: IterableOnce[Int]): BitSet = bitSetFactory.fromSpecific(coll)
   override protected def newSpecificBuilder: Builder[Int, BitSet] = bitSetFactory.newBuilder
   override def empty: BitSet = bitSetFactory.empty
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "BitSet"
   override def unsorted: Set[Int] = this
 }

--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -23,7 +23,6 @@ import scala.math.Ordering
 trait IndexedSeq[+A] extends Seq[A]
   with IndexedSeqOps[A, IndexedSeq, IndexedSeq[A]]
   with IterableFactoryDefaults[A, IndexedSeq] {
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix: String = "IndexedSeq"
 
   override def iterableFactory: SeqFactory[IndexedSeq] = IndexedSeq

--- a/src/library/scala/collection/IndexedSeqView.scala
+++ b/src/library/scala/collection/IndexedSeqView.scala
@@ -39,7 +39,6 @@ trait IndexedSeqView[+A] extends IndexedSeqOps[A, View, View[A]] with SeqView[A]
   def appendedAll[B >: A](suffix: IndexedSeqView.SomeIndexedSeqOps[B]): IndexedSeqView[B] = new IndexedSeqView.Concat(this, suffix)
   def prependedAll[B >: A](prefix: IndexedSeqView.SomeIndexedSeqOps[B]): IndexedSeqView[B] = new IndexedSeqView.Concat(prefix, this)
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix: String = "IndexedSeqView"
 }
 

--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -23,7 +23,6 @@ import scala.language.higherKinds
 trait LinearSeq[+A] extends Seq[A]
   with LinearSeqOps[A, LinearSeq, LinearSeq[A]]
   with IterableFactoryDefaults[A, LinearSeq] {
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix: String = "LinearSeq"
 
   override def iterableFactory: SeqFactory[LinearSeq] = LinearSeq

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -52,7 +52,6 @@ trait Map[K, +V]
   @deprecated("Use -- or removedAll on an immutable Map", "2.13.0")
   def - (key1: K, key2: K, keys: K*): Map[K, V]
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix: String = "Map"
 
   override def toString(): String = super[Iterable].toString() // Because `Function1` overrides `toString` too

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -50,7 +50,6 @@ trait Seq[+A]
 
   override def toString(): String = super[Iterable].toString()
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix: String = "Seq"
 }
 

--- a/src/library/scala/collection/SeqView.scala
+++ b/src/library/scala/collection/SeqView.scala
@@ -32,7 +32,6 @@ trait SeqView[+A] extends SeqOps[A, View, View[A]] with View[A] {
 
   override def sorted[B >: A](implicit ord: Ordering[B]): SeqView[A] = new SeqView.Sorted(this, ord)
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix: String = "SeqView"
 }
 

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -41,7 +41,6 @@ trait Set[A]
 
   override def iterableFactory: IterableFactory[Set] = Set
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix: String = "Set"
 
   override def toString(): String = super[Iterable].toString() // Because `Function1` overrides `toString` too

--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -26,7 +26,6 @@ trait SortedMap[K, +V]
 
   def sortedMapFactory: SortedMapFactory[SortedMap] = SortedMap
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix: String = "SortedMap"
 }
 

--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -25,7 +25,6 @@ trait SortedSet[A] extends Set[A]
 
   def sortedIterableFactory: SortedIterableFactory[SortedSet] = SortedSet
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix: String = "SortedSet"
 }
 

--- a/src/library/scala/collection/View.scala
+++ b/src/library/scala/collection/View.scala
@@ -36,7 +36,6 @@ trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] with Itera
 
   override def toString: String  = stringPrefix + "(<not computed>)"
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix: String = "View"
 
   @deprecated("Views no longer know about their underlying collection type; .force always returns an IndexedSeq", "2.13.0")

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -483,7 +483,6 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
 
   protected[this] def writeReplace(): AnyRef = new DefaultSerializationProxy(AnyRefMap.toFactory[K, V](AnyRefMap), this)
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "AnyRefMap"
 }
 

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -218,7 +218,6 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   @deprecatedOverriding("ArrayBuffer[A] no longer extends Builder[A, ArrayBuffer[A]]", "2.13.0")
   @inline def mapResult[NewTo](f: (ArrayBuffer[A]) => NewTo): Builder[A, NewTo] = new GrowableBuilder[A, ArrayBuffer[A]](this).mapResult(f)
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "ArrayBuffer"
 
   override def copyToArray[B >: A](xs: Array[B], start: Int): Int = copyToArray[B](xs, start, length)

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -494,7 +494,6 @@ class ArrayDeque[A] protected (
     reset(array = array2, start = 0, end = n)
   }
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "ArrayDeque"
 }
 

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -95,7 +95,6 @@ sealed abstract class ArraySeq[T]
     s.asInstanceOf[S with EfficientSplit]
   }
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "ArraySeq"
 
   /** Clones this object, including the underlying Array. */

--- a/src/library/scala/collection/mutable/Buffer.scala
+++ b/src/library/scala/collection/mutable/Buffer.scala
@@ -168,7 +168,6 @@ trait Buffer[A]
     this
   }
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "Buffer"
 }
 

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -459,7 +459,6 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
 
   override def mapFactory: MapFactory[HashMap] = HashMap
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "HashMap"
 }
 

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -361,7 +361,6 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
 
   protected[this] def writeReplace(): AnyRef = new DefaultSerializationProxy(new HashSet.DeserializationFactory[A](table.length, loadFactor), this)
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "HashSet"
 }
 

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -223,7 +223,6 @@ class LinkedHashMap[K, V]
     table.init(in, table.createNewEntry(in.readObject().asInstanceOf[K], in.readObject().asInstanceOf[V]))
   }
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "LinkedHashMap"
 }
 

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -149,7 +149,6 @@ class LinkedHashSet[A]
     table.init(in, table.createNewEntry(in.readObject().asInstanceOf[A], null))
   }
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "LinkedHashSet"
 }
 

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -351,7 +351,6 @@ class ListBuffer[A]
    */
   override def lastOption: Option[A] = if (last0 eq null) None else Some(last0.head)
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "ListBuffer"
 
 }

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -42,7 +42,6 @@ class Queue[A] protected (array: Array[AnyRef], start: Int, end: Int)
 
   override def iterableFactory: SeqFactory[Queue] = Queue
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "Queue"
 
   /**

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -45,7 +45,6 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
 
   override def iterableFactory: SeqFactory[Stack] = Stack
 
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "Stack"
 
   /**

--- a/src/library/scala/collection/mutable/WeakHashMap.scala
+++ b/src/library/scala/collection/mutable/WeakHashMap.scala
@@ -38,7 +38,6 @@ class WeakHashMap[K, V] extends JMapWrapper[K, V](new java.util.WeakHashMap)
     with MapFactoryDefaults[K, V, WeakHashMap, Iterable] {
   override def empty = new WeakHashMap[K, V]
   override def mapFactory: MapFactory[WeakHashMap] = WeakHashMap
-  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "WeakHashMap"
 }
 

--- a/test/files/neg/FooMapView.check
+++ b/test/files/neg/FooMapView.check
@@ -1,0 +1,6 @@
+FooMapView.scala:6: warning: overriding method stringPrefix in trait Iterable is deprecated (since 2.13.0): Override className instead
+  override def stringPrefix = "FooMapView"
+               ^
+error: No warnings can be incurred under -Werror.
+one warning found
+one error found

--- a/test/files/neg/FooMapView.scala
+++ b/test/files/neg/FooMapView.scala
@@ -1,0 +1,7 @@
+// scalac: -Xfatal-warnings -deprecation
+//
+class FooMapView extends collection.MapView[Int,Int] {
+  def iterator: Iterator[(Int,Int)] = ???
+  def get(key: Int) = None
+  override def stringPrefix = "FooMapView"
+}


### PR DESCRIPTION
While looking at #8090, I noticed the deprecation warning for `stringPrefix` is repeated in a bunch of places.  When client code tries to override `stringPrefix` for the third time, this produces multiple instances of the deprecation warning.

```
FooMapView.scala:6: warning: overriding method stringPrefix in trait View 
is deprecated (since 2.13.0): Override className instead
  override def stringPrefix = "FooMapView"
               ^
FooMapView.scala:6: warning: overriding method stringPrefix in trait Iterable 
is deprecated (since 2.13.0): Override className instead
  override def stringPrefix = "FooMapView"
               ^
```

For some reason, there are a few places where the warning is different:

```scala
@deprecatedOverriding("Compatibility override", since="2.13.0")
override protected[this] def stringPrefix = ...
```
