### PR TITLE
Scope: use direct iterator to checkNoAbstractMembers

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -594,7 +594,15 @@ abstract class RefChecks extends Transform {
         def checkNoAbstractMembers(): Unit = {
           // Avoid spurious duplicates: first gather any missing members.
           def memberList = clazz.info.nonPrivateMembersAdmitting(VBRIDGE)
-          val missing = memberList.reverseIterator.filter(m => m.isDeferred && !ignoreDeferred(m)).toList.reverse
+          var missing: List[Symbol] = Nil
+          var rest: List[Symbol] = Nil
+          memberList.reverseIterator.foreach {
+            case m if m.isDeferred && !ignoreDeferred(m) =>
+              missing ::= m
+            case m if m.isAbstractOverride && m.isIncompleteIn(clazz) =>
+              rest ::= m
+            case _ => // No more
+          }
           // Group missing members by the name of the underlying symbol,
           // to consolidate getters and setters.
           val grouped = missing groupBy (_.name.getterName)
@@ -712,10 +720,7 @@ abstract class RefChecks extends Transform {
           }
 
           // Check the remainder for invalid absoverride.
-          val rest = memberList.reverseIterator.filter { m =>
-            (!m.isDeferred || ignoreDeferred(m) ) && m.isAbstractOverride && m.isIncompleteIn(clazz)
-          }
-          rest.toList.reverse.foreach { member =>
+          rest.foreach { member =>
             val other = member.superSymbolIn(clazz)
             val explanation =
               if (other != NoSymbol) " and overrides incomplete superclass member\n" + infoString(other)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -594,7 +594,7 @@ abstract class RefChecks extends Transform {
         def checkNoAbstractMembers(): Unit = {
           // Avoid spurious duplicates: first gather any missing members.
           def memberList = clazz.info.nonPrivateMembersAdmitting(VBRIDGE)
-          val (missing, rest) = memberList partition (m => m.isDeferred && !ignoreDeferred(m))
+          val missing = memberList.reverseIterator.filter(m => m.isDeferred && !ignoreDeferred(m)).toList.reverse
           // Group missing members by the name of the underlying symbol,
           // to consolidate getters and setters.
           val grouped = missing groupBy (_.name.getterName)
@@ -712,7 +712,10 @@ abstract class RefChecks extends Transform {
           }
 
           // Check the remainder for invalid absoverride.
-          for (member <- rest ; if (member.isAbstractOverride && member.isIncompleteIn(clazz))) {
+          val rest = memberList.reverseIterator.filter { m =>
+            (!m.isDeferred || ignoreDeferred(m) ) && m.isAbstractOverride && m.isIncompleteIn(clazz)
+          }
+          rest.toList.reverse.foreach { member =>
             val other = member.superSymbolIn(clazz)
             val explanation =
               if (other != NoSymbol) " and overrides incomplete superclass member\n" + infoString(other)

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -431,6 +431,10 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
      */
     def iterator: Iterator[Symbol] = toList.iterator
 
+    /** Returns all symbols as an iterator, in an order reversed to that in which they
+      * were entered: symbols first in the scopes are last out of the iterator.
+      * NOTE: when using the `reverseIterator`, it is not safe to mutate the Scope.
+      *  So, be careful not to use this when you do need to mutate this Scope. */
     def reverseIterator: Iterator[Symbol] = new ScopeIterator(this)
 
     override def foreach[U](p: Symbol => U): Unit = toList foreach p


### PR DESCRIPTION
When profiling a compilation, I noticed that the `checkNoAbstractMembers` was the source of 6% of all the `::` allocations. 

Now, Scope implements a sort of single-linked list of `ScopeEntry` nodes. Now, its default iterator needs to traverse that list in reversed order, for which it needs to keep a list (stack) to LIFO those elements. Creating that stack is the source of those `::` allocations. 

It turns out that, as long as we only want to do a forall or exists with the iterator, as in `checkNoAbstractMethods`, the order does not matter. Thus: 

- We introduce a simple iterator for the `Scope` class that, unlike the
normal iterator, processes the elements as reachable through the
entries, and thus needs no extra list (stack) to LIFO its elements.
- We use this iterator in the `checkNoAbstractMethods`.