### PR TITLE
[nomerge] HashMap#transform reuses structure

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -236,6 +236,12 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.util.Properties.scalaProps"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.util.Properties.propFilename"),
 
+    // https://github.com/scala/scala/pull/8630
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap.transformImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashTrieMap.transformImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashMap1.transformImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashMapCollision1.transformImpl"),
+
     //
     // scala-relect
     //

--- a/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPathFactory.scala
@@ -13,7 +13,6 @@
 package scala.tools.nsc.classpath
 
 import scala.reflect.io.{AbstractFile, VirtualDirectory}
-import scala.reflect.io.Path.string2path
 import scala.tools.nsc.{CloseableRegistry, Settings}
 import FileUtils.AbstractFileOps
 import scala.tools.nsc.util.ClassPath

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -73,7 +73,6 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
     */
   protected def findMacroClassLoader(): ClassLoader = {
     import java.net.URL
-    import scala.tools.nsc.io.AbstractFile
 
     val classpath: Seq[URL] = if (settings.YmacroClasspath.isSetByUser) {
       for {

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashMapBenchmark.scala
@@ -2,8 +2,6 @@ package scala.collection.immutable
 
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra._
-import org.openjdk.jmh.runner.IterationType
-import benchmark._
 import java.util.concurrent.TimeUnit
 
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -52,5 +50,12 @@ class HashMapBenchmark {
       bh.consume(map.get(missingKeys(i)))
       i += 1
     }
+  }
+
+  @Benchmark def transform(): Unit = {
+    map.transform((_, _) => "")
+  }
+  @Benchmark def transformConserve(): Unit = {
+    map.transform((_, v) => v)
   }
 }

--- a/test/junit/scala/collection/immutable/HashMapTest.scala
+++ b/test/junit/scala/collection/immutable/HashMapTest.scala
@@ -116,4 +116,29 @@ class HashMapTest extends AllocationTest {
       shared == base
     })
   }
+
+  private val transformTestCases: List[HashMap[String, String]] = List(
+    HashMap("a" -> "b"),
+    HashMap("a" -> "b", "b" -> "c"),
+    HashMap("a" -> "b", "b" -> "c", "c" -> "d"),
+    HashMap("Ea" -> "FB", "FB" -> "Ea", "xyz" -> "xyz")
+  )
+
+  @Test
+  def transform {
+    def check(hm: HashMap[String, String]) {
+      val hm1 = hm transform ((k, v) => s"$k, $v")
+      assert(hm.size == hm1.size, (hm, hm1))
+      assert(hm.map { case (k, v) => k -> s"$k, $v" }.toSet == hm1.toSet, (hm, hm1))
+    }
+    transformTestCases foreach check
+  }
+  @Test
+  def transformBreakout {
+    def check(hm: HashMap[String, String]) {
+      val hm1: List[(String, String)] = hm.transform((k, v) => s"$k, $v")(collection.breakOut)
+      assert(hm1 == hm.toList.map { case (k, v) => k -> s"$k, $v"})
+    }
+    transformTestCases foreach check
+  }
 }


### PR DESCRIPTION
(2.12.x only, of course)

The keys in the resulting map are the same, so the internal structure will also be the same, and that can be used to avoid allocating tuples and going through `MapBuilder` and other such convolutions.

