### PR TITLE
Change markdown code blocks to Scaladoc

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
@@ -256,7 +256,7 @@ trait AccessorSynthesis extends Transform with ast.TreeDSL {
       /**
         * The compute method (slow path) looks like:
         *
-        * ```
+        * {{{
         * def l\$compute() = {
         *   synchronized(this) {
         *     if ((bitmap\$n & MASK) == 0) {
@@ -270,7 +270,7 @@ trait AccessorSynthesis extends Transform with ast.TreeDSL {
         *   this.fn = null
         *   l\$
         * }
-        * ```
+        * }}}
         *
         * `bitmap\$n` is a byte, int or long value acting as a bitmap of initialized values.
         * The kind of the bitmap determines how many bit indicators for lazy vals are stored in it.

--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -567,7 +567,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
       * Desugar a local `lazy val x: Int = rhs`
       * or a local `object x { ...}` (the rhs will be instantiating the module's class) into:
       *
-      * ```
+      * {{{
       * val x\$lzy = new scala.runtime.LazyInt()
       * def x\$lzycompute(): Int =
       *   x\$lzy.synchronized {
@@ -575,7 +575,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
       *     else x\$lzy.initialize(rhs) // for a Unit-typed lazy val, this becomes `{ rhs ; x\$lzy.initialize() }` to avoid passing around BoxedUnit
       *  }
       * def x(): Int = if (x\$lzy.initialized()) x\$lzy.value() else x\$lzycompute()
-      * ```
+      * }}}
       *
       * The expansion is the same for local lazy vals and local objects,
       * except for the suffix of the underlying val's name (\$lzy or \$module)

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1385,7 +1385,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
    * the new info then guides the tree changes. But if a symbol is created during duplication,
    * which runs after specialization, its info is not visited and thus the corresponding tree
    * is not specialized. One manifestation is the following:
-   * ```
+   * {{{
    * object Test {
    *   class Parent[@specialized(Int) T]
    *
@@ -1398,7 +1398,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
    *     ...
    *   }
    * }
-   * ```
+   * }}}
    * We fix this by forcing duplication to take place before specialization.
    *
    * Note: The constructors phase (which also uses duplication) comes after erasure and uses the
@@ -1594,10 +1594,10 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       }
 
       /** Computes residual type parameters after rewiring, like "String" in the following example:
-       *  ```
+       *  {{{
        *    def specMe[@specialized T, U](t: T, u: U) = ???
        *    specMe[Int, String](1, "2") => specMe\$mIc\$sp[String](1, "2")
-       *  ```
+       *  }}}
        */
       def computeResidualTypeVars(baseTree: Tree, specMember: Symbol, specTree: Tree, baseTargs: List[Tree], env: TypeEnv): Tree = {
         val residualTargs = symbol.info.typeParams zip baseTargs collect {

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -735,29 +735,29 @@ abstract class UnCurry extends InfoTransform
               val tempVal: ValDef = {
                 // scala/bug#9442: using the "uncurry-erased" type (the one after the uncurry phase) can lead to incorrect
                 // tree transformations. For example, compiling:
-                // ```
+                //
                 //   def foo(c: Ctx)(l: c.Tree): Unit = {
                 //     val l2: c.Tree = l
                 //   }
-                // ```
+                //
                 // Results in the following AST:
-                // ```
+                //
                 //   def foo(c: Ctx, l: Ctx#Tree): Unit = {
                 //     val l$1: Ctx#Tree = l.asInstanceOf[Ctx#Tree]
                 //     val l2: c.Tree = l$1 // no, not really, it's not.
                 //   }
-                // ```
+                //
                 // Of course, this is incorrect, since `l$1` has type `Ctx#Tree`, which is not a subtype of `c.Tree`.
                 //
                 // So what we need to do is to use the pre-uncurry type when creating `l$1`, which is `c.Tree` and is
                 // correct. Now, there are two additional problems:
                 // 1. when varargs and byname params are involved, the uncurry transformation desugars these special
                 //    cases to actual typerefs, eg:
-                //    ```
+                //
                 //           T*   ~> Seq[T] (Scala-defined varargs)
                 //           T*   ~> Array[T] (Java-defined varargs)
                 //           => T ~> Function0[T] (by name params)
-                //    ```
+                //
                 //    we use the DesugaredParameterType object (defined in scala.reflect.internal.transform.UnCurry)
                 //    to redo this desugaring manually here
                 // 2. the type needs to be normalized, since `gen.mkCast` checks this (no HK here, just aliases have

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternExpansion.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternExpansion.scala
@@ -184,7 +184,6 @@ trait PatternExpansion {
       // scala/bug#9029 A pattern with arity-1 that doesn't match the arity of
       // the Product-like result of the `get` method, will match that result in its entirety.
       //
-      // ```
       // warning: there was one deprecation warning; re-run with -deprecation for details
       // scala> object Extractor { def unapply(a: Any): Option[(Int, String)] = Some((1, "2")) }
       // defined object Extractor
@@ -193,7 +192,6 @@ trait PatternExpansion {
       //
       // scala> "" match { case Extractor(xy : (Int, String)) => }
       // warning: there was one deprecation warning; re-run with -deprecation for details
-      // ```
       else if (totalArity == 1 && equivConstrParamTypes.tail.nonEmpty) {
         warnPatternTupling()
         (if (tupleValuedUnapply) tupleType(equivConstrParamTypes) else resultOfGetInMonad()) :: Nil

--- a/src/compiler/scala/tools/nsc/typechecker/EtaExpansion.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/EtaExpansion.scala
@@ -30,7 +30,7 @@ trait EtaExpansion { self: Analyzer =>
     * the target of the application and its supplied arguments if needed (they are not stable),
     * and then wraps a Function that abstracts over the missing arguments.
     *
-    * ```
+    * {{{
     * {
     *   private synthetic val eta\$f   = p.f   // if p is not stable
     *   ...
@@ -38,7 +38,7 @@ trait EtaExpansion { self: Analyzer =>
     *   ...
     *   (ps_1 => ... => ps_m => eta\$f([es_1])...([es_m])(ps_1)...(ps_m))
     * }
-    * ```
+    * }}}
     *
     * This is called from typedEtaExpansion, which itself is called from
     *   - instantiateToMethodType (for a naked method reference), or

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2884,12 +2884,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       * where `S` is the expected type that defines a single abstract method (call it `apply` for the example),
       * that has signature `(p1: T1', ..., pN: TN'): T'`, synthesize the instantiation of the following anonymous class
       *
-      * ```
+      * {{{
       *   new S {
       *    def apply\$body(p1: T1, ..., pN: TN): T = body
       *    def apply(p1: T1', ..., pN: TN'): T' = apply\$body(p1,..., pN)
       *   }
-      * ```
+      * }}}
       *
       * The `apply` method is identified by the argument `sam`; `S` corresponds to the argument `pt`,
       * If `pt` is not fully defined, we derive `samClassTpFullyDefined` by inferring any unknown type parameters.

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2802,7 +2802,7 @@ trait Types
         val len = params.length
         val paramsTpes: Array[Type] = new Array[Type](len)
 
-        // returns the result of ```params.forall(_.tpe.isTrivial))```
+        // returns the result of `params.forall(_.tpe.isTrivial))`
         // along the way, it loads each param' tpe into array
         def forallIsTrivial: Boolean = {
           var res = true

--- a/test/files/specialized/t7343.scala
+++ b/test/files/specialized/t7343.scala
@@ -9,11 +9,12 @@ object Test extends App {
    * classes, which usually end up inside methods. For these closures we do
    * want their parents rewired correctly:
    *
-   * ```
+   * {{{
    *  def checkSuperClass$mIc$sp[T](t: T, ...) = {
    *    class X extends Parent$mcI$sp // instead of just Parent
    *    ...
    *  }
+   * }}}
    */
   def checkSuperClass[@specialized(Int) T](t: T, expectedXSuper: String) = {
     // test target:


### PR DESCRIPTION
Scaladoc doesn't support triple-backticks.  It does support single-backticks, so the presence of triple-backticks are interpreted as an empty single-backtick, then the code, then another empty backticks.  This gets rendered a single line of code by Scaladoc.  For example:

https://www.scala-lang.org/api/2.13.0/scala-compiler/scala/tools/nsc/typechecker/EtaExpansion.html#etaExpand