### PR TITLE
Optimize immutable.{TreeSet, TreeMap} by backporting the 2.13.x RedBlackTree improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -177,7 +177,6 @@ val mimaFilterSettings = Seq {
 
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap.foreachEntry"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.Map$HashCodeAccumulator"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.RedBlackTree.foreachEntry"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashTrieMap.foreachEntry"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.ListMap.foreachEntry"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashMap1.foreachEntry"),
@@ -186,6 +185,23 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.util.hashing.MurmurHash3.emptyMapHash"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.HashMap$HashMapKeys"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.HashMap$HashMapValues"),
+
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.RedBlackTree.*"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.RedBlackTree$NList"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.RedBlackTree$NList$"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.RedBlackTree$EntriesIterator"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.RedBlackTree$ValuesIterator"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.RedBlackTree$TreeIterator"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.generic.SortedMapFactory#SortedMapCanBuildFrom.ordering"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.TreeMap.tree"),
+
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.TreeMap.removeAllImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.TreeMap.filterImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.TreeSet.tree"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.TreeSet.addAllTreeSetImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.TreeSet.addAllImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.TreeSet.removeAll"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.TreeSet.filterImpl"),
 
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.package$WrappedCanBuildFrom"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.HashMap$HashMapBuilder"),

--- a/src/library/scala/collection/SetLike.scala
+++ b/src/library/scala/collection/SetLike.scala
@@ -14,9 +14,10 @@ package scala
 package collection
 
 import generic._
-import mutable.{ Builder, SetBuilder }
+import mutable.{Builder, SetBuilder}
 import scala.annotation.migration
 import parallel.ParSet
+import scala.collection.immutable.TreeSet
 
 /** A template trait for sets.
  *
@@ -171,6 +172,13 @@ self =>
         elems match {
           case that: GenSet[A] =>
             hs.union(that).asInstanceOf[This]
+          case _ =>
+            (repr /: elems.seq) (_ + _)
+        }
+      case ts1: TreeSet[A] =>
+        elems match {
+          case ts2: TreeSet[A] if ts1.ordering == ts2.ordering  =>
+            ts1.addAllTreeSetImpl(ts2).asInstanceOf[This]
           case _ =>
             (repr /: elems.seq) (_ + _)
         }

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -165,8 +165,14 @@ trait TraversableLike[+A, +Repr] extends Any
           (s union that.asInstanceOf[GenSet[A]]).asInstanceOf[That]
         case _ => defaultPlusPlus
       }
-
-    } else defaultPlusPlus
+    } else {
+      this match {
+        case thisTS: collection.immutable.TreeSet[A] =>
+          thisTS.addAllImpl[B, That](that)(bf.asInstanceOf[CanBuildFrom[immutable.TreeSet[A], B, That]])
+        case _ =>
+          defaultPlusPlus
+      }
+    }
 
   }
 
@@ -222,8 +228,14 @@ trait TraversableLike[+A, +Repr] extends Any
           (s union that.asInstanceOf[GenSet[A]]).asInstanceOf[That]
         case _ => defaultPlusPlus
       }
-
-    } else defaultPlusPlus
+    } else {
+      this match {
+        case thisTS: immutable.TreeSet[A] =>
+          thisTS.addAllImpl[B, That](that)(bf.asInstanceOf[CanBuildFrom[immutable.TreeSet[A], B, That]])
+        case _ =>
+          defaultPlusPlus
+      }
+    }
 
   }
 

--- a/src/library/scala/collection/generic/SortedMapFactory.scala
+++ b/src/library/scala/collection/generic/SortedMapFactory.scala
@@ -33,6 +33,7 @@ abstract class SortedMapFactory[CC[A, B] <: SortedMap[A, B] with SortedMapLike[A
     new MapBuilder[A, B, CC[A, B]](empty(ord))
 
   class SortedMapCanBuildFrom[A, B](implicit ord: Ordering[A]) extends CanBuildFrom[Coll, (A, B), CC[A, B]] {
+    private[collection] def ordering = ord
     def apply(from: Coll) = newBuilder[A, B](ord)
     def apply() = newBuilder[A, B]
   }

--- a/src/library/scala/collection/generic/Subtractable.scala
+++ b/src/library/scala/collection/generic/Subtractable.scala
@@ -14,7 +14,7 @@ package scala
 package collection
 package generic
 
-import scala.collection.immutable.HashSet
+import scala.collection.immutable.{HashSet, TreeMap, TreeSet}
 
 
 /** This trait represents collection-like objects that can be reduced
@@ -64,6 +64,10 @@ trait Subtractable[A, +Repr <: Subtractable[A, Repr]] { self =>
   def --(xs: GenTraversableOnce[A]): Repr = this match {
     case hs: HashSet[A] if xs.isInstanceOf[HashSet[A]] =>
       hs.diff(xs.asInstanceOf[HashSet[A]]).asInstanceOf[Repr]
+    case ts: TreeMap[A, _] if xs.isInstanceOf[TreeSet[A]] && ts.ordering == xs.asInstanceOf[TreeSet[A]].ordering =>
+      ts.removeAllImpl(xs.asInstanceOf[TreeSet[A]]).asInstanceOf[Repr]
+    case ts: TreeSet[A] if xs.isInstanceOf[TreeSet[A]] && ts.ordering == xs.asInstanceOf[TreeSet[A]].ordering =>
+      ts.removeAll(xs.asInstanceOf[TreeSet[A]]).asInstanceOf[Repr]
     case _ =>
       (repr /: xs.seq) (_ - _)
   }

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -14,8 +14,12 @@ package scala
 package collection
 package immutable
 
+import collection.Iterator
+
 import scala.annotation.tailrec
 import scala.annotation.meta.getter
+
+import java.lang.{Integer, String}
 
 /** An object containing the RedBlack tree implementation used by for `TreeMaps` and `TreeSets`.
  *
@@ -23,11 +27,8 @@ import scala.annotation.meta.getter
  *  uses `null` to represent empty trees. This also means pattern matching cannot
  *  easily be used. The API represented by the RedBlackTree object tries to hide these
  *  optimizations behind a reasonably clean API.
- *
- *  @since 2.10
  */
