### PR TITLE
Reduce allocations in the backend

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -576,7 +576,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
                 asm.Opcodes.PUTSTATIC,
                 thisBType.internalName,
                 strMODULE_INSTANCE_FIELD,
-                thisBType.descriptor
+                thisBTypeDescriptor
               )
             }
           }

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -1092,7 +1092,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
       if (style == Super) {
         if (receiverClass.isTrait && !method.isJavaDefined) {
           val staticDesc = MethodBType(typeToBType(method.owner.info) :: bmType.argumentTypes, bmType.returnType).descriptor
-          val staticName = traitSuperAccessorName(method).toString
+          val staticName = traitSuperAccessorName(method)
           bc.invokestatic(receiverName, staticName, staticDesc, isInterface, pos)
         } else {
           if (receiverClass.isTraitOrInterface) {

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -61,10 +61,10 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
 
   def needsStaticImplMethod(sym: Symbol) = sym.hasAttachment[global.mixer.NeedStaticImpl.type]
 
-  final def traitSuperAccessorName(sym: Symbol): Name = {
+  final def traitSuperAccessorName(sym: Symbol): String = {
     val name = sym.javaSimpleName
-    if (sym.isMixinConstructor) name
-    else name.append(nme.NAME_JOIN_STRING)
+    if (sym.isMixinConstructor) name.toString
+    else name + nme.NAME_JOIN_STRING
   }
 
   /**

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -64,8 +64,9 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
     final val MaximumJvmParameters = 254
 
     // current class
-    var cnode: asm.tree.ClassNode  = null
-    var thisBType: ClassBType      = null
+    var cnode: asm.tree.ClassNode   = null
+    var thisBType: ClassBType       = null
+    var thisBTypeDescriptor: String = null
 
     var claszSymbol: Symbol        = null
     var isCZParcelable             = false
@@ -89,11 +90,12 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
     def genPlainClass(cd: ClassDef) {
       assert(cnode == null, "GenBCode detected nested methods.")
 
-      claszSymbol       = cd.symbol
-      isCZParcelable    = isAndroidParcelableClass(claszSymbol)
-      isCZStaticModule  = isStaticModuleClass(claszSymbol)
-      isCZRemote        = isRemote(claszSymbol)
-      thisBType         = classBTypeFromSymbol(claszSymbol)
+      claszSymbol         = cd.symbol
+      isCZParcelable      = isAndroidParcelableClass(claszSymbol)
+      isCZStaticModule    = isStaticModuleClass(claszSymbol)
+      isCZRemote          = isRemote(claszSymbol)
+      thisBType           = classBTypeFromSymbol(claszSymbol)
+      thisBTypeDescriptor = thisBType.descriptor
 
       cnode = new ClassNode1()
 
@@ -194,7 +196,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
       val fv =
         cnode.visitField(mods,
                          strMODULE_INSTANCE_FIELD,
-                         thisBType.descriptor,
+                         thisBTypeDescriptor,
                          null, // no java-generic-signature
                          null  // no initial value
         )
@@ -622,7 +624,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
             if (!hasStaticBitSet) {
               mnode.visitLocalVariable(
                 "this",
-                thisBType.descriptor,
+                thisBTypeDescriptor,
                 null,
                 veryFirstProgramPoint,
                 onePastLastProgramPoint,

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -500,7 +500,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
               genDefDef(statified)
             } else {
               val forwarderDefDef = {
-                val dd1 = global.gen.mkStatic(deriveDefDef(dd)(_ => EmptyTree), traitSuperAccessorName(sym), _.cloneSymbol.withoutAnnotations)
+                val dd1 = global.gen.mkStatic(deriveDefDef(dd)(_ => EmptyTree), newTermName(traitSuperAccessorName(sym)), _.cloneSymbol.withoutAnnotations)
                 dd1.symbol.setFlag(Flags.ARTIFACT).resetFlag(Flags.OVERRIDE)
                 val selfParam :: realParams = dd1.vparamss.head.map(_.symbol)
                 deriveDefDef(dd1)(_ =>

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -593,7 +593,7 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
             annotatedNoInline = methodSym.hasAnnotation(ScalaNoInlineClass))
 
           if (needsStaticImplMethod(methodSym)) {
-            val staticName = traitSuperAccessorName(methodSym).toString
+            val staticName = traitSuperAccessorName(methodSym)
             val selfParam = methodSym.newSyntheticValueParam(methodSym.owner.typeConstructor, nme.SELF)
             val staticMethodType = methodSym.info match {
               case mt@MethodType(params, res) => copyMethodType(mt, selfParam :: params, res)


### PR DESCRIPTION
- Avoid repeating BType.toString for the descriptor of `this`
 - Reduce some temporary strings in `traitSuperAccessorName` usage