### PR TITLE
JVM Backend: use fieldSymbolsForeach method.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -335,6 +335,12 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
     ) yield f
   }
 
+  def fieldSymbolsForeach(cls: Symbol)(act: Symbol => Unit): Unit =
+    cls.info.decls.reverseIterator.foreach { sym =>
+      if (!sym.isMethod && sym.isTerm && !sym.isModule)
+        act(sym)
+    }
+
   /*
    * can-multi-thread
    */

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -119,9 +119,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
         // TODO should we do this transformation earlier, say in Constructors? Or would that just cause
         // pain for scala-{js, native}?
 
-        for (f <- fieldSymbols(claszSymbol)) {
-          f.setFlag(Flags.STATIC)
-        }
+        fieldSymbolsForeach(claszSymbol)(_.setFlag(Flags.STATIC))
         val constructorDefDef = treeInfo.firstConstructor(cd0.impl.body).asInstanceOf[DefDef]
         val (uptoSuperStats, remainingConstrStats) = treeInfo.splitAtSuper(constructorDefDef.rhs.asInstanceOf[Block].stats, classOnly = true)
         val clInitSymbol = claszSymbol.newMethod(nme.CLASS_CONSTRUCTOR, claszSymbol.pos, Flags.STATIC).setInfo(NullaryMethodType(definitions.UnitTpe))
@@ -263,7 +261,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
     }
 
     def addClassFields(): Unit = {
-      for (f <- fieldSymbols(claszSymbol)) {
+      fieldSymbolsForeach(claszSymbol) { f =>
         val javagensig = getGenericSignature(f, claszSymbol)
         val flags = javaFieldFlags(f)
 


### PR DESCRIPTION
The two calls to `fieldSymbols` are followed with a `foreach` operation, and since `fieldSymbols` itself is a filter, we can:
- We merge the `filter` and the `foreach` in a single operation. 
- Iterate through the context reversed iterator, rather than through its `toList`.