### PR TITLE
Improve performance of BitSet.range methods (also solves #11748)

### DIFF
--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -212,25 +212,22 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
     val a = coll.toBitMask
     val len = a.length
     if (from.isDefined) {
-      var f = from.get
-      var pos = 0
-      while (f >= 64 && pos < len) {
-        f -= 64
-        a(pos) = 0
-        pos += 1
+      val f = from.get
+      val w = f >> LogWL
+      val b = f & (WordLength - 1)
+      if (w >= 0) {
+        java.util.Arrays.fill(a, 0, math.min(w, len), 0)
+        if (b > 0 && w < len) a(w) &= ~((1L << b) - 1)
       }
-      if (f > 0 && pos < len) a(pos) &= ~((1L << f)-1)
     }
     if (until.isDefined) {
       val u = until.get
-      val w = u / 64
-      val b = u % 64
-      var clearw = w+1
-      while (clearw < len) {
-        a(clearw) = 0
-        clearw += 1
+      val w = u >> LogWL
+      val b = u & (WordLength - 1)
+      if (w < len) {
+        java.util.Arrays.fill(a, math.max(w + 1, 0), len, 0)
+        if (w >= 0) a(w) &= (1L << b) - 1
       }
-      if (w < len) a(w) &= (1L << b)-1
     }
     coll.fromBitMaskNoCopy(a)
   }

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -119,6 +119,37 @@ class BitSetTest {
     assert(BitSet().diff(BitSet()) == BitSet())
   }
 
+  @Test def range(): Unit = {
+    val a = (0 until 512).to(BitSet)
+    assert(a.range(0, 511) == (0 until 511).to(BitSet))
+    assert(a.range(1, 512) == (1 until 512).to(BitSet))
+    assert(a.range(1, 511) == (1 until 511).to(BitSet))
+    assert(a.range(1, 63) == (1 until 63).to(BitSet))
+    assert(a.range(1, 64) == (1 until 64).to(BitSet))
+    assert(a.range(448, 511) == (448 until 511).to(BitSet))
+    assert(a.range(449, 511) == (449 until 511).to(BitSet))
+    assert(a.range(512, 512).isEmpty)
+    assert(a.range(512, 576).isEmpty)
+  }
+
+  @Test def rangeFrom(): Unit = {
+    val a = (0 until 512).to(BitSet)
+    assert(a.rangeFrom(1) == (1 until 512).to(BitSet))
+    assert(a.rangeFrom(63) == (63 until 512).to(BitSet))
+    assert(a.rangeFrom(64) == (64 until 512).to(BitSet))
+    assert(a.rangeFrom(512).isEmpty)
+    assert(a.rangeFrom(-100) == a)
+  }
+
+  @Test def rangeUntil(): Unit = {
+    val a = (0 until 512).to(BitSet)
+    assert(a.rangeUntil(511) == (0 until 511).to(BitSet))
+    assert(a.rangeUntil(448) == (0 until 448).to(BitSet))
+    assert(a.rangeUntil(449) == (0 until 449).to(BitSet))
+    assert(a.rangeUntil(0).isEmpty)
+    assert(a.rangeUntil(-100).isEmpty)
+  }
+
   @Test def buildFromRange(): Unit = {
     import scala.util.chaining._
     assert((1 to 1000).to(BitSet) == BitSet().tap(bs => (1 to 1000).foreach(bs.addOne)))

--- a/test/scalacheck/scala/collection/mutable/BitSetProperties.scala
+++ b/test/scalacheck/scala/collection/mutable/BitSetProperties.scala
@@ -68,4 +68,8 @@ object BitSetProperties extends Properties("mutable.BitSet") {
     left.subsetOf(leftUnionRight) && right.subsetOf(leftUnionRight)
   }
 
+  property("range") = forAll{ (bs: BitSet, range: Range) =>
+    bs.range(range.start, range.end) ?= bs.filter(b => b >= range.start && b < range.end)
+  }
+
 }


### PR DESCRIPTION
This improves the performance of `BitSet.range*` methods by using `Arrays.fill` for out-of-range bit clearing (instead of `while` loops). Also, this implementation does not suffer from https://github.com/scala/bug/issues/11748.

There was a limited `partest` coverage. I have added both `JUnit` and `ScalaCheck` tests, in case this is too much I would appreciate some guidance here.

Notes on benchmark results: 
- all benchmarks were run with https://github.com/scala/scala/pull/8412 merged in (it improves performance of `toBitMask` which is a significant part of `rangeImpl`)
- there is some performance degradation on small BitSets, part of it can be attributed to additional checks against negative indices

Benchmark results (`size` is the size of underlying array of longs):
```
[info] Benchmark                          (size)  Mode  Cnt      Score     Error  Units

[info] BitSetRangeBenchmark.rangeImplNew       1  avgt    6     31.678 ±   0.442  ns/op
[info] BitSetRangeBenchmark.rangeImplNew       8  avgt    6     35.587 ±   1.052  ns/op
[info] BitSetRangeBenchmark.rangeImplNew      64  avgt    6     61.869 ±   3.015  ns/op
[info] BitSetRangeBenchmark.rangeImplNew     512  avgt    6    397.586 ±  12.641  ns/op
[info] BitSetRangeBenchmark.rangeImplNew    4096  avgt    6   3679.449 ± 110.955  ns/op
[info] BitSetRangeBenchmark.rangeImplNew   32768  avgt    6  37506.904 ± 782.200  ns/op

[info] BitSetRangeBenchmark.rangeImplOld       1  avgt    6     29.394 ±   0.106  ns/op
[info] BitSetRangeBenchmark.rangeImplOld       8  avgt    6     33.986 ±   0.389  ns/op
[info] BitSetRangeBenchmark.rangeImplOld      64  avgt    6     79.663 ±  13.198  ns/op
[info] BitSetRangeBenchmark.rangeImplOld     512  avgt    6    500.025 ±  20.516  ns/op
[info] BitSetRangeBenchmark.rangeImplOld    4096  avgt    6   4371.550 ±  97.034  ns/op
[info] BitSetRangeBenchmark.rangeImplOld   32768  avgt    6  41832.326 ± 876.154  ns/op
```

Setup:
```
[info] # JMH version: 1.20
[info] # VM version: JDK 11.0.4, VM 11.0.4+11
[info] # VM invoker: /Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/bin/java
[info] # VM options: -XX:+UseSerialGC
```

Benchmark code:
```
package scala.collection.mutable

import org.openjdk.jmh.annotations._
import org.openjdk.jmh.infra._
import java.util.concurrent.TimeUnit

import scala.collection.mutable

@BenchmarkMode(Array(Mode.AverageTime))
@Fork(1)
@Threads(1)
@Warmup(iterations = 6)
@Measurement(iterations = 6)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@State(Scope.Benchmark)
class BitSetRangeBenchmark {

  @Param(Array("1", "8", "64", "512", "4096", "32768"))
  var size: Int = _

  var bs: mutable.BitSet = _
  var from, until: Some[Int] = _

  @Setup(Level.Iteration) def initialize(): Unit = {
    val length = size * 64
    bs = (0 until length).to(mutable.BitSet)
    from = Some(length / 3)
    until = Some(2 * length / 3)
  }

  @Benchmark def rangeImplOld(bh: Blackhole): Unit = {
    bs.rangeImpl(from, until)
  }

  @Benchmark def rangeImplNew(bh: Blackhole): Unit = {
    bs.rangeImplNew(from, until)
  }

}
```