### PR TITLE
Simplify ReflectionUtils.unwrapHandler

### DIFF
--- a/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
+++ b/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
@@ -36,9 +36,8 @@ object ReflectionUtils {
   }
   // Transforms an exception handler into one which will only receive the unwrapped
   // exceptions (for the values of wrap covered in unwrapThrowable.)
-  def unwrapHandler[T](pf: PartialFunction[Throwable, T]): PartialFunction[Throwable, T] = {
-    case ex if pf isDefinedAt unwrapThrowable(ex)   => pf(unwrapThrowable(ex))
-  }
+  def unwrapHandler[T](pf: PartialFunction[Throwable, T]): PartialFunction[Throwable, T] =
+    pf.compose({ case ex => unwrapThrowable(ex) })
 
   def show(cl: ClassLoader): String = {
     import scala.language.reflectiveCalls


### PR DESCRIPTION
As detailed in the scaladoc of PartialFunction's compose, using
isDefinedAt and then apply on the resulting PartialFunction will apply
the first partial function twice: once for isDefinedAt, and discarded,
and then again for apply.  This means it works exactly like the previous
encoding did.

The benefit of this encoding is that the resulting partial function's
applyOrElse will only apply the first partial function once.