### PR TITLE
Improve performance of BitSet.iterator

### DIFF
--- a/test/benchmarks/src/main/scala/scala/collection/mutable/BitSetIteratorBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/BitSetIteratorBenchmark.scala
@@ -1,0 +1,33 @@
+package scala.collection.mutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import scala.collection.mutable
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 6)
+@Measurement(iterations = 6)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class BitSetIteratorBenchmark {
+
+  @Param(Array("0", "1", "3", "15", "63", "255"))
+  var spacing: Int = _
+
+  var bs: mutable.BitSet = _
+
+  @Setup(Level.Iteration) def initializeRange(): Unit = {
+    bs = mutable.BitSet(0 until 1000 by (spacing + 1): _*)
+  }
+
+  @Benchmark def iterateAll(): Unit = {
+    var sum = 0
+    val it = bs.iterator
+    while (it.hasNext) sum += it.next
+  }
+
+}

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -153,6 +153,20 @@ class BitSetTest {
   @Test def buildFromRange(): Unit = {
     import scala.util.chaining._
     assert((1 to 1000).to(BitSet) == BitSet().tap(bs => (1 to 1000).foreach(bs.addOne)))
-
   }
+
+  @Test def iteratorFrom(): Unit = {
+    val a = (0 to 127).to(BitSet)
+    assertEquals(0 to 127, a.iteratorFrom(0).toSeq)
+    assertEquals(1 to 127, a.iteratorFrom(1).toSeq)
+    assertEquals(63 to 127, a.iteratorFrom(63).toSeq)
+    assertEquals(64 to 127, a.iteratorFrom(64).toSeq)
+    assertEquals(0 to 127, a.iteratorFrom(-1).toSeq)
+    assertEquals(0 to 127, a.iteratorFrom(-100).toSeq)
+    assertEquals(Seq(0), BitSet(0).iteratorFrom(0).toSeq)
+    assertTrue(a.iteratorFrom(128).isEmpty)
+    assertTrue(BitSet.empty.iteratorFrom(0).isEmpty)
+    assertThrows[NoSuchElementException](BitSet.empty.iteratorFrom(0).next)
+  }
+
 }

--- a/test/scalacheck/scala/collection/immutable/BitSetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/BitSetProperties.scala
@@ -53,4 +53,11 @@ object BitSetProperties extends Properties("immutable.BitSet") {
     val (left, right) = bs.partition(p)
     (left ?= bs.filter(p)) && (right ?= bs.filterNot(p))
   }
+
+  property("iteratorFrom") = forAll(
+    listOfN(200, oneOf(0 to 10000)).map(_.to(Set)),
+    Gen.chooseNum[Int](0, 10000)) { (xs: Set[Int], start: Int) =>
+    val bs = xs.to(BitSet)
+    bs.iteratorFrom(start).to(Set) ?= xs.filter(_ >= start)
+  }
 }


### PR DESCRIPTION
Improves performance of `BitSet.iterator` by utilising `Long.numberOfTrailingZeros` (instead of iterating through all integers in range and checking their presence in the `BitSet`). Partially solves https://github.com/scala/bug/issues/11418.

Benchmarks (`spacing` is the number of `0`s between `1`s, so `spacing = 0` is `11111...`, `spacing = 1` is `101010...`, etc.).
```
Original:
[info] Benchmark                           (spacing)  Mode  Cnt     Score     Error  Units
[info] BitSetIteratorBenchmark.iterateAll          0  avgt    6  7283.606 ±  74.967  ns/op
[info] BitSetIteratorBenchmark.iterateAll          1  avgt    6  5933.497 ±  28.653  ns/op
[info] BitSetIteratorBenchmark.iterateAll          3  avgt    6  3371.763 ±  21.047  ns/op
[info] BitSetIteratorBenchmark.iterateAll         15  avgt    6  2191.009 ±  10.818  ns/op
[info] BitSetIteratorBenchmark.iterateAll         63  avgt    6  1664.190 ±  11.116  ns/op
[info] BitSetIteratorBenchmark.iterateAll        255  avgt    6  1614.554 ±  96.813  ns/op

Modified:
[info] Benchmark                           (spacing)  Mode  Cnt     Score    Error  Units
[info] BitSetIteratorBenchmark.iterateAll          0  avgt    6  3526.702 ± 36.208  ns/op
[info] BitSetIteratorBenchmark.iterateAll          1  avgt    6  2953.840 ± 29.800  ns/op
[info] BitSetIteratorBenchmark.iterateAll          3  avgt    6  1442.062 ± 11.518  ns/op
[info] BitSetIteratorBenchmark.iterateAll         15  avgt    6   395.849 ±  2.110  ns/op
[info] BitSetIteratorBenchmark.iterateAll         63  avgt    6   127.068 ±  0.477  ns/op
[info] BitSetIteratorBenchmark.iterateAll        255  avgt    6    53.174 ±  2.066  ns/op
```

Benchmark setup:
```
[info] # JMH version: 1.20
[info] # VM version: JDK 11.0.4, VM 11.0.4+11
[info] # VM invoker: /Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/bin/java
[info] # VM options: <none>
```

Benchmark code:
```
package scala.collection.mutable

import java.util.concurrent.TimeUnit

import org.openjdk.jmh.annotations._
import org.openjdk.jmh.infra._

import scala.collection.mutable

@BenchmarkMode(Array(Mode.AverageTime))
@Fork(1)
@Threads(1)
@Warmup(iterations = 6)
@Measurement(iterations = 6)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@State(Scope.Benchmark)
class BitSetIteratorBenchmark {

  @Param(Array("0", "1", "3", "15", "63", "255"))
  var spacing: Int = _

  var bs: mutable.BitSet = _

  @Setup(Level.Iteration) def initializeRange(): Unit = {
    bs = mutable.BitSet(0 until 1000 by (spacing + 1): _*)
  }

  @Benchmark def iterateAll(): Unit = {
    var sum = 0
    val it = bs.iterator
    while (it.hasNext) sum += it.next
  }

}
```