### PR TITLE
Propagate type of bind tree

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -24,14 +24,14 @@ trait TreeAndTypeAnalysis extends Debugging {
 
   /** Compute the type T implied for a value `v` matched by a pattern `pat` (with expected type `pt`).
    *
-   * Usually, this is the pattern's type because pattern matching implies instance-of checks.
+   *  Usually, this is the pattern's type because pattern matching implies instance-of checks.
    *
-   * However, Stable Identifier and Literal patterns are matched using `==`,
-   * which does not imply a type for the binder that binds the matched value.
+   *  However, Stable Identifier and Literal patterns are matched using `==`,
+   *  which does not imply a type for the binder that binds the matched value.
    *
-   * See scala/bug#1503, scala/bug#5024: don't cast binders to types we're not sure they have
+   *  See scala/bug#1503, scala/bug#5024: don't cast binders to types we're not sure they have
    */
-  def binderTypeImpliedByPattern(pat: Tree, pt: Type, binder: Symbol): Type =
+  def binderTypeImpliedByPattern(pat: Tree, pt: Type): Type =
     pat match {
       // because `==` decides whether these patterns match, stable identifier patterns (ident or selection)
       // do not contribute any type information (beyond the pattern's expected type)

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -36,7 +36,7 @@ trait TreeAndTypeAnalysis extends Debugging {
       // because `==` decides whether these patterns match, stable identifier patterns (ident or selection)
       // do not contribute any type information (beyond the pattern's expected type)
       // e.g., in case x@Nil => x --> all we know about `x` is that it satisfies Nil == x, which could be anything
-      case Ident(_) | Select(_, _) => pt
+      case Ident(_) | Select(_, _) | Literal(_) => pt
 
       // the other patterns imply type tests, so we can safely assume the binder has the pattern's type when the pattern matches
       // concretely, a literal, type pattern, a case class (the constructor's result type) or extractor (the unapply's argument type) all imply type tests

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -42,7 +42,8 @@ trait TreeAndTypeAnalysis extends Debugging {
    */
   def binderTypeImpliedByPattern(pat: Tree, pt: Type): Type =
     pat match {
-      case _ if pat.tpe <:< BooleanTpe || pat.tpe <:< UnitTpe => pat.tpe
+      case _ if pat.tpe <:< BooleanTpe || pat.tpe <:< UnitTpe || pat.tpe <:< StringTpe
+                                                              => pat.tpe
       case Ident(_) | Select(_, _) | Literal(_)               => pt
       case Typed(_, _) if pat.tpe.isInstanceOf[ConstantType]  => pt
       case _                                                  => pat.tpe

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -28,20 +28,24 @@ trait TreeAndTypeAnalysis extends Debugging {
    *
    *  However, Stable Identifier and Literal patterns are matched using `==`,
    *  which does not imply a type for the binder that binds the matched value.
+   *  E.g., in `case x@Nil => x `, all we know about `x` is that it satisfies `Nil == x`, which could be anything.
+   *  A type pattern with a literal type works the same as the corresponding literal pattern.
+   *  A literal pattern with a Boolean or Unit pattern does enforce that the respective value (`true`, `false`, `()`)
+   *  was matched, so in those cases, the pattern type is assumed.
+   *
+   *  The other patterns imply type tests, so we can safely deduce that the binder has
+   *  the pattern's type when the pattern matches.
+   *  Concretely, a literal, type pattern, a case class (the constructor's result type)
+   *  or extractor (the unapply's argument type) all imply type tests.
    *
    *  See scala/bug#1503, scala/bug#5024: don't cast binders to types we're not sure they have
    */
   def binderTypeImpliedByPattern(pat: Tree, pt: Type): Type =
     pat match {
-      // because `==` decides whether these patterns match, stable identifier patterns (ident or selection)
-      // do not contribute any type information (beyond the pattern's expected type)
-      // e.g., in case x@Nil => x --> all we know about `x` is that it satisfies Nil == x, which could be anything
-      case Ident(_) | Select(_, _) | Literal(_) => pt
-
-      // the other patterns imply type tests, so we can safely assume the binder has the pattern's type when the pattern matches
-      // concretely, a literal, type pattern, a case class (the constructor's result type) or extractor (the unapply's argument type) all imply type tests
-      // (and, inductively, an alternative)
-      case _                       => pat.tpe
+      case _ if pat.tpe <:< BooleanTpe || pat.tpe <:< UnitTpe => pat.tpe
+      case Ident(_) | Select(_, _) | Literal(_)               => pt
+      case Typed(_, _) if pat.tpe.isInstanceOf[ConstantType]  => pt
+      case _                                                  => pat.tpe
     }
 
   // we use subtyping as a model for implication between instanceof tests

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4572,7 +4572,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       def typedBind(tree: Bind) =
         tree match {
           case Bind(name: TypeName, body)  =>
-            assert(body == EmptyTree, s"${context.unit} typedBind: ${name.debugString} $body ${body.getClass}")
+            assert(body.isEmpty, s"${context.unit} typedBind: ${name.debugString} ${body} ${body.getClass}")
             val sym =
               if (tree.symbol != NoSymbol) tree.symbol
               else {
@@ -4600,7 +4600,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             }
 
             val body1 = typed(body, mode, pt)
-            val impliedType = patmat.binderTypeImpliedByPattern(body1, pt, sym) // scala/bug#1503, scala/bug#5204
+            val impliedType = patmat.binderTypeImpliedByPattern(body1, pt) // scala/bug#1503, scala/bug#5204
             val symTp =
               if (treeInfo.isSequenceValued(body)) seqType(impliedType)
               else impliedType

--- a/test/files/neg/t10763.check
+++ b/test/files/neg/t10763.check
@@ -1,0 +1,6 @@
+t10763.scala:6: warning: pattern var x in value $anonfun is never used: use a wildcard `_` or suppress this warning with `x@_`
+  for (x @ 1 <- List(1.0)) ()
+       ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t10763.scala
+++ b/test/files/neg/t10763.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror -Wunused
+
+object Test extends App {
+  // cf test/files/pos/t10763.scala test/files/run/t11938.scala
+  // withFilter is exempt from warning but foreach is not.
+  for (x @ 1 <- List(1.0)) ()
+}

--- a/test/files/neg/t1503.check
+++ b/test/files/neg/t1503.check
@@ -8,9 +8,14 @@ t1503.scala:12: error: type mismatch;
  required: scala.collection.immutable.Nil.type
   val b: Nil.type = (Vector(): Any) match { case n @ (m @ Nil) => n } // error was: CCE
                                                                   ^
-t1503.scala:16: error: type mismatch;
+t1503.scala:18: error: type mismatch;
  found   : Any
  required: Int
   val d: Int = (1.0: Any) match { case x @ 1 => x }                   // error
                                                 ^
-3 errors
+t1503.scala:20: error: type mismatch;
+ found   : Any
+ required: Int
+  val e: Int = (1.0: Any) match { case x @ (_: 1) => x }              // error was: CCE
+                                                     ^
+4 errors

--- a/test/files/neg/t1503.check
+++ b/test/files/neg/t1503.check
@@ -1,0 +1,11 @@
+t1503.scala:10: error: type mismatch;
+ found   : n.type (with underlying type Any)
+ required: scala.collection.immutable.Nil.type
+  val a: Nil.type = (Vector(): Any) match { case n @ Nil => n }       // error
+                                                            ^
+t1503.scala:12: error: type mismatch;
+ found   : n.type (with underlying type Any)
+ required: scala.collection.immutable.Nil.type
+  val b: Nil.type = (Vector(): Any) match { case n @ (m @ Nil) => n } // error was: CCE
+                                                                  ^
+2 errors

--- a/test/files/neg/t1503.check
+++ b/test/files/neg/t1503.check
@@ -8,4 +8,9 @@ t1503.scala:12: error: type mismatch;
  required: scala.collection.immutable.Nil.type
   val b: Nil.type = (Vector(): Any) match { case n @ (m @ Nil) => n } // error was: CCE
                                                                   ^
-2 errors
+t1503.scala:16: error: type mismatch;
+ found   : Any
+ required: Int
+  val d: Int = (1.0: Any) match { case x @ 1 => x }                   // error
+                                                ^
+3 errors

--- a/test/files/neg/t1503.scala
+++ b/test/files/neg/t1503.scala
@@ -12,4 +12,8 @@ class Test {
   val b: Nil.type = (Vector(): Any) match { case n @ (m @ Nil) => n } // error was: CCE
 
   //val c = List(42) match { case xs @ (ys @ _*) => xs }              // syntax error
+
+  val d: Int = (1.0: Any) match { case x @ 1 => x }                   // error
+
+  val e: Int = (1.0: Any) match { case x @ (_: 1) => x }              // error CCE
 } 

--- a/test/files/neg/t1503.scala
+++ b/test/files/neg/t1503.scala
@@ -1,0 +1,15 @@
+// scalac: -Xlint -Werror
+//
+object Whatever {
+  override def equals(x: Any) = true
+}
+
+class Test {
+  def matchWhateverCCE(x: Any) = x match { case n @ Whatever => n }   // used to warn
+
+  val a: Nil.type = (Vector(): Any) match { case n @ Nil => n }       // error
+
+  val b: Nil.type = (Vector(): Any) match { case n @ (m @ Nil) => n } // error was: CCE
+
+  //val c = List(42) match { case xs @ (ys @ _*) => xs }              // syntax error
+} 

--- a/test/files/neg/t1503.scala
+++ b/test/files/neg/t1503.scala
@@ -27,4 +27,10 @@ class Test {
 
   def g(): Unit  = ((): Any) match { case u @ () => u }
   def g2(): Unit = ((): Any) match { case u @ (_: Unit) => u }        // no value discard
+
+  def h(x: Any): String = x match { case s @ "hello, world" => s }
+  def h2(x: Any): String = x match { case s @ (_: "hello, world") => s }
+  //def h3(x: Any): "hello, world" = x match { case s @ "hello, world" => s }  // crash
+
+  //def j(x: Any): Array[Int] = x match { case xs @ Array(42) => xs } // found Array[T] required Array[Int]
 }

--- a/test/files/neg/t1503.scala
+++ b/test/files/neg/t1503.scala
@@ -1,4 +1,4 @@
-// scalac: -Xlint -Werror
+// scalac: -Xlint -Werror -Wvalue-discard
 //
 object Whatever {
   override def equals(x: Any) = true
@@ -11,9 +11,20 @@ class Test {
 
   val b: Nil.type = (Vector(): Any) match { case n @ (m @ Nil) => n } // error was: CCE
 
-  //val c = List(42) match { case xs @ (ys @ _*) => xs }              // syntax error
+  //val c = List(42) match { case xs @ (ys @ _*) => xs }              // syntax error in parser
+
+  // numeric value classes compare equals betwixt themselves
 
   val d: Int = (1.0: Any) match { case x @ 1 => x }                   // error
 
-  val e: Int = (1.0: Any) match { case x @ (_: 1) => x }              // error CCE
-} 
+  val e: Int = (1.0: Any) match { case x @ (_: 1) => x }              // error was: CCE
+
+  // edge case, Boolean and Unit only equal themselves
+
+  val f: Boolean  = (true: Any) match { case b @ true => b }
+  val f2: Boolean = (true: Any) match { case b @ (_: true) => b }
+  val f3: true    = (true: Any) match { case b @ (_: true) => b }
+
+  def g(): Unit  = ((): Any) match { case u @ () => u }
+  def g2(): Unit = ((): Any) match { case u @ (_: Unit) => u }        // no value discard
+}

--- a/test/files/pos/t10763.scala
+++ b/test/files/pos/t10763.scala
@@ -1,10 +1,11 @@
 
-// scalac: -Xfatal-warnings -Ywarn-unused
+// scalac: -Werror -Wunused
+
 class Test {
   def xsUnused = {
     val xs: List[Int] = List(0)
 
-    for (refute@1 <- xs) {}
+    for (refute@1 <- xs) println(refute)
   }
   def f() = for (Some(i: Int) <- List(Option(42))) println(i)
 }

--- a/test/files/run/t11938.scala
+++ b/test/files/run/t11938.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror -Wunused
+object Test extends App {
+  for (x @ 1 <- List(1.0)) {
+    assert(x.isInstanceOf[Double])
+    assert(!x.isNaN)
+  }
+}


### PR DESCRIPTION
After inferring type of Bind for equals semantics,
use it for the tree type so enclosing binds know
about it.

Rebased and added tests for literal type. Previously, `pos/t10763.scala` was not testing anything because the typed case was `case 1` not `case x @ 1`. Now the patvar must be used in the `foreach`; the test is that the unused check does not warn about the lambda to `withFilter`. Added the `neg` test for that. Added a `run` test to check the type of the patvar.

Fixes scala/bug#12119