### PR TITLE
add -Wconf flag for configurable warnings, @nowarn annotation for local suppression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ jitwatch.out
 # metals
 .metals
 .bloop
+project/metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -186,6 +186,7 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.VirtualFile.unsafeToByteArray"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive#Entry.unsafeToByteArray"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.NoAbstractFile.unsafeToByteArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUniverse#PerRunReporting.deprecationWarning"),
   ),
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -189,6 +189,7 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUniverse#PerRunReporting.deprecationWarning"),
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.nowarn$"),
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.nowarn"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.Settings#*.clearSetByUser"),
   ),
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -187,6 +187,8 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive#Entry.unsafeToByteArray"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.NoAbstractFile.unsafeToByteArray"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUniverse#PerRunReporting.deprecationWarning"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.nowarn$"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.nowarn"),
   ),
 }
 

--- a/src/compiler/scala/reflect/macros/contexts/FrontEnds.scala
+++ b/src/compiler/scala/reflect/macros/contexts/FrontEnds.scala
@@ -14,6 +14,7 @@ package scala.reflect.macros
 package contexts
 
 import scala.reflect.macros.runtime.AbortMacroException
+import scala.tools.nsc.Reporting.WarningCategory
 
 trait FrontEnds {
   self: Context =>
@@ -27,7 +28,8 @@ trait FrontEnds {
 
   def hasErrors: Boolean = universe.reporter.hasErrors
 
-  def warning(pos: Position, msg: String): Unit = callsiteTyper.context.warning(pos, msg)
+  // TODO: add WarningCategory parameter in 2.14 (not binary compatible)
+  def warning(pos: Position, msg: String): Unit = callsiteTyper.context.warning(pos, msg, WarningCategory.Other)
 
   def error(pos: Position, msg: String): Unit = callsiteTyper.context.error(pos, msg)
 

--- a/src/compiler/scala/tools/nsc/CompilationUnits.scala
+++ b/src/compiler/scala/tools/nsc/CompilationUnits.scala
@@ -142,21 +142,6 @@ trait CompilationUnits { global: Global =>
     /** For sbt compatibility (https://github.com/scala/scala/pull/4588) */
     val icode: LinkedHashSet[icodes.IClass] = new LinkedHashSet
 
-    @deprecated("Call global.reporter.echo directly instead.", "2.11.2")
-    final def echo(pos: Position, msg: String): Unit    = reporter.echo(pos, msg)
-    @deprecated("Call global.reporter.error (or typer.context.error) directly instead.", "2.11.2")
-    final def error(pos: Position, msg: String): Unit   = reporter.error(pos, msg)
-    @deprecated("Call global.reporter.warning (or typer.context.warning) directly instead.", "2.11.2")
-    final def warning(pos: Position, msg: String): Unit = reporter.warning(pos, msg)
-
-    @deprecated("Call global.currentRun.reporting.deprecationWarning directly instead.", "2.11.2")
-    final def deprecationWarning(pos: Position, msg: String, since: String): Unit = currentRun.reporting.deprecationWarning(pos, msg, since)
-    @deprecated("Call global.currentRun.reporting.uncheckedWarning directly instead.", "2.11.2")
-    final def uncheckedWarning(pos: Position, msg: String): Unit   = currentRun.reporting.uncheckedWarning(pos, msg)
-
-    @deprecated("This method will be removed. It does nothing.", "2.11.2")
-    final def comment(pos: Position, msg: String): Unit = {}
-
     /** Is this about a .java source file? */
     val isJava: Boolean = source.isJava
 

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -884,7 +884,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
         case Some(oldEntry) =>
           Some(oldEntry -> ClassPathFactory.newClassPath(dir, settings, closeableRegistry))
         case None =>
-          error(s"Error adding entry to classpath. During invalidation, no entry named $path in classpath $classPath")
+          globalError(s"Error adding entry to classpath. During invalidation, no entry named $path in classpath $classPath")
           None
       }
     }

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1544,6 +1544,9 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
         if (settings.YstatisticsEnabled && settings.Ystatistics.contains(phase.name))
           printStatisticsFor(phase)
 
+        if (!globalPhase.hasNext || reporter.hasErrors)
+          runReporting.warnUnusedSuppressions()
+
         advancePhase()
       }
       profiler.finished()

--- a/src/compiler/scala/tools/nsc/GlobalSymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/GlobalSymbolLoaders.scala
@@ -14,6 +14,8 @@ package scala
 package tools
 package nsc
 
+import scala.tools.nsc.Reporting.WarningCategory
+
 /**
  * Symbol loaders implementation that wires dependencies using Global.
  */
@@ -34,4 +36,7 @@ abstract class GlobalSymbolLoaders extends symtab.SymbolLoaders {
 
   protected def compileLate(srcfile: io.AbstractFile): Unit =
     currentRun.compileLate(srcfile)
+
+  def warning(pos: Position, msg: String, category: WarningCategory, site: String): Unit =
+    runReporting.warning(pos, msg, category, site)
 }

--- a/src/compiler/scala/tools/nsc/PhaseAssembly.scala
+++ b/src/compiler/scala/tools/nsc/PhaseAssembly.scala
@@ -13,6 +13,7 @@
 package scala.tools.nsc
 
 import scala.collection.mutable
