### PR TITLE
PickleBuffer: reuse Scan objects, and their inner arrays.

### DIFF
--- a/src/compiler/scala/tools/nsc/util/ShowPickled.scala
+++ b/src/compiler/scala/tools/nsc/util/ShowPickled.scala
@@ -127,6 +127,7 @@ object ShowPickled extends Names {
   def printFile(buf: PickleBuffer, out: PrintStream): Unit = {
     out.println("Version " + buf.readNat() + "." + buf.readNat())
     val index = buf.createIndex
+    val indexSize = buf.getIndexSize
     val entryList = makeEntryList(buf, index)
     buf.readIndex = 0
 
@@ -278,7 +279,7 @@ object ShowPickled extends Names {
       }
     }
 
-    for (i <- 0 until index.length) printEntry(i)
+    for (i <- 0 until indexSize) printEntry(i)
   }
 
   def fromFile(path: String) = fromBytes(io.File(path).toByteArray())

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -417,6 +417,14 @@ trait Collections {
       these = these.tail
     }
   }
+
+  final def fillArray[A <: AnyRef](arr: Array[A], value: A): Unit = {
+    var ix = 0
+    while (ix < arr.length) {
+      arr(ix) = value
+      ix += 1
+    }
+  }
 }
 
 object Collections extends Collections


### PR DESCRIPTION
Examining a build of the `monix/coreJVM`, I noticed that there are some allocations of `int[]` objects, from the class `PickleBuffer` and its subclass Scan. This is because of the "index" object that is created in each
`Picklebuffer`, which is used to indicate special stop points in the data given in the `_bytes` array.

The goal of this commit is to avoid allocations in there by reusing and recycling a mutable instance, one in which we try to keep and clear and reuse the arrays that are created. 

One small hindrance is that, when some Lazy type instances are created (which keeps a pointer back to the array) we cannot recycle the Scan object.