### PR TITLE
travis: Add a check to allow forks to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ stages:
 jobs:
     include:
 
-      # full bootstrap and publish
-      - stage: build
+      - name: full bootstrap and publish
+        stage: build
         if: type != pull_request
         script:
           # see comment in `bootstrap_fun` for details on the procedure
@@ -31,8 +31,8 @@ jobs:
           - triggerScalaDist
           - sbt -Dscala.build.compileWithDotty=true library/compile
 
-      # pull request validation (w/ mini-bootstrap)
-      - stage: build
+      - name: pull request validation with mini-bootstrap
+        stage: build
         name: "JDK 8 pr validation"
         if: type = pull_request
         script:
@@ -42,8 +42,8 @@ jobs:
           - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
           - sbt -Dscala.build.compileWithDotty=true library/compile
 
-      # build the spec using jekyll
-      - stage: build
+      - name: build the spec using jekyll
+        stage: build
         language: ruby
         install:
           - ruby -v
@@ -52,7 +52,7 @@ jobs:
           - bundle install
         script:
           - set -e
-          - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then (cd admin && ./init.sh); fi'
+          - (cd admin && ./init.sh)
           - bundle exec jekyll build -s spec/ -d build/spec
         after_success:
           - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./scripts/travis-publish-spec.sh; fi'

--- a/admin/init.sh
+++ b/admin/init.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+if [ -z "$GPG_SUBKEY_SECRET" ]; then
+  echo "GPG_SUBKEY_SECRET is missing/empty, so skipping credentials & gpg setup"
+  exit
+fi
+
 sensitive() {
   perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' < files/credentials-private-repo > ~/.credentials-private-repo
   perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' < files/credentials-sonatype     > ~/.credentials-sonatype


### PR DESCRIPTION
Add an early return to admin/init.sh so forks don't fail (without
output, btw, due to how "sensitive" is called) when running
admin/init.sh.

I decided to go with "exit" instead of something like "exit 1", but I
could be convinced the opposite is better (either way, without using
something like `travis_terminate` in .travis.yml, it'll get ignored).

Also, give jobs names.