### PR TITLE
Don't assume overload alternative is method

### DIFF
--- a/test/files/neg/t11866.check
+++ b/test/files/neg/t11866.check
@@ -1,0 +1,25 @@
+t11866.scala:11: error: ambiguous reference to overloaded definition,
+both object f in class X of type Test.x.f.type
+and  method f in class X of type (n: Int)Int
+match argument types (Int)
+  def t1 = x.f(42)
+             ^
+t11866.scala:13: error: ambiguous reference to overloaded definition,
+both object f in class X of type Test.x.f.type
+and  method f in class X of type (n: Int)Int
+match argument types (Int)
+  def t2 = x.f(n)
+             ^
+t11866.scala:15: error: ambiguous reference to overloaded definition,
+both method f in class Y of type [A <: 42](a: A)Int
+and  method f in class Y of type (n: 42)Int
+match argument types (42)
+  def t3 = y.f(n)
+             ^
+t11866.scala:17: error: ambiguous reference to overloaded definition,
+both object f in class Z of type Test.z.f.type
+and  method f in class Z of type [A <: 42](a: A)Int
+match argument types (Int) and expected result type Any
+  println(z.f(n))
+            ^
+4 errors

--- a/test/files/neg/t11866.scala
+++ b/test/files/neg/t11866.scala
@@ -1,0 +1,18 @@
+
+// error message won't follow apply into object f,
+// so it won't keep narrow type in z
+//
+class X { def f(n: Int) = 42 ; object f { def apply(i: Int) = 42 + i } }
+class Y { def f(n: 42) = 42 ; def f[A <: 42](a: A) = 27 }
+class Z { def f[A <: 42](a: A) = 42 ; object f { def apply(i: 42) = i } }
+
+object Test extends App {
+  val x = new X()
+  def t1 = x.f(42)
+  val n: 42 = 42
+  def t2 = x.f(n)
+  val y = new Y()
+  def t3 = y.f(n)
+  val z = new Z()
+  println(z.f(n))
+}


### PR DESCRIPTION
Improved error messaging for literal types
added this assumption.

Fixes scala/bug#11866