### PR TITLE
Instantiate CountDownLatch in Future.never lazily

### DIFF
--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -566,7 +566,7 @@ object Future {
    */
   object never extends Future[Nothing] {
 
-    private[this] final val notGoingToHappen = new CountDownLatch(1)
+    private[this] final lazy val notGoingToHappen = new CountDownLatch(1)
 
     @throws[TimeoutException]
     @throws[InterruptedException]


### PR DESCRIPTION
This is in order to make `Future.never` work in ScalaJS. Currently using `Future.never` causes a linking error because `CountDownLatch` is not implemented for ScalaJS. See https://github.com/scala-js/scala-js/issues/3818