### PR TITLE
Fix 2.12-only bug where some toX methods could expose the underlying mutability of a ListBuffer-generated collection

### DIFF
--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -306,12 +306,17 @@ final class ListBuffer[A]
   def result: List[A] = toList
 
   /** Converts this buffer to a list. Takes constant time. The buffer is
-   *  copied lazily, the first time it is mutated.
+   *  copied lazily the first time it is mutated.
    */
   override def toList: List[A] = {
     exported = !isEmpty
     start
   }
+
+  // scala/bug#11869
+  override def toSeq: collection.Seq[A] = toList
+  override def toIterable: collection.Iterable[A] = toList
+  override def toStream: immutable.Stream[A] = toList.toStream // mind the laziness
 
 // New methods in ListBuffer
 

--- a/test/junit/scala/collection/IndexedSeqTest.scala
+++ b/test/junit/scala/collection/IndexedSeqTest.scala
@@ -2,13 +2,9 @@ package scala.collection
 
 import org.junit.Test
 import org.junit.Ignore
-import org.junit.Assert.{assertEquals, _}
+import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-
-// with the Ant JUnit runner, it's necessary to @Ignore the abstract
-// classes here, or JUnit tries to instantiate them.  the annotations
-// can be removed when this is merged forward (TODO 2.12.x)
 
 /**
   * base class for testing common methods on a various implementations
@@ -17,7 +13,6 @@ import org.junit.runners.JUnit4
   * @tparam E the element type
   */
 @RunWith(classOf[JUnit4])
-@Ignore
 abstract class IndexedTest[T, E] {
 
   protected def size = 10

--- a/test/junit/scala/collection/mutable/ListBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ListBufferTest.scala
@@ -1,0 +1,36 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.mutable
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class ListBufferTest {
+  @Test def `toSeq and friends should not expose mutability (scala/bug#11869)` {
+    def check[CC[x] <: collection.Traversable[x]](export: ListBuffer[Int] => CC[Int]) {
+      val buf = ListBuffer.empty[Int]
+      buf += 1; buf += 2
+      val res = export(buf)
+      buf += 3
+      assertEquals(3, buf.size)
+      assertEquals(2, res.size)
+    }
+    check(_.toList)
+    check(_.toSeq)
+    check(_.toIterable)
+    check(_.toStream)
+  }
+}


### PR DESCRIPTION
Any `TraversableForwarder` method with the danger of returning `underlying` itself needs to go through `toList` (which marks the underlying list as needing to be copied on the next mutation).

Notice that `toStream` is also affected since `List#toStream` builds the result lazily.

Fixes scala/bug#11869