### PR TITLE
Don't introduce parse error in probe for package

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -1170,15 +1170,17 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
 
   /** Does code start with a package definition? */
   def isPackaged(line: String): Boolean =
-    reporter.suppressOutput {
+    !reporter.hasErrors && reporter.suppressOutput {
       reporter.reset()
       val tree = newUnitParser(line).parse()
-      !reporter.hasErrors && {
+      val res  = !reporter.hasErrors && {
         tree match {
           case PackageDef(Ident(id), _) => id != nme.EMPTY_PACKAGE_NAME
           case _ => false
         }
       }
+      if (reporter.hasErrors) reporter.reset()
+      res
     }
 
   def symbolOfLine(code: String): Symbol =

--- a/test/files/run/t11991.check
+++ b/test/files/run/t11991.check
@@ -1,0 +1,19 @@
+
+scala> :paste <| EOF
+// Entering paste mode (EOF to finish)
+
+    |// comment 1
+    |val x = 3
+    |// comment 2
+    |val y = 4
+EOF
+
+// Exiting paste mode, now interpreting.
+
+val x: Int = 3
+val y: Int = 4
+
+scala> (x, y)
+val res0: (Int, Int) = (3,4)
+
+scala> :quit

--- a/test/files/run/t11991.scala
+++ b/test/files/run/t11991.scala
@@ -1,0 +1,11 @@
+
+object Test extends scala.tools.partest.ReplTest {
+  def code = """:paste <| EOF
+    |// comment 1
+    |val x = 3
+    |// comment 2
+    |val y = 4
+EOF
+(x, y)
+  """
+}


### PR DESCRIPTION
REPL autodetects when user inputs a package statement.
Parsing fails if they did not. Don't leak that error.

Fixes scala/bug#11991