### PR TITLE
Avoid compiler crash in REPL with string interpolation

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -1223,6 +1223,11 @@ private[internal] trait TypeMaps {
         if (clazz.isPackageClass) tp
         else {
           val parents1 = parents mapConserve (this)
+          decls.foreach { decl =>
+            if (decl.hasAllFlags(METHOD | MODULE))
+              // HACK: undo flag Uncurry's flag mutation from prior run
+              decl.resetFlag(METHOD | STABLE)
+          }
           if (parents1 eq parents) tp
           else ClassInfoType(parents1, decls, clazz)
         }

--- a/test/files/run/t11564.check
+++ b/test/files/run/t11564.check
@@ -1,0 +1,13 @@
+
+scala> val x = ""; s"$x"
+x: String = ""
+res0: String = ""
+
+scala> val s"$y" = ""
+y: String = ""
+
+scala> val x = ""; s"$x"
+x: String = ""
+res1: String = ""
+
+scala> :quit

--- a/test/files/run/t11564.scala
+++ b/test/files/run/t11564.scala
@@ -1,0 +1,21 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = """
+val x = ""; s"$x"
+val s"$y" = ""
+val x = ""; s"$x"
+  """
+}


### PR DESCRIPTION
The addition of the `object s` alongside the existing method
`StringContext.s` leads to an overloaded symbol for
`currentRun.runDefinitions.StringContext_s`.

e26b4f49 stopped using `lateMETHOD`, which would have hidden
the methodicalness of the symbol during the typer phase of
the next phase.

Maybe we should revisit that choice, but for now this commit
reverses the mutation in `adaptToNewRun`

I'l think we should backport this patch to 2.12.x -- other use cases for the presentation compiler could be broken by witnessing the `METHOD` flag on later runs.

Fixes scala/bug#11564