### PR TITLE
[nomerge] faster ++ and union for HashSet

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,6 +187,20 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.HashMap$HashMapKeys"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.HashMap$HashMapValues"),
 
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.collection.immutable.HashSet#HashSetCollision1.union0"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#HashSetCollision1.union0"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#HashSetCollision1.this"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.collection.immutable.HashSet.union0"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet.union0"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.collection.immutable.HashSet#HashTrieSet.union0"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#HashTrieSet.union0"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.collection.immutable.HashSet#HashSet1.union0"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#HashSet1.union0"),
+    ProblemFilters.exclude[FinalMethodProblem]("scala.collection.immutable.HashSet#LeafHashSet.hash"),
+    ProblemFilters.exclude[DirectAbstractMethodProblem]("scala.collection.immutable.HashSet#LeafHashSet.hash"),
+    ProblemFilters.exclude[ReversedAbstractMethodProblem]("scala.collection.immutable.HashSet#LeafHashSet.hash"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#LeafHashSet.this"),
+
     // Some static forwarder changes detected after a MiMa upgrade.
     // e.g. static method apply(java.lang.Object)java.lang.Object in class scala.Symbol does not have a correspondent in current version
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Symbol.apply"),

--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -291,7 +291,7 @@ self =>
     b.result()
   }
 
