### PR TITLE
Enable autoAPIMappings in build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -215,7 +215,8 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
       Map.empty[File,URL]
     }
   },
-  apiURL := Some(url("https://www.scala-lang.org/api/" + versionProperties.value.mavenVersion + "/")),
+  apiURL := None, // set on a per-project basis
+  autoAPIMappings := true,
   pomIncludeRepository := { _ => false },
   pomExtra := {
     <scm>
@@ -406,6 +407,7 @@ lazy val library = configureAsSubproject(project)
       "/project/description" -> <description>Standard library for the Scala Programming Language</description>,
       "/project/packaging" -> <packaging>jar</packaging>
     ),
+    apiURL := Some(url(s"https://www.scala-lang.org/api/${versionProperties.value.mavenVersion}/")),
     mimaPreviousArtifacts := mimaReferenceVersion.value.map(organization.value % name.value % _).toSet,
     mimaCheckDirection := "both",
     mimaFilterSettings,
@@ -438,6 +440,7 @@ lazy val reflect = configureAsSubproject(project)
       "/project/description" -> <description>Compiler for the Scala Programming Language</description>,
       "/project/packaging" -> <packaging>jar</packaging>
     ),
+    apiURL := Some(url(s"https://www.scala-lang.org/api/${versionProperties.value.mavenVersion}/scala-${thisProject.value.id}/")),
     mimaPreviousArtifacts := mimaReferenceVersion.value.map(organization.value % name.value % _).toSet,
     mimaCheckDirection := "both",
     mimaFilterSettings,
@@ -507,7 +510,7 @@ lazy val compiler = configureAsSubproject(project)
       "/project/description" -> <description>Compiler for the Scala Programming Language</description>,
       "/project/packaging" -> <packaging>jar</packaging>
     ),
-    apiURL := None,
+    apiURL := Some(url(s"https://www.scala-lang.org/api/${versionProperties.value.mavenVersion}/scala-${thisProject.value.id}/")),
     pomDependencyExclusions += (("org.scala-lang.modules", "scala-asm"))
   )
   .dependsOn(library, reflect)


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11706

The canonical location of scala-compiler and scala-reflect are different from scala-library:

https://www.scala-lang.org/api/2.13.0/
https://www.scala-lang.org/api/2.13.0/scala-compiler/
https://www.scala-lang.org/api/2.13.0/scala-reflect/

Changes here are continuation of squashing Scaladoc warnings #8290, #8339, and #8359, and also conflict with #8284.