### PR TITLE
More imports clean up

### DIFF
--- a/test/files/neg/t11690.check
+++ b/test/files/neg/t11690.check
@@ -1,0 +1,6 @@
+t11690.scala:11: warning: Unused import
+  import X._
+           ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t11690.scala
+++ b/test/files/neg/t11690.scala
@@ -1,0 +1,18 @@
+
+// scalac: -Wunused:imports -Werror
+
+object X {
+  val v = 27
+}
+object Y {
+  val v = 42
+}
+object Main {
+  import X._
+  import Y.v
+  def main(args: Array[String]) = println {
+    //import Y.v // warns
+    v
+  }
+}
+


### PR DESCRIPTION
Besides the fix for unused imports, inlines a bit of code around implicit imports. Exploiting the idiom to ask for alternatives only when overloaded. No more parameter to "record usage", which is done only when done.

Fixes scala/bug#11690