### PR TITLE
Fix start of local var visibility in classfiles

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -276,8 +276,8 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
           val Local(tk, _, idx, isSynth) = locals.getOrMakeLocal(sym)
           if (rhs == EmptyTree) { emitZeroOf(tk) }
           else { genLoad(rhs, tk) }
-          val localVarStart = currProgramPoint()
           bc.store(idx, tk)
+          val localVarStart = currProgramPoint()
           if (!isSynth) { // there are case <synthetic> ValDef's emitted by patmat
             varsInScope ::= (sym -> localVarStart)
           }

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -205,14 +205,14 @@ class BytecodeTest extends BytecodeTesting {
     val t = getMethod(c, "t")
     val isFrameLine = (x: Instruction) => x.isInstanceOf[FrameEntry] || x.isInstanceOf[LineNumber]
     assertSameCode(t.instructions.filterNot(isFrameLine), List(
-      Label(0), Ldc(LDC, ""), Label(3), VarOp(ASTORE, 1),
-      Label(5), VarOp(ALOAD, 1), Jump(IFNULL, Label(21)),
-      Label(10), VarOp(ALOAD, 0), Invoke(INVOKEVIRTUAL, "C", "foo", "()V", false), Label(14), Op(ACONST_NULL), VarOp(ASTORE, 1), Label(18), Jump(GOTO, Label(5)),
-      Label(21), VarOp(ALOAD, 0), Invoke(INVOKEVIRTUAL, "C", "bar", "()V", false), Label(26), Op(RETURN), Label(28)))
+      Label(0), Ldc(LDC, ""), VarOp(ASTORE, 1),
+      Label(4), VarOp(ALOAD, 1), Jump(IFNULL, Label(20)),
+      Label(9), VarOp(ALOAD, 0), Invoke(INVOKEVIRTUAL, "C", "foo", "()V", false), Label(13), Op(ACONST_NULL), VarOp(ASTORE, 1), Label(17), Jump(GOTO, Label(4)),
+      Label(20), VarOp(ALOAD, 0), Invoke(INVOKEVIRTUAL, "C", "bar", "()V", false), Label(25), Op(RETURN), Label(27)))
     val labels = t.instructions collect { case l: Label => l }
     val x = t.localVars.find(_.name == "x").get
     assertEquals(x.start, labels(1))
-    assertEquals(x.end, labels(7))
+    assertEquals(x.end, labels(6))
   }
 
   @Test

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/UnusedLocalVariablesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/UnusedLocalVariablesTest.scala
@@ -35,7 +35,7 @@ class UnusedLocalVariablesTest extends BytecodeTesting {
     assertLocalVarCount(code, 6)
 
     val code2 = """def f(a: Long): Unit = { var x = if (a == 0l) return else () }"""
-    assertLocalVarCount(code2, 3) // remains
+    assertLocalVarCount(code2, 2)
   }
 
   @Test
@@ -76,7 +76,7 @@ class UnusedLocalVariablesTest extends BytecodeTesting {
   }
 
   def assertLocalVarCount(code: String, numVars: Int): Unit = {
-    assertTrue(compileMethod(code).localVars.length == numVars)
+    assertEquals(compileMethod(code).localVars.toString, numVars, compileMethod(code).localVars.length)
   }
 
 }


### PR DESCRIPTION
Like javac, we should start _after_ the initial value is stored from the stack

