### PR TITLE
Optimize immutable.HashSet builder (inspired by the 2.13 implementation)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -221,6 +221,18 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[ReversedAbstractMethodProblem]("scala.collection.immutable.HashSet#LeafHashSet.hash"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#LeafHashSet.this"),
 
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet.elemHashCode"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet.computeHash"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet.improve"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#HashTrieSet.bitmap"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#HashTrieSet.bitmap_="),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#HashTrieSet.elems_="),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#HashTrieSet.size0"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#HashTrieSet.size0_="),
+    ProblemFilters.exclude[FinalMethodProblem]("scala.collection.immutable.HashSet#HashTrieSet.size"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.HashSet$HashSetBuilder"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.Set$SetBuilderImpl"),
+
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.RedBlackTree$EqualsIterator"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.RedBlackTree#TreeIterator.findLeftMostOrPopOnEmpty"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.RedBlackTree#TreeIterator.popNext"),
@@ -228,7 +240,7 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.RedBlackTree#TreeIterator.lookahead_="),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.RedBlackTree#TreeIterator.goRight"),
 
-    // Some static forwarder changes detected after a MiMa upgrade.
+  // Some static forwarder changes detected after a MiMa upgrade.
     // e.g. static method apply(java.lang.Object)java.lang.Object in class scala.Symbol does not have a correspondent in current version
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Symbol.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.sys.process.Process.Future"),

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -19,7 +19,6 @@ import java.util
 import generic._
 import scala.collection.parallel.immutable.ParHashSet
 import scala.annotation.tailrec
-import scala.collection.mutable.SetBuilder
 
 /** This class implements immutable sets using a hash trie.
  *
@@ -179,8 +178,6 @@ sealed class HashSet[A] extends AbstractSet[A]
       nullToEmpty(filter0(p, true, 0, buffer, 0))
   }
 
-
-
   protected def filter0(p: A => Boolean, negate: Boolean, level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = null
 
   protected def elemHashCode(key: A) = key.##
@@ -218,12 +215,7 @@ sealed class HashSet[A] extends AbstractSet[A]
  *  @define willNotTerminateInf
  */
 object HashSet extends ImmutableSetFactory[HashSet] {
-  override def newBuilder[A]: mutable.Builder[A, HashSet[A]] = new SetBuilder[A, HashSet[A]](empty[A]) {
-    override def ++=(xs: TraversableOnce[A]): this.type = {
-      elems = elems ++ xs
-      this
-    }
-  }
+  override def newBuilder[A]: mutable.Builder[A, HashSet[A]] = new HashSetBuilder[A]
 
   /** $setCanBuildFromInfo */
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, HashSet[A]] =
@@ -541,8 +533,9 @@ object HashSet extends ImmutableSetFactory[HashSet] {
    * elems: [a,b]
    * children:        ---b----------------a-----------
    */
-  class HashTrieSet[A](private val bitmap: Int, private[collection] val elems: Array[HashSet[A]], override val size: Int)
+  class HashTrieSet[A](private[HashSet] var bitmap: Int, private[collection] var elems: Array[HashSet[A]], private[HashSet] var size0: Int)
         extends HashSet[A] {
+    @inline override final def size = size0
     // assert(Integer.bitCount(bitmap) == elems.length)
     // assertion has to remain disabled until scala/bug#6197 is solved
     // assert(elems.length > 1 || (elems.length == 1 && elems(0).isInstanceOf[HashTrieSet[_]]))
@@ -1113,6 +1106,16 @@ object HashSet extends ImmutableSetFactory[HashSet] {
       }
     }
   }
+  protected def elemHashCode(key: Any) = key.##
+
+  protected final def improve(hcode: Int) = {
+    var h: Int = hcode + ~(hcode << 9)
+    h = h ^ (h >>> 14)
+    h = h + (h << 4)
+    h ^ (h >>> 10)
+  }
+
+  private[collection] def computeHash(key: Any) = improve(elemHashCode(key))
 
   /**
    * Calculates the maximum buffer size given the maximum possible total size of the trie-based collection
@@ -1183,4 +1186,297 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     private def readResolve(): AnyRef = orig
   }
 
+
+  /** Builder for HashSet.
+   */
+  private[collection] final class HashSetBuilder[A] extends mutable.ReusableBuilder[A, HashSet[A]] {
+
+
+    /* Nodes in the tree are either regular HashSet1, HashTrieSet, HashSetCollision1, or a mutable HashTrieSet
+      mutable HashTrieSet nodes are designated by having size == -1
+
+      mutable HashTrieSet nodes can have child nodes that are mutable, or immutable
+      immutable HashTrieSet child nodes can only be immutable
+
+      mutable HashTrieSet elems are always a Array of size 32,size -1, bitmap -1
+     */
+
+    /** The root node of the partially build hashmap */
+    private var rootNode: HashSet[A] = HashSet.empty
+
+    private def isMutable(hs: HashSet[A]) = {
+      hs.isInstanceOf[HashTrieSet[A]] && hs.size == -1
+    }
+
+    private def makeMutable(hs: HashTrieSet[A]): HashTrieSet[A] = {
+      if (isMutable(hs)) hs
+      else {
+        val elems = new Array[HashSet[A]](32)
+        var bit = 0
+        var iBit = 0
+        while (bit < 32) {
+          if ((hs.bitmap & (1 << bit)) != 0) {
+            elems(bit) = hs.elems(iBit)
+            iBit += 1
+          }
+          bit += 1
+        }
+        new HashTrieSet[A](-1, elems, -1)
+      }
+    }
+
+    private def makeImmutable(hs: HashSet[A]): HashSet[A] = {
+      hs match {
+        case trie: HashTrieSet[A] if isMutable(trie) =>
+          var bit = 0
+          var bitmap = 0
+          var size = 0
+          while (bit < 32) {
+            if (trie.elems(bit) ne null)
+              trie.elems(bit) = makeImmutable(trie.elems(bit))
+            if (trie.elems(bit) ne null) {
+              bitmap |= 1 << bit
+              size += trie.elems(bit).size
+            }
+            bit += 1
+          }
+          Integer.bitCount(bitmap) match {
+            case 0 => null
+            case 1
+              if trie.elems(Integer.numberOfTrailingZeros(bitmap)).isInstanceOf[LeafHashSet[A]] =>
+              trie.elems(Integer.numberOfTrailingZeros(bitmap))
+
+            case bc =>
+              val elems = if (bc == 32) trie.elems else {
+                val elems = new Array[HashSet[A]](bc)
+                var oBit = 0
+                bit = 0
+                while (bit < 32) {
+                  if (trie.elems(bit) ne null) {
+                    elems(oBit) = trie.elems(bit)
+                    oBit += 1
+                  }
+                  bit += 1
+                }
+                assert(oBit == bc)
+                elems
+              }
+              trie.size0 = size
+              trie.elems = elems
+              trie.bitmap = bitmap
+              trie
+          }
+        case _ => hs
+      }
+    }
+
+    override def clear(): Unit = {
+      rootNode match {
+        case trie: HashTrieSet[A] if isMutable(trie) =>
+          util.Arrays.fill(trie.elems.asInstanceOf[Array[AnyRef]], null)
+        case _ => rootNode = HashSet.empty
+      }
+    }
+
+    override def result(): HashSet[A] = {
+        rootNode = nullToEmpty(makeImmutable(rootNode))
+        rootNode
+    }
+
+
+    override def +=(elem1: A, elem2: A, elems: A*): HashSetBuilder.this.type = {
+      this += elem1
+      this += elem2
+      this ++= elems
+    }
+
+    override def +=(elem: A): HashSetBuilder.this.type = {
+      val hash = computeHash(elem)
+      rootNode = addOne(rootNode, elem, hash, 0)
+      this
+    }
+
+    override def ++=(xs: TraversableOnce[A]): HashSetBuilder.this.type = xs match {
+      case hs: HashSet[A] =>
+        if (rootNode.isEmpty) {
+          if (!hs.isEmpty)
+            rootNode = hs
+        } else
+          rootNode = addHashSet(rootNode, hs, 0)
+        this
+      //      case hs: HashMap.HashMapKeys =>
+      //      //TODO
+      case hs: mutable.HashSet[A] =>
+        //TODO
+        super.++=(xs)
+      case _ =>
+        super.++=(xs)
+    }
+
+    def makeMutableTrie(aLeaf: LeafHashSet[A], bLeaf: LeafHashSet[A], level: Int): HashTrieSet[A] = {
+      val elems = new Array[HashSet[A]](32)
+      val aRawIndex = (aLeaf.hash >>> level) & 0x1f
+      val bRawIndex = (bLeaf.hash >>> level) & 0x1f
+      if (aRawIndex == bRawIndex) {
+        elems(aRawIndex) = makeMutableTrie(aLeaf, bLeaf, level + 5)
+      } else {
+        elems(aRawIndex) = aLeaf
+        elems(bRawIndex) = bLeaf
+      }
+      new HashTrieSet[A](-1, elems, -1)
+    }
+
+    def makeMutableTrie(leaf: LeafHashSet[A], elem: A, elemImprovedHash: Int, level: Int): HashTrieSet[A] = {
+      makeMutableTrie(leaf, new HashSet1(elem, elemImprovedHash), level)
+    }
+
+    private def addOne(toNode: HashSet[A], elem: A, improvedHash: Int, level: Int): HashSet[A] = {
+      toNode match {
+        case leaf: LeafHashSet[A] =>
+          if (leaf.hash == improvedHash)
+            leaf.updated0(elem, improvedHash, level)
+          else makeMutableTrie(leaf, elem, improvedHash, level)
+
+        case trie: HashTrieSet[A] if isMutable((trie)) =>
+          val arrayIndex = (improvedHash >>> level) & 0x1f
+          val old = trie.elems(arrayIndex)
+          trie.elems(arrayIndex) = if (old eq null) new HashSet1(elem, improvedHash)
+          else addOne(old, elem, improvedHash, level + 5)
+          trie
+
+        case trie: HashTrieSet[A] =>
+          val rawIndex = (improvedHash >>> level) & 0x1f
+          val arrayIndex = compressedIndex(trie, rawIndex)
+          if (arrayIndex == -1)
+            addOne(makeMutable(trie), elem, improvedHash, level)
+          else {
+            val old = trie.elems(arrayIndex)
+            val merged = if (old eq null) new HashSet1(elem, improvedHash)
+            else addOne(old, elem, improvedHash, level + 5)
+
+            if (merged eq old) trie
+            else {
+              val newMutableTrie = makeMutable(trie)
+              newMutableTrie.elems(rawIndex) = merged
+              newMutableTrie
+            }
+          }
+        case empty if empty.isEmpty => toNode.updated0(elem, improvedHash, level)
+      }
+    }
+
+    /** return the bit index of the rawIndex in the bitmap of the trie, or -1 if the bit is not in the bitmap */
+    private def compressedIndex(trie: HashTrieSet[A], rawIndex: Int): Int = {
+      if (trie.bitmap == -1) rawIndex
+      else if ((trie.bitmap & (1 << rawIndex)) == 0) {
+        //the value is not in this index
+        -1
+      } else {
+        Integer.bitCount(((1 << rawIndex) - 1) & trie.bitmap)
+      }
+    }
+    /** return the array index for the rawIndex, in the trie elem array
+     * The trei may be mutable, or immutable
+     * returns -1 if the trie is compressed and the index in not in the array */
+    private def trieIndex(trie: HashTrieSet[A], rawIndex: Int): Int = {
+      if (isMutable(trie) || trie.bitmap == -1) rawIndex
+      else compressedIndex(trie, rawIndex)
+    }
+
+    private def addHashSet(toNode: HashSet[A], toBeAdded: HashSet[A], level: Int): HashSet[A] = {
+      toNode match {
+        case aLeaf: LeafHashSet[A] => addToLeafHashSet(aLeaf, toBeAdded, level)
+        case trie: HashTrieSet[A] => addToTrieHashSet(trie, toBeAdded, level)
+        case empty if empty.isEmpty => toNode
+      }
+    }
+
+    private def addToTrieHashSet(toNode: HashTrieSet[A], toBeAdded: HashSet[A], level: Int): HashSet[A] = {
+      if (toNode eq toBeAdded) toNode
+      else toBeAdded match {
+        case bLeaf: LeafHashSet[A] =>
+          val rawIndex = (bLeaf.hash >>> level) & 0x1f
+          val arrayIndex = trieIndex(toNode, rawIndex)
+          if (arrayIndex == -1) {
+            val newToNode = makeMutable(toNode)
+            newToNode.elems(rawIndex) = toBeAdded
+            newToNode
+          } else {
+            val old = toNode.elems(arrayIndex)
+            if (old eq toBeAdded) toNode
+            else if (old eq null) {
+              assert(isMutable(toNode))
+              toNode.elems(arrayIndex) = toBeAdded
+              toNode
+            } else {
+              val result = addHashSet(old, toBeAdded, level + 5)
+              if (result eq old) toNode
+              else {
+                val newToNode = makeMutable(toNode)
+                newToNode.elems(rawIndex) = result
+                newToNode
+              }
+            }
+          }
+        case bTrie: HashTrieSet[A] =>
+          var result = toNode
+          var bBitSet = bTrie.bitmap
+          var bArrayIndex = 0
+          while (bBitSet != 0) {
+            val bValue = bTrie.elems(bArrayIndex)
+            val rawIndex = Integer.numberOfTrailingZeros(bBitSet)
+            val aArrayIndex = trieIndex(result, rawIndex)
+            if (aArrayIndex == -1) {
+              result = makeMutable(result)
+              result.elems(rawIndex) = bValue
+            } else {
+              val aValue = result.elems(aArrayIndex)
+              if (aValue ne bValue) {
+                if (aValue eq null) {
+                  assert(isMutable(result))
+                  result.elems(rawIndex) = bValue
+                } else {
+                  val resultAtIndex = addHashSet(aValue, bValue, level + 5)
+                  if (resultAtIndex ne aValue) {
+                    result = makeMutable(result)
+                    result.elems(rawIndex) = resultAtIndex
+                  }
+                }
+              }
+            }
+            bBitSet ^= 1 << rawIndex
+            bArrayIndex += 1
+          }
+          result
+        case empty if empty.isEmpty => toNode
+      }
+    }
+    private def addToLeafHashSet(toNode: LeafHashSet[A], toBeAdded: HashSet[A], level: Int): HashSet[A] = {
+      if (toNode eq toBeAdded) toNode
+      else toBeAdded match {
+        case bLeaf: LeafHashSet[A] =>
+          if (toNode.hash == bLeaf.hash) toNode.union0(bLeaf, level)
+          else makeMutableTrie(toNode, bLeaf, level)
+        case bTrie: HashTrieSet[A] =>
+          val rawIndex = (toNode.hash >>> level) & 0x1f
+          val arrayIndex = compressedIndex(bTrie, rawIndex)
+          if (arrayIndex == -1) {
+            val result = makeMutable(bTrie)
+            result.elems(rawIndex) = toNode
+            result
+          } else {
+            val newEle = addToLeafHashSet(toNode, bTrie.elems(arrayIndex), level + 5)
+            if (newEle eq toBeAdded)
+              toBeAdded
+            else {
+              val result = makeMutable(bTrie)
+              result.elems(rawIndex) = newEle
+              result
+            }
+          }
+        case empty if empty.isEmpty =>
+          toNode
+      }
+    }
+  }
 }

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -1279,8 +1279,9 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     }
 
     override def result(): HashSet[A] = {
-        rootNode = nullToEmpty(makeImmutable(rootNode))
-        rootNode
+      rootNode = nullToEmpty(makeImmutable(rootNode))
+      VM.releaseFence()
+      rootNode
     }
 
 

