### PR TITLE
Check for null on `getSystemJavaCompiler`

### DIFF
--- a/src/testkit/scala/tools/testkit/VirtualCompilerTesting.scala
+++ b/src/testkit/scala/tools/testkit/VirtualCompilerTesting.scala
@@ -30,7 +30,8 @@ import scala.tools.nsc.{Global, Settings}
   */
 class VirtualCompiler {
   /** A java compiler instance that we can use. */
-  lazy val javac = ToolProvider.getSystemJavaCompiler
+  lazy val javac = Option(ToolProvider.getSystemJavaCompiler)
+                   .getOrElse(throw new UnsupportedOperationException("No java compiler found in current Java runtime"))
 
   /** The directory in which are placed classfiles. */
   lazy val output = new VirtualDirectory("out", maybeContainer = None)

--- a/test/junit/scala/tools/nsc/DeterminismTest.scala
+++ b/test/junit/scala/tools/nsc/DeterminismTest.scala
@@ -299,6 +299,7 @@ class DeterminismTest {
           }
           val options = List("-d", output.toString)
           val javac = ToolProvider.getSystemJavaCompiler
+          assert(javac != null, "No javac from getSystemJavaCompiler. If the java on your path isn't a JDK version, but $JAVA_HOME is, launch sbt with --java-home \"$JAVA_HOME\"")
           val fileMan = javac.getStandardFileManager(null, null, null)
           val javaFileObjects = fileMan.getJavaFileObjects(javaSources.map(s => tempFileFor(s).toAbsolutePath.toString): _*)
           val task = javac.getTask(new OutputStreamWriter(System.out), fileMan, null, options.asJava, Nil.asJava, javaFileObjects)


### PR DESCRIPTION
Throw UnsupportedOperationException when getSystemJavaCompiler returns null to be a bit clearer in signalling what the problem is. AKA "At least it's not a NRE"

Small boyscout DRYup in `PipelineMain`

Arguably `sbt` should launch with which JDK_HOME/java orElse JAVA_HOME/java orElse path/java, but that's a different story.

cc @dwijnand 