### PR TITLE
Add a test for library/reflect jar sizes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -889,6 +889,7 @@ lazy val root: Project = (project in file("."))
     },
 
     testJDeps := TestJDeps.testJDepsImpl.value,
+    testJarSize := TestJarSize.testJarSizeImpl.value,
 
     testAll := {
       val results = ScriptCommands.sequence[(Result[Unit], String)](List(
@@ -905,6 +906,7 @@ lazy val root: Project = (project in file("."))
         (mimaReportBinaryIssues in library).result map (_ -> "library/mimaReportBinaryIssues"),
         (mimaReportBinaryIssues in reflect).result map (_ -> "reflect/mimaReportBinaryIssues"),
         testJDeps.result map (_ -> "testJDeps"),
+        testJarSize.result map (_ -> "testJarSize"),
         (compile in Compile in bench).map(_ => ()).result map (_ -> "bench/compile"),
         Def.task(()).dependsOn( // Run these in parallel:
           doc in Compile in library,
@@ -1026,6 +1028,7 @@ lazy val mkPack = taskKey[File]("Generate a full build, including scripts, in bu
 lazy val testAll = taskKey[Unit]("Run all test tasks sequentially")
 
 val testJDeps = taskKey[Unit]("Run jdeps to check dependencies")
+val testJarSize = taskKey[Unit]("Test that jars have the expected size")
 
 // Defining these settings is somewhat redundant as we also redefine settings that depend on them.
 // However, IntelliJ's project import works better when these are set correctly.

--- a/project/TestJarSize.scala
+++ b/project/TestJarSize.scala
@@ -1,0 +1,34 @@
+package scala.build
+
+import sbt._, Keys._
+
+object TestJarSize {
+  final private case class JarSize(currentBytes: Long, errorThreshold: Double, warnThreshold: Double)
+
+  private val libraryJarSize = JarSize(5525657L, 1.03, 1.015)
+  private val reflectJarSize = JarSize(3531794L, 1.03, 1.015)
+
+  val testJarSizeImpl: Def.Initialize[Task[Unit]] = Def.task {
+    testJarSize1("library", libraryJarSize).value
+    testJarSize1("reflect", reflectJarSize).value
+  }
+
+  private def testJarSize1(projectId: String, jarSize: JarSize): Def.Initialize[Task[Unit]] = Def.task {
+    import jarSize._
+    val log = state.value.log
+    val jar = (packageBin in Compile in LocalProject(projectId)).value
+    val actualBytes = jar.length()
+    if (actualBytes > (currentBytes * errorThreshold)) {
+      fail(s"The $projectId jar is too big: $actualBytes bytes.")
+    } else if (actualBytes > (currentBytes * warnThreshold)) {
+      val percent = (actualBytes - currentBytes).toDouble / currentBytes.toDouble
+      log.warn(s"The $projectId jar is getting too big: $actualBytes bytes or $percent% larger.")
+    }
+  }
+
+  private def fail(message: String): Nothing = {
+    val fail = new MessageOnlyException(message)
+    fail.setStackTrace(new Array[StackTraceElement](0))
+    throw fail
+  }
+}


### PR DESCRIPTION
Failures look like this:

    > testJarSize
    [info] Packaging /d/scala/build/pack/lib/scala-library.jar ...
    [info] Packaging /d/scala/build/pack/lib/scala-reflect.jar ...
    [info] Done packaging.
    [info] Done packaging.
    [error] The library jar is too big: 5525657 bytes.
    [error] (testJarSize) The library jar is too big: 5525657 bytes.
    [error] Total time: 3 s, completed 26-Jun-2019 07:52:30

Warnings look like this:

    > testJarSize
    [info] Packaging /d/scala/build/pack/lib/scala-library.jar ...
    [info] Packaging /d/scala/build/pack/lib/scala-reflect.jar ...
    [info] Done packaging.
    [info] Done packaging.
    [warn] The library jar is getting too big: 5525657 bytes or 0.022740644234703674% larger.
    [success] Total time: 1 s, completed 26-Jun-2019 08:07:46

Successes look like this:

    > testJarSize
    [info] Packaging /d/scala/build/pack/lib/scala-library.jar ...
    [info] Packaging /d/scala/build/pack/lib/scala-reflect.jar ...
    [info] Done packaging.
    [info] Done packaging.
    [success] Total time: 3 s, completed 26-Jun-2019 08:05:30

Fixes scala/bug#11578

I can backport to the 2.12.x (and sbt 0.13.x) branch.