### PR TITLE
Reduce the size of WrappedArray

### DIFF
--- a/src/library/scala/collection/mutable/WrappedArray.scala
+++ b/src/library/scala/collection/mutable/WrappedArray.scala
@@ -187,7 +187,7 @@ object WrappedArray {
   def newBuilder[A]: Builder[A, IndexedSeq[A]] = new ArrayBuffer
 
   final class ofRef[T <: AnyRef](val array: Array[T]) extends WrappedArray[T] with Serializable {
-    lazy val elemTag = ClassTag[T](array.getClass.getComponentType)
+    def elemTag = ClassTag[T](array.getClass.getComponentType)
     def length: Int = array.length
     def apply(index: Int): T = array(index).asInstanceOf[T]
     def update(index: Int, elem: T) { array(index) = elem }

--- a/test/junit/scala/collection/Sizes.scala
+++ b/test/junit/scala/collection/Sizes.scala
@@ -1,46 +1,22 @@
 package scala.collection
 
-import org.junit.Assert._
 import org.junit._
-import org.openjdk.jol.info.GraphLayout
-
 import scala.collection.mutable.ListBuffer
+import scala.tools.testing.JOL
+import scala.tools.testing.JOL.assertTotalSize
 
-object Sizes {
-  lazy val list:  Long = 24
-  lazy val listBuffer: Long = 32
-
-  def refArray(length:Int): Long = {
-    (16 + (length+1) * 4) /8 * 8
-  }
-  def wrappedRefArray(length:Int): Long = refArray(length) + 16
-
-}
-class Sizes{
+class Sizes {
   @Test
   def list: Unit = {
-    val parsed = GraphLayout.parseInstance(new ::("", Nil)).subtract(GraphLayout.parseInstance(Nil)).subtract(GraphLayout.parseInstance(""))
-    assertEquals(parsed.toPrintable, Sizes.list, parsed.totalSize())
+    assertTotalSize(24, JOL.netLayout(null :: Nil, Nil))
   }
   @Test
   def listBuffer: Unit = {
-    val parsed = GraphLayout.parseInstance(new ListBuffer[String]).subtract(GraphLayout.parseInstance(Nil))
-    assertEquals(parsed.toPrintable, Sizes.listBuffer, parsed.totalSize())
-  }
-
-  @Test
-  def rawArray: Unit = {
-    for (length <- 0 to 10) {
-      val parsed = GraphLayout.parseInstance(new Array[String](length))
-      assertEquals(parsed.toPrintable, Sizes.refArray(length), parsed.totalSize())
-    }
+    assertTotalSize(32, JOL.netLayout(new ListBuffer[String], Nil))
   }
   @Test
   def wrappedArray: Unit = {
-    for (length <- 1 to 10) {
-      val parsed = GraphLayout.parseInstance(mutable.WrappedArray.make[String](new Array[String](length)))
-      assertEquals(parsed.toPrintable, Sizes.wrappedRefArray(length), parsed.totalSize())
-    }
+    val wrapped = Array[String]("")
+    assertTotalSize(16, JOL.netLayout(mutable.WrappedArray.make[String](wrapped), wrapped))
   }
-
 }

--- a/test/junit/scala/collection/Sizes.scala
+++ b/test/junit/scala/collection/Sizes.scala
@@ -1,0 +1,46 @@
+package scala.collection
+
+import org.junit.Assert._
+import org.junit._
+import org.openjdk.jol.info.GraphLayout
+
+import scala.collection.mutable.ListBuffer
+
+object Sizes {
+  lazy val list:  Long = 24
+  lazy val listBuffer: Long = 32
+
+  def refArray(length:Int): Long = {
+    (16 + (length+1) * 4) /8 * 8
+  }
+  def wrappedRefArray(length:Int): Long = refArray(length) + 24
+
+}
+class Sizes{
+  @Test
+  def list: Unit = {
+    val parsed = GraphLayout.parseInstance(new ::("", Nil)).subtract(GraphLayout.parseInstance(Nil)).subtract(GraphLayout.parseInstance(""))
+    assertEquals(parsed.toPrintable, Sizes.list, parsed.totalSize())
+  }
+  @Test
+  def listBuffer: Unit = {
+    val parsed = GraphLayout.parseInstance(new ListBuffer[String]).subtract(GraphLayout.parseInstance(Nil))
+    assertEquals(parsed.toPrintable, Sizes.listBuffer, parsed.totalSize())
+  }
+
+  @Test
+  def rawArray: Unit = {
+    for (length <- 0 to 10) {
+      val parsed = GraphLayout.parseInstance(new Array[String](length))
+      assertEquals(parsed.toPrintable, Sizes.refArray(length), parsed.totalSize())
+    }
+  }
+  @Test
+  def wrappedArray: Unit = {
+    for (length <- 1 to 10) {
+      val parsed = GraphLayout.parseInstance(mutable.WrappedArray.make[String](new Array[String](length)))
+      assertEquals(parsed.toPrintable, Sizes.wrappedRefArray(length), parsed.totalSize())
+    }
+  }
+
+}

--- a/test/junit/scala/collection/Sizes.scala
+++ b/test/junit/scala/collection/Sizes.scala
@@ -13,7 +13,7 @@ object Sizes {
   def refArray(length:Int): Long = {
     (16 + (length+1) * 4) /8 * 8
   }
-  def wrappedRefArray(length:Int): Long = refArray(length) + 24
+  def wrappedRefArray(length:Int): Long = refArray(length) + 16
 
 }
 class Sizes{

--- a/test/junit/scala/tools/testing/JOL.scala
+++ b/test/junit/scala/tools/testing/JOL.scala
@@ -1,0 +1,15 @@
+package scala.tools.testing
+
+import org.junit.Assert
+import org.openjdk.jol.info.GraphLayout
+
+object JOL {
+  def netLayout(wrapper: AnyRef, wrapped: AnyRef = null): GraphLayout = {
+    val wrapperLayout = GraphLayout.parseInstance(wrapper)
+    if (wrapped eq null) wrapperLayout
+    else wrapperLayout.subtract(GraphLayout.parseInstance(wrapped))
+  }
+  def assertTotalSize(expectedSize: Int, layout: GraphLayout): Unit = {
+    Assert.assertEquals(layout.toFootprint + "\n\n", expectedSize, layout.totalSize)
+  }
+}


### PR DESCRIPTION
WrappedArray is used in varargs, and IMO its rare to need the `elemTag:ClassTag[T]`

As its backed by a `ClassValue` cache anyway is seems unnecessary to cache it in array as well, and this reduces the size of the WrappedArray by 8 bytes, and removes and object ref from the GC traversal