### PR TITLE
Avoid Tuple Allocation in groupBy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -440,6 +440,8 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashTrieMap.getOrElse0"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashMap1.getOrElse0"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashMapCollision1.getOrElse0"),
+
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.EfficientMapBuilder")
   )
 }
 

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -464,7 +464,7 @@ trait TraversableLike[+A, +Repr] extends Any
     val it = m.entriesIterator
     while (it.hasNext) {
       val entry = it.next()
-      b += ((entry.key, entry.value.result()))
+      b.asInstanceOf[mutable.EfficientMapBuilder[K, Repr]].addOne(entry.key, entry.value.result(), null)
     }
 
     b.result()

--- a/src/library/scala/collection/mutable/EfficientMapBuilder.scala
+++ b/src/library/scala/collection/mutable/EfficientMapBuilder.scala
@@ -1,0 +1,17 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+package scala.collection.mutable
+
+private[collection] trait EfficientMapBuilder[K, V] extends ((K, V, (K, V)) => Unit) {
+  final def apply(k: K, v: V, kvOrNull: (K, V)): Unit = addOne(k, v, kvOrNull)
+  private[collection] def addOne(k: K, v: V, kvOrNull: (K, V)): Unit
+}


### PR DESCRIPTION
Iterate the entry set of the mutable map without tuples and avoid the need for tuples for each entry when building the immutable Map result.