### PR TITLE
Don't warn-unused private ctor default args

### DIFF
--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -524,6 +524,16 @@ trait StdNames {
       }
     )
 
+    def splitDefaultGetterName(name: Name): (Name, Int) = {
+      val (n, i) =
+        if (name.startsWith(DEFAULT_GETTER_INIT_STRING)) (nme.CONSTRUCTOR, DEFAULT_GETTER_INIT_STRING.length)
+        else name.indexOf(DEFAULT_GETTER_STRING) match {
+          case -1  => (name.toTermName, -1)
+          case idx => (name.toTermName.take(idx), idx + DEFAULT_GETTER_STRING.length)
+        }
+      if (i >= 0) (n, name.encoded.substring(i).toInt) else (n, -1)
+    }
+
     def localDummyName(clazz: Symbol): TermName = newTermName(LOCALDUMMY_PREFIX + clazz.name + ">")
     def superName(name: Name, mix: Name = EMPTY): TermName = newTermName(SUPER_PREFIX_STRING + name + (if (mix.isEmpty) "" else "$" + mix))
 

--- a/test/files/pos/t7707.scala
+++ b/test/files/pos/t7707.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror -Xlint
+
+object O { O() ; def f(): Unit = O() }
+case class O private (x: Int = 3)
+
+object Q { Q[Int]() ; def f(): Unit = Q[Int]() }
+case class Q[A] private (x: Int = 3)


### PR DESCRIPTION
For case classes, they are duplicated by apply args.

Otherwise, they don't represent public API.

Arguably, default args should warn under `params`,
as they represent an extraneous specification
of parameters.

This differs from the previous PR: doesn't try to repair the default arg used in the apply rewrite, which might be nice to do but doesn't matter. It might be nice to elide a default arg that is just an unused duplicate. Or apply defaults should always forward to ctor defaults.

Fixes scala/bug#7707