### PR TITLE
Exclude universal members (getClass, toString, etc) from root module import

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -39,7 +39,7 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
   def mkImport(qualSym: Symbol, name: Name, toName: Name): Import =
     mkImportFromSelector(qualSym, ImportSelector(name, 0, toName, 0) :: Nil)
 
-  private def mkImportFromSelector(qualSym: Symbol, selector: List[ImportSelector]): Import = {
+  def mkImportFromSelector(qualSym: Symbol, selector: List[ImportSelector]): Import = {
     assert(qualSym ne null, this)
     val qual = gen.mkAttributedStableRef(qualSym)
     val importSym = (

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -498,6 +498,7 @@ trait Trees extends api.Trees {
     val wild     = ImportSelector(nme.WILDCARD, -1, null, -1)
     val wildList = List(wild) // OPT This list is shared for performance.
     def wildAt(pos: Int) = ImportSelector(nme.WILDCARD, pos, null, -1)
+    def mask(name: Name) = ImportSelector(name, -1, nme.WILDCARD, -1)
   }
 
   case class Import(expr: Tree, selectors: List[ImportSelector])

--- a/test/files/neg/t5389.check
+++ b/test/files/neg/t5389.check
@@ -1,0 +1,4 @@
+t5389.scala:2: error: not found: object ne
+import ne.scala
+       ^
+one error found

--- a/test/files/neg/t5389.scala
+++ b/test/files/neg/t5389.scala
@@ -1,0 +1,4 @@
+
+import ne.scala
+
+class C


### PR DESCRIPTION
`definitions.isImportable` makes the faulty assertion that universal members are not importable.

In fact, they are imported by default from `Predef`. This is observable in scala 2 imports and in scala 3 top level definitions.

Fixes scala/bug#5389