### PR TITLE
[backport] Bump Xmx for type-tag-leak

### DIFF
--- a/test/files/run/type-tag-leak.javaopts
+++ b/test/files/run/type-tag-leak.javaopts
@@ -1,1 +1,1 @@
--Xmx128M -XX:+ExitOnOutOfMemoryError
+-Xmx192M -XX:+ExitOnOutOfMemoryError


### PR DESCRIPTION
The test allocates 16*16 MB, so testing with a 192 MB heap should
be safe to catch the leak.

Tested with running the test in a `while true` loop locally
  - constanly fails with 192 MB on 2.13.1
  - constantly succeeds with 192 MB on 2.13.2-bin-9ef8fc3
  - flaky with 128 MB on 2.13.2-bin-9ef8fc3

(cherry picked from commit ffcffc6cb18753c255e931f217dca5a9c41e3846)