### PR TITLE
"Improve" root import filter for universal members

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -250,7 +250,7 @@ trait Definitions extends api.StandardDefinitions {
      *  - constructors, because <init> is not a real name
      *  - private[this] members, which cannot be referenced from anywhere else
      *  - members of Any or Object, because every instance will inherit a
-     *    definition which supersedes the imported one
+     *    definition which supersedes the imported one, unless renamed
      */
     def isUnimportable(sym: Symbol) = (
          (sym eq NoSymbol)


### PR DESCRIPTION
Instead of elaborate import selector machinery,
just filter at ImportInfo.

Follow-up to https://github.com/scala/scala/pull/8541 with JZ's clever suggestion.

He really doesn't like it when you mess up his benchmarks.