### PR TITLE
make Scala docs more print friendly

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlFactory.scala
@@ -84,6 +84,7 @@ class HtmlFactory(val universe: doc.Universe, val reporter: Reporter) {
     "ref-index.css",
     "template.css",
     "diagrams.css",
+    "print.css",
 
     "class_diagram.png",
     "object_diagram.png",

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -54,6 +54,7 @@ trait EntityPage extends HtmlPage {
     canonicalLink ++ List(
       HtmlTags.Link(href = relativeLinkTo(List("index.css", "lib")), media = "screen", `type` = "text/css", rel = "stylesheet"),
     HtmlTags.Link(href = relativeLinkTo(List("template.css", "lib")), media = "screen", `type` = "text/css", rel = "stylesheet"),
+    HtmlTags.Link(href = relativeLinkTo(List("print.css", "lib")), media = "print", `type` = "text/css", rel = "stylesheet"),
     HtmlTags.Link(href = relativeLinkTo(List("diagrams.css", "lib")), media = "screen", `type` = "text/css", rel = "stylesheet", id = "diagrams-css"),
     libScript("jquery.js"),
     libScript("index.js"),

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/print.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/print.css
@@ -1,0 +1,11 @@
+@media print {
+  * {
+    text-decoration: none;
+    font-family: "Lato", Arial, sans-serif;
+    border-width: 0px;
+    margin: 0px;
+  }
+  #textfilter, #package, #subpackage-spacer, #memberfilter, #filterby, div#definition .big-circle {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
hide unnecessary elements when printing docs.

Fixes scala/bug#9541