### PR TITLE
Stricten @varargs check.

### DIFF
--- a/test/files/neg/varargs.check
+++ b/test/files/neg/varargs.check
@@ -1,10 +1,19 @@
-varargs.scala:16: error: A method with a varargs annotation produces a forwarder method with the same signature (a: Int, b: Array[String])Int as an existing method.
-    @varargs def v1(a: Int, b: String*) = a + b.length
+varargs.scala:11: error: A method annotated with @varargs produces a forwarder method with the same signature (a: Int, b: Array[String])Int as an existing method.
+    @varargs def v1(a: Int, b: String*) = a + b.length // nok
                  ^
-varargs.scala:19: error: A method without repeated parameters cannot be annotated with the `varargs` annotation.
-  @varargs def nov(a: Int) = 0
+varargs.scala:14: error: A method annotated with @varargs must have a single repeated parameter in its last parameter list.
+  @varargs def nov(a: Int) = 0 // nok
                ^
-varargs.scala:21: error: A method with a varargs annotation produces a forwarder method with the same signature (a: Int, b: Array[String])Int as an existing method.
-  @varargs def v2(a: Int, b: String*) = 0
+varargs.scala:16: error: A method annotated with @varargs produces a forwarder method with the same signature (a: Int, b: Array[String])Int as an existing method.
+  @varargs def v2(a: Int, b: String*) = 0 // nok
                ^
-three errors found
+varargs.scala:19: error: A method annotated with @varargs must have a single repeated parameter in its last parameter list.
+  @varargs def v3(a: String*)(b: Int) = b + a.length // nok
+               ^
+varargs.scala:20: error: A method annotated with @varargs must have a single repeated parameter in its last parameter list.
+  @varargs def v4(a: String)(b: Int) = b + a.length // nok
+               ^
+varargs.scala:23: error: A method annotated with @varargs must have a single repeated parameter in its last parameter list.
+  @varargs def v6: Int = 1 // nok
+               ^
+6 errors found

--- a/test/files/neg/varargs.scala
+++ b/test/files/neg/varargs.scala
@@ -1,9 +1,4 @@
-
-
-
 import annotation.varargs
-
-
 
 // Failing varargs annotation
 object Test {
@@ -13,15 +8,19 @@ object Test {
   }
 
   trait B extends A {
-    @varargs def v1(a: Int, b: String*) = a + b.length
+    @varargs def v1(a: Int, b: String*) = a + b.length // nok
   }
 
-  @varargs def nov(a: Int) = 0
-  @varargs def v(a: Int, b: String*) = a + b.length
-  @varargs def v2(a: Int, b: String*) = 0
+  @varargs def nov(a: Int) = 0 // nok
+  @varargs def v(a: Int, b: String*) = a + b.length // ok
+  @varargs def v2(a: Int, b: String*) = 0 // nok
   def v2(a: Int, b: Array[String]) = 0
 
-  def main(args: Array[String]) {
-  }
+  @varargs def v3(a: String*)(b: Int) = b + a.length // nok
+  @varargs def v4(a: String)(b: Int) = b + a.length // nok
+  @varargs def v5(a: String)(b: Int*) = a + b.sum // ok
+
+  @varargs def v6: Int = 1 // nok
+  @varargs def v7(i: Int*)() = i.sum // ok (?)
 
 }


### PR DESCRIPTION
If you get it wrong, the JVM will complain. Now we complain first.

Not a refcheck for some reason.

I hope it's ok to do a "good first issue" as a "good first issue after several months' hiatus". For what it's worth, it was. Who doesn't like adding new compiler errors?

Closes scala/bug#11714.