### PR TITLE
Java class literals on raw types are okay

### DIFF
--- a/test/files/pos/java-raw-class-literal/Ann.java
+++ b/test/files/pos/java-raw-class-literal/Ann.java
@@ -1,0 +1,3 @@
+public @interface Ann {
+  Class<?> as();
+}

--- a/test/files/pos/java-raw-class-literal/J.java
+++ b/test/files/pos/java-raw-class-literal/J.java
@@ -1,0 +1,3 @@
+public class J {
+  @Ann(as = java.util.List.class) public static void foo() {}
+}

--- a/test/files/pos/java-raw-class-literal/test.scala
+++ b/test/files/pos/java-raw-class-literal/test.scala
@@ -1,0 +1,3 @@
+class Test {
+  J.foo
+}


### PR DESCRIPTION
Since we started typecheking Java annotation arguments,
the enclosed test case runs afoul of:

```
test/files/pos/java-raw-class-literal/J.java:2: error: kinds of the type arguments (java.util.List) do not conform to the expected kinds of the type parameters (type T).
java.util.List's type parameters do not match type T's expected parameters:
trait List has one type parameter, but type T has none
  @Ann(as = java.util.List.class) public static void foo() {}
```

Skipping the kind bounds lets out this error:

```
J.java:2: error: kinds of the type arguments (java.util.List) do not conform to the expected kinds of the type parameters (type T).
java.util.List's type parameters do not match type T's expected parameters:
trait List has one type parameter, but type T has none
  @Ann(as = java.util.List.class) public static void foo() {}
```

This commit disabled the bounds check for `classOf` calls in
Java sources and converts the raw type to an existential
when typechecking the `classOf` call.