### PR TITLE
clamp down on warnings in REPL code

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -16,7 +16,7 @@ package interactive
 import java.io.{FileReader, FileWriter}
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.annotation.{elidable, tailrec}
+import scala.annotation.{elidable, tailrec, nowarn}
 import scala.collection.mutable
 import scala.collection.mutable.{HashSet, LinkedHashMap}
 import scala.jdk.javaapi.CollectionConverters
@@ -424,7 +424,8 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     while (loop) {
       breakable{
         loop = false
-        if (!interruptsEnabled) return
+        // TODO refactor to eliminate breakable/break/return?
+        (if (!interruptsEnabled) return): @nowarn("cat=lint-nonlocal-return")
         if (pos == NoPosition || nodesSeen % yieldPeriod == 0)
           Thread.`yield`()
 
@@ -636,8 +637,8 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
 
   /** Reset unit to unloaded state */
   private def reset(unit: RichCompilationUnit): Unit = {
-    unit.depends.clear()
-    unit.defined.clear()
+    unit.depends.clear(): @nowarn("cat=deprecation")
+    unit.defined.clear(): @nowarn("cat=deprecation")
     unit.synthetics.clear()
     unit.toCheck.clear()
     unit.checkedFeatures = Set()

--- a/src/library/scala/runtime/NonLocalReturnControl.scala
+++ b/src/library/scala/runtime/NonLocalReturnControl.scala
@@ -15,6 +15,7 @@ package scala.runtime
 import scala.util.control.ControlThrowable
 
 // remove Unit specialization when binary compatibility permits
+@annotation.nowarn("cat=lint-unit-specialization")
 class NonLocalReturnControl[@specialized(Byte, Short, Int, Long, Char, Float, Double, Boolean, Unit) T](val key: AnyRef, val value: T) extends ControlThrowable {
   final override def fillInStackTrace(): Throwable = this
 }

--- a/src/repl/scala/tools/nsc/interpreter/Imports.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Imports.scala
@@ -153,14 +153,13 @@ trait Imports {
       trailingBraces append "}\n"+ request.postwrap +"\n"
       accessPath append s".$iw"
     }
-    def addWrapper() {
+    def addWrapper(): Unit =
       if (useMagicImport) {
         addLevelChangingImport()
       } else {
         addWrapperCode()
       }
       currentImps.clear()
-    }
     def maybeWrap(names: Name*) = if (names exists currentImps) addWrapper()
 
     // imports from Predef are relocated to the template header to allow hiding.
@@ -181,11 +180,11 @@ trait Imports {
         // level if the import might conflict with some other import
         case x: ImportHandler if x.importsWildcard =>
           addWrapper()
-          code append (x.member + "\n")
+          code append (x.member.toString + "\n")
           addWrapper()
         case x: ImportHandler =>
           maybeWrap(x.importedNames: _*)
-          code append (x.member + "\n")
+          code append (x.member.toString + "\n")
           currentImps ++= x.importedNames
 
         case x if isClassBased =>


### PR DESCRIPTION
configurable warnings ftw!

attn contributors, more PRs in this vein (and the vein of Som's epic #8890) would be welcome. I just did the projects I happen to be working in at the moment

actually fixing warnings is of course good and I did fix some, but simply silencing existing warnings is okay too, the key thing is to enable `-Werror` by hook or by crook, to set a baseline and discourage backsliding