### PR TITLE
Run DCE also on large methods

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
@@ -364,20 +364,18 @@ abstract class LocalOpt {
       (codeChanged, requireEliminateUnusedLocals)
     }
 
-    val (nullnessDceBoxesCastsCopypropPushpopOrJumpsChanged, requireEliminateUnusedLocals) = if (AsmAnalyzer.sizeOKForBasicValue(method)) {
-      // we run DCE even if the method is already in the `unreachableCodeEliminated` map: the DCE
-      // here is more thorough than `minimalRemoveUnreachableCode` that run before inlining.
-      val r = removalRound(
-        requestNullness = true,
-        requestDCE = true,
-        requestBoxUnbox = true,
-        requestStaleStores = true,
-        requestPushPop = true,
-        requestStoreLoad = true,
-        firstIteration = true)
-      if (compilerSettings.optUnreachableCode) BackendUtils.setDceDone(method)
-      r
-    } else (false, false)
+    // we run DCE even if the method is already in the `unreachableCodeEliminated` map: the DCE
+    // here is more thorough than `minimalRemoveUnreachableCode` that run before inlining.
+    val (nullnessDceBoxesCastsCopypropPushpopOrJumpsChanged, requireEliminateUnusedLocals) = removalRound(
+      requestNullness = true,
+      requestDCE = true,
+      requestBoxUnbox = true,
+      requestStaleStores = true,
+      requestPushPop = true,
+      requestStoreLoad = true,
+      firstIteration = true)
+
+    if (compilerSettings.optUnreachableCode) BackendUtils.setDceDone(method)
 
     // (*) Removing stale local variable descriptors is required for correctness, see comment in `methodOptimizations`
     val localsRemoved =


### PR DESCRIPTION
e1a2d7dff7 added a `maxLocals` method that ensures the value is actually
always computed when used. Before we relied on a false assumption, and
ended up using `0` for `maxLocals` instead of the actual value.

As a result,

```
if (AsmAnalyzer.sizeOKForBasicValue(method)) {
  doLocalOpts(...)
}
```

would actually always enter the local optimizations and DCE was done,
also for large methods. (The other local optimizations have their own
size guard, so they were (probably) not executed on large methods.)

With the recent re-implementation of DCE in 2424146490, the size guard
is no longer necessary, as we no longer use an ASM Analyzer. So we
simply run `doLocalOpts` (therefore DCE) unconditionally. The other
local optimizations remain guarded by their own size checks.

This was discovered in scala/community-build#1159, `linter` turns out
to have a really huge method that exceeds the JVM method size limit
if DCE doesn't run on it.

https://github.com/HairyFotr/linter/blob/7bfe88acad7072c65bffe9c29b51ae72f141bf8b/src/main/scala/LinterPlugin.scala#L449-L2029