### PR TITLE
Fix table format in Scaladoc for PartialFunction

### DIFF
--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -58,7 +58,7 @@ package scala
  * | How to convert ... | to a [[PartialFunction]] | to an optional [[Function]] | to an extractor |
  * | :---:  | ---  | --- | --- |
  * | from a [[PartialFunction]] | [[Predef.identity]] | [[lift]] | [[Predef.identity]] |
- * | from optional [[Function]] | [[Function.UnliftOps#unlift]] or [[Function.unlift]] | [[Predef.identity]] | [[Function.UnliftOps#unlift]] |
+ * | from optional [[Function]] | [[Function1.UnliftOps#unlift]] or [[Function.unlift]] | [[Predef.identity]] | [[Function1.UnliftOps#unlift]] |
  * | from an extractor | `{ case extractor(x) => x }` | `extractor.unapply _` | [[Predef.identity]] |
  *  &nbsp;
  *

--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -55,11 +55,12 @@ package scala
  *  @note Optional [[Function]]s, [[PartialFunction]]s and extractor objects
  *        can be converted to each other as shown in the following table.
  *
- *        | How to convert ... | to a [[PartialFunction]] | to an optional [[Function]] | to an extractor |
- *        | :---:  | ---  | --- | --- |
- *        | from a [[PartialFunction]] | [[Predef.identity]] | [[lift]] | [[Predef.identity]] |
- *        | from optional [[Function]] | [[Function.UnliftOps#unlift]] or [[Function.unlift]] | [[Predef.identity]] | [[Function.UnliftOps#unlift]] |
- *        | from an extractor | `{ case extractor(x) => x }` | `extractor.unapply _` | [[Predef.identity]] |
+ * | How to convert ... | to a [[PartialFunction]] | to an optional [[Function]] | to an extractor |
+ * | :---:  | ---  | --- | --- |
+ * | from a [[PartialFunction]] | [[Predef.identity]] | [[lift]] | [[Predef.identity]] |
+ * | from optional [[Function]] | [[Function.UnliftOps#unlift]] or [[Function.unlift]] | [[Predef.identity]] | [[Function.UnliftOps#unlift]] |
+ * | from an extractor | `{ case extractor(x) => x }` | `extractor.unapply _` | [[Predef.identity]] |
+ *  &nbsp;
  *
  *  @since   1.0
  */


### PR DESCRIPTION
The current API reference contains a broken table in the page: https://www.scala-lang.org/api/2.13.0/scala/PartialFunction.html

As I tested locally, scaladoc only accept table rows with one space between the leading `*`. Also a dummy trailing `&nbsp;` is required in case of mess up the last row.