### PR TITLE
Improve performance of BitSet.toBitMask (and .range*)

### DIFF
--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -345,6 +345,8 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
         }
       }
     }
+
+    override def toBitMask: Array[Long] = elems.clone()
   }
 
   @SerialVersionUID(3L)

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -353,6 +353,8 @@ class BitSet(protected[collection] final var elems: Array[Long])
     }
     this
   }
+
+  override def toBitMask: Array[Long] = elems.clone()
 }
 
 @SerialVersionUID(3L)


### PR DESCRIPTION
This improves the performance of `BitSet.toBitMask` (and, transitively `BitSet.range*` methods) by overriding the default implementation (copying via `while` loop) with `Array.clone` in `mutable.BitSet` and `immutable.BitSet.BitSetN`.

Existing test coverage looks adequate to me.

~~Note: the results are not as convincing as I had hoped originally, so I would completely understand if this does not get approved. Still worth having a look, IMHO.~~
Update: I was advised to experiment with various GCs. Since the benchmark is allocating a lot, this indeed had a significant effect. Now, with `-XX:+UseSerialGC`, the results are more consistent and convincing: https://github.com/scala/scala/pull/8412#issuecomment-530335704

(OUTDATED, see https://github.com/scala/scala/pull/8412#issuecomment-530335704) Benchmark results (`size` is the size of underlying array of longs):
```
Original:
[info] Benchmark                           (size)  Mode  Cnt      Score     Error  Units
[info] BitSetToBitMaskBenchmark.toBitMask       1  avgt    6     11.004 ±   0.023  ns/op
[info] BitSetToBitMaskBenchmark.toBitMask       8  avgt    6     22.476 ±   0.620  ns/op
[info] BitSetToBitMaskBenchmark.toBitMask      64  avgt    6     83.246 ±   0.855  ns/op
[info] BitSetToBitMaskBenchmark.toBitMask     512  avgt    6    548.364 ±  17.084  ns/op
[info] BitSetToBitMaskBenchmark.toBitMask    4096  avgt    6   5287.501 ±  15.449  ns/op
[info] BitSetToBitMaskBenchmark.toBitMask   32768  avgt    6  45144.393 ± 515.695  ns/op

Modified:
[info] Benchmark                           (size)  Mode  Cnt      Score     Error  Units
[info] BitSetToBitMaskBenchmark.toBitMask       1  avgt    6     12.148 ±   0.698  ns/op
[info] BitSetToBitMaskBenchmark.toBitMask       8  avgt    6     14.945 ±   0.119  ns/op
[info] BitSetToBitMaskBenchmark.toBitMask      64  avgt    6     78.903 ±   0.949  ns/op
[info] BitSetToBitMaskBenchmark.toBitMask     512  avgt    6    565.565 ±   3.771  ns/op
[info] BitSetToBitMaskBenchmark.toBitMask    4096  avgt    6   4743.584 ±  22.519  ns/op
[info] BitSetToBitMaskBenchmark.toBitMask   32768  avgt    6  40291.784 ± 365.573  ns/op
```

Benchmark code:
```
package scala.collection.mutable

import org.openjdk.jmh.annotations._
import org.openjdk.jmh.infra._
import java.util.concurrent.TimeUnit

import scala.collection.mutable

@BenchmarkMode(Array(Mode.AverageTime))
@Fork(1)
@Threads(1)
@Warmup(iterations = 6)
@Measurement(iterations = 6)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@State(Scope.Benchmark)
class BitSetToBitMaskBenchmark {

  @Param(Array("1", "8", "64", "512", "4096", "32768"))
  var size: Int = _

  var bs: mutable.BitSet = _

  @Setup(Level.Iteration) def initialize(): Unit = {
    bs = (0 until size * 64).to(mutable.BitSet)
  }

  @Benchmark def toBitMask(bh: Blackhole): Unit = {
    bh consume bs.toBitMask
  }

}
```

Review by @Ichoran 