### PR TITLE
Fix memory leak in runtime reflections TypeTag caches

### DIFF
--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -27,6 +27,7 @@ import java.lang.reflect.{
   ParameterizedType, WildcardType, AnnotatedElement }
 import java.lang.annotation.{Annotation => jAnnotation}
 import java.io.IOException
+import java.lang.ref.{WeakReference => jWeakReference}
 import scala.reflect.internal.{ MissingRequirementError, JavaAccFlags }
 import internal.pickling.ByteCodecs
 import internal.pickling.UnPickler
@@ -105,20 +106,26 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
     private val fieldCache       = new TwoWayCache[jField, TermSymbol]
     private val tparamCache      = new TwoWayCache[jTypeVariable[_ <: GenericDeclaration], TypeSymbol]
 
-    private[this] object typeTagCache extends ClassValue[TypeTag[_]]() {
+    private[this] object typeTagCache extends ClassValue[jWeakReference[TypeTag[_]]]() {
       val typeCreator = new ThreadLocal[TypeCreator]()
 
-      override protected def computeValue(cls: jClass[_]): TypeTag[_] = {
+      override protected def computeValue(cls: jClass[_]): jWeakReference[TypeTag[_]] = {
         val creator = typeCreator.get()
         assert(creator.getClass == cls, (creator, cls))
-        TypeTagImpl[AnyRef](thisMirror.asInstanceOf[Mirror], creator)
+        new jWeakReference(TypeTagImpl[AnyRef](thisMirror.asInstanceOf[Mirror], creator))
       }
     }
 
     final def typeTag(typeCreator: TypeCreator): TypeTag[_] = {
       typeTagCache.typeCreator.set(typeCreator)
       try {
-        typeTagCache.get(typeCreator.getClass)
+        val ref = typeTagCache.get(typeCreator.getClass)
+        var tag = ref.get
+        if (tag == null) {
+          typeTagCache.remove(typeCreator.getClass)
+          tag = TypeTagImpl[AnyRef](thisMirror.asInstanceOf[Mirror], typeCreator)
+        }
+        tag
       } finally  {
         typeTagCache.typeCreator.remove()
       }

--- a/test/files/run/type-tag-leak.javaopts
+++ b/test/files/run/type-tag-leak.javaopts
@@ -1,0 +1,1 @@
+-Xmx128M -XX:+ExitOnOutOfMemoryError

--- a/test/files/run/type-tag-leak.scala
+++ b/test/files/run/type-tag-leak.scala
@@ -1,0 +1,30 @@
+import scala.reflect.runtime.universe
+import scala.reflect.runtime.universe._
+
+class Test {
+
+  def repo(): String = {
+    val tag = implicitly[TypeTag[Array[Byte]]]
+    val mirror = universe.runtimeMirror(Thread.currentThread().getContextClassLoader)
+    tag.in(mirror).tpe.dealias.toString
+  }
+}
+
+object Test extends Test {
+
+  def main(args: Array[String]): Unit = {
+    for (i <- 1 to 16) {
+      val settings = new scala.tools.nsc.Settings
+      settings.Xnojline.value = true
+      settings.usejavacp.value = true
+      val intp = new scala.tools.nsc.interpreter.IMain(settings)
+
+      try {
+        intp.quietRun("object C { val data = new Array[Byte](16 * 1024 * 1024) }")
+        intp.quietRun("identity(C.data); Test.repo()")
+      } finally {
+        intp.close()
+      }
+    }
+  }
+}


### PR DESCRIPTION
Keep a weak reference to the TypeTag value stored in the ClassValue as it refers
to the key.

Fixes scala/bug#11767