### PR TITLE
Deprecate old-style constructor syntax

### DIFF
--- a/test/files/jvm/javaReflection/Classes_1.scala
+++ b/test/files/jvm/javaReflection/Classes_1.scala
@@ -57,7 +57,7 @@ class A {
     (() => "5")
   }
 
-  def this(x: Int) {
+  def this(x: Int) = {
     this()
     class Q
     trait R

--- a/test/files/neg/procedure-deprecation.check
+++ b/test/files/neg/procedure-deprecation.check
@@ -10,6 +10,9 @@ procedure-deprecation.scala:6: warning: procedure syntax is deprecated: instead,
 procedure-deprecation.scala:7: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type
   def boz(i: Int, l: Long) {}
                            ^
+procedure-deprecation.scala:8: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition
+  def this(i: Int) { this() } // Don't complain here! or maybe do complain
+                  ^
 error: No warnings can be incurred under -Werror.
-4 warnings
+5 warnings
 1 error

--- a/test/files/neg/procedure-deprecation.scala
+++ b/test/files/neg/procedure-deprecation.scala
@@ -1,10 +1,10 @@
-// scalac: -deprecation -Xfatal-warnings
+// scalac: -Werror -Xlint:deprecation
 //
 abstract class Foo {
   def bar {}
   def baz
   def boo(i: Int, l: Long)
   def boz(i: Int, l: Long) {}
-  def this(i: Int) { this() } // Don't complain here!
+  def this(i: Int) { this() } // Don't complain here! or maybe do complain
   def foz: Unit               // Don't complain here!
 }

--- a/test/files/neg/procedure-removal.check
+++ b/test/files/neg/procedure-removal.check
@@ -10,4 +10,10 @@ procedure-removal.scala:6: error: procedure syntax is unsupported: instead, add 
 procedure-removal.scala:7: error: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `boz`'s return type
   def boz(i: Int, l: Long) {}
                            ^
-4 errors
+procedure-removal.scala:8: error: '=' expected but '{' found.
+  def this(i: Int) { this() } // Don't complain here! Just slap them with an error.
+                   ^
+procedure-removal.scala:9: error: 'this' expected.
+  def foz: Unit               // Don't complain here!
+^
+6 errors

--- a/test/files/neg/procedure-removal.scala
+++ b/test/files/neg/procedure-removal.scala
@@ -5,6 +5,6 @@ abstract class Foo {
   def baz
   def boo(i: Int, l: Long)
   def boz(i: Int, l: Long) {}
-  def this(i: Int) { this() } // Don't complain here!
+  def this(i: Int) { this() } // Don't complain here! Just slap them with an error.
   def foz: Unit               // Don't complain here!
 }

--- a/test/files/run/analyzerPlugins.scala
+++ b/test/files/run/analyzerPlugins.scala
@@ -36,7 +36,7 @@ object Test extends DirectTest {
         nested()
       }
 
-      def this(str: String) {
+      def this(str: String) = {
         this(str.toDouble)
         math.random
         count += 1

--- a/test/files/run/names-defaults.scala
+++ b/test/files/run/names-defaults.scala
@@ -480,13 +480,13 @@ class A2 {
 // using names / defaults in self constructor call.
 // overloading resolution: calling A3("string") picks the second, method with default is always less specific.
 class A3(x: String, y: Int = 10) {
-  def this(a: Object) {
+  def this(a: Object) = {
     this(y = 10, x = a.toString())
     println(x)
   }
 }
 class A4(x: String, y: Int = 11) {
-  def this(b: Double, sep: String) {
+  def this(b: Double, sep: String) = {
     this(sep + b + sep)
     println(y)
   }

--- a/test/files/run/productElementName.scala
+++ b/test/files/run/productElementName.scala
@@ -14,7 +14,7 @@ case class Symbols(:: : String, || : Int)
 case class MultipleParamLists(a: String, b: Int)(c: Boolean)
 
 case class AuxiliaryConstructor(a: String, b: Int) {
-  def this(x: String) {
+  def this(x: String) = {
     this(x, 123)
   }
 }

--- a/test/files/run/t5543.scala
+++ b/test/files/run/t5543.scala
@@ -40,6 +40,6 @@ object T {
   class D(val x: Any) {
     override def toString() = "D"
     // `this` refers again to T
-    def this(a: Int, b: Int, c: Any = {println(this); this}) { this(c); println(this) } // prints T, then prints D
+    def this(a: Int, b: Int, c: Any = {println(this); this}) = { this(c); println(this) } // prints T, then prints D
   }
 }

--- a/test/files/run/t8197.scala
+++ b/test/files/run/t8197.scala
@@ -3,9 +3,7 @@ class A
 class B
 
 class Foo(val x: A = null) {
-  def this(bla: B*) {
-    this(new A)
-  }
+  def this(bla: B*) = this(new A)
 }
 
 object Test extends App {


### PR DESCRIPTION
Ref https://github.com/scala/scala/pull/6325
Ref https://github.com/scala/scala/pull/3076

I wonder if there was a particular reason this wasn't done during the first round, besides that it was already a big delta.

Fixes scala/bug#11824