+import scala.tools.nsc.Reporting.WarningCategory
 
 /** Converts an unordered morass of components into an order that
  *  satisfies their mutual constraints.
@@ -202,7 +203,7 @@ trait PhaseAssembly {
           edges -= edge
           edge.frm.after -= edge
           if (edge.frm.phaseobj exists (lsc => !lsc.head.internal))
-            warning(msg)
+            runReporting.warning(NoPosition, msg, WarningCategory.Other, site = "")
         }
       }
     }

--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -31,6 +31,7 @@ import scala.math.Ordering.Double.TotalOrdering
 import scala.reflect.internal.util.{BatchSourceFile, FakePos, NoPosition, Position}
 import scala.reflect.io.PlainNioFile
 import scala.tools.nsc.PipelineMain.{OutlineTypePipeline, Pipeline, Traditional}
+import scala.tools.nsc.Reporting.WarningCategory
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.reporters.{ConsoleReporter, Reporter}
 import scala.tools.nsc.util.ClassPath
@@ -564,7 +565,7 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
               }
               diagnostic.getKind match {
                 case Kind.ERROR                            => reporter.error(position, msg)
-                case Kind.WARNING | Kind.MANDATORY_WARNING => reporter.warning(position, msg)
+                case Kind.WARNING | Kind.MANDATORY_WARNING => Task.this.compiler.runReporting.warning(position, msg, WarningCategory.JavaSource, site = "")
                 case Kind.NOTE | Kind.OTHER                => reporter.echo(position, msg)
               }
             }

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -565,7 +565,7 @@ object Reporting {
         if (!arg.endsWith("$")) pat += '$'
         regex(pat.toString).map(SourcePattern)
       } else {
-        Left(s"filter not yet implemented: $s")
+        Left(s"unknown filter: $s")
       }
     }
 

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -25,9 +25,8 @@ import scala.reflect.internal, internal.util.StringOps.countElementsAsString
 trait Reporting extends internal.Reporting { self: ast.Positions with CompilationUnits with internal.Symbols =>
   def settings: Settings
 
-  // not deprecated yet, but a method called "error" imported into
-  // nearly every trait really must go.  For now using globalError.
-  def error(msg: String) = globalError(msg)
+  @deprecated("use `globalError` instead")
+  def error(msg: String): Unit = globalError(msg)
 
   // a new instance of this class is created for every Run (access the current instance via `currentRun.reporting`)
   protected def PerRunReporting = new PerRunReporting
@@ -103,13 +102,13 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
       val fqname  = "scala.language." + featureName
       val explain = (
         if (reportedFeature contains featureTrait) "" else
-        s"""|
-            |----
-            |This can be achieved by adding the import clause 'import $fqname'
-            |or by setting the compiler option -language:$featureName.
-            |See the Scaladoc for value $fqname for a discussion
-            |why the feature $req be explicitly enabled.""".stripMargin
-      )
+          s"""
+             |----
+             |This can be achieved by adding the import clause 'import $fqname'
+             |or by setting the compiler option -language:$featureName.
+             |See the Scaladoc for value $fqname for a discussion
+             |why the feature $req be explicitly enabled.""".stripMargin
+        )
       reportedFeature += featureTrait
 
       val msg = s"$featureDesc $req be enabled\nby making the implicit value $fqname visible.$explain" replace ("#", construct)

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -336,7 +336,7 @@ object Reporting {
     object WFlagDeadCode extends WFlag; add(WFlagDeadCode)
     object WFlagExtraImplicit extends WFlag; add(WFlagExtraImplicit)
     object WFlagNumericWiden extends WFlag; add(WFlagNumericWiden)
-    object WFlagOctalLiteral extends WFlag; add(WFlagOctalLiteral)
+    object WFlagSelfImplicit extends WFlag; add(WFlagSelfImplicit)
     object WFlagValueDiscard extends WFlag; add(WFlagValueDiscard)
 
     sealed trait Unused extends WarningCategory { override def summaryCategory: WarningCategory = Unused }
@@ -373,7 +373,7 @@ object Reporting {
     object LintDeprecation extends Lint; add(LintDeprecation)
     object LintBynameImplicit extends Lint; add(LintBynameImplicit)
     object LintRecurseWithDefault extends Lint; add(LintRecurseWithDefault)
-
+    object LintUnitSpecialization extends Lint; add(LintUnitSpecialization)
 
     sealed trait Feature extends WarningCategory { override def summaryCategory: WarningCategory = Feature }
     object Feature extends Feature { override def includes(o: WarningCategory): Boolean = o.isInstanceOf[Feature] }; add(Feature)

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -179,7 +179,14 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
       }
     }
 
-    private def siteName(s: Symbol) = if (s.exists) s.fullNameString else ""
+    private def siteName(sym: Symbol) = if (sym.exists) {
+      // Similar to fullNameString, but don't jump to enclosing class. Keep full chain of symbols.
+      def impl(s: Symbol): String =
+        if (s.isRootSymbol || s == NoSymbol) s.nameString
+        else if (s.owner.isEffectiveRoot) s.nameString
+        else impl(s.effectiveOwner) + "." + s.nameString
+      impl(sym)
+    } else ""
 
     def deprecationWarning(pos: Position, msg: String, since: String, site: String, origin: String): Unit =
       checkSuppressedAndIssue(Message.Deprecation(pos, msg, site, origin, Version.fromString(since)))

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -14,13 +14,18 @@ package scala
 package tools
 package nsc
 
+import java.util.regex.PatternSyntaxException
+
 import scala.collection.mutable
-import scala.reflect.internal, internal.util.StringOps.countElementsAsString
+import scala.reflect.internal
+import scala.reflect.internal.util.StringOps.countElementsAsString
+import scala.reflect.internal.util.{Position, SourceFile}
+import scala.tools.nsc.Reporting.Version.{NonParseableVersion, ParseableVersion}
+import scala.tools.nsc.Reporting._
+import scala.util.matching.Regex
 
 /** Provides delegates to the reporter doing the actual work.
  * PerRunReporting implements per-Run stateful info tracking and reporting
- *
- * TODO: make reporting configurable
  */
 trait Reporting extends internal.Reporting { self: ast.Positions with CompilationUnits with internal.Symbols =>
   def settings: Settings
@@ -28,76 +33,133 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
   @deprecated("use `globalError` instead")
   def error(msg: String): Unit = globalError(msg)
 
-  // a new instance of this class is created for every Run (access the current instance via `currentRun.reporting`)
+  // a new instance of this class is created for every Run (access the current instance via `runReporting`)
   protected def PerRunReporting = new PerRunReporting
   class PerRunReporting extends PerRunReportingBase {
-    /** Collects for certain classes of warnings during this run. */
-    private class ConditionalWarning(what: String, doReport: Boolean, setting: Settings#Setting) {
-      def this(what: String, booleanSetting: Settings#BooleanSetting) =
-        this(what, booleanSetting.value, booleanSetting)
-      val warnings = mutable.LinkedHashMap[Position, (String, String)]()
-      def warn(pos: Position, msg: String, since: String = "") =
-        if (doReport) reporter.warning(pos, msg)
-        else if (!(warnings contains pos)) warnings += ((pos, (msg, since)))
-      def summarize() =
-        if (warnings.nonEmpty && (setting.isDefault || doReport)) {
-          val sinceAndAmount = mutable.TreeMap[String, Int]()
-          warnings.valuesIterator.foreach { case (_, since) =>
-            val value = sinceAndAmount.get(since)
-            if (value.isDefined) sinceAndAmount += ((since, value.get + 1))
-            else sinceAndAmount += ((since, 1))
-          }
-          val deprecationSummary = sinceAndAmount.size > 1
-          sinceAndAmount.foreach { case (since, numWarnings) =>
-            val warningsSince = if (since.nonEmpty) s" (since $since)" else ""
-            val warningCount  = countElementsAsString(numWarnings, what)
-            val rerun         = if (deprecationSummary) "" else reporter.rerunWithDetails(setting, setting.name)
-            reporter.warning(NoPosition, s"$warningCount$warningsSince$rerun")
-          }
-          if (deprecationSummary) {
-            val numWarnings   = warnings.size
-            val warningCount  = countElementsAsString(numWarnings, what)
-            val rerun         = reporter.rerunWithDetails(setting, setting.name)
-            reporter.warning(NoPosition, s"$warningCount in total$rerun")
-          }
-        }
+    val rootDirPrefix: String =
+      if (settings.rootdir.value.isEmpty) ""
+      else Regex.quote(new java.io.File(settings.rootdir.value).getCanonicalPath.replace("\\", "/"))
+    lazy val wconf = WConf.parse(settings.Wconf.value, rootDirPrefix) match {
+      case Left(msgs) =>
+        val multiHelp =
+          if (settings.Wconf.value.exists(_.contains(",")))
+            """
+              |Note: for multiple filters, use `-Wconf:filter1:action1,filter2:action2` (recommended)
+              |      or alternatively          `-Wconf filter1:action1 filter2:action2`""".stripMargin
+          else ""
+        globalError(s"Failed to parse `-Wconf` configuration: ${settings.Wconf.value}\n${msgs.mkString("\n")}$multiHelp")
+        WConf(Nil)
+      case Right(c) => c
     }
 
-    // This change broke sbt; I gave it the thrilling name of uncheckedWarnings0 so
-    // as to recover uncheckedWarnings for its ever-fragile compiler interface.
-    private val _deprecationWarnings    = new ConditionalWarning("deprecation", settings.deprecation)
-    private val _uncheckedWarnings      = new ConditionalWarning("unchecked warning", settings.unchecked)
-    private val _featureWarnings        = new ConditionalWarning("feature warning", settings.feature)
-    private val _inlinerWarnings        = new ConditionalWarning("inliner warning", !settings.optWarningsSummaryOnly, settings.optWarnings)
-    private val _allConditionalWarnings = List(_deprecationWarnings, _uncheckedWarnings, _featureWarnings, _inlinerWarnings)
+    private val summarizedWarnings: mutable.Map[WarningCategory, mutable.LinkedHashMap[Position, Message]] = mutable.HashMap.empty
+    private val summarizedInfos: mutable.Map[WarningCategory, mutable.LinkedHashMap[Position, Message]] = mutable.HashMap.empty
 
-    // TODO: remove in favor of the overload that takes a Symbol, give that argument a default (NoSymbol)
-    def deprecationWarning(pos: Position, msg: String, since: String): Unit = _deprecationWarnings.warn(pos, msg, since)
-    def uncheckedWarning(pos: Position, msg: String): Unit   = _uncheckedWarnings.warn(pos, msg)
-    def featureWarning(pos: Position, msg: String): Unit     = _featureWarnings.warn(pos, msg)
-    def inlinerWarning(pos: Position, msg: String): Unit     = _inlinerWarnings.warn(pos, msg)
+    private def summaryMap(action: Action, category: WarningCategory) = {
+      val sm = (action: @unchecked) match {
+        case Action.WarningSummary => summarizedWarnings
+        case Action.InfoSummary => summarizedInfos
+      }
+      sm.getOrElseUpdate(category, mutable.LinkedHashMap.empty)
+    }
 
-    def deprecationWarnings = _deprecationWarnings.warnings.toList
-    def uncheckedWarnings   = _uncheckedWarnings.warnings.toList
-    def featureWarnings     = _featureWarnings.warnings.toList
-    def inlinerWarnings     = _inlinerWarnings.warnings.toList
+    private def issueWarning(warning: Message): Unit = {
+      def verbose = warning match {
+        case Message.Deprecation(_, msg, site, origin, version) => s"[${warning.category.name} @ $site | origin=$origin | version=${version.filterString}] $msg"
+        case Message.Plain(_, msg, category, site) => s"[${category.name} @ $site] $msg"
+      }
+      wconf.action(warning) match {
+        case Action.Error => reporter.error(warning.pos, warning.msg)
+        case Action.Warning => reporter.warning(warning.pos, warning.msg)
+        case Action.WarningVerbose => reporter.warning(warning.pos, verbose)
+        case Action.Info => reporter.echo(warning.pos, warning.msg)
+        case Action.InfoVerbose => reporter.echo(warning.pos, verbose)
+        case a @ (Action.WarningSummary | Action.InfoSummary) =>
+          val m = summaryMap(a, warning.category.summaryCategory)
+          if (!m.contains(warning.pos)) m.addOne((warning.pos, warning))
+        case Action.Silent =>
+      }
+    }
 
-    def allConditionalWarnings = _allConditionalWarnings flatMap (_.warnings)
+    private def summarize(action: Action, category: WarningCategory): Unit = {
+      def rerunMsg: String = {
+        val s: Settings#Setting = category match {
+          case WarningCategory.Deprecation => settings.deprecation
+          case WarningCategory.Feature => settings.feature
+          case WarningCategory.Optimizer => settings.optWarnings
+          case WarningCategory.Unchecked => settings.unchecked
+          case _ => null
+        }
+        if (s != null) reporter.rerunWithDetails(s, s.name)
+        else s"; change -Wconf for cat=${category.name} to display individual messages"
+      }
 
-    // useful in REPL because line parsing doesn't entail a new Run
-    def clearAllConditionalWarnings() = _allConditionalWarnings.foreach(_.warnings.clear())
+      val m = summaryMap(action, category)
+      if (m.nonEmpty) {
+        val sinceAndAmount = mutable.TreeMap[String, Int]()
+        m.valuesIterator.foreach { msg =>
+          val since = msg match {
+            case d: Message.Deprecation => d.since.orig
+            case _ => ""
+          }
+          val value = sinceAndAmount.get(since)
+          if (value.isDefined) sinceAndAmount += ((since, value.get + 1))
+          else sinceAndAmount += ((since, 1))
+        }
+        val deprecationSummary = sinceAndAmount.size > 1
+        val isWarn = action == Action.WarningSummary
+        val messageKind =
+          if (isWarn) { if (category == WarningCategory.Deprecation) "" else " warning" }
+          else " info message"
+        sinceAndAmount.foreach { case (since, numWarnings) =>
+          val warningsSince = if (since.nonEmpty) s" (since $since)" else ""
+          val warningCount  = countElementsAsString(numWarnings, s"${category.name}$messageKind")
+          val rerun         = if (deprecationSummary) "" else rerunMsg
+          val msg           = s"$warningCount$warningsSince$rerun"
+          if (isWarn) reporter.warning(NoPosition, msg)
+          else reporter.echo(NoPosition, msg)
+        }
+        if (deprecationSummary) {
+          val numWarnings   = m.size
+          val warningCount  = countElementsAsString(numWarnings, s"${category.name}$messageKind")
+          val rerun         = rerunMsg
+          val msg           = s"$warningCount in total$rerun"
+          if (isWarn) reporter.warning(NoPosition, msg)
+          else reporter.echo(NoPosition, msg)
+        }
+      }
+    }
 
-    // behold! the symbol that caused the deprecation warning (may not be deprecated itself)
-    def deprecationWarning(pos: Position, sym: Symbol, msg: String, since: String): Unit = _deprecationWarnings.warn(pos, msg, since)
-    def deprecationWarning(pos: Position, sym: Symbol): Unit = {
-      val version = sym.deprecationVersion.getOrElse("")
+    private def siteName(s: Symbol) = if (s.exists) s.fullNameString else ""
+
+    def deprecationWarning(pos: Position, msg: String, since: String, site: String, origin: String): Unit =
+      issueWarning(Message.Deprecation(pos, msg, site, origin, Version.fromString(since)))
+
+    def deprecationWarning(pos: Position, origin: Symbol, site: Symbol, msg: String, since: String): Unit =
+      deprecationWarning(pos, msg, since, siteName(site), siteName(origin))
+
+    def deprecationWarning(pos: Position, origin: Symbol, site: Symbol): Unit = {
+      val version = origin.deprecationVersion.getOrElse("")
       val since   = if (version.isEmpty) version else s" (since $version)"
-      val message = sym.deprecationMessage.map(": " + _).getOrElse("")
-      deprecationWarning(pos, sym, s"$sym${sym.locationString} is deprecated$since$message", version)
+      val message = origin.deprecationMessage.map(": " + _).getOrElse("")
+      deprecationWarning(pos, origin, site, s"$origin${origin.locationString} is deprecated$since$message", version)
     }
 
     private[this] var reportedFeature = Set[Symbol]()
-    def featureWarning(pos: Position, featureName: String, featureDesc: String, featureTrait: Symbol, construct: => String = "", required: Boolean): Unit = {
+    // we don't have access to runDefinitions here, so mapping from strings instead of feature symbols
+    private val featureCategory: Map[String, WarningCategory.Feature] = {
+      import WarningCategory._
+      Map(
+        ("dynamics", FeatureDynamics),
+        ("existentials", FeatureExistentials),
+        ("higherKinds", FeatureHigherKinds),
+        ("implicitConversions", FeatureImplicitConversions),
+        ("postfixOps", FeaturePostfixOps),
+        ("reflectiveCalls", FeatureReflectiveCalls),
+        ("macros", FeatureMacros)
+      ).withDefaultValue(Feature)
+    }
+    def featureWarning(pos: Position, featureName: String, featureDesc: String, featureTrait: Symbol, construct: => String = "", required: Boolean, site: Symbol): Unit = {
       val req     = if (required) "needs to" else "should"
       val fqname  = "scala.language." + featureName
       val explain = (
@@ -121,23 +183,380 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
         && parentFileName(pos.source).getOrElse("") == "xsbt"
         && Thread.currentThread.getStackTrace.exists(_.getClassName.startsWith("sbt."))
       )
-      if (required && !isSbtCompat) reporter.error(pos, msg) else featureWarning(pos, msg)
+      if (required && !isSbtCompat) reporter.error(pos, msg)
+      else warning(pos, msg, featureCategory(featureTrait.nameString), site)
+    }
+
+    // Used in the optimizer where we don't have no symbols, the site string is created from the class internal name and method name.
+    def warning(pos: Position, msg: String, category: WarningCategory, site: String): Unit =
+      issueWarning(Message.Plain(pos, msg, category, site))
+
+    // Preferred over the overload above whenever a site symbol is available
+    def warning(pos: Position, msg: String, category: WarningCategory, site: Symbol): Unit =
+      warning(pos, msg, category, siteName(site))
+
+    // used by Global.deprecationWarnings, which is used by sbt
+    def deprecationWarnings: List[(Position, String)] = summaryMap(Action.WarningSummary, WarningCategory.Deprecation).toList.map(p => (p._1, p._2.msg))
+    def uncheckedWarnings: List[(Position, String)]   = summaryMap(Action.WarningSummary, WarningCategory.Unchecked).toList.map(p => (p._1, p._2.msg))
+
+    def allConditionalWarnings: List[(Position, String)] = summarizedWarnings.toList.sortBy(_._1.name).flatMap(_._2.toList.map(p => (p._1, p._2.msg)))
+
+    // useful in REPL because line parsing doesn't entail a new Run
+    def clearAllConditionalWarnings(): Unit = {
+      summarizedWarnings.clear()
+      summarizedInfos.clear()
     }
 
     /** Has any macro expansion used a fallback during this run? */
     var seenMacroExpansionsFallingBack = false
 
     def summarizeErrors(): Unit = if (!reporter.hasErrors) {
-      _allConditionalWarnings foreach (_.summarize())
+      for (c <- summarizedWarnings.keys.toList.sortBy(_.name))
+        summarize(Action.WarningSummary, c)
+      for (c <- summarizedInfos.keys.toList.sortBy(_.name))
+        summarize(Action.InfoSummary, c)
 
       if (seenMacroExpansionsFallingBack)
-        reporter.warning(NoPosition, "some macros could not be expanded and code fell back to overridden methods;"+
-                "\nrecompiling with generated classfiles on the classpath might help.")
+        warning(NoPosition, "some macros could not be expanded and code fell back to overridden methods;"+
+                "\nrecompiling with generated classfiles on the classpath might help.", WarningCategory.Other, site = "")
 
       // todo: migrationWarnings
 
       if (settings.fatalWarnings && reporter.hasWarnings)
         reporter.error(NoPosition, "No warnings can be incurred under -Werror.")
+    }
+  }
+}
+
+object Reporting {
+  sealed trait Message {
+    def pos: Position
+    def msg: String
+    def category: WarningCategory
+    def site: String // sym.FullName of the location where the warning is positioned, may be empty
+  }
+
+  object Message {
+    final case class Plain(pos: Position, msg: String, category: WarningCategory, site: String) extends Message
+
+    // `site` and `origin` may be empty
+    final case class Deprecation(pos: Position, msg: String, site: String, origin: String, since: Version) extends Message {
+      def category: WarningCategory = WarningCategory.Deprecation
+    }
+  }
+
+  sealed trait WarningCategory {
+    lazy val name: String = {
+      val objectName = this.getClass.getName.split('$').last
+      WarningCategory.insertDash.replaceAllIn(objectName, "-")
+        .stripPrefix("-")
+        .stripSuffix("-")
+        .toLowerCase
+    }
+
+    def includes(o: WarningCategory): Boolean = this eq o
+    def summaryCategory: WarningCategory = this
+  }
+
+  object WarningCategory {
+    private val insertDash = "(?=[A-Z][a-z])".r
+
+    var all: mutable.Map[String, WarningCategory] = mutable.Map.empty
+    private def add(c: WarningCategory): Unit = all += ((c.name, c))
+
+    object Deprecation extends WarningCategory; add(Deprecation)
+
+    object Unchecked extends WarningCategory; add(Unchecked)
+
+    object Optimizer extends WarningCategory; add(Optimizer)
+
+    object Scaladoc extends WarningCategory; add(Scaladoc)
+
+    object JavaSource extends WarningCategory; add(JavaSource)
+
+    sealed trait Other extends WarningCategory { override def summaryCategory: WarningCategory = Other }
+    object Other extends Other { override def includes(o: WarningCategory): Boolean = o.isInstanceOf[Other] }; add(Other)
+    object OtherShadowing extends Other; add(OtherShadowing)
+    object OtherPureStatement extends Other; add(OtherPureStatement)
+    object OtherMigration extends Other; add(OtherMigration)
+    object OtherMatchAnalysis extends WarningCategory; add(OtherMatchAnalysis)
+    object OtherDebug extends WarningCategory; add(OtherDebug)
+
+    sealed trait WFlag extends WarningCategory { override def summaryCategory: WarningCategory = WFlag }
+    object WFlag extends WFlag { override def includes(o: WarningCategory): Boolean = o.isInstanceOf[WFlag] }; add(WFlag)
+    object WFlagDeadCode extends WFlag; add(WFlagDeadCode)
+    object WFlagExtraImplicit extends WFlag; add(WFlagExtraImplicit)
+    object WFlagNumericWiden extends WFlag; add(WFlagNumericWiden)
+    object WFlagOctalLiteral extends WFlag; add(WFlagOctalLiteral)
+    object WFlagValueDiscard extends WFlag; add(WFlagValueDiscard)
+
+    sealed trait Unused extends WarningCategory { override def summaryCategory: WarningCategory = Unused }
+    object Unused extends Unused { override def includes(o: WarningCategory): Boolean = o.isInstanceOf[Unused] }; add(Unused)
+    object UnusedImports extends Unused; add(UnusedImports)
+    object UnusedPatVars extends Unused; add(UnusedPatVars)
+    object UnusedPrivates extends Unused; add(UnusedPrivates)
+    object UnusedLocals extends Unused; add(UnusedLocals)
+    object UnusedParams extends Unused; add(UnusedParams)
+
+    sealed trait Lint extends WarningCategory { override def summaryCategory: WarningCategory = Lint }
+    object Lint extends Lint { override def includes(o: WarningCategory): Boolean = o.isInstanceOf[Lint] }; add(Lint)
+    object LintAdaptedArgs extends Lint; add(LintAdaptedArgs)
+    object LintNullaryUnit extends Lint; add(LintNullaryUnit)
+    object LintInaccessible extends Lint; add(LintInaccessible)
+    object LintNullaryOverride extends Lint; add(LintNullaryOverride)
+    object LintInferAny extends Lint; add(LintInferAny)
+    object LintMissingInterpolator extends Lint; add(LintMissingInterpolator)
+    object LintDocDetached extends Lint; add(LintDocDetached)
+    object LintPrivateShadow extends Lint; add(LintPrivateShadow)
+    object LintTypeParameterShadow extends Lint; add(LintTypeParameterShadow)
+    object LintPolyImplicitOverload extends Lint; add(LintPolyImplicitOverload)
+    object LintOptionImplicit extends Lint; add(LintOptionImplicit)
+    object LintDelayedinitSelect extends Lint; add(LintDelayedinitSelect)
+    object LintPackageObjectClasses extends Lint; add(LintPackageObjectClasses)
+    object LintStarsAlign extends Lint; add(LintStarsAlign)
+    object LintConstant extends Lint; add(LintConstant)
+    object LintNonlocalReturn extends Lint; add(LintNonlocalReturn)
+    object LintImplicitNotFound extends Lint; add(LintImplicitNotFound)
+    object LintSerial extends Lint; add(LintSerial)
+    object LintEtaZero extends Lint; add(LintEtaZero)
+    object LintEtaSam extends Lint; add(LintEtaSam)
+    object LintDeprecation extends Lint; add(LintDeprecation)
+    object LintBynameImplicit extends Lint; add(LintBynameImplicit)
+    object LintRecurseWithDefault extends Lint; add(LintRecurseWithDefault)
+
+
+    sealed trait Feature extends WarningCategory { override def summaryCategory: WarningCategory = Feature }
+    object Feature extends Feature { override def includes(o: WarningCategory): Boolean = o.isInstanceOf[Feature] }; add(Feature)
+    object FeatureDynamics extends Feature; add(FeatureDynamics)
+    object FeatureExistentials extends Feature; add(FeatureExistentials)
+    object FeatureHigherKinds extends Feature; add(FeatureHigherKinds)
+    object FeatureImplicitConversions extends Feature; add(FeatureImplicitConversions)
+    object FeaturePostfixOps extends Feature; add(FeaturePostfixOps)
+    object FeatureReflectiveCalls extends Feature; add(FeatureReflectiveCalls)
+    object FeatureMacros extends Feature; add(FeatureMacros)
+  }
+
+  sealed trait Version {
+    def orig: String
+    def filterString: String
+  }
+  object Version {
+    final case class NonParseableVersion(orig: String) extends Version {
+      def filterString: String = ""
+    }
+
+    final case class ParseableVersion(orig: String, maj: Int, min: Option[Int], patch: Option[Int]) extends Version {
+      def filterString: String = s"$maj" + min.map(m => s".$m" + patch.map(p => s".$p").getOrElse("")).getOrElse("")
+      def greater(other: ParseableVersion): Boolean = {
+        maj > other.maj ||
+          maj == other.maj && {
+            val am = min.getOrElse(0)
+            val bm = other.min.getOrElse(0)
+            am > bm ||
+              am == bm && {
+                val ap = patch.getOrElse(0)
+                val bp = other.patch.getOrElse(0)
+                ap > bp
+              }
+          }
+      }
+
+      def same(other: ParseableVersion): Boolean =
+        maj == other.maj &&
+          min.getOrElse(0) == other.min.getOrElse(0) &&
+          patch.getOrElse(0) == other.patch.getOrElse(0)
+
+      def smaller(other: ParseableVersion): Boolean = {
+        maj < other.maj ||
+          maj == other.maj && {
+            val am = min.getOrElse(0)
+            val bm = other.min.getOrElse(0)
+            am < bm ||
+              am == bm && {
+                val ap = patch.getOrElse(0)
+                val bp = other.patch.getOrElse(0)
+                ap < bp
+              }
+          }
+      }
+    }
+
+    val VersionPattern: Regex = """(?:.*?\s+)??(\d+)(?:\.(\d+)(?:\.(\d+))?)?(?:\W.*)?""".r
+    def fromString(s: String): Version = s match {
+      case VersionPattern(maj, min, pat) =>
+        ParseableVersion(s, maj.toInt, Option(min).map(_.toInt), Option(pat).map(_.toInt))
+      case _ =>
+        NonParseableVersion(s)
+    }
+
+    val VersionNumberPattern: Regex = """(\d+)(?:\.(\d+)(?:\.(\d+))?)?""".r
+    def fromNumberOnlyString(s: String): Version = s match {
+      case VersionNumberPattern(maj, min, pat) =>
+        ParseableVersion(s, maj.toInt, Option(min).map(_.toInt), Option(pat).map(_.toInt))
+      case _ =>
+        NonParseableVersion(s)
+    }
+  }
+
+  sealed trait MessageFilter {
+    def matches(message: Message): Boolean
+  }
+
+  object MessageFilter {
+    object Any extends MessageFilter {
+      def matches(message: Message): Boolean = true
+    }
+
+    final case class Category(cat: WarningCategory) extends MessageFilter {
+      def matches(message: Message): Boolean = cat.includes(message.category)
+    }
+
+    final case class MessagePattern(pattern: Regex) extends MessageFilter {
+      def matches(message: Message): Boolean = pattern.findFirstIn(message.msg).nonEmpty
+    }
+
+    final case class SitePattern(pattern: Regex) extends MessageFilter {
+      def matches(message: Message): Boolean = pattern.matches(message.site)
+    }
+
+    final case class SourcePattern(pattern: Regex) extends MessageFilter {
+      private[this] val cache = mutable.Map.empty[SourceFile, Boolean]
+
+      def matches(message: Message): Boolean = cache.getOrElseUpdate(message.pos.source, {
+        val sourcePath = message.pos.source.file.canonicalPath.replace("\\", "/")
+        pattern.findFirstIn(sourcePath).nonEmpty
+      })
+    }
+
+    final case class DeprecatedOrigin(pattern: Regex) extends MessageFilter {
+      def matches(message: Message): Boolean = message match {
+        case m: Message.Deprecation => pattern.matches(m.origin)
+        case _ => false
+      }
+    }
+
+    final case class DeprecatedSince(comp: Int, version: ParseableVersion) extends MessageFilter {
+      def matches(message: Message): Boolean = message match {
+        case Message.Deprecation(_, _, _, _, mv: ParseableVersion) =>
+          if (comp == -1) mv.smaller(version)
+          else if (comp == 0) mv.same(version)
+          else mv.greater(version)
+        case _ => false
+      }
+    }
+  }
+
+  sealed trait Action
+
+  object Action {
+    object Error extends Action
+    object Warning extends Action
+    object WarningSummary extends Action
+    object WarningVerbose extends Action
+    object Info extends Action
+    object InfoSummary extends Action
+    object InfoVerbose extends Action
+    object Silent extends Action
+  }
+
+  final case class WConf(filters: List[(List[MessageFilter], Action)]) {
+    def action(message: Message): Action = filters.find(_._1.forall(_.matches(message))) match {
+      case Some((_, action)) => action
+      case _ => Action.Warning
+    }
+  }
+
+  object WConf {
+    import Action._
+    import MessageFilter._
+
+    private def regex(s: String) =
+      try Right(s.r)
+      catch { case e: PatternSyntaxException => Left(s"invalid pattern `$s`: ${e.getMessage}") }
+
+    def parseFilter(s: String, rootDir: String): Either[String, MessageFilter] = {
+      if (s == "any") {
+        Right(Any)
+      } else if (s.startsWith("msg=")) {
+        regex(s.substring(4)).map(MessagePattern)
+      } else if (s.startsWith("cat=")) {
+        val cs = s.substring(4)
+        val c = WarningCategory.all.get(cs).map(Category)
+        c.toRight(s"Unknown category: `$cs`")
+      } else if (s.startsWith("site=")) {
+        regex(s.substring(5)).map(SitePattern)
+      } else if (s.startsWith("origin=")) {
+        regex(s.substring(7)).map(DeprecatedOrigin)
+      } else if(s.startsWith("since")) {
+        def fail = Left(s"invalid since filter: `$s`; required shape: `since<1.2.3`, `since=3.2`, `since>2`")
+        if (s.length < 6) fail
+        else {
+          val v = Version.fromNumberOnlyString(s.substring(6))
+          val op = s.charAt(5) match {
+            case '<' => -1
+            case '=' => 0
+            case '>' => 1
+            case _ => 99
+          }
+          (v, op) match {
+            case (_: NonParseableVersion, _) => fail
+            case (_, 99) => fail
+            case (pv: ParseableVersion, o) => Right(DeprecatedSince(o, pv))
+          }
+        }
+      } else if (s.startsWith("src=")) {
+        val arg = s.substring(4)
+        var pat = new mutable.StringBuilder()
+        if (rootDir.nonEmpty) pat += '^' ++= rootDir
+        // Also prepend prepend a `/` if rootDir is empty, the pattern has to match
+        // the beginning of a path segment
+        if (!rootDir.endsWith("/") && !arg.startsWith("/")) pat += '/'
+        pat ++= arg
+        if (!arg.endsWith("$")) pat += '$'
+        regex(pat.toString).map(SourcePattern)
+      } else {
+        Left(s"filter not yet implemented: $s")
+      }
+    }
+
+    def parse(setting: List[String], rootDir: String): Either[List[String], WConf] = {
+      def parseAction(s: String): Either[List[String], Action] = s match {
+        case "error" | "e" => Right(Error)
+        case "warning" | "w" => Right(Warning)
+        case "warning-summary" | "ws" => Right(WarningSummary)
+        case "warning-verbose" | "wv" => Right(WarningVerbose)
+        case "info" | "i" => Right(Info)
+        case "info-summary" | "is" => Right(InfoSummary)
+        case "info-verbose" | "iv" => Right(InfoVerbose)
+        case "silent" | "s" => Right(Silent)
+        case _ => Left(List(s"unknonw action: `$s`"))
+      }
+
+      if (setting.isEmpty) Right(WConf(Nil))
+      else {
+        val parsedConfs: List[Either[List[String], (List[MessageFilter], Action)]] = setting.map(conf => {
+          val parts = conf.split("[&:]") // TODO: don't split on escaped \&
+          val (ms, fs) = parts.view.init.map(parseFilter(_, rootDir)).toList.partitionMap(identity)
+          if (ms.nonEmpty) Left(ms)
+          else if (fs.isEmpty) Left(List("no filters or no action defined"))
+          else parseAction(parts.last).map((fs, _))
+        })
+        val (ms, fs) = parsedConfs.partitionMap(identity)
+        if (ms.nonEmpty) Left(ms.flatten)
+        else Right(WConf(fs))
+      }
+    }
+  }
+
+  case class Suppression(annotPos: Position, filters: List[MessageFilter], start: Int, end: Int) {
+    private[this] var _used = false
+    def used: Boolean = _used
+    def markUsed(): Unit = { _used = true }
+
+
+    def matches(message: Message): Boolean = {
+      val pos = message.pos
+      pos.isDefined && start <= pos.start && pos.end <= end && filters.exists(_.matches(message))
     }
   }
 }

--- a/src/compiler/scala/tools/nsc/ast/DocComments.scala
+++ b/src/compiler/scala/tools/nsc/ast/DocComments.scala
@@ -17,6 +17,7 @@ import scala.annotation.tailrec
 import symtab._
 import util.DocStrings._
 import scala.collection.mutable
+import scala.tools.nsc.Reporting.WarningCategory
 
 /*
  *  @author  Martin Odersky
@@ -86,7 +87,7 @@ trait DocComments { self: Global =>
       case None =>
         // scala/bug#8210 - The warning would be false negative when this symbol is a setter
         if (ownComment.indexOf("@inheritdoc") != -1 && ! sym.isSetter)
-          reporter.warning(sym.pos, s"The comment for ${sym} contains @inheritdoc, but no parent comment is available to inherit from.")
+          runReporting.warning(sym.pos, s"The comment for ${sym} contains @inheritdoc, but no parent comment is available to inherit from.", WarningCategory.Scaladoc, sym)
         ownComment.replace("@inheritdoc", "<invalid inheritdoc annotation>")
       case Some(sc) =>
         if (ownComment == "") sc
@@ -364,7 +365,7 @@ trait DocComments { self: Global =>
                 case None              =>
                   val pos = docCommentPos(sym)
                   val loc = pos withPoint (pos.start + vstart + 1)
-                  reporter.warning(loc, s"Variable $vname undefined in comment for $sym in $site")
+                  runReporting.warning(loc, s"Variable $vname undefined in comment for $sym in $site", WarningCategory.Scaladoc, sym)
               }
             }
         }
@@ -411,7 +412,7 @@ trait DocComments { self: Global =>
       val comment      = "/** " + raw.substring(commentStart, end) + "*/"
       val commentPos   = subPos(commentStart, end)
 
-      self.currentRun.reporting.deprecationWarning(codePos, "The @usecase tag is deprecated, instead use the @example tag to document the usage of your API", "2.13.0")
+      runReporting.deprecationWarning(codePos, "The @usecase tag is deprecated, instead use the @example tag to document the usage of your API", "2.13.0", site = "", origin = "")
 
       UseCase(DocComment(comment, commentPos, codePos), code, codePos)
     }
@@ -495,9 +496,11 @@ trait DocComments { self: Global =>
         }
         val result = rest.foldLeft(start)(select(_, _, NoType))
         if (result == NoType)
-          reporter.warning(comment.codePos, "Could not find the type " + variable + " points to while expanding it " +
-                                            "for the usecase signature of " + sym + " in " + site + "." +
-                                            "In this context, " + variable + " = \"" + str + "\".")
+          runReporting.warning(
+            comment.codePos,
+            s"""Could not find the type $variable points to while expanding it for the usecase signature of $sym in $site. In this context, $variable = "$str".""",
+            WarningCategory.Scaladoc,
+            site)
         result
       }
 

--- a/src/compiler/scala/tools/nsc/ast/Positions.scala
+++ b/src/compiler/scala/tools/nsc/ast/Positions.scala
@@ -13,6 +13,8 @@
 package scala.tools.nsc
 package ast
 
+import scala.tools.nsc.Reporting.WarningCategory
+
 trait Positions extends scala.reflect.internal.Positions {
   self: Global =>
 
@@ -27,7 +29,7 @@ trait Positions extends scala.reflect.internal.Positions {
         t.children foreach { c =>
           if (!c.canHaveAttrs) ()
           else if (c.pos == NoPosition) {
-            reporter.warning(t.pos, " Positioned tree has unpositioned child in phase " + globalPhase)
+            runReporting.warning(t.pos, " Positioned tree has unpositioned child in phase " + globalPhase, WarningCategory.OtherDebug, currentOwner)
             inform("parent: " + treeSymStatus(t))
             inform(" child: " + treeSymStatus(c) + "\n")
           }

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -18,10 +18,12 @@ import scala.reflect.internal.util._
 import scala.reflect.internal.Chars._
 import Tokens._
 import scala.annotation.{switch, tailrec}
-import scala.collection.mutable, mutable.{ListBuffer, ArrayBuffer}
+import scala.collection.mutable
+import mutable.{ArrayBuffer, ListBuffer}
 import scala.tools.nsc.ast.parser.xml.Utility.isNameStart
-
 import java.lang.StringBuilder
+
+import scala.tools.nsc.Reporting.WarningCategory
 
 object Cbuf {
   final val TargetCapacity = 256
@@ -69,6 +71,7 @@ trait ScannersCommon {
     // things to fill in, in addition to buf, decodeUni which come from CharArrayReader
     def error(off: Offset, msg: String): Unit
     def incompleteInputError(off: Offset, msg: String): Unit
+    def warning(off: Offset, msg: String, category: WarningCategory): Unit
     def deprecationWarning(off: Offset, msg: String, since: String): Unit
   }
 
@@ -1440,6 +1443,7 @@ trait Scanners extends ScannersCommon {
     val buf = source.content
 
     // suppress warnings, throw exception on errors
+    def warning(off: Offset, msg: String, category: WarningCategory): Unit = ()
     def deprecationWarning(off: Offset, msg: String, since: String): Unit = ()
     def error(off: Offset, msg: String): Unit = throw new MalformedInput(off, msg)
     def incompleteInputError(off: Offset, msg: String): Unit = throw new MalformedInput(off, msg)
@@ -1450,9 +1454,10 @@ trait Scanners extends ScannersCommon {
   class UnitScanner(val unit: CompilationUnit, patches: List[BracePatch]) extends SourceFileScanner(unit.source) {
     def this(unit: CompilationUnit) = this(unit, List())
 
-    override def deprecationWarning(off: Offset, msg: String, since: String) = currentRun.reporting.deprecationWarning(unit.position(off), msg, since)
-    override def error(off: Offset, msg: String)                             = reporter.error(unit.position(off), msg)
-    override def incompleteInputError(off: Offset, msg: String)              = currentRun.parsing.incompleteInputError(unit.position(off), msg)
+    override def warning(off: Offset, msg: String, category: WarningCategory): Unit   = runReporting.warning(unit.position(off), msg, category, site = "")
+    override def deprecationWarning(off: Offset, msg: String, since: String)          = runReporting.deprecationWarning(unit.position(off), msg, since, site = "", origin = "")
+    override def error(off: Offset, msg: String)                                      = reporter.error(unit.position(off), msg)
+    override def incompleteInputError(off: Offset, msg: String)                       = currentRun.parsing.incompleteInputError(unit.position(off), msg)
 
     private var bracePatches: List[BracePatch] = patches
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -19,9 +19,9 @@ import BackendReporting._
 import scala.tools.asm.ClassWriter
 import scala.tools.nsc.backend.jvm.BCodeHelpers.ScalaSigBytes
 import scala.tools.nsc.reporters.NoReporter
-
 import PartialFunction.cond
 import scala.annotation.tailrec
+import scala.tools.nsc.Reporting.WarningCategory
 
 /*
  *  Traits encapsulating functionality to convert Scala AST Trees into ASM ClassNodes.
@@ -267,19 +267,21 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
      */
     def apply(sym: Symbol, csymCompUnit: CompilationUnit, mainClass: Option[String]): Boolean = sym.hasModuleFlag && {
       val warn = mainClass.fold(true)(_ == sym.fullNameString)
-      def warnBadMain(msg: String, pos: Position): Unit = if (warn) reporter.warning(pos,
+      def warnBadMain(msg: String, pos: Position): Unit = if (warn) runReporting.warning(pos,
         s"""|not a valid main method for ${sym.fullName('.')},
             |  because $msg.
             |  To define an entry point, please define the main method as:
             |    def main(args: Array[String]): Unit
-            |""".stripMargin
-      )
-      def warnNoForwarder(msg: String, hasExact: Boolean, mainly: Type) = if (warn) reporter.warning(sym.pos,
+            |""".stripMargin,
+        WarningCategory.Other,
+        sym)
+      def warnNoForwarder(msg: String, hasExact: Boolean, mainly: Type) = if (warn) runReporting.warning(sym.pos,
         s"""|${sym.name.decoded} has a ${if (hasExact) "valid " else ""}main method${if (mainly != NoType) " "+mainly else ""},
             |  but ${sym.fullName('.')} will not have an entry point on the JVM.
             |  Reason: $msg, which means no static forwarder can be generated.
-            |""".stripMargin
-      )
+            |""".stripMargin,
+        WarningCategory.Other,
+        sym)
       val possibles = (sym.tpe nonPrivateMember nme.main).alternatives
       val hasApproximate = possibles.exists(m => cond(m.info) { case MethodType(p :: Nil, _) => p.tpe.typeSymbol == definitions.ArrayClass })
 
@@ -697,11 +699,13 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
         }
 
         if(!isValidSignature) {
-          reporter.warning(sym.pos,
+          runReporting.warning(sym.pos,
             sm"""|compiler bug: created invalid generic signature for $sym in ${sym.owner.skipPackageObject.fullName}
                  |signature: $sig
                  |if this is reproducible, please report bug at https://github.com/scala/bug/issues
-              """.trim)
+              """.trim,
+            WarningCategory.Other,
+            sym)
           return null
         }
       }
@@ -710,14 +714,16 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
         val normalizedTpe = enteringErasure(erasure.prepareSigMap(memberTpe))
         val bytecodeTpe = owner.thisType.memberInfo(sym)
         if (!sym.isType && !sym.isConstructor && !(erasure.erasure(sym)(normalizedTpe) =:= bytecodeTpe)) {
-          reporter.warning(sym.pos,
+          runReporting.warning(sym.pos,
             sm"""|compiler bug: created generic signature for $sym in ${sym.owner.skipPackageObject.fullName} that does not conform to its erasure
                  |signature: $sig
                  |original type: $memberTpe
                  |normalized type: $normalizedTpe
                  |erasure type: $bytecodeTpe
                  |if this is reproducible, please report bug at https://github.com/scala/bug/issues
-              """.trim)
+              """.trim,
+            WarningCategory.Other,
+            sym)
            return null
         }
       }

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -15,6 +15,7 @@ package backend.jvm
 
 import scala.reflect.internal.Flags.{DEFERRED, SYNTHESIZE_IMPL_IN_SUBCLASS}
 import scala.tools.asm
+import scala.tools.nsc.Reporting.WarningCategory
 import scala.tools.nsc.backend.jvm.BTypes._
 import scala.tools.nsc.backend.jvm.BackendReporting._
 
@@ -195,9 +196,12 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
        */
 
       case tp =>
-        warning(tp.typeSymbol.pos,
+        runReporting.warning(
+          tp.typeSymbol.pos,
           s"an unexpected type representation reached the compiler backend while compiling $currentUnit: $tp. " +
-            "If possible, please file a bug on https://github.com/scala/bug/issues.")
+            "If possible, please file a bug on https://github.com/scala/bug/issues.",
+          WarningCategory.Other,
+          site = "")
 
         tp match {
           case ThisType(ArrayClass)    => ObjectRef // was introduced in 9b17332f11 to fix scala/bug#999, but this code is not reached in its test, or any other test

--- a/src/compiler/scala/tools/nsc/backend/jvm/CodeGen.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CodeGen.scala
@@ -51,7 +51,7 @@ abstract class CodeGen[G <: Global](val global: G) extends PerRunInit {
       case ex: InterruptedException => throw ex
       case ex: Throwable =>
         if (settings.debug) ex.printStackTrace()
-        error(s"Error while emitting ${unit.source}\n${ex.getMessage}")
+        globalError(s"Error while emitting ${unit.source}\n${ex.getMessage}")
     }
 
     def genClassDefs(tree: Tree): Unit = tree match {

--- a/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
@@ -20,7 +20,6 @@ import java.util.concurrent._
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
-import scala.reflect.internal.util.NoPosition
 import scala.tools.nsc.backend.jvm.PostProcessorFrontendAccess.BufferingBackendReporting
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.profile.ThreadPoolFactory
@@ -101,6 +100,8 @@ private[jvm] object GeneratedClassHandler {
 
   sealed abstract class WritingClassHandler(val javaExecutor: Executor) extends GeneratedClassHandler {
     import postProcessor.bTypes.frontendAccess
+
+    import scala.reflect.internal.util.NoPosition
 
     def tryStealing: Option[Runnable]
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
@@ -20,6 +20,7 @@ import java.util.concurrent._
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
+import scala.tools.nsc.Reporting.WarningCategory
 import scala.tools.nsc.backend.jvm.PostProcessorFrontendAccess.BufferingBackendReporting
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.profile.ThreadPoolFactory
@@ -58,8 +59,8 @@ private[jvm] object GeneratedClassHandler {
         new SyncWritingClassHandler(postProcessor)
 
       case maxThreads =>
-        if (global.statistics.enabled)
-          global.reporter.warning(global.NoPosition, "jvm statistics are not reliable with multi-threaded jvm class writing")
+        if (statistics.enabled)
+          runReporting.warning(NoPosition, "jvm statistics are not reliable with multi-threaded jvm class writing", WarningCategory.Other, site = "")
         val additionalThreads = maxThreads - 1
         // The thread pool queue is limited in size. When it's full, the `CallerRunsPolicy` causes
         // a new task to be executed on the main thread, which provides back-pressure.

--- a/src/compiler/scala/tools/nsc/backend/jvm/PostProcessorFrontendAccess.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/PostProcessorFrontendAccess.scala
@@ -19,6 +19,8 @@ import scala.reflect.io.AbstractFile
 import scala.tools.nsc.backend.jvm.BTypes.InternalName
 import java.util.{Collection => JCollection, Map => JMap}
 
+import scala.tools.nsc.Reporting.WarningCategory
+
 /**
  * Functionality needed in the post-processor whose implementation depends on the compiler
  * frontend. All methods are synchronized.
@@ -96,7 +98,12 @@ object PostProcessorFrontendAccess {
   }
 
   trait BackendReporting {
-    def inlinerWarning(pos: Position, message: String): Unit
+    def siteString(owner: InternalName, method: String): String = {
+      val c = owner.replace('/', '.').replaceAll("\\$+", ".").replaceAll("\\.$", "")
+      if (method.isEmpty) c
+      else s"$c.$method"
+    }
+    def optimizerWarning(pos: Position, message: String, site: String): Unit
     def error(pos: Position, message: String): Unit
     def warning(pos: Position, message: String): Unit
     def inform(message: String): Unit
@@ -110,8 +117,8 @@ object PostProcessorFrontendAccess {
     // consumed in another
     private var bufferedReports = List.empty[Report]
 
-    def inlinerWarning(pos: Position, message: String): Unit =
-      this.synchronized(bufferedReports ::= new ReportInlinerWarning(pos, message))
+    def optimizerWarning(pos: Position, message: String, site: String): Unit =
+      this.synchronized(bufferedReports ::= new ReportOptimizerWarning(pos, message, site))
 
     def error(pos: Position, message: String): Unit =
       this.synchronized(bufferedReports ::= new ReportError(pos, message))
@@ -136,9 +143,9 @@ object PostProcessorFrontendAccess {
       def relay(backendReporting: BackendReporting): Unit
     }
 
-    private class ReportInlinerWarning(pos: Position, message: String) extends Report {
+    private class ReportOptimizerWarning(pos: Position, message: String, site: String) extends Report {
       override def relay(reporting: BackendReporting): Unit =
-        reporting.inlinerWarning(pos, message)
+        reporting.optimizerWarning(pos, message, site)
     }
 
     private class ReportError(pos: Position, message: String) extends Report {
@@ -236,8 +243,8 @@ object PostProcessorFrontendAccess {
     }
 
     object directBackendReporting extends BackendReporting {
-      def inlinerWarning(pos: Position, message: String): Unit = frontendSynch {
-        currentRun.reporting.inlinerWarning(pos, message)
+      def optimizerWarning(pos: Position, message: String, site: String): Unit = frontendSynch {
+        runReporting.warning(pos, message, WarningCategory.Optimizer, site)
       }
 
       def error(pos: Position, message: String): Unit = frontendSynch {
@@ -245,7 +252,7 @@ object PostProcessorFrontendAccess {
       }
 
       def warning(pos: Position, message: String): Unit = frontendSynch {
-        global.warning(pos, message)
+        runReporting.warning(pos, message, WarningCategory.Other, site = "")
       }
 
       def inform(message: String): Unit = frontendSynch {

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -479,6 +479,10 @@ abstract class BackendUtils extends PerRunInit {
   def indyLambdaBodyMethods(hostClass: InternalName, method: MethodNode): Map[InvokeDynamicInsnNode, Handle] = {
     onIndyLambdaImplMethodIfPresent(hostClass)(ms => ms.getOrElse(method, Nil).toMap).getOrElse(Map.empty)
   }
+
+  // not in `backendReporting` since there we don't have access to the `Callsite` class
+  def optimizerWarningSiteString(cs: callGraph.Callsite): String =
+    frontendAccess.backendReporting.siteString(cs.callsiteClass.internalName, cs.callsiteMethod.name)
 }
 
 object BackendUtils {

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
@@ -122,7 +122,7 @@ abstract class ClosureOptimizer {
 
             for (init <- closureInits.valuesIterator) closureCallsites(init, prodCons) foreach {
               case Left(warning) =>
-                backendReporting.inlinerWarning(warning.pos, warning.toString)
+                backendReporting.optimizerWarning(warning.pos, warning.toString, backendReporting.siteString(ownerClass, method.name))
 
               case Right((invocation, stackHeight)) =>
                 addRewrite(init, invocation, stackHeight)

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -412,15 +412,17 @@ abstract class Inliner {
                 case Some(inlinedCallsite) =>
                   val rw = inlinedCallsite.warning.get
                   if (rw.emitWarning(compilerSettings)) {
-                    backendReporting.inlinerWarning(
+                    backendReporting.optimizerWarning(
                       inlinedCallsite.eliminatedCallsite.callsitePosition,
-                      rw.toString + inlineChainSuffix(r.callsite, state.inlineChain(inlinedCallsite.eliminatedCallsite.callsiteInstruction, skipForwarders = true)))
+                      rw.toString + inlineChainSuffix(r.callsite, state.inlineChain(inlinedCallsite.eliminatedCallsite.callsiteInstruction, skipForwarders = true)),
+                      backendUtils.optimizerWarningSiteString(inlinedCallsite.eliminatedCallsite))
                   }
                 case _ =>
                   if (w.emitWarning(compilerSettings))
-                    backendReporting.inlinerWarning(
+                    backendReporting.optimizerWarning(
                       r.callsite.callsitePosition,
-                      w.toString + inlineChainSuffix(r.callsite, state.inlineChain(r.callsite.callsiteInstruction, skipForwarders = true)))
+                      w.toString + inlineChainSuffix(r.callsite, state.inlineChain(r.callsite.callsiteInstruction, skipForwarders = true)),
+                      backendUtils.optimizerWarningSiteString(r.callsite))
               }
           }
         }
@@ -471,7 +473,10 @@ abstract class Inliner {
                 val w = inlinedCallsite.warning.get
                 state.inlineLog.logRollback(callsite, s"Instruction ${AsmUtils.textify(notInlinedIllegalInsn)} would cause an IllegalAccessError, and is not selected for (or failed) inlining", state.outerCallsite(notInlinedIllegalInsn))
                 if (w.emitWarning(compilerSettings))
-                  backendReporting.inlinerWarning(callsite.callsitePosition, w.toString + inlineChainSuffix(callsite, state.inlineChain(callsite.callsiteInstruction, skipForwarders = true)))
+                  backendReporting.optimizerWarning(
+                    callsite.callsitePosition,
+                    w.toString + inlineChainSuffix(callsite, state.inlineChain(callsite.callsiteInstruction, skipForwarders = true)),
+                    backendUtils.optimizerWarningSiteString(callsite))
               case _ =>
                 // TODO: replace by dev warning after testing
                 assert(false, "should not happen")

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/InlinerHeuristics.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/InlinerHeuristics.scala
@@ -109,17 +109,17 @@ abstract class InlinerHeuristics extends PerRunInit {
 
             case Some(Left(w)) =>
               if (w.emitWarning(compilerSettings)) {
-                backendReporting.inlinerWarning(callsite.callsitePosition, w.toString)
+                backendReporting.optimizerWarning(callsite.callsitePosition, w.toString, backendUtils.optimizerWarningSiteString(callsite))
               }
 
             case None =>
               if (callsiteWarning.isDefined && callsiteWarning.get.emitWarning(compilerSettings))
-                backendReporting.inlinerWarning(pos, s"there was a problem determining if method ${callee.name} can be inlined: \n"+ callsiteWarning.get)
+                backendReporting.optimizerWarning(pos, s"there was a problem determining if method ${callee.name} can be inlined: \n"+ callsiteWarning.get, backendUtils.optimizerWarningSiteString(callsite))
           }
 
-        case Callsite(ins, _, _, Left(warning), _, _, _, pos, _, _) =>
+        case callsite @ Callsite(ins, _, _, Left(warning), _, _, _, pos, _, _) =>
           if (warning.emitWarning(compilerSettings))
-            backendReporting.inlinerWarning(pos, s"failed to determine if ${ins.name} should be inlined:\n$warning")
+            backendReporting.optimizerWarning(pos, s"failed to determine if ${ins.name} should be inlined:\n$warning", backendUtils.optimizerWarningSiteString(callsite))
       }
       (methodNode, requests)
     }).filterNot(_._2.isEmpty).toMap

--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -23,6 +23,7 @@ import scala.annotation.tailrec
 import scala.language.implicitConversions
 import scala.reflect.internal.util.Position
 import scala.reflect.internal.util.ListOfNil
+import scala.tools.nsc.Reporting.WarningCategory
 
 trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
   val global : Global
@@ -36,9 +37,9 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
     def freshName(prefix: String): Name = freshTermName(prefix)
     def freshTermName(prefix: String): TermName = unit.freshTermName(prefix)
     def freshTypeName(prefix: String): TypeName = unit.freshTypeName(prefix)
-    def deprecationWarning(off: Int, msg: String, since: String) = currentRun.reporting.deprecationWarning(off, msg, since)
+    def deprecationWarning(off: Int, msg: String, since: String) = runReporting.deprecationWarning(off, msg, since, site = "", origin = "")
     implicit def i2p(offset : Int) : Position = Position.offset(unit.source, offset)
-    def warning(pos : Int, msg : String) : Unit = reporter.warning(pos, msg)
+    def warning(pos : Int, msg : String) : Unit = runReporting.warning(pos, msg, WarningCategory.JavaSource, site = "")
     def syntaxError(pos: Int, msg: String) : Unit = reporter.error(pos, msg)
   }
 

--- a/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
@@ -17,9 +17,10 @@ import scala.tools.nsc.util.JavaCharArrayReader
 import scala.reflect.internal.util._
 import scala.reflect.internal.Chars._
 import JavaTokens._
-import scala.annotation.{ switch, tailrec }
+import scala.annotation.{switch, tailrec}
 import scala.language.implicitConversions
 import scala.collection.immutable.ArraySeq
+import scala.tools.nsc.Reporting.WarningCategory
 
 // Todo merge these better with Scanners
 trait JavaScanners extends ast.parser.ScannersCommon {
@@ -885,7 +886,8 @@ trait JavaScanners extends ast.parser.ScannersCommon {
     init()
     def error(pos: Int, msg: String) = reporter.error(pos, msg)
     def incompleteInputError(pos: Int, msg: String) = currentRun.parsing.incompleteInputError(pos, msg)
-    def deprecationWarning(pos: Int, msg: String, since: String) = currentRun.reporting.deprecationWarning(pos, msg, since)
+    def warning(pos: Int, msg: String, category: WarningCategory) = runReporting.warning(pos, msg, category, site = "")
+    def deprecationWarning(pos: Int, msg: String, since: String) = runReporting.deprecationWarning(pos, msg, since, site = "", origin = "")
     implicit def g2p(pos: Int): Position = Position.offset(unit.source, pos)
   }
 }

--- a/src/compiler/scala/tools/nsc/plugins/Plugins.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugins.scala
@@ -18,6 +18,7 @@ import java.util
 
 import scala.reflect.internal.util.ScalaClassLoader
 import scala.reflect.io.Path
+import scala.tools.nsc.Reporting.WarningCategory
 import scala.tools.nsc.plugins.Plugin.pluginClassLoadersCache
 import scala.tools.nsc.typechecker.Macros
 import scala.tools.nsc.util.ClassPath
@@ -44,7 +45,7 @@ trait Plugins { global: Global =>
     // Explicit parameterization of recover to avoid -Xlint warning about inferred Any
     errors foreach (_.recover[Any] {
       // legacy behavior ignores altogether, so at least warn devs
-      case e: MissingPluginException => if (global.isDeveloper) warning(e.getMessage)
+      case e: MissingPluginException => if (global.isDeveloper) runReporting.warning(NoPosition, e.getMessage, WarningCategory.OtherDebug, site = "")
       case e: Exception              => inform(e.getMessage)
     })
     val classes = goods map (_.get)  // flatten

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -220,7 +220,8 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
     add(new ChoiceSetting(name, helpArg, descr, choices, default, choicesHelp))
   def IntSetting(name: String, descr: String, default: Int, range: Option[(Int, Int)], parser: String => Option[Int]) =
     add(new IntSetting(name, descr, default, range, parser))
-  def MultiStringSetting(name: String, arg: String, descr: String, helpText: Option[String] = None) = add(new MultiStringSetting(name, arg, descr, helpText))
+  def MultiStringSetting(name: String, arg: String, descr: String, helpText: Option[String] = None, prepend: Boolean = false) =
+    add(new MultiStringSetting(name, arg, descr, helpText, prepend))
   def MultiChoiceSetting[E <: MultiChoiceEnumeration](name: String, helpArg: String, descr: String, domain: E, default: Option[List[String]] = None) =
     add(new MultiChoiceSetting[E](name, helpArg, descr, domain, default))
   def OutputSetting(outputDirs: OutputDirs, default: String) = add(new OutputSetting(outputDirs, default))
@@ -784,7 +785,8 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
     name: String,
     val arg: String,
     descr: String,
-    helpText: Option[String])
+    helpText: Option[String],
+    prepend: Boolean)
   extends Setting(name, descr) with Clearable {
     type T = List[String]
     protected var v: T = Nil
@@ -800,12 +802,13 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
           if (halting && (arg startsWith "-")) args
           else {
             if (helpText.isDefined && arg == "help") sawHelp = true
+            else if (prepend) value ::= arg
             else value ++= List(arg)
             loop(rest)
           }
         case Nil         => Nil
       }
-      Some(loop(args))
+      Some(loop(if (prepend) args.reverse else args))
     }
     def tryToSet(args: List[String])                  = tryToSetArgs(args, halting = true)
     override def tryToSetColon(args: List[String])    = tryToSetArgs(args, halting = false)

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -400,9 +400,13 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
     helpArg = "warning",
     descr = "Enable optimizer warnings, `help` for details.",
     domain = optWarningsChoices,
-    default = Some(List(optWarningsChoices.atInlineFailed.name)))
+    default = Some(List(optWarningsChoices.atInlineFailed.name))) withPostSetHook { _ =>
+    // no need to set `Wconf` to `silent` if optWarnings is none, since no warnings are reported
+    if (optWarningsSummaryOnly) Wconf.tryToSet(List(s"cat=optimizer:ws"))
+    else Wconf.tryToSet(List(s"cat=optimizer:w"))
+  }
 
-  def optWarningsSummaryOnly = optWarnings.value subsetOf Set(optWarningsChoices.none, optWarningsChoices.atInlineFailedSummary)
+  def optWarningsSummaryOnly: Boolean = optWarnings.value subsetOf Set(optWarningsChoices.none, optWarningsChoices.atInlineFailedSummary)
 
   def optWarningEmitAtInlineFailed =
     !optWarnings.isSetByUser ||

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -34,21 +34,31 @@ trait StandardScalaSettings {
   val javabootclasspath = PathSetting ("-javabootclasspath", "Override java boot classpath.", Defaults.javaBootClassPath) withAbbreviation "--java-boot-class-path"
   val javaextdirs =       PathSetting ("-javaextdirs", "Override java extdirs classpath.", Defaults.javaExtDirs) withAbbreviation "--java-extension-directories"
   val sourcepath =        PathSetting ("-sourcepath", "Specify location(s) of source files.", "") withAbbreviation "--source-path" // Defaults.scalaSourcePath
+  val rootdir =           PathSetting ("-rootdir", "The absolute path of the project root directory, usually the git / scm checkout.", "") withAbbreviation "--root-directory"
 
   /** Other settings.
    */
   val dependencyfile =  StringSetting ("-dependencyfile", "file", "Set dependency tracking file.", ".scala_dependencies") withAbbreviation "--dependency-file"
-  val deprecation =    BooleanSetting ("-deprecation", "Emit warning and location for usages of deprecated APIs.") withAbbreviation "--deprecation"
+  val deprecation =    BooleanSetting ("-deprecation", "Emit warning and location for usages of deprecated APIs.") withAbbreviation "--deprecation" withPostSetHook { s =>
+    if (s.value) Wconf.tryToSet(List(s"cat=deprecation:w"))
+    else Wconf.tryToSet(List(s"cat=deprecation:s"))
+  }
   val encoding =        StringSetting ("-encoding", "encoding", "Specify character encoding used by source files.", Properties.sourceEncoding) withAbbreviation "--encoding"
   val explaintypes =   BooleanSetting ("-explaintypes", "Explain type errors in more detail.") withAbbreviation "--explain-types"
-  val feature =        BooleanSetting ("-feature", "Emit warning and location for usages of features that should be imported explicitly.") withAbbreviation "--feature"
+  val feature =        BooleanSetting ("-feature", "Emit warning and location for usages of features that should be imported explicitly.") withAbbreviation "--feature" withPostSetHook { s =>
+    if (s.value) Wconf.tryToSet(List(s"cat=feature:w"))
+    else Wconf.tryToSet(List(s"cat=feature:s"))
+  }
   val g =               ChoiceSetting ("-g", "level", "Set level of generated debugging info.", List("none", "source", "line", "vars", "notailcalls"), "vars")
   val help =           BooleanSetting ("-help", "Print a synopsis of standard options") withAbbreviation "--help"
   val nowarn =         BooleanSetting ("-nowarn", "Generate no warnings.") withAbbreviation "--no-warnings"
   val optimise:        BooleanSetting // depends on post hook which mutates other settings
   val print =          BooleanSetting ("-print", "Print program with Scala-specific features removed.") withAbbreviation "--print"
   val target =         ChoiceSetting  ("-target", "target", "Target platform for object files.", AllTargetVersions, "8") withPreSetHook normalizeTarget _ withAbbreviation "--target"
-  val unchecked =      BooleanSetting ("-unchecked", "Enable additional warnings where generated code depends on assumptions.") withAbbreviation "--unchecked"
+  val unchecked =      BooleanSetting ("-unchecked", "Enable additional warnings where generated code depends on assumptions.") withAbbreviation "--unchecked" withPostSetHook { s =>
+    if (s.value) Wconf.tryToSet(List(s"cat=unchecked:w"))
+    else Wconf.tryToSet(List(s"cat=unchecked:s"))
+  }
   val uniqid =         BooleanSetting ("-uniqid", "Uniquely tag all identifiers in debugging output.") withAbbreviation "--unique-id"
   val usejavacp =      BooleanSetting ("-usejavacp", "Utilize the java.class.path in classpath resolution.") withAbbreviation "--use-java-class-path"
   val usemanifestcp =  BooleanSetting ("-usemanifestcp", "Utilize the manifest in classpath resolution.") withAbbreviation "--use-manifest-class-path"

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -34,18 +34,18 @@ trait StandardScalaSettings {
   val javabootclasspath = PathSetting ("-javabootclasspath", "Override java boot classpath.", Defaults.javaBootClassPath) withAbbreviation "--java-boot-class-path"
   val javaextdirs =       PathSetting ("-javaextdirs", "Override java extdirs classpath.", Defaults.javaExtDirs) withAbbreviation "--java-extension-directories"
   val sourcepath =        PathSetting ("-sourcepath", "Specify location(s) of source files.", "") withAbbreviation "--source-path" // Defaults.scalaSourcePath
-  val rootdir =           PathSetting ("-rootdir", "The absolute path of the project root directory, usually the git / scm checkout.", "") withAbbreviation "--root-directory"
+  val rootdir =           PathSetting ("-rootdir", "The absolute path of the project root directory, usually the git/scm checkout. Used by -Wconf.", "") withAbbreviation "--root-directory"
 
   /** Other settings.
    */
   val dependencyfile =  StringSetting ("-dependencyfile", "file", "Set dependency tracking file.", ".scala_dependencies") withAbbreviation "--dependency-file"
-  val deprecation =    BooleanSetting ("-deprecation", "Emit warning and location for usages of deprecated APIs.") withAbbreviation "--deprecation" withPostSetHook { s =>
+  val deprecation =    BooleanSetting ("-deprecation", "Emit warning and location for usages of deprecated APIs. See also -Wconf.") withAbbreviation "--deprecation" withPostSetHook { s =>
     if (s.value) Wconf.tryToSet(List(s"cat=deprecation:w"))
     else Wconf.tryToSet(List(s"cat=deprecation:s"))
   }
   val encoding =        StringSetting ("-encoding", "encoding", "Specify character encoding used by source files.", Properties.sourceEncoding) withAbbreviation "--encoding"
   val explaintypes =   BooleanSetting ("-explaintypes", "Explain type errors in more detail.") withAbbreviation "--explain-types"
-  val feature =        BooleanSetting ("-feature", "Emit warning and location for usages of features that should be imported explicitly.") withAbbreviation "--feature" withPostSetHook { s =>
+  val feature =        BooleanSetting ("-feature", "Emit warning and location for usages of features that should be imported explicitly. See also -Wconf.") withAbbreviation "--feature" withPostSetHook { s =>
     if (s.value) Wconf.tryToSet(List(s"cat=feature:w"))
     else Wconf.tryToSet(List(s"cat=feature:s"))
   }
@@ -55,7 +55,7 @@ trait StandardScalaSettings {
   val optimise:        BooleanSetting // depends on post hook which mutates other settings
   val print =          BooleanSetting ("-print", "Print program with Scala-specific features removed.") withAbbreviation "--print"
   val target =         ChoiceSetting  ("-target", "target", "Target platform for object files.", AllTargetVersions, "8") withPreSetHook normalizeTarget _ withAbbreviation "--target"
-  val unchecked =      BooleanSetting ("-unchecked", "Enable additional warnings where generated code depends on assumptions.") withAbbreviation "--unchecked" withPostSetHook { s =>
+  val unchecked =      BooleanSetting ("-unchecked", "Enable additional warnings where generated code depends on assumptions. See also -Wconf.") withAbbreviation "--unchecked" withPostSetHook { s =>
     if (s.value) Wconf.tryToSet(List(s"cat=unchecked:w"))
     else Wconf.tryToSet(List(s"cat=unchecked:s"))
   }

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -95,7 +95,7 @@ trait Warnings {
          |Note: on the command-line you might need to quote configurations containing `*` or `&`
          |to prevent the shell from expanding patterns.""".stripMargin),
     prepend = true)
-  locally { Wconf.tryToSet(WconfDefault) }
+  locally { Wconf.tryToSet(WconfDefault); Wconf.clearSetByUser() }
 
   // Non-lint warnings. -- TODO turn into MultiChoiceEnumeration
   val warnMacros           = ChoiceSetting(

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -181,7 +181,7 @@ trait Warnings {
     val PackageObjectClasses   = LintWarning("package-object-classes",    "Class or object defined in package object.")
     val StarsAlign             = LintWarning("stars-align",               "In a pattern, a sequence wildcard `_*` should match all of a repeated parameter.")
     val Constant               = LintWarning("constant",                  "Evaluation of a constant arithmetic expression resulted in an error.")
-    val Unused                 = LintWarning("unused",                    "Enable -Wunused:imports,privates,locals,implicits.")
+    val Unused                 = LintWarning("unused",                    "Enable -Wunused:imports,privates,locals,implicits,nowarn.")
     val NonlocalReturn         = LintWarning("nonlocal-return",           "A return statement used an exception for flow control.")
     val ImplicitNotFound       = LintWarning("implicit-not-found",        "Check @implicitNotFound and @implicitAmbiguous messages.")
     val Serial                 = LintWarning("serial",                    "@SerialVersionUID on traits and non-serializable classes.")

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -38,8 +38,8 @@ trait Warnings {
          |Syntax: -Wconf:<filters>:<action>,<filters>:<action>,...
          |multiple <filters> are combined with &, i.e., <filter>&...&<filter>
          |
-         |Note: Run with `-Wconf:any:warning-verbose` to cause warnings to be printed with their
-         |category, site, and (for deprecations) origin and since-version.
+         |Note: Run with `-Wconf:any:warning-verbose` to print warnings with their category, site,
+         |and (for deprecations) origin and since-version.
          |
          |<filter>
          |  - Any message: any
@@ -51,7 +51,7 @@ trait Warnings {
          |    The regex need only match some part of the message, not all of it.
          |
          |  - Site where the warning is triggered: site=my\\.package\\..*
-         |    The regex must match the full name of the warning position.
+         |    The regex must match the full name (`package.Class.method`) of the warning position.
          |
          |  - Source file name: src=src_managed/.*
          |    If `-rootdir` is specified, the regex must match the canonical path relative to the
@@ -60,7 +60,7 @@ trait Warnings {
          |    Use unix-style paths, separated by `/`.
          |
          |  - Origin of deprecation: origin=external\\.package\\..*
-         |    The regex must match the full name of the deprecated entity.
+         |    The regex must match the full name (`package.Class.method`) of the deprecated entity.
          |
          |  - Since of deprecation: since<1.24
          |    Valid operators: <, =, >, valid versions: N, N.M, N.M.P. Compares against the first
@@ -70,9 +70,9 @@ trait Warnings {
          |<action>
          |  - error / e
          |  - warning / w
-         |  - warning-summary / ws
+         |  - warning-summary / ws (summary with the number of warnings, like for deprecations)
          |  - warning-verbose / wv (show warning category and site)
-         |  - info / i
+         |  - info / i             (infos are not counted as warnings and don't affect `-Werror`)
          |  - info-summary / is
          |  - info-verbose / iv
          |  - silent / s

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -90,6 +90,8 @@ trait Warnings {
          |Full list of message categories:
          |${WarningCategory.all.keys.groupBy(_.split('-').head).toList.sortBy(_._1).map(_._2.toList.sorted.mkString(", ")).mkString(" - ", "\n - ", "")}
          |
+         |To suppress warnings locally, use the `scala.annotation.nowarn` annotation.
+         |
          |Note: on the command-line you might need to quote configurations containing `*` or `&`
          |to prevent the shell from expanding patterns.""".stripMargin),
     prepend = true)
@@ -121,8 +123,9 @@ trait Warnings {
     val Locals    = Choice("locals",    "Warn if a local definition is unused.")
     val Explicits = Choice("explicits", "Warn if an explicit parameter is unused.")
     val Implicits = Choice("implicits", "Warn if an implicit parameter is unused.")
+    val Nowarn    = Choice("nowarn",    "Warn if a @nowarn annotation does not suppress any warnings.")
     val Params    = Choice("params",    "Enable -Wunused:explicits,implicits.", expandsTo = List(Explicits, Implicits))
-    val Linted    = Choice("linted",    "-Xlint:unused.", expandsTo = List(Imports, Privates, Locals, Implicits))
+    val Linted    = Choice("linted",    "-Xlint:unused.", expandsTo = List(Imports, Privates, Locals, Implicits, Nowarn))
   }
 
   // The -Ywarn-unused warning group.
@@ -141,6 +144,7 @@ trait Warnings {
   def warnUnusedParams    = warnUnusedExplicits || warnUnusedImplicits
   def warnUnusedExplicits = warnUnused contains UnusedWarnings.Explicits
   def warnUnusedImplicits = warnUnused contains UnusedWarnings.Implicits
+  def warnUnusedNowarn    = warnUnused contains UnusedWarnings.Nowarn
 
   val warnExtraImplicit   = BooleanSetting("-Wextra-implicit", "Warn when more than one implicit parameter section is defined.") withAbbreviation "-Ywarn-extra-implicit"
 

--- a/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
@@ -13,6 +13,7 @@
 package scala.tools.nsc
 package symtab
 
+import scala.tools.nsc.Reporting.WarningCategory
 import scala.tools.nsc.io.AbstractFile
 
 /** A subclass of SymbolLoaders that implements browsing behavior.
@@ -119,7 +120,7 @@ abstract class BrowsingLoaders extends GlobalSymbolLoaders {
     val browser = new BrowserTraverser
     browser.traverse(body)
     if (browser.entered == 0)
-      warning("No classes or objects found in "+source+" that go in "+root)
+      runReporting.warning(NoPosition, "No classes or objects found in "+source+" that go in "+root, WarningCategory.OtherDebug, site = "")
   }
 
   /** Enter top-level symbols from a source file

--- a/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
@@ -53,7 +53,7 @@ abstract class BrowsingLoaders extends GlobalSymbolLoaders {
         val memberSourceFile = member.sourceFile
         if (memberSourceFile != null) {
           if (existingSourceFile != memberSourceFile)
-            error(""+member+"is defined twice,"+
+            globalError(""+member+"is defined twice,"+
               "\n in "+existingSourceFile+
               "\n and also in "+memberSourceFile)
         }

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -15,10 +15,12 @@ package symtab
 
 import classfile.{ClassfileParser, ReusableDataReader}
 import java.io.IOException
+
 import scala.reflect.internal.MissingRequirementError
 import scala.reflect.io.{AbstractFile, NoAbstractFile}
 import scala.tools.nsc.util.{ClassPath, ClassRepresentation}
 import scala.reflect.internal.util.{ReusableInstance, StatisticsStatics}
+import scala.tools.nsc.Reporting.WarningCategory
 
 /** This class ...
  *
@@ -44,6 +46,9 @@ abstract class SymbolLoaders {
    * interface.
    */
   protected def compileLate(srcfile: AbstractFile): Unit
+
+  // forwards to runReporting.warning, but we don't have global in scope here
+  def warning(pos: Position, msg: String, category: WarningCategory, site: String): Unit
 
   protected def enterIfNew(owner: Symbol, member: Symbol, completer: SymbolLoader): Symbol = {
     assert(owner.info.decls.lookup(member.name) == NoSymbol, owner.fullName + "." + member.name)
@@ -104,16 +109,20 @@ abstract class SymbolLoaders {
         )
       else if (settings.termConflict.value == "package") {
         warning(
+          NoPosition,
           "Resolving package/object name conflict in favor of package " +
-          preExisting.fullName + ".  The object will be inaccessible."
-        )
+          preExisting.fullName + ".  The object will be inaccessible.",
+          WarningCategory.Other,
+          site = "")
         root.info.decls.unlink(preExisting)
       }
       else {
         warning(
+          NoPosition,
           "Resolving package/object name conflict in favor of object " +
-          preExisting.fullName + ".  The package will be inaccessible."
-        )
+          preExisting.fullName + ".  The package will be inaccessible.",
+          WarningCategory.Other,
+          site = "")
         return NoSymbol
       }
     }

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -25,6 +25,7 @@ import scala.reflect.internal.JavaAccFlags
 import scala.reflect.internal.pickling.ByteCodecs
 import scala.reflect.internal.util.ReusableInstance
 import scala.reflect.io.NoAbstractFile
+import scala.tools.nsc.Reporting.WarningCategory
 import scala.tools.nsc.util.ClassPath
 import scala.tools.nsc.io.AbstractFile
 import scala.util.control.NonFatal
@@ -406,7 +407,7 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
     //   - better owner than `NoSymbol`
     //   - remove eager warning
     val msg = s"Class $name not found - continuing with a stub."
-    if ((!settings.isScaladoc) && (settings.verbose || settings.developer)) warning(msg)
+    if ((!settings.isScaladoc) && (settings.verbose || settings.developer)) loaders.warning(NoPosition, msg, WarningCategory.OtherDebug, clazz.fullNameString)
     NoSymbol.newStubSymbol(name.toTypeName, msg)
   }
 
@@ -935,10 +936,12 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
         val s = module.info.decls.lookup(n)
         if (s != NoSymbol) Some(LiteralAnnotArg(Constant(s)))
         else {
-          warning(
+          loaders.warning(
+            NoPosition,
             sm"""While parsing annotations in ${file}, could not find $n in enum ${module.nameString}.
-                |This is likely due to an implementation restriction: an annotation argument cannot refer to a member of the annotated class (scala/bug#7014)."""
-          )
+                |This is likely due to an implementation restriction: an annotation argument cannot refer to a member of the annotated class (scala/bug#7014).""",
+            WarningCategory.Other,
+            clazz.fullNameString)
           None
         }
 
@@ -985,7 +988,7 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
       // the classpath would *not* end up here. A class not found is signaled
       // with a `FatalError` exception, handled above. Here you'd end up after a NPE (for example),
       // and that should never be swallowed silently.
-      warning(s"Caught: $ex while parsing annotations in ${file}")
+      loaders.warning(NoPosition, s"Caught: $ex while parsing annotations in ${file}", WarningCategory.Other, clazz.fullNameString)
       if (settings.debug) ex.printStackTrace()
       None // ignore malformed annotations
   }

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -16,6 +16,7 @@ package transform
 import symtab._
 import Flags._
 import scala.collection._
+import scala.tools.nsc.Reporting.WarningCategory
 
 abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
   import global._
@@ -334,11 +335,17 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
               assert(params.length == mparams.length, ((params, mparams)))
               (mparams, resType)
             case tpe @ OverloadedType(pre, alts) =>
-              reporter.warning(ad.pos, s"Overloaded type reached the backend! This is a bug in scalac.\n     Symbol: ${ad.symbol}\n  Overloads: $tpe\n  Arguments: " + ad.args.map(_.tpe))
+              runReporting.warning(ad.pos,
+                s"Overloaded type reached the backend! This is a bug in scalac.\n     Symbol: ${ad.symbol}\n  Overloads: $tpe\n  Arguments: " + ad.args.map(_.tpe),
+                WarningCategory.Other,
+                currentOwner)
               val fittingAlts = alts collect { case alt if sumSize(alt.paramss, 0) == params.length => alt.tpe }
               fittingAlts match {
                 case mt @ MethodType(mparams, resType) :: Nil =>
-                  reporter.warning(NoPosition, "Only one overload has the right arity, proceeding with overload " + mt)
+                  runReporting.warning(ad.pos,
+                    "Only one overload has the right arity, proceeding with overload " + mt,
+                    WarningCategory.Other,
+                    currentOwner)
                   (mparams, resType)
                 case _ =>
                   reporter.error(ad.pos, "Cannot resolve overload.")

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -15,6 +15,7 @@ package transform
 
 import scala.collection.mutable
 import scala.reflect.internal.util.ListOfNil
+import scala.tools.nsc.Reporting.WarningCategory
 import symtab.Flags._
 
 /** This phase converts classes with parameters into Java-like classes with
@@ -60,7 +61,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
         def check(tree: Tree) = {
           for (t <- tree) t match {
             case t: RefTree if uninitializedVals(t.symbol.accessedOrSelf) && t.qualifier.symbol == clazz =>
-              reporter.warning(t.pos, s"Reference to uninitialized ${t.symbol.accessedOrSelf}")
+              runReporting.warning(t.pos, s"Reference to uninitialized ${t.symbol.accessedOrSelf}", WarningCategory.Other, t.symbol)
             case _ =>
           }
         }

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -18,6 +18,7 @@ import symtab._
 import Flags.{CASE => _, _}
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
+import scala.tools.nsc.Reporting.WarningCategory
 
 /** This class ...
  *
@@ -475,7 +476,7 @@ abstract class ExplicitOuter extends InfoTransform
               // at least don't crash... this duplicates maybeOmittable from constructors
               (acc.owner.isEffectivelyFinal && !acc.isOverridingSymbol)) {
             if (!base.tpe.hasAnnotation(UncheckedClass))
-              currentRun.reporting.uncheckedWarning(tree.pos, "The outer reference in this type test cannot be checked at run time.")
+              runReporting.warning(tree.pos, "The outer reference in this type test cannot be checked at run time.", WarningCategory.Unchecked, currentOwner)
             transform(TRUE) // urgh... drop condition if there's no accessor (or if it may disappear after constructors)
           } else {
             // println("(base, acc)= "+(base, acc))

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -746,7 +746,11 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
           if (settings.unitSpecialization && m.isPrimaryConstructor && specCtor.paramLists.exists(_.exists(_.tpe =:= UnitTpe)))
             m.paramLists.flatten.zip(specCtor.paramLists.flatten).foreach {
               case (orig, spec) if spec.tpe =:= UnitTpe && m.enclClass.typeParams.contains(orig.tpe.typeSymbol) =>
-                reporter.warning(m.pos, "Fruitless specialization of Unit in parameter position. Consider using `@specialized(Specializable.Arg)` instead.")
+                runReporting.warning(
+                  m.pos,
+                  "Fruitless specialization of Unit in parameter position. Consider using `@specialized(Specializable.Arg)` instead.",
+                  WarningCategory.LintUnitSpecialization,
+                  m)
               case _ =>
             }
           info(specCtor) = Forward(m)

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -16,6 +16,7 @@ package transform
 
 import scala.collection.mutable
 import scala.tools.nsc.symtab.Flags
+import scala.tools.nsc.Reporting.WarningCategory
 
 /** Specialize code on types.
  *
@@ -412,7 +413,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       specializedOn(sym).map(s => specializesClass(s).tpe).sorted
 
     if (isBoundedGeneric(sym.tpe) && (types contains AnyRefTpe))
-      reporter.warning(sym.pos, s"$sym is always a subtype of $AnyRefTpe.")
+      runReporting.warning(sym.pos, s"$sym is always a subtype of $AnyRefTpe.", WarningCategory.Other, sym)
 
     types
   }
@@ -656,7 +657,10 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
               if (p.typeSymbol.isTrait) res ::= stp
               else if (currentRun.compiles(clazz))
                 // TODO change to error
-                reporter.warning(clazz.pos, s"${p.typeSymbol} must be a trait. Specialized version of $clazz will inherit generic $p")
+                runReporting.warning(clazz.pos,
+                  s"${p.typeSymbol} must be a trait. Specialized version of $clazz will inherit generic $p",
+                  WarningCategory.Other,
+                  clazz)
           }
           res
         }
@@ -922,11 +926,12 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
         // their type parameters are used in non-specializable positions.  Why is
         // unusedStvars.nonEmpty for these classes???
         if (unusedStvars.nonEmpty && currentRun.compiles(sym) && !sym.isSynthetic) {
-          reporter.warning(sym.pos,
+          runReporting.warning(sym.pos,
             "%s %s unused or used in non-specializable positions.".format(
               unusedStvars.mkString("", ", ", ""),
-              if (unusedStvars.lengthIs == 1) "is" else "are")
-          )
+              if (unusedStvars.lengthIs == 1) "is" else "are"),
+            WarningCategory.Other,
+            sym)
           unusedStvars foreach (_ removeAnnotation SpecializedClass)
           specializingOn = specializingOn filterNot (unusedStvars contains _)
         }
@@ -1327,7 +1332,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     env forall { case (tvar, tpe) =>
       matches(tvar.info.lowerBound, tpe) && matches(tpe, tvar.info.upperBound) || {
         if (warnings)
-          reporter.warning(tvar.pos, s"Bounds prevent specialization of $tvar")
+          runReporting.warning(tvar.pos, s"Bounds prevent specialization of $tvar", WarningCategory.Other, tvar)
 
         debuglog("specvars: " +
           tvar.info.lowerBound + ": " +

--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -19,7 +19,7 @@ import scala.reflect.internal.util.Collections._
 import scala.reflect.internal.util.{HashSet, NoPosition, Position, StatisticsStatics}
 
 trait Logic extends Debugging  {
-  import global.statistics
+  import global._
 
   private def max(xs: Seq[Int]) = if (xs.isEmpty) 0 else xs.max
   private def alignedColumns(cols: Seq[Any]): Seq[String] = {
@@ -77,7 +77,7 @@ trait Logic extends Debugging  {
       def unapply(v: Var): Some[Tree]
     }
 
-    def uncheckedWarning(pos: Position, msg: String): Unit
+    def uncheckedWarning(pos: Position, msg: String, site: Symbol): Unit
 
     def reportWarning(message: String): Unit
 
@@ -498,7 +498,7 @@ trait Logic extends Debugging  {
 
     def findModelFor(solvable: Solvable): Model
 
-    def findAllModelsFor(solvable: Solvable, pos: Position = NoPosition): List[Solution]
+    def findAllModelsFor(solvable: Solvable, sym: Symbol = NoSymbol): List[Solution]
   }
 }
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -15,6 +15,7 @@ package scala.tools.nsc.transform.patmat
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.reflect.internal.util.StatisticsStatics
+import scala.tools.nsc.Reporting.WarningCategory
 
 trait TreeAndTypeAnalysis extends Debugging {
   import global._
@@ -422,9 +423,9 @@ trait MatchAnalysis extends MatchApproximation {
   import global.definitions._
 
   trait MatchAnalyzer extends MatchApproximator  {
-    def uncheckedWarning(pos: Position, msg: String) = currentRun.reporting.uncheckedWarning(pos, msg)
-    def warn(pos: Position, ex: AnalysisBudget.Exception, kind: String) = uncheckedWarning(pos, s"Cannot check match for $kind.\n${ex.advice}")
-    def reportWarning(message: String) = global.reporter.warning(typer.context.tree.pos, message)
+    def uncheckedWarning(pos: Position, msg: String, site: Symbol) = runReporting.warning(pos, msg, WarningCategory.Unchecked, site)
+    def warn(pos: Position, ex: AnalysisBudget.Exception, kind: String, site: Symbol) = uncheckedWarning(pos, s"Cannot check match for $kind.\n${ex.advice}", site)
+    def reportWarning(message: String) = typer.context.warning(typer.context.tree.pos, message, WarningCategory.OtherMatchAnalysis)
 
   // TODO: model dependencies between variables: if V1 corresponds to (x: List[_]) and V2 is (x.hd), V2 cannot be assigned when V1 = null or V1 = Nil
     // right now hackily implement this by pruning counter-examples
@@ -495,7 +496,7 @@ trait MatchAnalysis extends MatchApproximation {
         if (reachable) None else Some(caseIndex)
       } catch {
         case ex: AnalysisBudget.Exception =>
-          warn(prevBinder.pos, ex, "unreachability")
+          warn(prevBinder.pos, ex, "unreachability", prevBinder)
           None // CNF budget exceeded
       }
     }
@@ -547,7 +548,7 @@ trait MatchAnalysis extends MatchApproximation {
 
         try {
           // find the models (under which the match fails)
-          val matchFailModels = findAllModelsFor(propToSolvable(matchFails), prevBinder.pos)
+          val matchFailModels = findAllModelsFor(propToSolvable(matchFails), prevBinder)
 
           val scrutVar = Var(prevBinderTree)
           val counterExamples = {
@@ -567,7 +568,7 @@ trait MatchAnalysis extends MatchApproximation {
           pruned
         } catch {
           case ex: AnalysisBudget.Exception =>
-            warn(prevBinder.pos, ex, "exhaustivity")
+            warn(prevBinder.pos, ex, "exhaustivity", prevBinder)
             Nil // CNF budget exceeded
         }
       }

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -15,6 +15,7 @@ package scala.tools.nsc.transform.patmat
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.tools.nsc.symtab.Flags.{MUTABLE, STABLE}
+import scala.tools.nsc.Reporting.WarningCategory
 
 /** Optimize and analyze matches based on their TreeMaker-representation.
  *
@@ -449,7 +450,9 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
                   val distinctAlts = distinctBy(switchableAlts)(extractConst)
                   if (distinctAlts.size < switchableAlts.size) {
                     val duplicated = switchableAlts.groupBy(extractConst).flatMap(_._2.drop(1).take(1)) // report the first duplicated
-                    reporter.warning(pos, s"Pattern contains duplicate alternatives: ${duplicated.mkString(", ")}")
+                    typer.context.warning(pos,
+                      s"Pattern contains duplicate alternatives: ${duplicated.mkString(", ")}",
+                      WarningCategory.OtherMatchAnalysis)
                   }
                   CaseDef(Alternative(distinctAlts), guard, body)
                 }

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -15,6 +15,7 @@ package scala.tools.nsc.transform.patmat
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.tools.nsc.symtab.Flags.{SYNTHETIC, ARTIFACT}
+import scala.tools.nsc.Reporting.WarningCategory
 
 /** Translate our IR (TreeMakers) into actual Scala Trees using the factory methods in MatchCodeGen.
  *
@@ -629,7 +630,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
           }
 
         emitSwitch(scrut, scrutSym, casesNoSubstOnly, pt, matchFailGenOverride, unchecked = suppression.suppressExhaustive).getOrElse{
-          if (requireSwitch) reporter.warning(scrut.pos, "could not emit switch for @switch annotated match")
+          if (requireSwitch) typer.context.warning(scrut.pos, "could not emit switch for @switch annotated match", WarningCategory.OtherMatchAnalysis)
 
           if (!casesNoSubstOnly.isEmpty) {
             // before optimizing, check casesNoSubstOnly for presence of a default case,

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchWarnings.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchWarnings.scala
@@ -12,6 +12,8 @@
 
 package scala.tools.nsc.transform.patmat
 
+import scala.tools.nsc.Reporting.WarningCategory
+
 trait MatchWarnings {
   self: PatternMatching =>
 
@@ -69,7 +71,7 @@ trait MatchWarnings {
         val cdef = it.next()
         // If a default case has been seen, then every succeeding case is unreachable.
         if (vpat != null)
-          reporter.warning(cdef.body.pos, "unreachable code due to " + vpat + addendum(cdef.pat)) // TODO: make configurable whether this is an error
+          typer.context.warning(cdef.body.pos, "unreachable code due to " + vpat + addendum(cdef.pat), WarningCategory.OtherMatchAnalysis) // TODO: make configurable whether this is an error
         // If this is a default case and more cases follow, warn about this one so
         // we have a reason to mention its pattern variable name and any corresponding
         // symbol in scope.  Errors will follow from the remaining cases, at least
@@ -80,7 +82,7 @@ trait MatchWarnings {
             case _               => ""
           }
           vpat = s"variable pattern$vpatName on line ${cdef.pat.pos.line}"
-          reporter.warning(cdef.pos, s"patterns after a variable pattern cannot match (SLS 8.1.1)" + addendum(cdef.pat))
+          typer.context.warning(cdef.pos, s"patterns after a variable pattern cannot match (SLS 8.1.1)" + addendum(cdef.pat), WarningCategory.OtherMatchAnalysis)
         }
       }
     }

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -19,6 +19,7 @@ import scala.reflect.internal.util.Statistics
 import scala.tools.nsc.Global
 import scala.tools.nsc.ast
 import scala.tools.nsc.transform.{Transform, TypingTransformers}
+import scala.tools.nsc.Reporting.WarningCategory
 
 /** Translate pattern matching.
   *
@@ -186,13 +187,13 @@ trait Interface extends ast.TreeDSL {
     val matchOwner = typer.context.owner
     def pureType(tp: Type): Type = tp
 
-    def reportUnreachable(pos: Position) = reporter.warning(pos, "unreachable code")
+    def reportUnreachable(pos: Position) = typer.context.warning(pos, "unreachable code", WarningCategory.OtherMatchAnalysis)
     def reportMissingCases(pos: Position, counterExamples: List[String]) = {
       val ceString =
         if (counterExamples.tail.isEmpty) "input: " + counterExamples.head
         else "inputs: " + counterExamples.mkString(", ")
 
-      reporter.warning(pos, "match may not be exhaustive.\nIt would fail on the following "+ ceString)
+      typer.context.warning(pos, "match may not be exhaustive.\nIt would fail on the following "+ ceString, WarningCategory.OtherMatchAnalysis)
     }
   }
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
@@ -45,7 +45,7 @@ object Lit {
 /** Solve pattern matcher exhaustivity problem via DPLL.
  */
 trait Solving extends Logic {
-  import global.statistics
+  import global._
 
   trait CNF extends PropositionalLogic {
 
@@ -423,7 +423,7 @@ trait Solving extends Logic {
     val NoTseitinModel: TseitinModel = null
 
     // returns all solutions, if any (TODO: better infinite recursion backstop -- detect fixpoint??)
-    def findAllModelsFor(solvable: Solvable, pos: Position): List[Solution] = {
+    def findAllModelsFor(solvable: Solvable, owner: Symbol): List[Solution] = {
       debug.patmat("find all models for\n"+ cnfString(solvable.cnf))
 
       // we must take all vars from non simplified formula
@@ -449,7 +449,7 @@ trait Solving extends Logic {
                         models: List[TseitinSolution],
                         recursionDepthAllowed: Int = AnalysisBudget.maxDPLLdepth): List[TseitinSolution]=
         if (recursionDepthAllowed == 0) {
-          uncheckedWarning(pos, AnalysisBudget.recursionDepthReached)
+          uncheckedWarning(owner.pos, AnalysisBudget.recursionDepthReached, owner)
           models
         } else {
           debug.patmat("find all models for\n" + cnfString(clauses))

--- a/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
@@ -13,6 +13,8 @@
 package scala.tools.nsc
 package typechecker
 
+import scala.tools.nsc.Reporting.WarningCategory
+
 /** This trait provides logic for assessing the validity of argument
  *  adaptations, such as tupling, unit-insertion, widening, etc.  Such
  *  logic is spread around the compiler, without much ability on the
@@ -87,8 +89,8 @@ trait Adaptations {
       }
       @inline def warnAdaptation = {
         if (settings.warnAdaptedArgs) context.warning(t.pos, adaptWarningMessage(
-          s"adapted the argument list to the expected ${args.size}-tuple: add additional parens instead"
-        ))
+          s"adapted the argument list to the expected ${args.size}-tuple: add additional parens instead"),
+          WarningCategory.LintAdaptedArgs)
         true // keep adaptation
       }
       if (args.isEmpty) {

--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -109,6 +109,7 @@ trait Analyzer extends AnyRef
         // defensive measure in case the bookkeeping in deferred macro expansion is buggy
         clearDelayed()
         if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(statistics.typerNanos, start)
+        runReporting.reportSuspendedMessages()
       }
       def apply(unit: CompilationUnit): Unit = {
         try {

--- a/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
@@ -16,6 +16,8 @@ package typechecker
 
 import java.lang.ArithmeticException
 
+import scala.tools.nsc.Reporting.WarningCategory
+
 /** This class ...
  *
  *  @author Martin Odersky
@@ -53,7 +55,7 @@ abstract class ConstantFolder {
     }
 
   /** If tree is a constant operation, replace with result. */
-  def apply(tree: Tree): Tree = {
+  def apply(tree: Tree, site: Symbol): Tree = {
     try {
       tree match {
         case Apply(Select(FoldableTerm(x), op), List(FoldableTerm(y))) => fold(tree, foldBinop(op, x, y), true)
@@ -65,7 +67,7 @@ abstract class ConstantFolder {
     } catch {
       case e: ArithmeticException =>
         if (settings.warnConstant)
-          warning(tree.pos, s"Evaluation of a constant expression results in an arithmetic error: ${e.getMessage}")
+          runReporting.warning(tree.pos, s"Evaluation of a constant expression results in an arithmetic error: ${e.getMessage}", WarningCategory.LintConstant, site)
         tree
     }
   }
@@ -73,8 +75,8 @@ abstract class ConstantFolder {
   /** If tree is a constant value that can be converted to type `pt`, perform
    *  the conversion.
    */
-  def apply(tree: Tree, pt: Type): Tree = {
-    val orig = apply(tree)
+  def apply(tree: Tree, pt: Type, site: Symbol): Tree = {
+    val orig = apply(tree, site)
     orig.tpe match {
       case tp@ConstantType(x) => fold(orig, x convertTo pt, isConstantType(tp))
       case _ => orig

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -785,6 +785,7 @@ trait Contexts { self: Analyzer =>
     }
 
 
+    // TODO: buffer deprecations under silent (route through ContextReporter, store in BufferingReporter)
     def deprecationWarning(pos: Position, sym: Symbol, msg: String, since: String): Unit =
       runReporting.deprecationWarning(fixPosition(pos), sym, owner, msg, since)
     def deprecationWarning(pos: Position, sym: Symbol): Unit =

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -17,6 +17,7 @@ import scala.annotation.tailrec
 import scala.collection.{immutable, mutable}
 import scala.reflect.internal.util.{ReusableInstance, shortClassOfInstance, ListOfNil, SomeOfNil}
 import scala.util.chaining._
+import scala.tools.nsc.Reporting.WarningCategory
 
 /**
  *  @author  Martin Odersky
@@ -66,16 +67,16 @@ trait Contexts { self: Analyzer =>
   private lazy val allUsedSelectors =
     mutable.Map[ImportInfo, Set[ImportSelector]]() withDefaultValue Set()
   private lazy val allImportInfos =
-    mutable.Map[CompilationUnit, List[ImportInfo]]() withDefaultValue Nil
+    mutable.Map[CompilationUnit, List[(ImportInfo, Symbol)]]() withDefaultValue Nil
 
   def warnUnusedImports(unit: CompilationUnit) = if (!unit.isJava) {
     for (imps <- allImportInfos.remove(unit)) {
-      for (imp <- imps.distinct.reverse) {
+      for ((imp, owner) <- imps.distinct.reverse) {
         val used = allUsedSelectors(imp)
         for (sel <- imp.tree.selectors if !sel.isMask && !used(sel))
-          reporter.warning(imp.posOf(sel), "Unused import")
+          runReporting.warning(imp.posOf(sel), "Unused import", WarningCategory.UnusedImports, site = owner)
       }
-      allUsedSelectors --= imps
+      allUsedSelectors --= imps.iterator.map(_._1)
     }
   }
 
@@ -775,7 +776,8 @@ trait Contexts { self: Analyzer =>
     /** Issue/throw the given error message according to the current mode for error reporting. */
     def error(pos: Position, msg: String)                                    = reporter.error(fixPosition(pos), msg)
     /** Issue/throw the given error message according to the current mode for error reporting. */
-    def warning(pos: Position, msg: String)                                  = reporter.warning(fixPosition(pos), msg)
+    def warning(pos: Position, msg: String, category: WarningCategory)       = reporter.warning(fixPosition(pos), msg, category, owner)
+    def warning(pos: Position, msg: String, category: WarningCategory, site: Symbol) = reporter.warning(fixPosition(pos), msg, category, site)
     def echo(pos: Position, msg: String)                                     = reporter.echo(fixPosition(pos), msg)
     def fixPosition(pos: Position): Position = pos match {
       case NoPosition => nextEnclosing(_.tree.pos != NoPosition).tree.pos
@@ -784,12 +786,12 @@ trait Contexts { self: Analyzer =>
 
 
     def deprecationWarning(pos: Position, sym: Symbol, msg: String, since: String): Unit =
-      currentRun.reporting.deprecationWarning(fixPosition(pos), sym, msg, since)
+      runReporting.deprecationWarning(fixPosition(pos), sym, owner, msg, since)
     def deprecationWarning(pos: Position, sym: Symbol): Unit =
-      currentRun.reporting.deprecationWarning(fixPosition(pos), sym) // TODO: allow this to escalate to an error, and implicit search will ignore deprecated implicits
+      runReporting.deprecationWarning(fixPosition(pos), sym, owner) // TODO: allow this to escalate to an error, and implicit search will ignore deprecated implicits
 
     def featureWarning(pos: Position, featureName: String, featureDesc: String, featureTrait: Symbol, construct: => String = "", required: Boolean): Unit =
-      currentRun.reporting.featureWarning(fixPosition(pos), featureName, featureDesc, featureTrait, construct, required)
+      runReporting.featureWarning(fixPosition(pos), featureName, featureDesc, featureTrait, construct, required, owner)
 
 
     @tailrec
@@ -1568,7 +1570,7 @@ trait Contexts { self: Analyzer =>
     private[this] val impInfo: ImportInfo = {
       val info = new ImportInfo(tree.asInstanceOf[Import], outerDepth, isRootImport)
       if (settings.warnUnusedImport && openMacros.isEmpty && !isRootImport) // excludes java.lang/scala/Predef imports
-        allImportInfos(unit) ::= info
+        allImportInfos(unit) ::= (info, owner)
       info
     }
     override final def imports      = impInfo :: super.imports
@@ -1589,15 +1591,20 @@ trait Contexts { self: Analyzer =>
    *
    *  To handle nested contexts, reporters share buffers. TODO: only buffer in BufferingReporter, emit immediately in ImmediateReporter
    */
-  abstract class ContextReporter(private[this] var _errorBuffer: mutable.LinkedHashSet[AbsTypeError] = null, private[this] var _warningBuffer: mutable.LinkedHashSet[(Position, String)] = null) {
+  abstract class ContextReporter(private[this] var _errorBuffer: mutable.LinkedHashSet[AbsTypeError] = null, private[this] var _warningBuffer: mutable.LinkedHashSet[(Position, String, WarningCategory, Symbol)] = null) {
     type Error = AbsTypeError
-    type Warning = (Position, String)
+    type Warning = (Position, String, WarningCategory, Symbol)
 
     def issue(err: AbsTypeError)(implicit context: Context): Unit = error(context.fixPosition(err.errPos), addDiagString(err.errMsg))
 
-    def echo(msg: String): Unit                   = echo(NoPosition, msg)
-    def echo(pos: Position, msg: String): Unit    = reporter.echo(pos, msg)
-    def warning(pos: Position, msg: String): Unit = reporter.warning(pos, msg)
+    def echo(msg: String): Unit = echo(NoPosition, msg)
+
+    def echo(pos: Position, msg: String): Unit =
+      reporter.echo(pos, msg)
+
+    def warning(pos: Position, msg: String, category: WarningCategory, site: Symbol): Unit =
+      runReporting.warning(pos, msg, category, site)
+
     def error(pos: Position, msg: String): Unit
 
     protected def handleSuppressedAmbiguous(err: AbsAmbiguousTypeError): Unit = ()
@@ -1691,7 +1698,7 @@ trait Contexts { self: Analyzer =>
 
     final def emitWarnings() = if (_warningBuffer != null) {
       _warningBuffer foreach {
-        case (pos, msg) => reporter.warning(pos, msg)
+        case (pos, msg, category, site) => runReporting.warning(pos, msg, category, site)
       }
       _warningBuffer = null
     }
@@ -1715,20 +1722,22 @@ trait Contexts { self: Analyzer =>
     final def clearAllErrors(): Unit = { _errorBuffer = null }
   }
 
-  private[typechecker] class ImmediateReporter(_errorBuffer: mutable.LinkedHashSet[AbsTypeError] = null, _warningBuffer: mutable.LinkedHashSet[(Position, String)] = null) extends ContextReporter(_errorBuffer, _warningBuffer) {
+  private[typechecker] class ImmediateReporter(_errorBuffer: mutable.LinkedHashSet[AbsTypeError] = null, _warningBuffer: mutable.LinkedHashSet[(Position, String, WarningCategory, Symbol)] = null) extends ContextReporter(_errorBuffer, _warningBuffer) {
     override def makeBuffering: ContextReporter = new BufferingReporter(errorBuffer, warningBuffer)
     def error(pos: Position, msg: String): Unit = reporter.error(pos, msg)
  }
 
-  private[typechecker] class BufferingReporter(_errorBuffer: mutable.LinkedHashSet[AbsTypeError] = null, _warningBuffer: mutable.LinkedHashSet[(Position, String)] = null) extends ContextReporter(_errorBuffer, _warningBuffer) {
+  private[typechecker] class BufferingReporter(_errorBuffer: mutable.LinkedHashSet[AbsTypeError] = null, _warningBuffer: mutable.LinkedHashSet[(Position, String, WarningCategory, Symbol)] = null) extends ContextReporter(_errorBuffer, _warningBuffer) {
     override def isBuffering = true
 
     override def issue(err: AbsTypeError)(implicit context: Context): Unit             = errorBuffer += err
 
     // this used to throw new TypeError(pos, msg) -- buffering lets us report more errors (test/files/neg/macro-basic-mamdmi)
     // the old throwing behavior was relied on by diagnostics in manifestOfType
-    def error(pos: Position, msg: String): Unit                        = errorBuffer += TypeErrorWrapper(new TypeError(pos, msg))
-    override def warning(pos: Position, msg: String): Unit             = warningBuffer += ((pos, msg))
+    def error(pos: Position, msg: String): Unit = errorBuffer += TypeErrorWrapper(new TypeError(pos, msg))
+
+    override def warning(pos: Position, msg: String, category: WarningCategory, site: Symbol): Unit =
+      warningBuffer += ((pos, msg, category, site))
 
     override protected def handleSuppressedAmbiguous(err: AbsAmbiguousTypeError): Unit = errorBuffer += err
 

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -129,7 +129,7 @@ trait Contexts { self: Analyzer =>
           getModuleIfDefined(s) orElse
           getPackageObjectIfDefined(s) orElse
           getPackageIfDefined(s) orElse {
-            error(s"bad preamble import $s")
+            globalError(s"bad preamble import $s")
             NoSymbol
           }
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -133,7 +133,7 @@ trait Implicits {
         else if (result.tree.symbol.isModule) result.tree.symbol.moduleClass
         else result.tree.symbol
       if (s != NoSymbol && context.owner.hasTransOwner(s))
-        context.warning(result.tree.pos, s"Implicit resolves to enclosing ${result.tree.symbol}", WarningCategory.Other)
+        context.warning(result.tree.pos, s"Implicit resolves to enclosing ${result.tree.symbol}", WarningCategory.WFlagSelfImplicit)
     }
     implicitSearchContext.emitImplicitDictionary(result)
   }

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -27,6 +27,7 @@ import symtab.Flags._
 import scala.reflect.internal.util.{ReusableInstance, Statistics, StatisticsStatics, TriState}
 import scala.reflect.internal.TypesStats
 import scala.language.implicitConversions
+import scala.tools.nsc.Reporting.WarningCategory
 
 /** This trait provides methods to find various kinds of implicits.
  *
@@ -132,7 +133,7 @@ trait Implicits {
         else if (result.tree.symbol.isModule) result.tree.symbol.moduleClass
         else result.tree.symbol
       if (s != NoSymbol && context.owner.hasTransOwner(s))
-        context.warning(result.tree.pos, s"Implicit resolves to enclosing ${result.tree.symbol}")
+        context.warning(result.tree.pos, s"Implicit resolves to enclosing ${result.tree.symbol}", WarningCategory.Other)
     }
     implicitSearchContext.emitImplicitDictionary(result)
   }

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -17,6 +17,7 @@ import scala.collection.{immutable, mutable}, mutable.ListBuffer
 import scala.reflect.internal.Depth
 import scala.util.control.ControlThrowable
 import symtab.Flags._
+import scala.tools.nsc.Reporting.WarningCategory
 
 /** This trait contains methods related to type parameter inference.
  *
@@ -608,7 +609,7 @@ trait Infer extends Checkable {
           warning = !hasAny
         }
         def canWarnAboutAny = { if (!checked) checkForAny() ; warning }
-        targs.foreach(targ => if (topTypes.contains(targ.typeSymbol) && canWarnAboutAny) reporter.warning(fn.pos, s"a type was inferred to be `${targ.typeSymbol.name}`; this may indicate a programming error."))
+        targs.foreach(targ => if (topTypes.contains(targ.typeSymbol) && canWarnAboutAny) context.warning(fn.pos, s"a type was inferred to be `${targ.typeSymbol.name}`; this may indicate a programming error.", WarningCategory.Other))
       }
       adjustTypeArgs(tparams, tvars, targs, restpe)
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -609,7 +609,7 @@ trait Infer extends Checkable {
           warning = !hasAny
         }
         def canWarnAboutAny = { if (!checked) checkForAny() ; warning }
-        targs.foreach(targ => if (topTypes.contains(targ.typeSymbol) && canWarnAboutAny) context.warning(fn.pos, s"a type was inferred to be `${targ.typeSymbol.name}`; this may indicate a programming error.", WarningCategory.Other))
+        targs.foreach(targ => if (topTypes.contains(targ.typeSymbol) && canWarnAboutAny) context.warning(fn.pos, s"a type was inferred to be `${targ.typeSymbol.name}`; this may indicate a programming error.", WarningCategory.LintInferAny))
       }
       adjustTypeArgs(tparams, tvars, targs, restpe)
     }

--- a/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
@@ -12,6 +12,8 @@
 
 package scala.tools.nsc.typechecker
 
+import scala.tools.nsc.Reporting.WarningCategory
+
 // imported from scalamacros/paradise
 trait MacroAnnotationNamers { self: Analyzer =>
   import global._
@@ -241,10 +243,10 @@ trait MacroAnnotationNamers { self: Analyzer =>
             }
             val owner = tree.symbol.owner
             if (settings.warnPackageObjectClasses && owner.isPackageObjectClass && !mods.isImplicit) {
-              reporter.warning(tree.pos,
+              context.warning(tree.pos,
                                "it is not recommended to define classes/objects inside of package objects.\n" +
-                               "If possible, define " + tree.symbol + " in " + owner.skipPackageObject + " instead."
-                              )
+                               "If possible, define " + tree.symbol + " in " + owner.skipPackageObject + " instead.",
+                              WarningCategory.LintPackageObjectClasses)
             }
             // Suggested location only.
             if (mods.isImplicit) {

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -721,7 +721,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
 
   sealed abstract class MacroStatus(val result: Tree)
   case class Success(expanded: Tree) extends MacroStatus(expanded)
-  case class Fallback(fallback: Tree) extends MacroStatus(fallback) { currentRun.reporting.seenMacroExpansionsFallingBack = true }
+  case class Fallback(fallback: Tree) extends MacroStatus(fallback) { runReporting.seenMacroExpansionsFallingBack = true }
   case class Delayed(delayed: Tree) extends MacroStatus(delayed)
   case class Skipped(skipped: Tree) extends MacroStatus(skipped)
   case class Failure(failure: Tree) extends MacroStatus(failure)

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -17,6 +17,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import symtab.Flags._
 import scala.reflect.internal.util.ListOfNil
+import scala.tools.nsc.Reporting.WarningCategory
 
 /** This trait declares methods to create symbols and to enter them into scopes.
  *
@@ -808,10 +809,10 @@ trait Namers extends MethodSynthesis {
       }
       val owner = tree.symbol.owner
       if (settings.warnPackageObjectClasses && owner.isPackageObjectClass && !mods.isImplicit) {
-        reporter.warning(tree.pos,
+        context.warning(tree.pos,
           "it is not recommended to define classes/objects inside of package objects.\n" +
-          "If possible, define " + tree.symbol + " in " + owner.skipPackageObject + " instead."
-        )
+          "If possible, define " + tree.symbol + " in " + owner.skipPackageObject + " instead.",
+          WarningCategory.LintPackageObjectClasses)
       }
 
       // Suggested location only.

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -870,7 +870,7 @@ trait Namers extends MethodSynthesis {
         // on these flag checks so it can't hurt.
         def needsCycleCheck = sym.isNonClassType && !sym.isParameter && !sym.isExistential
 
-        val annotations = annotSig(tree.mods.annotations, _ => true)
+        val annotations = annotSig(tree.mods.annotations, tree, _ => true)
 
         val tp = typeSig(tree, annotations)
 
@@ -938,7 +938,7 @@ trait Namers extends MethodSynthesis {
             val pred: AnnotationInfo => Boolean =
               if (isGetter) accessorAnnotsFilter(tree.mods)
               else annotationFilter(FieldTargetClass, !mods.isParamAccessor)
-            annotSig(mods.annotations, pred)
+            annotSig(mods.annotations, tree, pred)
           }
 
         // must use typeSig, not memberSig (TODO: when do we need to switch namers?)
@@ -986,7 +986,7 @@ trait Namers extends MethodSynthesis {
             val mods = valDef.mods
             val annots =
               if (mods.annotations.isEmpty) Nil
-              else annotSig(mods.annotations, accessorAnnotsFilter(valDef.mods, isSetter, isBean))
+              else annotSig(mods.annotations, valDef, accessorAnnotsFilter(valDef.mods, isSetter, isBean))
 
             // for a setter, call memberSig to attribute the parameter (for a bean, we always use the regular method sig completer since they receive method types)
             // for a regular getter, make sure it gets a NullaryMethodType (also, no need to recompute it: we already have the valSig)
@@ -1871,13 +1871,13 @@ trait Namers extends MethodSynthesis {
      * they were added only in typer, depending on the compilation order, they may
      * or may not be visible.
      */
-    def annotSig(annotations: List[Tree], pred: AnnotationInfo => Boolean): List[AnnotationInfo] =
+    def annotSig(annotations: List[Tree], annotee: Tree, pred: AnnotationInfo => Boolean): List[AnnotationInfo] =
       annotations filterNot (_ eq null) map { ann =>
         val ctx = typer.context
         // need to be lazy, #1782. enteringTyper to allow inferView in annotation args, scala/bug#5892.
         AnnotationInfo lazily {
           enteringTyper {
-            val annotSig = newTyper(ctx.makeNonSilent(ann)) typedAnnotation ann
+            val annotSig = newTyper(ctx.makeNonSilent(ann)).typedAnnotation(ann, Some(annotee))
             if (pred(annotSig)) annotSig else UnmappableAnnotation // UnmappableAnnotation will be dropped in typedValDef and typedDefDef
           }
         }

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -19,8 +19,9 @@ package scala
 package tools.nsc
 package typechecker
 
-import scala.collection.{ mutable, immutable }
+import scala.collection.{immutable, mutable}
 import mutable.ListBuffer
+import scala.tools.nsc.Reporting.WarningCategory
 import symtab.Flags._
 
 /** This phase performs the following functions, each of which could be split out in a
@@ -306,10 +307,12 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
                     qual.symbol.ancestors foreach { parent =>
                       parent.info.decls filterNot (x => x.isPrivate || x.isLocalToThis) foreach { m2 =>
                         if (sym.name == m2.name && m2.isGetter && m2.accessed.isMutable) {
-                          reporter.warning(sel.pos,
+                          runReporting.warning(sel.pos,
                             sym.accessString + " " + sym.fullLocationString + " shadows mutable " + m2.name
                               + " inherited from " + m2.owner + ".  Changes to " + m2.name + " will not be visible within "
-                              + sym.owner + " - you may want to give them distinct names.")
+                              + sym.owner + " - you may want to give them distinct names.",
+                            WarningCategory.LintPrivateShadow,
+                            currentOwner)
                         }
                       }
                     }

--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -15,7 +15,7 @@ package typechecker
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-
+import scala.tools.nsc.Reporting.WarningCategory
 import symtab.Flags._
 
 /** Synthetic method implementations for case classes and case objects.
@@ -386,7 +386,7 @@ trait SyntheticMethods extends ast.TreeDSL {
               // Without a means to suppress this warning, I've thought better of it.
               if (settings.warnValueOverrides) {
                  (clazz.info nonPrivateMember m.name) filter (m => (m.owner != AnyClass) && (m.owner != clazz) && !m.isDeferred) andAlso { m =>
-                   typer.context.warning(clazz.pos, s"Implementation of ${m.name} inherited from ${m.owner} overridden in $clazz to enforce value class semantics")
+                   typer.context.warning(clazz.pos, s"Implementation of ${m.name} inherited from ${m.owner} overridden in $clazz to enforce value class semantics", WarningCategory.Other /* settings.warnValueOverrides is not exposed as compiler flag */)
                  }
                }
               true

--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -16,13 +16,16 @@ package typechecker
 import scala.collection.mutable
 import scala.reflect.internal.util.shortClassOfInstance
 import scala.reflect.internal.util.StringOps._
+import scala.tools.nsc.Reporting.WarningCategory
 
 abstract class TreeCheckers extends Analyzer {
   import global._
 
   override protected def onTreeCheckerError(pos: Position, msg: String): Unit = {
+    // could thread the `site` through ContextReporter for errors, like we do for warnings, but it
+    // looks like an overkill since it would only be used here.
     if (settings.fatalWarnings)
-      reporter.warning(pos, "\n** Error during internal checking:\n" + msg)
+      runReporting.warning(pos, "\n** Error during internal checking:\n" + msg, WarningCategory.OtherDebug, site = "")
   }
 
   case class DiffResult[T](lost: List[T], gained: List[T]) {
@@ -173,7 +176,7 @@ abstract class TreeCheckers extends Analyzer {
   )
 
 
-  def errorFn(pos: Position, msg: Any): Unit = reporter.warning(pos, "[check: %s] %s".format(phase.prev, msg))
+  def errorFn(pos: Position, msg: Any): Unit = runReporting.warning(pos, "[check: %s] %s".format(phase.prev, msg), WarningCategory.OtherDebug, site = "")
   def errorFn(msg: Any): Unit                = errorFn(NoPosition, msg)
 
   def informFn(msg: Any): Unit = {

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -20,6 +20,7 @@ import scala.util.control.Exception.ultimately
 import symtab.Flags._
 import PartialFunction.{cond, condOpt}
 import scala.annotation.tailrec
+import scala.tools.nsc.Reporting.WarningCategory
 
 /** An interface to enable higher configurability of diagnostic messages
  *  regarding type errors.  This is barely a beginning as error messages are
@@ -48,8 +49,8 @@ trait TypeDiagnostics {
   /** For errors which are artifacts of the implementation: such messages
    *  indicate that the restriction may be lifted in the future.
    */
-  def restrictionWarning(pos: Position, unit: CompilationUnit, msg: String): Unit =
-    reporter.warning(pos, "Implementation restriction: " + msg)
+  def restrictionWarning(pos: Position, unit: CompilationUnit, msg: String, category: WarningCategory, site: Symbol): Unit =
+    runReporting.warning(pos, "Implementation restriction: " + msg, category, site)
   def restrictionError(pos: Position, unit: CompilationUnit, msg: String): Unit =
     reporter.error(pos, "Implementation restriction: " + msg)
 
@@ -481,7 +482,7 @@ trait TypeDiagnostics {
 
     def apply(context: Context, tree: Tree): Tree = {
       if (settings.warnDeadCode && context.unit.exists && treeOK(tree) && !context.contextMode.inAny(ContextMode.SuppressDeadArgWarning))
-        context.warning(tree.pos, "dead code following this construct")
+        context.warning(tree.pos, "dead code following this construct", WarningCategory.WFlagDeadCode)
       tree
     }
 
@@ -671,6 +672,7 @@ trait TypeDiagnostics {
           if (sym.isPrivate) settings.warnUnusedPrivates && !sym.isTopLevel
           else settings.warnUnusedLocals
         val valAdvice = "is never updated: consider using immutable val"
+        def wcat(sym: Symbol) = if (sym.isPrivate) WarningCategory.UnusedPrivates else WarningCategory.UnusedLocals
         def termWarning(defn: SymTree): Unit = {
           val sym = defn.symbol
           val pos = (
@@ -700,23 +702,23 @@ trait TypeDiagnostics {
             else if (sym.isModule) s"object ${sym.name.decoded}"
             else "term"
           )
-          typer.context.warning(pos, s"$why $what in ${sym.owner} $cond")
+          typer.context.warning(pos, s"$why $what in ${sym.owner} $cond", wcat(sym))
         }
         def typeWarning(defn: SymTree): Unit = {
           val why = if (defn.symbol.isPrivate) "private" else "local"
-          typer.context.warning(defn.pos, s"$why ${defn.symbol.fullLocationString} is never used")
+          typer.context.warning(defn.pos, s"$why ${defn.symbol.fullLocationString} is never used", wcat(defn.symbol))
         }
 
         for (defn <- unusedPrivates.unusedTerms if shouldWarnOn(defn.symbol)) { termWarning(defn) }
         for (defn <- unusedPrivates.unusedTypes if shouldWarnOn(defn.symbol)) { typeWarning(defn) }
 
         for (v <- unusedPrivates.unsetVars) {
-          typer.context.warning(v.pos, s"local var ${v.name} in ${v.owner} ${valAdvice}")
+          typer.context.warning(v.pos, s"local var ${v.name} in ${v.owner} ${valAdvice}", WarningCategory.UnusedPrivates)
         }
       }
       if (settings.warnUnusedPatVars) {
         for (v <- unusedPrivates.unusedPatVars)
-          typer.context.warning(v.pos, s"pattern var ${v.name} in ${v.owner} is never used: use a wildcard `_` or suppress this warning with `${v.name}@_`")
+          typer.context.warning(v.pos, s"pattern var ${v.name} in ${v.owner} is never used: use a wildcard `_` or suppress this warning with `${v.name}@_`", WarningCategory.UnusedPatVars)
       }
       if (settings.warnUnusedParams) {
         def isImplementation(m: Symbol): Boolean = {
@@ -737,7 +739,7 @@ trait TypeDiagnostics {
             && !isConvention(s)
           )
         for (s <- unusedPrivates.unusedParams if warnable(s))
-          typer.context.warning(s.pos, s"parameter $s in ${if (s.owner.isAnonymousFunction) "anonymous function" else s.owner} is never used")
+          typer.context.warning(s.pos, s"parameter $s in ${if (s.owner.isAnonymousFunction) "anonymous function" else s.owner} is never used", WarningCategory.UnusedParams)
       }
     }
     def apply(unit: CompilationUnit): Unit = if (warningsEnabled && !unit.isJava && !typer.context.reporter.hasErrors) {
@@ -757,7 +759,7 @@ trait TypeDiagnostics {
     self: Typer =>
 
     def permanentlyHiddenWarning(pos: Position, hidden: Name, defn: Symbol) =
-      context.warning(pos, "imported `%s` is permanently hidden by definition of %s".format(hidden, defn.fullLocationString))
+      context.warning(pos, "imported `%s` is permanently hidden by definition of %s".format(hidden, defn.fullLocationString), WarningCategory.OtherShadowing)
 
     private def symWasOverloaded(sym: Symbol) = sym.owner.isClass && sym.owner.info.member(sym.name).isOverloaded
     private def cyclicAdjective(sym: Symbol)  = if (symWasOverloaded(sym)) "overloaded" else "recursive"
@@ -785,7 +787,8 @@ trait TypeDiagnostics {
         // we don't care about type params shadowing other type params in the same declaration
         enclClassOrMethodOrTypeMember(context).outer.lookupSymbol(tp.name, s => s != tp.symbol && s.hasRawInfo && reallyExists(s)) match {
           case LookupSucceeded(_, sym2) => context.warning(tp.pos,
-            s"type parameter ${tp.name} defined in $sym shadows $sym2 defined in ${sym2.owner}. You may want to rename your type parameter, or possibly remove it.")
+            s"type parameter ${tp.name} defined in $sym shadows $sym2 defined in ${sym2.owner}. You may want to rename your type parameter, or possibly remove it.",
+            WarningCategory.LintTypeParameterShadow)
           case _ =>
         }
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1155,6 +1155,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 tpSym == LongClass && (ptSym == FloatClass || ptSym == DoubleClass)
               )
               if (isInharmonic)
+                // not `context.deprecationWarning` because they are not buffered in silent mode
                 context.warning(tree.pos, s"Widening conversion from ${tpSym.name} to ${ptSym.name} is deprecated because it loses precision. Write `.to${ptSym.name}` instead.", WarningCategory.Deprecation)
               else if (settings.warnNumericWiden) context.warning(tree.pos, "implicit numeric widening", WarningCategory.WFlagNumericWiden)
             }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3908,10 +3908,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           val filters = (info.assocs: @unchecked) match {
             case Nil => List(MessageFilter.Any)
             case (_, LiteralAnnotArg(s)) :: Nil =>
-              val (ms, fs) = s.stringValue.split('&').map(WConf.parseFilter(_, runReporting.rootDirPrefix)).toList.partitionMap(identity)
-              if (ms.nonEmpty)
-                reporter.error(info.pos, s"Invalid message filter:\n${ms.mkString("\n")}")
-              fs
+              if (s.stringValue.isEmpty) List()
+              else {
+                val (ms, fs) = s.stringValue.split('&').map(WConf.parseFilter(_, runReporting.rootDirPrefix)).toList.partitionMap(identity)
+                if (ms.nonEmpty)
+                  reporter.error(info.pos, s"Invalid message filter:\n${ms.mkString("\n")}")
+                fs
+              }
           }
           val (start, end) =
             if (settings.Yrangepos) {

--- a/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
@@ -40,7 +40,7 @@ trait FastStringInterpolator extends FormatInterpolator {
                                    case ((p, o), i) if p != o => i
                                  }.getOrElse(processed.length - 1)
                                  
-                                 currentRun.reporting.deprecationWarning(lit.pos.withShift(diffindex), "Unicode escapes in raw interpolations are deprecated. Use literal characters instead.", "2.13.2")
+                                 runReporting.deprecationWarning(lit.pos.withShift(diffindex), "Unicode escapes in raw interpolations are deprecated. Use literal characters instead.", "2.13.2", "", "")
                                }
                                processed
                              }

--- a/src/library/scala/annotation/nowarn.scala
+++ b/src/library/scala/annotation/nowarn.scala
@@ -1,0 +1,34 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+
+/** An annotation for local warning suppression.
+  *
+  * The optional `value` parameter allows selectively silencing messages, see `scalac -Wconf:help`
+  * for help. Examples:
+  *
+  * {{{
+  *   def f = {
+  *     1: @nowarn // don't warn "a pure expression does nothing in statement position"
+  *     2
+  *   }
+  *
+  *   @nowarn def f = { 1; deprecated() } // don't warn
+  *
+  *   @nowarn("msg=pure expression does nothing")
+  *   def f = { 1; deprecated() } // show deprecation warning
+  * }}}
+  *
+  * To ensure that a `@nowarn` annotation actually suppresses a warning, enable `-Xlint:nowarn`.
+  */
+class nowarn(value: String = "") extends ConstantAnnotation

--- a/src/library/scala/annotation/tailrec.scala
+++ b/src/library/scala/annotation/tailrec.scala
@@ -18,4 +18,4 @@ package scala.annotation
  *  If it is present, the compiler will issue an error if the method cannot
  *  be optimized into a loop.
  */
-final class tailrec extends scala.annotation.StaticAnnotation
+final class tailrec extends StaticAnnotation

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1267,6 +1267,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val SwitchClass                = requiredClass[scala.annotation.switch]
     lazy val TailrecClass               = requiredClass[scala.annotation.tailrec]
     lazy val VarargsClass               = requiredClass[scala.annotation.varargs]
+    lazy val NowarnClass                = getClassIfDefined("scala.annotation.nowarn")
     lazy val uncheckedStableClass       = requiredClass[scala.annotation.unchecked.uncheckedStable]
     lazy val uncheckedVarianceClass     = requiredClass[scala.annotation.unchecked.uncheckedVariance]
 

--- a/src/reflect/scala/reflect/internal/Reporting.scala
+++ b/src/reflect/scala/reflect/internal/Reporting.scala
@@ -35,7 +35,7 @@ trait Reporting { self : Positions =>
   type PerRunReporting <: PerRunReportingBase
   protected def PerRunReporting: PerRunReporting
   abstract class PerRunReportingBase {
-    def deprecationWarning(pos: Position, msg: String, since: String): Unit
+    def deprecationWarning(pos: Position, msg: String, since: String, site: String, origin: String): Unit
 
     /** Have we already supplemented the error message of a compiler crash? */
     private[this] var supplementedError = false
@@ -45,7 +45,6 @@ trait Reporting { self : Positions =>
         supplementedError = true
         supplementTyperState(errorMessage)
       }
-
   }
 
   // overridden in Global
@@ -56,6 +55,7 @@ trait Reporting { self : Positions =>
   @deprecatedOverriding("This forwards to the corresponding method in reporter -- override reporter instead", "2.11.2")
   def inform(msg: String): Unit      = inform(NoPosition, msg)
   @deprecatedOverriding("This forwards to the corresponding method in reporter -- override reporter instead", "2.11.2")
+  @deprecated("Use `runReporting.warning` instead")
   def warning(msg: String): Unit     = warning(NoPosition, msg)
   // globalError(msg: String) used to abort -- not sure that was a good idea, so I made it more regular
   // (couldn't find any uses that relied on old behavior)
@@ -72,6 +72,7 @@ trait Reporting { self : Positions =>
   @deprecatedOverriding("This forwards to the corresponding method in reporter -- override reporter instead", "2.11.2")
   def inform(pos: Position, msg: String)      = reporter.echo(pos, msg)
   @deprecatedOverriding("This forwards to the corresponding method in reporter -- override reporter instead", "2.11.2")
+  @deprecated("Use `runReporting.warning` instead")
   def warning(pos: Position, msg: String)     = reporter.warning(pos, msg)
   @deprecatedOverriding("This forwards to the corresponding method in reporter -- override reporter instead", "2.11.2")
   def globalError(pos: Position, msg: String) = reporter.error(pos, msg)

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -811,7 +811,7 @@ abstract class TreeGen {
               if (vars.isEmpty) {
                 v.updateAttachment(PatVarDefAttachment)  // warn later if this introduces a Unit-valued field
                 if (mods.isImplicit)
-                  currentRun.reporting.deprecationWarning(matchExpr.pos, "Implicit pattern definition binds no variables", since="2.13")
+                  currentRun.reporting.deprecationWarning(matchExpr.pos, "Implicit pattern definition binds no variables", since="2.13", "", "")
               }
               v
             }

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -33,6 +33,7 @@ abstract class MutableSettings extends AbsSettings {
     def postSetHook(): Unit = ()
     def isDefault = !setByUser
     def isSetByUser = setByUser
+    private[scala] def clearSetByUser(): Unit = setByUser = false
     def value: T = v
     def value_=(arg: T) = {
       setByUser = true

--- a/src/reflect/scala/reflect/runtime/JavaUniverse.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverse.scala
@@ -44,7 +44,7 @@ class JavaUniverse extends InternalSymbolTable with JavaUniverseForce with Refle
   // minimal Run to get Reporting wired
   def currentRun = new RunReporting {}
   class PerRunReporting extends PerRunReportingBase {
-    def deprecationWarning(pos: Position, msg: String, since: String): Unit = reporter.warning(pos, msg)
+    def deprecationWarning(pos: Position, msg: String, since: String, site: String, origin: String): Unit = reporter.warning(pos, msg)
   }
   protected def PerRunReporting = new PerRunReporting
 

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -412,6 +412,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.SwitchClass
     definitions.TailrecClass
     definitions.VarargsClass
+    definitions.NowarnClass
     definitions.uncheckedStableClass
     definitions.uncheckedVarianceClass
     definitions.BeanPropertyAttr

--- a/src/repl-frontend/scala/tools/nsc/MainGenericRunner.scala
+++ b/src/repl-frontend/scala/tools/nsc/MainGenericRunner.scala
@@ -78,8 +78,8 @@ class MainGenericRunner {
           None
         case _  =>
           // We start the repl when no arguments are given.
-          // If user is agnostic about both -feature and -deprecation, turn them on.
-          if (settings.deprecation.isDefault && settings.feature.isDefault && settings.lint.isDefault) {
+          if (settings.Wconf.isDefault && settings.lint.isDefault) {
+            // If user is agnostic about -Wconf and -Xlint, enable -deprecation and -feature
             settings.deprecation.value = true
             settings.feature.value = true
           }

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -691,7 +691,7 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
           }
           ((pos, msg)) :: loop(filtered)
       }
-      val warnings = loop(run.reporting.allConditionalWarnings.map{ case (pos, (msg, since@_)) => (pos, msg) })
+      val warnings = loop(run.reporting.allConditionalWarnings)
       if (warnings.nonEmpty)
         mostRecentWarnings = warnings
     }
@@ -1128,8 +1128,8 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
     currentRun.parsing.withIncompleteHandler(handler) {
       val unit = newCompilationUnit(line, label)
       val trees = newUnitParser(unit).parseStats()
-      if (!isIncomplete) 
-        currentRun.reporting.summarizeErrors()
+      if (!isIncomplete)
+        runReporting.summarizeErrors()
       if (reporter.hasErrors) Left(Error)
       else if (isIncomplete) Left(Incomplete)
       else if (reporter.hasWarnings && settings.fatalWarnings) Left(Error)

--- a/src/scaladoc/scala/tools/nsc/ScalaDoc.scala
+++ b/src/scaladoc/scala/tools/nsc/ScalaDoc.scala
@@ -97,20 +97,4 @@ object ScalaDoc extends ScalaDoc {
   def main(args: Array[String]): Unit = {
     System.exit(if (process(args)) 0 else 1)
   }
-
-  implicit class SummaryReporter(val rep: Reporter) extends AnyVal {
-    /** Adds print lambda to ScalaDocReporter, executes it on other reporter */
-    private[this] def summaryMessage(pos: Position, msg: String, print: () => Unit): Unit = rep match {
-      case r: ScalaDocReporter => r.addDelayedMessage(pos, msg, print)
-      case _ => print()
-    }
-
-    def summaryEcho(pos: Position, msg: String): Unit    = summaryMessage(pos, msg, () => rep.echo(pos, msg))
-    def summaryError(pos: Position, msg: String): Unit   = summaryMessage(pos, msg, () => rep.error(pos, msg))
-    def summaryWarning(pos: Position, msg: String): Unit = summaryMessage(pos, msg, () => rep.warning(pos, msg))
-
-    def summaryEcho(msg: String): Unit    = summaryEcho(NoPosition, msg)
-    def summaryError(msg: String): Unit   = summaryError(NoPosition, msg)
-    def summaryWarning(msg: String): Unit = summaryWarning(NoPosition, msg)
-  }
 }

--- a/src/scaladoc/scala/tools/nsc/doc/DocFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/DocFactory.scala
@@ -13,7 +13,7 @@
 package scala.tools.nsc
 package doc
 
-import reporters.Reporter
+import scala.tools.nsc.reporters.Reporter
 import scala.util.control.ControlThrowable
 import scala.reflect.internal.util.BatchSourceFile
 
@@ -36,6 +36,7 @@ import scala.reflect.internal.util.BatchSourceFile
   * @param settings The settings to be used by the documenter and compiler for generating documentation.
   *
   * @author Gilles Dubochet */
+// takes a `Reporter`, not `FilteringReporter` for sbt compatibility
 class DocFactory(val reporter: Reporter, val settings: doc.Settings) { processor =>
   /** The unique compiler instance used by this processor and constructed from its `settings`. */
   object compiler extends ScaladocGlobal(settings, reporter)

--- a/src/scaladoc/scala/tools/nsc/doc/DocFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/DocFactory.scala
@@ -14,8 +14,9 @@ package scala.tools.nsc
 package doc
 
 import scala.tools.nsc.reporters.Reporter
+import scala.reflect.internal.util.{BatchSourceFile, NoPosition}
+import scala.tools.nsc.Reporting.WarningCategory
 import scala.util.control.ControlThrowable
-import scala.reflect.internal.util.BatchSourceFile
 
 /** A documentation processor controls the process of generating Scala
   * documentation, which is as follows.
@@ -40,6 +41,7 @@ import scala.reflect.internal.util.BatchSourceFile
 class DocFactory(val reporter: Reporter, val settings: doc.Settings) { processor =>
   /** The unique compiler instance used by this processor and constructed from its `settings`. */
   object compiler extends ScaladocGlobal(settings, reporter)
+  def runReporting: compiler.PerRunReporting = compiler.currentRun.reporting
 
   /** Creates a scaladoc site for all symbols defined in this call's `source`,
     * as well as those defined in `sources` of previous calls to the same processor.
@@ -123,7 +125,7 @@ class DocFactory(val reporter: Reporter, val settings: doc.Settings) { processor
         }
         .map(_.newInstance(reporter))
         .getOrElse{
-          reporter.warning(null, "Doclets should be created with the Reporter constructor, otherwise logging reporters will not be shared by the creating parent")
+          runReporting.warning(NoPosition, "Doclets should be created with the Reporter constructor, otherwise logging reporters will not be shared by the creating parent", WarningCategory.Scaladoc, site = "")
           docletClass.getConstructor().newInstance()
         }
         .asInstanceOf[Generator]

--- a/src/scaladoc/scala/tools/nsc/doc/ScaladocGlobal.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/ScaladocGlobal.scala
@@ -13,7 +13,7 @@
 package scala.tools.nsc
 package doc
 
-import reporters.Reporter
+import scala.tools.nsc.reporters.Reporter
 import scala.tools.nsc.typechecker.MacroAnnotationNamers
 
 trait ScaladocGlobalTrait extends Global {
@@ -44,6 +44,7 @@ trait ScaladocGlobalTrait extends Global {
   }
 }
 
+// takes a `Reporter`, not `FilteringReporter` for sbt compatibility
 class ScaladocGlobal(settings: doc.Settings, reporter: Reporter) extends Global(settings, reporter) with ScaladocGlobalTrait {
   override protected def computeInternalPhases(): Unit = {
     phasesSet += syntaxAnalyzer

--- a/src/scaladoc/scala/tools/nsc/doc/Uncompilable.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Uncompilable.scala
@@ -13,6 +13,8 @@
 package scala.tools.nsc
 package doc
 import scala.language.implicitConversions
+import scala.reflect.internal.util.NoPosition
+import scala.tools.nsc.Reporting.WarningCategory
 
 /** Some glue between DocParser (which reads source files which can't be compiled)
  *  and the scaladoc model.
@@ -21,7 +23,7 @@ trait Uncompilable {
   val global: Global
   val settings: Settings
 
-  import global.{ reporter, inform, warning, newTypeName, newTermName, Symbol, DocComment, NoSymbol }
+  import global.{ reporter, inform, newTypeName, newTermName, runReporting, Symbol, DocComment, NoSymbol }
   import global.definitions.AnyRefClass
   import global.rootMirror.RootClass
 
@@ -47,7 +49,7 @@ trait Uncompilable {
       inform("Found %d uncompilable files: %s".format(files.size, files mkString ", "))
 
     if (pairs.isEmpty)
-      warning("no doc comments read from " + settings.docUncompilable.value)
+      runReporting.warning(NoPosition, "no doc comments read from " + settings.docUncompilable.value, WarningCategory.Scaladoc, site = "")
 
     pairs
   }

--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -19,6 +19,7 @@ import scala.annotation.tailrec
 import scala.collection._
 import scala.util.matching.Regex
 import scala.reflect.internal.util.Position
+import scala.tools.nsc.Reporting.WarningCategory
 
 /** The comment parser transforms raw comment strings into `Comment` objects.
   * Call `parse` to run the parser. Note that the parser is stateless and
@@ -29,7 +30,7 @@ import scala.reflect.internal.util.Position
 trait CommentFactoryBase { this: MemberLookupBase =>
 
   val global: Global
-  import global.{ reporter, Symbol, NoSymbol }
+  import global.{ runReporting, Symbol, NoSymbol }
 
   /* Creates comments with necessary arguments */
   def createComment (
@@ -338,7 +339,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
         def oneTag(key: SimpleTagKey, filterEmpty: Boolean = true): Option[Body] =
           bodyTags remove key match {
             case Some(r :: rs) if !(filterEmpty && r.blocks.isEmpty) =>
-              if (rs.nonEmpty) reporter.warning(pos, s"Only one '@${key.name}' tag is allowed")
+              if (rs.nonEmpty) runReporting.warning(pos, s"Only one '@${key.name}' tag is allowed", WarningCategory.Scaladoc, site)
               Some(r)
             case _ => None
           }
@@ -351,7 +352,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
             bodyTags.keys.toSeq flatMap {
               case stk: SymbolTagKey if stk.name == key.name => Some(stk)
               case stk: SimpleTagKey if stk.name == key.name =>
-                reporter.warning(pos, s"Tag '@${stk.name}' must be followed by a symbol name")
+                runReporting.warning(pos, s"Tag '@${stk.name}' must be followed by a symbol name", WarningCategory.Scaladoc, site)
                 None
               case _ => None
             }
@@ -359,7 +360,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
             for (key <- keys) yield {
               val bs = (bodyTags remove key).get
               if (bs.lengthIs > 1)
-                reporter.warning(pos, s"Only one '@${key.name}' tag for symbol ${key.symbol} is allowed")
+                runReporting.warning(pos, s"Only one '@${key.name}' tag for symbol ${key.symbol} is allowed", WarningCategory.Scaladoc, site)
               (key.symbol, bs.head)
             }
           Map.empty[String, Body] ++ (if (filterEmpty) pairs.filterNot(_._2.blocks.isEmpty) else pairs)
@@ -408,7 +409,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
         )
 
         for ((key, _) <- bodyTags)
-          reporter.warning(pos, s"Tag '@${key.name}' is not recognised")
+          runReporting.warning(pos, s"Tag '@${key.name}' is not recognised", WarningCategory.Scaladoc, site)
 
         com
     }
@@ -522,7 +523,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
       jump("{{{")
       val str = readUntil("}}}")
       if (char == endOfText)
-        reportError(pos, "unclosed code block")
+        reportError(pos, "unclosed code block", site)
       else
         jump("}}}")
       blockEnded("code block")
@@ -536,7 +537,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
       val text = inline(check("=" * inLevel))
       val outLevel = repeatJump('=', inLevel)
       if (inLevel != outLevel)
-        reportError(pos, "unbalanced or unclosed heading")
+        reportError(pos, "unbalanced or unclosed heading", site)
       blockEnded("heading")
       Title(text, inLevel)
     }
@@ -600,7 +601,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
       def finalizeHeaderCells(): Unit = {
         if (cells.nonEmpty) {
           if (header.isDefined) {
-            reportError(pos, "more than one table header")
+            reportError(pos, "more than one table header", site)
           } else {
             header = Some(Row(cells.toList))
           }
@@ -696,7 +697,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
           // Case 1
           storeContents()
           finalizeRow()
-          reportError(pos, "unclosed table row")
+          reportError(pos, "unclosed table row", site)
         } else if (isStartMarkNewline) {
           // peek("2: start-mark-new-line/before")
           // Case 2
@@ -716,7 +717,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
         } else {
           // Case π√ⅈ
           // When the impossible happens leave some clues.
-          reportError(pos, "unexpected table row markdown")
+          reportError(pos, "unexpected table row markdown", site)
           peek("parseCell0")
           storeContents()
           finalizeRow()
@@ -751,7 +752,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
       // TODO: Do not return a table when: The header row must match the delimiter row in the number of cells. If not, a table will not be recognized
 
       if (cells.nonEmpty) {
-        reportError(pos, s"Parsed and unused content: $cells")
+        reportError(pos, s"Parsed and unused content: $cells", site)
       }
       assert(header.isDefined, "table header was not parsed")
       val enforcedCellCount = header.get.cells.size
@@ -761,7 +762,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
           row
         else if (row.cells.size > enforcedCellCount) {
           val excess = row.cells.size - enforcedCellCount
-          reportError(pos, s"Dropping $excess excess table $rowType cells from row.")
+          reportError(pos, s"Dropping $excess excess table $rowType cells from row.", site)
           Row(row.cells.take(enforcedCellCount))
         } else {
           val missing = enforcedCellCount - row.cells.size
@@ -773,7 +774,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
       val delimiterRow :: dataRows = if (rows.nonEmpty)
         rows.toList
       else {
-        reportError(pos, "Fixing missing delimiter row")
+        reportError(pos, "Fixing missing delimiter row", site)
         Row(Cell(Paragraph(Text("-")) :: Nil) :: Nil) :: Nil
       }
 
@@ -803,11 +804,11 @@ trait CommentFactoryBase { this: MemberLookupBase =>
                 case centerAlignmentPattern(_*) => ColumnOptionCenter
                 case rightAlignmentPattern(_*) => ColumnOptionRight
                 case x =>
-                  reportError(pos, s"Fixing invalid column alignment: $x")
+                  reportError(pos, s"Fixing invalid column alignment: $x", site)
                   defaultColumnOption
               }
             case x =>
-              reportError(pos, s"Fixing invalid column alignment: $x")
+              reportError(pos, s"Fixing invalid column alignment: $x", site)
               defaultColumnOption
           }
       }
@@ -1017,7 +1018,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
     /** {{{ eol ::= { whitespace } '\n' }}} */
     def blockEnded(blockType: String): Unit = {
       if (char != endOfLine && char != endOfText) {
-        reportError(pos, "no additional content on same line after " + blockType)
+        reportError(pos, "no additional content on same line after " + blockType, site)
         jumpUntil(endOfLine)
       }
       while (char == endOfLine)
@@ -1076,8 +1077,8 @@ trait CommentFactoryBase { this: MemberLookupBase =>
       }
     }
 
-    def reportError(pos: Position, message: String): Unit = {
-      reporter.warning(pos, message)
+    def reportError(pos: Position, message: String, site: Symbol): Unit = {
+      runReporting.warning(pos, message, WarningCategory.Scaladoc, site)
     }
   }
 

--- a/src/scaladoc/scala/tools/nsc/doc/base/MemberLookupBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/MemberLookupBase.scala
@@ -15,6 +15,7 @@ package doc
 package base
 
 import comment._
+import scala.tools.nsc.Reporting.WarningCategory
 
 /** This trait extracts all required information for documentation from compilation units.
  *  The base trait has been extracted to allow getting light-weight documentation
@@ -84,7 +85,7 @@ trait MemberLookupBase {
     links match {
       case Nil =>
         if (warnNoLink)
-          reporter.warning(pos, "Could not find any member to link for \"" + query + "\".")
+          runReporting.warning(pos, "Could not find any member to link for \"" + query + "\".", WarningCategory.Scaladoc, site)
         // (4) if we still haven't found anything, create a tooltip
         Tooltip(query)
       case List(l) => l
@@ -97,10 +98,12 @@ trait MemberLookupBase {
         }
         if (warnNoLink) {
           val allLinks = links.map(linkToString).mkString
-          reporter.warning(pos,
+          runReporting.warning(pos,
             s"""The link target \"$query\" is ambiguous. Several members fit the target:
             |$allLinks
-            |$explanation""".stripMargin)
+            |$explanation""".stripMargin,
+            WarningCategory.Scaladoc,
+            site)
         }
         chosen
     }

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
@@ -15,6 +15,7 @@ package doc
 package model
 
 import scala.collection._
+import scala.tools.nsc.Reporting.WarningCategory
 
 /**
  * This trait finds implicit conversions for a class in the default scope and creates scaladoc entries for each of them.
@@ -200,7 +201,7 @@ trait ModelFactoryImplicitSupport {
 
           case global.analyzer.SilentResultValue(t: Tree) => t
           case global.analyzer.SilentTypeError(err) =>
-            global.reporter.warning(sym.pos, err.toString)
+            context.warning(sym.pos, err.toString, WarningCategory.Scaladoc)
             return Nil
         }
       }

--- a/src/scaladoc/scala/tools/nsc/doc/model/diagram/DiagramDirectiveParser.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/diagram/DiagramDirectiveParser.scala
@@ -16,6 +16,8 @@ package diagram
 
 import model._
 import java.util.regex.Pattern
+
+import scala.tools.nsc.Reporting.WarningCategory
 import scala.util.matching.Regex
 
 /**
@@ -191,7 +193,7 @@ trait DiagramDirectiveParser {
         // we need the position from the package object (well, ideally its comment, but yeah ...)
         val sym = if (template.sym.hasPackageFlag) template.sym.packageObject else template.sym
         assert((sym != global.NoSymbol) || (sym == global.rootMirror.RootPackage))
-        global.reporter.warning(sym.pos, message)
+        global.runReporting.warning(sym.pos, message, WarningCategory.Scaladoc, sym)
       }
 
       def preparePattern(className: String) =

--- a/src/testkit/scala/tools/testkit/BytecodeTesting.scala
+++ b/src/testkit/scala/tools/testkit/BytecodeTesting.scala
@@ -36,7 +36,7 @@ trait BytecodeTesting extends ClearAfterClass {
    */
   def compilerArgs = ""
 
-  val compiler = cached("compiler", () => BytecodeTesting.newCompiler(extraArgs = compilerArgs))
+  val compiler: Compiler = cached("compiler", () => BytecodeTesting.newCompiler(extraArgs = compilerArgs))
 }
 
 class Compiler(val global: Global) {
@@ -68,7 +68,7 @@ class Compiler(val global: Global) {
     global.settings.outputDirs.setSingleOutput(new VirtualDirectory("(memory)", None))
   }
 
-  def newRun: global.Run = {
+  def newRun(): global.Run = {
     global.reporter.reset()
     resetOutput()
     keptPerRunCaches.foreach(_.clear())
@@ -86,7 +86,7 @@ class Compiler(val global: Global) {
   }
 
   def compileToBytes(scalaCode: String, javaCode: List[(String, String)] = Nil, allowMessage: StoreReporter.Info => Boolean = _ => false): List[(String, Array[Byte])] = {
-    val run = newRun
+    val run = newRun()
     run.compileSources(makeSourceFile(scalaCode, "unitTestSource.scala") :: javaCode.map(p => makeSourceFile(p._1, p._2)))
     checkReport(allowMessage)
     getGeneratedClassfiles(global.settings.outputDirs.getSingleOutput.get)
@@ -104,7 +104,7 @@ class Compiler(val global: Global) {
   def compileToBytesTransformed(scalaCode: String, javaCode: List[(String, String)] = Nil, beforeBackend: global.Tree => global.Tree): List[(String, Array[Byte])] = {
     import global._
     settings.stopBefore.value = "jvm" :: Nil
-    val run = newRun
+    val run = newRun()
     val scalaUnit = newCompilationUnit(scalaCode, "unitTestSource.scala")
     val javaUnits = javaCode.map(p => newCompilationUnit(p._1, p._2))
     val units = scalaUnit :: javaUnits
@@ -112,7 +112,7 @@ class Compiler(val global: Global) {
     settings.stopBefore.value = Nil
     scalaUnit.body = beforeBackend(scalaUnit.body)
     checkReport(_ => false)
-    val run1 = newRun
+    val run1 = newRun()
     run1.compileUnits(units, run1.phaseNamed("jvm"))
     checkReport(_ => false)
     getGeneratedClassfiles(settings.outputDirs.getSingleOutput.get)

--- a/test/files/neg/badtok-1-212.check
+++ b/test/files/neg/badtok-1-212.check
@@ -4,14 +4,14 @@ badtok-1-212.scala:4: error: unclosed character literal (or use " not ' for stri
 badtok-1-212.scala:4: error: unclosed character literal (or use " not ' for string literal)
 '42'
    ^
-badtok-1-212.scala:8: warning: deprecated syntax for character literal (use '\'' for single quote)
-'''
-^
 badtok-1-212.scala:10: error: empty character literal
 '';
 ^
 badtok-1-212.scala:12: error: unclosed character literal
 '
+^
+badtok-1-212.scala:8: warning: deprecated syntax for character literal (use '\'' for single quote)
+'''
 ^
 1 warning
 4 errors

--- a/test/files/neg/early-type-defs.check
+++ b/test/files/neg/early-type-defs.check
@@ -1,8 +1,8 @@
-early-type-defs.scala:4: warning: early initializers are deprecated; use trait parameters instead.
-object Test extends { type A1 = Int } with Runnable { def run() = () }
-                    ^
 early-type-defs.scala:4: error: early type members are unsupported: move them to the regular body; the semantics are the same
 object Test extends { type A1 = Int } with Runnable { def run() = () }
                            ^
+early-type-defs.scala:4: warning: early initializers are deprecated; use trait parameters instead.
+object Test extends { type A1 = Int } with Runnable { def run() = () }
+                    ^
 1 warning
 1 error

--- a/test/files/neg/for-comprehension-old.check
+++ b/test/files/neg/for-comprehension-old.check
@@ -1,15 +1,3 @@
-for-comprehension-old.scala:5: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
-  for (x <- 1 to 5 ; val y = x) yield x+y       // fail
-                           ^
-for-comprehension-old.scala:7: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
-  for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
-                               ^
-for-comprehension-old.scala:10: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
-  for (z <- 1 to 2 ; x <- 1 to 5 ; val y = x) yield x+y       // fail
-                                         ^
-for-comprehension-old.scala:12: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
-  for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
-                                             ^
 for-comprehension-old.scala:6: error: `val` keyword in for comprehension is unsupported: just remove `val`
   for (val x <- 1 to 5 ; y = x) yield x+y       // fail
              ^
@@ -22,5 +10,17 @@ for-comprehension-old.scala:11: error: `val` keyword in for comprehension is uns
 for-comprehension-old.scala:12: error: `val` keyword in for comprehension is unsupported: just remove `val`
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
                            ^
+for-comprehension-old.scala:5: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
+  for (x <- 1 to 5 ; val y = x) yield x+y       // fail
+                           ^
+for-comprehension-old.scala:7: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
+  for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
+                               ^
+for-comprehension-old.scala:10: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
+  for (z <- 1 to 2 ; x <- 1 to 5 ; val y = x) yield x+y       // fail
+                                         ^
+for-comprehension-old.scala:12: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
+  for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
+                                             ^
 4 warnings
 4 errors

--- a/test/files/neg/literals.check
+++ b/test/files/neg/literals.check
@@ -1,26 +1,8 @@
 literals.scala:4: error: invalid literal number
   def missingHex: Int    = { 0x }        // line 4: was: not reported, taken as zero
                              ^
-literals.scala:6: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
-  def leadingZeros: Int  = { 01 }        // line 6: no leading zero
-                             ^
-literals.scala:8: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
-  def tooManyZeros: Int  = { 00 }        // line 8: no leading zero
-                             ^
-literals.scala:10: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
-  def zeroOfNine: Int    = { 09 }        // line 10: no leading zero
-                             ^
-literals.scala:14: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
-  def zeroOfNineDot: Int = { 09. }       // line 14: malformed integer, ident expected
-                             ^
 literals.scala:22: error: invalid literal number
   def missingHex: Int    = 0x            // line 22: was: not reported, taken as zero
-                           ^
-literals.scala:26: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
-  def tooManyZeros: Int  = 00            // line 26: no leading zero
-                           ^
-literals.scala:28: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
-  def zeroOfNine: Int    = 09            // line 28: no leading zero
                            ^
 literals.scala:39: error: floating point number too small
   def tooTiny: Float     = { 0.7e-45f }      // floating point number too small
@@ -34,12 +16,6 @@ literals.scala:43: error: floating point number too large
 literals.scala:45: error: double precision floating point number too large
   def twoHuge: Double    = { 1.7976931348623159e308 } // double precision floating point number too large
                              ^
-literals.scala:50: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
-  def bad = 1l
-             ^
-literals.scala:52: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
-  def worse = 123l
-                 ^
 literals.scala:12: error: identifier expected but '}' found.
   def orphanDot: Int     = { 9. }        // line 12: ident expected
                                 ^
@@ -55,5 +31,29 @@ literals.scala:24: error: ';' expected but 'def' found.
 literals.scala:32: error: identifier expected but 'def' found.
   def zeroOfNineDot: Int = 09.           // line 32: malformed integer, ident expected
   ^
+literals.scala:6: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
+  def leadingZeros: Int  = { 01 }        // line 6: no leading zero
+                             ^
+literals.scala:8: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
+  def tooManyZeros: Int  = { 00 }        // line 8: no leading zero
+                             ^
+literals.scala:10: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
+  def zeroOfNine: Int    = { 09 }        // line 10: no leading zero
+                             ^
+literals.scala:14: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
+  def zeroOfNineDot: Int = { 09. }       // line 14: malformed integer, ident expected
+                             ^
+literals.scala:26: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
+  def tooManyZeros: Int  = 00            // line 26: no leading zero
+                           ^
+literals.scala:28: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
+  def zeroOfNine: Int    = 09            // line 28: no leading zero
+                           ^
+literals.scala:50: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
+  def bad = 1l
+             ^
+literals.scala:52: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
+  def worse = 123l
+                 ^
 8 warnings
 11 errors

--- a/test/files/neg/macro-deprecate-idents.check
+++ b/test/files/neg/macro-deprecate-idents.check
@@ -49,9 +49,6 @@ macro-deprecate-idents.scala:52: error: macro is now a reserved word; usage as a
 macro-deprecate-idents.scala:57: error: macro is now a reserved word; usage as an identifier is disallowed
   def macro = 2
       ^
-macro-deprecate-idents.scala:57: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `<error>`'s return type
-  def macro = 2
-               ^
 macro-deprecate-idents.scala:5: error: '=' expected but '}' found.
 }
 ^
@@ -67,5 +64,8 @@ macro-deprecate-idents.scala:47: error: '{' expected but '}' found.
 macro-deprecate-idents.scala:54: error: ')' expected but '}' found.
 }
 ^
+macro-deprecate-idents.scala:57: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `<error>`'s return type
+  def macro = 2
+               ^
 1 warning
 22 errors

--- a/test/files/neg/names-defaults-neg-213.check
+++ b/test/files/neg/names-defaults-neg-213.check
@@ -1,16 +1,16 @@
-names-defaults-neg-213.scala:9: warning: a pure expression does nothing in statement position
-    f1(x = 1) // named arg in 2.13 (value discard), not ambiguous
-           ^
 names-defaults-neg-213.scala:10: error: unknown parameter name: x
 Note that assignments in argument position are no longer allowed since Scala 2.13.
 To express the assignment expression, wrap it in brackets, e.g., `{ x = ... }`.
     f2(x = 1) // error, no parameter named x. error message mentions change in 2.13
          ^
-names-defaults-neg-213.scala:15: warning: a pure expression does nothing in statement position
-    f1(x = 1) // ok, named arg (value discard)
-           ^
 names-defaults-neg-213.scala:16: error: unknown parameter name: x
     f2(x = 1) // error (no such parameter). no mention of new semantics in 2.13
          ^
+names-defaults-neg-213.scala:9: warning: a pure expression does nothing in statement position
+    f1(x = 1) // named arg in 2.13 (value discard), not ambiguous
+           ^
+names-defaults-neg-213.scala:15: warning: a pure expression does nothing in statement position
+    f1(x = 1) // ok, named arg (value discard)
+           ^
 2 warnings
 2 errors

--- a/test/files/neg/names-defaults-neg-pu.check
+++ b/test/files/neg/names-defaults-neg-pu.check
@@ -11,9 +11,6 @@ names-defaults-neg-pu.scala:7: error: type mismatch;
 names-defaults-neg-pu.scala:10: error: positional after named argument.
   test1(b = "(*", 23)
                   ^
-names-defaults-neg-pu.scala:15: warning: a pure expression does nothing in statement position
-  test2(x = 1)
-            ^
 names-defaults-neg-pu.scala:16: error: unknown parameter name: y
   test2(y = 1)
           ^
@@ -112,24 +109,12 @@ names-defaults-neg-pu.scala:92: error: deprecated parameter name x has to be dis
 names-defaults-neg-pu.scala:93: error: deprecated parameter name a has to be distinct from any other parameter name (deprecated or not).
   def deprNam2(a: String)(@deprecatedName("a") b: Int) = 1
                                                ^
-names-defaults-neg-pu.scala:95: warning: the parameter name y is deprecated: use b instead
-  deprNam3(y = 10, b = 2)
-             ^
 names-defaults-neg-pu.scala:95: error: parameter 'b' is already specified at parameter position 1
   deprNam3(y = 10, b = 2)
                      ^
-names-defaults-neg-pu.scala:98: warning: naming parameter deprNam4Arg is deprecated.
-  deprNam4(deprNam4Arg = null)
-                       ^
-names-defaults-neg-pu.scala:100: warning: naming parameter deprNam5Arg is deprecated.
-  deprNam5(deprNam5Arg = null)
-                       ^
 names-defaults-neg-pu.scala:104: error: unknown parameter name: m
   f3818(y = 1, m = 1)
                  ^
-names-defaults-neg-pu.scala:137: warning: a pure expression does nothing in statement position
-  delay(var2 = 40)
-               ^
 names-defaults-neg-pu.scala:140: error: missing parameter type for expanded function ((<x$1: error>) => a = x$1)
   val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
                                          ^
@@ -142,5 +127,20 @@ names-defaults-neg-pu.scala:141: error: parameter 'a' is already specified at pa
 names-defaults-neg-pu.scala:142: error: missing parameter type for expanded function ((<x$4: error>) => b = x$4)
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                       ^
+names-defaults-neg-pu.scala:15: warning: a pure expression does nothing in statement position
+  test2(x = 1)
+            ^
+names-defaults-neg-pu.scala:95: warning: the parameter name y is deprecated: use b instead
+  deprNam3(y = 10, b = 2)
+             ^
+names-defaults-neg-pu.scala:98: warning: naming parameter deprNam4Arg is deprecated.
+  deprNam4(deprNam4Arg = null)
+                       ^
+names-defaults-neg-pu.scala:100: warning: naming parameter deprNam5Arg is deprecated.
+  deprNam5(deprNam5Arg = null)
+                       ^
+names-defaults-neg-pu.scala:137: warning: a pure expression does nothing in statement position
+  delay(var2 = 40)
+               ^
 5 warnings
 33 errors

--- a/test/files/neg/names-defaults-neg-warn.check
+++ b/test/files/neg/names-defaults-neg-warn.check
@@ -1,12 +1,3 @@
-names-defaults-neg-warn.scala:13: warning: the parameter name s is deprecated: use x instead
-  deprNam2.f(s = "dlfkj")
-               ^
-names-defaults-neg-warn.scala:14: warning: the parameter name x is deprecated: use s instead
-  deprNam2.g(x = "dlkjf")
-               ^
-names-defaults-neg-warn.scala:24: warning: a pure expression does nothing in statement position
-    f1(x = 1) // 2.12: error, ambiguous (named arg or assign). 2.13: named arg
-           ^
 names-defaults-neg-warn.scala:25: error: unknown parameter name: x
 Note that assignments in argument position are no longer allowed since Scala 2.13.
 To express the assignment expression, wrap it in brackets, e.g., `{ x = ... }`.
@@ -17,11 +8,20 @@ Note that assignments in argument position are no longer allowed since Scala 2.1
 To express the assignment expression, wrap it in brackets, e.g., `{ x = ... }`.
     synchronized(x = 1) // deprecation warning in 2.12, error in 2.13
                    ^
-names-defaults-neg-warn.scala:44: warning: a pure expression does nothing in statement position
-    f1(x = 1) // 2.12, 2.13: ok, named arg (value discard)
-           ^
 names-defaults-neg-warn.scala:45: error: unknown parameter name: x
     f2(x = 1) // 2.12, 2.13: error (no such parameter). no deprecation warning in 2.12, x is not a variable.
          ^
+names-defaults-neg-warn.scala:13: warning: the parameter name s is deprecated: use x instead
+  deprNam2.f(s = "dlfkj")
+               ^
+names-defaults-neg-warn.scala:14: warning: the parameter name x is deprecated: use s instead
+  deprNam2.g(x = "dlkjf")
+               ^
+names-defaults-neg-warn.scala:24: warning: a pure expression does nothing in statement position
+    f1(x = 1) // 2.12: error, ambiguous (named arg or assign). 2.13: named arg
+           ^
+names-defaults-neg-warn.scala:44: warning: a pure expression does nothing in statement position
+    f1(x = 1) // 2.12, 2.13: ok, named arg (value discard)
+           ^
 4 warnings
 3 errors

--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -1,9 +1,3 @@
-names-defaults-neg.scala:103: warning: symbol literal is deprecated; use Symbol("foo") instead
-  def deprNam6(@deprecatedName('foo) deprNam6Arg: String) = 0
-                               ^
-names-defaults-neg.scala:105: warning: symbol literal is deprecated; use Symbol("bar") instead
-  def deprNam7(@deprecatedName('bar, "2.12.0") deprNam7Arg: String) = 0
-                               ^
 names-defaults-neg.scala:7: error: type mismatch;
  found   : String("#")
  required: Int
@@ -17,9 +11,6 @@ names-defaults-neg.scala:7: error: type mismatch;
 names-defaults-neg.scala:10: error: positional after named argument.
   test1(b = "(*", 23)
                   ^
-names-defaults-neg.scala:15: warning: a pure expression does nothing in statement position
-  test2(x = 1)
-            ^
 names-defaults-neg.scala:16: error: unknown parameter name: y
   test2(y = 1)
           ^
@@ -118,30 +109,12 @@ names-defaults-neg.scala:92: error: deprecated parameter name x has to be distin
 names-defaults-neg.scala:93: error: deprecated parameter name a has to be distinct from any other parameter name (deprecated or not).
   def deprNam2(a: String)(@deprecatedName("a") b: Int) = 1
                                                ^
-names-defaults-neg.scala:95: warning: the parameter name y is deprecated: use b instead
-  deprNam3(y = 10, b = 2)
-             ^
 names-defaults-neg.scala:95: error: parameter 'b' is already specified at parameter position 1
   deprNam3(y = 10, b = 2)
                      ^
-names-defaults-neg.scala:98: warning: naming parameter deprNam4Arg is deprecated.
-  deprNam4(deprNam4Arg = null)
-                       ^
-names-defaults-neg.scala:100: warning: naming parameter deprNam5Arg is deprecated.
-  deprNam5(deprNam5Arg = null)
-                       ^
-names-defaults-neg.scala:104: warning: the parameter name foo is deprecated: use deprNam6Arg instead
-  deprNam6(foo = null)
-               ^
-names-defaults-neg.scala:106: warning: the parameter name bar is deprecated (since 2.12.0): use deprNam7Arg instead
-  deprNam7(bar = null)
-               ^
 names-defaults-neg.scala:110: error: unknown parameter name: m
   f3818(y = 1, m = 1)
                  ^
-names-defaults-neg.scala:143: warning: a pure expression does nothing in statement position
-  delay(var2 = 40)
-               ^
 names-defaults-neg.scala:146: error: missing parameter type for expanded function ((<x$1: error>) => a = x$1)
   val taf2: Int => Unit = testAnnFun(a = _, b = get("+"))
                                          ^
@@ -154,5 +127,32 @@ names-defaults-neg.scala:147: error: parameter 'a' is already specified at param
 names-defaults-neg.scala:148: error: missing parameter type for expanded function ((<x$4: error>) => b = x$4)
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                       ^
+names-defaults-neg.scala:103: warning: symbol literal is deprecated; use Symbol("foo") instead
+  def deprNam6(@deprecatedName('foo) deprNam6Arg: String) = 0
+                               ^
+names-defaults-neg.scala:105: warning: symbol literal is deprecated; use Symbol("bar") instead
+  def deprNam7(@deprecatedName('bar, "2.12.0") deprNam7Arg: String) = 0
+                               ^
+names-defaults-neg.scala:15: warning: a pure expression does nothing in statement position
+  test2(x = 1)
+            ^
+names-defaults-neg.scala:95: warning: the parameter name y is deprecated: use b instead
+  deprNam3(y = 10, b = 2)
+             ^
+names-defaults-neg.scala:98: warning: naming parameter deprNam4Arg is deprecated.
+  deprNam4(deprNam4Arg = null)
+                       ^
+names-defaults-neg.scala:100: warning: naming parameter deprNam5Arg is deprecated.
+  deprNam5(deprNam5Arg = null)
+                       ^
+names-defaults-neg.scala:104: warning: the parameter name foo is deprecated: use deprNam6Arg instead
+  deprNam6(foo = null)
+               ^
+names-defaults-neg.scala:106: warning: the parameter name bar is deprecated (since 2.12.0): use deprNam7Arg instead
+  deprNam7(bar = null)
+               ^
+names-defaults-neg.scala:143: warning: a pure expression does nothing in statement position
+  delay(var2 = 40)
+               ^
 9 warnings
 33 errors

--- a/test/files/neg/nowarnMacros.check
+++ b/test/files/neg/nowarnMacros.check
@@ -1,0 +1,12 @@
+Test_2.scala:10: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+    1 // warn
+    ^
+Test_2.scala:19: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+    1 // warn
+    ^
+Test_2.scala:28: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+    1 // warn
+    ^
+error: No warnings can be incurred under -Werror.
+3 warnings
+1 error

--- a/test/files/neg/nowarnMacros/Macro_1.scala
+++ b/test/files/neg/nowarnMacros/Macro_1.scala
@@ -1,0 +1,8 @@
+import scala.reflect.macros.blackbox.Context
+
+object Macro {
+  def discard(c: Context)(expr: c.Expr[Any]): c.Tree = {
+    import c.universe._
+    q"()"
+  }
+}

--- a/test/files/neg/nowarnMacros/Test_2.scala
+++ b/test/files/neg/nowarnMacros/Test_2.scala
@@ -1,0 +1,35 @@
+// scalac: -Werror
+
+import language.experimental.macros
+import scala.annotation.nowarn
+
+object Test {
+  def discard(expr: Any): Unit = macro Macro.discard
+
+  def t1a = discard {
+    1 // warn
+    2
+  }
+  def t1b = discard {
+    1: @nowarn
+    2
+  }
+
+  def t2a = discard {
+    1 // warn
+    2
+  }
+  @nowarn def t2b = discard {
+    1
+    2
+  }
+
+  def t3a = discard {
+    1 // warn
+    2
+  }
+  def t3b = discard {
+    1 // warn
+    2
+  }: @nowarn
+}

--- a/test/files/neg/nowarnPointPos.check
+++ b/test/files/neg/nowarnPointPos.check
@@ -1,0 +1,48 @@
+nowarnPointPos.scala:31: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+  val t7b = { 0; 1 }
+              ^
+nowarnPointPos.scala:37: warning: a pure expression does nothing in statement position
+    def f: Unit = 1
+                  ^
+nowarnPointPos.scala:56: warning: a pure expression does nothing in statement position
+      123
+      ^
+nowarnPointPos.scala:67: warning: a pure expression does nothing in statement position
+    123
+    ^
+nowarnPointPos.scala:75: warning: a pure expression does nothing in statement position
+    123
+    ^
+nowarnPointPos.scala:11: warning: method dep in class C is deprecated (since 1.2.3): message
+  @nowarn @ann(dep) def t2 = 0          // deprecation warning, @nowarn unused
+               ^
+nowarnPointPos.scala:80: warning: method dep in class C is deprecated (since 1.2.3): message
+    a + dep
+        ^
+nowarnPointPos.scala:45: warning: I3b has a valid main method (args: Array[String]): Unit,
+  but C.I3b will not have an entry point on the JVM.
+  Reason: companion is a trait, which means no static forwarder can be generated.
+
+  object I3b {
+         ^
+nowarnPointPos.scala:9: warning: @nowarn annotation does not suppress any warnings
+  @nowarn def t0 = { 0: @nowarn; 1 }     // outer @nowarn unused
+   ^
+nowarnPointPos.scala:10: warning: @nowarn annotation does not suppress any warnings
+  @nowarn def t1 = { 0: Int @nowarn; 1 } // inner @nowarn unused, it covers the type, not the expression
+                             ^
+nowarnPointPos.scala:11: warning: @nowarn annotation does not suppress any warnings
+  @nowarn @ann(dep) def t2 = 0          // deprecation warning, @nowarn unused
+   ^
+nowarnPointPos.scala:19: warning: @nowarn annotation does not suppress any warnings
+  @nowarn class I1a { // unused @nowarn
+   ^
+nowarnPointPos.scala:24: warning: @nowarn annotation does not suppress any warnings
+  @nowarn class I1b { // unused @nowarn
+   ^
+nowarnPointPos.scala:65: warning: @nowarn annotation does not suppress any warnings
+  @nowarn("msg=something else")
+   ^
+error: No warnings can be incurred under -Werror.
+14 warnings
+1 error

--- a/test/files/neg/nowarnPointPos.scala
+++ b/test/files/neg/nowarnPointPos.scala
@@ -1,0 +1,88 @@
+// scalac: -deprecation -Wunused:nowarn -Yrangepos:false -Werror
+import scala.annotation._
+
+class ann(a: Any) extends Annotation
+
+class C {
+  @deprecated("message", "1.2.3") def dep = 0
+
+  @nowarn def t0 = { 0: @nowarn; 1 }     // outer @nowarn unused
+  @nowarn def t1 = { 0: Int @nowarn; 1 } // inner @nowarn unused, it covers the type, not the expression
+  @nowarn @ann(dep) def t2 = 0          // deprecation warning, @nowarn unused
+  @ann(dep: @nowarn) def t3 = 0         // silent
+
+  @nowarn("cat=deprecation") def t4 = dep
+
+  def t5 = (new I1a).m
+
+  // completion forced by method above
+  @nowarn class I1a { // unused @nowarn
+    @nowarn def m = { 1; 2 }
+  }
+
+  // completion during type checking
+  @nowarn class I1b { // unused @nowarn
+    @nowarn def m = { 1; 2 }
+  }
+
+  def t6 = (new I1b).m
+
+  @nowarn val t7a = { 0; 1 }
+  val t7b = { 0; 1 }
+
+  @nowarn class I2a {
+    def f: Unit = 1
+  }
+  class I2b {
+    def f: Unit = 1
+  }
+
+  trait I3a
+  @nowarn object I3a {
+    def main(args: Array[String]) = ()
+  }
+  trait I3b
+  object I3b {
+    def main(args: Array[String]) = () // main method in companion of trait triggers a warning in the backend
+  }
+
+  def t8(): Unit = {
+    @nowarn
+    val a = {
+      123
+      ()
+    }
+    val b = {
+      123
+      ()
+    }
+  }
+
+  @nowarn("msg=pure expression")
+  def t9a(): Unit = {
+    123
+  }
+  @nowarn("msg=something else")
+  def t9b(): Unit = {
+    123
+  }
+
+  @nowarn
+  def t10a(): Unit = {
+    123
+  }
+  def t10b(): Unit = {
+    123
+  }
+  
+  def t11(): Unit = {
+    val a = dep: @nowarn
+    a + dep
+  }
+}
+
+trait T {
+  @nowarn val t1 = { 0; 1 }
+}
+
+class K extends T

--- a/test/files/neg/nowarnPointPos.scala
+++ b/test/files/neg/nowarnPointPos.scala
@@ -86,3 +86,10 @@ trait T {
 }
 
 class K extends T
+
+@nowarn("site=Uh.f.g")
+class Uh {
+  def f = {
+    def g(c: C) = c.dep
+  }
+}

--- a/test/files/neg/nowarnRangePos.check
+++ b/test/files/neg/nowarnRangePos.check
@@ -1,0 +1,48 @@
+nowarnRangePos.scala:31: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+  val t7b = { 0; 1 }
+              ^
+nowarnRangePos.scala:37: warning: a pure expression does nothing in statement position
+    def f: Unit = 1
+                  ^
+nowarnRangePos.scala:56: warning: a pure expression does nothing in statement position
+      123
+      ^
+nowarnRangePos.scala:67: warning: a pure expression does nothing in statement position
+    123
+    ^
+nowarnRangePos.scala:75: warning: a pure expression does nothing in statement position
+    123
+    ^
+nowarnRangePos.scala:11: warning: method dep in class C is deprecated (since 1.2.3): message
+  @nowarn @ann(dep) def t2 = 0          // deprecation warning, @nowarn unused
+               ^
+nowarnRangePos.scala:80: warning: method dep in class C is deprecated (since 1.2.3): message
+    a + dep
+        ^
+nowarnRangePos.scala:45: warning: I3b has a valid main method (args: Array[String]): Unit,
+  but C.I3b will not have an entry point on the JVM.
+  Reason: companion is a trait, which means no static forwarder can be generated.
+
+  object I3b {
+         ^
+nowarnRangePos.scala:9: warning: @nowarn annotation does not suppress any warnings
+  @nowarn def t0 = { 0: @nowarn; 1 }     // outer @nowarn unused
+   ^
+nowarnRangePos.scala:10: warning: @nowarn annotation does not suppress any warnings
+  @nowarn def t1 = { 0: Int @nowarn; 1 } // inner @nowarn unused, it covers the type, not the expression
+                             ^
+nowarnRangePos.scala:11: warning: @nowarn annotation does not suppress any warnings
+  @nowarn @ann(dep) def t2 = 0          // deprecation warning, @nowarn unused
+   ^
+nowarnRangePos.scala:19: warning: @nowarn annotation does not suppress any warnings
+  @nowarn class I1a { // unused @nowarn
+   ^
+nowarnRangePos.scala:24: warning: @nowarn annotation does not suppress any warnings
+  @nowarn class I1b { // unused @nowarn
+   ^
+nowarnRangePos.scala:65: warning: @nowarn annotation does not suppress any warnings
+  @nowarn("msg=something else") // unused
+   ^
+error: No warnings can be incurred under -Werror.
+14 warnings
+1 error

--- a/test/files/neg/nowarnRangePos.scala
+++ b/test/files/neg/nowarnRangePos.scala
@@ -86,3 +86,10 @@ trait T {
 }
 
 class K extends T
+
+@nowarn("site=Uh.f.g")
+class Uh {
+  def f = {
+    def g(c: C) = c.dep
+  }
+}

--- a/test/files/neg/nowarnRangePos.scala
+++ b/test/files/neg/nowarnRangePos.scala
@@ -1,0 +1,88 @@
+// scalac: -deprecation -Wunused:nowarn -Yrangepos:true -Werror
+import scala.annotation._
+
+class ann(a: Any) extends Annotation
+
+class C {
+  @deprecated("message", "1.2.3") def dep = 0
+
+  @nowarn def t0 = { 0: @nowarn; 1 }     // outer @nowarn unused
+  @nowarn def t1 = { 0: Int @nowarn; 1 } // inner @nowarn unused, it covers the type, not the expression
+  @nowarn @ann(dep) def t2 = 0          // deprecation warning, @nowarn unused
+  @ann(dep: @nowarn) def t3 = 0         // silent
+
+  @nowarn("cat=deprecation") def t4 = dep
+
+  def t5 = (new I1a).m
+
+  // completion forced by method above
+  @nowarn class I1a { // unused @nowarn
+    @nowarn def m = { 1; 2 }
+  }
+
+  // completion during type checking
+  @nowarn class I1b { // unused @nowarn
+    @nowarn def m = { 1; 2 }
+  }
+
+  def t6 = (new I1b).m
+
+  @nowarn val t7a = { 0; 1 }
+  val t7b = { 0; 1 }
+
+  @nowarn class I2a {
+    def f: Unit = 1
+  }
+  class I2b {
+    def f: Unit = 1
+  }
+
+  trait I3a
+  @nowarn object I3a {
+    def main(args: Array[String]) = ()
+  }
+  trait I3b
+  object I3b {
+    def main(args: Array[String]) = () // main method in companion of trait triggers a warning in the backend
+  }
+
+  def t8(): Unit = {
+    @nowarn
+    val a = {
+      123
+      ()
+    }
+    val b = {
+      123
+      ()
+    }
+  }
+
+  @nowarn("msg=pure expression")
+  def t9a(): Unit = {
+    123
+  }
+  @nowarn("msg=something else") // unused
+  def t9b(): Unit = {
+    123
+  }
+
+  @nowarn
+  def t10a(): Unit = {
+    123
+  }
+  def t10b(): Unit = {
+    123
+  }
+  
+  def t11(): Unit = {
+    val a = dep: @nowarn
+    a + dep
+  }
+}
+
+trait T {
+  @nowarn val t1 = { 0; 1 }
+}
+
+class K extends T

--- a/test/files/neg/outer-ref-checks.scala
+++ b/test/files/neg/outer-ref-checks.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -unchecked
+// scalac: -Xfatal-warnings
 //
 import scala.annotation.unchecked.uncheckedVariance
 

--- a/test/files/neg/patmat-classtag-compound.scala
+++ b/test/files/neg/patmat-classtag-compound.scala
@@ -1,4 +1,4 @@
-// scalac: -unchecked -Xfatal-warnings
+// scalac: -Xfatal-warnings
 //
 object Test extends App{
   trait Bar

--- a/test/files/neg/patmat-type-check.check
+++ b/test/files/neg/patmat-type-check.check
@@ -1,22 +1,13 @@
-patmat-type-check.scala:11: warning: fruitless type test: a value of type Test.Bop4[T] cannot also be a Seq[A]
-  def s3[T](x: Bop4[T]) = x match { case Seq('b', 'o', 'b') => true }
-                                            ^
 patmat-type-check.scala:11: error: pattern type is incompatible with expected type;
  found   : Seq[A]
  required: Test.Bop4[T]
   def s3[T](x: Bop4[T]) = x match { case Seq('b', 'o', 'b') => true }
                                             ^
-patmat-type-check.scala:15: warning: fruitless type test: a value of type Test.Bop5[_$1,T1,T2] cannot also be a Seq[A]
-  def s4[T1, T2](x: Bop5[_, T1, T2]) = x match { case Seq('b', 'o', 'b') => true }
-                                                         ^
 patmat-type-check.scala:15: error: pattern type is incompatible with expected type;
  found   : Seq[A]
  required: Test.Bop5[_$1,T1,T2] where type _$1
   def s4[T1, T2](x: Bop5[_, T1, T2]) = x match { case Seq('b', 'o', 'b') => true }
                                                          ^
-patmat-type-check.scala:19: warning: fruitless type test: a value of type Test.Bop3[T] cannot also be a Seq[A]
-  def f4[T](x: Bop3[T]) = x match { case Seq('b', 'o', 'b') => true }
-                                            ^
 patmat-type-check.scala:19: error: pattern type is incompatible with expected type;
  found   : Seq[A]
  required: Test.Bop3[T]
@@ -42,5 +33,4 @@ patmat-type-check.scala:30: error: scrutinee is incompatible with pattern type;
  required: Test.Bop3[Char]
   def f4[T](x: Bop3[Char]) = x match { case Seq('b', 'o', 'b') => true } // fail
                                                ^
-3 warnings
 7 errors

--- a/test/files/neg/scopes.check
+++ b/test/files/neg/scopes.check
@@ -7,9 +7,6 @@ scopes.scala:5: error: x is already defined as value x
 scopes.scala:8: error: y is already defined as value y
     val y: Float = .0f
         ^
-scopes.scala:6: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-  {
-  ^
 scopes.scala:11: error: x is already defined as value x
   def f1(x: Int, x: Float) = x
                  ^
@@ -22,5 +19,8 @@ scopes.scala:13: error: x is already defined as value x
 scopes.scala:15: error: x is already defined as value x
     case x::x => x
             ^
+scopes.scala:6: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  {
+  ^
 1 warning
 7 errors

--- a/test/files/neg/stringinterpolation_macro-neg.check
+++ b/test/files/neg/stringinterpolation_macro-neg.check
@@ -142,15 +142,6 @@ stringinterpolation_macro-neg.scala:58: error: Argument index out of range
 stringinterpolation_macro-neg.scala:59: error: Argument index out of range
   f"${8}%d ${9}%d%0$$d"
                   ^
-stringinterpolation_macro-neg.scala:62: warning: Index is not this arg
-  f"${8}%d ${9}%1$$d"
-                ^
-stringinterpolation_macro-neg.scala:63: warning: Argument index ignored if '<' flag is present
-  f"$s%s $s%s %1$$<s"
-               ^
-stringinterpolation_macro-neg.scala:64: warning: Index is not this arg
-  f"$s%s $s%1$$s"
-            ^
 stringinterpolation_macro-neg.scala:67: error: type mismatch;
  found   : String
  required: java.util.Formattable
@@ -168,5 +159,14 @@ stringinterpolation_macro-neg.scala:72: error: Missing conversion operator in '%
 stringinterpolation_macro-neg.scala:75: error: conversions must follow a splice; use %% for literal %, %n for newline
   f"${d}random-leading-junk%d"
                            ^
+stringinterpolation_macro-neg.scala:62: warning: Index is not this arg
+  f"${8}%d ${9}%1$$d"
+                ^
+stringinterpolation_macro-neg.scala:63: warning: Argument index ignored if '<' flag is present
+  f"$s%s $s%s %1$$<s"
+               ^
+stringinterpolation_macro-neg.scala:64: warning: Index is not this arg
+  f"$s%s $s%1$$s"
+            ^
 3 warnings
 45 errors

--- a/test/files/neg/t10678.check
+++ b/test/files/neg/t10678.check
@@ -1,11 +1,11 @@
-t10678.scala:6: warning: Using `<:` for `extends` is deprecated
-trait U <: T
-        ^
 t10678.scala:8: error: ';' expected but '<:' found.
 class C <: T {
         ^
 t10678.scala:11: error: ';' expected but '<:' found.
 object O <: T {
          ^
+t10678.scala:6: warning: Using `<:` for `extends` is deprecated
+trait U <: T
+        ^
 1 warning
 2 errors

--- a/test/files/neg/t10729.check
+++ b/test/files/neg/t10729.check
@@ -7,14 +7,14 @@ ArrayAsAnnotation.scala:2: error: class Array does not extend scala.annotation.A
 SeqAsAnnotation.scala:2: error: trait Seq is abstract; cannot be instantiated
   1: @Seq(10)
       ^
-Switch.scala:1: warning: imported `switch` is permanently hidden by definition of class switch
-import annotation.switch
-                  ^
 Switch.scala:4: error: class switch does not extend scala.annotation.Annotation
   def test(x: Int) = (x: @switch) match {
                           ^
 TraitAnnotation.scala:6: error: trait TraitAnnotation is abstract; cannot be instantiated
   1: @TraitAnnotation
       ^
+Switch.scala:1: warning: imported `switch` is permanently hidden by definition of class switch
+import annotation.switch
+                  ^
 1 warning
 5 errors

--- a/test/files/neg/t11374b.check
+++ b/test/files/neg/t11374b.check
@@ -1,11 +1,11 @@
 t11374b.scala:3: error: not found: value _
   val Some(`_`) = Option(42)  // was crashola
            ^
-t11374b.scala:3: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
-  val Some(`_`) = Option(42)  // was crashola
-          ^
 t11374b.scala:6: error: not found: value _
     val Some(`_`) = Option(42)  // was crashola
              ^
+t11374b.scala:3: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
+  val Some(`_`) = Option(42)  // was crashola
+          ^
 1 warning
 2 errors

--- a/test/files/neg/t2405.check
+++ b/test/files/neg/t2405.check
@@ -1,8 +1,8 @@
-t2405.scala:6: warning: imported `y` is permanently hidden by definition of method y
-		import A.{x => y}
-                          ^
 t2405.scala:8: error: could not find implicit value for parameter e: Int
 		implicitly[Int]
+                          ^
+t2405.scala:6: warning: imported `y` is permanently hidden by definition of method y
+		import A.{x => y}
                           ^
 1 warning
 1 error

--- a/test/files/neg/t2866.check
+++ b/test/files/neg/t2866.check
@@ -1,6 +1,3 @@
-t2866.scala:30: warning: imported `one` is permanently hidden by definition of value one
-    import A.one // warning: imported `one` is permanently hidden by definition of value one.
-             ^
 t2866.scala:42: error: ambiguous implicit values:
  both value two of type Int
  and value one in object A of type Int
@@ -13,5 +10,8 @@ t2866.scala:50: error: ambiguous implicit values:
  match expected type Int
     assert(implicitly[Int] == 2) // !!! Not ambiguous in 2.8.0. Ambiguous in 2.7.6
                      ^
+t2866.scala:30: warning: imported `one` is permanently hidden by definition of value one
+    import A.one // warning: imported `one` is permanently hidden by definition of value one.
+             ^
 1 warning
 2 errors

--- a/test/files/neg/t4302.scala
+++ b/test/files/neg/t4302.scala
@@ -1,4 +1,4 @@
-// scalac: -unchecked -Xfatal-warnings
+// scalac: -Xfatal-warnings
 //
 object Test {
   def hasMatch[T](x: AnyRef) = x.isInstanceOf[T]

--- a/test/files/neg/t4440.scala
+++ b/test/files/neg/t4440.scala
@@ -1,4 +1,4 @@
-// scalac: -unchecked -Xfatal-warnings
+// scalac: -Xfatal-warnings
 //
 // constructors used to drop outer fields when they were not accessed
 // however, how can you know (respecting separate compilation) that they're not accessed!?

--- a/test/files/neg/t5887.check
+++ b/test/files/neg/t5887.check
@@ -1,11 +1,11 @@
-t5887.scala:8: warning: A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
-  def g = try 42
-          ^
 t5887.scala:10: error: missing parameter type for expanded function
 The argument types of an anonymous function must be fully known. (SLS 8.5)
 Expected type was: ?
   def h = List("x") map (s => try { case _ => 7 })
                                   ^
+t5887.scala:8: warning: A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
+  def g = try 42
+          ^
 t5887.scala:10: warning: A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
   def h = List("x") map (s => try { case _ => 7 })
                               ^

--- a/test/files/neg/t6582_exhaust_big.scala
+++ b/test/files/neg/t6582_exhaust_big.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -unchecked
+// scalac: -Xfatal-warnings
 //
 sealed abstract class Z
 object Z {

--- a/test/files/neg/t6675.check
+++ b/test/files/neg/t6675.check
@@ -1,4 +1,4 @@
-t6675.scala:12: warning: object X expects 3 patterns to hold (Int, Int, Int) but crushing into 3-tuple to fit single pattern (scala/bug#6675)
+t6675.scala:12: warning: deprecated adaptation: object X expects 3 patterns to hold (Int, Int, Int) but crushing into 3-tuple to fit single pattern (scala/bug#6675)
   "" match { case X(b) => b } // should warn under -Xlint. Not an error because of scala/bug#6111
                   ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t6675b.check
+++ b/test/files/neg/t6675b.check
@@ -1,37 +1,37 @@
-t6675b.scala:19: warning: deprecated adaptation: object LeftOrRight expects 2 patterns to hold (Int, Int) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
-  def f1 = (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match { case LeftOrRight(a) => a  }          // warn
-                                                                       ^
 t6675b.scala:21: error: constructor cannot be instantiated to expected type;
  found   : (T1, T2, T3)
  required: (Int, Int)
   def f3 = (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match { case LeftOrRight((a, b, c)) => a  }  // fail
                                                                                    ^
-t6675b.scala:26: warning: deprecated adaptation: object LeftOrRight expects 2 patterns to hold (A, A) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
-  def f2[A](x: A) = (Left(x -> x): Either[(A, A), (A, A)]) match { case LeftOrRight(a) => a  }          // warn
-                                                                        ^
 t6675b.scala:28: error: constructor cannot be instantiated to expected type;
  found   : (T1, T2, T3)
  required: (?A1, ?A2) where type ?A2 <: A (this is a GADT skolem), type ?A1 <: A (this is a GADT skolem)
   def f4[A](x: A) = (Left(x -> x): Either[(A, A), (A, A)]) match { case LeftOrRight((a, b, c)) => a  }  // fail
                                                                                     ^
-t6675b.scala:32: warning: deprecated adaptation: object NativelyTwo expects 2 patterns to hold ((Int, Int), (Int, Int)) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
-  def f1 = (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match { case NativelyTwo(a) => a  }          // warn
-                                                                       ^
 t6675b.scala:34: error: constructor cannot be instantiated to expected type;
  found   : (T1, T2, T3)
  required: ((Int, Int), (Int, Int))
   def f3 = (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match { case NativelyTwo((a, b, c)) => a  }  // fail
                                                                                    ^
+t6675b.scala:41: error: constructor cannot be instantiated to expected type;
+ found   : (T1, T2, T3)
+ required: ((?A1, ?A2), (?A3, ?A4)) where type ?A4 <: A (this is a GADT skolem), type ?A3 <: A (this is a GADT skolem), type ?A2 <: A (this is a GADT skolem), type ?A1 <: A (this is a GADT skolem)
+  def f4[A](x: A) = (Left(x -> x): Either[(A, A), (A, A)]) match { case NativelyTwo((a, b, c)) => a  }  // fail
+                                                                                    ^
+t6675b.scala:19: warning: deprecated adaptation: object LeftOrRight expects 2 patterns to hold (Int, Int) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
+  def f1 = (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match { case LeftOrRight(a) => a  }          // warn
+                                                                       ^
+t6675b.scala:26: warning: deprecated adaptation: object LeftOrRight expects 2 patterns to hold (A, A) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
+  def f2[A](x: A) = (Left(x -> x): Either[(A, A), (A, A)]) match { case LeftOrRight(a) => a  }          // warn
+                                                                        ^
+t6675b.scala:32: warning: deprecated adaptation: object NativelyTwo expects 2 patterns to hold ((Int, Int), (Int, Int)) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
+  def f1 = (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match { case NativelyTwo(a) => a  }          // warn
+                                                                       ^
 t6675b.scala:38: warning: deprecated adaptation: object NativelyTwo expects 2 patterns to hold (A, A) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
   def f1[A](x: A) = (Left(x): Either[A, A])                match { case NativelyTwo(a) => a  }          // warn
                                                                         ^
 t6675b.scala:39: warning: deprecated adaptation: object NativelyTwo expects 2 patterns to hold ((A, A), (A, A)) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
   def f2[A](x: A) = (Left(x -> x): Either[(A, A), (A, A)]) match { case NativelyTwo(a) => a  }          // warn
                                                                         ^
-t6675b.scala:41: error: constructor cannot be instantiated to expected type;
- found   : (T1, T2, T3)
- required: ((?A1, ?A2), (?A3, ?A4)) where type ?A4 <: A (this is a GADT skolem), type ?A3 <: A (this is a GADT skolem), type ?A2 <: A (this is a GADT skolem), type ?A1 <: A (this is a GADT skolem)
-  def f4[A](x: A) = (Left(x -> x): Either[(A, A), (A, A)]) match { case NativelyTwo((a, b, c)) => a  }  // fail
-                                                                                    ^
 5 warnings
 4 errors

--- a/test/files/neg/t6675b.check
+++ b/test/files/neg/t6675b.check
@@ -1,4 +1,4 @@
-t6675b.scala:19: warning: object LeftOrRight expects 2 patterns to hold (Int, Int) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
+t6675b.scala:19: warning: deprecated adaptation: object LeftOrRight expects 2 patterns to hold (Int, Int) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
   def f1 = (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match { case LeftOrRight(a) => a  }          // warn
                                                                        ^
 t6675b.scala:21: error: constructor cannot be instantiated to expected type;
@@ -6,7 +6,7 @@ t6675b.scala:21: error: constructor cannot be instantiated to expected type;
  required: (Int, Int)
   def f3 = (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match { case LeftOrRight((a, b, c)) => a  }  // fail
                                                                                    ^
-t6675b.scala:26: warning: object LeftOrRight expects 2 patterns to hold (A, A) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
+t6675b.scala:26: warning: deprecated adaptation: object LeftOrRight expects 2 patterns to hold (A, A) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
   def f2[A](x: A) = (Left(x -> x): Either[(A, A), (A, A)]) match { case LeftOrRight(a) => a  }          // warn
                                                                         ^
 t6675b.scala:28: error: constructor cannot be instantiated to expected type;
@@ -14,7 +14,7 @@ t6675b.scala:28: error: constructor cannot be instantiated to expected type;
  required: (?A1, ?A2) where type ?A2 <: A (this is a GADT skolem), type ?A1 <: A (this is a GADT skolem)
   def f4[A](x: A) = (Left(x -> x): Either[(A, A), (A, A)]) match { case LeftOrRight((a, b, c)) => a  }  // fail
                                                                                     ^
-t6675b.scala:32: warning: object NativelyTwo expects 2 patterns to hold ((Int, Int), (Int, Int)) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
+t6675b.scala:32: warning: deprecated adaptation: object NativelyTwo expects 2 patterns to hold ((Int, Int), (Int, Int)) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
   def f1 = (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match { case NativelyTwo(a) => a  }          // warn
                                                                        ^
 t6675b.scala:34: error: constructor cannot be instantiated to expected type;
@@ -22,10 +22,10 @@ t6675b.scala:34: error: constructor cannot be instantiated to expected type;
  required: ((Int, Int), (Int, Int))
   def f3 = (Left((0, 0)): Either[(Int, Int), (Int, Int)]) match { case NativelyTwo((a, b, c)) => a  }  // fail
                                                                                    ^
-t6675b.scala:38: warning: object NativelyTwo expects 2 patterns to hold (A, A) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
+t6675b.scala:38: warning: deprecated adaptation: object NativelyTwo expects 2 patterns to hold (A, A) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
   def f1[A](x: A) = (Left(x): Either[A, A])                match { case NativelyTwo(a) => a  }          // warn
                                                                         ^
-t6675b.scala:39: warning: object NativelyTwo expects 2 patterns to hold ((A, A), (A, A)) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
+t6675b.scala:39: warning: deprecated adaptation: object NativelyTwo expects 2 patterns to hold ((A, A), (A, A)) but crushing into 2-tuple to fit single pattern (scala/bug#6675)
   def f2[A](x: A) = (Left(x -> x): Either[(A, A), (A, A)]) match { case NativelyTwo(a) => a  }          // warn
                                                                         ^
 t6675b.scala:41: error: constructor cannot be instantiated to expected type;

--- a/test/files/neg/t7171.scala
+++ b/test/files/neg/t7171.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -unchecked
+// scalac: -Xfatal-warnings
 //
 trait T {
   final case class A()

--- a/test/files/neg/t7171b.scala
+++ b/test/files/neg/t7171b.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -unchecked
+// scalac: -Xfatal-warnings
 //
 trait T {
   final case class A()

--- a/test/files/neg/t7187.check
+++ b/test/files/neg/t7187.check
@@ -1,7 +1,3 @@
-t7187.scala:12: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => Any), rather than applied to `()`.
-Write foo() to invoke method foo, or change the expected type.
-  val t1b: () => Any = foo   // eta-expansion, but lint warning
-                       ^
 t7187.scala:16: error: _ must follow method; cannot follow () => String
   val t1f: Any       = foo() _ // error: _ must follow method
                           ^
@@ -18,13 +14,22 @@ t7187.scala:23: error: not enough arguments for method apply: (i: Int): Char in 
 Unspecified value parameter i.
   val t2e: Any       = bar() _ // error: not enough arguments for method apply
                           ^
+t7187.scala:29: error: _ must follow method; cannot follow String
+  val t3d: Any       = baz() _ // error: _ must follow method
+                          ^
+t7187.scala:38: error: missing argument list for method zup in class EtaExpandZeroArg
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `zup _` or `zup(_)` instead of `zup`.
+  val t5a = zup // error in 2.13, eta-expansion in 2.14
+            ^
+t7187.scala:12: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => Any), rather than applied to `()`.
+Write foo() to invoke method foo, or change the expected type.
+  val t1b: () => Any = foo   // eta-expansion, but lint warning
+                       ^
 t7187.scala:26: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => Any), rather than applied to `()`.
 Write baz() to invoke method baz, or change the expected type.
   val t3a: () => Any = baz   // eta-expansion, but lint warning
                        ^
-t7187.scala:29: error: _ must follow method; cannot follow String
-  val t3d: Any       = baz() _ // error: _ must follow method
-                          ^
 t7187.scala:32: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => Any), rather than applied to `()`.
 Write zap() to invoke method zap, or change the expected type.
   val t4a: () => Any = zap     // eta-expansion, but lint warning
@@ -33,11 +38,6 @@ t7187.scala:33: warning: An unapplied 0-arity method was eta-expanded (due to th
 Write zap()() to invoke method zap, or change the expected type.
   val t4b: () => Any = zap()   // ditto
                           ^
-t7187.scala:38: error: missing argument list for method zup in class EtaExpandZeroArg
-Unapplied methods are only converted to functions when a function type is expected.
-You can make this conversion explicit by writing `zup _` or `zup(_)` instead of `zup`.
-  val t5a = zup // error in 2.13, eta-expansion in 2.14
-            ^
 t7187.scala:40: warning: Eta-expansion performed to meet expected type AcciSamOne, which is SAM-equivalent to Int => Int,
 even though trait AcciSamOne is not annotated with `@FunctionalInterface`;
 to suppress warning, add the annotation or write out the equivalent function literal.

--- a/test/files/neg/t7294.check
+++ b/test/files/neg/t7294.check
@@ -1,10 +1,6 @@
-t7294.scala:4: warning: fruitless type test: a value of type (Int, Int) cannot also be a Seq[A]
-  (1, 2) match { case Seq() => 0; case _ => 1 }
-                         ^
 t7294.scala:4: error: pattern type is incompatible with expected type;
  found   : Seq[A]
  required: (Int, Int)
   (1, 2) match { case Seq() => 0; case _ => 1 }
                          ^
-1 warning
 1 error

--- a/test/files/neg/t7691.check
+++ b/test/files/neg/t7691.check
@@ -1,3 +1,21 @@
+t7691.scala:16: error: value _ is not a member of object X
+  def x = X.`_`       // value _ is not a member of object X
+            ^
+t7691.scala:18: error: value _ is not a member of object Y
+  def y = Y.`_`       // still not
+            ^
+t7691.scala:20: error: value _ is not a member of object Z
+  def z = Z.`_`       // still not
+            ^
+t7691.scala:22: error: value _ is not a member of object V
+  def v = V.`_`       // still not
+            ^
+t7691.scala:24: error: value _ is not a member of object W
+  def w = W.`_`       // still not
+            ^
+t7691.scala:26: error: value _ is not a member of object Q
+  def q = Q.`_`       // still not
+            ^
 t7691.scala:2: warning: Pattern definition introduces Unit-valued member of X; consider wrapping it in `locally { ... }`.
 object X { val _ = 42 }
                ^
@@ -31,23 +49,5 @@ object Q { val _ @ _ = 42 ; val _ = 17 }         // was error
 t7691.scala:12: warning: Pattern definition introduces Unit-valued member of Q; consider wrapping it in `locally { ... }`.
 object Q { val _ @ _ = 42 ; val _ = 17 }         // was error
                                 ^
-t7691.scala:16: error: value _ is not a member of object X
-  def x = X.`_`       // value _ is not a member of object X
-            ^
-t7691.scala:18: error: value _ is not a member of object Y
-  def y = Y.`_`       // still not
-            ^
-t7691.scala:20: error: value _ is not a member of object Z
-  def z = Z.`_`       // still not
-            ^
-t7691.scala:22: error: value _ is not a member of object V
-  def v = V.`_`       // still not
-            ^
-t7691.scala:24: error: value _ is not a member of object W
-  def w = W.`_`       // still not
-            ^
-t7691.scala:26: error: value _ is not a member of object Q
-  def q = Q.`_`       // still not
-            ^
 11 warnings
 6 errors

--- a/test/files/neg/t8704.check
+++ b/test/files/neg/t8704.check
@@ -1,11 +1,11 @@
-t8704.scala:9: warning: 2 parameter sections are effectively implicit
-class D(private implicit val i: Int)(implicit s: String)
-                                                        ^
 t8704.scala:5: error: an implicit parameter section must be last
 class C(i: Int)(implicit j: Int)(implicit k: Int)(n: Int) {
                 ^
 t8704.scala:5: error: multiple implicit parameter sections are not allowed
 class C(i: Int)(implicit j: Int)(implicit k: Int)(n: Int) {
                                  ^
+t8704.scala:9: warning: 2 parameter sections are effectively implicit
+class D(private implicit val i: Int)(implicit s: String)
+                                                        ^
 1 warning
 2 errors

--- a/test/files/neg/unchecked-impossible.check
+++ b/test/files/neg/unchecked-impossible.check
@@ -1,10 +1,6 @@
-unchecked-impossible.scala:7: warning: fruitless type test: a value of type T2[Int,Int] cannot also be a Seq[A]
-    case Seq(x) =>
-            ^
 unchecked-impossible.scala:7: error: pattern type is incompatible with expected type;
  found   : Seq[A]
  required: T2[Int,Int]
     case Seq(x) =>
             ^
-1 warning
 1 error

--- a/test/files/neg/unchecked.scala
+++ b/test/files/neg/unchecked.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -unchecked
+// scalac: -Xfatal-warnings
 //
 import language.existentials
 

--- a/test/files/neg/unchecked2.scala
+++ b/test/files/neg/unchecked2.scala
@@ -1,4 +1,4 @@
-// scalac: -unchecked -Xfatal-warnings
+// scalac: -Xfatal-warnings
 //
 object Test {
   // These warn because it can be statically shown they won't match.

--- a/test/files/neg/virtpatmat_exhaust_big.scala
+++ b/test/files/neg/virtpatmat_exhaust_big.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -unchecked
+// scalac: -Xfatal-warnings
 //
 sealed abstract class Z
 object Z {

--- a/test/files/neg/wconfSource1.check
+++ b/test/files/neg/wconfSource1.check
@@ -1,0 +1,7 @@
+wconfSource1.scala:10: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+  def u = { 1; 2 }
+            ^
+wconfSource1.scala:9: error: method dep in class C is deprecated:
+  def t = dep
+          ^
+1 error

--- a/test/files/neg/wconfSource1.scala
+++ b/test/files/neg/wconfSource1.scala
@@ -1,0 +1,11 @@
+// scalac: -Wconf:src=.*Source.*&cat=deprecation:e,src=Source1.scala&msg=statement:e,src=wconfSource1&msg=statement:e,src=wconfSource1.scala&msg=statement:i
+
+// src=Source1.scala doesn't match: the pattern needs to start at a path segment (after `/`)
+// src=wconfSource1 doesn't match: the pattern needs to match to the end of the path (.scala)
+// src=wconfSource1.scala matches
+
+class C {
+  @deprecated("", "") def dep = 0
+  def t = dep
+  def u = { 1; 2 }
+}

--- a/test/files/neg/wconfSource2.check
+++ b/test/files/neg/wconfSource2.check
@@ -1,0 +1,15 @@
+wconfSource2.scala:6: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+  def u = { 1; 2 }
+            ^
+wconfSource2.scala:7: reflective access of structural type member method f should be enabled
+by making the implicit value scala.language.reflectiveCalls visible.
+This can be achieved by adding the import clause 'import scala.language.reflectiveCalls'
+or by setting the compiler option -language:reflectiveCalls.
+See the Scaladoc for value scala.language.reflectiveCalls for a discussion
+why the feature should be explicitly enabled.
+  def v(a: { def f: Int }) = a.f
+                               ^
+wconfSource2.scala:5: error: method dep in class C is deprecated:
+  def t = dep
+          ^
+1 error

--- a/test/files/neg/wconfSource2.scala
+++ b/test/files/neg/wconfSource2.scala
@@ -1,0 +1,8 @@
+// scalac: -Wconf:src=test/files/neg/wconfSource2.scala&cat=deprecation:e,src=test/.*&msg=statement:i,src=/neg/.*&cat=feature-reflective-calls:i
+
+class C {
+  @deprecated("", "") def dep = 0
+  def t = dep
+  def u = { 1; 2 }
+  def v(a: { def f: Int }) = a.f
+}

--- a/test/files/pos/nonlocal-unchecked.scala
+++ b/test/files/pos/nonlocal-unchecked.scala
@@ -1,4 +1,4 @@
-// scalac: -unchecked -Xfatal-warnings
+// scalac: -Xfatal-warnings
 class A {
   def f: Boolean = {
     val xs = Nil map (_ => return false)

--- a/test/files/pos/polymorphic-case-class.scala
+++ b/test/files/pos/polymorphic-case-class.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -unchecked
+// scalac: -Xfatal-warnings
 //
 // no unchecked warnings
 case class Bippy[T, -U, +V](x: T, z: V) { }

--- a/test/files/pos/t1439.scala
+++ b/test/files/pos/t1439.scala
@@ -1,5 +1,5 @@
 
-// scalac: -unchecked -Xfatal-warnings
+// scalac: -Xfatal-warnings
 
 import language.higherKinds
 

--- a/test/files/pos/t4911.scala
+++ b/test/files/pos/t4911.scala
@@ -1,5 +1,5 @@
 
-// scalac: -unchecked -Xfatal-warnings
+// scalac: -Xfatal-warnings
 //
 import language._
 

--- a/test/files/pos/t5542.scala
+++ b/test/files/pos/t5542.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -unchecked
+// scalac: -Xfatal-warnings
 //
 class Test {
   Option(3) match { case Some(n) => n; case None => 0 }

--- a/test/files/pos/t9369.scala
+++ b/test/files/pos/t9369.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -unchecked
+// scalac: -Xfatal-warnings
 //
 object Test {
 

--- a/test/files/pos/unchecked-a.scala
+++ b/test/files/pos/unchecked-a.scala
@@ -1,4 +1,4 @@
-// scalac: -unchecked -Xfatal-warnings
+// scalac: -Xfatal-warnings
 //
 trait Y
 trait Z extends Y

--- a/test/files/run/indyLambdaKinds.check
+++ b/test/files/run/indyLambdaKinds.check
@@ -35,7 +35,7 @@ Inlining into Main$.t2b
 Inlining into Main$.t3b
  inlined A_1.c (the callsite is annotated `@inline`). Before: 10 ins, after: 21 ins.
  rewrote invocations of closure allocated in Main$.t3b with body <init>: INVOKEINTERFACE java/util/function/Function.apply (Ljava/lang/Object;)Ljava/lang/Object; (itf)
-warning: 6 inliner warnings; re-run enabling -opt-warnings for details, or try -help
+warning: 6 optimizer warnings; re-run enabling -opt-warnings for details, or try -help
 m1
 m1
 m2

--- a/test/files/run/settings-parse.check
+++ b/test/files/run/settings-parse.check
@@ -1,15 +1,12 @@
 0) List(-cp, ) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 1) List(-cp, , ) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 2) List(, -cp, ) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
@@ -68,22 +65,18 @@
 }
 
 12) List(-cp, , foo.scala) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 13) List(-cp, , , foo.scala) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 14) List(-cp, , foo.scala, ) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 15) List(, -cp, , foo.scala) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
@@ -202,22 +195,18 @@
 }
 
 35) List(foo.scala, -cp, ) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 36) List(, foo.scala, -cp, ) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 37) List(foo.scala, -cp, , ) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 38) List(foo.scala, , -cp, ) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
@@ -282,17 +271,14 @@
 }
 
 0) List(-cp, /tmp:/bippy) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 1) List(-cp, /tmp:/bippy, ) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 2) List(, -cp, /tmp:/bippy) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
@@ -351,22 +337,18 @@
 }
 
 12) List(-cp, /tmp:/bippy, foo.scala) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 13) List(-cp, /tmp:/bippy, , foo.scala) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 14) List(-cp, /tmp:/bippy, foo.scala, ) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 15) List(, -cp, /tmp:/bippy, foo.scala) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
@@ -485,22 +467,18 @@
 }
 
 35) List(foo.scala, -cp, /tmp:/bippy) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 36) List(, foo.scala, -cp, /tmp:/bippy) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 37) List(foo.scala, -cp, /tmp:/bippy, ) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 38) List(foo.scala, , -cp, /tmp:/bippy) ==> Settings {
-  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 

--- a/test/files/run/settings-parse.check
+++ b/test/files/run/settings-parse.check
@@ -1,468 +1,566 @@
 0) List(-cp, ) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 1) List(-cp, , ) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 2) List(, -cp, ) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 3) List(-cp, , -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 4) List(-cp, , , -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 5) List(-cp, , -deprecation, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 6) List(, -cp, , -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 7) List(-cp, , -deprecation, foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 8) List(-cp, , , -deprecation, foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 9) List(-cp, , -deprecation, , foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 10) List(-cp, , -deprecation, foo.scala, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 11) List(, -cp, , -deprecation, foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 12) List(-cp, , foo.scala) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 13) List(-cp, , , foo.scala) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 14) List(-cp, , foo.scala, ) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 15) List(, -cp, , foo.scala) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 16) List(-cp, , foo.scala, -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 17) List(-cp, , , foo.scala, -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 18) List(-cp, , foo.scala, , -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 19) List(-cp, , foo.scala, -deprecation, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 20) List(, -cp, , foo.scala, -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 21) List(-deprecation, -cp, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 22) List(, -deprecation, -cp, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 23) List(-deprecation, -cp, , ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 24) List(-deprecation, , -cp, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 25) List(-deprecation, -cp, , foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 26) List(, -deprecation, -cp, , foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 27) List(-deprecation, -cp, , , foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 28) List(-deprecation, -cp, , foo.scala, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 29) List(-deprecation, , -cp, , foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 30) List(-deprecation, foo.scala, -cp, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 31) List(, -deprecation, foo.scala, -cp, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 32) List(-deprecation, , foo.scala, -cp, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 33) List(-deprecation, foo.scala, -cp, , ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 34) List(-deprecation, foo.scala, , -cp, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 35) List(foo.scala, -cp, ) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 36) List(, foo.scala, -cp, ) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 37) List(foo.scala, -cp, , ) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 38) List(foo.scala, , -cp, ) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 39) List(foo.scala, -cp, , -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 40) List(, foo.scala, -cp, , -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 41) List(foo.scala, -cp, , , -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 42) List(foo.scala, -cp, , -deprecation, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 43) List(foo.scala, , -cp, , -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 44) List(foo.scala, -deprecation, -cp, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 45) List(, foo.scala, -deprecation, -cp, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 46) List(foo.scala, , -deprecation, -cp, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 47) List(foo.scala, -deprecation, -cp, , ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 48) List(foo.scala, -deprecation, , -cp, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 0) List(-cp, /tmp:/bippy) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 1) List(-cp, /tmp:/bippy, ) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 2) List(, -cp, /tmp:/bippy) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 3) List(-cp, /tmp:/bippy, -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 4) List(-cp, /tmp:/bippy, , -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 5) List(-cp, /tmp:/bippy, -deprecation, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 6) List(, -cp, /tmp:/bippy, -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 7) List(-cp, /tmp:/bippy, -deprecation, foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 8) List(-cp, /tmp:/bippy, , -deprecation, foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 9) List(-cp, /tmp:/bippy, -deprecation, , foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 10) List(-cp, /tmp:/bippy, -deprecation, foo.scala, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 11) List(, -cp, /tmp:/bippy, -deprecation, foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 12) List(-cp, /tmp:/bippy, foo.scala) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 13) List(-cp, /tmp:/bippy, , foo.scala) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 14) List(-cp, /tmp:/bippy, foo.scala, ) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 15) List(, -cp, /tmp:/bippy, foo.scala) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 16) List(-cp, /tmp:/bippy, foo.scala, -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 17) List(-cp, /tmp:/bippy, , foo.scala, -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 18) List(-cp, /tmp:/bippy, foo.scala, , -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 19) List(-cp, /tmp:/bippy, foo.scala, -deprecation, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 20) List(, -cp, /tmp:/bippy, foo.scala, -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 21) List(-deprecation, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 22) List(, -deprecation, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 23) List(-deprecation, -cp, /tmp:/bippy, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 24) List(-deprecation, , -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 25) List(-deprecation, -cp, /tmp:/bippy, foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 26) List(, -deprecation, -cp, /tmp:/bippy, foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 27) List(-deprecation, -cp, /tmp:/bippy, , foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 28) List(-deprecation, -cp, /tmp:/bippy, foo.scala, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 29) List(-deprecation, , -cp, /tmp:/bippy, foo.scala) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 30) List(-deprecation, foo.scala, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 31) List(, -deprecation, foo.scala, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 32) List(-deprecation, , foo.scala, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 33) List(-deprecation, foo.scala, -cp, /tmp:/bippy, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 34) List(-deprecation, foo.scala, , -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 35) List(foo.scala, -cp, /tmp:/bippy) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 36) List(, foo.scala, -cp, /tmp:/bippy) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 37) List(foo.scala, -cp, /tmp:/bippy, ) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 38) List(foo.scala, , -cp, /tmp:/bippy) ==> Settings {
+  -Wconf = List(cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 39) List(foo.scala, -cp, /tmp:/bippy, -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 40) List(, foo.scala, -cp, /tmp:/bippy, -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 41) List(foo.scala, -cp, /tmp:/bippy, , -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 42) List(foo.scala, -cp, /tmp:/bippy, -deprecation, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 43) List(foo.scala, , -cp, /tmp:/bippy, -deprecation) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 44) List(foo.scala, -deprecation, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 45) List(, foo.scala, -deprecation, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 46) List(foo.scala, , -deprecation, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 47) List(foo.scala, -deprecation, -cp, /tmp:/bippy, ) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 48) List(foo.scala, -deprecation, , -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
+  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 

--- a/test/files/run/synchronized.scala
+++ b/test/files/run/synchronized.scala
@@ -1,7 +1,7 @@
 // scalac: -opt:l:inline -opt-inline-from:**
 //
 /*
- * filter: inliner warnings;
+ * filter: optimizer warnings;
  */
 import java.lang.Thread.holdsLock
 import scala.collection.mutable.StringBuilder

--- a/test/files/run/t10067.flags
+++ b/test/files/run/t10067.flags
@@ -1,1 +1,0 @@
--unchecked

--- a/test/files/run/t7171.check
+++ b/test/files/run/t7171.check
@@ -1,6 +1,6 @@
-t7171.scala:4: warning: The outer reference in this type test cannot be checked at run time.
+t7171.scala:2: warning: The outer reference in this type test cannot be checked at run time.
   final case class A()
                    ^
-t7171.scala:11: warning: The outer reference in this type test cannot be checked at run time.
+t7171.scala:9: warning: The outer reference in this type test cannot be checked at run time.
     case _: A => true; case _ => false
           ^

--- a/test/files/run/t7171.scala
+++ b/test/files/run/t7171.scala
@@ -1,5 +1,3 @@
-// scalac: -unchecked
-//
 trait T {
   final case class A()
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -1512,7 +1512,7 @@ class InlinerTest extends BytecodeTesting {
         |  def t3 = mc // lines
         |}
       """.stripMargin
-    val run = compiler.newRun
+    val run = compiler.newRun()
     run.compileSources(List(makeSourceFile(code1, "A.scala"), makeSourceFile(code2, "B.scala")))
     val List(_, _, c) = readAsmClasses(getGeneratedClassfiles(global.settings.outputDirs.getSingleOutput.get))
     def is(name: String) = getMethod(c, name).instructions.filterNot(_.isInstanceOf[FrameEntry])

--- a/test/junit/scala/tools/nsc/reporters/WConfTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/WConfTest.scala
@@ -1,0 +1,348 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.nsc
+package reporters
+
+import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.Test
+import java.io.{File => JFile}
+
+import scala.collection.mutable.ListBuffer
+import scala.reflect.internal.util.{BatchSourceFile, Position}
+import scala.reflect.internal.{Reporter => InternalReporter}
+import scala.reflect.io.PlainFile
+import scala.tools.nsc.Reporting.{Version, WarningCategory}
+import scala.reflect.io.File
+import scala.tools.nsc.reporters.StoreReporter.Info
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.BytecodeTesting._
+
+class WConfTest extends BytecodeTesting {
+  import compiler._
+
+  override def compilerArgs: String = "-opt:l:inline -opt-inline-from:**"
+
+  def Wconf = global.settings.Wconf
+  val WconfDefault = cached("WConfDefault", () => Wconf.value)
+
+  def errors(code: String, extraWconf: String = "", lint: Boolean = false): List[Info] =
+    reports(code, extraWconf, lint).filter(_.severity == InternalReporter.ERROR)
+
+  def infos(code: String, extraWconf: String = "", lint: Boolean = false): List[Info] =
+    reports(code, extraWconf, lint).filter(_.severity == InternalReporter.INFO)
+
+  def reports(code: String, extraWconf: String = "", lint: Boolean = false): List[Info] = {
+    // lint has a postSetHook to enable `deprecated`, which in turn adds to `Wconf`,
+    // but since we override Wconf after, that effect is cancelled
+    if (lint) global.settings.lint.tryToSet(List("_"))
+    Wconf.clear()
+    Wconf.tryToSet(WconfDefault)
+    if (extraWconf.nonEmpty) Wconf.tryToSet(extraWconf.split(',').toList)
+    val run = newRun()
+    run.compileSources(makeSourceFile(code, "unitTestSource.scala") :: Nil)
+    if (lint) global.settings.lint.clear()
+    global.reporter.asInstanceOf[StoreReporter].infos.toList.sortBy(p => (if (p.pos.isDefined) p.pos.point else -1, p.msg))
+  }
+
+  val code =
+    """class A {
+      |  @deprecated def f = 0
+      |  @deprecated("message", "my specs2 1.2.3-custom") def g = 0
+      |
+      |  def invokeDeprecated = f + g
+      |
+      |  def featureReflectiveCalls(a: { def f: Int }) = a.f
+      |
+      |  def pureExpressionAsStatement = {1; 2}
+      |
+      |  def fruitlessTypeTest = Some(List(1)).isInstanceOf[Option[List[String]]]
+      |
+      |  def uncheckedTypeTest = Some(123).isInstanceOf[Option[Option[_]]]
+      |
+      |  class Outer {
+      |    final case class UncheckedWarningSummarized(val s: String)
+      |  }
+      |
+      |  @inline def nonFinal = 0
+      |  def optimizerWarning = nonFinal
+      |
+      |  def tupleMethod(a: (Int, Int)) = 0
+      |  def lintAdaptedArgs = tupleMethod(1, 2)
+      |}
+      |""".stripMargin
+
+  val l2 = (2, "Specify both message and version: @deprecated(\"message\", since = \"1.0\")")
+  val l5a = (5, "method f in class A is deprecated")
+  val l5b = (5, "method g in class A is deprecated")
+  val l7 = (7, "reflective access of structural type member method f should be enabled")
+  val l9 = (9, "a pure expression does nothing in statement position")
+  val l11 = (11, "fruitless type test: a value of type Some[List[Int]] cannot also be a Option[List[String]]")
+  val l13 = (13, "non-variable type argument Option[_] in type Option[Option[_]] is unchecked since it is eliminated by erasure")
+  val l16 = (16, "The outer reference in this type test cannot be checked at run time")
+  val l20 = (20, "A::nonFinal()I is annotated @inline but could not be inlined")
+  val l23 = (23, "adapted the argument list to the expected 2-tuple")
+
+  val s1a = (-1, "1 deprecation")
+  val s1b = (-1, "1 deprecation (since my specs2 1.2.3-custom)")
+  val s1c = (-1, "2 deprecations in total")
+  val s2 = (-1, "1 feature warning")
+  val s3 = (-1, "1 optimizer warning")
+  val s4 = (-1, "2 unchecked warnings")
+
+  def check(actual: List[Info], expected: List[(Int, String)]): Unit = {
+    def m(a: Info, e: (Int, String)) = a != null && e != null && (if (a.pos.isDefined) a.pos.line else -1) == e._1 && a.msg.contains(e._2)
+    val ok = actual.zipAll(expected, null, null) forall {
+      case (a, e) => m(a, e)
+    }
+    if (!ok) {
+      val msg = ListBuffer.empty[String]
+      actual
+        .filterNot(a => expected.exists(e => m(a, e)))
+        .foreach(a => msg += s"not expected: $a")
+      expected
+        .filterNot(e => actual.exists(a => m(a, e)))
+        .foreach(e => msg += s"no actual for: $e")
+      assert(false, s"\n-----------------\nactual:\n${actual.mkString("\n")}\n-----------------\nexpected:\n${expected.mkString("\n")}\n-----------------\n${msg.mkString("\n")}")
+    }
+  }
+
+  @Test
+  def default(): Unit = {
+    check(reports(code), List(s1a, s1b, s2, s3, s1c, l9, l11, l13, l16))
+    check(reports(code, "cat=unchecked:ws"), List(s1a, s1b, s2, s3, s1c, s4, l9, l11))
+  }
+
+  @Test
+  def noSummarizing(): Unit = {
+    check(reports(code, "any:w"), List(l5a, l5b, l7, l9, l11, l13, l16, l20))
+    check(reports(code, "any:w", lint = true), List(l2, l5a, l5b, l7, l9, l11, l13, l16, l20, l23))
+  }
+
+  @Test
+  def warnVerbose(): Unit = {
+    check(reports(code, "any:wv"), List(
+      l5a.copy(_2 = "[deprecation @ A.invokeDeprecated | origin=A.f | version=] " + l5a._2),
+      l5b.copy(_2 = "[deprecation @ A.invokeDeprecated | origin=A.g | version=1.2.3] " + l5b._2),
+      l7.copy(_2 = "[feature-reflective-calls @ A.featureReflectiveCalls] " + l7._2),
+      l9.copy(_2 = "[other-pure-statement @ A.pureExpressionAsStatement] " + l9._2),
+      l11.copy(_2 = "[other @ A.fruitlessTypeTest] " + l11._2),
+      l13.copy(_2 = "[unchecked @ A.uncheckedTypeTest] " + l13._2),
+      l16.copy(_2 = "[unchecked @ A.Outer.UncheckedWarningSummarized.equals] " + l16._2),
+      l20.copy(_2 = "[optimizer @ A.optimizerWarning] " + l20._2)))
+  }
+
+  @Test
+  def silence(): Unit = {
+    check(reports(code, "any:s"), Nil)
+  }
+
+  @Test
+  def deprecationSiteOrigin(): Unit = {
+    check(infos(code, "site=A.f:i"), Nil)
+    check(infos(code, "site=A.invokeDeprecated:i"), List(l5a, l5b))
+    check(infos(code, "origin=A.f:i"), List(l5a))
+    check(infos(code, "origin=A.invokeDeprecated:i"), Nil)
+  }
+
+  @Test
+  def deprecatedSince(): Unit = {
+    check(infos(code, "cat=deprecation:i"), List(l5a, l5b))
+    check(infos(code, "origin=A.[fg]:i"), List(l5a, l5b))
+
+    check(infos(code, "since=1.2.3:i"), List(l5b))
+    check(infos(code, "since=1.2:i"), Nil)
+    check(infos(code, "since=1:i"), Nil)
+
+    check(infos(code, "since>1:i"), List(l5b))
+    check(infos(code, "since>1.2:i"), List(l5b))
+    check(infos(code, "since>1.2.1:i"), List(l5b))
+    check(infos(code, "since>1.2.2:i"), List(l5b))
+    check(infos(code, "since>1.2.3:i"), Nil)
+    check(infos(code, "since>1.3:i"), Nil)
+    check(infos(code, "since>2:i"), Nil)
+
+    check(infos(code, "since<1.2.4:i"), List(l5b))
+    check(infos(code, "since<1.3.0:i"), List(l5b))
+    check(infos(code, "since<1.3:i"), List(l5b))
+    check(infos(code, "since<2:i"), List(l5b))
+    check(infos(code, "since<2.3:i"), List(l5b))
+    check(infos(code, "since<2.3.4:i"), List(l5b))
+    check(infos(code, "since<1.2.3:i"), Nil)
+    check(infos(code, "since<1.2:i"), Nil)
+    check(infos(code, "since<1:i"), Nil)
+
+  }
+
+  @Test
+  def filterUnchecked(): Unit = {
+    check(infos(code, "cat=unchecked:i"), List(l13, l16))
+  }
+
+  @Test
+  def featureWarnings(): Unit = {
+    check(infos(code, "cat=feature:i"), List(l7))
+    check(infos(code, "cat=feature-reflective-calls:i"), List(l7))
+    check(infos(code, "cat=feature-higher-kinds:i"), Nil)
+    check(infos(code, "cat=feature&site=A.*:i"), List(l7))
+    check(infos(code, "cat=feature&site=A.featureReflectiveCalls:i"), List(l7))
+    check(infos(code, "cat=unchecked&site=A.featureReflectiveCalls:i"), Nil)
+    check(infos(code, "cat=feature&site=A.invokeDeprecated:i"), Nil)
+  }
+
+  @Test
+  def lint(): Unit = {
+    check(infos(code, "cat=lint:i"), Nil)
+    check(infos(code, "cat=lint:i", lint = true), List(l2, l23))
+    check(reports(code, "cat=lint:ws,any:s", lint = true), List((-1, "2 lint warnings")))
+    check(infos(code, "cat=lint-deprecation:i", lint = true), List(l2))
+    check(infos(code, "cat=lint-adapted-args:i", lint = true), List(l23))
+  }
+
+  @Test
+  def messageFilters(): Unit = {
+    check(errors(code, "msg=(b"), (-1, "no filters or no action defined") :: Nil)
+    check(errors(code, "msg=(b:i"), (-1, "invalid pattern `(b`: Unclosed group near index 2") :: Nil)
+    check(infos(code, "msg=method:i"), List(l5a, l5b, l7, l20))
+    check(infos(code, "msg=.*is deprecated.*:i"), List(l5a, l5b))
+    check(infos(code, "msg=is deprecated$:i"), List(l5a))
+    check(infos(code, "msg=^is deprecated:i"), Nil)
+  }
+
+  @Test
+  def parseVersion(): Unit = {
+    def check(s: String, ev: Version): Unit = Version.fromString(s) match {
+      case pv: Version.ParseableVersion =>
+        assertEquals(ev, pv.copy(orig = ""))
+      case nv: Version.NonParseableVersion =>
+        assertTrue(s"failed to parse $s, expected $ev", ev.isInstanceOf[Version.NonParseableVersion])
+    }
+
+    val v123 = Version.ParseableVersion("", 1, Some(2), Some(3))
+    val v12 = Version.ParseableVersion("", 1, Some(2), None)
+    val v1 = Version.ParseableVersion("", 1, None, None)
+    val nv = Version.NonParseableVersion("")
+
+    check("1.2.3", v123)
+    check("1.2.3m", v12)
+    check("1.2x.3", v1)
+    check("my library 1.2.3-patch-44.0", v123)
+    check("specs2-33 1.2.3.10-patch-44.0", v123)
+    check("   1.2.3.10-patch-44.0 has a tail", v123)
+    check("knut 1.2-m3.10-patch-44.0 has a tail", v12)
+    check("knut 1 am 1.2.3 so", v1)
+    check("spec2.2", nv)
+    check("only text, 1here", nv)
+    check("", nv)
+  }
+
+  @Test
+  def versionComparison(): Unit = {
+    val s = (a: Version.ParseableVersion, b: Version.ParseableVersion) => a.smaller(b)
+    val e = (a: Version.ParseableVersion, b: Version.ParseableVersion) => a.same(b)
+    val g = (a: Version.ParseableVersion, b: Version.ParseableVersion) => a.greater(b)
+
+    val ns = (a: Version.ParseableVersion, b: Version.ParseableVersion) => !a.smaller(b)
+    val ne = (a: Version.ParseableVersion, b: Version.ParseableVersion) => !a.same(b)
+    val ng = (a: Version.ParseableVersion, b: Version.ParseableVersion) => !a.greater(b)
+
+    val name = Map(s -> "!<", e -> "!=", g -> "!>", ns -> "<", ne -> "=", ng -> ">")
+
+    def check(a: Version.ParseableVersion, b: Version.ParseableVersion, op: (Version.ParseableVersion, Version.ParseableVersion) => Boolean): Unit ={
+      assertTrue(s"$a ${name(op)} $b", op(a, b))
+    }
+
+    object v {
+      def apply(maj: Int) = Version.ParseableVersion("", maj, None, None)
+      def apply(maj: Int, min: Int) = Version.ParseableVersion("", maj, Some(min), None)
+      def apply(maj: Int, min: Int, pat: Int) = Version.ParseableVersion("", maj, Some(min), Some(pat))
+    }
+
+    val v1 = v(1)
+    val v12 = v(1, 2)
+    val v123 = v(1,2,3)
+    val v124 = v(1,2,4)
+
+    val v10 = v(1, 0)
+    val v100 = v(1, 0, 0)
+
+    check(v1, v1, ns)
+    check(v1, v1, e)
+    check(v1, v1, ng)
+
+    check(v1, v12, s)
+    check(v1, v12, ne)
+    check(v1, v12, ng)
+
+    check(v1, v123, s)
+    check(v1, v123, ne)
+    check(v1, v123, ng)
+
+    check(v1, v10, ns)
+    check(v1, v10, e)
+    check(v1, v10, ng)
+
+    check(v1, v100, ns)
+    check(v1, v100, e)
+    check(v1, v100, ng)
+
+    check(v123, v1, ns)
+    check(v123, v1, ne)
+    check(v123, v1, g)
+
+    check(v123, v12, ns)
+    check(v123, v12, ne)
+    check(v123, v12, g)
+
+    check(v123, v123, ns)
+    check(v123, v123, e)
+    check(v123, v123, ng)
+
+    check(v123, v124, s)
+    check(v123, v124, ne)
+    check(v123, v124, ng)
+  }
+
+  @Test
+  def sourcePatternTest(): Unit = {
+    def m(p: String) = Reporting.Message.Plain(
+      Position.offset(new BatchSourceFile(new PlainFile(new File(new JFile(p))) {
+        override lazy val canonicalPath: String = p
+      }, Array()), 0),
+      msg = "",
+      WarningCategory.Other,
+      site = "")
+
+    val aTest = Reporting.WConf.parseFilter("src=a/.*Test.scala", rootDir = "").getOrElse(null)
+    assertTrue(aTest.matches(m("/a/FooTest.scala")))
+    assertTrue(aTest.matches(m("/x/a/b/FooTest.scala")))
+    assertTrue(aTest.matches(m("c:\\my user\\a\\Test.scala")))
+    assertTrue(!aTest.matches(m("/x/mama/Test.scala")))
+
+    val noScala = Reporting.WConf.parseFilter("src=a/.*Test", rootDir = "").getOrElse(null)
+    assertTrue(!noScala.matches(m("/x/a/FooTest.scala")))
+
+    val withRootDir = Reporting.WConf.parseFilter("src=a/.*Test.scala", rootDir = "/root/path").getOrElse(null)
+    assertTrue(withRootDir.matches(m("/root/path/a/FooTest.scala")))
+    assertTrue(withRootDir.matches(m("/root/path/a/b/c/FooTest.scala")))
+    assertTrue(!withRootDir.matches(m("/root/path/xa/FooTest.scala")))
+    assertTrue(!withRootDir.matches(m("/root/a/FooTest.scala")))
+    assertTrue(!withRootDir.matches(m("/root/path/b/a/FooTest.scala")))
+
+    val withRootDirWin = Reporting.WConf.parseFilter("src=a/.*Test.scala", rootDir = "c:/root/path").getOrElse(null)
+    assertTrue(withRootDirWin.matches(m("c:/root/path/a/FooTest.scala")))
+    assertTrue(withRootDirWin.matches(m("c:/root/path/a/b/c/FooTest.scala")))
+    assertTrue(!withRootDirWin.matches(m("c:/root/path/xa/FooTest.scala")))
+    assertTrue(!withRootDirWin.matches(m("c:/root/a/FooTest.scala")))
+    assertTrue(!withRootDirWin.matches(m("c:/root/path/b/a/FooTest.scala")))
+  }
+}

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
@@ -7,6 +7,7 @@ import scala.reflect.internal.util.Statistics
 import scala.tools.util.PathResolver
 import util.ClassPath
 import io.AbstractFile
+import scala.tools.nsc.Reporting.WarningCategory
 
 /**
  * A complete SymbolTable implementation designed to be used in JUnit tests.
@@ -51,6 +52,8 @@ class SymbolTableForUnitTesting extends SymbolTable {
       sym.info.member(name)
     protected override def compileLate(srcfile: AbstractFile): Unit =
       sys.error(s"We do not expect compileLate to be called in SymbolTableTest. The srcfile passed in is $srcfile")
+    def warning(pos: Position, msg: String, category: WarningCategory, site: String): Unit =
+      reporter.warning(pos, msg)
   }
 
   class GlobalMirror extends Roots(NoSymbol) {
@@ -88,7 +91,7 @@ class SymbolTableForUnitTesting extends SymbolTable {
   // minimal Run to get Reporting wired
   def currentRun = new RunReporting {}
   class PerRunReporting extends PerRunReportingBase {
-    def deprecationWarning(pos: Position, msg: String, since: String): Unit = reporter.warning(pos, msg)
+    def deprecationWarning(pos: Position, msg: String, since: String, site: String, origin: String): Unit = reporter.warning(pos, msg)
   }
   protected def PerRunReporting = new PerRunReporting
 

--- a/test/junit/scala/tools/nsc/transform/patmat/SolvingTest.scala
+++ b/test/junit/scala/tools/nsc/transform/patmat/SolvingTest.scala
@@ -7,6 +7,7 @@ import org.junit.runners.JUnit4
 
 import scala.collection.mutable
 import scala.reflect.internal.util.Position
+import scala.tools.nsc.transform.patmat.TestSolver.global
 import scala.tools.nsc.{Global, Settings}
 
 object TestSolver extends Logic with Solving {
@@ -75,7 +76,7 @@ object TestSolver extends Logic with Solving {
 
     def prepareNewAnalysis() = {}
 
-    def uncheckedWarning(pos: Position, msg: String) = sys.error(msg)
+    def uncheckedWarning(pos: Position, msg: String, site: global.Symbol): Unit = sys.error(msg)
 
     def reportWarning(msg: String) = sys.error(msg)
 

--- a/test/junit/scala/tools/nsc/typechecker/OverridingPairsTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/OverridingPairsTest.scala
@@ -19,7 +19,7 @@ class OverridingPairsTest extends BytecodeTesting {
         |abstract class AS extends SO
         |class L extends AS with SOSO
       """.stripMargin
-    val run = compiler.newRun
+    val run = compiler.newRun()
     run.compileSources(List(BytecodeTesting.makeSourceFile(code, "UnitTestSource.scala")))
 
     val g = compiler.global

--- a/test/junit/scala/tools/nsc/typechecker/TypedTreeTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/TypedTreeTest.scala
@@ -18,7 +18,7 @@ class TypedTreeTest extends BytecodeTesting {
         |  f(O.x)
         |}
       """.stripMargin
-    val run = compiler.newRun
+    val run = compiler.newRun()
     run.compileSources(List(BytecodeTesting.makeSourceFile(code, "UnitTestSource.scala")))
     val tree = run.units.next().body
     val List(t) = tree.filter(_.attachments.all.nonEmpty).toList

--- a/test/scaladoc/run/t5235.check
+++ b/test/scaladoc/run/t5235.check
@@ -1,5 +1,5 @@
 warning: 1 deprecation (since 2.13.0); re-run with -deprecation for details
-newSource:10: warning: Could not find the type $Coll points to while expanding it for the usecase signature of method reverse in trait SpecificColl.In this context, $Coll = "BullSh".
+newSource:10: warning: Could not find the type $Coll points to while expanding it for the usecase signature of method reverse in trait SpecificColl. In this context, $Coll = "BullSh".
              * @usecase def reverse(): $Coll
                         ^
 Done.

--- a/test/scaladoc/run/t5527.check
+++ b/test/scaladoc/run/t5527.check
@@ -1,12 +1,3 @@
-newSource1.scala:47: warning: discarding unmoored doc comment
-        /** Document this crucial constant for posterity.
-        ^
-newSource1.scala:64: warning: discarding unmoored doc comment
-        /*************************\
-        ^
-newSource1.scala:73: warning: discarding unmoored doc comment
-        val i = 10 */** Important!
-                   ^
 [[syntax trees at end of                    parser]] // newSource1.scala
 package <empty> {
   object UselessComments extends scala.AnyRef {
@@ -130,3 +121,15 @@ package <empty> {
   }
 }
 
+newSource1.scala:42: warning: Tag '@martin' is not recognised
+        /** @martin is this right? It shouldn't flag me as scaladoc. */
+        ^
+newSource1.scala:47: warning: discarding unmoored doc comment
+        /** Document this crucial constant for posterity.
+        ^
+newSource1.scala:64: warning: discarding unmoored doc comment
+        /*************************\
+        ^
+newSource1.scala:73: warning: discarding unmoored doc comment
+        val i = 10 */** Important!
+                   ^


### PR DESCRIPTION
This PR adds a `-Wconf` compiler flag that allows filtering and configuring compiler warnings (silence them, or turn them into errors).

It also integrates the fantastic [silencer](https://github.com/ghik/silencer) compiler plugin by @ghik into the compiler, which allows suppressing warnings locally using the `@nowarn` annotation.

### Configurable Warnings

Warnings are assigned a category.

Warnings can be filtered by category, by message regex, by site where they are issued, and by source path. Deprecations can additionally be filtered by origin (deprecated definition) and `since` version.

Filtered warnings can be reported as error, warning, info, summary (like deprecations) or silent.

### Local Suppression

The `@nowarn` annotation suppresses warnings within the scope covered by the annotation.
  - `@nowarn def foo = ...`, `@nowarn class C { ... }`: suppress warnings in a definition
  - `expression: @nowarn`: suppress warnings in a specific expression

The annotation can be configured to filter selected warnings, for example `@nowarn("cat=deprecation")` only suppresses deprecation warnings. The filter configuration syntax is the same as in `-Wconf`.

### Help Text

```
$> scalac -Wconf:help
Configure compiler warnings.
Syntax: -Wconf:<filters>:<action>,<filters>:<action>,...
multiple <filters> are combined with &, i.e., <filter>&...&<filter>

Note: Run with `-Wconf:any:warning-verbose` to print warnings with their category, site,
and (for deprecations) origin and since-version.

<filter>
  - Any message: any

  - Message categories: cat=deprecation, cat=lint, cat=lint-infer-any
    The full list of warning categories is shown at the end of this help text.

  - Message content: msg=regex
    The regex need only match some part of the message, not all of it.

  - Site where the warning is triggered: site=my\.package\..*
    The regex must match the full name (`package.Class.method`) of the warning position.

  - Source file name: src=src_managed/.*
    If `-rootdir` is specified, the regex must match the canonical path relative to the
    root directory. Otherwise, the regex must match the canonical path relative to any
    path segment (`b/.*Test.scala` matches `/a/b/XTest.scala` but not `/ab/Test.scala`).
    Use unix-style paths, separated by `/`.

  - Origin of deprecation: origin=external\.package\..*
    The regex must match the full name (`package.Class.method`) of the deprecated entity.

  - Since of deprecation: since<1.24
    Valid operators: <, =, >, valid versions: N, N.M, N.M.P. Compares against the first
    version of the form N, N.M or N.M.P found in the `since` parameter of the deprecation,
    for example `1.2.3` in `@deprecated("", "some lib 1.2.3-foo")`.

<action>
  - error / e
  - warning / w
  - warning-summary / ws (summary with the number of warnings, like for deprecations)
  - warning-verbose / wv (show warning category and site)
  - info / i             (infos are not counted as warnings and don't affect `-Werror`)
  - info-summary / is
  - info-verbose / iv
  - silent / s

The default configuration is:
  -Wconf:cat=deprecation:ws,cat=feature:ws,cat=optimizer:ws

User-defined configurations are added to the left. The leftmost rule matching
a warning message defines the action.

Examples:
  - change every warning into an error: -Wconf:any:error
  - silence certain deprecations: -Wconf:origin=some\.lib\..*&since>2.2:s

Full list of message categories:
 - deprecation
 - feature, feature-dynamics, feature-existentials, feature-higher-kinds, feature-implicit-conversions, feature-macros, feature-postfix-ops, feature-reflective-calls
 - java-source
 - lint, lint-adapted-args, lint-byname-implicit, lint-constant, lint-delayedinit-select, lint-deprecation, lint-doc-detached, lint-eta-sam, lint-eta-zero, lint-implicit-not-found, lint-inaccessible, lint-infer-any, lint-missing-interpolator, lint-nonlocal-return, lint-nullary-override, lint-nullary-unit, lint-option-implicit, lint-package-object-classes, lint-poly-implicit-overload, lint-private-shadow, lint-recurse-with-default, lint-serial, lint-stars-align, lint-type-parameter-shadow, lint-unit-specialization
 - optimizer
 - other, other-debug, other-match-analysis, other-migration, other-pure-statement, other-shadowing
 - scaladoc
 - unchecked
 - unused, unused-imports, unused-locals, unused-nowarn, unused-params, unused-pat-vars, unused-privates
 - w-flag, w-flag-dead-code, w-flag-extra-implicit, w-flag-numeric-widen, w-flag-self-implicit, w-flag-value-discard

To suppress warnings locally, use the `scala.annotation.nowarn` annotation.

Note: on the command-line you might need to quote configurations containing `*` or `&`
to prevent the shell from expanding patterns.
```

## Significant changes

  - What's described above in the PR description
  - MiMa exception for addition of `scala.annotation.nowarn`
  - Adds a `-rootdir` compiler flag. It is used to relativize file paths when using source filters (`-Wconf:src=some/source/File.scala:s`), there might be other uses for it in the future.
  - Compiler API changes
    - `warning` methods in currentRun.reporting and context reporter take new `Category` parameter. The `global.reporter` is unchanged, warnings reported through it are not filtered by `Wconf`.
    - Removed a few deprecated methods (compilationUnit.error/warning)
  - Reporting warnings is now delayed until after typer, because the typer collects `@nowarn` annotations.
  - If we stop before typer (e.g., because there are errors in the parser), all warnings are shown, even if they are enclosed in `@nowarn`
  - If a phase before typer has both errors and warnings, all errors are printed before the warnings.
  - Unchecked warnings are now all shown by default (they were summarized like deprecations before)
  - The `-deprecation`, `-feature` and `-unchecked` settings are no longer directly used in the compiler, they are shortcuts for specific `Wconf` configurations. the compiler only looks at `-Wconf`.
