### PR TITLE
Optimize setting initialization with large classpaths

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilerCommand.scala
+++ b/src/compiler/scala/tools/nsc/CompilerCommand.scala
@@ -111,7 +111,7 @@ class CompilerCommand(arguments: List[String], val settings: Settings) {
       val components = global.phaseNames // global.phaseDescriptors // one initializes
       s"Phase graph of ${components.size} components output to ${genPhaseGraph.value}*.dot."
     }
-    else allSettings.filter(_.isHelping).map(_.help).mkString("\n\n")
+    else allSettings.valuesIterator.filter(_.isHelping).map(_.help).mkString("\n\n")
   }
 
   /**

--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -67,8 +67,8 @@ class ScriptRunner extends HasCompileSocket {
    */
   private def compileWithDaemon(settings: GenericRunnerSettings, scriptFileIn: String) = {
     val scriptFile       = Path(scriptFileIn).toAbsolute.path
-    val compSettingNames = new Settings(sys.error).visibleSettings.toList map (_.name)
-    val compSettings     = settings.visibleSettings.toList filter (compSettingNames contains _.name)
+    val compSettingNames = new Settings(sys.error).visibleSettings map (_.name)
+    val compSettings     = settings.visibleSettings filter (compSettingNames contains _.name)
     val coreCompArgs     = compSettings flatMap (_.unparse)
     val compArgs         = coreCompArgs ++ List("-Xscript", scriptMain(settings), scriptFile)
 

--- a/src/compiler/scala/tools/nsc/settings/AbsSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/AbsSettings.scala
@@ -22,19 +22,19 @@ trait AbsSettings extends scala.reflect.internal.settings.AbsSettings {
   type Setting <: AbsSetting      // Fix to the concrete Setting type
   type ResultOfTryToSet           // List[String] in mutable, (Settings, List[String]) in immutable
   def errorFn: String => Unit
-  protected def allSettings: scala.collection.Set[Setting]
+  protected def allSettings: scala.collection.Map[String, Setting]
 
   // settings minus internal usage settings
-  def visibleSettings = allSettings filterNot (_.isInternalOnly)
+  def visibleSettings: List[Setting] = allSettings.valuesIterator.filterNot(_.isInternalOnly).toList
 
   // only settings which differ from default
-  def userSetSettings = visibleSettings filterNot (_.isDefault)
+  def userSetSettings: List[Setting] = visibleSettings.filterNot(_.isDefault)
 
   // an argument list which (should) be usable to recreate the Settings
-  def recreateArgs = userSetSettings.toList flatMap (_.unparse)
+  def recreateArgs: List[String] = userSetSettings flatMap (_.unparse)
 
   // checks both name and any available abbreviations
-  def lookupSetting(cmd: String): Option[Setting] = allSettings find (_ respondsTo cmd)
+  def lookupSetting(cmd: String): Option[Setting] = allSettings.valuesIterator find (_ respondsTo cmd)
 
   // two AbsSettings objects are equal if their visible settings are equal.
   override def hashCode() = visibleSettings.size  // going for cheap

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -38,8 +38,8 @@ class MutableSettings(val errorFn: String => Unit)
   }
 
   def copyInto(settings: MutableSettings) {
-    allSettings foreach { thisSetting =>
-      val otherSetting = settings.allSettings find { _.name == thisSetting.name }
+    allSettings.valuesIterator foreach { thisSetting =>
+      val otherSetting = settings.allSettings.get(thisSetting.name)
       otherSetting foreach { otherSetting =>
         if (thisSetting.isSetByUser || otherSetting.isSetByUser) {
           otherSetting.value = thisSetting.value.asInstanceOf[otherSetting.T]
@@ -112,7 +112,7 @@ class MutableSettings(val errorFn: String => Unit)
   /** A list of settings which act based on prefix rather than an exact
    *  match.  This is basically -D and -J.
    */
-  lazy val prefixSettings = allSettings collect { case x: PrefixSetting => x }
+  lazy val prefixSettings = allSettings.valuesIterator.collect { case x: PrefixSetting => x }.toList
 
   /** Split the given line into parameters.
    */
@@ -222,7 +222,7 @@ class MutableSettings(val errorFn: String => Unit)
 
   // a wrapper for all Setting creators to keep our list up to date
   private def add[T <: Setting](s: T): T = {
-    allSettings += s
+    allSettings(s.name) = s
     s
   }
 

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -31,7 +31,7 @@ trait ScalaSettings extends AbsScalaSettings
   self: MutableSettings =>
 
   /** Set of settings */
-  protected[scala] lazy val allSettings = mutable.HashSet[Setting]()
+  protected[scala] lazy val allSettings = mutable.LinkedHashMap[String, Setting]()
 
   /** The user class path, specified by `-classpath` or `-cp`,
    *  defaults to the value of CLASSPATH env var if it is set, as in Java,
@@ -49,10 +49,10 @@ trait ScalaSettings extends AbsScalaSettings
   def infoSettings = List[Setting](version, help, Xhelp, Yhelp, showPlugins, showPhases, genPhaseGraph)
 
   /** Is an info setting set? Any -option:help? */
-  def isInfo = infoSettings.exists(_.isSetByUser) || allSettings.exists(_.isHelping)
+  def isInfo = infoSettings.exists(_.isSetByUser) || allSettings.valuesIterator.exists(_.isHelping)
 
   /** Disable a setting */
-  def disable(s: Setting) = allSettings -= s
+  def disable(s: Setting) = allSettings -= s.name
 
   val jvmargs  = PrefixSetting("-J<flag>", "-J", "Pass <flag> directly to the runtime system.")
   val defines  = PrefixSetting("-Dproperty=value", "-D", "Pass -Dproperty=value directly to the runtime system.")

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -128,7 +128,10 @@ object ClassPath {
   def split(path: String): List[String] = (path split pathSeparator).toList.filterNot(_ == "").distinct
 
   /** Join classpath using platform-dependent path separator */
-  def join(paths: String*): String  = paths filterNot (_ == "") mkString pathSeparator
+  def join(paths: String*): String  = paths.toList.filterNot(_ == "") match {
+    case only :: Nil => only // optimize for a common case when called by PathSetting.value
+    case xs => xs.mkString(pathSeparator)
+  }
 
   /** Split the classpath, apply a transformation function, and reassemble it. */
   def map(cp: String, f: String => String): String = join(split(cp) map f: _*)

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -247,7 +247,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter) extend
       buffer.substring(0, cursor) match {
         case trailingWord(s) =>
           val maybes = settings.visibleSettings.filter(_.name.startsWith(s)).map(_.name)
-                               .filterNot(when(_) { case "-"|"-X"|"-Y" => true }).toList.sorted
+                               .filterNot(when(_) { case "-"|"-X"|"-Y" => true }).sorted
           if (maybes.isEmpty) NoCandidates else Candidates(cursor - s.length, maybes)
         case _ => NoCandidates
       }
@@ -362,7 +362,8 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter) extend
   }
 
   private def changeSettings(line: String): Result = {
-    def showSettings() = for (s <- settings.userSetSettings.toSeq.sorted) echo(s.toString)
+    val s = settings
+    def showSettings() = for (s <- s.userSetSettings.sorted(Ordering.ordered[s.Setting])) echo(s.toString)
     if (line.isEmpty) showSettings() else { updateSettings(line) ; () }
   }
   private def updateSettings(line: String) = {

--- a/test/files/run/settings-parse.check
+++ b/test/files/run/settings-parse.check
@@ -1,566 +1,566 @@
 0) List(-cp, ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 1) List(-cp, , ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 2) List(, -cp, ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 3) List(-cp, , -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 4) List(-cp, , , -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 5) List(-cp, , -deprecation, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 6) List(, -cp, , -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 7) List(-cp, , -deprecation, foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 8) List(-cp, , , -deprecation, foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 9) List(-cp, , -deprecation, , foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 10) List(-cp, , -deprecation, foo.scala, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 11) List(, -cp, , -deprecation, foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 12) List(-cp, , foo.scala) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 13) List(-cp, , , foo.scala) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 14) List(-cp, , foo.scala, ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 15) List(, -cp, , foo.scala) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 16) List(-cp, , foo.scala, -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 17) List(-cp, , , foo.scala, -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 18) List(-cp, , foo.scala, , -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 19) List(-cp, , foo.scala, -deprecation, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 20) List(, -cp, , foo.scala, -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 21) List(-deprecation, -cp, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 22) List(, -deprecation, -cp, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 23) List(-deprecation, -cp, , ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 24) List(-deprecation, , -cp, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 25) List(-deprecation, -cp, , foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 26) List(, -deprecation, -cp, , foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 27) List(-deprecation, -cp, , , foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 28) List(-deprecation, -cp, , foo.scala, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 29) List(-deprecation, , -cp, , foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 30) List(-deprecation, foo.scala, -cp, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 31) List(, -deprecation, foo.scala, -cp, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 32) List(-deprecation, , foo.scala, -cp, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 33) List(-deprecation, foo.scala, -cp, , ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 34) List(-deprecation, foo.scala, , -cp, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 35) List(foo.scala, -cp, ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 36) List(, foo.scala, -cp, ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 37) List(foo.scala, -cp, , ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 38) List(foo.scala, , -cp, ) ==> Settings {
-  -d = .
   -classpath = ""
+  -d = .
 }
 
 39) List(foo.scala, -cp, , -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 40) List(, foo.scala, -cp, , -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 41) List(foo.scala, -cp, , , -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 42) List(foo.scala, -cp, , -deprecation, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 43) List(foo.scala, , -cp, , -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 44) List(foo.scala, -deprecation, -cp, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 45) List(, foo.scala, -deprecation, -cp, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 46) List(foo.scala, , -deprecation, -cp, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 47) List(foo.scala, -deprecation, -cp, , ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 48) List(foo.scala, -deprecation, , -cp, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = ""
+  -d = .
 }
 
 0) List(-cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 1) List(-cp, /tmp:/bippy, ) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 2) List(, -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 3) List(-cp, /tmp:/bippy, -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 4) List(-cp, /tmp:/bippy, , -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 5) List(-cp, /tmp:/bippy, -deprecation, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 6) List(, -cp, /tmp:/bippy, -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 7) List(-cp, /tmp:/bippy, -deprecation, foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 8) List(-cp, /tmp:/bippy, , -deprecation, foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 9) List(-cp, /tmp:/bippy, -deprecation, , foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 10) List(-cp, /tmp:/bippy, -deprecation, foo.scala, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 11) List(, -cp, /tmp:/bippy, -deprecation, foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 12) List(-cp, /tmp:/bippy, foo.scala) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 13) List(-cp, /tmp:/bippy, , foo.scala) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 14) List(-cp, /tmp:/bippy, foo.scala, ) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 15) List(, -cp, /tmp:/bippy, foo.scala) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 16) List(-cp, /tmp:/bippy, foo.scala, -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 17) List(-cp, /tmp:/bippy, , foo.scala, -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 18) List(-cp, /tmp:/bippy, foo.scala, , -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 19) List(-cp, /tmp:/bippy, foo.scala, -deprecation, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 20) List(, -cp, /tmp:/bippy, foo.scala, -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 21) List(-deprecation, -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 22) List(, -deprecation, -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 23) List(-deprecation, -cp, /tmp:/bippy, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 24) List(-deprecation, , -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 25) List(-deprecation, -cp, /tmp:/bippy, foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 26) List(, -deprecation, -cp, /tmp:/bippy, foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 27) List(-deprecation, -cp, /tmp:/bippy, , foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 28) List(-deprecation, -cp, /tmp:/bippy, foo.scala, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 29) List(-deprecation, , -cp, /tmp:/bippy, foo.scala) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 30) List(-deprecation, foo.scala, -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 31) List(, -deprecation, foo.scala, -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 32) List(-deprecation, , foo.scala, -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 33) List(-deprecation, foo.scala, -cp, /tmp:/bippy, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 34) List(-deprecation, foo.scala, , -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 35) List(foo.scala, -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 36) List(, foo.scala, -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 37) List(foo.scala, -cp, /tmp:/bippy, ) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 38) List(foo.scala, , -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 39) List(foo.scala, -cp, /tmp:/bippy, -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 40) List(, foo.scala, -cp, /tmp:/bippy, -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 41) List(foo.scala, -cp, /tmp:/bippy, , -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 42) List(foo.scala, -cp, /tmp:/bippy, -deprecation, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 43) List(foo.scala, , -cp, /tmp:/bippy, -deprecation) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 44) List(foo.scala, -deprecation, -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 45) List(, foo.scala, -deprecation, -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 46) List(foo.scala, , -deprecation, -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 47) List(foo.scala, -deprecation, -cp, /tmp:/bippy, ) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 
 48) List(foo.scala, -deprecation, , -cp, /tmp:/bippy) ==> Settings {
-  -d = .
   -deprecation = true
   -classpath = /tmp:/bippy
+  -d = .
 }
 

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -13,7 +13,7 @@ class SettingsTest {
     def check(args: String*): MutableSettings#BooleanSetting = {
       val s = new MutableSettings(msg => throw new IllegalArgumentException(msg))
       val b1 = new s.BooleanSetting("-Ytest-setting", "")
-      s.allSettings += b1
+      s.allSettings(b1.name) = b1
       val (ok, residual) = s.processArguments(args.toList, processAll = true)
       assert(residual.isEmpty)
       b1


### PR DESCRIPTION
PathSetting.hashCode can be expensive when a large classpath
is configured.

This commit changes `allSettings` into a hash map keyed on the
setting name. Using the `Setting` itself (which is mutable!)
as hashed element in the old `allSettings: Set[Setting]` seems
plain wrong.

Derived settings collextions (`visibleSettings` and friends) are
now lists, rather than sets.