### PR TITLE
Default true -Yrepl-{class-based,use-magic-imports}

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -242,8 +242,8 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
   val Ymacroexpand    = ChoiceSetting     ("-Ymacro-expand", "policy", "Control expansion of macros, useful for scaladoc and presentation compiler.", List(MacroExpand.Normal, MacroExpand.None, MacroExpand.Discard), MacroExpand.Normal)
   val YmacroFresh     = BooleanSetting    ("-Ymacro-global-fresh-names", "Should fresh names in macros be unique across all compilation units")
   val YmacroAnnotations = BooleanSetting  ("-Ymacro-annotations", "Enable support for macro annotations, formerly in macro paradise.")
-  val Yreplclassbased = BooleanSetting    ("-Yrepl-class-based", "Use classes to wrap REPL snippets instead of objects")
-  val YreplMagicImport = BooleanSetting   ("-Yrepl-use-magic-imports", "In the code that wraps REPL snippets, use magic imports rather than nesting wrapper object/classes")
+  val Yreplclassbased = BooleanSetting    ("-Yrepl-class-based", "Use classes to wrap REPL snippets instead of objects") withDefault true
+  val YreplMagicImport = BooleanSetting   ("-Yrepl-use-magic-imports", "In the code that wraps REPL snippets, use magic imports rather than nesting wrapper object/classes") withDefault true
   val Yreploutdir     = StringSetting     ("-Yrepl-outdir", "path", "Write repl-generated classfiles to given output directory (use \"\" to generate a temporary dir)" , "")
   @deprecated("Unused setting will be removed", since="2.13")
   val Yreplsync       = new BooleanSetting    ("-Yrepl-sync", "Legacy setting for sbt compatibility, unused.").internalOnly()

--- a/test/files/run/repl-colon-type.check
+++ b/test/files/run/repl-colon-type.check
@@ -35,12 +35,12 @@ Int
 
 scala> :type protected lazy val f = 5
 
-         lazy val $result = $line16.$read.INSTANCE.$iw.$iw.f
-                                                           ^
-<synthetic>:4: error: lazy value f cannot be accessed as a member of object $iw from object $eval in package 
+         lazy val $result = $line16.$read.INSTANCE.$iw.f
+                                                       ^
+<synthetic>:4: error: lazy value f cannot be accessed as a member of INSTANCE.$iw from object $eval in package 
         Access to protected lazy value f not permitted because
         enclosing object $eval in package $line16 is not a subclass of
-        object $iw where target is defined
+        class $iw where target is defined
 
 (To diagnose errors in synthetic code, try adding `// show` to the end of your input.)
 

