### PR TITLE
Small performance improvements to sorting

### DIFF
--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -65,6 +65,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
 
   override protected[this] def thisCollection: Seq[A] = this.asInstanceOf[Seq[A]]
   override protected[this] def toCollection(repr: Repr): Seq[A] = repr.asInstanceOf[Seq[A]]
+  protected[this] type repr = Repr
 
   def length: Int
 

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -487,6 +487,15 @@ case object Nil extends List[Nothing] {
 final case class ::[B](override val head: B, private[scala] var tl: List[B]) extends List[B] {
   override def tail : List[B] = tl
   override def isEmpty: Boolean = false
+  override private[scala] def fromAnyRefArray(arr: Array[AnyRef]) = {
+    var tail: List[B] = Nil
+    var i = arr.length-1
+    while (i >= 0) {
+      tail = new ::(arr(i).asInstanceOf[B], tail)
+      i -= 1
+    }
+    tail
+  }
 }
 
 /** $factoryInfo

--- a/src/library/scala/collection/immutable/Seq.scala
+++ b/src/library/scala/collection/immutable/Seq.scala
@@ -37,17 +37,17 @@ trait Seq[+A] extends Iterable[A]
   override def toSeq: Seq[A] = this
   override def seq: Seq[A] = this
   protected[this] override def parCombiner = ParSeq.newCombiner[A] // if `immutable.SeqLike` gets introduced, please move this there!
-  override def sorted[B >: A](implicit ord: Ordering[B]): this.type = {
+  override def sorted[B >: A](implicit ord: Ordering[B]) = {
     val len = this.length
     if (len < 2 || (len == 2 && ord.compare(apply(0), apply(1)) <= 0)) this
     else if (len == 2) {
       //we know the order should be reversed
       //and some implementations have optimised methods for this
-      reverse.asInstanceOf[this.type]
+      reverse
     } else {
       val arr = toArray[Any].asInstanceOf[Array[AnyRef]]
       java.util.Arrays.sort(arr, ord.asInstanceOf[Ordering[Object]])
-      fromAnyRefArray(arr).asInstanceOf[this.type]
+      fromAnyRefArray(arr)
     }
   }
 

--- a/src/library/scala/collection/immutable/Seq.scala
+++ b/src/library/scala/collection/immutable/Seq.scala
@@ -17,6 +17,7 @@ package immutable
 import generic._
 import mutable.Builder
 import parallel.immutable.ParSeq
+import scala.math.Ordering
 
 /** A subtrait of `collection.Seq` which represents sequences
  *  that are guaranteed immutable.
@@ -36,6 +37,20 @@ trait Seq[+A] extends Iterable[A]
   override def toSeq: Seq[A] = this
   override def seq: Seq[A] = this
   protected[this] override def parCombiner = ParSeq.newCombiner[A] // if `immutable.SeqLike` gets introduced, please move this there!
+  override def sorted[B >: A](implicit ord: Ordering[B]): this.type = {
+    val len = this.length
+    if (len < 2 || (len == 2 && ord.compare(apply(0), apply(1)) <= 0)) this
+    else if (len == 2) {
+      //we know the order should be reversed
+      //and some implementations have optimised methods for this
+      reverse.asInstanceOf[this.type]
+    } else {
+      val arr = toArray[Any].asInstanceOf[Array[AnyRef]]
+      java.util.Arrays.sort(arr, ord.asInstanceOf[Ordering[Object]])
+      fromAnyRefArray(arr).asInstanceOf[this.type]
+    }
+  }
+
 }
 
 /** $factoryInfo

--- a/src/library/scala/collection/immutable/Seq.scala
+++ b/src/library/scala/collection/immutable/Seq.scala
@@ -37,7 +37,8 @@ trait Seq[+A] extends Iterable[A]
   override def toSeq: Seq[A] = this
   override def seq: Seq[A] = this
   protected[this] override def parCombiner = ParSeq.newCombiner[A] // if `immutable.SeqLike` gets introduced, please move this there!
-  override def sorted[B >: A](implicit ord: Ordering[B]) = {
+
+  override def sorted[B >: A](implicit ord: Ordering[B]): repr = {
     val len = this.length
     if (len < 2 || (len == 2 && ord.compare(apply(0), apply(1)) <= 0)) this
     else if (len == 2) {

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -201,6 +201,7 @@ import scala.language.implicitConversions
  *  @define orderDependentFold
  *  @define willTerminateInf Note: lazily evaluated; will terminate for infinite-sized collections.
  */
+@SerialVersionUID(4897901117128916054L)
 sealed abstract class Stream[+A] extends AbstractSeq[A]
                              with LinearSeq[A]
                              with GenericTraversableTemplate[A, Stream]

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -97,7 +97,11 @@ extends AbstractSeq[A]
       override val array = cloned
     }
   }
