### PR TITLE
Add more XML to partest suite

### DIFF
--- a/test/files/neg/xml-attributes.check
+++ b/test/files/neg/xml-attributes.check
@@ -1,0 +1,5 @@
+xml-attributes.scala:4: error: To compile XML syntax, the scala.xml package must be on the classpath.
+Please see https://github.com/scala/scala-xml for details.
+    <root lang="en" type='xml'>
+    ^
+one error found

--- a/test/files/neg/xml-attributes.scala
+++ b/test/files/neg/xml-attributes.scala
@@ -1,0 +1,8 @@
+object foo {
+  val bar = "baz"
+  val xml =
+    <root lang="en" type='xml'>
+      <child attr="&quot;" foo={bar}/>
+      <child ns:attr="" foo={bar}/>
+    </root>
+}

--- a/test/files/neg/xml-comments.check
+++ b/test/files/neg/xml-comments.check
@@ -1,0 +1,5 @@
+xml-comments.scala:4: error: To compile XML syntax, the scala.xml package must be on the classpath.
+Please see https://github.com/scala/scala-xml for details.
+    <root>
+    ^
+one error found

--- a/test/files/neg/xml-comments.scala
+++ b/test/files/neg/xml-comments.scala
@@ -1,0 +1,8 @@
+object foo {
+  val bar = "baz"
+  val xml = 
+    <root>
+      <!---->
+      <!-- {bar} --->
+    </root>
+}

--- a/test/files/neg/xml-entityref.check
+++ b/test/files/neg/xml-entityref.check
@@ -1,0 +1,5 @@
+xml-entityref.scala:4: error: To compile XML syntax, the scala.xml package must be on the classpath.
+Please see https://github.com/scala/scala-xml for details.
+    <root>
+    ^
+one error found

--- a/test/files/neg/xml-entityref.scala
+++ b/test/files/neg/xml-entityref.scala
@@ -1,0 +1,7 @@
+object foo {
+  val bar = "baz"
+  val xml =
+    <root>
+      &amp; &quot; &#x27; &lt; &gt;
+    </root>
+}

--- a/test/files/neg/xml-match.check
+++ b/test/files/neg/xml-match.check
@@ -1,0 +1,5 @@
+xml-match.scala:3: error: To compile XML syntax, the scala.xml package must be on the classpath.
+Please see https://github.com/scala/scala-xml for details.
+    case <t>{ _* }</t> => <q/>
+         ^
+one error found

--- a/test/files/neg/xml-match.scala
+++ b/test/files/neg/xml-match.scala
@@ -1,0 +1,22 @@
+object foo {
+  def bar(e: Elem) = e match {
+    case <t>{ _* }</t> => <q/>
+    case <t>{ _ }</t> => <q/>
+    case <t>{{3}}</t> => <t>{{3}}</t>
+    case <t> {{3}}</t> => <t> {{3}}</t>
+    case <version>{ x }</version> if x.toString.toInt < 4 =>
+      <version>{ x.toString.toInt + 1 }</version>
+  }
+  def bar(n: Node) = n match {
+    case <t>{ _* }</t> => <q/>
+    case <t>{ _ }</t> => <q/>
+    case <t>{{3}}</t> => <t>{{3}}</t>
+    case <t> {{3}} </t> => <t> {{3}} </t>
+    case <version>{ x }</version> if x.toString.toInt < 4 =>
+      <version>{ x.toString.toInt + 1 }</version>
+  }
+  def bar(n: Any) = null match {
+    // illegal - bug #1764
+    case <p> { _* } </p> =>
+  }
+}

--- a/test/files/neg/xml-ns-empty.check
+++ b/test/files/neg/xml-ns-empty.check
@@ -1,0 +1,5 @@
+xml-ns-empty.scala:3: error: To compile XML syntax, the scala.xml package must be on the classpath.
+Please see https://github.com/scala/scala-xml for details.
+    <a xmlns=""/>
+    ^
+one error found

--- a/test/files/neg/xml-ns-empty.scala
+++ b/test/files/neg/xml-ns-empty.scala
@@ -1,0 +1,5 @@
+object foo {
+  val n = 
+    <a xmlns=""/>
+  n.namespace == null
+}

--- a/test/files/neg/xml-parens.check
+++ b/test/files/neg/xml-parens.check
@@ -1,0 +1,5 @@
+xml-parens.scala:4: error: To compile XML syntax, the scala.xml package must be on the classpath.
+Please see https://github.com/scala/scala-xml for details.
+  <e></e>()
+  ^
+one error found

--- a/test/files/neg/xml-parens.scala
+++ b/test/files/neg/xml-parens.scala
@@ -1,0 +1,5 @@
+// scalac: -Ystop-after:typer
+//
+object Test {
+  <e></e>()
+}

--- a/test/files/neg/xml-pcdata.check
+++ b/test/files/neg/xml-pcdata.check
@@ -1,0 +1,5 @@
+xml-pcdata.scala:4: error: To compile XML syntax, the scala.xml package must be on the classpath.
+Please see https://github.com/scala/scala-xml for details.
+    <![CDATA[]]>
+    ^
+one error found

