### PR TITLE
reduce tupling in hashcode of maps

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -79,6 +79,14 @@ sealed class ListMap[A, +B] extends AbstractMap[A, B]
   override def isEmpty: Boolean = true
 
   def get(key: A): Option[B] = None
+  private[immutable] final def foreachKV[U](f: (A, B) => U): Unit = {
+    def process(n: ListMap[_, _]): Unit = if (!n.isEmpty) {
+      f(n.key, n.value)
+      process(n.next)
+    }
+
+    process(this)
+  }
 
   override def updated[B1 >: B](key: A, value: B1): ListMap[A, B1] = new Node[B1](key, value)
 

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -97,11 +97,17 @@ object RedBlackTree {
 
 
   def foreach[A,B,U](tree:Tree[A,B], f:((A,B)) => U):Unit = if (tree ne null) _foreach(tree,f)
+  private[immutable] def foreachKV[A,B,U](tree:Tree[A,B], f:(A,B) => U):Unit = if (tree ne null) _foreachKV(tree,f)
 
   private[this] def _foreach[A, B, U](tree: Tree[A, B], f: ((A, B)) => U) {
     if (tree.left ne null) _foreach(tree.left, f)
     f((tree.key, tree.value))
     if (tree.right ne null) _foreach(tree.right, f)
+  }
+  private[this] def _foreachKV[A, B, U](tree: Tree[A, B], f: (A, B) => U) {
+    if (tree.left ne null) _foreachKV(tree.left, f)
+    f(tree.key, tree.value)
+    if (tree.right ne null) _foreachKV(tree.right, f)
   }
 
   def foreachKey[A, U](tree:Tree[A,_], f: A => U):Unit = if (tree ne null) _foreachKey(tree,f)

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -203,4 +203,23 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
   override def isDefinedAt(key: A): Boolean = RB.contains(tree, key)
 
   override def foreach[U](f : ((A,B)) => U) = RB.foreach(tree, f)
+
+  private[TreeMap] def foreachKV[U](f: (A, B) => U): Unit = RB.foreachKV(tree, f)
+  override def hashCode(): Int = {
+    import scala.util.hashing.MurmurHash3
+    var a, b, n = 0
+    var c = 1
+    this foreachKV { (k,v) =>
+      val h = MurmurHash3.product2Hash(k,v)
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+      n += 1
+    }
+    var h = MurmurHash3.mapSeed
+    h = MurmurHash3.mix(h, a)
+    h = MurmurHash3.mix(h, b)
+    h = MurmurHash3.mixLast(h, c)
+    MurmurHash3.finalizeHash(h, n)
+  }
 }

--- a/src/library/scala/util/hashing/MurmurHash3.scala
+++ b/src/library/scala/util/hashing/MurmurHash3.scala
@@ -52,6 +52,12 @@ private[hashing] class MurmurHash3 {
     h
   }
 
+  private[scala] def product2Hash(x: Any, y: Any, seed: Int): Int = {
+    var h = seed
+    h = mix(h, x.##)
+    h = mix(h, y.##)
+    finalizeHash(h, 2)
+  }
   /** Compute the hash of a product */
   final def productHash(x: Product, seed: Int): Int = {
     val arr = x.productArity
@@ -212,6 +218,7 @@ object MurmurHash3 extends MurmurHash3 {
   def arrayHash[@specialized T](a: Array[T]): Int  = arrayHash(a, arraySeed)
   def bytesHash(data: Array[Byte]): Int            = arrayHash(data, arraySeed)
   def orderedHash(xs: TraversableOnce[Any]): Int   = orderedHash(xs, symmetricSeed)
+  private [scala] def product2Hash(x: Any, y: Any): Int = product2Hash(x, y, productSeed)
   def productHash(x: Product): Int                 = productHash(x, productSeed)
   def stringHash(x: String): Int                   = stringHash(x, stringSeed)
   def unorderedHash(xs: TraversableOnce[Any]): Int = unorderedHash(xs, traversableSeed)


### PR DESCRIPTION
until 2.13 has a better solution

this should not affect the hashcode result, other then not producing lots of Tuple2 while doing it