### PR TITLE
[nomerge] Convert implicit by-name error to a type error

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2378,10 +2378,6 @@ self =>
                 in.offset,
                 (if (mods.isMutable) "`var'" else "`val'") +
                 " parameters may not be call-by-name", skipIt = false)
-            else if (implicitmod != 0)
-              syntaxError(
-                in.offset,
-                "implicit parameters may not be call-by-name", skipIt = false)
             else bynamemod = Flags.BYNAMEPARAM
           }
           paramType()

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -302,6 +302,9 @@ trait ContextErrors {
       def InvalidConstructorDefError(ddef: Tree) =
         issueNormalTypeError(ddef, "constructor definition not allowed here")
 
+      def ImplicitByNameError(param: Symbol) =
+        issueSymbolTypeError(param, "implicit parameters may not be call-by-name")
+
       def DeprecatedParamNameError(param: Symbol, name: Name) =
         issueSymbolTypeError(param, "deprecated parameter name "+ name +" has to be distinct from any other parameter name (deprecated or not).")
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2336,9 +2336,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           StarWithDefaultError(meth)
 
         if (!isPastTyper) {
-          for (pp <- meth.paramss ; p <- pp){
+          for (pp <- meth.paramss; p <- pp) {
+            if (p.isImplicit && p.isByNameParam) ImplicitByNameError(p)
             for (n <- p.deprecatedParamName) {
-              if (mexists(meth.paramss)(p1 => p != p1 && (p1.name == n || p1.deprecatedParamName.exists(_ == n))))
+              if (mexists(meth.paramss)(p1 => p != p1 && (p1.name == n || p1.deprecatedParamName.contains(n))))
                 DeprecatedParamNameError(p, n)
             }
           }

--- a/test/files/neg/implicit-by-name.check
+++ b/test/files/neg/implicit-by-name.check
@@ -1,0 +1,4 @@
+implicit-by-name.scala:2: error: implicit parameters may not be call-by-name
+  implicit def reverseOrd[A](implicit ord: => Ordering[A]): Ordering[A] =
+                                      ^
+one error found

--- a/test/files/neg/implicit-by-name.scala
+++ b/test/files/neg/implicit-by-name.scala
@@ -1,0 +1,4 @@
+object Test {
+  implicit def reverseOrd[A](implicit ord: => Ordering[A]): Ordering[A] =
+    ord.reverse
+}


### PR DESCRIPTION
By-name implicits survive the parser so that a plugin can take over.
In particular a compiler plugin to ease Shapeless migration.