### PR TITLE
Make the method `##` have no parameter list (instead of a single empty one)

### DIFF
--- a/src/library-aux/scala/Any.scala
+++ b/src/library-aux/scala/Any.scala
@@ -108,7 +108,7 @@ abstract class Any {
    *
    *  @return   a hash value consistent with ==
    */
-  final def ##(): Int = sys.error("##")
+  final def ## : Int = sys.error("##")
 
   /** Test whether the dynamic type of the receiver object is `T0`.
    *

--- a/test/files/neg/auto-application.check
+++ b/test/files/neg/auto-application.check
@@ -1,0 +1,10 @@
+auto-application.scala:2: error: Int does not take parameters
+  ("": Any).##()
+              ^
+auto-application.scala:3: error: Int does not take parameters
+  ("": AnyRef).##()
+                 ^
+auto-application.scala:4: error: Int does not take parameters
+  ("": Object).##()
+                 ^
+3 errors

--- a/test/files/neg/auto-application.scala
+++ b/test/files/neg/auto-application.scala
@@ -1,0 +1,5 @@
+class Test {
+  ("": Any).##()
+  ("": AnyRef).##()
+  ("": Object).##()
+}

--- a/test/files/pos/auto-application.scala
+++ b/test/files/pos/auto-application.scala
@@ -8,7 +8,6 @@ class Test {
   def a5(xs: List[String]): Class[_] = xs.getClass
   def a6(xs: List[String]): Class[_] = xs.getClass()
   def a7(xs: List[String]): Int = xs.##
-  def a8(xs: List[String]): Int = xs.##()
   def a9(x: Address): String = x.toString
   def a10(x: Address): String = x.toString()
   def a11(x: A): String = x.toString

--- a/test/files/presentation/callcc-interpreter.check
+++ b/test/files/presentation/callcc-interpreter.check
@@ -38,7 +38,7 @@ def toString(): String
 def unitM[A](a: A): callccInterpreter.M[A]
 def →[B](y: B): (callccInterpreter.type, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean

--- a/test/files/presentation/completion-implicit-chained.check
+++ b/test/files/presentation/completion-implicit-chained.check
@@ -11,7 +11,7 @@ def hashCode(): Int
 def map(x: Int => Int)(implicit a: DummyImplicit): test.O.type
 def toString(): String
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean

--- a/test/files/presentation/ide-bug-1000349.check
+++ b/test/files/presentation/ide-bug-1000349.check
@@ -17,7 +17,7 @@ def hashCode(): Int
 def toString(): String
 def →[B](y: B): (Foo, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean

--- a/test/files/presentation/ide-bug-1000475.check
+++ b/test/files/presentation/ide-bug-1000475.check
@@ -18,7 +18,7 @@ def hashCode(): Int
 def toString(): String
 def →[B](y: B): (Object, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean
@@ -50,7 +50,7 @@ def hashCode(): Int
 def toString(): String
 def →[B](y: B): (Object, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean
@@ -82,7 +82,7 @@ def hashCode(): Int
 def toString(): String
 def →[B](y: B): (Object, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean

--- a/test/files/presentation/ide-bug-1000531.check
+++ b/test/files/presentation/ide-bug-1000531.check
@@ -20,7 +20,7 @@ def next: T
 def toString(): String
 def →[B](y: B): (other.TestIterator[Nothing], B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean

--- a/test/files/presentation/implicit-member.check
+++ b/test/files/presentation/implicit-member.check
@@ -17,7 +17,7 @@ def toString(): String
 def →[B](y: B): (Implicit.type, B)
 final class AppliedImplicit[A] extends AnyRef
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean

--- a/test/files/presentation/infix-completion.check
+++ b/test/files/presentation/infix-completion.check
@@ -172,7 +172,7 @@ def |(x: Long): Long
 def |(x: Short): Int
 def →[B](y: B): (Int, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean

--- a/test/files/presentation/infix-completion2.check
+++ b/test/files/presentation/infix-completion2.check
@@ -172,7 +172,7 @@ def |(x: Long): Long
 def |(x: Short): Int
 def →[B](y: B): (Int, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean

--- a/test/files/presentation/ping-pong.check
+++ b/test/files/presentation/ping-pong.check
@@ -19,7 +19,7 @@ def hashCode(): Int
 def poke(): Unit
 def →[B](y: B): (Pong, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean
@@ -55,7 +55,7 @@ def name: String
 def poke: Unit
 def →[B](y: B): (Ping, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean

--- a/test/files/presentation/t5708.check
+++ b/test/files/presentation/t5708.check
@@ -22,7 +22,7 @@ def hashCode(): Int
 def toString(): String
 def →[B](y: B): (test.Compat.type, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean

--- a/test/files/presentation/visibility.check
+++ b/test/files/presentation/visibility.check
@@ -19,7 +19,7 @@ def someTests(other: accessibility.Foo): Unit
 def toString(): String
 def →[B](y: B): (accessibility.Foo, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean
@@ -56,7 +56,7 @@ def someTests(other: accessibility.Foo): Unit
 def toString(): String
 def →[B](y: B): (accessibility.Foo, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean
@@ -95,7 +95,7 @@ def someTests: Unit
 def toString(): String
 def →[B](y: B): (accessibility.AccessibilityChecks, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean
@@ -136,7 +136,7 @@ def someTests(other: accessibility.Foo): Unit
 def toString(): String
 def →[B](y: B): (accessibility.Foo, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean
@@ -175,7 +175,7 @@ def someTests(other: accessibility.Foo): Unit
 def toString(): String
 def →[B](y: B): (accessibility.Foo, B)
 final def !=(x$1: Any): Boolean
-final def ##(): Int
+final def ## : Int
 final def ==(x$1: Any): Boolean
 final def asInstanceOf[T0]: T0
 final def eq(x$1: AnyRef): Boolean

--- a/test/files/run/compiler-asSeenFrom.scala
+++ b/test/files/run/compiler-asSeenFrom.scala
@@ -148,10 +148,13 @@ package ll {
 
   def pretty(xs: List[_]) = if (xs.isEmpty) "" else xs.mkString("\n  ", "\n  ", "\n")
 
-  def signaturesIn(info: Type): List[String] = (
-    info.members.toList
-      filterNot (s => s.isType || s.owner == ObjectClass || s.owner == AnyClass || s.isConstructor)
-      map (_.defString)
+  def signaturesIn(sym: Symbol): List[String] = (
+    if (sym.owner == ObjectClass || sym.owner == AnyClass) Nil
+    else {
+      sym.tpe.members.toList
+        .filterNot(s => s.isType || s.owner == ObjectClass || s.owner == AnyClass || s.isConstructor)
+        .map(_.defString)
+    }
   )
 
   def check(source: String, unit: global.CompilationUnit) = {
@@ -161,10 +164,10 @@ package ll {
       val typeArgs = List[Type](IntClass.tpe, ListClass[Int]) ++ tparams.map(_.tpe)
       permute(typeArgs) foreach println
     }
-    for (x <- classes ++ terms) {
-      afterEachPhase(signaturesIn(x.tpe)) collect {
+    for (sym <- classes ++ terms) {
+      afterEachPhase(signaturesIn(sym)) collect {
         case (ph, sigs) if sigs.nonEmpty =>
-          println(sigs.mkString(x.toString + " { // after " + ph + "\n  ", "\n  ", "\n}\n"))
+          println(sigs.mkString(s"$sym { // after $ph\n  ", "\n  ", "\n}\n"))
       }
     }
   }

--- a/test/files/run/reflection-magicsymbols-invoke.check
+++ b/test/files/run/reflection-magicsymbols-invoke.check
@@ -3,7 +3,7 @@ Any
 it's important to print the list of Any's members
 if some of them change (possibly, adding and/or removing magic symbols), we must update this test
 method !=: (x$1: Any): Boolean
-method ##: (): Int
+method ##: Int
 method ==: (x$1: Any): Boolean
 method asInstanceOf: [T0]T0
 method equals: (x$1: Any): Boolean
@@ -36,7 +36,7 @@ it's important to print the list of AnyRef's members
 if some of them change (possibly, adding and/or removing magic symbols), we must update this test
 constructor Object: (): Object
 method !=: (x$1: Any): Boolean
-method ##: (): Int
+method ##: Int
 method $asInstanceOf: [T0](): T0
 method $isInstanceOf: [T0](): Boolean
 method ==: (x$1: Any): Boolean
@@ -81,7 +81,7 @@ it's important to print the list of Array's members
 if some of them change (possibly, adding and/or removing magic symbols), we must update this test
 constructor Array: (_length: Int): Array[T]
 method !=: (x$1: Any): Boolean
-method ##: (): Int
+method ##: Int
 method $asInstanceOf: [T0](): T0
 method $isInstanceOf: [T0](): Boolean
 method ==: (x$1: Any): Boolean

--- a/test/files/run/reflection-valueclasses-magic.check
+++ b/test/files/run/reflection-valueclasses-magic.check
@@ -11,7 +11,7 @@ method !=: (x: Float): Boolean
 method !=: (x: Int): Boolean
 method !=: (x: Long): Boolean
 method !=: (x: Short): Boolean
-method ##: (): Int
+method ##: Int
 method %: (x: Byte): Int
 method %: (x: Char): Int
 method %: (x: Double): Double
@@ -219,7 +219,7 @@ method !=: (x: Float): Boolean
 method !=: (x: Int): Boolean
 method !=: (x: Long): Boolean
 method !=: (x: Short): Boolean
-method ##: (): Int
+method ##: Int
 method %: (x: Byte): Int
 method %: (x: Char): Int
 method %: (x: Double): Double
@@ -427,7 +427,7 @@ method !=: (x: Float): Boolean
 method !=: (x: Int): Boolean
 method !=: (x: Long): Boolean
 method !=: (x: Short): Boolean
-method ##: (): Int
+method ##: Int
 method %: (x: Byte): Int
 method %: (x: Char): Int
 method %: (x: Double): Double
@@ -635,7 +635,7 @@ method !=: (x: Float): Boolean
 method !=: (x: Int): Boolean
 method !=: (x: Long): Boolean
 method !=: (x: Short): Boolean
-method ##: (): Int
+method ##: Int
 method %: (x: Byte): Int
 method %: (x: Char): Int
 method %: (x: Double): Double
@@ -843,7 +843,7 @@ method !=: (x: Float): Boolean
 method !=: (x: Int): Boolean
 method !=: (x: Long): Boolean
 method !=: (x: Short): Boolean
-method ##: (): Int
+method ##: Int
 method %: (x: Byte): Long
 method %: (x: Char): Long
 method %: (x: Double): Double
@@ -1051,7 +1051,7 @@ method !=: (x: Float): Boolean
 method !=: (x: Int): Boolean
 method !=: (x: Long): Boolean
 method !=: (x: Short): Boolean
-method ##: (): Int
+method ##: Int
 method %: (x: Byte): Float
 method %: (x: Char): Float
 method %: (x: Double): Double
@@ -1237,7 +1237,7 @@ method !=: (x: Float): Boolean
 method !=: (x: Int): Boolean
 method !=: (x: Long): Boolean
 method !=: (x: Short): Boolean
-method ##: (): Int
+method ##: Int
 method %: (x: Byte): Double
 method %: (x: Char): Double
 method %: (x: Double): Double
@@ -1417,7 +1417,7 @@ if some of them change (possibly, adding and/or removing magic symbols), we must
 constructor Boolean: (): Boolean
 method !=: (x$1: Any): Boolean
 method !=: (x: Boolean): Boolean
-method ##: (): Int
+method ##: Int
 method &&: (x: Boolean): Boolean
 method &: (x: Boolean): Boolean
 method ==: (x$1: Any): Boolean
@@ -1446,7 +1446,7 @@ it's important to print the list of Byte's members
 if some of them change (possibly, adding and/or removing magic symbols), we must update this test
 constructor Unit: (): Unit
 method !=: (x$1: Any): Boolean
-method ##: (): Int
+method ##: Int
 method ==: (x$1: Any): Boolean
 method asInstanceOf: [T0]T0
 method equals: (x$1: Any): Boolean


### PR DESCRIPTION
In Dotty, the method `##` has no parameter list (instead of having a single empty one), so this aligns Scala 2.13 to that.  It would appear calling `.##()` is highly unlikely so this was changed to error immediately (no warnings).