### PR TITLE
Fix scaladoc tool on JDK 11 with -release 8: Exclude sig files in Symbol.sourceFile

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2567,7 +2567,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     // return actual source code.) So sourceFile has classfiles filtered out.
     final def sourceFile: AbstractFile = {
       val file = associatedFile
-      if ((file eq NoAbstractFile) || (file.path endsWith ".class")) null else file
+      if (
+        (file eq NoAbstractFile) || {
+          val path = file.path
+          path.endsWith(".class") || path.endsWith(".sig")
+        }) null else file
     }
 
     /** Overridden in ModuleSymbols to delegate to the module class.


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11927 (running scaladoc with on JDK 11 with `-release 8`). Scaladoc checks for the `sourceFile` here: https://github.com/scala/scala/blob/998541a92c0e0b4a2efa33ec858ceeeb012c4297/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala#L1002-L1007