### PR TITLE
Relax a few Java checks

### DIFF
--- a/test/files/pos/t11917.flags
+++ b/test/files/pos/t11917.flags
@@ -1,0 +1,1 @@
+-Ypickle-java

--- a/test/files/pos/t11917/A.java
+++ b/test/files/pos/t11917/A.java
@@ -1,0 +1,3 @@
+package foo;
+
+public class A<T> {}

--- a/test/files/pos/t11917/X.java
+++ b/test/files/pos/t11917/X.java
@@ -1,0 +1,3 @@
+package foo;
+
+public class X extends A/*<String>*/ {}

--- a/test/files/pos/t11917/Z.scala
+++ b/test/files/pos/t11917/Z.scala
@@ -1,0 +1,3 @@
+package bar
+
+class Z


### PR DESCRIPTION
Last time I tried this I got called out for relaxing too much. As justification, Java does not respect self types (so there would be a separate-compilation inconsistency to try to enforce them) nor does it understand non-stable prefixes.

Fixes scala/bug#11917. (Or at least kinda patches over it.)