### PR TITLE
Optimize the classpath implementation

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/ClassfileWriters.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/ClassfileWriters.scala
@@ -12,7 +12,7 @@
 
 package scala.tools.nsc.backend.jvm
 
-import java.io.{BufferedOutputStream, DataOutputStream, FileOutputStream, IOException}
+import java.io.{DataOutputStream, IOException}
 import java.nio.ByteBuffer
 import java.nio.channels.{ClosedByInterruptException, FileChannel}
 import java.nio.charset.StandardCharsets

--- a/src/compiler/scala/tools/nsc/classpath/AggregateClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/AggregateClassPath.scala
@@ -13,11 +13,11 @@
 package scala.tools.nsc.classpath
 
 import java.net.URL
+
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.internal.FatalError
 import scala.reflect.io.AbstractFile
-import scala.tools.nsc.util.ClassPath
-import scala.tools.nsc.util.ClassRepresentation
+import scala.tools.nsc.util.{ClassPath, ClassRepresentation, EfficientClassPath}
 
 /**
  * A classpath unifying multiple class- and sourcepath entries.
@@ -30,13 +30,13 @@ import scala.tools.nsc.util.ClassRepresentation
 case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
   override def findClassFile(className: String): Option[AbstractFile] = {
     val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
-    aggregatesForPackage(pkg).iterator.map(_.findClassFile(className)).collectFirst {
+    aggregatesForPackage(PackageName(pkg)).iterator.map(_.findClassFile(className)).collectFirst {
       case Some(x) => x
     }
   }
   private[this] val packageIndex: collection.mutable.Map[String, Seq[ClassPath]] = collection.mutable.Map()
-  private def aggregatesForPackage(pkg: String): Seq[ClassPath] = packageIndex.synchronized {
-    packageIndex.getOrElseUpdate(pkg, aggregates.filter(_.hasPackage(pkg)))
+  private def aggregatesForPackage(pkg: PackageName): Seq[ClassPath] = packageIndex.synchronized {
+    packageIndex.getOrElseUpdate(pkg.dottedString, aggregates.filter(_.hasPackage(pkg)))
   }
 
   // This method is performance sensitive as it is used by SBT's ExtractDependencies phase.
@@ -44,7 +44,7 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
     val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
 
     def findEntry(isSource: Boolean): Option[ClassRepresentation] = {
-      aggregatesForPackage(pkg).iterator.map(_.findClass(className)).collectFirst {
+      aggregatesForPackage(PackageName(pkg)).iterator.map(_.findClass(className)).collectFirst {
         case Some(s: SourceFileEntry) if isSource => s
         case Some(s: ClassFileEntry) if !isSource => s
       }
@@ -66,31 +66,44 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
 
   override def asSourcePathString: String = ClassPath.join(aggregates map (_.asSourcePathString): _*)
 
-  override private[nsc] def packages(inPackage: String): Seq[PackageEntry] = {
+  override private[nsc] def packages(inPackage: PackageName): Seq[PackageEntry] = {
     val aggregatedPackages = aggregates.flatMap(_.packages(inPackage)).distinct
     aggregatedPackages
   }
 
-  override private[nsc] def classes(inPackage: String): Seq[ClassFileEntry] =
+  override private[nsc] def classes(inPackage: PackageName): Seq[ClassFileEntry] =
     getDistinctEntries(_.classes(inPackage))
 
-  override private[nsc] def sources(inPackage: String): Seq[SourceFileEntry] =
+  override private[nsc] def sources(inPackage: PackageName): Seq[SourceFileEntry] =
     getDistinctEntries(_.sources(inPackage))
 
-  override private[nsc] def hasPackage(pkg: String) = aggregates.exists(_.hasPackage(pkg))
-  override private[nsc] def list(inPackage: String): ClassPathEntries = {
-    val (packages, classesAndSources) = aggregates.map { cp =>
+  override private[nsc] def hasPackage(pkg: PackageName) = aggregates.exists(_.hasPackage(pkg))
+  override private[nsc] def list(inPackage: PackageName): ClassPathEntries = {
+    val packages: java.util.HashSet[PackageEntry] = new java.util.HashSet[PackageEntry]()
+    val classesAndSourcesBuffer = collection.mutable.ArrayBuffer[ClassRepresentation]()
+    val onPackage: PackageEntry => Unit = packages.add(_)
+    val onClassesAndSources: ClassRepresentation => Unit = classesAndSourcesBuffer += _
+
+    aggregates.foreach { cp =>
       try {
-        cp.list(inPackage)
+        cp match {
+          case ecp: EfficientClassPath =>
+            ecp.list(inPackage, onPackage, onClassesAndSources)
+          case _ =>
+            val entries = cp.list(inPackage)
+            entries._1.foreach(entry => packages.add(entry))
+            classesAndSourcesBuffer ++= entries._2
+        }
       } catch {
         case ex: java.io.IOException =>
           val e = FatalError(ex.getMessage)
           e.initCause(ex)
           throw e
       }
-    }.unzip
-    val distinctPackages = packages.flatten.distinct
-    val distinctClassesAndSources = mergeClassesAndSources(classesAndSources)
+    }
+
+    val distinctPackages: Seq[PackageEntry] = if (packages == null) Nil else packages.toArray(new Array[PackageEntry](packages.size()))
+    val distinctClassesAndSources = mergeClassesAndSources(classesAndSourcesBuffer)
     ClassPathEntries(distinctPackages, distinctClassesAndSources)
   }
 
@@ -99,18 +112,16 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
    * creates an entry containing both of them. If there would be more than one class or source
    * entries for the same class it always would use the first entry of each type found on a classpath.
    */
