### PR TITLE
Code cleanup: Mostly more parens

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1148,18 +1148,18 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       private val underlying = new mutable.ArrayBuffer[CompilationUnit]
       def size = synchronized { underlying.size }
       def +=(cu: CompilationUnit): this.type = { synchronized { underlying += cu }; this }
-      def head: CompilationUnit = synchronized{ underlying.head }
+      def head: CompilationUnit = synchronized { underlying.head }
       def apply(i: Int): CompilationUnit = synchronized { underlying(i) }
       def iterator: Iterator[CompilationUnit] = new collection.AbstractIterator[CompilationUnit] {
         private var used = 0
-        def hasNext = self.synchronized{ used < underlying.size }
-        def next = self.synchronized {
+        def hasNext = self.synchronized { used < underlying.size }
+        def next() = self.synchronized {
           if (!hasNext) throw new NoSuchElementException("next on empty Iterator")
           used += 1
           underlying(used-1)
         }
       }
-      def toList: List[CompilationUnit] = synchronized{ underlying.toList }
+      def toList: List[CompilationUnit] = synchronized { underlying.toList }
     }
 
     private val unitbuf = new SyncedCompilationBuffer

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -2032,13 +2032,12 @@ trait Namers extends MethodSynthesis {
   }
 
   abstract class TypeCompleter extends LazyType {
-    val tree: Tree
-    override def forceDirectSuperclasses: Unit = {
+    def tree: Tree
+    override def forceDirectSuperclasses(): Unit =
       tree.foreach {
         case dt: DefTree => global.withPropagateCyclicReferences(Option(dt.symbol).map(_.maybeInitialize))
         case _ =>
       }
-    }
   }
 
   @deprecated("Instantiate TypeCompleterBase (for monomorphic, non-wrapping completer) or CompleterWrapper directly.", "2.12.2")

--- a/src/repl-frontend/scala/tools/nsc/interpreter/jline/Reader.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/jline/Reader.scala
@@ -13,11 +13,9 @@
 package scala.tools.nsc.interpreter
 package jline
 
-
 import java.util.{List => JList}
 import org.jline.reader.{Candidate, Completer, CompletingParsedLine, EOFError, EndOfFileException, History, LineReader, ParsedLine, Parser, UserInterruptException}
 import org.jline.reader.impl.DefaultParser
-import org.jline.reader.LineReader.Option
 import org.jline.terminal.Terminal
 import shell.{Accumulator, ShellConfig}
 import Parser.ParseContext

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
@@ -57,7 +57,7 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
   def isTrace: Boolean = config.isReplTrace
 
   var printResults: Boolean = true
