### PR TITLE
[2.12] Bump down baseVersion to 2.12.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ lazy val publishSettings : Seq[Setting[_]] = Seq(
 // should not be set directly. It is the same as the Maven version and derived automatically from `baseVersion` and
 // `baseVersionSuffix`.
 globalVersionSettings
-baseVersion in Global       := "2.12.12"
+baseVersion in Global       := "2.12.11"
 baseVersionSuffix in Global := "SNAPSHOT"
 organization in ThisBuild   := "org.scala-lang"
 homepage in ThisBuild       := Some(url("https://www.scala-lang.org"))


### PR DESCRIPTION
Making this change will make CrossVersion.patch work properly when using
the "merge-ly" publishes, which would now have the version
"2.12.11-bin-[sha]", which translates into the artefact suffix _2.12.11.

CrossVersion.patch is an improved version of CrossVersion.full, which
strips the `-bin-..." suffix and is what should be used for anything
that depends on the scala-compiler, such as compiler plugins.

The motivation here was to make it much, much easier (as in: actually
humanly possible) to consume the HEAD publishes of Scala when using
Scalafix (and Scalameta) in a multi-project build.