### PR TITLE
Don't clear PRIVATE/PROTECTED flags from Java inner classes

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -367,9 +367,9 @@ abstract class ExplicitOuter extends InfoTransform
     /** The main transformation method */
     override def transform(tree: Tree): Tree = {
       val sym = tree.symbol
-      if (sym != null && sym.isType) { //(9)
+      if (sym != null && sym.isType) { // (9)
         if (sym.isPrivate) sym setFlag notPRIVATE
-        if (sym.isProtected) sym setFlag notPROTECTED
+        if (sym.isProtected && !sym.isJavaDefined) sym setFlag notPROTECTED
       }
       tree match {
         case Template(parents, self, decls) =>

--- a/test/files/pos/java-protected-inner-class/A.java
+++ b/test/files/pos/java-protected-inner-class/A.java
@@ -1,0 +1,5 @@
+package a;
+public class A {
+  protected class I {}
+  protected static class S{}
+}

--- a/test/files/pos/java-protected-inner-class/B.scala
+++ b/test/files/pos/java-protected-inner-class/B.scala
@@ -1,0 +1,5 @@
+import a._, A._
+object W extends A {
+  new I // error: Unable to emit reference to constructor I in class I, class I is not accessible in object W
+  new S // error: Unable to emit reference to constructor S in class S, class S is not accessible in object W
+}


### PR DESCRIPTION
Because javac didn't, and so we can't.

Happy New Year!