### PR TITLE
Neg test case for using non-accessible annotation

### DIFF
--- a/test/files/neg/t11607.check
+++ b/test/files/neg/t11607.check
@@ -1,0 +1,4 @@
+t11607.scala:2: error: class migration in package annotation cannot be accessed in package annotation
+@migration("", "") class C
+ ^
+one error found

--- a/test/files/neg/t11607.scala
+++ b/test/files/neg/t11607.scala
@@ -1,0 +1,2 @@
+import scala.annotation.migration
+@migration("", "") class C


### PR DESCRIPTION
No more compiler crash. Fixed by #7546.

Closes https://github.com/scala/bug/issues/11607