### PR TITLE
There is no more -Xsource:2.14, only -Xsource:3

### DIFF
--- a/src/compiler/scala/reflect/macros/contexts/FrontEnds.scala
+++ b/src/compiler/scala/reflect/macros/contexts/FrontEnds.scala
@@ -28,7 +28,7 @@ trait FrontEnds {
 
   def hasErrors: Boolean = universe.reporter.hasErrors
 
-  // TODO: add WarningCategory parameter in 2.14 (not binary compatible)
+  // TODO: add WarningCategory parameter (not binary compatible)
   def warning(pos: Position, msg: String): Unit = callsiteTyper.context.warning(pos, msg, WarningCategory.Other)
 
   def error(pos: Position, msg: String): Unit = callsiteTyper.context.error(pos, msg)

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1137,8 +1137,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     // We hit these checks regularly. They shouldn't change inside the same run, so cache the comparisons here.
     val isScala212: Boolean = settings.isScala212
     val isScala213: Boolean = settings.isScala213
-    val isScala214: Boolean = settings.isScala214
-    val isScala300: Boolean = settings.isScala300
+    val isScala3: Boolean   = settings.isScala3
 
     // used in sbt
     def uncheckedWarnings: List[(Position, String)]   = reporting.uncheckedWarnings

--- a/src/compiler/scala/tools/nsc/Parsing.scala
+++ b/src/compiler/scala/tools/nsc/Parsing.scala
@@ -23,7 +23,6 @@ trait Parsing { self : Positions with Reporting =>
   trait RunParsing {
     val parsing: PerRunParsing = new PerRunParsing
     def isScala213: Boolean
-    def isScala214: Boolean
   }
 
   class PerRunParsing {

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -452,7 +452,7 @@ trait Scanners extends ScannersCommon {
           (sepRegions.isEmpty || sepRegions.head == RBRACE)) {
         if (pastBlankLine()) insertNL(NEWLINES)
         else if (!isLeadingInfixOperator) insertNL(NEWLINE)
-        else if (!currentRun.isScala214) {
+        else if (!currentRun.isScala3) {
           val msg = """|Line starts with an operator that in future
                        |will be taken as an infix expression continued from the previous line.
                        |To force the previous interpretation as a separate statement,
@@ -874,7 +874,7 @@ trait Scanners extends ScannersCommon {
         nextRawChar()
         if (isTripleQuote()) {
           setStrVal()
-          if(!currentRun.isScala214) replaceUnicodeEscapesInTriple()
+          if(!currentRun.isScala3) replaceUnicodeEscapesInTriple()
           token = STRINGLIT
         } else
           getRawStringLit()

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -93,7 +93,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
   def releaseValue: Option[String] = Option(release.value).filter(_ != "")
 
   /*
-   * The previous "-source" option is intended to be used mainly
+   * The previous "-Xsource" option is intended to be used mainly
    * though this helper.
    */
   private[this] val version212 = ScalaVersion("2.12.0")
@@ -101,9 +101,8 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
   private[this] val version213 = ScalaVersion("2.13.0")
   def isScala213: Boolean = source.value >= version213
   private[this] val version214 = ScalaVersion("2.14.0")
-  def isScala214: Boolean = source.value >= version214
-  private[this] val version300 = ScalaVersion("3.0.0")
-  def isScala300: Boolean = source.value >= version300
+  private[this] val version3 = ScalaVersion("3.0.0")
+  def isScala3: Boolean = source.value >= version3
 
   /**
    * -X "Advanced" settings
@@ -133,8 +132,10 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
   val mainClass          = StringSetting       ("-Xmain-class", "path", "Class for manifest's Main-Class entry (only useful with -d <jar>)", "")
   val sourceReader       = StringSetting       ("-Xsource-reader", "classname", "Specify a custom method for reading source files.", "")
   val reporter           = StringSetting       ("-Xreporter", "classname", "Specify a custom subclass of FilteringReporter for compiler messages.", "scala.tools.nsc.reporters.ConsoleReporter")
-  val source             = ScalaVersionSetting ("-Xsource", "version", "Enable features that will be available in a future version of Scala, for purposes of early migration and alpha testing.", initial = version213).withPostSetHook(s =>
-      if (s.value < version213) errorFn.apply(s"-Xsource must be at least the current major version (${version213.versionString})"))
+  val source             = ScalaVersionSetting ("-Xsource", "version", "Enable features that will be available in a future version of Scala, for purposes of early migration and alpha testing.", initial = version213).withPostSetHook { s =>
+      if (s.value < version213) errorFn.apply(s"-Xsource must be at least the current major version (${version213.versionString})")
+      if (s.value >= version214 && s.value < version3) s.withDeprecationMessage("instead of -Xsource:2.14, use -Xsource:3").value = version3
+  }
 
   val XnoPatmatAnalysis = BooleanSetting ("-Xno-patmat-analysis", "Don't perform exhaustivity/unreachability analysis. Also, ignore @switch annotation.")
 

--- a/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
@@ -94,7 +94,7 @@ trait Adaptations {
         true // keep adaptation
       }
       if (args.isEmpty) {
-        if (currentRun.isScala300) noAdaptation else deprecatedAdaptation
+        if (currentRun.isScala3) noAdaptation else deprecatedAdaptation
       } else
         warnAdaptation
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1049,9 +1049,9 @@ trait Contexts { self: Analyzer =>
       sym.isImplicit &&
       isAccessible(sym, pre) &&
       !(
-        // [eed3si9n] ideally I'd like to do this: val fd = currentRun.isScala214 && sym.isDeprecated
+        // [eed3si9n] ideally I'd like to do this: val fd = currentRun.isScala3 && sym.isDeprecated
         // but implicit caching currently does not report sym.isDeprecated correctly.
-        currentRun.isScala214 && (sym == currentRun.runDefinitions.Predef_any2stringaddMethod)
+        currentRun.isScala3 && (sym == currentRun.runDefinitions.Predef_any2stringaddMethod)
       ) &&
       !(imported && {
         val e = scope.lookupEntry(name)

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -905,7 +905,7 @@ trait Infer extends Checkable {
       case _                         =>
         tpe2 match {
           case PolyType(tparams2, rtpe2) => isAsSpecificValueType(tpe1, rtpe2, undef1, undef2 ::: tparams2)
-          case _ if !currentRun.isScala300 => existentialAbstraction(undef1, tpe1) <:< existentialAbstraction(undef2, tpe2)
+          case _ if !currentRun.isScala3 => existentialAbstraction(undef1, tpe1) <:< existentialAbstraction(undef2, tpe2)
           case _                         =>
             // Backport of fix for https://github.com/scala/bug/issues/2509
             // from Dotty https://github.com/lampepfl/dotty/commit/89540268e6c49fb92b9ca61249e46bb59981bf5a

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -529,7 +529,7 @@ trait NamesDefaults { self: Analyzer =>
         val NamedArg(Ident(name), rhs) = arg
         params indexWhere (p => matchesName(p, name, argIndex)) match {
           case -1 =>
-            val warnVariableInScope = !currentRun.isScala214 && context0.lookupSymbol(name, _.isVariable).isSuccess
+            val warnVariableInScope = !currentRun.isScala3 && context0.lookupSymbol(name, _.isVariable).isSuccess
             UnknownParameterNameNamesDefaultError(arg, name, warnVariableInScope)
           case paramPos if argPos contains paramPos =>
             val existingArgIndex = argPos.indexWhere(_ == paramPos)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -824,7 +824,7 @@ abstract class RefChecks extends Transform {
             .filter(c => c.exists && c.isClass)
           overridden foreach { sym2 =>
             def msg(what: String) = s"shadowing a nested class of a parent is $what but $clazz shadows $sym2 defined in ${sym2.owner}; rename the class to something else"
-            if (currentRun.isScala300) reporter.error(clazz.pos, msg("unsupported"))
+            if (currentRun.isScala3) reporter.error(clazz.pos, msg("unsupported"))
             else runReporting.deprecationWarning(clazz.pos, clazz, currentOwner, msg("deprecated"), "2.13.2")
           }
         }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -899,7 +899,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         val arity = mt.params.length
 
-        val sourceLevel2_14 = currentRun.isScala214
+        val sourceLevel3 = currentRun.isScala3
 
         def warnTree = original orElse tree
 
@@ -927,7 +927,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         // until 2.13:
         //   - for arity > 0: function or sam type is expected
         //   - for arity == 0: Function0 is expected -- SAM types do not eta-expand because it could be an accidental SAM scala/bug#9489
-        // 2.14:
+        // 3.0:
         //   - for arity > 0: unconditional
         //   - for arity == 0: a function-ish type of arity 0 is expected (including SAM)
         //
@@ -935,7 +935,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         //   - 2.12: eta-expansion of zero-arg methods was deprecated (scala/bug#7187)
         //   - 2.13: deprecation dropped in favor of setting the scene for uniform eta-expansion in 3.0
         //           (arity > 0) expected type is a SAM that is not annotated with `@FunctionalInterface`
-        //   - 2.14: (arity == 0) expected type is a SAM that is not annotated with `@FunctionalInterface`
+        //   - 3.0: (arity == 0) expected type is a SAM that is not annotated with `@FunctionalInterface`
         def checkCanEtaExpand(): Boolean = {
           def expectingSamOfArity = {
             val sam = samOf(ptUnderlying)
@@ -950,7 +950,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           val doIt =
             if (arity == 0) {
               val doEtaZero =
-                expectingFunctionOfArity || sourceLevel2_14 && expectingSamOfArity
+                expectingFunctionOfArity || sourceLevel3 && expectingSamOfArity
 
               if (doEtaZero && settings.warnEtaZero) {
                 val ptHelp =
@@ -963,7 +963,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                   WarningCategory.LintEtaZero)
               }
               doEtaZero
-            } else sourceLevel2_14 || expectingFunctionOfArity || expectingSamOfArity
+            } else sourceLevel3 || expectingFunctionOfArity || expectingSamOfArity
 
           if (doIt && !expectingFunctionOfArity && settings.warnEtaSam) warnEtaSam()
 
@@ -979,7 +979,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         }
         // (4.2) condition for auto-application by -Xsource level
         //
-        // until 2.14: none (assuming condition for (4.3) was not met)
+        // until 3.0: none (assuming condition for (4.3) was not met)
         // in 3.0: `meth.isJavaDefined`
         //         (TODO decide -- currently the condition is more involved to give slack to Scala methods overriding Java-defined ones;
         //          I think we should resolve that by introducing slack in overriding e.g. a Java-defined `def toString()` by a Scala-defined `def toString`.
@@ -988,10 +988,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         //          > val vparamSymssOrEmptyParamsFromOverride =
         //          This means an accessor that overrides a Java-defined method gets a MethodType instead of a NullaryMethodType, which breaks lots of assumptions about accessors)
         def checkCanAutoApply(): Boolean = {
-          if (sourceLevel2_14 && !isPastTyper && !matchNullaryLoosely) {
+          if (sourceLevel3 && !isPastTyper && !matchNullaryLoosely) {
             context.deprecationWarning(tree.pos, NoSymbol, s"Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method ${meth.decodedName},\n" +
                                                            s"or remove the empty argument list from its definition (Java-defined methods are exempt).\n"+
-                                                           s"In Scala 3, an unapplied method like this will be eta-expanded into a function.", "2.14.0")
+                                                           s"In Scala 3, an unapplied method like this will be eta-expanded into a function.", "3.0.0")
           }
           true
         }

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -98,7 +98,7 @@ trait Unapplies extends ast.TreeDSL {
 
 
   private def applyShouldInheritAccess(mods: Modifiers) =
-    currentRun.isScala214 && (mods.hasFlag(PRIVATE) || (!mods.hasFlag(PROTECTED) && mods.hasAccessBoundary))
+    currentRun.isScala3 && (mods.hasFlag(PRIVATE) || (!mods.hasFlag(PROTECTED) && mods.hasAccessBoundary))
 
   /** The module corresponding to a case class; overrides toString to show the module's name
    */
@@ -272,7 +272,7 @@ trait Unapplies extends ast.TreeDSL {
       val argss = mmap(paramss)(toIdent)
       val body: Tree = New(classTpe, argss)
       val copyMods =
-        if (currentRun.isScala214) {
+        if (currentRun.isScala3) {
           val inheritedMods = constrMods(cdef)
           Modifiers(SYNTHETIC | (inheritedMods.flags & AccessFlags), inheritedMods.privateWithin)
         }

--- a/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
@@ -32,7 +32,7 @@ trait FastStringInterpolator extends FormatInterpolator {
       val treated = 
         try
           parts.mapConserve { case lit@Literal(Constant(stringVal: String)) =>
-            val k = Constant(if (isRaw && currentRun.isScala214) stringVal
+            val k = Constant(if (isRaw && currentRun.isScala3) stringVal
                              else if (isRaw) {
                                val processed = StringContext.processUnicode(stringVal)
                                if(processed != stringVal){

--- a/src/library/scala/SerialVersionUID.scala
+++ b/src/library/scala/SerialVersionUID.scala
@@ -23,5 +23,5 @@ package scala
   * @see [[http://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html `java.io.Serializable`]]
   * @see [[Serializable]]
   */
-@deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
+@deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class SerialVersionUID(value: Long) extends scala.annotation.ConstantAnnotation

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -138,7 +138,7 @@ case class StringContext(parts: String*) {
    *
    *  ''Note:'' Even when using the raw interpolator, Scala will process Unicode escapes.
    *  Unicode processing in the raw interpolator is deprecated as of scala 2.13.2 and
-   *  will be removed in scala 2.14
+   *  will be removed in the future
    *  For example:
    *  {{{
    *    scala> raw"\u005cu0023"

--- a/src/library/scala/UninitializedError.scala
+++ b/src/library/scala/UninitializedError.scala
@@ -14,6 +14,6 @@ package scala
 
 /** This class represents uninitialized variable/value errors.
  */
-// TODO: remove in 2.14
+// TODO: remove
 @deprecated("will be removed in a future release", since = "2.12.7")
 final class UninitializedError extends RuntimeException("uninitialized value")

--- a/src/library/scala/annotation/showAsInfix.scala
+++ b/src/library/scala/annotation/showAsInfix.scala
@@ -35,5 +35,5 @@ package scala.annotation
   *
   * @param enabled whether to show this type as an infix type operator.
   */
-@deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
+@deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class showAsInfix(enabled: Boolean = true) extends annotation.StaticAnnotation

--- a/src/library/scala/annotation/strictfp.scala
+++ b/src/library/scala/annotation/strictfp.scala
@@ -15,5 +15,5 @@ package scala.annotation
 /** If this annotation is present on a method or its enclosing class,
  *  the strictfp flag will be emitted.
  */
-@deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
+@deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class strictfp extends scala.annotation.StaticAnnotation

--- a/src/library/scala/annotation/unspecialized.scala
+++ b/src/library/scala/annotation/unspecialized.scala
@@ -16,5 +16,5 @@ package scala.annotation
  *  additional specialized forms based on enclosing specialized
  *  type parameters.
  */
-@deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
+@deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class unspecialized extends scala.annotation.StaticAnnotation

--- a/src/library/scala/beans/BeanProperty.scala
+++ b/src/library/scala/beans/BeanProperty.scala
@@ -27,5 +27,5 @@ package scala.beans
  *  use the `scala.beans.BooleanBeanProperty` annotation instead.
  */
 @scala.annotation.meta.field
-@deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
+@deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class BeanProperty extends scala.annotation.StaticAnnotation

--- a/src/library/scala/beans/BooleanBeanProperty.scala
+++ b/src/library/scala/beans/BooleanBeanProperty.scala
@@ -17,5 +17,5 @@ package scala.beans
  *  named `isFieldName` instead of `getFieldName`.
  */
 @scala.annotation.meta.field
-@deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
+@deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class BooleanBeanProperty extends scala.annotation.StaticAnnotation

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -994,7 +994,7 @@ trait MapFactoryDefaults[K, +V,
   override protected def fromSpecific(coll: IterableOnce[(K, V @uncheckedVariance)]): CC[K, V @uncheckedVariance] = mapFactory.from(coll)
   override protected def newSpecificBuilder: mutable.Builder[(K, V @uncheckedVariance), CC[K, V @uncheckedVariance]] = mapFactory.newBuilder[K, V]
   override def empty: CC[K, V @uncheckedVariance] = (this: AnyRef) match {
-    // Implemented here instead of in TreeSeqMap since overriding empty in TreeSeqMap is not forwards compatible (should be moved for 2.14)
+    // Implemented here instead of in TreeSeqMap since overriding empty in TreeSeqMap is not forwards compatible (should be moved)
     case self: immutable.TreeSeqMap[K, V] => immutable.TreeSeqMap.empty(self.orderedBy).asInstanceOf[CC[K, V]]
     case _ => mapFactory.empty
   }

--- a/src/library/scala/collection/immutable/TreeSeqMap.scala
+++ b/src/library/scala/collection/immutable/TreeSeqMap.scala
@@ -67,7 +67,7 @@ final class TreeSeqMap[K, +V] private (
   override def isEmpty = size == 0
 
   /*
-  // This should have been overridden in 2.13.0 but wasn't so it will have to wait until 2.14 since it is not forwards compatible
+  // This should have been overridden in 2.13.0 but wasn't so it will have to wait since it is not forwards compatible
   // Now handled in inherited method from scala.collection.MapFactoryDefaults instead.
   override def empty = TreeSeqMap.empty[K, V](orderedBy)
   */

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -513,7 +513,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     this
   }
 
-  // TODO in 2.14: rename to `mapValuesInPlace` and override the base version (not binary compatible)
+  // TODO: rename to `mapValuesInPlace` and override the base version (not binary compatible)
   private[mutable] def mapValuesInPlaceImpl(f: (K, V) => V): this.type = {
     val len = table.length
     var i = 0

--- a/src/library/scala/compat/Platform.scala
+++ b/src/library/scala/compat/Platform.scala
@@ -13,7 +13,7 @@
 package scala
 package compat
 
-@deprecated("Will be removed in Scala 2.14.0.", since = "2.13.0")
+@deprecated("Will be removed in the future.", since = "2.13.0")
 object Platform {
 
   /** Thrown when a stack overflow occurs because a method or function recurses too deeply.

--- a/src/library/scala/concurrent/DelayedLazyVal.scala
+++ b/src/library/scala/concurrent/DelayedLazyVal.scala
@@ -24,7 +24,7 @@ package scala.concurrent
  *  @param  f      the function to obtain the current value at any point in time
  *  @param  body   the computation to run to completion in another thread
  */
-@deprecated("`DelayedLazyVal` Will be removed in Scala 2.14.0 release.", since = "2.13.0")
+@deprecated("`DelayedLazyVal` Will be removed in the future.", since = "2.13.0")
 class DelayedLazyVal[T](f: () => T, body: => Unit)(implicit exec: ExecutionContext){
   @volatile private[this] var _isDone = false
   private[this] lazy val complete = f()

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -791,7 +791,7 @@ object Future {
    * @return         the `Future` holding the result of the fold
    */
   @deprecated("use Future.foldLeft instead", "2.12.0")
-  // not removed in 2.13, to facilitate 2.11/2.12/2.13 cross-building; remove in 2.14 (see scala/scala#6319)
+  // not removed in 2.13, to facilitate 2.11/2.12/2.13 cross-building; remove further down the line (see scala/scala#6319)
   def fold[T, R](futures: IterableOnce[Future[T]])(zero: R)(@deprecatedName("foldFun") op: (R, T) => R)(implicit executor: ExecutionContext): Future[R] =
     if (futures.isEmpty) successful(zero)
     else sequence(futures)(ArrayBuffer, executor).map(_.foldLeft(zero)(op))
@@ -810,7 +810,7 @@ object Future {
    * @return         the `Future` holding the result of the reduce
    */
   @deprecated("use Future.reduceLeft instead", "2.12.0")
-  // not removed in 2.13, to facilitate 2.11/2.12/2.13 cross-building; remove in 2.14 (see scala/scala#6319)
+  // not removed in 2.13, to facilitate 2.11/2.12/2.13 cross-building; remove further down the line (see scala/scala#6319)
   final def reduce[T, R >: T](futures: IterableOnce[Future[T]])(op: (R, T) => R)(implicit executor: ExecutionContext): Future[R] =
     if (futures.isEmpty) failed(new NoSuchElementException("reduce attempted on empty collection"))
     else sequence(futures)(ArrayBuffer, executor).map(_ reduceLeft op)

--- a/src/library/scala/deprecated.scala
+++ b/src/library/scala/deprecated.scala
@@ -46,7 +46,7 @@ import scala.annotation.meta._
  *  be preserved at least for the current major version.
  *
  *  This means that an element deprecated in some 2.13.x release will be preserved in
- *  all 2.13.x releases, but may be removed in 2.14. (A deprecated element
+ *  all 2.13.x releases, but may be removed in the future. (A deprecated element
  *  might be kept longer to ease migration, but developers should not rely on this.)
  *
  *  @see    The official documentation on [[http://www.scala-lang.org/news/2.11.0/#binary-compatibility binary compatibility]].
@@ -57,5 +57,5 @@ import scala.annotation.meta._
  *  @see    [[scala.deprecatedName]]
  */
 @getter @setter @beanGetter @beanSetter @field
-@deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
+@deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class deprecated(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation

--- a/src/library/scala/deprecatedName.scala
+++ b/src/library/scala/deprecatedName.scala
@@ -41,7 +41,7 @@ import scala.annotation.meta._
   *  @see    [[scala.deprecatedOverriding]]
   */
 @param
-@deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
+@deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class deprecatedName(name: String = "<none>", since: String = "") extends scala.annotation.StaticAnnotation {
   @deprecated("The parameter name should be a String, not a symbol.", "2.13.0") def this(name: Symbol, since: String) = this(name.name, since)
   @deprecated("The parameter name should be a String, not a symbol.", "2.13.0") def this(name: Symbol) = this(name.name, "")

--- a/src/library/scala/deprecatedOverriding.scala
+++ b/src/library/scala/deprecatedOverriding.scala
@@ -48,5 +48,5 @@ import scala.annotation.meta._
  *  @see    [[scala.deprecatedName]]
  */
 @getter @setter @beanGetter @beanSetter
-@deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
+@deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class deprecatedOverriding(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation

--- a/src/library/scala/inline.scala
+++ b/src/library/scala/inline.scala
@@ -47,5 +47,5 @@ package scala
  * def t2 = f1(1) + (f1(1): @noinline) // the second call to f1 is not inlined
  * }}}
  */
-@deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
+@deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class inline extends scala.annotation.StaticAnnotation

--- a/src/library/scala/native.scala
+++ b/src/library/scala/native.scala
@@ -23,5 +23,5 @@ package scala
   *
   * A method marked @native must be a member of a class, not a trait (since 2.12).
   */
-@deprecatedInheritance("Scheduled for being final in 2.14", "2.13.0")
+@deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class native extends scala.annotation.StaticAnnotation {}

--- a/test/files/neg/caseclass_private_constructor.scala
+++ b/test/files/neg/caseclass_private_constructor.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:2.14
+// scalac: -Xsource:3
 
 case class A private (i: Int)
 object A

--- a/test/files/neg/deprecate_package_object_extends.scala
+++ b/test/files/neg/deprecate_package_object_extends.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -deprecation -Xsource:2.14
+// scalac: -Xfatal-warnings -deprecation -Xsource:3
 class C
 package object foo extends C
 

--- a/test/files/neg/deprecated-options.check
+++ b/test/files/neg/deprecated-options.check
@@ -1,6 +1,7 @@
+warning: -Xsource is deprecated: instead of -Xsource:2.14, use -Xsource:3
 warning: -Xfuture is deprecated: Not used since 2.13.
 warning: -optimize is deprecated: Since 2.12, enables -opt:l:inline -opt-inline-from:**. See -opt:help.
 warning: -Xexperimental is deprecated: Not used since 2.13.
 error: No warnings can be incurred under -Werror.
-3 warnings
+4 warnings
 1 error

--- a/test/files/neg/deprecated-options.scala
+++ b/test/files/neg/deprecated-options.scala
@@ -1,4 +1,4 @@
 //
-// scalac: -Werror -deprecation -optimise -Xexperimental -Xfuture
+// scalac: -Werror -deprecation -optimise -Xexperimental -Xfuture -Xsource:2.14
 //
 // Deprecated options are announced before compilation.

--- a/test/files/neg/early-type-defs.scala
+++ b/test/files/neg/early-type-defs.scala
@@ -1,4 +1,4 @@
 //
-// scalac: -deprecation -Xsource:2.14
+// scalac: -deprecation -Xsource:3
 //
 object Test extends { type A1 = Int } with Runnable { def run() = () }

--- a/test/files/neg/for-comprehension-val.scala
+++ b/test/files/neg/for-comprehension-val.scala
@@ -1,4 +1,4 @@
-// scalac: -deprecation -Xsource:2.14
+// scalac: -deprecation -Xsource:3
 //
 class A {
   for (x <- 1 to 5 ; y = x) yield x+y           // ok

--- a/test/files/neg/implicit-any2stringadd.scala
+++ b/test/files/neg/implicit-any2stringadd.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:2.14 -Xlog-implicits
+// scalac: -Xsource:3 -Xlog-implicits
 //
 object Test {
   true + "what"

--- a/test/files/neg/implicit-log.scala
+++ b/test/files/neg/implicit-log.scala
@@ -1,4 +1,4 @@
-/* scalac: -Xlog-implicits -Xsource:2.14 -Xfatal-warnings */
+/* scalac: -Xlog-implicits -Xsource:3 -Xfatal-warnings */
 
 package foo
 

--- a/test/files/neg/multiLineOps-b.scala
+++ b/test/files/neg/multiLineOps-b.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xsource:2.14
+// scalac: -Werror -Xsource:3
 
 class Test {
   val b1 = {

--- a/test/files/neg/multiLineOps-c.scala
+++ b/test/files/neg/multiLineOps-c.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xsource:2.14
+// scalac: -Werror -Xsource:3
 
 class Test {
   val x = 42

--- a/test/files/neg/multiLineOps.scala
+++ b/test/files/neg/multiLineOps.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xsource:2.14
+// scalac: -Werror -Xsource:3
 
 class Test {
   val x = 1

--- a/test/files/neg/procedure-removal.scala
+++ b/test/files/neg/procedure-removal.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:2.14
+// scalac: -Xsource:3
 //
 abstract class Foo {
   def bar {}

--- a/test/files/neg/symbol-literal-removal.scala
+++ b/test/files/neg/symbol-literal-removal.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:2.14
+// scalac: -Xsource:3
 //
 abstract class Foo {
   val foo = 'TestSymbol

--- a/test/files/neg/t2796.check
+++ b/test/files/neg/t2796.check
@@ -1,13 +1,13 @@
-t2796.scala:9: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+t2796.scala:9: warning: early initializers are deprecated; they will be replaced by trait parameters in 3.0, see the migration guide on avoiding var/val in traits.
 trait T1 extends {
                  ^
-t2796.scala:13: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+t2796.scala:13: warning: early initializers are deprecated; they will be replaced by trait parameters in 3.0, see the migration guide on avoiding var/val in traits.
 trait T2 extends {
                  ^
 t2796.scala:14: warning: early type members are deprecated: move them to the regular body; the semantics are the same
   type X = Int                       // warn
        ^
-t2796.scala:17: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+t2796.scala:17: warning: early initializers are deprecated; they will be replaced by trait parameters in 3.0, see the migration guide on avoiding var/val in traits.
 class C1 extends {
                  ^
 t2796.scala:10: warning: Implementation restriction: early definitions in traits are not initialized before the super class is initialized.

--- a/test/files/neg/t6595.check
+++ b/test/files/neg/t6595.check
@@ -1,4 +1,4 @@
-t6595.scala:5: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+t6595.scala:5: warning: early initializers are deprecated; they will be replaced by trait parameters in 3.0, see the migration guide on avoiding var/val in traits.
 class Foo extends {
                   ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t7187-3.check
+++ b/test/files/neg/t7187-3.check
@@ -1,22 +1,22 @@
-t7187-2.14.scala:13: error: type mismatch;
+t7187-3.scala:13: error: type mismatch;
  found   : Int
  required: () => Any
   val t1: () => Any  = m1   // error
                        ^
-t7187-2.14.scala:14: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => Any), rather than applied to `()`.
+t7187-3.scala:14: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => Any), rather than applied to `()`.
 Write m2() to invoke method m2, or change the expected type.
   val t2: () => Any  = m2   // eta-expanded with lint warning
                        ^
-t7187-2.14.scala:15: warning: An unapplied 0-arity method was eta-expanded (due to the expected type AcciSamZero, which is SAM-equivalent to () => Int), rather than applied to `()`.
+t7187-3.scala:15: warning: An unapplied 0-arity method was eta-expanded (due to the expected type AcciSamZero, which is SAM-equivalent to () => Int), rather than applied to `()`.
 Write m2() to invoke method m2, or change the expected type.
   val t2AcciSam: AcciSamZero = m2   // eta-expanded with lint warning + sam warning
                                ^
-t7187-2.14.scala:15: warning: Eta-expansion performed to meet expected type AcciSamZero, which is SAM-equivalent to () => Int,
+t7187-3.scala:15: warning: Eta-expansion performed to meet expected type AcciSamZero, which is SAM-equivalent to () => Int,
 even though trait AcciSamZero is not annotated with `@FunctionalInterface`;
 to suppress warning, add the annotation or write out the equivalent function literal.
   val t2AcciSam: AcciSamZero = m2   // eta-expanded with lint warning + sam warning
                                ^
-t7187-2.14.scala:16: warning: An unapplied 0-arity method was eta-expanded (due to the expected type SamZero, which is SAM-equivalent to () => Int), rather than applied to `()`.
+t7187-3.scala:16: warning: An unapplied 0-arity method was eta-expanded (due to the expected type SamZero, which is SAM-equivalent to () => Int), rather than applied to `()`.
 Write m2() to invoke method m2, or change the expected type.
   val t2Sam: SamZero = m2   // eta-expanded with lint warning
                        ^

--- a/test/files/neg/t7187-3.scala
+++ b/test/files/neg/t7187-3.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:2.14 -Xlint:eta-zero -Xlint:eta-sam
+// scalac: -Xsource:3 -Xlint:eta-zero -Xlint:eta-sam
 //
 trait AcciSamZero { def apply(): Int }
 
@@ -18,7 +18,7 @@ class EtaExpand214 {
 
   val t4 = m1 // apply
   val t5 = m2 // apply, ()-insertion
-  val t6 = m3 // eta-expansion in 2.14
+  val t6 = m3 // eta-expansion in 3.0
 
   val t4a: Int        = t4 // ok
   val t5a: Int        = t5 // ok

--- a/test/files/neg/t7187-deprecation.scala
+++ b/test/files/neg/t7187-deprecation.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:2.14 -deprecation -Werror
+// scalac: -Xsource:3 -deprecation -Werror
 //
 trait AcciSamZero { def apply(): Int }
 
@@ -22,7 +22,7 @@ class EtaExpand214 {
 
   val t4 = m1 // apply
   val t5 = m2 // apply, ()-insertion
-  val t6 = m3 // eta-expansion in 2.14
+  val t6 = m3 // eta-expansion in 3.0
 
   val t4a: Int        = t4 // ok
   val t5a: Int        = t5 // ok

--- a/test/files/neg/t7187.check
+++ b/test/files/neg/t7187.check
@@ -20,7 +20,7 @@ t7187.scala:29: error: _ must follow method; cannot follow String
 t7187.scala:38: error: missing argument list for method zup in class EtaExpandZeroArg
 Unapplied methods are only converted to functions when a function type is expected.
 You can make this conversion explicit by writing `zup _` or `zup(_)` instead of `zup`.
-  val t5a = zup // error in 2.13, eta-expansion in 2.14
+  val t5a = zup // error in 2.13, eta-expansion in 3.0
             ^
 t7187.scala:12: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => Any), rather than applied to `()`.
 Write foo() to invoke method foo, or change the expected type.

--- a/test/files/neg/t7187.scala
+++ b/test/files/neg/t7187.scala
@@ -35,7 +35,7 @@ class EtaExpandZeroArg {
   val t4d: () => Any = zap() _ // ok
 
   def zup(x: Int) = x
-  val t5a = zup // error in 2.13, eta-expansion in 2.14
+  val t5a = zup // error in 2.13, eta-expansion in 3.0
   val t5Fun: Int => Int = zup // ok
   val t5AcciSam: AcciSamOne = zup // ok, but warning
   val t5Sam: SamOne = zup // ok

--- a/test/files/neg/view-bounds-removal.scala
+++ b/test/files/neg/view-bounds-removal.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:2.14
+// scalac: -Xsource:3
 //
 object Test {
   def f[A <% Int](a: A) = null

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -1,4 +1,4 @@
-warn-unused-privates.scala:31: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+warn-unused-privates.scala:31: warning: early initializers are deprecated; they will be replaced by trait parameters in 3.0, see the migration guide on avoiding var/val in traits.
 class Boppy extends {
                     ^
 warn-unused-privates.scala:5: warning: private constructor in class Bippy is never used

--- a/test/files/pos/auto-application.scala
+++ b/test/files/pos/auto-application.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -deprecation -Xsource:2.14
+// scalac: -Werror -deprecation -Xsource:3
 //
 class Test {
   def a1(xs: List[String]): Int = xs.hashCode

--- a/test/files/pos/caseclass_private_constructor.scala
+++ b/test/files/pos/caseclass_private_constructor.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:2.14
+// scalac: -Xsource:3
 
 case class A private (i: Int)
 object A {

--- a/test/files/pos/lazyref-autoapply.scala
+++ b/test/files/pos/lazyref-autoapply.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xsource:2.14 -Xlint
+// scalac: -Werror -Xsource:3 -Xlint
 
 object Test {
   def doti(i: Int): Product = {

--- a/test/files/pos/multiLineOps.scala
+++ b/test/files/pos/multiLineOps.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xsource:2.14
+// scalac: -Werror -Xsource:3
 
 class Channel {
   def ! (msg: String): Channel = this

--- a/test/files/run/deprecate-early-type-defs.check
+++ b/test/files/run/deprecate-early-type-defs.check
@@ -1,4 +1,4 @@
-deprecate-early-type-defs.scala:3: warning: early initializers are deprecated; they will be replaced by trait parameters in 2.14, see the migration guide on avoiding var/val in traits.
+deprecate-early-type-defs.scala:3: warning: early initializers are deprecated; they will be replaced by trait parameters in 3.0, see the migration guide on avoiding var/val in traits.
 object Test extends { type T = Int } with App
                     ^
 deprecate-early-type-defs.scala:3: warning: early type members are deprecated: move them to the regular body; the semantics are the same

--- a/test/files/run/multiLineOps.scala
+++ b/test/files/run/multiLineOps.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:2.14
+// scalac: -Xsource:3
 //
 // without backticks, "not found: value +"
 //

--- a/test/files/run/t3220-214.scala
+++ b/test/files/run/t3220-214.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:2.14
+// scalac: -Xsource:3
 
 object Literals214 {
   def inTripleQuoted = """\u000A"""

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -168,6 +168,8 @@ class SettingsTest {
       assert(s"(${s.source.value} == ${ScalaVersion(expected)})", s.source.value == ScalaVersion(expected))
     }
     check(expected = "2.13.0") // default
+    check(expected = "3",      "-Xsource:2.14")
+    check(expected = "3",      "-Xsource:2.15")
     check(expected = "9.11.0", "-Xsource:9.11")
     check(expected = "9.10",   "-Xsource:9.10.0")
     check(expected = "9.12",   "-Xsource:9.12")


### PR DESCRIPTION
Back when it was introduced, Scala 2.14 was in the plan.  But now the plan is to not have a 2.14 as a transition to 3.0 but to transition straight from 2.13.  So this repoints 2.14 to 3.