### PR TITLE
Cache the wildcard substituted implicit type

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -190,16 +190,6 @@ trait Implicits {
     improvesCache.clear()
   }
 
-  /* Map a polytype to one in which all type parameters and argument-dependent types are replaced by wildcards.
-   * Consider `implicit def b(implicit x: A): x.T = error("")`. We need to approximate de Bruijn index types
-   * when checking whether `b` is a valid implicit, as we haven't even searched a value for the implicit arg `x`,
-   * so we have to approximate (otherwise it is excluded a priori).
-   */
-  private def depoly(tp: Type): Type = tp match {
-    case PolyType(tparams, restpe) => deriveTypeWithWildcards(tparams)(ApproximateDependentMap(restpe))
-    case _                         => ApproximateDependentMap(tp)
-  }
-
   /** The result of an implicit search
    *  @param  tree    The tree representing the implicit
    *  @param  subst   A substituter that represents the undetermined type parameters
@@ -237,12 +227,28 @@ trait Implicits {
    */
   class ImplicitInfo(val name: Name, val pre: Type, val sym: Symbol) {
     private var tpeCache: Type = null
+    private var depolyCache: Type = null
     private var isErroneousCache: TriState = TriState.Unknown
 
     /** Computes member type of implicit from prefix `pre` (cached). */
-    def tpe: Type = {
+    final def tpe: Type = {
       if (tpeCache eq null) tpeCache = pre.memberType(sym)
       tpeCache
+    }
+
+    /* Map a polytype to one in which all type parameters and argument-dependent types are replaced by wildcards.
+     * Consider `implicit def b(implicit x: A): x.T = error("")`. We need to approximate de Bruijn index types
+     * when checking whether `b` is a valid implicit, as we haven't even searched a value for the implicit arg `x`,
+     * so we have to approximate (otherwise it is excluded a priori).
+     */
+    final def depoly: Type = {
+      if (depolyCache eq null) {
+        depolyCache = tpe match {
+          case PolyType(tparams, restpe) => deriveTypeWithWildcards(tparams)(ApproximateDependentMap(restpe))
+          case _                         => ApproximateDependentMap(tpe)
+        }
+      }
+      depolyCache
     }
 
     def dependsOnPrefix: Boolean = pre match {
@@ -654,7 +660,7 @@ trait Implicits {
       result
     }
     private def matchesPt(info: ImplicitInfo): Boolean = (
-      info.isStablePrefix && matchesPt(depoly(info.tpe), wildPt, Nil)
+      info.isStablePrefix && matchesPt(info.depoly, wildPt, Nil)
     )
 
     private def matchesPtView(tp: Type, ptarg: Type, ptres: Type, undet: List[Symbol]): Boolean = tp match {


### PR DESCRIPTION
Profiling compilation of `cats` showed 1% of allocations
underneath `depoly`. Given that we cache `ImplicitInfo`, we can
save some of this by only doing it once per `ImplicitInfo`.

```
➜  compiler-benchmark git:(master) time (for v in 2.13.2-bin-9612d05-SNAPSHOT 2.13.2-bin-c2e57a6-SNAPSHOT; do echo $v; sbt 'set scalaVersion in compilation := "'$v'"' 'hot -psource=@/Users/jz/code/cats/core/.jvm/target/cats-core-compile.args -prof gc -wi 6 -i 6 -f 2' | grep 'HotScalacBenchmark\.compile:.gc\.alloc\.rate\.norm'; done)
2.13.2-bin-9612d05-SNAPSHOT
[info] Secondary result "scala.tools.nsc.HotScalacBenchmark.compile:·gc.alloc.rate.norm":
[info] HotScalacBenchmark.compile:·gc.alloc.rate.norm                       ../corpus           latest                    false  2.13.2-bin-9612d05-SNAPSHOT  @/Users/jz/code/cats/core/.jvm/target/cats-core-compile.args  sample   12  2660826123.667 ±  11030524.888    B/op
2.13.2-bin-c2e57a6-SNAPSHOT
[info] Secondary result "scala.tools.nsc.HotScalacBenchmark.compile:·gc.alloc.rate.norm":
[info] HotScalacBenchmark.compile:·gc.alloc.rate.norm                       ../corpus           latest                    false  2.13.2-bin-c2e57a6-SNAPSHOT  @/Users/jz/code/cats/core/.jvm/target/cats-core-compile.args  sample   12  2626353996.667 ±   9585399.734    B/op
```

= 0.987x allocation.