### PR TITLE
[#11589]s.c.Map#values returns a strict Iterable rather than a View

### DIFF
--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -181,7 +181,10 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
     *
     *  @return the values of this map as an iterable.
     */
-  def values: Iterable[V] = View.fromIteratorProvider(() => valuesIterator)
+  def values: Iterable[V] = new AbstractIterable[V] with DefaultSerializable {
+    override def knownSize: Int = MapOps.this.knownSize
+    override def iterator: Iterator[V] = valuesIterator
+  }
 
   /** Creates an iterator for all keys.
     *

--- a/test/junit/scala/collection/MapTest.scala
+++ b/test/junit/scala/collection/MapTest.scala
@@ -65,4 +65,61 @@ class MapTest {
     val m4 = m.flatMap(_ => Some(3))
     (m4: Iterable[Int]).head
   }
+
+  @Test
+  def t11589(): Unit = {
+    // tests the strictness of Map#values
+
+    def check(m: collection.Map[Int, Int]): Unit = {
+      def checkImmutable[K, V](m: immutable.Map[Int, Int]): Unit = {
+        var i = 0
+        m.withDefault(_ => -1).values.map{v => i = 1; v}
+        assertEquals(1, i)
+        i = 0
+        m.withDefaultValue(-1).values.map{v => i = 1; v}
+        assertEquals(1, i)
+      }
+      var i = 0
+      m.values.map{v => i = 1; v}
+      assertEquals(1, i)
+
+      m match {
+        case im: immutable.Map[Int, Int] =>
+          checkImmutable(im)
+        case _ =>
+          ()
+      }
+    }
+
+
+
+    check(collection.Map(1 -> 1))
+    check(immutable.Map(1 -> 1))
+    check(mutable.Map(1 -> 1))
+
+    check(collection.SortedMap(1 -> 1))
+    check(immutable.SortedMap(1 -> 1))
+    check(mutable.SortedMap(1 -> 1))
+
+    check(immutable.HashMap(1 -> 1))
+    check(mutable.HashMap(1 -> 1))
+
+    check(immutable.TreeMap(1 -> 1))
+    check(mutable.TreeMap(1 -> 1))
+
+    check(immutable.SeqMap(1 -> 1))
+    check(mutable.SeqMap(1 -> 1))
+
+    check(immutable.ListMap(1 -> 1))
+    check(mutable.ListMap(1 -> 1))
+
+    check(immutable.VectorMap(1 -> 1))
+    check(immutable.TreeSeqMap(1 -> 1))
+
+    check(mutable.LinkedHashMap(1 -> 1))
+
+    check(mutable.OpenHashMap(1 -> 1))
+    check(mutable.CollisionProofHashMap(1 -> 1))
+  }
+
 }


### PR DESCRIPTION
Fixes scala/bug#11589
Closes scala/bug#11589