### PR TITLE
Allow infix operators at start of line (under `-Xsource:3` only)

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -693,18 +693,9 @@ self =>
     def isLiteralToken(token: Token) = token match {
       case CHARLIT | INTLIT | LONGLIT | FLOATLIT | DOUBLELIT |
            STRINGLIT | INTERPOLATIONID | SYMBOLLIT | TRUE | FALSE | NULL => true
-      case _                                                        => false
+      case _                                                             => false
     }
     def isLiteral = isLiteralToken(in.token)
-
-    def isSimpleExprIntroToken(token: Token): Boolean = isLiteralToken(token) || (token match {
-      case IDENTIFIER | BACKQUOTED_IDENT |
-           THIS | SUPER | NEW | USCORE |
-           LPAREN | LBRACE | XMLSTART => true
-      case _ => false
-    })
-
-    def isSimpleExprIntro: Boolean = isExprIntroToken(in.token)
 
     def isExprIntroToken(token: Token): Boolean = isLiteralToken(token) || (token match {
       case IDENTIFIER | BACKQUOTED_IDENT |
@@ -1707,23 +1698,22 @@ self =>
      *  PrefixExpr   ::= [`-` | `+` | `~` | `!`] SimpleExpr
      *  }}}
      */
-    def prefixExpr(): Tree = {
-      if (isUnaryOp) {
+    def prefixExpr(): Tree =
+      if (isUnaryOp)
         atPos(in.offset) {
-          if (lookingAhead(isSimpleExprIntro)) {
+          if (lookingAhead(isExprIntro)) {
             val namePos = in.offset
             val uname = nme.toUnaryName(rawIdent().toTermName)
             if (uname == nme.UNARY_- && isNumericLit)
-              /* start at the -, not the number */
+              // start at the -, not the number
               simpleExprRest(literal(isNegated = true, start = namePos), canApply = true)
             else
               Select(stripParens(simpleExpr()), uname)
           }
           else simpleExpr()
         }
-      }
       else simpleExpr()
-    }
+
     def xmlLiteral(): Tree
 
     /** {{{

--- a/test/files/neg/infixed.check
+++ b/test/files/neg/infixed.check
@@ -1,0 +1,4 @@
+infixed.scala:8: error: ';' expected but integer literal found.
+    x 42
+      ^
+1 error

--- a/test/files/neg/infixed.scala
+++ b/test/files/neg/infixed.scala
@@ -1,0 +1,10 @@
+// scalac: -Xsource:3
+
+class K { def x(y: Int) = 0 }
+
+class Test {
+  def bad = {
+    (new K)
+    x 42
+  }
+}

--- a/test/files/neg/multiLineOps-b.check
+++ b/test/files/neg/multiLineOps-b.check
@@ -1,0 +1,4 @@
+multiLineOps-b.scala:7: error: ';' expected but integer literal found.
+    */*one more*/22 // error: end of statement expected
+                 ^
+1 error

--- a/test/files/neg/multiLineOps-b.scala
+++ b/test/files/neg/multiLineOps-b.scala
@@ -1,0 +1,9 @@
+// scalac: -Werror -Xsource:2.14
+
+class Test {
+  val b1 = {
+    22
+    * 22  // ok
+    */*one more*/22 // error: end of statement expected
+  }                 // error: ';' expected, but '}' found
+}

--- a/test/files/neg/multiLineOps-c.check
+++ b/test/files/neg/multiLineOps-c.check
@@ -1,0 +1,5 @@
+multiLineOps-c.scala:7: error: value ! is not a member of Unit
+possible cause: maybe a semicolon is missing before `value !`?
+    ! "hello".isEmpty  // error: value ! is not a member of Unit
+    ^
+1 error

--- a/test/files/neg/multiLineOps-c.scala
+++ b/test/files/neg/multiLineOps-c.scala
@@ -1,0 +1,9 @@
+// scalac: -Werror -Xsource:2.14
+
+class Test {
+  val x = 42
+  val b2: Boolean = {
+    println(x)
+    ! "hello".isEmpty  // error: value ! is not a member of Unit
+  }
+}

--- a/test/files/neg/multiLineOps.check
+++ b/test/files/neg/multiLineOps.check
@@ -1,0 +1,6 @@
+multiLineOps.scala:6: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+    +3 // error: Expected a toplevel definition
+    ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/multiLineOps.scala
+++ b/test/files/neg/multiLineOps.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror -Xsource:2.14
+
+class Test {
+  val x = 1
+    + 2
+    +3 // error: Expected a toplevel definition
+}

--- a/test/files/neg/stmt-expr-discard.check
+++ b/test/files/neg/stmt-expr-discard.check
@@ -1,3 +1,15 @@
+stmt-expr-discard.scala:5: warning: Line starts with an operator that in future
+will be taken as an infix expression continued from the previous line.
+To force the previous interpretation as a separate statement,
+add an explicit `;`, add an empty line, or remove spaces after the operator.
+    + 2
+    ^
+stmt-expr-discard.scala:6: warning: Line starts with an operator that in future
+will be taken as an infix expression continued from the previous line.
+To force the previous interpretation as a separate statement,
+add an explicit `;`, add an empty line, or remove spaces after the operator.
+    - 4
+    ^
 stmt-expr-discard.scala:5: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
     + 2
     ^
@@ -5,5 +17,5 @@ stmt-expr-discard.scala:6: warning: a pure expression does nothing in statement 
     - 4
     ^
 error: No warnings can be incurred under -Werror.
-2 warnings
+4 warnings
 1 error

--- a/test/files/neg/stmt-expr-discard.scala
+++ b/test/files/neg/stmt-expr-discard.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings
+// scalac: -Werror -Xsource:2.13 -Xlint:deprecation
 //
 class A {
   def f = 1

--- a/test/files/neg/t9847.check
+++ b/test/files/neg/t9847.check
@@ -1,3 +1,15 @@
+t9847.scala:10: warning: Line starts with an operator that in future
+will be taken as an infix expression continued from the previous line.
+To force the previous interpretation as a separate statement,
+add an explicit `;`, add an empty line, or remove spaces after the operator.
+  + 1
+  ^
+t9847.scala:14: warning: Line starts with an operator that in future
+will be taken as an infix expression continued from the previous line.
+To force the previous interpretation as a separate statement,
+add an explicit `;`, add an empty line, or remove spaces after the operator.
+  + 1
+  ^
 t9847.scala:6: warning: discarded non-Unit value
   def f(): Unit = 42
                   ^
@@ -35,5 +47,5 @@ t9847.scala:24: warning: a pure expression does nothing in statement position; m
   class D { 42 ; 17 }
                  ^
 error: No warnings can be incurred under -Werror.
-12 warnings
+14 warnings
 1 error

--- a/test/files/neg/t9847.scala
+++ b/test/files/neg/t9847.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -Ywarn-value-discard
+// scalac: -Werror -Xlint:deprecation -Ywarn-value-discard
 //
 
 trait T {

--- a/test/files/pos/infixed.scala
+++ b/test/files/pos/infixed.scala
@@ -1,0 +1,10 @@
+// scalac: -Xsource:3
+
+class K { def x(y: Int) = 0 }
+
+class Test {
+  def ok = {
+    (new K)
+    `x` 42
+  }
+}

--- a/test/files/pos/multiLineOps.scala
+++ b/test/files/pos/multiLineOps.scala
@@ -1,0 +1,30 @@
+// scalac: -Werror -Xsource:2.14
+
+class Channel {
+  def ! (msg: String): Channel = this
+  def send_! (msg: String): Channel = this
+}
+
+class Test {
+  val x = 1
+    + 2
+    + 3
+
+  val c = new Channel()
+
+  def send() =
+    c ! "hello"
+      ! "world"
+      send_! "!"
+
+  val b: Boolean =
+    "hello".isEmpty
+    && true &&
+    !"hello".isEmpty
+
+  val b2: Boolean = {
+    println(x)
+    !"hello".isEmpty
+    ???
+  }
+}

--- a/test/files/run/multiLineOps.scala
+++ b/test/files/run/multiLineOps.scala
@@ -1,0 +1,12 @@
+// scalac: -Xsource:2.14
+//
+// without backticks, "not found: value +"
+//
+object Test extends App {
+  val a = 7
+  val x = 1
+    + //
+    `a` * 6
+
+  assert(x == 1)
+}


### PR DESCRIPTION
Backport from dotty under ~~`-Xsource:2.14`~~ `-Xsource:3`.

The simple expr token test was unused, and is moved
to scanner. Partests are more verbose than in dotty.