### PR TITLE
Add `hr` label for hours in Duration.timeUnitLabels

### DIFF
--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -38,7 +38,7 @@ object Duration {
    * Construct a finite duration from the given length and time unit, where the latter is
    * looked up in a list of string representation. Valid choices are:
    *
-   * `d, day, h, hour, m, min, minute, s, sec, second, ms, milli, millisecond, µs, micro, microsecond, ns, nano, nanosecond`
+   * `d, day, h, hr, hour, m, min, minute, s, sec, second, ms, milli, millisecond, µs, micro, microsecond, ns, nano, nanosecond`
    * and their pluralized forms (for every but the first mentioned form of each unit, i.e. no "ds", but "days").
    */
   def apply(length: Long, unit: String): FiniteDuration   = new FiniteDuration(length,  Duration.timeUnit(unit))
@@ -79,7 +79,7 @@ object Duration {
   }
   private[this] val timeUnitLabels = List(
     DAYS         -> "d day",
-    HOURS        -> "h hour",
+    HOURS        -> "h hr hour",
     MINUTES      -> "m min minute",
     SECONDS      -> "s sec second",
     MILLISECONDS -> "ms milli millisecond",

--- a/test/files/jvm/duration-tck.scala
+++ b/test/files/jvm/duration-tck.scala
@@ -177,7 +177,7 @@ object Test extends App {
   // test unit labels
   for ((unit, labels) <- Seq(
     DAYS         -> "d day days",
-    HOURS        -> "h hour hours",
+    HOURS        -> "h hr hrs hour hours",
     MINUTES      -> "m min mins minute minutes",
     SECONDS      -> "s sec secs second seconds",
     MILLISECONDS -> "ms milli millis millisecond milliseconds",


### PR DESCRIPTION
Applying this PR will add the common `hr` abbreviation for hour. Similar to https://github.com/scala/scala/pull/8325.