### PR TITLE
Fix override checks involving raw Java types

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
+++ b/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
@@ -45,6 +45,9 @@ abstract class OverridingPairs extends SymbolPairs {
       && !exclude(low)                 // this admits private, as one can't have a private member that matches a less-private member.
       && (lowMemberType matches (self memberType high))
     ) // TODO we don't call exclude(high), should we?
+
+    override def skipOwnerPair(lowClass: Symbol, highClass: Symbol): Boolean =
+      lowClass.isJavaDefined && highClass.isJavaDefined // javac is already checking this better than we could
   }
 
   private def bothJavaOwnedAndEitherIsField(low: Symbol, high: Symbol): Boolean = {

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -506,6 +506,7 @@ abstract class RefChecks extends Transform {
             overrideErrorWithMemberInfo("volatile type member cannot override type member with non-volatile upper bound:")
         }
         def checkOverrideTerm(): Unit = {
+          member.cookJavaRawInfo() // #11584, #11840
           other.cookJavaRawInfo() // #2454
           if (!overridesTypeInPrefix(lowType, highType, rootType, member.isModuleOrModuleClass && other.isModuleOrModuleClass)) { // 8
             overrideTypeError()

--- a/test/files/pos/t11840/A_1.java
+++ b/test/files/pos/t11840/A_1.java
@@ -1,0 +1,12 @@
+public class A_1 {
+    public static abstract class X<T> {}
+
+    public static abstract class Y {
+        public X appendFile(String s) { return null; }
+    }
+
+    public static class Z extends Y {
+        @Override
+        public X appendFile(String s) { return null; }
+    }
+}

--- a/test/files/pos/t11840/B_2.scala
+++ b/test/files/pos/t11840/B_2.scala
@@ -1,0 +1,1 @@
+object B extends A_1.Z


### PR DESCRIPTION
In particular, this fixes https://github.com/scala/bug/issues/11840 which is a blocker for getting Spark on Scala 2.13. Also fixes https://github.com/scala/bug/issues/11584.