### PR TITLE
Retain var class param if used

### DIFF
--- a/test/files/run/t12002.check
+++ b/test/files/run/t12002.check
@@ -1,0 +1,1 @@
+good boy!

--- a/test/files/run/t12002.scala
+++ b/test/files/run/t12002.scala
@@ -1,0 +1,17 @@
+// cf t6880
+class C(private[this] var c: String) {
+  private[this] var x: String = _
+  c = "good"
+  x = c + " boy!"
+  override def toString = x
+}
+
+object Test {
+  def main(args: Array[String]) = println {
+    new C("bad")
+  }
+}
+
+// was
+// java.lang.NoSuchFieldError: c
+//         at C.<init>(t12002.scala:6)


### PR DESCRIPTION
Normally a `private[this]` class parameter does not get
a field if it is not referenced outside the constructor.
For a var, also check that it is not assigned to inside
the constructor.

Fixes scala/bug#12002