### PR TITLE
bump sbt-whitesource to 0.1.18 (was 0.1.16)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -39,4 +39,4 @@ if (Option(System.getProperty("scala.build.compileWithDotty")).map(_.toBoolean).
 else
   Seq()
 
-addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.16")
+addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.18")


### PR DESCRIPTION
I already used the new version to update our WhiteSource info for
2.13.2 and it went fine. the expected changes related to the JLine 3 upgrade
showed up.

motivation: dogfooding. there are bugfixes but I don't think they
affect this project. regardless, best to be on the latest.
(regardless, I chose to leave 2.12.x alone)