### PR TITLE
Reduce allocations when loading packages from classpath

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPath.scala
@@ -52,22 +52,24 @@ trait PackageEntry {
 }
 
 private[nsc] case class ClassFileEntryImpl(file: AbstractFile) extends ClassFileEntry {
-  override val name = FileUtils.stripClassExtension(file.name) // class name
+  override final def fileName: String = file.name
+  override lazy val name = FileUtils.stripClassExtension(file.name) // class name
 
   override def binary: Option[AbstractFile] = Some(file)
   override def source: Option[AbstractFile] = None
 }
 
 private[nsc] case class SourceFileEntryImpl(file: AbstractFile) extends SourceFileEntry {
-  override val name = FileUtils.stripSourceExtension(file.name)
+  override final def fileName: String = file.name
+  override lazy val name = FileUtils.stripSourceExtension(file.name)
 
   override def binary: Option[AbstractFile] = None
   override def source: Option[AbstractFile] = Some(file)
 }
 
 private[nsc] case class ClassAndSourceFilesEntry(classFile: AbstractFile, srcFile: AbstractFile) extends ClassRepresentation {
-  override val name = FileUtils.stripClassExtension(classFile.name)
-
+  override final def fileName: String = classFile.name
+  override lazy val name = FileUtils.stripClassExtension(fileName)
   override def binary: Option[AbstractFile] = Some(classFile)
   override def source: Option[AbstractFile] = Some(srcFile)
 }

--- a/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/BrowsingLoaders.scala
@@ -124,7 +124,7 @@ abstract class BrowsingLoaders extends GlobalSymbolLoaders {
 
   /** Enter top-level symbols from a source file
    */
-  override def enterToplevelsFromSource(root: Symbol, name: String, src: AbstractFile) {
+  override def enterToplevelsFromSource(root: Symbol, name: TermName, src: AbstractFile) {
     try {
       if (root.isEffectiveRoot || !src.name.endsWith(".scala")) // RootClass or EmptyPackageClass
         super.enterToplevelsFromSource(root, name, src)

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -202,7 +202,19 @@ object ClassPath {
 }
 
 trait ClassRepresentation {
+  def fileName: String
   def name: String
+  /** Low level way to extract the entry name without allocation. */
+  final def nameChars(buffer: Array[Char]): Int = {
+    val ix = fileName.lastIndexOf('.')
+    val nameLength = if (ix < 0) fileName.length else ix
+    if (nameLength > buffer.length)
+      -1
+    else {
+      fileName.getChars(0, fileName.lastIndexOf('.'), buffer, 0)
+      nameLength
+    }
+  }
   def binary: Option[AbstractFile]
   def source: Option[AbstractFile]
 }


### PR DESCRIPTION
Avoid the need to sub-string "Foo.class" to strip the extension
and the need to allocate temporary character array when converting
"Foo" to a Name.