-
+  override private[scala] def fromAnyRefArray(arr: Array[AnyRef]) = {
+    new ArraySeq[A](length) {
+      override val array = arr
+    }
+  }
 }
 
 /** $factoryInfo

--- a/src/library/scala/collection/mutable/WrappedArray.scala
+++ b/src/library/scala/collection/mutable/WrappedArray.scala
@@ -18,7 +18,6 @@ import scala.reflect.ClassTag
 import scala.collection.generic._
 import scala.collection.parallel.mutable.ParArray
 import scala.util.hashing.MurmurHash3
-
 import java.util.Arrays
 
 /**
@@ -192,6 +191,15 @@ object WrappedArray {
     def apply(index: Int): T = array(index).asInstanceOf[T]
     def update(index: Int, elem: T) { array(index) = elem }
     override def hashCode = MurmurHash3.wrappedArrayHash(array)
+    override private[scala] def fromAnyRefArray(arr: Array[AnyRef]) = {
+      val raw: Array[T] = if (array.getClass.getComponentType == arr.getClass.getComponentType) arr.asInstanceOf[Array[T]]
+      else {
+        val r = java.lang.reflect.Array.newInstance(array.getClass.getComponentType, arr.length).asInstanceOf[Array[T]]
+        System.arraycopy(arr, 0, r, 0, arr.length)
+        r
+      }
+      new ofRef[T](raw)
+    }
   }
 
   final class ofByte(val array: Array[Byte]) extends WrappedArray[Byte] with Serializable {

--- a/test/files/run/t4332.scala
+++ b/test/files/run/t4332.scala
@@ -11,8 +11,8 @@ object Test extends DirectTest {
     checkViews()
   }
 
+  lazy val exempt = Set("view", "repr", "sliceWithKnownDelta", "sliceWithKnownBound", "transform", "filterImpl", "fromAnyRefArray")
   def isExempt(sym: Symbol) = {
-    val exempt = Set("view", "repr", "sliceWithKnownDelta", "sliceWithKnownBound", "transform", "filterImpl")
     (exempt contains sym.name.decoded)
   }
 

--- a/test/junit/scala/collection/immutable/ListTest.scala
+++ b/test/junit/scala/collection/immutable/ListTest.scala
@@ -170,4 +170,36 @@ class ListTest extends AllocationTest {
     exactAllocates(Sizes.list * 20 + Sizes.wrappedRefArray(20), "list  size 20")(
       List("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"))
   }
+
+  @Test def emptySortNonAllocating: Unit = {
+    val empty = List.empty[String]
+    val ord = Ordering[String]
+    assertSame(Nil, nonAllocating(empty.sorted(ord)))
+  }
+  @Test def singleSortNonAllocating: Unit = {
+    val single = List("abc")
+    val ord = Ordering[String]
+    assertSame(single, nonAllocating(single.sorted(ord)))
+  }
+  @Test def dualSortSmallAllocating: Unit = {
+    val small = List("AAA", "BBB")
+    val reversed = small.reverse
+    val ord = Ordering[String]
+    assertSame(small, exactAllocates(0)(small.sorted(ord)))
+    assertEquals(small, exactAllocates(48)(reversed.sorted(ord)))
+  }
+  @Test def genSortSmall3Allocating: Unit = {
+    val small = List("AAA", "BBB", "CCC")
+    val reversed = small.reverse
+    val ord = Ordering[String]
+    assertEquals(small, exactAllocates(120)(small.sorted(ord)))
+    assertEquals(small, exactAllocates(120)(reversed.sorted(ord)))
+  }
+  @Test def genSortSmall4Allocating: Unit = {
+    val small = List("AAA", "BBB", "CCC", "DDD")
+    val reversed = small.reverse
+    val ord = Ordering[String]
+    assertEquals(small, exactAllocates(144)(small.sorted(ord)))
+    assertEquals(small, exactAllocates(144)(reversed.sorted(ord)))
+  }
 }


### PR DESCRIPTION
Reduce some allocation in sorting for small cases where we only have a couple of elements to sort, which seems to happen a lot

Also for List, we can avoid the builder. We could apply this pattern to other cases