### PR TITLE
Elim erased value types from sammy bridges

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -196,12 +196,12 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
 
         val bridgeParamTypes = map2(samParamTypes, functionParamTypes){ (samParamTp, funParamTp) =>
           if (isReferenceType(samParamTp) && funParamTp <:< samParamTp) funParamTp
-          else samParamTp
+          else postErasure.elimErasedValueType(samParamTp)
         }
 
         val bridgeResultType =
           if (resTpOk && isReferenceType(samResultType) && functionResultType <:< samResultType) functionResultType
-          else samResultType
+          else postErasure.elimErasedValueType(samResultType)
 
         val typeAdapter = new TypeAdapter { def typedPos(pos: Position)(tree: Tree): Tree = localTyper.typedPos(pos)(tree) }
         import typeAdapter.{adaptToType, unboxValueClass}

--- a/test/files/pos/t10600.scala
+++ b/test/files/pos/t10600.scala
@@ -1,0 +1,17 @@
+class A(val value: Int) extends AnyVal
+class B(val value: Int) extends AnyVal
+
+package vcArg {
+  trait TC[T] { def v(x: A): T }
+  object TC {
+    implicit val tcB: TC[B] = _ => new B(0)
+  }
+}
+
+package vcRes {
+  trait TC[T] { def v(x: T): A }
+  object TC {
+    implicit val tcB: TC[B] = _ => new A(0)
+  }
+}
+


### PR DESCRIPTION
Delambdafy looks at the info of SAMs exiting erasure, so that it can tell whether an unboxing conversion needs to be applied. If you look at infos exiting erasure, though, you will see `ErasedValueTypes`, which generally aren't valid types and under no circumstances should make it to the backend.

It turns out that the posterasure transformer was already being applied to the bridge def, but the symbols weren't getting the posterased type.

Fixes scala/bug#10600.