### PR TITLE
In REPL, get more precise error on load file

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -447,8 +447,8 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
     prevRequestList collectFirst { case r if r.defines contains sym => r }
   }
 
-  private[interpreter] def requestFromLine(input: String, synthetic: Boolean = false): Either[Result, Request] =
-    parse(input) flatMap {
+  private[interpreter] def requestFromLine(input: String, synthetic: Boolean = false, fatally: Boolean = false): Either[Result, Request] =
+    parse(input, fatally) flatMap {
       case (Nil, _) => Left(Error)
       case (trees, firstXmlPos) =>
         executingRequest = new Request(input, trees, firstXmlPos, synthetic = synthetic)
@@ -470,9 +470,11 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
     *  The return value is whether the line was interpreter successfully,
     *  e.g. that there were no parse errors.
     */
+  override def interpretFinally(line: String): Result = doInterpret(line, synthetic = false, fatally = true)
   override def interpret(line: String): Result = interpret(line, synthetic = false)
   def interpretSynthetic(line: String): Result = interpret(line, synthetic = true)
-  override def interpret(line: String, synthetic: Boolean): Result = {
+  override def interpret(line: String, synthetic: Boolean): Result = doInterpret(line, synthetic, fatally = false)
+  private def doInterpret(line: String, synthetic: Boolean, fatally: Boolean): Result = {
     def loadAndRunReq(req: Request) = classLoader.asContext {
       val res = req.loadAndRun // TODO: move classLoader.asContext into loadAndRun ?
 
@@ -487,13 +489,14 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
       }
     }
 
-    compile(line, synthetic).fold(identity, loadAndRunReq)
+    compile(line, synthetic, fatally).fold(identity, loadAndRunReq)
   }
 
   // create a Request and compile it
-  def compile(line: String, synthetic: Boolean): Either[Result, Request] =
+  def compile(line: String, synthetic: Boolean): Either[Result, Request] = compile(line, synthetic, fatally = false)
+  def compile(line: String, synthetic: Boolean, fatally: Boolean): Either[Result, Request] =
     if (global == null) Left(Error)
-    else requestFromLine(line, synthetic).filterOrElse(_.compile, Error)
+    else requestFromLine(line, synthetic, fatally).filterOrElse(_.compile, Error)
 
   /** Bind a specified name to a specified value.  The name may
     *  later be used by expressions passed to interpret.
@@ -1121,9 +1124,11 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
   } with ExprTyper { }
 
   /** Parse a line into and return parsing result (error, incomplete or success with list of trees) */
-  def parse(line: String): Either[Result, (List[Tree], Position)] = {
+  def parse(line: String): Either[Result, (List[Tree], Position)] = parse(line, fatally = false)
+  def parse(line: String, fatally: Boolean): Either[Result, (List[Tree], Position)] = {
     var isIncomplete = false
-    currentRun.parsing.withIncompleteHandler((_, _) => isIncomplete = true) {
+    val handler = if (fatally) null else (_: Position, _: String) => isIncomplete = true
+    currentRun.parsing.withIncompleteHandler(handler) {
       reporter.reset()
       val unit = newCompilationUnit(line, label)
       val trees = newUnitParser(unit).parseStats()

--- a/src/repl/scala/tools/nsc/interpreter/Interface.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Interface.scala
@@ -134,6 +134,9 @@ trait Repl extends ReplCore {
 
   def interpret(line: String, synthetic: Boolean): Result
 
+  // Error on incomplete input
+  def interpretFinally(line: String): Result
+
   final def beQuietDuring(body: => Unit): Unit = reporter.withoutPrintingResults(body)
 
 

--- a/test/files/run/t11838.check
+++ b/test/files/run/t11838.check
@@ -1,0 +1,21 @@
+
+scala> :load t11838.script
+val args: Array[String] = Array()
+Loading t11838.script...
+
+// Detected repl transcript. Paste more, or ctrl-D to finish.
+
+// Replaying 1 commands from transcript.
+
+scala> val m = status match {
+  case 42 => "ok"
+  case 27 => {
+    println("oops")
+    "oops"
+  }
+
+         }
+          ^
+t11838.script:6: error: '}' expected but eof found.
+
+scala> :quit

--- a/test/files/run/t11838.scala
+++ b/test/files/run/t11838.scala
@@ -1,0 +1,11 @@
+
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def code = s":load $script"
+  def script = testPath.changeExtension("script")
+}
+
+// was: <script>:1: error: expected class or object definition
+// now: error: '}' expected but eof found.
+

--- a/test/files/run/t11838.script
+++ b/test/files/run/t11838.script
@@ -1,0 +1,6 @@
+scala> val m = status match {
+     |   case 42 => "ok"
+     |   case 27 => {
+     |     println("oops")
+     |     "oops"
+     |   }


### PR DESCRIPTION
Usually REPL parses with incomplete handling, but at EOF
of a file, try again without incomplete handling to get
the parse error.

Fixes scala/bug#11838