### PR TITLE
Fix race condition in pipeline builds

### DIFF
--- a/test/junit/scala/tools/nsc/PipelineMainTest.scala
+++ b/test/junit/scala/tools/nsc/PipelineMainTest.scala
@@ -5,7 +5,7 @@ import java.nio.charset.Charset
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 
-import org.junit.{After, Before, Ignore, Test}
+import org.junit.{After, Before, Test}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -32,17 +32,14 @@ class PipelineMainTest {
 
   private def projectsBase = createDir(base, "projects")
 
-  @Ignore("scala/scala-dev#637")
   @Test def pipelineMainBuildsSeparate(): Unit = {
     check(allBuilds.map(_.projects))
   }
 
-  @Ignore("scala/scala-dev#637")
   @Test def pipelineMainBuildsCombined(): Unit = {
     check(List(allBuilds.flatMap(_.projects)))
   }
 
-  @Ignore("scala/scala-dev#637")
   @Test def pipelineMainBuildsJavaAccessor(): Unit = {
     // Tests the special case in Typer:::canSkipRhs to make outline typing descend into method bodies might
     // give rise to super accssors


### PR DESCRIPTION
Javac must await completion of javac for internal projects on
its classpath. I hadn't noticed this problem before because
javac is so fast!

This commit also fixes the return status of `PipelineMain.process`
based on whether the reporter has errors or not. I also close
Javac's filemanager explicitly, which is good practice but not
actually related to this bug.

Fixes scala/scala-dev#637