### PR TITLE
Fix ambiguous failure in implicit search for language features.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1239,7 +1239,9 @@ trait Implicits {
               val pendingImprovingBest = undoLog undo {
                 otherPending filterNot firstPendingImproves
               }
-              rankImplicits(pendingImprovingBest, (newBest, firstPending) :: acc)
+
+              if (pt.typeSymbol.hasAnnotation(definitions.LanguageFeatureAnnot)) (newBest, firstPending):: Nil
+              else rankImplicits(pendingImprovingBest, (newBest, firstPending) :: acc)
           }
       }
 

--- a/test/files/pos/t8176.scala
+++ b/test/files/pos/t8176.scala
@@ -1,0 +1,5 @@
+object Test {
+  implicit lazy val ambiguousPostfixOps1: language.postfixOps.type = language.postfixOps
+  implicit lazy val ambiguousPostfixOps2: language.postfixOps.type = language.postfixOps
+  List(1, 2, 3) tail
+}


### PR DESCRIPTION
Turned out a bit hacky by bypassing the implicit ranking for language features.

Thanks @lrytz for the help!

Fixes https://github.com/scala/bug/issues/8176.