### PR TITLE
Java fields don't override each other

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
+++ b/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
@@ -40,10 +40,16 @@ abstract class OverridingPairs extends SymbolPairs {
      */
     override protected def matches(high: Symbol) = low.isType || (
          (low.owner != high.owner)     // don't try to form pairs from overloaded members
+      && !bothJavaOwnedAndEitherIsField(low, high)
       && !high.isPrivate               // private or private[this] members never are overridden
       && !exclude(low)                 // this admits private, as one can't have a private member that matches a less-private member.
       && (lowMemberType matches (self memberType high))
     ) // TODO we don't call exclude(high), should we?
+  }
+
+  private def bothJavaOwnedAndEitherIsField(low: Symbol, high: Symbol): Boolean = {
+    low.owner.isJavaDefined && high.owner.isJavaDefined &&
+      (low.isField || high.isField)
   }
 
   final class BridgesCursor(base: Symbol) extends Cursor(base) {

--- a/src/reflect/scala/reflect/internal/SymbolPairs.scala
+++ b/src/reflect/scala/reflect/internal/SymbolPairs.scala
@@ -180,7 +180,7 @@ abstract class SymbolPairs {
           val high    = nextEntry.sym
           val isMatch = matches(high) && { visited addEntry nextEntry ; true } // side-effect visited on all matches
 
-          // Advance if no match, or if the particular cursor is not intested in this pair
+          // Advance if no match, or if the particular cursor is not interested in this pair
           if (!isMatch || skipOwnerPair(low.owner, high.owner)) advanceNextEntry()
           else highSymbol = high
         }

--- a/test/files/neg/t11575b.check
+++ b/test/files/neg/t11575b.check
@@ -1,0 +1,7 @@
+LocalImpl.scala:2: error: incompatible type in overriding
+private[package <empty>] var counts: Array[Int] (defined in class Cover);
+ found   : String
+ required: Array[Int]
+    override var counts: String = ""
+                 ^
+one error found

--- a/test/files/neg/t11575b/Base.java
+++ b/test/files/neg/t11575b/Base.java
@@ -1,0 +1,3 @@
+public class Base {
+    long[] counts;
+}

--- a/test/files/neg/t11575b/Cover.java
+++ b/test/files/neg/t11575b/Cover.java
@@ -1,0 +1,3 @@
+public class Cover extends Base {
+    int[] counts;
+}

--- a/test/files/neg/t11575b/LocalImpl.scala
+++ b/test/files/neg/t11575b/LocalImpl.scala
@@ -1,0 +1,3 @@
+class LocalImpl extends Cover {
+    override var counts: String = ""
+}

--- a/test/files/pos/t11575/Base.java
+++ b/test/files/pos/t11575/Base.java
@@ -1,0 +1,3 @@
+public class Base {
+    long[] counts;
+}

--- a/test/files/pos/t11575/Cover.java
+++ b/test/files/pos/t11575/Cover.java
@@ -1,0 +1,3 @@
+public class Cover extends Base {
+    int[] counts;
+}

--- a/test/files/pos/t11575/LocalImpl.scala
+++ b/test/files/pos/t11575/LocalImpl.scala
@@ -1,0 +1,1 @@
+class LocalImpl extends Cover

--- a/test/files/pos/t11575c/LocalImpl.scala
+++ b/test/files/pos/t11575c/LocalImpl.scala
@@ -1,0 +1,9 @@
+class Base {
+    private[this] var counts: Array[Long] = _
+}
+
+class Cover extends Base {
+    private[this] var counts: Array[Int] = _
+}
+
+class LocalImpl extends Cover


### PR DESCRIPTION
While we model Java fields are overridable from Scala (which is
questionable, because clients can still access the field in the
super class), we definitely shouldn't treat them as such for
pairs of Java owners.

Fixes scala/bug#11575