### PR TITLE
[SUPERSEDED] Inherited members have same binding level as package level [ci: last-only]

### DIFF
--- a/spec/02-identifiers-names-and-scopes.md
+++ b/spec/02-identifiers-names-and-scopes.md
@@ -17,14 +17,14 @@ which are collectively called _bindings_.
 Bindings of different kinds have a precedence defined on them:
 
 1. Definitions and declarations that are local, inherited, or made
-   available by a package clause and also defined in the same compilation unit
+   available by a package clause, and also defined in the same compilation unit
    as the reference to them, have highest precedence.
 1. Explicit imports have next highest precedence.
 1. Wildcard imports have next highest precedence.
-1. Definitions made available by a package clause, but not also defined in the
-   same compilation unit as the reference to them, as well as imports which
-   are supplied by the compiler but not explicitly written in source code,
-   have lowest precedence.
+1. Bindings made available by definitions in other compilation units than the unit
+   containing the reference to them have lowest precedence. Such bindings may be
+   introduced by a package clause, inheritance, or imports which
+   are supplied by the compiler but not explicitly written in source code.
 
 There are two different name spaces, one for [types](03-types.html#types)
 and one for [terms](06-expressions.html#expressions). The same name may designate a

--- a/src/compiler/scala/reflect/macros/compiler/Errors.scala
+++ b/src/compiler/scala/reflect/macros/compiler/Errors.scala
@@ -19,10 +19,10 @@ import scala.reflect.macros.util.Traces
 trait Errors extends Traces {
   self: DefaultMacroCompiler =>
 
-  import global._
-  import analyzer._
+  import global.{abort => _, _}
+  import analyzer.{global => _, _}
   import definitions._
-  import treeInfo._
+  import treeInfo.{global => _, _}
   import typer.infer.InferErrorGen._
   import runDefinitions._
   def globalSettings = global.settings

--- a/src/compiler/scala/reflect/macros/compiler/Resolvers.scala
+++ b/src/compiler/scala/reflect/macros/compiler/Resolvers.scala
@@ -16,7 +16,7 @@ package compiler
 trait Resolvers {
   self: DefaultMacroCompiler =>
 
-  import global._
+  import global.{abort => _, _}
   import analyzer._
   import treeInfo._
 

--- a/src/compiler/scala/reflect/macros/compiler/Validators.scala
+++ b/src/compiler/scala/reflect/macros/compiler/Validators.scala
@@ -19,7 +19,7 @@ trait Validators {
   self: DefaultMacroCompiler =>
 
   import global._
-  import analyzer._
+  import analyzer.{isBlackbox => _, _}
   import definitions._
   import runDefinitions.Predef_???
 

--- a/src/compiler/scala/reflect/macros/contexts/ExprUtils.scala
+++ b/src/compiler/scala/reflect/macros/contexts/ExprUtils.scala
@@ -16,7 +16,7 @@ package contexts
 trait ExprUtils {
   self: Context =>
 
-  import universe._
+  import universe.{definitions, Constant, Literal}
 
   def literalNull = Expr[Null](Literal(Constant(null)))(TypeTag.Null)
 

--- a/src/compiler/scala/reflect/quasiquotes/Parsers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Parsers.scala
@@ -91,7 +91,7 @@ trait Parsers { self: Quasiquotes =>
               case _ => gen.mkBlock(stats, doFlatten = true)
             }
           case nme.unapply => gen.mkBlock(stats, doFlatten = false)
-          case other       => global.abort("unreachable")
+          case other       => this.global.abort("unreachable")
         }
 
         // tq"$a => $b"

--- a/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
@@ -18,7 +18,7 @@ import scala.reflect.reify.{Reifier => ReflectReifier}
 import scala.reflect.internal.Flags._
 
 trait Reifiers { self: Quasiquotes =>
-  import global._
+  import global.{reify => _, _}
   import global.build._
   import global.definitions._
   import Rank._

--- a/src/compiler/scala/reflect/reify/Phases.scala
+++ b/src/compiler/scala/reflect/reify/Phases.scala
@@ -21,7 +21,7 @@ trait Phases extends Reshape
 
   self: Reifier =>
 
-  import global._
+  import global.{reify => _, _}
 
   private var alreadyRun = false
 

--- a/src/compiler/scala/reflect/reify/Reifier.scala
+++ b/src/compiler/scala/reflect/reify/Reifier.scala
@@ -26,7 +26,7 @@ abstract class Reifier extends States
                           with Utils {
 
   val global: Global
-  import global._
+  import global.{reify => _, _}
   import definitions._
   private val runDefinitions = currentRun.runDefinitions
 

--- a/src/compiler/scala/reflect/reify/codegen/GenAnnotationInfos.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenAnnotationInfos.scala
@@ -16,7 +16,7 @@ package codegen
 trait GenAnnotationInfos {
   self: Reifier =>
 
-  import global._
+  import global.{reify => _, _}
 
   // usually annotations are reified as their originals from Modifiers
   // however, when reifying free and tough types, we're forced to reify annotation infos as is

--- a/src/compiler/scala/reflect/reify/codegen/GenSymbols.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenSymbols.scala
@@ -18,7 +18,7 @@ import scala.reflect.internal.Flags._
 trait GenSymbols {
   self: Reifier =>
 
-  import global._
+  import global.{reify => _, _}
 
   /** Symbol table of the reifee.
    *

--- a/src/compiler/scala/reflect/reify/codegen/GenTrees.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenTrees.scala
@@ -16,7 +16,7 @@ package codegen
 trait GenTrees {
   self: Reifier =>
 
-  import global._
+  import global.{reify => _, _}
   import definitions._
 
   // unfortunately, these are necessary to reify AnnotatedTypes

--- a/src/compiler/scala/reflect/reify/codegen/GenTypes.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenTypes.scala
@@ -16,7 +16,7 @@ package codegen
 trait GenTypes {
   self: Reifier =>
 
-  import global._
+  import global.{reify => _, _}
   import definitions._
   private val runDefinitions = currentRun.runDefinitions
   import runDefinitions.{ReflectRuntimeUniverse, ReflectRuntimeCurrentMirror, _}

--- a/src/compiler/scala/reflect/reify/codegen/GenUtils.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenUtils.scala
@@ -18,7 +18,7 @@ import scala.annotation.tailrec
 trait GenUtils {
   self: Reifier =>
 
-  import global._
+  import global.{reify => _, _}
 
   def reifyList(xs: List[Any]): Tree =
     mkList(xs map reify)
@@ -57,7 +57,7 @@ trait GenUtils {
     call("" + nme.UNIVERSE_BUILD_PREFIX + name, args: _*)
 
   def reifyBuildCall(name: TermName, args: Any*) =
-      mirrorBuildCall(name, args map reify: _*)
+    mirrorBuildCall(name, args.map(reify): _*)
 
   def mirrorMirrorCall(name: TermName, args: Tree*): Tree =
     call("" + nme.MIRROR_PREFIX + name, args: _*)

--- a/src/compiler/scala/reflect/reify/phases/Metalevels.scala
+++ b/src/compiler/scala/reflect/reify/phases/Metalevels.scala
@@ -18,7 +18,7 @@ import scala.collection.mutable
 trait Metalevels {
   self: Reifier =>
 
-  import global._
+  import global.{reify => _, _}
 
   /**
    *  Makes sense of cross-stage bindings.

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1153,7 +1153,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       def iterator: Iterator[CompilationUnit] = new collection.AbstractIterator[CompilationUnit] {
         private var used = 0
         def hasNext = self.synchronized{ used < underlying.size }
-        def next = self.synchronized {
+        def next() = self.synchronized {
           if (!hasNext) throw new NoSuchElementException("next on empty Iterator")
           used += 1
           underlying(used-1)

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -10,16 +10,14 @@
  * additional information regarding copyright ownership.
  */
 
-package scala
-package tools
-package nsc
+package scala.tools.nsc
 
 import java.util.regex.PatternSyntaxException
 
 import scala.collection.mutable
 import scala.reflect.internal
+import scala.reflect.internal.util.SourceFile
 import scala.reflect.internal.util.StringOps.countElementsAsString
-import scala.reflect.internal.util.{Position, SourceFile}
 import scala.tools.nsc.Reporting.Version.{NonParseableVersion, ParseableVersion}
 import scala.tools.nsc.Reporting._
 import scala.util.matching.Regex
@@ -285,6 +283,7 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
 }
 
 object Reporting {
+  import scala.reflect.internal.util.Position
   sealed trait Message {
     def pos: Position
     def msg: String

--- a/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
@@ -24,8 +24,8 @@ import scala.tools.nsc.Reporting.WarningCategory
 
 // Todo merge these better with Scanners
 trait JavaScanners extends ast.parser.ScannersCommon {
-  val global : Global
-  import global._
+  val global: Global
+  import global.{error => _, _}
 
   abstract class AbstractJavaTokenData {
     def token: Int

--- a/src/compiler/scala/tools/nsc/reporters/StoreReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/StoreReporter.scala
@@ -15,7 +15,6 @@ package reporters
 
 import scala.annotation.unchecked.uncheckedStable
 import scala.collection.mutable
-import scala.reflect.internal.Reporter.Severity
 import scala.reflect.internal.util.Position
 
 /** This class implements a Reporter that stores its reports in the set `infos`. */
@@ -40,6 +39,7 @@ class StoreReporter(val settings: Settings) extends FilteringReporter {
   }
 }
 object StoreReporter {
+  import scala.reflect.internal.Reporter.Severity
   case class Info(pos: Position, msg: String, severity: Severity) {
     override def toString: String = s"pos: $pos $msg $severity"
   }

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -19,7 +19,7 @@ import scala.collection._
 import scala.tools.nsc.Reporting.WarningCategory
 
 abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
-  import global._
+  import global.{treeCopy => _, _}
   import definitions._
   import CODE._
   import treeInfo.StripCast

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -22,7 +22,7 @@ import symtab.Flags._
  *  fields, which are assigned to from constructors.
  */
 abstract class Constructors extends Statics with Transform with TypingTransformers with ast.TreeDSL {
-  import global._
+  import global.{treeCopy => _, _}
   import definitions._
 
   /** the following two members override abstract members in Transform */

--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -32,7 +32,7 @@ import scala.collection._
   * The captured arguments include `this` if `liftedBody` is unable to be made STATIC.
   */
 abstract class Delambdafy extends Transform with TypingTransformers with ast.TreeDSL with TypeAdaptingTransformer {
-  import global._
+  import global.{treeCopy => _, _}
   import definitions._
 
   val analyzer: global.analyzer.type = global.analyzer

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -28,7 +28,7 @@ abstract class ExplicitOuter extends InfoTransform
       with TypingTransformers
       with ast.TreeDSL
 {
-  import global._
+  import global.{treeCopy => _, _}
   import definitions._
   import CODE._
 

--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -20,7 +20,7 @@ import scala.collection.mutable
 import scala.collection.mutable.{LinkedHashMap, LinkedHashSet}
 
 abstract class LambdaLift extends InfoTransform {
-  import global._
+  import global.{treeCopy => _, _}
   import definitions._
 
   /** the following two members override abstract members in Transform */

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -21,10 +21,9 @@ import scala.reflect.NameTransformer
 
 
 abstract class Mixin extends Transform with ast.TreeDSL with AccessorSynthesis {
-  import global._
+  import global.{treeCopy => _, _}
   import definitions._
   import CODE._
-
 
   /** The name of the phase: */
   val phaseName: String = "mixin"

--- a/src/compiler/scala/tools/nsc/transform/SampleTransform.scala
+++ b/src/compiler/scala/tools/nsc/transform/SampleTransform.scala
@@ -18,7 +18,7 @@ package transform
 abstract class SampleTransform extends Transform {
   // inherits abstract value `global` and class `Phase` from Transform
 
-  import global._       // the global environment
+  import global.{treeCopy => _, _} // the global environment
   import typer.typed    // method to type trees
 
   /** the following two members override abstract members in Transform */

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -56,7 +56,7 @@ import scala.tools.nsc.Reporting.WarningCategory
  *     Above, `A\$mcI\$sp` cannot access `d`, so the method cannot be typechecked.
  */
 abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
-  import global._
+  import global.{treeCopy => _, _}
   import definitions._
   import Flags._
 

--- a/src/compiler/scala/tools/nsc/transform/Statics.scala
+++ b/src/compiler/scala/tools/nsc/transform/Statics.scala
@@ -14,7 +14,7 @@ package scala.tools.nsc
 package transform
 
 abstract class Statics extends Transform with ast.TreeDSL {
-  import global._
+  import global.{treeCopy => _, _}
 
   trait StaticsTransformer extends Transformer {
     /** generate a static constructor with symbol fields inits, or an augmented existing static ctor

--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -23,7 +23,7 @@ import scala.annotation.tailrec
  *  @author Iulian Dragos
  */
 abstract class TailCalls extends Transform {
-  import global._                     // the global environment
+  import global.{treeCopy => _, _}
   import definitions._                // standard classes and methods
   import typer.typedPos               // methods to type trees
 

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -65,7 +65,7 @@ abstract class UnCurry extends InfoTransform
                           with TypingTransformers with ast.TreeDSL {
   val global: Global               // need to repeat here because otherwise last mixin defines global as
                                    // SymbolTable. If we had DOT this would not be an issue
-  import global._                  // the global environment
+  import global.{treeCopy => _, uncurry => _, _}
   import definitions._             // standard classes and methods
   import CODE._
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -198,8 +198,7 @@ trait TreeAndTypeAnalysis extends Debugging {
 }
 
 trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchTreeMaking {
-  import global._
-  import global.definitions._
+  import global.{Tree => _, Type => _, _}, definitions._
 
   /**
    * Represent a match as a formula in propositional logic that encodes whether the match matches (abstractly: we only consider types)
@@ -419,8 +418,7 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
 }
 
 trait MatchAnalysis extends MatchApproximation {
-  import global._
-  import global.definitions._
+  import global.{Tree => _, Type => _, _}, definitions._
 
   trait MatchAnalyzer extends MatchApproximator  {
     def uncheckedWarning(pos: Position, msg: String, site: Symbol) = runReporting.warning(pos, msg, WarningCategory.Unchecked, site)

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -24,11 +24,10 @@ import scala.tools.nsc.Reporting.WarningCategory
  */
 // TODO: split out match analysis
 trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
-  import global._
-  import global.definitions._
 
-  ////
   trait CommonSubconditionElimination extends OptimizedCodegen with MatchApproximator {
+    import global.{Tree => _, Type => _, _}, definitions._
+
     /** a flow-sensitive, generalised, common sub-expression elimination
      * reuse knowledge from performed tests
      * the only sub-expressions we consider are the conditions and results of the three tests (type, type&equality, equality)
@@ -215,6 +214,7 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
 
   //// SWITCHES -- TODO: operate on Tests rather than TreeMakers
   trait SwitchEmission extends TreeMakers with MatchMonadInterface {
+    import global._, definitions._
     import treeInfo.isGuardedCase
 
     abstract class SwitchMaker {
@@ -607,6 +607,8 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
   trait MatchOptimizer extends OptimizedCodegen
                           with SwitchEmission
                           with CommonSubconditionElimination {
+    import global._
+
     override def optimizeCases(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type, selectorPos: Position): (List[List[TreeMaker]], List[Tree]) = {
       // TODO: do CSE on result of doDCE(prevBinder, cases, pt)
       val optCases = doCSE(prevBinder, cases, pt, selectorPos)

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -19,7 +19,7 @@ import scala.reflect.internal.util.StatisticsStatics
 trait MatchTranslation {
   self: PatternMatching =>
 
-  import global._
+  import global.{treeCopy => _, typer => _, _}
   import definitions._
   import treeInfo.{ Unapplied, unbind }
   import CODE._

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -23,7 +23,7 @@ import scala.tools.nsc.Reporting.WarningCategory
  * mostly agnostic to whether we're in optimized/pure (virtualized) mode.
  */
 trait MatchTreeMaking extends MatchCodeGen with Debugging {
-  import global._
+  import global.{typer => _, _}
   import definitions._
 
   final case class Suppression(suppressExhaustive: Boolean, suppressUnreachable: Boolean)

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchWarnings.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchWarnings.scala
@@ -17,7 +17,7 @@ import scala.tools.nsc.Reporting.WarningCategory
 trait MatchWarnings {
   self: PatternMatching =>
 
-  import global._
+  import global.{typer => _, _}
 
   trait TreeMakerWarnings {
     self: MatchTranslator =>

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -54,7 +54,7 @@ trait PatternMatching extends Transform
                       with MatchOptimization
                       with MatchWarnings
                       with PatternExpansion {
-  import global._
+  import global.{treeCopy => _, _}
 
   val phaseName: String = "patmat"
 

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -26,7 +26,7 @@ import scala.reflect.internal.util.NoSourceFile
 trait ContextErrors {
   self: Analyzer =>
 
-  import global._
+  import global.{explainTypes => _, typer => _, _}
   import definitions._
 
   sealed abstract class AbsTypeError {
@@ -1468,7 +1468,7 @@ trait ContextErrors {
   }
 
   object NamesDefaultsErrorsGen {
-    import typer.infer.setError
+    import global.typer.infer.setError
 
     def NameClashError(sym: Symbol, arg: Tree)(implicit context: Context) = {
       setError(arg) // to distinguish it from ambiguous reference error

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1543,7 +1543,7 @@ trait Contexts { self: Analyzer =>
           done = (cx eq NoContext) || defSym.exists && !foreignDefined
           if (!done && (cx ne NoContext)) cx = cx.outer
         }
-        if (defSym.exists && (defSym ne defSym0)) {
+        if (defSym.exists && (defSym ne defSym0) && !defSym0.overrides.contains(defSym) && !defSym.overrides.contains(defSym0)) {
           // TODO if defSym.isParamAccessor then check aliasing
           val ambiguity =
             if (preferDef) ambiguousDefinitions(owner = defSym.owner, defSym0)

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -23,7 +23,7 @@ import scala.tools.nsc.Reporting.WarningCategory
  *  @author  Martin Odersky
  */
 trait Contexts { self: Analyzer =>
-  import global._
+  import global.{treeCopy => _, _}
   import definitions.{JavaLangPackage, ScalaPackage, PredefModule, ScalaXmlTopScope, ScalaXmlPackage}
   import ContextMode._
   import scala.reflect.internal.Flags._

--- a/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
@@ -24,7 +24,7 @@ trait MacroAnnotationNamers { self: Analyzer =>
 
   class MacroAnnotationNamer(context: Context) extends Namer(context) {
     import NamerErrorGen._
-    import typer.TyperErrorGen._
+    import this.typer.TyperErrorGen._
 
     override def standardEnterSym(tree: Tree): Context = {
       def dispatch() = {

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -57,9 +57,9 @@ import Fingerprint._
 trait Macros extends MacroRuntimes with Traces with Helpers {
   self: Analyzer =>
 
-  import global._
-  import definitions._
-  import treeInfo.{isRepeatedParamType => _, _}
+  import global.{Expr => _, TypeTag => _, _}
+  import global.definitions._
+  import global.treeInfo.{isRepeatedParamType => _, _}
 
   lazy val fastTrack = new FastTrack[self.type](self)
 
@@ -417,7 +417,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
               val fingerprint = implParams(min(j, implParams.length - 1))
               val duplicatedArg = duplicateAndKeepPositions(arg)
               fingerprint match {
-                case LiftedTyped => context.Expr[Nothing](duplicatedArg)(TypeTag.Nothing) // TODO: scala/bug#5752
+                case LiftedTyped => context.Expr[Nothing](duplicatedArg)(context.TypeTag.Nothing) // TODO: scala/bug#5752
                 case LiftedUntyped => duplicatedArg
                 case _ => abort(s"unexpected fingerprint $fingerprint in $binding with paramss being $paramss " +
                                 s"corresponding to arg $arg in $argss")
@@ -593,8 +593,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
    *  @param outerPt Expected type that comes from enclosing context (something that's traditionally called `pt`).
    *  @param innerPt Expected type that comes from the signature of a macro def, possibly wildcarded to help type inference.
    */
-  class DefMacroExpander(typer: Typer, expandee: Tree, mode: Mode, outerPt: Type)
-  extends MacroExpander(typer, expandee) {
+  class DefMacroExpander(typer: Typer, expandee: Tree, mode: Mode, outerPt: Type) extends MacroExpander(typer, expandee) {
     lazy val innerPt = {
       val tp = if (isNullaryInvocation(expandee)) expandee.tpe.finalResultType else expandee.tpe
       if (isBlackbox(expandee)) tp
@@ -789,7 +788,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
             Success(result)
           }
           expanded match {
-            case expanded: Expr[_] if expandee.symbol.isTermMacro => validateResultingTree(expanded.tree)
+            case expanded: global.Expr[_] if expandee.symbol.isTermMacro => validateResultingTree(expanded.tree)
             case expanded: Tree if expandee.symbol.isTermMacro    => validateResultingTree(expanded)
             case _ => MacroExpansionHasInvalidTypeError(expandee, expanded)
           }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1764,7 +1764,7 @@ abstract class RefChecks extends Transform {
               inPattern = true
               transform(pat)
             }
-            treeCopy.CaseDef(tree, pat1, transform(guard), transform(body))
+            this.treeCopy.CaseDef(tree, pat1, transform(guard), transform(body))
           case _ =>
             result.transform(this)
         }

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -67,7 +67,7 @@ import symtab.Flags._
  *  TODO: Rename phase to "Accessors" because it handles more than just super accessors
  */
 abstract class SuperAccessors extends transform.Transform with transform.TypingTransformers {
-  import global._
+  import global.{treeCopy => _, _}
   import definitions._
   import analyzer.restrictionError
 

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -761,7 +761,7 @@ trait TypeDiagnostics {
     self: Typer =>
 
     def permanentlyHiddenWarning(pos: Position, hidden: Name, defn: Symbol) =
-      context.warning(pos, "imported `%s` is permanently hidden by definition of %s".format(hidden, defn.fullLocationString), WarningCategory.OtherShadowing)
+      context.warning(pos, s"imported `$hidden` is permanently hidden by definition of ${defn.fullLocationString}", WarningCategory.OtherShadowing)
 
     private def symWasOverloaded(sym: Symbol) = sym.owner.isClass && sym.owner.info.member(sym.name).isOverloaded
     private def cyclicAdjective(sym: Symbol)  = if (symWasOverloaded(sym)) "overloaded" else "recursive"

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -39,7 +39,7 @@ import scala.tools.nsc.Reporting.{MessageFilter, Suppression, WConf, WarningCate
 trait Typers extends Adaptations with Tags with TypersTracking with PatternTypers {
   self: Analyzer =>
 
-  import global._
+  import global.{adaptAnnotations => _, canAdaptAnnotations => _, _}
   import definitions._
   import statistics._
 

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -44,8 +44,8 @@ trait CommentPreservingTypers extends Typers {
 }
 
 trait InteractiveAnalyzer extends Analyzer {
-  val global : Global
-  import global._
+  val global: Global
+  import global.{Context => _, _}
 
   override def newTyper(context: Context): InteractiveTyper = new Typer(context) with InteractiveTyper
   override def newNamer(context: Context): InteractiveNamer = new Namer(context) with InteractiveNamer

--- a/src/interactive/scala/tools/nsc/interactive/Picklers.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Picklers.scala
@@ -13,22 +13,23 @@
 package scala.tools.nsc
 package interactive
 
-import util.InterruptReq
-import scala.reflect.internal.util.{ SourceFile, BatchSourceFile }
-import io.{ AbstractFile, PlainFile }
-import util.EmptyAction
-import scala.reflect.internal.util.Position
+import scala.collection.mutable, mutable.ListBuffer
+import scala.reflect.internal.util.{
+  BatchSourceFile,
+  SourceFile,
+}
+import scala.reflect.internal.util.Position.{offset, range}
+import scala.reflect.io.{AbstractFile, PlainFile}
+import scala.tools.nsc.util.{EmptyAction, InterruptReq}
 import Pickler._
-import scala.collection.mutable
-import mutable.ListBuffer
 
 trait Picklers { self: Global =>
 
   lazy val freshRunReq =
     unitPickler
-      .wrapped { _ => new FreshRunReq } { x => () }
-      .labelled ("FreshRunReq")
-      .cond (_.isInstanceOf[FreshRunReq])
+      .wrapped(_ => new FreshRunReq)(x => ())
+      .labelled("FreshRunReq")
+      .cond(_.isInstanceOf[FreshRunReq])
 
       lazy val shutdownReq = singletonPickler(ShutdownReq)
 
@@ -73,17 +74,17 @@ trait Picklers { self: Global =>
 
   lazy val offsetPosition: CondPickler[Position] =
     (pkl[SourceFile] ~ pkl[Int])
-      .wrapped { case x ~ y => Position.offset(x, y) } { p => p.source ~ p.point }
+      .wrapped { case x ~ y => offset(x, y) } { p => p.source ~ p.point }
       .asClass (classOf[Position])
 
   lazy val rangePosition: CondPickler[Position] =
     (pkl[SourceFile] ~ pkl[Int] ~ pkl[Int] ~ pkl[Int])
-      .wrapped { case source ~ start ~ point ~ end => Position.range(source, start, point, end) } { p => p.source ~ p.start ~ p.point ~ p.end }
+      .wrapped { case source ~ start ~ point ~ end => range(source, start, point, end) } { p => p.source ~ p.start ~ p.point ~ p.end }
       .asClass (classOf[Position])
 
   lazy val transparentPosition: CondPickler[Position] =
     (pkl[SourceFile] ~ pkl[Int] ~ pkl[Int] ~ pkl[Int])
-      .wrapped { case source ~ start ~ point ~ end => Position.range(source, start, point, end).makeTransparent } { p => p.source ~ p.start ~ p.point ~ p.end }
+      .wrapped { case source ~ start ~ point ~ end => range(source, start, point, end).makeTransparent } { p => p.source ~ p.start ~ p.point ~ p.end }
       .asClass (classOf[Position])
 
   lazy val noPosition = singletonPickler(NoPosition)

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -67,7 +67,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   private class ResizableArrayAccess[A0] extends ArrayBuffer[A0] {
     override def mapInPlace(f: A0 => A0): this.type = {
       var i = 1 // see "we do not use array(0)" comment below (???)
-      val siz = size
+      val siz = ResizableArrayAccess.this.size
       while (i < siz) { this(i) = f(this(i)); i += 1 }
       this
     }

--- a/src/partest/scala/tools/partest/ScaladocModelTest.scala
+++ b/src/partest/scala/tools/partest/ScaladocModelTest.scala
@@ -12,8 +12,10 @@
 
 package scala.tools.partest
 
+import scala.reflect.io
 import scala.tools.cmd.CommandLineParser
-import scala.tools.nsc._
+import scala.tools.nsc.ScalaDoc
+import scala.tools.nsc.doc
 import scala.tools.nsc.doc.base.comment._
 import scala.tools.nsc.doc.model._
 import scala.tools.nsc.doc.model.diagram._

--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -238,7 +238,7 @@ class Runner(val testInfo: TestInfo, val suiteRunner: AbstractRunner) {
           try {
             val out = Files.newOutputStream(log.toPath, StandardOpenOption.APPEND)
             try {
-              val loader = new URLClassLoader(classesDir.toURI.toURL :: Nil, getClass.getClassLoader)
+              val loader = new URLClassLoader(classesDir.toURI.toURL :: Nil, this.getClass.getClassLoader)
               StreamCapture.capturingOutErr(out) {
                 val cls = loader.loadClass("Test")
                 val main = cls.getDeclaredMethod("main", classOf[Array[String]])

--- a/src/reflect/scala/reflect/internal/ReificationSupport.scala
+++ b/src/reflect/scala/reflect/internal/ReificationSupport.scala
@@ -10,12 +10,10 @@
  * additional information regarding copyright ownership.
  */
 
-package scala
-package reflect
-package internal
+package scala.reflect.internal
 
 import Flags._
-import util._
+import util.{FreshNameCreator, ListOfNil, SomeOfNil}
 
 trait ReificationSupport { self: SymbolTable =>
   import definitions._

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -68,7 +68,7 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
     private[this] var elem: ScopeEntry = owner.elems
 
     def hasNext: Boolean = (elem ne null) && (elem.owner == this.owner)
-    def next: Symbol =
+    def next(): Symbol =
       if (hasNext){
         val res = elem
         elem = elem.next

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1229,7 +1229,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def ownersIterator: Iterator[Symbol] = new collection.AbstractIterator[Symbol] {
       private[this] var current = Symbol.this
       def hasNext = current ne NoSymbol
-      def next = { val r = current; current = current.owner; r }
+      def next() = { val r = current; current = current.owner; r }
     }
 
     /** Same as `ownerChain contains sym` but more efficient, and

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -10,9 +10,7 @@
  * additional information regarding copyright ownership.
  */
 
-package scala
-package reflect
-package internal
+package scala.reflect.internal
 
 import Flags._
 import util._
@@ -21,7 +19,7 @@ import scala.collection.mutable.ListBuffer
 abstract class TreeGen {
   val global: SymbolTable
 
-  import global._
+  import global.{treeCopy => _, _}
   import definitions._
 
   def rootId(name: Name)             = Select(Ident(nme.ROOTPKG), name)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -10,22 +10,20 @@
  * additional information regarding copyright ownership.
  */
 
-package scala
-package reflect
+package scala.reflect
 package internal
 
 import java.util.Objects
 
-import scala.collection.{immutable, mutable}
-import scala.ref.WeakReference
-import mutable.{ListBuffer, LinkedHashSet}
-import Flags._
-import scala.util.control.ControlThrowable
 import scala.annotation.{tailrec, unused}
+import scala.collection.{immutable, mutable}, mutable.{ListBuffer, LinkedHashSet}
+import scala.ref.WeakReference
+import scala.util.control.ControlThrowable
+import Flags._
 import util.{Statistics, StatisticsStatics}
 import util.ThreeValues._
 import Variance._
-import Depth._
+import Depth.{apply => _, _}
 import TypeConstants._
 
 /* A standard type pattern match:
@@ -777,8 +775,8 @@ trait Types
     def withFilter(p: Type => Boolean) = new FilterMapForeach(p)
 
     class FilterMapForeach(p: Type => Boolean) extends FilterTypeCollector(p){
-      def foreach[U](f: Type => U): Unit = collect(Type.this) foreach f
-      def map[T](f: Type => T): List[T]  = collect(Type.this) map f
+      def foreach[U](f: Type => U): Unit = this.collect(Type.this).foreach(f)
+      def map[T](f: Type => T): List[T]  = this.collect(Type.this).map(f)
     }
 
     @inline final def orElse(alt: => Type): Type = if (this ne NoType) this else alt

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -310,7 +310,7 @@ trait Types
      *  This is assessed to be the case if the class is final,
      *  and all type parameters (if any) are invariant.
      */
-    def isFinalType = typeSymbol.hasOnlyBottomSubclasses && prefix.isStable
+    def isFinalType: Boolean = typeSymbol.hasOnlyBottomSubclasses && prefix.isStable
 
     /** Is this type completed (i.e. not a lazy type)? */
     def isComplete: Boolean = true
@@ -319,7 +319,7 @@ trait Types
     def isShowAsInfixType: Boolean = false
 
     /** If this is a lazy type, assign a new type to `sym`. */
-    def complete(sym: Symbol): Unit = {}
+    def complete(sym: Symbol): Unit = ()
 
     /** If this is a lazy type corresponding to a subclass add it to its
      *  parents children
@@ -417,7 +417,7 @@ trait Types
     /** For a class with !isEmpty parents, the first parent.
      *  Otherwise some specific fixed top type.
      */
-    def firstParent = if (!parents.isEmpty) parents.head else ObjectTpe
+    def firstParent: Type = if (!parents.isEmpty) parents.head else ObjectTpe
 
     /** For a typeref or single-type, the prefix of the normalized type (@see normalize).
      *  NoType for all other types. */
@@ -2127,9 +2127,9 @@ trait Types
       super.invalidateTypeRefCaches()
       narrowedCache = null
     }
-    override def forceDirectSuperclasses: Unit =
+    override def forceDirectSuperclasses() =
       sym0.rawInfo.decls.foreach { decl =>
-        if(decl.isModule || !decl.isTerm) decl.rawInfo.forceDirectSuperclasses
+        if (decl.isModule || !decl.isTerm) decl.rawInfo.forceDirectSuperclasses()
       }
     override protected def finishPrefix(rest: String) = objectPrefix + rest
     override def directObjectString = super.safeToString

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -15,7 +15,6 @@ package reflect
 package internal
 
 import Variance._
-import scala.collection.mutable
 import scala.annotation.tailrec
 import scala.reflect.internal.util.ReusableInstance
 

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -1050,16 +1050,18 @@ private[internal] trait TypeMaps {
         if (pred(t.symbol)) result = true else apply(t.tpe)
         result
       }
-      new FindTreeTraverser(inTree) {
-        def collect(arg: Tree): Boolean = {
-          /*super[FindTreeTraverser].*/ result = None
-          traverse(arg)
-          /*super[FindTreeTraverser].*/ result.isDefined
-        }
-      }
+      new FindTreeTraverser2(inTree)
     }
 
     override def foldOver(arg: Tree) = if (!result) findInTree.collect(arg)
+  }
+
+  private class FindTreeTraverser2(p: Tree => Boolean) extends FindTreeTraverser(p) {
+    def collect(arg: Tree): Boolean = {
+      result = None
+      traverse(arg)
+      result.isDefined
+    }
   }
 
   /** A map to implement the `contains` method. */

--- a/src/reflect/scala/reflect/internal/util/JavaClearable.scala
+++ b/src/reflect/scala/reflect/internal/util/JavaClearable.scala
@@ -22,10 +22,10 @@ object JavaClearable {
   def forMap[T <: JMap[_,_]](data: T): JavaClearable[T] = new JavaClearableMap(new WeakReference(data))
 
   private final class JavaClearableMap[T <: JMap[_,_]](dataRef:WeakReference[T]) extends JavaClearable(dataRef) {
-    override def clear: Unit = Option(dataRef.get) foreach (_.clear())
+    override def clear() = Option(dataRef.get).foreach(_.clear())
   }
   private final class JavaClearableCollection[T <: JCollection[_]](dataRef:WeakReference[T]) extends JavaClearable(dataRef) {
-    override def clear: Unit = Option(dataRef.get) foreach (_.clear())
+    override def clear() = Option(dataRef.get).foreach(_.clear())
   }
 }
 sealed abstract class JavaClearable[T <: AnyRef] protected (protected val dataRef: WeakReference[T]) extends Clearable {
@@ -44,7 +44,7 @@ sealed abstract class JavaClearable[T <: AnyRef] protected (protected val dataRe
     case _ => false
   }
 
-  def clear : Unit
+  def clear(): Unit
 
   def isValid = dataRef.get() ne null
 }

--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -163,7 +163,7 @@ final class FileZipArchive(file: JFile, release: Option[String]) extends ZipArch
     override def lastModified: Long = time // could be stale
     override def input: InputStream = {
       val zipFile  = openZipFile()
-      val entry    = zipFile.getEntry(name) // with `-release`, returns the correct version under META-INF/versions
+      val entry    = zipFile.getEntry(this.name) // with `-release`, returns the correct version under META-INF/versions
       val delegate = zipFile.getInputStream(entry)
       new FilterInputStream(delegate) {
         override def close(): Unit = { zipFile.close() }
@@ -334,7 +334,7 @@ final class ManifestResources(val url: URL) extends ZipArchive(null) {
       if (!zipEntry.isDirectory) {
         class FileEntry() extends Entry(zipEntry.getName) {
           override def lastModified = zipEntry.getTime()
-          override def input        = resourceInputStream(path)
+          override def input        = resourceInputStream(this.path)
           override def sizeOption   = None
         }
         val f = new FileEntry()

--- a/src/scaladoc/scala/tools/nsc/doc/base/MemberLookupBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/MemberLookupBase.scala
@@ -23,7 +23,7 @@ import scala.tools.nsc.Reporting.WarningCategory
 trait MemberLookupBase {
 
   val global: Global
-  import global._
+  import global.{toString => _, _}
 
   def internalLink(sym: Symbol, site: Symbol): Option[LinkTo]
   def chooseLink(links: List[LinkTo]): LinkTo
@@ -31,7 +31,6 @@ trait MemberLookupBase {
   def findExternalLink(sym: Symbol, name: String): Option[LinkTo]
   def warnNoLink: Boolean
 
-  import global._
   import rootMirror.{RootPackage, EmptyPackage}
 
   private def isRoot(s: Symbol) = (s eq NoSymbol) || s.isRootSymbol || s.isEmptyPackage || s.isEmptyPackageClass

--- a/src/scaladoc/scala/tools/nsc/doc/model/MemberLookup.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/MemberLookup.scala
@@ -20,7 +20,7 @@ import base._
 trait MemberLookup extends base.MemberLookupBase {
   thisFactory: ModelFactory =>
 
-  import global._
+  import global.{settings => _, _}
   import definitions.{ NothingClass, AnyClass, AnyValClass, AnyRefClass }
 
   override def internalLink(sym: Symbol, site: Symbol): Option[LinkTo] =
@@ -73,7 +73,7 @@ trait MemberLookup extends base.MemberLookupBase {
       }
     }
     classpathEntryFor(sym1) flatMap { path =>
-      settings.extUrlMapping get path map { url => {
+      this.settings.extUrlMapping get path map { url => {
          LinkToExternalTpl(name, url, makeTemplate(sym))
         }
       }

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
@@ -52,7 +52,7 @@ import scala.tools.nsc.Reporting.WarningCategory
 trait ModelFactoryImplicitSupport {
   thisFactory: ModelFactory with ModelFactoryTypeSupport with CommentFactory with TreeFactory =>
 
-  import global._
+  import global.{settings => _, _}
   import global.analyzer._
   import global.definitions._
   import settings.hardcoded

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryTypeSupport.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryTypeSupport.scala
@@ -29,7 +29,7 @@ trait ModelFactoryTypeSupport {
                with TreeFactory
                with MemberLookup =>
 
-  import global._
+  import global.{settings => _, _}
   import definitions.{ ObjectClass, AnyClass, AnyRefClass }
 
   protected val typeCache = new mutable.LinkedHashMap[Type, TypeEntity]

--- a/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ScalaSigPrinter.scala
+++ b/src/scalap/scala/tools/scalap/scalax/rules/scalasig/ScalaSigPrinter.scala
@@ -21,7 +21,7 @@ import scala.reflect.NameTransformer
 
 
 class ScalaSigPrinter(stream: PrintStream, printPrivates: Boolean) {
-  import stream._
+  import stream.{toString => _, _}
 
   val CONSTRUCTOR_NAME = "<init>"
 

--- a/test/files/neg/t11921a.check
+++ b/test/files/neg/t11921a.check
@@ -1,0 +1,27 @@
+t11921a.scala:14: error: reference to X is ambiguous;
+it is both defined in package p and imported subsequently by
+import Z.X
+      def f = X       // ambiguous if p.X defined in this file
+              ^
+t11921a.scala:19: error: reference to x is ambiguous;
+it is both defined in class C and imported subsequently by
+import Z.x
+        x             // ambiguous if inherited member defined in this file
+        ^
+t11921a.scala:15: warning: imported `x` is permanently hidden by definition of value x in class C
+      import Z.x      // unused because shadowed by inherited member defined in this file
+               ^
+t11921a.scala:13: warning: Unused import
+      import Z.X      // unused due to ambiguity
+               ^
+t11921a.scala:15: warning: Unused import
+      import Z.x      // unused because shadowed by inherited member defined in this file
+               ^
+t11921a.scala:18: warning: Unused import
+        import Z.x    // unused due to ambiguity
+                 ^
+t11921a.scala:23: warning: parameter value x in method f is never used
+      def f(x: Int) = {
+            ^
+5 warnings
+2 errors

--- a/test/files/neg/t11921a.scala
+++ b/test/files/neg/t11921a.scala
@@ -1,0 +1,31 @@
+// scalac: -Wunused:imports,params
+//
+package p {
+  object X
+  class C {
+    val x = 42
+  }
+  class D extends C {
+    def y = 27
+  }
+  package q {
+    object Y extends C {
+      import Z.X      // unused due to ambiguity
+      def f = X       // ambiguous if p.X defined in this file
+      import Z.x      // unused because shadowed by inherited member defined in this file
+      def g = x       // inherited member defined in this file
+      def k = {
+        import Z.x    // unused due to ambiguity
+        x             // ambiguous if inherited member defined in this file
+      }
+    }
+    object Test {
+      def f(x: Int) = {
+        new D { override def y = x }    // OK, inherited member defined in this file
+      }
+    }
+    object Z extends C {
+      object X
+    }
+  }
+}

--- a/test/files/neg/t11921b.check
+++ b/test/files/neg/t11921b.check
@@ -1,0 +1,9 @@
+test.scala:13: error: reference to x is ambiguous;
+it is both defined in method f and available as value x in class C
+        new D { override def y = x }      // ambiguous
+                                 ^
+test.scala:12: warning: parameter value x in method f is never used
+      def f(x: Int) = {                   // unused
+            ^
+1 warning
+1 error

--- a/test/files/neg/t11921b/p.scala
+++ b/test/files/neg/t11921b/p.scala
@@ -1,0 +1,10 @@
+
+package p {
+  object X
+  class C {
+    val x = 42
+  }
+  class D extends C {
+    def y = 27
+  }
+}

--- a/test/files/neg/t11921b/test.scala
+++ b/test/files/neg/t11921b/test.scala
@@ -1,0 +1,20 @@
+// scalac: -Wunused:imports,params
+//
+package p {
+  package q {
+    object Y extends C {
+      import Z.X      // used
+      def f = X       // OK
+      import Z.x      // used
+      def g = x       // OK
+    }
+    object Test {
+      def f(x: Int) = {                   // unused
+        new D { override def y = x }      // ambiguous
+      }
+    }
+    object Z extends C {
+      object X
+    }
+  }
+}

--- a/test/files/pos/t11921/p.scala
+++ b/test/files/pos/t11921/p.scala
@@ -1,0 +1,10 @@
+
+package p {
+  object X
+  class C {
+    val x = 42
+  }
+  class D extends C {
+    def y = 27
+  }
+}

--- a/test/files/pos/t11921/test.scala
+++ b/test/files/pos/t11921/test.scala
@@ -1,0 +1,16 @@
+// scalac: -Werror
+
+package p {
+  package q {
+    object Y extends C {
+      import Z.X
+      def f = X       // import beats foreign definition
+      import Z.x
+      def g = x       // import also beats foreign inheritance, was:
+      //warning: imported `x` is permanently hidden by definition of value x in class C
+    }
+    object Z extends C {
+      object X
+    }
+  }
+}


### PR DESCRIPTION
As with names introduced by package statements, base classes
can introduce definitions that shadow local definitions and
import statements.

Let inherited members have the same name-binding precedence
as package-level definitions: highest when defined in the current
compilation unit, and lowest otherwise. This means that a base
class defined elsewhere cannot introduce a name that shadows a
local definition.

The inherited name can be referred to unambiguously using `this`;
a conflicting local variable or parameter must be renamed or
aliased; a conflicting member using a `C.this` prefix.

Fixes scala/bug#11921