### PR TITLE
Improve warning that parameter is Unit-specialized

### DIFF
--- a/test/files/neg/t5507.check
+++ b/test/files/neg/t5507.check
@@ -1,4 +1,4 @@
-t5507.scala:5: warning: Fruitless specialization of Unit in parameter position. Consider using `@specialized(Specializable.Arg)` instead.
+t5507.scala:5: warning: Class parameter is specialized for type Unit. Consider using `@specialized(Specializable.Arg)` instead.
 final class C[@specialized A, @specialized B](a: A, b: B)
                                              ^
 error: No warnings can be incurred under -Werror.


### PR DESCRIPTION
Detect the condition when generating forwarders
for constructors. Previously, it was done at class
specialization, which happens at use sites.

Fixes scala/bug#11965