### PR TITLE
remove outdated JLine-related comment

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -6,6 +6,5 @@ starr.version=2.13.1
 #  - scala-compiler: jline (% "optional")
 # Other usages:
 #  - scala-asm: jar content included in scala-compiler
-#  - jline: shaded with JarJar and included in scala-compiler
 scala-asm.version=7.3.1-scala-1
 jline.version=2.14.6


### PR DESCRIPTION
on 2.13.x, we no longer shade JLine