### PR TITLE
`Map.WithDefault.get` should return the same result as `Map.WithDefault.apply`

### DIFF
--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -19,6 +19,8 @@ import scala.collection.generic.DefaultSerializable
 import scala.collection.immutable.Map.Map4
 import scala.collection.mutable.{Builder, ReusableBuilder}
 
+import scala.util.control.NonFatal
+
 /** Base type of immutable Maps */
 trait Map[K, +V]
   extends Iterable[(K, V)]
@@ -177,7 +179,8 @@ object Map extends MapFactory[Map] {
     extends AbstractMap[K, V]
       with MapOps[K, V, Map, WithDefault[K, V]] with Serializable {
 
-    def get(key: K): Option[V] = underlying.get(key)
+    override def get(key: K): Option[V] =
+      underlying.get(key).orElse(try Some(defaultValue(key)) catch { case NonFatal(_) => None })
 
     override def default(key: K): V = defaultValue(key)
 

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -14,6 +14,8 @@ package scala
 package collection
 package mutable
 
+import scala.util.control.NonFatal
+
 /** Base type of mutable Maps */
 trait Map[K, V]
   extends Iterable[(K, V)]
@@ -241,7 +243,8 @@ object Map extends MapFactory.Delegate[Map](HashMap) {
 
     override def clear(): Unit = underlying.clear()
 
-    def get(key: K): Option[V] = underlying.get(key)
+    override def get(key: K): Option[V] =
+      underlying.get(key).orElse(try Some(defaultValue(key)) catch { case NonFatal(_) => None })
 
     def subtractOne(elem: K): WithDefault.this.type = { underlying.subtractOne(elem); this }
 


### PR DESCRIPTION
Hi everyone,

I was hit by this today.

I think that the result of `Map.WithDefault.get` should be the same as `Map.WithDefault.apply`.

It's not the case right now:

```scala
val map = Map(1 -> 1).withDefaultValue(2)

map(36) // => 2
map.get(36) // => None. IMHO, should be `Some(2)`
```

Let me know what you think about it.
If you like it. Can you indicate me where I should write the tests please? 

Jules 🙂