### PR TITLE
Don't evaluate suffix twice in LazyList#lazyAppendedAll

### DIFF
--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -349,7 +349,7 @@ final class LazyList[+A] private(private[this] var lazyState: () => LazyList.Sta
       if (isEmpty) suffix match {
         case lazyList: LazyList[B]       => lazyList.state // don't recompute the LazyList
         case coll if coll.knownSize == 0 => State.Empty
-        case _                           => stateFromIterator(suffix.iterator)
+        case coll                        => stateFromIterator(coll.iterator)
       }
       else sCons(head, tail lazyAppendedAll suffix)
     }

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -368,4 +368,12 @@ class LazyListTest {
     assertNoStackOverflow((new L).a)
     assertNoStackOverflow((new L).b)
   }
+
+  // scala/bug#11931
+  @Test
+  def lazyAppendedAllExecutesOnce(): Unit = {
+    var count = 0
+    LazyList(1).lazyAppendedAll({ count += 1; Seq(2)}).toList
+    assertEquals(1, count)
+  }
 }


### PR DESCRIPTION
Fixes scala/bug#11931

H/T @xuwei-k for doing the heavy lifting