### PR TITLE
better diagnostics from AllocationTest

### DIFF
--- a/test/junit/scala/tools/testing/AllocationTest.scala
+++ b/test/junit/scala/tools/testing/AllocationTest.scala
@@ -5,6 +5,8 @@ import java.lang.management.ManagementFactory
 
 import org.junit.Assert.{assertEquals, assertTrue, fail}
 
+import scala.reflect.{ClassTag, classTag}
+
 object AllocationTest {
   val allocationCounter = ManagementFactory.getThreadMXBean.asInstanceOf[com.sun.management.ThreadMXBean]
   assertTrue(allocationCounter.isThreadAllocatedMemorySupported)
@@ -28,22 +30,30 @@ object AllocationTest {
     def double = 1D
 
     def unit = ()
+
+    def sizeOf[T <: AnyRef](fn: => T): T = fn
   }
   private def trace(Type:String, value:Long) :Long = {
     println(s"cost of tracking allocations - cost of $Type   = $value")
     value
   }
 
-  lazy val costObject:  Long = trace("Object", coster.allocationInfoImpl(coster, new AllocationExecution(), 0).min)
-  lazy val costByte:    Long =  trace("Byte", coster.allocationInfoImpl(coster.byte, new AllocationExecution(), 0).min)
-  lazy val costShort:   Long =  trace("Short", coster.allocationInfoImpl(coster.short, new AllocationExecution(), 0).min)
-  lazy val costInt:     Long =  trace("Int", coster.allocationInfoImpl(coster.int, new AllocationExecution(), 0).min)
-  lazy val costLong:    Long =  trace("Long", coster.allocationInfoImpl(coster.long, new AllocationExecution(), 0).min)
-  lazy val costBoolean: Long =  trace("Boolean", coster.allocationInfoImpl(coster.boolean, new AllocationExecution(), 0).min)
-  lazy val costChar:    Long =  trace("Char", coster.allocationInfoImpl(coster.char, new AllocationExecution(), 0).min)
-  lazy val costFloat:   Long =  trace("Float", coster.allocationInfoImpl(coster.float, new AllocationExecution(), 0).min)
-  lazy val costDouble:  Long =  trace("Double", coster.allocationInfoImpl(coster.double, new AllocationExecution(), 0).min)
-  lazy val costUnit:    Long =  trace("Unit", coster.allocationInfoImpl(coster.unit, new AllocationExecution(), 0).min)
+  lazy val costObject:  Long = trace("Object", coster.allocationInfoImpl(coster, new AllocationExecution(), 0, "", false).min)
+  lazy val costByte:    Long =  trace("Byte", coster.allocationInfoImpl(coster.byte, new AllocationExecution(), 0, "", false).min)
+  lazy val costShort:   Long =  trace("Short", coster.allocationInfoImpl(coster.short, new AllocationExecution(), 0, "", false).min)
+  lazy val costInt:     Long =  trace("Int", coster.allocationInfoImpl(coster.int, new AllocationExecution(), 0, "", false).min)
+  lazy val costLong:    Long =  trace("Long", coster.allocationInfoImpl(coster.long, new AllocationExecution(), 0, "", false).min)
+  lazy val costBoolean: Long =  trace("Boolean", coster.allocationInfoImpl(coster.boolean, new AllocationExecution(), 0, "", false).min)
+  lazy val costChar:    Long =  trace("Char", coster.allocationInfoImpl(coster.char, new AllocationExecution(), 0, "", false).min)
+  lazy val costFloat:   Long =  trace("Float", coster.allocationInfoImpl(coster.float, new AllocationExecution(), 0, "", false).min)
+  lazy val costDouble:  Long =  trace("Double", coster.allocationInfoImpl(coster.double, new AllocationExecution(), 0, "", false).min)
+  lazy val costUnit:    Long =  trace("Unit", coster.allocationInfoImpl(coster.unit, new AllocationExecution(), 0, "", false).min)
+
+  def sizeOf[T <: AnyRef](fn: => T, msg: String, ignoreEqualCheck: Boolean = false): Long = {
+    val size = coster.allocationInfoImpl(coster.sizeOf(fn), new AllocationExecution(), costObject, msg, ignoreEqualCheck).min
+    println(s"size of $msg = $size")
+    size
+  }
 
 }
 
