### PR TITLE
fix mutable.HashSet.addAll: remove redundant call to super method

### DIFF
--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -99,7 +99,6 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
         this
       case _ => super.addAll(xs)
     }
-    super.addAll(xs)
   }
 
   override def subtractAll(xs: IterableOnce[A]): this.type = {

--- a/test/junit/scala/collection/mutable/HashSetTest.scala
+++ b/test/junit/scala/collection/mutable/HashSetTest.scala
@@ -70,4 +70,44 @@ class HashSetTest {
     val hs = HashSet[PackageEntryImpl](PackageEntryImpl("javax"), PackageEntryImpl("java"))
     assertFalse(hs.add(PackageEntryImpl("java")))
   }
+
+  class Type1(val value:String)
+  class Type2(val value:String)
+
+  import scala.jdk.CollectionConverters._
+
+  @Test
+  def addAll: Unit = {
+    val jhs: java.util.HashSet[Type1] = new java.util.HashSet[Type1]
+    jhs.add(new Type1("A"))
+    jhs.add(new Type1("B"))
+    val shs: scala.collection.mutable.Set[Type2] = jhs.asScala.map(x => new Type2(x.value))
+    assertEquals(jhs.size, shs.size)
+  }
+
+  class OnceOnly extends IterableOnce[Int] {
+    override def knownSize: Int = 1
+
+    var iterated:Boolean = false
+
+    override def iterator: Iterator[Int] = {
+      new Iterator[Int] {
+        assert(!iterated)
+        iterated = true
+        private var v = Option(42)
+        override def hasNext: Boolean = v.nonEmpty && knownSize > 0
+        override def next(): Int = {
+          val res = v.get
+          v = None
+          res
+        }
+      }
+    }
+  }
+
+  @Test
+  def addAllTest2: Unit = {
+    val hs = HashSet.empty[Int]
+    hs.addAll(new OnceOnly)
+  }
 }


### PR DESCRIPTION
Removed redundant call to super method.

Fixes scala/bug#11601