### PR TITLE
[REJECTED] Exempt import scala.collection.compat._

### DIFF
--- a/test/files/pos/compat-exemption.scala
+++ b/test/files/pos/compat-exemption.scala
@@ -1,0 +1,9 @@
+// scalac: -Xlint -Werror
+//
+package scala.collection {
+  package object compat
+}
+
+package test {
+  import scala.collection.compat._
+}


### PR DESCRIPTION
Quick and dirty exemption of `import scala.collection.compat._` from unused import warning.

Note that the package is not empty under 2.13, and even if it were empty of definitions, it would still include the package object itself.

Even if we had handy mima-like exclusions, it's not obvious you'd want to impose that tax in this case.