### PR TITLE
Reduce allocations in the backend

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -1359,7 +1359,8 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
           lambdaTarget.name.toString,
           methodBTypeFromSymbol(lambdaTarget).descriptor,
           /* itf = */ isInterface)
-      val numCaptured = lambdaTarget.paramss.head.length - arity
+      val lambdaTargetParamss = lambdaTarget.paramss
+      val numCaptured = lambdaTargetParamss.head.length - arity
       val invokedType = {
         val numArgs = if (isStaticMethod) numCaptured else 1 + numCaptured
         val argsArray: Array[asm.Type] = new Array[asm.Type](numArgs)
@@ -1368,7 +1369,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
           argsArray(0) = typeToBType(lambdaTarget.owner.info).toASMType
           i = 1
         }
-        var xs = lambdaTarget.paramss.head
+        var xs = lambdaTargetParamss.head
         while (i < numArgs && (!xs.isEmpty)) {
           argsArray(i) = typeToBType(xs.head.info).toASMType
           i += 1
@@ -1376,7 +1377,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
         }
         asm.Type.getMethodDescriptor(asmType(functionalInterface), argsArray:_*)
       }
-      val lambdaParams = lambdaTarget.paramss.head.drop(numCaptured)
+      val lambdaParams = lambdaTargetParamss.head.drop(numCaptured)
       val lambdaParamsBTypes = new Array[BType](lambdaParams.size)
       lambdaParams.iterator.map(p => typeToBType(p.tpe)).copyToArray(lambdaParamsBTypes)
       val constrainedType = MethodBType(lambdaParamsBTypes, typeToBType(lambdaTarget.tpe.resultType)).toASMType

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -1378,8 +1378,8 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
         asm.Type.getMethodDescriptor(asmType(functionalInterface), argsArray:_*)
       }
       val lambdaParams = lambdaTargetParamss.head.drop(numCaptured)
-      val lambdaParamsBTypes = new Array[BType](lambdaParams.size)
-      lambdaParams.iterator.map(p => typeToBType(p.tpe)).copyToArray(lambdaParamsBTypes)
+      val lambdaParamsBTypes = BType.newArray(lambdaParams.size)
+      mapToArray(lambdaParams, lambdaParamsBTypes, 0)(symTpeToBType)
       val constrainedType = MethodBType(lambdaParamsBTypes, typeToBType(lambdaTarget.tpe.resultType)).toASMType
       val samMethodType = methodBTypeFromSymbol(sam).toASMType
       val overriddenMethods = bridges.map(b => methodBTypeFromSymbol(b).toASMType)
@@ -1390,6 +1390,8 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
       }
     }
   }
