### PR TITLE
Reduce allocations in Typer / Attachments

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -466,7 +466,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
      *  packageOk is equal false when qualifying class symbol
      */
     def qualifyingClass(tree: Tree, qual: Name, packageOK: Boolean) =
-      context.enclClass.owner.ownerChain.find(o => qual.isEmpty || o.isClass && o.name == qual) match {
+      context.enclClass.owner.ownersIterator.find(o => qual.isEmpty || o.isClass && o.name == qual) match {
         case Some(c) if packageOK || !c.isPackageClass => c
         case _                                         => QualifyingClassError(tree, qual) ; NoSymbol
       }

--- a/src/reflect/mima-filters/2.12.0.forwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.forwards.excludes
@@ -37,3 +37,5 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaMi
 ProblemFilters.exclude[MissingClassProblem]("scala.reflect.runtime.JavaMirrors$JavaMirror$typeTagCache$")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.TypeTags.TypeTagImpl")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.Universe.TypeTagImpl")
+
+ProblemFilters.exclude[MissingClassProblem]("scala.reflect.macros.Attachments$")


### PR DESCRIPTION
Removes two hotspots for allocation.