### PR TITLE
Return Range.Exclusive on RichInt.until instead of abstract Range

### DIFF
--- a/src/library/scala/runtime/RichInt.scala
+++ b/src/library/scala/runtime/RichInt.scala
@@ -55,7 +55,7 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
     * @return A [[scala.collection.immutable.Range]] from `this` up to but
     *         not including `end`.
     */
-  def until(end: Int): Range = Range(self, end)
+  def until(end: Int): Range.Exclusive = Range(self, end)
 
   /**
     * @param end The final bound of the range to make.
@@ -63,7 +63,7 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
     * @return A [[scala.collection.immutable.Range]] from `this` up to but
     *         not including `end`.
     */
-  def until(end: Int, step: Int): Range = Range(self, end, step)
+  def until(end: Int, step: Int): Range.Exclusive = Range(self, end, step)
 
   /** like `until`, but includes the last index */
   /**

--- a/test/files/pos/t11875.scala
+++ b/test/files/pos/t11875.scala
@@ -1,0 +1,4 @@
+object ShuffleTest {
+  scala.util.Random.shuffle(1 until 10)
+  scala.util.Random.shuffle(1 until (10,2))
+}

--- a/test/files/presentation/infix-completion.check
+++ b/test/files/presentation/infix-completion.check
@@ -161,8 +161,8 @@ def toString(): String
 def unary_+: Int
 def unary_-: Int
 def unary_~: Int
-def until(end: Int): scala.collection.immutable.Range
-def until(end: Int, step: Int): scala.collection.immutable.Range
+def until(end: Int): scala.collection.immutable.Range.Exclusive
+def until(end: Int, step: Int): scala.collection.immutable.Range.Exclusive
 def until(end: Long): scala.collection.immutable.NumericRange.Exclusive[Long]
 def until(end: Long, step: Long): scala.collection.immutable.NumericRange.Exclusive[Long]
 def |(x: Byte): Int

--- a/test/files/presentation/infix-completion2.check
+++ b/test/files/presentation/infix-completion2.check
@@ -161,8 +161,8 @@ def toString(): String
 def unary_+: Int
 def unary_-: Int
 def unary_~: Int
-def until(end: Int): scala.collection.immutable.Range
-def until(end: Int, step: Int): scala.collection.immutable.Range
+def until(end: Int): scala.collection.immutable.Range.Exclusive
+def until(end: Int, step: Int): scala.collection.immutable.Range.Exclusive
 def until(end: Long): scala.collection.immutable.NumericRange.Exclusive[Long]
 def until(end: Long, step: Long): scala.collection.immutable.NumericRange.Exclusive[Long]
 def |(x: Byte): Int


### PR DESCRIPTION
Fixes scala/bug#11875

Shuffling an exclusive range of `Int`s created using `until` would fail in the block below as a result of the return type being an abstract type: `Range`, causing the `Random.shuffle` to look for an implicit of type: `scala.collection.BuildFrom[Range, Int, _]`.
```scala
scala.util.Random.shuffle(1 to 10)
```
In addition, this change would also align the types which extend `RangedProxy[T]`, namely: `RichInt` and `IntegralProxy[T]` in terms of their return types for `.until`. While `IntegralProxy[T].until` already returned a `NumericRange.Exclusive[T]`, `RichInt.until` returned an abstract `Range`.

P.S.: This is my first PR here. Any feedback/suggestions are welcome and would be greatly appreciated. Thanks