### PR TITLE
[nomerge] Avoid some Some allocations in HashMaps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -431,7 +431,12 @@ val mimaFilterSettings = Seq {
 
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.ReflectSetup.phaseWithId"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.ReflectSetup.scala$reflect$runtime$ReflectSetup$_setter_$phaseWithId_="),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.ReflectSetup.phaseWithId")
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.ReflectSetup.phaseWithId"),
+
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap.getOrElse0"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashTrieMap.getOrElse0"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashMap1.getOrElse0"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashMapCollision1.getOrElse0"),
   )
 }
 

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -71,6 +71,13 @@ class LinkedHashMap[A, B] extends AbstractMap[A, B]
     else Some(e.value)
   }
 
+  override def contains(key: A): Boolean = {
+    if (getClass eq classOf[LinkedHashMap[_, _]])
+      findEntry(key) != null
+    else
+      super.contains(key) // A subclass might override `get`, use the default implementation `contains`.
+  }
+
   override def put(key: A, value: B): Option[B] = {
     val e = findOrAddEntry(key, value)
     if (e eq null) None


### PR DESCRIPTION
Override `immutable.HashMap.getOrElse` and
`mutable.LinkedHashMap.contains` to avoid internally allocating
a `Some`.