### PR TITLE
ZipArchiveFileLookup: avoid Option.withfilter

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipArchiveFileLookup.scala
@@ -50,11 +50,15 @@ trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends Efficie
     } yield createFileEntry(entry)
 
   protected def file(inPackage: PackageName, name: String): Option[FileEntryType] =
-    for {
-      dirEntry <- findDirEntry(inPackage)
-      entry <- Option(dirEntry.lookupName(name, directory = false))
-      if isRequiredFileType(entry)
-    } yield createFileEntry(entry)
+    findDirEntry(inPackage) match {
+      case Some(dirEntry) =>
+        val entry = dirEntry.lookupName(name, directory = false)
+        if (entry != null && isRequiredFileType(entry))
+          Some(createFileEntry(entry))
+        else
+          None
+      case _ => None
+    }
 
   override private[nsc] def hasPackage(pkg: PackageName) = findDirEntry(pkg).isDefined
 


### PR DESCRIPTION
Adding an `if` clause to a for comprehension on the Option data type is going to introduce a "WithFilter" object. To avoid that, we unfold the for-comprehension.

Noticed this in a profile from a cold monix compilation. Gave 8 MiB, out of a total of 3.7 Gb (.2%).