### PR TITLE
Under -Xsource:3, don't auto-eta-expand nilary methods to SAM types 

### DIFF
--- a/test/files/neg/t7187-3.check
+++ b/test/files/neg/t7187-3.check
@@ -3,6 +3,16 @@ t7187-3.scala:13: error: type mismatch;
  required: () => Any
   val t1: () => Any  = m1   // error
                        ^
+t7187-3.scala:15: error: type mismatch;
+ found   : Int
+ required: AcciSamZero
+  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+                               ^
+t7187-3.scala:16: error: type mismatch;
+ found   : Int
+ required: SamZero
+  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+                       ^
 t7187-3.scala:27: error: Methods without a parameter list and by-name params can not be converted to functions as `m _`, write a function literal `() => m` instead
   val t7 = m1 _ // error: eta-expanding a nullary method
            ^
@@ -10,18 +20,5 @@ t7187-3.scala:14: warning: An unapplied 0-arity method was eta-expanded (due to 
 Write m2() to invoke method m2, or change the expected type.
   val t2: () => Any  = m2   // eta-expanded with lint warning
                        ^
-t7187-3.scala:15: warning: An unapplied 0-arity method was eta-expanded (due to the expected type AcciSamZero, which is SAM-equivalent to () => Int), rather than applied to `()`.
-Write m2() to invoke method m2, or change the expected type.
-  val t2AcciSam: AcciSamZero = m2   // eta-expanded with lint warning + sam warning
-                               ^
-t7187-3.scala:15: warning: Eta-expansion performed to meet expected type AcciSamZero, which is SAM-equivalent to () => Int,
-even though trait AcciSamZero is not annotated with `@FunctionalInterface`;
-to suppress warning, add the annotation or write out the equivalent function literal.
-  val t2AcciSam: AcciSamZero = m2   // eta-expanded with lint warning + sam warning
-                               ^
-t7187-3.scala:16: warning: An unapplied 0-arity method was eta-expanded (due to the expected type SamZero, which is SAM-equivalent to () => Int), rather than applied to `()`.
-Write m2() to invoke method m2, or change the expected type.
-  val t2Sam: SamZero = m2   // eta-expanded with lint warning
-                       ^
-4 warnings
-2 errors
+1 warning
+4 errors

--- a/test/files/neg/t7187-3.scala
+++ b/test/files/neg/t7187-3.scala
@@ -12,8 +12,8 @@ class EtaExpand214 {
 
   val t1: () => Any  = m1   // error
   val t2: () => Any  = m2   // eta-expanded with lint warning
-  val t2AcciSam: AcciSamZero = m2   // eta-expanded with lint warning + sam warning
-  val t2Sam: SamZero = m2   // eta-expanded with lint warning
+  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types under -Xsource:3
   val t3: Int => Any = m3   // ok
 
   val t4 = m1 // apply

--- a/test/files/neg/t7187-deprecation.check
+++ b/test/files/neg/t7187-deprecation.check
@@ -3,14 +3,19 @@ t7187-deprecation.scala:17: error: type mismatch;
  required: () => Any
   val t1: () => Any  = m1   // error
                        ^
+t7187-deprecation.scala:19: error: type mismatch;
+ found   : Int
+ required: AcciSamZero
+  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+                               ^
+t7187-deprecation.scala:20: error: type mismatch;
+ found   : Int
+ required: SamZero
+  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+                       ^
 t7187-deprecation.scala:31: error: Methods without a parameter list and by-name params can not be converted to functions as `m _`, write a function literal `() => m` instead
   val t7 = m1 _ // error: eta-expanding a nullary method
            ^
-t7187-deprecation.scala:19: warning: Eta-expansion performed to meet expected type AcciSamZero, which is SAM-equivalent to () => Int,
-even though trait AcciSamZero is not annotated with `@FunctionalInterface`;
-to suppress warning, add the annotation or write out the equivalent function literal.
-  val t2AcciSam: AcciSamZero = m2   // warn, eta-expanded to non @FunctionalInterface SAM
-                               ^
 t7187-deprecation.scala:24: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method m2,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
 In Scala 3, an unapplied method like this will be eta-expanded into a function.
@@ -21,5 +26,5 @@ or remove the empty argument list from its definition (Java-defined methods are 
 In Scala 3, an unapplied method like this will be eta-expanded into a function.
   a.boom // warning: apply, ()-insertion
     ^
-3 warnings
-2 errors
+2 warnings
+4 errors

--- a/test/files/neg/t7187-deprecation.scala
+++ b/test/files/neg/t7187-deprecation.scala
@@ -16,8 +16,8 @@ class EtaExpand214 {
 
   val t1: () => Any  = m1   // error
   val t2: () => Any  = m2   // eta-expanded, only warns w/ -Xlint:eta-zero
-  val t2AcciSam: AcciSamZero = m2   // warn, eta-expanded to non @FunctionalInterface SAM
-  val t2Sam: SamZero = m2   // eta-expanded, only warns w/ -Xlint:eta-zero
+  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types under -Xsource:3
   val t3: Int => Any = m3   // ok
 
   val t4 = m1 // apply

--- a/test/files/pos/t12006.scala
+++ b/test/files/pos/t12006.scala
@@ -1,0 +1,10 @@
+// scalac: -Xsource:3
+
+// see https://github.com/scala/bug/issues/12006
+// java.io.InputStream looks like a SAM (read method),
+// but u.openStream returns InputStream so don't eta-expand.
+class C1(s: => java.io.InputStream)
+class D1(u: java.net.URL) extends C1(u.openStream) // ok
+
+class C2(s: java.io.InputStream)
+class D2(u: java.net.URL) extends C2(u.openStream) // ok


### PR DESCRIPTION
A piece of code such as:

```scala
class C(s: java.io.InputStream)
class D(u: java.net.URL) extends C(u.openStream)
```

could be interpreted in two ways.

1. `InputStream` is a SAM of `def read(): Int`, and `C(u.openStream)` requires an eta-expansion from openStream method to `() => Int`.
2. `u.openStream` needs auto application `()`.

Under `-Xsource:3` Scala 2.13.2 took the first interpretation, since https://github.com/scala/scala/pull/7660, and then errored with surprising:

```
       error: type mismatch;
        found   : java.io.InputStream
        required: Int
```

This PR fixes that by not eta-expanding nilary methods when a SAM type is expected.

Fixes scala/bug#12006; supersedes #9027