### PR TITLE
Add a mode to write separate .sig files without really private members

### DIFF
--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -13,9 +13,12 @@
 package scala.tools.nsc
 
 import java.net.URL
+
+import scala.tools.nsc.settings.{DefaultPathFactory, PathFactory}
 import scala.tools.util.PathResolver
 
-class GenericRunnerSettings(error: String => Unit) extends Settings(error) {
+class GenericRunnerSettings(error: String => Unit, pathFactory: PathFactory) extends Settings(error, pathFactory) {
+  def this(error: String => Unit) = this(error, DefaultPathFactory)
   lazy val classpathURLs: Seq[URL] = {
     val registry = new CloseableRegistry
     try {

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -367,7 +367,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   def getSourceFile(f: AbstractFile): BatchSourceFile = new BatchSourceFile(f, reader read f)
 
   def getSourceFile(name: String): SourceFile = {
-    val f = AbstractFile.getFile(name)
+    val f = settings.pathFactory.getFile(name)
     if (f eq null) throw new FileNotFoundException(
       "source file '" + name + "' could not be found")
     getSourceFile(f)
@@ -874,11 +874,11 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
         case cp: ClassPath => Seq(cp)
       }
 
-      val dir = AbstractFile.getDirectory(path) // if path is a `jar`, this is a FileZipArchive (isDirectory is true)
+      val dir = settings.pathFactory.getDirectory(path) // if path is a `jar`, this is a FileZipArchive (isDirectory is true)
       val canonical = dir.canonicalPath         // this is the canonical path of the .jar
       def matchesCanonical(e: ClassPath) = origin(e) match {
         case Some(opath) =>
-          AbstractFile.getDirectory(opath).canonicalPath == canonical
+          settings.pathFactory.getDirectory(opath).canonicalPath == canonical
         case None =>
           false
       }

--- a/src/compiler/scala/tools/nsc/Settings.scala
+++ b/src/compiler/scala/tools/nsc/Settings.scala
@@ -12,11 +12,12 @@
 
 package scala.tools.nsc
 
-import settings.MutableSettings
+import settings.{DefaultPathFactory, MutableSettings, PathFactory}
 
 /** A compatibility stub.
  */
-class Settings(errorFn: String => Unit) extends MutableSettings(errorFn) {
+class Settings(errorFn: String => Unit, pathFactory: PathFactory) extends MutableSettings(errorFn, pathFactory) {
+  def this(errorFn: String => Unit) = this(errorFn, DefaultPathFactory)
   def this() = this(Console.println)
 
   override def withErrorFn(errorFn: String => Unit): Settings = {

--- a/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
@@ -38,7 +38,7 @@ class ClassPathFactory(settings: Settings, closeableRegistry: CloseableRegistry 
   def sourcesInPath(path: String): List[ClassPath] =
     for {
       file <- expandPath(path, expandStar = false)
-      dir <- Option(AbstractFile getDirectory file)
+      dir <- Option(settings.pathFactory.getDirectory(file))
     } yield createSourcePath(dir)
 
 
@@ -50,7 +50,7 @@ class ClassPathFactory(settings: Settings, closeableRegistry: CloseableRegistry 
     for {
       dir <- expandPath(path, expandStar = false)
       name <- expandDir(dir)
-      entry <- Option(AbstractFile.getDirectory(name))
+      entry <- Option(settings.pathFactory.getDirectory(name))
     } yield newClassPath(entry)
 
   def classesInExpandedPath(path: String): IndexedSeq[ClassPath] =
@@ -67,8 +67,8 @@ class ClassPathFactory(settings: Settings, closeableRegistry: CloseableRegistry 
     for {
       file <- expandPath(path, expand)
       dir <- {
-        def asImage = if (file.endsWith(".jimage")) Some(AbstractFile.getFile(file)) else None
-        Option(AbstractFile.getDirectory(file)).orElse(asImage)
+        def asImage = if (file.endsWith(".jimage")) Some(settings.pathFactory.getFile(file)) else None
+        Option(settings.pathFactory.getDirectory(file)).orElse(asImage)
       }
     } yield newClassPath(dir)
 

--- a/src/compiler/scala/tools/nsc/io/SourceReader.scala
+++ b/src/compiler/scala/tools/nsc/io/SourceReader.scala
@@ -59,7 +59,7 @@ class SourceReader(decoder: CharsetDecoder, reporter: Reporter) {
     try file match {
       case p: PlainFile        => read(p.file)
       case z: ZipArchive#Entry => read(Channels.newChannel(z.input))
-      case _                   => read(ByteBuffer.wrap(file.toByteArray))
+      case _                   => read(ByteBuffer.wrap(file.unsafeToByteArray))
     }
     catch {
       case ex: InterruptedException => throw ex

--- a/src/compiler/scala/tools/nsc/settings/FscSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/FscSettings.scala
@@ -17,7 +17,7 @@ package settings
 import util.ClassPath
 import io.{ Path, AbstractFile }
 
-class FscSettings(error: String => Unit) extends Settings(error) {
+class FscSettings(error: String => Unit, pathFactory: PathFactory = DefaultPathFactory) extends Settings(error, pathFactory) {
   outer =>
 
   locally {

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -24,15 +24,16 @@ import scala.reflect.{ ClassTag, classTag }
 
 /** A mutable Settings object.
  */
-class MutableSettings(val errorFn: String => Unit)
+class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
               extends scala.reflect.internal.settings.MutableSettings
                  with AbsSettings
                  with ScalaSettings
                  with Mutable {
+  def this(errorFn: String => Unit) = this(errorFn, DefaultPathFactory)
   type ResultOfTryToSet = List[String]
 
   def withErrorFn(errorFn: String => Unit): MutableSettings = {
-    val settings = new MutableSettings(errorFn)
+    val settings = new MutableSettings(errorFn, pathFactory)
     copyInto(settings)
     settings
   }
@@ -273,8 +274,8 @@ class MutableSettings(val errorFn: String => Unit)
      *  Both directories should exist.
      */
     def add(srcDir: String, outDir: String): Unit = // used in ide?
-      add(checkDir(AbstractFile.getDirectory(srcDir), srcDir),
-          checkDir(AbstractFile.getDirectory(outDir), outDir))
+      add(checkDir(pathFactory.getDirectory(srcDir), srcDir),
+          checkDir(pathFactory.getDirectory(outDir), outDir))
 
     /** Check that dir is exists and is a directory. */
     private def checkDir(dir: AbstractFile, name: String, allowJar: Boolean = false): AbstractFile = (
@@ -290,7 +291,7 @@ class MutableSettings(val errorFn: String => Unit)
      *  be dumped in there, regardless of previous calls to 'add'.
      */
     def setSingleOutput(outDir: String) {
-      val dst = AbstractFile.getDirectory(outDir)
+      val dst = pathFactory.getDirectory(outDir)
       setSingleOutput(checkDir(dst, outDir, allowJar = true))
     }
 

--- a/src/compiler/scala/tools/nsc/settings/PathFactory.scala
+++ b/src/compiler/scala/tools/nsc/settings/PathFactory.scala
@@ -1,0 +1,27 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.nsc.settings
+
+import scala.reflect.io.{AbstractFile, PlainFile}
+
+/** Converts paths provided in compiler options (e.g elements of `-classpath` or the target directory of `-d`) to
+ *  an `AbstractFile`. */
+trait PathFactory {
+  def getDirectory(path: String): AbstractFile
+  def getFile(path: String): AbstractFile
+}
+
+object DefaultPathFactory extends PathFactory {
+  override def getDirectory(path: String): AbstractFile = AbstractFile.getDirectory(path)
+  override def getFile(path: String): AbstractFile = new PlainFile(path)
+}

--- a/src/compiler/scala/tools/nsc/settings/PathFactory.scala
+++ b/src/compiler/scala/tools/nsc/settings/PathFactory.scala
@@ -17,7 +17,22 @@ import scala.reflect.io.{AbstractFile, PlainFile}
 /** Converts paths provided in compiler options (e.g elements of `-classpath` or the target directory of `-d`) to
  *  an `AbstractFile`. */
 trait PathFactory {
+  /**
+   * Convert the given path into an `AbstractFile` representing an existing directory-like structure, such as a
+   * directory on disk, a JAR, or a `VirtualDirectory`. Calling this method will _not_ create the directory
+   * if it is absent.
+   *
+   * @param path The string representing the directory-like path
+   * @return the `AbstractFile`, or `null` if the path does not exist or does not represent a directory.
+   */
   def getDirectory(path: String): AbstractFile
+
+  /**
+   * Convert the given path into an `AbstractFile` representing an file.
+   *
+   * @param path The string representing the file path
+   * @return the `AbstractFile`
+   */
   def getFile(path: String): AbstractFile
 }
 

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -258,7 +258,7 @@ trait ScalaSettings extends AbsScalaSettings
     Deflater.DEFAULT_COMPRESSION, Some((Deflater.DEFAULT_COMPRESSION,Deflater.BEST_COMPRESSION)), (x: String) => None)
   val YpickleJava = BooleanSetting("-Ypickle-java", "Pickler phase should compute pickles for .java defined symbols for use by build tools").internalOnly()
   val YpickleWrite = StringSetting("-Ypickle-write", "directory|jar", "destination for generated .sig files containing type signatures.", "", None).internalOnly()
-  val YpickleWriteNoPrivate = BooleanSetting("-Ypickle-write-no-private", "Exclude private members (other than those material to subclass compilation) from generated .sig files containing type signatures.").internalOnly()
+  val YpickleWriteApiOnly = BooleanSetting("-Ypickle-write-api-only", "Exclude private members (other than those material to subclass compilation, such as private trait vals) from generated .sig files containing type signatures.").internalOnly()
 
   sealed abstract class CachePolicy(val name: String, val help: String)
   object CachePolicy {

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -258,6 +258,7 @@ trait ScalaSettings extends AbsScalaSettings
     Deflater.DEFAULT_COMPRESSION, Some((Deflater.DEFAULT_COMPRESSION,Deflater.BEST_COMPRESSION)), (x: String) => None)
   val YpickleJava = BooleanSetting("-Ypickle-java", "Pickler phase should compute pickles for .java defined symbols for use by build tools").internalOnly()
   val YpickleWrite = StringSetting("-Ypickle-write", "directory|jar", "destination for generated .sig files containing type signatures.", "", None).internalOnly()
+  val YpickleWriteNoPrivate = BooleanSetting("-Ypickle-write-no-private", "Exclude private members (other than those material to subclass compilation) from generated .sig files containing type signatures.").internalOnly()
 
   sealed abstract class CachePolicy(val name: String, val help: String)
   object CachePolicy {

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -148,7 +148,7 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
         this.staticModule = module
         this.isScala = false
 
-        val fileContents = file.toByteArray
+        val fileContents = file.unsafeToByteArray
         this.in = new AbstractFileReader(fileContents)
         val magic = in.getInt(in.bp)
         if (magic != JAVA_MAGIC && file.name.endsWith(".sig")) {

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -24,7 +24,6 @@ import scala.reflect.internal.util.shortClassOfInstance
 import scala.collection.mutable
 import PickleFormat._
 import Flags._
-import scala.reflect.io.PlainFile
 
 /**
  * Serialize a top-level module and/or class.
@@ -61,8 +60,10 @@ abstract class Pickler extends SubComponent {
   class PicklePhase(prev: Phase) extends StdPhase(prev) {
     import global.genBCode.postProcessor.classfileWriters.FileWriter
     private lazy val sigWriter: Option[FileWriter] =
-      if (settings.YpickleWrite.isSetByUser && !settings.YpickleWrite.value.isEmpty)
-        Some(FileWriter(global, new PlainFile(settings.YpickleWrite.value), None))
+      if (settings.YpickleWrite.isSetByUser && !settings.YpickleWrite.value.isEmpty) {
+        val file = settings.pathFactory.getFile(settings.YpickleWrite.value) // might be a JAR (possibly still to be created) or a directory
+        Some(FileWriter(global, file, None))
+      }
       else
         None
 

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -87,7 +87,7 @@ abstract class Pickler extends SubComponent {
                 if (writeToSigFile)
                   writeSigFile(sym, pickle)
               }
-              if (sigWriter.isDefined && settings.YpickleWriteNoPrivate) {
+              if (sigWriter.isDefined && settings.YpickleWriteApiOnly) {
                 pickle(noPrivates = false, writeToSymData = true, writeToSigFile = false)
                 pickle(noPrivates = true, writeToSymData = false, writeToSigFile = true)
               } else {

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -78,7 +78,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
     val classpath: Seq[URL] = if (settings.YmacroClasspath.isSetByUser) {
       for {
         file <- scala.tools.nsc.util.ClassPath.expandPath(settings.YmacroClasspath.value, true)
-        af <- Option(AbstractFile getDirectory file)
+        af <- Option(settings.pathFactory.getDirectory(file))
       } yield af.file.toURI.toURL
     } else global.classPath.asURLs
     def newLoader: () => ScalaClassLoader.URLClassLoader = () => {

--- a/src/reflect/mima-filters/2.12.0.forwards.excludes
+++ b/src/reflect/mima-filters/2.12.0.forwards.excludes
@@ -47,3 +47,6 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.Synchr
 ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.SynchronizedTypes.scala$reflect$runtime$SynchronizedTypes$$super$defineNormalized")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedTypes.defineNormalized")
 ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUniverse.defineNormalized")
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.AbstractFile.unsafeToByteArray")
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.VirtualFile.unsafeToByteArray")
+ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive#Entry.unsafeToByteArray")

--- a/src/reflect/scala/reflect/io/AbstractFile.scala
+++ b/src/reflect/scala/reflect/io/AbstractFile.scala
@@ -193,6 +193,9 @@ abstract class AbstractFile extends Iterable[AbstractFile] {
     }
   }
 
+  /** Returns the context of this file (if applicable) in a byte array. This array might _not_ be defensively copied. */
+  def unsafeToByteArray: Array[Byte] = toByteArray
+
   /** Returns all abstract subfiles of this abstract directory. */
   def iterator: Iterator[AbstractFile]
 

--- a/src/reflect/scala/reflect/io/VirtualFile.scala
+++ b/src/reflect/scala/reflect/io/VirtualFile.scala
@@ -59,6 +59,10 @@ class VirtualFile(val name: String, override val path: String) extends AbstractF
     }
   }
 
+  override def unsafeToByteArray: Array[Byte] = {
+    content
+  }
+
   def container: AbstractFile = NoAbstractFile
 
   /** Is this abstract file a directory? */

--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -94,6 +94,7 @@ abstract class ZipArchive(override val file: JFile, release: Option[String]) ext
     def getArchive: ZipFile = null
     override def underlyingSource = Some(self)
     override def toString = self.path + "(" + path + ")"
+    override def unsafeToByteArray: Array[Byte] = toByteArray
   }
 
   /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */

--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -14,12 +14,14 @@ package scala.tools.nsc
 package doc
 
 import java.io.File
+
 import scala.language.postfixOps
+import scala.tools.nsc.settings.{DefaultPathFactory, PathFactory}
 
 /** An extended version of compiler settings, with additional Scaladoc-specific options.
   * @param error A function that prints a string to the appropriate error stream
   * @param printMsg A function that prints the string, without any extra boilerplate of error */
-class Settings(error: String => Unit, val printMsg: String => Unit = println(_)) extends scala.tools.nsc.Settings(error) {
+class Settings(error: String => Unit, val printMsg: String => Unit = println(_), pathFactory: PathFactory = DefaultPathFactory) extends scala.tools.nsc.Settings(error, pathFactory) {
 
   // TODO 2.13 Remove
   private def removalIn213 = "This flag is scheduled for removal in 2.13. If you have a case where you need this flag then please report a bug."

--- a/test/junit/scala/tools/nsc/Build.scala
+++ b/test/junit/scala/tools/nsc/Build.scala
@@ -1,0 +1,49 @@
+package scala.tools.nsc
+
+import java.io.File
+import java.nio.charset.Charset
+import java.nio.file.{Files, Path}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import FileUtils.createDir
+
+final class Build(base: Path, name: String) {
+
+  val buildBase = createDir(base, name)
+  val scalacOptions = mutable.ListBuffer[String]()
+  final class Project(val name: String) {
+    def fullName: String = Build.this.name + "." + name
+    val base = createDir(buildBase, name)
+    val out = createDir(base, "target")
+    val src = createDir(base, "src")
+    val scalacOptions = mutable.ListBuffer[String]()
+    scalacOptions += "-usejavacp"
+    val classpath = mutable.ListBuffer[Path]()
+    val sources = mutable.ListBuffer[Path]()
+    def withSource(relativePath: String)(code: String): this.type = {
+      val srcFile = src.resolve(relativePath)
+      Files.createDirectories(srcFile.getParent)
+      Files.write(srcFile, code.getBytes(Charset.defaultCharset()))
+      sources += srcFile
+      this
+    }
+    def argsFile(extraOpts: List[String], printArgs: Boolean): Path = {
+      val cp = List("-cp", if (classpath.isEmpty) "__DUMMY__" else classpath.mkString(File.pathSeparator)) // Dummy to avoid default classpath of "."
+      val printArgsOpt = if (printArgs) List("-Xprint-args", "-") else Nil
+      val entries = List(
+        Build.this.scalacOptions.toList,
+        scalacOptions.toList,
+        extraOpts,
+        printArgsOpt,
+        List("-d", out.toString) ::: cp ::: sources.toList.map(_.toString)
+      ).flatten
+      Files.write(out.resolve(fullName + ".args"), entries.asJava)
+    }
+  }
+  private val projectsMap = mutable.LinkedHashMap[String, Project]()
+  def projects: List[Project] = projectsMap.valuesIterator.toList
+  def project(name: String): Project = {
+    projectsMap.getOrElseUpdate(name, new Project(name))
+  }
+}

--- a/test/junit/scala/tools/nsc/Build.scala
+++ b/test/junit/scala/tools/nsc/Build.scala
@@ -19,8 +19,18 @@ final class Build(base: Path, name: String) {
     val src = createDir(base, "src")
     val scalacOptions = mutable.ListBuffer[String]()
     scalacOptions += "-usejavacp"
-    val classpath = mutable.ListBuffer[Path]()
     val sources = mutable.ListBuffer[Path]()
+    object classpath {
+      val value = mutable.ListBuffer[String]()
+      def +=(path: Path): classpath.type = {
+        value += path.toString
+        this
+      }
+      def +=(path: String): classpath.type = {
+        value += path
+        this
+      }
+    }
     def withSource(relativePath: String)(code: String): this.type = {
       val srcFile = src.resolve(relativePath)
       Files.createDirectories(srcFile.getParent)
@@ -28,8 +38,8 @@ final class Build(base: Path, name: String) {
       sources += srcFile
       this
     }
-    def argsFile(extraOpts: List[String], printArgs: Boolean): Path = {
-      val cp = List("-cp", if (classpath.isEmpty) "__DUMMY__" else classpath.mkString(File.pathSeparator)) // Dummy to avoid default classpath of "."
+    def argsFile(extraOpts: List[String] = Nil, printArgs: Boolean = false): Path = {
+      val cp = List("-cp", if (classpath.value.isEmpty) "__DUMMY__" else classpath.value.mkString(File.pathSeparator)) // Dummy to avoid default classpath of "."
       val printArgsOpt = if (printArgs) List("-Xprint-args", "-") else Nil
       val entries = List(
         Build.this.scalacOptions.toList,

--- a/test/junit/scala/tools/nsc/FileUtils.scala
+++ b/test/junit/scala/tools/nsc/FileUtils.scala
@@ -10,6 +10,11 @@ import scala.reflect.io.PlainNioFile
 import scala.tools.nsc.backend.jvm.AsmUtils
 
 object FileUtils {
+  def createDir(dir: Path, s: String): Path = {
+    val subDir = dir.resolve(s)
+    Files.createDirectories(subDir)
+  }
+
   def assertDirectorySame(dir1: Path, dir2: Path, dir2Label: String): Unit = {
     val diffs = FileUtils.diff(dir1, dir2)
     def diffText = {

--- a/test/junit/scala/tools/nsc/PickleWriteTest.scala
+++ b/test/junit/scala/tools/nsc/PickleWriteTest.scala
@@ -1,0 +1,99 @@
+package scala.tools.nsc
+
+import java.nio.file.{Files, Path}
+import java.util.regex.Pattern
+
+import org.junit.{After, Before, Test}
+
+import scala.reflect.io.{AbstractFile, VirtualDirectory}
+import scala.tools.nsc.FileUtils._
+import scala.tools.nsc.settings.{DefaultPathFactory, PathFactory}
+
+class PickleWriteTest {
+  private var base: Path = _
+
+  // Enables verbose output to console to help understand what the test is doing.
+  private val debug = false
+  private var deleteBaseAfterTest = true
+
+  @Before def before(): Unit = {
+    base = Files.createTempDirectory("pickleWriteTest")
+  }
+
+  @After def after(): Unit = {
+    if (base != null && !debug && deleteBaseAfterTest) {
+      deleteRecursive(base)
+    }
+  }
+
+  private def projectsBase = createDir(base, "projects")
+
+  object VirtualFilePathFactory {
+    private val prefix = "_MEMORY_"
+    def path(name: String) = prefix + "/" + name
+    val MemPattern = s"""${Pattern.quote(prefix)}/(.*)""".r
+  }
+  private class VirtualFilePathFactory extends PathFactory {
+    import VirtualFilePathFactory._
+    val virtualDirs = new java.util.concurrent.ConcurrentHashMap[String, VirtualDirectory]()
+    override def getDirectory(path: String): AbstractFile = path match {
+      case MemPattern(ident) => virtualDirs.computeIfAbsent(ident, dirName => new VirtualDirectory(dirName, None))
+      case _ => DefaultPathFactory.getDirectory(path)
+    }
+    override def getFile(path: String): AbstractFile = path match {
+      case MemPattern(ident) => virtualDirs.computeIfAbsent(ident, dirName => new VirtualDirectory(dirName, None))
+      case _ => DefaultPathFactory.getFile(path)
+    }
+
+  }
+
+  @Test
+  def testPickleWriteVirtual(): Unit = {
+    // Demonstrating how to use a custom PathFactory to keep the .sig files in memory. A real build tool
+    // would need to manage merging/deletion of these with the results of prior builds to support incremental compilation.
+    val pathFactory = new VirtualFilePathFactory
+
+    val build = new Build(projectsBase, "b1")
+    val p1 = build.project("p1")
+    val p1ApiVirtual = VirtualFilePathFactory.path("p1")
+    p1.scalacOptions ++= List(
+      "-Ypickle-write", p1ApiVirtual, // write .sig files to the virtual directory
+      "-Ypickle-write-no-private",    // Only export the public API in the .sig files
+      "-Ystop-after:pickler"          // Don't bother creating .class files.
+    )
+    p1.withSource("b1/p1/C.scala")(
+      """
+        |package b1.p1
+        |class C {
+        |  private def foo = 42
+        |  def bar = ""
+        |}
+    """.stripMargin)
+
+    val p2 = build.project("p2")
+    p2.classpath += p1ApiVirtual
+    p2.withSource("b1/p2/Client.scala")(
+      """
+        |package b1.p2
+        |class Client {
+        |  new b1.p1.C().bar.charAt(0)
+        |}
+    """.stripMargin)
+
+    val settings1 = new Settings(Console.println, pathFactory)
+    settings1.usejavacp.value = true
+    val argsFile1 = p1.argsFile()
+    val command1 = new CompilerCommand("@" + argsFile1.toAbsolutePath.toString :: Nil, settings1)
+    val global1 = new Global(command1.settings)
+    new global1.Run().compile(command1.files)
+    assert(!global1.reporter.hasErrors)
+
+    val argsFile2 = p2.argsFile()
+    val settings2 = new Settings(Console.println, pathFactory)
+    settings2.usejavacp.value = true
+    val command2 = new CompilerCommand("@" + argsFile2.toAbsolutePath.toString :: Nil, settings2)
+    val global2 = new Global(command2.settings)
+    new global2.Run().compile(command2.files)
+    assert(!global2.reporter.hasErrors)
+  }
+}

--- a/test/junit/scala/tools/nsc/PickleWriteTest.scala
+++ b/test/junit/scala/tools/nsc/PickleWriteTest.scala
@@ -58,7 +58,7 @@ class PickleWriteTest {
     val p1ApiVirtual = VirtualFilePathFactory.path("p1")
     p1.scalacOptions ++= List(
       "-Ypickle-write", p1ApiVirtual, // write .sig files to the virtual directory
-      "-Ypickle-write-no-private",    // Only export the public API in the .sig files
+      "-Ypickle-write-api-only",      // Only export the public API in the .sig files
       "-Ystop-after:pickler"          // Don't bother creating .class files.
     )
     p1.withSource("b1/p1/C.scala")(


### PR DESCRIPTION
When no source files have changes, a build tools could do a coarse grained up-to-date check before Zinc's more expensive fine-grained check. It could also opt not to use Zinc, and rely solely on the coarse grained check. For the purposes of discussion below, we'll assume the second model. 

The coarse grained check is simply: if the full classpath is unchanged, no recompilation is needed.

This is clearly overly sensitive to irrelevant changes. Firstly, a change to a method implementation trigger downstream recompilation.

We can avoid that problem by using `.sig` files on the classpath, which just contain the Scala APIs. We are now immune to changes in implementations.

However, the .sig files also contain type signatures for private methods, so introducing or editing these will create unwanted recompilation.

This patch introduces `-Ypickle-write-no-privates`, which removes some private members from the `.sig` files in order to make the up-to-date change insensitive to such changes. The ScalaSignature annotations in the `.class` files still contain all members.

Why not all private members? Private vals/vars in traits must not be omitted -- compilation of subclasses need to implement these methods and provide fields to store the data.

Example:

```
➜ cat sandbox/test.scala
trait T {
    def foo = 42
    private val x = 42
    private def blerg = 42
}
class D extends T {
    def d1 = 0
    private def d2 = 2
}

➜ rm -rf /tmp/pickle-test*/*; qscalac -d /tmp/pickle-test -Ypickle-write /tmp/pickle-test-sigs -Ypickle-write-no-private sandbox/test.scala
zsh: sure you want to delete all the files in /tmp/pickle-test* [yn]? y

➜ jardiff -i'*.asm' /tmp/pickle-test /tmp/pickle-test-sigs
diff --git a/D.class.scalap b/D.class.scalap
deleted file mode 100644
index 03b72c3..0000000
--- a/D.class.scalap
+++ /dev/null
@@ -1,5 +0,0 @@
-class D extends scala.AnyRef with T {
-  def this() = { /* compiled code */ }
-  def d1: scala.Int = { /* compiled code */ }
-  private def d2: scala.Int = { /* compiled code */ }
-}
diff --git a/D.sig.scalap b/D.sig.scalap
new file mode 100644
index 0000000..2f2c919
--- /dev/null
+++ b/D.sig.scalap
@@ -0,0 +1,4 @@
+class D extends scala.AnyRef with T {
+  def this() = { /* compiled code */ }
+  def d1: scala.Int = { /* compiled code */ }
+}
diff --git a/T.class.scalap b/T.class.scalap
deleted file mode 100644
index cecca9b..0000000
--- a/T.class.scalap
+++ /dev/null
@@ -1,6 +0,0 @@
-trait T extends scala.AnyRef {
-  def $init$(): scala.Unit = { /* compiled code */ }
-  def foo: scala.Int = { /* compiled code */ }
-  private val x: scala.Int = { /* compiled code */ }
-  private def blerg: scala.Int = { /* compiled code */ }
-}
diff --git a/T.sig.scalap b/T.sig.scalap
new file mode 100644
index 0000000..9e529b5
--- /dev/null
+++ b/T.sig.scalap
@@ -0,0 +1,5 @@
+trait T extends scala.AnyRef {
+  def $init$(): scala.Unit = { /* compiled code */ }
+  def foo: scala.Int = { /* compiled code */ }
+  private val x: scala.Int = { /* compiled code */ }
+}
```

## TODO
 - [ ] Think through the exclusion for trait vals/vars and think of any more cases. Use Zinc's test suite as a guide for this.
 - [ ] Update `PickleExtractor` (which shrinks a regular `.class` files to `.sig` files) with a mode to parse the full pickle and filter out the privates before writing the `.sig`. This will help with third-party JARs.
 When no source files have changes, a build tools could do a coarse grained up-to-date check before Zinc's more expensive fine-grained check. It could also opt not to use Zinc, and really solely on the coarse grained check. For the purposes of discussion below, we'll assume the second model. 

The coarse grained check is simply: if the full classpath is unchanged, no recompilation is needed.

This is clearly overly sensitive to irrelevant changes. Firstly, a change to a method implementation trigger downstream recompilation.

We can avoid that problem by using `.sig` files on the classpath, which just contain the Scala APIs. We are now immune to changes in implementations.

However, the .sig files also contain type signatures for private methods, so introducing or editing these will create unwanted recompilation.

This patch introduces `-Ypickle-write-no-privates`, which removes some private members from the `.sig` files in order to make the up-to-date change insensitive to such changes. The ScalaSignature annotations in the `.class` files still contain all members.

Why not all private members? Private vals/vars in traits must not be omitted -- compilation of subclasses need to implement these methods and provide fields to store the data.

Example:

```
➜ cat sandbox/test.scala
trait T {
    def foo = 42
    private val x = 42
    private def blerg = 42
}
class D extends T {
    def d1 = 0
    private def d2 = 2
}

➜ rm -rf /tmp/pickle-test*/*; qscalac -d /tmp/pickle-test -Ypickle-write /tmp/pickle-test-sigs -Ypickle-write-no-private sandbox/test.scala
zsh: sure you want to delete all the files in /tmp/pickle-test* [yn]? y

➜ jardiff -i'*.asm' /tmp/pickle-test /tmp/pickle-test-sigs
diff --git a/D.class.scalap b/D.class.scalap
deleted file mode 100644
index 03b72c3..0000000
--- a/D.class.scalap
+++ /dev/null
@@ -1,5 +0,0 @@
-class D extends scala.AnyRef with T {
-  def this() = { /* compiled code */ }
-  def d1: scala.Int = { /* compiled code */ }
-  private def d2: scala.Int = { /* compiled code */ }
-}
diff --git a/D.sig.scalap b/D.sig.scalap
new file mode 100644
index 0000000..2f2c919
--- /dev/null
+++ b/D.sig.scalap
@@ -0,0 +1,4 @@
+class D extends scala.AnyRef with T {
+  def this() = { /* compiled code */ }
+  def d1: scala.Int = { /* compiled code */ }
+}
diff --git a/T.class.scalap b/T.class.scalap
deleted file mode 100644
index cecca9b..0000000
--- a/T.class.scalap
+++ /dev/null
@@ -1,6 +0,0 @@
-trait T extends scala.AnyRef {
-  def $init$(): scala.Unit = { /* compiled code */ }
-  def foo: scala.Int = { /* compiled code */ }
-  private val x: scala.Int = { /* compiled code */ }
-  private def blerg: scala.Int = { /* compiled code */ }
-}
diff --git a/T.sig.scalap b/T.sig.scalap
new file mode 100644
index 0000000..9e529b5
--- /dev/null
+++ b/T.sig.scalap
@@ -0,0 +1,5 @@
+trait T extends scala.AnyRef {
+  def $init$(): scala.Unit = { /* compiled code */ }
+  def foo: scala.Int = { /* compiled code */ }
+  private val x: scala.Int = { /* compiled code */ }
+}
```