### PR TITLE
Limit early initializer deprecation to -Xsource:2.14.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -3024,10 +3024,9 @@ self =>
         // @S: pre template body cannot stub like post body can!
         val (self, body) = templateBody(isPre = true)
         if (in.token == WITH && (self eq noSelfType)) {
-          val advice =
-            if (currentRun.isScala214) "use trait parameters instead."
-            else "they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits."
-          deprecationWarning(braceOffset, s"early initializers are deprecated; $advice", "2.13.0")
+          if (currentRun.isScala214) {
+            deprecationWarning(braceOffset, "early initializers are deprecated; use trait parameters instead.", "2.13.0")
+          }
           val earlyDefs: List[Tree] = body.map(ensureEarlyDef).filter(_.nonEmpty)
           in.nextToken()
           val parents = templateParents()

--- a/test/files/neg/t2796.check
+++ b/test/files/neg/t2796.check
@@ -1,18 +1,14 @@
-t2796.scala:9: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+t2796.scala:9: warning: early initializers are deprecated; use trait parameters instead.
 trait T1 extends {
                  ^
-t2796.scala:13: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+t2796.scala:13: warning: early initializers are deprecated; use trait parameters instead.
 trait T2 extends {
                  ^
-t2796.scala:14: warning: early type members are deprecated: move them to the regular body; the semantics are the same
-  type X = Int                       // warn
-       ^
-t2796.scala:17: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+t2796.scala:17: warning: early initializers are deprecated; use trait parameters instead.
 class C1 extends {
                  ^
-t2796.scala:10: warning: Implementation restriction: early definitions in traits are not initialized before the super class is initialized.
-  val abstractVal = "T1.abstractVal" // warn
-      ^
-error: No warnings can be incurred under -Werror.
-5 warnings found
+t2796.scala:14: error: early type members are unsupported: move them to the regular body; the semantics are the same
+  type X = Int                       // warn
+       ^
+three warnings found
 one error found

--- a/test/files/neg/t2796.scala
+++ b/test/files/neg/t2796.scala
@@ -1,5 +1,5 @@
 //
-// scalac: -deprecation -Xfatal-warnings
+// scalac: -deprecation -Xfatal-warnings -Xsource:2.14
 //
 trait Base {
   val abstractVal: String

--- a/test/files/neg/t6595.check
+++ b/test/files/neg/t6595.check
@@ -1,4 +1,4 @@
-t6595.scala:5: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+t6595.scala:5: warning: early initializers are deprecated; use trait parameters instead.
 class Foo extends {
                   ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t6595.scala
+++ b/test/files/neg/t6595.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -deprecation
+// scalac: -Xfatal-warnings -deprecation -Xsource:2.14
 //
 import scala.annotation.switch
 

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -1,4 +1,4 @@
-warn-unused-privates.scala:31: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+warn-unused-privates.scala:31: warning: early initializers are deprecated; use trait parameters instead.
 class Boppy extends {
                     ^
 warn-unused-privates.scala:5: warning: private constructor in class Bippy is never used
@@ -70,6 +70,16 @@ warn-unused-privates.scala:237: warning: private class D in class nonprivate ali
 warn-unused-privates.scala:102: warning: local var x in method f2 is never updated: consider using immutable val
     var x = 100 // warn about it being a var
         ^
+warn-unused-privates.scala:17: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_!,
+or remove the empty argument list from its definition (Java-defined methods are exempt).
+In Scala 3, an unapplied method like this will be eta-expanded into a function.
+  private lazy val BOOL: Boolean = true   // warn
+                   ^
+warn-unused-privates.scala:118: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method initialized,
+or remove the empty argument list from its definition (Java-defined methods are exempt).
+In Scala 3, an unapplied method like this will be eta-expanded into a function.
+    object HiObject { def f = this } // warn
+           ^
 error: No warnings can be incurred under -Werror.
-24 warnings found
+26 warnings found
 one error found

--- a/test/files/neg/warn-unused-privates.scala
+++ b/test/files/neg/warn-unused-privates.scala
@@ -1,5 +1,5 @@
 //
-// scalac: -deprecation -Ywarn-unused:privates -Xfatal-warnings
+// scalac: -deprecation -Ywarn-unused:privates -Xfatal-warnings -Xsource:2.14
 //
 class Bippy(a: Int, b: Int) {
   private def this(c: Int) = this(c, c)           // warn

--- a/test/files/presentation/doc.check
+++ b/test/files/presentation/doc.check
@@ -1,2 +1,1 @@
-warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details
 reload: Base.scala, Class.scala, Derived.scala

--- a/test/files/run/analyzerPlugins.check
+++ b/test/files/run/analyzerPlugins.check
@@ -1,4 +1,3 @@
-warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details
 adaptBoundsToAnnots(List( <: Int), List(type T), List(Int @testAnn)) [2]
 annotationsConform(Boolean @testAnn, Boolean @testAnn) [2]
 annotationsConform(Boolean @testAnn, Boolean) [1]

--- a/test/files/run/ctor-order.check
+++ b/test/files/run/ctor-order.check
@@ -1,3 +1,2 @@
-warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details
 10
 10

--- a/test/files/run/delay-bad.check
+++ b/test/files/run/delay-bad.check
@@ -4,9 +4,7 @@ delay-bad.scala:53: warning: a pure expression does nothing in statement positio
 delay-bad.scala:73: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
     f(new { val x = 5 } with E() { 5 })
                                    ^
-warning: there was one deprecation warning (since 2.11.0)
-warning: there were four deprecation warnings (since 2.13.0)
-warning: there were 5 deprecation warnings in total; re-run with -deprecation for details
+warning: there was one deprecation warning (since 2.11.0); re-run with -deprecation for details
 
 
 // new C { }

--- a/test/files/run/delay-good.check
+++ b/test/files/run/delay-good.check
@@ -4,7 +4,6 @@ delay-good.scala:53: warning: a pure expression does nothing in statement positi
 delay-good.scala:73: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
     f(new { val x = 5 } with E() { 5 })
                                    ^
-warning: there were four deprecation warnings (since 2.13.0); re-run with -deprecation for details
 
 
 // new C { }

--- a/test/files/run/deprecate-early-type-defs.check
+++ b/test/files/run/deprecate-early-type-defs.check
@@ -1,4 +1,4 @@
-deprecate-early-type-defs.scala:3: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+deprecate-early-type-defs.scala:3: warning: early initializers are deprecated; use trait parameters instead.
 object Test extends { type T = Int } with App
                     ^
 deprecate-early-type-defs.scala:3: warning: early type members are deprecated: move them to the regular body; the semantics are the same

--- a/test/files/run/deprecate-early-type-defs.scala
+++ b/test/files/run/deprecate-early-type-defs.scala
@@ -1,3 +1,3 @@
-// scalac: -deprecation
+// scalac: -deprecation -Xsource:2.14
 //
 object Test extends { type T = Int } with App

--- a/test/files/run/outertest.check
+++ b/test/files/run/outertest.check
@@ -1,1 +1,0 @@
-warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details

--- a/test/files/run/preinits.check
+++ b/test/files/run/preinits.check
@@ -4,7 +4,6 @@ trait B extends { override val x = 1 } with A { println("B") }
 preinits.scala:3: warning: Implementation restriction: early definitions in traits are not initialized before the super class is initialized.
 trait C extends { override val x = 2 } with A
                                ^
-warning: there were two deprecation warnings (since 2.13.0); re-run with -deprecation for details
 A
 B
 2

--- a/test/files/run/t0911.check
+++ b/test/files/run/t0911.check
@@ -1,1 +1,0 @@
-warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details

--- a/test/files/run/t4680.check
+++ b/test/files/run/t4680.check
@@ -4,9 +4,7 @@ t4680.scala:51: warning: a pure expression does nothing in statement position; m
 t4680.scala:69: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
     new { val x = 5 } with E() { 5 }
                                  ^
-warning: there was one deprecation warning (since 2.11.0)
-warning: there were four deprecation warnings (since 2.13.0)
-warning: there were 5 deprecation warnings in total; re-run with -deprecation for details
+warning: there was one deprecation warning (since 2.11.0); re-run with -deprecation for details
 
 
 // new C { }

--- a/test/files/run/t5603.check
+++ b/test/files/run/t5603.check
@@ -27,4 +27,3 @@
   }
 }
 
-warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details

--- a/test/files/run/t6259.check
+++ b/test/files/run/t6259.check
@@ -1,1 +1,0 @@
-warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details

--- a/test/files/run/t6309.check
+++ b/test/files/run/t6309.check
@@ -1,2 +1,1 @@
-warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details
 7

--- a/test/files/specialized/spec-early.check
+++ b/test/files/specialized/spec-early.check
@@ -1,4 +1,3 @@
-warning: there was one deprecation warning (since 2.13.0); re-run with -deprecation for details
 a
 abc
 42


### PR DESCRIPTION
Previously, a deprecation message was always reported for early
initializers with the following message:

```
early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
```

This commit changes the deprecation message so that it's only reported
when users have enabled `-Xsource:2.14`.

The original idea for this PR came from this comment here https://github.com/scala/scala-dev/issues/513#issuecomment-402627809 by @adriaanm.