### PR TITLE
Improve Name.lastIndexOf

### DIFF
--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -413,11 +413,28 @@ trait Names extends api.Names {
       false
     }
 
+    def lastIndexOf(s: String): Int = {
+      if (s.isEmpty()) return length
+
+      val last = s(s.length - 1)
+      var i = length
+      while (s.length() <= i) {
+        if (_chrs(start + i - 1) == last) {
+          var j = 2
+          while (j <= s.length() && _chrs(start + i - j) == s.charAt(s.length() - j))
+            j += 1
+          if (j > s.length()) return i - s.length()
+        }
+        i -= 1
+      }
+      return -1
+    }
+
     /** Some thoroughly self-explanatory convenience functions.  They
      *  assume that what they're being asked to do is known to be valid.
      */
-    final def startChar: Char                   = this charAt 0
-    final def endChar: Char                     = this charAt len - 1
+    final def startChar: Char                   = charAt(0)
+    final def endChar: Char                     = charAt(len - 1)
     final def startsWith(char: Char): Boolean   = len > 0 && startChar == char
     final def startsWith(name: String): Boolean = startsWith(name, 0)
     final def endsWith(char: Char): Boolean     = len > 0 && endChar == char
@@ -434,7 +451,6 @@ trait Names extends api.Names {
 
     /** The lastPos methods already return -1 on failure. */
     def lastIndexOf(ch: Char): Int  = lastPos(ch)
-    def lastIndexOf(s: String): Int = toString lastIndexOf s
 
     /** Replace all occurrences of `from` by `to` in
      *  name; result is always a term name.

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -14,7 +14,6 @@ package scala
 package reflect
 package internal
 
-import scala.annotation.tailrec
 import scala.io.Codec
 
 trait Names extends api.Names {
@@ -421,11 +420,10 @@ trait Names extends api.Names {
       val contents  = _chrs
       val base      = start
       val min       = base + lastIndex
+      var end       = base + length - 1
 
-      @tailrec
-      def scan(end: Int): Int =
-        if (end < min) -1
-        else if (contents(end) == lastChar) {
+      while (end >= min) {
+        if (contents(end) == lastChar) {
           var i  = end - 1
           val i0 = i - lastIndex
           var at = lastIndex - 1
@@ -433,11 +431,11 @@ trait Names extends api.Names {
             i -= 1
             at -= 1
           }
-          if (i > i0) scan(end - 1) else i0 + 1 - base
+          if (i == i0) return i0 + 1 - base
         }
-        else scan(end - 1)
-
-      scan(base + length - 1)
+        end -= 1
+      }
+      -1
     }
 
     /** Some thoroughly self-explanatory convenience functions.  They

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -456,9 +456,8 @@ trait StdNames {
      *  or $ followed by an operator that gets encoded, go directly to compiler
      *  crash. Do not pass go and don't even think about collecting any $$
      */
-    def unexpandedName(name: Name): Name = {
-      if (!name.containsChar('$')) name // lastIndexOf calls Name.toString, add a fast path to avoid that.
-      else name lastIndexOf "$$" match {
+    def unexpandedName(name: Name): Name =
+      name.lastIndexOf("$$") match {
         case 0 | -1 => name
         case idx0   =>
           // Sketchville - We've found $$ but if it's part of $$$ or $$$$
@@ -467,9 +466,8 @@ trait StdNames {
           var idx = idx0
           while (idx > 0 && name.charAt(idx - 1) == '$')
             idx -= 1
-          name drop idx + 2
+          name.drop(idx + 2)
       }
-    }
 
     @deprecated("use unexpandedName", "2.11.0") def originalName(name: Name): Name            = unexpandedName(name)
     @deprecated("use Name#dropModule", "2.11.0") def stripModuleSuffix(name: Name): Name      = name.dropModule

--- a/test/junit/scala/reflect/internal/NamesTest.scala
+++ b/test/junit/scala/reflect/internal/NamesTest.scala
@@ -12,15 +12,15 @@ class NamesTest {
   object symbolTable extends SymbolTableForUnitTesting
   import symbolTable._
 
-  val h1 = newTermName("hai")
-  val h2 = newTermName("hai")
-  val f  = newTermName("fisch")
+  val h1 = TermName("hai")
+  val h2 = TermName("hai")
+  val f  = TermName("fisch")
 
   val h1y = h1.toTypeName
-  val h2y = newTypeName("hai")
-  val fy  = newTypeName("fisch")
+  val h2y = TypeName("hai")
+  val fy  = TypeName("fisch")
 
-  val uy = newTypeName("uhu")
+  val uy = TypeName("uhu")
   val u  = uy.toTermName // calling toTermName after constructing a typeName. This tests the fact
                          // that creating a typeName always also first creates a termName. There is
                          // an assertion for that in toTermName.
@@ -55,7 +55,7 @@ class NamesTest {
     assertTrue(lookupTypeName("uhu".toCharArray) eq uy)
 
     assertThrows[AssertionError](lookupTypeName("dog".toCharArray), _ contains "not yet created")
-    val d = newTermName("dog")
+    val d = TermName("dog")
     assertThrows[AssertionError](lookupTypeName("dog".toCharArray), _ contains "not yet created")
     val dy = d.toTypeName
     assertTrue(lookupTypeName("dog".toCharArray) eq dy)
@@ -63,12 +63,12 @@ class NamesTest {
 
   @Test
   def emptyName(): Unit = {
-    val z = newTermName("")
+    val z = TermName("")
     val zy = z.toTypeName
     assertEquals(z.toString, "")
     assertEquals(zy.toString, "")
-    assertTrue(z eq newTermName(""))
-    assertTrue(zy eq newTypeName(""))
+    assertTrue(z eq TermName(""))
+    assertTrue(zy eq TypeName(""))
   }
 
   @Test
@@ -81,8 +81,8 @@ class NamesTest {
     assertTrue(iy.start == (fy.start + 1) && iy.length == (fy.length - 1))
     assertTrue(fy.subName(0, fy.length) eq fy)
 
-    assertTrue(f.subName(1,1) eq newTermName(""))
-    assertTrue(f.subName(1, 0) eq newTermName(""))
+    assertTrue(f.subName(1,1) eq TermName(""))
+    assertTrue(f.subName(1, 0) eq TermName(""))
 
     assertThrows[IllegalArgumentException](f.subName(0 - f.start - 1, 1))
   }
@@ -116,5 +116,24 @@ class NamesTest {
     check("ab", "ba")
     check("", "x")
     check("", "xy")
+  }
+
+  @Test
+  def `name.lastIndexOf is name.toString.lastIndexOf`(): Unit = {
+    def check(name: Name, sub: String): Unit = {
+      val javaResult = name.toString.lastIndexOf(sub)
+      val nameResult = name.lastIndexOf(sub)
+      assertEquals(s""""$name".lastIndexOf("$sub")""", javaResult, nameResult)
+    }
+    check(f,  "isch")  // put the isch in fisch
+    check(fy, "isch")
+    check(f,  "")
+    check(TermName(""),  "")
+    check(TermName(""),  "abc")
+    check(f,  "ischbiisch")
+    check(fy, "ischbiisch")
+    check(fy, "fyou")
+    check(f,  "disch")
+    check(fy, "disch")
   }
 }

--- a/test/junit/scala/reflect/internal/NamesTest.scala
+++ b/test/junit/scala/reflect/internal/NamesTest.scala
@@ -125,15 +125,19 @@ class NamesTest {
       val nameResult = name.lastIndexOf(sub)
       assertEquals(s""""$name".lastIndexOf("$sub")""", javaResult, nameResult)
     }
-    check(f,  "isch")  // put the isch in fisch
+    val d = TermName("x$default$42")
+    val e = TermName("")
+    check(f,  "isch")  // the isch in fisch
     check(fy, "isch")
     check(f,  "")
-    check(TermName(""),  "")
-    check(TermName(""),  "abc")
+    check(e,  "")
+    check(e,  "abc")
     check(f,  "ischbiisch")
     check(fy, "ischbiisch")
     check(fy, "fyou")
     check(f,  "disch")
     check(fy, "disch")
+    check(f,  "hai")   // happens to be earlier in name array
+    check(d,  "$$")    // likely to be earlier in name array
   }
 }


### PR DESCRIPTION
Perform the test instead of creating a string to
delegate to. We have access to the underlying Name
array; if testing for short strings, the penalty
for indexing into them is small.

Maybe improves https://github.com/scala/scala/pull/8928 which avoids incurring the allocation by probing for a character.