### PR TITLE
[nomerge] Fix regression in HashMapBuilder.++

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -1294,18 +1294,24 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
           var bBitSet = bTrie.bitmap
           var bArrayIndex = 0
           while (bBitSet != 0) {
-            val rawIndex = Integer.numberOfTrailingZeros(bBitSet)
-            val aValue = result.elems(trieIndex(result, rawIndex))
             val bValue = bTrie.elems(bArrayIndex)
-            if (aValue ne bValue) {
-              if (aValue eq null) {
-                assert (isMutable(result))
-                result.elems(rawIndex) = bValue
-              } else {
-                val resultAtIndex = addHashMap(aValue, bValue, level + 5)
-                if (resultAtIndex ne aValue) {
-                  result = makeMutable(result)
-                  result.elems(rawIndex) = resultAtIndex
+            val rawIndex = Integer.numberOfTrailingZeros(bBitSet)
+            val arrayIndex = trieIndex(result, rawIndex)
+            if (arrayIndex == -1) {
+              result = makeMutable(result)
+              result.elems(rawIndex) = bValue
+            } else {
+              val aValue = result.elems(arrayIndex)
+              if (aValue ne bValue) {
+                if (aValue eq null) {
+                  assert(isMutable(result))
+                  result.elems(rawIndex) = bValue
+                } else {
+                  val resultAtIndex = addHashMap(aValue, bValue, level + 5)
+                  if (resultAtIndex ne aValue) {
+                    result = makeMutable(result)
+                    result.elems(rawIndex) = resultAtIndex
+                  }
                 }
               }
             }

--- a/test/scalacheck/scala/collection/immutable/MapBuilderProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/MapBuilderProperties.scala
@@ -1,0 +1,42 @@
+package scala.collection.immutable
+
+import org.scalacheck.{Arbitrary, Gen, Properties}
+import org.scalacheck.Prop.forAll
+
+object MapBuilderProperties extends Properties("immutable.MapBuilder") {
+  case class MapPair(m1: Map[Int, Int], m2: Map[Int, Int]) {
+    lazy val s1 = m1.iterator.map(_._1).toSet
+    lazy val s2 = m2.iterator.map(_._1).toSet
+  }
+  implicit def MapPairArbitray: Arbitrary[MapPair] = Arbitrary(Arbitrary.arbitrary[IndexedSeq[Int]].flatMap { is =>
+    val all = Map(is.map(x => (x -> x)): _*)
+    val subset2 = all.filter(_._1 % 2 == 0)
+    val subset3 = all.filter(_._1 % 3 == 0)
+    val subset5 = all.filter(_._1 % 5 == 0)
+    val combinations = List(all, subset2, subset3, subset5).combinations(2).map {
+      case List(m1, m2) => MapPair(m1, m2)
+    }.toSeq
+    Gen.oneOf(combinations)
+  })
+
+  property("map bulk append exiting collection") = forAll { (mp: MapPair) =>
+    val reference = collection.mutable.Map[Int, Int]()
+    val builder = Map.newBuilder[Int, Int]
+    builder ++= mp.m1
+    builder ++= mp.m2
+    reference ++= mp.m1
+    reference ++= mp.m2
+    builder.result == reference
+  }
+
+  property("set bulk append exiting collection") = forAll { (mp: MapPair) =>
+    val reference = collection.mutable.Set[Int]()
+    val builder = Set.newBuilder[Int]
+    builder ++= mp.s1
+    builder ++= mp.s2
+    reference ++= mp.s1
+    reference ++= mp.s2
+    builder.result == reference
+  }
+}
+


### PR DESCRIPTION
Was:

```
scala> while(true) { val List(m1, m2) = List(10, 20).map(n => collection.immutable.HashMap(List.fill(n)(scala.util.Random.nextInt(10000)).map(x => (x, x)): _*)); print("."); try { val b1 = collection.immutable.HashMap.newBuilder[Int, Int]; b1 ++= m1; b1 ++= m2 } catch { case t: Throwable => println((m1, m2)); throw t}}
.(Map(8703 -> 8703, 7185 -> 7185, 9662 -> 9662, 7682 -> 7682, 8442 -> 8442, 9531 -> 9531, 3118 -> 3118, 1499 -> 1499, 7348 -> 7348, 4071 -> 4071),Map(2263 -> 2263, 4647 -> 4647, 7147 -> 7147, 7683 -> 7683, 9497 -> 9497, 9616 -> 9616, 2809 -> 2809, 2277 -> 2277, 3000 -> 3000, 1712 -> 1712, 4662 -> 4662, 9097 -> 9097, 3356 -> 3356, 876 -> 876, 1517 -> 1517, 3992 -> 3992, 4895 -> 4895, 8484 -> 8484, 4395 -> 4395, 1769 -> 1769))
java.lang.ArrayIndexOutOfBoundsException: -1
  at scala.collection.immutable.HashMap$HashMapBuilder.addToTrieHashMap(HashMap.scala:1298)
  at scala.collection.immutable.HashMap$HashMapBuilder.addHashMap(HashMap.scala:1220)
  at scala.collection.immutable.HashMap$HashMapBuilder.$plus$plus$eq(HashMap.scala:1133)
  at scala.collection.immutable.HashMap$HashMapBuilder.$plus$plus$eq(HashMap.scala:1015)
  at .liftedTree1$1(<console>:12)
  ... 28 elided

```