--- a/src/library/scala/collection/parallel/immutable/ParHashSet.scala
+++ b/src/library/scala/collection/parallel/immutable/ParHashSet.scala
@@ -140,11 +140,12 @@ private[immutable] abstract class HashSetCombiner[T]
 extends scala.collection.parallel.BucketCombiner[T, ParHashSet[T], Any, HashSetCombiner[T]](HashSetCombiner.rootsize) {
 //self: EnvironmentPassingCombiner[T, ParHashSet[T]] =>
   import HashSetCombiner._
+  import HashSet.computeHash
   val emptyTrie = HashSet.empty[T]
 
   def +=(elem: T) = {
     sz += 1
-    val hc = emptyTrie.computeHash(elem)
+    val hc = computeHash(elem)
     val pos = hc & 0x1f
     if (buckets(pos) eq null) {
       // initialize bucket
@@ -200,7 +201,7 @@ extends scala.collection.parallel.BucketCombiner[T, ParHashSet[T], Any, HashSetC
         val chunksz = unrolled.size
         while (i < chunksz) {
           val v = chunkarr(i).asInstanceOf[T]
-          val hc = trie.computeHash(v)
+          val hc = computeHash(v)
           trie = trie.updated0(v, hc, rootbits)  // internal API, private[collection]
           i += 1
         }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetBenchmarkData.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetBenchmarkData.scala
@@ -1,0 +1,14 @@
+package scala.collection.immutable
+
+object HashSetBenchmarkData {
+  def apply(hashCode: Int, data: String) = new HashSetBenchmarkData(hashCode, data.intern())
+}
+
+class HashSetBenchmarkData private(override val hashCode: Int, val data: String) {
+  override def equals(obj: Any): Boolean = obj match {
+    case that: HashSetBenchmarkData => this.hashCode == that.hashCode && (this.data eq that.data)
+    case _ => false
+  }
+
+  override def toString: String = s"$hashCode-$data"
+}

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetBuilderBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetBuilderBenchmark.scala
@@ -1,0 +1,249 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+
+//typically run with
+// bench/jmh:run scala.collection.immutable.HashSetBuilder -prof gc -rf csv
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+abstract class HashSetBuilderBaseBenchmark {
+  @Param(Array(
+    "10",
+    "100",
+    "1000",
+    "10000"))
+  var size: Int = _
+  @Param(Array("true", "false"))
+  var colliding: Boolean = _
+
+  @Param(Array("Set+=", "Set++=", "HashSet+=", "HashSet++="))
+  var op: String = _
+  var operation: (Blackhole, Set[HashSetBenchmarkData], Set[HashSetBenchmarkData]) => Any = _
+
+  // base data of specified size. All values are distinct
+  var baseData: Array[HashSet[HashSetBenchmarkData]] = _
+  // overlap(i) contains baseData(i) .. baseData(i+9) but with no structural sharing
+  var overlap: Array[HashSet[HashSetBenchmarkData]] = _
+  // overlap2(i) contains the same data as overlap(i) but with no structural sharing
+  var overlap2: Array[HashSet[HashSetBenchmarkData]] = _
+  // shared(i) contains baseData(i) .. baseData(i+9) but with structural sharing, both to the base data and preceding/subsequent entries
+  var shared: Array[HashSet[HashSetBenchmarkData]] = _
+
+
+  @Setup(Level.Trial) def initKeys(): Unit = {
+    operation = op match {
+      case "Set+=" => operationSetPlusEquals
+      case "Set++=" => operationSetPlusPlusEquals
+      case "HashSet+=" => operationHashSetPlusEquals
+      case "HashSet++=" => operationHashSetPlusPlusEquals
+    }
+
+    def generate(prefix: String, size: Int) = {
+      Array.tabulate(30)(i => (0 until size).map { k =>
+        val data = s"key $i $k"
+        val hash = if (colliding) (k >> 2) * i else data.hashCode
+        HashSetBenchmarkData(hash, data)
+      }(scala.collection.breakOut): HashSet[HashSetBenchmarkData])
+    }
+
+    baseData = generate("", size)
+
+    overlap = new Array[HashSet[HashSetBenchmarkData]](baseData.length - 10)
+    overlap2 = new Array[HashSet[HashSetBenchmarkData]](baseData.length - 10)
+    shared = new Array[HashSet[HashSetBenchmarkData]](baseData.length - 10)
+    for (i <- 0 until baseData.length - 10) {
+      var s1: HashSet[HashSetBenchmarkData] = HashSet.empty[HashSetBenchmarkData]
+      var s2: HashSet[HashSetBenchmarkData] = HashSet.empty[HashSetBenchmarkData]
+      for (j <- i until i + 10) {
+        baseData(j) foreach {
+          x =>
+            s1 += x
+            s2 += x
+        }
+      }
+      overlap(i) = s1
+      overlap2(i) = s2
+    }
+
+    def base(i: Int) = {
+      baseData(if (i < 0) baseData.length + i else i)
+    }
+
+    shared(0) = (-10 to(0, 1)).foldLeft(base(-10)) { case (a, b) => a ++ base(b) }
+    for (i <- 1 until shared.length) {
+      shared(i) = shared(i - 1) -- base(i - 10) ++ base(i)
+    }
+
+  }
+
+  def operationSetPlusEquals(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    val builder = Set.newBuilder[HashSetBenchmarkData]
+    builder ++= set1
+    set2 foreach {
+      builder += _
+    }
+    bh.consume(builder.result)
+  }
+
+  def operationSetPlusPlusEquals(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    val builder = Set.newBuilder[HashSetBenchmarkData]
+    builder ++= set1
+    builder ++= set2
+    bh.consume(builder.result)
+  }
+
+  def operationHashSetPlusEquals(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    val builder = Set.newBuilder[HashSetBenchmarkData]
+    builder ++= set1
+    set2 foreach {
+      builder += _
+    }
+    bh.consume(builder.result)
+  }
+
+  def operationHashSetPlusPlusEquals(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    val builder = Set.newBuilder[HashSetBenchmarkData]
+    builder ++= set1
+    builder ++= set2
+    bh.consume(builder.result)
+  }
+}
+
+class HashSetBuilderUnsharedBenchmark extends HashSetBuilderBaseBenchmark {
+
+  @OperationsPerInvocation(30)
+  @Benchmark def opDataWithEmpty(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 30) {
+      operation(bh, baseData(i), HashSet.empty)
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(30)
+  @Benchmark def opEmptyWithData(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 30) {
+      operation(bh, HashSet.empty, baseData(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(30)
+  @Benchmark def opDataWithSetEmpty(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 30) {
+      operation(bh, baseData(i), Set.empty)
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(30)
+  @Benchmark def opSetEmptyWithData(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 30) {
+      operation(bh, Set.empty, baseData(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(29)
+  @Benchmark def opWithDistinct(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 29) {
+      operation(bh, baseData(i), baseData(i + 1))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(20)
+  @Benchmark def opDataWithContainedUnshared(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 20) {
+      operation(bh, overlap(i), baseData(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(20)
+  @Benchmark def opDataWithContainedShared(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 20) {
+      operation(bh, shared(i), baseData(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(20)
+  @Benchmark def opContainedUnsharedWithData(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 20) {
+      operation(bh, baseData(i), overlap(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(20)
+  @Benchmark def opContainedSharedWithData(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 20) {
+      operation(bh, baseData(i), shared(i))
+      i += 1
+    }
+  }
+}
+
+class HashSetBuilderSharedBenchmark extends HashSetBuilderBaseBenchmark {
+  @Param(Array("0", "20", "40", "60", "80", "90", "100"))
+  var sharing: Int = _
+
+  @OperationsPerInvocation(10)
+  @Benchmark def opWithOverlapUnshared(bh: Blackhole): Unit = {
+    var i = 10;
+    while (i < 20) {
+      operation(bh, overlap(i - (10 - sharing / 10)), overlap2(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(10)
+  @Benchmark def opWithOverlapShared(bh: Blackhole): Unit = {
+    var i = 10;
+    while (i < 20) {
+      operation(bh, shared(i - (10 - sharing / 10)), shared(i))
+      i += 1
+    }
+  }
+}
+
+
+//for testing, debugging, optimising etc
+object TestHashSetBenchmark extends App {
+
+  val bh = new Blackhole("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.")
+  val test = new HashSetBuilderUnsharedBenchmark
+
+  test.size = 10000
+  test.op = "++"
+  test.colliding = true
+  test.initKeys()
+  while (true) {
+    var j = 0
+    val start = System.nanoTime()
+    while (j < 100) {
+      test.opDataWithContainedUnshared(bh)
+      j += 1
+    }
+    val end = System.nanoTime()
+    println((end - start) / 1000000)
+  }
+}

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetBulkBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetBulkBenchmark.scala
@@ -226,19 +226,8 @@ abstract class HashSetBaseBulkBenchmark {
     bh.consume(set1.sameElements(set2))
   }
 }
-object HashSetBenchmarkData {
-  def apply(hashCode: Int, data: String) = new HashSetBenchmarkData(hashCode, data.intern())
-}
-class HashSetBenchmarkData private (override val hashCode: Int, val data: String) {
-  override def equals(obj: Any): Boolean = obj match {
-    case that: HashSetBenchmarkData => this.hashCode == that.hashCode && (this.data eq that.data)
-    case _ => false
-  }
-
-  override def toString: String = s"$hashCode-$data"
-}
 //for testing, debugging, optimising etc
-object Test extends App {
+object HashSetBulkBenchmarkTestApp extends App {
 
   val bh = new Blackhole("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.")
   val test = new HashSetBulkUnsharedBenchmark


### PR DESCRIPTION
The builder allows `TrieHashSet` to be mutated in place until it is visible this reduces the memory churn while building `Set`s.

Benchmark results: https://gist.github.com/mkeskells/7a4b80bb358f18afe541e0ce737aa691