### PR TITLE
Make compiler phase ordering unambiguous (2.12.x)

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -546,19 +546,19 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     val runsRightAfter = None
   } with TailCalls
 
-  // phaseName = "explicitouter"
-  object explicitOuter extends {
-    val global: Global.this.type = Global.this
-    val runsAfter = List("tailcalls")
-    val runsRightAfter = None
-  } with ExplicitOuter
-
   // phaseName = "specialize"
   object specializeTypes extends {
     val global: Global.this.type = Global.this
     val runsAfter = List("")
     val runsRightAfter = Some("tailcalls")
   } with SpecializeTypes
+
+  // phaseName = "explicitouter"
+  object explicitOuter extends {
+    val global: Global.this.type = Global.this
+    val runsAfter = List("specialize")
+    val runsRightAfter = None
+  } with ExplicitOuter
 
   // phaseName = "erasure"
   override object erasure extends {
@@ -578,7 +578,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   // phaseName = "lambdalift"
   object lambdaLift extends {
     val global: Global.this.type = Global.this
-    val runsAfter = List("erasure")
+    val runsAfter = List("posterasure")
     val runsRightAfter = None
   } with LambdaLift
 
@@ -599,7 +599,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   // phaseName = "mixin"
   object mixer extends {
     val global: Global.this.type = Global.this
-    val runsAfter = List("flatten", "constructors")
+    val runsAfter = List("flatten")
     val runsRightAfter = None
   } with Mixin
 


### PR DESCRIPTION
explicitouter and specialize both were defining

    val runsRightAfter = Some("tailcalls")

So it was up to the algorithm to define the phase ordering. This can
cause subtle issues, as seen in lightbend/genjavadoc#191.

This change can potentially affect the compiler phase ordering for projects using compiler plugins.