### PR TITLE
 Add `@inheritSignature` for forwards binary compatible overrides

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -35,6 +35,9 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[MissingTypesProblem]("scala.annotation.migration"),
 
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.inheritSignature"),
+
+    // This method could be removed with `@inheritSignature`
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.HashMap.mapValuesInPlaceImpl"),
   )
 
   override val buildSettings = Seq(

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -33,6 +33,8 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[MissingTypesProblem]("scala.annotation.implicitAmbiguous"),
     ProblemFilters.exclude[MissingTypesProblem]("scala.annotation.implicitNotFound"),
     ProblemFilters.exclude[MissingTypesProblem]("scala.annotation.migration"),
+
+    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.inheritSignature"),
   )
 
   override val buildSettings = Seq(

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -777,7 +777,7 @@ abstract class Erasure extends InfoTransform
         case Apply(fun @ Select(qual, _), args) if fun.symbol.hasAnnotation(definitions.inheritSignatureClass) =>
           if (!context.enclMethod.owner.isBridge) {
             val os = enteringTyper(fun.symbol.nextOverriddenSymbol)
-            adaptMember(atPos(tree.pos)(Apply(Select(qual, os), args)))
+            adaptMember(atPos(tree.pos)(treeCopy.Apply(tree, Select(qual, os), args)))
           } else
             tree
 

--- a/src/compiler/scala/tools/nsc/transform/PostErasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/PostErasure.scala
@@ -13,6 +13,8 @@
 package scala.tools.nsc
 package transform
 
+import scala.reflect.internal.Flags
+
 /** This phase maps ErasedValueTypes to the underlying unboxed representation and
  *  performs peephole optimizations.
  */
@@ -44,6 +46,10 @@ trait PostErasure extends InfoTransform with TypingTransformers with scala.refle
         case AsInstanceOf(v, tpe) if v.tpe <:< tpe => finish(v)          // x.asInstanceOf[X]       ==> x
         case ValueClass.BoxAndUnbox(v)             => finish(v)          // (new B(v)).unbox        ==> v
         case ValueClass.BoxAndCompare(v1, op, v2)  => binop(v1, op, v2)  // new B(v1) == new B(v2)  ==> v1 == v2
+        case dd: DefDef if dd.symbol.hasAttachment[InheritedSignature] =>
+          dd.symbol.setFlag(Flags.PRIVATE).resetFlag(Flags.OVERRIDE)
+          dd.symbol.getAndRemoveAttachment[InheritedSignature].get.bridge.resetFlag(Flags.ARTIFACT).setFlag(Flags.OVERRIDE)
+          tree
         case tree                                  => tree
       }
     }

--- a/src/compiler/scala/tools/nsc/transform/PostErasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/PostErasure.scala
@@ -47,7 +47,9 @@ trait PostErasure extends InfoTransform with TypingTransformers with scala.refle
         case ValueClass.BoxAndUnbox(v)             => finish(v)          // (new B(v)).unbox        ==> v
         case ValueClass.BoxAndCompare(v1, op, v2)  => binop(v1, op, v2)  // new B(v1) == new B(v2)  ==> v1 == v2
         case dd: DefDef if dd.symbol.hasAttachment[InheritedSignature] =>
-          dd.symbol.setFlag(Flags.PRIVATE).resetFlag(Flags.OVERRIDE)
+          // the ARTIFACT and BRIDGE flags have no effect on scalac or the jvm, but they matter to javac when
+          // compiling Java code against inheritSignature methods. The selection here seem to work best.
+          dd.symbol.setFlag(Flags.PRIVATE | Flags.ARTIFACT).resetFlag(Flags.OVERRIDE)
           dd.symbol.getAndRemoveAttachment[InheritedSignature].get.bridge.resetFlag(Flags.ARTIFACT).setFlag(Flags.OVERRIDE)
           tree
         case tree                                  => tree

--- a/src/compiler/scala/tools/nsc/transform/PostErasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/PostErasure.scala
@@ -50,7 +50,8 @@ trait PostErasure extends InfoTransform with TypingTransformers with scala.refle
           // the ARTIFACT and BRIDGE flags have no effect on scalac or the jvm, but they matter to javac when
           // compiling Java code against inheritSignature methods. The selection here seem to work best.
           dd.symbol.setFlag(Flags.PRIVATE | Flags.ARTIFACT).resetFlag(Flags.OVERRIDE)
