### PR TITLE
Warnings patrol, 2.12.11 edition

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -953,23 +953,6 @@ lazy val root: Project = (project in file("."))
       state
     },
 
-    testRun := (testOnly in IntegrationTest in testP).toTask(" -- run").result.value,
-
-    testPosPres := (testOnly in IntegrationTest in testP).toTask(" -- pos presentation").result.value,
-
-    testRest := ScriptCommands.sequence[Result[Unit]](List(
-          (mimaReportBinaryIssues in library).result,
-          (mimaReportBinaryIssues in reflect).result,
-          (Keys.test in Test in junit).result,
-          (Keys.test in Test in scalacheck).result,
-          (testOnly in IntegrationTest in testP).toTask(" -- neg jvm").result,
-          (testOnly in IntegrationTest in testP).toTask(" -- res scalap specialized").result,
-          (testOnly in IntegrationTest in testP).toTask(" -- instrumented").result,
-          (testOnly in IntegrationTest in testP).toTask(" -- --srcpath scaladoc").result,
-          (Keys.test in Test in osgiTestFelix).result,
-          (Keys.test in Test in osgiTestEclipse).result)).value,
-
-    // all of testRun, testPosPres, testRest and more
     testAll := {
       val results = ScriptCommands.sequence[(Result[Unit], String)](List(
         (Keys.test in Test in junit).result map (_ -> "junit/test"),
@@ -1108,10 +1091,6 @@ lazy val mkBin = taskKey[Seq[File]]("Generate shell script (bash or Windows batc
 lazy val mkQuick = taskKey[File]("Generate a full build, including scripts, in build/quick")
 lazy val mkPack = taskKey[File]("Generate a full build, including scripts, in build/pack")
 lazy val testAll = taskKey[Unit]("Run all test tasks sequentially")
-
-lazy val testRun = taskKey[Unit]("Run compute intensive test tasks sequentially")
-lazy val testPosPres = taskKey[Unit]("Run compilation test (pos + presentation) sequentially")
-lazy val testRest = taskKey[Unit]("Run the remaining test tasks sequentially")
 
 // Defining these settings is somewhat redundant as we also redefine settings that depend on them.
 // However, IntelliJ's project import works better when these are set correctly.

--- a/src/compiler/scala/tools/nsc/plugins/Plugin.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugin.scala
@@ -14,7 +14,6 @@ package scala.tools.nsc
 package plugins
 
 import java.util.jar
-import scala.collection.JavaConverters._
 import scala.reflect.internal.util.ScalaClassLoader
 import scala.reflect.io.{AbstractFile, File, Path}
 import scala.collection.mutable
@@ -96,8 +95,8 @@ abstract class Plugin {
    * A callback to allow a plugin to customise the manifest of a jar. This is only called if the output is a jar.
    * In the case of a multi-output compile, it is called once for each output (if the output is a jar).
    * Typically this extension point is to avoid the build system having an additional step
-   * to add this information, while would otherwise require the jar to be re-built ( as the manifest is required
-   * to be the first entry in a jar.
+   * to add this information, while would otherwise require the jar to be rebuilt (as the manifest is required
+   * to be the first entry in a jar).
    * The default implementation is a NO-OP
    *
    * @param file the file that will contains this manifest. Int the case of a multi-output compile, the plugin can
@@ -108,11 +107,6 @@ abstract class Plugin {
 
 }
 
-/** ...
- *
- *  @author Lex Spoon
- *  @version 1.0, 2007-5-21
- */
 object Plugin {
 
   val PluginXML = "scalac-plugin.xml"

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -319,8 +319,8 @@ trait Definitions extends api.StandardDefinitions {
       def AnyVal_getClass = getMemberMethod(AnyValClass, nme.getClass_)
 
     // bottom types
-    lazy val RuntimeNothingClass  = getClassByName(fulltpnme.RuntimeNothing)
-    lazy val RuntimeNullClass     = getClassByName(fulltpnme.RuntimeNull)
+    lazy val RuntimeNothingClass = requiredClass[scala.runtime.Nothing$]
+    lazy val RuntimeNullClass    = requiredClass[scala.runtime.Null$]
 
     sealed abstract class BottomClassSymbol(name: TypeName, parent: Symbol) extends ClassSymbol(ScalaPackageClass, NoPosition, name) {
       locally {
@@ -509,7 +509,7 @@ trait Definitions extends api.StandardDefinitions {
 
     // XML
     lazy val ScalaXmlTopScope = getModuleIfDefined("scala.xml.TopScope")
-    lazy val ScalaXmlPackage  = getPackageIfDefined(TermName("scala.xml"))
+    lazy val ScalaXmlPackage  = getPackageIfDefined("scala.xml")
 
     // scala.reflect
     lazy val ReflectPackage              = requiredModule[scala.reflect.`package`.type]

--- a/src/reflect/scala/reflect/internal/Mirrors.scala
+++ b/src/reflect/scala/reflect/internal/Mirrors.scala
@@ -197,29 +197,35 @@ trait Mirrors extends api.Mirrors {
         case _                                                   => MissingRequirementError.notFound("package " + fullname)
       }
 
-    @deprecated("Use overload that accepts a String.", "2.13.0")
+    @deprecated("use overload that accepts a String.", since = "2.13.0")
     def getPackage(fullname: TermName): ModuleSymbol =
       getPackage(fullname.toString)
     def getPackage(fullname: String): ModuleSymbol =
       ensurePackageSymbol(fullname, getModuleOrClass(fullname, newTermName(_)), allowModules = true)
 
+    @deprecated("use overload that accepts a String.", since = "2.12.11")
     def getPackageIfDefined(fullname: TermName): Symbol =
+      getPackageIfDefined(fullname.toString)
+    def getPackageIfDefined(fullname: String): Symbol =
       wrapMissing(getPackage(fullname))
 
-    @deprecated("use getPackage", "2.11.0") def getRequiredPackage(fullname: String): ModuleSymbol =
-      getPackage(newTermNameCached(fullname))
+    @deprecated("use getPackage", "2.11.0")
+    def getRequiredPackage(fullname: String): ModuleSymbol =
+      getPackage(fullname)
 
-    def getPackageObject(fullname: String): ModuleSymbol = getPackageObject(newTermName(fullname))
+    @deprecated("use overload that accepts a String.", since = "2.12.11")
     def getPackageObject(fullname: TermName): ModuleSymbol =
-      (getPackage(fullname).packageObject) match {
+      getPackageObject(fullname.toString)
+    def getPackageObject(fullname: String): ModuleSymbol =
+      getPackage(fullname).packageObject match {
         case x: ModuleSymbol => x
         case _               => MissingRequirementError.notFound("package object " + fullname)
       }
 
-    def getPackageObjectIfDefined(fullname: String): Symbol =
-      getPackageObjectIfDefined(newTermNameCached(fullname))
-
+    @deprecated("use overload that accepts a String.", since = "2.12.11")
     def getPackageObjectIfDefined(fullname: TermName): Symbol =
+      getPackageObjectIfDefined(fullname.toString)
+    def getPackageObjectIfDefined(fullname: String): Symbol =
       wrapMissing(getPackageObject(fullname))
 
     override def staticPackage(fullname: String): ModuleSymbol =

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -80,7 +80,7 @@ trait Names extends api.Names {
     while (i < len) {
       if (nc + i == _chrs.length) {
         val newchrs = new Array[Char](_chrs.length * 2)
-        java.lang.System.arraycopy(_chrs, 0, newchrs, 0, chrs.length)
+        java.lang.System.arraycopy(_chrs, 0, newchrs, 0, _chrs.length)
         _chrs = newchrs
       }
       _chrs(nc + i) = cs(offset + i)

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1719,11 +1719,11 @@ trait Trees extends api.Trees {
     }
   }
   trait TreeStackTraverser extends Traverser {
-    import collection.mutable
-    val path: mutable.Stack[Tree] = mutable.Stack()
+    var path: List[Tree] = Nil
     abstract override def traverse(t: Tree) = {
-      path push t
-      try super.traverse(t) finally path.pop()
+      path ::= t
+      try super.traverse(t)
+      finally path = path.tail
     }
   }
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1096,7 +1096,8 @@ trait Types
     override def baseTypeSeq: BaseTypeSeq = supertype.baseTypeSeq
     override def baseTypeSeqDepth: Depth = supertype.baseTypeSeqDepth
     override def baseClasses: List[Symbol] = supertype.baseClasses
-    override def boundSyms: Set[Symbol] = emptySymbolSet
+   @deprecated("No longer used in the compiler implementation", since = "2.12.3")
+   override def boundSyms: Set[Symbol] = emptySymbolSet
  }
 
   /** A base class for types that represent a single value


### PR DESCRIPTION
The "unused import" warning in Plugin.scala was getting tiresome, and then I just followed `-deprecation` for the duration of my commute home. `[nomerge]` because 2.13.x has its own set of warnings.

