### PR TITLE
Reuse an instance of FindMember

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -300,7 +300,7 @@ abstract class SymbolLoaders {
       }
     }
   }
-  private val classFileDataReader: ReusableInstance[ReusableDataReader] = new ReusableInstance[ReusableDataReader](() => new ReusableDataReader())
+  private val classFileDataReader: ReusableInstance[ReusableDataReader] = new ReusableInstance[ReusableDataReader](() => new ReusableDataReader(), enabled = true)
   class ClassfileLoader(val classfile: AbstractFile, clazz: ClassSymbol, module: ModuleSymbol) extends SymbolLoader with FlagAssigningCompleter {
     private object classfileParser extends {
       val symbolTable: SymbolLoaders.this.symbolTable.type = SymbolLoaders.this.symbolTable

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1107,7 +1107,7 @@ trait Contexts { self: Analyzer =>
    *  the search continuing as long as no qualifying name is found.
    */
   // OPT: moved this into a (cached) object to avoid costly and non-eliminated {Object,Int}Ref allocations
-  private[Contexts] final val symbolLookupCache = ReusableInstance[SymbolLookup](new SymbolLookup)
+  private[Contexts] final val symbolLookupCache = ReusableInstance[SymbolLookup](new SymbolLookup, enabled = true)
   private[Contexts] final class SymbolLookup {
     private[this] var lookupError: NameLookup  = _ // set to non-null if a definite error is encountered
     private[this] var inaccessible: NameLookup = _ // records inaccessible symbol for error reporting in case none is found

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1731,7 +1731,7 @@ trait Implicits {
     def isShadowed(name: Name): Boolean
   }
   object Shadower {
-    private[this] val localShadowerCache = new ReusableInstance[LocalShadower](() => new LocalShadower)
+    private[this] val localShadowerCache = new ReusableInstance[LocalShadower](() => new LocalShadower, enabled = true)
 
     def using[T](local: Boolean)(f: Shadower => T): T =
       if (local) localShadowerCache.using { shadower =>

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1037,7 +1037,10 @@ trait Types
      *  @param stableOnly     If set, return only members that are types or stable values
      */
     def findMember(name: Name, excludedFlags: Long, requiredFlags: Long, stableOnly: Boolean): Symbol = {
-      def findMemberInternal = new FindMember(this, name, excludedFlags, requiredFlags, stableOnly).apply()
+      def findMemberInternal = findMemberInstance.using { findMember =>
+        findMember.init(this, name, excludedFlags, requiredFlags, stableOnly)
+        findMember()
+      }
 
       if (this.isGround) findMemberInternal
       else suspendingTypeVars(typeVarsInType(this))(findMemberInternal)

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -213,7 +213,7 @@ trait Variances {
   final def varianceInType(tp: Type)(tparam: Symbol): Variance = {
     varianceInTypeCache.using(_.apply(tp, tparam))
   }
-  private[this] val varianceInTypeCache = new ReusableInstance[varianceInType](() => new varianceInType)
+  private[this] val varianceInTypeCache = new ReusableInstance[varianceInType](() => new varianceInType, enabled = true)
 
   private final class varianceInType {
     private[this] var tp: Type = _

--- a/src/reflect/scala/reflect/internal/util/ReusableInstance.scala
+++ b/src/reflect/scala/reflect/internal/util/ReusableInstance.scala
@@ -19,12 +19,12 @@ package util
   *
   * Not thread safe.
   */
-final class ReusableInstance[T <: AnyRef](make: () => T) {
+final class ReusableInstance[T <: AnyRef](make: () => T, enabled: Boolean) {
   private val cached = make()
   private var taken = false
 
   @inline def using[R](action: T => R): R =
-    if (taken) action(make())
+    if (!enabled || taken) action(make())
     else try {
       taken = true
       action(cached)
@@ -32,6 +32,6 @@ final class ReusableInstance[T <: AnyRef](make: () => T) {
 }
 
 object ReusableInstance {
-  def apply[T <: AnyRef](make: => T): ReusableInstance[T] =
-    new ReusableInstance[T](make _)
+  def apply[T <: AnyRef](make: => T, enabled: Boolean): ReusableInstance[T] =
+    new ReusableInstance[T](make _, enabled)
 }


### PR DESCRIPTION
`findMember` and `findMembers` were refactored sometime ago to share
an implenentation (`FindMemberBase`). This came at the cost of
incurring an allocation.

This commit uses a one-element cache to reuse an instance for the
hot call `findMember`. Initialization logic is removed from the
constructor and put in an `init` method that must be called
before reusing the instance.

I'm seeing a 3.5% reduction in allocation in `-Ystop-after:typer`
as a result of this change.