### PR TITLE
Extra help for bad interpolation

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4938,11 +4938,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             loop(tree)
           }
           val retry = typeErrors.forall(_.errPos != null) && (errorInResult(fun) || errorInResult(tree) || args.exists(errorInResult))
-          typingStack.printTyping({
-            val funStr = ptTree(fun) + " and " + (args map ptTree mkString ", ")
-            if (retry) "second try: " + funStr
-            else "no second try: " + funStr + " because error not in result: " + typeErrors.head.errPos+"!="+tree.pos
-          })
+          typingStack.printTyping {
+            val funStr = s"${ptTree(fun)} and ${args.map(ptTree).mkString(", ")}"
+            if (retry) s"second try: $funStr"
+            else s"no second try: $funStr because error not in result: ${typeErrors.head.errPos}!=${tree.pos}"
+          }
           if (retry) {
             val Select(qual, name) = fun
             tryTypedArgs(args, forArgMode(fun, mode)) match {
@@ -4957,7 +4957,18 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               case _ => ()
             }
           }
-          typeErrors foreach context.issue
+          def adjust(err: AbsTypeError) =
+            if (tree.hasAttachment[InterpolatedString.type])
+              tree match {
+                case Apply(sc @ Ident(nme.StringContextName), _) =>
+                  if (sc.isErroneous) err
+                  else NormalTypeError(tree, s"${err.errMsg}; signature for interpolation must be `StringContext.apply(String*)`")
+                case Apply(Select(_, nm), badargs) =>
+                  if (badargs.exists(_.isErroneous)) err
+                  else NormalTypeError(tree, s"${err.errMsg}; incompatible interpolation method $nm")
+              }
+            else err
+          typeErrors.foreach(err => context.issue(adjust(err)))
           warnings foreach { case (p, m, c, s) => context.warning(p, m, c, s) }
           setError(treeCopy.Apply(tree, fun, args))
         }

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -129,4 +129,6 @@ trait StdAttachments {
 
   // When typing a Def with this attachment, change the owner of its RHS from origalOwner to the symbol of the Def
   case class ChangeOwnerAttachment(originalOwner: Symbol)
+
+  case object InterpolatedString extends PlainAttachment
 }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -67,6 +67,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.MultiargInfixAttachment
     this.NullaryOverrideAdapted
     this.ChangeOwnerAttachment
+    this.InterpolatedString
     this.noPrint
     this.typeDebug
     // inaccessible: this.posAssigner

--- a/test/files/neg/t6352.check
+++ b/test/files/neg/t6352.check
@@ -1,0 +1,23 @@
+t6352.scala:9: error: too many arguments (found 2, expected 1) for method apply: (i: Int): H1.StringContext in object StringContext; signature for interpolation must be `StringContext.apply(String*)`
+  val str = s"a: $x"
+            ^
+t6352.scala:15: error: type mismatch;
+ found   : String("a: ")
+ required: Int; signature for interpolation must be `StringContext.apply(String*)`
+  val str = s"a: $x"
+            ^
+t6352.scala:23: error: Int does not take parameters; incompatible interpolation method s
+  val str = s"a: $x"
+            ^
+t6352.scala:31: error: not found: value y
+  val bad = s"b: $y"
+                  ^
+t6352.scala:38: error: value t is not a member of X2.StringContext
+  val bad = t"a: $x"
+            ^
+t6352.scala:45: error: type mismatch;
+ found   : Int
+ required: String; incompatible interpolation method s
+  val bad = s"a: $x"
+            ^
+6 errors

--- a/test/files/neg/t6352.scala
+++ b/test/files/neg/t6352.scala
@@ -1,0 +1,46 @@
+//scalac: -Yimports:java.lang
+
+import scala.Int
+
+object H1 {
+  case class StringContext(i: Int)
+
+  val x = 3
+  val str = s"a: $x"
+}
+object H2 {
+  case class StringContext(i: Int*)
+
+  val x = 3
+  val str = s"a: $x"
+}
+object H3 {
+  case class StringContext(strs: String*) {
+    def s: Int = 3
+  }
+
+  val x = 3
+  val str = s"a: $x"
+}
+object X1 {
+  case class StringContext(strs: String*) {
+    def s(args: Int*): String = strs.mkString + args.sum
+  }
+  val x = 3
+  val str = s"a: $x"
+  val bad = s"b: $y"
+}
+object X2 {
+  case class StringContext(strs: String*) {
+    def s(args: Int*): String = strs.mkString + args.sum
+  }
+  val x = 3
+  val bad = t"a: $x"
+}
+object X3 {
+  case class StringContext(strs: String*) {
+    def s(args: String*): String = scala.StringContext(strs: _*).s(args: _*)
+  }
+  val x = 3
+  val bad = s"a: $x"
+}


### PR DESCRIPTION
    If interpolation fails to typecheck,
    supplement weird error with some explanation.
    This commit targets the two applications,
    due to bad StringContext.apply or bad
    interpolator method signature.

    This doesn't cover "no such interpolator"
    for "not a member of StringContext".

Context here was supplemental explanations. You'd think there would be more calls for improved errors for interpolation; there are more calls for improved for-syntax translation. Maybe there is not peak diversity in interpolators. Besides s, f, q, if there is only one custom interpolator per project, there is small chance for confusion.

Fixes scala/bug#6352