### PR TITLE
ArrayDeque.alloc doc: do not use macro syntax

### DIFF
--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -554,7 +554,7 @@ object ArrayDeque extends StrictOptimizedSeqFactory[ArrayDeque] {
   private[ArrayDeque] final val StableSize = 128
 
   /**
-    * Allocates an array whose size is next power of 2 > $len
+    * Allocates an array whose size is next power of 2 > `len`
     * Largest possible len is 1<<30 - 1
     *
     * @param len


### PR DESCRIPTION
`$len` is a macro injection while `len` is not a macro defined somewhere