### PR TITLE
[backport] SetN / MapN optimizations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -382,7 +382,17 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.NoAbstractFile.seq"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.NoAbstractFile.view"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.NoAbstractFile.view"),
-  )
+
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Set#Set3.filterImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Set#Set4.filterImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map2.filterImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map4.filterImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map1.filterImpl"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.Set$SetNIterator"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Set#Set2.filterImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Set#Set1.filterImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map3.filterImpl"),
+    )
 }
 
 scalaVersion in Global         := versionProps("starr.version")

--- a/build.sbt
+++ b/build.sbt
@@ -383,16 +383,16 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.NoAbstractFile.view"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.NoAbstractFile.view"),
 
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map1.filterImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map2.filterImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map3.filterImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map4.filterImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Set#Set1.filterImpl"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Set#Set2.filterImpl"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Set#Set3.filterImpl"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Set#Set4.filterImpl"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map2.filterImpl"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map4.filterImpl"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map1.filterImpl"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.Set$SetNIterator"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Set#Set2.filterImpl"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Set#Set1.filterImpl"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.Map#Map3.filterImpl"),
-    )
+  )
 }
 
 scalaVersion in Global         := versionProps("starr.version")

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -153,6 +153,10 @@ object Map extends ImmutableMapFactory[Map] {
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1))
     }
+    override def exists(p: ((K, V)) => Boolean): Boolean = p((key1, value1))
+    override def forall(p: ((K, V)) => Boolean): Boolean = p((key1, value1))
+    override private[scala] def filterImpl(pred: ((K, V)) => Boolean, isFlipped: Boolean): Map[K, V] =
+      if (pred((key1, value1)) != isFlipped) this else Map.empty
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
       var a, b = 0
