### PR TITLE
TapEach for Futures

### DIFF
--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -239,6 +239,17 @@ trait Future[+T] extends Awaitable[T] {
    */
   def map[S](f: T => S)(implicit executor: ExecutionContext): Future[S] = transform(_ map f)
 
+
+  /** Applies a side-effecting function to the encapsulated value in this Futur
+    * @param f a function to apply to each element in this Future
+    * @tparam U the return type of f
+    * @return The same Future as this
+    */
+  def tapEach[U](f: T => U)(implicit executor: ExecutionContext): Future[T] = transform{ t =>
+    try t.foreach(f(_)) catch { case e if NonFatal(e) => executor.reportFailure(e)}
+    t
+  }
+
   /** Creates a new future by applying a function to the successful result of
    *  this future, and returns the result of the function as the new future.
    *  If this future is completed with an exception then the new future will

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -240,7 +240,7 @@ trait Future[+T] extends Awaitable[T] {
   def map[S](f: T => S)(implicit executor: ExecutionContext): Future[S] = transform(_ map f)
 
 
-  /** Applies a side-effecting function to the encapsulated value in this Futur
+  /** Applies a side-effecting function to the encapsulated value in this Future
     * @param f a function to apply to each element in this Future
     * @tparam U the return type of f
     * @return The same Future as this


### PR DESCRIPTION
```tapEach``` should be defined for ```Futures```

**Basic Example Use Case**
 The problem arises when we want to apply a monadic operation to all applicable types (Options, Iterable, Futures and all other Product Types), most basic example being logging. 

If you want to do something like 

`Future|Option|Try .log(s"logging the value $_").map(...).log(...)`

You either have to do  

`F|O|T.map(r => {
     log(....)
    r})`

which arguably is ugly.

Or define an implicit class for all possibilities for each operation you want

```
implicit class MonadicLog[+B <: Product, A] (val u: B){
  def log(l: String): B = {
      log(l)
      u
    }  
 }

implicit class FutureLog[T, A](val u: Future[T]){
    def log(l: String) : Future[T] = {
      println(l)
      u
    }
  }

And so on ....
```

With `tapEach` defined on `Futures` we get a consistent interface across the board

i.e.

```
Future.successful(List(Some(1), Some(2), Some(3), Some(4)))
   .tapEach(println)
   .map(_.flatten
        .tapEach(println)
        .filter(_ > 1)
   ).tapEach(println)
```