### PR TITLE
Add IterableOnce operations to IterableOnceOps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,13 @@ val mimaFilterSettings = Seq(
     ProblemFilters.exclude[MissingClassProblem]("scala.reflect.runtime.JavaMirrors$JavaMirror$typeTagCache$"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.TypeTags.TypeTagImpl"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.Universe.TypeTagImpl"),
-  ),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.collection.IterableOnceOps.stepper"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.collection.IterableOnceOps.iterator"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.collection.IterableOnceOps.knownSize"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.IterableOnceOps.stepper"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.IterableOnceOps.iterator"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.IterableOnceOps.knownSize")
+  )
 )
 
 // Save MiMa logs

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -297,6 +297,35 @@ object IterableOnce {
   *
   */
 trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
+  // Methods declared in IterableOnce, but which are not inherited because IterableOnceOps is a universal trait
+  /** Iterator can be used only once */
+  def iterator: Iterator[A]
+  /** Returns a [[Stepper]] for the elements of this collection.
+   *
+   * The Stepper enables creating a Java stream to operate on the collection, see
+   * [[scala.jdk.StreamConverters]]. For collections holding primitive values, the Stepper can be
+   * used as an iterator which doesn't box the elements.
+   *
+   * The implicit [[StepperShape]] parameter defines the resulting Stepper type according to the
+   * element type of this collection.
+   *
+   *   - For collections of `Int`, `Short`, `Byte` or `Char`, an [[IntStepper]] is returned
+   *   - For collections of `Double` or `Float`, a [[DoubleStepper]] is returned
+   *   - For collections of `Long` a [[LongStepper]] is returned
+   *   - For any other element type, an [[AnyStepper]] is returned
+   *
+   * Note that this method is overridden in subclasses and the return type is refined to
+   * `S with EfficientSplit`, for example [[IndexedSeqOps.stepper]]. For Steppers marked with
+   * [[scala.collection.Stepper.EfficientSplit]], the converters in [[scala.jdk.StreamConverters]]
+   * allow creating parallel streams, whereas bare Steppers can be converted only to sequential
+   * streams.
+   */
+  def stepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S
+  /** @return The number of elements in this $coll, if it can be cheaply computed,
+   *  -1 otherwise. Cheaply usually means: Not requiring a collection traversal.
+   */
+  def knownSize: Int
+
   /////////////////////////////////////////////////////////////// Abstract methods that must be implemented
 
   /** Produces a $coll containing cumulative results of applying the

--- a/test/files/neg/abstract-report.check
+++ b/test/files/neg/abstract-report.check
@@ -1,6 +1,6 @@
 abstract-report.scala:1: error: class Unimplemented needs to be abstract.
 Missing implementations for 6 members. Stub implementations follow:
-  // Members declared in scala.collection.IterableOnce
+  // Members declared in scala.collection.IterableOnceOps
   def iterator: Iterator[String] = ???
 
   // Members declared in scala.collection.IterableOps

--- a/test/files/neg/abstract-report2.check
+++ b/test/files/neg/abstract-report2.check
@@ -54,7 +54,7 @@ class Baz[T] extends Collection[T]
       ^
 abstract-report2.scala:15: error: class Dingus needs to be abstract.
 Missing implementations for 7 members. Stub implementations follow:
-  // Members declared in scala.collection.IterableOnce
+  // Members declared in scala.collection.IterableOnceOps
   def iterator: Iterator[(Set[Int], String)] = ???
 
   // Members declared in scala.collection.IterableOps


### PR DESCRIPTION
Fixes scala/bug#11675

This change is backward compatible, because nothing is removed.
It should also be forward compatible, because `IterableOnceOps[A]` had
`IterableOnce[A]` as a self-type on 2.13.0, meaning that code relying on the
newly introduced methods also worked on 2.13.0 because any `IterableOnceOps[A]`
instance was also effectively an `IterableOnce[A]`.