### PR TITLE
Widen abstract types to AnyTpe rather than crashing

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -796,7 +796,7 @@ trait ScalaLogic extends Interface with Logic with TreeAndTypeAnalysis {
     // (At least conceptually: `true` is an instance of class `Boolean`)
     private def widenToClass(tp: Type): Type =
       if (tp.typeSymbol.isClass) tp
-      else if (tp.baseClasses.isEmpty) throw new IllegalArgumentException("Bad type: " + tp)
+      else if (tp.baseClasses.isEmpty) AnyTpe
       else tp.baseType(tp.baseClasses.head)
 
     object TypeConst extends TypeConstExtractor {

--- a/test/files/pos/t12077.scala
+++ b/test/files/pos/t12077.scala
@@ -1,0 +1,13 @@
+object Main {
+  type Foo[+A] <: A
+
+  final class Bar {
+    def bar = ???
+  }
+
+  class Ops[A](private val self: Foo[A]) {
+    def baz: A = self match {
+      case x: Bar => x.bar
+    }
+  }
+}


### PR DESCRIPTION
This is what it used to do before it was "simplified"
(d97f7d95436d88e2c6a1e2ed3599f4847ca8662c) (and re-introduced with a
throw in 017460e63c3ca9d5cc1ceb836c1e223492d47c7e).

Fixes scala/bug#12077