### PR TITLE
Add typesafe bintray repo for sbt-mima-plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,6 +17,8 @@ buildInfoKeys := Seq[BuildInfoKey](buildClasspath)
 
 buildInfoPackage := "scalabuild"
 
+resolvers += Resolver.url("bintray",
+  new java.net.URL("https://dl.bintray.com/typesafe/sbt-plugins"))(Resolver.defaultIvyPatterns)
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 
 libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,6 @@ buildInfoPackage := "scalabuild"
 
 resolvers += Resolver.url("bintray",
   new java.net.URL("https://dl.bintray.com/typesafe/sbt-plugins"))(Resolver.defaultIvyPatterns)
-
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 
 libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,6 +19,7 @@ buildInfoPackage := "scalabuild"
 
 resolvers += Resolver.url("bintray",
   new java.net.URL("https://dl.bintray.com/typesafe/sbt-plugins"))(Resolver.defaultIvyPatterns)
+
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
## What changes were proposed in this pull request?
When I build this project locally. I met the exception below.

`(*:update) sbt.ResolveException: unresolved dependency: com.typesafe#sbt-mima-plugin;0.3.0: not found`
These versions of sbt-mima-plugin seems to be removed from the old repo.

This PR add typesafe bintray repo for sbt-mima-plugin.

In fact, Spark also met this issue. It was fixed by https://github.com/apache/spark/pull/26217.
I just cherry-pick it here.