### PR TITLE
[WIP] Fix running a Process with connectInput=true breaks with 'Stream closed'

### DIFF
--- a/src/library/mima-filters/2.13.0.forwards.excludes
+++ b/src/library/mima-filters/2.13.0.forwards.excludes
@@ -1,0 +1,2 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.sys.process.ProcessIO.connectInput")
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.sys.process.ProcessIO.this")

--- a/src/library/scala/sys/process/ProcessBuilderImpl.scala
+++ b/src/library/scala/sys/process/ProcessBuilderImpl.scala
@@ -17,6 +17,7 @@ package process
 import processInternal._
 import Process._
 import java.io.{ FileInputStream, FileOutputStream }
+import java.lang.ProcessBuilder.Redirect
 import BasicIO.{ LazilyListed, Streamed, Uncloseable }
 import Uncloseable.protect
 import scala.util.control.NonFatal
@@ -75,6 +76,7 @@ private[process] trait ProcessBuilderImpl {
     override def run(io: ProcessIO): Process = {
       import io._
 
+      if(io.connectInput) p.redirectInput(Redirect.INHERIT)
       val process = p.start() // start the external process
 
       // spawn threads that process the input, output, and error streams using the functions defined in `io`

--- a/src/library/scala/sys/process/ProcessIO.scala
+++ b/src/library/scala/sys/process/ProcessIO.scala
@@ -54,9 +54,11 @@ final class ProcessIO(
   val writeInput: OutputStream => Unit,
   val processOutput: InputStream => Unit,
   val processError: InputStream => Unit,
-  val daemonizeThreads: Boolean
+  val daemonizeThreads: Boolean,
+  val connectInput: Boolean
 ) {
-  def this(in: OutputStream => Unit, out: InputStream => Unit, err: InputStream => Unit) = this(in, out, err, false)
+  def this(in: OutputStream => Unit, out: InputStream => Unit, err: InputStream => Unit) = this(in, out, err, false, false)
+  def this(in: OutputStream => Unit, out: InputStream => Unit, err: InputStream => Unit, daemonizeThreads: Boolean) = this(in, out, err, daemonizeThreads, false)
 
   /** Creates a new `ProcessIO` with a different handler for the process input. */
   def withInput(write: OutputStream => Unit): ProcessIO   = new ProcessIO(write, processOutput, processError, daemonizeThreads)


### PR DESCRIPTION
This fixes https://github.com/scala/bug/issues/7963. 

This is my first PR to scala/scala, so please correct me if I'm not doing right.
Also this does not have tests yet (so marked as `WIP`), but I'd like to know if I'm in right direction or not.

This is basically a port of  https://github.com/sbt/sbt/commit/8d123081a20488cfc76bbf59cb8114f6ad04b368, in a backward-compatible manner.
I can confirm that after applying this fix, running

```scala
sys.process.Process("ls").run(true).exitValue()
```

in `repl-frontend/run` no longer causes `java.io.IOException: Stream closed`.

Thank you all for the hard work of maintaining this great language!