### PR TITLE
Inline replaceAllLiterally and reduce ells

### DIFF
--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -45,7 +45,7 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
     val newExtension = if (useJars) ".jar" else ""
     val root = file.getRoot
     // An empty component on Unix, just the drive letter on Windows
-    val validRootPathComponent = root.toString.replaceAllLiterally("/", "").replaceAllLiterally(":", "")
+    val validRootPathComponent = root.toString.replace("/", "").replace(":", "")
     val result = changeExtension(pickleCache.resolve(validRootPathComponent).resolve(root.relativize(file)).normalize(), newExtension)
     if (useJars) Files.createDirectories(result.getParent)
     strippedAndExportedClassPath.put(file.toRealPath().normalize(), result)

--- a/src/compiler/scala/tools/nsc/ast/DocComments.scala
+++ b/src/compiler/scala/tools/nsc/ast/DocComments.scala
@@ -87,7 +87,7 @@ trait DocComments { self: Global =>
         // scala/bug#8210 - The warning would be false negative when this symbol is a setter
         if (ownComment.indexOf("@inheritdoc") != -1 && ! sym.isSetter)
           reporter.warning(sym.pos, s"The comment for ${sym} contains @inheritdoc, but no parent comment is available to inherit from.")
-        ownComment.replaceAllLiterally("@inheritdoc", "<invalid inheritdoc annotation>")
+        ownComment.replace("@inheritdoc", "<invalid inheritdoc annotation>")
       case Some(sc) =>
         if (ownComment == "") sc
         else expandInheritdoc(sc, merge(sc, ownComment, sym), sym)
@@ -245,7 +245,7 @@ trait DocComments { self: Global =>
         if (childSection.indexOf("@inheritdoc") == -1)
           childSection
         else
-          childSection.replaceAllLiterally("@inheritdoc", parentSection)
+          childSection.replace("@inheritdoc", parentSection)
 
       def getParentSection(section: (Int, Int)): String = {
 
@@ -378,7 +378,7 @@ trait DocComments { self: Global =>
 
     // We suppressed expanding \$ throughout the recursion, and now we
     // need to replace \$ with $ so it looks as intended.
-    expandInternal(initialStr, 0).replaceAllLiterally("""\$""", "$")
+    expandInternal(initialStr, 0).replace("""\$""", "$")
   }
 
   // !!! todo: inherit from Comment?

--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -51,7 +51,7 @@ abstract class TreeCheckers extends Analyzer {
     case _                            => diffTrees(t1, t2).toString // "<error: different tree classes>"
   }
 
-  private def clean_s(s: String) = s.replaceAllLiterally("scala.collection.", "s.c.")
+  private def clean_s(s: String) = s.replace("scala.collection.", "s.c.")
   private def typestr(x: Type)    = " (tpe = " + x + ")"
   private def treestr(t: Tree)    = t + " [" + classString(t) + "]" + typestr(t.tpe)
   private def ownerstr(s: Symbol) = "'" + s + "'" + s.locationString

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -138,7 +138,7 @@ object ClassPath {
     else if (pattern endsWith wildSuffix) lsDir(Directory(pattern dropRight 2))
     else if (pattern contains '*') {
       try {
-        val regexp = ("^" + pattern.replaceAllLiterally("""\*""", """.*""") + "$").r
+        val regexp = s"^${pattern.replace(raw"\*", ".*")}$$".r
         lsDir(Directory(pattern).parent, regexp.findFirstIn(_).isDefined)
       }
       catch { case _: PatternSyntaxException => List(pattern) }

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -728,12 +728,13 @@ final class StringOps(private val s: String) extends AnyVal {
     else s
 
   /** Replace all literal occurrences of `literal` with the literal string `replacement`.
-    *  This method is equivalent to [[java.lang.String#replace(CharSequence,CharSequence)]].
+    * This method is equivalent to [[java.lang.String#replace(CharSequence,CharSequence)]].
     *
-    *  @param    literal     the string which should be replaced everywhere it occurs
-    *  @param    replacement the replacement string
-    *  @return               the resulting string
+    * @param    literal     the string which should be replaced everywhere it occurs
+    * @param    replacement the replacement string
+    * @return               the resulting string
     */
+  @deprecated("Use `s.replace` as an exact replacement", "2.13.2")
   def replaceAllLiterally(literal: String, replacement: String): String = s.replace(literal, replacement)
 
   /** For every line in this string:

--- a/src/partest/scala/tools/partest/BytecodeTest.scala
+++ b/src/partest/scala/tools/partest/BytecodeTest.scala
@@ -84,7 +84,7 @@ abstract class BytecodeTest {
     }
     else ms1.lazyZip(ms2).forall { (m1, m2) =>
       val c1 = f(m1)
-      val c2 = f(m2).replaceAllLiterally(name2, name1)
+      val c2 = f(m2).replace(name2, name1)
       if (c1 == c2)
         println(s"[ok] $m1")
       else

--- a/test/files/run/inferred-type-constructors-hou.scala
+++ b/test/files/run/inferred-type-constructors-hou.scala
@@ -37,7 +37,7 @@ object Test {
   def extract[A, CC[X]](xs: CC[A]): CC[A] = xs
   def whatis[T: TypeTag](x: T): Unit = {
     val tpe = typeOf[T]
-    val access = tpe.typeSymbol.asInstanceOf[scala.reflect.internal.HasFlags].accessString.replaceAllLiterally("package ", "")
+    val access = tpe.typeSymbol.asInstanceOf[scala.reflect.internal.HasFlags].accessString.replace("package ", "")
     println(f"$access%15s $tpe")
   }
 

--- a/test/files/run/inferred-type-constructors.scala
+++ b/test/files/run/inferred-type-constructors.scala
@@ -37,7 +37,7 @@ object Test {
   def extract[A, CC[X]](xs: CC[A]): CC[A] = xs
   def whatis[T: TypeTag](x: T): Unit = {
     val tpe = typeOf[T]
-    val access = tpe.typeSymbol.asInstanceOf[scala.reflect.internal.HasFlags].accessString.replaceAllLiterally("package ", "")
+    val access = tpe.typeSymbol.asInstanceOf[scala.reflect.internal.HasFlags].accessString.replace("package ", "")
     println(f"$access%15s $tpe")
   }
 

--- a/test/files/run/t6411a.scala
+++ b/test/files/run/t6411a.scala
@@ -37,7 +37,7 @@ object a {
 
 object Test extends App {
   // strip module name
-  def filtered(s: Any) = s.toString.replaceAllLiterally("java.base/", "")
+  def filtered(s: Any) = s.toString.replace("java.base/", "")
 
   def test(methName: String, arg: Any) = {
     val moduleA = cm.reflect(a)


### PR DESCRIPTION
JDK5 is required, so prefer string.replace.

Go ahead and deprecate the method you can't
say ten times fast.