### PR TITLE
Fix end of range position of Scaladoc use case

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/DocComments.scala
+++ b/src/compiler/scala/tools/nsc/ast/DocComments.scala
@@ -415,7 +415,7 @@ trait DocComments { self: Global =>
       if (pos == NoPosition) NoPosition
       else {
         val start1 = pos.start + start
-        val end1 = pos.end + end
+        val end1 = pos.start + end
         pos withStart start1 withPoint start1 withEnd end1
       }
 


### PR DESCRIPTION
The invalid end of the range position crashes recent versions
of Zinc.

Manually tested with:

https://github.com/retronym/sbt-scaladoc-aioooe

Fixes scala/bug#11865