### PR TITLE
Optimize compiler phase assembly

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -527,13 +527,6 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     val runsRightAfter = None
   } with UnCurry
 
-  // phaseName = "tailcalls"
-  object tailCalls extends {
-    val global: Global.this.type = Global.this
-    val runsAfter = List("uncurry")
-    val runsRightAfter = None
-  } with TailCalls
-
   // phaseName = "fields"
   object fields extends {
     val global: Global.this.type = Global.this
@@ -546,10 +539,17 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     val runsRightAfter = None
   } with Fields
 
+  // phaseName = "tailcalls"
+  object tailCalls extends {
+    val global: Global.this.type = Global.this
+    val runsAfter = List("fields")
+    val runsRightAfter = None
+  } with TailCalls
+
   // phaseName = "explicitouter"
   object explicitOuter extends {
     val global: Global.this.type = Global.this
-    val runsAfter = List("fields")
+    val runsAfter = List("tailcalls")
     val runsRightAfter = None
   } with ExplicitOuter
 
@@ -620,7 +620,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   // phaseName = "jvm"
   object genBCode extends {
     val global: Global.this.type = Global.this
-    val runsAfter = List("cleanup")
+    val runsAfter = List("delambdafy")
     val runsRightAfter = None
   } with GenBCode
 

--- a/src/compiler/scala/tools/nsc/PhaseAssembly.scala
+++ b/src/compiler/scala/tools/nsc/PhaseAssembly.scala
@@ -166,6 +166,8 @@ trait PhaseAssembly {
         }
         node.level = level
       }
+      def phaseDebug = stack.toSeq.groupBy(_.level).toList.sortBy(_._1).map { case (level, nodes) => (level,  nodes.sortBy(_.phasename).map(_.phaseobj.map(_.map(_.phaseName).mkString(":")).mkString(" ")).mkString(" "))}.mkString("\n")
+      debuglog("Phase assembly levels: " + phaseDebug)
     }
 
     /* Find all edges in the given graph that are hard links. For each hard link we

--- a/src/compiler/scala/tools/nsc/PhaseAssembly.scala
+++ b/src/compiler/scala/tools/nsc/PhaseAssembly.scala
@@ -112,16 +112,19 @@ trait PhaseAssembly {
 
       if (node.level < lvl) node.level = lvl
 
-      var hls = Nil ++ node.before.filter(_.hard)
-      while (hls.size > 0) {
-        for (hl <- hls) {
-          node.phaseobj = Some(node.phaseobj.get ++ hl.frm.phaseobj.get)
-          node.before = hl.frm.before
-          nodes -= hl.frm.phasename
-          edges -= hl
-          for (edge <- node.before) edge.to = node
+      var befores = node.before
+      def hasHardLinks() = befores.exists(_.hard)
+      while (hasHardLinks()) {
+        for (hl <- befores) {
+          if (hl.hard) {
+            node.phaseobj = Some(node.phaseobj.get ++ hl.frm.phaseobj.get)
+            node.before = hl.frm.before
+            nodes -= hl.frm.phasename
+            edges -= hl
+            for (edge <- node.before) edge.to = node
+          }
         }
-        hls = Nil ++ node.before.filter(_.hard)
+        befores = node.before
       }
       node.visited = true
 

--- a/src/compiler/scala/tools/nsc/PhaseAssembly.scala
+++ b/src/compiler/scala/tools/nsc/PhaseAssembly.scala
@@ -40,7 +40,7 @@ trait PhaseAssembly {
       var phaseobj: Option[List[SubComponent]] = None
       val after = new mutable.HashSet[Edge]()
       var before = new mutable.HashSet[Edge]()
-      var visited = false
+      var visited: VisitStatus = NotVisited
       var level = 0
 
       def allPhaseNames(): String = phaseobj match {
@@ -48,6 +48,10 @@ trait PhaseAssembly {
         case Some(lst) => lst.map(_.phaseName).reduceLeft(_+","+_)
       }
     }
+    sealed abstract class VisitStatus
+    case object NotVisited extends VisitStatus
+    case object Visiting extends VisitStatus
+    case object Visited extends VisitStatus
 
     val nodes = new mutable.HashMap[String,Node]()
     val edges = new mutable.HashSet[Edge]()
@@ -104,35 +108,64 @@ trait PhaseAssembly {
     /* Test if there are cycles in the graph, assign levels to the nodes
      * and collapse hard links into nodes
      */
