### PR TITLE
More source compatibility tweaks for reporters

### DIFF
--- a/src/compiler/scala/tools/nsc/reporters/Reporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/Reporter.scala
@@ -89,7 +89,8 @@ abstract class FilteringReporter extends Reporter {
   // this should be the abstract method all the way up in reflect.internal.Reporter, but sbt compat
   def doReport(pos: Position, msg: String, severity: Severity): Unit
 
-  final protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = doReport(pos, msg, severity)
+  @deprecatedOverriding("override doReport instead", "2.13.1") // overridden in scalameta for example
+  protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = doReport(pos, msg, severity)
 
   private lazy val positions = mutable.Map[Position, Severity]() withDefaultValue INFO
   private lazy val messages  = mutable.Map[Position, List[String]]() withDefaultValue Nil

--- a/src/compiler/scala/tools/nsc/reporters/StoreReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/StoreReporter.scala
@@ -13,19 +13,26 @@
 package scala.tools.nsc
 package reporters
 
+import scala.annotation.unchecked.uncheckedStable
 import scala.collection.mutable
 import scala.reflect.internal.Reporter.Severity
 import scala.reflect.internal.util.Position
-import scala.tools.nsc.reporters.StoreReporter._
 
 /** This class implements a Reporter that stores its reports in the set `infos`. */
 class StoreReporter(val settings: Settings) extends FilteringReporter {
   @deprecated("use the constructor with a `Settings` parameter", "2.13.1")
   def this() = this(new Settings())
-  val infos = new mutable.LinkedHashSet[Info]
+
+  @deprecated("use StoreReporter.Info") // used in scalameta for example
+  type Info = StoreReporter.Info
+
+  @deprecated("use StoreReporter.Info")
+  @uncheckedStable def Info: StoreReporter.Info.type = StoreReporter.Info
+
+  val infos = new mutable.LinkedHashSet[StoreReporter.Info]
 
   def doReport(pos: Position, msg: String, severity: Severity): Unit =
-    infos += Info(pos, msg, severity)
+    infos += StoreReporter.Info(pos, msg, severity)
 
   override def reset(): Unit = {
     super.reset()
@@ -34,6 +41,6 @@ class StoreReporter(val settings: Settings) extends FilteringReporter {
 }
 object StoreReporter {
   case class Info(pos: Position, msg: String, severity: Severity) {
-    override def toString() = s"pos: $pos $msg $severity"
+    override def toString: String = s"pos: $pos $msg $severity"
   }
 }

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1548,6 +1548,7 @@ trait Contexts { self: Analyzer =>
 
     def issue(err: AbsTypeError)(implicit context: Context): Unit = error(context.fixPosition(err.errPos), addDiagString(err.errMsg))
 
+    def echo(msg: String): Unit                   = echo(NoPosition, msg)
     def echo(pos: Position, msg: String): Unit    = reporter.echo(pos, msg)
     def warning(pos: Position, msg: String): Unit = reporter.warning(pos, msg)
     def error(pos: Position, msg: String): Unit


### PR DESCRIPTION
- echo without Position parameter to ContextReporter, used in splain
- StoreReporter.Info type/value aliases (scalameta, scapegoat)
- make `info0` deprecatedOverriding instead of final (scalameta)