### PR TITLE
Avoid using the "lines" method.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -657,7 +657,7 @@ trait Contexts { self: Analyzer =>
 
     def enclosingContextChain: List[Context] = this :: outer.enclosingContextChain
 
-    private def treeTruncated       = tree.toString.replaceAll("\\s+", " ").lines.mkString("\\n").take(70)
+    private def treeTruncated       = tree.toString.replaceAll("\\s+", " ").linesIterator.toList.mkString("\\n").take(70)
     private def treeIdString        = if (settings.uniqid.value) "#" + System.identityHashCode(tree).toString.takeRight(3) else ""
     private def treeString          = tree match {
       case x: Import => "" + x

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4796,7 +4796,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             if (e.errPos samePointAs tree.pos) {
               val header = f"${e.errMsg}%n  Expression does not convert to assignment because:%n    "
               val expansion = f"%n    expansion: ${show(convo)}"
-              NormalTypeError(tree, err.errors.flatMap(_.errMsg.lines.toList).mkString(header, f"%n    ", expansion))
+              NormalTypeError(tree, err.errors.flatMap(_.errMsg.linesIterator.toList).mkString(header, f"%n    ", expansion))
             } else e
           }
         def advice2(errors: List[AbsTypeError]): List[AbsTypeError] =

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -42,7 +42,7 @@ object PathResolver {
   }
   implicit class AsLines(val s: String) extends AnyVal {
     // sm"""...""" could do this in one pass
-    def asLines = s.trim.stripMargin.lines.mkLines
+    def asLines = s.trim.stripMargin.linesIterator.toList.mkLines
   }
 
   /** pretty print class path */

--- a/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTest.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTest.scala
@@ -91,7 +91,7 @@ abstract class InteractiveTest
         loadSources()
         runDefaultTests()
       }
-    }.lines.map(normalize).foreach(println)
+    }.linesIterator.map(normalize).foreach(println)
   }
 
   protected def normalize(s: String) = s

--- a/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTestSettings.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTestSettings.scala
@@ -69,7 +69,7 @@ trait InteractiveTestSettings extends TestSettings with PresentationCompilerInst
     val str = try File(optsFile).slurp() catch {
       case e: java.io.IOException => ""
     }
