### PR TITLE
Restore warn-any improvement

### DIFF
--- a/test/files/neg/warn-inferred-any.check
+++ b/test/files/neg/warn-inferred-any.check
@@ -13,9 +13,6 @@ warn-inferred-any.scala:27: warning: a type was inferred to be `Any`; this may i
 warn-inferred-any.scala:37: warning: a type was inferred to be `Object`; this may indicate a programming error.
   cs.contains(new C2)             // warns
      ^
-warn-inferred-any.scala:52: warning: a type was inferred to be `Any`; this may indicate a programming error.
-  stream.mapM(f)                  // should not warn
-         ^
 error: No warnings can be incurred under -Werror.
-6 warnings
+5 warnings
 1 error


### PR DESCRIPTION
This restores the previous commit, which was withdrawn because of noise from the community build, which broke for a good reason.

See https://github.com/scala/scala/pull/8586 for context but please don't laugh.

The ticket was re-opened after the reversion.

Fixes scala/bug#11798