### PR TITLE
Assume StubSymbols are not StaticAnnotations

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -251,7 +251,7 @@ abstract class Pickler extends SubComponent {
 
             putChildren(sym, children.toList sortBy (_.sealedSortName))
           }
-          for (annot <- (sym.annotations filter (ann => ann.isStatic && !ann.isErroneous)).reverse)
+          for (annot <- (sym.annotations filter (ann => {ann.failIfStub; ann.isStatic && !ann.isErroneous})).reverse)
             putAnnotation(sym, annot)
         }
         else if (sym != NoSymbol) {
@@ -304,6 +304,7 @@ abstract class Pickler extends SubComponent {
           putSymbols(tparams)
         case AnnotatedType(_, underlying) =>
           putType(underlying)
+          tp.annotations.foreach(_.failIfStub) // staticAnnotations skips stubs but we want a hard error
           tp.staticAnnotations foreach putAnnotation
         case _ =>
           throw new FatalError("bad type: " + tp + "(" + tp.getClass + ")")

--- a/src/reflect/scala/reflect/internal/AnnotationInfos.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationInfos.scala
@@ -296,6 +296,7 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
      *  metaAnnotations = List(getter).
      */
     def symbol = atp.typeSymbol
+    final def failIfStub: Unit = symbol.info
 
     /** These are meta-annotations attached at the use site; they
      *  only apply to this annotation usage.  For instance, in
@@ -323,7 +324,14 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
     /** Check whether the type or any of the arguments are erroneous */
     def isErroneous = atp.isErroneous || args.exists(_.isErroneous)
 
-    def isStatic = symbol isNonBottomSubClass StaticAnnotationClass
+    def isStatic = {
+      symbol match {
+        case _: StubSymbol =>
+          false // See scala/bug#11679
+        case _ =>
+          symbol isNonBottomSubClass StaticAnnotationClass
+      }
+    }
 
     /** Check whether any of the arguments mention a symbol */
     def refsSymbol(sym: Symbol) = hasArgWhich(_.symbol == sym)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3461,9 +3461,12 @@ trait Types
   object AnnotatedType extends AnnotatedTypeExtractor
 
   object StaticallyAnnotatedType {
-    def unapply(tp: Type): Option[(List[AnnotationInfo], Type)] = tp.staticAnnotations match {
-      case Nil    => None
-      case annots => Some((annots, tp.withoutAnnotations))
+    def unapply(tp: Type): Option[(List[AnnotationInfo], Type)] = {
+      tp.annotations.foreach(_.failIfStub) // staticAnnotations skips stubs but we want a hard error
+      tp.staticAnnotations match {
+        case Nil    => None
+        case annots => Some((annots, tp.withoutAnnotations))
+      }
     }
   }
 


### PR DESCRIPTION
In the reproduction in scala/bug#11679, an SBT build that uses
`--release 8` and as such does not have `sun._` on the classpath,
`APIPhase` (a custom compiler phase in SBT/Zinc that serializes the API
of each file to perform change detection in incremental compilation)
is attempting to serialize the API of the member
`@CallerSensitive ClassLoader getParent` that
`de.sciss.synth.proc.impl.MemoryClassLoader` inherits from
`j.l.ClassLoader`.

Until that point, scalac was doing okay without having a classfile
for `CallerSensitve` -- it just used a `StubSymbol` in its place.
Scala's pickle phase only serializes `.decls`, not `.members`.

When `APIPhase` filters the list of annotations:

  https://github.com/sbt/zinc/blob/4b414b6677/internal/compiler-bridge/src/main/scala/xsbt/ExtractAPI.scala#L789-L800

for those that extend `scala.StaticAnnotation`, the stub symbol fails
and aborts compilation. Static annotations are part of the API because
the are could affect how client code is compiled.

This commit changes `AnnotationInfo.isStatic` to return false
for annotations to absent classfiles. It also makes sure that we
still have a hard-error if annotations based on absent classfiles
are processed by the pickle phase.

I have manually tested this commit with the SBT project in the bug.

Fixes scala/bug#11679