### PR TITLE
Show expected in AssertUtil.assertThrows

### DIFF
--- a/src/testkit/scala/tools/testkit/AssertUtil.scala
+++ b/src/testkit/scala/tools/testkit/AssertUtil.scala
@@ -87,12 +87,7 @@ object AssertUtil {
    */
   def assertThrows[T <: Throwable: ClassTag](body: => Any,
       checkMessage: String => Boolean = s => true): Unit = {
-    try {
-      body
-      fail("Expression did not throw!")
-    } catch {
-      case e: T if checkMessage(e.getMessage) =>
-    }
+    assertThrown[T](t => checkMessage(t.getMessage))(body)
   }
 
   def assertThrown[T <: Throwable: ClassTag](checker: T => Boolean)(body: => Any): Unit =
@@ -106,7 +101,7 @@ object AssertUtil {
         ae.addSuppressed(failed)
         throw ae
       case NonFatal(other) =>
-        val ae = new AssertionError(s"Exception not a ${implicitly[ClassTag[T]]}: $other")
+        val ae = new AssertionError(s"Wrong exception: expected ${implicitly[ClassTag[T]]} but was ${other.getClass.getName}")
         ae.addSuppressed(other)
         throw ae
     }

--- a/test/junit/scala/tools/testkit/AssertThrowsTest.scala
+++ b/test/junit/scala/tools/testkit/AssertThrowsTest.scala
@@ -31,14 +31,15 @@ class AssertThrowsTest {
   def catchSubclass = assertThrows[Foo] { throw new SubFoo }
 
   @Test
-  def rethrowBar =
-    assertTrue("exception wasn't rethrown", {
+  def wrongThrow =
+    assertTrue("Wrong exception thrown", {
       try {
         assertThrows[Foo] { throw new Bar }
         false
       } catch {
-        case bar: Bar => true
-        case e: Throwable => fail(s"expected Bar but got $e"); false
+        case b: Bar => fail("Bar shouldn't have been rethrown"); false
+        case e: AssertionError => true
+        case t: Throwable => fail(s"expected AssertionError but got $t"); false
       }
     })
 
@@ -71,7 +72,7 @@ class AssertThrowsTest {
     } catch {
       case ae: AssertionError =>
         assertEquals(1, ae.getSuppressed.length)
-        assertEquals("Exception not a scala.tools.testkit.AssertThrowsTest$Foo: scala.tools.testkit.AssertThrowsTest$Bar", ae.getMessage)
+        assertEquals("Wrong exception: expected scala.tools.testkit.AssertThrowsTest$Foo but was scala.tools.testkit.AssertThrowsTest$Bar", ae.getMessage)
         assertEquals(classOf[Bar], ae.getSuppressed.head.getClass)
       case t: Throwable => fail("Expected an AssertionError: $t")
     }

--- a/test/scalacheck/scala/reflect/quasiquotes/QuasiquoteProperties.scala
+++ b/test/scalacheck/scala/reflect/quasiquotes/QuasiquoteProperties.scala
@@ -68,7 +68,7 @@ trait Helpers {
       } catch {
         case u: Throwable =>
           if (!clazz.isAssignableFrom(u.getClass))
-            assert(false, s"wrong exception: $u")
+            assert(false, s"wrong exception: expected ${clazz.getName} but was ${u.getClass.getName}")
           true
       }
     if(!thrown)


### PR DESCRIPTION
Error should mention what was expected exception:

    wrong exception: expected Foo but was Bar

Current test error is simply re-throwing the failed exception:

    failed: Bar