### PR TITLE
Enable hyperlinking to Java docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -175,6 +175,19 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
   ),
   //maxErrors := 10,
   setIncOptions,
+  // http://stackoverflow.com/questions/16934488
+  apiMappings ++= {
+    Option(System.getProperty("sun.boot.class.path")).flatMap { classPath =>
+      classPath.split(java.io.File.pathSeparator).find(_.endsWith(java.io.File.separator + "rt.jar"))
+    }.map { jarPath =>
+      Map(
+        file(jarPath) -> url("https://docs.oracle.com/javase/8/docs/api")
+      )
+    }.getOrElse {
+      streams.value.log.warn("Failed to add bootstrap class path of Java to apiMappings")
+      Map.empty[File,URL]
+    }
+  },
   apiURL := Some(url("https://www.scala-lang.org/api/" + versionProperties.value.mavenVersion + "/")),
   pomIncludeRepository := { _ => false },
   pomExtra := {

--- a/src/compiler/scala/tools/nsc/util/StackTracing.scala
+++ b/src/compiler/scala/tools/nsc/util/StackTracing.scala
@@ -17,7 +17,7 @@ private[util] trait StackTracing extends Any {
   /** Format a stack trace, returning the prefix consisting of frames that satisfy
    *  a given predicate.
    *  The format is similar to the typical case described in the Javadoc
-   *  for [[java.lang.Throwable#printStackTrace]].
+   *  for [[java.lang.Throwable#printStackTrace()*]].
    *  If a stack trace is truncated, it will be followed by a line of the form
    *  `... 3 elided`, by analogy to the lines `... 3 more` which indicate
    *  shared stack trace segments.

--- a/src/compiler/scala/tools/nsc/util/package.scala
+++ b/src/compiler/scala/tools/nsc/util/package.scala
@@ -105,7 +105,7 @@ package object util {
     /** Format the stack trace, returning the prefix consisting of frames that satisfy
      *  a given predicate.
      *  The format is similar to the typical case described in the Javadoc
-     *  for [[java.lang.Throwable#printStackTrace]].
+     *  for [[java.lang.Throwable#printStackTrace()*]].
      *  If a stack trace is truncated, it will be followed by a line of the form
      *  `... 3 elided`, by analogy to the lines `... 3 more` which indicate
      *  shared stack trace segments.

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -728,7 +728,7 @@ final class StringOps(private val s: String) extends AnyVal {
     else s
 
   /** Replace all literal occurrences of `literal` with the literal string `replacement`.
-    *  This method is equivalent to [[java.lang.String#replace]].
+    *  This method is equivalent to [[java.lang.String#replace(CharSequence,CharSequence)]].
     *
     *  @param    literal     the string which should be replaced everywhere it occurs
     *  @param    replacement the replacement string

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -52,7 +52,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     *  initial capacity specified by the `capacity` argument.
     *
     *  @param  capacity  the initial capacity.
-    *  @throws NegativeArraySizeException  if capacity < 0.
+    *  @throws java.lang.NegativeArraySizeException  if capacity < 0.
     */
   def this(capacity: Int) = this(new java.lang.StringBuilder(capacity))
 

--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -663,7 +663,7 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
   /**
    * Return the quotient of this duration and the given integer factor.
    *
-   * @throws ArithmeticException if the factor is 0
+   * @throws java.lang.ArithmeticException if the factor is 0
    */
   def /(divisor: Long): FiniteDuration = fromNanos(toNanos / divisor)
 
@@ -697,7 +697,7 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
   /**
    * Return the quotient of this duration and the given integer factor.
    *
-   * @throws ArithmeticException if the factor is 0
+   * @throws java.lang.ArithmeticException if the factor is 0
    */
   def div(divisor: Long): FiniteDuration = this / divisor
 

--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -149,7 +149,7 @@ object Equiv extends LowPriorityEquiv {
   object Float {
     /** An equivalence for `Float`s which is reflexive (treats all `NaN`s
       * as equivalent), and treats `-0.0` and `0.0` as not equivalent; it
-      * behaves the same as [[java.lang.Float.compare()]].
+      * behaves the same as [[java.lang.Float#compare]].
       *
       * $floatEquiv
       *
@@ -193,7 +193,7 @@ object Equiv extends LowPriorityEquiv {
   object Double {
     /** An equivalence for `Double`s which is reflexive (treats all `NaN`s
       * as equivalent), and treats `-0.0` and `0.0` as not equivalent; it
-      * behaves the same as [[java.lang.Double.compare()]].
+      * behaves the same as [[java.lang.Double#compare]].
       *
       * $doubleEquiv
       *

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -380,7 +380,7 @@ object Ordering extends LowPriorityOrderingImplicits {
   object Float {
     /** An ordering for `Float`s which is a fully consistent total ordering,
       * and treats `NaN` as larger than all other `Float` values; it behaves
-      * the same as [[java.lang.Float.compare()]].
+      * the same as [[java.lang.Float#compare]].
       *
       * $floatOrdering
       *
@@ -401,7 +401,7 @@ object Ordering extends LowPriorityOrderingImplicits {
       * `NaN`.
       *   - `min` and `max` are consistent with `math.min` and `math.max`, and
       * return `NaN` when called with `NaN` as either argument.
-      *   - `compare` behaves the same as [[java.lang.Float.compare()]].
+      *   - `compare` behaves the same as [[java.lang.Float#compare]].
       *
       * $floatOrdering
       *
@@ -440,7 +440,7 @@ object Ordering extends LowPriorityOrderingImplicits {
   object Double {
     /** An ordering for `Double`s which is a fully consistent total ordering,
       * and treats `NaN` as larger than all other `Double` values; it behaves
-      * the same as [[java.lang.Double.compare()]].
+      * the same as [[java.lang.Double#compare]].
       *
       * $doubleOrdering
       *
@@ -461,7 +461,7 @@ object Ordering extends LowPriorityOrderingImplicits {
       * `NaN`.
       *   - `min` and `max` are consistent with `math.min` and `math.max`, and
       * return `NaN` when called with `NaN` as either argument.
-      *   - `compare` behaves the same as [[java.lang.Double.compare()]].
+      *   - `compare` behaves the same as [[java.lang.Double#compare]].
       *
       * $doubleOrdering
       *

--- a/src/library/scala/util/Using.scala
+++ b/src/library/scala/util/Using.scala
@@ -67,7 +67,7 @@ import scala.util.control.{ControlThrowable, NonFatal}
   *
   * If two exceptions are thrown (e.g., by an operation and closing a resource),
   * one of them is re-thrown, and the other is
-  * [[java.lang.Throwable.addSuppressed(Throwable) added to it as a suppressed exception]].
+  * [[java.lang.Throwable#addSuppressed added to it as a suppressed exception]].
   * If the two exceptions are of different 'severities' (see below), the one of a higher
   * severity is re-thrown, and the one of a lower severity is added to it as a suppressed
   * exception. If the two exceptions are of the same severity, the one thrown first is

--- a/src/reflect/scala/reflect/api/Mirrors.scala
+++ b/src/reflect/scala/reflect/api/Mirrors.scala
@@ -506,7 +506,7 @@ trait Mirrors { self: Universe =>
     def runtimeClass(tpe: Type): RuntimeClass
 
     /** Maps a Scala class symbol to the corresponding Java class object
-     *  @throws ClassNotFoundException if there is no Java class
+     *  @throws java.lang.ClassNotFoundException if there is no Java class
      *          corresponding to the given Scala class symbol.
      *  Note: If the Scala symbol is ArrayClass, a ClassNotFound exception is thrown
      *        because there is no unique Java class corresponding to a Scala generic array


### PR DESCRIPTION
- Add Java 8 entry to `apiMappings` of sbt build.
- Fix a few ambiguous references.

```
Could not find any member to link for "ArithmeticException".
Could not find any member to link for "java.lang.Throwable#printStackTrace".
Could not find any member to link for "java.lang.Float.compare()".
```

Fixes https://github.com/scala/bug/issues/11655.