### PR TITLE
More accurate description of BitSet memory footprint in scaladoc

### DIFF
--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable.Builder
   *
   * @define bitsetinfo
   *  Bitsets are sets of non-negative integers which are represented as
-  *  variable-size arrays of bits packed into 64-bit words. The memory footprint of a bitset is
+  *  variable-size arrays of bits packed into 64-bit words. The lower bound of memory footprint of a bitset is
   *  determined by the largest number stored in it.
   * @define coll bitset
   * @define Coll `BitSet`


### PR DESCRIPTION
Noticed that `BitSet` (both mutable and immutable) docs mention an invariant that is not respected in practice. I can create an empty `BitSet` of arbitrary size, eg.:
```scala
val aThousandWords = BitSet(1000 * 64)
// aThousandWords: scala.collection.BitSet = BitSet(64000)
val aThousandOfEmptyWords = aThousandWords ^ aThousandWords
// aThousandOfEmptyWords: scala.collection.BitSet = BitSet()
aThousandOfEmptyWords.toBitMask.length
// res4: Int = 1024
```
I believe changing the implementation would be problematic in some cases performance wise (especially for single bit flip operation of mutable `BitSet`). 

Also, maybe there is a better formulation of this - just want to bring up the issue.

Related: https://github.com/scala/scala-collection-contrib/pull/86