### PR TITLE
Heed warning about cache invalidation after making object Serializable

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1840,6 +1840,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       info match {
         case ci @ ClassInfoType(_, _, _) =>
           setInfo(ci.copy(parents = ci.parents :+ SerializableTpe))
+          invalidateCaches(ci.typeSymbol.typeOfThis.underlying, ci.typeSymbol :: Nil)
         case i =>
           abort("Only ClassInfoTypes can be made serializable: "+ i)
       }

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1840,7 +1840,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       info match {
         case ci @ ClassInfoType(_, _, _) =>
           setInfo(ci.copy(parents = ci.parents :+ SerializableTpe))
-          invalidateCaches(ci.typeSymbol.typeOfThis.underlying, ci.typeSymbol :: Nil)
+          invalidateCaches(ci.typeSymbol.typeOfThis, ci.typeSymbol :: Nil)
         case i =>
           abort("Only ClassInfoTypes can be made serializable: "+ i)
       }

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4744,11 +4744,15 @@ trait Types
         invalidateCaches(tp, updatedSyms)
       }
 
-  def invalidateCaches(t: Type, updatedSyms: List[Symbol]) =
+  def invalidateCaches(t: Type, updatedSyms: List[Symbol]): Unit =
     t match {
-      case st: SingleType   if updatedSyms.contains(st.sym) => st.invalidateSingleTypeCaches()
       case tr: TypeRef      if updatedSyms.contains(tr.sym) => tr.invalidateTypeRefCaches()
       case ct: CompoundType if ct.baseClasses.exists(updatedSyms.contains) => ct.invalidatedCompoundTypeCaches()
+      case st: SingleType =>
+        if (updatedSyms.contains(st.sym)) st.invalidateSingleTypeCaches()
+        val underlying = st.underlying
+        if (underlying ne st)
+          invalidateCaches(underlying, updatedSyms)
       case _ =>
     }
 

--- a/test/files/pos/case-object-add-serializable.flags
+++ b/test/files/pos/case-object-add-serializable.flags
@@ -1,0 +1,1 @@
+-Xdev -Xfatal-warnings

--- a/test/files/pos/case-object-add-serializable.scala
+++ b/test/files/pos/case-object-add-serializable.scala
@@ -1,0 +1,10 @@
+// Was: "warning: !!! base trait Serializable not found in basetypes of object Person. This might indicate incorrect caching of TypeRef#parents."
+// under -Xdev
+class Test {
+  def apply = {
+    case class Person(name: String)
+    val x = Person("")
+    Person.getClass
+    x.name
+  }
+}


### PR DESCRIPTION
Compiling the enclosed test case with `-Xdev` told me:

```
warning: !!! base trait Serializable not found in basetypes of object Person. This might indicate incorrect caching of TypeRef#parents.
```

Indeed, the `ModuleTypeRef` associated with the newly seralizable
module class had cached the base type sequence prior to the addition
of `Serializable`.

A more serious examination of how we add this parent would be
worthwhile, but for now I'll just do a bandaid job by invalidating
internal caches of the `ModuleTypeRef`.