### PR TITLE
Add `-Xlint:pattern-shadow` to lint pattern varids which are backquotable

### DIFF
--- a/src/compiler/scala/reflect/reify/codegen/GenTrees.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenTrees.scala
@@ -117,7 +117,7 @@ trait GenTrees {
                 abort("free var local to the reifee, should have already been inlined by Metalevels: " + inlinedSymtab.symDef(sym))
               state.symtab ++= inlinedSymtab
               rtree
-            case tree =>
+            case _ =>
               val migrated = Apply(Select(splicee, nme.in), List(Ident(nme.MIRROR_SHORT)))
               Select(migrated, nme.tree)
           }

--- a/src/compiler/scala/reflect/reify/phases/Reshape.scala
+++ b/src/compiler/scala/reflect/reify/phases/Reshape.scala
@@ -240,7 +240,7 @@ trait Reshape {
         def toScalaAnnotation(jann: ClassfileAnnotArg): Tree = (jann: @unchecked) match {
           case LiteralAnnotArg(const) => Literal(const)
           case ArrayAnnotArg(arr)     => Apply(Ident(definitions.ArrayModule), arr.toList map toScalaAnnotation)
-          case NestedAnnotArg(ann)    => toPreTyperAnnotation(ann)
+          case NestedAnnotArg(naa)    => toPreTyperAnnotation(naa)
         }
 
         ann.assocs map { case (nme, arg) => NamedArg(Ident(nme), toScalaAnnotation(arg)) }

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -91,10 +91,10 @@ abstract class TreeBuilder {
   /** Create tree for a pattern alternative */
   def makeAlternative(ts: List[Tree]): Tree = {
     def alternatives(t: Tree): List[Tree] = t match {
-      case Alternative(ts)  => ts
-      case _                => List(t)
+      case Alternative(alts) => alts
+      case _                 => List(t)
     }
-    Alternative(ts flatMap alternatives)
+    Alternative(ts.flatMap(alternatives))
   }
 
   /** Create tree for case definition <case pat if guard => rhs> */

--- a/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
@@ -196,12 +196,11 @@ final class FileBasedCache[K, T] {
   private case class Entry(k: K, stamps: Seq[Stamp], t: T) {
     val referenceCount: AtomicInteger = new AtomicInteger(1)
     var timerTask: TimerTask = null
-    def cancelTimer(): Unit = {
+    def cancelTimer(): Unit =
       timerTask match {
         case null =>
-        case t => t.cancel()
+        case task => task.cancel()
       }
-    }
   }
   private val cache = collection.mutable.Map.empty[(K, Seq[Path]), Entry]
 

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -811,7 +811,7 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
       def loop(seen: List[String], args: List[String]): (List[String], List[String]) = args match {
         case Optionlike() :: _ if halting         => (seen, args)
         case "help" :: rest if helpText.isDefined => sawHelp = true ; loop(seen, rest)
-        case arg :: rest                          => loop(arg :: seen, rest)
+        case head :: rest                         => loop(head :: seen, rest)
         case Nil                                  => (seen, Nil)
       }
       val (seen, rest) = loop(Nil, args)

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -217,6 +217,7 @@ trait Warnings {
     val ArgDiscard             = LintWarning("arg-discard",               "-Wvalue-discard for adapted arguments.")
     val IntDivToFloat          = LintWarning("int-div-to-float",          "Warn when an integer division is converted (widened) to floating point: `(someInt / 2): Double`.")
     val NamedBooleans          = LintWarning("named-booleans",            "Boolean literals should be named args unless param is @deprecatedName.")
+    val PatternShadow          = LintWarning("pattern-shadow",            "Pattern variable id is also a term in scope.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
   }
@@ -254,6 +255,7 @@ trait Warnings {
   def lintArgDiscard             = lint.contains(ArgDiscard)
   def lintIntDivToFloat          = lint.contains(IntDivToFloat)
   def lintNamedBooleans          = lint.contains(NamedBooleans)
+  def warnPatternShadow          = lint.contains(PatternShadow)
 
   // The Xlint warning group.
   val lint = MultiChoiceSetting(

--- a/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
@@ -92,8 +92,8 @@ abstract class BrowsingLoaders extends GlobalSymbolLoaders {
       }
 
       override def traverse(tree: Tree): Unit = tree match {
-        case PackageDef(pkg, body) =>
-          inPackagePrefix(pkg) { body foreach traverse }
+        case PackageDef(pid, stats) =>
+          inPackagePrefix(pid) { stats.foreach(traverse) }
 
         case ClassDef(_, name, _, _) =>
           if (packagePrefix == root.fullName) {

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -648,10 +648,8 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
         case BOOL_TAG   => BooleanTpe
         case 'L' =>
           def processInner(tp: Type): Type = tp match {
-            case TypeRef(pre, sym, args) if (!sym.isStatic) =>
-              typeRef(processInner(pre.widen), sym, args)
-            case _ =>
-              tp
+            case TypeRef(pre, sym, args) if !sym.isStatic => typeRef(processInner(pre.widen), sym, args)
+            case _ => tp
           }
           def processClassType(tp: Type): Type = tp match {
             case TypeRef(pre, classSym, args) =>
@@ -699,9 +697,11 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
               tp
           }
 
-          val classSym = classNameToSymbol(subName(c => c == ';' || c == '<'))
-          assert(!classSym.isOverloaded, classSym.alternatives)
-          val classTpe = if (classSym eq ObjectClass) ObjectTpeJava else classSym.tpe_*
+          val classTpe = {
+            val classSym = classNameToSymbol(subName(c => c == ';' || c == '<'))
+            assert(!classSym.isOverloaded, classSym.alternatives)
+            if (classSym eq ObjectClass) ObjectTpeJava else classSym.tpe_*
+          }
           var tpe = processClassType(processInner(classTpe))
           while (sig.charAt(index) == '.') {
             accept('.')

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -585,7 +585,7 @@ abstract class Pickler extends SubComponent {
         case StringTag  => writeRef(newTermName(c.stringValue))
         case ClazzTag   => writeRef(c.typeValue)
         case EnumTag    => writeRef(c.symbolValue)
-        case tag        => if (ByteTag <= tag && tag <= LongTag) writeLong(c.longValue)
+        case ctag       => if (ByteTag <= ctag && ctag <= LongTag) writeLong(c.longValue)
       }
 
       def writeModifiers(mods: Modifiers): Unit = {

--- a/src/compiler/scala/tools/nsc/transform/PostErasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/PostErasure.scala
@@ -44,7 +44,7 @@ trait PostErasure extends InfoTransform with TypingTransformers with scala.refle
         case AsInstanceOf(v, tpe) if v.tpe <:< tpe => finish(v)          // x.asInstanceOf[X]       ==> x
         case ValueClass.BoxAndUnbox(v)             => finish(v)          // (new B(v)).unbox        ==> v
         case ValueClass.BoxAndCompare(v1, op, v2)  => binop(v1, op, v2)  // new B(v1) == new B(v2)  ==> v1 == v2
-        case tree                                  => tree
+        case transformed                           => transformed
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/transform/async/AnfTransform.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/AnfTransform.scala
@@ -131,10 +131,11 @@ private[async] trait AnfTransform extends TransformUtils {
             case ld: LabelDef if ld.tpe.typeSymbol == definitions.BoxedUnitClass =>
               currentStats += ld
               literalBoxedUnit
-            case ld: LabelDef if ld.tpe.typeSymbol == definitions.UnitClass      =>
+            case ld: LabelDef if ld.tpe.typeSymbol == definitions.UnitClass =>
               currentStats += ld
               literalUnit
-            case expr                                                            => expr
+            case expr1 =>
+              expr1
           }
 
         case ValDef(mods, name, tpt, rhs) => atOwner(tree.symbol) {

--- a/src/compiler/scala/tools/nsc/transform/async/AsyncPhase.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/AsyncPhase.scala
@@ -149,8 +149,7 @@ abstract class AsyncPhase extends Transform with TypingTransformers with AnfTran
               currentTransformState = saved
             }
           }
-        case tree =>
-          tree
+        case transformed => transformed
       }
 
     private def asyncTransform(asyncBody: Tree): (Tree, List[Tree]) = {

--- a/src/compiler/scala/tools/nsc/transform/async/ExprBuilder.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/ExprBuilder.scala
@@ -35,7 +35,7 @@ trait ExprBuilder extends TransformUtils with AsyncAnalysis {
               Block(StateTransitionStyle.UpdateAndContinue.trees(state, new StateSet), typedCurrentPos(literalUnit)).setType(definitions.UnitTpe)
             case None => ap
           }
-        case tree => tree
+        case transformed => transformed
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -70,7 +70,7 @@ trait MatchTranslation {
       def pt      = unbound match {
         case Star(tpt)      => seqType(tpt.tpe)
         case TypeBound(tpe) => tpe
-        case tree           => tree.tpe
+        case unbound        => unbound.tpe
       }
 
       object SymbolAndTypeBound {

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -646,7 +646,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
           // `case 1 | 2` is considered as two cases.
           def exceedsTwoCasesOrAlts = {
             // avoids traversing the entire list if there are more than 3 elements
-            def lengthMax3(l: List[List[TreeMaker]]): Int = l match {
+            def lengthMax3(cases: List[List[TreeMaker]]): Int = cases match {
               case a :: b :: c :: _ => 3
               case cases            => cases.map {
                 case AlternativesTreeMaker(_, alts, _) :: _ => lengthMax3(alts)

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -84,16 +84,16 @@ trait PatternMatching extends Transform
           // but for the rest of us pass in top as the expected type to avoid waste.
           val pt = if (origTp <:< definitions.AnyTpe) definitions.AnyTpe else WildcardType
           localTyper.typed(translated, pt) match {
-            case b @ Block(stats, m: Match) =>
+            case b @ Block(_, m: Match) =>
               b.setType(origTp)
               m.setType(origTp)
               b
-            case tree => tree setType origTp
+            case t => t.setType(origTp)
           }
         } catch {
-          case x: (Types#TypeError) =>
+          case x: Types#TypeError =>
             // TODO: this should never happen; error should've been reported during type checking
-            reporter.error(tree.pos, "error during expansion of this match (this is a scalac bug).\nThe underlying error was: "+ x.msg)
+            reporter.error(tree.pos, s"error during expansion of this match (this is a scalac bug).\nThe underlying error was: ${x.msg}")
             translated
         }
       case Try(block, catches, finalizer) =>

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -84,18 +84,18 @@ trait Contexts { self: Analyzer =>
       var unused = List.empty[Culled]
       @tailrec def loop(infos: List[(ImportInfo, Symbol)]): Unit =
         infos match {
-          case (info, owner) :: rest =>
+          case (info, owner) :: infos =>
             val used = allUsedSelectors.remove(info).getOrElse(Set.empty)
             def checkSelectors(selectors: List[ImportSelector]): Unit =
               selectors match {
-                case selector :: rest =>
-                  checkSelectors(rest)
+                case selector :: selectors =>
+                  checkSelectors(selectors)
                   if (!selector.isMask && !used(selector))
                     unused ::= ((selector, info, owner))
                 case _ =>
               }
             checkSelectors(info.tree.selectors)
-            loop(rest)
+            loop(infos)
           case _ =>
         }
       loop(infos0)

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -297,9 +297,9 @@ trait Infer extends Checkable {
         tree setSymbol sym setType ErrorType
       else accessible match {
         case NoSymbol                                                 => checkAccessibleError(tree, sym, pre, site)
-        case sym if context.owner.isTermMacro && (sym hasFlag LOCKED) => throw CyclicReference(sym, CheckAccessibleMacroCycle)
-        case sym                                                      =>
-          val sym1 = if (sym.isTerm) sym.cookJavaRawInfo() else sym // xform java rawtypes into existentials
+        case acc if context.owner.isTermMacro && (acc hasFlag LOCKED) => throw CyclicReference(acc, CheckAccessibleMacroCycle)
+        case acc                                                      =>
+          val sym1 = if (acc.isTerm) acc.cookJavaRawInfo() else acc // xform java rawtypes into existentials
           val owntype = (
             try pre memberType sym1
             catch { case ex: MalformedType => malformed(ex, pre memberType underlyingSymbol(sym)) }

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -809,9 +809,9 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
             case _ => MacroExpansionHasInvalidTypeError(expandee, expanded)
           }
         } catch {
-          case ex: Throwable =>
+          case t: Throwable =>
             if (openMacros.nonEmpty) popMacroContext() // weirdly we started popping on an empty stack when refactoring fatalWarnings logic
-            val realex = ReflectionUtils.unwrapThrowable(ex)
+            val realex = ReflectionUtils.unwrapThrowable(t)
             realex match {
               case ex: InterruptedException => throw ex
               case ex: AbortMacroException => MacroGeneratedAbort(expandee, ex)

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -639,7 +639,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
       else {
         // approximation is necessary for whitebox macros to guide type inference
         // read more in the comments for onDelayed below
-        val undetparams = tp collect { case tp if tp.typeSymbol.isTypeParameter => tp.typeSymbol }
+        val undetparams = tp collect { case tp1 if tp1.typeSymbol.isTypeParameter => tp1.typeSymbol }
         deriveTypeWithWildcards(undetparams)(tp)
       }
     }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -2046,7 +2046,11 @@ abstract class RefChecks extends Transform {
             if (isMultiline && settings.warnByNameImplicit) checkImplicitlyAdaptedBlockResult(expr)
 
             tree
-          case Match(selector, cases) =>
+          case Match(selector0, cases) =>
+            val selector = selector0 match {
+              case Typed(expr, _) => expr
+              case _              => selector0
+            }
             def notNull(s: Symbol) = if (s != null) s else NoSymbol
             val selectorSymbol = notNull(selector.symbol)
             // true to warn about shadowed when selSym is the scrutinee

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2710,7 +2710,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       initChildren(selectorTp.typeSymbol)
 
       def finish(cases: List[CaseDef], matchType: Type) = {
-        if (!isPastTyper && settings.warnPatternShadow && !context.owner.isSynthetic && selector.symbol != null)
+        if (!isPastTyper && settings.warnPatternShadow && !context.owner.isSynthetic)
           for (cdef <- cases; bind @ Bind(name, _) <- cdef.pat if !bind.hasAttachment[NoWarnAttachment.type])
             context.lookupSymbol(name, _ => true) match {
               case LookupSucceeded(_, sym) => bind.updateAttachment(PatShadowAttachment(sym))

--- a/src/interactive/scala/tools/nsc/interactive/Pickler.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Pickler.scala
@@ -106,32 +106,32 @@ object Pickler {
      *  @param   f the function to apply.
      */
     def map[U](f: T => U): Unpickled[U] = this match {
-      case UnpickleSuccess(x) => UnpickleSuccess(f(x))
-      case f: UnpickleFailure => f
+      case UnpickleSuccess(x)    => UnpickleSuccess(f(x))
+      case fail: UnpickleFailure => fail
     }
     /** Transforms success values to successes or failures using given function,
      *  leaves failures alone.
      *  @param   f the function to apply.
      */
     def flatMap[U](f: T => Unpickled[U]): Unpickled[U] = this match {
-      case UnpickleSuccess(x) => f(x)
-      case f: UnpickleFailure => f
+      case UnpickleSuccess(x)    => f(x)
+      case fail: UnpickleFailure => fail
     }
     /** Tries alternate expression if current result is a failure
      *  @param alt  the alternate expression to be tried in case of failure
      */
     def orElse[U >: T](alt: => Unpickled[U]): Unpickled[U] = this match {
       case UnpickleSuccess(x) => this
-      case f: UnpickleFailure => alt
+      case _: UnpickleFailure => alt
     }
 
     /** Transforms failures into thrown `MalformedInput` exceptions.
      *  @throws  Lexer.MalformedInput   if current result is a failure
      */
     def requireSuccess: UnpickleSuccess[T] = this match {
-      case s @ UnpickleSuccess(x) => s
+      case s @ UnpickleSuccess(_) => s
       case f: UnpickleFailure =>
-        throw new MalformedInput(f.rd, "Unrecoverable unpickle failure:\n"+f.errMsg)
+        throw new MalformedInput(f.rd, s"Unrecoverable unpickle failure:\n${f.errMsg}")
     }
   }
 

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -314,9 +314,7 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen, equiv: E
     startgen: Gen,
     ct: TrieMap[K, V]): Option[V] = {
 
-    val m = GCAS_READ(ct) // use -Yinline!
-
-    m match {
+    GCAS_READ(ct) match {
       case cn: CNode[K, V] =>
         val idx = (hc >>> lev) & 0x1f
         val bmp = cn.bitmap
@@ -343,8 +341,8 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen, equiv: E
           if (res == None || (res eq null)) res
           else {
             @tailrec def cleanParent(nonlive: AnyRef): Unit = {
-              val pm = parent.GCAS_READ(ct)
-              pm match {
+              val cn = parent.GCAS_READ(ct)
+              cn match {
                 case cn: CNode[K, V] =>
                   val idx = (hc >>> (lev - 5)) & 0x1f
                   val bmp = cn.bitmap

--- a/src/library/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/src/library/scala/collection/convert/JavaCollectionWrappers.scala
@@ -456,22 +456,13 @@ private[collection] object JavaCollectionWrappers extends Serializable {
 
     def underlyingConcurrentMap: concurrent.Map[K, V] = underlying
 
-    override def putIfAbsent(k: K, v: V) = underlying.putIfAbsent(k, v) match {
-      case Some(v) => v
-      case None => null.asInstanceOf[V]
-    }
+    override def putIfAbsent(k: K, v: V) = underlying.putIfAbsent(k, v).getOrElse(null.asInstanceOf[V])
 
-    override def remove(k: AnyRef, v: AnyRef) = try {
-      underlying.remove(k.asInstanceOf[K], v.asInstanceOf[V])
-    } catch {
-      case ex: ClassCastException =>
-        false
-    }
+    override def remove(k: AnyRef, v: AnyRef) =
+      try underlying.remove(k.asInstanceOf[K], v.asInstanceOf[V])
+      catch { case ex: ClassCastException => false }
 
-    override def replace(k: K, v: V): V = underlying.replace(k, v) match {
-      case Some(v) => v
-      case None => null.asInstanceOf[V]
-    }
+    override def replace(k: K, v: V): V = underlying.replace(k, v).getOrElse(null.asInstanceOf[V])
 
     override def replace(k: K, oldval: V, newval: V) = underlying.replace(k, oldval, newval)
   }

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -31,8 +31,8 @@ private[collection] object RedBlackTree {
 
   def contains[A: Ordering](tree: Tree[A, _], x: A): Boolean = lookup(tree, x) ne null
   def get[A: Ordering, B](tree: Tree[A, B], x: A): Option[B] = lookup(tree, x) match {
-    case null => None
-    case tree => Some(tree.value)
+    case null  => None
+    case found => Some(found.value)
   }
 
   @tailrec

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -120,7 +120,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
    * `ArraySeq.make(a.asInstanceOf[Array[Int]])` does not work, it throws a `ClassCastException`
    * at runtime.
    */
-  def make[T](x: Array[T]): ArraySeq[T] = ((x.asInstanceOf[Array[_]]: @unchecked) match {
+  def make[T](x: Array[T]): ArraySeq[T] = ((x: @unchecked) match {
     case null              => null
     case x: Array[AnyRef]  => new ofRef[AnyRef](x)
     case x: Array[Int]     => new ofInt(x)

--- a/src/partest/scala/tools/partest/ReplTest.scala
+++ b/src/partest/scala/tools/partest/ReplTest.scala
@@ -12,6 +12,8 @@
 
 package scala.tools.partest
 
+import java.io.File.pathSeparator
+
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter.shell.{ILoop, ShellConfig}
 import scala.util.matching.Regex.{quoteReplacement, Match}
@@ -34,7 +36,7 @@ abstract class ReplTest extends DirectTest {
     if (getClass.getClassLoader.getParent != null) {
       s.classpath.value = s.classpath.value match {
         case "" => testOutput.toString
-        case s => s + java.io.File.pathSeparator + testOutput.toString
+        case cp => s"$cp$pathSeparator$testOutput"
       }
       s.usejavacp.value = true
     }

--- a/src/partest/scala/tools/partest/ScaladocModelTest.scala
+++ b/src/partest/scala/tools/partest/ScaladocModelTest.scala
@@ -189,11 +189,11 @@ abstract class ScaladocModelTest extends DirectTest {
 
     def countLinks(c: Comment, p: EntityLink => Boolean): Int = countLinksInBody(c.body, p)
 
-    def countLinksInBody(body: Body, p: EntityLink => Boolean): Int = {
+    def countLinksInBody(body: Body, linkTest: EntityLink => Boolean): Int = {
       def countLinks(b: Any): Int = b match {
-        case el: EntityLink if p(el) => 1
+        case el: EntityLink if linkTest(el) => 1
         case s: collection.Seq[_] => s.toList.map(countLinks(_)).sum
-        case p: Product => p.productIterator.toList.map(countLinks(_)).sum
+        case p: Product => p.productIterator.map(countLinks(_)).sum
         case _ => 0
       }
       countLinks(body)

--- a/src/reflect/scala/reflect/internal/AnnotationInfos.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationInfos.scala
@@ -338,8 +338,8 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
           // in that case we're going to have correctly typed Array.apply calls, however that's 2.12 territory
           // and for 2.11 exposing an untyped call to ArrayModule should suffice
           Apply(Ident(ArrayModule), args.toList)
-        case NestedAnnotArg(ann: Annotation) =>
-          annotationToTree(ann)
+        case NestedAnnotArg(jarg: Annotation) =>
+          annotationToTree(jarg)
         case _ =>
           EmptyTree
       }

--- a/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
+++ b/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
@@ -230,23 +230,21 @@ trait BaseTypeSeqs {
           i += 1
         }
         var minTypes: List[Type] = List()
-        def alreadyInMinTypes(tp: Type): Boolean = {
-          @annotation.tailrec def loop(tps: List[Type]): Boolean = tps match {
-            case x :: xs => (tp =:= x) || loop(xs)
-            case _       => false
+        def updateInMinTypes(tp: Type): Unit = {
+          def loop(tps: List[Type]): Boolean = tps match {
+            case x :: tps => (tp =:= x) || loop(tps)
+            case _        => false
           }
-          loop(minTypes)
+          if (!loop(minTypes))
+            minTypes ::= tp
         }
 
         i = 0
         while (i < nparents) {
           if (nextTypeSymbol(i) == minSym) {
             nextRawElem(i) match {
-              case RefinedType(variants, decls) =>
-                for (tp <- variants)
-                  if (!alreadyInMinTypes(tp)) minTypes ::= tp
-              case tp =>
-                if (!alreadyInMinTypes(tp)) minTypes ::= tp
+              case RefinedType(variants, _) => variants.foreach(updateInMinTypes)
+              case ntp => updateInMinTypes(ntp)
             }
             index(i) = index(i) + 1
           }

--- a/src/reflect/scala/reflect/internal/Importers.scala
+++ b/src/reflect/scala/reflect/internal/Importers.scala
@@ -398,7 +398,7 @@ trait Importers { to: SymbolTable =>
       case from.Ident(name) =>
         new Ident(importName(name))
       case from.ReferenceToBoxed(ident) =>
-        new ReferenceToBoxed(importTree(ident) match { case ident: Ident => ident case x => throw new MatchError(x) })
+        new ReferenceToBoxed(importTree(ident).asInstanceOf[Ident])
       case from.Literal(constant @ from.Constant(_)) =>
         new Literal(importConstant(constant))
       case theirtt @ from.TypeTree() =>

--- a/src/reflect/scala/reflect/internal/Kinds.scala
+++ b/src/reflect/scala/reflect/internal/Kinds.scala
@@ -295,7 +295,7 @@ trait Kinds {
           case 2 => "X"
           case 3 => "Y"
           case 4 => "Z"
-          case n if n < 12 => ('O'.toInt - 5 + n).toChar.toString
+          case x if x < 12 => ('O'.toInt - 5 + x).toChar.toString
           case _ => "V"
         }
     }

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -743,7 +743,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
         case treeInfo.Applied(core, _, argss) =>
           print("@")
           core match {
-            case Select(New(tree), _) => print(tree)
+            case Select(New(ann), _) => print(ann)
             case _ =>
           }
           printArgss(argss)

--- a/src/reflect/scala/reflect/internal/ReificationSupport.scala
+++ b/src/reflect/scala/reflect/internal/ReificationSupport.scala
@@ -114,7 +114,7 @@ trait ReificationSupport { self: SymbolTable =>
     }
 
     def mkAnnotation(tree: Tree): Tree = tree match {
-      case SyntacticNew(Nil, SyntacticApplied(SyntacticAppliedType(_, _), _) :: Nil, noSelfType, Nil) =>
+      case SyntacticNew(Nil, SyntacticApplied(SyntacticAppliedType(_, _), _) :: Nil, `noSelfType`, Nil) =>
         tree
       case _ =>
         throw new IllegalArgumentException(s"Tree ${showRaw(tree)} isn't a correct representation of annotation." +
@@ -876,10 +876,10 @@ trait ReificationSupport { self: SymbolTable =>
     // drop potential @scala.unchecked annotation
     protected object MaybeUnchecked {
       def unapply(tree: Tree): Some[Tree] = tree match {
-        case Annotated(SyntacticNew(Nil, ScalaDot(tpnme.unchecked) :: Nil, noSelfType, Nil), annottee) =>
+        case Annotated(SyntacticNew(Nil, ScalaDot(tpnme.unchecked) :: Nil, `noSelfType`, Nil), annottee) =>
           Some(annottee)
         case Typed(annottee, MaybeTypeTreeOriginal(
-          Annotated(SyntacticNew(Nil, ScalaDot(tpnme.unchecked) :: Nil, noSelfType, Nil), _))) =>
+          Annotated(SyntacticNew(Nil, ScalaDot(tpnme.unchecked) :: Nil, `noSelfType`, Nil), _))) =>
           Some(annottee)
         case annottee => Some(annottee)
       }
@@ -904,7 +904,7 @@ trait ReificationSupport { self: SymbolTable =>
         case Typed(
                Block(
                  List(ClassDef(clsMods, tpnme.ANON_FUN_NAME, Nil, Template(
-                   List(abspf: TypeTree, ser: TypeTree), noSelfType, List(
+                   List(abspf: TypeTree, ser: TypeTree), `noSelfType`, List(
                      DefDef(_, nme.CONSTRUCTOR, _, _, _, _),
                      DefDef(_, nme.applyOrElse, _, _, _,
                        Match(_, cases :+

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -88,6 +88,10 @@ trait StdAttachments {
    */
   case object NoWarnAttachment extends PlainAttachment
 
+  /** A pattern binding that shadows a symbol in scope. Removed by refchecks.
+   */
+  case class PatShadowAttachment(shadowed: Symbol)
+
   /** Indicates that a `ValDef` was synthesized from a pattern definition, `val P(x)`.
    */
   case object PatVarDefAttachment extends PlainAttachment

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -1128,7 +1128,7 @@ trait StdNames {
     def primitiveMethodName(name: Name): TermName =
       primitiveInfixMethodName(name) match {
         case NO_NAME => primitivePostfixMethodName(name)
-        case name => name
+        case ok_name => ok_name
       }
 
     /** Translate a String into a list of simple TypeNames and TermNames.

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2719,6 +2719,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
                    isPrimaryConstructor))        ("primary constructor",  "constructor",     "PCTOR")
         else if (isClassConstructor)             ("constructor",          "constructor",     "CTOR")
         else if (isMethod)                       ("method",               "method",          "METH")
+        //else if (isValueParameter)               ("value parameter",      "parameter",       "VAL")
         else if (isTerm)                         ("value",                "value",           "VAL")
         else                                     ("",                     "",                "???")
 
@@ -2813,8 +2814,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      *  for backward compatibility reasons.
      */
     def locationString: String = ownsString match {
-      case ""   => ""
-      case s    => " in " + s
+      case "" => ""
+      case s  => s" in $s"
     }
     def fullLocationString: String = toString + locationString
     def signatureString: String    = if (hasRawInfo) infoString(rawInfo) else "<_>"
@@ -2857,8 +2858,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     }
 
     private def defStringCompose(infoString: String) = compose(
-      flagString,
-      keyString,
+      compose(flagString, keyString),
       varianceString + nameString + infoString + flagsExplanationString
     )
 
@@ -2877,8 +2877,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      */
     def defStringSeenAs(info: Type) = defStringCompose(infoString(info))
 
-    /** Concatenate strings separated by spaces */
-    private def compose(ss: String*) = ss filter (_ != "") mkString " "
+    /** Concatenate non-empty strings separated by a space. */
+    private def compose(x: String, y: String): String =
+      if (x.isEmpty) y else if (y.isEmpty) x else s"$x $y"
 
     def isSingletonExistential: Boolean =
       nme.isSingletonName(name)

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -723,8 +723,7 @@ abstract class TreeGen {
         val valeqs = rest.take(definitions.MaxTupleArity - 1).takeWhile { ValEq.unapply(_).nonEmpty }
         assert(!valeqs.isEmpty, "Missing ValEq")
         val rest1 = rest.drop(valeqs.length)
-        val pats = valeqs.collect { case ValEq(pat, _) => pat }
-        val rhss = valeqs.collect { case ValEq(_, rhs) => rhs }
+        val (pats, rhss) = valeqs.map(ValEq.unapply(_).get).unzip
         val defpat1 = makeBind(pat)
         val defpats = pats map makeBind
         val pdefs = defpats.lazyZip(rhss).flatMap(mkPatDef)

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -852,7 +852,7 @@ abstract class TreeInfo {
     def core: Tree = callee match {
       case TypeApply(fn, _)       => fn
       case AppliedTypeTree(fn, _) => fn
-      case tree                   => tree
+      case callee                 => callee
     }
 
     /** The type arguments of the `callee`.

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1827,8 +1827,8 @@ trait Types
       val flattened: LinkedHashSet[Type] = LinkedHashSet.empty[Type]
       def dealiasRefinement(tp: Type) = if (tp.dealias.isInstanceOf[RefinedType]) tp.dealias else tp
       def loop(tp: Type): Unit = dealiasRefinement(tp) match {
-        case RefinedType(parents, ds) if ds.isEmpty => parents.foreach(loop)
-        case tp => flattened.add(tp)
+        case RefinedType(parents, decls) if decls.isEmpty => parents.foreach(loop)
+        case tp1 => flattened.add(tp1)
       }
       parents foreach loop
       if (decls.isEmpty && flattened.size == 1) {
@@ -4369,24 +4369,21 @@ trait Types
       case _                                    => NoType
     }
   }
-  def elementExtractOption(container: Symbol, tp: Type): Option[Type] = {
+  def elementExtractOption(container: Symbol, tp: Type): Option[Type] =
     elementExtract(container, tp) match {
       case NoType => None
-      case tp => Some(tp)
+      case tp1    => Some(tp1)
     }
-  }
-  def elementTest(container: Symbol, tp: Type)(f: Type => Boolean): Boolean = {
+  def elementTest(container: Symbol, tp: Type)(f: Type => Boolean): Boolean =
     elementExtract(container, tp) match {
       case NoType => false
-      case tp => f(tp)
+      case tp1    => f(tp1)
     }
-  }
-  def elementTransform(container: Symbol, tp: Type)(f: Type => Type): Type = {
+  def elementTransform(container: Symbol, tp: Type)(f: Type => Type): Type =
     elementExtract(container, tp) match {
       case NoType => NoType
-      case tp => f(tp)
+      case tp1    => f(tp1)
     }
-  }
 
   def transparentShallowTransform(container: Symbol, tp: Type)(f: Type => Type): Type = {
     def loop(tp: Type): Type = tp match {
@@ -5345,7 +5342,7 @@ trait Types
   @tailrec
   private[scala] final def typeIsNothing(tp: Type): Boolean =
     tp.dealias match {
-      case PolyType(_, tp) => typeIsNothing(tp)
+      case PolyType(_, resultType) => typeIsNothing(resultType)
       case TypeRef(_, NothingClass, _) => true
       case _ => false
     }
@@ -5353,7 +5350,7 @@ trait Types
   @tailrec
   private[scala] final def typeIsAnyOrJavaObject(tp: Type): Boolean =
     tp.dealias match {
-      case PolyType(_, tp) => typeIsAnyOrJavaObject(tp)
+      case PolyType(_, resultType) => typeIsAnyOrJavaObject(resultType)
       case TypeRef(_, AnyClass, _) => true
       case _: ObjectTpeJavaRef => true
       case _ => false
@@ -5361,7 +5358,7 @@ trait Types
 
   private[scala] final def typeIsAnyExactly(tp: Type): Boolean =
     tp.dealias match {
-      case PolyType(_, tp) => typeIsAnyExactly(tp)
+      case PolyType(_, resultType) => typeIsAnyExactly(resultType)
       case TypeRef(_, AnyClass, _) => true
       case _ => false
     }

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -281,15 +281,10 @@ abstract class UnPickler {
       val owner        = readSymbolRef()
       val flags        = pickledToRawFlags(readLongNat())
 
-      var privateWithin: Symbol = null
-      var inforef: Int = 0
-      readNat() match {
-        case index if isSymbolRef(index) =>
-          privateWithin = at(index, () => readSymbol())
-          inforef = readNat()
-        case index =>
-          privateWithin = NoSymbol
-          inforef = index
+      val (privateWithin: Symbol, inforef: Int) = {
+        val index = readNat()
+        if (isSymbolRef(index)) (at(index, () => readSymbol()), readNat())
+        else (NoSymbol, index)
       }
 
       def isModuleFlag      = (flags & MODULE) != 0L

--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -323,7 +323,7 @@ private[internal] trait GlbLubs {
   }
 
   /** The least upper bound wrt <:< of a list of types */
-  protected[internal] def lub(ts: List[Type], depth: Depth): Type = {
+  protected[internal] def lub(ts0: List[Type], depth: Depth): Type = {
     def lub0(ts0: List[Type]): Type = elimSub(ts0, depth) match {
       case List() => NothingTpe
       case List(t) => t
@@ -437,15 +437,15 @@ private[internal] trait GlbLubs {
       existentialAbstraction(tparams, dropIllegalStarTypes(lubType))
     }
     if (printLubs) {
-      println(indent + "lub of " + ts + " at depth "+depth)//debug
+      println(indent + "lub of " + ts0 + " at depth "+depth)//debug
       indent = indent + "  "
       assert(indent.length <= 100, "LUB is highly indented")
     }
     if (settings.areStatisticsEnabled) statistics.incCounter(nestedLubCount)
-    val res = lub0(ts)
+    val res = lub0(ts0)
     if (printLubs) {
       indent = indent stripSuffix "  "
-      println(indent + "lub of " + ts + " is " + res)//debug
+      println(indent + "lub of " + ts0 + " is " + res)//debug
     }
     res
   }
@@ -485,7 +485,7 @@ private[internal] trait GlbLubs {
 
   /** The greatest lower bound of a list of types (as determined by `<:<`), which have been normalized
     *  with regard to `elimSuper`. */
-  protected def glbNorm(ts: List[Type], depth: Depth): Type = {
+  protected def glbNorm(ts0: List[Type], depth: Depth): Type = {
     def glb0(ts0: List[Type]): Type = ts0 match {
       case List() => AnyTpe
       case List(t) => t
@@ -591,13 +591,13 @@ private[internal] trait GlbLubs {
         existentialAbstraction(tparams, glbType)
       } catch {
         case GlbFailure =>
-          if (ts forall (t => NullTpe <:< t)) NullTpe
+          if (ts0.forall(NullTpe <:< _)) NullTpe
           else NothingTpe
       }
     }
     // if (settings.debug.value) { println(indent + "glb of " + ts + " at depth "+depth); indent = indent + "  " } //DEBUG
     if (settings.areStatisticsEnabled) statistics.incCounter(nestedLubCount)
-    glb0(ts)
+    glb0(ts0)
     // if (settings.debug.value) { indent = indent.substring(0, indent.length() - 2); log(indent + "glb of " + ts + " is " + res) }//DEBUG
   }
 
@@ -617,7 +617,7 @@ private[internal] trait GlbLubs {
 
     @tailrec
     def normalizeIter(ty: Type): PolyType = ty match {
-      case pt @ PolyType(tparams1, _) if sameLength(tparams1, tparamsHead) => pt
+      case pt @ PolyType(typeParams, _) if sameLength(typeParams, tparamsHead) => pt
       case tp =>
         val tpn = tp.normalize
         if (tp ne tpn) normalizeIter(tpn) else throw new NoCommonType(ptHead :: ptRest)

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -413,11 +413,11 @@ trait TypeComparers {
       case (_: PolyType, MethodType(ps, _)) if ps exists (_.tpe.isWildcard) => false // don't warn on HasMethodMatching on right hand side
       // TODO: rethink whether ExistentialType should be considered isHigherKinded when its underlying type is;
       // in any case, we do need to handle one of the types being an existential
-      case (tp1, et2: ExistentialType)                                      => et2.withTypeVars(isSubType(tp1, _, depth), depth)
-      case (et1: ExistentialType, tp2)                                      =>
+      case (ntp1, et2: ExistentialType)                                     => et2.withTypeVars(isSubType(ntp1, _, depth), depth)
+      case (et1: ExistentialType, ntp2)                                     =>
         try {
           skolemizationLevel += 1
-          isSubType(et1.skolemizeExistential, tp2, depth)
+          isSubType(et1.skolemizeExistential, ntp2, depth)
         } finally { skolemizationLevel -= 1 }
       case _                                                                => // @assume !(both .isHigherKinded) thus cannot be subtypes
         def tp_s(tp: Type): String = f"$tp%-20s ${util.shortClassOfInstance(tp)}%s"

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -611,7 +611,7 @@ private[internal] trait TypeMaps {
       /** Rewrite `This` trees in annotation argument trees */
       override def transform(tree: Tree): Tree = super.transform(tree) match {
         case This(_) if matchesThis(tree.symbol) => newThis()
-        case tree                                => tree
+        case transformed                         => transformed
       }
     }
 
@@ -842,7 +842,7 @@ private[internal] trait TypeMaps {
             transformIfMapped(id)(toSym => strictCopy.Ident(id, toSym.name))
           case sel @ Select(qual, _) =>
             transformIfMapped(sel)(toSym => strictCopy.Select(sel, qual, toSym.name))
-          case tree => tree
+          case transformed => transformed
         }
     }
 

--- a/src/reflect/scala/reflect/internal/util/ChromeTrace.scala
+++ b/src/reflect/scala/reflect/internal/util/ChromeTrace.scala
@@ -188,8 +188,8 @@ final class ChromeTrace(f: Path) extends Closeable {
       case oc @ ObjectContext(first) =>
         if (first) oc.first = false
         else traceWriter.write(",")
-      case context =>
-        throw new IllegalStateException("Wrong context: " + context)
+      case otherContext =>
+        throw new IllegalStateException(s"Wrong context: $otherContext")
     }
     traceWriter.write("\"")
     traceWriter.write(name)

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -86,11 +86,11 @@ trait Collections {
   }
 
   final def collectFirst[A, B](as: List[A])(pf: PartialFunction[A, B]): Option[B] = {
-    @tailrec
-    def loop(rest: List[A]): Option[B] = rest match {
-      case Nil => None
-      case a :: as if pf.isDefinedAt(a) => Some(pf(a))
-      case a :: as => loop(as)
+    def loop(as: List[A]): Option[B] = as match {
+      case a :: as =>
+        if (pf.isDefinedAt(a)) Some(pf(a))
+        else loop(as)
+      case _ => None
     }
     loop(as)
   }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -60,6 +60,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.InfixAttachment
     this.AutoApplicationAttachment
     this.NoWarnAttachment
+    this.PatShadowAttachment
     this.PatVarDefAttachment
     this.MultiDefAttachment
     this.ForAttachment

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/LoopCommands.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/LoopCommands.scala
@@ -144,7 +144,7 @@ trait LoopCommands {
               def complete(buffer: String, cursor: Int, filter: Boolean) =
                 CompletionResult(buffer, cursor = 1, List(CompletionCandidate(completion)), "", "")
             }
-          case cmd :: rest =>
+          case cmd :: _ =>
             new Completion {
               def complete(buffer: String, cursor: Int, filter: Boolean) =
                 CompletionResult(buffer, cursor = 1, cmds.map(cmd => CompletionCandidate(":" + cmd.name)), "", "")

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Scripted.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Scripted.scala
@@ -69,7 +69,7 @@ class Scripted(@BeanProperty val factory: ScriptEngineFactory, settings: Setting
   def dynamicContext_=(ctx: ScriptContext): Unit = intp.call("set", ctx)
 
   def dynamicContext: ScriptContext = intp.call("value") match {
-    case Right(ctx: ScriptContext) => ctx
+    case Right(scriptctx: ScriptContext) => scriptctx
     case Left(e) => throw e
     case Right(other) => throw new ScriptException(s"Unexpected value for context: $other")
   }

--- a/src/sbt-bridge/scala/tools/xsbt/ExtractAPI.scala
+++ b/src/sbt-bridge/scala/tools/xsbt/ExtractAPI.scala
@@ -632,7 +632,7 @@ class ExtractAPI[GlobalType <: Global](
             xsbti.api.Annotated.of(processType(in, at.underlying), mkAnnotations(in, annots))
         }
       case rt: CompoundType   => structure(rt, rt.typeSymbol)
-      case t: ExistentialType => makeExistentialType(in, t)
+      case et: ExistentialType => makeExistentialType(in, et)
       case NoType =>
         Constants.emptyType // this can happen when there is an error that will be reported by a later phase
       case PolyType(typeParams, resultType) =>

--- a/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ScalaSigPrinter.scala
+++ b/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ScalaSigPrinter.scala
@@ -207,7 +207,7 @@ class ScalaSigPrinter(stream: PrintStream, printPrivates: Boolean) {
 
       // Print result type
       mt.resultType match {
-        case mt: MethodType => printMethodType(mt, printResult)({})
+        case res: MethodType => printMethodType(res, printResult)(())
         case x => if (printResult) {
           print(": ")
           printType(x)

--- a/src/testkit/scala/tools/testkit/AllocationTest.scala
+++ b/src/testkit/scala/tools/testkit/AllocationTest.scala
@@ -77,16 +77,17 @@ trait AllocationTest {
   }
 
   private def showAllocations(allocations: List[Long]): String = allocations match {
-    case Nil       => ""
-    case a :: tail =>
+    case a :: allocations =>
       val sb = new StringBuilder
       def append(a: Long, count: Int) = sb.append(s" allocation $a ($count times)\n")
-      @tailrec def loop(allocations: List[Long], last: Long, count: Int): String = allocations match {
-        case Nil                    => append(last, count).result()
-        case a :: tail if a != last => append(a, count); loop(tail, a, 1)
-        case a :: tail              => loop(tail, a, count + 1)
+      def loop(allocations: List[Long], last: Long, count: Int): String = allocations match {
+        case Nil => append(last, count).result()
+        case b :: allocations =>
+          val n = if (b != last) { append(b, count); 1 } else count + 1
+          loop(allocations, b, n)
       }
-      loop(tail, a, 1)
+      loop(allocations, a, 1)
+    case _         => ""
   }
 
   /** Asserts that the execution of `fn` allocates `size` bytes or less. */

--- a/test/files/neg/t11850.check
+++ b/test/files/neg/t11850.check
@@ -1,0 +1,21 @@
+t11850.scala:9: warning: Name x is already introduced in an enclosing scope as value x in trait T. Did you intend to match it using backquoted `x`?
+      case x   => 1     // warn
+           ^
+t11850.scala:28: warning: Name x is already introduced in an enclosing scope as value x in class CT. Did you intend to match it using backquoted `x`?
+      case x   => 1     // warn
+           ^
+t11850.scala:118: warning: Name x is already introduced in an enclosing scope as value x. Did you intend to match it using backquoted `x`?
+    case Y(x, y)  => x+y // only allow 1-1
+           ^
+t11850.scala:118: warning: Name y is already introduced in an enclosing scope as value y. Did you intend to match it using backquoted `y`?
+    case Y(x, y)  => x+y // only allow 1-1
+              ^
+t11850.scala:125: warning: Name self is already introduced in an enclosing scope as value self in class Selfie. Did you intend to match it using backquoted `self`?
+    case (x, self) => x
+             ^
+t11850.scala:170: warning: Name _1 is already introduced in an enclosing scope as value _1 in class weird but true. Did you intend to match it using backquoted `_1`?
+    case (_1, 27) => 3 // briefly did not warn as param name
+          ^
+error: No warnings can be incurred under -Werror.
+6 warnings
+1 error

--- a/test/files/neg/t11850.check
+++ b/test/files/neg/t11850.check
@@ -4,10 +4,10 @@ t11850.scala:9: warning: Name x is already introduced in an enclosing scope as v
 t11850.scala:28: warning: Name x is already introduced in an enclosing scope as value x in class CT. Did you intend to match it using backquoted `x`?
       case x   => 1     // warn
            ^
-t11850.scala:118: warning: Name x is already introduced in an enclosing scope as value x. Did you intend to match it using backquoted `x`?
+t11850.scala:118: warning: Name x is already introduced in an enclosing scope as value x at line 117. Did you intend to match it using backquoted `x`?
     case Y(x, y)  => x+y // only allow 1-1
            ^
-t11850.scala:118: warning: Name y is already introduced in an enclosing scope as value y. Did you intend to match it using backquoted `y`?
+t11850.scala:118: warning: Name y is already introduced in an enclosing scope as value y at line 117. Did you intend to match it using backquoted `y`?
     case Y(x, y)  => x+y // only allow 1-1
               ^
 t11850.scala:125: warning: Name self is already introduced in an enclosing scope as value self in class Selfie. Did you intend to match it using backquoted `self`?
@@ -16,12 +16,15 @@ t11850.scala:125: warning: Name self is already introduced in an enclosing scope
 t11850.scala:170: warning: Name _1 is already introduced in an enclosing scope as value _1 in class weird but true. Did you intend to match it using backquoted `_1`?
     case (_1, 27) => 3 // briefly did not warn as param name
           ^
-t11850.scala:187: warning: Name x is already introduced in an enclosing scope as value x. Did you intend to match it using backquoted `x`?
+t11850.scala:187: warning: Name x is already introduced in an enclosing scope as value x at line 186. Did you intend to match it using backquoted `x`?
     case x => x.toString
          ^
 t11850.scala:203: warning: Name c is already introduced in an enclosing scope as value c in class pattern matches occasionally appear in pattern-matching anonymous functions. Did you intend to match it using backquoted `c`?
   def f = c.collect { case c if c.flag => c.toString }
                            ^
+t11850.scala:212: warning: Name x is already introduced in an enclosing scope as object x in object is it worth qualifying what kind of term. Did you intend to match it using backquoted `x`?
+      case x   => 1
+           ^
 error: No warnings can be incurred under -Werror.
-8 warnings
+9 warnings
 1 error

--- a/test/files/neg/t11850.check
+++ b/test/files/neg/t11850.check
@@ -16,6 +16,9 @@ t11850.scala:125: warning: Name self is already introduced in an enclosing scope
 t11850.scala:170: warning: Name _1 is already introduced in an enclosing scope as value _1 in class weird but true. Did you intend to match it using backquoted `_1`?
     case (_1, 27) => 3 // briefly did not warn as param name
           ^
+t11850.scala:187: warning: Name x is already introduced in an enclosing scope as value x. Did you intend to match it using backquoted `x`?
+    case x => x.toString
+         ^
 error: No warnings can be incurred under -Werror.
-6 warnings
+7 warnings
 1 error

--- a/test/files/neg/t11850.check
+++ b/test/files/neg/t11850.check
@@ -19,6 +19,9 @@ t11850.scala:170: warning: Name _1 is already introduced in an enclosing scope a
 t11850.scala:187: warning: Name x is already introduced in an enclosing scope as value x. Did you intend to match it using backquoted `x`?
     case x => x.toString
          ^
+t11850.scala:203: warning: Name c is already introduced in an enclosing scope as value c in class pattern matches occasionally appear in pattern-matching anonymous functions. Did you intend to match it using backquoted `c`?
+  def f = c.collect { case c if c.flag => c.toString }
+                           ^
 error: No warnings can be incurred under -Werror.
-7 warnings
+8 warnings
 1 error

--- a/test/files/neg/t11850.check
+++ b/test/files/neg/t11850.check
@@ -4,27 +4,18 @@ t11850.scala:9: warning: Name x is already introduced in an enclosing scope as v
 t11850.scala:28: warning: Name x is already introduced in an enclosing scope as value x in class CT. Did you intend to match it using backquoted `x`?
       case x   => 1     // warn
            ^
-t11850.scala:118: warning: Name x is already introduced in an enclosing scope as value x at line 117. Did you intend to match it using backquoted `x`?
-    case Y(x, y)  => x+y // only allow 1-1
-           ^
-t11850.scala:118: warning: Name y is already introduced in an enclosing scope as value y at line 117. Did you intend to match it using backquoted `y`?
-    case Y(x, y)  => x+y // only allow 1-1
-              ^
-t11850.scala:125: warning: Name self is already introduced in an enclosing scope as value self in class Selfie. Did you intend to match it using backquoted `self`?
+t11850.scala:135: warning: Name self is already introduced in an enclosing scope as value self in class Selfie. Did you intend to match it using backquoted `self`?
     case (x, self) => x
              ^
-t11850.scala:170: warning: Name _1 is already introduced in an enclosing scope as value _1 in class weird but true. Did you intend to match it using backquoted `_1`?
-    case (_1, 27) => 3 // briefly did not warn as param name
-          ^
-t11850.scala:187: warning: Name x is already introduced in an enclosing scope as value x at line 186. Did you intend to match it using backquoted `x`?
+t11850.scala:202: warning: Name x is already introduced in an enclosing scope as value x at line 201. Did you intend to match it using backquoted `x`?
     case x => x.toString
          ^
-t11850.scala:203: warning: Name c is already introduced in an enclosing scope as value c in class pattern matches occasionally appear in pattern-matching anonymous functions. Did you intend to match it using backquoted `c`?
+t11850.scala:224: warning: Name c is already introduced in an enclosing scope as value c in class pattern matches occasionally appear in pattern-matching anonymous functions. Did you intend to match it using backquoted `c`?
   def f = c.collect { case c if c.flag => c.toString }
                            ^
-t11850.scala:212: warning: Name x is already introduced in an enclosing scope as object x in object is it worth qualifying what kind of term. Did you intend to match it using backquoted `x`?
+t11850.scala:233: warning: Name x is already introduced in an enclosing scope as object x in object is it worth qualifying what kind of term. Did you intend to match it using backquoted `x`?
       case x   => 1
            ^
 error: No warnings can be incurred under -Werror.
-9 warnings
+6 warnings
 1 error

--- a/test/files/neg/t11850.scala
+++ b/test/files/neg/t11850.scala
@@ -194,3 +194,11 @@ class `lukas asked whats that null check for` {
     case c => false
   }
 }
+case class Collector() {
+  def collect[T](pf: PartialFunction[Collector, T]): List[T] = ???
+  def flag = true
+}
+class `pattern matches occasionally appear in pattern-matching anonymous functions` {
+  val c = Collector()
+  def f = c.collect { case c if c.flag => c.toString }
+}

--- a/test/files/neg/t11850.scala
+++ b/test/files/neg/t11850.scala
@@ -202,3 +202,13 @@ class `pattern matches occasionally appear in pattern-matching anonymous functio
   val c = Collector()
   def f = c.collect { case c if c.flag => c.toString }
 }
+object `is it worth qualifying what kind of term` {
+  trait T
+  object x extends T
+
+  def f(t: T) =
+    t match {
+      case `x` => 0
+      case x   => 1
+    }
+}

--- a/test/files/neg/t11850.scala
+++ b/test/files/neg/t11850.scala
@@ -187,3 +187,10 @@ class `kosher selector` {
     case x => x.toString
   }
 }
+class `lukas asked whats that null check for` {
+  import annotation._
+  def isOperatorPart(c: Char): Boolean = (c: @unchecked) match {
+    case '+' => true
+    case c => false
+  }
+}

--- a/test/files/neg/t11850.scala
+++ b/test/files/neg/t11850.scala
@@ -1,0 +1,189 @@
+//> using options -Werror -Xlint:pattern-shadow
+
+trait T {
+  val x = 42
+
+  def f(i: Int) =
+    i match {
+      case `x` => 0     // presence of this case really obviates warning on the next?
+      case x   => 1     // warn
+    }
+  def g(i: Int) =
+    i match {
+      case x @ _ => 1   // never warn if user writes bind of wildcard
+    }
+  def h(i: Any) =
+    i match {
+      case i: Int => i  // alias of scrutinee
+      case _ => 42
+    }
+}
+// same but in a class
+class CT {
+  val x = 42
+
+  def f(i: Int) =
+    i match {
+      case `x` => 0     // presence of this case really obviates warning on the next?
+      case x   => 1     // warn
+    }
+  def g(i: Int) =
+    i match {
+      case x @ _ => 1   // never warn if user writes bind of wildcard
+    }
+  def h(i: Any) =
+    i match {
+      case i: Int => i  // alias of scrutinee
+      case _ => 42
+    }
+}
+trait Overload[A] {
+  def map[B](f: A => B): Int = ???
+}
+trait Overloader[K, V] extends Overload[(K, V)] {
+  def map[K2, V2](f: ((K, V)) => (K2, V2)): String = ???
+
+  def f() = this match {
+    case map: Overloader[k, v] => // shadows overloaded members which are not stable
+  }
+}
+class C {
+  val (x, y) = (42, 27)
+  def f(): Unit = {
+    val (a, b) = (42, 27)
+    println(a+b)
+  }
+}
+final class D(private val xs: List[Int]) extends AnyVal {
+  def f: List[Int] =
+    (xs: Any @unchecked) match {
+      case xs: List[_] => Nil
+      case _ => Nil
+    }
+}
+sealed class Tree
+final case class Apply(fn: Tree, args: List[Tree]) extends Tree
+final class Applied(val tree: Tree) {
+  /** The tree stripped of the possibly nested applications.
+   *  The original tree if it's not an application.
+   */
+  def callee: Tree = {
+    @annotation.tailrec
+    def loop(tree: Tree): Tree = tree match {
+      case Apply(fn, _) => loop(fn)
+      case tree         => tree   // alias of scrutinee
+    }
+    loop(tree)
+  }
+
+  def `ident introduced by case class`(): Unit = {
+    val fn = 42
+    tree match {
+      case Apply(fn, Nil) => println(fn)  // name of parameter
+      case _ => println(fn)
+    }
+  }
+
+  def `ident introduced by case class with a twist`(): Unit = {
+    val fn = 42
+    tree match {
+      case t @ Apply(fn, Nil) => println((t, fn)) // name of parameter but not top level pattern
+      case _ => println(fn)
+    }
+  }
+
+  def `bound var in pattern is selector`(t: Tree): Unit = {
+    t match {
+      case Apply(t, args) => println((t, args)) // alias of scrutinee but not top level pattern
+      case _ =>
+    }
+  }
+}
+object X { def unapply(p: (Int, Int)): Option[(Int, Int)] = Option(p).filter(p => p._1 == p._2) }
+object Y { def unapply(p: (Int, Int, Int)): Option[(Int, Int)] = Option(p).map { case (x, y, z) => (x, y+z) } }
+class Tupling {
+  def f(x: Int, y: Int): Int = (x, y) match {
+    case (42, 27) => 5
+    case (x, y)   => x+y // correspond to tuple arg
+  }
+  def g(x: Some[Int], y: Some[Int]): Int = (x, y) match {
+    case (Some(42), Some(27)) => 5
+    case (Some(x), Some(y))   => x+y // correspond to tuple arg but not top level pattern
+  }
+  def e(x: Int, y: Int): Int = (x, y) match {
+    case X(x, y)  => x+y // extractor args correspond to tuple args
+    case _        => -1
+  }
+  def err(x: Int, y: Int, z: Int): Int = (x, y, z) match {
+    case Y(x, y)  => x+y // only allow 1-1
+    case _        => -1
+  }
+}
+class Selfie { self =>
+  def f(x: Int, y: Selfie): Int = (x, y) match {
+    case (42, this) => 5
+    case (x, self) => x
+    case _ => 42
+  }
+  def g(): Int = self match {
+    case self: Selfie => 5
+    case _ => 42
+  }
+}
+class Deconstruct[K, +V](val mapping: Deconstruct.Mapping[K, V]) {
+  def test(k: K): V = {
+    val (_, v) = mapping(k)
+    v
+  }
+}
+object Deconstruct {
+  type Mapping[K, +V] = Map[K, (Int, V)]
+}
+class Init {
+  def f(): Int = 42
+  val res = f() match {
+    case res => res
+  }
+}
+package p {
+  class P {
+    def m = ???
+    def test(x: Any, y: => Any) = x match {
+      case p: Int => p
+      case m: String => m.toInt
+      case y: Double => y.toInt
+      case _ => 42
+    }
+  }
+}
+class `multi extraction of singular scrutinee` {
+  val r = raw"(\d)(\d)".r
+  val x = "42"
+  def test = x match {
+    case r(x, y) => x * y.toInt
+    case _ => ""
+  }
+}
+class `weird but true` {
+  val _1 = "yup"
+  def test = (42, 27) match {
+    case (_1, 27) => 3 // briefly did not warn as param name
+    case _ => 5
+  }
+}
+case class Thing(i: Int, other: Thing)
+class `derived thing is refinement` {
+  val t0 = Thing(27, null)
+  val t  = Thing(42, t0)
+  t.other match {
+    case t => // ok because select from t is another Thing maybe related
+  }
+  t.copy(i = 5) match {
+    case t => // ok because deriving from t is another Thing maybe related
+  }
+}
+class `kosher selector` {
+  def f(x: Any) = 42 match {
+    case x => x.toString
+  }
+}

--- a/test/files/neg/t11850.scala
+++ b/test/files/neg/t11850.scala
@@ -104,19 +104,29 @@ object Y { def unapply(p: (Int, Int, Int)): Option[(Int, Int)] = Option(p).map {
 class Tupling {
   def f(x: Int, y: Int): Int = (x, y) match {
     case (42, 27) => 5
-    case (x, y)   => x+y // correspond to tuple arg
+    case (x, y)   => x+y // correspond to tuple arg (or anywhere in selector)
   }
   def g(x: Some[Int], y: Some[Int]): Int = (x, y) match {
     case (Some(42), Some(27)) => 5
-    case (Some(x), Some(y))   => x+y // correspond to tuple arg but not top level pattern
+    case (Some(x), Some(y))   => x+y // correspond to tuple arg but not top level pattern (or anywhere in selector)
   }
   def e(x: Int, y: Int): Int = (x, y) match {
-    case X(x, y)  => x+y // extractor args correspond to tuple args
+    case X(x, y)  => x+y // extractor args correspond to tuple args (or anywhere in selector)
     case _        => -1
   }
   def err(x: Int, y: Int, z: Int): Int = (x, y, z) match {
-    case Y(x, y)  => x+y // only allow 1-1
+    case Y(x, y)  => x+y // only allow 1-1 (or anywhere in selector)
     case _        => -1
+  }
+  def swap(x: Int, y: Int): Int = (x, y) match {
+    case X(y, x)  => x+y // anywhere in selector
+    case _        => -1
+  }
+  def add1(x: Int): Int = x + 1 match {
+    case x => x+42 // anywhere in selector
+  }
+  def add2(x: Int): Int = 1 + x match {
+    case x => x+42 // anywhere in selector
   }
 }
 class Selfie { self =>
@@ -183,8 +193,19 @@ class `derived thing is refinement` {
   }
 }
 class `kosher selector` {
+  def f(x: Any) = x.toString match {
+    case x => x
+  }
+}
+class `unkosher selector` {
   def f(x: Any) = 42 match {
     case x => x.toString
+  }
+}
+class `also unkosher selector` {
+  // selector is a value derived from x but it is an unrelated type; x does not "refine" Thing
+  def f(x: Thing) = x.toString match {
+    case x => x
   }
 }
 class `lukas asked whats that null check for` {

--- a/test/junit/scala/SerializationStabilityTest.scala
+++ b/test/junit/scala/SerializationStabilityTest.scala
@@ -85,9 +85,9 @@ object SerializationStability {
   def check[T <: AnyRef](stack: Array[StackTraceElement])(instance: => T)(prevResult: String, f: T => AnyRef = (x: T) => x): Unit = {
     val result = serialize(instance)
     overwrite match {
-      case Some(f) =>
+      case Some(ov) =>
         val lineNumberOfLiteralString = stack.apply(2).getLineNumber
-        patch(f, lineNumberOfLiteralString, prevResult, result)
+        patch(ov, lineNumberOfLiteralString, prevResult, result)
       case None =>
         if (!isCheckInitEnabled) {
           checkRoundTrip(instance)(f)

--- a/test/junit/scala/tools/nsc/reporters/WConfTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/WConfTest.scala
@@ -242,7 +242,7 @@ class WConfTest extends BytecodeTesting {
     def check(s: String, ev: Version): Unit = Version.fromString(s) match {
       case pv: Version.ParseableVersion =>
         assertEquals(ev, pv.copy(orig = ""))
-      case nv: Version.NonParseableVersion =>
+      case _: Version.NonParseableVersion =>
         assertTrue(s"failed to parse $s, expected $ev", ev.isInstanceOf[Version.NonParseableVersion])
     }
 

--- a/test/junit/scala/tools/nsc/util/StackTraceTest.scala
+++ b/test/junit/scala/tools/nsc/util/StackTraceTest.scala
@@ -71,7 +71,7 @@ class StackTraceTest {
     val res = s.linesIterator.toList
     assertEquals(9, res.length)
     assertTrue(res.exists(_.startsWith(CausedBy)))
-    assertEquals(2, res.collect { case s if s.startsWith(CausedBy) => s }.size)
+    assertEquals(2, res.filter(_.startsWith(CausedBy)).size)
   }
 
   // summary + one frame + elision times two with extra frame

--- a/test/junit/scala/util/TryTest.scala
+++ b/test/junit/scala/util/TryTest.scala
@@ -175,8 +175,8 @@ class TryTest {
     val t = Success(1)
     val n = t.filter(x => x < 0)
     n match {
-      case Success(v) => fail()
-      case Failure(e: NoSuchElementException) => ()
+      case Success(_) => fail()
+      case Failure(_: NoSuchElementException) => ()
       case _          => fail()
     }
   }
@@ -234,7 +234,7 @@ class TryTest {
     val t = Success(1)
     val n = t.failed
     n match {
-      case Failure(e: UnsupportedOperationException) =>
+      case Failure(_: UnsupportedOperationException) =>
       case _ => fail()
     }
   }
@@ -243,7 +243,7 @@ class TryTest {
     val t = Failure(new Exception("foo"))
     val n = t.failed
     n match {
-      case Success(e: Exception) =>
+      case Success(_: Exception) =>
       case _ => fail()
     }
   }


### PR DESCRIPTION
Lint `-Xlint:pattern-shadow` warns when a pattern has a variable that may have been intended to match a value in scope using "backtick" notation.
```
def compare(x: Any, y: Any) = x match { case y => true }  // intended case `y` =>
```
For the common idiom of "refining" a value through pattern matching, there is no warning if the value in scope is used in the selector expression:
```
def asString(x: Any) = x match { case x: String => x case _ => stringOf(x) }

def f(x: X) = x.alias match { case x => } // does not check that x in pattern conforms to the input parameter

def f(x: X) = g(x) match { case x => } // arbitrary functions in x may extract arbitrary values without incurring a warning
```
This exception is permissive. For example, tuple arguments need not "align" in the pattern:
```
def swap(x: Any, y: Any) = (x, y) match { case (y, x) => }
```

Fixes scala/bug#11850