### PR TITLE
faster equals for HashSet

### DIFF
--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -14,6 +14,8 @@ package scala
 package collection
 package immutable
 
+import java.util
+
 import generic._
 import scala.collection.parallel.immutable.ParHashSet
 import scala.collection.GenSet
@@ -258,12 +260,21 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     override protected def get0(key: A, hash: Int, level: Int): Boolean =
       (hash == this.hash && key == this.key)
 
+    override def equals(other: Any): Boolean = {
+      other match {
+        case that: HashSet1[A] =>
+          (this eq that) || (this.hash == that.hash && this.key == that.key)
+        case _ : HashSet[_] => false
+        case _ => super.equals(other)
+      }
+    }
+
     override protected def subsetOf0(that: HashSet[A], level: Int) = {
       // check if that contains this.key
       // we use get0 with our key and hash at the correct level instead of calling contains,
       // which would not work since that might not be a top-level HashSet
       // and in any case would be inefficient because it would require recalculating the hash code
-      that.get0(key, hash, level)
+      (this eq that) || that.get0(key, hash, level)
     }
 
     override private[collection] def updated0(key: A, hash: Int, level: Int): HashSet[A] =
@@ -328,12 +339,21 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     override protected def get0(key: A, hash: Int, level: Int): Boolean =
       if (hash == this.hash) ks.contains(key) else false
 
+    override def equals(other: Any): Boolean = {
+      other match {
+        case that: HashSetCollision1[A] =>
+          (this eq that) || (this.hash == that.hash && this.ks == that.ks)
+        case miss : HashSet[_] => false
+        case _ => super.equals(other)
+      }
+    }
+
     override protected def subsetOf0(that: HashSet[A], level: Int) = {
       // we have to check each element
       // we use get0 with our hash at the correct level instead of calling contains,
       // which would not work since that might not be a top-level HashSet
       // and in any case would be inefficient because it would require recalculating the hash code
-      ks.forall(key => that.get0(key, hash, level))
+      (this eq that) || ks.forall(key => that.get0(key, hash, level))
     }
 
     override private[collection] def updated0(key: A, hash: Int, level: Int): HashSet[A] =
@@ -878,7 +898,17 @@ object HashSet extends ImmutableSetFactory[HashSet] {
       }
     }
 
