### PR TITLE
faster HashMap equality check

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -14,6 +14,8 @@ package scala
 package collection
 package immutable
 
+import java.{util => ju}
+
 import generic._
 import scala.annotation.unchecked.{uncheckedVariance => uV}
 import parallel.immutable.ParHashMap
@@ -248,6 +250,18 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
     protected override def merge0[B1 >: B](that: HashMap[A, B1], level: Int, merger: Merger[A, B1]): HashMap[A, B1] = {
       that.updated0(key, hash, level, value, kv, merger.invert)
     }
+
+    override def equals(that: Any): Boolean = {
+      that match {
+        case hm: HashMap1[_,_] =>
+          (this eq hm) ||
+            (hm.hash == hash && hm.key == key && hm.value == value)
+        case _: HashMap[_, _] =>
+          false
+        case _ =>
+          super.equals(that)
+      }
+    }
   }
 
   private[collection] class HashMapCollision1[A, +B](private[collection] val hash: Int, val kvs: ListMap[A, B @uV])
@@ -319,6 +333,19 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
       for (p <- kvs) m = m.updated0(p._1, this.hash, level, p._2, p, merger.invert)
       m
     }
+
+    override def equals(that: Any): Boolean = {
+      that match {
+        case hm: HashMapCollision1[_,_] =>
+          (this eq hm) ||
+            (hm.hash == hash && hm.kvs == kvs)
+        case _: HashMap[_, _] =>
+          false
+        case _ =>
+          super.equals(that)
+      }
+    }
+
   }
 
   @deprecatedInheritance("This class will be made final in a future release.", "2.12.2")
@@ -578,6 +605,22 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
       case hm: HashMap[_, _] => this
       case _ => sys.error("section supposed to be unreachable.")
     }
