### PR TITLE
Set `sourceFile` in specialization only for classes being compiled

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -613,8 +613,11 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       def cloneInSpecializedClass(member: Symbol, flagFn: Long => Long, newName: Name = null) =
         member.cloneSymbol(sClass, flagFn(member.flags | SPECIALIZED), newName)
 
-      sClass.associatedFile = clazz.sourceFile
-      currentRun.symSource(sClass) = clazz.sourceFile // needed later on by mixin
+      val sourceFile = clazz.sourceFile
+      if (sourceFile ne null) {
+        sClass.associatedFile = sourceFile
+        currentRun.symSource(sClass) = sourceFile // needed later on by mixin
+      }
 
       val env = mapAnyRefsInSpecSym(env0, clazz, sClass)
       typeEnv(sClass) = env

--- a/test/files/pos/t11663/A_1.scala
+++ b/test/files/pos/t11663/A_1.scala
@@ -1,0 +1,6 @@
+class A {
+   @inline final def m: Int = {
+     val (x, y) = (10, 20)
+     x
+  }
+}

--- a/test/files/pos/t11663/B_2.scala
+++ b/test/files/pos/t11663/B_2.scala
@@ -1,0 +1,4 @@
+// scalac: -opt:l:inline -opt-inline-from:** -opt-warnings:_
+class B {
+   def bar(c: A) = c.m
+}


### PR DESCRIPTION
Specialization sets the `sourceFile` and adds specialized subclasses to
the global `symSource` map. This should only be done for symbols
being compiled, not for symbols from the classpath.

Otherwise, `symSource`  contains an entry `(Tuple2$mcII$sp, null)`,
which makes `currentRun.compiles(Tuple2$mcII$sp)` true.

Fixes https://github.com/scala/bug/issues/11663