### PR TITLE
Encourage using `transform` in deprecation messages

### DIFF
--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -222,7 +222,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
     *  @return an immutable map consisting only of those key value pairs of this map where the key satisfies
     *          the predicate `p`. The resulting map wraps the original map without copying any elements.
     */
-  @deprecated("Use .view.filterKeys(f). A future version will include a strict version of this method (for now, .view.filterKeys(p).toMap).", "2.13.0")
+  @deprecated("Use .view.filterKeys(f). A future version will include a strict version of this method (for now, `.view.filterKeys(p).toMap`).", "2.13.0")
   def filterKeys(p: K => Boolean): MapView[K, V] = new MapView.FilterKeys(this, p)
 
   /** Transforms this map by applying a function to every retrieved value.
@@ -230,7 +230,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
     *  @return a map view which maps every key of this map
     *          to `f(this(key))`. The resulting map wraps the original map without copying any elements.
     */
-  @deprecated("Use .view.mapValues(f). A future version will include a strict version of this method (for now, .view.mapValues(f).toMap).", "2.13.0")
+  @deprecated("Use .view.mapValues(f). A future version will include a strict version of this method (for now, `.transform((_, v) => f(v))`).", "2.13.0")
   def mapValues[W](f: V => W): MapView[K, W] = new MapView.MapValues(this, f)
 
   /** Defines the default value computation for the map,

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -1531,8 +1531,8 @@ final class StringOps(private val s: String) extends AnyVal {
     *               for which `f(x)` equals `k`.
     *
     */
-  @deprecated("Use `s.toSeq.groupBy(...).view.mapValues(_.unwrap)` instead of `s.groupBy(...)`", "2.13.0")
-  def groupBy[K](f: Char => K): immutable.Map[K, String] = new WrappedString(s).groupBy(f).view.mapValues(_.unwrap).toMap
+  @deprecated("Use `s.toSeq.groupBy(...).transform((_, v) => v.unwrap))` instead of `s.groupBy(...)`", "2.13.0")
+  def groupBy[K](f: Char => K): immutable.Map[K, String] = new WrappedString(s).groupBy(f).transform((_, v) => v.unwrap)
 
   /** Groups chars in fixed size blocks by passing a "sliding window"
     *  over them (as opposed to partitioning them, as is done in grouped.)

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -982,10 +982,10 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
 
   override def view: MapView[K, V] = if (nonReadOnly) readOnlySnapshot().view else super.view
 
-  @deprecated("Use .view.filterKeys(f). A future version will include a strict version of this method (for now, .view.filterKeys(p).toMap).", "2.13.0")
+  @deprecated("Use .view.filterKeys(f). A future version will include a strict version of this method (for now, `.view.filterKeys(p).toMap`).", "2.13.0")
   override def filterKeys(p: K => Boolean): collection.MapView[K, V] = view.filterKeys(p)
 
-  @deprecated("Use .view.mapValues(f). A future version will include a strict version of this method (for now, .view.mapValues(f).toMap).", "2.13.0")
+  @deprecated("Use .view.mapValues(f). A future version will include a strict version of this method (for now, `.transform((_, v) => f(v))`).", "2.13.0")
   override def mapValues[W](f: V => W): collection.MapView[K, W] = view.mapValues(f)
   // END extra overrides
   ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
It's much nicer than `.view.mapValues(f).toMap`.