### PR TITLE
Avoid awkward silences during CI builds which Travis finds unacceptable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ jobs:
           - determineScalaVersion
           - removeExistingBuilds $integrationRepoUrl
           - if [ ! -z "$STARR_REF" ]; then buildStarr; fi
-          - travis_wait 90 buildLocker
-          - travis_wait 90 buildQuick
+          - buildLocker
+          - buildQuick
           - triggerScalaDist
           - sbt -Dscala.build.compileWithDotty=true library/compile
 
@@ -48,10 +48,10 @@ jobs:
         if: type = pull_request
         script:
           - set -e
-          - travis_wait 90 sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
+          - sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
           - STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
-          - travis_wait 90 sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
-          - travis_wait 90 sbt -Dscala.build.compileWithDotty=true library/compile
+          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
+          - sbt -Dscala.build.compileWithDotty=true library/compile
 
       # build the spec using jekyll
       - stage: build

--- a/build.sbt
+++ b/build.sbt
@@ -1382,3 +1382,8 @@ def findJar(files: Seq[Attributed[File]], dep: ModuleID): Option[Attributed[File
 whitesourceProduct               := "Lightbend Reactive Platform"
 whitesourceAggregateProjectName  := "scala-2.13-stable"
 whitesourceIgnoredScopes         := Vector("test", "scala-tool")
+
+{
+  scala.build.TravisOutput.installIfOnTravis()
+  Nil
+}

--- a/project/TravisOutput.scala
+++ b/project/TravisOutput.scala
@@ -1,0 +1,69 @@
+package scala.build
+
+import java.util.TimerTask
+import java.io._
+import java.util.concurrent.TimeUnit
+
+// Prints some output to console periodically if the build itself is silent to avoid Travis CI's 10 minute timeout
+// from aborting the build.
+//
+// A hopefully better behaved version of travis_wait and travis_wait_enhanced.
+object TravisOutput {
+  def install(): Unit = {
+    val out = System.out
+    if (out.getClass.getName != classOf[Redirecter].getName) {
+      schedule()
+      System.setOut(new Redirecter(out))
+      savedOut = out
+    }
+  }
+
+  def installIfOnTravis(): Unit =
+    if (sys.env.contains("TRAVIS")) install()
+
+  private var savedOut: PrintStream = _
+  private val delayMS = TimeUnit.MINUTES.toMillis(9)
+  private lazy val timer = new java.util.Timer(true)
+  private var task: TimerTask = _
+
+  private def schedule(): Unit = {
+    task = new PrintNewline
+    val period = delayMS
+    timer.schedule(task, delayMS, period)
+  }
+
+  private def reschedule(): Unit = {
+    task.cancel()
+    schedule()
+  }
+
+  private class PrintNewline extends java.util.TimerTask() {
+    override def run(): Unit = {
+      savedOut.println("")
+    }
+  }
+
+  private class Redirecter(stream: PrintStream) extends PrintStream(new OutputStream {
+    def write(b: Int): Unit = {
+      reschedule()
+      stream.write(b)
+    }
+    override def write(b: Array[Byte]): Unit = {
+      reschedule()
+      stream.write(b)
+    }
+    override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+      reschedule()
+      stream.write(b, off, len)
+    }
+    override def flush(): Unit = {
+      reschedule()
+      stream.flush()
+    }
+    override def close(): Unit = {
+      reschedule()
+      stream.close()
+    }
+  })
+
+}


### PR DESCRIPTION
Recently my PRs have been plauged by these sort of errors:

```
[warn] bnd: Invalid package name: 'scala-buildcharacter.properties'
[warn] there were 20 deprecation warnings (since 2.13.0); re-run with -deprecation for details
[warn] there were three feature warnings; re-run with -feature for details
[warn] two warnings found
/home/travis/.travis/functions: line 553:  4714 Terminated              travis_jigger "${!}" "${timeout}" "${cmd[@]}"
The command "travis_wait 90 sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal" exited with 0.
0.01s$ STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
2.13.2-bin-aa15711-SNAPSHOT
The command "STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR" exited with 0.
$ travis_wait 90 sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
```


`travis_wait` seems to have [problems](https://github.com/travis-ci/travis-ci/issues/8526). `travis_wait_enhanced` traded them for its own set of problems.

This PR hijacks `System.out` in our SBT build and injects `\n` when nothing has been printed for 9 minutes.