### PR TITLE
Improve some compiler debugging output

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/SymbolTrackers.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolTrackers.scala
@@ -188,7 +188,7 @@ trait SymbolTrackers {
             val xs = if (back.isEmpty) front else front :+ "..."
             xs mkString " -> "
         }
-        val treeStrings = symMap(sym).map(t => s"${t.shortClass}%10s: $t")
+        val treeStrings = symMap(sym).map(t => f"${t.shortClass}%10s: $t")
 
         ownerString :: treeStrings mkString "\n"
       }


### PR DESCRIPTION

Debug output formatting lacks the format interpolator. That probably calls for a lint rule.

```
<      Apply: x1.isInstanceOf[ok.C]()
<     Select: x1.isInstanceOf
<  TypeApply: x1.isInstanceOf[ok.C]
---
> Apply%10s: x1.isInstanceOf[ok.C]()
> Select%10s: x1.isInstanceOf
> TypeApply%10s: x1.isInstanceOf[ok.C]
```
Also note diff in ordering of synthetics compared to 2.13.0, not sure what this means but order is reversed, perhaps due to forcing toString:
```
  object C (<synthetic>)
  object C (<synthetic>)
      constructor C
      method apply (case <synthetic>)
          value c
      method toString (final override <synthetic>)
      method unapply (case <synthetic>)
          value x$0 (<synthetic>)
      method writeReplace (private <synthetic>)
      value <local C>
```