### PR TITLE
fix indentation for dotc

### DIFF
--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -589,7 +589,7 @@ object Future {
             now = System.nanoTime()
           }
           // Done waiting, drop out
-          case _: FiniteDuration => // Drop out if 0 or less
+        case _: FiniteDuration => // Drop out if 0 or less
       }
       throw new TimeoutException(s"Future timed out after [$atMost]")
     }


### PR DESCRIPTION
https://travis-ci.org/scala/scala/jobs/608501518

```
[error] -- [E040] Syntax Error: /home/travis/build/scala/scala/src/library/scala/concurrent/Future.scala:592:10 
[error] 592 |          case _: FiniteDuration => // Drop out if 0 or less
[error]     |          ^^^^
[error]     |          unindent expected, but 'case' found
```