-          dd.symbol.getAndRemoveAttachment[InheritedSignature].get.bridge.resetFlag(Flags.ARTIFACT).setFlag(Flags.OVERRIDE)
+          // we leave the attachment on the symbol to for `adaptToNewRunMap`
+          dd.symbol.attachments.get[InheritedSignature].get.bridge.resetFlag(Flags.ARTIFACT).setFlag(Flags.OVERRIDE)
           tree
         case tree                                  => tree
       }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1707,6 +1707,18 @@ abstract class RefChecks extends Transform {
                   deriveDefDef(dd)(_ => typed(gen.mkThrowNewRuntimeException("native method stub")))
                 } else
                   tree
+
+              case _: DefDef if sym.hasAnnotation(inheritSignatureClass) =>
+                val os = sym.nextOverriddenSymbol
+                if (os == NoSymbol) {
+                  reporter.error(sym.pos, "Invalid `@inheritSignature` annotation, the method overrides nothing.")
+                  sym.removeAnnotation(definitions.inheritSignatureClass)
+                } else if (exitingErasure(os.tpe =:= sym.tpe) && !os.hasAnnotation(inheritSignatureClass)) {
+                  reporter.error(sym.pos, "Invalid `@inheritSignature` annotation, the overridden member has the same signature.")
+                  sym.removeAnnotation(definitions.inheritSignatureClass)
+                }
+                tree
+
               case _ => tree
             }
 

--- a/src/library/scala/annotation/inheritSignature.scala
+++ b/src/library/scala/annotation/inheritSignature.scala
@@ -1,0 +1,42 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+
+/**
+ * Methods annotated `@inheritSignature` are emitted `private` in bytecode, which
+ * allows adding binary compatible overrides when the bytecode signature is refined.
+ *
+ * Example:
+ *
+ * {{{
+ *   class A { def f: AnyRef = "A.f" }
+ *   class C extends A
+ * }}}
+ *
+ * Adding an override of `f` to `C` and refining the result type is not forwards
+ * binary compatible:
+ *
+ * {{{
+ *    class C extends A { override def f: String = "C.f" }
+ * }}}
+ *
+ * The class `C` gets a new method in bytecode with return type `String`. In order
+ * to implement overriding, the compiler generates a "bridge" method in `C` which
+ * has the same signature as the overridden method (return type `Object`).
+ *
+ * By annotating the override `@inheritSignature`, the new method `C.f: String`
+ * is made `private`, only the bridge method remains `public`.
+ *
+ * Invocations of `C.f: String` are rewritten to `A.f`.
+ */
+final class inheritSignature extends StaticAnnotation

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -13,7 +13,7 @@
 package scala.collection
 package mutable
 
-import scala.annotation.{nowarn, tailrec}
+import scala.annotation.{inheritSignature, nowarn, tailrec}
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.generic.DefaultSerializationProxy
 import scala.util.hashing.MurmurHash3
@@ -537,8 +537,8 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     this
   }
 
