### PR TITLE
Fix broken Scaladoc external references with JDK11

### DIFF
--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -124,7 +124,7 @@ object ScalaOptionParser {
   private def scalaDocBooleanSettingNames = List("-implicits", "-implicits-debug", "-implicits-show-all", "-implicits-sound-shadowing", "-implicits-hide", "-author", "-diagrams", "-diagrams-debug", "-raw-output", "-no-prefixes", "-no-link-warnings", "-expand-all-types", "-groups")
   private def scalaDocIntSettingNames = List("-diagrams-max-classes", "-diagrams-max-implicits", "-diagrams-dot-timeout", "-diagrams-dot-restart")
   private def scalaDocChoiceSettingNames = Map("-doc-format" -> List("html"))
-  private def scaladocStringSettingNames = List("-doc-title", "-doc-version", "-doc-footer", "-doc-no-compile", "-doc-source-url", "-doc-generator", "-skip-packages")
+  private def scaladocStringSettingNames = List("-doc-title", "-doc-version", "-doc-footer", "-doc-no-compile", "-doc-source-url", "-doc-generator", "-skip-packages", "-jdk-api-doc-base")
   private def scaladocPathSettingNames = List("-doc-root-content", "-diagrams-dot-path")
   private def scaladocMultiStringSettingNames = List("-doc-external-doc")
 

--- a/src/manual/scala/man1/scaladoc.scala
+++ b/src/manual/scala/man1/scaladoc.scala
@@ -77,7 +77,11 @@ object scaladoc extends Command {
           "Define a URL to be concatenated with source locations for link to source files."),
         Definition(
           CmdOption("doc-external-doc", Argument("external-doc")),
-          "Define a comma-separated list of classpath_entry_path#doc_URL pairs describing external dependencies."))),
+          "Define a comma-separated list of classpath_entry_path#doc_URL pairs describing external dependencies."),
+        Definition(
+          CmdOption("jdk-api-doc-base", Argument("url")),
+          "Define a URL to be concatenated with source locations for link to Java API."))
+    ),
 
     Section("Compiler Options",
       DefinitionList(

--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -87,6 +87,13 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_),
     "comma-separated list of classpath_entry_path#doc_URL pairs describing external dependencies."
   )
 
+  val jdkApiDocBase = StringSetting (
+    "-jdk-api-doc-base",
+    "url",
+    "URL used to link Java API references.",
+    ""
+  )
+
   val docgenerator = StringSetting (
     "-doc-generator",
     "class-name",


### PR DESCRIPTION
Constructs URL for Java API references based on java.version; can override using -jdk-api-doc-base argument. partially addresses scala/bug#11839

only supports mappings to the `java.base` module — supporting other modules remains as future work