### PR TITLE
Bug fixes in divergent implicits checker

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -503,7 +503,12 @@ trait Implicits {
       }
       val dtor1 = stripped(core(dtor))
       val dted1 = stripped(core(dted))
-      overlaps(dtor1, dted1) && (dtor1 =:= dted1 || complexity(dtor1) > complexity(dted1))
+      overlaps(dtor1, dted1) && {
+        complexity(dtor1) compareTo complexity(dted1) match {
+          case 0 => dtor1 =:= dted1
+          case cmp => cmp > 0
+        }
+      }
     }
 
     private def core(tp: Type): Type = tp.dealiasWiden match {
@@ -576,10 +581,7 @@ trait Implicits {
           lazy val spt = stripped(core(pt))
           lazy val sptSyms = allSymbols(spt)
           // Are all the symbols of the stripped core of pt contained in the stripped core of tp?
-          def coversPt(tp: Type): Boolean = {
-            val stp = stripped(core(tp))
-            (stp =:= spt) || (sptSyms == allSymbols(stp))
-          }
+          def coversPt(tp: Type): Boolean = sptSyms == allSymbols(stripped(core(tp)))
 
           @tailrec
           def loop(ois: List[OpenImplicit], belowByName: Boolean): Boolean = {

--- a/test/files/neg/byname-implicits-16.check
+++ b/test/files/neg/byname-implicits-16.check
@@ -1,5 +1,5 @@
 byname-implicits-16.scala:14: error: diverging implicit expansion for type Test.O[Test.Z]
-starting with method expande in object Expand
+starting with method mkN in object Test
   implicitly[O[Z]]
             ^
 one error found

--- a/test/files/pos/t10080.scala
+++ b/test/files/pos/t10080.scala
@@ -1,0 +1,3 @@
+class OC[T1: Ordering, T2: Ordering]() {
+  val ordering = implicitly[Ordering[((Int, T1), T2)]]
+}

--- a/test/files/pos/t11768.scala
+++ b/test/files/pos/t11768.scala
@@ -1,0 +1,16 @@
+object A {
+  trait B[T]
+  implicit def c[T <: Singleton]: B[T] = ???
+  implicit def d[T1: B, T2: B]: B[Tuple2[T1, T2]] = ???
+  implicit def e[T: B]: B[Option[T]] = ???
+  implicit def f[C[_] <: Iterable[_], T](implicit r: B[T]): B[C[T]] = ???
+}
+
+object G {
+  class H[T: A.B, V: A.B](t: Option[(V, T)]){
+    implicitly[A.B[Option[(V, T)]]]
+  }
+  def h[T: A.B, V: A.B](t: Option[(V, T)]){
+    implicitly[A.B[Option[(V, T)]]]
+  }
+}


### PR DESCRIPTION
We can't rely on type equality (`=:=`) to indicate domination
or covering when the types contain wildcards (`?`) because
wildcards are equal to anything by definition (e.g. `? =:= (?, ?)`).
But we explicitly add those wildcards in the `stripped` method.
Since type equality is not essential to the computation we omit it,
unless the complexity is exactly equal, then we need to check. 

To offset the possible perfomance degradation we optimize:
  * Don't allocate `Option[Boolean]` in `existsDominatedImplicit`
  * Eliminate redundant calls to `stripped(core(tp))`
    in `dominates` and `coversPt`

Also removed some unused pattern bindings in the area.

Fixes scala/bug#11768 and fixes scala/bug#10080