### PR TITLE
Do not rely on `ArrayIndexOOBE` in new-Vector `Vector.{head,last}`.

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -250,15 +250,16 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
     new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${length-1})")
 
   override final def head: A =
-    try prefix1(0).asInstanceOf[A]
-    catch { case _: ArrayIndexOutOfBoundsException => throw new NoSuchElementException("empty.head") }
+    if (prefix1.length == 0) throw new NoSuchElementException("empty.head")
+    else prefix1(0).asInstanceOf[A]
 
-  override final def last: A = try {
+  override final def last: A = {
     if(this.isInstanceOf[BigVector[_]]) {
-      val v = this.asInstanceOf[BigVector[_]]
-      v.suffix1(v.suffix1.length-1)
+      val suffix = this.asInstanceOf[BigVector[_]].suffix1
+      if(suffix.length == 0) throw new NoSuchElementException("empty.tail")
+      else suffix(suffix.length-1)
     } else prefix1(prefix1.length-1)
-  }.asInstanceOf[A] catch { case _: ArrayIndexOutOfBoundsException => throw new NoSuchElementException("empty.tail") }
+  }.asInstanceOf[A]
 
   override final def foreach[U](f: A => U): Unit = {
     val c = vectorSliceCount


### PR DESCRIPTION
This is necessary for Scala.js, where `ArrayIndexOutOfBoundsException`s are Undefined Behavior, and cannot be reliably caught.

Those methods throw a `NoSuchElementException` for an empty vector, and those exceptions have never been considered UB in Scala.js before. It is therefore a breach of contract for `Vector.{head,last}` to become UB on empty vectors.

There are many other places where we catch AIOOBEs, but in those other places we throw an `IndexOutOfBoundsException` instead. While it is not quite correct to turn them into UBs either, at *least* there is precedent for OOBEs to be considered UB in Scala.js. So this commit does not change them, being afraid of the consequences to JVM performance.

It *is* still bad, though (index out of bounds on Scala collections were never UB before), but at least it is a bit less bad than before.

---

This combines with #8828 to fix https://github.com/scala/bug/issues/11920.