### PR TITLE
Java allows importing from types

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilationUnits.scala
+++ b/src/compiler/scala/tools/nsc/CompilationUnits.scala
@@ -158,7 +158,7 @@ trait CompilationUnits { global: Global =>
     final def comment(pos: Position, msg: String): Unit = {}
 
     /** Is this about a .java source file? */
-    val isJava = source.file.name.endsWith(".java")
+    val isJava: Boolean = source.isJava
 
     override def toString() = source.toString()
   }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -560,17 +560,17 @@ trait Namers extends MethodSynthesis {
       }
       def checkSelector(s: ImportSelector) = {
         val ImportSelector(from, fromPos, to, _) = s
-        def isValid(original: Name) =
-          (base nonLocalMember original.toTermName) == NoSymbol &&
-            (base nonLocalMember original.toTypeName) == NoSymbol
+        def isValid(original: Name, base: Type) =
+          (base nonLocalMember original.toTermName) != NoSymbol ||
+            (base nonLocalMember original.toTypeName) != NoSymbol
 
         if (from != nme.WILDCARD && base != ErrorType) {
-          if (isValid(from)) {
-            // for Java code importing Scala objects
-            if (!nme.isModuleName(from) || isValid(from.dropModule)) {
-              typer.TyperErrorGen.NotAMemberError(tree, expr, from)
-            }
-          }
+          val okay = isValid(from, base) || context.unit.isJava && (      // Java code...
+               (nme.isModuleName(from) && isValid(from.dropModule, base)) // - importing Scala module classes
+            || isValid(from, base.companion)                              // - importing type members from types
+          )
+          if (!okay) typer.TyperErrorGen.NotAMemberError(tree, expr, from)
+
           // Setting the position at the import means that if there is
           // more than one hidden name, the second will not be warned.
           // So it is the position of the actual hidden name.
@@ -1812,7 +1812,7 @@ trait Namers extends MethodSynthesis {
             typer.TyperErrorGen.UnstableTreeError(expr1)
         }
 
-        val newImport = treeCopy.Import(imp, expr1, selectors).asInstanceOf[Import]
+        val newImport = treeCopy.Import(imp, expr1, selectors)
         checkSelectors(newImport)
         context.unit.transformed(imp) = newImport
         // copy symbol and type attributes back into old expression

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -220,6 +220,9 @@ trait Names extends api.Names {
     @deprecated("Use either toTermName or toTypeName", "2.12.9")
     def bothNames: List[Name] = List(toTermName, toTypeName)
 
+    final def asTypeOf[N <: Name](other: N): N =
+      (if (other.isTermName) toTermName else toTypeName).asInstanceOf[N]
+
     /** Return the subname with characters from from to to-1. */
     def subName(from: Int, to: Int): Name with ThisNameType
     override def subSequence(from: Int, to: Int): CharSequence = subName(from, to)

--- a/src/reflect/scala/reflect/internal/util/SourceFile.scala
+++ b/src/reflect/scala/reflect/internal/util/SourceFile.scala
@@ -62,6 +62,8 @@ abstract class SourceFile {
     * Bounds are checked and clipped as necessary.
     */
   def lines(start: Int = 0, end: Int = lineCount): Iterator[String]
+
+  final def isJava: Boolean = file.name endsWith ".java"
 }
 
 /** An object representing a missing source file.

--- a/test/files/pos/java-type-import/J.java
+++ b/test/files/pos/java-type-import/J.java
@@ -1,0 +1,5 @@
+package java_type_import.a;
+
+public class J {
+    public class JInner {}
+}

--- a/test/files/pos/java-type-import/K.java
+++ b/test/files/pos/java-type-import/K.java
@@ -1,0 +1,9 @@
+package java_type_import.b;
+
+import java_type_import.a.J.*;
+import java_type_import.a.L.LInner;
+
+public class K {
+    public static JInner testj() { return null; } // from wildcard
+    public static LInner testl() { return null; } // from explicit
+}

--- a/test/files/pos/java-type-import/L.java
+++ b/test/files/pos/java-type-import/L.java
@@ -1,0 +1,5 @@
+package java_type_import.a;
+
+public class L {
+    public class LInner {}
+}

--- a/test/files/pos/java-type-import/S.scala
+++ b/test/files/pos/java-type-import/S.scala
@@ -1,0 +1,4 @@
+package java_type_import
+import a._, b._
+
+object Test { K.testj(); K.testl() }


### PR DESCRIPTION
Scala only allows importing from paths, but Java has no such concept, and will gladly let you import inner types from types.