### PR TITLE
Show MiMa logs at the end of testAll in case of MiMa failures

### DIFF
--- a/project/SavedLogs.scala
+++ b/project/SavedLogs.scala
@@ -1,0 +1,62 @@
+package scala.build
+
+import java.io.StringWriter
+
+import scala.collection.mutable
+import sbt._
+import Keys._
+import org.apache.logging.log4j.core
+import org.apache.logging.log4j.core.appender.{AbstractAppender, WriterAppender}
+import sbt.internal.util.StringEvent
+
+/** Save MiMa logs so they don't get lost in lots of debug output */
+object SavedLogs {
+  val savedLogs = new mutable.HashMap[String, mutable.ArrayBuffer[StringEvent]]
+
+  val showSavedLogs = TaskKey[Unit]("showSavedLogs", "Print all saved logs to the console")
+  val clearSavedLogs = TaskKey[Unit]("clearSavedLogs", "Clear all saved logs")
+
+  def showSavedLogsImpl(println: String => Unit): Unit = synchronized {
+    savedLogs.foreach {
+      case (k, buf) if buf.nonEmpty =>
+        println(s"Saved log of $k:")
+        buf.foreach { e => println(e.message) }
+      case _ =>
+    }
+  }
+
+  def clearSavedLogsImpl(): Unit = synchronized { savedLogs.clear() }
+
+  class MyAppender(val name: String) extends AbstractAppender(name, null, null, true) {
+    start()
+    val buf = new mutable.ArrayBuffer[StringEvent]
+    override def append(logEvent: core.LogEvent): Unit = {
+      logEvent.getMessage.getParameters match {
+        case Array(s: StringEvent) => buf.append(s)
+        case _ =>
+      }
+    }
+  }
+
+  lazy val settings = Seq[Setting[_]](
+    (Global / extraLoggers) := {
+      val previous = (Global / extraLoggers).value
+      (key: ScopedKey[_]) => {
+        key.scope match {
+          case Scope(Select(ProjectRef(_, p)), _, Select(t), _) if t.label == "mimaReportBinaryIssues" =>
+            val a = new MyAppender(s"$p/${t.label}")
+            SavedLogs.synchronized { savedLogs.put(a.name, a.buf) }
+            a +: previous(key)
+          case _ => previous(key)
+        }
+      }
+    },
+
+    showSavedLogs := {
+      val log = streams.value.log
+      showSavedLogsImpl(s => log.info(s))
+    },
+
+    clearSavedLogs := { clearSavedLogsImpl() }
+  )
+}


### PR DESCRIPTION
I tried three basic ways of getting the required log data:
- Look at sbt's streams files from a shell script: This requires
  knowledge about sbt's on-disk logs (which may change), plus doing
  everything in sbt seems nicer.
- Write a command similar to `last` that reads the log files. This
  requires the use of internal sbt classes to locate the right log.
  Both solutions have the disadvantage that the log files contain the
  complete raw log text, including all debug output and potentially
  ANSI color sequences, which makes filtering awkward.
- Add an additional logger to only the desired tasks, which captures
  the log events (without debug logging and in an easy to use form) in
  memory. This is the current implementation. It exposes the logs via
  the new `showSavedLogs` and `clearSavedLogs` tasks and can be easily
  adapted to capture the logs of other tasks (currently only MiMa logs
  are saved). It is also easy to integrate into `testAll`.
  Unfortunately, it still requires the use of internal sbt code to
  access the log events.