-  private def mergeClassesAndSources(entries: Seq[Seq[ClassRepresentation]]): Seq[ClassRepresentation] = {
+  private def mergeClassesAndSources(entries: Seq[ClassRepresentation]): Seq[ClassRepresentation] = {
     var count = 0
-    val indices = collection.mutable.HashMap[String, Int]()
-    val mergedEntries = new ArrayBuffer[ClassRepresentation](1024)
-
+    val indices = new java.util.HashMap[String, Int]((entries.size * 1.25).toInt)
+    val mergedEntries = new ArrayBuffer[ClassRepresentation](entries.size)
     for {
-      partOfEntries <- entries
-      entry <- partOfEntries
+      entry <- entries
     } {
       val name = entry.name
-      if (indices contains name) {
-        val index = indices(name)
+      if (indices.containsKey(name)) {
+        val index = indices.get(name)
         val existing = mergedEntries(index)
 
         if (existing.binary.isEmpty && entry.binary.isDefined)
@@ -119,7 +130,7 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
           mergedEntries(index) = ClassAndSourceFilesEntry(existing.binary.get, entry.source.get)
       }
       else {
-        indices(name) = count
+        indices.put(name, count)
         mergedEntries += entry
         count += 1
       }

--- a/src/compiler/scala/tools/nsc/classpath/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPath.scala
@@ -32,6 +32,21 @@ trait SourceFileEntry extends ClassRepresentation {
   def file: AbstractFile
 }
 
+case class PackageName(dottedString: String) {
+  def isRoot: Boolean = dottedString.isEmpty
+  val dirPathTrailingSlash: String = FileUtils.dirPath(dottedString) + "/"
+
+  def entryName(entry: String): String = {
+    if (isRoot) entry else {
+      val builder = new java.lang.StringBuilder(dottedString.length + 1 + entry.length)
+      builder.append(dottedString)
+      builder.append('.')
+      builder.append(entry)
+      builder.toString
+    }
+  }
+}
+
 trait PackageEntry {
   def name: String
 }
@@ -61,10 +76,10 @@ private[nsc] case class PackageEntryImpl(name: String) extends PackageEntry
 
 private[nsc] trait NoSourcePaths {
   final def asSourcePathString: String = ""
-  final private[nsc] def sources(inPackage: String): Seq[SourceFileEntry] = Seq.empty
+  final private[nsc] def sources(inPackage: PackageName): Seq[SourceFileEntry] = Seq.empty
 }
 
 private[nsc] trait NoClassPaths {
   final def findClassFile(className: String): Option[AbstractFile] = None
-  private[nsc] final def classes(inPackage: String): Seq[ClassFileEntry] = Seq.empty
+  private[nsc] final def classes(inPackage: PackageName): Seq[ClassFileEntry] = Seq.empty
 }

--- a/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
@@ -18,7 +18,7 @@ import java.nio.file.{FileSystems, Files}
 import java.util
 
 import scala.reflect.io.{AbstractFile, PlainFile, PlainNioFile}
-import scala.tools.nsc.util.{ClassPath, ClassRepresentation}
+import scala.tools.nsc.util.{ClassPath, ClassRepresentation, EfficientClassPath}
 import FileUtils._
 import scala.collection.JavaConverters._
 import scala.reflect.internal.JDK9Reflectors
@@ -32,7 +32,7 @@ import scala.tools.nsc.classpath.PackageNameUtils.{packageContains, separatePkgA
  * when we have a name of a package.
  * It abstracts over the file representation to work with both JFile and AbstractFile.
  */
-trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
+trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends EfficientClassPath {
   type F
 
   val dir: F
@@ -47,28 +47,26 @@ trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
   protected def createFileEntry(file: AbstractFile): FileEntryType
   protected def isMatchingFile(f: F): Boolean
 
-  private def getDirectory(forPackage: String): Option[F] = {
-    if (forPackage == ClassPath.RootPackage) {
+  private def getDirectory(forPackage: PackageName): Option[F] = {
+    if (forPackage.isRoot) {
       Some(dir)
     } else {
-      val packageDirName = FileUtils.dirPath(forPackage)
-      getSubDir(packageDirName)
+      getSubDir(forPackage.dirPathTrailingSlash)
     }
   }
-  override private[nsc] def hasPackage(pkg: String) = getDirectory(pkg).isDefined
+  override private[nsc] def hasPackage(pkg: PackageName) = getDirectory(pkg).isDefined
 
-  private[nsc] def packages(inPackage: String): Seq[PackageEntry] = {
+  private[nsc] def packages(inPackage: PackageName): Seq[PackageEntry] = {
     val dirForPackage = getDirectory(inPackage)
 
     val nestedDirs: Array[F] = dirForPackage match {
       case None => emptyFiles
       case Some(directory) => listChildren(directory, Some(isPackage))
     }
-    val prefix = PackageNameUtils.packagePrefix(inPackage)
-    nestedDirs.map(f => PackageEntryImpl(prefix + getName(f)))
+    nestedDirs.map(f => PackageEntryImpl(inPackage.entryName(getName(f))))
   }
 
-  protected def files(inPackage: String): Seq[FileEntryType] = {
+  protected def files(inPackage: PackageName): Seq[FileEntryType] = {
     val dirForPackage = getDirectory(inPackage)
     val files: Array[F] = dirForPackage match {
       case None => emptyFiles
@@ -77,22 +75,18 @@ trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
     files.map(f => createFileEntry(toAbstractFile(f)))
   }
 
-  private[nsc] def list(inPackage: String): ClassPathEntries = {
+  override private[nsc] def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit = {
     val dirForPackage = getDirectory(inPackage)
-    val files: Array[F] = dirForPackage match {
-      case None => emptyFiles
-      case Some(directory) => listChildren(directory)
+    dirForPackage match {
+      case None =>
+      case Some(directory) =>
+        for (file <- listChildren(directory)) {
+          if (isPackage(file))
+            onPackageEntry(PackageEntryImpl(inPackage.entryName(getName(file))))
+          else if (isMatchingFile(file))
+            onClassesAndSources(createFileEntry(toAbstractFile(file)))
+        }
     }
-    val packagePrefix = PackageNameUtils.packagePrefix(inPackage)
-    val packageBuf = collection.mutable.ArrayBuffer.empty[PackageEntry]
-    val fileBuf = collection.mutable.ArrayBuffer.empty[FileEntryType]
-    for (file <- files) {
-      if (isPackage(file))
-        packageBuf += PackageEntryImpl(packagePrefix + getName(file))
-      else if (isMatchingFile(file))
-        fileBuf += createFileEntry(toAbstractFile(file))
-    }
-    ClassPathEntries(packageBuf, fileBuf)
   }
 }
 
@@ -196,21 +190,21 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with No
   }
 
   /** Empty string represents root package */
-  override private[nsc] def hasPackage(pkg: String) = packageToModuleBases.contains(pkg)
-  override private[nsc] def packages(inPackage: String): Seq[PackageEntry] = {
-    packageToModuleBases.keysIterator.filter(pack => packageContains(inPackage, pack)).map(PackageEntryImpl(_)).toVector
+  override private[nsc] def hasPackage(pkg: PackageName) = packageToModuleBases.contains(pkg.dottedString)
+  override private[nsc] def packages(inPackage: PackageName): Seq[PackageEntry] = {
+    packageToModuleBases.keysIterator.filter(pack => packageContains(inPackage.dottedString, pack)).map(PackageEntryImpl(_)).toVector
   }
-  private[nsc] def classes(inPackage: String): Seq[ClassFileEntry] = {
-    if (inPackage == "") Nil
+  private[nsc] def classes(inPackage: PackageName): Seq[ClassFileEntry] = {
+    if (inPackage.isRoot) Nil
     else {
-      packageToModuleBases.getOrElse(inPackage, Nil).flatMap(x =>
-        Files.list(x.resolve(inPackage.replace('.', '/'))).iterator().asScala.filter(_.getFileName.toString.endsWith(".class"))).map(x =>
+      packageToModuleBases.getOrElse(inPackage.dottedString, Nil).flatMap(x =>
+        Files.list(x.resolve(inPackage.dirPathTrailingSlash)).iterator().asScala.filter(_.getFileName.toString.endsWith(".class"))).map(x =>
         ClassFileEntryImpl(new PlainNioFile(x))).toVector
     }
   }
 
-  override private[nsc] def list(inPackage: String): ClassPathEntries =
-    if (inPackage == "") ClassPathEntries(packages(inPackage), Nil)
+  override private[nsc] def list(inPackage: PackageName): ClassPathEntries =
+    if (inPackage.isRoot) ClassPathEntries(packages(inPackage), Nil)
     else ClassPathEntries(packages(inPackage), classes(inPackage))
 
   def asURLs: Seq[URL] = Seq(new URL("jrt:/"))
@@ -262,21 +256,21 @@ final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends Clas
   }
 
   /** Empty string represents root package */
-  override private[nsc] def hasPackage(pkg: String) = packageIndex.contains(pkg)
-  override private[nsc] def packages(inPackage: String): Seq[PackageEntry] = {
-    packageIndex.keysIterator.filter(pack => packageContains(inPackage, pack)).map(PackageEntryImpl(_)).toVector
+  override private[nsc] def hasPackage(pkg: PackageName) = packageIndex.contains(pkg.dottedString)
+  override private[nsc] def packages(inPackage: PackageName): Seq[PackageEntry] = {
+    packageIndex.keysIterator.filter(pack => packageContains(inPackage.dottedString, pack)).map(PackageEntryImpl(_)).toVector
   }
-  private[nsc] def classes(inPackage: String): Seq[ClassFileEntry] = {
-    if (inPackage == "") Nil
+  private[nsc] def classes(inPackage: PackageName): Seq[ClassFileEntry] = {
+    if (inPackage.isRoot) Nil
     else {
-      val sigFiles = packageIndex.getOrElse(inPackage, Nil).iterator.flatMap(p =>
+      val sigFiles = packageIndex.getOrElse(inPackage.dottedString, Nil).iterator.flatMap(p =>
         Files.list(p).iterator().asScala.filter(_.getFileName.toString.endsWith(".sig")))
       sigFiles.map(f => ClassFileEntryImpl(new PlainNioFile(f))).toVector
     }
   }
 
-  override private[nsc] def list(inPackage: String): ClassPathEntries =
-    if (inPackage == "") ClassPathEntries(packages(inPackage), Nil)
+  override private[nsc] def list(inPackage: PackageName): ClassPathEntries =
+    if (inPackage.isRoot) ClassPathEntries(packages(inPackage), Nil)
     else ClassPathEntries(packages(inPackage), classes(inPackage))
 
   def asURLs: Seq[URL] = Nil
@@ -310,7 +304,7 @@ case class DirectoryClassPath(dir: File) extends JFileDirectoryLookup[ClassFileE
   protected def createFileEntry(file: AbstractFile): ClassFileEntryImpl = ClassFileEntryImpl(file)
   protected def isMatchingFile(f: File): Boolean = f.isClass
 
-  private[nsc] def classes(inPackage: String): Seq[ClassFileEntry] = files(inPackage)
+  private[nsc] def classes(inPackage: PackageName): Seq[ClassFileEntry] = files(inPackage)
 }
 
 case class DirectorySourcePath(dir: File) extends JFileDirectoryLookup[SourceFileEntryImpl] with NoClassPaths {
@@ -334,5 +328,5 @@ case class DirectorySourcePath(dir: File) extends JFileDirectoryLookup[SourceFil
     }
   }
 
-  private[nsc] def sources(inPackage: String): Seq[SourceFileEntry] = files(inPackage)
+  private[nsc] def sources(inPackage: PackageName): Seq[SourceFileEntry] = files(inPackage)
 }

--- a/src/compiler/scala/tools/nsc/classpath/VirtualDirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/VirtualDirectoryClassPath.scala
@@ -45,7 +45,7 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
     Option(AbstractFileClassLoader.lookupPath(dir)(relativePath split '/', directory = false))
   }
 
-  private[nsc] def classes(inPackage: String): Seq[ClassFileEntry] = files(inPackage)
+  private[nsc] def classes(inPackage: PackageName): Seq[ClassFileEntry] = files(inPackage)
 
   protected def createFileEntry(file: AbstractFile): ClassFileEntryImpl = ClassFileEntryImpl(file)
   protected def isMatchingFile(f: AbstractFile): Boolean = f.isClass

--- a/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
@@ -14,18 +14,19 @@ package scala.tools.nsc.classpath
 
 import java.io.{Closeable, File}
 import java.net.URL
+
 import scala.collection.Seq
 import scala.reflect.io.AbstractFile
 import scala.reflect.io.FileZipArchive
 import FileUtils.AbstractFileOps
-import scala.tools.nsc.util.{ClassPath, ClassRepresentation}
+import scala.tools.nsc.util.{ClassRepresentation, EfficientClassPath}
 
 /**
  * A trait allowing to look for classpath entries of given type in zip and jar files.
  * It provides common logic for classes handling class and source files.
  * It's aware of things like e.g. META-INF directory which is correctly skipped.
  */
-trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPath with Closeable {
+trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends EfficientClassPath with Closeable {
   val zipFile: File
   def release: Option[String]
 
@@ -36,54 +37,47 @@ trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPa
   private val archive = new FileZipArchive(zipFile, release)
   override def close(): Unit = archive.close()
 
-  override private[nsc] def packages(inPackage: String): Seq[PackageEntry] = {
-    val prefix = PackageNameUtils.packagePrefix(inPackage)
+  override private[nsc] def packages(inPackage: PackageName): Seq[PackageEntry] = {
     for {
       dirEntry <- findDirEntry(inPackage).toSeq
       entry <- dirEntry.iterator if entry.isPackage
-    } yield PackageEntryImpl(prefix + entry.name)
+    } yield PackageEntryImpl(inPackage.entryName(entry.name))
   }
 
-  protected def files(inPackage: String): Seq[FileEntryType] =
+  protected def files(inPackage: PackageName): Seq[FileEntryType] =
     for {
       dirEntry <- findDirEntry(inPackage).toSeq
       entry <- dirEntry.iterator if isRequiredFileType(entry)
     } yield createFileEntry(entry)
 
-  protected def file(inPackage: String, name: String): Option[FileEntryType] =
+  protected def file(inPackage: PackageName, name: String): Option[FileEntryType] =
     for {
       dirEntry <- findDirEntry(inPackage)
       entry <- Option(dirEntry.lookupName(name, directory = false))
       if isRequiredFileType(entry)
     } yield createFileEntry(entry)
 
-  override private[nsc] def hasPackage(pkg: String) = findDirEntry(pkg).isDefined
-  override private[nsc] def list(inPackage: String): ClassPathEntries = {
-    val foundDirEntry = findDirEntry(inPackage)
+  override private[nsc] def hasPackage(pkg: PackageName) = findDirEntry(pkg).isDefined
 
-    foundDirEntry map { dirEntry =>
-      val pkgBuf = collection.mutable.ArrayBuffer.empty[PackageEntry]
-      val fileBuf = collection.mutable.ArrayBuffer.empty[FileEntryType]
-      val prefix = PackageNameUtils.packagePrefix(inPackage)
-
-      for (entry <- dirEntry.iterator) {
-        if (entry.isPackage)
-          pkgBuf += PackageEntryImpl(prefix + entry.name)
-        else if (isRequiredFileType(entry))
-          fileBuf += createFileEntry(entry)
-      }
-      ClassPathEntries(pkgBuf, fileBuf)
-    } getOrElse ClassPathEntries.empty
+  private[nsc] def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit = {
+    findDirEntry(inPackage) match {
+      case Some(dirEntry) =>
+        for (entry <- dirEntry.iterator) {
+          if (entry.isPackage)
+            onPackageEntry(PackageEntryImpl(inPackage.entryName(entry.name)))
+          else if (isRequiredFileType(entry))
+            onClassesAndSources(createFileEntry(entry))
+        }
+      case None =>
+    }
   }
 
-  private def findDirEntry(pkg: String): Option[archive.DirEntry] = {
-    archive.allDirs.get(dottedToPath(pkg))
+  private def findDirEntry(pkg: PackageName): Option[archive.DirEntry] = {
+    Option(archive.allDirs.get(pkg.dirPathTrailingSlash))
   }
 
-  private def dottedToPath(dotted: String): String = {
-    dotted.replace('.', '/') + "/"
-  }
 
   protected def createFileEntry(file: FileZipArchive#Entry): FileEntryType
   protected def isRequiredFileType(file: AbstractFile): Boolean
 }
+

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -20,6 +20,7 @@ import java.util.regex.PatternSyntaxException
 
 import File.pathSeparator
 import Jar.isJarOrZip
+import scala.tools.nsc.classpath.{ClassPathEntries, PackageEntry, PackageName}
 
 /**
   * A representation of the compiler's class- or sourcepath.
@@ -27,6 +28,12 @@ import Jar.isJarOrZip
 trait ClassPath {
   import scala.tools.nsc.classpath._
   def asURLs: Seq[URL]
+
+  final def hasPackage(pkg: String): Boolean = hasPackage(PackageName(pkg))
+  final def packages(inPackage: String): Seq[PackageEntry] = packages(PackageName(inPackage))
+  final def classes(inPackage: String): Seq[ClassFileEntry] = classes(PackageName(inPackage))
+  final def sources(inPackage: String): Seq[SourceFileEntry] = sources(PackageName(inPackage))
+  final def list(inPackage: String): ClassPathEntries = list(PackageName(inPackage))
 
   /*
    * These methods are mostly used in the ClassPath implementation to implement the `list` and
@@ -38,11 +45,10 @@ trait ClassPath {
    *
    * The `inPackage` string is a full package name, e.g. "" or "scala.collection".
    */
-
-  private[nsc] def hasPackage(pkg: String): Boolean
-  private[nsc] def packages(inPackage: String): Seq[PackageEntry]
-  private[nsc] def classes(inPackage: String): Seq[ClassFileEntry]
-  private[nsc] def sources(inPackage: String): Seq[SourceFileEntry]
+  private[nsc] def hasPackage(pkg: PackageName): Boolean
+  private[nsc] def packages(inPackage: PackageName): Seq[PackageEntry]
+  private[nsc] def classes(inPackage: PackageName): Seq[ClassFileEntry]
+  private[nsc] def sources(inPackage: PackageName): Seq[SourceFileEntry]
 
   /**
    * Returns packages and classes (source or classfile) that are members of `inPackage` (not
@@ -51,7 +57,7 @@ trait ClassPath {
    * This is the main method uses to find classes, see class `PackageLoader`. The
    * `rootMirror.rootLoader` is created with `inPackage = ""`.
    */
-  private[nsc] def list(inPackage: String): ClassPathEntries
+  private[nsc] def list(inPackage: PackageName): ClassPathEntries
 
   /**
    * Returns the class file and / or source file for a given external name, e.g., "java.lang.String".
@@ -70,8 +76,9 @@ trait ClassPath {
     // solution for a given type of ClassPath
     val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
 
-    val foundClassFromClassFiles = classes(pkg).find(_.name == simpleClassName)
-    def findClassInSources = sources(pkg).find(_.name == simpleClassName)
+    val packageName = PackageName(pkg)
+    val foundClassFromClassFiles = classes(packageName).find(_.name == simpleClassName)
+    def findClassInSources = sources(packageName).find(_.name == simpleClassName)
 
     foundClassFromClassFiles orElse findClassInSources
   }
@@ -99,6 +106,21 @@ trait ClassPath {
   /** The whole sourcepath in the form of one String.
     */
   def asSourcePathString: String
+}
+
+trait EfficientClassPath extends ClassPath {
+  private[nsc] def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit
+  override private[nsc] def list(inPackage: PackageName): ClassPathEntries = {
+    val packageBuf = collection.mutable.ArrayBuffer.empty[PackageEntry]
+    val classRepBuf = collection.mutable.ArrayBuffer.empty[ClassRepresentation]
+    list(inPackage, packageBuf += _, classRepBuf += _)
+    if (packageBuf.isEmpty && classRepBuf.isEmpty) ClassPathEntries.empty
+    else ClassPathEntries(packageBuf, classRepBuf)
+  }
+}
+trait EfficientClassPathCallBack {
+  def packageEntry(entry: PackageEntry): Unit
+  def classesAndSources(entry: ClassRepresentation): Unit
 }
 
 object ClassPath {

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -108,8 +108,10 @@ extends AbstractMap[K, V]
     var e = h & mask
     var x = 0
     var g = 0
-    while ({ g = _hashes(e); g != 0}) {
-      if (g == h && { val q = _keys(e); (q eq k) || ((q ne null) && (q equals k)) }) return e
+    val hashes = _hashes
+    val keys = _keys
+    while ({ g = hashes(e); g != 0}) {
+      if (g == h && { val q = keys(e); (q eq k) || ((q ne null) && (q equals k)) }) return e
       x += 1
       e = (e + 2*(x+1)*x - 3) & mask
     }

--- a/src/reflect/mima-filters/2.12.0.backwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.backwards.excludes
@@ -16,3 +16,6 @@ ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.IOStats$")
 ProblemFilters.exclude[MissingTypesProblem]("scala.reflect.runtime.JavaUniverse")
 
 ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.io.ZipArchive.close")
+
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.reflect.io.ZipArchive.getDir")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.reflect.io.FileZipArchive.allDirs")

--- a/src/reflect/mima-filters/2.12.0.forwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.forwards.excludes
@@ -39,3 +39,6 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.TypeTags.T
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.Universe.TypeTagImpl")
 
 ProblemFilters.exclude[MissingClassProblem]("scala.reflect.macros.Attachments$")
+
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.reflect.io.ZipArchive.getDir")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.reflect.io.FileZipArchive.allDirs")

--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -108,19 +108,19 @@ abstract class ZipArchive(override val file: JFile, release: Option[String]) ext
     }
   }
 
-  private def ensureDir(dirs: mutable.Map[String, DirEntry], path: String, zipEntry: ZipEntry): DirEntry = {
+  private def ensureDir(dirs: java.util.Map[String, DirEntry], path: String, zipEntry: ZipEntry): DirEntry = {
     dirs get path match {
-      case Some(v) => v
-      case None =>
+      case null =>
         val parent = ensureDir(dirs, dirName(path), null)
         val dir = new DirEntry(path)
         parent.entries(baseName(path)) = dir
-        dirs(path) = dir
+        dirs.put(path, dir)
         dir
+      case v => v
     }
   }
 
-  protected def getDir(dirs: mutable.Map[String, DirEntry], entry: ZipEntry): DirEntry = {
+  protected def getDir(dirs: java.util.Map[String, DirEntry], entry: ZipEntry): DirEntry = {
     if (entry.isDirectory) ensureDir(dirs, entry.getName, entry)
     else ensureDir(dirs, dirName(entry.getName), null)
   }
@@ -172,10 +172,10 @@ final class FileZipArchive(file: JFile, release: Option[String]) extends ZipArch
     override def sizeOption: Option[Int] = Some(zipEntry.getSize.toInt)
   }
 
-  private[this] val dirs = mutable.HashMap[String, DirEntry]()
+  private[this] val dirs = new java.util.HashMap[String, DirEntry]()
   lazy val root: DirEntry = {
     val root = new DirEntry("/")
-    dirs("/") = root
+    dirs.put("/", root)
     val zipFile = openZipFile()
     val enum    = zipFile.entries()
 
@@ -209,7 +209,7 @@ final class FileZipArchive(file: JFile, release: Option[String]) extends ZipArch
     root
   }
 
-  lazy val allDirs: mutable.HashMap[String, DirEntry] = { root; dirs }
+  lazy val allDirs: java.util.Map[String, DirEntry] = { root; dirs }
 
   def iterator: Iterator[Entry] = root.iterator
 
@@ -234,7 +234,8 @@ final class FileZipArchive(file: JFile, release: Option[String]) extends ZipArch
 final class URLZipArchive(val url: URL) extends ZipArchive(null) {
   def iterator: Iterator[Entry] = {
     val root     = new DirEntry("/")
-    val dirs     = mutable.HashMap[String, DirEntry]("" -> root)
+    val dirs     = new java.util.HashMap[String, DirEntry]()
+    dirs.put("", root)
     val in       = new ZipInputStream(new ByteArrayInputStream(Streamable.bytes(input)))
     closeables ::= in
 
@@ -307,7 +308,8 @@ final class URLZipArchive(val url: URL) extends ZipArchive(null) {
 final class ManifestResources(val url: URL) extends ZipArchive(null) {
   def iterator = {
     val root     = new DirEntry("/")
-    val dirs     = mutable.HashMap[String, DirEntry]("" -> root)
+    val dirs     = new java.util.HashMap[String, DirEntry]
+    dirs.put("", root)
     val manifest = new Manifest(input)
     closeables ::= input
 

--- a/test/benchmarks/src/main/scala/scala/tools/nsc/AggregateClassPathBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/tools/nsc/AggregateClassPathBenchmark.scala
@@ -1,0 +1,43 @@
+package scala.tools.nsc
+
+import java.nio.file.{Files, Paths}
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.tools.nsc
+import scala.tools.nsc.util.ClassPath
+import scala.tools.util.PathResolver
+
+@BenchmarkMode(Array(jmh.annotations.Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class AggregateClassPathBenchmark {
+  @Param(Array(""))
+  var classpathString: String = _
+  var classpath: ClassPath = _
+  val closeableRegistry = new CloseableRegistry
+  @Setup def setup(): Unit = {
+    val settings = new nsc.Settings()
+    if (classpathString.startsWith("@"))
+      classpathString = new String(Files.readAllBytes(Paths.get(classpathString.drop(1))))
+    settings.classpath.value = classpathString
+    val resolver = new PathResolver(settings, closeableRegistry)
+    classpath = resolver.result
+    classpath.list("")
+  }
+
+  @TearDown def teardown(): Unit = {
+    closeableRegistry.close()
+  }
+
+  @Benchmark def test(bh: Blackhole) = {
+    classpath.list("")._1.foreach(entry => bh.consume(classpath.list(entry.name)))
+  }
+}

--- a/test/junit/scala/tools/nsc/classpath/AggregateClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/AggregateClassPathTest.scala
@@ -21,12 +21,12 @@ import scala.tools.nsc.util.ClassPath
 class AggregateClassPathTest {
 
   private abstract class TestClassPathBase extends ClassPath {
-    override private[nsc] def hasPackage(pkg: String) = true
-    override def packages(inPackage: String): Seq[PackageEntry] = unsupported
-    override def sources(inPackage: String): Seq[SourceFileEntry] = unsupported
-    override def classes(inPackage: String): Seq[ClassFileEntry] = unsupported
+    override private[nsc] def hasPackage(pkg: PackageName) = true
+    override def packages(inPackage: PackageName): Seq[PackageEntry] = unsupported
+    override def sources(inPackage: PackageName): Seq[SourceFileEntry] = unsupported
+    override def classes(inPackage: PackageName): Seq[ClassFileEntry] = unsupported
 
-    override def list(inPackage: String): ClassPathEntries = unsupported
+    override def list(inPackage: PackageName): ClassPathEntries = unsupported
     override def findClassFile(name: String): Option[AbstractFile] = unsupported
 
     override def asClassPathStrings: Seq[String] = unsupported
@@ -36,30 +36,30 @@ class AggregateClassPathTest {
 
   private case class TestClassPath(virtualPath: String, classesInPackage: EntryNamesInPackage*) extends TestClassPathBase {
 
-    override def classes(inPackage: String): Seq[ClassFileEntry] =
+    override def classes(inPackage: PackageName): Seq[ClassFileEntry] =
       for {
-        entriesWrapper <- classesInPackage if entriesWrapper.inPackage == inPackage
+        entriesWrapper <- classesInPackage if entriesWrapper.inPackage == inPackage.dottedString
         name <- entriesWrapper.names
-      } yield classFileEntry(virtualPath, inPackage, name)
+      } yield classFileEntry(virtualPath, inPackage.dottedString, name)
 
-    override def sources(inPackage: String): Seq[SourceFileEntry] = Nil
+    override def sources(inPackage: PackageName): Seq[SourceFileEntry] = Nil
 
     // we'll ignore packages
-    override def list(inPackage: String): ClassPathEntries = ClassPathEntries(Nil, classes(inPackage))
+    override def list(inPackage: PackageName): ClassPathEntries = ClassPathEntries(Nil, classes(inPackage))
   }
 
   private case class TestSourcePath(virtualPath: String, sourcesInPackage: EntryNamesInPackage*) extends TestClassPathBase {
 
-    override def sources(inPackage: String): Seq[SourceFileEntry] =
+    override def sources(inPackage: PackageName): Seq[SourceFileEntry] =
       for {
-        entriesWrapper <- sourcesInPackage if entriesWrapper.inPackage == inPackage
+        entriesWrapper <- sourcesInPackage if entriesWrapper.inPackage == inPackage.dottedString
         name <- entriesWrapper.names
-      } yield sourceFileEntry(virtualPath, inPackage, name)
+      } yield sourceFileEntry(virtualPath, inPackage.dottedString, name)
 
-    override def classes(inPackage: String): Seq[ClassFileEntry] = Nil
+    override def classes(inPackage: PackageName): Seq[ClassFileEntry] = Nil
 
     // we'll ignore packages
-    override def list(inPackage: String): ClassPathEntries = ClassPathEntries(Nil, sources(inPackage))
+    override def list(inPackage: PackageName): ClassPathEntries = ClassPathEntries(Nil, sources(inPackage))
   }
 
   private case class EntryNamesInPackage(inPackage: String)(val names: String*)
@@ -109,8 +109,8 @@ class AggregateClassPathTest {
   @Test
   def testGettingPackages: Unit = {
     case class ClassPathWithPackages(packagesInPackage: EntryNamesInPackage*) extends TestClassPathBase {
-      override def packages(inPackage: String): Seq[PackageEntry] =
-        packagesInPackage.find(_.inPackage == inPackage).map(_.names).getOrElse(Nil) map PackageEntryImpl
+      override def packages(inPackage: PackageName): Seq[PackageEntry] =
+        packagesInPackage.find(_.inPackage == inPackage.dottedString).map(_.names).getOrElse(Nil) map PackageEntryImpl
     }
 
     val partialClassPaths = Seq(ClassPathWithPackages(EntryNamesInPackage(pkg1)("pkg1.a", "pkg1.d", "pkg1.f")),


### PR DESCRIPTION
 - Avoid repeated conversion between package dotted names ("com.foo")
    and relative paths ("com/foo/") by threading a `PackageName`
    instance through the aggregate classpath lookup which caches
    the path name.
  - Avoid creating result buffers inside of each element of the
    aggregate classpath by introducing a callback based API that
    lets `AggregateClasspath` use a single buffer.

Before:

```
[info] Benchmark                                                                                  (classpathString)  Mode  Cnt        Score         Error   Units
[info] AggregateClassPathBenchmark.test                                   @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10  2109607.861 ±  339561.922   ns/op
[info] AggregateClassPathBenchmark.test:·gc.alloc.rate                    @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10      732.202 ±      94.633  MB/sec
[info] AggregateClassPathBenchmark.test:·gc.alloc.rate.norm               @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10  2411260.302 ±      50.691    B/op
[info] AggregateClassPathBenchmark.test:·gc.churn.PS_Eden_Space           @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10      792.591 ±    1269.210  MB/sec
[info] AggregateClassPathBenchmark.test:·gc.churn.PS_Eden_Space.norm      @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10  2732481.613 ± 4514800.213    B/op
[info] AggregateClassPathBenchmark.test:·gc.churn.PS_Survivor_Space       @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10        0.019 ±       0.063  MB/sec
[info] AggregateClassPathBenchmark.test:·gc.churn.PS_Survivor_Space.norm  @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10       59.982 ±     203.957    B/op
[info] AggregateClassPathBenchmark.test:·gc.count                         @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10        5.000                counts
[info] AggregateClassPathBenchmark.test:·gc.time                          @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10        5.000                    ms
```

After:

```
[info] Benchmark                                                                                  (classpathString)  Mode  Cnt       Score        Error   Units
[info] AggregateClassPathBenchmark.test                                   @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10  580983.606 ±  14088.052   ns/op
[info] AggregateClassPathBenchmark.test:·gc.alloc.rate                    @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10     405.902 ±      9.647  MB/sec
[info] AggregateClassPathBenchmark.test:·gc.alloc.rate.norm               @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10  371348.000 ±     14.589    B/op
[info] AggregateClassPathBenchmark.test:·gc.churn.PS_Eden_Space           @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10     429.614 ±    351.032  MB/sec
[info] AggregateClassPathBenchmark.test:·gc.churn.PS_Eden_Space.norm      @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10  392532.252 ± 320194.247    B/op
[info] AggregateClassPathBenchmark.test:·gc.churn.PS_Survivor_Space       @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10       0.006 ±      0.030  MB/sec
[info] AggregateClassPathBenchmark.test:·gc.churn.PS_Survivor_Space.norm  @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10       5.595 ±     26.749    B/op
[info] AggregateClassPathBenchmark.test:·gc.count                         @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10       8.000               counts
[info] AggregateClassPathBenchmark.test:·gc.time                          @/code/scala-2.12.x/sandbox/classpath.txt  avgt   10       7.000                   ms
```

Given:

```
$ coursier fetch -p org.apache.spark:spark-repl_2.12:2.4.3 -p org.apache.cassandra:cassandra-all:3.11.4 | tee /code/scala-2.12.x/sandbox/classpath.txt
```