### PR TITLE
Fix Scaladoc eliding "case" for case objects

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
@@ -214,7 +214,7 @@ abstract class HtmlPage extends Page { thisPage =>
   }
 
   def hasPage(e: DocTemplateEntity) = {
-    e.isPackage || e.isTrait || e.isClass || e.isObject || e.isCaseClass
+    e.isPackage || e.isTrait || e.isClass || e.isObject || e.isCase
   }
 
   /** Returns the HTML code that represents the template in `tpl` as a hyperlinked name. */

--- a/src/scaladoc/scala/tools/nsc/doc/html/Page.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/Page.scala
@@ -114,10 +114,10 @@ abstract class Page {
 
   def kindToString(mbr: MemberEntity) =
     mbr match {
-      case c: Class => if (c.isCaseClass) "case class" else "class"
+      case c: Class => if (c.isCase) "case class" else "class"
       case _: Trait => "trait"
       case _: Package => "package"
-      case _: Object => "object"
+      case o: Object => if (o.isCase) "case object" else "object"
       case _: AbstractType => "type"
       case _: AliasType => "type"
       case _: Constructor => "new"

--- a/src/scaladoc/scala/tools/nsc/doc/model/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/Entity.scala
@@ -102,8 +102,8 @@ trait TemplateEntity extends Entity {
   /** Whether documentation is available for this template. */
   def isDocTemplate: Boolean
 
-  /** Whether this template is a case class. */
-  def isCaseClass: Boolean
+  /** Whether this template is a case class or a case object. */
+  def isCase: Boolean
 
   /** The self-type of this template, if it differs from the template type. */
   def selfType : Option[TypeEntity]

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -98,7 +98,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     def isTrait = sym.isTrait
     def isClass = sym.isClass && !sym.isTrait
     def isObject = sym.isModule && !sym.hasPackageFlag
-    def isCaseClass = sym.isCaseClass
+    def isCase = sym.isCase
     def isRootPackage = false
     def selfType = if (sym.thisSym eq sym) None else Some(makeType(sym.thisSym.typeOfThis, this))
   }
@@ -452,7 +452,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     def primaryConstructor: Option[MemberImpl with Constructor] = if (isClass) constructors find { _.isPrimary } else None
     override def valueParams =
       // we don't want params on a class (non case class) signature
-      if (isCaseClass) primaryConstructor match {
+      if (isCase) primaryConstructor match {
         case Some(const) => const.sym.paramss map (_ map (makeValueParam(_, this)))
         case None => List()
       }

--- a/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
+++ b/test/scalacheck/scala/tools/nsc/scaladoc/HtmlFactoryTest.scala
@@ -627,4 +627,16 @@ object HtmlFactoryTest extends Properties("HtmlFactory") {
         s.contains("""protected[<a href="index.html" name="p" id="p" class="extype">p</a>]""")
     }
   }
+
+  property("scala/bug#11871 case objects should have the case flag on the index page") = {
+    checkTemplate("t11871.scala", "main/index.html"){(_, s) =>
+      s.contains("""<span class="kind">case object</span>""") && s.contains("""<span class="name">ObjectA</span>""".stripMargin)
+    }
+  }
+
+  property("scala/bug#11871 case objects should have the case flag on the object's page") = {
+    checkTemplate("t11871.scala", "main/ObjectA$.html"){(_, s) =>
+      s.contains("""<span class="kind">case object</span>""") && s.contains("""<span class="name">ObjectA</span>""".stripMargin)
+    }
+  }
 }

--- a/test/scaladoc/resources/t11871.scala
+++ b/test/scaladoc/resources/t11871.scala
@@ -1,0 +1,3 @@
+package main
+
+case object ObjectA


### PR DESCRIPTION
Fixes scala/bug#11871

Scaladoc's HTML generated for a `case object`,
```scala
case object ObjectA
```

doesn't include the `case` flag as shown here:
![before11871](https://user-images.githubusercontent.com/427908/73714183-0e183780-4708-11ea-909e-1afbb907ea31.png)
This change fixes that to generate the following:
![after11871](https://user-images.githubusercontent.com/427908/73714501-e9708f80-4708-11ea-97d3-1008a999fc5f.png)

