### PR TITLE
s.c.i.Queue optimizations for Queue.from, queue#apply, queue#appendedAll

### DIFF
--- a/test/scalacheck/scala/collection/immutable/QueueProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/QueueProperties.scala
@@ -1,0 +1,69 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.immutable
+
+
+import org.scalacheck._
+import Prop._
+
+import scala.collection.{IterableFactory, View, mutable}
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+
+object QueueProperties extends Properties("immutable.Queue") {
+
+  val iterableGen: Gen[collection.Iterable[Int]] =
+    for {
+      data <- Gen.listOf(Arbitrary.arbInt.arbitrary)
+      factory <-
+      Gen.oneOf[IterableFactory[collection.Iterable]](
+        List, Vector, ArrayBuffer, mutable.ArrayDeque, Queue, ListBuffer, View
+      )
+    } yield factory.from(data)
+
+  property("(Queue.from(list1) ++ list2).apply(i) == (list1 ++ list2).apply(i)") = {
+
+    val testCases = for {
+      list1 <- Gen.listOf(Arbitrary.arbInt.arbitrary)
+      list2 <- Gen.listOf(Arbitrary.arbInt.arbitrary)
+      length = list1.length + list2.length
+      if length > 0
+      i <- Gen.choose(0, length - 1)
+    } yield (list1, list2, i)
+
+    // we do not shrink because shrinking will result in empty lists which will result in exceptions thrown in apply
+    forAllNoShrink(testCases) { case (list1, list2, i) =>
+      val left = Queue.from(list1).concat(list2)
+      left.apply(i) ?= list1.concat(list2).apply(i)
+    }
+  }
+  property("queue.concat(iterable) == list.concat(iterable)") = {
+    val testCases = for {
+      list1 <- Gen.listOf(Arbitrary.arbInt.arbitrary)
+      list2 <- Gen.listOf(Arbitrary.arbInt.arbitrary)
+      iterable: collection.Iterable[Int] <- iterableGen
+    } yield (list1, list2, iterable)
+
+    forAll(testCases) { case (list1, list2, iterable) =>
+      val result = list1.concat(list2).appendedAll(iterable)
+      ((Queue.from(list1).concat(list2).concat(iterable): Seq[Int]) ?= result).label("concat") &&
+        ((Queue.from(list1).appendedAll(list2).appendedAll(iterable): Seq[Int]) ?= result).label("appendedAll") &&
+        ((Queue.from(list1).enqueueAll(list2).enqueueAll(iterable): Seq[Int]) ?= result).label("enqueueAll")
+    }
+  }
+
+  property("Queue.from(iterable) == List.from(iterable)") = {
+    forAll(iterableGen) { it =>
+      (Queue.from(it): Seq[Int]) ?= List.from(it)
+    }
+  }
+}


### PR DESCRIPTION
Includes optimizations for:

* s.c.i.Queue#apply(i: Int):

Currently we are always calling `out.length` and then if the i-th element is in that list, we call `out.apply(i)`, for a total of ~1.5 traversals when the element is contained in `out`, or 1 traversal when not contained in `out. 

This change makes it so that we early-return the ith element as soon as it is encountered in `out`, for a total of ~0.5 traversals when the element is in `out`, and 1 traversal when not contained in `out`

* s.c.i.Queue.from[A](it: IterableOnce[A])

We replace `ListBuffer.from(source).toList` with `List.from(source)`. In cases where `source` happens to be a `List` or a `ListBuffer`, no data will be copied now, since `List.from` will return the list, or the listBuffer's `toList` which also does not copy. 

* s.c.i.Queue#appendedAll

The existing code is copying the incoming data twice, once to turn the new data into a `List` and then again to prepend that `List` onto the front of `in`. This PR includes the change to only perform one copy of the data, by manually prepending elements from the `it.iterator` onto `this.in`. A "fast path" in the case of `List` is included, but not yet verified to be faster, where we avoid creating an iterator and instead iterate through the List via head/tail. 

* s.c.i.Queue#enqueueAll

This is currently a reimplementation of appendedAll, so now is set to just delegate to appendedAll

## Benchmarks
code:
```scala
package scala.collection.immutable

import java.util.concurrent.TimeUnit

import org.openjdk.jmh.infra.Blackhole
import org.openjdk.jmh.annotations._

import scala.collection.mutable.ArrayBuffer
import scala.util.Random

@BenchmarkMode(Array(Mode.AverageTime))
@Fork(1)
@Threads(1)
@Warmup(iterations = 6)
@Measurement(iterations = 6)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@State(Scope.Benchmark)
class QueueBenchmark {
  @Param(Array("0", "1", "5", "10", "1000", "1000000"))
  var size: Int = _

  var outsize: Int = _


  var queue: Queue[Int] = _
  var list: List[Int] = _
  var buffer: ArrayBuffer[Int] = _
  var vector: Vector[Int] = _
  var index: Int = 0

