### PR TITLE
un-deprecate default floating point `Equiv`s

### DIFF
--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -40,7 +40,7 @@ trait LowPriorityEquiv {
   self: Equiv.type =>
 
   /**
-   * @deprecated since 2.13.0. This implicit universal `Equiv` instance allows accidentally
+   * @deprecated This implicit universal `Equiv` instance allows accidentally
    * comparing instances of types for which equality isn't well-defined or implemented.
    * (For example, it does not make sense to compare two `Function1` instances.)
    *
@@ -48,9 +48,9 @@ trait LowPriorityEquiv {
    * despite the potential problems, consider `implicit def universalEquiv[T]: Equiv[T] = universal[T]`.
    */
   @deprecated("Use explicit Equiv.universal instead. See Scaladoc entry for more information: " +
-    "https://www.scala-lang.org/api/2.13.0/scala/math/Equiv$.html#universalEquiv[T]:scala.math.Equiv[T]",
+    "https://www.scala-lang.org/api/current/scala/math/Equiv$.html#universalEquiv[T]:scala.math.Equiv[T]",
     since = "2.13.0")
-  implicit def universalEquiv[T] : Equiv[T] = universal[T]
+  implicit def universalEquiv[T]: Equiv[T] = universal[T]
 }
 
 object Equiv extends LowPriorityEquiv {
@@ -125,11 +125,11 @@ object Equiv extends LowPriorityEquiv {
   implicit object Short extends Equiv[Short] {
     def equiv(x: Short, y: Short): Boolean = x == y
   }
-  
+
   implicit object Int extends Equiv[Int] {
     def equiv(x: Int, y: Int): Boolean = x == y
   }
-  
+
   implicit object Long extends Equiv[Long] {
     def equiv(x: Long, y: Long): Boolean = x == y
   }
@@ -147,7 +147,7 @@ object Equiv extends LowPriorityEquiv {
   object Float {
     /** An equivalence for `Float`s which is reflexive (treats all `NaN`s
       * as equivalent), and treats `-0.0` and `0.0` as not equivalent; it
-      * behaves the same as [[java.lang.Float#compare]].
+      * behaves the same as [[java.lang.Float.compare]].
       *
       * $floatEquiv
       *
@@ -173,6 +173,7 @@ object Equiv extends LowPriorityEquiv {
     }
     implicit object IeeeEquiv extends IeeeEquiv
   }
+
   @deprecated("There are multiple equivalences for Floats (Equiv.Float.TotalEquiv, " +
     "Equiv.Float.IeeeEquiv). Specify one by using a local import, assigning an implicit val, or passing it " +
     "explicitly. See the documentation for details.", since = "2.13.0")
@@ -191,7 +192,7 @@ object Equiv extends LowPriorityEquiv {
   object Double {
     /** An equivalence for `Double`s which is reflexive (treats all `NaN`s
       * as equivalent), and treats `-0.0` and `0.0` as not equivalent; it
-      * behaves the same as [[java.lang.Double#compare]].
+      * behaves the same as [[java.lang.Double.compare]].
       *
       * $doubleEquiv
       *

--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -14,6 +14,7 @@ package scala
 package math
 
 import java.util.Comparator
+import scala.annotation.migration
 
 /** A trait for representing equivalence relations.  It is important to
  *  distinguish between a type that can be compared for equality or
@@ -174,9 +175,11 @@ object Equiv extends LowPriorityEquiv {
     implicit object IeeeEquiv extends IeeeEquiv
   }
 
-  @deprecated("There are multiple equivalences for Floats (Equiv.Float.TotalEquiv, " +
-    "Equiv.Float.IeeeEquiv). Specify one by using a local import, assigning an implicit val, or passing it " +
-    "explicitly. See the documentation for details.", since = "2.13.0")
+  @migration(
+    "  The default implicit equivalence for floats no longer conforms to\n" +
+    "  to IEEE 754's behavior for -0.0F and NaN.\n" +
+    "  Import `Equiv.Float.IeeeEquiv` to recover the previous behavior.\n" +
+    "  See also https://www.scala-lang.org/api/current/scala/math/Equiv$$Float$.html.", "2.13.2")
   implicit object DeprecatedFloatEquiv extends Float.StrictEquiv
 
   /** `Equiv`s for `Double`s.
@@ -186,7 +189,7 @@ object Equiv extends LowPriorityEquiv {
     *                     relation for `NaN` (it is not reflexive), there are two
     *                     equivalences defined for `Double`: `StrictEquiv`, which
     *                     is reflexive, and `IeeeEquiv`, which is consistent
-    *                     with IEEE spec and doubleing point operations defined in
+    *                     with IEEE spec and floating point operations defined in
     *                     [[scala.math]].
     */
   object Double {
@@ -218,9 +221,11 @@ object Equiv extends LowPriorityEquiv {
     }
     implicit object IeeeEquiv extends IeeeEquiv
   }
-  @deprecated("There are multiple equivalences for Doubles (Equiv.Double.TotalEquiv, " +
-    "Equiv.Double.IeeeEquiv). Specify one by using a local import, assigning an implicit val, or passing it " +
-    "explicitly. See the documentation for details.", since = "2.13.0")
+  @migration(
+    "  The default implicit equivalence for doubles no longer conforms to\n" +
+    "  to IEEE 754's behavior for -0.0D and NaN.\n" +
+    "  Import `Equiv.Double.IeeeEquiv` to recover the previous behavior.\n" +
+    "  See also https://www.scala-lang.org/api/current/scala/math/Equiv$$Double$.html.", "2.13.2")
   implicit object DeprecatedDoubleEquiv extends Double.StrictEquiv
 
   implicit object BigInt extends Equiv[BigInt] {

--- a/test/files/neg/equiv-migration.check
+++ b/test/files/neg/equiv-migration.check
@@ -1,0 +1,17 @@
+equiv-migration.scala:3: warning: object DeprecatedFloatEquiv in object Equiv has changed semantics in version 2.13.2:
+  The default implicit equivalence for floats no longer conforms to
+  to IEEE 754's behavior for -0.0F and NaN.
+  Import `Equiv.Float.IeeeEquiv` to recover the previous behavior.
+  See also https://www.scala-lang.org/api/current/scala/math/Equiv$$Float$.html.
+  val f = Equiv[Float]
+               ^
+equiv-migration.scala:4: warning: object DeprecatedDoubleEquiv in object Equiv has changed semantics in version 2.13.2:
+  The default implicit equivalence for doubles no longer conforms to
+  to IEEE 754's behavior for -0.0D and NaN.
+  Import `Equiv.Double.IeeeEquiv` to recover the previous behavior.
+  See also https://www.scala-lang.org/api/current/scala/math/Equiv$$Double$.html.
+  val d = Equiv[Double]
+               ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/equiv-migration.scala
+++ b/test/files/neg/equiv-migration.scala
@@ -1,0 +1,12 @@
+// scalac: -Xmigration -Werror
+object Test {
+  val f = Equiv[Float]
+  val d = Equiv[Double]
+
+  // In our similar test for `Ordering`, we check that the migration warning is produced
+  // when e.g. calling `sorted` on a list.  I wanted to add something like that here,
+  // but I couldn't find anywhere where `Equiv` is actually used, except by
+  // `scala.collection.concurrent.TrieMap`, but that class defaults to using
+  // the (deprecated) `Equiv.universal`, so you don't run into the migration warning
+  // normally.
+}


### PR DESCRIPTION
but give a migration warning, since the default is now the strict one rather than the IEEE one

we should have done this when we did the same for `Ordering`; it was just an oversight

context: scala/bug#11844