### PR TITLE
Improve assertion failure in bytecode diffing tests / Disable flaky test

### DIFF
--- a/test/junit/scala/tools/nsc/FileUtils.scala
+++ b/test/junit/scala/tools/nsc/FileUtils.scala
@@ -3,23 +3,87 @@ package scala.tools.nsc
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 
-import scala.collection.JavaConverters.asScalaIteratorConverter
+import difflib.DiffUtils
+
+import scala.collection.JavaConverters.{asJavaIteratorConverter, asScalaBufferConverter, asScalaIteratorConverter}
 import scala.reflect.io.PlainNioFile
+import scala.tools.nsc.backend.jvm.AsmUtils
 
 object FileUtils {
   def assertDirectorySame(dir1: Path, dir2: Path, dir2Label: String): Unit = {
-    assert(FileUtils.diff(dir1, dir2), s"Difference detected between recompiling $dir2Label Run:\njardiff -r $dir1 $dir2\n")
+    val diffs = FileUtils.diff(dir1, dir2)
+    def diffText = {
+      val builder = new java.lang.StringBuilder
+      var showDetail = 1 // limit printing of diff to first class
+      diffs.foreach { diff =>
+        val showDiff = {
+          try showDetail > 0
+          finally showDetail -= 1
+        }
+        diff.diffString(builder, showDiff)
+      }
+      builder.toString
+    }
+    assert(diffs.isEmpty, s"Difference detected between recompiling $dir2Label Run:\njardiff -r $dir1 $dir2\n$diffText")
   }
-  def diff(dir1: Path, dir2: Path): Boolean = {
-    def allFiles(dir: Path) = Files.walk(dir).iterator().asScala.map(x => (dir.relativize(x), x)).toList.filter(_._2.getFileName.toString.endsWith(".class")).sortBy(_._1.toString)
+  sealed abstract class Diff(path: Path) {
+    def diffString(builder: java.lang.StringBuilder, showDiff: Boolean): Unit = builder.append(toString)
+  }
+  final case class ContentsDiffer(relativePath: Path, path1: Path, path2: Path, left: Array[Byte], right: Array[Byte]) extends Diff(relativePath) {
+    override def toString: String = {
+      s"ContentsDiffer($relativePath)"
+    }
+    override def diffString(builder: java.lang.StringBuilder, showDiff: Boolean): Unit = {
+      builder.append(productPrefix).append("(").append(relativePath).append(")")
+      if (relativePath.getFileName.toString.endsWith(".class")) {
+        if (showDiff) {
+          val class1 = AsmUtils.readClass(path1.toFile.getAbsolutePath)
+          val class2 = AsmUtils.readClass(path2.toFile.getAbsolutePath)
+          val text1 = AsmUtils.textify(class1)
+          val text2 = AsmUtils.textify(class2)
+          builder.append(unifiedDiff(path1, path2, text1, text2))
+        } else {
+          builder.append("[diff suppressed for brevity]")
+        }
+      }
+    }
+  }
 
+  final case class Missing(relativePath: Path, foundPath: Path) extends Diff(relativePath)
+
+  def diff(dir1: Path, dir2: Path): List[Diff] = {
+    val diffs = collection.mutable.ListBuffer[Diff]()
+    def allFiles(dir: Path): Map[Path, Map[String, Path]] = {
+      val classFiles: List[(Path, Path)] = Files.walk(dir).iterator().asScala.map(x => (dir.relativize(x), x)).toList.filter(_._2.getFileName.toString.endsWith(".class")).toList
+      classFiles.groupBy(_._1).mapValues(ps => ps.map { case (_, p) => (p.getFileName.toString, p)}.toMap).toMap
+    }
     val dir1Files = allFiles(dir1)
     val dir2Files = allFiles(dir2)
-    val identical = dir1Files.corresponds(dir2Files) {
-      case ((rel1, file1), (rel2, file2)) =>
-        rel1 == rel2 && java.util.Arrays.equals(Files.readAllBytes(file1), Files.readAllBytes(file2))
+    val allSubDirs = dir1Files.keySet ++ dir2Files.keySet
+    for (subDir <- allSubDirs.toList.sortBy(_.iterator().asScala.map(_.toString).toIterable)) {
+      val files1 = dir1Files.getOrElse(subDir, Map.empty)
+      val files2 = dir2Files.getOrElse(subDir, Map.empty)
+      val allFileNames = files1.keySet ++ files2.keySet
+      for (name <- allFileNames.toList.sorted) {
+        (files1.get(name), files2.get(name)) match {
+          case (Some(file1), Some(file2)) =>
+            val bytes1 = Files.readAllBytes(file1)
+            val bytes2 = Files.readAllBytes(file2)
+            if (!java.util.Arrays.equals(bytes1, bytes2)) {
+              diffs += ContentsDiffer(dir1.relativize(file1), file1, file2, bytes1, bytes2)
+            }
+          case (Some(file1), None) =>
+            val relativePath = file1.relativize(dir1)
+            diffs += Missing(relativePath, file1)
+          case (None, Some(file2)) =>
+            val relativePath = file2.relativize(dir2)
+            diffs += Missing(relativePath, file2)
+          case (None, None) =>
+            throw new IllegalStateException()
+        }
+      }
     }
-    identical
+    diffs.toList
   }
 
   def deleteRecursive(f: Path) = new PlainNioFile(f).delete()
@@ -35,5 +99,20 @@ object FileUtils {
       }
     }
     Files.walkFileTree(src, new CopyVisitor(src, dest))
+  }
+
+  private def unifiedDiff(path1: Path, path2: Path, text1: String, text2: String) = {
+    def lines(s: String) = {
+      val result = new java.util.ArrayList[String]()
+      s.linesIterator.foreach(result.add)
+      result
+    }
+
+    val lines1 = lines(text1)
+    val lines2 = lines(text2)
+    val patch = DiffUtils.diff(lines1, lines2)
+    val value = DiffUtils.generateUnifiedDiff(path1.toString, path2.toString, lines1, patch, 10)
+    val diffToString = value.asScala.mkString("\n")
+    diffToString
   }
 }

