### PR TITLE
[nomerge] Error trees conceal references

### DIFF
--- a/test/files/neg/t11643.check
+++ b/test/files/neg/t11643.check
@@ -1,0 +1,7 @@
+t11643.scala:6: error: could not find implicit value for parameter i: Int
+  def g(j: Int) = j + f
+                      ^
+t11643.scala:7: error: could not find implicit value for parameter i: Int
+  def k(j: Int) = { val x = j + f ; 42 }
+                                ^
+two errors found

--- a/test/files/neg/t11643.scala
+++ b/test/files/neg/t11643.scala
@@ -1,0 +1,19 @@
+
+// scalac: -Werror -Wunused:params
+
+trait T {
+  def f(implicit i: Int) = i
+  def g(j: Int) = j + f
+  def k(j: Int) = { val x = j + f ; 42 }
+}
+
+/*
+t11643.scala:6: error: could not find implicit value for parameter i: Int
+  def g(j: Int) = j + f
+                      ^
+t11643.scala:6: warning: parameter value j in method g is never used
+  def g(j: Int) = j + f
+        ^
+one warning found
+one error found
+ */


### PR DESCRIPTION
Instead of not descending into erroneous trees,
just don't register new symbols for diagnostics.

The previous commit was https://github.com/scala/scala/commit/a05cd477ea279f9214cfc371d22bc10517310d2e#diff-6b2403127534a61cd03d206241b53bf4

Not sure if there was a specific use case for that change, except that an erroneous tree is inherently more dangerous to analyze ad-hoc. 

Fixes https://github.com/scala/bug/issues/11643