### PR TITLE
docs(scala.collection.iterator): add doc for sameElements method

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -826,6 +826,9 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     }
   }
 
+  /** check if this iterator has the same set of elements and order of elements with the other iterator
+    * @param that The iterator to be compared with
+    */
   def sameElements[B >: A](that: IterableOnce[B]): Boolean = {
     val those = that.iterator
     while (hasNext && those.hasNext)


### PR DESCRIPTION
Before this commit, the documentation for `sameElements` method was missing.