### PR TITLE
Allow companion object's `apply` to have default arguments (in more cases)

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3501,13 +3501,16 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             isApplicableSafe(context.undetparams, followApply(pre memberType alt), argtypes, pt)
           }
           if (sym.isOverloaded) {
-              // eliminate functions that would result from tupling transforms
-              // keeps alternatives with repeated params
-            val sym1 = sym filter (alt =>
-                 isApplicableBasedOnArity(pre memberType alt, argtypes.length, varargsStar = false, tuplingAllowed = false)
-              || alt.tpe.params.exists(_.hasDefault)
-            )
-            if (sym1 != NoSymbol) sym = sym1
+            // retracted synthetic apply in favor of user-defined apply
+            def isRetracted(alt: Symbol) = alt.isError && alt.isSynthetic
+            // loose arity check: based on args, prefer no tupling, assume no args: _*,
+            // but keep alt with repeated params or default args, this is a loose fitting
+            def isLooseFit(alt: Symbol)  =
+              isApplicableBasedOnArity(pre memberType alt, argtypes.length, varargsStar = false, tuplingAllowed = false) || alt.tpe.params.exists(_.hasDefault)
+            sym.filter(alt => !isRetracted(alt) && isLooseFit(alt)) match {
+              case _: NoSymbol =>
+              case sym1        => sym = sym1
+            }
           }
           if (sym == NoSymbol) fun
           else adaptAfterOverloadResolution(fun setSymbol sym setType pre.memberType(sym), mode.forFunMode)

--- a/test/files/pos/t11460.scala
+++ b/test/files/pos/t11460.scala
@@ -1,0 +1,43 @@
+package ok1 {
+  case class test private (foo: Map[String, List[Int]],
+                           bar: List[Int],
+                           baz: Map[String, List[String]]) {}
+
+  case object test {
+    def getInstance = apply(Map.empty, List.empty, Map.empty)
+
+    def apply(foo: Map[String, List[Int]],
+              bar: List[Int],
+              baz: Map[String, List[String]]) = new test(foo, bar, baz)
+  }
+}
+
+package ok2 {
+  case class test private (foo: Map[String, List[Int]],
+                           bar: List[Int],
+                           baz: Map[String, List[String]]) {}
+
+  case object test {
+    def getInstance = apply(Map.empty)
+
+    def apply(foo: Map[String, List[Int]] = Map.empty,
+              bar: List[Int] = List.empty,
+              baz: Map[String, List[String]] = Map.empty) =
+      new test(foo, bar, baz)
+  }
+}
+
+package notok {
+  case class test private (foo: Map[String, List[Int]],
+                             bar: List[Int],
+                             baz: Map[String, List[String]]) {}
+
+  case object test {
+    def getInstance = apply()
+
+    def apply(foo: Map[String, List[Int]] = Map.empty,
+              bar: List[Int] = List.empty,
+              baz: Map[String, List[String]] = Map.empty) =
+      new test(foo, bar, baz)
+  }
+}


### PR DESCRIPTION

The weird difference in the two applications, supplying one arg or none, was because "preselect overload" does an arity test. With no args, the overloaded alternatives include the synthetic apply which had not been fully retracted. The type is completed (to error) by virtue of the preselect test.

Fixes scala/bug#11460