### PR TITLE
Relational Operators

### DIFF
--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -418,10 +418,11 @@ trait StdNames {
       )
     }
 
-    def isOpAssignmentName(name: Name) = name match {
+    def isOpAssignmentName(name: Name): Boolean = name match {
       case raw.NE | raw.LE | raw.GE | EMPTY => false
-      case _                                =>
-      name.endChar == '=' && name.startChar != '=' && isOperatorPart(name.startChar)
+      case _ =>
+        name.endChar == '=' && name.startChar != '=' && isOperatorPart(name.startChar) &&
+          !(name.startsWith(raw.NE) || name.startsWith(raw.GE) || name.startsWith(raw.LE))
     }
 
     /** Is name a left-associative operator? */


### PR DESCRIPTION
This is a draft PR for an upcoming SIP to allow `!*=`, `<*=`, `>*=` to be treated as relational operators from order of precedence standpoint (e.g. not treated as assignment operators).

See: https://contributors.scala-lang.org/t/pre-sip-assignment-operator-precedence-exceptions/2925

I would like to see results of a community build built against it to gather additional data.