### PR TITLE
Reuse buffers in pickler

### DIFF
--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -426,6 +426,15 @@ extends AbstractMap[K, V]
     this
   }
 
+  override def clear(): Unit = {
+    import java.util.Arrays.fill
+    fill(_keys, null)
+    fill(_values, null)
+    fill(_hashes, 0)
+    _size = 0
+    _vacant = 0
+  }
+
 }
 
 object AnyRefMap {

--- a/test/junit/scala/collection/mutable/AnyRefMapTest.scala
+++ b/test/junit/scala/collection/mutable/AnyRefMapTest.scala
@@ -3,10 +3,8 @@ package scala.collection.mutable
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
-import org.junit.Assert.assertTrue
+import org.junit.Assert._
 
-
-/* Test for scala/bug#10540 */
 @RunWith(classOf[JUnit4])
 class AnyRefMapTest {
   @Test
@@ -19,5 +17,42 @@ class AnyRefMapTest {
     assertTrue(AnyRefMap(equivalent -> 1) contains equivalent)
     assertTrue(AnyRefMap(sameHashCode -> 1) contains sameHashCode)
     assertTrue(sameHashCode.hashCode == badHashCode)  // Make sure test works
+  }
+  @Test
+  def testClear: Unit = {
+    val map = new AnyRefMap[String, String]()
+    map("greeting") = "hi"
+    map("farewell") = "bye"
+    assertEquals(2, map.size)
+    map.clear()
+    assertEquals(0, map.size)
+    map("greeting") = "howdy"
+    assertEquals(1, map.size)
+    map("farewell") = "auf Wiedersehen"
+    map("good day") = "labdien"
+    assertEquals(3, map.size)
+  }
+  @Test
+  def testClearMemoryReuse: Unit = { // otherwise there's no point to the override
+    val map = new AnyRefMap[String, Int]
+    def getField[T <: AnyRef](name: String): T =
+      reflect.ensureAccessible(map.getClass.getDeclaredField("scala$collection$mutable$AnyRefMap$$" + name)).get(map).asInstanceOf[T]
+    def hashesSz = getField[Array[Int]]("_hashes").length
+    def keysSz = getField[Array[AnyRef]]("_keys").length
+    def valuesSz = getField[Array[AnyRef]]("_values").length
+    def assertArraysSize(sz: Int) = {
+      assertEquals(sz, hashesSz)
+      assertEquals(sz, keysSz)
+      assertEquals(sz, valuesSz)
+    }
+    for (i <- (1 to 1000000)) map(i.toString) = i
+    assertEquals(1000000, map.size)
+    assertArraysSize(1 << 21)
+    map.clear()
+    assertEquals(0, map.size)
+    assertArraysSize(1 << 21)
+    for (i <- (-10000 to 10000)) map(i.toString) = i
+    assertEquals(20001, map.size)
+    assertArraysSize(1 << 21)
   }
 }


### PR DESCRIPTION
Each `Pickle` object previously contained an `index` and `entries`, which are only used to populate the raw pickle bytes. Profiles show this as a significant source of allocations in some runs, and since the arrays backing these collections are held until jvm, the memory is likely to survive for several garbage collections and be tenured into an older space.

Since the `bytes` array is the actual result of the pickling, this commit moves the other large (mutable!) collections to the pickler phase factory itself, and arranges that they be cleared before use and replaced at the end of each pickler phase (so as not to retain the memory for longer than needed). As a sanity check, each pickle has a field `active` which is used to assert that accesses to both mutable fields is safe -- it's set to false when they're cleared.

The new override of `clear` in `AnyRefMap` is safe, since scala itself currently generates calls to `AnyRefMap.clear` when asked to:

```
[nix-shell:/code/scala/sandbox]$ scala -version
Scala code runner version 2.12.9 -- Copyright 2002-2019, LAMP/EPFL and Lightbend, Inc.

[nix-shell:/code/scala/sandbox]$ cat Test.scala
object Test extends App {
  val map = new collection.mutable.AnyRefMap[String, Int]()
  map("a") = 0
  map.clear()
}

[nix-shell:/code/scala/sandbox]$ scalac Test.scala -d .

[nix-shell:/code/scala/sandbox]$ javap -c Test\$.class | grep '\.clear'
      28: invokevirtual #87                 // Method scala/collection/mutable/AnyRefMap.clear:()V
```

As for actual numbers: this shows about 85 MB saved per compilation of scala/scala, and 22MB fewer promoted to survivor space.