### PR TITLE
Handle compilation cancellation in SBT's entry point

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1605,7 +1605,10 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
         profiler.afterPhase(Global.InitPhase, snap)
         compileSources(sources)
       }
-      catch { case ex: IOException => globalError(ex.getMessage()) }
+      catch {
+        case ex: InterruptedException => reporter.cancelled = true
+        case ex: IOException => globalError(ex.getMessage())
+      }
     }
 
     /** If this compilation is scripted, convert the source to a script source. */


### PR DESCRIPTION
Before this change, hitting CTRL-C in an SBT compile task that was
still reading source files would result in:

```
sbt:root> library/compile
^C
[warn] Canceling execution...
[info] Compiling 530 Scala sources and 33 Java sources to /Users/jz/code/scala/build/quick/classes/library ...
[error] ## Exception when compiling 563 sources to /Users/jz/code/scala/build/quick/classes/library
[error] null
[error] scala.tools.nsc.io.SourceReader.read(SourceReader.scala:50)
[error] scala.tools.nsc.io.SourceReader.read(SourceReader.scala:60)
[error] scala.tools.nsc.Global.getSourceFile(Global.scala:365)
[error] scala.tools.nsc.Global.getSourceFile(Global.scala:371)
[error] scala.tools.nsc.Global$Run.$anonfun$compile$1(Global.scala:1611)
[error] scala.tools.nsc.Global$Run.compile(Global.scala:1611)
[error] xsbt.CachedCompiler0.run(CompilerInterface.scala:130)
[error] xsbt.CachedCompiler0.run(CompilerInterface.scala:105)
[error] xsbt.CompilerInterface.run(CompilerInterface.scala:31)
[error] sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error] sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
```

Rather than a clean `[info] Compilation has been cancelled` message.