### PR TITLE
type safety: replaced getOrElse with fold

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -195,7 +195,7 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
       deprecationWarning(pos, msg, since, siteName(site), siteName(origin))
 
     def deprecationWarning(pos: Position, origin: Symbol, site: Symbol): Unit = {
-      val version = origin.deprecationVersion.getOrElse("")
+      val version = origin.deprecationVersion.fold("")(identity)
       val since   = if (version.isEmpty) version else s" (since $version)"
       val message = origin.deprecationMessage.map(": " + _).getOrElse("")
       deprecationWarning(pos, origin, site, s"$origin${origin.locationString} is deprecated$since$message", version)

--- a/test/scaladoc/run/tables-warnings.scala
+++ b/test/scaladoc/run/tables-warnings.scala
@@ -98,7 +98,7 @@ object Test extends ScaladocModelTest {
     val blockComparisons = blocks.zipWithIndex.collect {
       case ((expectedBlock, actualBlock), idx) if expectedBlock != actualBlock =>
         s"Block mismatch at index $idx\nExpected block: $expectedBlock\nActual block  : $actualBlock"
-    }.headOption.getOrElse("")
+    }.headOption.fold("")(identity)
 
     assert(expectedBody == actualBody, s"$blockComparisons\n\nExpected: $expectedBody, Actual: $actualBody")
   }

--- a/test/scaladoc/run/tables.scala
+++ b/test/scaladoc/run/tables.scala
@@ -372,7 +372,7 @@ object Test extends ScaladocModelTest {
     val blockComparisons = blocks.zipWithIndex.collect {
       case ((expectedBlock, actualBlock), idx) if expectedBlock != actualBlock =>
         s"Block mismatch at index $idx\nExpected block: $expectedBlock\nActual block  : $actualBlock"
-    }.headOption.getOrElse("")
+    }.headOption.fold("")(identity)
 
     assert(expectedBody == actualBody, s"$blockComparisons\n\nExpected: $expectedBody, Actual: $actualBody")
   }


### PR DESCRIPTION
Replaced getOrElse with fold for better type safety