### PR TITLE
Fix a link to the separately shipped scala-reflect library

### DIFF
--- a/src/library/rootdoc.txt
+++ b/src/library/rootdoc.txt
@@ -31,11 +31,11 @@ Other packages exist.  See the complete list on the right.
 
 Additional parts of the standard library are shipped as separate libraries. These include:
 
-  - [[scala.reflect       `scala.reflect`]]   - Scala's reflection API (scala-reflect.jar)
-  - [[https://github.com/scala/scala-xml `scala.xml`]]    - XML parsing, manipulation, and serialization (scala-xml.jar)
+  - [[https://www.scala-lang.org/api/current/scala-reflect/scala/reflect/index.html `scala.reflect`]] - Scala's reflection API (scala-reflect.jar)
+  - [[https://github.com/scala/scala-xml `scala.xml`]] - XML parsing, manipulation, and serialization (scala-xml.jar)
   - [[https://github.com/scala/scala-parallel-collections `scala.collection.parallel`]] - Parallel collections (scala-parallel-collections.jar)
   - [[https://github.com/scala/scala-parser-combinators `scala.util.parsing`]] - Parser combinators (scala-parser-combinators.jar)
-  - [[https://github.com/scala/scala-swing `scala.swing`]]  - A convenient wrapper around Java's GUI framework called Swing (scala-swing.jar)
+  - [[https://github.com/scala/scala-swing `scala.swing`]] - A convenient wrapper around Java's GUI framework called Swing (scala-swing.jar)
 
 == Automatic imports ==
 


### PR DESCRIPTION
Fixe scala/bug/issues/12068
- Link before fix: the `scala.reflect` package in the standard library
- Link after fix: the API page to the separately shipped scala.reflect.jar
