### PR TITLE
Hardcode macro annotation not expanded error for the common case

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1014,19 +1014,16 @@ trait ContextErrors {
       }
 
       def MacroAnnotationMustBeStaticError(clazz: Symbol) =
-        issueSymbolTypeError(clazz, s"macro annotation must extend scala.annotation.StaticAnnotation")
+        issueSymbolTypeError(clazz, "macro annotation must extend scala.annotation.StaticAnnotation")
 
       def MacroAnnotationCannotBeInheritedError(clazz: Symbol) =
-        issueSymbolTypeError(clazz, s"macro annotation cannot be @Inherited")
+        issueSymbolTypeError(clazz, "macro annotation cannot be @Inherited")
 
       def MacroAnnotationCannotBeMemberError(clazz: Symbol) =
-        issueSymbolTypeError(clazz, s"macro annotation cannot be a member of another class")
+        issueSymbolTypeError(clazz, "macro annotation cannot be a member of another class")
 
-      def MacroAnnotationNotExpandedMessage: String = {
-        "macro annotation could not be expanded " + (
-          if (!settings.YmacroAnnotations) "(since these are experimental, you must enable them with -Ymacro-annotations)"
-          else "(you cannot use a macro annotation in the same compilation run that defines it)")
-      }
+      def MacroAnnotationNotExpandedMessage: String =
+        "macro annotation could not be expanded (since these are experimental, you must enable them with -Ymacro-annotations)"
 
       def MacroAnnotationOnlyDefinitionError(ann: Tree) =
         issueNormalTypeError(ann, "macro annotations can only be put on definitions")

--- a/test/files/neg/macro-annot-not-expanded.check
+++ b/test/files/neg/macro-annot-not-expanded.check
@@ -1,0 +1,4 @@
+Test_2.scala:2: error: macro annotation could not be expanded (since these are experimental, you must enable them with -Ymacro-annotations)
+class Test
+      ^
+1 error

--- a/test/files/neg/macro-annot-not-expanded/Macros_1.scala
+++ b/test/files/neg/macro-annot-not-expanded/Macros_1.scala
@@ -1,0 +1,12 @@
+// scalac: -Ymacro-annotations
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+import scala.annotation.StaticAnnotation
+
+object Macros {
+  def annotImpl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = ???
+}
+
+class annot extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro Macros.annotImpl
+}

--- a/test/files/neg/macro-annot-not-expanded/Test_2.scala
+++ b/test/files/neg/macro-annot-not-expanded/Test_2.scala
@@ -1,0 +1,2 @@
+@annot
+class Test


### PR DESCRIPTION
The error is added as `compileTimeOnly` during definition time.
And a macro annotation cannot be defined without `-Ymacro-annotations`.
So the user never sees the recommentation to enable the flag.
Library authours that define macro annotations should be less confused.