### PR TITLE
[nomerge] workaround for SDKMAN getting stuck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,11 @@ before_install:
   - "[[ -d $HOME/.sdkman/bin/ ]] || rm -rf $HOME/.sdkman/"
   - curl -sL https://get.sdkman.io | bash
   - echo sdkman_auto_answer=true > $HOME/.sdkman/etc/config
+  - echo sdkman_auto_selfupdate=true >> $HOME/.sdkman/etc/config
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
 
 install:
-  - sdk install java $(sdk list java | grep -o "$ADOPTOPENJDK\.[0-9\.]*hs-adpt" | head -1)
+  - sdk install java $(sdk list java | grep -o "$ADOPTOPENJDK\.[0-9\.]*hs-adpt" | head -1) | true
   - unset JAVA_HOME
   - java -Xmx32m -version
   - javac -J-Xmx32m -version


### PR DESCRIPTION
backport of #8528
fixes scala/scala-dev#659

---

Currently SDKMAN blocks for prompt when there's a new version of SDKMAN.

```
$ sdk list java
...
ATTENTION: A new version of SDKMAN is available...

The current version is 5.7.4+362, but you have 5.7.3+337.

Would you like to upgrade now? (Y/n):
```

This in turn blocks our automated AdoptOpenJDK installation script:

```
sdk install java $(sdk list java | grep -o "$ADOPTOPENJDK\.[0-9\.]*hs-adpt" | head -1)
```

An additional setting `sdkman_auto_selfupdate=true` is needed so it's updated automatically.

This also adds `| true` to `sdk install` because it started to return 1 if the same Jave version is already installed.

(cherry picked from commit 43b11a38b0ae0213e33eb3b9d50d47900d09707b)