### PR TITLE
Reuse StringBuilder used for printing BTypes.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -889,7 +889,7 @@ abstract class BTypes {
 
   object BTypeExporter {
     private[this] val builderTL: ThreadLocal[StringBuilder] = new ThreadLocal[StringBuilder](){
-      override protected val initialValue: StringBuilder = new StringBuilder(64)
+      override protected def initialValue: StringBuilder = new StringBuilder(64)
     }
 
     final def btypeToString(btype: BType): String = {
@@ -908,6 +908,12 @@ abstract class BTypes {
         args.foreach(appendBType(builder, _))
         builder.append(')')
         appendBType(builder, res)
+    }
+    def close(): Unit = {
+      // This will eagerly remove the thread local from the calling thread's ThreadLocalMap. It won't
+      // do the same for other threads used by `-Ybackend-parallelism=N`, but in practice this doesn't
+      // matter as that thread pool is shutdown at the end of compilation.
+      builderTL.remove()
     }
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -14,6 +14,7 @@ package scala.tools.nsc
 package backend.jvm
 
 import java.{util => ju}
+import java.lang.{StringBuilder, ThreadLocal}
 import scala.annotation.tailrec
 import scala.tools.asm
 import scala.tools.asm.Opcodes
@@ -54,21 +55,7 @@ abstract class BTypes {
     recordPerRunJavaMapCache(new ju.concurrent.ConcurrentHashMap[InternalName, ClassBType])
 
   sealed abstract class BType {
-    override def toString: String = {
-      val builder = new java.lang.StringBuilder(64)
-      buildString(builder)
-      builder.toString
-    }
-    final def buildString(builder: java.lang.StringBuilder): Unit = this match {
-      case p: PrimitiveBType        => builder.append(p.desc)
-      case ClassBType(internalName) => builder.append('L').append(internalName).append(';')
-      case ArrayBType(component)    => builder.append('['); component.buildString(builder)
-      case MethodBType(args, res)   =>
-        builder.append('(')
-        args.foreach(_.buildString(builder))
-        builder.append(')')
-        res.buildString(builder)
-    }
+    override def toString: String = BTypeExporter.btypeToString(this)
 
     /**
      * @return The Java descriptor of this type. Examples:
@@ -899,6 +886,30 @@ abstract class BTypes {
   }
 
   final case class MethodBType(argumentTypes: List[BType], returnType: BType) extends BType
+
+  object BTypeExporter {
+    private[this] val builderTL: ThreadLocal[StringBuilder] = new ThreadLocal[StringBuilder](){
+      override protected val initialValue: StringBuilder = new StringBuilder(64)
+    }
+
+    final def btypeToString(btype: BType): String = {
+      val builder = builderTL.get()
+      builder.setLength(0)
+      appendBType(builder, btype)
+      builder.toString
+    }
+
+    final def appendBType(builder: StringBuilder, btype: BType): Unit = btype match {
+      case p: PrimitiveBType        => builder.append(p.desc)
+      case ClassBType(internalName) => builder.append('L').append(internalName).append(';')
+      case ArrayBType(component)    => builder.append('['); appendBType(builder, component)
+      case MethodBType(args, res)   =>
+        builder.append('(')
+        args.foreach(appendBType(builder, _))
+        builder.append(')')
+        appendBType(builder, res)
+    }
+  }
 
   /* Some definitions that are required for the implementation of BTypes. They are abstract because
    * initializing them requires information from types / symbols, which is not accessible here in

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -105,6 +105,7 @@ abstract class GenBCode extends SubComponent {
     private def close(): Unit = {
       postProcessor.classfileWriter.close()
       generatedClassHandler.close()
+      bTypes.BTypeExporter.close()
     }
   }
 }


### PR DESCRIPTION
In the `BType` class hierarchy, to print the BType to a String (needed to get the `descriptor` used in ASM) we use a `StringBuilder`. However, unlike the builders in the Scala collections library, a `StringBuilder` does not share memory with the
built objects: a call to `StringBuilder.toString` dumps all its contents into a new String, backed by a new array. So, using a new StringBuilder every time means wasting all the memory used in that builder.

To prevent these memory allocations, we extract the toString printing logic to an object, and use a single shared StringBuilder. Before and after a printing starts, we clear the builder.

To sustain the possible cost effect of this changes, here is a screenshot of a ZMC recording, of a compilation of `cats` with the latest `2.13.1` version.
![Screenshot 2019-10-18 at 21 46 59](https://user-images.githubusercontent.com/1764610/67123535-ddf86780-f1f0-11e9-8160-18e1d48c37b5.png)


**DOWNSIDE** Note that, because a string builder is mutable and not concurrent (unlike a StringBuffer), this change would make it impossible to print from two threads, or for the method to be reentrant.  
