### PR TITLE
Remove NameOps implicit class (syntax extension)

### DIFF
--- a/src/compiler/scala/reflect/reify/phases/Reshape.scala
+++ b/src/compiler/scala/reflect/reify/phases/Reshape.scala
@@ -262,7 +262,7 @@ trait Reshape {
             val name = defdef.name.toString.substring(prefix.length)
             def uncapitalize(s: String) = if (s.length == 0) "" else { val chars = s.toCharArray; chars(0) = chars(0).toLower; new String(chars) }
             def findValDef(name: String) = symdefs.values collectFirst {
-              case vdef: ValDef if vdef.name.dropLocal string_== name => vdef
+              case vdef: ValDef if NameOps.dropLocal(vdef.name) string_== name => vdef
             }
             val valdef = findValDef(name).orElse(findValDef(uncapitalize(name))).orNull
             if (valdef != null) accessors(valdef) = accessors.getOrElse(valdef, Nil) :+ defdef
@@ -290,7 +290,7 @@ trait Reshape {
             mods
           }
           val mods2 = toPreTyperModifiers(mods1, vdef.symbol)
-          val name1 = name.dropLocal
+          val name1 = NameOps.dropLocal(name)
           val vdef1 = ValDef(mods2, name1.toTermName, tpt, rhs)
           if (reifyDebug) println("resetting visibility of field: %s => %s".format(vdef, vdef1))
           Some(vdef1) // no copyAttrs here, because new ValDef and old symbols are now out of sync

--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -272,7 +272,7 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
     }
     val ownerName = nonLocalEnclosingMember(fun.symbol.originalOwner).name match {
       case nme.CONSTRUCTOR => nme.NEWkw // do as javac does for the suffix, prefer "new" to "$lessinit$greater$1"
-      case x => x.dropLocal
+      case x => NameOps.dropLocal(x)
     }
     val newName = nme.ANON_FUN_NAME.append(nme.NAME_JOIN_STRING).append(ownerName)
     mkMethodForFunctionBody(localTyper)(owner, fun, newName)(additionalFlags = ARTIFACT)

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -185,8 +185,10 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
 
   def getClassSymbol(name: String): Symbol = {
     name match {
-      case name if name.endsWith(nme.MODULE_SUFFIX_STRING) => rootMirror getModuleByName newTermName(name).dropModule
-      case name                           => classNameToSymbol(name)
+      case name if name.endsWith(nme.MODULE_SUFFIX_STRING) =>
+        rootMirror getModuleByName NameOps.dropModule(newTermName(name))
+      case name =>
+        classNameToSymbol(name)
     }
   }
 

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -479,7 +479,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
     def usesSpecializedField = intoConstructor.usesSpecializedField
 
     // The constructor parameter corresponding to an accessor
-    def parameter(acc: Symbol): Symbol = parameterNamed(acc.unexpandedName.getterName)
+    def parameter(acc: Symbol): Symbol = parameterNamed(NameOps.getterName(acc.unexpandedName))
 
     // The constructor parameter with given name. This means the parameter
     // has given name, or starts with given name, and continues with a `$` afterwards.
@@ -726,7 +726,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
 
         // sometimes acc is a field with a local name (when it's a val/var constructor param) --> exclude the `acc` itself when looking for conflicting decl
         // sometimes it's not (just a constructor param) --> any conflicting decl is a problem
