### PR TITLE
Improve message with overloaded constructor

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1042,7 +1042,7 @@ trait ContextErrors {
 
     private def applyErrorMsg(tree: Tree, msg: String, argtpes: List[Type], pt: Type) = {
       def asParams(xs: List[Any]) =
-        if (xs.isEmpty && tree.symbol.isConstructor) "empty args"
+        if (xs.isEmpty && tree.symbol.isConstructor) "no arguments"
         else xs.mkString("(", ", ", ")")
 
       def resType   = if (pt.isWildcard) "" else " with expected result type " + pt

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1041,7 +1041,9 @@ trait ContextErrors {
     self: Inferencer =>
 
     private def applyErrorMsg(tree: Tree, msg: String, argtpes: List[Type], pt: Type) = {
-      def asParams(xs: List[Any]) = xs.mkString("(", ", ", ")")
+      def asParams(xs: List[Any]) =
+        if (xs.isEmpty && tree.symbol.isConstructor) "empty args"
+        else xs.mkString("(", ", ", ")")
 
       def resType   = if (pt.isWildcard) "" else " with expected result type " + pt
       def allTypes  = (alternatives(tree) flatMap (_.paramTypes)) ++ argtpes :+ pt
@@ -1145,9 +1147,12 @@ trait ContextErrors {
       def NoBestMethodAlternativeError(tree: Tree, argtpes: List[Type], pt: Type, lastTry: Boolean) = {
         val alts = alternatives(tree)
         val widenedArgtpes = widenArgs(argtpes, alts.head.params, alts.tail.head.params)
+        val proscription =
+          if (tree.symbol.isConstructor) " cannot be invoked with "
+          else " cannot be applied to "
 
         issueNormalTypeError(tree,
-          applyErrorMsg(tree, " cannot be applied to ", widenedArgtpes, pt))
+          applyErrorMsg(tree, proscription, widenedArgtpes, pt))
         // since inferMethodAlternative modifies the state of the tree
         // we have to set the type of tree to ErrorType only in the very last
         // fallback action that is done in the inference.

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -170,7 +170,9 @@ trait TypeDiagnostics {
 
     def patternMessage    = "pattern " + tree.tpe.finalResultType + valueParamsString(tree.tpe)
     def exprMessage       = "expression of type " + tree.tpe
-    def overloadedMessage = s"overloaded method $sym with alternatives:\n" + alternativesString(tree)
+    def overloadedMessage =
+      if (sym.isConstructor) s"multiple constructors for ${sym.owner.decodedName}${sym.idString} with alternatives:\n${alternativesString(tree)}"
+      else s"overloaded method $sym with alternatives:\n${alternativesString(tree)}"
     def moduleMessage     = "" + sym
     def defaultMessage    = moduleMessage + preResultString + tree.tpe
     def applyMessage      = defaultMessage + tree.symbol.locationString

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -172,7 +172,7 @@ trait TypeDiagnostics {
     def exprMessage       = "expression of type " + tree.tpe
     def overloadedMessage =
       if (sym.isConstructor) s"multiple constructors for ${sym.owner.decodedName}${sym.idString} with alternatives:\n${alternativesString(tree)}"
-      else s"overloaded method $sym with alternatives:\n${alternativesString(tree)}"
+      else s"overloaded method ${sym.decodedName} with alternatives:\n${alternativesString(tree)}"
     def moduleMessage     = "" + sym
     def defaultMessage    = moduleMessage + preResultString + tree.tpe
     def applyMessage      = defaultMessage + tree.symbol.locationString

--- a/test/files/neg/deadline-inf-illegal.check
+++ b/test/files/neg/deadline-inf-illegal.check
@@ -6,7 +6,7 @@ deadline-inf-illegal.scala:6: error: type mismatch;
  required: scala.concurrent.duration.FiniteDuration
   Deadline.now + d
                  ^
-deadline-inf-illegal.scala:7: error: overloaded method value - with alternatives:
+deadline-inf-illegal.scala:7: error: overloaded method - with alternatives:
   (other: scala.concurrent.duration.Deadline)scala.concurrent.duration.FiniteDuration <and>
   (other: scala.concurrent.duration.FiniteDuration)scala.concurrent.duration.Deadline
  cannot be applied to (scala.concurrent.duration.Duration)

--- a/test/files/neg/overload-msg.check
+++ b/test/files/neg/overload-msg.check
@@ -1,4 +1,4 @@
-overload-msg.scala:3: error: overloaded method value + with alternatives:
+overload-msg.scala:3: error: overloaded method + with alternatives:
   (x: Double)Double <and>
   (x: Float)Float <and>
   (x: Long)Long <and>

--- a/test/files/neg/sammy_overload.check
+++ b/test/files/neg/sammy_overload.check
@@ -1,4 +1,4 @@
-sammy_overload.scala:14: error: overloaded method value m with alternatives:
+sammy_overload.scala:14: error: overloaded method m with alternatives:
   (x: ToString)Int <and>
   (x: Int => String)Int
  cannot be applied to (Int => Int)

--- a/test/files/neg/t2488.check
+++ b/test/files/neg/t2488.check
@@ -1,28 +1,28 @@
-t2488.scala:7: error: overloaded method value f with alternatives:
+t2488.scala:7: error: overloaded method f with alternatives:
   ()Int <and>
   (a: Int,b: Int)Int
  cannot be applied to (b: Int, Int)
   println(c.f(b = 2, 2))
             ^
-t2488.scala:8: error: overloaded method value f with alternatives:
+t2488.scala:8: error: overloaded method f with alternatives:
   ()Int <and>
   (a: Int,b: Int)Int
  cannot be applied to (a: Int, c: Int)
   println(c.f(a = 2, c = 2))
             ^
-t2488.scala:9: error: overloaded method value f with alternatives:
+t2488.scala:9: error: overloaded method f with alternatives:
   ()Int <and>
   (a: Int,b: Int)Int
  cannot be applied to (Int, c: Int)
   println(c.f(2, c = 2))
             ^
-t2488.scala:10: error: overloaded method value f with alternatives:
+t2488.scala:10: error: overloaded method f with alternatives:
   ()Int <and>
   (a: Int,b: Int)Int
  cannot be applied to (c: Int, Int)
   println(c.f(c = 2, 2))
             ^
-t2488.scala:11: error: overloaded method value f with alternatives:
+t2488.scala:11: error: overloaded method f with alternatives:
   ()Int <and>
   (a: Int,b: Int)Int
  cannot be applied to (Int)

--- a/test/files/neg/t278.check
+++ b/test/files/neg/t278.check
@@ -1,4 +1,4 @@
-t278.scala:5: error: overloaded method value a with alternatives:
+t278.scala:5: error: overloaded method a with alternatives:
   => C.this.A => Unit <and>
   => () => Unit
  does not take type parameters

--- a/test/files/neg/t4460c.check
+++ b/test/files/neg/t4460c.check
@@ -1,7 +1,7 @@
 t4460c.scala:4: error: multiple constructors for B with alternatives:
   (a: String)B <and>
   (x: Int)B
- cannot be invoked with empty args
+ cannot be invoked with no arguments
   def this(a: String) = this()
                         ^
 1 error

--- a/test/files/neg/t4460c.check
+++ b/test/files/neg/t4460c.check
@@ -1,7 +1,7 @@
-t4460c.scala:4: error: overloaded method constructor B with alternatives:
+t4460c.scala:4: error: multiple constructors for B with alternatives:
   (a: String)B <and>
   (x: Int)B
- cannot be applied to ()
+ cannot be invoked with empty args
   def this(a: String) = this()
                         ^
 1 error

--- a/test/files/neg/t5452-new.check
+++ b/test/files/neg/t5452-new.check
@@ -1,4 +1,4 @@
-t5452-new.scala:30: error: overloaded method value apply with alternatives:
+t5452-new.scala:30: error: overloaded method apply with alternatives:
   ()Queryable[CoffeesTable] <and>
   (t: Tree)(implicit evidence$2: scala.reflect.ClassTag[CoffeesTable])Nothing <and>
   (implicit evidence$1: scala.reflect.ClassTag[CoffeesTable])Nothing

--- a/test/files/neg/t5452-old.check
+++ b/test/files/neg/t5452-old.check
@@ -1,4 +1,4 @@
-t5452-old.scala:28: error: overloaded method value apply with alternatives:
+t5452-old.scala:28: error: overloaded method apply with alternatives:
   ()Queryable[CoffeesTable] <and>
   (t: Tree)(implicit evidence$2: Manifest[CoffeesTable])Nothing <and>
   (implicit evidence$1: Manifest[CoffeesTable])Nothing

--- a/test/files/neg/t5969.check
+++ b/test/files/neg/t5969.check
@@ -1,4 +1,4 @@
-t5969.scala:9: error: overloaded method value g with alternatives:
+t5969.scala:9: error: overloaded method g with alternatives:
   (x: C2)String <and>
   (x: C1)String
  cannot be applied to (String)

--- a/test/files/neg/t7752.check
+++ b/test/files/neg/t7752.check
@@ -1,4 +1,4 @@
-t7752.scala:25: error: overloaded method value foo with alternatives:
+t7752.scala:25: error: overloaded method foo with alternatives:
   [A](heading: String, rows: A*)(A,) <and>
   [A, B](heading: (String, String), rows: (A, B)*)(A, B) <and>
   [A, B, C](heading: (String, String, String), rows: (A, B, C)*)(A, B, C) <and>

--- a/test/files/neg/t8376.check
+++ b/test/files/neg/t8376.check
@@ -1,4 +1,4 @@
-S.scala:2: error: overloaded method value m with alternatives:
+S.scala:2: error: overloaded method m with alternatives:
   (a: J*)Unit <and>
   (a: String*)Unit
  cannot be applied to (Int)


### PR DESCRIPTION
The spec says constructors are like methods, but speaking of
overloaded constructors might sound confusing.

Also, in the world of optional parens, they are more optional
in class definitions, even though a parameter list can never
be omitted. Instead of determining whether the user wrote
empty parens or no parens, call them "empty args" for
purposes of this message.

Fixes scala/bug#7387