### PR TITLE
Fix VectorMap Bug [scala/bug#11933]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -298,7 +298,15 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Vector.fillSparse"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.VectorIterator.it"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.VectorIterator.it_="),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Vector.filterImpl")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Vector.filterImpl"),
+
+
+    ProblemFilters.exclude[IncompatibleTemplateDefProblem]("scala.collection.immutable.VectorMap$Tombstone"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.VectorMap$Tombstone$NextOfKin"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.VectorMap$Tombstone$NextOfKin$"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.VectorMap$Tombstone$Kinless$"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.VectorMap$Tombstone$"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.VectorMap#Tombstone.unapply")
   ),
 }
 

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -29,7 +29,7 @@ import scala.annotation.tailrec
   */
 final class VectorMap[K, +V] private (
     private[immutable] val fields: Vector[Any],
-    private[immutable] val underlying: Map[K, (Int, V)], dummy: Boolean, dropped: Int)
+    private[immutable] val underlying: Map[K, (Int, V)], dropped: Int)
   extends AbstractMap[K, V]
     with SeqMap[K, V]
     with StrictOptimizedMapOps[K, V, VectorMap, VectorMap[K, V]]
@@ -40,7 +40,7 @@ final class VectorMap[K, +V] private (
   override protected[this] def className: String = "VectorMap"
 
   private[immutable] def this(fields: Vector[K], underlying: Map[K, (Int, V)]) = {
-    this(fields, underlying, false, 0)
+    this(fields, underlying, 0)
   }
 
   override val size = underlying.size
@@ -52,9 +52,9 @@ final class VectorMap[K, +V] private (
   def updated[V1 >: V](key: K, value: V1): VectorMap[K, V1] = {
     underlying.get(key) match {
       case Some((slot, _)) =>
-        new VectorMap(fields, underlying.updated[(Int, V1)](key, (slot, value)), false, dropped)
+        new VectorMap(fields, underlying.updated[(Int, V1)](key, (slot, value)), dropped)
       case None =>
-        new VectorMap(fields :+ key, underlying.updated[(Int, V1)](key, (fields.length + dropped, value)), false, dropped)
+        new VectorMap(fields :+ key, underlying.updated[(Int, V1)](key, (fields.length + dropped, value)), dropped)
     }
   }
 
@@ -160,7 +160,7 @@ final class VectorMap[K, +V] private (
           if (last != first) {
             fs = fs.updated(last, Tombstone(first - 1 - last))
           }
-          new VectorMap(fs, underlying - key, false, dropped)
+          new VectorMap(fs, underlying - key, dropped)
         case _ =>
           this
       }
@@ -195,7 +195,7 @@ final class VectorMap[K, +V] private (
   override def tail: VectorMap[K, V] = {
     if (isEmpty) throw new UnsupportedOperationException("empty.tail")
     val (slot, key) = nextValidField(0)
-    new VectorMap(fields.drop(slot + 1), underlying - key, false, dropped + slot + 1)
+    new VectorMap(fields.drop(slot + 1), underlying - key, dropped + slot + 1)
   }
 
   override def init: VectorMap[K, V] = {
@@ -207,7 +207,7 @@ final class VectorMap[K, +V] private (
       case Tombstone(d) => throw new IllegalStateException("tombstone indicate wrong position: " + d)
       case k => (lastSlot, k.asInstanceOf[K])
     }
-    new VectorMap(fields.dropRight(fields.size - slot), underlying - key, false, dropped)
+    new VectorMap(fields.dropRight(fields.size - slot), underlying - key, dropped)
   }
 
   override def keys: Vector[K] = keysIterator.toVector

--- a/test/junit/scala/collection/immutable/VectorMapTest.scala
+++ b/test/junit/scala/collection/immutable/VectorMapTest.scala
@@ -73,4 +73,40 @@ class VectorMapTest {
     val m = VectorMap(1 -> "a") - 1 + (2 -> "b") - 2
     assertEquals(List(), m.toList)
   }
+
+  @Test
+  def removeLast_t11220: Unit = {
+    val m = VectorMap(1 -> "a", 2 -> "b").removed(2).updated(3, "c")
+    assertEquals(List(1 -> "a", 3 -> "c"), m.toList)
+  }
+
+  @Test
+  def removeLast_t11220_2: Unit = {
+    val m = VectorMap(1 -> "a", 2 -> "b").removed(2).updated(3, "c").removed(3)
+    assertEquals(List(1 -> "a"), m.toList)
+  }
+
+  @Test
+  def hasCorrectInit_t11218_2: Unit = {
+    val m = VectorMap(1 -> "a", 2 -> "b", 3 -> "c").removed(3).init
+    assertEquals(List(1 -> "a"), m.toList)
+  }
+
+  @Test
+  def hasCorrectTail: Unit = {
+    val m = VectorMap(1 -> "a", 2 -> "b", 3 -> "c").tail.removed(3)
+    assertEquals(List(2 -> "b"), m.toList)
+  }
+
+  @Test
+  def removeInit: Unit = {
+    val m = VectorMap(1 -> "a", 2 -> "b", 3 -> "c").removed(1).init
+    assertEquals(List(2 -> "b"), m.toList)
+  }
+
+  @Test
+  def removeInit_2: Unit = {
+    val m = VectorMap(1 -> "a", 2 -> "b", 3 -> "c", 4 -> "d", 5 -> "e").removed(1).removed(4).init
+    assertEquals(List(2 -> "b", 3 -> "c"), m.toList)
+  }
 }


### PR DESCRIPTION
see also scala/bug#11933

Change usage of Tombstone

- First element of Tombstone sequence, indicates next valid element of the Tombstone sequence.
- Last element of Tombstone sequence if it not first element (in other words, the Tombstone sequence's length > 1), then indicates prev valid element of the Tombstone sequence.
- The others, Not Concerned.

So remove Kinless class.


Add parameter 'dropped'

- 'dropped' indicates sum count of drop fields. It also indicates gap between actual slot and slot that underlying indicates.


Change method 'removed'

- It only merge preceding tombstone sequence and succeeding tombstone sequence.

Change method 'init'


Fixes scala/bug#11933