### PR TITLE
Support macro annotation expansions in -Wmacros:MODE

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -651,11 +651,13 @@ trait TypeDiagnostics {
     }
     object skipMacroExpansion extends UnusedPrivates {
       override def traverse(t: Tree): Unit =
-        if (!hasMacroExpansionAttachment(t)) super.traverse(t)
+        if (!hasMacroExpansionAttachment(t) && !(t.hasSymbol && isExpanded(t.symbol)))
+          super.traverse(t)
     }
     object checkMacroExpandee extends UnusedPrivates {
       override def traverse(t: Tree): Unit =
-        super.traverse(if (hasMacroExpansionAttachment(t)) macroExpandee(t) else t)
+        if (!(t.hasSymbol && isExpanded(t.symbol)))
+          super.traverse(if (hasMacroExpansionAttachment(t)) macroExpandee(t) else t)
     }
 
     private def warningsEnabled: Boolean = {

--- a/test/files/neg/macro-annot-unused-param.check
+++ b/test/files/neg/macro-annot-unused-param.check
@@ -1,0 +1,6 @@
+Test_2.scala:2: warning: parameter value x in anonymous function is never used
+@mymacro
+ ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/macro-annot-unused-param/Macros_1.scala
+++ b/test/files/neg/macro-annot-unused-param/Macros_1.scala
@@ -1,0 +1,22 @@
+// scalac: -Ymacro-annotations
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+import scala.annotation.StaticAnnotation
+
+object Macros {
+  def annotImpl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    val classTree = annottees.head.tree
+    val objectTree = q"""
+    object X {
+      def f: Int => String = { x => "hello" }
+    }
+    """
+
+    c.Expr[Any](Block(List(classTree, objectTree), Literal(Constant(()))))
+  }
+}
+
+class mymacro extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro Macros.annotImpl
+}

--- a/test/files/neg/macro-annot-unused-param/Test_2.scala
+++ b/test/files/neg/macro-annot-unused-param/Test_2.scala
@@ -1,0 +1,7 @@
+// scalac: -Ymacro-annotations -Wunused:params -Wmacros:after -Werror
+@mymacro
+class X
+
+object Test {
+  println(X.f(123))
+}

--- a/test/files/pos/macro-annot-unused-param/Macros_1.scala
+++ b/test/files/pos/macro-annot-unused-param/Macros_1.scala
@@ -1,0 +1,22 @@
+// scalac: -Ymacro-annotations
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+import scala.annotation.StaticAnnotation
+
+object Macros {
+  def annotImpl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    val classTree = annottees.head.tree
+    val objectTree = q"""
+    object X {
+      def f: Int => String = { x => "hello" }
+    }
+    """
+
+    c.Expr[Any](Block(List(classTree, objectTree), Literal(Constant(()))))
+  }
+}
+
+class mymacro extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro Macros.annotImpl
+}

--- a/test/files/pos/macro-annot-unused-param/Test_2.scala
+++ b/test/files/pos/macro-annot-unused-param/Test_2.scala
@@ -1,0 +1,7 @@
+// scalac: -Ymacro-annotations -Wunused:params -Werror
+@mymacro
+class X
+
+object Test {
+  println(X.f(123))
+}


### PR DESCRIPTION
From the [compiler options documentation](https://docs.scala-lang.org/overviews/compiler-options/index.html#Warning_Settings):

>-Wmacros:before
>Only inspect unexpanded user-written code for unused symbols.

I would argue that if we don't warn about unused symbols in trees expanded from def macros, we shouldn't warn about unused symbols in trees expanded from macro annotations either.