### PR TITLE
List optimizations for List.from, ::: and prependedAll

### DIFF
--- a/test/junit/scala/collection/immutable/ListTest.scala
+++ b/test/junit/scala/collection/immutable/ListTest.scala
@@ -1,6 +1,6 @@
 package scala.collection.immutable
 
-import org.junit.Assert.assertSame
+import org.junit.Assert._
 import org.junit.{Assert, Test}
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -75,4 +75,28 @@ class ListTest {
   }
 
   @Test def checkSearch: Unit = SeqTests.checkSearch(List(0 to 1000: _*), 15,  implicitly[Ordering[Int]])
+
+
+  @Test def colonColonColon(): Unit = {
+
+    assertEquals(Nil, Nil ::: Nil)
+    assertEquals(List(1), List(1) ::: List())
+    assertEquals(List(1), List() ::: List(1))
+    assertEquals(List(1, 2), List(1, 2) ::: List())
+    assertEquals(List(1, 2), List(1) ::: List(2))
+    assertEquals(List(1, 2), List() ::: List(1, 2))
+  }
+
+
+  @Test def listFrom(): Unit = {
+    for {
+      dataSize <- 0 to 1000 by 4
+      data = 0 until dataSize
+      vector = data.to(Vector)
+    } {
+      assertEquals(data, List.from(data))
+      assertEquals(vector, List.from(vector))
+    }
+  }
 }
+

--- a/test/scalacheck/scala/collection/immutable/ListProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ListProperties.scala
@@ -1,0 +1,48 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.immutable
+
+import org.scalacheck.Prop._
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.collection.{IterableFactory, View, mutable}
+
+object ListProperties extends Properties("immutable.List") {
+
+  val iterableGen: Gen[collection.Iterable[Int]] =
+    for {
+      data <- Gen.listOf(Arbitrary.arbInt.arbitrary)
+      factory <- Gen.oneOf[IterableFactory[collection.Iterable]](
+        List, Vector, ArrayBuffer, mutable.ArrayDeque, Queue, ListBuffer, View
+      )
+    } yield factory.from(data)
+
+
+  val iterableOnceGen: Gen[() => IterableOnce[Int]] =
+    Gen.oneOf(iterableGen.map(it => () => it), iterableGen.map(it => () => it.iterator))
+
+  property("list1 ::: list2 == list1.toVector.prependedAll(list2)") = forAll { (list1: List[Int], list2: List[Int]) =>
+    (list1.prependedAll(list2): Seq[Int]) ?= list1.toVector.prependedAll(list2)
+  }
+  property("list1.prependedAll(iterableOnce) == list1.prependedAll(iterableOnce)") =
+    forAll(arbitrary[List[Int]], iterableOnceGen){ (list1, it) =>
+      (list1.prependedAll(it()): Seq[Int]) ?= list1.toVector.prependedAll(it())
+  }
+
+  property("List.from(iterableOnce) == Vector.from(iterableOnce)") =
+    forAll(iterableOnceGen) { it =>
+      (List.from(it()): Seq[Int]) ?= Vector.from(it())
+    }
+}


### PR DESCRIPTION
`:::`:
* we avoid creating intermediate `ListBuffer`, and `list.iterator` objects, and also avoid doing extra work in ListBuffer's `++=` method such as `ensureUnaliased()` calls and `this.last0 = ...; this.size += ...;` updates etc. 

`prependedAll`:
* same optimizations as above, but with the added bonus that currently `prependedAll` will also copy all of `this` since the `super.prependedAll` implementation is:
```scala
// StrictOptimizedSeqOps...
  override def prependedAll[B >: A](prefix: IterableOnce[B]): CC[B] = {
    val b = iterableFactory.newBuilder[B]
    b ++= prefix
    b ++= this
    b.result()
  }
```
This PR avoids that extra copying by doing a similar approach to the `:::` algorithm.

Also note: This is the method that underlies list concatenation (`++`/`concat`/`appendedAll`)


## Benchmarks 
code:
```scala
  @Param(Array("0", "1", "10", "100", "1000", "10000"))
  var size: Int = _

  var prefix: List[Int] = Nil
  var prefixVector: Vector[Int] = Vector()
  var suffix: List[Int] = Nil

  @Setup(Level.Trial) def initKeys(): Unit = {
    prefix = List.fill(size)(0)
    prefixVector = Vector.fill(size)(0)
    suffix = List.fill(size)(0)
  }

  @Benchmark def colonColonColon(bh: Blackhole): Unit = {
    bh.consume(prefix ::: suffix)
  }
  @Benchmark def prependedAll(bh: Blackhole): Unit = {
    bh.consume(suffix.prependedAll(prefixVector))
  }
```
this branch:
```
[info] Benchmark                      (size)  Mode  Cnt      Score       Error  Units
[info] ListBenchmark.colonColonColon       0  avgt   20      3.210 ±     0.288  ns/op
[info] ListBenchmark.colonColonColon       1  avgt   20      7.205 ±     0.630  ns/op
[info] ListBenchmark.colonColonColon      10  avgt   20     51.701 ±     7.002  ns/op
[info] ListBenchmark.colonColonColon     100  avgt   20    552.057 ±    83.209  ns/op
[info] ListBenchmark.colonColonColon    1000  avgt   20   8129.771 ±  5933.402  ns/op
[info] ListBenchmark.colonColonColon   10000  avgt   20  54518.199 ± 15867.176  ns/op
[info] ListBenchmark.prependedAll          0  avgt   20      3.447 ±     0.144  ns/op
[info] ListBenchmark.prependedAll          1  avgt   20     39.401 ±    24.351  ns/op
[info] ListBenchmark.prependedAll         10  avgt   20     76.843 ±    11.932  ns/op
[info] ListBenchmark.prependedAll        100  avgt   20    478.878 ±    12.370  ns/op
[info] ListBenchmark.prependedAll       1000  avgt   20   5143.790 ±   841.873  ns/op
[info] ListBenchmark.prependedAll      10000  avgt   20  73089.342 ± 14821.023  ns/op
```
2.13.x:
```
[info] Benchmark                      (size)  Mode  Cnt       Score       Error  Units
[info] ListBenchmark.colonColonColon       0  avgt   20       2.769 ±     0.091  ns/op
[info] ListBenchmark.colonColonColon       1  avgt   20      15.965 ±     2.040  ns/op
[info] ListBenchmark.colonColonColon      10  avgt   20      93.735 ±     2.598  ns/op
[info] ListBenchmark.colonColonColon     100  avgt   20     933.721 ±    40.424  ns/op
[info] ListBenchmark.colonColonColon    1000  avgt   20    8770.294 ±   546.587  ns/op
[info] ListBenchmark.colonColonColon   10000  avgt   20  123632.790 ± 30704.689  ns/op
[info] ListBenchmark.prependedAll          0  avgt   20      23.060 ±     1.769  ns/op
[info] ListBenchmark.prependedAll          1  avgt   20      60.048 ±    29.049  ns/op
[info] ListBenchmark.prependedAll         10  avgt   20     178.528 ±    38.932  ns/op
[info] ListBenchmark.prependedAll        100  avgt   20    1107.418 ±   146.895  ns/op
[info] ListBenchmark.prependedAll       1000  avgt   20   10747.862 ±   627.832  ns/op
[info] ListBenchmark.prependedAll      10000  avgt   20  107582.601 ±  9426.232  ns/op

```

## TODO

- [x] Write more property/unit tests for `:::` and `prependedAll`

- [x] Benchmark more thoroughly with more forks and iterations and 