### PR TITLE
[nomerge] Reduce allocations in groupBy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -492,6 +492,7 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.Settings.async"),
 
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.Internals#InternalApi.markForAsyncTransform"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.HashMap.entriesIterator0"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive.RootEntry"),
   )
 }

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -20,6 +20,7 @@ import scala.annotation.unchecked.{uncheckedVariance => uV}
 import parallel.ParIterable
 import scala.collection.immutable.{::, List, Nil}
 import scala.language.higherKinds
+import scala.runtime.AbstractFunction0
 
 /** A template trait for traversable collections of type `Traversable[A]`.
  *
@@ -451,23 +452,77 @@ trait TraversableLike[+A, +Repr] extends Any
   }
 
   def groupBy[K](f: A => K): immutable.Map[K, Repr] = {
-    object m extends mutable.HashMap[K, Builder[A, Repr]] {
-      override def entriesIterator: Iterator[mutable.DefaultEntry[K, Builder[A, Repr]]] =
-        super.entriesIterator
+    object grouper extends AbstractFunction0[Builder[A, Repr]] with Function1[A, Unit] {
+      var k0, k1, k2, k3: K = null.asInstanceOf[K]
+      var v0, v1, v2, v3    = (null : Builder[A, Repr])
+      var size              = 0
+      var hashMap: mutable.HashMap[K, Builder[A, Repr]] = null
+      override def apply(): mutable.Builder[A, Repr] = {
+        size += 1
+        newBuilder
+      }
+      def apply(elem: A): Unit = {
+        val key  = f(elem)
+        val bldr = builderFor(key)
+        bldr += elem
+      }
+      def builderFor(key: K): Builder[A, Repr] =
+        size match {
+          case 0 =>
+            k0 = key
+            v0 = apply()
+            v0
+          case 1 =>
+            if (k0 == key) v0
+            else {k1 = key; v1 = apply(); v1 }
+          case 2 =>
+            if (k0 == key) v0
+            else if (k1 == key) v1
+            else {k2 = key; v2 = apply(); v2 }
+          case 3 =>
+            if (k0 == key) v0
+            else if (k1 == key) v1
+            else if (k2 == key) v2
+            else {k3 = key; v3 = apply(); v3 }
+          case 4 =>
+            if (k0 == key) v0
+            else if (k1 == key) v1
+            else if (k2 == key) v2
+            else if (k3 == key) v3
+            else {
+              hashMap = new mutable.HashMap
+              hashMap += ((k0, v0))
+              hashMap += ((k1, v1))
+              hashMap += ((k2, v2))
+              hashMap += ((k3, v3))
+              val bldr = apply()
+              hashMap(key) = bldr
+              bldr
+            }
+          case _ =>
+            hashMap.getOrElseUpdate(key, apply())
+        }
+
+      def result(): immutable.Map[K, Repr] =
+        size match {
+          case 0 => immutable.Map.empty
+          case 1 => new immutable.Map.Map1(k0, v0.result())
+          case 2 => new immutable.Map.Map2(k0, v0.result(), k1, v1.result())
+          case 3 => new immutable.Map.Map3(k0, v0.result(), k1, v1.result(), k2, v2.result())
+          case 4 => new immutable.Map.Map4(k0, v0.result(), k1, v1.result(), k2, v2.result(), k3, v3.result())
+          case _ =>
+            val it = hashMap.entriesIterator0
+            val m1 = immutable.HashMap.newBuilder[K, Repr]
+            while (it.hasNext) {
+              val entry = it.next()
+              m1.+=((entry.key, entry.value.result()))
+            }
+            m1.result()
+        }
+
     }
-    val newBuilderFunction = () => newBuilder
-    for (elem <- this.seq) {
-      val key  = f(elem)
-      val bldr = m.getOrElseUpdate(key, newBuilderFunction())
-      bldr += elem
-    }
-    val it = m.entriesIterator
-    val m1 = if (m.size > 4) immutable.HashMap.newBuilder[K, Repr] else immutable.Map.newBuilder[K, Repr]
-    while (it.hasNext) {
-      val entry = it.next()
-      m1.+=((entry.key, entry.value.result()))
-    }
-    m1.result()
+    this.seq.foreach(grouper)
+    grouper.result()
   }
 
   def forall(p: A => Boolean): Boolean = {

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -172,6 +172,8 @@ extends AbstractMap[A, B]
     def next()  = iter.next().value
   }
 
+  private[collection] def entriesIterator0: Iterator[DefaultEntry[A, B]] = entriesIterator
+
   /** Toggles whether a size map is used to track hash map statistics.
    */
   def useSizeMap(t: Boolean) = if (t) {

--- a/src/partest/scala/tools/partest/StubErrorMessageTest.scala
+++ b/src/partest/scala/tools/partest/StubErrorMessageTest.scala
@@ -51,7 +51,7 @@ trait StubErrorMessageTest extends StoreReporterDirectTest {
     if (extraUserCode == "") compileCode(userCode)
     else compileCode(userCode, extraUserCode)
     import scala.reflect.internal.util.Position
-    filteredInfos.map { report =>
+    filteredInfos.sortBy(_.pos.point).foreach { report =>
       print(if (report.severity == storeReporter.ERROR) "error: " else "")
       println(Position.formatMessage(report.pos, report.msg, true))
     }

--- a/test/benchmarks/src/main/scala/scala/collection/GroupByBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/GroupByBenchmark.scala
@@ -1,0 +1,73 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection
+
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Fork, Level, Measurement, Mode, OutputTimeUnit, Param, Scope, Setup, State, Threads, Warmup}
+import org.openjdk.jmh.infra.Blackhole
+import scala.collection.mutable.ArrayBuffer
+
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class GroupByBenchmark {
+  @Param(Array("128", "512", "2048", "8192"))
+  var size        : Int = _
+
+  @Param(Array("0", "32"))
+  var hashCodeCost: Int = _
+
+  @Param(Array("8", "2147483647"))
+  var maxNumGroups: Int = _
+
+  private case class Key(a: Int) {
+    override def hashCode(): Int = {
+      Blackhole.consumeCPU(hashCodeCost)
+      Integer.hashCode(a)
+    }
+  }
+
+  private case class Groupable(a: Int) {
+    val key = new Key(a % maxNumGroups)
+  }
+
+  private var groupables: ArrayBuffer[Groupable] = _
+
+  private class GroupByWrapper[A](as: collection.Iterable[A]) extends collection.Iterable[A] {
+    override def iterator: Iterator[A] = as.iterator
+    override protected def newBuilder = new mutable.Builder[A, Iterable[A]] {
+      override def clear(): Unit = ()
+      override def result(): Iterable[A] = Nil
+      override def +=(elem: A): this.type = this
+    }
+  }
+
+  @Setup(Level.Trial) def setup(): Unit = {
+    groupables = ArrayBuffer.tabulate(size)(Groupable(_))
+  }
+
+  @Benchmark def buildArrayBuffer(): AnyRef = {
+    groupBy(groupables)
+  }
+  @Benchmark def buildNil(): AnyRef = {
+    groupBy(new GroupByWrapper[Groupable](groupables))
+  }
+
+  private def groupBy[B](as: collection.Iterable[Groupable]) = as.groupBy(_.key)
+}

--- a/test/files/run/StubErrorReturnTypePolyFunction.check
+++ b/test/files/run/StubErrorReturnTypePolyFunction.check
@@ -1,9 +1,9 @@
+error: newSource1.scala:13: type arguments [stuberrors.D] do not conform to method foo's type parameter bounds [T <: stuberrors.A]
+      b.foo[D]
+           ^
 error: newSource1.scala:13: Symbol 'type stuberrors.A' is missing from the classpath.
 This symbol is required by 'class stuberrors.D'.
 Make sure that type A is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
 A full rebuild may help if 'D.class' was compiled against an incompatible version of stuberrors.
       b.foo[D]
             ^
-error: newSource1.scala:13: type arguments [stuberrors.D] do not conform to method foo's type parameter bounds [T <: stuberrors.A]
-      b.foo[D]
-           ^

--- a/test/files/run/StubErrorTypeDef.check
+++ b/test/files/run/StubErrorTypeDef.check
@@ -1,13 +1,13 @@
-error: newSource1.scala:4: overriding type D in class B with bounds <: stuberrors.A;
- type D has incompatible type
-      new B { type D = E }
-                   ^
 error: newSource1.scala:4: Symbol 'type stuberrors.A' is missing from the classpath.
 This symbol is required by 'type stuberrors.B.D'.
 Make sure that type A is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
 A full rebuild may help if 'B.class' was compiled against an incompatible version of stuberrors.
       new B { type D = E }
       ^
+error: newSource1.scala:4: overriding type D in class B with bounds <: stuberrors.A;
+ type D has incompatible type
+      new B { type D = E }
+                   ^
 error: newSource1.scala:4: Symbol 'type stuberrors.A' is missing from the classpath.
 This symbol is required by 'class stuberrors.E'.
 Make sure that type A is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.


### PR DESCRIPTION
  - Avoid lambda allocation in getOrElseUpdate call
  - Avoid intermediate Tuple2 instances when iterating through
    the mutable map.
  - Avoid allocating Map1-4 during building the result if
    the size of the grouped exceeds 4. Intead build a HashMap
    directly.

```
./benchdb list --limit 2 && ./benchdb results --run 5 --run 6 --pivot size  && ./benchdb results --run 5 --run 6 --pivot size --metric "·gc.alloc.rate.norm"
┏━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
┃ ID ┃ Timestamp           ┃ Msg              ┃
┣━━━━╋━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━┫
┃  6 ┃ 2020-08-24 07:14:36 ┃ PR 8948          ┃
┃  5 ┃ 2020-08-24 07:06:47 ┃ PR 8948 Baseline ┃
┗━━━━┻━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━┛
2 test runs found (limit reached).
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━┓
┃                                                (size) ┃                ┃                ┃      ┃     ┃        128         ┃         512         ┃         2048          ┃         8192          ┃       ┃
┃ Benchmark                                             ┃ (hashCodeCost) ┃ (maxNumGroups) ┃ Mode ┃ Cnt ┃    Score ┃   Error ┃     Score ┃   Error ┃      Score ┃    Error ┃      Score ┃    Error ┃ Units ┃
┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━╋━━━━━━╋━━━━━╋━━━━━━━━━━╋━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━╋━━━━━━━━━━━━╋━━━━━━━━━━╋━━━━━━━━━━━━╋━━━━━━━━━━╋━━━━━━━┫
┃ #5:scala.collection.GroupByBenchmark.buildArrayBuffer ┃             32 ┃              8 ┃ avgt ┃  30 ┃ 8631.963 ┃ 116.790 ┃ 30969.939 ┃ 456.711 ┃ 119820.013 ┃ 1741.671 ┃ 480813.306 ┃ 7268.723 ┃ ns/op ┃
┃ #6:scala.collection.GroupByBenchmark.buildArrayBuffer ┃             32 ┃              8 ┃ avgt ┃  30 ┃ 8287.717 ┃ 135.038 ┃ 30672.551 ┃ 540.409 ┃ 119356.530 ┃ 1592.624 ┃ 477570.346 ┃ 6365.010 ┃ ns/op ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━┻━━━━━┻━━━━━━━━━━┻━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━━━━┻━━━━━━━┛
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━┳━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━┓
┃                                                (size) ┃                ┃                ┃      ┃     ┃       128        ┃        512        ┃        2048        ┃        8192        ┃       ┃
┃ Benchmark [·gc.alloc.rate.norm]                       ┃ (hashCodeCost) ┃ (maxNumGroups) ┃ Mode ┃ Cnt ┃    Score ┃ Error ┃     Score ┃ Error ┃     Score ┃  Error ┃      Score ┃ Error ┃ Units ┃
┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━╋━━━━━━╋━━━━━╋━━━━━━━━━━╋━━━━━━━╋━━━━━━━━━━━╋━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━╋━━━━━━━╋━━━━━━━┫
┃ #5:scala.collection.GroupByBenchmark.buildArrayBuffer ┃             32 ┃              8 ┃ avgt ┃  30 ┃ 2192.014 ┃ 0.022 ┃ 13712.051 ┃ 0.076 ┃ 50949.533 ┃ 56.381 ┃ 198544.803 ┃ 1.213 ┃ B/op  ┃
┃ #6:scala.collection.GroupByBenchmark.buildArrayBuffer ┃             32 ┃              8 ┃ avgt ┃  30 ┃ 1896.014 ┃ 0.021 ┃  5224.051 ┃ 0.077 ┃ 17768.204 ┃  0.305 ┃  67176.786 ┃ 1.180 ┃ B/op  ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━┻━━━━━━┻━━━━━┻━━━━━━━━━━┻━━━━━━━┻━━━━━━━━━━━┻━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━┻━━━━━━━┻━━━━━━━┛
```



2.12.x appropriate version of of #8947