### PR TITLE
[MORIBUND] Avoid aliasing errors in process env

### DIFF
--- a/src/compiler/scala/tools/reflect/FormatInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FormatInterpolator.scala
@@ -27,8 +27,8 @@ abstract class FormatInterpolator {
   import definitions._
   import treeInfo.Applied
 
-  @inline private def truly(body: => Unit): Boolean = { body ; true }
-  @inline private def falsely(body: => Unit): Boolean = { body ; false }
+  @inline private def truly(body: => Unit)  : true  = { body ; true }
+  @inline private def falsely(body: => Unit): false = { body ; false }
 
   private def bail(msg: String) = global.abort(msg)
 

--- a/src/testkit/scala/tools/testkit/AssertUtil.scala
+++ b/src/testkit/scala/tools/testkit/AssertUtil.scala
@@ -44,6 +44,12 @@ object AssertUtil {
   // junit fail is Unit
   def fail(message: String): Nothing = throw new AssertionError(message)
 
+  // use an asserting body in a boolean test, true if not failure by throwing
+  def truly[U](body: => U): true = { body: Unit ; true }
+
+  // run a side-effecting body in a boolean test
+  def falsely[U](body: => U): false = { body: Unit ; false }
+
   private final val timeout = 60 * 1000L                 // wait a minute
 
   private implicit class `ref helper`[A](val r: Reference[A]) extends AnyVal {

--- a/test/junit/scala/sys/process/ProcessTest.scala
+++ b/test/junit/scala/sys/process/ProcessTest.scala
@@ -126,4 +126,11 @@ class ProcessTest {
       case (_, other)                        => fail(s"Expected one IOException, got $other")
     }
   }
+
+  @Test def `12093 avoid aliasing env keys`(): Unit = if (isWin) sys.env.keys.headOption.foreach { key =>
+    val i = key.indexWhere(c => c.toUpper != c.toLower)
+    val c = key.charAt(i) match { case x if x.isUpper => x.toLower case x => x.toUpper }
+    val s = key.patch(i, c.toString, 1)
+    assertThrows[IllegalArgumentException](Process("dummy", None, s -> "DUMMY"), msg => truly(assertEquals(s"Environment key '$s' differs only in case from existing key '$key'", msg)))
+  }
 }


### PR DESCRIPTION
Minimal intervention avoids introducing a false alias on windows.

The behavior is to throw if there is an existing env key that "differs only in case".

Fixes scala/bug#12093
