### PR TITLE
Scope: avoid accidental List allocations in matching.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -330,9 +330,12 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
    *  must-single-thread
    */
   def fieldSymbols(cls: Symbol): List[Symbol] = {
-    for (f <- cls.info.decls.toList ;
-         if !f.isMethod && f.isTerm && !f.isModule
-    ) yield f
+    var res: List[Symbol] = Nil
+    cls.info.decls.reverseIterator.foreach { f =>
+      if (!f.isMethod && f.isTerm && !f.isModule)
+        res ::= f
+    }
+    res
   }
 
   /*

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -61,7 +61,7 @@ abstract class Pickler extends SubComponent {
               val pickle = initPickle(sym) { pickle =>
                 def reserveDeclEntries(sym: Symbol): Unit = {
                   pickle.reserveEntry(sym)
-                  if (sym.isClass) sym.info.decls.foreach(reserveDeclEntries)
+                  if (sym.isClass) sym.info.decls.reverseIterator.foreach(reserveDeclEntries)
                   else if (sym.isModule) reserveDeclEntries(sym.moduleClass)
                 }
 
@@ -317,7 +317,7 @@ abstract class Pickler extends SubComponent {
         case tp: CompoundType =>
           putSymbol(tp.typeSymbol)
           putTypes(tp.parents)
-          putSymbols(tp.decls.toList)
+          tp.decls.reverseIterator.foreach(putSymbol)
         case MethodType(params, restpe) =>
           putType(restpe)
           putSymbols(params)

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -373,16 +373,14 @@ trait Implicits {
       memberWildcardType(name, mtpe)
     }
     def unapply(pt: Type): Option[(Name, List[Type], Type)] = pt match {
-      case RefinedType(List(WildcardType), decls) =>
-        decls.toList match {
-          case List(sym) =>
+      case RefinedType(List(WildcardType), decls)
+          if decls.size == 1 =>
+        val sym = decls.last
             sym.tpe match {
               case MethodType(params, restpe)
               if (params forall (_.tpe.isInstanceOf[BoundedWildcardType])) =>
                 Some((sym.name, params map (_.tpe.lowerBound), restpe))
               case _ => None
-            }
-          case _ => None
         }
       case _ => None
     }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -665,9 +665,9 @@ abstract class RefChecks extends Transform {
                 sameLength(m.tpe.typeParams, underlying.tpe.typeParams)
               }
 
-              matchingArity match {
+              if (matchingArity.size == 1){
                 // So far so good: only one candidate method
-                case Scope(concrete) =>
+                  val concrete = matchingArity.last
                   val aplIter = abstractParamLists .iterator.flatten
                   val cplIter = concrete.paramLists.iterator.flatten
                   def mismatch(apl: Symbol, cpl: Symbol): Option[(Type, Type)] =
@@ -708,8 +708,7 @@ abstract class RefChecks extends Transform {
                       msg
                     case _ => ""
                   }
-                case _ => ""
-              }
+              } else ""
             }
             else ""
           }

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -681,7 +681,7 @@ trait Definitions extends api.StandardDefinitions {
           sym.allOverriddenSymbols.contains(MacroContextPrefixType)
 
         tp.dealias match {
-          case RefinedType(List(tp), Scope(sym)) if isOneOfContextTypes(tp) && isPrefix(sym) => Some(tp)
+          case RefinedType(List(tp), scope) if isOneOfContextTypes(tp) && scope.size == 1 && isPrefix(scope.last) => Some(tp)
           case tp if isOneOfContextTypes(tp) => Some(tp)
           case _ => None
         }

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -401,6 +401,10 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
       other.reverseIterator.forall(scopeContainsSym)
     }
 
+    override def last: Symbol =
+      if (elems ne null) elems.sym
+      else throw new NoSuchElementException("last symbol of empty context")
+
     /** Return all symbols as a list in the order they were entered in this scope.
      */
     override def toList: List[Symbol] = {


### PR DESCRIPTION
Because Scopes are implemented as LIFO single-linked lists, the `toList` method of Scope needs to allocate a whole list, and should therefore be avoided.

- In the `Implicits` file, instead of toList we can just use the size to decide the branch, and the `last` method to use a single item.
- Since a Scope is a form of reversed linked list, we have direct access to its last element, so we can override the last method.
