### PR TITLE
Avoid duplicate repl-jline.properties entries in compiler/packageBin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1272,7 +1272,6 @@ def configureAsSubproject(project: Project): Project = {
   val base = file(".") / "src" / project.id
   (project in base)
     .settings(scalaSubprojectSettings)
-    .settings(generatePropertiesFileSettings)
 }
 
 lazy val buildDirectory = settingKey[File]("The directory where all build products go. By default ./build")


### PR DESCRIPTION
I removed `generatePropertiesFileSettings` from commonSettings
leaving projects that really need to use it to directly add it
to the settings. This was already being done (redundatly in some
cases) in `library`, `reflect`, `compiler`, `partestExtras`
and `partestJavaAgent`.

Before this PR (but after the SBT upgrade on 2.12.x branch):

```
➜  sbt 'show compiler/Compile/packageBin/mappings' | egrep 'repl-jline\.properties'
[info] * (/Users/jz/code/scala-2.12.x-reference/build/quick/classes/repl-jline/repl-jline.properties,repl-jline.properties)
[info] * (/Users/jz/code/scala-2.12.x-reference/build/quick/classes/repl-jline-embedded/repl-jline.properties,repl-jline.properties)

➜  sbt scala
[info] Loading global plugins from /Users/jz/.sbt/1.0/plugins
[info] Loading settings for project scala-2-12-x-reference-build-build from plugins.sbt ...
[info] Loading project definition from /Users/jz/code/scala-2.12.x-reference/project/project
[info] Loading settings for project scala-2-12-x-reference-build from plugins.sbt,build.sbt ...
[info] Loading project definition from /Users/jz/code/scala-2.12.x-reference/project
[info] Loading settings for project root from build.sbt ...
[info] Resolving key references (18230 settings) ...
[error] Could not determine commit date + SHA: org.eclipse.jgit.errors.MissingObjectException: Missing unknown b8c33ad8f1d1238bc03c148854972522f0357f44
[info] *** Welcome to the sbt build definition for Scala! ***
[info] Check README.md for more information.
[error] java.util.zip.ZipException: duplicate entry: repl-jline.properties
```

After this PR:

```
fg: no current job
➜  sbt 'show compiler/Compile/packageBin/mappings' | egrep 'repl-jline\.properties'
[info] * (/Users/jz/code/scala-2.12.x-reference/build/quick/classes/repl-jline-embedded/repl-jline.properties,repl-jline.properties)

➜  sbt scala
[info] Loading global plugins from /Users/jz/.sbt/1.0/plugins
[info] Loading settings for project scala-2-12-x-reference-build-build from plugins.sbt ...
[info] Loading project definition from /Users/jz/code/scala-2.12.x-reference/project/project
[info] Loading settings for project scala-2-12-x-reference-build from plugins.sbt,build.sbt ...
[info] Loading project definition from /Users/jz/code/scala-2.12.x-reference/project
[info] Loading settings for project root from build.sbt ...
[info] Resolving key references (18194 settings) ...
[info] *** Welcome to the sbt build definition for Scala! ***
[info] Check README.md for more information.
[info] running (fork) scala.tools.nsc.MainGenericRunner -usejavacp
Welcome to Scala 2.12.11-20200203-035143-5bdfd31 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_221).
Type in expressions for evaluation. Or try :help.
```

Prior to the SBT upgrade, we also had the duplicate mapping:

```
sbt 'show compiler/compile:packageBin::mappings' | egrep 'repl-jline\.properties'
[info] * (/Users/jz/code/scala-2.12.x-reference/build/quick/classes/repl-jline/repl-jline.properties,repl-jline.properties)
[info] * (/Users/jz/code/scala-2.12.x-reference/build/quick/classes/repl-jline-embedded/repl-jline.properties,repl-jline.properties)
```