### PR TITLE
HasTypeMember: add specialised method query.

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3269,9 +3269,9 @@ trait Types
       bound.decls enter bsym
       bound
     }
-    def unapply(tp: Type): Option[(TypeName, Type)] = tp match {
-      case RefinedType(List(WildcardType), Scope(sym)) => Some((sym.name.toTypeName, sym.info))
-      case _ => None
+    def unapply(tp: Type): Boolean = tp match {
+      case RefinedType(List(WildcardType), scope) => scope.size == 1
+      case _ => false
     }
   }
 

--- a/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
@@ -139,7 +139,7 @@ private[internal] trait TypeConstraints {
     def checkWidening(tp: Type): Unit = {
       if (TypeVar.precludesWidening(tp)) stopWidening()
       else tp match {
-        case HasTypeMember(_, _) => stopWidening()
+        case HasTypeMember() => stopWidening()
         case _ =>
       }
     }


### PR DESCRIPTION
The `unapply` method from the `HasTypeMember` object is only used once, in the `TypeConstraints` object, and just to check if it is defined or not. We add a boolean `query` method to check that, which does not need to call to `Scope.toList`.