### PR TITLE
Preserve position of argument of right-associative method

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -858,7 +858,7 @@ self =>
           val x = freshTermName()
           Block(
             List(ValDef(Modifiers(symtab.Flags.SYNTHETIC | symtab.Flags.ARTIFACT), x, TypeTree(), stripParens(left))),
-            Apply(mkSelection(right), List(Ident(x))))
+            Apply(mkSelection(right), List(atPos(left.pos.makeTransparent)(Ident(x)))))
         }
       } else {
         Apply(Ident(op.encode), stripParens(left) :: arguments)

--- a/test/files/neg/t4701.check
+++ b/test/files/neg/t4701.check
@@ -1,0 +1,6 @@
+t4701.scala:9: error: type mismatch;
+ found   : Int
+ required: String
+  hasType[HL[String]](nnn :: HN) // type mismatch error should have position at `nnn`
+                      ^
+one error found

--- a/test/files/neg/t4701.scala
+++ b/test/files/neg/t4701.scala
@@ -1,0 +1,10 @@
+// scalac: -Yrangepos
+trait HL[A]
+object HN {
+  def :: [A](x: A): HL[A] = new HL[A] {}
+}
+object Test {
+  import Predef.{identity => hasType}
+  final val nnn = 1
+  hasType[HL[String]](nnn :: HN) // type mismatch error should have position at `nnn`
+}


### PR DESCRIPTION
To preserve evaluation order, `x :: y` is rewritten not to `y.::(x)` but to `{ val x$1 = x; y.::(x$1) }`. But, the `Ident(x$1)` tree is the target of any type-mismatch errors issued later on, so it should steal the position of `x` for the error message.

The important effect of this important change:
```
% diff /code/scala/test/files/neg/t4701-neg.log /code/scala/test/files/neg/t4701.check--- t4701-neg.log
+++ t4701.check
@@ -4,3 +4,3 @@
   hasType[HL[String]](nnn :: HN) // type mismatch error should have position at `nnn`
-                          ^
+                      ^
```

Fixes scala/bug#4701