### PR TITLE
add helper types to IsIterable + def instance

### DIFF
--- a/src/library/scala/collection/generic/IsIterable.scala
+++ b/src/library/scala/collection/generic/IsIterable.scala
@@ -157,11 +157,11 @@ trait IsIterableLowPriority {
   // Makes `IsSeq` instances visible in `IsIterable` companion
   implicit def isSeqLikeIsIterable[Repr](implicit
     isSeqLike: IsSeq[Repr]
-  ): IsIterable.WithElement[Repr] { type A = isSeqLike.A; type C = isSeqLike.C } = isSeqLike
+  ): IsIterable.FixAC[Repr, isSeqLike.A, isSeqLike.C] = isSeqLike
 
   // Makes `IsMap` instances visible in `IsIterable` companion
   implicit def isMapLikeIsIterable[Repr](implicit
     isMapLike: IsMap[Repr]
-  ): IsIterable[Repr] { type A = isMapLike.A; type C = isMapLike.C } = isMapLike
+  ): IsIterable.FixAC[Repr, isMapLike.A, isMapLike.C] = isMapLike
 
 }


### PR DESCRIPTION
Has to be seen as proposition and not as full PR (done via web-gui)
I think we could simplify the definition of custom IsIterable with a `instance` method. 
Also, I have added some helper type alias to ease constraining IsIterable's `A` or `C` (or both). As the default case is to fix `C` with `Repr` I have added `WithA` which `FixA` and takes `Repr` as `C`.

Please let me know if something like that should be opened elsewhere