### PR TITLE
Runtime mirror must follow class loader

### DIFF
--- a/test/files/run/t11915.check
+++ b/test/files/run/t11915.check
@@ -1,0 +1,4 @@
+val x: Int = 42
+val y: Option[Any] = Some(42)
+val x: Int = 27
+val y: Option[Any] = Some(27)

--- a/test/files/run/t11915.scala
+++ b/test/files/run/t11915.scala
@@ -1,0 +1,19 @@
+
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = """
+  |:power
+  |val x = 42
+  |val y = intp.valueOfTerm("x")
+  |:reset
+  |val x = 27
+  |val y = intp.valueOfTerm("x")
+  |:quit""".stripMargin
+
+  def valsOnly(s: String) = {
+    val r = raw"val [xy]:".r
+    r.findPrefixOf(s).nonEmpty
+  }
+  override def eval() = super.eval().filter(valsOnly)
+}


### PR DESCRIPTION
Cache but clear the mirror when class loader is reset.

Fixes scala/bug#11915