### PR TITLE
Deprecate empty-paren (nilary) prefix unary operator

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2815,6 +2815,16 @@ self =>
             }
             expr()
           }
+        if (nme.isEncodedUnary(name) && vparamss.nonEmpty) {
+          val tpeStr = if (restype.isEmpty) "" else s" : $restype"
+          def unaryMsg(what: String) = s"empty-paren (nilary) prefix unary operator is $what: instead, remove () to declare as `def ${name.decodedName}$tpeStr`"
+          vparamss match {
+            case List(List()) =>
+              if (currentRun.isScala3) syntaxError(nameOffset, unaryMsg("unsupported"))
+              else deprecationWarning(nameOffset, unaryMsg("deprecated"), "2.13.4")
+            case _ => // ok
+          }
+        }
         DefDef(newmods, name.toTermName, tparams, vparamss, restype, rhs)
       }
       signalParseProgress(result.pos)

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2817,7 +2817,7 @@ self =>
           }
         if (nme.isEncodedUnary(name) && vparamss.nonEmpty) {
           val tpeStr = if (restype.isEmpty) "" else s" : $restype"
-          def unaryMsg(what: String) = s"empty-paren (nilary) prefix unary operator is $what: instead, remove () to declare as `def ${name.decodedName}$tpeStr`"
+          def unaryMsg(what: String) = s"unary prefix operator definition with empty parameter list is $what: instead, remove () to declare as `def ${name.decodedName}$tpeStr`"
           vparamss match {
             case List(List()) =>
               if (currentRun.isScala3) syntaxError(nameOffset, unaryMsg("unsupported"))

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -988,6 +988,8 @@ trait StdNames {
     val UNARY_- = encode("unary_-")
     val UNARY_! = encode("unary_!")
 
+    val isEncodedUnary = Set[Name](UNARY_~, UNARY_+, UNARY_-, UNARY_!)
+
     // Grouped here so Cleanup knows what tests to perform.
     val CommonOpNames   = Set[Name](OR, XOR, AND, EQ, NE)
     val BooleanOpNames  = Set[Name](ZOR, ZAND, UNARY_!) ++ CommonOpNames

--- a/test/files/neg/prefix-unary-nilary-deprecation.check
+++ b/test/files/neg/prefix-unary-nilary-deprecation.check
@@ -1,4 +1,4 @@
-prefix-unary-nilary-deprecation.scala:4: warning: empty-paren (nilary) prefix unary operator is deprecated: instead, remove () to declare as `def unary_~ : Foo`
+prefix-unary-nilary-deprecation.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo`
   def unary_~() : Foo = this
       ^
 prefix-unary-nilary-deprecation.scala:10: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,

--- a/test/files/neg/prefix-unary-nilary-deprecation.check
+++ b/test/files/neg/prefix-unary-nilary-deprecation.check
@@ -1,0 +1,11 @@
+prefix-unary-nilary-deprecation.scala:4: warning: empty-paren (nilary) prefix unary operator is deprecated: instead, remove () to declare as `def unary_~ : Foo`
+  def unary_~() : Foo = this
+      ^
+prefix-unary-nilary-deprecation.scala:10: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
+or remove the empty argument list from its definition (Java-defined methods are exempt).
+In Scala 3, an unapplied method like this will be eta-expanded into a function.
+  val f2 = ~f
+           ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/prefix-unary-nilary-deprecation.check
+++ b/test/files/neg/prefix-unary-nilary-deprecation.check
@@ -1,11 +1,14 @@
-prefix-unary-nilary-deprecation.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo`
+prefix-unary-nilary-deprecation.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this`
   def unary_~() : Foo = this
       ^
-prefix-unary-nilary-deprecation.scala:10: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
+prefix-unary-nilary-deprecation.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this`
+  def unary_-()(implicit pos: Long) = this
+      ^
+prefix-unary-nilary-deprecation.scala:12: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
 In Scala 3, an unapplied method like this will be eta-expanded into a function.
   val f2 = ~f
            ^
 error: No warnings can be incurred under -Werror.
-2 warnings
+3 warnings
 1 error

--- a/test/files/neg/prefix-unary-nilary-deprecation.scala
+++ b/test/files/neg/prefix-unary-nilary-deprecation.scala
@@ -2,8 +2,10 @@
 //
 class Foo {
   def unary_~() : Foo = this
+  def unary_-()(implicit pos: Long) = this
 
   def unary_! : Foo = this // ok
+  def unary_+(implicit pos: Long) = this // ok
 }
 object Test {
   val f = new Foo

--- a/test/files/neg/prefix-unary-nilary-deprecation.scala
+++ b/test/files/neg/prefix-unary-nilary-deprecation.scala
@@ -1,0 +1,11 @@
+// scalac: -Werror -Xlint:deprecation
+//
+class Foo {
+  def unary_~() : Foo = this
+
+  def unary_! : Foo = this // ok
+}
+object Test {
+  val f = new Foo
+  val f2 = ~f
+}

--- a/test/files/neg/prefix-unary-nilary-removal.check
+++ b/test/files/neg/prefix-unary-nilary-removal.check
@@ -1,0 +1,4 @@
+prefix-unary-nilary-removal.scala:4: error: empty-paren (nilary) prefix unary operator is unsupported: instead, remove () to declare as `def unary_~ : Foo`
+  def unary_~() : Foo = this
+      ^
+1 error

--- a/test/files/neg/prefix-unary-nilary-removal.check
+++ b/test/files/neg/prefix-unary-nilary-removal.check
@@ -1,4 +1,4 @@
-prefix-unary-nilary-removal.scala:4: error: empty-paren (nilary) prefix unary operator is unsupported: instead, remove () to declare as `def unary_~ : Foo`
+prefix-unary-nilary-removal.scala:4: error: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_~ : Foo`
   def unary_~() : Foo = this
       ^
 1 error

--- a/test/files/neg/prefix-unary-nilary-removal.check
+++ b/test/files/neg/prefix-unary-nilary-removal.check
@@ -1,4 +1,7 @@
-prefix-unary-nilary-removal.scala:4: error: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_~ : Foo`
+prefix-unary-nilary-removal.scala:4: error: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_~ : Foo = this`
   def unary_~() : Foo = this
       ^
-1 error
+prefix-unary-nilary-removal.scala:5: error: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_-(implicit pos: Long) = this`
+  def unary_-()(implicit pos: Long) = this
+      ^
+2 errors

--- a/test/files/neg/prefix-unary-nilary-removal.scala
+++ b/test/files/neg/prefix-unary-nilary-removal.scala
@@ -2,8 +2,10 @@
 //
 class Foo {
   def unary_~() : Foo = this
+  def unary_-()(implicit pos: Long) = this
 
   def unary_! : Foo = this // ok
+  def unary_+(implicit pos: Long) = this // ok
 }
 object Test {
   val f = new Foo

--- a/test/files/neg/prefix-unary-nilary-removal.scala
+++ b/test/files/neg/prefix-unary-nilary-removal.scala
@@ -1,0 +1,11 @@
+// scalac: -Xsource:3
+//
+class Foo {
+  def unary_~() : Foo = this
+
+  def unary_! : Foo = this // ok
+}
+object Test {
+  val f = new Foo
+  val f2 = ~f
+}


### PR DESCRIPTION
Ref https://github.com/scala/bug/issues/12055

> Now that auto-application is deprecated, a prefix with a nilary creates a warning that cannot be avoided while maintaining a prefix position (or permanently applying warning suppression).

This adds the following warning

> deprecation.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this`
>   def unary_~() : Foo = this
>       ^
> deprecation.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this`
>   def unary_-()(implicit pos: Long) = this
>       ^
> 

I've opted to use the term "empty-paren" as defined in https://www.artima.com/pins1ed/composition-and-inheritance.html.

Note that removing an empty parameter list from a definition does not break binary compatibility.

Under `-Xsource:3`, error instead.