### PR TITLE
Use Scope's reverseIterator to compute maximum type depth in Scope

### DIFF
--- a/src/reflect/scala/reflect/internal/Depth.scala
+++ b/src/reflect/scala/reflect/internal/Depth.scala
@@ -62,4 +62,12 @@ object Depth {
     }
     mm
   }
+
+  def maximumBy[A](iterator: Iterator[A])(ff: DepthFunction[A]): Depth = {
+    var mm: Depth = Zero
+    while (iterator.hasNext){
+      mm = mm max ff(iterator.next())
+    }
+    mm
+  }
 }

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4462,6 +4462,7 @@ trait Types
 
   private def infoTypeDepth(sym: Symbol): Depth = typeDepth(sym.info)
   private def symTypeDepth(syms: List[Symbol]): Depth  = Depth.maximumBy(syms)(infoTypeDepth)
+  private def symTypeDepthIterator(syms: Iterator[Symbol]): Depth = Depth.maximumBy(syms)(infoTypeDepth)
   private def baseTypeSeqDepth(tps: List[Type]): Depth = Depth.maximumBy(tps)((t: Type) => t.baseTypeSeqDepth)
 
   /** Is intersection of given types populated? That is,
@@ -5287,7 +5288,7 @@ trait Types
   /** The maximum depth of type `tp` */
   final def typeDepth(tp: Type): Depth = tp match {
     case TypeRef(pre, sym, args)          => typeDepth(pre) max maxDepth(args).incr
-    case RefinedType(parents, decls)      => maxDepth(parents) max symTypeDepth(decls.toList).incr
+    case RefinedType(parents, decls)      => maxDepth(parents) max symTypeDepthIterator(decls.reverseIterator).incr
     case TypeBounds(lo, hi)               => typeDepth(lo) max typeDepth(hi)
     case MethodType(paramtypes, result)   => typeDepth(result)
     case NullaryMethodType(result)        => typeDepth(result)


### PR DESCRIPTION
The `reverseIterator` does not need to allocate a full list of scope elements,  whereas `toList` would force it.

Of course, because the `Scope` object keeps that generated list, this may not avoid that list allocation (the same object needs that list before or after this call), and would often allocate the iterator itself. 

Uses some lines off #8532 