### PR TITLE
[REJECTED] Add string.strip for replace with empty

### DIFF
--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -727,6 +727,9 @@ final class StringOps(private val s: String) extends AnyVal {
     if (s endsWith suffix) s.substring(0, s.length - suffix.length)
     else s
 
+  /** Remove all occurrences of the given substring. */
+  @`inline` def strip(substring: String) = s.replace(substring, "")
+
   /** Replace all literal occurrences of `literal` with the literal string `replacement`.
     *  This method is equivalent to [[java.lang.String#replace(CharSequence,CharSequence)]].
     *


### PR DESCRIPTION
The use case for replace is often replace with empty string. I was inclined to add `remove` and maybe an appropriate minus-based operator, but `strip` already has a storied heritage.