### PR TITLE
Adds exponentiation operator \.

### DIFF
--- a/spec/12-the-scala-standard-library.md
+++ b/spec/12-the-scala-standard-library.md
@@ -164,8 +164,8 @@ Any numeric value type $T$ supports the following methods.
     their operation type and performing the given comparison operation of
     that type.
   * Arithmetic methods addition (`+`), subtraction (`-`),
-    multiplication (`*`), division (`/`), and remainder
-    (`%`), which each exist in 7 overloaded alternatives. Each
+    multiplication (`*`), division (`/`), remainder (`%`), and exponentiation (`\ `),
+    which each exist in 7 overloaded alternatives. Each
     alternative takes a parameter of some numeric value type $U$.  Its
     result type is the operation type of $T$ and $U$. The operation is
     evaluated by converting the receiver and its argument to their
@@ -256,7 +256,7 @@ abstract sealed class Int extends AnyVal {
   def + (that: Short): Int        // int addition
   def + (that: Byte): Int         // int addition
   def + (that: Char): Int         // int addition
-  /* analogous for -, *, /, % */
+  /* analogous for -, *, /, %, \ */
 
   def & (that: Long): Long        // long bitwise and
   def & (that: Int): Int          // int bitwise and

--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -529,6 +529,10 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    */
   def pow (n: Int): BigDecimal = new BigDecimal(this.bigDecimal.pow(n, mc), mc)
 
+  /** Returns a BigDecimal whose value is this to the i.
+   */
+  def \ (i: Int): BigDecimal = pow(i)
+
   /** Returns a BigDecimal whose value is the negation of this BigDecimal
    */
   def unary_- : BigDecimal = new BigDecimal(this.bigDecimal.negate(mc), mc)

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -209,6 +209,10 @@ final class BigInt(val bigInteger: BigInteger)
     (new BigInt(dr(0)), new BigInt(dr(1)))
   }
 
+  /** Returns a BigInt whose value is this to the i.
+   */
+  def \ (i: Int): BigInt = new BigInt(this.bigInteger.pow(i))
+
   /** Leftshift of BigInt
    */
   def << (n: Int): BigInt = new BigInt(this.bigInteger.shiftLeft(n))

--- a/src/library/scala/math/package.scala
+++ b/src/library/scala/math/package.scala
@@ -341,7 +341,7 @@ package object math {
   /** Returns the natural logarithm of a `Double` value.
     *
     *  @param  x the number to take the natural logarithm of
-    *  @return the value `logₑ(x)` where `e` is Eulers number
+    *  @return the value `logₑ(x)` where `e` is Euler's number
     *  @group explog
     */
   def log(x: Double): Double = java.lang.Math.log(x)

--- a/src/library/scala/runtime/RichByte.scala
+++ b/src/library/scala/runtime/RichByte.scala
@@ -30,4 +30,25 @@ final class RichByte(val self: Byte) extends AnyVal with ScalaWholeNumberProxy[B
   override def abs: Byte             = math.abs(self).toByte
   override def max(that: Byte): Byte = math.max(self, that).toByte
   override def min(that: Byte): Byte = math.min(self, that).toByte
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Byte): Int = Math.pow(self, x).toInt
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Char): Int = Math.pow(self, x).toInt
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Short): Int = Math.pow(self, x).toInt
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Int): Int = Math.pow(self, x).toInt
+
+  /** Returns a Long whose value is this number raised to the power of x. */
+  def \ (x: Long): Long = Math.pow(self, x).toLong
+
+  /** Returns a Float whose value is this number raised to the power of x. */
+  def \ (x: Float): Float = Math.pow(self, x).toFloat
+
+  /** Returns a Double whose value is this number raised to the power of x. */
+  def \ (x: Double): Double = Math.pow(self, x)
 }

