### PR TITLE
Precompile -i files for script runner

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -38,7 +38,7 @@ import scala.tools.nsc.symtab.{Flags, SymbolTable, SymbolTrackers}
 import scala.tools.nsc.transform._
 import scala.tools.nsc.transform.patmat.PatternMatching
 import scala.tools.nsc.typechecker._
-import scala.tools.nsc.util.{ClassPath, returning}
+import scala.tools.nsc.util.ClassPath
 
 class Global(var currentSettings: Settings, reporter0: Reporter)
     extends SymbolTable
@@ -1604,8 +1604,11 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
         val snap = profiler.beforePhase(Global.InitPhase)
 
         val sources: List[SourceFile] =
-          if (settings.script.isSetByUser && filenames.size > 1) returning(Nil)(_ => globalError("can only compile one script at a time"))
-          else filenames map getSourceFile
+          if (settings.script.isSetByUser && filenames.size > 1) {
+            globalError("can only compile one script at a time")
+            Nil
+          }
+          else filenames.map(getSourceFile)
 
         profiler.afterPhase(Global.InitPhase, snap)
         compileSources(sources)

--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -57,12 +57,12 @@ trait ScriptRunner {
 
 class DefaultScriptRunner(settings: GenericRunnerSettings) extends AbstractScriptRunner(settings) {
   protected def doCompile(scriptFile: String) = {
-    // Setting settings.script.value informs the compiler this is not a self-contained compilation unit.
-    settings.script.value = mainClass
     val reporter = new ConsoleReporter(settings)
     val compiler = newGlobal(settings, reporter)
-    val run      = new compiler.Run
-    run.compile(List(scriptFile))
+    if (settings.pastefiles.value.nonEmpty) new compiler.Run().compile(settings.pastefiles.value)
+    // Setting settings.script.value informs the compiler this is not a self-contained compilation unit.
+    settings.script.value = mainClass
+    new compiler.Run().compile(scriptFile :: Nil)
     !reporter.hasErrors
   }
 


### PR DESCRIPTION
This enables `scala -howtorun:script -i t4033b.scala -- t4033.scala`
where the main script depends on utility code in the `-i` files.

Fixes scala/bug#5161