### PR TITLE
HashMap bulk operations should retain existing keys

### DIFF
--- a/test/junit/scala/collection/immutable/HashMapTest.scala
+++ b/test/junit/scala/collection/immutable/HashMapTest.scala
@@ -1,5 +1,7 @@
 package scala.collection.immutable
 
+import java.util.Collections
+
 import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -203,7 +205,7 @@ class HashMapTest extends AllocationTest {
       "i" -> 9,
       "j" -> 10
     )
-    assertSame(nonEmpty2, nonAllocating(nonEmpty1 ++ nonEmpty2))
+    assertSame(nonEmpty1, nonAllocating(nonEmpty1 ++ nonEmpty2))
   }
 
   @Test
@@ -268,5 +270,32 @@ class HashMapTest extends AllocationTest {
     val m2 = Map[Int, Int] (2->2)
     //calls GenTraversableOnce.++
     assertEquals(1, (m2 ++ m1).apply(2))
+  }
+
+  @Test
+  def retainLeft(): Unit = {
+    case class C(a: Int)(override val toString: String)
+    implicit val ordering: Ordering[C] = Ordering.by(_.a)
+    val c0l = C(0)("l")
+    val c0r = C(0)("r")
+    def assertIdenticalKeys(expected: Map[C, Unit], actual: Map[C, Unit]): Unit = {
+      val expected1, actual1 = Collections.newSetFromMap[C](new java.util.IdentityHashMap())
+      expected.keys.foreach(expected1.add)
+      actual.keys.foreach(actual1.add)
+      assertEquals(expected1, actual1)
+    }
+    assertIdenticalKeys(Map((c0l, ())), HashMap((c0l, ())).updated(c0r, ()))
+
+    def check(factory: Seq[(C, Unit)] => Map[C, Unit]): Unit = {
+      val c0LMap = factory(Seq((c0l, ())))
+      val c0RMap = factory(Seq((c0r, ())))
+      assertIdenticalKeys(Map((c0l, ())), HashMap((c0l, ())).++(c0RMap))
+      assertIdenticalKeys(Map((c0l, ())), HashMap.newBuilder[C, Unit].++=(HashMap((c0l, ()))).++=(c0RMap).result())
+      assertIdenticalKeys(Map((c0l, ())), HashMap((c0l, ())).++(c0RMap))
+      assertIdenticalKeys(Map((c0l, ())), c0LMap ++: HashMap((c0r, ())))
+    }
+    check(cs => HashMap(cs: _*)) // exercise special case for HashMap/HashMap
+    check(cs => TreeMap(cs: _*)) // exercise special case for HashMap/HasForEachEntry
+    check(cs => HashMap(cs: _*).withDefault(_ => ???)) // default cases
   }
 }

--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -176,7 +176,7 @@ class TreeMapTest extends AllocationTest {
   }
 
   @Test
-  def unionAndIntersectRetainLeft(): Unit = {
+  def retainLeft(): Unit = {
     case class C(a: Int)(override val toString: String)
     implicit val ordering: Ordering[C] = Ordering.by(_.a)
     val c0l = C(0)("l")
@@ -188,14 +188,12 @@ class TreeMapTest extends AllocationTest {
       assertEquals(expected1, actual1)
     }
 
-    // This holds in 2.13.x only
-    //assertIdenticalKeys(Map((c0l, ())), HashMap((c0l, ())).++(HashMap((c0r, ()))))
+    assertIdenticalKeys(Map((c0l, ())), HashMap((c0l, ())).++(HashMap((c0r, ()))))
 
     assertIdenticalKeys(Map((c0l, ())), TreeMap((c0l, ())).++(HashMap((c0r, ()))))
     assertIdenticalKeys(Map((c0l, ())), TreeMap((c0l, ())).++(TreeMap((c0r, ()))))
 
-    // This holds in 2.13.x only
-    //assertIdenticalKeys(Map((c0l, ())), HashMap.newBuilder[C, Unit].++=(HashMap((c0l, ()))).++=(HashMap((c0r, ()))).result())
+    assertIdenticalKeys(Map((c0l, ())), HashMap.newBuilder[C, Unit].++=(HashMap((c0l, ()))).++=(HashMap((c0r, ()))).result())
 
     assertIdenticalKeys(Map((c0l, ())), TreeMap.newBuilder[C, Unit].++=(TreeMap((c0l, ()))).++=(HashMap((c0r, ()))).result())
     assertIdenticalKeys(Map((c0l, ())), TreeMap.newBuilder[C, Unit].++=(TreeMap((c0l, ()))).++=(TreeMap((c0r, ()))).result())

--- a/test/junit/scala/collection/immutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSetTest.scala
@@ -230,6 +230,10 @@ class TreeSetTest extends AllocationTest{
     assertIdenticalElements(Set(c0l), TreeSet(c0l).union(HashSet(c0r)))
     assertIdenticalElements(Set(c0l), TreeSet(c0l).union(TreeSet(c0r)))
 
+    assertIdenticalElements(Set(c0l), HashSet(c0l).+(c0r))
+    assertIdenticalElements(Set(c0l), TreeSet(c0l).+(c0r))
+    assertIdenticalElements(Set(c0l), TreeSet(c0l).+(c0r))
+
     assertIdenticalElements(Set(c0l), HashSet(c0l).++(HashSet(c0r)))
     assertIdenticalElements(Set(c0l), TreeSet(c0l).++(HashSet(c0r)))
     assertIdenticalElements(Set(c0l), TreeSet(c0l).++(TreeSet(c0r)))


### PR DESCRIPTION
... when the operand overwrites mapping with a key that is == but ne.

This is consistent with the super class implementation, which was
overridden in 2.12.11 for efficiency.

I also found a pair of ClassCastExceptions in the new implementations of
`HashMap.++:`, for instance:

``` case class C(a: Int)(override val toString: String); implicit val
Ordering_C: Ordering[C] = Ordering.by(_.a); val c0l = C(0)("l"); val c0r =
C(0)("r"); import collection.immutable._; println(HashMap((c0l,
())).++:(TreeMap((c0r, ()))))'; done v2.12.10 Map(r -> ()) v2.12.11 
java.lang.ClassCastException: scala.collection.immutable.HashMap$adder$1$
cannot be cast to scala.collection.immutable.HashMap
at scala.collection.immutable.HashMap$adder$1$.<init>(HashMap.scala:215)
```

Fixes scala/bug#12047