--- a/src/library/scala/runtime/RichChar.scala
+++ b/src/library/scala/runtime/RichChar.scala
@@ -67,4 +67,25 @@ final class RichChar(val self: Char) extends AnyVal with IntegralProxy[Char] {
   // public static boolean isDefined(char ch)
   // public static boolean isJavaIdentifierStart(char ch)
   // public static boolean isJavaIdentifierPart(char ch)
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Byte): Int = Math.pow(self, x).toInt
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Char): Int = Math.pow(self, x).toInt
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Short): Int = Math.pow(self, x).toInt
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Int): Int = Math.pow(self, x).toInt
+
+  /** Returns a Long whose value is this number raised to the power of x. */
+  def \ (x: Long): Long = Math.pow(self, x).toLong
+
+  /** Returns a Float whose value is this number raised to the power of x. */
+  def \ (x: Float): Float = Math.pow(self, x).toFloat
+
+  /** Returns a Double whose value is this number raised to the power of x. */
+  def \ (x: Double): Double = Math.pow(self, x)
 }

--- a/src/library/scala/runtime/RichDouble.scala
+++ b/src/library/scala/runtime/RichDouble.scala
@@ -63,4 +63,25 @@ final class RichDouble(val self: Double) extends AnyVal with FractionalProxy[Dou
    *  @return the measurement of the angle x in degrees.
    */
   def toDegrees: Double = math.toDegrees(self)
+
+  /** Returns a Double whose value is this number raised to the power of x. */
+  def \ (x: Byte): Double = Math.pow(self, x)
+
+  /** Returns a Double whose value is this number raised to the power of x. */
+  def \ (x: Char): Double = Math.pow(self, x)
+
+  /** Returns a Double whose value is this number raised to the power of x. */
+  def \ (x: Short): Double = Math.pow(self, x)
+
+  /** Returns a Double whose value is this number raised to the power of x. */
+  def \ (x: Int): Double = Math.pow(self, x)
+
+  /** Returns a Double whose value is this number raised to the power of x. */
+  def \ (x: Long): Double = Math.pow(self, x)
+
+  /** Returns a Double whose value is this number raised to the power of x. */
+  def \ (x: Float): Double = Math.pow(self, x)
+
+  /** Returns a Double whose value is this number raised to the power of x. */
+  def \ (x: Double): Double = Math.pow(self, x)
 }

--- a/src/library/scala/runtime/RichFloat.scala
+++ b/src/library/scala/runtime/RichFloat.scala
@@ -64,4 +64,25 @@ final class RichFloat(val self: Float) extends AnyVal with FractionalProxy[Float
    *  @return the measurement of the angle `x` in degrees.
    */
   def toDegrees: Float = math.toDegrees(self.toDouble).toFloat
+
+  /** Returns a Float whose value is this number raised to the power of x. */
+  def \ (x: Byte): Float = Math.pow(self, x).toFloat
+
+  /** Returns a Float whose value is this number raised to the power of x. */
+  def \ (x: Char): Float = Math.pow(self, x).toFloat
+
+  /** Returns a Float whose value is this number raised to the power of x. */
+  def \ (x: Short): Float = Math.pow(self, x).toFloat
+
+  /** Returns a Float whose value is this number raised to the power of x. */
+  def \ (x: Int): Float = Math.pow(self, x).toFloat
+
+  /** Returns a Float whose value is this number raised to the power of x. */
+  def \ (x: Long): Float = Math.pow(self, x).toFloat
+
+  /** Returns a Float whose value is this number raised to the power of x. */
+  def \ (x: Float): Float = Math.pow(self, x).toFloat
+
+  /** Returns a Double whose value is this number raised to the power of x. */
+  def \ (x: Double): Double = Math.pow(self, x)
 }

