### PR TITLE
WIP Reduce allocations in Erasure retyping by avoiding scope copying

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -705,8 +705,11 @@ trait Contexts { self: Analyzer =>
       else make(tree, owner, scope, unit)
 
     /** Make a child context that represents a new nested scope */
-    def makeNewScope(tree: Tree, owner: Symbol, reporter: ContextReporter = this.reporter): Context =
-      make(tree, owner, newNestedScope(scope), reporter = reporter)
+    def makeNewScope(tree: Tree, owner: Symbol, reporter: ContextReporter = this.reporter): Context = {
+      // OPT Erasure typer doesn't need new scopes
+      val nestedScope = if (globalPhase.isErasurePhase) scope else newNestedScope(scope)
+      make(tree, owner, nestedScope, reporter = reporter)
+    }
 
     /** Make a child context that buffers errors and warnings into a fresh report buffer. */
     def makeSilent(reportAmbiguousErrors: Boolean = ambiguousErrors, newtree: Tree = tree): Context = {

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -221,7 +221,7 @@ trait Namers extends MethodSynthesis {
     )
 
     private def allowsOverload(sym: Symbol) = (
-      sym.isSourceMethod && sym.owner.isClass && !sym.isTopLevel
+      globalPhase.isErasurePhase || (sym.isSourceMethod && sym.owner.isClass && !sym.isTopLevel)
     )
 
     private def inCurrentScope(m: Symbol): Boolean = {

--- a/src/reflect/scala/reflect/internal/Phase.scala
+++ b/src/reflect/scala/reflect/internal/Phase.scala
@@ -52,6 +52,7 @@ abstract class Phase(val prev: Phase) {
   final val flatClasses: Boolean   = ((prev ne null) && (prev ne NoPhase)) && (prev.name == "flatten"    || prev.flatClasses)
   final val specialized: Boolean   = ((prev ne null) && (prev ne NoPhase)) && (prev.name == "specialize" || prev.specialized)
   final val refChecked: Boolean    = ((prev ne null) && (prev ne NoPhase)) && (prev.name == "refchecks"  || prev.refChecked)
+  final val isErasurePhase: Boolean = name == "erasure"
 
   // are we past the fields phase, so that:
   //   - we should allow writing to vals (as part of type checking trait setters)


### PR DESCRIPTION
Allocation for compiling `catsJVM` improves by a factor 0.979x 

```
[info] HotScalacBenchmark.compile:·gc.alloc.rate.norm                       ../corpus           latest                    false  2.13.2-bin-05d028e-SNAPSHOT  @/Users/jz/code/cats/core/.jvm/target/cats-core-compile.args  sample   25  2558738109.440 ±   4386033.970    B/op
[info] HotScalacBenchmark.compile:·gc.alloc.rate.norm                       ../corpus           latest                    false  2.13.2-bin-ba0b1c4-SNAPSHOT  @/Users/jz/code/cats/core/.jvm/target/cats-core-compile.args  sample   25  2503968283.840 ±   3156812.247    B/op
```