### PR TITLE
immutable.LinkedHashMap

### DIFF
--- a/src/library/scala/collection/immutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/immutable/LinkedHashMap.scala
@@ -39,6 +39,27 @@ import scala.collection.immutable.{LinkedHashMap => LHM}
  *           ->   is a forward reference by KEY (via lookup in an immutable HashMap)
  *           <-   is a backward reference by KEY (via lookup in an immutable HashMap)
  *
+ *
+ *
+ * Performance Characteristics:
+ *
+ *   Construction: Extremely fast (fastest of all immutable SeqMaps)! O(n log n). Approximately as fast as constructing
+ *   a HashMap, with minimal overhead involved in wrapping values in `Link[K, V]` instances and mutating prev/next
+ *   values during building.
+ *
+ *   Traversal/Iteration: Extremely fast (fastest of all immutable SeqMaps)! O(n + (1/arity) * n log n).
+ *   Almost as fast as traversing a `List`, but every `arity` elements, a hashmap lookup is required. For reference,
+ *   each lookup is approximately 25 ns.
+ *
+ *   Lookup: Extremely fast (on par with other immutable SeqMaps)! O(log n). Simply a lookup in a
+ *   `HashMap[K, Link[K, V]]`, and then an additional dereferencing of the value. Virtually as fast as HashMap itself.
+ *
+ *   Updates: Quite slow, but not pathological (1/3 as fast as VectorMap)! O((arity/2) * log n). When updating a key, all nodes
+ *   that PRECEDE that node, in its `arity`-sized segment must be updated accordingly. Any nodes occurring after
+ *   the node only refer backwards by key, not by reference, so they need not be adjusted. So an update is equivalent to
+ *   roughly arity/2 lookups and arity/2 updates. The shallow mutation capabilities of immutable.HashMap are however
+ *   utilized to mitigate the downside.
+ *
  */
 final class LinkedHashMap[K, +V] private (private val _first: LHM.Link[K, V], private val _last: LHM.Link[K, V], hm: HashMap[K, LHM.Link[K, V]])
   extends AbstractMap[K, V]

