### PR TITLE
[REVERTED] Test for fixed private this var ctor param

### DIFF
--- a/test/files/run/t6165.scala
+++ b/test/files/run/t6165.scala
@@ -1,0 +1,10 @@
+
+
+class C(private[this] var c: String) {
+  c = "changed"
+  def f = c
+}
+
+object Test extends App {
+  assert(new C("changeme").f == "changed")
+}


### PR DESCRIPTION
Test for scala/bug#6165 fixed in 2.13.0-RC1.