### PR TITLE
Avoid Option.WithFilter allocations.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3341,12 +3341,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           }
           for (sym <- scope)
             // OPT: shouldAdd is usually true. Call it here, rather than in the outer loop
-            for (tree <- context.unit.synthetics.get(sym) if shouldAdd(sym)) {
+            for (tree <- context.unit.synthetics.get(sym)) { (tree: Tree) => if (shouldAdd(sym)) {
               // if the completer set the IS_ERROR flag, retract the stat (currently only used by applyUnapplyMethodCompleter)
               if (!sym.initialize.hasFlag(IS_ERROR))
                 newStats += typedStat(tree) // might add even more synthetics to the scope
               context.unit.synthetics -= sym
-            }
+            }}
           // the type completer of a synthetic might add more synthetics. example: if the
           // factory method of a case class (i.e. the constructor) has a default.
           moreToAdd = scope.elems ne initElems


### PR DESCRIPTION
When we use a for-comprehension (a foreach in this case) over the
Option class, and when we use an `if` clause in the comprehension
(which corresponds to using a `withFilter`), then an object of the
class `Option.withFilter` is created.

Checking the same predicate inside the body of the for comprehension
should avoid that allocation.