### PR TITLE
[nomerge] set every sourcesInBase := false

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -240,6 +240,9 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
   baseDirectory in Compile := (baseDirectory in ThisBuild).value,
   baseDirectory in Test := (baseDirectory in ThisBuild).value,
 
+  // Don't pick up source files from the project root.
+  sourcesInBase := false,
+
   // Don't log process output (e.g. of forked `compiler/runMain ...Main`), just pass it
   // directly to stdout
   outputStrategy in run := Some(StdoutOutput)


### PR DESCRIPTION
This would have saved me a headache, although it would also have been saved by me being minimally hygienic and not leaving `.scala` files lying around in my git repos.