-    def collapseHardLinksAndLevels(node: Node, lvl: Int) {
-      if (node.visited) {
-        dump("phase-cycle")
-        throw new FatalError(s"Cycle in phase dependencies detected at ${node.phasename}, created phase-cycle.dot")
+    def collapseHardLinks() {
+      for (node <- nodes.valuesIterator.toList) {
+        val hardBefores = node.before.iterator.filter(_.hard).toList
+        for (hl <- hardBefores) {
+          node.phaseobj = Some(node.phaseobj.get ++ hl.frm.phaseobj.get)
+          node.before = hl.frm.before
+          nodes -= hl.frm.phasename
+          edges -= hl
+        }
       }
+    }
 
-      if (node.level < lvl) node.level = lvl
-
-      var befores = node.before
-      def hasHardLinks() = befores.exists(_.hard)
-      while (hasHardLinks()) {
-        for (hl <- befores) {
-          if (hl.hard) {
-            node.phaseobj = Some(node.phaseobj.get ++ hl.frm.phaseobj.get)
-            node.before = hl.frm.before
-            nodes -= hl.frm.phasename
-            edges -= hl
-            for (edge <- node.before) edge.to = node
+    /* Test if there are cycles in the graph, assign levels to the nodes
+     * and collapse hard links into nodes
+     */
+    def assignLevelsAndDetectCycles(node: Node) {
+      val stack = mutable.ArrayStack[Node]()
+      def visitNode(node: Node): Unit = {
+        node.visited = Visiting
+        for (edge <- node.before) {
+          val from = edge.frm
+          from.visited match {
+            case NotVisited =>
+              visitNode(edge.frm)
+            case Visiting =>
+              dump("phase-cycle")
+              throw new FatalError(s"Cycle in phase dependencies detected at ${node.phasename}, created phase-cycle.dot")
+            case Visited =>
           }
         }
-        befores = node.before
+        node.visited = Visited
+        stack.push(node)
       }
-      node.visited = true
-
-      for (edge <- node.before) {
-        collapseHardLinksAndLevels( edge.frm, lvl + 1)
+      try {
+        visitNode(node)
+      } finally {
+        nodes.values.foreach(_.visited = NotVisited)
       }
 
-      node.visited = false
+      val topoSort: Map[Node, Int] = stack.zipWithIndex.toMap
+      val root = node
+      assert(stack.head == root, stack)
+      root.level = 1
+
+      // Nodes that have been collapsed into their hard-linked predecessor
+      val collapsed: Map[String, Node] = stack.iterator.flatMap(p => p.phaseobj.toList.flatMap(_.map(x => (x.phaseName, p)))).toMap
+      def followHard(node: Node): Node = collapsed.getOrElse(node.phasename, node)
+
+      // find the longest path to the root node to assign as the level.
+      stack.iterator.drop(1).foreach { node =>
+        var n = node
+        var level = 1
+        while (n != root && n.after.nonEmpty) {
+          n = n.after.maxBy(edge => topoSort.get(followHard(edge.to))).to
+          level += 1
+        }
+        node.level = level
+      }
     }
 
     /* Find all edges in the given graph that are hard links. For each hard link we
@@ -225,10 +258,15 @@ trait PhaseAssembly {
 
     dump(3)
 
-    // test for cycles, assign levels and collapse hard links into nodes
-    graph.collapseHardLinksAndLevels(graph.getNodeByPhase("parser"), 1)
+    // collapse hard links into nodes
+    graph.collapseHardLinks()
 
     dump(4)
+
+    // test for cycles, assign levels
+    graph.assignLevelsAndDetectCycles(graph.getNodeByPhase("parser"))
+
+    dump(5)
 
     // assemble the compiler
     graph.compilerPhaseList()

--- a/src/compiler/scala/tools/nsc/PhaseAssembly.scala
+++ b/src/compiler/scala/tools/nsc/PhaseAssembly.scala
@@ -26,7 +26,7 @@ trait PhaseAssembly {
    * Aux data structure for solving the constraint system
    * The dependency graph container with helper methods for node and edge creation
    */
-  private class DependencyGraph {
+  private[nsc] class DependencyGraph {
 
     /** Simple edge with to and from refs */
     case class Edge(var frm: Node, var to: Node, var hard: Boolean)
@@ -234,7 +234,7 @@ trait PhaseAssembly {
   /** Given the phases set, will build a dependency graph from the phases set
    *  Using the aux. method of the DependencyGraph to create nodes and edges.
    */
-  private def phasesSetToDepGraph(phsSet: mutable.HashSet[SubComponent]): DependencyGraph = {
+  private[nsc] def phasesSetToDepGraph(phsSet: Iterable[SubComponent]): DependencyGraph = {
     val graph = new DependencyGraph()
 
     for (phs <- phsSet) {

--- a/test/benchmarks/src/main/scala/scala/tools/nsc/PhaseAssemblyBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/tools/nsc/PhaseAssemblyBenchmark.scala
@@ -1,0 +1,61 @@
+package scala.tools.nsc
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh
+
+import scala.tools.nsc.plugins.{Plugin, PluginComponent}
+
+@BenchmarkMode(Array(jmh.annotations.Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class PhaseAssemblyBenchmark {
+  class Data[G <: Global with Singleton](val global: G, val components: List[SubComponent { val global: G}])
+  var data: Data[_] = _
+
+  @Param(Array("1", "4", "8", "16"))
+  var size: Int = 0
+
+  @Setup
+  def setup(): Unit = {
+    val global = new Global(new Settings)
+    case class component[G <: Global with Singleton](val global: G, val phaseName: String, override val runsRightAfter: Option[String], override val runsAfter: List[String], override val runsBefore: List[String]) extends SubComponent {
+        override def newPhase(prev: Phase): Phase = ???
+
+    }
+    object component {
+      def apply(phaseName: String, runsRightAfter: Option[String], runsAfter: List[String], runsBefore: List[String]): component[global.type] = {
+        new component[global.type](global, phaseName, runsRightAfter, runsAfter, runsBefore)
+      }
+    }
+    val N = size
+    val components = List.tabulate(N){ i =>
+      component(i.toString, None, if (i == 0) List("parser") else List.tabulate(2)(j => i - j - 1).filter(_ >= 0).map(_.toString), List("terminal"))
+    } ::: List(component("parser", None, Nil, Nil), component("terminal", None, Nil, List(N.toString)))
+
+
+    data = new Data[global.type](global, components )
+  }
+
+  @Benchmark def assemble(): Object = {
+    val s = data.asInstanceOf[Data[Global with Singleton]]
+    val g = s.global
+    val graph = g.phasesSetToDepGraph(s.components.reverse)
+    graph.removeDanglingNodes()
+    graph.collapseHardLinksAndLevels(graph.getNodeByPhase("parser"), 1)
+    graph
+  }
+}
+
+object PhaseAssemblyBenchmark {
+  def main(args: Array[String]): Unit = {
+    val bench = new PhaseAssemblyBenchmark
+    bench.setup()
+    bench.assemble()
+  }
+}

--- a/test/benchmarks/src/main/scala/scala/tools/nsc/PhaseAssemblyBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/tools/nsc/PhaseAssemblyBenchmark.scala
@@ -19,7 +19,7 @@ class PhaseAssemblyBenchmark {
   var data: Data[_] = _
 
   @Param(Array("1", "4", "8", "16"))
-  var size: Int = 0
+  var size: Int = 16
 
   @Setup
   def setup(): Unit = {
@@ -47,7 +47,8 @@ class PhaseAssemblyBenchmark {
     val g = s.global
     val graph = g.phasesSetToDepGraph(s.components.reverse)
     graph.removeDanglingNodes()
-    graph.collapseHardLinksAndLevels(graph.getNodeByPhase("parser"), 1)
+    graph.collapseHardLinks()
+    graph.assignLevelsAndDetectCycles(graph.getNodeByPhase("parser"))
     graph
   }
 }

--- a/test/files/neg/t7622-cyclic-dependency.check
+++ b/test/files/neg/t7622-cyclic-dependency.check
@@ -1,1 +1,1 @@
-error: Cycle in phase dependencies detected at cyclicdependency1, created phase-cycle.dot
+error: Cycle in phase dependencies detected at cyclicdependency2, created phase-cycle.dot

--- a/test/files/neg/t7622-cyclic-dependency.check
+++ b/test/files/neg/t7622-cyclic-dependency.check
@@ -1,1 +1,1 @@
-error: Cycle in phase dependencies detected at cyclicdependency2, created phase-cycle.dot
+error: Cycle in phase dependencies detected at cyclicdependency1, created phase-cycle.dot


### PR DESCRIPTION
I noticed in profiles that filtering the the `before` set
for hard links generated a lot of garbage in compilers configured
with a large number of plugins.

This commit filters on the fly instead.

Fixes scala/scala-dev#538