### PR TITLE
Fix MapView.toString when overriden

### DIFF
--- a/src/library/scala/collection/MapView.scala
+++ b/src/library/scala/collection/MapView.scala
@@ -53,7 +53,7 @@ trait MapView[K, +V]
 
   override def toString: String = super[View].toString
 
-  override protected[this] def className: String = "MapView"
+  override protected[this] def stringPrefix: String = "MapView"
 }
 
 object MapView extends MapViewFactory {

--- a/test/junit/scala/collection/MapViewTest.scala
+++ b/test/junit/scala/collection/MapViewTest.scala
@@ -11,4 +11,22 @@ class MapViewTest {
   def _toString(): Unit = {
     assertEquals("MapView(<not computed>)", Map(1 -> 2).view.toString)
   }
+  @Test
+  def testStringPrefixToString(): Unit = {
+    val mapView = new collection.MapView[Int,Int] {
+      override def stringPrefix = "FooMapView" // !
+      def iterator: Iterator[(Int,Int)] = ???
+      def get(key: Int) = None
+    }
+    assertEquals("FooMapView(<not computed>)", mapView.toString)
+  }
+  @Test
+  def testClassNameToString(): Unit = {
+    val mapView = new collection.MapView[Int,Int] {
+      override def className = "FooMapView"         // !
+      def iterator: Iterator[(Int,Int)] = ???
+      def get(key: Int) = None
+    }
+    assertEquals("FooMapView(<not computed>)", mapView.toString)
+  }
 }


### PR DESCRIPTION
Since `MapView` isn't marked final and can be subclassed, the deprecated `stringPrefix` field needs to be set instead of `className`, for now, until the former is removed.  This is consistent with the rest of collections.