### PR TITLE
Reduce allocation in unexpandedName

### DIFF
--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -433,16 +433,19 @@ trait StdNames {
      *  part of the string after that; but if the string is "$$$" or longer,
      *  be sure to retain the extra dollars.
      */
-    def unexpandedName(name: Name): Name = name lastIndexOf "$$" match {
-      case 0 | -1 => name
-      case idx0   =>
-        // Sketchville - We've found $$ but if it's part of $$$ or $$$$
-        // or something we need to keep the bonus dollars, so e.g. foo$$$outer
-        // has an original name of $outer.
-        var idx = idx0
-        while (idx > 0 && name.charAt(idx - 1) == '$')
-          idx -= 1
-        name drop idx + 2
+    def unexpandedName(name: Name): Name = {
+      if (!name.containsChar('$')) name // lastIndexOf calls Name.toString, add a fast path to avoid that.
+      else name lastIndexOf "$$" match {
+        case 0 | -1 => name
+        case idx0   =>
+          // Sketchville - We've found $$ but if it's part of $$$ or $$$$
+          // or something we need to keep the bonus dollars, so e.g. foo$$$outer
+          // has an original name of $outer.
+          var idx = idx0
+          while (idx > 0 && name.charAt(idx - 1) == '$')
+            idx -= 1
+          name drop idx + 2
+      }
     }
 
     @deprecated("use unexpandedName", "2.11.0") def originalName(name: Name): Name            = unexpandedName(name)


### PR DESCRIPTION
This ic called often by ExtractAPI in Zinc:

```
  private def simpleName(s: Symbol): String = {
    val n = s.unexpandedName
    val n2 = if (n == nme.CONSTRUCTOR) constructorNameAsString(s.enclClass) else n.decode.toString
    n2.trim
  }
```