### PR TITLE
Fix condition where subtraction can overflow

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -286,7 +286,7 @@ private sealed abstract class VectorImpl[+A](_prefix1: Arr1) extends Vector[A](_
     val hi = mmin(until, length)
     val newlen = hi - lo
     if(newlen == length) this
-    else if(newlen <= 0) Vector0
+    else if(hi <= lo) Vector0
     else slice0(lo, hi)
   }
 }

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -371,6 +371,11 @@ class VectorTest {
   }
 
   @Test
+  def testSlice3: Unit = {
+    assertEquals(Vector(1).slice(1, -2147483648), Vector())
+  }
+
+  @Test
   def testTail: Unit = for(size <- verySmallSizes) {
     var i = 0
     var v = Vector.range(0, size)


### PR DESCRIPTION
Fixes [this bug in 2.13.2](https://github.com/scala/bug/issues/11990):

```scala
scala> Vector(1).slice(1, -2147483648)
java.lang.OutOfMemoryError: Requested array size exceeds VM limit
  at java.util.Arrays.copyOfRange(Arrays.java:3482)
  at java.util.Arrays.copyOfRange(Arrays.java:3441)
  at scala.collection.immutable.Vector1.slice0(Vector.scala:377)
  at scala.collection.immutable.VectorImpl.slice(Vector.scala:290)
  at scala.collection.immutable.VectorImpl.slice(Vector.scala:282)
  ... 27 elided
```

I've seen this error in a couple of projects when updating to 2.13.2 and finally took a closer look at it today. Passing a large negative value of `until` may seem like a strange corner case, but it happens all the time when you're writing property-based tests and have `xs.slice(x, y + z)` somewhere and `y` and `z` are arbitrary positive `Int` values.