### PR TITLE
Get rid of the last implicit conversions from String to Names.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
@@ -35,32 +35,32 @@ abstract class SymbolicXMLBuilder(p: Parsers#Parser, preserveWS: Boolean) {
   private[parser] var isPattern: Boolean = _
 
   private object xmltypes extends TypeNames {
-    val _Comment: NameType             = "Comment"
-    val _Elem: NameType                = "Elem"
-    val _EntityRef: NameType           = "EntityRef"
-    val _Group: NameType               = "Group"
-    val _MetaData: NameType            = "MetaData"
-    val _NamespaceBinding: NameType    = "NamespaceBinding"
-    val _NodeBuffer: NameType          = "NodeBuffer"
-    val _PCData: NameType              = "PCData"
-    val _PrefixedAttribute: NameType   = "PrefixedAttribute"
-    val _ProcInstr: NameType           = "ProcInstr"
-    val _Text: NameType                = "Text"
-    val _Unparsed: NameType            = "Unparsed"
-    val _UnprefixedAttribute: NameType = "UnprefixedAttribute"
+    val _Comment: NameType             = nameType("Comment")
+    val _Elem: NameType                = nameType("Elem")
+    val _EntityRef: NameType           = nameType("EntityRef")
+    val _Group: NameType               = nameType("Group")
+    val _MetaData: NameType            = nameType("MetaData")
+    val _NamespaceBinding: NameType    = nameType("NamespaceBinding")
+    val _NodeBuffer: NameType          = nameType("NodeBuffer")
+    val _PCData: NameType              = nameType("PCData")
+    val _PrefixedAttribute: NameType   = nameType("PrefixedAttribute")
+    val _ProcInstr: NameType           = nameType("ProcInstr")
+    val _Text: NameType                = nameType("Text")
+    val _Unparsed: NameType            = nameType("Unparsed")
+    val _UnprefixedAttribute: NameType = nameType("UnprefixedAttribute")
   }
 
   private object xmlterms extends TermNames {
-    val _Null: NameType     = "Null"
-    val __Elem: NameType    = "Elem"
-    val _PCData: NameType   = "PCData"
-    val __Text: NameType    = "Text"
-    val _buf: NameType      = "$buf"
-    val _md: NameType       = "$md"
-    val _plus: NameType     = "$amp$plus"
-    val _scope: NameType    = "$scope"
-    val _tmpscope: NameType = "$tmpscope"
-    val _xml: NameType      = "xml"
+    val _Null: NameType     = nameType("Null")
+    val __Elem: NameType    = nameType("Elem")
+    val _PCData: NameType   = nameType("PCData")
+    val __Text: NameType    = nameType("Text")
+    val _buf: NameType      = nameType("$buf")
+    val _md: NameType       = nameType("$md")
+    val _plus: NameType     = nameType("$amp$plus")
+    val _scope: NameType    = nameType("$scope")
+    val _tmpscope: NameType = nameType("$tmpscope")
+    val _xml: NameType      = nameType("xml")
   }
 
   import xmltypes.{

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -337,7 +337,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
         val macroImplRef = macroCompiler.resolveMacroImpl
         if (macroImplRef.isEmpty) fail() else {
           def hasTypeTag = {
-            val marker = NoSymbol.newErrorValue("restricted")
+            val marker = NoSymbol.newErrorValue(TermName("restricted"))
             val xformed = transformTypeTagEvidenceParams(macroImplRef, (_, _) => marker)
             xformed.nonEmpty && xformed.last.contains(marker)
           }

--- a/src/reflect/scala/reflect/api/Names.scala
+++ b/src/reflect/scala/reflect/api/Names.scala
@@ -41,19 +41,27 @@ import scala.language.implicitConversions
  *  @group ReflectionAPI
  */
 trait Names {
-  /** An implicit conversion from String to TermName.
-   * Enables an alternative notation `"map": TermName` as opposed to `TermName("map")`.
-   * @group Names
+  /** A former implicit conversion from String to TermName.
+   *
+   *  This used to be an implicit conversion, enabling an alternative notation
+   *  `"map": TermName` as opposed to `TermName("map")`. It is only kept for
+   *  binary compatibility reasons, and should not be used anymore.
+   *
+   *  @group Names
    */
-  @deprecated("use explicit `TermName(s)` instead", "2.11.0")
-  implicit def stringToTermName(s: String): TermName = TermName(s)
+  @deprecated("use `TermName(s)` instead", "2.11.0")
+  def stringToTermName(s: String): TermName = TermName(s)
 
-  /** An implicit conversion from String to TypeName.
-   * Enables an alternative notation `"List": TypeName` as opposed to `TypeName("List")`.
-   * @group Names
+  /** A former implicit conversion from String to TypeName.
+   *
+   *  This used to be an implicit conversion, enabling an alternative notation
+   *  `"List": TypeName` as opposed to `TypeName("List")`. It is only kept for
+   *  binary compatibility reasons, and should not be used anymore.
+   *
+   *  @group Names
    */
-  @deprecated("use explicit `TypeName(s)` instead", "2.11.0")
-  implicit def stringToTypeName(s: String): TypeName = TypeName(s)
+  @deprecated("use `TypeName(s)` instead", "2.11.0")
+  def stringToTypeName(s: String): TypeName = TypeName(s)
 
   /** The abstract type of names.
    *  @group Names

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -88,14 +88,12 @@ trait StdNames {
 
   abstract class CommonNames extends NamesApi {
     type NameType >: Null <: Name
-    // Masking some implicits so as to allow our targeted => NameType.
-    protected val stringToTermName = null
-    protected val stringToTypeName = null
-    protected implicit def createNameType(name: String): NameType
+    protected def nameType(name: String): NameType
 
     def flattenedName(owner: Symbol, name: Name): NameType = {
       val flat = owner.name.toString + NAME_JOIN_STRING + name.toString
-      if (owner.isJava) flat else compactify(flat) // scala/bug#11277
+      val nameString = if (owner.isJava) flat else compactify(flat) // scala/bug#11277
+      nameType(nameString)
     }
 
     // TODO: what is the purpose of all this duplication!?!?!
@@ -108,18 +106,18 @@ trait StdNames {
     final val TRAIT_SETTER_SEPARATOR_STRING    = NameTransformer.TRAIT_SETTER_SEPARATOR_STRING
     final val SINGLETON_SUFFIX                 = ".type"
 
-    val ANON_CLASS_NAME: NameType              = "$anon"
-    val DELAMBDAFY_LAMBDA_CLASS_NAME: NameType = "$lambda"
-    val ANON_FUN_NAME: NameType                = "$anonfun"
-    val EMPTY: NameType                        = ""
-    val EMPTY_PACKAGE_NAME: NameType           = "<empty>"
-    val IMPORT: NameType                       = "<import>"
-    val MODULE_SUFFIX_NAME: NameType           = MODULE_SUFFIX_STRING
-    val MODULE_VAR_SUFFIX: NameType            = MODULE_VAR_SUFFIX_STRING
-    val PACKAGE: NameType                      = "package"
-    val ROOT: NameType                         = "<root>"
-    val SPECIALIZED_SUFFIX: NameType           = "$sp"
-    val CASE_ACCESSOR: NameType                = "$access"
+    val ANON_CLASS_NAME: NameType              = nameType("$anon")
+    val DELAMBDAFY_LAMBDA_CLASS_NAME: NameType = nameType("$lambda")
+    val ANON_FUN_NAME: NameType                = nameType("$anonfun")
+    val EMPTY: NameType                        = nameType("")
+    val EMPTY_PACKAGE_NAME: NameType           = nameType("<empty>")
+    val IMPORT: NameType                       = nameType("<import>")
+    val MODULE_SUFFIX_NAME: NameType           = nameType(MODULE_SUFFIX_STRING)
+    val MODULE_VAR_SUFFIX: NameType            = nameType(MODULE_VAR_SUFFIX_STRING)
+    val PACKAGE: NameType                      = nameType("package")
+    val ROOT: NameType                         = nameType("<root>")
+    val SPECIALIZED_SUFFIX: NameType           = nameType("$sp")
+    val CASE_ACCESSOR: NameType                = nameType("$access")
 
     val NESTED_IN: String                      = "$nestedIn"
     val NESTED_IN_ANON_CLASS: String           = NESTED_IN + ANON_CLASS_NAME.toString.replace("$", "")
@@ -140,35 +138,35 @@ trait StdNames {
 
     // value types (and AnyRef) are all used as terms as well
     // as (at least) arguments to the @specialize annotation.
-    final val Boolean: NameType = "Boolean"
-    final val Byte: NameType    = "Byte"
-    final val Char: NameType    = "Char"
-    final val Double: NameType  = "Double"
-    final val Float: NameType   = "Float"
-    final val Int: NameType     = "Int"
-    final val Long: NameType    = "Long"
-    final val Short: NameType   = "Short"
-    final val Unit: NameType    = "Unit"
+    final val Boolean: NameType = nameType("Boolean")
+    final val Byte: NameType    = nameType("Byte")
+    final val Char: NameType    = nameType("Char")
+    final val Double: NameType  = nameType("Double")
+    final val Float: NameType   = nameType("Float")
+    final val Int: NameType     = nameType("Int")
+    final val Long: NameType    = nameType("Long")
+    final val Short: NameType   = nameType("Short")
+    final val Unit: NameType    = nameType("Unit")
 
     // some types whose companions we utilize
-    final val AnyRef: NameType        = "AnyRef"
-    final val Array: NameType         = "Array"
-    final val List: NameType          = "List"
-    final val Option: NameType        = "Option"
-    final val Seq: NameType           = "Seq"
-    final val Symbol: NameType        = "Symbol"
-    final val WeakTypeTag: NameType   = "WeakTypeTag"
-    final val TypeTag : NameType      = "TypeTag"
-    final val Expr: NameType          = "Expr"
-    final val String: NameType        = "String"
+    final val AnyRef: NameType        = nameType("AnyRef")
+    final val Array: NameType         = nameType("Array")
+    final val List: NameType          = nameType("List")
+    final val Option: NameType        = nameType("Option")
+    final val Seq: NameType           = nameType("Seq")
+    final val Symbol: NameType        = nameType("Symbol")
+    final val WeakTypeTag: NameType   = nameType("WeakTypeTag")
+    final val TypeTag : NameType      = nameType("TypeTag")
+    final val Expr: NameType          = nameType("Expr")
+    final val String: NameType        = nameType("String")
 
     // some names whose name we utilize
-    final val StringContextName: NameType = "StringContext"
+    final val StringContextName: NameType = nameType("StringContext")
 
     // fictions we use as both types and terms
-    final val ERROR: NameType    = "<error>"
-    final val NO_NAME: NameType  = "<none>"  // formerly NOSYMBOL
-    final val WILDCARD: NameType = "_"
+    final val ERROR: NameType    = nameType("<error>")
+    final val NO_NAME: NameType  = nameType("<none>")  // formerly NOSYMBOL
+    final val WILDCARD: NameType = nameType("_")
   }
 
   /** This should be the first trait in the linearization. */
@@ -237,80 +235,80 @@ trait StdNames {
   abstract class TypeNames extends Keywords with TypeNamesApi {
     override type NameType = TypeName
 
-    protected implicit def createNameType(name: String): TypeName = newTypeNameCached(name)
+    protected def nameType(name: String): TypeName = newTypeNameCached(name)
 
-    final val BYNAME_PARAM_CLASS_NAME: NameType        = "<byname>"
-    final val JAVA_REPEATED_PARAM_CLASS_NAME: NameType = "<repeated...>"
-    final val LOCAL_CHILD: NameType                    = "<local child>"
-    final val REFINE_CLASS_NAME: NameType              = "<refinement>"
-    final val REPEATED_PARAM_CLASS_NAME: NameType      = "<repeated>"
-    final val WILDCARD_STAR: NameType                  = "_*"
-    final val REIFY_TREECREATOR_PREFIX: NameType       = "$treecreator"
-    final val REIFY_TYPECREATOR_PREFIX: NameType       = "$typecreator"
-    final val MACRO_BUNDLE_SUFFIX: NameType            = "$Bundle"
+    final val BYNAME_PARAM_CLASS_NAME: NameType        = nameType("<byname>")
+    final val JAVA_REPEATED_PARAM_CLASS_NAME: NameType = nameType("<repeated...>")
+    final val LOCAL_CHILD: NameType                    = nameType("<local child>")
+    final val REFINE_CLASS_NAME: NameType              = nameType("<refinement>")
+    final val REPEATED_PARAM_CLASS_NAME: NameType      = nameType("<repeated>")
+    final val WILDCARD_STAR: NameType                  = nameType("_*")
+    final val REIFY_TREECREATOR_PREFIX: NameType       = nameType("$treecreator")
+    final val REIFY_TYPECREATOR_PREFIX: NameType       = nameType("$typecreator")
+    final val MACRO_BUNDLE_SUFFIX: NameType            = nameType("$Bundle")
 
-    final val Any: NameType             = "Any"
-    final val AnyVal: NameType          = "AnyVal"
-    final val App: NameType             = "App"
-    final val FlagSet: NameType         = "FlagSet"
-    final val Mirror: NameType          = "Mirror"
-    final val Modifiers: NameType       = "Modifiers"
-    final val Nothing: NameType         = "Nothing"
-    final val Null: NameType            = "Null"
-    final val Object: NameType          = "Object"
-    final val PrefixType: NameType      = "PrefixType"
-    final val Product: NameType         = "Product"
-    final val Serializable: NameType    = "Serializable"
-    final val Singleton: NameType       = "Singleton"
-    final val Throwable: NameType       = "Throwable"
-    final val unchecked: NameType       = "unchecked"
-    final val ValueOf: NameType         = "ValueOf"
+    final val Any: NameType             = nameType("Any")
+    final val AnyVal: NameType          = nameType("AnyVal")
+    final val App: NameType             = nameType("App")
+    final val FlagSet: NameType         = nameType("FlagSet")
+    final val Mirror: NameType          = nameType("Mirror")
+    final val Modifiers: NameType       = nameType("Modifiers")
+    final val Nothing: NameType         = nameType("Nothing")
+    final val Null: NameType            = nameType("Null")
+    final val Object: NameType          = nameType("Object")
+    final val PrefixType: NameType      = nameType("PrefixType")
+    final val Product: NameType         = nameType("Product")
+    final val Serializable: NameType    = nameType("Serializable")
+    final val Singleton: NameType       = nameType("Singleton")
+    final val Throwable: NameType       = nameType("Throwable")
+    final val unchecked: NameType       = nameType("unchecked")
+    final val ValueOf: NameType         = nameType("ValueOf")
 
-    final val api: NameType                 = "api"
-    final val Annotation: NameType          = "Annotation"
-    final val CaseDef: NameType             = "CaseDef"
-    final val ClassManifest: NameType       = "ClassManifest"
-    final val Enum: NameType                = "Enum"
-    final val Group: NameType               = "Group"
-    final val implicitNotFound: NameType    = "implicitNotFound"
-    final val Liftable: NameType            = "Liftable"
-    final val Unliftable: NameType          = "Unliftable"
-    final val Name: NameType                = "Name"
-    final val StaticAnnotation: NameType    = "StaticAnnotation"
-    final val Tree: NameType                = "Tree"
-    final val Text: NameType                = "Text"
-    final val TermName: NameType            = "TermName"
-    final val Type : NameType               = "Type"
-    final val TypeName: NameType            = "TypeName"
-    final val TypeDef: NameType             = "TypeDef"
-    final val Quasiquote: NameType          = "Quasiquote"
+    final val api: NameType                 = nameType("api")
+    final val Annotation: NameType          = nameType("Annotation")
+    final val CaseDef: NameType             = nameType("CaseDef")
+    final val ClassManifest: NameType       = nameType("ClassManifest")
+    final val Enum: NameType                = nameType("Enum")
+    final val Group: NameType               = nameType("Group")
+    final val implicitNotFound: NameType    = nameType("implicitNotFound")
+    final val Liftable: NameType            = nameType("Liftable")
+    final val Unliftable: NameType          = nameType("Unliftable")
+    final val Name: NameType                = nameType("Name")
+    final val StaticAnnotation: NameType    = nameType("StaticAnnotation")
+    final val Tree: NameType                = nameType("Tree")
+    final val Text: NameType                = nameType("Text")
+    final val TermName: NameType            = nameType("TermName")
+    final val Type : NameType               = nameType("Type")
+    final val TypeName: NameType            = nameType("TypeName")
+    final val TypeDef: NameType             = nameType("TypeDef")
+    final val Quasiquote: NameType          = nameType("Quasiquote")
 
     // quasiquote-specific names
-    final val QUASIQUOTE_FUNCTION: NameType     = "$quasiquote$function$"
-    final val QUASIQUOTE_MODS: NameType         = "$quasiquote$mods$"
-    final val QUASIQUOTE_TUPLE: NameType        = "$quasiquote$tuple$"
+    final val QUASIQUOTE_FUNCTION: NameType     = nameType("$quasiquote$function$")
+    final val QUASIQUOTE_MODS: NameType         = nameType("$quasiquote$mods$")
+    final val QUASIQUOTE_TUPLE: NameType        = nameType("$quasiquote$tuple$")
 
     // Annotation simple names, used in Namer
-    final val BeanPropertyAnnot: NameType = "BeanProperty"
-    final val BooleanBeanPropertyAnnot: NameType = "BooleanBeanProperty"
+    final val BeanPropertyAnnot: NameType        = nameType("BeanProperty")
+    final val BooleanBeanPropertyAnnot: NameType = nameType("BooleanBeanProperty")
 
     // Classfile Attributes
-    final val AnnotationDefaultATTR: NameType      = "AnnotationDefault"
-    final val BridgeATTR: NameType                 = "Bridge"
-    final val CodeATTR: NameType                   = "Code"
-    final val ConstantValueATTR: NameType          = "ConstantValue"
-    final val DeprecatedATTR: NameType             = "Deprecated"
-    final val ExceptionsATTR: NameType             = "Exceptions"
-    final val InnerClassesATTR: NameType           = "InnerClasses"
-    final val MethodParametersATTR: NameType       = "MethodParameters"
-    final val RuntimeAnnotationATTR: NameType      = "RuntimeVisibleAnnotations"   // RetentionPolicy.RUNTIME
-    final val ScalaATTR: NameType                  = "Scala"
-    final val ScalaSignatureATTR: NameType         = "ScalaSig"
-    final val SignatureATTR: NameType              = "Signature"
-    final val SourceFileATTR: NameType             = "SourceFile"
-    final val SyntheticATTR: NameType              = "Synthetic"
+    final val AnnotationDefaultATTR: NameType      = nameType("AnnotationDefault")
+    final val BridgeATTR: NameType                 = nameType("Bridge")
+    final val CodeATTR: NameType                   = nameType("Code")
+    final val ConstantValueATTR: NameType          = nameType("ConstantValue")
+    final val DeprecatedATTR: NameType             = nameType("Deprecated")
+    final val ExceptionsATTR: NameType             = nameType("Exceptions")
+    final val InnerClassesATTR: NameType           = nameType("InnerClasses")
+    final val MethodParametersATTR: NameType       = nameType("MethodParameters")
+    final val RuntimeAnnotationATTR: NameType      = nameType("RuntimeVisibleAnnotations") // RetentionPolicy.RUNTIME
+    final val ScalaATTR: NameType                  = nameType("Scala")
+    final val ScalaSignatureATTR: NameType         = nameType("ScalaSig")
+    final val SignatureATTR: NameType              = nameType("Signature")
+    final val SourceFileATTR: NameType             = nameType("SourceFile")
+    final val SyntheticATTR: NameType              = nameType("Synthetic")
 
-    final val scala_ : NameType = "scala"
+    final val scala_ : NameType = nameType("scala")
 
     def dropSingletonName(name: Name): TypeName = (name dropRight SINGLETON_SUFFIX.length).toTypeName
     def singletonName(name: Name): TypeName     = (name append SINGLETON_SUFFIX).toTypeName
@@ -319,19 +317,7 @@ trait StdNames {
   abstract class TermNames extends Keywords with TermNamesApi {
     override type NameType = TermName
 
-    protected implicit def createNameType(name: String): TermName = newTermNameCached(name)
-    // create a name with leading dollar, avoiding the appearance that
-    // interpolation of a value (possibly named "value") was intended
-    private class NameContext(s: String) {
-      def n(args: Any*): TermName = {
-        require(args.isEmpty, "Interpolating args in a name is not supported")
-        createNameType("$" + s)
-      }
-    }
-    private def StringContext(parts: String*) = {
-      require(parts.size == 1, "Interpolating multiple parts in a name is not supported")
-      new NameContext(parts.head)
-    }
+    protected def nameType(name: String): TermName = newTermNameCached(name)
 
     /** Base strings from which synthetic names are derived. */
     val BITMAP_PREFIX                  = "bitmap$"
@@ -357,52 +343,52 @@ trait StdNames {
     val STABILIZER_PREFIX              = "stabilizer$"
 
     // Compiler internal names
-    val ANYname: NameType                  = "<anyname>"
-    val CONSTRUCTOR: NameType              = "<init>"
-    val CLASS_CONSTRUCTOR: NameType        = "<clinit>"
-    val DEFAULT_CASE: NameType             = "defaultCase$"
-    val EQEQ_LOCAL_VAR: NameType           = "eqEqTemp$"
-    val FAKE_LOCAL_THIS: NameType          = "this$"
-    val LAZY_SLOW_SUFFIX: NameType         = "$lzycompute"
-    val UNIVERSE_BUILD_PREFIX: NameType    = "$u.internal.reificationSupport."
-    val UNIVERSE_PREFIX: NameType          = "$u."
-    val UNIVERSE_SHORT: NameType           = "$u"
-    val MIRROR_PREFIX: NameType            = "$m."
-    val MIRROR_SHORT: NameType             = "$m"
-    val MIRROR_UNTYPED: NameType           = "$m$untyped"
-    val REIFY_FREE_PREFIX: NameType        = "free$"
-    val REIFY_FREE_THIS_SUFFIX: NameType   = "$this"
-    val REIFY_FREE_VALUE_SUFFIX: NameType  = n"value"      // looks like missing interpolator due to `value` in scopre
-    val REIFY_SYMDEF_PREFIX: NameType      = "symdef$"
-    val QUASIQUOTE_CASE: NameType          = "$quasiquote$case$"
-    val QUASIQUOTE_EARLY_DEF: NameType     = "$quasiquote$early$def$"
+    val ANYname: NameType                  = nameType("<anyname>")
+    val CONSTRUCTOR: NameType              = nameType("<init>")
+    val CLASS_CONSTRUCTOR: NameType        = nameType("<clinit>")
+    val DEFAULT_CASE: NameType             = nameType("defaultCase$")
+    val EQEQ_LOCAL_VAR: NameType           = nameType("eqEqTemp$")
+    val FAKE_LOCAL_THIS: NameType          = nameType("this$")
+    val LAZY_SLOW_SUFFIX: NameType         = nameType("$lzycompute")
+    val UNIVERSE_BUILD_PREFIX: NameType    = nameType("$u.internal.reificationSupport.")
+    val UNIVERSE_PREFIX: NameType          = nameType("$u.")
+    val UNIVERSE_SHORT: NameType           = nameType("$u")
+    val MIRROR_PREFIX: NameType            = nameType("$m.")
+    val MIRROR_SHORT: NameType             = nameType("$m")
+    val MIRROR_UNTYPED: NameType           = nameType("$m$untyped")
+    val REIFY_FREE_PREFIX: NameType        = nameType("free$")
+    val REIFY_FREE_THIS_SUFFIX: NameType   = nameType("$this")
+    val REIFY_FREE_VALUE_SUFFIX: NameType  = nameType("$" + "value") // looks like missing interpolator due to `value` in scopre
+    val REIFY_SYMDEF_PREFIX: NameType      = nameType("symdef$")
+    val QUASIQUOTE_CASE: NameType          = nameType("$quasiquote$case$")
+    val QUASIQUOTE_EARLY_DEF: NameType     = nameType("$quasiquote$early$def$")
     val QUASIQUOTE_FILE: String            = "<quasiquote>"
-    val QUASIQUOTE_FOR_ENUM: NameType      = "$quasiquote$for$enum$"
+    val QUASIQUOTE_FOR_ENUM: NameType      = nameType("$quasiquote$for$enum$")
     val QUASIQUOTE_NAME_PREFIX: String     = "nn$"
-    val QUASIQUOTE_PACKAGE_STAT: NameType  = "$quasiquote$package$stat$"
-    val QUASIQUOTE_PARAM: NameType         = "$quasiquote$param$"
-    val QUASIQUOTE_PAT_DEF: NameType       = "$quasiquote$pat$def$"
+    val QUASIQUOTE_PACKAGE_STAT: NameType  = nameType("$quasiquote$package$stat$")
+    val QUASIQUOTE_PARAM: NameType         = nameType("$quasiquote$param$")
+    val QUASIQUOTE_PAT_DEF: NameType       = nameType("$quasiquote$pat$def$")
     val QUASIQUOTE_PREFIX: String          = "qq$"
-    val QUASIQUOTE_REFINE_STAT: NameType   = "$quasiquote$refine$stat$"
-    val QUASIQUOTE_TUPLE: NameType         = "$quasiquote$tuple$"
+    val QUASIQUOTE_REFINE_STAT: NameType   = nameType("$quasiquote$refine$stat$")
+    val QUASIQUOTE_TUPLE: NameType         = nameType("$quasiquote$tuple$")
     val QUASIQUOTE_UNLIFT_HELPER: String   = "$quasiquote$unlift$helper$"
-    val MIXIN_CONSTRUCTOR: NameType        = "$init$"
-    val MODULE_INSTANCE_FIELD: NameType    = NameTransformer.MODULE_INSTANCE_NAME  // "MODULE$"
-    val OUTER: NameType                    = "$outer"
+    val MIXIN_CONSTRUCTOR: NameType        = nameType("$init$")
+    val MODULE_INSTANCE_FIELD: NameType    = nameType(NameTransformer.MODULE_INSTANCE_NAME) // "MODULE$"
+    val OUTER: NameType                    = nameType("$outer")
     val OUTER_LOCAL: NameType              = OUTER.localName
-    val OUTER_ARG: NameType                = "arg" + OUTER
-    val OUTER_SYNTH: NameType              = "<outer>" // emitted by virtual pattern matcher, replaced by outer accessor in explicitouter
-    val ROOTPKG: NameType                  = "_root_"
-    val SELECTOR_DUMMY: NameType           = "<unapply-selector>"
-    val SELF: NameType                     = "$this"
-    val SETTER_SUFFIX: NameType            = NameTransformer.SETTER_SUFFIX_STRING
-    val SPECIALIZED_INSTANCE: NameType     = "specInstance$"
-    val STAR: NameType                     = "*"
-    val THIS: NameType                     = "_$this"
+    val OUTER_ARG: NameType                = nameType("arg" + OUTER)
+    val OUTER_SYNTH: NameType              = nameType("<outer>") // emitted by virtual pattern matcher, replaced by outer accessor in explicitouter
+    val ROOTPKG: NameType                  = nameType("_root_")
+    val SELECTOR_DUMMY: NameType           = nameType("<unapply-selector>")
+    val SELF: NameType                     = nameType("$this")
+    val SETTER_SUFFIX: NameType            = nameType(NameTransformer.SETTER_SUFFIX_STRING)
+    val SPECIALIZED_INSTANCE: NameType     = nameType("specInstance$")
+    val STAR: NameType                     = nameType("*")
+    val THIS: NameType                     = nameType("_$this")
 
 
-    val annottees: NameType               = "annottees"       // for macro annotations
-    val macroTransform: NameType          = "macroTransform"  // for macro annotations
+    val annottees: NameType               = nameType("annottees")       // for macro annotations
+    val macroTransform: NameType          = nameType("macroTransform")  // for macro annotations
 
     def isConstructorName(name: Name)       = name == CONSTRUCTOR || name == MIXIN_CONSTRUCTOR
     def isExceptionResultName(name: Name)   = name startsWith EXCEPTION_RESULT_PREFIX
@@ -510,9 +496,9 @@ trait StdNames {
     // Nominally, name$default$N, encoded for <init>
     def defaultGetterName(name: Name, pos: Int): TermName = (
       if (isConstructorName(name))
-        DEFAULT_GETTER_INIT_STRING + pos
+        nameType(DEFAULT_GETTER_INIT_STRING + pos)
       else
-        name.toString + DEFAULT_GETTER_STRING + pos
+        nameType(name.toString + DEFAULT_GETTER_STRING + pos)
     )
     // Nominally, name from name$default$N, CONSTRUCTOR for <init>
     def defaultGetterToMethod(name: Name): TermName = (
@@ -547,42 +533,42 @@ trait StdNames {
     private def existentialName0(i: Int) = newTypeName("_" + i)
     final def existentialName(i: Int): TypeName = if (i < existentialNames.length) existentialNames(i) else existentialName0(i)
 
-    final val Nil: NameType                 = "Nil"
-    final val Predef: NameType              = "Predef"
+    final val Nil: NameType    = nameType("Nil")
+    final val Predef: NameType = nameType("Predef")
 
-    val _1 : NameType  = "_1"
-    val _2 : NameType  = "_2"
-    val _3 : NameType  = "_3"
-    val _4 : NameType  = "_4"
-    val _5 : NameType  = "_5"
-    val _6 : NameType  = "_6"
-    val _7 : NameType  = "_7"
-    val _8 : NameType  = "_8"
-    val _9 : NameType  = "_9"
-    val _10 : NameType = "_10"
-    val _11 : NameType = "_11"
-    val _12 : NameType = "_12"
-    val _13 : NameType = "_13"
-    val _14 : NameType = "_14"
-    val _15 : NameType = "_15"
-    val _16 : NameType = "_16"
-    val _17 : NameType = "_17"
-    val _18 : NameType = "_18"
-    val _19 : NameType = "_19"
-    val _20 : NameType = "_20"
-    val _21 : NameType = "_21"
-    val _22 : NameType = "_22"
+    val _1 : NameType  = nameType("_1")
+    val _2 : NameType  = nameType("_2")
+    val _3 : NameType  = nameType("_3")
+    val _4 : NameType  = nameType("_4")
+    val _5 : NameType  = nameType("_5")
+    val _6 : NameType  = nameType("_6")
+    val _7 : NameType  = nameType("_7")
+    val _8 : NameType  = nameType("_8")
+    val _9 : NameType  = nameType("_9")
+    val _10 : NameType = nameType("_10")
+    val _11 : NameType = nameType("_11")
+    val _12 : NameType = nameType("_12")
+    val _13 : NameType = nameType("_13")
+    val _14 : NameType = nameType("_14")
+    val _15 : NameType = nameType("_15")
+    val _16 : NameType = nameType("_16")
+    val _17 : NameType = nameType("_17")
+    val _18 : NameType = nameType("_18")
+    val _19 : NameType = nameType("_19")
+    val _20 : NameType = nameType("_20")
+    val _21 : NameType = nameType("_21")
+    val _22 : NameType = nameType("_22")
 
-    val x_0 : NameType  = "x$0"
-    val x_1 : NameType  = "x$1"
-    val x_2 : NameType  = "x$2"
-    val x_3 : NameType  = "x$3"
-    val x_4 : NameType  = "x$4"
-    val x_5 : NameType  = "x$5"
-    val x_6 : NameType  = "x$6"
-    val x_7 : NameType  = "x$7"
-    val x_8 : NameType  = "x$8"
-    val x_9 : NameType  = "x$9"
+    val x_0 : NameType  = nameType("x$0")
+    val x_1 : NameType  = nameType("x$1")
+    val x_2 : NameType  = nameType("x$2")
+    val x_3 : NameType  = nameType("x$3")
+    val x_4 : NameType  = nameType("x$4")
+    val x_5 : NameType  = nameType("x$5")
+    val x_6 : NameType  = nameType("x$6")
+    val x_7 : NameType  = nameType("x$7")
+    val x_8 : NameType  = nameType("x$8")
+    val x_9 : NameType  = nameType("x$9")
 
     def syntheticParamName(i: Int): TermName = (i: @switch) match {
       case 0  => nme.x_0
@@ -628,319 +614,319 @@ trait StdNames {
     val =:= = encode("=:=")
     val <:< = encode("<:<")
 
-    val DummyImplicit: NameType    = "DummyImplicit"
+    val DummyImplicit: NameType    = nameType("DummyImplicit")
 
-    val wrapRefArray: NameType     = "wrapRefArray"
-    val wrapByteArray: NameType    = "wrapByteArray"
-    val wrapShortArray: NameType   = "wrapShortArray"
-    val wrapCharArray: NameType    = "wrapCharArray"
-    val wrapIntArray: NameType     = "wrapIntArray"
-    val wrapLongArray: NameType    = "wrapLongArray"
-    val wrapFloatArray: NameType   = "wrapFloatArray"
-    val wrapDoubleArray: NameType  = "wrapDoubleArray"
-    val wrapBooleanArray: NameType = "wrapBooleanArray"
-    val wrapUnitArray: NameType    = "wrapUnitArray"
-    val genericWrapArray: NameType = "genericWrapArray"
+    val wrapRefArray: NameType     = nameType("wrapRefArray")
+    val wrapByteArray: NameType    = nameType("wrapByteArray")
+    val wrapShortArray: NameType   = nameType("wrapShortArray")
+    val wrapCharArray: NameType    = nameType("wrapCharArray")
+    val wrapIntArray: NameType     = nameType("wrapIntArray")
+    val wrapLongArray: NameType    = nameType("wrapLongArray")
+    val wrapFloatArray: NameType   = nameType("wrapFloatArray")
+    val wrapDoubleArray: NameType  = nameType("wrapDoubleArray")
+    val wrapBooleanArray: NameType = nameType("wrapBooleanArray")
+    val wrapUnitArray: NameType    = nameType("wrapUnitArray")
+    val genericWrapArray: NameType = nameType("genericWrapArray")
 
-    val copyArrayToImmutableIndexedSeq: NameType = "copyArrayToImmutableIndexedSeq"
+    val copyArrayToImmutableIndexedSeq: NameType = nameType("copyArrayToImmutableIndexedSeq")
 
     // Compiler utilized names
 
-    val AnnotatedType: NameType        = "AnnotatedType"
-    val Annotation: NameType           = "Annotation"
-    val Any: NameType                  = "Any"
-    val AnyVal: NameType               = "AnyVal"
-    val Apply: NameType                = "Apply"
-    val ArrayAnnotArg: NameType        = "ArrayAnnotArg"
-    val CaseDef: NameType              = "CaseDef"
-    val ClassInfoType: NameType        = "ClassInfoType"
-    val ConstantType: NameType         = "ConstantType"
-    val EmptyPackage: NameType         = "EmptyPackage"
-    val EmptyPackageClass: NameType    = "EmptyPackageClass"
-    val ExistentialType: NameType      = "ExistentialType"
-    val Flag : NameType                = "Flag"
-    val FlagsRepr: NameType            = "FlagsRepr"
-    val Ident: NameType                = "Ident"
-    val ImplicitParams: NameType       = "ImplicitParams"
-    val Import: NameType               = "Import"
-    val Literal: NameType              = "Literal"
-    val LiteralAnnotArg: NameType      = "LiteralAnnotArg"
-    val MethodType: NameType           = "MethodType"
-    val Modifiers: NameType            = "Modifiers"
-    val NestedAnnotArg: NameType       = "NestedAnnotArg"
-    val New: NameType                  = "New"
-    val NoFlags: NameType              = "NoFlags"
-    val NoSymbol: NameType             = "NoSymbol"
-    val NoMods: NameType               = "NoMods"
-    val Nothing: NameType              = "Nothing"
-    val Null: NameType                 = "Null"
-    val NullaryMethodType: NameType    = "NullaryMethodType"
-    val Object: NameType               = "Object"
-    val PolyType: NameType             = "PolyType"
-    val RefinedType: NameType          = "RefinedType"
-    val RootPackage: NameType          = "RootPackage"
-    val RootClass: NameType            = "RootClass"
-    val Select: NameType               = "Select"
-    val SelectFromTypeTree: NameType   = "SelectFromTypeTree"
-    val SingleType: NameType           = "SingleType"
-    val SuperType: NameType            = "SuperType"
-    val This: NameType                 = "This"
-    val ThisType: NameType             = "ThisType"
-    val Tuple2: NameType               = "Tuple2"
-    val TYPE_ : NameType               = "TYPE"
-    val TypeBounds: NameType           = "TypeBounds"
-    val TypeRef: NameType              = "TypeRef"
-    val TypeTree: NameType             = "TypeTree"
-    val UNIT : NameType                = "UNIT"
-    val accessor: NameType             = "accessor"
-    val add_ : NameType                = "add"
-    val annotation: NameType           = "annotation"
-    val any2stringadd: NameType        = "any2stringadd"
-    val anyHash: NameType              = "anyHash"
-    val anyValClass: NameType          = "anyValClass"
-    val apply: NameType                = "apply"
-    val applyDynamic: NameType         = "applyDynamic"
-    val applyDynamicNamed: NameType    = "applyDynamicNamed"
-    val applyOrElse: NameType          = "applyOrElse"
-    val args : NameType                = "args"
-    val arrayClass: NameType           = "arrayClass"
-    val array_apply : NameType         = "array_apply"
-    val array_clone : NameType         = "array_clone"
-    val array_length : NameType        = "array_length"
-    val array_update : NameType        = "array_update"
-    val asModule: NameType             = "asModule"
-    val asType: NameType               = "asType"
-    val asInstanceOf_ : NameType       = "asInstanceOf"
-    val asInstanceOf_Ob : NameType     = n"asInstanceOf"   // looks like missing interpolator due to Any member in scope
-    val box: NameType                  = "box"
-    val bytes: NameType                = "bytes"
-    val c: NameType                    = "c"
-    val canEqual_ : NameType           = "canEqual"
-    val classOf: NameType              = "classOf"
-    val clone_ : NameType              = "clone"
-    val collection: NameType           = "collection"
-    val conforms: NameType             = n"conforms"       // $ prefix to avoid shadowing Predef.conforms
-    val copy: NameType                 = "copy"
-    val create: NameType               = "create"
-    val currentMirror: NameType        = "currentMirror"
-    val delayedInit: NameType          = "delayedInit"
-    val delayedInitArg: NameType       = "delayedInit$body"
-    val dollarScope: NameType          = "$scope"
-    val doubleHash: NameType           = "doubleHash"
-    val drop: NameType                 = "drop"
-    val elem: NameType                 = "elem"
-    val noSelfType: NameType           = "noSelfType"
-    val ensureAccessible : NameType    = "ensureAccessible"
-    val eq: NameType                   = "eq"
-    val equalsNumChar : NameType       = "equalsNumChar"
-    val equalsNumNum : NameType        = "equalsNumNum"
-    val equalsNumObject : NameType     = "equalsNumObject"
-    val equals_ : NameType             = "equals"
-    val error: NameType                = "error"
-    val ex: NameType                   = "ex"
-    val experimental: NameType         = "experimental"
-    val f: NameType                    = "f"
-    val false_ : NameType              = "false"
-    val filter: NameType               = "filter"
-    val finalize_ : NameType           = "finalize"
-    val find_ : NameType               = "find"
-    val flatMap: NameType              = "flatMap"
-    val floatHash: NameType            = "floatHash"
-    val foreach: NameType              = "foreach"
-    val freshTermName: NameType        = "freshTermName"
-    val freshTypeName: NameType        = "freshTypeName"
-    val get: NameType                  = "get"
-    val parameterTypes: NameType       = "parameterTypes"
-    val hashCode_ : NameType           = "hashCode"
-    val head : NameType                = "head"
-    val immutable: NameType            = "immutable"
-    val implicitly: NameType           = "implicitly"
-    val in: NameType                   = "in"
-    val initialize : NameType          = "initialize"
-    val initialized : NameType         = "initialized"
-    val internal: NameType             = "internal"
-    val inlinedEquals: NameType        = "inlinedEquals"
-    val ioobe : NameType               = "ioobe"
-    val isArray: NameType              = "isArray"
-    val isDefinedAt: NameType          = "isDefinedAt"
-    val isEmpty: NameType              = "isEmpty"
-    val isInstanceOf_ : NameType       = "isInstanceOf"
-    val isInstanceOf_Ob : NameType     = n"isInstanceOf"   // looks like missing interpolator due to Any member in scope
-    val java: NameType                 = "java"
-    val key: NameType                  = "key"
-    val lang: NameType                 = "lang"
-    val length: NameType               = "length"
-    val lengthCompare: NameType        = "lengthCompare"
-    val longHash: NameType             = "longHash"
-    val macroContext : NameType        = "c"
-    val main: NameType                 = "main"
-    val manifestToTypeTag: NameType    = "manifestToTypeTag"
-    val map: NameType                  = "map"
-    val materializeClassTag: NameType  = "materializeClassTag"
-    val materializeWeakTypeTag: NameType = "materializeWeakTypeTag"
-    val materializeTypeTag: NameType   = "materializeTypeTag"
-    val moduleClass : NameType         = "moduleClass"
-    val mkAnnotation: NameType         = "mkAnnotation"
-    val mkEarlyDef: NameType           = "mkEarlyDef"
-    val mkIdent: NameType              = "mkIdent"
-    val mkPackageStat: NameType        = "mkPackageStat"
-    val mkRefineStat: NameType         = "mkRefineStat"
-    val mkRefTree: NameType            = "mkRefTree"
-    val mkSelect: NameType             = "mkSelect"
-    val mkThis: NameType               = "mkThis"
-    val mkTypeTree: NameType           = "mkTypeTree"
-    val ne: NameType                   = "ne"
-    val newArray: NameType             = "newArray"
-    val newFreeTerm: NameType          = "newFreeTerm"
-    val newFreeType: NameType          = "newFreeType"
-    val newNestedSymbol: NameType      = "newNestedSymbol"
-    val newScopeWith: NameType         = "newScopeWith"
-    val notifyAll_ : NameType          = "notifyAll"
-    val notify_ : NameType             = "notify"
-    val null_ : NameType               = "null"
-    val pendingSuperCall: NameType     = "pendingSuperCall"
-    val prefix : NameType              = "prefix"
-    val productArity: NameType         = "productArity"
-    val productElement: NameType       = "productElement"
-    val productElementName: NameType   = "productElementName"
-    val productIterator: NameType      = "productIterator"
-    val productPrefix: NameType        = "productPrefix"
-    val raw_ : NameType                = "raw"
-    val readResolve: NameType          = "readResolve"
-    val releaseFence: NameType         = "releaseFence"
-    val refl: NameType                 = "refl"
-    val reify : NameType               = "reify"
-    val reificationSupport : NameType  = "reificationSupport"
-    val rootMirror : NameType          = "rootMirror"
-    val runtime: NameType              = "runtime"
-    val runtimeClass: NameType         = "runtimeClass"
-    val runtimeMirror: NameType        = "runtimeMirror"
-    val s: NameType                    = "s"
-    val scala_ : NameType              = "scala"
-    val selectDynamic: NameType        = "selectDynamic"
-    val selectOverloadedMethod: NameType = "selectOverloadedMethod"
-    val selectTerm: NameType           = "selectTerm"
-    val selectType: NameType           = "selectType"
-    val self: NameType                 = "self"
-    val setAnnotations: NameType       = "setAnnotations"
-    val setInfo: NameType              = "setInfo"
-    val setSymbol: NameType            = "setSymbol"
-    val setType: NameType              = "setType"
-    val splice: NameType               = "splice"
-    val staticClass : NameType         = "staticClass"
-    val staticModule : NameType        = "staticModule"
-    val staticPackage : NameType       = "staticPackage"
-    val synchronized_ : NameType       = "synchronized"
-    val ScalaDot: NameType             = "ScalaDot"
-    val TermName: NameType             = "TermName"
-    val this_ : NameType               = "this"
-    val thisPrefix : NameType          = "thisPrefix"
-    val toArray: NameType              = "toArray"
-    val toList: NameType               = "toList"
-    val toObjectArray : NameType       = "toObjectArray"
-    val toSeq: NameType                = "toSeq"
-    val toStats: NameType              = "toStats"
-    val TopScope: NameType             = "TopScope"
-    val toString_ : NameType           = "toString"
-    val toTypeConstructor: NameType    = "toTypeConstructor"
-    val tpe : NameType                 = "tpe"
-    val tree : NameType                = "tree"
-    val true_ : NameType               = "true"
-    val typedProductIterator: NameType = "typedProductIterator"
-    val TypeName: NameType             = "TypeName"
-    val typeTagToManifest: NameType    = "typeTagToManifest"
-    val unapply: NameType              = "unapply"
-    val unapplySeq: NameType           = "unapplySeq"
-    val unbox: NameType                = "unbox"
-    val universe: NameType             = "universe"
-    val UnliftListElementwise: NameType = "UnliftListElementwise"
-    val UnliftListOfListsElementwise: NameType = "UnliftListOfListsElementwise"
-    val update: NameType               = "update"
-    val updateDynamic: NameType        = "updateDynamic"
-    val value: NameType                = "value"
-    val valueOf : NameType             = "valueOf"
-    val values : NameType              = "values"
-    val wait_ : NameType               = "wait"
-    val withFilter: NameType           = "withFilter"
-    val writeReplace: NameType         = "writeReplace"
-    val xml: NameType                  = "xml"
-    val zero: NameType                 = "zero"
+    val AnnotatedType: NameType        = nameType("AnnotatedType")
+    val Annotation: NameType           = nameType("Annotation")
+    val Any: NameType                  = nameType("Any")
+    val AnyVal: NameType               = nameType("AnyVal")
+    val Apply: NameType                = nameType("Apply")
+    val ArrayAnnotArg: NameType        = nameType("ArrayAnnotArg")
+    val CaseDef: NameType              = nameType("CaseDef")
+    val ClassInfoType: NameType        = nameType("ClassInfoType")
+    val ConstantType: NameType         = nameType("ConstantType")
+    val EmptyPackage: NameType         = nameType("EmptyPackage")
+    val EmptyPackageClass: NameType    = nameType("EmptyPackageClass")
+    val ExistentialType: NameType      = nameType("ExistentialType")
+    val Flag : NameType                = nameType("Flag")
+    val FlagsRepr: NameType            = nameType("FlagsRepr")
+    val Ident: NameType                = nameType("Ident")
+    val ImplicitParams: NameType       = nameType("ImplicitParams")
+    val Import: NameType               = nameType("Import")
+    val Literal: NameType              = nameType("Literal")
+    val LiteralAnnotArg: NameType      = nameType("LiteralAnnotArg")
+    val MethodType: NameType           = nameType("MethodType")
+    val Modifiers: NameType            = nameType("Modifiers")
+    val NestedAnnotArg: NameType       = nameType("NestedAnnotArg")
+    val New: NameType                  = nameType("New")
+    val NoFlags: NameType              = nameType("NoFlags")
+    val NoSymbol: NameType             = nameType("NoSymbol")
+    val NoMods: NameType               = nameType("NoMods")
+    val Nothing: NameType              = nameType("Nothing")
+    val Null: NameType                 = nameType("Null")
+    val NullaryMethodType: NameType    = nameType("NullaryMethodType")
+    val Object: NameType               = nameType("Object")
+    val PolyType: NameType             = nameType("PolyType")
+    val RefinedType: NameType          = nameType("RefinedType")
+    val RootPackage: NameType          = nameType("RootPackage")
+    val RootClass: NameType            = nameType("RootClass")
+    val Select: NameType               = nameType("Select")
+    val SelectFromTypeTree: NameType   = nameType("SelectFromTypeTree")
+    val SingleType: NameType           = nameType("SingleType")
+    val SuperType: NameType            = nameType("SuperType")
+    val This: NameType                 = nameType("This")
+    val ThisType: NameType             = nameType("ThisType")
+    val Tuple2: NameType               = nameType("Tuple2")
+    val TYPE_ : NameType               = nameType("TYPE")
+    val TypeBounds: NameType           = nameType("TypeBounds")
+    val TypeRef: NameType              = nameType("TypeRef")
+    val TypeTree: NameType             = nameType("TypeTree")
+    val UNIT : NameType                = nameType("UNIT")
+    val accessor: NameType             = nameType("accessor")
+    val add_ : NameType                = nameType("add")
+    val annotation: NameType           = nameType("annotation")
+    val any2stringadd: NameType        = nameType("any2stringadd")
+    val anyHash: NameType              = nameType("anyHash")
+    val anyValClass: NameType          = nameType("anyValClass")
+    val apply: NameType                = nameType("apply")
+    val applyDynamic: NameType         = nameType("applyDynamic")
+    val applyDynamicNamed: NameType    = nameType("applyDynamicNamed")
+    val applyOrElse: NameType          = nameType("applyOrElse")
+    val args : NameType                = nameType("args")
+    val arrayClass: NameType           = nameType("arrayClass")
+    val array_apply : NameType         = nameType("array_apply")
+    val array_clone : NameType         = nameType("array_clone")
+    val array_length : NameType        = nameType("array_length")
+    val array_update : NameType        = nameType("array_update")
+    val asModule: NameType             = nameType("asModule")
+    val asType: NameType               = nameType("asType")
+    val asInstanceOf_ : NameType       = nameType("asInstanceOf")
+    val asInstanceOf_Ob : NameType     = nameType("$" + "asInstanceOf") // looks like missing interpolator due to Any member in scope
+    val box: NameType                  = nameType("box")
+    val bytes: NameType                = nameType("bytes")
+    val c: NameType                    = nameType("c")
+    val canEqual_ : NameType           = nameType("canEqual")
+    val classOf: NameType              = nameType("classOf")
+    val clone_ : NameType              = nameType("clone")
+    val collection: NameType           = nameType("collection")
+    val conforms: NameType             = nameType("$" + "conforms") // $ prefix to avoid shadowing Predef.conforms
+    val copy: NameType                 = nameType("copy")
+    val create: NameType               = nameType("create")
+    val currentMirror: NameType        = nameType("currentMirror")
+    val delayedInit: NameType          = nameType("delayedInit")
+    val delayedInitArg: NameType       = nameType("delayedInit$body")
+    val dollarScope: NameType          = nameType("$scope")
+    val doubleHash: NameType           = nameType("doubleHash")
+    val drop: NameType                 = nameType("drop")
+    val elem: NameType                 = nameType("elem")
+    val noSelfType: NameType           = nameType("noSelfType")
+    val ensureAccessible : NameType    = nameType("ensureAccessible")
+    val eq: NameType                   = nameType("eq")
+    val equalsNumChar : NameType       = nameType("equalsNumChar")
+    val equalsNumNum : NameType        = nameType("equalsNumNum")
+    val equalsNumObject : NameType     = nameType("equalsNumObject")
+    val equals_ : NameType             = nameType("equals")
+    val error: NameType                = nameType("error")
+    val ex: NameType                   = nameType("ex")
+    val experimental: NameType         = nameType("experimental")
+    val f: NameType                    = nameType("f")
+    val false_ : NameType              = nameType("false")
+    val filter: NameType               = nameType("filter")
+    val finalize_ : NameType           = nameType("finalize")
+    val find_ : NameType               = nameType("find")
+    val flatMap: NameType              = nameType("flatMap")
+    val floatHash: NameType            = nameType("floatHash")
+    val foreach: NameType              = nameType("foreach")
+    val freshTermName: NameType        = nameType("freshTermName")
+    val freshTypeName: NameType        = nameType("freshTypeName")
+    val get: NameType                  = nameType("get")
+    val parameterTypes: NameType       = nameType("parameterTypes")
+    val hashCode_ : NameType           = nameType("hashCode")
+    val head : NameType                = nameType("head")
+    val immutable: NameType            = nameType("immutable")
+    val implicitly: NameType           = nameType("implicitly")
+    val in: NameType                   = nameType("in")
+    val initialize : NameType          = nameType("initialize")
+    val initialized : NameType         = nameType("initialized")
+    val internal: NameType             = nameType("internal")
+    val inlinedEquals: NameType        = nameType("inlinedEquals")
+    val ioobe : NameType               = nameType("ioobe")
+    val isArray: NameType              = nameType("isArray")
+    val isDefinedAt: NameType          = nameType("isDefinedAt")
+    val isEmpty: NameType              = nameType("isEmpty")
+    val isInstanceOf_ : NameType       = nameType("isInstanceOf")
+    val isInstanceOf_Ob : NameType     = nameType("$" + "isInstanceOf") // looks like missing interpolator due to Any member in scope
+    val java: NameType                 = nameType("java")
+    val key: NameType                  = nameType("key")
+    val lang: NameType                 = nameType("lang")
+    val length: NameType               = nameType("length")
+    val lengthCompare: NameType        = nameType("lengthCompare")
+    val longHash: NameType             = nameType("longHash")
+    val macroContext : NameType        = nameType("c")
+    val main: NameType                 = nameType("main")
+    val manifestToTypeTag: NameType    = nameType("manifestToTypeTag")
+    val map: NameType                  = nameType("map")
+    val materializeClassTag: NameType  = nameType("materializeClassTag")
+    val materializeWeakTypeTag: NameType = nameType("materializeWeakTypeTag")
+    val materializeTypeTag: NameType   = nameType("materializeTypeTag")
+    val moduleClass : NameType         = nameType("moduleClass")
+    val mkAnnotation: NameType         = nameType("mkAnnotation")
+    val mkEarlyDef: NameType           = nameType("mkEarlyDef")
+    val mkIdent: NameType              = nameType("mkIdent")
+    val mkPackageStat: NameType        = nameType("mkPackageStat")
+    val mkRefineStat: NameType         = nameType("mkRefineStat")
+    val mkRefTree: NameType            = nameType("mkRefTree")
+    val mkSelect: NameType             = nameType("mkSelect")
+    val mkThis: NameType               = nameType("mkThis")
+    val mkTypeTree: NameType           = nameType("mkTypeTree")
+    val ne: NameType                   = nameType("ne")
+    val newArray: NameType             = nameType("newArray")
+    val newFreeTerm: NameType          = nameType("newFreeTerm")
+    val newFreeType: NameType          = nameType("newFreeType")
+    val newNestedSymbol: NameType      = nameType("newNestedSymbol")
+    val newScopeWith: NameType         = nameType("newScopeWith")
+    val notifyAll_ : NameType          = nameType("notifyAll")
+    val notify_ : NameType             = nameType("notify")
+    val null_ : NameType               = nameType("null")
+    val pendingSuperCall: NameType     = nameType("pendingSuperCall")
+    val prefix : NameType              = nameType("prefix")
+    val productArity: NameType         = nameType("productArity")
+    val productElement: NameType       = nameType("productElement")
+    val productElementName: NameType   = nameType("productElementName")
+    val productIterator: NameType      = nameType("productIterator")
+    val productPrefix: NameType        = nameType("productPrefix")
+    val raw_ : NameType                = nameType("raw")
+    val readResolve: NameType          = nameType("readResolve")
+    val releaseFence: NameType         = nameType("releaseFence")
+    val refl: NameType                 = nameType("refl")
+    val reify : NameType               = nameType("reify")
+    val reificationSupport : NameType  = nameType("reificationSupport")
+    val rootMirror : NameType          = nameType("rootMirror")
+    val runtime: NameType              = nameType("runtime")
+    val runtimeClass: NameType         = nameType("runtimeClass")
+    val runtimeMirror: NameType        = nameType("runtimeMirror")
+    val s: NameType                    = nameType("s")
+    val scala_ : NameType              = nameType("scala")
+    val selectDynamic: NameType        = nameType("selectDynamic")
+    val selectOverloadedMethod: NameType = nameType("selectOverloadedMethod")
+    val selectTerm: NameType           = nameType("selectTerm")
+    val selectType: NameType           = nameType("selectType")
+    val self: NameType                 = nameType("self")
+    val setAnnotations: NameType       = nameType("setAnnotations")
+    val setInfo: NameType              = nameType("setInfo")
+    val setSymbol: NameType            = nameType("setSymbol")
+    val setType: NameType              = nameType("setType")
+    val splice: NameType               = nameType("splice")
+    val staticClass : NameType         = nameType("staticClass")
+    val staticModule : NameType        = nameType("staticModule")
+    val staticPackage : NameType       = nameType("staticPackage")
+    val synchronized_ : NameType       = nameType("synchronized")
+    val ScalaDot: NameType             = nameType("ScalaDot")
+    val TermName: NameType             = nameType("TermName")
+    val this_ : NameType               = nameType("this")
+    val thisPrefix : NameType          = nameType("thisPrefix")
+    val toArray: NameType              = nameType("toArray")
+    val toList: NameType               = nameType("toList")
+    val toObjectArray : NameType       = nameType("toObjectArray")
+    val toSeq: NameType                = nameType("toSeq")
+    val toStats: NameType              = nameType("toStats")
+    val TopScope: NameType             = nameType("TopScope")
+    val toString_ : NameType           = nameType("toString")
+    val toTypeConstructor: NameType    = nameType("toTypeConstructor")
+    val tpe : NameType                 = nameType("tpe")
+    val tree : NameType                = nameType("tree")
+    val true_ : NameType               = nameType("true")
+    val typedProductIterator: NameType = nameType("typedProductIterator")
+    val TypeName: NameType             = nameType("TypeName")
+    val typeTagToManifest: NameType    = nameType("typeTagToManifest")
+    val unapply: NameType              = nameType("unapply")
+    val unapplySeq: NameType           = nameType("unapplySeq")
+    val unbox: NameType                = nameType("unbox")
+    val universe: NameType             = nameType("universe")
+    val UnliftListElementwise: NameType =nameType( "UnliftListElementwise")
+    val UnliftListOfListsElementwise: NameType = nameType("UnliftListOfListsElementwise")
+    val update: NameType               = nameType("update")
+    val updateDynamic: NameType        = nameType("updateDynamic")
+    val value: NameType                = nameType("value")
+    val valueOf : NameType             = nameType("valueOf")
+    val values : NameType              = nameType("values")
+    val wait_ : NameType               = nameType("wait")
+    val withFilter: NameType           = nameType("withFilter")
+    val writeReplace: NameType         = nameType("writeReplace")
+    val xml: NameType                  = nameType("xml")
+    val zero: NameType                 = nameType("zero")
 
     // quasiquote interpolators:
-    val q: NameType  = "q"
-    val tq: NameType = "tq"
-    val cq: NameType = "cq"
-    val pq: NameType = "pq"
-    val fq: NameType = "fq"
+    val q: NameType  = nameType("q")
+    val tq: NameType = nameType("tq")
+    val cq: NameType = nameType("cq")
+    val pq: NameType = nameType("pq")
+    val fq: NameType = nameType("fq")
 
     // quasiquote's syntactic combinators
-    val SyntacticAnnotatedType: NameType    = "SyntacticAnnotatedType"
-    val SyntacticApplied: NameType          = "SyntacticApplied"
-    val SyntacticAppliedType: NameType      = "SyntacticAppliedType"
-    val SyntacticAssign: NameType           = "SyntacticAssign"
-    val SyntacticBlock: NameType            = "SyntacticBlock"
-    val SyntacticClassDef: NameType         = "SyntacticClassDef"
-    val SyntacticCompoundType: NameType     = "SyntacticCompoundType"
-    val SyntacticDefDef: NameType           = "SyntacticDefDef"
-    val SyntacticEmptyTypeTree: NameType    = "SyntacticEmptyTypeTree"
-    val SyntacticExistentialType: NameType  = "SyntacticExistentialType"
-    val SyntacticFilter: NameType           = "SyntacticFilter"
-    val SyntacticFor: NameType              = "SyntacticFor"
-    val SyntacticForYield: NameType         = "SyntacticForYield"
-    val SyntacticFunction: NameType         = "SyntacticFunction"
-    val SyntacticFunctionType: NameType     = "SyntacticFunctionType"
-    val SyntacticImport: NameType           = "SyntacticImport"
-    val SyntacticMatch: NameType            = "SyntacticMatch"
-    val SyntacticNew: NameType              = "SyntacticNew"
-    val SyntacticObjectDef: NameType        = "SyntacticObjectDef"
-    val SyntacticPackageObjectDef: NameType = "SyntacticPackageObjectDef"
-    val SyntacticPartialFunction: NameType  = "SyntacticPartialFunction"
-    val SyntacticPatDef: NameType           = "SyntacticPatDef"
-    val SyntacticSelectTerm: NameType       = "SyntacticSelectTerm"
-    val SyntacticSelectType: NameType       = "SyntacticSelectType"
-    val SyntacticSingletonType: NameType    = "SyntacticSingletonType"
-    val SyntacticTermIdent: NameType        = "SyntacticTermIdent"
-    val SyntacticTraitDef: NameType         = "SyntacticTraitDef"
-    val SyntacticTry: NameType              = "SyntacticTry"
-    val SyntacticTuple: NameType            = "SyntacticTuple"
-    val SyntacticTupleType: NameType        = "SyntacticTupleType"
-    val SyntacticTypeApplied: NameType      = "SyntacticTypeApplied"
-    val SyntacticTypeIdent: NameType        = "SyntacticTypeIdent"
-    val SyntacticTypeProjection: NameType   = "SyntacticTypeProjection"
-    val SyntacticValDef: NameType           = "SyntacticValDef"
-    val SyntacticValEq: NameType            = "SyntacticValEq"
-    val SyntacticValFrom: NameType          = "SyntacticValFrom"
-    val SyntacticVarDef: NameType           = "SyntacticVarDef"
+    val SyntacticAnnotatedType: NameType    = nameType("SyntacticAnnotatedType")
+    val SyntacticApplied: NameType          = nameType("SyntacticApplied")
+    val SyntacticAppliedType: NameType      = nameType("SyntacticAppliedType")
+    val SyntacticAssign: NameType           = nameType("SyntacticAssign")
+    val SyntacticBlock: NameType            = nameType("SyntacticBlock")
+    val SyntacticClassDef: NameType         = nameType("SyntacticClassDef")
+    val SyntacticCompoundType: NameType     = nameType("SyntacticCompoundType")
+    val SyntacticDefDef: NameType           = nameType("SyntacticDefDef")
+    val SyntacticEmptyTypeTree: NameType    = nameType("SyntacticEmptyTypeTree")
+    val SyntacticExistentialType: NameType  = nameType("SyntacticExistentialType")
+    val SyntacticFilter: NameType           = nameType("SyntacticFilter")
+    val SyntacticFor: NameType              = nameType("SyntacticFor")
+    val SyntacticForYield: NameType         = nameType("SyntacticForYield")
+    val SyntacticFunction: NameType         = nameType("SyntacticFunction")
+    val SyntacticFunctionType: NameType     = nameType("SyntacticFunctionType")
+    val SyntacticImport: NameType           = nameType("SyntacticImport")
+    val SyntacticMatch: NameType            = nameType("SyntacticMatch")
+    val SyntacticNew: NameType              = nameType("SyntacticNew")
+    val SyntacticObjectDef: NameType        = nameType("SyntacticObjectDef")
+    val SyntacticPackageObjectDef: NameType = nameType("SyntacticPackageObjectDef")
+    val SyntacticPartialFunction: NameType  = nameType("SyntacticPartialFunction")
+    val SyntacticPatDef: NameType           = nameType("SyntacticPatDef")
+    val SyntacticSelectTerm: NameType       = nameType("SyntacticSelectTerm")
+    val SyntacticSelectType: NameType       = nameType("SyntacticSelectType")
+    val SyntacticSingletonType: NameType    = nameType("SyntacticSingletonType")
+    val SyntacticTermIdent: NameType        = nameType("SyntacticTermIdent")
+    val SyntacticTraitDef: NameType         = nameType("SyntacticTraitDef")
+    val SyntacticTry: NameType              = nameType("SyntacticTry")
+    val SyntacticTuple: NameType            = nameType("SyntacticTuple")
+    val SyntacticTupleType: NameType        = nameType("SyntacticTupleType")
+    val SyntacticTypeApplied: NameType      = nameType("SyntacticTypeApplied")
+    val SyntacticTypeIdent: NameType        = nameType("SyntacticTypeIdent")
+    val SyntacticTypeProjection: NameType   = nameType("SyntacticTypeProjection")
+    val SyntacticValDef: NameType           = nameType("SyntacticValDef")
+    val SyntacticValEq: NameType            = nameType("SyntacticValEq")
+    val SyntacticValFrom: NameType          = nameType("SyntacticValFrom")
+    val SyntacticVarDef: NameType           = nameType("SyntacticVarDef")
 
     // unencoded operators
     object raw {
-      final val BANG : NameType  = "!"
-      final val BAR  : NameType  = "|"
-      final val DOLLAR: NameType = "$"
-      final val GE: NameType     = ">="
-      final val LE: NameType     = "<="
-      final val MINUS: NameType  = "-"
-      final val NE: NameType     = "!="
-      final val PLUS : NameType  = "+"
-      final val STAR : NameType  = "*"
-      final val TILDE: NameType  = "~"
+      final val BANG : NameType  = nameType("!")
+      final val BAR  : NameType  = nameType("|")
+      final val DOLLAR: NameType = nameType("$")
+      final val GE: NameType     = nameType(">=")
+      final val LE: NameType     = nameType("<=")
+      final val MINUS: NameType  = nameType("-")
+      final val NE: NameType     = nameType("!=")
+      final val PLUS : NameType  = nameType("+")
+      final val STAR : NameType  = nameType("*")
+      final val TILDE: NameType  = nameType("~")
 
       final val isUnary: Set[Name] = Set(MINUS, PLUS, TILDE, BANG)
     }
 
     // value-conversion methods
-    val toByte: NameType   = "toByte"
-    val toShort: NameType  = "toShort"
-    val toChar: NameType   = "toChar"
-    val toInt: NameType    = "toInt"
-    val toLong: NameType   = "toLong"
-    val toFloat: NameType  = "toFloat"
-    val toDouble: NameType = "toDouble"
+    val toByte: NameType   = nameType("toByte")
+    val toShort: NameType  = nameType("toShort")
+    val toChar: NameType   = nameType("toChar")
+    val toInt: NameType    = nameType("toInt")
+    val toLong: NameType   = nameType("toLong")
+    val toFloat: NameType  = nameType("toFloat")
+    val toDouble: NameType = nameType("toDouble")
 
     // primitive operation methods for structural types mostly
     // overlap with the above, but not for these two.
-    val toCharacter: NameType = "toCharacter"
-    val toInteger: NameType   = "toInteger"
+    val toCharacter: NameType = nameType("toCharacter")
+    val toInteger: NameType   = nameType("toInteger")
 
     def newLazyValSlowComputeName(lzyValName: Name) = (lzyValName stripSuffix MODULE_VAR_SUFFIX append LAZY_SLOW_SUFFIX).toTermName
 
@@ -983,29 +969,29 @@ trait StdNames {
     val CommonOpNames   = Set[Name](OR, XOR, AND, EQ, NE)
     val BooleanOpNames  = Set[Name](ZOR, ZAND, UNARY_!) ++ CommonOpNames
 
-    val add: NameType                    = "add"
-    val complement: NameType             = "complement"
-    val divide: NameType                 = "divide"
-    val multiply: NameType               = "multiply"
-    val negate: NameType                 = "negate"
-    val positive: NameType               = "positive"
-    val shiftLogicalRight: NameType      = "shiftLogicalRight"
-    val shiftSignedLeft: NameType        = "shiftSignedLeft"
-    val shiftSignedRight: NameType       = "shiftSignedRight"
-    val subtract: NameType               = "subtract"
-    val takeAnd: NameType                = "takeAnd"
-    val takeConditionalAnd: NameType     = "takeConditionalAnd"
-    val takeConditionalOr: NameType      = "takeConditionalOr"
-    val takeModulo: NameType             = "takeModulo"
-    val takeNot: NameType                = "takeNot"
-    val takeOr: NameType                 = "takeOr"
-    val takeXor: NameType                = "takeXor"
-    val testEqual: NameType              = "testEqual"
-    val testGreaterOrEqualThan: NameType = "testGreaterOrEqualThan"
-    val testGreaterThan: NameType        = "testGreaterThan"
-    val testLessOrEqualThan: NameType    = "testLessOrEqualThan"
-    val testLessThan: NameType           = "testLessThan"
-    val testNotEqual: NameType           = "testNotEqual"
+    val add: NameType                    = nameType("add")
+    val complement: NameType             = nameType("complement")
+    val divide: NameType                 = nameType("divide")
+    val multiply: NameType               = nameType("multiply")
+    val negate: NameType                 = nameType("negate")
+    val positive: NameType               = nameType("positive")
+    val shiftLogicalRight: NameType      = nameType("shiftLogicalRight")
+    val shiftSignedLeft: NameType        = nameType("shiftSignedLeft")
+    val shiftSignedRight: NameType       = nameType("shiftSignedRight")
+    val subtract: NameType               = nameType("subtract")
+    val takeAnd: NameType                = nameType("takeAnd")
+    val takeConditionalAnd: NameType     = nameType("takeConditionalAnd")
+    val takeConditionalOr: NameType      = nameType("takeConditionalOr")
+    val takeModulo: NameType             = nameType("takeModulo")
+    val takeNot: NameType                = nameType("takeNot")
+    val takeOr: NameType                 = nameType("takeOr")
+    val takeXor: NameType                = nameType("takeXor")
+    val testEqual: NameType              = nameType("testEqual")
+    val testGreaterOrEqualThan: NameType = nameType("testGreaterOrEqualThan")
+    val testGreaterThan: NameType        = nameType("testGreaterThan")
+    val testLessOrEqualThan: NameType    = nameType("testLessOrEqualThan")
+    val testLessThan: NameType           = nameType("testLessThan")
+    val testNotEqual: NameType           = nameType("testNotEqual")
 
     def toUnaryName(name: TermName): TermName = name match {
       case raw.MINUS => UNARY_-
@@ -1101,10 +1087,10 @@ trait StdNames {
     def newBitmapName(bitmapPrefix: Name, n: Int) = bitmapPrefix append ("" + n)
     def isTransientBitmap(name: Name) = name == nme.BITMAP_TRANSIENT || name == nme.BITMAP_CHECKINIT_TRANSIENT
 
-    val BITMAP_NORMAL: NameType              = BITMAP_PREFIX + ""           // initialization bitmap for public/protected lazy vals
-    val BITMAP_TRANSIENT: NameType           = BITMAP_PREFIX + "trans$"     // initialization bitmap for transient lazy vals
-    val BITMAP_CHECKINIT: NameType           = BITMAP_PREFIX + "init$"      // initialization bitmap for checkinit values
-    val BITMAP_CHECKINIT_TRANSIENT: NameType = BITMAP_PREFIX + "inittrans$" // initialization bitmap for transient checkinit values
+    val BITMAP_NORMAL: NameType              = nameType(BITMAP_PREFIX + "")           // initialization bitmap for public/protected lazy vals
+    val BITMAP_TRANSIENT: NameType           = nameType(BITMAP_PREFIX + "trans$")     // initialization bitmap for transient lazy vals
+    val BITMAP_CHECKINIT: NameType           = nameType(BITMAP_PREFIX + "init$")      // initialization bitmap for checkinit values
+    val BITMAP_CHECKINIT_TRANSIENT: NameType = nameType(BITMAP_PREFIX + "inittrans$") // initialization bitmap for transient checkinit values
   }
 
   lazy val typeNames: tpnme.type = tpnme
@@ -1114,8 +1100,8 @@ trait StdNames {
   /** For fully qualified type names.
    */
   object fulltpnme extends TypeNames {
-    val RuntimeNothing: NameType = "scala.runtime.Nothing$"
-    val RuntimeNull: NameType    = "scala.runtime.Null$"
+    val RuntimeNothing: NameType = nameType("scala.runtime.Nothing$")
+    val RuntimeNull: NameType    = nameType("scala.runtime.Null$")
   }
 
   /** Java binary names, like scala/runtime/Nothing$.
@@ -1140,13 +1126,13 @@ trait StdNames {
     def getMethod_       = sn.GetMethod
     def invoke_          = sn.Invoke
 
-    val isBoxedNumberOrBoolean: NameType = "isBoxedNumberOrBoolean"
-    val isBoxedNumber: NameType = "isBoxedNumber"
+    val isBoxedNumberOrBoolean: NameType = nameType("isBoxedNumberOrBoolean")
+    val isBoxedNumber: NameType          = nameType("isBoxedNumber")
 
-    val reflPolyCacheName: NameType   = "reflPoly$Cache"
-    val reflParamsCacheName: NameType = "reflParams$Cache"
-    val reflMethodName: NameType      = "reflMethod$Method"
-    val argument: NameType            = "<argument>"
+    val reflPolyCacheName: NameType   = nameType("reflPoly$Cache")
+    val reflParamsCacheName: NameType = nameType("reflParams$Cache")
+    val reflMethodName: NameType      = nameType("reflMethod$Method")
+    val argument: NameType            = nameType("<argument>")
 
   }
 
@@ -1210,9 +1196,7 @@ trait StdNames {
   }
 
   sealed abstract class SymbolNames {
-    protected val stringToTermName = null
-    protected val stringToTypeName = null
-    protected implicit def createNameType(s: String): TypeName = newTypeNameCached(s)
+    protected def nameType(s: String): TypeName = newTypeNameCached(s)
 
     final val BoxedBoolean: String       = "java.lang.Boolean"
     final val BoxedByte: String          = "java.lang.Byte"

--- a/test/junit/scala/reflect/internal/TypesTest.scala
+++ b/test/junit/scala/reflect/internal/TypesTest.scala
@@ -85,14 +85,14 @@ class TypesTest {
     import rootMirror.EmptyPackageClass
 
     // class M[A]
-    val MClass = EmptyPackageClass.newClass("M")
-    val A = MClass.newTypeParameter("A").setInfo(TypeBounds.empty)
+    val MClass = EmptyPackageClass.newClass(TypeName("M"))
+    val A = MClass.newTypeParameter(TypeName("A")).setInfo(TypeBounds.empty)
     MClass.setInfo(PolyType(A :: Nil, ClassInfoType(ObjectClass.tpeHK :: Nil, newScopeWith(), MClass)))
 
     // (M[Int] with M[X] { def m: Any }) forSome { type X }
-    val X = NoSymbol.newExistential("X").setInfo(TypeBounds.empty)
+    val X = NoSymbol.newExistential(TypeName("X")).setInfo(TypeBounds.empty)
     val T: Type = {
-      val decls = newScopeWith(MClass.newMethod("m").setInfo(NullaryMethodType(AnyClass.tpeHK)))
+      val decls = newScopeWith(MClass.newMethod(TermName("m")).setInfo(NullaryMethodType(AnyClass.tpeHK)))
       val refined = refinedType(appliedType(MClass, IntClass.tpeHK) :: appliedType(MClass, X.tpeHK) :: Nil, NoSymbol, decls, NoPosition)
       newExistentialType(X :: Nil, refined)
     }


### PR DESCRIPTION
This requires a fair amount of explicit calls to `createNameType` in `StdNames`, which is not pleasing to the eye, but the result is a saner codebase nevertheless.

We use the opportunity to replace the `n"foo"` interopolator trick, which was used to avoid spurious "possible missing interpolator" warnings, by a simple concatenation like `"$" + "foo"`.

In the `scala-reflect` API, we do not remove the methods to preserve binary compatibility. We simply drop their `implicit` marker, which is not source compatible but is binary compatible.

---

After that, we integrate methods of `NameOps` directly in `Name`.

Now that there are no more implicit conversion from `String` to `Name`s, we can safely put those methods directly in `Name`, which is better for performance and readability. Previously, doing so would cause ambiguous implicit conversions between those and `Predef.augmentString`.

/cc @diesalbla @hrhino 
Inspired by #8535.