### PR TITLE
Add HasForeachEntry to support optimizations to avoid `Tuple2` allocations.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -242,6 +242,28 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashMap1.transformImpl"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashMapCollision1.transformImpl"),
 
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.HasForeachEntry"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.TreeMap.foreachEntry"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#EmptyMap.foreachEntry"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map1.foreachEntry"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map2.foreachEntry"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map3.foreachEntry"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map4.foreachEntry"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.ListMap"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.TreeMap"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.HashMap"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.HashMap$HashMap1"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.HashMap$HashTrieMap"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.HashMap$HashMapCollision1"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.ListMap$Node"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.ListMap$EmptyListMap$"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.HashMap$EmptyHashMap$"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.Map$Map1"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.Map$Map2"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.Map$Map3"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.Map$Map4"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.Map$EmptyMap$"),
+
     //
     // scala-relect
     //

--- a/src/library/scala/collection/immutable/HasForeachEntry.scala
+++ b/src/library/scala/collection/immutable/HasForeachEntry.scala
@@ -1,0 +1,17 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.immutable
+
+private[immutable] trait HasForeachEntry[A, +B] {
+  private[immutable] def foreachEntry[U](f: (A, B) => U): Unit
+}

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -44,6 +44,7 @@ sealed class HashMap[A, +B] extends AbstractMap[A, B]
                         with MapLike[A, B, HashMap[A, B]]
                         with Serializable
                         with CustomParallelizable[(A, B), ParHashMap[A, B]]
+                        with HasForeachEntry[A, B]
 {
   import HashMap.{nullToEmpty, bufferSize}
 

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -73,7 +73,8 @@ object ListMap extends ImmutableMapFactory[ListMap] {
 sealed class ListMap[A, +B] extends AbstractMap[A, B]
   with Map[A, B]
   with MapLike[A, B, ListMap[A, B]]
-  with Serializable {
+  with Serializable
+  with HasForeachEntry[A,B] {
 
   override def empty = ListMap.empty
 

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -99,7 +99,7 @@ object Map extends ImmutableMapFactory[Map] {
   }
 
   @SerialVersionUID(-5626373049574850357L)
-  private object EmptyMap extends AbstractMap[Any, Nothing] with Map[Any, Nothing] with Serializable {
+  private object EmptyMap extends AbstractMap[Any, Nothing] with Map[Any, Nothing] with Serializable with HasForeachEntry[Any, Nothing]{
     override def size: Int = 0
     override def apply(key: Any) = throw new NoSuchElementException("key not found: " + key)
     override def contains(key: Any) = false
@@ -110,10 +110,11 @@ object Map extends ImmutableMapFactory[Map] {
     def + [V1](kv: (Any, V1)): Map[Any, V1] = updated(kv._1, kv._2)
     def - (key: Any): Map[Any, Nothing] = this
     override def hashCode: Int = MurmurHash3.emptyMapHash
+    override private[immutable] def foreachEntry[U](f: (Any, Nothing) => U): Unit = ()
   }
 
   @SerialVersionUID(-9131943191104946031L)
-  class Map1[K, +V](key1: K, value1: V) extends AbstractMap[K, V] with Map[K, V] with Serializable {
+  class Map1[K, +V](key1: K, value1: V) extends AbstractMap[K, V] with Map[K, V] with Serializable with HasForeachEntry[K, V] {
     override def size = 1
     override def apply(key: K) = if (key == key1) value1 else throw new NoSuchElementException("key not found: " + key)
     override def contains(key: K) = key == key1
@@ -148,10 +149,13 @@ object Map extends ImmutableMapFactory[Map] {
       h = MurmurHash3.mixLast(h, c)
       MurmurHash3.finalizeHash(h, N)
     }
+    override private[immutable] def foreachEntry[U](f: (K, V) => U): Unit = {
+      f(key1, value1)
+    }
   }
 
   @SerialVersionUID(-85684685400398742L)
-  class Map2[K, +V](key1: K, value1: V, key2: K, value2: V) extends AbstractMap[K, V] with Map[K, V] with Serializable {
+  class Map2[K, +V](key1: K, value1: V, key2: K, value2: V) extends AbstractMap[K, V] with Map[K, V] with Serializable with HasForeachEntry[K, V] {
     override def size = 2
     override def apply(key: K) =
       if (key == key1) value1
@@ -201,10 +205,14 @@ object Map extends ImmutableMapFactory[Map] {
       h = MurmurHash3.mixLast(h, c)
       MurmurHash3.finalizeHash(h, N)
     }
+    override private[immutable] def foreachEntry[U](f: (K, V) => U): Unit = {
+      f(key1, value1)
+      f(key2, value2)
+    }
   }
 
   @SerialVersionUID(-6400718707310517135L)
-  class Map3[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V) extends AbstractMap[K, V] with Map[K, V] with Serializable {
+  class Map3[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V) extends AbstractMap[K, V] with Map[K, V] with Serializable with HasForeachEntry[K, V] {
     override def size = 3
     override def apply(key: K) =
       if (key == key1) value1
@@ -264,10 +272,15 @@ object Map extends ImmutableMapFactory[Map] {
       h = MurmurHash3.mixLast(h, c)
       MurmurHash3.finalizeHash(h, N)
     }
+    override private[immutable] def foreachEntry[U](f: (K, V) => U): Unit = {
+      f(key1, value1)
+      f(key2, value2)
+      f(key3, value3)
+    }
   }
 
   @SerialVersionUID(-7992135791595275193L)
-  class Map4[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V, key4: K, value4: V) extends AbstractMap[K, V] with Map[K, V] with Serializable {
+  class Map4[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V, key4: K, value4: V) extends AbstractMap[K, V] with Map[K, V] with Serializable with HasForeachEntry[K, V] {
     override def size = 4
     override def apply(key: K) =
       if (key == key1) value1
@@ -336,6 +349,12 @@ object Map extends ImmutableMapFactory[Map] {
       h = MurmurHash3.mix(h, b)
       h = MurmurHash3.mixLast(h, c)
       MurmurHash3.finalizeHash(h, N)
+    }
+    override private[immutable] def foreachEntry[U](f: (K, V) => U): Unit = {
+      f(key1, value1)
+      f(key2, value2)
+      f(key3, value3)
+      f(key4, value4)
     }
   }
   private [immutable] final class HashCodeAccumulator extends scala.runtime.AbstractFunction2[Any, Any, Unit] {

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -52,7 +52,8 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
   extends SortedMap[A, B]
      with SortedMapLike[A, B, TreeMap[A, B]]
      with MapLike[A, B, TreeMap[A, B]]
-     with Serializable {
+     with Serializable
+     with HasForeachEntry[A, B] {
 
   override protected[this] def newBuilder : Builder[(A, B), TreeMap[A, B]] =
     TreeMap.newBuilder[A, B]
@@ -204,6 +205,8 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
   override def isDefinedAt(key: A): Boolean = RB.contains(tree, key)
 
   override def foreach[U](f : ((A,B)) => U) = RB.foreach(tree, f)
+
+  override private[immutable] def foreachEntry[U](f: (A, B) => U): Unit = RB.foreachEntry(tree, f)
 
   override def hashCode(): Int = {
     if (isEmpty) {


### PR DESCRIPTION
This supports, for example, a [proposed optimization](https://github.com/scala/scala/pull/8466/commits/b5295241811cf939fa4ce61b30c535f675aefde2#diff-ef59ae1920818cddd42a380fc636af4fR213-R223) in `HashMap.++` which can avoid intermediate `Tuple2` allocation for a wider range of operand collections.