### PR TITLE
Fix presentation compiler having wrong name in CompletionResult when comments between qualifier and pos.

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1247,9 +1247,9 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
         val qualPos = qual.pos
         def fallback = qualPos.end + 2
         val source = pos.source
-        val nameStart: Int = (qualPos.end + 1 until focus1.pos.end).find(p =>
-          source.identifier(source.position(p)).exists(_.length > 0)
-        ).getOrElse(fallback)
+        val nameStart: Int = (focus1.pos.end - 1 to qualPos.end by -1).find(p =>
+          source.identifier(source.position(p)).exists(_.length == 0)
+        ).map(_ + 1).getOrElse(fallback)
         typeCompletions(sel, qual, nameStart, name)
       case Ident(name) =>
         val allMembers = scopeMembers(pos)

--- a/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
@@ -232,6 +232,28 @@ class CompletionTest {
   }
 
   @Test
+  def completionWithComment(): Unit = {
+    val intp = newIMain()
+    val completer = new PresentationCompilerCompleter(intp)
+
+    val withMultilineCommit =
+      """|Array(1, 2, 3)
+         |  .map(_ + 1) /* then we do reverse */
+         |  .rev""".stripMargin
+    assert(
+      completer.complete(withMultilineCommit).candidates.contains("reverseMap")
+    )
+
+    val withInlineCommit =
+      """|Array(1, 2, 3)
+         |  .map(_ + 1) // then we do reverse
+         |  .rev""".stripMargin
+    assert(
+      completer.complete(withInlineCommit).candidates.contains("reverseMap")
+    )
+  }
+
+  @Test
   def dependentTypeImplicits_t10353(): Unit = {
     val code =
       """


### PR DESCRIPTION
While working on https://github.com/scalameta/metals/pull/814/files we bumped into this bug and when I checked in ScalaIDE they were not using the same method, so they never encountered this issue.

~~Not sure if this is even properly tested, the presentation compiler tests I run with `partest --verbose test/files/presentation/` were not picking this up. Let me know if I can add a test or what should I do to have this merged.~~

Edit: Actually after some more digging `CompletionTest` did use that method underneath. Added a test and was able to reproduce the error without my fix.

Full explanation:

Previously, when looking for the start of the name in case of `Select` we were looking starting from the qualifier which was an issue when there were comments between like:

```scala
List(1,2,3).
  .map(_ + 1) // this comments would be included in name
  .@@
```
The name would be something like `\\$div\\$div.+\\$u000A` which was not a proper identifier.
In this commit we start at focus end and look for something that is empty to get the start of the name.