### PR TITLE
build: sys props & java opts support to commands

### DIFF
--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -44,11 +44,15 @@ object ScalaOptionParser {
       val EqualsValue = concat("=" ~ token(OptNotSpace, TokenCompletions.displayOnly("<property value>")))
       concat(PropName ~ EqualsValue.?.map(_.getOrElse("")))
     }
+    val JavaOption: Parser[String] = {
+      val OptionName = concat(token("-J" ~ oneOrMore(NotSpaceClass & not('=', "not =")).string, TokenCompletions.displayOnly("-J<java option>")))
+      val EqualsValue = concat("=" ~ token(OptNotSpace, TokenCompletions.displayOnly("<option value>")))
+      concat(OptionName ~ EqualsValue.?.map(_.getOrElse("")))
+    }
 
     val sourceFile = FileParser(GlobFilter("*.scala") | GlobFilter("*.java"))
 
-    // TODO Allow JVM settings via -J-... and temporarily add them to the ForkOptions
-    val UniversalOpt = Property | oneOf(pathSettingNames.map(PathSetting) ++ phaseSettings.map(PhaseSettingParser) ++ booleanSettingNames.map(BooleanSetting) ++ stringSettingNames.map(StringSetting) ++ multiStringSettingNames.map(MultiStringSetting) ++ intSettingNames.map(IntSetting) ++ choiceSettingNames.map { case (k, v) => ChoiceSetting(k, v) } ++ multiChoiceSettingNames.map { case (k, v) => MultiChoiceSetting(k, v) } ++ scalaVersionSettings.map(ScalaVersionSetting))
+    val UniversalOpt = Property | JavaOption | oneOf(pathSettingNames.map(PathSetting) ++ phaseSettings.map(PhaseSettingParser) ++ booleanSettingNames.map(BooleanSetting) ++ stringSettingNames.map(StringSetting) ++ multiStringSettingNames.map(MultiStringSetting) ++ intSettingNames.map(IntSetting) ++ choiceSettingNames.map { case (k, v) => ChoiceSetting(k, v) } ++ multiChoiceSettingNames.map { case (k, v) => MultiChoiceSetting(k, v) } ++ scalaVersionSettings.map(ScalaVersionSetting))
     val ScalacOpt = sourceFile | UniversalOpt
 
     val ScalaExtraSettings = oneOf(


### PR DESCRIPTION
This allows, for instance:

    > scala -Dscala.color
    [warn] Modifying the sbt shell's session: set LocalProject("repl-frontend") / Compile / run / javaOptions ++= List("-Dscala.color")
    [info] Defining repl-frontend / Compile / run / javaOptions
    [info] The new value will be used by repl-frontend / Compile / run / forkOptions, repl-frontend / Compile / run / runner and 1 others.
    [info] 	Run `last` for details.
    [info] Reapplying settings...
    [info] *** Welcome to the sbt build definition for Scala! ***
    [info] Check README.md for more information.
    [info] running (fork) scala.tools.nsc.MainGenericRunner -usejavacp -Dscala.color
    Welcome to Scala 2.13.2-20200126-132334-4591d4a (OpenJDK 64-Bit Server VM, Java 11.0.1).
    Type in expressions for evaluation. Or try :help.

    scala>

Using the "set" command (with string shenanigans) because using
`Extracted.appendWithSession` didn't work, for unknown reasons.

Note, that this doesn't remove the added java options, but at least it
doesn't keep adding the same java options multiple times.