### PR TITLE
Mutable Symbol Substitution maps

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -20,7 +20,7 @@ package internal
 
 import scala.collection.immutable
 import scala.collection.mutable.ListBuffer
-import util.{ Statistics, shortClassOfInstance }
+import util.{ ReusableInstance, Statistics, shortClassOfInstance }
 import Flags._
 import scala.annotation.tailrec
 import scala.reflect.io.{AbstractFile, NoAbstractFile}
@@ -3760,7 +3760,19 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
   /** Convenience functions which derive symbols by cloning.
    */
   def cloneSymbols(syms: List[Symbol]): List[Symbol] =
-    deriveSymbols(syms, _.cloneSymbol)
+    if (syms.isEmpty) Nil
+    else {
+      val syms1 = mapList(syms)(_.cloneSymbol)
+      cloneSymbolsSubstSymMap.using { (msm: MutableSubstSymMap) =>
+        msm.reset(syms, syms1)
+        syms1.foreach(_.modifyInfo(msm))
+      }
+      syms1
+    }
+
+  private[this] val cloneSymbolsSubstSymMap: ReusableInstance[MutableSubstSymMap] =
+    ReusableInstance[MutableSubstSymMap]( new MutableSubstSymMap())
+
   def cloneSymbolsAtOwner(syms: List[Symbol], owner: Symbol): List[Symbol] =
     deriveSymbols(syms, _ cloneSymbol owner)
 


### PR DESCRIPTION
Reboot of https://github.com/scala/scala/pull/8731 to clear the conversation cruft. This had mostly turned to the design of `ReusableVariable` for reentrance, which was address separately by https://github.com/scala/scala/pull/8871.
_____________________

We found an allocation hotspot of `SubstSymMap` objects in the methods `cloneSymbols` and `copyRefinedType`. Attached is a measurement we took for compiling a project, where these objects made up 2.83% of total allocations. 
![subssymmaphot](https://user-images.githubusercontent.com/1764610/83954202-70fd1500-a847-11ea-9ecc-e08ef235d0e7.png)


We cool them using Reusable Instances and mutable symbol substitution map. We add mutable substitution maps using a _template object_ pattern: two abstract classes `AbstractSubstTypeMap` and `AbstractSubstMap` keep all of the logic of substitution maps. The subclasses for mutable maps then introduce a `reset` method that replicate the logic of initialisation of a non-mutable maps.

