### PR TITLE
spec: Replace "first-order types" with "proper types"

### DIFF
--- a/spec/03-types.md
+++ b/spec/03-types.md
@@ -29,8 +29,8 @@ chapter: 3
   Types             ::=  Type {‘,’ Type}
 ```
 
-We distinguish between first-order types and type constructors, which
-take type parameters and yield types. A subset of first-order types
+We distinguish between proper types and type constructors, which
+take type parameters and yield types. A subset of proper types
 called _value types_ represents sets of (first-class) values.
 Value types are either _concrete_ or _abstract_.
 
@@ -55,7 +55,7 @@ Non-value types capture properties of identifiers that
 [are not values](#non-value-types). For example, a
 [type constructor](#type-constructors) does not directly specify a type of
 values. However, when a type constructor is applied to the correct type
-arguments, it yields a first-order type, which may be a value type.
+arguments, it yields a proper type, which may be a value type.
 
 Non-value types are expressed indirectly in Scala. E.g., a method type is
 described by writing down a method signature, which in itself is not a real

--- a/spec/04-basic-declarations-and-definitions.md
+++ b/spec/04-basic-declarations-and-definitions.md
@@ -304,7 +304,7 @@ TypeDef    ::=  id [TypeParamClause] ‘=’ Type
 
 A _type declaration_ `type $t$[$\mathit{tps}\,$] >: $L$ <: $U$` declares
 $t$ to be an abstract type with lower bound type $L$ and upper bound
-type $U$. If the type parameter clause `[$\mathit{tps}\,$]` is omitted, $t$ abstracts over a first-order type, otherwise $t$ stands for a type constructor that accepts type arguments as described by the type parameter clause.
+type $U$. If the type parameter clause `[$\mathit{tps}\,$]` is omitted, $t$ abstracts over a proper type, otherwise $t$ stands for a type constructor that accepts type arguments as described by the type parameter clause.
 
 If a type declaration appears as a member declaration of a
 type, implementations of the type may implement $t$ with any type $T$
@@ -406,7 +406,7 @@ definitions with lower bounds `>: $L$` and upper bounds
 `: $U$` and view bounds `<% $U$`
 is deferred to [here](07-implicits.html#context-bounds-and-view-bounds).
 
-The most general form of a first-order type parameter is
+The most general form of a proper type parameter is
 `$@a_1 \ldots @a_n$ $\pm$ $t$ >: $L$ <: $U$`.
 Here, $L$, and $U$ are lower and upper bounds that
 constrain possible type arguments for the parameter.  It is a

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -352,7 +352,9 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
        |    ~>'s kind is X[-F1[A1],+F2[A2]]
        |
        |This shows that `~>` accepts something of `F[A]` kind, such as
-       |`List` or `Vector`.
+       |`List` or `Vector`. It's an example of a type constructor that
+       |abstracts over type constructors, also known as a higher-order
+       |type constructor or a higher-kinded type.
        |""".stripMargin
 
   private def kindCommand(expr: String): Result = {


### PR DESCRIPTION
Refering to non type constructors as "first-order types" I think might
be why there's confusion as to what a "higher-kinded type" is.  So I
propose they're referred to as "proper types" instead.

So in terms of "kindness" it's:
* proper types, e.g. `Int`
* (first-order) type constructors, e.g. `Option`
* higher-kinded types, or higher-order type constructors, e.g. `~>`
  (the natural transformation of type constructor `F[_]` to `G[_]`)