### PR TITLE
Make test direct

### DIFF
--- a/test/files/pos/t10344.flags
+++ b/test/files/pos/t10344.flags
@@ -1,1 +1,0 @@
--Vprint:typer -language:higherKinds

--- a/test/files/pos/t10344.scala
+++ b/test/files/pos/t10344.scala
@@ -1,5 +1,0 @@
-object t10344 {
-  def unwrap[F[_]](f: F[Unit] => Unit): Unit = ()
-  val f: (=> Unit) => Unit = { _ => () }
-  unwrap(f)
-}

--- a/test/files/run/t10344.check
+++ b/test/files/run/t10344.check
@@ -1,0 +1,14 @@
+[[syntax trees at end of                     typer]] // newSource1.scala
+package <empty> {
+  object t10344 extends scala.AnyRef {
+    def <init>(): t10344.type = {
+      t10344.super.<init>();
+      ()
+    };
+    def unwrap[F[_] >: [_]Nothing <: [_]Any](f: F[Unit] => Unit): Unit = ();
+    private[this] val f: (=> Unit) => Unit = ((x$1: => Unit) => ());
+    <stable> <accessor> def f: (=> Unit) => Unit = t10344.this.f;
+    t10344.this.unwrap[<byname>](t10344.this.f)
+  }
+}
+

--- a/test/files/run/t10344.scala
+++ b/test/files/run/t10344.scala
@@ -1,0 +1,21 @@
+import scala.tools.partest.DirectTest
+
+object Test extends DirectTest {
+
+  override def extraSettings: String =
+    s"-usejavacp -Vprint:typer -language:higherKinds -Ystop-after:typer"
+
+  override def code = """
+object t10344 {
+  def unwrap[F[_]](f: F[Unit] => Unit): Unit = ()
+  val f: (=> Unit) => Unit = { _ => () }
+  unwrap(f)
+}
+  """
+
+  override def show(): Unit = {
+    Console.withErr(System.out) {
+      compile()
+    }
+  }
+}


### PR DESCRIPTION
Currently, the pos test tests for non-crasher, but output to stderr is noisy.

Neg test does not capture stderr.

Run test can do so, as seen in similar tests.