### PR TITLE
Tweak URI creation in RootPath for better windows support

### DIFF
--- a/src/reflect/scala/reflect/io/RootPath.scala
+++ b/src/reflect/scala/reflect/io/RootPath.scala
@@ -14,7 +14,10 @@ package scala.reflect.io
 
 import java.io.Closeable
 import java.nio
-import java.nio.file.{FileSystems, Files}
+import java.nio.file.Files
+import java.nio.file.spi.FileSystemProvider
+
+import scala.collection.JavaConverters.collectionAsScalaIterableConverter
 
 
 abstract class RootPath extends Closeable {
@@ -22,10 +25,9 @@ abstract class RootPath extends Closeable {
 }
 
 object RootPath {
+  private lazy val jarFsProvider = FileSystemProvider.installedProviders().asScala.find(_.getScheme == "jar").getOrElse(throw new RuntimeException("No jar filesystem provider"))
   def apply(path: nio.file.Path, writable: Boolean): RootPath = {
     if (path.getFileName.toString.endsWith(".jar")) {
-      import java.net.URI
-      val zipFile = URI.create("jar:file:" + path.toUri.getPath)
       val env = new java.util.HashMap[String, String]()
       if (!Files.exists(path.getParent))
         Files.createDirectories(path.getParent)
@@ -34,7 +36,8 @@ object RootPath {
         if (Files.exists(path))
           Files.delete(path)
       }
-      val zipfs = FileSystems.newFileSystem(zipFile, env)
+      val zipfs = jarFsProvider.newFileSystem(path, env)
+
       new RootPath {
         def root = zipfs.getRootDirectories.iterator().next()
         def close(): Unit = {


### PR DESCRIPTION
The `getPath` I used was incomplete, it doesn't include the server
name on windows UNC paths (\\servername\a\b)

I could have tried the `toString` or `toAsciiString`, but after
reading about pitfalls in:

   https://stackoverflow.com/questions/9873845/java-7-zip-file-system-provider-doesnt-seem-to-accept-spaces-in-uri

I opted instead to just find the relevent FileSystemProvider
and use the Path itself.