--- a/src/library/scala/runtime/RichInt.scala
+++ b/src/library/scala/runtime/RichInt.scala
@@ -80,4 +80,25 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
     *         and including `end`.
     */
   def to(end: Int, step: Int): Range.Inclusive = Range.inclusive(self, end, step)
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Byte): Int = Math.pow(self, x).toInt
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Char): Int = Math.pow(self, x).toInt
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Short): Int = Math.pow(self, x).toInt
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Int): Int = Math.pow(self, x).toInt
+
+  /** Returns a Long whose value is this number raised to the power of x. */
+  def \ (x: Long): Long = Math.pow(self, x).toLong
+
+  /** Returns a Float whose value is this number raised to the power of x. */
+  def \ (x: Float): Float = Math.pow(self, x).toFloat
+
+  /** Returns a Double whose value is this number raised to the power of x. */
+  def \ (x: Double): Double = Math.pow(self, x)
 }

--- a/src/library/scala/runtime/RichLong.scala
+++ b/src/library/scala/runtime/RichLong.scala
@@ -43,4 +43,25 @@ final class RichLong(val self: Long) extends AnyVal with IntegralProxy[Long] {
   def toBinaryString: String = java.lang.Long.toBinaryString(self)
   def toHexString: String    = java.lang.Long.toHexString(self)
   def toOctalString: String  = java.lang.Long.toOctalString(self)
+
+  /** Returns a Long whose value is this number raised to the power of x. */
+  def \ (x: Byte): Long = Math.pow(self, x).toLong
+
+  /** Returns a Long whose value is this number raised to the power of x. */
+  def \ (x: Char): Long = Math.pow(self, x).toLong
+
+  /** Returns a Long whose value is this number raised to the power of x. */
+  def \ (x: Short): Long = Math.pow(self, x).toLong
+
+  /** Returns a Long whose value is this number raised to the power of x. */
+  def \ (x: Int): Long = Math.pow(self, x).toLong
+
+  /** Returns a Long whose value is this number raised to the power of x. */
+  def \ (x: Long): Long = Math.pow(self, x).toLong
+
+  /** Returns a Float whose value is this number raised to the power of x. */
+  def \ (x: Float): Float = Math.pow(self, x).toFloat
+
+  /** Returns a Double whose value is this number raised to the power of x. */
+  def \ (x: Double): Double = Math.pow(self, x)
 }

--- a/src/library/scala/runtime/RichShort.scala
+++ b/src/library/scala/runtime/RichShort.scala
@@ -30,4 +30,25 @@ final class RichShort(val self: Short) extends AnyVal with ScalaWholeNumberProxy
   override def abs: Short              = math.abs(self.toInt).toShort
   override def max(that: Short): Short = math.max(self.toInt, that.toInt).toShort
   override def min(that: Short): Short = math.min(self.toInt, that.toInt).toShort
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Byte): Int = Math.pow(self, x).toInt
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Char): Int = Math.pow(self, x).toInt
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Short): Int = Math.pow(self, x).toInt
+
+  /** Returns an Int whose value is this number raised to the power of x. */
+  def \ (x: Int): Int = Math.pow(self, x).toInt
+
+  /** Returns a Long whose value is this number raised to the power of x. */
+  def \ (x: Long): Long = Math.pow(self, x).toLong
+
+  /** Returns a Float whose value is this number raised to the power of x. */
+  def \ (x: Float): Float = Math.pow(self, x).toFloat
+
+  /** Returns a Double whose value is this number raised to the power of x. */
+  def \ (x: Double): Double = Math.pow(self, x)
 }

--- a/test/files/presentation/infix-completion.check
+++ b/test/files/presentation/infix-completion.check
@@ -3,7 +3,7 @@ reload: Snippet.scala
 askTypeCompletion at Snippet.scala(1,34)
 ================================================================================
 [response] askTypeCompletion at (1,34)
-retrieved 203 members
+retrieved 210 members
 [inaccessible] protected def num: Fractional[Double]
 [inaccessible] protected def ord: Ordering[Double]
 [inaccessible] protected def unifiedPrimitiveEquals(x: Any): Boolean
@@ -100,6 +100,13 @@ def >>(x: Int): Int
 def >>(x: Long): Int
 def >>>(x: Int): Int
 def >>>(x: Long): Int
