### PR TITLE
Avoid race in test for firstCompletedOf 

### DIFF
--- a/test/junit/scala/concurrent/FutureTest.scala
+++ b/test/junit/scala/concurrent/FutureTest.scala
@@ -1,6 +1,7 @@
 
 package scala.concurrent
 
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 import scala.tools.testkit.AssertUtil._
@@ -9,13 +10,27 @@ import scala.util.Try
 class FutureTest {
   @Test
   def `bug/issues#10513 firstCompletedOf must not leak references`(): Unit = {
-    import ExecutionContext.Implicits._
     val unfulfilled = Promise[AnyRef]()
-    val quick = Promise[AnyRef]()
-    val result = new AnyRef
-    Future.firstCompletedOf(List(quick.future, unfulfilled.future)): Unit
+    val quick       = Promise[AnyRef]()
+    val result      = new AnyRef
+    // all callbacks will be registered
+    val first = Future.firstCompletedOf(List(quick.future, unfulfilled.future))(ExecutionContext.parasitic)
+    // callbacks run parasitically to avoid race or waiting for first future;
+    // normally we have no guarantee that firstCompletedOf completed, so we assert that this assumption held
     assertNotReachable(result, unfulfilled) {
       quick.complete(Try(result))
+      assertTrue("First must complete", first.isCompleted)
     }
+    /* The test has this structure under the hood:
+    val p = Promise[String]
+    val q = Promise[String]
+    val res = Promise[String]
+    val s = "hi"
+    p.future.onComplete(t => res.complete(t))
+    q.future.onComplete(t => res.complete(t))   // previously, uncompleted promise held reference to promise completed with value
+    assertNotReachable(s, q) {
+      p.complete(Try(s))
+    }
+    */
   }
 }


### PR DESCRIPTION
Observed in travis build:
```
[error] Test scala.concurrent.FutureTest.bug$divissues$hash10513$u0020firstCompletedOf$u0020must$u0020not$u0020leak$u0020references failed: java.lang.AssertionError: Root Future(<not completed>) held reference java.lang.Object@3d785ff2, took 0.011 sec
[error]     at scala.tools.testkit.AssertUtil$.loop$2(AssertUtil.scala:138)
[error]     at scala.tools.testkit.AssertUtil$.$anonfun$assertNotReachable$5(AssertUtil.scala:148)
[error]     at scala.tools.testkit.AssertUtil$.$anonfun$assertNotReachable$5$adapted(AssertUtil.scala:144)
[error]     at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:553)
[error]     at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:551)
[error]     at scala.collection.AbstractIterable.foreach(Iterable.scala:920)
[error]     at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:890)
```

Also restore comment in the test that kind of explains what it's supposed to be testing.
