### PR TITLE
Avoid dotty compiler crash

### DIFF
--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -200,7 +200,7 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
     */
   def mapValuesInPlace(f: (K, V) => V): this.type = {
     if (nonEmpty) this match {
-      case hm: mutable.HashMap[K, V] => hm.mapValuesInPlaceImpl(f)
+      case hm: mutable.HashMap[_, _] => hm.asInstanceOf[mutable.HashMap[K, V]].mapValuesInPlaceImpl(f)
       case _ =>
         val array = this.toArray[Any]
         val arrayLength = array.length


### PR DESCRIPTION
```
[error] 203 |      case hm: mutable.HashMap[K, V] => hm.mapValuesInPlaceImpl(f)
[error]     |           ^
[error]     |Recursion limit exceeded.
[error]     |Maybe there is an illegal cyclic reference?
[error]     |If that's not the case, you could also try to increase the stacksize using the -Xss JVM option.
[error]     |A recurring operation is (inner to outer):
[error]     |
[error]     |  subtype scala.collection.mutable.HashMap <:< LazyRef(...)
```