### PR TITLE
Fix unmoored Scaladoc comments

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -227,7 +227,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
       markedTagComment.linesIterator.toList map cleanLine
     }
 
-    /** Parses a comment (in the form of a list of lines) to a `Comment`
+     /* Parses a comment (in the form of a list of lines) to a `Comment`
       * instance, recursively on lines. To do so, it splits the whole comment
       * into main body and tag bodies, then runs the `WikiParser` on each body
       * before creating the comment instance.
@@ -634,7 +634,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
 
       def contentNonEmpty(content: Inline) = content != Text("")
 
-      /**
+       /* Parse cells of a table.
         * @param cellStartMark The char indicating the start or end of a cell
         * @param finalizeRow   Function to invoke when the row has been fully parsed
         */


### PR DESCRIPTION
These warnings are for nested definitions with Scaladoc comments.

```
> doc
[warn] src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala:228:5: discarding unmoored doc comment
[warn]     /** Parses a comment (in the form of a list of lines) to a `Comment`
[warn]     ^
[warn] src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala:635:7: discarding unmoored doc comment
[warn]       /**
[warn]       ^
```

The easiest solution is just to make them regular non-Scaladoc block comments.  If they get moved back to un-nested definitions, they can be re-enabled Scaladoc comments.    However, the Scaladoc for Scaladoc isn't published.  It's project is set to `publishArtifact in (Compile, packageDoc) := false` in the build.