### PR TITLE
Add a one-element cache for Type.substSym

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -117,6 +117,15 @@ trait Types
       cached
     } else new SubstTypeMap(from, to)
   }
+  private object substSymMapCache {
+    private[this] var cached: SubstSymMap = new SubstSymMap(Nil, Nil)
+
+    def apply(from: List[Symbol], to: List[Symbol]): SubstSymMap = if (isCompilerUniverse) {
+      if ((cached.from ne from) || (cached.to ne to))
+        cached = new SubstSymMap(from, to)
+      cached
+    } else new SubstSymMap(from, to)
+  }
 
   /** The current skolemization level, needed for the algorithms
    *  in isSameType, isSubType that do constraint solving under a prefix.
@@ -754,7 +763,7 @@ trait Types
      */
     def substSym(from: List[Symbol], to: List[Symbol]): Type =
       if ((from eq to) || from.isEmpty) this
-      else new SubstSymMap(from, to) apply this
+      else substSymMapCache(from, to)(this)
 
     /** Substitute all occurrences of `ThisType(from)` in this type by `to`.
      *

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -728,7 +728,7 @@ private[internal] trait TypeMaps {
   }
 
   /** A base class to compute all substitutions */
-  abstract class SubstMap[T](from: List[Symbol], to: List[T]) extends TypeMap {
+  abstract class SubstMap[T](val from: List[Symbol], val to: List[T]) extends TypeMap {
     // OPT this check was 2-3% of some profiles, demoted to -Xdev
     if (isDeveloper) assert(sameLength(from, to), "Unsound substitution from "+ from +" to "+ to)
 
@@ -892,7 +892,7 @@ private[internal] trait TypeMaps {
   }
 
   /** A map to implement the `subst` method. */
-  class SubstTypeMap(val from: List[Symbol], val to: List[Type]) extends SubstMap(from, to) {
+  class SubstTypeMap(from: List[Symbol], to: List[Type]) extends SubstMap(from, to) {
     protected def toType(fromtp: Type, tp: Type) = tp
 
     override def mapOver(tree: Tree, giveup: () => Nothing): Tree = {

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -377,7 +377,7 @@ trait Collections {
   /** True if two lists have the same length.  Since calling length on linear sequences
     *  is O(n), it is an inadvisable way to test length equality.
     */
-  final def sameLength(xs1: List[_], xs2: List[_]) = compareLengths(xs1, xs2) == 0
+  final def sameLength(xs1: List[_], xs2: List[_]) = (xs1 eq xs2) || compareLengths(xs1, xs2) == 0
   @tailrec final def compareLengths(xs1: List[_], xs2: List[_]): Int =
     if (xs1.isEmpty) { if (xs2.isEmpty) 0 else -1 }
     else if (xs2.isEmpty) 1


### PR DESCRIPTION
This helps in the common pattern of performing the same
substitution in a loop, for instance in `isPolySubType`
and `matchesType`.