### PR TITLE
CodePrinter prints backquoted names

### DIFF
--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -562,7 +562,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
 
       def addBackquotes(s: String) =
         if (decoded && (decName.exists(ch => brackets.contains(ch) || isWhitespace(ch) || isDot(ch)) ||
-          (name.isOperatorName && decName.exists(isOperatorPart) && decName.exists(isScalaLetter) && !decName.contains(bslash))))
+          ((name.isOperatorName || decName.exists(isOperatorPart)) && decName.exists(isScalaLetter) && !decName.contains(bslash))))
           s"`$s`" else s
 
       if (name == nme.CONSTRUCTOR) "this"

--- a/test/junit/scala/reflect/internal/PrintersTest.scala
+++ b/test/junit/scala/reflect/internal/PrintersTest.scala
@@ -137,6 +137,10 @@ class BasePrintTest {
 
   @Test def testName21 = assertPrintedCode("""class `test.name`""")
 
+  @Test def testName22 = assertEquals("val `some-val`: Int = 1", showCode(q"""val ${TermName("some-val")}: Int = 1"""))
+
+  @Test def testName23 = assertEquals("val `some+`: String = \"foo\"", showCode(q"""val ${TermName("some+")}: String = "foo""""))
+
   @Test def testIfExpr1 = assertResultCode(code = sm"""
     |val a = 1
     |if (a > 1)


### PR DESCRIPTION
```scala
scala> import scala.reflect.runtime.universe._
import scala.reflect.runtime.universe._

scala> print(showCode(q"""val ${TermName("some-val")} = 1"""))
val `some-val` = 1

scala> print(showCode(q"""val ${TermName("some$minusval")} = 1"""))
val `some-val` = 1

scala> print(showCode(q"""val ${TermName("foo-bar-goo")} = 1"""))
val `foo-bar-goo` = 1

scala> print(showCode(q"""val ${TermName("foo-bar goo")} = 1"""))
val `foo-bar goo` = 1

scala> print(showCode(q"""val ${TermName("some-val")}:String = "lala""""))
val `some-val`: String = "lala"

scala> print(showCode(q"""val ${TermName("some$minusval")}:String = "lala""""))
val `some-val` : String = "lala"
```
@SethTisue @VladimirNik @densh Please review.

Fixes scala/bug#9250