### PR TITLE
Adjust error message for order of constructors

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -520,7 +520,7 @@ trait ContextErrors {
           "Expected type was: " + pt.toLongString)
 
       def ConstructorsOrderError(tree: Tree) = {
-        issueNormalTypeError(tree, "called constructor's definition must precede calling constructor's definition")
+        issueNormalTypeError(tree, "self constructor invocation must refer to a constructor definition which precedes it, to prevent infinite cycles")
         setError(tree)
       }
 

--- a/test/files/neg/constrs.check
+++ b/test/files/neg/constrs.check
@@ -4,7 +4,7 @@ constrs.scala:6: error: type T is not a member of object test
 constrs.scala:6: error: value u is not a member of object test
     def this(y: Int)(z: Int)(t: this.T) = { this(this.u + y + z); Console.println(x) }
                                                       ^
-constrs.scala:10: error: called constructor's definition must precede calling constructor's definition
+constrs.scala:10: error: self constructor invocation must refer to a constructor definition which precedes it, to prevent infinite cycles
     def this() = this("abc")
                  ^
 constrs.scala:12: error: constructor invokes itself

--- a/test/files/neg/t10507.check
+++ b/test/files/neg/t10507.check
@@ -1,4 +1,4 @@
-Test_2.scala:2: error: called constructor's definition must precede calling constructor's definition
+Test_2.scala:2: error: self constructor invocation must refer to a constructor definition which precedes it, to prevent infinite cycles
   Macros_1.seq
            ^
 1 error

--- a/test/files/neg/t9045.check
+++ b/test/files/neg/t9045.check
@@ -1,7 +1,7 @@
 t9045.scala:3: error: constructor invokes itself
   def this(axes: Array[Int]) = this(axes)
                                ^
-t9045.scala:6: error: called constructor's definition must precede calling constructor's definition
+t9045.scala:6: error: self constructor invocation must refer to a constructor definition which precedes it, to prevent infinite cycles
   def this(d: Double) = this(d.toLong)
                         ^
 2 errors


### PR DESCRIPTION
The current wording made me look twice and squint during code review.

(Maybe because the subject is the "called constructor", which is also not the site of the error.)

Proposed wording is from the spec. It has some specese in "self constructor invocation", but on the upside now we know what to call it. Also, it explains why.

Deleted the phrase, "as a restriction," to avoid the impression that it is merely an implementation restriction.