### PR TITLE
[nomerge] Revert backported RBTree changes that are 2.13.x only

### DIFF
--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -281,8 +281,8 @@ private[collection] object RedBlackTree {
       balanceLeft(tree, upd(tree.left, k, v, overwrite))
     else if (cmp > 0)
       balanceRight(tree, upd(tree.right, k, v, overwrite))
-    else if (overwrite && (v.asInstanceOf[AnyRef] ne tree.value.asInstanceOf[AnyRef]))
-      mkTree(isBlackTree(tree), tree.key, v, tree.left, tree.right)
+    else if ((overwrite && (v.asInstanceOf[AnyRef] ne tree.value.asInstanceOf[AnyRef])) || k != tree.key)
+      mkTree(isBlackTree(tree), k, v, tree.left, tree.right)
     else tree
   }
   private[this] def updNth[A, B, B1 >: B](tree: Tree[A, B], idx: Int, k: A, v: B1): Tree[A, B1] = if (tree eq null) {

--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -163,4 +163,13 @@ class TreeMapTest extends AllocationTest {
       assertEquals(s"$rText $lText", rhs, lhs)
     }
   }
+
+  @Test def keyOverwriteIn212(): Unit = {
+    // see https://github.com/scala/scala/pull/7481 and https://github.com/scala/scala/pull/8783
+    // for 2.13.x changes that we don't want to include in the RedBlackTree backports to 2.12.x
+    // for compatibility.
+    val map = collection.immutable.TreeMap.apply(2 -> 2)(Ordering.by(x => x / 2))
+    val map2 = map.updated(3, 3)
+    assertEquals(List(3 -> 3), map2.toList)
+  }
 }


### PR DESCRIPTION
Changes from:

   https://github.com/scala/scala/pull/7481
   https://github.com/scala/scala/pull/8783

Backported in:

https://github.com/scala/scala/commit/b87dd51447233580aedbb340822e0c6dc0a41119#diff-f99536a3327e638dcf239518f2c3f0ceR195
https://github.com/scala/scala/commit/93afae77c83d8c84c682c56535a3a158b17097c8#diff-f99536a3327e638dcf239518f2c3f0ceL214

... are reverted. I've added a test for the legacy behaviour
that we don't want to break.