### PR TITLE
Extend `-Xlint:nullary-override` for the reverse (nilary) case

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1465,7 +1465,7 @@ trait Namers extends MethodSynthesis {
             context.unit.toCheck += {() =>
               def javaDetermined(sym: Symbol) = sym.isJavaDefined || isUniversalMember(sym)
               if (!meth.overrides.exists(javaDetermined))
-                reporter.warning(ddef.pos, "nullary method assumes an empty parameter list from the overridden definition")
+                context.warning(ddef.pos, "nullary method assumes an empty parameter list from the overridden definition", WarningCategory.LintNullaryOverride)
             }
           ListOfNil
         } else vparamSymss

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1456,9 +1456,20 @@ trait Namers extends MethodSynthesis {
       }
 
       // Add a () parameter section if this overrides some method with () parameters
-      val vparamSymssOrEmptyParamsFromOverride =
-        if (overridden != NoSymbol && vparamSymss.isEmpty && overridden.alternatives.exists(_.info.isInstanceOf[MethodType])) ListOfNil // NOTE: must check `.info.isInstanceOf[MethodType]`, not `.isMethod`!
-        else vparamSymss
+      val vparamSymssOrEmptyParamsFromOverride = {
+        // must check `.info.isInstanceOf[MethodType]`, not `.isMethod`!
+        // Note that matching MethodType of NullaryMethodType must be nilary not nelary.
+        def overriddenNilary(sym: Symbol) = sym.info.isInstanceOf[MethodType]
+        if (overridden != NoSymbol && vparamSymss.isEmpty && overridden.alternatives.exists(overriddenNilary)) {
+          if (settings.warnNullaryOverride)
+            context.unit.toCheck += {() =>
+              def javaDetermined(sym: Symbol) = sym.isJavaDefined || isUniversalMember(sym)
+              if (!meth.overrides.exists(javaDetermined))
+                reporter.warning(ddef.pos, "nullary method assumes an empty parameter list from the overridden definition")
+            }
+          ListOfNil
+        } else vparamSymss
+      }
 
       val methSig = deskolemizedPolySig(vparamSymssOrEmptyParamsFromOverride, resTp)
       pluginsTypeSig(methSig, typer, ddef, resTpGiven)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2404,10 +2404,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         if (meth.isClassConstructor && !isPastTyper && !meth.owner.isSubClass(AnyValClass) && !meth.isJava) {
           // There are no supercalls for AnyVal or constructors from Java sources, which
-        // would blow up in analyzeSuperConsructor; there's nothing to be computed for them
-          // anyway.
+          // would blow up in analyzeSuperConsructor; there's nothing to be computed for them anyway.
           if (meth.isPrimaryConstructor)
-          analyzeSuperConsructor(meth, vparamss1, rhs1)
+            analyzeSuperConsructor(meth, vparamss1, rhs1)
           else
             checkSelfConstructorArgs(ddef, meth.owner)
         }

--- a/src/library/scala/annotation/nowarn.scala
+++ b/src/library/scala/annotation/nowarn.scala
@@ -29,6 +29,6 @@ package scala.annotation
   *   def f = { 1; deprecated() } // show deprecation warning
   * }}}
   *
-  * To ensure that a `@nowarn` annotation actually suppresses a warning, enable `-Xlint:nowarn`.
+  * To ensure that a `@nowarn` annotation actually suppresses a warning, enable `-Xlint:unused` or `-Wunused:nowarn`.
   */
 class nowarn(value: String = "") extends ConstantAnnotation

--- a/test/files/neg/nilary-override.check
+++ b/test/files/neg/nilary-override.check
@@ -1,0 +1,9 @@
+nilary-override.scala:7: warning: nullary method assumes an empty parameter list from the overridden definition
+class D extends C { override def x: Int = 4 }
+                                 ^
+nilary-override.scala:4: warning: non-nullary method overrides nullary method
+class B extends A { override def x(): Int = 4 }
+                                 ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/nilary-override.scala
+++ b/test/files/neg/nilary-override.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xlint:nullary-override
+// scalac: -Werror -Xlint:nullary-override -Wunused:nowarn
 //
 class A { def x: Int = 3 }
 class B extends A { override def x(): Int = 4 }
@@ -7,3 +7,7 @@ class C { def x(): Int = 3 }
 class D extends C { override def x: Int = 4 }
 
 class J { override def toString = "happy J" }
+
+import annotation._
+class E { def x(): Int = 3 }
+class F extends E { @nowarn override def x: Int = 4 }

--- a/test/files/neg/nilary-override.scala
+++ b/test/files/neg/nilary-override.scala
@@ -1,0 +1,9 @@
+// scalac: -Werror -Xlint:nullary-override
+//
+class A { def x: Int = 3 }
+class B extends A { override def x(): Int = 4 }
+
+class C { def x(): Int = 3 }
+class D extends C { override def x: Int = 4 }
+
+class J { override def toString = "happy J" }

--- a/test/files/neg/nullary-override.check
+++ b/test/files/neg/nullary-override.check
@@ -1,6 +1,9 @@
+nullary-override.scala:15: warning: nullary method assumes an empty parameter list from the overridden definition
+class Q extends P { override def x: Int = 4 }
+                                 ^
 nullary-override.scala:4: warning: non-nullary method overrides nullary method
 class B extends A { override def x(): Int = 4 }
                                  ^
 error: No warnings can be incurred under -Werror.
-1 warning
+2 warnings
 1 error

--- a/test/files/neg/nullary-override.scala
+++ b/test/files/neg/nullary-override.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xlint
+// scalac: -Werror -Xlint:nullary-override
 //
 class A { def x: Int = 3 }
 class B extends A { override def x(): Int = 4 }
@@ -8,3 +8,11 @@ class C extends java.lang.CharSequence {
   def length: Int = ???
   def subSequence(x$1: Int, x$2: Int): CharSequence = ???
 }
+
+// P has parens
+class P { def x(): Int = 3 }
+// Q is questionable
+class Q extends P { override def x: Int = 4 }
+
+// Welcome to the Happy J
+class J { override def toString = "Happy J" }


### PR DESCRIPTION
If `def m` is overriding a `def m()` `-Xlint:nullary-override` now reports it as well, unless the `def m()` is defined in Java (such as Object's toString or hashCode) which are exempt.