Benchmark results:
- 2.12.x:
```
[info] Benchmark                                                            (size)  Mode  Cnt       Score      Error   Units
[info] HashMapBenchmark.transform                                               10  avgt   20     656.603 ±    2.354   ns/op
[info] HashMapBenchmark.transform:·gc.alloc.rate                                10  avgt   20    1355.348 ±    4.860  MB/sec
[info] HashMapBenchmark.transform:·gc.alloc.rate.norm                           10  avgt   20    1400.001 ±    0.002    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space                       10  avgt   20    1362.048 ±   52.022  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space.norm                  10  avgt   20    1406.807 ±   50.904    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space                   10  avgt   20       0.143 ±    0.028  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space.norm              10  avgt   20       0.147 ±    0.029    B/op
[info] HashMapBenchmark.transform:·gc.count                                     10  avgt   20     241.000             counts
[info] HashMapBenchmark.transform:·gc.time                                      10  avgt   20     181.000                 ms
[info] HashMapBenchmark.transform                                              100  avgt   20    5664.033 ±   20.978   ns/op
[info] HashMapBenchmark.transform:·gc.alloc.rate                               100  avgt   20    2280.462 ±    8.412  MB/sec
[info] HashMapBenchmark.transform:·gc.alloc.rate.norm                          100  avgt   20   20320.009 ±    0.018    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space                      100  avgt   20    2275.425 ±   98.654  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space.norm                 100  avgt   20   20275.297 ±  878.556    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space                  100  avgt   20       0.114 ±    0.036  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space.norm             100  avgt   20       1.012 ±    0.325    B/op
[info] HashMapBenchmark.transform:·gc.count                                    100  avgt   20     249.000             counts
[info] HashMapBenchmark.transform:·gc.time                                     100  avgt   20     186.000                 ms
[info] HashMapBenchmark.transform                                             1000  avgt   20  111883.999 ± 2776.556   ns/op
[info] HashMapBenchmark.transform:·gc.alloc.rate                              1000  avgt   20    1519.829 ±   37.714  MB/sec
[info] HashMapBenchmark.transform:·gc.alloc.rate.norm                         1000  avgt   20  267298.361 ±    6.651    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space                     1000  avgt   20    1512.921 ±   66.094  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space.norm                1000  avgt   20  266064.016 ± 9137.317    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space                 1000  avgt   20       0.170 ±    0.048  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space.norm            1000  avgt   20      29.943 ±    8.709    B/op
[info] HashMapBenchmark.transform:·gc.count                                   1000  avgt   20     239.000             counts
[info] HashMapBenchmark.transform:·gc.time                                    1000  avgt   20     182.000                 ms
[info] HashMapBenchmark.transformConserve                                       10  avgt   20     619.002 ±    4.256   ns/op
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate                        10  avgt   20    1437.758 ±    9.867  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate.norm                   10  avgt   20    1400.001 ±    0.002    B/op
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Eden_Space               10  avgt   20    1431.354 ±   43.512  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Eden_Space.norm          10  avgt   20    1393.801 ±   42.144    B/op
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Survivor_Space           10  avgt   20       0.114 ±    0.029  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Survivor_Space.norm      10  avgt   20       0.111 ±    0.028    B/op
[info] HashMapBenchmark.transformConserve:·gc.count                             10  avgt   20     244.000             counts
[info] HashMapBenchmark.transformConserve:·gc.time                              10  avgt   20     181.000                 ms
[info] HashMapBenchmark.transformConserve                                      100  avgt   20    5459.810 ±   30.177   ns/op
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate                       100  avgt   20    2365.863 ±   13.078  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate.norm                  100  avgt   20   20320.009 ±    0.018    B/op
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Eden_Space              100  avgt   20    2360.973 ±   69.873  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Eden_Space.norm         100  avgt   20   20278.754 ±  607.945    B/op
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Survivor_Space          100  avgt   20       0.111 ±    0.033  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Survivor_Space.norm     100  avgt   20       0.957 ±    0.283    B/op
[info] HashMapBenchmark.transformConserve:·gc.count                            100  avgt   20     255.000             counts
[info] HashMapBenchmark.transformConserve:·gc.time                             100  avgt   20     190.000                 ms
[info] HashMapBenchmark.transformConserve                                     1000  avgt   20  100900.656 ±  621.356   ns/op
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate                      1000  avgt   20    1684.007 ±   10.358  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate.norm                 1000  avgt   20  267290.290 ±    4.321    B/op
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Eden_Space             1000  avgt   20    1685.846 ±   53.919  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Eden_Space.norm        1000  avgt   20  267592.455 ± 8666.193    B/op
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Survivor_Space         1000  avgt   20       0.159 ±    0.039  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Survivor_Space.norm    1000  avgt   20      25.298 ±    6.220    B/op
[info] HashMapBenchmark.transformConserve:·gc.count                           1000  avgt   20     244.000             counts
[info] HashMapBenchmark.transformConserve:·gc.time                            1000  avgt   20     188.000                 ms
```

