### PR TITLE
Adds doc string to Array.from

### DIFF
--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -58,6 +58,7 @@ object Array {
   /** Creates an array from a given iterable
    *
    * @param it the source iterable
+   * @return an array containing all the elements from it
    *
    */
   def from[A : ClassTag](it: IterableOnce[A]): Array[A] = it match {

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -55,6 +55,11 @@ object Array {
    */
   def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](t)
 
+  /** Creates an array from a given iterable
+   *
+   * @param it the source iterable
+   *
+   */
   def from[A : ClassTag](it: IterableOnce[A]): Array[A] = it match {
     case it: Iterable[A] => it.toArray[A]
     case _ => it.iterator.toArray[A]


### PR DESCRIPTION
This change adds in the missing doc string for the `Array.from` function. (https://github.com/scala/bug/issues/12064)