### PR TITLE
Enable selection of equals for case class

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -195,7 +195,7 @@ trait SyntheticMethods extends ast.TreeDSL {
             if (isPrimitiveValueType(resultType))
               prims += fn(thisAcc, op, otherAcc)
             else
-              refs  += fn(thisAcc, op, otherAcc)   //gen.mkCast(otherAcc, AnyTpe)
+              refs  += fn(thisAcc, op, gen.mkCast(otherAcc, AnyTpe))
           }
         }
         prims.prependToList(refs.toList)      // (prims ++ refs).toList

--- a/test/files/pos/t10536.scala
+++ b/test/files/pos/t10536.scala
@@ -1,0 +1,9 @@
+trait A
+
+trait B[C <: B[C]] {
+  def ==(o: C)(implicit a: A): Boolean = ???
+}
+
+trait D[C <: B[C]]
+
+case class E[C <: B[C]](c: C) extends D[C]

--- a/test/files/run/t10539.scala
+++ b/test/files/run/t10539.scala
@@ -1,4 +1,5 @@
-
+// scalac: -Xdev
+//
 class A {
   def ==(a: A) = "LOL"
 }

--- a/test/files/run/t10539.scala
+++ b/test/files/run/t10539.scala
@@ -1,0 +1,11 @@
+
+class A {
+  def ==(a: A) = "LOL"
+}
+case class B(a: A)
+
+object Test extends App {
+  B(new A) == B(new A)
+}
+
+// was: java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Boolean


### PR DESCRIPTION
Forget to enable the `other.asInstanceOf[Any]` so you always get the right `equals`.

Fixes scala/bug#10536
Fixes scala/bug#10539