--- a/test/files/run/repl-deadlock.scala
+++ b/test/files/run/repl-deadlock.scala
@@ -2,11 +2,6 @@ import scala.tools.nsc.Settings
 import scala.tools.partest.ReplTest
 
 object Test extends ReplTest {
-    override def transformSettings(s: Settings) = {
-    s.Yreplclassbased.value = true // TODO: drop when it's default true, to assert it works out the box
-    s
-  }
-
   def code = """
     |import scala.concurrent._
     |import scala.concurrent.duration._

--- a/test/files/run/repl-out-dir.check
+++ b/test/files/run/repl-out-dir.check
@@ -15,31 +15,27 @@ repl-out-dir-run.obj
     $line2
         $eval$.class
         $eval.class
-        $read$$iw$$iw$.class
-        $read$$iw$.class
+        $read$$iw.class
         $read$.class
         $read.class
     $line3
         $eval$.class
         $eval.class
-        $read$$iw$$iw$.class
-        $read$$iw$$iw$Bippy$.class
-        $read$$iw$$iw$Bippy.class
-        $read$$iw$.class
+        $read$$iw$Bippy$.class
+        $read$$iw$Bippy.class
+        $read$$iw.class
         $read$.class
         $read.class
     $line4
         $eval$.class
         $eval.class
-        $read$$iw$$iw$.class
-        $read$$iw$.class
+        $read$$iw.class
         $read$.class
         $read.class
     $line5
         $eval$.class
         $eval.class
-        $read$$iw$$iw$.class
-        $read$$iw$.class
+        $read$$iw.class
         $read$.class
         $read.class
     $repl_$init.class

--- a/test/files/run/repl-trim-stack-trace.check
+++ b/test/files/run/repl-trim-stack-trace.check
@@ -4,7 +4,7 @@ def f: Nothing
 
 scala> f
 java.lang.Exception: Uh-oh
-  at .f(<console>:XX)
+  at f(<console>:XX)
   ... ??? elided
 
 scala> def f = throw new Exception("")
@@ -12,7 +12,7 @@ def f: Nothing
 
 scala> f
 java.lang.Exception:
-  at .f(<console>:XX)
+  at f(<console>:XX)
   ... ??? elided
 
 scala> def f = throw new Exception
@@ -20,7 +20,7 @@ def f: Nothing
 
 scala> f
 java.lang.Exception
-  at .f(<console>:XX)
+  at f(<console>:XX)
   ... ??? elided
 
 scala> null.asInstanceOf

--- a/test/files/run/t5256d.check
+++ b/test/files/run/t5256d.check
@@ -15,7 +15,7 @@ scala> println(c)
 class A
 
 scala> println(c.fullName)
-$line8.$read.$iw.$iw.$iw.$iw.A
+$line8.$read.$iw.A
 
 scala> println(c.info)
 AnyRef {

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -238,25 +238,18 @@ package $line10 {
       super.<init>;
       ()
     };
+    import $line7.$read.INSTANCE.$iw.BippyBups;
+    import $line7.$read.INSTANCE.$iw.BippyBups;
+    import $line8.$read.INSTANCE.$iw.PuppyPups;
+    import $line8.$read.INSTANCE.$iw.PuppyPups;
+    import $line9.$read.INSTANCE.$iw.Bingo;
+    import $line9.$read.INSTANCE.$iw.Bingo;
     sealed class $iw extends _root_.java.io.Serializable {
       def <init>() = {
         super.<init>;
         ()
       };
-      import $line7.$read.INSTANCE.$iw.$iw.BippyBups;
-      import $line7.$read.INSTANCE.$iw.$iw.BippyBups;
-      import $line8.$read.INSTANCE.$iw.$iw.PuppyPups;
-      import $line8.$read.INSTANCE.$iw.$iw.PuppyPups;
-      import $line9.$read.INSTANCE.$iw.$iw.Bingo;
-      import $line9.$read.INSTANCE.$iw.$iw.Bingo;
-      sealed class $iw extends _root_.java.io.Serializable {
-        def <init>() = {
-          super.<init>;
-          ()
-        };
-        val res3 = List(BippyBups, PuppyPups, Bingo)
-      };
-      val $iw = new $iw.<init>
+      val res3 = List(BippyBups, PuppyPups, Bingo)
     };
     val $iw = new $iw.<init>
   };
@@ -271,11 +264,11 @@ package $line10 {
 
 package $line10 {
 object $eval {
-  lazy val $result = $line10.$read.INSTANCE.$iw.$iw.res3
+  lazy val $result = $line10.$read.INSTANCE.$iw.res3
   lazy val $print: _root_.java.lang.String =  {
-    $line10.$read.INSTANCE.$iw.$iw
+    $line10.$read.INSTANCE.$iw
 
-""  + "val res3: List[Product with java.io.Serializable]" + " = " + _root_.scala.runtime.ScalaRunTime.replStringOf($line10.$read.INSTANCE.$iw.$iw.res3, 1000)
+""  + "val res3: List[Product with java.io.Serializable]" + " = " + _root_.scala.runtime.ScalaRunTime.replStringOf($line10.$read.INSTANCE.$iw.res3, 1000)
 
   }
 }}

--- a/test/files/run/t8843-repl-xlat.check
+++ b/test/files/run/t8843-repl-xlat.check
@@ -5,12 +5,12 @@ class Bippy
 scala> $intp.reporter.withoutUnwrapping {
      |   println($intp.classLoader getResource "Bippy.class")
      | }
-memory:(memory)/$line3/$read$$iw$$iw$Bippy.class
+memory:(memory)/$line3/$read$$iw$Bippy.class
 
 scala> $intp.reporter.withoutUnwrapping {
      |   println(($intp.classLoader getResources "Bippy.class").nextElement)
      | }
-memory:(memory)/$line3/$read$$iw$$iw$Bippy.class
+memory:(memory)/$line3/$read$$iw$Bippy.class
 
 scala> ($intp.classLoader classBytes "Bippy").nonEmpty
 val res2: Boolean = true


### PR DESCRIPTION
This makes the following changes to the REPL the default behaviour:

* it now uses the "class-based wrappers" implementation, see #8712
  * among other benefits, this reduces the tendency for e.g. parallel collections to deadlock in the REPL
* it now uses the "magic imports" implementation to reduce wrapping, see #8576
  * this improves performance in long sessions

Fixes scala/bug#9076