### PR TITLE
Skip checking selectors in Java imports

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1813,7 +1813,7 @@ trait Namers extends MethodSynthesis {
         }
 
         val newImport = treeCopy.Import(imp, expr1, selectors)
-        checkSelectors(newImport)
+        if (!context.unit.isJava) checkSelectors(newImport) // trust in javac
         context.unit.transformed(imp) = newImport
         // copy symbol and type attributes back into old expression
         // so that the structure builder will find it.


### PR DESCRIPTION
Trust javac to do it for us.

Saves a small amount of time, but more importantly, saves us from choking on code that imports static members from superclasses if we wind up running `importSig` on them. 