### PR TITLE
Report original errors in adaptToImplicitMethod

### DIFF
--- a/test/files/neg/divergent-implicit.check
+++ b/test/files/neg/divergent-implicit.check
@@ -3,7 +3,7 @@ divergent-implicit.scala:4: error: type mismatch;
  required: String
   val x1: String = 1
                    ^
-divergent-implicit.scala:5: error: diverging implicit expansion for type Int => String
+divergent-implicit.scala:5: error: diverging implicit expansion for type Int => Nothing
 starting with method cast in object Test1
   val x2: String = cast[Int, String](1)
                                     ^

--- a/test/files/neg/t11823.check
+++ b/test/files/neg/t11823.check
@@ -1,0 +1,7 @@
+t11823.scala:7: error: could not find implicit value for parameter e: Test.Foo[String]
+  val fooString: Foo[String] = implicitly
+                               ^
+t11823.scala:8: error: could not find implicit value for parameter foo: Test.Foo[String]
+  val barString: Bar[String] = bar
+                               ^
+2 errors

--- a/test/files/neg/t11823.scala
+++ b/test/files/neg/t11823.scala
@@ -1,0 +1,9 @@
+object Test {
+  trait Foo[A]
+  trait Bar[A]
+  implicit def fooInt: Foo[Int] = ???
+  implicit def fooLong: Foo[Long] = ???
+  def bar[A](implicit foo: Foo[A]): Bar[A] = ???
+  val fooString: Foo[String] = implicitly
+  val barString: Bar[String] = bar
+}

--- a/test/files/neg/t8322.check
+++ b/test/files/neg/t8322.check
@@ -4,10 +4,8 @@ t8322.scala:17: error: ambiguous implicit values:
  match expected type T
   implicit def wr[E] = jw(implicitly, implicitly)
                           ^
-t8322.scala:17: error: ambiguous implicit values:
- both method $conforms in object Predef of type [A]=> A => A
- and value ew in trait F of type => Writes[Any]
- match expected type T
+t8322.scala:17: error: diverging implicit expansion for type W[Any]
+starting with method jw in trait F
   implicit def wr[E] = jw(implicitly, implicitly)
                                       ^
 t8322.scala:19: error: type mismatch;

--- a/test/files/neg/t8372.check
+++ b/test/files/neg/t8372.check
@@ -1,7 +1,7 @@
 t8372.scala:7: error: No ClassTag available for A1
   def unzip[T1, T2](a: Array[(T1, T2)]) = a.unzip
                                             ^
-t8372.scala:9: error: No ClassTag available for A1
+t8372.scala:9: error: No ClassTag available for T1
   def unzip3[T1, T2, T3](a: Array[(T1, T2, T3)]): (Array[T1], Array[T2], Array[T3]) = a.unzip3
                                                                                         ^
 2 errors

--- a/test/files/neg/t9960.check
+++ b/test/files/neg/t9960.check
@@ -1,4 +1,4 @@
-t9960.scala:27: error: could not find implicit value for parameter m: NNN.Aux[NNN.Reader,NNN.FxAppend[NNN.Fx1[NNN.Task],NNN.Fx2[NNN.Validate,NNN.Reader]],U]
+t9960.scala:27: error: could not find implicit value for parameter m: NNN.Aux[NNN.Reader,NNN.FxAppend[NNN.Fx1[NNN.Task],NNN.Fx2[NNN.Validate,NNN.Reader]],NNN.Fx2[NNN.Task,NNN.Validate]]
       val hhhh: Eff[Fx2[Task, Validate], Unit] = runReader(gggg)
                                                           ^
 1 error


### PR DESCRIPTION
when failed to retype without expected type.

Fixes scala/bug#11823, fixes scala/bug#9427