### PR TITLE
Fixes x.toString and value classes causing auto-application warnings under -Xsource:2.14

### DIFF
--- a/test/files/neg/t7187-deprecation.check
+++ b/test/files/neg/t7187-deprecation.check
@@ -1,0 +1,17 @@
+t7187-deprecation.scala:17: error: type mismatch;
+ found   : Int
+ required: () => Any
+  val t1: () => Any  = m1   // error
+                       ^
+t7187-deprecation.scala:24: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method m2,
+or remove the empty argument list from its definition (Java-defined methods are exempt).
+In Scala 3, an unapplied method like this will be eta-expanded into a function.
+  val t5 = m2 // apply, ()-insertion
+           ^
+t7187-deprecation.scala:40: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method boom,
+or remove the empty argument list from its definition (Java-defined methods are exempt).
+In Scala 3, an unapplied method like this will be eta-expanded into a function.
+  a.boom // error
+    ^
+2 warnings
+1 error

--- a/test/files/neg/t7187-deprecation.scala
+++ b/test/files/neg/t7187-deprecation.scala
@@ -1,0 +1,45 @@
+// scalac: -Xsource:2.14 -deprecation -Werror
+//
+trait AcciSamZero { def apply(): Int }
+
+@FunctionalInterface
+trait SamZero { def apply(): Int }
+
+class A {
+  def boom(): Unit
+}
+
+class EtaExpand214 {
+  def m1 = 1
+  def m2() = 1
+  def m3(x: Int) = x
+
+  val t1: () => Any  = m1   // error
+  val t2: () => Any  = m2   // eta-expanded with lint warning
+  val t2AcciSam: AcciSamZero = m2   // eta-expanded with lint warning + sam warning
+  val t2Sam: SamZero = m2   // eta-expanded with lint warning
+  val t3: Int => Any = m3   // ok
+
+  val t4 = m1 // apply
+  val t5 = m2 // apply, ()-insertion
+  val t6 = m3 // eta-expansion in 2.14
+
+  val t4a: Int        = t4 // ok
+  val t5a: Int        = t5 // ok
+  val t6a: Int => Any = t6 // ok
+
+  val t7 = m1 _
+  val t8 = m2 _
+  val t9 = m3 _
+
+  val t7a: () => Any  = t7 // ok
+  val t8a: () => Any  = t8 // ok
+  val t9a: Int => Any = t9 // ok
+
+  val a = new A
+  a.boom // error
+
+  import scala.collection.mutable.Map
+  val xs = Map(1 -> "foo")
+  val ys = xs.clone // ok
+}

--- a/test/files/pos/auto-application.scala
+++ b/test/files/pos/auto-application.scala
@@ -1,0 +1,47 @@
+// scalac: -Werror -deprecation -Xsource:2.14
+//
+class Test {
+  def a1(xs: List[String]): Int = xs.hashCode
+  def a2(xs: List[String]): Int = xs.hashCode()
+  def a3(xs: List[String]): String = xs.toString
+  def a4(xs: List[String]): String = xs.toString()
+  def a5(xs: List[String]): Class[_] = xs.getClass
+  def a6(xs: List[String]): Class[_] = xs.getClass()
+  def a7(xs: List[String]): Int = xs.##
+  def a8(xs: List[String]): Int = xs.##()
+  def a9(x: Address): String = x.toString
+  def a10(x: Address): String = x.toString()
+  def a11(x: A): String = x.toString
+  def a12(x: A): String = x.toString()
+  def a13(x: B): String = x.toString
+  def a14(x: B): String = x.toString()
+}
+
+case class Address()
+
+class A() {
+  override def toString(): String = "A()"
+}
+
+class B() {
+  override def toString: String = "B()"
+}
+
+// Value class generates this.underlying.hashCode
+case class C(c: Int) extends AnyVal
+
+// This generates toString$extension
+class Bibbity(val i: Int) extends AnyVal {
+  override def toString = "hi"
+}
+
+class City extends Runnable { override def run(): Unit = () }
+object City {
+  val c = new City
+  c.run // should be ok without parens
+}
+
+object Sam {
+  val r: java.lang.Runnable = () => ()
+  r.run // should be ok without parens
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11639
Fixes https://github.com/scala/bug/issues/11657

The compiler gets confused about the lineage of `toString` apparently, so instead of trying to look for the Java flag, I am just going to see if the name exists under `AnyTpe`.