### PR TITLE
Trailing comma is parsed

### DIFF
--- a/test/files/neg/quasiquotes-syntax-error-position.check
+++ b/test/files/neg/quasiquotes-syntax-error-position.check
@@ -1,7 +1,7 @@
 quasiquotes-syntax-error-position.scala:5: error: '=' expected but identifier found.
   q"def $a f"
            ^
-quasiquotes-syntax-error-position.scala:6: error: illegal start of simple expression
+quasiquotes-syntax-error-position.scala:6: error: ')' expected but end of quote found.
   q"$a("
        ^
 quasiquotes-syntax-error-position.scala:7: error: '}' expected but end of quote found.
@@ -31,7 +31,7 @@ quasiquotes-syntax-error-position.scala:14: error: ')' expected but end of quote
 quasiquotes-syntax-error-position.scala:15: error: ':' expected but ')' found.
   q"def foo(x)"
              ^
-quasiquotes-syntax-error-position.scala:16: error: illegal start of simple expression
+quasiquotes-syntax-error-position.scala:16: error: ')' expected but ']' found.
   q"$a(])"
        ^
 quasiquotes-syntax-error-position.scala:17: error: in XML literal: '>' expected instead of '$'

--- a/test/files/neg/t11900.check
+++ b/test/files/neg/t11900.check
@@ -1,0 +1,13 @@
+t11900.scala:35: error: ';' expected but ',' found.
+      a => a + 1,   // error: weird comma
+                ^
+t11900.scala:39: error: ';' expected but ',' found.
+    println("a"),   // error: weird comma
+                ^
+t11900.scala:43: error: ';' expected but ',' found.
+    println("b"),   // error: weird comma
+                ^
+t11900.scala:55: error: bad simple pattern: bad use of _* (a sequence pattern must be the last pattern)
+        _*,
+          ^
+4 errors

--- a/test/files/neg/t11900.scala
+++ b/test/files/neg/t11900.scala
@@ -1,0 +1,70 @@
+
+trait t11900 {
+  // cf pos/trailing-commas
+  //
+  import scala.collection.{
+    immutable,
+    mutable,
+  }
+
+  def h[A,
+       ]: List[A] = Nil
+
+  def g = List(
+    1,
+    2,
+    3,
+  )
+
+  def star =
+    List(1, 2, 3, 4, 5) match {
+      case List(
+        1,
+        2,
+        3,
+      ) => false
+      case List(
+        1,
+        2,
+        _*,
+      ) => true
+    }
+
+  def f =
+    List(1, 2, 3).map {
+      a => a + 1,   // error: weird comma
+    }
+
+  class A() {
+    println("a"),   // error: weird comma
+  }
+
+  def b() = {
+    println("b"),   // error: weird comma
+  }
+
+  def starcrossed =
+    List(1, 2, 3, 4, 5) match {
+      case List(
+        1,
+        2,
+        3,
+      ) => false
+      case List(
+        1,
+        _*,
+        2,
+      ) => true
+    }
+
+  def p(p: (Int,
+            String,
+           )
+       ): Unit
+
+  def q: (Int,
+          String,
+         )
+
+  val z = 42
+}


### PR DESCRIPTION
Instead of taking any old comma in scanner, let parser
target when skipping a trailing comma makes sense.

Bring the implementation closer to the SIP.

Fixes scala/bug#11900