### PR TITLE
Improve VectorMap.last complexity.

### DIFF
--- a/test/junit/scala/collection/immutable/VectorMapTest.scala
+++ b/test/junit/scala/collection/immutable/VectorMapTest.scala
@@ -109,4 +109,38 @@ class VectorMapTest {
     val m = VectorMap(1 -> "a", 2 -> "b", 3 -> "c", 4 -> "d", 5 -> "e").removed(1).removed(4).init
     assertEquals(List(2 -> "b", 3 -> "c"), m.toList)
   }
+
+  @Test
+  def hasCorrectHeadTailWithRemove(): Unit = {
+    val m = VectorMap(1 -> "a", 2 -> "b", 3 -> "c", 4 -> "d", 5 -> "e")
+    assertEquals(2 -> "b", m.removed(1).head)
+    assertEquals(3 -> "c", m.removed(1).removed(2).head)
+    assertEquals(3 -> "c", m.removed(2).removed(1).head)
+    assertEquals(List(3 -> "c", 4 -> "d", 5 -> "e"), m.removed(1).tail.toList)
+    assertEquals(List(3 -> "c", 4 -> "d", 5 -> "e"), m.removed(2).tail.toList)
+    assertEquals(List(4 -> "d", 5 -> "e"), m.removed(1).removed(2).tail.toList)
+    assertEquals(List(4 -> "d", 5 -> "e"), m.removed(2).removed(1).tail.toList)
+    assertEquals(List(4 -> "d", 5 -> "e"), m.removed(3).removed(2).tail.toList)
+    assertEquals(List(4 -> "d", 5 -> "e"), m.removed(2).removed(3).tail.toList)
+  }
+  @Test
+  def hasCorrectLastInitWithRemove(): Unit = {
+    val m = VectorMap(1 -> "a", 2 -> "b", 3 -> "c", 4 -> "d", 5 -> "e")
+    assertEquals(4 -> "d", m.removed(5).last)
+    assertEquals(3 -> "c", m.removed(5).removed(4).last)
+    assertEquals(3 -> "c", m.removed(4).removed(5).last)
+    assertEquals(6 -> "f", m.removed(5).updated(6, "f").last)
+    assertEquals(3 -> "c", m.removed(4).removed(5).updated(6, "f").removed(6).last)
+    assertEquals(3 -> "c", m.removed(5).removed(4).updated(6, "f").removed(6).last)
+    assertEquals(List(1 -> "a", 2 -> "b", 3 -> "c"), m.removed(5).init.toList)
+    assertEquals(List(1 -> "a", 2 -> "b", 3 -> "c"), m.removed(4).init.toList)
+    assertEquals(List(1 -> "a", 2 -> "b"), m.removed(5).removed(4).init.toList)
+    assertEquals(List(1 -> "a", 2 -> "b"), m.removed(4).removed(5).init.toList)
+    assertEquals(List(1 -> "a", 2 -> "b"), m.removed(3).removed(4).init.toList)
+    assertEquals(List(1 -> "a", 2 -> "b"), m.removed(4).removed(3).init.toList)
+    assertEquals(List(1 -> "a", 2 -> "b", 3 -> "c", 4 -> "d"), m.removed(5).updated(6, "f").init.toList)
+    assertEquals(List(1 -> "a", 2 -> "b", 3 -> "c"), m.removed(5).updated(6, "f").removed(6).init.toList)
+    assertEquals(List(1 -> "a", 2 -> "b"), m.removed(4).removed(5).updated(6, "f").removed(6).init.toList)
+    assertEquals(List(1 -> "a", 2 -> "b"), m.removed(5).removed(4).updated(6, "f").removed(6).init.toList)
+  }
 }

--- a/test/scalacheck/scala/collection/immutable/VectorMapProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/VectorMapProperties.scala
@@ -4,6 +4,10 @@ import org.scalacheck._
 import Arbitrary.arbitrary
 import Prop._
 import Gen._
+import commands.Commands
+
+import scala.util.Try
+
 
 object VectorMapProperties extends Properties("immutable.VectorMap") {
 
@@ -65,4 +69,78 @@ object VectorMapProperties extends Properties("immutable.VectorMap") {
     }
   }
 