-  def sameElements[B >: A](that: GenIterable[B]): Boolean = {
+  def sameElements[B >: A](that: GenIterable[B]): Boolean = (this.asInstanceOf[AnyRef] eq that.asInstanceOf[AnyRef]) || {
     that match {
       case thatVector: Vector[_] if this.isInstanceOf[Vector[_]] =>
         val thisVector = this.asInstanceOf[Vector[_]]
@@ -307,6 +307,9 @@ self =>
           }
           equal
         }
+      case thatSet: GenSet[A] if this.isInstanceOf[GenSetLike[A,_]]=>
+        val thisSet = this.asInstanceOf[GenSetLike[A,_]]
+          thisSet.size == thatSet.size && thisSet.subsetOf(thatSet)
 
       case _ =>
         val these = this.iterator

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -145,11 +145,29 @@ trait TraversableLike[+A, +Repr] extends Any
   def hasDefiniteSize = true
 
   def ++[B >: A, That](that: GenTraversableOnce[B])(implicit bf: CanBuildFrom[Repr, B, That]): That = {
-    val b = bf(repr)
-    if (that.isInstanceOf[IndexedSeqLike[_, _]]) b.sizeHint(this, that.seq.size)
-    b ++= thisCollection
-    b ++= that.seq
-    b.result
+    def defaultPlusPlus: That = {
+      val b = bf(repr)
+      if (that.isInstanceOf[IndexedSeqLike[_, _]]) b.sizeHint(this, that.seq.size)
+      b ++= thisCollection
+      b ++= that.seq
+      b.result
+    }
+
+    if (bf eq immutable.Set.canBuildFrom) {
+      this match {
+        case s: immutable.Set[A] if that.isInstanceOf[GenSet[A]] =>
+          (s union that.asInstanceOf[GenSet[A]]).asInstanceOf[That]
+        case _ => defaultPlusPlus
+      }
+    } else if (bf eq immutable.HashSet.canBuildFrom) {
+      this match {
+        case s: immutable.HashSet[A] if that.isInstanceOf[GenSet[A]] =>
+          (s union that.asInstanceOf[GenSet[A]]).asInstanceOf[That]
+        case _ => defaultPlusPlus
+      }
+
+    } else defaultPlusPlus
+
   }
 
   /** As with `++`, returns a new collection containing the elements from the left operand followed by the
@@ -185,11 +203,28 @@ trait TraversableLike[+A, +Repr] extends Any
    *                  followed by all elements of `that`.
    */
   def ++:[B >: A, That](that: TraversableOnce[B])(implicit bf: CanBuildFrom[Repr, B, That]): That = {
-    val b = bf(repr)
-    if (that.isInstanceOf[IndexedSeqLike[_, _]]) b.sizeHint(this, that.size)
-    b ++= that
-    b ++= thisCollection
-    b.result
+    def defaultPlusPlus: That = {
+      val b = bf(repr)
+      if (that.isInstanceOf[IndexedSeqLike[_, _]]) b.sizeHint(this, that.size)
+      b ++= that
+      b ++= thisCollection
+      b.result
+    }
+    if (bf eq immutable.Set.canBuildFrom) {
+      this match {
+        case s: immutable.Set[A] if that.isInstanceOf[GenSet[A]] =>
+          (s union that.asInstanceOf[GenSet[A]]).asInstanceOf[That]
+        case _ => defaultPlusPlus
+      }
+    } else if (bf eq immutable.HashSet.canBuildFrom) {
+      this match {
+        case s: immutable.HashSet[A] if that.isInstanceOf[GenSet[A]] =>
+          (s union that.asInstanceOf[GenSet[A]]).asInstanceOf[That]
+        case _ => defaultPlusPlus
+      }
+
+    } else defaultPlusPlus
+
   }
 
   /** As with `++`, returns a new collection containing the elements from the

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -18,8 +18,8 @@ import java.util
 
 import generic._
 import scala.collection.parallel.immutable.ParHashSet
-import scala.collection.GenSet
 import scala.annotation.tailrec
+import scala.collection.mutable.SetBuilder
 
 /** This class implements immutable sets using a hash trie.
  *
@@ -41,7 +41,7 @@ sealed class HashSet[A] extends AbstractSet[A]
                     with CustomParallelizable[A, ParHashSet[A]]
                     with Serializable
 {
-  import HashSet.{nullToEmpty, bufferSize, LeafHashSet}
+  import HashSet.{nullToEmpty, bufferSize}
 
   override def companion: GenericCompanion[HashSet] = HashSet
 
@@ -90,9 +90,20 @@ sealed class HashSet[A] extends AbstractSet[A]
 
   override def union(that: GenSet[A]): HashSet[A] = that match {
     case that: HashSet[A] =>
-      val buffer = new Array[HashSet[A]](bufferSize(this.size + that.size))
-      nullToEmpty(union0(that, 0, buffer, 0))
-    case _ => super.union(that)
+      if (this eq that) this
+      else nullToEmpty(union0(that, 0))
+    case _ =>
+      if (that.isEmpty) this else {
+        object acc extends Function1[A, Unit] {
+          var res = HashSet.this
+          override def apply(v1: A): Unit = res += v1
+        }
+        if (that.isInstanceOf[Set[A]])
+          that foreach acc
+        else
+          that.iterator foreach acc
+        acc.res
+      }
   }
 
   override def intersect(that: GenSet[A]): HashSet[A] = that match {
@@ -110,27 +121,13 @@ sealed class HashSet[A] extends AbstractSet[A]
   }
 
   /**
-   * Union with a leaf HashSet at a given level.
-   * @param that a leaf HashSet
-   * @param level the depth in the tree. We need this when we have to create a branch node on top of this and that
-   * @return The union of this and that at the given level. Unless level is zero, the result is not a self-contained
-   *         HashSet but needs to be stored at the correct depth
-   */
-  private[immutable] def union0(that: LeafHashSet[A], level: Int): HashSet[A] = {
-    // the default implementation is for the empty set, so we just return that
-    that
-  }
-
-  /**
    * Union with a HashSet at a given level
    * @param that a HashSet
    * @param level the depth in the tree. We need to keep track of the level to know how deep we are in the tree
-   * @param buffer a temporary buffer that is used for temporarily storing elements when creating new branch nodes
-   * @param offset0 the first offset into the buffer in which we are allowed to write
    * @return The union of this and that at the given level. Unless level is zero, the result is not a self-contained
    *         HashSet but needs to be stored at the correct depth
    */
-  private[immutable] def union0(that: HashSet[A], level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = {
+  private[immutable] def union0(that: HashSet[A], level: Int): HashSet[A] = {
     // the default implementation is for the empty set, so we just return that
     that
   }
@@ -213,6 +210,12 @@ sealed class HashSet[A] extends AbstractSet[A]
  *  @define willNotTerminateInf
  */
 object HashSet extends ImmutableSetFactory[HashSet] {
+  override def newBuilder[A]: mutable.Builder[A, HashSet[A]] = new SetBuilder[A, HashSet[A]](empty[A]) {
+    override def ++=(xs: TraversableOnce[A]): this.type = {
+      elems = elems ++ xs
+      this
+    }
+  }
 
   /** $setCanBuildFromInfo */
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, HashSet[A]] =
@@ -226,7 +229,8 @@ object HashSet extends ImmutableSetFactory[HashSet] {
   private[collection] def emptyInstance: HashSet[Any] = EmptyHashSet
 
   // utility method to create a HashTrieSet from two leaf HashSets (HashSet1 or HashSetCollision1) with non-colliding hash code)
-  private def makeHashTrieSet[A](hash0:Int, elem0:HashSet[A], hash1:Int, elem1:HashSet[A], level:Int) : HashTrieSet[A] = {
+  private def makeHashTrieSet[A](hash0:Int, elem0:HashSet[A], hash1:Int, elem1:HashSet[A], level:Int, newSize: Int) : HashTrieSet[A] = {
+    // assert elem0.size + elem1.size == newSize
     val index0 = (hash0 >>> level) & 0x1f
     val index1 = (hash1 >>> level) & 0x1f
     if(index0 != index1) {
@@ -239,24 +243,22 @@ object HashSet extends ImmutableSetFactory[HashSet] {
         elems(0) = elem1
         elems(1) = elem0
       }
-      new HashTrieSet[A](bitmap, elems, elem0.size + elem1.size)
+      new HashTrieSet[A](bitmap, elems, newSize)
     } else {
-      val elems = new Array[HashSet[A]](1)
       val bitmap = (1 << index0)
-      val child = makeHashTrieSet(hash0, elem0, hash1, elem1, level + 5)
+      val child = makeHashTrieSet(hash0, elem0, hash1, elem1, level + 5, newSize)
+      val elems = new Array[HashSet[A]](1)
       elems(0) = child
-      new HashTrieSet[A](bitmap, elems, child.size)
+      new HashTrieSet[A](bitmap, elems,  newSize)
     }
   }
 
   /**
    * Common superclass of HashSet1 and HashSetCollision1, which are the two possible leaves of the Trie
    */
-  private[HashSet] sealed abstract class LeafHashSet[A] extends HashSet[A] {
-    private[HashSet] def hash:Int
-  }
+  private[HashSet] sealed abstract class LeafHashSet[A](private[HashSet] final val hash: Int) extends HashSet[A]
 
-  class HashSet1[A](private[HashSet] val key: A, private[HashSet] val hash: Int) extends LeafHashSet[A] {
+  class HashSet1[A](private[HashSet] val key: A, hash: Int) extends LeafHashSet[A](hash) {
     override def size = 1
 
     override protected def get0(key: A, hash: Int, level: Int): Boolean =
@@ -280,43 +282,37 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     }
 
     override private[collection] def updated0(key: A, hash: Int, level: Int): HashSet[A] =
-      if (hash == this.hash && key == this.key) this
-      else {
-        if (hash != this.hash) {
-          makeHashTrieSet(this.hash, this, hash, new HashSet1(key, hash), level)
-        } else {
-          // 32-bit hash collision (rare, but not impossible)
-          new HashSetCollision1(hash, ListSet.empty + this.key + key)
-        }
+      if (hash == this.hash)
+        if (key == this.key) this
+        else
+        // 32-bit hash collision (rare, but not impossible)
+          new HashSetCollision1(hash, ListSet.empty + this.key + key, 2)
+      else
+        //size known to be 2 because this is a HashSet1, and so is the created set
+        makeHashTrieSet(this.hash, this, hash, new HashSet1(key, hash), level, 2)
+
+    override private[immutable] def union0(that: HashSet[A], level: Int) =
+      that match {
+        case that: HashSet1[A] =>
+          if (this.hash == that.hash)
+            if (this.key == that.key) this
+            else {
+              // 32-bit hash collision (rare, but not impossible)
+              new HashSetCollision1[A](hash, ListSet.empty + this.key + that.key, 2)
+            }
+          else {
+            // different hash code, so just create a branch node containing the two.
+            // size known to be 2 because this is a HashSet1, and so is the created set
+            makeHashTrieSet(this.hash, this, that.hash, that, level, 2)
+          }
+
+        case _ => //Trie, collision or empty
+          // we can exchange the arguments because union is symmetrical
+          // generally we prefer to return this where we can,
+          // but the result cannot be this for trie and collision (as they have size > 1)
+          // and is this for empty
+          that.union0(this, level)
       }
-
-    override private[immutable] def union0(that: LeafHashSet[A], level: Int): HashSet[A] = that match {
-      case that if that.hash != this.hash =>
-        // different hash code, so there is no need to investigate further.
-        // Just create a branch node containing the two.
-        makeHashTrieSet(this.hash, this, that.hash, that, level)
-      case that: HashSet1[A] =>
-        if (this.key == that.key) {
-          this
-        } else {
-          // 32-bit hash collision (rare, but not impossible)
-          new HashSetCollision1[A](hash, ListSet.empty + this.key + that.key)
-        }
-      case that: HashSetCollision1[A] =>
-        val ks1 = that.ks + key
-        // Could use eq check (faster) if ListSet was guaranteed to return itself
-        if (ks1.size == that.ks.size) {
-          that
-        } else {
-          new HashSetCollision1[A](hash, ks1)
-        }
-    }
-
-    override private[immutable] def union0(that: HashSet[A], level: Int, buffer: Array[HashSet[A]], offset0: Int) = {
-      // switch to the Leaf version of union
-      // we can exchange the arguments because union is symmetrical
-      that.union0(this, level)
-    }
 
     override private[immutable] def intersect0(that: HashSet[A], level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] =
       if (that.get0(key, hash, level)) this else null
@@ -334,9 +330,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     override def foreach[U](f: A => U): Unit = f(key)
   }
 
-  private[immutable] class HashSetCollision1[A](private[HashSet] val hash: Int, val ks: ListSet[A]) extends LeafHashSet[A] {
-
-    override def size = ks.size
+  private[immutable] class HashSetCollision1[A](hash: Int, val ks: ListSet[A],  override val size: Int) extends LeafHashSet[A](hash) {
 
     override protected def get0(key: A, hash: Int, level: Int): Boolean =
       if (hash == this.hash) ks.contains(key) else false
@@ -359,54 +353,68 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     }
 
     override private[collection] def updated0(key: A, hash: Int, level: Int): HashSet[A] =
-      if (hash == this.hash) new HashSetCollision1(hash, ks + key)
-      else makeHashTrieSet(this.hash, this, hash, new HashSet1(key, hash), level)
-
-    override private[immutable] def union0(that: LeafHashSet[A], level: Int): HashSet[A] = that match {
-      case that if that.hash != this.hash =>
-        // different hash code, so there is no need to investigate further.
-        // Just create a branch node containing the two.
-        makeHashTrieSet(this.hash, this, that.hash, that, level)
-      case that: HashSet1[A] =>
-        val ks1 = ks + that.key
-        // Could use eq check (faster) if ListSet was guaranteed to return itself
-        if (ks1.size == ks.size) {
+      if (hash == this.hash)  {
+        val ks1 = ks + key
+        // ListSet is guaranteed to return itself if key was already present
+        if (ks1 eq ks)
           this
-        } else {
+        else
           // create a new HashSetCollision with the existing hash
           // we don't have to check for size=1 because union is never going to remove elements
-          new HashSetCollision1[A](hash, ks1)
-        }
-      case that: HashSetCollision1[A] =>
-        val ks1 = this.ks ++ that.ks
-        ks1.size match {
-          case size if size == this.ks.size =>
-            // could this check be made faster by doing an eq check?
-            // I am not sure we can rely on ListSet returning itself when all elements are already in the set,
-            // so it seems unwise to rely on it.
+          new HashSetCollision1[A](hash, ks1, size + 1)
+      }
+      else {
+        // size known to be one larger then my size
+        makeHashTrieSet(this.hash, this, hash, new HashSet1(key, hash), level, size + 1)
+      }
+
+    override private[immutable] def union0(that: HashSet[A], level: Int): HashSet[A] = that match {
+      case that: HashSet1[A] =>
+        if (that.hash != this.hash)
+        // Just create a branch node containing the two.
+        // size known to be one larger then my size
+          makeHashTrieSet(this.hash, this, that.hash, that, level, size + 1)
+        else {
+          val ks1 = ks + that.key
+          // ListSet is guaranteed to return itself if key was already present
+          if (ks1 eq ks)
             this
-          case size if size == that.ks.size =>
-            // we have to check this as well, since we don't want to create a new instance if this is a subset of that
-            that
-          case _ =>
+          else
             // create a new HashSetCollision with the existing hash
             // we don't have to check for size=1 because union is never going to remove elements
-            new HashSetCollision1[A](hash, ks1)
+            new HashSetCollision1[A](hash, ks1, size + 1)
         }
-    }
-
-    override private[immutable] def union0(that: HashSet[A], level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = that match {
-      case that: LeafHashSet[A] =>
-        // switch to the simpler Tree/Leaf implementation
-        this.union0(that, level)
-      case that: HashTrieSet[A] =>
-        // switch to the simpler Tree/Leaf implementation
-        // we can swap this and that because union is symmetrical
+      case that: HashSetCollision1[A] =>
+        if (that.hash != this.hash)
+        // Just create a branch node containing the two.
+        // size unknown - just the sum of the sizes
+          makeHashTrieSet(this.hash, this, that.hash, that, level, size + that.size)
+        else if (this eq that) this
+        else {
+          val ks1 = this.ks ++ that.ks
+          // ListSet is guaranteed to return itself when all elements are already in the set,
+          if (ks1 eq ks) this
+          else {
+            val newSize = ks1.size
+            if (newSize == that.size)
+            // we have to check this as well, since we don't want to create a new instance if this is a subset of that
+            // we dont care about the ordering on the ListSet
+              that
+            else
+            // create a new HashSetCollision with the existing hash
+            // we don't have to check for size=1 because union is never going to remove elements
+              new HashSetCollision1[A](hash, ks1, newSize)
+          }
+        }
+      case _ =>
+        // we can swap this and that because union is symmetrical and that is either a
+        // HashTrieSet - in which case the result could not be this
+        // EmptyHashSet - in which case the result will be this
         that.union0(this, level)
-      case _ => this
     }
 
-    override private[immutable] def intersect0(that: HashSet[A], level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = {
+    override private[immutable] def intersect0(that: HashSet[A], level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] =
+      if (this eq that) this else {
       // filter the keys, taking advantage of the fact that we know their hash code
       val ks1 = ks.filter(that.get0(_, hash, level))
       ks1.size match {
@@ -426,13 +434,14 @@ object HashSet extends ImmutableSetFactory[HashSet] {
         case 1 =>
           // create a new HashSet1 with the hash we already know
           new HashSet1(ks1.head, hash)
-        case _ =>
+        case newSize =>
           // create a new HashSetCollision with the hash we already know and the new keys
-          new HashSetCollision1(hash, ks1)
+          new HashSetCollision1(hash, ks1, newSize)
       }
     }
 
-    override private[immutable] def diff0(that: HashSet[A], level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = {
+    override private[immutable] def diff0(that: HashSet[A], level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] =
+      if (this eq that) null else {
       val ks1 = ks.filterNot(that.get0(_, hash, level))
       ks1.size match {
         case 0 =>
@@ -446,42 +455,40 @@ object HashSet extends ImmutableSetFactory[HashSet] {
         case 1 =>
           // create a new HashSet1 with the hash we already know
           new HashSet1(ks1.head, hash)
-        case _ =>
+        case newSize =>
           // create a new HashSetCollision with the hash we already know and the new keys
-          new HashSetCollision1(hash, ks1)
+          new HashSetCollision1(hash, ks1, newSize)
       }
     }
 
     override protected def removed0(key: A, hash: Int, level: Int): HashSet[A] =
       if (hash == this.hash) {
         val ks1 = ks - key
-        ks1.size match {
-          case 0 =>
-            // the empty set
-            null
-          case 1 =>
-            // create a new HashSet1 with the hash we already know
-            new HashSet1(ks1.head, hash)
-          case size if size == ks.size =>
-            // Should only have HSC1 if size > 1
-            this
-          case _ =>
-            // create a new HashSetCollision with the hash we already know and the new keys
-            new HashSetCollision1(hash, ks1)
+        // ListSet guarantees to return itself if `key` is not present
+        if (ks1 eq ks) this
+        else if (size == 2) {
+          // our size was 2, its changed via removing one element, so it must be 1 now
+          // create a new HashSet1 with the hash we already know
+          new HashSet1(ks1.head, hash)
+        } else {
+          // we know our size, and we only removed one element, so it must be size -1 now
+          // create a new HashSetCollision with the hash we already know and the new keys
+          new HashSetCollision1(hash, ks1, size  -1)
         }
       } else this
 
     override protected def filter0(p: A => Boolean, negate: Boolean, level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = {
       val ks1 = if(negate) ks.filterNot(p) else ks.filter(p)
-      ks1.size match {
+      if (ks1 eq ks) this
+      else ks1.size match {
         case 0 =>
           null
         case 1 =>
           new HashSet1(ks1.head, hash)
-        case x if x == ks.size =>
+        case x if x == size =>
           this
-        case _ =>
-          new HashSetCollision1(hash, ks1)
+        case newSize =>
+          new HashSetCollision1(hash, ks1, newSize)
       }
     }
 
@@ -496,7 +503,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
    * @param bitmap encodes which element corresponds to which child
    * @param elems the up to 32 children of this node.
    *              the number of children must be identical to the number of 1 bits in bitmap
-   * @param size0 the total number of elements. This is stored just for performance reasons.
+   * @param size the total number of elements. This is stored just for performance reasons.
    * @tparam A      the type of the elements contained in this hash set.
    *
    * How levels work:
@@ -526,13 +533,11 @@ object HashSet extends ImmutableSetFactory[HashSet] {
    * elems: [a,b]
    * children:        ---b----------------a-----------
    */
-  class HashTrieSet[A](private val bitmap: Int, private[collection] val elems: Array[HashSet[A]], private val size0: Int)
+  class HashTrieSet[A](private val bitmap: Int, private[collection] val elems: Array[HashSet[A]], override val size: Int)
         extends HashSet[A] {
-    assert(Integer.bitCount(bitmap) == elems.length)
+    // assert(Integer.bitCount(bitmap) == elems.length)
     // assertion has to remain disabled until scala/bug#6197 is solved
     // assert(elems.length > 1 || (elems.length == 1 && elems(0).isInstanceOf[HashTrieSet[_]]))
-
-    override def size = size0
 
     override protected def get0(key: A, hash: Int, level: Int): Boolean = {
       val index = (hash >>> level) & 0x1f
@@ -556,45 +561,23 @@ object HashSet extends ImmutableSetFactory[HashSet] {
         if (sub eq subNew) this
         else {
           val elemsNew = new Array[HashSet[A]](elems.length)
-          Array.copy(elems, 0, elemsNew, 0, elems.length)
+          System.arraycopy(elems, 0, elemsNew, 0, elems.length)
           elemsNew(offset) = subNew
-          new HashTrieSet(bitmap, elemsNew, size + (subNew.size - sub.size))
+          // assert (subNew.size - sub.size == 1)
+          new HashTrieSet(bitmap, elemsNew, size + 1)
         }
       } else {
         val elemsNew = new Array[HashSet[A]](elems.length + 1)
-        Array.copy(elems, 0, elemsNew, 0, offset)
+        System.arraycopy(elems, 0, elemsNew, 0, offset)
         elemsNew(offset) = new HashSet1(key, hash)
-        Array.copy(elems, offset, elemsNew, offset + 1, elems.length - offset)
+        System.arraycopy(elems, offset, elemsNew, offset + 1, elems.length - offset)
         val bitmapNew = bitmap | mask
         new HashTrieSet(bitmapNew, elemsNew, size + 1)
       }
     }
 
-    override private[immutable] def union0(that: LeafHashSet[A], level: Int): HashSet[A] = {
-      val index = (that.hash >>> level) & 0x1f
-      val mask = (1 << index)
-      val offset = Integer.bitCount(bitmap & (mask - 1))
-      if ((bitmap & mask) != 0) {
-        val sub = elems(offset)
-        val sub1 = sub.union0(that, level + 5)
-        if (sub eq sub1) this
-        else {
-          val elems1 = new Array[HashSet[A]](elems.length)
-          Array.copy(elems, 0, elems1, 0, elems.length)
-          elems1(offset) = sub1
-          new HashTrieSet(bitmap, elems1, size + (sub1.size - sub.size))
-        }
-      } else {
-        val elems1 = new Array[HashSet[A]](elems.length + 1)
-        Array.copy(elems, 0, elems1, 0, offset)
-        elems1(offset) = that
-        Array.copy(elems, offset, elems1, offset + 1, elems.length - offset)
-        val bitmap1 = bitmap | mask
-        new HashTrieSet(bitmap1, elems1, size + that.size)
-      }
-    }
 
-    override private[immutable] def union0(that: HashSet[A], level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = that match {
+    override private[immutable] def union0(that: HashSet[A], level: Int) = that match {
       case that if that eq this =>
         // shortcut for when that is this
         // this happens often for nodes deeper in the tree, especially when that and this share a common "heritage"
@@ -603,74 +586,195 @@ object HashSet extends ImmutableSetFactory[HashSet] {
         // at these nodes.
         this
       case that: LeafHashSet[A] =>
-        // when that is a leaf, we can switch to the simpler Tree/Leaf implementation
-        this.union0(that, level)
+        val index = (that.hash >>> level) & 0x1f
+        val mask = (1 << index)
+        val offset = Integer.bitCount(bitmap & (mask - 1))
+        if ((bitmap & mask) != 0) {
+          val sub = elems(offset)
+          if (sub eq that) this
+          else {
+            val sub1 = sub.union0(that, level + 5)
+            if (sub eq sub1) this
+            else {
+              val elems1 = elems.clone()
+              // its just a little faster than new Array[HashSet[A]](elems.length); System.arraycopy(elems, 0, elems1, 0, elems.length)
+              elems1(offset) = sub1
+              new HashTrieSet(bitmap, elems1, size + (sub1.size - sub.size))
+            }
+          }
+        } else {
+          val elems1 = new Array[HashSet[A]](elems.length + 1)
+          System.arraycopy(elems, 0, elems1, 0, offset)
+          elems1(offset) = that
+          System.arraycopy(elems, offset, elems1, offset + 1, elems.length - offset)
+          val bitmap1 = bitmap | mask
+          new HashTrieSet(bitmap1, elems1, size + that.size)
+        }
       case that: HashTrieSet[A] =>
-        val a = this.elems
-        var abm = this.bitmap
-        var ai = 0
+        def addMaybeSubset(larger: HashTrieSet[A], smaller: HashTrieSet[A]): HashTrieSet[A] = {
+          var resultElems: Array[HashSet[A]] = null
+          var ai = 0
+          var bi = 0
+          var abm = larger.bitmap
+          var bbm = smaller.bitmap
+          val a = larger.elems
+          val b = smaller.elems
 
-        val b = that.elems
-        var bbm = that.bitmap
-        var bi = 0
+          //larger has all the bits or smaller, and if they have the same bits, is at least the bigger
+          //so we try to merge `smaller`into `larger`and hope that `larger is a superset
 
-        // fetch a new temporary array that is guaranteed to be big enough (32 elements)
-        var offset = offset0
-        var rs = 0
+          //the additional size in the results, so the eventual size of the result is larger.size + additionalSize
+          var additionalSize = 0
 
-        // loop as long as there are bits left in either abm or bbm
-        while ((abm | bbm) != 0) {
-          // lowest remaining bit in abm
-          val alsb = abm ^ (abm & (abm - 1))
-          // lowest remaining bit in bbm
-          val blsb = bbm ^ (bbm & (bbm - 1))
-          if (alsb == blsb) {
-            val sub1 = a(ai).union0(b(bi), level + 5, buffer, offset)
-            rs += sub1.size
-            buffer(offset) = sub1
-            offset += 1
-            // clear lowest remaining one bit in abm and increase the a index
-            abm &= ~alsb
+          // could be lsb = Integer.lowestOneBit(abm)
+          //but is this faster!!
+          // keep fastest in step with adjustments in the loop
+          //we know abm contains all of the bits in bbm, we only loop through bbm
+          //bsb is the next lowest bit in smaller
+          var bsb = bbm ^ (bbm & (bbm - 1))
+          while (bsb != 0) {
+            val skippedBitsInA = abm & (bsb - 1)
+            ai += Integer.bitCount(skippedBitsInA)
+            abm ^= skippedBitsInA
+            val aai = a(ai)
+            val bbi = b(bi)
+
+            val result = if (aai eq bbi) aai
+            else aai.union0(bbi, level + 5)
+            if (result ne aai) {
+              if (resultElems eq null)
+                resultElems = a.clone()
+              additionalSize += result.size - aai.size
+              //assert (result.size > aai.size)
+              resultElems(ai) = result
+            }
+            abm ^= bsb
+            bbm ^= bsb
+            bsb = bbm ^ (bbm & (bbm - 1))
+
             ai += 1
-            // clear lowest remaining one bit in bbm and increase the b index
-            bbm &= ~blsb
-            bi += 1
-          } else if (unsignedCompare(alsb - 1, blsb - 1)) {
-            // alsb is smaller than blsb, or alsb is set and blsb is 0
-            // in any case, alsb is guaranteed to be set here!
-            val sub1 = a(ai)
-            rs += sub1.size
-            buffer(offset) = sub1
-            offset += 1
-            // clear lowest remaining one bit in abm and increase the a index
-            abm &= ~alsb
-            ai += 1
-          } else {
-            // blsb is smaller than alsb, or blsb is set and alsb is 0
-            // in any case, blsb is guaranteed to be set here!
-            val sub1 = b(bi)
-            rs += sub1.size
-            buffer(offset) = sub1
-            offset += 1
-            // clear lowest remaining one bit in bbm and increase the b index
-            bbm &= ~blsb
             bi += 1
           }
-        }
-        if (rs == this.size) {
-          // if the result would be identical to this, we might as well return this
-          this
-        } else if (rs == that.size) {
-          // if the result would be identical to that, we might as well return that
-          that
-        } else {
           // we don't have to check whether the result is a leaf, since union will only make the set larger
           // and this is not a leaf to begin with.
-          val length = offset - offset0
-          val elems = new Array[HashSet[A]](length)
-          System.arraycopy(buffer, offset0, elems, 0, length)
-          new HashTrieSet(this.bitmap | that.bitmap, elems, rs)
+          if (resultElems eq null) larger // happy days - no change
+          else new HashTrieSet(larger.bitmap, resultElems, larger.size + additionalSize)
         }
+
+        def addDistinct(that: HashTrieSet[A]): HashTrieSet[A] = {
+
+          // the sets are distinct, so its a bit simpler to combine
+          // and we can avoid all of the quite expensive size calls on the children
+
+          var ai = 0
+          var bi = 0
+          var offset = 0
+          val abm = this.bitmap
+          val bbm = that.bitmap
+          val a = this.elems
+          val b = that.elems
+          var allBits = abm | bbm
+
+          val resultElems = new Array[HashSet[A]](Integer.bitCount(allBits))
+          // could be lsb = Integer.lowestOneBit(abm)
+          //but is this faster!!
+          // keep fastest in step with adjustments in the loop
+          // lowest remaining bit
+          var lsb = allBits ^ (allBits & (allBits - 1))
+
+          while (lsb != 0) {
+            if ((lsb & abm) != 0) {
+              resultElems(offset) = a(ai)
+              ai += 1
+            } else {
+              resultElems(offset) = b(bi)
+              bi += 1
+            }
+            offset += 1
+            allBits ^= lsb
+            lsb = allBits ^ (allBits & (allBits - 1))
+          }
+          // we don't have to check whether the result is a leaf, since union will only make the set larger
+          // and this is not a leaf to begin with.
+          new HashTrieSet(abm | bbm, resultElems, this.size + that.size)
+        }
+
+        def addCommon(that: HashTrieSet[A]): HashTrieSet[A] = {
+          var ai = 0
+          var bi = 0
+          val abm = this.bitmap
+          val bbm = that.bitmap
+          val a = this.elems
+          val b = that.elems
+          var allBits = abm | bbm
+          val resultElems = new Array[HashSet[A]](Integer.bitCount(allBits))
+
+          //output index
+          var offset = 0
+
+          // the size of the results so far
+          var rs = 0
+
+          // could be alsb = Integer.lowestOneBit(abm)
+          //but is this faster!!
+          // keep fastest in step with adjustments in the loop
+          // lowest remaining bit
+          var lsb = allBits ^ (allBits & (allBits - 1))
+
+          var result: HashSet[A] = null
+          // loop as long as there are bits left in either abm or bbm
+          while (lsb != 0) {
+            if ((lsb & abm) != 0) {
+              if ((lsb & bbm) != 0) {
+                // lsb is in a and b, so combine
+                val aai = a(ai)
+                val bbi = b(bi)
+
+                result = if (aai eq bbi) aai
+                else aai.union0(bbi, level + 5)
+                ai += 1
+                bi += 1
+              } else {
+                // lsb is in a
+                result = a(ai)
+                ai += 1
+              }
+            } else {
+              // lsb is in b
+              result = b(bi)
+              bi += 1
+            }
+            // update lsb
+            allBits ^= lsb
+            lsb = allBits ^ (allBits & (allBits - 1))
+
+            resultElems(offset) = result
+            rs += result.size
+            offset += 1
+          }
+          // we don't have to check whether the result is a leaf, since union will only make the set larger
+          // and this is not a leaf to begin with.
+          new HashTrieSet(this.bitmap | that.bitmap, resultElems, rs)
+
+        }
+
+        // if we have a subset/superset relationship, then we can merge and not allocate if thats a real subset
+        // we check on that relationship based on the bitssets, and if he bitsets are the same than we look at the size
+        // to work out the subset vs the superset
+        // a superset here is  a trie that has all the bits of the other and is possible to be a superset
+        //
+        // if the bits are distinct we can skip some processing so we have a path for that
+        // otherwise the general case
+
+        val abm = this.bitmap
+        val bbm = that.bitmap
+        val allBits = abm | bbm
+
+        if (allBits == abm && (allBits != bbm || this.size >= that.size)) addMaybeSubset(this, that)
+        else if (allBits == bbm) addMaybeSubset(that, this)
+        else if ((abm & bbm) == 0) addDistinct(that)
+        else addCommon(that)
+
       case _ => this
     }
 
@@ -743,11 +847,11 @@ object HashSet extends ImmutableSetFactory[HashSet] {
         if (rbm == 0) {
           // if the result bitmap is empty, the result is the empty set
           null
-        } else if (rs == size0) {
+        } else if (rs == size) {
           // if the result has the same number of elements as this, it must be identical to this,
           // so we might as well return this
           this
-        } else if (rs == that.size0) {
+        } else if (rs == that.size) {
           // if the result has the same number of elements as that, it must be identical to that,
           // so we might as well return that
           that
@@ -824,7 +928,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
         }
         if (rbm == 0) {
           null
-        } else if (rs == this.size0) {
+        } else if (rs == this.size) {
           // if the result has the same number of elements as this, it must be identical to this,
           // so we might as well return this
           this
@@ -859,25 +963,28 @@ object HashSet extends ImmutableSetFactory[HashSet] {
         else if (subNew eq null) {
           val bitmapNew = bitmap ^ mask
           if (bitmapNew != 0) {
-            val elemsNew = new Array[HashSet[A]](elems.length - 1)
-            Array.copy(elems, 0, elemsNew, 0, offset)
-            Array.copy(elems, offset + 1, elemsNew, offset, elems.length - offset - 1)
-            val sizeNew = size - sub.size
-            // if we have only one child, which is not a HashTrieSet but a self-contained set like
-            // HashSet1 or HashSetCollision1, return the child instead
-            if (elemsNew.length == 1 && !elemsNew(0).isInstanceOf[HashTrieSet[_]])
-              elemsNew(0)
-            else
+            if (elems.length == 2 && !elems(offset ^ 1).isInstanceOf[HashTrieSet[_]] ) {
+              // if we have only one child, which is not a HashTrieSet but a self-contained set like
+              // HashSet1 or HashSetCollision1, return the child instead
+              elems(offset ^ 1)
+            } else {
+              val elemsNew = new Array[HashSet[A]](elems.length - 1)
+              System.arraycopy(elems, 0, elemsNew, 0, offset)
+              System.arraycopy(elems, offset + 1, elemsNew, offset, elems.length - offset - 1)
+              //assert (sub.size == 1)
+              val sizeNew = size - 1
               new HashTrieSet(bitmapNew, elemsNew, sizeNew)
+            }
           } else
             null
         } else if(elems.length == 1 && !subNew.isInstanceOf[HashTrieSet[_]]) {
           subNew
         } else {
           val elemsNew = new Array[HashSet[A]](elems.length)
-          Array.copy(elems, 0, elemsNew, 0, elems.length)
+          System.arraycopy(elems, 0, elemsNew, 0, elems.length)
           elemsNew(offset) = subNew
-          val sizeNew = size + (subNew.size - sub.size)
+          //assert (subNew.size - sub.size == -1)
+          val sizeNew = size -1
           new HashTrieSet(bitmap, elemsNew, sizeNew)
         }
       } else {
@@ -888,7 +995,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     override def equals(other: Any): Boolean = {
       other match {
         case that: HashTrieSet[A] =>
-          (this eq that) || (this.bitmap == that.bitmap && this.size0 == that.size0 &&
+          (this eq that) || (this.bitmap == that.bitmap && this.size == that.size &&
             util.Arrays.equals(this.elems.asInstanceOf[Array[AnyRef]], that.elems.asInstanceOf[Array[AnyRef]]))
         case _ : HashSet[_] => false
         case _ => super.equals(other)
@@ -896,7 +1003,9 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     }
 
     override protected def subsetOf0(that: HashSet[A], level: Int): Boolean = (that eq this) || (that match {
-      case that: HashTrieSet[A] if this.size0 <= that.size0 =>
+      case that: HashTrieSet[A]
+        if (this.bitmap & ~that.bitmap) == 0
+          && this.size <= that.size =>
         // create local mutable copies of members
         var abm = this.bitmap
         val a = this.elems
@@ -962,7 +1071,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
       if (offset == offset0) {
         // empty
         null
-      } else if (rs == size0) {
+      } else if (rs == size) {
         // unchanged
         this
       } else if (offset == offset0 + 1 && !buffer(offset0).isInstanceOf[HashTrieSet[A]]) {
@@ -1067,4 +1176,3 @@ object HashSet extends ImmutableSetFactory[HashSet] {
   }
 
 }
-

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetBulkBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetBulkBenchmark.scala
@@ -1,0 +1,260 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+
+class HashSetBulkUnsharedBenchmark extends HashSetBaseBulkBenchmark {
+
+  @OperationsPerInvocation(30)
+  @Benchmark def opDataWithEmpty(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 30) {
+      operation(bh, baseData(i), HashSet.empty)
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(30)
+  @Benchmark def opEmptyWithData(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 30) {
+      operation(bh, HashSet.empty, baseData(i))
+      i += 1
+    }
+  }
+  @OperationsPerInvocation(30)
+  @Benchmark def opDataWithSetEmpty(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 30) {
+      operation(bh, baseData(i), Set.empty)
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(30)
+  @Benchmark def opSetEmptyWithData(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 30) {
+      operation(bh, Set.empty, baseData(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(29)
+  @Benchmark def opWithDistinct(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 29) {
+      operation(bh, baseData(i), baseData(i+1))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(20)
+  @Benchmark def opDataWithContainedUnshared(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 20) {
+      operation(bh, overlap(i), baseData(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(20)
+  @Benchmark def opDataWithContainedShared(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 20) {
+      operation(bh, shared(i), baseData(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(20)
+  @Benchmark def opContainedUnsharedWithData(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 20) {
+      operation(bh,  baseData(i), overlap(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(20)
+  @Benchmark def opContainedSharedWithData(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 20) {
+      operation(bh,  baseData(i), shared(i))
+      i += 1
+    }
+  }
+}
+class HashSetBulkSharedBenchmark extends HashSetBaseBulkBenchmark {
+  @Param(Array("0", "20", "40", "60", "80", "90", "100"))
+  var sharing: Int = _
+
+  @OperationsPerInvocation(10)
+  @Benchmark def opWithOverlapUnshared(bh: Blackhole): Unit = {
+    var i = 10;
+    while (i < 20) {
+      operation(bh, overlap(i - (10 - sharing / 10)), overlap2(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(10)
+  @Benchmark def opWithOverlapShared(bh: Blackhole): Unit = {
+    var i = 10;
+    while (i < 20) {
+      operation(bh, shared(i - (10 - sharing / 10)), shared(i))
+      i += 1
+    }
+  }
+}
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+abstract class HashSetBaseBulkBenchmark {
+  @Param(Array(
+    "10",
+    "100",
+    "1000",
+    "10000"))
+  var size: Int = _
+  @Param(Array("true", "false"))
+  var colliding: Boolean = _
+
+  @Param(Array("+", "-", "++", "--", "union", "diff", "intersect", "subsetOf", "sameElements"))
+  var op: String = _
+  var operation: (Blackhole, Set[HashSetBenchmarkData], Set[HashSetBenchmarkData]) => Any = _
+
+  // base data of specified size. All values are distinct
+  var baseData: Array[HashSet[HashSetBenchmarkData]] = _
+  // overlap(i) contains baseData(i) .. baseData(i+9) but with no structural sharing
+  var overlap: Array[HashSet[HashSetBenchmarkData]] = _
+  // overlap2(i) contains the same data as overlap(i) but with no structural sharing
+  var overlap2: Array[HashSet[HashSetBenchmarkData]] = _
+  // shared(i) contains baseData(i) .. baseData(i+9) but with structural sharing, both to the base data and preceding/subsequent entries
+  var shared: Array[HashSet[HashSetBenchmarkData]] = _
+
+
+  @Setup(Level.Trial) def initKeys(): Unit = {
+    operation = op match {
+      case "+" => operationPlus
+      case "-" => operationMinus
+      case "++" => operationPlusPlus
+      case "--" => operationMinusMinus
+      case "union" => operationUnion
+      case "diff" => operationDiff
+      case "intersect" => operationIntersect
+      case "subsetOf" => operationSubsetOf
+      case "sameElements" => operationSameElements
+    }
+
+    def generate(prefix: String, size: Int) = {
+      Array.tabulate(30)(i => (0 until size).map { k =>
+        val data = s"key $i $k"
+        val hash = if (colliding) (k >> 2) * i else data.hashCode
+        HashSetBenchmarkData(hash, data)
+      }(scala.collection.breakOut): HashSet[HashSetBenchmarkData])
+    }
+
+    baseData = generate("", size)
+
+    overlap = new Array[HashSet[HashSetBenchmarkData]](baseData.length - 10)
+    overlap2 = new Array[HashSet[HashSetBenchmarkData]](baseData.length - 10)
+    shared = new Array[HashSet[HashSetBenchmarkData]](baseData.length - 10)
+    for (i <- 0 until baseData.length - 10) {
+      var s1: HashSet[HashSetBenchmarkData] = HashSet.empty[HashSetBenchmarkData]
+      var s2: HashSet[HashSetBenchmarkData] = HashSet.empty[HashSetBenchmarkData]
+      for (j <- i until i + 10) {
+        baseData(j) foreach {
+          x =>
+            s1 += x
+            s2 += x
+        }
+      }
+      overlap(i) = s1
+      overlap2(i) = s2
+    }
+    def base (i:Int) = {
+      baseData(if (i < 0) baseData.length+i else i)
+    }
+    shared(0) = (-10 to (0, 1)).foldLeft (base(-10)) {case (a, b) => a ++ base(b)}
+    for (i <- 1 until shared.length) {
+      shared(i) = shared(i - 1) -- base(i - 10) ++ base(i)
+    }
+
+  }
+
+  def operationPlus(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    var res = set1
+    set2 foreach {
+      res += _
+    }
+    bh.consume(res)
+  }
+  def operationMinus(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    var res = set1
+    set2 foreach {
+      res -= _
+    }
+    bh.consume(res)
+  }
+  def operationPlusPlus(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    bh.consume(set1 ++ set2)
+  }
+  def operationMinusMinus(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    bh.consume(set1 -- set2)
+  }
+  def operationUnion(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    bh.consume(set1.union(set2))
+  }
+  def operationDiff(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    bh.consume(set1.diff(set2))
+  }
+  def operationIntersect(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    bh.consume(set1.intersect(set2))
+  }
+  def operationSubsetOf(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    bh.consume(set1.subsetOf(set2))
+  }
+  def operationSameElements(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    bh.consume(set1.sameElements(set2))
+  }
+}
+object HashSetBenchmarkData {
+  def apply(hashCode: Int, data: String) = new HashSetBenchmarkData(hashCode, data.intern())
+}
+class HashSetBenchmarkData private (override val hashCode: Int, val data: String) {
+  override def equals(obj: Any): Boolean = obj match {
+    case that: HashSetBenchmarkData => this.hashCode == that.hashCode && (this.data eq that.data)
+    case _ => false
+  }
+
+  override def toString: String = s"$hashCode-$data"
+}
+//for testing, debugging, optimising etc
+object Test extends App {
+
+  val bh = new Blackhole("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.")
+  val test = new HashSetBulkUnsharedBenchmark
+
+  test.size = 10000
+  test.op = "++"
+  test.colliding = true
+  test.initKeys()
+  while (true) {
+    var j = 0
+    val start = System.nanoTime()
+    while (j < 100) {
+      test.opDataWithContainedUnshared(bh)
+      j += 1
+    }
+    val end = System.nanoTime()
+    println((end - start) / 1000000)
+  }
+}

--- a/test/junit/scala/collection/immutable/HashSetTest.scala
+++ b/test/junit/scala/collection/immutable/HashSetTest.scala
@@ -1,6 +1,6 @@
 package scala.collection.immutable
 
-import org.junit.Assert.assertTrue
+import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -16,7 +16,7 @@ class HashSetTest extends AllocationTest {
   }
 
   @Test
-  def nonAllocatingIdentical(): Unit = {
+  def nonAllocatingEqualsIdentical(): Unit = {
     val base = generate()
     assertTrue(nonAllocating {
       base == base
@@ -24,7 +24,7 @@ class HashSetTest extends AllocationTest {
   }
 
   @Test
-  def nonAllocatingNotShared(): Unit = {
+  def nonAllocatingEqualsNotShared(): Unit = {
     val base = generate()
     val notShared = generate()
 
@@ -37,7 +37,7 @@ class HashSetTest extends AllocationTest {
   }
 
   @Test
-  def nonAllocatingShared(): Unit = {
+  def nonAllocatingEqualsShared(): Unit = {
     val base = generate()
     val shared = (base - base.head) + base.head
 
@@ -47,6 +47,174 @@ class HashSetTest extends AllocationTest {
     assertTrue(nonAllocating {
       shared == base
     })
+  }
+
+  @Test
+  def nonAllocatingUnionIdentical(): Unit = {
+    val base = generate()
+    assertSame(base, nonAllocating {
+      base union base
+    })
+  }
+
+  @Test
+  def nonAllocatingPlusPlusIdentical(): Unit = {
+    val base = generate()
+    assertSame(base, nonAllocating {
+      base ++ base
+    })
+  }
+  @Test
+  def nonAllocatingUnionEqual(): Unit = {
+    val base1 = generate()
+    val base2 = generate()
+    assertSame(base1, nonAllocating {
+      base1 union base2
+    })
+  }
+
+  @Test
+  def nonAllocatingPlusPlusEqual(): Unit = {
+    val base1 = generate()
+    val base2 = generate()
+    assertSame(base1, nonAllocating {
+      base1 ++ base2
+    })
+  }
+  @Test
+  def nonAllocatingUnionEmpty(): Unit = {
+    val base1 = generate()
+    val base2 = HashSet.empty[String]
+    assertSame(base1, nonAllocating {
+      base1 union base2
+    })
+  }
+
+  @Test
+  def nonAllocatingPlusPlusEmpty(): Unit = {
+    val base1 = generate()
+    val base2 = HashSet.empty[String]
+    assertSame(base1, nonAllocating {
+      base1 ++ base2
+    })
+  }
+  @Test
+  def nonAllocatingUnionEmptySet(): Unit = {
+    val base1 = generate()
+    val base2 = Set.empty[String]
+    assertSame(base1, nonAllocating {
+      base1 union base2
+    })
+  }
+
+  @Test
+  def nonAllocatingPlusPlusEmptySet(): Unit = {
+    val base1 = generate()
+    val base2 = Set.empty[String]
+    assertSame(base1, nonAllocating {
+      base1 ++ base2
+    })
+  }
+  @Test
+  def nonAllocatingUnionSubsetShared(): Unit = {
+    val base1 = generate()
+    val base2 = base1 - base1.head
+    assertSame(base1, nonAllocating {
+      base1 union base2
+    })
+  }
+
+  @Test
+  def nonAllocatingPlusPlusSubsetShared(): Unit = {
+    val base1 = generate()
+    val base2 = base1 - base1.head
+    assertSame(base1, nonAllocating {
+      base1 ++ base2
+    })
+  }
+  @Test
+  def nonAllocatingUnionSubsetUnshared(): Unit = {
+    val base1 = generate()
+    val base2 = generate() - base1.head
+    assertSame(base1, nonAllocating {
+      base1 union base2
+    })
+  }
+
+  @Test
+  def nonAllocatingPlusPlusSubsetUnshared(): Unit = {
+    val base1 = generate()
+    val base2 = generate() - base1.head
+    assertSame(base1, nonAllocating {
+      base1 ++ base2
+    })
+  }
+  @Test
+  def nonAllocatingUnionSupersetShared(): Unit = {
+    val base1 = generate()
+    val base2 = base1 + "Mike"
+    assertSame(base2, nonAllocating {
+      base1 union base2
+    })
+  }
+
+  @Test
+  def nonAllocatingPlusPlusSupersetShared(): Unit = {
+    val base1 = generate()
+    val base2 = base1 + "Mike"
+    assertSame(base2, nonAllocating {
+      base1 ++ base2
+    })
+  }
+  @Test
+  def nonAllocatingUnionSupersetUnshared(): Unit = {
+    val base1 = generate()
+    val base2 = generate() + "Mike"
+    assertSame(base2, nonAllocating {
+      base1 union base2
+    })
+  }
+
+  @Test
+  def nonAllocatingPlusPlusSupersetUnshared(): Unit = {
+    val base1 = generate()
+    val base2 = generate() + "Mike"
+    assertSame(base2, nonAllocating {
+      base1 ++ base2
+    })
+  }
+
+
+
+  def generateWithCollisions(start:Int, end:Int): HashSet[Colliding] = {
+    (start to end).map { i => new Colliding(i/10, s"key $i") }(scala.collection.breakOut)
+  }
+
+  class Colliding(override val hashCode: Int, val other:String) {
+    override def equals(obj: Any): Boolean = obj match {
+      case that:Colliding => this.hashCode == that.hashCode && this.other == that.other
+      case _ => false
+    }
+
+    override def toString: String = s"$hashCode-$other"
+  }
+  @Test def collidingAdd: Unit = {
+    val initial = generateWithCollisions(1, 1000)
+    assertEquals(1000, initial.size)
+    assertEquals(1000, initial.toList.size)
+
+    val more = generateWithCollisions(1, 1000)
+    assertSame(initial, nonAllocating {
+      initial ++ more
+    })
+    assertSame(more, nonAllocating {
+      more ++ initial
+    })
+
+    val first = initial.head
+    assertSame(initial, initial + first)
+    assertSame(initial, initial + new Colliding(first.hashCode, first.other))
+
   }
 
 }

--- a/test/junit/scala/collection/immutable/SetTest.scala
+++ b/test/junit/scala/collection/immutable/SetTest.scala
@@ -5,8 +5,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.tools.testing.AllocationTest
+
 @RunWith(classOf[JUnit4])
-class SetTest {
+class SetTest extends AllocationTest {
   @Test
   def test_SI8346_toSet_soundness(): Unit = {
     val any2stringadd = "Disabled string conversions so as not to get confused!"
@@ -78,4 +80,50 @@ class SetTest {
     val mapseta = any(mapset)
     assert(mapset eq mapseta)
   }
+
+  def generate(n:Int): Set[String] = {
+    (0 until n).map { i => s"key $i" }(scala.collection.breakOut)
+  }
+  def nonAllocatingEmptyPlusPlusN(n:Int): Unit = {
+    val base = generate(n)
+    assertSame(base, nonAllocating {
+      Set.empty[String] ++ base
+    })
+  }
+  def nonAllocatingEmptyUnionN(n:Int): Unit = {
+    val base = generate(n)
+    assertSame(base, nonAllocating {
+      Set.empty[String] union base
+    })
+  }
+  @Test
+  def testGenerate(): Unit = {
+    assertSame(Set.empty, generate(0))
+    assertEquals(Set("key 0"), generate(1))
+  }
+  @Test
+  def nonAllocatingEmptyUnionEmpty(): Unit = {
+    nonAllocatingEmptyUnionN(0)
+  }
+  @Test
+  def nonAllocatingEmptyPlusPlusEmpty(): Unit = {
+    nonAllocatingEmptyPlusPlusN(0)
+  }
+  @Test
+  def nonAllocatingEmptyUnionSmall(): Unit = {
+    (1 to 4) foreach nonAllocatingEmptyUnionN
+  }
+  @Test
+  def nonAllocatingEmptyPlusPlusSmall(): Unit = {
+    (1 to 4) foreach nonAllocatingEmptyPlusPlusN
+  }
+  @Test
+  def nonAllocatingEmptyUnionLarge(): Unit = {
+    nonAllocatingEmptyUnionN (100)
+  }
+  @Test
+  def nonAllocatingEmptyPlusPlusLarge(): Unit = {
+    nonAllocatingEmptyPlusPlusN(100)
+  }
+
 }


### PR DESCRIPTION
for 2.12 only - this will not merge directly into 2.13. A separate PR will be needed if any of these changes need to be ported to 2.13

faster operations (mostly union and ++) for HashSet
EmptySet and SetBuilder adjusted to take advantage of ++ optimisation for simple and common cases

eliminate unneeded allocations for HashSets where the result is already built for -
   subSet ++ superSet
   subSet union superSet
   superSet union subSet
   superSet ++ subSet

make a fast path when there is structural sharing in the HashSet
for union, guarantee internal operations will only return a new HashSet if one of the existing HashSet parameters or internal values cant be used

use System.arraycopy rather than Array.copy as it avoid JVM nulling the array

add missing `eq` fast path to intersect0 and diff0

minor improvements to + to reduce allocations

reduce calls to size which is expensive, especially when we know the size beforehand

