### PR TITLE
immutable.*Map computes hashcode without intermediate Tuple2 creation

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -16,6 +16,7 @@ package immutable
 
 import generic._
 import scala.annotation.tailrec
+import scala.collection.immutable.Map.HashcodeHelper
 
 /**
   * $factoryInfo
@@ -41,7 +42,9 @@ object ListMap extends ImmutableMapFactory[ListMap] {
   def empty[A, B]: ListMap[A, B] = EmptyListMap.asInstanceOf[ListMap[A, B]]
 
   @SerialVersionUID(-8256686706655863282L)
-  private object EmptyListMap extends ListMap[Any, Nothing]
+  private object EmptyListMap extends ListMap[Any, Nothing] {
+    override def hashCode: Int = -1609326920
+  }
 }
 
 /**
@@ -79,6 +82,21 @@ sealed class ListMap[A, +B] extends AbstractMap[A, B]
   override def isEmpty: Boolean = true
 
   def get(key: A): Option[B] = None
+
+  private[immutable] def includeHash(hasher: HashcodeHelper) = {
+    var current = this
+    while (!current.isEmpty) {
+      hasher(current.key, current.value)
+      current = current.next
+    }
+  }
+
+  override def hashCode(): Int = {
+    val hasher = new HashcodeHelper()
+
+    includeHash(hasher)
+    hasher.finalizeHash
+  }
 
   override def updated[B1 >: B](key: A, value: B1): ListMap[A, B1] = new Node[B1](key, value)
 

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -106,6 +106,7 @@ object Map extends ImmutableMapFactory[Map] {
     override def updated [V1] (key: Any, value: V1): Map[Any, V1] = new Map1(key, value)
     def + [V1](kv: (Any, V1)): Map[Any, V1] = updated(kv._1, kv._2)
     def - (key: Any): Map[Any, Nothing] = this
+    override def hashCode: Int = -1609326920
   }
 
   @SerialVersionUID(-9131943191104946031L)
@@ -126,6 +127,22 @@ object Map extends ImmutableMapFactory[Map] {
       if (key == key1) Map.empty else this
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1))
+    }
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      var a, b, n = 0
+      var c = 1
+
+      var h = MurmurHash3.product2Hash(key1, value1)
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+
+      h = MurmurHash3.mapSeed
+      h = MurmurHash3.mix(h, a)
+      h = MurmurHash3.mix(h, b)
+      h = MurmurHash3.mixLast(h, c)
+      MurmurHash3.finalizeHash(h, n)
     }
   }
 
@@ -157,6 +174,27 @@ object Map extends ImmutableMapFactory[Map] {
       else this
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1)); f((key2, value2))
+    }
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      var a, b, n = 0
+      var c = 1
+
+      var h = MurmurHash3.product2Hash(key1, value1)
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+
+      h = MurmurHash3.product2Hash(key2, value2)
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+
+      h = MurmurHash3.mapSeed
+      h = MurmurHash3.mix(h, a)
+      h = MurmurHash3.mix(h, b)
+      h = MurmurHash3.mixLast(h, c)
+      MurmurHash3.finalizeHash(h, n)
     }
   }
 
@@ -193,6 +231,32 @@ object Map extends ImmutableMapFactory[Map] {
       else this
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1)); f((key2, value2)); f((key3, value3))
+    }
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      var a, b, n = 0
+      var c = 1
+
+      var h = MurmurHash3.product2Hash(key1, value1)
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+
+      h = MurmurHash3.product2Hash(key2, value2)
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+
+      h = MurmurHash3.product2Hash(key3, value3)
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+
+      h = MurmurHash3.mapSeed
+      h = MurmurHash3.mix(h, a)
+      h = MurmurHash3.mix(h, b)
+      h = MurmurHash3.mixLast(h, c)
+      MurmurHash3.finalizeHash(h, n)
     }
   }
 
@@ -234,6 +298,56 @@ object Map extends ImmutableMapFactory[Map] {
       else this
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1)); f((key2, value2)); f((key3, value3)); f((key4, value4))
+    }
+    override def hashCode(): Int = {
+      import scala.util.hashing.MurmurHash3
+      var a, b, n = 0
+      var c = 1
+
+      var h = MurmurHash3.product2Hash(key1, value1)
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+
+      h = MurmurHash3.product2Hash(key2, value2)
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+
+      h = MurmurHash3.product2Hash(key3, value3)
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+
+      h = MurmurHash3.product2Hash(key4, value4)
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+
+      h = MurmurHash3.mapSeed
+      h = MurmurHash3.mix(h, a)
+      h = MurmurHash3.mix(h, b)
+      h = MurmurHash3.mixLast(h, c)
+      MurmurHash3.finalizeHash(h, n)
+    }
+  }
+  private [immutable] final class HashcodeHelper {
+    import scala.util.hashing.MurmurHash3
+    private var a, b, n = 0
+    private var c = 1
+    def apply(key: Any, value: Any): Unit = {
+      val h = MurmurHash3.product2Hash(key, value)
+      a += h
+      b ^= h
+      if (h != 0) c *= h
+    }
+
+    def finalizeHash: Int = {
+      var h = MurmurHash3.mapSeed
+      h = MurmurHash3.mix(h, a)
+      h = MurmurHash3.mix(h, b)
+      h = MurmurHash3.mixLast(h, c)
+      MurmurHash3.finalizeHash(h, n)
     }
   }
 }

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -16,6 +16,7 @@ package immutable
 
 import scala.annotation.tailrec
 import scala.annotation.meta.getter
+import scala.collection.immutable.Map.HashcodeHelper
 
 /** An object containing the RedBlack tree implementation used by for `TreeMaps` and `TreeSets`.
  *
@@ -97,11 +98,18 @@ object RedBlackTree {
 
 
   def foreach[A,B,U](tree:Tree[A,B], f:((A,B)) => U):Unit = if (tree ne null) _foreach(tree,f)
+  private[immutable] def includeHash[A,B](tree:Tree[A,B], hasher: HashcodeHelper): Unit =
+    if (tree ne null) _includeHash(tree, hasher)
 
   private[this] def _foreach[A, B, U](tree: Tree[A, B], f: ((A, B)) => U) {
     if (tree.left ne null) _foreach(tree.left, f)
     f((tree.key, tree.value))
     if (tree.right ne null) _foreach(tree.right, f)
+  }
+  private[this] def _includeHash[A, B](tree: Tree[A, B], hasher: HashcodeHelper) {
+    if (tree.left ne null) _includeHash(tree.left, hasher)
+    hasher(tree.key, tree.value)
+    if (tree.right ne null) _includeHash(tree.right, hasher)
   }
 
   def foreachKey[A, U](tree:Tree[A,_], f: A => U):Unit = if (tree ne null) _foreachKey(tree,f)

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -17,6 +17,7 @@ package immutable
 import generic._
 import immutable.{RedBlackTree => RB}
 import mutable.Builder
+import scala.collection.immutable.Map.HashcodeHelper
 
 /** $factoryInfo
  *  @define Coll immutable.TreeMap
@@ -203,4 +204,12 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
   override def isDefinedAt(key: A): Boolean = RB.contains(tree, key)
 
   override def foreach[U](f : ((A,B)) => U) = RB.foreach(tree, f)
+
+  private[immutable] def includeHash(hasher: HashcodeHelper): Unit = ()
+  override def hashCode(): Int = {
+    val hasher = new HashcodeHelper()
+    RB.includeHash(tree, hasher)
+    hasher.finalizeHash
+  }
+
 }

--- a/src/library/scala/util/hashing/MurmurHash3.scala
+++ b/src/library/scala/util/hashing/MurmurHash3.scala
@@ -52,6 +52,12 @@ private[hashing] class MurmurHash3 {
     h
   }
 
+  private[scala] def product2Hash(x: Any, y: Any, seed: Int): Int = {
+    var h = seed
+    h = mix(h, x.##)
+    h = mix(h, y.##)
+    finalizeHash(h, 2)
+  }
   /** Compute the hash of a product */
   final def productHash(x: Product, seed: Int): Int = {
     val arr = x.productArity
@@ -212,6 +218,7 @@ object MurmurHash3 extends MurmurHash3 {
   def arrayHash[@specialized T](a: Array[T]): Int  = arrayHash(a, arraySeed)
   def bytesHash(data: Array[Byte]): Int            = arrayHash(data, arraySeed)
   def orderedHash(xs: TraversableOnce[Any]): Int   = orderedHash(xs, symmetricSeed)
+  private [scala] def product2Hash(x: Any, y: Any): Int = product2Hash(x, y, productSeed)
   def productHash(x: Product): Int                 = productHash(x, productSeed)
   def stringHash(x: String): Int                   = stringHash(x, stringSeed)
   def unorderedHash(xs: TraversableOnce[Any]): Int = unorderedHash(xs, traversableSeed)

--- a/test/junit/scala/collection/immutable/MapHashcodeTest.scala
+++ b/test/junit/scala/collection/immutable/MapHashcodeTest.scala
@@ -1,0 +1,229 @@
+package scala.collection.immutable
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MapHashcodeTest extends AllocationTest {
+
+  @Test def nonAllocatingCustom(): Unit = {
+    val t0 = Map.empty
+    val t1 = new Map.Map1(1,1)
+    val t2 = new Map.Map2(1,1, 2,2)
+    val t3 = new Map.Map3(1,1, 2,2, 3,3)
+    val t4 = new Map.Map4(1,1, 2,2, 3,3, 4,4)
+
+    nonAllocating{ t0.hashCode() }
+    nonAllocating{ t0.## }
+
+    nonAllocating{ t1.hashCode() }
+    nonAllocating{ t1.## }
+
+    nonAllocating{ t2.hashCode() }
+    nonAllocating{ t2.## }
+
+    nonAllocating{ t3.hashCode() }
+    nonAllocating{ t3.## }
+
+    nonAllocating{ t4.hashCode() }
+    nonAllocating{ t4.## }
+  }
+
+  @Test def nonAllocatingListMap(): Unit = {
+    val t0 = ListMap.empty[String, String]
+    val t1 = t0.updated("1","1")
+    val t2 = t1.updated("2","2")
+    val t3 = t2.updated("3","3")
+    val t4 = t3.updated("4","4")
+
+    val tlarge = (1 to 10000).foldLeft(t0){
+      (a,b) => a.updated(b.toString,b.toString)
+    }
+
+    nonAllocating{ t0.hashCode() }
+    nonAllocating{ t0.## }
+
+    onlyAllocates(32){ t1.hashCode() }
+    onlyAllocates(32){ t1.## }
+
+    onlyAllocates(32){ t2.hashCode() }
+    onlyAllocates(32){ t2.## }
+
+    onlyAllocates(32){ t3.hashCode() }
+    onlyAllocates(32){ t3.## }
+
+    onlyAllocates(32){ t4.hashCode() }
+    onlyAllocates(32){ t4.## }
+
+    onlyAllocates(32){ tlarge.hashCode() }
+    onlyAllocates(32){ tlarge.## }
+  }
+
+  @Test def nonAllocatingSortedMap(): Unit = {
+    val t0 = SortedMap.empty[String, String]
+    val t1 = t0.updated("1","1")
+    val t2 = t1.updated("2","2")
+    val t3 = t2.updated("3","3")
+    val t4 = t3.updated("4","4")
+
+    val tlarge = (1 to 10000).foldLeft(t0){
+      (a,b) => a.updated(b.toString,b.toString)
+    }
+
+    onlyAllocates(32){ t0.hashCode() }
+    onlyAllocates(32){ t0.## }
+
+    onlyAllocates(32){ t1.hashCode() }
+    onlyAllocates(32){ t1.## }
+
+    onlyAllocates(32){ t2.hashCode() }
+    onlyAllocates(32){ t2.## }
+
+    onlyAllocates(32){ t3.hashCode() }
+    onlyAllocates(32){ t3.## }
+
+    onlyAllocates(32){ t4.hashCode() }
+    onlyAllocates(32){ t4.## }
+
+    onlyAllocates(32){ tlarge.hashCode() }
+    onlyAllocates(32){ tlarge.## }
+  }
+
+  @Test def nonAllocatingHashMap(): Unit = {
+    val t0 = HashMap.empty[String, String]
+    val t1 = t0.updated("1","1")
+    val t2 = t1.updated("2","2")
+    val t3 = t2.updated("3","3")
+    val t4 = t3.updated("4","4")
+
+    val tlarge = (1 to 10000).foldLeft(t0){
+      (a,b) => a.updated(b.toString,b.toString)
+    }
+
+    nonAllocating{ t0.hashCode() }
+    nonAllocating{ t0.## }
+
+    onlyAllocates(32){ t1.hashCode() }
+    onlyAllocates(32){ t1.## }
+
+    onlyAllocates(32){ t2.hashCode() }
+    onlyAllocates(32){ t2.## }
+
+    onlyAllocates(32){ t3.hashCode() }
+    onlyAllocates(32){ t3.## }
+
+    onlyAllocates(32){ t4.hashCode() }
+    onlyAllocates(32){ t4.## }
+
+    onlyAllocates(32){ tlarge.hashCode() }
+    onlyAllocates(32){ tlarge.## }
+  }
+  object MyEmptyMap extends AbstractMap[String, String] {
+    override def +[V1 >: String](kv: (String, V1)): Map[String, V1] = ???
+    override def get(key: String): Option[String] = None
+    override def -(key: String): Map[String, String] = this
+
+    override def iterator: Iterator[(String, String)] = Iterator.empty
+  }
+  @Test def emptyHashCodes() {
+    val expected = MyEmptyMap.hashCode()
+    assertEquals(expected, Map.empty.hashCode())
+    assertEquals(expected, ListMap.empty.hashCode())
+    assertEquals(expected, SortedMap.empty.hashCode())
+    assertEquals(expected, HashMap.empty.hashCode())
+  }
+}
+
+import java.lang.management.ManagementFactory
+
+import org.junit.Assert.{assertEquals, assertTrue, fail}
+import org.junit.Test
+
+object AllocationTest {
+  val allocationCounter = ManagementFactory.getThreadMXBean.asInstanceOf[com.sun.management.ThreadMXBean]
+  assertTrue(allocationCounter.isThreadAllocatedMemorySupported)
+  allocationCounter.setThreadAllocatedMemoryEnabled(true)
+  val costObject: Long = {
+    object coster extends AllocationTest
+    val costs = coster.allocationInfoImpl("" equals "xx", new AllocationExecution(), 0)
+    costs.min
+  }
+  val costInt: Long = {
+    object coster extends AllocationTest
+    val costs = coster.allocationInfoImpl(coster.hashCode(), new AllocationExecution(), 0)
+    costs.min
+  }
+
+  println(s"cost of tracking allocations - Object = $costObject")
+  println(s"cost of tracking allocations - Int = $costInt")
+}
+
+trait AllocationTest {
+
+  import AllocationTest._
+
+  def nonAllocating[T: Manifest](fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): T = {
+    onlyAllocates(0)(fn)
+  }
+  def onlyAllocates[T: Manifest](size:Int)(fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): T = {
+    val result = allocationInfo(fn)
+
+    if (result.min > size) {
+      result.allocations foreach {
+        x => println(s"allocation $x")
+      }
+      fail(s"allocating min = ${result.min}")
+    }
+    result.result
+  }
+
+  def allocationInfo[T: Manifest](fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): AllocationInfo[T] = {
+    val cls = manifest[T].runtimeClass
+    val cost =
+      if (cls == classOf[Int]) costInt
+      else if (cls.isPrimitive) ???
+      else costObject
+    allocationInfoImpl(fn, execution, cost)
+  }
+
+  private[AllocationTest] def allocationInfoImpl[T](fn: => T, execution: AllocationExecution, cost: Long): AllocationInfo[T] = {
+    val expected = fn
+    val id = Thread.currentThread().getId
+
+    var i = 0
+    //warmup
+    while (i < execution.warmupCount) {
+      val actual = fn
+      if (actual != expected)
+        assertEquals(s"warmup at index $i $expected $actual", expected, actual)
+      i += 1
+    }
+
+    //test
+    i = 0
+    val counts = new Array[Long](execution.executionCount)
+    while (i < execution.warmupCount) {
+      val before: Long = allocationCounter.getThreadAllocatedBytes(id)
+      val actual = fn
+      val after: Long = allocationCounter.getThreadAllocatedBytes(id)
+      counts(i) = after - cost - before
+      if (actual != expected)
+        assertEquals(s"at index $i $expected $actual", expected, actual)
+      i += 1
+    }
+    AllocationInfo(expected, counts)
+  }
+
+}
+
+case class AllocationExecution(executionCount: Int = 1000, warmupCount: Int = 1000)
+
+case class AllocationInfo[T](result: T, allocations: Array[Long]) {
+  def min: Long = {
+    var min = allocations(0)
+    var i = 1
+    while (i < allocations.length) {
+      min = Math.min(min, allocations(i))
+      i += i
+    }
+    min
+  }
+}


### PR DESCRIPTION
Scala 2.13.x improves the efficiency of `immutable.HashMap#hashCode` in two ways: temporary `Tuple2` instances are [not created during iteration](https://github.com/scala/scala/blob/456d3ef425019870328a2fd4639afab6e9496ebd/src/library/scala/collection/immutable/HashMap.scala#L2089-L2110) when computing the hash code of the map, and the hash codes of keys are stored during map creation.

This PR backports the first improvement to 2.12.x _and_ extends it to the low-arity specialized `immutable.{MapN, TreeMap, ListMap}. 

This doesnt affect the hashcode result, it just uses less tuples.