### PR TITLE
Handle IINC instructions in AliasingAnalyzer

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingAnalyzer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingAnalyzer.scala
@@ -118,7 +118,7 @@ class AliasingFrame[V <: Value](nLocals: Int, nStack: Int) extends Frame[V](nLoc
         newAlias(assignee = stackTop, source = insn.asInstanceOf[VarInsnNode].`var`)
 
       case IINC =>
-        removeAlias(insn.asInstanceOf[VarInsnNode].`var`)
+        removeAlias(insn.asInstanceOf[IincInsnNode].`var`)
       
       case DUP =>
         val top = stackTop

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingAnalyzer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingAnalyzer.scala
@@ -117,6 +117,9 @@ class AliasingFrame[V <: Value](nLocals: Int, nStack: Int) extends Frame[V](nLoc
       case ILOAD | LLOAD | FLOAD | DLOAD | ALOAD =>
         newAlias(assignee = stackTop, source = insn.asInstanceOf[VarInsnNode].`var`)
 
+      case IINC =>
+        removeAlias(insn.asInstanceOf[VarInsnNode].`var`)
+      
       case DUP =>
         val top = stackTop
         newAlias(assignee = top, source = top - 1)


### PR DESCRIPTION
It seems like an oversight that IINC instructions do not modify the alias sets.

I use a similar analysis in another project and stumbled across this bug.
I'm not familiar with the Scala code base, so there might be a reason for leaving out IINC that I'm not aware of. :)