### PR TITLE
Fix StackOverflowError in getParts: dropExistential

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1417,10 +1417,12 @@ trait Implicits {
             for (p <- ps) getParts(p)
           case AnnotatedType(_, t) =>
             getParts(t)
-          case ExistentialType(_, t) =>
-            getParts(t)
+          case ExistentialType(_, _) =>
+            getParts(dropExistential(tp))
           case PolyType(_, t) =>
             getParts(t)
+          case BoundedWildcardType(bounds) =>
+            getParts(bounds.hi)
           // not needed, a view's expected type is normalized in typer by normalizeProtoForView:
           // case proto: OverloadedArgProto => getParts(proto.underlying)
           case _ =>


### PR DESCRIPTION
As a consequence add a case for `BoundedWildcardType`s.