### PR TITLE
Avoid the use of List.flatten

### DIFF
--- a/src/compiler/scala/reflect/macros/compiler/Validators.scala
+++ b/src/compiler/scala/reflect/macros/compiler/Validators.scala
@@ -51,7 +51,7 @@ trait Validators {
       // we only check strict correspondence between value parameterss
       // type parameters of macro defs and macro impls don't have to coincide with each other
       if (aparamss.length != rparamss.length) MacroImplParamssMismatchError()
-      map2(aparamss, rparamss)((aparams, rparams) => {
+      foreach2(aparamss, rparamss)((aparams, rparams) => {
         if (aparams.length < rparams.length) MacroImplMissingParamsError(aparams, rparams)
         if (rparams.length < aparams.length) MacroImplExtraParamsError(aparams, rparams)
       })
@@ -59,7 +59,7 @@ trait Validators {
       try {
         // cannot fuse this map2 and the map2 above because if aparamss.flatten != rparamss.flatten
         // then `atpeToRtpe` is going to fail with an unsound substitution
-        map2(aparamss.flatten, rparamss.flatten)((aparam, rparam) => {
+        foreach2(aparamss, rparamss){ foreach2(_, _){ (aparam, rparam) => {
           if (aparam.name != rparam.name && !rparam.isSynthetic) MacroImplParamNameMismatchError(aparam, rparam)
           if (isRepeated(aparam) ^ isRepeated(rparam)) MacroImplVarargMismatchError(aparam, rparam)
           val aparamtpe = aparam.tpe match {
@@ -67,7 +67,7 @@ trait Validators {
             case tpe => tpe
           }
           checkMacroImplParamTypeMismatch(atpeToRtpe(aparamtpe), rparam)
-        })
+        }}}
 
         checkMacroImplResultTypeMismatch(atpeToRtpe(aret), rret)
 

--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -57,7 +57,7 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
 
   // wrap the given expression in a SoftReference so it can be gc-ed
   def mkSoftRef(expr: Tree): Tree = atPos(expr.pos) {
-    val constructor = SoftReferenceClass.info.nonPrivateMember(nme.CONSTRUCTOR).suchThat(_.paramss.flatten.size == 1)
+    val constructor = SoftReferenceClass.info.nonPrivateMember(nme.CONSTRUCTOR).suchThat(x => sumSize(x.paramss, 0) == 1)
     NewFromConstructor(constructor, expr)
   }
 

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -481,7 +481,7 @@ trait Definitions extends api.StandardDefinitions {
     // arrays and their members
     lazy val ArrayModule                   = requiredModule[scala.Array.type]
       lazy val ArrayModule_overloadedApply = getMemberMethod(ArrayModule, nme.apply)
-           def ArrayModule_genericApply    = ArrayModule_overloadedApply.suchThat(_.paramss.flatten.last.tpe.typeSymbol == ClassTagClass) // [T: ClassTag](xs: T*): Array[T]
+           def ArrayModule_genericApply    = ArrayModule_overloadedApply.suchThat(x => lastNonEmpty(x.paramss).last.tpe.typeSymbol == ClassTagClass) // [T: ClassTag](xs: T*): Array[T]
            def ArrayModule_apply(tp: Type) = ArrayModule_overloadedApply.suchThat(_.tpe.resultType =:= arrayType(tp)) // (p1: AnyVal1, ps: AnyVal1*): Array[AnyVal1]
     lazy val ArrayClass                    = getRequiredClass("scala.Array") // requiredClass[scala.Array[_]]
       lazy val Array_apply                 = getMemberMethod(ArrayClass, nme.apply)

--- a/src/reflect/scala/reflect/internal/ReificationSupport.scala
+++ b/src/reflect/scala/reflect/internal/ReificationSupport.scala
@@ -315,7 +315,7 @@ trait ReificationSupport { self: SymbolTable =>
             }
             // undo flag modifications by merging flag info from constructor args and fieldDefs
             val modsMap = fieldDefs.map { case ValDef(mods, name, _, _) => name -> mods }.toMap
-            def ctorArgsCorrespondToFields = vparamssRestoredImplicits.flatten.forall { vd => modsMap.contains(vd.name) }
+            val ctorArgsCorrespondToFields = mforall(vparamssRestoredImplicits)(vd => modsMap.contains(vd.name) )
             if (!ctorArgsCorrespondToFields) None
             else {
               val vparamss = mmap(vparamssRestoredImplicits) { vd =>
@@ -611,7 +611,7 @@ trait ReificationSupport { self: SymbolTable =>
     def UnliftListOfListsElementwise[T](unliftable: Unliftable[T]) = new UnliftListOfListsElementwise[T] {
       def unapply(lst: List[List[Tree]]): Option[List[List[T]]] = {
         val unlifted = lst.map { l => l.flatMap { unliftable.unapply(_) } }
-        if (unlifted.flatten.length == lst.flatten.length) Some(unlifted) else None
+        if (sumSize(unlifted, 0) == sumSize(lst, 0)) Some(unlifted) else None
       }
     }
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3017,7 +3017,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       res
     }
 
-    override def isVarargs: Boolean = definitions.isVarArgsList(paramss.flatten)
+    override def isVarargs: Boolean = definitions.isVarArgsList(lastNonEmpty(paramss))
 
     override def returnType: Type = {
       def loop(tpe: Type): Type =

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -69,6 +69,19 @@ trait Collections {
     head
   }
 
+  /** From a list of lists, get the last list which is not empty (or Nil if none exists)  */
+  final def lastNonEmpty[A](xss: List[List[A]]): List[A] = {
+    var zs: List[A] = Nil
+    var yss = xss
+    while (! yss.isEmpty){
+      val ys = yss.head
+      if (!ys.isEmpty) zs = ys
+      yss = yss.tail
+    }
+    zs
+  }
+
+
   final def sameElementsEquals(thiss: List[AnyRef], that: List[AnyRef]): Boolean = {
     // Probably immutable, so check reference identity first (it's quick anyway)
     (thiss eq that) || {

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -329,7 +329,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
 
     // the "symbol == Any_getClass || symbol == Object_getClass" test doesn't cut it
     // because both AnyVal and its primitive descendants define their own getClass methods
-    private def isGetClass(meth: MethodSymbol) = (meth.name string_== "getClass") && meth.paramss.flatten.isEmpty
+    private def isGetClass(meth: MethodSymbol) = (meth.name string_== "getClass") && lastNonEmpty(meth.paramss).isEmpty
     private def isStringConcat(meth: MethodSymbol) = meth == String_+ || (meth.owner.isPrimitiveValueClass && meth.returnType =:= StringClass.toType)
     lazy val bytecodelessMethodOwners = Set[Symbol](AnyClass, AnyValClass, AnyRefClass, ObjectClass, ArrayClass) ++ ScalaPrimitiveValueClasses
     lazy val bytecodefulObjectMethods = Set[Symbol](Object_clone, Object_equals, Object_finalize, Object_hashCode, Object_toString,


### PR DESCRIPTION
Flattening a list of lists can create as many allocations as total elements in the lists. In several places, the flattened list is only used just to collect the last element, or the sum of the lengths. So those allocations are wasted. In this PR, we replace several of those flattenings with a memory-constant function. 

- We add to the `Collections` a function `lastNonEmpty(List[List[A]]): List[A]`, which as its name suggests returns the last list which is non empty, i.e., `xss.lastNonEmpty === xss.filterNot(_.isEmpty).lastOption.getOrElse(Nil)`. 
