### PR TITLE
REPL: JLine 3: Fixes Repl not cleaning after itself

### DIFF
--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -137,6 +137,10 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
       intp.close()
       intp = null
     }
+    if (in ne null) {
+      in.close()
+      in = null
+    }
   }
 
 

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/InteractiveReader.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/InteractiveReader.scala
@@ -44,6 +44,11 @@ trait InteractiveReader {
 
   @deprecated("No longer used", "2.13.1")
   def initCompletion(completion: Completion): Unit = ()
+
+  /*
+   * Closes the underlying resource created by the reader.
+   */
+  def close(): Unit
 }
 
 object InteractiveReader {

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/SimpleReader.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/SimpleReader.scala
@@ -42,6 +42,8 @@ class SimpleReader(in: BufferedReader, out: JPrintWriter, val completion: Comple
     out.print(s)
     out.flush()
   }
+
+  override def close(): Unit = ()
 }
 
 object SimpleReader {


### PR DESCRIPTION
Fixes https://github.com/scala/scala-dev/issues/702

@lrytz discovered that 2.13.2 nightlies do not work when called from sbt shell `console` task more than once. This is likely because JLine 3 terminal is created inside `Reader#apply` but it's never closed. So when it's invoked the second time within the same JVM we get:

```
	Suppressed: java.lang.IllegalStateException: A system terminal is already running. Make sure to use the created system Terminal on the LineReaderBuilder if you're using one or that previously created system Terminals have been correctly closed.
		at org.jline.terminal.TerminalBuilder.doBuild(TerminalBuilder.java:397)
```

To fix this I added `def close(): Unit` to `InteractiveReader` trait, which gets called after REPL is done.