### PR TITLE
Add mutable Substitution maps to reuse instances

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -22,7 +22,7 @@ import mutable.{ListBuffer, LinkedHashSet}
 import Flags._
 import scala.util.control.ControlThrowable
 import scala.annotation.{tailrec, unused}
-import util.{Statistics, StatisticsStatics}
+import util.{ReusableInstance, Statistics, StatisticsStatics}
 import util.ThreeValues._
 import Variance._
 import Depth._
@@ -4030,6 +4030,9 @@ trait Types
   def refinedType(parents: List[Type], owner: Symbol): Type =
     refinedType(parents, owner, newScope, owner.pos)
 
+  private[this] val copyRefinedTypeSSM: ReusableInstance[MutableSubstSymMap] =
+    ReusableInstance[MutableSubstSymMap](new MutableSubstSymMap())
+
   def copyRefinedType(original: RefinedType, parents: List[Type], decls: Scope) =
     if ((parents eq original.parents) && (decls eq original.decls)) original
     else {
@@ -4044,9 +4047,10 @@ trait Types
         val syms2 = result.decls.toList
         val resultThis = result.typeSymbol.thisType
         val substThisMap = new SubstThisMap(original.typeSymbol, resultThis)
-        val substMap = new SubstSymMap(syms1, syms2)
-        for (sym <- syms2)
-          sym.modifyInfo(info => substMap.apply(substThisMap.apply(info)))
+        copyRefinedTypeSSM.using { (msm: MutableSubstSymMap) =>
+          msm.reset(syms1, syms2)
+          syms2.foreach(_.modifyInfo(info => msm.apply(substThisMap.apply(info))))
+        }
       }
       result
     }

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -663,20 +663,31 @@ private[internal] trait TypeMaps {
   }
 
   /** A base class to compute all substitutions */
-  abstract class SubstMap[T](from: List[Symbol], to: List[T]) extends TypeMap {
-    // OPT this check was 2-3% of some profiles, demoted to -Xdev
-    if (isDeveloper) assert(sameLength(from, to), "Unsound substitution from "+ from +" to "+ to)
+  abstract class AbstractSubstMap[T >: Null] extends TypeMap {
+    protected def from: List[Symbol] = Nil
+    protected def to: List[T] = Nil
 
     private[this] var fromHasTermSymbol = false
     private[this] var fromMin = Int.MaxValue
     private[this] var fromMax = Int.MinValue
     private[this] var fromSize = 0
-    from.foreach {
-      sym =>
+
+    protected def reload(): Unit = {
+      // OPT this check was 2-3% of some profiles, demoted to -Xdev
+      if (isDeveloper) assert(sameLength(from, to), "Unsound substitution from "+ from +" to "+ to)
+
+      fromHasTermSymbol = false
+      fromMin = Int.MaxValue
+      fromMax = Int.MinValue
+      fromSize = 0
+
+      from.foreach {
+        sym =>
         fromMin = math.min(fromMin, sym.id)
         fromMax = math.max(fromMax, sym.id)
         fromSize += 1
         if (sym.isTerm) fromHasTermSymbol = true
+      }
     }
 
     /** Are `sym` and `sym1` the same? Can be tuned by subclasses. */
@@ -758,9 +769,7 @@ private[internal] trait TypeMaps {
     }
   }
 
-  /** A map to implement the `substSym` method. */
-  class SubstSymMap(from: List[Symbol], to: List[Symbol]) extends SubstMap(from, to) {
-    def this(pairs: (Symbol, Symbol)*) = this(pairs.toList.map(_._1), pairs.toList.map(_._2))
+  abstract class AbstractSubstSymMap extends AbstractSubstMap[Symbol] {
 
     protected def toType(fromtp: Type, sym: Symbol) = fromtp match {
       case TypeRef(pre, _, args) => copyTypeRef(fromtp, pre, sym, args)
@@ -826,9 +835,31 @@ private[internal] trait TypeMaps {
     }
   }
 
+  /** A map to implement the `substSym` method. */
+  class SubstSymMap(override val from: List[Symbol], override val to: List[Symbol]) extends AbstractSubstSymMap {
+    reload()
+
+    def this(pairs: (Symbol, Symbol)*) = this(pairs.toList.map(_._1), pairs.toList.map(_._2))
+  }
+
+  class MutableSubstSymMap extends AbstractSubstSymMap {
+    private[this] var _from: List[Symbol] = Nil
+    private[this] var _to: List[Symbol] = Nil
+
+    override def from: List[Symbol] = _from
+    override def to  : List[Symbol] =   _to
+
+    def reset(nfrom: List[Symbol], nto: List[Symbol]): Unit = {
+      _from = nfrom
+      _to   = nto
+      reload
+    }
+  }
+
   /** A map to implement the `subst` method. */
-  class SubstTypeMap(val from: List[Symbol], val to: List[Type]) extends SubstMap(from, to) {
-    protected def toType(fromtp: Type, tp: Type) = tp
+  class SubstTypeMap(override val from: List[Symbol], override val to: List[Type]) extends AbstractSubstMap[Type] {
+    super.reload()
+    override protected def toType(fromtp: Type, tp: Type) = tp
 
     override def mapOver(tree: Tree, giveup: () => Nothing): Tree = {
       object trans extends TypeMapTransformer {


### PR DESCRIPTION

In a profiled compilation (on `2.13.1`) I noticed that the `SubsySymMap` created by the `cloneSymbols` method was allocating 14 MiB of data, about 1% of this build. 

To alleviate this allocation, I have reused some changes from #8465:

- In the `TypeMaps`, we introduce an intermediate abstractions, `AbstractSubstMap`, and keep as much of the logic as possible in there, using the "template method" design pattern. In this case, we make the logic dependent upon a "find" method, which looks for a symbol (key) in the "map", which in the common case is implemented as two lists.
- We add a new implementation of symbol substitution type map, which uses an internal mutable stack (for reentrance). We use this implementation in the `cloneSymbols`, to mitigate the allocation spot detected above.
![Screenshot 2020-02-19 at 18 57 47](https://user-images.githubusercontent.com/1764610/74865904-c5888d00-5349-11ea-9e2b-53ba29173375.png)
