### PR TITLE
optimize immutable.TreeSet#{max, min}

### DIFF
--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -68,6 +68,22 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
   override def tail = new TreeSet(RB.delete(tree, firstKey))
   override def init = new TreeSet(RB.delete(tree, lastKey))
 
+  override def min[A1 >: A](implicit ord: Ordering[A1]): A = {
+    if ((ord eq ordering) && nonEmpty) {
+      head
+    } else {
+      super.min(ord)
+    }
+  }
+
+  override def max[A1 >: A](implicit ord: Ordering[A1]): A = {
+    if ((ord eq ordering) && nonEmpty) {
+      last
+    } else {
+      super.max(ord)
+    }
+  }
+
   override def drop(n: Int) = {
     if (n <= 0) this
     else if (n >= size) empty

--- a/test/junit/scala/collection/immutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSetTest.scala
@@ -17,4 +17,32 @@ class TreeSetTest {
     assertEquals(set, set drop Int.MinValue)
     assertEquals(set, set dropRight Int.MinValue)
   }
+
+  @Test
+  def min(): Unit = {
+    assertEquals(1, TreeSet(1, 2, 3).min)
+    assertEquals(3, TreeSet(1, 2, 3).min(implicitly[Ordering[Int]].reverse))
+
+    try {
+      TreeSet.empty[Int].min
+      fail("expect UnsupportedOperationException")
+    } catch {
+      case e: UnsupportedOperationException =>
+        assertEquals("empty.min", e.getMessage)
+    }
+  }
+
+  @Test
+  def max(): Unit = {
+    assertEquals(3, TreeSet(1, 2, 3).max)
+    assertEquals(1, TreeSet(1, 2, 3).max(implicitly[Ordering[Int]].reverse))
+
+    try {
+      TreeSet.empty[Int].max
+      fail("expect UnsupportedOperationException")
+    } catch {
+      case e: UnsupportedOperationException =>
+        assertEquals("empty.max", e.getMessage)
+    }
+  }
 }


### PR DESCRIPTION
fix https://github.com/scala/bug/issues/11598