### PR TITLE
Build improvement (fix performance issue with test sources)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -857,9 +857,11 @@ lazy val test = project
   .settings(
     libraryDependencies ++= Seq(asmDep),
     // no main sources
-    sources in Compile := Seq.empty,
+    Compile / unmanagedSourceDirectories := Nil,
+    Compile / sources := Nil,
     // test sources are compiled in partest run, not here
-    sources in IntegrationTest := Seq.empty,
+    IntegrationTest / unmanagedSourceDirectories := Nil,
+    IntegrationTest / sources := Nil,
     fork in IntegrationTest := true,
     // enable this in 2.13, when tests pass
     //scalacOptions in Compile += "-Yvalidate-pos:parser,typer",


### PR DESCRIPTION
This is a minor improvement on the build.
Even though `Compile / sources` would wipe out the sources seen by compilation, the "external hook" used to calculate the changed source for incremental compilation currently looks at the `unmanagedSources` as well, causing all `*.scala` files under partest to be stamped.

This was initially reported on [Gitter](https://gitter.im/scala/contributors?at=5e4ef469ff00c664eed6320a) by @som-snytt 

> Idly curious what this means in the current sbt build: `=> test / Compile / unmanagedSources / inputFileStamps 22s`