### PR TITLE
Scaladoc on AnyRef#wait

### DIFF
--- a/src/library-aux/scala/AnyRef.scala
+++ b/src/library-aux/scala/AnyRef.scala
@@ -116,15 +116,13 @@ trait AnyRef extends Any {
    */
   final def notifyAll(): Unit
 
-  /** Causes the current Thread to wait until another Thread invokes
-   *  the notify() or notifyAll() methods.
+  /** See [[https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait--]].
    *
    *  @note   not specified by SLS as a member of AnyRef
    */
   final def wait (): Unit
 
-  /** Causes the current Thread to wait until another Thread invokes
-   * the notify() or notifyAll() methods, or a specified amount of time has elapsed.
+  /** See [[https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait-long-int-]]
    *
    * @param timeout the maximum time to wait in milliseconds.
    * @param nanos   additional time, in nanoseconds range 0-999999.
@@ -132,8 +130,7 @@ trait AnyRef extends Any {
    */
   final def wait (timeout: Long, nanos: Int): Unit
 
-  /** Causes the current Thread to wait until another Thread invokes
-   * the notify() or notifyAll() methods, or a specified amount of time has elapsed.
+  /** See [[https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait-long-]].
    *
    * @param timeout the maximum time to wait in milliseconds.
    * @note not specified by SLS as a member of AnyRef

--- a/src/scaladoc/scala/tools/nsc/doc/Uncompilable.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Uncompilable.scala
@@ -43,6 +43,7 @@ trait Uncompilable {
         val wait = AnyRefTpe.members find {
           case m: MethodSymbol =>
             m.name == newTermName("wait") && m.paramLists.flatten.size == arity
+          case _ => false
         }
         wait.getOrElse(sys.error(s"Object#wait with $arity parameters was not found"))
       case xs => xs.foldLeft(RootClass: Symbol)(_.tpe member _)

--- a/test/scaladoc/run/anyref-doc.check
+++ b/test/scaladoc/run/anyref-doc.check
@@ -1,0 +1,17 @@
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(Wakes up all threads that are waiting on the receiver object's monitor), Text(.)))), Text(
+))))))
+)
+List(scala.AnyRef#wait, scala.AnyRef#wait, scala.AnyRef#wait)
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(Causes the current Thread to wait until another Thread invokes
+ the notify() or notifyAll() methods), Text(.)))), Text(
+))))))
+)
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(Causes the current Thread to wait until another Thread invokes
+the notify() or notifyAll() methods, or a specified amount of time has elapsed), Text(.)))), Text(
+))))))
+)
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(Causes the current Thread to wait until another Thread invokes
+the notify() or notifyAll() methods, or a specified amount of time has elapsed), Text(.)))), Text(
+))))))
+)
+Done.

--- a/test/scaladoc/run/anyref-doc.check
+++ b/test/scaladoc/run/anyref-doc.check
@@ -2,16 +2,13 @@ Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(Wakes up all threads
 ))))))
 )
 List(scala.AnyRef#wait, scala.AnyRef#wait, scala.AnyRef#wait)
-Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(Causes the current Thread to wait until another Thread invokes
- the notify() or notifyAll() methods), Text(.)))), Text(
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Chain(List(Text(See ), Link(https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait--,Text(https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait--)))), Text(.)))), Text(
 ))))))
 )
-Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(Causes the current Thread to wait until another Thread invokes
-the notify() or notifyAll() methods, or a specified amount of time has elapsed), Text(.)))), Text(
-))))))
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(See ), Link(https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait-long-int-,Text(https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait-long-int-)), Text(
+), Text()))))))))
 )
-Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(Causes the current Thread to wait until another Thread invokes
-the notify() or notifyAll() methods, or a specified amount of time has elapsed), Text(.)))), Text(
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Chain(List(Text(See ), Link(https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait-long-,Text(https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait-long-)))), Text(.)))), Text(
 ))))))
 )
 Done.

--- a/test/scaladoc/run/anyref-doc.scala
+++ b/test/scaladoc/run/anyref-doc.scala
@@ -1,0 +1,38 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+import scala.tools.nsc.{ScalaDocReporter, doc, io}
+import scala.tools.nsc.doc.DocFactory
+import scala.tools.nsc.doc.model._
+import scala.tools.nsc.reporters.ConsoleReporter
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+  def destinationDir = "target/anyref"
+  override def code = """class A"""
+  override def scaladocSettings =
+    s"-doc-no-compile src/library-aux -d ${destinationDir}"
+
+  def testModel(rootPackage: Package): Unit = {
+    import access._
+    val t = rootPackage._package("scala")._class("AnyRef")
+
+    val notifyAll = t._method("notifyAll")
+    println(notifyAll.comment)
+
+    val List(wait1, wait2, wait3) = t._methods("wait")
+    println(List(wait1, wait2, wait3))
+    println(wait1.comment)
+    println(wait2.comment)
+    println(wait3.comment)
+  }
+}


### PR DESCRIPTION
Ref https://github.com/scala/bug/issues/11310

As a background, AnyRef is a fictional class for documentation only. This is achieved by a special mode in scaladoc called `-doc-no-compile`, which accepts `src/library-aux`.

Internally, AnyRef is a type alias of Object (for example in definitions.AnyRefClass).
Object has 3 overloads of wait method, but `Uncompilable` mode was matching on the method name so it was returning a field named `wait` to be paired with the Scaladocs on `AnyRef#wait` methods.

This fixes that by checking both the name and the arity for `scala.AnyRef#wait`. Here's from running `doc` after switching starr to locally published 2.13.3-pre-271afd8.

<img width="778" alt="wait" src="https://user-images.githubusercontent.com/184683/83980951-a6f1d600-a8e7-11ea-906c-c3962cc45f7c.png">

