### PR TITLE
Small optimisations - some faster array copies, reuse empty arrays

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -352,7 +352,10 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.generic.SortedSetFactory#SortedSetCanBuildFrom.factory"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.generic.SortedSetFactory#SortedSetCanBuildFrom.ordering"),
 
-    //
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Array.emptyUnitArray"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.WrappedArrayBuilder$"),
+
+  //
     // scala-reflect
     //
     ProblemFilters.exclude[Problem]("scala.reflect.internal.*"),

--- a/build.sbt
+++ b/build.sbt
@@ -355,6 +355,27 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Array.emptyUnitArray"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.WrappedArrayBuilder$"),
 
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassTag#GenericClassTag.emptyArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassTag#GenericClassTag.emptyWrappedArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#IntersectionTypeManifest.emptyArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#IntersectionTypeManifest.emptyWrappedArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#ClassTypeManifest.emptyArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#ClassTypeManifest.emptyWrappedArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.AnyValManifest.emptyArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.AnyValManifest.emptyWrappedArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassTag.emptyArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassTag.emptyWrappedArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#WildcardManifest.emptyArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#WildcardManifest.emptyWrappedArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#SingletonTypeManifest.emptyArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#SingletonTypeManifest.emptyWrappedArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassManifestFactory#AbstractTypeClassManifest.emptyArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassManifestFactory#AbstractTypeClassManifest.emptyWrappedArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#AbstractTypeManifest.emptyArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#AbstractTypeManifest.emptyWrappedArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassTypeManifest.emptyArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassTypeManifest.emptyWrappedArray"),
+
   //
     // scala-reflect
     //

--- a/build.sbt
+++ b/build.sbt
@@ -353,30 +353,13 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.generic.SortedSetFactory#SortedSetCanBuildFrom.ordering"),
 
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Array.emptyUnitArray"),
-    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.WrappedArrayBuilder$"),
 
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassTag#GenericClassTag.emptyArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassTag#GenericClassTag.emptyWrappedArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#IntersectionTypeManifest.emptyArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#IntersectionTypeManifest.emptyWrappedArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#ClassTypeManifest.emptyArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#ClassTypeManifest.emptyWrappedArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.AnyValManifest.emptyArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.AnyValManifest.emptyWrappedArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassTag.emptyArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassTag.emptyWrappedArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#WildcardManifest.emptyArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#WildcardManifest.emptyWrappedArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#SingletonTypeManifest.emptyArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#SingletonTypeManifest.emptyWrappedArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassManifestFactory#AbstractTypeClassManifest.emptyArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassManifestFactory#AbstractTypeClassManifest.emptyWrappedArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#AbstractTypeManifest.emptyArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ManifestFactory#AbstractTypeManifest.emptyWrappedArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassTypeManifest.emptyArray"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.ClassTypeManifest.emptyWrappedArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.*Tag.emptyArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.*Tag.emptyWrappedArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.*Manifest.emptyArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.*Manifest.emptyWrappedArray"),
 
