### PR TITLE
Mechanism to exclude l:none from -opt:_

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -291,7 +291,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
     val allowSkipClassLoading   = Choice("allow-skip-class-loading",    "Allow optimizations that can skip or delay class loading.")
     val inline                  = Choice("inline",                      "Inline method invocations according to -Yopt-inline-heuristics and -opt-inline-from.")
 
-    // note: unlike the other optimizer levels, "l:none" appears up in the `opt.value` set because it's not an expanding option (expandsTo is empty)
+    // l:none is not an expanding option, unlike the other l: levels. But it is excluded from -opt:_ below.
     val lNone = Choice("l:none",
       "Disable optimizations. Takes precedence: `-opt:l:none,+box-unbox` / `-opt:l:none -opt:box-unbox` don't enable box-unbox.")
 
@@ -311,6 +311,9 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
     val lInline = Choice("l:inline",
       "Enable cross-method optimizations (note: inlining requires -opt-inline-from): " + inlineChoices.mkString("", ",", "."),
       expandsTo = inlineChoices)
+
+    // "l:none" is excluded from wildcard expansion so that -opt:_ does not disable all settings
+    override def wildcardChoices = super.wildcardChoices.filter(_ ne lNone)
   }
 
   // We don't use the `default` parameter of `MultiChoiceSetting`: it specifies the default values
@@ -320,7 +323,8 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
     name = "-opt",
     helpArg = "optimization",
     descr = "Enable optimizations",
-    domain = optChoices)
+    domain = optChoices,
+  )
 
   private def optEnabled(choice: optChoices.Choice) = {
     !opt.contains(optChoices.lNone) && {

--- a/test/files/neg/t11746.check
+++ b/test/files/neg/t11746.check
@@ -1,0 +1,7 @@
+t11746.scala:18: warning: failed to determine if e should be inlined:
+The method e()Ljava/lang/Throwable; could not be found in the class java/lang/Object or any of its parents.
+    case Failure(e) => println(e.toString)
+                 ^
+error: No warnings can be incurred under -Werror.
+one warning found
+one error found

--- a/test/files/neg/t11746.scala
+++ b/test/files/neg/t11746.scala
@@ -1,0 +1,20 @@
+//
+// scalac: -Werror -opt:l:inline -opt-inline-from:'**' -opt-warnings:none,_
+//
+// compare -opt-warnings:none,at-inline-failed-summary
+
+trait Try
+
+object Try {
+  def apply(s: String): Try = Success(s)
+}
+
+case class Success(s: String) extends Try
+case class Failure(e: Throwable) extends Try
+
+class C {
+  private def get(a: String): Unit = Try(a) match {
+    case Failure(e: Exception) => 
+    case Failure(e) => println(e.toString)
+  }
+}

--- a/test/files/run/t11746.scala
+++ b/test/files/run/t11746.scala
@@ -1,0 +1,23 @@
+
+import scala.tools.partest.DirectTest
+import scala.tools.nsc.reporters.{Reporter, StoreReporter}
+import scala.tools.nsc.Settings
+import scala.tools.nsc.util.stringFromStream
+
+object Test extends DirectTest {
+
+  override def extraSettings = "-usejavacp -opt:_ -opt-inline-from:** -Vinline _"
+
+  override def reporter(settings: Settings): Reporter = new StoreReporter(settings)
+
+  override def code = "class C { def f = locally(42) }"
+
+  override def show() = {
+    val res = stringFromStream { os =>
+      Console.withOut(os) {
+        assert(compile())
+      }
+    }
+    assert(res.startsWith("Inlining into C.f"))
+  }
+}

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -224,4 +224,16 @@ class SettingsTest {
       marginallyEquals(expected, m.help)
     })
   }
+  @Test def `wildcard doesn't disable everything`(): Unit = {
+    val settings = new Settings()
+    settings.processArguments("-opt:_" :: Nil, true)
+    assertTrue("has the choice", settings.opt.contains(settings.optChoices.inline))
+    assertTrue("is enabled", settings.optInlinerEnabled)
+  }
+  @Test def `kill switch can be enabled explicitly`(): Unit = {
+    val settings = new Settings()
+    settings.processArguments("-opt:inline,l:none" :: Nil, true)
+    assertTrue("has the choice", settings.opt.contains(settings.optChoices.inline))
+    assertFalse("is not enabled", settings.optInlinerEnabled)
+  }
 }


### PR DESCRIPTION
Let the enum of choices specify what _ means.

Fixes part of scala/bug#11746