### PR TITLE
Efficient implementation for BitSet minAfter / maxBefore

### DIFF
--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -175,7 +175,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
     throw new UnsupportedOperationException("empty.largestInt")
   }
 
-  override def minAfter(key: Int): Option[Int] = {
+  override def minAfter(key: Elem): Option[Elem] = {
     val adjustedKey = math.max(key, 0)
     var i = adjustedKey / WordLength
     if (i >= nwords) None
@@ -191,7 +191,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
     }
   }
 
-  override def maxBefore(key: Int): Option[Int] = {
+  override def maxBefore(key: Elem): Option[Elem] = {
     if (key <= 0) None
     else {
       val adjustedKey = key - 1

--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -175,7 +175,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
     throw new UnsupportedOperationException("empty.largestInt")
   }
 
-  override def minAfter(key: Elem): Option[Elem] = {
+  override def minAfter(key: Int): Option[Int] = {
     val adjustedKey = math.max(key, 0)
     var i = adjustedKey / WordLength
     if (i >= nwords) None
@@ -191,7 +191,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
     }
   }
 
-  override def maxBefore(key: Elem): Option[Elem] = {
+  override def maxBefore(key: Int): Option[Int] = {
     if (key <= 0) None
     else {
       val adjustedKey = key - 1

--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -32,8 +32,6 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]
      with SortedOps[A, C] {
 
-  protected type Elem = A
-
   /** The companion object of this sorted set, providing various factory methods.
     *
     * @note When implementing a custom collection type and refining `CC` to the new type, this

--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -32,6 +32,8 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]
      with SortedOps[A, C] {
 
+  protected type Elem = A
+
   /** The companion object of this sorted set, providing various factory methods.
     *
     * @note When implementing a custom collection type and refining `CC` to the new type, this

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -169,4 +169,36 @@ class BitSetTest {
     assertThrows[NoSuchElementException](BitSet.empty.iteratorFrom(0).next)
   }
 
+  @Test def minAfter(): Unit = {
+    assertEquals(Some(0), (0 to 127).to(BitSet).minAfter(-2))
+    assertEquals(Some(0), (0 to 127).to(BitSet).minAfter(-1))
+    assertEquals(Some(0), (0 to 127).to(BitSet).minAfter(0))
+    assertEquals(Some(1), (0 to 127).to(BitSet).minAfter(1))
+    assertEquals(Some(63), (0 to 127).to(BitSet).minAfter(63))
+    assertEquals(Some(64), (0 to 127).to(BitSet).minAfter(64))
+    assertEquals(Some(2), BitSet(2).minAfter(1))
+    assertEquals(Some(2), BitSet(2).minAfter(2))
+    assertEquals(None, BitSet(2).minAfter(3))
+    assertEquals(None, BitSet(2).minAfter(1000))
+    assertEquals(None, BitSet.empty.minAfter(-1))
+    assertEquals(None, BitSet.empty.minAfter(0))
+    assertEquals(None, BitSet.empty.minAfter(Int.MaxValue))
+  }
+
+  @Test def maxBefore(): Unit = {
+    assertEquals(Some(0), (0 to 127).to(BitSet).maxBefore(1))
+    assertEquals(Some(1), (0 to 127).to(BitSet).maxBefore(2))
+    assertEquals(Some(62), (0 to 127).to(BitSet).maxBefore(63))
+    assertEquals(Some(63), (0 to 127).to(BitSet).maxBefore(64))
+    assertEquals(Some(64), (0 to 127).to(BitSet).maxBefore(65))
+    assertEquals(Some(2), BitSet(2).maxBefore(3))
+    assertEquals(Some(2), BitSet(2).maxBefore(1000))
+    assertEquals(None, BitSet(2).maxBefore(2))
+    assertEquals(None, BitSet(2).maxBefore(1))
+    assertEquals(None, BitSet(2).maxBefore(0))
+    assertEquals(None, BitSet.empty.maxBefore(-1))
+    assertEquals(None, BitSet.empty.maxBefore(0))
+    assertEquals(None, BitSet.empty.maxBefore(Int.MaxValue))
+  }
+
 }

--- a/test/scalacheck/scala/collection/immutable/BitSetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/BitSetProperties.scala
@@ -60,4 +60,21 @@ object BitSetProperties extends Properties("immutable.BitSet") {
     val bs = xs.to(BitSet)
     bs.iteratorFrom(start).to(Set) ?= xs.filter(_ >= start)
   }
+
+  property("minAfter") = forAll(
+    listOfN(200, oneOf(0 to 10000)).map(_.to(Set)),
+    Gen.chooseNum[Int](0, 10000)) {
+    (xs: Set[Int], after: Int) =>
+      val bs = xs.to(BitSet)
+      bs.minAfter(after) ?= xs.filter(_ >= after).minOption
+  }
+
+  property("maxBefore") = forAll(
+    listOfN(200, oneOf(0 to 10000)).map(_.to(Set)),
+    Gen.chooseNum[Int](0, 10000)) {
+    (xs: Set[Int], before: Int) =>
+      val bs = xs.to(BitSet)
+      bs.maxBefore(before) ?= xs.filter(_ < before).maxOption
+  }
+
 }


### PR DESCRIPTION
Currently `BitSet` is using implementations of `minAfter`/`maxBefore` inherited from `SortedSet`. These implementations are very inefficient for `BitSet`:
- allocate a clone of `BitSet` and erase bits outside of the range (`rangeFrom`/`rangeUntil`)
- allocate and traverse first `Iterator` for `isEmpty` check
- allocate and traverse another `Iterator` for `head` / `last`

This PR implements dedicated overrides of `minAfter`/`maxBefore` for `BitSet`. No object allocations are performed, and a minimal traversal of `BitSet` words is done.

Current implementation:
```
[info] Benchmark                               (spacing)  Mode  Cnt     Score    Error  Units
[info] BitSetBoundedMinMaxBenchmark.maxBefore          0  avgt    6  2058.881 ± 23.838  ns/op
[info] BitSetBoundedMinMaxBenchmark.maxBefore          8  avgt    6   345.129 ±  4.539  ns/op
[info] BitSetBoundedMinMaxBenchmark.maxBefore        255  avgt    6    87.353 ±  0.714  ns/op
[info] BitSetBoundedMinMaxBenchmark.minAfter           0  avgt    6    64.473 ±  1.092  ns/op
[info] BitSetBoundedMinMaxBenchmark.minAfter           8  avgt    6    62.591 ±  0.859  ns/op
[info] BitSetBoundedMinMaxBenchmark.minAfter         255  avgt    6    62.375 ±  0.426  ns/op
```

This PR:
```
[info] Benchmark                               (spacing)  Mode  Cnt   Score   Error  Units
[info] BitSetBoundedMinMaxBenchmark.maxBefore          0  avgt    6  13.595 ± 0.148  ns/op
[info] BitSetBoundedMinMaxBenchmark.maxBefore          8  avgt    6  13.725 ± 0.344  ns/op
[info] BitSetBoundedMinMaxBenchmark.maxBefore        255  avgt    6  15.008 ± 0.535  ns/op
[info] BitSetBoundedMinMaxBenchmark.minAfter           0  avgt    6  13.334 ± 0.134  ns/op
[info] BitSetBoundedMinMaxBenchmark.minAfter           8  avgt    6  13.270 ± 0.155  ns/op
[info] BitSetBoundedMinMaxBenchmark.minAfter         255  avgt    6  16.770 ± 0.054  ns/op
```

Benchmark code:
```scala
package scala.collection.mutable

import java.util.concurrent.TimeUnit

import org.openjdk.jmh.annotations._

import scala.collection.mutable

@BenchmarkMode(Array(Mode.AverageTime))
@Fork(1)
@Threads(1)
@Warmup(iterations = 6)
@Measurement(iterations = 6)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@State(Scope.Benchmark)
class BitSetBoundedMinMaxBenchmark {

  @Param(Array("0", "8", "255"))
  var spacing: Int = _

  var bs: mutable.BitSet = _
  var middle: Int = _

  @Setup(Level.Iteration) def initializeRange(): Unit = {
    bs = mutable.BitSet(0 until 1000 by (spacing + 1): _*)
    middle = bs.max / 2
  }

  @Benchmark def minAfter = bs.minAfter(middle)

  @Benchmark def maxBefore = bs.maxBefore(middle)

}
```

