### PR TITLE
Add `m` label for minutes in Duration.timeUnitLabels

### DIFF
--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -38,7 +38,7 @@ object Duration {
    * Construct a finite duration from the given length and time unit, where the latter is
    * looked up in a list of string representation. Valid choices are:
    *
-   * `d, day, h, hour, min, minute, s, sec, second, ms, milli, millisecond, µs, micro, microsecond, ns, nano, nanosecond`
+   * `d, day, h, hour, m, min, minute, s, sec, second, ms, milli, millisecond, µs, micro, microsecond, ns, nano, nanosecond`
    * and their pluralized forms (for every but the first mentioned form of each unit, i.e. no "ds", but "days").
    */
   def apply(length: Long, unit: String): FiniteDuration   = new FiniteDuration(length,  Duration.timeUnit(unit))
@@ -80,7 +80,7 @@ object Duration {
   private[this] val timeUnitLabels = List(
     DAYS         -> "d day",
     HOURS        -> "h hour",
-    MINUTES      -> "min minute",
+    MINUTES      -> "m min minute",
     SECONDS      -> "s sec second",
     MILLISECONDS -> "ms milli millisecond",
     MICROSECONDS -> "µs micro microsecond",

--- a/test/files/jvm/duration-tck.scala
+++ b/test/files/jvm/duration-tck.scala
@@ -130,7 +130,7 @@ object Test extends App {
 
 
   // test overflow protection
-  for (unit ← Seq(DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS, MICROSECONDS, NANOSECONDS)) {
+  for (unit <- Seq(DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS, MICROSECONDS, NANOSECONDS)) {
     val x = unit.convert(Long.MaxValue, NANOSECONDS)
     val dur = Duration(x, unit)
     val mdur = Duration(-x, unit)
@@ -172,6 +172,20 @@ object Test extends App {
   (1000.millis + 0.days).unit mustBe MILLISECONDS
   1.second.unit mustBe SECONDS
   (1.second + 1.millisecond).unit mustBe MILLISECONDS
+
+
+  // test unit labels
+  for ((unit, labels) <- Seq(
+    DAYS         -> "d day days",
+    HOURS        -> "h hour hours",
+    MINUTES      -> "m min mins minute minutes",
+    SECONDS      -> "s sec secs second seconds",
+    MILLISECONDS -> "ms milli millis millisecond milliseconds",
+    MICROSECONDS -> "µs micro micros microsecond microseconds",
+    NANOSECONDS  -> "ns nano nanos nanosecond nanoseconds"
+  ); label <- labels.split(" ")) {
+    Duration("1" + label).unit mustBe unit
+  }
 
 
   // test Deadline


### PR DESCRIPTION
This allows `Duration.apply(s: String)` to parse successfully inputs like `10m` as minutes instead of throwing a `NumberFormatException`.

```
scala> scala.concurrent.duration.Duration.apply("10m")
java.lang.NumberFormatException: format error 10m
  at scala.concurrent.duration.Duration$.apply(Duration.scala:71)
  ... 28 elided
```