### PR TITLE
Optimize flag lookup in findMember

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -761,9 +761,14 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     }
 
     final def flags: Long = {
-      val fs = _rawflags & phase.flagMask
+      flags(phase.flagMask)
+    }
+
+    private[reflect] final def flags(phaseFlagMask: Long): Long = {
+      val fs = _rawflags & phaseFlagMask
       (fs | ((fs & LateFlags) >>> LateShift)) & ~((fs & AntiFlags) >>> AntiShift)
     }
+
     def flags_=(fs: Long) = _rawflags = fs
     def rawflags_=(x: Long) { _rawflags = x }
 

--- a/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
@@ -101,13 +101,20 @@ trait FindMembers {
 
       val findAll = name == nme.ANYname
 
+      val phaseFlagMask = phase.flagMask
+      val fastFlags = (phaseFlagMask & ~InitialFlags) == 0
+
       while (!bcs.isEmpty) {
         val currentBaseClass = bcs.head
         val decls = currentBaseClass.info.decls
         var entry = if (findAll) decls.elems else decls.lookupEntry(name)
         while (entry ne null) {
           val sym = entry.sym
-          val flags = sym.flags
+          val flags =
+            if (fastFlags)
+              sym.rawflags & phaseFlagMask
+            else
+              sym.flags(phaseFlagMask)
           val meetsRequirements = (flags & required) == required
           if (meetsRequirements) {
             val excl: Long = flags & excluded


### PR DESCRIPTION
Hoist the lookup of the phase's flag mask and avoid bit twiddling when the
current phase mask excludes anti/late flags.