### PR TITLE
Lint recursive application using default args, quick use of lint roller

### DIFF
--- a/src/compiler/scala/tools/nsc/PhaseAssembly.scala
+++ b/src/compiler/scala/tools/nsc/PhaseAssembly.scala
@@ -103,7 +103,7 @@ trait PhaseAssembly {
     /* Test if there are cycles in the graph, assign levels to the nodes
      * and collapse hard links into nodes
      */
-    def collapseHardLinksAndLevels(node: Node, lvl: Int) {
+    def collapseHardLinksAndLevels(node: Node, lvl: Int): Unit = {
       if (node.visited) {
         dump("phase-cycle")
         throw new FatalError(s"Cycle in phase dependencies detected at ${node.phasename}, created phase-cycle.dot")
@@ -287,7 +287,7 @@ trait PhaseAssembly {
    * file showing its structure.
    * Plug-in supplied phases are marked as green nodes and hard links are marked as blue edges.
    */
-  private def graphToDotFile(graph: DependencyGraph, filename: String) {
+  private def graphToDotFile(graph: DependencyGraph, filename: String): Unit = {
     val sbuf = new StringBuilder
     val extnodes = new mutable.HashSet[graph.Node]()
     val fatnodes = new mutable.HashSet[graph.Node]()

--- a/src/compiler/scala/tools/nsc/PhaseAssembly.scala
+++ b/src/compiler/scala/tools/nsc/PhaseAssembly.scala
@@ -13,7 +13,6 @@
 package scala.tools.nsc
 
 import scala.collection.mutable
-import scala.language.postfixOps
 
 /** Converts an unordered morass of components into an order that
  *  satisfies their mutual constraints.

--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -12,11 +12,9 @@
 
 package scala.tools.nsc
 
-import java.io.{BufferedOutputStream, File}
+import java.io.File
 import java.lang.Thread.UncaughtExceptionHandler
-import java.nio.file.attribute.FileTime
 import java.nio.file.{Files, Path, Paths}
-import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import java.util.{Collections, Locale}
@@ -30,9 +28,8 @@ import scala.concurrent._
 import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters._
 import scala.math.Ordering.Double.TotalOrdering
-import scala.reflect.internal.pickling.PickleBuffer
 import scala.reflect.internal.util.{BatchSourceFile, FakePos, NoPosition, Position}
-import scala.reflect.io.{PlainNioFile, RootPath}
+import scala.reflect.io.PlainNioFile
 import scala.tools.nsc.PipelineMain.{OutlineTypePipeline, Pipeline, Traditional}
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.reporters.{ConsoleReporter, Reporter}
@@ -112,7 +109,6 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
     val projects: List[Task] = argFiles.toList.map(commandFor)
     if (reporter.hasErrors) return false
 
-    val numProjects = projects.size
     val produces = mutable.LinkedHashMap[Path, Task]()
     for (p <- projects) {
       produces(p.outputDir) = p

--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -25,6 +25,7 @@ import javax.tools.Diagnostic.Kind
 import javax.tools.{Diagnostic, DiagnosticListener, JavaFileObject, ToolProvider}
 
 import scala.collection.{immutable, mutable}
+import scala.collection.immutable.ArraySeq.unsafeWrapArray
 import scala.concurrent._
 import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters._
@@ -664,7 +665,7 @@ object PipelineMain {
       case Array(path) if Files.isDirectory(Paths.get(path)) =>
         Files.walk(Paths.get(path)).iterator().asScala.filter(_.getFileName.toString.endsWith(".args")).toList
       case _ =>
-        args.map(Paths.get(_))
+        unsafeWrapArray(args.map(Paths.get(_)))
     }
     val main = new PipelineMainClass(argFiles, defaultSettings)
     val result = main.process()

--- a/src/compiler/scala/tools/nsc/ast/TreeBrowsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeBrowsers.scala
@@ -276,7 +276,7 @@ abstract class TreeBrowsers {
       val jmiGoto = new JMenuItem(
         new AbstractAction("Go to unit") {
           putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_N, menuKey, false))
-          override def actionPerformed(actionEvent: ActionEvent) {
+          override def actionPerformed(actionEvent: ActionEvent): Unit = {
             val query = JOptionPane.showInputDialog("Go to unit:", frame.getOwner)
             if (query ne null) { // "Cancel" returns null
               val units = treeModel.program.units

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -1094,10 +1094,10 @@ trait Scanners extends ScannersCommon {
         syntaxError("Invalid literal number")
     }
 
-    @inline private def isNumberSeparator(c: Char): Boolean = c == '_' //|| c == '\''
+    @inline private def isNumberSeparator(c: Char): Boolean = c == '_'
 
     @inline private def removeNumberSeparators(s: String): String =
-      if (s.indexOf('_') > 0) s.replaceAllLiterally("_", "") /*.replaceAll("'","")*/ else s
+      if (s.indexOf('_') > 0) s.replace("_", "") else s
 
     // disallow trailing numeric separator char, but let lexing limp along
     def checkNoTrailingSeparator(): Unit =

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -64,9 +64,9 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
   def needsStaticImplMethod(sym: Symbol) = sym.hasAttachment[global.mixer.NeedStaticImpl.type]
 
   final def traitSuperAccessorName(sym: Symbol): String = {
-    val name = sym.javaSimpleName
-    if (sym.isMixinConstructor) name.toString
-    else name + nme.NAME_JOIN_STRING
+    val nameString = sym.javaSimpleName.toString
+    if (sym.isMixinConstructor) nameString
+    else nameString + nme.NAME_JOIN_STRING
   }
 
   /**

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -18,8 +18,8 @@ import java.lang.{StringBuilder, ThreadLocal}
 
 import scala.annotation.tailrec
 import scala.collection.SortedMap
-import scala.tools.asm
-import scala.tools.asm.Opcodes
+import scala.collection.immutable.ArraySeq.unsafeWrapArray
+import scala.tools.asm, asm.Opcodes
 import scala.tools.nsc.backend.jvm.BTypes.{InlineInfo, InternalName}
 import scala.tools.nsc.backend.jvm.BackendReporting._
 import scala.tools.nsc.backend.jvm.opt._
@@ -1145,8 +1145,7 @@ object BTypes {
         i += 1
       }
       scala.util.Sorting.quickSort(result)(Ordering.by(_._1))
-      import scala.collection.immutable.ArraySeq
-      ArraySeq.unsafeWrapArray(result)
+      unsafeWrapArray(result)
     }
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -1145,7 +1145,8 @@ object BTypes {
         i += 1
       }
       scala.util.Sorting.quickSort(result)(Ordering.by(_._1))
-      result
+      import scala.collection.immutable.ArraySeq
+      ArraySeq.unsafeWrapArray(result)
     }
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -404,9 +404,9 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
      * Here we get rid of the module class B, making sure that the class B is present.
      */
     def nestedClassSymbolsNoJavaModuleClasses = nestedClassSymbols.filter { s =>
-      val ok = !(s.isJavaDefined && s.isModuleClass) && !s.isPackage
+      val ok = !(s.isJavaDefined && s.isModuleClass) && !s.hasPackageFlag
       if (!ok)
-        if (!s.isPackage) {
+        if (!s.hasPackageFlag) {
           // We could also search in nestedClassSymbols for s.linkedClassOfClass, but sometimes that
           // returns NoSymbol, so it doesn't work.
           val nb = nestedClassSymbols.count(mc => mc.name == s.name && mc.owner == s.owner)

--- a/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
@@ -14,7 +14,6 @@ package scala.tools.nsc
 package backend.jvm
 
 import java.nio.channels.ClosedByInterruptException
-import java.nio.file.Path
 import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy
 import java.util.concurrent._
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingAnalyzer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingAnalyzer.scala
@@ -36,7 +36,7 @@ class AliasingFrame[V <: Value](nLocals: Int, nStack: Int) extends Frame[V](nLoc
   import Opcodes._
 
   // Auxiliary constructor required for implementing `AliasingAnalyzer.newFrame`
-  def this(src: Frame[_ <: V]) {
+  def this(src: Frame[_ <: V]) = {
     this(src.getLocals, src.getMaxStackSize)
     init(src)
   }

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzer.scala
@@ -152,7 +152,7 @@ class NullnessFrame(nLocals: Int, nStack: Int) extends AliasingFrame[NullnessVal
   private[this] var ifNullAliases: AliasSet = null
 
   // Auxiliary constructor required for implementing `NullnessAnalyzer.newFrame`
-  def this(src: Frame[_ <: NullnessValue]) {
+  def this(src: Frame[_ <: NullnessValue]) = {
     this(src.getLocals, src.getMaxStackSize)
     init(src)
   }

--- a/src/compiler/scala/tools/nsc/classpath/AggregateClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/AggregateClassPath.scala
@@ -14,6 +14,7 @@ package scala.tools.nsc.classpath
 
 import java.net.URL
 
+import scala.collection.immutable.ArraySeq.unsafeWrapArray
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.internal.FatalError
 import scala.reflect.io.AbstractFile
@@ -102,7 +103,7 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
       }
     }
 
-    val distinctPackages: Seq[PackageEntry] = if (packages == null) Nil else packages.toArray(new Array[PackageEntry](packages.size()))
+    val distinctPackages: Seq[PackageEntry] = if (packages == null) Nil else unsafeWrapArray(packages.toArray(new Array[PackageEntry](packages.size())))
     val distinctClassesAndSources = mergeClassesAndSources(classesAndSourcesBuffer)
     ClassPathEntries(distinctPackages, distinctClassesAndSources)
   }

--- a/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
@@ -63,7 +63,9 @@ trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends EfficientCla
       case None => emptyFiles
       case Some(directory) => listChildren(directory, Some(isPackage))
     }
-    nestedDirs.map(f => PackageEntryImpl(inPackage.entryName(getName(f))))
+    scala.collection.immutable.ArraySeq.unsafeWrapArray(
+      nestedDirs.map(f => PackageEntryImpl(inPackage.entryName(getName(f))))
+    )
   }
 
   protected def files(inPackage: PackageName): Seq[FileEntryType] = {
@@ -317,7 +319,7 @@ case class DirectorySourcePath(dir: File) extends JFileDirectoryLookup[SourceFil
 
   private def findSourceFile(className: String): Option[AbstractFile] = {
     val relativePath = FileUtils.dirPath(className)
-    val sourceFile = Stream("scala", "java")
+    val sourceFile = Iterator("scala", "java")
       .map(ext => new File(s"$dir/$relativePath.$ext"))
       .collectFirst { case file if file.exists() => file }
 

--- a/src/compiler/scala/tools/nsc/plugins/OutputFileWriter.scala
+++ b/src/compiler/scala/tools/nsc/plugins/OutputFileWriter.scala
@@ -15,5 +15,5 @@ package scala.tools.nsc.plugins
 import scala.reflect.io.AbstractFile
 
 trait OutputFileWriter {
-  def writeFile(relativeName: String, data: Array[Byte], outputDir: AbstractFile)
+  def writeFile(relativeName: String, data: Array[Byte], outputDir: AbstractFile): Unit
 }

--- a/src/compiler/scala/tools/nsc/profile/Profiler.scala
+++ b/src/compiler/scala/tools/nsc/profile/Profiler.scala
@@ -172,7 +172,7 @@ private [profile] class RealProfiler(reporter : ProfileReporter, val settings: S
     reporter.reportBackground(this, threadRange)
   }
 
-  def outDir = settings.outputDirs.getSingleOutput.getOrElse(settings.outputDirs.outputs.head._2.file).toString
+  def outDir = settings.outputDirs.getSingleOutput.map(_.path).getOrElse(settings.outputDirs.outputs.head._2.path)
 
   RealProfiler.gcMx foreach {
     case emitter: NotificationEmitter => emitter.addNotificationListener(this, null, null)

--- a/src/compiler/scala/tools/nsc/profile/Profiler.scala
+++ b/src/compiler/scala/tools/nsc/profile/Profiler.scala
@@ -181,7 +181,7 @@ private [profile] class RealProfiler(reporter : ProfileReporter, val settings: S
 
   val active = RealProfiler.allPlugins map (_.generate(this, settings))
 
-  private def doGC: Unit = {
+  private def doGC(): Unit = {
     System.gc()
     System.runFinalization()
   }
@@ -241,7 +241,7 @@ private [profile] class RealProfiler(reporter : ProfileReporter, val settings: S
     assert(mainThread eq Thread.currentThread())
     if (chromeTrace != null) chromeTrace.traceDurationEventStart(Category.Phase, phase.name)
     if (settings.YprofileRunGcBetweenPhases.containsPhase(phase))
-      doGC
+      doGC()
     if (settings.YprofileExternalTool.containsPhase(phase)) {
       println("Profile hook start")
       ExternalToolHook.before()
@@ -259,7 +259,7 @@ private [profile] class RealProfiler(reporter : ProfileReporter, val settings: S
       ExternalToolHook.after()
     }
     val finalSnap = if (settings.YprofileRunGcBetweenPhases.containsPhase(phase)) {
-      doGC
+      doGC()
       initialSnap.updateHeap(RealProfiler.readHeapUsage())
     } else initialSnap
     if (chromeTrace != null) chromeTrace.traceDurationEventEnd(Category.Phase, phase.name)

--- a/src/compiler/scala/tools/nsc/reporters/StoreReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/StoreReporter.scala
@@ -20,13 +20,13 @@ import scala.reflect.internal.util.Position
 
 /** This class implements a Reporter that stores its reports in the set `infos`. */
 class StoreReporter(val settings: Settings) extends FilteringReporter {
-  @deprecated("use the constructor with a `Settings` parameter", "2.13.1")
+  @deprecated("use the constructor with a `Settings` parameter", since = "2.13.1")
   def this() = this(new Settings())
 
-  @deprecated("use StoreReporter.Info") // used in scalameta for example
+  @deprecated("use StoreReporter.Info", since = "2.13.0") // used in scalameta for example
   type Info = StoreReporter.Info
 
-  @deprecated("use StoreReporter.Info")
+  @deprecated("use StoreReporter.Info", since = "2.13.0")
   @uncheckedStable def Info: StoreReporter.Info.type = StoreReporter.Info
 
   val infos = new mutable.LinkedHashSet[StoreReporter.Info]

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -115,6 +115,7 @@ trait Warnings {
     val EtaSam                 = LintWarning("eta-sam",                   "The Java-defined target interface for eta-expansion was not annotated @FunctionalInterface.")
     val Deprecation            = LintWarning("deprecation",               "Enable -deprecation and also check @deprecated annotations.")
     val ByNameImplicit         = LintWarning("byname-implicit",           "Block adapted by implicit with by-name parameter.")
+    val RecurseWithDefault     = LintWarning("recurse-with-default",      "Recursive call used default argument.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
   }
@@ -144,6 +145,7 @@ trait Warnings {
   def warnEtaSam                 = lint contains EtaSam
   def lintDeprecation            = lint contains Deprecation
   def warnByNameImplicit         = lint contains ByNameImplicit
+  def warnRecurseWithDefault     = lint contains RecurseWithDefault
 
   // The Xlint warning group.
   val lint = MultiChoiceSetting(

--- a/src/compiler/scala/tools/nsc/symtab/SymbolTrackers.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolTrackers.scala
@@ -183,14 +183,14 @@ trait SymbolTrackers {
       val hierarchy = Node(current)
       val Change(_, removed, symMap, _, _) = history.head
       def detailString(sym: Symbol) = {
-        val ownerString = sym.ownerChain splitAt 3 match {
-          case (front, back) =>
-            val xs = if (back.isEmpty) front else front :+ "..."
-            xs mkString " -> "
+        val ownerString = {
+          val (few, rest) = sym.ownersIterator.splitAt(3)
+          val ellipsis = Iterator("...").filter(_ => rest.hasNext)
+          (few ++ ellipsis).mkString(" -> ")
         }
         val treeStrings = symMap(sym).map(t => f"${t.shortClass}%10s: $t")
 
-        ownerString :: treeStrings mkString "\n"
+        (ownerString :: treeStrings).mkString("\n")
       }
       def removedString = (removed: List[Symbol]).zipWithIndex map {
         case (t, i) => "(%2s) ".format(i + 1) + detailString(t)

--- a/src/compiler/scala/tools/nsc/symtab/classfile/AbstractFileReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/AbstractFileReader.scala
@@ -27,7 +27,7 @@ import scala.tools.nsc.io.AbstractFile
  */
 final class AbstractFileReader(val buf: Array[Byte]) extends DataReader {
   @deprecated("Use other constructor", "2.13.0")
-  def this(file: AbstractFile) {
+  def this(file: AbstractFile) = {
     this(file.toByteArray)
   }
 

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -183,12 +183,11 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
     }
   }
 
-  def getClassSymbol(name: String): Symbol = {
+  def getClassSymbol(name: String): Symbol =
     name match {
-      case name if name.endsWith(nme.MODULE_SUFFIX_STRING) => rootMirror getModuleByName newTermName(name).dropModule
-      case name                           => classNameToSymbol(name)
+      case name if name.endsWith(nme.MODULE_SUFFIX_STRING) => rootMirror.getModuleByName(name.stripSuffix(nme.MODULE_SUFFIX_STRING))
+      case name                                            => classNameToSymbol(name)
     }
-  }
 
   /**
    * Constructor of this class should not be called directly, use `newConstantPool` instead.

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -484,10 +484,10 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
     // The constructor parameter with given name. This means the parameter
     // has given name, or starts with given name, and continues with a `$` afterwards.
     def parameterNamed(name: Name): Symbol = {
-      def matchesName(param: Symbol) = param.name == name || param.name.startsWith(name + nme.NAME_JOIN_STRING)
+      def matchesName(param: Symbol) = param.name == name || param.name.startsWith(s"${name}${nme.NAME_JOIN_STRING}")
 
       primaryConstrParams filter matchesName match {
-        case Nil    => abort(name + " not in " + primaryConstrParams)
+        case Nil    => abort(s"$name not in $primaryConstrParams")
         case p :: _ => p
       }
     }

--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -254,7 +254,7 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
 
     private def transformFunction(originalFunction: Function): Tree = {
       val target = targetMethod(originalFunction)
-      assert(target.hasFlag(Flags.STATIC))
+      assert(target.hasFlag(Flags.STATIC), "static")
       target.setFlag(notPRIVATE)
 
       val funSym = originalFunction.tpe.typeSymbolDirect

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -47,7 +47,7 @@ abstract class Erasure extends InfoTransform
     val mname      = newTermName("to" + numericSym.name)
     val conversion = tree.tpe member mname
 
-    assert(conversion != NoSymbol, tree + " => " + numericSym)
+    assert(conversion != NoSymbol, s"$tree => $numericSym")
     atPos(tree.pos)(Apply(Select(tree, conversion), Nil))
   }
 
@@ -570,10 +570,10 @@ abstract class Erasure extends InfoTransform
       if (member.isModule) newFlags = (newFlags | METHOD) & ~(MODULE | STABLE)
       val bridge = other.cloneSymbolImpl(root, newFlags).setPos(root.pos).setAnnotations(member.annotations)
 
-      debuglog("generating bridge from %s (%s): %s to %s: %s".format(
+      debuglog("generating bridge from %s (%s): %s%s to %s: %s%s".format(
         other, flagsToString(newFlags),
-        otpe + other.locationString, member,
-        specialErasure(root)(member.tpe) + member.locationString)
+        otpe, other.locationString, member,
+        specialErasure(root)(member.tpe), member.locationString)
       )
 
       // the parameter symbols need to have the new owner

--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -56,11 +56,11 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
            |
            | Candidates:
            |
-           | ${candidates.map(c => c.name+":"+c.tpe).mkString("\n")}
+           | ${candidates.map(c => s"${c.name}:${c.tpe}").mkString("\n")}
            |
            | Candidates (signatures normalized):
            |
-           | ${candidates.map(c => c.name+":"+normalize(c.tpe, imeth.owner)).mkString("\n")}" """)
+           | ${candidates.map(c => s"${c.name}:${normalize(c.tpe, imeth.owner)}").mkString("\n")}" """)
     matching.head
   }
 

--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -517,7 +517,7 @@ abstract class LambdaLift extends InfoTransform {
         case Assign(Apply(TypeApply(sel @ Select(qual, _), _), List()), rhs) =>
           // eliminate casts introduced by selecting a captured variable field
           // on the lhs of an assignment.
-          assert(sel.symbol == Object_asInstanceOf, "$asInstanceOf")
+          assert(sel.symbol == Object_asInstanceOf, "asInstanceOf")
           treeCopy.Assign(tree, qual, rhs)
         case Ident(name) =>
           val tree1 =

--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -517,7 +517,7 @@ abstract class LambdaLift extends InfoTransform {
         case Assign(Apply(TypeApply(sel @ Select(qual, _), _), List()), rhs) =>
           // eliminate casts introduced by selecting a captured variable field
           // on the lhs of an assignment.
-          assert(sel.symbol == Object_asInstanceOf)
+          assert(sel.symbol == Object_asInstanceOf, "$asInstanceOf")
           treeCopy.Assign(tree, qual, rhs)
         case Ident(name) =>
           val tree1 =

--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -352,7 +352,7 @@ abstract class TailCalls extends Transform {
         case CaseDef(pat, guard, body) =>
           // CaseDefs are already translated and guards were moved into the body.
           // If this was not the case, guards would have to be transformed here as well.
-          assert(guard.isEmpty)
+          assert(guard.isEmpty, "empty guard")
           deriveCaseDef(tree)(transform)
 
         case If(cond, thenp, elsep) =>

--- a/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
+++ b/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
@@ -61,7 +61,7 @@ trait TypeAdaptingTransformer { self: TreeDSL =>
               else BLOCK(tree, REF(BoxedUnit_UNIT))
             case NothingClass => tree // a non-terminating expression doesn't need boxing
             case x =>
-              assert(x != ArrayClass)
+              assert(x != ArrayClass, "array")
               tree match {
                 case Apply(boxFun, List(arg)) if isSafelyRemovableUnbox(tree, arg) =>
                   arg
@@ -96,7 +96,7 @@ trait TypeAdaptingTransformer { self: TreeDSL =>
               case UnitClass  =>
                 preservingSideEffects(tree, UNIT)
               case x          =>
-                assert(x != ArrayClass)
+                assert(x != ArrayClass, "array")
                 // don't `setType pt` the Apply tree, as the Apply's fun won't be typechecked if the Apply tree already has a type
                 Apply(currentRun.runDefinitions.unboxMethod(pt.typeSymbol), tree)
             }

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -279,7 +279,7 @@ abstract class UnCurry extends InfoTransform
         // when calling into java varargs, make sure it's an array - see bug #1360
         def sequenceToArray(tree: Tree): Tree = {
           val toArraySym = tree.tpe member nme.toArray
-          assert(toArraySym != NoSymbol)
+          assert(toArraySym != NoSymbol, "toArray")
           @tailrec
           def getClassTag(tp: Type): Tree = {
             val tag = localTyper.resolveClassTag(tree.pos, tp)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1315,11 +1315,8 @@ abstract class RefChecks extends Transform {
         else "may be unable to override"
 
       reporter.warning(memberSym.pos,
-        "%s%s references %s %s.".format(
-          memberSym.fullLocationString, comparison,
-          accessFlagsToString(otherSym), otherSym
-        ) + "\nClasses which cannot access %s %s %s.".format(
-          otherSym.decodedName, cannot, memberSym.decodedName)
+        s"""|${memberSym.fullLocationString}${comparison} references ${accessFlagsToString(otherSym)} ${otherSym}.
+            |Classes which cannot access ${otherSym.decodedName} ${cannot} ${memberSym.decodedName}.""".stripMargin
       )
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -458,9 +458,9 @@ abstract class RefChecks extends Transform {
               // Only warn for the pair that has one leg in `clazz`.
               if (clazz == memberClass) checkOverrideDeprecated()
               if (settings.warnNullaryOverride) {
-                if (other.paramss.isEmpty && !member.paramss.isEmpty && !member.isJavaDefined) {
+                def javaDetermined(sym: Symbol) = sym.isJavaDefined || isUniversalMember(sym)
+                if (other.paramss.isEmpty && !member.paramss.isEmpty && !javaDetermined(member) && !member.overrides.exists(javaDetermined))
                   reporter.warning(member.pos, "non-nullary method overrides nullary method")
-                }
               }
             }
           }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -873,7 +873,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                     // Q: `typed` already calls `pluginsTyped` and `adapt`. the only difference here is that
                     // we pass `EmptyTree` as the `original`. intended? added in 2009 (53d98e7d42) by martin.
                     tree1 setType pluginsTyped(tree1.tpe, typer1, tree1, mode, pt)
-                    if (tree1.isEmpty) tree1 else typer1.adapt(tree1, mode, pt)
+                    if (tree1.isEmpty) tree1 else typer1.adapt(tree1, mode, pt, original = EmptyTree)
                   } orElse { _ =>
                     originalErrors.foreach(context.issue)
                     setError(tree)
@@ -1111,7 +1111,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         val boundOrSkolems = if (canIgnoreMismatch) bound ++ pt.skolemsExceptMethodTypeParams else Nil
         boundOrSkolems match {
           case Nil => AdaptTypeError(tree, tree.tpe, pt)
-          case _   => logResult(msg)(adapt(tree, mode, deriveTypeWithWildcards(boundOrSkolems)(pt)))
+          case _   => logResult(msg)(adapt(tree, mode, deriveTypeWithWildcards(boundOrSkolems)(pt), original = EmptyTree))
         }
       }
 
@@ -1225,7 +1225,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           instantiatePossiblyExpectingUnit(tree, mode, pt)
         }
         // TODO: we really shouldn't use T* as a first class types (e.g. for repeated case fields), but we can't allow T* to conform to other types (see isCompatible) because that breaks overload resolution
-        else if (isScalaRepeatedParamType(tree.tpe) && !isScalaRepeatedParamType(pt)) adapt(tree setType(repeatedToSeq(tree.tpe)), mode, pt)
+        else if (isScalaRepeatedParamType(tree.tpe) && !isScalaRepeatedParamType(pt)) adapt(tree setType(repeatedToSeq(tree.tpe)), mode, pt, original = EmptyTree)
         else if (tree.tpe <:< pt)
           tree
         else if (mode.inPatternMode && { inferModulePattern(tree, pt); isPopulated(tree.tpe, approximateAbstracts(pt)) })

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3721,7 +3721,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                   context.set(ContextMode.DiagUsedDefaults)
                   def checkRecursive(res: Tree): Unit =
                     if (settings.warnRecurseWithDefault && !res.isErroneous && context.owner.hasTransOwner(funSym))
-                      context.warning(res.pos, "Recursive call used default arguments.")
+                      context.warning(res.pos, "Recursive call used default arguments instead of passing current argument values.")
 
                   doTypedApply(tree, if (blockIsEmpty) fun else fun1, allArgs, mode, pt).tap(checkRecursive)
                 } else {

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1117,7 +1117,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     /** Create a function application of a given view function to `tree` and typechecked it.
      */
     def viewApply(view: SearchResult): Tree = {
-      assert(view.tree != EmptyTree)
+      assert(view.tree != EmptyTree, "view.tree should be non-empty")
       val t = analyzer.newTyper(context.makeImplicit(reportAmbiguousErrors = false))
         .typed(Apply(view.tree, List(tree)) setPos tree.pos)
       if (!t.tpe.isErroneous) t
@@ -1352,7 +1352,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
 
   class TyperResult(val tree: Tree) extends ControlThrowable
 
-  assert(globalPhase.id == 0)
+  assert(globalPhase.id == 0, "phase at zero")
 
   implicit def addOnTypeError[T](x: => T): OnTypeError[T] = new OnTypeError(x)
 

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1268,7 +1268,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
 
 
   /** Implements CompilerControl.askLoadedTyped */
-  private[interactive] def waitLoadedTyped(source: SourceFile, response: Response[Tree], keepLoaded: Boolean = false, onSameThread: Boolean = true): Unit = {
+  private[interactive] def waitLoadedTyped(source: SourceFile, response: Response[Tree], keepLoaded: Boolean, onSameThread: Boolean): Unit = {
     getUnit(source) match {
       case Some(unit) =>
         if (unit.isUpToDate) {
@@ -1287,7 +1287,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
         debugLog("load unit and type")
         try reloadSources(List(source))
         finally {
-          waitLoadedTyped(source, response, onSameThread)
+          waitLoadedTyped(source, response, keepLoaded, onSameThread = true)
           if (!keepLoaded) removeUnitOf(source)
         }
     }

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -193,23 +193,22 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
    */
   protected val toBeRemovedAfterRun: HashSet[AbstractFile] = new HashSet[AbstractFile]
 
-  class ResponseMap extends mutable.HashMap[SourceFile, Set[Response[Tree]]] {
-    override def default(key: SourceFile): Set[Response[Tree]] = Set()
-    override def addOne (binding: (SourceFile, Set[Response[Tree]])) = {
+  private def newResponseMap: ResponseMap =
+    mutable.HashMap.empty[SourceFile, Set[Response[Tree]]].withDefaultValue(Set.empty[Response[Tree]])
+  type ResponseMap = mutable.Map[SourceFile, Set[Response[Tree]]]
+  /* TODO restore assert on addOne
       assert(interruptsEnabled, "delayed operation within an ask")
-      super.addOne(binding)
-    }
-  }
+  */
 
   /** A map that associates with each abstract file the set of responses that are waiting
    *  (via waitLoadedTyped) for the unit associated with the abstract file to be loaded and completely typechecked.
    */
-  protected val waitLoadedTypeResponses = new ResponseMap
+  protected val waitLoadedTypeResponses = newResponseMap
 
   /** A map that associates with each abstract file the set of responses that ware waiting
    *  (via build) for the unit associated with the abstract file to be parsed and entered
    */
-  protected var getParsedEnteredResponses = new ResponseMap
+  protected var getParsedEnteredResponses = newResponseMap
 
   private def cleanResponses(rmap: ResponseMap): Unit = {
     for ((source, rs) <- rmap.toList) {

--- a/src/interactive/scala/tools/nsc/interactive/Lexer.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Lexer.scala
@@ -285,7 +285,7 @@ class Lexer(rd: Reader) {
    */
   def accept(t: Token): Unit = {
     if (token == t) nextToken()
-    else error(t+" expected, but "+token+" found")
+    else error(s"$t expected, but $token found")
   }
 
   /** The current token is a delimiter consisting of given character, reads next token,

--- a/src/interactive/scala/tools/nsc/interactive/Picklers.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Picklers.scala
@@ -42,9 +42,7 @@ trait Picklers { self: Global =>
       .wrapped[AbstractFile] { new PlainFile(_) } { _.path }
       .asClass (classOf[PlainFile])
 
-  private val sourceFilesSeen = new mutable.HashMap[AbstractFile, Array[Char]] {
-    override def default(key: AbstractFile) = Array()
-  }
+  private val sourceFilesSeen = mutable.HashMap.empty[AbstractFile, Array[Char]].withDefaultValue(Array.empty[Char])
 
   type Diff = (Int /*start*/, Int /*end*/, String /*replacement*/)
 

--- a/src/interactive/scala/tools/nsc/interactive/Picklers.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Picklers.scala
@@ -108,7 +108,7 @@ trait Picklers { self: Global =>
           val sym1 = sym.owner.info.decl(sym.name)
           if (sym1.isOverloaded) {
             val index = sym1.alternatives.indexOf(sym)
-            assert(index >= 0, sym1+" not found in alternatives "+sym1.alternatives)
+            assert(index >= 0, s"$sym1 not found in alternatives ${sym1.alternatives}")
             buf += newTermName(index.toString)
           }
         }

--- a/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTest.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTest.scala
@@ -96,11 +96,11 @@ abstract class InteractiveTest
     // ask the presentation compiler to track all sources. We do
     // not wait for the file to be entirely typed because we do want
     // to exercise the presentation compiler on scoped type requests.
-    askReload(sourceFiles)
+    askReload(sourceFiles.toIndexedSeq)
     // make sure all sources are parsed before running the test. This
     // is because test may depend on the sources having been parsed at
     // least once
-    askParse(sourceFiles)
+    askParse(sourceFiles.toIndexedSeq)
   }
 
   /** Run all defined `PresentationCompilerTestDef` */

--- a/src/interactive/scala/tools/nsc/interactive/tests/Tester.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/Tester.scala
@@ -189,7 +189,7 @@ class Tester(ntests: Int, inputs: Array[SourceFile], settings: Settings) {
 
   /**/
   def run(): Unit = {
-    askReload(inputs: _*)
+    askReload(inputs.toIndexedSeq: _*)
     for (i <- 0 until ntests)
       testFileChanges(randomSourceFileIdx())
   }

--- a/src/interactive/scala/tools/nsc/interactive/tests/core/AskCommand.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/core/AskCommand.scala
@@ -14,6 +14,7 @@ package scala.tools.nsc
 package interactive
 package tests.core
 
+import scala.annotation.unused
 import scala.tools.nsc.interactive.Response
 import scala.reflect.internal.util.Position
 import scala.reflect.internal.util.SourceFile
@@ -121,7 +122,7 @@ trait AskTypeAt extends AskCommand {
 trait AskLoadedTyped extends AskCommand {
   import compiler.Tree
 
-  protected def askLoadedTyped(source: SourceFile, keepLoaded: Boolean = false)(implicit reporter: Reporter): Response[Tree] = {
+  protected def askLoadedTyped(source: SourceFile, keepLoaded: Boolean = false)(implicit @unused reporter: Reporter): Response[Tree] = {
     ask {
       compiler.askLoadedTyped(source, keepLoaded, _)
     }

--- a/src/interactive/scala/tools/nsc/interactive/tests/core/PresentationCompilerRequestsWorkingMode.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/core/PresentationCompilerRequestsWorkingMode.scala
@@ -43,7 +43,7 @@ trait PresentationCompilerRequestsWorkingMode extends TestResources {
   }
 
   /** All positions of the given string in all source files. */
-  private def allPositionsOf(srcs: Seq[SourceFile] = sourceFiles, str: String): Seq[Position] =
+  private def allPositionsOf(srcs: Seq[SourceFile] = sourceFiles.toIndexedSeq, str: String): Seq[Position] =
     for (s <- srcs; p <- positionsOf(s, str)) yield p
 
   /** Return all positions of the given str in the given source file. */

--- a/src/interactive/scala/tools/nsc/interactive/tests/core/SourcesCollector.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/core/SourcesCollector.scala
@@ -23,7 +23,7 @@ private[tests] object SourcesCollector {
    * With the default `filter` only .scala and .java files are collected.
    * */
   def apply(base: Path, filter: SourceFilter): Array[SourceFile] = {
-    assert(base.isDirectory, base + " is not a directory")
+    assert(base.isDirectory, s"$base is not a directory")
     base.walk.filter(filter).map(source).toList.toArray.sortBy(_.file.name)
   }
 

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -18,7 +18,7 @@ import mutable.ArrayBuilder
 import immutable.ArraySeq
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
-import scala.runtime.{BoxedUnit, ScalaRunTime}
+import scala.runtime.BoxedUnit
 import scala.runtime.ScalaRunTime.{array_apply, array_update}
 
 /** Utility methods for operating on arrays.

--- a/src/library/scala/collection/BuildFrom.scala
+++ b/src/library/scala/collection/BuildFrom.scala
@@ -12,9 +12,8 @@
 
 package scala.collection
 
-import scala.language.higherKinds
-import scala.collection.mutable.Builder
 import scala.annotation.implicitNotFound
+import scala.collection.mutable.Builder
 import scala.collection.immutable.WrappedString
 import scala.reflect.ClassTag
 

--- a/src/library/scala/collection/Factory.scala
+++ b/src/library/scala/collection/Factory.scala
@@ -14,7 +14,7 @@ package scala
 package collection
 
 import scala.collection.immutable.NumericRange
-import scala.language.{higherKinds, implicitConversions}
+import scala.language.implicitConversions
 import scala.collection.mutable.Builder
 import scala.annotation.unchecked.uncheckedVariance
 import scala.reflect.ClassTag

--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -16,7 +16,6 @@ package collection
 import scala.annotation.tailrec
 import scala.collection.Searching.{Found, InsertionPoint, SearchResult}
 import scala.collection.Stepper.EfficientSplit
-import scala.language.higherKinds
 import scala.math.Ordering
 
 /** Base trait for indexed sequences that have efficient `apply` and `length` */

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -13,7 +13,6 @@
 package scala
 package collection
 
-import scala.language.higherKinds
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.mutable.Builder
 import scala.collection.View.{LeftPartitionMapped, RightPartitionMapped}

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -15,7 +15,7 @@ package collection
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.mutable.StringBuilder
-import scala.language.{higherKinds, implicitConversions}
+import scala.language.implicitConversions
 import scala.math.{Numeric, Ordering}
 import scala.reflect.ClassTag
 

--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -14,7 +14,6 @@ package scala
 package collection
 
 import scala.annotation.tailrec
-import scala.language.higherKinds
 
 /** Base trait for linearly accessed sequences that have efficient `head` and
   *  `tail` operations.

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -15,7 +15,6 @@ package collection
 
 import scala.collection.generic.DefaultSerializable
 import scala.collection.mutable.StringBuilder
-import scala.language.higherKinds
 import scala.util.hashing.MurmurHash3
 
 /** Base Map type */

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -13,7 +13,6 @@
 package scala.collection
 
 import scala.collection.immutable.Range
-import scala.language.higherKinds
 import scala.util.hashing.MurmurHash3
 import Searching.{Found, InsertionPoint, SearchResult}
 

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -220,5 +220,4 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
 object Set extends IterableFactory.Delegate[Set](immutable.Set)
 
 /** Explicit instantiation of the `Set` trait to reduce class file size in subclasses. */
-@SerialVersionUID(3L)
 abstract class AbstractSet[A] extends AbstractIterable[A] with Set[A]

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -13,7 +13,6 @@
 package scala
 package collection
 
-import scala.language.higherKinds
 import scala.util.hashing.MurmurHash3
 import java.lang.String
 

--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -14,7 +14,6 @@ package scala
 package collection
 
 import scala.annotation.implicitNotFound
-import scala.language.higherKinds
 
 /** A Map whose keys are sorted according to a [[scala.math.Ordering]]*/
 trait SortedMap[K, +V]

--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -14,7 +14,6 @@ package scala.collection
 
 import scala.annotation.implicitNotFound
 import scala.annotation.unchecked.uncheckedVariance
-import scala.language.higherKinds
 
 /** Base type of sorted sets */
 trait SortedSet[A] extends Set[A]

--- a/src/library/scala/collection/StrictOptimizedIterableOps.scala
+++ b/src/library/scala/collection/StrictOptimizedIterableOps.scala
@@ -14,7 +14,6 @@ package scala
 package collection
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.language.higherKinds
 import scala.runtime.Statics
 
 /**

--- a/src/library/scala/collection/StrictOptimizedMapOps.scala
+++ b/src/library/scala/collection/StrictOptimizedMapOps.scala
@@ -12,8 +12,6 @@
 
 package scala.collection
 
-import scala.language.higherKinds
-
 /**
   * Trait that overrides map operations to take advantage of strict builders.
   *

--- a/src/library/scala/collection/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSeqOps.scala
@@ -12,8 +12,6 @@
 
 package scala.collection
 
-import scala.language.higherKinds
-
 /**
   * Trait that overrides operations on sequences in order
   * to take advantage of strict builders.

--- a/src/library/scala/collection/StrictOptimizedSortedSetOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSortedSetOps.scala
@@ -13,10 +13,8 @@
 package scala
 package collection
 
-
 import scala.annotation.implicitNotFound
 import scala.annotation.unchecked.uncheckedVariance
-import scala.language.higherKinds
 
 /**
   * Trait that overrides sorted set operations to take advantage of strict builders.

--- a/src/library/scala/collection/WithFilter.scala
+++ b/src/library/scala/collection/WithFilter.scala
@@ -12,8 +12,6 @@
 
 package scala.collection
 
-import scala.language.higherKinds
-
 /** A template trait that contains just the `map`, `flatMap`, `foreach` and `withFilter` methods
   * of trait `Iterable`.
   *

--- a/src/library/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/src/library/scala/collection/convert/JavaCollectionWrappers.scala
@@ -18,7 +18,6 @@ import java.util.{concurrent => juc}
 import java.{lang => jl, util => ju}
 
 import scala.jdk.CollectionConverters._
-import scala.language.higherKinds
 
 /** Wrappers for exposing Scala collections as Java collections and vice-versa */
 @SerialVersionUID(3L)

--- a/src/library/scala/collection/generic/IsIterable.scala
+++ b/src/library/scala/collection/generic/IsIterable.scala
@@ -13,8 +13,6 @@
 package scala.collection
 package generic
 
-import scala.language.higherKinds
-
 /** A trait which can be used to avoid code duplication when defining extension
  *  methods that should be applicable both to existing Scala collections (i.e.,
  *  types extending `Iterable`) as well as other (potentially user-defined)

--- a/src/library/scala/collection/generic/IsIterableOnce.scala
+++ b/src/library/scala/collection/generic/IsIterableOnce.scala
@@ -51,7 +51,6 @@ trait IsIterableOnce[Repr] {
 }
 
 object IsIterableOnce extends IsIterableOnceLowPriority {
-  import scala.language.higherKinds
 
   // Straightforward case: IterableOnce subclasses
   implicit def iterableOnceIsIterableOnce[CC0[A] <: IterableOnce[A], A0]: IsIterableOnce[CC0[A0]] { type A = A0 } =

--- a/src/library/scala/collection/generic/IsMap.scala
+++ b/src/library/scala/collection/generic/IsMap.scala
@@ -15,7 +15,6 @@ package generic
 
 import IsMap.Tupled
 import scala.collection.immutable.{IntMap, LongMap}
-import scala.language.higherKinds
 
 /**
   * Type class witnessing that a collection type `Repr`

--- a/src/library/scala/collection/generic/IsSeq.scala
+++ b/src/library/scala/collection/generic/IsSeq.scala
@@ -40,7 +40,6 @@ trait IsSeq[Repr] extends IsIterable[Repr] {
 }
 
 object IsSeq {
-  import scala.language.higherKinds
 
   private val seqOpsIsSeqVal: IsSeq[Seq[Any]] =
     new IsSeq[Seq[Any]] {

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -66,7 +66,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     override def incl(elem: K): Set[K] = {
       val originalHash = elem.##
       val improvedHash = improve(originalHash)
-      val newNode = rootNode.updated(elem, null, originalHash, improvedHash, 0, replaceValue = false)
+      val newNode = rootNode.updated(elem, null.asInstanceOf[V], originalHash, improvedHash, 0, replaceValue = false)
       newKeySetOrThis(newNode)
     }
     override def excl(elem: K): Set[K] = newKeySetOrThis(HashMap.this - elem)
@@ -332,7 +332,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     }
 
   override def transform[W](f: (K, V) => W): HashMap[K, W] =
-    newHashMapOrThis(rootNode.transform(f)).asInstanceOf[HashMap[K, W]]
+    newHashMapOrThis(rootNode.transform[Any](f)).asInstanceOf[HashMap[K, W]]
 
   override protected[collection] def filterImpl(pred: ((K, V)) => Boolean, isFlipped: Boolean): HashMap[K, V] = {
     val newRootNode = rootNode.filterImpl(pred, isFlipped)

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -19,7 +19,6 @@ import scala.collection.generic.DefaultSerializable
 import scala.collection.immutable.Map.Map4
 import scala.collection.mutable.{Builder, ReusableBuilder}
 import scala.language.higherKinds
-import scala.util.hashing.MurmurHash3
 
 /** Base type of immutable Maps */
 trait Map[K, +V]

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -18,7 +18,6 @@ import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.generic.DefaultSerializable
 import scala.collection.immutable.Map.Map4
 import scala.collection.mutable.{Builder, ReusableBuilder}
-import scala.language.higherKinds
 
 /** Base type of immutable Maps */
 trait Map[K, +V]

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -78,7 +78,7 @@ private[collection] object RedBlackTree {
   }
 
   def tail[A, B](tree: Tree[A, B]): Tree[A, B] = {
-    def _tail[A, B](tree: Tree[A, B]): Tree[A, B] =
+    def _tail(tree: Tree[A, B]): Tree[A, B] =
       if(tree eq null) throw new NoSuchElementException("empty tree")
       else if(tree.left eq null) tree.right
       else if(isBlackTree(tree.left)) balLeft(tree.key, tree.value, _tail(tree.left), tree.right)
@@ -87,7 +87,7 @@ private[collection] object RedBlackTree {
   }
 
   def init[A, B](tree: Tree[A, B]): Tree[A, B] = {
-    def _init[A, B](tree: Tree[A, B]): Tree[A, B] =
+    def _init(tree: Tree[A, B]): Tree[A, B] =
       if(tree eq null) throw new NoSuchElementException("empty tree")
       else if(tree.right eq null) tree.left
       else if(isBlackTree(tree.right)) balRight(tree.key, tree.value, tree.left, _init(tree.right))

--- a/src/library/scala/collection/immutable/Seq.scala
+++ b/src/library/scala/collection/immutable/Seq.scala
@@ -14,8 +14,6 @@ package scala
 package collection
 package immutable
 
-import scala.language.higherKinds
-
 trait Seq[+A] extends Iterable[A]
                  with collection.Seq[A]
                  with SeqOps[A, Seq, Seq[A]]

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -16,7 +16,6 @@ package immutable
 
 import scala.collection.immutable.Set.Set4
 import scala.collection.mutable.{Builder, ReusableBuilder}
-import scala.language.higherKinds
 
 /** Base trait for immutable set collections */
 trait Set[A] extends Iterable[A]

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -16,8 +16,6 @@ package immutable
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.mutable.Builder
-import scala.language.higherKinds
-
 
 /** An immutable map whose key-value pairs are sorted according to an [[scala.math.Ordering]] on the keys.
   *

--- a/src/library/scala/collection/immutable/SortedSet.scala
+++ b/src/library/scala/collection/immutable/SortedSet.scala
@@ -14,8 +14,6 @@ package scala
 package collection
 package immutable
 
-import scala.language.higherKinds
-
 /** Base trait for sorted sets */
 trait SortedSet[A]
   extends Set[A]

--- a/src/library/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -14,8 +14,6 @@ package scala
 package collection
 package immutable
 
-import scala.language.higherKinds
-
 /**
   * Trait that overrides operations to take advantage of strict builders.
   */

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -18,7 +18,6 @@ import scala.collection.Stepper.EfficientSplit
 import scala.collection.generic.DefaultSerializable
 import scala.collection.immutable.{RedBlackTree => RB}
 import scala.collection.mutable.ReusableBuilder
-import scala.util.hashing.MurmurHash3
 
 /** An immutable SortedMap whose values are stored in a red-black tree.
   *

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -1075,7 +1075,7 @@ private[immutable] trait VectorPointer[+T] {
 
     // STUFF BELOW USED BY APPEND / UPDATE
 
-    private[immutable] final def nullSlotAndCopy[T <: AnyRef](array: Array[Array[T]], index: Int): Array[T] = {
+    private[immutable] final def nullSlotAndCopy[A <: AnyRef](array: Array[Array[A]], index: Int): Array[A] = {
       val x = array(index)
       array(index) = null
       x.clone()
@@ -1225,8 +1225,8 @@ private[immutable] trait VectorPointer[+T] {
 
     // USED IN DROP
 
-    private[immutable] final def copyRange[T <: AnyRef](array: Array[T], oldLeft: Int, newLeft: Int) = {
-      val elems = java.lang.reflect.Array.newInstance(array.getClass.getComponentType, 32).asInstanceOf[Array[T]]
+    private[immutable] final def copyRange[A <: AnyRef](array: Array[A], oldLeft: Int, newLeft: Int): Array[A] = {
+      val elems = java.lang.reflect.Array.newInstance(array.getClass.getComponentType, 32).asInstanceOf[Array[A]]
       java.lang.System.arraycopy(array, oldLeft, elems, newLeft, 32 - Math.max(newLeft, oldLeft))
       elems
     }

--- a/src/library/scala/collection/mutable/Buffer.scala
+++ b/src/library/scala/collection/mutable/Buffer.scala
@@ -227,5 +227,4 @@ object Buffer extends SeqFactory.Delegate[Buffer](ArrayBuffer)
 object IndexedBuffer extends SeqFactory.Delegate[IndexedBuffer](ArrayBuffer)
 
 /** Explicit instantiation of the `Buffer` trait to reduce class file size in subclasses. */
-@SerialVersionUID(3L)
 abstract class AbstractBuffer[A] extends AbstractSeq[A] with Buffer[A]

--- a/src/library/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/src/library/scala/collection/mutable/CollisionProofHashMap.scala
@@ -13,7 +13,7 @@
 package scala.collection
 package mutable
 
-import scala.annotation.{implicitNotFound, tailrec}
+import scala.annotation.{implicitNotFound, tailrec, unused}
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.generic.DefaultSerializationProxy
 import scala.runtime.Statics
@@ -181,7 +181,7 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
   // returns the old value or Statics.pfMarker if not found
   private[this] def remove0(elem: K) : Any = {
     val hash = computeHash(elem)
-    var idx = index(hash)
+    val idx = index(hash)
     table(idx) match {
       case null => Statics.pfMarker
       case t: RBNode =>
@@ -462,7 +462,7 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
   @`inline` private[this] def isRed(node: RBNode) = (node ne null) && node.red
   @`inline` private[this] def isBlack(node: RBNode) = (node eq null) || !node.red
 
-  @`inline` private[this] def compare(key: K, hash: Int, node: LLNode): Int = {
+  @unused @`inline` private[this] def compare(key: K, hash: Int, node: LLNode): Int = {
     val i = hash - node.hash
     if(i != 0) i else ordering.compare(key, node.key)
   }
@@ -769,7 +769,7 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
     def newBuilder: Builder[(K, V), CollisionProofHashMap[K, V]] = CollisionProofHashMap.newBuilder(tableLength, loadFactor)(ordering)
   }
 
-  @`inline` private def compare[K, V](key: K, hash: Int, node: LLNode[K, V])(implicit ord: Ordering[K]): Int = {
+  @unused @`inline` private def compare[K, V](key: K, hash: Int, node: LLNode[K, V])(implicit ord: Ordering[K]): Int = {
     val i = hash - node.hash
     if(i != 0) i else ord.compare(key, node.key)
   }
@@ -841,7 +841,7 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
     }
   }
 
-  private final class RBNodesIterator[A, B](tree: RBNode[A, B])(implicit ord: Ordering[A]) extends AbstractIterator[RBNode[A, B]] {
+  private final class RBNodesIterator[A, B](tree: RBNode[A, B])(implicit @unused ord: Ordering[A]) extends AbstractIterator[RBNode[A, B]] {
     private[this] var nextNode: RBNode[A, B] = if(tree eq null) null else minNodeNonNull(tree)
 
     def hasNext: Boolean = nextNode ne null

--- a/src/library/scala/collection/mutable/IndexedSeq.scala
+++ b/src/library/scala/collection/mutable/IndexedSeq.scala
@@ -13,8 +13,6 @@
 package scala.collection
 package mutable
 
-import scala.language.higherKinds
-
 trait IndexedSeq[T] extends Seq[T]
   with scala.collection.IndexedSeq[T]
   with IndexedSeqOps[T, IndexedSeq, IndexedSeq[T]]

--- a/src/library/scala/collection/mutable/Iterable.scala
+++ b/src/library/scala/collection/mutable/Iterable.scala
@@ -31,5 +31,4 @@ trait Iterable[A]
 object Iterable extends IterableFactory.Delegate[Iterable](ArrayBuffer)
 
 /** Explicit instantiation of the `Iterable` trait to reduce class file size in subclasses. */
-@SerialVersionUID(3L)
 abstract class AbstractIterable[A] extends scala.collection.AbstractIterable[A] with Iterable[A]

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -14,8 +14,6 @@ package scala
 package collection
 package mutable
 
-import scala.language.higherKinds
-
 /** Base type of mutable Maps */
 trait Map[K, V]
   extends Iterable[(K, V)]

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -262,5 +262,4 @@ object Map extends MapFactory.Delegate[Map](HashMap) {
 }
 
 /** Explicit instantiation of the `Map` trait to reduce class file size in subclasses. */
-@SerialVersionUID(3L)
 abstract class AbstractMap[K, V] extends scala.collection.AbstractMap[K, V] with Map[K, V]

--- a/src/library/scala/collection/mutable/Seq.scala
+++ b/src/library/scala/collection/mutable/Seq.scala
@@ -64,5 +64,4 @@ trait SeqOps[A, +CC[_], +C <: AnyRef]
 }
 
 /** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses. */
-@SerialVersionUID(3L)
 abstract class AbstractSeq[A] extends scala.collection.AbstractSeq[A] with Seq[A]

--- a/src/library/scala/collection/mutable/Seq.scala
+++ b/src/library/scala/collection/mutable/Seq.scala
@@ -13,7 +13,6 @@
 package scala.collection.mutable
 
 import scala.collection.{IterableFactoryDefaults, SeqFactory}
-import scala.language.higherKinds
 
 trait Seq[A]
   extends Iterable[A]

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -114,5 +114,4 @@ object Set extends IterableFactory.Delegate[Set](HashSet)
 
 
 /** Explicit instantiation of the `Set` trait to reduce class file size in subclasses. */
-@SerialVersionUID(3L)
 abstract class AbstractSet[A] extends scala.collection.AbstractSet[A] with Set[A]

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -13,7 +13,6 @@
 package scala.collection.mutable
 
 import scala.collection.{IterableFactory, IterableFactoryDefaults, IterableOps}
-import scala.language.higherKinds
 
 /** Base trait for mutable sets */
 trait Set[A]

--- a/src/library/scala/collection/mutable/SortedMap.scala
+++ b/src/library/scala/collection/mutable/SortedMap.scala
@@ -14,7 +14,6 @@ package scala
 package collection.mutable
 
 import scala.collection.{SortedMapFactory, SortedMapFactoryDefaults}
-import scala.language.higherKinds
 
 /**
   * Base type for mutable sorted map collections

--- a/src/library/scala/collection/mutable/SortedSet.scala
+++ b/src/library/scala/collection/mutable/SortedSet.scala
@@ -14,8 +14,6 @@ package scala
 package collection
 package mutable
 
-import scala.language.higherKinds
-
 /**
   * Base type for mutable sorted set collections
   */

--- a/src/library/scala/collection/package.scala
+++ b/src/library/scala/collection/package.scala
@@ -12,8 +12,6 @@
 
 package scala
 
-import scala.language.higherKinds
-
 package object collection {
   @deprecated("Use Iterable instead of Traversable", "2.13.0")
   type Traversable[+X] = Iterable[X]

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -12,7 +12,6 @@
 
 package scala.concurrent
 
-import scala.language.higherKinds
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.LockSupport
 

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -13,7 +13,6 @@
 package scala.concurrent
 
 import scala.language.higherKinds
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.LockSupport
 

--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -76,7 +76,7 @@ object Duration {
   // "ms milli millisecond" -> List("ms", "milli", "millis", "millisecond", "milliseconds")
   private[this] def words(s: String) = (s.trim split "\\s+").toList
   private[this] def expandLabels(labels: String): List[String] = {
-    val hd :: rest = words(labels)
+    val hd :: rest = words(labels): @unchecked
     hd :: rest.flatMap(s => List(s, s + "s"))
   }
   private[this] val timeUnitLabels = List(

--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -15,8 +15,6 @@ package math
 
 import java.util.Comparator
 
-import scala.language.higherKinds
-
 /** A trait for representing equivalence relations.  It is important to
  *  distinguish between a type that can be compared for equality or
  *  equivalence and a representation of equivalence on some type. This

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -15,7 +15,7 @@ package math
 
 import java.util.Comparator
 
-import scala.language.{higherKinds, implicitConversions}
+import scala.language.implicitConversions
 
 /** Ordering is a trait whose instances each represent a strategy for sorting
   * instances of a type.

--- a/src/partest/scala/tools/partest/AsmNode.scala
+++ b/src/partest/scala/tools/partest/AsmNode.scala
@@ -12,7 +12,7 @@
 
 package scala.tools.partest
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.tools.asm
 import asm._
 import asm.tree._

--- a/src/partest/scala/tools/partest/BytecodeTest.scala
+++ b/src/partest/scala/tools/partest/BytecodeTest.scala
@@ -12,7 +12,7 @@
 
 package scala.tools.partest
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.tools.asm.{ClassReader, ClassWriter}
 import scala.tools.asm.tree._
 import java.io.{InputStream, File => JFile}

--- a/src/partest/scala/tools/partest/CompilerTest.scala
+++ b/src/partest/scala/tools/partest/CompilerTest.scala
@@ -56,7 +56,7 @@ abstract class CompilerTest extends DirectTest {
   }
 
   class SymsInPackage(pkgName: String) {
-    def pkg     = rootMirror.getPackage(TermName(pkgName))
+    def pkg     = rootMirror.getPackage(pkgName)
     def classes = allMembers(pkg) filter (_.isClass)
     def modules = allMembers(pkg) filter (_.isModule)
     def symbols = classes ++ terms filterNot (_ eq NoSymbol)

--- a/src/partest/scala/tools/partest/MemoryTest.scala
+++ b/src/partest/scala/tools/partest/MemoryTest.scala
@@ -21,7 +21,7 @@ abstract class MemoryTest {
     val rt = Runtime.getRuntime()
     def memUsage() = {
       import java.lang.management._
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val pools = ManagementFactory.getMemoryPoolMXBeans.asScala
       pools.map(_.getUsage.getUsed).sum / 1000000d
     }

--- a/src/partest/scala/tools/partest/instrumented/Instrumentation.scala
+++ b/src/partest/scala/tools/partest/instrumented/Instrumentation.scala
@@ -12,7 +12,7 @@
 
 package scala.tools.partest.instrumented
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 case class MethodCallTrace(className: String, methodName: String, methodDescriptor: String) {
   override def toString(): String = className + "." + methodName + methodDescriptor

--- a/src/partest/scala/tools/partest/nest/FileManager.scala
+++ b/src/partest/scala/tools/partest/nest/FileManager.scala
@@ -84,7 +84,7 @@ object FileManager {
    *  @return the unified diff of the `origLines` and `newLines` or the empty string if they're equal
    */
   def compareContents(original: Seq[String], revised: Seq[String], originalName: String = "a", revisedName: String = "b"): String = {
-    import collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     val diff = difflib.DiffUtils.diff(original.asJava, revised.asJava)
     if (diff.getDeltas.isEmpty) ""
@@ -113,9 +113,8 @@ class FileManager(val testClassLoader: URLClassLoader) {
 
   lazy val testClassPath = testClassLoader.getURLs().map(url => Path(new File(url.toURI))).toList
 
-  def this(testClassPath: List[Path]) {
+  def this(testClassPath: List[Path]) =
     this(new URLClassLoader(testClassPath.toArray map (_.toURI.toURL)))
-  }
 
   def distKind = {
     val p = libraryUnderTest.getAbsolutePath

--- a/src/partest/scala/tools/partest/package.scala
+++ b/src/partest/scala/tools/partest/package.scala
@@ -15,6 +15,7 @@ package scala.tools
 import java.util.concurrent.{Callable, ExecutorService}
 
 import scala.concurrent.duration.Duration
+import scala.jdk.CollectionConverters._
 import scala.tools.nsc.util.Exceptional
 
 package object partest {
@@ -60,8 +61,6 @@ package object partest {
   }
 
   implicit class FileOps(val f: File) {
-    import scala.collection.JavaConverters._
-
     private def sf = SFile(f)
 
     // e.g. pos/t1234
@@ -176,7 +175,6 @@ package object partest {
   }
 
   def vmArgString = {
-    import scala.collection.JavaConverters._
     val javaVmArguments =
       java.lang.management.ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toList
     javaVmArguments.mkString(
@@ -187,7 +185,6 @@ package object partest {
   }
 
   def allPropertiesString = {
-    import scala.collection.JavaConverters._
     System.getProperties.asScala.toList.sorted map { case (k, v) => "%s -> %s\n".format(k, v) } mkString ""
   }
 

--- a/src/reflect/scala/reflect/api/Internals.scala
+++ b/src/reflect/scala/reflect/api/Internals.scala
@@ -15,7 +15,6 @@ package reflect
 package api
 
 import scala.language.implicitConversions
-import scala.language.higherKinds
 
 /**
  *  <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>

--- a/src/reflect/scala/reflect/api/Names.scala
+++ b/src/reflect/scala/reflect/api/Names.scala
@@ -14,8 +14,6 @@ package scala
 package reflect
 package api
 
-import scala.language.implicitConversions
-
 /**
  * <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>
  *

--- a/src/reflect/scala/reflect/api/TypeTags.scala
+++ b/src/reflect/scala/reflect/api/TypeTags.scala
@@ -318,6 +318,7 @@ trait TypeTags { self: Universe =>
   // This class only exists to silence MIMA complaining about a binary incompatibility.
   // Only the top-level class (api.PredefTypeCreator) should be used.
   @deprecated("This class only exists to silence MIMA complaining about a binary incompatibility.", since="forever")
+  @annotation.unused
   private class PredefTypeCreator[T](copyIn: Universe => Universe#TypeTag[T]) extends TypeCreator {
     def apply[U <: Universe with Singleton](m: scala.reflect.api.Mirror[U]): U # Type = {
       copyIn(m.universe).asInstanceOf[U # TypeTag[T]].tpe

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -744,7 +744,7 @@ trait Definitions extends api.StandardDefinitions {
       pt match {
         case oap: OverloadedArgProto => (oap.hofParamTypes.head, WildcardType)
         case _                       =>
-          val arg :: res :: Nil = pt.baseType(PartialFunctionClass).typeArgs
+          val arg :: res :: Nil = pt.baseType(PartialFunctionClass).typeArgs: @unchecked
           (arg, res)
       }
 

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1736,7 +1736,7 @@ trait Definitions extends api.StandardDefinitions {
         }
       }
 
-      lazy val Scala_Java8_CompatPackage = rootMirror.getPackageIfDefined(TermName("scala.runtime.java8"))
+      lazy val Scala_Java8_CompatPackage = rootMirror.getPackageIfDefined("scala.runtime.java8")
     }
   }
 }

--- a/src/reflect/scala/reflect/internal/Depth.scala
+++ b/src/reflect/scala/reflect/internal/Depth.scala
@@ -31,6 +31,7 @@ final class Depth private (val depth: Int) extends AnyVal with Ordered[Depth] {
   override def toString = s"Depth($depth)"
 }
 
+@FunctionalInterface
 trait DepthFunction[A] { def apply(a: A): Depth }
 
 object Depth {

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -14,8 +14,6 @@ package scala
 package reflect
 package internal
 
-import scala.language.implicitConversions
-
 import scala.io.Codec
 
 trait Names extends api.Names {

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -305,7 +305,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
     }
 
     protected def printSuper(tree: Super, resultName: => String, checkSymbol: Boolean = true) = {
-      val Super(This(qual), mix) = tree
+      val Super(This(qual), mix) = tree: @unchecked
       if (qual.nonEmpty || (checkSymbol && tree.symbol != NoSymbol)) print(resultName + ".")
       print("super")
       if (mix.nonEmpty) print(s"[$mix]")
@@ -885,7 +885,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
             }
 
           if (printedParents.nonEmpty) {
-            val (clParent :: traits) = printedParents
+            val (clParent :: traits) = printedParents: @unchecked
             print(clParent)
 
             val constrArgss = ap match {

--- a/src/reflect/scala/reflect/internal/ReificationSupport.scala
+++ b/src/reflect/scala/reflect/internal/ReificationSupport.scala
@@ -527,7 +527,7 @@ trait ReificationSupport { self: SymbolTable =>
 
     object SyntacticFunction extends SyntacticFunctionExtractor {
       def apply(params: List[Tree], body: Tree): Function = {
-        val params0 :: Nil = mkParam(params :: Nil, PARAM)
+        val params0 :: Nil = mkParam(params :: Nil, PARAM): @unchecked
         require(params0.forall { _.rhs.isEmpty }, "anonymous functions don't support parameters with default values")
         Function(params0, body)
       }

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -14,8 +14,6 @@ package scala
 package reflect
 package internal
 
-import scala.language.implicitConversions
-
 import java.security.MessageDigest
 import Chars.isOperatorPart
 import scala.annotation.switch

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -180,7 +180,7 @@ abstract class TreeGen {
   def mkUnattributedRef(sym: Symbol): RefTree = mkUnattributedRef(sym.fullNameAsName('.'))
 
   def mkUnattributedRef(fullName: Name): RefTree = {
-    val hd :: tl = nme.segments(fullName.toString, assumeTerm = fullName.isTermName)
+    val hd :: tl = nme.segments(fullName.toString, assumeTerm = fullName.isTermName): @unchecked
     tl.foldLeft(Ident(hd): RefTree)(Select(_,_))
   }
 

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -482,7 +482,7 @@ trait Trees extends api.Trees {
   }
 
   case class ImportSelector(name: Name, namePos: Int, rename: Name, renamePos: Int) extends ImportSelectorApi {
-    assert(name == nme.WILDCARD && rename == null || rename != null)
+    assert(name == nme.WILDCARD && rename == null || rename != null, s"Bad import selector $name => $rename")
     def isWildcard = name == nme.WILDCARD && rename == null
     def isMask = name != nme.WILDCARD && rename == nme.WILDCARD
     def isSpecific = !isWildcard
@@ -857,7 +857,7 @@ trait Trees extends api.Trees {
 
   case class Literal(value: Constant)
         extends TermTree with LiteralApi {
-    assert(value ne null)
+    assert(value ne null, "null value for literal")
     override def transform(transformer: Transformer): Tree =
       transformer.treeCopy.Literal(this, value)
     override def traverse(traverser: Traverser): Unit = {

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2533,10 +2533,9 @@ trait Types
     }
 
     // TODO: test case that is compiled in a specific order and in different runs
-    private[Types] final def defineNormalized: Unit = {
-      if (normalized eq null) // In runtime reflection, this null check is part of double-checked locking
-        normalized = normalizeImpl
-    }
+    private[Types] final def defineNormalized() : Unit =
+      // In runtime reflection, this null check is part of double-checked locking
+      if (normalized eq null) normalized = normalizeImpl
 
     override def isGround = (
          sym.isPackageClass
@@ -2662,7 +2661,7 @@ trait Types
        * Therefore, if op is left associative, anything on its right
        * needs to be parenthesized if it's an infix type, and vice versa. */
       // we should only get here after `isShowInfixType` says we have 2 args
-      val l :: r :: Nil = args
+      val l :: r :: Nil = args: @unchecked
 
       val isRightAssoc = typeSymbol.decodedName endsWith ":"
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -21,7 +21,7 @@ import scala.ref.WeakReference
 import mutable.{ListBuffer, LinkedHashSet}
 import Flags._
 import scala.util.control.ControlThrowable
-import scala.annotation.tailrec
+import scala.annotation.{tailrec, unused}
 import util.{Statistics, StatisticsStatics}
 import util.ThreeValues._
 import Variance._
@@ -98,9 +98,9 @@ trait Types
   import statistics._
 
   private[this] var explainSwitch = false
-  private final val emptySymbolSet = immutable.Set.empty[Symbol]
+  @unused private final val emptySymbolSet = immutable.Set.empty[Symbol]
 
-  private final val breakCycles = settings.breakCycles.value
+  @unused private final val breakCycles = settings.breakCycles.value
   /** In case anyone wants to turn on type parameter bounds being used
    *  to seed type constraints.
    */
@@ -2718,7 +2718,7 @@ trait Types
     )
     // Suppressing case class copy method which risks subverting our single point of creation.
     @deprecated("Suppressing case class copy method", since="forever")
-    private def copy = null
+    @unused private def copy = null
     override def kind = "TypeRef"
   }
 

--- a/src/reflect/scala/reflect/internal/Variance.scala
+++ b/src/reflect/scala/reflect/internal/Variance.scala
@@ -92,6 +92,7 @@ object Variance {
   val Contravariant = new Variance(-1)
   val Invariant     = new Variance(0)
 
+  @FunctionalInterface
   trait Extractor[A]     { def apply(x: A): Variance }
   trait Extractor2[A, B] { def apply(x: A, y: B): Variance }
 

--- a/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
@@ -214,9 +214,9 @@ trait FindMembers {
     }
   }
 
-  private[reflect] final class FindMembers(tpe: Type, excludedFlags: Long, requiredFlags: Long)
+  private[reflect] final class FindMembers(tpe0: Type, excludedFlags0: Long, requiredFlags0: Long)
     extends FindMemberBase[Scope]() {
-    init(tpe, nme.ANYname, excludedFlags, requiredFlags)
+    init(tpe0, nme.ANYname, excludedFlags0, requiredFlags0)
 
     private[this] var _membersScope: Scope   = null
     private def membersScope: Scope = {
@@ -325,8 +325,8 @@ trait FindMembers {
     }
   }
 
-  private[scala] final class HasMember(tpe: Type, name: Name, excludedFlags: Long, requiredFlags: Long) extends FindMemberBase[Boolean] {
-    init(tpe, name, excludedFlags, requiredFlags)
+  private[scala] final class HasMember(tpe0: Type, name0: Name, excludedFlags0: Long, requiredFlags0: Long) extends FindMemberBase[Boolean] {
+    init(tpe0, name0, excludedFlags0, requiredFlags0)
     private[this] var _result = false
     override protected def result: Boolean = _result
 

--- a/src/reflect/scala/reflect/internal/util/ChromeTrace.scala
+++ b/src/reflect/scala/reflect/internal/util/ChromeTrace.scala
@@ -13,8 +13,7 @@
 package scala.reflect.internal.util
 
 import java.io.Closeable
-import java.nio.file.{Files, Path}
-import java.util
+import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable

--- a/src/reflect/scala/reflect/internal/util/SourceFile.scala
+++ b/src/reflect/scala/reflect/internal/util/SourceFile.scala
@@ -13,8 +13,7 @@
 package scala
 package reflect.internal.util
 
-import scala.reflect.io.{ AbstractFile, VirtualFile }
-import scala.collection.mutable.ArrayBuffer
+import scala.reflect.io.{AbstractFile, VirtualFile}
 import scala.annotation.tailrec
 import java.util.regex.Pattern
 import java.io.IOException

--- a/src/reflect/scala/reflect/internal/util/Statistics.scala
+++ b/src/reflect/scala/reflect/internal/util/Statistics.scala
@@ -276,7 +276,7 @@ quant)
     def pop(prev: TimerSnapshot) = {
       val (nanos0, start) = prev
       val duration = System.nanoTime() - start
-      val (topTimer, nestedNanos) :: rest = elems
+      val (topTimer, nestedNanos) :: rest = elems: @unchecked
       topTimer.totalNanos.addAndGet(nanos0 + duration)
       topTimer.specificNanos += duration - nestedNanos
       topTimer.timings.incrementAndGet()

--- a/src/reflect/scala/reflect/internal/util/StringOps.scala
+++ b/src/reflect/scala/reflect/internal/util/StringOps.scala
@@ -28,7 +28,7 @@ trait StringOps {
     case w :: Nil => w
     case _        =>
       def lcp(ss: List[String]): String = {
-        val w :: ws = ss
+        val w :: ws = ss: @unchecked
         if (w == "") ""
         else if (ws exists (s => s == "" || (s charAt 0) != (w charAt 0))) ""
         else w.substring(0, 1) + lcp(ss map (_ substring 1))

--- a/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
+++ b/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
@@ -285,8 +285,9 @@ final class WeakHashSet[A <: AnyRef](val initialCapacity: Int, val loadFactor: D
   override def isEmpty: Boolean = size == 0
   override def foreach[U](f: A => U): Unit = iterator foreach f
 
-  // It has the `()` because iterator runs `removeStaleEntries()`
-  override def toList(): List[A] = iterator.toList
+  // It had the `()` because iterator runs `removeStaleEntries()`.
+  // Instead of just using a different name, keep the name and lose the parens.
+  override def toList: List[A] = iterator.toList
 
   // Iterator over all the elements in this set in no particular order
   override def iterator: Iterator[A] = {

--- a/src/reflect/scala/reflect/macros/Universe.scala
+++ b/src/reflect/scala/reflect/macros/Universe.scala
@@ -15,7 +15,6 @@ package reflect
 package macros
 
 import scala.language.implicitConversions
-import scala.language.higherKinds
 
 /**
  * <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -309,7 +309,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
       val isDerivedValueClass = symbol.isDerivedValueClass
       lazy val boxer = runtimeClass(symbol.toType).getDeclaredConstructors().head
       lazy val unboxer = {
-        val fields @ (field :: _) = symbol.toType.decls.collect{ case ts: TermSymbol if ts.isParamAccessor && ts.isMethod => ts }.toList
+        val fields @ (field :: _) = symbol.toType.decls.collect{ case ts: TermSymbol if ts.isParamAccessor && ts.isMethod => ts }.toList: @unchecked
         assert(fields.lengthIs == 1, s"$symbol: $fields")
         runtimeClass(symbol.asClass).getDeclaredMethod(field.name.toString)
       }

--- a/src/repl-frontend/scala/tools/nsc/Interpreter.scala
+++ b/src/repl-frontend/scala/tools/nsc/Interpreter.scala
@@ -92,6 +92,7 @@ class InterpreterLoop {
   //   - https://github.com/sbt/zinc/blob/1.0/internal/compiler-bridge/src/main/scala/xsbt/InteractiveConsoleInterface.scala
   //   - https://github.com/sbt/zinc/blob/1.0/internal/compiler-bridge/src/main/scala/xsbt/ConsoleInterface.scala
   @deprecated("Only here to ensure we don't break the sbt interface.", "2.13.0-M2")
+  @annotation.unused
   private def __SbtConsoleInterface(compilerSettings: Settings, interpreterSettings: Settings, bootClasspathString: String, classpathString: String, initialCommands: String, cleanupCommands: String, loader: ClassLoader, bindNames: Array[String], bindValues: Array[Any]): Unit = {
     import scala.tools.nsc.interpreter.InteractiveReader
     import scala.tools.nsc.reporters.Reporter

--- a/src/repl-frontend/scala/tools/nsc/interpreter/jline/FileBackedHistory.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/jline/FileBackedHistory.scala
@@ -18,7 +18,7 @@ import java.nio.file.{FileSystems, Files, Path}
 
 import _root_.jline.console.history.PersistentHistory
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.io.Codec
 import scala.reflect.internal.util.OwnerOnlyChmod
 import scala.util.control.NonFatal

--- a/src/repl-frontend/scala/tools/nsc/interpreter/jline/JLineHistory.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/jline/JLineHistory.scala
@@ -62,7 +62,7 @@ object JLineHistory {
 
     override def toString = "History(size = " + size + ", index = " + index + ")"
 
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     override def asStrings(from: Int, to: Int): List[String] =
       entries(from).asScala.take(to - from).map(_.value.toString).toList

--- a/src/repl-frontend/scala/tools/nsc/interpreter/jline/JLineReader.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/jline/JLineReader.scala
@@ -102,24 +102,26 @@ private class JLineConsoleReader(val isAcross: Boolean) extends jconsole.Console
   }
 
   override def printColumns(items: ju.Collection[_ <: CharSequence]): Unit = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     printColumns_(items.asScala.toList map (_.toString))
   }
 
-  private def printColumns_(items: List[String]): Unit = if (items exists (_ != "")) {
-    val grouped = tabulate(items)
-    var linesLeft = if (isPaginationEnabled()) height - 1 else Int.MaxValue
-    grouped foreach { xs =>
-      println(xs.mkString)
-      linesLeft -= 1
-      if (linesLeft <= 0) {
-        linesLeft = emulateMore()
-        if (linesLeft < 0)
-          return
-      }
+  private def printColumns_(items: List[String]): Unit =
+    if (items.exists(_ != "")) {
+      val grouped = tabulate(items)
+      var linesLeft = if (isPaginationEnabled()) height - 1 else Int.MaxValue
+      def doLine(groups: Seq[Seq[String]]): Unit =
+        if (!groups.isEmpty) {
+          println(groups.head.mkString)
+          linesLeft -= 1
+          if (linesLeft <= 0)
+            linesLeft = emulateMore()
+          if (linesLeft >= 0)
+            doLine(groups.tail)
+        }
+      doLine(grouped)
     }
-  }
 
   def readOneKey(prompt: String) = {
     this.print(prompt)

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -333,11 +333,19 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
       intp.lastWarnings foreach { case (pos, msg) => intp.reporter.warning(pos, msg) }
   }
 
-  private def javapCommand(line: String): Result =
-    Javap(intp)(words(line): _*) foreach { res =>
-      if (res.isError) return s"${res.value}"
-      else res.show()
-    }
+  private def javapCommand(line: String): Result = {
+    def handle(results: List[Javap.JpResult]): Result =
+      results match {
+        case Nil => ()
+        case res :: rest =>
+          if (res.isError) res.value.toString
+          else {
+            res.show()
+            handle(rest)
+          }
+      }
+    handle(Javap(intp)(words(line): _*))
+  }
 
   private def pathToPhaseWrapper = intp.originalPath("$r") + ".phased.atCurrent"
 

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -21,25 +21,18 @@ import java.util.concurrent.TimeUnit
 import scala.PartialFunction.cond
 import scala.Predef.{println => _, _}
 import scala.annotation.tailrec
+import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
-import scala.util.Properties.jdkHome
 import scala.reflect.classTag
-import scala.reflect.internal.util.ScalaClassLoader._
 import scala.reflect.internal.util.{BatchSourceFile, NoPosition}
 import scala.reflect.io.{AbstractFile, Directory, File, Path}
 import scala.tools.asm.ClassReader
-import scala.tools.util.PathResolver
 import scala.tools.nsc.Settings
 import scala.tools.nsc.util.{stackTraceString, stringFromStream}
 import scala.tools.nsc.interpreter.{AbstractOrMissingHandler, Repl, IMain, Phased, jline}
 import scala.tools.nsc.interpreter.Results.{Error, Incomplete, Success}
 import scala.tools.nsc.interpreter.StdReplTags._
-import scala.tools.nsc.util.Exceptional.rootCause
 import scala.util.chaining._
-import scala.util.control.ControlThrowable
-import scala.jdk.CollectionConverters._
-
-
 
 /** The Scala interactive shell. This part provides the user interface,
   * with evaluation and auto-complete handled by IMain.

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/JavapClass.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/JavapClass.scala
@@ -447,8 +447,8 @@ class JavapTask(val loader: ScalaClassLoader, intp: Repl) extends JavapTool {
   import java.io.CharArrayWriter
   import java.util.Locale
   import java.util.concurrent.ConcurrentLinkedQueue
-  import scala.collection.JavaConverters._
-  import scala.collection.generic.Clearable
+  import scala.jdk.CollectionConverters._
+  import scala.collection.mutable.Clearable
   import JavapTool._
   import Javap.{filterLines, showable}
 

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Scripted.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Scripted.scala
@@ -18,7 +18,7 @@ import java.util.Arrays.asList
 import javax.script._
 
 import scala.beans.BeanProperty
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect.internal.util.Position
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter.Results.Incomplete

--- a/src/repl/scala/tools/nsc/interpreter/Imports.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Imports.scala
@@ -39,7 +39,7 @@ object `{{`
 trait Imports {
   self: IMain =>
 
-  import global.{Type, Tree, Import, ImportSelector, Select, Ident, TermName, Symbol, TermSymbol, NoType, Name, enteringPickler}
+  import global.{Tree, Import, ImportSelector, Select, Ident, TermName, Symbol, NoType, Name, enteringPickler}
   import global.nme.{ INTERPRETER_IMPORT_WRAPPER => iw, INTERPRETER_IMPORT_LEVEL_UP }
   import global.definitions.{ ScalaPackage, JavaLangPackage, PredefModule }
   import memberHandlers._

--- a/src/repl/scala/tools/nsc/interpreter/Imports.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Imports.scala
@@ -39,14 +39,14 @@ object `{{`
 trait Imports {
   self: IMain =>
 
-  import global.{Type, Tree, Import, ImportSelector, Select, Ident, newTermName, Symbol, TermSymbol, NoType, Name, enteringPickler}
+  import global.{Type, Tree, Import, ImportSelector, Select, Ident, TermName, Symbol, TermSymbol, NoType, Name, enteringPickler}
   import global.nme.{ INTERPRETER_IMPORT_WRAPPER => iw, INTERPRETER_IMPORT_LEVEL_UP }
   import global.definitions.{ ScalaPackage, JavaLangPackage, PredefModule }
   import memberHandlers._
 
   /** Synthetic import handlers for the language defined imports. */
   private def makeWildcardImportHandler(sym: Symbol): ImportHandler = {
-    val hd :: tl = sym.fullName.split('.').toList map newTermName
+    val hd :: tl = sym.fullName.split('.').toList.map(TermName(_)): @unchecked
     val tree = Import(
       tl.foldLeft(Ident(hd): Tree)((x, y) => Select(x, y)),
       ImportSelector.wildList

--- a/src/repl/scala/tools/nsc/interpreter/Naming.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Naming.scala
@@ -67,8 +67,8 @@ object Naming {
 
     // Prefixes used in repl machinery.  Default to $line, $read, etc.
     def line = propOr("line")
-    def read = "$read"
-    def iw = "$iw"
+    def read = "$" + "read"
+    def iw = "$" + "iw"
     def eval = propOr("eval")
     def print = propOr("print")
     def result = propOr("result")

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
@@ -13,10 +13,9 @@
 package scala.tools.nsc.interpreter
 
 import scala.reflect.internal.util.{Position, RangePosition, StringOps}
-import scala.reflect.io.AbstractFile
 import scala.tools.nsc.backend.JavaPlatform
 import scala.tools.nsc.util.ClassPath
-import scala.tools.nsc.{CloseableRegistry, Settings, interactive}
+import scala.tools.nsc.{Settings, interactive}
 import scala.tools.nsc.reporters.StoreReporter
 import scala.tools.nsc.classpath._
 import scala.tools.nsc.interpreter.Results.{Error, Result}

--- a/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -15,7 +15,6 @@ package interpreter
 
 import scala.tools.nsc.classpath.{AggregateClassPath, ClassPathFactory}
 import scala.tools.nsc.util.ClassPath
-import typechecker.Analyzer
 
 trait ReplGlobal extends Global {
 

--- a/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -13,6 +13,7 @@
 package scala.tools.nsc
 package interpreter
 
+import scala.reflect.internal.util.AbstractFileClassLoader
 import scala.tools.nsc.classpath.{AggregateClassPath, ClassPathFactory}
 import scala.tools.nsc.util.ClassPath
 
@@ -28,7 +29,7 @@ trait ReplGlobal extends Global {
     val loader = super.findMacroClassLoader
     analyzer.macroLogVerbose("macro classloader: initializing from a REPL classloader: %s".format(classPath.asURLs))
     val virtualDirectory = analyzer.globalSettings.outputDirs.getSingleOutput.get
-    new util.AbstractFileClassLoader(virtualDirectory, loader) {}
+    new AbstractFileClassLoader(virtualDirectory, loader) {}
   }
 
   override def optimizerClassPath(base: ClassPath): ClassPath = {

--- a/src/repl/scala/tools/nsc/interpreter/Scripted.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Scripted.scala
@@ -54,7 +54,7 @@ class ScriptedInterpreter(initialSettings: Settings, reporter: ReplReporter, imp
       val newReq = requestFromLine(
         (s"val $$INSTANCE = new ${req.lineRep.readPath}" :: (defines map (d =>
             s"val `$d` = $$INSTANCE${req.accessPath}.`$d`"))).mkString(";")
-      ).right.get
+      ).toOption.get
       newReq.compile
       Right(newReq)
     }

--- a/src/scaladoc/scala/tools/nsc/doc/DocParser.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/DocParser.scala
@@ -68,7 +68,7 @@ object DocParser {
     def raw: String           = docDef.comment.raw
 
     override def toString = (
-      nameChain.init.map(x => if (x.isTypeName) x + "#" else x + ".").mkString + nameChain.last
+      nameChain.init.map(x => if (x.isTypeName) s"$x#" else s"$x.").mkString + nameChain.last
     )
   }
 }

--- a/src/scaladoc/scala/tools/nsc/doc/Uncompilable.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Uncompilable.scala
@@ -51,7 +51,7 @@ trait Uncompilable {
 
     pairs
   }
-  override def toString = pairs.size + " uncompilable symbols:\n" + (
+  override def toString = "" + pairs.size + " uncompilable symbols:\n" + (
     symbols filterNot (_ == NoSymbol) map (x => "  " + x.owner.fullName + " " + x.defString) mkString "\n"
   )
 }

--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlTags.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlTags.scala
@@ -15,8 +15,6 @@ package scala.tools.nsc.doc.html
 import java.io.Writer
 import javax.xml.stream.XMLStreamWriter
 
-import scala.collection.Iterator
-
 // a lightweight replacement for scala-xml
 object HtmlTags {
   def textOf(elems: Elems) = elems.map(_.toText).foldLeft("")(_ + _)

--- a/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ClassFileParser.scala
+++ b/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ClassFileParser.scala
@@ -15,8 +15,6 @@ package scalax
 package rules
 package scalasig
 
-import language.postfixOps
-
 import java.io.IOException
 
 object ByteCode {

--- a/src/testkit/scala/tools/testkit/AssertUtil.scala
+++ b/src/testkit/scala/tools/testkit/AssertUtil.scala
@@ -15,7 +15,6 @@ package scala.tools.testkit
 import org.junit.Assert, Assert._
 import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime.stringOf
-import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.concurrent.{Await, Awaitable}
 import scala.util.chaining._

--- a/src/testkit/scala/tools/testkit/BytecodeTesting.scala
+++ b/src/testkit/scala/tools/testkit/BytecodeTesting.scala
@@ -18,7 +18,7 @@ import org.junit.Assert._
 import scala.collection.JavaConverters._
 import scala.collection.generic.Clearable
 import scala.collection.mutable.ListBuffer
-import scala.reflect.internal.util.{BatchSourceFile, NoPosition}
+import scala.reflect.internal.util.BatchSourceFile
 import scala.reflect.io.VirtualDirectory
 import scala.tools.asm.Opcodes
 import scala.tools.asm.tree.{AbstractInsnNode, ClassNode, MethodNode}

--- a/src/testkit/scala/tools/testkit/BytecodeTesting.scala
+++ b/src/testkit/scala/tools/testkit/BytecodeTesting.scala
@@ -15,9 +15,8 @@ package scala.tools.testkit
 import junit.framework.AssertionFailedError
 import org.junit.Assert._
 
-import scala.collection.JavaConverters._
-import scala.collection.generic.Clearable
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.{Clearable, ListBuffer}
+import scala.jdk.CollectionConverters._
 import scala.reflect.internal.util.BatchSourceFile
 import scala.reflect.io.VirtualDirectory
 import scala.tools.asm.Opcodes

--- a/src/testkit/scala/tools/testkit/VirtualCompilerTesting.scala
+++ b/src/testkit/scala/tools/testkit/VirtualCompilerTesting.scala
@@ -19,7 +19,7 @@ import java.util.Locale
 
 import javax.tools._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect.internal.util.AbstractFileClassLoader
 import scala.reflect.io.{AbstractFile, VirtualDirectory}
 import scala.tools.nsc.classpath.{AggregateClassPath, VirtualDirectoryClassPath}

--- a/test/files/neg/nullary-override.scala
+++ b/test/files/neg/nullary-override.scala
@@ -1,5 +1,10 @@
-// scalac: -Xfatal-warnings -Xlint
+// scalac: -Werror -Xlint
 //
 class A { def x: Int = 3 }
 class B extends A { override def x(): Int = 4 }
 
+class C extends java.lang.CharSequence {
+  def charAt(x$1: Int): Char = ???
+  def length: Int = ???
+  def subSequence(x$1: Int, x$2: Int): CharSequence = ???
+}

--- a/test/files/neg/recursive-method-default.check
+++ b/test/files/neg/recursive-method-default.check
@@ -1,0 +1,27 @@
+recursive-method-default.scala:5: warning: Recursive call used default arguments.
+    rec1(0)     // warn
+        ^
+recursive-method-default.scala:10: warning: Recursive call used default arguments.
+      rec2(0)   // warn
+          ^
+recursive-method-default.scala:13: warning: Recursive call used default arguments.
+      rec2(0)   // warn
+          ^
+recursive-method-default.scala:16: warning: Recursive call used default arguments.
+      rec2(0)   // warn
+          ^
+recursive-method-default.scala:27: warning: Recursive call used default arguments.
+    rec4(0)()   // warn
+           ^
+recursive-method-default.scala:31: warning: Recursive call used default arguments.
+    rec5(0)()   // warn
+           ^
+recursive-method-default.scala:35: warning: Recursive call used default arguments.
+    rec6()(0)   // warn
+        ^
+recursive-method-default.scala:39: warning: Recursive call used default arguments.
+    rec7()(0)   // one warning only
+        ^
+error: No warnings can be incurred under -Werror.
+8 warnings
+1 error

--- a/test/files/neg/recursive-method-default.check
+++ b/test/files/neg/recursive-method-default.check
@@ -1,25 +1,25 @@
-recursive-method-default.scala:5: warning: Recursive call used default arguments.
+recursive-method-default.scala:5: warning: Recursive call used default arguments instead of passing current argument values.
     rec1(0)     // warn
         ^
-recursive-method-default.scala:10: warning: Recursive call used default arguments.
+recursive-method-default.scala:10: warning: Recursive call used default arguments instead of passing current argument values.
       rec2(0)   // warn
           ^
-recursive-method-default.scala:13: warning: Recursive call used default arguments.
+recursive-method-default.scala:13: warning: Recursive call used default arguments instead of passing current argument values.
       rec2(0)   // warn
           ^
-recursive-method-default.scala:16: warning: Recursive call used default arguments.
+recursive-method-default.scala:16: warning: Recursive call used default arguments instead of passing current argument values.
       rec2(0)   // warn
           ^
-recursive-method-default.scala:27: warning: Recursive call used default arguments.
+recursive-method-default.scala:27: warning: Recursive call used default arguments instead of passing current argument values.
     rec4(0)()   // warn
            ^
-recursive-method-default.scala:31: warning: Recursive call used default arguments.
+recursive-method-default.scala:31: warning: Recursive call used default arguments instead of passing current argument values.
     rec5(0)()   // warn
            ^
-recursive-method-default.scala:35: warning: Recursive call used default arguments.
+recursive-method-default.scala:35: warning: Recursive call used default arguments instead of passing current argument values.
     rec6()(0)   // warn
         ^
-recursive-method-default.scala:39: warning: Recursive call used default arguments.
+recursive-method-default.scala:39: warning: Recursive call used default arguments instead of passing current argument values.
     rec7()(0)   // one warning only
         ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/recursive-method-default.scala
+++ b/test/files/neg/recursive-method-default.scala
@@ -1,0 +1,41 @@
+// scalac: -Werror -Xlint:recurse-with-default
+object Test {
+  def rec1(a: Any, b: Any = "".reverse): Any = {
+    rec1(0, 0)  // okay
+    rec1(0)     // warn
+  }
+
+  def rec2(a: Any, b: Any = "".reverse): Any = {
+    def nested = {
+      rec2(0)   // warn
+    }
+    object X {
+      rec2(0)   // warn
+    }
+    class X {
+      rec2(0)   // warn
+    }
+  }
+
+
+  def rec3(a: Any) = ()
+  def rec3(a: Any, b: Any = "".reverse): Any = {
+    rec3(0)     // okay
+  }
+
+  def rec4(a: Any)(b: Any = "".reverse): Any = {
+    rec4(0)()   // warn
+  }
+
+  def rec5(a: Any)(b: Any = 0): Any = {
+    rec5(0)()   // warn
+  }
+
+  def rec6(a: Any = 0)(b: Any = 0): Any = {
+    rec6()(0)   // warn
+  }
+
+  def rec7(a: Any = 0)(b: Any = 0): Any = {
+    rec7()(0)   // one warning only
+  }
+}


### PR DESCRIPTION
Revives retronym's warning for using default args when recursing, since you don't know if the default was intended or to thread the arg down the stack.

In this case paulp was the good angel on his shoulder.

https://github.com/retronym/scala/commit/3bfb6830

It would have caught [this one](https://github.com/scala/scala/commit/7d4109486b2266f8491d3473f43555dec6e996ee#diff-18ea56bad5c5d7a7b5af47b7131bebc1R1087), where the coder even says, "I shouldn't be using a boolean param this way."

I didn't devise a test for that code path; it's clearly wrong; but maybe fixing it breaks ~~someone's workaround~~ some tests.

This PR also partially addresses `jsig` in `Erasure` by adding a specialized version for the common recursive case, and otherwise adding args, including naming boolean literals, or `booterals` as I just typed.

Fixed up some stray unused imports.

I may add a commit for the infamous `higherKinds` import. ~~Or maybe just by always tagging it used? Where is the harm?~~