### PR TITLE
Backport changes to Names and ClassfileParser

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1548,6 +1548,9 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
 
       reporting.summarizeErrors()
 
+      // val allNamesArray: Array[String] = allNames().map(_.toString).toArray.sorted
+      // allNamesArray.foreach(println(_))
+
       if (traceSymbolActivity)
         units map (_.body) foreach (traceSymbols recordSymbolsInTree _)
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -415,7 +415,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
      */
     def getAnnotPickle(jclassName: String, sym: Symbol): Option[AnnotationInfo] = {
       currentRun.symData get sym match {
-        case Some(pickle) if !sym.isModuleClass =>
+        case Some(pickle) if !sym.isModuleClass => // pickles for module classes are in the companion / mirror class
           val scalaAnnot = {
             val sigBytes = ScalaSigBytes(pickle.bytes.take(pickle.writeIndex))
             AnnotationInfo(sigBytes.sigAnnot, Nil, (nme.bytes, sigBytes) :: Nil)

--- a/src/compiler/scala/tools/nsc/symtab/classfile/AbstractFileReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/AbstractFileReader.scala
@@ -14,8 +14,10 @@ package scala.tools.nsc
 package symtab
 package classfile
 
-import java.lang.Float.intBitsToFloat
+import java.io.{ByteArrayInputStream, DataInputStream}
 import java.lang.Double.longBitsToDouble
+import java.lang.Float.intBitsToFloat
+import java.util
 
 import scala.tools.nsc.io.AbstractFile
 
@@ -25,8 +27,11 @@ import scala.tools.nsc.io.AbstractFile
  * @author Philippe Altherr
  * @version 1.0, 23/03/2004
  */
-class AbstractFileReader(val file: AbstractFile, val buf: Array[Byte]) {
-  def this(file: AbstractFile) = this(file, file.toByteArray)
+final class AbstractFileReader(val buf: Array[Byte]) extends DataReader {
+  @deprecated("Use other constructor", "2.13.0")
+  def this(file: AbstractFile) {
+    this(file.toByteArray)
+  }
 
   /** the current input pointer
    */
@@ -59,17 +64,25 @@ class AbstractFileReader(val file: AbstractFile, val buf: Array[Byte]) {
     ((nextByte & 0xff) << 24) + ((nextByte & 0xff) << 16) +
     ((nextByte & 0xff) <<  8) +  (nextByte & 0xff)
 
+  /** extract a byte at position bp from buf
+   */
+  def getByte(mybp: Int): Byte =
+    buf(mybp)
+
+  def getBytes(mybp: Int, bytes: Array[Byte]): Unit = {
+    System.arraycopy(buf, mybp, bytes, 0, bytes.length)
+  }
 
   /** extract a character at position bp from buf
    */
   def getChar(mybp: Int): Char =
-    (((buf(mybp) & 0xff) << 8) + (buf(mybp+1) & 0xff)).toChar
+    (((getByte(mybp) & 0xff) << 8) + (getByte(mybp+1) & 0xff)).toChar
 
   /** extract an integer at position bp from buf
    */
   def getInt(mybp: Int): Int =
-    ((buf(mybp  ) & 0xff) << 24) + ((buf(mybp+1) & 0xff) << 16) +
-    ((buf(mybp+2) & 0xff) << 8) + (buf(mybp+3) & 0xff)
+    ((getByte(mybp) & 0xff) << 24) + ((getByte(mybp + 1) & 0xff) << 16) +
+    ((getByte(mybp + 2) & 0xff) << 8) + (getByte(mybp + 3) & 0xff)
 
   /** extract a long integer at position bp from buf
    */
@@ -84,8 +97,11 @@ class AbstractFileReader(val file: AbstractFile, val buf: Array[Byte]) {
    */
   def getDouble(mybp: Int): Double = longBitsToDouble(getLong(mybp))
 
+  def getUTF(mybp: Int, len: Int): String = {
+    new DataInputStream(new ByteArrayInputStream(buf, mybp, len)).readUTF
+  }
+
   /** skip next 'n' bytes
    */
-  def skip(n: Int) { bp += n }
-
+  def skip(n: Int): Unit = { bp += n }
 }

--- a/src/compiler/scala/tools/nsc/symtab/classfile/DataReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/DataReader.scala
@@ -1,0 +1,68 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.nsc.symtab.classfile
+
+trait DataReader {
+
+  def bp: Int
+  def bp_=(i: Int): Unit
+
+  /** read a byte
+    */
+  @throws(classOf[IndexOutOfBoundsException])
+  def nextByte: Byte
+
+  /** read some bytes
+    */
+  def nextBytes(len: Int): Array[Byte]
+
+  /** read a character
+    */
+  def nextChar: Char
+
+  /** read an integer
+    */
+  def nextInt: Int
+
+  /** extract a character at position bp from buf
+    */
+  def getChar(mybp: Int): Char
+
+  /** extract an integer at position bp from buf
+    */
+  def getByte(mybp: Int): Byte
+
+  def getBytes(mybp: Int, bytes: Array[Byte]): Unit
+
+  /** extract an integer at position bp from buf
+    */
+  def getInt(mybp: Int): Int
+
+  /** extract a long integer at position bp from buf
+    */
+  def getLong(mybp: Int): Long
+
+  /** extract a float at position bp from buf
+    */
+  def getFloat(mybp: Int): Float
+
+  /** extract a double at position bp from buf
+    */
+  def getDouble(mybp: Int): Double
+
+  def getUTF(mybp: Int, len: Int): String
+
+  /** skip next 'n' bytes
+    */
+  def skip(n: Int): Unit
+}

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ReusableDataReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ReusableDataReader.scala
@@ -1,0 +1,156 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.nsc.symtab.classfile
+
+import java.io.{ByteArrayInputStream, DataInputStream, InputStream}
+import java.nio.channels.Channels
+import java.nio.{BufferUnderflowException, ByteBuffer}
+
+final class ReusableDataReader() extends DataReader {
+  private[this] var data = new Array[Byte](32768)
+  private[this] var bb: ByteBuffer = ByteBuffer.wrap(data)
+  private[this] var size = 0
+  private[this] val reader: DataInputStream = {
+    val stream = new InputStream {
+      override def read(): Int = try {
+        bb.get & 0xff
+      } catch {
+        case _: BufferUnderflowException => -1
+      }
+
+      override def read(b: Array[Byte], off: Int, len: Int): Int = {
+        val pos = bb.position()
+        bb.get(b, off, len)
+        bb.position() - pos
+      }
+
+      override def markSupported(): Boolean = false
+    }
+    new DataInputStream(stream)
+  }
+
+  private def nextPositivePowerOfTwo(target: Int): Int = 1 << -Integer.numberOfLeadingZeros(target - 1)
+
+  def reset(file: scala.reflect.io.AbstractFile): this.type = {
+    this.size = 0
+    file.sizeOption match {
+      case Some(size) =>
+        if (size > data.length) {
+          data = new Array[Byte](nextPositivePowerOfTwo(size))
+        } else {
+          java.util.Arrays.fill(data, 0.toByte)
+        }
+        val input = file.input
+        try {
+          var endOfInput = false
+          while (!endOfInput) {
+            val remaining = data.length - this.size
+            if (remaining == 0) endOfInput = true
+            else {
+              val read = input.read(data, this.size, remaining)
+              if (read < 0) endOfInput = true
+              else this.size += read
+            }
+          }
+          bb = ByteBuffer.wrap(data, 0, size)
+        } finally {
+          input.close()
+        }
+      case None =>
+        val input = file.input
+        try {
+          var endOfInput = false
+          while (!endOfInput) {
+            val remaining = data.length - size
+            if (remaining == 0) {
+              data = java.util.Arrays.copyOf(data, nextPositivePowerOfTwo(size))
+            }
+            val read = input.read(data, this.size, data.length - this.size)
+            if (read < 0) endOfInput = true
+            else this.size += read
+          }
+          bb = ByteBuffer.wrap(data, 0, size)
+        } finally {
+          input.close()
+        }
+    }
+    this
+  }
+
+  @throws(classOf[IndexOutOfBoundsException])
+  def nextByte: Byte = bb.get
+
+  def nextBytes(len: Int): Array[Byte] = {
+    val result = new Array[Byte](len)
+    reader.readFully(result)
+    result
+  }
+
+  def nextChar: Char = bb.getChar()
+
+  def nextInt: Int = bb.getInt()
+
+  def getChar(mybp: Int): Char = {
+    bb.getChar(mybp)
+  }
+
+  def getInt(mybp: Int): Int = {
+    bb.getInt(mybp)
+  }
+
+  def getLong(mybp: Int): Long = {
+    bb.getLong(mybp)
+  }
+
+  def getFloat(mybp: Int): Float = {
+    bb.getFloat(mybp)
+  }
+
+  def getDouble(mybp: Int): Double = {
+    bb.getDouble(mybp)
+  }
+
+  def skip(n: Int): Unit = {
+    bb.position(bb.position() + n)
+  }
+  def bp: Int = bb.position()
+  def bp_=(i: Int): Unit = {
+    try {
+      bb.position(i)
+    } catch {
+      case ex: IllegalArgumentException =>
+        throw ex
+    }
+  }
+
+  def getByte(mybp: Int): Byte = {
+    bb.get(mybp)
+  }
+  def getBytes(mybp: Int, bytes: Array[Byte]): Unit = {
+    val saved = bb.position()
+    bb.position(mybp)
+    try reader.readFully(bytes)
+    finally bb.position(saved)
+  }
+  def getUTF(mybp: Int, len: Int): String = {
+    val saved = bb.position()
+    val savedLimit = bb.limit()
+    bb.position(mybp)
+    bb.limit(mybp + len)
+    try reader.readUTF()
+    finally {
+      bb.limit(savedLimit)
+      bb.position(saved)
+    }
+  }
+}

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -192,11 +192,11 @@ trait Definitions extends api.StandardDefinitions {
 
     // It becomes tricky to create dedicated objects for other symbols because
     // of initialization order issues.
-    lazy val JavaLangPackage      = getPackage(TermName("java.lang"))
+    lazy val JavaLangPackage      = getPackage("java.lang")
     lazy val JavaLangPackageClass = JavaLangPackage.moduleClass.asClass
-    lazy val ScalaPackage         = getPackage(TermName("scala"))
+    lazy val ScalaPackage         = getPackage("scala")
     lazy val ScalaPackageClass    = ScalaPackage.moduleClass.asClass
-    lazy val RuntimePackage       = getPackage(TermName("scala.runtime"))
+    lazy val RuntimePackage       = getPackage("scala.runtime")
     lazy val RuntimePackageClass  = RuntimePackage.moduleClass.asClass
 
     def javaTypeToValueClass(jtype: Class[_]): Symbol = jtype match {
@@ -292,7 +292,7 @@ trait Definitions extends api.StandardDefinitions {
     // top types
     lazy val AnyClass    = enterNewClass(ScalaPackageClass, tpnme.Any, Nil, ABSTRACT) markAllCompleted
     lazy val AnyRefClass = newAlias(ScalaPackageClass, tpnme.AnyRef, ObjectTpe) markAllCompleted
-    lazy val ObjectClass = getRequiredClass(sn.Object.toString)
+    lazy val ObjectClass = getRequiredClass("java.lang.Object")
 
     // Cached types for core monomorphic classes
     lazy val AnyRefTpe       = AnyRefClass.tpe
@@ -343,12 +343,12 @@ trait Definitions extends api.StandardDefinitions {
 
     // exceptions and other throwables
     lazy val ClassCastExceptionClass        = requiredClass[ClassCastException]
-    lazy val IndexOutOfBoundsExceptionClass = getClassByName(sn.IOOBException)
-    lazy val InvocationTargetExceptionClass = getClassByName(sn.InvTargetException)
+    lazy val IndexOutOfBoundsExceptionClass = getClassByName("java.lang.IndexOutOfBoundsException")
+    lazy val InvocationTargetExceptionClass = getClassByName("java.lang.reflect.InvocationTargetException")
     lazy val MatchErrorClass                = requiredClass[MatchError]
     lazy val NonLocalReturnControlClass     = requiredClass[scala.runtime.NonLocalReturnControl[_]]
-    lazy val NullPointerExceptionClass      = getClassByName(sn.NPException)
-    lazy val ThrowableClass                 = getClassByName(sn.Throwable)
+    lazy val NullPointerExceptionClass      = getClassByName("java.lang.NullPointerException")
+    lazy val ThrowableClass                 = getClassByName("java.lang.Throwable")
     lazy val UninitializedErrorClass        = requiredClass[UninitializedFieldError]
     lazy val IllegalArgExceptionClass       = requiredClass[IllegalArgumentException]
 
@@ -422,7 +422,10 @@ trait Definitions extends api.StandardDefinitions {
     def isByName(param: Symbol)            = isByNameParamType(param.tpe_*)
     def isCastSymbol(sym: Symbol)          = sym == Any_asInstanceOf || sym == Object_asInstanceOf
 
-    def isJavaVarArgsMethod(m: Symbol)      = m.isMethod && isJavaVarArgs(m.info.params)
+    def isJavaVarArgsMethod(m: Symbol)      = m.isMethod && (m.rawInfo match {
+      case completer: LazyType => completer.isJavaVarargsMethod
+      case _ => isJavaVarArgs(m.info.params)
+    })
     def isJavaVarArgs(params: Seq[Symbol])  = !params.isEmpty && isJavaRepeatedParamType(params.last.tpe)
     def isScalaVarArgs(params: Seq[Symbol]) = !params.isEmpty && isScalaRepeatedParamType(params.last.tpe)
     def isVarArgsList(params: Seq[Symbol])  = !params.isEmpty && isRepeatedParamType(params.last.tpe)
@@ -488,7 +491,7 @@ trait Definitions extends api.StandardDefinitions {
 
     // reflection / structural types
     lazy val SoftReferenceClass     = requiredClass[java.lang.ref.SoftReference[_]]
-    lazy val MethodClass            = getClassByName(sn.MethodAsObject)
+    lazy val MethodClass            = getClassByName("java.lang.reflect.Method")
     lazy val EmptyMethodCacheClass  = requiredClass[scala.runtime.EmptyMethodCache]
     lazy val MethodCacheClass       = requiredClass[scala.runtime.MethodCache]
       def methodCache_find          = getMemberMethod(MethodCacheClass, nme.find_)
@@ -1219,7 +1222,7 @@ trait Definitions extends api.StandardDefinitions {
       // Trying to allow for deprecated locations
       sym.isAliasType && isMetaAnnotation(sym.info.typeSymbol)
     )
-    lazy val metaAnnotations: Set[Symbol] = getPackage(TermName("scala.annotation.meta")).info.members filter (_ isSubClass StaticAnnotationClass) toSet
+    lazy val metaAnnotations: Set[Symbol] = getPackage("scala.annotation.meta").info.members filter (_ isSubClass StaticAnnotationClass) toSet
 
     // According to the scala.annotation.meta package object:
     // * By default, annotations on (`val`-, `var`- or plain) constructor parameters

--- a/src/reflect/scala/reflect/internal/Mirrors.scala
+++ b/src/reflect/scala/reflect/internal/Mirrors.scala
@@ -46,19 +46,23 @@ trait Mirrors extends api.Mirrors {
     }
 
     /** Todo: organize similar to mkStatic in scala.reflect.Base */
-    private def getModuleOrClass(path: Name, len: Int): Symbol = {
-      val point = path lastPos('.', len - 1)
+    private def getModuleOrClass(path: Name, len: Int): Symbol =
+      getModuleOrClass(path.toString, len, path.newName(_))
+
+    private def getModuleOrClass(path: String, len: Int, toName: String => Name): Symbol = {
+      val point = path lastIndexOf ('.', len - 1)
       val owner =
-        if (point > 0) getModuleOrClass(path.toTermName, point)
+        if (point > 0) getModuleOrClass(path, point, newTermName(_))
         else RootClass
-      val name = path subName (point + 1, len)
+
+      val name = toName(path.substring(point + 1, len))
       val sym = owner.info member name
-      val result = if (path.isTermName) sym.suchThat(_ hasFlag MODULE) else sym
+      val result = if (name.isTermName) sym.suchThat(_ hasFlag MODULE) else sym
       if (result != NoSymbol) result
       else {
         if (settings.debug) { log(sym.info); log(sym.info.members) }//debug
         thisMirror.missingHook(owner, name) orElse {
-          MissingRequirementError.notFound((if (path.isTermName) "object " else "class ")+path+" in "+thisMirror)
+          MissingRequirementError.notFound((if (name.isTermName) "object " else "class ")+path+" in "+thisMirror)
         }
       }
     }
@@ -69,8 +73,8 @@ trait Mirrors extends api.Mirrors {
      *  Unlike `getModuleOrClass`, this function
      *  loads unqualified names from the root package.
      */
-    private def getModuleOrClass(path: Name): Symbol =
-      getModuleOrClass(path, path.length)
+    private def getModuleOrClass(path: String, toName: String => Name): Symbol =
+      getModuleOrClass(path, path.length, toName)
 
     /** If you're looking for a class, pass a type name.
      *  If a module, a term name.
@@ -78,10 +82,10 @@ trait Mirrors extends api.Mirrors {
      *  Unlike `getModuleOrClass`, this function
      *  loads unqualified names from the empty package.
      */
-    private def staticModuleOrClass(path: Name): Symbol = {
-      val isPackageless = path.pos('.') == path.length
-      if (isPackageless) EmptyPackageClass.info decl path
-      else getModuleOrClass(path)
+    private def staticModuleOrClass(path: String, toName: String => Name): Symbol = {
+      val isPackageless = !path.contains('.')
+      if (isPackageless) EmptyPackageClass.info decl toName(path)
+      else getModuleOrClass(path, toName)
     }
 
     protected def mirrorMissingHook(owner: Symbol, name: Name): Symbol = NoSymbol
@@ -104,20 +108,33 @@ trait Mirrors extends api.Mirrors {
       }
     }
 
+    @deprecated("Use overload that accepts a String.", "2.13.0")
     def getClassByName(fullname: Name): ClassSymbol =
-      ensureClassSymbol(fullname.toString, getModuleOrClass(fullname.toTypeName))
+      ensureClassSymbol(fullname.toString, getModuleOrClass(fullname.toString, fullname.length, newTypeName(_)))
+
+    def getClassByName(fullname: String): ClassSymbol =
+      getRequiredClass(fullname)
+
+    // TODO_NAMES
+    def getRequiredClass(fullname: String, toName: String => Name): ClassSymbol =
+      ensureClassSymbol(fullname, getModuleOrClass(fullname, fullname.length, toName))
 
     def getRequiredClass(fullname: String): ClassSymbol =
-      getClassByName(newTypeNameCached(fullname))
+      ensureClassSymbol(fullname, getModuleOrClass(fullname, fullname.length, newTypeName(_)))
 
     def requiredClass[T: ClassTag] : ClassSymbol =
-      getRequiredClass(erasureName[T])
+      getRequiredClass(erasureName[T], newTypeName(_))
 
     def getClassIfDefined(fullname: String): Symbol =
-      getClassIfDefined(newTypeNameCached(fullname))
+      getClassIfDefined(fullname, newTypeName(_))
 
+    @deprecated("Use overload that accepts a String.", "2.13.0")
     def getClassIfDefined(fullname: Name): Symbol =
       wrapMissing(getClassByName(fullname.toTypeName))
+
+    // TODO_NAMES
+    def getClassIfDefined(fullname: String, toName: String => Name): Symbol =
+      wrapMissing(getRequiredClass(fullname, toName))
 
     /** @inheritdoc
      *
@@ -125,7 +142,7 @@ trait Mirrors extends api.Mirrors {
      *  Compiler might ignore them, but they should be loadable with macros.
      */
     override def staticClass(fullname: String): ClassSymbol =
-      try ensureClassSymbol(fullname, staticModuleOrClass(newTypeNameCached(fullname)))
+      try ensureClassSymbol(fullname, staticModuleOrClass(fullname, newTypeName(_)))
       catch { case mre: MissingRequirementError => throw new ScalaReflectionException(mre.msg) }
 
     /************************ loaders of module symbols ************************/
@@ -136,11 +153,15 @@ trait Mirrors extends api.Mirrors {
         case _                                                     => MissingRequirementError.notFound("object " + fullname)
       }
 
+    @deprecated("Use overload that accepts a String.", "2.13.0")
     def getModuleByName(fullname: Name): ModuleSymbol =
-      ensureModuleSymbol(fullname.toString, getModuleOrClass(fullname.toTermName), allowPackages = true)
+      getModuleByName(fullname.toString)
+
+    def getModuleByName(fullname: String): ModuleSymbol =
+      ensureModuleSymbol(fullname, getModuleOrClass(fullname, fullname.length, newTermName(_)), allowPackages = true)
 
     def getRequiredModule(fullname: String): ModuleSymbol =
-      getModuleByName(newTermNameCached(fullname))
+      getModuleByName(fullname)
 
     // TODO: What syntax do we think should work here? Say you have an object
     // like scala.Predef.  You can't say requiredModule[scala.Predef] since there's
@@ -153,10 +174,11 @@ trait Mirrors extends api.Mirrors {
       getRequiredModule(erasureName[T] stripSuffix "$")
 
     def getModuleIfDefined(fullname: String): Symbol =
-      getModuleIfDefined(newTermNameCached(fullname))
+      wrapMissing(getModuleByName(fullname))
 
+    @deprecated("Use overload that accepts a String.", "2.13.0")
     def getModuleIfDefined(fullname: Name): Symbol =
-      wrapMissing(getModuleByName(fullname.toTermName))
+      getModuleIfDefined(fullname.toString)
 
     /** @inheritdoc
      *
@@ -164,7 +186,7 @@ trait Mirrors extends api.Mirrors {
      *  Compiler might ignore them, but they should be loadable with macros.
      */
     override def staticModule(fullname: String): ModuleSymbol =
-      try ensureModuleSymbol(fullname, staticModuleOrClass(newTermNameCached(fullname)), allowPackages = false)
+      try ensureModuleSymbol(fullname, staticModuleOrClass(fullname, newTermName(_)), allowPackages = false)
       catch { case mre: MissingRequirementError => throw new ScalaReflectionException(mre.msg) }
 
     /************************ loaders of package symbols ************************/
@@ -175,8 +197,11 @@ trait Mirrors extends api.Mirrors {
         case _                                                   => MissingRequirementError.notFound("package " + fullname)
       }
 
+    @deprecated("Use overload that accepts a String.", "2.13.0")
     def getPackage(fullname: TermName): ModuleSymbol =
-      ensurePackageSymbol(fullname.toString, getModuleOrClass(fullname), allowModules = true)
+      getPackage(fullname.toString)
+    def getPackage(fullname: String): ModuleSymbol =
+      ensurePackageSymbol(fullname, getModuleOrClass(fullname, newTermName(_)), allowModules = true)
 
     def getPackageIfDefined(fullname: TermName): Symbol =
       wrapMissing(getPackage(fullname))
@@ -198,7 +223,7 @@ trait Mirrors extends api.Mirrors {
       wrapMissing(getPackageObject(fullname))
 
     override def staticPackage(fullname: String): ModuleSymbol =
-      try ensurePackageSymbol(fullname.toString, getModuleOrClass(newTermNameCached(fullname)), allowModules = false)
+      try ensurePackageSymbol(fullname.toString, getModuleOrClass(fullname, fullname.length, newTermName(_)), allowModules = false)
       catch { case mre: MissingRequirementError => throw new ScalaReflectionException(mre.msg) }
 
     /************************ helpers ************************/

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -52,6 +52,8 @@ trait Names extends api.Names {
   /** Hashtable for finding type names quickly. */
   private val typeHashtable = new Array[TypeName](HASH_SIZE)
 
+  final def allNames(): Iterator[TermName] = termHashtable.iterator.filter(_ ne null).flatMap(n => Iterator.iterate(n)(_.next).takeWhile(_ ne null))
+
   private def hashValue(cs: Array[Char], offset: Int, len: Int): Int = {
     var h = 0
     var i = 0

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -1170,21 +1170,15 @@ trait StdNames {
     protected val stringToTypeName = null
     protected implicit def createNameType(s: String): TypeName = newTypeNameCached(s)
 
-    final val BoxedBoolean: TypeName       = "java.lang.Boolean"
-    final val BoxedByte: TypeName          = "java.lang.Byte"
-    final val BoxedCharacter: TypeName     = "java.lang.Character"
-    final val BoxedDouble: TypeName        = "java.lang.Double"
-    final val BoxedFloat: TypeName         = "java.lang.Float"
-    final val BoxedInteger: TypeName       = "java.lang.Integer"
-    final val BoxedLong: TypeName          = "java.lang.Long"
-    final val BoxedNumber: TypeName        = "java.lang.Number"
-    final val BoxedShort: TypeName         = "java.lang.Short"
-    final val IOOBException: TypeName      = "java.lang.IndexOutOfBoundsException"
-    final val InvTargetException: TypeName = "java.lang.reflect.InvocationTargetException"
-    final val MethodAsObject: TypeName     = "java.lang.reflect.Method"
-    final val NPException: TypeName        = "java.lang.NullPointerException"
-    final val Object: TypeName             = "java.lang.Object"
-    final val Throwable: TypeName          = "java.lang.Throwable"
+    final val BoxedBoolean: String       = "java.lang.Boolean"
+    final val BoxedByte: String          = "java.lang.Byte"
+    final val BoxedCharacter: String     = "java.lang.Character"
+    final val BoxedDouble: String        = "java.lang.Double"
+    final val BoxedFloat: String         = "java.lang.Float"
+    final val BoxedInteger: String       = "java.lang.Integer"
+    final val BoxedLong: String          = "java.lang.Long"
+    final val BoxedNumber: String        = "java.lang.Number"
+    final val BoxedShort: String         = "java.lang.Short"
 
     final val GetCause: TermName         = newTermName("getCause")
     final val GetClass: TermName         = newTermName("getClass")
@@ -1197,7 +1191,7 @@ trait StdNames {
     final val AltMetafactory: TermName      = newTermName("altMetafactory")
     final val Bootstrap: TermName           = newTermName("bootstrap")
 
-    val Boxed = immutable.Map[TypeName, TypeName](
+    val Boxed = immutable.Map[TypeName, String](
       tpnme.Boolean -> BoxedBoolean,
       tpnme.Byte    -> BoxedByte,
       tpnme.Char    -> BoxedCharacter,

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable.ListBuffer
 import util.{ Statistics, shortClassOfInstance, StatisticsStatics }
 import Flags._
 import scala.annotation.tailrec
-import scala.reflect.io.{ AbstractFile, NoAbstractFile }
+import scala.reflect.io.{AbstractFile, NoAbstractFile}
 import Variance._
 
 trait Symbols extends api.Symbols { self: SymbolTable =>
@@ -3030,7 +3030,14 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       loop(info)
     }
 
-    override def exceptions = for (ThrownException(tp) <- annotations) yield tp.typeSymbol
+    override def exceptions = {
+      rawInfo match {
+        case lt: LazyType if isJava =>
+          lt.javaThrownExceptions
+        case _ =>
+          for (ThrownException(tp) <- annotations) yield tp.typeSymbol
+      }
+    }
   }
   implicit val MethodSymbolTag = ClassTag[MethodSymbol](classOf[MethodSymbol])
 

--- a/src/reflect/scala/reflect/io/AbstractFile.scala
+++ b/src/reflect/scala/reflect/io/AbstractFile.scala
@@ -17,6 +17,7 @@ package io
 import java.io.{ IOException, InputStream, OutputStream, BufferedOutputStream, ByteArrayOutputStream }
 import java.io.{ File => JFile }
 import java.net.URL
+import java.nio.ByteBuffer
 
 /**
  * An abstraction over files for use in the reflection/compiler libraries.

--- a/src/reflect/scala/reflect/io/PlainFile.scala
+++ b/src/reflect/scala/reflect/io/PlainFile.scala
@@ -14,6 +14,10 @@ package scala
 package reflect
 package io
 
+import java.nio.ByteBuffer
+import java.nio.file.StandardOpenOption
+import java.util
+
 /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
 class PlainDirectory(givenPath: Directory) extends PlainFile(givenPath) {
   override def isDirectory = true

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -162,7 +162,6 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.SuperType
     this.TypeBounds
     this.CompoundType
-    this.baseClassesCycleMonitor
     this.RefinedType
     this.ClassInfoType
     this.ConstantType

--- a/test/files/jvm/throws-annot-from-java.check
+++ b/test/files/jvm/throws-annot-from-java.check
@@ -8,10 +8,10 @@ scala> :paste
 // Entering paste mode (ctrl-D to finish)
 
 {
-  val clazz = rootMirror.getClassByName(newTermName("test.ThrowsDeclaration_2"));
+  val clazz = rootMirror.getClassByName("test.ThrowsDeclaration_2");
   {
   	val method = clazz.info.member(newTermName("foo"))
-  	val throwsAnn = method.annotations.head
+  	val throwsAnn = method.initialize.annotations.head
   	val atp = throwsAnn.atp
   	println("foo")
   	println("atp.typeParams.isEmpty: " + atp.typeParams.isEmpty)
@@ -21,7 +21,7 @@ scala> :paste
 
   {
   	val method = clazz.info.member(newTermName("bar"))
-  	val throwsAnn = method.annotations.head
+  	val throwsAnn = method.initialize.annotations.head
   	val Literal(const) = throwsAnn.args.head
   	val tp = const.typeValue
   	println("bar")
@@ -37,7 +37,7 @@ atp.typeParams.isEmpty: true
 throws[IllegalStateException](classOf[java.lang.IllegalStateException])
 
 bar
-tp.typeParams.isEmpty: true
-throws[test.PolymorphicException[_]](classOf[test.PolymorphicException])
+tp.typeParams.isEmpty: false
+throws[test.PolymorphicException](classOf[test.PolymorphicException])
 
 scala> :quit

--- a/test/files/jvm/throws-annot-from-java/Test_3.scala
+++ b/test/files/jvm/throws-annot-from-java/Test_3.scala
@@ -4,10 +4,10 @@ object Test extends ReplTest {
 	def code = """:power
 :paste
 {
-  val clazz = rootMirror.getClassByName(newTermName("test.ThrowsDeclaration_2"));
+  val clazz = rootMirror.getClassByName("test.ThrowsDeclaration_2");
   {
   	val method = clazz.info.member(newTermName("foo"))
-  	val throwsAnn = method.annotations.head
+  	val throwsAnn = method.initialize.annotations.head
   	val atp = throwsAnn.atp
   	println("foo")
   	println("atp.typeParams.isEmpty: " + atp.typeParams.isEmpty)
@@ -17,7 +17,7 @@ object Test extends ReplTest {
 
   {
   	val method = clazz.info.member(newTermName("bar"))
-  	val throwsAnn = method.annotations.head
+  	val throwsAnn = method.initialize.annotations.head
   	val Literal(const) = throwsAnn.args.head
   	val tp = const.typeValue
   	println("bar")

--- a/test/files/neg/moduleClassReference.check
+++ b/test/files/neg/moduleClassReference.check
@@ -1,0 +1,4 @@
+moduleClassReference.scala:2: error: not found: value Predef$
+  def foo = Predef$.MODULE$ == Predef
+            ^
+one error found

--- a/test/files/neg/moduleClassReference.scala
+++ b/test/files/neg/moduleClassReference.scala
@@ -1,0 +1,3 @@
+object Test {
+  def foo = Predef$.MODULE$ == Predef
+}

--- a/test/files/neg/t7251.check
+++ b/test/files/neg/t7251.check
@@ -1,4 +1,4 @@
-B_2.scala:5: error: class s.Outer$Triple$ is not a value
+B_2.scala:5: error: object Outer$Triple$ is not a member of package s
     println( s.Outer$Triple$ )
                ^
 one error found

--- a/test/files/run/compiler-asSeenFrom.scala
+++ b/test/files/run/compiler-asSeenFrom.scala
@@ -42,7 +42,7 @@ abstract class CompilerTest extends DirectTest {
   }
 
   class SymsInPackage(pkgName: String) {
-    def pkg     = rootMirror.getPackage(TermName(pkgName))
+    def pkg     = rootMirror.getPackage(pkgName)
     def classes = allMembers(pkg) filter (_.isClass)
     def modules = allMembers(pkg) filter (_.isModule)
     def symbols = classes ++ terms filterNot (_ eq NoSymbol)

--- a/test/files/run/existentials-in-compiler.scala
+++ b/test/files/run/existentials-in-compiler.scala
@@ -74,8 +74,8 @@ package extest {
 }
   """
 
-  override def check(source: String, unit: global.CompilationUnit) {
-    getPackage(TermName("extest")).moduleClass.info.decls.toList.filter(_.isType).map(_.initialize).sortBy(_.name.toString) foreach { clazz =>
+  override def check(source: String, unit: global.CompilationUnit): Unit = {
+    getPackage("extest").moduleClass.info.decls.toList.filter(_.isType).map(_.initialize).sortBy(_.name.toString) foreach { clazz =>
       exitingTyper {
         clazz.info
         println(clazz.defString)

--- a/test/files/run/t7008-scala-defined/Impls_Macros_2.scala
+++ b/test/files/run/t7008-scala-defined/Impls_Macros_2.scala
@@ -5,6 +5,8 @@ object Macros {
   def impl(c: Context) = {
     import c.universe._
     val decls = c.typeOf[ScalaClassWithCheckedExceptions_1[_]].decls.toList
+    decls.foreach(_.info)
+    decls.foreach(_.annotations.foreach(_.tpe))
     val s = decls.sortBy(_.name.toString).map(decl => (s"${decl.name}: ${decl.annotations}")).mkString(scala.compat.Platform.EOL)
     reify(println(c.Expr[String](Literal(Constant(s))).splice))
   }

--- a/test/files/run/t7008/Impls_Macros_2.scala
+++ b/test/files/run/t7008/Impls_Macros_2.scala
@@ -5,6 +5,8 @@ object Macros {
   def impl(c: Context) = {
     import c.universe._
     val decls = c.typeOf[JavaClassWithCheckedExceptions_1[_]].decls.toList
+    decls.foreach(_.info)
+    decls.foreach(_.annotations.foreach(_.tpe))
     val s = decls.sortBy(_.name.toString).map(decl => (s"${decl.name}: ${decl.annotations}")).mkString(scala.compat.Platform.EOL)
     reify(println(c.Expr[String](Literal(Constant(s))).splice))
   }

--- a/test/files/run/t7096.scala
+++ b/test/files/run/t7096.scala
@@ -41,7 +41,7 @@ abstract class CompilerTest extends DirectTest {
   }
 
   class SymsInPackage(pkgName: String) {
-    def pkg     = rootMirror.getPackage(TermName(pkgName))
+    def pkg     = rootMirror.getPackage(pkgName)
     def classes = allMembers(pkg) filter (_.isClass)
     def modules = allMembers(pkg) filter (_.isModule)
     def symbols = classes ++ terms filterNot (_ eq NoSymbol)

--- a/test/files/run/t7455/Test.scala
+++ b/test/files/run/t7455/Test.scala
@@ -23,8 +23,8 @@ object Test extends DirectTest {
       clazz = compiler.rootMirror.staticClass(name)
       constr <- clazz.info.member(termNames.CONSTRUCTOR).alternatives
     } {
-      println(constr.defString)
       fullyInitializeSymbol(constr)
+      println(constr.defString)
     }
   }
 }


### PR DESCRIPTION
The motivation to backport is performance and reducing cyclic errors.

The cyclic errors now occur when linking against libraries generated by the latest version of Protobuf, which makes this more important to make the fix available in 2.12.

Closes scala/bug#11573

------------------------------------------------------------------------

Reuse the buffer for classfile reading

Classfile parsing does re-enter when we're reading package objects
or classfiles for things like `scala/native.class`.

But for the most part the prior refactorings mean that we typically
only parse a single classfile at a time, and as such we can profit
from a one-element cache for the buffer to read this into.

(cherry picked from commit ed8d95eb3092a6fd239820362034b42ad636d85b)

------------------------------------------------------------------------

Eagerly read from the constant pool as a basis for lazy types java class/method

I've used lazy types for field/method/class infos, which is analagous to what we
do in `Unpickler` for scala originated types.  We read all data needed by the
inner class table and the type completers from the pool eagerly, but still be
lazy about interning strings to Names and completion of the field/method
types themselves.

This fixes some long standing spurious cyclic errors:

Manually tested with:

```
$ scalac -cp $(coursier fetch -q -p com.datastax.cassandra:dse-driver:1.0.0) test.scala
test.scala:2: error: illegal cyclic reference involving class Cluster
        new com.datastax.driver.dse.DseCluster.Builder()
                                               ^
one error found

$ /code/scala/build/quick/bin/scalac -cp $(coursier fetch -q -p com.datastax.cassandra:dse-driver:1.0.0) test.scala

$ cat test.scala
class Test {
        new com.datastax.driver.dse.DseCluster.Builder()
}
```
------------------------------------------------------------------------

Avoid using Names for fully qualified class names

There is no good reason for these dotted names to be
Names and stick around in the name table. Let's use
short lived strings instead.

Reduces the name table by 5% in terms of entries and 10%
in terms of characters when compiling src/scalap/**/*.scala

(cherry picked from commit ae18049a6c5f8851e01ac5baebb4b95262df0685)

------------------------------------------------------------------------

Avoid Names for descriptors, generic sigs, and string constants

We can just keep these are short-lived Strings, rather than interning
them into the Name table for the entire lifetime of Global.

(cherry picked from commit 688bf0fcae4ced47fa440def73e3940005c841b1)

------------------------------------------------------------------------

Invalidate symbols for artifact classfiles, refactor classfile parser

No longer run the classfile parser on Scala generated classfiles that
don't have a Scala signature (module classes, inner classes, etc).

Various cleanups in the classfile parser, minimize the work performed
on Scala classfiles. Before, the attributes section was parsed twice:
once to find the ScalaSig attribute, the second time to find the
ScalaSignature in the RuntimeVisibleAnnotations. Now everything happens
in the first iteration.

Also fixes a bug in the backend: classes ending in `$` did not get a
ScalaSignature by mistake. They were filtered out by the name-based
test that is supposed to identify module classes.

(cherry picked from commit 3aea776ca1aa82c9de44cc6806dcdb242f3b40f8)

------------------------------------------------------------------------

Remove unnecessary abstraction

Added in ced7214959, no longer needed since ICodeReader is gone.

(cherry picked from commit e216e0ef0376c550846de974d5b71b39b92120b8)

