### PR TITLE
Add many type annotations to public members

### DIFF
--- a/src/library/scala/Console.scala
+++ b/src/library/scala/Console.scala
@@ -136,15 +136,15 @@ object Console extends AnsiColor {
   /** The default output, can be overridden by `withOut`
    *  @group io-default
    */
-  def out = outVar.value
+  def out: PrintStream = outVar.value
   /** The default error, can be overridden by `withErr`
    *  @group io-default
    */
-  def err = errVar.value
+  def err: PrintStream = errVar.value
   /** The default input, can be overridden by `withIn`
    *  @group io-default
    */
-  def in = inVar.value
+  def in: BufferedReader = inVar.value
 
   /** Sets the default output stream for the duration
    *  of execution of one thunk.

--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -96,7 +96,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
 
   /** The name of this enumeration.
    */
-  override def toString =
+  override def toString: String =
     ((getClass.getName stripSuffix MODULE_SUFFIX_STRING split '.').last split
        Regex.quote(NAME_JOIN_STRING)).last
 
@@ -231,14 +231,14 @@ abstract class Enumeration (initial: Int) extends Serializable {
       if (this.id < that.id) -1
       else if (this.id == that.id) 0
       else 1
-    override def equals(other: Any) = other match {
+    override def equals(other: Any): Boolean = other match {
       case that: Enumeration#Value  => (outerEnum eq that.outerEnum) && (id == that.id)
       case _                        => false
     }
     override def hashCode: Int = id.##
 
     /** Create a ValueSet which contains this value and another one */
-    def + (v: Value) = ValueSet(this, v)
+    def + (v: Value): ValueSet = ValueSet(this, v)
   }
 
   /** A class implementing the [[scala.Enumeration.Value]] type. This class
@@ -257,8 +257,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
     nextId = i + 1
     if (nextId > topId) topId = nextId
     if (i < bottomId) bottomId = i
-    def id = i
-    override def toString() =
+    def id: Int = i
+    override def toString(): String =
       if (name != null) name
       else try thisenum.nameOf(i)
       catch { case _: NoSuchElementException => "<Invalid enum: no field for #" + i + ">" }
@@ -293,20 +293,20 @@ abstract class Enumeration (initial: Int) extends Serializable {
     def rangeImpl(from: Option[Value], until: Option[Value]): ValueSet =
       new ValueSet(nnIds.rangeImpl(from.map(_.id - bottomId), until.map(_.id - bottomId)))
 
-    override def empty = ValueSet.empty
+    override def empty: ValueSet = ValueSet.empty
     override def knownSize: Int = nnIds.size
     override def isEmpty: Boolean = nnIds.isEmpty
-    def contains(v: Value) = nnIds contains (v.id - bottomId)
-    def incl (value: Value) = new ValueSet(nnIds + (value.id - bottomId))
-    def excl (value: Value) = new ValueSet(nnIds - (value.id - bottomId))
-    def iterator = nnIds.iterator map (id => thisenum.apply(bottomId + id))
-    override def iteratorFrom(start: Value) = nnIds iteratorFrom start.id  map (id => thisenum.apply(bottomId + id))
-    override def className = s"$thisenum.ValueSet"
+    def contains(v: Value): Boolean = nnIds contains (v.id - bottomId)
+    def incl (value: Value): ValueSet = new ValueSet(nnIds + (value.id - bottomId))
+    def excl (value: Value): ValueSet = new ValueSet(nnIds - (value.id - bottomId))
+    def iterator: Iterator[Value] = nnIds.iterator map (id => thisenum.apply(bottomId + id))
+    override def iteratorFrom(start: Value): Iterator[Value] = nnIds iteratorFrom start.id  map (id => thisenum.apply(bottomId + id))
+    override def className: String = s"$thisenum.ValueSet"
     /** Creates a bit mask for the zero-adjusted ids in this set as a
      *  new array of longs */
     def toBitMask: Array[Long] = nnIds.toBitMask
 
-    override protected def fromSpecific(coll: IterableOnce[Value]) = ValueSet.fromSpecific(coll)
+    override protected def fromSpecific(coll: IterableOnce[Value]): ValueSet = ValueSet.fromSpecific(coll)
     override protected def newSpecificBuilder = ValueSet.newBuilder
 
     def map(f: Value => Value): ValueSet = fromSpecific(new View.Map(toIterable, f))
@@ -330,7 +330,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
     private final val zipOrdMsg = "No implicit Ordering[${B}] found to build a SortedSet[(Value, ${B})]. You may want to upcast to a Set[Value] first by calling `unsorted`."
 
     /** The empty value set */
-    val empty = new ValueSet(immutable.BitSet.empty)
+    val empty: ValueSet = new ValueSet(immutable.BitSet.empty)
     /** A value set containing all the values for the zero-adjusted ids
      *  corresponding to the bits in an array */
     def fromBitMask(elems: Array[Long]): ValueSet = new ValueSet(immutable.BitSet.fromBitMask(elems))

--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -79,7 +79,7 @@ trait PartialFunction[-A, +B] extends (A => B) { self =>
    *           }
    *           }}}
    */
-  def elementWise = new ElementWiseExtractor(this)
+  def elementWise: ElementWiseExtractor[A, B] = new ElementWiseExtractor[A, B](this)
 
   /** Checks if a value is contained in the function's domain.
    *

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -126,7 +126,7 @@ case class StringContext(parts: String*) {
      *  Here, we use the `TimeSplitter` regex within the `s` matcher, further splitting the
      *  matched string "10.50" into its constituent parts
      */
