### PR TITLE
Queue.iterator reverses in lazily

### DIFF
--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -67,7 +67,7 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
 
   /** Returns the elements in the list as an iterator
     */
-  override def iterator: Iterator[A] = (out ::: in.reverse).iterator
+  override def iterator: Iterator[A] = out.iterator.concat(in.reverse)
 
   /** Checks if the queue is empty.
     *

--- a/test/junit/scala/collection/immutable/QueueTest.scala
+++ b/test/junit/scala/collection/immutable/QueueTest.scala
@@ -1,40 +1,50 @@
 package scala.collection.immutable
 
+import org.junit.Assert.assertEquals
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import org.junit.Test
-
-
-import org.junit.Assert.assertEquals
 
 @RunWith(classOf[JUnit4])
 /* Tests for collection.immutable.Queue  */
 class QueueTest {
-  val emptyQueue = Queue.empty[Int]
-  val oneAdded = emptyQueue.enqueue(1)
-  val threeAdded = emptyQueue.enqueue(1 to 3)
 
-
+  private val emptyQueue = Queue.empty[Int]
 
   @Test
   def dequeueOptionOnEmpty(): Unit = {
-    assertEquals(emptyQueue.dequeueOption, None)
+    assertEquals(None, emptyQueue.dequeueOption)
   }
 
   @Test
   def dequeueOptionOneAdded(): Unit = {
-    assertEquals(oneAdded.dequeueOption, Some((1,emptyQueue)))
+    val oneAdded = emptyQueue.enqueue(1)
+    assertEquals(Some((1,emptyQueue)), oneAdded.dequeueOption)
   }
 
   @Test
   def dequeueOptionThreeAdded(): Unit = {
-    assertEquals(threeAdded.dequeueOption, Some((1,Queue(2 to 3:_*))))
+    val threeAdded = emptyQueue.enqueueAll(1 to 3)
+    assertEquals(
+      Some((1,Queue(2 to 3:_*))),
+      threeAdded.dequeueOption,
+    )
   }
 
   @Test
   def copyToArrayOutOfBounds: Unit = {
     val target = Array[Int]()
     assertEquals(0, Queue(1,2).copyToArray(target, 1, 0))
+  }
+
+  @Test def `iterator works as lazy concat`(): Unit = {
+    val three = Queue(1, 2, 3)
+    val six   = three.enqueueAll(4 to 6)
+    val it    = six.iterator
+    val more  = six.enqueue(7)
+    assertEquals(1, it.next())   // no list.reverse here
+    assertEquals(5, it.size)
+    assertEquals(7, more.iterator.size)
   }
 
 }


### PR DESCRIPTION
Make the iterator a concatenation of the `out` iterator and the lazily computed `in.reverse`.

For operations which only inspect a prefix of the queue, the expensive reversal might be avoided.

Inspired by scala/bug#11396