+def \(x: Byte): Double
+def \(x: Char): Double
+def \(x: Double): Double
+def \(x: Float): Double
+def \(x: Int): Double
+def \(x: Long): Double
+def \(x: Short): Double
 def ^(x: Byte): Int
 def ^(x: Char): Int
 def ^(x: Int): Int

--- a/test/files/presentation/infix-completion2.check
+++ b/test/files/presentation/infix-completion2.check
@@ -3,7 +3,7 @@ reload: Snippet.scala
 askTypeCompletion at Snippet.scala(1,34)
 ================================================================================
 [response] askTypeCompletion at (1,34)
-retrieved 203 members
+retrieved 210 members
 [inaccessible] protected def num: Fractional[Double]
 [inaccessible] protected def ord: Ordering[Double]
 [inaccessible] protected def unifiedPrimitiveEquals(x: Any): Boolean
@@ -100,6 +100,13 @@ def >>(x: Int): Int
 def >>(x: Long): Int
 def >>>(x: Int): Int
 def >>>(x: Long): Int
+def \(x: Byte): Double
+def \(x: Char): Double
+def \(x: Double): Double
+def \(x: Float): Double
+def \(x: Int): Double
+def \(x: Long): Double
+def \(x: Short): Double
 def ^(x: Byte): Int
 def ^(x: Char): Int
 def ^(x: Int): Int

--- a/test/junit/scala/math/BigDecimalTest.scala
+++ b/test/junit/scala/math/BigDecimalTest.scala
@@ -307,4 +307,7 @@ class BigDecimalTest {
 
     assert(bds.product == prod)
   }
+
+  @Test def exponentiationOperator(): Unit = assert( BigDecimal(2)\3 == BigDecimal(8) )
+
 }

--- a/test/junit/scala/math/BigIntTest.scala
+++ b/test/junit/scala/math/BigIntTest.scala
@@ -7,4 +7,7 @@ class BigIntTest {
   @Test
   def testIsComparable(): Unit =
     assert(BigInt(1).isInstanceOf[java.lang.Comparable[_]])
+
+  @Test def exponentiationOperator(): Unit = assert( BigInt(2)\3 == BigInt(8) )
+
 }

--- a/test/junit/scala/runtime/RichByteTest.scala
+++ b/test/junit/scala/runtime/RichByteTest.scala
@@ -1,0 +1,35 @@
+package scala.runtime
+
+import org.junit.Test
+
+class RichByteTest {
+
+  @Test def exponentiationOperator(): Unit = {
+    val char: Char = 3
+    val byte: Byte = 2
+    val short: Short = 3
+
+    assert( byte\byte == 4 )
+    assert( (byte\byte).isInstanceOf[Int] )
+
+    assert( byte\char == 8 )
+    assert( (byte\char).isInstanceOf[Int] )
+
+    assert( byte\short == 8 )
+    assert( (byte\short).isInstanceOf[Int] )
+
+    assert( byte\0 == 1 )
+    assert( (byte\0).isInstanceOf[Int] )
+
+    assert( byte\1L == 2 )
+    assert( (byte\1L).isInstanceOf[Long] )
+
+    assert( byte\4f == 16 )
+    assert( (byte\4f).isInstanceOf[Float] )
+
+    assert( byte\5d == 32 )
+    assert( (byte\5d).isInstanceOf[Double] )
+
+  }
+
+}

