### PR TITLE
Avoid spurious shadowed import warning

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -561,9 +561,9 @@ trait Namers extends MethodSynthesis {
           }
         }
         if (!tree.symbol.isSynthetic && expr.symbol != null && !expr.symbol.isInterpreterWrapper) {
-          if (base.member(from) != NoSymbol)
+          if (base.member(from).exists)
             check(to0)
-          if (base.member(from.toTypeName) != NoSymbol)
+          if (base.member(from.toTypeName).exists)
             check(to0.toTypeName)
         }
       }

--- a/src/library/scala/annotation/migration.scala
+++ b/src/library/scala/annotation/migration.scala
@@ -27,4 +27,4 @@ package scala.annotation
  * @param changedIn The version, in which the behaviour change was
  * introduced.
  */
- private[scala] final class migration(message: String, changedIn: String) extends scala.annotation.StaticAnnotation
+private[scala] final class migration(message: String, changedIn: String) extends scala.annotation.StaticAnnotation

--- a/test/files/neg/t11607.check
+++ b/test/files/neg/t11607.check
@@ -1,4 +1,4 @@
-t11607.scala:2: error: class migration in package annotation cannot be accessed as a member of package annotation from package <empty>
+t11607.scala:2: error: not found: type migration
 @migration("", "") class C
  ^
 1 error

--- a/test/files/pos/t8121/A_1.scala
+++ b/test/files/pos/t8121/A_1.scala
@@ -1,0 +1,2 @@
+package a
+object Foo

--- a/test/files/pos/t8121/B_2.scala
+++ b/test/files/pos/t8121/B_2.scala
@@ -1,0 +1,4 @@
+// scalac: -Werror
+package b
+import a.Foo
+class Foo


### PR DESCRIPTION
Use `!sym.exists` instead of `!= NoSymbol`. The compiler generates a
`ClassSymbol` when it sees `Foo.class`, but that symbol then doesn't
exist if `Foo` is only an `object` without companion class (`Foo.class`
is the mirror class with static forwarders for Java interop).

Fixes https://github.com/scala/bug/issues/8121

There might be a risk of this PR causing cyclic references because symbols are completed earlier.