### PR TITLE
Replace wildcardToTypeVarMap with identityTypeMap

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3675,11 +3675,9 @@ trait Types
       if (suspended) tp =:= origin
       else if (instValid) checkIsSameType(tp)
       else isRelatable(tp) && {
-        val newInst = wildcardToTypeVarMap(tp)
-        (constr isWithinBounds newInst) && {
-          setInst(newInst)
-          instValid
-        }
+        // Calling `identityTypeMap` instantiates valid type vars (see `TypeVar.mapOver`).
+        val newInst = identityTypeMap(tp)
+        constr.isWithinBounds(newInst) && setInst(newInst).instValid
       }
     }
 

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -1004,13 +1004,9 @@ private[internal] trait TypeMaps {
     }
   }
 
-  /** A map to convert every occurrence of a wildcard type to a fresh
-    *  type variable */
-  object wildcardToTypeVarMap extends TypeMap {
-    def apply(tp: Type): Type = tp match {
-      case pt: ProtoType => TypeVar(tp, new TypeConstraint(pt.toBounds))
-      case _ => tp.mapOver(this)
-    }
+  /** A map that is conceptually an identity, but in practice may perform some side effects. */
+  object identityTypeMap extends TypeMap {
+    def apply(tp: Type): Type = tp.mapOver(this)
   }
 
   /** A map to convert each occurrence of a type variable to its origin. */

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -198,7 +198,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.wildcardExtrapolation
     this.IsDependentCollector
     this.ApproximateDependentMap
-    this.wildcardToTypeVarMap
+    this.identityTypeMap
     this.typeVarToOriginMap
     this.ErroneousCollector
     this.adaptToNewRunMap

--- a/test/files/pos/t11579.scala
+++ b/test/files/pos/t11579.scala
@@ -1,0 +1,13 @@
+import scala.collection.generic.IsIterable
+import scala.language.implicitConversions
+
+object Test {
+  class Ops[I] {
+    def method: Unit = ()
+  }
+
+  implicit def ToOps[Repr, L, R](aCol: Repr)(implicit isIterable: IsIterable[Repr]{type A = (L, R)}): Ops[isIterable.type] =
+    new Ops[isIterable.type]
+
+  List(1 -> 2).method
+}


### PR DESCRIPTION
Converting wildcards to type vars is not useful, because:
  1. The resulting type vars are never instantiated.
  2. Later on we convert each type var to its origin.

However it is necessary to perform a type map over the new instance,
in order to instantiate valid type vars (see `TypeVar.mapOver`).

fixes scala/bug#11579 (again)
followup reverted #8272 