### PR TITLE
Fix "cannot be represented as URI" in JDK 13

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
@@ -216,7 +216,7 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with No
     if (inPackage == "") ClassPathEntries(packages(inPackage), Nil)
     else ClassPathEntries(packages(inPackage), classes(inPackage))
 
-  def asURLs: Seq[URL] = Seq(dir.toUri.toURL)
+  def asURLs: Seq[URL] = Seq(new URL("jrt:/"))
   // We don't yet have a scheme to represent the JDK modules in our `-classpath`.
   // java models them as entries in the new "module path", we'll probably need to follow this.
   def asClassPathStrings: Seq[String] = Nil


### PR DESCRIPTION
This change in the JDK:

https://github.com/openjdk/jdk/commit/ac6c642cf4fe243d88c2b762502860fdd41676f4#diff-e9881878ce74700a8063f67f65ec0657

Led us to the "cannot be represented as URI" exception.

This commit just hard-codes jrt:/ as the URI

fixes scala/bug#11608