### PR TITLE
Fix 2.13.2-only false positives in `-Woctal-literal`

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -1150,7 +1150,7 @@ trait Scanners extends ScannersCommon {
           syntaxError("missing integer number") // e.g., 0x; previous error shadows this one
           0L
         } else {
-          if (settings.warnOctalLiteral && strVal.charAt(0) == '0')
+          if (settings.warnOctalLiteral && base == 10 && strVal.charAt(0) == '0' && strVal.length() > 1)
             deprecationWarning("Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)", since="2.10")
           convertIt
         }

--- a/test/files/neg/literals.scala
+++ b/test/files/neg/literals.scala
@@ -1,4 +1,4 @@
-// scalac: -Ywarn-octal-literal -Xfatal-warnings -deprecation
+// scalac: -Woctal-literal -Werror -deprecation
 trait RejectedLiterals {
 
   def missingHex: Int    = { 0x }        // line 4: was: not reported, taken as zero
@@ -50,4 +50,9 @@ trait Lengthy {
   def bad = 1l
 
   def worse = 123l
+}
+
+trait Regressions {
+  def oopsy = 0         // nowarn
+  def hexed = 0x0F      // nowarn
 }


### PR DESCRIPTION
Removing base 8 handling broke the test for "leading zero" for `-Woctal-literal`, which
should only flag base 10 literals with a leading zero that are not exactly one zero.

Fixes scala/bug#11950

Regressed at https://github.com/scala/scala/commit/1af6048eebdfa82a588b6da908cce659e230edad