### PR TITLE
Remove travis_wait, increasing SBT verbosity instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ jobs:
           - determineScalaVersion
           - removeExistingBuilds $integrationRepoUrl
           - if [ ! -z "$STARR_REF" ]; then buildStarr; fi
-          - travis_wait 90 buildLocker
-          - travis_wait 90 buildQuick
+          - buildLocker
+          - buildQuick
           - triggerScalaDist
           - sbt -Dscala.build.compileWithDotty=true library/compile
 
@@ -48,10 +48,10 @@ jobs:
         if: type = pull_request
         script:
           - set -e
-          - travis_wait 90 sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
+          - sbt setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
           - STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
-          - travis_wait 90 sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
-          - travis_wait 90 sbt -Dscala.build.compileWithDotty=true library/compile
+          - sbt -Dstarr.version=$STARR setupValidateTest test:compile info testAll
+          - sbt -Dscala.build.compileWithDotty=true library/compile
 
       # build the spec using jekyll
       - stage: build

--- a/scripts/jobs/integrate/windows
+++ b/scripts/jobs/integrate/windows
@@ -10,8 +10,8 @@ generateRepositoriesConfig
 SBT="java $JAVA_OPTS -Dsbt.ivy.home=$WORKSPACE/.ivy2 -jar $sbtLauncher -Dsbt.override.build.repos=true -Dsbt.repository.config=$sbtRepositoryConfig"
 
 # Build locker with STARR
-$SBT -warn "setupPublishCore" generateBuildCharacterPropertiesFile publishLocal
+$SBT "setupPublishCore" generateBuildCharacterPropertiesFile publishLocal
 
 # Build quick and run the tests
 parseScalaProperties buildcharacter.properties
-$SBT -Dstarr.version=$maven_version_number -warn "setupValidateTest" testAll
+$SBT -Dstarr.version=$maven_version_number "setupValidateTest" testAll

--- a/scripts/jobs/validate/publish-core
+++ b/scripts/jobs/validate/publish-core
@@ -17,7 +17,7 @@ case $prDryRun in
     ;;
   *)
     echo ">>> Getting Scala version number."
-    $SBT -warn "setupPublishCore $prRepoUrl" generateBuildCharacterPropertiesFile
+    $SBT "setupPublishCore $prRepoUrl" generateBuildCharacterPropertiesFile
     parseScalaProperties buildcharacter.properties # produce maven_version_number
 
     echo ">>> Checking availability of Scala ${maven_version_number} in $prRepoUrl."
@@ -28,7 +28,7 @@ case $prDryRun in
     if $libraryAvailable && $reflectAvailable && $compilerAvailable; then
       echo "Scala core already built!"
     else
-      $SBT -warn "setupPublishCore $prRepoUrl" publish
+      $SBT "setupPublishCore $prRepoUrl" publish
     fi
 
     mv buildcharacter.properties jenkins.properties # parsed by the jenkins job

--- a/scripts/jobs/validate/test
+++ b/scripts/jobs/validate/test
@@ -18,7 +18,6 @@ case $prDryRun in
     # and run JUnit tests, ScalaCheck tests, partest, OSGi tests, MiMa and scaladoc
     $SBT \
        -Dstarr.version=$scalaVersion \
-       -warn \
        "setupValidateTest $prRepoUrl" \
        $testExtraArgs \
        testAll


### PR DESCRIPTION
I'm thinking that the removal of deprecation warnings from our code base
might be the reason that we're getting less build output and needing to
resort to hacks like travis_wait.

travis_wait seems to have issues:

https://github.com/travis-ci/travis-ci/issues/8526

And travis_wait_enhanced wasn't much better.

Trying to fix errors like:

```
[warn] bnd: Invalid package name: 'scala-buildcharacter.properties'
[warn] there were 20 deprecation warnings (since 2.13.0); re-run with -deprecation for details
[warn] there were three feature warnings; re-run with -feature for details
[warn] two warnings found
/home/travis/.travis/functions: line 553:  4714 Terminated              travis_jigger "${!}" "${timeout}" "${cmd[@]}"
The command "travis_wait 90 sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal" exited with 0.
0.01s$ STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
2.13.2-bin-aa15711-SNAPSHOT
The command "STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR" exited with 0.
$ travis_wait 90 sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
```