### PR TITLE
Require types to be conformant for eta-expansion of SAM under -Xsource:3

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -653,4 +653,16 @@ trait TypeComparers {
     }
     loop(tp.baseClasses)
   }
+
+  /** Test if arg can be applied to expected.
+   */
+  def isApplicableMethod(arg: MethodType, expected: MethodType): Boolean = {
+    val params1 = arg.params
+    val params2 = expected.params
+    val substMap1 = new SubstSymMap(params1, params2)
+    val substMap2 = new SubstSymMap(params2, params1)
+    sameLength(params1, params2) &&
+    ((params1 corresponds params2) { (sym1, sym2) => isSubType(sym2.tpe, substMap1(sym1.tpe)) || isSubType(substMap2(sym2.tpe), sym1.tpe) }) &&
+    isSubType(substMap1(arg.resultType), expected.resultType) || isSubType(arg.resultType, substMap2(expected.resultType))
+  }
 }

--- a/test/files/neg/t7187-3.scala
+++ b/test/files/neg/t7187-3.scala
@@ -31,4 +31,13 @@ class EtaExpand214 {
   val t7a: () => Any  = t7 // error: t7 is an error
   val t8a: () => Any  = t8 // ok
   val t9a: Int => Any = t9 // ok
+
+  // see https://github.com/scala/bug/issues/12006
+  // java.io.InputStream looks like a SAM (read method),
+  // but u.openStream returns InputStream so don't eta-expand.
+  class C1(s: => java.io.InputStream)
+  class D1(u: java.net.URL) extends C1(u.openStream) // ok
+
+  class C2(s: java.io.InputStream)
+  class D2(u: java.net.URL) extends C2(u.openStream) // ok
 }


### PR DESCRIPTION
Ref https://github.com/scala/bug/issues/12006
Ref https://github.com/scala/scala/pull/7660

```scala
class C(s: java.io.InputStream); class D(u: java.net.URL) extends C(u.openStream)
```

raised in https://github.com/scala/bug/issues/12006 a weird piece of code under -Xsource:3 since we can interpret it in two ways.

1. `InputStream` is a SAM of `def read(): Int`, and `C(u.openStream)` requires an eta-expansion from openStream method to `() => Int`.
2. `u.openStream` needs auto application `()`.

Under -Xsource:3 Scala 2.13.2 takes the first interpretation since https://github.com/scala/scala/pull/7660 and then errors with surprising:

```
       error: type mismatch;
        found   : java.io.InputStream
        required: Int
```

This PR adds an additional check to see if the types match up between `def read(): Int` and `URL#openStream` before saying yes to eta-expansion.