### PR TITLE
Avoid memory leaks in Stream methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,6 +121,7 @@ val mimaFilterSettings = Seq(
     ProblemFilters.exclude[MissingTypesProblem]("scala.collection.ArrayOps$ReverseIterator$mcZ$sp"),
     ProblemFilters.exclude[MissingTypesProblem]("scala.collection.ArrayOps$ArrayIterator$mcI$sp"),
     ProblemFilters.exclude[MissingTypesProblem]("scala.collection.ArrayOps$ArrayIterator$mcS$sp"),
+    ProblemFilters.exclude[FinalMethodProblem]("scala.collection.immutable.Stream.find"),
   ),
 )
 

--- a/project/TestJarSize.scala
+++ b/project/TestJarSize.scala
@@ -5,8 +5,8 @@ import sbt._, Keys._
 object TestJarSize {
   final private case class JarSize(currentBytes: Long, errorThreshold: Double, warnThreshold: Double)
 
-  private val libraryJarSize = JarSize(5525657L, 1.03, 1.015)
-  private val reflectJarSize = JarSize(3531794L, 1.03, 1.015)
+  private val libraryJarSize = JarSize(5693071L, 1.03, 1.015)
+  private val reflectJarSize = JarSize(3608830L, 1.03, 1.015)
 
   val testJarSizeImpl: Def.Initialize[Task[Unit]] = Def.task {
     testJarSize1("library", libraryJarSize).value

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -66,6 +66,13 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
     }
   }
 
