### PR TITLE
 Inline calls to static trait super accessors if trait method is trivial

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1155,7 +1155,7 @@ intellij := {
   }
 
   def moduleDep(name: String, jars: Seq[File]) = {
-    val entries = jars.map(f => s"""        <root url="jar://${f.toURI.getRawPath}!/" />""").mkString("\n")
+    val entries = jars.map(f => s"""        <root url="jar://${f.toURI.getPath}!/" />""").mkString("\n")
     s"""|    <library name="$name-deps">
         |      <CLASSES>
         |$entries
@@ -1166,7 +1166,7 @@ intellij := {
   }
 
   def starrDep(jars: Seq[File]) = {
-    val entries = jars.map(f => s"""          <root url="file://${f.toURI.getRawPath}" />""").mkString("\n")
+    val entries = jars.map(f => s"""          <root url="file://${f.toURI.getPath}" />""").mkString("\n")
     s"""|    <library name="starr" type="Scala">
         |      <properties>
         |        <option name="languageLevel" value="Scala_2_12" />


### PR DESCRIPTION
Generally we don't inline static trait super accessors because they
contain an `invokespecial`, which has different semantics if inlined
into another classfile. However, if the target trait method itself is
a forwarder or trivial, we should inline the static super accessor.
The `invokespecial` will be inlined in the next round.

Fixes https://github.com/scala/scala-dev/issues/618