### PR TITLE
[SUPERSEDED] Warn constant promotions

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1344,7 +1344,12 @@ If $e$ has a primitive number type which [weakly conforms](03-types.html#weak-co
 to the expected type, it is widened to
 the expected type using one of the numeric conversion methods
 `toShort`, `toChar`, `toInt`, `toLong`,
-`toFloat`, `toDouble` defined [here](12-the-scala-standard-library.html#numeric-value-types).
+`toFloat`, `toDouble` defined [in the standard library](12-the-scala-standard-library.html#numeric-value-types).
+
+Since conversions from `Int` to `Float` and from `Long` to `Float` or `Double`
+may incur a loss of precision, those implicit conversions are deprecated.
+The conversion is permitted for literals if the original value can be recovered,
+that is, if conversion back to the original type produces the original value.
 
 ###### Numeric Literal Narrowing
 If the expected type is `Byte`, `Short` or `Char`, and

--- a/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
@@ -90,9 +90,12 @@ abstract class ConstantFolder {
   private def warnWidening(tree: Tree, pos: Position, k: Constant, to: Int): Unit = {
     val from = k.tag
     def tagString(tag: Int) = names(tag - IntTag)
-    def warn() = tree.updateAttachment[DeferredRefCheck](DeferredRefCheck(t =>
-      currentRun.reporting.deprecationWarning(pos, s"Deprecated widening conversion ${tagString(from)} to ${tagString(to)}", "2.13.2")
-    ))
+    def warn() = {
+      val msg = s"Widening conversion from ${tagString(from)} to ${tagString(to)} is deprecated because it loses precision. Write `.to${tagString(to)}` instead."
+      tree.updateAttachment[DeferredRefCheck](DeferredRefCheck(_ =>
+        currentRun.reporting.deprecationWarning(pos, msg, "2.13.2")
+      ))
+    }
     if (to == FloatTag) {
       val bad = from == IntTag && k.intValue != k.intValue.toFloat.toInt || from == LongTag && k.longValue != k.longValue.toFloat.toLong
       if (bad) warn()

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1653,6 +1653,14 @@ abstract class RefChecks extends Transform {
       try {
         val sym = tree.symbol
 
+        // Apply RefChecks which might easily have run earlier.
+        def runDeferredCheck(): Unit =
+          tree.getAndRemoveAttachment[DeferredRefCheck] match {
+            case Some(DeferredRefCheck(check)) => check(tree) ; runDeferredCheck()
+            case None => ()
+          }
+        runDeferredCheck()
+
         // Apply RefChecks to annotations. Makes sure the annotations conform to
         // type bounds (bug #935), issues deprecation warnings for symbols used
         // inside annotations.

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1142,8 +1142,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 tpSym == IntClass  && ptSym == FloatClass ||
                 tpSym == LongClass && (ptSym == FloatClass || ptSym == DoubleClass)
               )
-              if (isInharmonic)
-                context.warning(tree.pos, s"Automatic conversion from ${tpSym.name} to ${ptSym.name} is deprecated (since 2.13.1) because it loses precision. Write `.to${ptSym.name}` instead.")
+              if (isInharmonic) {
+                val msg = s"Widening conversion from ${tpSym.name} to ${ptSym.name} is deprecated because it loses precision. Write `.to${ptSym.name}` instead."
+                tree.updateAttachment[DeferredRefCheck](DeferredRefCheck(t =>
+                  currentRun.reporting.deprecationWarning(t.pos, msg, "2.13.2")
+                ))
+              }
               else if (settings.warnNumericWiden) context.warning(tree.pos, "implicit numeric widening")
             }
 

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -119,4 +119,6 @@ trait StdAttachments {
   class QualTypeSymAttachment(val sym: Symbol)
 
   case object ConstructorNeedsFence extends PlainAttachment
+
+  case class DeferredRefCheck(check: Tree => Unit) extends PlainAttachment
 }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -64,6 +64,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.TypeParamVarargsAttachment
     this.KnownDirectSubclassesCalled
     this.ConstructorNeedsFence
+    this.DeferredRefCheck
     this.noPrint
     this.typeDebug
     // inaccessible: this.posAssigner

--- a/test/files/jvm/duration-tck.scala
+++ b/test/files/jvm/duration-tck.scala
@@ -3,10 +3,9 @@
  */
 
 import scala.concurrent.duration._
-import scala.reflect._
 import scala.tools.testkit.AssertUtil.assertThrows
 
-import scala.language.{ postfixOps }
+import scala.language.postfixOps
 
 object Test extends App {
 

--- a/test/files/neg/deprecated_widening.check
+++ b/test/files/neg/deprecated_widening.check
@@ -1,10 +1,10 @@
-deprecated_widening.scala:5: warning: Automatic conversion from Int to Float is deprecated (since 2.13.1) because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:5: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
     val i_f: Float = i  // deprecated
                      ^
-deprecated_widening.scala:7: warning: Automatic conversion from Long to Float is deprecated (since 2.13.1) because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:7: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
     val l_f: Float = l  // deprecated
                      ^
-deprecated_widening.scala:8: warning: Automatic conversion from Long to Double is deprecated (since 2.13.1) because it loses precision. Write `.toDouble` instead.
+deprecated_widening.scala:8: warning: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
     val l_d: Double = l // deprecated
                       ^
 deprecated_widening.scala:12: warning: method int2float in object Int is deprecated (since 2.13.1): Implicit conversion from Int to Float is dangerous because it loses precision. Write `.toFloat` instead.
@@ -16,37 +16,37 @@ deprecated_widening.scala:14: warning: method long2float in object Long is depre
 deprecated_widening.scala:15: warning: method long2double in object Long is deprecated (since 2.13.1): Implicit conversion from Long to Double is dangerous because it loses precision. Write `.toDouble` instead.
     implicitly[Long => Double] // deprecated
               ^
-deprecated_widening.scala:26: warning: Deprecated widening conversion Int to Float
+deprecated_widening.scala:26: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
                              ^
-deprecated_widening.scala:26: warning: Deprecated widening conversion Int to Float
+deprecated_widening.scala:26: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
                                          ^
-deprecated_widening.scala:26: warning: Deprecated widening conversion Int to Float
+deprecated_widening.scala:26: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
                                                      ^
-deprecated_widening.scala:27: warning: Deprecated widening conversion Long to Float
+deprecated_widening.scala:27: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                              ^
-deprecated_widening.scala:27: warning: Deprecated widening conversion Long to Float
+deprecated_widening.scala:27: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                                           ^
-deprecated_widening.scala:27: warning: Deprecated widening conversion Long to Float
+deprecated_widening.scala:27: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                                                        ^
-deprecated_widening.scala:27: warning: Deprecated widening conversion Long to Float
+deprecated_widening.scala:27: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                                                                     ^
-deprecated_widening.scala:29: warning: Deprecated widening conversion Int to Float
+deprecated_widening.scala:29: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def `pick one` = Set[Float](0x1000003, 0x1000004, 0x1000005)
                               ^
-deprecated_widening.scala:29: warning: Deprecated widening conversion Int to Float
+deprecated_widening.scala:29: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def `pick one` = Set[Float](0x1000003, 0x1000004, 0x1000005)
                                                     ^
-deprecated_widening.scala:31: warning: Deprecated widening conversion Int to Float
+deprecated_widening.scala:31: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def `lossy arg`       = 1f + 2147483584
                                ^
-deprecated_widening.scala:32: warning: Deprecated widening conversion Int to Float
+deprecated_widening.scala:32: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def `lossy receiver`  = 2147483584 + 1f
                           ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/deprecated_widening.check
+++ b/test/files/neg/deprecated_widening.check
@@ -16,6 +16,39 @@ deprecated_widening.scala:14: warning: method long2float in object Long is depre
 deprecated_widening.scala:15: warning: method long2double in object Long is deprecated (since 2.13.1): Implicit conversion from Long to Double is dangerous because it loses precision. Write `.toDouble` instead.
     implicitly[Long => Double] // deprecated
               ^
+deprecated_widening.scala:26: warning: Deprecated widening conversion Int to Float
+  def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
+                             ^
+deprecated_widening.scala:26: warning: Deprecated widening conversion Int to Float
+  def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
+                                         ^
+deprecated_widening.scala:26: warning: Deprecated widening conversion Int to Float
+  def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
+                                                     ^
+deprecated_widening.scala:27: warning: Deprecated widening conversion Long to Float
+  def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
+                             ^
+deprecated_widening.scala:27: warning: Deprecated widening conversion Long to Float
+  def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
+                                          ^
+deprecated_widening.scala:27: warning: Deprecated widening conversion Long to Float
+  def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
+                                                       ^
+deprecated_widening.scala:27: warning: Deprecated widening conversion Long to Float
+  def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
+                                                                    ^
+deprecated_widening.scala:29: warning: Deprecated widening conversion Int to Float
+  def `pick one` = Set[Float](0x1000003, 0x1000004, 0x1000005)
+                              ^
+deprecated_widening.scala:29: warning: Deprecated widening conversion Int to Float
+  def `pick one` = Set[Float](0x1000003, 0x1000004, 0x1000005)
+                                                    ^
+deprecated_widening.scala:31: warning: Deprecated widening conversion Int to Float
+  def `lossy arg`       = 1f + 2147483584
+                               ^
+deprecated_widening.scala:32: warning: Deprecated widening conversion Int to Float
+  def `lossy receiver`  = 2147483584 + 1f
+                          ^
 error: No warnings can be incurred under -Werror.
-6 warnings
+17 warnings
 1 error

--- a/test/files/neg/deprecated_widening.scala
+++ b/test/files/neg/deprecated_widening.scala
@@ -18,4 +18,21 @@ object Test {
   // don't leak silent warning from float conversion
   val n = 42
   def clean = n max 27
+
+  // literals don't get a pass -- *especially* literals!
+
+  // 0x7ffffffc0 - 0x7fffffff
+  // Set[Float](2147483584, 2147483645, 2147483646, 2147483647)
+  def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
+  def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
+
+  def `pick one` = Set[Float](0x1000003, 0x1000004, 0x1000005)
+
+  def `lossy arg`       = 1f + 2147483584
+  def `lossy receiver`  = 2147483584 + 1f
+
+  // currently does not warn
+  def f = 1f
+  def `lossy arg to overload` = f + 2147483584
+
 }

--- a/test/files/neg/deprecated_widening.scala
+++ b/test/files/neg/deprecated_widening.scala
@@ -1,4 +1,4 @@
-// scalac: -deprecation -Werror
+// scalac: -Werror -Xlint:deprecation
 //
 object Test {
   def foo(i: Int, l: Long): Unit = {


### PR DESCRIPTION
Warn if widening of literal Int or Long is not safe,
which is defined as the conversion roundtrips, the
test used for harmonization.

Fixes scala/bug#10773