### PR TITLE
Fix regression in LocalVariableTable attribute

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
@@ -767,7 +767,13 @@ object LocalOptImpls {
       val index = local.index
       // parameters and `this` (the lowest indices, starting at 0) are never removed or renumbered
       if (index >= firstLocalIndex) {
-        if (!variableIsUsed(local.start, local.end, index)) localsIter.remove()
+        def previousOrSelf(insn: AbstractInsnNode) = insn.getPrevious match {
+          case null => insn
+          case i => i
+        }
+        val storeInsn = previousOrSelf(local.start) // the start index is after the store, see scala/scala#8897
+        val used = variableIsUsed(storeInsn, local.end, index)
+        if (!used) localsIter.remove()
         else if (renumber(index) != index) local.index = renumber(index)
       }
     }

--- a/test/junit/scala/tools/nsc/backend/jvm/LineNumberTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/LineNumberTest.scala
@@ -1,0 +1,43 @@
+package scala.tools.nsc
+package backend.jvm
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.asm.Opcodes._
+import scala.tools.partest.ASMConverters._
+import scala.tools.testing.AssertUtil._
+import scala.tools.testing.BytecodeTesting
+import scala.tools.testing.BytecodeTesting._
+
+@RunWith(classOf[JUnit4])
+class LineNumberTest extends BytecodeTesting {
+
+  import compiler._
+
+  @Test
+  def lineNumberSynthetics(): Unit = {
+    // Checking that minimalRemoveUnreachableCode doesn't eliminate the local variable
+    // enties for a, a1
+    val code                    =
+      """
+        |class Test {
+        |  def main() {
+        |    for {
+        |      a <- Seq(1)
+        |      a1 = a + 1
+        |    } {
+        |      def getA = a
+        |      def getA1 = a1
+        |      println("")
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val cls = compileClass(code)
+    val m = getMethod(cls, "$anonfun$main$2")
+    assertEquals(m.localVars.toString, m.localVars.map(_.name).sorted, List("a", "a1", "x$1"))
+  }
+}

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/UnusedLocalVariablesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/UnusedLocalVariablesTest.scala
@@ -35,7 +35,7 @@ class UnusedLocalVariablesTest extends BytecodeTesting {
     assertLocalVarCount(code, 6)
 
     val code2 = """def f(a: Long): Unit = { var x = if (a == 0l) return else () }"""
-    assertLocalVarCount(code2, 2)
+    assertLocalVarCount(code2, 3)
   }
 
   @Test


### PR DESCRIPTION
The change to fix an off-by-one-statement error in the start
BCI of entries in the LocalVariableTable caused the on-by-default
version of dead code elimination to incorrectly remove entries
in some cases.

This commit changes `removeUnusedLocalVariableNodes` to do a full
pass of the instructions to mark used variables before doing the
removal. This allows it to find the xSTORE instruction that at
a BCI that precedes the start of the active range.

Relates to #8897

Fixes scala/bug#12095