### PR TITLE
Deprecate varargs -= in Shrinkable

### DIFF
--- a/src/library/scala/collection/mutable/Growable.scala
+++ b/src/library/scala/collection/mutable/Growable.scala
@@ -48,7 +48,7 @@ trait Growable[-A] extends Clearable {
    *  @param elems the remaining elements to $add.
    *  @return the $coll itself
    */
-  @deprecated("Use `++=` (addAll) instead of varargs `+=`", "2.13.0")
+  @deprecated("Use `++=` aka `addAll` instead of varargs `+=`; infix operations with an operand of multiple args will be deprecated", "2.13.0")
   @`inline` final def += (elem1: A, elem2: A, elems: A*): this.type = this += elem1 += elem2 ++= (elems: IterableOnce[A])
 
   /** ${Add}s all elements produced by an IterableOnce to this $coll.

--- a/src/library/scala/collection/mutable/Shrinkable.scala
+++ b/src/library/scala/collection/mutable/Shrinkable.scala
@@ -40,6 +40,7 @@ trait Shrinkable[-A] {
     *  @param elems the remaining elements to remove.
     *  @return the $coll itself
     */
+  @deprecated("Use `--=` aka `subtractAll` instead of varargs `-=`; infix operations with an operand of multiple args will be deprecated", "2.13.3")
   def -= (elem1: A, elem2: A, elems: A*): this.type = {
     this -= elem1
     this -= elem2


### PR DESCRIPTION
Follow-up to https://github.com/scala/scala/pull/6719