### PR TITLE
Dealias chain all the things when looking for Any

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -587,8 +587,10 @@ trait Infer extends Checkable {
       // explicitly anywhere amongst the formal, argument, result, or expected type.
       // ...or lower bound of a type param, since they're asking for it.
       def canWarnAboutAny = {
-        val coll = new ContainsAnyCollector(topTypes)
-        def containsAny(t: Type) = t.dealiasWidenChain.exists(coll.collect)
+        val collector = new ContainsAnyCollector(topTypes) {
+          override def apply(t: Type) = if (!result) t.dealiasWidenChain.foreach(super.apply)
+        }
+        @`inline` def containsAny(t: Type) = collector.collect(t)
         val hasAny = containsAny(pt) || containsAny(restpe) ||
           formals.exists(containsAny) ||
           argtpes.exists(containsAny) ||

--- a/test/files/neg/warn-inferred-any.check
+++ b/test/files/neg/warn-inferred-any.check
@@ -2,16 +2,16 @@ warn-inferred-any.scala:10: warning: a type was inferred to be `Any`; this may i
   { List(1, 2, 3) contains "a" }  // only this warns
                   ^
 warn-inferred-any.scala:18: warning: a type was inferred to be `AnyVal`; this may indicate a programming error.
-  { 1L to 5L contains 5 }
+  { 1L to 5L contains 5 }         // warn
              ^
 warn-inferred-any.scala:19: warning: a type was inferred to be `AnyVal`; this may indicate a programming error.
-  { 1L to 5L contains 5d }
+  { 1L to 5L contains 5d }        // warn
              ^
 warn-inferred-any.scala:27: warning: a type was inferred to be `Any`; this may indicate a programming error.
   def za = f(1, "one")
            ^
 warn-inferred-any.scala:37: warning: a type was inferred to be `Object`; this may indicate a programming error.
-  cs.contains(new C2) // warns
+  cs.contains(new C2)             // warns
      ^
 error: No warnings can be incurred under -Werror.
 5 warnings found

--- a/test/files/neg/warn-inferred-any.scala
+++ b/test/files/neg/warn-inferred-any.scala
@@ -14,15 +14,15 @@ trait Xs[+A] {
 }
 
 trait Ys[+A] {
-  { 1 to 5 contains 5L }
-  { 1L to 5L contains 5 }
-  { 1L to 5L contains 5d }
+  { 1 to 5 contains 5L }          // should warn: scala.Predef.intWrapper(1).to(5).contains[AnyVal](5L)
+  { 1L to 5L contains 5 }         // warn
+  { 1L to 5L contains 5d }        // warn
   { 1L to 5L contains 5L }
 }
 
 trait Zs {
   def f[A](a: A*) = 42
-  def g[A >: Any](a: A*) = 42  // don't warn
+  def g[A >: Any](a: A*) = 42     // don't warn
 
   def za = f(1, "one")
   def zu = g(1, "one")
@@ -33,6 +33,40 @@ class C2
 
 trait Cs {
   val cs = List(new C1)
-  cs.contains[AnyRef](new C2) // doesn't warn
-  cs.contains(new C2) // warns
+  cs.contains[AnyRef](new C2)     // doesn't warn
+  cs.contains(new C2)             // warns
 }
+
+object t11798 {
+
+  trait ZIO[-R, +E, +A]
+  type Task[A] = ZIO[Any, Throwable, A]  // explicit Any
+
+  trait ZStream[-R, +E, +A] {
+    def mapM[R1 <: R, E1 >: E, B](f: A => ZIO[R1, E1, B]): ZStream[R1, E1, B] =
+      ???
+  }
+
+  val stream: ZStream[Any, Throwable, Int] = ???
+  def f(n: Int): Task[Int] = ???
+  stream.mapM(f)                  // should not warn
+  stream.mapM(n => (f(n): ZIO[Any, Throwable, Int]))
+  stream.mapM(f: Int => ZIO[Any, Throwable, Int])
+}
+
+/**
+ * 1 to 5 contains 5L fails to warn, because silent mode due to overload
+ *
+scala> :type 1 to 5
+scala.collection.immutable.Range.Inclusive
+
+scala> :type 1L to 5L
+scala.collection.immutable.NumericRange.Inclusive[Long]
+
+warning: !!! HK subtype check on scala.this.Int and [B >: scala.this.Int]B, but both don't normalize to polytypes:
+  tp1=scala.this.Int       ClassNoArgsTypeRef
+  tp2=[B >: scala.this.Int]B PolyType
+[log typer] infer method alt value contains with alternatives List([B >: scala.this.Int](<param> elem: B)scala.this.Boolean, (<param> x: scala.this.Int)scala.this.Boolean) argtpes=List(5L) pt=?
+[log typer] infer method inst scala.Predef.intWrapper(1).to(5).contains[B], tparams = List(type B), args = List(scala.this.Long(5L)), pt = ?, lobounds = List(scala.this.Int), parambounds = List( >: scala.this.Int)
+[log typer] checkKindBounds0(List(type B), List(scala.this.AnyVal), <noprefix>, <none>, true)
+ */


### PR DESCRIPTION
When examining trees for explicit top types,
look at all aliases.

Fixes scala/bug#11798