### PR TITLE
Add restarr/restarrFull custom commands

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1362,7 +1362,8 @@ lazy val root: Project = (project in file("."))
   .aggregate(library, reflect, compiler, compilerOptionsExporter, interactive, repl, replJline, replJlineEmbedded,
     scaladoc, scalap, partestExtras, junit, libraryAll, scalaDist).settings(
     sources in Compile := Seq.empty,
-    onLoadMessage := """|*** Welcome to the sbt build definition for Scala! ***
+    onLoadMessage := s"""|*** Welcome to the sbt build definition for Scala! ***
+      |version=${(Global / version).value} scalaVersion=${(Global / scalaVersion).value}
       |Check README.md for more information.""".stripMargin
   )
 

--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -183,15 +183,18 @@ object VersionUtil {
     propFile
   }
 
-  /** The global versions.properties data */
-  lazy val versionProps: Map[String, String] = {
+  private[build] def readProps(f: File): Map[String, String] = {
     val props = new Properties()
-    val in = new FileInputStream(file("versions.properties"))
+    val in = new FileInputStream(f)
     try props.load(in)
     finally in.close()
-    props.asScala.toMap.map {
-      case (k, v) => (k, sys.props.getOrElse(k, v)) // allow system properties to override versions.properties
-    }
+    props.asScala.toMap
+  }
+
+  /** The global versions.properties data */
+  lazy val versionProps: Map[String, String] = {
+    val versionProps = readProps(file("versions.properties"))
+    versionProps.map { case (k, v) => (k, sys.props.getOrElse(k, v)) } // allow sys props to override versions.properties
   }
 
   /** Get a subproject version number from `versionProps` */


### PR DESCRIPTION
* `restarr`: sets `scalaVersion` to the version in `/buildcharacter.properties` or the given arg.
* `restarrFull`: publishes locally (without optimizing) & then sets the new `scalaVersion`.