### PR TITLE
Remove well-intentioned yet incorrect assertion

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1167,7 +1167,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         else if (shouldInsertApply(tree))
           insertApply()
         else if (hasUndetsInMonoMode) { // (9)
-          assert(!context.inTypeConstructorAllowed, context) //@M
+          // This used to have
+          //     assert(!context.inTypeConstructorAllowed, context)
+          // but that's not guaranteed to be true in the face of erroneous code; errors in typedApply might mean we
+          // never get around to inferring them, and they leak out and wind up here.
           instantiatePossiblyExpectingUnit(tree, mode, pt)
         }
         else if (tree.tpe <:< pt)

--- a/test/files/neg/t11282.check
+++ b/test/files/neg/t11282.check
@@ -1,0 +1,10 @@
+t11282.scala:4: error: Unit does not take parameters
+  a().fail[scala.Int] // error
+   ^
+t11282.scala:6: error: Unit does not take parameters
+  b().fail[scala.Int] // error
+   ^
+t11282.scala:9: error: wrong number of type parameters for method asInstanceOf of type [T0]=> T0
+  Map().empty.asInstanceOf[String, (String, String)] // error
+                          ^
+three errors found

--- a/test/files/neg/t11282.scala
+++ b/test/files/neg/t11282.scala
@@ -1,0 +1,10 @@
+// These all used to be crashers; now they're just errors.
+object t11282 {
+  def a[T] = ()
+  a().fail[scala.Int] // error
+  def b[F[_]] = ()
+  b().fail[scala.Int] // error
+}
+object t11333 {
+  Map().empty.asInstanceOf[String, (String, String)] // error
+}


### PR DESCRIPTION
The comment should explain it.

I tried very hard to play around with the inference code until `undetparams` was always empty by the type we get here, but it became complicated, and I didn't much want to change inference all that much just to deal with an erroneous condition.

Fixes scala/bug#11282.
Fixes scala/bug#11333.
Fixes scala/bug#11776, as well as I can tell with the provided code.