### PR TITLE
Remove the verbosity of a partest

### DIFF
--- a/test/files/pos/t11525.scala
+++ b/test/files/pos/t11525.scala
@@ -1,4 +1,4 @@
-// scalac: -Ystop-after:refchecks -verbose -Ydebug -uniqid
+// scalac: -Ystop-after:refchecks -Ydebug -uniqid
 package java.lang
 
 /* This is a pretty random test that very indirectly tests `unique`ing of `ObjectTpeJavaRef`


### PR DESCRIPTION
It ruins the `partest --terse` experience.