### PR TITLE
REPL Fix :type command to not widen literal types

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -1151,7 +1151,9 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
     }
 
   def symbolOfLine(code: String): Symbol =
-    exprTyper.symbolOfLine(code)
+    // specific to :type command, it might need interpret code again with
+    // 'final val' instead of 'def', to infer literal type
+    exprTyper.symbolOfLine(code, allowInterpretTwice = true)
 
   def typeOfExpression(expr: String, silent: Boolean = true): Type =
     exprTyper.typeOfExpression(expr, silent)

--- a/test/files/run/repl-type-literal.check
+++ b/test/files/run/repl-type-literal.check
@@ -1,0 +1,35 @@
+
+scala> :type 42
+Int
+
+scala> val x: 23 = 23
+val x: 23 = 23
+
+scala> :type x
+23
+
+scala> val y = x
+val y: Int = 23
+
+scala> :type y
+Int
+
+scala> final val z = x
+val z: 23 = 23
+
+scala> :type z
+23
+
+scala> def xx: 23 = 23
+def xx: 23
+
+scala> :type xx
+Int
+
+scala> final val yy = xx
+val yy: 23 = 23
+
+scala> :type yy
+23
+
+scala> :quit

--- a/test/files/run/repl-type-literal.scala
+++ b/test/files/run/repl-type-literal.scala
@@ -1,0 +1,31 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def extraSettings = "-feature -language:_"
+
+  def code = """
+:type 42
+val x: 23 = 23
+:type x
+val y = x
+:type y
+final val z = x
+:type z
+def xx: 23 = 23
+:type xx
+final val yy = xx
+:type yy
+  """.trim
+}


### PR DESCRIPTION
Fixes scala/bug#11786

I think the below would make sense now

```scala
scala> :type 42
Int

scala> val x: 23 = 23
val x: 23 = 23

scala> :type x
23

scala> val y = x
val y: Int = 23

scala> :type y
Int

scala> final val z = x
val z: 23 = 23

scala> :type z
23

scala> def xx: 23 = 23
def xx: 23

scala> :type xx
Int

scala> final val yy = xx
val yy: 23 = 23

scala> :type yy
23
```