### PR TITLE
Reduce allocations in some hot Symbol queries

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -325,7 +325,7 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
       //
       // Analogous to this special case in ExplicitOuter: https://github.com/scala/scala/blob/d2d33ddf8c/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala#L410-L412
       // that understands that such references shouldn't give rise to outer params.
-      val enclosingStaticModules = owner.enclClassChain.filter(x => !x.hasPackageFlag && x.isModuleClass && x.isStatic)
+      val enclosingStaticModules = owner.ownersIterator.filter(x => !x.hasPackageFlag && x.isModuleClass && x.isStatic)
       enclosingStaticModules.foldLeft(tree)((tree, moduleClass) => tree.substituteThis(moduleClass, gen.mkAttributedIdent(moduleClass.sourceModule)) )
     }
 

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -107,8 +107,8 @@ abstract class Erasure extends InfoTransform
   private def isTypeParameterInSig(sym: Symbol, initialSymbol: Symbol) = (
     !sym.isHigherOrderTypeParameter &&
     sym.isTypeParameterOrSkolem && (
-      (initialSymbol.enclClassChain.exists(sym isNestedIn _)) ||
-      (initialSymbol.isMethod && initialSymbol.typeParams.contains(sym))
+      (initialSymbol.isMethod && initialSymbol.typeParams.contains(sym)) ||
+      (initialSymbol.ownersIterator.exists(encl => encl.isClass && !encl.hasPackageFlag && sym.isNestedIn(encl)))
     )
   )
 

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -403,6 +403,7 @@ trait Definitions extends api.StandardDefinitions {
 
     lazy val TypeConstraintClass   = requiredClass[scala.annotation.TypeConstraint]
     lazy val SingletonClass        = enterNewClass(ScalaPackageClass, tpnme.Singleton, AnyTpe :: Nil, ABSTRACT | TRAIT | FINAL).markAllCompleted
+    lazy val ListOfSingletonClassTpe = SingletonClass.tpe :: Nil
     lazy val SerializableClass     = requiredClass[java.io.Serializable] modifyInfo fixupAsAnyTrait
     lazy val ComparableClass       = requiredClass[java.lang.Comparable[_]] modifyInfo fixupAsAnyTrait
     lazy val JavaCloneableClass    = requiredClass[java.lang.Cloneable] modifyInfo fixupAsAnyTrait

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2399,11 +2399,12 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      *
      *  @param baseClass is a base class of this symbol's owner.
      */
-    final def overriddenSymbol(baseClass: Symbol): Symbol = (
+    final def overriddenSymbol(baseClass: Symbol): Symbol = {
       // concrete always overrides abstract, so don't let an abstract definition
       // claim to be overriding an inherited concrete one.
-      matchingInheritedSymbolIn(baseClass) filter (res => res.isDeferred || !this.isDeferred)
-    )
+      val matching = matchingInheritedSymbolIn(baseClass)
+      if (isDeferred) matching.filter(_.isDeferred) else matching
+    }
 
     private def matchingInheritedSymbolIn(baseClass: Symbol): Symbol =
       if (canMatchInheritedSymbols) matchingSymbol(baseClass, owner.thisType) else NoSymbol

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4381,7 +4381,7 @@ trait Types
     && isRawIfWithoutArgs(sym)
   )
 
-  def singletonBounds(hi: Type) = TypeBounds.upper(intersectionType(hi :: SingletonClass.tpe :: Nil))
+  def singletonBounds(hi: Type) = TypeBounds.upper(intersectionType(hi :: ListOfSingletonClassTpe))
 
   /**
    * A more persistent version of `Type#memberType` which does not require

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2872,9 +2872,16 @@ trait Types
 
     override def paramTypes = mapList(params)(symTpe) // OPT use mapList rather than .map
 
+    final def resultTypeOwnParamTypes: Type =
+      if (isTrivial || phase.erasedTypes) resultType
+      else resultType0(paramTypes)
+
     override def resultType(actuals: List[Type]) =
       if (isTrivial || phase.erasedTypes) resultType
-      else if (/*isDependentMethodType &&*/ sameLength(actuals, params)) {
+      else resultType0(actuals)
+
+    private def resultType0(actuals: List[Type]): Type =
+      if (/*isDependentMethodType &&*/ sameLength(actuals, params)) {
         val idm = new InstantiateDependentMap(params, actuals)
         val res = idm(resultType).deconst
         existentialAbstraction(idm.existentialsNeeded, res)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4540,6 +4540,21 @@ trait Types
     i.isEmpty && j.isEmpty
   }
 
+  /** Are `tps1` and `tps2` lists of pairwise equivalent symbols according to `_.tpe` ? */
+  def isSameSymbolTypes(syms1: List[Symbol], syms2: List[Symbol]): Boolean = {
+    // OPT: hand inlined (syms1 corresponds syms1)((x, y) (x.tpe =:= y.tpe)) to avoid cost of boolean unboxing (which includes
+    // a null check)
+    var i = syms1
+    var j = syms2
+    while (!(i.isEmpty || j.isEmpty)) {
+      if (!(i.head.tpe =:= j.head.tpe))
+        return false
+      i = i.tail
+      j = j.tail
+    }
+    i.isEmpty && j.isEmpty
+  }
+
   private[this] var _basetypeRecursions: Int = 0
   def basetypeRecursions = _basetypeRecursions
   def basetypeRecursions_=(value: Int) = _basetypeRecursions = value

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -170,7 +170,7 @@ trait TypeComparers {
   }
 
   private def isSameMethodType(mt1: MethodType, mt2: MethodType) = (
-       isSameTypes(mt1.paramTypes, mt2.paramTypes)
+       isSameSymbolTypes(mt1.params, mt2.params)
     && (mt1.resultType =:= mt2.resultType.substSym(mt2.params, mt1.params))
     && (mt1.isImplicit == mt2.isImplicit)
   )

--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -155,7 +155,7 @@ trait Erasure {
           if (restpe.typeSymbol == UnitClass) UnitTpe
           // this replaces each typeref that refers to an argument
           // by the type `p.tpe` of the actual argument p (p in params)
-          else apply(mt.resultType(mt.paramTypes)))
+          else apply(mt.resultTypeOwnParamTypes))
       case RefinedType(parents, decls) =>
         apply(mergeParents(parents))
       case AnnotatedType(_, atp) =>

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -274,6 +274,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.DelayedInitClass
     definitions.TypeConstraintClass
     definitions.SingletonClass
+    definitions.ListOfSingletonClassTpe
     definitions.SerializableClass
     definitions.ComparableClass
     definitions.JavaCloneableClass


### PR DESCRIPTION
In total, a 0.994x improvement in allocations.

```
[info] HotScalacBenchmark.compile:·gc.alloc.rate.norm                  ../corpus          a8c43dc                    false  2.13.2-bin-05d028e-SNAPSHOT    scalap  sample   25  192820273.616 ±   201445.686    B/op
[info] HotScalacBenchmark.compile:·gc.alloc.rate.norm                  ../corpus          a8c43dc                    false  2.13.2-bin-84512cc-SNAPSHOT    scalap  sample   25  191759047.468 ±   373873.616    B/op
```