### PR TITLE
Apply `LazyRef#initialized` to empty args after uncurry

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -613,7 +613,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
           case _ => tree
         }
 
-      def initialized = Select(Ident(holderSym), initializedSym)
+      def initialized = Apply(Select(Ident(holderSym), initializedSym), Nil)
       def initialize  = Select(Ident(holderSym), initializeSym)
       def getValue    = if (isUnit) UNIT else refineLiteral(Apply(Select(Ident(holderSym), valueSym), Nil))
 

--- a/test/files/pos/lazyref-autoapply.scala
+++ b/test/files/pos/lazyref-autoapply.scala
@@ -1,0 +1,8 @@
+// scalac: -Xsource:2.14
+
+object Test {
+  def doti(i: Int): Product = {
+    case class Dot(i: Int) // was: warning: auto-application to `()` is deprecated ...
+    Dot(i)
+  }
+}


### PR DESCRIPTION
Otherwise we run afoul of a Dotty anticipation warning.

Reported on the lampepfl/dotty gitter.
