### PR TITLE
[backport] Defensively compute maxlocals or mark it as stale

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -110,7 +110,10 @@ abstract class BackendUtils extends PerRunInit {
   object AsmAnalyzer {
     // jvm limit is 65535 for both number of instructions and number of locals
 
-    private def size(method: MethodNode) = method.instructions.size.toLong * method.maxLocals * method.maxLocals
+    private def size(method: MethodNode) = {
+      val ml = maxLocals(method)
+      method.instructions.size.toLong * ml * ml
+    }
 
     // with the limits below, analysis should not take more than one second
 
@@ -420,6 +423,16 @@ abstract class BackendUtils extends PerRunInit {
       onIndyLambdaImplMethodIfPresent(hostClass) {
         _ --= handle
       }
+  }
+
+  def maxLocals(method: MethodNode): Int = {
+    computeMaxLocalsMaxStack(method)
+    method.maxLocals
+  }
+
+  def maxStack(method: MethodNode): Int = {
+    computeMaxLocalsMaxStack(method)
+    method.maxStack
   }
 
   /**

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BoxUnbox.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BoxUnbox.scala
@@ -21,6 +21,7 @@ import scala.tools.asm.Opcodes._
 import scala.tools.asm.Type
 import scala.tools.asm.tree._
 import scala.tools.nsc.backend.jvm.BTypes.InternalName
+import scala.tools.nsc.backend.jvm.analysis.BackendUtils
 import scala.tools.nsc.backend.jvm.opt.BytecodeUtils._
 
 abstract class BoxUnbox {
@@ -188,7 +189,7 @@ abstract class BoxUnbox {
 
       lazy val prodCons = new ProdConsAnalyzer(method, owner)
 
-      var nextLocal = method.maxLocals
+      var nextLocal = backendUtils.maxLocals(method)
       def getLocal(size: Int) = {
         val r = nextLocal
         nextLocal += size
@@ -425,7 +426,7 @@ abstract class BoxUnbox {
       }
 
       method.maxLocals = nextLocal
-      method.maxStack += maxStackGrowth
+      method.maxStack = backendUtils.maxStack(method) + maxStackGrowth
       toInsertBefore.nonEmpty || toReplace.nonEmpty || toDelete.nonEmpty
     }
   }

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ClosureOptimizer.scala
@@ -148,7 +148,7 @@ abstract class ClosureOptimizer {
     // allocate locals for storing the arguments of the closure apply callsites.
     // if there are multiple callsites, the same locals are re-used.
     val argTypes = closureInit.lambdaMetaFactoryCall.samMethodType.getArgumentTypes
-    val firstArgLocal = ownerMethod.maxLocals
+    val firstArgLocal = backendUtils.maxLocals(ownerMethod)
 
     val argLocals = LocalsList.fromTypes(firstArgLocal, argTypes)
     ownerMethod.maxLocals = firstArgLocal + argLocals.size
@@ -332,7 +332,7 @@ abstract class ClosureOptimizer {
     // One slot per value is correct for long / double, see comment in the `analysis` package object.
     val numCapturedValues = localsForCapturedValues.locals.length
     val invocationStackHeight = stackHeight + numCapturedValues - 1 + (if (isNew) 2 else 0) // -1 because the closure is gone
-    if (invocationStackHeight > ownerMethod.maxStack)
+    if (invocationStackHeight > backendUtils.maxStack(ownerMethod))
       ownerMethod.maxStack = invocationStackHeight
 
     // replace the callsite with a new call to the body method
@@ -423,7 +423,7 @@ abstract class ClosureOptimizer {
   private def storeCaptures(closureInit: ClosureInstantiation): LocalsList = {
     val indy = closureInit.lambdaMetaFactoryCall.indy
     val capturedTypes = Type.getArgumentTypes(indy.desc)
-    val firstCaptureLocal = closureInit.ownerMethod.maxLocals
+    val firstCaptureLocal = backendUtils.maxLocals(closureInit.ownerMethod)
 
     // This could be optimized: in many cases the captured values are produced by LOAD instructions.
     // If the variable is not modified within the method, we could avoid introducing yet another

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/CopyProp.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/CopyProp.scala
@@ -53,7 +53,7 @@ abstract class CopyProp {
       //
       // In this example, we should change the second load from 1 to 3, which might render the
       // local variable 1 unused.
-      val knownUsed = new Array[Boolean](method.maxLocals)
+      val knownUsed = new Array[Boolean](backendUtils.maxLocals(method))
 
       def usedOrMinAlias(it: IntIterator, init: Int): Int = {
         if (knownUsed(init)) init
@@ -115,7 +115,7 @@ abstract class CopyProp {
       val toNullOut = mutable.ArrayBuffer.empty[(VarInsnNode, Boolean)]
 
       // `true` for variables that are known to be live
-      val liveVars = new Array[Boolean](method.maxLocals)
+      val liveVars = new Array[Boolean](backendUtils.maxLocals(method))
 
       val it = method.instructions.iterator
       while (it.hasNext) it.next() match {
@@ -499,7 +499,7 @@ abstract class CopyProp {
    */
   def eliminateStoreLoad(method: MethodNode): Boolean = {
     val removePairs = mutable.Set.empty[RemovePair]
-    val liveVars = new Array[Boolean](method.maxLocals)
+    val liveVars = new Array[Boolean](backendUtils.maxLocals(method))
     val liveLabels = mutable.Set.empty[LabelNode]
 
     def mkRemovePair(store: VarInsnNode, other: AbstractInsnNode, depends: List[RemovePairDependency]): RemovePair = {

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
@@ -398,6 +398,7 @@ abstract class LocalOpt {
     assert(nullOrEmpty(method.visibleLocalVariableAnnotations), method.visibleLocalVariableAnnotations)
     assert(nullOrEmpty(method.invisibleLocalVariableAnnotations), method.invisibleLocalVariableAnnotations)
 
+    // clear the non-official "access" flags once we're done and no longer look at them
     BackendUtils.clearMaxsComputed(method)
     BackendUtils.clearDceDone(method)
 


### PR DESCRIPTION
Tests failed on 2.13.x after we [forward merged](https://github.com/scala/scala/pull/8993) the ASM-analyser-free
implementation of minimal DCE as other places in the backend where
observing an unitialized or stale value of maxlocals.

I'm not sure whether the absense of similar test failures back
here on 2.12.x represents an absense of the problem or if we're
short on tests or getting lucky with the way the optimizer is
organized here.

The defensive calls to initialize maxlocals, or mark it as
unitialized after inlining, seems safe to do.

Ideally we could intercept reads of `maxlocals` to trigger
the computation and intercept mutations of `instructions` to
mark the cached value as stale.