- This PR:
```
[info] Benchmark                                                            (size)  Mode  Cnt      Score      Error   Units
[info] HashMapBenchmark.transform                                               10  avgt   20    110.214 ±    0.501   ns/op
[info] HashMapBenchmark.transform:·gc.alloc.rate                                10  avgt   20   2768.441 ±   12.595  MB/sec
[info] HashMapBenchmark.transform:·gc.alloc.rate.norm                           10  avgt   20    480.000 ±    0.001    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space                       10  avgt   20   2770.594 ±  121.884  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space.norm                  10  avgt   20    480.376 ±   21.031    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space                   10  avgt   20      0.138 ±    0.044  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space.norm              10  avgt   20      0.024 ±    0.008    B/op
[info] HashMapBenchmark.transform:·gc.count                                     10  avgt   20    235.000             counts
[info] HashMapBenchmark.transform:·gc.time                                      10  avgt   20    179.000                 ms
[info] HashMapBenchmark.transform                                              100  avgt   20   1314.796 ±   10.701   ns/op
[info] HashMapBenchmark.transform:·gc.alloc.rate                               100  avgt   20   2490.990 ±   19.863  MB/sec
[info] HashMapBenchmark.transform:·gc.alloc.rate.norm                          100  avgt   20   5152.002 ±    0.004    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space                      100  avgt   20   2490.424 ±   71.604  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space.norm                 100  avgt   20   5151.372 ±  157.034    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space                  100  avgt   20      0.142 ±    0.033  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space.norm             100  avgt   20      0.293 ±    0.068    B/op
[info] HashMapBenchmark.transform:·gc.count                                    100  avgt   20    254.000             counts
[info] HashMapBenchmark.transform:·gc.time                                     100  avgt   20    199.000                 ms
[info] HashMapBenchmark.transform                                             1000  avgt   20  14301.752 ±   69.119   ns/op
[info] HashMapBenchmark.transform:·gc.alloc.rate                              1000  avgt   20   2225.222 ±   10.718  MB/sec
[info] HashMapBenchmark.transform:·gc.alloc.rate.norm                         1000  avgt   20  50064.024 ±    0.047    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space                     1000  avgt   20   2227.828 ±   69.428  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space.norm                1000  avgt   20  50122.329 ± 1533.214    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space                 1000  avgt   20      0.173 ±    0.028  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space.norm            1000  avgt   20      3.888 ±    0.630    B/op
[info] HashMapBenchmark.transform:·gc.count                                   1000  avgt   20    252.000             counts
[info] HashMapBenchmark.transform:·gc.time                                    1000  avgt   20    188.000                 ms
[info] HashMapBenchmark.transformConserve                                       10  avgt   20     72.495 ±    0.174   ns/op
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate                        10  avgt   20    911.916 ±    2.184  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate.norm                   10  avgt   20    104.000 ±    0.001    B/op
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Eden_Space               10  avgt   20    909.602 ±   26.879  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Eden_Space.norm          10  avgt   20    103.740 ±    3.143    B/op
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Survivor_Space           10  avgt   20      0.117 ±    0.030  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Survivor_Space.norm      10  avgt   20      0.013 ±    0.003    B/op
[info] HashMapBenchmark.transformConserve:·gc.count                             10  avgt   20    255.000             counts
[info] HashMapBenchmark.transformConserve:·gc.time                              10  avgt   20    193.000                 ms
[info] HashMapBenchmark.transformConserve                                      100  avgt   20    949.201 ±    1.603   ns/op
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate                       100  avgt   20   1269.699 ±    2.140  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate.norm                  100  avgt   20   1896.002 ±    0.003    B/op
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Eden_Space              100  avgt   20   1267.611 ±   29.572  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Eden_Space.norm         100  avgt   20   1892.899 ±   44.587    B/op
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Survivor_Space          100  avgt   20      0.156 ±    0.035  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Survivor_Space.norm     100  avgt   20      0.233 ±    0.053    B/op
[info] HashMapBenchmark.transformConserve:·gc.count                            100  avgt   20    254.000             counts
[info] HashMapBenchmark.transformConserve:·gc.time                             100  avgt   20    189.000                 ms
[info] HashMapBenchmark.transformConserve                                     1000  avgt   20   9524.194 ±  111.590   ns/op
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate                      1000  avgt   20   1202.089 ±   14.115  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate.norm                 1000  avgt   20  18008.016 ±    0.031    B/op
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Eden_Space             1000  avgt   20   1201.171 ±   40.637  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Eden_Space.norm        1000  avgt   20  17995.335 ±  594.724    B/op
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Survivor_Space         1000  avgt   20      0.137 ±    0.039  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.churn.PS_Survivor_Space.norm    1000  avgt   20      2.056 ±    0.565    B/op
[info] HashMapBenchmark.transformConserve:·gc.count                           1000  avgt   20    253.000             counts
[info] HashMapBenchmark.transformConserve:·gc.time                            1000  avgt   20    190.000                 ms
```

