### PR TITLE
Tweak deprecation messages for Ordering[{Float,Double}]

### DIFF
--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -424,7 +424,7 @@ object Ordering extends LowPriorityOrderingImplicits {
   }
   @deprecated("There are multiple ways to order Floats (Ordering.Float.TotalOrdering, " +
     "Ordering.Float.IeeeOrdering). Specify one by using a local import, assigning an implicit val, or passing it " +
-    "explicitly. See the documentation for details.", since = "2.13.0")
+    "explicitly. See their documentation for details.", since = "2.13.0")
   implicit object DeprecatedFloatOrdering extends Float.TotalOrdering
 
   /** `Ordering`s for `Double`s.
@@ -484,7 +484,7 @@ object Ordering extends LowPriorityOrderingImplicits {
   }
   @deprecated("There are multiple ways to order Doubles (Ordering.Double.TotalOrdering, " +
     "Ordering.Double.IeeeOrdering). Specify one by using a local import, assigning an implicit val, or passing it " +
-    "explicitly. See the documentation for details.", since = "2.13.0")
+    "explicitly. See their documentation for details.", since = "2.13.0")
   implicit object DeprecatedDoubleOrdering extends Double.TotalOrdering
 
   trait BigIntOrdering extends Ordering[BigInt] {

--- a/test/files/neg/t10511.check
+++ b/test/files/neg/t10511.check
@@ -1,10 +1,10 @@
-t10511.scala:3: warning: object DeprecatedFloatOrdering in object Ordering is deprecated (since 2.13.0): There are multiple ways to order Floats (Ordering.Float.TotalOrdering, Ordering.Float.IeeeOrdering). Specify one by using a local import, assigning an implicit val, or passing it explicitly. See the documentation for details.
+t10511.scala:3: warning: object DeprecatedFloatOrdering in object Ordering is deprecated (since 2.13.0): There are multiple ways to order Floats (Ordering.Float.TotalOrdering, Ordering.Float.IeeeOrdering). Specify one by using a local import, assigning an implicit val, or passing it explicitly. See their documentation for details.
   val f = Ordering[Float]
                   ^
-t10511.scala:4: warning: object DeprecatedDoubleOrdering in object Ordering is deprecated (since 2.13.0): There are multiple ways to order Doubles (Ordering.Double.TotalOrdering, Ordering.Double.IeeeOrdering). Specify one by using a local import, assigning an implicit val, or passing it explicitly. See the documentation for details.
+t10511.scala:4: warning: object DeprecatedDoubleOrdering in object Ordering is deprecated (since 2.13.0): There are multiple ways to order Doubles (Ordering.Double.TotalOrdering, Ordering.Double.IeeeOrdering). Specify one by using a local import, assigning an implicit val, or passing it explicitly. See their documentation for details.
   val d = Ordering[Double]
                   ^
-t10511.scala:7: warning: object DeprecatedDoubleOrdering in object Ordering is deprecated (since 2.13.0): There are multiple ways to order Doubles (Ordering.Double.TotalOrdering, Ordering.Double.IeeeOrdering). Specify one by using a local import, assigning an implicit val, or passing it explicitly. See the documentation for details.
+t10511.scala:7: warning: object DeprecatedDoubleOrdering in object Ordering is deprecated (since 2.13.0): There are multiple ways to order Doubles (Ordering.Double.TotalOrdering, Ordering.Double.IeeeOrdering). Specify one by using a local import, assigning an implicit val, or passing it explicitly. See their documentation for details.
   list.sorted
        ^
 error: No warnings can be incurred under -Werror.


### PR DESCRIPTION
Followup to [this comment](https://github.com/scala/scala/pull/6410#issuecomment-395309658). Sorry it took so long @dwijnand.