### PR TITLE
Syntax clean up indicated by -Xsource:3 [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -775,7 +775,7 @@ abstract class UnCurry extends InfoTransform
                       tpe
                   }
                 val info = info0.normalize
-                val tempValName = unit freshTermName (p.name + "$")
+                val tempValName = unit.freshTermName(s"${p.name.decoded}$$")
                 val newSym = dd.symbol.newTermSymbol(tempValName, p.pos, SYNTHETIC).setInfo(info)
                 atPos(p.pos)(ValDef(newSym, gen.mkAttributedCast(Ident(p.symbol), info)))
               }

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -646,9 +646,8 @@ trait MatchAnalysis extends MatchApproximation {
 
     def varAssignmentString(varAssignment: Map[Var, (Seq[Const], Seq[Const])]) =
       varAssignment.toSeq.sortBy(_._1.toString).map { case (v, (trues, falses)) =>
-         val assignment = "== "+ trues.mkString("(", ", ", ")") +"  != ("+ falses.mkString(", ") +")"
-         v +"(="+ v.path +": "+ v.staticTpCheckable +") "+ assignment
-       }.mkString("\n")
+        s"$v(=${v.path}: ${v.staticTpCheckable}) == ${trues.mkString("(", ", ", ")")}  != (${falses.mkString(", ")})"
+      }.mkString("\n")
 
     /**
      * The models we get from the DPLL solver need to be mapped back to counter examples.

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchWarnings.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchWarnings.scala
@@ -58,20 +58,19 @@ trait MatchWarnings {
       // Using an iterator so we can recognize the last case
       val it = cases.iterator
 
-      def addendum(pat: Tree) = {
+      def addendum(pat: Tree) =
         matchingSymbolInScope(pat) match {
           case NoSymbol   => ""
           case sym        =>
-            val desc = if (sym.isParameter) s"parameter ${sym.nameString} of" else sym + " in"
+            val desc = if (sym.isParameter) s"parameter ${sym.nameString} of" else s"$sym in"
             s"\nIf you intended to match against $desc ${sym.owner}, you must use backticks, like: case `${sym.nameString}` =>"
         }
-      }
 
       while (it.hasNext) {
         val cdef = it.next()
         // If a default case has been seen, then every succeeding case is unreachable.
         if (vpat != null)
-          typer.context.warning(cdef.body.pos, "unreachable code due to " + vpat + addendum(cdef.pat), WarningCategory.OtherMatchAnalysis) // TODO: make configurable whether this is an error
+          typer.context.warning(cdef.body.pos, s"unreachable code due to $vpat${addendum(cdef.pat)}", WarningCategory.OtherMatchAnalysis) // TODO: make configurable whether this is an error
         // If this is a default case and more cases follow, warn about this one so
         // we have a reason to mention its pattern variable name and any corresponding
         // symbol in scope.  Errors will follow from the remaining cases, at least

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -259,7 +259,7 @@ trait ContextErrors {
 
       // additional parentTypes errors
       def ConstrArgsInParentWhichIsTraitError(arg: Tree, parent: Symbol) =
-        issueNormalTypeError(arg, parent + " is a trait; does not take constructor arguments")
+        issueNormalTypeError(arg, s"$parent is a trait; does not take constructor arguments")
 
       def ConstrArgsInParentOfTraitError(arg: Tree, parent: Symbol) =
         issueNormalTypeError(arg, "parents of traits may not have parameters")
@@ -277,7 +277,7 @@ trait ContextErrors {
 
       // typedAppliedTypeTree
       def AppliedTypeNoParametersError(tree: Tree, errTpe: Type) = {
-        issueNormalTypeError(tree, errTpe + " does not take type parameters")
+        issueNormalTypeError(tree, s"$errTpe does not take type parameters")
         setError(tree)
       }
 
@@ -359,7 +359,7 @@ trait ContextErrors {
 
       //typedSuper
       def MixinMissingParentClassNameError(tree: Tree, mix: Name, clazz: Symbol) =
-        issueNormalTypeError(tree, mix+" does not name a parent class of "+clazz)
+        issueNormalTypeError(tree, s"$mix does not name a parent class of $clazz")
 
       def AmbiguousParentClassError(tree: Tree) =
         issueNormalTypeError(tree, "ambiguous parent class qualifier")
@@ -445,7 +445,7 @@ trait ContextErrors {
 
       //typedNew
       def IsAbstractError(tree: Tree, sym: Symbol) = {
-        issueNormalTypeError(tree, sym + " is abstract; cannot be instantiated")
+        issueNormalTypeError(tree, s"$sym is abstract; cannot be instantiated")
         setError(tree)
       }
 
@@ -454,7 +454,7 @@ trait ContextErrors {
       }
 
       def DoesNotConformToSelfTypeError(tree: Tree, sym: Symbol, tpe0: Type) = {
-        issueNormalTypeError(tree, sym + " cannot be instantiated because it does not conform to its self-type " + tpe0)
+        issueNormalTypeError(tree, s"$sym cannot be instantiated because it does not conform to its self-type $tpe0")
         setError(tree)
       }
 
@@ -483,7 +483,7 @@ trait ContextErrors {
       }
 
       def ReturnWithoutTypeError(tree: Tree, owner: Symbol) = {
-        issueNormalTypeError(tree, owner + " has return statement; needs result type")
+        issueNormalTypeError(tree, s"$owner has return statement; needs result type")
         setError(tree)
       }
 
@@ -673,11 +673,11 @@ trait ContextErrors {
         NormalTypeError(tree, "wrong number of arguments for "+ treeSymTypeMsg(fun))
 
       def ApplyWithoutArgsError(tree: Tree, fun: Tree) =
-        NormalTypeError(tree, fun.tpe+" does not take parameters")
+        NormalTypeError(tree, s"${fun.tpe} does not take parameters")
 
       // Dynamic
       def DynamicVarArgUnsupported(tree: Tree, name: Name) = {
-        issueNormalTypeError(tree, name + " does not support passing a vararg parameter")
+        issueNormalTypeError(tree, s"$name does not support passing a vararg parameter")
         setError(tree)
       }
 
@@ -706,10 +706,10 @@ trait ContextErrors {
                    "\n of the mixin " + mixin)
 
       def ParentNotATraitMixinError(parent: Tree, mixin: Symbol) =
-        NormalTypeError(parent, mixin+" needs to be a trait to be mixed in")
+        NormalTypeError(parent, s"$mixin needs to be a trait to be mixed in")
 
       def ParentFinalInheritanceError(parent: Tree, mixin: Symbol) =
-        NormalTypeError(parent, "illegal inheritance from final "+mixin)
+        NormalTypeError(parent, s"illegal inheritance from final $mixin")
 
       def ParentSelfTypeConformanceError(parent: Tree, selfType: Type) =
         NormalTypeError(parent,
@@ -717,7 +717,7 @@ trait ContextErrors {
           parent +"'s selftype "+parent.tpe.typeOfThis)
 
       def ParentInheritedTwiceError(parent: Tree, parentSym: Symbol) =
-        NormalTypeError(parent, parentSym+" is inherited twice")
+        NormalTypeError(parent, s"$parentSym is inherited twice")
 
       //adapt
       def MissingArgsForMethodTpeError(tree: Tree, meth: Symbol) = {
@@ -736,14 +736,13 @@ trait ContextErrors {
       }
 
       def MissingTypeParametersError(tree: Tree) = {
-        issueNormalTypeError(tree, tree.symbol+" takes type parameters")
+        issueNormalTypeError(tree, s"${tree.symbol} takes type parameters")
         setError(tree)
       }
 
       def KindArityMismatchError(tree: Tree, pt: Type) = {
         issueNormalTypeError(tree,
-          tree.tpe+" takes "+countElementsAsString(tree.tpe.typeParams.length, "type parameter")+
-          ", expected: "+countAsString(pt.typeParams.length))
+          s"${tree.tpe} takes ${countElementsAsString(tree.tpe.typeParams.length, "type parameter")}, expected: ${countAsString(pt.typeParams.length)}")
         setError(tree)
       }
 
@@ -770,7 +769,7 @@ trait ContextErrors {
       }
 
       def ConstructorPrefixError(tree: Tree, restpe: Type) = {
-        issueNormalTypeError(tree, restpe.prefix+" is not a legal prefix for a constructor")
+        issueNormalTypeError(tree, s"${restpe.prefix} is not a legal prefix for a constructor")
         setError(tree)
       }
 
@@ -936,15 +935,12 @@ trait ContextErrors {
       }
 
       def MacroFreeSymbolError(expandee: Tree, sym: FreeSymbol) = {
-        def template(kind: String) = (
-            s"Macro expansion contains free $kind variable %s. Have you forgotten to use %s? "
-          + s"If you have troubles tracking free $kind variables, consider using -Xlog-free-${kind}s"
+        val kind = sym.name.nameKind
+        val name = s"${sym.name} ${sym.origin}"
+        val forgotten = if (sym.isTerm) "splice when splicing this variable into a reifee" else "c.WeakTypeTag annotation for this type parameter"
+        macroExpansionError(expandee,
+          s"Macro expansion contains free $kind variable $name. Have you forgotten to use $forgotten? If you have troubles tracking free $kind variables, consider using -Xlog-free-${kind}s"
         )
-        val forgotten = (
-          if (sym.isTerm) "splice when splicing this variable into a reifee"
-          else "c.WeakTypeTag annotation for this type parameter"
-        )
-        macroExpansionError(expandee, template(sym.name.nameKind).format(sym.name + " " + sym.origin, forgotten))
       }
 
       def MacroExpansionHasInvalidTypeError(expandee: Tree, expanded: Any) = {
@@ -957,7 +953,7 @@ trait ContextErrors {
           s"macro must return a compiler-specific $expected; returned value is " + (
             if (expanded == null) "null"
             else if (isPathMismatch) s"$actual, but it doesn't belong to this compiler's universe"
-            else "of " + expanded.getClass
+            else s"of ${expanded.getClass}"
         ))
       }
 
@@ -1288,7 +1284,7 @@ trait ContextErrors {
       }
 
       def GetterDefinedTwiceError(getter: Symbol) =
-        issueSymbolTypeError(getter, getter+" is defined twice")
+        issueSymbolTypeError(getter, s"$getter is defined twice")
 
       def ValOrVarWithSetterSuffixError(tree: Tree) =
         issueNormalTypeError(tree, "Names of vals or vars may not end in `_=`")
@@ -1311,10 +1307,10 @@ trait ContextErrors {
         val s3 = if (prevSym.isCase) "case class " + prevSym.name else "" + prevSym
         val where = if (currentSym.isTopLevel != prevSym.isTopLevel) {
                       val inOrOut = if (prevSym.isTopLevel) "outside of" else "in"
-                      " %s package object %s".format(inOrOut, ""+prevSym.effectiveOwner.name)
+                      s" $inOrOut package object ${prevSym.effectiveOwner.name}"
                     } else ""
 
-        issueSymbolTypeError(currentSym, prevSym.name + " is already defined as " + s2 + s3 + where)
+        issueSymbolTypeError(currentSym, s"${prevSym.name} is already defined as $s2$s3$where")
       }
 
       def MissingParameterOrValTypeError(vparam: Tree) =

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1852,11 +1852,10 @@ trait Contexts { self: Analyzer =>
       }
     }
 
-    private def selectorString(s: ImportSelector): String = {
+    private def selectorString(s: ImportSelector): String =
       if (s.isWildcard) "_"
-      else if (s.isRename) s.name + " => " + s.rename
-      else "" + s.name
-    }
+      else if (s.isRename) s"${s.name} => ${s.rename}"
+      else s.name.decoded
 
     /** Optionally record that a selector was used to import the given symbol. */
     def recordUsage(sel: ImportSelector, result: Symbol): Unit = {

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -302,10 +302,7 @@ trait Implicits {
       import scala.util.hashing.MurmurHash3._
       finalizeHash(mix(mix(productSeed, name.##), sym.##), 2)
     }
-    override def toString = (
-      if (tpeCache eq null) name + ": ?"
-      else name + ": " + tpe
-    )
+    override def toString = s"$name: ${ if (tpeCache eq null) "?" else tpe.toString }"
   }
 
   /** A class which is used to track pending implicits to prevent infinite implicit searches.
@@ -447,7 +444,7 @@ trait Implicits {
 
     @inline final def failure(what: Any, reason: => String, pos: Position = this.pos): SearchResult = {
       if (settings.XlogImplicits)
-        reporter.echo(pos, what+" is not a valid implicit value for "+pt+" because:\n"+reason)
+        reporter.echo(pos, s"$what is not a valid implicit value for $pt because:\n$reason")
       SearchFailure
     }
     /** Is implicit info `info1` better than implicit info `info2`?

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -354,10 +354,10 @@ abstract class RefChecks extends Transform {
 
         def overrideErrorConcreteMissingOverride() = {
           if (isNeitherInClass && !(otherClass isSubClass memberClass))
-            emitOverrideError(clazz + " inherits conflicting members:\n"
-                               + indent + infoStringWithLocation(other) + " and\n"
-                               + indent + infoStringWithLocation(member) + "\n"
-                               + indent + s"(note: this can be resolved by declaring an `override` in $clazz.)")
+            emitOverrideError(sm"""|$clazz inherits conflicting members:
+                                   |$indent${infoStringWithLocation(other)} and
+                                   |$indent${infoStringWithLocation(member)}
+                                   |$indent(note: this can be resolved by declaring an `override` in $clazz.)""")
           else
             overrideErrorWithMemberInfo("`override` modifier required to override concrete member:")
         }
@@ -545,8 +545,8 @@ abstract class RefChecks extends Transform {
         def abstractClassError(mustBeMixin: Boolean, msg: String): Unit = {
           def prelude = (
             if (clazz.isAnonymousClass || clazz.isModuleClass) "object creation impossible."
-            else if (mustBeMixin) clazz + " needs to be a mixin."
-            else clazz + " needs to be abstract."
+            else if (mustBeMixin) s"$clazz needs to be a mixin."
+            else s"$clazz needs to be abstract."
           )
 
           if (abstractErrors.isEmpty) abstractErrors ++= List(prelude, msg)
@@ -984,7 +984,7 @@ abstract class RefChecks extends Transform {
       def onSyms[T](f: List[Symbol] => T) = f(List(receiver, actual))
 
       // @MAT normalize for consistency in error message, otherwise only part is normalized due to use of `typeSymbol`
-      def typesString = normalizeAll(qual.tpe.widen)+" and "+normalizeAll(other.tpe.widen)
+      def typesString = s"${normalizeAll(qual.tpe.widen)} and ${normalizeAll(other.tpe.widen)}"
 
       // TODO: this should probably be used in more type comparisons in checkSensibleEquals
       def erasedClass(tp: Type) = erasure.javaErasure(tp).typeSymbol

--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -179,7 +179,7 @@ trait SyntheticMethods extends ast.TreeDSL {
      * - asInstanceOf if no equality checks need made (see scala/bug#9240, scala/bug#10361)
      */
     def equalsCore(eqmeth: Symbol, accessors: List[Symbol]) = {
-      val otherName = freshTermName(clazz.name + "$")(freshNameCreatorFor(context))
+      val otherName = freshTermName(s"${clazz.name}$$")(freshNameCreatorFor(context))
       val otherSym  = eqmeth.newValue(otherName, eqmeth.pos, SYNTHETIC) setInfo clazz.tpe
       val pairwise  = {
         //compare primitive fields first, slow equality checks of non-primitive fields can be skipped when primitives differ
@@ -428,9 +428,9 @@ trait SyntheticMethods extends ast.TreeDSL {
         val i = original.owner.caseFieldAccessors.indexOf(original)
         def freshAccessorName = {
           devWarning(s"Unable to find $original among case accessors of ${original.owner}: ${original.owner.caseFieldAccessors}")
-          freshTermName(original.name + "$")(freshNameCreatorFor(context))
+          freshTermName(s"${original.name}$$")(freshNameCreatorFor(context))
         }
-        def nameSuffixedByParamIndex = original.name.append(nme.CASE_ACCESSOR + "$" + i).toTermName
+        def nameSuffixedByParamIndex = original.name.append(s"${nme.CASE_ACCESSOR}$$${i}").toTermName
         val newName = if (i < 0) freshAccessorName else nameSuffixedByParamIndex
         val newAcc = deriveMethod(ddef.symbol, name => newName) { newAcc =>
           newAcc.makePublic

--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -56,19 +56,16 @@ abstract class TreeCheckers extends Analyzer {
 
   private def clean_s(s: String) = s.replace("scala.collection.", "s.c.")
   private def typestr(x: Type)    = " (tpe = " + x + ")"
-  private def treestr(t: Tree)    = t + " [" + classString(t) + "]" + typestr(t.tpe)
-  private def ownerstr(s: Symbol) = "'" + s + "'" + s.locationString
-  private def wholetreestr(t: Tree) = nodeToString(t) + "\n"
-  private def truncate(str: String, len: Int): String = (
-    if (str.length <= len) str
-    else (str takeWhile (_ != '\n') take len - 3) + "..."
-  )
+  private def treestr(t: Tree)    = s"$t [${classString(t)}]${typestr(t.tpe)}"
+  private def ownerstr(s: Symbol) = s"'$s'${s.locationString}"
+  private def wholetreestr(t: Tree) = s"${nodeToString(t)}\n"
+  private def truncate(str: String, len: Int): String = if (str.length <= len) str else s"${str.takeWhile(_ != '\n').take(len - 3)}..."
   private def signature(sym: Symbol) = clean_s(sym match {
     case null           => "null"
-    case _: ClassSymbol => sym.name + ": " + sym.tpe_*
+    case _: ClassSymbol => s"${sym.name}: ${sym.tpe_*}"
     case _              => sym.defString
   })
-  private def classString(x: Any) = x match {
+  private def classString(x: Any): String = x match {
     case null      => ""
     case t: Tree   => t.shortClass
     case s: Symbol => s.shortSymbolClass
@@ -315,10 +312,7 @@ abstract class TreeCheckers extends Analyzer {
                   if (accessed != NoSymbol) {
                     val agetter = accessed.getterIn(sym.owner)
                     val asetter = accessed.setterIn(sym.owner)
-
-                    assertFn(agetter == sym || asetter == sym,
-                      sym + " is getter or setter, but accessed sym " + accessed + " shows " + agetter + " and " + asetter
-                    )
+                    assertFn(agetter == sym || asetter == sym, s"$sym is getter or setter, but accessed sym $accessed shows $agetter and $asetter")
                   }
               }
             }
@@ -351,14 +345,13 @@ abstract class TreeCheckers extends Analyzer {
           checkSym(tree)
 
           tree match {
-            case x: PackageDef    =>
-              if ((sym.ownerChain contains currentOwner) || currentOwner.isEmptyPackageClass) ()
-              else fail(sym + " owner chain does not contain currentOwner " + currentOwner + sym.ownerChain)
+            case _: PackageDef if sym.ownerChain.contains(currentOwner) || currentOwner.isEmptyPackageClass => ()
+            case _: PackageDef => fail(s"$sym owner chain does not contain currentOwner ${currentOwner}${sym.ownerChain}")
             case _ =>
               def cond(s: Symbol) = !s.isTerm || s.isMethod || s == sym.owner
 
               if (sym.owner != currentOwner) {
-                val expected = currentOwner.ownerChain find (x => cond(x)) getOrElse { fail("DefTree can't find owner: ") ; NoSymbol }
+                val expected = currentOwner.ownerChain.find(cond(_)).getOrElse { fail("DefTree can't find owner: ") ; NoSymbol }
                 if (sym.owner != expected)
                   fail(sm"""|
                             | currentOwner chain: ${currentOwner.ownerChain take 3 mkString " -> "}

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -350,7 +350,7 @@ trait TypeDiagnostics {
       else
         "`case _: " + (clazz.typeParams match {
           case Nil  => "" + clazz.name
-          case xs   => xs.map(_ => "_").mkString(clazz.name + "[", ",", "]")
+          case xs   => xs.map(_ => "_").mkString(s"${clazz.name}[", ",", "]")
         })+ "`"
 
     if (!clazz.exists) ""

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -756,13 +756,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       isPastTyper || {
         val nestedOwners =
           featureTrait.owner.ownerChain.takeWhile(_ != languageFeatureModule.moduleClass).reverse
-        val featureName = (nestedOwners map (_.name + ".")).mkString + featureTrait.name
+        val featureName = nestedOwners.map(s => s"${s.name}.").mkString + featureTrait.name
         def action(): Boolean = {
           def hasImport = inferImplicitByType(featureTrait.tpe, context).isSuccess
-          def hasOption = settings.language contains featureName
+          def hasOption = settings.language.contains(featureName)
           hasOption || hasImport || {
             val Some(AnnotationInfo(_, List(Literal(Constant(featureDesc: String)), Literal(Constant(required: Boolean))), _)) =
-              featureTrait getAnnotation LanguageFeatureAnnot
+              featureTrait.getAnnotation(LanguageFeatureAnnot)
             context.featureWarning(pos, featureName, featureDesc, featureTrait, construct, required)
             false
           }
@@ -5606,7 +5606,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             AppliedTypeNoParametersError(tree, tpt1.tpe)
           } else {
             //Console.println("\{tpt1}:\{tpt1.symbol}:\{tpt1.symbol.info}")
-            if (settings.debug) Console.println(tpt1+":"+tpt1.symbol+":"+tpt1.symbol.info)//debug
+            if (settings.debug) Console.println(s"$tpt1:${tpt1.symbol}:${tpt1.symbol.info}")//debug
             AppliedTypeWrongNumberOfArgsError(tree, tpt1, tparams)
           }
         }

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -454,7 +454,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
                 debugLog("ask finished"+timeStep)
                 interruptsEnabled = true
               }
-            loop = true; break
+            loop = true; break()
             case _ =>
           }
 

--- a/src/library/scala/sys/process/ProcessBuilderImpl.scala
+++ b/src/library/scala/sys/process/ProcessBuilderImpl.scala
@@ -33,7 +33,7 @@ private[process] trait ProcessBuilderImpl {
     override def canPipeTo = true
   }
 
-  private[process] class URLInput(url: URL) extends IStreamBuilder(url.openStream, url.toString)
+  private[process] class URLInput(url: URL) extends IStreamBuilder(url.openStream(), url.toString)
   private[process] class FileInput(file: File) extends IStreamBuilder(new FileInputStream(file), file.getAbsolutePath)
   private[process] class FileOutput(file: File, append: Boolean) extends OStreamBuilder(new FileOutputStream(file, append), file.getAbsolutePath)
 
@@ -85,10 +85,10 @@ private[process] trait ProcessBuilderImpl {
       val inThread =
         if (inherit || (writeInput eq BasicIO.connectNoOp)) null
         else Spawn("Simple-input", daemon = true)(writeInput(process.getOutputStream))
-      val outThread = Spawn("Simple-output", daemonizeThreads)(processOutput(process.getInputStream))
+      val outThread = Spawn("Simple-output", daemonizeThreads)(processOutput(process.getInputStream()))
       val errorThread =
         if (p.redirectErrorStream) Nil
-        else List(Spawn("Simple-error", daemonizeThreads)(processError(process.getErrorStream)))
+        else List(Spawn("Simple-error", daemonizeThreads)(processError(process.getErrorStream())))
 
       new SimpleProcess(process, inThread, outThread :: errorThread)
     }

--- a/src/partest/scala/tools/partest/nest/Opt.scala
+++ b/src/partest/scala/tools/partest/nest/Opt.scala
@@ -75,7 +75,7 @@ object Opt {
     def --|                             = parsed get opt
     def --^[T: FromString]              = {
       val fs = implicitly[FromString[T]]
-      --| map { arg =>
+      --|.map { arg =>
         if (fs isDefinedAt arg) fs(arg)
         else failOption(arg, "not a " + fs.targetString)
       }

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3797,7 +3797,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
   }
 
   /** A class for type histories */
-  private final case class TypeHistory private (private var _validFrom: Period, private var _info: Type, private var _prev: TypeHistory) {
+  private final case class TypeHistory protected (private var _validFrom: Period, private var _info: Type, private var _prev: TypeHistory) {
     assert((prev eq null) || phaseId(validFrom) > phaseId(prev.validFrom), this)
     assert(validFrom != NoPeriod, this)
 

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -325,7 +325,7 @@ trait Collections {
 
       def hasNext: Boolean = {
         advanceHead()
-        ! head.isEmpty
+        !head.isEmpty
       }
 
       def next(): C = {

--- a/src/reflect/scala/reflect/internal/util/OwnerOnlyChmod.scala
+++ b/src/reflect/scala/reflect/internal/util/OwnerOnlyChmod.scala
@@ -38,7 +38,7 @@ object OwnerOnlyChmod {
 
       val acls = {
         val builder = AclEntry.newBuilder
-        builder.setPrincipal(view.getOwner)
+        builder.setPrincipal(view.getOwner())
         builder.setPermissions(AclEntryPermission.values(): _*)
         builder.setType(AclEntryType.ALLOW)
         val entry = builder.build

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -798,7 +798,7 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
         label = name
         withFile(name) { f =>
           shouldReplay = Some(s":paste $arg")
-          val s = f.slurp.trim
+          val s = f.slurp().trim()
           if (s.isEmpty) echo(s"File contains no code: $f")
           else echo(s"Pasting file $f...")
           s
@@ -952,7 +952,7 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
         throw new InterruptedException
       }
 
-      echoOff { interpretPreamble }
+      echoOff { interpretPreamble() }
     })
 
     // start full loop (if initialization was successful)

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
@@ -187,7 +187,7 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
 
       // for errors in synthetic code, don't remove wrapping so we can see what's really going on
       def printLineContent() = printMessage(indentation + posIn.lineContent)
-      if (isSynthetic) withoutUnwrapping(printLineContent) else printLineContent
+      if (isSynthetic) withoutUnwrapping(printLineContent()) else printLineContent()
 
       printMessage(indentation + posIn.lineCaret)
 

--- a/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -28,8 +28,8 @@ trait ReplGlobal extends Global {
   }
 
   override def findMacroClassLoader(): ClassLoader = {
-    val loader = super.findMacroClassLoader
-    analyzer.macroLogVerbose("macro classloader: initializing from a REPL classloader: %s".format(classPath.asURLs))
+    val loader = super.findMacroClassLoader()
+    analyzer.macroLogVerbose(s"macro classloader: initializing from a REPL classloader: ${classPath.asURLs}")
     val virtualDirectory = analyzer.globalSettings.outputDirs.getSingleOutput.get
     new AbstractFileClassLoader(virtualDirectory, loader) {}
   }

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -701,7 +701,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
           }
       else {
         // no class inheritance at this point
-        assert(inOriginalOwner(bSym, inTpl), bSym + " in " + inTpl)
+        assert(inOriginalOwner(bSym, inTpl), s"$bSym in $inTpl")
         Some(createDocTemplate(bSym, inTpl))
       }
     }

--- a/src/scalap/scala/tools/scalap/scalax/rules/Memoisable.scala
+++ b/src/scalap/scala/tools/scalap/scalax/rules/Memoisable.scala
@@ -47,15 +47,12 @@ trait DefaultMemoisable extends Memoisable {
   protected def compute[A](key: AnyRef, a: => A): Any = a match {
     case success: Success[_, _] => onSuccess(key, success); success
     case other =>
-      if(DefaultMemoisable.debug) println(key + " -> " + other)
+      if (DefaultMemoisable.debug) println(s"$key -> $other")
       other
   }
 
   protected def onSuccess[S, T](key: AnyRef,  result: Success[S, T]): Unit =  {
     val Success(out, t) = result
-    if(DefaultMemoisable.debug) println(key + " -> " + t + " (" + out + ")")
+    if (DefaultMemoisable.debug) println(s"$key -> $t ($out)")
   }
 }
-
-
-

--- a/test/junit/scala/SerializationStabilityTest.scala
+++ b/test/junit/scala/SerializationStabilityTest.scala
@@ -33,9 +33,7 @@ object SerializationStability {
     printBase64Binary(bos.toByteArray())
   }
 
-  def amend(file: File)(f: String => String): Unit = {
-    file.writeAll(f(file.slurp))
-  }
+  def amend(file: File)(f: String => String): Unit = file.writeAll(f(file.slurp()))
   def quote(s: String) = List("\"", s, "\"").mkString
 
   def patch(file: File, line: Int, prevResult: String, result: String): Unit = {

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -18,7 +18,7 @@ class IteratorTest {
     var counter = 0
     val it = new Iterator[Int] { var i = 0 ; def hasNext = { counter = i; true } ; def next() = { i += 1; i } }
     val slidingIt = it sliding 2
-    slidingIt.next
+    slidingIt.next()
     assertEquals("Counter should be one, that means we didn't look further than needed", 1, counter)
   }
 
@@ -26,7 +26,7 @@ class IteratorTest {
     var counter = 0
     def it = new Iterator[Int] { var i = 0 ; def hasNext = { counter = i; true } ; def next() = { i += 1; i } }
     val slidingIt = it sliding 2 withPadding -1
-    slidingIt.next
+    slidingIt.next()
     assertEquals("Counter should be one, that means we didn't look further than needed", 1, counter)
   }
 
@@ -272,13 +272,13 @@ class IteratorTest {
     assertEquals(8, counter)
     // JoinIterator
     counter = 0
-    res.clear
+    res.clear()
     (it ++ it).foreach(res += _)
     assertSameElements(exp, res)
     assertEquals(8, counter) // was 17
     // ConcatIterator
     counter = 0
-    res.clear
+    res.clear()
     (Iterator.empty ++ it ++ it).foreach(res += _)
     assertSameElements(exp, res)
     assertEquals(8, counter) // was 14

--- a/test/junit/scala/collection/ReusableBuildersTest.scala
+++ b/test/junit/scala/collection/ReusableBuildersTest.scala
@@ -12,10 +12,10 @@ class ReusableBuildersTest {
   def test_SI8648(): Unit = {
     val b = collection.mutable.HashSet.newBuilder[Int]
     b += 3
-    b.clear
+    b.clear()
     assert(!b.isInstanceOf[collection.mutable.ReusableBuilder[_,_]])
     assert(b.isInstanceOf[collection.mutable.GrowableBuilder[_,_]])
-    assert(b.result == Set[Int]())
+    assert(b.result() == Set[Int]())
   }
 
   // ArrayBuilders ARE reusable, regardless of whether they returned their internal array or not
@@ -23,13 +23,13 @@ class ReusableBuildersTest {
   def test_SI9564(): Unit = {
     val b = Array.newBuilder[Float]
     b += 3f
-    val three = b.result
-    b.clear
+    val three = b.result()
+    b.clear()
     b ++= (1 to 16).map(_.toFloat)
     val sixteen = b.result
-    b.clear
+    b.clear()
     b += 0f
-    val zero = b.result
+    val zero = b.result()
     assert(b.isInstanceOf[collection.mutable.ReusableBuilder[_,_]])
     assert(three.toList == 3 :: Nil)
     assert(sixteen.toList == (1 to 16))

--- a/test/junit/scala/collection/SetMapConsistencyTest.scala
+++ b/test/junit/scala/collection/SetMapConsistencyTest.scala
@@ -80,11 +80,11 @@ class SetMapConsistencyTest {
       case _ => oor("get", n)
     }
     override def fiddlers = 2
-    override def fiddle(n: Int): Unit = { n match {
+    override def fiddle(n: Int): Unit = n match {
       case 0 => m = arm.clone
-      case 1 => arm.repack
+      case 1 => arm.repack()
       case _ => oor("fiddle", n)
-    }}
+    }
   }
   
   def boxMjm = new BoxMutableMap[Long, cm.LongMap[Int]](new cm.LongMap[Int](_ => -1), "mutable.LongMap") {
@@ -102,7 +102,7 @@ class SetMapConsistencyTest {
     override def fiddlers = 2
     override def fiddle(n: Int): Unit = { n match {
       case 0 => m = lm.clone
-      case 1 => lm.repack
+      case 1 => lm.repack()
       case _ => oor("fiddle", n)
     }}
   }
@@ -265,7 +265,7 @@ class SetMapConsistencyTest {
           n
         })
       }
-      if (rn.nextBoolean) {
+      if (rn.nextBoolean()) {
         val idx = rn.nextInt(keys.length)
         val key = keys(rn.nextInt(keys.length))
         val n1 = rn.nextInt(map1.adders)
@@ -299,7 +299,7 @@ class SetMapConsistencyTest {
           }
           case _ => None
         }
-        throw new Exception(s"Disagreement after ${what.result} between ${map1.title} and ${map2.title} on get of ${keys(j)} (#$j) on step $i: $g1 != $g2 using methods $gn1 and $gn2 resp.; in full\n$map1\n$map2\n$temp")
+        throw new Exception(s"Disagreement after ${what.result()} between ${map1.title} and ${map2.title} on get of ${keys(j)} (#$j) on step $i: $g1 != $g2 using methods $gn1 and $gn2 resp.; in full\n$map1\n$map2\n$temp")
       }
     }
     true
@@ -460,7 +460,7 @@ class SetMapConsistencyTest {
     def ihm: M = ci.HashMap.empty[Int, Boolean] ++ manyKVs
     val densities = List(0, 0.05, 0.2, 0.5, 0.8, 0.95, 1)
     def repeat = rn.nextInt(100) < 33
-    def pick(m: M, density: Double) = m.keys.filter(_ => rn.nextDouble < density).toSet
+    def pick(m: M, density: Double) = m.keys.filter(_ => rn.nextDouble() < density).toSet
     def test: Boolean =
       (1 to 100).forall { _ =>
         var ms = List(mhm, mohm, ihm)
@@ -481,11 +481,11 @@ class SetMapConsistencyTest {
   def testSI8213(): Unit = {
     val am = new scala.collection.mutable.AnyRefMap[String, Int]
     for (i <- 0 until 1024) am += i.toString -> i
-    am.getOrElseUpdate("1024", { am.clear; -1 })
+    am.getOrElseUpdate("1024", { am.clear(); -1 })
     assert(am == scala.collection.mutable.AnyRefMap("1024" -> -1))
     val lm = new scala.collection.mutable.LongMap[Int]
     for (i <- 0 until 1024) lm += i.toLong -> i
-    lm.getOrElseUpdate(1024, { lm.clear; -1 })
+    lm.getOrElseUpdate(1024, { lm.clear(); -1 })
     assert(lm == scala.collection.mutable.LongMap(1024L -> -1))
   }
   
@@ -499,7 +499,7 @@ class SetMapConsistencyTest {
       it.hasNext
       xs.clear()
     
-      if (it.hasNext) Some(it.next)
+      if (it.hasNext) Some(it.next())
       else None
     }
     assert(f() match {

--- a/test/junit/scala/collection/immutable/RangeConsistencyTest.scala
+++ b/test/junit/scala/collection/immutable/RangeConsistencyTest.scala
@@ -52,30 +52,30 @@ class RangeConsistencyTest {
   def rangeChurnTest(): Unit = {
     val rn = new Random(4370)
     for (i <- 0 to 10000) { control.Breaks.breakable {
-      val start = rn.nextInt
-      val end = rn.nextInt
+      val start = rn.nextInt()
+      val end = rn.nextInt()
       val step = rn.nextInt(4) match {
         case 0 => 1
         case 1 => -1
         case 2 => (rn.nextInt(11)+2)*(2*rn.nextInt(2)+1)
-        case 3 => var x = rn.nextInt; while (x==0) x = rn.nextInt; x
+        case 3 => var x = rn.nextInt(); while (x==0) x = rn.nextInt(); x
       }
-      val r = if (rn.nextBoolean) Range.inclusive(start, end, step) else Range(start, end, step)
+      val r = if (rn.nextBoolean()) Range.inclusive(start, end, step) else Range(start, end, step)
       
       try { r.length }
-      catch { case iae: IllegalArgumentException => control.Breaks.break }
+      catch { case iae: IllegalArgumentException => control.Breaks.break() }
       
       val lpuff = rn.nextInt(4) match {
         case 0 => 1L
         case 1 => rn.nextInt(11)+2L
         case 2 => 1L << rn.nextInt(60)
-        case 3 => math.max(1L, math.abs(rn.nextLong))
+        case 3 => math.max(1L, math.abs(rn.nextLong()))
       }
       val lstride = rn.nextInt(4) match {
         case 0 => lpuff
         case 1 => 1L
         case 2 => 1L << rn.nextInt(60)
-        case 3 => math.max(1L, math.abs(rn.nextLong))
+        case 3 => math.max(1L, math.abs(rn.nextLong()))
       }
       val lr = r2nr[Long](
         r, lpuff, lstride, 
@@ -93,7 +93,7 @@ class RangeConsistencyTest {
       
       val bipuff = rn.nextInt(3) match {
         case 0 => BigInt(1)
-        case 1 => BigInt(rn.nextLong) + Long.MaxValue + 2
+        case 1 => BigInt(rn.nextLong()) + Long.MaxValue + 2
         case 2 => BigInt("1" + "0"*(rn.nextInt(100)+1))
       }
       val bistride = rn.nextInt(3) match {

--- a/test/junit/scala/collection/immutable/RangeTest.scala
+++ b/test/junit/scala/collection/immutable/RangeTest.scala
@@ -59,7 +59,7 @@ class RangeTest {
     val it = test.iterator
     it.drop(1)
 
-    assertEquals(11, it.next)
+    assertEquals(11, it.next())
   }
   @Test
   def dropToEnd2(): Unit = {
@@ -67,7 +67,7 @@ class RangeTest {
     val it = test.iterator
     it.drop(0)
 
-    assertEquals(10, it.next)
+    assertEquals(10, it.next())
   }
 
   @Test(expected = classOf[IllegalArgumentException])

--- a/test/junit/scala/collection/immutable/StreamTest.scala
+++ b/test/junit/scala/collection/immutable/StreamTest.scala
@@ -234,7 +234,7 @@ class StreamTest {
     val s2 = it1.toStream
     s2.iterator.next()
     assertEquals(1, it1.current)
-    s2.flatMap { i => (if(i < 3) None else Some(i)): Option[Int] }.iterator.next
+    s2.flatMap { i => (if(i < 3) None else Some(i)): Option[Int] }.iterator.next()
     assertEquals(3, it1.current)
     s2.flatMap { i => (if(i < 5) None else Some(i)): Option[Int] }.headOption
     assertEquals(5, it1.current)

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -113,23 +113,23 @@ class VectorTest {
       {
         var it = underlying.iterator.drop(start)
         assertFalse(it.hasNext)
-        intercept[NoSuchElementException](it.next)
+        intercept[NoSuchElementException](it.next())
         it = it.drop(0)
         assertFalse(it.hasNext)
         it = it.drop(1)
         assertFalse(it.hasNext)
         it = it.drop(99)
         assertFalse(it.hasNext)
-        intercept[NoSuchElementException](it.next)
+        intercept[NoSuchElementException](it.next())
       }
 
       {
         var it = underlying.iterator.drop(start)
-        intercept[NoSuchElementException](it.next)
+        intercept[NoSuchElementException](it.next())
         it = it.drop(0)
         it = it.drop(1)
         it = it.drop(99)
-        intercept[NoSuchElementException](it.next)
+        intercept[NoSuchElementException](it.next())
       }
     }
   }

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -345,7 +345,7 @@ class ArrayBufferTest {
   @Test def t11417_sortInPlace(): Unit = {
     val a = ArrayBuffer(5,4,3,2,1)
     a.trimEnd(2)
-    a.sortInPlace
+    a.sortInPlace()
     assertEquals(List(3,4,5), a)
   }
 

--- a/test/junit/scala/collection/mutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/mutable/ArraySeqTest.scala
@@ -12,7 +12,7 @@ class ArraySeqTest {
   @Test
   def t11187(): Unit = {
     assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sorted)
-    assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sortInPlace)
+    assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sortInPlace())
     assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sortBy(identity))
     assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sortInPlaceBy(identity))
     assertEquals(ArraySeq(1, 2), ArraySeq(2, 1).sortWith(_ < _))

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -166,7 +166,7 @@ class BitSetTest {
     assertEquals(Seq(0), BitSet(0).iteratorFrom(0).toSeq)
     assertTrue(a.iteratorFrom(128).isEmpty)
     assertTrue(BitSet.empty.iteratorFrom(0).isEmpty)
-    assertThrows[NoSuchElementException](BitSet.empty.iteratorFrom(0).next)
+    assertThrows[NoSuchElementException](BitSet.empty.iteratorFrom(0).next())
   }
 
 }

--- a/test/junit/scala/concurrent/FutureTest.scala
+++ b/test/junit/scala/concurrent/FutureTest.scala
@@ -10,8 +10,8 @@ class FutureTest {
   @Test
   def `bug/issues#10513 firstCompletedOf must not leak references`(): Unit = {
     import ExecutionContext.Implicits._
-    val unfulfilled = Promise[AnyRef]
-    val quick = Promise[AnyRef]
+    val unfulfilled = Promise[AnyRef]()
+    val quick = Promise[AnyRef]()
     val result = new AnyRef
     Future.firstCompletedOf(List(quick.future, unfulfilled.future)): Unit
     assertNotReachable(result, unfulfilled) {

--- a/test/junit/scala/io/SourceTest.scala
+++ b/test/junit/scala/io/SourceTest.scala
@@ -20,13 +20,11 @@ class SourceTest {
 
   private def in = new ByteArrayInputStream(sampler.getBytes)
 
-  @Test def canIterateLines() = {
-    assertEquals(sampler.linesIterator.size, (Source fromString sampler).getLines.size)
-  }
+  @Test def canIterateLines() = assertEquals(sampler.linesIterator.size, (Source fromString sampler).getLines().size)
   @Test def loadFromResource() = {
     val res = Source.fromResource("rootdoc.txt")
     val ls = res.getLines()
-    ls.next match {
+    ls.next() match {
       case "The Scala compiler and reflection APIs." =>
       case "This is the documentation for the Scala standard library." =>
       case l =>

--- a/test/junit/scala/math/BigDecimalTest.scala
+++ b/test/junit/scala/math/BigDecimalTest.scala
@@ -177,7 +177,7 @@ class BigDecimalTest {
   def churnRepresentationTest(): Unit = {
     val rn = new scala.util.Random(42)
     for (i <- 1 to 1000) {
-      val d = rn.nextDouble
+      val d = rn.nextDouble()
       assert({
         BigDecimal.decimal(d).isDecimalDouble &&
         BigDecimal.binary(d).isBinaryDouble &&
@@ -185,7 +185,7 @@ class BigDecimalTest {
       }, s"At least one wrong BigDecimal representation for $d")
     }
     for (i <- 1 to 1000) {
-      val f = rn.nextFloat
+      val f = rn.nextFloat()
       assert({
         BigDecimal.decimal(f).isDecimalFloat &&
         BigDecimal.binary(f).isBinaryFloat &&

--- a/test/junit/scala/reflect/internal/TypesTest.scala
+++ b/test/junit/scala/reflect/internal/TypesTest.scala
@@ -240,7 +240,7 @@ class TypesTest {
     assertTrue(F() <:< FooTpe)
     assertTrue(FooTpe <:< F())
     assertTrue(F() =:= FooTpe)
-    assertTrue(FooTpe =:= F)
+    assertTrue(FooTpe =:= F())
 
     // test that ?F unifies with [A]Foo[A]
     assertTrue(F() <:< polyType(A => Foo(A)))

--- a/test/junit/scala/reflect/internal/util/FileUtilsTest.scala
+++ b/test/junit/scala/reflect/internal/util/FileUtilsTest.scala
@@ -27,8 +27,8 @@ class FileUtilsTest {
     for (i <- 1 to 2000) {
       writeBoth(s"line $i text;", true)
       writeBoth(s"line $i chars", false)
-      sTest.newLine
-      sExpected.newLine
+      sTest.newLine()
+      sExpected.newLine()
     }
     sTest.close()
     sExpected.close()
@@ -66,14 +66,14 @@ class FileUtilsTest {
       val t1 = System.nanoTime()
       List.tabulate(10000) {i =>
         sTest.write(s"line $i text;")
-        sTest.newLine
+        sTest.newLine()
       }
       val t2 = System.nanoTime()
       sTest.close()
       val t3 = System.nanoTime()
       List.tabulate(10000) {i =>
         sExpected.write(s"line $i text;")
-        sExpected.newLine
+        sExpected.newLine()
       }
       val t4 = System.nanoTime()
       sExpected.close()

--- a/test/junit/scala/reflect/internal/util/WeakHashSetTest.scala
+++ b/test/junit/scala/reflect/internal/util/WeakHashSetTest.scala
@@ -19,7 +19,7 @@ class WeakHashSetTest {
   def checkEmpty: Unit = {
     val hs = new WeakHashSet[String]()
     assertEquals(0, hs.size)
-    hs.diagnostics.fullyValidate
+    hs.diagnostics.fullyValidate()
   }
 
   // make sure += works
@@ -31,7 +31,7 @@ class WeakHashSetTest {
     assertEquals(2, hs.size)
     assertTrue(hs contains "hello")
     assertTrue(hs contains "goodbye")
-    hs.diagnostics.fullyValidate
+    hs.diagnostics.fullyValidate()
   }
 
   // make sure += works when there are collisions
@@ -43,7 +43,7 @@ class WeakHashSetTest {
     assertEquals(2, hs.size)
     assertTrue(hs contains Collider("hello"))
     assertTrue(hs contains Collider("goodbye"))
-    hs.diagnostics.fullyValidate
+    hs.diagnostics.fullyValidate()
   }
 
   // add a large number of elements to force rehashing and then validate
@@ -54,7 +54,7 @@ class WeakHashSetTest {
     val elements = (0 until size).toList map ("a" + _)
     elements foreach (hs += _)
     elements foreach {i => assertTrue(hs contains i)}
-    hs.diagnostics.fullyValidate
+    hs.diagnostics.fullyValidate()
   }
 
   // make sure rehashing works properly when the set is rehashed
@@ -65,7 +65,7 @@ class WeakHashSetTest {
     val elements = (0 until size).toList map {x => Collider("a" + x)}
     elements foreach (hs += _)
     elements foreach {i => assertTrue(hs contains i)}
-    hs.diagnostics.fullyValidate
+    hs.diagnostics.fullyValidate()
   }
 
   // test that unreferenced objects are removed
@@ -88,7 +88,7 @@ class WeakHashSetTest {
     for (i <- 0 until size) {
       assertFalse(hs contains Collider("b" + i))
     }
-    hs.diagnostics.fullyValidate
+    hs.diagnostics.fullyValidate()
   }
 
   // make sure findOrUpdate returns the originally entered element
@@ -103,7 +103,7 @@ class WeakHashSetTest {
       // original put in
       assertTrue(hs.findEntryOrUpdate(Collider("a" + i)) eq elements(i))
     }
-    hs.diagnostics.fullyValidate
+    hs.diagnostics.fullyValidate()
   }
 
   // check -= functionality
@@ -116,7 +116,7 @@ class WeakHashSetTest {
     assertEquals(1, hs.size)
     assertTrue(hs contains "hello")
     assertFalse(hs contains "goodbye")
-    hs.diagnostics.fullyValidate
+    hs.diagnostics.fullyValidate()
   }
 
   // check -= when there are collisions
@@ -132,7 +132,7 @@ class WeakHashSetTest {
     hs -= Collider("hello")
     assertEquals(0, hs.size)
     assertFalse(hs contains Collider("hello"))
-    hs.diagnostics.fullyValidate
+    hs.diagnostics.fullyValidate()
   }
 
   // check that the clear method actually cleans everything
@@ -145,7 +145,7 @@ class WeakHashSetTest {
     hs.clear()
     assertEquals(0, hs.size)
     elements foreach {i => assertFalse(hs contains i)}
-    hs.diagnostics.fullyValidate
+    hs.diagnostics.fullyValidate()
   }
 
   // check that the iterator covers all the contents
@@ -155,7 +155,7 @@ class WeakHashSetTest {
     val elements = (0 until 20).toList map ("a" + _)
     elements foreach (hs += _)
     assertTrue(elements.iterator.toList.sorted == elements.sorted)
-    hs.diagnostics.fullyValidate
+    hs.diagnostics.fullyValidate()
   }
 
   // check that the iterator covers all the contents even when there is a collision
@@ -165,7 +165,7 @@ class WeakHashSetTest {
     val elements = (0 until 20).toList map {x => Collider("a" + x)}
     elements foreach (hs += _)
     assertTrue(elements.iterator.toList.sorted == elements.sorted)
-    hs.diagnostics.fullyValidate
+    hs.diagnostics.fullyValidate()
   }
 
 }

--- a/test/junit/scala/tools/nsc/reporters/ConsoleReporterTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/ConsoleReporterTest.scala
@@ -41,12 +41,12 @@ class ConsoleReporterTest {
       test(pos)
       val buf = writerOut.toString
       if (msg.isEmpty && severity.isEmpty) assertTrue(s"Expected no message output but saw: [$buf]", buf.isEmpty)
-      else if (!pos.isDefined) assertEquals(severity + msg, buf.linesIterator.next)
+      else if (!pos.isDefined) assertEquals(severity + msg, buf.linesIterator.next())
       else {
         val it = buf.linesIterator
-        assertEquals(source + ":1: " + severity + msg, it.next)
-        assertEquals(content, it.next)
-        assertEquals("    ^", it.next)
+        assertEquals(source + ":1: " + severity + msg, it.next())
+        assertEquals(content, it.next())
+        assertEquals("    ^", it.next())
       }
     } finally writerOut.reset()
 
@@ -144,8 +144,8 @@ class ConsoleReporterTest {
     val reporter = createConsoleReporter("s", writerOut, echoWriterOut)
     reporter.displayPrompt()
     val it = writerOut.toString.linesIterator
-    assertTrue(it.next.isEmpty)
-    assertEquals(output + "java.lang.Throwable", it.next)
+    assertTrue(it.next().isEmpty)
+    assertEquals(output + "java.lang.Throwable", it.next())
     assertTrue(it.hasNext)
 
     /** Check for no stack trace */
@@ -154,7 +154,7 @@ class ConsoleReporterTest {
     reporter2.displayPrompt()
     val it2 = writerOut2.toString.linesIterator
     assertTrue(it2.next.isEmpty)
-    assertEquals(output, it2.next)
+    assertEquals(output, it2.next())
     assertFalse(it2.hasNext)
 
     /** Check for no stack trace */
@@ -162,8 +162,8 @@ class ConsoleReporterTest {
     val reporter3 = createConsoleReporter("r", writerOut3)
     reporter3.displayPrompt()
     val it3 = writerOut3.toString.linesIterator
-    assertTrue(it3.next.isEmpty)
-    assertEquals(output, it3.next)
+    assertTrue(it3.next().isEmpty)
+    assertEquals(output, it3.next())
     assertFalse(it3.hasNext)
   }
 

--- a/test/junit/scala/util/SortingTest.scala
+++ b/test/junit/scala/util/SortingTest.scala
@@ -55,7 +55,7 @@ class SortingTest {
     } runOneTest(size, v)
     
     for (size <- sizes) {
-      val b = Array.fill(size)(rng.nextBoolean)
+      val b = Array.fill(size)(rng.nextBoolean())
       val bfwd = Sorting.stableSort(b.clone.toIndexedSeq)
       val bbkw = Sorting.stableSort(b.clone.toIndexedSeq, (x: Boolean, y: Boolean) => x && !y)
       assertTrue("All falses should be first", bfwd.dropWhile(_ == false).forall(_ == true))

--- a/test/scalacheck/duration.scala
+++ b/test/scalacheck/duration.scala
@@ -32,7 +32,7 @@ object DurationTest extends Properties("Division of Duration by Long") {
   val genClose = for {
     a <- weightedLong
     if a != 0
-    val center = Long.MaxValue / a
+    center = Long.MaxValue / a
     b <-
       if (center - 10 < center + 10) choose(center - 10,  center + 10)
       else choose(center + 10,  center - 10) // deal with overflow if abs(a) == 1


### PR DESCRIPTION
Mostly strings and parens.

One or two caused by leading infix and case class ctor modifiers affect apply and copy.

For case classes, `final case class C protected (c: Int)` instead of private suffices. See `TypeHistory`.

The invasive change not included here is due to no nested class ~overriding~ shadowing, which affects `TreePrinter`, `Transform`, `Phase`. Also no changes to quasiquote tests.