### PR TITLE
ScriptRunner respects -d under -save

### DIFF
--- a/src/compiler/scala/tools/nsc/fsc/FscSettings.scala
+++ b/src/compiler/scala/tools/nsc/fsc/FscSettings.scala
@@ -61,7 +61,7 @@ class FscSettings(error: String => Unit, pathFactory: PathFactory = DefaultPathF
   /** All user set settings rewritten with absolute paths based on currentDir */
   def absolutize(): Unit = {
     userSetSettings foreach {
-      case p: OutputSetting => p.outputDirs setSingleOutput AbstractFile.getDirectory(absolutizePath(p.value))
+      case p: OutputSetting => outputDirs.setSingleOutput(AbstractFile.getDirectory(absolutizePath(p.value)))
       case p: PathSetting   => p.value = ClassPath.map(p.value, absolutizePath)
       case p: StringSetting => if (holdsPath(p)) p.value = absolutizePath(p.value)
       case _                => ()

--- a/src/compiler/scala/tools/nsc/fsc/FscSettings.scala
+++ b/src/compiler/scala/tools/nsc/fsc/FscSettings.scala
@@ -44,7 +44,7 @@ class FscSettings(error: String => Unit, pathFactory: PathFactory = DefaultPathF
   /** If a setting (other than a PathSetting) represents a path or paths.
    *  For use in absolutization.
    */
-  private def holdsPath = Set[Settings#Setting](d, dependencyfile, pluginsDir)
+  private def holdsPath = Set[Settings#Setting](outdir, dependencyfile, pluginsDir)
 
   override def processArguments(arguments: List[String], processAll: Boolean): (Boolean, List[String]) = {
     val (r, args) = super.processArguments(arguments, processAll)

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -59,7 +59,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
   // argfiles is only for the help message
   /*val argfiles = */ BooleanSetting    ("@<file>", "A text file containing compiler arguments (options and source files)")
   val classpath     = PathSetting       ("-classpath", "Specify where to find user class files.", defaultClasspath) withAbbreviation "-cp" withAbbreviation "--class-path"
-  val d             = OutputSetting     (outputDirs, ".")
+  val outdir        = OutputSetting     (outputDirs, ".")
   val nospecialization = BooleanSetting ("-no-specialization", "Ignore @specialize annotations.") withAbbreviation "--no-specialization"
 
   // Would be nice to build this dynamically from scala.languageFeature.
@@ -185,7 +185,8 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
   def debuginfo = g
   def dependenciesFile = dependencyfile
   def nowarnings = nowarn
-  def outdir = d
+  @deprecated("Use outdir instead.", since="2.13.2")
+  def d = outdir
   def printLate = print
 
   /**

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -27,8 +27,7 @@ import scala.reflect.internal.util.StringContextStripMarginOps
 import scala.tools.nsc.util.DefaultJarFactory
 
 
-trait ScalaSettings extends StandardScalaSettings with Warnings {
-  self: MutableSettings =>
+trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSettings =>
 
   /** Set of settings */
   protected[scala] lazy val allSettings = mutable.LinkedHashMap[String, Setting]()
@@ -57,10 +56,11 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
    *  Standard settings
    */
   // argfiles is only for the help message
-  /*val argfiles = */ BooleanSetting    ("@<file>", "A text file containing compiler arguments (options and source files)")
-  val classpath     = PathSetting       ("-classpath", "Specify where to find user class files.", defaultClasspath) withAbbreviation "-cp" withAbbreviation "--class-path"
-  val outdir        = OutputSetting     (outputDirs, ".")
-  val nospecialization = BooleanSetting ("-no-specialization", "Ignore @specialize annotations.") withAbbreviation "--no-specialization"
+  /*val argfiles = */ BooleanSetting("@<file>", "A text file containing compiler arguments (options and source files)")
+  val classpath     = PathSetting   ("-classpath", "Specify where to find user class files.", defaultClasspath) withAbbreviation "-cp" withAbbreviation "--class-path"
+  val outdir        = OutputSetting (outputDirs, ".").withPostSetHook(s => try outputDirs.setSingleOutput(s.value) catch { case FatalError(msg) => errorFn(msg) })
+
+  val nospecialization = BooleanSetting("-no-specialization", "Ignore @specialize annotations.") withAbbreviation "--no-specialization"
 
   // Would be nice to build this dynamically from scala.languageFeature.
   // The two requirements: delay error checking until you have symbols, and let compiler command build option-specific help.
@@ -256,11 +256,11 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
   val Ymacroexpand    = ChoiceSetting     ("-Ymacro-expand", "policy", "Control expansion of macros, useful for scaladoc and presentation compiler.", List(MacroExpand.Normal, MacroExpand.None, MacroExpand.Discard), MacroExpand.Normal)
   val YmacroFresh     = BooleanSetting    ("-Ymacro-global-fresh-names", "Should fresh names in macros be unique across all compilation units")
   val YmacroAnnotations = BooleanSetting  ("-Ymacro-annotations", "Enable support for macro annotations, formerly in macro paradise.")
-  val Yreplclassbased = BooleanSetting    ("-Yrepl-class-based", "Use classes to wrap REPL snippets instead of objects") withDefault true
-  val YreplMagicImport = BooleanSetting   ("-Yrepl-use-magic-imports", "In the code that wraps REPL snippets, use magic imports rather than nesting wrapper object/classes") withDefault true
+  val Yreplclassbased = BooleanSetting    ("-Yrepl-class-based", "Use classes to wrap REPL snippets instead of objects", default = true)
+  val YreplMagicImport = BooleanSetting   ("-Yrepl-use-magic-imports", "In the code that wraps REPL snippets, use magic imports rather than nesting wrapper object/classes", default = true)
   val Yreploutdir     = StringSetting     ("-Yrepl-outdir", "path", "Write repl-generated classfiles to given output directory (use \"\" to generate a temporary dir)" , "")
   @deprecated("Unused setting will be removed", since="2.13")
-  val Yreplsync       = new BooleanSetting    ("-Yrepl-sync", "Legacy setting for sbt compatibility, unused.").internalOnly()
+  val Yreplsync       = new BooleanSetting    ("-Yrepl-sync", "Legacy setting for sbt compatibility, unused.", default = false).internalOnly()
   val Yscriptrunner   = StringSetting     ("-Yscriptrunner", "classname", "Specify a scala.tools.nsc.ScriptRunner (default, resident, shutdown, or a class name).", "default")
   val YdisableFlatCpCaching  = BooleanSetting    ("-Yno-flat-classpath-cache", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.").withAbbreviation("-YdisableFlatCpCaching")
   // Zinc adds YdisableFlatCpCaching automatically for straight-to-JAR compilation, this is a way to override that choice.
@@ -283,7 +283,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
   val YpickleJava = BooleanSetting("-Ypickle-java", "Pickler phase should compute pickles for .java defined symbols for use by build tools").internalOnly()
   val YpickleWrite = StringSetting("-Ypickle-write", "directory|jar", "destination for generated .sig files containing type signatures.", "", None).internalOnly()
   val YpickleWriteApiOnly = BooleanSetting("-Ypickle-write-api-only", "Exclude private members (other than those material to subclass compilation, such as private trait vals) from generated .sig files containing type signatures.").internalOnly()
-  val YtrackDependencies = BooleanSetting("-Ytrack-dependencies", "Record references to in unit.depends. Deprecated feature that supports SBT 0.13 with incOptions.withNameHashing(false) only.").withDefault(true)
+  val YtrackDependencies = BooleanSetting("-Ytrack-dependencies", "Record references to in unit.depends. Deprecated feature that supports SBT 0.13 with incOptions.withNameHashing(false) only.", default = true)
 
   sealed abstract class CachePolicy(val name: String, val help: String)
   object CachePolicy {

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -29,7 +29,6 @@ trait StandardScalaSettings {
    */
   val bootclasspath =     PathSetting ("-bootclasspath", "Override location of bootstrap class files.", Defaults.scalaBootClassPath) withAbbreviation "--boot-class-path"
   val classpath:          PathSetting // is mutated directly in various places (thus inspiring this very effort)
-  val d:                OutputSetting // depends on mutable OutputDirs class
   val extdirs =           PathSetting ("-extdirs", "Override location of installed extensions.", Defaults.scalaExtDirs) withAbbreviation "--extension-directories"
   val javabootclasspath = PathSetting ("-javabootclasspath", "Override java boot classpath.", Defaults.javaBootClassPath) withAbbreviation "--java-boot-class-path"
   val javaextdirs =       PathSetting ("-javaextdirs", "Override java extdirs classpath.", Defaults.javaExtDirs) withAbbreviation "--java-extension-directories"

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -15,13 +15,12 @@ package settings
 
 import scala.tools.util.PathResolver.Defaults
 
-/** Settings which aren't behind a -X, -Y, -V, or -P option.
+/** Settings which aren't behind a -V, -W, -X, -Y, or -P option.
  *  When possible, the val and the option have identical names.
  *  The abstract settings are commented as to why they are as yet
  *  implemented in MutableSettings rather than mutation-generically.
  */
-trait StandardScalaSettings {
-  self: MutableSettings =>
+trait StandardScalaSettings { _: MutableSettings =>
 
   import StandardScalaSettings._
 
@@ -68,8 +67,7 @@ trait StandardScalaSettings {
   //   - `jvm-` (from back when we also had `msil`)
   //   - `1.` (from back when Java 2 was a possibility)
   // `-target:1.jvm-13` is ridiculous, though.
-  private[this] def normalizeTarget(in: String): String =
-    in stripPrefix "jvm-" stripPrefix "1."
+  private[this] def normalizeTarget(in: String): String = in.stripPrefix("jvm-").stripPrefix("1.")
 }
 
 object StandardScalaSettings {
@@ -77,5 +75,5 @@ object StandardScalaSettings {
   val MinTargetVersion = 8
   val MaxTargetVersion = 12 // this one goes to twelve
 
-  private val AllTargetVersions = MinTargetVersion to MaxTargetVersion map (_.toString) to List
+  private val AllTargetVersions = (MinTargetVersion to MaxTargetVersion).map(_.toString).to(List)
 }

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -33,6 +33,7 @@ trait Warnings {
     "-Wconf",
     "patterns",
     "Configure reporting of compiler warnings; use `help` for details.",
+    default = WconfDefault,
     helpText = Some(
       s"""Configure compiler warnings.
          |Syntax: -Wconf:<filters>:<action>,<filters>:<action>,...
@@ -95,7 +96,6 @@ trait Warnings {
          |Note: on the command-line you might need to quote configurations containing `*` or `&`
          |to prevent the shell from expanding patterns.""".stripMargin),
     prepend = true)
-  locally { Wconf.tryToSet(WconfDefault); Wconf.clearSetByUser() }
 
   // Non-lint warnings. -- TODO turn into MultiChoiceEnumeration
   val warnMacros           = ChoiceSetting(
@@ -154,11 +154,7 @@ trait Warnings {
   // They are not activated by -Xlint and can't be enabled on the command line because they are not
   // created using the standard factory methods.
 
-  val warnValueOverrides = {
-    val flag = new BooleanSetting("value-overrides", "Generated value class method overrides an implementation.")
-    flag.value = false
-    flag
-  }
+  val warnValueOverrides = new BooleanSetting("value-overrides", "Generated value class method overrides an implementation.", default = false)
 
   // Lint warnings
 

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -33,7 +33,6 @@ abstract class MutableSettings extends AbsSettings {
     def postSetHook(): Unit = ()
     def isDefault = !setByUser
     def isSetByUser = setByUser
-    private[scala] def clearSetByUser(): Unit = setByUser = false
     def value: T = v
     def value_=(arg: T) = {
       setByUser = true

--- a/test/files/run/settings-parse.scala
+++ b/test/files/run/settings-parse.scala
@@ -1,20 +1,20 @@
 
-import scala.language.postfixOps
-import scala.tools.nsc._
+import scala.tools.nsc.settings.MutableSettings
 
 object Test {
   val tokens        = "" :: "-deprecation" :: "foo.scala" :: Nil
   val permutations0 = tokens.toSet.subsets().flatMap(_.toList.permutations).toList.distinct
 
   def runWithCp(cp: String) = {
-    val permutations = permutations0 flatMap ("-cp CPTOKEN" :: _ permutations)
+    val permutations = permutations0.flatMap(s => ("-cp CPTOKEN" :: s).permutations)
 
     for ((p, i) <- permutations.distinct.sortBy(_ mkString "").zipWithIndex) {
-      val args           = p flatMap (_ split "\\s+") map (x => if (x == "CPTOKEN") cp else x)
-      val s              = new settings.MutableSettings(println)
+      val args     = p.flatMap(_.split("\\s+")).map(x => if (x == "CPTOKEN") cp else x)
+      val expected = args.filter(_ == "foo.scala")
+
+      val s              = new MutableSettings(println)
       val (ok, residual) = s.processArguments(args, processAll = true)
 
-      val expected = args filter (_ == "foo.scala")
       assert(residual == expected, residual)
       assert(ok, args)
       println(s"$i) $args ==> $s")

--- a/test/junit/scala/tools/nsc/ScriptRunnerTest.scala
+++ b/test/junit/scala/tools/nsc/ScriptRunnerTest.scala
@@ -13,10 +13,16 @@ class ScriptRunnerTest {
     s.usejavacp.value = true
 
     // scala -e ''
-    assertTrue(ScriptRunner(s).runScriptText("", Nil).isEmpty)
+    ScriptRunner(s).runScriptText("", Nil) match {
+      case Some(e) => throw e
+      case None    => ()
+    }
 
     // scala -save -e ''
     s.save.value = true
-    assertTrue(ScriptRunner(s).runScriptText("", Nil).isEmpty)
+    ScriptRunner(s).runScriptText("", Nil) match {
+      case Some(e) => throw e
+      case None    => ()
+    }
   }
 }

--- a/test/junit/scala/tools/nsc/ScriptRunnerTest.scala
+++ b/test/junit/scala/tools/nsc/ScriptRunnerTest.scala
@@ -1,6 +1,5 @@
 package scala.tools.nsc
 
-import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -12,7 +12,7 @@ class SettingsTest {
   @Test def booleanSettingColon(): Unit = {
     def check(args: String*): MutableSettings#BooleanSetting = {
       val s = new MutableSettings(msg => throw new IllegalArgumentException(msg))
-      val b1 = new s.BooleanSetting("-Ytest-setting", "")
+      val b1 = new s.BooleanSetting("-Ytest-setting", descr="", default=false)
       s.allSettings(b1.name) = b1
       val (ok, residual) = s.processArguments(args.toList, processAll = true)
       assert(residual.isEmpty)


### PR DESCRIPTION
Under -save, use -d target.jar.

If -d is a directory, then assemble the usual script.jar.

Also, `settings.d` is too minimalistic; prefer `settings.outdir`.

Also improve the idiom for "default" `settings.outdir` so it is not always `isSetByUser`.

Fixes scala/bug#2943