### PR TITLE
Fix inconsistency in Java interop with Any/Object and Java wildcards

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -308,7 +308,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
         if (in.token == QMARK) {
           val pos = in.currentPos
           in.nextToken()
-          val hi = if (in.token == EXTENDS) { in.nextToken() ; typ() } else EmptyTree
+          val hi = if (in.token == EXTENDS) { in.nextToken() ; typ() } else Ident(definitions.ObjectClass)
           val lo = if (in.token == SUPER)   { in.nextToken() ; typ() } else EmptyTree
           val tdef = atPos(pos) {
             TypeDef(

--- a/test/files/pos/t11469_joint/Test.java
+++ b/test/files/pos/t11469_joint/Test.java
@@ -1,0 +1,11 @@
+import java.util.Optional;
+
+public class Test{
+  public abstract static class A<T> {
+    public void m(Optional<? extends T> a) { }
+  }
+  public abstract static class B extends A<Object> {
+    @Override
+    public void m(Optional<?> a) { }
+  }
+}

--- a/test/files/pos/t11469_joint/Test.scala
+++ b/test/files/pos/t11469_joint/Test.scala
@@ -1,0 +1,11 @@
+class A {
+  new Test.B() { }
+
+  new Test.B() {
+    override def m(a: java.util.Optional[_ <: Object]): Unit = { }
+  }
+
+  new Test.B() {
+    override def m(a: java.util.Optional[_]): Unit = { }
+  }
+}


### PR DESCRIPTION
Corresponds to the treatment of '*' in ClassfileParser.