--- a/test/junit/scala/runtime/RichCharTest.scala
+++ b/test/junit/scala/runtime/RichCharTest.scala
@@ -1,0 +1,35 @@
+package scala.runtime
+
+import org.junit.Test
+
+class RichCharTest {
+
+  @Test def exponentiationOperator(): Unit = {
+    val char: Char = 2
+    val byte: Byte = 2
+    val short: Short = 3
+
+    assert( char\byte == 4 )
+    assert( (char\byte).isInstanceOf[Int] )
+
+    assert( char\char == 4 )
+    assert( (char\char).isInstanceOf[Int] )
+
+    assert( char\short == 8 )
+    assert( (char\short).isInstanceOf[Int] )
+
+    assert( char\0 == 1 )
+    assert( (char\0).isInstanceOf[Int] )
+
+    assert( char\1L == 2 )
+    assert( (char\1L).isInstanceOf[Long] )
+
+    assert( char\4f == 16 )
+    assert( (char\4f).isInstanceOf[Float] )
+
+    assert( char\5d == 32 )
+    assert( (char\5d).isInstanceOf[Double] )
+
+  }
+
+}

--- a/test/junit/scala/runtime/RichDoubleTest.scala
+++ b/test/junit/scala/runtime/RichDoubleTest.scala
@@ -1,0 +1,35 @@
+package scala.runtime
+
+import org.junit.Test
+
+class RichDoubleTest {
+
+  @Test def exponentiationOperator(): Unit = {
+    val byte: Byte = 2
+    val char: Char = 2
+    val short: Short = 3
+
+    assert( 2d\byte == 4 )
+    assert( (2d\byte).isInstanceOf[Double] )
+
+    assert( 2d\char == 4 )
+    assert( (2d\char).isInstanceOf[Double] )
+
+    assert( 2d\short == 8 )
+    assert( (2d\short).isInstanceOf[Double] )
+
+    assert( 2d\0 == 1 )
+    assert( (2d\0).isInstanceOf[Double] )
+
+    assert( 2d\1L == 2 )
+    assert( (2d\1L).isInstanceOf[Double] )
+
+    assert( 2d\4f == 16 )
+    assert( (2d\4f).isInstanceOf[Double] )
+
+    assert( 2d\5d == 32 )
+    assert( (2d\5d).isInstanceOf[Double] )
+
+  }
+
+}

--- a/test/junit/scala/runtime/RichFloatTest.scala
+++ b/test/junit/scala/runtime/RichFloatTest.scala
@@ -1,0 +1,35 @@
+package scala.runtime
+
+import org.junit.Test
+
+class RichFloatTest {
+
+  @Test def exponentiationOperator(): Unit = {
+    val byte: Byte = 2
+    val char: Char = 3
+    val short: Short = 3
+
+    assert( 2f\byte == 4 )
+    assert( (2f\byte).isInstanceOf[Float] )
+
+    assert( 2f\char == 8 )
+    assert( (2f\char).isInstanceOf[Float] )
+
+    assert( 2f\short == 8 )
+    assert( (2f\short).isInstanceOf[Float] )
+
+    assert( 2f\0 == 1 )
+    assert( (2f\0).isInstanceOf[Float] )
+
+    assert( 2f\1L == 2 )
+    assert( (2f\1L).isInstanceOf[Float] )
+
+    assert( 2f\4f == 16 )
+    assert( (2f\4f).isInstanceOf[Float] )
+
+    assert( 2f\5d == 32 )
+    assert( (2f\5d).isInstanceOf[Double] )
+
+  }
+
+}

--- a/test/junit/scala/runtime/RichIntTest.scala
+++ b/test/junit/scala/runtime/RichIntTest.scala
@@ -1,0 +1,35 @@
+package scala.runtime
+
+import org.junit.Test
+
+class RichIntTest {
+
+  @Test def exponentiationOperator(): Unit = {
+    val byte: Byte = 2
+    val char: Char = 3
+    val short: Short = 3
+
+    assert( 2\byte == 4 )
+    assert( (2\byte).isInstanceOf[Int] )
+
+    assert( 2\char == 8 )
+    assert( (2\char).isInstanceOf[Int] )
+
+    assert( 2\short == 8 )
+    assert( (2\short).isInstanceOf[Int] )
+
+    assert( 2\0 == 1 )
+    assert( (2\0).isInstanceOf[Int] )
+
+    assert( 2\1L == 2 )
+    assert( (2\1L).isInstanceOf[Long] )
+
+    assert( 2\4f == 16 )
+    assert( (2\4f).isInstanceOf[Float] )
+
+    assert( 2\5d == 32 )
+    assert( (2\5d).isInstanceOf[Double] )
+
+  }
+
+}

