### PR TITLE
Distinguish super calls from instantiations in `splitAtSuper`

### DIFF
--- a/test/files/run/t11736.scala
+++ b/test/files/run/t11736.scala
@@ -1,0 +1,50 @@
+trait Foo1 {
+  override def toString = "FU"
+  trait Bar1 { assert(Foo1.this.toString == "FU") }
+  class Bar2 { assert(Foo1.this.toString == "FU") }
+}
+
+class Foo2 {
+  override def toString = "FU"
+  trait Bar1 { assert(Foo2.this.toString == "FU") }
+  class Bar2 { assert(Foo2.this.toString == "FU") }
+}
+
+trait Baz1 extends Foo1
+class Baz2 extends Foo1
+
+trait Baz3 extends Foo2
+class Baz4 extends Foo2
+
+object Biz1 extends Baz1 {
+  new Bar1 {}
+  new Bar2 {}
+  new Bar2
+}
+
+object Biz2 extends Baz2 {
+  new Bar1 {}
+  new Bar2 {}
+  new Bar2
+}
+
+object Biz3 extends Baz3 {
+  new Bar1 {}
+  new Bar2 {}
+  new Bar2
+}
+
+object Biz4 extends Baz4 {
+  new Bar1 {}
+  new Bar2 {}
+  new Bar2
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+     Biz1
+     Biz2
+     Biz3
+     Biz4
+  }
+}


### PR DESCRIPTION
`TreeInfo.splitAtSuper` splits a list of statements after the super
calls. The implementation failed to tell the difference between a
super call and an instantiation (`new C`).

Follow-up for https://github.com/scala/scala/pull/7270/commits/05f8e5aa3bdb77e317bb6bdb3d96621ce3fd2d39

Fixes https://github.com/scala/bug/issues/11736