### PR TITLE
Do not lint multiarg for mixed op def

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2426,7 +2426,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
           if (settings.multiargInfix && !meth.isConstructor && meth.owner.isClass && !meth.isDeprecated && !meth.hasAnnotation(UnusedClass) && !meth.ownerChain.exists(_.isDeprecated))
             meth.paramss match {
-              case (h :: _ :: _) :: Nil if !h.isImplicit && Chars.isOperatorPart(meth.name.decoded.last) =>
+              case (h :: _ :: _) :: Nil if !h.isImplicit && Chars.isOperatorPart(meth.name.decoded.head) =>
                 context.warning(meth.pos, "multiarg infix syntax looks like a tuple and will be deprecated", WarningCategory.LintMultiargInfix)
               case _ =>
             }

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -504,14 +504,13 @@ trait Names extends api.Names {
       }
 
     def decodedName: ThisNameType = newName(decode)
-    def isOperatorName: Boolean = decode != toString  // used by ide
-    def longString: String      = nameKind + " " + decode
-    def debugString = { val s = decode ; if (isTypeName) s + "!" else s }
+    def isOperatorName: Boolean   = decoded != toString
+    def longString: String        = s"$nameKind $decoded"
+    def debugString               = if (isTypeName) s"$decoded!" else decoded
 
     override final def toString: String = if (cachedString == null) new String(_chrs, index, len) else cachedString
-    final def appendTo(buffer: java.lang.StringBuffer, start: Int, length: Int): Unit = {
+    final def appendTo(buffer: java.lang.StringBuffer, start: Int, length: Int): Unit =
       buffer.append(_chrs, this.start + start, length)
-    }
   }
 
   implicit val NameTag = ClassTag[Name](classOf[Name])

--- a/test/files/neg/sd503.check
+++ b/test/files/neg/sd503.check
@@ -19,12 +19,6 @@ sd503.scala:15: warning: multiarg infix syntax looks like a tuple and will be de
 sd503.scala:19: warning: multiarg infix syntax looks like a tuple and will be deprecated
   def f5() = c x_= (42, 27)           // multiarg, warn
                ^
-sd503.scala:29: warning: multiarg infix syntax looks like a tuple and will be deprecated
-  def x_=(i: Int, j: Int): Unit = value = i + j           // multiarg, warn
-      ^
-sd503.scala:34: warning: multiarg infix syntax looks like a tuple and will be deprecated
-  def x_=(i: Int, j: Int = 1): Unit = devalue = i + j     // multiarg, warn
-      ^
 sd503.scala:54: warning: multiarg infix syntax looks like a tuple and will be deprecated
   def +=(x: A, y: A, zs: A*): this.type = addAll(x +: y +: zs)                // very multiarg, warn
       ^
@@ -34,5 +28,8 @@ sd503.scala:59: warning: multiarg infix syntax looks like a tuple and will be de
 sd503.scala:70: warning: multiarg infix syntax looks like a tuple and will be deprecated
   def f(x: A, y: A, zs: A*): this.type = this += (x, y, zs: _*)               // warn but could defer to deprecation
                                               ^
-9 warnings
+sd503.scala:80: warning: multiarg infix syntax looks like a tuple and will be deprecated
+  def f = this lines_! (42, 27)                                               // warn usage, of course
+               ^
+8 warnings
 2 errors

--- a/test/files/neg/sd503.scala
+++ b/test/files/neg/sd503.scala
@@ -26,12 +26,12 @@ trait T {
 class C {
   private var value: Int = _
   def x: Int = value
-  def x_=(i: Int, j: Int): Unit = value = i + j           // multiarg, warn
+  def x_=(i: Int, j: Int): Unit = value = i + j           // multiarg, but don't warn
 }
 class D {
   private var devalue: Int = _                            // d.value
   def x: Int = devalue
-  def x_=(i: Int, j: Int = 1): Unit = devalue = i + j     // multiarg, warn
+  def x_=(i: Int, j: Int = 1): Unit = devalue = i + j     // multiarg, but don't warn
 }
 
 // If the application is adapted such that what looks like a tuple is taken as a tuple,
@@ -73,4 +73,9 @@ trait Exceptions[A] {
 trait AlsoExceptions[A] {
   def addAll(as: Seq[A]): this.type
   def +=(x: A, y: A, zs: A*): this.type = addAll(x +: y +: zs)                // nowarn!
+}
+
+trait WhyNamingIsHard {
+  def lines_!(x: Int, y: Int): List[String] = ???                             // nowarn, give it a pass
+  def f = this lines_! (42, 27)                                               // warn usage, of course
 }

--- a/test/junit/scala/collection/Sizes.scala
+++ b/test/junit/scala/collection/Sizes.scala
@@ -31,12 +31,10 @@ class Sizes {
       assertTotalSize(Sizes.refArray(length), JOL.netLayout(new Array[String](length), Nil))
     }
   }
-  @Test
-  def wrappedArray2: Unit = {
-    for (length <- 1 to 10) {
+  @Test @deprecated("Tests deprecated API", since="2.13.3")
+  def wrappedArray2: Unit =
+    for (length <- 1 to 10)
       assertTotalSize(Sizes.wrappedRefArray(length), JOL.netLayout(mutable.WrappedArray.make[String](new Array[String](length)), Nil))
-    }
-  }
 
   @Test
   def wrappedArray: Unit = {

--- a/test/junit/scala/collection/SortedSetMapEqualsTest.scala
+++ b/test/junit/scala/collection/SortedSetMapEqualsTest.scala
@@ -1,12 +1,10 @@
 package scala.collection
 
-import org.junit.Assert.assertEquals
-import org.junit.{Assert, Test}
+import org.junit.{Assert, Test}, Assert.assertEquals
 
 class SortedSetMapEqualsTest {
   @Test
   def noOptimizedSetEqualityWhenOrderingsDiffer(): Unit = {
-    import scala.collection.immutable.SortedSet
     checkSet(ord => mutable.SortedSet.newBuilder[Int](ord))
     checkSet(ord => immutable.SortedSet.newBuilder[Int](ord))
     checkMap(ord => mutable.SortedMap.newBuilder[Int, Any](ord))
@@ -25,8 +23,8 @@ class SortedSetMapEqualsTest {
       b += 2
       b += 3
       val m = b.result
-      val m1 = m + 4
-      m1
+      val res = m.union(Set(4))
+      res
     }
 
     val m2 = {
@@ -54,8 +52,8 @@ class SortedSetMapEqualsTest {
       b += (2 -> "")
       b += (3 -> "")
       val m = b.result
-      val m1 = m + (4 -> "")
-      m1
+      val res = m.concat(List(4 -> ""))
+      res
     }
 
     val m2 = {


### PR DESCRIPTION

Follow-up per review by @SethTisue 

Remove lint of definition of `lines_!`, which is arguably innocent.
