### PR TITLE
Avoid redundant field in TermName, reducing size 40->32 bytes

### DIFF
--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -190,7 +190,7 @@ trait Names extends api.Names {
    *  or Strings as Names.  Give names the key functions the absence of which
    *  make people want Strings all the time.
    */
-  sealed abstract class Name(protected val index: Int, protected val len: Int, cachedString: String) extends NameApi with CharSequence {
+  sealed abstract class Name(protected val index: Int, protected val len: Int, protected val cachedString: String) extends NameApi with CharSequence {
     type ThisNameType >: Null <: Name
     protected[this] def thisName: ThisNameType
 


### PR DESCRIPTION
Before:

```
➜  scala git:(topic/name-waste) ✗ java -Djdk.attach.allowAttachSelf=true -cp $(coursier fetch -q -p 'org.openjdk.jol:jol-cli:0.9') org.openjdk.jol.Main internals -cp $(scala-classpath $(scala-ref-version 2.13.x)) 'scala.reflect.internal.Names$TermName'

Failed to find matching constructor, falling back to class-only introspection.

scala.reflect.internal.Names$TermName object internals:
 OFFSET  SIZE                                    TYPE DESCRIPTION                               VALUE
      0    12                                         (object header)                           N/A
     12     4                 scala.reflect.api.Names NameApi.$outer                            N/A
     16     4                                     int Name.index                                N/A
     20     4                                     int Name.len                                  N/A
     24     4                        java.lang.String Name.cachedString                         N/A
     28     4   scala.reflect.internal.Names.TermName TermName.next                             N/A
     32     4                        java.lang.String TermName.cachedString                     N/A
     36     4                                         (loss due to the next object alignment)
Instance size: 40 bytes
Space losses: 0 bytes internal + 4 bytes external = 4 bytes total
```

After:

```
➜  scala git:(topic/name-waste) ✗ java -Djdk.attach.allowAttachSelf=true -cp $(coursier fetch -q -p 'org.openjdk.jol:jol-cli:0.9') org.openjdk.jol.Main internals -cp build/quick/classes/reflect 'scala.reflect.internal.Names$TermName'

Failed to find matching constructor, falling back to class-only introspection.

scala.reflect.internal.Names$TermName object internals:
 OFFSET  SIZE                                    TYPE DESCRIPTION                               VALUE
      0    12                                         (object header)                           N/A
     12     4                 scala.reflect.api.Names NameApi.$outer                            N/A
     16     4                                     int Name.index                                N/A
     20     4                                     int Name.len                                  N/A
     24     4                        java.lang.String Name.cachedString                         N/A
     28     4   scala.reflect.internal.Names.TermName TermName.next                             N/A
Instance size: 32 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```

Exposing `Name.cachedString` as a protected val makes it eligible for
the parameter aliasing layout optimization.