### PR TITLE
[backport] Restore flags of nested modules in resident mode

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -1275,6 +1275,11 @@ private[internal] trait TypeMaps {
         if (clazz.isPackageClass) tp
         else {
           val parents1 = parents mapConserve (this)
+          decls.foreach { decl =>
+            if (decl.hasAllFlags(METHOD | MODULE))
+              // HACK: undo flag Uncurry's flag mutation from prior run
+              decl.resetFlag(METHOD | STABLE)
+          }
           if (parents1 eq parents) tp
           else ClassInfoType(parents1, decls, clazz)
         }

--- a/test/files/run/t11564.check
+++ b/test/files/run/t11564.check
@@ -1,0 +1,13 @@
+
+scala> :power
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
+
+scala> class C { object o }
+defined class C
+
+scala> typeOf[C].member(newTermName("o")).debugFlagString
+res0: String = <module>
+
+scala> :quit

--- a/test/files/run/t11564.scala
+++ b/test/files/run/t11564.scala
@@ -1,0 +1,21 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = """
+:power
+class C { object o }
+typeOf[C].member(newTermName("o")).debugFlagString
+  """
+}


### PR DESCRIPTION
The addition of the `object s` alongside the existing method
`StringContext.s` leads to an overloaded symbol for
`currentRun.runDefinitions.StringContext_s`.

e26b4f49 stopped using `lateMETHOD`, which would have hidden
the methodicalness of the symbol during the typer phase of
the next phase.

Maybe we should revisit that choice, but for now this commit
reverses the mutation in `adaptToNewRun`.

Backport of 7a4d6ee6e9