### PR TITLE
Thread the needle of static handle ownership

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -137,10 +137,15 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
   }
 
   def staticHandleFromSymbol(sym: Symbol): asm.Handle = {
-    val owner = if (sym.owner.isModuleClass) sym.owner.linkedClassOfClass else sym.owner
     val descriptor = methodBTypeFromMethodType(sym.info, isConstructor = false).descriptor
-    val ownerBType = classBTypeFromSymbol(owner)
-    new asm.Handle(asm.Opcodes.H_INVOKESTATIC, ownerBType.internalName, sym.name.encoded, descriptor, /* itf = */ ownerBType.isInterface.get)
+    val ownerBType = classBTypeFromSymbol(sym.owner)
+    val rawInternalName = ownerBType.internalName
+    // object Qux { def foo = 1 } --> we want the handle to be to (static) Qux.foo, not (member) Qux$.foo
+    val mustUseMirrorClass = !sym.isJava && sym.owner.isModuleClass && !sym.isStaticMember
+    // ... but we don't know that the mirror class exists! (if there's no companion, the class is synthesized in jvm without a symbol)
+    val ownerInternalName = if (mustUseMirrorClass) rawInternalName stripSuffix nme.MODULE_SUFFIX_STRING else rawInternalName
+    val isInterface = sym.owner.linkedClassOfClass.isTraitOrInterface
+    new asm.Handle(asm.Opcodes.H_INVOKESTATIC, ownerInternalName, sym.name.encoded, descriptor, isInterface)
   }
 
   /**


### PR DESCRIPTION
Using `linkedClassOfClass` here doesn't work properly if the owner is a module without a companion, since the mirror class gets generated during `jvm`.

I tried to handle all of the cases I could think of:
- `public class Foo { public static void test() {} }`:
  - `sym.isStaticMember`: `true`
  - `sym.owner.internalName`: `Foo`
  - `ownerInternalName`: `Foo`
- `class Foo; object Foo { def test() { } }`
  - `sym.isStaticMember`: `false`
  - `sym.owner.internalName`: `Foo$`
  - `ownerInternalName`: `Foo`
- `object Foo { def test() { } }`
  - `sym.isStaticMember`: `false`
  - `sym.owner.internalName`: `Foo$`
  - `ownerInternalName`: `Foo` (even though this doesn't exist yet!)
- `object Foo { <static> def test() { } }`
  - `sym.isStaticMember`: true
  - `sym.owner.internalName`: `Foo$`
  - `ownerInternalName`: `Foo$` (!)