### PR TITLE
TypeMaps: avoid allocation of Tuple2 objects.

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -500,9 +500,11 @@ private[internal] trait TypeMaps {
       *  @param   lhs    its symbol is a type parameter of `clazz`
       *  @param   rhs    a type application constructed from `clazz`
       */
-    private def correspondingTypeArgument(lhs: Type, rhs: Type): Type = {
-      val TypeRef(_, lhsSym, lhsArgs) = lhs
-      val TypeRef(_, rhsSym, rhsArgs) = rhs
+    private def correspondingTypeArgument(lhs: TypeRef, rhs: TypeRef): Type = {
+      val lhsSym  = lhs.sym
+      val lhsArgs = lhs.args
+      val rhsSym  = rhs.sym
+      val rhsArgs = rhs.args
       require(lhsSym.owner == rhsSym, s"$lhsSym is not a type parameter of $rhsSym")
 
       // Find the type parameter position; we'll use the corresponding argument.
@@ -651,7 +653,7 @@ private[internal] trait TypeMaps {
     }
 
     private def singleTypeAsSeen(tp: SingleType): Type = {
-      val SingleType(pre, sym) = tp
+      import tp.{pre, sym}
 
       val pre1 = this(pre)
       if (pre1 eq pre) tp


### PR DESCRIPTION
In the `TypeMaps` file, these calls to the unapply methods of `TypeRef` and `SingleType` was showing numerous allocations of `Tuple2` objects. Since we do not need to type-cast in this case, we can save these allocations by just  accessing the fields.

_Lead_: I noticed this in the ZMC profile of a compilation of `monix`-`coreJVM`, running it with a binary of the compiler generated from the current `2.13.x`. In this profile, the 4th entry by total allocations is 110 MB of `Tuple2` objects, of which about a quarter comes from these lines (so this may save 27 MB).

_Note_: These allocations were measured on a cold JVM, so perhaps they may be melted away on a warm compiler. Still, no harm either. Also, I have found that Continuous Integration is often served cold. 

![tuple2_typemaps](https://user-images.githubusercontent.com/1764610/68084449-e332f480-fe35-11e9-9889-f3ba728a1133.png)

