### PR TITLE
emit specific error for selftype annotations in parens

### DIFF
--- a/test/files/neg/t1565-alt.check
+++ b/test/files/neg/t1565-alt.check
@@ -1,0 +1,13 @@
+t1565-alt.scala:3: error: not a legal formal parameter.
+Note: Tuples cannot be directly destructured in method or function parameters.
+      Either create a single parameter accepting the Tuple1,
+      or consider a pattern matching anonymous function: `{ case (param1, param1) => ... }
+trait SelfFirst { (this: Int, that: Int) =>
+                       ^
+t1565-alt.scala:6: error: not a legal formal parameter.
+Note: Tuples cannot be directly destructured in method or function parameters.
+      Either create a single parameter accepting the Tuple1,
+      or consider a pattern matching anonymous function: `{ case (param1, param1) => ... }
+trait SelfSecond { (that: Int, this: Int) =>
+                                   ^
+2 errors

--- a/test/files/neg/t1565-alt.scala
+++ b/test/files/neg/t1565-alt.scala
@@ -1,0 +1,7 @@
+//No special error message for multiple parameters, it's not likely
+//that the user was trying to use a self-type
+trait SelfFirst { (this: Int, that: Int) =>
+}
+
+trait SelfSecond { (that: Int, this: Int) =>
+}

--- a/test/files/neg/t1565.check
+++ b/test/files/neg/t1565.check
@@ -1,0 +1,4 @@
+t1565.scala:1: error: self-type annotation may not be in parentheses
+trait HasSelf { (this: Forbidden) =>
+                ^
+1 error

--- a/test/files/neg/t1565.scala
+++ b/test/files/neg/t1565.scala
@@ -1,0 +1,2 @@
+trait HasSelf { (this: Forbidden) =>
+}


### PR DESCRIPTION
Fix conflicting assumptions about the what potentially can be on the lhs of => at the start of a template