### PR TITLE
remove @since and @version tags from Scaladoc

### DIFF
--- a/project/genprod.scala
+++ b/project/genprod.scala
@@ -416,7 +416,6 @@ object {className} {{
 }}
 
 /** {className} is a Cartesian product of {i} component{s}.
- *  @since 2.3
  */
 trait {className}{covariantArgs} extends Any with Product {{
   /** The arity of this product.

--- a/src/compiler/scala/reflect/reify/Reifier.scala
+++ b/src/compiler/scala/reflect/reify/Reifier.scala
@@ -19,8 +19,6 @@ import scala.reflect.reify.utils.Utils
 
 /** Given a tree or a type, generate a tree that when executed at runtime produces the original tree or type.
  *  See more info in the comments to `reify` in scala.reflect.api.Universe.
- *
- *  @since    2.10
  */
 abstract class Reifier extends States
                           with Phases

--- a/src/compiler/scala/tools/nsc/ConsoleWriter.scala
+++ b/src/compiler/scala/tools/nsc/ConsoleWriter.scala
@@ -17,7 +17,6 @@ import java.io.Writer
 /** A Writer that writes onto the Scala Console.
  *
  *  @author  Lex Spoon
- *  @version 1.0
  */
 class ConsoleWriter extends Writer {
   def close() = flush()

--- a/src/compiler/scala/tools/nsc/ObjectRunner.scala
+++ b/src/compiler/scala/tools/nsc/ObjectRunner.scala
@@ -39,6 +39,5 @@ trait CommonRunner {
 /** An object that runs another object specified by name.
  *
  *  @author  Lex Spoon
- *  @version 1.1, 2007/7/13
  */
 object ObjectRunner extends CommonRunner

--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -40,7 +40,6 @@ import java.io.IOException
  *  }}}
  *
  *  @author  Lex Spoon
- *  @version 1.0, 15/05/2006
  *  @todo    It would be better if error output went to stderr instead
  *           of stdout...
  */

--- a/src/compiler/scala/tools/nsc/ast/DocComments.scala
+++ b/src/compiler/scala/tools/nsc/ast/DocComments.scala
@@ -20,7 +20,6 @@ import scala.collection.mutable
 
 /*
  *  @author  Martin Odersky
- *  @version 1.0
  */
 trait DocComments { self: Global =>
 

--- a/src/compiler/scala/tools/nsc/ast/TreeBrowsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeBrowsers.scala
@@ -31,7 +31,6 @@ import scala.annotation.tailrec
  * way, useful for debugging and understanding.
  *
  * @author Iulian Dragos
- * @version 1.0
  */
 abstract class TreeBrowsers {
   val global: Global
@@ -125,7 +124,6 @@ abstract class TreeBrowsers {
    * displaying information
    *
    * @author Iulian Dragos
-   * @version 1.0
    */
   class BrowserFrame(phaseName: String = "unknown") {
     try {
@@ -669,7 +667,6 @@ object TreeBrowsers {
     * of Wadler's adaptation of Hughes' pretty-printer.
     *
     * @author Michel Schinz
-    * @version 1.0
     */
   abstract class Document {
     def ::(hd: Document): Document = DocCons(hd, this)

--- a/src/compiler/scala/tools/nsc/ast/TreeInfo.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeInfo.scala
@@ -18,7 +18,6 @@ import scala.reflect.internal.MacroAnnotionTreeInfo
 /** This class ...
  *
  *  @author Martin Odersky
- *  @version 1.0
  */
 abstract class TreeInfo extends scala.reflect.internal.TreeInfo with MacroAnnotionTreeInfo {
   val global: Global

--- a/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
@@ -27,7 +27,6 @@ import scala.reflect.internal.util.StringOps.splitWhere
  *  who understands this part better wants to give it a shot, please do!
  *
  *  @author  Burak Emir
- *  @version 1.0
  */
 abstract class SymbolicXMLBuilder(p: Parsers#Parser, preserveWS: Boolean) {
   val global: Global

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -25,7 +25,6 @@ import scala.tools.nsc.backend.jvm.GenBCode._
 /*
  *
  *  @author  Miguel Garcia, http://lamp.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/
- *  @version 1.0
  *
  */
 abstract class BCodeBodyBuilder extends BCodeSkelBuilder {

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -27,7 +27,6 @@ import scala.annotation.tailrec
  *  Traits encapsulating functionality to convert Scala AST Trees into ASM ClassNodes.
  *
  *  @author  Miguel Garcia, http://lamp.epfl.ch/~magarcia/ScalaCompilerCornerReloaded
- *  @version 1.0
  *
  */
 abstract class BCodeHelpers extends BCodeIdiomatic {

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
@@ -24,7 +24,6 @@ import scala.tools.nsc.backend.jvm.GenBCode._
  *  A high-level facade to the ASM API for bytecode generation.
  *
  *  @author  Miguel Garcia, http://lamp.epfl.ch/~magarcia/ScalaCompilerCornerReloaded
- *  @version 1.0
  *
  */
 abstract class BCodeIdiomatic {

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -21,10 +21,7 @@ import GenBCode._
 import BackendReporting._
 
 /*
- *
  *  @author  Miguel Garcia, http://lamp.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/
- *  @version 1.0
- *
  */
 abstract class BCodeSkelBuilder extends BCodeHelpers {
   import global._

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
@@ -21,7 +21,6 @@ import scala.tools.asm
 /*
  *
  *  @author  Miguel Garcia, http://lamp.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/
- *  @version 1.0
  *
  */
 abstract class BCodeSyncAndTry extends BCodeBodyBuilder {

--- a/src/compiler/scala/tools/nsc/fsc/CompileServer.scala
+++ b/src/compiler/scala/tools/nsc/fsc/CompileServer.scala
@@ -27,7 +27,6 @@ import scala.util.Properties
  *  that it can respond more quickly.
  *
  *  @author Martin Odersky
- *  @version 1.0
  */
 class StandardCompileServer(fixPort: Int = 0) extends SocketServer(fixPort) {
   lazy val compileSocket: CompileSocket = CompileSocket

--- a/src/compiler/scala/tools/nsc/fsc/SocketServer.scala
+++ b/src/compiler/scala/tools/nsc/fsc/SocketServer.scala
@@ -35,7 +35,6 @@ trait CompileOutputCommon {
  *  communication for the fast Scala compiler.
  *
  *  @author  Martin Odersky
- *  @version 1.0
  */
 abstract class SocketServer(fixPort: Int = 0) extends CompileOutputCommon {
   def shutdown: Boolean

--- a/src/compiler/scala/tools/nsc/plugins/Plugin.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugin.scala
@@ -33,7 +33,6 @@ import scala.util.{Failure, Success, Try}
  *  }}}
  *
  *  @author Lex Spoon
- *  @version 1.0, 2007-5-21
  */
 abstract class Plugin {
   /** The name of this plugin */
@@ -89,7 +88,6 @@ abstract class Plugin {
 /** ...
  *
  *  @author Lex Spoon
- *  @version 1.0, 2007-5-21
  */
 object Plugin {
 

--- a/src/compiler/scala/tools/nsc/plugins/PluginComponent.scala
+++ b/src/compiler/scala/tools/nsc/plugins/PluginComponent.scala
@@ -16,7 +16,6 @@ package plugins
 /** A component that is part of a Plugin.
  *
  * @author Lex Spoon
- * @version 1.1, 2009/1/2
  * Updated 2009/1/2 by Anders Bach Nielsen: Added features to implement SIP 00002
  */
 abstract class PluginComponent extends SubComponent {

--- a/src/compiler/scala/tools/nsc/plugins/PluginDescription.scala
+++ b/src/compiler/scala/tools/nsc/plugins/PluginDescription.scala
@@ -19,9 +19,7 @@ import scala.reflect.internal.util.StringContextStripMarginOps
  *  to XML for inclusion in the plugin's .jar file.
  *
  * @author Lex Spoon
- * @version 1.0, 2007-5-21
  * @author Adriaan Moors
- * @version 2.0, 2013
  * @param name A short name of the plugin, used to identify it in
  *   various contexts. The phase defined by the plugin
  *   should have the same name.
@@ -39,11 +37,6 @@ case class PluginDescription(name: String, classname: String) {
 }
 
 /** Utilities for the PluginDescription class.
- *
- * @author Lex Spoon
- * @version 1.0, 2007-5-21
- * @author Adriaan Moors
- * @version 2.0, 2013
  */
 object PluginDescription {
   private def text(ns: org.w3c.dom.NodeList): String =

--- a/src/compiler/scala/tools/nsc/plugins/Plugins.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugins.scala
@@ -25,10 +25,6 @@ import scala.tools.nsc.util.ClassPath
 import scala.tools.util.PathResolver.Defaults
 
 /** Support for run-time loading of compiler plugins.
- *
- *  @author Lex Spoon
- *  @version 1.1, 2009/1/2
- *  Updated 2009/1/2 by Anders Bach Nielsen: Added features to implement SIP 00002
  */
 trait Plugins { global: Global =>
 

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -23,7 +23,6 @@ import scala.reflect.internal.util.{ReusableInstance, StatisticsStatics}
 /** This class ...
  *
  *  @author  Martin Odersky
- *  @version 1.0
  */
 abstract class SymbolLoaders {
   val symbolTable: symtab.SymbolTable {

--- a/src/compiler/scala/tools/nsc/symtab/classfile/AbstractFileReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/AbstractFileReader.scala
@@ -25,7 +25,6 @@ import scala.tools.nsc.io.AbstractFile
  * This class reads files byte per byte. Only used by ClassFileParser
  *
  * @author Philippe Altherr
- * @version 1.0, 23/03/2004
  */
 final class AbstractFileReader(val buf: Array[Byte]) extends DataReader {
   @deprecated("Use other constructor", "2.13.0")

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -33,7 +33,6 @@ import scala.util.control.NonFatal
 /** This abstract class implements a class file parser.
  *
  *  @author Martin Odersky
- *  @version 1.0
  */
 abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
   val symbolTable: SymbolTable {

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -31,7 +31,6 @@ import scala.annotation.tailrec
  * @see EntryTags.scala for symbol table attribute format.
  *
  * @author Martin Odersky
- * @version 1.0
  */
 abstract class Pickler extends SubComponent {
   import global._

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -22,7 +22,6 @@ import scala.collection.mutable.ListBuffer
 /** This class ...
  *
  *  @author  Martin Odersky
- *  @version 1.0
  */
 abstract class ExplicitOuter extends InfoTransform
       with TypingTransformers

--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -23,7 +23,6 @@ import scala.collection.mutable
  * methods in a value class, except parameter or super accessors, or constructors.
  *
  *  @author Martin Odersky
- *  @version 2.10
  */
 abstract class ExtensionMethods extends Transform with TypingTransformers {
 

--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -21,7 +21,6 @@ import scala.annotation.tailrec
 /** Perform tail recursive call elimination.
  *
  *  @author Iulian Dragos
- *  @version 1.0
  */
 abstract class TailCalls extends Transform {
   import global._                     // the global environment
@@ -51,7 +50,6 @@ abstract class TailCalls extends Transform {
    * A Tail Call Transformer
    *
    * @author     Erik Stenman, Iulian Dragos
-   * @version    1.1
    *
    * What it does:
    * <p>

--- a/src/compiler/scala/tools/nsc/transform/Transform.scala
+++ b/src/compiler/scala/tools/nsc/transform/Transform.scala
@@ -21,7 +21,6 @@ package transform
  *  </p>
  *
  *  @author Martin Odersky
- *  @version 1.0
  */
 trait Transform extends SubComponent {
 

--- a/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
@@ -15,7 +15,6 @@ package typechecker
 
 /**
  *  @author Lukas Rytz
- *  @version 1.0
  */
 trait AnalyzerPlugins { self: Analyzer =>
   import global._

--- a/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
@@ -19,7 +19,6 @@ import java.lang.ArithmeticException
 /** This class ...
  *
  *  @author Martin Odersky
- *  @version 1.0
  */
 abstract class ConstantFolder {
 

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -20,7 +20,6 @@ import scala.reflect.internal.Reporter
 
 /**
  *  @author  Martin Odersky
- *  @version 1.0
  */
 trait Contexts { self: Analyzer =>
   import global._

--- a/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
@@ -20,7 +20,6 @@ import scala.collection.mutable
  *  and create fresh symbols for new local definitions.
  *
  *  @author  Iulian Dragos
- *  @version 1.0
  */
 abstract class Duplicators extends Analyzer {
   import global._

--- a/src/compiler/scala/tools/nsc/typechecker/EtaExpansion.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/EtaExpansion.scala
@@ -20,7 +20,6 @@ import symtab.Flags._
 /** This trait ...
  *
  *  @author  Martin Odersky
- *  @version 1.0
  */
 trait EtaExpansion { self: Analyzer =>
   import global._

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -31,7 +31,6 @@ import scala.language.implicitConversions
 /** This trait provides methods to find various kinds of implicits.
  *
  *  @author  Martin Odersky
- *  @version 1.0
  */
 trait Implicits {
   self: Analyzer =>

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -22,7 +22,6 @@ import scala.reflect.internal.Depth
 /** This trait contains methods related to type parameter inference.
  *
  *  @author Martin Odersky
- *  @version 1.0
  */
 trait Infer extends Checkable {
   self: Analyzer =>

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -21,7 +21,6 @@ import scala.reflect.internal.util.ListOfNil
 /** This trait declares methods to create symbols and to enter them into scopes.
  *
  *  @author Martin Odersky
- *  @version 1.0
  */
 trait Namers extends MethodSynthesis {
   self: Analyzer =>

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1020,7 +1020,7 @@ trait Namers extends MethodSynthesis {
     // Annotations on ValDefs can be targeted towards the following: field, getter, setter, beanGetter, beanSetter, param.
     // The defaults are:
     //   - (`val`-, `var`- or plain) constructor parameter annotations end up on the parameter, not on any other entity.
-    //   - val/var member annotations solely end up on the underlying field, except in traits and for all lazy vals (@since 2.12),
+    //   - val/var member annotations solely end up on the underlying field, except in traits and for all lazy vals,
     //     where there is no field, and the getter thus holds annotations targeting both getter & field.
     //     As soon as there is a field/getter (in subclasses mixing in the trait, or after expanding the lazy val during the fields phase),
     //     we triage the annotations.

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -20,7 +20,6 @@ import PartialFunction.{ cond => when }
 
 /**
  *  @author Lukas Rytz
- *  @version 1.0
  */
 trait NamesDefaults { self: Analyzer =>
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -43,7 +43,6 @@ import transform.Transform
  *  </ul>
  *
  *  @author  Martin Odersky
- *  @version 1.0
  *
  *  @todo    Check whether we always check type parameter bounds.
  */

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -37,7 +37,6 @@ import scala.annotation.tailrec
  *  And more, and there is plenty of overlap, so it'll be a process.
  *
  *  @author Paul Phillips
- *  @version 1.0
  */
 trait TypeDiagnostics {
   self: Analyzer with StdAttachments =>

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -33,7 +33,6 @@ import PartialFunction.cond
 /** This trait provides methods to assign types to trees.
  *
  *  @author  Martin Odersky
- *  @version 1.0
  */
 trait Typers extends Adaptations with Tags with TypersTracking with PatternTypers {
   self: Analyzer =>

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -19,7 +19,6 @@ import scala.reflect.internal.util.ListOfNil
 
 /*
  *  @author  Martin Odersky
- *  @version 1.0
  */
 trait Unapplies extends ast.TreeDSL {
   self: Analyzer =>

--- a/src/library/scala/App.scala
+++ b/src/library/scala/App.scala
@@ -35,8 +35,6 @@ import scala.collection.mutable.ListBuffer
  *  before the main method has been executed.'''''
  *
  *  Future versions of this trait will no longer extend `DelayedInit`.
- *
- *  @since   2.1
  */
 trait App extends DelayedInit {
 

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -30,8 +30,6 @@ import scala.runtime.ScalaRunTime.{array_apply, array_update}
  *  }}}
  *  where the array objects `a`, `b` and `c` have respectively the values
  *  `Array(1, 2)`, `Array(0, 0)` and `Array(1, 2, 0, 0)`.
- *
- *  @since  1.0
  */
 object Array {
   val emptyBooleanArray = new Array[Boolean](0)
@@ -608,7 +606,6 @@ object Array {
  *  by converting to `ArraySeq` first and invoking the variant of `reverse` that returns another
  *  `ArraySeq`.
  *
- *  @since  1.0
  *  @see [[http://www.scala-lang.org/files/archive/spec/2.13/ Scala Language Specification]], for in-depth information on the transformations the Scala compiler makes on Arrays (Sections 6.6 and 6.15 respectively.)
  *  @see [[http://docs.scala-lang.org/sips/completed/scala-2-8-arrays.html "Scala 2.8 Arrays"]] the Scala Improvement Document detailing arrays since Scala 2.8.
  *  @see [[http://docs.scala-lang.org/overviews/collections/arrays.html "The Scala 2.8 Collections' API"]] section on `Array` by Martin Odersky for more information.

--- a/src/library/scala/Console.scala
+++ b/src/library/scala/Console.scala
@@ -109,8 +109,6 @@ import scala.util.DynamicVariable
  *    <tr><td style="background-color:#000;color:#fff">First primes: Vector(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47)</td></tr>
  *  </table>
  *
- *  @since   1.0
- *
  *  @groupname console-output Console Output
  *  @groupprio console-output 30
  *  @groupdesc console-output These methods provide output via the console.

--- a/src/library/scala/Function.scala
+++ b/src/library/scala/Function.scala
@@ -13,8 +13,6 @@
 package scala
 
 /** A module defining utility methods for higher-order functional programming.
- *
- *  @since   1.0
  */
 object Function {
   /** Given a sequence of functions `f,,1,,`, ..., `f,,n,,`, return the

--- a/src/library/scala/Function0.scala
+++ b/src/library/scala/Function0.scala
@@ -11,7 +11,7 @@
  */
 
 // GENERATED CODE: DO NOT EDIT.
-// genprod generated these sources at: 2019-01-20T09:16:45.854Z
+// genprod generated these sources at: 2019-06-18T20:49:11.955Z
 
 package scala
 

--- a/src/library/scala/MatchError.scala
+++ b/src/library/scala/MatchError.scala
@@ -15,8 +15,6 @@ package scala
 /** This class implements errors which are thrown whenever an
  *  object doesn't match any pattern of a pattern matching
  *  expression.
- *
- *  @since   2.0
  */
 final class MatchError(@transient obj: Any) extends RuntimeException {
   /** There's no reason we need to call toString eagerly,

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -126,7 +126,6 @@ object Option {
  *  the implicit conversion tends to leave one with an Iterable in
  *  situations where one could have retained an Option.
  *
- *  @since   1.1
  *  @define none `None`
  *  @define some [[scala.Some]]
  *  @define option [[scala.Option]]
@@ -614,8 +613,6 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
 
 /** Class `Some[A]` represents existing values of type
  *  `A`.
- *
- *  @since   1.0
  */
 @SerialVersionUID(1234815782226070388L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
 final case class Some[+A](value: A) extends Option[A] {
@@ -624,8 +621,6 @@ final case class Some[+A](value: A) extends Option[A] {
 
 
 /** This case object represents non-existent values.
- *
- *  @since   1.0
  */
 @SerialVersionUID(5066590221178148012L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
 case object None extends Option[Nothing] {

--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -61,8 +61,6 @@ package scala
  * | from optional [[Function]] | [[Function1.UnliftOps#unlift]] or [[Function.unlift]] | [[Predef.identity]] | [[Function1.UnliftOps#unlift]] |
  * | from an extractor | `{ case extractor(x) => x }` | `extractor.unapply _` | [[Predef.identity]] |
  *  &nbsp;
- *
- *  @since   1.0
  */
 trait PartialFunction[-A, +B] extends (A => B) { self =>
   import PartialFunction._
@@ -184,7 +182,6 @@ trait PartialFunction[-A, +B] extends (A => B) { self =>
    *  @param  x       the function argument
    *  @param default  the fallback function
    *  @return   the result of this function or fallback function application.
-   *  @since   2.10
    */
   def applyOrElse[A1 <: A, B1 >: B](x: A1, default: A1 => B1): B1 =
     if (isDefinedAt(x)) apply(x) else default(x)
@@ -202,7 +199,6 @@ trait PartialFunction[-A, +B] extends (A => B) { self =>
    *  @param   action  the action function
    *  @return  a function which maps arguments `x` to `isDefinedAt(x)`. The resulting function
    *           runs `action(this(x))` where `this` is defined.
-   *  @since   2.10
    */
   def runWith[U](action: B => U): A => Boolean = { x =>
     val z = applyOrElse(x, checkFallback[B])
@@ -221,8 +217,6 @@ trait PartialFunction[-A, +B] extends (A => B) { self =>
  *  }
  *  def onlyInt(v: Any): Option[Int] = condOpt(v) { case x: Int => x }
  *  }}}
- *
- *  @since   2.8
  */
 object PartialFunction {
 
@@ -354,7 +348,6 @@ object PartialFunction {
 
   /** The partial function with empty domain.
    *  Any attempt to invoke empty partial function leads to throwing [[scala.MatchError]] exception.
-   *  @since   2.10
    */
   def empty[A, B] : PartialFunction[A, B] = empty_pf
 

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -509,8 +509,6 @@ object Predef extends LowPriorityImplicits {
 *  are valid in all Scala compilation units without explicit qualification,
 *  but that are partially overridden by higher-priority conversions in object
 *  `Predef`.
-*
-*  @since 2.8
 */
 // scala/bug#7335 Parents of Predef are defined in the same compilation unit to avoid
 // cyclic reference errors compiling the standard library *without* a previously

--- a/src/library/scala/Product.scala
+++ b/src/library/scala/Product.scala
@@ -16,8 +16,6 @@ package scala
  *  least [[scala.Product1]] through [[scala.Product22]] and therefore also
  *  their subclasses [[scala.Tuple1]] through [[scala.Tuple22]].  In addition,
  *  all case classes implement `Product` with synthetically generated methods.
- *
- *  @since   2.3
  */
 trait Product extends Any with Equals {
   /** The size of this product.

--- a/src/library/scala/Product1.scala
+++ b/src/library/scala/Product1.scala
@@ -20,7 +20,6 @@ object Product1 {
 }
 
 /** Product1 is a Cartesian product of 1 component.
- *  @since 2.3
  */
 trait Product1[@specialized(Int, Long, Double) +T1] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product10.scala
+++ b/src/library/scala/Product10.scala
@@ -20,7 +20,6 @@ object Product10 {
 }
 
 /** Product10 is a Cartesian product of 10 components.
- *  @since 2.3
  */
 trait Product10[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product11.scala
+++ b/src/library/scala/Product11.scala
@@ -20,7 +20,6 @@ object Product11 {
 }
 
 /** Product11 is a Cartesian product of 11 components.
- *  @since 2.3
  */
 trait Product11[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product12.scala
+++ b/src/library/scala/Product12.scala
@@ -20,7 +20,6 @@ object Product12 {
 }
 
 /** Product12 is a Cartesian product of 12 components.
- *  @since 2.3
  */
 trait Product12[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product13.scala
+++ b/src/library/scala/Product13.scala
@@ -20,7 +20,6 @@ object Product13 {
 }
 
 /** Product13 is a Cartesian product of 13 components.
- *  @since 2.3
  */
 trait Product13[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product14.scala
+++ b/src/library/scala/Product14.scala
@@ -20,7 +20,6 @@ object Product14 {
 }
 
 /** Product14 is a Cartesian product of 14 components.
- *  @since 2.3
  */
 trait Product14[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product15.scala
+++ b/src/library/scala/Product15.scala
@@ -20,7 +20,6 @@ object Product15 {
 }
 
 /** Product15 is a Cartesian product of 15 components.
- *  @since 2.3
  */
 trait Product15[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product16.scala
+++ b/src/library/scala/Product16.scala
@@ -20,7 +20,6 @@ object Product16 {
 }
 
 /** Product16 is a Cartesian product of 16 components.
- *  @since 2.3
  */
 trait Product16[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product17.scala
+++ b/src/library/scala/Product17.scala
@@ -20,7 +20,6 @@ object Product17 {
 }
 
 /** Product17 is a Cartesian product of 17 components.
- *  @since 2.3
  */
 trait Product17[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product18.scala
+++ b/src/library/scala/Product18.scala
@@ -20,7 +20,6 @@ object Product18 {
 }
 
 /** Product18 is a Cartesian product of 18 components.
- *  @since 2.3
  */
 trait Product18[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product19.scala
+++ b/src/library/scala/Product19.scala
@@ -20,7 +20,6 @@ object Product19 {
 }
 
 /** Product19 is a Cartesian product of 19 components.
- *  @since 2.3
  */
 trait Product19[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product2.scala
+++ b/src/library/scala/Product2.scala
@@ -20,7 +20,6 @@ object Product2 {
 }
 
 /** Product2 is a Cartesian product of 2 components.
- *  @since 2.3
  */
 trait Product2[@specialized(Int, Long, Double) +T1, @specialized(Int, Long, Double) +T2] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product20.scala
+++ b/src/library/scala/Product20.scala
@@ -20,7 +20,6 @@ object Product20 {
 }
 
 /** Product20 is a Cartesian product of 20 components.
- *  @since 2.3
  */
 trait Product20[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product21.scala
+++ b/src/library/scala/Product21.scala
@@ -20,7 +20,6 @@ object Product21 {
 }
 
 /** Product21 is a Cartesian product of 21 components.
- *  @since 2.3
  */
 trait Product21[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20, +T21] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product22.scala
+++ b/src/library/scala/Product22.scala
@@ -20,7 +20,6 @@ object Product22 {
 }
 
 /** Product22 is a Cartesian product of 22 components.
- *  @since 2.3
  */
 trait Product22[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20, +T21, +T22] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product3.scala
+++ b/src/library/scala/Product3.scala
@@ -20,7 +20,6 @@ object Product3 {
 }
 
 /** Product3 is a Cartesian product of 3 components.
- *  @since 2.3
  */
 trait Product3[+T1, +T2, +T3] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product4.scala
+++ b/src/library/scala/Product4.scala
@@ -20,7 +20,6 @@ object Product4 {
 }
 
 /** Product4 is a Cartesian product of 4 components.
- *  @since 2.3
  */
 trait Product4[+T1, +T2, +T3, +T4] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product5.scala
+++ b/src/library/scala/Product5.scala
@@ -20,7 +20,6 @@ object Product5 {
 }
 
 /** Product5 is a Cartesian product of 5 components.
- *  @since 2.3
  */
 trait Product5[+T1, +T2, +T3, +T4, +T5] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product6.scala
+++ b/src/library/scala/Product6.scala
@@ -20,7 +20,6 @@ object Product6 {
 }
 
 /** Product6 is a Cartesian product of 6 components.
- *  @since 2.3
  */
 trait Product6[+T1, +T2, +T3, +T4, +T5, +T6] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product7.scala
+++ b/src/library/scala/Product7.scala
@@ -20,7 +20,6 @@ object Product7 {
 }
 
 /** Product7 is a Cartesian product of 7 components.
- *  @since 2.3
  */
 trait Product7[+T1, +T2, +T3, +T4, +T5, +T6, +T7] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product8.scala
+++ b/src/library/scala/Product8.scala
@@ -20,7 +20,6 @@ object Product8 {
 }
 
 /** Product8 is a Cartesian product of 8 components.
- *  @since 2.3
  */
 trait Product8[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Product9.scala
+++ b/src/library/scala/Product9.scala
@@ -20,7 +20,6 @@ object Product9 {
 }
 
 /** Product9 is a Cartesian product of 9 components.
- *  @since 2.3
  */
 trait Product9[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9] extends Any with Product {
   /** The arity of this product.

--- a/src/library/scala/Proxy.scala
+++ b/src/library/scala/Proxy.scala
@@ -22,8 +22,6 @@ package scala
  *  }}}
  *  '''Note:''' forwarding methods in this way will most likely create
  *  an asymmetric equals method, which is not generally recommended.
- *
- *  @since   1.0
  */
 @deprecated("Explicitly override hashCode, equals and toString instead.", "2.13.0")
 trait Proxy extends Any {

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -51,7 +51,6 @@ import scala.annotation.tailrec
  *  Here the `JsonHelper` extension class implicitly adds the `json` method to
  *  `StringContext` which can be used for `json` string literals.
  *
- *  @since 2.10.0
  *  @param   parts  The parts that make up the interpolated string,
  *                  without the expressions that get inserted by interpolation.
  */

--- a/src/library/scala/Symbol.scala
+++ b/src/library/scala/Symbol.scala
@@ -20,8 +20,6 @@ package scala
  *  For instance, the Scala term `'mysym` will
  *  invoke the constructor of the `Symbol` class in the following way:
  *  `Symbol("mysym")`.
- *
- *  @since   1.7
  */
 final class Symbol private (val name: String) extends Serializable {
   /** Converts this symbol to a string.

--- a/src/library/scala/UninitializedError.scala
+++ b/src/library/scala/UninitializedError.scala
@@ -13,8 +13,6 @@
 package scala
 
 /** This class represents uninitialized variable/value errors.
- *
- *  @since   2.5
  */
 // TODO: remove in 2.14
 @deprecated("will be removed in a future release", since = "2.12.7")

--- a/src/library/scala/UninitializedFieldError.scala
+++ b/src/library/scala/UninitializedFieldError.scala
@@ -17,8 +17,6 @@ package scala
  *
  *  Such runtime checks are not emitted by default.
  *  They can be enabled by the `-Xcheckinit` compiler option.
- *
- *  @since 2.7
  */
 final case class UninitializedFieldError(msg: String) extends RuntimeException(msg) {
   def this(obj: Any) = this("" + obj)

--- a/src/library/scala/annotation/Annotation.scala
+++ b/src/library/scala/annotation/Annotation.scala
@@ -22,7 +22,5 @@ package scala.annotation
  * Annotation classes defined in Scala are not stored in classfiles in a Java-compatible manner
  * and therefore not visible in Java reflection. In order to achieve this, the annotation has to
  * be written in Java.
- *
- *  @since 2.4
  */
 abstract class Annotation

--- a/src/library/scala/annotation/ClassfileAnnotation.scala
+++ b/src/library/scala/annotation/ClassfileAnnotation.scala
@@ -15,8 +15,6 @@ package scala.annotation
 /** A base class for classfile annotations. These are stored as
  *  [[http://docs.oracle.com/javase/8/docs/technotes/guides/language/annotations.html Java annotations]]]
  *  in classfiles.
- *
- *  @since 2.4
  */
 @deprecated("Annotation classes need to be written in Java in order to be stored in classfiles in a Java-compatible manner", "2.13.0")
 trait ClassfileAnnotation extends ConstantAnnotation

--- a/src/library/scala/annotation/StaticAnnotation.scala
+++ b/src/library/scala/annotation/StaticAnnotation.scala
@@ -19,7 +19,5 @@ package scala.annotation
  * Annotation classes defined in Scala are not stored in classfiles in a Java-compatible manner
  * and therefore not visible in Java reflection. In order to achieve this, the annotation has to
  * be written in Java.
- *
- *  @since   2.4
  */
 trait StaticAnnotation extends Annotation

--- a/src/library/scala/annotation/TypeConstraint.scala
+++ b/src/library/scala/annotation/TypeConstraint.scala
@@ -22,7 +22,5 @@ package scala.annotation
  *  down is not a proper constrained type, and this marker should not be
  *  applied.  A Scala compiler will drop such annotations in cases where it
  *  would rewrite a type constraint.
- *
- *  @since   2.6
  */
 trait TypeConstraint extends Annotation

--- a/src/library/scala/annotation/compileTimeOnly.scala
+++ b/src/library/scala/annotation/compileTimeOnly.scala
@@ -28,7 +28,6 @@ import scala.annotation.meta._
  *
  * @param  message the error message to print during compilation if a reference remains
  *                 after type checking
- * @since  2.11.0
  */
 @getter @setter @beanGetter @beanSetter @companionClass @companionMethod
 final class compileTimeOnly(message: String) extends scala.annotation.StaticAnnotation

--- a/src/library/scala/annotation/elidable.scala
+++ b/src/library/scala/annotation/elidable.scala
@@ -75,8 +75,6 @@ package scala.annotation
  *     (O: C).f() // elided if compiled with `-Xelide-below 1`
  *   }
  * }}}
- *
- *  @since    2.8
  */
 final class elidable(final val level: Int) extends scala.annotation.StaticAnnotation
 
@@ -88,8 +86,6 @@ final class elidable(final val level: Int) extends scala.annotation.StaticAnnota
  *  (Select(Level, Select(FINEST, Apply(intValue, Nil))))
  *  }}}
  *  instead of the number `300`.
- *
- *  @since 2.8
  */
 object elidable {
   /** The levels `ALL` and `OFF` are confusing in this context because

--- a/src/library/scala/annotation/implicitAmbiguous.scala
+++ b/src/library/scala/annotation/implicitAmbiguous.scala
@@ -37,8 +37,6 @@ package scala.annotation
   *
   * implicitly[Int =!= Int]
   * }}}
-  *
-  * @since 2.12.0
   */
 @meta.getter
 final class implicitAmbiguous(msg: String) extends scala.annotation.StaticAnnotation

--- a/src/library/scala/annotation/implicitNotFound.scala
+++ b/src/library/scala/annotation/implicitNotFound.scala
@@ -51,8 +51,5 @@ package scala.annotation
  *   k.n[String]
  *      ^
  * </pre>
- *
- *
- * @since 2.8.1
  */
 final class implicitNotFound(msg: String) extends scala.annotation.StaticAnnotation {}

--- a/src/library/scala/annotation/migration.scala
+++ b/src/library/scala/annotation/migration.scala
@@ -26,7 +26,5 @@ package scala.annotation
  *
  * @param changedIn The version, in which the behaviour change was
  * introduced.
- *
- * @since 2.8
  */
  private[scala] final class migration(message: String, changedIn: String) extends scala.annotation.StaticAnnotation

--- a/src/library/scala/annotation/showAsInfix.scala
+++ b/src/library/scala/annotation/showAsInfix.scala
@@ -34,7 +34,6 @@ package scala.annotation
   }}}
   *
   * @param enabled whether to show this type as an infix type operator.
-  * @since 2.12.2
   */
 @deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
 class showAsInfix(enabled: Boolean = true) extends annotation.StaticAnnotation

--- a/src/library/scala/annotation/strictfp.scala
+++ b/src/library/scala/annotation/strictfp.scala
@@ -14,8 +14,6 @@ package scala.annotation
 
 /** If this annotation is present on a method or its enclosing class,
  *  the strictfp flag will be emitted.
- *
- *  @since 2.9
  */
 @deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
 class strictfp extends scala.annotation.StaticAnnotation

--- a/src/library/scala/annotation/switch.scala
+++ b/src/library/scala/annotation/switch.scala
@@ -29,7 +29,5 @@ package scala.annotation
  *
  *  Note: for pattern matches with one or two cases, the compiler generates jump instructions.
  *  Annotating such a match with `@switch` does not issue any warning.
- *
- *  @since    2.8
  */
 final class switch extends scala.annotation.StaticAnnotation

--- a/src/library/scala/annotation/tailrec.scala
+++ b/src/library/scala/annotation/tailrec.scala
@@ -17,7 +17,5 @@ package scala.annotation
  *
  *  If it is present, the compiler will issue an error if the method cannot
  *  be optimized into a loop.
- *
- *  @since 2.8
  */
 final class tailrec extends scala.annotation.StaticAnnotation

--- a/src/library/scala/annotation/unchecked/uncheckedStable.scala
+++ b/src/library/scala/annotation/unchecked/uncheckedStable.scala
@@ -14,7 +14,5 @@ package scala.annotation.unchecked
 
 /** An annotation for values that are assumed to be stable even though their
  *  types are volatile.
- *
- *  @since 2.7
  */
 final class uncheckedStable extends scala.annotation.StaticAnnotation {}

--- a/src/library/scala/annotation/unchecked/uncheckedVariance.scala
+++ b/src/library/scala/annotation/unchecked/uncheckedVariance.scala
@@ -13,7 +13,5 @@
 package scala.annotation.unchecked
 
 /** An annotation for type arguments for which one wants to suppress variance checking.
- *
- *  @since 2.7
  */
 final class uncheckedVariance extends scala.annotation.StaticAnnotation {}

--- a/src/library/scala/annotation/unspecialized.scala
+++ b/src/library/scala/annotation/unspecialized.scala
@@ -15,8 +15,6 @@ package scala.annotation
 /** A method annotation which suppresses the creation of
  *  additional specialized forms based on enclosing specialized
  *  type parameters.
- *
- *  @since 2.10
  */
 @deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
 class unspecialized extends scala.annotation.StaticAnnotation

--- a/src/library/scala/annotation/varargs.scala
+++ b/src/library/scala/annotation/varargs.scala
@@ -15,7 +15,5 @@ package scala.annotation
 /** A method annotation which instructs the compiler to generate a
  *  Java varargs-style forwarder method for interop. This annotation can
  *  only be applied to methods with repeated parameters.
- *
- *  @since 2.9
  */
 final class varargs extends scala.annotation.StaticAnnotation

--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -178,9 +178,7 @@ object ArrayOps {
   *  `immutable.ArraySeq` serve this purpose.
   *
   *  The difference between this class and `ArraySeq`s is that calling transformer methods such as
- *   `filter` and `map` will yield an array, whereas an `ArraySeq` will remain an `ArraySeq`.
-  *
-  *  @since 2.8
+  *  `filter` and `map` will yield an array, whereas an `ArraySeq` will remain an `ArraySeq`.
   *
   *  @tparam A   type of the elements contained in this array.
   */

--- a/src/library/scala/collection/BufferedIterator.scala
+++ b/src/library/scala/collection/BufferedIterator.scala
@@ -15,8 +15,6 @@ package scala.collection
 
 /** Buffered iterators are iterators which provide a method `head`
  *  that inspects the next element without discarding it.
- *
- *  @since   2.8
  */
 trait BufferedIterator[+A] extends Iterator[A] {
 

--- a/src/library/scala/collection/DefaultMap.scala
+++ b/src/library/scala/collection/DefaultMap.scala
@@ -16,8 +16,6 @@ package collection
 
 /** A default map which builds a default `immutable.Map` implementation for all
   * transformations.
-  *
-  *  @since 2.8
   */
 @deprecated("DefaultMap is no longer necessary; extend Map directly", "2.13.0")
 trait DefaultMap[K, +V] extends Map[K, V]

--- a/src/library/scala/collection/Factory.scala
+++ b/src/library/scala/collection/Factory.scala
@@ -76,7 +76,6 @@ object Factory {
   * @tparam CC Collection type constructor (e.g. `List`)
   * @define factoryInfo
   *   This object provides a set of operations to create $Coll values.
-  *   @since 2.13
   *
   * @define coll collection
   * @define Coll `Iterable`
@@ -359,7 +358,6 @@ trait StrictOptimizedSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extends SeqFac
   * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
   * @define factoryInfo
   *   This object provides a set of operations to create $Coll values.
-  *   @since  2.13
   *
   * @define coll collection
   * @define Coll `Iterable`
@@ -376,7 +374,6 @@ trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
 /**
   * @define factoryInfo
   *   This object provides a set of operations to create $Coll values.
-  *   @since 2.13
   *
   * @define coll collection
   * @define Coll `Iterable`
@@ -714,7 +711,6 @@ trait StrictOptimizedClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extend
 /**
   * @define factoryInfo
   *   This object provides a set of operations to create $Coll values.
-  *   @since 2.13
   *
   * @define coll collection
   * @define Coll `Iterable`

--- a/src/library/scala/collection/JavaConverters.scala
+++ b/src/library/scala/collection/JavaConverters.scala
@@ -73,8 +73,6 @@ import scala.collection.convert._
  *    scala> val ss = asScalaBuffer(vs)
  *    ss: scala.collection.mutable.Buffer[String] = Buffer(hi, bye)
  *  }}}
- *
- *  @since  2.8.1
  */
 @deprecated("Use `scala.jdk.CollectionConverters` instead", "2.13.0")
 object JavaConverters extends AsJavaConverters with AsScalaConverters {

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -992,7 +992,6 @@ object SeqOps {
  /**  A KMP implementation, based on the undoubtedly reliable wikipedia entry.
    *  Note: I made this private to keep it from entering the API.  That can be reviewed.
    *
-   *  @since  2.10
    *  @param  S       Sequence that may contain target
    *  @param  m0      First index of S to consider
    *  @param  m1      Last index of S to consider (exclusive)
@@ -1080,7 +1079,6 @@ object SeqOps {
 
   /** Make sure a target sequence has fast, correctly-ordered indexing for KMP.
    *
-   *  @since  2.10
    *  @param  W    The target sequence
    *  @param  n0   The first element in the target sequence that we should use
    *  @param  n1   The far end of the target sequence that we should use (exclusive)
@@ -1119,7 +1117,6 @@ object SeqOps {
 
  /** Make a jump table for KMP search.
    *
-   *  @since  2.10
    *  @param  Wopt The target sequence
    *  @param  wlen Just in case we're only IndexedSeq and not IndexedSeqOptimized
    *  @return KMP jump table for target sequence

--- a/src/library/scala/collection/SeqMap.scala
+++ b/src/library/scala/collection/SeqMap.scala
@@ -21,7 +21,6 @@ package scala.collection
   *
   * @tparam K      the type of the keys contained in this linked map.
   * @tparam V      the type of the values associated with the keys in this linked map.
-  * @version 2.13
   * @define coll immutable seq map
   * @define Coll `immutable.SeqMap`
   */

--- a/src/library/scala/collection/SeqMap.scala
+++ b/src/library/scala/collection/SeqMap.scala
@@ -22,7 +22,6 @@ package scala.collection
   * @tparam K      the type of the keys contained in this linked map.
   * @tparam V      the type of the values associated with the keys in this linked map.
   * @version 2.13
-  * @since 2.13
   * @define coll immutable seq map
   * @define Coll `immutable.SeqMap`
   */

--- a/src/library/scala/collection/concurrent/Map.scala
+++ b/src/library/scala/collection/concurrent/Map.scala
@@ -20,7 +20,6 @@ import scala.annotation.tailrec
   *
   *  $concurrentmapinfo
   *
-  *  @since 2.8
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#concurrent_maps "Scala's Collection Library overview"]]
   *  section on `Concurrent Maps` for more information.
   *
@@ -117,7 +116,6 @@ trait Map[K, V] extends scala.collection.mutable.Map[K, V] {
    * @param key the key value
    * @param remappingFunction a partial function that receives current optionally-mapped value and return a new mapping
    * @return the new value associated with the specified key
-   * @since 2.13.0
    */
   override def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = updateWithAux(key)(remappingFunction)
 

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -677,8 +677,6 @@ private[concurrent] case class RDCSS_Descriptor[K, V](old: INode[K, V], expected
   *  distributed across subsequent updates, thus making snapshot evaluation horizontally scalable.
   *
   *  For details, see: [[http://lampwww.epfl.ch/~prokopec/ctries-snapshot.pdf]]
-  *
-  *  @since 2.10
   */
 final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater[TrieMap[K, V], AnyRef], hashf: Hashing[K], ef: Equiv[K])
   extends scala.collection.mutable.AbstractMap[K, V]

--- a/src/library/scala/collection/generic/IsIterableOnce.scala
+++ b/src/library/scala/collection/generic/IsIterableOnce.scala
@@ -36,8 +36,6 @@ package generic
  *    List(1, 2, 3, 4, 5) filterMap (i => if(i % 2 == 0) Some(i) else None)
  *    // == List(2, 4)
  * }}}
- *
- * @since 2.10
  */
 trait IsIterableOnce[Repr] {
 

--- a/src/library/scala/collection/generic/Subtractable.scala
+++ b/src/library/scala/collection/generic/Subtractable.scala
@@ -23,7 +23,6 @@ import scala.collection.IterableOnce
   *
   *  @tparam   A    the type of the elements of the $coll.
   *  @tparam   Repr the type of the $coll itself
-  *  @version  2.8
   *  @define   coll collection
   *  @define   Coll Subtractable
   */

--- a/src/library/scala/collection/generic/Subtractable.scala
+++ b/src/library/scala/collection/generic/Subtractable.scala
@@ -24,7 +24,6 @@ import scala.collection.IterableOnce
   *  @tparam   A    the type of the elements of the $coll.
   *  @tparam   Repr the type of the $coll itself
   *  @version  2.8
-  *  @since    2.8
   *  @define   coll collection
   *  @define   Coll Subtractable
   */

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -31,7 +31,6 @@ import scala.util.hashing.MurmurHash3
   *  @tparam K      the type of the keys contained in this hash set.
   *  @tparam V      the type of the values associated with the keys in this hash map.
   *
-  *  @since   2.13
   *  @define Coll `immutable.HashMap`
   *  @define coll immutable champ hash map
   */

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -28,8 +28,6 @@ import scala.util.hashing.MurmurHash3
   * See paper https://michael.steindorfer.name/publications/oopsla15.pdf for more details.
   *
   *  @tparam A      the type of the elements contained in this hash set.
-  *
-  *  @since   2.13
   *  @define Coll `immutable.HashSet`
   *  @define coll immutable champ hash set
   */

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -44,7 +44,6 @@ import IntMapUtils._
 /** A companion object for integer maps.
   *
   *  @define Coll  `IntMap`
-  *  @since 2.7
   */
 object IntMap {
   def empty[T] : IntMap[T]  = IntMap.Nil
@@ -173,7 +172,6 @@ import IntMap._
   *
   *  @tparam T    type of the values associated with integer keys.
   *
-  *  @since 2.7
   *  @define Coll `immutable.IntMap`
   *  @define coll immutable integer map
   *  @define mayNotTerminateInf

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -186,7 +186,6 @@ import scala.runtime.Statics
   *
   *  @tparam A    the type of the elements contained in this lazy list.
   *
-  *  @since   2.13
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#lazylists "Scala's Collection Library overview"]]
   *  section on `LazyLists` for more information.
   *  @define Coll `LazyList`

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -67,7 +67,6 @@ import scala.runtime.Statics.releaseFence
   *        objects that rely on structural sharing), will be serialized and deserialized with multiple lists, one for
   *        each reference to it. I.e. structural sharing is lost after serialization/deserialization.
   *
-  *  @since   1.0
   *  @see  [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#lists "Scala's Collection Library overview"]]
   *  section on `Lists` for more information.
   *

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -35,7 +35,6 @@ import scala.runtime.Statics.releaseFence
   * @tparam K the type of the keys contained in this list map
   * @tparam V the type of the values associated with the keys
   *
-  * @since 1
   * @define Coll ListMap
   * @define coll list map
   * @define mayNotTerminateInf
@@ -98,7 +97,6 @@ sealed class ListMap[K, +V]
   *
   * @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#list-maps "Scala's Collection Library overview"]]
   * section on `List Maps` for more information.
-  * @since 1
   * @define Coll ListMap
   * @define coll list map
   */

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -34,7 +34,6 @@ import scala.collection.generic.DefaultSerializable
   *
   * @tparam A the type of the elements contained in this list set
   *
-  * @since 1
   * @define Coll ListSet
   * @define coll list set
   * @define mayNotTerminateInf
@@ -114,7 +113,6 @@ sealed class ListSet[A]
   * n elements will take O(n^2^) time. This makes the builder suitable only for a small number of
   * elements.
   *
-  * @since 1
   * @define Coll ListSet
   * @define coll list set
   */

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -46,7 +46,6 @@ import LongMapUtils._
 /** A companion object for long maps.
   *
   *  @define Coll  `LongMap`
-  *  @since 2.7
   */
 object LongMap {
   def empty[T]: LongMap[T]  = LongMap.Nil
@@ -169,7 +168,6 @@ private[immutable] class LongMapKeyIterator[V](it: LongMap[V]) extends LongMapIt
   *
   *  @tparam T      type of the values associated with the long keys.
   *
-  *  @since 2.7
   *  @define Coll `immutable.LongMap`
   *  @define coll immutable long integer map
   *  @define mayNotTerminateInf

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -114,7 +114,6 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
    * @param key the key value
    * @param remappingFunction a partial function that receives current optionally-mapped value and return a new mapping
    * @return A new map with the updated mapping with the key
-   * @since 2.13.0
    */
   def updatedWith[V1 >: V](key: K)(remappingFunction: Option[V] => Option[V1]): CC[K,V1] = {
     val previousValue = this.get(key)

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -30,7 +30,6 @@ import scala.collection.mutable.{Builder, ListBuffer}
   *  where a pivot is required, in which case, a cost of `O(n)` is incurred, where `n` is the number of elements in the queue. When this happens,
   *  `n` remove operations with `O(1)` cost are guaranteed. Removing an item is on average `O(1)`.
   *
-  *  @since   1
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable-queues "Scala's Collection Library overview"]]
   *  section on `Immutable Queues` for more information.
   *

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -27,8 +27,6 @@ import java.lang.{Integer, String}
   *  uses `null` to represent empty trees. This also means pattern matching cannot
   *  easily be used. The API represented by the RedBlackTree object tries to hide these
   *  optimizations behind a reasonably clean API.
-  *
-  *  @since 2.10
   */
 private[collection] object RedBlackTree {
 

--- a/src/library/scala/collection/immutable/SeqMap.scala
+++ b/src/library/scala/collection/immutable/SeqMap.scala
@@ -28,7 +28,6 @@ import scala.collection.mutable.Builder
   * @tparam V      the type of the values associated with the keys in this linked map.
   *
   * @version 2.13
-  * @since 2.13
   * @define coll immutable seq map
   * @define Coll `immutable.SeqMap`
   */

--- a/src/library/scala/collection/immutable/SeqMap.scala
+++ b/src/library/scala/collection/immutable/SeqMap.scala
@@ -27,7 +27,6 @@ import scala.collection.mutable.Builder
   * @tparam K      the type of the keys contained in this linked map.
   * @tparam V      the type of the values associated with the keys in this linked map.
   *
-  * @version 2.13
   * @define coll immutable seq map
   * @define Coll `immutable.SeqMap`
   */

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -59,7 +59,6 @@ import scala.collection.mutable.ReusableBuilder
   *  @tparam V         the type of the values associated with the keys.
   *  @param ordering   the implicit ordering used to compare objects of type `A`.
   *
-  *  @since   1
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
   *  section on `Red-Black Trees` for more information.
   *

--- a/src/library/scala/collection/immutable/TreeSeqMap.scala
+++ b/src/library/scala/collection/immutable/TreeSeqMap.scala
@@ -40,7 +40,6 @@ import scala.annotation.unchecked.uncheckedVariance
   *
   *  @tparam K the type of the keys contained in this map.
   *  @tparam V the type of the values associated with the keys in this map.
-  * @version 2.13
   * @define coll immutable tree seq map
   * @define Coll `immutable.TreeSeqMap`
   */

--- a/src/library/scala/collection/immutable/TreeSeqMap.scala
+++ b/src/library/scala/collection/immutable/TreeSeqMap.scala
@@ -41,7 +41,6 @@ import scala.annotation.unchecked.uncheckedVariance
   *  @tparam K the type of the keys contained in this map.
   *  @tparam V the type of the values associated with the keys in this map.
   * @version 2.13
-  * @since 2.13
   * @define coll immutable tree seq map
   * @define Coll `immutable.TreeSeqMap`
   */

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -25,7 +25,6 @@ import scala.collection.mutable.ReusableBuilder
   *  @tparam A         the type of the elements contained in this tree set
   *  @param ordering   the implicit ordering used to compare objects of type `A`
   *
-  *  @since   1
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
   *  section on `Red-Black Trees` for more information.
   *

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -24,7 +24,6 @@ import scala.annotation.tailrec
   *  @tparam K      the type of the keys contained in this vector map.
   *  @tparam V      the type of the values associated with the keys in this vector map.
   *
-  * @version 2.13
   * @define coll immutable vector map
   * @define Coll `immutable.VectorMap`
   */

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -25,7 +25,6 @@ import scala.annotation.tailrec
   *  @tparam V      the type of the values associated with the keys in this vector map.
   *
   * @version 2.13
-  * @since 2.13
   * @define coll immutable vector map
   * @define Coll `immutable.VectorMap`
   */

--- a/src/library/scala/collection/immutable/WrappedString.scala
+++ b/src/library/scala/collection/immutable/WrappedString.scala
@@ -28,7 +28,6 @@ import scala.collection.mutable.{Builder, StringBuilder}
   *
   *  @param self    a string contained within this wrapped string
   *
-  *  @since 2.8
   *  @define Coll `WrappedString`
   *  @define coll wrapped string
   */
@@ -124,8 +123,6 @@ final class WrappedString(private val self: String) extends AbstractSeq[Char] wi
 }
 
 /** A companion object for wrapped strings.
-  *
-  *  @since 2.8
   */
 @SerialVersionUID(3L)
 object WrappedString extends SpecificIterableFactory[Char, WrappedString] {

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -24,7 +24,6 @@ import scala.collection.generic.DefaultSerializable
   *  access take constant time (amortized time). Prepends and removes are
   *  linear in the buffer size.
   *
-  *  @since   1
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array-buffers "Scala's Collection Library overview"]]
   *  section on `Array Buffers` for more information.
 

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -17,8 +17,6 @@ import scala.reflect.ClassTag
 
 /** A builder class for arrays.
  *
- *  @since 2.8
- *
  *  @tparam T    the type of the elements for the builder.
  */
 @SerialVersionUID(3L)
@@ -74,8 +72,6 @@ sealed abstract class ArrayBuilder[T]
 }
 
 /** A companion object for array builders.
- *
- *  @since 2.8
  */
 object ArrayBuilder {
 

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -27,8 +27,6 @@ import scala.reflect.ClassTag
   *
   *  @note Subclasses ''must'' override the `ofArray` protected method to return a more specific type.
   *
-  *  @since   2.13
-  *
   *  @tparam A  the type of this ArrayDeque's elements.
   *
   *  @define Coll `mutable.ArrayDeque`

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -26,7 +26,6 @@ import scala.util.hashing.MurmurHash3
   *
   *  @tparam T    type of the elements in this wrapped array.
   *
-  *  @since 2.8
   *  @define Coll `ArraySeq`
   *  @define coll wrapped array
   *  @define orderDependent

--- a/src/library/scala/collection/mutable/Cloneable.scala
+++ b/src/library/scala/collection/mutable/Cloneable.scala
@@ -15,8 +15,6 @@ package scala.collection.mutable
 
 /** A trait for cloneable collections.
   *
-  *  @since 2.8
-  *
   *  @tparam C    Type of the collection, covariant and with reference types as upperbound.
   */
 trait Cloneable[+C <: AnyRef] extends scala.Cloneable {

--- a/src/library/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/src/library/scala/collection/mutable/CollisionProofHashMap.scala
@@ -25,7 +25,6 @@ import scala.runtime.Statics
   * as determined by the `Ordering` has to be consistent with `equals` and `hashCode`. Universal equality
   * of numeric types is not supported (similar to `AnyRefMap`).
   *
-  * @since   2.13
   * @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
   * section on `Hash Tables` for more information.
   *

--- a/src/library/scala/collection/mutable/GrowableBuilder.scala
+++ b/src/library/scala/collection/mutable/GrowableBuilder.scala
@@ -19,8 +19,6 @@ package collection.mutable
   *
   * GrowableBuilders can produce only a single instance of the collection they are growing.
   *
-  * @since 2.8
-  *
   * @define Coll `GrowingBuilder`
   * @define coll growing builder
   */

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -19,7 +19,6 @@ import scala.collection.generic.DefaultSerializationProxy
 
 /** This class implements mutable maps using a hashtable.
   *
-  *  @since 1
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
   *  section on `Hash Tables` for more information.
   *

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -19,7 +19,6 @@ import scala.collection.generic.DefaultSerializationProxy
 
 /** This class implements mutable sets using a hashtable.
   *
-  * @since   1
   * @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
   * section on `Hash Tables` for more information.
   *

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -33,8 +33,6 @@ import java.lang.Integer
  *  its size is automatically doubled. Both parameters may be changed by
  *  overriding the corresponding values in class `HashTable`.
  *
- *  @since   1
- *
  *  @tparam A     type of the elements contained in this hash table.
  */
 // Was an abstract class, but to simplify the upgrade of the parallel collections I’ve made it a trait
@@ -408,7 +406,6 @@ private[collection] object HashTable {
 }
 
 /** Class used internally.
-  * @since 2.8
   */
 private[collection] trait HashEntry[A, E <: HashEntry[A, E]] {
   val key: A

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -36,7 +36,6 @@ object LinkedHashMap extends MapFactory[LinkedHashMap] {
   def newBuilder[K, V] = new GrowableBuilder(empty[K, V])
 
   /** Class for the linked hash map entry, used internally.
-    *  @since 2.8
     */
   private[mutable] final class LinkedEntry[K, V](val key: K, var value: V)
     extends HashEntry[K, LinkedEntry[K, V]] {

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -21,8 +21,6 @@ import scala.collection.generic.DefaultSerializable
 /** This class implements mutable sets using a hashtable.
  *  The iterator and all traversal methods of this class visit elements in the order they were inserted.
  *
- *  @since   1
- *
  *  @tparam A     the type of the elements contained in this set.
  *
  *  @define Coll `LinkedHashSet`
@@ -170,7 +168,6 @@ object LinkedHashSet extends IterableFactory[LinkedHashSet] {
   def newBuilder[A] = new GrowableBuilder(empty[A])
 
   /** Class for the linked hash set entry, used internally.
-   *  @since 2.10
    */
   private[mutable] final class Entry[A](val key: A) extends HashEntry[A, Entry[A]] {
     var earlier: Entry[A] = null

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -23,7 +23,6 @@ import scala.runtime.Statics.releaseFence
 /** A `Buffer` implementation backed by a list. It provides constant time
   *  prepend and append. Most other operations are linear.
   *
-  *  @since   1
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#list-buffers "Scala's Collection Library overview"]]
   *  section on `List Buffers` for more information.
   *

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -116,7 +116,6 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
    * @param key the key value
    * @param remappingFunction a partial function that receives current optionally-mapped value and return a new mapping
    * @return the new value associated with the specified key
-   * @since 2.13.0
    */
   def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = {
     val previousValue = this.get(key)

--- a/src/library/scala/collection/mutable/MultiMap.scala
+++ b/src/library/scala/collection/mutable/MultiMap.scala
@@ -49,7 +49,6 @@ package scala.collection.mutable
   *
   *  @define coll multimap
   *  @define Coll `MultiMap`
-  *  @since   1
   */
 @deprecated("Use a scala.collection.mutable.MultiDict in the scala-collection-contrib module", "2.13.0")
 trait MultiMap[K, V] extends Map[K, Set[V]] {

--- a/src/library/scala/collection/mutable/OpenHashMap.scala
+++ b/src/library/scala/collection/mutable/OpenHashMap.scala
@@ -20,8 +20,6 @@ import scala.collection.generic.DefaultSerializable
 /**
   *  @define Coll `OpenHashMap`
   *  @define coll open hash map
-  *
-  *  @since 2.7
   */
 @deprecated("Use HashMap or one of the specialized versions (LongMap, AnyRefMap) instead of OpenHashMap", "2.13.0")
 @SerialVersionUID(3L)
@@ -54,8 +52,6 @@ object OpenHashMap extends MapFactory[OpenHashMap] {
   *  @tparam Key          type of the keys in this map.
   *  @tparam Value        type of the values in this map.
   *  @param initialSize   the initial size of the internal hash table.
-  *
-  *  @since  2.7
   *
   *  @define Coll `OpenHashMap`
   *  @define coll open hash map

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -45,8 +45,6 @@ import scala.math.Ordering
   *  @tparam A    type of the elements in this priority queue.
   *  @param ord   implicit ordering used to compare the elements of type `A`.
   *
-  *  @since   1
-  *
   *  @define Coll PriorityQueue
   *  @define coll priority queue
   *  @define orderDependent

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -19,8 +19,6 @@ import scala.collection.generic.DefaultSerializable
 /** `Queue` objects implement data structures that allow to
   *  insert and retrieve elements in a first-in-first-out (FIFO) manner.
   *
-  *  @since   2.13
-  *
   *  @define Coll `mutable.Queue`
   *  @define coll mutable queue
   *  @define orderDependent

--- a/src/library/scala/collection/mutable/RedBlackTree.scala
+++ b/src/library/scala/collection/mutable/RedBlackTree.scala
@@ -21,8 +21,6 @@ import java.lang.String
  * An object containing the red-black tree implementation used by mutable `TreeMaps`.
  *
  * The trees implemented in this object are *not* thread safe.
- *
- * @since 2.12
  */
 private[collection] object RedBlackTree {
 

--- a/src/library/scala/collection/mutable/ReusableBuilder.scala
+++ b/src/library/scala/collection/mutable/ReusableBuilder.scala
@@ -29,8 +29,6 @@ package mutable
   *  @tparam  Elem  the type of elements that get added to the builder.
   *  @tparam  To    the type of collection that it produced.
   *
-  *  @since 2.12
-  *
   *  @define multipleResults
   *
   *     This Builder can be reused after calling `result()` without an

--- a/src/library/scala/collection/mutable/SeqMap.scala
+++ b/src/library/scala/collection/mutable/SeqMap.scala
@@ -25,7 +25,6 @@ package mutable
   * @tparam V      the type of the values associated with the keys in this linked map.
   *
   * @version 2.13
-  * @since 2.13
   * @define coll mutable Seq map
   * @define Coll `mutable.SeqMap`
   */

--- a/src/library/scala/collection/mutable/SeqMap.scala
+++ b/src/library/scala/collection/mutable/SeqMap.scala
@@ -24,7 +24,6 @@ package mutable
   * @tparam K      the type of the keys contained in this linked map.
   * @tparam V      the type of the values associated with the keys in this linked map.
   *
-  * @version 2.13
   * @define coll mutable Seq map
   * @define Coll `mutable.SeqMap`
   */

--- a/src/library/scala/collection/mutable/Shrinkable.scala
+++ b/src/library/scala/collection/mutable/Shrinkable.scala
@@ -18,7 +18,6 @@ import scala.annotation.tailrec
 /** This trait forms part of collections that can be reduced
   *  using a `-=` operator.
   *
-  *  @since   2.8
   *  @define coll shrinkable collection
   *  @define Coll `Shrinkable`
   */

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -21,8 +21,6 @@ import scala.collection.{IterableFactoryDefaults, IterableOnce, SeqFactory, Stri
   *
   *  @tparam A    type of the elements contained in this stack.
   *
-  *  @since   2.13
-  *
   *  @define Coll `Stack`
   *  @define coll stack
   *  @define orderDependent

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -32,7 +32,6 @@ import scala.Predef.{ // unimport char-related implicit conversions to avoid tri
   *
   * $multipleResults
   *
-  * @since   2.7
   * @define Coll `mutable.IndexedSeq`
   * @define coll string builder
   * @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#stringbuilders "Scala's Collection Library overview"]]

--- a/src/library/scala/collection/mutable/TreeMap.scala
+++ b/src/library/scala/collection/mutable/TreeMap.scala
@@ -26,8 +26,6 @@ import scala.collection.mutable.{RedBlackTree => RB}
   * @tparam K the type of the keys contained in this tree map.
   * @tparam V the type of the values associated with the keys.
   *
-  * @since 2.12
-  *
   * @define Coll mutable.TreeMap
   * @define coll mutable tree map
   */

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -24,8 +24,6 @@ import scala.collection.{SortedIterableFactory, SortedSetFactoryDefaults, Steppe
   * @param ordering the implicit ordering used to compare objects of type `A`.
   * @tparam A the type of the keys contained in this tree set.
   *
-  * @since 2.10
-  *
   * @define Coll mutable.TreeSet
   * @define coll mutable tree set
   */

--- a/src/library/scala/collection/mutable/WeakHashMap.scala
+++ b/src/library/scala/collection/mutable/WeakHashMap.scala
@@ -23,7 +23,6 @@ import scala.collection.convert.JavaCollectionWrappers.{JMapWrapper, JMapWrapper
  *  @tparam K      type of keys contained in this map
  *  @tparam V      type of values associated with the keys
  *
- *  @since 2.8
  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#weak-hash-maps "Scala's Collection Library overview"]]
  *  section on `Weak Hash Maps` for more information.
  *

--- a/src/library/scala/concurrent/DelayedLazyVal.scala
+++ b/src/library/scala/concurrent/DelayedLazyVal.scala
@@ -23,8 +23,6 @@ package scala.concurrent
  *
  *  @param  f      the function to obtain the current value at any point in time
  *  @param  body   the computation to run to completion in another thread
- *
- *  @since 2.8
  */
 @deprecated("`DelayedLazyVal` Will be removed in Scala 2.14.0 release.", since = "2.13.0")
 class DelayedLazyVal[T](f: () => T, body: => Unit)(implicit exec: ExecutionContext){

--- a/src/library/scala/concurrent/SyncChannel.scala
+++ b/src/library/scala/concurrent/SyncChannel.scala
@@ -15,8 +15,6 @@ package scala.concurrent
 /** A `SyncChannel` allows one to exchange data synchronously between
  *  a reader and a writer thread. The writer thread is blocked until the
  *  data to be written has been read by a corresponding reader thread.
- *
- *  @since 2.0
  */
 @deprecated("Use `java.util.concurrent.Exchanger` instead.", since = "2.13.0")
 class SyncChannel[A] {

--- a/src/library/scala/deprecated.scala
+++ b/src/library/scala/deprecated.scala
@@ -52,7 +52,6 @@ import scala.annotation.meta._
  *  @see    The official documentation on [[http://www.scala-lang.org/news/2.11.0/#binary-compatibility binary compatibility]].
  *  @param  message the message to print during compilation if the definition is accessed
  *  @param  since   a string identifying the first version in which the definition was deprecated
- *  @since  2.3
  *  @see    [[scala.deprecatedInheritance]]
  *  @see    [[scala.deprecatedOverriding]]
  *  @see    [[scala.deprecatedName]]

--- a/src/library/scala/deprecatedInheritance.scala
+++ b/src/library/scala/deprecatedInheritance.scala
@@ -42,7 +42,6 @@ import scala.annotation.meta._
  *
  *  @param  message the message to print during compilation if the class was sub-classed
  *  @param  since   a string identifying the first version in which inheritance was deprecated
- *  @since  2.10
  *  @see    [[scala.deprecated]]
  *  @see    [[scala.deprecatedOverriding]]
  *  @see    [[scala.deprecatedName]]

--- a/src/library/scala/deprecatedName.scala
+++ b/src/library/scala/deprecatedName.scala
@@ -36,7 +36,6 @@ import scala.annotation.meta._
   *           ^
   *  }}}
   *
-  *  @since  2.8.1
   *  @see    [[scala.deprecated]]
   *  @see    [[scala.deprecatedInheritance]]
   *  @see    [[scala.deprecatedOverriding]]

--- a/src/library/scala/deprecatedOverriding.scala
+++ b/src/library/scala/deprecatedOverriding.scala
@@ -43,7 +43,6 @@ import scala.annotation.meta._
  *
  *  @param  message the message to print during compilation if the member was overridden
  *  @param  since   a string identifying the first version in which overriding was deprecated
- *  @since  2.10
  *  @see    [[scala.deprecated]]
  *  @see    [[scala.deprecatedInheritance]]
  *  @see    [[scala.deprecatedName]]

--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -18,9 +18,6 @@ import scala.language.implicitConversions
 import java.math.{ MathContext, BigDecimal => BigDec }
 import scala.collection.immutable.NumericRange
 
-/**
- *  @since 2.7
- */
 object BigDecimal {
   private final val maximumHashScale = 4934           // Quit maintaining hash identity with BigInt beyond this scale
   private final val hashCodeNotComputed = 0x5D50690F  // Magic value (happens to be "BigDecimal" old MurmurHash3 value)

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -16,9 +16,6 @@ package math
 import java.math.BigInteger
 import scala.language.implicitConversions
 
-/**
- *  @since 2.1
- */
 object BigInt {
 
   private[this] val minCached = -1024

--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -30,8 +30,6 @@ import scala.language.higherKinds
  *    1. symmetric: `equiv(x, y) == equiv(y, x)` for any `x` and `y` of type `T`.
  *    1. transitive: if `equiv(x, y) == true` and `equiv(y, z) == true`, then
  *       `equiv(x, z) == true` for any `x`, `y`, and `z` of type `T`.
- *
- *  @since 2.7
  */
 
 trait Equiv[T] extends Any with Serializable {

--- a/src/library/scala/math/Fractional.scala
+++ b/src/library/scala/math/Fractional.scala
@@ -15,9 +15,6 @@ package math
 
 import scala.language.implicitConversions
 
-/**
- * @since 2.8
- */
 trait Fractional[T] extends Numeric[T] {
   def div(x: T, y: T): T
 

--- a/src/library/scala/math/Integral.scala
+++ b/src/library/scala/math/Integral.scala
@@ -15,9 +15,6 @@ package math
 
 import scala.language.implicitConversions
 
-/**
- * @since 2.8
- */
 trait Integral[T] extends Numeric[T] {
   def quot(x: T, y: T): T
   def rem(x: T, y: T): T

--- a/src/library/scala/math/Numeric.scala
+++ b/src/library/scala/math/Numeric.scala
@@ -17,9 +17,6 @@ import scala.collection.StringParsers
 import scala.language.implicitConversions
 import scala.util.Try
 
-/**
- * @since 2.8
- */
 object Numeric {
   @inline def apply[T](implicit num: Numeric[T]): Numeric[T] = num
 

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -65,7 +65,6 @@ import scala.language.{higherKinds, implicitConversions}
   * You can import scala.math.Ordering.Implicits to gain access to other
   * implicit orderings.
   *
-  * @since 2.7
   * @see [[scala.math.Ordered]], [[scala.util.Sorting]]
   */
 @annotation.implicitNotFound(msg = "No implicit Ordering defined for ${T}.")

--- a/src/library/scala/math/PartialOrdering.scala
+++ b/src/library/scala/math/PartialOrdering.scala
@@ -36,8 +36,6 @@ package math
  *  `lteq(x, y) && lteq(y, x) == '''true'''`. This equivalence relation is
  *  exposed as the `equiv` method, inherited from the
  *  [[scala.math.Equiv Equiv]] trait.
- *
- *  @since 2.7
  */
 
 trait PartialOrdering[T] extends Equiv[T] {

--- a/src/library/scala/math/ScalaNumber.java
+++ b/src/library/scala/math/ScalaNumber.java
@@ -14,7 +14,6 @@ package scala.math;
 
 /** A marker class for Number types introduced by Scala
  *  @version 2.8
- *  @since 2.8
  */
 public abstract class ScalaNumber extends java.lang.Number {
   protected abstract boolean isWhole();

--- a/src/library/scala/math/ScalaNumber.java
+++ b/src/library/scala/math/ScalaNumber.java
@@ -13,7 +13,6 @@
 package scala.math;
 
 /** A marker class for Number types introduced by Scala
- *  @version 2.8
  */
 public abstract class ScalaNumber extends java.lang.Number {
   protected abstract boolean isWhole();

--- a/src/library/scala/native.scala
+++ b/src/library/scala/native.scala
@@ -22,8 +22,6 @@ package scala
   * while discarding the method's body (if any). The body will be type checked if present.
   *
   * A method marked @native must be a member of a class, not a trait (since 2.12).
-  *
-  * @since 2.6
   */
 @deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
 class native extends scala.annotation.StaticAnnotation {}

--- a/src/library/scala/runtime/AbstractPartialFunction.scala
+++ b/src/library/scala/runtime/AbstractPartialFunction.scala
@@ -23,8 +23,6 @@ package runtime
  *    of partial function literals.
  *
  *  This trait is used as a basis for implementation of all partial function literals.
- *
- *  @since   2.10
  */
 abstract class AbstractPartialFunction[@specialized(Specializable.Arg) -T1, @specialized(Specializable.Return) +R] extends Function1[T1, R] with PartialFunction[T1, R] { self =>
   // this method must be overridden for better performance,

--- a/src/library/scala/runtime/BoxesRunTime.java
+++ b/src/library/scala/runtime/BoxesRunTime.java
@@ -23,8 +23,7 @@ import scala.math.ScalaNumber;
   *   - The generalised comparison method to be used when an object may
   *     be a boxed value.
   *   - Standard value operators for boxed number and quasi-number values.
-  *
-  * @version 2.0 */
+  */
 public final class BoxesRunTime
 {
     private static final int CHAR = 0, /* BYTE = 1, SHORT = 2, */ INT = 3, LONG = 4, FLOAT = 5, DOUBLE = 6, OTHER = 7;

--- a/src/library/scala/runtime/ScalaNumberProxy.scala
+++ b/src/library/scala/runtime/ScalaNumberProxy.scala
@@ -20,8 +20,6 @@ import Proxy.Typed
 
 /** Base classes for the Rich* wrappers of the primitive types.
  *  As with all classes in scala.runtime.*, this is not a supported API.
- *
- *  @since   2.9
  */
 trait ScalaNumberProxy[T] extends Any with ScalaNumericAnyConversions with Typed[T] with OrderedProxy[T] {
   protected implicit def num: Numeric[T]

--- a/src/library/scala/specialized.scala
+++ b/src/library/scala/specialized.scala
@@ -25,8 +25,6 @@ import Specializable._
  *  {{{
  *    class MyList[@specialized(Int, Double, Boolean) T] ..
  *  }}}
- *
- *  @since 2.8
  */
 // class tspecialized[T](group: Group[T]) extends scala.annotation.StaticAnnotation {
 

--- a/src/library/scala/sys/Prop.scala
+++ b/src/library/scala/sys/Prop.scala
@@ -18,8 +18,6 @@ package sys
  *  is not a requirement.
  *
  *  See `scala.sys.SystemProperties` for an example usage.
- *
- *  @since   2.9
  */
 trait Prop[+T] {
   /** The full name of the property, e.g., "java.awt.headless".

--- a/src/library/scala/sys/ShutdownHookThread.scala
+++ b/src/library/scala/sys/ShutdownHookThread.scala
@@ -15,8 +15,6 @@ package sys
 
 /** A minimal Thread wrapper to enhance shutdown hooks.  It knows
  *  how to unregister itself.
- *
- *  @since   2.9
  */
 class ShutdownHookThread private (runnable: Runnable, name: String) extends Thread(runnable, name) {
   def remove() = Runtime.getRuntime removeShutdownHook this

--- a/src/library/scala/sys/SystemProperties.scala
+++ b/src/library/scala/sys/SystemProperties.scala
@@ -27,8 +27,6 @@ import scala.language.implicitConversions
  *  will be caught and discarded.
  *  @define Coll `collection.mutable.Map`
  *  @define coll mutable map
- *
- *  @since   2.9
  */
 class SystemProperties
 extends mutable.AbstractMap[String, String] {

--- a/src/library/scala/sys/package.scala
+++ b/src/library/scala/sys/package.scala
@@ -18,8 +18,6 @@ import scala.collection.JavaConverters._
 /** The package object `scala.sys` contains methods for reading
  *  and altering core aspects of the virtual machine as well as the
  *  world outside of it.
- *
- *  @since   2.9
  */
 package object sys {
   /** Throw a new RuntimeException with the supplied message.

--- a/src/library/scala/throws.scala
+++ b/src/library/scala/throws.scala
@@ -22,8 +22,6 @@ package scala
  *   def read() = in.read()
  * }
  * }}}
- *
- * @since   2.1
  */
 final class throws[T <: Throwable](cause: String = "") extends scala.annotation.StaticAnnotation {
   def this(clazz: Class[T]) = this("")

--- a/src/library/scala/unchecked.scala
+++ b/src/library/scala/unchecked.scala
@@ -34,7 +34,5 @@ package scala
  *      def g(xs: Any) = xs match { case x: List[String @unchecked] => x.head }
  *    }
  * }}}
- *
- *  @since 2.4
  */
 final class unchecked extends scala.annotation.Annotation {}

--- a/src/library/scala/util/DynamicVariable.scala
+++ b/src/library/scala/util/DynamicVariable.scala
@@ -37,8 +37,6 @@ import java.lang.InheritableThreadLocal
  *  of the stack of bindings from the parent thread, and
  *  from then on the bindings for the new thread
  *  are independent of those for the original thread.
- *
- *  @since   2.6
  */
 class DynamicVariable[T](init: T) {
   private[this] val tl = new InheritableThreadLocal[T] {

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -116,8 +116,6 @@ package util
  *  } yield x + y + z
  *  // Left(42.0), but unexpectedly a `Either[Double,String]`
  *  }}}
- *
- *  @since 2.7
  */
 sealed abstract class Either[+A, +B] extends Product with Serializable {
   /** Projects this `Either` as a `Left`.

--- a/src/library/scala/util/Random.scala
+++ b/src/library/scala/util/Random.scala
@@ -232,8 +232,6 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
 
   /** Returns a LazyList of pseudorandomly chosen alphanumeric characters,
    *  equally chosen from A-Z, a-z, and 0-9.
-   *
-   *  @since 2.8
    */
   @migration("`alphanumeric` returns a LazyList instead of a Stream", "2.13.0")
   def alphanumeric: LazyList[Char] = {
@@ -249,8 +247,6 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
 
 /** The object `Random` offers a default implementation
  *  of scala.util.Random and random-related convenience methods.
- *
- *  @since 2.8
  */
 object Random extends Random {
 

--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -60,8 +60,6 @@ import scala.util.control.NonFatal
  * ''Note:'': all Try combinators will catch exceptions and return failure unless otherwise specified in the documentation.
  *
  * `Try` comes to the Scala standard library after years of use as an integral part of Twitter's stack.
- *
- * @since 2.10
  */
 sealed abstract class Try[+T] extends Product with Serializable {
 

--- a/src/library/scala/util/control/NoStackTrace.scala
+++ b/src/library/scala/util/control/NoStackTrace.scala
@@ -19,8 +19,6 @@ package util.control
  *  [[scala.sys.SystemProperties]].
  *
  *  @note Since JDK 1.7, a similar effect can be achieved with `class Ex extends Throwable(..., writableStackTrace = false)`
- *
- *  @since    2.8
  */
 trait NoStackTrace extends Throwable {
   override def fillInStackTrace(): Throwable =

--- a/src/library/scala/util/hashing/Hashing.scala
+++ b/src/library/scala/util/hashing/Hashing.scala
@@ -23,8 +23,6 @@ import scala.annotation.implicitNotFound
   *
   * Note: when using a custom `Hashing`, make sure to use it with the `Equiv`
   * such that if any two objects are equal, then their hash codes must be equal.
-  *
-  * @since 2.10
   */
 @implicitNotFound(msg = "No implicit Hashing defined for ${T}.")
 trait Hashing[T] extends Serializable {

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -64,8 +64,6 @@ trait StdAttachments {
     * @param samTp the expected type that triggered sam conversion (may be a subtype of the type corresponding to sam's owner)
     * @param sam the single abstract method implemented by the Function we're attaching this to
     * @param synthCls the (synthetic) class representing the eventual implementation class (spun at runtime by LMF on the JVM)
-    *
-    * @since 2.12.0-M4
     */
   case class SAMFunction(samTp: Type, sam: Symbol, synthCls: Symbol) extends PlainAttachment
 

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -17,10 +17,6 @@ package internal
 import Flags._
 import scala.annotation.tailrec
 
-/** This class ...
- *
- *  @version 1.0
- */
 abstract class TreeInfo {
   val global: SymbolTable
 

--- a/src/reflect/scala/reflect/internal/annotations/uncheckedBounds.scala
+++ b/src/reflect/scala/reflect/internal/annotations/uncheckedBounds.scala
@@ -19,7 +19,5 @@ package annotations
  * type parameter bounds in the `refchecks` phase of the compiler. This can be used by synthesized
  * code the uses an inferred type of an expression as the type of an artifact val/def (for example,
  * a temporary value introduced by an ANF transform). See [[https://github.com/scala/bug/issues/7694]].
- *
- * @since  2.10.3
  */
 final class uncheckedBounds extends scala.annotation.StaticAnnotation

--- a/src/reflect/scala/reflect/internal/pickling/PickleFormat.scala
+++ b/src/reflect/scala/reflect/internal/pickling/PickleFormat.scala
@@ -19,8 +19,6 @@ package pickling
  *
  *  If you extend the format, be sure to increase the
  *  version minor number.
- *
- *  @version 1.0
  */
 object PickleFormat {
 

--- a/src/reflect/scala/reflect/internal/util/StringOps.scala
+++ b/src/reflect/scala/reflect/internal/util/StringOps.scala
@@ -19,7 +19,6 @@ import java.lang.System.{lineSeparator => EOL}
 
 /** This object provides utility methods to extract elements
  *  from Strings.
- *  @version 1.0
  */
 trait StringOps {
   def oempty(xs: String*)        = xs filterNot (x => x == null || x == "")

--- a/src/reflect/scala/reflect/io/AbstractFile.scala
+++ b/src/reflect/scala/reflect/io/AbstractFile.scala
@@ -25,8 +25,6 @@ import scala.collection.AbstractIterable
  * An abstraction over files for use in the reflection/compiler libraries.
  *
  * ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
- *
- * @version 1.0, 23/03/2004
  */
 object AbstractFile {
   /** Returns "getFile(new File(path))". */

--- a/src/reflect/scala/reflect/io/Directory.scala
+++ b/src/reflect/scala/reflect/io/Directory.scala
@@ -36,8 +36,6 @@ object Directory {
 
 /** An abstraction for directories.
  *
- *  @since   2.8
- *
  *  ''Note:  This is library is considered experimental and should not be used unless you know what you are doing.''
  */
 class Directory(jfile: JFile) extends Path(jfile) {

--- a/src/reflect/scala/reflect/io/File.scala
+++ b/src/reflect/scala/reflect/io/File.scala
@@ -42,8 +42,6 @@ object File {
  *  precedence if supplied.) If neither is available, the value
  *  of scala.io.Codec.default is used.
  *
- *  @since   2.8
- *
  *  ''Note:  This is library is considered experimental and should not be used unless you know what you are doing.''
  */
 class File(jfile: JFile)(implicit constructorCodec: Codec) extends Path(jfile) with Streamable.Chars {

--- a/src/reflect/scala/reflect/io/Path.scala
+++ b/src/reflect/scala/reflect/io/Path.scala
@@ -32,8 +32,6 @@ import scala.util.Random.alphanumeric
  *  Also available are createFile and createDirectory, which attempt
  *  to create the path in question.
  *
- *  @since   2.8
- *
  *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
 object Path {

--- a/src/reflect/scala/reflect/io/Streamable.scala
+++ b/src/reflect/scala/reflect/io/Streamable.scala
@@ -24,8 +24,6 @@ import scala.annotation.tailrec
 
 /** Traits for objects which can be represented as Streams.
  *
- *  @since  2.8
- *
  *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
 object Streamable {

--- a/src/reflect/scala/reflect/io/VirtualFile.scala
+++ b/src/reflect/scala/reflect/io/VirtualFile.scala
@@ -18,8 +18,6 @@ import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, InputStream, Outpu
 
 /** This class implements an in-memory file.
  *
- *  @version 1.0, 23/03/2004
- *
  *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
 class VirtualFile(val name: String, override val path: String) extends AbstractFile {

--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -29,8 +29,6 @@ import scala.reflect.internal.JDK9Reflectors
  *  it is for performance: we come through here a lot on every run.  Be careful
  *  about changing it.
  *
- *  @version 2.0,
- *
  *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
 object ZipArchive {

--- a/src/scalacheck/org/scalacheck/commands/Commands.scala
+++ b/src/scalacheck/org/scalacheck/commands/Commands.scala
@@ -15,8 +15,6 @@ import scala.util.{Try, Success, Failure}
 /** An API for stateful testing in ScalaCheck.
  *
  *  For an implementation overview, see the examples in ScalaCheck's source tree.
- *
- *  @since 1.12.0
  */
 trait Commands {
 

--- a/src/scaladoc/scala/tools/nsc/doc/html/SyntaxHigh.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/SyntaxHigh.scala
@@ -19,7 +19,6 @@ import scala.annotation.{switch, tailrec}
   * (see method `HtmlPage.blockToHtml`).
   *
   * @author Stephane Micheloud
-  * @version 1.0
   */
 private[html] object SyntaxHigh {
   import HtmlTags.{Elems, Raw, NoElems}

--- a/test/instrumented/boxes.patch
+++ b/test/instrumented/boxes.patch
@@ -9,7 +9,7 @@
  package scala.runtime;
 
  import scala.math.ScalaNumber;
-@@ -44,37 +44,54 @@
+@@ -43,37 +43,54 @@
 
  /* BOXING ... BOXING ... BOXING ... BOXING ... BOXING ... BOXING ... BOXING ... BOXING */
 


### PR DESCRIPTION
the `@version` tags are well and truly useless, afaict.
I suspect some IDE templating thing inserted them,
back in the day.

perhaps the `@since` tags have some small nonzero value, but they
were never consistently applied. most classes don't have them,
and the ones that exist are often for really ancient versions.
it seems like noise to me.

separate commits in case there's dissent on the `@since`.