### PR TITLE
[backport] Set class and module symbol associated files

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -321,16 +321,8 @@ abstract class SymbolLoaders {
     protected def doComplete(root: Symbol) {
       val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(statistics.classReadNanos) else null
       classfileParser.parse(classfile, clazz, module)
-      if (root.associatedFile eq NoAbstractFile) {
-        root match {
-          // In fact, the ModuleSymbol forwards its setter to the module class
-          case _: ClassSymbol | _: ModuleSymbol =>
-            debuglog("ClassfileLoader setting %s.associatedFile = %s".format(root.name, classfile))
-            root.associatedFile = classfile
-          case _ =>
-            debuglog("Not setting associatedFile to %s because %s is a %s".format(classfile, root.name, root.shortSymbolClass))
-        }
-      }
+      if (clazz.associatedFile eq NoAbstractFile) clazz.associatedFile = classfile
+      if (module.associatedFile eq NoAbstractFile) module.associatedFile = classfile
       if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(statistics.classReadNanos, start)
     }
     override def sourcefile: Option[AbstractFile] = classfileParser.srcfile

--- a/test/junit/scala/tools/nsc/symtab/SymbolLoadersAssociatedFileTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolLoadersAssociatedFileTest.scala
@@ -1,0 +1,34 @@
+package scala.tools.nsc.symtab
+
+import org.junit.Test
+
+import scala.reflect.io.NoAbstractFile
+import scala.tools.nsc.{Global, Settings}
+
+class SymbolLoadersAssociatedFileTest {
+  @Test
+  def classSymbolAssociatedFileIsSetWhenModuleIsReferencedFirst(): Unit = {
+    val g = new Global(new Settings)
+    g.settings.usejavacp.value = true
+    g.settings.stopAfter.value = List("typer")
+    val r = new g.Run()
+    r.compileUnits(g.newCompilationUnit("class Test { identity(Tuple5) }") :: Nil, r.parserPhase)
+    val Tuple5_class = g.rootMirror.getRequiredClass("scala.Tuple5")
+    Tuple5_class.info
+    assert(Tuple5_class.associatedFile != NoAbstractFile)
+    assert(Tuple5_class.associatedFile.name == "Tuple5.class", Tuple5_class.associatedFile.name)
+  }
+
+  @Test
+  def moduleSymbolAssociatedFileIsSetWhenClassIsReferencedFirst(): Unit = {
+    val g = new Global(new Settings)
+    g.settings.usejavacp.value = true
+    g.settings.stopAfter.value = List("typer")
+    val r2 = new g.Run()
+    r2.compileUnits(g.newCompilationUnit("class Test { identity[Tuple5[Any, Any, Any, Any, Any]](null) }") :: Nil, r2.parserPhase)
+    val Tuple5_module = g.rootMirror.getRequiredModule("scala.Tuple5")
+    Tuple5_module.info
+    assert(Tuple5_module.associatedFile != NoAbstractFile)
+    assert(Tuple5_module.associatedFile.name == "Tuple5.class", Tuple5_module.associatedFile.name)
+  }
+}


### PR DESCRIPTION
Partial backport of 774ebffbd3b8af3c2390e544ebacb9f5dab3312c

The second commit contains a unit test that can be merged
to 2.13.x.

I believe that this is the root cause of bugs reported:

  https://github.com/sbt/zinc/issues/559

.. and worked around in Zinc:

  https://github.com/sbt/zinc/pull/591

I found that the workaround in Zinc was a performance
bottleneck when really large classpaths are involved, as
it has to O(N) scan through the elements of the classpaths
to find the corresponding entry for a classfile. It only
does this once per class thanks to its cache, but zero
times is the number we're after!