### PR TITLE
Parse annotation in jointly compiled Java source files and honour @Deprecated

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -95,6 +95,23 @@ trait ParsersCommon extends ScannersCommon { self =>
      */
     @inline final def makeParens(body: => List[Tree]): Parens =
       Parens(inParens(if (in.token == RPAREN) Nil else body))
+
+    /** {{{ part { `sep` part } }}}, or if sepFirst is true, {{{ { `sep` part } }}}. */
+    final def tokenSeparated[T](separator: Token, sepFirst: Boolean, part: => T): List[T] = {
+      val ts = new ListBuffer[T]
+      if (!sepFirst)
+        ts += part
+
+      while (in.token == separator) {
+        in.nextToken()
+        ts += part
+      }
+      ts.toList
+    }
+
+    /** {{{ tokenSeparated }}}, with the separator fixed to commas. */
+    @inline final def commaSeparated[T](part: => T): List[T] =
+      tokenSeparated(COMMA, sepFirst = false, part)
   }
 }
 
@@ -791,20 +808,6 @@ self =>
         errorTypeTree
       }
     }
-
-    /** {{{ part { `sep` part } }}},or if sepFirst is true, {{{ { `sep` part } }}}. */
-    final def tokenSeparated[T](separator: Token, sepFirst: Boolean, part: => T): List[T] = {
-      val ts = new ListBuffer[T]
-      if (!sepFirst)
-        ts += part
-
-      while (in.token == separator) {
-        in.nextToken()
-        ts += part
-      }
-      ts.toList
-    }
-    @inline final def commaSeparated[T](part: => T): List[T] = tokenSeparated(COMMA, sepFirst = false, part)
     @inline final def caseSeparated[T](part: => T): List[T] = tokenSeparated(CASE, sepFirst = true, part)
     def readAnnots(part: => Tree): List[Tree] = tokenSeparated(AT, sepFirst = true, part)
 

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -40,6 +40,9 @@ trait ScannersCommon {
   }
 
   trait ScannerCommon extends CommonTokenData {
+    /** Consume and discard the next token. */
+    def nextToken(): Unit
+
     // things to fill in, in addition to buf, decodeUni which come from CharArrayReader
     def error(off: Offset, msg: String): Unit
     def incompleteInputError(off: Offset, msg: String): Unit

--- a/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
@@ -52,12 +52,13 @@ trait JavaScanners extends ast.parser.ScannersCommon {
     /** the base of a number */
     var base: Int = 0
 
-    def copyFrom(td: JavaTokenData) = {
+    def copyFrom(td: JavaTokenData): this.type = {
       this.token = td.token
       this.pos = td.pos
       this.lastPos = td.lastPos
       this.name = td.name
       this.base = td.base
+      this
     }
   }
 

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -821,11 +821,9 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
           in.skip(attrLen)
 
         case tpnme.DeprecatedATTR =>
-          val arg = Literal(Constant("see corresponding Javadoc for more information."))
-          sym.addAnnotation(DeprecatedAttr, arg, Literal(Constant("")))
           in.skip(attrLen)
           if (sym == clazz)
-            staticModule.addAnnotation(DeprecatedAttr, arg, Literal(Constant("")))
+            staticModule.addAnnotation(JavaDeprecatedAttr)
 
         case tpnme.ConstantValueATTR =>
           completer.constant = pool.getConstant(u2)

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -851,8 +851,15 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
 
         case tpnme.RuntimeAnnotationATTR =>
           val numAnnots = u2
+          val annots = new ListBuffer[AnnotationInfo]
           for (n <- 0 until numAnnots; annot <- parseAnnotation(u2))
-            sym.addAnnotation(annot)
+            annots += annot
+          /* `sym.withAnnotations(annots)`, like `sym.addAnnotation(annot)`, prepends,
+           * so if we parsed in classfile order we would wind up with the annotations
+           * in reverse order in `sym.annotations`. Instead we just read them out the
+           * other way around, for now. TODO: sym.addAnnotation add to the end?
+           */
+          sym.setAnnotations(sym.annotations ::: annots.toList)
 
         // TODO 1: parse runtime visible annotations on parameters
         // case tpnme.RuntimeParamAnnotationATTR

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1369,7 +1369,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     val symbols =
       Set(UnitClass, BooleanClass, ByteClass,
           ShortClass, IntClass, LongClass, FloatClass,
-          DoubleClass, NilModule, ListClass) ++ TupleClass.seq
+          DoubleClass, NilModule, ListClass, PredefModule) ++ TupleClass.seq ++ ArrayModule_overloadedApply.alternatives
     symbols.foreach(_.initialize)
   }
 

