### PR TITLE
Construct Vector without an invalid internal state

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -496,7 +496,7 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
           if (shift != 0) {
             if (depth > 1) {
               val newBlockIndex = blockIndex - shift
-              val newFocus = focus - shift
+              val newFocus = math.abs(focus - shift)
 
               val s = new Vector(startIndex - shift, endIndex + 1 - shift, newBlockIndex)
               s.initFrom(this)

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -219,4 +219,18 @@ class VectorTest {
       assertArrayEquals(s"<${v2.length}>.slice($j, $k)", v2.toArray.slice(j, k), v2.iterator.slice(j, k).toArray)
     }
   }
+
+  @Test
+  def vectorAdd(): Unit = {
+    val a = "O" +: Iterator.continually("E").take(2101).foldLeft(Vector.empty[String])((v, e) => v :+ e) :+ "C"
+    val b = "O" +: Iterator.continually("E").take(223) .foldLeft(Vector.empty[String])((v, e) => v :+ e) :+ "C"
+    val c = "O" +: Iterator.continually("E").take(135) .foldLeft(Vector.empty[String])((v, e) => v :+ e) :+ "C"
+    val d = "O" +: Iterator.continually("E").take(0)   .foldLeft(Vector.empty[String])((v, e) => v :+ e) :+ "C"
+    val e = "O" +: Iterator.continually("E").take(376) .foldLeft(Vector.empty[String])((v, e) => v :+ e) :+ "C"
+    val f = "O" +: Iterator.continually("E").take(365) .foldLeft(Vector.empty[String])((v, e) => v :+ e) :+ "C"
+
+    val v = a ++ b ++ c ++ d ++ e ++ f
+
+    assertEquals( 3212,v.map(_ => 0).size)
+  }
 }


### PR DESCRIPTION
when i debug vector's add behavior, i found out the reason why scala throw NPE is because the value of variable `newFocus` is negative. So accordingly, the code judges its depth is 0(the actual depth should be 2), which lead to a incorrect start position.
```scala
    //Vector.scala method appended() line 501
    val s = new Vector(startIndex - shift, endIndex + 1 - shift, newBlockIndex)
    s.initFrom(this)
    s.dirty = dirty
    s.shiftTopLevel(shiftBlocks, 0) // shift left by n blocks
    //which result this problem
    s.gotoFreshPosWritable(newFocus, newBlockIndex, newFocus ^ newBlockIndex)
    s.display0(lo) = value.asInstanceOf[AnyRef]
```
Thus i think the value of `newFocus` should be positive all the time, we only need to pay attention to its absolute value

Fixes scala/bug#11636