### PR TITLE
Parent implicitNotFound message is supplemental

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1863,7 +1863,7 @@ trait Implicits {
     private def typeArgsAtSym(paramTp: Type) = paramTp.baseType(sym).typeArgs
 
     def formatDefSiteMessage(paramTp: Type): String =
-      formatDefSiteMessage(typeArgsAtSym(paramTp) map (_.toString))
+      formatDefSiteMessage(typeArgsAtSym(paramTp).map(_.toString))
 
     def formatDefSiteMessage(typeArgs: List[String]): String =
       interpolate(msg, Map(symTypeParamNames zip typeArgs: _*))
@@ -1877,13 +1877,13 @@ trait Implicits {
         case _ => NoType
       }
 
-      val argTypes1 = if (prefix == NoType) paramTypeRefs else paramTypeRefs.map(t => t.asSeenFrom(prefix, fun.symbol.owner))
+      val argTypes1 = if (prefix == NoType) paramTypeRefs else paramTypeRefs.map(_.asSeenFrom(prefix, fun.symbol.owner))
       val argTypes2 = fun match {
         case treeInfo.Applied(_, targs, _) => argTypes1.map(_.instantiateTypeParams(fun.symbol.info.typeParams, targs.map(_.tpe)))
         case _ => argTypes1
       }
 
-      val argTypes = argTypes2.map{
+      val argTypes = argTypes2.map {
         case PolyType(tps, tr@TypeRef(_, _, tprefs)) =>
           if (tps.corresponds(tprefs)((p, r) => p == r.typeSymbol)) tr.typeConstructor.toString
           else {

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -928,12 +928,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def migrationMessage     = getAnnotation(MigrationAnnotationClass) flatMap { _.stringArg(0) }
     def migrationVersion     = getAnnotation(MigrationAnnotationClass) flatMap { _.stringArg(1) }
     def elisionLevel         = getAnnotation(ElidableMethodClass) flatMap { _.intArg(0) }
-    def implicitNotFoundMsg  = {
-      def onParents =
-        if (isType) parentSymbolsIterator.flatMap(_.getAnnotation(ImplicitNotFoundClass)).nextOption()
-        else None
-      getAnnotation(ImplicitNotFoundClass).orElse(onParents).flatMap(_.stringArg(0))
-    }
+    def implicitNotFoundMsg  = getAnnotation(ImplicitNotFoundClass).flatMap(_.stringArg(0))
     def implicitAmbiguousMsg = getAnnotation(ImplicitAmbiguousClass) flatMap { _.stringArg(0) }
 
     def isCompileTimeOnly       = hasAnnotation(CompileTimeOnlyAttr)

--- a/test/files/neg/missing-implicit.check
+++ b/test/files/neg/missing-implicit.check
@@ -1,10 +1,10 @@
-missing-implicit.scala:23: error: foo
+missing-implicit.scala:23: error: could not find implicit value for parameter e: TC[String]{type Int} (foo)
   implicitly[TC[String] { type Int}]
             ^
 missing-implicit.scala:24: error: bar
   implicitly[XC[String]]
             ^
-missing-implicit.scala:25: error: nope
+missing-implicit.scala:25: error: could not find implicit value for parameter e: U (nope)
   implicitly[U]
             ^
 missing-implicit.scala:26: error: no way
@@ -16,4 +16,16 @@ missing-implicit.scala:31: error: no way
 missing-implicit.scala:32: error: huh
   g
   ^
-6 errors found
+missing-implicit.scala:49: error: No F of Int
+  implicitly[F[Int]]
+            ^
+missing-implicit.scala:50: error: could not find implicit value for parameter e: M[Int] (No F of Int)
+  implicitly[M[Int]]
+            ^
+missing-implicit.scala:51: error: could not find implicit value for parameter e: AX (No F of String)
+  implicitly[AX]
+            ^
+missing-implicit.scala:52: error: could not find implicit value for parameter e: X0 (Missing X3 of Char and Int and String)
+  implicitly[X0]
+            ^
+10 errors found

--- a/test/files/neg/missing-implicit.scala
+++ b/test/files/neg/missing-implicit.scala
@@ -31,3 +31,23 @@ object Example {
   f
   g
 }
+
+@implicitNotFound("No F of ${A}")
+trait F[A]
+
+trait M[A] extends F[A]
+
+trait AX extends F[String]
+
+@implicitNotFound("Missing X3 of ${A} and ${B} and ${C}")
+trait X3[A, B, C]
+trait X2[A, B] extends X3[A, B, String]
+trait X1[A] extends X2[A, Int]
+trait X0 extends X1[Char]
+
+object SuperSubstitutions {
+  implicitly[F[Int]]
+  implicitly[M[Int]]
+  implicitly[AX]
+  implicitly[X0]
+}


### PR DESCRIPTION
It's not obvious that the implicitNotFound message on a base
class is helpful, so just tack it on the end of the message
as a supplemental hint.

Fixes scala/bug#11653