--- a/src/partest-extras/scala/tools/partest/BytecodeTest.scala
+++ b/src/partest-extras/scala/tools/partest/BytecodeTest.scala
@@ -124,6 +124,10 @@ abstract class BytecodeTest {
   }
 
 // loading
+  protected def getField(classNode: ClassNode, name: String): FieldNode =
+    classNode.fields.asScala.find(_.name == name) getOrElse
+      sys.error(s"Didn't find field '$name' in class '${classNode.name}'")
+
   protected def getMethod(classNode: ClassNode, name: String): MethodNode =
     classNode.methods.asScala.find(_.name == name) getOrElse
       sys.error(s"Didn't find method '$name' in class '${classNode.name}'")

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1200,6 +1200,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val UncheckedBoundsClass       = getClassIfDefined("scala.reflect.internal.annotations.uncheckedBounds")
     lazy val UnspecializedClass         = requiredClass[scala.annotation.unspecialized]
     lazy val VolatileAttr               = requiredClass[scala.volatile]
+    lazy val JavaDeprecatedAttr         = requiredClass[java.lang.Deprecated]
     lazy val FunctionalInterfaceClass   = requiredClass[java.lang.FunctionalInterface]
 
     // Meta-annotations

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -904,7 +904,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isStrictFP: Boolean    = !isDeferred && (hasAnnotation(ScalaStrictFPAttr) || originalOwner.isStrictFP)
     def isSerializable         = info.baseClasses.exists(p => p == SerializableClass || p == JavaSerializableClass)
     def hasBridgeAnnotation    = hasAnnotation(BridgeClass)
-    def isDeprecated           = hasAnnotation(DeprecatedAttr)
+    def isDeprecated           = hasAnnotation(DeprecatedAttr) || (isJava && hasAnnotation(JavaDeprecatedAttr))
     def deprecationMessage     = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 0)
     def deprecationVersion     = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 1)
     def deprecatedParamName    = getAnnotation(DeprecatedNameAttr) flatMap (_ symbolArg 0 orElse Some(nme.NO_NAME))

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -428,6 +428,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.UncheckedBoundsClass
     definitions.UnspecializedClass
     definitions.VolatileAttr
+    definitions.JavaDeprecatedAttr
     definitions.FunctionalInterfaceClass
     definitions.BeanGetterTargetClass
     definitions.BeanSetterTargetClass

--- a/test/files/jvm/deprecation.check
+++ b/test/files/jvm/deprecation.check
@@ -1,3 +1,2 @@
-warning: there were four deprecation warnings; re-run with -deprecation for details
 Note: deprecation/Use_2.java uses or overrides a deprecated API.
 Note: Recompile with -Xlint:deprecation for details.

--- a/test/files/neg/t9617.check
+++ b/test/files/neg/t9617.check
@@ -1,7 +1,7 @@
-Test_2.scala:2: warning: class DeprecatedClass in package p1 is deprecated
+Test.scala:3: warning: class DeprecatedClass in package p1 is deprecated
   def useC = p1.DeprecatedClass.foo
                 ^
-Test_2.scala:3: warning: method foo in class DeprecatedMethod is deprecated
+Test.scala:4: warning: method foo in class DeprecatedMethod is deprecated
   def useM = p1.DeprecatedMethod.foo
                                  ^
 error: No warnings can be incurred under -Xfatal-warnings.

--- a/test/files/neg/t9617/DeprecatedClass.java
+++ b/test/files/neg/t9617/DeprecatedClass.java
@@ -1,0 +1,6 @@
+package p1;
+
+@Deprecated
+public class DeprecatedClass {
+  public static void foo() {}
+}

