### PR TITLE
Make `-Wunused:imports` work again even when `-Ymacro-annotations` is enabled

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
@@ -35,7 +35,7 @@ trait MacroAnnotationNamers { self: Analyzer =>
           case tree @ Import(_, _) =>
             createAssignAndEnterSymbol(tree)
             finishSymbol(tree)
-            returnContext = context.make(tree)
+            returnContext = context.makeImportContext(tree)
           case tree: MemberDef =>
             createAssignAndEnterSymbol(tree)
             finishSymbol(tree)

--- a/test/files/neg/warn-unused-imports-b.check
+++ b/test/files/neg/warn-unused-imports-b.check
@@ -1,0 +1,55 @@
+warn-unused-imports_2.scala:135: error: type mismatch;
+ found   : Int(42)
+ required: Sample.X
+    f(42)                       // error
+      ^
+warn-unused-imports_2.scala:59: warning: Unused import
+    import p1.A // warn
+              ^
+warn-unused-imports_2.scala:64: warning: Unused import
+    import p1.{ A, B } // warn on A
+                ^
+warn-unused-imports_2.scala:69: warning: Unused import
+    import p1.{ A, B } // warn on both
+                ^
+warn-unused-imports_2.scala:69: warning: Unused import
+    import p1.{ A, B } // warn on both
+                   ^
+warn-unused-imports_2.scala:75: warning: Unused import
+    import c._  // warn
+             ^
+warn-unused-imports_2.scala:80: warning: Unused import
+    import p1._ // warn
+              ^
+warn-unused-imports_2.scala:87: warning: Unused import
+    import c._  // warn
+             ^
+warn-unused-imports_2.scala:93: warning: Unused import
+    import p1.c._  // warn
+                ^
+warn-unused-imports_2.scala:100: warning: Unused import
+    import p1._   // warn
+              ^
+warn-unused-imports_2.scala:120: warning: Unused import
+    import p1.A   // warn
+              ^
+warn-unused-imports_2.scala:134: warning: Unused import
+    import Sample.Implicits._   // warn
+                            ^
+warn-unused-imports_2.scala:145: warning: Unused import
+    import Sample.Implicits.useless     // warn
+                            ^
+warn-unused-imports_2.scala:149: warning: Unused import
+    import java.io.File                 // warn
+                   ^
+warn-unused-imports_2.scala:150: warning: Unused import
+    import scala.concurrent.Future      // warn
+                            ^
+warn-unused-imports_2.scala:151: warning: Unused import
+    import scala.concurrent.ExecutionContext.Implicits.global // warn
+                                                       ^
+warn-unused-imports_2.scala:152: warning: Unused import
+    import p1.A                         // warn
+              ^
+16 warnings
+1 error

--- a/test/files/neg/warn-unused-imports-b/sample_1.scala
+++ b/test/files/neg/warn-unused-imports-b/sample_1.scala
@@ -1,0 +1,32 @@
+
+import language._
+
+object Sample {
+  trait X
+  trait Y
+
+  // import of the non-implicit should be unused
+  object Implicits {
+    def `int to X`(i: Int): X = null
+    implicit def `int to Y`(i: Int): Y = null
+    implicit def useless(i: Int): String = null
+  }
+
+  def f(x: X) = ???
+  def g(y: Y) = ???
+}
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+ 
+object Macro {
+  def f: Int = macro fImpl
+  def fImpl(c: Context): c.Tree = {
+    import c.universe._
+ 
+    q"""
+     import scala.util.Random
+     42 // TODO randomize
+    """
+  }
+}

--- a/test/files/neg/warn-unused-imports-b/warn-unused-imports_2.scala
+++ b/test/files/neg/warn-unused-imports-b/warn-unused-imports_2.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Wunused:imports
+// scalac: -Werror -Wunused:imports -Ymacro-annotations
 //
 class Bippo {
   def length: Int = 123


### PR DESCRIPTION
MacroAnnotationNamers uses makeImportContext

This entry point is required for bookkeeping used imports.

Fixes scala/bug#11978