### PR TITLE
Reduce allocation cost of dead code elimination

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
@@ -105,7 +105,7 @@ abstract class ClosureOptimizer {
         val ownerClass = closureInitsBeforeDCE.head._2.ownerClass.internalName
 
         // Advanced ProdCons queries (initialProducersForValueAt) expect no unreachable code.
-        localOpt.minimalRemoveUnreachableCode(method, ownerClass)
+        localOpt.minimalRemoveUnreachableCode(method)
 
         if (AsmAnalyzer.sizeOKForSourceValue(method)) closureInstantiations.get(method) match {
           case Some(closureInits) =>

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -392,7 +392,7 @@ abstract class Inliner {
     //   def g = f; println() // println is unreachable after inlining f
     // If we have an inline request for a call to g, and f has been already inlined into g, we
     // need to run DCE on g's body before inlining g.
-    localOpt.minimalRemoveUnreachableCode(callee, calleeDeclarationClass.internalName)
+    localOpt.minimalRemoveUnreachableCode(callee)
 
     // If the callsite was eliminated by DCE, do nothing.
     if (!callGraph.containsCallsite(callsite)) return

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/UnreachableCodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/UnreachableCodeTest.scala
@@ -24,7 +24,7 @@ class UnreachableCodeTest extends ClearAfterClass {
 
   def assertEliminateDead(code: (Instruction, Boolean)*): Unit = {
     val method = genMethod()(code.map(_._1): _*)
-    dceCompiler.global.genBCode.postProcessor.localOpt.removeUnreachableCodeImpl(method, "C")
+    dceCompiler.global.genBCode.postProcessor.localOpt.removeUnreachableCodeImpl(method)
     val nonEliminated = instructionsFromMethod(method)
     val expectedLive = code.filter(_._2).map(_._1).toList
     assertSameCode(nonEliminated, expectedLive)


### PR DESCRIPTION
Re-implement dead code elimination without relying on ASM's Analyzer.
Analyzers are allocation-heavy, as they allocate an array of abstract
values (a `Frame`) for every instruction in the method being analyzed.

DCE performance is important because it's enabled by default, unlike the
rest of the optimizer. The reason for that is getting cleaner bytecode.
The ASM ClassWriter doesn't eliminate dead code on the fly, but replaces
it by `throw null; nop; ...; nop;` to avoid re-allocating code array and
adjusting the offsets.

DCE now uses an abstract interpretation very similar to the existing
code in `BackendUtils.computeMaxLocalsMaxStack`. I decided to copy-paste
and adapt the implementation instead of trying to abstract over the
differences, in the interest of performance.

The new DCE implementation no longer computes the maxLocals / maxStack.
This could be done, but with the rest of the optimizer disabled these
are actually not needed. The values are needed to run an ASM Analyzer
for other optimizations, in which case they are computed when necessary.

So this PR replaces DCE by the new implementation, and it also skips the
invocation of `computeMaxLocalsMaxStack` that was previously necessary
in order to run the Analyzer.

Finally, I added a note about the interpretation of JSR/RET in
`computeMaxLocalsMaxStack` (and the new DCE), but note that they are
no longer in use since Java 7.