### PR TITLE
Emit method reference lambdas without helper method

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -15,7 +15,6 @@ package backend.jvm
 
 import scala.annotation.switch
 import scala.collection.mutable.ListBuffer
-import scala.reflect.internal.Flags
 import scala.tools.asm
 import scala.tools.asm.Opcodes
 import scala.tools.asm.tree.{MethodInsnNode, MethodNode}
@@ -1361,21 +1360,27 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
     def genLoadTry(tree: Try): BType
 
     def genInvokeDynamicLambda(canLMF: delambdafy.LambdaMetaFactoryCapable) = {
-      import canLMF._
+      import canLMF.{ lambdaTarget => originalTarget, _ }
 
-      val isStaticMethod = lambdaTarget.hasFlag(Flags.STATIC)
+      val lambdaTarget = originalTarget.attachments.get[JustMethodReference].map(_.lambdaTarget).getOrElse(originalTarget)
       def asmType(sym: Symbol) = classBTypeFromSymbol(sym).toASMType
 
       val isInterface = lambdaTarget.owner.isTrait
+      val tag =
+        if (lambdaTarget.isStaticMember) Opcodes.H_INVOKESTATIC
+        else if (lambdaTarget.isPrivate) Opcodes.H_INVOKESPECIAL
+        //else if (lambdaTarget.isClassConstructor) Opcodes.H_NEWINVOKESPECIAL // to invoke Foo::new directly
+        else if (isInterface) Opcodes.H_INVOKEINTERFACE
+        else Opcodes.H_INVOKEVIRTUAL
       val implMethodHandle =
-        new asm.Handle(if (lambdaTarget.hasFlag(Flags.STATIC)) asm.Opcodes.H_INVOKESTATIC else if (isInterface) asm.Opcodes.H_INVOKEINTERFACE else asm.Opcodes.H_INVOKEVIRTUAL,
+        new asm.Handle(
+          tag,
           classBTypeFromSymbol(lambdaTarget.owner).internalName,
           lambdaTarget.name.toString,
           methodBTypeFromSymbol(lambdaTarget).descriptor,
           /* itf = */ isInterface)
-      val receiver = if (isStaticMethod) Nil else lambdaTarget.owner :: Nil
-      val (capturedParams, lambdaParams) = lambdaTarget.paramss.head.splitAt(lambdaTarget.paramss.head.length - arity)
-      val invokedType = asm.Type.getMethodDescriptor(asmType(functionalInterface), (receiver ::: capturedParams).map(sym => typeToBType(sym.info).toASMType): _*)
+      val (capturedParams, lambdaParams) = originalTarget.paramss.head.splitAt(originalTarget.paramss.head.length - arity)
+      val invokedType = asm.Type.getMethodDescriptor(asmType(functionalInterface), capturedParams.map(sym => typeToBType(sym.info).toASMType): _*)
       val constrainedType = MethodBType(lambdaParams.map(p => typeToBType(p.tpe)), typeToBType(lambdaTarget.tpe.resultType)).toASMType
       val samMethodType = methodBTypeFromSymbol(sam).toASMType
       val markers = if (addScalaSerializableMarker) classBTypeFromSymbol(definitions.SerializableClass).toASMType :: Nil else Nil

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -553,6 +553,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
     def genDefDef(dd: DefDef) {
       // the only method whose implementation is not emitted: getClass()
       if (definitions.isGetClass(dd.symbol)) { return }
+      if (dd.symbol.hasAttachment[JustMethodReference]) { return }
       assert(mnode == null, "GenBCode detected nested method.")
 
       methSymbol  = dd.symbol

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -250,7 +250,7 @@ trait ScalaSettings extends AbsScalaSettings
   val Youtline        = BooleanSetting    ("-Youtline", "Don't compile method bodies. Use together with `-Ystop-afer:pickler to generate the pickled signatures for all source files.").internalOnly()
 
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
-  val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")
+  val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method", "method-ref"), "method")
   val YmacroClasspath = PathSetting       ("-Ymacro-classpath", "The classpath used to reflectively load macro implementations, default is the compilation classpath.", "")
 
   // Allows a specialised jar to be written. For instance one that provides stable hashing of content, or customisation of the file storage

--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -586,7 +586,7 @@ abstract class LambdaLift extends InfoTransform {
   private def addFree[A](sym: Symbol, free: List[A], original: List[A]): List[A] = {
     val prependFree = (
          !sym.isConstructor // this condition is redundant for now. It will be needed if we remove the second condition in 2.12.x
-      && (settings.Ydelambdafy.value == "method" && sym.isDelambdafyTarget) // scala/bug#8359 Makes the lambda body a viable as the target MethodHandle for a call to LambdaMetafactory
+      && (settings.Ydelambdafy.value != "inline" && sym.isDelambdafyTarget) // scala/bug#8359 Makes the lambda body a viable as the target MethodHandle for a call to LambdaMetafactory
     )
     if (prependFree) free ::: original
     else             original ::: free

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -71,6 +71,8 @@ trait StdAttachments {
 
   case object DelambdafyTarget extends PlainAttachment
 
+  case class JustMethodReference(lambdaTarget: Symbol) extends PlainAttachment
+
   /** When present, indicates that the host `Ident` has been created from a backquoted identifier.
    */
   case object BackquotedIdentifierAttachment extends PlainAttachment

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -51,6 +51,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.CompoundTypeTreeOriginalAttachment
     this.SAMFunction
     this.DelambdafyTarget
+    this.JustMethodReference
     this.BackquotedIdentifierAttachment
     this.NoWarnAttachment
     this.PatVarDefAttachment

--- a/test/files/run/indy-meth-refs-b.flags
+++ b/test/files/run/indy-meth-refs-b.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method-ref

--- a/test/files/run/indy-meth-refs-b.scala
+++ b/test/files/run/indy-meth-refs-b.scala
@@ -1,0 +1,7 @@
+object Test {
+  def min0[A](less: (A, A) => Boolean, xs: List[A]): Option[A] = None
+
+  def min(xs: List[Int]) = min0((x: Int, y: Int) => x < y, xs)
+
+  def main(args: Array[String]): Unit = min(List())
+}

--- a/test/files/run/indy-meth-refs-c.flags
+++ b/test/files/run/indy-meth-refs-c.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method-ref

--- a/test/files/run/indy-meth-refs-c.scala
+++ b/test/files/run/indy-meth-refs-c.scala
@@ -1,0 +1,11 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    val str = ""
+    val foo = new Foo()
+    use(foo.bar(str))
+  }
+
+  class Foo { def bar(x: Object) = Symbol("ok") }
+
+  def use(x: => Any) = ()
+}

--- a/test/files/run/indy-meth-refs-d.flags
+++ b/test/files/run/indy-meth-refs-d.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method-ref

--- a/test/files/run/indy-meth-refs-d.scala
+++ b/test/files/run/indy-meth-refs-d.scala
@@ -1,0 +1,5 @@
+object Test {
+  class Foo { def bar() = () }
+  def main(args: Array[String]): Unit =
+    Option(new Foo()).foreach(_.bar())
+}

--- a/test/files/run/indy-meth-refs-e.flags
+++ b/test/files/run/indy-meth-refs-e.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method-ref

--- a/test/files/run/indy-meth-refs-e.scala
+++ b/test/files/run/indy-meth-refs-e.scala
@@ -1,0 +1,5 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    List(Option("a")).map(_.map(_.toUpperCase))
+  }
+}

--- a/test/files/run/indy-meth-refs-f.flags
+++ b/test/files/run/indy-meth-refs-f.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method-ref

--- a/test/files/run/indy-meth-refs-f.scala
+++ b/test/files/run/indy-meth-refs-f.scala
@@ -1,0 +1,121 @@
+object Test {
+  def anyA(f: Any => Any)     = ()
+  def anyB(f: Any => Boolean) = ()
+  def anyI(f: Any => Int)     = ()
+
+  def objA(f: Object => Any)           = ()
+  def objB(f: Object => Boolean)       = ()
+  def objI(f: Object => Int)           = ()
+
+  def strS(f: String => String) = ()
+
+  def arrII(f: Array[Int] => Int)       = ()
+  def arrSI(f: Array[String] => Int)    = ()
+  def arrSS(f: Array[String] => String) = ()
+
+  def boolB(f: Boolean => Boolean) = ()
+
+  def intI(f: Int => Int)     = ()
+  def intB(f: Int => Boolean) = ()
+
+  class StrVC(val x: String) extends AnyVal {
+    def unwrap = x
+    def bang   = new StrVC(x + "!")
+  }
+  class BoolVC(val x: Boolean) extends AnyVal {
+    def unwrap = x
+    def not    = new BoolVC(!x)
+  }
+  class IntVC(val x: Int) extends AnyVal {
+    def unwrap   = x
+    def inc      = new IntVC(x + 1)
+    def isZero   = x == 0
+    def isZeroVC = new BoolVC(x == 0)
+  }
+
+  def mkStrVC(x: String): StrVC    = new StrVC(x)
+  def mkBoolVC(x: Boolean): BoolVC = new BoolVC(x)
+  def mkIntVC(x: Int): IntVC       = new IntVC(x)
+
+  def strVC1(f: StrVC => String) = ()
+  def strVC2(f: StrVC => StrVC)  = ()
+  def strVC3(f: String => StrVC) = ()
+
+  def boolVC1(f: BoolVC => Boolean) = ()
+  def boolVC2(f: BoolVC => BoolVC)  = ()
+  def boolVC3(f: Boolean => BoolVC) = ()
+
+  def intVC1(f: IntVC => Int)     = ()
+  def intVC2(f: IntVC => IntVC)   = ()
+  def intVC3(f: Int => IntVC)     = ()
+  def intVC4(f: IntVC => Boolean) = ()
+
+  def vcs1(f: IntVC => BoolVC) = ()
+
+  def main(args: Array[String]): Unit = {
+    anyB("" == _)
+    anyB("" != _)
+    anyB(_.isInstanceOf[String])
+    anyA(_.asInstanceOf[String])
+    anyI(_.##)
+
+    objB("" eq _)
+    objB("" ne _)
+    objB("" == _)
+    objB("" != _)
+    objB(_.isInstanceOf[String])
+    objA(_.asInstanceOf[String])
+    objA("".synchronized(_))
+
+    strS("" + _)
+
+    arrII(_.length)
+    arrII(xs => xs(0))
+    arrSI(_.length)
+    arrSS(xs => xs(0))
+
+    //boolB(true eq _) // the result type of an implicit conversion must be more specific than AnyRef  ¯\_(ツ)_/¯
+    //boolB(true ne _)
+    boolB(!_)
+    boolB(true || _)
+    boolB(true && _)
+    boolB(true | _)
+    boolB(true & _)
+    boolB(true ^ _)
+
+    //intB(1 eq _)
+    //intB(1 ne _)
+    intI(1 + _)
+    intI(1 - _)
+    intI(1 * _)
+    intI(1 / _)
+    intI(1 % _)
+    intB(1 < _)
+    intB(1 <= _)
+    intB(1 > _)
+    intB(1 >= _)
+    intI(1 ^ _)
+    intI(1 & _)
+    intI(1 << _)
+    intI(1 >>> _)
+    intI(1 >> _)
+    intI(_.toInt)
+    intI(i => -i)
+    intI(i => ~i)
+
+    strVC1(_.unwrap)
+    strVC2(_.bang)
+    strVC3(mkStrVC(_))
+
+    boolVC1(_.unwrap)
+    boolVC2(_.not)
+    boolVC3(mkBoolVC(_))
+
+    intVC1(_.unwrap)
+    intVC2(_.inc)
+    intVC3(mkIntVC(_))
+    intVC4(_.isZero)
+
+    vcs1(_.isZeroVC)
+  }
+}

--- a/test/files/run/indy-meth-refs-g.flags
+++ b/test/files/run/indy-meth-refs-g.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method-ref

--- a/test/files/run/indy-meth-refs-g.scala
+++ b/test/files/run/indy-meth-refs-g.scala
@@ -1,0 +1,15 @@
+import java.io.File
+
+import scala.collection.mutable
+
+object Test {
+  val fqnsToFiles = mutable.HashMap[String, (File, Boolean)]()
+
+  def main(args: Array[String]): Unit = test()
+
+  def test() = {
+    val fqn = "bob"
+    val newResult = Option((new File("f"), true))
+    newResult.foreach(res => fqnsToFiles.put(fqn, res))
+  }
+}

--- a/test/files/run/indy-meth-refs-h.flags
+++ b/test/files/run/indy-meth-refs-h.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method-ref

--- a/test/files/run/indy-meth-refs-h.scala
+++ b/test/files/run/indy-meth-refs-h.scala
@@ -1,0 +1,12 @@
+trait Entity {
+  def name: String
+  def announce = {
+    def msg = s"I am $name"
+    None.getOrElse(msg)
+  }
+}
+
+object Test extends Entity {
+  def name = "Test"
+  def main(args: Array[String]): Unit = assert(announce == "I am Test")
+}

--- a/test/files/run/indy-meth-refs-i.flags
+++ b/test/files/run/indy-meth-refs-i.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method-ref

--- a/test/files/run/indy-meth-refs-i.scala
+++ b/test/files/run/indy-meth-refs-i.scala
@@ -1,0 +1,16 @@
+class C {
+  def foo = 0
+}
+
+class D extends C {
+  override def foo = 1
+  def bar = () => super.foo
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val d = new D
+    val obtained = d.bar.apply()
+    assert(obtained == 0, obtained)
+  }
+}

--- a/test/files/run/indy-meth-refs.flags
+++ b/test/files/run/indy-meth-refs.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method-ref

--- a/test/files/run/indy-meth-refs.scala
+++ b/test/files/run/indy-meth-refs.scala
@@ -1,0 +1,9 @@
+case object Test {
+  def f0(f: Function0[String])      = ()
+  def f1(f: Function1[Any, String]) = ()
+
+  def main(args: Array[String]): Unit = {
+    f0(() => toString())
+    f1(_.toString())
+  }
+}

--- a/test/files/run/lambda-serialization-meth-ref.flags
+++ b/test/files/run/lambda-serialization-meth-ref.flags
@@ -1,0 +1,1 @@
+-Ydelambdafy:method-ref

--- a/test/files/run/lambda-serialization-meth-ref.scala
+++ b/test/files/run/lambda-serialization-meth-ref.scala
@@ -1,0 +1,36 @@
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.io.{ObjectInputStream, ObjectOutputStream}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    roundTripMethRef()
+    roundTripMethRef_F0()
+  }
+
+  // lambda targeting a method reference, not a SAM or FunctionN (should behave the same way)
+  def roundTripMethRef(): Unit = {
+    val lambda: String => String = (s: String) => s.toUpperCase
+    val reconstituted1 = serializeDeserialize(lambda).asInstanceOf[String => String]
+    val reconstituted2 = serializeDeserialize(reconstituted1).asInstanceOf[String => String]
+    assert(reconstituted1.apply("yo") == "YO")
+    assert(reconstituted1.getClass == reconstituted2.getClass)
+  }
+
+  def name = "Test"
+
+  def roundTripMethRef_F0(): Unit = {
+    val lambda: () => String = () => Test.name
+    val reconstituted1 = serializeDeserialize(lambda).asInstanceOf[() => String]
+    val reconstituted2 = serializeDeserialize(reconstituted1).asInstanceOf[() => String]
+    assert(reconstituted1.apply() == "Test")
+    assert(reconstituted1.getClass == reconstituted2.getClass)
+  }
+
+  def serializeDeserialize[T <: AnyRef](obj: T) = {
+    val buffer = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(obj)
+    val in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray))
+    in.readObject.asInstanceOf[T]
+  }
+}

