### PR TITLE
Expression for all zero bits

### DIFF
--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -723,7 +723,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
       throw new UnsupportedOperationException("empty.reduceLeft")
 
     var first = true
-    var acc: B = 0.asInstanceOf[B]
+    var acc: B = null.asInstanceOf[B]
 
     while (it.hasNext) {
       val x = it.next()


### PR DESCRIPTION
`null.asInstanceOf[A]` is more kosher than `0`.

It doesn't matter here because the value is never used
and is always re-assigned.

It's too bad someone started accusing `var x: A = _`
of undue ugliness. That remains the best expression of
non-assignment.