### PR TITLE
Symbols: share the set of Attachments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,8 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.TypeTags.TypeTagImpl"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.Universe.TypeTagImpl"),
     ProblemFilters.exclude[MissingClassProblem]("scala.reflect.macros.Attachments$"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.macros.Attachments.cloneAttachments"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.macros.NonemptyAttachments.cloneAttachments"),
     ProblemFilters.exclude[DirectAbstractMethodProblem]("scala.collection.immutable.ArraySeq.stepper"),
     ProblemFilters.exclude[ReversedAbstractMethodProblem]("scala.collection.immutable.ArraySeq.stepper"),
     ProblemFilters.exclude[DirectAbstractMethodProblem]("scala.collection.mutable.ArraySeq.stepper"),

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2039,7 +2039,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
           setInfo (this.info cloneInfo clone)
           setAnnotations this.annotations
       )
-      this.attachments.all.foreach(clone.updateAttachment)
+      updateAttachmentFun.theClone = clone
+      this.attachments.all.foreach(updateAttachmentFun)
       if (clone.thisSym != clone)
         clone.typeOfThis = (clone.typeOfThis cloneInfo clone)
 
@@ -2047,6 +2048,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         clone setName asNameType(newName)
 
       clone
+    }
+
+    private[this] object updateAttachmentFun extends Function1[Any, Unit] {
+      var theClone: TypeOfClonedSymbol = null
+      def apply(x: Any): Unit = theClone.updateAttachment(x)
     }
 
     /** Internal method to clone a symbol's implementation with the given flags and no info. */

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2039,8 +2039,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
           setInfo (this.info cloneInfo clone)
           setAnnotations this.annotations
       )
-      updateAttachmentFun.theClone = clone
-      this.attachments.all.foreach(updateAttachmentFun)
+      assert(clone.attachments.isEmpty)
+      clone.setAttachments(this.attachments.cloneAttachments)
       if (clone.thisSym != clone)
         clone.typeOfThis = (clone.typeOfThis cloneInfo clone)
 
@@ -2048,11 +2048,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         clone setName asNameType(newName)
 
       clone
-    }
-
-    private[this] object updateAttachmentFun extends Function1[Any, Unit] {
-      var theClone: TypeOfClonedSymbol = null
-      def apply(x: Any): Unit = theClone.updateAttachment(x)
     }
 
     /** Internal method to clone a symbol's implementation with the given flags and no info. */

--- a/src/reflect/scala/reflect/macros/Attachments.scala
+++ b/src/reflect/scala/reflect/macros/Attachments.scala
@@ -83,6 +83,7 @@ abstract class Attachments { self =>
   }
 
   def isEmpty: Boolean = true
+  def cloneAttachments: Attachments { type Pos = self.Pos } = this
 }
 
 private object Attachments {
@@ -97,4 +98,5 @@ private final class NonemptyAttachments[P >: Null](override val pos: P, override
   type Pos = P
   def withPos(newPos: Pos) = new NonemptyAttachments(newPos, all)
   override def isEmpty: Boolean = false
+  override def cloneAttachments: Attachments { type Pos = P } = new NonemptyAttachments[P](pos, all)
 }


### PR DESCRIPTION
In some profiles, we noticed that the call to `clone.updateAttachment` was generating up to 10 MiB of lambda objects. Since this seems to be non-reentrant, we can save those allocations by using a single `Function1` object with a mutable state.
![Screenshot 2020-02-15 at 15 10 32](https://user-images.githubusercontent.com/1764610/74590339-6eab4c80-5005-11ea-862e-74fe3cb17fb1.png)
