### PR TITLE
create less objects for zipWithIndex

### DIFF
--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -282,9 +282,10 @@ self =>
 
   def zipWithIndex[A1 >: A, That](implicit bf: CanBuildFrom[Repr, (A1, Int), That]): That = {
     val b = bf(repr)
+    val these = this.iterator
     var i = 0
-    for (x <- this) {
-      b += ((x, i))
+    while (these.hasNext) {
+      b += ((these.next(), i))
       i += 1
     }
     b.result()


### PR DESCRIPTION
avoid the IntRef  and foreach

if preferred we could keep the foreach and have an 'object zipper extends function` which contains the var, but I thought this was simpler, and more in line with the other usages in the class, and it saves another object