### PR TITLE
Scaladoc: avoid bad links in `protected[x]` when `x` is external

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -616,11 +616,11 @@ trait EntityPage extends HtmlPage {
 
     // --- start attributes block vals
     val attributes: NodeSeq = {
-      val fvs: List[comment.Paragraph] = visibility(mbr).toList
+      val fvs: List[NodeSeq] = visibility(mbr).toList
       if (fvs.isEmpty || isReduced) NodeSeq.Empty
       else {
         <dt>Attributes</dt>
-        <dd>{ fvs map { fv => { inlineToHtml(fv.text) ++ scala.xml.Text(" ") } } }</dd>
+        <dd>{ fvs.map(_ ++ scala.xml.Text(" ")) }</dd>
       }
     }
 
@@ -852,22 +852,20 @@ trait EntityPage extends HtmlPage {
     bound0(lo, " >: ") ++ bound0(hi, " <: ")
   }
 
-  def visibility(mbr: MemberEntity): Option[comment.Paragraph] = {
-    import comment._
-    import comment.{ Text => CText }
+  def visibility(mbr: MemberEntity): Option[NodeSeq] = {
     mbr.visibility match {
       case PrivateInInstance() =>
-        Some(Paragraph(CText("private[this]")))
-      case PrivateInTemplate(owner) if (owner == mbr.inTemplate) =>
-        Some(Paragraph(CText("private")))
-      case PrivateInTemplate(owner) =>
-        Some(Paragraph(Chain(List(CText("private["), EntityLink(comment.Text(owner.qualifiedName), LinkToTpl(owner)), CText("]")))))
+        Some(Text("private[this]"))
+      case PrivateInTemplate(None) =>
+        Some(Text("private"))
+      case PrivateInTemplate(Some(owner)) =>
+        Some(Text("private[") ++ typeToHtml(owner, true) ++ Text("]"))
       case ProtectedInInstance() =>
-        Some(Paragraph(CText("protected[this]")))
-      case ProtectedInTemplate(owner) if (owner == mbr.inTemplate) =>
-        Some(Paragraph(CText("protected")))
-      case ProtectedInTemplate(owner) =>
-        Some(Paragraph(Chain(List(CText("protected["), EntityLink(comment.Text(owner.qualifiedName), LinkToTpl(owner)), CText("]")))))
+        Some(Text("protected[this]"))
+      case ProtectedInTemplate(None) =>
+        Some(Text("protected"))
+      case ProtectedInTemplate(Some(owner)) =>
+        Some(Text("protected[") ++ typeToHtml(owner, true) ++ Text("]"))
       case Public() =>
         None
     }

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -130,13 +130,16 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
       else if (sym.isProtectedLocal) ProtectedInInstance()
       else {
         val qual =
-          if (sym.hasAccessBoundary)
-            Some(makeTemplate(sym.privateWithin))
-          else None
-        if (sym.isPrivate) PrivateInTemplate(inTpl)
-        else if (sym.isProtected) ProtectedInTemplate(qual getOrElse inTpl)
+          if (sym.hasAccessBoundary) {
+            val qualTpl = makeTemplate(sym.privateWithin)
+            if (qualTpl != inTpl) Some(qualTpl)
+            else None
+          } else None
+        def tp(c: TemplateImpl) = makeType(c.sym.tpe, inTpl)
+        if (sym.isPrivate) PrivateInTemplate(None)
+        else if (sym.isProtected) ProtectedInTemplate(qual.map(tp))
         else qual match {
-          case Some(q) => PrivateInTemplate(q)
+          case Some(q) => PrivateInTemplate(Some(tp(q)))
           case None => Public()
         }
       }

--- a/src/scaladoc/scala/tools/nsc/doc/model/Visibility.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/Visibility.scala
@@ -29,14 +29,14 @@ case class ProtectedInInstance() extends Visibility {
 }
 
 /** The visibility of `private[owner]` members. An unqualified private members
-  * is encoded with `owner` equal to the members's `inTemplate`. */
-case class PrivateInTemplate(owner: TemplateEntity) extends Visibility
+  * is encoded with `owner` equal to `None`. */
+case class PrivateInTemplate(owner: Option[TypeEntity]) extends Visibility
 
 /** The visibility of `protected[owner]` members. An unqualified protected
-  * members is encoded with `owner` equal to the members's `inTemplate`.
+  * members is encoded with `owner` equal to `None`.
   * Note that whilst the member is visible in any template owned by `owner`,
   * it is only visible in subclasses of the member's `inTemplate`. */
-case class ProtectedInTemplate(owner: TemplateEntity) extends Visibility {
+case class ProtectedInTemplate(owner: Option[TypeEntity]) extends Visibility {
   override def isProtected = true
 }
 

--- a/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
+++ b/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
@@ -772,4 +772,10 @@ object HtmlFactoryTest extends Properties("HtmlFactory") {
       case _ => false
     }
   }
+
+  property("protected[X] does not generate invalid link") = {
+    val ds = createTemplates("t11318.scala")("p/D.html").toString
+    ds.contains("""protected[<span class="extype" name="java.lang">lang</span>]""") &&
+      ds.contains("""protected[<a href="index.html" class="extype" name="p">p</a>]""")
+  }
 }

--- a/test/scaladoc/resources/t11318.scala
+++ b/test/scaladoc/resources/t11318.scala
@@ -1,0 +1,7 @@
+package p
+
+class C {
+  protected[p] def f = 0
+}
+
+class D extends C


### PR DESCRIPTION
When writing `protected[x]` in source, `x` must be an enclosing entity
and therefore is part of the project being documented. So a link to
`x` can be emitted.

However, an inherited member may have an access boundary `protected[y]`
where `y` is not part of the current project. In this case, avoid
generating a wrong internal link.

Fixes https://github.com/scala/bug/issues/11318