--- a/test/files/neg/t9617/DeprecatedMethod.java
+++ b/test/files/neg/t9617/DeprecatedMethod.java
@@ -1,0 +1,6 @@
+package p1;
+
+public class DeprecatedMethod {
+  @Deprecated
+  public static void foo() {}
+}

--- a/test/files/neg/t9617/Test.flags
+++ b/test/files/neg/t9617/Test.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings -deprecation

--- a/test/files/neg/t9617/Test.scala
+++ b/test/files/neg/t9617/Test.scala
@@ -1,0 +1,5 @@
+// Joint-compilation copy of test/files/neg/t10752/Test_2.scala
+object Test {
+  def useC = p1.DeprecatedClass.foo
+  def useM = p1.DeprecatedMethod.foo
+}

--- a/test/files/presentation/parse-invariants/src/a/A.java
+++ b/test/files/presentation/parse-invariants/src/a/A.java
@@ -1,5 +1,10 @@
 package syntax;
 
+@NoArgs
+@Empty()
+@Simple(n = 1, c = '2', f = 6.7f, d = 8.9, s = "t", z = A.class, e = P.Pluto, a = @C.I("t"))
+@Arrays({ @Array({0, 1, C._2}), @Array(3) })
+@Deprecated
 class A {
   transient volatile int x;
   strictfp void test() {
@@ -11,6 +16,7 @@ class A {
 
   void thrower() throws Throwable {}
 
+  @Deprecated void deprecated() {}
 }
 
 strictfp class B {}

--- a/test/files/run/t4788-separate-compilation.check
+++ b/test/files/run/t4788-separate-compilation.check
@@ -1,5 +1,9 @@
 Some(@Ljava/lang/Deprecated;())
 None
-Some(@LSAnnotation;())
-Some(@LCAnnotation;())
+None
+Some(@LCAnnotation;() // invisible)
 Some(@LRAnnotation;())
+Some(@LArgs_0$Ann;(value="a") // invisible)
+Some(@LArgs_0$Ann;(value="ab") // invisible)
+Some(@LArgs_0$Ann;(value="konst") // invisible)
+Some(@LArgs_0$Ann;(value="nokst") // invisible)

--- a/test/files/run/t4788-separate-compilation/Args_0.java
+++ b/test/files/run/t4788-separate-compilation/Args_0.java
@@ -1,0 +1,13 @@
+public class Args_0 {
+  public static @interface Ann {
+    String value();
+  }
+
+  public static final String konst = "konst";
+  public static final String nokst = "no" + "kst";
+
+  @Ann("a")          public static int x1 = 0; // parsed
+  @Ann(Args_0.konst) public static int x3 = 0; // parsed
+  @Ann("a" + "b")    public static int x2 = 0; // dropped
+  @Ann(Args_0.nokst) public static int x4 = 0; // dropped (error w/ type-checking)
+}

--- a/test/files/run/t4788-separate-compilation/Test_2.scala
+++ b/test/files/run/t4788-separate-compilation/Test_2.scala
@@ -18,6 +18,19 @@ object Test extends BytecodeTest {
       .map(_.trim)
   }
 
+  def annotationsForField(className: String, fieldName: String): Option[String] = {
+    val field = getField(loadClassNode(className, skipDebugInfo = false), fieldName)
+    val textifier = new Textifier
+    field.accept(new TraceClassVisitor(null, textifier, null))
+
+    val fieldString = stringFromWriter(w => textifier.print(w))
+    fieldString
+        .split('\n')
+        .filterNot(_.contains("@Lscala/reflect/ScalaSignature"))
+        .find(_.contains("@L"))
+        .map(_.trim)
+  }
+
   def show {
     // It seems like @java.lang.Deprecated shows up in both the
     // Deprecated attribute and RuntimeVisibleAnnotation attribute,
@@ -31,5 +44,12 @@ object Test extends BytecodeTest {
     println(annotationsForClass("S"))
     println(annotationsForClass("C"))
     println(annotationsForClass("R"))
+
+    println(annotationsForField("Args_0", "x1"))
+    println(annotationsForField("Args_0", "x2"))
+    println(annotationsForField("Args_0", "x3"))
+    println(annotationsForField("Args_0", "x4"))
+
+    Seq(Args_0.x1, Args_0.x2, Args_0.x3, Args_0.x4) // refer the values with annotations
   }
 }

--- a/test/files/run/t4788.check
+++ b/test/files/run/t4788.check
@@ -1,5 +1,9 @@
 Some(@Ljava/lang/Deprecated;())
 None
-Some(@LSAnnotation;())
-Some(@LCAnnotation;())
+None
+Some(@LCAnnotation;() // invisible)
 Some(@LRAnnotation;())
+Some(@LArgs$Ann;(value="a") // invisible)
+Some(@LArgs$Ann;(value="ab") // invisible)
+Some(@LArgs$Ann;(value="konst") // invisible)
+Some(@LArgs$Ann;(value="nokst") // invisible)

--- a/test/files/run/t4788/Args.java
+++ b/test/files/run/t4788/Args.java
@@ -1,0 +1,13 @@
+public class Args {
+  public static @interface Ann {
+    String value();
+  }
+
+  public static final String konst = "konst";
+  public static final String nokst = "no" + "kst";
+
+  @Ann("a")        public static int x1 = 0; // parsed
+  @Ann(Args.konst) public static int x3 = 0; // parsed
+  @Ann("a" + "b")  public static int x2 = 0; // dropped
+  @Ann(Args.nokst) public static int x4 = 0; // dropped
+}

--- a/test/files/run/t4788/Test.scala
+++ b/test/files/run/t4788/Test.scala
@@ -18,6 +18,19 @@ object Test extends BytecodeTest {
       .map(_.trim)
   }
 
+  def annotationsForField(className: String, fieldName: String): Option[String] = {
+    val field = getField(loadClassNode(className, skipDebugInfo = false), fieldName)
+    val textifier = new Textifier
+    field.accept(new TraceClassVisitor(null, textifier, null))
+
+    val fieldString = stringFromWriter(w => textifier.print(w))
+    fieldString
+        .split('\n')
+        .filterNot(_.contains("@Lscala/reflect/ScalaSignature"))
+        .find(_.contains("@L"))
+        .map(_.trim)
+  }
+
   def show {
     // It seems like @java.lang.Deprecated shows up in both the
     // Deprecated attribute and RuntimeVisibleAnnotation attribute,
@@ -31,5 +44,12 @@ object Test extends BytecodeTest {
     println(annotationsForClass("S"))
     println(annotationsForClass("C"))
     println(annotationsForClass("R"))
+
+    println(annotationsForField("Args", "x1"))
+    println(annotationsForField("Args", "x2"))
+    println(annotationsForField("Args", "x3"))
+    println(annotationsForField("Args", "x4"))
+
+    Seq(Args.x1, Args.x2, Args.x3, Args.x4) // refer the values with annotations
   }
 }

--- a/test/files/run/t8928.javaopts
+++ b/test/files/run/t8928.javaopts
@@ -1,0 +1,1 @@
+-Dneeds.forked.jvm

--- a/test/files/run/t8928/Annotated_0.java
+++ b/test/files/run/t8928/Annotated_0.java
@@ -1,0 +1,19 @@
+package test;
+
+// This should stay in sync with Annotated_1 to test annotations defined in the same compilation run
+
+@NoArgs_0
+@Simple_0(_byte = 1, _char = '2', _short = Simple_0.THREE, _int = 4, _long = 5, _float = 6.7f, _double = 8.9, _string = "ten", _class = Object.class)
+@Nested_0(
+    inner = @Nested_0.Inner("turkey")
+)
+@Array_0.Repeated({
+        @Array_0({8, 6, 7, 5, 3, 0, Annotated_0.NINE}),
+        @Array_0(6)
+})
+@Enum_0(choice = Enum_0.Enum.ONE)
+@Empty_0()
+public class Annotated_0 {
+    public static final int NINE = 9;
+}
+

--- a/test/files/run/t8928/Annotated_1.java
+++ b/test/files/run/t8928/Annotated_1.java
@@ -1,0 +1,19 @@
+package test;
+
+// This should stay in sync with Annotated_0 to test annotations defined in an earlier compilation run
+
+@NoArgs_0
+@Simple_0(_byte = 1, _char = '2', _short = Simple_0.THREE, _int = 4, _long = 5, _float = 6.7f, _double = 8.9, _string = "ten", _class = Object.class)
+@Nested_0(
+    inner = @Nested_0.Inner("turkey")
+)
+@Array_0.Repeated({
+        @Array_0({8, 6, 7, 5, 3, 0, Annotated_1.NINE}),
+        @Array_0(6)
+})
+@Enum_0(choice = Enum_0.Enum.ONE)
+@Empty_0()
+public class Annotated_1 {
+    public static final int NINE = 9;
+}
+

--- a/test/files/run/t8928/Array_0.java
+++ b/test/files/run/t8928/Array_0.java
@@ -1,0 +1,14 @@
+package test;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(Array_0.Repeated.class)
+public @interface Array_0 {
+    int[] value();
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Repeated {
+        Array_0[] value();
+    }
+}

--- a/test/files/run/t8928/Checks_0.scala
+++ b/test/files/run/t8928/Checks_0.scala
@@ -1,0 +1,84 @@
+package test
+
+import reflect.api.Universe
+
+class Checks[U <: Universe with Singleton](val universe: U, ordered: Boolean) {
+  import universe._
+
+  def check(tpe: Type): Unit = {
+    val ObjectTpe = typeOf[Object]
+
+    def assertMatch(name: String, v: Tree)(pf: PartialFunction[Tree, Any]): Unit =
+      if (!pf.isDefinedAt(v)) throw new AssertionError(s"$name: ${showRaw(v)}")
+
+    val anns: List[Annotation] = tpe.typeSymbol.annotations
+
+    anns match {
+      case List(noArgs, simple, nested, arrays, enum, empty) =>
+        assert(noArgs.tree.tpe =:= typeOf[NoArgs_0])
+        assert(noArgs.tree.children.size == 1)
+
+        assert(simple.tree.tpe =:= typeOf[Simple_0])
+
+        val parameters: List[(String, Tree)] =
+          simple.tree.children.tail.map {
+            case AssignOrNamedArg(Ident(TermName(name)), value) =>
+              name -> value
+          }
+
+        /* Runtime reflection does not preserve ordering on java annotations,
+         * so check only when we're in a macro universe. */
+        if (ordered) {
+          assert(parameters.map(_._1) == List(
+            "_byte", "_char", "_short", "_int", "_long", "_float", "_double", "_string", "_class"))
+        }
+
+        parameters.sortBy(_._1) match {
+          case ("_byte", byte)     :: ("_char", char)
+            :: ("_class", clasz)   :: ("_double", double)
+            :: ("_float", float)   :: ("_int", int)
+            :: ("_long", long)     :: ("_short", short)
+            :: ("_string", string) :: Nil =>
+
+            assertMatch("byte", byte)     { case Literal(Constant(1))         =>  }
+            assertMatch("char", char)     { case Literal(Constant('2'))       =>  }
+            assertMatch("short", short)   { case Literal(Constant(3))         =>  }
+            assertMatch("int", int)       { case Literal(Constant(4))         =>  }
+            assertMatch("long", long)     { case Literal(Constant(5L))        =>  }
+            assertMatch("float", float)   { case Literal(Constant(6.7f))      =>  }
+            assertMatch("double", double) { case Literal(Constant(8.9d))      =>  }
+            assertMatch("string", string) { case Literal(Constant("ten"))     =>  }
+            assertMatch("class", clasz)   { case Literal(Constant(ObjectTpe)) =>  }
+        }
+
+        assert(nested.tree.tpe =:= typeOf[Nested_0])
+        nested.tree.children match {
+          case _ :: inner :: Nil =>
+            assertMatch("inner", inner) {
+              case AssignOrNamedArg(Ident(TermName("inner")), Apply(Select(New(tpe), nme.CONSTRUCTOR), AssignOrNamedArg(Ident(TermName("value")), Literal(Constant("turkey"))) :: Nil))
+                if tpe.tpe =:= typeOf[Nested_0.Inner] =>
+            }
+        }
+
+        assert(arrays.tree.tpe =:= typeOf[Array_0.Repeated])
+        arrays.tree.children match {
+          case _ :: AssignOrNamedArg(Ident(TermName("value")), Apply(arr, fst :: snd :: Nil)) :: Nil =>
+            assertMatch("value(0)", fst) {
+              case Apply(Select(New(tpe), nme.CONSTRUCTOR), AssignOrNamedArg(Ident(TermName("value")), Apply(arr, args)) :: Nil)
+                if ((args zip Seq(8, 6, 7, 5, 3, 0, 9)) forall { case (Literal(Constant(l)), r) => l == r }) &&
+                  tpe.tpe =:= typeOf[Array_0] =>
+            }
+            assertMatch("value(1)", snd) {
+              case Apply(Select(New(tpe), nme.CONSTRUCTOR), AssignOrNamedArg(Ident(TermName("value")), Apply(arr, args)) :: Nil)
+                if ((args zip Seq(6)) forall { case (Literal(Constant(l)), r) => l == r }) &&
+                  tpe.tpe =:= typeOf[Array_0] =>
+            }
+        }
+        assert(enum.tree.tpe =:= typeOf[Enum_0])
+
+        assert(empty.tree.tpe =:= typeOf[Empty_0])
+        assert(empty.tree.children.size == 1)
+    }
+  }
+
+}

--- a/test/files/run/t8928/Empty_0.java
+++ b/test/files/run/t8928/Empty_0.java
@@ -1,0 +1,7 @@
+package test;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Empty_0 {}

--- a/test/files/run/t8928/Enum_0.java
+++ b/test/files/run/t8928/Enum_0.java
@@ -1,0 +1,12 @@
+package test;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Enum_0 {
+    Enum choice();
+
+    public enum Enum {
+        ONE, OTHER
+    }
+}

--- a/test/files/run/t8928/Macros_0.scala
+++ b/test/files/run/t8928/Macros_0.scala
@@ -1,0 +1,16 @@
+package test
+
+object Macros {
+  import language.experimental.macros
+  def apply[T]: Unit = macro impl[T]
+
+  import reflect.macros.whitebox
+  def impl[T: c.WeakTypeTag](c: whitebox.Context): c.Tree = {
+    import c.universe._
+
+    new Checks[c.universe.type](c.universe, ordered = true)
+      .check(weakTypeOf[T])
+
+    Literal(Constant(()))
+  }
+}

--- a/test/files/run/t8928/Nested_0.java
+++ b/test/files/run/t8928/Nested_0.java
@@ -1,0 +1,13 @@
+package test;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Nested_0 {
+    Inner inner();
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Inner {
+        String value();
+    }
+}

--- a/test/files/run/t8928/NoArgs_0.java
+++ b/test/files/run/t8928/NoArgs_0.java
@@ -1,0 +1,7 @@
+package test;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoArgs_0 {}
+

--- a/test/files/run/t8928/Simple_0.java
+++ b/test/files/run/t8928/Simple_0.java
@@ -1,0 +1,18 @@
+package test;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Simple_0 {
+    byte _byte();
+    char _char();
+    short _short();
+    int _int();
+    long _long();
+    float _float();
+    double _double();
+    String _string();
+    Class<?> _class();
+
+    short THREE = 3;
+}

--- a/test/files/run/t8928/Test_1.scala
+++ b/test/files/run/t8928/Test_1.scala
@@ -1,0 +1,16 @@
+import test._
+
+object Test extends App {
+  Macros.apply[Annotated_0]
+  Macros.apply[Annotated_1]
+
+  import reflect.runtime.universe
+  import universe._
+
+  /* consistency check with runtime universe */
+  val checks = new Checks[universe.type](universe, ordered = false)
+  checks.check(weakTypeOf[Annotated_0])
+  checks.check(weakTypeOf[Annotated_1])
+
+
+}


### PR DESCRIPTION
Rebased (with a small merge conflict) @hrhino's work in #5892 & extended it to handle `@Deprecated`.

Fixes scala/bug#8928 ("Java parser skips over annotations"), though limited to no args annotations and annotations with literal arguments.
Fixes scala/bug#9617 ("Deprecations from Java may be not taken into account in mixed projects") which is the joint-compilation variant of scala/bug#10752 (which was just fixed).
Fixes scala/bug#8883 ("Treat java / scala deprecated annotations more uniformly") (IMO) with the deprecated attribute adding the java annotation & `Symbol#isDeprecated` considering both.