### PR TITLE
some faster bulk operations for BitSets

### DIFF
--- a/src/library/scala/collection/generic/BitSetFactory.scala
+++ b/src/library/scala/collection/generic/BitSetFactory.scala
@@ -32,7 +32,9 @@ import mutable.Builder
 trait BitSetFactory[Coll <: BitSet with BitSetLike[Coll]] {
   def empty: Coll
   def newBuilder: Builder[Int, Coll]
-  def apply(elems: Int*): Coll = (empty /: elems) (_ + _)
+  def apply(elems: Int*): Coll =
+    if (elems.isEmpty) empty
+    else (newBuilder ++= elems).result
   def bitsetCanBuildFrom = new CanBuildFrom[Coll, Int, Coll] {
     def apply(from: Coll) = newBuilder
     def apply() = newBuilder

--- a/test/benchmarks/src/main/scala/scala/collection/BitSetBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/BitSetBenchmark.scala
@@ -1,0 +1,213 @@
+package scala.collection
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.collection.generic.BitSetFactory
+import scala.collection.immutable.{List, Range}
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class BitSetBenchmark {
+  @Param(Array("0", "1", "10", "100", "1000", "10000"))
+  var bitsetSize: Int = _
+
+  @Param(Array("true", "false"))
+  var mutable: Boolean = _
+
+  @Param(Array("empty", "half", "full", "spare-low", "spare-high"))
+  var fill: String = _
+
+  var bitset: BitSet = _
+  var bitset2: BitSet = _
+  var high: BitSet = _
+  var values: Array[Int] = _
+  var valuesList: List[Int] = _
+
+  var bitsetCompanion: BitSetFactory[_ <: BitSet] = _
+
+  @Setup(Level.Trial) def init(): Unit = {
+    val b1 = new collection.mutable.BitSet
+    if (bitsetSize > 0) {
+      b1 += bitsetSize - 1
+      b1 -= bitsetSize - 1
+    }
+
+    fill match {
+      case "empty" =>
+      case "half" => b1 ++= Range(0, bitsetSize, 2)
+      case "full" => b1 ++= Range(0, bitsetSize)
+      case "spare-low" =>
+        assert(bitsetSize > 0) //i.e. abort that specific combination
+        b1 += 0
+      case "spare-high" =>
+        assert(bitsetSize > 0) //i.e. abort that specific combination
+        b1 += bitsetSize - 1
+    }
+    values = b1.toArray
+    valuesList = b1.toList
+    if (mutable) {
+      bitset = b1.clone()
+      bitset2 = b1.clone()
+      bitsetCompanion = scala.collection.mutable.BitSet
+    } else {
+      bitset = b1.toImmutable
+      bitset2 = b1.toImmutable
+      bitsetCompanion = scala.collection.immutable.BitSet
+    }
+    high = bitsetCompanion(bitsetSize)
+  }
+
+
+  @Benchmark def iterator() = {
+    bitset.iterator
+  }
+
+  @Benchmark def iterate(bh: Blackhole): Unit = {
+    val it = bitset.iterator
+    while (it.hasNext) {
+      bh.consume(it.next)
+    }
+  }
+
+  @Benchmark def hash = {
+    bitset.hashCode()
+  }
+
+  @Benchmark def equals = {
+    bitset.equals(bitset2)
+  }
+
+  @Benchmark def apply = {
+    bitsetCompanion(values: _*)
+  }
+
+  @Benchmark def buildSingle = {
+    (bitsetCompanion.newBuilder += 5).result
+  }
+
+  @Benchmark def buildFromList = {
+    (bitsetCompanion.newBuilder ++= valuesList).result
+  }
+
+  @Benchmark def buildFromWrapped = {
+    (bitsetCompanion.newBuilder ++= values).result
+  }
+
+  @Benchmark def buildFromBitset = {
+    (bitsetCompanion.newBuilder ++= bitset).result
+  }
+
+  @Benchmark def isEmpty = {
+    bitset.isEmpty
+  }
+
+  object all extends Function1[Int, Unit] {
+    var result = 0
+
+    override def apply(v1: Int): Unit = result += v1
+  }
+
+  @Benchmark def foreachFn = {
+    bitset foreach all
+    all.result
+  }
+
+  @Benchmark def forallFn =
+    bitset forall (_ >= 0)
+
+  @Benchmark def existsFn = {
+    bitset exists (_ < 0)
+  }
+
+  @Benchmark def findFn = {
+    bitset find (_ == bitsetSize)
+  }
+
+  @Benchmark def filterFn = {
+    bitset filter (_ / 8 == 0)
+  }
+
+  @Benchmark def filterNotFn =
+    bitset filterNot (_ / 8 != 0)
+
+  @Benchmark def forallBitset =
+    bitset forall bitset2
+
+  @Benchmark def existsBitset =
+    bitset exists high
+
+  @Benchmark def findBitset =
+    bitset find high
+
+  @Benchmark def filterBitset =
+    bitset filter high
+
+  @Benchmark def filterNotBitset =
+    bitset filterNot high
+
+  @Benchmark def plus = {
+    bitset + 5
+  }
+
+  @Benchmark def plusPlusList =
+    bitset ++ valuesList
+
+  @Benchmark def plusPlusBitSet =
+    bitset ++ bitset2
+
+  @Benchmark def minus =
+    bitset - 5
+
+  @Benchmark def minusMinusList =
+    bitset -- valuesList
+
+  @Benchmark def union =
+    bitset union bitset2
+
+  @Benchmark def intersect =
+    bitset intersect bitset2
+
+  @Benchmark def diff =
+    bitset intersect bitset2
+
+  @Benchmark def hashcode =
+    bitset.hashCode()
+
+  @Benchmark def toBitMask =
+    bitset.toBitMask
+
+  @Benchmark def size_ =
+    bitset.size
+
+  @Benchmark def range =
+    bitset.range(1, 200)
+}
+
+//useful for testing
+//object Test_BitSetBenchmark extends App {
+//  val bm = new BitSetBenchmark
+//  bm.bitsetSize = 50
+//  bm.fill = "half"
+//  bm.init()
+//  var i = 0
+//  var start = System.currentTimeMillis()
+//  while (true) {
+//    bm.hash
+//    i += 1
+//    if (i == 1000000) {
+//      val now = System.currentTimeMillis()
+//      println(s"${now - start}")
+//      i = 0
+//      start = now
+//    }
+//  }
+//
+//}

--- a/test/junit/scala/collection/immutable/BitSetTest.scala
+++ b/test/junit/scala/collection/immutable/BitSetTest.scala
@@ -1,0 +1,364 @@
+package scala.collection.immutable
+
+import java.util
+import java.util.NoSuchElementException
+
+import org.junit.Test
+import org.junit.Assert._
+
+class BitSetTest {
+  val datasets =
+    List(
+      List(),
+      List(0),
+      List(1),
+      List(2),
+      List(1, 3, 5, 6, 7, 8, 9),
+      List(63, 64, 65, 10008),
+      List(64, 65, 10008),
+      List(65, 10008),
+      List(1, 100001),
+      List(99),
+      List(640)
+      )
+  @Test def testBuilder(): Unit = {
+    for (bulk1 <- List(true, false);
+         bulk2 <- List(true, false);
+         ds1 <- datasets;
+         ds2 <- datasets) {
+      val testBuilder1    = BitSet.newBuilder
+      val controlBuilder1 = TreeSet.newBuilder[Int]
+
+      if (bulk1) testBuilder1 ++= ds1
+      else ds1 foreach testBuilder1.+=
+      if (bulk2) testBuilder1 ++= ds2
+      else ds2 foreach testBuilder1.+=
+
+      controlBuilder1 ++= ds1
+      controlBuilder1 ++= ds2
+
+      assertEquals(s"ds1 $ds1 ds2 $ds2 bulk1 $bulk1 bulk2 $bulk2",
+                   controlBuilder1.result.mkString("[", " : ", "]"),
+                   testBuilder1.result.mkString("[", " : ", "]"))
+
+
+    }
+  }
+
+  def testIterator(data: List[Int]): Unit = {
+    val testBuilder = BitSet.newBuilder
+    testBuilder ++= data
+    val underTest = testBuilder.result()
+
+    assertEquals(data, underTest.iterator.toList)
+  }
+  def testIteratorFrom(data: List[Int], from: Int): Unit = {
+    val testBuilder = BitSet.newBuilder
+    testBuilder ++= data
+    val underTest = testBuilder.result()
+
+    assertEquals(s"data $data, from:$from", data.dropWhile(_ < from), underTest.iteratorFrom(from).toList)
+  }
+  @Test def iteratorNext(): Unit = {
+    val testBuilder = BitSet.newBuilder
+    testBuilder ++= List(1, 5, 4)
+    val underTest = testBuilder.result()
+
+    var it = underTest.iterator
+    assertEquals(1, it.next)
+    assertEquals(4, it.next)
+    assertEquals(5, it.next)
+    try {
+      it.next()
+      fail()
+    } catch {
+      case _: NoSuchElementException =>
+    }
+
+    it = underTest.iterator
+    assertTrue(it.hasNext)
+    assertTrue(it.hasNext)
+    assertEquals(1, it.next)
+    assertEquals(4, it.next)
+    assertTrue(it.hasNext)
+    assertTrue(it.hasNext)
+    assertTrue(it.hasNext)
+    assertEquals(5, it.next)
+    assertFalse(it.hasNext)
+    try {
+      it.next()
+      fail()
+    } catch {
+      case _: NoSuchElementException =>
+    }
+  }
+
+  @Test def iterator(): Unit = {
+    datasets foreach testIterator
+  }
+
+  @Test def iteratorFrom(): Unit = {
+    for (from <- -1 to 10;
+         ds <- datasets) {
+      testIteratorFrom(ds, from)
+    }
+  }
+  @Test def isEmpty(): Unit = {
+    val data = new Array[Long](10)
+    for (length <- 0 to 10) {
+      val bs = BitSet.fromBitMask(data.take(length))
+      assertTrue(bs.isEmpty)
+      assertEquals(0, bs.size)
+      assertTrue(bs.hasDefiniteSize)
+    }
+    for (length <- 1 to 10;
+         bit <- 0 until 63;
+         word <- 0 until length) {
+
+      util.Arrays.fill(data, 0L)
+      data(word) = 1L << bit
+      val bs = BitSet.fromBitMask(data.take(length))
+
+      assertFalse(bs.isEmpty)
+      assertEquals(1, bs.size)
+      assertTrue(bs.hasDefiniteSize)
+    }
+  }
+  def testForEach(data: List[Int]): Unit = {
+    val testBuilder = BitSet.newBuilder
+    testBuilder ++= data
+    val underTest = testBuilder.result()
+
+    val sbExpected = new StringBuilder()
+    val sbActual   = new StringBuilder()
+    data foreach { i => sbExpected append i.toString append " : " }
+    underTest foreach { i => sbActual append i.toString append " : " }
+
+    assertEquals(sbExpected.toString, sbActual.toString)
+  }
+  @Test def forEach: Unit = {
+    datasets foreach testForEach
+  }
+  val sbExpected = new StringBuilder()
+  val sbActual   = new StringBuilder()
+  def testForAllImpl(data: List[Int], underTest: BitSet, p: Int => Boolean): Unit = {
+    sbActual.clear
+    sbExpected.clear
+
+    assertEquals(s"data $data test $underTest p $p", data.forall(p), underTest.forall(p))
+    assertEquals(s"data $data test $underTest p $p", sbExpected.toString, sbActual.toString)
+  }
+  def testExistsImpl(data: List[Int], underTest: BitSet, p: Int => Boolean): Unit = {
+    sbActual.clear
+    sbExpected.clear
+
+    assertEquals(s"data $data test $underTest p $p", data.exists(p), underTest.exists(p))
+    assertEquals(s"data $data test $underTest p $p", sbExpected.toString, sbActual.toString)
+  }
+  def testFindImpl(data: List[Int], underTest: BitSet, p: Int => Boolean): Unit = {
+    sbActual.clear
+    sbExpected.clear
+
+    assertEquals(s"data $data test $underTest p $p", data.find(p), underTest.find(p))
+    assertEquals(s"data $data test $underTest p $p", sbExpected.toString, sbActual.toString)
+  }
+  def testFilterImpl(data: List[Int], underTest: BitSet, p: Int => Boolean): Unit = {
+    sbActual.clear
+    sbExpected.clear
+
+    assertEquals(s"data $data test $underTest p $p", data.filter(p).mkString("[", " : ", "]"), underTest.filter(p).mkString("[", " : ", "]"))
+    assertEquals(s"data $data test $underTest p $p", sbExpected.toString, sbActual.toString)
+  }
+  def testFilterNotImpl(data: List[Int], underTest: BitSet, p: Int => Boolean): Unit = {
+    sbActual.clear
+    sbExpected.clear
+
+    assertEquals(s"data $data test $underTest p $p", data.filterNot(p).mkString("[", " : ", "]"), underTest.filterNot(p).mkString("[", " : ", "]"))
+    assertEquals(s"data $data test $underTest p $p", sbExpected.toString, sbActual.toString)
+  }
+  def testFor(data: List[Int], testImpl: (List[Int], BitSet, Int => Boolean) => Unit): Unit = {
+    val testBuilder = BitSet.newBuilder
+    testBuilder ++= data
+    val underTest = testBuilder.result()
+
+    testImpl(data, underTest, _ == -1)
+    testImpl(data, underTest, _ >= 0)
+    testImpl(data, underTest, _ > 0)
+    testImpl(data, underTest, _ < 10000000)
+    if (!data.isEmpty) {
+      for (point <- List(data.head, data.last, data(data.size / 2))) {
+        testImpl(data, underTest, _ < point)
+        testImpl(data, underTest, _ <= point)
+        testImpl(data, underTest, _ > point)
+        testImpl(data, underTest, _ >= point)
+        testImpl(data, underTest, _ == point)
+        testImpl(data, underTest, _ != point)
+      }
+    }
+    for (ds <- datasets) {
+      val testBuilder = BitSet.newBuilder
+      testBuilder ++= ds
+      val filter = testBuilder.result()
+      //as a set if a function, and there as special cases for them
+      testImpl(data, underTest, filter)
+    }
+  }
+  @Test def forAll: Unit = {
+    datasets foreach (ds => testFor(ds, testForAllImpl _))
+  }
+  @Test def exists: Unit = {
+    datasets foreach (ds => testFor(ds, testExistsImpl _))
+  }
+  @Test def find: Unit = {
+    datasets foreach (ds => testFor(ds, testFindImpl _))
+  }
+  @Test def bulkAndSingleAddition: Unit = {
+    for (ds1 <- datasets;
+         ds2 <- datasets) {
+      val expected = (ds1 ++ ds2).distinct.sorted.mkString("[", " : ", "]")
+
+      val testBuilder1 = BitSet.newBuilder
+      testBuilder1 ++= ds1
+      var underTest = testBuilder1.result()
+
+      val testBuilder2 = BitSet.newBuilder
+      testBuilder2 ++= ds2
+      val bs2 = testBuilder2.result()
+
+      assertEquals(s"$underTest ... $ds2", expected, (underTest ++ ds2).mkString("[", " : ", "]"))
+      assertEquals(s"$underTest ... $bs2", expected, (underTest ++ bs2).mkString("[", " : ", "]"))
+
+      var control = (TreeSet.newBuilder[Int] ++= ds1).result
+      assertEquals(s"$control ... $underTest",
+                   control.mkString("[", " : ", "]"),
+                   underTest.mkString("[", " : ", "]"))
+      ds2 foreach {
+        value =>
+          control += value
+          underTest += value
+          assertEquals(s"$control ... $underTest  $value",
+                       control.mkString("[", " : ", "]"),
+                       underTest.mkString("[", " : ", "]"))
+
+      }
+    }
+  }
+  @Test def bulkAndSingleSubtraction: Unit = {
+    for (ds1 <- datasets;
+         ds2 <- datasets) {
+      val expected = (ds1.toSet -- ds2).toList.sorted.mkString("[", " : ", "]")
+
+      val testBuilder1 = BitSet.newBuilder
+      testBuilder1 ++= ds1
+      var underTest = testBuilder1.result()
+
+      val testBuilder2 = BitSet.newBuilder
+      testBuilder2 ++= ds2
+      val bs2 = testBuilder2.result()
+
+      assertEquals(expected, (underTest -- ds2).mkString("[", " : ", "]"))
+      assertEquals(expected, (underTest -- bs2).mkString("[", " : ", "]"))
+
+      var control = (TreeSet.newBuilder[Int] ++= ds1).result
+      assertEquals(s"$control ... $underTest",
+                   control.mkString("[", " : ", "]"),
+                   underTest.mkString("[", " : ", "]"))
+      ds2 foreach {
+        value =>
+          control -= value
+          underTest -= value
+          assertEquals(s"$control ... $underTest  $value",
+                       control.mkString("[", " : ", "]"),
+                       underTest.mkString("[", " : ", "]"))
+
+      }
+    }
+  }
+  @Test def union: Unit = {
+    for (ds1 <- datasets;
+         ds2 <- datasets) {
+      val expected = (ds1.toSet union ds2.toSet).toList.sorted.mkString("[", " : ", "]")
+
+      val testBuilder1 = BitSet.newBuilder
+      testBuilder1 ++= ds1
+      val underTest = testBuilder1.result()
+
+      val testBuilder2 = BitSet.newBuilder
+      testBuilder2 ++= ds2
+      val bs2 = testBuilder2.result()
+
+      assertEquals(expected, (underTest union ds2.toSet).mkString("[", " : ", "]"))
+      assertEquals(expected, (underTest union bs2).mkString("[", " : ", "]"))
+
+      assertEquals(expected, (underTest | bs2).mkString("[", " : ", "]"))
+    }
+  }
+  @Test def intersect: Unit = {
+    for (ds1 <- datasets;
+         ds2 <- datasets) {
+      val expected = (ds1.toSet intersect ds2.toSet).toList.sorted.mkString("[", " : ", "]")
+
+      val testBuilder1 = BitSet.newBuilder
+      testBuilder1 ++= ds1
+      val underTest = testBuilder1.result()
+
+      val testBuilder2 = BitSet.newBuilder
+      testBuilder2 ++= ds2
+      val bs2 = testBuilder2.result()
+
+      assertEquals(expected, (underTest intersect ds2.toSet).mkString("[", " : ", "]"))
+      assertEquals(expected, (underTest intersect bs2).mkString("[", " : ", "]"))
+
+      assertEquals(expected, (underTest & bs2).mkString("[", " : ", "]"))
+    }
+  }
+  @Test def diff: Unit = {
+    for (ds1 <- datasets;
+         ds2 <- datasets) {
+      val expected = (ds1.toSet diff ds2.toSet).toList.sorted.mkString("[", " : ", "]")
+
+      val testBuilder1 = BitSet.newBuilder
+      testBuilder1 ++= ds1
+      val underTest = testBuilder1.result()
+
+      val testBuilder2 = BitSet.newBuilder
+      testBuilder2 ++= ds2
+      val bs2 = testBuilder2.result()
+
+      assertEquals(expected, (underTest diff ds2.toSet).mkString("[", " : ", "]"))
+      assertEquals(expected, (underTest diff bs2).mkString("[", " : ", "]"))
+
+      assertEquals(expected, (underTest &~ bs2).mkString("[", " : ", "]"))
+    }
+  }
+  @Test def filter: Unit = {
+    datasets foreach (ds => testFor(ds, testFilterImpl _))
+  }
+  @Test def filterNot: Unit = {
+    datasets foreach (ds => testFor(ds, testFilterNotImpl _))
+  }
+  @Test def testHashCode: Unit = {
+    for (data <- datasets) {
+      val testBuilder = BitSet.newBuilder
+      testBuilder ++= data
+      val underTest = testBuilder.result()
+
+      val control = (TreeSet.newBuilder[Int] ++= data).result
+      assertEquals(control.hashCode, underTest.hashCode)
+    }
+  }
+  @Test def applyTrimmedToSize: Unit = {
+    val l2 = (0 to 256 toList)
+    val b2 = BitSet(l2: _*)
+
+    assertEquals("List(ffffffffffffffff, ffffffffffffffff, ffffffffffffffff, ffffffffffffffff, 1)",
+                 b2.toBitMask.toList.map(_.toHexString).toString)
+  }
+  @Test def builderTrimmedToSize: Unit = {
+    val l2 = (0 to 256 toList)
+    val b2 = (BitSet.newBuilder ++= (l2) ).result
+
+    assertEquals("List(ffffffffffffffff, ffffffffffffffff, ffffffffffffffff, ffffffffffffffff, 1)",
+                 b2.toBitMask.toList.map(_.toHexString).toString)
+  }
+}


### PR DESCRIPTION
It seems that these are faster, with a local benchmark using a word and methods on that

Had a look at the class and made some modifications that seem sensible 

See what breaks and then I will provide benchmarks and change the scope as appropriate, add some test and benchmarks etc
Probably some silly mistakes lurking here