### PR TITLE
Fix two warnings for deprecated narrowing conversions.

### DIFF
--- a/src/library/scala/jdk/AnyAccumulator.scala
+++ b/src/library/scala/jdk/AnyAccumulator.scala
@@ -26,9 +26,6 @@ final class AnyAccumulator[A]
     with mutable.SeqOps[A, AnyAccumulator, AnyAccumulator[A]]
     with IterableFactoryDefaults[A, AnyAccumulator]
     with Serializable {
-  // Elements are added to `current`. Once full, it's added to `history`, and a new `current` is
-  // created with `nextBlockSize` (which depends on `totalSize`).
-  // `cumul(i)` is `(0 until i).map(history(_).length)`
   private[jdk] var current: Array[AnyRef] = AnyAccumulator.emptyAnyRefArray
   private[jdk] var history: Array[Array[AnyRef]] = AnyAccumulator.emptyAnyRefArrayArray
   private[jdk] var cumul: Array[Long] = AnyAccumulator.emptyLongArray

--- a/src/library/scala/jdk/DoubleAccumulator.scala
+++ b/src/library/scala/jdk/DoubleAccumulator.scala
@@ -107,7 +107,7 @@ final class DoubleAccumulator
           }
           else current
         pv = pv + index
-        x(x.length - 1) = pv
+        x(x.length - 1) = pv.toDouble // see comment on Accumulator.cumulative
         history(hIndex) = x
         hIndex += 1
       }
@@ -116,7 +116,7 @@ final class DoubleAccumulator
         pv = pv + cuml - prev
         prev = cuml
         val x = that.history(h)
-        x(x.length - 1) = pv
+        x(x.length - 1) = pv.toDouble // see comment on Accumulator.cumulative
         history(hIndex) = x
         h += 1
         hIndex += 1


### PR DESCRIPTION
The introduced explicit `.toDouble` preserve the behavior of the algorithm. Previously the same conversion was implicitly applied.

---

These two warnings pollute my logs when compiling Scala.js, because they appear in full even without `-deprecation`. This is why I bother sending this PR.

---

Remark: I did not assess whether doing that narrowing conversion at that point is actually safe. Perhaps the reported warning is actually a sign that something wrong is happening there. I tried to convince myself either way for 10-15 minutes but then abandoned. @lrytz Maybe you'll want to double-check that this conversion is safe.