-  // TODO: rename to `mapValuesInPlace` and override the base version (not binary compatible)
-  private[mutable] def mapValuesInPlaceImpl(f: (K, V) => V): this.type = {
+  @inheritSignature
+  override def mapValuesInPlace(f: (K, V) => V): this.type = {
     val len = table.length
     var i = 0
     while (i < len) {

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -197,17 +197,15 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
     * @return   the map itself.
     */
   def mapValuesInPlace(f: (K, V) => V): this.type = {
-    if (nonEmpty) this match {
-      case hm: mutable.HashMap[_, _] => hm.asInstanceOf[mutable.HashMap[K, V]].mapValuesInPlaceImpl(f)
-      case _ =>
-        val array = this.toArray[Any]
-        val arrayLength = array.length
-        var i = 0
-        while (i < arrayLength) {
-          val (k, v) = array(i).asInstanceOf[(K, V)]
-          update(k, f(k, v))
-          i += 1
-        }
+    if (nonEmpty) {
+      val array = this.toArray[Any]
+      val arrayLength = array.length
+      var i = 0
+      while (i < arrayLength) {
+        val (k, v) = array(i).asInstanceOf[(K, V)]
+        update(k, f(k, v))
+        i += 1
+      }
     }
     this
   }

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1308,6 +1308,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val NowarnClass                = getClassIfDefined("scala.annotation.nowarn")
     lazy val uncheckedStableClass       = requiredClass[scala.annotation.unchecked.uncheckedStable]
     lazy val uncheckedVarianceClass     = requiredClass[scala.annotation.unchecked.uncheckedVariance]
+    lazy val inheritSignatureClass      = getClassIfDefined("scala.annotation.inheritSignature")
 
     // Tasty Unpickling Helpers - only access when Scala 3 library is expected to be available
     lazy val ChildAnnotationClass        = getClassIfDefined("scala.annotation.internal.Child")

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -135,4 +135,6 @@ trait StdAttachments {
   case class ChangeOwnerAttachment(originalOwner: Symbol)
 
   case object InterpolatedString extends PlainAttachment
+
+  case class InheritedSignature(bridge: Symbol)
 }

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -1235,6 +1235,8 @@ private[internal] trait TypeMaps {
             if (decl.hasAllFlags(METHOD | MODULE))
               // HACK: undo flag Uncurry's flag mutation from prior run
               decl.resetFlag(METHOD | STABLE)
+            if (decl.hasFlag(METHOD) && decl.hasAttachment[InheritedSignature])
+              decl.setFlag(Flags.OVERRIDE).resetFlag(Flags.PRIVATE | Flags.ARTIFACT)
           }
           if (parents1 eq parents) tp
           else ClassInfoType(parents1, decls, clazz)

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -72,6 +72,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.NullaryOverrideAdapted
     this.ChangeOwnerAttachment
     this.InterpolatedString
+    this.InheritedSignature
     this.noPrint
     this.typeDebug
     // inaccessible: this.posAssigner
@@ -433,6 +434,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.NowarnClass
     definitions.uncheckedStableClass
     definitions.uncheckedVarianceClass
+    definitions.inheritSignatureClass
     definitions.ChildAnnotationClass
     definitions.RepeatedAnnotationClass
     definitions.TargetNameAnnotationClass

--- a/test/files/neg/inheritSignature.check
+++ b/test/files/neg/inheritSignature.check
@@ -1,0 +1,13 @@
+inheritSignature.scala:8: error: Invalid `@inheritSignature` annotation, the overridden member has the same signature.
+class C1 extends B1 { @inheritSignature override def f: String = "c" } // error, same signature
+                                                     ^
+inheritSignature.scala:11: error: Invalid `@inheritSignature` annotation, the method overrides nothing.
+class D { @inheritSignature def f: String = "d" } // error, overrides nothing
+                                ^
+inheritSignature.scala:19: error: Invalid `@inheritSignature` annotation, the method overrides nothing.
+    @annotation.inheritSignature override def f: String = "c" // message is not very accurate, but it's a niche feature anyway
+                                              ^
+inheritSignature.scala:20: error: Invalid `@inheritSignature` annotation, the method overrides nothing.
+    @annotation.inheritSignature override def g(x: Int): String = "c" // message is not very accurate, but it's a niche feature anyway
+                                              ^
+4 errors

--- a/test/files/neg/inheritSignature.scala
+++ b/test/files/neg/inheritSignature.scala
@@ -1,0 +1,22 @@
+import scala.annotation.inheritSignature
+
+class A { def f: Object = "a" }
+
+class B1 extends A  {                   override def f: String = "b" }
+class B2 extends A  { @inheritSignature override def f: String = "b" }
+
+class C1 extends B1 { @inheritSignature override def f: String = "c" } // error, same signature
+class C2 extends B2 { @inheritSignature override def f: String = "c" } // ok
+
+class D { @inheritSignature def f: String = "d" } // error, overrides nothing
+
+object VC {
+  trait A[T] extends Any {
+    def f: Object = "a"
+    def g(x: T): String = "a"
+  }
+  implicit class C(private val x: String) extends AnyVal with A[Int] {
+    @annotation.inheritSignature override def f: String = "c" // message is not very accurate, but it's a niche feature anyway
+    @annotation.inheritSignature override def g(x: Int): String = "c" // message is not very accurate, but it's a niche feature anyway
+  }
+}

--- a/test/files/run/inheritSignature.check
+++ b/test/files/run/inheritSignature.check
@@ -1,0 +1,45 @@
+22
+22
+hai
+3
+44
+77
+hai
+36
+44
+77
+hai
+36
+A
+- public abstract int A.g(java.lang.Object)
+- public abstract java.lang.Object A.f()
+BI
+- private int BI.f()
+- private int BI.g(int)
+- public int BI.g(java.lang.Object)
+- public java.lang.Object BI.f()
+BS
+- private int BS.g(java.lang.String)
+- private java.lang.String BS.f()
+- public int BS.g(java.lang.Object)
+- public java.lang.Object BS.f()
+BIO1
+- public int BIO1.f()
+- public int BIO1.g(int)
+- public int BIO1.g(java.lang.Object)
+- public java.lang.Object BIO1.f()
+BSO1
+- public int BSO1.g(java.lang.Object)
+- public int BSO1.g(java.lang.String)
+- public java.lang.Object BSO1.f()
+- public java.lang.String BSO1.f()
+BIO2
+- private int BIO2.f()
+- private int BIO2.g(int)
+- public int BIO2.g(java.lang.Object)
+- public java.lang.Object BIO2.f()
+BSO2
+- private int BSO2.g(java.lang.String)
+- private java.lang.String BSO2.f()
+- public int BSO2.g(java.lang.Object)
+- public java.lang.Object BSO2.f()

--- a/test/files/run/inheritSignature.scala
+++ b/test/files/run/inheritSignature.scala
@@ -1,0 +1,96 @@
+abstract class A[T] {
+  def f: T
+  def g(t: T): Int
+}
+
+import scala.annotation.inheritSignature
+
+class BI extends A[Int] {
+  @inheritSignature
+  def f: Int = 11 // need box - return type in bytecode is Object
+
+  @inheritSignature
+  def g(i: Int): Int = i + 11 // need unbox - param type in bytecode is Object
+}
+
+class BS extends A[String] {
+  @inheritSignature
+  def f: String = " hai " // ok - return type in bytecode is Object
+
+  @inheritSignature
+  def g(s: String): Int = s.trim.length // need cast - param type in bytecode is Object
+}
+
+class BIO1 extends BI {
+  // works fine. generates a bridge.
+  // genearates public `f: Int` has the `override` flag, but that's fine as it doesn't exist in bytecode
+  override def f: Int = super.f + 22
+
+  override def g(i: Int): Int = super.g(i + 22) + 33
+}
+
+class BSO1 extends BS {
+  override def f: String = super.f.trim()
+
+  override def g(s: String): Int = super.g(s.trim) + 33
+}
+
+class BIO2 extends BI {
+  // works fine. bridge becomes override, `f: Int` stays private
+  @inheritSignature
+  override def f: Int = super.f + 22
+
+  @inheritSignature
+  override def g(i: Int): Int = super.g(i + 22) + 33
+}
+
+class BSO2 extends BS {
+  @inheritSignature
+  override def f: String = super.f.trim()
+
+  @inheritSignature
+  override def g(s: String): Int = super.g(s.trim) + 33
+}
+
+object Test {
+  def show(i: Int) = println(i)
+  def show(s: String) = println(s)
+  def showSigs[T](implicit t: reflect.ClassTag[T]) = {
+    val c = t.runtimeClass
+    println(c.getName)
+    println(c.getDeclaredMethods.filter(m => m.getName == "f" || m.getName == "g").map(_.toString).sorted.mkString("- ", "\n- ", ""))
+  }
+  def main(args: Array[String]): Unit = {
+    val bi = new BI
+    show(bi.f + 11)  // need unbox
+    show(bi.g(11))   // need box
+
+    val bs = new BS
+    show(bs.f.trim)      // need cast
+    show(bs.g(" hui "))  // ok
+
+    val bio1 = new BIO1
+    show(bio1.f + 11)
+    show(bio1.g(11))
+
+    val bso1 = new BSO1
+    show(bso1.f.trim)
+    show(bso1.g(" hui "))
+
+    val bio2 = new BIO2
+    show(bio2.f + 11)
+    show(bio2.g(11))
+
+    val bso2 = new BSO2
+    show(bso2.f.trim)
+    show(bso2.g(" hui "))
+
+    showSigs[A[_]]
+    showSigs[BI]
+    showSigs[BS]
+    showSigs[BIO1]
+    showSigs[BSO1]
+    showSigs[BIO2]
+    showSigs[BSO2]
+  }
+}

--- a/test/files/run/inheritSignatureJava.check
+++ b/test/files/run/inheritSignatureJava.check
@@ -1,2 +1,2 @@
-Test-hai
-Test-hai-Buk-hai
+(A)(Sub)(C)hai
+(B)(Buk)(Sub)(C)hai(Sub)(C)hai

--- a/test/files/run/inheritSignatureJava.check
+++ b/test/files/run/inheritSignatureJava.check
@@ -1,0 +1,2 @@
+Test-hai
+Test-hai-Buk-hai

--- a/test/files/run/inheritSignatureJava/C.scala
+++ b/test/files/run/inheritSignatureJava/C.scala
@@ -1,0 +1,12 @@
+class C[A] {
+  def foo(a: A): A = a
+}
+
+class Sub extends C[String] {
+  @scala.annotation.inheritSignature
+  override def foo(a: String): String = a
+}
+
+class Buk extends Sub {
+  final def superFoo(a: String) = "-Buk-" + super[Sub].foo(a)
+}

--- a/test/files/run/inheritSignatureJava/C.scala
+++ b/test/files/run/inheritSignatureJava/C.scala
@@ -1,12 +1,12 @@
 class C[A] {
-  def foo(a: A): A = a
+  def foo(a: A): String = "(C)" + a
 }
 
 class Sub extends C[String] {
   @scala.annotation.inheritSignature
-  override def foo(a: String): String = a
+  override def foo(a: String): String = "(Sub)" + super.foo(a)
 }
 
 class Buk extends Sub {
-  final def superFoo(a: String) = "-Buk-" + super[Sub].foo(a)
+  final def superFoo(a: String) = "(Buk)" + super[Sub].foo(a)
 }

--- a/test/files/run/inheritSignatureJava/Test.java
+++ b/test/files/run/inheritSignatureJava/Test.java
@@ -1,13 +1,13 @@
 class A extends Sub {
   @Override
   public String foo(String a) {
-    return "Test-" + a /*+ super.foo(a)*/; // super call doesn't compile
+    return "(A)" + super.foo(a);
   }
 }
 class B extends Buk {
   @Override
   public String foo(String a) {
-    return "Test-" + a + superFoo(a) /*+ super.foo(a)*/; // super call doesn't compile
+    return "(B)" + superFoo(a) + super.foo(a);
   }
 }
 

--- a/test/files/run/inheritSignatureJava/Test.java
+++ b/test/files/run/inheritSignatureJava/Test.java
@@ -1,0 +1,19 @@
+class A extends Sub {
+  @Override
+  public String foo(String a) {
+    return "Test-" + a /*+ super.foo(a)*/; // super call doesn't compile
+  }
+}
+class B extends Buk {
+  @Override
+  public String foo(String a) {
+    return "Test-" + a + superFoo(a) /*+ super.foo(a)*/; // super call doesn't compile
+  }
+}
+
+public class Test {
+  public static void main(String[] args) {
+    System.out.println(new A().foo("hai"));
+    System.out.println(new B().foo("hai"));
+  }
+}

--- a/test/files/run/inheritSignatureRepl.check
+++ b/test/files/run/inheritSignatureRepl.check
@@ -1,0 +1,14 @@
+
+scala> abstract class A { def f: Object }
+class A
+
+scala> object B extends A { @annotation.inheritSignature def f: String = " b "; def g: String = f }
+object B
+
+scala> B.f.trim
+val res0: String = b
+
+scala> B.g.trim
+val res1: String = b
+
+scala> :quit

--- a/test/files/run/inheritSignatureRepl.scala
+++ b/test/files/run/inheritSignatureRepl.scala
@@ -1,0 +1,10 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code =
+    """abstract class A { def f: Object }
+      |object B extends A { @annotation.inheritSignature def f: String = " b "; def g: String = f }
+      |B.f.trim
+      |B.g.trim
+      |""".stripMargin
+}


### PR DESCRIPTION
Methods annotated `@inheritSignature` are emitted `private` in bytecode, which allows adding binary compatible overrides when the bytecode signature is refined.

```
class A { def f: AnyRef = "A.f" }
class C extends A { @inheritSignature override def f: String = "C.f" }
```

The method `C.f: String` is made `private`, the bridge remains `public` (~and the `bridge` flag is removed~). Calls to `C.f` are rewritten to `A.f`.

Closes https://github.com/scala/bug/issues/11804. Hat-tip to @szeiger for the idea and for doing the initial research.