### PR TITLE
Add a Partest option to use a different compiler

### DIFF
--- a/project/PartestUtil.scala
+++ b/project/PartestUtil.scala
@@ -37,6 +37,7 @@ object PartestUtil {
       "--instrumented", "--presentation", "--failed", "--update-check", "--no-exec",
       "--show-diff", "--show-log", "--verbose", "--terse", "--debug", "--version", "--help")
     val srcPathOption = "--srcpath"
+    val compilerPathOption = "--compilerpath"
     val grepOption = "--grep"
 
     // HACK: if we parse `--srcpath scaladoc`, we overwrite this var. The parser for test file paths
@@ -93,9 +94,14 @@ object PartestUtil {
         opt + " " + path
     }
 
+   val CompilerPath = ((token(compilerPathOption) <~ Space) ~ token(NotSpace)) map {
+     case opt ~ path =>
+       opt + " " + path
+   }
+
     val ScalacOptsParser = (token("-Dpartest.scalac_opts=") ~ token(NotSpace)) map { case opt ~ v => opt + v }
 
-    val P = oneOf(knownUnaryOptions.map(x => token(x))) | SrcPath | TestPathParser | Grep | ScalacOptsParser
+    val P = oneOf(knownUnaryOptions.map(x => token(x))) | SrcPath | CompilerPath | TestPathParser | Grep | ScalacOptsParser
     (Space ~> repsep(P, oneOrMore(Space))).map(_.mkString(" ")).?.map(_.getOrElse(""))
   }
 }

--- a/src/partest/scala/tools/partest/nest/RunnerSpec.scala
+++ b/src/partest/scala/tools/partest/nest/RunnerSpec.scala
@@ -42,6 +42,10 @@ trait RunnerSpec extends Spec with Meta.StdOpts with Interpolation {
   val optBuildPath    = "buildpath"    / "set (relative) path to build jars (ex.: --buildpath build/pack)"                --|
   val optClassPath    = "classpath"    / "set (absolute) path to build classes"                                           --|
   val optSourcePath   = "srcpath"      / "set (relative) path to test source files (ex.: --srcpath pending)"              --|
+  // Compile with a different compiler, not used internally. Used by AxLang, see PR #8407.
+  // Note: this will be much slower than creating a new global in the same JVM.
+  // Note: run tests will still use the internal Scala version for running.
+  val optCompilerPath = "compilerpath" / "set (absolute) path to a different compiler to test (ex.: --compilerpath /usr/local/bin/scalac)" --|
 
   heading("Test output options:")
   val optShowDiff     = "show-diff"    / "show diffs for failed tests"                       --?


### PR DESCRIPTION
See https://contributors.scala-lang.org/t/using-partest-with-a-different-compiler/3379 for our motivation in testing AxLang with Partest; I hope this will also be useful for others developing compilers and/or languages related to Scala.
    I didn’t see how to create automated tests for a non-standard option for the test harness; I tested manually by using the option to crash-test our compiler, and by running Partest with no options.  (Using the new option to select my locally-built pack/bin/scalac, and Homebrew scalac with a version corresponding to our compiler frontend, seemed to reveal differences in behavior due to the different execution methods, and hence weren’t very interesting tests.)
