### PR TITLE
make LazyList.apply mark results as already-evaluated

### DIFF
--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -948,6 +948,13 @@ object LazyList extends SeqFactory[LazyList] {
   // Eagerly evaluate cached empty instance
   private[this] val _empty = newLL(State.Empty).force
 
+  // We cannot make the arguments be lazily evaluated; Scala 2 doesn't have
+  // by-name varargs, and even Dotty's by-name varargs (SIP-24) don't make the individual
+  // elements by-name separately from each other.  So the arguments have already been
+  // evaluated; calling `force` marks them as such, which matters to `toString`
+  override def apply[A](elems: A*): LazyList[A] =
+    super.apply(elems: _*).force
+
   private sealed trait State[+A] extends Serializable {
     def head: A
     def tail: LazyList[A]

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -70,20 +70,20 @@ class LazyListTest {
 
   @Test
   def testLazyListToStringWhenHeadAndTailBothAreNotEvaluated = {
-    val l = LazyList(1, 2, 3, 4, 5)
+    val l = LazyList.from(1).take(5)
     assertEquals("LazyList(<not computed>)", l.toString)
   }
 
   @Test
   def testLazyListToStringWhenOnlyHeadIsEvaluated = {
-    val l = LazyList(1, 2, 3, 4, 5)
+    val l = LazyList.from(1).take(5)
     l.head
     assertEquals("LazyList(1, <not computed>)", l.toString)
   }
 
   @Test
   def testLazyListToStringWhenHeadAndTailIsEvaluated = {
-    val l = LazyList(1, 2, 3, 4, 5)
+    val l = LazyList.from(1).take(5)
     l.head
     l.tail
     assertEquals("LazyList(1, <not computed>)", l.toString)
@@ -91,36 +91,42 @@ class LazyListTest {
 
   @Test
   def testLazyListToStringWhenHeadAndTailHeadIsEvaluated = {
-    val l = LazyList(1, 2, 3, 4, 5)
+    val l = LazyList.from(1).take(5)
     l.head
     l.tail.head
     assertEquals("LazyList(1, 2, <not computed>)", l.toString)
   }
 
   @Test
+  def testLazyListToStringFromApply = {
+    val l = LazyList(1, 2, 3)
+    assertEquals("LazyList(1, 2, 3)", l.toString)
+  }
+
+  @Test
   def testLazyListToStringWhenHeadIsNotEvaluatedAndOnlyTailIsEvaluated = {
-    val l = LazyList(1, 2, 3, 4, 5)
+    val l = LazyList.from(1).take(5)
     l.tail
     assertEquals("LazyList(1, <not computed>)", l.toString)
   }
 
   @Test
   def testLazyListToStringWhenHeadIsNotEvaluatedAndTailHeadIsEvaluated = {
-    val l = LazyList(1, 2, 3, 4, 5)
+    val l = LazyList.from(1).take(5)
     l.tail.head
     assertEquals("LazyList(1, 2, <not computed>)", l.toString)
   }
 
   @Test
   def testLazyListToStringWhenHeadIsNotEvaluatedAndTailTailIsEvaluated = {
-    val l = LazyList(1, 2, 3, 4, 5)
+    val l = LazyList.from(1).take(5)
     l.tail.tail
     assertEquals("LazyList(1, 2, <not computed>)", l.toString)
   }
 
   @Test
   def testLazyListToStringWhendHeadIsNotEvaluatedAndTailTailHeadIsEvaluated = {
-    val l = LazyList(1, 2, 3, 4, 5)
+    val l = LazyList.from(1).take(5)
     l.tail.tail.head
     assertEquals("LazyList(1, 2, 3, <not computed>)", l.toString)
   }
@@ -145,7 +151,6 @@ class LazyListTest {
   @Test
   def testLazyListToStringForSingleElementList: Unit = {
     val l = LazyList(1)
-    l.force
     assertEquals("LazyList(1)", l.toString)
   }
 


### PR DESCRIPTION
formerly `LazyList(1,2,3).toString` was `LazyList(<not computed>)` which doesn't seem right to me, the elements certainly have been computed, as we see here:

```
scala 2.13.1> LazyList(1, {println("foo"); 2}, 3)
foo
res0: scala.collection.immutable.LazyList[Int] = LazyList(<not computed>)
```

I consciously chose to leave `Stream` alone here, since it's deprecated.