### PR TITLE
Temporarily reinstate global.treeTpe for compat with scala-meta

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4758,6 +4758,8 @@ trait Types
     "scala.collection.IndexedSeq",
     "scala.collection.Iterator")
 
+  @deprecated("Use _.tpe", "2.12.12") // used by scala-meta, leave until they remove the dependency.
+  private[scala] val treeTpe = (t: Tree) => t.tpe
   private[scala] val typeContainsTypeVar = { val collector = new FindTypeCollector(_.isInstanceOf[TypeVar]); (tp: Type) => collector.collect(tp).isDefined }
   private[scala] val typeIsSubTypeOfSerializable = (tp: Type) => tp <:< SerializableTpe
 


### PR DESCRIPTION
References https://github.com/scala/community-build/pull/1137