### PR TITLE
Add protected and private visibility filters to scaladoc

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -226,6 +226,11 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_))
     ""
   )
 
+  val visibilityPrivate = BooleanSetting (
+    "-private",
+    "Show all types and members. Unless specified, show only public and protected types and members."
+  )
+
   // For improved help output.
   def scaladocSpecific = Set[Settings#Setting](
     docformat, doctitle, docfooter, docversion, docUncompilable, docsourceurl, docgenerator, docRootContent,

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -290,7 +290,12 @@ trait EntityPage extends HtmlPage {
           Div(id="visbl", elems=
               Span(`class`="filtertype", elems=Txt("Visibility")) ::
               Ol(elems=
-                Li(`class`="public in", elems= Span(elems=Txt("Public"))) :: Li(`class`="all out", elems= Span(elems=Txt("All"))))
+                List(
+                  Li(`class`="public in", elems=Span(elems=Txt("Public"))),
+                  Li(`class`="protected out", elems=Span(elems=Txt("Protected"))),
+                  Li(`class`="private out", elems=Span(elems=Txt("Private"))),
+                  Li(`class`="all out", elems=Span(elems=Txt("All"))))
+                )
           ))
         )
       ))
@@ -365,7 +370,8 @@ trait EntityPage extends HtmlPage {
     }
 
     val memberComment = memberToCommentHtml(mbr, inTpl, isSelf = false)