- Alternative with [more aggressive conservation](https://gist.github.com/hrhino/c2fd850395b93ca6a7f84b85e5ec1317):
```
REG (with conserve)
[info] Benchmark                                                    (size)  Mode  Cnt      Score      Error   Units
[info] HashMapBenchmark.transform                                       10  avgt   20    114.979 ±    0.622   ns/op
[info] HashMapBenchmark.transform:·gc.alloc.rate                        10  avgt   20   2653.780 ±   14.209  MB/sec
[info] HashMapBenchmark.transform:·gc.alloc.rate.norm                   10  avgt   20    480.000 ±    0.001    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space               10  avgt   20   2649.555 ±   65.764  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space.norm          10  avgt   20    479.241 ±   11.759    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space           10  avgt   20      0.141 ±    0.038  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space.norm      10  avgt   20      0.025 ±    0.007    B/op
[info] HashMapBenchmark.transform:·gc.count                             10  avgt   20    252.000             counts
[info] HashMapBenchmark.transform:·gc.time                              10  avgt   20    190.000                 ms
[info] HashMapBenchmark.transform                                      100  avgt   20   1369.913 ±    6.994   ns/op
[info] HashMapBenchmark.transform:·gc.alloc.rate                       100  avgt   20   2390.664 ±   12.162  MB/sec
[info] HashMapBenchmark.transform:·gc.alloc.rate.norm                  100  avgt   20   5152.002 ±    0.004    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space              100  avgt   20   2393.799 ±   78.711  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space.norm         100  avgt   20   5158.951 ±  172.124    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space          100  avgt   20      0.152 ±    0.037  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space.norm     100  avgt   20      0.328 ±    0.080    B/op
[info] HashMapBenchmark.transform:·gc.count                            100  avgt   20    256.000             counts
[info] HashMapBenchmark.transform:·gc.time                             100  avgt   20    192.000                 ms
[info] HashMapBenchmark.transform                                     1000  avgt   20  14520.254 ±   73.534   ns/op
[info] HashMapBenchmark.transform:·gc.alloc.rate                      1000  avgt   20   2191.753 ±   11.074  MB/sec
[info] HashMapBenchmark.transform:·gc.alloc.rate.norm                 1000  avgt   20  50064.024 ±    0.047    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space             1000  avgt   20   2185.506 ±   86.944  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Eden_Space.norm        1000  avgt   20  49919.103 ± 1925.011    B/op
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space         1000  avgt   20      0.160 ±    0.056  MB/sec
[info] HashMapBenchmark.transform:·gc.churn.PS_Survivor_Space.norm    1000  avgt   20      3.664 ±    1.275    B/op
[info] HashMapBenchmark.transform:·gc.count                           1000  avgt   20    244.000             counts
[info] HashMapBenchmark.transform:·gc.time                            1000  avgt   20    182.000                 ms
[info] HashMapBenchmark.transformConserve                               10  avgt   20     15.104 ±    0.013   ns/op
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate                10  avgt   20      0.001 ±    0.002  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate.norm           10  avgt   20     ≈ 10⁻⁵               B/op
[info] HashMapBenchmark.transformConserve:·gc.count                     10  avgt   20        ≈ 0             counts
[info] HashMapBenchmark.transformConserve                              100  avgt   20    176.766 ±    0.472   ns/op
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate               100  avgt   20      0.001 ±    0.002  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate.norm          100  avgt   20     ≈ 10⁻⁴               B/op
[info] HashMapBenchmark.transformConserve:·gc.count                    100  avgt   20        ≈ 0             counts
[info] HashMapBenchmark.transformConserve                             1000  avgt   20   3624.239 ±   59.248   ns/op
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate              1000  avgt   20      0.001 ±    0.002  MB/sec
[info] HashMapBenchmark.transformConserve:·gc.alloc.rate.norm         1000  avgt   20      0.006 ±    0.012    B/op
[info] HashMapBenchmark.transformConserve:·gc.count                   1000  avgt   20        ≈ 0             counts
```

@mkeskells 