--- a/test/junit/scala/runtime/RichLongTest.scala
+++ b/test/junit/scala/runtime/RichLongTest.scala
@@ -1,0 +1,35 @@
+package scala.runtime
+
+import org.junit.Test
+
+class RichLongTest {
+
+  @Test def exponentiationOperator(): Unit = {
+    val byte: Byte = 2
+    val char: Char = 3
+    val short: Short = 3
+
+    assert( 2L\byte == 4 )
+    assert( (2L\byte).isInstanceOf[Long] )
+
+    assert( 2L\char == 8 )
+    assert( (2L\char).isInstanceOf[Long] )
+
+    assert( 2L\short == 8 )
+    assert( (2L\short).isInstanceOf[Long] )
+
+    assert( 2L\0 == 1 )
+    assert( (2L\0).isInstanceOf[Long] )
+
+    assert( 2L\1L == 2 )
+    assert( (2L\1L).isInstanceOf[Long] )
+
+    assert( 2L\4f == 16 )
+    assert( (2L\4f).isInstanceOf[Float] )
+
+    assert( 2L\5d == 32 )
+    assert( (2L\5d).isInstanceOf[Double] )
+
+  }
+
+}

--- a/test/junit/scala/runtime/RichShortTest.scala
+++ b/test/junit/scala/runtime/RichShortTest.scala
@@ -1,0 +1,35 @@
+package scala.runtime
+
+import org.junit.Test
+
+class RichShortTest {
+
+  @Test def exponentiationOperator(): Unit = {
+    val byte: Byte = 2
+    val char: Char = 2
+    val short: Short = 2
+
+    assert( short\byte == 4 )
+    assert( (short\byte).isInstanceOf[Int] )
+
+    assert( short\char == 4 )
+    assert( (short\char).isInstanceOf[Int] )
+
+    assert( short\short == 4 )
+    assert( (short\short).isInstanceOf[Int] )
+
+    assert( short\0 == 1 )
+    assert( (short\0).isInstanceOf[Int] )
+
+    assert( short\1L == 2 )
+    assert( (short\1L).isInstanceOf[Long] )
+
+    assert( short\4f == 16 )
+    assert( (short\4f).isInstanceOf[Float] )
+
+    assert( short\5d == 32 )
+    assert( (short\5d).isInstanceOf[Double] )
+
+  }
+
+}


### PR DESCRIPTION
## argument

In maths, exponentiation is expressed by layout rather than by a symbol. We can't do that.

I propose the symbol \ (backslash). It suggests the traditional layout. You can imagine that if the two arguments were squashed a little, the right argument might slide up a little. For example 3\2 = 9. Backslash is not used already. It has the right precedence.

Other languages use ^ or **. Although ^ suggests the traditional notation, in Scala, we can't use it because it's XOR and it has wrong precedence. We can't use ** because it has wrong precedence.

I suggest this in https://contributors.scala-lang.org/t/proposal-new-operator-for-exponentiation/4382.
Sherpal suggests this in https://contributors.scala-lang.org/t/exponent-for-fractional-and-or-numeric-type-classe-s/4204.
Somebody already suggests it in https://www.scala-lang.org/old/node/4142.

## implementation

This PR gives no new implementation of exponentiation, it just maps it to the existing implementations:
- scala.math.BigDecimal.pow(Int): BigDecimal
- java.lang.BigInteger.pow(int): java.lang.BigInteger
- java.lang.Math.pow(double,double): double

Roughly: the result is clamped to the width of the return type.
The maximum value if it's too big, or NaN if it should be complex.
The minimum value if it's too small.
Zero if it's absolutely too small.

The PR makes a separate operator for every primitive type.
The return type is the same primitive type, just as the other operators do.