### PR TITLE
Fix doc for ArrayDeque

### DIFF
--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -20,7 +20,8 @@ import scala.collection.Stepper.EfficientSplit
 import scala.collection.generic.DefaultSerializable
 import scala.reflect.ClassTag
 
-/** An implementation of a double-ended queue that internally uses a resizable circular buffer
+/** An implementation of a double-ended queue that internally uses a resizable circular buffer.
+  *
   *  Append, prepend, removeFirst, removeLast and random-access (indexed-lookup and indexed-replacement)
   *  take amortized constant time. In general, removals and insertions at i-th index are O(min(i, n-i))
   *  and thus insertions and removals from end/beginning are fast.


### PR DESCRIPTION
Changes to punctuation and whitespace in first line.

See https://www.scala-lang.org/api/2.13.0/scala/collection/mutable/ArrayDeque.html