### PR TITLE
Improve exception thrown by Source.fromResource

### DIFF
--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -14,8 +14,8 @@ package scala
 package io
 
 import scala.collection.{AbstractIterator, BufferedIterator}
-import java.io.{ FileInputStream, InputStream, PrintStream, File => JFile, Closeable }
-import java.net.{ URI, URL }
+import java.io.{Closeable, FileInputStream, FileNotFoundException, InputStream, PrintStream, File => JFile}
+import java.net.{URI, URL}
 
 /** This object provides convenience methods to create an iterable
  *  representation of a source file.
@@ -176,7 +176,10 @@ object Source {
    *  @return              the buffered source
    */
   def fromResource(resource: String, classLoader: ClassLoader = Thread.currentThread().getContextClassLoader())(implicit codec: Codec): BufferedSource =
-    fromInputStream(classLoader.getResourceAsStream(resource))
+    Option(classLoader.getResourceAsStream(resource)) match {
+      case Some(in) => fromInputStream(in)
+      case None     => throw new FileNotFoundException(s"resource '$resource' was not found in the classpath from the given classloader.")
+    }
 
 }
 

--- a/test/junit/scala/io/SourceTest.scala
+++ b/test/junit/scala/io/SourceTest.scala
@@ -31,6 +31,10 @@ class SourceTest {
         assertTrue(s"$l\n${ls.mkString("\n")}", false)
     }
   }
+  @Test(expected = classOf[java.io.FileNotFoundException])
+  def loadFromMissingResource(): Unit = {
+    Source.fromResource("missing.txt")
+  }
   @Test def canCustomizeReporting() = {
     class CapitalReporting(is: InputStream) extends BufferedSource(is) {
       override def report(pos: Int, msg: String, out: PrintStream): Unit = {


### PR DESCRIPTION
Fixes scala/bug#11743

Improves the exception message a bit. Adds a [basic method call test](https://github.com/scala/scala/pull/8443#issuecomment-545667622).

I unfortunately orphaned PR https://github.com/scala/scala/pull/8443. This is the replacement.

I need pointers about two things:

I want to write a test that (1) creates two classloader instances A & B each with its own resources path, then (2) call `Source.fromResource('file_in_B.txt', classLoaderA)`. I wanted to test the case where it should throw the exception if the resource exists but not in the given resource path.

I'm trying [MissingResourceException](https://docs.oracle.com/javase/8/docs/api/java/util/MissingResourceException.html) instead, but I don't know what to use to fill in the `className` and `key` arguments.