@@ -203,6 +207,21 @@ object Map extends ImmutableMapFactory[Map] {
       else this
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1)); f((key2, value2))
+    }
+    override def exists(p: ((K, V)) => Boolean): Boolean = p((key1, value1)) || p((key2, value2))
+    override def forall(p: ((K, V)) => Boolean): Boolean = p((key1, value1)) && p((key2, value2))
+    override private[scala] def filterImpl(pred: ((K, V)) => Boolean, isFlipped: Boolean): Map[K, V] = {
+      var k1 = null.asInstanceOf[K]
+      var v1 = null.asInstanceOf[V]
+      var n = 0
+      if (pred((key1, value1)) != isFlipped) {             {k1 = key1; v1 = value1}; n += 1}
+      if (pred((key2, value2)) != isFlipped) { if (n == 0) {k1 = key2; v1 = value2}; n += 1}
+
+      n match {
+        case 0 => Map.empty
+        case 1 => new Map1(k1, v1)
+        case 2 => this
+      }
     }
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
@@ -265,6 +284,23 @@ object Map extends ImmutableMapFactory[Map] {
       else this
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1)); f((key2, value2)); f((key3, value3))
+    }
+    override def exists(p: ((K, V)) => Boolean): Boolean = p((key1, value1)) || p((key2, value2)) || p((key3, value3))
+    override def forall(p: ((K, V)) => Boolean): Boolean = p((key1, value1)) && p((key2, value2)) && p((key3, value3))
+    override private[scala] def filterImpl(pred: ((K, V)) => Boolean, isFlipped: Boolean): Map[K, V] = {
+      var k1, k2 = null.asInstanceOf[K]
+      var v1, v2 = null.asInstanceOf[V]
+      var n = 0
+      if (pred((key1, value1)) != isFlipped) {             { k1 = key1; v1 = value1 };                                             n += 1}
+      if (pred((key2, value2)) != isFlipped) { if (n == 0) { k1 = key2; v1 = value2 } else             { k2 = key2; v2 = value2 }; n += 1}
+      if (pred((key3, value3)) != isFlipped) { if (n == 0) { k1 = key3; v1 = value3 } else if (n == 1) { k2 = key3; v2 = value3 }; n += 1}
+
+      n match {
+        case 0 => Map.empty
+        case 1 => new Map1(k1, v1)
+        case 2 => new Map2(k1, v1, k2, v2)
+        case 3 => this
+      }
     }
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3
@@ -338,6 +374,25 @@ object Map extends ImmutableMapFactory[Map] {
       else this
     override def foreach[U](f: ((K, V)) => U): Unit = {
       f((key1, value1)); f((key2, value2)); f((key3, value3)); f((key4, value4))
+    }
+    override def exists(p: ((K, V)) => Boolean): Boolean = p((key1, value1)) || p((key2, value2)) || p((key3, value3)) || p((key4, value4))
+    override def forall(p: ((K, V)) => Boolean): Boolean = p((key1, value1)) && p((key2, value2)) && p((key3, value3)) && p((key4, value4))
+    override private[scala] def filterImpl(pred: ((K, V)) => Boolean, isFlipped: Boolean): Map[K, V] = {
+      var k1, k2, k3 = null.asInstanceOf[K]
+      var v1, v2, v3 = null.asInstanceOf[V]
+      var n = 0
+      if (pred((key1, value1)) != isFlipped) {             { k1 = key1; v1 = value1 };                                                                                         n += 1}
+      if (pred((key2, value2)) != isFlipped) { if (n == 0) { k1 = key2; v1 = value2 } else             { k2 = key2; v2 = value2 };                                             n += 1}
+      if (pred((key3, value3)) != isFlipped) { if (n == 0) { k1 = key3; v1 = value3 } else if (n == 1) { k2 = key3; v2 = value3 } else             { k3 = key3; v3 = value3};  n += 1}
+      if (pred((key4, value4)) != isFlipped) { if (n == 0) { k1 = key4; v1 = value4 } else if (n == 1) { k2 = key4; v2 = value4 } else if (n == 2) { k3 = key4; v3 = value4 }; n += 1}
+
+      n match {
+        case 0 => Map.empty
+        case 1 => new Map1(k1, v1)
+        case 2 => new Map2(k1, v1, k2, v2)
+        case 3 => new Map3(k1, v1, k2, v2, k3, v3)
+        case 4 => this
+      }
     }
     override def hashCode(): Int = {
       import scala.util.hashing.MurmurHash3

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -37,7 +37,7 @@ trait Set[A] extends Iterable[A]
 {
   override def companion: GenericCompanion[Set] = Set
 
-  
+
   /** Returns this $coll as an immutable set, perhaps accepting a
    *  wider range of elements.  Since it already is an
    *  immutable set, it will only be rebuilt if the underlying structure
@@ -54,7 +54,7 @@ trait Set[A] extends Iterable[A]
     foreach(sb += _)
     sb.result()
   }
-  
+
   override def seq: Set[A] = this
   protected override def parCombiner = ParSet.newCombiner[A] // if `immutable.SetLike` gets introduced, please move this there!
 }
@@ -106,6 +106,29 @@ object Set extends ImmutableSetFactory[Set] {
   }
   private[collection] def emptyInstance: Set[Any] = EmptySet
 
+  @SerialVersionUID(3L)
+  private abstract class SetNIterator[A](n: Int) extends AbstractIterator[A] with Serializable {
+    private[this] var current = 0
+    private[this] var remainder = n
+    def hasNext = remainder > 0
+    def apply(i: Int): A
+    def next(): A =
+      if (hasNext) {
+        val r = apply(current)
+        current += 1
+        remainder -= 1
+        r
+      } else Iterator.empty.next()
+
+    override def drop(n: Int): Iterator[A] = {
+      if (n > 0) {
+        current += n
+        remainder = Math.max(0, remainder - n)
+      }
+      this
+    }
+  }
+
   /** An optimized representation for immutable sets of size 1 */
   @SerialVersionUID(1233385750652442003L)
   class Set1[A] private[collection] (elem1: A) extends AbstractSet[A] with Set[A] with Serializable {
@@ -119,7 +142,7 @@ object Set extends ImmutableSetFactory[Set] {
       if (elem == elem1) Set.empty
       else this
     def iterator: Iterator[A] =
-      Iterator(elem1)
+      Iterator.single(elem1)
     override def foreach[U](f: A => U): Unit = {
       f(elem1)
     }
@@ -129,6 +152,8 @@ object Set extends ImmutableSetFactory[Set] {
     override def forall(@deprecatedName('f) p: A => Boolean): Boolean = {
       p(elem1)
     }
+    override private[scala] def filterImpl(pred: A => Boolean, isFlipped: Boolean): Set[A] =
+      if (pred(elem1) != isFlipped) this else Set.empty
     override def find(@deprecatedName('f) p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)
       else None
@@ -153,8 +178,11 @@ object Set extends ImmutableSetFactory[Set] {
       if (elem == elem1) new Set1(elem2)
       else if (elem == elem2) new Set1(elem1)
       else this
-    def iterator: Iterator[A] =
-      Iterator(elem1, elem2)
+    def iterator: Iterator[A] = new SetNIterator[A](size) {
+      def apply(i: Int) = getElem(i)
+    }
+    private def getElem(i: Int) = i match { case 0 => elem1 case 1 => elem2 }
+
     override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2)
     }
@@ -163,6 +191,18 @@ object Set extends ImmutableSetFactory[Set] {
     }
     override def forall(@deprecatedName('f) p: A => Boolean): Boolean = {
       p(elem1) && p(elem2)
+    }
+    override private[scala] def filterImpl(pred: A => Boolean, isFlipped: Boolean): Set[A] = {
+      var r1: A = null.asInstanceOf[A]
+      var n = 0
+      if (pred(elem1) != isFlipped) {             r1 = elem1; n += 1}
+      if (pred(elem2) != isFlipped) { if (n == 0) r1 = elem2; n += 1}
+
+      n match {
+        case 0 => Set.empty
+        case 1 => new Set1(r1)
+        case 2 => this
+      }
     }
     override def find(@deprecatedName('f) p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)
@@ -190,8 +230,11 @@ object Set extends ImmutableSetFactory[Set] {
       else if (elem == elem2) new Set2(elem1, elem3)
       else if (elem == elem3) new Set2(elem1, elem2)
       else this
-    def iterator: Iterator[A] =
-      Iterator(elem1, elem2, elem3)
+    def iterator: Iterator[A] = new SetNIterator[A](size) {
+      def apply(i: Int) = getElem(i)
+    }
+    private def getElem(i: Int) = i match { case 0 => elem1 case 1 => elem2 case 2 => elem3 }
+
     override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2); f(elem3)
     }
@@ -200,6 +243,20 @@ object Set extends ImmutableSetFactory[Set] {
     }
     override def forall(@deprecatedName('f) p: A => Boolean): Boolean = {
       p(elem1) && p(elem2) && p(elem3)
+    }
+    override private[scala] def filterImpl(pred: A => Boolean, isFlipped: Boolean): Set[A] = {
+      var r1, r2: A = null.asInstanceOf[A]
+      var n = 0
+      if (pred(elem1) != isFlipped) {             r1 = elem1;                             n += 1}
+      if (pred(elem2) != isFlipped) { if (n == 0) r1 = elem2 else             r2 = elem2; n += 1}
+      if (pred(elem3) != isFlipped) { if (n == 0) r1 = elem3 else if (n == 1) r2 = elem3; n += 1}
+
+      n match {
+        case 0 => Set.empty
+        case 1 => new Set1(r1)
+        case 2 => new Set2(r1, r2)
+        case 3 => this
+      }
     }
     override def find(@deprecatedName('f) p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)
@@ -229,8 +286,11 @@ object Set extends ImmutableSetFactory[Set] {
       else if (elem == elem3) new Set3(elem1, elem2, elem4)
       else if (elem == elem4) new Set3(elem1, elem2, elem3)
       else this
-    def iterator: Iterator[A] =
-      Iterator(elem1, elem2, elem3, elem4)
+    def iterator: Iterator[A] = new SetNIterator[A](size) {
+      def apply(i: Int) = getElem(i)
+    }
+    private def getElem(i: Int) = i match { case 0 => elem1 case 1 => elem2 case 2 => elem3 case 3 => elem4 }
+
     override def foreach[U](f: A => U): Unit = {
       f(elem1); f(elem2); f(elem3); f(elem4)
     }
@@ -240,6 +300,23 @@ object Set extends ImmutableSetFactory[Set] {
     override def forall(@deprecatedName('f) p: A => Boolean): Boolean = {
       p(elem1) && p(elem2) && p(elem3) && p(elem4)
     }
+    override private[scala] def filterImpl(pred: A => Boolean, isFlipped: Boolean): Set[A] = {
+      var r1, r2, r3: A = null.asInstanceOf[A]
+      var n = 0
+      if (pred(elem1) != isFlipped) {             r1 = elem1;                                                         n += 1}
+      if (pred(elem2) != isFlipped) { if (n == 0) r1 = elem2 else             r2 = elem2;                             n += 1}
+      if (pred(elem3) != isFlipped) { if (n == 0) r1 = elem3 else if (n == 1) r2 = elem3 else             r3 = elem3; n += 1}
+      if (pred(elem4) != isFlipped) { if (n == 0) r1 = elem4 else if (n == 1) r2 = elem4 else if (n == 2) r3 = elem4; n += 1}
+
+      n match {
+        case 0 => Set.empty
+        case 1 => new Set1(r1)
+        case 2 => new Set2(r1, r2)
+        case 3 => new Set3(r1, r2, r3)
+        case 4 => this
+      }
+    }
+
     override def find(@deprecatedName('f) p: A => Boolean): Option[A] = {
       if (p(elem1)) Some(elem1)
       else if (p(elem2)) Some(elem2)


### PR DESCRIPTION
Direct implementations of MapN.{filterImpl,exists,forall}

(cherry picked from commit 8821b30ee6202144e3d2cb07c3d27b082ac2574b)

Optimized iterators for immutable.SetN

Avoids projecting to a temporary List.

(cherry picked from commit 3e223d1c7fff68aed51820539085b908c32f6ebf)

Optimized filter for immutable.SetN

Avoids creating iterators and using builders and reuses the
input collection when the predicate selects all elements.

(cherry picked from commit 20b4596bc340ccfc5ba37847d6b21215586f0398)