### PR TITLE
Spec grammar touchups pointed out by Ducanhta

### DIFF
--- a/spec/05-classes-and-objects.md
+++ b/spec/05-classes-and-objects.md
@@ -45,7 +45,7 @@ class which is not a trait. It is possible to write a list of
 parents that starts with a trait reference, e.g.
 `$mt_1$ with $\ldots$ with $mt_n$`. In that case the list
 of parents is implicitly extended to include the supertype of $mt_1$
-as first parent type. The new supertype must have at least one
+as the first parent type. The new supertype must have at least one
 constructor that does not take parameters.  In the following, we will
 always assume that this implicit extension has been performed, so that
 the first parent class of a template is a regular superclass
@@ -110,10 +110,13 @@ object O extends Base with Mixin {}
 
 <!-- TODO: Make all references to Java generic -->
 
-**Inheriting from Java Types** A template may have a Java class as its superclass and Java interfaces as its
-mixins.
+**Inheriting from Java Types**
 
-**Template Evaluation** Consider a template `$sc$ with $mt_1$ with $mt_n$ { $\mathit{stats}$ }`.
+A template may have a Java class as its superclass and Java interfaces as its mixins.
+
+**Template Evaluation**
+
+Consider a template `$sc$ with $mt_1$ with $mt_n$ { $\mathit{stats}$ }`.
 
 If this is the template of a [trait](#traits) then its _mixin-evaluation_
 consists of an evaluation of the statement sequence $\mathit{stats}$.
@@ -130,17 +133,18 @@ consists of the following steps.
 - Finally the statement sequence $\mathit{stats}\,$ is evaluated.
 
 ###### Delayed Initialization
-The initialization code of an object or class (but not a trait) that follows
-the superclass
-constructor invocation and the mixin-evaluation of the template's base
-classes is passed to a special hook, which is inaccessible from user
-code. Normally, that hook simply executes the code that is passed to
-it. But templates inheriting the `scala.DelayedInit` trait
-can override the hook by re-implementing the `delayedInit`
-method, which is defined as follows:
+This statement sequence constitutes the initialization code for an object
+or class after the superclass constructor invocation and the mixin-evaluation
+of the template's base classes as described above.
+Normally, this code is passed to a special hook, inaccessible to user code,
+which simply executes it.
+
+However, in objects and classes (but not traits) which extend `scala.DelayedInit`,
+the initialization code is passed to a `delayedInit` method which can be
+overridden to implement arbitrary semantics.
 
 ```scala
-def delayedInit(body: => Unit)
+def delayedInit(body: => Unit): Unit
 ```
 
 ### Constructor Invocations
@@ -435,19 +439,20 @@ An early definition is type-checked and evaluated in the scope which
 is in effect just before the template being defined, augmented by any
 type parameters of the enclosing class and by any early definitions
 preceding the one being defined. In particular, any reference to
-`this` in the right-hand side of an early definition refers
+`this` in an early definition refers
 to the identity of `this` just outside the template. Consequently, it
-is impossible that an early definition refers to the object being
-constructed by the template, or refers to one of its fields and
+is impossible for an early definition to refer to the object being
+constructed by the template, or to refer to one of its fields and
 methods, except for any other preceding early definition in the same
 section. Furthermore, references to preceding early definitions
-always refer to the value that's defined there, and do not take into account
+always refer to the value that's defined there and do not take into account
 overriding definitions. In other words, a block of early definitions
-is evaluated exactly as if it was a local bock containing a number of value
+is evaluated exactly as if it were a local block containing a number of value
 definitions.
 
-Early definitions are evaluated in the order they are being defined
-before the superclass constructor of the template is called.
+Early definitions are evaluated
+before the superclass constructor of the template is called,
+in the order they are defined.
 
 ###### Example
 Early definitions are particularly useful for


### PR DESCRIPTION
Follow-up to https://github.com/scala/scala/pull/8568

It's nice that early definitions are now well-defined, and a clear explanation of delayed initialization is not further delayed. At least they can go out in style.