### PR TITLE
Introduce and use SymbolMap.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -319,7 +319,7 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
     methSym setInfo MethodType(methParamSyms, resTp)
 
     // we must rewire reference to the function's param symbols -- and not methParamProtos -- to methParamSyms
-    val useMethodParams = new TreeSymSubstituter(fun.vparams.map(_.symbol), methParamSyms)
+    val useMethodParams = new TreeSymSubstituter(new ZippedContraMappedSM( (x: ValDef) => x.symbol, fun.vparams, methParamSyms))
     // we're now owned by the method that holds the body, and not the function
     val moveToMethod = new ChangeOwnerTraverser(fun.symbol, methSym)
     def substThisForModule(tree: Tree) = {

--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -125,7 +125,7 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
       GenPolyType(mtparams,
         normalize(restpe.substSym(ctparams, clazz.typeParams), clazz))
     case ExtensionMethodType(thiz, etpe) =>
-      etpe.substituteTypes(thiz :: Nil, clazz.thisType :: Nil)
+      etpe.substituteTypes(new SingletonSM(thiz, clazz.thisType))
     case _ =>
       stpe
   }

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -771,7 +771,8 @@ abstract class UnCurry extends InfoTransform
         val rhs1 = if (rhs == EmptyTree || tempVals.isEmpty) rhs else {
           localTyper.typedPos(rhs.pos) {
             // Patch the method body to refer to the temp vals
-            val rhsSubstituted = rhs.substituteSymbols(packedParamsSyms, tempVals.map(_.symbol))
+            val symMap = new ZippedMapSM(packedParamsSyms, tempVals, (t: Tree) => t.symbol)
+            val rhsSubstituted = rhs.substituteSymbols(symMap)
             // The new method body: { val p$1 = p.asInstanceOf[<dependent type>]; ...; <rhsSubstituted> }
             Block(tempVals, rhsSubstituted)
           }

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -279,7 +279,7 @@ trait Interface extends ast.TreeDSL {
         }
         if (containsSym) {
           if (to.forall(_.isInstanceOf[Ident]))
-            tree.duplicate.substituteSymbols(from, to.map(_.symbol)) // scala/bug#7459 catches `case t => new t.Foo`
+            tree.duplicate.substituteSymbols(new ZippedMapSM(from, to, (t: Tree) => t.symbol)) // scala/bug#7459 catches `case t => new t.Foo`
           else
             substIdentsForTrees.transform(tree)
         }

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1044,7 +1044,8 @@ trait ContextErrors {
 
       private[scala] def NotWithinBoundsErrorMessage(prefix: String, targs: List[Type], tparams: List[Symbol], explaintypes: Boolean) = {
         if (explaintypes) {
-          val bounds = tparams map (tp => tp.info.instantiateTypeParams(tparams, targs).bounds)
+          val instMap = new ZipSM(tparams, targs)
+          val bounds = tparams map (tp => tp.info.instantiateTypeParams(instMap).bounds)
           foreach2(targs, bounds)((targ, bound) => explainTypes(bound.lo, targ))
           foreach2(targs, bounds)((targ, bound) => explainTypes(targ, bound.hi))
         }

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -823,7 +823,7 @@ trait Contexts { self: Analyzer =>
 
         if (isUnique && isPresent)
           devWarningResult(s"Preserving inference: ${sym.nameString}=$hi in $current (based on $current_s) before restoring $sym to saved $saved_s")(
-            current.instantiateTypeParams(List(sym), List(hi))
+            current.instantiateTypeParams(new SingletonSM(sym, hi))
           )
         else if (isPresent)
           devWarningResult(s"Discarding inferred $current_s because it does not uniquely determine $sym in")(current)

--- a/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
@@ -37,7 +37,7 @@ abstract class Duplicators extends Analyzer {
       newClassOwner = newThis
     } else resetClassOwners()
 
-    envSubstitution = new SubstSkolemsTypeMap(env.keysIterator.toList, env.valuesIterator.toList)
+    envSubstitution = new SubstTypeMap(new SubstSkolemsSM(env.keysIterator.toList, env.valuesIterator.toList))
     debuglog("retyped with env: " + env)
 
     newBodyDuplicator(context).typed(tree)
@@ -58,8 +58,8 @@ abstract class Duplicators extends Analyzer {
   private var newClassOwner: Symbol = _
   private var envSubstitution: SubstTypeMap = _
 
-  private class SubstSkolemsTypeMap(from: List[Symbol], to: List[Type]) extends SubstTypeMap(from, to) {
-    protected override def matches(sym1: Symbol, sym2: Symbol) =
+  private class SubstSkolemsSM(from: List[Symbol], to: List[Type]) extends ZipSM[Type](from, to) {
+    override protected def matches(sym1: Symbol, sym2: Symbol) =
       if (sym2.isTypeSkolem) sym2.deSkolemize eq sym1
       else sym1 eq sym2
   }

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -340,7 +340,8 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
         var runtimeType = decreaseMetalevel(macroImpl.info.finalResultType)
 
         // Step II. Transform type parameters of a macro implementation into type arguments in a macro definition's body
-        runtimeType = runtimeType.substituteTypes(macroImpl.typeParams, targs map (_.tpe))
+        val subst = new ZippedMapSM(macroImpl.typeParams, targs, (x: Tree) => x.tpe)
+        runtimeType = runtimeType.substituteTypes(subst)
 
         // Step III. Transform c.prefix.value.XXX to this.XXX and implParam.value.YYY to defParam.YYY
         def unsigma(tpe: Type): Type =

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -514,7 +514,7 @@ trait NamesDefaults { self: Analyzer =>
       //   f(x = 1)   <<  "x = 1" typechecks with expected type WildcardType
       val udp = context.undetparams
       context.savingUndeterminedTypeParams(reportAmbiguous = false) {
-        val subst = new SubstTypeMap(udp, udp map (_ => WildcardType)) {
+        val subst = new SubstTypeMap(new KeysFunctionSM(udp, _ => WildcardType)) {
           override def apply(tp: Type): Type = super.apply(dropByName(tp))
         }
         // This throws an exception which is caught in `tryTypedApply` (as it

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -65,8 +65,8 @@ abstract class RefChecks extends Transform {
   def newTransformer(unit: CompilationUnit): RefCheckTransformer =
     new RefCheckTransformer(unit)
 
-  val toJavaRepeatedParam  = new SubstSymMap(RepeatedParamClass -> JavaRepeatedParamClass)
-  val toScalaRepeatedParam = new SubstSymMap(JavaRepeatedParamClass -> RepeatedParamClass)
+  val toJavaRepeatedParam  = new SubstSymMap(new SingletonSM(RepeatedParamClass , JavaRepeatedParamClass))
+  val toScalaRepeatedParam = new SubstSymMap(new SingletonSM(JavaRepeatedParamClass, RepeatedParamClass))
 
   def accessFlagsToString(sym: Symbol) = flagsToString(
     sym getFlag (PRIVATE | PROTECTED),
@@ -1238,7 +1238,8 @@ abstract class RefChecks extends Transform {
         case ex: TypeError =>
           reporter.error(tree0.pos, ex.getMessage())
           if (settings.explaintypes) {
-            val bounds = tparams map (tp => tp.info.instantiateTypeParams(tparams, argtps).bounds)
+            val instMap = new ZipSM(tparams, argtps)
+            val bounds = tparams map (tp => tp.info.instantiateTypeParams(instMap).bounds)
             foreach2(argtps, bounds)((targ, bound) => explainTypes(bound.lo, targ))
             foreach2(argtps, bounds)((targ, bound) => explainTypes(targ, bound.hi))
           }

--- a/src/reflect/scala/reflect/internal/Kinds.scala
+++ b/src/reflect/scala/reflect/internal/Kinds.scala
@@ -126,6 +126,7 @@ trait Kinds {
     owner: Symbol,
     explainErrors: Boolean
   ): List[(Type, Symbol, KindErrors)] = {
+    val instSymMap: SymbolMap[Type] = new ZipSM(tparams, targs)
 
     // instantiate type params that come from outside the abstract type we're currently checking
     def transform(tp: Type, clazz: Symbol): Type = tp.asSeenFrom(pre, clazz)
@@ -176,7 +177,7 @@ trait Kinds {
           // conceptually the same. Could also replace the types by
           // polytypes, but can't just strip the symbols, as ordering
           // is lost then.
-          val declaredBounds     = transform(hkparam.info.instantiateTypeParams(tparams, targs).bounds, paramowner)
+          val declaredBounds     = transform(hkparam.info.instantiateTypeParams(instSymMap).bounds, paramowner)
           val declaredBoundsInst = transform(bindHKParams(declaredBounds), owner)
           val argumentBounds     = transform(hkarg.info.bounds, owner)
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3625,7 +3625,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     if (syms.isEmpty) Nil
     else {
       val syms1 = mapList(syms)(symFn)
-      val map = new SubstSymMap(syms, syms1)
+      val map = new SubstSymMap(new ZipSM(syms, syms1))
       syms1.foreach(_.modifyInfo(map))
       syms1
     }
@@ -3684,7 +3684,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
    */
   def deriveTypeWithWildcards(syms: List[Symbol])(tpe: Type): Type = {
     if (syms.isEmpty) tpe
-    else tpe.instantiateTypeParams(syms, syms map (_ => WildcardType))
+    else tpe.instantiateTypeParams(new KeysConstantSM(syms, WildcardType))
   }
   /** Convenience functions which derive symbols by cloning.
    */

--- a/src/reflect/scala/reflect/internal/tpe/SymbolMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/SymbolMaps.scala
@@ -1,0 +1,184 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package reflect
+package internal
+package tpe
+
+import scala.annotation.tailrec
+
+private[internal] trait SymbolMaps {
+  self: SymbolTable =>
+
+  /**
+    * A SymbolMap of T is just a finite mapping from Symbols to elements of a generic type T.
+    * This is a restricted version of the maps from the Scala collections.
+    * We want to allow functions that are just constants, functions, or access on an array. 
+    */
+  abstract class SymbolMap[+T] {
+    def isEmpty: Boolean
+    def hasTermKey: Boolean
+    def find(sym: Symbol): Option[T]
+    def hasKey(sym: Symbol): Boolean
+  }
+
+  class SingletonSM[+T](key: Symbol, value: T) extends SymbolMap[T]{
+    override def isEmpty: Boolean = false
+    override def hasTermKey: Boolean = key.isTerm
+    override def find(sym: Symbol): Option[T] = if (key eq sym) Some(value) else None
+    override def hasKey(sym: Symbol): Boolean = key eq sym
+  }
+
+  class MapSM[+T](env: scala.collection.Map[Symbol, T]) extends SymbolMap[T]{
+    override final def isEmpty: Boolean = env.isEmpty
+    override final val hasTermKey: Boolean = env.keysIterator.exists(_.isTerm)
+    override def find(sym: Symbol): Option[T] = env.get(sym)
+    override final def hasKey(sym: Symbol): Boolean = env.contains(sym)
+  }
+
+  abstract class KeysListSM[+T](from: List[Symbol]) extends SymbolMap[T] {
+    private[this] var fromHasTermSymbol = false
+    private[this] var fromMin = Int.MaxValue
+    private[this] var fromMax = Int.MinValue
+    private[this] var fromSize = 0
+    from.foreach {
+      sym =>
+        fromMin = math.min(fromMin, sym.id)
+        fromMax = math.max(fromMax, sym.id)
+        fromSize += 1
+        if (sym.isTerm) fromHasTermSymbol = true
+    }
+
+    final def hasTermKey: Boolean = fromHasTermSymbol
+
+    /** Are `sym` and `sym1` the same? Can be tuned by subclasses. */
+    protected def matches(sym: Symbol, sym1: Symbol): Boolean = sym eq sym1
+
+    final def hasKey(sym: Symbol): Boolean = {
+      // OPT Try cheap checks based on the range of symbol ids in from first.
+      //     Equivalent to `from.contains(sym)`
+      val symId = sym.id
+      val fromMightContainSym = symId >= fromMin && symId <= fromMax
+      fromMightContainSym && (
+        symId == fromMin || symId == fromMax || (fromSize > 2 && from.contains(sym))
+      )
+    }
+
+    override final def isEmpty: Boolean = from.isEmpty
+  }
+
+  class KeysConstantSM[+T](from: List[Symbol], const: T) extends KeysListSM[T](from) {
+    def find(sym: Symbol): Option[T] =
+      if (from.exists(matches(_, sym))) Some(const) else None
+  }
+
+  class KeysFunctionSM[+T](from: List[Symbol], fun: Symbol => T) extends KeysListSM[T](from) {
+    def find(sym: Symbol): Option[T] =
+      if (from.exists(matches(_, sym))) Some(fun(sym)) else None
+  }
+
+  class ZipSM[+T](val from: List[Symbol], val to: List[T]) extends KeysListSM[T](from) {
+    // OPT this check was 2-3% of some profiles, demoted to -Xdev
+    if (isDeveloper) assert(sameLength(from, to), "Unsound substitution from "+ from +" to "+ to)
+
+    def find(sym: Symbol): Option[T] = {
+      @tailrec def loop(from: List[Symbol], to: List[T]): Option[T] =
+        if (from.isEmpty) None
+        else if (matches(from.head, sym)) Some(to.head)
+        else loop(from.tail, to.tail)
+      loop(from, to)
+    }
+  }
+
+  class ZippedMapSM[A, +T](from: List[Symbol], to: List[A], toFun: A => T) extends KeysListSM[T](from){
+    def find(sym: Symbol): Option[T] = {
+      @tailrec def loop(from: List[Symbol], to: List[A]): Option[T] =
+        if (from.isEmpty) None
+        else if (matches(from.head, sym)) Some(toFun(to.head))
+        else loop(from.tail, to.tail)
+      loop(from, to)
+    }
+  }
+
+  class ZippedContraMappedSM[A, T](fromFun: A => Symbol, from: List[A], to: List[T]) extends SymbolMap[T] {
+    private[this] var fromHasTermSymbol = false
+    private[this] var fromMin = Int.MaxValue
+    private[this] var fromMax = Int.MinValue
+    private[this] var fromSize = 0
+    from.foreach { a =>
+      val sym = fromFun(a)
+      fromMin = math.min(fromMin, sym.id)
+      fromMax = math.max(fromMax, sym.id)
+      fromSize += 1
+      if (sym.isTerm) fromHasTermSymbol = true
+    }
+
+    final def hasTermKey: Boolean = fromHasTermSymbol
+
+    /** Are `sym` and `sym1` the same? Can be tuned by subclasses. */
+    protected def matches(sym: Symbol, sym1: Symbol): Boolean = sym eq sym1
+
+    final def hasKey(sym: Symbol): Boolean = {
+      // OPT Try cheap checks based on the range of symbol ids in from first.
+      //     Equivalent to `from.contains(sym)`
+      val symId = sym.id
+      val fromMightContainSym = symId >= fromMin && symId <= fromMax
+      fromMightContainSym && (
+        symId == fromMin || symId == fromMax || (fromSize > 2 && from.contains(sym))
+      )
+    }
+
+    override final def isEmpty: Boolean = from.isEmpty
+
+    override def find(sym: Symbol): Option[T] = {
+      @tailrec def loop(from: List[A], to: List[T]): Option[T] =
+        if (from.isEmpty) None
+        else if (matches(fromFun(from.head), sym)) Some(to.head)
+        else loop(from.tail, to.tail)
+      loop(from, to)
+    }
+  }
+
+  class TypeVarsSM(typeVars: List[TypeVar]) extends SymbolMap[TypeVar] {
+    private[this] var hasTermSymbol = false
+    private[this] var fromMin = Int.MaxValue
+    private[this] var fromMax = Int.MinValue
+    private[this] var fromSize = 0
+
+    typeVars.foreach { tvar =>
+      val sym = tvar.origin.typeSymbol
+      fromMin = math.min(fromMin, sym.id)
+      fromMax = math.max(fromMax, sym.id)
+      fromSize += 1
+      if (sym.isTerm) hasTermSymbol = true
+    }
+
+    def isEmpty: Boolean = typeVars.isEmpty
+    def hasTermKey: Boolean = hasTermSymbol
+    def find(sym: Symbol): Option[TypeVar] =
+      if (fromMin <= sym.id && sym.id <= fromMax) {
+        var tvs = typeVars
+        var res: Option[TypeVar] = None
+        while (res.isEmpty && !tvs.isEmpty){
+          val tv = tvs.head
+          if (tv.origin.typeSymbol eq sym) res = Some(tv)
+          tvs = tvs.tail
+        }
+        res
+      } else None
+
+    def hasKey(sym: Symbol): Boolean =
+      fromMin <= sym.id && sym.id <= fromMax && (fromSize == 1 || ! find(sym).isEmpty)
+  }
+
+}

--- a/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
@@ -208,6 +208,7 @@ private[internal] trait TypeConstraints {
     foreachWithIndex(tparams){(tparam, ix) =>
       if (getVariance(tparam).isContravariant) areContravariant += ix
     }
+    val symMap = new ZipSM(tparams, tvars)
 
     def solveOne(tvar: TypeVar, ix: Int): Unit = {
       val tparam = tvar.origin.typeSymbol
@@ -234,25 +235,25 @@ private[internal] trait TypeConstraints {
           if (up) {
             if (bound.typeSymbol != AnyClass) {
               debuglog(s"$tvar addHiBound $bound.instantiateTypeParams($tparams, $tvars)")
-              tvar addHiBound bound.instantiateTypeParams(tparams, tvars)
+              tvar addHiBound bound.instantiateTypeParams(symMap)
             }
             for (tparam2 <- tparams)
               tparam2.info.lowerBound.dealias match {
                 case TypeRef(_, `tparam`, _) =>
                   debuglog(s"$tvar addHiBound $tparam2.tpeHK.instantiateTypeParams($tparams, $tvars)")
-                  tvar addHiBound tparam2.tpeHK.instantiateTypeParams(tparams, tvars)
+                  tvar addHiBound tparam2.tpeHK.instantiateTypeParams(symMap)
                 case _ =>
               }
           } else {
             if (bound.typeSymbol != NothingClass && bound.typeSymbol != tparam) {
               debuglog(s"$tvar addLoBound $bound.instantiateTypeParams($tparams, $tvars)")
-              tvar addLoBound bound.instantiateTypeParams(tparams, tvars)
+              tvar addLoBound bound.instantiateTypeParams(symMap)
             }
             for (tparam2 <- tparams)
               tparam2.info.upperBound.dealias match {
                 case TypeRef(_, `tparam`, _) =>
                   debuglog(s"$tvar addLoBound $tparam2.tpeHK.instantiateTypeParams($tparams, $tvars)")
-                  tvar addLoBound tparam2.tpeHK.instantiateTypeParams(tparams, tvars)
+                  tvar addLoBound tparam2.tpeHK.instantiateTypeParams(symMap)
                 case _ =>
               }
           }


### PR DESCRIPTION
Across the compiler there are several points at which a mapping is used between a Symbol and another object. Examples of the use of these mappings is when substituting symbols, or then substituting type variables by the computed bounds.

At present, those mappings are directly encoded in the class SubstMap, but this is not an adequeate representation.
For one thing, it mixes the logic of this mapping (symbol to something else) with that logic of the transformation involved, or the logic of the structure on which the substitution is applied (Tree or Type). For another reason, it only allows for one implementation of the mapping, based on a List of keys and the list of values.

In this PR, we introduce a new separate class hierarchy, of SymbolMap. A `SymbolMap[T]` represents in general a mapping from a set of symbols to a set of values of type T.  Having a separate class hierarchy allows us to use some special cases
for different applications:

- Some mappings simply go from one set of Symbols to a constant value (e.g the Wildcard type), but we don't need a list of Wildcard.   We use a form of Constant symbol map for that.
- Some SymbolMaps have a single key and single value. So we use a class of Singleton symbol map for that.
- In some cases, the list of _values_ of the mapping is computed from another list `as`, using a `as.map(f)` transformation.
  Instead of generating another list, we can apply it to value. We use the `ZippedMapSM` for this.
- Contrariwise, we can use a `ZippedContravariantSM` if the list of keys is not directly known, but we look for the keys in another list of objects.
- We can use a SymbolMapping that is based on a Scala Map, and we do not need to get the lists of keys and values.

To make use of this SymbolMaps, we need to change some methods (like `instantiateTypeParams`, or `substSym`) to have two variants, where the new one takes directly the SymbolMap.

Other benefits that we have found with this approach are that, if a same symnbol mapping is used at several places, we can create it only once.