### PR TITLE
Faster sliding for IndexedSeq

### DIFF
--- a/test/benchmarks/src/main/scala/scala/collection/immutable/ArraySeqBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/ArraySeqBenchmark.scala
@@ -17,7 +17,7 @@ import scala.reflect.ClassTag
 @State(Scope.Benchmark)
 class ArraySeqBenchmark {
 
-  @Param(Array("0", "1", "10", "1000", "10000"))
+  @Param(Array("0", "1", "10", "100", "1000", "10000"))
   var size: Int = _
   var integersS: ArraySeq[Int] = _
   var stringsS: ArraySeq[String] = _
@@ -67,5 +67,10 @@ class ArraySeqBenchmark {
       }
     }
     b.result()
+  }
+
+  @Benchmark def sliding(bh: Blackhole): Any = {
+    var coll = stringsS
+    coll.sliding(2).foreach(bh.consume)
   }
 }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorBenchmark2.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorBenchmark2.scala
@@ -587,4 +587,9 @@ class VectorBenchmark2 {
     var coll = nv
     bh.consume(coll.filter(x => false))
   }
+
+  @Benchmark def nvSliding(bh: Blackhole): Any = {
+    var coll = nv
+    coll.sliding(2).foreach(bh.consume)
+  }
 }


### PR DESCRIPTION
The default implementation of `Iterable.sliding` via `Iterator.sliding`
is rather inefficient and can benefit greatly from `IndexedSeq`-specific
optimizations. The new `IndexedSeqSlidingIterator` provides a
`slice`-based implementation of the basic functionality without any of
the additional features of `GroupedIterator` (which is only exposed as a
return type in `Iterator` but not in `Iterable`).

`ArraySeq` before and after:

```
[info] Benchmark                  (size)  Mode  Cnt       Score       Error  Units
[info] ArraySeqBenchmark.sliding       0  avgt   20      21.577 ±     0.095  ns/op
[info] ArraySeqBenchmark.sliding       1  avgt   20     113.886 ±     0.413  ns/op
[info] ArraySeqBenchmark.sliding      10  avgt   20     746.002 ±     8.406  ns/op
[info] ArraySeqBenchmark.sliding     100  avgt   20    8406.715 ±    16.674  ns/op
[info] ArraySeqBenchmark.sliding    1000  avgt   20   82459.407 ±   727.042  ns/op
[info] ArraySeqBenchmark.sliding   10000  avgt   20  904497.382 ± 22167.582  ns/op

[info] Benchmark                  (size)  Mode  Cnt       Score      Error  Units
[info] ArraySeqBenchmark.sliding       0  avgt   20       2.129 ±    0.004  ns/op
[info] ArraySeqBenchmark.sliding       1  avgt   20       4.182 ±    0.007  ns/op
[info] ArraySeqBenchmark.sliding      10  avgt   20     104.823 ±    0.269  ns/op
[info] ArraySeqBenchmark.sliding     100  avgt   20    1151.197 ±    4.519  ns/op
[info] ArraySeqBenchmark.sliding    1000  avgt   20   11558.780 ±   46.500  ns/op
[info] ArraySeqBenchmark.sliding   10000  avgt   20  111791.981 ± 5818.898  ns/op
```

`Vector` before and after:

```
[info] Benchmark                   (size)  Mode  Cnt        Score       Error  Units
[info] VectorBenchmark2.nvSliding       1  avgt   20      149.515 ±     3.024  ns/op
[info] VectorBenchmark2.nvSliding      10  avgt   20     1161.639 ±     4.830  ns/op
[info] VectorBenchmark2.nvSliding     100  avgt   20     9404.339 ±    20.832  ns/op
[info] VectorBenchmark2.nvSliding    1000  avgt   20    95593.970 ±   941.371  ns/op
[info] VectorBenchmark2.nvSliding   10000  avgt   20   983106.693 ±  5448.359  ns/op
[info] VectorBenchmark2.nvSliding   50000  avgt   20  6577156.953 ± 33311.750  ns/op

[info] Benchmark                   (size)  Mode  Cnt        Score       Error  Units
[info] VectorBenchmark2.nvSliding       1  avgt   20        4.272 ±     0.007  ns/op
[info] VectorBenchmark2.nvSliding      10  avgt   20      106.079 ±     0.389  ns/op
[info] VectorBenchmark2.nvSliding     100  avgt   20     2485.535 ±     5.458  ns/op
[info] VectorBenchmark2.nvSliding    1000  avgt   20    26025.697 ±    92.586  ns/op
[info] VectorBenchmark2.nvSliding   10000  avgt   20   298733.143 ±  1098.659  ns/op
[info] VectorBenchmark2.nvSliding   50000  avgt   20  1638234.848 ± 17268.758  ns/op
```