### PR TITLE
Allow references to inner classes in java signatures

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -708,9 +708,9 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
           while (sig.charAt(index) == '.') {
             accept('.')
             val name = newTypeName(subName(c => c == ';' || c == '<' || c == '.'))
-            val clazz = tpe.member(name)
+            val member = if (tpe.typeSymbol == clazz) instanceScope.lookup(name) else tpe.member(name)
             val dummyArgs = Nil // the actual arguments are added in processClassType
-            val inner = typeRef(pre = tpe, sym = clazz, args = dummyArgs)
+            val inner = typeRef(pre = tpe, sym = member, args = dummyArgs)
             tpe = processClassType(inner)
           }
           accept(';')

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -1127,7 +1127,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
       case japplied: ParameterizedType =>
         // http://stackoverflow.com/questions/5767122/parameterizedtype-getrawtype-returns-j-l-r-type-not-class
         val sym = classToScala(japplied.getRawType.asInstanceOf[jClass[_]])
-        val pre = sym.owner.thisType
+        val pre = if (japplied.getOwnerType ne null) typeToScala(japplied.getOwnerType) else sym.owner.thisType
         val args0 = japplied.getActualTypeArguments
         val (args, bounds) = targsToScala(pre.typeSymbol, args0.toList)
         newExistentialType(bounds, typeRef(pre, sym, args))

--- a/test/files/jvm/t11726.check
+++ b/test/files/jvm/t11726.check
@@ -1,0 +1,30 @@
+class CS_1.info: [T, U <: jli.CS_1[T,U]#R]Object {
+  class R extends Object
+  object R
+  def <init>(): jli.CS_1[T,U]
+}
+class SD_1.companion.moduleClass.info:  {
+  class Q extends CS_1[String,jli.SD_1]
+  object Q
+}
+
+class CS_2.info: [T, U <: jli.CS_2[T,U]#R]Object {
+  def <init>(): jli.CS_2[T,U]
+  object R
+  class R extends Object
+}
+class SD_2.companion.moduleClass.info: AnyRef {
+  def <init>(): jli.SD_2.type
+  object Q
+  class Q extends CS_2[String,jli.SD_2]
+}
+
+class CS_1.info: [T, U <: jli.CS_1[T,U]#$R]Object {
+  class $R extends Object
+  object $R
+  def <init>(): jli.CS_1[T,U]
+}
+class SD_1.companion.moduleClass.info:  {
+  class Q extends CS_1[String,jli.SD_1]
+  object Q
+}

--- a/test/files/jvm/t11726/CS_1.java
+++ b/test/files/jvm/t11726/CS_1.java
@@ -1,0 +1,5 @@
+package jli;
+
+public abstract class CS_1<T, U extends CS_1<T, U>.R> {
+    public class R {}
+}

--- a/test/files/jvm/t11726/CS_2.java
+++ b/test/files/jvm/t11726/CS_2.java
@@ -1,0 +1,5 @@
+package jli;
+
+public abstract class CS_2<T, U extends CS_2<T, U>.R> {
+    public class R {}
+}

--- a/test/files/jvm/t11726/M_1.scala
+++ b/test/files/jvm/t11726/M_1.scala
@@ -1,0 +1,21 @@
+import language.experimental.{macros => m}
+import reflect._
+
+object M_1 {
+
+  def test(phase: Int, u: api.Universe)(m: u.Mirror): String = {
+    val cs = m.staticClass("jli.CS_" + phase)
+    val sd = m.staticClass("jli.SD_" + phase)
+    s"""$cs.info: ${cs.info}
+       |$sd.companion.moduleClass.info: ${sd.companion.asModule.moduleClass.info}
+     """.stripMargin.trim
+  }
+
+  def testMacro_impl(c: macros.blackbox.Context)(p: c.Tree): c.Tree = {
+    import c.universe._
+    val Literal(Constant(ph: Int)) = p
+    Literal(Constant(test(ph, c.universe)(rootMirror)))
+  }
+  def testMacro(p: Int): String = macro testMacro_impl
+
+}

--- a/test/files/jvm/t11726/SD_1.java
+++ b/test/files/jvm/t11726/SD_1.java
@@ -1,0 +1,8 @@
+package jli;
+
+public class SD_1 extends CS_1<String, SD_1>.R {
+    public static class Q extends CS_1<String, SD_1> {}
+    public SD_1() {
+        new Q().super();
+    }
+}

--- a/test/files/jvm/t11726/SD_2.java
+++ b/test/files/jvm/t11726/SD_2.java
@@ -1,0 +1,8 @@
+package jli;
+
+public class SD_2 extends CS_2<String, SD_2>.R {
+    public static class Q extends CS_2<String, SD_2> {}
+    public SD_2() {
+        new Q().super();
+    }
+}

--- a/test/files/jvm/t11726/S_2.scala
+++ b/test/files/jvm/t11726/S_2.scala
@@ -1,0 +1,13 @@
+import jli._
+import reflect.runtime
+
+object Test extends App {
+  val x = new SD_1.Q
+  val y = new SD_2.Q
+
+  println(M_1.testMacro(1)); println()
+  println(M_1.testMacro(2)); println()
+  // the output of this is befouled by scala/bug#7072
+  print(M_1.test(1, runtime.universe)(runtime.currentMirror))
+
+}


### PR DESCRIPTION
Java 11 started shipping a class similar to the enclosed `CS_1`, which has a class signature referring to its own inner class. What does this mean? I've been writing Scala too long for it to be intuitive, but the good news is that we can avoid failing simply by looking for the inner class in the `instanceScope` rather than going through `tpe.member`.

Fixes scala/bug#11726, but the test case is sadly much longer than the provided one-liner because CI isn't running on Java 11 yet.