### PR TITLE
Replace deprecated operator `/:` with `foldLeft` in spec files

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -305,7 +305,7 @@ Assume the following method which computes the sum of a
 variable number of arguments:
 
 ```scala
-def sum(xs: Int*) = (0 /: xs) ((x, y) => x + y)
+def sum(xs: Int*) = xs.foldLeft(0)((x, y) => x + y)
 ```
 
 Then

--- a/spec/08-pattern-matching.md
+++ b/spec/08-pattern-matching.md
@@ -752,13 +752,13 @@ method is omitted if one of the patterns $p_1 , \ldots , p_n$ is
 already a variable or wildcard pattern.
 
 ###### Example
-Here is a method which uses a fold-left operation
-`/:` to compute the scalar product of
+Here's an example which uses 
+`foldLeft` to compute the scalar product of
 two vectors:
 
 ```scala
 def scalarProduct(xs: Array[Double], ys: Array[Double]) =
-  (0.0 /: (xs zip ys)) {
+  (xs zip ys).foldLeft(0.0) {
     case (a, (b, c)) => a + b * c
   }
 ```

--- a/spec/15-changelog.md
+++ b/spec/15-changelog.md
@@ -330,7 +330,7 @@ directly for functions of arities greater than one. Previously, only
 unary functions could be defined that way. Example:
 
     def scalarProduct(xs: Array[Double], ys: Array[Double]) =
-      (0.0 /: (xs zip ys)) {
+      (xs zip ys).foldLeft(0.0) {
         case (a, (b, c)) => a + b * c
       }
 


### PR DESCRIPTION
It seems that there are still deprecated operator `/:` in 2.13 spec files, here replace them with `foldLeft`.