### PR TITLE
[backport] Fixes Issue 493, to avoid unnecessary allocation.

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
@@ -22,7 +22,7 @@ trait FindMembers {
 
   /** Implementation of `Type#{findMember, findMembers}` */
   private[internal] abstract class FindMemberBase[T](tpe: Type, name: Name, excludedFlags: Long, requiredFlags: Long) {
-    protected val initBaseClasses: List[Symbol] = tpe.baseClasses
+    protected[this] final val initBaseClasses: List[Symbol] = tpe.baseClasses
 
     // The first base class, or the symbol of the ThisType
     // e.g in:
@@ -81,9 +81,9 @@ trait FindMembers {
       // Have we seen a candidate deferred member?
       var deferredSeen = false
 
-      // All direct parents of refinement classes in the base class sequence
+      // All refinement classes in the base class sequence
       // from the current `walkBaseClasses`
-      var refinementParents: List[Symbol] = Nil
+      var refinementClasses: List[Symbol] = Nil
 
       // Has the current `walkBaseClasses` encountered a non-refinement class?
       var seenFirstNonRefinementClass = false
@@ -101,7 +101,7 @@ trait FindMembers {
           if (meetsRequirements) {
             val excl: Long = flags & excluded
             val isExcluded: Boolean = excl != 0L
-            if (!isExcluded && isPotentialMember(sym, flags, currentBaseClass, seenFirstNonRefinementClass, refinementParents)) {
+            if (!isExcluded && isPotentialMember(sym, flags, currentBaseClass, seenFirstNonRefinementClass, refinementClasses)) {
               if (shortCircuit(sym)) return false
               else addMemberIfNew(sym)
             } else if (excl == DEFERRED) {
@@ -118,7 +118,7 @@ trait FindMembers {
           //           the component types T1, ..., Tn and the refinement {R }
           //
           //           => private members should be included from T1, ... Tn. (scala/bug#7475)
-          refinementParents :::= currentBaseClass.parentSymbols
+          refinementClasses ::= currentBaseClass
         else if (currentBaseClass.isClass)
           seenFirstNonRefinementClass = true // only inherit privates of refinement parents after this point
 
@@ -138,23 +138,22 @@ trait FindMembers {
     // Q. When does a potential member fail to be an actual member?
     // A. if it is subsumed by an member in a subclass.
     private def isPotentialMember(sym: Symbol, flags: Long, owner: Symbol,
-                                  seenFirstNonRefinementClass: Boolean, refinementParents: List[Symbol]): Boolean = {
+                                  seenFirstNonRefinementClass: Boolean, refinementClasses: List[Symbol]): Boolean = {
       // conservatively (performance wise) doing this with flags masks rather than `sym.isPrivate`
       // to avoid multiple calls to `Symbol#flags`.
       val isPrivate      = (flags & PRIVATE) == PRIVATE
       val isPrivateLocal = (flags & PrivateLocal) == PrivateLocal
 
       // TODO Is the special handling of `private[this]` vs `private` backed up by the spec?
-      def admitPrivate(sym: Symbol): Boolean =
-        (selectorClass == owner) || (
-             !isPrivateLocal // private[this] only a member from within the selector class. (Optimization only? Does the spec back this up?)
-          && (
-                  !seenFirstNonRefinementClass
-               || refinementParents.contains(owner)
-             )
+      def admitPrivate: Boolean =
+          // private[this] only a member from within the selector class.
+          // (Optimization only? Does the spec back this up?)
+        !isPrivateLocal && ( !seenFirstNonRefinementClass ||
+          refinementClasses.exists(_.info.parents.exists(_.typeSymbol == owner))
         )
 
-      (!isPrivate || admitPrivate(sym)) && (sym.name != nme.CONSTRUCTOR || owner == initBaseClasses.head)
+      (sym.name != nme.CONSTRUCTOR || owner == initBaseClasses.head) &&
+        (!isPrivate || owner == selectorClass || admitPrivate)
     }
 
     // True unless the already-found member of type `memberType` matches the candidate symbol `other`.


### PR DESCRIPTION
This commit avoids unnecessary memory use noticed
in Issue 493 of https://github.com/scala/scala-dev.

The line: `refinementParents :::= currentBaseClass.parentSymbols`
in each iteration pre-prends `currentBaseClass.parentSymbols` to the
previous `refinementParens`. Thus, at the end of the loop,
the length of `refinementParens` is the sum of the `parentSymbols`
lists obtained from each symbol in `initBaseClasses` which is a
refinement classes. That creates as many cons (`::`) objects.
Moreover, since `parentSymbols` is not a `val` but a `def`, it creates
a list of length `m`, copies it (to prepend it) and the throws it away.

To prevent these allocations, we replace the flattened
`refinedParents` list by a `refinedClasses` list, which
stores the classes whose parents we have not yet looked into.
We just use the `exists` methods of the List class to look for a
refinedClass with at least one parent is the currentBaseClass.

(cherry picked from commit 0db7dd4e251ec7be75f6f8178977faae9c8274e9)