-    def unapplySeq(s: String) = glob(parts, s)
+    def unapplySeq(s: String): Option[Seq[String]] = glob(parts, s)
   }
   /** The raw string interpolator.
    *

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -103,7 +103,7 @@ final class IterableOnceExtensionMethods[A](private val it: IterableOnce[A]) ext
   def maxBy[B](f: A => B)(implicit cmp: Ordering[B]): A = it.iterator.maxBy(f)
 
   @deprecated("Use .iterator.reduceLeft(...) instead", "2.13.0")
-  def reduceLeft(f: (A, A) => A) = it.iterator.reduceLeft(f)
+  def reduceLeft(f: (A, A) => A): A = it.iterator.reduceLeft(f)
 
   @deprecated("Use .iterator.sum instead", "2.13.0")
   def sum(implicit num: Numeric[A]): A = it.iterator.sum

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -1010,15 +1010,15 @@ object TrieMap extends MapFactory[TrieMap] {
 
   def empty[K, V]: TrieMap[K, V] = new TrieMap[K, V]
 
-  def from[K, V](it: IterableOnce[(K, V)]) = new TrieMap[K, V]() ++= it
+  def from[K, V](it: IterableOnce[(K, V)]): TrieMap[K, V] = new TrieMap[K, V]() ++= it
 
-  def newBuilder[K, V] = new GrowableBuilder(empty[K, V])
+  def newBuilder[K, V]: mutable.GrowableBuilder[(K, V), TrieMap[K, V]] = new GrowableBuilder(empty[K, V])
 
   @transient
-  val inodeupdater = AtomicReferenceFieldUpdater.newUpdater(classOf[INodeBase[_, _]], classOf[MainNode[_, _]], "mainnode")
+  val inodeupdater: AtomicReferenceFieldUpdater[INodeBase[_, _], MainNode[_, _]] = AtomicReferenceFieldUpdater.newUpdater(classOf[INodeBase[_, _]], classOf[MainNode[_, _]], "mainnode")
 
   class MangledHashing[K] extends Hashing[K] {
-    def hash(k: K)= scala.util.hashing.byteswap32(k.##)
+    def hash(k: K): Int = scala.util.hashing.byteswap32(k.##)
   }
 }
 
@@ -1090,9 +1090,9 @@ private[collection] class TrieMapIterator[K, V](var level: Int, private var ct: 
     }
   } else current = null
 
-  protected def newIterator(_lev: Int, _ct: TrieMap[K, V], _mustInit: Boolean) = new TrieMapIterator[K, V](_lev, _ct, _mustInit)
+  protected def newIterator(_lev: Int, _ct: TrieMap[K, V], _mustInit: Boolean): TrieMapIterator[K, V] = new TrieMapIterator[K, V](_lev, _ct, _mustInit)
 
-  protected def dupTo(it: TrieMapIterator[K, V]) = {
+  protected def dupTo(it: TrieMapIterator[K, V]): Unit = {
     it.level = this.level
     it.ct = this.ct
     it.depth = this.depth

--- a/src/library/scala/collection/immutable/ListSet.scala
+++ b/src/library/scala/collection/immutable/ListSet.scala
@@ -82,7 +82,7 @@ sealed class ListSet[A]
 
     override def isEmpty: Boolean = false
 
-    override def contains(e: A) = containsInternal(this, e)
+    override def contains(e: A): Boolean = containsInternal(this, e)
 
     @tailrec private[this] def containsInternal(n: ListSet[A], e: A): Boolean =
       !n.isEmpty && (n.elem == e || containsInternal(n.next, e))

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -237,13 +237,13 @@ object Map extends MapFactory[Map] {
     override def size: Int = 1
     override def knownSize: Int = 1
     override def isEmpty: Boolean = false
-    override def apply(key: K) = if (key == key1) value1 else throw new NoSuchElementException("key not found: " + key)
-    override def contains(key: K) = key == key1
+    override def apply(key: K): V = if (key == key1) value1 else throw new NoSuchElementException("key not found: " + key)
+    override def contains(key: K): Boolean = key == key1
     def get(key: K): Option[V] =
       if (key == key1) Some(value1) else None
     override def getOrElse [V1 >: V](key: K, default: => V1): V1 =
       if (key == key1) value1 else default
-    def iterator = Iterator.single((key1, value1))
+    def iterator: Iterator[(K, V)] = Iterator.single((key1, value1))
     override def keysIterator: Iterator[K] = Iterator.single(key1)
     override def valuesIterator: Iterator[V] = Iterator.single(value1)
     def updated[V1 >: V](key: K, value: V1): Map[K, V1] =
@@ -266,11 +266,11 @@ object Map extends MapFactory[Map] {
     override def size: Int = 2
     override def knownSize: Int = 2
     override def isEmpty: Boolean = false
-    override def apply(key: K) =
+    override def apply(key: K): V =
       if (key == key1) value1
       else if (key == key2) value2
       else throw new NoSuchElementException("key not found: " + key)
-    override def contains(key: K) = (key == key1) || (key == key2)
+    override def contains(key: K): Boolean = (key == key1) || (key == key2)
     def get(key: K): Option[V] =
       if (key == key1) Some(value1)
       else if (key == key2) Some(value2)
@@ -328,12 +328,12 @@ object Map extends MapFactory[Map] {
     override def size: Int = 3
     override def knownSize: Int = 3
     override def isEmpty: Boolean = false
-    override def apply(key: K) =
+    override def apply(key: K): V =
       if (key == key1) value1
       else if (key == key2) value2
       else if (key == key3) value3
       else throw new NoSuchElementException("key not found: " + key)
-    override def contains(key: K) = (key == key1) || (key == key2) || (key == key3)
+    override def contains(key: K): Boolean = (key == key1) || (key == key2) || (key == key3)
     def get(key: K): Option[V] =
       if (key == key1) Some(value1)
       else if (key == key2) Some(value2)
@@ -400,13 +400,13 @@ object Map extends MapFactory[Map] {
     override def size: Int = 4
     override def knownSize: Int = 4
     override def isEmpty: Boolean = false
-    override def apply(key: K) =
+    override def apply(key: K): V =
       if (key == key1) value1
       else if (key == key2) value2
       else if (key == key3) value3
       else if (key == key4) value4
       else throw new NoSuchElementException("key not found: " + key)
-    override def contains(key: K) = (key == key1) || (key == key2) || (key == key3) || (key == key4)
+    override def contains(key: K): Boolean = (key == key1) || (key == key2) || (key == key3) || (key == key4)
     def get(key: K): Option[V] =
       if (key == key1) Some(value1)
       else if (key == key2) Some(value2)

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -369,7 +369,7 @@ sealed abstract class Range(
     if (isInclusive) this
     else new Range.Inclusive(start, end, step)
 
-  final def contains(x: Int) = {
+  final def contains(x: Int): Boolean = {
     if (x == end && !isInclusive) false
     else if (step > 0) {
       if (x < start || x > end) false
@@ -457,7 +457,7 @@ sealed abstract class Range(
     }
   override protected final def applyPreferredMaxLength: Int = Int.MaxValue
 
-  final override def equals(other: Any) = other match {
+  final override def equals(other: Any): Boolean = other match {
     case x: Range =>
       // Note: this must succeed for overfull ranges (length > Int.MaxValue)
       if (isEmpty) x.isEmpty                  // empty sequences are equal
@@ -578,23 +578,23 @@ object Range {
 
   @SerialVersionUID(3L)
   final class Inclusive(start: Int, end: Int, step: Int) extends Range(start, end, step) {
-    def isInclusive = true
+    def isInclusive: Boolean = true
   }
 
   @SerialVersionUID(3L)
   final class Exclusive(start: Int, end: Int, step: Int) extends Range(start, end, step) {
-    def isInclusive = false
+    def isInclusive: Boolean = false
   }
 
   // BigInt and Long are straightforward generic ranges.
   object BigInt {
-    def apply(start: BigInt, end: BigInt, step: BigInt) = NumericRange(start, end, step)
-    def inclusive(start: BigInt, end: BigInt, step: BigInt) = NumericRange.inclusive(start, end, step)
+    def apply(start: BigInt, end: BigInt, step: BigInt): NumericRange.Exclusive[BigInt] = NumericRange(start, end, step)
+    def inclusive(start: BigInt, end: BigInt, step: BigInt): NumericRange.Inclusive[BigInt] = NumericRange.inclusive(start, end, step)
   }
 
   object Long {
-    def apply(start: Long, end: Long, step: Long) = NumericRange(start, end, step)
-    def inclusive(start: Long, end: Long, step: Long) = NumericRange.inclusive(start, end, step)
+    def apply(start: Long, end: Long, step: Long): NumericRange.Exclusive[Long] = NumericRange(start, end, step)
+    def inclusive(start: Long, end: Long, step: Long): NumericRange.Inclusive[Long] = NumericRange.inclusive(start, end, step)
   }
 
   // BigDecimal uses an alternative implementation of Numeric in which
@@ -605,9 +605,9 @@ object Range {
   object BigDecimal {
     implicit val bigDecAsIntegral: Numeric.BigDecimalAsIfIntegral = Numeric.BigDecimalAsIfIntegral
 
-    def apply(start: BigDecimal, end: BigDecimal, step: BigDecimal) =
+    def apply(start: BigDecimal, end: BigDecimal, step: BigDecimal): NumericRange.Exclusive[BigDecimal] =
       NumericRange(start, end, step)
-    def inclusive(start: BigDecimal, end: BigDecimal, step: BigDecimal) =
+    def inclusive(start: BigDecimal, end: BigDecimal, step: BigDecimal): NumericRange.Inclusive[BigDecimal] =
       NumericRange.inclusive(start, end, step)
   }
 
@@ -623,8 +623,8 @@ object Range {
   // indefinitely, for performance and because the compiler seems to bootstrap
   // off it and won't do so with our parameterized version without modifications.
   object Int {
-    def apply(start: Int, end: Int, step: Int) = NumericRange(start, end, step)
-    def inclusive(start: Int, end: Int, step: Int) = NumericRange.inclusive(start, end, step)
+    def apply(start: Int, end: Int, step: Int): NumericRange.Exclusive[Int] = NumericRange(start, end, step)
+    def inclusive(start: Int, end: Int, step: Int): NumericRange.Inclusive[Int] = NumericRange.inclusive(start, end, step)
   }
 
   private def emptyRangeError(what: String): Throwable =

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -206,7 +206,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
   /** Defers to defaultEntry to find a default value for the key.  Throws an
    *  exception if no other default behavior was specified.
    */
