### PR TITLE
[backport] Fix the build for newer Java Virtual Machines.

### DIFF
--- a/project/GenerateAnyVals.scala
+++ b/project/GenerateAnyVals.scala
@@ -28,7 +28,7 @@ import scala.language.implicitConversions"""
         case _     => Nil
       }
       if (coercions.isEmpty) Nil
-      else coercionComment.lines.toList ++ coercions
+      else coercionComment.linesIterator.toList ++ coercions
     }
 
     def isCardinal: Boolean = isIntegerType(this)
@@ -174,7 +174,7 @@ import scala.language.implicitConversions"""
     }
     def objectLines = {
       val comp = if (isCardinal) cardinalCompanion else floatingCompanion
-      interpolate(comp + allCompanions + "\n" + nonUnitCompanions).trim.lines.toList ++ (implicitCoercions map interpolate)
+      interpolate(comp + allCompanions + "\n" + nonUnitCompanions).trim.linesIterator.toList ++ (implicitCoercions map interpolate)
     }
 
     /** Makes a set of binary operations based on the given set of ops, args, and resultFn.
@@ -220,7 +220,7 @@ import scala.language.implicitConversions"""
     def representation = repr.map(", a " + _).getOrElse("")
 
     def indent(s: String)  = if (s == "") "" else "  " + s
-    def indentN(s: String) = s.lines map indent mkString "\n"
+    def indentN(s: String) = s.linesIterator map indent mkString "\n"
 
     def boxUnboxInterpolations = Map(
       "@boxRunTimeDoc@" -> """
@@ -448,9 +448,9 @@ def ^(x: Boolean): Boolean
 
 // Provide a more specific return type for Scaladoc
 override def getClass(): Class[Boolean] = ???
-    """.trim.lines.toList
+    """.trim.linesIterator.toList
 
-    def objectLines = interpolate(allCompanions + "\n" + nonUnitCompanions).lines.toList
+    def objectLines = interpolate(allCompanions + "\n" + nonUnitCompanions).linesIterator.toList
   }
   object U extends AnyValRep("Unit", None, "void") {
     override def classDoc = """
@@ -464,7 +464,7 @@ override def getClass(): Class[Boolean] = ???
       "// Provide a more specific return type for Scaladoc",
       "override def getClass(): Class[Unit] = ???"
     )
-    def objectLines = interpolate(allCompanions).lines.toList
+    def objectLines = interpolate(allCompanions).linesIterator.toList
 
     override def boxUnboxInterpolations = Map(
       "@boxRunTimeDoc@" -> "",

--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -31,9 +31,9 @@ object VersionUtil {
     shellWelcomeString := """
       |     ________ ___   / /  ___
       |    / __/ __// _ | / /  / _ |
-      |  __\ \/ /__/ __ |/ /__/ __ | 
+      |  __\ \/ /__/ __ |/ /__/ __ |
       | /____/\___/_/ |_/____/_/ | |
-      |                          |/  %s""".stripMargin.lines.drop(1).map(s => s"${ "%n" }${ s }").mkString,
+      |                          |/  %s""".stripMargin.linesIterator.drop(1).map(s => s"${ "%n" }${ s }").mkString,
     resourceGenerators in Compile += generateVersionPropertiesFile.map(file => Seq(file)).taskValue,
     generateVersionPropertiesFile := generateVersionPropertiesFileImpl.value
   )


### PR DESCRIPTION
The current build definition fails to load when using one of the more recent editiions of the JVM, This commit back-ports some changes to the build files, already in the 2.13.x branch.


The environment in which I was trying this was a Ubuntu (Linux), using the OpenJDK 12.