### PR TITLE
Rework insertion of stabilizing definitions

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -296,6 +296,8 @@ trait Contexts { self: Analyzer =>
     /** A root import is never unused and always bumps context depth. (e.g scala._ / Predef._ and magic REPL imports) */
     def isRootImport: Boolean = false
 
+    var pendingStabilizers: List[Tree] = Nil
+
     /** Types for which implicit arguments are currently searched */
     var openImplicits: List[OpenImplicit] = List()
     final def isSearchingForImplicitParam: Boolean = {

--- a/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
@@ -199,27 +199,6 @@ trait StdAttachments {
 
   /** Marks a Typed tree with Unit tpt. */
   case object TypedExpectingUnitAttachment
-
-  case class StabilizingDefinitions(vdefs: List[ValDef])
-  private[this] val StabilizingDefinitionsTag: reflect.ClassTag[StabilizingDefinitions] = reflect.classTag[StabilizingDefinitions]
-
-  def addStabilizingDefinition(tree: Tree, vdef: ValDef): Tree = {
-    tree.updateAttachment(StabilizingDefinitions(
-      tree.attachments.get[StabilizingDefinitions](StabilizingDefinitionsTag) match {
-        case Some(StabilizingDefinitions(vdefs)) => vdef :: vdefs
-        case _ => List(vdef)
-      }
-    ))(StabilizingDefinitionsTag)
-  }
-
-  def stabilizingDefinitions(tree: Tree): List[ValDef] =
-    tree.attachments.get[StabilizingDefinitions](StabilizingDefinitionsTag) match {
-      case Some(StabilizingDefinitions(vdefs)) => vdefs
-      case _ => Nil
-    }
-
-  def removeStabilizingDefinitions(tree: Tree): Tree =
-    tree.removeAttachment[StabilizingDefinitions](StabilizingDefinitionsTag)
 }
 
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -712,10 +712,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           val context1 = context.makeSilent(reportAmbiguousErrors, newtree)
           context1.undetparams = context.undetparams
           context1.savedTypeBounds = context.savedTypeBounds
+          context1.pendingStabilizers = context.pendingStabilizers
           val typer1 = newTyper(context1)
           val result = op(typer1)
           context.undetparams = context1.undetparams
           context.savedTypeBounds = context1.savedTypeBounds
+          context.pendingStabilizers = context1.pendingStabilizers
 
           // If we have a successful result, emit any warnings it created.
           if (!context1.reporter.hasErrors)
@@ -2568,7 +2570,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           }
         }
         val statsTyped = typedStats(block.stats, context.owner, warnPure = false)
-        val expr1 = typed(block.expr, mode &~ (FUNmode | QUALmode), pt)
+        val expr1 = typed(block.expr, mode &~ (FUNmode | QUALmode | APPSELmode), pt)
 
         // sanity check block for unintended expr placement
         if (!isPastTyper) {
@@ -5327,35 +5329,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               // implicit scopes which are accessible via lhs can be candidates for satisfying
               // implicit (conversions to) arguments of name.
 
-              // We have to introduce the ValDef before its use here, so we walk up the
-              // context tree and attach it to the original root of this expression. It will
-              // be extracted and inserted by insertStabilizer when typer unwinds out of this
-              // expression. Stabilized args are introduced in the block arg expression.
-              val insertionContext = context.nextEnclosing { ctx =>
-                def isInsertionNode(tree: Tree) =
-                  tree match {
-                    case _: Apply | _: TypeApply | _: Select => true
-                    case _                                   => false
-                  }
-                def isEnclosingInsertionNode(tree: Tree) =
-                  tree match {
-                    case Apply(_, args)           => args.contains(ctx.tree)
-                    case _: TypeApply | _: Select => false
-                    case _                        => true
-                  }
-                isInsertionNode(ctx.tree) && isEnclosingInsertionNode(ctx.outer.tree)
-              }
-
-              if (insertionContext != NoContext) {
-                val vsym = insertionContext.owner.newValue(freshTermName(nme.STABILIZER_PREFIX), qual.pos.focus, SYNTHETIC | ARTIFACT | STABLE)
-                vsym.setInfo(uncheckedBounds(qual.tpe))
-                insertionContext.scope enter vsym
-                val vdef = atPos(vsym.pos)(ValDef(vsym, focusInPlace(qual)) setType NoType)
-                qual.changeOwner(insertionContext.owner -> vsym)
-                addStabilizingDefinition(insertionContext.tree, vdef)
-                val newQual = Ident(vsym) setType singleType(NoPrefix, vsym) setPos qual.pos.focus
-                return typedSelect(tree, newQual, name)
-              }
+              val vsym = context.owner.newValue(freshTermName(nme.STABILIZER_PREFIX), qual.pos.focus, SYNTHETIC | ARTIFACT | STABLE)
+              vsym.setInfo(uncheckedBounds(qual.tpe))
+              val vdef = atPos(vsym.pos)(ValDef(vsym, focusInPlace(qual)) setType NoType)
+              context.pendingStabilizers ::= vdef
+              qual.changeOwner(context.owner -> vsym)
+              val newQual = Ident(vsym) setType singleType(NoPrefix, vsym) setPos qual.pos.focus
+              return typedSelect(tree, newQual, name)
             }
 
             val tree1 = tree match {
@@ -5956,23 +5936,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         case _                => abort(s"unexpected member def: ${tree.getClass}\n$tree")
       }
 
