### PR TITLE
Fix warnings in doc comments

### DIFF
--- a/src/compiler/scala/reflect/macros/compiler/DefaultMacroCompiler.scala
+++ b/src/compiler/scala/reflect/macros/compiler/DefaultMacroCompiler.scala
@@ -38,8 +38,9 @@ abstract class DefaultMacroCompiler extends Resolvers
   /** Resolves a macro impl reference provided in the right-hand side of the given macro definition.
    *
    *  Acceptable shapes of the right-hand side:
-   *    1) [<static object>].<method name>[[<type args>]] // vanilla macro impl ref
-   *    2) [<macro bundle>].<method name>[[<type args>]]  // shiny new macro bundle impl ref
+   *
+   *    1. `[<static object>].<method name>[ [<type args>] ] // vanilla macro impl ref`
+   *    1. `[<macro bundle>].<method name>[ [<type args>] ]  // shiny new macro bundle impl ref`
    *
    *  Produces a tree, which represents a reference to a macro implementation if everything goes well,
    *  otherwise reports found errors and returns EmptyTree. The resulting tree should have the following format:

--- a/src/compiler/scala/tools/nsc/ObjectRunner.scala
+++ b/src/compiler/scala/tools/nsc/ObjectRunner.scala
@@ -21,9 +21,9 @@ trait CommonRunner {
   /** Run a given object, specified by name, using a
    *  specified classpath and argument list.
    *
-   *  @throws ClassNotFoundException
-   *  @throws NoSuchMethodException
-   *  @throws InvocationTargetException
+   *  @throws java.lang.ClassNotFoundException
+   *  @throws java.lang.NoSuchMethodException
+   *  @throws java.lang.reflect.InvocationTargetException
    */
   def run(urls: Seq[URL], objectName: String, arguments: Seq[String]): Unit =
     ScalaClassLoader.fromURLs(urls).run(objectName, arguments)

--- a/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
@@ -203,7 +203,7 @@ trait MarkupParsers {
     }
 
     /** adds entity/character to ts as side-effect
-     *  @precond ch == '&'
+     *  @note Pre-condition: ch == '&'
      */
     def content_AMP(ts: ArrayBuffer[Tree]): Unit = {
       nextch()
@@ -223,8 +223,8 @@ trait MarkupParsers {
     }
 
     /**
-     *  @precond ch == '{'
-     *  @postcond: xEmbeddedBlock == false!
+     *  @note Pre-condition: ch == '{'
+     *  @note Post-condition: xEmbeddedBlock == false!
      */
     def content_BRACE(p: Position, ts: ArrayBuffer[Tree]): Unit =
       if (xCheckEmbeddedBlock) ts += xEmbeddedExpr

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -209,8 +209,8 @@ trait Scanners extends ScannersCommon {
       }
     }
 
