### PR TITLE
Add specialised SubstTypeMap for WildcardType

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2132,7 +2132,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             // When typechecking default parameter, replace all type parameters in the expected type by Wildcard.
             // This allows defining "def foo[T](a: T = 1)"
             val tparams = sym.owner.skipConstructor.info.typeParams
-            val subst = new SubstTypeMap(tparams, tparams map (_ => WildcardType)) {
+            val subst = new SubstByWildcardTypeMap(tparams) {
               override def matches(sym: Symbol, sym1: Symbol) =
                 if (sym.isSkolem) matches(sym.deSkolemize, sym1)
                 else if (sym1.isSkolem) matches(sym, sym1.deSkolemize)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1291,9 +1291,9 @@ trait Types
     private def toWild(tp: Type): Type = tp match {
       case PolyType(tparams, tp) =>
         val undets = tparams ++ origUndets
-        new SubstTypeMap(undets, undets map (_ => WildcardType)).apply(tp)
+        new SubstByWildcardTypeMap(undets).apply(tp)
       case tp                    =>
-        new SubstTypeMap(origUndets, origUndets map (_ => WildcardType)).apply(tp)
+        new SubstByWildcardTypeMap(origUndets).apply(tp)
     }
 
     private lazy val sameTypesFolded = {


### PR DESCRIPTION
We introduce two middle "abstract" classes, `AbstractSubstTypeMap` and `AbstractSubstMap`, and we keep as much of the logic as possible in there, using the "template method" design pattern. In this case, we make the logic dependent upon a "find" method, which looks for a symbol (key) in the "map", which in the common case is implemented as two lists.

We then introduce a special class `SubstByWildcardTypeMap`, which does not have a "to" list, but always returns WildcardType. This allows us to replace the calls to `new SubstTypeMap(xs, xs map (_ => WildcardType))`, with calls to `new SubstByWildcardTypeMap(xs)`, thus avoiding the cost of creating that bogus list of values.