### PR TITLE
Scaladoc on AnyRef#synchronized

### DIFF
--- a/test/scaladoc/run/anyref-doc.check
+++ b/test/scaladoc/run/anyref-doc.check
@@ -11,4 +11,7 @@ Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(See ), Link(https://
 Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Chain(List(Text(See ), Link(https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait-long-,Text(https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait-long-)))), Text(.)))), Text(
 ))))))
 )
+Some(Body(List(Paragraph(Chain(List(Summary(Chain(List(Chain(List(Text(Executes the code in ), Monospace(Text(body)), Text( with an exclusive lock on ), Monospace(Text(this)))), Text(.)))), Text(
+))))))
+@return Body(List(Paragraph(Chain(List(Summary(Chain(List(Text(the result of ), Monospace(Text(body)))))))))))
 Done.

--- a/test/scaladoc/run/anyref-doc.scala
+++ b/test/scaladoc/run/anyref-doc.scala
@@ -34,5 +34,8 @@ object Test extends ScaladocModelTest {
     println(wait1.comment)
     println(wait2.comment)
     println(wait3.comment)
+
+    val sync = t._method("synchronized")
+    println(sync.comment)
   }
 }


### PR DESCRIPTION
Ref https://github.com/scala/bug/issues/11310
Ref https://github.com/scala/bug/issues/4086

This PR attempts to surface the Scaladoc of `AnyRef#synchronized`. A quick test can be done using https://github.com/scala/scala/blob/0ff65a000d60b4158776687c7f73940d9dcdf85b/test/scaladoc/run/anyref-doc.scala

```
> partest --srcpath scaladoc --grep anyref-doc
```

As a background, AnyRef is a fictional class for documentation only. This is achieved by a special mode in scaladoc called `-doc-no-compile`, which accepts `src/library-aux`.