### PR TITLE
Don't move RHS of specialized trait val into ctor

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -681,7 +681,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
             case dd: DefDef =>
               // either move the RHS to ctor (for getter of stored field) or just drop it (for corresponding setter)
               def shouldMoveRHS =
-                clazz.isTrait && statSym.isAccessor && !statSym.isLazy && (statSym.isSetter || memoizeValue(statSym))
+                clazz.isTrait && statSym.isAccessor && !statSym.isLazy && !statSym.isSpecialized && (statSym.isSetter || memoizeValue(statSym))
 
               if ((dd.rhs eq EmptyTree) || !shouldMoveRHS) { defBuf += dd }
               else {

--- a/test/files/run/t11934.scala
+++ b/test/files/run/t11934.scala
@@ -1,0 +1,9 @@
+trait T[@specialized(Int, Unit) S] {
+  var value: S = _
+}
+
+final class C[@specialized(Int, Unit) S] extends T[S]
+
+object Test extends App {
+  new C[Int]
+}


### PR DESCRIPTION
Coming into `constructors` phase, specialized vars in traits have at least 4 methods associated with them (and 0 fields): a getter, a setter, a specialized getter, and a specialized setter. The specialized getter calls the normal getter and unboxes the result; the specialized setter boxes its argument and calls the normal setter.

If the var is initialized, then the user-provided value is currently held in the RHS of the (normal) getter, post 2.12. Constructors phase moves such RHSes into setter calls in the trait constructor.

However, without this patch the specialized getters were considered as encoding the same pattern, and their RHSes were moved into the trait constructor and made into calls to the specialized setters. This guarantees that at least one of the specializations will fail if the trait is specialized multiple times.

Fixes scala/bug#11934.