### PR TITLE
Use Java semantics for imports in .java files

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -940,7 +940,8 @@ trait Contexts { self: Analyzer =>
     /** @return None if a cycle is detected, or Some(infos) containing the in-scope implicits at this context */
     private def implicits(nextOuter: Context): Option[List[ImplicitInfo]] = {
       val firstImport = this.firstImport
-      if (owner != nextOuter.owner && owner.isClass && !owner.isPackageClass && !inSelfSuperCall) {
+      if (unit.isJava) SomeOfNil
+      else if (owner != nextOuter.owner && owner.isClass && !owner.isPackageClass && !inSelfSuperCall) {
         if (!owner.isInitialized) None
         else savingEnclClass(this) {
           // !!! In the body of `class C(implicit a: A) { }`, `implicitss` returns `List(List(a), List(a), List(<predef..)))`

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1548,15 +1548,22 @@ trait Contexts { self: Analyzer =>
         def sameName(name: Name, other: Name) = {
           (name eq other) || (name ne null) && name.start == other.start && name.length == other.length
         }
-        def tryJavaCompanion(target: Name) =
-          if (pos.source.isJava) qual.tpe.companion nonLocalMember target else NoSymbol
+        def lookup(target: Name): Symbol = {
+          if (pos.source.isJava) {
+            val (_, sym) = NoContext.javaFindMember(qual.tpe, target, _ => true)
+            // We don't need to propagate the new prefix back out to the result of `Context.lookupSymbol`
+            // because typechecking .java sources doesn't need it.
+            sym
+          }
+          else qual.tpe nonLocalMember target
+        }
         if (sameName(current.rename, name)) {
           val target = current.name asTypeOf name
-          result = qual.tpe nonLocalMember target orElse tryJavaCompanion(target)
+          result = lookup(target)
         } else if (sameName(current.name, name))
           renamed = true
         else if (current.name == nme.WILDCARD && !renamed && !requireExplicit)
-          result = qual.tpe nonLocalMember name orElse tryJavaCompanion(name)
+          result = lookup(name)
 
         if (result == NoSymbol)
           selectors = selectors.tail

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -560,9 +560,14 @@ trait Namers extends MethodSynthesis {
       }
       def checkSelector(s: ImportSelector) = {
         val ImportSelector(from, fromPos, to, _) = s
-        def isValid(original: Name, base: Type) =
-          (base nonLocalMember original.toTermName) != NoSymbol ||
-            (base nonLocalMember original.toTypeName) != NoSymbol
+        def isValid(original: Name, base: Type) = {
+          def lookup(name: Name) =
+            if (context.unit.isJava)
+              NoContext.javaFindMember(base, name, _ => true)._2
+            else
+              base.nonLocalMember(name)
+          lookup(original.toTermName) != NoSymbol || lookup(original.toTypeName) != NoSymbol
+        }
 
         if (from != nme.WILDCARD && base != ErrorType) {
           val okay = isValid(from, base) || context.unit.isJava && (      // Java code...

--- a/test/files/neg/java-import-non-existing-selector.check
+++ b/test/files/neg/java-import-non-existing-selector.check
@@ -1,0 +1,6 @@
+java-import-non-existing-selector/BadClient.java:3: error: cannot find symbol
+import static p1.Test.DoesNotExist;
+^
+  symbol:   static DoesNotExist
+  location: class
+1 error

--- a/test/files/neg/java-import-non-existing-selector.flags
+++ b/test/files/neg/java-import-non-existing-selector.flags
@@ -1,0 +1,1 @@
+-Ypickle-java

--- a/test/files/neg/java-import-non-existing-selector/BadClient.java
+++ b/test/files/neg/java-import-non-existing-selector/BadClient.java
@@ -1,0 +1,7 @@
+package p1;
+
+import static p1.Test.DoesNotExist;
+
+class BadClient {
+
+}

--- a/test/files/neg/java-import-non-existing-selector/Test.java
+++ b/test/files/neg/java-import-non-existing-selector/Test.java
@@ -1,0 +1,6 @@
+package p1;
+
+public class Test extends Base {}
+class Base {
+  static class I {}
+}

--- a/test/files/pos/java-import-static-from-subclass.flags
+++ b/test/files/pos/java-import-static-from-subclass.flags
@@ -1,0 +1,1 @@
+-Ypickle-java

--- a/test/files/pos/java-import-static-from-subclass/Client.java
+++ b/test/files/pos/java-import-static-from-subclass/Client.java
@@ -1,0 +1,7 @@
+package p1;
+
+import static p1.Test.I;
+
+class Client {
+  void foo(I i) {}
+}

--- a/test/files/pos/java-import-static-from-subclass/Test.java
+++ b/test/files/pos/java-import-static-from-subclass/Test.java
@@ -1,0 +1,6 @@
+package p1;
+
+public class Test extends Base {}
+class Base {
+  static class I {}
+}

--- a/test/files/pos/java-import-static-from-subclass/Test.scala
+++ b/test/files/pos/java-import-static-from-subclass/Test.scala
@@ -1,0 +1,1 @@
+class Test


### PR DESCRIPTION
An static member of a superclass may be referred to in an static import in
Java sources qualified by a reference to the subclass.

We've accounted for related problems previously in `typedIdent` and
`typedSelect` by delegating to `javaFindMember`.

This commit uses the same facility when checking that import selectors are
valid and when checking if such an import contributes a name we are looking
up.

The test cases here use `-Ypickle-java` as a straightforward way to force
typechecking all Java imports and signatures, however the bug fix is also
beneficial outside of that mode if Scala code transitively depends on the
correct interpretation of such a Java import.