### PR TITLE
MultiStringSetting preserves remaining args

### DIFF
--- a/test/files/neg/t12098.check
+++ b/test/files/neg/t12098.check
@@ -1,0 +1,7 @@
+t12098.scala:9: warning: method f in class C is deprecated (since 1.0): don't
+  def g() = f()
+            ^
+warning: 1 lint warning; change -Wconf for cat=lint to display individual messages
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/t12098.scala
+++ b/test/files/neg/t12098.scala
@@ -1,0 +1,10 @@
+//xlint supersedes default Wconf setting, which is ws warn-summary for deprecation
+//scalac: -Werror -Wconf:cat=lint-missing-interpolator:ws -Xlint
+
+class C(i: Int) {
+  def p() = println("hi $i")
+
+  @deprecated("don't", since="1.0") def f() = 42
+
+  def g() = f()
+}

--- a/test/junit/scala/tools/nsc/reporters/WConfTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/WConfTest.scala
@@ -43,7 +43,7 @@ class WConfTest extends BytecodeTesting {
 
   def reports(code: String, extraWconf: String = "", lint: Boolean = false): List[Info] = {
     // lint has a postSetHook to enable `deprecated`, which in turn adds to `Wconf`,
-    // but since we override Wconf after, that effect is cancelled
+    // but since we clear and initialize Wconf after enabling lint, that effect is cancelled.
     if (lint) {
       global.settings.warnUnused.clear()
       global.settings.lint.tryToSet(List("_"))
@@ -212,6 +212,7 @@ class WConfTest extends BytecodeTesting {
   def lint(): Unit = {
     check(infos(code, "cat=lint:i"), Nil)
     check(infos(code, "cat=lint:i", lint = true), List(l2, l23))
+    check(reports(code, "any:s,cat=lint:ws", lint = true), Nil)
     check(reports(code, "cat=lint:ws,any:s", lint = true), List((-1, "2 lint warnings")))
     check(infos(code, "cat=lint-deprecation:i", lint = true), List(l2))
     check(infos(code, "cat=lint-adapted-args:i", lint = true), List(l23))

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -267,4 +267,24 @@ class SettingsTest {
     assertEquals("processing stops at bad option", 2, rest.length)
     assertEquals(2, errors.size)  // missing arg and bad option
   }
+  @Test def `t12098 MultiStringSetting with prepend handles non-colon args`(): Unit = {
+    import scala.collection.mutable.ListBuffer
+    val errors   = ListBuffer.empty[String]
+    val settings = new Settings(errors.addOne)
+    val (ok, rest) = settings.processArguments("-Wconf" :: "help" :: "-Vdebug" :: "x.scala" :: Nil, true)
+    assert("processing should succeed", ok)
+    assertEquals("processing stops at argument", 1, rest.length)
+    assertEquals("processing stops at the correct argument", "x.scala", rest.head)
+    assertEquals(0, errors.size)
+    assert(settings.debug)
+    assert(settings.Wconf.isHelping)
+  }
+  @Test def `t12098 MultiStringSetting prepends`(): Unit = {
+    val settings = new Settings(msg => fail(s"Unexpected error: $msg"))
+    val (ok, rest) = settings.processArguments("-Wconf:cat=lint-missing-interpolator:ws" :: "-Xlint" :: "x.scala" :: Nil, true)
+    assert("processing should succeed", ok)
+    assert(settings.warnMissingInterpolator)
+    assert(settings.lintDeprecation)
+    // test/files/neg/t12098.scala shows that cat=deprecation:w due to xlint supersedes default cat=deprecation:ws
+  }
 }


### PR DESCRIPTION
This is so that later settings override earlier settings.
But inputs may be due to colon `-Setting:value` or `-Setting value`.
The latter form presents all remaining args, so reversing those
inputs is not appropriate. Instead, reverse the result.

Fixes scala/bug#12098