### PR TITLE
Optimise fold{Left,Right} in IndexedSeqs

### DIFF
--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -25,6 +25,28 @@ trait IndexedSeq[+A] extends Seq[A]
   override protected[this] def stringPrefix: String = "IndexedSeq"
 
   override def iterableFactory: SeqFactory[IndexedSeq] = IndexedSeq
+
+  override def foldLeft[B](z: B)(f: (B, A) => B): B = {
+    var b = z
+    var i = 0
+    while (i < length) {
+      val a = apply(i)
+      i += 1
+      b = f(b, a)
+    }
+    b
+  }
+
+  override def foldRight[B](z: B)(f: (A, B) => B): B = {
+    var b = z
+    var i = length
+    while (i > 0) {
+      i -= 1
+      val a = apply(i)
+      b = f(a, b)
+    }
+    b
+  }
 }
 
 @SerialVersionUID(3L)


### PR DESCRIPTION
* foldLeft is slightly faster in that it uses a while-loop and avoids
  allocation of an iterator.

* foldRight is much faster in that it uses a while-loop rather than
  calling reverse.foldLeft.
