### PR TITLE
[11630] Iterator#flatMap#hasNext calls outer#hasNext 1 time, not 2-3 times

### DIFF
--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -1,4 +1,3 @@
-
 package scala.collection
 
 import org.junit.Assert._
@@ -610,5 +609,94 @@ class IteratorTest {
       .take(3)
       .foreach(_ => ())
     assertEquals(3, i)
+  }
+
+  @Test
+  def flatMap(): Unit = {
+    def check[T](mkIterator: () => Iterator[T], expected: Array[T]): Unit = {
+      // tests that the iterator produces the expected array of elems, when alternating hasNext/next() calls
+      // then continues to be empty after repeated calls to hasNext/next after exhausted
+      // additional variants are included, where we:
+      // * avoid calls to hasNext, in this case `next()` should still work as expected
+      // * avoid calls to hasNext in the post-exhaustion check -- next() should still throw each time
+      // * avoid calls to next() in the post-exhaustion check -- hasNext should still return `false` each time
+      locally {
+        val iter = mkIterator()
+        var i = 0
+        while (i < expected.length) {
+          assert(iter.hasNext)
+          assertEquals(expected(i), iter.next())
+          i += 1
+        }
+        i = 0
+        while (i < 10) {
+          assertThrows[Exception](iter.next())
+          assert(!iter.hasNext)
+          i += 1
+        }
+      }
+      locally {
+        val iter = mkIterator()
+        var i = 0
+        while (i < expected.length) {
+          assertEquals(expected(i), iter.next())
+          i += 1
+        }
+        i = 0
+        while (i < 10) {
+          assertThrows[Exception](iter.next())
+          assert(!iter.hasNext)
+          i += 1
+        }
+      }
+      locally {
+        val iter = mkIterator()
+        var i = 0
+        while (i < expected.length) {
+          assertEquals(expected(i), iter.next())
+          i += 1
+        }
+        i = 0
+        while (i < 10) {
+          assertThrows[Exception](iter.next())
+          i += 1
+        }
+      }
+      locally {
+        val iter = mkIterator()
+        var i = 0
+        while (i < expected.length) {
+          assertEquals(expected(i), iter.next())
+          i += 1
+        }
+        i = 0
+        while (i < 10) {
+          i += 1
+          assert(!iter.hasNext)
+        }
+      }
+    }
+
+    check(() => Iterator.empty[Int].flatMap(_ => Iterator.empty[Int]), Array())
+    check(() => Iterator.empty[Int].flatMap(_ => 1 to 10), Array())
+    check(() => Iterator(1).flatMap(i => List(i + 1, i + 2)), Array(2, 3))
+    check(() => Iterator(1).flatMap(i => List(i + 1, i + 2)), Array(2, 3))
+
+    check(() => (0 to 100 by 10).iterator.flatMap(i => i to (i + 9)), (0 to 109).toArray)
+
+
+    check(() => Iterator.from(1 to 10).flatMap {
+      case 1 => Nil
+      case 2 => List(1,2,3)
+      case 3 => Nil
+      case 4 => List(4)
+      case 5 => List(5,6,7,8,9)
+      case 6 => List(10)
+      case 7 => List(11,12,13,14,15)
+      case 8 => Nil
+      case 9 => Nil
+      case 10 => Nil
+      case _ => Nil
+    }, Array.from(1 to 15))
   }
 }


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11630

When doing two calls in succession to `Iterator#flatMap`:
```scala
it.hasNext()
it.next()
```

the status quo is to have the flatmapped iterator call the sub-iterator's `hasNext` 3 times:
* once during the "advance to next non-empty sub-iterator, if required, and return it" phase
* a second time, to return that now-current sub-iterator's `hasNext` to the outside caller
* a third time, when calling `next()`

This PR replaces that logic with a system where these 3 calls are replaced with a single call during the `it.hasNext` phase, which is achieved by caching the state of the iterator in a new private field `_hasNext: Int` which can either be:
* `0` = known to be false (hasNext is known to be false)
* `1` = known to be true (hasNext is known to be true true)
* `-1` = unknown (not known if hasNext would be true or false)

The resulting state of the iterator  after a `hasNext` call is either `0` or `1`. After a call to `next()` we won't know if we have exhausted the entire iterator or not, since we are not forcing any more work to be done, so we set our state to `-1`.

This partially was a port of the old 2.12 implementation, but that implementation still required 2 calls to `cur.hasNext`, whereas this PR represents the additional improvement to only call `cur.hasNext` once during a `hasNext(); next();` call sequence. 

## TODO

- [x] Write some unit tests