### PR TITLE
Update jQuery used in specs page to 3.4.1

### DIFF
--- a/spec/_layouts/default.yml
+++ b/spec/_layouts/default.yml
@@ -6,6 +6,7 @@
   <link rel="icon" type="image/png" href="public/favicon.ico">
   <link rel="shortcut icon" type="image/png" href="public/favicon.ico">
 
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
     tex2jax: {
@@ -15,9 +16,8 @@
     }
   });
   </script>
-  <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-  <script src="//code.jquery.com/jquery-2.1.3.min.js"></script>
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/styles/default.min.css">
+  <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/styles/default.min.css">
   <!-- need to use include to see value of page.chapter variable -->
   <style type="text/css">
     {% include numbering.css %}

--- a/spec/_layouts/toc.yml
+++ b/spec/_layouts/toc.yml
@@ -6,7 +6,7 @@
   <link rel="icon" type="image/png" href="public/favicon.ico">
   <link rel="shortcut icon" type="image/png" href="public/favicon.ico">
 
-  <script src="//code.jquery.com/jquery-2.1.3.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
   <title>{{ page.title }}</title>
 
   <link rel="stylesheet" type="text/css" href="public/stylesheets/screen.css">

--- a/spec/public/scripts/toc.js
+++ b/spec/public/scripts/toc.js
@@ -45,7 +45,7 @@ $.fn.toc = function(options) {
     }, 50);
   };
   if (opts.highlightOnScroll) {
-    $(window).bind('scroll', highlightOnScroll);
+    $(window).on('scroll', highlightOnScroll);
     highlightOnScroll();
   }
 
@@ -69,10 +69,10 @@ $.fn.toc = function(options) {
       var a = $('<a/>')
         .text(opts.headerText(i, heading, $h))
         .attr('href', '#' + anchorName)
-        .bind('click', function(e) {
-          $(window).unbind('scroll', highlightOnScroll);
+        .on('click', function(e) {
+          $(window).off('scroll', highlightOnScroll);
           scrollTo(e, function() {
-            $(window).bind('scroll', highlightOnScroll);
+            $(window).on('scroll', highlightOnScroll);
           });
           el.trigger('selected', $(this).attr('href'));
         });


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11594

I used jQuery Migrate (https://github.com/jquery/jquery-migrate/) to let it print out deprecation warnings, and updated `.bind` to `.on`.

Here's how I locally tested the page:

```
bundle exec jekyll build -s spec/ -d build/spec
ruby -run -e httpd build/spec -p 9090
```

<img width="1004" alt="toc" src="https://user-images.githubusercontent.com/184683/61553616-cad6cf80-aa28-11e9-829d-a86a3d5b98e6.png">

The toc is built using jQuery, so the fact that it's displaying that a good sign.