--- a/test/junit/scala/tools/nsc/PipelineMainTest.scala
+++ b/test/junit/scala/tools/nsc/PipelineMainTest.scala
@@ -5,7 +5,7 @@ import java.nio.charset.Charset
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 
-import org.junit.{After, Before, Test}
+import org.junit.{After, Before, Ignore, Test}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -32,14 +32,17 @@ class PipelineMainTest {
 
   private def projectsBase = createDir(base, "projects")
 
+  @Ignore("scala/scala-dev#637")
   @Test def pipelineMainBuildsSeparate(): Unit = {
     check(allBuilds.map(_.projects))
   }
 
+  @Ignore("scala/scala-dev#637")
   @Test def pipelineMainBuildsCombined(): Unit = {
     check(List(allBuilds.flatMap(_.projects)))
   }
 
+  @Ignore("scala/scala-dev#637")
   @Test def pipelineMainBuildsJavaAccessor(): Unit = {
     // Tests the special case in Typer:::canSkipRhs to make outline typing descend into method bodies might
     // give rise to super accssors


### PR DESCRIPTION
List "added", "deleted" files, and show ASM bytecode
diff for the first changed file.

Diagnostic related to: scala/scala-dev#637

Sample output:

```

java.lang.AssertionError: assertion failed: Difference detected between recompiling OutlineTypePipeline Run:
jardiff -r /var/folders/b7/xcc2k0ln6ldcv247ffpy2d1w0000gp/T/pipelineBase7354584447902237582/Traditional/classes /var/folders/b7/xcc2k0ln6ldcv247ffpy2d1w0000gp/T/pipelineBase7354584447902237582/OutlineTypePipeline/classes
ContentsDiffer(b5/p2/target/b5/p2/ScalaSub.class)--- /var/folders/b7/xcc2k0ln6ldcv247ffpy2d1w0000gp/T/pipelineBase7354584447902237582/Traditional/classes/b5/p2/target/b5/p2/ScalaSub.class
+++ /var/folders/b7/xcc2k0ln6ldcv247ffpy2d1w0000gp/T/pipelineBase7354584447902237582/OutlineTypePipeline/classes/b5/p2/target/b5/p2/ScalaSub.class
@@ -3,32 +3,20 @@
 public class b5/p2/ScalaSub extends b5/p1/JavaProtectedMethod implements b5/p1/NeedSuperAccessor {

   // compiled from: ScalaSub.scala

   @Lscala/reflect/ScalaSignature;(bytes="\u0006\u0001Y1AAA\u0002\u0001\u0011!)!\u0003\u0001C\u0001'\u0009A1kY1mCN+(M\u0003\u0002\u0005\u000b\u0005\u0011\u0001O\r\u0006\u0002\r\u0005\u0011!-N\u0002\u0001'\r\u0001\u0011b\u0004\u0009\u0003\u00155i\u0011a\u0003\u0006\u0003\u0019\u0015\u0009!\u0001]\u0019\n\u00059Y!a\u0005&bm\u0006\u0004&o\u001c;fGR,G-T3uQ>$\u0007C\u0001\u0006\u0011\u0013\u0009\u00092BA\u0009OK\u0016$7+\u001e9fe\u0006\u001b7-Z:t_J\u000ca\u0001P5oSRtD#\u0001\u000b\u0011\u0005U\u0001Q\"A\u0002")

   ATTRIBUTE ScalaSig : unknown

   ATTRIBUTE ScalaInlineInfo : unknown

-  // access flags 0x1001
-  public synthetic b5$p1$NeedSuperAccessor$$super$foo$JavaProtectedMethod()Ljava/lang/String;
-   L0
-    LINENUMBER 3 L0
-    ALOAD 0
-    INVOKESPECIAL b5/p1/JavaProtectedMethod.foo ()Ljava/lang/String;
-    ARETURN
-   L1
-    LOCALVARIABLE this Lb5/p2/ScalaSub; L0 L1 0
-    MAXSTACK = 1
-    MAXLOCALS = 1
-
   // access flags 0x1
   public foo()Ljava/lang/String;
    L0
     LINENUMBER 3 L0
     ALOAD 0
     INVOKESTATIC b5/p1/NeedSuperAccessor.foo$ (Lb5/p1/NeedSuperAccessor;)Ljava/lang/String; (itf)
     ARETURN
    L1
     LOCALVARIABLE this Lb5/p2/ScalaSub; L0 L1 0
     MAXSTACK = 1

	at scala.Predef$.assert(Predef.scala:223)
	at scala.tools.nsc.FileUtils$.assertDirectorySame(FileUtils.scala:27)
	at scala.tools.nsc.PipelineMainTest.$anonfun$check$3(PipelineMainTest.scala:76)
	at scala.tools.nsc.PipelineMainTest.$anonfun$check$3$adapted(PipelineMainTest.scala:71)
	at scala.collection.immutable.List.foreach(List.scala:392)
	at scala.tools.nsc.PipelineMainTest.check(PipelineMainTest.scala:71)
	at scala.tools.nsc.PipelineMainTest.pipelineMainBuildsSeparate(PipelineMainTest.scala:36)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)

```