### PR TITLE
Symbols: store StringBuilder used for getting nameString.

### DIFF
--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -206,6 +206,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.IsRelatableCollector
     this.SubTypePair
     this.SymbolKind
+    this.Symbol
     this.NoSymbol
     this.CyclicReference
     this.SymbolOps


### PR DESCRIPTION
We noticed in some profiles that the calls to `nameString` were
allocating over 1 MiB of StringBuilder objects, which suggests that
too many objects are created, each one carrying a 32-byte array.
By caching this object, we hope to reduce the number of allocations
from here.