### PR TITLE
Namers, PolyTypeCompleter: reuse the list of typeParams.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -2076,7 +2076,7 @@ trait Namers extends MethodSynthesis {
 
     if (defnSym.isTerm) {
       // for polymorphic DefDefs, create type skolems and assign them to the tparam trees.
-      val skolems = deriveFreshSkolems(tparams map (_.symbol))
+      val skolems = deriveFreshSkolems(typeParams)
       foreach2(tparams, skolems)(_ setSymbol _)
     }
 


### PR DESCRIPTION
This list is already computed in the variable `typeParams`, a few lines above.