### PR TITLE
Defer "pure expression .. in statement position" warnings until refchecks.

### DIFF
--- a/test/files/neg/macro-invalidret.check
+++ b/test/files/neg/macro-invalidret.check
@@ -27,8 +27,5 @@ java.lang.NullPointerException
 Macros_Test_2.scala:15: error: macro implementation is missing
   foo4
   ^
-Macros_Test_2.scala:17: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-  foo6
-  ^
-two warnings found
+one warning found
 5 errors found

--- a/test/files/neg/names-defaults-neg-213.check
+++ b/test/files/neg/names-defaults-neg-213.check
@@ -1,16 +1,9 @@
-names-defaults-neg-213.scala:7: warning: a pure expression does nothing in statement position
-    f1(x = 1) // named arg in 2.13 (value discard), not ambiguous
-           ^
 names-defaults-neg-213.scala:8: error: unknown parameter name: x
 Note that assignments in argument position are no longer allowed since Scala 2.13.
 To express the assignment expression, wrap it in brackets, e.g., `{ x = ... }`.
     f2(x = 1) // error, no parameter named x. error message mentions change in 2.13
          ^
-names-defaults-neg-213.scala:13: warning: a pure expression does nothing in statement position
-    f1(x = 1) // ok, named arg (value discard)
-           ^
 names-defaults-neg-213.scala:14: error: unknown parameter name: x
     f2(x = 1) // error (no such parameter). no mention of new semantics in 2.13
          ^
-two warnings found
 two errors found

--- a/test/files/neg/names-defaults-neg-warn.check
+++ b/test/files/neg/names-defaults-neg-warn.check
@@ -13,11 +13,8 @@ names-defaults-neg-warn.scala:23: warning: assignments in argument position are 
 names-defaults-neg-warn.scala:34: warning: assignments in argument position are deprecated in favor of named arguments. Wrap the assignment in brackets, e.g., `{ x = ... }`.
     synchronized(x = 1) // deprecation warning in 2.12, error in 2.13
                    ^
-names-defaults-neg-warn.scala:42: warning: a pure expression does nothing in statement position
-    f1(x = 1) // 2.12, 2.13: ok, named arg (value discard)
-           ^
 names-defaults-neg-warn.scala:43: error: reassignment to val
     f2(x = 1) // 2.12, 2.13: error (no such parameter). no deprecation warning in 2.12, x is not a variable.
          ^
-5 warnings found
+four warnings found
 two errors found

--- a/test/files/neg/scopes.check
+++ b/test/files/neg/scopes.check
@@ -7,9 +7,6 @@ scopes.scala:5: error: x is already defined as value x
 scopes.scala:8: error: y is already defined as value y
     val y: Float = .0f
         ^
