### PR TITLE
Improve floating point IEEE Ordering consistency

### DIFF
--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -380,7 +380,7 @@ object Ordering extends LowPriorityOrderingImplicits {
   object Float {
     /** An ordering for `Float`s which is a fully consistent total ordering,
       * and treats `NaN` as larger than all other `Float` values; it behaves
-      * the same as [[java.lang.Float#compare]].
+      * the same as [[java.lang.Float.compare]].
       *
       * $floatOrdering
       *
@@ -401,7 +401,8 @@ object Ordering extends LowPriorityOrderingImplicits {
       * `NaN`.
       *   - `min` and `max` are consistent with `math.min` and `math.max`, and
       * return `NaN` when called with `NaN` as either argument.
-      *   - `compare` behaves the same as [[java.lang.Float#compare]].
+      *   - `compare` treats `-0.0f` and `0.0f` as equal, but otherwise
+      * behaves the same as [[java.lang.Float.compare]].
       *
       * $floatOrdering
       *
@@ -410,7 +411,8 @@ object Ordering extends LowPriorityOrderingImplicits {
       * @see [[TotalOrdering]]
       */
     trait IeeeOrdering extends Ordering[Float] {
-      def compare(x: Float, y: Float) = java.lang.Float.compare(x, y)
+      def compare(x: Float, y: Float) =
+        if (x == 0f && y == 0f) 0 else java.lang.Float.compare(x, y)
 
       override def lteq(x: Float, y: Float): Boolean = x <= y
       override def gteq(x: Float, y: Float): Boolean = x >= y
@@ -440,7 +442,7 @@ object Ordering extends LowPriorityOrderingImplicits {
   object Double {
     /** An ordering for `Double`s which is a fully consistent total ordering,
       * and treats `NaN` as larger than all other `Double` values; it behaves
-      * the same as [[java.lang.Double#compare]].
+      * the same as [[java.lang.Double.compare]].
       *
       * $doubleOrdering
       *
@@ -461,7 +463,8 @@ object Ordering extends LowPriorityOrderingImplicits {
       * `NaN`.
       *   - `min` and `max` are consistent with `math.min` and `math.max`, and
       * return `NaN` when called with `NaN` as either argument.
-      *   - `compare` behaves the same as [[java.lang.Double#compare]].
+      *   - `compare` treats `-0.0d` and `0.0d` as equal, but otherwise
+      * behaves the same as [[java.lang.Double.compare]].
       *
       * $doubleOrdering
       *
@@ -470,7 +473,8 @@ object Ordering extends LowPriorityOrderingImplicits {
       * @see [[TotalOrdering]]
       */
     trait IeeeOrdering extends Ordering[Double] {
-      def compare(x: Double, y: Double) = java.lang.Double.compare(x, y)
+      def compare(x: Double, y: Double) =
+        if (x == 0d && y == 0d) 0 else java.lang.Double.compare(x, y)
 
       override def lteq(x: Double, y: Double): Boolean = x <= y
       override def gteq(x: Double, y: Double): Boolean = x >= y

--- a/test/junit/scala/math/OrderingTest.scala
+++ b/test/junit/scala/math/OrderingTest.scala
@@ -237,6 +237,62 @@ class OrderingTest {
     checkDoubles(doubles: _*)
   }
 
+  @Test
+  def floatDoubleIeeeOrdering(): Unit = {
+    def checkFloats(floats: Float*): Unit = {
+      val O = Ordering.Float.IeeeOrdering
+      for (i <- floats; j <- floats) {
+        val msg = s"for i=$i, j=$j"
+
+        // consistency with `compare`
+        assertEquals(msg, O.compare(i, j) < 0, O.lt(i, j))
+        assertEquals(msg, O.compare(i, j) <= 0, O.lteq(i, j))
+        assertEquals(msg, O.compare(i, j) == 0, O.equiv(i, j))
+        assertEquals(msg, O.compare(i, j) >= 0, O.gteq(i, j))
+        assertEquals(msg, O.compare(i, j) > 0, O.gt(i, j))
+
+        // consistency with other ops
+        assertTrue(msg, O.lteq(i, j) || O.gteq(i, j))
+        assertTrue(msg, O.lteq(i, j) || O.gt(i, j))
+        assertTrue(msg, O.lteq(i, j) != O.gt(i, j))
+        assertTrue(msg, O.lt(i, j) || O.gteq(i, j))
+        assertTrue(msg, O.lt(i, j) != O.gteq(i, j))
+        // exactly one of `lt`, `equiv`, `gt` is true
+        assertTrue(msg,
+          (O.lt(i, j) ^ O.equiv(i, j) ^ O.gt(i, j))
+            && !(O.lt(i, j) && O.equiv(i, j) && O.gt(i, j)))
+      }
+    }
+
+    def checkDoubles(doubles: Double*): Unit = {
+      val O = Ordering.Double.IeeeOrdering
+      for (i <- doubles; j <- doubles) {
+        val msg = s"for i=$i, j=$j"
+
+        // consistency with `compare`
+        assertEquals(msg, O.compare(i, j) < 0, O.lt(i, j))
+        assertEquals(msg, O.compare(i, j) <= 0, O.lteq(i, j))
+        assertEquals(msg, O.compare(i, j) == 0, O.equiv(i, j))
+        assertEquals(msg, O.compare(i, j) >= 0, O.gteq(i, j))
+        assertEquals(msg, O.compare(i, j) > 0, O.gt(i, j))
+
+        // consistency with other ops
+        assertTrue(msg, O.lteq(i, j) || O.gteq(i, j))
+        assertTrue(msg, O.lteq(i, j) || O.gt(i, j))
+        assertTrue(msg, O.lteq(i, j) != O.gt(i, j))
+        assertTrue(msg, O.lt(i, j) || O.gteq(i, j))
+        assertTrue(msg, O.lt(i, j) != O.gteq(i, j))
+        // exactly one of `lt`, `equiv`, `gt` is true
+        assertTrue(msg,
+          (O.lt(i, j) ^ O.equiv(i, j) ^ O.gt(i, j))
+            && !(O.lt(i, j) && O.equiv(i, j) && O.gt(i, j)))
+      }
+    }
+
+    checkFloats(floats.filterNot(jl.Float.isNaN): _*)
+    checkDoubles(doubles.filterNot(jl.Double.isNaN): _*)
+  }
+
   /* Test for scala/bug#8664 */
   @Test
   def symbolOrdering(): Unit = {


### PR DESCRIPTION
Make `Ordering#compare(0.0, -0.0)` consistent with
the IEEE specification for floating point `Ordering`s.

I randomly noticed this was not consistent with the IEEE spec (or with `lt`, `gt`, etc.), but could be.