### PR TITLE
Fix compiler crash: don't access typeSymbol.typeConstructor

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1721,7 +1721,7 @@ trait Types
           val varToParam = new TypeMap {
             def apply(tp: Type) = tp match {
               case tv: TypeVar => // Applying a type constructor variable to arguments results in a new instance of AppliedTypeVar each time
-                val toOrigin = appliedType(tv.origin.typeSymbol.typeConstructor, tv.typeArgs.mapConserve(this))
+                val toOrigin = appliedType(tv.origin.typeConstructor, tv.typeArgs.mapConserve(this))
                 tvarFor(toOrigin) = tv
                 toOrigin
               case _ => tp.mapOver(this)

--- a/test/files/pos/t11579.scala
+++ b/test/files/pos/t11579.scala
@@ -1,0 +1,13 @@
+import scala.collection.generic.IsIterable
+import scala.language.implicitConversions
+
+object Test {
+  class Ops[I] {
+    def method: Unit = ()
+  }
+
+  implicit def ToOps[Repr, L, R](aCol: Repr)(implicit isIterable: IsIterable[Repr]{type A = (L, R)}): Ops[isIterable.type] =
+    new Ops[isIterable.type]
+
+  List(1 -> 2).method
+}


### PR DESCRIPTION
The `origin` of a `TypeVar` could be a `WildcardType`.
Such type variables are created by `wildcardToTypeVarMap`.
The `typeSymbol` of `WildcardType` is `NoSymbol`.
Accessing `NoSymbol.typeConstructor` aborts the compiler.

Fixes scala/bug#11579
Regressed in #7376

I hope this is the right fix