### PR TITLE
Skip implicit class members in implicit search at super call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@
 /build-sbt/
 local.sbt
 jitwatch.out
+
+# metals
+.metals
+.bloop

--- a/test/files/neg/t9717.check
+++ b/test/files/neg/t9717.check
@@ -1,0 +1,16 @@
+t9717.scala:2: error: ambiguous implicit values:
+ both value F of type Int
+ and value v of type Int
+ match expected type Int
+class B(implicit F: Int) extends A({ implicit val v: Int = 1; implicitly[Int] }) // ambiguous
+                                                                        ^
+t9717.scala:6: error: could not find implicit value for parameter e: Int
+  def this() = this(implicitly[Int]) // neg
+                              ^
+t9717.scala:7: error: not found: value f
+  def this(s: String) = this(f) // neg (`this` is not in scope!)
+                             ^
+t9717.scala:12: error: could not find implicit value for parameter e: Int
+  def this() = { this(implicitly[Int]) } // not in scope (spec 5.3.1, scope which is in effect at the point of the enclosing class definition)
+                                ^
+four errors found

--- a/test/files/neg/t9717.scala
+++ b/test/files/neg/t9717.scala
@@ -1,0 +1,16 @@
+class A(val a: Int)(implicit val F: Int)
+class B(implicit F: Int) extends A({ implicit val v: Int = 1; implicitly[Int] }) // ambiguous
+
+class C(x: Int) {
+  implicit def f: Int = 1
+  def this() = this(implicitly[Int]) // neg
+  def this(s: String) = this(f) // neg (`this` is not in scope!)
+}
+
+class D(x: Int) {
+  import D.f
+  def this() = { this(implicitly[Int]) } // not in scope (spec 5.3.1, scope which is in effect at the point of the enclosing class definition)
+}
+object D {
+  implicit def f: Int = 1
+}

--- a/test/files/pos/aladdin883.scala
+++ b/test/files/pos/aladdin883.scala
@@ -1,0 +1,11 @@
+import scala.language.implicitConversions
+
+trait Foo[A] {
+  implicit def convert(a : A) : Ordered[A];
+  class Filter(f : A => Boolean) extends Foo[A] {
+    implicit def convert(a : A) = Foo.this.convert(a);
+  }
+  class Range(x : A, y : A) extends Filter(a => {
+    (a).compare(x) >= 0 && (a).compare(y) < 0;
+  }) {}
+}

--- a/test/files/pos/t9717.scala
+++ b/test/files/pos/t9717.scala
@@ -1,0 +1,29 @@
+// scalac: -Yno-predef
+
+import scala.Predef.implicitly
+
+class A(val a: Int)
+class B(implicit F: Int) extends A( implicitly[Int] )
+class C(implicit F: Int) extends A( {
+  val v = implicitly[Int]
+  v
+})
+
+
+class A1(val a: Int)(implicit val F: Int)
+class B1(implicit F: Int) extends A1(implicitly[Int])
+class C1(implicit F: Int) extends A1({
+  val v = implicitly[Int]
+  v
+})
+class D1 extends A1({
+  implicit val v: Int = 1; implicitly[Int]
+})(0)
+
+class D(x: Int) {
+  import D.f
+  def this() = { this(D.f); implicitly[Int] } // D.f in scope after self constr call
+}
+object D {
+  implicit def f: Int = 1
+}

--- a/test/files/pos/t9717_2.scala
+++ b/test/files/pos/t9717_2.scala
@@ -1,0 +1,8 @@
+class Ann(implicit val i: Int)
+
+abstract class Bob(implicit i: Int) extends Ann {
+  def foo: Int
+  def dee(): Bob = new Bob {
+    def foo = 23
+  }
+}


### PR DESCRIPTION
When an implicit search is triggered in a super constructor argument,
there needs to be an exception due to special scoping. Concretely, in

    object T {
      implicit val x: Int = 0
      class A(x: Int)
      class B extends A(implicitly)
    }

we get the super call

    def <init>(): T.B = B.super.<init>(implicitly)

The context nesting at the super call is something like
  - [owner=constructor B, tree=Block{B.super...}]
  - [owner=constructor B, tree=Block{B.super...}] // same owner, tree
  - [owner=constructor B, tree=Block{B.super...}] // again
  - [owner=class B, tree=ClassDef{class C ...}]
  - [owner=object T, tree=Template{extends AnyRef ...}]

When searching for the implicit, we need to skip over the context with
owner `class B`. Members (implicits) of `B` are not in scope at the
super call, by spec

  > The signature and the self constructor invocation of a constructor
  > definition are type-checked and evaluated in the scope which is in
  > effect at the point of the enclosing class definition

The `context.implicitss` implementation searches implicits in the
current context and recursively in all outer contexts. So we need to
skip the correct context in the recursive calls.

This was originally done in 198906f (only 12.5 years ago...), refined
in 86a6ad4, refined again in 78007ac. The current version is still
buggy when the super argument is a block (scala/bug#9717).

The `inSelfSuperCall` context flag added in 86a6ad4 is interesting
because it's set for the context of the super call. It's used here:

    if (.. owner.isClass .. && !inSelfSuperCall)

But `implicitss` calls `outer.implicitss` recursively, and at the point
where we're `owner.isClass`, `inSelfSuperCall` is no longer defined
even if we started at the super call context. So (I think) this flag
was never doing anything.

The new implementation of this PR now checks the `inSelfSuperCall` flag.
When it's set, the enclosing class (`B` in the exmaple) is passed down
to the recursive `outer.implicitss` calls, so the class context can be
skipped. No more guessing of the context nesting structure is necessary.

Co-authored-by: Jasper Moeys <jaspermoeys@hotmail.com>
Co-authored-by: Diego Esteban Alonso Blas <diesalbla@gmail.com>

Fixes scala/bug#9717