### PR TITLE
Fixes Non-Iterators have iterator reuse warnings in scaladoc#11595

### DIFF
--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -290,16 +290,6 @@ object IterableOnce {
   * @define consumesIterator
   *              After calling this method, one should discard the iterator it was called
   * on. Using it is undefined and subject to change.
-  * @define consumesAndProducesIterator
-  *              After calling this method, one should discard the iterator it was called
-  *              on, and use only the iterator that was returned. Using the old iterator
-  *              is undefined, subject to change, and may result in changes to the new
-  *              iterator as well.
-  * @define consumesOneAndProducesTwoIterators
-  *              After calling this method, one should discard the iterator it was called
-  *              on, and use only the iterators that were returned. Using the old iterator
-  *              is undefined, subject to change, and may result in changes to the new
-  *              iterators as well.
   * @define undefinedorder
   *              The order in which operations are performed on elements is unspecified
   *              and may be nondeterministic.
@@ -319,7 +309,6 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *  @param z       the initial value
     *  @param op      the binary operator applied to the intermediate result and the element
     *  @return        collection with intermediate results
-    *  @note          Reuse: $consumesAndProducesIterator
     */
   def scanLeft[B](z: B)(op: (B, A) => B): CC[B]
 
@@ -345,7 +334,6 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *  @return a $coll consisting only of the first `n` elements of this $coll,
     *          or else the whole $coll, if it has less than `n` elements.
     *          If `n` is negative, returns an empty $coll.
-    *  @note    Reuse: $consumesAndProducesIterator
     */
   def take(n: Int): C
 
@@ -354,7 +342,6 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *  @param   p  The predicate used to test elements.
     *  @return  the longest prefix of this $coll whose elements all satisfy
     *           the predicate `p`.
-    *  @note    Reuse: $consumesAndProducesIterator
     */
   def takeWhile(p: A => Boolean): C
 
@@ -364,7 +351,6 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *  @return a $coll consisting of all elements of this $coll except the first `n` ones, or else the
     *          empty $coll, if this $coll has less than `n` elements.
     *          If `n` is negative, don't drop any elements.
-    *  @note    Reuse: $consumesAndProducesIterator
     */
   def drop(n: Int): C
 
@@ -373,7 +359,6 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *  @param   p  The predicate used to test elements.
     *  @return  the longest suffix of this $coll whose first element
     *           does not satisfy the predicate `p`.
-    *  @note    Reuse: $consumesAndProducesIterator
     */
   def dropWhile(p: A => Boolean): C
 
@@ -389,7 +374,6 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *  @return  a $coll containing the elements greater than or equal to
     *           index `from` extending up to (but not including) index `until`
     *           of this $coll.
-    *  @note    Reuse: $consumesAndProducesIterator
     */
   def slice(from: Int, until: Int): C
 
@@ -399,7 +383,6 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *  @tparam B     the element type of the returned $coll.
     *  @return       a new $coll resulting from applying the given function
     *                `f` to each element of this $coll and collecting the results.
-    *  @note    Reuse: $consumesAndProducesIterator
     */
   def map[B](f: A => B): CC[B]
 
@@ -433,7 +416,6 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *  @tparam B     the element type of the returned collection.
     *  @return       a new $coll resulting from applying the given collection-valued function
     *                `f` to each element of this $coll and concatenating the results.
-    *  @note    Reuse: $consumesAndProducesIterator
     */
   def flatMap[B](f: A => IterableOnce[B]): CC[B]
 
@@ -462,7 +444,6 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *  @param asIterable an implicit conversion which asserts that the element
     *          type of this $coll is a `GenTraversable`.
     *  @return a new $coll resulting from concatenating all element ${coll}s.
-    *  @note    Reuse: $consumesAndProducesIterator
     */
   def flatten[B](implicit asIterable: A => IterableOnce[B]): CC[B]
 
@@ -474,7 +455,6 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *  @return       a new $coll resulting from applying the given partial function
     *                `pf` to each element on which it is defined and collecting the results.
     *                The order of the elements is preserved.
-    *  @note    Reuse: $consumesAndProducesIterator
     */
   def collect[B](pf: PartialFunction[A, B]): CC[B]
 
@@ -484,7 +464,6 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *                 Indices start at `0`.
     *  @example
     *    `List("a", "b", "c").zipWithIndex == List(("a", 0), ("b", 1), ("c", 2))`
-    *  @note    Reuse: $consumesAndProducesIterator
     */
   def zipWithIndex: CC[(A @uncheckedVariance, Int)]
 
@@ -498,7 +477,6 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *  @param p the test predicate
     *  @return  a pair consisting of the longest prefix of this $coll whose
     *           elements all satisfy `p`, and the rest of this $coll.
-    *  @note    Reuse: $consumesOneAndProducesTwoIterators
     */
   def span(p: A => Boolean): (C, C)
 
@@ -511,7 +489,6 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    *  @param n the position at which to split.
    *  @return  a pair of ${coll}s consisting of the first `n`
    *           elements of this $coll, and the other elements.
-   *  @note    Reuse: $consumesOneAndProducesTwoIterators
    */
   def splitAt(n: Int): (C, C) = {
     var i = 0

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -633,6 +633,11 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
       else Iterator.empty.next()
   }
 
+  /**
+    * @inheritdoc
+    *
+    * @note    Reuse: $consumesOneAndProducesTwoIterators
+    */
   def span(p: A => Boolean): (Iterator[A], Iterator[A]) = {
     /*
      * Giving a name to following iterator (as opposed to trailing) because


### PR DESCRIPTION
detail : https://github.com/scala/bug/issues/11595
just remove `@note` annotation in IterableOnce.scala