### PR TITLE
Fix generateDocsData 

### DIFF
--- a/project/GenerateDocsData.scala
+++ b/project/GenerateDocsData.scala
@@ -105,12 +105,15 @@ class SettingsDescriptor extends SettingsDescriptorModel {
     }
     val sb = new StringBuilder
     var indent = 0
+    def escape(text: String): String = {
+      text.replaceAllLiterally("\"", "\\\"").replaceAllLiterally("\\u ", "\\\\u ")
+    }
     def element(tag: String, value: String = "", head: Boolean = false): Unit = {
       sb.append("  " * indent).append(if (head) "- " else "  ")
       if (tag.nonEmpty) sb.append(tag).append(":")
       if (value.nonEmpty) {
         if (tag.nonEmpty) sb.append(" ")
-        sb.append("\"").append(value).append("\"")
+        sb.append("\"").append(escape(value)).append("\"")
       }
       sb.append("\n")
     }

--- a/project/GenerateDocsData.scala
+++ b/project/GenerateDocsData.scala
@@ -138,8 +138,9 @@ class SettingsDescriptor extends SettingsDescriptorModel {
               maybe("multiple", multiple)
               maybe("default", default)
               maybes("choices", choices,
-                (c: Choice) => element("choice", c.choice, head = true),
-                (c: Choice) => maybe("description", c.description))
+                (c: Choice) => indented(element("choice", c.choice, head = true)),
+                (c: Choice) => indented(maybe("description", c.description))
+              )
               maybe("min", min)
               maybe("max", max)
             }


### PR DESCRIPTION
The sbt command `generateDocsData` generates the YAML file for [Scala Compiler Options](https://docs.scala-lang.org/overviews/compiler-options/index.html) page.
However, it produces broken YAML that cannot generate the page.

This PR fixes
* Wrong indentation in `choices` properties.
* Some unescaped chars `\u` and `"` in string

Related https://github.com/scala/docs.scala-lang/pull/1442