### PR TITLE
Increase laziness of LazyList.cons.apply

### DIFF
--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -1134,7 +1134,7 @@ object LazyList extends SeqFactory[LazyList] {
       *  @param hd   The first element of the result lazy list
       *  @param tl   The remaining elements of the result lazy list
       */
-    def apply[A](hd: => A, tl: => LazyList[A]): LazyList[A] = newLL(sCons(hd, tl))
+    def apply[A](hd: => A, tl: => LazyList[A]): LazyList[A] = newLL(sCons(hd, newLL(tl.state)))
 
     /** Maps a lazy list to its head and tail */
     def unapply[A](xs: LazyList[A]): Option[(A, LazyList[A])] = #::.unapply(xs)


### PR DESCRIPTION
Change `LazyList.cons.apply` so that the tail computation
is wrapped as a state computation for a new `LazyList`,
thus deferring its execution as long as possible.

Follow-up to #8985

--------

Before (Scala 2.13.3-):

```scala
scala 2.13.3> LazyList.cons(1, { println("hey"); LazyList() })
val res6: scala.collection.immutable.LazyList[Int] = LazyList(<not computed>)

scala 2.13.3> res6.head
hey
val res7: Int = 1
```

After (Scala 2.13.4+):

```scala
scala 2.13.4> LazyList.cons(1, { println("hey"); LazyList() })
val res6: scala.collection.immutable.LazyList[Int] = LazyList(<not computed>)

scala 2.13.4> res6.head
val res7: Int = 1
```