### PR TITLE
Fix broken Scaladoc external Java references

### DIFF
--- a/src/reflect/scala/reflect/io/PlainFile.scala
+++ b/src/reflect/scala/reflect/io/PlainFile.scala
@@ -151,7 +151,7 @@ final class PlainNioFile(val nioPath: java.nio.file.Path) extends AbstractFile {
         if (nioPath.getNameCount > 2 && nioPath.startsWith("/modules")) {
           // TODO limit this to OpenJDK based JVMs?
           val moduleName = nioPath.getName(1)
-          Some(new PlainNioFile(Paths.get(System.getProperty("java.home"), "jmods", moduleName.toString + ".jmod")))
+          Some(new PlainNioFile(Paths.get("/modules", moduleName.toString + ".jmod")))
         } else None
       case _ => None
     }


### PR DESCRIPTION
The problem was that PlainNioFile.underlyingSource was expanding "/modules/java.base" into a full path, where as the lookup in findExternalLink was using relative paths ("/modules/java.base.jmod")

Fixes scala/bug#11839

Supersedes #8647