### PR TITLE
Say cannot be accessed as a member, cf dotc

### DIFF
--- a/project/PartestUtil.scala
+++ b/project/PartestUtil.scala
@@ -58,10 +58,19 @@ object PartestUtil {
     val Grep = {
       def expandGrep(x: String): Seq[String] = {
         val matchingFileContent = try {
-          val Pattern = ("(?i)" + x).r
+          val Pattern = raw"(?i)$x".r
           testFiles.allTestCases.filter {
             case (testFile, testPath) =>
-              val assocFiles = List(".check", ".flags").map(testFile.getParentFile / _)
+              def sibling(suffix: String) = {
+                val name = testFile.name
+                val prefix = name.lastIndexOf('.') match {
+                  case -1 => name
+                  case i  => name.substring(0, i)
+                }
+                val next = prefix + suffix
+                testFile.getParentFile / next
+              }
+              val assocFiles = List(".check", ".flags").map(sibling)
               val sourceFiles = if (testFile.isFile) List(testFile) else testFile.**(AllPassFilter).get.toList
               val allFiles = testFile :: assocFiles ::: sourceFiles
               allFiles.exists { f => f.exists && f.isFile && Pattern.findFirstIn(IO.read(f)).isDefined }

--- a/project/PartestUtil.scala
+++ b/project/PartestUtil.scala
@@ -58,7 +58,8 @@ object PartestUtil {
     val Grep = {
       def expandGrep(x: String): Seq[String] = {
         val matchingFileContent = try {
-          val Pattern = raw"(?i)$x".r
+          import scala.util.matching.Regex
+          val re = raw"(?i)${Regex.quote(x)}".r
           testFiles.allTestCases.filter {
             case (testFile, testPath) =>
               def sibling(suffix: String) = {
@@ -73,7 +74,7 @@ object PartestUtil {
               val assocFiles = List(".check", ".flags").map(sibling)
               val sourceFiles = if (testFile.isFile) List(testFile) else testFile.**(AllPassFilter).get.toList
               val allFiles = testFile :: assocFiles ::: sourceFiles
-              allFiles.exists { f => f.exists && f.isFile && Pattern.findFirstIn(IO.read(f)).isDefined }
+              allFiles.exists(f => f.isFile && re.findFirstIn(IO.read(f)).isDefined)
           }
         } catch {
           case _: Throwable => Nil

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1093,8 +1093,9 @@ trait ContextErrors {
       def AccessError(tree: Tree, sym: Symbol, pre: Type, owner0: Symbol, explanation: String): AbsTypeError = {
         val errMsg = {
           val location = if (sym.isClassConstructor) s"in $owner0" else s"as a member of ${pre.widen.directObjectString}"
+          val from = s" from ${owner0.fullLocationString}"
 
-          underlyingSymbol(sym).fullLocationString + " cannot be accessed " + location + explanation
+          underlyingSymbol(sym).fullLocationString + " cannot be accessed " + location + from + explanation
         }
         AccessTypeError(tree, errMsg)
       }

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1091,11 +1091,10 @@ trait ContextErrors {
         AccessError(tree, sym, ctx.enclClass.owner.thisType, ctx.enclClass.owner, explanation)
 
       def AccessError(tree: Tree, sym: Symbol, pre: Type, owner0: Symbol, explanation: String): AbsTypeError = {
-        def errMsg = {
-          val location = if (sym.isClassConstructor) owner0 else pre.widen.directObjectString
+        val errMsg = {
+          val location = if (sym.isClassConstructor) s"in $owner0" else s"as a member of ${pre.widen.directObjectString}"
 
-          underlyingSymbol(sym).fullLocationString + " cannot be accessed in " +
-          location + explanation
+          underlyingSymbol(sym).fullLocationString + " cannot be accessed " + location + explanation
         }
         AccessTypeError(tree, errMsg)
       }

--- a/test/files/neg/private-implicit-class.check
+++ b/test/files/neg/private-implicit-class.check
@@ -1,4 +1,4 @@
-private-implicit-class.scala:6: error: method BarExtender in class ImplicitsPrivate cannot be accessed as a member of ImplicitsPrivate
+private-implicit-class.scala:6: error: method BarExtender in class ImplicitsPrivate cannot be accessed as a member of ImplicitsPrivate from class TestPrivate
   override implicit def BarExtender(bar: Int) = super.BarExtender(bar) // error
                                                       ^
 one error found

--- a/test/files/neg/private-implicit-class.check
+++ b/test/files/neg/private-implicit-class.check
@@ -1,4 +1,4 @@
-private-implicit-class.scala:6: error: method BarExtender in class ImplicitsPrivate cannot be accessed in ImplicitsPrivate
+private-implicit-class.scala:6: error: method BarExtender in class ImplicitsPrivate cannot be accessed as a member of ImplicitsPrivate
   override implicit def BarExtender(bar: Int) = super.BarExtender(bar) // error
                                                       ^
 one error found

--- a/test/files/neg/protected-constructors.check
+++ b/test/files/neg/protected-constructors.check
@@ -1,4 +1,4 @@
-protected-constructors.scala:15: error: class Foo3 in object Ding cannot be accessed in object dingus.Ding
+protected-constructors.scala:15: error: class Foo3 in object Ding cannot be accessed as a member of object dingus.Ding
  Access to protected class Foo3 not permitted because
  enclosing object P in package hungus is not a subclass of
  object Ding in package dingus where target is defined
@@ -16,7 +16,7 @@ protected-constructors.scala:18: error: constructor Foo2 in class Foo2 cannot be
  class Foo2 in package dingus where target is defined
     val foo2 = new Foo2("abc")
                ^
-protected-constructors.scala:19: error: class Foo3 in object Ding cannot be accessed in object dingus.Ding
+protected-constructors.scala:19: error: class Foo3 in object Ding cannot be accessed as a member of object dingus.Ding
  Access to protected class Foo3 not permitted because
  enclosing object P in package hungus is not a subclass of
  object Ding in package dingus where target is defined

--- a/test/files/neg/protected-constructors.check
+++ b/test/files/neg/protected-constructors.check
@@ -1,4 +1,4 @@
-protected-constructors.scala:15: error: class Foo3 in object Ding cannot be accessed as a member of object dingus.Ding
+protected-constructors.scala:15: error: class Foo3 in object Ding cannot be accessed as a member of object dingus.Ding from object P in package hungus
  Access to protected class Foo3 not permitted because
  enclosing object P in package hungus is not a subclass of
  object Ding in package dingus where target is defined
@@ -10,13 +10,13 @@ protected-constructors.scala:15: error: no arguments allowed for nullary constru
 protected-constructors.scala:17: error: no arguments allowed for nullary constructor Foo1: ()dingus.Foo1
     val foo1 = new Foo1("abc")
                         ^
-protected-constructors.scala:18: error: constructor Foo2 in class Foo2 cannot be accessed in object P
+protected-constructors.scala:18: error: constructor Foo2 in class Foo2 cannot be accessed in object P from object P in package hungus
  Access to protected constructor Foo2 not permitted because
  enclosing object P in package hungus is not a subclass of
  class Foo2 in package dingus where target is defined
     val foo2 = new Foo2("abc")
                ^
-protected-constructors.scala:19: error: class Foo3 in object Ding cannot be accessed as a member of object dingus.Ding
+protected-constructors.scala:19: error: class Foo3 in object Ding cannot be accessed as a member of object dingus.Ding from object P in package hungus
  Access to protected class Foo3 not permitted because
  enclosing object P in package hungus is not a subclass of
  object Ding in package dingus where target is defined

--- a/test/files/neg/protected-static-fail.check
+++ b/test/files/neg/protected-static-fail.check
@@ -1,13 +1,13 @@
-S.scala:5: error: method f in class J cannot be accessed as a member of object bippy.J
+S.scala:5: error: method f in class J cannot be accessed as a member of object bippy.J from object Test in package bippy
     J.f()
       ^
-S.scala:6: error: method f1 in object S1 cannot be accessed as a member of object bippy.S1
+S.scala:6: error: method f1 in object S1 cannot be accessed as a member of object bippy.S1 from object Test in package bippy
  Access to protected method f1 not permitted because
  enclosing object Test in package bippy is not a subclass of
  object S1 in package bippy where target is defined
     S1.f1()
        ^
-S.scala:8: error: method f2 in class S2 cannot be accessed as a member of bippy.S2
+S.scala:8: error: method f2 in class S2 cannot be accessed as a member of bippy.S2 from object Test in package bippy
  Access to protected method f2 not permitted because
  enclosing object Test in package bippy is not a subclass of
  class S2 in package bippy where target is defined

--- a/test/files/neg/protected-static-fail.check
+++ b/test/files/neg/protected-static-fail.check
@@ -1,13 +1,13 @@
-S.scala:5: error: method f in class J cannot be accessed in object bippy.J
+S.scala:5: error: method f in class J cannot be accessed as a member of object bippy.J
     J.f()
       ^
-S.scala:6: error: method f1 in object S1 cannot be accessed in object bippy.S1
+S.scala:6: error: method f1 in object S1 cannot be accessed as a member of object bippy.S1
  Access to protected method f1 not permitted because
  enclosing object Test in package bippy is not a subclass of
  object S1 in package bippy where target is defined
     S1.f1()
        ^
-S.scala:8: error: method f2 in class S2 cannot be accessed in bippy.S2
+S.scala:8: error: method f2 in class S2 cannot be accessed as a member of bippy.S2
  Access to protected method f2 not permitted because
  enclosing object Test in package bippy is not a subclass of
  class S2 in package bippy where target is defined

--- a/test/files/neg/sensitive.check
+++ b/test/files/neg/sensitive.check
@@ -1,4 +1,4 @@
-sensitive.scala:17: error: constructor Sensitive in class Sensitive cannot be accessed in object Attacker
+sensitive.scala:17: error: constructor Sensitive in class Sensitive cannot be accessed in object Attacker from object Attacker
   val y = new Sensitive()
           ^
 one error found

--- a/test/files/neg/t11607.check
+++ b/test/files/neg/t11607.check
@@ -1,4 +1,4 @@
-t11607.scala:2: error: class migration in package annotation cannot be accessed in package annotation
+t11607.scala:2: error: class migration in package annotation cannot be accessed as a member of package annotation
 @migration("", "") class C
  ^
 one error found

--- a/test/files/neg/t11607.check
+++ b/test/files/neg/t11607.check
@@ -1,4 +1,4 @@
-t11607.scala:2: error: class migration in package annotation cannot be accessed as a member of package annotation
+t11607.scala:2: error: class migration in package annotation cannot be accessed as a member of package annotation from package <empty>
 @migration("", "") class C
  ^
 one error found

--- a/test/files/neg/t1422.check
+++ b/test/files/neg/t1422.check
@@ -1,7 +1,7 @@
 t1422.scala:1: error: private[this] not allowed for case class parameters
 case class A(private[this] val foo:String) { }
                                ^
-t1422.scala:1: error: value foo in class A cannot be accessed in A
+t1422.scala:1: error: value foo in class A cannot be accessed as a member of A
 case class A(private[this] val foo:String) { }
            ^
 two errors found

--- a/test/files/neg/t1422.check
+++ b/test/files/neg/t1422.check
@@ -1,7 +1,7 @@
 t1422.scala:1: error: private[this] not allowed for case class parameters
 case class A(private[this] val foo:String) { }
                                ^
-t1422.scala:1: error: value foo in class A cannot be accessed as a member of A
+t1422.scala:1: error: value foo in class A cannot be accessed as a member of A from object A
 case class A(private[this] val foo:String) { }
            ^
 two errors found

--- a/test/files/neg/t3663.check
+++ b/test/files/neg/t3663.check
@@ -1,4 +1,4 @@
-main.scala:11: error: variable foo in class PackageProtected cannot be accessed as a member of test.Test
+main.scala:11: error: variable foo in class PackageProtected cannot be accessed as a member of test.Test from object Main in package another
       println(t.foo)
                 ^
 one error found

--- a/test/files/neg/t3663.check
+++ b/test/files/neg/t3663.check
@@ -1,4 +1,4 @@
-main.scala:11: error: variable foo in class PackageProtected cannot be accessed in test.Test
+main.scala:11: error: variable foo in class PackageProtected cannot be accessed as a member of test.Test
       println(t.foo)
                 ^
 one error found

--- a/test/files/neg/t3714-neg.check
+++ b/test/files/neg/t3714-neg.check
@@ -1,10 +1,10 @@
-t3714-neg.scala:17: error: value break in class BreakImpl cannot be accessed as a member of BreakImpl
+t3714-neg.scala:17: error: value break in class BreakImpl cannot be accessed as a member of BreakImpl from object Test
  Access to protected value break not permitted because
  enclosing object Test is not a subclass of
  class BreakImpl where target is defined
     case b: BreakImpl => b.break
                            ^
-t3714-neg.scala:25: error: value break in class BreakImpl cannot be accessed as a member of BreakImpl
+t3714-neg.scala:25: error: value break in class BreakImpl cannot be accessed as a member of BreakImpl from object Test
  Access to protected value break not permitted because
  enclosing object Test is not a subclass of
  class BreakImpl where target is defined

--- a/test/files/neg/t3714-neg.check
+++ b/test/files/neg/t3714-neg.check
@@ -1,10 +1,10 @@
-t3714-neg.scala:17: error: value break in class BreakImpl cannot be accessed in BreakImpl
+t3714-neg.scala:17: error: value break in class BreakImpl cannot be accessed as a member of BreakImpl
  Access to protected value break not permitted because
  enclosing object Test is not a subclass of
  class BreakImpl where target is defined
     case b: BreakImpl => b.break
                            ^
-t3714-neg.scala:25: error: value break in class BreakImpl cannot be accessed in BreakImpl
+t3714-neg.scala:25: error: value break in class BreakImpl cannot be accessed as a member of BreakImpl
  Access to protected value break not permitted because
  enclosing object Test is not a subclass of
  class BreakImpl where target is defined

--- a/test/files/neg/t3871.check
+++ b/test/files/neg/t3871.check
@@ -1,4 +1,4 @@
-t3871.scala:4: error: variable foo in class Sub2 cannot be accessed as a member of Sub2
+t3871.scala:4: error: variable foo in class Sub2 cannot be accessed as a member of Sub2 from class Base
  Access to protected variable foo not permitted because
  enclosing class Base is not a subclass of
  class Sub2 where target is defined

--- a/test/files/neg/t3871.check
+++ b/test/files/neg/t3871.check
@@ -1,4 +1,4 @@
-t3871.scala:4: error: variable foo in class Sub2 cannot be accessed in Sub2
+t3871.scala:4: error: variable foo in class Sub2 cannot be accessed as a member of Sub2
  Access to protected variable foo not permitted because
  enclosing class Base is not a subclass of
  class Sub2 where target is defined

--- a/test/files/neg/t3871b.check
+++ b/test/files/neg/t3871b.check
@@ -1,7 +1,7 @@
 t3871b.scala:61: error: not found: value protOT
     protOT // not allowed
     ^
-t3871b.scala:77: error: method prot in class A cannot be accessed in E.this.A
+t3871b.scala:77: error: method prot in class A cannot be accessed as a member of E.this.A
  Access to protected method prot not permitted because
  prefix type E.this.A does not conform to
  class B in class E where the access takes place
@@ -19,7 +19,7 @@ t3871b.scala:81: error: value protT is not a member of E.this.A
 did you mean protE?
       a.protT   // not allowed
         ^
-t3871b.scala:91: error: method prot in class A cannot be accessed in E.this.A
+t3871b.scala:91: error: method prot in class A cannot be accessed as a member of E.this.A
  Access to protected method prot not permitted because
  prefix type E.this.A does not conform to
  object B in class E where the access takes place
@@ -37,19 +37,19 @@ t3871b.scala:95: error: value protT is not a member of E.this.A
 did you mean protE?
       a.protT   // not allowed
         ^
-t3871b.scala:102: error: method prot in class A cannot be accessed in E.this.B
+t3871b.scala:102: error: method prot in class A cannot be accessed as a member of E.this.B
  Access to protected method prot not permitted because
  enclosing class Z in class E is not a subclass of
  class A in class E where target is defined
       b.prot    // not allowed
         ^
-t3871b.scala:103: error: method prot in class A cannot be accessed in E.this.C
+t3871b.scala:103: error: method prot in class A cannot be accessed as a member of E.this.C
  Access to protected method prot not permitted because
  enclosing class Z in class E is not a subclass of
  class A in class E where target is defined
       c.prot    // not allowed
         ^
-t3871b.scala:104: error: method prot in class A cannot be accessed in E.this.A
+t3871b.scala:104: error: method prot in class A cannot be accessed as a member of E.this.A
  Access to protected method prot not permitted because
  enclosing class Z in class E is not a subclass of
  class A in class E where target is defined
@@ -67,37 +67,37 @@ t3871b.scala:111: error: value protT is not a member of E.this.A
 did you mean protE?
       a.protT   // not allowed
         ^
-t3871b.scala:120: error: method prot in class A cannot be accessed in Other.this.e.B
+t3871b.scala:120: error: method prot in class A cannot be accessed as a member of Other.this.e.B
  Access to protected method prot not permitted because
  enclosing class Other is not a subclass of
  class A in class E where target is defined
     b.prot    // not allowed
       ^
-t3871b.scala:121: error: method prot in class A cannot be accessed in Other.this.e.C
+t3871b.scala:121: error: method prot in class A cannot be accessed as a member of Other.this.e.C
  Access to protected method prot not permitted because
  enclosing class Other is not a subclass of
  class A in class E where target is defined
     c.prot    // not allowed
       ^
-t3871b.scala:122: error: method prot in class A cannot be accessed in Other.this.e.A
+t3871b.scala:122: error: method prot in class A cannot be accessed as a member of Other.this.e.A
  Access to protected method prot not permitted because
  enclosing class Other is not a subclass of
  class A in class E where target is defined
     a.prot    // not allowed
       ^
-t3871b.scala:123: error: method protE in class A cannot be accessed in Other.this.e.B
+t3871b.scala:123: error: method protE in class A cannot be accessed as a member of Other.this.e.B
  Access to protected method protE not permitted because
  enclosing class Other is not a subclass of
  class A in class E where target is defined
     b.protE   // not allowed
       ^
-t3871b.scala:124: error: method protE in class A cannot be accessed in Other.this.e.A
+t3871b.scala:124: error: method protE in class A cannot be accessed as a member of Other.this.e.A
  Access to protected method protE not permitted because
  enclosing class Other is not a subclass of
  class A in class E where target is defined
     a.protE   // not allowed
       ^
-t3871b.scala:125: error: method protE in class A cannot be accessed in Other.this.e.C
+t3871b.scala:125: error: method protE in class A cannot be accessed as a member of Other.this.e.C
  Access to protected method protE not permitted because
  enclosing class Other is not a subclass of
  class A in class E where target is defined

--- a/test/files/neg/t3871b.check
+++ b/test/files/neg/t3871b.check
@@ -1,7 +1,7 @@
 t3871b.scala:61: error: not found: value protOT
     protOT // not allowed
     ^
-t3871b.scala:77: error: method prot in class A cannot be accessed as a member of E.this.A
+t3871b.scala:77: error: method prot in class A cannot be accessed as a member of E.this.A from class B in class E
  Access to protected method prot not permitted because
  prefix type E.this.A does not conform to
  class B in class E where the access takes place
@@ -19,7 +19,7 @@ t3871b.scala:81: error: value protT is not a member of E.this.A
 did you mean protE?
       a.protT   // not allowed
         ^
-t3871b.scala:91: error: method prot in class A cannot be accessed as a member of E.this.A
+t3871b.scala:91: error: method prot in class A cannot be accessed as a member of E.this.A from object B in class E
  Access to protected method prot not permitted because
  prefix type E.this.A does not conform to
  object B in class E where the access takes place
@@ -37,19 +37,19 @@ t3871b.scala:95: error: value protT is not a member of E.this.A
 did you mean protE?
       a.protT   // not allowed
         ^
-t3871b.scala:102: error: method prot in class A cannot be accessed as a member of E.this.B
+t3871b.scala:102: error: method prot in class A cannot be accessed as a member of E.this.B from class Z in class E
  Access to protected method prot not permitted because
  enclosing class Z in class E is not a subclass of
  class A in class E where target is defined
       b.prot    // not allowed
         ^
-t3871b.scala:103: error: method prot in class A cannot be accessed as a member of E.this.C
+t3871b.scala:103: error: method prot in class A cannot be accessed as a member of E.this.C from class Z in class E
  Access to protected method prot not permitted because
  enclosing class Z in class E is not a subclass of
  class A in class E where target is defined
       c.prot    // not allowed
         ^
-t3871b.scala:104: error: method prot in class A cannot be accessed as a member of E.this.A
+t3871b.scala:104: error: method prot in class A cannot be accessed as a member of E.this.A from class Z in class E
  Access to protected method prot not permitted because
  enclosing class Z in class E is not a subclass of
  class A in class E where target is defined
@@ -67,37 +67,37 @@ t3871b.scala:111: error: value protT is not a member of E.this.A
 did you mean protE?
       a.protT   // not allowed
         ^
-t3871b.scala:120: error: method prot in class A cannot be accessed as a member of Other.this.e.B
+t3871b.scala:120: error: method prot in class A cannot be accessed as a member of Other.this.e.B from class Other
  Access to protected method prot not permitted because
  enclosing class Other is not a subclass of
  class A in class E where target is defined
     b.prot    // not allowed
       ^
-t3871b.scala:121: error: method prot in class A cannot be accessed as a member of Other.this.e.C
+t3871b.scala:121: error: method prot in class A cannot be accessed as a member of Other.this.e.C from class Other
  Access to protected method prot not permitted because
  enclosing class Other is not a subclass of
  class A in class E where target is defined
     c.prot    // not allowed
       ^
-t3871b.scala:122: error: method prot in class A cannot be accessed as a member of Other.this.e.A
+t3871b.scala:122: error: method prot in class A cannot be accessed as a member of Other.this.e.A from class Other
  Access to protected method prot not permitted because
  enclosing class Other is not a subclass of
  class A in class E where target is defined
     a.prot    // not allowed
       ^
-t3871b.scala:123: error: method protE in class A cannot be accessed as a member of Other.this.e.B
+t3871b.scala:123: error: method protE in class A cannot be accessed as a member of Other.this.e.B from class Other
  Access to protected method protE not permitted because
  enclosing class Other is not a subclass of
  class A in class E where target is defined
     b.protE   // not allowed
       ^
-t3871b.scala:124: error: method protE in class A cannot be accessed as a member of Other.this.e.A
+t3871b.scala:124: error: method protE in class A cannot be accessed as a member of Other.this.e.A from class Other
  Access to protected method protE not permitted because
  enclosing class Other is not a subclass of
  class A in class E where target is defined
     a.protE   // not allowed
       ^
-t3871b.scala:125: error: method protE in class A cannot be accessed as a member of Other.this.e.C
+t3871b.scala:125: error: method protE in class A cannot be accessed as a member of Other.this.e.C from class Other
  Access to protected method protE not permitted because
  enclosing class Other is not a subclass of
  class A in class E where target is defined

--- a/test/files/neg/t3934.check
+++ b/test/files/neg/t3934.check
@@ -1,10 +1,10 @@
-t3934.scala:15: error: method f2 in class J cannot be accessed in test.J
+t3934.scala:15: error: method f2 in class J cannot be accessed as a member of test.J
  Access to protected method f2 not permitted because
  enclosing class S1 in package nest is not a subclass of
  class J in package test where target is defined
   def g2(x: J) = x.f2()
                    ^
-t3934.scala:20: error: method f2 in class J cannot be accessed in test.J
+t3934.scala:20: error: method f2 in class J cannot be accessed as a member of test.J
  Access to protected method f2 not permitted because
  prefix type test.J does not conform to
  class S2 in package nest where the access takes place

--- a/test/files/neg/t3934.check
+++ b/test/files/neg/t3934.check
@@ -1,10 +1,10 @@
-t3934.scala:15: error: method f2 in class J cannot be accessed as a member of test.J
+t3934.scala:15: error: method f2 in class J cannot be accessed as a member of test.J from class S1 in package nest
  Access to protected method f2 not permitted because
  enclosing class S1 in package nest is not a subclass of
  class J in package test where target is defined
   def g2(x: J) = x.f2()
                    ^
-t3934.scala:20: error: method f2 in class J cannot be accessed as a member of test.J
+t3934.scala:20: error: method f2 in class J cannot be accessed as a member of test.J from class S2 in package nest
  Access to protected method f2 not permitted because
  prefix type test.J does not conform to
  class S2 in package nest where the access takes place

--- a/test/files/neg/t4417.check
+++ b/test/files/neg/t4417.check
@@ -1,4 +1,4 @@
-t4417.scala:11: error: constructor Pixel$mcD$sp in class Pixel$mcD$sp cannot be accessed in object Pixel
+t4417.scala:11: error: constructor Pixel$mcD$sp in class Pixel$mcD$sp cannot be accessed in object Pixel from object Pixel
  Access to protected constructor Pixel$mcD$sp not permitted because
  enclosing object Pixel is not a subclass of
  class Pixel$mcD$sp where target is defined

--- a/test/files/neg/t4541.check
+++ b/test/files/neg/t4541.check
@@ -1,4 +1,4 @@
-t4541.scala:11: error: variable data in class Sparse cannot be accessed in Sparse[Int]
+t4541.scala:11: error: variable data in class Sparse cannot be accessed as a member of Sparse[Int]
  Access to protected variable data not permitted because
  prefix type Sparse[Int] does not conform to
  class Sparse$mcI$sp where the access takes place

--- a/test/files/neg/t4541.check
+++ b/test/files/neg/t4541.check
@@ -1,4 +1,4 @@
-t4541.scala:11: error: variable data in class Sparse cannot be accessed as a member of Sparse[Int]
+t4541.scala:11: error: variable data in class Sparse cannot be accessed as a member of Sparse[Int] from class Sparse$mcI$sp
  Access to protected variable data not permitted because
  prefix type Sparse[Int] does not conform to
  class Sparse$mcI$sp where the access takes place

--- a/test/files/neg/t4541b.check
+++ b/test/files/neg/t4541b.check
@@ -1,4 +1,4 @@
-t4541b.scala:13: error: variable data in class SparseArray cannot be accessed in SparseArray[Int]
+t4541b.scala:13: error: variable data in class SparseArray cannot be accessed as a member of SparseArray[Int]
  Access to protected variable data not permitted because
  prefix type SparseArray[Int] does not conform to
  class SparseArray$mcI$sp where the access takes place

--- a/test/files/neg/t4541b.check
+++ b/test/files/neg/t4541b.check
@@ -1,4 +1,4 @@
-t4541b.scala:13: error: variable data in class SparseArray cannot be accessed as a member of SparseArray[Int]
+t4541b.scala:13: error: variable data in class SparseArray cannot be accessed as a member of SparseArray[Int] from class SparseArray$mcI$sp
  Access to protected variable data not permitted because
  prefix type SparseArray[Int] does not conform to
  class SparseArray$mcI$sp where the access takes place

--- a/test/files/neg/t464-neg.check
+++ b/test/files/neg/t464-neg.check
@@ -1,16 +1,16 @@
 t464-neg.scala:7: error: not found: value f1
   f1()
   ^
-t464-neg.scala:8: error: method f1 in class A cannot be accessed in A
+t464-neg.scala:8: error: method f1 in class A cannot be accessed as a member of A
   super.f1()
         ^
 t464-neg.scala:9: error: value f2 is not a member of B
   def otherb(b2: B) = b2.f2()
                          ^
-t464-neg.scala:10: error: method f3 in class A cannot be accessed in B
+t464-neg.scala:10: error: method f3 in class A cannot be accessed as a member of B
   f3()
   ^
-t464-neg.scala:11: error: method f3 in class A cannot be accessed in A
+t464-neg.scala:11: error: method f3 in class A cannot be accessed as a member of A
   super.f3()
         ^
 5 errors found

--- a/test/files/neg/t464-neg.check
+++ b/test/files/neg/t464-neg.check
@@ -1,16 +1,16 @@
 t464-neg.scala:7: error: not found: value f1
   f1()
   ^
-t464-neg.scala:8: error: method f1 in class A cannot be accessed as a member of A
+t464-neg.scala:8: error: method f1 in class A cannot be accessed as a member of A from class B
   super.f1()
         ^
 t464-neg.scala:9: error: value f2 is not a member of B
   def otherb(b2: B) = b2.f2()
                          ^
-t464-neg.scala:10: error: method f3 in class A cannot be accessed as a member of B
+t464-neg.scala:10: error: method f3 in class A cannot be accessed as a member of B from class B
   f3()
   ^
-t464-neg.scala:11: error: method f3 in class A cannot be accessed as a member of A
+t464-neg.scala:11: error: method f3 in class A cannot be accessed as a member of A from class B
   super.f3()
         ^
 5 errors found

--- a/test/files/neg/t4987.check
+++ b/test/files/neg/t4987.check
@@ -1,4 +1,4 @@
-t4987.scala:2: error: constructor Foo2 in class Foo2 cannot be accessed in object Bar2
+t4987.scala:2: error: constructor Foo2 in class Foo2 cannot be accessed in object Bar2 from object Bar2
 object Bar2 { new Foo2(0, 0) }
               ^
 one error found

--- a/test/files/neg/t5352.check
+++ b/test/files/neg/t5352.check
@@ -4,7 +4,7 @@ t5352.scala:13: error: type mismatch;
     (which expands to)  AnyRef{def f(): Int}
   x = xs.head
          ^
-t5352.scala:16: error: method f in class Bar1 cannot be accessed as a member of boop.Bar1
+t5352.scala:16: error: method f in class Bar1 cannot be accessed as a member of boop.Bar1 from object boop
  Access to protected method f not permitted because
  enclosing object boop is not a subclass of
  class Bar1 in object boop where target is defined

--- a/test/files/neg/t5352.check
+++ b/test/files/neg/t5352.check
@@ -4,7 +4,7 @@ t5352.scala:13: error: type mismatch;
     (which expands to)  AnyRef{def f(): Int}
   x = xs.head
          ^
-t5352.scala:16: error: method f in class Bar1 cannot be accessed in boop.Bar1
+t5352.scala:16: error: method f in class Bar1 cannot be accessed as a member of boop.Bar1
  Access to protected method f not permitted because
  enclosing object boop is not a subclass of
  class Bar1 in object boop where target is defined

--- a/test/files/neg/t6074.check
+++ b/test/files/neg/t6074.check
@@ -1,4 +1,4 @@
-t6074.scala:5: error: constructor A in class A cannot be accessed in object T
+t6074.scala:5: error: constructor A in class A cannot be accessed in object T from object T
   def t = new A()
           ^
 one error found

--- a/test/files/neg/t6601.check
+++ b/test/files/neg/t6601.check
@@ -1,4 +1,4 @@
-AccessPrivateConstructor_2.scala:2: error: constructor PrivateConstructor in class PrivateConstructor cannot be accessed in class AccessPrivateConstructor
+AccessPrivateConstructor_2.scala:2: error: constructor PrivateConstructor in class PrivateConstructor cannot be accessed in class AccessPrivateConstructor from class AccessPrivateConstructor
   new PrivateConstructor("") // Scalac should forbid accessing to the private constructor!
   ^
 one error found

--- a/test/files/neg/t6934.check
+++ b/test/files/neg/t6934.check
@@ -1,4 +1,4 @@
-ScalaMain.scala:6: error: variable STATIC_PROTECTED_FIELD in class JavaClass cannot be accessed in object test.JavaClass
+ScalaMain.scala:6: error: variable STATIC_PROTECTED_FIELD in class JavaClass cannot be accessed as a member of object test.JavaClass
  Access to protected variable STATIC_PROTECTED_FIELD not permitted because
  enclosing object ScalaMain in package test2 is not a subclass of
  class JavaClass in package test where target is defined

--- a/test/files/neg/t6934.check
+++ b/test/files/neg/t6934.check
@@ -1,4 +1,4 @@
-ScalaMain.scala:6: error: variable STATIC_PROTECTED_FIELD in class JavaClass cannot be accessed as a member of object test.JavaClass
+ScalaMain.scala:6: error: variable STATIC_PROTECTED_FIELD in class JavaClass cannot be accessed as a member of object test.JavaClass from object ScalaMain in package test2
  Access to protected variable STATIC_PROTECTED_FIELD not permitted because
  enclosing object ScalaMain in package test2 is not a subclass of
  class JavaClass in package test where target is defined

--- a/test/files/neg/t7475f.check
+++ b/test/files/neg/t7475f.check
@@ -1,4 +1,4 @@
-t7475f.scala:12: error: method c1 in class C cannot be accessed as a member of C[T]
+t7475f.scala:12: error: method c1 in class C cannot be accessed as a member of C[T] from trait D
   c1 // a member, but inaccessible.
   ^
 t7475f.scala:13: error: not found: value c2

--- a/test/files/neg/t7475f.check
+++ b/test/files/neg/t7475f.check
@@ -1,4 +1,4 @@
-t7475f.scala:12: error: method c1 in class C cannot be accessed in C[T]
+t7475f.scala:12: error: method c1 in class C cannot be accessed as a member of C[T]
   c1 // a member, but inaccessible.
   ^
 t7475f.scala:13: error: not found: value c2

--- a/test/files/neg/t7859.check
+++ b/test/files/neg/t7859.check
@@ -1,7 +1,7 @@
 B_2.scala:6: error: not found: value x
   new p1.A(x).x
            ^
-B_2.scala:6: error: value x in class A cannot be accessed as a member of p1.A
+B_2.scala:6: error: value x in class A cannot be accessed as a member of p1.A from object Test
   new p1.A(x).x
               ^
 B_2.scala:7: error: not found: value x
@@ -13,7 +13,7 @@ B_2.scala:7: error: value x is not a member of B
 B_2.scala:8: error: not found: value x
   new C(x).x
         ^
-B_2.scala:8: error: value x in class C cannot be accessed as a member of C
+B_2.scala:8: error: value x in class C cannot be accessed as a member of C from object Test
   new C(x).x
            ^
 6 errors found

--- a/test/files/neg/t7859.check
+++ b/test/files/neg/t7859.check
@@ -1,7 +1,7 @@
 B_2.scala:6: error: not found: value x
   new p1.A(x).x
            ^
-B_2.scala:6: error: value x in class A cannot be accessed in p1.A
+B_2.scala:6: error: value x in class A cannot be accessed as a member of p1.A
   new p1.A(x).x
               ^
 B_2.scala:7: error: not found: value x
@@ -13,7 +13,7 @@ B_2.scala:7: error: value x is not a member of B
 B_2.scala:8: error: not found: value x
   new C(x).x
         ^
-B_2.scala:8: error: value x in class C cannot be accessed in C
+B_2.scala:8: error: value x in class C cannot be accessed as a member of C
   new C(x).x
            ^
 6 errors found

--- a/test/files/neg/t8002-nested-scope.check
+++ b/test/files/neg/t8002-nested-scope.check
@@ -1,4 +1,4 @@
-t8002-nested-scope.scala:8: error: method x in class C cannot be accessed as a member of C
+t8002-nested-scope.scala:8: error: method x in class C cannot be accessed as a member of C from object C
         new C().x
                 ^
 one error found

--- a/test/files/neg/t8002-nested-scope.check
+++ b/test/files/neg/t8002-nested-scope.check
@@ -1,4 +1,4 @@
-t8002-nested-scope.scala:8: error: method x in class C cannot be accessed in C
+t8002-nested-scope.scala:8: error: method x in class C cannot be accessed as a member of C
         new C().x
                 ^
 one error found

--- a/test/files/neg/t9849.check
+++ b/test/files/neg/t9849.check
@@ -1,7 +1,7 @@
-t9849.scala:14: error: method h in object O cannot be accessed as a member of object p.O
+t9849.scala:14: error: method h in object O cannot be accessed as a member of object p.O from object Test in package p
   O.h()
     ^
-t9849.scala:15: error: method h$default$1 in object O cannot be accessed as a member of object p.O
+t9849.scala:15: error: method h$default$1 in object O cannot be accessed as a member of object p.O from object Test in package p
   O.h$default$1
     ^
 two errors found

--- a/test/files/neg/t9849.check
+++ b/test/files/neg/t9849.check
@@ -1,7 +1,7 @@
-t9849.scala:14: error: method h in object O cannot be accessed in object p.O
+t9849.scala:14: error: method h in object O cannot be accessed as a member of object p.O
   O.h()
     ^
-t9849.scala:15: error: method h$default$1 in object O cannot be accessed in object p.O
+t9849.scala:15: error: method h$default$1 in object O cannot be accessed as a member of object p.O
   O.h$default$1
     ^
 two errors found

--- a/test/files/run/repl-colon-type.check
+++ b/test/files/run/repl-colon-type.check
@@ -37,7 +37,7 @@ scala> :type protected lazy val f = 5
 
          lazy val $result = $line16.$read.$iw.$iw.f
                                                   ^
-<synthetic>:4: error: lazy value f cannot be accessed in object $iw
+<synthetic>:4: error: lazy value f cannot be accessed as a member of object $iw
         Access to protected lazy value f not permitted because
         enclosing object $eval in package $line16 is not a subclass of
         object $iw where target is defined

--- a/test/files/run/repl-colon-type.check
+++ b/test/files/run/repl-colon-type.check
@@ -37,7 +37,7 @@ scala> :type protected lazy val f = 5
 
          lazy val $result = $line16.$read.$iw.$iw.f
                                                   ^
-<synthetic>:4: error: lazy value f cannot be accessed as a member of object $iw
+<synthetic>:4: error: lazy value f cannot be accessed as a member of object $iw from object $eval in package $line16
         Access to protected lazy value f not permitted because
         enclosing object $eval in package $line16 is not a subclass of
         object $iw where target is defined


### PR DESCRIPTION
Also fix `partest --grep "string in check file"`.

Fixes scala/bug#11680