### PR TITLE
Avoid allocation of TreeInfo.Applied

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -320,7 +320,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
   }
   private val macroImplBindingCache = perRunCaches.newAnyRefMap[Symbol, Option[MacroImplBinding]]()
 
-  def isBlackbox(expandee: Tree): Boolean = isBlackbox(dissectApplied(expandee).core.symbol)
+  def isBlackbox(expandee: Tree): Boolean = isBlackbox(dissectCore(expandee).symbol)
   def isBlackbox(macroDef: Symbol): Boolean = pluginsIsBlackbox(macroDef)
 
   /** Default implementation of `isBlackbox`.

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4295,7 +4295,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         // If tp == NoType, pass only explicit type arguments to applyXXX.  Not used at all
         // here - it is for scala-virtualized, where tp will be passed as an argument (for
         // selection on a staged Struct)
-        def matches(t: Tree)          = isDesugaredApply || treeInfo.dissectApplied(t).core == treeSelection
+        def matches(t: Tree)          = isDesugaredApply || treeInfo.dissectCore(t) == treeSelection
 
         /* Note that the trees which arrive here are potentially some distance from
          * the trees of direct interest. `cxTree` is some enclosing expression which


### PR DESCRIPTION
While profiling a build I noticed that calls to disectApplied
via `isSelfOrSuperConstrCall` was an allocation hotspot.

These use cases only need to strip Apply/TypeApply, so in this
commit I've duplicated a few lines of code to to this.