### PR TITLE
Fix StackOverflow in getParts cause by existential types

### DIFF
--- a/test/files/neg/t11775.check
+++ b/test/files/neg/t11775.check
@@ -1,0 +1,11 @@
+t11775.scala:4: error: type mismatch;
+ found   : Test.K[Int]
+ required: Test.K[_ >: String]
+Note: Int <: Any, but class K is invariant in type T.
+You may wish to define T as +T instead. (SLS 4.5)
+  (new K[String]).compareTo(new K[Int])
+                            ^
+t11775.scala:7: error: value weight is not a member of Test.Event[_$4]
+    def compare(that: Event[_ <: T]): Int = weight - that.weight
+                                                          ^
+2 errors

--- a/test/files/neg/t11775.scala
+++ b/test/files/neg/t11775.scala
@@ -1,0 +1,9 @@
+object Test {
+  trait Cmp[T] { def compareTo(o: T): Int }
+  class K[T] extends Cmp[K[_ >: T]] { def compareTo(that: K[_ >: T]): Int = ??? }
+  (new K[String]).compareTo(new K[Int])
+
+  class Event[+T](weight: Int, data: T) extends Ordered[Event[_ <: T]] {
+    def compare(that: Event[_ <: T]): Int = weight - that.weight
+  }
+}


### PR DESCRIPTION
Existential types ruin structural equality.
Luckily we don't care about the quantified variables
except potentially their upper bounds for implicit scope.
So we just instantiate them to their upper bounds.