### PR TITLE
Fix BigDecimal.Range for some very small step sizes

### DIFF
--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -340,10 +340,18 @@ object NumericRange {
           // Jump in three pieces:
           //   * start to -1 or 1, whichever is closer (waypointA)
           //   * one step, which will take us at least to 0 (ends at waypointB)
+          //   * (except with really small numbers)
           //   * there to the end
           val negone = num.fromInt(-1)
           val startlim  = if (posStep) negone else one
-          val startdiff = num.minus(startlim, start)
+          //Use start value if the start value is closer to zero than startlim
+          //   * e.g. .5 is closer to zero than 1 and -.5 is closer to zero than -1
+          val startdiff = {
+            if ((posStep && num.lt(startlim, start)) || (!posStep && num.gt(startlim, start)))
+              start
+            else
+              num.minus(startlim, start)
+          }
           val startq    = check(num.quot(startdiff, step))
           val waypointA = if (startq == zero) start else num.plus(start, num.times(startq, step))
           val waypointB = num.plus(waypointA, step)


### PR DESCRIPTION
Checks if the start value is closer to zero than startlim because of issues caused by `num.minus(startlim, start)`.

These issues were caused by BigDecimal precision (underflow) during `num.minus(startlim, start)`, which caused the downstream values to be incorrect.  This resulted in operations where `num.quot(startdiff, step)` and/or `num.quot(enddiff, step)` were dividing a "larger number" by a "very small number" e.g. (1E-34/1E-64) where the result was larger than Int.MaxValue.

Fixes scala/bug#12073

review by @szeiger 
review by @Ichoran 
review by @lrytz 