### PR TITLE
Check unused imports for undesirable properties

### DIFF
--- a/test/files/neg/t11758.check
+++ b/test/files/neg/t11758.check
@@ -1,0 +1,24 @@
+t11758.scala:3: warning: Unused import of deprecated lazy value higherKinds: higherKinds no longer needs to be imported explicitly
+import language.higherKinds
+                ^
+t11758.scala:19: warning: Unused import from deprecated object outer: no outer
+  import outer.other
+               ^
+t11758.scala:21: warning: Unused import of deprecated object inner: no inner
+  import outer.{inner => odder}
+                ^
+t11758.scala:25: warning: Unused import of deprecated class C: no see
+  import nest.C
+              ^
+t11758.scala:23: warning: object inner in object outer is deprecated (since 2.0): no inner
+  def f = inner
+          ^
+t11758.scala:23: warning: object outer is deprecated (since 1.0): no outer
+  def f = inner
+          ^
+t11758.scala:30: warning: class C in object nest is deprecated (since 3.0): no see
+  def g = new C
+              ^
+error: No warnings can be incurred under -Werror.
+7 warnings
+1 error

--- a/test/files/neg/t11758.scala
+++ b/test/files/neg/t11758.scala
@@ -1,0 +1,35 @@
+// scalac: -Xlint:deprecation -Wunused:imports -Werror
+
+import language.higherKinds
+
+@deprecated("no outer", "1.0")
+object outer {
+  @deprecated("no inner", "2.0")
+  object inner
+  object other
+}
+object nest {
+  @deprecated("no see", "3.0")
+  class C
+
+  val status = true
+}
+
+trait T {
+  import outer.other
+  import outer.inner
+  import outer.{inner => odder}
+
+  def f = inner
+
+  import nest.C
+  def g = ()
+}
+trait U {
+  import nest.C
+  def g = new C
+}
+trait OK {
+  import nest.{C => _, _}
+  def ok = status
+}


### PR DESCRIPTION
~~Ref~~ check imports for undesirable properties
    
This ensures that deprecations trigger in unused imports.
    
The "permanently hidden" check is really just
supplemental advice for "unused import". Probably
it was more useful when precedence four definitions
incorrectly shadowed imports. It would be nice to
provide more robust diagnostics for shadowing.

The last commit adds advice for deprecation to unused import warnings.

Fixes scala/bug#11758