### PR TITLE
Improve reachability test

### DIFF
--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -652,7 +652,8 @@ class IteratorTest {
     val it0: Iterator[Int] = Iterator(1, 2)
     lazy val it: Iterator[String] = it0.flatMap {
       case 1 => Option(seq1.get).getOrElse(Nil)
-      case _ => check(); seq2
+      case 2 => check(); seq2
+      case _ => ???
     }
 
     def check() = assertNotReachable(seq1.get, it)(())


### PR DESCRIPTION
It failed due to [gc](https://scala-ci.typesafe.com/job/scala-2.13.x-validate-main/9761/testReport/junit/scala.collection/IteratorTest/flatMap$u0020is$u0020memory$u0020efficient$u0020in$u0020previous$u0020element/).

Improve the test for correctness by handling null ref.

Improve the utility by failing fast. That's not a gain, because it should not fail, but for some reason it reads better.