### PR TITLE
RedBlackTree should not allocate a new tree if the Key and Value is eq the existing one

### DIFF
--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -209,18 +209,31 @@ private[collection] object RedBlackTree {
     RedTree(k, v, null, null)
   } else {
     val cmp = ordering.compare(k, tree.key)
-    if (cmp < 0) balanceLeft(isBlackTree(tree), tree.key, tree.value, upd(tree.left, k, v, overwrite), tree.right)
-    else if (cmp > 0) balanceRight(isBlackTree(tree), tree.key, tree.value, tree.left, upd(tree.right, k, v, overwrite))
-    else if (overwrite || k != tree.key) mkTree(isBlackTree(tree), tree.key, v, tree.left, tree.right)
+    if (cmp < 0) {
+      val newLeft = upd(tree.left, k, v, overwrite)
+      if (newLeft eq tree.left) tree
+      else balanceLeft(isBlackTree(tree), tree.key, tree.value, newLeft, tree.right)
+    } else if (cmp > 0) {
+      val newRight = upd(tree.right, k, v, overwrite)
+      if (newRight eq tree.right) tree
+      else balanceRight(isBlackTree(tree), tree.key, tree.value, tree.left, newRight)
+    } else if (overwrite && (v.asInstanceOf[AnyRef] ne tree.value.asInstanceOf[AnyRef]))
+      mkTree(isBlackTree(tree), tree.key, v, tree.left, tree.right)
     else tree
   }
   private[this] def updNth[A, B, B1 >: B](tree: Tree[A, B], idx: Int, k: A, v: B1): Tree[A, B1] = if (tree eq null) {
     RedTree(k, v, null, null)
   } else {
     val rank = count(tree.left) + 1
-    if (idx < rank) balanceLeft(isBlackTree(tree), tree.key, tree.value, updNth(tree.left, idx, k, v), tree.right)
-    else if (idx > rank) balanceRight(isBlackTree(tree), tree.key, tree.value, tree.left, updNth(tree.right, idx - rank, k, v))
-    else tree
+    if (idx < rank) {
+      val newLeft = updNth(tree.left, idx, k, v)
+      if (newLeft eq tree.left) tree
+      else balanceLeft(isBlackTree(tree), tree.key, tree.value, newLeft, tree.right)
+    } else if (idx > rank) {
+      val newRight = updNth(tree.right, idx - rank, k, v)
+      if (newRight eq tree.right) tree
+      else balanceRight(isBlackTree(tree), tree.key, tree.value, tree.left, newRight)
+    } else tree
   }
 
   private[this] def doFrom[A, B](tree: Tree[A, B], from: A)(implicit ordering: Ordering[A]): Tree[A, B] = {

--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -5,8 +5,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.tools.testing.AllocationTest
+
 @RunWith(classOf[JUnit4])
-class TreeMapTest {
+class TreeMapTest extends AllocationTest {
 
   @Test
   def hasCorrectDropAndTakeMethods() {
@@ -56,5 +58,15 @@ class TreeMapTest {
 
     assertEquals(tree1, tree1)
     assertEquals(tree1.drop(5), tree1.drop(5))
+  }
+  @Test
+  def plusWithContains() {
+    val data = Array.tabulate(1000)(i => s"${i}Key" -> s"${i}Value")
+    val tree = (TreeMap.newBuilder[String, String] ++= data).result
+
+    data foreach {
+      case (k, v) =>
+        assertSame(tree, nonAllocating(tree.updated(k, v)))
+    }
   }
 }

--- a/test/junit/scala/collection/immutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSetTest.scala
@@ -8,8 +8,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.tools.testing.AllocationTest
+
 @RunWith(classOf[JUnit4])
-class TreeSetTest {
+class TreeSetTest extends AllocationTest{
 
   @Test
   def hasCorrectDropAndTakeMethods() {
@@ -106,4 +108,24 @@ class TreeSetTest {
     assertEquals(tree1.drop(5), tree1.drop(5))
   }
 
+  @Test
+  def plusWithContains() {
+    val data = Array.tabulate(1000)(i => s"${i}Value")
+    val tree = (TreeSet.newBuilder[String] ++= data).result
+
+    data foreach {
+      case (k) =>
+        assertSame(tree, nonAllocating(tree + k))
+    }
+  }
+  @Test
+  def plusWithContainsFromMap() {
+    val data = Array.tabulate(1000)(i => s"${i}Key" -> s"${i}Value")
+    val tree = (TreeMap.newBuilder[String, String] ++= data).result.keySet
+
+    data foreach {
+      case (k, v) =>
+        assertSame(tree, nonAllocating(tree + k))
+    }
+  }
 }


### PR DESCRIPTION
quick check to see if the tree needs to be altered

benchmarks (after 5 hours of running) are below
the only marked differences (that dont seem anomalous are 
improvement |   |   |   |   | before |   |   |   |   |   | after |   |   |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
ns/op | B/op | Benchmark | Param: diff | Param: size | 0 | ns/op | Score Error (99.9%) | B/op | Score Error (99.9%) |   | ns/op | Score Error (99.9%) | B/op | Score Error (99.9%)
23.9% | 37.1% | scala.collection.immutable.TreeMapBenchmark.builderPlusPlusSame |   |   |   | 689,121.76 | 35229.92 | 873,041 | 2.256428 |   |   | 524,247.86 | 3834.976 | 549,009 | 1.69756
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
12.4% | 38.2% | scala.collection.immutable.TreeMapBenchmark.builderPlusPlusSameHash |   |   |   | 697,299.52 | 11040.79 | 849,041 | 2.249845 |   |   | 610,930.00 | 66657.67 | 525,009 | 2.13216
34.9% | 100.0% | scala.collection.immutable.TreeSetBenchmark.builderPlusPlusSameHash |   |   |   | 286,830.06 | 3375.954 | 265,984 | 0.927461 |   |   | 186,609.35 | 1901.334 | 64 | 0.605157
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --





full results are 


improvement |   |   |   |   | before |   |   |   |   |   | after |   |   |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
ns/op | B/op | Benchmark | Param: diff | Param: size | 0 | ns/op | Score Error (99.9%) | B/op | Score Error (99.9%) |   | ns/op | Score Error (99.9%) | B/op | Score Error (99.9%)
2.2% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.build |   | 0 |   | 63.82 | 4.326517 | 48 | 0.000238 |   |   | 62.40 | 2.945801 | 48 | 0.000203
4.7% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.build |   | 1 |   | 72.64 | 5.487177 | 80 | 0.000222 |   |   | 69.26 | 0.912309 | 80 | 0.000221
-11.2% | -0.5% | scala.collection.immutable.RedBlackTreeBenchmark.build |   | 10 |   | 723.03 | 104.8224 | 1,624 | 7.127487 |   |   | 803.87 | 143.4122 | 1,632 | 0.002398
-16.8% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.build |   | 100 |   | 12,292.55 | 708.6131 | 31,640 | 7.128501 |   |   | 14,362.04 | 1979.752 | 31,640 | 7.127034
-7.1% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.build |   | 1000 |   | 219,938.30 | 3897.56 | 490,944 | 0.707431 |   |   | 235,508.04 | 18919.79 | 490,944 | 0.743994
4.4% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.build |   | 10000 |   | 3,259,511.33 | 306454.8 | 6,501,109 | 10.46307 |   |   | 3,117,250.46 | 98762.9 | 6,501,107 | 11.98974
1.6% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.buildRandom |   | 0 |   | 42.48 | 2.031042 | 24 | 0.000137 |   |   | 41.82 | 0.391707 | 24 | 0.000137
0.4% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.buildRandom |   | 1 |   | 52.94 | 0.258931 | 56 | 0.000172 |   |   | 52.71 | 0.410156 | 56 | 0.000171
8.0% | 1.0% | scala.collection.immutable.RedBlackTreeBenchmark.buildRandom |   | 10 |   | 734.70 | 11.87559 | 1,608 | 0.002391 |   |   | 676.27 | 75.81326 | 1,592 | 0.002365
-3.1% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.buildRandom |   | 100 |   | 12,558.31 | 809.5362 | 31,616 | 7.12874 |   |   | 12,944.18 | 949.4979 | 31,616 | 7.128935
3.5% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.buildRandom |   | 1000 |   | 248,144.82 | 34708.42 | 490,943 | 17.47836 |   |   | 239,407.13 | 19331.5 | 490,942 | 17.16215
-1.3% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.buildRandom |   | 10000 |   | 3,142,972.72 | 37438.85 | 6,501,115 | 19.30718 |   |   | 3,182,886.46 | 23235.17 | 6,501,116 | 18.9515
-- | -- | scala.collection.immutable.RedBlackTreeBenchmark.drain |   | 0 |   | 4.52 | 0.043712 | 0 | 0.000015 |   |   | 4.46 | 0.026341 | 0 | 0.000014
3.0% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.drain |   | 1 |   | 18.86 | 2.108321 | 24 | 0.000057 |   |   | 18.28 | 1.043394 | 24 | 0.000058
-2.9% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.drain |   | 10 |   | 527.41 | 5.278554 | 1,488 | 0.00169 |   |   | 542.85 | 46.73479 | 1,488 | 0.001885
5.2% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.drain |   | 100 |   | 11,591.80 | 1189.549 | 33,440 | 0.034934 |   |   | 10,987.77 | 328.3577 | 33,440 | 0.035114
1.3% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.drain |   | 1000 |   | 185,983.31 | 14643.76 | 563,104 | 0.843975 |   |   | 183,626.86 | 14730.27 | 563,104 | 1.692853
1.8% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.drain |   | 10000 |   | 2,628,386.18 | 62329.2 | 7,746,916 | 8.492873 |   |   | 2,582,003.93 | 26974.31 | 7,746,916 | 8.348339
-- | -- | scala.collection.immutable.RedBlackTreeBenchmark.drop |   | 0 |   | 4.55 | 0.018234 | 0 | 0.000015 |   |   | 4.54 | 0.024664 | 0 | 0.000015
4.3% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.drop |   | 1 |   | 45.08 | 1.479936 | 24 | 0.000145 |   |   | 43.14 | 0.351042 | 24 | 0.000139
16.1% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.drop |   | 10 |   | 418.86 | 138.3044 | 784 | 0.001237 |   |   | 351.35 | 22.68109 | 784 | 0.001114
-1.9% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.drop |   | 100 |   | 836.81 | 22.20289 | 1,744 | 0.002712 |   |   | 853.07 | 4.144068 | 1,744 | 0.002731
0.9% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.drop |   | 1000 |   | 1,402.98 | 16.73308 | 2,608 | 0.0045 |   |   | 1,390.41 | 10.22948 | 2,608 | 0.004479
-1.8% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.drop |   | 10000 |   | 1,999.87 | 13.79913 | 3,280 | 0.006471 |   |   | 2,035.91 | 40.75411 | 3,280 | 0.006601
-- | -- | scala.collection.immutable.RedBlackTreeBenchmark.filterDrop |   | 0 |   | 4.19 | 0.041365 | 0 | 0.000014 |   |   | 4.15 | 0.02098 | 0 | 0.000013
-- | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.filterDrop |   | 1 |   | 8.35 | 0.052106 | 24 | 0.000027 |   |   | 8.29 | 0.088931 | 24 | 0.000027
3.6% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.filterDrop |   | 10 |   | 48.74 | 1.357484 | 24 | 0.000157 |   |   | 46.98 | 0.367182 | 24 | 0.000152
0.3% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.filterDrop |   | 100 |   | 445.86 | 1.491681 | 24 | 0.001446 |   |   | 444.37 | 2.038203 | 24 | 0.001451
-3.6% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.filterDrop |   | 1000 |   | 8,905.80 | 2521.956 | 24 | 0.044363 |   |   | 9,222.42 | 1771.718 | 24 | 0.032446
25.3% | 0.2% | scala.collection.immutable.RedBlackTreeBenchmark.filterDrop |   | 10000 |   | 290,187.70 | 94671.98 | 24 | 0.761441 |   |   | 216,864.05 | 6193.346 | 24 | 0.706777
-- | -- | scala.collection.immutable.RedBlackTreeBenchmark.filterKeep |   | 0 |   | 4.22 | 0.097618 | 0 | 0.000014 |   |   | 4.21 | 0.196757 | 0 | 0.000013
-- | -- | scala.collection.immutable.RedBlackTreeBenchmark.filterKeep |   | 1 |   | 5.73 | 0.068561 | 0 | 0.000019 |   |   | 5.68 | 0.033861 | 0 | 0.000018
2.7% | -- | scala.collection.immutable.RedBlackTreeBenchmark.filterKeep |   | 10 |   | 51.34 | 3.468781 | 0 | 0.000163 |   |   | 49.93 | 1.275209 | 0 | 0.000162
-4.6% | -- | scala.collection.immutable.RedBlackTreeBenchmark.filterKeep |   | 100 |   | 560.35 | 4.831182 | 0 | 0.001827 |   |   | 585.96 | 49.38692 | 0 | 0.002033
9.4% | -- | scala.collection.immutable.RedBlackTreeBenchmark.filterKeep |   | 1000 |   | 11,828.24 | 1604.06 | 0 | 0.040407 |   |   | 10,715.20 | 98.76602 | 0 | 0.034651
8.6% | -- | scala.collection.immutable.RedBlackTreeBenchmark.filterKeep |   | 10000 |   | 265,062.25 | 5860.554 | 0 | 0.867457 |   |   | 242,220.02 | 7323.373 | 0 | 0.785407
-- | -- | scala.collection.immutable.RedBlackTreeBenchmark.filterPartial |   | 0 |   | 4.19 | 0.020504 | 0 | 0.000014 |   |   | 4.16 | 0.024603 | 0 | 0.000014
-8.9% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.filterPartial |   | 1 |   | 9.76 | 0.052634 | 24 | 0.000031 |   |   | 10.63 | 1.451539 | 24 | 0.000031
-2.4% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.filterPartial |   | 10 |   | 208.84 | 1.935652 | 344 | 0.00068 |   |   | 213.80 | 15.86961 | 344 | 0.000689
6.2% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.filterPartial |   | 100 |   | 1,845.29 | 238.2012 | 2,360 | 0.005553 |   |   | 1,731.20 | 167.7117 | 2,360 | 0.005466
0.5% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.filterPartial |   | 1000 |   | 13,700.77 | 415.902 | 17,272 | 0.044239 |   |   | 13,638.85 | 225.463 | 17,272 | 0.044807
0.0% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.filterPartial |   | 10000 |   | 133,884.97 | 6868.847 | 162,232 | 0.451482 |   |   | 133,839.18 | 895.9163 | 162,232 | 0.431162
-- | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.foreach |   | 0 |   | 5.41 | 0.040511 | 16 | 0.000017 |   |   | 5.35 | 0.051028 | 16 | 0.000017
-- | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.foreach |   | 1 |   | 6.82 | 0.048117 | 16 | 0.000022 |   |   | 6.84 | 0.152844 | 16 | 0.000022
-1.6% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.foreach |   | 10 |   | 49.32 | 0.325349 | 32 | 0.000161 |   |   | 50.11 | 0.43913 | 32 | 0.000162
0.0% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.foreach |   | 100 |   | 344.14 | 1.440233 | 32 | 0.00111 |   |   | 344.17 | 4.424556 | 32 | 0.001107
0.8% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.foreach |   | 1000 |   | 4,287.87 | 1064.542 | 32 | 0.012428 |   |   | 4,254.06 | 1047.202 | 32 | 0.012327
5.7% | 0.1% | scala.collection.immutable.RedBlackTreeBenchmark.foreach |   | 10000 |   | 182,488.91 | 3397.693 | 32 | 0.610468 |   |   | 172,043.58 | 5249.687 | 32 | 0.545045
-- | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.iterator |   | 0 |   | 7.88 | 0.040488 | 32 | 0.000026 |   |   | 7.80 | 0.047971 | 32 | 0.000025
2.3% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.iterator |   | 1 |   | 33.14 | 0.542066 | 56 | 0.000107 |   |   | 32.37 | 0.298757 | 56 | 0.000104
0.3% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.iterator |   | 10 |   | 74.33 | 1.042508 | 72 | 0.000243 |   |   | 74.10 | 0.737963 | 72 | 0.00024
-0.5% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.iterator |   | 100 |   | 465.90 | 3.676129 | 96 | 0.00151 |   |   | 468.19 | 3.128209 | 96 | 0.00151
-6.9% | 5.9% | scala.collection.immutable.RedBlackTreeBenchmark.iterator |   | 1000 |   | 4,285.93 | 14.67812 | 136 | 0.013839 |   |   | 4,582.87 | 467.471 | 128 | 7.12704
7.3% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.iterator |   | 10000 |   | 171,262.30 | 3404.381 | 152 | 0.551002 |   |   | 158,768.31 | 3694.379 | 152 | 0.52302
-- | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.partition |   | 0 |   | 7.87 | 0.594547 | 24 | 0.000025 |   |   | 7.84 | 0.434079 | 24 | 0.000025
3.5% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.partition |   | 1 |   | 14.79 | 1.243835 | 48 | 0.000047 |   |   | 14.26 | 0.097621 | 48 | 0.000047
0.0% | -1.5% | scala.collection.immutable.RedBlackTreeBenchmark.partition |   | 10 |   | 482.51 | 9.222644 | 808 | 0.001615 |   |   | 482.28 | 26.80128 | 820 | 10.69098
-14.7% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.partition |   | 100 |   | 5,592.37 | 511.1848 | 10,000 | 0.017613 |   |   | 6,412.67 | 748.1595 | 10,000 | 0.022305
3.3% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.partition |   | 1000 |   | 57,534.48 | 2477.351 | 93,128 | 0.190542 |   |   | 55,660.30 | 380.0746 | 93,128 | 0.17994
19.3% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.partition |   | 10000 |   | 695,332.35 | 84264.51 | 922,385 | 2.364277 |   |   | 561,425.41 | 76669.13 | 922,385 | 1.888507
24.2% | -- | scala.collection.immutable.RedBlackTreeBenchmark.range |   | 0 |   | 21.47 | 2.822701 | 0 | 0.000067 |   |   | 16.27 | 0.115078 | 0 | 0.000052
-2.2% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.range |   | 1 |   | 536.97 | 7.238809 | 16 | 0.001714 |   |   | 549.02 | 5.597849 | 16 | 0.001768
-22.3% | -17.8% | scala.collection.immutable.RedBlackTreeBenchmark.range |   | 10 |   | 2,268.15 | 28.40556 | 2,160 | 0.007322 |   |   | 2,773.42 | 286.2138 | 2,544 | 0.008473
4.3% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.range |   | 100 |   | 5,795.56 | 718.0717 | 5,872 | 171.0575 |   |   | 5,549.04 | 164.6631 | 5,872 | 171.0559
9.3% | 1.8% | scala.collection.immutable.RedBlackTreeBenchmark.range |   | 1000 |   | 10,122.06 | 1068.786 | 10,800 | 171.0558 |   |   | 9,180.41 | 83.21827 | 10,608 | 0.029325
8.7% | 2.8% | scala.collection.immutable.RedBlackTreeBenchmark.range |   | 10000 |   | 12,801.25 | 287.8159 | 15,232 | 384.8755 |   |   | 11,682.48 | 110.0892 | 14,800 | 0.037531
0.8% | -- | scala.collection.immutable.RedBlackTreeBenchmark.slice |   | 0 |   | 16.34 | 0.089381 | 0 | 0.000053 |   |   | 16.21 | 0.063787 | 0 | 0.000052
0.8% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.slice |   | 1 |   | 256.81 | 1.65956 | 744 | 0.000822 |   |   | 254.64 | 1.31826 | 744 | 0.000816
7.9% | 5.5% | scala.collection.immutable.RedBlackTreeBenchmark.slice |   | 10 |   | 1,170.53 | 5.956026 | 2,312 | 0.003772 |   |   | 1,077.97 | 84.76055 | 2,184 | 114.0372
0.6% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.slice |   | 100 |   | 2,175.19 | 39.95274 | 4,080 | 7.127257 |   |   | 2,161.22 | 39.90093 | 4,080 | 7.127268
2.4% | 0.2% | scala.collection.immutable.RedBlackTreeBenchmark.slice |   | 1000 |   | 3,873.17 | 88.07807 | 6,840 | 0.012439 |   |   | 3,781.37 | 22.19864 | 6,824 | 0.012188
2.7% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.slice |   | 10000 |   | 5,494.77 | 86.99848 | 9,128 | 0.017599 |   |   | 5,345.93 | 71.42151 | 9,128 | 0.017243
4.7% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.tails |   | 0 |   | 100.57 | 4.817472 | 216 | 0.000331 |   |   | 95.86 | 0.932456 | 216 | 0.000309
3.1% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.tails |   | 1 |   | 299.17 | 1.970009 | 392 | 0.000972 |   |   | 289.96 | 2.323182 | 392 | 0.000938
-5.0% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.tails |   | 10 |   | 4,739.99 | 33.73646 | 11,200 | 0.015274 |   |   | 4,975.63 | 362.3924 | 11,200 | 0.01567
-2.7% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.tails |   | 100 |   | 704,229.99 | 38530 | 1,587,065 | 2.23258 |   |   | 723,385.25 | 7340.188 | 1,587,065 | 2.337614
0.5% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.tails |   | 1000 |   | 114,040,142.08 | 8510982 | 233,292,912 | 326.6418 |   |   | 113,483,821.39 | 1188069 | 233,292,921 | 345.4244
-0.7% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.tails |   | 10000 |   | 15,081,116,790.00 | 70709265 | 31,230,902,986 | 3270.753 |   |   | 15,191,774,775.00 | 1.5E+08 | 31,230,902,985 | 3271.226
-- | -- | scala.collection.immutable.RedBlackTreeBenchmark.take |   | 0 |   | 4.93 | 0.020566 | 0 | 0.000016 |   |   | 4.92 | 0.042459 | 0 | 0.000016
-4.5% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.take |   | 1 |   | 64.05 | 2.892169 | 240 | 0.000206 |   |   | 66.91 | 7.848461 | 240 | 0.000216
4.2% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.take |   | 10 |   | 535.19 | 52.12389 | 1,296 | 0.00164 |   |   | 512.50 | 6.268933 | 1,296 | 0.00165
-5.9% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.take |   | 100 |   | 1,136.02 | 8.333969 | 2,576 | 0.003641 |   |   | 1,202.67 | 71.36592 | 2,576 | 0.00382
-2.3% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.take |   | 1000 |   | 2,104.77 | 16.06151 | 3,984 | 0.006788 |   |   | 2,152.59 | 48.63315 | 3,984 | 0.006835
5.3% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.take |   | 10000 |   | 3,404.51 | 348.5091 | 5,488 | 0.010554 |   |   | 3,223.87 | 24.15852 | 5,488 | 0.010411
-- | -- | scala.collection.immutable.RedBlackTreeBenchmark.transformAll |   | 0 |   | 5.72 | 0.063796 | 0 | 0.000018 |   |   | 5.81 | 0.41977 | 0 | 0.000018
1.7% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.transformAll |   | 1 |   | 24.65 | 3.045155 | 68 | 10.69098 |   |   | 24.23 | 2.666103 | 68 | 10.69098
2.5% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.transformAll |   | 10 |   | 163.11 | 14.0188 | 368 | 0.000514 |   |   | 159.00 | 1.422968 | 368 | 0.000514
-9.3% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.transformAll |   | 100 |   | 1,469.90 | 8.780568 | 3,224 | 0.004786 |   |   | 1,605.89 | 173.8077 | 3,224 | 0.005376
-27.1% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.transformAll |   | 1000 |   | 17,227.12 | 1172.453 | 46,008 | 0.054397 |   |   | 21,896.07 | 2479.308 | 46,008 | 0.07008
-9.2% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.transformAll |   | 10000 |   | 186,736.83 | 18404.35 | 478,029 | 6.674122 |   |   | 203,840.11 | 18541.77 | 478,023 | 10.47721
-- | -- | scala.collection.immutable.RedBlackTreeBenchmark.transformHalf |   | 0 |   | 5.69 | 0.015826 | 0 | 0.000018 |   |   | 5.68 | 0.062737 | 0 | 0.000019
0.4% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.transformHalf |   | 1 |   | 22.08 | 0.142835 | 56 | 0.000072 |   |   | 21.99 | 0.240366 | 56 | 0.000071
-7.9% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.transformHalf |   | 10 |   | 157.91 | 1.072024 | 312 | 0.000509 |   |   | 170.37 | 18.62417 | 312 | 0.000509
-4.4% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.transformHalf |   | 100 |   | 1,606.23 | 12.06028 | 3,192 | 0.005256 |   |   | 1,676.80 | 172.4871 | 3,192 | 0.005116
6.3% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.transformHalf |   | 1000 |   | 19,127.79 | 2091.894 | 46,008 | 0.06811 |   |   | 17,932.04 | 268.8382 | 46,008 | 0.058866
0.1% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.transformHalf |   | 10000 |   | 184,722.88 | 1260.059 | 478,028 | 8.198893 |   |   | 184,544.60 | 1844.414 | 478,028 | 7.350361
-- | -- | scala.collection.immutable.RedBlackTreeBenchmark.transformNone |   | 0 |   | 5.71 | 0.035025 | 0 | 0.000018 |   |   | 5.66 | 0.023039 | 0 | 0.000018
6.0% | -- | scala.collection.immutable.RedBlackTreeBenchmark.transformNone |   | 1 |   | 14.04 | 1.131115 | 0 | 0.000043 |   |   | 13.19 | 0.042261 | 0 | 0.000043
3.3% | -- | scala.collection.immutable.RedBlackTreeBenchmark.transformNone |   | 10 |   | 82.12 | 2.558764 | 0 | 0.000269 |   |   | 79.41 | 0.344831 | 0 | 0.000258
3.3% | -- | scala.collection.immutable.RedBlackTreeBenchmark.transformNone |   | 100 |   | 824.12 | 49.58159 | 0 | 0.002724 |   |   | 796.83 | 1.977807 | 0 | 0.002578
-0.5% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.transformNone |   | 1000 |   | 16,939.29 | 131.4244 | 41,928 | 0.055103 |   |   | 17,030.49 | 272.6418 | 41,928 | 0.055053
2.1% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.transformNone |   | 10000 |   | 186,327.86 | 4533.88 | 473,948 | 7.261573 |   |   | 182,327.26 | 1026.298 | 473,949 | 6.967821
0.3% | -- | scala.collection.immutable.RedBlackTreeBenchmark.union |   | 0 |   | 40.21 | 0.110245 | 0 | 0.00013 |   |   | 40.08 | 0.456815 | 0 | 0.000129
-0.1% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.union |   | 1 |   | 74.58 | 0.600787 | 136 | 0.000239 |   |   | 74.65 | 0.426319 | 136 | 0.000241
-0.9% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.union |   | 10 |   | 1,433.75 | 9.757475 | 3,064 | 0.004591 |   |   | 1,446.31 | 22.11076 | 3,064 | 0.004653
1.0% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.union |   | 100 |   | 10,097.35 | 104.2148 | 20,280 | 0.032654 |   |   | 9,998.42 | 75.40598 | 20,280 | 0.032462
-3.2% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.union |   | 1000 |   | 49,155.70 | 479.3275 | 105,048 | 0.159024 |   |   | 50,728.54 | 3079.929 | 105,048 | 0.161165
-4.7% | 0.0% | scala.collection.immutable.RedBlackTreeBenchmark.union |   | 10000 |   | 412,430.76 | 25949.57 | 766,385 | 1.298382 |   |   | 431,970.93 | 55283.5 | 766,385 | 1.301254
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 0 | 0 |   | 4.62 | 0.148608 | 0 | 0.000015 |   |   | 4.62 | 0.099735 | 0 | 0.000015
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 0 | 1 |   | 4.58 | 0.060411 | 0 | 0.000015 |   |   | 4.59 | 0.231984 | 0 | 0.000015
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 0 | 10 |   | 4.56 | 0.025154 | 0 | 0.000015 |   |   | 4.56 | 0.105703 | 0 | 0.000015
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 0 | 100 |   | 4.66 | 0.234951 | 0 | 0.000015 |   |   | 4.54 | 0.029461 | 0 | 0.000015
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 0 | 1000 |   | 4.58 | 0.035641 | 0 | 0.000015 |   |   | 4.86 | 0.488343 | 0 | 0.000017
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 0 | 10000 |   | 4.80 | 0.40955 | 0 | 0.000015 |   |   | 4.55 | 0.049032 | 0 | 0.000015
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 1 | 1 |   | 5.35 | 0.018632 | 0 | 0.000017 |   |   | 5.48 | 0.204312 | 0 | 0.000018
1.9% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 1 | 10 |   | 115.60 | 1.070706 | 112 | 0.000378 |   |   | 113.39 | 2.350418 | 112 | 0.000371
1.7% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 1 | 100 |   | 357.01 | 4.521881 | 160 | 0.001162 |   |   | 350.90 | 1.682702 | 160 | 0.001149
-4.3% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 1 | 1000 |   | 801.91 | 10.95211 | 208 | 0.002629 |   |   | 836.57 | 93.80863 | 208 | 0.002613
7.9% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 1 | 10000 |   | 1,387.17 | 149.7935 | 272 | 0.004315 |   |   | 1,277.23 | 6.253419 | 272 | 0.004186
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 10 | 1 |   | 5.35 | 0.054922 | 0 | 0.000017 |   |   | 5.31 | 0.022461 | 0 | 0.000017
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 10 | 10 |   | 5.38 | 0.066195 | 0 | 0.000018 |   |   | 5.39 | 0.275168 | 0 | 0.000017
1.6% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 10 | 100 |   | 678.99 | 8.36218 | 160 | 0.002207 |   |   | 668.46 | 3.296927 | 160 | 0.002179
-0.4% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 10 | 1000 |   | 2,614.04 | 10.26384 | 208 | 0.008616 |   |   | 2,624.19 | 205.7042 | 208 | 0.008224
2.8% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 10 | 10000 |   | 7,677.28 | 396.491 | 272 | 0.024607 |   |   | 7,463.83 | 155.0543 | 272 | 0.025625
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 0 | 0 |   | 4.56 | 0.010759 | 0 | 0.000015 |   |   | 4.59 | 0.143459 | 0 | 0.000015
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 0 | 1 |   | 4.63 | 0.108007 | 0 | 0.000015 |   |   | 4.61 | 0.257532 | 0 | 0.000015
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 0 | 10 |   | 4.65 | 0.224017 | 0 | 0.000015 |   |   | 4.55 | 0.049228 | 0 | 0.000015
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 0 | 100 |   | 4.87 | 0.354993 | 0 | 0.000016 |   |   | 4.54 | 0.022175 | 0 | 0.000015
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 0 | 1000 |   | 4.58 | 0.040443 | 0 | 0.000015 |   |   | 4.88 | 0.484326 | 0 | 0.000017
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 0 | 10000 |   | 4.56 | 0.028131 | 0 | 0.000015 |   |   | 4.59 | 0.112858 | 0 | 0.000015
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 1 | 1 |   | 5.42 | 0.095781 | 0 | 0.000018 |   |   | 5.30 | 0.017833 | 0 | 0.000017
-8.0% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 1 | 10 |   | 115.01 | 2.099961 | 112 | 0.000378 |   |   | 124.17 | 12.78875 | 112 | 0.000407
0.7% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 1 | 100 |   | 356.84 | 2.137375 | 160 | 0.001164 |   |   | 354.32 | 2.989299 | 160 | 0.001153
5.7% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 1 | 1000 |   | 895.01 | 85.36013 | 208 | 0.002782 |   |   | 843.80 | 5.212091 | 208 | 0.002787
-0.7% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 1 | 10000 |   | 1,301.60 | 113.426 | 272 | 0.004112 |   |   | 1,310.81 | 97.43093 | 272 | 0.004247
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 10 | 1 |   | 5.34 | 0.01965 | 0 | 0.000017 |   |   | 5.32 | 0.023946 | 0 | 0.000017
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 10 | 10 |   | 5.37 | 0.057636 | 0 | 0.000017 |   |   | 6.09 | 1.30963 | 0 | 0.000018
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 10 | 100 |   | 5.33 | 0.015121 | 0 | 0.000017 |   |   | 5.31 | 0.017931 | 0 | 0.000017
-- | -- | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 10 | 1000 |   | 5.83 | 0.724715 | 0 | 0.000018 |   |   | 5.32 | 0.03029 | 0 | 0.000017
-3.5% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 10 | 10000 |   | 7,393.24 | 53.85461 | 272 | 0.024028 |   |   | 7,650.90 | 310.9755 | 272 | 0.025037
6.6% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsUnsharedBenchmark.mapEqualsOther |   | 10 |   | 132.67 | 16.40566 | 112 | 0.000404 |   |   | 123.92 | 1.057405 | 112 | 0.000408
-4.0% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsUnsharedBenchmark.mapEqualsOther |   | 100 |   | 754.30 | 20.07831 | 160 | 0.002458 |   |   | 784.46 | 48.71371 | 160 | 0.002493
0.4% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsUnsharedBenchmark.mapEqualsOther |   | 1000 |   | 9,899.60 | 78.95526 | 208 | 0.031977 |   |   | 9,855.47 | 52.16632 | 208 | 0.032066
5.4% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsUnsharedBenchmark.mapEqualsOther |   | 10000 |   | 610,804.25 | 65131.8 | 305 | 2.009436 |   |   | 577,785.29 | 26335.33 | 305 | 1.854856
-3.2% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsUnsharedBenchmark.setEqualsOther |   | 10 |   | 116.03 | 2.789383 | 112 | 0.00038 |   |   | 119.80 | 1.012486 | 112 | 0.000392
0.2% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsUnsharedBenchmark.setEqualsOther |   | 100 |   | 763.11 | 2.903094 | 160 | 0.002493 |   |   | 761.89 | 9.876364 | 160 | 0.002497
2.2% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsUnsharedBenchmark.setEqualsOther |   | 1000 |   | 8,597.80 | 120.1942 | 208 | 0.027869 |   |   | 8,408.32 | 71.99191 | 208 | 0.027659
4.2% | 0.0% | scala.collection.immutable.RedBlackTreeEqualsUnsharedBenchmark.setEqualsOther |   | 10000 |   | 591,799.66 | 14039.47 | 305 | 1.919905 |   |   | 566,790.20 | 14056.46 | 305 | 1.868437
2.7% | 0.0% | scala.collection.immutable.TreeMapBenchmark.builderPlus |   |   |   | 306.08 | 2.439162 | 483 | 0.000999 |   |   | 297.94 | 2.624058 | 483 | 0.000967
0.7% | 0.0% | scala.collection.immutable.TreeMapBenchmark.builderPlusPlusDifferntValues |   |   |   | 1,010,599.12 | 53043.41 | 1,221,090 | 3.305777 |   |   | 1,003,491.34 | 60567.46 | 1,221,090 | 3.292324
2.7% | 0.0% | scala.collection.immutable.TreeMapBenchmark.builderPlusPlusInitial |   |   |   | 343,110.71 | 6100.726 | 524,993 | 1.130152 |   |   | 333,952.44 | 2376.374 | 524,993 | 1.098416
5.6% | 0.0% | scala.collection.immutable.TreeMapBenchmark.builderPlusPlusInitialHash |   |   |   | 369,257.50 | 2708.557 | 379,073 | 1.221027 |   |   | 348,547.70 | 5181.497 | 379,073 | 1.140073
4.8% | 0.0% | scala.collection.immutable.TreeMapBenchmark.builderPlusPlusLargeLarge |   |   |   | 675,556.85 | 54292.73 | 936,817 | 2.195171 |   |   | 642,934.94 | 8201.858 | 936,817 | 2.094576
1.6% | 0.0% | scala.collection.immutable.TreeMapBenchmark.builderPlusPlusLargeLargeHash |   |   |   | 723,770.11 | 7971.674 | 912,817 | 2.362418 |   |   | 712,441.92 | 9072.799 | 912,817 | 2.334777
2.9% | 0.0% | scala.collection.immutable.TreeMapBenchmark.builderPlusPlusLargeSmall |   |   |   | 374,933.48 | 2497.965 | 528,369 | 1.216228 |   |   | 364,087.29 | 2928.148 | 528,369 | 1.191054
23.9% | 37.1% | scala.collection.immutable.TreeMapBenchmark.builderPlusPlusSame |   |   |   | 689,121.76 | 35229.92 | 873,041 | 2.256428 |   |   | 524,247.86 | 3834.976 | 549,009 | 1.69756
12.4% | 38.2% | scala.collection.immutable.TreeMapBenchmark.builderPlusPlusSameHash |   |   |   | 697,299.52 | 11040.79 | 849,041 | 2.249845 |   |   | 610,930.00 | 66657.67 | 525,009 | 2.13216
8.9% | 0.0% | scala.collection.immutable.TreeMapBenchmark.builderPlusPlusSmallLarge |   |   |   | 405,431.67 | 48518.7 | 526,737 | 1.429586 |   |   | 369,267.06 | 8629.391 | 526,737 | 1.196517
3.6% | 0.0% | scala.collection.immutable.TreeMapBenchmark.builderPlusPlusSmallLargeHash |   |   |   | 397,196.05 | 3861.16 | 385,521 | 1.322489 |   |   | 382,766.22 | 4360.392 | 385,521 | 1.265116
0.3% | 0.0% | scala.collection.immutable.TreeMapBenchmark.plusPlus |   |   |   | 152,654.25 | 1500.965 | 264,240 | 0.498578 |   |   | 152,183.82 | 1330.674 | 264,240 | 0.494188
3.6% | 0.0% | scala.collection.immutable.TreeSetBenchmark.builderPlus |   |   |   | 299.31 | 2.401155 | 459 | 0.000981 |   |   | 288.62 | 2.126404 | 459 | 0.00093
-- | 0.0% | scala.collection.immutable.TreeSetBenchmark.builderPlusPlusInitial |   |   |   | 9.14 | 0.135115 | 24 | 0.000029 |   |   | 9.59 | 0.974516 | 24 | 0.000033
9.6% | 0.0% | scala.collection.immutable.TreeSetBenchmark.builderPlusPlusInitialHash |   |   |   | 381,221.29 | 31754.38 | 358,177 | 1.184208 |   |   | 344,586.97 | 13342.42 | 358,177 | 1.112737
3.5% | 0.0% | scala.collection.immutable.TreeSetBenchmark.builderPlusPlusLargeLarge |   |   |   | 156,140.45 | 7956.685 | 264,276 | 46.82502 |   |   | 150,708.39 | 819.1756 | 264,264 | 0.498127
2.2% | 0.0% | scala.collection.immutable.TreeSetBenchmark.builderPlusPlusLargeLargeHash |   |   |   | 355,278.67 | 3583.093 | 361,857 | 1.164918 |   |   | 347,550.62 | 3741.558 | 361,857 | 1.143008
-0.6% | -0.1% | scala.collection.immutable.TreeSetBenchmark.builderPlusPlusLargeSmall |   |   |   | 5,022.45 | 54.07135 | 9,868 | 10.69106 |   |   | 5,052.54 | 260.4248 | 9,880 | 0.016159
0.0% | 0.0% | scala.collection.immutable.TreeSetBenchmark.builderPlusPlusSame |   |   |   | 35,300.17 | 2332.904 | 63,096 | 0.134309 |   |   | 35,282.56 | 2383.225 | 63,096 | 0.11205
34.9% | 100.0% | scala.collection.immutable.TreeSetBenchmark.builderPlusPlusSameHash |   |   |   | 286,830.06 | 3375.954 | 265,984 | 0.927461 |   |   | 186,609.35 | 1901.334 | 64 | 0.605157
1.1% | 0.0% | scala.collection.immutable.TreeSetBenchmark.builderPlusPlusSmallLarge |   |   |   | 5,859.98 | 48.53319 | 12,576 | 0.019143 |   |   | 5,793.76 | 83.56547 | 12,576 | 0.018905
10.5% | 0.6% | scala.collection.immutable.TreeSetBenchmark.builderPlusPlusSmallLargeHash |   |   |   | 384,073.14 | 36496.23 | 359,137 | 1.221056 |   |   | 343,801.91 | 3778.503 | 357,025 | 1.129038
1.8% | 0.0% | scala.collection.immutable.TreeSetBenchmark.plusPlus |   |   |   | 154,558.35 | 6649.057 | 264,240 | 0.561493 |   |   | 151,700.87 | 1300.852 | 264,240 | 0.50122

