### PR TITLE
avoid creation of ListBuffers for small Seq.apply,

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -477,6 +477,7 @@ trait Definitions extends api.StandardDefinitions {
          def List_apply       = getMemberMethod(ListModule, nme.apply)
     lazy val NilModule        = requiredModule[scala.collection.immutable.Nil.type]
     lazy val SeqModule        = requiredModule[scala.collection.Seq.type]
+    lazy val ISeqModule       = requiredModule[scala.collection.immutable.Seq.type]
 
     // arrays and their members
     lazy val ArrayModule                   = requiredModule[scala.Array.type]

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -694,6 +694,7 @@ trait StdNames {
     val drop: NameType                 = "drop"
     val elem: NameType                 = "elem"
     val noSelfType: NameType           = "noSelfType"
+    val empty: NameType                = "empty"
     val ensureAccessible : NameType    = "ensureAccessible"
     val eq: NameType                   = "eq"
     val equalsNumChar : NameType       = "equalsNumChar"

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -294,6 +294,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.ListModule
     definitions.NilModule
     definitions.SeqModule
+    definitions.ISeqModule
     definitions.ArrayModule
     definitions.ArrayModule_overloadedApply
     definitions.ArrayClass

--- a/test/junit/scala/collection/SeqTest.scala
+++ b/test/junit/scala/collection/SeqTest.scala
@@ -71,4 +71,22 @@ class SeqTest extends AllocationTest{
     //each :: is 20 bytes (padded to 24)
     exactAllocates(24) (t2 map fn)
   }
+
+  @Test def smallSeqAllocation: Unit = {
+    exactAllocates(Sizes.list * 1, "collection seq  size 1")(Seq("0"))
+    exactAllocates(Sizes.list * 2, "collection seq  size 2")(Seq("0", "1"))
+    exactAllocates(Sizes.list * 3, "collection seq  size 3")(Seq("0", "1", ""))
+    exactAllocates(Sizes.list * 4, "collection seq  size 4")(Seq("0", "1", "2", "3"))
+    exactAllocates(Sizes.list * 5, "collection seq  size 5")(Seq("0", "1", "2", "3", "4"))
+    exactAllocates(Sizes.list * 6, "collection seq  size 6")(Seq("0", "1", "2", "3", "4", "5"))
+    exactAllocates(Sizes.list * 7, "collection seq  size 7")(Seq("0", "1", "2", "3", "4", "5", "6"))
+  }
+  @Test def largeSeqAllocation: Unit = {
+    exactAllocates(Sizes.list * 10 + Sizes.wrappedRefArray(10) + Sizes.listBuffer + 16, "collection seq size 10")(
+      Seq("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"))
+    exactAllocates(Sizes.list * 20 + Sizes.wrappedRefArray(20) + Sizes.listBuffer + 16, "collection seq size 20")(
+      Seq("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"))
+  }
+
+
 }

--- a/test/junit/scala/collection/Sizes.scala
+++ b/test/junit/scala/collection/Sizes.scala
@@ -5,15 +5,39 @@ import scala.collection.mutable.ListBuffer
 import scala.tools.testing.JOL
 import scala.tools.testing.JOL.assertTotalSize
 
+
+object Sizes {
+  def list: Int = 24
+  def listBuffer: Int = 32
+
+  def refArray(length:Int): Int = {
+    (16 + (length+1) * 4) /8 * 8
+  }
+  def wrappedRefArray(length:Int): Int = refArray(length) + 16
+
+}
 class Sizes {
   @Test
   def list: Unit = {
-    assertTotalSize(24, JOL.netLayout(null :: Nil, Nil))
+    assertTotalSize(Sizes.list, JOL.netLayout(null :: Nil, Nil))
   }
   @Test
   def listBuffer: Unit = {
-    assertTotalSize(32, JOL.netLayout(new ListBuffer[String], Nil))
+    assertTotalSize(Sizes.listBuffer, JOL.netLayout(new ListBuffer[String], Nil))
   }
+  @Test
+  def rawArray: Unit = {
+    for (length <- 0 to 10) {
+      assertTotalSize(Sizes.refArray(length), JOL.netLayout(new Array[String](length), Nil))
+    }
+  }
+  @Test
+  def wrappedArray2: Unit = {
+    for (length <- 1 to 10) {
+      assertTotalSize(Sizes.wrappedRefArray(length), JOL.netLayout(mutable.WrappedArray.make[String](new Array[String](length)), Nil))
+    }
+  }
+
   @Test
   def wrappedArray: Unit = {
     val wrapped = Array[String]("")

--- a/test/junit/scala/collection/immutable/ListTest.scala
+++ b/test/junit/scala/collection/immutable/ListTest.scala
@@ -7,6 +7,7 @@ import Assert._
 
 import scala.collection.{GenTraversableOnce, mutable}
 import scala.collection.generic.CanBuildFrom
+import scala.collection.Sizes
 import scala.ref.WeakReference
 import scala.tools.testing.AllocationTest
 
@@ -147,5 +148,21 @@ class ListTest extends AllocationTest {
     assertEquals(listClass, build(2, collection.Seq.ReusableCBF).getClass())
 
 
+  }
+
+  @Test def smallListAllocation: Unit = {
+    exactAllocates(Sizes.list * 1, "list  size 1")(List("0"))
+    exactAllocates(Sizes.list * 2, "list  size 2")(List("0", "1"))
+    exactAllocates(Sizes.list * 3, "list  size 3")(List("0", "1", ""))
+    exactAllocates(Sizes.list * 4, "list  size 4")(List("0", "1", "2", "3"))
+    exactAllocates(Sizes.list * 5, "list  size 5")(List("0", "1", "2", "3", "4"))
+    exactAllocates(Sizes.list * 6, "list  size 6")(List("0", "1", "2", "3", "4", "5"))
+    exactAllocates(Sizes.list * 7, "list  size 7")(List("0", "1", "2", "3", "4", "5", "6"))
+  }
+  @Test def largeListAllocation: Unit = {
+    exactAllocates(Sizes.list * 10 + Sizes.wrappedRefArray(10), "list  size 10")(
+      List("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"))
+    exactAllocates(Sizes.list * 20 + Sizes.wrappedRefArray(20), "list  size 20")(
+      List("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"))
   }
 }

--- a/test/junit/scala/collection/immutable/SeqTest.scala
+++ b/test/junit/scala/collection/immutable/SeqTest.scala
@@ -6,6 +6,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scala.collection.GenTraversableOnce
+import scala.collection.Sizes
 import scala.tools.testing.AllocationTest
 
 @RunWith(classOf[JUnit4])
@@ -71,4 +72,21 @@ class SeqTest extends AllocationTest{
     //each :: is 20 bytes (padded to 24)
     exactAllocates(24) (t2 map fn)
   }
+
+  @Test def smallSeqAllocation: Unit = {
+    exactAllocates(Sizes.list * 1, "immutable seq  size 1")(Seq("0"))
+    exactAllocates(Sizes.list * 2, "immutable seq  size 2")(Seq("0", "1"))
+    exactAllocates(Sizes.list * 3, "immutable seq  size 3")(Seq("0", "1", ""))
+    exactAllocates(Sizes.list * 4, "immutable seq  size 4")(Seq("0", "1", "2", "3"))
+    exactAllocates(Sizes.list * 5, "immutable seq  size 5")(Seq("0", "1", "2", "3", "4"))
+    exactAllocates(Sizes.list * 6, "immutable seq  size 6")(Seq("0", "1", "2", "3", "4", "5"))
+    exactAllocates(Sizes.list * 7, "immutable seq  size 7")(Seq("0", "1", "2", "3", "4", "5", "6"))
+  }
+  @Test def largeSeqAllocation: Unit = {
+    exactAllocates(Sizes.list * 10 + Sizes.wrappedRefArray(10) + Sizes.listBuffer + 16, "immutable seq size 10")(
+      Seq("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"))
+    exactAllocates(Sizes.list * 20 + Sizes.wrappedRefArray(20) + Sizes.listBuffer + 16, "immutable seq size 20")(
+      Seq("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"))
+  }
+
 }


### PR DESCRIPTION
 Like we do for List.apply

Also for `Seq.apply()` and `Seq.empty`