### PR TITLE
Partially revert infer-any lint improvement aka realias all the…

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -589,18 +589,8 @@ trait Infer extends Checkable {
         // ...or lower bound of a type param, since they're asking for it.
         var checked, warning = false
         def checkForAny(): Unit = {
-          val collector = new ContainsAnyCollector(topTypes) {
-            val seen = collection.mutable.Set.empty[Type]
-            override def apply(t: Type): Unit = {
-              def saw(dw: Type): Unit =
-                if (!result && !seen(dw)) {
-                  seen += dw
-                  if (!dw.typeSymbol.isRefinementClass) super.apply(dw)
-                }
-              if (!result && !seen(t)) t.dealiasWidenChain.foreach(saw)
-            }
-          }
-          @`inline` def containsAny(t: Type) = collector.collect(t)
+          val collector = new ContainsAnyCollector(topTypes)
+          @`inline` def containsAny(t: Type) = t.dealiasWidenChain.exists(collector.collect)
           val hasAny = containsAny(pt) || containsAny(restpe) ||
             formals.exists(containsAny) ||
             argtpes.exists(containsAny) ||

--- a/test/files/neg/warn-inferred-any.check
+++ b/test/files/neg/warn-inferred-any.check
@@ -13,6 +13,9 @@ warn-inferred-any.scala:27: warning: a type was inferred to be `Any`; this may i
 warn-inferred-any.scala:37: warning: a type was inferred to be `Object`; this may indicate a programming error.
   cs.contains(new C2)             // warns
      ^
+warn-inferred-any.scala:52: warning: a type was inferred to be `Any`; this may indicate a programming error.
+  stream.mapM(f)                  // should not warn
+         ^
 error: No warnings can be incurred under -Werror.
-5 warnings
+6 warnings
 1 error


### PR DESCRIPTION
Drilling through type trees looking for `Any` hazards
various cycles, especially with extended dealias+widenings.

Still check for inferred Any before inspecting for explicit
Any, which is performed once lazily instead of up front.

Hopefully this will give Seth a break. I'll try to test the akka build again before he has to.
Akka sure tested the machinery for inferring Any. Smoke was coming out of its ears.