### PR TITLE
[backport] Bulk ops on TreeSet, TreeMap prefer keys from the left

### DIFF
--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -760,9 +760,9 @@ private[collection] object RedBlackTree {
   // of child nodes from it. Where possible the black height is used directly instead of deriving the rank from it.
   // Our trees are supposed to have a black root so we always blacken as the last step of union/intersect/difference.
 
-  def union[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] = blacken(_union(t2, t1))
+  def union[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] = blacken(_union(t1, t2))
 
-  def intersect[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] = blacken(_intersect(t2, t1))
+  def intersect[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] = blacken(_intersect(t1, t2))
 
   def difference[A, B](t1: Tree[A, B], t2: Tree[A, _])(implicit ordering: Ordering[A]): Tree[A, B] =
     blacken(_difference(t1, t2.asInstanceOf[Tree[A, B]]))
@@ -851,22 +851,22 @@ private[collection] object RedBlackTree {
 
   private[this] def _union[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] =
     if((t1 eq null) || (t1 eq t2)) t2
-    else if(t2 eq null) t1
+    else if(t1 eq null) t2
     else {
-      val (l1, _, r1) = split(t1, t2.key)
-      val tl = _union(l1, t2.left)
-      val tr = _union(r1, t2.right)
-      join(tl, t2.key, t2.value, tr)
+      val (l2, _, r2) = split(t2, t1.key)
+      val tl = _union(t1.left, l2)
+      val tr = _union(t1.right, r2)
+      join(tl, t1.key, t1.value, tr)
     }
 
   private[this] def _intersect[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] =
     if((t1 eq null) || (t2 eq null)) null
     else if (t1 eq t2) t1
     else {
-      val (l1, b, r1) = split(t1, t2.key)
-      val tl = _intersect(l1, t2.left)
-      val tr = _intersect(r1, t2.right)
-      if(b ne null) join(tl, t2.key, t2.value, tr)
+      val (l2, b, r2) = split(t2, t1.key)
+      val tl = _intersect(t1.left, l2)
+      val tr = _intersect(t1.right, r2)
+      if(b ne null) join(tl, t1.key, t1.value, tr)
       else join2(tl, tr)
     }
 

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -760,9 +760,9 @@ private[collection] object RedBlackTree {
   // of child nodes from it. Where possible the black height is used directly instead of deriving the rank from it.
   // Our trees are supposed to have a black root so we always blacken as the last step of union/intersect/difference.
 
-  def union[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] = blacken(_union(t1, t2))
+  def union[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] = blacken(_union(t2, t1))
 
-  def intersect[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] = blacken(_intersect(t1, t2))
+  def intersect[A, B](t1: Tree[A, B], t2: Tree[A, B])(implicit ordering: Ordering[A]): Tree[A, B] = blacken(_intersect(t2, t1))
 
   def difference[A, B](t1: Tree[A, B], t2: Tree[A, _])(implicit ordering: Ordering[A]): Tree[A, B] =
     blacken(_difference(t1, t2.asInstanceOf[Tree[A, B]]))

--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -172,4 +172,30 @@ class TreeMapTest extends AllocationTest {
     val map2 = map.updated(3, 3)
     assertEquals(List(3 -> 3), map2.toList)
   }
+
+  @Test
+  def unionAndIntersectRetainLeft(): Unit = {
+    case class C(a: Int)(override val toString: String)
+    implicit val ordering: Ordering[C] = Ordering.by(_.a)
+    val c0l = C(0)("l")
+    val c0r = C(0)("r")
+    def assertIdenticalKeys(expected: Map[C, Unit], actual: Map[C, Unit]): Unit = {
+      val expected1, actual1 = new java.util.IdentityHashMap[C, Unit]()
+      expected.keys.foreach(expected1.put(_, ()))
+      actual.keys.foreach(actual1.put(_, ()))
+      assertEquals(expected1, actual1)
+    }
+
+    // This holds in 2.13.x only
+    //assertIdenticalKeys(Map((c0l, ())), HashMap((c0l, ())).++(HashMap((c0r, ()))))
+
+    assertIdenticalKeys(Map((c0l, ())), TreeMap((c0l, ())).++(HashMap((c0r, ()))))
+    assertIdenticalKeys(Map((c0l, ())), TreeMap((c0l, ())).++(TreeMap((c0r, ()))))
+
+    // This holds in 2.13.x only
+    //assertIdenticalKeys(Map((c0l, ())), HashMap.newBuilder[C, Unit].++=(HashMap((c0l, ()))).++=(HashMap((c0r, ()))).result())
+
+    assertIdenticalKeys(Map((c0l, ())), TreeMap.newBuilder[C, Unit].++=(TreeMap((c0l, ()))).++=(HashMap((c0r, ()))).result())
+    assertIdenticalKeys(Map((c0l, ())), TreeMap.newBuilder[C, Unit].++=(TreeMap((c0l, ()))).++=(TreeMap((c0r, ()))).result())
+  }
 }

--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -1,5 +1,7 @@
 package scala.collection.immutable
 
+import java.util.Collections
+
 import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -180,9 +182,9 @@ class TreeMapTest extends AllocationTest {
     val c0l = C(0)("l")
     val c0r = C(0)("r")
     def assertIdenticalKeys(expected: Map[C, Unit], actual: Map[C, Unit]): Unit = {
-      val expected1, actual1 = new java.util.IdentityHashMap[C, Unit]()
-      expected.keys.foreach(expected1.put(_, ()))
-      actual.keys.foreach(actual1.put(_, ()))
+      val expected1, actual1 = Collections.newSetFromMap[C](new java.util.IdentityHashMap())
+      expected.keys.foreach(expected1.add)
+      actual.keys.foreach(actual1.add)
       assertEquals(expected1, actual1)
     }
 

--- a/test/junit/scala/collection/immutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSetTest.scala
@@ -221,9 +221,9 @@ class TreeSetTest extends AllocationTest{
     val c0l = C(0)("l")
     val c0r = C(0)("r")
     def assertIdenticalElements(expected: Set[C], actual: Set[C]): Unit = {
-      val expected1, actual1 = new java.util.IdentityHashMap[C, Unit]()
-      expected.foreach(expected1.put(_, ()))
-      actual.foreach(actual1.put(_, ()))
+      val expected1, actual1 = Collections.newSetFromMap[C](new java.util.IdentityHashMap())
+      expected.foreach(expected1.add)
+      actual.foreach(actual1.add)
       assertEquals(expected1, actual1)
     }
     assertIdenticalElements(Set(c0l), HashSet(c0l).union(HashSet(c0r)))

--- a/test/junit/scala/collection/immutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSetTest.scala
@@ -213,4 +213,33 @@ class TreeSetTest extends AllocationTest{
       assertEquals(s"$rText $lText", rhs, lhs)
     }
   }
+
+  @Test
+  def unionAndIntersectRetainLeft(): Unit = {
+    case class C(a: Int)(override val toString: String)
+    implicit val ordering: Ordering[C] = Ordering.by(_.a)
+    val c0l = C(0)("l")
+    val c0r = C(0)("r")
+    def assertIdenticalElements(expected: Set[C], actual: Set[C]): Unit = {
+      val expected1, actual1 = new java.util.IdentityHashMap[C, Unit]()
+      expected.foreach(expected1.put(_, ()))
+      actual.foreach(actual1.put(_, ()))
+      assertEquals(expected1, actual1)
+    }
+    assertIdenticalElements(Set(c0l), HashSet(c0l).union(HashSet(c0r)))
+    assertIdenticalElements(Set(c0l), TreeSet(c0l).union(HashSet(c0r)))
+    assertIdenticalElements(Set(c0l), TreeSet(c0l).union(TreeSet(c0r)))
+
+    assertIdenticalElements(Set(c0l), HashSet(c0l).++(HashSet(c0r)))
+    assertIdenticalElements(Set(c0l), TreeSet(c0l).++(HashSet(c0r)))
+    assertIdenticalElements(Set(c0l), TreeSet(c0l).++(TreeSet(c0r)))
+
+    assertIdenticalElements(Set(c0l), HashSet.newBuilder[C].++=(HashSet(c0l)).++=(HashSet(c0r)).result())
+    assertIdenticalElements(Set(c0l), TreeSet.newBuilder[C].++=(TreeSet(c0l)).++=(HashSet(c0r)).result())
+    assertIdenticalElements(Set(c0l), TreeSet.newBuilder[C].++=(TreeSet(c0l)).++=(TreeSet(c0r)).result())
+
+    assertIdenticalElements(Set(c0l), HashSet(c0l).intersect(HashSet(c0r)))
+    assertIdenticalElements(Set(c0l), TreeSet(c0l).intersect(HashSet(c0r)))
+    assertIdenticalElements(Set(c0l), TreeSet(c0l).intersect(TreeSet(c0r)))
+  }
 }


### PR DESCRIPTION
Backport of #9061
Fixes scala/bug#12039