### PR TITLE
Under `-Xsource:3`, warn when eta-expanding SAMs

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -967,7 +967,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               doEtaZero
             } else sourceLevel3 || expectingFunctionOfArity || expectingSamOfArity
 
-          if (doIt && !expectingFunctionOfArity && settings.warnEtaSam) warnEtaSam()
+          if (doIt && !expectingFunctionOfArity && (currentRun.isScala3 || settings.warnEtaSam)) warnEtaSam()
 
           doIt
         }

--- a/test/files/neg/t7187-3.scala
+++ b/test/files/neg/t7187-3.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3 -Xlint:eta-zero -Xlint:eta-sam
+// scalac: -Xsource:3 -Xlint:eta-zero
 //
 trait AcciSamZero { def apply(): Int }
 

--- a/test/files/neg/t7187-deprecation.check
+++ b/test/files/neg/t7187-deprecation.check
@@ -6,6 +6,11 @@ t7187-deprecation.scala:17: error: type mismatch;
 t7187-deprecation.scala:31: error: Methods without a parameter list and by-name params can not be converted to functions as `m _`, write a function literal `() => m` instead
   val t7 = m1 _ // error: eta-expanding a nullary method
            ^
+t7187-deprecation.scala:19: warning: Eta-expansion performed to meet expected type AcciSamZero, which is SAM-equivalent to () => Int,
+even though trait AcciSamZero is not annotated with `@FunctionalInterface`;
+to suppress warning, add the annotation or write out the equivalent function literal.
+  val t2AcciSam: AcciSamZero = m2   // warn, eta-expanded to non @FunctionalInterface SAM
+                               ^
 t7187-deprecation.scala:24: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method m2,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
 In Scala 3, an unapplied method like this will be eta-expanded into a function.
@@ -16,5 +21,5 @@ or remove the empty argument list from its definition (Java-defined methods are 
 In Scala 3, an unapplied method like this will be eta-expanded into a function.
   a.boom // warning: apply, ()-insertion
     ^
-2 warnings
+3 warnings
 2 errors

--- a/test/files/neg/t7187-deprecation.scala
+++ b/test/files/neg/t7187-deprecation.scala
@@ -16,7 +16,7 @@ class EtaExpand214 {
 
   val t1: () => Any  = m1   // error
   val t2: () => Any  = m2   // eta-expanded, only warns w/ -Xlint:eta-zero
-  val t2AcciSam: AcciSamZero = m2   // eta-expanded, only warns w/ -Xlint:eta-zero or -Xlint:eta-sam
+  val t2AcciSam: AcciSamZero = m2   // warn, eta-expanded to non @FunctionalInterface SAM
   val t2Sam: SamZero = m2   // eta-expanded, only warns w/ -Xlint:eta-zero
   val t3: Int => Any = m3   // ok
 


### PR DESCRIPTION
Dotty emits the following:

    -- Warning: target/tests/EtaX/EtaX.meth1/EtaX.meth1/EtaX.meth1.01.scala:10:24 --
    10 |  val t5b: Sam1S      = meth1                   // ok, but warning
       |                        ^^^^^
       |method meth1 is eta-expanded even though Sam1S does not have the @FunctionalInterface annotation.
    1 warning found

(given the following source:)

    trait Sam1S { def apply(x: Any): Any }

    class Test {
      def meth1(x: Any) = ""
      val t5b: Sam1S      = meth1                   // ok, but warning
    }

So it makes sense for Scala 2.13 to do the same, under `-Xsource:3`.

Now it actually also emits in Dotty under `-source 3.0-migration` (which used to be called `-language:Scala2Compat`), so there's an argument that it should be on by default in 2.13...  But let's do `-Xsource:3` at the very least.