### PR TITLE
take control of the serialised form of a TreeMap/TreeSet

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -338,6 +338,9 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashTrieMap.size0_="),
     ProblemFilters.exclude[FinalMethodProblem]("scala.collection.immutable.HashMap#HashTrieMap.size"),
 
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.TreeMap$TreeMapProxy"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.TreeMap.this"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.TreeSet$TreeSetProxy"),
     //
     // scala-relect
     //

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -14,6 +14,8 @@ package scala
 package collection
 package immutable
 
+import java.io.IOException
+
 import generic._
 import immutable.{RedBlackTree => RB}
 import mutable.Builder
@@ -53,6 +55,32 @@ object TreeSet extends ImmutableSortedSetFactory[TreeSet] {
     }
 
     override def result(): TreeSet[A] = new TreeSet(tree)(ordering)
+  }
+  private val legacySerialisation = System.getProperty("scala.collection.immutable.TreeSet.newSerialisation", "false") != "false"
+
+  private class TreeSetProxy[A](
+    @transient private[this] var tree: RedBlackTree.Tree[A, Any],
+    @transient private[this] var ordering: Ordering[A]) extends Serializable {
+
+    @throws[IOException]
+    private[this] def writeObject(out: java.io.ObjectOutputStream) = {
+      out.writeInt(RB.count(tree))
+      out.writeObject(ordering)
+      RB.foreachKey(tree, out.writeObject)
+    }
+    @throws[IOException]
+    private[this] def readObject(in: java.io.ObjectInputStream) = {
+      val size = in.readInt()
+      ordering = in.readObject().asInstanceOf[Ordering[A]]
+      val data = Iterable.newBuilder[A]
+      data.sizeHint(size)
+      for (i <- 0 until size)
+        data += in.readObject().asInstanceOf[A]
+      tree = RB.fromOrderedKeys(data.result.iterator, size)
+    }
+    @throws[IOException]
+    private[this] def readResolve(): AnyRef =
+      new TreeSet(tree)(ordering)
   }
 }
 
@@ -249,4 +277,8 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
     case _ => super.equals(obj)
   }
 
+
+  @throws[IOException]
+  private[this] def writeReplace(out: java.io.ObjectOutputStream): AnyRef =
+    if (TreeSet.legacySerialisation) this else new TreeSet.TreeSetProxy(tree, ordering)
 }


### PR DESCRIPTION
The current serialised form exposed the internal machinery of `RedBlackTree`
this format contain redundant information ( e.g. size, trees, and `()` for the values of the Sets)

I am not sure that the existing format is guaranteed for be stable across VMs anyway, e.g. consider an ordering based on hashcode or identityHashCode

Having a format that doesn't depend on the implementation allows us to improve the time/space efficiency by changing the data structure without constraints