-        val conflict = clazz.info.decl(acc.name.localName).filter(sym => sym ne acc)
+        val conflict = clazz.info.decl(NameOps.localName(acc.name)).filter(sym => sym ne acc)
         if (conflict ne NoSymbol) {
           val orig = exitingTyper(clazz.info.nonPrivateMember(acc.name).filter(_ hasFlag ACCESSOR))
           reporter.error(acc.pos, s"parameter '${acc.name}' requires field but conflicts with ${(orig orElse conflict).fullLocationString}")

--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -265,7 +265,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
       // Add setter for an immutable, memoizing getter
       // (can't emit during namers because we don't yet know whether it's going to be memoized or not)
       val setterFlags = (getter.flags & ~(STABLE | PrivateLocal | OVERRIDE | IMPLICIT | FINAL)) | MUTABLE | ACCESSOR | TRAIT_SETTER_FLAGS
-      val setterName  = nme.expandedSetterName(getter.name.setterName, clazz)
+      val setterName  = nme.expandedSetterName(NameOps.setterName(getter.name), clazz)
       val setter      = clazz.newMethod(setterName, getter.pos.focus, setterFlags)
       val fieldTp     = fieldTypeForGetterIn(getter, clazz.thisType)
       // println(s"newTraitSetter in $clazz for $getter = $setterName : $fieldTp")

--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -298,11 +298,11 @@ abstract class LambdaLift extends InfoTransform {
 
                   // TODO do we need to preserve pre-erasure info for the accessors (and a NullaryMethodType for the getter)?
                   // can't have a field in the trait, so add a setter
-                  val setter = owner.newMethod(nme.expandedSetterName(proxyName.setterName, owner), fv.pos, accessorFlags)
+                  val setter = owner.newMethod(nme.expandedSetterName(NameOps.setterName(proxyName), owner), fv.pos, accessorFlags)
                   setter setInfoAndEnter MethodType(setter.newSyntheticValueParams(List(fv.info)), UnitTpe)
 
                   // the getter serves as the proxy -- entered below
-                  owner.newMethod(proxyName.getterName, fv.pos, accessorFlags | STABLE) setInfo MethodType(Nil, fv.info)
+                  owner.newMethod(NameOps.getterName(proxyName), fv.pos, accessorFlags | STABLE) setInfo MethodType(Nil, fv.info)
                 } else
                   owner.newValue(proxyName.toTermName, fv.pos, newFlags.toLong | PrivateLocal) setInfo fv.info
 

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -506,7 +506,7 @@ abstract class Mixin extends Transform with ast.TreeDSL with AccessorSynthesis {
           // only consider usages from non-transient lazy vals (scala/bug#9365)
           val singlyUsedIn = usedIn.filter {
             case (_, member :: Nil) if member.name.endsWith(nme.LAZY_SLOW_SUFFIX) =>
-              val lazyAccessor = member.owner.info.decl(member.name.stripSuffix(nme.LAZY_SLOW_SUFFIX))
+              val lazyAccessor = member.owner.info.decl(NameOps.stripSuffix(member.name, nme.LAZY_SLOW_SUFFIX))
               !lazyAccessor.accessedOrSelf.hasAnnotation(TransientAttr)
             case _ => false
           }.toMap

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -379,9 +379,9 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     if (name == nme.CONSTRUCTOR || (types1.isEmpty && types2.isEmpty))
       name.toTermName
     else if (nme.isSetterName(name))
-      specializedName(name.getterName, types1, types2).setterName
+      NameOps.setterName(specializedName(NameOps.getterName(name), types1, types2))
     else if (nme.isLocalName(name))
-      specializedName(name.getterName, types1, types2).localName
+      NameOps.localName(specializedName(NameOps.getterName(name), types1, types2))
     else {
       val (base, cs, ms) = nme.splitSpecializedName(name)
       newTermName(base.toString + "$"

--- a/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MethodSynthesis.scala
@@ -215,7 +215,7 @@ trait MethodSynthesis {
 
           val rhs =
             if (tree.mods.isDeferred) EmptyTree
-            else if (isSetter) Apply(Ident(tree.name.setterName), List(Ident(setterParam)))
+            else if (isSetter) Apply(Ident(NameOps.setterName(tree.name)), List(Ident(setterParam)))
             else Select(This(owner), tree.name)
 
           val sym = createMethod(tree, name, derivedPos, tree.mods.flags & BeanPropertyFlags)

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -574,7 +574,7 @@ trait Namers extends MethodSynthesis {
         if (!s.isWildcard && base != ErrorType) {
           if (isValid(from)) {
             // for Java code importing Scala objects
-            if (!nme.isModuleName(from) || isValid(from.dropModule)) {
+            if (!nme.isModuleName(from) || isValid(NameOps.dropModule(from))) {
               typer.TyperErrorGen.NotAMemberError(tree, expr, from, context.outer)
             }
           }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -605,7 +605,7 @@ abstract class RefChecks extends Transform {
           }
           // Group missing members by the name of the underlying symbol,
           // to consolidate getters and setters.
-          val grouped = missing groupBy (_.name.getterName)
+          val grouped = missing groupBy (x => NameOps.getterName(x.name))
           val missingMethods = grouped.toList flatMap {
             case (name, syms) =>
               if (syms exists (_.isSetter)) syms filterNot (_.isGetter)
@@ -641,7 +641,7 @@ abstract class RefChecks extends Transform {
 
             // Give a specific error message for abstract vars based on why it fails:
             // It could be unimplemented, have only one accessor, or be uninitialized.
-            val groupedAccessors = grouped.getOrElse(member.name.getterName, Nil)
+            val groupedAccessors = grouped.getOrElse(NameOps.getterName(member.name), Nil)
             val isMultiple = groupedAccessors.size > 1
 
             if (groupedAccessors.exists(_.isSetter) || (member.isGetter && !isMultiple && member.setterIn(member.owner).exists)) {

--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -127,7 +127,9 @@ trait SyntheticMethods extends ast.TreeDSL {
 
     def productElementNameMethod = {
       val constrParamAccessors = clazz.constrParamAccessors
-      createSwitchMethod(nme.productElementName, constrParamAccessors.indices, StringTpe)(idx => LIT(constrParamAccessors(idx).name.dropLocal.decode))
+      createSwitchMethod(nme.productElementName, constrParamAccessors.indices, StringTpe){ idx =>
+        LIT(NameOps.dropLocal(constrParamAccessors(idx).name).decode)
+      }
     }
 
     var syntheticCanEqual = false

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -682,13 +682,13 @@ trait TypeDiagnostics {
             else if (
               sym.isVar
                 || sym.isGetter && (sym.accessed.isVar || (sym.owner.isTrait && !sym.hasFlag(STABLE)))
-            ) s"var ${sym.name.getterName.decoded}"
+            ) s"var ${NameOps.getterName(sym.name).decoded}"
             else if (
               sym.isVal
                 || sym.isGetter && (sym.accessed.isVal || (sym.owner.isTrait && sym.hasFlag(STABLE)))
                 || sym.isLazy
             ) s"val ${sym.name.decoded}"
-            else if (sym.isSetter) { cond = valAdvice ; s"var ${sym.name.getterName.decoded}" }
+            else if (sym.isSetter) { cond = valAdvice ; s"var ${NameOps.getterName(sym.name).decoded}" }
             else if (sym.isMethod) s"method ${sym.name.decoded}"
             else if (sym.isModule) s"object ${sym.name.decoded}"
             else "term"

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3374,7 +3374,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
             // ValDef and Accessor
             case (ValDef(_, cname, _, _), DefDef(_, dname, _, _, _, _)) =>
-              cname.getterName == dname.getterName
+              NameOps.getterName(cname) == NameOps.getterName(dname)
 
             case _ => false
           }
@@ -4576,7 +4576,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         if (treeInfo.mayBeVarGetter(varsym)) {
           lhs1 match {
             case treeInfo.Applied(Select(qual, _), _, _) =>
-              val sel = Select(qual, varsym.name.setterName) setPos lhs.pos
+              val sel = Select(qual, NameOps.setterName(varsym.name)) setPos lhs.pos
               val app = Apply(sel, List(rhs)) setPos tree.pos
               return typed(app, mode, pt)
 
@@ -4994,7 +4994,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       }
 
       def convertToAssignment(fun: Tree, qual: Tree, name: Name, args: List[Tree]): Tree = {
-        val prefix = name.toTermName stripSuffix nme.EQL
+        val prefix = NameOps.stripSuffix(name.toTermName, nme.EQL)
         def mkAssign(vble: Tree): Tree =
           Assign(
             vble,

--- a/src/interactive/scala/tools/nsc/interactive/CompilerControl.scala
+++ b/src/interactive/scala/tools/nsc/interactive/CompilerControl.scala
@@ -281,7 +281,7 @@ trait CompilerControl { self: Global =>
     val tpe: Type
     val accessible: Boolean
     def implicitlyAdded = false
-    def symNameDropLocal: Name = if (sym.name.isTermName) sym.name.dropLocal else sym.name
+    def symNameDropLocal: Name = if (sym.name.isTermName) NameOps.dropLocal(sym.name) else sym.name
 
     private def accessible_s = if (accessible) "" else "[inaccessible] "
     def forceInfoString = {

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1200,7 +1200,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
 
       {
         candidate: Name =>
-          def candidateChunks = camelComponents(candidate.dropLocal.toString, allowSnake)
+          def candidateChunks = camelComponents(NameOps.dropLocal(candidate).toString, allowSnake)
           // Loosely based on IntelliJ's autocompletion: the user can just write everything in
           // lowercase, as we'll let `isl` match `GenIndexedSeqLike` or `isLovely`.
           def lenientMatch(entered: String, candidate: List[String], matchCount: Int): Boolean = {

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -37,8 +37,8 @@ trait Printers extends api.Printers { self: SymbolTable =>
 
   private def symNameInternal(tree: Tree, name: Name, decoded: Boolean): String = {
     val sym     = tree.symbol
-    def qname   = quotedName(name.dropLocal, decoded)
-    def qowner  = quotedName(sym.owner.name.dropLocal, decoded)
+    def qname   = quotedName(NameOps.dropLocal(name), decoded)
+    def qowner  = quotedName(NameOps.dropLocal(sym.owner.name), decoded)
     def qsymbol = quotedName(sym.nameString)
 
     if (sym == null || sym == NoSymbol)

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -312,7 +312,7 @@ trait StdNames {
 
     final val scala_ : NameType = "scala"
 
-    def dropSingletonName(name: Name): TypeName = (name dropRight SINGLETON_SUFFIX.length).toTypeName
+    def dropSingletonName(name: Name): TypeName = NameOps.dropRight(name, SINGLETON_SUFFIX.length).toTypeName
     def singletonName(name: Name): TypeName     = (name append SINGLETON_SUFFIX).toTypeName
   }
 
@@ -389,7 +389,7 @@ trait StdNames {
     val MIXIN_CONSTRUCTOR: NameType        = "$init$"
     val MODULE_INSTANCE_FIELD: NameType    = NameTransformer.MODULE_INSTANCE_NAME  // "MODULE$"
     val OUTER: NameType                    = "$outer"
-    val OUTER_LOCAL: NameType              = OUTER.localName
+    val OUTER_LOCAL: NameType              = NameOps.localName(OUTER)
     val OUTER_ARG: NameType                = "arg" + OUTER
     val OUTER_SYNTH: NameType              = "<outer>" // emitted by virtual pattern matcher, replaced by outer accessor in explicitouter
     val ROOTPKG: NameType                  = "_root_"
@@ -461,17 +461,17 @@ trait StdNames {
         var idx = idx0
         while (idx > 0 && name.charAt(idx - 1) == '$')
           idx -= 1
-        name drop idx + 2
+        NameOps.drop(name, idx + 2)
     }
 
     @deprecated("use unexpandedName", "2.11.0") def originalName(name: Name): Name            = unexpandedName(name)
-    @deprecated("use Name#dropModule", "2.11.0") def stripModuleSuffix(name: Name): Name      = name.dropModule
-    @deprecated("use Name#dropLocal", "2.11.0") def localToGetter(name: TermName): TermName   = name.dropLocal
-    @deprecated("use Name#dropLocal", "2.11.0") def dropLocalSuffix(name: Name): TermName     = name.dropLocal
-    @deprecated("use Name#localName", "2.11.0") def getterToLocal(name: TermName): TermName   = name.localName
-    @deprecated("use Name#setterName", "2.11.0") def getterToSetter(name: TermName): TermName = name.setterName
-    @deprecated("use Name#getterName", "2.11.0") def getterName(name: TermName): TermName     = name.getterName
-    @deprecated("use Name#getterName", "2.11.0") def setterToGetter(name: TermName): TermName = name.getterName
+    @deprecated("use Name#dropModule", "2.11.0") def stripModuleSuffix(name: Name): Name      = NameOps.dropModule(name)
+    @deprecated("use Name#dropLocal", "2.11.0") def localToGetter(name: TermName): TermName   = NameOps.dropLocal(name)
+    @deprecated("use Name#dropLocal", "2.11.0") def dropLocalSuffix(name: Name): TermName     = NameOps.dropLocal(name)
+    @deprecated("use Name#localName", "2.11.0") def getterToLocal(name: TermName): TermName   = NameOps.localName(name)
+    @deprecated("use Name#setterName", "2.11.0") def getterToSetter(name: TermName): TermName = NameOps.setterName(name)
+    @deprecated("use Name#getterName", "2.11.0") def getterName(name: TermName): TermName     = NameOps.getterName(name)
+    @deprecated("use Name#getterName", "2.11.0") def setterToGetter(name: TermName): TermName = NameOps.getterName(name)
 
     /**
      * Convert `Tuple2$mcII` to `Tuple2`, or `T1$sp` to `T1`.
@@ -497,7 +497,7 @@ trait StdNames {
     def splitSpecializedName(name: Name): (Name, String, String) =
       // DUPLICATED LOGIC WITH `unspecializedName`
     if (name endsWith SPECIALIZED_SUFFIX) {
-      val name1 = name dropRight SPECIALIZED_SUFFIX.length
+      val name1 = NameOps.dropRight(name, SPECIALIZED_SUFFIX.length)
       val idxC  = name1 lastIndexOf 'c'
       val idxM  = name1 lastIndexOf 'm'
 
@@ -520,7 +520,7 @@ trait StdNames {
         nme.CONSTRUCTOR
       else name indexOf DEFAULT_GETTER_STRING match {
         case -1  => name.toTermName
-        case idx => name.toTermName take idx
+        case idx => NameOps.take(name.toTermName, idx)
       }
     )
 
@@ -529,7 +529,7 @@ trait StdNames {
         if (name.startsWith(DEFAULT_GETTER_INIT_STRING)) (nme.CONSTRUCTOR, DEFAULT_GETTER_INIT_STRING.length)
         else name.indexOf(DEFAULT_GETTER_STRING) match {
           case -1  => (name.toTermName, -1)
-          case idx => (name.toTermName.take(idx), idx + DEFAULT_GETTER_STRING.length)
+          case idx => (NameOps.take(name.toTermName, idx), idx + DEFAULT_GETTER_STRING.length)
         }
       if (i >= 0) (n, name.encoded.substring(i).toInt) else (n, -1)
     }
@@ -942,7 +942,7 @@ trait StdNames {
     val toCharacter: NameType = "toCharacter"
     val toInteger: NameType   = "toInteger"
 
-    def newLazyValSlowComputeName(lzyValName: Name) = (lzyValName stripSuffix MODULE_VAR_SUFFIX append LAZY_SLOW_SUFFIX).toTermName
+    def newLazyValSlowComputeName(lzyValName: Name) = (NameOps.stripSuffix(lzyValName, MODULE_VAR_SUFFIX) append LAZY_SLOW_SUFFIX).toTermName
 
     // ASCII names for operators
     val ADD       = encode("+")

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1278,7 +1278,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     )
     /** These should be moved somewhere like JavaPlatform.
      */
-    def javaSimpleName: Name = addModuleSuffix(simpleName.dropLocal)
+    def javaSimpleName: Name = addModuleSuffix(NameOps.dropLocal(simpleName))
     def javaBinaryName: Name = name.newName(javaBinaryNameString)
     def javaBinaryNameString: String = {
       if (javaBinaryNameStringCache == null)
@@ -2119,7 +2119,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       //
       // The slightly more principled approach of using the paramss of the
       // primary constructor leads to cycles in, for example, pos/t5084.scala.
-      val primaryNames = constrParamAccessors map (_.name.dropLocal)
+      val primaryNames = constrParamAccessors map (x => NameOps.dropLocal(x.name))
       def nameStartsWithOrigDollar(name: Name, prefix: Name) =
         name.startsWith(prefix) && name.length > prefix.length + 1 && name.charAt(prefix.length) == '$'
       caseFieldAccessorsUnsorted.sortBy { acc =>
@@ -2517,9 +2517,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     final def getterIn(base: Symbol): Symbol =
       base.info decl getterName filter (_.hasAccessorFlag)
 
-    def getterName: TermName = name.getterName
-    def setterName: TermName = name.setterName
-    def localName: TermName  = name.localName
+    def getterName: TermName = NameOps.getterName(name)
+    def setterName: TermName = NameOps.setterName(name)
+    def localName: TermName  = NameOps.localName(name)
 
     @deprecated("use `setterIn` instead", "2.11.0")
     final def setter(base: Symbol, hasExpandedName: Boolean = needsExpandedSetterName): Symbol =
@@ -2721,7 +2721,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      *  If settings.Yshowsymkinds, adds abbreviated symbol kind.
      */
     def nameString: String = {
-      val name_s = if (settings.debug.value) "" + unexpandedName else unexpandedName.dropLocal.decode
+      val name_s = if (settings.debug.value) "" + unexpandedName else NameOps.dropLocal(unexpandedName).decode
       val kind_s = if (settings.Yshowsymkinds.value) "#" + abbreviatedKindString else ""
 
       name_s + idString + kind_s
@@ -2754,7 +2754,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         val kind = kindString
         val _name: String =
           if (hasMeaninglessName) owner.decodedName + idString
-          else if (simplifyNames && (kind == "variable" || kind == "value")) unexpandedName.getterName.decode.toString // TODO: make condition less gross?
+          else if (simplifyNames && (kind == "variable" || kind == "value"))
+            NameOps.getterName(unexpandedName).decode.toString // TODO: make condition less gross?
           else nameString
 
         compose(kind, _name)

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -479,7 +479,7 @@ abstract class TreeInfo {
       case _: ValDef | _: TypeDef => true
       // keep valdef or getter for val/var
       case dd: DefDef if dd.mods.hasAccessorFlag => !nme.isSetterName(dd.name) && !tbody.exists {
-        case vd: ValDef => dd.name == vd.name.dropLocal
+        case vd: ValDef => dd.name == NameOps.dropLocal(vd.name)
         case _ => false
       }
       case md: MemberDef => !md.mods.isSynthetic
@@ -495,7 +495,7 @@ abstract class TreeInfo {
     def recoverBody(body: List[Tree]) = body map {
       case vd @ ValDef(vmods, vname, _, vrhs) if nme.isLocalName(vname) =>
         tbody find {
-          case dd: DefDef => dd.name == vname.dropLocal
+          case dd: DefDef => dd.name == NameOps.dropLocal(vname)
           case _ => false
         } map { dd =>
           val DefDef(dmods, dname, _, _, _, drhs) = dd

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -263,9 +263,9 @@ trait Trees extends api.Trees {
 
   trait NameTree extends Tree with NameTreeApi {
     def name: Name
-    def getterName: TermName = name.getterName
-    def setterName: TermName = name.setterName
-    def localName: TermName = name.localName
+    def getterName: TermName = NameOps.getterName(name)
+    def setterName: TermName = NameOps.setterName(name)
+    def localName: TermName = NameOps.localName(name)
   }
 
   trait RefTree extends SymTree with NameTree with RefTreeApi {

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -980,7 +980,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
       val ownerModule: ModuleSymbol =
         if (split > 0) packageNameToScala(fullname take split) else this.RootPackage
       val owner = ownerModule.moduleClass
-      val name = TermName(fullname) drop split + 1
+      val name = NameOps.drop(TermName(fullname), split + 1)
       // Be tolerant of clashes between, e.g. a subpackage and a package object member. These could arise
       // under separate compilation.
       val opkg = owner.info.decl(name).filter(_.hasPackageFlag)
@@ -1029,10 +1029,10 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
         def lookupClass = {
           def coreLookup(name: Name): Symbol =
             owner.info.decl(name) orElse {
-              if (name.startsWith(nme.NAME_JOIN_STRING)) coreLookup(name drop 1) else NoSymbol
+              if (name.startsWith(nme.NAME_JOIN_STRING)) coreLookup(NameOps.drop(name, 1)) else NoSymbol
             }
           if (nme.isModuleName(simpleName))
-            coreLookup(simpleName.dropModule.toTermName) map (_.moduleClass)
+            coreLookup(NameOps.dropModule(simpleName).toTermName) map (_.moduleClass)
           else
             coreLookup(simpleName)
         }
@@ -1316,7 +1316,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
      */
     def fieldToJava(fld: TermSymbol): jField = fieldCache.toJava(fld) {
       val jclazz = classToJava(fld.owner.asClass)
-      val jname = fld.name.dropLocal.toString
+      val jname = NameOps.dropLocal(fld.name).toString
       try jclazz getDeclaredField jname
       catch {
         case ex: NoSuchFieldException => jclazz getDeclaredField expandedName(fld)
@@ -1329,7 +1329,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
     def methodToJava(meth: MethodSymbol): jMethod = methodCache.toJava(meth) {
       val jclazz = classToJava(meth.owner.asClass)
       val paramClasses = transformedType(meth).paramTypes map typeToJavaClass
-      val jname = meth.name.dropLocal.toString
+      val jname = NameOps.dropLocal(meth.name).toString
       try jclazz getDeclaredMethod (jname, paramClasses: _*)
       catch {
         case ex: NoSuchMethodException =>

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -209,6 +209,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.NoSymbol
     this.CyclicReference
     this.SymbolOps
+    this.NameOps
     this.TermName
     this.TypeName
     this.Liftable

--- a/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
+++ b/src/repl/scala/tools/nsc/interpreter/MemberHandlers.scala
@@ -53,7 +53,7 @@ trait MemberHandlers {
           //   scala> val xxx = ""
           //   scala> def foo: x<TAB>
           if (name.endsWith(IMain.DummyCursorFragment)) {
-            val stripped = name.stripSuffix(IMain.DummyCursorFragment)
+            val stripped = NameOps.stripSuffix(name, IMain.DummyCursorFragment)
             importVars += stripped
           }
         }
@@ -212,7 +212,7 @@ trait MemberHandlers {
     private def isFlattenedSymbol(sym: Symbol) =
       sym.owner.isPackageClass &&
         sym.name.containsName(nme.NAME_JOIN_STRING) &&
-        sym.owner.info.member(sym.name.take(sym.name.indexOf(nme.NAME_JOIN_STRING))) != NoSymbol
+        sym.owner.info.member(NameOps.take(sym.name, sym.name.indexOf(nme.NAME_JOIN_STRING)) ) != NoSymbol
 
     private def importableTargetMembers =
       importableMembers(exitingTyper(targetType)).filterNot(isFlattenedSymbol).toList

--- a/test/files/run/reflection-names.scala
+++ b/test/files/run/reflection-names.scala
@@ -5,9 +5,9 @@ object Test {
   import global._
 
   val x1 = "abc" drop 1                    // "bc": String
-  val x2 = TermName("abc") drop 1          // "bc": TermName
-  val x3 = TypeName("abc") drop 1          // "bc": TypeName
-  val x4 = (TypeName("abc"): Name) drop 1  // "bc": Name
+  val x2 = NameOps.drop(TermName("abc"), 1)  // "bc": TermName
+  val x3 = NameOps.drop(TypeName("abc"), 1)  // "bc": TypeName
+  val x4 = NameOps.drop(TypeName("abc"), 1)  // "bc": Name
 
   def main(args: Array[String]): Unit = {
     List(x1, x2, x3, x4) foreach (x => println(x.getClass.getName, x))


### PR DESCRIPTION
The `NameOps` implicit class is used to provide some extension methods to the Name classes and subclasses. However, because of some problem of outer references (being defined in a cake slice) they could not be turned into a plain `AnyVal`, so there was an allocation cost to them.

While that allocation cost was not significant (0.2%), nevertheless it is easily avoidable, by just adding some syntactic salt and vinegar to our cake.

