### PR TITLE
Don't recurse without bound in outerPath (backport)

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -272,7 +272,11 @@ abstract class ExplicitOuter extends InfoTransform
     protected def outerPath(base: Tree, from: Symbol, to: Symbol): Tree = {
       //Console.println("outerPath from "+from+" to "+to+" at "+base+":"+base.tpe)
       if (from == to) base
-      else outerPath(outerSelect(base), from.outerClass, to)
+      else {
+        val outerSel = outerSelect(base)
+        if (outerSel.isEmpty) EmptyTree
+        else outerPath(outerSel, from.outerClass, to)
+      }
     }
 
     override def transform(tree: Tree): Tree = {

--- a/test/files/pos/t10035.scala
+++ b/test/files/pos/t10035.scala
@@ -1,0 +1,11 @@
+trait Inner {
+  def f(): Outer
+}
+
+class Outer(o: Set[Inner]) {
+  def this() = this(Set(1).map{
+    case k => new Inner{
+      def f(): Outer = Outer.this
+    }
+  })
+}


### PR DESCRIPTION
This is a copy-paste solution from the 2.13.x branch of @milessabin philosophical [PR #7178](https://github.com/scala/scala/pull/7178)
It's an attempt at back-porting the solution to the 2.12.x branch.

Fixes [scala/bug#10035](https://github.com/scala/bug/issues/10035)

Honestly I [have no idea](https://candlesandherbs.files.wordpress.com/2015/02/d6a1143f571184db25f94613edd43b40af6d3a629221aba00d9efdcfef5efd84.jpg) why this should work, but the new test scenario passes on this branch too, so I'm making the attempt to merge it.
I would expect someone better positioned to evaluate potential errors in the solution.
