### PR TITLE
Amend mumurhash3 doc to remind users to check hashes in between versions

### DIFF
--- a/src/library/scala/util/hashing/MurmurHash3.scala
+++ b/src/library/scala/util/hashing/MurmurHash3.scala
@@ -321,7 +321,9 @@ private[hashing] class MurmurHash3 {
  * This is based on the earlier MurmurHash3 code by Rex Kerr, but the
  * MurmurHash3 algorithm was since changed by its creator Austin Appleby
  * to remedy some weaknesses and improve performance. This represents the
- * latest and supposedly final version of the algorithm (revision 136).
+ * latest and supposedly final version of the algorithm (revision 136). Even
+ * so, test the generated hashes in between Scala versions, even for point
+ * releases, as fast, non-cryptographic hashing algorithms evolve rapidly.
  *
  * @see [[https://github.com/aappleby/smhasher]]
  */


### PR DESCRIPTION
Closes scala/bug#11646

Adds instructive reminder for users of `MurmurHash3`, about the nature of this algorithm. The initially added lines are a direct distillation of [Ichoran's comment](https://github.com/scala/bug/issues/11646#issuecomment-513488398). I'm describing this as _initially_ because I think the lines are a bit loaded, unless it's clear enough?

PS: Can I consider `final val productSeed = 0xcafebabe` an easter egg?