--- a/test/files/run/lambda-serialization.scala
+++ b/test/files/run/lambda-serialization.scala
@@ -39,8 +39,18 @@ object Test {
   }
 
   def fakeLambdaFailsToDeserialize(): Unit = {
-    val fake = new SerializedLambda(classOf[C], classOf[FakeSam].getName, "apply", "()V",
-      MethodHandleInfo.REF_invokeVirtual, classOf[C].getName, "foo", "()V", "()V", Array(new C))
+    val fake = new SerializedLambda(
+      /*           capturingClass           = */ classOf[C],
+      /* functionalInterfaceClass           = */ classOf[FakeSam].getName,
+      /* functionalInterfaceMethodName      = */ "apply",
+      /* functionalInterfaceMethodSignature = */ "()V",
+      /*                implMethodKind      = */ MethodHandleInfo.REF_invokeVirtual,
+      /*                implClass           = */ classOf[C].getName,
+      /*                implMethodName      = */ "foo",
+      /*                implMethodSignature = */ "()V",
+      /*        instantiatedMethodType      = */ "()V",
+      /*            capturedArgs            = */ Array(new C),
+    )
     try {
       serializeDeserialize(fake).asInstanceOf[FakeSam].apply()
       assert(false)

--- a/test/junit/scala/tools/nsc/backend/jvm/IndyLambdaDirectTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/IndyLambdaDirectTest.scala
@@ -1,0 +1,23 @@
+package scala.tools.nsc.backend.jvm
+
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.tools.testing.BytecodeTesting
+
+class IndyLambdaDirectTest extends BytecodeTesting {
+  import compiler._
+  override def compilerArgs = "-Ydelambdafy:method-ref"
+
+  @Test def f0(): Unit = {
+    compileToBytes("object F0 { def f0(f: Function0[String]) = () }")
+    val meths = compileAsmMethods("def f() = F0.f0(() => toString())").map(_.name)
+    assertTrue(s"Expected no anonfuns: $meths", meths.forall(!_.contains("anonfun")))
+  }
+
+  @Test def f1(): Unit = {
+    compileToBytes("object F1 { def f1(f: Function1[Any, String]) = () }")
+    val meths = compileAsmMethods("def f() = F1.f1(_.toString())").map(_.name)
+    assertTrue(s"Expected no anonfuns: $meths", meths.forall(!_.contains("anonfun")))
+  }
+}


### PR DESCRIPTION
Under -Ydelambdafy:method-ref, when a lambda is just invoking a method
(i.e. is "just a method reference"), such as `foo()` or `x => bar(x)`,
(and other caveats around specialisation, boxing concerns for primitives
and its value classes, arrays, etc) then rather than emit an
`invokedynamic` to a helper method that invokes the target method, emit
an `invokedynamic` to the target method directly.

- [x] add some tests around serialization, ensure that the generated `$deserializeLambda$` works as intended

## Explanation

Note that this is opt-in, with `-Ydelambdafy:method-ref`.  The reason it's opt-in is because there's an assumption (an "invariant") in serialisation: if you serialise the lambda from one version of some code (v1) then deserialising it in a later version (v2) should run the new (v2) behaviour.

For example, if you serialise the lambda `(x => x.toString())` then deserialise it when the code is `(x => x.toString().toUpperCase())`, then the result should be upper-cased.  Under `-Ydelambdafy:method-ref` the deserialised lambda will continue to just be a reference to Object's `toString` method.  Also worth mentioning that in the same example, but with the versions swapped, the lambda will be a reference an `$anonfun$...` method that no longer exists in v2... which means that it will throw a `LinkageError` at runtime.