-scopes.scala:6: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-  {
-  ^
 scopes.scala:11: error: x is already defined as value x
   def f1(x: Int, x: Float) = x
                  ^
@@ -22,5 +19,4 @@ scopes.scala:13: error: x is already defined as value x
 scopes.scala:15: error: x is already defined as value x
     case x::x => x
             ^
-one warning found
 7 errors found

--- a/test/files/neg/t1181.check
+++ b/test/files/neg/t1181.check
@@ -3,8 +3,4 @@ t1181.scala:9: error: type mismatch;
  required: Symbol
      _ => buildMap(map.updated(keyList.head, valueList.head), keyList.tail, valueList.tail)
                   ^
-t1181.scala:8: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
-     case (Nil, Nil) => map
-                        ^
-one warning found
 one error found

--- a/test/files/neg/t9847.check
+++ b/test/files/neg/t9847.check
@@ -1,28 +1,10 @@
 t9847.scala:4: warning: discarded non-Unit value
   def f(): Unit = 42
                   ^
-t9847.scala:4: warning: a pure expression does nothing in statement position
-  def f(): Unit = 42
-                  ^
 t9847.scala:5: warning: discarded non-Unit value
   def g = (42: Unit)
            ^
-t9847.scala:5: warning: a pure expression does nothing in statement position
-  def g = (42: Unit)
-           ^
-t9847.scala:7: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
-    1
-    ^
 t9847.scala:12: warning: discarded non-Unit value
-  + 1
-  ^
-t9847.scala:12: warning: a pure expression does nothing in statement position
-  + 1
-  ^
-t9847.scala:11: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
-    1
-    ^
-t9847.scala:12: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
   + 1
   ^
 t9847.scala:16: warning: discarded non-Unit value
@@ -31,6 +13,24 @@ t9847.scala:16: warning: discarded non-Unit value
 t9847.scala:19: warning: discarded non-Unit value
   def j(): Unit = x + 1
                     ^
+t9847.scala:4: warning: a pure expression does nothing in statement position
+  def f(): Unit = 42
+                  ^
+t9847.scala:5: warning: a pure expression does nothing in statement position
+  def g = (42: Unit)
+           ^
+t9847.scala:7: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+    1
+    ^
+t9847.scala:11: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+    1
+    ^
+t9847.scala:12: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
+  + 1
+  ^
+t9847.scala:12: warning: a pure expression does nothing in statement position
+  + 1
+  ^
 t9847.scala:21: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
   class C { 42 }
             ^

--- a/test/files/neg/unit-returns-value.check
+++ b/test/files/neg/unit-returns-value.check
@@ -1,9 +1,9 @@
-unit-returns-value.scala:4: warning: a pure expression does nothing in statement position
-    if (b) return 5
-                  ^
 unit-returns-value.scala:4: warning: enclosing method f has result type Unit: return value discarded
     if (b) return 5
            ^
+unit-returns-value.scala:4: warning: a pure expression does nothing in statement position
+    if (b) return 5
+                  ^
 unit-returns-value.scala:22: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
     i1 // warn
     ^

--- a/test/files/run/contrib674.check
+++ b/test/files/run/contrib674.check
@@ -1,6 +1,6 @@
-contrib674.scala:15: warning: a pure expression does nothing in statement position
+contrib674.scala:15: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
     1
     ^
-contrib674.scala:15: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
+contrib674.scala:15: warning: a pure expression does nothing in statement position
     1
     ^

--- a/test/files/run/names-defaults.check
+++ b/test/files/run/names-defaults.check
@@ -1,7 +1,7 @@
-names-defaults.scala:269: warning: a pure expression does nothing in statement position
+names-defaults.scala:269: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
     spawn(b = { val ttt = 1; ttt }, a = 0)
                              ^
-names-defaults.scala:269: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
+names-defaults.scala:269: warning: a pure expression does nothing in statement position
     spawn(b = { val ttt = 1; ttt }, a = 0)
                              ^
 warning: there were four deprecation warnings

--- a/test/files/run/patmatnew.check
+++ b/test/files/run/patmatnew.check
@@ -1,21 +1,21 @@
-patmatnew.scala:351: warning: a pure expression does nothing in statement position
-        case 1 => "OK"
-                  ^
-patmatnew.scala:352: warning: a pure expression does nothing in statement position
-        case 2 => assert(false); "KO"
-                                 ^
-patmatnew.scala:352: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
-        case 2 => assert(false); "KO"
-                                 ^
-patmatnew.scala:353: warning: a pure expression does nothing in statement position
-        case 3 => assert(false); "KO"
-                                 ^
-patmatnew.scala:353: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
-        case 3 => assert(false); "KO"
-                                 ^
 patmatnew.scala:670: warning: This catches all Throwables. If this is really intended, use `case e : Throwable` to clear this warning.
             case e => {
                  ^
 patmatnew.scala:489: warning: unreachable code
         case _ if false =>
                         ^
+patmatnew.scala:351: warning: a pure expression does nothing in statement position
+        case 1 => "OK"
+                  ^
+patmatnew.scala:352: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
+        case 2 => assert(false); "KO"
+                                 ^
+patmatnew.scala:352: warning: a pure expression does nothing in statement position
+        case 2 => assert(false); "KO"
+                                 ^
+patmatnew.scala:353: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
+        case 3 => assert(false); "KO"
+                                 ^
+patmatnew.scala:353: warning: a pure expression does nothing in statement position
+        case 3 => assert(false); "KO"
+                                 ^

--- a/test/files/run/pure-warning-post-macro/Macro_1.scala
+++ b/test/files/run/pure-warning-post-macro/Macro_1.scala
@@ -1,0 +1,13 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+object Macro {
+  def blockToList[T](block: T): List[T] = macro impl[T]
+  def impl[T: c.WeakTypeTag](c: Context)(block: c.Tree): c.Tree = {
+    import c.universe._
+    block match {
+      case Block(stats, expr) =>
+        q"_root_.scala.List.apply[${weakTypeOf[T]}](..${stats :+ expr})"
+    }
+  }
+}

--- a/test/files/run/pure-warning-post-macro/test_2.scala
+++ b/test/files/run/pure-warning-post-macro/test_2.scala
@@ -1,0 +1,13 @@
+// scalac: -Xfatal-errors
+object Test {
+  def main(args: Array[String]): Unit = {
+    // We don't want a "pure expression discarded" warning here as the macro will
+    // eliminate the block
+    val is = Macro.blockToList[Int] {
+      1
+      2
+      3
+    }
+    assert(is == List(1, 2, 3))
+  }
+}

--- a/test/files/run/reify_lazyunit.check
+++ b/test/files/run/reify_lazyunit.check
@@ -1,6 +1,3 @@
-reify_lazyunit.scala:6: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
-    lazy val x = { 0; println("12")}
-                   ^
 12
 one
 two

--- a/test/files/run/t3488.check
+++ b/test/files/run/t3488.check
@@ -1,13 +1,13 @@
-t3488.scala:4: warning: a pure expression does nothing in statement position
-  println(foo { val List(_*)=List(0); 1 } ())
-                                      ^
 t3488.scala:4: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
   println(foo { val List(_*)=List(0); 1 } ())
                                       ^
-t3488.scala:5: warning: a pure expression does nothing in statement position
-  println(foo { val List(_*)=List(0); 1 } (1))
+t3488.scala:4: warning: a pure expression does nothing in statement position
+  println(foo { val List(_*)=List(0); 1 } ())
                                       ^
 t3488.scala:5: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
+  println(foo { val List(_*)=List(0); 1 } (1))
+                                      ^
+t3488.scala:5: warning: a pure expression does nothing in statement position
   println(foo { val List(_*)=List(0); 1 } (1))
                                       ^
 0

--- a/test/files/run/t5380.check
+++ b/test/files/run/t5380.check
@@ -1,9 +1,9 @@
+t5380.scala:3: warning: enclosing method main has result type Unit: return value discarded
+    val f = () => return try { 1 } catch { case _: Throwable => 0 }
+                  ^
 t5380.scala:3: warning: a pure expression does nothing in statement position
     val f = () => return try { 1 } catch { case _: Throwable => 0 }
                                ^
 t5380.scala:3: warning: a pure expression does nothing in statement position
     val f = () => return try { 1 } catch { case _: Throwable => 0 }
                                                                 ^
-t5380.scala:3: warning: enclosing method main has result type Unit: return value discarded
-    val f = () => return try { 1 } catch { case _: Throwable => 0 }
-                  ^


### PR DESCRIPTION
This allows a macro to transform code that used to warn into something that 
does not.