### PR TITLE
`Symbol#toString` is now `Symbol(foo)` instead of the deprecated single-quote form `'foo`

### DIFF
--- a/src/library/scala/Symbol.scala
+++ b/src/library/scala/Symbol.scala
@@ -24,7 +24,7 @@ package scala
 final class Symbol private (val name: String) extends Serializable {
   /** Converts this symbol to a string.
    */
-  override def toString(): String = "'" + name
+  override def toString(): String = "Symbol(" + name + ")"
 
   @throws(classOf[java.io.ObjectStreamException])
   private def readResolve(): Any = Symbol.apply(name)

--- a/test/files/jvm/manifests-new.check
+++ b/test/files/jvm/manifests-new.check
@@ -4,13 +4,13 @@ x=true, t=TypeTag[Boolean], k=TypeRef, s=class Boolean
 x=a, t=TypeTag[Char], k=TypeRef, s=class Char
 x=1, t=TypeTag[Int], k=TypeRef, s=class Int
 x=abc, t=TypeTag[String], k=TypeRef, s=class String
-x='abc, t=TypeTag[Symbol], k=TypeRef, s=class Symbol
+x=Symbol(abc), t=TypeTag[Symbol], k=TypeRef, s=class Symbol
 
 x=List(()), t=TypeTag[List[Unit]], k=TypeRef, s=class List
 x=List(true), t=TypeTag[List[Boolean]], k=TypeRef, s=class List
 x=List(1), t=TypeTag[List[Int]], k=TypeRef, s=class List
 x=List(abc), t=TypeTag[List[String]], k=TypeRef, s=class List
-x=List('abc), t=TypeTag[List[Symbol]], k=TypeRef, s=class List
+x=List(Symbol(abc)), t=TypeTag[List[Symbol]], k=TypeRef, s=class List
 
 x=[Z, t=TypeTag[Array[Boolean]], k=TypeRef, s=class Array
 x=[C, t=TypeTag[Array[Char]], k=TypeRef, s=class Array
@@ -22,7 +22,7 @@ x=((),()), t=TypeTag[(Unit, Unit)], k=TypeRef, s=class Tuple2
 x=(true,false), t=TypeTag[(Boolean, Boolean)], k=TypeRef, s=class Tuple2
 x=(1,2), t=TypeTag[(Int, Int)], k=TypeRef, s=class Tuple2
 x=(abc,xyz), t=TypeTag[(String, String)], k=TypeRef, s=class Tuple2
-x=('abc,'xyz), t=TypeTag[(Symbol, Symbol)], k=TypeRef, s=class Tuple2
+x=(Symbol(abc),Symbol(xyz)), t=TypeTag[(Symbol, Symbol)], k=TypeRef, s=class Tuple2
 
 x=Test$, t=TypeTag[Test.type], k=SingleType, s=object Test
 x=scala.collection.immutable.List$, t=TypeTag[scala.collection.immutable.List.type], k=SingleType, s=object List
@@ -39,11 +39,11 @@ x=Test1$$anon$2, t=TypeTag[Bar[String]], k=RefinedType, s=<refinement of Bar[Str
 true=true
 a=a
 1=1
-'abc='abc
+'abc=Symbol(abc)
 
 List(())=List(())
 List(true)=List(true)
-List('abc)=List('abc)
+List('abc)=List(Symbol(abc))
 
 Array()=Array()
 Array(true)=Array(true)

--- a/test/files/jvm/manifests-old.check
+++ b/test/files/jvm/manifests-old.check
@@ -4,13 +4,13 @@ x=true, m=Boolean
 x=a, m=Char
 x=1, m=Int
 x=abc, m=java.lang.String
-x='abc, m=scala.Symbol
+x=Symbol(abc), m=scala.Symbol
 
 x=List(()), m=scala.collection.immutable.List[Unit]
 x=List(true), m=scala.collection.immutable.List[Boolean]
 x=List(1), m=scala.collection.immutable.List[Int]
 x=List(abc), m=scala.collection.immutable.List[java.lang.String]
-x=List('abc), m=scala.collection.immutable.List[scala.Symbol]
+x=List(Symbol(abc)), m=scala.collection.immutable.List[scala.Symbol]
 
 x=[Z, m=Array[Boolean]
 x=[C, m=Array[Char]
@@ -22,7 +22,7 @@ x=((),()), m=scala.Tuple2[Unit, Unit]
 x=(true,false), m=scala.Tuple2[Boolean, Boolean]
 x=(1,2), m=scala.Tuple2[Int, Int]
 x=(abc,xyz), m=scala.Tuple2[java.lang.String, java.lang.String]
-x=('abc,'xyz), m=scala.Tuple2[scala.Symbol, scala.Symbol]
+x=(Symbol(abc),Symbol(xyz)), m=scala.Tuple2[scala.Symbol, scala.Symbol]
 
 
 x=Foo, m=Foo[Int]
@@ -36,11 +36,11 @@ x=Test1$$anon$1, m=Object with Bar[java.lang.String]
 true=true
 a=a
 1=1
-'abc='abc
+'abc=Symbol(abc)
 
 List(())=List(())
 List(true)=List(true)
-List('abc)=List('abc)
+List('abc)=List(Symbol(abc))
 
 Array()=Array()
 Array(true)=Array(true)

--- a/test/files/jvm/serialization-new.check
+++ b/test/files/jvm/serialization-new.check
@@ -55,8 +55,8 @@ _o2 = Some(1)
 o2 eq _o2: false, _o2 eq o2: false
 o2 equals _o2: true, _o2 equals o2: true
 
-s1 = 'hello
-_s1 = 'hello
+s1 = Symbol(hello)
+_s1 = Symbol(hello)
 s1 eq _s1: true, _s1 eq s1: true
 s1 equals _s1: true, _s1 equals s1: true
 
@@ -125,8 +125,8 @@ x = TreeSet(0, 2)
 y = TreeSet(0, 2)
 x equals y: true, y equals x: true
 
-x = Vector('a, 'b, 'c)
-y = Vector('a, 'b, 'c)
+x = Vector(Symbol(a), Symbol(b), Symbol(c))
+y = Vector(Symbol(a), Symbol(b), Symbol(c))
 x equals y: true, y equals x: true
 
 x = ArrayBuffer(one, two)

--- a/test/files/jvm/serialization.check
+++ b/test/files/jvm/serialization.check
@@ -55,8 +55,8 @@ _o2 = Some(1)
 o2 eq _o2: false, _o2 eq o2: false
 o2 equals _o2: true, _o2 equals o2: true
 
-s1 = 'hello
-_s1 = 'hello
+s1 = Symbol(hello)
+_s1 = Symbol(hello)
 s1 eq _s1: true, _s1 eq s1: true
 s1 equals _s1: true, _s1 equals s1: true
 
@@ -125,8 +125,8 @@ x = TreeSet(0, 2)
 y = TreeSet(0, 2)
 x equals y: true, y equals x: true
 
-x = Vector('a, 'b, 'c)
-y = Vector('a, 'b, 'c)
+x = Vector(Symbol(a), Symbol(b), Symbol(c))
+y = Vector(Symbol(a), Symbol(b), Symbol(c))
 x equals y: true, y equals x: true
 
 x = ArrayBuffer(one, two)

--- a/test/files/run/SymbolsTest.scala
+++ b/test/files/run/SymbolsTest.scala
@@ -164,7 +164,7 @@ object Test {
     }
     assert(nested.sign == Symbol("sign"))
     assert(nested.insignia == Symbol("insignia"))
-    assert((Symbol("insignia")).toString == "'insignia")
+    assert((Symbol("insignia")).toString == "Symbol(insignia)")
   }
 
   def testInheritance: Unit = {
@@ -187,7 +187,7 @@ object Test {
     assert(nested.objsymbol == Symbol("symobj"))
     assert(nested.subsymbol == Symbol("symsub"))
     assert(nested.basesymbol == Symbol("symbase"))
-    assert((Symbol("symbase")).toString == "'symbase")
+    assert((Symbol("symbase")).toString == "Symbol(symbase)")
   }
 
   def testTraits: Unit = {
@@ -198,7 +198,7 @@ object Test {
     assert(fromTrait.traitsymbol == Symbol("traitSymbol"))
     assert(fromTrait.ind == Symbol("indication"))
     assert(fromTrait.trace == Symbol("trace"))
-    assert((Symbol("trace")).toString == "'trace")
+    assert((Symbol("trace")).toString == "Symbol(trace)")
 
     trait Compl {
       val s1 = Symbol("s1")
@@ -237,7 +237,7 @@ object Test {
     assert(Local.s2 == Symbol("s2"))
     assert(Local.trace == Symbol("trace"))
     assert(Local.ind == Symbol("indication"))
-    assert((Symbol("s8")).toString == "'s8")
+    assert((Symbol("s8")).toString == "Symbol(s8)")
   }
 
   def testLazyTraits: Unit = {
@@ -248,7 +248,7 @@ object Test {
     l1.v1
     l2.v2
     l3.v3
-    assert((l1.s1).toString == "'lazySymbol1")
+    assert((l1.s1).toString == "Symbol(lazySymbol1)")
     assert(l2.s2 == Symbol("lazySymbol" + 2))
     assert(l3.s3 == Symbol("lazySymbol3"))
   }
@@ -256,7 +256,7 @@ object Test {
   def testLazyObjects: Unit = {
     assert(SingletonOfLazyness.lazysym == Symbol("lazySymbol"))
     assert(SingletonOfLazyness.another == Symbol("ano" + "ther"))
-    assert((SingletonOfLazyness.lastone).toString == "'lastone")
+    assert((SingletonOfLazyness.lastone).toString == "Symbol(lastone)")
 
     object nested {
       lazy val sym1 = Symbol("snested1")

--- a/test/files/run/lisp.check
+++ b/test/files/run/lisp.check
@@ -11,7 +11,7 @@ faculty(10) = 3628800
 faculty(10) = 3628800
 foobar = ("a" "bc" "def" "z")
 
-List('lambda, List('x), List('+, List('*, 'x, 'x), 1))
+List(Symbol(lambda), List(Symbol(x)), List(Symbol(+), List(Symbol(*), Symbol(x), Symbol(x)), 1))
 (lambda (x) (+ (* x x) 1))
 
 (    '(1 2 3)) = (1 2 3)

--- a/test/files/run/t4560.check
+++ b/test/files/run/t4560.check
@@ -1,7 +1,7 @@
 warning: 3 deprecations (since 2.13.0); re-run with -deprecation for details
-'Test
+Symbol(Test)
 Success 1
-'Test
+Symbol(Test)
 Success 2
-'Test
+Symbol(Test)
 Success 3

--- a/test/files/run/t4601.check
+++ b/test/files/run/t4601.check
@@ -1,2 +1,2 @@
 warning: 1 deprecation (since 2.13.0); re-run with -deprecation for details
-'blubber
+Symbol(blubber)

--- a/test/files/run/t6549.check
+++ b/test/files/run/t6549.check
@@ -4,7 +4,7 @@ class X$u0022
 
 scala> val m = Map(("": Any) -> `X"`("\""), ('s: Any) -> `X"`("\""))
 warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
-val m: scala.collection.immutable.Map[Any,X"] = Map("" -> X"("), 's -> X"("))
+val m: scala.collection.immutable.Map[Any,X"] = Map("" -> X"("), Symbol(s) -> X"("))
 
 scala> m("")
 val res0: X" = X"(")

--- a/test/files/run/t6633.scala
+++ b/test/files/run/t6633.scala
@@ -20,7 +20,7 @@ object Test extends App {
   }
 
   val replStr = scala.runtime.ScalaRunTime.replStringOf(lb1, 100)
-  if (replStr == "ListBuffer('a, 'b, 'c, 'd, 'e)\n")
+  if (replStr == "ListBuffer(Symbol(a), Symbol(b), Symbol(c), Symbol(d), Symbol(e))\n")
     println("replStringOf OK")
   else
     println("replStringOf FAILED: " + replStr)

--- a/test/files/run/t6634.scala
+++ b/test/files/run/t6634.scala
@@ -66,7 +66,7 @@ object Test extends App {
   // buffer should neither be changed nor corrupted after calling remove with invalid arguments
   def checkNotCorrupted(
     lb: ListBuffer[Symbol],
-    expectedString: String = "ListBuffer('a, 'b, 'c, 'd, 'e)",
+    expectedString: String = "ListBuffer(Symbol(a), Symbol(b), Symbol(c), Symbol(d), Symbol(e))",
     expectedLength: Int = 5) = {
     println("Checking ...")
     val replStr = scala.runtime.ScalaRunTime.replStringOf(lb, 100)

--- a/test/files/run/t8933.check
+++ b/test/files/run/t8933.check
@@ -1,1 +1,1 @@
-'traitSymbol
+Symbol(traitSymbol)

--- a/test/junit/scala/lang/stringinterpol/StringContextTest.scala
+++ b/test/junit/scala/lang/stringinterpol/StringContextTest.scala
@@ -173,7 +173,7 @@ class StringContextTest {
       f"${s}%S"     -> "SCALA",
       f"${5}"       -> "5",
       f"${i}"       -> "42",
-      f"${'foo}"    -> "'foo",
+      f"${'foo}"    -> "Symbol(foo)",
 
       f"${Thread.State.NEW}" -> "NEW",
 


### PR DESCRIPTION
Before:

```scala
scala 2.13.2> Symbol("foo")
val res0: Symbol = 'foo
```

After:

```scala
scala 2.13.3> Symbol("foo")
val res0: Symbol = Symbol(foo)
```

Fixes https://github.com/scala/bug/issues/11943