### PR TITLE
Add `contains` and `exists` functions to `Try` type

### DIFF
--- a/test/files/jvm/future-spec/TryTests.scala
+++ b/test/files/jvm/future-spec/TryTests.scala
@@ -126,5 +126,27 @@ class TryTests extends MinimalScalaTest {
         }
       }
     }
+
+    "contains" in {
+      Success(1) contains 1 mustEqual true
+      Success(2) contains 1 mustEqual false
+      Failure(new Exception) contains 1 mustEqual false
+    }
+
+    "exists" in {
+      Success(1).exists(_ > 0) mustEqual true
+      Success(2).exists(_ < 1) mustEqual false
+
+      Failure(new Exception).exists(_ => true) mustEqual false
+      Failure(new Exception).exists(_ => false) mustEqual false
+    }
+
+    "forall" in {
+      Success(1).forall(_ > 0) mustEqual true
+      Success(2).forall(_ < 1) mustEqual false
+
+      Failure(new Exception).exists(_ => true) mustEqual true
+      Failure(new Exception).exists(_ => false) mustEqual true
+    }
   }
 }

--- a/test/files/jvm/try-type-tests.scala
+++ b/test/files/jvm/try-type-tests.scala
@@ -63,6 +63,46 @@ trait TryStandard {
     t.recoverWith{ case x => assert(false); Try(()) }
   }
 
+  def testContainsSuccess(): Unit = {
+    val t = Success(1)
+
+    assert(t contains 1)
+    assert(!t.contains(2))
+  }
+
+  def testContainsFailure(): Unit = {
+    val t = Failure(new Exception("foo"))
+
+    assert(!t.contains(1))
+  }
+
+  def testExistsSuccess(): Unit = {
+    val t = Success(1)
+
+    assert(t.exists(_ > 0))
+    assert(!t.exists(_ <= 0))
+  }
+
+  def testExistsFailure(): Unit = {
+    val t = Failure(new Exception("foo"))
+
+    assert(!t.exists(_ => true))
+  }
+
+  def testForallSuccess(): Unit = {
+    val t = Success(1)
+
+    assert(t.forall(_ > 0))
+    assert(!t.forall(_ <= 0))
+  }
+
+  def testForallFailure(): Unit = {
+    val t = Failure(new Exception("foo"))
+
+    assert(t.forall(_ => false))
+    assert(t.forall(_ => true))
+  }
+
   def testRescueFailure(): Unit = {
     val t = Failure(new Exception("foo"))
     val n = t.recoverWith{ case x => Try(1) }


### PR DESCRIPTION
Hi,

I may have miss some discussion about that, but as I don't find a corresponding Issue or PullRequest, I would rather push this one as a suggestion to add `.contains(value)` and `.exists(predicate)` on `scala.util.Try` type.

Currently it could be expressed using pattern matching or `Try.filter`, but more verbosely.

*contains:*

```scala
import scala.util._

def computation: Try[String] = ???
def expected: String = "foo"

def currentContains1: Boolean = computation match {
  case Success(x) => x == expected
  case Failure(_) => false
}

def currentContains2: Boolean =
  computation.filter(_ == expected).isSuccess

// With added .contains:
computation.contains(expected)

// Specs (similar to those for existing types such as collection or Option)
Success(1).contains(1) // true
Success(2).contains(1) // false
Failure(new Exception("foo")).contains(1) // false
```

*exists:*

```scala
import scala.util._

def computation: Try[String] = ???
val predicate: String => Boolean = _.size > 4

def currentExists1: Boolean = computation match {
  case Success(x) => predicate(x)
  case Failure(_) => false
}

def currentExists2: Boolean = computation.filter(predicate).isSuccess

// With added .exists:
computation.exists(predicate)

// Specs
Success(1).exists(_ > 0) // true
Success(2).exists(_ <= 1) // false
Failure(new Exception("foo")).exists(_ => true) // false
```