-private[collection]
-object RedBlackTree {
+private[collection] object RedBlackTree {
 
   def isEmpty(tree: Tree[_, _]): Boolean = tree eq null
 
@@ -46,25 +47,6 @@ object RedBlackTree {
   }
 
   def count(tree: Tree[_, _]) = if (tree eq null) 0 else tree.count
-  /**
-   * Count all the nodes with keys greater than or equal to the lower bound and less than the upper bound.
-   * The two bounds are optional.
-   */
-  def countInRange[A](tree: Tree[A, _], from: Option[A], to:Option[A])(implicit ordering: Ordering[A]) : Int =
-    if (tree eq null) 0 else
-    (from, to) match {
-      // with no bounds use this node's count
-      case (None, None) => tree.count
-      // if node is less than the lower bound, try the tree on the right, it might be in range
-      case (Some(lb), _) if ordering.lt(tree.key, lb) => countInRange(tree.right, from, to)
-      // if node is greater than or equal to the upper bound, try the tree on the left, it might be in range
-      case (_, Some(ub)) if ordering.gteq(tree.key, ub) => countInRange(tree.left, from, to)
-      // node is in range so the tree on the left will all be less than the upper bound and the tree on the
-      // right will all be greater than or equal to the lower bound. So 1 for this node plus
-      // count the subtrees by stripping off the bounds that we don't need any more
-      case _ => 1 + countInRange(tree.left, from, None) + countInRange(tree.right, None, to)
-
-    }
   def update[A: Ordering, B, B1 >: B](tree: Tree[A, B], k: A, v: B1, overwrite: Boolean): Tree[A, B1] = blacken(upd(tree, k, v, overwrite))
   def delete[A: Ordering, B](tree: Tree[A, B], k: A): Tree[A, B] = blacken(del(tree, k))
   def rangeImpl[A: Ordering, B](tree: Tree[A, B], from: Option[A], until: Option[A]): Tree[A, B] = (from, until) match {
@@ -83,38 +65,82 @@ object RedBlackTree {
   def slice[A: Ordering, B](tree: Tree[A, B], from: Int, until: Int): Tree[A, B] = blacken(doSlice(tree, from, until))
 
   def smallest[A, B](tree: Tree[A, B]): Tree[A, B] = {
-    if (tree eq null) throw new NoSuchElementException("empty map")
+    if (tree eq null) throw new NoSuchElementException("empty tree")
     var result = tree
     while (result.left ne null) result = result.left
     result
   }
   def greatest[A, B](tree: Tree[A, B]): Tree[A, B] = {
-    if (tree eq null) throw new NoSuchElementException("empty map")
+    if (tree eq null) throw new NoSuchElementException("empty tree")
     var result = tree
     while (result.right ne null) result = result.right
     result
   }
 
-  def foreach[A,B,U](tree:Tree[A,B], f:((A,B)) => U):Unit = if (tree ne null) _foreach(tree,f)
-  def foreachEntry[A,B,U](tree:Tree[A,B], f:(A,B) => U):Unit = if (tree ne null) _foreachEntry(tree,f)
+  def tail[A, B](tree: Tree[A, B]): Tree[A, B] = {
+    def _tail(tree: Tree[A, B]): Tree[A, B] =
+      if(tree eq null) throw new NoSuchElementException("empty tree")
+      else if(tree.left eq null) tree.right
+      else if(isBlackTree(tree.left)) balLeft(tree.key, tree.value, _tail(tree.left), tree.right)
+      else RedTree(tree.key, tree.value, _tail(tree.left), tree.right)
+    blacken(_tail(tree))
+  }
 
-  private[this] def _foreach[A, B, U](tree: Tree[A, B], f: ((A, B)) => U) {
+  def init[A, B](tree: Tree[A, B]): Tree[A, B] = {
+    def _init(tree: Tree[A, B]): Tree[A, B] =
+      if(tree eq null) throw new NoSuchElementException("empty tree")
+      else if(tree.right eq null) tree.left
+      else if(isBlackTree(tree.right)) balRight(tree.key, tree.value, tree.left, _init(tree.right))
+      else RedTree(tree.key, tree.value, tree.left, _init(tree.right))
+    blacken(_init(tree))
+  }
+
+  /**
+   * Returns the smallest node with a key larger than or equal to `x`. Returns `null` if there is no such node.
+   */
+  def minAfter[A, B](tree: Tree[A, B], x: A)(implicit ordering: Ordering[A]): Tree[A, B] = if (tree eq null) null else {
+    val cmp = ordering.compare(x, tree.key)
+    if (cmp == 0) tree
+    else if (cmp < 0) {
+      val l = minAfter(tree.left, x)
+      if (l != null) l else tree
+    } else minAfter(tree.right, x)
+  }
+
+  /**
+   * Returns the largest node with a key smaller than `x`. Returns `null` if there is no such node.
+   */
+  def maxBefore[A, B](tree: Tree[A, B], x: A)(implicit ordering: Ordering[A]): Tree[A, B] = if (tree eq null) null else {
+    val cmp = ordering.compare(x, tree.key)
+    if (cmp <= 0) maxBefore(tree.left, x)
+    else {
+      val r = maxBefore(tree.right, x)
+      if (r != null) r else tree
+    }
+  }
+
+  def foreach[A,B,U](tree:Tree[A,B], f:((A,B)) => U):Unit = if (tree ne null) _foreach(tree,f)
+
+  private[this] def _foreach[A, B, U](tree: Tree[A, B], f: ((A, B)) => U): Unit = {
     if (tree.left ne null) _foreach(tree.left, f)
     f((tree.key, tree.value))
     if (tree.right ne null) _foreach(tree.right, f)
   }
+
+  def foreachKey[A, U](tree:Tree[A,_], f: A => U):Unit = if (tree ne null) _foreachKey(tree,f)
+
+  private[this] def _foreachKey[A, U](tree: Tree[A, _], f: A => U): Unit = {
+    if (tree.left ne null) _foreachKey(tree.left, f)
+    f((tree.key))
+    if (tree.right ne null) _foreachKey(tree.right, f)
+  }
+
+  def foreachEntry[A, B, U](tree:Tree[A,B], f: (A, B) => U):Unit = if (tree ne null) _foreachEntry(tree,f)
+
   private[this] def _foreachEntry[A, B, U](tree: Tree[A, B], f: (A, B) => U): Unit = {
     if (tree.left ne null) _foreachEntry(tree.left, f)
     f(tree.key, tree.value)
     if (tree.right ne null) _foreachEntry(tree.right, f)
-  }
-
-  def foreachKey[A, U](tree:Tree[A,_], f: A => U):Unit = if (tree ne null) _foreachKey(tree,f)
-
-  private[this] def _foreachKey[A, U](tree: Tree[A, _], f: A => U) {
-    if (tree.left ne null) _foreachKey(tree.left, f)
-    f((tree.key))
-    if (tree.right ne null) _foreachKey(tree.right, f)
   }
 
   def iterator[A: Ordering, B](tree: Tree[A, B], start: Option[A] = None): Iterator[(A, B)] = new EntriesIterator(tree, start)
@@ -131,10 +157,15 @@ object RedBlackTree {
 
   def isBlack(tree: Tree[_, _]) = (tree eq null) || isBlackTree(tree)
 
-  private[this] def isRedTree(tree: Tree[_, _]) = tree.isInstanceOf[RedTree[_, _]]
-  private[this] def isBlackTree(tree: Tree[_, _]) = tree.isInstanceOf[BlackTree[_, _]]
+  @`inline` private[this] def isRedTree(tree: Tree[_, _]) = tree.isInstanceOf[RedTree[_, _]]
+  @`inline` private[this] def isBlackTree(tree: Tree[_, _]) = tree.isInstanceOf[BlackTree[_, _]]
 
   private[this] def blacken[A, B](t: Tree[A, B]): Tree[A, B] = if (t eq null) null else t.black
+
+  // Blacken if the tree is red and has a red child. This is necessary when using methods such as `upd` or `updNth`
+  // for building subtrees. Use `blacken` instead when building top-level trees.
+  private[this] def maybeBlacken[A, B](t: Tree[A, B]): Tree[A, B] =
+    if(isBlack(t)) t else if(isRedTree(t.left) || isRedTree(t.right)) t.black else t
 
   private[this] def mkTree[A, B](isBlack: Boolean, k: A, v: B, l: Tree[A, B], r: Tree[A, B]) =
     if (isBlack) BlackTree(k, v, l, r) else RedTree(k, v, l, r)
@@ -161,7 +192,7 @@ object RedBlackTree {
     val cmp = ordering.compare(k, tree.key)
     if (cmp < 0) balanceLeft(isBlackTree(tree), tree.key, tree.value, upd(tree.left, k, v, overwrite), tree.right)
     else if (cmp > 0) balanceRight(isBlackTree(tree), tree.key, tree.value, tree.left, upd(tree.right, k, v, overwrite))
-    else if (overwrite || k != tree.key) mkTree(isBlackTree(tree), k, v, tree.left, tree.right)
+    else if (overwrite || k != tree.key) mkTree(isBlackTree(tree), tree.key, v, tree.left, tree.right)
     else tree
   }
   private[this] def updNth[A, B, B1 >: B](tree: Tree[A, B], idx: Int, k: A, v: B1, overwrite: Boolean): Tree[A, B1] = if (tree eq null) {
@@ -174,94 +205,13 @@ object RedBlackTree {
     else tree
   }
 
-  /* Based on Stefan Kahrs' Haskell version of Okasaki's Red&Black Trees
-   * Constructing Red-Black Trees, Ralf Hinze: [[http://www.cs.ox.ac.uk/ralf.hinze/publications/WAAAPL99b.ps.gz]]
-   * Red-Black Trees in a Functional Setting, Chris Okasaki: [[https://wiki.rice.edu/confluence/download/attachments/2761212/Okasaki-Red-Black.pdf]] */
-  private[this] def del[A, B](tree: Tree[A, B], k: A)(implicit ordering: Ordering[A]): Tree[A, B] = if (tree eq null) null else {
-    def balance(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tl)) {
-      if (isRedTree(tr)) {
-        RedTree(x, xv, tl.black, tr.black)
-      } else if (isRedTree(tl.left)) {
-        RedTree(tl.key, tl.value, tl.left.black, BlackTree(x, xv, tl.right, tr))
-      } else if (isRedTree(tl.right)) {
-        RedTree(tl.right.key, tl.right.value, BlackTree(tl.key, tl.value, tl.left, tl.right.left), BlackTree(x, xv, tl.right.right, tr))
-      } else {
-        BlackTree(x, xv, tl, tr)
-      }
-    } else if (isRedTree(tr)) {
-      if (isRedTree(tr.right)) {
-        RedTree(tr.key, tr.value, BlackTree(x, xv, tl, tr.left), tr.right.black)
-      } else if (isRedTree(tr.left)) {
-        RedTree(tr.left.key, tr.left.value, BlackTree(x, xv, tl, tr.left.left), BlackTree(tr.key, tr.value, tr.left.right, tr.right))
-      } else {
-        BlackTree(x, xv, tl, tr)
-      }
-    } else {
-      BlackTree(x, xv, tl, tr)
-    }
-    def subl(t: Tree[A, B]) =
-      if (t.isInstanceOf[BlackTree[_, _]]) t.red
-      else sys.error("Defect: invariance violation; expected black, got "+t)
-
-    def balLeft(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tl)) {
-      RedTree(x, xv, tl.black, tr)
-    } else if (isBlackTree(tr)) {
-      balance(x, xv, tl, tr.red)
-    } else if (isRedTree(tr) && isBlackTree(tr.left)) {
-      RedTree(tr.left.key, tr.left.value, BlackTree(x, xv, tl, tr.left.left), balance(tr.key, tr.value, tr.left.right, subl(tr.right)))
-    } else {
-      sys.error("Defect: invariance violation")
-    }
-    def balRight(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tr)) {
-      RedTree(x, xv, tl, tr.black)
-    } else if (isBlackTree(tl)) {
-      balance(x, xv, tl.red, tr)
-    } else if (isRedTree(tl) && isBlackTree(tl.right)) {
-      RedTree(tl.right.key, tl.right.value, balance(tl.key, tl.value, subl(tl.left), tl.right.left), BlackTree(x, xv, tl.right.right, tr))
-    } else {
-      sys.error("Defect: invariance violation")
-    }
-    def delLeft = if (isBlackTree(tree.left)) balLeft(tree.key, tree.value, del(tree.left, k), tree.right) else RedTree(tree.key, tree.value, del(tree.left, k), tree.right)
-    def delRight = if (isBlackTree(tree.right)) balRight(tree.key, tree.value, tree.left, del(tree.right, k)) else RedTree(tree.key, tree.value, tree.left, del(tree.right, k))
-    def append(tl: Tree[A, B], tr: Tree[A, B]): Tree[A, B] = if (tl eq null) {
-      tr
-    } else if (tr eq null) {
-      tl
-    } else if (isRedTree(tl) && isRedTree(tr)) {
-      val bc = append(tl.right, tr.left)
-      if (isRedTree(bc)) {
-        RedTree(bc.key, bc.value, RedTree(tl.key, tl.value, tl.left, bc.left), RedTree(tr.key, tr.value, bc.right, tr.right))
-      } else {
-        RedTree(tl.key, tl.value, tl.left, RedTree(tr.key, tr.value, bc, tr.right))
-      }
-    } else if (isBlackTree(tl) && isBlackTree(tr)) {
-      val bc = append(tl.right, tr.left)
-      if (isRedTree(bc)) {
-        RedTree(bc.key, bc.value, BlackTree(tl.key, tl.value, tl.left, bc.left), BlackTree(tr.key, tr.value, bc.right, tr.right))
-      } else {
-        balLeft(tl.key, tl.value, tl.left, BlackTree(tr.key, tr.value, bc, tr.right))
-      }
-    } else if (isRedTree(tr)) {
-      RedTree(tr.key, tr.value, append(tl, tr.left), tr.right)
-    } else if (isRedTree(tl)) {
-      RedTree(tl.key, tl.value, tl.left, append(tl.right, tr))
-    } else {
-      sys.error("unmatched tree on append: " + tl + ", " + tr)
-    }
-
-    val cmp = ordering.compare(k, tree.key)
-    if (cmp < 0) delLeft
-    else if (cmp > 0) delRight
-    else append(tree.left, tree.right)
-  }
-
   private[this] def doFrom[A, B](tree: Tree[A, B], from: A)(implicit ordering: Ordering[A]): Tree[A, B] = {
     if (tree eq null) return null
     if (ordering.lt(tree.key, from)) return doFrom(tree.right, from)
     val newLeft = doFrom(tree.left, from)
     if (newLeft eq tree.left) tree
     else if (newLeft eq null) upd(tree.right, tree.key, tree.value, overwrite = false)
-    else rebalance(tree, newLeft, tree.right)
+    else join(newLeft, tree.key, tree.value, tree.right)
   }
   private[this] def doTo[A, B](tree: Tree[A, B], to: A)(implicit ordering: Ordering[A]): Tree[A, B] = {
     if (tree eq null) return null
@@ -269,7 +219,7 @@ object RedBlackTree {
     val newRight = doTo(tree.right, to)
     if (newRight eq tree.right) tree
     else if (newRight eq null) upd(tree.left, tree.key, tree.value, overwrite = false)
-    else rebalance(tree, tree.left, newRight)
+    else join (tree.left, tree.key, tree.value, newRight)
   }
   private[this] def doUntil[A, B](tree: Tree[A, B], until: A)(implicit ordering: Ordering[A]): Tree[A, B] = {
     if (tree eq null) return null
@@ -277,8 +227,9 @@ object RedBlackTree {
     val newRight = doUntil(tree.right, until)
     if (newRight eq tree.right) tree
     else if (newRight eq null) upd(tree.left, tree.key, tree.value, overwrite = false)
-    else rebalance(tree, tree.left, newRight)
+    else join(tree.left, tree.key, tree.value, newRight)
   }
+
   private[this] def doRange[A, B](tree: Tree[A, B], from: A, until: A)(implicit ordering: Ordering[A]): Tree[A, B] = {
     if (tree eq null) return null
     if (ordering.lt(tree.key, from)) return doRange(tree.right, from, until)
@@ -288,148 +239,41 @@ object RedBlackTree {
     if ((newLeft eq tree.left) && (newRight eq tree.right)) tree
     else if (newLeft eq null) upd(newRight, tree.key, tree.value, overwrite = false)
     else if (newRight eq null) upd(newLeft, tree.key, tree.value, overwrite = false)
-    else rebalance(tree, newLeft, newRight)
+    else join(newLeft, tree.key, tree.value, newRight)
   }
 
-  private[this] def doDrop[A, B](tree: Tree[A, B], n: Int): Tree[A, B] = {
-    if (n <= 0) return tree
-    if (n >= this.count(tree)) return null
-    val count = this.count(tree.left)
-    if (n > count) return doDrop(tree.right, n - count - 1)
-    val newLeft = doDrop(tree.left, n)
-    if (newLeft eq tree.left) tree
-    else if (newLeft eq null) updNth(tree.right, n - count - 1, tree.key, tree.value, overwrite = false)
-    else rebalance(tree, newLeft, tree.right)
-  }
-  private[this] def doTake[A, B](tree: Tree[A, B], n: Int): Tree[A, B] = {
-    if (n <= 0) return null
-    if (n >= this.count(tree)) return tree
-    val count = this.count(tree.left)
-    if (n <= count) return doTake(tree.left, n)
-    val newRight = doTake(tree.right, n - count - 1)
-    if (newRight eq tree.right) tree
-    else if (newRight eq null) updNth(tree.left, n, tree.key, tree.value, overwrite = false)
-    else rebalance(tree, tree.left, newRight)
-  }
-  private[this] def doSlice[A, B](tree: Tree[A, B], from: Int, until: Int): Tree[A, B] = {
-    if (tree eq null) return null
-    val count = this.count(tree.left)
-    if (from > count) return doSlice(tree.right, from - count - 1, until - count - 1)
-    if (until <= count) return doSlice(tree.left, from, until)
-    val newLeft = doDrop(tree.left, from)
-    val newRight = doTake(tree.right, until - count - 1)
-    if ((newLeft eq tree.left) && (newRight eq tree.right)) tree
-    else if (newLeft eq null) updNth(newRight, from - count - 1, tree.key, tree.value, overwrite = false)
-    else if (newRight eq null) updNth(newLeft, until, tree.key, tree.value, overwrite = false)
-    else rebalance(tree, newLeft, newRight)
-  }
-
-  // The zipper returned might have been traversed left-most (always the left child)
-  // or right-most (always the right child). Left trees are traversed right-most,
-  // and right trees are traversed leftmost.
-
-  // Returns the zipper for the side with deepest black nodes depth, a flag
-  // indicating whether the trees were unbalanced at all, and a flag indicating
-  // whether the zipper was traversed left-most or right-most.
-
-  // If the trees were balanced, returns an empty zipper
-  private[this] def compareDepth[A, B](left: Tree[A, B], right: Tree[A, B]): (NList[Tree[A, B]], Boolean, Boolean, Int) = {
-    import NList.cons
-    // Once a side is found to be deeper, unzip it to the bottom
-    def unzip(zipper: NList[Tree[A, B]], leftMost: Boolean): NList[Tree[A, B]] = {
-      val next = if (leftMost) zipper.head.left else zipper.head.right
-      if (next eq null) zipper
-      else unzip(cons(next, zipper), leftMost)
+  private[this] def doDrop[A, B](tree: Tree[A, B], n: Int): Tree[A, B] =
+    if((tree eq null) || (n <= 0)) tree
+    else if(n >= tree.count) null
+    else {
+      val l = count(tree.left)
+      if(n > l) doDrop(tree.right, n-l-1)
+      else if(n == l) join(null, tree.key, tree.value, tree.right)
+      else join(doDrop(tree.left, n), tree.key, tree.value, tree.right)
     }
 
-    // Unzip left tree on the rightmost side and right tree on the leftmost side until one is
-    // found to be deeper, or the bottom is reached
-    def unzipBoth(left: Tree[A, B],
-                  right: Tree[A, B],
-                  leftZipper: NList[Tree[A, B]],
-                  rightZipper: NList[Tree[A, B]],
-                  smallerDepth: Int): (NList[Tree[A, B]], Boolean, Boolean, Int) = {
-      if (isBlackTree(left) && isBlackTree(right)) {
-        unzipBoth(left.right, right.left, cons(left, leftZipper), cons(right, rightZipper), smallerDepth + 1)
-      } else if (isRedTree(left) && isRedTree(right)) {
-        unzipBoth(left.right, right.left, cons(left, leftZipper), cons(right, rightZipper), smallerDepth)
-      } else if (isRedTree(right)) {
-        unzipBoth(left, right.left, leftZipper, cons(right, rightZipper), smallerDepth)
-      } else if (isRedTree(left)) {
-        unzipBoth(left.right, right, cons(left, leftZipper), rightZipper, smallerDepth)
-      } else if ((left eq null) && (right eq null)) {
-        (null, true, false, smallerDepth)
-      } else if ((left eq null) && isBlackTree(right)) {
-        val leftMost = true
-        (unzip(cons(right, rightZipper), leftMost), false, leftMost, smallerDepth)
-      } else if (isBlackTree(left) && (right eq null)) {
-        val leftMost = false
-        (unzip(cons(left, leftZipper), leftMost), false, leftMost, smallerDepth)
-      } else {
-        sys.error("unmatched trees in unzip: " + left + ", " + right)
-      }
-    }
-    unzipBoth(left, right, null, null, 0)
-  }
-
-  private[this] def rebalance[A, B](tree: Tree[A, B], newLeft: Tree[A, B], newRight: Tree[A, B]) = {
-    // This is like drop(n-1), but only counting black nodes
-    @tailrec
-    def  findDepth(zipper: NList[Tree[A, B]], depth: Int): NList[Tree[A, B]] =
-      if (zipper eq null) {
-        sys.error("Defect: unexpected empty zipper while computing range")
-      } else if (isBlackTree(zipper.head)) {
-        if (depth == 1) zipper else findDepth(zipper.tail, depth - 1)
-      } else {
-        findDepth(zipper.tail, depth)
-      }
-
-    // Blackening the smaller tree avoids balancing problems on union;
-    // this can't be done later, though, or it would change the result of compareDepth
-    val blkNewLeft = blacken(newLeft)
-    val blkNewRight = blacken(newRight)
-    val (zipper, levelled, leftMost, smallerDepth) = compareDepth(blkNewLeft, blkNewRight)
-
-    if (levelled) {
-      BlackTree(tree.key, tree.value, blkNewLeft, blkNewRight)
-    } else {
-      val zipFrom = findDepth(zipper, smallerDepth)
-      val union = if (leftMost) {
-        RedTree(tree.key, tree.value, blkNewLeft, zipFrom.head)
-      } else {
-        RedTree(tree.key, tree.value, zipFrom.head, blkNewRight)
-      }
-      val zippedTree = NList.foldLeft(zipFrom.tail, union: Tree[A, B]) { (tree, node) =>
-        if (leftMost)
-          balanceLeft(isBlackTree(node), node.key, node.value, tree, node.right)
-        else
-          balanceRight(isBlackTree(node), node.key, node.value, node.left, tree)
-      }
-      zippedTree
-    }
-  }
-
-  // Null optimized list implementation for tree rebalancing. null presents Nil.
-  private[this] final class NList[A](val head: A, val tail: NList[A])
-
-  private[this] final object NList {
-
-    def cons[B](x: B, xs: NList[B]): NList[B] = new NList(x, xs)
-
-    def foldLeft[A, B](xs: NList[A], z: B)(op: (B, A) => B): B = {
-      var acc = z
-      var these = xs
-      while (these ne null) {
-        acc = op(acc, these.head)
-        these = these.tail
-      }
-      acc
+  private[this] def doTake[A, B](tree: Tree[A, B], n: Int): Tree[A, B] =
+    if((tree eq null) || (n <= 0)) null
+    else if(n >= tree.count) tree
+    else {
+      val l = count(tree.left)
+      if(n <= l) doTake(tree.left, n)
+      else if(n == l+1) maybeBlacken(updNth(tree.left, n, tree.key, tree.value, overwrite = false))
+      else join(tree.left, tree.key, tree.value, doTake(tree.right, n-l-1))
     }
 
-  }
+  private[this] def doSlice[A, B](tree: Tree[A, B], from: Int, until: Int): Tree[A, B] =
+    if((tree eq null) || (from >= until) || (from >= tree.count) || (until <= 0)) null
+    else if((from <= 0) && (until >= tree.count)) tree
+    else {
+      val l = count(tree.left)
+      if(until <= l) doSlice(tree.left, from, until)
+      else if(from > l) doSlice(tree.right, from-l-1, until-l-1)
+      else join(doDrop(tree.left, from), tree.key, tree.value, doTake(tree.right, until-l-1))
+    }
 
   /*
-   * Forcing direct fields access using the @inline annotation helps speed up
+   * Forcing direct fields access using the @`inline` annotation helps speed up
    * various operations (especially smallest/greatest and update/delete).
    *
    * Unfortunately the direct field access is not guaranteed to work (but
@@ -438,12 +282,12 @@ object RedBlackTree {
    * An alternative is to implement the these classes using plain old Java code...
    */
   sealed abstract class Tree[A, +B](
-    @(inline @getter) final val key: A,
-    @(inline @getter) final val value: B,
-    @(inline @getter) final val left: Tree[A, B],
-    @(inline @getter) final val right: Tree[A, B])
-  extends Serializable {
-    @(inline @getter) final val count: Int = 1 + RedBlackTree.count(left) + RedBlackTree.count(right)
+                                     @(`inline` @getter) final val key: A,
+                                     @(`inline` @getter) final val value: B,
+                                     @(`inline` @getter) final val left: Tree[A, B],
+                                     @(`inline` @getter) final val right: Tree[A, B]) extends Serializable
+  {
+    @(`inline` @getter) final val count: Int = 1 + RedBlackTree.count(left) + RedBlackTree.count(right)
     def black: Tree[A, B]
     def red: Tree[A, B]
   }
@@ -465,11 +309,11 @@ object RedBlackTree {
   }
 
   object RedTree {
-    @inline def apply[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new RedTree(key, value, left, right)
+    @`inline` def apply[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new RedTree(key, value, left, right)
     def unapply[A, B](t: RedTree[A, B]) = Some((t.key, t.value, t.left, t.right))
   }
   object BlackTree {
-    @inline def apply[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new BlackTree(key, value, left, right)
+    @`inline` def apply[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new BlackTree(key, value, left, right)
     def unapply[A, B](t: BlackTree[A, B]) = Some((t.key, t.value, t.left, t.right))
   }
 
@@ -478,12 +322,13 @@ object RedBlackTree {
 
     override def hasNext: Boolean = lookahead ne null
 
-    override def next: R = lookahead match {
-      case null =>
-        throw new NoSuchElementException("next on empty iterator")
-      case tree =>
+    @throws[NoSuchElementException]
+    override def next(): R = {
+      val tree = lookahead
+      if(tree ne null) {
         lookahead = findLeftMostOrPopOnEmpty(goRight(tree))
         nextResult(tree)
+      } else Iterator.empty.next()
     }
 
     @tailrec
@@ -492,24 +337,9 @@ object RedBlackTree {
       else if (tree.left eq null) tree
       else findLeftMostOrPopOnEmpty(goLeft(tree))
 
-    private[this] def pushNext(tree: Tree[A, B]) {
-      try {
-        stackOfNexts(index) = tree
-        index += 1
-      } catch {
-        case _: ArrayIndexOutOfBoundsException =>
-          /*
-           * Either the tree became unbalanced or we calculated the maximum height incorrectly.
-           * To avoid crashing the iterator we expand the path array. Obviously this should never
-           * happen...
-           *
-           * An exception handler is used instead of an if-condition to optimize the normal path.
-           * This makes a large difference in iteration speed!
-           */
-          assert(index >= stackOfNexts.length)
-          stackOfNexts :+= null
-          pushNext(tree)
-      }
+    private[this] def pushNext(tree: Tree[A, B]): Unit = {
+      stackOfNexts(index) = tree
+      index += 1
     }
     private[this] def popNext(): Tree[A, B] = if (index == 0) null else {
       index -= 1
@@ -548,12 +378,12 @@ object RedBlackTree {
       find(root)
     }
 
-    private[this] def goLeft(tree: Tree[A, B]) = {
+    @`inline` private[this] def goLeft(tree: Tree[A, B]) = {
       pushNext(tree)
       tree.left
     }
 
-    private[this] def goRight(tree: Tree[A, B]) = tree.right
+    @`inline` private[this] def goRight(tree: Tree[A, B]) = tree.right
   }
 
   private[this] class EntriesIterator[A: Ordering, B](tree: Tree[A, B], focus: Option[A]) extends TreeIterator[A, B, (A, B)](tree, focus) {
@@ -567,4 +397,345 @@ object RedBlackTree {
   private[this] class ValuesIterator[A: Ordering, B](tree: Tree[A, B], focus: Option[A]) extends TreeIterator[A, B, B](tree, focus) {
     override def nextResult(tree: Tree[A, B]) = tree.value
   }
+
+  /** Build a Tree suitable for a TreeSet from an ordered sequence of keys */
+  def fromOrderedKeys[A](xs: Iterator[A], size: Int): Tree[A, Null] = {
+    val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
+    def f(level: Int, size: Int): Tree[A, Null] = size match {
+      case 0 => null
+      case 1 => mkTree(level != maxUsedDepth || level == 1, xs.next(), null, null, null)
+      case n =>
+        val leftSize = (size-1)/2
+        val left = f(level+1, leftSize)
+        val x = xs.next()
+        val right = f(level+1, size-1-leftSize)
+        BlackTree(x, null, left, right)
+    }
+    f(1, size)
+  }
+
+  /** Build a Tree suitable for a TreeMap from an ordered sequence of key/value pairs */
+  def fromOrderedEntries[A, B](xs: Iterator[(A, B)], size: Int): Tree[A, B] = {
+    val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
+    def f(level: Int, size: Int): Tree[A, B] = size match {
+      case 0 => null
+      case 1 =>
+        val (k, v) = xs.next()
+        mkTree(level != maxUsedDepth || level == 1, k, v, null, null)
+      case n =>
+        val leftSize = (size-1)/2
+        val left = f(level+1, leftSize)
+        val (k, v) = xs.next()
+        val right = f(level+1, size-1-leftSize)
+        BlackTree(k, v, left, right)
+    }
+    f(1, size)
+  }
+
+  def transform[A, B, C](t: Tree[A, B], f: (A, B) => C): Tree[A, C] =
+    if(t eq null) null
+    else {
+      val k = t.key
+      val v = t.value
+      val l = t.left
+      val r = t.right
+      val l2 = transform(l, f)
+      val v2 = f(k, v)
+      val r2 = transform(r, f)
+      if((v2.asInstanceOf[AnyRef] eq v.asInstanceOf[AnyRef])
+        && (l2 eq l)
+        && (r2 eq r)) t.asInstanceOf[Tree[A, C]]
+      else mkTree(isBlackTree(t), k, v2, l2, r2)
+    }
+
+  def filterEntries[A, B](t: Tree[A, B], f: (A, B) => Boolean): Tree[A, B] = if(t eq null) null else {
+    def fk(t: Tree[A, B]): Tree[A, B] = {
+      val k = t.key
+      val v = t.value
+      val l = t.left
+      val r = t.right
+      val l2 = if(l eq null) null else fk(l)
+      val keep = f(k, v)
+      val r2 = if(r eq null) null else fk(r)
+      if(!keep) join2(l2, r2)
+      else if((l2 eq l) && (r2 eq r)) t
+      else join(l2, k, v, r2)
+    }
+    blacken(fk(t))
+  }
+
+  def filterKeys[A, B](t: Tree[A, B], f: A => Boolean, isFlipped: Boolean): Tree[A, B] = if(t eq null) null else {
+    def fk(t: Tree[A, B]): Tree[A, B] = {
+      val k = t.key
+      val l = t.left
+      val r = t.right
+      val l2 = if(l eq null) null else fk(l)
+      val keep = isFlipped ^ f(k)
+      val r2 = if(r eq null) null else fk(r)
+      if(!keep) join2(l2, r2)
+      else if((l2 eq l) && (r2 eq r)) t
+      else join(l2, k, t.value, r2)
+    }
+    blacken(fk(t))
+  }
+
+  def partitionEntries[A, B](t: Tree[A, B], p: (A, B) => Boolean): (Tree[A, B], Tree[A, B]) = if(t eq null) (null, null) else {
+    var tmpk, tmpd = null: Tree[A, B] // shared vars to avoid returning tuples from fk
+    def fk(t: Tree[A, B]): Unit = {
+      val k = t.key
+      val v = t.value
+      val l = t.left
+      val r = t.right
+      var l2k, l2d, r2k, r2d = null: Tree[A, B]
+      if(l ne null) {
+        fk(l)
+        l2k = tmpk
+        l2d = tmpd
+      }
+      val keep = p(k, v)
+      if(r ne null) {
+        fk(r)
+        r2k = tmpk
+        r2d = tmpd
+      }
+      val jk =
+        if(!keep) join2(l2k, r2k)
+        else if((l2k eq l) && (r2k eq r)) t
+        else join(l2k, k, v, r2k)
+      val jd =
+        if(keep) join2(l2d, r2d)
+        else if((l2d eq l) && (r2d eq r)) t
+        else join(l2d, k, v, r2d)
+      tmpk = jk
+      tmpd = jd
+    }
+    fk(t)
+    (blacken(tmpk), blacken(tmpd))
+  }
+
+  def partitionKeys[A, B](t: Tree[A, B], p: A => Boolean): (Tree[A, B], Tree[A, B]) = if(t eq null) (null, null) else {
+    var tmpk, tmpd = null: Tree[A, B] // shared vars to avoid returning tuples from fk
+    def fk(t: Tree[A, B]): Unit = {
+      val k = t.key
+      val v = t.value
+      val l = t.left
+      val r = t.right
+      var l2k, l2d, r2k, r2d = null: Tree[A, B]
+      if(l ne null) {
+        fk(l)
+        l2k = tmpk
+        l2d = tmpd
+      }
+      val keep = p(k)
+      if(r ne null) {
+        fk(r)
+        r2k = tmpk
+        r2d = tmpd
+      }
+      val jk =
+        if(!keep) join2(l2k, r2k)
+        else if((l2k eq l) && (r2k eq r)) t
+        else join(l2k, k, v, r2k)
+      val jd =
+        if(keep) join2(l2d, r2d)
+        else if((l2d eq l) && (r2d eq r)) t
+        else join(l2d, k, v, r2d)
+      tmpk = jk
+      tmpd = jd
+    }
+    fk(t)
+    (blacken(tmpk), blacken(tmpd))
+  }
+
+
+  // Based on Stefan Kahrs' Haskell version of Okasaki's Red&Black Trees
+  // Constructing Red-Black Trees, Ralf Hinze: [[http://www.cs.ox.ac.uk/ralf.hinze/publications/WAAAPL99b.ps.gz]]
+  // Red-Black Trees in a Functional Setting, Chris Okasaki: [[https://wiki.rice.edu/confluence/download/attachments/2761212/Okasaki-Red-Black.pdf]] */
+
+  private[this] def del[A, B](tree: Tree[A, B], k: A)(implicit ordering: Ordering[A]): Tree[A, B] = if (tree eq null) null else {
+    def delLeft =
+      if (isBlackTree(tree.left)) balLeft(tree.key, tree.value, del(tree.left, k), tree.right)
+      else RedTree(tree.key, tree.value, del(tree.left, k), tree.right)
+    def delRight =
+      if (isBlackTree(tree.right)) balRight(tree.key, tree.value, tree.left, del(tree.right, k))
+      else RedTree(tree.key, tree.value, tree.left, del(tree.right, k))
+    val cmp = ordering.compare(k, tree.key)
+    if (cmp < 0) delLeft
+    else if (cmp > 0) delRight
+    else append(tree.left, tree.right)
+  }
+
+  private[this] def balance[A, B](x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) =
+    if (isRedTree(tl)) {
+      if (isRedTree(tr)) RedTree(x, xv, tl.black, tr.black)
+      else if (isRedTree(tl.left)) RedTree(tl.key, tl.value, tl.left.black, BlackTree(x, xv, tl.right, tr))
+      else if (isRedTree(tl.right))
+        RedTree(tl.right.key, tl.right.value, BlackTree(tl.key, tl.value, tl.left, tl.right.left), BlackTree(x, xv, tl.right.right, tr))
+      else BlackTree(x, xv, tl, tr)
+    } else if (isRedTree(tr)) {
+      if (isRedTree(tr.right)) RedTree(tr.key, tr.value, BlackTree(x, xv, tl, tr.left), tr.right.black)
+      else if (isRedTree(tr.left))
+        RedTree(tr.left.key, tr.left.value, BlackTree(x, xv, tl, tr.left.left), BlackTree(tr.key, tr.value, tr.left.right, tr.right))
+      else BlackTree(x, xv, tl, tr)
+    } else BlackTree(x, xv, tl, tr)
+
+  private[this] def balLeft[A, B](x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) =
+    if (isRedTree(tl)) RedTree(x, xv, tl.black, tr)
+    else if (isBlackTree(tr)) balance(x, xv, tl, tr.red)
+    else if (isRedTree(tr) && isBlackTree(tr.left))
+      RedTree(tr.left.key, tr.left.value, BlackTree(x, xv, tl, tr.left.left), balance(tr.key, tr.value, tr.left.right, tr.right.red))
+    else sys.error("Defect: invariance violation")
+
+  private[this] def balRight[A, B](x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) =
+    if (isRedTree(tr)) RedTree(x, xv, tl, tr.black)
+    else if (isBlackTree(tl)) balance(x, xv, tl.red, tr)
+    else if (isRedTree(tl) && isBlackTree(tl.right))
+      RedTree(tl.right.key, tl.right.value, balance(tl.key, tl.value, tl.left.red, tl.right.left), BlackTree(x, xv, tl.right.right, tr))
+    else sys.error("Defect: invariance violation")
+
+  /** `append` is similar to `join2` but requires that both subtrees have the same black height */
+  private[this] def append[A, B](tl: Tree[A, B], tr: Tree[A, B]): Tree[A, B] =
+    if (tl eq null) tr
+    else if (tr eq null) tl
+    else if (isRedTree(tl) && isRedTree(tr)) {
+      val bc = append(tl.right, tr.left)
+      if (isRedTree(bc)) {
+        RedTree(bc.key, bc.value, RedTree(tl.key, tl.value, tl.left, bc.left), RedTree(tr.key, tr.value, bc.right, tr.right))
+      } else {
+        RedTree(tl.key, tl.value, tl.left, RedTree(tr.key, tr.value, bc, tr.right))
+      }
+    } else if (isBlackTree(tl) && isBlackTree(tr)) {
+      val bc = append(tl.right, tr.left)
+      if (isRedTree(bc)) {
+        RedTree(bc.key, bc.value, BlackTree(tl.key, tl.value, tl.left, bc.left), BlackTree(tr.key, tr.value, bc.right, tr.right))
+      } else {
+        balLeft(tl.key, tl.value, tl.left, BlackTree(tr.key, tr.value, bc, tr.right))
+      }
+    } else if (isRedTree(tr)) RedTree(tr.key, tr.value, append(tl, tr.left), tr.right)
+    else if (isRedTree(tl)) RedTree(tl.key, tl.value, tl.left, append(tl.right, tr))
+    else sys.error("unmatched tree on append: " + tl + ", " + tr)
+
+
+  // Bulk operations based on "Just Join for Parallel Ordered Sets" (https://www.cs.cmu.edu/~guyb/papers/BFS16.pdf)
+  // We don't store the black height in the tree so we pass it down into the join methods and derive the black height
+  // of child nodes from it. Where possible the black height is used directly instead of deriving the rank from it.
+  // Our trees are supposed to have a black root so we always blacken as the last step of union/intersect/difference.
+
+  def union[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] = blacken(_union(t1, t2))
+
+  def intersect[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] = blacken(_intersect(t1, t2))
+
+  def difference[A, B](t1: Tree[A, B], t2: Tree[A, _])(implicit ordering: Ordering[A]): Tree[A, B] =
+    blacken(_difference(t1, t2.asInstanceOf[Tree[A, B]]))
+
+  /** Compute the rank from a tree and its black height */
+  @`inline` private[this] def rank(t: Tree[_, _], bh: Int): Int = {
+    if(t eq null) 0
+    else if(isBlackTree(t)) 2*(bh-1)
+    else 2*bh-1
+  }
+
+  private[this] def joinRight[A, B](tl: Tree[A, B], k: A, v: B, tr: Tree[A, B], bhtl: Int, rtr: Int): Tree[A, B] = {
+    val rtl = rank(tl, bhtl)
+    if(rtl == (rtr/2)*2) RedTree(k, v, tl, tr)
+    else {
+      val tlBlack = isBlackTree(tl)
+      val bhtlr = if(tlBlack) bhtl-1 else bhtl
+      val ttr = joinRight(tl.right, k, v, tr, bhtlr, rtr)
+      if(tlBlack && isRedTree(ttr) && isRedTree(ttr.right))
+        RedTree(ttr.key, ttr.value,
+          BlackTree(tl.key, tl.value, tl.left, ttr.left),
+          ttr.right.black)
+      else mkTree(tlBlack, tl.key, tl.value, tl.left, ttr)
+    }
+  }
+
+  private[this] def joinLeft[A, B](tl: Tree[A, B], k: A, v: B, tr: Tree[A, B], rtl: Int, bhtr: Int): Tree[A, B] = {
+    val rtr = rank(tr, bhtr)
+    if(rtr == (rtl/2)*2) RedTree(k, v, tl, tr)
+    else {
+      val trBlack = isBlackTree(tr)
+      val bhtrl = if(trBlack) bhtr-1 else bhtr
+      val ttl = joinLeft(tl, k, v, tr.left, rtl, bhtrl)
+      if(trBlack && isRedTree(ttl) && isRedTree(ttl.left))
+        RedTree(ttl.key, ttl.value,
+          ttl.left.black,
+          BlackTree(tr.key, tr.value, ttl.right, tr.right))
+      else mkTree(trBlack, tr.key, tr.value, ttl, tr.right)
+    }
+  }
+
+  private[this] def join[A, B](tl: Tree[A, B], k: A, v: B, tr: Tree[A, B]): Tree[A, B] = {
+    @tailrec def h(t: Tree[_, _], i: Int): Int =
+      if(t eq null) i+1 else h(t.left, if(isBlackTree(t)) i+1 else i)
+    val bhtl = h(tl, 0)
+    val bhtr = h(tr, 0)
+    if(bhtl > bhtr) {
+      val tt = joinRight(tl, k, v, tr, bhtl, rank(tr, bhtr))
+      if(isRedTree(tt) && isRedTree(tt.right)) tt.black
+      else tt
+    } else if(bhtr > bhtl) {
+      val tt = joinLeft(tl, k, v, tr, rank(tl, bhtl), bhtr)
+      if(isRedTree(tt) && isRedTree(tt.left)) tt.black
+      else tt
+    } else mkTree(isRedTree(tl) || isRedTree(tr), k, v, tl, tr)
+  }
+
+  private[this] def split[A, B](t: Tree[A, B], k: A)(implicit ordering: Ordering[A]): (Tree[A, B], Tree[A, B], Tree[A, B]) =
+    if(t eq null) (null, null, null)
+    else {
+      val cmp = ordering.compare(k, t.key)
+      if(cmp == 0) (t.left, t, t.right)
+      else if(cmp < 0) {
+        val (ll, b, lr) = split(t.left, k)
+        (ll, b, join(lr, t.key, t.value, t.right))
+      } else {
+        val (rl, b, rr) = split(t.right, k)
+        (join(t.left, t.key, t.value, rl), b, rr)
+      }
+    }
+
+  private[this] def splitLast[A, B](t: Tree[A, B]): (Tree[A, B], A, B) =
+    if(t.right eq null) (t.left, t.key, t.value)
+    else {
+      val (tt, kk, vv) = splitLast(t.right)
+      (join(t.left, t.key, t.value, tt), kk, vv)
+    }
+
+  private[this] def join2[A, B](tl: Tree[A, B], tr: Tree[A, B]): Tree[A, B] =
+    if(tl eq null) tr
+    else if(tr eq null) tl
+    else {
+      val (ttl, k, v) = splitLast(tl)
+      join(ttl, k, v, tr)
+    }
+
+  private[this] def _union[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] =
+    if(t1 eq null) t2
+    else if(t2 eq null) t1
+    else {
+      val (l1, _, r1) = split(t1, t2.key)
+      val tl = _union(l1, t2.left)
+      val tr = _union(r1, t2.right)
+      join(tl, t2.key, t2.value, tr)
+    }
+
+  private[this] def _intersect[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] =
+    if((t1 eq null) || (t2 eq null)) null
+    else {
+      val (l1, b, r1) = split(t1, t2.key)
+      val tl = _intersect(l1, t2.left)
+      val tr = _intersect(r1, t2.right)
+      if(b ne null) join(tl, t2.key, t2.value, tr)
+      else join2(tl, tr)
+    }
+
+  private[this] def _difference[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] =
+    if((t1 eq null) || (t2 eq null)) t1
+    else {
+      val (l1, _, r1) = split(t1, t2.key)
+      val tl = _difference(l1, t2.left)
+      val tr = _difference(r1, t2.right)
+      join2(tl, tr)
+    }
 }

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -56,7 +56,7 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
      with Serializable
      with HasForeachEntry[A, B] {
   // Manually use this from inner classes to avoid having scalac rename `tree` to an expanded name which is not
-  // serialization compatbile.
+  // serialization compatible.
   private def tree0: RB.Tree[A, B] = tree
 
   override protected[this] def newBuilder : Builder[(A, B), TreeMap[A, B]] =
@@ -66,11 +66,11 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
 
   def this()(implicit ordering: Ordering[A]) = this(null)(ordering)
 
-  override def rangeImpl(from: Option[A], until: Option[A]): TreeMap[A, B] = newMap[B](RB.rangeImpl(tree, from, until))
-  override def range(from: A, until: A): TreeMap[A, B] = newMap[B](RB.range(tree, from, until))
-  override def from(from: A): TreeMap[A, B] = newMap[B](RB.from(tree, from))
-  override def to(to: A): TreeMap[A, B] = newMap[B](RB.to(tree, to))
-  override def until(until: A): TreeMap[A, B] = newMap[B](RB.until(tree, until))
+  override def rangeImpl(from: Option[A], until: Option[A]): TreeMap[A, B] = newMapOrSelf[B](RB.rangeImpl(tree, from, until))
+  override def range(from: A, until: A): TreeMap[A, B] = newMapOrSelf[B](RB.range(tree, from, until))
+  override def from(from: A): TreeMap[A, B] = newMapOrSelf[B](RB.from(tree, from))
+  override def to(to: A): TreeMap[A, B] = newMapOrSelf[B](RB.to(tree, to))
+  override def until(until: A): TreeMap[A, B] = newMapOrSelf[B](RB.until(tree, until))
 
   override def firstKey = RB.smallest(tree).key
   override def lastKey = RB.greatest(tree).key
@@ -87,22 +87,22 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
   }
   override def lastOption = if (RB.isEmpty(tree)) None else Some(last)
 
-  override def tail = newMap(RB.delete(tree, firstKey))
-  override def init = newMap(RB.delete(tree, lastKey))
+  override def tail = newMapOrSelf(RB.delete(tree, firstKey))
+  override def init = newMapOrSelf(RB.delete(tree, lastKey))
 
   override def drop(n: Int) = {
     if (n <= 0) this
     else if (n >= size) empty
-    else newMap(RB.drop(tree, n))
+    else newMapOrSelf(RB.drop(tree, n))
   }
 
   override def take(n: Int) = {
     if (n <= 0) empty
     else if (n >= size) this
-    else newMap(RB.take(tree, n))
+    else newMapOrSelf(RB.take(tree, n))
   }
 
-  private def newMap[B1 >: B](newTree: RedBlackTree.Tree[A, B1]): TreeMap[A, B1] = {
+  private def newMapOrSelf[B1 >: B](newTree: RB.Tree[A, B1]): TreeMap[A, B1] = {
     if (newTree eq tree) this
     else new TreeMap(newTree)
   }
@@ -111,7 +111,7 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
     if (until <= from) empty
     else if (from <= 0) take(until)
     else if (until >= size) drop(from)
-    else newMap(RB.slice(tree, from, until))
+    else newMapOrSelf(RB.slice(tree, from, until))
   }
 
   override def dropRight(n: Int) = take(size - math.max(n, 0))
@@ -130,7 +130,7 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
 
   /** A factory to create empty maps of the same type of keys.
    */
-  override def empty: TreeMap[A, B] = newMap(null)
+  override def empty: TreeMap[A, B] = newMapOrSelf(null)
 
   /** A new TreeMap with the entry added is returned,
    *  if key is <em>not</em> in the TreeMap, otherwise
@@ -141,7 +141,8 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
    *  @param value   the value to be associated with `key`
    *  @return        a new $coll with the updated binding
    */
-  override def updated [B1 >: B](key: A, value: B1): TreeMap[A, B1] = newMap(RB.update(tree, key, value, overwrite = true))
+  override def updated [B1 >: B](key: A, value: B1): TreeMap[A, B1] =
+    newMapOrSelf(RB.update(tree, key, value, overwrite = true))
 
   /** Add a key/value pair to this map.
    *  @tparam   B1   type of the value of the new binding, a supertype of `B`
@@ -168,8 +169,21 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
    *
    *  @param xs     the traversable object.
    */
-  override def ++[B1 >: B] (xs: GenTraversableOnce[(A, B1)]): TreeMap[A, B1] =
-    ((repr: TreeMap[A, B1]) /: xs.seq) (_ + _)
+  override def ++[B1 >: B] (xs: GenTraversableOnce[(A, B1)]): TreeMap[A, B1] = {
+    xs match {
+      case tm: TreeMap[A, B] if ordering == tm.ordering =>
+        newMapOrSelf(RB.union(tree, tm.tree0))
+      case _ =>
+        // probably should be something like
+        //        val builder = TreeMap.newBuilder[A, B1]
+        //        builder ++= this
+        //        builder ++= xs
+        //        builder.result()
+        //but for compat and simplicity
+
+        ((repr: TreeMap[A, B1]) /: xs.seq) (_ + _)
+    }
+  }
 
   /** A new TreeMap with the entry added is returned,
    *  assuming that key is <em>not</em> in the TreeMap.
@@ -181,12 +195,16 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
    */
   def insert [B1 >: B](key: A, value: B1): TreeMap[A, B1] = {
     assert(!RB.contains(tree, key))
-    newMap(RB.update(tree, key, value, overwrite = true))
+    newMapOrSelf(RB.update(tree, key, value, overwrite = true))
   }
 
   def - (key:A): TreeMap[A, B] =
-    if (!RB.contains(tree, key)) this
-    else newMap(RB.delete(tree, key))
+   newMapOrSelf(RB.delete(tree, key))
+
+  private[collection] def removeAllImpl(ts: TreeSet[A]): TreeMap[A, B] =  {
+    assert(ordering == ts.ordering)
+    newMapOrSelf(RB.difference(tree, ts.tree))
+  }
 
   /** Check if this map maps `key` to a value and return the
    *  value if it exists.
@@ -226,12 +244,26 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
       hasher.finalizeHash
     }
   }
-
-  override def keySet: SortedSet[A] = new DefaultKeySortedSet {
-    override def foreach[U](f: A => U): Unit = RB.foreachEntry(tree0, {(key: A, _: B) => f(key)})
-  }
+  override def keySet: SortedSet[A] = new TreeSet[A](tree)(ordering)
 
   override def values: scala.Iterable[B] = new DefaultValuesIterable {
     override def foreach[U](f: B => U): Unit = RB.foreachEntry(tree0, {(_: A, value: B) => f(value)})
+  }
+  override private[scala] def filterImpl(f: ((A, B)) => Boolean, isFlipped: Boolean) =
+    newMapOrSelf(RB.filterEntries[A, B](tree, (k, v) => isFlipped ^ f((k, v))))
+
+  override def partition(p: ((A, B)) => Boolean): (TreeMap[A, B], TreeMap[A, B]) = {
+    val (l, r) = RB.partitionEntries[A, B](tree, (k, v) => p((k, v)))
+    (newMapOrSelf(l), newMapOrSelf(r))
+  }
+
+  override def transform[W, That](f: (A, B) => W)(implicit bf: CanBuildFrom[TreeMap[A, B], (A, W), That]): That = {
+    bf match {
+      case sm: TreeMap.SortedMapCanBuildFrom[A, B] if sm.ordering == ordering =>
+        val t2 = RB.transform[A, B, W](tree, f)
+        if (t2 eq tree) this.asInstanceOf[That]
+        else new TreeMap(t2).asInstanceOf[That]
+      case _ => super.transform(f)
+    }
   }
 }


### PR DESCRIPTION
Backport https://github.com/scala/scala/pull/7284 and related changes from 2.13.x to make `immutable.{TreeMap,TreeSet}` more efficient.

Adapt what is needed for the API changes. This means that 2.12 improvements can be more easily forward ported, as the APIs are more aligned