### PR TITLE
No Unit.depends bookkeeping if -Ytrack-dependencies:false

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilationUnits.scala
+++ b/src/compiler/scala/tools/nsc/CompilationUnits.scala
@@ -68,10 +68,10 @@ trait CompilationUnits { global: Global =>
     /** Note: depends now contains toplevel classes.
      *  To get their sourcefiles, you need to dereference with .sourcefile
      */
-    private[this] val _depends = mutable.HashSet[Symbol]()
+    private[this] val _depends = if (settings.YtrackDependencies.value) mutable.HashSet[Symbol]() else null
     @deprecated("Not supported and no longer used by Zinc", "2.12.9")
-    def depends = _depends
-    def registerDependency(symbol: Symbol): Unit = {
+    def depends: mutable.HashSet[Symbol] = if (_depends == null) mutable.HashSet[Symbol]() else _depends
+    def registerDependency(symbol: Symbol): Unit = if (settings.YtrackDependencies.value) {
       // sbt compatibility (scala/bug#6875)
       //
       // imagine we have a file named A.scala, which defines a trait named Foo and a module named Main

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -260,6 +260,7 @@ trait ScalaSettings extends AbsScalaSettings
   val YpickleJava = BooleanSetting("-Ypickle-java", "Pickler phase should compute pickles for .java defined symbols for use by build tools").internalOnly()
   val YpickleWrite = StringSetting("-Ypickle-write", "directory|jar", "destination for generated .sig files containing type signatures.", "", None).internalOnly()
   val YpickleWriteApiOnly = BooleanSetting("-Ypickle-write-api-only", "Exclude private members (other than those material to subclass compilation, such as private trait vals) from generated .sig files containing type signatures.").internalOnly()
+  val YtrackDependencies = BooleanSetting("-Ytrack-dependencies", "Record references to in unit.depends. Deprecated feature that supports SBT 0.13 with incOptions.withNameHashing(false) only.").withDefault(true)
 
   sealed abstract class CachePolicy(val name: String, val help: String)
   object CachePolicy {

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -267,8 +267,7 @@ trait Infer extends Checkable {
         case NoSymbol if sym.isJavaDefined && context.unit.isJava => sym  // don't try to second guess Java; see #4402
         case sym1                                                 => sym1
       }
-      // XXX So... what's this for exactly?
-      if (context.unit.exists)
+      if (context.unit.exists && settings.YtrackDependencies.value)
         context.unit.registerDependency(sym.enclosingTopLevelClass)
 
       if (sym.isError)


### PR DESCRIPTION
Comtemporary usage of SBT / Zinc don't touch this code path, you need to run with SBT 0.13.x [with name hashing disabled](https://github.com/sbt/sbt/blob/v0.13.18/compile/interface/src/main/scala/xsbt/Dependency.scala#L50).

This PR adds a `-Y` option to let performance conscious users opt out of the overhead.