### PR TITLE
HashMapBuilder bug fix

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -1295,17 +1295,23 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
           var bArrayIndex = 0
           while (bBitSet != 0) {
             val rawIndex = Integer.numberOfTrailingZeros(bBitSet)
-            val aValue = result.elems(trieIndex(result, rawIndex))
+            val arrayIndex = trieIndex(result, rawIndex)
             val bValue = bTrie.elems(bArrayIndex)
-            if (aValue ne bValue) {
-              if (aValue eq null) {
-                assert (isMutable(result))
-                result.elems(rawIndex) = bValue
-              } else {
-                val resultAtIndex = addHashMap(aValue, bValue, level + 5)
-                if (resultAtIndex ne aValue) {
-                  result = makeMutable(result)
-                  result.elems(rawIndex) = resultAtIndex
+            if (arrayIndex == -1) {
+              result = makeMutable(result)
+              result.elems(rawIndex) = bValue
+            } else {
+              val aValue = result.elems(arrayIndex)
+              if (aValue ne bValue) {
+                if (aValue eq null) {
+                  assert(isMutable(result))
+                  result.elems(rawIndex) = bValue
+                } else {
+                  val resultAtIndex = addHashMap(aValue, bValue, level + 5)
+                  if (resultAtIndex ne aValue) {
+                    result = makeMutable(result)
+                    result.elems(rawIndex) = resultAtIndex
+                  }
                 }
               }
             }

--- a/test/junit/scala/collection/immutable/HashMapTest.scala
+++ b/test/junit/scala/collection/immutable/HashMapTest.scala
@@ -226,4 +226,21 @@ class HashMapTest extends AllocationTest {
     check(hm(1, 2, 3), hm(1, 2, 3, 4))
     check(hm((1 to 1000): _*), hm((2000 to 3000): _*))
   }
+  @Test
+  def mixTrie(): Unit = {
+    for (start <- 1 to 20) {
+      val m1: Map[Int, Int] = ((start + 1) to (start + 20)).map(x => x -> x).toMap
+      val m2: Map[Int, Int] = ((start + 101) to (start + 120)).map(x => x -> x).toMap
+
+      val b = HashMap.newBuilder[Int, Int]
+      b ++= m1
+      b ++= m2
+      val res = b.result()
+      assertEquals(40, res.size)
+      for (i <- (start + 1) to (start + 20)) {
+        assertEquals(Some(i), res.get(i))
+        assertEquals(Some(i + 100), res.get(i + 100))
+      }
+    }
+  }
 }

--- a/test/junit/scala/collection/immutable/HashSetTest.scala
+++ b/test/junit/scala/collection/immutable/HashSetTest.scala
@@ -244,4 +244,22 @@ class HashSetTest extends AllocationTest {
     b ++= s // was scala.MatchError: Set() (of class scala.collection.immutable.HashSet)... at ... addToTrieHashSet(HashSet.scala:1386)
     assertEquals(List(1, 2, 3, 4), b.result().toList.sorted)
   }
+
+  @Test
+  def mixTrie(): Unit = {
+    for (start <- 1 to 10) {
+      val m1: Set[Int] = ((start + 1) to (start + 20)).toSet
+      val m2: Set[Int] = ((start + 101) to (start + 120)).toSet
+
+      val b = HashSet.newBuilder[Int]
+      b ++= m1
+      b ++= m2
+      val res = b.result()
+      assertEquals(40, res.size)
+      for (i <- (start + 1) to (start + 20)) {
+        assertTrue(res.contains(i))
+        assertTrue(res.contains(i + 100))
+      }
+    }
+  }
 }


### PR DESCRIPTION
Discovered in internal (closed source) testing

Cope with a `HashMapBuilder` merging a two `HashTrieMaps`, where the builder contains an immutable compressed bitmap that doesn't contain the target bit of the first bit position to be merged