### PR TITLE
[MORIBUND] Deprecate naming arg to println

### DIFF
--- a/src/library/scala/Console.scala
+++ b/src/library/scala/Console.scala
@@ -12,7 +12,8 @@
 
 package scala
 
-import java.io.{ BufferedReader, InputStream, InputStreamReader, OutputStream, PrintStream, Reader }
+import java.io.{BufferedReader, InputStream, InputStreamReader, OutputStream, PrintStream, Reader}
+
 import scala.io.AnsiColor
 import scala.util.DynamicVariable
 
@@ -160,8 +161,7 @@ object Console extends AnsiColor {
    *  @see `withOut[T](out:OutputStream)(thunk: => T)`
    *  @group io-redefinition
    */
-  def withOut[T](out: PrintStream)(thunk: => T): T =
-    outVar.withValue(out)(thunk)
+  def withOut[T](out: PrintStream)(thunk: => T): T = outVar.withValue(out)(thunk)
 
   /** Sets the default output stream for the duration
    *  of execution of one thunk.
@@ -173,8 +173,7 @@ object Console extends AnsiColor {
    *  @see `withOut[T](out:PrintStream)(thunk: => T)`
    *  @group io-redefinition
    */
-  def withOut[T](out: OutputStream)(thunk: => T): T =
-    withOut(new PrintStream(out))(thunk)
+  def withOut[T](out: OutputStream)(thunk: => T): T = withOut(new PrintStream(out))(thunk)
 
   /** Set the default error stream for the duration
    *  of execution of one thunk.
@@ -189,8 +188,7 @@ object Console extends AnsiColor {
    *  @see `withErr[T](err:OutputStream)(thunk: => T)`
    *  @group io-redefinition
    */
-  def withErr[T](err: PrintStream)(thunk: => T): T =
-    errVar.withValue(err)(thunk)
+  def withErr[T](err: PrintStream)(thunk: => T): T = errVar.withValue(err)(thunk)
 
   /** Sets the default error stream for the duration
    *  of execution of one thunk.
@@ -202,8 +200,7 @@ object Console extends AnsiColor {
    *  @see `withErr[T](err:PrintStream)(thunk: => T)`
    *  @group io-redefinition
    */
-  def withErr[T](err: OutputStream)(thunk: => T): T =
-    withErr(new PrintStream(err))(thunk)
+  def withErr[T](err: OutputStream)(thunk: => T): T = withErr(new PrintStream(err))(thunk)
 
   /** Sets the default input stream for the duration
    *  of execution of one thunk.
@@ -223,8 +220,7 @@ object Console extends AnsiColor {
    *  @see `withIn[T](in:InputStream)(thunk: => T)`
    *  @group io-redefinition
    */
-  def withIn[T](reader: Reader)(thunk: => T): T =
-    inVar.withValue(new BufferedReader(reader))(thunk)
+  def withIn[T](reader: Reader)(thunk: => T): T = inVar.withValue(new BufferedReader(reader))(thunk)
 
   /** Sets the default input stream for the duration
    *  of execution of one thunk.
@@ -236,36 +232,33 @@ object Console extends AnsiColor {
    *  @see `withIn[T](reader:Reader)(thunk: => T)`
    *  @group io-redefinition
    */
-  def withIn[T](in: InputStream)(thunk: => T): T =
-    withIn(new InputStreamReader(in))(thunk)
+  def withIn[T](in: InputStream)(thunk: => T): T = withIn(new InputStreamReader(in))(thunk)
 
   /** Prints an object to `out` using its `toString` method.
    *
    *  @param obj the object to print; may be null.
    *  @group console-output
    */
-  def print(obj: Any): Unit = {
-    out.print(if (null == obj) "null" else obj.toString())
-  }
+  def print(@deprecatedName("obj") obj: Any): Unit = out.print(obj)
 
   /** Flushes the output stream. This function is required when partial
    *  output (i.e. output not terminated by a newline character) has
    *  to be made visible on the terminal.
     * @group console-output
    */
-  def flush(): Unit = { out.flush() }
+  def flush(): Unit = out.flush()
 
   /** Prints a newline character on the default output.
     * @group console-output
    */
-  def println(): Unit = { out.println() }
+  def println(): Unit = out.println()
 
   /** Prints out an object to the default output, followed by a newline character.
    *
    *  @param x the object to print.
    *  @group console-output
    */
-  def println(x: Any): Unit = { out.println(x) }
+  def println(@deprecatedName("x") x: Any): Unit = out.println(x)
 
   /** Prints its arguments as a formatted string to the default output,
    *  based on a string pattern (in a fashion similar to printf in C).
@@ -277,5 +270,5 @@ object Console extends AnsiColor {
    *  @throws java.lang.IllegalArgumentException if there was a problem with the format string or arguments
    *  @group console-output
    */
-  def printf(text: String, args: Any*): Unit = { out.print(text.format(args: _*)) }
+  def printf(text: String, args: Any*): Unit = out.print(text.format(args: _*))
 }

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -412,7 +412,7 @@ object Predef extends LowPriorityImplicits {
    *  @param x the object to print; may be null.
    *  @group console-output
    */
-  def print(x: Any): Unit = Console.print(x)
+  def print(@deprecatedName("x") x: Any): Unit = Console.print(x)
 
   /** Prints a newline character on the default output.
    *  @group console-output
@@ -424,7 +424,7 @@ object Predef extends LowPriorityImplicits {
    *  @param x the object to print.
    *  @group console-output
    */
-  def println(x: Any): Unit = Console.println(x)
+  def println(@deprecatedName("x") x: Any): Unit = Console.println(x)
 
   /** Prints its arguments as a formatted string to the default output,
    *  based on a string pattern (in a fashion similar to printf in C).
@@ -435,13 +435,13 @@ object Predef extends LowPriorityImplicits {
    *  Consider using the [[scala.StringContext.f f interpolator]] as more type safe and idiomatic.
    *
    *  @param text the pattern for formatting the arguments.
-   *  @param xs   the arguments used to instantiate the pattern.
+   *  @param args the arguments used to instantiate the pattern.
    *  @throws java.lang.IllegalArgumentException if there was a problem with the format string or arguments
    *
    *  @see [[scala.StringContext.f StringContext.f]]
    *  @group console-output
    */
-  def printf(text: String, xs: Any*): Unit = Console.print(text.format(xs: _*))
+  def printf(text: String, @deprecatedName("xs") args: Any*): Unit = Console.print(text.format(args: _*))
 
   // views --------------------------------------------------------------
 


### PR DESCRIPTION
As for `locally`, avoid a confusing error such as:

```
{ var x = 0 ; println(x = 1) ; x }
```
A deprecation at least warns.

Do the same for `Console.println` and also align
the parameter names for `printf`. It is deemed
reasonable to use named args to name `args`:
```
printf(text="hello, %s", args=Seq(name): _*)
```

This just came up on stack overflow.

Also `Console.print` can just forward to `out.print` which has the required behavior.