### PR TITLE
lengthen timeout in concurrency test case

### DIFF
--- a/test/files/jvm/scala-concurrent-tck.scala
+++ b/test/files/jvm/scala-concurrent-tck.scala
@@ -23,7 +23,7 @@ trait TestBase {
     body(new Done {
       def apply(proof: => Boolean): Unit = q offer Try(proof)
     })
-    assert(Option(q.poll(2000, TimeUnit.MILLISECONDS)).map(_.get).getOrElse(false))
+    assert(Option(q.poll(5000, TimeUnit.MILLISECONDS)).map(_.get).getOrElse(false))
     // Check that we don't get more than one completion
     assert(q.poll(50, TimeUnit.MILLISECONDS) eq null)
   }


### PR DESCRIPTION
this assertion periodically fails in our Windows CI
(https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-windows/),
often enough to be annoying

I've verified that if I decrease this timeout enough (say, to 50ms or
10ms), I see similar failures even on MacOS

I've also verified that making the timeout a lot longer doesn't make a
successful run take any longer (it takes about 13 seconds regardless)