### PR TITLE
Revert invert type signature change

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -430,7 +430,7 @@ object Predef extends LowPriorityImplicits {
    *  Consider using the [[scala.StringContext.f f interpolator]] as more type safe and idiomatic.
    *
    *  @param text the pattern for formatting the arguments.
-   *  @param args the arguments used to instantiating the pattern.
+   *  @param xs   the arguments used to instantiate the pattern.
    *  @throws java.lang.IllegalArgumentException if there was a problem with the format string or arguments
    *
    *  @see [[scala.StringContext.f StringContext.f]]
@@ -440,9 +440,9 @@ object Predef extends LowPriorityImplicits {
 
   // views --------------------------------------------------------------
 
-  @deprecated("Use xs.lazyZip(ys).", "2.13.0")
+  // these two are morally deprecated but the @deprecated annotation has been moved to the extension method themselves,
+  // in order to provide a more specific deprecation method.
   implicit def tuple2ToZippedOps[T1, T2](x: (T1, T2)): runtime.Tuple2Zipped.Ops[T1, T2]             = new runtime.Tuple2Zipped.Ops(x)
-  @deprecated("Use xs.lazyZip(ys).lazyZip(zs).", "2.13.0")
   implicit def tuple3ToZippedOps[T1, T2, T3](x: (T1, T2, T3)): runtime.Tuple3Zipped.Ops[T1, T2, T3] = new runtime.Tuple3Zipped.Ops(x)
 
   // Not specialized anymore since 2.13 but we still need separate methods

--- a/src/library/scala/runtime/Tuple2Zipped.scala
+++ b/src/library/scala/runtime/Tuple2Zipped.scala
@@ -117,13 +117,14 @@ final class Tuple2Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2]](p
   override def toString = s"($coll1, $coll2).zipped"
 }
 
-@deprecated("Use scala.collection.LazyZip2.", "2.13.0")
+@deprecated("Use scala.collection.LazyZip2.", since = "2.13.0")
 object Tuple2Zipped {
   final class Ops[T1, T2](private val x: (T1, T2)) extends AnyVal {
-    def invert[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2], That]
-      (implicit w1: T1 <:< It1,
-                w2: T2 <:< It2,
-                bf: BuildFrom[It1, (El1, El2), That]
+    @deprecated("Use xs.lazyZip(yz).map((_, _))", since = "2.13.0")
+    def invert[El1, It1[a] <: Iterable[a], El2, It2[a] <: Iterable[a], That]
+      (implicit w1: T1 <:< It1[El1],
+                w2: T2 <:< It2[El2],
+                bf: BuildFrom[T1, (El1, El2), That]
       ): That = {
         val buf = bf.newBuilder(x._1)
         val it1 = x._1.iterator
@@ -134,6 +135,7 @@ object Tuple2Zipped {
         buf.result()
       }
 
+    @deprecated("Use xs.lazyZip(ys)", since = "2.13.0")
     def zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2]]
       (implicit w1: T1 => IterableOps[El1, Iterable, It1] with It1,
                 w2: T2 => IterableOps[El2, Iterable, It2] with It2

--- a/src/library/scala/runtime/Tuple3Zipped.scala
+++ b/src/library/scala/runtime/Tuple3Zipped.scala
@@ -126,14 +126,15 @@ final class Tuple3Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2], E
   override def toString = s"($coll1, $coll2, $coll3).zipped"
 }
 
