### PR TITLE
Optimize check for by-name expressions

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -130,6 +130,7 @@ abstract class UnCurry extends InfoTransform
     def isByNameRef(tree: Tree) = (
          tree.isTerm
       && (tree.symbol ne null)
+      && !(tree.symbol.hasPackageFlag || tree.isInstanceOf[This] || tree.isInstanceOf[Super])
       && isByName(tree.symbol)
       && !byNameArgs(tree)
     )


### PR DESCRIPTION
Rule out some cases by the type of tree / flags before
looking at the symbol's info.