### PR TITLE
Tweak fresh name

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -775,7 +775,7 @@ abstract class UnCurry extends InfoTransform
                       tpe
                   }
                 val info = info0.normalize
-                val tempValName = unit.freshTermName(s"${p.name.decoded}$$")
+                val tempValName = unit.freshTermName(s"${p.name}$$")
                 val newSym = dd.symbol.newTermSymbol(tempValName, p.pos, SYNTHETIC).setInfo(info)
                 atPos(p.pos)(ValDef(newSym, gen.mkAttributedCast(Ident(p.symbol), info)))
               }


### PR DESCRIPTION
Previous tweak to use interpolation did not preserve behavior.
Avoid potential decode of name to no benefit.

Follow-up to https://github.com/scala/scala/pull/8991 per review