### PR TITLE
REPL: JLine 3: bring back `-Xnojline`, but deprecate it

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -119,6 +119,9 @@ trait ScalaSettings extends StandardScalaSettings with Warnings {
   val maxerrs            = IntSetting          ("-Xmaxerrs", "Maximum errors to print", 100, None, _ => None)
   val maxwarns           = IntSetting          ("-Xmaxwarns", "Maximum warnings to print", 100, None, _ => None)
   val Xmigration         = ScalaVersionSetting ("-Xmigration", "version", "Warn about constructs whose behavior may have changed since version.", initial = NoScalaVersion, default = Some(AnyScalaVersion))
+  val Xnojline           = BooleanSetting      ("-Xnojline", "Do not use JLine for editing.")
+    .withDeprecationMessage("Replaced by -Xjline:off")
+    .withPostSetHook(_ => Xjline.value = "off")
   val Xjline             = ChoiceSetting       (
     name    = "-Xjline",
     helpArg = "mode",


### PR DESCRIPTION
instead, `-Xjline:off` is now recommended

fixes https://github.com/scala/scala-dev/issues/694