### PR TITLE
Issue “does nothing other than call itself recursively” warning in more cases

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1147,9 +1147,9 @@ abstract class RefChecks extends Transform {
     // scala/bug#6276 warn for trivial recursion, such as `def foo = foo` or `val bar: X = bar`, which come up more frequently than you might think.
     // TODO: Move to abide rule. Also, this does not check that the def is final or not overridden, for example
     def checkInfiniteLoop(sym: Symbol, rhs: Tree): Unit =
-      if (!sym.isValueParameter && sym.paramss.isEmpty) {
+      if (!sym.isValueParameter && sym.paramss.forall(_.isEmpty)) {
         rhs match {
-          case t@(Ident(_) | Select(This(_), _)) if t hasSymbolWhich (_.accessedOrSelf == sym) =>
+          case Ident(_) | Select(This(_), _) | Apply(Select(This(_), _), _) if rhs hasSymbolWhich (_.accessedOrSelf == sym) =>
             refchecksWarning(rhs.pos, s"${sym.fullLocationString} does nothing other than call itself recursively", WarningCategory.Other)
           case _ =>
         }

--- a/test/files/neg/t6276.check
+++ b/test/files/neg/t6276.check
@@ -10,12 +10,16 @@ t6276.scala:9: warning: method c in class C does nothing other than call itself 
 t6276.scala:10: warning: method d in class C does nothing other than call itself recursively
       def d: Any = C.this.d // warn
                           ^
-t6276.scala:15: warning: method a does nothing other than call itself recursively
+t6276.scala:11: warning: method e in class C does nothing other than call itself recursively
+      def e(): Any = e //warn
+                     ^
+t6276.scala:16: warning: method a does nothing other than call itself recursively
       def a: Any = a // warn
                    ^
-t6276.scala:24: warning: method a does nothing other than call itself recursively
+t6276.scala:25: warning: method a does nothing other than call itself recursively
       def a = a // warn
               ^
+warning: 1 deprecation (since 2.13.3); re-run with -deprecation for details
 error: No warnings can be incurred under -Werror.
-6 warnings
+8 warnings
 1 error

--- a/test/files/neg/t6276.scala
+++ b/test/files/neg/t6276.scala
@@ -8,6 +8,7 @@ object Test {
 
       def c: Any = this.c // warn
       def d: Any = C.this.d // warn
+      def e(): Any = e //warn
     }
 
     def method: Unit = {


### PR DESCRIPTION
Fixes scala/bug#11614 by adding a recursive warning to functions with empty parentheses, covering a method with an apply.
