### PR TITLE
`this(...)` ctor apply cannot supply type params...

### DIFF
--- a/test/files/pos/t11774.scala
+++ b/test/files/pos/t11774.scala
@@ -1,0 +1,3 @@
+class C[T](x: AnyRef, y: Boolean = false) {
+  def this(x: T) = this(x.asInstanceOf[AnyRef])
+}


### PR DESCRIPTION
... thus, do not include them when computing specificity

Fix scala/bug#11774