### PR TITLE
[nomerge] add sbt-whitesource

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -34,3 +34,5 @@ concurrentRestrictions in Global := Seq(
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
+
+addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.16")


### PR DESCRIPTION
we use this at Lightbend to help audit the licenses of all our dependencies, on all of our projects, including Scala

once this is merged, I will submit a separate 2.13.x PR