### PR TITLE
Extend the Gradle / sbt 0.13 leniency to Windows

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -115,7 +115,9 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
       val msg = s"$featureDesc $req be enabled\nby making the implicit value $fqname visible.$explain" replace ("#", construct)
       // don't error on postfix in pre-0.13.18 xsbt/Compat.scala
       def isSbtCompat =
-        (featureName == "postfixOps" && pos.source.path.endsWith("/xsbt/Compat.scala") && Thread.currentThread.getStackTrace.exists(_.getClassName.startsWith("sbt.")))
+        (featureName == "postfixOps" &&
+        (pos.source.path.endsWith("/xsbt/Compat.scala") || pos.source.path.endsWith("""\xsbt\Compat.scala""")) &&
+        Thread.currentThread.getStackTrace.exists(_.getClassName.startsWith("sbt.")))
       if (required && !isSbtCompat) {
         reporter.error(pos, msg)
       } else featureWarning(pos, msg)


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11731

postfixOps error exempts `/xsbt/Compat.scala` specifically to allow sbt 0.13 to work
with Scala 2.13.0. Because this uses forward slash, apparently this did not work on Windows. This extends the compassion to Gradle + Windows users.