### PR TITLE
[scaladoc] Do not toggle full content if symbol have no full content.

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.js
@@ -219,6 +219,9 @@ $(document).ready(function() {
 
     function commentToggleFct(element){
         $("#template li.selected").removeClass("selected");
+        if (element.is("[fullcomment=no]")) {
+            return;
+        }
         element.toggleClass("open");
         var signature = element.find(".modifier_kind")
         var shortComment = element.find(".shortcomment");


### PR DESCRIPTION
Closes https://github.com/scala/bug/issues/11586

A member without full comment does not disapper when it is opened via permalink like `com/example/Main.html#foo(x:Int):Int`.

![fullcomment-single](https://user-images.githubusercontent.com/127635/60262285-c54e0400-9918-11e9-91f0-44e6833c1246.gif)
