### PR TITLE
Check all bindings exhaustively, e.g. tuples components

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -398,10 +398,9 @@ trait Logic extends Debugging  {
 
       object gatherEqualities extends PropTraverser {
         override def apply(p: Prop) = p match {
-          case Eq(v, c) =>
-            vars += v
-            v.registerEquality(c)
-          case _ => super.apply(p)
+          case Eq(v, NullConst) if !modelNull => vars += v // not modeling equality to null
+          case Eq(v, c)                       => vars += v; v.registerEquality(c)
+          case _                              => super.apply(p)
         }
       }
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -246,10 +246,6 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
       override def toString = s"T${id}C($prop)"
     }
 
-    class TreeMakersToPropsIgnoreNullChecks(root: Symbol) extends TreeMakersToProps(root) {
-      override def uniqueNonNullProp(p: Tree): Prop = True
-    }
-
     // returns (tree, tests), where `tree` will be used to refer to `root` in `tests`
     class TreeMakersToProps(val root: Symbol) {
       prepareNewAnalysis() // reset hash consing for Var and Const
@@ -261,7 +257,6 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
       def uniqueEqualityProp(testedPath: Tree, rhs: Tree): Prop =
         uniqueEqualityProps getOrElseUpdate((testedPath, rhs), Eq(Var(testedPath), ValueConst(rhs)))
 
-      // overridden in TreeMakersToPropsIgnoreNullChecks
       def uniqueNonNullProp (testedPath: Tree): Prop =
         uniqueNonNullProps getOrElseUpdate(testedPath, Not(Eq(Var(testedPath), NullConst)))
 
@@ -537,7 +532,7 @@ trait MatchAnalysis extends MatchApproximation {
       val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(statistics.patmatAnaExhaust) else null
       var backoff = false
 
-      val approx = new TreeMakersToPropsIgnoreNullChecks(prevBinder)
+      val approx = new TreeMakersToProps(prevBinder)
       val symbolicCases = approx.approximateMatch(cases, approx.onUnknown { tm =>
         approx.fullRewrite.applyOrElse[TreeMaker, Prop](tm, {
           case BodyTreeMaker(_, _) => True // irrelevant -- will be discarded by symbolCase later

--- a/test/files/neg/t10019.check
+++ b/test/files/neg/t10019.check
@@ -1,0 +1,11 @@
+t10019.scala:4: warning: match may not be exhaustive.
+It would fail on the following input: Foo(None)
+  def single(t: Foo): Nothing = t match {
+                                ^
+t10019.scala:8: warning: match may not be exhaustive.
+It would fail on the following input: (Foo(None), _)
+  def tuple(s: Foo, t: Foo): Nothing = (s, t) match {
+                                       ^
+error: No warnings can be incurred under -Xfatal-warnings.
+two warnings found
+one error found

--- a/test/files/neg/t10019.flags
+++ b/test/files/neg/t10019.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/t10019.scala
+++ b/test/files/neg/t10019.scala
@@ -1,0 +1,11 @@
+object Bug {
+  sealed case class Foo(e: Option[Int])
+
+  def single(t: Foo): Nothing = t match {
+    case Foo(Some(_)) => ???
+  }
+
+  def tuple(s: Foo, t: Foo): Nothing = (s, t) match {
+    case (Foo(Some(_)), _) => ???
+  }
+}

--- a/test/scaladoc/run/t10673.scala
+++ b/test/scaladoc/run/t10673.scala
@@ -32,6 +32,8 @@ object Test extends ScaladocModelTest {
     import access._
     def showParents(e: MemberTemplateEntity): Unit = {
       e.parentTypes.foreach(_._2.refEntity.foreach {
+        case (_, (LinkToMember(mbr, tpl), _))          => println(s"found link for member $mbr to $tpl")
+        case (_, (LinkToTpl(tpl), _))                  => println(s"found link $tpl")
         case (_, (LinkToExternalTpl(name, _, tpl), _)) => println(s"'$name' links to $tpl")
         case (_, (Tooltip(name), _))                   => println(s"'$name' no link!")
       })


### PR DESCRIPTION
With this fix the exhaustivity checker now emits exhaustivity warnings for tuples (and possibly other pattern matches that were affected).

Fixes scala/bug#10019

## Technically

The change to drop the null checks (introducing
`TreeMakersToPropsIgnoreNullChecks`) over-reached and got rid of all the
Vars that those null-checks were referencing.  So, instead of that,
finish honouring the `modelNull` option in `removeVarEq`.
