### PR TITLE
Remove extraneous check file

### DIFF
--- a/test/files/neg/java-annotation-match-error.check
+++ b/test/files/neg/java-annotation-match-error.check
@@ -1,7 +1,0 @@
-J.java:11: error: identifier expected but `int' found.
-  int int int // check we get this syntax error
-      ^
-J.java:12: error: `;' expected but `}' found.
-}
-^
-two errors found


### PR DESCRIPTION
Partest reports
```
Extraneous file:
.../scala/test/files/neg/java-annotation-match-error.check
```
Among the test variants at https://github.com/scala/scala/pull/8982 was the one that got deleted after producing a check file.

Just noticed the branch is "issue bad check".
