### PR TITLE
11191 Attempt at optimizing exhaustivity 

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -615,7 +615,6 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
                           with ExhaustiveOptimizer
   {
     //TODO how can I tell I have the @exhaustive annotation here?
-    //Follow stack trace up I can see exhaustive in selector. Might have to pass somehow?
     override def optimizeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type, selectorPos: Position): (List[List[TreeMaker]], List[Tree]) = {
       // TODO: do CSE on result of doDCE(prevBinder, cases, pt)
       val optCases = doCSE(prevBinder, doExhaustive(prevBinder, pt, selectorPos, cases), pt, selectorPos)

--- a/src/library/scala/annotation/exhaustive.scala
+++ b/src/library/scala/annotation/exhaustive.scala
@@ -1,0 +1,36 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+
+/** An annotation to be applied to a match expression.  If present,
+  *  the compiler will verify that the match has been compiled to a
+  *  [[http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-3.html#jvms-3.10 tableswitch or lookupswitch]]
+  *  and issue an error if it instead compiles into a series of conditional expressions.
+  *  Example usage:
+{{{
+  val Constant = 'Q'
+  def tokenMe(ch: Char) = (ch: @switch) match {
+    case ' ' | '\t' | '\n'  => 1
+    case 'A' | 'Z' | '$'    => 2
+    case '5' | Constant     => 3  // a non-literal may prevent switch generation: this would not compile
+    case _                  => 4
+  }
+}}}
+  *
+  *  Note: for pattern matches with one or two cases, the compiler generates jump instructions.
+  *  Annotating such a match with `@switch` does not issue any warning.
+  *
+  *  @since    2.8
+  *  TODO update docs
+  */
+final class exhaustive extends scala.annotation.StaticAnnotation

--- a/src/library/scala/annotation/exhaustive.scala
+++ b/src/library/scala/annotation/exhaustive.scala
@@ -12,25 +12,7 @@
 
 package scala.annotation
 
-/** An annotation to be applied to a match expression.  If present,
-  *  the compiler will verify that the match has been compiled to a
-  *  [[http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-3.html#jvms-3.10 tableswitch or lookupswitch]]
-  *  and issue an error if it instead compiles into a series of conditional expressions.
-  *  Example usage:
-{{{
-  val Constant = 'Q'
-  def tokenMe(ch: Char) = (ch: @switch) match {
-    case ' ' | '\t' | '\n'  => 1
-    case 'A' | 'Z' | '$'    => 2
-    case '5' | Constant     => 3  // a non-literal may prevent switch generation: this would not compile
-    case _                  => 4
-  }
-}}}
-  *
-  *  Note: for pattern matches with one or two cases, the compiler generates jump instructions.
-  *  Annotating such a match with `@switch` does not issue any warning.
-  *
-  *  @since    2.8
-  *  TODO update docs
+/**
+  * TODO document stuff
   */
 final class exhaustive extends scala.annotation.StaticAnnotation

--- a/test/files/run/11191.check
+++ b/test/files/run/11191.check
@@ -1,0 +1,31 @@
+[[syntax trees at end of                    patmat]] // newSource1.scala
+package <empty>{<empty>.type} {
+  class C extends scala.AnyRef {
+    def <init>(): C = {
+      C.super{C.super.type}.<init>{()Object}(){Object};
+      (){Unit}
+    }{Unit};
+    def optimizeDefault(b: Boolean): Int = {
+      case <synthetic> val x1: Boolean = b{Boolean};
+      case6(){
+        if (true{Boolean(true)}.=={(x: Boolean)Boolean}(x1{Boolean}){Boolean})
+          matchEnd5{(x: Int)Int}(10{Int(10)}){Int}
+        else
+          case7{()Int}(){Int}{Int}
+      }{Int};
+      case7(){
+        if (false{Boolean(false)}.=={(x: Boolean)Boolean}(x1{Boolean}){Boolean})
+          matchEnd5{(x: Int)Int}(11{Int(11)}){Int}
+        else
+          case8{()Int}(){Int}{Int}
+      }{Int};
+      case8(){
+        matchEnd5{(x: Int)Int}(throw new MatchError{MatchError}{(obj: Any)MatchError}(x1{Boolean}){MatchError}{Nothing}){Int}
+      }{Int};
+      matchEnd5(x: Int){
+        x{Int}
+      }{Int}
+    }{Int}
+  }
+}
+

--- a/test/files/run/11191.check
+++ b/test/files/run/11191.check
@@ -14,10 +14,7 @@ package <empty>{<empty>.type} {
           case7{()Int}(){Int}{Int}
       }{Int};
       case7(){
-        if (false{Boolean(false)}.=={(x: Boolean)Boolean}(x1{Boolean}){Boolean})
-          matchEnd5{(x: Int)Int}(11{Int(11)}){Int}
-        else
-          case8{()Int}(){Int}{Int}
+        matchEnd5{(x: Int)Int}(11{Int(11)}){Int}
       }{Int};
       case8(){
         matchEnd5{(x: Int)Int}(throw new MatchError{MatchError}{(obj: Any)MatchError}(x1{Boolean}){MatchError}{Nothing}){Int}

--- a/test/files/run/11191.scala
+++ b/test/files/run/11191.scala
@@ -1,0 +1,45 @@
+import scala.annotation.exhaustive
+import scala.tools.partest._
+import java.io.{Console => _, _}
+
+
+object Test extends DirectTest {
+  override def extraSettings: String = "-usejavacp -Vprint:patmat -Vprint-types -d " + testOutput.path
+
+  override def code = """class C {
+  def optimizeDefault(b: Boolean): Int = b match {
+        case true  => 10
+        case false => 11
+      }
+  }
+  """
+//  def optimize(b: Boolean): Int = (b: @exhaustive) match {
+//    case true  => 10
+//    case false => 11
+//  }
+
+  //For comparison
+//  def optimize(b: Boolean): Int = b match {
+//    case true  => 10
+//    case _ => 11 //This is a BodyTreeMaker instead. Maybe the trick is to make the above a BodyTreeMaker if exhaustive and we have the annotation
+//  }
+//
+//  optimize(false)
+
+//  sealed trait Woah
+//  case object Woah1 extends Woah
+//  case object Woah2 extends Woah
+//
+//  def optimize2(w: Woah): Int = (w: @exhaustive) match {
+//    case Woah1 => 9
+//    case Woah2 => 3
+//  }
+
+//  optimize2(Woah1)
+
+  override def show(): Unit = {
+    Console.withErr(System.out) {
+      compile()
+    }
+  }
+}

--- a/test/files/run/11191.scala
+++ b/test/files/run/11191.scala
@@ -13,29 +13,46 @@ object Test extends DirectTest {
       }
   }
   """
+
+// Just some comments that will be removed. Feel free to ignore.
+//For comparison
+//  def optimize(b: Boolean): Int = b match {
+//    case true  => 10
+//    case _ => 11 //This is a BodyTreeMaker instead. Maybe the trick is to make the above a BodyTreeMaker if ok? Ahh I see how it works. The first thing is the condition just drop the first thing.
+//  }
+//
+//  optimize(false)
+
+// Would not actually do this since it's a Boolean. Just need to figure out how to know if @exhaustive is present in optimizeCase.
+// TODO would I even want to use @exhaustive in this way. This is how @switch is used.
 //  def optimize(b: Boolean): Int = (b: @exhaustive) match {
 //    case true  => 10
 //    case false => 11
 //  }
 
-  //For comparison
-//  def optimize(b: Boolean): Int = b match {
-//    case true  => 10
-//    case _ => 11 //This is a BodyTreeMaker instead. Maybe the trick is to make the above a BodyTreeMaker if exhaustive and we have the annotation
-//  }
-//
-//  optimize(false)
-
+// This should also optimize by default
 //  sealed trait Woah
 //  case object Woah1 extends Woah
 //  case object Woah2 extends Woah
 //
-//  def optimize2(w: Woah): Int = (w: @exhaustive) match {
+//  def optimize2(w: Woah): Int = w match {
 //    case Woah1 => 9
 //    case Woah2 => 3
 //  }
-
 //  optimize2(Woah1)
+
+
+// Don't optimize by default since we don't know if something else extends Woah
+// But do optimize in this case since the @exhaustive annotation is present
+//    trait Woah
+//    case object Woah1 extends Woah
+//    case object Woah2 extends Woah
+//
+//    def optimize2(w: Woah): Int = (w: @exhaustive match {
+//      case Woah1 => 9
+//      case Woah2 => 3
+//    }
+//    optimize2(Woah1)
 
   override def show(): Unit = {
     Console.withErr(System.out) {


### PR DESCRIPTION
https://github.com/scala/bug/issues/11191 
I know there was hesitance at doing this in the linked issue but I was interested in attempting it anyway and if we don't like this then I would have at least got to learn something.

Edit: I'm looking for guidance before I proceed.

## Summary

So in summary this is what I understand from the conversation:
* We can optimize for Boolean and sealed sum types safely.
* Optimizing for other cases could cause an NPE but we could make it opt-in with an annotation.
* Optimization should produce something equivalent to `case _ => ...` for the last case.

Here's my attempt. I believe I was able to optimize the Boolean case so far and I have other WIP stuff as well.

In my test I have:
```
  def optimizeDefault(b: Boolean): Int = b match {
        case true  => 10
        case false => 11
      }
```

That should ideally produce something identical to:
```
  def optimizeDefault(b: Boolean): Int = b match {
        case true  => 10
        case _ => 11
      }
```

`MatchOptimization.optimizeCases` was provided as a hint in the linked issue. So I thought all I would have to do is create the same output as `case _ => ` for an exhaustive pattern match.

However with my changes running my test with `-Vprint:patmat -Vprint-types -d` still produces a `case[number](){...throw new MatchError{MatchError}...}` although it seems to not call that method.

Without my change the test would generate this:
```
-        matchEnd5{(x: Int)Int}(11{Int(11)}){Int} 
+        if (false{Boolean(false)}.=={(x: Boolean)Boolean}(x1{Boolean}){Boolean})
+          matchEnd5{(x: Int)Int}(11{Int(11)}){Int}
+        else
+          case8{()Int}(){Int}{Int} //This is not called anymore so case8() is dead code and would be eliminated?
...
      case8(){
        matchEnd5{(x: Int)Int}(throw new MatchError{MatchError}{(obj: Any)MatchError}(x1{Boolean}){MatchError}{Nothing}){Int}
      }{Int};
```

Ideally it should generate the same output for `case _ => 11` and `case false => 11` if I'm right but if the method isn't called and I'm right that it would be eliminated later than that seems like that would effectively make it the same.

## TODOs

- Make annotation work
- Verify if the usage of the annotation should 
- Should I match the output of `case _ =>` or is this good enough?
- Sealed sum types should be optimized without annotation by default as well
- Should I be concerned with performance of `MatchAnalyzer.exhaustive`? Although it would only be called if it's one of the three conditions (Boolean, sealed sum type, and annotation).