### PR TITLE
Try to keep dots aligned

### DIFF
--- a/src/partest/scala/tools/partest/ConsoleLog.scala
+++ b/src/partest/scala/tools/partest/ConsoleLog.scala
@@ -23,9 +23,13 @@ class ConsoleLog(colorEnabled: Boolean) {
   val magenta = colored(Console.MAGENTA)
 
   private[this] var dotCount = 0
-  private[this] val DotWidth = 72
+  private[this] final val DotWidth = 72
 
-  def leftFlush(): Unit = {
+  def print(text: String) = synchronized {
+    Console.out.print(text)
+  }
+
+  def leftFlush(): Unit = synchronized {
     if (dotCount != 0) {
       normal("\n")
       dotCount = 0
@@ -62,7 +66,7 @@ class ConsoleLog(colorEnabled: Boolean) {
 
   def printDot(): Unit = printProgress(".")
   def printEx(): Unit  = printProgress(_failure + "X" + _default)
-  private def printProgress(icon: String): Unit =
+  private def printProgress(icon: String): Unit = synchronized {
     if (dotCount >= DotWidth) {
       outline("\n" + icon)
       dotCount = 1
@@ -70,4 +74,5 @@ class ConsoleLog(colorEnabled: Boolean) {
       outline(icon)
       dotCount += 1
     }
+  }
 }


### PR DESCRIPTION
Sprinkle more synch.

In CI builds, the blocks of dots in terse mode occasionally run long, or there is an orphan dot. This is sad.

It still doesn't interact well with status line, similar to stdout from tests.