### PR TITLE
Scopes: use reverse iterators instead of default ones.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -470,7 +470,7 @@ abstract class Mixin extends Transform with ast.TreeDSL with AccessorSynthesis {
     /** Map lazy values to the fields they should null after initialization. */
     def lazyValNullables(clazz: Symbol, templStats: List[Tree]): Map[Symbol, List[Symbol]] = {
       // if there are no lazy fields, take the fast path and save a traversal of the whole AST
-      if (!clazz.info.decls.exists(_.isLazy)) Map()
+      if (!clazz.info.decls.reverseIterator.exists(_.isLazy)) Map()
       else {
         // A map of single-use fields to the lazy value that uses them during initialization.
         // Each field has to be private and defined in the enclosing class, and there must

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -913,13 +913,13 @@ trait Definitions extends api.StandardDefinitions {
       def isVolatileRefinedType: Boolean = {
         val RefinedType(parents, decls)         = tp
         def isVisibleDeferred(m: Symbol)        = m.isDeferred && ((tp nonPrivateMember m.name).alternatives contains m)
-        def contributesAbstractMembers(p: Type) = p.deferredMembers exists isVisibleDeferred
+        def contributesAbstractMembers(p: Type) = p.deferredMembers.reverseIterator exists isVisibleDeferred
         def dropConcreteParents                 = parents dropWhile (p => !p.typeSymbol.isAbstractType)
 
         (parents exists isVolatile) || {
           dropConcreteParents match {
             case Nil => false
-            case ps  => (ps ne parents) || (ps.tail exists contributesAbstractMembers) || (decls exists isVisibleDeferred)
+            case ps  => (ps ne parents) || (ps.tail exists contributesAbstractMembers) || (decls.reverseIterator exists isVisibleDeferred)
           }
         }
       }

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1669,7 +1669,7 @@ trait Types
     override def narrow: Type = typeSymbol.thisType
 
     override def isStructuralRefinement: Boolean =
-      typeSymbol.isAnonOrRefinementClass && (decls exists symbolIsPossibleInRefinement)
+      typeSymbol.isAnonOrRefinementClass && (decls.reverseIterator exists symbolIsPossibleInRefinement)
 
     protected def shouldForceScope = settings.debug || parents.isEmpty || !decls.isEmpty
     protected def initDecls        = fullyInitializeScope(decls)

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -548,7 +548,7 @@ trait TypeComparers {
         thirdTryRef(tp1, tr2)
       case rt2: RefinedType =>
         (rt2.parents forall (isSubType(tp1, _, depth))) &&
-          (rt2.decls forall (specializesSym(tp1, _, depth)))
+          (rt2.decls.reverseIterator forall (specializesSym(tp1, _, depth)))
       case et2: ExistentialType =>
         et2.withTypeVars(isSubType(tp1, _, depth), depth) || fourthTry
       case mt2: MethodType =>


### PR DESCRIPTION
There are some operations on the Scopes that are inherited from the
Iterable interface, and therefore rely on the `Iterator` created.
Now, since the default Iterator requires creating a List, this
can be a source of excessive allocations. To avoid this, we
explicitly use a reverse iterator when applicable.