### PR TITLE
Warn about unintended underscores

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2167,6 +2167,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       val vdef1 = treeCopy.ValDef(vdef, typedMods, sym.name, tpt1, checkDead(context, rhs1)) setType NoType
       if (sym.isSynthetic && sym.name.startsWith(nme.RIGHT_ASSOC_OP_PREFIX))
         rightAssocValDefs += ((sym, vdef1.rhs))
+      if (sym.isSynthetic && sym.owner.isClass && (tpt1.tpe eq UnitTpe) && vdef.hasAttachment[PatVarDefAttachment.type] && sym.isPrivateThis && vdef.mods.isPrivateLocal && !sym.enclClassChain.exists(_.isInterpreterWrapper)) {
+        context.warning(vdef.pos, s"Pattern definition introduces Unit-valued member of ${sym.owner.name}; consider wrapping it in `locally { ... }`.")
+        vdef.removeAttachment[PatVarDefAttachment.type]
+      }
       vdef1
     }
 

--- a/src/partest/scala/tools/partest/DirectTest.scala
+++ b/src/partest/scala/tools/partest/DirectTest.scala
@@ -18,10 +18,19 @@ import scala.tools.nsc._
 import scala.tools.nsc.reporters.{ConsoleReporter, Reporter}
 import scala.tools.nsc.settings.ScalaVersion
 