-    override protected def subsetOf0(that: HashSet[A], level: Int): Boolean = if (that eq this) true else that match {
+    override def equals(other: Any): Boolean = {
+      other match {
+        case that: HashTrieSet[A] =>
+          (this eq that) || (this.bitmap == that.bitmap && this.size0 == that.size0 &&
+            util.Arrays.equals(this.elems.asInstanceOf[Array[AnyRef]], that.elems.asInstanceOf[Array[AnyRef]]))
+        case _ : HashSet[_] => false
+        case _ => super.equals(other)
+      }
+    }
+
+    override protected def subsetOf0(that: HashSet[A], level: Int): Boolean = (that eq this) || (that match {
       case that: HashTrieSet[A] if this.size0 <= that.size0 =>
         // create local mutable copies of members
         var abm = this.bitmap
@@ -919,7 +949,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
         // if the other set is a HashSetCollision1, we can not be a subset of it because we are a HashTrieSet with at least two different hash codes
         // if the other set is the empty set, we are not a subset of it because we are not empty
         false
-    }
+    })
 
     override protected def filter0(p: A => Boolean, negate: Boolean, level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = {
       // current offset

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetEqualsBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetEqualsBenchmark.scala
@@ -1,0 +1,53 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class HashSetEqualsBenchmark {
+  @Param(Array("10", "100", "1000", "10000", "100000", "1000000"))
+  var size: Int = _
+
+  var base: HashSet[String] = _
+  var notShared: HashSet[String] = _
+  var identical: HashSet[String] = _
+  var shared: HashSet[String] = _
+  var differentShared: HashSet[String] = _
+
+  @Setup(Level.Trial) def initKeys(): Unit = {
+    base = (1 to size).map { i => s"key $i" }(scala.collection.breakOut)
+    notShared = (1 to size).map { i => s"key $i"  }(scala.collection.breakOut)
+    identical = base
+    shared = (base - base.head) + base.head
+    differentShared = (base - base.last) + (base.last + "xx")
+  }
+
+
+  @Benchmark
+  def bmIdentical() = {
+    base == base
+    base .equals(base)
+  }
+
+  @Benchmark
+  def bmNotShared() = {
+    base == notShared
+  }
+
+  @Benchmark
+  def bmShared() {
+    base == shared
+  }
+  @Benchmark
+  def bmDifferentShared() {
+    base == differentShared
+  }
+}

--- a/test/junit/scala/collection/immutable/HashSetTest.scala
+++ b/test/junit/scala/collection/immutable/HashSetTest.scala
@@ -1,0 +1,52 @@
+package scala.collection.immutable
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.AllocationTest
+
+@RunWith(classOf[JUnit4])
+class HashSetTest extends AllocationTest {
+
+
+  def generate(): HashSet[String] = {
+    (1 to 1000).map { i => s"key $i" }(scala.collection.breakOut)
+  }
+
+  @Test
+  def nonAllocatingIdentical(): Unit = {
+    val base = generate()
+    assertTrue(nonAllocating {
+      base == base
+    })
+  }
+
+  @Test
+  def nonAllocatingNotShared(): Unit = {
+    val base = generate()
+    val notShared = generate()
+
+    assertTrue(nonAllocating {
+      base == notShared
+    })
+    assertTrue(nonAllocating {
+      notShared == base
+    })
+  }
+
+  @Test
+  def nonAllocatingShared(): Unit = {
+    val base = generate()
+    val shared = (base - base.head) + base.head
+
+    assertTrue(nonAllocating {
+      base == shared
+    })
+    assertTrue(nonAllocating {
+      shared == base
+    })
+  }
+
+}

--- a/test/junit/scala/tools/testing/AllocationTest.scala
+++ b/test/junit/scala/tools/testing/AllocationTest.scala
@@ -9,19 +9,42 @@ object AllocationTest {
   val allocationCounter = ManagementFactory.getThreadMXBean.asInstanceOf[com.sun.management.ThreadMXBean]
   assertTrue(allocationCounter.isThreadAllocatedMemorySupported)
   allocationCounter.setThreadAllocatedMemoryEnabled(true)
-  val costObject: Long = {
-    object coster extends AllocationTest
-    val costs = coster.allocationInfoImpl("" equals "xx", new AllocationExecution(), 0)
-    costs.min
+
+  private object coster extends AllocationTest {
+    def byte = 1.toByte
+
+    def short = 1.toShort
+
+    def int = 100000000
+
+    def long = 100000000000000L
+
+    def boolean = true
+
+    def char = 's'
+
+    def float = 1F
+
+    def double = 1D
+
+    def unit = ()
   }
-  val costInt: Long = {
-    object coster extends AllocationTest
-    val costs = coster.allocationInfoImpl(coster.hashCode(), new AllocationExecution(), 0)
-    costs.min
+  private def trace(Type:String, value:Long) :Long = {
+    println(s"cost of tracking allocations - cost of $Type   = $value")
+    value
   }
 
-  println(s"cost of tracking allocations - Object = $costObject")
-  println(s"cost of tracking allocations - Int = $costInt")
+  lazy val costObject:  Long = trace("Object", coster.allocationInfoImpl(coster, new AllocationExecution(), 0).min)
+  lazy val costByte:    Long =  trace("Byte", coster.allocationInfoImpl(coster.byte, new AllocationExecution(), 0).min)
+  lazy val costShort:   Long =  trace("Short", coster.allocationInfoImpl(coster.short, new AllocationExecution(), 0).min)
+  lazy val costInt:     Long =  trace("Int", coster.allocationInfoImpl(coster.int, new AllocationExecution(), 0).min)
+  lazy val costLong:    Long =  trace("Long", coster.allocationInfoImpl(coster.long, new AllocationExecution(), 0).min)
+  lazy val costBoolean: Long =  trace("Boolean", coster.allocationInfoImpl(coster.boolean, new AllocationExecution(), 0).min)
+  lazy val costChar:    Long =  trace("Char", coster.allocationInfoImpl(coster.char, new AllocationExecution(), 0).min)
+  lazy val costFloat:   Long =  trace("Float", coster.allocationInfoImpl(coster.float, new AllocationExecution(), 0).min)
+  lazy val costDouble:  Long =  trace("Double", coster.allocationInfoImpl(coster.double, new AllocationExecution(), 0).min)
+  lazy val costUnit:    Long =  trace("Unit", coster.allocationInfoImpl(coster.unit, new AllocationExecution(), 0).min)
+
 }
 
 trait AllocationTest {
@@ -31,7 +54,8 @@ trait AllocationTest {
   def nonAllocating[T: Manifest](fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): T = {
     onlyAllocates(0)(fn)
   }
-  def onlyAllocates[T: Manifest](size:Int)(fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): T = {
+
+  def onlyAllocates[T: Manifest](size: Int)(fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): T = {
     val result = allocationInfo(fn)
 
     if (result.min > size) {
@@ -46,7 +70,15 @@ trait AllocationTest {
   def allocationInfo[T: Manifest](fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): AllocationInfo[T] = {
     val cls = manifest[T].runtimeClass
     val cost =
-      if (cls == classOf[Int]) costInt
+      if (cls == classOf[Byte]) costByte
+      else if (cls == classOf[Short]) costShort
+      else if (cls == classOf[Int]) costInt
+      else if (cls == classOf[Long]) costLong
+      else if (cls == classOf[Boolean]) costBoolean
+      else if (cls == classOf[Char]) costChar
+      else if (cls == classOf[Float]) costFloat
+      else if (cls == classOf[Double]) costDouble
+      else if (cls == classOf[Unit]) costUnit
       else if (cls.isPrimitive) ???
       else costObject
     allocationInfoImpl(fn, execution, cost)


### PR DESCRIPTION
faster implementation of equals for HashSet

add a benchmark for HashSet equals

add some unit test to ensure that HashSet equals is non allocation (it was already)

```
before
[info] Benchmark                                  (size)  Mode  Cnt          Score          Error  Units
[info] HashSetEqualsBenchmark.bmDifferentShared       10  avgt   20          2.710 ▒        0.202  ns/op
[info] HashSetEqualsBenchmark.bmDifferentShared      100  avgt   20        244.558 ▒        2.110  ns/op
[info] HashSetEqualsBenchmark.bmDifferentShared     1000  avgt   20        795.462 ▒      643.988  ns/op
[info] HashSetEqualsBenchmark.bmDifferentShared    10000  avgt   20        894.765 ▒      408.431  ns/op
[info] HashSetEqualsBenchmark.bmDifferentShared   100000  avgt   20        975.240 ▒      300.178  ns/op
[info] HashSetEqualsBenchmark.bmDifferentShared  1000000  avgt   20        998.376 ▒       28.418  ns/op
[info] HashSetEqualsBenchmark.bmIdentical             10  avgt   20          4.097 ▒        0.172  ns/op
[info] HashSetEqualsBenchmark.bmIdentical            100  avgt   20          4.004 ▒        0.061  ns/op
[info] HashSetEqualsBenchmark.bmIdentical           1000  avgt   20          4.158 ▒        0.391  ns/op
[info] HashSetEqualsBenchmark.bmIdentical          10000  avgt   20          4.044 ▒        0.091  ns/op
[info] HashSetEqualsBenchmark.bmIdentical         100000  avgt   20          7.962 ▒        4.067  ns/op
[info] HashSetEqualsBenchmark.bmIdentical        1000000  avgt   20          4.970 ▒        0.282  ns/op
[info] HashSetEqualsBenchmark.bmNotShared             10  avgt   20        229.680 ▒       15.493  ns/op
[info] HashSetEqualsBenchmark.bmNotShared            100  avgt   20      11263.387 ▒    25018.840  ns/op
[info] HashSetEqualsBenchmark.bmNotShared           1000  avgt   20      82702.868 ▒    31806.552  ns/op
[info] HashSetEqualsBenchmark.bmNotShared          10000  avgt   20    2664341.563 ▒   969486.733  ns/op
[info] HashSetEqualsBenchmark.bmNotShared         100000  avgt   20   11433809.714 ▒  9776475.388  ns/op
[info] HashSetEqualsBenchmark.bmNotShared        1000000  avgt   20  118030875.214 ▒ 41105813.880  ns/op
[info] HashSetEqualsBenchmark.bmShared                10  avgt   20         51.285 ▒       12.615  ns/op
[info] HashSetEqualsBenchmark.bmShared               100  avgt   20        216.223 ▒        2.933  ns/op
[info] HashSetEqualsBenchmark.bmShared              1000  avgt   20        376.017 ▒       20.112  ns/op
[info] HashSetEqualsBenchmark.bmShared             10000  avgt   20        594.879 ▒       19.141  ns/op
[info] HashSetEqualsBenchmark.bmShared            100000  avgt   20        788.357 ▒       55.650  ns/op
[info] HashSetEqualsBenchmark.bmShared           1000000  avgt   20        934.781 ▒       40.151  ns/op
							  
							  
[info] Benchmark                                  (size)  Mode  Cnt          Score          Error  Units
[info] HashSetEqualsBenchmark.bmDifferentShared       10  avgt   20          3.891 ▒        4.488  ns/op
[info] HashSetEqualsBenchmark.bmDifferentShared      100  avgt   20        122.570 ▒       35.533  ns/op
[info] HashSetEqualsBenchmark.bmDifferentShared     1000  avgt   20        130.723 ▒       64.441  ns/op
[info] HashSetEqualsBenchmark.bmDifferentShared    10000  avgt   20         18.862 ▒       10.310  ns/op
[info] HashSetEqualsBenchmark.bmDifferentShared   100000  avgt   20        233.979 ▒      361.354  ns/op
[info] HashSetEqualsBenchmark.bmDifferentShared  1000000  avgt   20         36.045 ▒       11.735  ns/op
[info] HashSetEqualsBenchmark.bmIdentical             10  avgt   20          3.858 ▒        0.273  ns/op
[info] HashSetEqualsBenchmark.bmIdentical            100  avgt   20          4.061 ▒        0.943  ns/op
[info] HashSetEqualsBenchmark.bmIdentical           1000  avgt   20          4.356 ▒        1.006  ns/op
[info] HashSetEqualsBenchmark.bmIdentical          10000  avgt   20          3.663 ▒        0.127  ns/op
[info] HashSetEqualsBenchmark.bmIdentical         100000  avgt   20          3.714 ▒        0.258  ns/op
[info] HashSetEqualsBenchmark.bmIdentical        1000000  avgt   20          3.608 ▒        0.045  ns/op
[info] HashSetEqualsBenchmark.bmNotShared             10  avgt   20        131.382 ▒       12.079  ns/op
[info] HashSetEqualsBenchmark.bmNotShared            100  avgt   20       2436.161 ▒      100.829  ns/op
[info] HashSetEqualsBenchmark.bmNotShared           1000  avgt   20      41505.524 ▒     1442.893  ns/op
[info] HashSetEqualsBenchmark.bmNotShared          10000  avgt   20    1334112.094 ▒   108088.006  ns/op
[info] HashSetEqualsBenchmark.bmNotShared         100000  avgt   20    6902236.773 ▒   892850.643  ns/op
[info] HashSetEqualsBenchmark.bmNotShared        1000000  avgt   20  102725846.807 ▒ 36422815.619  ns/op
[info] HashSetEqualsBenchmark.bmShared                10  avgt   20         43.446 ▒       21.047  ns/op
[info] HashSetEqualsBenchmark.bmShared               100  avgt   20        343.322 ▒       20.615  ns/op
[info] HashSetEqualsBenchmark.bmShared              1000  avgt   20        333.927 ▒        2.962  ns/op
[info] HashSetEqualsBenchmark.bmShared             10000  avgt   20        474.486 ▒       14.454  ns/op
[info] HashSetEqualsBenchmark.bmShared            100000  avgt   20        661.510 ▒        7.285  ns/op
[info] HashSetEqualsBenchmark.bmShared           1000000  avgt   20        749.659 ▒       11.418  ns/op

```
