### PR TITLE
Reduce allocations in Typer

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5736,7 +5736,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         if (tree1.tpe eq null)
           return setError(tree)
 
-        tree1 modifyType (pluginsTyped(_, this, tree1, mode, ptPlugins))
+        tree1 setType pluginsTyped(tree1.tpe, this, tree1, mode, ptPlugins)
 
         val result =
           if (tree1.isEmpty) tree1

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -553,7 +553,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
      *  (illegal type applications in pre will be skipped -- that's why typedSelect wraps the resulting tree in a TreeWithDeferredChecks)
      *  @return modified tree and new prefix type
      */
-    private def makeAccessible(tree: Tree, sym: Symbol, pre: Type, site: Tree): (Tree, Type) =
+    private def makeAccessible(tree: Tree, sym: Symbol, pre: Type, site: Tree): Any /*Type | (Tree, Type)*/ =
       if (!unit.isJava && context.isInPackageObject(sym, pre.typeSymbol)) {
         if (pre.typeSymbol == ScalaPackageClass && sym.isTerm) {
           // short cut some aliases. It seems pattern matching needs this
@@ -590,7 +590,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         }
         (checkAccessible(tree1, sym, qual.tpe, qual), qual.tpe)
       } else {
-        (checkAccessible(tree, sym, pre, site), pre)
+        checkAccessible(tree, sym, pre, site)
       }
 
     /** Post-process an identifier or selection node, performing the following:
@@ -5079,14 +5079,19 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               case Select(_, _) => treeCopy.Select(tree, qual, name)
               case SelectFromTypeTree(_, _) => treeCopy.SelectFromTypeTree(tree, qual, name)
             }
-            val (result, accessibleError) = silent(_.makeAccessible(tree1, sym, qual.tpe, qual)) match {
+            val pre = qual.tpe
+            var accessibleError: AccessTypeError = null
+            val result = silent(_.makeAccessible(tree1, sym, pre, qual)) match {
               case SilentTypeError(err: AccessTypeError) =>
-                (tree1, Some(err))
+                accessibleError = err
+                tree1
               case SilentTypeError(err) =>
                 SelectWithUnderlyingError(tree, err)
                 return tree
-              case SilentResultValue((qual, pre)) =>
-                (stabilize(qual, pre, mode, pt), None)
+              case SilentResultValue((qual: Tree, pre1: Type)) =>
+                stabilize(qual, pre1, mode, pt)
+              case SilentResultValue(qual: Tree) =>
+                stabilize(qual, pre, mode, pt)
             }
 
             result match {
@@ -5100,7 +5105,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                     qual // you only get to see the wrapped tree after running this check :-p
                   }) setType qual.tpe setPos qual.pos,
                   name)
-              case _ if accessibleError.isDefined =>
+              case _ if accessibleError != null =>
                 // don't adapt constructor, scala/bug#6074
                 val qual1 = if (name == nme.CONSTRUCTOR) qual
                             else adaptToMemberWithArgs(tree, qual, name, mode, reportAmbiguous = false, saveErrors = false)
@@ -5109,7 +5114,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 else
                   // before failing due to access, try a dynamic call.
                   asDynamicCall getOrElse {
-                    context.issue(accessibleError.get)
+                    context.issue(accessibleError)
                     setError(tree)
                   }
               case _ =>
@@ -5217,7 +5222,15 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 val pos = tree.pos
                 Select(atPos(pos.focusStart)(qual), name).setPos(pos)
               }
-              val (tree2, pre2) = makeAccessible(tree1, sym, pre1, qual)
+              var tree2: Tree = null
+              var pre2: Type = pre1
+              makeAccessible(tree1, sym, pre1, qual) match {
+                case (t: Tree, tp: Type) =>
+                  tree2 = t
+                  pre2 = tp
+                case t: Tree =>
+                  tree2 = t
+              }
             // scala/bug#5967 Important to replace param type A* with Seq[A] when seen from from a reference, to avoid
             //         inference errors in pattern matching.
               stabilize(tree2, pre2, mode, pt) modifyType dropIllegalStarTypes


### PR DESCRIPTION
I'm measuring a 2.7% reduction in allocation rate (`gc.alloc.rate.norm`) in `-Ystop-after:typer`. There might be a small speedup as a result of this,
but that reading is noisier than the allocation profiling.

Before:

```
 for sha in 1314b45 98b9a6c; do sbt 'set scalaVersion in compilation := "2.12.9-bin-'$sha'-SNAPSHOT"' 'hot -psource=scalap  -pextraArgs=-Ystop-after:typer -f3 -prof gc -jvmArgs -XX:MaxInlineLevel=18'; done
...

info] Benchmark                                                    (corpusPath)  (corpusVersion)         (extraArgs)  (resident)               (scalaVersion)  (source)    Mode   Cnt         Score         Error   Units
[info] HotScalacBenchmark.compile                                      ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample  1309       231.710 ±       0.571   ms/op
[info] HotScalacBenchmark.compile:compile·p0.00                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample             223.085                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.50                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample             229.638                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.90                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample             240.386                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.95                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample             244.318                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.99                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample             254.568                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.999                       ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample             271.167                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999                      ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample             272.630                 ms/op
[info] HotScalacBenchmark.compile:compile·p1.00                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample             272.630                 ms/op
[info] HotScalacBenchmark.compile:·gc.alloc.rate                       ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample    30       378.301 ±       2.123  MB/sec
[info] HotScalacBenchmark.compile:·gc.alloc.rate.norm                  ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample    30  96551476.213 ±  195846.399    B/op
[info] HotScalacBenchmark.compile:·gc.churn.PS_Eden_Space              ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample    30       379.304 ±      10.312  MB/sec
[info] HotScalacBenchmark.compile:·gc.churn.PS_Eden_Space.norm         ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample    30  96808470.750 ± 2608853.743    B/op
[info] HotScalacBenchmark.compile:·gc.churn.PS_Survivor_Space          ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample    30         2.729 ±       0.602  MB/sec
[info] HotScalacBenchmark.compile:·gc.churn.PS_Survivor_Space.norm     ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample    30    695981.651 ±  152543.882    B/op
[info] HotScalacBenchmark.compile:·gc.count                            ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample    30       344.000                counts
[info] HotScalacBenchmark.compile:·gc.time                             ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-1314b45-SNAPSHOT    scalap  sample    30      2816.000                    ms
```

After:
```
[info] HotScalacBenchmark.compile                                      ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample  1324       228.940 ±       0.575   ms/op
[info] HotScalacBenchmark.compile:compile·p0.00                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample             221.512                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.50                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample             227.017                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.90                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample             238.027                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.95                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample             242.418                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.99                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample             251.199                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.999                       ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample             267.498                 ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999                      ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample             268.435                 ms/op
[info] HotScalacBenchmark.compile:compile·p1.00                        ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample             268.435                 ms/op
[info] HotScalacBenchmark.compile:·gc.alloc.rate                       ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample    30       376.478 ±       2.682  MB/sec
[info] HotScalacBenchmark.compile:·gc.alloc.rate.norm                  ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample    30  94957705.639 ±  127928.287    B/op
[info] HotScalacBenchmark.compile:·gc.churn.PS_Eden_Space              ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample    30       374.880 ±      18.140  MB/sec
[info] HotScalacBenchmark.compile:·gc.churn.PS_Eden_Space.norm         ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample    30  94557225.117 ± 4515558.175    B/op
[info] HotScalacBenchmark.compile:·gc.churn.PS_Survivor_Space          ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample    30         1.849 ±       0.921  MB/sec
[info] HotScalacBenchmark.compile:·gc.churn.PS_Survivor_Space.norm     ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample    30    468210.635 ±  232583.244    B/op
[info] HotScalacBenchmark.compile:·gc.count                            ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample    30       269.000                counts
[info] HotScalacBenchmark.compile:·gc.time                             ../corpus          a8c43dc  -Ystop-after:typer       false  2.12.9-bin-98b9a6c-SNAPSHOT    scalap  sample    30      2429.000                    ms
[success] Total time: 652 s, completed 15/08/2019 11:37:04 AM
```