+
+    override def equals(that: Any): Boolean = {
+      that match {
+        case hm: HashTrieMap[_, _] =>
+          (this eq hm) || {
+            this.bitmap == hm.bitmap &&
+              this.size0 == hm.size0 &&
+              ju.Arrays.equals(this.elems.asInstanceOf[Array[AnyRef]], hm.elems.asInstanceOf[Array[AnyRef]])
+          }
+        case _: HashMap[_, _] =>
+          false
+        case _ =>
+          super.equals(that)
+      }
+    }
+
   }
 
   /**

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashMapEqualsBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashMapEqualsBenchmark.scala
@@ -1,0 +1,52 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class HashMapEqualsBenchmark {
+  @Param(Array("10", "100", "1000", "10000", "100000", "1000000"))
+  var size: Int = _
+
+  var base: HashMap[String, String] = _
+  var notShared: HashMap[String, String] = _
+  var identical: HashMap[String, String] = _
+  var shared: HashMap[String, String] = _
+  var differentShared: HashMap[String, String] = _
+
+  @Setup(Level.Trial) def initKeys(): Unit = {
+    base = (1 to size).map { i => s"key $i" -> s"value $i" }(scala.collection.breakOut)
+    notShared = (1 to size).map { i => s"key $i" -> s"value $i" }(scala.collection.breakOut)
+    identical = base
+    shared = (base - base.head._1) + base.head
+    differentShared = (base - base.last._1) + (base.last._1 -> (base.last._2 + "xx"))
+  }
+
+
+  @Benchmark
+  def nonAllocatingIdentical() = {
+    base == base
+  }
+
+  @Benchmark
+  def nonAllocatingNotShared() = {
+    base == notShared
+  }
+
+  @Benchmark
+  def nonAllocatingShared() {
+    base == shared
+  }
+  @Benchmark
+  def nonAllocatingDifferentShared() {
+    base == differentShared
+  }
+}

--- a/test/junit/scala/collection/immutable/HashMapTest.scala
+++ b/test/junit/scala/collection/immutable/HashMapTest.scala
@@ -1,12 +1,14 @@
 package scala.collection.immutable
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.tools.testing.AllocationTest
+
 @RunWith(classOf[JUnit4])
-class HashMapTest {
+class HashMapTest extends AllocationTest {
 
   private val computeHashF = {
     HashMap.empty.computeHash _
@@ -15,6 +17,7 @@ class HashMapTest {
   @Test
   def canMergeIdenticalHashMap1sWithNullKvs() {
     def m = new HashMap.HashMap1(1, computeHashF(1), 1, null)
+
     val merged = m.merged(m)(null)
     assertEquals(m, merged)
   }
@@ -22,6 +25,7 @@ class HashMapTest {
   @Test
   def canMergeIdenticalHashMap1sWithNullKvsCustomMerge() {
     def m = new HashMap.HashMap1(1, computeHashF(1), 1, null)
+
     val merged = m.merged(m) {
       case ((k1, v1), (k2, v2)) =>
         (k1, v1 + v2)
@@ -48,7 +52,9 @@ class HashMapTest {
 
   @Test
   def canMergeHashMapCollision1WithCorrectMerege() {
-    case class A(k: Int) { override def hashCode = 0 }
+    case class A(k: Int) {
+      override def hashCode = 0
+    }
     val m1 = HashMap(A(0) -> 2, A(1) -> 2)
     val m2 = HashMap(A(0) -> 1, A(1) -> 1)
     val merged = m1.merged(m2) { case ((k, l), (_, r)) => k -> (l - r) }
@@ -71,5 +77,43 @@ class HashMapTest {
     assert(stillSingleElement.isInstanceOf[HashMap.HashMap1[_, _]])
     val twoElemTrie = stillSingleElement + (PoorlyHashed(2) -> 2)
     assert(twoElemTrie.isInstanceOf[HashMap.HashTrieMap[_, _]])
+  }
+
+  def generate(): HashMap[String, String] = {
+    (1 to 1000).map { i => s"key $i" -> s"value $i" }(scala.collection.breakOut)
+  }
+
+  @Test
+  def nonAllocatingIdentical(): Unit = {
+    val base = generate()
+    assertTrue(nonAllocating {
+      base == base
+    })
+  }
+
+  @Test
+  def nonAllocatingNotShared(): Unit = {
+    val base = generate()
+    val notShared = generate()
+
+    assertTrue(nonAllocating {
+      base == notShared
+    })
+    assertTrue(nonAllocating {
+      notShared == base
+    })
+  }
+
+  @Test
+  def nonAllocatingShared(): Unit = {
+    val base = generate()
+    val shared = (base - base.head._1) + base.head
+
+    assertTrue(nonAllocating {
+      base == shared
+    })
+    assertTrue(nonAllocating {
+      shared == base
+    })
   }
 }

--- a/test/junit/scala/tools/testing/AllocationTest.scala
+++ b/test/junit/scala/tools/testing/AllocationTest.scala
@@ -9,19 +9,42 @@ object AllocationTest {
   val allocationCounter = ManagementFactory.getThreadMXBean.asInstanceOf[com.sun.management.ThreadMXBean]
   assertTrue(allocationCounter.isThreadAllocatedMemorySupported)
   allocationCounter.setThreadAllocatedMemoryEnabled(true)
-  val costObject: Long = {
-    object coster extends AllocationTest
-    val costs = coster.allocationInfoImpl("" equals "xx", new AllocationExecution(), 0)
-    costs.min
+
+  private object coster extends AllocationTest {
+    def byte = 1.toByte
+
+    def short = 1.toShort
+
+    def int = 100000000
+
+    def long = 100000000000000L
+
+    def boolean = true
+
+    def char = 's'
+
+    def float = 1F
+
+    def double = 1D
+
+    def unit = ()
   }
-  val costInt: Long = {
-    object coster extends AllocationTest
-    val costs = coster.allocationInfoImpl(coster.hashCode(), new AllocationExecution(), 0)
-    costs.min
+  private def trace(Type:String, value:Long) :Long = {
+    println(s"cost of tracking allocations - cost of $Type   = $value")
+    value
   }
 
-  println(s"cost of tracking allocations - Object = $costObject")
-  println(s"cost of tracking allocations - Int = $costInt")
+  lazy val costObject:  Long = trace("Object", coster.allocationInfoImpl(coster, new AllocationExecution(), 0).min)
+  lazy val costByte:    Long =  trace("Byte", coster.allocationInfoImpl(coster.byte, new AllocationExecution(), 0).min)
+  lazy val costShort:   Long =  trace("Short", coster.allocationInfoImpl(coster.short, new AllocationExecution(), 0).min)
+  lazy val costInt:     Long =  trace("Int", coster.allocationInfoImpl(coster.int, new AllocationExecution(), 0).min)
+  lazy val costLong:    Long =  trace("Long", coster.allocationInfoImpl(coster.long, new AllocationExecution(), 0).min)
+  lazy val costBoolean: Long =  trace("Boolean", coster.allocationInfoImpl(coster.boolean, new AllocationExecution(), 0).min)
+  lazy val costChar:    Long =  trace("Char", coster.allocationInfoImpl(coster.char, new AllocationExecution(), 0).min)
+  lazy val costFloat:   Long =  trace("Float", coster.allocationInfoImpl(coster.float, new AllocationExecution(), 0).min)
+  lazy val costDouble:  Long =  trace("Double", coster.allocationInfoImpl(coster.double, new AllocationExecution(), 0).min)
+  lazy val costUnit:    Long =  trace("Unit", coster.allocationInfoImpl(coster.unit, new AllocationExecution(), 0).min)
+
 }
 
 trait AllocationTest {
@@ -31,7 +54,8 @@ trait AllocationTest {
   def nonAllocating[T: Manifest](fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): T = {
     onlyAllocates(0)(fn)
   }
-  def onlyAllocates[T: Manifest](size:Int)(fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): T = {
+
+  def onlyAllocates[T: Manifest](size: Int)(fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): T = {
     val result = allocationInfo(fn)
 
     if (result.min > size) {
@@ -46,7 +70,15 @@ trait AllocationTest {
   def allocationInfo[T: Manifest](fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): AllocationInfo[T] = {
     val cls = manifest[T].runtimeClass
     val cost =
-      if (cls == classOf[Int]) costInt
+      if (cls == classOf[Byte]) costByte
+      else if (cls == classOf[Short]) costShort
+      else if (cls == classOf[Int]) costInt
+      else if (cls == classOf[Long]) costLong
+      else if (cls == classOf[Boolean]) costBoolean
+      else if (cls == classOf[Char]) costChar
+      else if (cls == classOf[Float]) costFloat
+      else if (cls == classOf[Double]) costDouble
+      else if (cls == classOf[Unit]) costUnit
       else if (cls.isPrimitive) ???
       else costObject
     allocationInfoImpl(fn, execution, cost)


### PR DESCRIPTION
Specialise equality checking in the common case - where we are comparing a `HashMap` with another `HashMap`

Allocation are reduced  - for tests 
Before
```
nonAllocatingShared    - 16136 bytes
nonAllocatingNotShared - 16136 bytes
```
After 
no allocations


benchmarks are afster except one case when the maps are 10K long and contain the same keys and values, but don't have structural sharing

before
```
[info] Benchmark                                             (size)  Mode  Cnt          Score         Error  Units
[info] HashMapEqualsBenchmark.nonAllocatingDifferentShared       10  avgt   20        146.773 ▒       0.683  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingDifferentShared      100  avgt   20       2674.760 ▒      66.553  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingDifferentShared     1000  avgt   20      34981.565 ▒     147.489  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingDifferentShared    10000  avgt   20     476650.815 ▒    6520.751  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingDifferentShared   100000  avgt   20    8162619.004 ▒  389834.682  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingDifferentShared  1000000  avgt   20   89039389.932 ▒ 7529599.778  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingIdentical             10  avgt   20          3.320 ▒       0.072  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingIdentical            100  avgt   20          3.336 ▒       0.155  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingIdentical           1000  avgt   20          3.283 ▒       0.009  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingIdentical          10000  avgt   20          3.304 ▒       0.045  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingIdentical         100000  avgt   20          3.282 ▒       0.008  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingIdentical        1000000  avgt   20          3.310 ▒       0.088  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingNotShared             10  avgt   20        281.047 ▒       0.868  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingNotShared            100  avgt   20       4686.888 ▒     350.649  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingNotShared           1000  avgt   20      62615.105 ▒    2637.198  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingNotShared          10000  avgt   20     878134.430 ▒   12359.797  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingNotShared         100000  avgt   20   14366528.698 ▒  382193.350  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingNotShared        1000000  avgt   20  153765590.238 ▒ 8026359.807  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingShared                10  avgt   20        141.260 ▒       2.140  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingShared               100  avgt   20       2344.717 ▒     146.374  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingShared              1000  avgt   20      35268.297 ▒     490.699  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingShared             10000  avgt   20     469588.756 ▒    7917.860  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingShared            100000  avgt   20    8300822.380 ▒  344675.154  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingShared           1000000  avgt   20   84340060.629 ▒ 5215737.960  ns/op
```

after 
```
[info] Benchmark                                             (size)  Mode  Cnt          Score         Error  Units
[info] HashMapEqualsBenchmark.nonAllocatingDifferentShared       10  avgt   20         61.066 ▒       0.288  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingDifferentShared      100  avgt   20        280.327 ▒       6.648  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingDifferentShared     1000  avgt   20        333.969 ▒      16.837  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingDifferentShared    10000  avgt   20        410.014 ▒       8.288  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingDifferentShared   100000  avgt   20        653.467 ▒      25.404  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingDifferentShared  1000000  avgt   20        692.037 ▒      19.032  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingIdentical             10  avgt   20          3.337 ▒       0.133  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingIdentical            100  avgt   20          3.363 ▒       0.111  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingIdentical           1000  avgt   20          3.468 ▒       0.171  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingIdentical          10000  avgt   20          3.367 ▒       0.140  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingIdentical         100000  avgt   20          3.347 ▒       0.179  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingIdentical        1000000  avgt   20          3.288 ▒       0.022  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingNotShared             10  avgt   20        167.913 ▒       0.859  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingNotShared            100  avgt   20       3488.789 ▒      43.233  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingNotShared           1000  avgt   20      61236.023 ▒     350.485  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingNotShared          10000  avgt   20    2147060.290 ▒   40854.180  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingNotShared         100000  avgt   20   14091224.088 ▒  144209.350  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingNotShared        1000000  avgt   20  155706817.857 ▒ 1366210.091  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingShared                10  avgt   20         20.921 ▒       0.142  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingShared               100  avgt   20        280.882 ▒      12.614  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingShared              1000  avgt   20        296.281 ▒       7.070  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingShared             10000  avgt   20        447.103 ▒      28.182  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingShared            100000  avgt   20        254.787 ▒       2.039  ns/op
[info] HashMapEqualsBenchmark.nonAllocatingShared           1000000  avgt   20        690.022 ▒      23.636  ns/op
```



