### PR TITLE
expose 2.13 style API for minAfter and maxBefore on 2.12 TreeMap and TreeSet

### DIFF
--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -338,4 +338,21 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
       case _ => super.transform(f)
     }
   }
+
+  /**
+   * Expose this 2.13 API as a private[scala] method
+   */
+  private[scala] def minAfter(key: A): Option[(A, B)] = RB.minAfter(tree, key) match {
+    case null => Option.empty
+    case x => Some((x.key, x.value))
+  }
+
+  /**
+   * Expose this 2.13 API as a private[scala] method
+   */
+  private[scala] def maxBefore(key: A): Option[(A, B)] = RB.maxBefore(tree, key) match {
+    case null => Option.empty
+    case x => Some((x.key, x.value))
+  }
+
 }

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -249,4 +249,21 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
     case _ => super.equals(obj)
   }
 
+  /**
+   * Expose this 2.13 API as a private[scala] method
+   */
+  private[scala] def minAfter(key: A): Option[A] = {
+    val v = RB.minAfter(tree, key)
+    if (v eq null) Option.empty else Some(v.key)
+  }
+
+  /**
+   * Expose this 2.13 API as a private[scala] method
+   */
+  private[scala] def maxBefore(key: A): Option[A] = {
+    val v = RB.maxBefore(tree, key)
+    if (v eq null) Option.empty else Some(v.key)
+  }
+
+
 }


### PR DESCRIPTION
This is part of the 2.13 API, but would be usefule to expose in 2.12

Clearly we cant change the public API, but by making it private[scala] a client can access this functionality via opting in and providing an appropriate implicit function/class to access this behaviour