-  override def togglePrintResults: Unit = printResults = !printResults
+  override def togglePrintResults(): Unit = printResults = !printResults
   def withoutPrintingResults[T](body: => T): T = {
     val saved = printResults
     printResults = false
@@ -112,8 +112,8 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
   }
 
   /** String unwrapping can be disabled if it is causing issues.
-    *  Setting this to false means you will see Strings like "$iw.$iw.".
-    */
+   *  Setting this to false means you will see Strings like "\$iw.\$iw.".
+   */
   var unwrapStrings = true
   def withoutUnwrapping(op: => Unit): Unit = {
     val saved = unwrapStrings

--- a/src/scaladoc/scala/tools/nsc/ScalaDoc.scala
+++ b/src/scaladoc/scala/tools/nsc/ScalaDoc.scala
@@ -14,14 +14,13 @@ package scala.tools.nsc
 
 import scala.tools.nsc.doc.DocFactory
 import scala.tools.nsc.reporters.ConsoleReporter
-import scala.reflect.internal.Reporter
-import scala.reflect.internal.util.{ FakePos, NoPosition, Position }
+import scala.reflect.internal.util.{FakePos, Position}
 
 /** The main class for scaladoc, a front-end for the Scala compiler
  *  that generates documentation from source files.
  */
 class ScalaDoc {
-  val versionMsg = "Scaladoc %s -- %s".format(Properties.versionString, Properties.copyrightString)
+  val versionMsg = s"Scaladoc ${Properties.versionString} -- ${Properties.copyrightString}"
 
   def process(args: Array[String]): Boolean = {
     var reporter: ScalaDocReporter = null

--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -303,6 +303,7 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_),
       ("scala.reflect.api.TypeTags.WeakTypeTag" -> ((tparam: String) => tparam + " is accompanied by a WeakTypeTag, which is a runtime representation of its type that survives erasure")) +
       ("scala.reflect.api.TypeTags.TypeTag"     -> ((tparam: String) => tparam + " is accompanied by a TypeTag, which is a runtime representation of its type that survives erasure"))
 
+    /*
     private val excludedClassnamePatterns = Set(
       """^scala.Tuple.*""",
       """^scala.Product.*""",
@@ -323,6 +324,7 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_),
       "scala.runtime.AbstractFunction1",
       "scala.runtime.AbstractFunction2"
     )
+    */
 
     /** Common conversion targets that affect any class in Scala */
     val commonConversionTargets = Set(

--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -619,9 +619,9 @@ trait CommentFactoryBase { this: MemberLookupBase =>
 
       def isEndOfText = char == endOfText
 
-      def isNewline = char == endOfLine
+      //def isNewline = char == endOfLine
 
-      def skipNewline() = jump(endOfLine)
+      //def skipNewline() = jump(endOfLine)
 
       def isStartMarkNewline = check(TableCellStart + endOfLine)
 

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/IndexScript.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/IndexScript.scala
@@ -15,7 +15,6 @@ package html
 package page
 
 import scala.tools.nsc.doc
-import scala.tools.nsc.doc.model.{Package, DocTemplateEntity}
 import scala.tools.nsc.doc.html.{Page, HtmlFactory}
 
 class IndexScript(universe: doc.Universe) extends Page {

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -14,7 +14,7 @@ class IteratorTest {
 
   @Test def groupedIteratorShouldNotAskForUnneededElement(): Unit = {
     var counter = 0
-    val it = new Iterator[Int] { var i = 0 ; def hasNext = { counter = i; true } ; def next = { i += 1; i } }
+    val it = new Iterator[Int] { var i = 0 ; def hasNext = { counter = i; true } ; def next() = { i += 1; i } }
     val slidingIt = it sliding 2
     slidingIt.next
     assertEquals("Counter should be one, that means we didn't look further than needed", 1, counter)
@@ -22,16 +22,16 @@ class IteratorTest {
 
   @Test def groupedIteratorIsLazyWhenPadded(): Unit = {
     var counter = 0
-    def it = new Iterator[Int] { var i = 0 ; def hasNext = { counter = i; true } ; def next = { i += 1; i } }
+    def it = new Iterator[Int] { var i = 0 ; def hasNext = { counter = i; true } ; def next() = { i += 1; i } }
     val slidingIt = it sliding 2 withPadding -1
     slidingIt.next
     assertEquals("Counter should be one, that means we didn't look further than needed", 1, counter)
   }
 
   @Test def dropDoesNotGrowStack(): Unit = {
-    def it = new Iterator[Throwable] { def hasNext = true ; def next = new Throwable }
+    def it = new Iterator[Throwable] { def hasNext = true ; def next() = new Throwable }
 
-    assertEquals(it.drop(1).next.getStackTrace.length, it.drop(1).drop(1).next.getStackTrace.length)
+    assertEquals(it.drop(1).next().getStackTrace.length, it.drop(1).drop(1).next().getStackTrace.length)
   }
 
   @Test def dropIsChainable(): Unit = {
@@ -243,7 +243,7 @@ class IteratorTest {
     val z = x.toList
     assertEquals(1, z.size)
     assertFalse(x.hasNext)
-    assertEquals(1, y.next)
+    assertEquals(1, y.next())
     assertFalse(x.hasNext)   // was true, after advancing underlying iterator
   }
   // scala/bug#9913
@@ -258,7 +258,7 @@ class IteratorTest {
     val exp = List(1,2,3,1,2,3)
     def it: Iterator[Int] = new Iterator[Int] {
       val parent = List(1,2,3).iterator
-      def next(): Int = parent.next
+      def next(): Int = parent.next()
       def hasNext: Boolean = { counter += 1; parent.hasNext }
     }
     // Iterate separately
@@ -370,7 +370,7 @@ class IteratorTest {
 
   private def knownSizeDecreases[A](it: Iterator[A]): Unit = {
     val size = it.knownSize
-    it.next
+    it.next()
     assertEquals(size - 1, it.knownSize)
   }
 


### PR DESCRIPTION
Seeing Ichoran and IteratorTest not use parens for `next` is like seeing Ivanka travel back to NJ for Passover during lockdown.