+  @tailrec
+  override final def find(p: A => Boolean): Option[A] = {
+    if(isEmpty) None
+    else if(p(head)) Some(head)
+    else tail.find(p)
+  }
+
   override def take(n: Int): Stream[A] = {
     if (n <= 0 || isEmpty) Stream.empty
     else if (n == 1) new Stream.Cons(head, Stream.empty)
@@ -167,23 +174,23 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
     if (isEmpty) iterableFactory.empty
     else cons(f(head), tail.map(f))
 
-  override final def collect[B](pf: PartialFunction[A, B]): Stream[B] = {
-    // this implementation avoids:
-    // 1) stackoverflows (could be achieved with tailrec, too)
-    // 2) out of memory errors for big streams (`this` reference can be eliminated from the stack)
-    var rest: Stream[A] = coll
+  @tailrec override final def collect[B](pf: PartialFunction[A, B]): Stream[B] =
+    if(isEmpty) Stream.empty
+    else {
+      var newHead: B = null.asInstanceOf[B]
+      val runWith = pf.runWith((b: B) => newHead = b)
+      if(runWith(head)) Stream.collectedTail(newHead, this, pf)
+      else tail.collect(pf)
+    }
 
-    // Avoids calling both `pf.isDefined` and `pf.apply`.
-    var newHead: B = null.asInstanceOf[B]
-    val runWith = pf.runWith((b: B) => newHead = b)
-
-    while (rest.nonEmpty && !runWith(rest.head)) rest = rest.tail
-
-    //  without the call to the companion object, a thunk is created for the tail of the new stream,
-    //  and the closure of the thunk will reference `this`
-    if (rest.isEmpty) iterableFactory.empty
-    else Stream.collectedTail(newHead, rest, pf)
-  }
+  @tailrec override final def collectFirst[B](pf: PartialFunction[A, B]): Option[B] =
+    if(isEmpty) None
+    else {
+      var newHead: B = null.asInstanceOf[B]
+      val runWith = pf.runWith((b: B) => newHead = b)
+      if(runWith(head)) Some(newHead)
+      else tail.collectFirst(pf)
+    }
 
   // optimisations are not for speed, but for functionality
   // see tickets #153, #498, #2147, and corresponding tests in run/ (as well as run/stream_flatmap_odds.scala)

--- a/test/files/run/indyLambdaKinds.check
+++ b/test/files/run/indyLambdaKinds.check
@@ -11,13 +11,13 @@ Inlining into Main$.main
  inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 274 ins, after: 291 ins.
  inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 291 ins, after: 308 ins.
  inlined scala/Predef$.println (the callee is a forwarder or alias method). Before: 308 ins, after: 325 ins.
- inlined A_1.m1 (the callee is a small trivial method). Before: 325 ins, after: 341 ins.
- inlined A_1.m1 (the callee is a small trivial method). Before: 341 ins, after: 357 ins.
- inlined A_1.m1 (the callee is a small trivial method). Before: 357 ins, after: 373 ins.
- inlined A_1.m1 (the callee is a small trivial method). Before: 373 ins, after: 389 ins.
-Inlining into Main$.t1a: inlined A_1.a (the callsite is annotated `@inline`). Before: 7 ins, after: 16 ins.
-Inlining into Main$.t2a: inlined A_1.b (the callsite is annotated `@inline`). Before: 7 ins, after: 16 ins.
-Inlining into Main$.t3a: inlined A_1.c (the callsite is annotated `@inline`). Before: 7 ins, after: 16 ins.
+ inlined A_1.m1 (the callee is a small trivial method). Before: 325 ins, after: 343 ins.
+ inlined A_1.m1 (the callee is a small trivial method). Before: 343 ins, after: 361 ins.
+ inlined A_1.m1 (the callee is a small trivial method). Before: 361 ins, after: 379 ins.
+ inlined A_1.m1 (the callee is a small trivial method). Before: 379 ins, after: 397 ins.
+Inlining into Main$.t1a: inlined A_1.a (the callsite is annotated `@inline`). Before: 7 ins, after: 18 ins.
+Inlining into Main$.t2a: inlined A_1.b (the callsite is annotated `@inline`). Before: 7 ins, after: 18 ins.
+Inlining into Main$.t3a: inlined A_1.c (the callsite is annotated `@inline`). Before: 7 ins, after: 18 ins.
 Inlining into Main$.t4a: failed A_1.d (the callsite is annotated `@inline`). A_1::d(Ljava/lang/String;)Ljava/util/function/BiFunction; is annotated @inline but could not be inlined: The callee A_1::d(Ljava/lang/String;)Ljava/util/function/BiFunction; contains the instruction INVOKEDYNAMIC apply(Ljava/lang/String;)Ljava/util/function/BiFunction; [       // handle kind 0x6 : INVOKESTATIC       java/lang/invoke/LambdaMetafactory.metafactory(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;       // arguments:       (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;,        // handle kind 0x6 : INVOKESTATIC       A_1.lambda$d$0(Ljava/lang/String;LA_1;Ljava/lang/String;)Ljava/lang/String;,        (LA_1;Ljava/lang/String;)Ljava/lang/String;     ] that would cause an IllegalAccessError when inlined into class Main$.
 Inlining into Main$.t4b: failed A_1.d (the callsite is annotated `@inline`). A_1::d(Ljava/lang/String;)Ljava/util/function/BiFunction; is annotated @inline but could not be inlined: The callee A_1::d(Ljava/lang/String;)Ljava/util/function/BiFunction; contains the instruction INVOKEDYNAMIC apply(Ljava/lang/String;)Ljava/util/function/BiFunction; [       // handle kind 0x6 : INVOKESTATIC       java/lang/invoke/LambdaMetafactory.metafactory(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;       // arguments:       (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;,        // handle kind 0x6 : INVOKESTATIC       A_1.lambda$d$0(Ljava/lang/String;LA_1;Ljava/lang/String;)Ljava/lang/String;,        (LA_1;Ljava/lang/String;)Ljava/lang/String;     ] that would cause an IllegalAccessError when inlined into class Main$.
 Inlining into Main$.t5a: failed A_1.e (the callsite is annotated `@inline`). A_1::e(Ljava/lang/String;)Ljava/util/function/Function; is annotated @inline but could not be inlined: The callee A_1::e(Ljava/lang/String;)Ljava/util/function/Function; contains the instruction INVOKEDYNAMIC apply(Ljava/lang/String;)Ljava/util/function/Function; [       // handle kind 0x6 : INVOKESTATIC       java/lang/invoke/LambdaMetafactory.metafactory(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;       // arguments:       (Ljava/lang/Object;)Ljava/lang/Object;,        // handle kind 0x6 : INVOKESTATIC       A_1.lambda$e$1(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;,        (Ljava/lang/String;)Ljava/lang/String;     ] that would cause an IllegalAccessError when inlined into class Main$.
@@ -25,15 +25,15 @@ Inlining into Main$.t5b: failed A_1.e (the callsite is annotated `@inline`). A_1
 Inlining into Main$.t6a: failed A_1.f (the callsite is annotated `@inline`). A_1::f(Ljava/lang/String;)Ljava/util/function/Function; is annotated @inline but could not be inlined: The callee A_1::f(Ljava/lang/String;)Ljava/util/function/Function; contains the instruction INVOKEDYNAMIC apply(Ljava/lang/String;)Ljava/util/function/Function; [       // handle kind 0x6 : INVOKESTATIC       java/lang/invoke/LambdaMetafactory.metafactory(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;       // arguments:       (Ljava/lang/Object;)Ljava/lang/Object;,        // handle kind 0x6 : INVOKESTATIC       A_1.lambda$f$2(Ljava/lang/String;Ljava/lang/String;)LA_1;,        (Ljava/lang/String;)LA_1;     ] that would cause an IllegalAccessError when inlined into class Main$.
 Inlining into Main$.t6b: failed A_1.f (the callsite is annotated `@inline`). A_1::f(Ljava/lang/String;)Ljava/util/function/Function; is annotated @inline but could not be inlined: The callee A_1::f(Ljava/lang/String;)Ljava/util/function/Function; contains the instruction INVOKEDYNAMIC apply(Ljava/lang/String;)Ljava/util/function/Function; [       // handle kind 0x6 : INVOKESTATIC       java/lang/invoke/LambdaMetafactory.metafactory(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;       // arguments:       (Ljava/lang/Object;)Ljava/lang/Object;,        // handle kind 0x6 : INVOKESTATIC       A_1.lambda$f$2(Ljava/lang/String;Ljava/lang/String;)LA_1;,        (Ljava/lang/String;)LA_1;     ] that would cause an IllegalAccessError when inlined into class Main$.
 Inlining into Main$.t1b
- inlined A_1.a (the callsite is annotated `@inline`). Before: 11 ins, after: 20 ins.
+ inlined A_1.a (the callsite is annotated `@inline`). Before: 11 ins, after: 22 ins.
  rewrote invocations of closure allocated in Main$.t1b with body m1: INVOKEINTERFACE java/util/function/BiFunction.apply (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; (itf)
- inlined A_1.m1 (the callee is a small trivial method). Before: 27 ins, after: 34 ins.
+ inlined A_1.m1 (the callee is a small trivial method). Before: 29 ins, after: 38 ins.
 Inlining into Main$.t2b
- inlined A_1.b (the callsite is annotated `@inline`). Before: 10 ins, after: 19 ins.
+ inlined A_1.b (the callsite is annotated `@inline`). Before: 10 ins, after: 21 ins.
  rewrote invocations of closure allocated in Main$.t2b with body m2: INVOKEINTERFACE java/util/function/Function.apply (Ljava/lang/Object;)Ljava/lang/Object; (itf)
- inlined A_1.m2 (the callee is a small trivial method). Before: 23 ins, after: 29 ins.
+ inlined A_1.m2 (the callee is a small trivial method). Before: 25 ins, after: 33 ins.
 Inlining into Main$.t3b
- inlined A_1.c (the callsite is annotated `@inline`). Before: 10 ins, after: 19 ins.
+ inlined A_1.c (the callsite is annotated `@inline`). Before: 10 ins, after: 21 ins.
  rewrote invocations of closure allocated in Main$.t3b with body <init>: INVOKEINTERFACE java/util/function/Function.apply (Ljava/lang/Object;)Ljava/lang/Object; (itf)
 warning: there were 6 inliner warnings; re-run enabling -opt-warnings for details, or try -help
 m1

--- a/test/files/run/stream-gc.check
+++ b/test/files/run/stream-gc.check
@@ -1,0 +1,1 @@
+warning: there were three deprecation warnings (since 2.13.0); re-run with -deprecation for details

--- a/test/files/run/stream-gc.javaopts
+++ b/test/files/run/stream-gc.javaopts
@@ -1,0 +1,1 @@
+-Xmx3M -Xms3M

--- a/test/files/run/stream-gc.scala
+++ b/test/files/run/stream-gc.scala
@@ -1,0 +1,7 @@
+import scala.collection.immutable._
+
+object Test extends App {
+  Stream.tabulate(100)(_ => new Array[AnyRef](10000)).find(_ => false)
+  Stream.tabulate(100)(_ => new Array[AnyRef](10000)).collect { case x if false => x }
+  Stream.tabulate(100)(_ => new Array[AnyRef](10000)).collectFirst { case x if false => x }
+}


### PR DESCRIPTION
`Stream.collect/collectFirst/find` kept references to the original
receiver of the call which prevented any part of the Stream from
getting garbage collected as soon as possible.

The previous implementation of `Stream.collect` claimed to avoid this
but this only worked insofar as the resulting Stream did not hold on
unnecessarily to any references to the original Stream. It still kept
a reference to the original receiver while iterating over non-matching
elements which can only be avoided with a tail-recursive
implementation.

Fixes https://github.com/scala/bug/issues/11443