### PR TITLE
Make the empty method of TreeSeqMap respect the orderBy parameter

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -994,7 +994,11 @@ trait MapFactoryDefaults[K, +V,
     +WithFilterCC[x] <: IterableOps[x, WithFilterCC, WithFilterCC[x]] with Iterable[x]] extends MapOps[K, V, CC, CC[K, V @uncheckedVariance]] with IterableOps[(K, V), WithFilterCC, CC[K, V @uncheckedVariance]] {
   override protected def fromSpecific(coll: IterableOnce[(K, V @uncheckedVariance)]): CC[K, V @uncheckedVariance] = mapFactory.from(coll)
   override protected def newSpecificBuilder: mutable.Builder[(K, V @uncheckedVariance), CC[K, V @uncheckedVariance]] = mapFactory.newBuilder[K, V]
-  override def empty: CC[K, V @uncheckedVariance] = mapFactory.empty
+  override def empty: CC[K, V @uncheckedVariance] = (this: AnyRef) match {
+    // Implemented here instead of in TreeSeqMap since overriding empty in TreeSeqMap is not forwards compatible (should be moved for 2.14)
+    case self: immutable.TreeSeqMap[K, V] => immutable.TreeSeqMap.empty(self.orderedBy).asInstanceOf[CC[K, V]]
+    case _ => mapFactory.empty
+  }
 
   override def withFilter(p: ((K, V)) => Boolean): MapOps.WithFilter[K, V, WithFilterCC, CC] =
     new MapOps.WithFilter[K, V, WithFilterCC, CC](this, p)

--- a/src/library/scala/collection/immutable/TreeSeqMap.scala
+++ b/src/library/scala/collection/immutable/TreeSeqMap.scala
@@ -66,8 +66,15 @@ final class TreeSeqMap[K, +V] private (
 
   override def isEmpty = size == 0
 
+  /*
+  // This should have been overridden in 2.13.0 but wasn't so it will have to wait until 2.14 since it is not forwards compatible
+  // Now handled in inherited method from scala.collection.MapFactoryDefaults instead.
+  override def empty = TreeSeqMap.empty[K, V](orderedBy)
+  */
+
   def orderingBy(orderBy: OrderBy): TreeSeqMap[K, V] = {
     if (orderBy == this.orderedBy) this
+    else if (isEmpty) TreeSeqMap.empty(orderBy)
     else new TreeSeqMap(ordering, mapping, ordinal, orderBy)
   }
 
@@ -75,7 +82,7 @@ final class TreeSeqMap[K, +V] private (
     mapping.get(key) match {
       case e if ordinal == -1 && (orderedBy == OrderBy.Modification || e.isEmpty) =>
         // Reinsert into fresh instance to restart ordinal counting, expensive but only done after 2^32 updates.
-        TreeSeqMap.empty[K, V](orderedBy) ++ this + (key -> value)
+        TreeSeqMap.empty[K, V1](orderedBy) ++ this + (key -> value)
       case Some((o, _)) if orderedBy == OrderBy.Insertion =>
         new TreeSeqMap(
           ordering.include(o, key),
@@ -174,13 +181,13 @@ final class TreeSeqMap[K, +V] private (
 
   override def slice(from: Int, until: Int): TreeSeqMap[K, V] = {
     val sz = size
-    if (sz == 0 || from >= until) empty
+    if (sz == 0 || from >= until) TreeSeqMap.empty[K, V](orderedBy)
     else {
       val sz = size
       val f = if (from >= 0) from else 0
       val u = if (until <= sz) until else sz
       val l = u - f
-      if (l <= 0) empty
+      if (l <= 0) TreeSeqMap.empty[K, V](orderedBy)
       else if (l > sz / 2) {
         // Remove front and rear incrementally if majority of elements are to be kept
         val (front, rest) = ordering.splitAt(f)
@@ -286,9 +293,14 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
     case object Modification extends OrderBy
   }
 
-  val Empty = new TreeSeqMap[Nothing, Nothing](Ordering.empty, HashMap.empty, 0, OrderBy.Insertion)
+  private val EmptyByInsertion = new TreeSeqMap[Nothing, Nothing](Ordering.empty, HashMap.empty, 0, OrderBy.Insertion)
+  private val EmptyByModification = new TreeSeqMap[Nothing, Nothing](Ordering.empty, HashMap.empty, 0, OrderBy.Modification)
+  val Empty = EmptyByInsertion
   def empty[K, V]: TreeSeqMap[K, V] = empty(OrderBy.Insertion)
-  def empty[K, V](orderBy: OrderBy): TreeSeqMap[K, V] = Empty.asInstanceOf[TreeSeqMap[K, V]]
+  def empty[K, V](orderBy: OrderBy): TreeSeqMap[K, V] = {
+    if (orderBy == OrderBy.Modification) EmptyByModification
+    else EmptyByInsertion
+  }.asInstanceOf[TreeSeqMap[K, V]]
 
   def from[K, V](it: collection.IterableOnce[(K, V)]): TreeSeqMap[K, V] =
     it match {

--- a/test/junit/scala/collection/immutable/TreeSeqMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSeqMapTest.scala
@@ -147,6 +147,33 @@ class TreeSeqMapTest {
       assertEquals(s"$i", o3, o5)
     }
   }
+  @Test
+  def testEmpty: Unit = {
+    {
+      val e1 = TreeSeqMap.empty[Int, Int]
+      val e2 = e1 + (3 -> 1) + (2 -> 2) + (1 -> 3) + (3 -> 4)
+      val e3 = e2.tail
+      assertEquals(s"default empty keeps insertion order", List(2 -> 2, 1 -> 3), e3.toList)
+    }
+    {
+      val e1 = TreeSeqMap.empty[Int, Int](TreeSeqMap.OrderBy.Modification)
+      val e2 = e1 + (3 -> 1) + (2 -> 2) + (1 -> 3) + (3 -> 4)
+      val e3 = e2.tail
+      assertEquals(s"modification empty keeps modification order", List(1 -> 3, 3 -> 4), e3.toList)
+    }
+    {
+      val e1 = TreeSeqMap(3 -> 1).empty
+      val e2 = e1 + (3 -> 1) + (2 -> 2) + (1 -> 3) + (3 -> 4)
+      val e3 = e2.tail
+      assertEquals(s"default empty from instance keeps insertion order", List(2 -> 2, 1 -> 3), e3.toList)
+    }
+    {
+      val e1 = TreeSeqMap(3 -> 1).orderingBy(TreeSeqMap.OrderBy.Modification).empty
+      val e2 = e1 + (3 -> 1) + (2 -> 2) + (1 -> 3) + (3 -> 4)
+      val e3 = e2.tail
+      assertEquals(s"modification empty from instance keeps modification order", List(1 -> 3, 3 -> 4), e3.toList)
+    }
+  }
 }
 object TreeSeqMapTest extends App {
   import TreeSeqMap.Ordering._


### PR DESCRIPTION
Make `TreeSeqMap.empty(orderBy: OrderBy)` use the specified `orderBy` parameter for the returned empty instance (previously it always used insertion order). Also override the `empty` instance method to keep current `orderedBy` setting.