### PR TITLE
Avoid rare StackOverflow in diverging implicits check

### DIFF
--- a/test/files/neg/t12005.check
+++ b/test/files/neg/t12005.check
@@ -1,0 +1,5 @@
+t12005.scala:24: error: diverging implicit expansion for type AbstractSaleRepository.this.context.Encoder[A]
+starting with method mappedDecoder in trait Encoding
+  implicitly[Encoder[A]]
+            ^
+1 error

--- a/test/files/neg/t12005.scala
+++ b/test/files/neg/t12005.scala
@@ -1,0 +1,25 @@
+class A
+class B
+class MappedEncoding[I, O]
+
+trait Encoding {
+  type Encoder[T]
+  implicit def mappedEncoder[I, O](implicit mapped: MappedEncoding[I, O], encoder: Encoder[O]): Encoder[I]
+  implicit def mappedDecoder[I, O](implicit mapped: MappedEncoding[I, O], decoder: Encoder[I]): Encoder[O]
+}
+
+trait Tag[T]
+object Tag {
+  type Context[T] = Encoding with Tag[T]
+}
+
+trait WithContext[T] {
+  protected val context: Tag.Context[T]
+  implicit val encoder: MappedEncoding[A, B]
+  implicit val decoder: MappedEncoding[B, A]
+}
+
+trait AbstractSaleRepository[T] extends WithContext[T] {
+  import context._
+  implicitly[Encoder[A]]
+}


### PR DESCRIPTION
Two refined types may be equal wrt `=:=` but have different symbols.
We cannot use `=:=` because it is too pessimistic (wrt wildcards),
but this property of refined types makes `allSymbols` too optimistic.

For the implicit divergence check to work, we want the invariant:
`T =:= U` implies `allSymbols(T) == allSymbols(U)` to hold.
The solution is to exclude the symbols of refined types,
which makes `allSymbols` a bit more pessimistic.

Convert `allSymbols` from a recursive function to a `TypeCollector`
to avoid all the intermediate list allocations.

Fixes scala/bug#12005