### PR TITLE
fix buggy Java version check in Scaladoc tool

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/model/MemberLookup.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/MemberLookup.scala
@@ -127,16 +127,13 @@ trait MemberLookup extends base.MemberLookupBase {
     }
   }
 
-  lazy val javaVersion: Int = {
-    var version = System.getProperty("java.version")
-    (if (version.startsWith("1.")) {
-      version.substring(2, 3)
+  lazy val javaVersion: Int =
+    System.getProperty("java.specification.version").split('.').take(2).map(_.toIntOption) match {
+      case Array(Some(1), Some(n)) => n   // example: 1.8.0_242
+      case Array(Some(n))          => n   // example: 14
+      case Array(Some(n), _)       => n   // example: 11.0.7
+      case _                       => 8   // shrug!
     }
-    else {
-      val dot = version.indexOf(".")
-      version.substring(0, dot)
-    }).toInt
-  }
 
   override def warnNoLink = !settings.docNoLinkWarnings.value
 }


### PR DESCRIPTION
this is a post-2.13.1 regression, due to #8663

the bug was that the Java version might be e.g. "14", with
no `.` character at all, causing StringIndexOutOfBoundsException

this was caught by the Scala community build