### PR TITLE
apiStatus annotation, user-land compilation warning/errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -189,6 +189,7 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUniverse#PerRunReporting.deprecationWarning"),
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.nowarn$"),
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.nowarn"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.apiStatus*"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.Settings#*.clearSetByUser"),
 
     ////////////////////////////////////////////////////////////////////////////// Vector backward compatiblity

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -88,7 +88,7 @@ trait Warnings {
          |  - silence certain deprecations: -Wconf:origin=some\\.lib\\..*&since>2.2:s
          |
          |Full list of message categories:
-         |${WarningCategory.all.keys.groupBy(_.split('-').head).toList.sortBy(_._1).map(_._2.toList.sorted.mkString(", ")).mkString(" - ", "\n - ", "")}
+         |${WarningCategory.builtIn.keys.groupBy(_.split('-').head).toList.sortBy(_._1).map(_._2.toList.sorted.mkString(", ")).mkString(" - ", "\n - ", "")}
          |
          |To suppress warnings locally, use the `scala.annotation.nowarn` annotation.
          |

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1244,6 +1244,9 @@ abstract class RefChecks extends Transform {
     // warnings after the first, but I think it'd be better if we didn't have to
     // arbitrarily choose one as more important than the other.
     private def checkUndesiredProperties(sym: Symbol, pos: Position): Unit = {
+      if (sym.isApiStatus && !currentOwner.ownerChain.exists(x => x.isApiStatus))
+        currentRun.reporting.handleApiStatus(pos, sym, currentOwner)
+
       // If symbol is deprecated, and the point of reference is not enclosed
       // in either a deprecated member or a scala bridge method, issue a warning.
       if (sym.isDeprecated && !currentOwner.ownerChain.exists(x => x.isDeprecated))

--- a/src/library/scala/annotation/apiStatus.scala
+++ b/src/library/scala/annotation/apiStatus.scala
@@ -66,6 +66,33 @@ import scala.annotation.meta._
  * Using `-Wconf:cat=api-may-change&origin=foo\..*:silent` option, the user of the library can opt out of
  * the `api-may-change` warnings afterwards.
  *
+ * ==Defining a custom status annotation==
+ * Instead of directly using `@apiStatus` we can create a specific status annotation by extending `apiStatus`.
+ * However, due to the information available to the compiler, the default values for `message`, `category`, or
+ * `defaultAction` can be specified through the corresponding meta-annotations.
+ *
+ * {{{
+ * import scala.annotation.{ apiStatus, apiStatusCategory, apiStatusDefaultAction }
+ * import scala.annotation.meta._
+ *
+ * @apiStatusCategory(apiStatus.Category.ApiMayChange)
+ * @apiStatusDefaultAction(apiStatus.Action.Warning)
+ * @companionClass @companionMethod
+ * final class apiMayChange(
+ *   message: String,
+ *   since: String = "",
+ * ) extends apiStatus(message, since = since)
+ * }}}
+ *
+ * This can be used as follows:
+ *
+ * {{{
+ * @apiMayChange("should DSL is incubating, and future compatibility is not guaranteed")
+ * implicit class ShouldDSL(s: String) {
+ *   def should(o: String): Unit = ()
+ * }
+ * }}}
+ *
  * @param  message the advisory to print during compilation
  * @param  category a string identifying the categorization of the restriction
  * @param  since a string identifying the first version in which the status is applied
@@ -77,9 +104,10 @@ import scala.annotation.meta._
 @getter @setter @beanGetter @beanSetter @companionClass @companionMethod
 class apiStatus(
   message: String,
-  category: String,
+  category: String = apiStatus.Category.Unspecified,
   since: String = "",
-  defaultAction: String = apiStatus.Action.Warning) extends scala.annotation.StaticAnnotation
+  defaultAction: String = apiStatus.Action.Warning,
+) extends scala.annotation.StaticAnnotation
 
 object apiStatus {
   object Action {
@@ -96,5 +124,21 @@ object apiStatus {
     final val InternalOnly = "internal-only"
     final val ApiMayChange = "api-may-change"
     final val Mistake      = "mistake"
+    final val Unspecified  = "unspecified"
   }
 }
+
+/**
+ * Consult the documentation in [[scala.annotation.apiStatus]].
+ */
+final class apiStatusMessage(message: String) extends scala.annotation.StaticAnnotation
+
+/**
+ * Consult the documentation in [[scala.annotation.apiStatus]].
+ */
+final class apiStatusDefaultAction(defaultAction: String) extends scala.annotation.StaticAnnotation
+
+/**
+ * Consult the documentation in [[scala.annotation.apiStatus]].
+ */
+final class apiStatusCategory(category: String) extends scala.annotation.StaticAnnotation

--- a/src/library/scala/annotation/apiStatus.scala
+++ b/src/library/scala/annotation/apiStatus.scala
@@ -1,0 +1,100 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+
+import scala.annotation.meta._
+
+/** An annotation to denote the API status, like [[scala.deprecated]] but more powerful.
+ * While `@deprecated` is only able to discourage someone from using the some API,
+ * `@apiStatus` can be more nuanced about the state (for instance `Category.ApiMayChange`),
+ * and choose the default compile-time actions (`Action.Error`, `Action.Warning`, etc).
+ *
+ * In other words, this gives library authors the lever to trigger compilation warning or
+ * compilation errors! Here's an example of displaying a migration message:
+ *
+ * {{{
+ * import scala.annotation.apiStatus, apiStatus._
+ * @apiStatus(
+ *   "method <<= is removed; use := syntax instead",
+ *   category = Category.ForRemoval,
+ *   since = "foo-lib 1.0",
+ *   defaultAction = Action.Error,
+ * )
+ * def <<=() = ???
+ * }}}
+ *
+ * The compilation will fail and display the migration message if the method is called:
+ *
+ * {{{
+ * example.scala:26: error: method <<= is removed; use := syntax instead (foo-lib 1.0)
+ *   <<=()
+ *   ^
+ * }}}
+ *
+ * Here's another example of displaying a warning:
+ *
+ * {{{
+ * import scala.annotation.apiStatus, apiStatus._
+ * @apiStatus(
+ *   "should DSL is incubating, and future compatibility is not guaranteed",
+ *   category = Category.ApiMayChange,
+ *   since = "foo-lib 1.0",
+ * )
+ * implicit class ShouldDSL(s: String) {
+ *   def should(o: String): Unit = ()
+ * }
+ * }}}
+ *
+ * The compiler will emit warnings:
+ *
+ * {{{
+ * example.scala:28: warning: should DSL is incubating, and future compatibility is not guaranteed (foo-lib 1.0)
+ *   "bar" should "something"
+ *   ^
+ * }}}
+ *
+ * Using `-Wconf:cat=api-may-change&origin=foo\..*:silent` option, the user of the library can opt out of
+ * the `api-may-change` warnings afterwards.
+ *
+ * @param  message the advisory to print during compilation
+ * @param  category a string identifying the categorization of the restriction
+ * @param  since a string identifying the first version in which the status is applied
+ * @param  defaultAction the default severity of the restriction when the annotee is referenced
+ * @since  2.13.2
+ * @see    [[scala.annotation.apiStatus.Action]]
+ * @see    [[scala.annotation.apiStatus.Category]]
+ */
+@getter @setter @beanGetter @beanSetter @companionClass @companionMethod
+class apiStatus(
+  message: String,
+  category: String,
+  since: String = "",
+  defaultAction: String = apiStatus.Action.Warning) extends scala.annotation.StaticAnnotation
+
+object apiStatus {
+  object Action {
+    final val Error          = "error"
+    final val Warning        = "warning"
+    final val WarningSummary = "warning-summary"
+    final val Info           = "info"
+    final val InfoSummary    = "info-summary"
+    final val Silent         = "silent"
+  }
+
+  object Category {
+    final val ForRemoval   = "for-removal"
+    final val InternalOnly = "internal-only"
+    final val ApiMayChange = "api-may-change"
+    final val Mistake      = "mistake"
+  }
+}

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1278,6 +1278,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val DeprecatedNameAttr         = requiredClass[scala.deprecatedName]
     lazy val DeprecatedInheritanceAttr  = requiredClass[scala.deprecatedInheritance]
     lazy val DeprecatedOverridingAttr   = requiredClass[scala.deprecatedOverriding]
+    lazy val ApiStatusAttr              = getClassIfDefined("scala.annotation.apiStatus")
     lazy val NativeAttr                 = requiredClass[scala.native]
     lazy val ScalaInlineClass           = requiredClass[scala.inline]
     lazy val ScalaNoInlineClass         = requiredClass[scala.noinline]

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1279,6 +1279,9 @@ trait Definitions extends api.StandardDefinitions {
     lazy val DeprecatedInheritanceAttr  = requiredClass[scala.deprecatedInheritance]
     lazy val DeprecatedOverridingAttr   = requiredClass[scala.deprecatedOverriding]
     lazy val ApiStatusAttr              = getClassIfDefined("scala.annotation.apiStatus")
+    lazy val ApiStatusMessageAttr       = getClassIfDefined("scala.annotation.apiStatusMessage")
+    lazy val ApiStatusDefaultActionAttr = getClassIfDefined("scala.annotation.apiStatusDefaultAction")
+    lazy val ApiStatusCategoryAttr      = getClassIfDefined("scala.annotation.apiStatusCategory")
     lazy val NativeAttr                 = requiredClass[scala.native]
     lazy val ScalaInlineClass           = requiredClass[scala.inline]
     lazy val ScalaNoInlineClass         = requiredClass[scala.noinline]

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -913,6 +913,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
                                = getAnnotation(DeprecatedOverridingAttr) flatMap (_ stringArg 0)
     def deprecatedOverridingVersion
                                = getAnnotation(DeprecatedOverridingAttr) flatMap (_ stringArg 1)
+    def isApiStatus            = hasAnnotation(ApiStatusAttr)
+    def apiStatusMessage       = getAnnotation(ApiStatusAttr) flatMap (_ stringArg 0)
+    def apiStatusCategory      = getAnnotation(ApiStatusAttr) flatMap (_ stringArg 1)
+    def apiStatusVersion       = getAnnotation(ApiStatusAttr) flatMap (_ stringArg 2)
+    def apiStatusDefaultAction = getAnnotation(ApiStatusAttr) flatMap (_ stringArg 3)
 
     // !!! when annotation arguments are not literal strings, but any sort of
     // assembly of strings, there is a fair chance they will turn up here not as

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -423,6 +423,9 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.DeprecatedInheritanceAttr
     definitions.DeprecatedOverridingAttr
     definitions.ApiStatusAttr
+    definitions.ApiStatusMessageAttr
+    definitions.ApiStatusDefaultActionAttr
+    definitions.ApiStatusCategoryAttr
     definitions.NativeAttr
     definitions.ScalaInlineClass
     definitions.ScalaNoInlineClass

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -422,6 +422,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.DeprecatedNameAttr
     definitions.DeprecatedInheritanceAttr
     definitions.DeprecatedOverridingAttr
+    definitions.ApiStatusAttr
     definitions.NativeAttr
     definitions.ScalaInlineClass
     definitions.ScalaNoInlineClass

--- a/test/files/neg/report-deprecated-error.check
+++ b/test/files/neg/report-deprecated-error.check
@@ -1,7 +1,7 @@
-report-deprecated-error.scala:26: error: method <<= is removed; use := syntax instead (foo-lib 1.0)
+report-deprecated-error.scala:34: error: method <<= is removed; use := syntax instead (foo-lib 1.0)
   <<=()
   ^
-report-deprecated-error.scala:28: warning: should DSL is incubating, and future compatibility is not guaranteed (foo-lib 1.0)
+report-deprecated-error.scala:36: warning: should DSL is incubating, and future compatibility is not guaranteed
   "bar" should {
   ^
 1 warning

--- a/test/files/neg/report-deprecated-error.check
+++ b/test/files/neg/report-deprecated-error.check
@@ -1,0 +1,8 @@
+report-deprecated-error.scala:26: error: method <<= is removed; use := syntax instead (foo-lib 1.0)
+  <<=()
+  ^
+report-deprecated-error.scala:28: warning: should DSL is incubating, and future compatibility is not guaranteed (foo-lib 1.0)
+  "bar" should {
+  ^
+1 warning
+1 error

--- a/test/files/neg/report-deprecated-error.scala
+++ b/test/files/neg/report-deprecated-error.scala
@@ -1,4 +1,5 @@
-import scala.annotation.apiStatus
+import scala.annotation.{ apiStatus, apiStatusCategory, apiStatusDefaultAction }
+import scala.annotation.meta._
 
 package foo {
   object syntax {
@@ -10,15 +11,22 @@ package foo {
     )
     def <<=() = ???
 
-    @apiStatus(
-      "should DSL is incubating, and future compatibility is not guaranteed",
-      category = apiStatus.Category.ApiMayChange,
-      since = "foo-lib 1.0",
-    )
+    @apiMayChange("should DSL is incubating, and future compatibility is not guaranteed")
     implicit class ShouldDSL(s: String) {
       def should(o: String): Unit = ()
     }
   }
+
+  /**
+   * Demo of custom API status annotation.
+   */
+  @apiStatusCategory(apiStatus.Category.ApiMayChange)
+  @apiStatusDefaultAction(apiStatus.Action.Warning)
+  @companionClass @companionMethod
+  final class apiMayChange(
+    message: String,
+    since: String = "",
+  ) extends apiStatus(message, since = since)
 }
 
 object Test1 {

--- a/test/files/neg/report-deprecated-error.scala
+++ b/test/files/neg/report-deprecated-error.scala
@@ -1,0 +1,31 @@
+import scala.annotation.apiStatus
+
+package foo {
+  object syntax {
+    @apiStatus(
+      "method <<= is removed; use := syntax instead",
+      category = apiStatus.Category.ForRemoval,
+      since = "foo-lib 1.0",
+      defaultAction = apiStatus.Action.Error,
+    )
+    def <<=() = ???
+
+    @apiStatus(
+      "should DSL is incubating, and future compatibility is not guaranteed",
+      category = apiStatus.Category.ApiMayChange,
+      since = "foo-lib 1.0",
+    )
+    implicit class ShouldDSL(s: String) {
+      def should(o: String): Unit = ()
+    }
+  }
+}
+
+object Test1 {
+  import foo.syntax._
+  <<=()
+
+  "bar" should {
+    "something"
+  }
+}

--- a/test/files/pos/wconf-apistatus.scala
+++ b/test/files/pos/wconf-apistatus.scala
@@ -1,0 +1,21 @@
+// scalac: -Werror -Wconf:cat=api-may-change&origin=foo\..*&since>0.999:silent
+
+import scala.annotation.apiStatus, apiStatus._
+
+package foo {
+  object syntax {
+    @apiStatus(
+      "should DSL is incubating, and future compatibility is not guaranteed",
+      category = Category.ApiMayChange,
+      since = "foo-lib 1.0",
+    )
+    implicit class ShouldDSL(s: String) {
+      def should(o: String): Unit = ()
+    }
+  }
+}
+
+object Test1 {
+  import foo.syntax._
+  "bar" should "something"
+}

--- a/test/files/pos/wconf-apistatus.scala
+++ b/test/files/pos/wconf-apistatus.scala
@@ -1,18 +1,30 @@
 // scalac: -Werror -Wconf:cat=api-may-change&origin=foo\..*&since>0.999:silent
 
-import scala.annotation.apiStatus, apiStatus._
+import scala.annotation.{ apiStatus, apiStatusCategory, apiStatusDefaultAction }
+import scala.annotation.meta._
+import apiStatus._
 
 package foo {
   object syntax {
-    @apiStatus(
+    @apiMayChange(
       "should DSL is incubating, and future compatibility is not guaranteed",
-      category = Category.ApiMayChange,
       since = "foo-lib 1.0",
     )
     implicit class ShouldDSL(s: String) {
       def should(o: String): Unit = ()
     }
   }
+
+  /**
+   * Demo of custom API status annotation.
+   */
+  @apiStatusCategory(apiStatus.Category.ApiMayChange)
+  @apiStatusDefaultAction(apiStatus.Action.Warning)
+  @companionClass @companionMethod
+  final class apiMayChange(
+    message: String,
+    since: String = "",
+  ) extends apiStatus(message, since = since)
 }
 
 object Test1 {

--- a/test/junit/scala/tools/nsc/reporters/WConfTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/WConfTest.scala
@@ -131,7 +131,7 @@ class WConfTest extends BytecodeTesting {
   @Test
   def warnVerbose(): Unit = {
     check(reports(code, "any:wv"), List(
-      l5a.copy(_2 = "[deprecation @ A.invokeDeprecated | origin=A.f | version=] " + l5a._2),
+      l5a.copy(_2 = "[deprecation @ A.invokeDeprecated | origin=A.f] " + l5a._2),
       l5b.copy(_2 = "[deprecation @ A.invokeDeprecated | origin=A.g | version=1.2.3] " + l5b._2),
       l7.copy(_2 = "[feature-reflective-calls @ A.featureReflectiveCalls] " + l7._2),
       l9.copy(_2 = "[other-pure-statement @ A.pureExpressionAsStatement] " + l9._2),
@@ -319,8 +319,7 @@ class WConfTest extends BytecodeTesting {
         override lazy val canonicalPath: String = p
       }, Array()), 0),
       msg = "",
-      WarningCategory.Other,
-      site = "")
+      WarningCategory.Other)
 
     val aTest = Reporting.WConf.parseFilter("src=a/.*Test.scala", rootDir = "").getOrElse(null)
     assertTrue(aTest.matches(m("/a/FooTest.scala")))


### PR DESCRIPTION
This implements `apiStatus` annotation as a generic form of `deprecated` annotation. `apiStatus` takes `category` and `defaultAction` parameters, corresponding to configurable warning's category and action.

One of the usage is to trigger compiler error from the library when a method is invoked to display migration message. Another usage would be to denote bincompat status of the API as warning.

This is a resend of #7790 based on the configurable warnings.
Ref #8373 / https://twitter.com/not_xuwei_k/status/1240354073297268737
Ref https://github.com/scala/scala/pull/7528

### From Scaladoc

An annotation to denote the API status, like `scala.deprecated` but more powerful.
While `@deprecated` is only able to discourage someone from using the some API,
`@apiStatus` can be more nuanced about the state (for instance `Category.ApiMayChange`),
and choose the default compile-time actions (`Action.Error`, `Action.Warning`, etc).

In other words, this gives library authors the lever to trigger compilation warning or
compilation errors! Here's an example of displaying a migration message:

```scala
import scala.annotation.apiStatus, apiStatus._
@apiStatus(
  "method <<= is removed; use := syntax instead",
  category = Category.ForRemoval,
  since = "foo-lib 1.0",
  defaultAction = Action.Error,
)
def <<=() = ???
```

The compilation will fail and display the migration message if the method is called:

```scala
example.scala:26: error: method <<= is removed; use := syntax instead (foo-lib 1.0)
  <<=()
  ^
```

Here's another example of displaying a warning:

```scala
import scala.annotation.apiStatus, apiStatus._
@apiStatus(
  "should DSL is incubating, and future compatibility is not guaranteed",
  category = Category.ApiMayChange,
  since = "foo-lib 1.0",
)
implicit class ShouldDSL(s: String) {
  def should(o: String): Unit = ()
}
```

The compiler will emit warnings:

```scala
example.scala:28: warning: should DSL is incubating, and future compatibility is not guaranteed (foo-lib 1.0)
  "bar" should "something"
  ^
```

Using `-Wconf:cat=api-may-change&origin=foo\..*:silent` option, the user of the library can opt out of the `api-may-change` warnings afterwards.

### Defining a custom status annotation
 
Instead of directly using `@apiStatus` we can create a specific status annotation by extending `apiStatus`. However, due to the information available to the compiler, the default values for `message`, `category`, or `defaultAction` can be specified through the corresponding meta-annotations.
 
```scala
import scala.annotation.{ apiStatus, apiStatusCategory, apiStatusDefaultAction }
import scala.annotation.meta._

@apiStatusCategory(apiStatus.Category.ApiMayChange)
@apiStatusDefaultAction(apiStatus.Action.Warning)
@companionClass @companionMethod
final class apiMayChange(
  message: String,
  since: String = "",
) extends apiStatus(message, since = since)
```

 This can be used as follows:

```scala
@apiMayChange("should DSL is incubating, and future compatibility is not guaranteed")
implicit class ShouldDSL(s: String) {
  def should(o: String): Unit = ()
}
 ```
