### PR TITLE
Ensure that DelayedInit fields are non-final

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -760,8 +760,14 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
       * particulars.
       */
       val (delayedHookDefs, remainingConstrStatsDelayedInit) =
-        if (isDelayedInitSubclass && remainingConstrStats.nonEmpty) delayedInitDefsAndConstrStats(defs, remainingConstrStats)
-        else (Nil, remainingConstrStats)
+        if (isDelayedInitSubclass && remainingConstrStats.nonEmpty) {
+          remainingConstrStats foreach {
+            case Assign(lhs, _ ) => lhs.symbol.setFlag(MUTABLE) // delayed init fields cannot be final, scala/bug#11412
+            case _ =>
+          }
+          delayedInitDefsAndConstrStats(defs, remainingConstrStats)
+        } else
+          (Nil, remainingConstrStats)
 
       // Assemble final constructor
       val primaryConstructor = deriveDefDef(primaryConstr)(_ => {


### PR DESCRIPTION
Usually fields inside of a class or object body are initialized in an
initializer block, which is the correct way to initialize final fields,
but when they occur in a `DelayedInit` body, the initialization code is
put into a method instead. This is illegal according to
https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html#jls-8.3.1.2.
The fix is to emit these fields as non-final.

Fixes https://github.com/scala/bug/issues/11412