### PR TITLE
Replace map2 with foreach2.

### DIFF
--- a/src/compiler/scala/reflect/macros/compiler/Validators.scala
+++ b/src/compiler/scala/reflect/macros/compiler/Validators.scala
@@ -51,7 +51,7 @@ trait Validators {
       // we only check strict correspondence between value parameterss
       // type parameters of macro defs and macro impls don't have to coincide with each other
       if (aparamss.length != rparamss.length) MacroImplParamssMismatchError()
-      map2(aparamss, rparamss)((aparams, rparams) => {
+      foreach2(aparamss, rparamss)((aparams, rparams) => {
         if (aparams.length < rparams.length) MacroImplMissingParamsError(aparams, rparams)
         if (rparams.length < aparams.length) MacroImplExtraParamsError(aparams, rparams)
       })

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -534,7 +534,7 @@ trait Infer extends Checkable {
         if (!isFullyDefined(tvar)) tvar.constr.inst = NoType
 
       // Then define remaining type variables from argument types.
-      map2(argtpes, formals) { (argtpe, formal) =>
+      foreach2(argtpes, formals) { (argtpe, formal) =>
         val tp1 = argtpe.deconst.instantiateTypeParams(tparams, tvars)
         val pt1 = formal.instantiateTypeParams(tparams, tvars)
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1628,7 +1628,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             if (preSuperVals.isEmpty && preSuperStats.nonEmpty)
             devWarning("Wanted to zip empty presuper val list with " + preSuperStats)
             else
-            map2(preSuperStats, preSuperVals)((ldef, gdef) => gdef.tpt setType ldef.symbol.tpe)
+            foreach2(preSuperStats, preSuperVals)((ldef, gdef) => gdef.tpt setType ldef.symbol.tpe)
 
           if (superCall1 == cunit) EmptyTree
           else cbody2 match {


### PR DESCRIPTION
Continues https://github.com/scala/scala/pull/8302
________________

Using `foreach2` is more descriptive, since it indicates an action, not a function. On the performance side, a `map2` function allocates a new list, with as many elements as either of its inputs. The `foreach` allocates not.

It may be that the Java Virtual Machine would optimise away the allocation of objects and of an entire list that does not escape from its domain... but it may also not be the case.