### PR TITLE
Replace println with reporter.echo in doc

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/DocFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/DocFactory.scala
@@ -87,12 +87,12 @@ class DocFactory(val reporter: Reporter, val settings: doc.Settings) { processor
 
     modelFactory.makeModel match {
       case Some(madeModel) =>
-        if (!settings.scaladocQuietRun)
-          println("model contains " + modelFactory.templatesCount + " documentable templates")
+        if (settings.verbose)
+          reporter.echo("model contains " + modelFactory.templatesCount + " documentable templates")
         Some(madeModel)
       case None =>
-        if (!settings.scaladocQuietRun)
-          println("no documentable class found in compilation units")
+        if (settings.verbose)
+          reporter.echo("no documentable class found in compilation units")
         None
     }
   }
@@ -102,7 +102,7 @@ class DocFactory(val reporter: Reporter, val settings: doc.Settings) { processor
   val documentError: PartialFunction[Throwable, Unit] = {
     case NoCompilerRunException =>
       if (settings.verbose)
-        reporter.echo(null, "No documentation generated with unsuccessful compiler run")
+        reporter.echo("No documentation generated with unsuccessful compiler run")
     case e @ (_:ClassNotFoundException | _:IllegalAccessException | _:InstantiationException | _:SecurityException | _:ClassCastException) =>
       reporter.error(null, s"Cannot load the doclet class ${settings.docgenerator.value} (specified with ${settings.docgenerator.name}): $e. Leaving the default settings will generate the html version of scaladoc.")
   }


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/4607

Currently `doc` tasks outputs "model contains x documentable templates" directly to the console without going through the reporter. The information is not useful and it's odd since all other outputs come from the reporter.