### PR TITLE
Suppress Javac 8 output in test

### DIFF
--- a/test/files/run/t10641.check
+++ b/test/files/run/t10641.check
@@ -1,9 +1,0 @@
-/J_0.java:2: warning: '_' used as an identifier
-    public int _() { return 42; }
-               ^
-  (use of '_' as an identifier might not be supported in releases after Java SE 8)
-/J_0.java:4: warning: '_' used as an identifier
-    public int underscore() { return _(); }
-                                     ^
-  (use of '_' as an identifier might not be supported in releases after Java SE 8)
-2 warnings

--- a/test/files/run/t10641.scala
+++ b/test/files/run/t10641.scala
@@ -38,7 +38,7 @@ class S_1 {
       //val jfile = testOutput.jfile.toPath.resolve("J_0.java").tap(Files.writeString(_, jcode, UTF_8)
       val javac = ToolProvider.getSystemJavaCompiler()
       val fm    = javac.getStandardFileManager(null, null, UTF_8)  // null diagnostics, locale
-      val opts  = List("-d", testOutput.path).asJava
+      val opts  = List("-d", testOutput.path, "-nowarn").asJava
       val uri   = URI.create("string:///J_0.java")
       val kind  = JavaFileObject.Kind.SOURCE
       val unit  = new SimpleJavaFileObject(uri, kind) { override def getCharContent(ignore: Boolean) = jcode }


### PR DESCRIPTION
Avoid test failure on jdk 9+.

The previous test tweak avoids javac failure, but suffers from check file failure.