-    str.lines.filter(!_.startsWith(CommentStartDelimiter)).mkString(" ")
+    str.linesIterator.filter(!_.startsWith(CommentStartDelimiter)).mkString(" ")
   }
 
   override protected def printClassPath(implicit reporter: Reporter) {

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -1054,7 +1054,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
 
         case Literal(k @ Constant(s: String)) if s.contains(Chars.LF) =>
           val tq = "\"" * 3
-          val lines = s.lines.toList
+          val lines = s.linesIterator.toList
           if (lines.lengthCompare(1) <= 0) print(k.escapedStringValue)
           else {
             val tqp = """["]{3}""".r

--- a/src/reflect/scala/reflect/internal/util/StringOps.scala
+++ b/src/reflect/scala/reflect/internal/util/StringOps.scala
@@ -49,7 +49,7 @@ trait StringOps {
     else s.substring(0, end)
   }
   /** Breaks the string into lines and strips each line before reassembling. */
-  def trimAllTrailingSpace(s: String): String = s.lines.map(trimTrailingSpace).mkString(EOL)
+  def trimAllTrailingSpace(s: String): String = s.linesIterator.map(trimTrailingSpace).toList.mkString(EOL)
 
   def decompose(str: String, sep: Char): List[String] = {
     def ws(start: Int): List[String] =

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -580,7 +580,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter) extend
               tmp.safeSlurp() match {
                 case Some(edited) if edited.trim.isEmpty => echo("Edited text is empty.")
                 case Some(edited) =>
-                  echo(edited.lines map ("+" + _) mkString "\n")
+                  echo(edited.linesIterator map ("+" + _) mkString "\n")
                   val res = intp interpret edited
                   if (res == IR.Incomplete) diagnose(edited)
                   else {
@@ -811,7 +811,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter) extend
         val input = readWhile(s => delimiter.isEmpty || delimiter.get != s) mkString "\n"
         val text = (
           margin filter (_.nonEmpty) map {
-            case "-" => input.lines map (_.trim) mkString "\n"
+            case "-" => input.linesIterator map (_.trim) mkString "\n"
             case m   => input stripMargin m.head   // ignore excess chars in "<<||"
           } getOrElse input
         ).trim

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -581,7 +581,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
         if (printResults && result != "")
           printMessage(result stripSuffix "\n")
         else if (isReplDebug) // show quiet-mode activity
-          printMessage(result.trim.lines map ("[quiet] " + _) mkString "\n")
+          printMessage(result.trim.linesIterator.map("[quiet] " + _).toList.mkString("\n"))
 
         // Book-keeping.  Have to record synthetic requests too,
         // as they may have been issued for information, e.g. :type
@@ -1237,7 +1237,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
     /** Secret bookcase entrance for repl debuggers: end the line
      *  with "// show" and see what's going on.
      */
-    def isShow = code.lines exists (_.trim endsWith "// show")
+    def isShow = code.linesIterator exists (_.trim endsWith "// show")
     if (isReplDebug || isShow) {
       beSilentDuring(parse(code)) match {
         case parse.Success(ts) =>

--- a/src/repl/scala/tools/nsc/interpreter/Pasted.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Pasted.scala
@@ -26,7 +26,7 @@ abstract class Pasted(prompt: String) {
   def interpret(line: String): IR.Result
   def echo(message: String): Unit
 
-  val PromptString    = prompt.lines.toList.last
+  val PromptString    = Util.lastOf(prompt.linesIterator)
   val AltPromptString = "scala> "
   val ContinuePrompt  = replProps.continuePrompt
   val ContinueString  = replProps.continueText     // "     | "

--- a/src/repl/scala/tools/nsc/interpreter/Power.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Power.scala
@@ -16,6 +16,7 @@ package interpreter
 import scala.language.implicitConversions
 
 import scala.collection.mutable
+import scala.collection.JavaConverters._
 import scala.io.Codec
 import java.net.URL
 import scala.reflect.runtime.{universe => ru}
@@ -148,7 +149,7 @@ class Power[ReplValsImpl <: ReplVals : ru.TypeTag: ClassTag](val intp: IMain, re
     |replImplicits._
     |treedsl.CODE._""".stripMargin.lines
 
-  def init = customInit getOrElse initImports.mkString("import ", ", ", "")
+  def init = customInit getOrElse initImports.iterator.asScala.toList.mkString("import ", ", ", "")
 
   /** Quietly starts up power mode and runs whatever is in init.
    */
@@ -158,7 +159,7 @@ class Power[ReplValsImpl <: ReplVals : ru.TypeTag: ClassTag](val intp: IMain, re
     // Then we import everything from $r.
     intp interpret s"import ${ intp.originalPath("$r") }._"
     // And whatever else there is to do.
-    init.lines foreach (intp interpret _)
+    init.linesIterator foreach (intp interpret _)
   }
 
   trait LowPriorityInternalInfo {

--- a/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
@@ -59,7 +59,7 @@ class ReplProps {
   val continueString = Prop[String]("scala.repl.continue").option getOrElse "| "
   val continueText   = {
     val text   = enversion(continueString)
-    val margin = promptText.lines.toList.last.length - text.length
+    val margin = Util.lastOf(promptText.linesIterator).length - text.length
     if (margin > 0) " " * margin + text else text
   }
   val continuePrompt = encolor(continueText)

--- a/src/repl/scala/tools/nsc/interpreter/ReplReporter.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplReporter.scala
@@ -61,7 +61,7 @@ class ReplReporter(intp: IMain) extends ConsoleReporter(intp.settings, Console.i
     case INFO    => RESET
   }
 
-  private val promptLength = replProps.promptText.lines.toList.last.length
+  private val promptLength = Util.lastOf(replProps.promptText.linesIterator).length
   private val indentation  = " " * promptLength
 
   // colorized console labels

--- a/src/repl/scala/tools/nsc/interpreter/Util.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Util.scala
@@ -1,0 +1,24 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package tools.nsc
+package interpreter
+
+private[interpreter] object Util {
+  def lastOf[A](it: Iterator[A]): A = {
+    var res: A = it.next()
+    while (it.hasNext)
+      res = it.next()
+    res
+  }
+}

--- a/test/files/run/repl-serialization.scala
+++ b/test/files/run/repl-serialization.scala
@@ -39,7 +39,7 @@ object Test {
     imain = IMain(settings)
     println("== evaluating lines")
     imain.directBind("extract", "(AnyRef => Unit)", extract)
-    code.lines.foreach(imain.interpret)
+    code.linesIterator.foreach(imain.interpret)
 
     val virtualFile: AbstractFile = extract.value.getClass.getClassLoader.asInstanceOf[AbstractFileClassLoader].root
     val newLoader = new AbstractFileClassLoader(virtualFile, getClass.getClassLoader)

--- a/test/junit/scala/tools/nsc/backend/jvm/DefaultMethodTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/DefaultMethodTest.scala
@@ -7,6 +7,7 @@ import scala.collection.JavaConverters._
 import scala.reflect.internal.Flags
 import scala.tools.asm.Opcodes
 import scala.tools.asm.tree.ClassNode
+import scala.tools.nsc.interpreter.Util._
 import scala.tools.testing.BytecodeTesting
 
 class DefaultMethodTest extends BytecodeTesting {
@@ -26,7 +27,7 @@ class DefaultMethodTest extends BytecodeTesting {
       }
     }
     val asmClasses: List[ClassNode] = compiler.compileClassesTransformed(code, Nil, makeFooDefaultMethod.transform(_))
-    val foo = asmClasses.head.methods.iterator.asScala.toList.last
+    val foo = lastOf(asmClasses.head.methods.iterator)
     assertTrue("default method should not be abstract", (foo.access & Opcodes.ACC_ABSTRACT) == 0)
     assertTrue("default method body emitted", foo.instructions.size() > 0)
   }


### PR DESCRIPTION
When attempting to build Scala on one of the newest JDKs (11 or 12) the "lines" method is no longer available. Instead, we need to use
linesIterator. We add a utility to get last element in an iterator.

Spun off #8331 