### PR TITLE
Optimize writing of InlineInfoAttribute

### DIFF
--- a/src/compiler/scala/tools/nsc/PickleExtractor.scala
+++ b/src/compiler/scala/tools/nsc/PickleExtractor.scala
@@ -46,12 +46,19 @@ object PickleExtractor {
         }
         override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
           if (file.getFileName.toString.endsWith(".class")) {
-            stripClassFile(Files.readAllBytes(file)) match {
-              case Class(out) =>
-                Files.write(outputPath.root.resolve(root.relativize(file).toString), out)
-              case Pickle(out) =>
-                Files.write(outputPath.root.resolve(root.relativize(file).toString.replaceAll(".class$", ".sig")), out)
-              case Skip =>
+            try {
+              stripClassFile(Files.readAllBytes(file)) match {
+                case Class(out) =>
+                  Files.write(outputPath.root.resolve(root.relativize(file).toString), out)
+                case Pickle(out) =>
+                  Files.write(outputPath.root.resolve(root.relativize(file).toString.replaceAll(".class$", ".sig")), out)
+                case Skip =>
+              }
+            } catch {
+              case ex: RuntimeException =>
+                throw new RuntimeException("While parsing: " + file +  " in " + inputPath
+                  , ex)
+
             }
           }
           FileVisitResult.CONTINUE

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -1110,8 +1110,15 @@ object BTypes {
    */
   final case class InlineInfo(isEffectivelyFinal: Boolean,
                               sam: Option[String],
-                              methodInfos: Map[String, MethodInlineInfo],
-                              warning: Option[ClassInlineInfoWarning])
+                              methodInfos: Map[(String, String), MethodInlineInfo],
+                              warning: Option[ClassInlineInfoWarning]) {
+    lazy val methodInfosSorted: IndexedSeq[((String, String), MethodInlineInfo)] = {
+      val result = new Array[((String, String), MethodInlineInfo)](methodInfos.size)
+      methodInfos.copyToArray(result)
+      scala.util.Sorting.quickSort(result)(Ordering.by(_._1))
+      result
+    }
+  }
 
   val EmptyInlineInfo = InlineInfo(false, None, Map.empty, None)
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
@@ -155,12 +155,12 @@ abstract class BTypesFromClassfile {
       // require special handling. Excluding is OK because they are never inlined.
       // Here we are parsing from a classfile and we don't need to do anything special. Many of these
       // primitives don't even exist, for example Any.isInstanceOf.
-      val methodInfos:Map[String,MethodInlineInfo] = classNode.methods.asScala.map(methodNode => {
+      val methodInfos:Map[(String, String),MethodInlineInfo] = classNode.methods.asScala.map(methodNode => {
         val info = MethodInlineInfo(
           effectivelyFinal                    = BytecodeUtils.isFinalMethod(methodNode),
           annotatedInline                     = false,
           annotatedNoInline                   = false)
-        (methodNode.name + methodNode.desc, info)
+        ((methodNode.name, methodNode.desc), info)
       })(scala.collection.breakOut)
       InlineInfo(
         isEffectivelyFinal = BytecodeUtils.isFinalClass(classNode),

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -576,8 +576,8 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
           warning = Some(ClassSymbolInfoFailureSI9111(classSym.fullName))
           Nil
         } else {
-          val name      = methodSym.javaSimpleName.toString // same as in genDefDef
-          val signature = name + methodBTypeFromSymbol(methodSym).descriptor
+          val name = methodSym.javaSimpleName.toString // same as in genDefDef
+          val signature = (name, methodBTypeFromSymbol(methodSym).descriptor)
 
           // In `trait T { object O }`, `oSym.isEffectivelyFinalOrNotOverridden` is true, but the
           // method is abstract in bytecode, `defDef.rhs.isEmpty`. Abstract methods are excluded
@@ -588,20 +588,20 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
           val effectivelyFinal = methodSym.isEffectivelyFinalOrNotOverridden && !(methodSym hasFlag DEFERRED | SYNTHESIZE_IMPL_IN_SUBCLASS)
 
           val info = MethodInlineInfo(
-            effectivelyFinal  = effectivelyFinal,
-            annotatedInline   = methodSym.hasAnnotation(ScalaInlineClass),
+            effectivelyFinal = effectivelyFinal,
+            annotatedInline = methodSym.hasAnnotation(ScalaInlineClass),
             annotatedNoInline = methodSym.hasAnnotation(ScalaNoInlineClass))
 
           if (needsStaticImplMethod(methodSym)) {
             val staticName = traitSuperAccessorName(methodSym).toString
             val selfParam = methodSym.newSyntheticValueParam(methodSym.owner.typeConstructor, nme.SELF)
             val staticMethodType = methodSym.info match {
-              case mt @ MethodType(params, res) => copyMethodType(mt, selfParam :: params, res)
+              case mt@MethodType(params, res) => copyMethodType(mt, selfParam :: params, res)
             }
-            val staticMethodSignature = staticName + methodBTypeFromMethodType(staticMethodType, isConstructor = false)
+            val staticMethodSignature = (staticName, methodBTypeFromMethodType(staticMethodType, isConstructor = false).descriptor)
             val staticMethodInfo = MethodInlineInfo(
-              effectivelyFinal  = true,
-              annotatedInline   = info.annotatedInline,
+              effectivelyFinal = true,
+              annotatedInline = info.annotatedInline,
               annotatedNoInline = info.annotatedNoInline)
             if (methodSym.isMixinConstructor)
               (staticMethodSignature, staticMethodInfo) :: Nil

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/CallGraph.scala
@@ -295,7 +295,7 @@ abstract class CallGraph {
    * Analyze a callsite and gather meta-data that can be used for inlining decisions.
    */
   private def analyzeCallsite(calleeMethodNode: MethodNode, calleeDeclarationClassBType: ClassBType, call: MethodInsnNode, calleeSourceFilePath: Option[String]): CallsiteInfo = {
-    val methodSignature = calleeMethodNode.name + calleeMethodNode.desc
+    val methodSignature = (calleeMethodNode.name, calleeMethodNode.desc)
 
     try {
       // The inlineInfo.methodInfos of a ClassBType holds an InlineInfo for each method *declared*

--- a/src/reflect/scala/reflect/io/RootPath.scala
+++ b/src/reflect/scala/reflect/io/RootPath.scala
@@ -43,11 +43,13 @@ object RootPath {
         def close(): Unit = {
           zipfs.close()
         }
+        override def toString: String = path.toString
       }
     } else {
       new RootPath {
         override def root: nio.file.Path = path
         override def close(): Unit = ()
+        override def toString: String = path.toString
       }
     }
   }

--- a/test/junit/scala/tools/nsc/PipelineMainTest.scala
+++ b/test/junit/scala/tools/nsc/PipelineMainTest.scala
@@ -240,7 +240,7 @@ class PipelineMainTest {
         this
       }
       def argsFile(extraOpts: List[String]): Path = {
-        val cp = if (classpath.isEmpty) Nil else List("-cp", classpath.mkString(File.pathSeparator))
+        val cp = List("-cp", if (classpath.isEmpty) "__DUMMY__" else classpath.mkString(File.pathSeparator)) // Dummy to avoid default classpath of "."
         val printArgs = if (debug) List("-Xprint-args", "-") else Nil
         val entries = List(
           Build.this.scalacOptions.toList,

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
@@ -67,9 +67,9 @@ class InlineInfoTest extends BytecodeTesting {
     compileClasses("class C { new A }", javaCode = List((jCode, "A.java")))
     val info = global.genBCode.bTypes.cachedClassBType("A").info.get.inlineInfo
     assertEquals(info.methodInfos, Map(
-      "bar()I"    -> MethodInlineInfo(true,false,false),
-      "<init>()V" -> MethodInlineInfo(false,false,false),
-      "baz()I"    -> MethodInlineInfo(true,false,false)))
+      ("bar", "()I")    -> MethodInlineInfo(true,false,false),
+      ("<init>", "()V") -> MethodInlineInfo(false,false,false),
+      ("baz", "()I")    -> MethodInlineInfo(true,false,false)))
   }
 
   @Test
@@ -88,7 +88,7 @@ class InlineInfoTest extends BytecodeTesting {
     // the classpath (classfile WatchEvent$Kind.class) instead of the actual companion from the source, so the static method was missing.
     val info = global.genBCode.bTypes.cachedClassBType("java/nio/file/WatchEvent$Kind").info.get.inlineInfo
     assertEquals(info.methodInfos, Map(
-      "HAI()Ljava/lang/String;" -> MethodInlineInfo(true,false,false),
-      "<init>()V"               -> MethodInlineInfo(false,false,false)))
+      ("HAI", "()Ljava/lang/String;") -> MethodInlineInfo(true,false,false),
+      ("<init>", "()V")               -> MethodInlineInfo(false,false,false)))
   }
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ScalaInlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ScalaInlineInfoTest.scala
@@ -83,63 +83,63 @@ class ScalaInlineInfoTest extends BytecodeTesting {
       false, // final class
       None, // not a sam
       Map(
-        ("O()LT$O$;",                                                 MethodInlineInfo(false,false,false)),
-        ("T$$super$toString()Ljava/lang/String;",                     MethodInlineInfo(true ,false,false)),
-        ("T$_setter_$x1_$eq(I)V",                                     MethodInlineInfo(false,false,false)),
-        ("f1()I",                                                     MethodInlineInfo(false,false,false)),
-        ("f1$(LT;)I",                                                  MethodInlineInfo(true ,false,false)),
-        ("f2()I",                                                     MethodInlineInfo(true ,false,false)), // no static impl method for private method f2
-        ("f3()I",                                                     MethodInlineInfo(false,false,false)),
-        ("f3$(LT;)I",                                                  MethodInlineInfo(true ,false,false)),
-        ("f4()Ljava/lang/String;",                                    MethodInlineInfo(false,true, false)),
-        ("f4$(LT;)Ljava/lang/String;",                                 MethodInlineInfo(true ,true, false)),
-        ("f5()I",                                                     MethodInlineInfo(true ,false,false)),
-        ("f5$(LT;)I",                                                  MethodInlineInfo(true ,false,false)),
-        ("f6()I",                                                     MethodInlineInfo(false,false,true )), // no static impl method for abstract method f6
-        ("x1()I",                                                     MethodInlineInfo(false,false,false)),
-        ("y2()I",                                                     MethodInlineInfo(false,false,false)),
-        ("y2_$eq(I)V",                                                MethodInlineInfo(false,false,false)),
-        ("x3()I",                                                     MethodInlineInfo(false,false,false)),
-        ("x3_$eq(I)V",                                                MethodInlineInfo(false,false,false)),
-        ("x4()I",                                                     MethodInlineInfo(false,false,false)),
-        ("x4$(LT;)I",                                                  MethodInlineInfo(true ,false,false)),
-        ("x5()I",                                                     MethodInlineInfo(true, false,false)),
-        ("x5$(LT;)I",                                                  MethodInlineInfo(true ,false,false)),
-        ("L$2(Lscala/runtime/LazyRef;)LT$L$1$;",                      MethodInlineInfo(true, false,false)),
-        ("nest$1()I",                                                 MethodInlineInfo(true, false,false)),
-        ("$init$(LT;)V",                                              MethodInlineInfo(true,false,false)),
-        ("L$lzycompute$1(Lscala/runtime/LazyRef;)LT$L$1$;",           MethodInlineInfo(true,false,false))
+        (("O", "()LT$O$;"),                                                 MethodInlineInfo(false,false,false)),
+        (("T$$super$toString", "()Ljava/lang/String;"),                     MethodInlineInfo(true ,false,false)),
+        (("T$_setter_$x1_$eq", "(I)V"),                                     MethodInlineInfo(false,false,false)),
+        (("f1", "()I"),                                                     MethodInlineInfo(false,false,false)),
+        (("f1$", "(LT;)I"),                                                 MethodInlineInfo(true ,false,false)),
+        (("f2", "()I"),                                                     MethodInlineInfo(true ,false,false)), // no static impl method for private method f2
+        (("f3", "()I"),                                                     MethodInlineInfo(false,false,false)),
+        (("f3$", "(LT;)I"),                                                 MethodInlineInfo(true ,false,false)),
+        (("f4", "()Ljava/lang/String;"),                                    MethodInlineInfo(false,true, false)),
+        (("f4$", "(LT;)Ljava/lang/String;"),                                MethodInlineInfo(true ,true, false)),
+        (("f5", "()I"),                                                     MethodInlineInfo(true ,false,false)),
+        (("f5$", "(LT;)I"),                                                 MethodInlineInfo(true ,false,false)),
+        (("f6", "()I"),                                                     MethodInlineInfo(false,false,true )), // no static impl method for abstract method f6
+        (("x1", "()I"),                                                     MethodInlineInfo(false,false,false)),
+        (("y2", "()I"),                                                     MethodInlineInfo(false,false,false)),
+        (("y2_$eq", "(I)V"),                                                MethodInlineInfo(false,false,false)),
+        (("x3", "()I"),                                                     MethodInlineInfo(false,false,false)),
+        (("x3_$eq", "(I)V"),                                                MethodInlineInfo(false,false,false)),
+        (("x4", "()I"),                                                     MethodInlineInfo(false,false,false)),
+        (("x4$", "(LT;)I"),                                                 MethodInlineInfo(true ,false,false)),
+        (("x5", "()I"),                                                     MethodInlineInfo(true, false,false)),
+        (("x5$", "(LT;)I"),                                                 MethodInlineInfo(true ,false,false)),
+        (("L$2", "(Lscala/runtime/LazyRef;)LT$L$1$;"),                      MethodInlineInfo(true, false,false)),
+        (("nest$1", "()I"),                                                 MethodInlineInfo(true, false,false)),
+        (("$init$", "(LT;)V"),                                              MethodInlineInfo(true,false,false)),
+        (("L$lzycompute$1", "(Lscala/runtime/LazyRef;)LT$L$1$;"),           MethodInlineInfo(true,false,false))
       ),
       None // warning
     )
 
     assert(infoT == expectT, mapDiff(expectT.methodInfos, infoT.methodInfos) + infoT)
-    assertSameMethods(t, expectT.methodInfos.keySet)
+    assertSameMethods(t, expectT.methodInfos.keySet.map(x => x._1 + x._2))
 
     val infoC = inlineInfo(c)
     val expectC = InlineInfo(false, None, Map(
-      "O()LT$O$;"                             -> MethodInlineInfo(true ,false,false),
-      "f1()I"                                 -> MethodInlineInfo(false,false,false),
-      "f3()I"                                 -> MethodInlineInfo(false,false,false),
-      "f4()Ljava/lang/String;"                -> MethodInlineInfo(false,true,false),
-      "f5()I"                                 -> MethodInlineInfo(true,false,false),
-      "f6()I"                                 -> MethodInlineInfo(false,false,false),
-      "x1()I"                                 -> MethodInlineInfo(false,false,false),
-      "T$_setter_$x1_$eq(I)V"                 -> MethodInlineInfo(false,false,false),
-      "y2()I"                                 -> MethodInlineInfo(false,false,false),
-      "y2_$eq(I)V"                            -> MethodInlineInfo(false,false,false),
-      "x3()I"                                 -> MethodInlineInfo(false,false,false),
-      "x3_$eq(I)V"                            -> MethodInlineInfo(false,false,false),
-      "x4$lzycompute()I"                      -> MethodInlineInfo(true ,false,false),
-      "x4()I"                                 -> MethodInlineInfo(false,false,false),
-      "T$$super$toString()Ljava/lang/String;" -> MethodInlineInfo(true ,false,false),
-      "<init>()V"                             -> MethodInlineInfo(false,false,false),
-      "O$lzycompute$1()V"                     -> MethodInlineInfo(true,false,false)
+      ("O", "()LT$O$;")                             -> MethodInlineInfo(true ,false,false),
+      ("f1", "()I")                                 -> MethodInlineInfo(false,false,false),
+      ("f3", "()I")                                 -> MethodInlineInfo(false,false,false),
+      ("f4", "()Ljava/lang/String;")                -> MethodInlineInfo(false,true,false),
+      ("f5", "()I")                                 -> MethodInlineInfo(true,false,false),
+      ("f6", "()I")                                 -> MethodInlineInfo(false,false,false),
+      ("x1", "()I")                                 -> MethodInlineInfo(false,false,false),
+      ("T$_setter_$x1_$eq", "(I)V")                 -> MethodInlineInfo(false,false,false),
+      ("y2", "()I")                                 -> MethodInlineInfo(false,false,false),
+      ("y2_$eq", "(I)V")                            -> MethodInlineInfo(false,false,false),
+      ("x3", "()I")                                 -> MethodInlineInfo(false,false,false),
+      ("x3_$eq", "(I)V")                            -> MethodInlineInfo(false,false,false),
+      ("x4$lzycompute", "()I")                      -> MethodInlineInfo(true ,false,false),
+      ("x4", "()I")                                 -> MethodInlineInfo(false,false,false),
+      ("T$$super$toString", "()Ljava/lang/String;") -> MethodInlineInfo(true ,false,false),
+      ("<init>", "()V")                             -> MethodInlineInfo(false,false,false),
+      ("O$lzycompute$1", "()V")                     -> MethodInlineInfo(true,false,false)
     ),
       None)
 
     assert(infoC == expectC, mapDiff(expectC.methodInfos, infoC.methodInfos) + infoC)
-    assertSameMethods(c, expectC.methodInfos.keySet)
+    assertSameMethods(c, expectC.methodInfos.keySet.map(x => x._1 + x._2))
   }
 
   @Test
@@ -189,10 +189,10 @@ class ScalaInlineInfoTest extends BytecodeTesting {
     val List(c, om) = compileClasses(code)
     val infoC = inlineInfo(c)
     val expected = Map(
-      "<init>()V"            -> MethodInlineInfo(false,false,false),
-      "O$lzycompute$1()V"    -> MethodInlineInfo(true,false,false),
-      "O()LC$O$;"            -> MethodInlineInfo(true,false,false))
+      ("<init>", "()V")         -> MethodInlineInfo(false,false,false),
+      ("O$lzycompute$1", "()V") -> MethodInlineInfo(true,false,false),
+      ("O", "()LC$O$;")         -> MethodInlineInfo(true,false,false))
     assert(infoC.methodInfos == expected, mapDiff(infoC.methodInfos, expected))
-    assertSameMethods(c, expected.keySet)
+    assertSameMethods(c, expected.keySet.map(x => x._1 + x._2))
   }
 }


### PR DESCRIPTION
ASM seems to call InlineInfoAttribute.write twice: firstly as part of
computeAttributeSize and then again as part of writeAttributes.

This commit seeks some efficiencies:

   - Avoid sorting the the method infos twice
   - Avoid copying them from an Array back to a list
   as happens in .toList.sorted
   - Avoid concat / split of name/descriptor by
   using a Tuple2 as the map key

My profiles show that about 0.6% of compilation is spent in this code.