  @Setup(Level.Trial) def initKeys(): Unit = {
    outsize = size / 2
    val insize = size - outsize
    // there is no public way of constructing a Queue with a given `in` and `out`, so 
    // we hack it / couple to the implementation detail that Queue.from(list1) assigns list1 to `out`,
    // and then concat(list2) will assign list2.reverse to `in`
    queue = Queue.from(List.fill(outsize)(1)).concat(List.fill(insize)(1))
    list = List.fill(size)(1)
    buffer = list.to(ArrayBuffer)
    vector = list.to(Vector)
  }
  @Benchmark def concat(bh: Blackhole): Any = {
    bh.consume(queue.concat(list))
    bh.consume(queue.concat(buffer))
    bh.consume(queue.concat(vector))
  }
  @Benchmark def queueFrom(bh: Blackhole): Any = {
    bh.consume(Queue.from(list))
    bh.consume(Queue.from(buffer))
    bh.consume(Queue.from(vector))
  }
  @Benchmark def apply(bh: Blackhole): Any = {
    if (size > 0) {
      bh.consume(queue.apply(0))
      bh.consume(queue.apply(outsize / 2))
      bh.consume(queue.apply(size - 1))
    }
  }
}
```
results

this PR:

```
[info] Benchmark                  (size)  Mode  Cnt         Score         Error  Units
[info] QueueBenchmark.apply            0  avgt    6         2.870 ±       0.717  ns/op
[info] QueueBenchmark.apply            1  avgt    6        12.451 ±       1.863  ns/op
[info] QueueBenchmark.apply            5  avgt    6        19.046 ±       4.118  ns/op
[info] QueueBenchmark.apply           10  avgt    6        23.167 ±       3.511  ns/op
[info] QueueBenchmark.apply         1000  avgt    6      2145.306 ±     115.783  ns/op
[info] QueueBenchmark.apply      1000000  avgt    6   4244774.610 ± 1046992.161  ns/op
[info] QueueBenchmark.concat           0  avgt    6        26.352 ±       0.818  ns/op
[info] QueueBenchmark.concat           1  avgt    6        56.511 ±       2.909  ns/op
[info] QueueBenchmark.concat           5  avgt    6        93.958 ±      10.326  ns/op
[info] QueueBenchmark.concat          10  avgt    6       138.097 ±       8.693  ns/op
[info] QueueBenchmark.concat        1000  avgt    6     11764.657 ±     467.329  ns/op
[info] QueueBenchmark.concat     1000000  avgt    6  15313154.542 ± 2732619.166  ns/op
[info] QueueBenchmark.queueFrom        0  avgt    6        10.362 ±       1.239  ns/op
[info] QueueBenchmark.queueFrom        1  avgt    6        66.616 ±       1.970  ns/op
[info] QueueBenchmark.queueFrom        5  avgt    6       133.020 ±       5.321  ns/op
[info] QueueBenchmark.queueFrom       10  avgt    6       218.595 ±       6.757  ns/op
[info] QueueBenchmark.queueFrom     1000  avgt    6     10768.394 ±     113.968  ns/op
[info] QueueBenchmark.queueFrom  1000000  avgt    6  14191427.380 ± 1143827.060  ns/op
```

2.13.x:
```

[info] Benchmark                  (size)  Mode  Cnt         Score         Error  Units
[info] QueueBenchmark.apply            0  avgt    6         2.733 ±       0.348  ns/op
[info] QueueBenchmark.apply            1  avgt    6        19.399 ±       0.802  ns/op
[info] QueueBenchmark.apply            5  avgt    6        24.833 ±       2.210  ns/op
[info] QueueBenchmark.apply           10  avgt    6        38.168 ±       3.986  ns/op
[info] QueueBenchmark.apply         1000  avgt    6      4270.573 ±     169.482  ns/op
[info] QueueBenchmark.apply      1000000  avgt    6   8456933.675 ± 2475592.681  ns/op
[info] QueueBenchmark.concat           0  avgt    6        27.100 ±       1.114  ns/op
[info] QueueBenchmark.concat           1  avgt    6       125.689 ±       2.450  ns/op
[info] QueueBenchmark.concat           5  avgt    6       467.480 ±      15.402  ns/op
[info] QueueBenchmark.concat          10  avgt    6       914.262 ±      20.547  ns/op
[info] QueueBenchmark.concat        1000  avgt    6     80036.070 ±    3124.584  ns/op
[info] QueueBenchmark.concat     1000000  avgt    6  54119817.351 ± 1117919.938  ns/op
[info] QueueBenchmark.queueFrom        0  avgt    6        11.535 ±       0.274  ns/op
[info] QueueBenchmark.queueFrom        1  avgt    6       118.939 ±       1.768  ns/op
[info] QueueBenchmark.queueFrom        5  avgt    6       473.179 ±     154.741  ns/op
[info] QueueBenchmark.queueFrom       10  avgt    6       805.184 ±      52.279  ns/op
[info] QueueBenchmark.queueFrom     1000  avgt    6     69886.868 ±    1649.170  ns/op
[info] QueueBenchmark.queueFrom  1000000  avgt    6  43660987.504 ± 5882326.283  ns/op
```
# Todo
- [x] Write more unit tests for the two changed methods
- [x] Write benchmarks to prove that `apply` is improved 
- [x] Write benchmarks to prove that `appendedAll` is improved 
- [x] Write benchmarks to prove that `Queue.from` is improved 
