### PR TITLE
Use Java 7 redirection and avoid a thread

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ ThisBuild / headerLicense  := Some(HeaderLicense.Custom(
 Global / mimaReferenceVersion := Some("2.13.0")
 
 import com.typesafe.tools.mima.core._
-val mimaFilterSettings = Seq(
+val mimaFilterSettings = Seq {
   mimaBinaryIssueFilters ++= Seq(
     ProblemFilters.exclude[Problem]("scala.reflect.internal.*"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaMirrors#JavaMirror.typeTag"),
@@ -122,8 +122,10 @@ val mimaFilterSettings = Seq(
     ProblemFilters.exclude[MissingTypesProblem]("scala.collection.ArrayOps$ArrayIterator$mcI$sp"),
     ProblemFilters.exclude[MissingTypesProblem]("scala.collection.ArrayOps$ArrayIterator$mcS$sp"),
     ProblemFilters.exclude[FinalMethodProblem]("scala.collection.immutable.Stream.find"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.sys.process.BasicIO.connectNoOp"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.sys.process.BasicIO.connectToStdIn"),
   ),
-)
+}
 
 // Save MiMa logs
 SavedLogs.settings

--- a/src/library/scala/sys/process/BasicIO.scala
+++ b/src/library/scala/sys/process/BasicIO.scala
@@ -216,13 +216,15 @@ object BasicIO {
   def connectToIn(o: OutputStream): Unit = transferFully(Uncloseable protect stdin, o)
 
   /** Returns a function `OutputStream => Unit` that either reads the content
-    * from stdin or does nothing. This function can be used by
+    * from stdin or does nothing but close the stream. This function can be used by
     * [[scala.sys.process.ProcessIO]].
     */
-  def input(connect: Boolean): OutputStream => Unit = { outputToProcess =>
-    if (connect) connectToIn(outputToProcess)
-    outputToProcess.close()
-  }
+  def input(connect: Boolean): OutputStream => Unit =
+    if (connect) connectToStdIn
+    else _.close()
+
+  /** A sentinel value telling ProcessBuilderImpl to redirect. */
+  private[process] val connectToStdIn: OutputStream => Unit = _ => ()
 
   /** Returns a `ProcessIO` connected to stdout and stderr, and, optionally, stdin. */
   def standard(connectInput: Boolean): ProcessIO = standard(input(connectInput))

--- a/src/library/scala/sys/process/BasicIO.scala
+++ b/src/library/scala/sys/process/BasicIO.scala
@@ -219,12 +219,13 @@ object BasicIO {
     * from stdin or does nothing but close the stream. This function can be used by
     * [[scala.sys.process.ProcessIO]].
     */
-  def input(connect: Boolean): OutputStream => Unit =
-    if (connect) connectToStdIn
-    else _.close()
+  def input(connect: Boolean): OutputStream => Unit = if (connect) connectToStdIn else connectNoOp
 
   /** A sentinel value telling ProcessBuilderImpl to redirect. */
   private[process] val connectToStdIn: OutputStream => Unit = _ => ()
+
+  /** A sentinel value telling ProcessBuilderImpl not to process. */
+  private[process] val connectNoOp: OutputStream => Unit = _ => ()
 
   /** Returns a `ProcessIO` connected to stdout and stderr, and, optionally, stdin. */
   def standard(connectInput: Boolean): ProcessIO = standard(input(connectInput))

--- a/src/library/scala/sys/process/ProcessBuilderImpl.scala
+++ b/src/library/scala/sys/process/ProcessBuilderImpl.scala
@@ -73,7 +73,10 @@ private[process] trait ProcessBuilderImpl {
   /** Represents a simple command without any redirection or combination. */
   private[process] class Simple(p: JProcessBuilder) extends AbstractBuilder {
     override def run(io: ProcessIO): Process = {
+      import java.lang.ProcessBuilder.Redirect.{INHERIT => Inherit}
       import io._
+
+      if (writeInput eq BasicIO.connectToStdIn) p.redirectInput(Inherit)
 
       val process = p.start() // start the external process
 

--- a/src/library/scala/sys/process/ProcessBuilderImpl.scala
+++ b/src/library/scala/sys/process/ProcessBuilderImpl.scala
@@ -74,7 +74,7 @@ private[process] trait ProcessBuilderImpl {
   private[process] class Simple(p: JProcessBuilder) extends AbstractBuilder {
     override def run(io: ProcessIO): Process = {
       import java.lang.ProcessBuilder.Redirect.{INHERIT => Inherit}
-      import io._
+      import io.{daemonizeThreads, processError, processOutput, writeInput}
 
       val inherit = writeInput eq BasicIO.connectToStdIn
       if (inherit) p.redirectInput(Inherit)
@@ -83,7 +83,7 @@ private[process] trait ProcessBuilderImpl {
 
       // spawn threads that process the input, output, and error streams using the functions defined in `io`
       val inThread =
-        if (inherit) null
+        if (inherit || (writeInput eq BasicIO.connectNoOp)) null
         else Spawn("Simple-input", daemon = true)(writeInput(process.getOutputStream))
       val outThread = Spawn("Simple-output", daemonizeThreads)(processOutput(process.getInputStream))
       val errorThread =

--- a/test/junit/scala/sys/process/ProcessTest.scala
+++ b/test/junit/scala/sys/process/ProcessTest.scala
@@ -1,10 +1,10 @@
 package scala.sys.process
 
-import java.io.{ByteArrayInputStream, File, InputStream, IOException, StringReader}
+import java.io.{ByteArrayInputStream, File, InputStream, IOException}
 import java.nio.file.{Files, Paths}, Files.createTempFile
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.{CountDownLatch, TimeUnit}
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.JavaConverters._
 import scala.io.{Source => IOSource, StdIn}

--- a/test/junit/scala/sys/process/ProcessTest.scala
+++ b/test/junit/scala/sys/process/ProcessTest.scala
@@ -1,16 +1,18 @@
 package scala.sys.process
 
-import java.io.{ByteArrayInputStream, File, IOException}
+import java.io.{ByteArrayInputStream, File, IOException, StringReader}
 import java.nio.file.{Files, Paths}, Files.createTempFile
 import java.nio.charset.StandardCharsets.UTF_8
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
-import scala.io.{Source => IOSource}
+import scala.collection.JavaConverters._
+import scala.io.{Source => IOSource, StdIn}
+import scala.tools.testkit.AssertUtil._
 import scala.util.Try
 // should test from outside the package to ensure implicits work
 //import scala.sys.process._
 import scala.util.Properties._
-import scala.collection.JavaConverters._
-import scala.tools.testkit.AssertUtil._
 
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -21,6 +23,34 @@ import org.junit.Assert._
 class ProcessTest {
   private def testily(body: => Unit) = if (!isWin) body
   private val tempFiles = Seq(File.createTempFile("foo", "tmp"), File.createTempFile("bar", "tmp"))
+
+  // under the old regime, the thread to copy input would block on the read
+  // until after the latch, which is after the innocuous process exited,
+  // and then attempt to close the process.getOutputStream, which is known
+  // to be closed already (because that is how process exit was detected).
+  @Test def t7963(): Unit = testily {
+    var exception: Exception = null
+    val latch: CountDownLatch = new CountDownLatch(1)
+    val inputStream = new ByteArrayInputStream("a".getBytes) {
+      override def read(b: Array[Byte], off: Int, len: Int): Int = {
+        try {
+          latch.await(10, TimeUnit.SECONDS)
+        } catch {
+          case e: Exception => exception = e
+        }
+        super.read(b, off, len)
+      }
+    }
+    val originalIn = System.in
+    System.setIn(inputStream)
+    try {
+      Process("echo -n").run(true).exitValue()
+      latch.countDown()
+      assertNull(exception)
+    } finally {
+      System.setIn(originalIn)
+    }
+  }
 
   @Test def t10007(): Unit = testily {
     val res = ("cat" #< new ByteArrayInputStream("lol".getBytes)).!!
@@ -92,7 +122,7 @@ class ProcessTest {
     }
     val noFile = Paths.get("total", "junk")
     val p2 = new ProcessMock(false)
-    val failed = new java.util.concurrent.atomic.AtomicBoolean
+    val failed = new AtomicBoolean
     val pb2 = new ProcessBuilderMock(p2, error = true) {
       override def run(io: ProcessIO): Process = {
         failed.set(true)


### PR DESCRIPTION
Simplifies the previous contribution and goes further to avoid the useless thread.

Fixes scala/bug#7963