### PR TITLE
[bug#10131] Stop leaking head in LinearSeqOps#tails

### DIFF
--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -238,8 +238,10 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeq
     if (found) Some(last) else None
   }
 
-  override def tails: Iterator[C] =
-    Iterator.iterate(coll)(_.tail).takeWhile(_.nonEmpty) ++ Iterator.single(newSpecificBuilder.result())
+  override def tails: Iterator[C] = {
+    val end = Iterator.single(empty)
+    Iterator.iterate(coll)(_.tail).takeWhile(_.nonEmpty) ++ end
+  }
 }
 
 trait StrictOptimizedLinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with StrictOptimizedLinearSeqOps[A, CC, C]] extends Any with LinearSeqOps[A, CC, C] with StrictOptimizedSeqOps[A, CC, C] {

--- a/test/junit/scala/collection/immutable/LazyListGCTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListGCTest.scala
@@ -110,4 +110,10 @@ class LazyListGCTest {
   def tapEach_takeRight_headOption_allowsGC(): Unit = {
     assertLazyListOpAllowsGC(_.tapEach(_).takeRight(2).headOption, _ => ())
   }
+
+  // scala/bug#10131
+  @Test
+  def tails_zipWithIndex_foreach_allowsGC(): Unit = {
+    assertLazyListOpAllowsGC((ll, check) => ll.tails.zipWithIndex.foreach { case (_, i) => check(i) }, _ => ())
+  }
 }

--- a/test/junit/scala/collection/immutable/StreamTest.scala
+++ b/test/junit/scala/collection/immutable/StreamTest.scala
@@ -59,17 +59,17 @@ class StreamTest {
   }
 
   @Test // scala/bug#8990
-  def withFilter_after_first_foreach_allows_GC: Unit = {
+  def withFilter_after_first_foreach_allows_GC(): Unit = {
     assertStreamOpAllowsGC(_.withFilter(_ > 1).foreach(_), _ => ())
   }
 
   @Test // scala/bug#8990
-  def withFilter_after_first_withFilter_foreach_allows_GC: Unit = {
+  def withFilter_after_first_withFilter_foreach_allows_GC(): Unit = {
     assertStreamOpAllowsGC(_.withFilter(_ > 1).withFilter(_ < 100).foreach(_), _ => ())
   }
 
   @Test // scala/bug#8990
-  def withFilter_can_retry_after_exception_thrown_in_filter: Unit = {
+  def withFilter_can_retry_after_exception_thrown_in_filter(): Unit = {
     // use mutable state to control an intermittent failure in filtering the Stream
     var shouldThrow = true
 
@@ -82,6 +82,12 @@ class StreamTest {
     shouldThrow = false                              // won't throw next time
 
     assertTrue( wf.map(identity).length == 5 )       // success instead of NPE
+  }
+
+  // scala/bug#10131
+  @Test
+  def tails_zipWithIndex_foreach_allowsGC(): Unit = {
+    assertStreamOpAllowsGC((stream, check) => stream.tails.zipWithIndex.foreach { case (_, i) => check(i) }, _ => ())
   }
 
   /** Test helper to verify that the given Stream operation is properly lazy in the tail */


### PR DESCRIPTION
Fixes scala/bug#10131