-/** A class for testing code which is embedded as a string.
-  *  It allows for more complete control over settings, compiler
-  *  configuration, sequence of events, etc. than does partest.
-  */
+/** Test with code which is embedded as a string.
+ *
+ *  `DirectTest` allows for more complete control over settings, compiler
+ *  configuration, sequence of events, etc. than does partest alone.
+ *
+ *  Tests must define `code` and `show()`. Minimally:
+ *  ```
+ *  def show() = assert(compile())
+ *  ```
+ *
+ *  There are helper methods for creating settings and
+ *  invoking a (newly constructed) compiler.
+ */
 abstract class DirectTest {
   // The program being tested in some fashion
   def code: String

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -807,8 +807,13 @@ abstract class TreeGen {
           val tmp = freshTermName()
           val firstDef =
             atPos(matchExpr.pos) {
-              ValDef(Modifiers(PrivateLocal | SYNTHETIC | ARTIFACT | (mods.flags & LAZY)),
-                     tmp, TypeTree(), matchExpr)
+              val v = ValDef(Modifiers(PrivateLocal | SYNTHETIC | ARTIFACT | (mods.flags & LAZY)), tmp, TypeTree(), matchExpr)
+              if (vars.isEmpty) {
+                v.updateAttachment(PatVarDefAttachment)  // warn later if this introduces a Unit-valued field
+                if (mods.isImplicit)
+                  currentRun.reporting.deprecationWarning(matchExpr.pos, "Implicit pattern definition binds no variables", since="2.13")
+              }
+              v
             }
           var cnt = 0
           val restDefs = for ((vname, tpt, pos, original) <- vars) yield atPos(pos) {

--- a/test/files/neg/compile-time-only-a.check
+++ b/test/files/neg/compile-time-only-a.check
@@ -1,3 +1,6 @@
+compile-time-only-a.scala:49: warning: Pattern definition introduces Unit-valued member of Test; consider wrapping it in `locally { ... }`.
+  val _ = c6.x
+      ^
 compile-time-only-a.scala:10: error: C3
 @compileTimeOnly("C3") case class C3(x: Int)
                                   ^
@@ -79,4 +82,5 @@ compile-time-only-a.scala:75: error: placebo
 compile-time-only-a.scala:75: error: placebo
   @placebo def x = (2: @placebo)
                         ^
+1 warning
 27 errors

--- a/test/files/neg/t10474.check
+++ b/test/files/neg/t10474.check
@@ -4,4 +4,8 @@ t10474.scala:8: error: stable identifier required, but Test.this.Foo found.
 t10474.scala:15: error: stable identifier required, but hrhino.this.Foo found.
   val Foo.Crash = ???
       ^
+t10474.scala:15: warning: Pattern definition introduces Unit-valued member of hrhino; consider wrapping it in `locally { ... }`.
+  val Foo.Crash = ???
+          ^
+1 warning
 2 errors

--- a/test/files/neg/t10731.check
+++ b/test/files/neg/t10731.check
@@ -1,4 +1,8 @@
 t10731.scala:3: error: stable identifier required, but C.this.eq found.
   val eq.a = 1
       ^
+t10731.scala:3: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
+  val eq.a = 1
+         ^
+1 warning
 1 error

--- a/test/files/neg/t11374b.check
+++ b/test/files/neg/t11374b.check
@@ -1,7 +1,11 @@
 t11374b.scala:3: error: not found: value _
   val Some(`_`) = Option(42)  // was crashola
            ^
+t11374b.scala:3: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
+  val Some(`_`) = Option(42)  // was crashola
+          ^
 t11374b.scala:6: error: not found: value _
     val Some(`_`) = Option(42)  // was crashola
              ^
+1 warning
 2 errors

--- a/test/files/neg/t11618.check
+++ b/test/files/neg/t11618.check
@@ -1,0 +1,36 @@
+t11618.scala:9: warning: Implicit pattern definition binds no variables
+  implicit val _ = 42
+               ^
+t11618.scala:10: warning: Implicit pattern definition binds no variables
+  implicit val Some(_) = Option(42)
+                   ^
+t11618.scala:18: warning: Implicit pattern definition binds no variables
+    implicit val _ = i
+                 ^
+t11618.scala:19: warning: Implicit pattern definition binds no variables
+    implicit val Some(_) = Option(i)
+                     ^
+t11618.scala:24: warning: Implicit pattern definition binds no variables
+  implicit val Some(_) = Option(42)
+                   ^
+t11618.scala:7: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
+  val _ = 42
+      ^
+t11618.scala:8: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
+  val Some(_) = Option(42)
+          ^
+t11618.scala:9: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
+  implicit val _ = 42
+               ^
+t11618.scala:10: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
+  implicit val Some(_) = Option(42)
+                   ^
+t11618.scala:23: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
+  val Some(_) = Option(42)
+          ^
+t11618.scala:24: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
+  implicit val Some(_) = Option(42)
+                   ^
+error: No warnings can be incurred under -Werror.
+11 warnings
+1 error

--- a/test/files/neg/t11618.scala
+++ b/test/files/neg/t11618.scala
@@ -1,0 +1,25 @@
+// scalac: -Werror -Xlint:deprecation
+
+// warn about introducing Unit-valued fields instead of merely side-effecting.
+// warn about implicit not introducing any implicits
+//
+class C {
+  val _ = 42
+  val Some(_) = Option(42)
+  implicit val _ = 42
+  implicit val Some(_) = Option(42)
+
+  val p = println()  // nowarn
+  val Some(answer @ _) = Option(42)  // nowarn
+
+  def f(i: 42) = {
+    val _ = i                  // nowarn
+    val Some(_) = Option(i)    // nowarn
+    implicit val _ = i
+    implicit val Some(_) = Option(i)
+  }
+}
+object C {
+  val Some(_) = Option(42)
+  implicit val Some(_) = Option(42)
+}

--- a/test/files/neg/t7691.check
+++ b/test/files/neg/t7691.check
@@ -1,3 +1,36 @@
+t7691.scala:2: warning: Pattern definition introduces Unit-valued member of X; consider wrapping it in `locally { ... }`.
+object X { val _ = 42 }
+               ^
+t7691.scala:4: warning: Pattern definition introduces Unit-valued member of Y; consider wrapping it in `locally { ... }`.
+object Y { val (_, _) = (42, 17) }
+               ^
+t7691.scala:6: warning: Pattern definition introduces Unit-valued member of Z; consider wrapping it in `locally { ... }`.
+object Z { val _ = 42 ; val _ = 17 }             // was error
+               ^
+t7691.scala:6: warning: Pattern definition introduces Unit-valued member of Z; consider wrapping it in `locally { ... }`.
+object Z { val _ = 42 ; val _ = 17 }             // was error
+                            ^
+t7691.scala:8: warning: Pattern definition introduces Unit-valued member of V; consider wrapping it in `locally { ... }`.
+object V { val _, _, _ = println("hi") }         // was error
+               ^
+t7691.scala:8: warning: Pattern definition introduces Unit-valued member of V; consider wrapping it in `locally { ... }`.
+object V { val _, _, _ = println("hi") }         // was error
+                  ^
+t7691.scala:8: warning: Pattern definition introduces Unit-valued member of V; consider wrapping it in `locally { ... }`.
+object V { val _, _, _ = println("hi") }         // was error
+                     ^
+t7691.scala:10: warning: Pattern definition introduces Unit-valued member of W; consider wrapping it in `locally { ... }`.
+object W { val _: Int = 42 ; val _: Int = 17 }   // was error
+               ^
+t7691.scala:10: warning: Pattern definition introduces Unit-valued member of W; consider wrapping it in `locally { ... }`.
+object W { val _: Int = 42 ; val _: Int = 17 }   // was error
+                                 ^
+t7691.scala:12: warning: Pattern definition introduces Unit-valued member of Q; consider wrapping it in `locally { ... }`.
+object Q { val _ @ _ = 42 ; val _ = 17 }         // was error
+                   ^
+t7691.scala:12: warning: Pattern definition introduces Unit-valued member of Q; consider wrapping it in `locally { ... }`.
+object Q { val _ @ _ = 42 ; val _ = 17 }         // was error
+                                ^
 t7691.scala:16: error: value _ is not a member of object X
   def x = X.`_`       // value _ is not a member of object X
             ^
@@ -16,4 +49,5 @@ t7691.scala:24: error: value _ is not a member of object W
 t7691.scala:26: error: value _ is not a member of object Q
   def q = Q.`_`       // still not
             ^
+11 warnings
 6 errors

--- a/test/files/pos/t10641/J_0.java
+++ b/test/files/pos/t10641/J_0.java
@@ -1,8 +1,0 @@
-
-// (use of '_' as an identifier might not be supported in releases after Java SE 8)
-
-public class J_0 {
-    public int _() { return 42; }
-    public String funkyJavaNameFactory() { return "funk"; }
-    public int underscore() { return _(); }
-}

--- a/test/files/pos/t10641/S_1.scala
+++ b/test/files/pos/t10641/S_1.scala
@@ -1,7 +1,0 @@
-
-class S_1 {
-  val j = new J_0
-  import j.{ `_` => u, funkyJavaNameFactory => f }   // was: Wildcard import must be in last position
-  val x = u
-  def y = f
-}

--- a/test/files/run/repl-trim-stack-trace.scala
+++ b/test/files/run/repl-trim-stack-trace.scala
@@ -1,14 +1,5 @@
-import scala.tools.partest.SessionTest
+import scala.tools.partest.{SessionTest, StackCleaner}
 
-// scala/bug#7740
-object Test extends SessionTest  {
-  // normalize the "elided" lines because the frame count depends on test context
-  lazy val elided = """(\s+\.{3} )\d+( elided)""".r
-  lazy val frame  = """(\s+\Qat .f(<console>:\E)\d+(\))""".r
-  override def normalize(line: String) = line match {
-    case elided(ellipsis, suffix) => s"$ellipsis???$suffix"
-    case frame(prefix, suffix)    => s"${prefix}XX${suffix}"
-    case s                        => s
-  }
-  override def expected = super.expected map normalize
-}
+// scala/bug#7740 pretty print stack traces
+//
+object Test extends SessionTest with StackCleaner

--- a/test/files/run/t10641.check
+++ b/test/files/run/t10641.check
@@ -1,0 +1,9 @@
+/J_0.java:2: warning: '_' used as an identifier
+    public int _() { return 42; }
+               ^
+  (use of '_' as an identifier might not be supported in releases after Java SE 8)
+/J_0.java:4: warning: '_' used as an identifier
+    public int underscore() { return _(); }
+                                     ^
+  (use of '_' as an identifier might not be supported in releases after Java SE 8)
+2 warnings

--- a/test/files/run/t10641.scala
+++ b/test/files/run/t10641.scala
@@ -1,0 +1,51 @@
+
+import scala.tools.partest.DirectTest
+
+import java.net.URI
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file._
+import javax.tools._
+
+import scala.jdk.CollectionConverters._
+import scala.util.chaining._
+
+object Test extends DirectTest {
+  def jcode =
+    """
+public class J_0 {
+    public int _() { return 42; }
+    public String funkyJavaNameFactory() { return "funk"; }
+    public int underscore() { return _(); }
+}
+    """.trim()
+  def code =
+    """
+class S_1 {
+  val j = new J_0
+  import j.{`_` => u, funkyJavaNameFactory => f}   // was: Wildcard import must be in last position
+  val x = u
+  def y = f
+}
+    """.trim()
+
+  override def extraSettings = s"-usejavacp -classpath ${testOutput.path}"
+
+  def show() =
+    // (use of '_' as an identifier might not be supported in releases after Java SE 8)
+    testUnderJavaAtLeast("9") {
+      ()
+    } otherwise {
+      //val jfile = testOutput.jfile.toPath.resolve("J_0.java").tap(Files.writeString(_, jcode, UTF_8)
+      val javac = ToolProvider.getSystemJavaCompiler()
+      val fm    = javac.getStandardFileManager(null, null, UTF_8)  // null diagnostics, locale
+      val opts  = List("-d", testOutput.path).asJava
+      val uri   = URI.create("string:///J_0.java")
+      val kind  = JavaFileObject.Kind.SOURCE
+      val unit  = new SimpleJavaFileObject(uri, kind) { override def getCharContent(ignore: Boolean) = jcode }
+      val units = List(unit).asJava
+      val task  = javac.getTask(null, fm, null, opts, null, units) // null out, diagnostics, classes
+
+      assert(task.call())
+      assert(compile())
+    }
+}

--- a/test/files/run/t4950.check
+++ b/test/files/run/t4950.check
@@ -1,0 +1,8 @@
+
+scala> val 1 = 2
+scala.MatchError: 2 (of class java.lang.Integer)
+  ... ??? elided
+
+scala> val List(1) = List(1)
+
+scala> :quit

--- a/test/files/run/t4950.scala
+++ b/test/files/run/t4950.scala
@@ -1,25 +1,3 @@
-import scala.tools.partest.SessionTest
-import scala.PartialFunction.{ cond => when }
+import scala.tools.partest.{SessionTest, StackCleaner}
 
-object Elision {
-  val elideMsg = """  ... \d+ elided""".r
-}
-
-object Test extends SessionTest {
-  import Elision._
-
-  // Filter out the abbreviated stacktrace "... X elided" 
-  // because the number seems to differ between versions/platforms/...
-  def elided(s: String) = when(s) { case elideMsg() => true }
-  override def eval() = super.eval() filterNot elided
-  override def session =
-"""
-scala> val 1 = 2
-scala.MatchError: 2 (of class java.lang.Integer)
-
-scala> val List(1) = List(1)
-
-scala> :quit
-"""
-  override def show() = checkSession()
-}
+object Test extends SessionTest with StackCleaner

--- a/test/files/run/t7965.scala
+++ b/test/files/run/t7965.scala
@@ -38,9 +38,7 @@ object Test {
 }
 
 """
-  def main(args: Array[String]): Unit = {
-    if (util.Properties.isJavaAtLeast("1.7")) test()
-  }
+  def main(args: Array[String]): Unit = test()
 
   def test(): Unit = {
     import scala.reflect.runtime._


### PR DESCRIPTION
If a pattern definition binds no variables, it is
probably a mistake if it is marked implicit,
because it introduces no implicit values,
or if it is a template statement, because
it accidentally introduces a template member.

Fixes scala/bug#11618