### PR TITLE
Use cache of implicit pt function arity more often

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -407,8 +407,8 @@ trait Implicits {
       val dealiased = tp.dealiasWiden
       if (isFunctionTypeDirect(dealiased)) dealiased.typeArgs.length - 1 else -1
     }
-    private val cachedPtFunctionArity: Int = functionArityOf(pt)
-    final def functionArity(tp: Type): Int = if (tp eq pt) cachedPtFunctionArity else functionArityOf(tp)
+    private[this] val cachedPtFunctionArity: Int = functionArityOf(pt)
+    final def functionArity(tp: Type): Int = if ((tp eq pt) || (tp eq wildPt)) cachedPtFunctionArity else functionArityOf(tp)
 
     private val stableRunDefsForImport = currentRun.runDefinitions
     import stableRunDefsForImport._


### PR DESCRIPTION
In the `isPlausiblyCompatible` pass, implicit search uses the
approximate expected type (with undetermined type params replace
by wildcards.) This has the same function arity as the pt proper,
so let's use the cached value!