### PR TITLE
Literals can form part of stable paths

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -115,6 +115,7 @@ abstract class TreeInfo {
       case Apply(Select(free @ Ident(_), nme.apply), _) if free.symbol.name endsWith nme.REIFY_FREE_VALUE_SUFFIX =>
         // see a detailed explanation of this trick in `GenSymbols.reifyFreeTerm`
         free.symbol.hasStableFlag && isPath(free, allowVolatile)
+      case Literal(_)      => true // scala/bug#8855
       case _               => false
     }
 

--- a/test/files/pos/t8855.scala
+++ b/test/files/pos/t8855.scala
@@ -1,0 +1,13 @@
+object Test {
+  final val clasz = classOf[String]
+  final val str = "Str"
+
+  import java.lang.annotation.RetentionPolicy.CLASS.{ordinal => ord} // error: stable identifier required, but CLASS found
+  println(ord)
+
+  import clasz.{getName => claszName} // error: stable identifier required, but classOf[java.lang.String] found
+  println(claszName)
+
+  import str.{length => strLen} // error: stable identifier required, but "Str" found
+  println(strLen)
+}


### PR DESCRIPTION
References to enum constants or (literal-typed) class types get replaced with `Literal` trees, which can be selected from and should be considered stable for the purpose of the import check.

The second and third tests in the enclosed partest case argue for this change (as does the fact that the test is accepted by Dotty): removing `final` from the vals makes them compile prior to this change.

Fixes scala/bug#8855