### PR TITLE
Fix fallback of scalacOpts in partest's SBTRunner

### DIFF
--- a/src/partest/scala/tools/partest/sbt/SBTRunner.scala
+++ b/src/partest/scala/tools/partest/sbt/SBTRunner.scala
@@ -58,7 +58,7 @@ class SBTRunner(config: RunnerSpec.Config,
 
   override val scalacOpts = {
     val l = defs.collect { case ("partest.scalac_opts", v) => v }
-    if(l.isEmpty) PartestDefaults.javaOpts
+    if(l.isEmpty) PartestDefaults.scalacOpts
     else l.mkString(" ")
   }
 


### PR DESCRIPTION
If I understand the code correctly this means that when
-Dpartest.scalac_opts isn't specified as an argument of running
partest, the system property "partest.scalac_opts" will be honoured rather
than the "partest.java_opts" property.