### PR TITLE
test: Sanitise output from JDK 11's lambda names

### DIFF
--- a/src/partest/scala/tools/partest/ReplTest.scala
+++ b/src/partest/scala/tools/partest/ReplTest.scala
@@ -70,7 +70,7 @@ trait Lambdaless extends ReplTest {
   }
 }
 object Lambdaless {
-  private val lambdaless = """\$Lambda\$\d+/\d+(@[a-fA-F0-9]+)?""".r
+  private val lambdaless = """\$Lambda\$\d+/(?:0x[a-f0-9]{16}|\d+)(@[a-fA-F0-9]+)?""".r
   private def stripLambdaClassName(s: String): String = lambdaless.replaceAllIn(s, Regex.quoteReplacement("<function>"))
 }
 


### PR DESCRIPTION
I ran a few tests on JDK 11 (`--grep repl`) and the following had
different lambda names:

    run/repl-parens.scala
    run/t5789.scala
    run/t5535.scala
    run/repl-no-imports-no-predef.scala
    run/t7747-repl.scala
    run/t6434.scala

It looks like JDK 11's lambdas use a hex-formatted identifier instead
of decimal, so I made the minimal change to the test sanitisation to
handle those.