[Apparently](https://youtrack.jetbrains.com/issue/SCL-17422#comment=27-4100568) this off-by-one instruction error can result in:

> I'm able to run the debugger with Java but not with Scala. As I step through simple code (stepping over line 10 of the attached file), I get "Debug info might be corrupt: Unexpected JDWP Error: 35" or "Debug information is inconsistent". This is true of both IDEA and IDEA CE, with Java 11 or Java 13.


# javac

```scala
public class JavaTest {
  public static void main(String[] args) {
    Foo foo = new Foo();
    int n = foo.doIt(42);
    assert(n == 43);
  }
}

class Foo {
  int doIt(int n) { return n + 1; }
} 
```

```
  // access flags 0x1
  public main([Ljava/lang/String;)V
    // parameter final  args
   L0
    LINENUMBER 3 L0
    NEW Foo
    DUP
    INVOKESPECIAL Foo.<init> ()V
    ASTORE 2
   L1
    LINENUMBER 4 L1
    ALOAD 2
    BIPUSH 42
    INVOKEVIRTUAL Foo.doIt (I)I
    ISTORE 3
   L2
    LINENUMBER 5 L2
    GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
    ILOAD 3
    BIPUSH 43
    IF_ICMPNE L3
    ICONST_1
    GOTO L4
   L3
   FRAME FULL [Debug$ [Ljava/lang/String; Foo I] [scala/Predef$]
    ICONST_0
   L4
   FRAME FULL [Debug$ [Ljava/lang/String; Foo I] [scala/Predef$ I]
    INVOKEVIRTUAL scala/Predef$.assert (Z)V
   L5
    RETURN
   L6
    LOCALVARIABLE foo LFoo; L1 L5 2
    LOCALVARIABLE n I L2 L5 3
    LOCALVARIABLE this LDebug$; L0 L6 0
    LOCALVARIABLE args [Ljava/lang/String; L0 L6 1
    MAXSTACK = 3
    MAXLOCALS = 4
```

# scala (before this patch)

```scala
object Debug {
  def main(args: Array[String]): Unit = {
    val foo = new Foo()
    val n = foo.doIt(42)
    assert(n == 43)
  }
}

class Foo {
  def doIt(n: Int): Int = n + 1
}
```

```
  public main([Ljava/lang/String;)V
    // parameter final  args
   L0
    LINENUMBER 3 L0
    NEW Foo
    DUP
    INVOKESPECIAL Foo.<init> ()V
   L1
    ASTORE 2
   L2
    LINENUMBER 4 L2
    ALOAD 2
    BIPUSH 42
    INVOKEVIRTUAL Foo.doIt (I)I
   L3
    ISTORE 3
   L4
    LINENUMBER 5 L4
    GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
    ILOAD 3
    BIPUSH 43
    IF_ICMPNE L5
    ICONST_1
    GOTO L6
   L5
   FRAME FULL [Debug$ [Ljava/lang/String; Foo I] [scala/Predef$]
    ICONST_0
   L6
   FRAME FULL [Debug$ [Ljava/lang/String; Foo I] [scala/Predef$ I]
    INVOKEVIRTUAL scala/Predef$.assert (Z)V
   L7
    RETURN
   L8
    LOCALVARIABLE foo LFoo; L1 L7 2
    LOCALVARIABLE n I L3 L7 3
    LOCALVARIABLE this LDebug$; L0 L8 0
    LOCALVARIABLE args [Ljava/lang/String; L0 L8 1
    MAXSTACK = 3
    MAXLOCALS = 4
```

# scala (after this patch)

`LOCALVARIABLE n` now starts _after_ the `ISTORE`.

```
 // access flags 0x1
  public main([Ljava/lang/String;)V
    // parameter final  args
   L0
    LINENUMBER 3 L0
    NEW Foo
    DUP
    INVOKESPECIAL Foo.<init> ()V
    ASTORE 2
   L1
    LINENUMBER 4 L1
    ALOAD 2
    BIPUSH 42
    INVOKEVIRTUAL Foo.doIt (I)I
    ISTORE 3
   L2
    LINENUMBER 5 L2
    GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
    ILOAD 3
    BIPUSH 43
    IF_ICMPNE L3
    ICONST_1
    GOTO L4
   L3
   FRAME FULL [Debug$ [Ljava/lang/String; Foo I] [scala/Predef$]
    ICONST_0
   L4
   FRAME FULL [Debug$ [Ljava/lang/String; Foo I] [scala/Predef$ I]
    INVOKEVIRTUAL scala/Predef$.assert (Z)V
   L5
    RETURN
   L6
    LOCALVARIABLE foo LFoo; L1 L5 2
    LOCALVARIABLE n I L2 L5 3
    LOCALVARIABLE this LDebug$; L0 L6 0
    LOCALVARIABLE args [Ljava/lang/String; L0 L6 1
    MAXSTACK = 3
    MAXLOCALS = 4
```