### PR TITLE
Cleanup: remove `returning` from compiler internals, use `tap` instead now that we have it

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeDSL.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeDSL.scala
@@ -32,8 +32,6 @@ trait TreeDSL {
     def nullSafe[T](f: Tree => Tree, ifNull: Tree): Tree => Tree =
       tree => IF (tree MEMBER_== NULL) THEN ifNull ELSE f(tree)
 
-    def returning[T](x: T)(f: T => Unit): T = util.returning(x)(f)
-
     object LIT extends (Any => Literal) {
       def typed(x: Any)   = apply(x) setType ConstantType(Constant(x))
       def apply(x: Any)   = Literal(Constant(x))

--- a/src/compiler/scala/tools/nsc/ast/parser/xml/MarkupParserCommon.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/xml/MarkupParserCommon.scala
@@ -168,9 +168,6 @@ private[scala] trait MarkupParserCommon {
     if (isSpace(ch)) { nextch(); xSpaceOpt() }
     else xHandleError(ch, "whitespace expected")
 
-  /** Apply a function and return the passed value */
-  def returning[T](x: T)(f: T => Unit): T = { f(x); x }
-
   /** Execute body with a variable saved and restored after execution */
   def saving[A, B](getter: A, setter: A => Unit)(body: => B): B = {
     val saved = getter

--- a/src/compiler/scala/tools/nsc/util/package.scala
+++ b/src/compiler/scala/tools/nsc/util/package.scala
@@ -25,9 +25,6 @@ package object util {
   type HashSet[T >: Null <: AnyRef] = scala.reflect.internal.util.HashSet[T]
   val HashSet = scala.reflect.internal.util.HashSet
 
-  /** Apply a function and return the passed value */
-  def returning[T](x: T)(f: T => Unit): T = { f(x) ; x }
-
   /** Execute code and then wait for all non-daemon Threads
    *  created and begun during its execution to complete.
    */

--- a/src/partest/scala/tools/partest/nest/Opt.scala
+++ b/src/partest/scala/tools/partest/nest/Opt.scala
@@ -13,6 +13,7 @@
 package scala.tools.partest.nest
 
 import scala.tools.nsc.Properties.envOrElse
+import scala.util.chaining._
 import Spec.Info
 
 /** Machinery for what amounts to a command line specification DSL.
@@ -66,7 +67,7 @@ object Opt {
     def choiceOf[T: FromString](choices: T*)  = { addBinary(opt) ; None }
     def expandTo(args: String*)               = { addExpand(name, args.toList) ; addHelpAlias(() => args mkString " ") }
 
-    def /(descr: String)                = returning(name)(_ => addHelp(() => helpFormatStr.format(opt, descr)))
+    def /(descr: String)                = name.tap(_ => addHelp(() => helpFormatStr.format(opt, descr)))
   }
 
   class Instance(val programInfo: Info, val parsed: CommandLine, val name: String) extends Implicit with Error {

--- a/src/partest/scala/tools/partest/nest/Spec.scala
+++ b/src/partest/scala/tools/partest/nest/Spec.scala
@@ -12,6 +12,8 @@
 
 package scala.tools.partest.nest
 
+import scala.util.chaining._
+
 /** This trait works together with others in scala.tools.cmd to allow
  *  declaratively specifying a command line program, with many attendant
  *  benefits.  See scala.tools.cmd.DemoSpec for an example.
@@ -41,7 +43,7 @@ object Spec {
     private var _buf: List[T] = Nil
 
     def convert(s: String)    = implicitly[FromString[T]] apply s
-    def apply(s: String): T   = returning(convert(s))(_buf +:= _)
+    def apply(s: String): T   = convert(s).tap(_buf +:= _)
 
     lazy val get = _buf
   }

--- a/src/partest/scala/tools/partest/nest/package.scala
+++ b/src/partest/scala/tools/partest/nest/package.scala
@@ -13,7 +13,6 @@
 package scala.tools.partest
 
 package object nest {
-  def returning[T](x: T)(f: T => Unit): T = { f(x) ; x }
 
   def runAndExit(body: => Unit): Nothing = {
     body

--- a/test/files/pos/t7591/Property.scala
+++ b/test/files/pos/t7591/Property.scala
@@ -12,7 +12,8 @@
 
 import scala.tools.cmd.toArgs
 import scala.tools.nsc.io._
-import scala.tools.partest.nest.{ Reference, returning, toOpt }
+import scala.tools.partest.nest.{Reference, toOpt}
+import scala.util.chaining._
 import java.util.Properties
 import java.io.FileInputStream
 
@@ -41,7 +42,7 @@ class PropertyMapper(reference: Reference) extends (((String, String)) => List[S
 
     if (isUnaryOption(key) && isTrue(value)) List(opt)
     else if (isBinaryOption(key)) List(opt, value)
-    else returning(Nil)(_ => onError(key, value))
+    else Nil.tap(_ => onError(key, value))
   }
   def isTrue(value: String) = List("yes", "on", "true") contains value.toLowerCase
 
@@ -61,7 +62,7 @@ trait Property extends Reference {
   override def propertyArgs: List[String] = systemPropertiesToOptions
 
   def loadProperties(file: File): Properties  =
-    returning(new Properties)(_ load new FileInputStream(file.path))
+    new Properties().tap(_ load new FileInputStream(file.path))
 
   def systemPropertiesToOptions: List[String] =
     propertiesToOptions(System.getProperties)


### PR DESCRIPTION

Returning and returning in the [widening gyre](https://www.poetryfoundation.org/poems/43290/the-second-coming)...

There are no clients of returning; use `tap` from util.chaining instead.

Actually there's another returning in partest's old code; updated.