### PR TITLE
Don't check key equality in RedBlackTree

### DIFF
--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -192,7 +192,7 @@ private[collection] object RedBlackTree {
     val cmp = ordering.compare(k, tree.key)
     if (cmp < 0) balanceLeft(isBlackTree(tree), tree.key, tree.value, upd(tree.left, k, v, overwrite), tree.right)
     else if (cmp > 0) balanceRight(isBlackTree(tree), tree.key, tree.value, tree.left, upd(tree.right, k, v, overwrite))
-    else if (overwrite || k != tree.key) mkTree(isBlackTree(tree), tree.key, v, tree.left, tree.right)
+    else if (overwrite) mkTree(isBlackTree(tree), tree.key, v, tree.left, tree.right)
     else tree
   }
   private[this] def updNth[A, B, B1 >: B](tree: Tree[A, B], idx: Int, k: A, v: B1, overwrite: Boolean): Tree[A, B1] = if (tree eq null) {


### PR DESCRIPTION
This was left over from 2.12 when they old key would be overwritten.
The behavior changed in https://github.com/scala/scala/pull/7481 to
comply with the new map/set rules in
https://github.com/scala/bug/issues/10415#issuecomment-442926971.

I would also call it wrong in 2.12 because equality should be defined
exclusively by the Ordering, but we should keep the current behavior
for compatibility reasons.