### PR TITLE
No longer emit accessors for private fields

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -118,9 +118,6 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
         // TODO should we do this transformation earlier, say in Constructors? Or would that just cause
         // pain for scala-{js, native}?
 
-        for (f <- fieldSymbols(claszSymbol)) {
-          f.setFlag(Flags.STATIC)
-        }
         val constructorDefDef = treeInfo.firstConstructor(cd0.impl.body).asInstanceOf[DefDef]
         val (uptoSuperStats, remainingConstrStats) = treeInfo.splitAtSuper(constructorDefDef.rhs.asInstanceOf[Block].stats, classOnly = true)
         val clInitSymbol = claszSymbol.newMethod(nme.CLASS_CONSTRUCTOR, claszSymbol.pos, Flags.STATIC).setInfo(NullaryMethodType(definitions.UnitTpe))

--- a/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
@@ -119,6 +119,8 @@ trait StdAttachments {
       })
     )
 
+  object IsDerivedValueClassAttachment
+
   /** After being synthesized by the parser, primary constructors aren't fully baked yet.
    *  A call to super in such constructors is just a fill-me-in-later dummy resolved later
    *  by `parentTypes`. This attachment coordinates `parentTypes` and `typedTemplate` and

--- a/test/files/neg/t10790.check
+++ b/test/files/neg/t10790.check
@@ -1,6 +1,3 @@
-t10790.scala:13: warning: private val y in class X is never used
-  private val Some(y) = Option(42) // warn
-                  ^
 t10790.scala:10: warning: private class C in class X is never used
   private class C                  // warn
                 ^
@@ -8,5 +5,5 @@ t10790.scala:8: warning: parameter value x in method control is never used
   def control(x: Int) = 42         // warn to verify control
               ^
 error: No warnings can be incurred under -Werror.
-three warnings found
+two warnings found
 one error found

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -7,18 +7,9 @@ warn-unused-privates.scala:5: warning: private constructor in class Bippy is nev
 warn-unused-privates.scala:7: warning: private method boop in class Bippy is never used
   private def boop(x: Int)            = x+a+b     // warn
               ^
-warn-unused-privates.scala:9: warning: private val MILLIS2 in class Bippy is never used
-  final private val MILLIS2: Int      = 1000      // warn
-                    ^
-warn-unused-privates.scala:16: warning: private val HEY_INSTANCE in object Bippy is never used
-  private val HEY_INSTANCE: Int = 1000    // warn
-              ^
 warn-unused-privates.scala:17: warning: private val BOOL in object Bippy is never used
   private lazy val BOOL: Boolean = true   // warn
                    ^
-warn-unused-privates.scala:41: warning: private val hummer in class Boppy is never used
-  private val hummer = "def" // warn
-              ^
 warn-unused-privates.scala:48: warning: private var v1 in trait Accessors is never used
   private var v1: Int = 0 // warn
               ^
@@ -27,15 +18,6 @@ warn-unused-privates.scala:49: warning: private var v2 in trait Accessors is nev
               ^
 warn-unused-privates.scala:50: warning: private var v3 in trait Accessors is never used
   private var v3: Int = 0 // warn, never got
-              ^
-warn-unused-privates.scala:61: warning: private var s1 in class StableAccessors is never used
-  private var s1: Int = 0 // warn
-              ^
-warn-unused-privates.scala:62: warning: private var s2 in class StableAccessors is never updated: consider using immutable val
-  private var s2: Int = 0 // warn, never set
-              ^
-warn-unused-privates.scala:63: warning: private var s3 in class StableAccessors is never used
-  private var s3: Int = 0 // warn, never got
               ^
 warn-unused-privates.scala:75: warning: private default argument in trait DefaultArgs is never used
   private def bippy(x1: Int, x2: Int = 10, x3: Int = 15): Int = x1 + x2 + x3
@@ -71,5 +53,5 @@ warn-unused-privates.scala:102: warning: local var x in method f2 is never updat
     var x = 100 // warn about it being a var
         ^
 error: No warnings can be incurred under -Werror.
-24 warnings found
+18 warnings found
 one error found

--- a/test/files/presentation/scope-completion-2.check
+++ b/test/files/presentation/scope-completion-2.check
@@ -11,9 +11,9 @@ private class Cc1 extends AnyRef
 private class Co1 extends AnyRef
 private def fc1: Int
 private def fo1: Int
+private val vc1: Int
+private val vo1: Int
 private[this] val c: test.Completion1
-private[this] val vc1: Int
-private[this] val vo1: Int
 ================================================================================
 
 askScopeCompletion at Completions.scala(29,2)
@@ -27,7 +27,7 @@ private class Cc1 extends AnyRef
 private class Co1 extends AnyRef
 private def fc1: Int
 private def fo1: Int
+private val vc1: Int
+private val vo1: Int
 private[this] val c: test.Completion1
-private[this] val vc1: Int
-private[this] val vo1: Int
 ================================================================================

--- a/test/files/presentation/scope-completion-3.check
+++ b/test/files/presentation/scope-completion-3.check
@@ -28,15 +28,15 @@ private class Cc2 extends AnyRef
 private def fc2: Int
 private object Oc2
 private type tc2 = Completion1.this.tc2
+private val vc2: Int
+private var rc2: Int
 private[this] val vb1: Int
 private[this] val vb3: Int
 private[this] val vc1: Int
-private[this] val vc2: Int
 private[this] val vt3: Int
 private[this] var rb1: Int
 private[this] var rb3: Int
 private[this] var rc1: Int
-private[this] var rc2: Int
 private[this] var rt3: Int
 type tb1 = Completion1.this.tb1
 type tc1 = Completion1.this.tc1
@@ -72,15 +72,15 @@ private class Co2 extends AnyRef
 private def fo2: Int
 private object Oo2
 private type to2 = test.Completion2.to2
+private val vo2: Int
+private var ro2: Int
 private[this] val vb1: Int
 private[this] val vb3: Int
 private[this] val vo1: Int
-private[this] val vo2: Int
 private[this] val vt3: Int
 private[this] var rb1: Int
 private[this] var rb3: Int
 private[this] var ro1: Int
-private[this] var ro2: Int
 private[this] var rt3: Int
 type tb1 = test.Completion2.tb1
 type to1 = test.Completion2.to1

--- a/test/files/presentation/scope-completion-import.check
+++ b/test/files/presentation/scope-completion-import.check
@@ -4,8 +4,8 @@ askScopeCompletion at Completions.scala(23,4)
 ================================================================================
 [response] askScopeCompletion at (23,4)
 retrieved 16 members
-[inaccessible] private[this] val pVOOO: Int
-[inaccessible] private[this] var pROOO: Int
+[inaccessible] private val pVOOO: Int
+[inaccessible] private var pROOO: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -26,8 +26,8 @@ askScopeCompletion at Completions.scala(27,4)
 ================================================================================
 [response] askScopeCompletion at (27,4)
 retrieved 15 members
-[inaccessible] private[this] val pVOOO: Int
-[inaccessible] private[this] var pROOO: Int
+[inaccessible] private val pVOOO: Int
+[inaccessible] private var pROOO: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -47,8 +47,8 @@ askScopeCompletion at Completions.scala(32,4)
 ================================================================================
 [response] askScopeCompletion at (32,4)
 retrieved 13 members
-[inaccessible] private[this] val pVCCC: Int
-[inaccessible] private[this] var pRCCC: Int
+[inaccessible] private val pVCCC: Int
+[inaccessible] private var pRCCC: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -80,8 +80,8 @@ askScopeCompletion at Completions.scala(38,5)
 ================================================================================
 [response] askScopeCompletion at (38,5)
 retrieved 13 members
-[inaccessible] private[this] val pVCCC: Int
-[inaccessible] private[this] var pRCCC: Int
+[inaccessible] private val pVCCC: Int
+[inaccessible] private var pRCCC: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -99,10 +99,10 @@ askScopeCompletion at Completions.scala(40,5)
 ================================================================================
 [response] askScopeCompletion at (40,5)
 retrieved 18 members
-[inaccessible] private[this] val pVCCC: Int
-[inaccessible] private[this] val pVOOO: Int
-[inaccessible] private[this] var pRCCC: Int
-[inaccessible] private[this] var pROOO: Int
+[inaccessible] private val pVCCC: Int
+[inaccessible] private val pVOOO: Int
+[inaccessible] private var pRCCC: Int
+[inaccessible] private var pROOO: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -123,8 +123,8 @@ askScopeCompletion at Completions.scala(49,4)
 ================================================================================
 [response] askScopeCompletion at (49,4)
 retrieved 16 members
-[inaccessible] private[this] val pVOOO: Int
-[inaccessible] private[this] var pROOO: Int
+[inaccessible] private val pVOOO: Int
+[inaccessible] private var pROOO: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -145,8 +145,8 @@ askScopeCompletion at Completions.scala(59,4)
 ================================================================================
 [response] askScopeCompletion at (59,4)
 retrieved 17 members
-[inaccessible] private[this] val pVOOO: Int
-[inaccessible] private[this] var pROOO: Int
+[inaccessible] private val pVOOO: Int
+[inaccessible] private var pROOO: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef
@@ -168,8 +168,8 @@ askScopeCompletion at Completions.scala(69,4)
 ================================================================================
 [response] askScopeCompletion at (69,4)
 retrieved 14 members
-[inaccessible] private[this] val pVCCC: Int
-[inaccessible] private[this] var pRCCC: Int
+[inaccessible] private val pVCCC: Int
+[inaccessible] private var pRCCC: Int
 class C extends AnyRef
 class Foo extends AnyRef
 class Foo_1 extends AnyRef

--- a/test/files/presentation/t5708.check
+++ b/test/files/presentation/t5708.check
@@ -5,7 +5,7 @@ askTypeCompletion at Completions.scala(17,9)
 [response] askTypeCompletion at (17,9)
 retrieved 37 members
 [inaccessible] private def privateM: String
-[inaccessible] private[this] val privateV: String
+[inaccessible] private val privateV: String
 [inaccessible] private[this] val protectedV: String
 [inaccessible] protected def protectedValM: String
 [inaccessible] protected[package lang] def clone(): Object

--- a/test/files/run/t3897.check
+++ b/test/files/run/t3897.check
@@ -1,8 +1,9 @@
+one fields
 (One$$messages,scala.collection.mutable.ListBuffer<java.lang.String>)
-(One$$messages,scala.collection.mutable.ListBuffer<java.lang.String>)
+one methods
+two fields
 (messages,scala.collection.mutable.ListBuffer<java.lang.String>)
-(messages,scala.collection.mutable.ListBuffer<java.lang.String>)
+two methods
+now java
 (One$$messages,scala.collection.mutable.ListBuffer<java.lang.String>)
-(One$$messages,scala.collection.mutable.ListBuffer<java.lang.String>)
-(messages,scala.collection.mutable.ListBuffer<java.lang.String>)
 (messages,scala.collection.mutable.ListBuffer<java.lang.String>)

--- a/test/files/run/t3897/a_2.scala
+++ b/test/files/run/t3897/a_2.scala
@@ -13,11 +13,16 @@ object Test {
   )
 
   def main(args: Array[String]): Unit = {
+    println("one fields")
     f1(classOf[One])
+    println("one methods")
     f2(classOf[One])
+    println("two fields")
     f1(classOf[Two])
+    println("two methods")
     f2(classOf[Two])
 
+    println("now java")
     new J_2().javaRun
   }
 }

--- a/test/junit/scala/reflect/FieldAccessTest.scala
+++ b/test/junit/scala/reflect/FieldAccessTest.scala
@@ -1,7 +1,6 @@
 package scala.reflect
 
 import org.junit.Assert._
-import org.junit.Ignore
 import org.junit.Test
 
 class FieldAccessTest {
@@ -14,11 +13,11 @@ class FieldAccessTest {
   /** scala/bug#9306 */
   @Test
   def testFieldAccess(): Unit = {
-    import scala.reflect.runtime.universe._
     import scala.reflect.runtime.currentMirror
+    import scala.reflect.runtime.universe._
     val obj = new TestClass
     val objType = currentMirror.reflect(obj).symbol.toType
-    val objFields = objType.members.collect { case ms: MethodSymbol if ms.isGetter => ms }
-    assertEquals(123, currentMirror.reflect(obj).reflectField(objFields.head).get)
+    val objField = objType.member(TermName("x")).asTerm
+    assertEquals(123, currentMirror.reflect(obj).reflectField(objField).get)
   }
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
@@ -297,9 +297,11 @@ class OptimizedBytecodeTest extends BytecodeTesting {
         |}
       """.stripMargin
     val c = compileClass(code, allowMessage = _.msg.contains("exception handler declared in the inlined method"))
-    assertInvokedMethods(getMethod(c, "f1a"), List("C.C$$x1", "C.C$$x1_$eq", "C.C$$x1_$eq", "C.C$$x1_$eq")) // accessors not inlined
+    assertInvokedMethods(getMethod(c, "f1a"), List())
     assertInvoke(getMethod(c, "f1b"), "C", "wrapper1")
-    assertInvokedMethods(getMethod(c, "f2a"), List("C.x2", "C.x2_$eq", "C.x2_$eq", "C.x2_$eq"))
+    assertInvokedMethods(getMethod(c, "f2a"), List("C.x2", "C.x2_$eq", "C.x2_$eq", "C.x2_$eq")) // (*)
+    // (*) accessors not inlined: this would cause `f2a` to contain access to private members, which would in turn
+    //     prevent `f2a` from being into other classes
     assertInvoke(getMethod(c, "f2b"), "C", "wrapper2")  }
 
   @Test


### PR DESCRIPTION
Except for value class and case class parameters.

For value class parameters, the accessor is used as the `unbox` method in
other classes. There are a few assumptions in the compiler for that method
being present.

Private case class parameters are excluded because an accessor is generated
anyway to support extraction. We could change the backend avoid going through
the accessor within the class.

Mark object fields static in CleanUp, because:

```
class C { def f = C.x }
object C { private val x = 0 }
```

The field `x` is made `notPrivate` to allow access from C. In the
backend, the field is emitted static. However, if only the backend
phase adds the `static` flag to the symbol, it's not there yet when
emitting `C`, and therefore the field access has the wrong opcode.

