### PR TITLE
Add QualifierTypedAnnotationInfo

### DIFF
--- a/test/files/pos/t11870.scala
+++ b/test/files/pos/t11870.scala
@@ -1,0 +1,60 @@
+class Annot(arg: Any) extends scala.annotation.StaticAnnotation
+
+abstract class Demo1 {
+  @Annot(x)
+  def x: String = "foo"
+}
+
+abstract class Demo2 {
+  @Annot(y)
+  def x: String = "foo"
+
+  @Annot(x)
+  def y: String = "bar"
+}
+
+class Annot1(arg: Any) extends scala.annotation.StaticAnnotation
+class Annot2(arg: Any) extends scala.annotation.StaticAnnotation
+
+abstract class Demo3 {
+  @Annot1(y)
+  def x: String = "foo"
+
+  @Annot2(x)
+  def y: String = "bar"
+}
+
+// test annotations without argument
+import scala.annotation.unchecked
+
+class C {
+  class D
+}
+
+class Test {
+  locally {
+    val c = new C
+    import c._
+    new D
+  }
+
+  locally {
+    import unchecked.uncheckedStable
+    @uncheckedStable def c = new C
+    import c._
+    new D
+  }
+
+  locally {
+    @unchecked.uncheckedStable def c = new C
+    import c._
+    new D
+  }
+
+  locally {
+    import unchecked.{uncheckedStable => uc}
+    @uc def c = new C
+    import c._
+    new D
+  }
+}


### PR DESCRIPTION
fixes scala/bug#11870
Following https://github.com/scala/scala/pull/9023#issuecomment-645757880, add QualifierTypedAnnotationInfo used to match AnnotationInfo type without fully typechecked