-      // Extract and insert stabilizing ValDefs (if any) which might have been
-      // introduced during the typing of the original expression.
-      def insertStabilizer(tree: Tree, original: Tree): Tree = {
-        if (phase.erasedTypes) tree
-        else stabilizingDefinitions(original) match {
-          case Nil => tree
-          case vdefs =>
-            removeStabilizingDefinitions(tree)
-            Block(vdefs.reverse, tree) setType tree.tpe setPos tree.pos
-        }
-      }
-
       // Trees not allowed during pattern mode.
       def typedOutsidePatternMode(tree: Tree): Tree = tree match {
         case tree: Block            => typerWithLocalContext(context.makeNewScope(tree, context.owner))(_.typedBlock(tree, mode, pt))
         case tree: If               => typedIf(tree)
-        case tree: TypeApply        => insertStabilizer(typedTypeApply(tree), tree)
+        case tree: TypeApply        => typedTypeApply(tree)
         case tree: Function         => typedFunction(tree)
         case tree: Match            => typedVirtualizedMatch(tree)
         case tree: New              => typedNew(tree)
@@ -5995,8 +5963,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       @inline def typedInAnyMode(tree: Tree): Tree = tree match {
         case tree: Ident   => typedIdentOrWildcard(tree)
         case tree: Bind    => typedBind(tree)
-        case tree: Apply   => insertStabilizer(typedApply(tree), tree)
-        case tree: Select  => insertStabilizer(typedSelectOrSuperCall(tree), tree)
+        case tree: Apply   => typedApply(tree)
+        case tree: Select  => typedSelectOrSuperCall(tree)
         case tree: Literal => typedLiteral(tree)
         case tree: Typed   => typedTyped(tree)
         case tree: This    => typedThis(tree)  // scala/bug#6104
@@ -6017,14 +5985,39 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     }
 
     def typed(tree: Tree, mode: Mode, pt: Type): Tree = {
+      // Extract and insert stabilizing ValDefs (if any) which might have been
+      // introduced during the typing of the original expression.
+      @inline def insertStabilizer(doTyped: Mode => Tree): Tree = {
+        if (phase.erasedTypes || mode.in(APPSELmode) || isMacroImplRef(tree)) doTyped(mode)
+        else tree match {
+          case _: Select | _: Apply | _: TypeApply =>
+            val saved = context.pendingStabilizers
+            context.pendingStabilizers = Nil
+            val (res, vdefs) =
+              try {
+                val r = doTyped(mode | APPSELmode)
+                (r, context.pendingStabilizers)
+              }
+              finally
+                context.pendingStabilizers = saved
+            if (vdefs.isEmpty)
+              res
+            else {
+              devWarningIf(vdefs.forall(_.symbol.owner == context.owner))(s"${context.owner} - ${(vdefs.map(vd => (vd.symbol, vd.symbol.owner.fullNameString)), context.owner)}")
+              typed1(Block(vdefs.reverse, res) setPos res.pos, mode, pt)
+            }
+          case _ => doTyped(mode)
+        }
+      }
+
       lastTreeToTyper = tree
       val statsEnabled = StatisticsStatics.areSomeHotStatsEnabled() && statistics.areHotStatsLocallyEnabled
       val startByType = if (statsEnabled) statistics.pushTimer(byTypeStack, byTypeNanos(tree.getClass)) else null
       if (statsEnabled) statistics.incCounter(visitsByType, tree.getClass)
       val shouldPrintTyping = printTypings && !phase.erasedTypes && !noPrintTyping(tree)
       val shouldPopTypingStack = shouldPrintTyping && typingStack.beforeNextTyped(tree, mode, pt, context)
-      try {
 
+      try insertStabilizer { mode =>
         val ptPlugins = pluginsPt(pt, this, tree, mode)
         def retypingOk = (
           context.retyping

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3846,7 +3846,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def loop(mt: Type): Boolean = {
       mt match {
         case MethodType(params, restpe) => params.exists(_.info.dealias.exists(_ == tt)) || loop(restpe)
-        case PolyType(tparams, restpe) => loop(restpe)
+        case PolyType(_, restpe) => loop(restpe)
         case _ => false
       }
     }

--- a/test/files/run/t11609.check
+++ b/test/files/run/t11609.check
@@ -1,0 +1,24 @@
+new Foo 0
+new Foo 1
+new Bar 0
+new Foo 2
+new Foo 3
+new Bar 0
+new Bar 1
+sara
+frank
+new Foo 4
+new Bar 0
+new Bar 1
+new Foo 5
+new Foo 6
+new Bar 0
+new Foo 7
+new Foo 8
+new Bar 0
+new Bar 1
+sara
+frank
+new Foo 9
+new Bar 0
+new Bar 1

--- a/test/files/run/t11609.scala
+++ b/test/files/run/t11609.scala
@@ -1,0 +1,41 @@
+class Foo {
+  println(s"new Foo ${Foo.c}"); Foo.c += 1
+
+  class Bar {
+    println(s"new Bar ${Bar.c}"); Bar.c += 1
+  }
+
+  object Bar {
+    var c = 0
+    implicit def brr: Bar = new Bar
+  }
+  def m(implicit b: Bar): Foo = Foo.this
+}
+object Foo {
+  var c = 0
+}
+
+object Test {
+  (new Foo).m(null)
+  def a = (new Foo).m(null)
+
+  (new Foo).m
+  def b = (new Foo).m
+
+  (new Foo).m(null).m(null)
+  def c = (new Foo).m(null).m(null)
+
+  (new Foo).m.m
+  def d = (new Foo).m.m
+
+  { println("sara"); { println("frank"); new Foo}.m}.m
+  def e = { println("sara"); { println("frank"); new Foo}.m}.m
+
+  def main(args: Array[String]): Unit = {
+    a
+    b
+    c
+    d
+    e
+  }
+}

--- a/test/files/run/t11756.scala
+++ b/test/files/run/t11756.scala
@@ -1,0 +1,47 @@
+trait MyAny {
+  type TSomething
+  type This <: MyAny
+}
+
+class MyBool extends MyAny {
+  type TSomething = DummyImplicit
+  type This = MyBool
+}
+
+object Test extends App {
+  val i = new MyBool
+  var call = 0
+  var callList : List[Int] = List()
+
+  final class MyMatch[MV <: MyAny](val matchVal : MV)  {
+    def myCase[MC](pattern : Boolean)(block : => Unit)(
+      implicit patternBld : matchVal.TSomething
+    ) : MyMatch[MV] = {
+      call -= 1
+      block
+      this
+    }
+  }
+
+  def myMatch[MV <: MyAny](matchValue : MV) : MyMatch[matchValue.This] = {
+    callList = callList :+ call
+    call += 1
+    new MyMatch[matchValue.This](matchValue.asInstanceOf[matchValue.This])
+  }
+
+  myMatch(i)
+    .myCase(true) {
+      myMatch(i)
+        .myCase(true) {
+
+        }
+    }
+    .myCase(true) {
+      myMatch(i)
+        .myCase(true) {
+
+        }
+    }
+  
+  assert(callList == List(0, 0, -1))
+}


### PR DESCRIPTION
Introduce a typer mode to know when we're type checking a qualifier
of a select, or a function part of an application. When a stabilizing
qualifier is created, insert it once we get back out of this mode.

In `x.y.foo(bar)`, if `foo` has a second implicit argument list, make
sure that the block with the stabilizer is only created after the
implicit is inferred, i.e., run `adapt` on `$stabilizer.foo(bar)`
to get `$stabilizer.foo(bar)(<implicit arg>)` first, then create

```
{
  val $stabilizer = x.y
  $stabilizer.foo(bar)(<implicit arg>)
}
```

Before, we would create

```
{
  val $stabilizer = x.y
  $stabilizer.foo(bar)
}
```

then assign a `MethodType` to the block, and run `adapt`. This worked in
some situations by chance, but not always.

Fixes https://github.com/scala/bug/issues/11756 and fixes https://github.com/scala/bug/issues/11609 (tested also with shapeless)