### PR TITLE
Guard against unexpected flags files in partest

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTestSettings.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTestSettings.scala
@@ -17,15 +17,11 @@ package tests
 import java.io.File.pathSeparatorChar
 import java.io.File.separatorChar
 import scala.tools.nsc.interactive.tests.core.PresentationCompilerInstance
-import scala.tools.nsc.io.{File,Path}
+import scala.tools.nsc.io.Path
 import core.Reporter
 import core.TestSettings
 
 trait InteractiveTestSettings extends TestSettings with PresentationCompilerInstance {
-  /** Character delimiter for comments in .opts file */
-  private final val CommentStartDelimiter = "#"
-
-  private final val TestOptionsFileExtension = "flags"
 
   /** Prepare the settings object. Load the .opts file and adjust all paths from the
    *  Unix-like syntax to the platform specific syntax. This is necessary so that a
@@ -63,14 +59,7 @@ trait InteractiveTestSettings extends TestSettings with PresentationCompilerInst
     adjustPaths(settings.bootclasspath, settings.classpath, settings.javabootclasspath, settings.sourcepath)
   }
 
-  /** If there's a file ending in .opts, read it and parse it for cmd line arguments. */
-  protected val argsString = {
-    val optsFile = outDir / "%s.%s".format(System.getProperty("partest.testname"), TestOptionsFileExtension)
-    val str = try File(optsFile).slurp() catch {
-      case e: java.io.IOException => ""
-    }
-    str.linesIterator.filter(!_.startsWith(CommentStartDelimiter)).mkString(" ")
-  }
+  protected def argsString: String = ""
 
   override protected def printClassPath(implicit reporter: Reporter): Unit = {
     reporter.println("\toutDir: %s".format(outDir.path))

--- a/test/files/presentation/ide-t1000976.flags
+++ b/test/files/presentation/ide-t1000976.flags
@@ -1,1 +1,0 @@
--sourcepath src 

--- a/test/files/presentation/ide-t1000976/Test.scala
+++ b/test/files/presentation/ide-t1000976/Test.scala
@@ -3,6 +3,9 @@ import scala.reflect.internal.util.SourceFile
 import scala.tools.nsc.interactive.Response
 
 object Test extends InteractiveTest {
+
+  override def argsString = "-sourcepath src"
+
   override def execute(): Unit = {
     loadSourceAndWaitUntilTypechecked("A.scala")
     val sourceB = loadSourceAndWaitUntilTypechecked("B.scala")

--- a/test/files/presentation/t8085.flags
+++ b/test/files/presentation/t8085.flags
@@ -1,1 +1,0 @@
--sourcepath src

--- a/test/files/presentation/t8085/Test.scala
+++ b/test/files/presentation/t8085/Test.scala
@@ -4,6 +4,8 @@ import scala.tools.nsc.interactive.Response
 
 object Test extends InteractiveTest {
 
+  override def argsString = "-sourcepath src"
+
   override def execute(): Unit = {
     val src = loadSourceAndWaitUntilTypechecked("NodeScalaSuite.scala")
     checkErrors(src)

--- a/test/files/presentation/t8085b.flags
+++ b/test/files/presentation/t8085b.flags
@@ -1,1 +1,0 @@
--sourcepath src

--- a/test/files/presentation/t8085b/Test.scala
+++ b/test/files/presentation/t8085b/Test.scala
@@ -4,6 +4,8 @@ import scala.tools.nsc.interactive.Response
 
 object Test extends InteractiveTest {
 
+  override def argsString = "-sourcepath src"
+
   override def execute(): Unit = {
     val src = loadSourceAndWaitUntilTypechecked("NodeScalaSuite.scala")
     checkErrors(src)

--- a/test/macro-annot/pos.flags
+++ b/test/macro-annot/pos.flags
@@ -1,1 +1,0 @@
--Ymacro-annotations

--- a/test/macro-annot/run.flags
+++ b/test/macro-annot/run.flags
@@ -1,1 +1,0 @@
--Ymacro-annotations


### PR DESCRIPTION
Laboriously check for obsolete test-specific flags files.

Also delete kind-specific flags for macro-annot, which is
now hard-coded in the runner.

Delete a few presentation flags, which are defined in
the respective Test class.

Follow-up to https://github.com/scala/scala/pull/8800