### PR TITLE
Fix nondeterminism in optimizer (sort inline request before selecting according to method size limit)

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -456,7 +456,7 @@ abstract class Inliner {
             }
           case _ =>
         }
-        val newRequests = selectRequestsForMethodSize(method, rs.toList, mutable.Map.empty).sorted(inlineRequestOrdering)
+        val newRequests = selectRequestsForMethodSize(method, rs.toList.sorted(inlineRequestOrdering), mutable.Map.empty)
 
         state.illegalAccessInstructions.find(insn => newRequests.forall(_.callsite.callsiteInstruction != insn)) match {
           case None =>


### PR DESCRIPTION
`selectRequestsForMethodSize` filters a list of inline requests for a
method to make sure the final size of the method is within a defined
limit.

We need to make sure to sort the list of requests before calling that
method, otherwise the final bytecode is non-deterministic. The method
list comes from `callGraph.callsites`, which is a
`Map[MethodNode, Map[MethodInsnNode, Callsite]]`, so non defined order.

Fixes the issue described by @retronym in https://github.com/scala/scala/pull/8525#issuecomment-576520601.