### PR TITLE
[WIP] Rework of immutable.Queue to avoid copying data into the "in" list

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -167,6 +167,8 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.SynchronizedTypes.defineNormalized"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUniverse.defineNormalized"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive.RootEntry"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.Queue$Many"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.Queue$Many$"),
   ),
 }
 

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -73,19 +73,14 @@ sealed class Queue[+A] protected(protected val in: List[Any /* A | Many[A] */], 
       }
       else indexOutOfRange()
     } else {
-//      val indexFromBack = n - index
-//      val inLength = in.length
-//      if (indexFromBack >= inLength) indexOutOfRange()
-//      else {
-//        in(inLength - indexFromBack - 1)
-//      }
-//      ???
+      // TODO: this should be more optimized
       iterator.drop(n).next()
     }
   }
 
   override def iterator: Iterator[A] =
     new AbstractIterator[A] {
+      // TODO: build outside of the class
       private[this] var currentOut: List[A] = out
       private[this] var currentInIterator: Iterator[Any] = _
       private[this] var currentManyIterator: Iterator[Any] = _

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -275,3 +275,4 @@ object Queue extends StrictOptimizedSeqFactory[Queue] {
 
   private final case class Many[+A](seq: Seq[A])
 }
+


### PR DESCRIPTION
This is a reworking of the structure of Queue's `in: List[A]` to be now a `List[A | Many[A]]`, which allows for `enqueueAll` operations to be performed in O(1) by simply setting 
```scala
in = Many(that) :: this.in
```

When a rotation happens (when a dequeueing occurs which causes us to rotate the `in` list to the `out` list, at that point, the `in` list is flattened to construct the new `out` list. 

The end result is that instead of copying the data twice (copying once into `in` and again to rotate into `out`), we only perform one copying of the data, at rotation-time. We avoid the equeueAll-time copying by appending prepending the collection itself as the first element of `in`. 

An other more elaborated description was written here: https://github.com/scala/scala/pull/8565#issuecomment-562976067   
  
This is a very early version of this PR and it is definitely not ready for merging.

Also, this one is on pause until at least https://github.com/scala/scala/pull/8601 is through, since this code somewhat depends on that code to realize performance improvements, so benchmarks compared to the 2.13.x branch are underwhelming or even negative. 


## TODO
- [ ] Run benchmarks to ensure that the expected speedups are indeed worth the complexity, and other operations on queues are not slowed down (by much)

- [ ] Write more unit/prop tests for queues

- [ ] Implement faster `queue.apply(Int)` implementation
- [ ] Extract iterator class from queue
- [ ] Make any necessary changes to Queue scaladocs and if applicable, scala-lang.org



