### PR TITLE
Tokenize partest test flags

### DIFF
--- a/src/partest/scala/tools/partest/package.scala
+++ b/src/partest/scala/tools/partest/package.scala
@@ -16,6 +16,7 @@ import java.nio.file.Files
 import java.util.concurrent.{Callable, ExecutorService}
 
 import scala.concurrent.duration.Duration
+import scala.io.Codec
 import scala.jdk.CollectionConverters._
 import scala.tools.nsc.util.Exceptional
 
@@ -40,7 +41,7 @@ package object partest {
   def ojoin(xs: String*): String  = oempty(xs: _*) mkString space
   def nljoin(xs: String*): String = oempty(xs: _*) mkString EOL
 
-  implicit val codec = scala.io.Codec.UTF8
+  implicit val codec: Codec = Codec.UTF8
 
   def setUncaughtHandler() = {
     Thread.setDefaultUncaughtExceptionHandler(
@@ -98,7 +99,7 @@ package object partest {
   implicit class PathOps(p: Path) extends FileOps(p.jfile)
 
   implicit class Copier(val f: SFile) extends AnyVal {
-    def copyTo(dest: Path): Unit = dest.toFile writeAll f.slurp(scala.io.Codec.UTF8)
+    def copyTo(dest: Path): Unit = dest.toFile writeAll f.slurp(Codec.UTF8)
   }
 
   implicit class LoaderOps(val loader: ClassLoader) extends AnyVal {

--- a/test/junit/scala/tools/cmd/CommandLineParserTest.scala
+++ b/test/junit/scala/tools/cmd/CommandLineParserTest.scala
@@ -42,4 +42,5 @@ class CommandLineParserTest {
     assertThrows[ParseException](tokenize(""""x"""))         // was assertEquals(List("\"x"), tokenize(""""x"""))
     assertThrows[ParseException](tokenize("""x'"""))
   }
+  @Test def leadingSpaces(): Unit = assertEquals(List("text"), tokenize(" text"))
 }


### PR DESCRIPTION
For example, accept
/* scalac: -opt:l:inline '-opt-inline-from:**' -opt-warnings*/
by dropping trailing close comment and parsing quotes.

Follow-up to removing flags files, use CommandLineParser to tokenize the args string.

Flags files supported putting multiple flags on separate lines as a workaround for args with spaces; not sure if there was a use case for that feature.

Suggested reviewer hrhino for the close comment trick.