### PR TITLE
Increase laziness of #:: for LazyList

### DIFF
--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -1117,7 +1117,7 @@ object LazyList extends SeqFactory[LazyList] {
     /** Construct a LazyList consisting of a given first element followed by elements
       *  from another LazyList.
       */
-    def #:: [B >: A](elem: => B): LazyList[B] = newLL(sCons(elem, l()))
+    def #:: [B >: A](elem: => B): LazyList[B] = newLL(sCons(elem, newLL(l().state)))
     /** Construct a LazyList consisting of the concatenation of the given LazyList and
       *  another LazyList.
       */

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -163,7 +163,7 @@ class LazyListTest {
     cyc.tail.tail.head
     assertEquals("LazyList(1, 2, 3, <not computed>)", cyc.toString)
     cyc.tail.tail.tail.head
-    assertEquals("LazyList(1, 2, 3, 4, <cycle>)", cyc.toString)
+    assertEquals("LazyList(1, 2, 3, 4, <not computed>)", cyc.toString)
     cyc.tail.tail.tail.tail.head
     assertEquals("LazyList(1, 2, 3, 4, <cycle>)", cyc.toString)
   }


### PR DESCRIPTION
Change `#::` for `LazyList` so that the tail computation
is wrapped as a state computation for a new `LazyList`,
thus deferring its execution as long as possible.

Fixes scala/bug#11984

--------

Before (2.13.2-):

```scala
scala 2.13.2> 1 #:: { println("hey"); LazyList() }
val res4: scala.collection.immutable.LazyList[Int] = LazyList(<not computed>)

scala 2.13.2> res1.head
hey
val res5: Int = 1
```

After (2.13.3+):

```scala
scala 2.13.3> 1 #:: { println("hey"); LazyList() }
val res4: scala.collection.immutable.LazyList[Int] = LazyList(<not computed>)

scala 2.13.3> res1.head
val res5: Int = 1
```