### PR TITLE
Restore a test for XML parsing

### DIFF
--- a/test/files/run/t9027/test_2.scala
+++ b/test/files/run/t9027/test_2.scala
@@ -1,0 +1,11 @@
+
+object Test {
+  import scala.xml.NodeBuffer
+
+  def main(args: Array[String]): Unit = {
+    val xml =  <hello>world</hello>
+    assert(xml.toString == "helloworld")
+    val nodeBuffer: NodeBuffer = <hello/><world/>
+    assert(nodeBuffer.mkString == "helloworld")
+  }
+}

--- a/test/files/run/t9027/xml_1.scala
+++ b/test/files/run/t9027/xml_1.scala
@@ -1,0 +1,31 @@
+
+package scala.xml {
+  trait MetaData
+  trait NamespaceBinding
+  object TopScope extends NamespaceBinding
+  object Null extends MetaData
+  abstract class Node {
+    def label: String
+    def child: Seq[Node]
+    override def toString = label + child.mkString
+  }
+  class Elem(prefix: String, val label: String, attributes1: MetaData, scope: NamespaceBinding, minimizeEmpty: Boolean, val child: Node*) extends Node
+  class NodeBuffer extends Seq[Node] {
+    val nodes = scala.collection.mutable.ArrayBuffer.empty[Node]
+    def &+(o: Any): NodeBuffer =
+      o match {
+        case n: Node => nodes.addOne(n) ; this
+        case t: Text => nodes.addOne(Atom(t)) ; this
+      }
+    // Members declared in scala.collection.IterableOnce
+    def iterator: Iterator[scala.xml.Node] = nodes.iterator
+    // Members declared in scala.collection.SeqOps
+    def apply(i: Int): scala.xml.Node = nodes(i)
+    def length: Int = nodes.length
+  }
+  case class Text(text: String)
+  case class Atom(t: Text) extends Node {
+    def label = t.text
+    def child = Nil
+  }
+}


### PR DESCRIPTION
The test for issue 9027 was removed but never
reincarnated at scala-xml. But it's more natural
to build minimalist support for testing.

Backported from dotty.

Dotty allows the xml package in the same
compilation unit as the test, but Scala 2
requires xml pre-compiled.