### PR TITLE
-Xlint:captured to warn on *Ref boxing

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -109,6 +109,7 @@ trait Warnings {
     val UnsoundMatch           = LintWarning("unsound-match",             "Pattern match may not be typesafe.")
     val StarsAlign             = LintWarning("stars-align",               "Pattern sequence wildcard must align with sequence component.")
     val Constant               = LintWarning("constant",                  "Evaluation of a constant arithmetic expression results in an error.")
+    val Captured               = LintWarning("captured",                  "Modification of var in closure causes boxing.")
     val Unused                 = LintWarning("unused",                    "Enable -Ywarn-unused:imports,privates,locals,implicits.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
@@ -132,6 +133,7 @@ trait Warnings {
   def warnUnsoundMatch           = lint contains UnsoundMatch
   def warnStarsAlign             = lint contains StarsAlign
   def warnConstant               = lint contains Constant
+  def warnCaptured               = lint contains Captured
   def lintUnused                 = lint contains Unused
 
   // Lint warnings that are currently -Y, but deprecated in that usage

--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -503,6 +503,9 @@ abstract class LambdaLift extends InfoTransform {
               }
             }
 
+            if (settings.warnCaptured)
+              reporter.warning(tree.pos, s"Modification of variable $name within a closure causes it to be boxed.")
+
             treeCopy.ValDef(tree, mods, name, tpt1, factoryCall)
           } else tree
         case Return(Block(stats, value)) =>

--- a/test/files/neg/xlint-captured.check
+++ b/test/files/neg/xlint-captured.check
@@ -1,0 +1,6 @@
+xlint-captured.scala:4: warning: Modification of variable c within a closure causes it to be boxed.
+    var c = a // nok
+        ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/xlint-captured.flags
+++ b/test/files/neg/xlint-captured.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -Xlint:captured

--- a/test/files/neg/xlint-captured.scala
+++ b/test/files/neg/xlint-captured.scala
@@ -1,0 +1,8 @@
+object Test {
+  var a, b = 0 // ok
+  def mkStrangeCounter(): Int => Int = {
+    var c = a // nok
+    object _d { var d = b }; import _d._ // ok
+    e => { c += a; d += b; a *= b; b -= c; c ^ d }
+  }
+}


### PR DESCRIPTION
Maybe we need an -Xslow instead, for stuff that does what you expect but maybe not quite as fast. It's a testament either to the power of scalac's warning capability or of the simplicity of this feature that it's implemented in only around 5 lines of code.