### PR TITLE
reduce CPU in SortedMap and SortedSet #equals()

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -303,6 +303,9 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.TreeSet$TreeSetBuilder"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.TreeSet.this"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.TreeSet$TreeSetBuilder$adder$"),
+
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.collection.immutable.SortedSet.scala$collection$immutable$SortedSet$$super=uals"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.collection.immutable.SortedMap.scala$collection$immutable$SortedMap$$super=uals"),
     //
     // scala-relect
     //

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -102,6 +102,20 @@ self =>
     override def valuesIteratorFrom(start : A) = self valuesIteratorFrom start map f
   }
 
+  override def equals(that: Any): Boolean = that match {
+    case _ if this eq that.asInstanceOf[AnyRef] => true
+    case sm: SortedMap[k, v] if sm.ordering == this.ordering =>
+      (sm canEqual this) &&
+        (this.size == sm.size) && {
+        val i1 = this.iterator
+        val i2 = sm.iterator
+        var allEqual = true
+        while (allEqual && i1.hasNext)
+          allEqual = i1.next() == i2.next()
+        allEqual
+      }
+    case _ => super.equals(that)
+  }
 }
 
 /** $factoryInfo

--- a/src/library/scala/collection/immutable/SortedSet.scala
+++ b/src/library/scala/collection/immutable/SortedSet.scala
@@ -28,8 +28,23 @@ import generic._
 trait SortedSet[A] extends Set[A] with scala.collection.SortedSet[A] with SortedSetLike[A, SortedSet[A]] {
   /** Needs to be overridden in subclasses. */
   override def empty: SortedSet[A] = SortedSet.empty[A]
-}
 
+  override def equals(that: Any): Boolean = that match {
+    case _ if this eq that.asInstanceOf[AnyRef] => true
+    case ss: SortedSet[_] =>
+      (ss canEqual this) &&
+        (this.size == ss.size) && {
+        val i1 = this.iterator
+        val i2 = ss.iterator
+        var allEqual = true
+        while (allEqual && i1.hasNext)
+          allEqual = i1.next() == i2.next
+        allEqual
+      }
+    case _ =>
+      super.equals(that)
+  }
+}
 /** $factoryInfo
  *  @define Coll `immutable.SortedSet`
  *  @define coll immutable sorted set

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/RedBlackTreeEqualsBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/RedBlackTreeEqualsBenchmark.scala
@@ -1,0 +1,110 @@
+package scala.collection.immutable
+
+import java.util
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+
+import scala.util.Random
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class RedBlackTreeEqualsSharedBenchmark {
+
+  @Param(Array("0", "1", "10", "100", "1000", "10000"))
+  var size: Int = _
+
+  @Param(Array("0", "1", "10"))
+  var diff: Int = _
+
+  var set: TreeSet[Int] = _
+  var otherSet: TreeSet[Int] = _
+  var map: TreeMap[Int, Int] = _
+  var otherMap: TreeMap[Int, Int] = _
+
+  @Setup(Level.Trial) def init: Unit = {
+    val r = new Random()
+    r.setSeed(0x1234567890abcdefL)
+
+    def aSet(start: Int, end: Int) : TreeSet[Int] = (start to end).to[TreeSet]
+    def aMap(start: Int, end: Int) : TreeMap[Int, Int] = TreeMap.empty[Int, Int] ++ ((start to end) map {x => x-> x})
+
+    set = aSet(1, size)
+    otherSet = (1 to diff).foldLeft(set) {
+      case (s,n) => val n = r.nextInt(size)
+      s - n + n
+    }
+
+    map = aMap(1, size)
+    otherMap =(1 to diff).foldLeft(map) {
+      case (s,n) => val n = r.nextInt(size)
+        s - n + (n->n)
+    }
+  }
+
+  @Benchmark
+  def setEqualsOther =
+    set == otherSet
+
+  @Benchmark
+  def mapEqualsOther =
+    map == otherMap
+}
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class RedBlackTreeEqualsUnsharedBenchmark {
+
+  @Param(Array("10", "100", "1000", "10000"))
+  var size: Int = _
+
+  var set: TreeSet[Int] = _
+  var otherSet: TreeSet[Int] = _
+  var map: TreeMap[Int, Int] = _
+  var otherMap: TreeMap[Int, Int] = _
+
+  @Setup(Level.Trial) def init: Unit = {
+    def aSet(start: Int, end: Int) : TreeSet[Int] = (start to end).to[TreeSet]
+    def aMap(start: Int, end: Int) : TreeMap[Int, Int] = TreeMap.empty[Int, Int] ++ ((start to end) map {x => x-> x})
+    set = aSet(1, size)
+    otherSet =  aSet(1, size)
+
+    map = aMap(1, size)
+    otherMap = aMap(1, size)
+  }
+
+  @Benchmark
+  def setEqualsOther =
+    set == otherSet
+
+  @Benchmark
+  def mapEqualsOther =
+    map == otherMap
+}
+object Mike extends App {
+  val x = new RedBlackTreeEqualsUnsharedBenchmark
+  x.size = 10000
+  x.init
+  var i = 0
+  var start = System.currentTimeMillis()
+  while (true ) {
+    x.mapEqualsOther
+    i += 1
+    if (i == 1000) {
+      val now = System.currentTimeMillis()
+      println(s"${now - start}")
+      i = 0
+      start = now
+    }
+  }
+}


### PR DESCRIPTION
When comparing sorted Map/Set, and the ordering is the same, we can iterate the collection, rather than lookups which are typically O(log(n))

Set when comparing a compatable SortedSet/Map the cpu used is O(n) not O(n * log(n))

For maps there is an allocation penalty, as each iterator generates tuples, and previously only one iterator was used

Benchmarks to follow

