### PR TITLE
Fix typos, via a Levenshtein-style corrector

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1198,7 +1198,7 @@ However, if the function literal has the shape `x => x match { $\ldots$ }`,
 then `isDefinedAt` is derived from the pattern match in the following way:
 each case from the match expression evaluates to `true`,
 and if there is no default case,
-a default case is added that evalutes to `false`.
+a default case is added that evaluates to `false`.
 For more details on how that is implemented see
 ["Pattern Matching Anonymous Functions"](08-pattern-matching.html#pattern-matching-anonymous-functions).
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -113,7 +113,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
       val cd = if (isCZStaticModule) {
         // Move statements from the primary constructor following the superclass constructor call to
         // a newly synthesised tree representing the "<clinit>", which also assigns the MODULE$ field.
-        // Because the assigments to both the module instance fields, and the fields of the module itself
+        // Because the assignments to both the module instance fields, and the fields of the module itself
         // are in the <clinit>, these fields can be static + final.
 
         // TODO should we do this transformation earlier, say in Constructors? Or would that just cause

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -543,7 +543,7 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
         // empty parameter list in uncurry and would therefore be picked as SAM.
         // Similarly, the fields phases adds abstract trait setters, which should not be considered
         // abstract for SAMs (they do disqualify the SAM from LMF treatment,
-        // but an anonymous subclasss can be spun up by scalac after making just the single abstract method concrete)
+        // but an anonymous subclass can be spun up by scalac after making just the single abstract method concrete)
         val samSym = exitingPickler(definitions.samOf(classSym.tpe))
         if (samSym == NoSymbol) None
         else Some(samSym.javaSimpleName.toString + methodBTypeFromSymbol(samSym).descriptor)

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -940,7 +940,7 @@ abstract class Inliner {
           1
         }
         else if (hasNullOutInsn) {
-          // after the return value is laoded, local variables and the return local variable are
+          // after the return value is loaded, local variables and the return local variable are
           // nulled out, which means `null` is loaded to the stack. the max stack height is the
           // callsite stack height +1 (receiver consumed, result produced, null loaded), but +2
           // for static calls

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/InlinerHeuristics.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/InlinerHeuristics.scala
@@ -76,7 +76,7 @@ abstract class InlinerHeuristics extends PerRunInit {
           case RefParam =>
             "the callee has a Ref type parameter"
           case KnownArrayOp =>
-            "ScalaRuntime.array_apply and array_update are inlined if the array has a statically knonw type"
+            "ScalaRuntime.array_apply and array_update are inlined if the array has a statically known type"
         }
       }
   }

--- a/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
@@ -174,7 +174,7 @@ trait AnalyzerPlugins { self: Analyzer =>
      * Access the implicit search result from Scalac's typechecker.
      *
      * The motivation of this method is to allow analyzer plugins to control when/where
-     * implicit search results are returned, and inspec them for data capturing purposes.
+     * implicit search results are returned, and inspect them for data capturing purposes.
      *
      * @param result The result to a given implicit search.
      */

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -751,7 +751,7 @@ trait Infer extends Checkable {
         argtpes
     }
 
-    // This is primarily a duplicte of enhanceBounds in typedAppliedTypeTree
+    // This is primarily a duplicate of enhanceBounds in typedAppliedTypeTree
     // modified to use updateInfo rather than setInfo to avoid wiping out
     // type history.
     def enhanceBounds(okparams: List[Symbol], okargs: List[Type], undets: List[Symbol]): Unit =

--- a/src/library/scala/collection/concurrent/MainNode.java
+++ b/src/library/scala/collection/concurrent/MainNode.java
@@ -36,7 +36,7 @@ abstract class MainNode<K, V> extends BasicNode {
 
     // do we need this? unclear in the javadocs...
     // apparently not - volatile reads are supposed to be safe
-    // irregardless of whether there are concurrent ARFU updates
+    // regardless of whether there are concurrent ARFU updates
     @Deprecated @SuppressWarnings("unchecked")
     public MainNode<K, V> READ_PREV() {
         return (MainNode<K, V>) updater.get(this);

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -327,7 +327,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
   def flatMap[V2](f: ((Int, T)) => IterableOnce[(Int, V2)]): IntMap[V2] = intMapFrom(new View.FlatMap(toIterable, f))
 
   override def concat[V1 >: T](that: collection.IterableOnce[(Int, V1)]): IntMap[V1] =
-    super.concat(that).asInstanceOf[IntMap[V1]] // Already has corect type but not declared as such
+    super.concat(that).asInstanceOf[IntMap[V1]] // Already has correct type but not declared as such
 
   override def ++ [V1 >: T](that: collection.IterableOnce[(Int, V1)]): IntMap[V1] = concat(that)
 

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -479,7 +479,7 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
   def flatMap[V2](f: ((Long, T)) => IterableOnce[(Long, V2)]): LongMap[V2] = LongMap.from(new View.FlatMap(coll, f))
 
   override def concat[V1 >: T](that: scala.collection.IterableOnce[(Long, V1)]): LongMap[V1] =
-    super.concat(that).asInstanceOf[LongMap[V1]] // Already has corect type but not declared as such
+    super.concat(that).asInstanceOf[LongMap[V1]] // Already has correct type but not declared as such
 
   override def ++ [V1 >: T](that: scala.collection.IterableOnce[(Long, V1)]): LongMap[V1] = concat(that)
 

--- a/src/library/scala/collection/immutable/Seq.scala
+++ b/src/library/scala/collection/immutable/Seq.scala
@@ -92,7 +92,7 @@ trait IndexedSeq[+A] extends Seq[A]
   }
 
   /** a hint to the runtime when scanning values
-    * [[apply]] is perferred for scan with a max index less than this value
+    * [[apply]] is preferred for scan with a max index less than this value
     * [[iterator]] is preferred for scans above this range
     * @return a hint about when to use [[apply]] or [[iterator]]
     */

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -44,7 +44,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
 
   def this() = this(LongMap.exceptionDefault, 16, true)
 
-  // TODO: override clear() with an optimization more tailored for effciency.
+  // TODO: override clear() with an optimization more tailored for efficiency.
   override protected def fromSpecific(coll: scala.collection.IterableOnce[(Long, V)]): LongMap[V] = {
     //TODO should this be the default implementation of this method in StrictOptimizedIterableOps?
     val b = newSpecificBuilder

--- a/src/reflect/scala/reflect/internal/util/FileUtils.scala
+++ b/src/reflect/scala/reflect/internal/util/FileUtils.scala
@@ -188,7 +188,7 @@ object FileUtils {
         finally scheduled.set(false)
 
         //we are not scheduled any more
-        //as a last check ensure that we didnt race with an addition to the queue
+        //as a last check ensure that we didn't race with an addition to the queue
         //order is essential - queue is checked before CAS
         if ((!pending.isEmpty) && scheduled.compareAndSet(false, true)) {
           global.execute(background)

--- a/src/scalacheck/org/scalacheck/Prop.scala
+++ b/src/scalacheck/org/scalacheck/Prop.scala
@@ -496,7 +496,7 @@ object Prop {
 
   /**
    * This handles situations where we have a starting seed in our
-   * paramters.
+   * parameters.
    *
    * If we do, then we remove it from parameters and return it. If
    * not, we create a new random seed. The new parameters from this

--- a/src/scalacheck/org/scalacheck/Test.scala
+++ b/src/scalacheck/org/scalacheck/Test.scala
@@ -128,7 +128,7 @@ object Test {
   /** Test parameters used by the check methods. Default
    *  parameters are defined by [[Test.Parameters.default]]. */
   object Parameters {
-    /** Default test parameters. Can be overriden if you need to
+    /** Default test parameters. Can be overridden if you need to
      *  tweak the parameters:
      *
      *  {{{

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.js
@@ -283,7 +283,7 @@ function compilePattern(query) {
     }
 }
 
-/** Searches packages for entites matching the search query using a regex
+/** Searches packages for entities matching the search query using a regex
  *
  * @param {[Object]} pack: package being searched
  * @param {RegExp} regExp: a regular expression for finding matching entities

--- a/test/files/instrumented/README
+++ b/test/files/instrumented/README
@@ -3,7 +3,7 @@ they have additional byte-code instrumentation performed for profiling. You
 should put your tests in `instrumented` directory if you are interested in
 method call counts. Examples include tests for specialization (you want to
 count boxing and unboxing method calls) or high-level tests for optimizer
-where you are interested if methods are successfuly inlined (so they should
+where you are interested if methods are successfully inlined (so they should
 not be called at runtime) or closures are eliminated (so no constructors
 of closures are called).
 

--- a/test/files/run/bcodeInlinerMixed/B_1.scala
+++ b/test/files/run/bcodeInlinerMixed/B_1.scala
@@ -6,7 +6,7 @@
 //   3. scalc *.scala
 //
 // Because the inliner doesn't have access to the bytecode of `bar`, it cannot verify whether the
-// invocation of `bar` can be safely copied to a differnet place, so `flop` is not inlined to `B.g`
+// invocation of `bar` can be safely copied to a different place, so `flop` is not inlined to `B.g`
 // or `C.h`.
 
 class B {

--- a/test/files/run/reify_properties.scala
+++ b/test/files/run/reify_properties.scala
@@ -13,7 +13,7 @@ object Test extends App {
       /** The setter function, defaults to identity. */
       private var getter: T => T = identity[T]
 
-      /** Retrive the value held in this property.   */
+      /** Retrieve the value held in this property.   */
       def apply(): T = getter(value)
 
       /** Update the value held in this property, through the setter. */

--- a/test/files/run/t4835.scala
+++ b/test/files/run/t4835.scala
@@ -10,7 +10,7 @@ object Test {
   def testLazyListIterator(num: Int, stream: LazyList[Int]): Unit = {
     val iter = stream.iterator
     print(num)
-    // if num == -1, then steram is infinite sequence
+    // if num == -1, then stream is infinite sequence
     if (num == INFINITE) {
       for(i <- 0 until 10) {
         print(" " + iter.next())

--- a/test/files/run/t9529/Test_1.scala
+++ b/test/files/run/t9529/Test_1.scala
@@ -19,7 +19,7 @@ class Test @Ann_0(name = "<init>", value = "constructor") @Ann_0(name = "<init>"
   ) = ()
 
   // todo: annotations on types
-  // todo? annotaitons on packages
+  // todo? annotations on packages
 }
 
 object Test extends App {

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
@@ -167,7 +167,7 @@ class NullnessAnalyzerTest extends BytecodeTesting {
         |    d = null
         |  }
         |  b.toString // a, o, b aliases (so they become NotNull), but not c
-        |  // d is null here, assinged in both branches.
+        |  // d is null here, assigned in both branches.
         |}
       """.stripMargin
     val m = compileAsmMethod(code)
@@ -185,7 +185,7 @@ class NullnessAnalyzerTest extends BytecodeTesting {
       (trim, 5, UnknownValue1), // d
 
       (toSt, 2, UnknownValue1), // a, still the same
-      (toSt, 3, UnknownValue1), // b, was re-assinged in both branches to Unknown
+      (toSt, 3, UnknownValue1), // b, was re-assigned in both branches to Unknown
       (toSt, 4, UnknownValue1), // c, was re-assigned in one branch to Unknown
       (toSt, 5, NullValue),     // d, was assigned to null in both branches
 


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.