--- a/src/library/scala/collection/immutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/immutable/LinkedHashMap.scala
@@ -1,0 +1,167 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.immutable
+
+import scala.collection.{MapFactory, MapFactoryDefaults}
+import scala.collection.immutable.{LinkedHashMap => LHM}
+final class LinkedHashMap[K, +V] private (private val _first: LHM.Link[K, V], private val _last: LHM.Link[K, V], hm: HashMap[K, LHM.Link[K, V]])
+  extends AbstractMap[K, V]
+    with SeqMap[K, V]
+    with StrictOptimizedMapOps[K, V, LinkedHashMap, LinkedHashMap[K, V]]
+    with MapFactoryDefaults[K, V, LinkedHashMap, Iterable] {
+
+  override def mapFactory: MapFactory[LinkedHashMap] = LinkedHashMap
+
+  private[this] def allPreviousLinksInChain(link: LHM.Link[K, V], includeArgument: Boolean): List[LHM.Link[K, V]] = {
+    var result: List[LHM.Link[K, V]] = Nil
+    if (includeArgument) result = link :: result
+    var curr = link
+    while(curr.prev.asInstanceOf[AnyRef] ne LHM.End) {
+      val prevKey = curr.prev.asInstanceOf[K]
+      val prevLink = hm(prevKey)
+      if (prevLink.next.asInstanceOf[AnyRef] eq curr) {
+        result = prevLink :: result
+      } else {
+        return result
+      }
+      curr = prevLink
+    }
+    result
+  }
+
+  override def removed(key: K): LinkedHashMap[K, V] = ???
+  override def updated[V1 >: V](key: K, value: V1): LinkedHashMap[K, V1] = {
+    hm.get(key) match {
+      case Some(old) =>
+        if (old.value.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) {
+          this
+        } else {
+          val oldPrevLinks = allPreviousLinksInChain(old, includeArgument = false)
+          val newPrevLinks = oldPrevLinks.foldLeft(List.empty[(K, LHM.Link[K, V])]){
+            case (acc @ h :: _, link) =>
+              val copiedLink = link.copy()
+              h._2.next = copiedLink
+              (link.key, copiedLink) :: acc
+            case (Nil, link) =>
+              (link.key, link.copy()) :: Nil
+          }
+
+          val newLink = LHM.Link(key, value, old.prev, old.next)
+
+          newPrevLinks match {
+            case h :: _ => h._2.next = newLink
+            case _ =>
+          }
+
+          val allNewLinks = (newLink.key, newLink) :: newPrevLinks
+
+          val newHm = hm.concat(allNewLinks)
+
+          var newFirst: LHM.Link[K, V1] = _first
+          var newLast: LHM.Link[K, V1] = _last
+
+          if (newFirst == old) {
+            newFirst = newLink
+          } else if (newFirst == null) {
+            newFirst = newLink
+            newLast = newLink
+          } else if(oldPrevLinks.nonEmpty && (oldPrevLinks.head eq _first)) {
+            newFirst = newPrevLinks.last._2
+          }
+
+          if (newLast eq old) {
+            newLast = newLink
+          }
+          new LinkedHashMap(newFirst, newLast, newHm)
+        }
+      case None =>
+        if (_first == null) {
+          val newLink = LHM.Link(key, value, LHM.End, LHM.End)
+          return new LinkedHashMap(newLink, newLink, HashMap.empty.updated(key, newLink))
+        }
+
+        val oldPrevLinks = allPreviousLinksInChain(_last, includeArgument = true)
+        val newPrevLinks = oldPrevLinks.foldLeft(List.empty[(K, LHM.Link[K, V])]){
+          case (acc @ h :: _, link) =>
+            val copiedLink = link.copy()
+            h._2.next = copiedLink
+            (link.key, copiedLink) :: acc
+          case (Nil, link) =>
+            (link.key, link.copy()) :: Nil
+        }
+
+        val newPrevLink = newPrevLinks.head._2
+        val newLink = LHM.Link(key, value, newPrevLink.key, LHM.End)
+        newPrevLink.next = if (hm.size % LHM.arity == 0) key else newLink
+
+        val newHm = hm.concat((key, newLink) :: newPrevLinks)
+
+        var newFirst: LHM.Link[K, V1] = _first
+        if (oldPrevLinks.head eq _first) {
+          newFirst = newPrevLinks.last._2
+        }
+
+        new LinkedHashMap(newFirst, newLink, newHm)
+    }
+  }
+  override def get(key: K): Option[V] = hm.getOrElse(key, LHM.End) match {
+    case LHM.End => None
+    case v => Some(v).asInstanceOf[Option[V]]
+  }
+  override def iterator: Iterator[(K, V)] = {
+    if (_first == null) {
+      Iterator.empty
+    } else new Iterator[(K, V)] {
+      var curr: LHM.Link[K, V] = _first
+      override def hasNext: Boolean = curr ne null
+      override def next(): (K, V) = {
+        if (curr == null) {
+          Iterator.empty.next()
+        } else {
+          val result = curr.tuple
+          curr = curr.next match {
+            case link: LHM.Link[K, V] => link
+            case LHM.End => null
+            case key => hm(key.asInstanceOf[K])
+          }
+          result
+        }
+      }
+    }
+
+  }
+}
+
+object LinkedHashMap extends MapFactory[LinkedHashMap] {
+  private final def arity: Int = 3
+  private final val End: AnyRef = new AnyRef {}
+  private final case class Link[K, +V](key: K, value: V, prev: Any, var next: Any) {
+    def tuple: (K, V) = (key, value)
+  }
+
+  private final val Empty: LinkedHashMap[Nothing, Nothing] = new LinkedHashMap[Nothing, Nothing](null, null, HashMap.empty)
+
+  override def empty[K, V]: LinkedHashMap[K, V] = Empty.asInstanceOf[LinkedHashMap[K, V]]
+
+  override def from[K, V](it: IterableOnce[(K, V)]): LinkedHashMap[K, V] = it.iterator.foldLeft(empty[K, V]) {
+    case (acc, (k, v)) => acc.updated(k, v)
+  }
+
+  override def newBuilder[K, V]: collection.mutable.Builder[(K, V), LinkedHashMap[K, V]] =
+    new collection.mutable.ImmutableBuilder[(K, V), LinkedHashMap[K, V]](empty) {
+      override def addOne(elem: (K, V)): this.type = {
+        elems = elems.updated(elem._1, elem._2)
+        this
+      }
+    }
+}

