### PR TITLE
there is only one Diego

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -24,6 +24,8 @@ Damien Obristi <damien.obrist@gmail.com>
 Daniel C. Sobral <dcsobral@gmail.com>
 Daniel C. Sobral <dcsobral@gmail.com> <dcs@dcs-132-CK-NF79.(none)>
 Daniel Lorch <lorch@epfl.ch>
+Diego E. Alonso Blas <diesalbla@gmail.com>
+Diego E. Alonso Blas <diego.e.a@47deg.com>
 Erik Stenman <stenman@epfl.ch>
 Eugene Burmako <xeno.by@gmail.com>
 Eugene Burmako <xeno.by@gmail.com> <burmako@epfl.ch>


### PR DESCRIPTION
having three or four of @diesalbla around, operating in parallel, could dramatically improve compiler performance. but in reality we have only one

having these mailmap entries should prevent false Diegos from multiplying and proliferating when we're using `git shortlog -sn` for the release notes