-  override def default(key: K) = defaultEntry(key)
+  override def default(key: K): V = defaultEntry(key)
 
   private def repack(newMask: Int): Unit = {
     val oh = _hashes

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -97,7 +97,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     if (hi > size0) throw new IndexOutOfBoundsException(s"$hi is out of bounds (min 0, max ${size0 - 1})")
   }
 
-  def apply(n: Int) = {
+  def apply(n: Int): A = {
     checkWithinBounds(n, n + 1)
     array(n).asInstanceOf[A]
   }

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -125,7 +125,7 @@ object ArrayBuilder {
       this
     }
 
-    def result() = {
+    def result(): Array[T] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
         val res = elems
@@ -172,7 +172,7 @@ object ArrayBuilder {
       this
     }
 
-    def result() = {
+    def result(): Array[Byte] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
         val res = elems
@@ -214,7 +214,7 @@ object ArrayBuilder {
       this
     }
 
-    def result() = {
+    def result(): Array[Short] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
         val res = elems
@@ -256,7 +256,7 @@ object ArrayBuilder {
       this
     }
 
-    def result() = {
+    def result(): Array[Char] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
         val res = elems
@@ -298,7 +298,7 @@ object ArrayBuilder {
       this
     }
 
-    def result() = {
+    def result(): Array[Int] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
         val res = elems
@@ -340,7 +340,7 @@ object ArrayBuilder {
       this
     }
 
-    def result() = {
+    def result(): Array[Long] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
         val res = elems
@@ -382,7 +382,7 @@ object ArrayBuilder {
       this
     }
 
-    def result() = {
+    def result(): Array[Float] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
         val res = elems
@@ -424,7 +424,7 @@ object ArrayBuilder {
       this
     }
 
-    def result() = {
+    def result(): Array[Double] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
         val res = elems
@@ -466,7 +466,7 @@ object ArrayBuilder {
       this
     }
 
-    def result() = {
+    def result(): Array[Boolean] = {
       if (capacity != 0 && capacity == size) {
         capacity = 0
         val res = elems

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -68,22 +68,22 @@ class ArrayDeque[A] protected (
   // No-Op override to allow for more efficient stepper in a minor release.
   override def stepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S with EfficientSplit = super.stepper(shape)
 
-  def apply(idx: Int) = {
+  def apply(idx: Int): A = {
     requireBounds(idx)
     _get(idx)
   }
 
-  def update(idx: Int, elem: A) = {
+  def update(idx: Int, elem: A): Unit = {
     requireBounds(idx)
     _set(idx, elem)
   }
 
-  def addOne(elem: A) = {
+  def addOne(elem: A): this.type = {
     ensureSize(length + 1)
     appendAssumingCapacity(elem)
   }
 
-  def prepend(elem: A) = {
+  def prepend(elem: A): this.type = {
     ensureSize(length + 1)
     prependAssumingCapacity(elem)
   }

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -84,9 +84,9 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
 
   override def knownSize: Int = super[IndexedSeqOps].knownSize
 
-  def addOne(x: Char) = { underlying.append(x); this }
+  def addOne(x: Char): this.type = { underlying.append(x); this }
 
-  def clear() = underlying.setLength(0)
+  def clear(): Unit = underlying.setLength(0)
 
   /** Overloaded version of `addAll` that takes a string */
   def addAll(s: String): this.type = { underlying.append(s); this }
@@ -96,7 +96,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
 
   def result() = underlying.toString
 
-  override def toString = result()
+  override def toString: String = result()
 
   override def toArray[B >: Char](implicit ct: scala.reflect.ClassTag[B]) =
     ct.runtimeClass match {

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -16,7 +16,7 @@ package collection.mutable
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.generic.DefaultSerializable
 import scala.collection.mutable.{RedBlackTree => RB}
-import scala.collection.{SortedIterableFactory, SortedSetFactoryDefaults, Stepper, StepperShape, StrictOptimizedIterableOps, StrictOptimizedSortedSetOps}
+import scala.collection.{SortedIterableFactory, SortedSetFactoryDefaults, Stepper, StepperShape, StrictOptimizedIterableOps, StrictOptimizedSortedSetOps, mutable}
 
 /**
   * A mutable sorted set implemented using a mutable red-black tree as underlying data structure.
@@ -152,10 +152,10 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
 
     override def size = if (RB.size(tree) == 0) 0 else iterator.length
     override def knownSize: Int = if (RB.size(tree) == 0) 0 else -1
-    override def isEmpty = RB.size(tree) == 0 || !iterator.hasNext
+    override def isEmpty: Boolean = RB.size(tree) == 0 || !iterator.hasNext
 
-    override def head = headOption.get
-    override def headOption = {
+    override def head: A = headOption.get
+    override def headOption: Option[A] = {
       val elem = if (from.isDefined) RB.minKeyAfter(tree, from.get) else RB.minKey(tree)
       (elem, until) match {
         case (Some(e), Some(unt)) if ordering.compare(e, unt) >= 0 => None
@@ -163,7 +163,7 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
       }
     }
 
-    override def last = lastOption.get
+    override def last: A = lastOption.get
     override def lastOption = {
       val elem = if (until.isDefined) RB.maxKeyBefore(tree, until.get) else RB.maxKey(tree)
       (elem, from) match {
@@ -177,7 +177,7 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
     // https://github.com/scala/scala/pull/4608#discussion_r34307985 for a discussion about this.
     override def foreach[U](f: A => U): Unit = iterator.foreach(f)
 
-    override def clone() = super.clone().rangeImpl(from, until)
+    override def clone(): mutable.TreeSet[A] = super.clone().rangeImpl(from, until)
 
   }
 

--- a/src/library/scala/io/Codec.scala
+++ b/src/library/scala/io/Codec.scala
@@ -89,9 +89,9 @@ object Codec extends LowPriorityCodecImplicits {
    *  the fact that you can influence anything at all via -Dfile.encoding
    *  as an accident, with any anomalies considered "not a bug".
    */
-  def defaultCharsetCodec = apply(Charset.defaultCharset)
-  def fileEncodingCodec   = apply(scala.util.Properties.encodingString)
-  def default             = defaultCharsetCodec
+  def defaultCharsetCodec: Codec = apply(Charset.defaultCharset)
+  def fileEncodingCodec: Codec = apply(scala.util.Properties.encodingString)
+  def default: Codec = defaultCharsetCodec
 
   def apply(encoding: String): Codec        = new Codec(Charset forName encoding)
   def apply(charSet: Charset): Codec        = new Codec(charSet)

--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -213,8 +213,8 @@ abstract class Source extends Iterator[Char] with Closeable {
     private[this] val sb = new StringBuilder
 
     lazy val iter: BufferedIterator[Char] = Source.this.iter.buffered
-    def isNewline(ch: Char) = ch == '\r' || ch == '\n'
-    def getc() = iter.hasNext && {
+    def isNewline(ch: Char): Boolean = ch == '\r' || ch == '\n'
+    def getc(): Boolean = iter.hasNext && {
       val ch = iter.next()
       if (ch == '\n') false
       else if (ch == '\r') {
@@ -228,8 +228,8 @@ abstract class Source extends Iterator[Char] with Closeable {
         true
       }
     }
-    def hasNext = iter.hasNext
-    def next() = {
+    def hasNext: Boolean = iter.hasNext
+    def next(): String = {
       sb.clear()
       while (getc()) { }
       sb.toString
@@ -244,7 +244,7 @@ abstract class Source extends Iterator[Char] with Closeable {
 
   /** Returns `'''true'''` if this source has more characters.
    */
-  def hasNext = iter.hasNext
+  def hasNext: Boolean = iter.hasNext
 
   /** Returns next character.
    */
@@ -290,8 +290,8 @@ abstract class Source extends Iterator[Char] with Closeable {
   object NoPositioner extends Positioner(Position) {
     override def next(): Char = iter.next()
   }
-  def ch = positioner.ch
-  def pos = positioner.pos
+  def ch: Char = positioner.ch
+  def pos: Int = positioner.pos
 
   /** Reports an error message to the output stream `out`.
    *

--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -688,7 +688,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
     new Range.Partial(until(end, _))
 
   /** Same as the one-argument `until`, but creates the range immediately. */
-  def until(end: BigDecimal, step: BigDecimal) = Range.BigDecimal(this, end, step)
+  def until(end: BigDecimal, step: BigDecimal): NumericRange.Exclusive[BigDecimal] = Range.BigDecimal(this, end, step)
 
   /** Like `until`, but inclusive of the end value. */
   def to(end: BigDecimal): Range.Partial[BigDecimal, NumericRange.Inclusive[BigDecimal]] =

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -15,6 +15,7 @@ package math
 
 import java.math.BigInteger
 import scala.language.implicitConversions
+import scala.collection.immutable.NumericRange
 
 object BigInt {
 
@@ -124,14 +125,14 @@ final class BigInt(val bigInteger: BigInteger)
     case that: Float      => isValidFloat && toFloat == that
     case x                => isValidLong && unifiedPrimitiveEquals(x)
   }
-  override def isValidByte  = this >= Byte.MinValue && this <= Byte.MaxValue
-  override def isValidShort = this >= Short.MinValue && this <= Short.MaxValue
-  override def isValidChar  = this >= Char.MinValue && this <= Char.MaxValue
-  override def isValidInt   = this >= Int.MinValue && this <= Int.MaxValue
-           def isValidLong  = this >= Long.MinValue && this <= Long.MaxValue
+  override def isValidByte: Boolean = this >= Byte.MinValue && this <= Byte.MaxValue
+  override def isValidShort: Boolean = this >= Short.MinValue && this <= Short.MaxValue
+  override def isValidChar: Boolean = this >= Char.MinValue && this <= Char.MaxValue
+  override def isValidInt: Boolean = this >= Int.MinValue && this <= Int.MaxValue
+           def isValidLong: Boolean = this >= Long.MinValue && this <= Long.MaxValue
   /** Returns `true` iff this can be represented exactly by [[scala.Float]]; otherwise returns `false`.
     */
-  def isValidFloat = {
+  def isValidFloat: Boolean = {
     val bitLen = bitLength
     (bitLen <= 24 ||
       {
@@ -144,7 +145,7 @@ final class BigInt(val bigInteger: BigInteger)
   }
   /** Returns `true` iff this can be represented exactly by [[scala.Double]]; otherwise returns `false`.
     */
-  def isValidDouble = {
+  def isValidDouble: Boolean = {
     val bitLen = bitLength
     (bitLen <= 53 ||
       {
@@ -165,8 +166,8 @@ final class BigInt(val bigInteger: BigInteger)
     (shifted.signum != 0) && !(shifted equals BigInt.minusOne)
   }
 
-  def isWhole = true
-  def underlying = bigInteger
+  def isWhole: Boolean = true
+  def underlying: BigInteger = bigInteger
 
   /** Compares this BigInt with the specified BigInt for equality.
    */
@@ -322,28 +323,28 @@ final class BigInt(val bigInteger: BigInteger)
    *                    The execution time of this method is proportional to the value of
    *                    this parameter.
    */
-  def isProbablePrime(certainty: Int) = this.bigInteger.isProbablePrime(certainty)
+  def isProbablePrime(certainty: Int): Boolean = this.bigInteger.isProbablePrime(certainty)
 
   /** Converts this BigInt to a <tt>byte</tt>.
    *  If the BigInt is too big to fit in a byte, only the low-order 8 bits are returned.
    *  Note that this conversion can lose information about the overall magnitude of the
    *  BigInt value as well as return a result with the opposite sign.
    */
-  override def byteValue   = intValue.toByte
+  override def byteValue: Byte = intValue.toByte
 
   /** Converts this BigInt to a <tt>short</tt>.
    *  If the BigInt is too big to fit in a short, only the low-order 16 bits are returned.
    *  Note that this conversion can lose information about the overall magnitude of the
    *  BigInt value as well as return a result with the opposite sign.
    */
-  override def shortValue  = intValue.toShort
+  override def shortValue: Short = intValue.toShort
 
   /** Converts this BigInt to a <tt>char</tt>.
    *  If the BigInt is too big to fit in a char, only the low-order 16 bits are returned.
    *  Note that this conversion can lose information about the overall magnitude of the
    *  BigInt value and that it always returns a positive result.
    */
-  def charValue   = intValue.toChar
+  def charValue: Char = intValue.toChar
 
   /** Converts this BigInt to an <tt>int</tt>.
    *  If the BigInt is too big to fit in an int, only the low-order 32 bits
@@ -351,7 +352,7 @@ final class BigInt(val bigInteger: BigInteger)
    *  overall magnitude of the BigInt value as well as return a result with
    *  the opposite sign.
    */
-  def intValue    = this.bigInteger.intValue
+  def intValue: Int = this.bigInteger.intValue
 
   /** Converts this BigInt to a <tt>long</tt>.
    *  If the BigInt is too big to fit in a long, only the low-order 64 bits
@@ -359,21 +360,21 @@ final class BigInt(val bigInteger: BigInteger)
    *  overall magnitude of the BigInt value as well as return a result with
    *  the opposite sign.
    */
-  def longValue   = this.bigInteger.longValue
+  def longValue: Long = this.bigInteger.longValue
 
   /** Converts this `BigInt` to a `float`.
    *  If this `BigInt` has too great a magnitude to represent as a float,
    *  it will be converted to `Float.NEGATIVE_INFINITY` or
    *  `Float.POSITIVE_INFINITY` as appropriate.
    */
-  def floatValue  = this.bigInteger.floatValue
+  def floatValue: Float = this.bigInteger.floatValue
 
   /** Converts this `BigInt` to a `double`.
    *  if this `BigInt` has too great a magnitude to represent as a double,
    *  it will be converted to `Double.NEGATIVE_INFINITY` or
    *  `Double.POSITIVE_INFINITY` as appropriate.
    */
-  def doubleValue = this.bigInteger.doubleValue
+  def doubleValue: Double = this.bigInteger.doubleValue
 
   /** Create a `NumericRange[BigInt]` in range `[start;end)`
    *  with the specified step, where start is the target BigInt.
@@ -382,11 +383,11 @@ final class BigInt(val bigInteger: BigInteger)
    *  @param step   the distance between elements (defaults to 1)
    *  @return       the range
    */
-  def until(end: BigInt, step: BigInt = BigInt(1)) = Range.BigInt(this, end, step)
+  def until(end: BigInt, step: BigInt = BigInt(1)): NumericRange.Exclusive[BigInt] = Range.BigInt(this, end, step)
 
   /** Like until, but inclusive of the end value.
    */
-  def to(end: BigInt, step: BigInt = BigInt(1)) = Range.BigInt.inclusive(this, end, step)
+  def to(end: BigInt, step: BigInt = BigInt(1)): NumericRange.Inclusive[BigInt] = Range.BigInt.inclusive(this, end, step)
 
   /** Returns the decimal String representation of this BigInt.
    */

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -184,11 +184,11 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
 
   /** This inner class defines comparison operators available for `T`. */
   class OrderingOps(lhs: T) {
-    def <(rhs: T) = lt(lhs, rhs)
-    def <=(rhs: T) = lteq(lhs, rhs)
-    def >(rhs: T) = gt(lhs, rhs)
-    def >=(rhs: T) = gteq(lhs, rhs)
-    def equiv(rhs: T) = Ordering.this.equiv(lhs, rhs)
+    def <(rhs: T): Boolean = lt(lhs, rhs)
+    def <=(rhs: T): Boolean = lteq(lhs, rhs)
+    def >(rhs: T): Boolean = gt(lhs, rhs)
+    def >=(rhs: T): Boolean = gteq(lhs, rhs)
+    def equiv(rhs: T): Boolean = Ordering.this.equiv(lhs, rhs)
     def max(rhs: T): T = Ordering.this.max(lhs, rhs)
     def min(rhs: T): T = Ordering.this.min(lhs, rhs)
   }
@@ -338,32 +338,32 @@ object Ordering extends LowPriorityOrderingImplicits {
   implicit object Unit extends UnitOrdering
 
   trait BooleanOrdering extends Ordering[Boolean] {
-    def compare(x: Boolean, y: Boolean) = java.lang.Boolean.compare(x, y)
+    def compare(x: Boolean, y: Boolean): Int = java.lang.Boolean.compare(x, y)
   }
   implicit object Boolean extends BooleanOrdering
 
   trait ByteOrdering extends Ordering[Byte] {
-    def compare(x: Byte, y: Byte) = java.lang.Byte.compare(x, y)
+    def compare(x: Byte, y: Byte): Int = java.lang.Byte.compare(x, y)
   }
   implicit object Byte extends ByteOrdering
 
   trait CharOrdering extends Ordering[Char] {
-    def compare(x: Char, y: Char) = java.lang.Character.compare(x, y)
+    def compare(x: Char, y: Char): Int = java.lang.Character.compare(x, y)
   }
   implicit object Char extends CharOrdering
 
   trait ShortOrdering extends Ordering[Short] {
-    def compare(x: Short, y: Short) = java.lang.Short.compare(x, y)
+    def compare(x: Short, y: Short): Int = java.lang.Short.compare(x, y)
   }
   implicit object Short extends ShortOrdering
 
   trait IntOrdering extends Ordering[Int] {
-    def compare(x: Int, y: Int) = java.lang.Integer.compare(x, y)
+    def compare(x: Int, y: Int): Int = java.lang.Integer.compare(x, y)
   }
   implicit object Int extends IntOrdering with CachedReverse[Int]
 
   trait LongOrdering extends Ordering[Long] {
-    def compare(x: Long, y: Long) = java.lang.Long.compare(x, y)
+    def compare(x: Long, y: Long): Int = java.lang.Long.compare(x, y)
   }
   implicit object Long extends LongOrdering
 

--- a/src/library/scala/ref/Reference.scala
+++ b/src/library/scala/ref/Reference.scala
@@ -20,7 +20,7 @@ trait Reference[+T <: AnyRef] extends Function0[T] {
   def apply(): T
   /** return `Some` underlying if it hasn't been collected, otherwise `None` */
   def get: Option[T]
-  override def toString = get.map(_.toString).getOrElse("<deleted>")
+  override def toString: String = get.map(_.toString).getOrElse("<deleted>")
   def clear(): Unit
   def enqueue(): Boolean
   def isEnqueued: Boolean

--- a/src/library/scala/ref/ReferenceQueue.scala
+++ b/src/library/scala/ref/ReferenceQueue.scala
@@ -15,7 +15,7 @@ package scala.ref
 class ReferenceQueue[+T <: AnyRef] {
 
   private[ref] val underlying: java.lang.ref.ReferenceQueue[_ <: T] = new java.lang.ref.ReferenceQueue[T]
-  override def toString = underlying.toString
+  override def toString: String = underlying.toString
 
   protected def Wrapper(jref: java.lang.ref.Reference[_]): Option[Reference[T]] =
     jref match {

--- a/src/library/scala/ref/ReferenceWrapper.scala
+++ b/src/library/scala/ref/ReferenceWrapper.scala
@@ -20,10 +20,10 @@ trait ReferenceWrapper[+T <: AnyRef] extends Reference[T] with Proxy {
     if (ret eq null) throw new NoSuchElementException
     ret
   }
-  def clear() = underlying.clear()
-  def enqueue() = underlying.enqueue()
-  def isEnqueued = underlying.isEnqueued
-  def self = underlying
+  def clear(): Unit = underlying.clear()
+  def enqueue(): Boolean = underlying.enqueue()
+  def isEnqueued: Boolean = underlying.isEnqueued
+  def self: java.lang.ref.Reference[_ <: T] = underlying
 }
 
 private trait ReferenceWithWrapper[T <: AnyRef] {

--- a/src/library/scala/ref/SoftReference.scala
+++ b/src/library/scala/ref/SoftReference.scala
@@ -25,7 +25,7 @@ class SoftReference[+T <: AnyRef](value : T, queue : ReferenceQueue[T]) extends 
 object SoftReference {
 
   /** Creates a `SoftReference` pointing to `value` */
-  def apply[T <: AnyRef](value: T) = new SoftReference(value)
+  def apply[T <: AnyRef](value: T): SoftReference[T] = new SoftReference(value)
 
   /** Optionally returns the referenced value, or `None` if that value no longer exists */
   def unapply[T <: AnyRef](sr: SoftReference[T]): Option[T] = Option(sr.underlying.get)

--- a/src/library/scala/ref/WeakReference.scala
+++ b/src/library/scala/ref/WeakReference.scala
@@ -27,7 +27,7 @@ class WeakReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T]) extends Re
 object WeakReference {
 
   /** Creates a weak reference pointing to `value` */
-  def apply[T <: AnyRef](value: T) = new WeakReference(value)
+  def apply[T <: AnyRef](value: T): WeakReference[T] = new WeakReference(value)
 
   /** Optionally returns the referenced value, or `None` if that value no longer exists */
   def unapply[T <: AnyRef](wr: WeakReference[T]): Option[T] = Option(wr.underlying.get)

--- a/src/library/scala/sys/SystemProperties.scala
+++ b/src/library/scala/sys/SystemProperties.scala
@@ -30,7 +30,7 @@ import scala.language.implicitConversions
 class SystemProperties
 extends mutable.AbstractMap[String, String] {
 
-  override def empty = mutable.Map[String, String]()
+  override def empty: mutable.Map[String, String] = mutable.Map[String, String]()
   override def default(key: String): String = null
 
   def iterator: Iterator[(String, String)] = wrapAccess {
@@ -43,9 +43,9 @@ extends mutable.AbstractMap[String, String] {
     System.getProperties().stringPropertyNames().asScala.iterator
   ) getOrElse Iterator.empty
 
-  def get(key: String) =
+  def get(key: String): Option[String] =
     wrapAccess(Option(System.getProperty(key))) flatMap (x => x)
-  override def contains(key: String) =
+  override def contains(key: String): Boolean =
     wrapAccess(super.contains(key)) exists (x => x)
 
   override def clear(): Unit = wrapAccess(System.getProperties().clear())
@@ -66,7 +66,7 @@ object SystemProperties {
   /** An unenforceable, advisory only place to do some synchronization when
    *  mutating system properties.
    */
-  def exclusively[T](body: => T) = this synchronized body
+  def exclusively[T](body: => T): T = this synchronized body
 
   implicit def systemPropertiesToCompanion(p: SystemProperties): SystemProperties.type = this
 

--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -339,7 +339,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
     else unapplySeq(m.matched)
 
   //  @see UnanchoredRegex
-  protected def runMatcher(m: Matcher) = m.matches()
+  protected def runMatcher(m: Matcher): Boolean = m.matches()
 
   /** Return all non-overlapping matches of this `Regex` in the given character
    *  sequence as a [[scala.util.matching.Regex.MatchIterator]],
@@ -380,7 +380,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *  @return       A [[scala.util.matching.Regex.MatchIterator]] of matched substrings.
    *  @example      {{{for (words <- """\w+""".r findAllIn "A simple example.") yield words}}}
    */
-  def findAllIn(source: CharSequence) = new Regex.MatchIterator(source, this, groupNames)
+  def findAllIn(source: CharSequence): MatchIterator = new Regex.MatchIterator(source, this, groupNames)
 
   /** Return all non-overlapping matches of this regexp in given character sequence as a
    *  [[scala.collection.Iterator]] of [[scala.util.matching.Regex.Match]].
@@ -591,7 +591,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
   def regex: String = pattern.pattern
 
   /** The string defining the regular expression */
-  override def toString = regex
+  override def toString: String = regex
 }
 
 /** A [[Regex]] that finds the first match when used in a pattern match.
@@ -599,8 +599,8 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
  *  @see [[Regex#unanchored]]
  */
 trait UnanchoredRegex extends Regex {
-  override protected def runMatcher(m: Matcher) = m.find()
-  override def unanchored = this
+  override protected def runMatcher(m: Matcher): Boolean = m.find()
+  override def unanchored: UnanchoredRegex = this
 }
 
 /** This object defines inner classes that describe
@@ -709,7 +709,7 @@ object Regex {
     )
 
     /** The matched string; equivalent to `matched.toString`. */
-    override def toString = matched
+    override def toString: String = matched
   }
 
   /** Provides information about a successful match. */
@@ -718,13 +718,13 @@ object Regex {
               val groupNames: Seq[String]) extends MatchData {
 
     /** The index of the first matched character. */
-    val start = matcher.start
+    val start: Int = matcher.start
 
     /** The index following the last matched character. */
-    val end = matcher.end
+    val end: Int = matcher.end
 
     /** The number of subgroups. */
-    def groupCount = matcher.groupCount
+    def groupCount: Int = matcher.groupCount
 
     private[this] lazy val starts: Array[Int] =
       Array.tabulate(groupCount + 1) { matcher.start }
@@ -732,10 +732,10 @@ object Regex {
       Array.tabulate(groupCount + 1) { matcher.end }
 
     /** The index of the first matched character in group `i`. */
-    def start(i: Int) = starts(i)
+    def start(i: Int): Int = starts(i)
 
     /** The index following the last matched character in group `i`. */
-    def end(i: Int) = ends(i)
+    def end(i: Int): Int = ends(i)
 
     /** The match itself with matcher-dependent lazy vals forced,
      *  so that match is valid even once matcher is advanced.
@@ -826,7 +826,7 @@ object Regex {
     }
 
     /** Report emptiness. */
-    override def toString = super[AbstractIterator].toString
+    override def toString: String = super[AbstractIterator].toString
 
     // ensure we're at a match
     private[this] def ensure(): Unit = nextSeen match {
@@ -849,7 +849,7 @@ object Regex {
     def end(i: Int): Int = { ensure() ; matcher.end(i) }
 
     /** The number of subgroups. */
-    def groupCount = { ensure() ; matcher.groupCount }
+    def groupCount: Int = { ensure() ; matcher.groupCount }
 
     /** Convert to an iterator that yields MatchData elements instead of Strings. */
     def matchData: Iterator[Match] = new AbstractIterator[Match] {


### PR DESCRIPTION
Here is the list:

- Console
- Source
- Codec
- Enumeration
- SoftReference
- WeakReference
- ReferenceQueue
- Reference
- BigInt
- SystemProperties
- PartialFunction
- StringContext
- IterableOnce
- Regex
- Match
- ListSet
- Map
- AnyRefMap
- ArrayDeque
- Range
- ArrayBuilder
- ArrayBuffer
- ReferenceWrapper
- StringBuilder
- TreeSet
- Source#LineIterator
- ArrayBuffer
- ArrayBuilder
- BigDecimal
- Ordering