### PR TITLE
Fix regression in classpath when JARs have 'a.b' entries beside 'a/b'

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
@@ -77,7 +77,11 @@ trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPa
   }
 
   private def findDirEntry(pkg: String): Option[archive.DirEntry] = {
-    archive.allDirsByDottedName.get(pkg)
+    archive.allDirs.get(dottedToPath(pkg))
+  }
+
+  private def dottedToPath(dotted: String): String = {
+    dotted.replace('.', '/') + "/"
   }
 
   protected def createFileEntry(file: FileZipArchive#Entry): FileEntryType


### PR DESCRIPTION
Reverts 720b8a6efbced706a9b062f9b952d0866e474ced

Fixes scala/bug#11664