### PR TITLE
Bulk ops on TreeSet/TreeSet or TreeMap/TreeMap prefer keys from the left

### DIFF
--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -853,20 +853,20 @@ private[collection] object RedBlackTree {
     if((t1 eq null) || (t1 eq t2)) t2
     else if(t2 eq null) t1
     else {
-      val (l1, _, r1) = split(t1, t2.key)
-      val tl = _union(l1, t2.left)
-      val tr = _union(r1, t2.right)
-      join(tl, t2.key, t2.value, tr)
+      val (l2, _, r2) = split(t2, t1.key)
+      val tl = _union(t1.left, l2)
+      val tr = _union(t1.right, r2)
+      join(tl, t1.key, t1.value, tr)
     }
 
   private[this] def _intersect[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] =
     if((t1 eq null) || (t2 eq null)) null
     else if (t1 eq t2) t1
     else {
-      val (l1, b, r1) = split(t1, t2.key)
-      val tl = _intersect(l1, t2.left)
-      val tr = _intersect(r1, t2.right)
-      if(b ne null) join(tl, t2.key, t2.value, tr)
+      val (l2, b, r2) = split(t2, t1.key)
+      val tl = _intersect(t1.left, l2)
+      val tr = _intersect(t1.right, r2)
+      if(b ne null) join(tl, t1.key, t1.value, tr)
       else join2(tl, tr)
     }
 

--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -1,5 +1,7 @@
 package scala.collection.immutable
 
+import java.util.Collections
+
 import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -201,5 +203,26 @@ class TreeMapTest extends AllocationTest {
       assertEquals(s"$lText $rText", lhs, rhs)
       assertEquals(s"$rText $lText", rhs, lhs)
     }
+  }
+
+  @Test
+  def unionAndIntersectRetainLeft(): Unit = {
+    case class C(a: Int)(override val toString: String)
+    implicit val ordering: Ordering[C] = Ordering.by(_.a)
+    val c0l = C(0)("l")
+    val c0r = C(0)("r")
+    def assertIdenticalKeys(expected: Map[C, Unit], actual: Map[C, Unit]): Unit = {
+      val expected1, actual1 = Collections.newSetFromMap[C](new java.util.IdentityHashMap())
+      expected.keys.foreach(expected1.add)
+      actual.keys.foreach(actual1.add)
+      assertEquals(expected1, actual1)
+    }
+    assertIdenticalKeys(Map((c0l, ())), HashMap((c0l, ())).concat(HashMap((c0r, ()))))
+    assertIdenticalKeys(Map((c0l, ())), TreeMap((c0l, ())).concat(HashMap((c0r, ()))))
+    assertIdenticalKeys(Map((c0l, ())), TreeMap((c0l, ())).concat(TreeMap((c0r, ()))))
+
+    assertIdenticalKeys(Map((c0l, ())), HashMap.newBuilder[C, Unit].++=(HashMap((c0l, ()))).++=(HashMap((c0r, ()))).result())
+    assertIdenticalKeys(Map((c0l, ())), TreeMap.newBuilder[C, Unit].++=(TreeMap((c0l, ()))).++=(HashMap((c0r, ()))).result())
+    assertIdenticalKeys(Map((c0l, ())), TreeMap.newBuilder[C, Unit].++=(TreeMap((c0l, ()))).++=(TreeMap((c0r, ()))).result())
   }
 }

--- a/test/junit/scala/collection/immutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSetTest.scala
@@ -257,4 +257,33 @@ class TreeSetTest extends AllocationTest {
       assertEquals(s"$rText $lText", rhs, lhs)
     }
   }
+
+  @Test
+  def unionAndIntersectRetainLeft(): Unit = {
+    case class C(a: Int)(override val toString: String)
+    implicit val ordering: Ordering[C] = Ordering.by(_.a)
+    val c0l = C(0)("l")
+    val c0r = C(0)("r")
+    def assertIdenticalElements(expected: Set[C], actual: Set[C]): Unit = {
+      val expected1, actual1 = Collections.newSetFromMap[C](new java.util.IdentityHashMap())
+      expected.foreach(expected1.add)
+      actual.foreach(actual1.add)
+      assertEquals(expected1, actual1)
+    }
+    assertIdenticalElements(Set(c0l), HashSet(c0l).union(HashSet(c0r)))
+    assertIdenticalElements(Set(c0l), TreeSet(c0l).union(HashSet(c0r)))
+    assertIdenticalElements(Set(c0l), TreeSet(c0l).union(TreeSet(c0r)))
+
+    assertIdenticalElements(Set(c0l), HashSet(c0l).++(HashSet(c0r)))
+    assertIdenticalElements(Set(c0l), TreeSet(c0l).++(HashSet(c0r)))
+    assertIdenticalElements(Set(c0l), TreeSet(c0l).++(TreeSet(c0r)))
+
+    assertIdenticalElements(Set(c0l), HashSet.newBuilder[C].++=(HashSet(c0l)).++=(HashSet(c0r)).result())
+    assertIdenticalElements(Set(c0l), TreeSet.newBuilder[C].++=(TreeSet(c0l)).++=(HashSet(c0r)).result())
+    assertIdenticalElements(Set(c0l), TreeSet.newBuilder[C].++=(TreeSet(c0l)).++=(TreeSet(c0r)).result())
+
+    assertIdenticalElements(Set(c0l), HashSet(c0l).intersect(HashSet(c0r)))
+    assertIdenticalElements(Set(c0l), TreeSet(c0l).intersect(HashSet(c0r)))
+    assertIdenticalElements(Set(c0l), TreeSet(c0l).intersect(TreeSet(c0r)))
+  }
 }


### PR DESCRIPTION
The test suite that aimed to bring all of our sets and maps into
line did not exercise code paths optimized for:

   collection.$op(collectionOfSameType)

This commit updates the test to:

   - add test variants that generate operands of the same type as the
     input collection
   - add "preserves identity" tests for set intersection
   - fix the resulting failures by flipping the operands
     in `RedBlackTree.{union,intersection}`

I've also added concrete test cases to `Tree{Map,Set}Test` that
are easier to review and that also exercise builders.

Fixes scala/bug#12042

Backporting will remedy scala/bug#12039