### PR TITLE
bump copyright year to 2020

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 Scala
-Copyright (c) 2002-2019 EPFL
-Copyright (c) 2011-2019 Lightbend, Inc.
+Copyright (c) 2002-2020 EPFL
+Copyright (c) 2011-2020 Lightbend, Inc.
 
 Scala includes software developed at
 LAMP/EPFL (https://lamp.epfl.ch/) and

--- a/doc/LICENSE.md
+++ b/doc/LICENSE.md
@@ -2,9 +2,9 @@ Scala is licensed under the [Apache License Version 2.0](https://www.apache.org/
 
 ## Scala License
 
-Copyright (c) 2002-2019 EPFL
+Copyright (c) 2002-2020 EPFL
 
-Copyright (c) 2011-2019 Lightbend, Inc.
+Copyright (c) 2011-2020 Lightbend, Inc.
 
 All rights reserved.
 

--- a/doc/License.rtf
+++ b/doc/License.rtf
@@ -23,8 +23,8 @@ Scala is licensed under the\'a0{\field{\*\fldinst{HYPERLINK "https://www.apache.
 \fs48 \cf2 Scala License\
 \pard\pardeftab720\sl360\sa320\partightenfactor0
 
-\f0\b0\fs28 \cf2 Copyright (c) 2002-2019 EPFL\
-Copyright (c) 2011-2019 Lightbend, Inc.\
+\f0\b0\fs28 \cf2 Copyright (c) 2002-2020 EPFL\
+Copyright (c) 2011-2020 Lightbend, Inc.\
 All rights reserved.\
 \pard\pardeftab720\sl360\sa320\partightenfactor0
 \cf2 \cb4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at {\field{\*\fldinst{HYPERLINK "http://www.apache.org/licenses/LICENSE-2.0"}}{\fldrslt http://www.apache.org/licenses/LICENSE-2.0}}.\

--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -27,7 +27,7 @@ object VersionUtil {
   )
 
   lazy val generatePropertiesFileSettings = Seq[Setting[_]](
-    copyrightString := "Copyright 2002-2019, LAMP/EPFL and Lightbend, Inc.",
+    copyrightString := "Copyright 2002-2020, LAMP/EPFL and Lightbend, Inc.",
     shellWelcomeString := """
       |     ________ ___   / /  ___
       |    / __/ __// _ | / /  / _ |

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -108,7 +108,7 @@ private[scala] trait PropertiesTrait {
    *  or "version (unknown)" if it cannot be determined.
    */
   val versionString         = "version " + scalaPropOrElse("version.number", "(unknown)")
-  val copyrightString       = scalaPropOrElse("copyright.string", "Copyright 2002-2019, LAMP/EPFL and Lightbend, Inc.")
+  val copyrightString       = scalaPropOrElse("copyright.string", "Copyright 2002-2020, LAMP/EPFL and Lightbend, Inc.")
 
   /** This is the encoding to use reading in source files, overridden with -encoding.
    *  Note that it uses "prop" i.e. looks in the scala jar, not the system properties.

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -407,7 +407,7 @@ trait EntityPage extends HtmlPage {
 
       {
         if (Set("epfl", "EPFL").contains(tpl.universe.settings.docfooter.value))
-          <div id="footer">Scala programming documentation. Copyright (c) 2002-2019 <a href="http://www.epfl.ch" target="_top">EPFL</a>, with contributions from <a href="http://www.lightbend.com" target="_top">Lightbend</a>.</div>
+          <div id="footer">Scala programming documentation. Copyright (c) 2002-2020 <a href="http://www.epfl.ch" target="_top">EPFL</a>, with contributions from <a href="http://www.lightbend.com" target="_top">Lightbend</a>.</div>
         else
           <div id="footer"> { tpl.universe.settings.docfooter.value } </div>
       }

--- a/src/scalap/decoder.properties
+++ b/src/scalap/decoder.properties
@@ -1,2 +1,2 @@
 version.number=2.0.1
-copyright.string=(c) 2002-2019 LAMP/EPFL
+copyright.string=(c) 2002-2020 LAMP/EPFL


### PR DESCRIPTION
modeled on #7679, and also checked with `git grep 2019`