### PR TITLE
Add links for Scala modules in docs

### DIFF
--- a/src/library/rootdoc.txt
+++ b/src/library/rootdoc.txt
@@ -42,9 +42,9 @@ Other packages exist.  See the complete list on the right.
 Additional parts of the standard library are shipped as separate libraries. These include:
 
   - [[scala.reflect       `scala.reflect`]]   - Scala's reflection API (scala-reflect.jar)
-  - [[scala.xml           `scala.xml`]]    - XML parsing, manipulation, and serialization (scala-xml.jar)
-  - [[scala.swing         `scala.swing`]]  - A convenient wrapper around Java's GUI framework called Swing (scala-swing.jar)
-  - [[scala.util.parsing  `scala.util.parsing`]] - Parser combinators (scala-parser-combinators.jar)
+  - [[https://github.com/scala/scala-xml `scala.xml`]]    - XML parsing, manipulation, and serialization (scala-xml.jar)
+  - [[https://github.com/scala/scala-swing `scala.swing`]]  - A convenient wrapper around Java's GUI framework called Swing (scala-swing.jar)
+  - [[https://github.com/scala/scala-parser-combinators `scala.util.parsing`]] - Parser combinators (scala-parser-combinators.jar)
 
 == Automatic imports ==
 


### PR DESCRIPTION
Currently, these links go nowhere, see "Additional parts of the standard library":

https://www.scala-lang.org/api/2.12.9/

Scaladoc was emitting warnings that the cross-reference wasn't working but nobody saw them.