### PR TITLE
Revert "Fixes Iterable#toString forcing elements"

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -68,12 +68,12 @@ trait Iterable[+A] extends IterableOnce[A]
   protected[this] def stringPrefix: String = "Iterable"
 
   /** Converts this $coll to a string.
+    *
+    *  @return   a string representation of this collection. By default this
+    *            string consists of the `className` of this $coll, followed
+    *            by all elements separated by commas and enclosed in parentheses.
     */
-  override def toString: String  =
-    this match {
-      case _: StrictOptimizedIterableOps[_, _, _] => mkString(className + "(", ", ", ")")
-      case _                                      => className + (if (isEmpty) "()" else "(<iterable>)")
-    }
+  override def toString = mkString(className + "(", ", ", ")")
 
   /** Analogous to `zip` except that the elements in each collection are not consumed until a strict operation is
     * invoked on the returned `LazyZip2` decorator.

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -1002,7 +1002,6 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     else cachedSize()
   override def isEmpty: Boolean = size == 0
   override protected[this] def className = "TrieMap"
-  override def toString: String = mkString(className + "(", ", ", ")")
 
 }
 

--- a/src/partest/scala/tools/partest/Util.scala
+++ b/src/partest/scala/tools/partest/Util.scala
@@ -23,7 +23,6 @@ object Util {
     }
 
     override def className = "Array"
-    override def toString: String = mkString(className + "(", ", ", ")")
   }
 
   implicit class ArrayDeep(val a: Array[_]) extends AnyVal {

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -270,16 +270,6 @@ class IterableTest {
   }
 
   @Test
-  def infiniteIterable: Unit = {
-    class Foo extends Iterable[Int] {
-      def iterator = Iterator.continually(42)
-      override def className = "Fu"
-    }
-    val foo = new Foo
-    Assert.assertEquals("Fu(<iterable>)", foo.toString)
-  }
-
-  @Test
   def partitionMap: Unit = {
     val (left, right) = Seq(1, "1", 2, "2", 3, "3", 4, "4", 5, "5").partitionMap {
       case i: Int => Left(i)

--- a/test/scalacheck/SeqMap.scala
+++ b/test/scalacheck/SeqMap.scala
@@ -15,7 +15,7 @@ object SeqMapTest extends Properties("SeqMap") {
       def updated[V1 >: String](key: Int, value: V1): SeqMap[Int, V1] = ???
       override def get(key: Int): Option[String] = ???
       override def iterator: Iterator[(Int, String)] = Iterator(1 -> "hi")
-    }.toString == "SeqMap(<iterable>)"
+    }.toString == "SeqMap(1 -> hi)"
   }
 
   property("ordering") = forAll { (m: Map[Int, Int]) =>


### PR DESCRIPTION
This reverts commit dead51ba01a6cae23b78122244ee272bb5f7d928
(pull request #8554).

See discussion on https://github.com/scala/scala-dev/issues/671