### PR TITLE
Add JDK 9 constant types to the ClassfileParser

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -177,6 +177,7 @@ abstract class ClassfileParser {
         (u1: @switch) match {
           case CONSTANT_UTF8 | CONSTANT_UNICODE                                => in skip u2
           case CONSTANT_CLASS | CONSTANT_STRING | CONSTANT_METHODTYPE          => in skip 2
+          case CONSTANT_MODULE | CONSTANT_PACKAGE                              => in skip 2
           case CONSTANT_METHODHANDLE                                           => in skip 3
           case CONSTANT_FIELDREF | CONSTANT_METHODREF | CONSTANT_INTFMETHODREF => in skip 4
           case CONSTANT_NAMEANDTYPE | CONSTANT_INTEGER | CONSTANT_FLOAT        => in skip 4

--- a/src/reflect/scala/reflect/internal/ClassfileConstants.scala
+++ b/src/reflect/scala/reflect/internal/ClassfileConstants.scala
@@ -75,6 +75,8 @@ object ClassfileConstants {
   final val CONSTANT_METHODHANDLE  = 15
   final val CONSTANT_METHODTYPE    = 16
   final val CONSTANT_INVOKEDYNAMIC = 18
+  final val CONSTANT_MODULE        = 19
+  final val CONSTANT_PACKAGE       = 20
 
   // tags describing the type of a literal in attribute values
   final val BYTE_TAG   = 'B'

--- a/test/scaladoc/run/java-modules.check
+++ b/test/scaladoc/run/java-modules.check
@@ -1,0 +1,2 @@
+Text()
+Done.

--- a/test/scaladoc/run/java-modules.scala
+++ b/test/scaladoc/run/java-modules.scala
@@ -1,0 +1,20 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+
+  override def code = """
+    /**
+     * @see [[toBytes(i:java\.time\.Instant* ]]
+     */
+    class Foo
+  """
+
+  def scaladocSettings = ""
+
+  def testModel(root: Package) = {
+    import access._
+    val foo = root._class("Foo")
+    println(foo.comment.get.short)
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11635

Occasionally the compiler tries to parse the class files from the classpath. This happens, for example, during scaladoc comment referencing a class name `java.time.Instant`. This would cause error in JDK11 because it includes an unknown constant pool tag 9 (CONSTANT_Module). This updates the parser to skip it over.