### PR TITLE
Faster sliding for IndexedSeq

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -191,6 +191,7 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.nowarn$"),
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.nowarn"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.Settings#*.clearSetByUser"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.IndexedSeqSlidingIterator"),
 
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.RedBlackTree.*"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.RedBlackTree$EqualsIterator"),

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/ArraySeqBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/ArraySeqBenchmark.scala
@@ -17,7 +17,7 @@ import scala.reflect.ClassTag
 @State(Scope.Benchmark)
 class ArraySeqBenchmark {
 
-  @Param(Array("0", "1", "10", "1000", "10000"))
+  @Param(Array("0", "1", "10", "100", "1000", "10000"))
   var size: Int = _
   var integersS: ArraySeq[Int] = _
   var stringsS: ArraySeq[String] = _
@@ -67,5 +67,10 @@ class ArraySeqBenchmark {
       }
     }
     b.result()
+  }
+
+  @Benchmark def sliding(bh: Blackhole): Any = {
+    var coll = stringsS
+    coll.sliding(2).foreach(bh.consume)
   }
 }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorBenchmark2.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorBenchmark2.scala
@@ -587,4 +587,9 @@ class VectorBenchmark2 {
     var coll = nv
     bh.consume(coll.filter(x => false))
   }
+
+  @Benchmark def nvSliding(bh: Blackhole): Any = {
+    var coll = nv
+    coll.sliding(2).foreach(bh.consume)
+  }
 }


### PR DESCRIPTION
The default implementation of `Iterable.sliding` via `Iterator.sliding`
is rather inefficient and can benefit greatly from `IndexedSeq`-specific
optimizations. The new `IndexedSeqSlidingIterator` provides a
`slice`-based implementation of the basic functionality without any of
the additional features of `GroupedIterator` (which is only exposed as a
return type in `Iterator` but not in `Iterable`).

Supersedes https://github.com/scala/scala/pull/9103