### PR TITLE
REPL Fix :type command to not lose literal type

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -1269,7 +1269,10 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
     *  -c complete - leave nothing out
     */
   override def typeCommandInternal(expr: String, verbose: Boolean): (String, String) = {
-    symbolOfLine(expr) match {
+
+    // first assume that most user entering into :type command would put in an existing term name
+    // rather than some expression that requires additional interpretation.
+    (symbolOfTerm(expr) orElse symbolOfLine(expr)) match {
       case NoSymbol => ("", "")
       case sym => exitingTyper {
         (getterToResultTp(sym).toString, if (verbose) deconstruct.show(getterToResultTp(sym)).toString else "")

--- a/test/files/run/repl-type.check
+++ b/test/files/run/repl-type.check
@@ -1,0 +1,38 @@
+
+scala> :type 42
+Int
+
+scala> val x: 23 = 23
+val x: 23 = 23
+
+scala> :type x
+23
+
+scala> :type (23: 23)
+Int
+
+scala> val y = x
+val y: Int = 23
+
+scala> :type y
+Int
+
+scala> final val z = x
+val z: 23 = 23
+
+scala> :type z
+23
+
+scala> def xx: 23 = 23
+def xx: 23
+
+scala> :type xx
+=> 23
+
+scala> final val yy = xx
+val yy: 23 = 23
+
+scala> :type yy
+23
+
+scala> :quit

--- a/test/files/run/repl-type.scala
+++ b/test/files/run/repl-type.scala
@@ -1,0 +1,20 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def extraSettings = "-feature -language:_"
+
+  def code = """
+:type 42
+val x: 23 = 23
+:type x
+:type (23: 23)
+val y = x
+:type y
+final val z = x
+:type z
+def xx: 23 = 23
+:type xx
+final val yy = xx
+:type yy
+  """.trim
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11786

In Scala 2.13.1 the type of term `x: 23` is already correctly typed to 23.

```
scala> val x: 23 = 23
x: 23 = 23

scala> intp.typeOfTerm("x")
res0: $r.intp.global.Type = => 23
```

The problem happens in `:type` command when it uses `symbolOfLine` where it tries to relitigate the input `x` as a line. This fixes that by assuming that good faith user would pass in a term into `:type` command most of the times.