### PR TITLE
Preserve tab in caret line

### DIFF
--- a/src/reflect/scala/reflect/internal/util/Position.scala
+++ b/src/reflect/scala/reflect/internal/util/Position.scala
@@ -177,7 +177,16 @@ private[util] trait InternalPositionImpl {
   def line: Int           = if (hasSource) source.offsetToLine(point) + 1 else 0
   def column: Int         = if (hasSource) calculateColumn() else 0
   def lineContent: String = if (hasSource) source.lineToString(line - 1) else ""
-  def lineCaret: String   = if (hasSource) " " * (column - 1) + "^" else ""
+  def lineCaret: String   = if (!hasSource) "" else {
+    val buf = new StringBuilder
+    var idx = source.lineToOffset(source.offsetToLine(point))
+    while (idx < point) {
+      buf.append(if (source.content(idx) == '\t') '\t' else ' ')
+      idx += 1
+    }
+    buf.append('^')
+    buf.toString
+  }
   @deprecated("use `lineCaret`", since="2.11.0")
   def lineCarat: String   = lineCaret
 

--- a/test/files/neg/implicit-shadow.check
+++ b/test/files/neg/implicit-shadow.check
@@ -4,8 +4,8 @@ it is imported twice in the same scope by
 import C._
 and import B._
 	1.isEmpty
-        ^
+	^
 implicit-shadow.scala:6: error: value isEmpty is not a member of Int
 	1.isEmpty
-          ^
+	  ^
 1 error

--- a/test/files/neg/names-package-method-conflict.check
+++ b/test/files/neg/names-package-method-conflict.check
@@ -1,4 +1,4 @@
 names-package-method-conflict.scala:7: error: There is name conflict between the foo.bar and the package foo.bar.
 	package bar{
-                ^
+	        ^
 1 error

--- a/test/files/neg/t2066b.check
+++ b/test/files/neg/t2066b.check
@@ -3,5 +3,5 @@ def f[T[_]](x: T[Int]): T[Any] (defined in trait A);
  found   : [T(in method f)(in method f)[+_]](x: T(in method f)(in method f)[Int]): T(in method f)(in method f)[Any]
  required: [T(in method f)(in method f)[_]](x: T(in method f)(in method f)[Int]): T(in method f)(in method f)[Any]
 	 def f[T[+_]](x : T[Int]) : T[Any] = x
-             ^
+	     ^
 1 error

--- a/test/files/neg/t2208.check
+++ b/test/files/neg/t2208.check
@@ -1,4 +1,4 @@
 t2208.scala:7: error: type arguments [Any] do not conform to type Alias's type parameter bounds [X <: Test.A]
 	class C extends Alias[Any]   // not ok, normalisation should check bounds before expanding Alias
-                        ^
+	                ^
 1 error

--- a/test/files/neg/t2405.check
+++ b/test/files/neg/t2405.check
@@ -1,8 +1,8 @@
 t2405.scala:8: error: could not find implicit value for parameter e: Int
 		implicitly[Int]
-                          ^
+		          ^
 t2405.scala:6: warning: imported `y` is permanently hidden by definition of method y
 		import A.{x => y}
-                          ^
+		          ^
 1 warning
 1 error

--- a/test/files/neg/t4460b.check
+++ b/test/files/neg/t4460b.check
@@ -1,4 +1,4 @@
 t4460b.scala:7: error: constructor invokes itself
 	  def this() = this() // was binding to Predef.<init> !!
-                       ^
+	               ^
 1 error

--- a/test/files/neg/t4818.check
+++ b/test/files/neg/t4818.check
@@ -2,5 +2,5 @@ t4818.scala:4: error: type mismatch;
  found   : Int(5)
  required: Nothing
 	def f(x: Any) = x match { case Fn(f) => f(5) }
-                                                  ^
+	                                          ^
 1 error

--- a/test/files/neg/t6214.check
+++ b/test/files/neg/t6214.check
@@ -1,4 +1,4 @@
 t6214.scala:5: error: missing parameter type
   	m { s => case class Foo() }
-            ^
+  	    ^
 1 error

--- a/test/files/neg/t6258.check
+++ b/test/files/neg/t6258.check
@@ -2,12 +2,12 @@ t6258.scala:2: error: missing parameter type for expanded function
 The argument types of an anonymous function must be fully known. (SLS 8.5)
 Expected type was: PartialFunction[?, Int]
 	val f : PartialFunction[_, Int] = { case a : Int => a } // undefined param
-                                          ^
+	                                  ^
 t6258.scala:5: error: missing parameter type for expanded function
 The argument types of an anonymous function must be fully known. (SLS 8.5)
 Expected type was: PartialFunction[?,Int]
 	foo { case a : Int => a } // undefined param
-            ^
+	    ^
 t6258.scala:22: error: missing parameter type for expanded function
 The argument types of an anonymous function must be fully known. (SLS 8.5)
 Expected type was: PartialFunction[?,Any]

--- a/test/files/neg/t6558.check
+++ b/test/files/neg/t6558.check
@@ -6,5 +6,5 @@ t6558.scala:7: error: not found: type typeparam
            ^
 t6558.scala:10: error: not found: type valueparam
   	@valueparam x: Any
-         ^
+  	 ^
 3 errors

--- a/test/files/neg/t9438.check
+++ b/test/files/neg/t9438.check
@@ -1,0 +1,11 @@
+t9438.scala:3: error: type mismatch;
+ found   : Double(3.14)
+ required: Int
+	val i: Int = 3.14
+	             ^
+t9438.scala:5: error: type mismatch;
+ found   : Double(3.14)
+ required: Int
+		3.14
+		^
+2 errors

--- a/test/files/neg/t9438.scala
+++ b/test/files/neg/t9438.scala
@@ -1,0 +1,6 @@
+
+class C {
+	val i: Int = 3.14
+	def f(): Int =
+		3.14
+}


### PR DESCRIPTION
At least one test has interior tab chars.

Fixes scala/bug#9438