### PR TITLE
A jar or zip must be a regular file

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/FileUtils.scala
+++ b/src/compiler/scala/tools/nsc/classpath/FileUtils.scala
@@ -28,8 +28,7 @@ object FileUtils {
 
     def isScalaOrJavaSource: Boolean = !file.isDirectory && (file.hasExtension("scala") || file.hasExtension("java"))
 
-    // TODO do we need to check also other files using ZipMagicNumber like in scala.tools.nsc.io.Jar.isJarOrZip?
-    def isJarOrZip: Boolean = file.hasExtension("jar") || file.hasExtension("zip") || file.isInstanceOf[ZipArchive]
+    def isJarOrZip: Boolean = file.isInstanceOf[ZipArchive] || !file.isDirectory && (file.hasExtension("jar") || file.hasExtension("zip"))
 
     /**
      * Safe method returning a sequence containing one URL representing this file, when underlying file exists,

--- a/src/compiler/scala/tools/nsc/io/Jar.scala
+++ b/src/compiler/scala/tools/nsc/io/Jar.scala
@@ -169,11 +169,10 @@ object Jar {
   // See https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html
   // for some ideas.
   private val ZipMagicNumber = List[Byte](80, 75, 3, 4)
-  private def magicNumberIsZip(f: Path) = f.isFile && (f.toFile.bytes().take(4).toList == ZipMagicNumber)
+  private def magicNumberIsZip(f: Path) = f.toFile.bytes().take(4).toList == ZipMagicNumber
 
-  def isJarOrZip(f: Path): Boolean = isJarOrZip(f, examineFile = true)
-  def isJarOrZip(f: Path, examineFile: Boolean): Boolean =
-    f.hasExtension("zip", "jar") || (examineFile && magicNumberIsZip(f))
+  // file exists and either has name.jar or magic number
+  def isJarOrZip(f: Path): Boolean = f.isFile && (Path.isExtensionJarOrZip(f.name) || magicNumberIsZip(f))
 
   def create(file: File, sourceDir: Directory, mainClass: String): Unit = {
     val writer = new Jar(file).jarWriter(Name.MAIN_CLASS -> mainClass)

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -19,7 +19,6 @@ import java.net.URL
 import java.util.regex.PatternSyntaxException
 
 import File.pathSeparator
-import Jar.isJarOrZip
 import scala.tools.nsc.classpath.{ClassPathEntries, PackageEntry, PackageName}
 
 /**
@@ -132,7 +131,7 @@ object ClassPath {
 
     /* Get all subdirectories, jars, zips out of a directory. */
     def lsDir(dir: Directory, filt: String => Boolean = _ => true) =
-      dir.list.filter(x => filt(x.name) && (x.isDirectory || isJarOrZip(x))).map(_.path).toList
+      dir.list.filter(x => filt(x.name) && (x.isDirectory || Jar.isJarOrZip(x))).map(_.path).toList
 
     if (pattern == "*") lsDir(Directory("."))
     else if (pattern endsWith wildSuffix) lsDir(Directory(pattern dropRight 2))

--- a/src/reflect/scala/reflect/io/AbstractFile.scala
+++ b/src/reflect/scala/reflect/io/AbstractFile.scala
@@ -48,7 +48,7 @@ object AbstractFile {
    */
   def getDirectory(file: File): AbstractFile =
     if (file.isDirectory) new PlainFile(file)
-    else if (file.isFile && Path.isExtensionJarOrZip(file.jfile)) ZipArchive fromFile file
+    else if (file.isFile && Path.isExtensionJarOrZip(file.jfile)) ZipArchive.fromFile(file)
     else null
 
   /**
@@ -63,7 +63,7 @@ object AbstractFile {
       else getFile(f)
     } else null
 
-  def getResources(url: URL): AbstractFile = ZipArchive fromManifestURL url
+  def getResources(url: URL): AbstractFile = ZipArchive.fromManifestURL(url)
 }
 
 /**

--- a/src/reflect/scala/reflect/io/Path.scala
+++ b/src/reflect/scala/reflect/io/Path.scala
@@ -36,9 +36,15 @@ import scala.util.Random.alphanumeric
  */
 object Path {
   def isExtensionJarOrZip(jfile: JFile): Boolean = isExtensionJarOrZip(jfile.getName)
-  def isExtensionJarOrZip(name: String): Boolean = {
-    name.endsWith(".jar") || name.endsWith(".zip")
-  }
+  def isExtensionJarOrZip(name: String): Boolean =
+    name.lastIndexOf('.') match {
+      case i if i >= 0 =>
+        val xt = name.substring(i + 1)
+        xt.equalsIgnoreCase("jar") || xt.equalsIgnoreCase("zip")
+      case _ => false
+    }
+
+  /** Lower case "extension", following the last dot. */
   def extension(name: String): String = {
     val i = name.lastIndexOf('.')
     if (i < 0) ""

--- a/test/files/run/t12019/J_1.java
+++ b/test/files/run/t12019/J_1.java
@@ -1,0 +1,8 @@
+
+package p;
+
+public class J_1 {
+	public int f() {
+		return 42;
+	}
+}

--- a/test/files/run/t12019/Test.scala
+++ b/test/files/run/t12019/Test.scala
@@ -1,0 +1,32 @@
+
+import scala.tools.partest.DirectTest
+
+import scala.jdk.CollectionConverters._
+import scala.tools.testkit.ReleasablePath._
+import scala.util.Using
+
+import java.nio.file.Files._
+
+object Test extends DirectTest {
+
+  override def code: String = "class C { val c = new p.J_1().f() }"
+
+  override def show(): Unit =
+    Using.resource(createTempDirectory("t12019")) { dir =>
+      val target = createDirectory(dir.resolve("java.zip"))
+      val outdir = testOutput.jfile.toPath
+      val pkgdir = outdir.resolve("p")
+      Using.resource(walk(pkgdir)) { str =>
+        str.forEach { p =>
+          val partial = outdir.relativize(p)
+          val q = target.resolve(partial)
+          copy(p, q)
+        }
+      }
+      Using.resource(createTempDirectory("t12019out")) { out =>
+        val compiler = newCompiler(newSettings("-usejavacp" :: "-classpath" :: target.toString :: "-d" :: out.toString :: Nil))
+        compileString(compiler)(code)
+      }
+    }
+}
+// was: Error accessing /tmp/t120198214162953467729048/java.zip

--- a/test/files/run/t6240-universe-code-gen.scala
+++ b/test/files/run/t6240-universe-code-gen.scala
@@ -1,7 +1,6 @@
 
 import scala.jdk.CollectionConverters._
 import scala.tools.partest.nest.FileManager._
-import scala.util.Using
 
 import java.io.File
 import java.nio.file.Files


### PR DESCRIPTION
Construct a test that creates a directory.zip
on the classpath for compilation. After Using it,
remove the directory.

Fixes scala/bug#12019