### PR TITLE
make TreeSet/TreeMap equals faster and reduce allocations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -192,6 +192,11 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.RedBlackTree$EntriesIterator"),
     ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.RedBlackTree$ValuesIterator"),
     ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.RedBlackTree$TreeIterator"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.immutable.RedBlackTree.iterator"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.immutable.RedBlackTree.keysIterator"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.immutable.RedBlackTree.iterator"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.immutable.RedBlackTree.keysIterator"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.RedBlackTree#TreeIterator.moveNext"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.generic.SortedMapFactory#SortedMapCanBuildFrom.ordering"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.TreeMap.tree"),
 

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -243,4 +243,26 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
     val (l, r) = RB.partitionKeys(tree, p)
     (newSetOrSelf(l), newSetOrSelf(r))
   }
+  override def equals(that: Any): Boolean = that match {
+    case _ if this eq that.asInstanceOf[AnyRef] => true
+    case tm: TreeSet[k] if tm.ordering == this.ordering =>
+      (tm canEqual this) &&
+        (this.size == tm.size) && {
+        val i1: RedBlackTree.TreeIterator[A, _, (A, _)] = RB.iterator(this.tree)
+        val i2: RedBlackTree.TreeIterator[k, _, (k, _)] = {
+          implicit val ord2: Ordering[k] = tm.ordering.asInstanceOf[Ordering[k]]
+          RB.iterator(tm.tree)
+        }
+        var allEqual = true
+        while (allEqual && i1.hasNext) {
+          val n1 = i1.moveNext()
+          val n2 = i2.moveNext()
+
+          allEqual = (n1 eq n2) || (n1.key == n2.key)
+        }
+        allEqual
+      }
+    case _ => super.equals(that)
+  }
+
 }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/RedBlackTreeEqualsBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/RedBlackTreeEqualsBenchmark.scala
@@ -1,0 +1,110 @@
+package scala.collection.immutable
+
+import java.util
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+
+import scala.util.Random
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class RedBlackTreeEqualsSharedBenchmark {
+
+  @Param(Array("0", "1", "10", "100", "1000", "10000"))
+  var size: Int = _
+
+  @Param(Array("0", "1", "10"))
+  var diff: Int = _
+
+  var set: TreeSet[Int] = _
+  var otherSet: TreeSet[Int] = _
+  var map: TreeMap[Int, Int] = _
+  var otherMap: TreeMap[Int, Int] = _
+
+  @Setup(Level.Trial) def init: Unit = {
+    val r = new Random()
+    r.setSeed(0x1234567890abcdefL)
+
+    def aSet(start: Int, end: Int) : TreeSet[Int] = (start to end).to[TreeSet]
+    def aMap(start: Int, end: Int) : TreeMap[Int, Int] = TreeMap.empty[Int, Int] ++ ((start to end) map {x => x-> x})
+
+    set = aSet(1, size)
+    otherSet = (1 to diff).foldLeft(set) {
+      case (s,n) => val n = r.nextInt(size)
+      s - n + n
+    }
+
+    map = aMap(1, size)
+    otherMap =(1 to diff).foldLeft(map) {
+      case (s,n) => val n = r.nextInt(size)
+        s - n + (n->n)
+    }
+  }
+
+  @Benchmark
+  def setEqualsOther =
+    set == otherSet
+
+  @Benchmark
+  def mapEqualsOther =
+    map == otherMap
+}
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class RedBlackTreeEqualsUnsharedBenchmark {
+
+  @Param(Array("10", "100", "1000", "10000"))
+  var size: Int = _
+
+  var set: TreeSet[Int] = _
+  var otherSet: TreeSet[Int] = _
+  var map: TreeMap[Int, Int] = _
+  var otherMap: TreeMap[Int, Int] = _
+
+  @Setup(Level.Trial) def init: Unit = {
+    def aSet(start: Int, end: Int) : TreeSet[Int] = (start to end).to[TreeSet]
+    def aMap(start: Int, end: Int) : TreeMap[Int, Int] = TreeMap.empty[Int, Int] ++ ((start to end) map {x => x-> x})
+    set = aSet(1, size)
+    otherSet =  aSet(1, size)
+
+    map = aMap(1, size)
+    otherMap = aMap(1, size)
+  }
+
+  @Benchmark
+  def setEqualsOther =
+    set == otherSet
+
+  @Benchmark
+  def mapEqualsOther =
+    map == otherMap
+}
+object Mike extends App {
+  val x = new RedBlackTreeEqualsUnsharedBenchmark
+  x.size = 10000
+  x.init
+  var i = 0
+  var start = System.currentTimeMillis()
+  while (true ) {
+    x.mapEqualsOther
+    i += 1
+    if (i == 1000) {
+      val now = System.currentTimeMillis()
+      println(s"${now - start}")
+      i = 0
+      start = now
+    }
+  }
+}


### PR DESCRIPTION
avoid `Some`and `Tuple2` allocation then comparing two `TreeSet`s or `TreeMap`s

There is something still non-linear in the scaling though

Benchmarks 

  |   |   |   | Before |   |   | After |   |   | Improvement |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Benchmark | (size) |   |   | ns/op | B/op |   | ns/op | B/op |   | ns/op | B/op
RedBlackTreeEqualsUnsharedBenchmark.mapEqualsOther | 10 |   |   | 268 | 88 |   | 112 | 80 |   | 58% | 9%
RedBlackTreeEqualsUnsharedBenchmark.mapEqualsOther | 100 |   |   | 4,005 | 112 |   | 699 | 128 |   | 83% | -14%
RedBlackTreeEqualsUnsharedBenchmark.mapEqualsOther | 1000 |   |   | 120,988 | 5,614 |   | 9,581 | 176 |   | 92% | 97%
RedBlackTreeEqualsUnsharedBenchmark.mapEqualsOther | 10000 |   |   | 2,045,677 | 113,194 |   | 701,552 | 305 |   | 66% | 100%
RedBlackTreeEqualsUnsharedBenchmark.setEqualsOther | 10 |   |   | 209 | 128 |   | 107 | 80 |   | 49% | 38%
RedBlackTreeEqualsUnsharedBenchmark.setEqualsOther | 100 |   |   | 1,628 | 176 |   | 638 | 128 |   | 61% | 27%
RedBlackTreeEqualsUnsharedBenchmark.setEqualsOther | 1000 |   |   | 12,562 | 256 |   | 7,839 | 176 |   | 38% | 31%
RedBlackTreeEqualsUnsharedBenchmark.setEqualsOther | 10000 |   |   | 1,080,017 | 306 |   | 569,691 | 305 |   | 47% | 0%

