### PR TITLE
Fix em dashes and typos in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ You're always welcome to submit your PR straight away and start the discussion (
 
 ## The Scala Community
 
-In 2014, you -- the Scala community -- matched the core team at EPFL in number of commits contributed to Scala 2.11, doubling the percentage of commits from outside EPFL/Lightbend since 2.10. Excellent work! (The split was roughly 25/25/50 for you/EPFL/Lightbend.)
+In 2014, you—the Scala community—matched the core team at EPFL in number of commits contributed to Scala 2.11, doubling the percentage of commits from outside EPFL/Lightbend since 2.10. Excellent work! (The split was roughly 25/25/50 for you/EPFL/Lightbend.)
 
 We are super happy about this, and are eager to make your experience contributing to Scala productive and satisfying, so that we can keep up this growth. We can't do this alone (nor do we want to)!
 
@@ -57,7 +57,7 @@ chance of being accepted.
 
 ### Tests
 
-Bug fixes should include regression tests -- in the same commit as the fix.
+Bug fixes should include regression tests—in the same commit as the fix.
 
 If testing isn't feasible, the commit message should explain why.
 
@@ -280,7 +280,7 @@ When including review feedback, we typically amend the changes into the existing
 and `push -f` to the branch. This is to keep the git history clean. Additional commits
 are OK if they stand on their own.
 
-Once all these conditions are met, we will merge your changes -- if we
+Once all these conditions are met, we will merge your changes—if we
 agree with it!  We are available on scala/contributors (Gitter) or
 contributors.scala-lang.org (Discourse) to discuss changes beforehand,
 before you put in the coding work.

--- a/spec/03-types.md
+++ b/spec/03-types.md
@@ -897,8 +897,8 @@ The conformance relation $(<:)$ is the smallest transitive relation that satisfi
   $[a_1 , \ldots , a_n]$ and
   $[a_1' , \ldots , a_n']$, where an $a_i$ or $a_i'$ may include a variance
   annotation, a higher-order type parameter clause, and bounds. Then, $T$
-  conforms to $T'$ if any list $[t_1 , \ldots , t_n]$ -- with declared
-  variances, bounds and higher-order type parameter clauses -- of valid type
+  conforms to $T'$ if any list $[t_1 , \ldots , t_n]$ — with declared
+  variances, bounds and higher-order type parameter clauses—of valid type
   arguments for $T'$ is also a valid list of type arguments for $T$ and
   $T[t_1 , \ldots , t_n] <: T'[t_1 , \ldots , t_n]$. Note that this entails
   that:
