### PR TITLE
Don't warn unused synthetic case copy defaults

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -591,11 +591,12 @@ trait TypeDiagnostics {
         && !(treeTypes.exists(_.exists(_.typeSymbolDirect == m)))
       )
     def isSyntheticWarnable(sym: Symbol) = {
-      def rescindPrivateConstructorDefault: Boolean =
+      def privateSyntheticDefault: Boolean =
         cond(nme.defaultGetterToMethod(sym.name)) {
-          case nme.CONSTRUCTOR => true
+          case nme.CONSTRUCTOR => sym.owner.companion.isCaseClass
+          case nme.copy        => sym.owner.typeSignature.member(nme.copy).isSynthetic
         }
-      sym.isDefaultGetter && !rescindPrivateConstructorDefault
+      sym.isDefaultGetter && !privateSyntheticDefault
     }
     def isUnusedTerm(m: Symbol): Boolean = (
       m.isTerm

--- a/test/files/pos/t11980.scala
+++ b/test/files/pos/t11980.scala
@@ -1,0 +1,15 @@
+//scalac: -Werror -Wunused:privates -Xsource:3
+//
+object Domain {
+  def id(id: String): Domain = Domain(Some(id), None)
+  def name(name: String): Domain = Domain(None, Some(name))
+
+  // induces private copy and private copy defaults
+  def apply(id: String, name: String): Domain = Domain(Some(id), Some(name))
+}
+
+case class Domain private (id: Option[String], name: Option[String])
+
+// t7707
+object O { O() ; def f(): Unit = O() }
+case class O private (x: Int = 3)

--- a/test/files/pos/t7707.scala
+++ b/test/files/pos/t7707.scala
@@ -1,7 +1,12 @@
 // scalac: -Werror -Xlint
 
+// uses apply default, ctor default is unused
 object O { O() ; def f(): Unit = O() }
 case class O private (x: Int = 3)
 
 object Q { Q[Int]() ; def f(): Unit = Q[Int]() }
 case class Q[A] private (x: Int = 3)
+
+// normal usage
+object P { new P() ; def f(): Unit = new P() }
+class P private (x: Int = 3)


### PR DESCRIPTION
Copy is private if ctor is private and apply supplied.

Also tighten related warning on ctor defaults to
case class.

Fixes scala/bug#11980