### PR TITLE
avoid creating IntRefs and streamline some hashing operations

### DIFF
--- a/src/library/scala/util/hashing/MurmurHash3.scala
+++ b/src/library/scala/util/hashing/MurmurHash3.scala
@@ -96,31 +96,49 @@ private[hashing] class MurmurHash3 {
    *  This is useful for hashing sets, for example.
    */
   final def unorderedHash(xs: TraversableOnce[Any], seed: Int): Int = {
-    var a, b, n = 0
-    var c = 1
-    xs foreach { x =>
-      val h = x.##
-      a += h
-      b ^= h
-      if (h != 0) c *= h
-      n += 1
+    if  (xs.isEmpty) {
+      var h = seed
+      h = mix(h, 0)
+      h = mix(h, 0)
+      h = mixLast(h, 1)
+      finalizeHash(h, 0)
     }
-    var h = seed
-    h = mix(h, a)
-    h = mix(h, b)
-    h = mixLast(h, c)
-    finalizeHash(h, n)
+    else {
+      object hasher extends Function1[Any, Unit] {
+        var a, b, n = 0
+        var c = 1
+        override def apply(x: Any): Unit = {
+          val h = x.##
+          a += h
+          b ^= h
+          if (h != 0) c *= h
+          n += 1
+        }
+      }
+      xs foreach hasher
+      var h = seed
+      h = mix(h, hasher.a)
+      h = mix(h, hasher.b)
+      h = mixLast(h, hasher.c)
+      finalizeHash(h, hasher.n)
+    }
   }
   /** Compute a hash that depends on the order of its arguments.
    */
   final def orderedHash(xs: TraversableOnce[Any], seed: Int): Int = {
-    var n = 0
-    var h = seed
-    xs foreach { x =>
-      h = mix(h, x.##)
-      n += 1
+    if  (xs.isEmpty) finalizeHash(seed, 0)
+    else {
+      object hasher extends Function1[Any, Unit] {
+        var n = 0
+        var h = seed
+        override def apply(x: Any): Unit = {
+          h = mix(h, x.##)
+          n += 1
+        }
+      }
+      xs foreach hasher
+      finalizeHash(hasher.h, hasher.n)
     }
-    finalizeHash(h, n)
   }
 
   /** Compute the hash of an array.


### PR DESCRIPTION
Found the IntRefs here as an allocation hotspot in my day job

looks simple enough

Do we need additional unit tests/ allocation tests/benchmarks