### PR TITLE
Thoroughly typecheck Java sources for pickling

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -402,10 +402,8 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     def apply(unit: CompilationUnit): Unit
 
     // run only the phases needed
-    protected def shouldSkipThisPhaseForJava: Boolean = {
-      this.id > (if (createJavadoc) currentRun.typerPhase.id
-      else currentRun.namerPhase.id)
-    }
+    protected def shouldSkipThisPhaseForJava: Boolean =
+      this > currentRun.namerPhase // but see overrides for nuances
 
     /** Is current phase cancelled on this unit? */
     def cancelled(unit: CompilationUnit) = {

--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -90,6 +90,7 @@ trait Analyzer extends AnyRef
     def newPhase(prev: Phase): StdPhase = new TyperPhase(prev)
     final class TyperPhase(prev: Phase) extends StdPhase(prev) {
       override def keepsTypeParams = false
+      override def shouldSkipThisPhaseForJava: Boolean = !(settings.YpickleJava || createJavadoc)
       resetTyper()
       // the log accumulates entries over time, even though it should not (Adriaan, Martin said so).
       // Lacking a better fix, we clear it here (before the phase is created, meaning for each

--- a/src/reflect/scala/reflect/internal/Phase.scala
+++ b/src/reflect/scala/reflect/internal/Phase.scala
@@ -14,7 +14,7 @@ package scala
 package reflect
 package internal
 
-abstract class Phase(val prev: Phase) {
+abstract class Phase(val prev: Phase) extends Ordered[Phase] {
   if ((prev ne null) && (prev ne NoPhase))
     prev.nx = this
 
@@ -72,6 +72,7 @@ abstract class Phase(val prev: Phase) {
     case x: Phase   => id == x.id && name == x.name
     case _          => false
   }
+  override def compare(that: Phase): Id = this.id compare that.id
 }
 
 object NoPhase extends Phase(null) {

--- a/test/files/neg/pickle-java-crash.check
+++ b/test/files/neg/pickle-java-crash.check
@@ -1,0 +1,4 @@
+Crash.java:4: error: not found: type NotThere
+    NotThere notThere();
+    ^
+one error found

--- a/test/files/neg/pickle-java-crash.flags
+++ b/test/files/neg/pickle-java-crash.flags
@@ -1,0 +1,1 @@
+-Ypickle-java

--- a/test/files/neg/pickle-java-crash/Brash.scala
+++ b/test/files/neg/pickle-java-crash/Brash.scala
@@ -1,0 +1,3 @@
+package crashy
+
+object brash

--- a/test/files/neg/pickle-java-crash/Crash.java
+++ b/test/files/neg/pickle-java-crash/Crash.java
@@ -1,0 +1,5 @@
+package crashy;
+
+public class Crash {
+    NotThere notThere();
+}


### PR DESCRIPTION
Unlike `.scala` files, `.java` files are named and typed lazily: they will only be analyzed when necessary to typecheck a Scala source. However, under `-Ypickle-java`, `pickler` runs over them after typechecking, and can force infos that otherwise wouldn't be forced. If typing the Java source fails, the tree can contain erroneous types and symbols which will then crash `pickler` as it attempts to write out the pickle.

This patch makes `-Ypickle-java` eagerly typecheck Java sources during `typer`, so any errors will be emitted alongside Scala typer errors.

The enclosed test case previously crashed the compiler with a `MatchError` on `ErrorType`.
