### PR TITLE
[WIP] Reuse arrays pickles scanner

### DIFF
--- a/src/compiler/scala/tools/nsc/util/ShowPickled.scala
+++ b/src/compiler/scala/tools/nsc/util/ShowPickled.scala
@@ -127,6 +127,7 @@ object ShowPickled extends Names {
   def printFile(buf: PickleBuffer, out: PrintStream): Unit = {
     out.println("Version " + buf.readNat() + "." + buf.readNat())
     val index = buf.createIndex
+    val indexSize = buf.getIndexSize
     val entryList = makeEntryList(buf, index)
     buf.readIndex = 0
 
@@ -278,7 +279,7 @@ object ShowPickled extends Names {
       }
     }
 
-    for (i <- 0 until index.length) printEntry(i)
+    for (i <- 0 until indexSize) printEntry(i)
   }
 
   def fromFile(path: String) = fromBytes(io.File(path).toByteArray())

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -417,6 +417,14 @@ trait Collections {
       these = these.tail
     }
   }
+
+  final def fillArray[A <: AnyRef](arr: Array[A], value: A): Unit = {
+    var ix = 0
+    while (ix < arr.length) {
+      arr(ix) = value
+      ix += 1
+    }
+  }
 }
 
 object Collections extends Collections


### PR DESCRIPTION
This PR is built on top of #8519 .

The class PickleBuffer, and its subclass Scan, are a small allocation hotspot, of `int[]`, and `Object[]` instances. This is because of: 

- The field `index` of type `int[]`, which is used to mark special stop points in the main data (the `byte[]`).
- The field `entries` of type `Array[AnyRef]`, which is created twith the same size. 

The goal of this commit is to avoid allocations in there by reusing and recycling mutable instances of the `Pickler` class. One in which we try to keep and clear and reuse the arrays that are created.

_EDIT_ The problem I did not foresee when I started was those `LazyTypeRef` inner classes, which delay a computation of `readType` and `readSymbol` (for which they need to keep the parent object unaltered).

#### Data

This was motivated by a recording session on a compilation of the `monix` project, module `coreJVM`, using an instance of the Scala compiler built from the current `2.13.x` branch.