### PR TITLE
more process tests to ignore

### DIFF
--- a/test/junit/scala/sys/process/ProcessTest.scala
+++ b/test/junit/scala/sys/process/ProcessTest.scala
@@ -70,12 +70,12 @@ class ProcessTest {
     assertEquals(0, res)
   }
 
-  @Test def processApply(): Unit = {
+  @Test def processApply(): Unit = testily {
     val res = Process("cat", tempFiles.map(_.getAbsolutePath)).!
     assertEquals(0, res)
   }
 
-  @Test def t10696(): Unit = {
+  @Test def t10696(): Unit = testily {
     val res1 = Process("false").lazyLines
     assertEquals("LazyList(<not computed>)", res1.toString())
     val ex = Try(res1.head).failed.get


### PR DESCRIPTION
blacklists tests failing locally on CMD (passing in MSYS, though I have some other failures there), depending on `cat`, `false` and `true` being available as processes.

Integrate-windows is green. Looks like it doesn't run JUnit tests?