### PR TITLE
Mention `-opt:help` & `opt-warnings:help`

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -324,7 +324,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
   val opt = MultiChoiceSetting(
     name = "-opt",
     helpArg = "optimization",
-    descr = "Enable optimizations",
+    descr = "Enable optimizations, `help` for details.",
     domain = optChoices,
   )
 
@@ -399,7 +399,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
   val optWarnings = MultiChoiceSetting(
     name = "-opt-warnings",
     helpArg = "warning",
-    descr = "Enable optimizer warnings",
+    descr = "Enable optimizer warnings, `help` for details.",
     domain = optWarningsChoices,
     default = Some(List(optWarningsChoices.atInlineFailed.name)))
 


### PR DESCRIPTION
Looking at `scalac -help` I saw the mention of `help` for
`-opt-inline-from`, but it was only thanks to the deprecation message of
`-optimize` did I learn about `-opt:help`.

So how about we make that more prominent?