-  //
+    //
     // scala-reflect
     //
     ProblemFilters.exclude[Problem]("scala.reflect.internal.*"),

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -385,7 +385,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
      * can-multi-thread
      */
     def pickleMarkerForeign = {
-      createJAttribute(tpnme.ScalaATTR.toString, new Array[Byte](0), 0, 0)
+      createJAttribute(tpnme.ScalaATTR.toString, Array.emptyByteArray, 0, 0)
     }
 
     /*  Returns a ScalaSignature annotation if it must be added to this class, none otherwise.

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingFrame.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingFrame.scala
@@ -502,9 +502,7 @@ object AliasSet {
     else {
       var newLength = set.length
       while (index >= newLength) newLength *= 2
-      val newSet = new Array[Long](newLength)
-      Array.copy(set, 0, newSet, 0, set.length)
-      newSet
+      java.util.Arrays.copyOf(set, newLength)
     }
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -466,11 +466,8 @@ abstract class BackendUtils extends PerRunInit {
       var queue = new Array[Int](8)
       var top = -1
       def enq(i: Int): Unit = {
-        if (top == queue.length - 1) {
-          val nq = new Array[Int](queue.length * 2)
-          Array.copy(queue, 0, nq, 0, queue.length)
-          queue = nq
-        }
+        if (top == queue.length - 1)
+          queue = java.util.Arrays.copyOf(queue, queue.length * 2)
         top += 1
         queue(top) = i
       }

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
@@ -510,11 +510,8 @@ abstract class LocalOpt {
     var queue = new Array[Int](8)
     var top = -1
     def enq(i: Int): Unit = {
-      if (top == queue.length - 1) {
-        val nq = new Array[Int](queue.length * 2)
-        Array.copy(queue, 0, nq, 0, queue.length)
-        queue = nq
-      }
+      if (top == queue.length - 1)
+        queue = java.util.Arrays.copyOf(queue, queue.length * 2)
       top += 1
       queue(top) = i
     }

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -51,10 +51,6 @@ class FallbackArrayBuilding {
  *  @since  1.0
  */
 object Array extends FallbackArrayBuilding {
-  private val emptyArrays = new ClassValue[AnyRef] {
-    override def computeValue(cls: Class[_]): AnyRef =
-      java.lang.reflect.Array.newInstance(cls, 0)
-  }
 
   val emptyBooleanArray = empty[Boolean]
   val emptyByteArray    = empty[Byte]
@@ -188,8 +184,7 @@ object Array extends FallbackArrayBuilding {
 
   /** Returns an array of length 0 */
   def empty[T: ClassTag]: Array[T] =  {
-    val cls = implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]]
-    emptyArrays.get(cls).asInstanceOf[Array[T]]
+    implicitly[ClassTag[T]].emptyArray
   }
   /** Creates an array with given elements.
    *

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -51,15 +51,23 @@ class FallbackArrayBuilding {
  *  @since  1.0
  */
 object Array extends FallbackArrayBuilding {
-  val emptyBooleanArray = new Array[Boolean](0)
-  val emptyByteArray    = new Array[Byte](0)
-  val emptyCharArray    = new Array[Char](0)
-  val emptyDoubleArray  = new Array[Double](0)
-  val emptyFloatArray   = new Array[Float](0)
-  val emptyIntArray     = new Array[Int](0)
-  val emptyLongArray    = new Array[Long](0)
-  val emptyShortArray   = new Array[Short](0)
-  val emptyObjectArray  = new Array[Object](0)
+  private val emptyArrays = new ClassValue[AnyRef] {
+    override def computeValue(cls: Class[_]): AnyRef =
+      java.lang.reflect.Array.newInstance(cls, 0)
+  }
+
+  val emptyBooleanArray = empty[Boolean]
+  val emptyByteArray    = empty[Byte]
+  val emptyCharArray    = empty[Char]
+  val emptyDoubleArray  = empty[Double]
+  val emptyFloatArray   = empty[Float]
+  val emptyIntArray     = empty[Int]
+  val emptyLongArray    = empty[Long]
+  val emptyShortArray   = empty[Short]
+
+  private[scala] //this is only private because of binary compatability
+  val emptyUnitArray    = empty[scala.runtime.BoxedUnit].asInstanceOf[Array[Unit]]
+  val emptyObjectArray  = empty[Object]
 
   implicit def canBuildFrom[T](implicit tag: ClassTag[T]): CanBuildFrom[Array[_], T, Array[T]] = {
     val cls = tag.runtimeClass
@@ -179,8 +187,10 @@ object Array extends FallbackArrayBuilding {
   }
 
   /** Returns an array of length 0 */
-  def empty[T: ClassTag]: Array[T] = new Array[T](0)
-
+  def empty[T: ClassTag]: Array[T] =  {
+    val cls = implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]]
+    emptyArrays.get(cls).asInstanceOf[Array[T]]
+  }
   /** Creates an array with given elements.
    *
    *  @param xs the elements to put in the array

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -487,9 +487,7 @@ private[collection] final class CNode[K, V](val bitmap: Int, val array: Array[Ba
   }
 
   def updatedAt(pos: Int, nn: BasicNode, gen: Gen) = {
-    val len = array.length
-    val narr = new Array[BasicNode](len)
-    Array.copy(array, 0, narr, 0, len)
+    val narr = java.util.Arrays.copyOf(array, array.length)
     narr(pos) = nn
     new CNode[K, V](bitmap, narr, gen)
   }

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -133,9 +133,9 @@ object ArrayBuilder {
     private var size: Int = 0
 
     private def mkArray(size: Int): Array[Byte] = {
-      val newelems = new Array[Byte](size)
-      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
-      newelems
+      if (size == 0) Array.emptyByteArray
+      else if (elems eq null) new Array(size)
+      else java.util.Arrays.copyOf(elems, size)
     }
 
     private def resize(size: Int) {
@@ -198,9 +198,9 @@ object ArrayBuilder {
     private var size: Int = 0
 
     private def mkArray(size: Int): Array[Short] = {
-      val newelems = new Array[Short](size)
-      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
-      newelems
+      if (size == 0) Array.emptyShortArray
+      else if (elems eq null) new Array(size)
+      else java.util.Arrays.copyOf(elems, size)
     }
 
     private def resize(size: Int) {
@@ -263,9 +263,9 @@ object ArrayBuilder {
     private var size: Int = 0
 
     private def mkArray(size: Int): Array[Char] = {
-      val newelems = new Array[Char](size)
-      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
-      newelems
+      if (size == 0) Array.emptyCharArray
+      else if (elems eq null) new Array(size)
+      else java.util.Arrays.copyOf(elems, size)
     }
 
     private def resize(size: Int) {
@@ -328,9 +328,9 @@ object ArrayBuilder {
     private var size: Int = 0
 
     private def mkArray(size: Int): Array[Int] = {
-      val newelems = new Array[Int](size)
-      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
-      newelems
+      if (size == 0) Array.emptyIntArray
+      else if (elems eq null) new Array(size)
+      else java.util.Arrays.copyOf(elems, size)
     }
 
     private def resize(size: Int) {
@@ -393,9 +393,9 @@ object ArrayBuilder {
     private var size: Int = 0
 
     private def mkArray(size: Int): Array[Long] = {
-      val newelems = new Array[Long](size)
-      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
-      newelems
+      if (size == 0) Array.emptyLongArray
+      else if (elems eq null) new Array(size)
+      else java.util.Arrays.copyOf(elems, size)
     }
 
     private def resize(size: Int) {
@@ -458,9 +458,9 @@ object ArrayBuilder {
     private var size: Int = 0
 
     private def mkArray(size: Int): Array[Float] = {
-      val newelems = new Array[Float](size)
-      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
-      newelems
+      if (size == 0) Array.emptyFloatArray
+      else if (elems eq null) new Array(size)
+      else java.util.Arrays.copyOf(elems, size)
     }
 
     private def resize(size: Int) {
@@ -523,9 +523,9 @@ object ArrayBuilder {
     private var size: Int = 0
 
     private def mkArray(size: Int): Array[Double] = {
-      val newelems = new Array[Double](size)
-      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
-      newelems
+      if (size == 0) Array.emptyDoubleArray
+      else if (elems eq null) new Array(size)
+      else java.util.Arrays.copyOf(elems, size)
     }
 
     private def resize(size: Int) {
@@ -588,9 +588,9 @@ object ArrayBuilder {
     private var size: Int = 0
 
     private def mkArray(size: Int): Array[Boolean] = {
-      val newelems = new Array[Boolean](size)
-      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
-      newelems
+      if (size == 0) Array.emptyBooleanArray
+      else if (elems eq null) new Array(size)
+      else java.util.Arrays.copyOf(elems, size)
     }
 
     private def resize(size: Int) {
@@ -663,10 +663,12 @@ object ArrayBuilder {
     def clear() { size = 0 }
 
     def result() = {
-      val ans = new Array[Unit](size)
-      var i = 0
-      while (i < size) { ans(i) = (); i += 1 }
-      ans
+      if (size == 0) Array.emptyUnitArray
+      else {
+        val ans = new Array[Unit](size)
+        java.util.Arrays.fill(ans.asInstanceOf[Array[AnyRef]], ())
+        ans
+      }
     }
 
     override def equals(other: Any): Boolean = other match {

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -73,9 +73,7 @@ class BitSet(protected final var elems: Array[Long]) extends AbstractSet[Int]
     if (idx >= nwords) {
       var newlen = nwords
       while (idx >= newlen) newlen = (newlen * 2) min MaxSize
-      val elems1 = new Array[Long](newlen)
-      Array.copy(elems, 0, elems1, 0, nwords)
-      elems = elems1
+      elems = java.util.Arrays.copyOf(elems, newlen)
     }
   }
 
@@ -175,11 +173,8 @@ class BitSet(protected final var elems: Array[Long]) extends AbstractSet[Int]
     "immutability of the result.", "2.12.0")
   def toImmutable = immutable.BitSet.fromBitMaskNoCopy(elems)
 
-  override def clone(): BitSet = {
-    val elems1 = new Array[Long](elems.length)
-    Array.copy(elems, 0, elems1, 0, elems.length)
-    new BitSet(elems1)
-  }
+  override def clone(): BitSet =
+    new BitSet(elems.clone)
 }
 
 /** $factoryInfo
@@ -198,13 +193,8 @@ object BitSet extends BitSetFactory[BitSet] {
   /** A bitset containing all the bits in an array */
   def fromBitMask(elems: Array[Long]): BitSet = {
     val len = elems.length
-    if (len == 0) {
-      empty
-    } else {
-      val a = new Array[Long](len)
-      Array.copy(elems, 0, a, 0, len)
-      new BitSet(a)
-    }
+    if (len == 0) empty
+    else new BitSet(elems.clone)
   }
 
   /** A bitset containing all the bits in an array, wrapping the existing

--- a/src/library/scala/collection/mutable/WrappedArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/WrappedArrayBuilder.scala
@@ -35,7 +35,7 @@ class WrappedArrayBuilder[A](tag: ClassTag[A]) extends ReusableBuilder[A, Wrappe
   private var size: Int = 0
 
   private def mkArray(size: Int): WrappedArray[A] = {
-    if (size == 0) WrappedArrayBuilder.emptyWrappedArray(tag)
+    if (size == 0) tag.emptyWrappedArray
     else {
       import java.util.Arrays.copyOf
       val runtimeClass = tag.runtimeClass
@@ -111,25 +111,4 @@ class WrappedArrayBuilder[A](tag: ClassTag[A]) extends ReusableBuilder[A, Wrappe
   }
 
   // todo: add ++=
-}
-private [mutable] object WrappedArrayBuilder {
-  private def emptyWrappedArray[T](tag: ClassTag[T]): mutable.WrappedArray[T] =
-    emptyClass.get(tag.runtimeClass).asInstanceOf[WrappedArray[T]]
-  private[this] val emptyClass = new ClassValue[WrappedArray[_]] {
-    override def computeValue(cls: Class[_]): WrappedArray[_] = {
-      if (cls.isPrimitive)
-        cls match {
-          case java.lang.Integer.TYPE   => new WrappedArray.ofInt(Array.emptyIntArray)
-          case java.lang.Double.TYPE    => new WrappedArray.ofDouble(Array.emptyDoubleArray)
-          case java.lang.Long.TYPE      => new WrappedArray.ofLong(Array.emptyLongArray)
-          case java.lang.Float.TYPE     => new WrappedArray.ofFloat(Array.emptyFloatArray)
-          case java.lang.Character.TYPE => new WrappedArray.ofChar(Array.emptyCharArray)
-          case java.lang.Byte.TYPE      => new WrappedArray.ofByte(Array.emptyByteArray)
-          case java.lang.Short.TYPE     => new WrappedArray.ofShort(Array.emptyShortArray)
-          case java.lang.Boolean.TYPE   => new WrappedArray.ofBoolean(Array.emptyBooleanArray)
-          case java.lang.Void.TYPE      => new WrappedArray.ofUnit(Array.emptyUnitArray)
-        }
-      else new WrappedArray.ofRef(Array.empty[AnyRef])
-    }
-  }
 }

--- a/src/library/scala/collection/mutable/WrappedArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/WrappedArrayBuilder.scala
@@ -129,7 +129,7 @@ private [mutable] object WrappedArrayBuilder {
           case java.lang.Boolean.TYPE   => new WrappedArray.ofBoolean(Array.emptyBooleanArray)
           case java.lang.Void.TYPE      => new WrappedArray.ofUnit(Array.emptyUnitArray)
         }
-      else new WrappedArray.ofRef(Array.empty.asInstanceOf[Array[_ <: AnyRef]])
+      else new WrappedArray.ofRef(Array.empty[AnyRef])
     }
   }
 }

--- a/src/library/scala/collection/mutable/WrappedArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/WrappedArrayBuilder.scala
@@ -35,24 +35,45 @@ class WrappedArrayBuilder[A](tag: ClassTag[A]) extends ReusableBuilder[A, Wrappe
   private var size: Int = 0
 
   private def mkArray(size: Int): WrappedArray[A] = {
-    val runtimeClass = tag.runtimeClass
-    val newelems = if (runtimeClass.isPrimitive) {
-      runtimeClass match {
-        case java.lang.Integer.TYPE   => new WrappedArray.ofInt(new Array[Int](size)).asInstanceOf[WrappedArray[A]]
-        case java.lang.Double.TYPE    => new WrappedArray.ofDouble(new Array[Double](size)).asInstanceOf[WrappedArray[A]]
-        case java.lang.Long.TYPE      => new WrappedArray.ofLong(new Array[Long](size)).asInstanceOf[WrappedArray[A]]
-        case java.lang.Float.TYPE     => new WrappedArray.ofFloat(new Array[Float](size)).asInstanceOf[WrappedArray[A]]
-        case java.lang.Character.TYPE => new WrappedArray.ofChar(new Array[Char](size)).asInstanceOf[WrappedArray[A]]
-        case java.lang.Byte.TYPE      => new WrappedArray.ofByte(new Array[Byte](size)).asInstanceOf[WrappedArray[A]]
-        case java.lang.Short.TYPE     => new WrappedArray.ofShort(new Array[Short](size)).asInstanceOf[WrappedArray[A]]
-        case java.lang.Boolean.TYPE   => new WrappedArray.ofBoolean(new Array[Boolean](size)).asInstanceOf[WrappedArray[A]]
-        case java.lang.Void.TYPE      => new WrappedArray.ofUnit(new Array[Unit](size)).asInstanceOf[WrappedArray[A]]
+    if (size == 0) WrappedArrayBuilder.emptyWrappedArray(tag)
+    else {
+      import java.util.Arrays.copyOf
+      val runtimeClass = tag.runtimeClass
+      if (runtimeClass.isPrimitive)
+        runtimeClass match {
+          case java.lang.Integer.TYPE   =>
+            val array = if (elems eq null) new Array[Int](size) else copyOf(elems.array.asInstanceOf[Array[Int]], size)
+            new WrappedArray.ofInt(array).asInstanceOf[WrappedArray[A]]
+          case java.lang.Double.TYPE    =>
+            val array = if (elems eq null) new Array[Double](size) else copyOf(elems.array.asInstanceOf[Array[Double]], size)
+            new WrappedArray.ofDouble(array).asInstanceOf[WrappedArray[A]]
+          case java.lang.Long.TYPE      =>
+            val array = if (elems eq null) new Array[Long](size) else copyOf(elems.array.asInstanceOf[Array[Long]], size)
+            new WrappedArray.ofLong(array).asInstanceOf[WrappedArray[A]]
+          case java.lang.Float.TYPE     =>
+            val array = if (elems eq null) new Array[Float](size) else copyOf(elems.array.asInstanceOf[Array[Float]], size)
+            new WrappedArray.ofFloat(array).asInstanceOf[WrappedArray[A]]
+          case java.lang.Character.TYPE =>
+            val array = if (elems eq null) new Array[Char](size) else copyOf(elems.array.asInstanceOf[Array[Char]], size)
+            new WrappedArray.ofChar(array).asInstanceOf[WrappedArray[A]]
+          case java.lang.Byte.TYPE      =>
+            val array = if (elems eq null) new Array[Byte](size) else copyOf(elems.array.asInstanceOf[Array[Byte]], size)
+            new WrappedArray.ofByte(array).asInstanceOf[WrappedArray[A]]
+          case java.lang.Short.TYPE     =>
+            val array = if (elems eq null) new Array[Short](size) else copyOf(elems.array.asInstanceOf[Array[Short]], size)
+            new WrappedArray.ofShort(array).asInstanceOf[WrappedArray[A]]
+          case java.lang.Boolean.TYPE   =>
+            val array = if (elems eq null) new Array[Boolean](size) else copyOf(elems.array.asInstanceOf[Array[Boolean]], size)
+            new WrappedArray.ofBoolean(array).asInstanceOf[WrappedArray[A]]
+          case java.lang.Void.TYPE      =>
+            val array = if (elems eq null) new Array[Unit](size) else copyOf(elems.array.asInstanceOf[Array[AnyRef]], size).asInstanceOf[Array[Unit]]
+            new WrappedArray.ofUnit(array).asInstanceOf[WrappedArray[A]]
+        }
+      else {
+        val array = if (elems eq null) new Array[A with AnyRef](size) else copyOf(elems.array.asInstanceOf[Array[A with AnyRef]], size)
+        new WrappedArray.ofRef(array).asInstanceOf[WrappedArray[A]]
       }
-    } else {
-      new WrappedArray.ofRef[A with AnyRef](tag.newArray(size).asInstanceOf[Array[A with AnyRef]]).asInstanceOf[WrappedArray[A]]
     }
-    if (this.size > 0) Array.copy(elems.array, 0, newelems.array, 0, this.size)
-    newelems
   }
 
   private def resize(size: Int) {
@@ -90,4 +111,25 @@ class WrappedArrayBuilder[A](tag: ClassTag[A]) extends ReusableBuilder[A, Wrappe
   }
 
   // todo: add ++=
+}
+private [mutable] object WrappedArrayBuilder {
+  private def emptyWrappedArray[T](tag: ClassTag[T]): mutable.WrappedArray[T] =
+    emptyClass.get(tag.runtimeClass).asInstanceOf[WrappedArray[T]]
+  private[this] val emptyClass = new ClassValue[WrappedArray[_]] {
+    override def computeValue(cls: Class[_]): WrappedArray[_] = {
+      if (cls.isPrimitive)
+        cls match {
+          case java.lang.Integer.TYPE   => new WrappedArray.ofInt(Array.emptyIntArray)
+          case java.lang.Double.TYPE    => new WrappedArray.ofDouble(Array.emptyDoubleArray)
+          case java.lang.Long.TYPE      => new WrappedArray.ofLong(Array.emptyLongArray)
+          case java.lang.Float.TYPE     => new WrappedArray.ofFloat(Array.emptyFloatArray)
+          case java.lang.Character.TYPE => new WrappedArray.ofChar(Array.emptyCharArray)
+          case java.lang.Byte.TYPE      => new WrappedArray.ofByte(Array.emptyByteArray)
+          case java.lang.Short.TYPE     => new WrappedArray.ofShort(Array.emptyShortArray)
+          case java.lang.Boolean.TYPE   => new WrappedArray.ofBoolean(Array.emptyBooleanArray)
+          case java.lang.Void.TYPE      => new WrappedArray.ofUnit(Array.emptyUnitArray)
+        }
+      else new WrappedArray.ofRef(Array.empty.asInstanceOf[Array[_ <: AnyRef]])
+    }
+  }
 }

--- a/src/library/scala/collection/parallel/mutable/package.scala
+++ b/src/library/scala/collection/parallel/mutable/package.scala
@@ -65,11 +65,8 @@ package mutable {
     def internalArray = array
     def setInternalSize(s: Int) = size0 = s
     override def sizeHint(len: Int) = {
-      if (len > size && len >= 1) {
-        val newarray = new Array[AnyRef](len)
-        Array.copy(array, 0, newarray, 0, size0)
-        array = newarray
-      }
+      if (len > size && len >= 1)
+        java.util.Arrays.copyOf(array, len)
     }
   }
 

--- a/src/reflect/scala/reflect/internal/pickling/PickleBuffer.scala
+++ b/src/reflect/scala/reflect/internal/pickling/PickleBuffer.scala
@@ -28,10 +28,8 @@ class PickleBuffer(data: Array[Byte], from: Int, to: Int) {
   var writeIndex = to
 
   /** Double bytes array */
-  private def dble() {
-    val bytes1 = new Array[Byte](bytes.length * 2)
-    Array.copy(bytes, 0, bytes1, 0, writeIndex)
-    bytes = bytes1
+  private def dble(): Unit = {
+    bytes = java.util.Arrays.copyOf(bytes, bytes.length * 2)
   }
 
   def ensureCapacity(capacity: Int) =

--- a/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineDelimiter.scala
+++ b/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineDelimiter.scala
@@ -19,7 +19,7 @@ import _root_.jline.console.completer.ArgumentCompleter.{ ArgumentDelimiter, Arg
 // implements a jline interface
 class JLineDelimiter extends ArgumentDelimiter {
   def toJLine(args: List[String], cursor: Int): ArgumentList = args match {
-    case Nil => new ArgumentList(new Array[String](0), 0, 0, cursor)
+    case Nil => new ArgumentList(Array.empty[String], 0, 0, cursor)
     case xs => new ArgumentList(xs.toArray, xs.size - 1, xs.last.length, cursor)
   }
 


### PR DESCRIPTION
take advantage of JVM optimisation when copying arrays to avoid zeroing

reuse empty arrays where it is simple to do so

