### PR TITLE
[WIP] optimised classpath

### DIFF
--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -13,7 +13,6 @@
 package scala.tools.nsc
 
 import java.net.URL
-import scala.tools.util.PathResolver
 
 class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
   lazy val classpathURLs: Seq[URL] = {

--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -19,7 +19,7 @@ class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
   lazy val classpathURLs: Seq[URL] = {
     val registry = new CloseableRegistry
     try {
-      new PathResolver(this, registry).resultAsURLs
+      pathResolver(registry).resultAsURLs
     } finally {
       registry.close()
     }

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -41,7 +41,7 @@ import scala.tools.nsc.classpath._
 import scala.tools.nsc.profile.Profiler
 import java.io.Closeable
 
-import scala.tools.util.{PathResolverCaching, PathResolverNoCaching}
+import scala.tools.util.PathResolverNoCaching
 
 class Global(var currentSettings: Settings, reporter0: Reporter)
     extends SymbolTable

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -41,6 +41,8 @@ import scala.tools.nsc.classpath._
 import scala.tools.nsc.profile.Profiler
 import java.io.Closeable
 
+import scala.tools.util.{PathResolverCaching, PathResolverNoCaching}
+
 class Global(var currentSettings: Settings, reporter0: Reporter)
     extends SymbolTable
     with Closeable
@@ -822,7 +824,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
 
   /** Extend classpath of `platform` and rescan updated packages. */
   def extendCompilerClassPath(urls: URL*): Unit = {
-    val urlClasspaths = urls.map(u => ClassPathFactory.newClassPath(AbstractFile.getURL(u), settings, closeableRegistry))
+    val urlClasspaths = urls.map(u => ClassPathFactory.newClassPath(AbstractFile.getURL(u), settings, closeableRegistry, PathResolverNoCaching))
     val newClassPath = AggregateClassPath.createAggregate(platform.classPath +: urlClasspaths : _*)
     platform.currentClassPath = Some(newClassPath)
     invalidateClassPathEntries(urls.map(_.getPath): _*)
@@ -884,7 +886,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       }
       entries(classPath) find matchesCanonical match {
         case Some(oldEntry) =>
-          Some(oldEntry -> ClassPathFactory.newClassPath(dir, settings, closeableRegistry))
+          Some(oldEntry -> ClassPathFactory.newClassPath(dir, settings, closeableRegistry, PathResolverNoCaching))
         case None =>
           error(s"Error adding entry to classpath. During invalidation, no entry named $path in classpath $classPath")
           None

--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -360,7 +360,7 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
     override def toString: String = argsFile.toString
     def outputDir: Path = command.settings.outputDirs.getSingleOutput.get.file.toPath.toAbsolutePath.normalize()
     private def expand(s: command.settings.PathSetting): List[Path] = {
-      ClassPath.expandPath(s.value, expandStar = true).map(s => Paths.get(s).toAbsolutePath.normalize())
+      ClassPath.expandPath(s.value, expandStar = true).map(s => s.path.toAbsolutePath.normalize())
     }
     lazy val classPath: Seq[Path] = expand(command.settings.classpath)
     lazy val macroClassPath: Seq[Path] = expand(command.settings.YmacroClasspath)
@@ -613,7 +613,7 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
     if (strategy != Traditional) {
       val classPath = ClassPath.expandPath(settings.classpath.value, expandStar = true)
       val modifiedClassPath = classPath.map { entry =>
-        val entryPath = Paths.get(entry)
+        val entryPath = entry.path
         if (Files.exists(entryPath))
           strippedAndExportedClassPath.getOrElse(entryPath.toRealPath().normalize(), entryPath).toString
         else

--- a/src/compiler/scala/tools/nsc/Settings.scala
+++ b/src/compiler/scala/tools/nsc/Settings.scala
@@ -23,7 +23,7 @@ class Settings(errorFn: String => Unit) extends MutableSettings(errorFn) {
   var pathResolverFactory: (Settings, CloseableRegistry) => PathResolver =
     PathResolver.apply
 
-  def pathResolver(closeableRegistry: CloseableRegistry = new CloseableRegistry) =
+  def pathResolver(closeableRegistry: CloseableRegistry) =
     pathResolverFactory(this, closeableRegistry)
 
   override def withErrorFn(errorFn: String => Unit): Settings = {

--- a/src/compiler/scala/tools/nsc/Settings.scala
+++ b/src/compiler/scala/tools/nsc/Settings.scala
@@ -12,12 +12,19 @@
 
 package scala.tools.nsc
 
+import scala.tools.util.PathResolver
 import settings.MutableSettings
 
 /** A compatibility stub.
  */
 class Settings(errorFn: String => Unit) extends MutableSettings(errorFn) {
   def this() = this(Console.println)
+
+  var pathResolverFactory: (Settings, CloseableRegistry) => PathResolver =
+    PathResolver.apply
+
+  def pathResolver(closeableRegistry: CloseableRegistry = new CloseableRegistry) =
+    pathResolverFactory(this, closeableRegistry)
 
   override def withErrorFn(errorFn: String => Unit): Settings = {
     val settings = new Settings(errorFn)

--- a/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
+++ b/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
@@ -15,7 +15,6 @@ package backend
 
 import io.AbstractFile
 import scala.tools.nsc.classpath.AggregateClassPath
-import scala.tools.util.PathResolver
 import scala.tools.nsc.util.ClassPath
 
 trait JavaPlatform extends Platform {

--- a/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
+++ b/src/compiler/scala/tools/nsc/backend/JavaPlatform.scala
@@ -27,7 +27,7 @@ trait JavaPlatform extends Platform {
   private[nsc] var currentClassPath: Option[ClassPath] = None
 
   protected[nsc] def classPath: ClassPath = {
-    if (currentClassPath.isEmpty) currentClassPath = Some(new PathResolver(settings, global.closeableRegistry).result)
+    if (currentClassPath.isEmpty) currentClassPath = Some(settings.pathResolver(global.closeableRegistry).result)
     currentClassPath.get
   }
 

--- a/src/compiler/scala/tools/nsc/classpath/AggregateClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/AggregateClassPath.scala
@@ -85,8 +85,8 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
 
   override private[nsc] def hasPackage(pkg: PackageName) = aggregates.exists(_.hasPackage(pkg))
   override private[nsc] def list(inPackage: PackageName): ClassPathEntries = {
-    val packages = new java.util.HashSet[PackageEntry]()
-    val classesAndSources = new java.util.HashMap[String, ClassRepresentation]()
+    val packages = new java.util.LinkedHashSet[PackageEntry]()
+    val classesAndSources = new java.util.LinkedHashMap[String, ClassRepresentation]()
     val onPackage: PackageEntry => Unit = packages.add(_)
     /**
      * Only one entry for each name. Merges existing and new entry, but doesnt overwrite source or binary of an existing entry
@@ -101,7 +101,6 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
         if (existingBinary.isEmpty && { entryBinary = entry.binary; entryBinary.isDefined})
           classesAndSources.put(entry.name, ClassAndSourceFilesEntry(entryBinary.get, existingSource.get))
         else {
-
           var entrySource: Option[AbstractFile] = null
           if (existingSource.isEmpty && { entrySource = entry.source; entrySource.isDefined})
             classesAndSources.put(entry.name, ClassAndSourceFilesEntry(existingBinary.get, entrySource.get))

--- a/src/compiler/scala/tools/nsc/classpath/CachedClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/CachedClassPath.scala
@@ -1,0 +1,58 @@
+package scala.tools.nsc.classpath
+
+import java.net.URL
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.tools.nsc.io.AbstractFile
+import scala.tools.nsc.util.{ClassPath, ClassRepresentation, EfficientClassPath}
+
+class CachedClassPath(underlying: ClassPath) extends EfficientClassPath {
+  override private[nsc] def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit = {
+    val info = forPackage(inPackage)
+    info.entries.packages foreach onPackageEntry
+    info.entries.classesAndSources foreach onClassesAndSources
+  }
+
+  override private[nsc] def hasPackage(inPackage: PackageName) = forPackage(inPackage).isEmpty
+  override private[nsc] def packages(inPackage: PackageName) = forPackage(inPackage).entries.packages
+
+  override private[nsc] def classes(inPackage: PackageName) = forPackage(inPackage).classes
+  override private[nsc] def clazz(inPackage: PackageName, className: String) =
+    forPackage(inPackage).classesAndSourcesByName.get(className).collect{case cls:ClassFileEntry => cls}
+
+  override private[nsc] def sources(inPackage: PackageName) = forPackage(inPackage).sources
+  override private[nsc] def source(inPackage: PackageName, className: String) =
+    forPackage(inPackage).classesAndSourcesByName.get(className).collect{case cls:SourceFileEntry => cls}
+
+  override def findClassFile(className: String): Option[AbstractFile] = {
+    val (inPackage, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
+    forPackage(PackageName(inPackage)).classesAndSourcesByName.get(simpleClassName) flatMap (_.binary)
+  }
+
+  override lazy val asURLs: Seq[URL] = underlying.asURLs
+  override lazy val asClassPathStrings: Seq[String] = underlying.asClassPathStrings
+  override lazy val asSourcePathString: String = underlying.asSourcePathString
+
+  override private[nsc] def list(inPackage: PackageName) = forPackage(inPackage).entries
+
+  override def findClass(className: String): Option[ClassRepresentation] = {
+    val (inPackage, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
+    forPackage(PackageName(inPackage)).classesAndSourcesByName.get(simpleClassName)
+  }
+
+  override def asClassPathString: String = super.asClassPathString
+
+  def forPackage(inPackage: PackageName): PackageInfo = ???
+
+  case class PackageInfo(inPackage: String, entries: ClassPathEntries) {
+    def isEmpty = entries.packages.isEmpty && entries.classesAndSources.isEmpty
+
+    lazy val classesAndSourcesByName: Map[String, ClassRepresentation] = entries.classesAndSources.map(e => e.name -> e)(collection.breakOut)
+    lazy val sources = entries.classesAndSources.collect { case s: SourceFileEntry => s }
+    lazy val classes = entries.classesAndSources.collect { case c: ClassFileEntry => c }
+
+  }
+
+  private val packageCache = new ConcurrentHashMap[String, PackageInfo]()
+
+}

--- a/src/compiler/scala/tools/nsc/classpath/CachedClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/CachedClassPath.scala
@@ -42,9 +42,10 @@ class CachedClassPath(underlying: ClassPath) extends EfficientClassPath {
 
   override def asClassPathString: String = super.asClassPathString
 
-  def forPackage(inPackage: PackageName): PackageInfo = ???
+  def forPackage(inPackage: PackageName): PackageInfo = packageCache.computeIfAbsent(inPackage, p =>
+    PackageInfo(p, underlying.list(p)))
 
-  case class PackageInfo(inPackage: String, entries: ClassPathEntries) {
+  case class PackageInfo(inPackage: PackageName, entries: ClassPathEntries) {
     def isEmpty = entries.packages.isEmpty && entries.classesAndSources.isEmpty
 
     lazy val classesAndSourcesByName: Map[String, ClassRepresentation] = entries.classesAndSources.map(e => e.name -> e)(collection.breakOut)
@@ -53,6 +54,6 @@ class CachedClassPath(underlying: ClassPath) extends EfficientClassPath {
 
   }
 
-  private val packageCache = new ConcurrentHashMap[String, PackageInfo]()
+  private val packageCache = new ConcurrentHashMap[PackageName, PackageInfo]()
 
 }

--- a/src/compiler/scala/tools/nsc/classpath/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPath.scala
@@ -34,7 +34,7 @@ trait SourceFileEntry extends ClassRepresentation {
 
 case class PackageName(dottedString: String) {
   def isRoot: Boolean = dottedString.isEmpty
-  val dirPathTrailingSlash: String = FileUtils.dirPath(dottedString) + "/"
+  lazy val dirPathTrailingSlash: String = FileUtils.dirPath(dottedString) + "/"
 
   def entryName(entry: String): String = {
     if (isRoot) entry else {

--- a/src/compiler/scala/tools/nsc/classpath/ClassPathElement.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPathElement.scala
@@ -1,5 +1,6 @@
 package scala.tools.nsc.classpath
 
+import java.net.URL
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{Files, LinkOption, Path, Paths}
 
@@ -8,7 +9,7 @@ import scala.tools.nsc.classpath.FileUtils.{endsClass, endsJImage, endsJarOrZip,
 import scala.tools.nsc.util.ClassPath
 
 sealed trait ClassPathElement {
-
+  def url: URL
 }
 object ClassPathElement {
 
@@ -24,6 +25,8 @@ object ClassPathElement {
   def fromPathOption(path: String): Option[PathBasedClassPathElement] = fromPathOption(Paths.get(path))
 
   sealed trait PathBasedClassPathElement extends ClassPathElement {
+    def url: URL = path.toUri.toURL
+
     def isDirectory = false
     def isJarOrZip = false
     def isImage = false
@@ -33,9 +36,15 @@ object ClassPathElement {
     def file = path.toFile
     def path = underlying.path
   }
-  object JrtClassPathElement$ extends ClassPathElement
-  case class VirtualDirectoryClassPathElement(dir: VirtualDirectory) extends ClassPathElement
-  case class ManifestClassPathElement(manifest: ManifestResources) extends ClassPathElement
+  object JrtClassPathElement extends ClassPathElement{
+    def url = new URL("jrt://")
+  }
+  case class VirtualDirectoryClassPathElement(dir: VirtualDirectory) extends ClassPathElement {
+    def url = dir.toURL
+  }
+  case class ManifestClassPathElement(manifest: ManifestResources) extends ClassPathElement {
+    def url = manifest.url
+  }
 
 
   class ZipJarClassPathElement(private[ClassPathElement] val underlying: BasicPathElement) extends PathBasedClassPathElement {

--- a/src/compiler/scala/tools/nsc/classpath/ClassPathElement.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPathElement.scala
@@ -6,7 +6,6 @@ import java.nio.file.{Files, LinkOption, Path, Paths}
 
 import scala.reflect.io.{ManifestResources, VirtualDirectory}
 import scala.tools.nsc.classpath.FileUtils.{endsClass, endsJImage, endsJarOrZip, mayBeValidPackage}
-import scala.tools.nsc.util.ClassPath
 
 sealed trait ClassPathElement {
   def url: URL
@@ -35,6 +34,7 @@ object ClassPathElement {
 
     def file = path.toFile
     def path = underlying.path
+    def absolutePath = underlying.path
   }
   object JrtClassPathElement extends ClassPathElement{
     def url = new URL("jrt://")
@@ -77,7 +77,7 @@ object ClassPathElement {
 
     lazy val filename = path.getFileName.toString
     lazy val absoluePath = path.toAbsolutePath
-    lazy val uri = path.toUri
+    lazy val uri = absoluePath.toUri //path.toUri would call absolute, so we may as well cache the answer
     lazy val url = uri.toURL
 
     def isClass: Boolean = isRegularFile && endsClass(filename)

--- a/src/compiler/scala/tools/nsc/classpath/ClassPathElement.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPathElement.scala
@@ -1,0 +1,80 @@
+package scala.tools.nsc.classpath
+
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{Files, LinkOption, Path, Paths}
+
+import scala.reflect.io.{ManifestResources, VirtualDirectory}
+import scala.tools.nsc.classpath.FileUtils.{endsClass, endsJImage, endsJarOrZip, mayBeValidPackage}
+import scala.tools.nsc.util.ClassPath
+
+sealed trait ClassPathElement {
+
+}
+object ClassPathElement {
+
+  def fromPathOption(path: Path): Option[PathBasedClassPathElement] = {
+    val base = new BasicPathElement(path)
+    if (base.isJarOrZip) Some(new ZipJarClassPathElement(base))
+    else if (base.isDirectory) Some(new DirectoryClassPathElement(base))
+    else if (base.isImage) ??? // Some(new ImagePathElement(base))
+    else None
+  }
+
+  def fromPathOption(path: String): Option[PathBasedClassPathElement] = fromPathOption(Paths.get(path))
+
+  sealed trait PathBasedClassPathElement extends ClassPathElement {
+    def isDirectory = false
+    def isJarOrZip = false
+    def isImage = false
+
+    private[ClassPathElement] val underlying: BasicPathElement
+
+    def file = path.toFile
+    def path = underlying.path
+  }
+  object JrtClassPathElement$ extends ClassPathElement
+  case class VirtualDirectoryClassPathElement(dir: VirtualDirectory) extends ClassPathElement
+  case class ManifestClassPathElement(manifest: ManifestResources) extends ClassPathElement
+
+
+  class ZipJarClassPathElement(private[ClassPathElement] val underlying: BasicPathElement) extends PathBasedClassPathElement {
+    override def isJarOrZip: Boolean = true
+    assert(underlying.isJarOrZip)
+
+  }
+
+  class DirectoryClassPathElement(private[ClassPathElement] val underlying: BasicPathElement) extends PathBasedClassPathElement {
+
+    override def isDirectory: Boolean = true
+
+    def contents = {
+      import scala.collection.JavaConverters._
+      Files.list(path).iterator.asScala
+    }
+
+    assert(underlying.isDirectory)
+  }
+
+  private[ClassPathElement] final class BasicPathElement(val path: Path) {
+    import BasicPathElement._
+
+    val attributes = Files.readAttributes(path, classOf[BasicFileAttributes], noLinkOptions: _*)
+
+    def isDirectory: Boolean = attributes.isDirectory
+    def isRegularFile: Boolean = attributes.isRegularFile
+
+    lazy val filename = path.getFileName.toString
+    lazy val absoluePath = path.toAbsolutePath
+    lazy val uri = path.toUri
+    lazy val url = uri.toURL
+
+    def isClass: Boolean = isRegularFile && endsClass(filename)
+    def isJarOrZip: Boolean = isRegularFile && endsJarOrZip(filename)
+    def isImage: Boolean = isRegularFile && endsJImage(filename)
+
+    def isPackage: Boolean = isDirectory && mayBeValidPackage(filename)
+  }
+  private object BasicPathElement {
+    private val noLinkOptions = new Array[LinkOption](0)
+  }
+}

--- a/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
@@ -15,7 +15,6 @@ package scala.tools.nsc.classpath
 import java.net.URL
 
 import scala.reflect.io.{AbstractFile, VirtualDirectory}
-import scala.reflect.io.Path.string2path
 import scala.tools.nsc.{CloseableRegistry, Settings}
 import FileUtils.AbstractFileOps
 import scala.tools.nsc.classpath.ClassPathElement.{DirectoryClassPathElement, PathBasedClassPathElement, ZipJarClassPathElement}

--- a/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
@@ -67,18 +67,10 @@ class ClassPathFactory(settings: Settings, closeableRegistry: CloseableRegistry 
   protected def classesInPathImpl(path: String, expand: Boolean, pathResolverCaching: PathResolverCaching) =
     expandPath(path, expand).collect { case path: PathBasedClassPathElement => newClassPath(path, pathResolverCaching)}
 
-  private def createSourcePath(file: AbstractFile, pathResolverCaching: PathResolverCaching): ClassPath =
-    if (file.isJarOrZip)
-      ZipAndJarSourcePathFactory.create(file, settings, closeableRegistry, pathResolverCaching)
-    else if (file.isDirectory)
-      DirectorySourcePath(file.file)
-    else
-      sys.error(s"Unsupported sourcepath element: $file")
-
   private def createSourcePath(file: PathBasedClassPathElement, pathResolverCaching: PathResolverCaching): ClassPath =
     file match {
       case jar: ZipJarClassPathElement =>  ZipAndJarSourcePathFactory.create(jar, settings, closeableRegistry, pathResolverCaching)
-      case dir: DirectoryClassPathElement =>  DirectorySourcePath(file.file)
+      case dir: DirectoryClassPathElement =>  DirectorySourcePath(dir.file)
       case _  => sys.error(s"Unsupported sourcepath element: $file")
     }
 }

--- a/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
@@ -134,7 +134,7 @@ object JrtClassPath {
   private lazy val jrtClassPath = {
     try {
       val fs = FileSystems.getFileSystem(URI.create("jrt:/"))
-      Some(new CachedClassPath(new JrtClassPath(fs)))
+      Some(new CachedClassPath(new JrtClassPath(fs), "jrt"))
     } catch {
       case _: ProviderNotFoundException | _: FileSystemNotFoundException => None
     }

--- a/src/compiler/scala/tools/nsc/classpath/FileUtils.scala
+++ b/src/compiler/scala/tools/nsc/classpath/FileUtils.scala
@@ -47,6 +47,9 @@ object FileUtils {
   private val SUFFIX_SCALA = ".scala"
   private val SUFFIX_JAVA = ".java"
   private val SUFFIX_SIG = ".sig"
+  private val SUFFIX_JAR = ".jar"
+  private val SUFFIX_ZIP = ".zip"
+  private val SUFFIX_IMAGE = ".jimage"
 
   def stripSourceExtension(fileName: String): String = {
     if (endsScala(fileName)) stripClassExtension(fileName)
@@ -59,7 +62,13 @@ object FileUtils {
   @inline private def ends (filename:String, suffix:String) = filename.endsWith(suffix) && filename.length > suffix.length
 
   def endsClass(fileName: String): Boolean =
-    ends (fileName, SUFFIX_CLASS) || fileName.endsWith(SUFFIX_SIG)
+    ends (fileName, SUFFIX_CLASS) || ends (fileName, SUFFIX_SIG)
+
+  def endsJarOrZip(fileName: String): Boolean =
+    ends (fileName, SUFFIX_JAR) || ends (fileName, SUFFIX_ZIP)
+
+  def endsJImage(fileName: String): Boolean =
+    ends (fileName, SUFFIX_IMAGE)
 
   def endsScalaOrJava(fileName: String): Boolean =
     endsScala(fileName) || endsJava(fileName)

--- a/src/compiler/scala/tools/nsc/classpath/PackageNameUtils.scala
+++ b/src/compiler/scala/tools/nsc/classpath/PackageNameUtils.scala
@@ -30,6 +30,15 @@ object PackageNameUtils {
     else
       (fullClassName.substring(0, lastDotIndex), fullClassName.substring(lastDotIndex + 1))
   }
+  /**
+   * @param fullClassName full class name with package
+   * @return package
+   */
+  @inline def pkgName(fullClassName: String): String = {
+    val lastDotIndex = fullClassName.lastIndexOf('.')
+    if (lastDotIndex == -1) RootPackage
+    else fullClassName.substring(0, lastDotIndex)
+  }
 
   def packagePrefix(inPackage: String): String = if (inPackage == RootPackage) "" else inPackage + "."
 

--- a/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
@@ -288,7 +288,6 @@ final class FileBasedCache[T] {
     else Right(Some(Path(file.file).jfile.toPath))
   }
   def checkCacheability2(file: AbstractFile, checkStamps: Boolean, disableCache: Boolean): Either[String, Option[java.nio.file.Path]] = {
-    import scala.reflect.io.{Path}
     if (disableCache) Left("caching is disabled due to a policy setting")
     else if (!checkStamps) Right(Some(file.file.toPath))
     else if ((file eq null) || !Jar.isJarOrZip(file.file))
@@ -296,7 +295,6 @@ final class FileBasedCache[T] {
     else Right(Some(file.file.toPath))
   }
   def checkCacheability3(file: AbstractFile, checkStamps: Boolean, disableCache: Boolean): Either[String, java.nio.file.Path] = {
-    import scala.reflect.io.{Path}
     if (disableCache) Left("caching is disabled due to a policy setting")
     else if (!checkStamps) Right(file.file.toPath)
     else if ((file eq null) || !Jar.isJarOrZip(file.file))

--- a/src/compiler/scala/tools/nsc/plugins/Plugin.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugin.scala
@@ -14,7 +14,6 @@ package scala.tools.nsc
 package plugins
 
 import java.util.jar
-import scala.collection.JavaConverters._
 import scala.reflect.internal.util.ScalaClassLoader
 import scala.reflect.io.{AbstractFile, File, Path}
 import scala.collection.mutable

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -75,11 +75,12 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
     import java.net.URL
     import scala.tools.nsc.io.AbstractFile
 
+    //FIXME - dont use URLs
     val classpath: Seq[URL] = if (settings.YmacroClasspath.isSetByUser) {
       for {
-        file <- scala.tools.nsc.util.ClassPath.expandPath(settings.YmacroClasspath.value, true)
-        af <- Option(AbstractFile getDirectory file)
-      } yield af.file.toURI.toURL
+        //why just directories?
+        file <- scala.tools.nsc.util.ClassPath.expandPath(settings.YmacroClasspath.value, true) filter (_.isDirectory)
+      } yield file.file.toURI.toURL
     } else global.classPath.asURLs
     def newLoader: () => ScalaClassLoader.URLClassLoader = () => {
       analyzer.macroLogVerbose("macro classloader: initializing from -cp: %s".format(classpath))

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -73,7 +73,6 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
     */
   protected def findMacroClassLoader(): ClassLoader = {
     import java.net.URL
-    import scala.tools.nsc.io.AbstractFile
 
     //FIXME - dont use URLs
     val classpath: Seq[URL] = if (settings.YmacroClasspath.isSetByUser) {

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -48,7 +48,11 @@ trait ClassPath {
   private[nsc] def hasPackage(pkg: PackageName): Boolean
   private[nsc] def packages(inPackage: PackageName): Seq[PackageEntry]
   private[nsc] def classes(inPackage: PackageName): Seq[ClassFileEntry]
+  private[nsc] def clazz(inPackage: PackageName, className:String): Option[ClassFileEntry] =
+    classes(inPackage).find(_.name == className)
   private[nsc] def sources(inPackage: PackageName): Seq[SourceFileEntry]
+  private[nsc] def source(inPackage: PackageName, className:String): Option[SourceFileEntry] =
+    sources(inPackage).find(_.name == className)
 
   /**
    * Returns packages and classes (source or classfile) that are members of `inPackage` (not
@@ -77,8 +81,8 @@ trait ClassPath {
     val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
 
     val packageName = PackageName(pkg)
-    val foundClassFromClassFiles = classes(packageName).find(_.name == simpleClassName)
-    def findClassInSources = sources(packageName).find(_.name == simpleClassName)
+    val foundClassFromClassFiles = clazz(packageName, simpleClassName)
+    def findClassInSources = source(packageName, simpleClassName)
 
     foundClassFromClassFiles orElse findClassInSources
   }

--- a/src/compiler/scala/tools/reflect/ReflectMain.scala
+++ b/src/compiler/scala/tools/reflect/ReflectMain.scala
@@ -14,13 +14,12 @@ package scala.tools
 package reflect
 
 import scala.reflect.internal.util.ScalaClassLoader
-import scala.tools.nsc.{Driver, Global, CloseableRegistry, Settings}
-import scala.tools.util.PathResolver
+import scala.tools.nsc.{CloseableRegistry, Driver, Global, Settings}
 
 object ReflectMain extends Driver {
 
   private def classloaderFromSettings(settings: Settings) = {
-    val classPathURLs = settings.pathResolver().resultAsURLs
+    val classPathURLs = settings.pathResolver(new CloseableRegistry).resultAsURLs
     ScalaClassLoader.fromURLs(classPathURLs, getClass.getClassLoader)
   }
 

--- a/src/compiler/scala/tools/reflect/ReflectMain.scala
+++ b/src/compiler/scala/tools/reflect/ReflectMain.scala
@@ -20,7 +20,7 @@ import scala.tools.util.PathResolver
 object ReflectMain extends Driver {
 
   private def classloaderFromSettings(settings: Settings) = {
-    val classPathURLs = new PathResolver(settings, new CloseableRegistry).resultAsURLs
+    val classPathURLs = settings.pathResolver().resultAsURLs
     ScalaClassLoader.fromURLs(classPathURLs, getClass.getClassLoader)
   }
 

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -365,64 +365,64 @@ class ReuseAllPathResolver(settings: Settings, closeableRegistry: CloseableRegis
 
   override val calculated: Calculated = new DefaultCalculated {
 
-    def cached(cp: Option[ClassPath]) = {
-      cp.map(new CachedClassPath(_))
+    def cached(cp: Option[ClassPath], name: String) = {
+      cp.map(new CachedClassPath(_, name))
     }
 
-    def cachedTogether(cp: List[ClassPath]) = {
+    def cachedTogether(cp: List[ClassPath], name: String) = {
       cp match {
         case Nil => Nil
-        case _ => List(new CachedClassPath(new AggregateClassPath(cp)))
+        case _ => List(new CachedClassPath(new AggregateClassPath(cp), name))
       }
     }
-    def cachedIndividually(cp: List[ClassPath], individualCache: ConcurrentHashMap[String, CachedClassPath]) = {
+    def cachedIndividually(cp: List[ClassPath], individualCache: ConcurrentHashMap[String, CachedClassPath], name: String) = {
       cp match {
         case Nil => Nil
         case cp =>
           val cached = cp map { ele =>
             val key = ele.asClassPathString
-            val newPath = new CachedClassPath(ele)
+            val newPath = new CachedClassPath(ele, name)
             val existingPath = individualCache.computeIfAbsent(key, k => newPath)
             if (existingPath eq null) newPath else existingPath
           }
-          List(new CachedClassPath(new AggregateClassPath(cached)))
+          List(new CachedClassPath(new AggregateClassPath(cached), s"cached aggregate[$name]"))
       }
     }
 
     override protected def buildJrt(release: Option[String],classPathFactory: ClassPathFactory, pathResolverCaching: PathResolverCaching): Option[ClassPath] = {
-      jrtCache.computeIfAbsent(release, r => cached(super.buildJrt(r, classPathFactory, pathResolverCaching)))
+      jrtCache.computeIfAbsent(release, r => cached(super.buildJrt(r, classPathFactory, pathResolverCaching), "jrt"))
     }
 
     override protected def buildJavaBootClassPath(path: String,classPathFactory: ClassPathFactory, pathResolverCaching: PathResolverCaching): List[ClassPath] = {
-      javaRootCp.computeIfAbsent(path, p => cachedTogether(super.buildJavaBootClassPath(p, classPathFactory, pathResolverCaching)))
+      javaRootCp.computeIfAbsent(path, p => cachedTogether(super.buildJavaBootClassPath(p, classPathFactory, pathResolverCaching), "java boot cp"))
     }
 
     override protected def buildJavaExtClassPath(path: String,classPathFactory: ClassPathFactory, pathResolverCaching: PathResolverCaching): List[ClassPath] = {
-      javaExtCp.computeIfAbsent(path, p => cachedTogether(super.buildJavaExtClassPath(p, classPathFactory, pathResolverCaching)))
+      javaExtCp.computeIfAbsent(path, p => cachedTogether(super.buildJavaExtClassPath(p, classPathFactory, pathResolverCaching), "java ext cp"))
     }
 
     override protected def buildJavaAppClassPath(path: String,classPathFactory: ClassPathFactory, pathResolverCaching: PathResolverCaching): List[ClassPath] = {
-      javaAppCp.computeIfAbsent(path, p => cachedTogether(super.buildJavaAppClassPath(p, classPathFactory, pathResolverCaching)))
+      javaAppCp.computeIfAbsent(path, p => cachedTogether(super.buildJavaAppClassPath(p, classPathFactory, pathResolverCaching), "java app cp"))
     }
 
     override protected def buildScalaBootClassPath(path: String,classPathFactory: ClassPathFactory, pathResolverCaching: PathResolverCaching): List[ClassPath] = {
-      scalaRootCp.computeIfAbsent(path, p => cachedTogether(super.buildScalaBootClassPath(p, classPathFactory, pathResolverCaching)))
+      scalaRootCp.computeIfAbsent(path, p => cachedTogether(super.buildScalaBootClassPath(p, classPathFactory, pathResolverCaching), "scala boot cp"))
     }
 
     override protected def buildScalaExtClassPath(path: String,classPathFactory: ClassPathFactory, pathResolverCaching: PathResolverCaching): List[ClassPath] = {
-      scalaExtCp.computeIfAbsent(path, p => cachedTogether(super.buildScalaExtClassPath(p, classPathFactory, pathResolverCaching)))
+      scalaExtCp.computeIfAbsent(path, p => cachedTogether(super.buildScalaExtClassPath(p, classPathFactory, pathResolverCaching), "scala ext cp"))
     }
 
     override protected def buildScalaAppClassPath(path: String,classPathFactory: ClassPathFactory, pathResolverCaching: PathResolverCaching): List[ClassPath] = {
-      scalaAppCp.computeIfAbsent(path, p => cachedIndividually(super.buildScalaAppClassPath(p, classPathFactory, pathResolverCaching), individualClassCache))
+      scalaAppCp.computeIfAbsent(path, p => cachedIndividually(super.buildScalaAppClassPath(p, classPathFactory, pathResolverCaching), individualClassCache, "scala app cp"))
     }
 
     override protected def buildManifestClassPath(use: Boolean,classPathFactory: ClassPathFactory, pathResolverCaching: PathResolverCaching): List[ClassPath] = {
-      scalaManifestCp.computeIfAbsent(use, u => cachedTogether(super.buildManifestClassPath(u, classPathFactory, pathResolverCaching)))
+      scalaManifestCp.computeIfAbsent(use, u => cachedTogether(super.buildManifestClassPath(u, classPathFactory, pathResolverCaching), "manifest cp"))
     }
 
     override protected def buildSourceClassPath(path: String,classPathFactory: ClassPathFactory, pathResolverCaching: PathResolverCaching): List[ClassPath] = {
-      sourceCp.computeIfAbsent(path, p => cachedIndividually(super.buildSourceClassPath(p, classPathFactory, pathResolverCaching), individualSourceCache))
+      sourceCp.computeIfAbsent(path, p => cachedIndividually(super.buildSourceClassPath(p, classPathFactory, pathResolverCaching), individualSourceCache, "source cp"))
     }
   }
 }

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -372,7 +372,7 @@ class ReuseAllPathResolver(settings: Settings, closeableRegistry: CloseableRegis
     def cachedTogether(cp: List[ClassPath]) = {
       cp match {
         case Nil => Nil
-        case _ => List(new CachedClassPath(new AggregateClassPath((cp))))
+        case _ => List(new CachedClassPath(new AggregateClassPath(cp)))
       }
     }
     def cachedIndividually(cp: List[ClassPath], individualCache: ConcurrentHashMap[String, CachedClassPath]) = {
@@ -381,7 +381,9 @@ class ReuseAllPathResolver(settings: Settings, closeableRegistry: CloseableRegis
         case cp =>
           val cached = cp map { ele =>
             val key = ele.asClassPathString
-            individualCache.computeIfAbsent(key, k => new CachedClassPath(ele))
+            val newPath = new CachedClassPath(ele)
+            val existingPath = individualCache.computeIfAbsent(key, k => newPath)
+            if (existingPath eq null) newPath else existingPath
           }
           List(new CachedClassPath(new AggregateClassPath(cached)))
       }

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -204,14 +204,17 @@ object PathResolver {
         registry.close()
       }
     }
+
+  def apply(settings: Settings, closeableRegistry: CloseableRegistry = new CloseableRegistry): PathResolver =
+    new PathResolver(settings, closeableRegistry)
 }
 
-final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistry = new CloseableRegistry) {
+class PathResolver protected (settings: Settings, closeableRegistry: CloseableRegistry = new CloseableRegistry) {
 
   @deprecated("for bincompat in 2.12.x series", "2.12.9")  // TODO remove from 2.13.x
   def this(settings: Settings) = this(settings, new CloseableRegistry)
 
-  private val classPathFactory = new ClassPathFactory(settings, closeableRegistry)
+  protected val classPathFactory = new ClassPathFactory(settings, closeableRegistry)
 
   import PathResolver.{ AsLines, Defaults, ppcp }
 
@@ -311,6 +314,6 @@ final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistr
   @deprecated("Use resultAsURLs instead of this one", "2.11.5")
   def asURLs: List[URL] = resultAsURLs.toList
 
-  private def computeResult(): ClassPath = AggregateClassPath(containers.toIndexedSeq)
+  protected def computeResult(): ClassPath = AggregateClassPath(containers.toIndexedSeq)
 }
 

--- a/src/partest-extras/scala/tools/partest/BytecodeTest.scala
+++ b/src/partest-extras/scala/tools/partest/BytecodeTest.scala
@@ -149,7 +149,7 @@ abstract class BytecodeTest {
     val factory = new ClassPathFactory(new Settings(), new CloseableRegistry)
     val containers = factory.classesInExpandedPath(
       sys.props("partest.output") + java.io.File.pathSeparator + Defaults.javaUserClassPath,
-      PathResolverNoCaching)
+      PathResolverNoCaching, Set.empty)
     new AggregateClassPath(containers)
   }
 }

--- a/src/partest-extras/scala/tools/partest/BytecodeTest.scala
+++ b/src/partest-extras/scala/tools/partest/BytecodeTest.scala
@@ -19,6 +19,7 @@ import java.io.{InputStream, File => JFile}
 
 import AsmNode._
 import scala.tools.nsc.CloseableRegistry
+import scala.tools.util.PathResolverNoCaching
 
 /**
  * Provides utilities for inspecting bytecode using ASM library.
@@ -146,7 +147,9 @@ abstract class BytecodeTest {
     // logic inspired by scala.tools.util.PathResolver implementation
     // `Settings` is used to check YdisableFlatCpCaching in ZipArchiveFlatClassPath
     val factory = new ClassPathFactory(new Settings(), new CloseableRegistry)
-    val containers = factory.classesInExpandedPath(sys.props("partest.output") + java.io.File.pathSeparator + Defaults.javaUserClassPath)
+    val containers = factory.classesInExpandedPath(
+      sys.props("partest.output") + java.io.File.pathSeparator + Defaults.javaUserClassPath,
+      PathResolverNoCaching)
     new AggregateClassPath(containers)
   }
 }

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -100,7 +100,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
 
   def compilerClasspath: Seq[java.net.URL] = (
     if (isInitializeComplete) global.classPath.asURLs
-    else new PathResolver(settings, global.closeableRegistry).resultAsURLs  // the compiler's classpath
+    else settings.pathResolver(global.closeableRegistry).resultAsURLs  // the compiler's classpath
   )
   def settings = initialSettings
   // Run the code body with the given boolean settings flipped to true.

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
@@ -18,6 +18,7 @@ import scala.tools.nsc.util.ClassPath
 import scala.tools.nsc.{Settings, interactive}
 import scala.tools.nsc.reporters.StoreReporter
 import scala.tools.nsc.classpath._
+import scala.tools.util.PathResolverNoCaching
 
 trait PresentationCompilation {
   self: IMain =>
@@ -71,7 +72,7 @@ trait PresentationCompilation {
     val storeReporter: StoreReporter = new StoreReporter
     val interactiveGlobal = new interactive.Global(copySettings, storeReporter) { self =>
       def mergedFlatClasspath = {
-        val replOutClasspath = ClassPathFactory.newClassPath(replOutput.dir, settings, closeableRegistry)
+        val replOutClasspath = ClassPathFactory.newClassPath(replOutput.dir, settings, closeableRegistry, PathResolverNoCaching)
         AggregateClassPath(replOutClasspath :: global.platform.classPath :: Nil)
       }
 

--- a/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -15,6 +15,7 @@ package interpreter
 
 import scala.tools.nsc.classpath.{AggregateClassPath, ClassPathFactory}
 import scala.tools.nsc.util.ClassPath
+import scala.tools.util.PathResolverNoCaching
 import typechecker.Analyzer
 
 /** A layer on top of Global so I can guarantee some extra
@@ -45,7 +46,7 @@ trait ReplGlobal extends Global {
       case None => base
       case Some(out) =>
         // Make bytecode of previous lines available to the inliner
-        val replOutClasspath = ClassPathFactory.newClassPath(settings.outputDirs.getSingleOutput.get, settings, closeableRegistry)
+        val replOutClasspath = ClassPathFactory.newClassPath(settings.outputDirs.getSingleOutput.get, settings, closeableRegistry, PathResolverNoCaching)
         AggregateClassPath.createAggregate(platform.classPath, replOutClasspath)
     }
   }

--- a/src/scalap/scala/tools/scalap/Main.scala
+++ b/src/scalap/scala/tools/scalap/Main.scala
@@ -218,6 +218,6 @@ object Main extends Main {
       AggregateClassPath(new ClassPathFactory(settings, closeableRegistry).classesInExpandedPath(cp))
     case _ =>
       settings.classpath.value = "." // include '.' in the default classpath scala/bug#6669
-      new PathResolver(settings, closeableRegistry).result
+      settings.pathResolver(closeableRegistry).result
   }
 }

--- a/src/scalap/scala/tools/scalap/Main.scala
+++ b/src/scalap/scala/tools/scalap/Main.scala
@@ -215,7 +215,7 @@ object Main extends Main {
 
   private def createClassPath(cpArg: Option[String], settings: Settings, closeableRegistry: CloseableRegistry) = cpArg match {
     case Some(cp) =>
-      AggregateClassPath(new ClassPathFactory(settings, closeableRegistry).classesInExpandedPath(cp, PathResolverNoCaching ))
+      AggregateClassPath(new ClassPathFactory(settings, closeableRegistry).classesInExpandedPath(cp, PathResolverNoCaching, Set.empty))
     case _ =>
       settings.classpath.value = "." // include '.' in the default classpath scala/bug#6669
       settings.pathResolver(closeableRegistry).result

--- a/src/scalap/scala/tools/scalap/Main.scala
+++ b/src/scalap/scala/tools/scalap/Main.scala
@@ -19,7 +19,7 @@ import scala.reflect.NameTransformer
 import scala.tools.nsc.{CloseableRegistry, Settings}
 import scala.tools.nsc.classpath.{AggregateClassPath, ClassPathFactory}
 import scala.tools.nsc.util.ClassPath
-import scala.tools.util.PathResolver
+import scala.tools.util.{PathResolver, PathResolverNoCaching}
 import scalax.rules.scalasig._
 
 /**The main object used to execute scalap on the command-line.
@@ -215,7 +215,7 @@ object Main extends Main {
 
   private def createClassPath(cpArg: Option[String], settings: Settings, closeableRegistry: CloseableRegistry) = cpArg match {
     case Some(cp) =>
-      AggregateClassPath(new ClassPathFactory(settings, closeableRegistry).classesInExpandedPath(cp))
+      AggregateClassPath(new ClassPathFactory(settings, closeableRegistry).classesInExpandedPath(cp, PathResolverNoCaching ))
     case _ =>
       settings.classpath.value = "." // include '.' in the default classpath scala/bug#6669
       settings.pathResolver(closeableRegistry).result

--- a/test/benchmarks/src/main/scala/scala/tools/nsc/AggregateClassPathBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/tools/nsc/AggregateClassPathBenchmark.scala
@@ -9,25 +9,33 @@ import org.openjdk.jmh.infra.Blackhole
 
 import scala.tools.nsc
 import scala.tools.nsc.util.ClassPath
-import scala.tools.util.PathResolver
+import scala.tools.util.{PathResolver, ReuseAllPathResolver}
 
 @BenchmarkMode(Array(jmh.annotations.Mode.AverageTime))
 @Fork(0)
 @Threads(1)
-@Warmup(iterations = 0)
-@Measurement(iterations = 1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
 class AggregateClassPathBenchmark {
   @Param(Array("@s:/scala/classpath.txt"))
   var classpathString: String = _
+  @Param(Array("false", "true"))
+  var reuse: Boolean = _
   var classpath: ClassPath = _
   val closeableRegistry = new CloseableRegistry
+  val settings = new nsc.Settings()
+
   @Setup def setup(): Unit = {
-    val settings = new nsc.Settings()
     if (classpathString.startsWith("@"))
       classpathString = new String(Files.readAllBytes(Paths.get(classpathString.drop(1))))
     settings.classpath.value = classpathString
+    if (reuse)
+      settings.pathResolverFactory = ReuseAllPathResolver.create _
+    else
+      settings.pathResolverFactory = PathResolver.apply
+
     val resolver = settings.pathResolver(closeableRegistry)
     classpath = resolver.result
     classpath.list("")
@@ -37,51 +45,15 @@ class AggregateClassPathBenchmark {
     closeableRegistry.close()
   }
 
-  @Benchmark def test(bh: Blackhole) = {
-    classpath.list("")._1.foreach(entry => bh.consume(classpath.list(entry.name)))
-  }
-}
-@BenchmarkMode(Array(jmh.annotations.Mode.AverageTime))
-@Fork(2)
-@Threads(1)
-@Warmup(iterations = 10)
-@Measurement(iterations = 10000)
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
-class AggregateClassPathBenchmark2 {
-  @Param(Array("@s:/scala/classpath.txt"))
-  var classpathString: String = _
-  var classpath: ClassPath = _
-  val closeableRegistry = new CloseableRegistry
-  val settings = new nsc.Settings()
-
-  @Setup def setup(): Unit = {
-    if (classpathString.startsWith("@"))
-      classpathString = new String(Files.readAllBytes(Paths.get(classpathString.drop(1))))
-    settings.classpath.value = classpathString
-  }
-
-  @Benchmark def test(bh: Blackhole) = {
-    val resolver = new PathResolver(settings, closeableRegistry)
+  @Benchmark def testCreate(bh: Blackhole) = {
+    val resolver = settings.pathResolver(closeableRegistry)
     classpath = resolver.result
     bh.consume (classpath.list(""))
     closeableRegistry.close()
   }
-}
-object Mike extends App {
-  var classpathString: String = "@s:/scala/classpath.txt"
-  var classpath: ClassPath = _
-  val closeableRegistry = new CloseableRegistry
-  val settings = new nsc.Settings()
 
-  if (classpathString.startsWith("@"))
-    classpathString = new String(Files.readAllBytes(Paths.get(classpathString.drop(1))))
-  settings.classpath.value = classpathString
-
-  while (true) {
-    val resolver = new PathResolver(settings, closeableRegistry)
-    classpath = resolver.result
-    println(classpath.list(""))
-    closeableRegistry.close()
+  @Benchmark def testUse(bh: Blackhole) = {
+    classpath.list("")._1.foreach(entry => bh.consume(classpath.list(entry.name)))
   }
 }
+

--- a/test/benchmarks/src/main/scala/scala/tools/nsc/AggregateClassPathBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/tools/nsc/AggregateClassPathBenchmark.scala
@@ -12,14 +12,14 @@ import scala.tools.nsc.util.ClassPath
 import scala.tools.util.PathResolver
 
 @BenchmarkMode(Array(jmh.annotations.Mode.AverageTime))
-@Fork(2)
+@Fork(0)
 @Threads(1)
-@Warmup(iterations = 10)
-@Measurement(iterations = 10)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
 class AggregateClassPathBenchmark {
-  @Param(Array(""))
+  @Param(Array("@s:/scala/classpath.txt"))
   var classpathString: String = _
   var classpath: ClassPath = _
   val closeableRegistry = new CloseableRegistry
@@ -45,11 +45,11 @@ class AggregateClassPathBenchmark {
 @Fork(2)
 @Threads(1)
 @Warmup(iterations = 10)
-@Measurement(iterations = 10)
+@Measurement(iterations = 10000)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
-class OpenClassPathBenchmark {
-  @Param(Array(""))
+class AggregateClassPathBenchmark2 {
+  @Param(Array("@s:/scala/classpath.txt"))
   var classpathString: String = _
   var classpath: ClassPath = _
   val closeableRegistry = new CloseableRegistry
@@ -65,6 +65,23 @@ class OpenClassPathBenchmark {
     val resolver = new PathResolver(settings, closeableRegistry)
     classpath = resolver.result
     bh.consume (classpath.list(""))
+    closeableRegistry.close()
+  }
+}
+object Mike extends App {
+  var classpathString: String = "@s:/scala/classpath.txt"
+  var classpath: ClassPath = _
+  val closeableRegistry = new CloseableRegistry
+  val settings = new nsc.Settings()
+
+  if (classpathString.startsWith("@"))
+    classpathString = new String(Files.readAllBytes(Paths.get(classpathString.drop(1))))
+  settings.classpath.value = classpathString
+
+  while (true) {
+    val resolver = new PathResolver(settings, closeableRegistry)
+    classpath = resolver.result
+    println(classpath.list(""))
     closeableRegistry.close()
   }
 }

--- a/test/benchmarks/src/main/scala/scala/tools/nsc/AggregateClassPathBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/tools/nsc/AggregateClassPathBenchmark.scala
@@ -28,7 +28,7 @@ class AggregateClassPathBenchmark {
     if (classpathString.startsWith("@"))
       classpathString = new String(Files.readAllBytes(Paths.get(classpathString.drop(1))))
     settings.classpath.value = classpathString
-    val resolver = new PathResolver(settings, closeableRegistry)
+    val resolver = settings.pathResolver(closeableRegistry)
     classpath = resolver.result
     classpath.list("")
   }

--- a/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
@@ -23,7 +23,7 @@ class JrtClassPathTest {
     val cp: ClassPath =
       if (specVersion == "" || specVersion == "1.8") {
         val settings = new Settings()
-        val resolver = new PathResolver(settings, closeableRegistry)
+        val resolver = settings.pathResolver(closeableRegistry)
         val elements = new ClassPathFactory(settings, closeableRegistry).classesInPath(resolver.Calculated.javaBootClassPath)
         AggregateClassPath(elements)
       }

--- a/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
@@ -26,7 +26,7 @@ class JrtClassPathTest {
         val resolver = settings.pathResolver(closeableRegistry)
         val elements = new ClassPathFactory(settings, closeableRegistry).classesInPath(
           new resolver.DefaultCalculated().javaBootClassPath,
-          PathResolverNoCaching)
+          PathResolverNoCaching, Set.empty)
         AggregateClassPath(elements)
       }
       else JrtClassPath(None, closeableRegistry).get

--- a/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
@@ -11,7 +11,7 @@ import org.junit.runners.JUnit4
 import scala.tools.nsc.{CloseableRegistry, Settings}
 import scala.tools.nsc.backend.jvm.AsmUtils
 import scala.tools.nsc.util.ClassPath
-import scala.tools.util.PathResolver
+import scala.tools.util.{PathResolver, PathResolverNoCaching}
 
 @RunWith(classOf[JUnit4])
 class JrtClassPathTest {
@@ -24,7 +24,9 @@ class JrtClassPathTest {
       if (specVersion == "" || specVersion == "1.8") {
         val settings = new Settings()
         val resolver = settings.pathResolver(closeableRegistry)
-        val elements = new ClassPathFactory(settings, closeableRegistry).classesInPath(resolver.Calculated.javaBootClassPath)
+        val elements = new ClassPathFactory(settings, closeableRegistry).classesInPath(
+          new resolver.DefaultCalculated().javaBootClassPath,
+          PathResolverNoCaching)
         AggregateClassPath(elements)
       }
       else JrtClassPath(None, closeableRegistry).get

--- a/test/junit/scala/tools/nsc/classpath/PathResolverBaseTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/PathResolverBaseTest.scala
@@ -111,17 +111,5 @@ abstract class PathResolverBaseTest {
     }
   }
 
-  @Test
-  def testFindClass: Unit = {
-    val classPath = createFlatClassPath(settings)
-    classesToFind foreach { className =>
-      assertTrue(s"File for $className should be found", classPath.findClass(className).isDefined)
-    }
-  }
 
-  @Test
-  def testFind1Class: Unit = {
-    val classPath = new CachedClassPath(new DirectoryClassPath(new File("S:\\scala\\quick2\\build\\quick\\classes\\compiler")))
-    assertTrue("", classPath.findClass("scala.tools.util.PathResolver").isDefined)
-  }
 }

--- a/test/junit/scala/tools/nsc/classpath/PathResolverBaseTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/PathResolverBaseTest.scala
@@ -118,4 +118,10 @@ abstract class PathResolverBaseTest {
       assertTrue(s"File for $className should be found", classPath.findClass(className).isDefined)
     }
   }
+
+  @Test
+  def testFind1Class: Unit = {
+    val classPath = new CachedClassPath(new DirectoryClassPath(new File("S:\\scala\\quick2\\build\\quick\\classes\\compiler")))
+    assertTrue("", classPath.findClass("scala.tools.util.PathResolver").isDefined)
+  }
 }

--- a/test/junit/scala/tools/nsc/classpath/PathResolverBaseTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/PathResolverBaseTest.scala
@@ -59,7 +59,7 @@ class PathResolverBaseTest {
   def deleteTempDir: Unit = tempDir.delete()
 
   private def createFlatClassPath(settings: Settings) =
-    new PathResolver(settings, new CloseableRegistry).result
+    settings.pathResolver().result
 
   @Test
   def testEntriesFromListOperationAgainstSeparateMethods: Unit = {

--- a/test/junit/scala/tools/nsc/classpath/ZipAndJarFileLookupFactoryTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/ZipAndJarFileLookupFactoryTest.scala
@@ -4,7 +4,9 @@ package classpath
 import org.junit.Test
 import java.nio.file._
 import java.nio.file.attribute.FileTime
+
 import scala.reflect.io.AbstractFile
+import scala.tools.util.PathResolverNoCaching
 
 class ZipAndJarFileLookupFactoryTest {
   @Test def cacheInvalidation(): Unit = {
@@ -15,7 +17,7 @@ class ZipAndJarFileLookupFactoryTest {
     val g = new scala.tools.nsc.Global(new scala.tools.nsc.Settings())
     assert(!g.settings.YdisableFlatCpCaching.value) // we're testing with our JAR metadata caching enabled.
     val closeableRegistry = new CloseableRegistry
-    def createCp = ZipAndJarClassPathFactory.create(AbstractFile.getFile(f.toFile), g.settings, closeableRegistry)
+    def createCp = ZipAndJarClassPathFactory.create(AbstractFile.getFile(f.toFile), g.settings, closeableRegistry, PathResolverNoCaching)
     try {
       createZip(f, Array(), "p1/C.class")
       createZip(f, Array(), "p2/X.class")

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
@@ -36,7 +36,7 @@ class SymbolTableForUnitTesting extends SymbolTable {
 
     def platformPhases: List[SubComponent] = Nil
 
-    private[nsc] lazy val classPath: ClassPath = new PathResolver(settings, new CloseableRegistry).result
+    private[nsc] lazy val classPath: ClassPath = settings.pathResolver().result
 
     def isMaybeBoxed(sym: Symbol): Boolean = ???
     def needCompile(bin: AbstractFile, src: AbstractFile): Boolean = ???

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
@@ -36,7 +36,7 @@ class SymbolTableForUnitTesting extends SymbolTable {
 
     def platformPhases: List[SubComponent] = Nil
 
-    private[nsc] lazy val classPath: ClassPath = settings.pathResolver().result
+    private[nsc] lazy val classPath: ClassPath = settings.pathResolver(new CloseableRegistry).result
 
     def isMaybeBoxed(sym: Symbol): Boolean = ???
     def needCompile(bin: AbstractFile, src: AbstractFile): Boolean = ???


### PR DESCRIPTION
Allow customisation of a classpath caching lookup

Remove AbstractFile from classpath code
AbstractFile makes the whole lookup process very slow, as all the calls to isDirector, isFile ... take time, esp on Windows

will provide benchmark results when RFR