### PR TITLE
[WIP] repl: Don't cache compiler settings in IMain

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -75,7 +75,7 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
 
   import reporter.{debug => repldbg}
 
-  private[interpreter] lazy val useMagicImport: Boolean = settings.YreplMagicImport.value
+  private[interpreter] def useMagicImport: Boolean = settings.YreplMagicImport.value
 
   private var bindExceptions                  = true        // whether to bind the lastException variable
   private var _executionWrapper               = ""          // code to be wrapped around all lines
@@ -128,7 +128,7 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
     writer.toString
   }
 
-  lazy val isClassBased: Boolean = settings.Yreplclassbased.value
+  def isClassBased: Boolean = settings.Yreplclassbased.value
 
 
   override def initializeComplete = _initializeComplete
@@ -311,7 +311,7 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
   def originalPath(sym: Symbol): String  = translateOriginalPath(typerOp path sym)
 
   /** For class based repl mode we use an .INSTANCE accessor. */
-  val readInstanceName = if (isClassBased) ".INSTANCE" else ""
+  def readInstanceName = if (isClassBased) ".INSTANCE" else ""
   def translateOriginalPath(p: String): String = {
     if (isClassBased) p.replace(sessionNames.read, sessionNames.read + readInstanceName) else p
   }


### PR DESCRIPTION
WIP: Submitting as a draft pull request to see what PR validation says.

This breaks the usage of :settings

    scala> class C // show
    package $line3 {
      object $read extends _root_.scala.AnyRef {
        def <init>() = {
          super.<init>;
          ()
        };
        object $iw extends scala.AnyRef {
          def <init>() = {
            super.<init>;
            ()
          };
          object $iw extends scala.AnyRef {
            def <init>() = {
              super.<init>;
              ()
            };
            class C extends scala.AnyRef {
              def <init>() = {
                super.<init>;
                ()
              }
            }
          }
        }
      }
    }

    package $line3 {
    object $eval {

      lazy val $print: _root_.java.lang.String =  {
        $line3.$read.$iw.$iw

    "" + "defined class C" + "\n"

      }
    }}
    defined class C

    scala> :settings -Yrepl-class-based

    scala> class C // show
    package $line4 {
      object $read extends _root_.scala.AnyRef {
        def <init>() = {
          super.<init>;
          ()
        };
        object $iw extends scala.AnyRef {
          def <init>() = {
            super.<init>;
            ()
          };
          object $iw extends scala.AnyRef {
            def <init>() = {
              super.<init>;
              ()
            };
            class C extends scala.AnyRef {
              def <init>() = {
                super.<init>;
                ()
              }
            }
          }
        }
      }
    }

    package $line4 {
    object $eval {

      lazy val $print: _root_.java.lang.String =  {
        $line4.$read.$iw.$iw

    "" + "defined class C" + "\n"

      }
    }}
    defined class C