### PR TITLE
Add ILoop.internalReplAutorunCode in REPL

### DIFF
--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -907,6 +907,12 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
     }
   }
 
+  /**
+   * Allows to specify custom code to run quietly in the preamble
+   * @return custom Scala code to run automatically at the startup of the REPL
+   */
+  protected def internalReplAutorunCode(): Seq[String] = Seq.empty 
+  
   /** Actions to cram in parallel while collecting first user input at prompt.
     * Run with output muted both from ILoop and from the intp reporter.
     */
@@ -915,6 +921,8 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
     // we can get at it in generated code.
     intp.quietBind(intp.namedParam[Repl](s"$$intp", intp)(tagOfRepl, classTag[Repl]))
 
+    internalReplAutorunCode().foreach(intp.quietRun)
+    
     // Auto-run code via some setting.
     (config.replAutorunCode.option
       flatMap (f => File(f).safeSlurp())


### PR DESCRIPTION
This PR proposes to add a new method `ILoop.internalReplAutorunCode`, which may be overridden by subclasses. It provides a straightforward way of adding custom code at the start up of the REPL. By default, it's empty.

For the context: I'm trying to adapt Spark 3.0 REPL to Scala 2.13 ([PR](https://github.com/apache/spark/pull/28545)). 

In Spark, there is `SparkILoop` class that inherits from Scala's `ILoop`. I got it working, except that seemingly there's no easy way of executing some initialization code needed by Spark. Currently, it is done by [overriding and customising](https://github.com/apache/spark/commit/2bc7b75537ec81184048738883b282e257cc58de) the `ILoop.process`method. This seems quite hard to maintain.

I tested this new method in the aforementioned [PR](https://github.com/apache/spark/pull/28545) and it solves the problem nicely.

Pinging @SethTisue as he seems to [approve](https://github.com/apache/spark/pull/28545#issuecomment-629392140) this idea :) 