### PR TITLE
Make compiler Scope doubly linked

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -312,6 +312,8 @@ abstract class Pickler extends SubComponent {
       }
     }
 
+    private def putSymbols(syms: Scope) =
+      syms foreach putSymbol
     private def putSymbols(syms: List[Symbol]) =
       syms foreach putSymbol
 
@@ -341,7 +343,7 @@ abstract class Pickler extends SubComponent {
         case tp: CompoundType =>
           putSymbol(tp.typeSymbol)
           putTypes(tp.parents)
-          tp.decls.toList.foreach(putDecl)
+          tp.decls.foreach(putDecl)
         case MethodType(params, restpe) =>
           putType(restpe)
           putSymbols(params)

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1075,8 +1075,8 @@ trait Contexts { self: Analyzer =>
     }
 
     private def collectImplicits(syms: Scope, pre: Type, imported: Boolean = false): List[ImplicitInfo] =
-      for (sym <- syms.toList if isQualifyingImplicit(sym.name, sym, pre, imported)) yield
-        new ImplicitInfo(sym.name, pre, sym)
+      (for (sym <- syms.iterator if isQualifyingImplicit(sym.name, sym, pre, imported)) yield
+        new ImplicitInfo(sym.name, pre, sym)).toList
 
     private def collectImplicitImports(imp: ImportInfo): List[ImplicitInfo] = if (isExcludedRootImport(imp)) List() else {
       val qual = imp.qual
@@ -1091,7 +1091,7 @@ trait Contexts { self: Analyzer =>
           // I haven't been able to boil that down the an automated test yet.
           // Looking up implicit members in the package, rather than package object, here is at least
           // consistent with what is done just below for named imports.
-          collectImplicits(qual.tpe.implicitMembers, pre, imported = true)
+          collectImplicits(qual.tpe.implicitMembers, pre, imported = true).toList
         case (sel @ ImportSelector(from, _, to, _)) :: sels1 =>
           var impls = collect(sels1).filter(_.name != from)
           if (!sel.isMask)

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -374,15 +374,12 @@ trait Implicits {
       memberWildcardType(name, mtpe)
     }
     def unapply(pt: Type): Option[(Name, List[Type], Type)] = pt match {
-      case RefinedType(List(WildcardType), decls) =>
-        decls.toList match {
-          case List(sym) =>
-            sym.tpe match {
-              case MethodType(params, restpe)
-              if (params forall (_.tpe.isInstanceOf[BoundedWildcardType])) =>
-                Some((sym.name, params map (_.tpe.lowerBound), restpe))
-              case _ => None
-            }
+      case RefinedType(List(WildcardType), decls) if decls.size == 1 =>
+        val sym = decls.elems.sym
+        sym.tpe match {
+          case MethodType(params, restpe)
+          if (params forall (_.tpe.isInstanceOf[BoundedWildcardType])) =>
+            Some((sym.name, params map (_.tpe.lowerBound), restpe))
           case _ => None
         }
       case _ => None

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -467,7 +467,8 @@ trait Namers extends MethodSynthesis {
         //      opening up the package object on the classpath at all if one exists in source.
         if (existingModule.isPackageObject) {
           val packageScope = existingModule.enclosingPackageClass.rawInfo.decls
-          packageScope.foreach(mem => if (mem.owner != existingModule.enclosingPackageClass) packageScope unlink mem)
+          val toRemove = packageScope.iterator.filter(mem => mem.owner != existingModule.enclosingPackageClass).toList
+          toRemove.foreach(packageScope.unlink(_))
         }
         updatePosFlags(existingModule, tree.pos, moduleFlags)
         setPrivateWithin(tree, existingModule)
@@ -1680,7 +1681,7 @@ trait Namers extends MethodSynthesis {
     }
     private class DefaultMethodInOwningScope(c: Context, meth: Symbol) extends DefaultGetterNamerSearch {
       private lazy val ownerNamer: Namer = {
-        val ctx = context.nextEnclosing(c => c.scope.toList.contains(meth)) // TODO use lookup rather than toList.contains
+        val ctx = context.nextEnclosing(c => c.scope.lookupSymbolEntryNoOuterScope(meth) != null)
         assert(ctx != NoContext, meth)
         newNamer(ctx)
       }

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -237,16 +237,17 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
           def transformClassDef = {
             checkCompanionNameClashes(sym)
             val decls = sym.info.decls
-            for (s <- decls) {
+            val toExpand = decls.iterator.filter { s =>
               val privateWithin = s.privateWithin
-              if (privateWithin.isClass && !s.hasFlag(EXPANDEDNAME | PROTECTED) && !privateWithin.isModuleClass &&
-                  !s.isConstructor) {
-                val savedName = s.name
-                decls.unlink(s)
-                s.expandName(privateWithin)
-                decls.enter(s)
-                log("Expanded '%s' to '%s' in %s".format(savedName, s.name, sym))
-              }
+              privateWithin.isClass && !s.hasFlag(EXPANDEDNAME | PROTECTED) && !privateWithin.isModuleClass && !s.isConstructor
+            }.toList
+            for (s <- toExpand) {
+              val privateWithin = s.privateWithin
+              val savedName = s.name
+              decls.unlink(s)
+              s.expandName(privateWithin)
+              decls.enter(s)
+              log("Expanded '%s' to '%s' in %s".format(savedName, s.name, sym))
             }
             super.transform(tree)
           }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3401,14 +3401,21 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
             (!sym.isModule || shouldAddAsModule) && (inBlock || !context.isInPackageObject(sym, context.owner))
           }
-          for (sym <- scope)  context.unit.synthetics.get(sym) match {
-            // OPT: shouldAdd is usually true. Call it here, rather than in the outer loop
-            case Some(tree) if shouldAdd(sym) =>
-              // if the completer set the IS_ERROR flag, retract the stat (currently only used by applyUnapplyMethodCompleter)
-              if (!sym.initialize.hasFlag(IS_ERROR))
-                newStats += typedStat(tree) // might add even more synthetics to the scope
-              context.unit.synthetics -= sym
-            case _ => ()
+          val toAdd = scope.iterator.flatMap {
+            sym =>
+              context.unit.synthetics.get(sym) match {
+                case s @ Some(tree) if shouldAdd(sym) =>
+                  assert(tree.symbol eq sym, (tree.symbol, sym))
+                  s
+                case _ => None
+              }
+          }.toList
+          for (tree <- toAdd) {
+            val sym = tree.symbol
+            // if the completer set the IS_ERROR flag, retract the stat (currently only used by applyUnapplyMethodCompleter)
+            if (!sym.initialize.hasFlag(IS_ERROR))
+              newStats += typedStat(tree) // might add even more synthetics to the scope
+            context.unit.synthetics -= sym
           }
           // the type completer of a synthetic might add more synthetics. example: if the
           // factory method of a case class (i.e. the constructor) has a default.

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -995,8 +995,9 @@ trait Definitions extends api.StandardDefinitions {
             // must filter out "universal" members (getClass is deferred for some reason)
             val deferredMembers =
               tpSym.info.membersBasedOnFlags(excludedFlags = BridgeAndPrivateFlags, requiredFlags = METHOD)
-              .toList
+              .iterator
               .filter(mem => mem.isDeferred && !isUniversalMember(mem))
+              .toList
 
             // if there is only one, it's monomorphic and has a single argument list
             if (deferredMembers.lengthCompare(1) == 0 &&
@@ -1340,7 +1341,7 @@ trait Definitions extends api.StandardDefinitions {
       val sym = RuntimePackageClass.newClassSymbol(tpnme.AnnotationDefaultATTR, NoPosition, 0L)
       sym setInfo ClassInfoType(List(StaticAnnotationClass.tpe), newScope, sym)
       markAllCompleted(sym)
-      RuntimePackageClass.info.decls.toList.filter(_.name == sym.name) match {
+      RuntimePackageClass.info.decls.lookup(sym.name).alternatives match {
         case existing :: _ =>
           existing.asInstanceOf[ClassSymbol]
         case _ =>

--- a/src/reflect/scala/reflect/internal/Depth.scala
+++ b/src/reflect/scala/reflect/internal/Depth.scala
@@ -62,4 +62,12 @@ object Depth {
     }
     mm
   }
+
+  def maximumBy[A](iterator: Iterator[A])(ff: DepthFunction[A]): Depth = {
+    var mm: Depth = Zero
+    while (iterator.hasNext){
+      mm = mm max ff(iterator.next())
+    }
+    mm
+  }
 }

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -221,6 +221,7 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
     /** remove entry
      */
     def unlink(e: ScopeEntry): Unit = {
+      require(e.owner == this, "Scope entries may not be unlinked via nested scopes.")
       if (elems == e) {
         elems = e.next
       } else {

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2124,9 +2124,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         }
       }
     }
-    private final def caseFieldAccessorsUnsorted: List[Symbol] = info.decls.toList.filter(_.isCaseAccessorMethod)
+    private final def caseFieldAccessorsUnsorted: List[Symbol] = info.decls.iterator.filter(_.isCaseAccessorMethod).toList
 
-    final def constrParamAccessors: List[Symbol] = info.decls.toList.filter(sym => !sym.isMethod && sym.isParamAccessor)
+    final def constrParamAccessors: List[Symbol] = info.decls.iterator.filter(sym => !sym.isMethod && sym.isParamAccessor).toList
 
     /** The symbol accessed by this accessor (getter or setter) function. */
     final def accessed: Symbol = {

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4462,6 +4462,7 @@ trait Types
 
   private def infoTypeDepth(sym: Symbol): Depth = typeDepth(sym.info)
   private def symTypeDepth(syms: List[Symbol]): Depth  = Depth.maximumBy(syms)(infoTypeDepth)
+  private def symTypeDepthIterator(syms: Iterator[Symbol]): Depth = Depth.maximumBy(syms)(infoTypeDepth)
   private def baseTypeSeqDepth(tps: List[Type]): Depth = Depth.maximumBy(tps)((t: Type) => t.baseTypeSeqDepth)
 
   /** Is intersection of given types populated? That is,
@@ -5287,7 +5288,7 @@ trait Types
   /** The maximum depth of type `tp` */
   final def typeDepth(tp: Type): Depth = tp match {
     case TypeRef(pre, sym, args)          => typeDepth(pre) max maxDepth(args).incr
-    case RefinedType(parents, decls)      => maxDepth(parents) max symTypeDepth(decls.toList).incr
+    case RefinedType(parents, decls)      => maxDepth(parents) max symTypeDepthIterator(decls.iterator).incr
     case TypeBounds(lo, hi)               => typeDepth(lo) max typeDepth(hi)
     case MethodType(paramtypes, result)   => typeDepth(result)
     case NullaryMethodType(result)        => typeDepth(result)

--- a/test/junit/scala/reflect/internal/ScopeTest.scala
+++ b/test/junit/scala/reflect/internal/ScopeTest.scala
@@ -39,10 +39,5 @@ class ScopeTest {
     // Symbols entered in the nested scope aren't visible in the outer.
     assertTrue(nested.containsName(baz.name))
     assertTrue(!outer.containsName(baz.name))
-
-    // Unlinking a symbol in the inner scope doesn't modify the outer
-    nested.unlink(bar)
-    assertFalse(nested.containsName(bar.name))
-    assertTrue(outer.containsName(bar.name))
   }
 }


### PR DESCRIPTION
This avoids the need to materialize a temporary list to iterate through the
elements in insertion order.

The internally cached `List[Symbol]` is removed, and operations are all now
based on iterators.

The iterators will fail fast when a scope is mutated during iteration. So
far, I've found a few use sites that needed refactoring to avoid this
problem.

The previous definition of `size` was inconsistent with
`iterator.size`, as the latter only considered elements owned by the
current scope (ie, not ones from outer scopes in1 which this scope is
nested with `newNestedScope`). After reviewing its usage in the compiler,
I've redefined it only consider direct elements.