### PR TITLE
Fix `@nowarn` to use correct semantics for `&`

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -612,10 +612,9 @@ object Reporting {
     def used: Boolean = _used
     def markUsed(): Unit = { _used = true }
 
-
     def matches(message: Message): Boolean = {
       val pos = message.pos
-      pos.isDefined && start <= pos.start && pos.end <= end && filters.exists(_.matches(message))
+      pos.isDefined && start <= pos.start && pos.end <= end && filters.forall(_.matches(message))
     }
   }
 }

--- a/test/files/neg/t12026.check
+++ b/test/files/neg/t12026.check
@@ -1,0 +1,6 @@
+t12026.scala:11: warning: discarded non-Unit value
+  def f(): Unit = v()
+                   ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t12026.scala
+++ b/test/files/neg/t12026.scala
@@ -1,0 +1,14 @@
+//scalac: -Wvalue-discard -Werror
+
+import annotation._
+
+//the following option works and warns for f but not g
+//-Wconf:cat=w-flag-value-discard&site=T.g:s
+
+@nowarn("cat=w-flag-value-discard&site=T.g")
+trait T {
+  def v(): Int
+  def f(): Unit = v()
+  def g(): Unit = v()
+}
+// was: no warning


### PR DESCRIPTION
Fixes scala/bug#12026