+
+  private val symTpeToBType = (p: Symbol) => typeToBType(p.tpe) // OPT hoisted to save allocation
 
   private def visitInvokeDynamicInsnLMF(jmethod: MethodNode, samName: String, invokedType: String, samMethodType: asm.Type,
                                         implMethodHandle: asm.Handle, instantiatedMethodType: asm.Type, overriddenMethodTypes: Seq[asm.Type],

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -1072,7 +1072,10 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
       import InvokeStyle._
       if (style == Super) {
         if (receiverClass.isTrait && !method.isJavaDefined) {
-          val staticDesc = MethodBType(typeToBType(method.owner.info) :: bmType.argumentTypes, bmType.returnType).descriptor
+          val args = new Array[BType](bmType.argumentTypes.length + 1)
+          args(0) = typeToBType(method.owner.info)
+          bmType.argumentTypes.copyToArray(args, 1)
+          val staticDesc = MethodBType(args, bmType.returnType).descriptor
           val staticName = traitSuperAccessorName(method)
           bc.invokestatic(receiverName, staticName, staticDesc, isInterface, pos)
         } else {
@@ -1374,7 +1377,9 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
         asm.Type.getMethodDescriptor(asmType(functionalInterface), argsArray:_*)
       }
       val lambdaParams = lambdaTarget.paramss.head.drop(numCaptured)
-      val constrainedType = MethodBType(lambdaParams.map(p => typeToBType(p.tpe)), typeToBType(lambdaTarget.tpe.resultType)).toASMType
+      val lambdaParamsBTypes = new Array[BType](lambdaParams.size)
+      lambdaParams.iterator.map(p => typeToBType(p.tpe)).copyToArray(lambdaParamsBTypes)
+      val constrainedType = MethodBType(lambdaParamsBTypes, typeToBType(lambdaTarget.tpe.resultType)).toASMType
       val samMethodType = methodBTypeFromSymbol(sam).toASMType
       val overriddenMethods = bridges.map(b => methodBTypeFromSymbol(b).toASMType)
       visitInvokeDynamicInsnLMF(bc.jmethod, sam.name.toString, invokedType, samMethodType, implMethodHandle, constrainedType, overriddenMethods, isSerializable)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -750,9 +750,9 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
 
       val moduleName     = internalName(moduleClass)
       val methodInfo     = moduleClass.thisType.memberInfo(m)
-      val paramTypes = methodInfo.paramTypes
-      val paramJavaTypes = new Array[BType](paramTypes.length)
-      paramTypes.iterator.map(typeToBType).copyToArray(paramJavaTypes)
+      val paramTypes     = methodInfo.paramTypes
+      val paramJavaTypes = BType.newArray(paramTypes.length)
+      mapToArray(paramTypes, paramJavaTypes, 0)(typeToBType)
       // val paramNames     = 0 until paramJavaTypes.length map ("x_" + _)
 
       /* Forwarders must not be marked final,
@@ -974,7 +974,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
       )
 
       // INVOKEVIRTUAL `moduleName`.CREATOR() : android.os.Parcelable$Creator;
-      val bt = MethodBType(MethodBType.emptyBTypeArray, androidCreatorType)
+      val bt = MethodBType(BType.emptyArray, androidCreatorType)
       clinit.visitMethodInsn(
         asm.Opcodes.INVOKEVIRTUAL,
         moduleName,

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -750,7 +750,9 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
 
       val moduleName     = internalName(moduleClass)
       val methodInfo     = moduleClass.thisType.memberInfo(m)
-      val paramJavaTypes: List[BType] = methodInfo.paramTypes map typeToBType
+      val paramTypes = methodInfo.paramTypes
+      val paramJavaTypes = new Array[BType](paramTypes.length)
+      paramTypes.iterator.map(typeToBType).copyToArray(paramJavaTypes)
       // val paramNames     = 0 until paramJavaTypes.length map ("x_" + _)
 
       /* Forwarders must not be marked final,
@@ -972,7 +974,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
       )
 
       // INVOKEVIRTUAL `moduleName`.CREATOR() : android.os.Parcelable$Creator;
-      val bt = MethodBType(Nil, androidCreatorType)
+      val bt = MethodBType(MethodBType.emptyBTypeArray, androidCreatorType)
       clinit.visitMethodInsn(
         asm.Opcodes.INVOKEVIRTUAL,
         moduleName,

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
@@ -40,7 +40,7 @@ abstract class BCodeIdiomatic {
   val EMPTY_STRING_ARRAY   = Array.empty[String]
   val EMPTY_INT_ARRAY      = Array.empty[Int]
   val EMPTY_LABEL_ARRAY    = Array.empty[asm.Label]
-  val EMPTY_BTYPE_ARRAY    = Array.empty[BType]
+  val EMPTY_BTYPE_ARRAY    = BType.emptyArray
 
   /* can-multi-thread */
   final def mkArray(xs: List[BType]): Array[BType] = {

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
@@ -206,7 +206,7 @@ abstract class BCodeIdiomatic {
         case BYTE | SHORT                                             => INT
         case pt: PrimitiveBType                                       => pt
       }
-      val bt = MethodBType(List(paramType), jlStringBuilderRef)
+      val bt = MethodBType(Array(paramType), jlStringBuilderRef)
       invokevirtual(JavaStringBuilderClassName, "append", bt.descriptor, pos)
     }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -576,7 +576,8 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
 
       emitParamNames(mnode, params)
       emitAnnotations(mnode, others)
-      emitParamAnnotations(mnode, params.map(_.annotations))
+      if (params.exists(_.annotations.nonEmpty))
+        emitParamAnnotations(mnode, params.map(_.annotations))
 
     } // end of method initJMethod
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -53,7 +53,10 @@ abstract class BTypes {
   // Note usage should be private to this file, except for tests
   val classBTypeCache: ju.concurrent.ConcurrentHashMap[InternalName, ClassBType] =
     recordPerRunJavaMapCache(new ju.concurrent.ConcurrentHashMap[InternalName, ClassBType])
-
+  object BType {
+    val emptyArray = Array[BType]()
+    def newArray(n: Int): Array[BType] = if (n == 0) emptyArray else new Array[BType](n)
+  }
   sealed abstract class BType {
     override def toString: String = BTypeExporter.btypeToString(this)
 
@@ -793,6 +796,20 @@ abstract class BTypes {
     )
     def unapply(cr:ClassBType) = Some(cr.internalName)
 
+    /**
+     * Retrieve the `ClassBType` for the class with the given internal name, creating the entry if it doesn't
+     * already exist
+     *
+     * @param internalName The name of the class
+     * @param t            A value that will be passed to the `init` function. For efficiency, callers should use this
+     *                     value rather than capturing it in the `init` lambda, allowing that lambda to be hoisted.
+     * @param fromSymbol   Is this type being initialized from a `Symbol`, rather than from byte code?
+     * @param init         Function to initialize the info of this `BType`. During execution of this function,
+     *                     code _may_ reenter into `apply(internalName, ...)` and retrieve the initializing
+     *                     `ClassBType`.
+     * @tparam T           The type of the state that will be threaded into the `init` function.
+     * @return             The `ClassBType`
+     */
     final def apply[T](internalName: InternalName, t: T, fromSymbol: Boolean)(init: (ClassBType, T) => Either[NoClassBTypeInfo, ClassInfo]): ClassBType = {
       val cached = classBTypeCache.get(internalName)
       if (cached ne null) cached
@@ -885,17 +902,7 @@ abstract class BTypes {
     }
   }
 
-  final case class MethodBType(argumentTypes: Array[BType], returnType: BType) extends BType {
-
-  }
-  object MethodBType {
-    val emptyBTypeArray = Array[BType]()
-    @deprecated("Use primary constructor")
-    def apply(argumentTypes: List[BType], returnType: BType): MethodBType = {
-      val argumentTypesArray = if (argumentTypes.isEmpty) emptyBTypeArray else argumentTypes.toArray
-      new MethodBType(argumentTypesArray, returnType)
-    }
-  }
+  final case class MethodBType(argumentTypes: Array[BType], returnType: BType) extends BType
 
   object BTypeExporter {
     private[this] val builderTL: ThreadLocal[StringBuilder] = new ThreadLocal[StringBuilder](){

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -885,7 +885,17 @@ abstract class BTypes {
     }
   }
 
-  final case class MethodBType(argumentTypes: List[BType], returnType: BType) extends BType
+  final case class MethodBType(argumentTypes: Array[BType], returnType: BType) extends BType {
+
+  }
+  object MethodBType {
+    val emptyBTypeArray = Array[BType]()
+    @deprecated("Use primary constructor")
+    def apply(argumentTypes: List[BType], returnType: BType): MethodBType = {
+      val argumentTypesArray = if (argumentTypes.isEmpty) emptyBTypeArray else argumentTypes.toArray
+      new MethodBType(argumentTypesArray, returnType)
+    }
+  }
 
   object BTypeExporter {
     private[this] val builderTL: ThreadLocal[StringBuilder] = new ThreadLocal[StringBuilder](){

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -793,7 +793,7 @@ abstract class BTypes {
     )
     def unapply(cr:ClassBType) = Some(cr.internalName)
 
-    def apply(internalName: InternalName, fromSymbol: Boolean)(init: (ClassBType) => Either[NoClassBTypeInfo, ClassInfo]): ClassBType = {
+    final def apply[T](internalName: InternalName, t: T, fromSymbol: Boolean)(init: (ClassBType, T) => Either[NoClassBTypeInfo, ClassInfo]): ClassBType = {
       val cached = classBTypeCache.get(internalName)
       if (cached ne null) cached
       else {
@@ -805,7 +805,7 @@ abstract class BTypes {
         newRes.synchronized {
           classBTypeCache.putIfAbsent(internalName, newRes) match {
             case null =>
-              newRes._info = init(newRes)
+              newRes._info = init(newRes, t)
               newRes.checkInfoConsistency()
               newRes
           case old =>

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
@@ -64,7 +64,7 @@ abstract class BTypesFromClassfile {
    * be found in the `byteCodeRepository`, the `info` of the resulting ClassBType is undefined.
    */
   def classBTypeFromParsedClassfile(internalName: InternalName): ClassBType = {
-    ClassBType(internalName, fromSymbol = false) { res: ClassBType =>
+    ClassBType(internalName, internalName, fromSymbol = false) { (res: ClassBType, internalName) =>
       byteCodeRepository.classNode(internalName) match {
         case Left(msg) => Left(NoClassBTypeInfoMissingBytecode(msg))
         case Right(c) => computeClassInfoFromClassNode(c, res)
@@ -76,7 +76,7 @@ abstract class BTypesFromClassfile {
    * Construct the [[BTypes.ClassBType]] for a parsed classfile.
    */
   def classBTypeFromClassNode(classNode: ClassNode): ClassBType = {
-    ClassBType(classNode.name, fromSymbol = false) { res: ClassBType =>
+    ClassBType(classNode.name, classNode, fromSymbol = false) { (res: ClassBType, classNode) =>
       computeClassInfoFromClassNode(classNode, res)
     }
   }

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -102,16 +102,17 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
       val internalName = classSym.javaBinaryNameString
       // The new ClassBType is added to the map via its apply, before we set its info. This
       // allows initializing cyclic dependencies, see the comment on variable ClassBType._info.
-      val btype = ClassBType(internalName, fromSymbol = true) { res:ClassBType =>
-        if (completeSilentlyAndCheckErroneous(classSym))
-          Left(NoClassBTypeInfoClassSymbolInfoFailedSI9111(classSym.fullName))
-        else computeClassInfo(classSym, res)
-      }
+      val btype = ClassBType.apply(internalName, classSym, fromSymbol = true)(classBTypeFromSymbolInit)
       if (currentRun.compiles(classSym))
         assert(btype.fromSymbol, s"ClassBType for class being compiled was already created from a classfile: ${classSym.fullName}")
       btype
     }
   }
+
+  private val classBTypeFromSymbolInit = (res: ClassBType, classSym: Symbol) =>
+    if (completeSilentlyAndCheckErroneous(classSym))
+      Left(NoClassBTypeInfoClassSymbolInfoFailedSI9111(classSym.fullName))
+    else computeClassInfo(classSym, res)
 
   /**
    * Builds a [[MethodBType]] for a method symbol.
@@ -158,7 +159,10 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
      */
     def primitiveOrClassToBType(sym: Symbol): BType = {
       assertClassNotArray(sym)
-      primitiveTypeToBType.getOrElse(sym, classBTypeFromSymbol(sym))
+      primitiveTypeToBType.getOrElse(sym, null) match {
+        case null => classBTypeFromSymbol(sym)
+        case res => res
+      }
     }
 
     /**
@@ -612,7 +616,7 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
   def mirrorClassClassBType(moduleClassSym: Symbol): ClassBType = {
     assert(isTopLevelModuleClass(moduleClassSym), s"not a top-level module class: $moduleClassSym")
     val internalName = moduleClassSym.javaBinaryNameString.stripSuffix(nme.MODULE_SUFFIX_STRING)
-    ClassBType(internalName, fromSymbol = true) { c: ClassBType =>
+    ClassBType(internalName, moduleClassSym, fromSymbol = true) { (c: ClassBType, moduleClassSym) =>
       val shouldBeLazy = moduleClassSym.isJavaDefined || !currentRun.compiles(moduleClassSym)
       val nested = Lazy.withLockOrEager(shouldBeLazy, exitingPickler(memberClassesForInnerClassTable(moduleClassSym)) map classBTypeFromSymbol)
       Right(ClassInfo(

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -129,7 +129,17 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
     val resultType: BType =
       if (isConstructor) UNIT
       else typeToBType(tpe.resultType)
-    MethodBType(tpe.paramTypes map typeToBType, resultType)
+    val params = tpe.params
+    // OPT allocation hotspot
+    val paramBTypes = new Array[BType](params.length)
+    var i = 0
+    var these = params
+    while (i < paramBTypes.length) {
+      paramBTypes(i) = typeToBType(these.head.tpe)
+      i += 1
+      these = these.tail
+    }
+    MethodBType(paramBTypes, resultType)
   }
 
   def bootstrapMethodArg(t: Constant, pos: Position): AnyRef = t match {

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -131,14 +131,8 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
       else typeToBType(tpe.resultType)
     val params = tpe.params
     // OPT allocation hotspot
-    val paramBTypes = new Array[BType](params.length)
-    var i = 0
-    var these = params
-    while (i < paramBTypes.length) {
-      paramBTypes(i) = typeToBType(these.head.tpe)
-      i += 1
-      these = these.tail
-    }
+    val paramBTypes = BType.newArray(params.length)
+    mapToArray(params, paramBTypes, 0)(param => typeToBType(param.tpe))
     MethodBType(paramBTypes, resultType)
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -374,7 +374,7 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
     new Handle(Opcodes.H_INVOKESTATIC,
       coreBTypes.jliLambdaMetafactoryRef.internalName, sn.Metafactory.toString,
       MethodBType(
-        Array[BType](
+        Array(
           coreBTypes.jliMethodHandlesLookupRef,
           coreBTypes.StringRef,
           coreBTypes.jliMethodTypeRef,
@@ -391,7 +391,7 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
     new Handle(Opcodes.H_INVOKESTATIC,
       coreBTypes.jliLambdaMetafactoryRef.internalName, sn.AltMetafactory.toString,
       MethodBType(
-        Array[BType](
+        Array(
           coreBTypes.jliMethodHandlesLookupRef,
           coreBTypes.StringRef,
           coreBTypes.jliMethodTypeRef,
@@ -406,7 +406,7 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
     new Handle(Opcodes.H_INVOKESTATIC,
       coreBTypes.srLambdaDeserialize.internalName, sn.Bootstrap.toString,
       MethodBType(
-        Array[BType](
+        Array(
           coreBTypes.jliMethodHandlesLookupRef,
           coreBTypes.StringRef,
           coreBTypes.jliMethodTypeRef,

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -374,7 +374,7 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
     new Handle(Opcodes.H_INVOKESTATIC,
       coreBTypes.jliLambdaMetafactoryRef.internalName, sn.Metafactory.toString,
       MethodBType(
-        List(
+        Array[BType](
           coreBTypes.jliMethodHandlesLookupRef,
           coreBTypes.StringRef,
           coreBTypes.jliMethodTypeRef,
@@ -391,7 +391,7 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
     new Handle(Opcodes.H_INVOKESTATIC,
       coreBTypes.jliLambdaMetafactoryRef.internalName, sn.AltMetafactory.toString,
       MethodBType(
-        List(
+        Array[BType](
           coreBTypes.jliMethodHandlesLookupRef,
           coreBTypes.StringRef,
           coreBTypes.jliMethodTypeRef,
@@ -406,7 +406,7 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
     new Handle(Opcodes.H_INVOKESTATIC,
       coreBTypes.srLambdaDeserialize.internalName, sn.Bootstrap.toString,
       MethodBType(
-        List(
+        Array[BType](
           coreBTypes.jliMethodHandlesLookupRef,
           coreBTypes.StringRef,
           coreBTypes.jliMethodTypeRef,

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -62,10 +62,10 @@ abstract class BackendUtils extends PerRunInit {
     primitiveBoxConstructors.map(ownerDesc).toSet ++
       srRefConstructors.map(ownerDesc) ++
       tupleClassConstructors.map(ownerDesc) ++ Set(
-      (ObjectRef.internalName, MethodBType(MethodBType.emptyBTypeArray, UNIT).descriptor),
-      (StringRef.internalName, MethodBType(MethodBType.emptyBTypeArray, UNIT).descriptor),
-      (StringRef.internalName, MethodBType(Array[BType](StringRef), UNIT).descriptor),
-      (StringRef.internalName, MethodBType(Array[BType](ArrayBType(CHAR)), UNIT).descriptor))
+      (ObjectRef.internalName, MethodBType(BType.emptyArray, UNIT).descriptor),
+      (StringRef.internalName, MethodBType(BType.emptyArray, UNIT).descriptor),
+      (StringRef.internalName, MethodBType(Array(StringRef), UNIT).descriptor),
+      (StringRef.internalName, MethodBType(Array(ArrayBType(CHAR)), UNIT).descriptor))
   }
 
   private[this] lazy val classesOfSideEffectFreeConstructors: LazyVar[Set[String]] = perRunLazy(this)(sideEffectFreeConstructors.get.map(_._1))
@@ -120,7 +120,7 @@ abstract class BackendUtils extends PerRunInit {
     // stack map frames and invokes the `getCommonSuperClass` method. This method expects all
     // ClassBTypes mentioned in the source code to exist in the map.
 
-    val serlamObjDesc = MethodBType(Array[BType](jliSerializedLambdaRef), ObjectRef).descriptor
+    val serlamObjDesc = MethodBType(Array(jliSerializedLambdaRef), ObjectRef).descriptor
     val implMethodsArray = implMethods.toArray
 
     val mv = cw.visitMethod(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, "$deserializeLambda$", serlamObjDesc, null, null)

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -62,10 +62,10 @@ abstract class BackendUtils extends PerRunInit {
     primitiveBoxConstructors.map(ownerDesc).toSet ++
       srRefConstructors.map(ownerDesc) ++
       tupleClassConstructors.map(ownerDesc) ++ Set(
-      (ObjectRef.internalName, MethodBType(Nil, UNIT).descriptor),
-      (StringRef.internalName, MethodBType(Nil, UNIT).descriptor),
-      (StringRef.internalName, MethodBType(List(StringRef), UNIT).descriptor),
-      (StringRef.internalName, MethodBType(List(ArrayBType(CHAR)), UNIT).descriptor))
+      (ObjectRef.internalName, MethodBType(MethodBType.emptyBTypeArray, UNIT).descriptor),
+      (StringRef.internalName, MethodBType(MethodBType.emptyBTypeArray, UNIT).descriptor),
+      (StringRef.internalName, MethodBType(Array[BType](StringRef), UNIT).descriptor),
+      (StringRef.internalName, MethodBType(Array[BType](ArrayBType(CHAR)), UNIT).descriptor))
   }
 
   private[this] lazy val classesOfSideEffectFreeConstructors: LazyVar[Set[String]] = perRunLazy(this)(sideEffectFreeConstructors.get.map(_._1))
@@ -120,7 +120,7 @@ abstract class BackendUtils extends PerRunInit {
     // stack map frames and invokes the `getCommonSuperClass` method. This method expects all
     // ClassBTypes mentioned in the source code to exist in the map.
 
-    val serlamObjDesc = MethodBType(jliSerializedLambdaRef :: Nil, ObjectRef).descriptor
+    val serlamObjDesc = MethodBType(Array[BType](jliSerializedLambdaRef), ObjectRef).descriptor
     val implMethodsArray = implMethods.toArray
 
     val mv = cw.visitMethod(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, "$deserializeLambda$", serlamObjDesc, null, null)

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -407,6 +407,16 @@ trait Collections {
     }
     result
   }
+
+  final def mapToArray[A, B](as: List[A], arr: Array[B], i: Int)(f: A => B): Unit = {
+    var these = as
+    var index = i
+    while (!these.isEmpty) {
+      arr(index) = f(these.head)
+      index += 1
+      these = these.tail
+    }
+  }
 }
 
 object Collections extends Collections

--- a/test/junit/scala/tools/nsc/backend/jvm/BTypesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BTypesTest.scala
@@ -26,7 +26,7 @@ class BTypesTest extends BytecodeTesting {
   def o = classBTFS(jlo)
   def s = classBTFS(jls)
   def oArr = ArrayBType(o)
-  def method = MethodBType(List(oArr, INT, DOUBLE, s), UNIT)
+  def method = MethodBType(Array(oArr, INT, DOUBLE, s), UNIT)
 
   @Test
   def classBTypesEquality(): Unit = {


### PR DESCRIPTION
Allocation improvement is 0.98x:

```
[info] HotScalacBenchmark.compile:·gc.alloc.rate.norm                  ../corpus          a8c43dc                    false  2.13.2-bin-05d028e-SNAPSHOT    scalap  sample   10  192789854.118 ±    56253.073    B/op
[info] HotScalacBenchmark.compile:·gc.alloc.rate.norm                  ../corpus          a8c43dc                    false  2.13.2-bin-feb1e21-SNAPSHOT    scalap  sample   10  189227186.985 ±   352706.727    B/op
```