### PR TITLE
Enhance upper bounds of undetermined type parameters

### DIFF
--- a/test/files/neg/t8322.check
+++ b/test/files/neg/t8322.check
@@ -1,9 +1,3 @@
-t8322.scala:17: error: ambiguous implicit values:
- both method $conforms in object Predef of type [A]=> A => A
- and value ew in trait F of type => Writes[Any]
- match expected type T
-  implicit def wr[E] = jw(implicitly, implicitly)
-                          ^
 t8322.scala:17: error: diverging implicit expansion for type W[Any]
 starting with method jw in trait F
   implicit def wr[E] = jw(implicitly, implicitly)
@@ -13,4 +7,4 @@ t8322.scala:19: error: type mismatch;
  required: scala.util.Either[?,?]
   Right(0).right.flatMap(_ => new String())
                               ^
-3 errors
+2 errors

--- a/test/files/pos/t11427.scala
+++ b/test/files/pos/t11427.scala
@@ -1,0 +1,42 @@
+object example extends App {
+  trait MonoIO[F[_]]
+  trait BifunctorIO[F[+_, _]]
+
+  case class IO[+A]()
+  object IO {
+    implicit val monoInstance: MonoIO[IO] = new MonoIO[IO]{}
+  }
+
+  trait AnyIO[+F[_]]
+  object AnyIO {
+    implicit def fromMono[F[_]: MonoIO]: AnyIO[F] = new AnyIO[F]{}
+    implicit def fromBIO[F[+_, _]: BifunctorIO]: AnyIO[({ type l[A] = F[Nothing, A]})#l] =
+      new AnyIO[({ type l[A] = F[Nothing, A]})#l]{}
+  }
+
+  class SomeAlg[+F[_]]
+  type SomeAlg2[F[_, _]] = SomeAlg[({ type l[A] = F[Nothing, A]})#l]
+  object SomeAlg {
+    def make[F[_]: AnyIO](): SomeAlg[F] = new SomeAlg[F]
+  }
+
+  val alg: SomeAlg[IO] = SomeAlg.make[IO]()
+  val alg1: SomeAlg[IO] = SomeAlg.make()
+}
+
+object simplified {
+  class MonoIO[F] // it works if you make this covariant
+
+  class IO
+  object IO { implicit val monoInstance: MonoIO[IO] = new MonoIO[IO] }
+
+  class AnyIO[+F] // also works if you drop covariance here (and don't add it above)
+  object AnyIO { implicit def fromMono[F](implicit mono: MonoIO[F]): AnyIO[F] = new AnyIO[F] }
+
+  object Test {
+    // if we provide this explicitly, it works even for any mix of variance:
+    // implicit val ev = AnyIO.fromMono[IO]
+
+    implicitly[AnyIO[IO]] //(AnyIO.fromMono) even with this hint, type inference still fails
+  }
+}

--- a/test/files/pos/t7332.scala
+++ b/test/files/pos/t7332.scala
@@ -1,0 +1,7 @@
+object Test {
+  trait Foo[A]
+  implicit val c: Foo[Int] = ???
+  implicit val d: Foo[String] = ???
+  def bar[A: Foo]: A = ???
+  bar: Int
+}


### PR DESCRIPTION
Use the accumulated `TypeVar` constraints for that.

Fixes scala/bug#7332, fixes scala/bug#11427