--- a/src/library/scala/collection/immutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/immutable/LinkedHashMap.scala
@@ -281,10 +281,26 @@ final class LinkedHashMap[K, +V] private (private val _first: LHM.Link[K, V], pr
     }
 
   }
+
+  override def foreach[U](f: ((K, V)) => U): Unit = {
+    var curr = _first
+    while (curr != null) {
+      f(curr.tuple)
+      curr = curr.next match { case LHM.End => null case l: LHM.Link[K, V] => l case k => hm(k.asInstanceOf[K])}
+    }
+  }
+
+  override def foreachEntry[U](f: (K, V) => U): Unit = {
+    var curr = _first
+    while (curr != null) {
+      f(curr.key, curr.value)
+      curr = curr.next match { case LHM.End => null case l: LHM.Link[K, V] => l case k => hm(k.asInstanceOf[K])}
+    }
+  }
 }
 
 object LinkedHashMap extends MapFactory[LinkedHashMap] {
-  private final def arity: Int = 3
+  final def arity: Int = 3
   private final val End: AnyRef = new AnyRef {}
   private final class Link[K, +V](val key: K, var value: V @uncheckedVariance, val prev: Any, var next: Any) {
     def copy[V1 >: V](key: K = key, value: V1 = value, prev: Any = prev, next: Any = next): Link[K, V1] = new Link(key, value, prev, next)

--- a/src/library/scala/collection/immutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/immutable/LinkedHashMap.scala
@@ -21,7 +21,7 @@ import scala.collection.immutable.{LinkedHashMap => LHM}
  *  which refer forwards by REFERENCE to the next Link, and backwards by LOOKUP KEY to the previous Link.
  *
  * Referring forward by reference is beneficial for traversal, but to have acceptable update/remove performance, the
- * entire Map cannot be forward-linked by reference. That would necessetate a complete map reconstruction performing
+ * entire Map cannot be forward-linked by reference. That would necessetate a complete map reconstruction when performing
  * immutable writes. The forward-reference chain therefor breaks at regular intervals of `arity` nodes, where `arity`
  * is a configurable parameter in the companion object. After thorough benchmarking, it was found that `arity`= 2 strikes
  * the most sensible balance, as the costliness of updates becomes drastically greater for arities >=3, while benefit

--- a/src/library/scala/collection/immutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/immutable/LinkedHashMap.scala
@@ -199,7 +199,7 @@ final class LinkedHashMap[K, +V] private (private val _first: LHM.Link[K, V], pr
 }
 
 object LinkedHashMap extends MapFactory[LinkedHashMap] {
-  private final val arity: Int = 3
+  private final def arity: Int = 3
   private final val End: AnyRef = new AnyRef {}
   private final class Link[K, +V](val key: K, var value: V @uncheckedVariance, val prev: Any, var next: Any) {
     def copy(): Link[K, V] = new Link(key, value, prev, next)
@@ -257,7 +257,36 @@ object LinkedHashMap extends MapFactory[LinkedHashMap] {
       }
 
       override def addAll(xs: IterableOnce[(K, V)]): this.type = {
-        super.addAll(xs)
+        var __first = _first
+        var __last = _last
+        var __size = size
+        val iter = xs.iterator
+        while (iter.hasNext) {
+          val (k, v) = iter.next()
+          val old = hm.getOrElse(k, null)
+          if (old == null) {
+            val link = new Link(k, v, if (__last == null) End else __last.key, End)
+            if(__last != null) {
+              if (__size % arity != 0) {
+                __last.next = link
+              } else {
+                __last.next = k
+              }
+            }
+            if (__first == null) {
+              __first = link
+            }
+            hm.addOne(k, link)
+            __size += 1
+            __last = link
+          } else {
+            old.value = v
+          }
+        }
+        _first = __first
+        _last = __last
+        size = __size
+        this
       }
     }
 }

--- a/src/library/scala/collection/immutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/immutable/LinkedHashMap.scala
@@ -363,7 +363,7 @@ final class LinkedHashMap[K, +V] private (private val _first: LHM.Link[K, V], pr
 
   override def get(key: K): Option[V] = hm.getOrElse(key, LHM.End) match {
     case LHM.End => None
-    case v => Some(v).asInstanceOf[Option[V]]
+    case v => Some(v.asInstanceOf[LHM.Link[K, V]].value).asInstanceOf[Option[V]]
   }
   override def iterator: Iterator[(K, V)] = {
     if (_first == null) {

--- a/src/library/scala/collection/immutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/immutable/LinkedHashMap.scala
@@ -65,6 +65,7 @@ import scala.collection.immutable.{LinkedHashMap => LHM}
  *   Link, so that it refers back (by key) to the Link before the removed Link. Only the immediately succeeding node
  *   needs replacing though.
  *
+ * @author Josh Lemer
  */
 final class LinkedHashMap[K, +V] private (private val _first: LHM.Link[K, V], private val _last: LHM.Link[K, V], hm: HashMap[K, LHM.Link[K, V]])
   extends AbstractMap[K, V]

--- a/src/library/scala/collection/immutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/immutable/LinkedHashMap.scala
@@ -352,17 +352,7 @@ final class LinkedHashMap[K, +V] private (private val _first: LHM.Link[K, V], pr
 
             new LinkedHashMap(newFirst, newLast, if (newPrevNode == null) hm.updated(key, newLink) else concatToHm(newPrevNode :: newLink :: Nil))
 
-            }
-          // todo
-//          val newLink = new LHM.Link[K, V1](key, value, old.prev, old.next)
-        //          return updated(key, value)
-//          if (old.value.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) {
-//            this
-//          } else {
-//            val link = old.copy(value = value)
-//
-//            new LinkedHashMap(if (_first eq old) link else _first, if (_last eq old) link else _last, hm.updated(key, link))
-//          }
+          }
       }
     }
   }

--- a/src/library/scala/collection/immutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/immutable/LinkedHashMap.scala
@@ -57,7 +57,7 @@ import scala.collection.immutable.{LinkedHashMap => LHM}
  *   Lookup: Extremely fast (on par with other immutable SeqMaps)! O(log n). Simply a lookup in a
  *   `HashMap[K, Link[K, V]]`, and then an additional dereference of the value. Virtually as fast as HashMap itself.
  *
- *   Updates: Poor, but not pathological (50% slower than VectorMap)! O((arity/2) * log n). When updating a key,
+ *   Updates: Poor, but not pathological (40% slower than VectorMap)! O((arity/2) * log n). When updating a key,
  *   all nodes that PRECEDE that node, in its `arity`-sized segment must be updated accordingly. Any nodes occurring after
  *   the node only refer backwards by key, not by reference, so they need not be adjusted. So an update is equivalent to
  *   roughly arity/2 lookups and arity/2 updates. The shallow mutation capabilities of immutable.HashMap are however

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorMapBenchmark.scala
@@ -18,48 +18,48 @@ class VectorMapBenchmark {
   var size: Int = _
 
   var kvs: Seq[(Int, Int)] = _
-  var vm: VectorMap[Int, Int] = _
+//  var vm: VectorMap[Int, Int] = _
   var lhm: LinkedHashMap[Int, Int] = _
 
   @Setup(Level.Trial)
   def initKeys(): Unit = {
     val unique = (0 to size).map(i => i -> i)
     kvs = unique ++ unique
-    vm = VectorMap.from(kvs)
+//    vm = VectorMap.from(kvs)
     lhm = LinkedHashMap.from(kvs)
   }
-
-  @Benchmark
-  def buildVm(bh: Blackhole): Unit = {
-    bh.consume(VectorMap.from(kvs))
-  }
-  @Benchmark
-  def buildLhm(bh: Blackhole): Unit = {
-    bh.consume(LinkedHashMap.from(kvs))
-  }
-  @Benchmark
-  def foreachVm(bh: Blackhole): Unit = {
-    vm.foreach(bh.consume)
-  }
-  @Benchmark
-  def foreachLhm(bh: Blackhole): Unit = {
-    lhm.foreach(bh.consume)
-  }
-  @Benchmark
-  def getVm(bh: Blackhole): Unit = {
-    bh.consume(vm.get(size / 2))
-    bh.consume(vm.get(size))
-  }
-  @Benchmark
-  def getLhm(bh: Blackhole): Unit = {
-    bh.consume(lhm.get(size / 2))
-    bh.consume(lhm.get(size))
-  }
-  @Benchmark
-  def updatedVm(bh: Blackhole): Unit = {
-    bh.consume(vm.updated(size / 2, -1))
-    bh.consume(vm.updated(size, -1))
-  }
+//
+//  @Benchmark
+//  def buildVm(bh: Blackhole): Unit = {
+//    bh.consume(VectorMap.from(kvs))
+//  }
+//  @Benchmark
+//  def buildLhm(bh: Blackhole): Unit = {
+//    bh.consume(LinkedHashMap.from(kvs))
+//  }
+//  @Benchmark
+//  def foreachVm(bh: Blackhole): Unit = {
+//    vm.foreach(bh.consume)
+//  }
+//  @Benchmark
+//  def foreachLhm(bh: Blackhole): Unit = {
+//    lhm.foreach(bh.consume)
+//  }
+//  @Benchmark
+//  def getVm(bh: Blackhole): Unit = {
+//    bh.consume(vm.get(size / 2))
+//    bh.consume(vm.get(size))
+//  }
+//  @Benchmark
+//  def getLhm(bh: Blackhole): Unit = {
+//    bh.consume(lhm.get(size / 2))
+//    bh.consume(lhm.get(size))
+//  }
+//  @Benchmark
+//  def updatedVm(bh: Blackhole): Unit = {
+//    bh.consume(vm.updated(size / 2, -1))
+//    bh.consume(vm.updated(size, -1))
+//  }
   @Benchmark
   def updatedLhm(bh: Blackhole): Unit = {
     bh.consume(lhm.updated(size / 2, -1))

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorMapBenchmark.scala
@@ -55,14 +55,23 @@ class VectorMapBenchmark {
 //    bh.consume(lhm.get(size / 2))
 //    bh.consume(lhm.get(size))
 //  }
+//  @Benchmark
+//  def updatedVm(bh: Blackhole): Unit = {
+////    bh.consume(vm.updated(size / 2, -1))
+//    bh.consume(vm.updated(size, -1))
+//  }
+//  @Benchmark
+//  def updatedLhm(bh: Blackhole): Unit = {
+//    bh.consume(lhm.updated(size / 2, -1))
+////    bh.consume(lhm.updated(size, -1))
+//  }
+
   @Benchmark
-  def updatedVm(bh: Blackhole): Unit = {
-//    bh.consume(vm.updated(size / 2, -1))
-    bh.consume(vm.updated(size, -1))
+  def removedVm(bh: Blackhole): Unit = {
+    bh.consume(vm.removed(size/2))
   }
   @Benchmark
-  def updatedLhm(bh: Blackhole): Unit = {
-    bh.consume(lhm.updated(size / 2, -1))
-//    bh.consume(lhm.updated(size, -1))
+  def removedLhm(bh: Blackhole): Unit = {
+    bh.consume(lhm.removed(size/2))
   }
 }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorMapBenchmark.scala
@@ -18,14 +18,14 @@ class VectorMapBenchmark {
   var size: Int = _
 
   var kvs: Seq[(Int, Int)] = _
-//  var vm: VectorMap[Int, Int] = _
+  var vm: VectorMap[Int, Int] = _
   var lhm: LinkedHashMap[Int, Int] = _
 
   @Setup(Level.Trial)
   def initKeys(): Unit = {
     val unique = (0 to size).map(i => i -> i)
     kvs = unique ++ unique
-//    vm = VectorMap.from(kvs)
+    vm = VectorMap.from(kvs)
     lhm = LinkedHashMap.from(kvs)
   }
 //
@@ -55,14 +55,14 @@ class VectorMapBenchmark {
 //    bh.consume(lhm.get(size / 2))
 //    bh.consume(lhm.get(size))
 //  }
-//  @Benchmark
-//  def updatedVm(bh: Blackhole): Unit = {
+  @Benchmark
+  def updatedVm(bh: Blackhole): Unit = {
 //    bh.consume(vm.updated(size / 2, -1))
-//    bh.consume(vm.updated(size, -1))
-//  }
+    bh.consume(vm.updated(size, -1))
+  }
   @Benchmark
   def updatedLhm(bh: Blackhole): Unit = {
     bh.consume(lhm.updated(size / 2, -1))
-    bh.consume(lhm.updated(size, -1))
+//    bh.consume(lhm.updated(size, -1))
   }
 }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorMapBenchmark.scala
@@ -7,27 +7,62 @@ import benchmark._
 import java.util.concurrent.TimeUnit
 
 @BenchmarkMode(Array(Mode.AverageTime))
-@Fork(2)
+@Fork(1)
 @Threads(1)
-@Warmup(iterations = 10)
-@Measurement(iterations = 10)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
 class VectorMapBenchmark {
-  @Param(Array("1", "10", "100", "1000", "1000000"))
+  @Param(Array("1", "5", "10", "100", "1000", "1000000"))
   var size: Int = _
 
-  var kvs: Iterable[(Int, Int)] = _
+  var kvs: Seq[(Int, Int)] = _
+  var vm: VectorMap[Int, Int] = _
+  var lhm: LinkedHashMap[Int, Int] = _
 
   @Setup(Level.Trial)
   def initKeys(): Unit = {
     val unique = (0 to size).map(i => i -> i)
     kvs = unique ++ unique
+    vm = VectorMap.from(kvs)
+    lhm = LinkedHashMap.from(kvs)
   }
 
   @Benchmark
-  def builder(bh: Blackhole): Unit = {
-    val b = VectorMap.newBuilder[Int, Int]
-    bh.consume(b.addAll(kvs).result())
+  def buildVm(bh: Blackhole): Unit = {
+    bh.consume(VectorMap.from(kvs))
+  }
+  @Benchmark
+  def buildLhm(bh: Blackhole): Unit = {
+    bh.consume(LinkedHashMap.from(kvs))
+  }
+  @Benchmark
+  def foreachVm(bh: Blackhole): Unit = {
+    vm.foreach(bh.consume)
+  }
+  @Benchmark
+  def foreachLhm(bh: Blackhole): Unit = {
+    lhm.foreach(bh.consume)
+  }
+  @Benchmark
+  def getVm(bh: Blackhole): Unit = {
+    bh.consume(vm.get(size / 2))
+    bh.consume(vm.get(size))
+  }
+  @Benchmark
+  def getLhm(bh: Blackhole): Unit = {
+    bh.consume(lhm.get(size / 2))
+    bh.consume(lhm.get(size))
+  }
+  @Benchmark
+  def updatedVm(bh: Blackhole): Unit = {
+    bh.consume(vm.updated(size / 2, -1))
+    bh.consume(vm.updated(size, -1))
+  }
+  @Benchmark
+  def updatedLhm(bh: Blackhole): Unit = {
+    bh.consume(lhm.updated(size / 2, -1))
+    bh.consume(lhm.updated(size, -1))
   }
 }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorMapBenchmark.scala
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
 class VectorMapBenchmark {
-  @Param(Array("1", "5", "10", "100", "1000", "1000000"))
+  @Param(Array ("5", "10", "100", "1000", "1000000"))
   var size: Int = _
 
   var kvs: Seq[(Int, Int)] = _
@@ -27,8 +27,9 @@ class VectorMapBenchmark {
     kvs = unique ++ unique
     vm = VectorMap.from(kvs)
     lhm = LinkedHashMap.from(kvs)
+//    println("arity=" + LinkedHashMap.arity)
   }
-//
+
 //  @Benchmark
 //  def buildVm(bh: Blackhole): Unit = {
 //    bh.consume(VectorMap.from(kvs))
@@ -37,34 +38,38 @@ class VectorMapBenchmark {
 //  def buildLhm(bh: Blackhole): Unit = {
 //    bh.consume(LinkedHashMap.from(kvs))
 //  }
+
 //  @Benchmark
 //  def foreachVm(bh: Blackhole): Unit = {
 //    vm.foreach(bh.consume)
 //  }
-//  @Benchmark
-//  def foreachLhm(bh: Blackhole): Unit = {
-//    lhm.foreach(bh.consume)
-//  }
-//  @Benchmark
-//  def getVm(bh: Blackhole): Unit = {
-//    bh.consume(vm.get(size / 2))
-//    bh.consume(vm.get(size))
-//  }
-//  @Benchmark
-//  def getLhm(bh: Blackhole): Unit = {
-//    bh.consume(lhm.get(size / 2))
-//    bh.consume(lhm.get(size))
-//  }
+  @Benchmark
+  def foreachLhm(bh: Blackhole): Unit = {
+    lhm.foreach(bh.consume)
+  }
+  /*
+  @Benchmark
+  def getVm(bh: Blackhole): Unit = {
+    bh.consume(vm.get(size / 2))
+    bh.consume(vm.get(size))
+  }
+  @Benchmark
+  def getLhm(bh: Blackhole): Unit = {
+    bh.consume(lhm.get(size / 2))
+    bh.consume(lhm.get(size))
+  }
+  */
 //  @Benchmark
 //  def updatedVm(bh: Blackhole): Unit = {
-////    bh.consume(vm.updated(size / 2, -1))
-//    bh.consume(vm.updated(size, -1))
+//    bh.consume(vm.updated(size / 2, -1))
+////    bh.consume(vm.updated(size, -1))
 //  }
 //  @Benchmark
 //  def updatedLhm(bh: Blackhole): Unit = {
 //    bh.consume(lhm.updated(size / 2, -1))
 ////    bh.consume(lhm.updated(size, -1))
 //  }
+  /*
 
   @Benchmark
   def removedVm(bh: Blackhole): Unit = {
@@ -74,4 +79,6 @@ class VectorMapBenchmark {
   def removedLhm(bh: Blackhole): Unit = {
     bh.consume(lhm.removed(size/2))
   }
+
+   */
 }

--- a/test/junit/scala/collection/MapTest.scala
+++ b/test/junit/scala/collection/MapTest.scala
@@ -124,15 +124,29 @@ class MapTest {
 
   @Test def foo(): Unit = {
 
-    val lhm = immutable.LinkedHashMap("a" -> 1, "b" -> 2, "c" -> 3, "d" -> 4)
 
-    println(lhm)
-//    println(lhm.updated("b", 55))
-    val result = lhm.updated("a", 55)
+    var i = 0
+    for {
+      size <- 20 to 20
+      kvs = Array.tabulate(size)(i => i.toString -> i)
+      map = kvs.toMap
+      lhm = kvs.to(immutable.LinkedHashMap)
+    } {
+      println(lhm)
+      if (lhm != map) {
 
-    println(result)
-//    println(lhm.updated("d", 55))
-//    println(lhm.updated("e", 55))
+        print("fail A")
+        val x = lhm equals map
+        println(x)
+      }
+      for { (k, _) <- kvs } {
+        if (lhm.updated(k, "-1") != map.updated(k, "-1")) {
+          println("fail B")
+        }
+        i += 1
+      }
+    }
+    println(i)
 
   }
 

--- a/test/junit/scala/collection/MapTest.scala
+++ b/test/junit/scala/collection/MapTest.scala
@@ -131,7 +131,7 @@ class MapTest {
       kvs = Array.tabulate(size)(i => i.toString -> i)
       map = kvs.toMap
       lhm = kvs.to(immutable.LinkedHashMap)
-    } {
+    } try {
       println(lhm)
       if (lhm != map) {
 
@@ -145,6 +145,17 @@ class MapTest {
         }
         i += 1
       }
+      for { (k, _) <- kvs } {
+        try {
+          if (lhm.removed(k) != map.removed(k)) {
+            println("fail C")
+          }
+        } finally println(k)
+      }
+      if (lhm.removed("") != map.removed("")) {
+        println("fail D")
+      }
+    } finally {
     }
     println(i)
 

--- a/test/junit/scala/collection/MapTest.scala
+++ b/test/junit/scala/collection/MapTest.scala
@@ -122,4 +122,19 @@ class MapTest {
     check(mutable.CollisionProofHashMap(1 -> 1))
   }
 
+  @Test def foo(): Unit = {
+
+    val lhm = immutable.LinkedHashMap("a" -> 1, "b" -> 2, "c" -> 3, "d" -> 4)
+
+    println(lhm)
+//    println(lhm.updated("b", 55))
+    val result = lhm.updated("a", 55)
+
+    println(result)
+//    println(lhm.updated("d", 55))
+//    println(lhm.updated("e", 55))
+
+  }
+
+
 }


### PR DESCRIPTION
Hi folks, I thought I would bring up yet an other `immutable.SeqMap` impelementation for discussion, which beats the current best implementation (VectorMap) in terms of:  
* memory usage (~16% less memory usage than VectorMap) 
* build time (from ~50% faster for small to ~15% faster for large maps)
* iteration (2x as fast as VectorMap)

, is equal to VectorMap in:  

* lookups

, and performs worse than VectorMap in:

* updates (VectorMap is ~30% faster)
* removals (VectorMap is ~43% faster)


I won't describe here the exact explanation of the data structure, since [there is a quite detailed explanation of the structure, as well as the algorithms for the above operations, included in the Scaladoc for the `immutable.LinkedHashMap` class itself](https://github.com/scala/scala/pull/8644/files#diff-4fb0a2a81364b15cd17f335f3a30c263R20).

### Benchmarks:

I have included benchmark results for the above operations in this gist :https://gist.github.com/joshlemer/af5dcfe6d7a7e34a9ddb0c4d0dcec79f which includes as well memory consumption for building.

### Arity 
`arity` is what I'm calling the maximum length of chains of forward-referencing Links in the Map (please see the scaladoc for a complete explanation). It can be finely tuned by changing the `LinkedHashMap.arity` method, but after playing around with it a bit, it seems that arity=2 strikes the best balance between iteration and writes. There's something like a 50% speedup in going from arity=1 to arity=2 with very little cost to writes, but going from arity=2 to arity=3, there's a significant slowdown to writes with diminishing benefits to iteration.

The general `updated` method is fully general over any arity, but it pays for that generality in speed. For this reason I've written hand-optimized versions of the method for when arity=1 and arity=2, these are the `updatedArity1` and `updatedArity2` methods respectively. Once an arity is decided on, we can just replace `updated` with the appropriate implementation.   
  
### Thoughts?

I've opened this draft PR just to get some feedback on if this data structure seems valuable? If folks here think that the gains in build/iteration/memory are worth the cost to updates/removals, and maybe for consideration as possibly the default SeqMap in much later versions of Scala?

 When 2.13 was released I think there were a few unknowns or work left to do but time kinda ran out before they could be fully thought through:

* which SeqMap to set as default (VectorMap or TreeSeqMap)
* which SeqMap to include at all (VectorMap, or VectorMap+TreeSeqMap)
* if we should deprecate ListMap (IMO, yes)
* Can VectorMap be further optimized? Maybe an implementation with RelaxedRadixBalancedVector would be make VectorMap strictly dominate TreeSeqMap and so TreeSeqMap would be rendered obsolete. Now with Stefan's improvements to Vector this is also worth revisiting IMO.
* Are there other potential contenders for best general SeqMap we haven't considered yet? (Enter: LinkedHashMap)


So this proposal / draft is just a continuation of that whole discussion. @odd @Ichoran 





