### PR TITLE
faster equality checks for RedBlackTree - followup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -239,8 +239,9 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.RedBlackTree#TreeIterator.lookahead"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.RedBlackTree#TreeIterator.lookahead_="),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.RedBlackTree#TreeIterator.goRight"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.RedBlackTree#TreeIterator.stackOfNexts"),
 
-  // Some static forwarder changes detected after a MiMa upgrade.
+    // Some static forwarder changes detected after a MiMa upgrade.
     // e.g. static method apply(java.lang.Object)java.lang.Object in class scala.Symbol does not have a correspondent in current version
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Symbol.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.sys.process.Process.Future"),

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -355,16 +355,16 @@ private[collection] object RedBlackTree {
       else if (tree.left eq null) tree
       else findLeftMostOrPopOnEmpty(goLeft(tree))
 
-    private[this] def pushNext(tree: Tree[A, B]): Unit = {
+    @`inline` private[this] def pushNext(tree: Tree[A, B]): Unit = {
       stackOfNexts(index) = tree
       index += 1
     }
-    protected final def popNext(): Tree[A, B] = if (index == 0) null else {
+    @`inline` protected final def popNext(): Tree[A, B] = if (index == 0) null else {
       index -= 1
       stackOfNexts(index)
     }
 
-    private[this] var stackOfNexts = if (root eq null) null else {
+    protected[this] val stackOfNexts = if (root eq null) null else {
       /*
        * According to "Ralf Hinze. Constructing red-black trees" [http://www.cs.ox.ac.uk/ralf.hinze/publications/#P5]
        * the maximum height of a red-black tree is 2*log_2(n + 2) - 2.
@@ -378,7 +378,7 @@ private[collection] object RedBlackTree {
       new Array[Tree[A, B]](maximumHeight)
     }
     private[this] var index = 0
-    protected var lookahead: Tree[A, B] = start map startFrom getOrElse findLeftMostOrPopOnEmpty(root)
+    protected var lookahead: Tree[A, B] = if (start isDefined) startFrom(start.get) else findLeftMostOrPopOnEmpty(root)
 
     /**
      * Find the leftmost subtree whose key is equal to the given key, or if no such thing,


### PR DESCRIPTION
followup to https://github.com/scala/scala/pull/8774 

(common summary) walks though the tree the compare, with some ability to skip identical subtrees, when we have structural sharing

together with https://github.com/scala/scala/pull/8774 the benchmark result is 

improvement |   |   |   |   |   |   |   |   | before |   |   |   |   | after |   |   |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
time | Allocation | Benchmark | (diff) | (size) | Mode | Cnt |   |   | time(ns) | error | Allocation | error |   | time(ns) | error | Allocation | error
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 0 | 0 | avgt | 20 |   |   | 3.95 | 0.29 | - | 0 |   | 7.87 | 1.543 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 0 | 1 | avgt | 20 |   |   | 4.08 | 0.389 | - | 0 |   | 6.01 | 0.875 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 0 | 10 | avgt | 20 |   |   | 3.75 | 0.114 | - | 0 |   | 6.09 | 0.731 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 0 | 100 | avgt | 20 |   |   | 3.72 | 0.057 | - | 0 |   | 5.64 | 0.635 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 0 | 1000 | avgt | 20 |   |   | 3.80 | 0.151 | - | 0 |   | 6.57 | 0.962 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 0 | 10000 | avgt | 20 |   |   | 3.79 | 0.246 | - | 0 |   | 5.60 | 0.269 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 1 | 1 | avgt | 20 |   |   | 4.83 | 0.354 | - | 0 |   | 6.39 | 0.347 | - | 0
58.1% | 9.1% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 1 | 10 | avgt | 20 |   |   | 263.81 | 3.316 | 88 | 0.001 |   | 110.61 | 6.93 | 80 | 0.001
91.7% | -14.3% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 1 | 100 | avgt | 20 |   |   | 3,875.55 | 72.467 | 112 | 0.013 |   | 322.38 | 15.785 | 128 | 0.001
99.4% | -29.2% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 1 | 1000 | avgt | 20 |   |   | 104,861.15 | 2921.189 | 136 | 0.339 |   | 629.17 | 39.098 | 176 | 0.002
99.9% | 99.9% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 1 | 10000 | avgt | 20 |   |   | 963,262.23 | 19140.34 | 240,170 | 3.163 |   | 1,191.24 | 108.343 | 240 | 0.004
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 10 | 1 | avgt | 20 |   |   | 4.56 | 0.331 | - | 0 |   | 7.42 | 1.213 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 10 | 10 | avgt | 20 |   |   | 4.45 | 0.038 | - | 0 |   | 6.72 | 0.707 | - | 0
82.4% | -14.3% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 10 | 100 | avgt | 20 |   |   | 3,696.10 | 31.452 | 112 | 0.012 |   | 649.16 | 43.786 | 128 | 0.002
97.4% | -29.3% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 10 | 1000 | avgt | 20 |   |   | 102,506.75 | 1532.226 | 136 | 0.336 |   | 2,623.86 | 299.983 | 176 | 0.008
99.2% | 99.9% | RedBlackTreeEqualsSharedBenchmark.mapEqualsOther | 10 | 10000 | avgt | 20 |   |   | 1,013,379.22 | 56109.23 | 240,170 | 3.258 |   | 8,075.93 | 759.99 | 240 | 0.026
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 0 | 0 | avgt | 20 |   |   | 3.74 | 0.045 | - | 0 |   | 7.02 | 0.235 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 0 | 1 | avgt | 20 |   |   | 3.71 | 0.017 | - | 0 |   | 6.90 | 0.365 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 0 | 10 | avgt | 20 |   |   | 3.72 | 0.043 | - | 0 |   | 7.79 | 1.301 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 0 | 100 | avgt | 20 |   |   | 3.90 | 0.274 | - | 0 |   | 6.25 | 0.926 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 0 | 1000 | avgt | 20 |   |   | 3.70 | 0.014 | - | 0 |   | 5.76 | 0.568 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 0 | 10000 | avgt | 20 |   |   | 3.73 | 0.077 | - | 0 |   | 6.08 | 0.66 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 1 | 1 | avgt | 20 |   |   | 4.47 | 0.027 | - | 0 |   | 7.05 | 0.85 | - | 0
53.4% | 50.0% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 1 | 10 | avgt | 20 |   |   | 263.00 | 7.696 | 160 | 14.255 |   | 122.56 | 12.73 | 80 | 0.001
81.2% | 27.3% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 1 | 100 | avgt | 20 |   |   | 1,720.54 | 522.949 | 176 | 14.256 |   | 322.94 | 21.943 | 128 | 0.001
93.3% | 31.3% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 1 | 1000 | avgt | 20 |   |   | 13,420.77 | 945.309 | 256 | 0.044 |   | 901.77 | 24.258 | 176 | 0.003
99.7% | 21.3% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 1 | 10000 | avgt | 20 |   |   | 666,776.25 | 25747.83 | 305 | 2.138 |   | 1,700.80 | 325.435 | 240 | 0.006
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 10 | 1 | avgt | 20 |   |   | 4.50 | 0.119 | - | 0 |   | 6.85 | 0.773 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 10 | 10 | avgt | 20 |   |   | 4.43 | 0.041 | - | 0 |   | 6.74 | 0.714 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 10 | 100 | avgt | 20 |   |   | 4.61 | 0.371 | - | 0 |   | 6.57 | 0.945 | - | 0
-- | 0.0% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 10 | 1000 | avgt | 20 |   |   | 4.97 | 0.773 | - | 0 |   | 6.84 | 0.868 | - | 0
98.5% | 21.3% | RedBlackTreeEqualsSharedBenchmark.setEqualsOther | 10 | 10000 | avgt | 20 |   |   | 710,997.46 | 60296.47 | 305 | 2.296 |   | 10,936.23 | 1733.332 | 240 | 0.045
56.6% | 9.1% | RedBlackTreeEqualsUnsharedBenchmark.mapEqualsOther | N/A | 10 | avgt | 20 |   |   | 268.29 | 4.234 | 88 | 0.001 |   | 116.40 | 5.368 | 80 | 0.001
79.8% | -14.3% | RedBlackTreeEqualsUnsharedBenchmark.mapEqualsOther | N/A | 100 | avgt | 20 |   |   | 4,005.02 | 329.738 | 112 | 0.013 |   | 807.12 | 55.004 | 128 | 0.003
91.3% | 96.9% | RedBlackTreeEqualsUnsharedBenchmark.mapEqualsOther | N/A | 1000 | avgt | 20 |   |   | 120,987.55 | 6676.926 | 5,614 | 11288.8 |   | 10,501.54 | 310.559 | 176 | 0.037
61.5% | 99.8% | RedBlackTreeEqualsUnsharedBenchmark.mapEqualsOther | N/A | 10000 | avgt | 20 |   |   | 2,045,677.05 | 736091.4 | 113,194 | 102879.3 |   | 786,860.16 | 73146.38 | 241 | 2.516
46.8% | 37.5% | RedBlackTreeEqualsUnsharedBenchmark.setEqualsOther | N/A | 10 | avgt | 20 |   |   | 208.77 | 18.643 | 128 | 14.255 |   | 111.02 | 3.241 | 80 | 0.001
56.2% | 27.3% | RedBlackTreeEqualsUnsharedBenchmark.setEqualsOther | N/A | 100 | avgt | 20 |   |   | 1,627.75 | 522.891 | 176 | 14.255 |   | 712.37 | 21.821 | 128 | 0.002
34.2% | 31.3% | RedBlackTreeEqualsUnsharedBenchmark.setEqualsOther | N/A | 1000 | avgt | 20 |   |   | 12,562.36 | 323.324 | 256 | 0.041 |   | 8,267.09 | 194.825 | 176 | 0.027
35.7% | 21.1% | RedBlackTreeEqualsUnsharedBenchmark.setEqualsOther | N/A | 10000 | avgt | 20 |   |   | 1,080,016.71 | 39741.45 | 306 | 3.532 |   | 694,028.51 | 18735.94 | 241 | 2.237

