### PR TITLE
Fixes bug in scala docs while navigating the page with space bar/ shi…

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.css
@@ -457,7 +457,6 @@ div#search-progress > div#progress-fill {
 }
 
 div#content-scroll-container {
-  position: absolute;
   top: 0;
   right: 0;
   bottom: 0;


### PR DESCRIPTION
…ft+space

space/shift+space in all modern browsers scroll down/up respecitively.
But this functionality doesn't work on the scala docs. Because of
combination of  z-index and position of the elements in the dom, which makes the browser calculate the wrong dom size.

**Detailed Diagnosis:**
- search bar at the top of the page has a zindex of 103 And, the rest of
the page has the z-index of 100. By making the page position: absolute. 
search bar will be on top of the rest of the page. 
The effective dom size became the  size of search bar (as only the
search bar is in the focus).

The fix is to make the rest of the page position:relative (default), so
the dom size is calculated correctly.

Tested in chrome, edge and firefox. (and with couple of different resolutions)

small regression after the change (IMO should be fine, but is good to call out)

**Before**
![before_LI](https://user-images.githubusercontent.com/1584221/74760749-e0270d00-5248-11ea-91d7-4a754b3c5c56.jpg)

**After **
![after_LI](https://user-images.githubusercontent.com/1584221/74760759-e61cee00-5248-11ea-8570-59c80832d66a.jpg)

Fixes scala/bug#11878