### PR TITLE
Scaladoc links with '>' in signature now open an expanded definition in all browsers

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.js
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.js
@@ -274,7 +274,7 @@ $(document).ready(function() {
 
     // highlight and jump to selected member if an anchor is provided
     if (window.location.hash) {
-        var jqElem = findElementByHash(window.location.hash);
+        var jqElem = findElementByHash(decodeURIComponent(window.location.hash));
         if (jqElem.length > 0) {
             if (jqElem.hasClass("toggleContainer")) toggleShowContentFct(jqElem);
             else exposeMember(jqElem);


### PR DESCRIPTION
Fixes scala/bug#12029.
The `window.location.hash` attribute is urlencoded in Chrome and Firefox, but non-encoded in Safari, so automatic expanding only worked in Safari. Now this attribute is always decoded before looking up the anchor.