--- a/test/files/neg/xml-pcdata.scala
+++ b/test/files/neg/xml-pcdata.scala
@@ -1,0 +1,6 @@
+object foo {
+  val bar = "baz"
+  val cdata =
+    <![CDATA[]]>
+    <![CDATA[{bar}]]>
+}

--- a/test/files/neg/xml-procinstr.check
+++ b/test/files/neg/xml-procinstr.check
@@ -1,0 +1,5 @@
+xml-procinstr.scala:4: error: To compile XML syntax, the scala.xml package must be on the classpath.
+Please see https://github.com/scala/scala-xml for details.
+    <?xml-stylesheet href="style.xslt" type="text/xsl"?>
+    ^
+one error found

--- a/test/files/neg/xml-procinstr.scala
+++ b/test/files/neg/xml-procinstr.scala
@@ -1,0 +1,8 @@
+object foo {
+  val bar = "baz"
+  val xml =
+    <?xml-stylesheet href="style.xslt" type="text/xsl"?>
+    <root>
+      <?foo {bar}?>
+    </root>
+}

--- a/test/files/neg/xml-quasiquote.check
+++ b/test/files/neg/xml-quasiquote.check
@@ -1,0 +1,5 @@
+<quasiquote>:1: error: To compile XML syntax, the scala.xml package must be on the classpath.
+Please see https://github.com/scala/scala-xml for details.
+<sample xmlns='ns1'/>
+^
+one error found

--- a/test/files/neg/xml-quasiquote.scala
+++ b/test/files/neg/xml-quasiquote.scala
@@ -1,0 +1,6 @@
+import reflect.runtime.universe._
+
+object foo {
+  val ns1 =
+    q"<sample xmlns='ns1'/>"
+}

--- a/test/files/neg/xml-quasiquote2.check
+++ b/test/files/neg/xml-quasiquote2.check
@@ -1,0 +1,4 @@
+xml-quasiquote2.scala:5: error: input ended while parsing XML
+    q"<sample xmlns='ns1'>"
+                          ^
+one error found

--- a/test/files/neg/xml-quasiquote2.scala
+++ b/test/files/neg/xml-quasiquote2.scala
@@ -1,0 +1,6 @@
+import reflect.runtime.universe._
+
+object foo {
+  val ns1 =
+    q"<sample xmlns='ns1'>"
+}

--- a/test/files/pos/xml-interpolation.scala
+++ b/test/files/pos/xml-interpolation.scala
@@ -7,5 +7,7 @@ object foo {
       {bar}
       { bar }
       {{ bar }}
+      {{ 3 }}
+      {{3}}
     </root>
 }

--- a/test/files/pos/xml-match.scala
+++ b/test/files/pos/xml-match.scala
@@ -1,0 +1,20 @@
+// scalac: -Ystop-after:parser
+//
+object foo {
+  def bar(e: Elem) = e match {
+    case <t>{ _* }</t> => <q/>
+    case <t>{ _ }</t> => <q/>
+    case <t>{{3}}</t> => <t>{{3}}</t>
+    case <t> {{3}}</t> => <t> {{3}}</t>
+    case <version>{ x }</version> if x.toString.toInt < 4 =>
+      <version>{ x.toString.toInt + 1 }</version>
+  }
+  def bar(n: Node) = n match {
+    case <t>{ _* }</t> => <q/>
+    case <t>{ _ }</t> => <q/>
+    case <t>{{3}}</t> => <t>{{3}}</t>
+    case <t> {{3}} </t> => <t> {{3}} </t>
+    case <version>{ x }</version> if x.toString.toInt < 4 =>
+      <version>{ x.toString.toInt + 1 }</version>
+  }
+}

--- a/test/files/pos/xml-ns-empty.scala
+++ b/test/files/pos/xml-ns-empty.scala
@@ -1,0 +1,7 @@
+// scalac: -Ystop-after:parser
+//
+object foo {
+  val n = 
+    <a xmlns=""/>
+  n.namespace == null
+}

--- a/test/files/pos/xml-ns-text.scala
+++ b/test/files/pos/xml-ns-text.scala
@@ -1,0 +1,7 @@
+// scalac: -Ystop-after:parser
+//
+object foo {
+  val xml = 
+    <wsdl:definitions name={ serviceName } xmlns:tns={ new _root_.scala.xml.Text("target3") }>
+    </wsdl:definitions>;
+}

--- a/test/files/pos/xml-pcdata.scala
+++ b/test/files/pos/xml-pcdata.scala
@@ -7,4 +7,7 @@ object foo {
       <![CDATA[]]>
       <![CDATA[{bar}]]>
     </root>
+  val pcdata =
+      <![CDATA[]]>
+      <![CDATA[{bar}]]>
 }

--- a/test/files/pos/xml-quasiquote.scala
+++ b/test/files/pos/xml-quasiquote.scala
@@ -1,0 +1,8 @@
+// scalac: -Ystop-after:typer
+//
+import reflect.runtime.universe._
+
+object foo {
+  val ns1 =
+    q"<sample xmlns='ns1'/>"
+}


### PR DESCRIPTION
Highlights:

1. Surprisingly, there weren't any tests for checking the familiar error for parsing XML literals when the the scala-xml dependency is missing ("To compile XML syntax, the scala.xml package must be on the classpath.")
2. Pattern matching XML literals
3. Quasiquoted XML