@@ -1012,8 +1012,8 @@ trait ToString { def convert(x: Int): String }
 
 The application `foo((x: Int) => x.toString)` [resolves](06-expressions.html#overloading-resolution) to the first overload,
 as it's more specific:
-  - `Int => String` is compatible to `ToString` -- when expecting a value of type `ToString`, you may pass a function literal from `Int` to `String`, as it will be SAM-converted to said function;
-  - `ToString` is not compatible to `Int => String` -- when expecting a function from `Int` to `String`, you may not pass a `ToString`.
+  - `Int => String` is compatible to `ToString` — when expecting a value of type `ToString`, you may pass a function literal from `Int` to `String`, as it will be SAM-converted to said function;
+  - `ToString` is not compatible to `Int => String` — when expecting a function from `Int` to `String`, you may not pass a `ToString`.
 
 ## Volatile Types
 

--- a/src/compiler/scala/tools/nsc/ast/TreeDSL.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeDSL.scala
@@ -106,7 +106,7 @@ trait TreeDSL {
       // clear how to proceed, so for now it retains the non-duplicating behavior.
       def ===(rhs: Tree)            = Assign(target, rhs)
 
-      /** Casting & type tests -- working our way toward understanding exactly
+      /** Casting & type tests—working our way toward understanding exactly
        *  what differs between the different forms of IS and AS.
        *
        *  See ticket #2168 for one illustration of AS vs. AS_ANY.

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingAnalyzer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingAnalyzer.scala
@@ -290,7 +290,7 @@ class AliasingFrame[V <: Value](nLocals: Int, nStack: Int) extends Frame[V](nLoc
    *   x = a
    *   y = b     // (x, a) and (y, b)
    * }
-   * [...]       // (x, a) -- merge of ((x, y, a)) and ((x, a), (y, b))
+   * [...]       // (x, a) — merge of ((x, y, a)) and ((x, a), (y, b))
    */
   override def merge(other: Frame[_ <: V], interpreter: Interpreter[V]): Boolean = {
     // merge is the main performance hot spot of a data flow analysis.

--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -170,7 +170,7 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
         *  Ai =:= Ui || (Ai <:< Ui <:< AnyRef)
         *  Ru =:= void || (Ra =:= Ru || (Ra <:< AnyRef, Ru <:< AnyRef))
         *
-        * We can use the target method as-is -- if not, we create a bridging one that uses the types closest
+        * We can use the target method as-is — if not, we create a bridging one that uses the types closest
         * to the target method that still meet the above requirements.
         */
       val resTpOk = (

--- a/src/compiler/scala/tools/nsc/transform/InfoTransform.scala
+++ b/src/compiler/scala/tools/nsc/transform/InfoTransform.scala
@@ -14,7 +14,7 @@ package scala.tools.nsc
 package transform
 
 /**
- * An InfoTransform contains a compiler phase that transforms trees and symbol infos -- making sure they stay consistent.
+ * An InfoTransform contains a compiler phase that transforms trees and symbol info—making sure they stay consistent.
  * The symbol info is transformed assuming it is consistent right before this phase.
  * The info transformation is triggered by Symbol::rawInfo, which caches the results in the symbol's type history.
  * This way sym.info (during an enteringPhase(p)) can look up what the symbol's info should look like at the beginning of phase p.

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -24,7 +24,7 @@ import scala.tools.nsc.Reporting.WarningCategory
 import PartialFunction.cond
 
 /*<export> */
-/** - uncurry all symbol and tree types (@see UnCurryPhase) -- this includes normalizing all proper types.
+/** - uncurry all symbol and tree types (@see UnCurryPhase) — this includes normalizing all proper types.
  *  - for every curried parameter list:  (ps_1) ... (ps_n) ==> (ps_1, ..., ps_n)
  *  - for every curried application: f(args_1)...(args_n) ==> f(args_1, ..., args_n)
  *  - for every type application: f[Ts] ==> f[Ts]() unless followed by parameters

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -327,7 +327,7 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
         /** apply itself must render a faithful representation of the TreeMaker
          *
          * Concretely, True must only be used to represent a TreeMaker that is sure to match and that does not do any computation at all
-         * e.g., doCSE relies on apply itself being sound in this sense (since it drops TreeMakers that are approximated to True -- scala/bug#6077)
+         * e.g., doCSE relies on apply itself being sound in this sense (since it drops TreeMakers that are approximated to True — scala/bug#6077)
          *
          * handleUnknown may be customized by the caller to approximate further
          *

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -287,11 +287,11 @@ trait MatchTranslation {
       *     1) the substitution due to the variables bound by patterns
       *     2) the combination of the extractor calls using `flatMap`.
       *
-      * 2) is easy -- it looks like: `translatePattern_1.flatMap(translatePattern_2....flatMap(translatePattern_N.flatMap(translateGuard.flatMap((x_i) => success(Xbody(x_i)))))...)`
+      * 2) is easy—it looks like: `translatePattern_1.flatMap(translatePattern_2....flatMap(translatePattern_N.flatMap(translateGuard.flatMap((x_i) => success(Xbody(x_i)))))...)`
       *     this must be right-leaning tree, as can be seen intuitively by considering the scope of bound variables:
       *     variables bound by pat_1 must be visible from the function inside the left-most flatMap right up to Xbody all the way on the right
       * 1) is tricky because translatePattern_i determines the shape of translatePattern_i+1:
-      *    zoom in on `translatePattern_1.flatMap(translatePattern_2)` for example -- it actually looks more like:
+      *    zoom in on `translatePattern_1.flatMap(translatePattern_2)` for example—it actually looks more like:
       *      `translatePattern_1(x_scrut).flatMap((x_1) => {y_i -> x_1._i}translatePattern_2)`
       *
       *    `x_1` references the result (inside the monad) of the extractor corresponding to `pat_1`,

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -78,7 +78,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
        * See TreeMakerToCond#updateSubstitution.
        *
        * Overridden in PreserveSubPatBinders to pretend it replaces the subpattern binders by subpattern refs
-       * (Even though we don't do so anymore -- see scala/bug#5158, scala/bug#5739 and scala/bug#6070.)
+       * (Even though we don't do so anymore—see scala/bug#5158, scala/bug#5739 and scala/bug#6070.)
        *
        * TODO: clean this up, would be nicer to have some higher-level way to compute
        * the binders bound by this tree maker and the symbolic values that correspond to them
@@ -164,7 +164,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
       /** The substitution that specifies the trees that compute the values of the subpattern binders.
        *
        * We pretend to replace the subpattern binders by subpattern refs
-       * (Even though we don't do so anymore -- see scala/bug#5158, scala/bug#5739 and scala/bug#6070.)
+       * (Even though we don't do so anymore—see scala/bug#5158, scala/bug#5739 and scala/bug#6070.)
        */
       override def subPatternsAsSubstitution =
         Substitution(subPatBinders, subPatRefs) >> super.subPatternsAsSubstitution

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -275,7 +275,7 @@ trait Infer extends Checkable {
      *  of symbol infos on its way to transforming java raw types (but
      *  only of terms - why?)
      *
-     * Note: pre is not refchecked -- moreover, refchecking the resulting tree may not refcheck pre,
+     * Note: pre is not refchecked—moreover, refchecking the resulting tree may not refcheck pre,
      *       since pre may not occur in its type (callers should wrap the result in a TypeTreeWithDeferredRefCheck)
      */
     def checkAccessible(tree: Tree, sym: Symbol, pre: Type, site: Tree, isJava: Boolean): Tree = {

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -241,8 +241,8 @@ abstract class RefChecks extends Transform {
      *    1.7. If O is an abstract type then
      *       1.7.1 either M is an abstract type, and M's bounds are sharper than O's bounds.
      *             or M is a type alias or class which conforms to O's bounds.
-     *       1.7.2 higher-order type arguments must respect bounds on higher-order type parameters  -- @M
-     *              (explicit bounds and those implied by variance annotations) -- @see checkKindBounds
+     *       1.7.2 higher-order type arguments must respect bounds on higher-order type parameters  — @M
+     *              (explicit bounds and those implied by variance annotations) — @see checkKindBounds
      *    1.8. If O and M are values, then
      *    1.8.1  M's type is a subtype of O's type, or
      *    1.8.2  M is of type []S, O is of type ()T and S <: T, or

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -552,7 +552,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
      *  (exception for some symbols in scala package which are dealiased immediately)
      *  Call checkAccessible, which sets tree's attributes.
      *  Also note that checkAccessible looks up sym on pre without checking that pre is well-formed
-     *  (illegal type applications in pre will be skipped -- that's why typedSelect wraps the resulting tree in a TreeWithDeferredChecks)
+     *  (illegal type applications in pre will be skipped—that's why typedSelect wraps the resulting tree in a TreeWithDeferredChecks)
      *  @return modified tree and new prefix type
      */
     private def makeAccessible(tree: Tree, sym: Symbol, pre: Type, site: Tree): Any /*Type | (Tree, Type)*/ =
@@ -596,7 +596,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       }
 
     /** Post-process an identifier or selection node, performing the following:
-     *  1. Check that non-function pattern expressions are stable (ignoring volatility concerns -- scala/bug#6815)
+     *  1. Check that non-function pattern expressions are stable (ignoring volatility concerns — scala/bug#6815)
      *       (and narrow the type of modules: a module reference in a pattern has type Foo.type, not "object Foo")
      *  2. Check that packages and static modules are not used as values
      *  3. Turn tree type into stable type if possible and required by context.
@@ -2952,7 +2952,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       * is to keep the implementation of type inference (the computation of `samClassTpFullyDefined`) simple.
       *
       * Impl notes:
-      *   - `fun` has a FunctionType, but the expected type `pt` is some SAM type -- let's remedy that
+      *   - `fun` has a FunctionType, but the expected type `pt` is some SAM type—let's remedy that
       *   - `fun` is fully attributed, so we'll have to wrangle some symbols into shape (owner change, vparam syms)
       *   - after experimentation, it works best to type check function literals fully first and then adapt to a sam type,
       *     as opposed to a sam-specific code paths earlier on in type checking (in typedFunction).
@@ -6213,7 +6213,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     /** Types a (fully parameterized) type tree */
     def typedType(tree: Tree): Tree = typedType(tree, NOmode)
 
-    /** Types a higher-kinded type tree -- pt denotes the expected kind and must be one of `Kind.WildCard` and `Kind.FromParams` */
+    /** Types a higher-kinded type tree—pt denotes the expected kind and must be one of `Kind.WildCard` and `Kind.FromParams` */
     def typedHigherKindedType(tree: Tree, mode: Mode, pt: Type): Tree =
       if (pt != Kind.Wildcard && pt.typeParams.isEmpty) typedType(tree, mode) // kind is known and it's *
       else context withinTypeConstructorAllowed typed(tree, NOmode, pt)

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -31,7 +31,7 @@ import scala.runtime.Statics
   * are also the sole abstract methods: `next` and `hasNext`.
   *
   * Both these methods can be called any number of times without having to discard the
-  * iterator. Note that even `hasNext` may cause mutation -- such as when iterating
+  * iterator. Note that even `hasNext` may cause mutation—such as when iterating
   * from an input stream, where it will block until the stream is closed or some
   * input becomes available.
   *

--- a/src/library/scala/sys/process/ProcessBuilder.scala
+++ b/src/library/scala/sys/process/ProcessBuilder.scala
@@ -87,7 +87,7 @@ import ProcessBuilder.{Sink, Source}
   *   - `lazyLines`: returns immediately like `run`, and the output being generated
   *     is provided through a `LazyList[String]`. Getting the next element of that
   *     `LazyList` may block until it becomes available. This method will throw an
-  *     exception if the return code is different than zero -- if this is not
+  *     exception if the return code is different than zero—if this is not
   *     desired, use the `lazyLines_!` method.
   *
   * ==Handling Input and Output==
@@ -99,7 +99,7 @@ import ProcessBuilder.{Sink, Source}
   * semantics of these methods.
   *
   * Some methods will cause stdin to be used as input. Output can be controlled
-  * with a [[scala.sys.process.ProcessLogger]] -- `!!` and `lazyLines` will only
+  * with a [[scala.sys.process.ProcessLogger]] — `!!` and `lazyLines` will only
   * redirect error output when passed a `ProcessLogger`. If one desires full
   * control over input and output, then a [[scala.sys.process.ProcessIO]] can be
   * used with `run`.

--- a/src/library/scala/sys/process/package.scala
+++ b/src/library/scala/sys/process/package.scala
@@ -81,7 +81,7 @@ package scala.sys {
     * [[scala.sys.process.Process]]'s companion object, or through implicit
     * conversions available in this package object itself.  Implicitly, each
     * process is created either out of a `String`, with arguments separated by
-    * spaces -- no escaping of spaces is possible -- or out of a
+    * spaces (no escaping of spaces is possible) or out of a
     * [[scala.collection.Seq]], where the first element represents the command
     * name, and the remaining elements are arguments to it. In this latter case,
     * arguments may contain spaces.
@@ -126,7 +126,7 @@ package scala.sys {
     * get `java.io.InputStream` and `java.io.OutputStream` representing its
     * output and input respectively. That is, what one writes to an
     * `OutputStream` is turned into input to the process, and the output of a
-    * process can be read from an `InputStream` -- of which there are two, one
+    * process can be read from an `InputStream` — of which there are two, one
     * representing normal output, and the other representing error output.
     *
     * This model creates a difficulty, which is that the code responsible for

--- a/src/reflect/scala/reflect/api/Mirrors.scala
+++ b/src/reflect/scala/reflect/api/Mirrors.scala
@@ -109,7 +109,7 @@ package api
  * }}}
  *
  * '''[[scala.reflect.api.Mirrors#MethodMirror]]'''. Used for invoking instance methods (Scala only has
- * instance methods-- methods of objects are instance methods of object instances, obtainable
+ * instance methods—methods of objects are instance methods of object instances, obtainable
  * via `ModuleMirror.instance`). Entry point: `val mm = im.reflectMethod(<method symbol>)`.
  * Example:
  * {{{
@@ -124,7 +124,7 @@ package api
  * }}}
  *
  * '''[[scala.reflect.api.Mirrors#FieldMirror]]'''. Used for getting/setting instance fields
- * (Scala only has instance fields-- fields of objects are instance methods of object instances
+ * (Scala only has instance fields—fields of objects are instance methods of object instances
  * obtainable via ModuleMirror.instance). Entry point:
  * `val fm = im.reflectMethod(<field or accessor symbol>)`.
  * Example:

--- a/src/reflect/scala/reflect/api/Universe.scala
+++ b/src/reflect/scala/reflect/api/Universe.scala
@@ -22,7 +22,7 @@ package api
  *
  * [[scala.reflect.api.Universe]] has two specialized sub-universes for different scenarios.
  * [[scala.reflect.api.JavaUniverse]] adds operations that link symbols and types to the underlying
- * classes and runtime values of a JVM instance-- this can be thought of as the `Universe` that
+ * classes and runtime values of a JVM instance—this can be thought of as the `Universe` that
  * should be used for all typical use-cases of Scala reflection. [[scala.reflect.macros.Universe]]
  * adds operations which allow macros to access selected compiler data structures and operations--
  * this type of `Universe` should only ever exist within the implementation of a Scala macro.

--- a/src/reflect/scala/reflect/internal/Kinds.scala
+++ b/src/reflect/scala/reflect/internal/Kinds.scala
@@ -104,10 +104,10 @@ trait Kinds {
     || sym1.variance == sym2.variance
   )
 
-  /** Check well-kindedness of type application (assumes arities are already checked) -- @M
+  /** Check well-kindedness of type application (assumes arities are already checked) — @M
    *
-   * This check is also performed when abstract type members become concrete (aka a "type alias") -- then tparams.length==1
-   * (checked one type member at a time -- in that case, prefix is the name of the type alias)
+   * This check is also performed when abstract type members become concrete (aka a "type alias") — then tparams.length==1
+   * (checked one type member at a time—in that case, prefix is the name of the type alias)
    *
    * Type application is just like value application: it's "contravariant" in the sense that
    * the type parameters of the supplied type arguments must conform to the type parameters of

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -480,7 +480,7 @@ trait Types
 
     /** Replace formal type parameter symbols with actual type arguments. ErrorType on arity mismatch.
      *
-     * Amounts to substitution except for higher-kinded types. (See overridden method in TypeRef) -- \@M
+     * Amounts to substitution except for higher-kinded types. (See overridden method in TypeRef) — \@M
      */
     def instantiateTypeParams(formals: List[Symbol], actuals: List[Type]): Type =
       if (sameLength(formals, actuals)) this.subst(formals, actuals) else ErrorType
@@ -1003,7 +1003,7 @@ trait Types
 
     /** Find all members meeting the flag requirements.
      *
-     * If you require a DEFERRED member, you will get it if it exists -- even if there's an overriding concrete member.
+     * If you require a DEFERRED member, you will get it if it exists—even if there's an overriding concrete member.
      * If you exclude DEFERRED members, or don't specify any requirements,
      *    you won't get deferred members (whether they have an overriding concrete member or not)
      *
@@ -2296,10 +2296,10 @@ trait Types
      *  The only kind of "binds" we consider is where `prefix` (or its underlying type)
      *  is a refined type that declares `sym` (since the old prefix was discarded,
      *  the old symbol is now stale and we should update it, like in `def rebind`,
-     *  except this is not for overriding symbols -- a vertical move -- but a "lateral" change.)
+     *  except this is not for overriding symbols (a vertical move) but a "lateral" change.)
      *
      *  The reason for this hack is that substitution and asSeenFrom clone RefinedTypes and
-     *  their members, without updating the potential references to those members -- here, we aim to patch
+     *  their members, without updating the potential references to those members—here, we aim to patch
      *  this up, so that: when changing a TypeRef(pre, sym, args) to a TypeRef(pre', sym', args'), and pre
      *  embeds a symbol sym (pre is a RefinedType(_, Scope(..., sym,...)) or a SingleType with such an
      *  underlying type), make sure that we update sym' to compensate for the change of pre -> pre' (which may
@@ -3082,7 +3082,7 @@ trait Types
     // Is this existential of the form: T[Q1, ..., QN] forSome { type Q1 >: L1 <: U1, ..., QN >: LN <: UN}
     private def isStraightApplication = (quantified corresponds underlying.typeArgs){ (q, a) => q.tpe =:= a }
 
-    /** [scala/bug#6169, scala/bug#8197 -- companion to scala/bug#1786]
+    /** [scala/bug#6169, scala/bug#8197 — companion to scala/bug#1786]
      *
      * Approximation to improve the bounds of a Java-defined existential type,
      * based on the bounds of the type parameters of the quantified type

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -966,7 +966,7 @@ private[internal] trait TypeMaps {
      * (1) If `T` is stable, we can just use that.
      *
      * (2) scala/bug#3873: it'd be unsound to instantiate `param.type` to an unstable `T`,
-     * so we approximate to `X forSome {type X <: T with Singleton}` -- we can't soundly say more.
+     * so we approximate to `X forSome {type X <: T with Singleton}` — we can't soundly say more.
      */
     def apply(tp: Type): Type = tp match {
       case SingleType(NoPrefix, StabilizedArgTp(tp)) => tp

--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -344,8 +344,8 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_),
     def valueClassList = List("unit", "boolean", "byte", "short", "char", "int", "long", "float", "double")
     def valueClassFilterPrefixes = List("scala.LowPriorityImplicits", "scala.Predef")
 
-    /** Dirty, dirty, dirty hack: the value params conversions can all kick in -- and they are disambiguated by priority
-     *  but showing priority in scaladoc would make no sense -- so we have to manually remove the conversions that we
+    /** Dirty, dirty, dirty hack: the value params conversions can all kick in—and they are disambiguated by priority
+     *  but showing priority in scaladoc would make no sense—so we have to manually remove the conversions that we
      *  know will never get a chance to kick in. Anyway, DIRTY DIRTY DIRTY! */
     def valueClassFilter(value: String, conversionName: String): Boolean = {
       val valueName = value.toLowerCase

--- a/src/scaladoc/scala/tools/nsc/doc/model/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/Entity.scala
@@ -231,9 +231,9 @@ trait NoDocTemplate extends TemplateEntity {
 }
 
 /** An inherited template that was not documented in its original owner - example:
- *  in classpath:  trait T { class C } -- T (and implicitly C) are not documented
- *  in the source: trait U extends T -- C appears in U as a MemberTemplateImpl
- *    -- that is, U has a member for it but C doesn't get its own page */
+ *  in classpath:  trait T { class C } — T (and implicitly C) are not documented
+ *  in the source: trait U extends T — C appears in U as a MemberTemplateImpl
+ *    — that is, U has a member for it but C doesn't get its own page */
 trait MemberTemplateEntity extends TemplateEntity with MemberEntity with HigherKinded {
 
   /** The value parameters of this case class, or an empty list if this class is not a case class. As case class value

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -250,7 +250,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
 
   /** An inherited template that was not documented in its original owner - example:
    *  in classpath:  trait T { class C } — T (and implicitly C) are not documented
-   *  in the source: trait U extends T — C appears in U as a MemberTemplateImpl -- that is, U has a member for it
+   *  in the source: trait U extends T — C appears in U as a MemberTemplateImpl — that is, U has a member for it
    *  but C doesn't get its own page
    */
   abstract class MemberTemplateImpl(sym: Symbol, inTpl: DocTemplateImpl) extends MemberImpl(sym, inTpl) with TemplateImpl with HigherKindedImpl with MemberTemplateEntity {

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -249,8 +249,8 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
   }
 
   /** An inherited template that was not documented in its original owner - example:
-   *  in classpath:  trait T { class C } -- T (and implicitly C) are not documented
-   *  in the source: trait U extends T -- C appears in U as a MemberTemplateImpl -- that is, U has a member for it
+   *  in classpath:  trait T { class C } — T (and implicitly C) are not documented
+   *  in the source: trait U extends T — C appears in U as a MemberTemplateImpl -- that is, U has a member for it
    *  but C doesn't get its own page
    */
   abstract class MemberTemplateImpl(sym: Symbol, inTpl: DocTemplateImpl) extends MemberImpl(sym, inTpl) with TemplateImpl with HigherKindedImpl with MemberTemplateEntity {

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
@@ -486,7 +486,7 @@ trait ModelFactoryImplicitSupport {
    *  - before finding a view (implicit method in scope that maps class A[T1,T2,.. Tn] to something else) the type
    * parameters are transformed into "untouchable" type variables so that type inference does not attempt to
    * fully solve them down to a type but rather constrains them on both sides just enough for the view to be
-   * applicable -- now, we want to transform those type variables back to the original type parameters
+   * applicable—now, we want to transform those type variables back to the original type parameters
    *  - some of the bounds fail type inference and therefore refer to Nothing => when performing unification (lub, glb)
    * they start looking ugly => we (unsoundly) transform Nothing to WildcardType so we fool the unification algorithms
    * into thinking there's nothing there

--- a/test/files/pos/t796.scala
+++ b/test/files/pos/t796.scala
@@ -1,4 +1,4 @@
-/** I know what I am doing is wrong -- since I am about to look into
+/** I know what I am doing is wrong—since I am about to look into
  *  this bug, I add a test in pending/pos... however, I am afraid that
  *  once this bug is fixed, this test case might go into test/pos
  *  there it adds to the huge number of tiny little test cases.

--- a/test/files/run/t5971.scala
+++ b/test/files/run/t5971.scala
@@ -6,7 +6,7 @@
 /** When using `AbstractTransformed` abstract inner class in views in order
  *  to force generating bridges, one must take care to push the corresponding
  *  collection trait (such as `Iterable` or `Seq`) as far as possible to the
- *  left in the linearization order -- otherwise, overridden methods from these
+ *  left in the linearization order—otherwise, overridden methods from these
  *  traits can override the already overridden methods in view. This was the
  *  case with `takeWhile`.
  *  Mind blowing, I know.

--- a/test/scaladoc/resources/implicits-ambiguating-res.scala
+++ b/test/scaladoc/resources/implicits-ambiguating-res.scala
@@ -1,5 +1,5 @@
 /**
- *  Test scaladoc implicits distinguishing -- suppress all members by implicit conversion that are shadowed by the
+ *  Test scaladoc implicits distinguishing—suppress all members by implicit conversion that are shadowed by the
  *  class' own members
  *
  *  {{{

--- a/test/scaladoc/resources/implicits-shadowing-res.scala
+++ b/test/scaladoc/resources/implicits-shadowing-res.scala
@@ -1,5 +1,5 @@
 /**
- *  Test scaladoc implicits distinguishing -- suppress all members by implicit conversion that are shadowed by the
+ *  Test scaladoc implicits distinguishing—suppress all members by implicit conversion that are shadowed by the
  *  class' own members
  *
  *  {{{


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Dash#En_dash_versus_em_dash
https://www.thepunctuationguide.com/em-dash.html