### PR TITLE
Remove wildcardToTypeVarMap

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3667,13 +3667,7 @@ trait Types
 
       if (suspended) tp =:= origin
       else if (instValid) checkIsSameType(tp)
-      else isRelatable(tp) && {
-        val newInst = wildcardToTypeVarMap(tp)
-        (constr isWithinBounds newInst) && {
-          setInst(newInst)
-          instValid
-        }
-      }
+      else isRelatable(tp) && constr.isWithinBounds(tp) && setInst(tp).instValid
     }
 
     /**

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -999,15 +999,6 @@ private[internal] trait TypeMaps {
     }
   }
 
-  /** A map to convert every occurrence of a wildcard type to a fresh
-    *  type variable */
-  object wildcardToTypeVarMap extends TypeMap {
-    def apply(tp: Type): Type = tp match {
-      case pt: ProtoType => TypeVar(tp, new TypeConstraint(pt.toBounds))
-      case _ => tp.mapOver(this)
-    }
-  }
-
   /** A map to convert each occurrence of a type variable to its origin. */
   object typeVarToOriginMap extends TypeMap {
     def apply(tp: Type): Type = tp match {

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -198,7 +198,6 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.wildcardExtrapolation
     this.IsDependentCollector
     this.ApproximateDependentMap
-    this.wildcardToTypeVarMap
     this.typeVarToOriginMap
     this.ErroneousCollector
     this.adaptToNewRunMap

--- a/test/files/pos/t11579.scala
+++ b/test/files/pos/t11579.scala
@@ -1,0 +1,13 @@
+import scala.collection.generic.IsIterable
+import scala.language.implicitConversions
+
+object Test {
+  class Ops[I] {
+    def method: Unit = ()
+  }
+
+  implicit def ToOps[Repr, L, R](aCol: Repr)(implicit isIterable: IsIterable[Repr]{type A = (L, R)}): Ops[isIterable.type] =
+    new Ops[isIterable.type]
+
+  List(1 -> 2).method
+}

--- a/test/files/run/existentials.scala
+++ b/test/files/run/existentials.scala
@@ -59,17 +59,15 @@ object Test extends App {
   val y: (C[X], C[Y]) forSome { type X; type Y } = x
 
    def foo(x : Counter[T] { def name : String } forSome { type T }) = x match {
-     case ctr: Counter[t] =>
+     case ctr =>
        val c = ctr.newCounter
        println(ctr.name+" "+ctr.get(ctr.inc(ctr.inc(c))))
-     case _ =>
    }
 
    def fooW(x : Counter[T] { def name : String } forSome { type T }) = x match {
-     case ctr: Counter[t] =>
+     case ctr =>
        val c = ctr.newCounter
        println(ctr.name+" "+ctr.get(ctr.inc(ctr.inc(c))))
-     case _ =>
    }
 
    val ci = new Counter[Int] {


### PR DESCRIPTION
There exists only one test which needed an update.
Coincidentally, it never converted a wildcard to a typevar.
Instead it must have relied upon a side effect ot typemaps?
Unreachable cases were removed in response to warnings.
Also I heard existentials are out of fashion.

Fixes scala/bug#11579 which regressed in #7376 as an alternative to #8248