### PR TITLE
Fixed scaladoc error on processing of incorrect comment placeholder

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/DocComments.scala
+++ b/src/compiler/scala/tools/nsc/ast/DocComments.scala
@@ -58,8 +58,10 @@ trait DocComments { self: Global =>
    *  since r23926.
    */
   private def allInheritedOverriddenSymbols(sym: Symbol): List[Symbol] = {
-    if (!sym.owner.isClass) Nil
-    else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
+    val getter: Symbol = sym.getter
+    val symOrGetter = getter.orElse(sym)
+    if (!symOrGetter.owner.isClass) Nil
+    else symOrGetter.owner.ancestors map (symOrGetter overriddenSymbol _) filter (_ != NoSymbol)
   }
 
   def fillDocComment(sym: Symbol, comment: DocComment): Unit = {
@@ -143,8 +145,7 @@ trait DocComments { self: Global =>
 
   /** The cooked doc comment of an overridden symbol */
   protected def superComment(sym: Symbol): Option[String] = {
-    val getter: Symbol = sym.getter
-    allInheritedOverriddenSymbols(getter.orElse(sym)).iterator
+    allInheritedOverriddenSymbols(sym).iterator
       .map(cookedDocComment(_))
       .find(_ != "")
   }

--- a/test/scaladoc/resources/stray-dollar-sign-res.scala
+++ b/test/scaladoc/resources/stray-dollar-sign-res.scala
@@ -1,0 +1,14 @@
+package scaladoc.resources
+
+trait T {
+
+  /** $a */
+  def foo: Int
+
+}
+
+object O extends T {
+
+  val foo = 42
+
+}

--- a/test/scaladoc/run/stray-dollar-sign.check
+++ b/test/scaladoc/run/stray-dollar-sign.check
@@ -1,0 +1,4 @@
+newSource:5: warning: Variable a undefined in comment for value foo in object O
+  /** $a */
+       ^
+Done.

--- a/test/scaladoc/run/stray-dollar-sign.scala
+++ b/test/scaladoc/run/stray-dollar-sign.scala
@@ -1,0 +1,17 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+
+  override def resourceFile = "stray-dollar-sign-res.scala"
+
+  def scaladocSettings = ""
+
+  def testModel(rootPackage: Package) = {
+    // get the quick access implicit defs in scope (_package(s), _class(es), _trait(s), object(s) _method(s), _value(s))
+    import access._
+
+    val comment = rootPackage._package("scaladoc")._package("resources")._object("O")._value("foo").comment
+    assert(extractCommentText(comment.get) == "$a")
+  }
+}


### PR DESCRIPTION
Fixes scala/bug#11101
`DocComments#getDocComment` was inconsistent with `DocComments#superComment` in calling `allInheritedOverriddenSymbols`; field getter resolution moved down to `allInheritedOverriddenSymbols`.