### PR TITLE
REPL javap under JDK9+

### DIFF
--- a/test/files/run/t8608-no-format.scala
+++ b/test/files/run/t8608-no-format.scala
@@ -4,7 +4,7 @@ import scala.tools.partest.JavapTest
 object Test extends JavapTest {
   def code = """
     |f"hello, world"
-    |:javap -prv -
+    |:javap -pv -
   """.stripMargin
 
   // no format


### PR DESCRIPTION
Refactored so it can pick a strategy:

1. as previously under JDK 8, reflectively load the internal API from tools.jar
2. if we're loaded by the App loader, same as 1 except no tools.jar
3. if `-Yreploutdir` is on the class path, use JDK 9 ToolProvider, which runs javap without shenanigans
4. otherwise, have REPL compile the task adapter on the fly and run that :rocket: 

Fixes scala/bug#11154