### PR TITLE
Deprecate multiarg `+=` on `AnyRefMap` and `LongMap`

### DIFF
--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -293,6 +293,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
   }
 
   /** Adds a new key/value pair to this map and returns the map. */
+  @deprecated("Use `addOne` or `update` instead; infix operations with an operand of multiple args will be deprecated", "2.13.3")
   def +=(key: K, value: V): this.type = { update(key, value); this }
 
   /** Adds a new key/value pair to this map and returns the map. */

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -350,6 +350,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
   }
 
   /** Adds a new key/value pair to this map and returns the map. */
+  @deprecated("Use `addOne` or `update` instead; infix operations with an operand of multiple args will be deprecated", "2.13.3")
   def +=(key: Long, value: V): this.type = { update(key, value); this }
 
   /** Adds a new key/value pair to this map and returns the map. */


### PR DESCRIPTION
Fixes scala/bug#12012