### PR TITLE
Plug many variance holes (in higher-kinded types, refined types and private inner classes)

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1564,8 +1564,6 @@ abstract class RefChecks extends Transform {
 
       if (!sym.exists)
         devWarning("Select node has NoSymbol! " + tree + " / " + tree.tpe)
-      else if (sym.isLocalToThis)
-        varianceValidator.checkForEscape(sym, currentClass)
 
       def checkSuper(mix: Name) =
         // term should have been eliminated by super accessors

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -893,9 +893,9 @@ abstract class RefChecks extends Transform {
         case ClassInfoType(parents, _, clazz) => "supertype "+intersectionType(parents, clazz.owner)
         case _                                => "type "+tp
       }
-      override def issueVarianceError(base: Symbol, sym: Symbol, required: Variance): Unit = {
+      override def issueVarianceError(base: Symbol, sym: Symbol, required: Variance, tpe: Type): Unit = {
         reporter.error(base.pos,
-          s"${sym.variance} $sym occurs in $required position in ${tpString(base.info)} of $base")
+          s"${sym.variance} $sym occurs in $required position in ${tpString(tpe)} of $base")
       }
     }
 
@@ -1772,13 +1772,11 @@ abstract class RefChecks extends Transform {
             result.transform(this)
         }
         result1 match {
-          case ClassDef(_, _, _, _)
-             | TypeDef(_, _, _, _)
-             | ModuleDef(_, _, _) =>
+          case ClassDef(_, _, _, _) | TypeDef(_, _, _, _) | ModuleDef(_, _, _) =>
             if (result1.symbol.isLocalToBlock || result1.symbol.isTopLevel)
               varianceValidator.traverse(result1)
           case tt @ TypeTree() if tt.original != null =>
-            varianceValidator.traverse(tt.original) // See scala/bug#7872
+            varianceValidator.validateVarianceOfPolyTypesIn(tt.tpe)
           case _ =>
         }
 

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -287,6 +287,7 @@ trait Variances {
       case PolyType(tparams, restpe)                       => inSyms(tparams).flip & inType(restpe)
       case ExistentialType(tparams, restpe)                => inSyms(tparams)      & inType(restpe)
       case AnnotatedType(annots, tp)                       => inAnnots(annots)     & inType(tp)
+      case SuperType(thistpe, supertpe)                    => inType(thistpe)      & inType(supertpe)
     }
 
     def apply(tp: Type, tparam: Symbol): Variance = {

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -49,15 +49,18 @@ trait Variances {
       else escapedLocals += sym
     }
 
-    protected def issueVarianceError(base: Symbol, sym: Symbol, required: Variance): Unit = ()
+    protected def issueVarianceError(base: Symbol, sym: Symbol, required: Variance, tpe: Type): Unit = ()
 
     // Flip occurrences of type parameters and parameters, unless
     //  - it's a constructor, or case class factory or extractor
+    //  - it's a type parameter / parameter of a local definition
     //  - it's a type parameter of tvar's owner.
     def shouldFlip(sym: Symbol, tvar: Symbol) = (
          sym.isParameter
+      && !sym.owner.isLocalToThis
       && !(tvar.isTypeParameterOrSkolem && sym.isTypeParameterOrSkolem && tvar.owner == sym.owner)
     )
+
     // Is `sym` is local to a term or is private[this] or protected[this]?
     def isExemptFromVariance(sym: Symbol): Boolean = !sym.owner.isClass || (
          (sym.isLocalToThis || sym.isSuperAccessor) // super accessors are implicitly local #4345
@@ -66,6 +69,7 @@ trait Variances {
 
     private object ValidateVarianceMap extends VariancedTypeMap {
       private[this] var base: Symbol = _
+      private[this] var lowerBoundStack: List[Symbol] = Nil
 
       /** The variance of a symbol occurrence of `tvar` seen at the level of the definition of `base`.
        *  The search proceeds from `base` to the owner of `tvar`.
@@ -85,12 +89,14 @@ trait Variances {
           else v
 
         @tailrec
-        def loop(sym: Symbol, v: Variance): Variance = (
-          if (sym == tvar.owner || v.isBivariant) v
+        def loop(sym: Symbol, v: Variance): Variance =
+          if (v.isBivariant) v
+          else if (sym == tvar.owner) if (lowerBoundStack.contains(sym)) v.flip else v
           else loop(sym.owner, nextVariance(sym, v))
-        )
+
         loop(base, Covariant)
       }
+
       def isUncheckedVariance(tp: Type) = tp match {
         case AnnotatedType(annots, _)    => annots exists (_ matches definitions.uncheckedVarianceClass)
         case _                           => false
@@ -104,17 +110,19 @@ trait Variances {
           def base_s = s"$base in ${base.owner}" + (if (base.owner.isClass) "" else " in " + base.owner.enclClass)
           log(s"verifying $sym_s is $required at $base_s")
           if (sym.variance != required)
-            issueVarianceError(base, sym, required)
+            issueVarianceError(base, sym, required, base.info)
         }
       }
+
       override def mapOver(decls: Scope): Scope = {
         decls foreach (sym => withVariance(if (sym.isAliasType) Invariant else variance)(this(sym.info)))
         decls
       }
+
       private def resultTypeOnly(tp: Type) = tp match {
-        case mt: MethodType => !inRefinement
-        case pt: PolyType   => true
-        case _              => false
+        case _: MethodType => !inRefinement
+        case _: PolyType   => true
+        case _             => false
       }
 
       /** For PolyTypes, type parameters are skipped because they are defined
@@ -125,12 +133,12 @@ trait Variances {
       def apply(tp: Type): Type = {
         tp match {
           case _ if isUncheckedVariance(tp)                    =>
-          case _ if resultTypeOnly(tp)                         => this(tp.resultType)
-          case TypeRef(_, sym, _) if shouldDealias(sym)        => this(tp.normalize)
-          case TypeRef(_, sym, _) if !sym.variance.isInvariant => checkVarianceOfSymbol(sym) ; tp.mapOver(this)
+          case _ if resultTypeOnly(tp)                         => apply(tp.resultType)
+          case TypeRef(_, sym, _) if shouldDealias(sym)        => apply(tp.normalize)
+          case TypeRef(_, sym, _) if !sym.variance.isInvariant => checkVarianceOfSymbol(sym); tp.mapOver(this)
           case RefinedType(_, _)                               => withinRefinement(tp.mapOver(this))
-          case ClassInfoType(parents, _, _)                    => parents foreach this
-          case mt @ MethodType(_, result)                      => flipped(mt.paramTypes foreach this) ; this(result)
+          case ClassInfoType(parents, _, _)                    => parents.foreach(apply)
+          case mt @ MethodType(_, result)                      => flipped(mt.paramTypes.foreach(apply)); apply(result)
           case _                                               => tp.mapOver(this)
         }
         // We're using TypeMap here for type traversal only. To avoid wasteful symbol
@@ -138,24 +146,65 @@ trait Variances {
         // than the result of the pattern match above, which normalizes types.
         tp
       }
+
       private def shouldDealias(sym: Symbol): Boolean = {
         // The RHS of (private|protected)[this] type aliases are excluded from variance checks. This is
         // implemented in relativeVariance.
         // As such, we need to expand references to them to retain soundness. Example: neg/t8079a.scala
         sym.isAliasType && isExemptFromVariance(sym)
       }
+
+      /** Validate the variance of types in the definition of `base`. */
       def validateDefinition(base: Symbol): Unit = {
-        val saved = this.base
         this.base = base
-        try apply(base.info)
-        finally this.base = saved
+        base.info match {
+          case PolyType(_, TypeBounds(lo, hi)) =>
+            lowerBoundStack ::= base
+            try flipped(apply(lo))
+            finally lowerBoundStack = lowerBoundStack.tail
+            apply(hi)
+          case other =>
+            apply(other)
+        }
       }
     }
 
-    /** Validate variance of info of symbol `base` */
-    private def validateVariance(base: Symbol): Unit = {
-      ValidateVarianceMap validateDefinition base
+    private object PolyTypeVarianceMap extends TypeMap {
+
+      private def ownerOf(pt: PolyType): Symbol =
+        pt.typeParams.head.owner
+
+      private def checkPolyTypeParam(pt: PolyType, tparam: Symbol, tpe: Type): Unit =
+        if (!tparam.isInvariant) {
+          val required = varianceInType(tpe)(tparam)
+          if (!required.isBivariant && tparam.variance != required)
+            issueVarianceError(ownerOf(pt), tparam, required, pt)
+        }
+
+      def apply(tp: Type): Type = {
+        tp match {
+          case pt @ PolyType(typeParams, TypeBounds(lo, hi)) =>
+            typeParams.foreach { tparam =>
+              checkPolyTypeParam(pt, tparam, lo)
+              checkPolyTypeParam(pt, tparam, hi)
+            }
+
+            pt.mapOver(this)
+
+          case pt @ PolyType(typeParams, resultType) =>
+            typeParams.foreach(checkPolyTypeParam(pt, _, resultType))
+            pt.mapOver(this)
+
+          case _ =>
+            tp.mapOver(this)
+        }
+
+        tp
+      }
     }
+
+    def validateVarianceOfPolyTypesIn(tpe: Type): Unit =
+      PolyTypeVarianceMap(tpe)
 
     override def traverse(tree: Tree): Unit = {
       def sym = tree.symbol
@@ -163,37 +212,36 @@ trait Variances {
       // Or constructors, or case class factory or extractor.
       def skip = (
            sym == NoSymbol
-        || sym.isLocalToThis
-        || sym.owner.isConstructor
-        || sym.owner.isCaseApplyOrUnapply
+        || sym.owner.isConstructor                  // FIXME: this is unsound - scala/bug#8737
+        || sym.owner.isCaseApplyOrUnapply           // same treatment as constructors
+        || sym.isParamAccessor && sym.isLocalToThis // local class parameters are construction only
       )
+
       tree match {
-        case defn: MemberDef if skip =>
+        case _: MemberDef if skip =>
           debuglog(s"Skipping variance check of ${sym.defString}")
         case ClassDef(_, _, _, _) | TypeDef(_, _, _, _) =>
-          validateVariance(sym)
+          ValidateVarianceMap.validateDefinition(sym)
           tree.traverse(this)
         case ModuleDef(_, _, _) =>
-          validateVariance(sym.moduleClass)
+          ValidateVarianceMap.validateDefinition(sym.moduleClass)
           tree.traverse(this)
         case ValDef(_, _, _, _) =>
-          validateVariance(sym)
+          ValidateVarianceMap.validateDefinition(sym)
         case DefDef(_, _, tparams, vparamss, _, _) =>
-          validateVariance(sym)
+          ValidateVarianceMap.validateDefinition(sym)
           traverseTrees(tparams)
           traverseTreess(vparamss)
         case Template(_, _, _) =>
           tree.traverse(this)
-        case CompoundTypeTree(templ) =>
+        case CompoundTypeTree(_) =>
           tree.traverse(this)
-
         // scala/bug#7872 These two cases make sure we don't miss variance exploits
         // in originals, e.g. in `foo[({type l[+a] = List[a]})#l]`
         case tt @ TypeTree() if tt.original != null =>
           tt.original.traverse(this)
-        case tt : TypTree =>
+        case tt: TypTree =>
           tt.traverse(this)
-
         case _ =>
       }
     }
@@ -230,7 +278,7 @@ trait Variances {
       case ThisType(_) | ConstantType(_)                   => Bivariant
       case TypeRef(_, tparam, _) if tparam eq this.tparam  => Covariant
       case NullaryMethodType(restpe)                       => inType(restpe)
-      case SingleType(pre, sym)                            => inType(pre)
+      case SingleType(pre, _)                              => inType(pre)
       case TypeRef(pre, _, _) if tp.isHigherKinded         => inType(pre)          // a type constructor cannot occur in tp's args
       case TypeRef(pre, sym, args)                         => inType(pre)          & inArgs(sym, args)
       case TypeBounds(lo, hi)                              => inType(lo).flip      & inType(hi)

--- a/test/files/neg/t7872.check
+++ b/test/files/neg/t7872.check
@@ -1,7 +1,7 @@
 t7872.scala:6: error: contravariant type a occurs in covariant position in type [-a]Cov[a] of type l
   type x = {type l[-a] = Cov[a]}
                  ^
-t7872.scala:8: error: covariant type a occurs in contravariant position in type [+a]Inv[a] of type l
+t7872.scala:8: error: covariant type a occurs in contravariant position in type [+a]Inv[a] of value <local l>
   foo[({type l[+a] = Inv[a]})#l]
              ^
 t7872.scala:5: error: contravariant type a occurs in covariant position in type [-a]Cov[a] of type l

--- a/test/files/neg/t7872b.check
+++ b/test/files/neg/t7872b.check
@@ -1,7 +1,7 @@
-t7872b.scala:8: error: contravariant type a occurs in covariant position in type [-a]List[a] of type l
+t7872b.scala:8: error: contravariant type a occurs in covariant position in type [-a]List[a] of value <local l>
   def oops1 = down[({type l[-a] = List[a]})#l](List('whatever: Object)).head + "oops"
                           ^
-t7872b.scala:19: error: covariant type a occurs in contravariant position in type [+a]coinv.Stringer[a] of type l
+t7872b.scala:19: error: covariant type a occurs in contravariant position in type [+a]a => String of value <local l>
   def oops2 = up[({type l[+a] = Stringer[a]})#l]("printed: " + _)
                         ^
 2 errors

--- a/test/files/neg/t9911.check
+++ b/test/files/neg/t9911.check
@@ -1,0 +1,4 @@
+t9911.scala:23: error: super may not be used on value source
+      super.source.getSomething
+            ^
+1 error

--- a/test/files/neg/t9911.scala
+++ b/test/files/neg/t9911.scala
@@ -1,0 +1,28 @@
+// This should say:
+// Error: super may not be used on value source
+class ScalacBug {
+
+  class SomeClass {
+
+    type U
+
+    // Changing T or U stops the problem
+    def getSomething[T]: U = ???
+  }
+
+  trait Base {
+
+    // Changing this to a def like it should be stops the problem
+    val source: SomeClass = ???
+  }
+
+  class Bug extends Base {
+
+    override val source = {
+      // Not calling the function stops the problem
+      super.source.getSomething
+      ???
+    }
+  }
+
+}

--- a/test/files/neg/variance-holes.check
+++ b/test/files/neg/variance-holes.check
@@ -1,0 +1,22 @@
+variance-holes.scala:9: error: covariant type x occurs in contravariant position in type [+x, +y] >: F[x,y] of type F2
+    def asWiden[F2[+x, +y] >: F[x, y]]: F2[Int, Int] = v
+                ^
+variance-holes.scala:2: error: contravariant type A occurs in covariant position in type [-A] >: List[A] of type Lower1
+  type Lower1[-A] >: List[A]
+       ^
+variance-holes.scala:5: error: covariant type x occurs in contravariant position in type [+x] >: F[x] of type G
+    type G[+x] >: F[x]
+         ^
+variance-holes.scala:13: error: covariant type A occurs in contravariant position in type AnyRef{type T >: A} of method foo
+    def foo: { type T >: A }
+        ^
+variance-holes.scala:17: error: covariant type A occurs in contravariant position in type AnyRef{type T <: A} of value x
+    def foo(x: { type T <: A }): Unit
+            ^
+variance-holes.scala:20: error: covariant type A occurs in contravariant position in type  <: AnyRef{type T >: A} of type x
+  class RefinedLower[+A, x <: { type T >: A }]
+                         ^
+variance-holes.scala:21: error: covariant type A occurs in contravariant position in type A of value x_=
+  private[this] class PrivateThis[+A](var x: A)
+                                          ^
+7 errors

--- a/test/files/neg/variance-holes.scala
+++ b/test/files/neg/variance-holes.scala
@@ -1,0 +1,22 @@
+object Test {
+  type Lower1[-A] >: List[A]
+
+  class Lower2[F[-_]] {
+    type G[+x] >: F[x]
+  }
+
+  class Lower3[F[-_, -_]](v: F[Int, Int]) {
+    def asWiden[F2[+x, +y] >: F[x, y]]: F2[Int, Int] = v
+  }
+
+  trait Refined1[+A] {
+    def foo: { type T >: A }
+  }
+
+  trait Refined2[+A] {
+    def foo(x: { type T <: A }): Unit
+  }
+
+  class RefinedLower[+A, x <: { type T >: A }]
+  private[this] class PrivateThis[+A](var x: A)
+}

--- a/test/files/neg/variances.check
+++ b/test/files/neg/variances.check
@@ -1,9 +1,6 @@
 variances.scala:4: error: covariant type A occurs in contravariant position in type test.Vector[A] of value x
   def append(x: Vector[A]): Vector[A]
              ^
-variances.scala:75: error: covariant type A occurs in contravariant position in type A => A of value m
-      val m: A => A
-          ^
 variances.scala:18: error: covariant type A occurs in contravariant position in type A of value a
     private def setA3(a : A) = this.a = a
                       ^
@@ -22,4 +19,4 @@ variances.scala:89: error: covariant type T occurs in invariant position in type
 variances.scala:90: error: covariant type A occurs in contravariant position in type test.TestAlias.B[C.this.A] of method foo
     def foo: B[A]
         ^
-8 errors
+7 errors

--- a/test/files/pos/t9725.scala
+++ b/test/files/pos/t9725.scala
@@ -1,0 +1,14 @@
+trait Foo1[-X] { def bar[Y <: X](y: Y) = y } // typechecks
+
+// A variant of Foo1 encoding the type parameter Y using a dependent method type.
+// error: contravariant type X occurs in covariant position in type  <: X of type Y
+trait Foo2[-X] { def bar(x: { type Y <: X })(y: x.Y) = y }
+
+trait Foo3[+X] { def bar[Y >: X](y: Y) = y } // typechecks
+
+// A variant of Foo3 using a dependent method type.
+// error: covariant type X occurs in contravariant position in type  >: X of type Y
+trait Foo4[+X] { def bar(x: { type Y >: X })(y: x.Y) = y }
+
+// error: covariant type X occurs in contravariant position in type  >: X of type Y
+trait Foo9[+X] { def bar(x: { type Y >: X }): Any }

--- a/test/files/pos/variance-holes.scala
+++ b/test/files/pos/variance-holes.scala
@@ -29,8 +29,18 @@ object Test {
   class RefinedUpper2[+A, x <: { type T[_ <: A] }]
   trait RefinedLower[+A, x <: { type T[_ >: A] }]
 
-  class PrivateThis[+A] {
+  class PrivateThis1[+A] {
     private[this] object Foo { var x: A = _ }
+  }
+
+  class PrivateThis2[-A] {
+    private[this] val x: Set[A] = Set.empty
+    private[this] var y: Set[A] = Set.empty
+
+    class Escape {
+      println(x)
+      println(y)
+    }
   }
 
   def generic[A]: Unit = ()

--- a/test/files/pos/variance-holes.scala
+++ b/test/files/pos/variance-holes.scala
@@ -1,0 +1,37 @@
+object Test {
+  type Lower1[+A] >: List[A]
+
+  class Lower2[F[+_]] {
+    type G[+x] >: F[x]
+  }
+
+  class Lower3[F[+_, +_]](v: F[Int, Int]) {
+    def asWiden[F2[+x, +y] >: F[x, y]]: F2[Int, Int] = v
+  }
+
+  trait Refined1[+A] {
+    def foo: { type T <: A }
+  }
+
+  trait Refined2[+A] {
+    def foo(x: { type T >: A }): Unit
+  }
+
+  class Refined3[+A] {
+    generic[{ type T >: A } => Int]
+  }
+
+  class Refined4[+A] {
+    generic[{ type T <: A } => Int]
+  }
+
+  class RefinedUpper1[+A, x <: { type T <: A }]
+  class RefinedUpper2[+A, x <: { type T[_ <: A] }]
+  trait RefinedLower[+A, x <: { type T[_ >: A] }]
+
+  class PrivateThis[+A] {
+    private[this] object Foo { var x: A = _ }
+  }
+
+  def generic[A]: Unit = ()
+}


### PR DESCRIPTION
Most examples are fixed in dotty.

The variance checks root in `RefChecks` for `TypeTree`s is modified
to check only the variance of `PolyType`s (this includes type lambdas).
Checking the definition of the `PolyType`s' owners is not correct,
because `relativeVariance` doesn't work for types in arbitrary position.

To check the variance of `PolyType`s we introduce a new type map:
`PolyTypeVarianceMap`. This is similar to the way variance is checked
for type lambdas in dotty, where type lambdas are encoded explicitly.

We also add explicit tracking for lower bounds of `PolyType`s.
For a type parameter of a `PolyType`, the variance should not be
flipped (or equivalently, flipped twice) in the lower bound.
This applies to both `ValidateVarianceMap` and `PolyTypeVarianceMap`.
It fixes variance bugs for types appering in the bounds of HKTs.

Finally, we don't skip local definitions entirely (this is unsound),
but instead cutoff `relativeVariance` at local boundaries.

Fixes scala/bug#11789, fixes scala/bug#9911, fixes scala/bug#9725