### PR TITLE
Scaladoc: disambiguate links to inherited members

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/base/MemberLookupBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/MemberLookupBase.scala
@@ -168,9 +168,14 @@ trait MemberLookupBase {
       termSyms
     else if (member.endsWith("!"))
       typeSyms
-    else if (member.endsWith("*"))
-      cleanupBogusClasses(container.info.nonPrivateDecls) filter signatureMatch
-    else
+    else if (member.endsWith("*")) {
+      val declOnlyResults = cleanupBogusClasses(container.info.nonPrivateDecls) filter signatureMatch
+      if (declOnlyResults.nonEmpty) {
+        declOnlyResults
+      } else {
+        cleanupBogusClasses(container.info.nonPrivateMembers.toList) filter signatureMatch
+      }
+    } else
       strategy match {
         case BothTypeAndTerm => termSyms ::: typeSyms
         case OnlyType => typeSyms

--- a/test/scaladoc/resources/links.scala
+++ b/test/scaladoc/resources/links.scala
@@ -22,6 +22,8 @@ package scala.test.scaladoc.links {
     def baz(c: scala.test.scaladoc.links.C) = 7
   }
 
+  object ExtendsTarget extends Target 
+  
   object Target {
     type T = Int => Int
     type S = Int
@@ -50,6 +52,7 @@ package scala.test.scaladoc.links {
    *  - [[Target$.::                                       object Target -> type ::]]
    *  - [[Target$.foo(z:Str*                               object Target -> def foo]]
    *  - [[Target$.bar                                      object Target -> def bar]]
+   *  - [[ExtendsTarget.foo(i:Int)*                        object ExtendsTarget -> def bar (disambiguating between inherited members)]]
    *  - [[[[Target$.foo[A[_[_]]]*                          trait Target -> def foo with 3 nested tparams]]]] (should exercise nested parens)
    *  - [[Target.onlyInObject                              object Target -> onlyInObject]]
    *  - [[Target$.C                                        object Target -> class C]] (should link directly to C, not as a member)

--- a/test/scaladoc/run/links.scala
+++ b/test/scaladoc/run/links.scala
@@ -26,7 +26,7 @@ object Test extends ScaladocModelTest {
 
     val memberLinks = countLinks(TEST.comment.get, _.link.isInstanceOf[LinkToMember[_, _]])
     val templateLinks = countLinks(TEST.comment.get, _.link.isInstanceOf[LinkToTpl[_]])
-    assert(memberLinks == 18,  memberLinks +   " == 18 (the member links in object TEST)")
+    assert(memberLinks == 19,  memberLinks +   " == 19 (the member links in object TEST)")
     assert(templateLinks == 6, templateLinks + " ==  6 (the template links in object TEST)")
   }
 }


### PR DESCRIPTION
It's currently impossible to disambiguate inherited members in scaladoc. Disambiguation works in the following case: 
 
```scala
object Ok {
  def foo[A](a: A): A = a
  def foo[A, B](a: A, b: B): A = a
}

/**
 * @see [[Ok.foo]]
 * @see [[Ok.foo[A]*]]
 */
object OkDocs 
```

Running scaladoc results with a warning for the first `@see` and an arbitrary method is selected. The second case works as expected and a link to method with one type parameter is selected. 

However, if we extract the methods into a trait like so: 

```scala
trait ATrait {
  def foo[A](a: A): A = a
  def foo[A, B](a: A, b: B): A = a
}

object NotOk extends ATrait

/**
 * @see [[NotOk.foo]]
 * @see [[NotOk.foo[A]*]]
 */
object NotOkDocs 
```

An arbitrary method is selected for the first `@see`, but the disambiguation does not work and a warning that a member to link to is not found is generated. 

The cause seems to be in `MemberLookupBase`: when disambiguating members, only declarations are considered, so inherited members are ignored. 

In this PR i tried to be as backwards compatible as possible, and only consider members if a declaration is not found.