### PR TITLE
Don't lint multiargInfix on synthetics

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2420,7 +2420,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               if (mexists(meth.paramss)(p1 => p != p1 && (p1.name == n || p1.deprecatedParamName.contains(n))))
                 DeprecatedParamNameError(p, n)
 
-          if (settings.multiargInfix && !meth.isConstructor && meth.owner.isClass && !meth.isDeprecated && !meth.hasAnnotation(UnusedClass) && !meth.ownerChain.exists(_.isDeprecated))
+          if (settings.multiargInfix && !meth.isConstructor && meth.owner.isClass && !meth.isDeprecated && !meth.hasAnnotation(UnusedClass) && !meth.ownerChain.exists(_.isDeprecated) && !meth.isSynthetic)
             meth.paramss match {
               case (h :: _ :: _) :: Nil if !h.isImplicit && Chars.isOperatorPart(meth.name.decoded.head) =>
                 context.warning(meth.pos, "multiarg infix syntax looks like a tuple and will be deprecated", WarningCategory.LintMultiargInfix)

--- a/test/files/neg/sd503.scala
+++ b/test/files/neg/sd503.scala
@@ -79,3 +79,5 @@ trait WhyNamingIsHard {
   def lines_!(x: Int, y: Int): List[String] = ???                             // nowarn, give it a pass
   def f = this lines_! (42, 27)                                               // warn usage, of course
 }
+
+class A(a: Int, b: Int)(c: Int = 1) // nowarn on <synthetic> def <init>$default$3(a: Int, b: Int): Int = 1


### PR DESCRIPTION
Fixes the 2.13.x build. Follow-up for https://github.com/scala/scala/pull/9026. Likely a semantic merge conflict with https://github.com/scala/scala/pull/9030.