### PR TITLE
Lint confusing by-name conversion of block result

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -114,6 +114,7 @@ trait Warnings {
     val EtaZero                = LintWarning("eta-zero",                  "Usage `f` of parameterless `def f()` resulted in eta-expansion, not empty application `f()`.")
     val EtaSam                 = LintWarning("eta-sam",                   "The Java-defined target interface for eta-expansion was not annotated @FunctionalInterface.")
     val Deprecation            = LintWarning("deprecation",               "Enable -deprecation and also check @deprecated annotations.")
+    val ByNameImplicit         = LintWarning("byname-implicit",           "Block adapted by implicit with by-name parameter.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
   }
@@ -142,6 +143,7 @@ trait Warnings {
   def warnEtaZero                = lint contains EtaZero
   def warnEtaSam                 = lint contains EtaSam
   def lintDeprecation            = lint contains Deprecation
+  def warnByNameImplicit         = lint contains ByNameImplicit
 
   // The Xlint warning group.
   val lint = MultiChoiceSetting(

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2547,7 +2547,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           def checkPure(t: Tree, supple: Boolean): Unit =
             if (!explicitlyUnit(t) && treeInfo.isPureExprForWarningPurposes(t)) {
               val msg = "a pure expression does nothing in statement position"
-              val parens = if (statsTyped.length + count > 1) "multiline expressions might require enclosing parentheses" else ""
+              val parens = if (statsTyped.lengthCompare(1 - count) > 0) "multiline expressions might require enclosing parentheses" else ""
               val discard = if (adapted) "; a value can be silently discarded when Unit is expected" else ""
               val text =
                 if (supple) s"${parens}${discard}"

--- a/test/files/neg/byname-implicit.check
+++ b/test/files/neg/byname-implicit.check
@@ -1,0 +1,12 @@
+byname-implicit.scala:14: warning: Block result was adapted via implicit conversion (method ints are strs) taking a by-name parameter
+      42                      // warn
+      ^
+byname-implicit.scala:25: warning: Block result was adapted via implicit conversion (method bools are strs) taking a by-name parameter
+      true                    // warn
+      ^
+byname-implicit.scala:68: warning: Block result was adapted via implicit conversion (method fromBooleanCheck) taking a by-name parameter
+    false                  // warn
+    ^
+error: No warnings can be incurred under -Werror.
+3 warnings
+1 error

--- a/test/files/neg/byname-implicit.check
+++ b/test/files/neg/byname-implicit.check
@@ -7,6 +7,9 @@ byname-implicit.scala:25: warning: Block result was adapted via implicit convers
 byname-implicit.scala:68: warning: Block result was adapted via implicit conversion (method fromBooleanCheck) taking a by-name parameter
     false                  // warn
     ^
+byname-implicit.scala:84: warning: Implicits applied to block expressions after overload resolution may have unexpected semantics
+  Foo.bar { println("barring"); 0 }  // warn
+          ^
 error: No warnings can be incurred under -Werror.
-3 warnings
+4 warnings
 1 error

--- a/test/files/neg/byname-implicit.scala
+++ b/test/files/neg/byname-implicit.scala
@@ -71,3 +71,16 @@ object Test extends App {
   assert(res() == "nope")
   assert(count == 2)
 }
+
+// t9386
+class Foo
+object Foo {
+  implicit def int2Foo(a: => Int): Foo = new Foo //Never evaluate the argument
+  def bar(foo: Foo) = ()
+  def bar(foo: Boolean) = () //unrelated overload
+}
+
+object FooTest extends App {
+  Foo.bar { println("barring"); 0 }  // warn
+}
+

--- a/test/files/neg/byname-implicit.scala
+++ b/test/files/neg/byname-implicit.scala
@@ -1,0 +1,73 @@
+// scalac: -Werror -Xlint:byname-implicit
+
+import language._
+
+class C {
+  implicit def `ints are strs`(n: => Int): String = n.toString
+  implicit def `bools are strs`[A](b: => A)(implicit ev: A => Boolean): String = if (b) "yup" else "nah"
+
+  def show(s: String) = println(s"[$s]")
+
+  def f(): Unit =
+    show {
+      println("see me")
+      42                      // warn
+    }
+
+  def g(): Unit =
+    show {
+      42                      // no warn
+    }
+
+  def truly(): Unit =
+    show {
+      println("see me")
+      true                    // warn
+    }
+
+  def falsely(): Unit =
+    show {
+      false                   // no warn
+    }
+}
+
+// the workaround for https://github.com/erikvanoosten/metrics-scala/issues/42
+// This removes callsite verbosity with extra wrapping in a by-name arg, but the implicit still warns,
+// because the call to healthCheck still requires the implicit conversion to Magnet.
+// Here, the by-name should be removed from the implicit because by-name semantics is already provided by healthCheck.
+
+package object health {
+  type HealthCheck = () => String
+
+  def healthCheck(name: String, unhealthyMessage: String = "Health check failed")(checker: => HealthCheckMagnet): HealthCheck = {
+    () => checker(unhealthyMessage)()
+  }
+}
+
+package health {
+
+  /*sealed*/ trait HealthCheckMagnet {
+    def apply(unhealthyMessage: String): HealthCheck
+  }
+
+  object HealthCheckMagnet {
+
+    /** Magnet for checkers returning a [[scala.Boolean]] (possibly implicitly converted).  */
+    implicit def fromBooleanCheck[A](checker: => A)(implicit ev: A => Boolean): HealthCheckMagnet = new HealthCheckMagnet {
+      def apply(unhealthyMessage: String) = () => if (checker) "OK" else unhealthyMessage
+    }
+  }
+}
+
+object Test extends App {
+  import health._
+
+  var count = 0
+  val res = healthCheck("bool test", "nope") {
+    count += 1
+    false                  // warn
+  }
+  assert(res() == "nope")
+  assert(res() == "nope")
+  assert(count == 2)
+}


### PR DESCRIPTION
When adapting the result expression of a block with
an implicit conversion that takes a by-name parameter,
only the result expression is adapted; one may incorrectly
think the whole block (as an arg) receives by-name
evaluation semantics.

This lint warns when it notices an implicit applied
in result position of a multiline block.

"Solving 2014's problems today!"

Fixes scala/bug#3237
Fixes scala/bug#9386