@@ -51,35 +61,49 @@ trait AllocationTest {
 
   import AllocationTest._
 
-  def nonAllocating[T: Manifest](fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): T = {
-    onlyAllocates(0)(fn)
+  def nonAllocating[T: ClassTag](fn: => T, text: String = "", ignoreEqualCheck: Boolean = false)(implicit execution: AllocationExecution = AllocationExecution()): T = {
+    onlyAllocates(0, text, ignoreEqualCheck)(fn)
+  }
+  private def printAllocations[T: ClassTag](result: AllocationInfo[T]): String = {
+    var last = -1L
+    var count = 0
+    val sb = new StringBuilder
+    sb.append("Start allocation detail\n")
+    def printNow(next: Long): Unit = {
+      if (last != -1)
+        sb.append(s"allocation $last ($count times)\n")
+      last = next
+      count = 1
+    }
+    result.allocations foreach {
+      a =>
+        if (a == last) count += 1
+        else printNow(a)
+    }
+    printNow(-1)
+    sb.append("End allocation detail")
+    sb.toString
   }
 
-  def onlyAllocates[T: Manifest](size: Int)(fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): T = {
-    val result = allocationInfo(fn)
+  def onlyAllocates[T: ClassTag](size: Long, text: String = "", ignoreEqualCheck: Boolean = false)(fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): T = {
+    val result = allocationInfo(fn, text, ignoreEqualCheck)
 
     if (result.min > size) {
-      result.allocations foreach {
-        x => println(s"allocation $x")
-      }
-      fail(s"allocating min = ${result.min}")
+      fail(s"allocating min = ${result.min} allowed = ${size}${if (text.isEmpty) "" else s" -- $text"}\n result was ${result.result}\n result class ${if (result.result == null) "<null>" else result.result.getClass.getName}\n${printAllocations(result)}")
     }
     result.result
   }
-  def exactAllocates[T: Manifest](size:Int)(fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): T = {
-    val result = allocationInfo(fn)
+  def exactAllocates[T: ClassTag](size:Long, text: String = "", ignoreEqualCheck: Boolean = false)(fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): T = {
+    val result = allocationInfo(fn, text, ignoreEqualCheck)
 
     if (result.min != size) {
-      result.allocations foreach {
-        x => println(s"allocation $x")
-      }
-      fail(s"allocating min = ${result.min}")
+      fail(s"allocating min = ${result.min} allowed = ${size}${if (text.isEmpty) "" else s" -- $text"}\n result was ${result.result}\n result class ${if (result.result == null) "<null>" else result.result.getClass.getName}\n${printAllocations(result)}")
     }
     result.result
   }
 
-  def allocationInfo[T: Manifest](fn: => T)(implicit execution: AllocationExecution = AllocationExecution()): AllocationInfo[T] = {
-    val cls = manifest[T].runtimeClass
+  def allocationInfo[T: ClassTag](fn: => T, text: String, ignoreEqualCheck: Boolean)(implicit execution: AllocationExecution = AllocationExecution()): AllocationInfo[T] = {
+    val cls = classTag[T].runtimeClass
     val cost =
       if (cls == classOf[Byte]) costByte
       else if (cls == classOf[Short]) costShort
@@ -92,10 +116,10 @@ trait AllocationTest {
       else if (cls == classOf[Unit]) costUnit
       else if (cls.isPrimitive) ???
       else costObject
-    allocationInfoImpl(fn, execution, cost)
+    allocationInfoImpl(fn, execution, cost, text, ignoreEqualCheck)
   }
 
-  private[AllocationTest] def allocationInfoImpl[T](fn: => T, execution: AllocationExecution, cost: Long): AllocationInfo[T] = {
+  private[AllocationTest] def allocationInfoImpl[T](fn: => T, execution: AllocationExecution, cost: Long, text: String, ignoreEqualCheck: Boolean): AllocationInfo[T] = {
     val expected = fn
     val id = Thread.currentThread().getId
 
@@ -103,7 +127,7 @@ trait AllocationTest {
     //warmup
     while (i < execution.warmupCount) {
       val actual = fn
-      if (actual != expected)
+      if (!ignoreEqualCheck && actual != expected)
         assertEquals(s"warmup at index $i $expected $actual", expected, actual)
       i += 1
     }
@@ -116,7 +140,7 @@ trait AllocationTest {
       val actual = fn
       val after: Long = allocationCounter.getThreadAllocatedBytes(id)
       counts(i) = after - cost - before
-      if (actual != expected)
+      if (!ignoreEqualCheck && actual != expected)
         assertEquals(s"at index $i $expected $actual", expected, actual)
       i += 1
     }


### PR DESCRIPTION
This doesn't change the general functionality much
1. add an optional diagnostics text to the check
1. option to ignore the equals check
1. use of `ClassTag` rather than `Manifest`
1. Introduce a `sizeOf` method to facilitate testing

the main change is when a test fails, so get a summary of the allocations, not one line for each of the 1000 failures