-    /** @pre ch == '/'
-     *  Returns true if a comment was skipped.
+    /** Returns true if a comment was skipped.
+     *  @note Pre-condition: ch == '/'
      */
     final def skipComment(): Boolean = ch match {
       case '/' | '*' => skipToCommentEnd(isLineComment = ch == '/') ; finishDocComment(); true

--- a/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
@@ -143,7 +143,7 @@ abstract class SymbolicXMLBuilder(p: Parsers#Parser, preserveWS: Boolean) {
   protected def Comment(txt: Tree)                  = New(_scala_xml_Comment, LL(txt))
   protected def ProcInstr(target: Tree, txt: Tree)  = New(_scala_xml_ProcInstr, LL(target, txt))
 
-  /** @todo: attributes */
+  /** @todo attributes */
   def makeXMLpat(pos: Position, n: String, args: scala.collection.Seq[Tree]): Tree = {
     val (prepat, labpat) = splitPrefix(n) match {
       case (Some(pre), rest)  => (const(pre), const(rest))

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -468,7 +468,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
 
     /**
      * Annotations are not processed by the compilation pipeline like ordinary trees. Instead, the
-     * typer extracts them into [[AnnotationInfo]] objects which are attached to the corresponding
+     * typer extracts them into [[scala.reflect.internal.AnnotationInfos.AnnotationInfo]] objects which are attached to the corresponding
      * symbol (sym.annotations) or type (as an AnnotatedType, eliminated by erasure).
      *
      * For Scala annotations this is OK: they are stored in the pickle and ignored by the backend.
@@ -1066,11 +1066,11 @@ object BCodeHelpers {
 
     /**
      * The data in `bytes` mapped to 7-bit bytes and then each element incremented by 1 (modulo 0x80).
-     * This implements parts of the encoding documented in [[ByteCodecs]]. 0x00 values are NOT
+     * This implements parts of the encoding documented in [[scala.reflect.internal.pickling.ByteCodecs]]. 0x00 values are NOT
      * mapped to the overlong encoding (0xC0 0x80) but left as-is.
      * When creating a String from this array and writing it to a classfile as annotation argument
      * using ASM, the ASM library will replace 0x00 values by the overlong encoding. So the data in
-     * the classfile will have the format documented in [[ByteCodecs]].
+     * the classfile will have the format documented in [[scala.reflect.internal.pickling.ByteCodecs]].
      */
     lazy val sevenBitsMayBeZero: Array[Byte] = mapToNextModSevenBits(ByteCodecs.encode8to7(bytes))
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
@@ -60,7 +60,7 @@ abstract class BTypesFromClassfile {
   }
 
   /**
-   * Parse the classfile for `internalName` and construct the [[ClassBType]]. If the classfile cannot
+   * Parse the classfile for `internalName` and construct the [[BTypes.ClassBType]]. If the classfile cannot
    * be found in the `byteCodeRepository`, the `info` of the resulting ClassBType is undefined.
    */
   def classBTypeFromParsedClassfile(internalName: InternalName): ClassBType = {
@@ -73,7 +73,7 @@ abstract class BTypesFromClassfile {
   }
 
   /**
-   * Construct the [[ClassBType]] for a parsed classfile.
+   * Construct the [[BTypes.ClassBType]] for a parsed classfile.
    */
   def classBTypeFromClassNode(classNode: ClassNode): ClassBType = {
     ClassBType(classNode.name, fromSymbol = false) { res: ClassBType =>

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -520,7 +520,7 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
   }
 
   /**
-   * Build the [[InlineInfo]] for a class symbol.
+   * Build the [[scala.tools.nsc.backend.jvm.BTypes.InlineInfo]] for a class symbol.
    */
   def buildInlineInfoFromClassSymbol(classSym: Symbol): InlineInfo = {
     val isEffectivelyFinal = classSym.isEffectivelyFinal

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -1077,7 +1077,7 @@ abstract class Inliner {
   }
 
   /**
-   * Check if a member reference is accessible from the [[destinationClass]], as defined in the
+   * Check if a member reference is accessible from the `destinationClass`, as defined in the
    * JVMS 5.4.4. Note that the class name in a field / method reference is not necessarily the
    * class in which the member is declared:
    *

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -351,7 +351,7 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
 
     /**
      * Get an array of bytes stored in the classfile as a string. The data is encoded in the format
-     * described in object [[ByteCodecs]]. Used for the ScalaSignature annotation argument.
+     * described in object [[scala.reflect.internal.pickling.ByteCodecs]]. Used for the ScalaSignature annotation argument.
      */
     def getBytes(index: Int): Array[Byte] = {
       if (index <= 0 || len <= index) errorBadIndex(index)
@@ -368,7 +368,7 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
 
     /**
      * Get an array of bytes stored in the classfile as an array of strings. The data is encoded in
-     * the format described in object [[ByteCodecs]]. Used for the ScalaLongSignature annotation
+     * the format described in object [[scala.reflect.internal.pickling.ByteCodecs]]. Used for the ScalaLongSignature annotation
      * argument.
      */
     def getBytes(indices: List[Int]): Array[Byte] = {

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -364,7 +364,7 @@ abstract class ExplicitOuter extends InfoTransform
      *
      *  @param mixinClass The mixin class which defines the abstract outer
      *                    accessor which is implemented by the generated one.
-     *  @pre mixinClass is an inner class
+     *  @note Pre-condition: `mixinClass` is an inner class
      */
     def mixinOuterAccessorDef(mixinClass: Symbol): Tree = {
       val outerAcc    = outerAccessor(mixinClass) overridingSymbol currentClass

--- a/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
+++ b/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
@@ -113,7 +113,7 @@ trait TypeAdaptingTransformer { self: TreeDSL =>
 
     /** Generate a synthetic cast operation from tree.tpe to pt.
       *
-      *  @pre pt eq pt.normalize
+      *  @note Pre-condition: pt eq pt.normalize
      */
     final def cast(tree: Tree, pt: Type): Tree = {
       if (settings.debug && (tree.tpe ne null) && !(tree.tpe =:= ObjectTpe)) {

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -208,9 +208,9 @@ trait Contexts { self: Analyzer =>
    *     applications with and without an expected type, or when `Typer#tryTypedApply` tries to fit arguments to
    *     a function type with/without implicit views.
    *
-   *     When the error policies entail error/warning buffering, the mutable [[ReportBuffer]] records
+   *     When the error policies entail error/warning buffering, the mutable [[ContextReporter]] records
    *     everything that is issued. It is important to note, that child Contexts created with `make`
-   *     "inherit" the very same `ReportBuffer` instance, whereas children spawned through `makeSilent`
+   *     "inherit" the very same `ContextReporter` instance, whereas children spawned through `makeSilent`
    *     receive a separate, fresh buffer.
    *
    * @param tree  Tree associated with this context
@@ -1606,7 +1606,7 @@ trait Contexts { self: Analyzer =>
     // Implicit relies on this most heavily, but there you know reporter.isInstanceOf[BufferingReporter]
     // can we encode this statically?
 
-    // have to pass in context because multiple contexts may share the same ReportBuffer
+    // have to pass in context because multiple contexts may share the same ContextReporter
     def reportFirstDivergentError(fun: Tree, param: Symbol, paramTp: Type)(implicit context: Context): Unit =
       errors.collectFirst {
         case dte: DivergentImplicitTypeError => dte

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -267,7 +267,7 @@ trait Infer extends Checkable {
 
     /** Check that `sym` is defined and accessible as a member of
      *  tree `site` with type `pre` in current context.
-     *  @PP: In case it's not abundantly obvious to anyone who might read
+     *  @note PP: In case it's not abundantly obvious to anyone who might read
      *  this, the method does a lot more than "check" these things, as does
      *  nearly every method in the compiler, so don't act all shocked.
      *  This particular example "checks" its way to assigning both the
@@ -725,7 +725,7 @@ trait Infer extends Checkable {
     }
 
     /** The type of an argument list after being coerced to a tuple.
-     *  @pre: the argument list is eligible for tuple conversion.
+     *  @note Pre-condition: The argument list is eligible for tuple conversion.
      */
     private def typeAfterTupleConversion(argtpes: List[Type]): Type =
       if (argtpes.isEmpty) UnitTpe                 // aka "Tuple0"
@@ -1448,7 +1448,7 @@ trait Infer extends Checkable {
      *    the type is replaces by `Unit`, i.e. the argument is treated as an
      *    assignment expression.
      *
-     *  @pre  tree.tpe is an OverloadedType.
+     *  @note Pre-condition `tree.tpe` is an `OverloadedType`.
      */
     def inferMethodAlternative(tree: Tree, undetparams: List[Symbol], argtpes0: List[Type], pt0: Type): Unit = {
       // This potentially makes up to four attempts: tryOnce may execute

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -128,6 +128,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
    *
    *  We will have the following annotation added on the macro definition `foo`:
    *
+   *  {{{
    *    @scala.reflect.macros.internal.macroImpl(
    *      `macro`(
    *        "macroEngine" = <current macro engine>,
@@ -136,6 +137,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
    *        "signature" = List(Other),
    *        "methodName" = "impl",
    *        "className" = "Macros$"))
+   *  }}}
    */
   def macroEngine = "v7.0 (implemented in Scala 2.11.0-M8)"
   object MacroImplBinding {

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -117,8 +117,8 @@ trait NamesDefaults { self: Analyzer =>
    * @param mode the mode to use for calling typer.doTypedApply
    * @param pt the expected type for calling typer.doTypedApply
    *
-   * @param tree: the function application tree
-   * @argPos: a function mapping arguments from their current position to the
+   * @param tree the function application tree
+   * @param argPos a function mapping arguments from their current position to the
    *   position specified by the method type. example:
    *    def foo(a: Int, b: String)
    *    foo(b = "1", a = 2)

--- a/src/compiler/scala/tools/nsc/util/DocStrings.scala
+++ b/src/compiler/scala/tools/nsc/util/DocStrings.scala
@@ -44,7 +44,7 @@ object DocStrings {
   /** Returns index of string `str` after `start` skipping longest
    *  sequence of space and tab characters, possibly also containing
    *  a single `*` character or the `/``**` sequence.
-   *  @pre  start == str.length || str(start) == `\n`
+   *  @note Pre-condition:  start == str.length || str(start) == `\n`
    */
   def skipLineLead(str: String, start: Int): Int =
     if (start == str.length) start

--- a/src/interactive/scala/tools/nsc/interactive/CompilerControl.scala
+++ b/src/interactive/scala/tools/nsc/interactive/CompilerControl.scala
@@ -85,7 +85,7 @@ trait CompilerControl { self: Global =>
   }
 
   /** Locate smallest tree that encloses position
-   *  @pre Position must be loaded
+   *  @note Pre-condition: Position must be loaded
    */
   def locateTree(pos: Position): Tree = onUnitOf(pos.source) { unit => new Locator(pos) locateIn unit.body }
 
@@ -131,7 +131,7 @@ trait CompilerControl { self: Global =>
     postWorkItem(new AskTypeAtItem(pos, response))
 
   /** Sets sync var `response` to the fully attributed & typechecked tree contained in `source`.
-   *  @pre `source` needs to be loaded.
+   *  @note Pre-condition: `source` needs to be loaded.
    *  @note Deprecated because of race conditions in the typechecker when the background compiler
    *        is interrupted while typing the same `source`.
    *  @see  scala/bug#6578
@@ -175,14 +175,14 @@ trait CompilerControl { self: Global =>
 
   /** Sets sync var `response` to list of members that are visible
    *  as members of the tree enclosing `pos`, possibly reachable by an implicit.
-   *  @pre  source is loaded
+   *  @note Pre-condition: source is loaded
    */
   def askTypeCompletion(pos: Position, response: Response[List[Member]]) =
     postWorkItem(new AskTypeCompletionItem(pos, response))
 
   /** Sets sync var `response` to list of members that are visible
    *  as members of the scope enclosing `pos`.
-   *  @pre  source is loaded
+   *  @note  Pre-condition: source is loaded
    */
   def askScopeCompletion(pos: Position, response: Response[List[Member]]) =
     postWorkItem(new AskScopeCompletionItem(pos, response))

--- a/src/interactive/scala/tools/nsc/interactive/Lexer.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Lexer.scala
@@ -170,7 +170,7 @@ class Lexer(rd: Reader) {
   /** If last-read character equals given character, reads next character,
    *  otherwise raises an error
    *  @param  c   the given character to compare with last-read character
-   *  @throws  MalformedInput if character does not match
+   *  @throws  Lexer.MalformedInput if character does not match
    */
   def acceptChar(c: Char) = if (ch == c) nextChar() else error("'"+c+"' expected")
 
@@ -186,7 +186,7 @@ class Lexer(rd: Reader) {
   }
 
   /** Skips whitespace and reads next lexeme into `token`
-   *  @throws  MalformedInput if lexeme not recognized as a valid token
+   *  @throws  Lexer.MalformedInput if lexeme not recognized as a valid token
    */
   def nextToken(): Unit = {
     sb.clear()
@@ -214,7 +214,7 @@ class Lexer(rd: Reader) {
 
   /** Reads a string literal, and forms a `StringLit` token from it.
    *  Last-read input character `ch` must be opening `"`-quote.
-   *  @throws  MalformedInput if lexeme not recognized as a string literal.
+   *  @throws  Lexer.MalformedInput if lexeme not recognized as a string literal.
    */
   def getString(): Unit = {
     def udigit() = {
@@ -253,7 +253,7 @@ class Lexer(rd: Reader) {
 
   /** Reads a numeric literal, and forms an `IntLit` or `FloatLit` token from it.
    *  Last-read input character `ch` must be either `-` or a digit.
-   *  @throws  MalformedInput if lexeme not recognized as a numeric literal.
+   *  @throws  Lexer.MalformedInput if lexeme not recognized as a numeric literal.
    */
   def getNumber(): Unit = {
     def digit() =
@@ -281,7 +281,7 @@ class Lexer(rd: Reader) {
 
   /** If current token equals given token, reads next token, otherwise raises an error.
    *  @param  t   the given token to compare current token with
-   *  @throws MalformedInput  if the two tokens do not match.
+   *  @throws Lexer.MalformedInput  if the two tokens do not match.
    */
   def accept(t: Token): Unit = {
     if (token == t) nextToken()
@@ -291,7 +291,7 @@ class Lexer(rd: Reader) {
   /** The current token is a delimiter consisting of given character, reads next token,
    *  otherwise raises an error.
    *  @param  ch   the given delimiter character to compare current token with
-   *  @throws MalformedInput  if the current token `token` is not a delimiter, or
+   *  @throws Lexer.MalformedInput  if the current token `token` is not a delimiter, or
    *                          consists of a character different from `c`.
    */
   def accept(ch: Char): Unit = {
@@ -301,7 +301,7 @@ class Lexer(rd: Reader) {
     }
   }
 
-  /** Always throws a `MalformedInput` exception with given error message.
+  /** Always throws a [[Lexer.MalformedInput]] exception with given error message.
    *  @param msg  the error message
    */
   def error(msg: String) = throw new MalformedInput(this, msg)

--- a/src/interactive/scala/tools/nsc/interactive/Pickler.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Pickler.scala
@@ -53,8 +53,8 @@ abstract class Pickler[T] {
    *  @return An `UnpickleSuccess` value if the current input corresponds to the
    *          kind of value that is unpickled by the current subclass of `Pickler`,
    *          an `UnpickleFailure` value otherwise.
-   *  @throws  `Lexer.MalformedInput` if input is invalid, or if
-   *          an `Unpickle
+   *  @throws Lexer.MalformedInput if input is invalid, or if
+   *          an `Unpickle`
    */
   def unpickle(rd: Lexer): Unpickled[T]
 
@@ -68,7 +68,7 @@ abstract class Pickler[T] {
   /** A pickler that adds a label to the current pickler, using the representation
    *   `label ( <current pickler> )`
    *
-   *  @label  the string to be added as a label.
+   *  @param  label the string to be added as a label.
    */
   def labelled(label: String): Pickler[T] = labelledPickler(label, this)
 
@@ -125,7 +125,7 @@ object Pickler {
     }
 
     /** Transforms failures into thrown `MalformedInput` exceptions.
-     *  @throws  MalformedInput   if current result is a failure
+     *  @throws  Lexer.MalformedInput   if current result is a failure
      */
     def requireSuccess: UnpickleSuccess[T] = this match {
       case s @ UnpickleSuccess(x) => s

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -118,7 +118,7 @@ object Predef extends LowPriorityImplicits {
    * // mapIntString is java.lang.Class[Map[Int,String]] = interface scala.collection.immutable.Map
    * }}}
    *
-   * @return The runtime [[Class]] representation of type [[T]].
+   * @return The runtime [[Class]] representation of type `T`.
    * @group utilities
    */
   def classOf[T]: Class[T] = null // This is a stub method. The actual implementation is filled in by the compiler.
@@ -207,7 +207,7 @@ object Predef extends LowPriorityImplicits {
   /**
    * A method that returns its input value.
    * @tparam A type of the input value x.
-   * @param x the value of type [[A]] to be returned.
+   * @param x the value of type `A` to be returned.
    * @return the value `x`.
    * @group utilities */
   @inline def identity[A](x: A): A = x // see `$conforms` for the implicit version

--- a/src/library/scala/SerialVersionUID.scala
+++ b/src/library/scala/SerialVersionUID.scala
@@ -16,7 +16,7 @@ package scala
   * Annotation for specifying the `serialVersionUID` field of a (serializable) class.
   *
   * On the JVM, a class with this annotation will receive a `private`, `static`,
-  * and `final` field called `serialVersionUID` with the provided [[value]],
+  * and `final` field called `serialVersionUID` with the provided `value`,
   * which the JVM's serialization mechanism uses to determine serialization
   * compatibility between different versions of a class.
   *

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -163,7 +163,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     * @note When implementing a custom collection type and refining `C` to the new type, this
     *       method needs to be overridden (the compiler will issue an error otherwise). In the
     *       common case where `C =:= CC[A]`, this can be done by mixing in the
-    *       [[IterableFactoryDefaults]] trait, which implements the method using
+    *       [[scala.collection.IterableFactoryDefaults]] trait, which implements the method using
     *       [[iterableFactory]].
     *
     * @note As witnessed by the `@uncheckedVariance` annotation, using this method
@@ -188,7 +188,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   /**
     * @return a strict builder for the same collection type.
     *
-    * Note that in the case of lazy collections (e.g. [[View]] or [[immutable.LazyList]]),
+    * Note that in the case of lazy collections (e.g. [[scala.collection.View]] or [[scala.collection.immutable.LazyList]]),
     * it is possible to implement this method but the resulting `Builder` will break laziness.
     * As a consequence, operations should preferably be implemented with `fromSpecific`
     * instead of this method.
@@ -196,7 +196,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     * @note When implementing a custom collection type and refining `C` to the new type, this
     *       method needs to be overridden (the compiler will issue an error otherwise). In the
     *       common case where `C =:= CC[A]`, this can be done by mixing in the
-    *       [[IterableFactoryDefaults]] trait, which implements the method using
+    *       [[scala.collection.IterableFactoryDefaults]] trait, which implements the method using
     *       [[iterableFactory]].
     *
     * @note As witnessed by the `@uncheckedVariance` annotation, using this method might

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -43,22 +43,22 @@ trait IterableOnce[+A] extends Any {
   /** Iterator can be used only once */
   def iterator: Iterator[A]
 
-  /** Returns a [[Stepper]] for the elements of this collection.
+  /** Returns a [[scala.collection.Stepper]] for the elements of this collection.
     *
     * The Stepper enables creating a Java stream to operate on the collection, see
     * [[scala.jdk.StreamConverters]]. For collections holding primitive values, the Stepper can be
     * used as an iterator which doesn't box the elements.
     *
-    * The implicit [[StepperShape]] parameter defines the resulting Stepper type according to the
+    * The implicit [[scala.collection.StepperShape]] parameter defines the resulting Stepper type according to the
     * element type of this collection.
     *
-    *   - For collections of `Int`, `Short`, `Byte` or `Char`, an [[IntStepper]] is returned
-    *   - For collections of `Double` or `Float`, a [[DoubleStepper]] is returned
-    *   - For collections of `Long` a [[LongStepper]] is returned
-    *   - For any other element type, an [[AnyStepper]] is returned
+    *   - For collections of `Int`, `Short`, `Byte` or `Char`, an [[scala.collection.IntStepper]] is returned
+    *   - For collections of `Double` or `Float`, a [[scala.collection.DoubleStepper]] is returned
+    *   - For collections of `Long` a [[scala.collection.LongStepper]] is returned
+    *   - For any other element type, an [[scala.collection.AnyStepper]] is returned
     *
     * Note that this method is overridden in subclasses and the return type is refined to
-    * `S with EfficientSplit`, for example [[IndexedSeqOps.stepper]]. For Steppers marked with
+    * `S with EfficientSplit`, for example [[scala.collection.IndexedSeqOps.stepper]]. For Steppers marked with
     * [[scala.collection.Stepper.EfficientSplit]], the converters in [[scala.jdk.StreamConverters]]
     * allow creating parallel streams, whereas bare Steppers can be converted only to sequential
     * streams.

--- a/src/library/scala/collection/Stepper.scala
+++ b/src/library/scala/collection/Stepper.scala
@@ -30,7 +30,7 @@ import scala.collection.Stepper.EfficientSplit
   *
   * The selection of primitive types (`Int`, `Long` and `Double`) matches the hand-specialized
   * variants of Java Streams ([[java.util.stream.Stream]], [[java.util.stream.IntStream]], etc.)
-  * and the corresponding Java Spliterators ([[Spliterator]], [[Spliterator.OfInt]], etc.).
+  * and the corresponding Java Spliterators ([[java.util.Spliterator]], [[java.util.Spliterator.OfInt]], etc.).
   *
   * Steppers can be converted to Scala Iterators, Java Iterators and Java Spliterators. Primitive
   * Steppers are converted to the corresponding primitive Java Iterators and Spliterators.
@@ -49,29 +49,29 @@ trait Stepper[@specialized(Double, Int, Long) +A] {
     *
     * May return `null`, in which case the current Stepper yields the same elements as before.
     *
-    * See method `trySplit` in [[Spliterator]].
+    * See method `trySplit` in [[java.util.Spliterator]].
     */
   def trySplit(): Stepper[A]
 
   /** Returns an estimate of the number of elements of this Stepper, or [[Long.MaxValue]]. See
-    * method `estimateSize` in [[Spliterator]].
+    * method `estimateSize` in [[java.util.Spliterator]].
     */
   def estimateSize: Long
 
   /** Returns a set of characteristics of this Stepper and its elements. See method
-    * `characteristics` in [[Spliterator]].
+    * `characteristics` in [[java.util.Spliterator]].
     */
   def characteristics: Int
 
-  /** Returns a [[Spliterator]] corresponding to this Stepper.
+  /** Returns a [[java.util.Spliterator]] corresponding to this Stepper.
     *
     * Note that the return type is `Spliterator[_]` instead of `Spliterator[A]` to allow returning
-    * a [[Spliterator.OfInt]] (which is a `Spliterator[Integer]`) in the subclass [[IntStepper]]
+    * a [[java.util.Spliterator.OfInt]] (which is a `Spliterator[Integer]`) in the subclass [[IntStepper]]
     * (which is a `Stepper[Int]`).
     */
   def spliterator[B >: A]: Spliterator[_]
 
-  /** Returns a Java [[JIterator]] corresponding to this Stepper.
+  /** Returns a Java [[java.util.Iterator]] corresponding to this Stepper.
     *
     * Note that the return type is `Iterator[_]` instead of `Iterator[A]` to allow returning
     * a [[java.util.PrimitiveIterator.OfInt]] (which is a `Iterator[Integer]`) in the subclass

--- a/src/library/scala/collection/convert/StreamExtensions.scala
+++ b/src/library/scala/collection/convert/StreamExtensions.scala
@@ -24,7 +24,7 @@ import scala.jdk.CollectionConverters._
 import scala.jdk._
 
 /** Defines extension methods to create Java Streams for Scala collections, available through
-  * [[scala.jdk.StreamConverters.Ops]].
+  * [[scala.jdk.javaapi.StreamConverters]].
   */
 trait StreamExtensions {
   // collections
@@ -246,14 +246,14 @@ trait StreamExtensions {
     /**
      * Copy the elements of this stream into a Scala collection.
      *
-     * Converting a parallel streams to an [[Accumulator]] using `stream.toScala(Accumulator)`
+     * Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
      * builds the result in parallel.
      *
      * A `toScala(Accumulator)` call automatically converts streams of boxed integers, longs or
-     * doubles are converted to the primitive accumulators ([[IntAccumulator]], etc.).
+     * doubles are converted to the primitive accumulators ([[scala.jdk.IntAccumulator]], etc.).
      *
      * When converting a parallel stream to a different Scala collection, the stream is first
-     * converted into an [[Accumulator]], which supports parallel building. The accumulator is
+     * converted into an [[scala.jdk.Accumulator]], which supports parallel building. The accumulator is
      * then converted to the target collection. Note that the stream is processed eagerly while
      * building the accumulator, even if the target collection is lazy.
      *
@@ -281,14 +281,14 @@ trait StreamExtensions {
     /**
      * Copy the elements of this stream into a Scala collection.
      *
-     * Converting a parallel streams to an [[Accumulator]] using `stream.toScala(Accumulator)`
+     * Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
      * builds the result in parallel.
      *
      * A `toScala(Accumulator)` call automatically converts the `IntStream` to a primitive
-     * [[IntAccumulator]].
+     * [[scala.jdk.IntAccumulator]].
      *
      * When converting a parallel stream to a different Scala collection, the stream is first
-     * converted into an [[Accumulator]], which supports parallel building. The accumulator is
+     * converted into an [[scala.jdk.Accumulator]], which supports parallel building. The accumulator is
      * then converted to the target collection. Note that the stream is processed eagerly while
      * building the accumulator, even if the target collection is lazy.
      *
@@ -308,14 +308,14 @@ trait StreamExtensions {
     /**
      * Copy the elements of this stream into a Scala collection.
      *
-     * Converting a parallel streams to an [[Accumulator]] using `stream.toScala(Accumulator)`
+     * Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
      * builds the result in parallel.
      *
      * A `toScala(Accumulator)` call automatically converts the `LongStream` to a primitive
-     * [[LongAccumulator]].
+     * [[scala.jdk.LongAccumulator]].
      *
      * When converting a parallel stream to a different Scala collection, the stream is first
-     * converted into an [[Accumulator]], which supports parallel building. The accumulator is
+     * converted into an [[scala.jdk.Accumulator]], which supports parallel building. The accumulator is
      * then converted to the target collection. Note that the stream is processed eagerly while
      * building the accumulator, even if the target collection is lazy.
      *
@@ -335,14 +335,14 @@ trait StreamExtensions {
     /**
      * Copy the elements of this stream into a Scala collection.
      *
-     * Converting a parallel streams to an [[Accumulator]] using `stream.toScala(Accumulator)`
+     * Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
      * builds the result in parallel.
      *
      * A `toScala(Accumulator)` call automatically converts the `DoubleStream` to a primitive
-     * [[DoubleAccumulator]].
+     * [[scala.jdk.DoubleAccumulator]].
      *
      * When converting a parallel stream to a different Scala collection, the stream is first
-     * converted into an [[Accumulator]], which supports parallel building. The accumulator is
+     * converted into an [[scala.jdk.Accumulator]], which supports parallel building. The accumulator is
      * then converted to the target collection. Note that the stream is processed eagerly while
      * building the accumulator, even if the target collection is lazy.
      *
@@ -439,7 +439,7 @@ object StreamExtensions {
 
 
   /** An implicit `AccumulatorFactoryInfo` connects primitive element types to the corresponding
-    * specialized [[Accumulator]] factory. This is used in the `stream.toScala` extension methods
+    * specialized [[scala.jdk.Accumulator]] factory. This is used in the `stream.toScala` extension methods
     * to ensure collecting a primitive stream into a primitive accumulator does not box.
     *
     * When converting to a collection other than `Accumulator`, the generic

--- a/src/library/scala/jdk/Accumulator.scala
+++ b/src/library/scala/jdk/Accumulator.scala
@@ -57,7 +57,7 @@ import scala.collection.{Stepper, StepperShape, mutable}
   * [[IntAccumulator.map(f: Int => Int)* IntAccumulator.map]] or [[IntAccumulator.exists]]. Thanks to Scala's function specialization,
   * `intAcc.exists(x => testOn(x))` does not incur boxing.
   *
-  * The [[Stepper]] interface provides iterator-like `hasStep` and `nextStep` methods, and is
+  * The [[scala.collection.Stepper]] interface provides iterator-like `hasStep` and `nextStep` methods, and is
   * specialized for `Int`, `Long` and `Double`. The `intAccumulator.stepper` method creates an
   * [[scala.collection.IntStepper]] that yields the elements of the accumulator without boxing.
   *

--- a/src/library/scala/jdk/FutureConverters.scala
+++ b/src/library/scala/jdk/FutureConverters.scala
@@ -16,14 +16,14 @@ import java.util.concurrent.CompletionStage
 
 import scala.concurrent.Future
 
-/** This object provides extension methods that convert between Scala [[Future]] and Java
-  * [[CompletionStage]]
+/** This object provides extension methods that convert between Scala [[scala.concurrent.Future]] and Java
+  * [[java.util.concurrent.CompletionStage]]
   *
   * When writing Java code, use the explicit conversion methods defined in
   * [[javaapi.FutureConverters]] instead.
   *
   * Note that the bridge is implemented at the read-only side of asynchronous handles, namely
-  * [[Future]] (instead of [[scala.concurrent.Promise]]) and [[CompletionStage]] (instead of
+  * [[scala.concurrent.Future]] (instead of [[scala.concurrent.Promise]]) and [[java.util.concurrent.CompletionStage]] (instead of
   * [[java.util.concurrent.CompletableFuture]]). This is intentional, as the semantics of bridging
   * the write-handles would be prone to race conditions; if both ends (`CompletableFuture` and
   * `Promise`) are completed independently at the same time, they may contain different values

--- a/src/library/scala/jdk/javaapi/DurationConverters.scala
+++ b/src/library/scala/jdk/javaapi/DurationConverters.scala
@@ -29,7 +29,7 @@ object  DurationConverters {
     * the Scala duration will have a time unit of nanoseconds.
     *
     * @throws IllegalArgumentException If the given Java Duration is out of bounds of what can be
-    *                                  expressed by [[FiniteDuration]].
+    *                                  expressed by [[scala.concurrent.duration.FiniteDuration]].
     */
   def toScala(duration: JDuration): FiniteDuration = {
     val originalSeconds = duration.getSeconds

--- a/src/library/scala/jdk/javaapi/FutureConverters.scala
+++ b/src/library/scala/jdk/javaapi/FutureConverters.scala
@@ -17,13 +17,13 @@ import java.util.concurrent.CompletionStage
 import scala.concurrent.impl.FutureConvertersImpl.{CF, P}
 import scala.concurrent.{ExecutionContext, Future}
 
-/** This object contains methods that convert between Scala [[Future]] and Java [[CompletionStage]].
+/** This object contains methods that convert between Scala [[scala.concurrent.Future]] and Java [[java.util.concurrent.CompletionStage]].
   *
   * The explicit conversion methods defined here are intended to be used in Java code. For Scala
   * code, it is recommended to use the extension methods defined in [[scala.jdk.FutureConverters]].
   *
   * Note that the bridge is implemented at the read-only side of asynchronous handles, namely
-  * [[Future]] (instead of [[scala.concurrent.Promise]]) and [[CompletionStage]] (instead of
+  * [[scala.concurrent.Future]] (instead of [[scala.concurrent.Promise]]) and [[java.util.concurrent.CompletionStage]] (instead of
   * [[java.util.concurrent.CompletableFuture]]). This is intentional, as the semantics of bridging
   * the write-handles would be prone to race conditions; if both ends (`CompletableFuture` and
   * `Promise`) are completed independently at the same time, they may contain different values
@@ -31,8 +31,8 @@ import scala.concurrent.{ExecutionContext, Future}
   * `CompletionStage`s.
   */
 object FutureConverters {
-  /** Returns a [[CompletionStage]] that will be completed with the same value or exception as the
-    * given Scala [[Future]] when that completes. Since the Future is a read-only representation,
+  /** Returns a [[java.util.concurrent.CompletionStage]] that will be completed with the same value or exception as the
+    * given Scala [[scala.concurrent.Future]] when that completes. Since the Future is a read-only representation,
     * this CompletionStage does not support the `toCompletableFuture` method.
     *
     * The semantics of Scala Future demand that all callbacks are invoked asynchronously by default,
@@ -56,8 +56,8 @@ object FutureConverters {
     }
   }
 
-  /** Returns a Scala [[Future]] that will be completed with the same value or exception as the
-    * given [[CompletionStage]] when that completes. Transformations of the returned Future are
+  /** Returns a Scala [[scala.concurrent.Future]] that will be completed with the same value or exception as the
+    * given [[java.util.concurrent.CompletionStage]] when that completes. Transformations of the returned Future are
     * executed asynchronously as specified by the ExecutionContext that is given to the combinator
     * methods.
     *

--- a/src/library/scala/jdk/javaapi/StreamConverters.scala
+++ b/src/library/scala/jdk/javaapi/StreamConverters.scala
@@ -28,7 +28,7 @@ import java.{lang => jl}
   * For details how the stream converters work, see [[scala.jdk.StreamConverters]].
   *
   * @define parNote Note: parallel processing is only efficient for collections that have a
-  *                 [[Stepper]] implementation which supports efficient splitting. For collections
+  *                 [[scala.collection.Stepper]] implementation which supports efficient splitting. For collections
   *                 where this is the case, the [[scala.collection.IterableOnce.stepper `stepper`]]
   *                 method has a return type marked `with EfficientSplit`.
   *

--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -21,7 +21,7 @@ import java.lang.{ Class => jClass }
  * field. This is particularly useful for instantiating `Array`s whose element types are unknown
  * at compile time.
  *
- * `ClassTag`s are a weaker special case of [[scala.reflect.api.TypeTags#TypeTag]]s, in that they
+ * `ClassTag`s are a weaker special case of [[scala.reflect.api.TypeTags.TypeTag]]s, in that they
  * wrap only the runtime class of a given type, whereas a `TypeTag` contains all static type
  * information. That is, `ClassTag`s are constructed from knowing only the top-level class of a
  * type, without necessarily knowing all of its argument types. This runtime information is enough

--- a/src/partest/scala/tools/partest/BytecodeTest.scala
+++ b/src/partest/scala/tools/partest/BytecodeTest.scala
@@ -97,7 +97,7 @@ abstract class BytecodeTest {
   /**
    * Compare the bytecodes of two methods.
    *
-   * For the `similar` function, you probably want to pass [[ASMConverters.equivalentBytecode]].
+   * For the `similar` function, you probably want to pass [[scala.tools.testkit.ASMConverters.equivalentBytecode]].
    */
   def similarBytecode(methA: MethodNode, methB: MethodNode, similar: (List[Instruction], List[Instruction]) => Boolean) = {
     val isa = instructionsFromMethod(methA)

--- a/src/reflect/scala/reflect/api/FlagSets.scala
+++ b/src/reflect/scala/reflect/api/FlagSets.scala
@@ -190,7 +190,7 @@ trait FlagSets { self: Universe =>
 
     /** Flag indicating that tree represents a parameter of the primary constructor of some class
      *  or a synthetic member underlying thereof. E.g. here's how 'class C(val x: Int)' is represented:
-     *
+     * {{{
      *      [[syntax trees at end of parser]]// Scala source: tmposDU52
      *      class C extends scala.AnyRef {
      *        <paramaccessor> val x: Int = _;
@@ -210,12 +210,13 @@ trait FlagSets { self: Universe =>
      *              Modifiers(), nme.CONSTRUCTOR, List(),
      *              List(List(ValDef(Modifiers(PARAM | PARAMACCESSOR), TermName("x"), Ident(TypeName("Int")), EmptyTree))), TypeTree(),
      *              Block(List(pendingSuperCall), Literal(Constant(())))))))))
+     * }}}
      */
     val PARAMACCESSOR: FlagSet
 
     /** Flag indicating that tree represents a parameter of the primary constructor of some case class
      *  or a synthetic member underlying thereof.  E.g. here's how 'case class C(val x: Int)' is represented:
-     *
+     * {{{
      *      [[syntax trees at end of parser]]// Scala source: tmpnHkJ3y
      *      case class C extends scala.Product with scala.Serializable {
      *        <caseaccessor> <paramaccessor> val x: Int = _;
@@ -235,6 +236,7 @@ trait FlagSets { self: Universe =>
      *              Modifiers(), nme.CONSTRUCTOR, List(),
      *              List(List(ValDef(Modifiers(PARAM | PARAMACCESSOR), TermName("x"), Ident(TypeName("Int")), EmptyTree))), TypeTree(),
      *              Block(List(pendingSuperCall), Literal(Constant(())))))))))
+     * }}}
      */
     val CASEACCESSOR: FlagSet
 

--- a/src/reflect/scala/reflect/api/Internals.scala
+++ b/src/reflect/scala/reflect/api/Internals.scala
@@ -390,19 +390,19 @@ trait Internals { self: Universe =>
 
       /** @see [[TreeDecorator]] */
       class TreeDecoratorApi[T <: Tree](val tree: T) {
-        /** @see [[internal.freeTerms]] */
+        /** @see [[InternalApi.freeTerms]] */
         def freeTerms: List[FreeTermSymbol] = internal.freeTerms(tree)
 
-        /** @see [[internal.freeTypes]] */
+        /** @see [[InternalApi.freeTypes]] */
         def freeTypes: List[FreeTypeSymbol] = internal.freeTypes(tree)
 
-        /** @see [[internal.substituteSymbols]] */
+        /** @see [[InternalApi.substituteSymbols]] */
         def substituteSymbols(from: List[Symbol], to: List[Symbol]): Tree = internal.substituteSymbols(tree, from, to)
 
-        /** @see [[internal.substituteTypes]] */
+        /** @see [[InternalApi.substituteTypes]] */
         def substituteTypes(from: List[Symbol], to: List[Type]): Tree = internal.substituteTypes(tree, from, to)
 
-        /** @see [[internal.substituteThis]] */
+        /** @see [[InternalApi.substituteThis]] */
         def substituteThis(clazz: Symbol, to: => Tree): Tree = internal.substituteThis(tree, clazz, to)
       }
 
@@ -414,49 +414,49 @@ trait Internals { self: Universe =>
 
       /** @see [[SymbolDecorator]] */
       class SymbolDecoratorApi[T <: Symbol](val symbol: T) {
-        /** @see [[internal.isFreeTerm]] */
+        /** @see [[InternalApi.isFreeTerm]] */
         def isFreeTerm: Boolean = internal.isFreeTerm(symbol)
 
-        /** @see [[internal.asFreeTerm]] */
+        /** @see [[InternalApi.asFreeTerm]] */
         def asFreeTerm: FreeTermSymbol = internal.asFreeTerm(symbol)
 
-        /** @see [[internal.isFreeType]] */
+        /** @see [[InternalApi.isFreeType]] */
         def isFreeType: Boolean = internal.isFreeType(symbol)
 
-        /** @see [[internal.asFreeType]] */
+        /** @see [[InternalApi.asFreeType]] */
         def asFreeType: FreeTypeSymbol = internal.asFreeType(symbol)
 
-        /** @see [[internal.newTermSymbol]] */
+        /** @see [[InternalApi.newTermSymbol]] */
         def newTermSymbol(name: TermName, pos: Position = NoPosition, flags: FlagSet = NoFlags): TermSymbol = internal.newTermSymbol(symbol, name, pos, flags)
 
-        /** @see [[internal.newModuleAndClassSymbol]] */
+        /** @see [[InternalApi.newModuleAndClassSymbol]] */
         def newModuleAndClassSymbol(name: Name, pos: Position = NoPosition, flags: FlagSet = NoFlags): (ModuleSymbol, ClassSymbol) = internal.newModuleAndClassSymbol(symbol, name, pos, flags)
 
-        /** @see [[internal.newMethodSymbol]] */
+        /** @see [[InternalApi.newMethodSymbol]] */
         def newMethodSymbol(name: TermName, pos: Position = NoPosition, flags: FlagSet = NoFlags): MethodSymbol = internal.newMethodSymbol(symbol, name, pos, flags)
 
-        /** @see [[internal.newTypeSymbol]] */
+        /** @see [[InternalApi.newTypeSymbol]] */
         def newTypeSymbol(name: TypeName, pos: Position = NoPosition, flags: FlagSet = NoFlags): TypeSymbol = internal.newTypeSymbol(symbol, name, pos, flags)
 
-        /** @see [[internal.newClassSymbol]] */
+        /** @see [[InternalApi.newClassSymbol]] */
         def newClassSymbol(name: TypeName, pos: Position = NoPosition, flags: FlagSet = NoFlags): ClassSymbol = internal.newClassSymbol(symbol, name, pos, flags)
 
-        /** @see [[internal.isErroneous]] */
+        /** @see [[InternalApi.isErroneous]] */
         def isErroneous: Boolean = internal.isErroneous(symbol)
 
-        /** @see [[internal.isSkolem]] */
+        /** @see [[InternalApi.isSkolem]] */
         def isSkolem: Boolean = internal.isSkolem(symbol)
 
-        /** @see [[internal.deSkolemize]] */
+        /** @see [[InternalApi.deSkolemize]] */
         def deSkolemize: Symbol = internal.deSkolemize(symbol)
 
-        /** @see [[internal.initialize]] */
+        /** @see [[InternalApi.initialize]] */
         def initialize: T = internal.initialize(symbol)
 
-        /** @see [[internal.fullyInitialize]] */
+        /** @see [[InternalApi.fullyInitialize]] */
         def fullyInitialize: T = internal.fullyInitialize(symbol)
 
-        /** @see [[internal.flags]] */
+        /** @see [[InternalApi.flags]] */
         def flags: FlagSet = internal.flags(symbol)
       }
 
@@ -468,7 +468,7 @@ trait Internals { self: Universe =>
 
       /** @see [[TypeDecorator]] */
       implicit class TypeDecoratorApi[T <: Type](val tp: T) {
-        /** @see [[internal.fullyInitialize]] */
+        /** @see [[InternalApi.fullyInitialize]] */
         def fullyInitialize: T = internal.fullyInitialize(tp)
       }
     }

--- a/src/reflect/scala/reflect/api/Mirror.scala
+++ b/src/reflect/scala/reflect/api/Mirror.scala
@@ -19,7 +19,7 @@ package api
  *
  * The base class for all mirrors.
  *
- * See [[scala.reflect.api.Mirrors]] or [[docs.scala-lang.org/overviews/reflection/overview.html Reflection Guide]]
+ * See [[scala.reflect.api.Mirrors]] or [[https://docs.scala-lang.org/overviews/reflection/overview.html Reflection Guide]]
  * for a complete overview of `Mirror`s.
  *
  * @tparam U the type of the universe this mirror belongs to.

--- a/src/reflect/scala/reflect/api/Mirrors.scala
+++ b/src/reflect/scala/reflect/api/Mirrors.scala
@@ -516,7 +516,7 @@ trait Mirrors { self: Universe =>
     /** A class symbol for the specified runtime class.
      *  @return The class symbol for the runtime class in the current class loader.
      *  @throws java.lang.ClassNotFoundException if no class with that name exists
-     *  @throws scala.reflect.ScalaReflectionException if no corresponding symbol exists
+     *  @throws scala.ScalaReflectionException if no corresponding symbol exists
      *  to do: throws anything else?
      */
     def classSymbol(rtcls: RuntimeClass): ClassSymbol
@@ -524,7 +524,7 @@ trait Mirrors { self: Universe =>
     /** A module symbol for the specified runtime class.
      *  @return The module symbol for the runtime class in the current class loader.
      *  @throws java.lang.ClassNotFoundException if no class with that name exists
-     *  @throws scala.reflect.ScalaReflectionException if no corresponding symbol exists
+     *  @throws scala.ScalaReflectionException if no corresponding symbol exists
      *  to do: throws anything else?
      */
     def moduleSymbol(rtcls: RuntimeClass): ModuleSymbol

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -26,7 +26,7 @@ import scala.annotation.tailrec
  *
  * In Scala reflection, APIs that produce or use `Tree`s are:
  *
- *   - '''Annotations''' which use trees to represent their arguments, exposed in [[scala.reflect.api.Annotations#scalaArgs Annotation.scalaArgs]].
+ *   - '''Annotations''' which use trees to represent their arguments, exposed in [[scala.reflect.api.Annotations.AnnotationApi#scalaArgs Annotation.scalaArgs]].
  *   - '''[[scala.reflect.api.Universe#reify reify]]''', a special method on [[scala.reflect.api.Universe]] that takes an expression and returns an AST which represents the expression.
  *   - '''Macros and runtime compilation with toolboxes''' which both use trees as their program representation medium.
  *
@@ -397,7 +397,7 @@ trait Trees { self: Universe =>
     def apply(mods: Modifiers, name: TypeName, tparams: List[TypeDef], impl: Template): ClassDef
     def unapply(classDef: ClassDef): Option[(Modifiers, TypeName, List[TypeDef], Template)]
 
-    /** @see [[InternalApi.classDef]] */
+    /** @see [[Internals.InternalApi.classDef]] */
     @deprecated("use `internal.classDef` instead", "2.11.0")
     def apply(sym: Symbol, impl: Template)(implicit token: CompatToken): ClassDef = internal.classDef(sym, impl)
   }
@@ -446,7 +446,7 @@ trait Trees { self: Universe =>
     def apply(mods: Modifiers, name: TermName, impl: Template): ModuleDef
     def unapply(moduleDef: ModuleDef): Option[(Modifiers, TermName, Template)]
 
-    /** @see [[InternalApi.moduleDef]] */
+    /** @see [[Internals.InternalApi.moduleDef]] */
     @deprecated("use `internal.moduleDef` instead", "2.11.0")
     def apply(sym: Symbol, impl: Template)(implicit token: CompatToken): ModuleDef = internal.moduleDef(sym, impl)
   }
@@ -526,11 +526,11 @@ trait Trees { self: Universe =>
     def apply(mods: Modifiers, name: TermName, tpt: Tree, rhs: Tree): ValDef
     def unapply(valDef: ValDef): Option[(Modifiers, TermName, Tree, Tree)]
 
-    /** @see [[InternalApi.valDef]] */
+    /** @see [[Internals.InternalApi.valDef]] */
     @deprecated("use `internal.valDef` instead", "2.11.0")
     def apply(sym: Symbol, rhs: Tree)(implicit token: CompatToken): ValDef = internal.valDef(sym, rhs)
 
-    /** @see [[InternalApi.valDef]] */
+    /** @see [[Internals.InternalApi.valDef]] */
     @deprecated("use `internal.valDef` instead", "2.11.0")
     def apply(sym: Symbol)(implicit token: CompatToken): ValDef = internal.valDef(sym)
   }
@@ -577,23 +577,23 @@ trait Trees { self: Universe =>
     def apply(mods: Modifiers, name: TermName, tparams: List[TypeDef], vparamss: List[List[ValDef]], tpt: Tree, rhs: Tree): DefDef
     def unapply(defDef: DefDef): Option[(Modifiers, TermName, List[TypeDef], List[List[ValDef]], Tree, Tree)]
 
-    /** @see [[InternalApi.defDef]] */
+    /** @see [[Internals.InternalApi.defDef]] */
     @deprecated("use `internal.defDef` instead", "2.11.0")
     def apply(sym: Symbol, mods: Modifiers, vparamss: List[List[ValDef]], rhs: Tree)(implicit token: CompatToken): DefDef = internal.defDef(sym, mods, vparamss, rhs)
 
-    /** @see [[InternalApi.defDef]] */
+    /** @see [[Internals.InternalApi.defDef]] */
     @deprecated("use `internal.defDef` instead", "2.11.0")
     def apply(sym: Symbol, vparamss: List[List[ValDef]], rhs: Tree)(implicit token: CompatToken): DefDef = internal.defDef(sym, vparamss, rhs)
 
-    /** @see [[InternalApi.defDef]] */
+    /** @see [[Internals.InternalApi.defDef]] */
     @deprecated("use `internal.defDef` instead", "2.11.0")
     def apply(sym: Symbol, mods: Modifiers, rhs: Tree)(implicit token: CompatToken): DefDef = internal.defDef(sym, mods, rhs)
 
-    /** @see [[InternalApi.defDef]] */
+    /** @see [[Internals.InternalApi.defDef]] */
     @deprecated("use `internal.defDef` instead", "2.11.0")
     def apply(sym: Symbol, rhs: Tree)(implicit token: CompatToken): DefDef = internal.defDef(sym, rhs)
 
-    /** @see [[InternalApi.defDef]] */
+    /** @see [[Internals.InternalApi.defDef]] */
     @deprecated("use `internal.defDef` instead", "2.11.0")
     def apply(sym: Symbol, rhs: List[List[Symbol]] => Tree)(implicit token: CompatToken): DefDef = internal.defDef(sym, rhs)
   }
@@ -649,11 +649,11 @@ trait Trees { self: Universe =>
     def apply(mods: Modifiers, name: TypeName, tparams: List[TypeDef], rhs: Tree): TypeDef
     def unapply(typeDef: TypeDef): Option[(Modifiers, TypeName, List[TypeDef], Tree)]
 
-    /** @see [[InternalApi.typeDef]] */
+    /** @see [[Internals.InternalApi.typeDef]] */
     @deprecated("use `internal.typeDef` instead", "2.11.0")
     def apply(sym: Symbol, rhs: Tree)(implicit token: CompatToken): TypeDef = internal.typeDef(sym, rhs)
 
-    /** @see [[InternalApi.typeDef]] */
+    /** @see [[Internals.InternalApi.typeDef]] */
     @deprecated("use `internal.typeDef` instead", "2.11.0")
     def apply(sym: Symbol)(implicit token: CompatToken): TypeDef = internal.typeDef(sym)
   }
@@ -717,7 +717,7 @@ trait Trees { self: Universe =>
     def apply(name: TermName, params: List[Ident], rhs: Tree): LabelDef
     def unapply(labelDef: LabelDef): Option[(TermName, List[Ident], Tree)]
 
-    /** @see [[InternalApi.labelDef]] */
+    /** @see [[Internals.InternalApi.labelDef]] */
     @deprecated("use `internal.labelDef` instead", "2.11.0")
     def apply(sym: Symbol, params: List[Symbol], rhs: Tree)(implicit token: CompatToken): LabelDef = internal.labelDef(sym, params, rhs)
   }

--- a/src/reflect/scala/reflect/api/TypeTags.scala
+++ b/src/reflect/scala/reflect/api/TypeTags.scala
@@ -58,7 +58,7 @@ import java.io.ObjectStreamException
  * Each of these methods constructs a `TypeTag[T]` or `ClassTag[T]` for the given
  * type argument `T`.
  *
- * === #2 Using an implicit parameter of type `TypeTag[T]`, `ClassTag[T]`, or `WeakTypeTag[T]`
+ * === #2 Using an implicit parameter of type `TypeTag[T]`, `ClassTag[T]`, or `WeakTypeTag[T]` ===
  *
  * For example:
  * {{{

--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -454,7 +454,7 @@ trait Types {
   abstract class ThisTypeExtractor {
     def unapply(tpe: ThisType): Option[Symbol]
 
-    /** @see [[InternalApi.thisType]] */
+    /** @see [[Internals.InternalApi.thisType]] */
     @deprecated("use `internal.thisType` instead", "2.11.0")
     def apply(sym: Symbol)(implicit token: CompatToken): Type = internal.thisType(sym)
   }
@@ -493,7 +493,7 @@ trait Types {
   abstract class SingleTypeExtractor {
     def unapply(tpe: SingleType): Option[(Type, Symbol)]
 
-    /** @see [[InternalApi.singleType]] */
+    /** @see [[Internals.InternalApi.singleType]] */
     @deprecated("use `ClassSymbol.thisPrefix` or `internal.singleType` instead", "2.11.0")
     def apply(pre: Type, sym: Symbol)(implicit token: CompatToken): Type = internal.singleType(pre, sym)
   }
@@ -533,7 +533,7 @@ trait Types {
   abstract class SuperTypeExtractor {
     def unapply(tpe: SuperType): Option[(Type, Type)]
 
-    /** @see [[InternalApi.superType]] */
+    /** @see [[Internals.InternalApi.superType]] */
     @deprecated("use `ClassSymbol.superPrefix` or `internal.superType` instead", "2.11.0")
     def apply(thistpe: Type, supertpe: Type)(implicit token: CompatToken): Type = internal.superType(thistpe, supertpe)
   }
@@ -581,7 +581,7 @@ trait Types {
   abstract class ConstantTypeExtractor {
     def unapply(tpe: ConstantType): Option[Constant]
 
-    /** @see [[InternalApi.constantType]] */
+    /** @see [[Internals.InternalApi.constantType]] */
     @deprecated("use `value.tpe` or `internal.constantType` instead", "2.11.0")
     def apply(value: Constant)(implicit token: CompatToken): ConstantType = internal.constantType(value)
   }
@@ -624,7 +624,7 @@ trait Types {
   abstract class TypeRefExtractor {
     def unapply(tpe: TypeRef): Option[(Type, Symbol, List[Type])]
 
-    /** @see [[InternalApi.typeRef]] */
+    /** @see [[Internals.InternalApi.typeRef]] */
     @deprecated("use `internal.typeRef` instead", "2.11.0")
     def apply(pre: Type, sym: Symbol, args: List[Type])(implicit token: CompatToken): Type = internal.typeRef(pre, sym, args)
   }
@@ -684,11 +684,11 @@ trait Types {
   abstract class RefinedTypeExtractor {
     def unapply(tpe: RefinedType): Option[(List[Type], Scope)]
 
-    /** @see [[InternalApi.refinedType]] */
+    /** @see [[Internals.InternalApi.refinedType]] */
     @deprecated("use `internal.refinedType` instead", "2.11.0")
     def apply(parents: List[Type], decls: Scope)(implicit token: CompatToken): RefinedType = internal.refinedType(parents, decls)
 
-    /** @see [[InternalApi.refinedType]] */
+    /** @see [[Internals.InternalApi.refinedType]] */
     @deprecated("use `internal.refinedType` instead", "2.11.0")
     def apply(parents: List[Type], decls: Scope, clazz: Symbol)(implicit token: CompatToken): RefinedType = internal.refinedType(parents, decls, clazz)
   }
@@ -733,7 +733,7 @@ trait Types {
   abstract class ClassInfoTypeExtractor {
     def unapply(tpe: ClassInfoType): Option[(List[Type], Scope, Symbol)]
 
-    /** @see [[InternalApi.classInfoType]] */
+    /** @see [[Internals.InternalApi.classInfoType]] */
     @deprecated("use `internal.classInfoType` instead", "2.11.0")
     def apply(parents: List[Type], decls: Scope, typeSymbol: Symbol)(implicit token: CompatToken): ClassInfoType = internal.classInfoType(parents, decls, typeSymbol)
   }
@@ -782,7 +782,7 @@ trait Types {
   abstract class MethodTypeExtractor {
     def unapply(tpe: MethodType): Option[(List[Symbol], Type)]
 
-    /** @see [[InternalApi.methodType]] */
+    /** @see [[Internals.InternalApi.methodType]] */
     @deprecated("use `internal.methodType` instead", "2.11.0")
     def apply(params: List[Symbol], resultType: Type)(implicit token: CompatToken): MethodType = internal.methodType(params, resultType)
   }
@@ -818,7 +818,7 @@ trait Types {
   abstract class NullaryMethodTypeExtractor {
     def unapply(tpe: NullaryMethodType): Option[(Type)]
 
-    /** @see [[InternalApi.nullaryMethodType]] */
+    /** @see [[Internals.InternalApi.nullaryMethodType]] */
     @deprecated("use `internal.nullaryMethodType` instead", "2.11.0")
     def apply(resultType: Type)(implicit token: CompatToken): NullaryMethodType = internal.nullaryMethodType(resultType)
   }
@@ -852,7 +852,7 @@ trait Types {
   abstract class PolyTypeExtractor {
     def unapply(tpe: PolyType): Option[(List[Symbol], Type)]
 
-    /** @see [[InternalApi.polyType]] */
+    /** @see [[Internals.InternalApi.polyType]] */
     @deprecated("use `internal.polyType` instead", "2.11.0")
     def apply(typeParams: List[Symbol], resultType: Type)(implicit token: CompatToken): PolyType = internal.polyType(typeParams, resultType)
   }
@@ -890,7 +890,7 @@ trait Types {
   abstract class ExistentialTypeExtractor {
     def unapply(tpe: ExistentialType): Option[(List[Symbol], Type)]
 
-    /** @see [[InternalApi.existentialType]] */
+    /** @see [[Internals.InternalApi.existentialType]] */
     @deprecated("use `internal.existentialType` instead", "2.11.0")
     def apply(quantified: List[Symbol], underlying: Type)(implicit token: CompatToken): ExistentialType = internal.existentialType(quantified, underlying)
   }
@@ -928,7 +928,7 @@ trait Types {
   abstract class AnnotatedTypeExtractor {
     def unapply(tpe: AnnotatedType): Option[(List[Annotation], Type)]
 
-    /** @see [[InternalApi.annotatedType]] */
+    /** @see [[Internals.InternalApi.annotatedType]] */
     @deprecated("use `internal.annotatedType` instead", "2.11.0")
     def apply(annotations: List[Annotation], underlying: Type)(implicit token: CompatToken): AnnotatedType = internal.annotatedType(annotations, underlying)
   }
@@ -972,7 +972,7 @@ trait Types {
   abstract class TypeBoundsExtractor {
     def unapply(tpe: TypeBounds): Option[(Type, Type)]
 
-    /** @see [[InternalApi.typeBounds]] */
+    /** @see [[Internals.InternalApi.typeBounds]] */
     @deprecated("use `internal.typeBounds` instead", "2.11.0")
     def apply(lo: Type, hi: Type)(implicit token: CompatToken): TypeBounds = internal.typeBounds(lo, hi)
   }
@@ -1025,7 +1025,7 @@ trait Types {
   abstract class BoundedWildcardTypeExtractor {
     def unapply(tpe: BoundedWildcardType): Option[TypeBounds]
 
-    /** @see [[InternalApi.boundedWildcardType]] */
+    /** @see [[Internals.InternalApi.boundedWildcardType]] */
     @deprecated("use `internal.boundedWildcardType` instead", "2.11.0")
     def apply(bounds: TypeBounds)(implicit token: CompatToken): BoundedWildcardType = internal.boundedWildcardType(bounds)
   }

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -274,7 +274,7 @@ trait Types
      */
     def isTrivial: Boolean = false
 
-    /** Is this type higher-kinded, i.e., is it a type constructor @M */
+    /** Is this type higher-kinded, i.e., is it a type constructor \@M */
     def isHigherKinded: Boolean = false
     def takesTypeArgs: Boolean = this.isHigherKinded
 
@@ -435,7 +435,7 @@ trait Types
       case _ => List()
     }
 
-    /** This type, without its type arguments @M */
+    /** This type, without its type arguments \@M */
     def typeConstructor: Type = this
 
     /** For a typeref, its arguments. The empty list for all other types */
@@ -481,7 +481,7 @@ trait Types
 
     /** Replace formal type parameter symbols with actual type arguments. ErrorType on arity mismatch.
      *
-     * Amounts to substitution except for higher-kinded types. (See overridden method in TypeRef) -- @M
+     * Amounts to substitution except for higher-kinded types. (See overridden method in TypeRef) -- \@M
      */
     def instantiateTypeParams(formals: List[Symbol], actuals: List[Type]): Type =
       if (sameLength(formals, actuals)) this.subst(formals, actuals) else ErrorType
@@ -2341,9 +2341,9 @@ trait Types
   /** A class for named types of the form
    *    `<prefix>.<sym.name>[args]`
    *  Cannot be created directly; one should always use `typeRef`
-   *  for creation. (@M: Otherwise hashing breaks)
+   *  for creation. (\@M: Otherwise hashing breaks)
    *
-   * @M: a higher-kinded type is represented as a TypeRef with sym.typeParams.nonEmpty, but args.isEmpty
+   * \@M: a higher-kinded type is represented as a TypeRef with sym.typeParams.nonEmpty, but args.isEmpty
    */
   abstract case class TypeRef(pre: Type, sym: Symbol, args: List[Type]) extends UniqueType with TypeRefApi {
     override def mapOver(map: TypeMap): Type = {

--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -63,13 +63,13 @@ private[internal] trait GlbLubs {
     *
     *    xs <= ys   iff   forall y in ys exists x in xs such that x <: y
     *
-    *  @arg tsParams for each type in the original list of types `ts0`, its list of type parameters (if that type is a type constructor)
+    *  @param tsParams for each type in the original list of types `ts0`, its list of type parameters (if that type is a type constructor)
     *                (these type parameters may be referred to by type arguments in the BTS column of those types,
     *                and must be interpreted as bound variables; i.e., under a type lambda that wraps the types that refer to these type params)
-    *  @arg tsBts    a matrix whose columns are basetype sequences
+    *  @param tsBts    a matrix whose columns are basetype sequences
     *                the first row is the original list of types for which we're computing the lub
     *                  (except that type constructors have been applied to their dummyArgs)
-    *  @See baseTypeSeq  for a definition of sorted and upwards closed.
+    *  @see baseTypeSeq  for a definition of sorted and upwards closed.
     */
   def lubList(ts: List[Type], depth: Depth): List[Type] = {
     var lubListDepth = Depth.Zero

--- a/src/reflect/scala/reflect/macros/Enclosures.scala
+++ b/src/reflect/scala/reflect/macros/Enclosures.scala
@@ -30,7 +30,7 @@ package macros
  *  This is somewhat aligned with the overall evolution of macros during the 2.11 development cycle, where we played with
  *  `c.introduceTopLevel` and `c.introduceMember`, but at the end of the day decided to reject them.
  *
- *  If you're relying on the now deprecated APIs, consider using the new [[c.internal.enclosingOwner]] method that can be used to obtain
+ *  If you're relying on the now deprecated APIs, consider using the new [[Internals.ContextInternalApi.enclosingOwner]] method that can be used to obtain
  *  the names of enclosing definitions. Alternatively try reformulating your macros in terms of completely local expansion
  *  and/or joining a discussion of a somewhat related potential language feature at [[https://groups.google.com/forum/#!topic/scala-debate/f4CLmYShX6Q]].
  *  We also welcome questions and suggestions on our mailing lists, where we would be happy to further discuss this matter.

--- a/src/reflect/scala/reflect/macros/Typers.scala
+++ b/src/reflect/scala/reflect/macros/Typers.scala
@@ -120,7 +120,7 @@ trait Typers {
    *  are observationally different from typed trees (also known as typer trees, typechecked trees or attributed trees),
    *
    *  Usually, if some compiler API takes a tree, then both untyped and typed trees will do. However in some cases,
-   *  only untyped or only typed trees are appropriate. For example, [[eval]] only accepts untyped trees and one can only splice
+   *  only untyped or only typed trees are appropriate. For example, [[Evals.eval]] only accepts untyped trees and one can only splice
    *  typed trees inside typed trees. Therefore in the current reflection API, there is a need in functions
    *  that go back and forth between untyped and typed trees. For this we have [[typecheck]] and `untypecheck`.
    *

--- a/src/reflect/scala/reflect/macros/Universe.scala
+++ b/src/reflect/scala/reflect/macros/Universe.scala
@@ -32,10 +32,10 @@ import scala.language.higherKinds
  */
 abstract class Universe extends scala.reflect.api.Universe {
 
-  /** @inheritdoc */
+  /** @see [[MacroInternalApi]] */
   override type Internal <: MacroInternalApi
 
-  /** @inheritdoc */
+  /** @see [[InternalApi]] */
   trait MacroInternalApi extends InternalApi { internal =>
 
     /** Adds a given symbol to the given scope.
@@ -167,10 +167,10 @@ abstract class Universe extends scala.reflect.api.Universe {
      */
     def subpatterns(tree: Tree): Option[List[Tree]]
 
-    /** @inheritdoc */
+    /** @see MacroDecoratorApi */
     override type Decorators <: MacroDecoratorApi
 
-    /** @inheritdoc */
+    /** @see DecoratorApi */
     trait MacroDecoratorApi extends DecoratorApi {
       /** Extension methods for scopes */
       type ScopeDecorator[T <: Scope] <: MacroScopeDecoratorApi[T]
@@ -180,10 +180,10 @@ abstract class Universe extends scala.reflect.api.Universe {
 
       /** @see [[ScopeDecorator]] */
       class MacroScopeDecoratorApi[T <: Scope](val scope: T) {
-        /** @see [[internal.enter]] */
+        /** @see [[MacroInternalApi.enter]] */
         def enter(sym: Symbol): T = internal.enter(scope, sym)
 
-        /** @see [[internal.unlink]] */
+        /** @see [[MacroInternalApi.unlink]] */
         def unlink(sym: Symbol): T = internal.unlink(scope, sym)
       }
 
@@ -192,28 +192,28 @@ abstract class Universe extends scala.reflect.api.Universe {
 
       /** @see [[TreeDecorator]] */
       class MacroTreeDecoratorApi[T <: Tree](override val tree: T) extends TreeDecoratorApi[T](tree) {
-        /** @see [[internal.changeOwner]] */
+        /** @see [[MacroInternalApi.changeOwner]] */
         def changeOwner(prev: Symbol, next: Symbol): tree.type = internal.changeOwner(tree, prev, next)
 
-        /** @see [[internal.attachments]] */
+        /** @see [[MacroInternalApi.attachments]] */
         def attachments: Attachments { type Pos = Position } = internal.attachments(tree)
 
-        /** @see [[internal.updateAttachment]] */
+        /** @see [[MacroInternalApi.updateAttachment]] */
         def updateAttachment[A: ClassTag](attachment: A): tree.type = internal.updateAttachment(tree, attachment)
 
-        /** @see [[internal.removeAttachment]] */
+        /** @see [[MacroInternalApi.removeAttachment]] */
         def removeAttachment[A: ClassTag]: T = internal.removeAttachment[A](tree)
 
-        /** @see [[internal.setPos]] */
+        /** @see [[MacroInternalApi.setPos]] */
         def setPos(newpos: Position): T = internal.setPos(tree, newpos)
 
-        /** @see [[internal.setType]] */
+        /** @see [[MacroInternalApi.setType]] */
         def setType(tp: Type): T = internal.setType(tree, tp)
 
-        /** @see [[internal.defineType]] */
+        /** @see [[MacroInternalApi.defineType]] */
         def defineType(tp: Type): T = internal.defineType(tree, tp)
 
-        /** @see [[internal.setSymbol]] */
+        /** @see [[MacroInternalApi.setSymbol]] */
         def setSymbol(sym: Symbol): T = internal.setSymbol(tree, sym)
       }
 
@@ -225,7 +225,7 @@ abstract class Universe extends scala.reflect.api.Universe {
 
       /** @see [[TypeTreeDecorator]] */
       class MacroTypeTreeDecoratorApi[T <: TypeTree](val tt: T) {
-        /** @see [[internal.setOriginal]] */
+        /** @see [[MacroInternalApi.setOriginal]] */
         def setOriginal(tree: Tree): TypeTree = internal.setOriginal(tt, tree)
       }
 
@@ -234,34 +234,34 @@ abstract class Universe extends scala.reflect.api.Universe {
 
       /** @see [[TreeDecorator]] */
       class MacroSymbolDecoratorApi[T <: Symbol](override val symbol: T) extends SymbolDecoratorApi[T](symbol) {
-        /** @see [[internal.attachments]] */
+        /** @see [[MacroInternalApi.attachments]] */
         def attachments: Attachments { type Pos = Position } = internal.attachments(symbol)
 
-        /** @see [[internal.updateAttachment]] */
+        /** @see [[MacroInternalApi.updateAttachment]] */
         def updateAttachment[A: ClassTag](attachment: A): T = internal.updateAttachment(symbol, attachment)
 
-        /** @see [[internal.removeAttachment]] */
+        /** @see [[MacroInternalApi.removeAttachment]] */
         def removeAttachment[A: ClassTag]: T = internal.removeAttachment[A](symbol)
 
-        /** @see [[internal.setOwner]] */
+        /** @see [[MacroInternalApi.setOwner]] */
         def setOwner(newowner: Symbol): T = internal.setOwner(symbol, newowner)
 
-        /** @see [[internal.setInfo]] */
+        /** @see [[MacroInternalApi.setInfo]] */
         def setInfo(tpe: Type): T = internal.setInfo(symbol, tpe)
 
-        /** @see [[internal.setAnnotations]] */
+        /** @see [[MacroInternalApi.setAnnotations]] */
         def setAnnotations(annots: Annotation*): T = internal.setAnnotations(symbol, annots: _*)
 
-        /** @see [[internal.setName]] */
+        /** @see [[MacroInternalApi.setName]] */
         def setName(name: Name): T = internal.setName(symbol, name)
 
-        /** @see [[internal.setPrivateWithin]] */
+        /** @see [[MacroInternalApi.setPrivateWithin]] */
         def setPrivateWithin(sym: Symbol): T = internal.setPrivateWithin(symbol, sym)
 
-        /** @see [[internal.setFlag]] */
+        /** @see [[MacroInternalApi.setFlag]] */
         def setFlag(flags: FlagSet): T = internal.setFlag(symbol, flags)
 
-        /** @see [[internal.setFlag]] */
+        /** @see [[MacroInternalApi.setFlag]] */
         def resetFlag(flags: FlagSet): T = internal.resetFlag(symbol, flags)
       }
     }
@@ -343,7 +343,6 @@ abstract class Universe extends scala.reflect.api.Universe {
     def mkCast(tree: Tree, pt: Type): Tree
   }
 
-  /** @see [[internal.gen]] */
   @deprecated("use `internal.gen` instead", "2.11.0")
   val treeBuild: TreeGen
 

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -567,14 +567,15 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
    * package object abstraction and placing members directly in the package.
    *
    * Here's the explanation of what we do. The code:
-   *
+   * {{{
    * package foo {
    *   object `package` {
    *     class Bar
    *   }
    * }
-   *
+   * }}}
    * will yield this Symbol structure:
+   * <pre>
    *                                       +---------+ (2)
    *                                       |         |
    * +---------------+         +---------- v ------- | ---+                              +--------+ (2)
@@ -587,6 +588,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
    *                                                                +------------------- | ---+   |
    *                                                                                     |        |
    *                                                                                     +--------+
+   * </pre>
    * (1) sourceModule
    * (2) you get out of owners with .owner
    *


### PR DESCRIPTION
- Fixes a few formatting problems
- Fixes a bunch of warnings about cross-reference links
- Reduces the number of warnings in half

Follow-up to #8284, #8290, and #8339.