### PR TITLE
Don't lose NoWarnAttachment on ValDefs created in quasiquotes

### DIFF
--- a/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
@@ -180,10 +180,10 @@ trait Reifiers { self: Quasiquotes =>
       case SyntacticDefDef(mods, name, tparams, vparamss, tpt, rhs) =>
         mirrorBuildCall(nme.SyntacticDefDef, reify(mods), reify(name), reify(tparams),
                                              reifyVparamss(vparamss), reify(tpt), reify(rhs))
-      case SyntacticValDef(mods, name, tpt, rhs) if tree != noSelfType =>
-        reifyBuildCall(nme.SyntacticValDef, mods, name, tpt, rhs)
-      case SyntacticVarDef(mods, name, tpt, rhs) =>
-        reifyBuildCall(nme.SyntacticVarDef, mods, name, tpt, rhs)
+      case SyntacticValDef(mods, name, tpt, rhs, noWarnAttachment) if tree != noSelfType =>
+        reifyBuildCall(nme.SyntacticValDef, mods, name, tpt, rhs, noWarnAttachment)
+      case SyntacticVarDef(mods, name, tpt, rhs, noWarnAttachment) =>
+        reifyBuildCall(nme.SyntacticVarDef, mods, name, tpt, rhs, noWarnAttachment)
       case SyntacticValFrom(pat, rhs) =>
         reifyBuildCall(nme.SyntacticValFrom, pat, rhs)
       case SyntacticValEq(pat, rhs) =>
@@ -364,8 +364,8 @@ trait Reifiers { self: Quasiquotes =>
       case ParamPlaceholder(Hole(tree, DotDot)) => tree
       case SyntacticPatDef(mods, pat, tpt, rhs) =>
         reifyBuildCall(nme.SyntacticPatDef, mods, pat, tpt, rhs)
-      case SyntacticValDef(mods, p @ Placeholder(h: ApplyHole), tpt, rhs) if h.tpe <:< treeType =>
-        mirrorBuildCall(nme.SyntacticPatDef, reify(mods), h.tree, reify(tpt), reify(rhs))
+      case SyntacticValDef(mods, p @ Placeholder(h: ApplyHole), tpt, rhs, noWarnAttachment) if h.tpe <:< treeType =>
+        mirrorBuildCall(nme.SyntacticPatDef, reify(mods), h.tree, reify(tpt), reify(rhs), reify(noWarnAttachment))
     }
 
     val fillListOfListsHole: PartialFunction[Any, Tree] = {

--- a/src/compiler/scala/reflect/reify/codegen/GenUtils.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenUtils.scala
@@ -57,7 +57,7 @@ trait GenUtils {
     call("" + nme.UNIVERSE_BUILD_PREFIX + name, args: _*)
 
   def reifyBuildCall(name: TermName, args: Any*) =
-      mirrorBuildCall(name, args map reify: _*)
+    mirrorBuildCall(name, args map reify: _*)
 
   def mirrorMirrorCall(name: TermName, args: Tree*): Tree =
     call("" + nme.MIRROR_PREFIX + name, args: _*)

--- a/src/reflect/scala/reflect/api/Internals.scala
+++ b/src/reflect/scala/reflect/api/Internals.scala
@@ -711,7 +711,8 @@ trait Internals { self: Universe =>
 
     trait SyntacticValDefExtractor {
       def apply(mods: Modifiers, name: TermName, tpt: Tree, rhs: Tree): ValDef
-      def unapply(tree: Tree): Option[(Modifiers, TermName, Tree, Tree)]
+      def apply(mods: Modifiers, name: TermName, tpt: Tree, rhs: Tree, noWarnAttachment: Boolean): ValDef
+      def unapply(tree: Tree): Option[(Modifiers, TermName, Tree, Tree, Boolean)]
     }
 
     val SyntacticPatDef: SyntacticPatDefExtractor

--- a/src/reflect/scala/reflect/internal/ReificationSupport.scala
+++ b/src/reflect/scala/reflect/internal/ReificationSupport.scala
@@ -579,11 +579,19 @@ trait ReificationSupport { self: SymbolTable =>
     protected class SyntacticValDefBase(isMutable: Boolean) extends SyntacticValDefExtractor {
       def modifiers(mods: Modifiers): Modifiers = if (isMutable) mods | MUTABLE else mods
 
-      def apply(mods: Modifiers, name: TermName, tpt: Tree, rhs: Tree): ValDef = ValDef(modifiers(mods), name, tpt, rhs)
+      def apply(mods: Modifiers, name: TermName, tpt: Tree, rhs: Tree): ValDef =
+        apply(mods, name, tpt, rhs, noWarnAttachment = false)
 
-      def unapply(tree: Tree): Option[(Modifiers, TermName, Tree, Tree)] = tree match {
+      def apply(mods: Modifiers, name: TermName, tpt: Tree, rhs: Tree, noWarnAttachment: Boolean): ValDef = {
+        val valDef = ValDef(modifiers(mods), name, tpt, rhs)
+        if (noWarnAttachment)
+          valDef.updateAttachment(NoWarnAttachment)
+        valDef
+      }
+
+      def unapply(tree: Tree): Option[(Modifiers, TermName, Tree, Tree, Boolean)] = tree match {
         case ValDef(mods, name, tpt, rhs) if mods.hasFlag(MUTABLE) == isMutable =>
-          Some((mods, name, tpt, rhs))
+          Some((mods, name, tpt, rhs, tree.hasAttachment[NoWarnAttachment.type]))
         case _ =>
           None
       }

--- a/test/files/pos/quasiquotes-anon-fun-wildcard-param/Macros_1.scala
+++ b/test/files/pos/quasiquotes-anon-fun-wildcard-param/Macros_1.scala
@@ -1,0 +1,11 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+object Macros {
+  def fImpl(c: Context) = {
+    import c.universe._
+    q"""{ _ => "hello" }"""
+  }
+
+  def f: Int => String = macro fImpl
+}

--- a/test/files/pos/quasiquotes-anon-fun-wildcard-param/Test_2.scala
+++ b/test/files/pos/quasiquotes-anon-fun-wildcard-param/Test_2.scala
@@ -1,0 +1,4 @@
+// scalac: -Wunused:params -Wmacros:after -Werror
+object Test extends App {
+  println(Macros.f(123))
+}


### PR DESCRIPTION
If an anonymous function has a wildcard parameter, e.g.

```
{ _ => "hello" }
```

the `ValDef` for that parameter is given a `NoWarnAttachment` to signal that `-Wunused:params` shouldn't warn about it being unused.

However, if we wrote the same thing in quasiquotes,

```
q"""{ _ => "hello" }"""
```

it was triggering an unused-parameter warning.

The `NoWarnAttachment` was properly attached to the `ValDef` at creation time, but it was being lost during reification.

The fix was to add a parameter to re-attach the attachment to the reified tree if it was present on the original tree.

There is already precedent for doing similar things with attachments.
See e.g. https://github.com/scala/scala/blob/c14cd9433735d962da2972efc735261636b5590d/src/reflect/scala/reflect/internal/ReificationSupport.scala#L940