+  property("vectorMap.last == vectorMap.toList.last, after some operations") = {
+    //After vectorMap.updated(key, value), removed(key), tail, and init, verify if vectorMap.last == vectorMap.toList.last is satisfied.
+    object VectorMapCommandsChecker extends Commands {
+      //Perform the same operation on both maps and keep them in the same state.
+      override type State = SeqMap[K, V]
+      override type Sut = VectorMap[K, V]
+
+      override def canCreateNewSut(newState: SeqMap[K, V], initSuts: scala.Iterable[SeqMap[K, V]], runningSuts: scala.Iterable[VectorMap[K, V]]): Boolean = true
+      override def destroySut(sut: VectorMap[K, V]): Unit = ()
+      override def newSut(state: SeqMap[K, V]): VectorMap[K, V] = VectorMap.from(state)
+      override def initialPreCondition(state: SeqMap[K, V]): Boolean = true
+      override def genInitialState: Gen[SeqMap[K, V]] = implicitly[Arbitrary[Map[K, V]]].arbitrary.map(m => SeqMap.from(m))
+      override def genCommand(state: State): Gen[VectorMapCommandsChecker.Command] = {
+        if (state.isEmpty) {
+          append(state)
+        }else {
+          Gen.oneOf(removeRandom(state), updateRandom(state), append(state), tail(state), init(state))
+        }
+      }
+
+      def removeRandom(vm: State): Gen[Remove] = Gen.delay{
+        val random = new scala.util.Random()
+        const(Remove(random.shuffle(vm.keysIterator).next()))
+      }
+      def updateRandom(vm: State): Gen[Update] = Gen.delay{
+        val random = new scala.util.Random()
+        val key = random.shuffle(vm.keysIterator).next()
+        const(Update(key, key))
+      }
+      def append(state: State): Gen[Update] = Gen.delay {
+        if (state.isEmpty) const(Update(1, 1))
+        else {
+          val max = state.maxBy(_._1)
+          const(Update(max._1 + 1, max._1 + 1))
+        }
+      }
+      def tail(state: State): Gen[Tail.type] = {
+        const(Tail)
+      }
+      def init(state: State): Gen[Init.type ] = {
+        const(Init)
+      }
+
+      case class Remove(key: K) extends Command {
+        override type Result = Sut
+        override def run(sut: VectorMap[K, V]): VectorMap[K, V] = sut.removed(key)
+        override def nextState(state: State): State = state.removed(key)
+        override def preCondition(state: State): Boolean = true
+        override def postCondition(state: State, result: Try[VectorMap[K, V]]): Prop = result.map(_.lastOption) == result.map(_.toList.lastOption)
+      }
+      case class Update(key: K, value: V) extends Command {
+        override type Result = Sut
+        override def run(sut: VectorMap[K, V]): VectorMap[K, V] = sut.updated(key, value)
+        override def nextState(state: State): State = state.updated(key, value)
+        override def preCondition(state: State): Boolean = true
+        override def postCondition(state: State, result: Try[VectorMap[K, V]]): Prop = result.map(_.last) == result.map(_.toList.last)
+      }
+      case object Tail extends Command {
+        override type Result = Sut
+        override def run(sut: VectorMap[K, V]): VectorMap[K, V] = sut.tail
+        override def nextState(state: State): State = state.tail
+        override def preCondition(state: State): Boolean = true
+        override def postCondition(state: State, result: Try[VectorMap[K, V]]): Prop = result.map(_.lastOption) == result.map(_.toList.lastOption)
+      }
+      case object Init extends Command {
+        override type Result = Sut
+        override def run(sut: VectorMap[K, V]): VectorMap[K, V] = sut.init
+        override def nextState(state: State): State = state.init
+        override def preCondition(state: State): Boolean = true
+        override def postCondition(state: State, result: Try[VectorMap[K, V]]): Prop = result.map(_.lastOption) == result.map(_.toList.lastOption)
+      }
+    }
+    VectorMapCommandsChecker.property()
+  }
 }


### PR DESCRIPTION
Previously changed some behavior of VectorMap to improve it. See also #8854.
This PR will improve `VectorMap.last` complexity that is possible with it.

In the current code, It iterate Vector's reverse iterator to find the last key, but
The new code will directly find the key that the last Tombstone indicates.

This avoids the worst-case O(`fields.length`) complexity.