### PR TITLE
use fast intersect and diff where we can

### DIFF
--- a/src/library/scala/collection/generic/Subtractable.scala
+++ b/src/library/scala/collection/generic/Subtractable.scala
@@ -14,6 +14,8 @@ package scala
 package collection
 package generic
 
+import scala.collection.immutable.HashSet
+
 
 /** This trait represents collection-like objects that can be reduced
  *  using a '+' operator. It defines variants of `-` and `--`
@@ -59,5 +61,10 @@ trait Subtractable[A, +Repr <: Subtractable[A, Repr]] { self =>
    *  @return a new $coll that contains all elements of the current $coll
    *  except one less occurrence of each of the elements of `elems`.
    */
-  def --(xs: GenTraversableOnce[A]): Repr = (repr /: xs.seq) (_ - _)
+  def --(xs: GenTraversableOnce[A]): Repr = this match {
+    case hs: HashSet[A] if xs.isInstanceOf[HashSet[A]] =>
+      hs.diff(xs.asInstanceOf[HashSet[A]]).asInstanceOf[Repr]
+    case _ =>
+      (repr /: xs.seq) (_ - _)
+  }
 }

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -166,15 +166,23 @@ sealed class HashSet[A] extends AbstractSet[A]
 
   override def tail: HashSet[A] = this - head
 
-  override def filter(p: A => Boolean) = {
-    val buffer = new Array[HashSet[A]](bufferSize(size))
-    nullToEmpty(filter0(p, false, 0, buffer, 0))
+  override def filter(p: A => Boolean) = p match {
+    case hs: HashSet[A] =>
+      intersect(hs)
+    case _ =>
+      val buffer = new Array[HashSet[A]](bufferSize(size))
+      nullToEmpty(filter0(p, false, 0, buffer, 0))
   }
 
-  override def filterNot(p: A => Boolean) = {
-    val buffer = new Array[HashSet[A]](bufferSize(size))
-    nullToEmpty(filter0(p, true, 0, buffer, 0))
+  override def filterNot(p: A => Boolean) = p match {
+    case hs: HashSet[A] =>
+      diff(hs)
+    case _ =>
+      val buffer = new Array[HashSet[A]](bufferSize(size))
+      nullToEmpty(filter0(p, true, 0, buffer, 0))
   }
+
+
 
   protected def filter0(p: A => Boolean, negate: Boolean, level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = null
 


### PR DESCRIPTION
given  hashsets some operations can be optimised as we have fast paths

given
```
val a: HashSet[A] = ...
val b: HashSet[A] = ...
```
we can use the optimised diff rather than th O(n), and allocation heavy `--` or `filterNot` as 
`a -- b == a filterNot b == a diff b`

also we can use the optimised intersect rather than th O(n), and allocation heavy `filter` as 
`a filter b == a intersect b`
```