### PR TITLE
Reject incomplete implicit dictionaries

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -351,7 +351,8 @@ trait Contexts { self: Analyzer =>
         }
 
         val pruned = prune(List(result.tree), implicitDictionary.map(_._2), Nil)
-        if(pruned.isEmpty) result
+        if (pruned.isEmpty) result
+        else if (pruned.exists(_._2 == EmptyTree)) SearchFailure
         else {
           val pos = result.tree.pos
           val (dictClassSym, dictClass0) = {

--- a/test/files/neg/t11591.check
+++ b/test/files/neg/t11591.check
@@ -1,0 +1,4 @@
+t11591.scala:8: error: could not find implicit value for parameter e: Test.A
+  implicitly[A]
+            ^
+one error found

--- a/test/files/neg/t11591.scala
+++ b/test/files/neg/t11591.scala
@@ -1,0 +1,9 @@
+object Test {
+  class A
+  class B
+
+  implicit def mkA(implicit b: => B): A = ???
+  implicit def mkB(implicit a: A, i: Int): B = ???
+
+  implicitly[A]
+}


### PR DESCRIPTION
If any RHS of a recursive implicit dictionary (after pruning) is an `EmptyTree`, then this indicates that implicit search failed and we should report the overall search as a failure.

Fixes scala/bug#11591.