-@deprecated("Use scala.collection.LazyZip3.", "2.13.0")
+@deprecated("Use scala.collection.LazyZip3.", since = "2.13.0")
 object Tuple3Zipped {
   final class Ops[T1, T2, T3](private val x: (T1, T2, T3)) extends AnyVal {
-    def invert[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2], El3, It3 <: Iterable[El3], That]
-      (implicit w1: T1 <:< It1,
-                w2: T2 <:< It2,
-                w3: T3 <:< It3,
-                bf: BuildFrom[It1, (El1, El2, El3), That]
+    @deprecated("Use xs.lazyZip(yz).lazyZip(zs).map((_, _, _))", since = "2.13.0")
+    def invert[El1, It1[a] <: Iterable[a], El2, It2[a] <: Iterable[a], El3, It3[a] <: Iterable[a], That]
+      (implicit w1: T1 <:< It1[El1],
+                w2: T2 <:< It2[El2],
+                w3: T3 <:< It3[El3],
+                bf: BuildFrom[T1, (El1, El2, El3), That]
       ): That = {
         val buf = bf.newBuilder(x._1)
         val it1 = x._1.iterator
@@ -145,6 +146,7 @@ object Tuple3Zipped {
         buf.result()
       }
 
+    @deprecated("Use xs.lazyZip(ys).lazyZip(zs)", since = "2.13.0")
     def zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2], El3, It3 <: Iterable[El3]]
       (implicit w1: T1 => IterableOps[El1, Iterable, It1] with It1,
                 w2: T2 => IterableOps[El2, Iterable, It2] with It2,

--- a/test/junit/scala/runtime/ZippedTest.scala
+++ b/test/junit/scala/runtime/ZippedTest.scala
@@ -8,6 +8,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.collection.Seq
+import scala.collection.immutable.{List, Vector}
+
 /** Tests Tuple?Zipped */
 @RunWith(classOf[JUnit4])
 class ZippedTest {
@@ -64,5 +67,23 @@ class ZippedTest {
     val s = Stream.continually(b.inc)
     // zipped.toString must allow s to short-circuit evaluation
     assertTrue((s, s).zipped.toString contains s.toString)
+  }
+
+  @Test
+  def testTuple2Invert: Unit = {
+    // prolix actuals test inferred type
+    assertEquals(Seq((1, "a"), (2, "b")), { val r = (List(1, 2),   List("a", "b")).invert; r: List[(Int, String)] })
+    assertEquals(Seq((1, "a"), (2, "b")), { val r = (List(1, 2),    Seq("a", "b")).invert; r: List[(Int, String)] })
+    assertEquals(Seq((1, "a")          ), { val r = ( Seq(1, 2), Vector("a"     )).invert; r:  Seq[(Int, String)] })
+    assertEquals(Seq((1, "a")          ), { val r = ( Seq(1   ), Vector("a", "b")).invert; r:  Seq[(Int, String)] })
+  }
+
+  @Test
+  def testTuple3Invert: Unit = {
+    // prolix actuals test inferred type
+    assertEquals(Seq((1, "a", 4d), (2, "b", 5d)), { val r = (  List(1, 2),     List("a", "b"),  Seq(4d, 5d)).invert; r:   List[(Int, String, Double)] })
+    assertEquals(Seq((1, "a", 4d)              ), { val r = (   Seq(1   ),   Vector("a", "b"), List(4d, 5d)).invert; r:    Seq[(Int, String, Double)] })
+    assertEquals(Seq((1, "b", 4d)              ), { val r = (Vector(1, 2),      Seq(     "b"), List(4d, 5d)).invert; r: Vector[(Int, String, Double)] })
+    assertEquals(Seq((1, "a", 5d)              ), { val r = (Vector(1, 2),      Seq("a"     ), List(    5d)).invert; r: Vector[(Int, String, Double)] })
   }
 }


### PR DESCRIPTION
This aligns it with what 2.12 has. I was going to justify this with a comment on how Dotty also can't infer the types, but as it turns out Dotty can do so just fine, so now I need to justify this with a comment on how much more difficult type-inference bugs are to fix.

Plus, the bug's milestoned for 2.13.2, and I'd hate to let perfect be the enemy of gets-released-on-time.

Deprecation changes are to give a nicer error message for `(xs, ys).invert`... `use xs.lazyZip(ys)` isn't obvious enough IMO.

Fixes scala/bug#11766.