### PR TITLE
mark 2.12 spec as not current anymore

### DIFF
--- a/spec/_config.yml
+++ b/spec/_config.yml
@@ -1,5 +1,5 @@
 baseurl: /files/archive/spec/2.12
-latestScalaVersion: 2.12
+latestScalaVersion: 2.13
 thisScalaVersion: 2.12
 safe: true
 lsi: false


### PR DESCRIPTION
partially addresses scala/bug#11566

Pluto isn't a planet anymore, either. sorry 2.12, sorry Pluto