-    Li(name= mbr.definitionName, visbl= if (mbr.visibility.isProtected) "prt" else "pub",
+    Li(name= mbr.definitionName,
+      visbl=if (mbr.visibility.isPublic) "pub" else if (mbr.visibility.isProtected) "prt" else "prv",
       `class`= s"indented$indentation " + (if (mbr eq inTpl) "current" else ""),
       `data-isabs`= mbr.isAbstract.toString,
       fullComment= if(!memberComment.exists(_.tagName == "div")) "no" else "yes",

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -292,9 +292,8 @@ trait EntityPage extends HtmlPage {
               Ol(elems=
                 List(
                   Li(`class`="public in", elems=Span(elems=Txt("Public"))),
-                  Li(`class`="protected out", elems=Span(elems=Txt("Protected"))),
-                  Li(`class`="private out", elems=Span(elems=Txt("Private"))))
-                )
+                  Li(`class`="protected out", elems=Span(elems=Txt("Protected")))
+                ) ++ List(Li(`class`="private out", elems=Span(elems=Txt("Private")))).filter(_ => universe.settings.visibilityPrivate))
           ))
         )
       ))

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -293,8 +293,7 @@ trait EntityPage extends HtmlPage {
                 List(
                   Li(`class`="public in", elems=Span(elems=Txt("Public"))),
                   Li(`class`="protected out", elems=Span(elems=Txt("Protected"))),
-                  Li(`class`="private out", elems=Span(elems=Txt("Private"))),
-                  Li(`class`="all out", elems=Span(elems=Txt("All"))))
+                  Li(`class`="private out", elems=Span(elems=Txt("Private"))))
                 )
           ))
         )

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.js
@@ -11,10 +11,9 @@ $(document).ready(function() {
 
     var controls = {
         visibility: {
-            publicOnly: $("#visbl").find("> ol > li.public"),
-            protectedOnly: $("#visbl").find("> ol > li.protected"),
-            privateOnly: $("#visbl").find("> ol > li.private"),
-            all: $("#visbl").find("> ol > li.all")
+            publicFilter: $("#visbl").find("> ol > li.public"),
+            protectedFilter: $("#visbl").find("> ol > li.protected"),
+            privateFilter: $("#visbl").find("> ol > li.private")
         }
     };
 
@@ -23,24 +22,14 @@ $(document).ready(function() {
         return str.replace(/([;&,\.\+\*\~':"\!\^#$%@\[\]\(\)=<>\|])/g, '\\$1');
     }
 
-    function toggleVisibilityFilter(ctrlToEnable, visibilities) {
-        if (ctrlToEnable.hasClass("out")) {
-            ctrlToEnable.removeClass("out").addClass("in");
-            for (var key in visibilities) if (visibilities.hasOwnProperty(key)) {
-                var ctrToDisable = visibilities[key];
-                if (ctrlToEnable !== ctrToDisable) {
-                    ctrToDisable.removeClass("in").addClass("out");
-                }
-            }
-            filter();
-        }
+    function toggleVisibilityFilter() {
+        $(this).toggleClass("in").toggleClass("out");
+        filter();
     }
 
-    for (var key in controls.visibility) if (controls.visibility.hasOwnProperty(key)) (function(visControl){
-        visControl.on("click", function () {
-            toggleVisibilityFilter(visControl, controls.visibility);
-        });
-    })(controls.visibility[key]);
+    controls.visibility.publicFilter.on("click", toggleVisibilityFilter);
+    controls.visibility.protectedFilter.on("click", toggleVisibilityFilter);
+    controls.visibility.privateFilter.on("click", toggleVisibilityFilter);
 
     function exposeMember(jqElem) {
         var jqElemParent = jqElem.parent(),
@@ -49,7 +38,7 @@ $(document).ready(function() {
 
         // switch visibility filter if necessary
         if (jqElemParent.attr("visbl") == "prt") {
-            toggleVisibilityFilter(controls.visibility.all, controls.visibility);
+            controls.visibility.privateFilter.removeClass("out").addClass("in");
         }
 
         // toggle appropriate ancestor filter buttons
@@ -441,10 +430,9 @@ function filter() {
     query = query.replace(/[-[\]{}()*+?.,\\^$|#]/g, "\\$&").replace(/\s+/g, "|");
     var queryRegExp = new RegExp(query, "i");
 
-    var allMembersShown = $("#visbl > ol > li.all").hasClass("in");
-    var publicMembersShown = allMembersShown || $("#visbl > ol > li.public").hasClass("in");
-    var protectedMembersShown = allMembersShown || $("#visbl > ol > li.protected").hasClass("in");
-    var privateMembersShown = allMembersShown || $("#visbl > ol > li.private").hasClass("in");
+    var publicMembersShown = $("#visbl > ol > li.public").hasClass("in");
+    var protectedMembersShown = $("#visbl > ol > li.protected").hasClass("in");
+    var privateMembersShown = $("#visbl > ol > li.private").hasClass("in");
 
     var orderingAlphabetic = $("#order > ol > li.alpha").hasClass("in");
     var orderingInheritance = $("#order > ol > li.inherit").hasClass("in");

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -1020,7 +1020,8 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
   def localShouldDocument(aSym: Symbol): Boolean = {
     // For `private[X]`, isPrivate is false (while for protected[X], isProtected is true)
     def isPrivate = aSym.isPrivate || !aSym.isProtected && aSym.privateWithin != NoSymbol
-    !aSym.isSynthetic && !(isPrivate && aSym.isTopLevel)
+    // for private, only document if enabled in settings and not top-level
+    !aSym.isSynthetic && (!isPrivate || settings.visibilityPrivate.value && !aSym.isTopLevel)
   }
 
   // the classes that are excluded from the index should also be excluded from the diagrams

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -1018,7 +1018,9 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     aSym.info.members.exists(s => localShouldDocument(s) && (!s.isConstructor || s.owner == aSym))
 
   def localShouldDocument(aSym: Symbol): Boolean =
-    !aSym.isPrivate && (aSym.isProtected || aSym.privateWithin == NoSymbol) && !aSym.isSynthetic
+    ((aSym.isPrivate && !aSym.isTopLevel) ||
+     (!aSym.isPrivate && (aSym.isProtected || aSym.privateWithin == NoSymbol))) &&
+    !aSym.isSynthetic
 
   // the classes that are excluded from the index should also be excluded from the diagrams
   def classExcluded(clazz: TemplateEntity): Boolean = settings.hardcoded.isExcluded(clazz.qualifiedName)

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -1017,10 +1017,11 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     aSym.isModule && aSym.isJavaDefined &&
     aSym.info.members.exists(s => localShouldDocument(s) && (!s.isConstructor || s.owner == aSym))
 
-  def localShouldDocument(aSym: Symbol): Boolean =
-    ((aSym.isPrivate && !aSym.isTopLevel) ||
-     (!aSym.isPrivate && (aSym.isProtected || aSym.privateWithin == NoSymbol))) &&
-    !aSym.isSynthetic
+  def localShouldDocument(aSym: Symbol): Boolean = {
+    // For `private[X]`, isPrivate is false (while for protected[X], isProtected is true)
+    def isPrivate = aSym.isPrivate || !aSym.isProtected && aSym.privateWithin != NoSymbol
+    !aSym.isSynthetic && !(isPrivate && aSym.isTopLevel)
+  }
 
   // the classes that are excluded from the index should also be excluded from the diagrams
   def classExcluded(clazz: TemplateEntity): Boolean = settings.hardcoded.isExcluded(clazz.qualifiedName)

--- a/src/scaladoc/scala/tools/nsc/doc/model/Visibility.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/Visibility.scala
@@ -18,10 +18,13 @@ package model
 sealed trait Visibility {
   def isProtected: Boolean = false
   def isPublic: Boolean = false
+  def isPrivate: Boolean = false
 }
 
 /** The visibility of `private[this]` members. */
-case class PrivateInInstance() extends Visibility
+case class PrivateInInstance() extends Visibility {
+  override def isPrivate = true
+}
 
 /** The visibility of `protected[this]` members. */
 case class ProtectedInInstance() extends Visibility {
@@ -30,7 +33,9 @@ case class ProtectedInInstance() extends Visibility {
 
 /** The visibility of `private[owner]` members. An unqualified private members
   * is encoded with `owner` equal to the members's `inTemplate`. */
-case class PrivateInTemplate(owner: TemplateEntity) extends Visibility
+case class PrivateInTemplate(owner: TemplateEntity) extends Visibility {
+  override def isPrivate = true
+}
 
 /** The visibility of `protected[owner]` members. An unqualified protected
   * members is encoded with `owner` equal to the members's `inTemplate`.

--- a/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
+++ b/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
@@ -602,4 +602,12 @@ object HtmlFactoryTest extends Properties("HtmlFactory") {
   property("scala/bug#9599 Multiple @todo formatted with comma on separate line") = {
     checkTemplate("t9599.scala", "X.html") { (_, s) => s.contains("""<span class="cmt"><p>todo1</p></span><span class="cmt"><p>todo2</p></span><span class="cmt"><p>todo3</p></span>""") }
   }
+
+  property("scala/bug#10999 Private and Protected method should also be documented") = {
+    checkTemplate("t10999.scala", "T10999.html"){(_, s) =>
+      s.contains("protectedMethod:Boolean") &&
+      s.contains("privateMethod:String")
+    }
+  }
+
 }

--- a/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
+++ b/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
@@ -602,12 +602,4 @@ object HtmlFactoryTest extends Properties("HtmlFactory") {
   property("scala/bug#9599 Multiple @todo formatted with comma on separate line") = {
     checkTemplate("t9599.scala", "X.html") { (_, s) => s.contains("""<span class="cmt"><p>todo1</p></span><span class="cmt"><p>todo2</p></span><span class="cmt"><p>todo3</p></span>""") }
   }
-
-  property("scala/bug#10999 Private and Protected method should also be documented") = {
-    checkTemplate("t10999.scala", "T10999.html"){(_, s) =>
-      s.contains("protectedMethod:Boolean") &&
-      s.contains("privateMethod:String")
-    }
-  }
-
 }

--- a/test/scaladoc/resources/t10999.scala
+++ b/test/scaladoc/resources/t10999.scala
@@ -1,0 +1,5 @@
+class T10999 {
+  def publicMethod: Int = 1
+  protected def protectedMethod: Boolean = true
+  private def privateMethod: String = ""
+}

--- a/test/scaladoc/resources/t10999.scala
+++ b/test/scaladoc/resources/t10999.scala
@@ -1,18 +1,16 @@
-package scaladoc.resources
-
 class t10999 {
-	/**
-		* I am public method !
-		*/
-	def publicMethod: Int = 1
+  /**
+    * I am public method !
+    */
+  def publicMethod: Int = 1
 
-	/**
-		* I am protected method !
-		*/
-	protected def protectedMethod: Boolean = true
+  /**
+    * I am protected method !
+    */
+  protected def protectedMethod: Boolean = true
 
-	/**
-		* I am private method !
-		*/
-	private def privateMethod: String = ""
+  /**
+    * I am private method !
+    */
+  private def privateMethod: String = ""
 }

--- a/test/scaladoc/resources/t10999.scala
+++ b/test/scaladoc/resources/t10999.scala
@@ -1,5 +1,18 @@
-class T10999 {
-  def publicMethod: Int = 1
-  protected def protectedMethod: Boolean = true
-  private def privateMethod: String = ""
+package scaladoc.resources
+
+class t10999 {
+	/**
+		* I am public method !
+		*/
+	def publicMethod: Int = 1
+
+	/**
+		* I am protected method !
+		*/
+	protected def protectedMethod: Boolean = true
+
+	/**
+		* I am private method !
+		*/
+	private def privateMethod: String = ""
 }


### PR DESCRIPTION
Closes https://github.com/scala/bug/issues/10999

This PR adds `Protected` and `Private` visiblity filters.
`Private` filter is available only if `scaladoc -private` used, so user can omit private members to reduce scaladoc size. 
Existing `All` is removed since it is no longer required.
![visibility-filters-toggle](https://user-images.githubusercontent.com/127635/60260079-a6993e80-9913-11e9-86f8-550733165b66.gif)





