### PR TITLE
Fix 2.13.1 regression in overload resolution (specificity of overloaded constructor of generic class)

### DIFF
--- a/test/files/pos/t11755.scala
+++ b/test/files/pos/t11755.scala
@@ -1,0 +1,15 @@
+trait Map[K]
+class HashMap[K] extends Map[K]
+class IdentityBox[+A]
+
+class IdentityHashMap[K](inner: HashMap[IdentityBox[K]]) extends Map[K] {
+  def this(initialMap: Map[_ <: K]) = this(new HashMap[IdentityBox[K]]())
+
+  def bla[K](inner: HashMap[IdentityBox[K]]): IdentityHashMap[K] = ???
+  def bla[K](initialMap: Map[_ <: K]): IdentityHashMap[K] = bla(new HashMap[IdentityBox[K]]())
+
+  new IdentityHashMap(??? : HashMap[IdentityBox[K]])
+  bla(??? :HashMap[IdentityBox[K]])
+}
+
+// isApplicable true : (inner: HashMap[IdentityBox[K]])IdentityHashMap[K] to List(HashMap[IdentityBox[K]]) for ? under List()


### PR DESCRIPTION
There are two phases to picking a winning overload for the
constructor of a polymorphic class, but the type params
are not handled consistently:
  - isApplicable: we put the class's type params in undetparams
  - isAsSpecific: the constructor's info is a method type,
                  the class's type params appear unbound.

The second one is a problem because specificity should be able
to infer different type args for those parameters, as it's doing
a bunch of `isApplicable` calls itself to score the overloads.

To fix this, we push the class's poly type down to the constructor's
info. One caveat: we have to clone the class type params and
use the constructor as their owner, otherwise ASF will rewrite
them based on the prefix.

(`PolyType(tpars, res).ASF(pre, clazz)` means references in
`res` to type params owned by `clazz` will be rewritten to use
prefix `pre`, but the resulting poly type's type params will
not be adjusted.)

Fix scala/bug#11755