### PR TITLE
Ignore package-owned privates for unused warnings

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -656,7 +656,9 @@ trait TypeDiagnostics {
       unusedPrivates.traverse(body)
 
       if (settings.warnUnusedLocals || settings.warnUnusedPrivates) {
-        def shouldWarnOn(sym: Symbol) = if (sym.isPrivate) settings.warnUnusedPrivates else settings.warnUnusedLocals
+        def shouldWarnOn(sym: Symbol) =
+          if (sym.isPrivate) settings.warnUnusedPrivates && !sym.isTopLevel
+          else settings.warnUnusedLocals
         val valAdvice = "is never updated: consider using immutable val"
         def termWarning(defn: SymTree): Unit = {
           val sym = defn.symbol

--- a/test/files/neg/t11681.check
+++ b/test/files/neg/t11681.check
@@ -1,0 +1,14 @@
+t11681.scala:9: error: object bar is not a member of package com.example
+    def foobar: String = example.bar   // not a usage
+                                 ^
+t11681.scala:10: error: object Detest is not a member of package com.example
+    def detest = example.Detest        // not a usage
+                         ^
+t11681.scala:14: warning: private method bar in package object example is never used
+  private def bar: String = "bar"
+              ^
+t11681.scala:17: warning: private object Detest in package object example is never used
+  private object Detest
+                 ^
+two warnings found
+two errors found

--- a/test/files/neg/t11681.scala
+++ b/test/files/neg/t11681.scala
@@ -1,0 +1,18 @@
+//
+// scalac: -Wunused:privates -Werror
+//
+package com
+
+package example {
+  private object Test {
+    def foo: String = "foo"
+    def foobar: String = example.bar   // not a usage
+    def detest = example.Detest        // not a usage
+  }
+}
+package object example {
+  private def bar: String = "bar"
+  private[example] def barNone: String = "bar"   // not unqualified private
+
+  private object Detest
+}

--- a/test/files/pos/t11681.scala
+++ b/test/files/pos/t11681.scala
@@ -1,0 +1,10 @@
+//
+// scalac: -Wunused:privates -Werror
+//
+package com
+
+package example {
+  private object Test {
+    def foo: String = "foo"
+  }
+}


### PR DESCRIPTION
Packages are open. But do you open your packages
on Christmas Eve or wait until morning?

Fixes scala/bug#11681