### PR TITLE
Throw FileNotFoundException in Source.fromResource

### DIFF
--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -176,7 +176,10 @@ object Source {
    *  @return              the buffered source
    */
   def fromResource(resource: String, classLoader: ClassLoader = Thread.currentThread().getContextClassLoader())(implicit codec: Codec): BufferedSource =
-    fromInputStream(classLoader.getResourceAsStream(resource))
+    Option(classLoader.getResourceAsStream(resource)) match {
+      case Some(in) => fromInputStream(in)
+      case None     => throw new IllegalArgumentException(s"resource '$resource' was not found")
+    }
 
 }
 

--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -14,8 +14,8 @@ package scala
 package io
 
 import scala.collection.{AbstractIterator, BufferedIterator}
-import java.io.{ FileInputStream, InputStream, PrintStream, File => JFile, Closeable }
-import java.net.{ URI, URL }
+import java.io.{Closeable, FileInputStream, FileNotFoundException, InputStream, PrintStream, File => JFile}
+import java.net.{URI, URL}
 
 /** This object provides convenience methods to create an iterable
  *  representation of a source file.
@@ -178,7 +178,7 @@ object Source {
   def fromResource(resource: String, classLoader: ClassLoader = Thread.currentThread().getContextClassLoader())(implicit codec: Codec): BufferedSource =
     Option(classLoader.getResourceAsStream(resource)) match {
       case Some(in) => fromInputStream(in)
-      case None     => throw new IllegalArgumentException(s"resource '$resource' was not found")
+      case None     => throw new FileNotFoundException(s"resource '$resource' was not found")
     }
 
 }


### PR DESCRIPTION
Fixes scala/bug#11743

Commits [this comment quip](https://github.com/scala/bug/issues/11743#issuecomment-534774763). The quip makes sense to me. Just two questions.
1. Would `IllegalArgumentException` be okay over `FileNotFoundException`?
2. Is there a common workflow for running tests for this? I haven't really touched that.