### PR TITLE
Sanity check arg to string setting

### DIFF
--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -258,4 +258,13 @@ class SettingsTest {
     assert("has the choice", settings.opt.contains(settings.optChoices.inline))
     assertFalse("is not enabled", settings.optInlinerEnabled)
   }
+  @Test def `t12036 don't consume dash option as arg`(): Unit = {
+    import scala.collection.mutable.ListBuffer
+    val errors   = ListBuffer.empty[String]
+    val settings = new Settings(errors.addOne)
+    val (ok, rest) = settings.processArguments("-Vinline" :: "-Xlint" :: Nil, true)
+    assertFalse("processing should fail", ok)
+    assertEquals("processing stops at bad option", 2, rest.length)
+    assertEquals(2, errors.size)  // missing arg and bad option
+  }
 }


### PR DESCRIPTION
Don't accept an option arg that looks like an option.
Previously, `-Vinline -Xlint` would blithely consume
the second option.

Fixes scala/bug#12036