### PR TITLE
Reusable instance for the Contains Collector.

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -1063,7 +1063,11 @@ private[internal] trait TypeMaps {
   }
 
   /** A map to implement the `contains` method. */
-  class ContainsCollector(sym: Symbol) extends ExistsTypeRefCollector {
+  class ContainsCollector(private[this] var sym: Symbol) extends ExistsTypeRefCollector {
+    def reset(nsym: Symbol): Unit = {
+      result = false
+      sym = nsym
+    }
     override protected def pred(sym1: Symbol): Boolean = sym1 == sym
   }
   class ContainsAnyCollector(syms: List[Symbol]) extends ExistsTypeRefCollector {


### PR DESCRIPTION
In one profile measurement, 1% of total allocations were for
ContainsCollector object, in the locations in this part of the code.

- We make the `ContainsCollector` object into a mutable object,
  for which we add a reset method.
- We use a `ReusableInstance` pool of `ContainsCollector` objects.