### PR TITLE
[#11600] Vector.from(ArraySeq) copies elems rather than reusing unsafeArray

### DIFF
--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -219,4 +219,48 @@ class VectorTest {
       assertArrayEquals(s"<${v2.length}>.slice($j, $k)", v2.toArray.slice(j, k), v2.iterator.slice(j, k).toArray)
     }
   }
+
+  @Test
+  def t11600(): Unit = {
+    locally {
+      abstract class Base
+      class Derived1 extends Base
+      class Derived2 extends Base
+      val d1 = new Derived1
+      val d2 = new Derived2
+
+      locally {
+        val arraySeq = ArraySeq(d1)
+        val vector = Vector(arraySeq: _*)
+        assertEquals(arraySeq, ArraySeq(d1)) // ensure arraySeq is not mutated
+        assertEquals(vector.updated(0, d2), Vector(d2))
+      }
+
+      locally {
+        val list = List(d1)
+        val vector = Vector.from(list)
+        assertEquals(list, vector)
+        assertEquals(List(d2), vector.updated(0, d2))
+      }
+    }
+
+    locally {
+      // ensure boxing logic works:
+      val arraySeq = ArraySeq(1,2,3,4,5)
+      val vector = Vector(arraySeq: _*)
+
+      assertEquals(1 to 5, vector)
+      assertEquals(vector.updated(0, 20), Vector(20,2,3,4,5))
+      assertEquals(vector.updated(0, ""), Vector("",2,3,4,5))
+      assertEquals(1 to 5, arraySeq) // ensure arraySeq is not mutated
+    }
+    locally {
+      // ensure boxing logic works:
+      val arr = Array(1)
+      val vector = Vector.from(arr)
+      assertEquals(arr.toList, vector)
+      assertEquals(List(20), vector.updated(0, 20))
+      assertEquals(List(""), vector.updated(0, ""))
+    }
+  }
 }


### PR DESCRIPTION
Closes scala/bug#11600
Fixes scala/bug#11600

There were issues with reusing the ArraySeq unsafeArray which arose in
subsequent calls to Vector#updated which would then clone underlying
arrays, and insert into them the new updated element. However the
underlying array.clone() would return a new array with the same
componentType as the passed varargs, rather than an Array[AnyRef] which
is required in the general case.