### PR TITLE
Respect `-Xlint:-multiarg-infix` to suppress lint at callsite

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5077,7 +5077,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               // The enclosing context may be case c @ C(_) => or val c @ C(_) = v.
               tree1 modifyType (_.finalResultType)
               tree1
-            case tree1 @ Apply(_, args1) if tree.hasAttachment[MultiargInfixAttachment.type] && args1.lengthCompare(1) > 0 =>
+            case tree1 @ Apply(_, args1) if settings.multiargInfix && tree.hasAttachment[MultiargInfixAttachment.type] && args1.lengthCompare(1) > 0 =>
               context.warning(tree1.pos, "multiarg infix syntax looks like a tuple and will be deprecated", WarningCategory.LintMultiargInfix)
               tree1
             case tree1                                                               => tree1

--- a/test/files/run/infix.check
+++ b/test/files/run/infix.check
@@ -1,17 +1,2 @@
-infix.scala:6: warning: multiarg infix syntax looks like a tuple and will be deprecated
-  val xs = new op(null, 0, 0) op (1, 1) op (2, 2)
-                              ^
-infix.scala:6: warning: multiarg infix syntax looks like a tuple and will be deprecated
-  val xs = new op(null, 0, 0) op (1, 1) op (2, 2)
-                                        ^
-infix.scala:9: warning: multiarg infix syntax looks like a tuple and will be deprecated
-    case null op (0, 0) op (1, 1) op (2, 2) => Console.println("OK")
-              ^
-infix.scala:9: warning: multiarg infix syntax looks like a tuple and will be deprecated
-    case null op (0, 0) op (1, 1) op (2, 2) => Console.println("OK")
-                        ^
-infix.scala:9: warning: multiarg infix syntax looks like a tuple and will be deprecated
-    case null op (0, 0) op (1, 1) op (2, 2) => Console.println("OK")
-                                  ^
 op(op(op(null,0,0),1,1),2,2)
 OK

--- a/test/files/run/t5565.check
+++ b/test/files/run/t5565.check
@@ -1,3 +1,0 @@
-t5565.scala:10: warning: multiarg infix syntax looks like a tuple and will be deprecated
-  assert(math.abs(-4.0) ~== (4.0, 0.001))
-                        ^


### PR DESCRIPTION
Fixes scala/bug#12058