### PR TITLE
Use the first scalac-plugin.xml from the plugin classpath

### DIFF
--- a/src/compiler/scala/tools/nsc/plugins/Plugin.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugin.scala
@@ -152,9 +152,9 @@ object Plugin {
 
     val fromLoaders = paths.map {path =>
       val loader = findPluginClassloader(path)
-      loader.getResources(PluginXML).asScala.toList.lastOption match {
-        case None => Failure(new MissingPluginException(path))
-        case Some(url) =>
+      loader.getResource(PluginXML) match {
+        case null => Failure(new MissingPluginException(path))
+        case url =>
           val inputStream = url.openStream
           try {
             Try((PluginDescription.fromXML(inputStream), loader))

--- a/src/compiler/scala/tools/nsc/plugins/Plugins.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugins.scala
@@ -62,7 +62,8 @@ trait Plugins { global: Global =>
   /**
     * Locate or create the classloader to load a compiler plugin with `classpath`.
     *
-    * Subclasses may override to customise the behaviour.
+    * Subclasses may override to customise the behaviour. The returned classloader must return the first
+    * from plugin descriptor from `classpath` when `getResource("scalac-plugin.xml")` is called.
     *
     * @param classpath
     * @return


### PR DESCRIPTION
This commit reverts part of #8322

I recently changed to using the last entry from getResources to
avoid parent classloader delegation, but this leads to unwanted
results if the plugin classpath itself contains multiple
`scalac-plugin.xml` resources and wants the compiler to choose
the first.

I have _not_ reverted the other change in #8322 which overrides
`getResource` to avoid parent delegation for `scalac-plugin.xml`.
I have documented the `findPluginClassLoader` extension point
with instructions to do the same.