### PR TITLE
Add links for Scala modules in docs

### DIFF
--- a/src/library/rootdoc.txt
+++ b/src/library/rootdoc.txt
@@ -32,10 +32,10 @@ Other packages exist.  See the complete list on the right.
 Additional parts of the standard library are shipped as separate libraries. These include:
 
   - [[scala.reflect       `scala.reflect`]]   - Scala's reflection API (scala-reflect.jar)
-  - [[scala.xml           `scala.xml`]]    - XML parsing, manipulation, and serialization (scala-xml.jar)
-  - [[scala.collection.parallel `scala.collection.parallel`]] - Parallel collections (scala-parallel-collections.jar)
-  - [[scala.util.parsing  `scala.util.parsing`]] - Parser combinators (scala-parser-combinators.jar)
-  - [[scala.swing         `scala.swing`]]  - A convenient wrapper around Java's GUI framework called Swing (scala-swing.jar)
+  - [[https://github.com/scala/scala-xml `scala.xml`]]    - XML parsing, manipulation, and serialization (scala-xml.jar)
+  - [[https://github.com/scala/scala-parallel-collections `scala.collection.parallel`]] - Parallel collections (scala-parallel-collections.jar)
+  - [[https://github.com/scala/scala-parser-combinators `scala.util.parsing`]] - Parser combinators (scala-parser-combinators.jar)
+  - [[https://github.com/scala/scala-swing `scala.swing`]]  - A convenient wrapper around Java's GUI framework called Swing (scala-swing.jar)
 
 == Automatic imports ==
 


### PR DESCRIPTION
This is the 2.13 version of #8357.