### PR TITLE
Check if setter is shadowed for assignment

### DIFF
--- a/test/files/run/t3194.scala
+++ b/test/files/run/t3194.scala
@@ -1,0 +1,11 @@
+// scalac: -language:_
+import scala.util.chaining._
+
+class A(var x: Int)
+class B(x: Int) extends A(x) {
+  def update(v: Int): Unit = x = v
+}
+
+object Test extends App {
+  new B(27).tap(_.update(42)).ensuring(_.x == 42)
+}


### PR DESCRIPTION
Since a class parameter is an object-private member,
at least until it is eliminated in constructors,
it may shadow the setter of an actual member.

Check for this case before failing assignment.

Fixes scala/bug#3194