### PR TITLE
[backport] Ordering equality and other improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -445,6 +445,17 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashTrieMap.getOrElse0"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashMap1.getOrElse0"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashMap#HashMapCollision1.getOrElse0"),
+
+    ProblemFilters.exclude[MissingClassProblem]("scala.math.Ordering$IterableOrdering"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.math.Ordering$Tuple4Ordering"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.math.Ordering$Tuple9Ordering"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.math.Ordering$Reverse"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.math.Ordering$Tuple2Ordering"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.math.Ordering$Tuple3Ordering"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.math.Ordering$Tuple7Ordering"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.math.Ordering$Tuple6Ordering"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.math.Ordering$Tuple8Ordering"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.math.Ordering$Tuple5Ordering"),
   )
 }
 

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -109,10 +109,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   def min(x: T, y: T): T = if (lteq(x, y)) x else y
 
   /** Return the opposite ordering of this one. */
-  override def reverse: Ordering[T] = new Ordering[T] {
-    override def reverse = outer
-    def compare(x: T, y: T) = outer.compare(y, x)
-  }
+  override def reverse: Ordering[T] = new Ordering.Reverse[T](this)
 
   /** Given f, a function from U into T, creates an Ordering[U] whose compare
     * function is equivalent to:
@@ -163,26 +160,60 @@ trait LowPriorityOrderingImplicits {
   * new orderings.
   */
 object Ordering extends LowPriorityOrderingImplicits {
+  private final val reverseSeed  = 41
+  private final val optionSeed   = 43
+  private final val iterableSeed = 47
+
   def apply[T](implicit ord: Ordering[T]) = ord
+
+  /** A reverse ordering */
+  private final class Reverse[T](private val outer: Ordering[T]) extends Ordering[T] {
+    override def reverse: Ordering[T]       = outer
+    def compare(x: T, y: T): Int            = outer.compare(y, x)
+    override def lteq(x: T, y: T): Boolean  = outer.lteq(y, x)
+    override def gteq(x: T, y: T): Boolean  = outer.gteq(y, x)
+    override def lt(x: T, y: T): Boolean    = outer.lt(y, x)
+    override def gt(x: T, y: T): Boolean    = outer.gt(y, x)
+    override def equiv(x: T, y: T): Boolean = outer.equiv(y, x)
+    override def max(x: T, y: T): T = outer.min(x, y)
+    override def min(x: T, y: T): T = outer.max(x, y)
+
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: AnyRef if this eq that => true
+      case that: Reverse[T]             => this.outer == that.outer
+      case _                            => false
+    }
+    override def hashCode(): Int = outer.hashCode() * reverseSeed
+  }
+  private final val IntReverse: Ordering[Int] = new Reverse(Ordering.Int)
+
+  private final class IterableOrdering[CC[X] <: Iterable[X], T](private val ord: Ordering[T]) extends Ordering[CC[T]] {
+    def compare(x: CC[T], y: CC[T]): Int = {
+      val xe = x.iterator
+      val ye = y.iterator
+
+      while (xe.hasNext && ye.hasNext) {
+        val res = ord.compare(xe.next(), ye.next())
+        if (res != 0) return res
+      }
+
+      Boolean.compare(xe.hasNext, ye.hasNext)
+    }
+
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: AnyRef if this eq that  => true
+      case that: IterableOrdering[CC, T] => this.ord == that.ord
+      case _                             => false
+    }
+    override def hashCode(): Int = ord.hashCode() * iterableSeed
+  }
 
   trait ExtraImplicits {
     /** Not in the standard scope due to the potential for divergence:
       * For instance `implicitly[Ordering[Any]]` diverges in its presence.
       */
     implicit def seqDerivedOrdering[CC[X] <: scala.collection.Seq[X], T](implicit ord: Ordering[T]): Ordering[CC[T]] =
-      new Ordering[CC[T]] {
-        def compare(x: CC[T], y: CC[T]): Int = {
-          val xe = x.iterator
-          val ye = y.iterator
-
-          while (xe.hasNext && ye.hasNext) {
-            val res = ord.compare(xe.next(), ye.next())
-            if (res != 0) return res
-          }
-
-          Ordering.Boolean.compare(xe.hasNext, ye.hasNext)
-        }
-      }
+      new IterableOrdering[CC, T](ord)
 
     /** This implicit creates a conversion from any value for which an
       * implicit `Ordering` exists to the class which creates infix operations.
@@ -253,6 +284,7 @@ object Ordering extends LowPriorityOrderingImplicits {
 
   trait IntOrdering extends Ordering[Int] {
     def compare(x: Int, y: Int) = java.lang.Integer.compare(x, y)
+    override def reverse: Ordering[Int] = IntReverse
   }
   implicit object Int extends IntOrdering
 
@@ -262,8 +294,6 @@ object Ordering extends LowPriorityOrderingImplicits {
   implicit object Long extends LongOrdering
 
   trait FloatOrdering extends Ordering[Float] {
-    outer =>
-
     def compare(x: Float, y: Float) = java.lang.Float.compare(x, y)
 
     override def lteq(x: Float, y: Float): Boolean = x <= y
@@ -273,25 +303,10 @@ object Ordering extends LowPriorityOrderingImplicits {
     override def equiv(x: Float, y: Float): Boolean = x == y
     override def max(x: Float, y: Float): Float = math.max(x, y)
     override def min(x: Float, y: Float): Float = math.min(x, y)
-
-    override def reverse: Ordering[Float] = new FloatOrdering {
-      override def reverse = outer
-      override def compare(x: Float, y: Float) = outer.compare(y, x)
-
-      override def lteq(x: Float, y: Float): Boolean = outer.lteq(y, x)
-      override def gteq(x: Float, y: Float): Boolean = outer.gteq(y, x)
-      override def lt(x: Float, y: Float): Boolean = outer.lt(y, x)
-      override def gt(x: Float, y: Float): Boolean = outer.gt(y, x)
-      override def min(x: Float, y: Float): Float = outer.max(x, y)
-      override def max(x: Float, y: Float): Float = outer.min(x, y)
-
-    }
   }
   implicit object Float extends FloatOrdering
 
   trait DoubleOrdering extends Ordering[Double] {
-    outer =>
-
     def compare(x: Double, y: Double) = java.lang.Double.compare(x, y)
 
     override def lteq(x: Double, y: Double): Boolean = x <= y
@@ -301,18 +316,6 @@ object Ordering extends LowPriorityOrderingImplicits {
     override def equiv(x: Double, y: Double): Boolean = x == y
     override def max(x: Double, y: Double): Double = math.max(x, y)
     override def min(x: Double, y: Double): Double = math.min(x, y)
-
-    override def reverse: Ordering[Double] = new DoubleOrdering {
-      override def reverse = outer
-      override def compare(x: Double, y: Double) = outer.compare(y, x)
-
-      override def lteq(x: Double, y: Double): Boolean = outer.lteq(y, x)
-      override def gteq(x: Double, y: Double): Boolean = outer.gteq(y, x)
-      override def lt(x: Double, y: Double): Boolean = outer.lt(y, x)
-      override def gt(x: Double, y: Double): Boolean = outer.gt(y, x)
-      override def min(x: Double, y: Double): Double = outer.max(x, y)
-      override def max(x: Double, y: Double): Double = outer.min(x, y)
-    }
   }
   implicit object Double extends DoubleOrdering
 
@@ -339,167 +342,319 @@ object Ordering extends LowPriorityOrderingImplicits {
       case (_, None)          => 1
       case (Some(x), Some(y)) => optionOrdering.compare(x, y)
     }
+
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: AnyRef if this eq that => true
+      case that: OptionOrdering[T]      => this.optionOrdering == that.optionOrdering
+      case _                            => false
+    }
+    override def hashCode(): Int = optionOrdering.hashCode() * optionSeed
   }
   implicit def Option[T](implicit ord: Ordering[T]): Ordering[Option[T]] =
     new OptionOrdering[T] { val optionOrdering = ord }
 
   implicit def Iterable[T](implicit ord: Ordering[T]): Ordering[Iterable[T]] =
-    new Ordering[Iterable[T]] {
-      def compare(x: Iterable[T], y: Iterable[T]): Int = {
-        val xe = x.iterator
-        val ye = y.iterator
-
-        while (xe.hasNext && ye.hasNext) {
-          val res = ord.compare(xe.next(), ye.next())
-          if (res != 0) return res
-        }
-
-        Boolean.compare(xe.hasNext, ye.hasNext)
-      }
-    }
+    new IterableOrdering[Iterable, T](ord)
 
   implicit def Tuple2[T1, T2](implicit ord1: Ordering[T1], ord2: Ordering[T2]): Ordering[(T1, T2)] =
-    new Ordering[(T1, T2)]{
-      def compare(x: (T1, T2), y: (T1, T2)): Int = {
-        val compare1 = ord1.compare(x._1, y._1)
-        if (compare1 != 0) return compare1
+    new Tuple2Ordering(ord1, ord2)
+
+  private[this] final class Tuple2Ordering[T1, T2](private val ord1: Ordering[T1],
+                                                   private val ord2: Ordering[T2]) extends Ordering[(T1, T2)] {
+    def compare(x: (T1, T2), y: (T1, T2)): Int = {
+      val compare1 = ord1.compare(x._1, y._1)
+      if (compare1 != 0) return compare1
         val compare2 = ord2.compare(x._2, y._2)
         if (compare2 != 0) return compare2
         0
-      }
     }
+
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: AnyRef if this eq that => true
+      case that: Tuple2Ordering[T1, T2] =>
+        this.ord1 == that.ord1 &&
+        this.ord2 == that.ord2
+      case _ => false
+    }
+    override def hashCode(): Int = (ord1, ord2).hashCode()
+  }
 
   implicit def Tuple3[T1, T2, T3](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3]) : Ordering[(T1, T2, T3)] =
-    new Ordering[(T1, T2, T3)]{
-      def compare(x: (T1, T2, T3), y: (T1, T2, T3)): Int = {
-        val compare1 = ord1.compare(x._1, y._1)
-        if (compare1 != 0) return compare1
-        val compare2 = ord2.compare(x._2, y._2)
-        if (compare2 != 0) return compare2
+    new Tuple3Ordering(ord1, ord2, ord3)
+
+  private[this] final class Tuple3Ordering[T1, T2, T3](private val ord1: Ordering[T1],
+                                                       private val ord2: Ordering[T2],
+                                                       private val ord3: Ordering[T3]) extends Ordering[(T1, T2, T3)] {
+    def compare(x: (T1, T2, T3), y: (T1, T2, T3)): Int = {
+      val compare1 = ord1.compare(x._1, y._1)
+      if (compare1 != 0) return compare1
+      val compare2 = ord2.compare(x._2, y._2)
+      if (compare2 != 0) return compare2
         val compare3 = ord3.compare(x._3, y._3)
         if (compare3 != 0) return compare3
         0
-      }
     }
+
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: AnyRef if this eq that => true
+      case that: Tuple3Ordering[T1, T2, T3] =>
+        this.ord1 == that.ord1 &&
+        this.ord2 == that.ord2 &&
+        this.ord3 == that.ord3
+      case _ => false
+    }
+    override def hashCode(): Int = (ord1, ord2, ord3).hashCode()
+  }
 
   implicit def Tuple4[T1, T2, T3, T4](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4]) : Ordering[(T1, T2, T3, T4)] =
-    new Ordering[(T1, T2, T3, T4)]{
-      def compare(x: (T1, T2, T3, T4), y: (T1, T2, T3, T4)): Int = {
-        val compare1 = ord1.compare(x._1, y._1)
-        if (compare1 != 0) return compare1
-        val compare2 = ord2.compare(x._2, y._2)
-        if (compare2 != 0) return compare2
-        val compare3 = ord3.compare(x._3, y._3)
-        if (compare3 != 0) return compare3
+    new Tuple4Ordering(ord1, ord2, ord3, ord4)
+
+  private[this] final class Tuple4Ordering[T1, T2, T3, T4](private val ord1: Ordering[T1],
+                                                           private val ord2: Ordering[T2],
+                                                           private val ord3: Ordering[T3],
+                                                           private val ord4: Ordering[T4])
+    extends Ordering[(T1, T2, T3, T4)] {
+    def compare(x: (T1, T2, T3, T4), y: (T1, T2, T3, T4)): Int = {
+      val compare1 = ord1.compare(x._1, y._1)
+      if (compare1 != 0) return compare1
+      val compare2 = ord2.compare(x._2, y._2)
+      if (compare2 != 0) return compare2
+      val compare3 = ord3.compare(x._3, y._3)
+      if (compare3 != 0) return compare3
         val compare4 = ord4.compare(x._4, y._4)
         if (compare4 != 0) return compare4
         0
-      }
     }
+
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: AnyRef if this eq that => true
+      case that: Tuple4Ordering[T1, T2, T3, T4] =>
+        this.ord1 == that.ord1 &&
+        this.ord2 == that.ord2 &&
+        this.ord3 == that.ord3 &&
+        this.ord4 == that.ord4
+      case _ => false
+    }
+    override def hashCode(): Int = (ord1, ord2, ord3, ord4).hashCode()
+  }
 
   implicit def Tuple5[T1, T2, T3, T4, T5](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5]): Ordering[(T1, T2, T3, T4, T5)] =
-    new Ordering[(T1, T2, T3, T4, T5)]{
-      def compare(x: (T1, T2, T3, T4, T5), y: Tuple5[T1, T2, T3, T4, T5]): Int = {
-        val compare1 = ord1.compare(x._1, y._1)
-        if (compare1 != 0) return compare1
-        val compare2 = ord2.compare(x._2, y._2)
-        if (compare2 != 0) return compare2
-        val compare3 = ord3.compare(x._3, y._3)
-        if (compare3 != 0) return compare3
-        val compare4 = ord4.compare(x._4, y._4)
-        if (compare4 != 0) return compare4
+    new Tuple5Ordering(ord1, ord2, ord3, ord4, ord5)
+
+  private[this] final class Tuple5Ordering[T1, T2, T3, T4, T5](private val ord1: Ordering[T1],
+                                                               private val ord2: Ordering[T2],
+                                                               private val ord3: Ordering[T3],
+                                                               private val ord4: Ordering[T4],
+                                                               private val ord5: Ordering[T5])
+    extends Ordering[(T1, T2, T3, T4, T5)] {
+    def compare(x: (T1, T2, T3, T4, T5), y: (T1, T2, T3, T4, T5)): Int = {
+      val compare1 = ord1.compare(x._1, y._1)
+      if (compare1 != 0) return compare1
+      val compare2 = ord2.compare(x._2, y._2)
+      if (compare2 != 0) return compare2
+      val compare3 = ord3.compare(x._3, y._3)
+      if (compare3 != 0) return compare3
+      val compare4 = ord4.compare(x._4, y._4)
+      if (compare4 != 0) return compare4
         val compare5 = ord5.compare(x._5, y._5)
         if (compare5 != 0) return compare5
         0
-      }
     }
+
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: AnyRef if this eq that => true
+      case that: Tuple5Ordering[T1, T2, T3, T4, T5] =>
+        this.ord1 == that.ord1 &&
+        this.ord2 == that.ord2 &&
+        this.ord3 == that.ord3 &&
+        this.ord4 == that.ord4 &&
+        this.ord5 == that.ord5
+      case _ => false
+    }
+    override def hashCode(): Int = (ord1, ord2, ord3, ord4, ord5).hashCode()
+  }
 
   implicit def Tuple6[T1, T2, T3, T4, T5, T6](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5], ord6: Ordering[T6]): Ordering[(T1, T2, T3, T4, T5, T6)] =
-    new Ordering[(T1, T2, T3, T4, T5, T6)]{
-      def compare(x: (T1, T2, T3, T4, T5, T6), y: (T1, T2, T3, T4, T5, T6)): Int = {
-        val compare1 = ord1.compare(x._1, y._1)
-        if (compare1 != 0) return compare1
-        val compare2 = ord2.compare(x._2, y._2)
-        if (compare2 != 0) return compare2
-        val compare3 = ord3.compare(x._3, y._3)
-        if (compare3 != 0) return compare3
-        val compare4 = ord4.compare(x._4, y._4)
-        if (compare4 != 0) return compare4
-        val compare5 = ord5.compare(x._5, y._5)
-        if (compare5 != 0) return compare5
+    new Tuple6Ordering(ord1, ord2, ord3, ord4, ord5, ord6)
+
+  private[this] final class Tuple6Ordering[T1, T2, T3, T4, T5, T6](private val ord1: Ordering[T1],
+                                                                   private val ord2: Ordering[T2],
+                                                                   private val ord3: Ordering[T3],
+                                                                   private val ord4: Ordering[T4],
+                                                                   private val ord5: Ordering[T5],
+                                                                   private val ord6: Ordering[T6])
+    extends Ordering[(T1, T2, T3, T4, T5, T6)] {
+    def compare(x: (T1, T2, T3, T4, T5, T6), y: (T1, T2, T3, T4, T5, T6)): Int = {
+      val compare1 = ord1.compare(x._1, y._1)
+      if (compare1 != 0) return compare1
+      val compare2 = ord2.compare(x._2, y._2)
+      if (compare2 != 0) return compare2
+      val compare3 = ord3.compare(x._3, y._3)
+      if (compare3 != 0) return compare3
+      val compare4 = ord4.compare(x._4, y._4)
+      if (compare4 != 0) return compare4
+      val compare5 = ord5.compare(x._5, y._5)
+      if (compare5 != 0) return compare5
         val compare6 = ord6.compare(x._6, y._6)
         if (compare6 != 0) return compare6
         0
-      }
     }
+
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: AnyRef if this eq that => true
+      case that: Tuple6Ordering[T1, T2, T3, T4, T5, T6] =>
+        this.ord1 == that.ord1 &&
+        this.ord2 == that.ord2 &&
+        this.ord3 == that.ord3 &&
+        this.ord4 == that.ord4 &&
+        this.ord5 == that.ord5 &&
+        this.ord6 == that.ord6
+      case _ => false
+    }
+    override def hashCode(): Int = (ord1, ord2, ord3, ord4, ord5, ord6).hashCode()
+  }
 
   implicit def Tuple7[T1, T2, T3, T4, T5, T6, T7](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5], ord6: Ordering[T6], ord7: Ordering[T7]): Ordering[(T1, T2, T3, T4, T5, T6, T7)] =
-    new Ordering[(T1, T2, T3, T4, T5, T6, T7)]{
-      def compare(x: (T1, T2, T3, T4, T5, T6, T7), y: (T1, T2, T3, T4, T5, T6, T7)): Int = {
-        val compare1 = ord1.compare(x._1, y._1)
-        if (compare1 != 0) return compare1
-        val compare2 = ord2.compare(x._2, y._2)
-        if (compare2 != 0) return compare2
-        val compare3 = ord3.compare(x._3, y._3)
-        if (compare3 != 0) return compare3
-        val compare4 = ord4.compare(x._4, y._4)
-        if (compare4 != 0) return compare4
-        val compare5 = ord5.compare(x._5, y._5)
-        if (compare5 != 0) return compare5
-        val compare6 = ord6.compare(x._6, y._6)
-        if (compare6 != 0) return compare6
+    new Tuple7Ordering(ord1, ord2, ord3, ord4, ord5, ord6, ord7)
+
+  private[this] final class Tuple7Ordering[T1, T2, T3, T4, T5, T6, T7](private val ord1: Ordering[T1],
+                                                                       private val ord2: Ordering[T2],
+                                                                       private val ord3: Ordering[T3],
+                                                                       private val ord4: Ordering[T4],
+                                                                       private val ord5: Ordering[T5],
+                                                                       private val ord6: Ordering[T6],
+                                                                       private val ord7: Ordering[T7])
+    extends Ordering[(T1, T2, T3, T4, T5, T6, T7)] {
+    def compare(x: (T1, T2, T3, T4, T5, T6, T7), y: (T1, T2, T3, T4, T5, T6, T7)): Int = {
+      val compare1 = ord1.compare(x._1, y._1)
+      if (compare1 != 0) return compare1
+      val compare2 = ord2.compare(x._2, y._2)
+      if (compare2 != 0) return compare2
+      val compare3 = ord3.compare(x._3, y._3)
+      if (compare3 != 0) return compare3
+      val compare4 = ord4.compare(x._4, y._4)
+      if (compare4 != 0) return compare4
+      val compare5 = ord5.compare(x._5, y._5)
+      if (compare5 != 0) return compare5
+      val compare6 = ord6.compare(x._6, y._6)
+      if (compare6 != 0) return compare6
         val compare7 = ord7.compare(x._7, y._7)
         if (compare7 != 0) return compare7
         0
-      }
     }
+
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: AnyRef if this eq that => true
+      case that: Tuple7Ordering[T1, T2, T3, T4, T5, T6, T7] =>
+        this.ord1 == that.ord1 &&
+        this.ord2 == that.ord2 &&
+        this.ord3 == that.ord3 &&
+        this.ord4 == that.ord4 &&
+        this.ord5 == that.ord5 &&
+        this.ord6 == that.ord6 &&
+        this.ord7 == that.ord7
+      case _ => false
+    }
+    override def hashCode(): Int = (ord1, ord2, ord3, ord4, ord5, ord6, ord7).hashCode()
+  }
 
   implicit def Tuple8[T1, T2, T3, T4, T5, T6, T7, T8](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5], ord6: Ordering[T6], ord7: Ordering[T7], ord8: Ordering[T8]): Ordering[(T1, T2, T3, T4, T5, T6, T7, T8)] =
-    new Ordering[(T1, T2, T3, T4, T5, T6, T7, T8)]{
-      def compare(x: (T1, T2, T3, T4, T5, T6, T7, T8), y: (T1, T2, T3, T4, T5, T6, T7, T8)): Int = {
-        val compare1 = ord1.compare(x._1, y._1)
-        if (compare1 != 0) return compare1
-        val compare2 = ord2.compare(x._2, y._2)
-        if (compare2 != 0) return compare2
-        val compare3 = ord3.compare(x._3, y._3)
-        if (compare3 != 0) return compare3
-        val compare4 = ord4.compare(x._4, y._4)
-        if (compare4 != 0) return compare4
-        val compare5 = ord5.compare(x._5, y._5)
-        if (compare5 != 0) return compare5
-        val compare6 = ord6.compare(x._6, y._6)
-        if (compare6 != 0) return compare6
-        val compare7 = ord7.compare(x._7, y._7)
-        if (compare7 != 0) return compare7
+    new Tuple8Ordering(ord1, ord2, ord3, ord4, ord5, ord6, ord7, ord8)
+
+  private[this] final class Tuple8Ordering[T1, T2, T3, T4, T5, T6, T7, T8](private val ord1: Ordering[T1],
+                                                                           private val ord2: Ordering[T2],
+                                                                           private val ord3: Ordering[T3],
+                                                                           private val ord4: Ordering[T4],
+                                                                           private val ord5: Ordering[T5],
+                                                                           private val ord6: Ordering[T6],
+                                                                           private val ord7: Ordering[T7],
+                                                                           private val ord8: Ordering[T8])
+    extends Ordering[(T1, T2, T3, T4, T5, T6, T7, T8)] {
+    def compare(x: (T1, T2, T3, T4, T5, T6, T7, T8), y: (T1, T2, T3, T4, T5, T6, T7, T8)): Int = {
+      val compare1 = ord1.compare(x._1, y._1)
+      if (compare1 != 0) return compare1
+      val compare2 = ord2.compare(x._2, y._2)
+      if (compare2 != 0) return compare2
+      val compare3 = ord3.compare(x._3, y._3)
+      if (compare3 != 0) return compare3
+      val compare4 = ord4.compare(x._4, y._4)
+      if (compare4 != 0) return compare4
+      val compare5 = ord5.compare(x._5, y._5)
+      if (compare5 != 0) return compare5
+      val compare6 = ord6.compare(x._6, y._6)
+      if (compare6 != 0) return compare6
+      val compare7 = ord7.compare(x._7, y._7)
+      if (compare7 != 0) return compare7
         val compare8 = ord8.compare(x._8, y._8)
         if (compare8 != 0) return compare8
         0
-      }
     }
 
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: AnyRef if this eq that => true
+      case that: Tuple8Ordering[T1, T2, T3, T4, T5, T6, T7, T8] =>
+        this.ord1 == that.ord1 &&
+        this.ord2 == that.ord2 &&
+        this.ord3 == that.ord3 &&
+        this.ord4 == that.ord4 &&
+        this.ord5 == that.ord5 &&
+        this.ord6 == that.ord6 &&
+        this.ord7 == that.ord7 &&
+        this.ord8 == that.ord8
+      case _ => false
+    }
+    override def hashCode(): Int = (ord1, ord2, ord3, ord4, ord5, ord6, ord7, ord8).hashCode()
+  }
+
   implicit def Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5], ord6: Ordering[T6], ord7: Ordering[T7], ord8 : Ordering[T8], ord9: Ordering[T9]): Ordering[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] =
-    new Ordering[(T1, T2, T3, T4, T5, T6, T7, T8, T9)]{
-      def compare(x: (T1, T2, T3, T4, T5, T6, T7, T8, T9), y: (T1, T2, T3, T4, T5, T6, T7, T8, T9)): Int = {
-        val compare1 = ord1.compare(x._1, y._1)
-        if (compare1 != 0) return compare1
-        val compare2 = ord2.compare(x._2, y._2)
-        if (compare2 != 0) return compare2
-        val compare3 = ord3.compare(x._3, y._3)
-        if (compare3 != 0) return compare3
-        val compare4 = ord4.compare(x._4, y._4)
-        if (compare4 != 0) return compare4
-        val compare5 = ord5.compare(x._5, y._5)
-        if (compare5 != 0) return compare5
-        val compare6 = ord6.compare(x._6, y._6)
-        if (compare6 != 0) return compare6
-        val compare7 = ord7.compare(x._7, y._7)
-        if (compare7 != 0) return compare7
-        val compare8 = ord8.compare(x._8, y._8)
-        if (compare8 != 0) return compare8
+    new Tuple9Ordering(ord1, ord2, ord3, ord4, ord5, ord6, ord7, ord8, ord9)
+
+  private[this] final class Tuple9Ordering[T1, T2, T3, T4, T5, T6, T7, T8, T9](private val ord1: Ordering[T1],
+                                                                               private val ord2: Ordering[T2],
+                                                                               private val ord3: Ordering[T3],
+                                                                               private val ord4: Ordering[T4],
+                                                                               private val ord5: Ordering[T5],
+                                                                               private val ord6: Ordering[T6],
+                                                                               private val ord7: Ordering[T7],
+                                                                               private val ord8: Ordering[T8],
+                                                                               private val ord9: Ordering[T9])
+    extends Ordering[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] {
+    def compare(x: (T1, T2, T3, T4, T5, T6, T7, T8, T9), y: (T1, T2, T3, T4, T5, T6, T7, T8, T9)): Int = {
+      val compare1 = ord1.compare(x._1, y._1)
+      if (compare1 != 0) return compare1
+      val compare2 = ord2.compare(x._2, y._2)
+      if (compare2 != 0) return compare2
+      val compare3 = ord3.compare(x._3, y._3)
+      if (compare3 != 0) return compare3
+      val compare4 = ord4.compare(x._4, y._4)
+      if (compare4 != 0) return compare4
+      val compare5 = ord5.compare(x._5, y._5)
+      if (compare5 != 0) return compare5
+      val compare6 = ord6.compare(x._6, y._6)
+      if (compare6 != 0) return compare6
+      val compare7 = ord7.compare(x._7, y._7)
+      if (compare7 != 0) return compare7
+      val compare8 = ord8.compare(x._8, y._8)
+      if (compare8 != 0) return compare8
         val compare9 = ord9.compare(x._9, y._9)
         if (compare9 != 0) return compare9
         0
-      }
     }
 
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case that: AnyRef if this eq that => true
+      case that: Tuple9Ordering[T1, T2, T3, T4, T5, T6, T7, T8, T9] =>
+        this.ord1 == that.ord1 &&
+        this.ord2 == that.ord2 &&
+        this.ord3 == that.ord3 &&
+        this.ord4 == that.ord4 &&
+        this.ord5 == that.ord5 &&
+        this.ord6 == that.ord6 &&
+        this.ord7 == that.ord7 &&
+        this.ord8 == that.ord8 &&
+        this.ord9 == that.ord9
+      case _ => false
+    }
+    override def hashCode(): Int = (ord1, ord2, ord3, ord4, ord5, ord6, ord7, ord8, ord9).hashCode()
+  }
 }

--- a/src/library/scala/math/PartialOrdering.scala
+++ b/src/library/scala/math/PartialOrdering.scala
@@ -77,7 +77,11 @@ trait PartialOrdering[T] extends Equiv[T] {
 
   def reverse : PartialOrdering[T] = new PartialOrdering[T] {
     override def reverse = outer
-    def lteq(x: T, y: T) = outer.lteq(y, x)
     def tryCompare(x: T, y: T) = outer.tryCompare(y, x)
+    def lteq(x: T, y: T) = outer.lteq(y, x)
+    override def gteq(x: T, y: T) = outer.gteq(y, x)
+    override def lt(x: T, y: T) = outer.lt(y, x)
+    override def gt(x: T, y: T) = outer.gt(y, x)
+    override def equiv(x: T, y: T) = outer.equiv(y, x)
   }
 }

--- a/test/junit/scala/math/OrderingTest.scala
+++ b/test/junit/scala/math/OrderingTest.scala
@@ -57,5 +57,29 @@ class OrderingTest {
     checkAll[Iterable[Int]](Nil, List(1), List(1, 2))
     checkAll[(Int, Int)]((1, 2), (1, 3), (4, 5))
   }
-}
 
+  @Test
+  def orderingEquality(): Unit = {
+    def check[T](ord: => Ordering[T]): Unit = {
+      assertEquals(ord, ord)
+      assertEquals(ord.hashCode(), ord.hashCode())
+      assertEquals(ord.reverse, ord.reverse)
+      assertEquals(ord.reverse.hashCode(), ord.reverse.hashCode())
+    }
+
+    check(Ordering[Int])
+    check(Ordering[(Int, Long)])
+    check(Ordering[(Int, Long, Float)])
+    check(Ordering[(Int, Long, Float, Double)])
+    check(Ordering[(Int, Long, Float, Double, Byte)])
+    check(Ordering[(Int, Long, Float, Double, Byte, Char)])
+    check(Ordering[(Int, Long, Float, Double, Byte, Char, Short)])
+    check(Ordering[(Int, Long, Float, Double, Byte, Char, Short, BigInt)])
+    check(Ordering[(Int, Long, Float, Double, Byte, Char, Short, BigInt, BigDecimal)])
+    check(Ordering[Option[Int]])
+    check(Ordering[Iterable[Int]])
+
+    import Ordering.Implicits._
+    check(Ordering[Seq[Int]])
+  }
+}


### PR DESCRIPTION
Forward more methods for reverse orderings

Forward most comparison methods (not just abstract
ones) in default implementations of Ordering.reverse
and PartialOrdering.reverse.

Remove unnecessary overrides for FloatOrdering and
DoubleOrdering.

(cherry picked from commit 3dd2681f20bd64173e765dcc514c83738835a509)

Add equality for Orderings

(cherry picked from commit 86d6d31eba1beb851b15267fffe7e39a9d286f37)

Make IntOrdering.reverse a val.

partial cherry-pick of 9bccb6bfd1b293ab69b7a34cf9a23b763574f3ea)