### PR TITLE
Fix "a pure expression does nothing" in synthetic REPL code

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -923,7 +923,7 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
            |object ${lineRep.evalName} {
            |  ${if (resValSym != NoSymbol) s"lazy val ${lineRep.resultName} = ${originalPath(resValSym)}" else ""}
            |  lazy val ${lineRep.printName}: _root_.java.lang.String = $executionWrapper {
-           |    $fullAccessPath
+           |    val _ = $fullAccessPath
            |""".stripMargin)
         if (contributors.lengthCompare(1) > 0) {
           code.println("val sb = new _root_.scala.StringBuilder")

--- a/test/files/run/repl-any-error.check
+++ b/test/files/run/repl-any-error.check
@@ -1,0 +1,5 @@
+
+scala> 42
+val res0: Int = 42
+
+scala> :quit

--- a/test/files/run/repl-any-error.scala
+++ b/test/files/run/repl-any-error.scala
@@ -1,0 +1,9 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def extraSettings = "-Wconf:any:error"
+
+  def code = """
+42
+  """.trim
+}

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -266,7 +266,7 @@ package $line10 {
 object $eval {
   lazy val $result = $line10.$read.INSTANCE.$iw.res3
   lazy val $print: _root_.java.lang.String =  {
-    $line10.$read.INSTANCE.$iw
+    val _ = $line10.$read.INSTANCE.$iw
 
 ""  + "val res3: List[Product with java.io.Serializable]" + " = " + _root_.scala.runtime.ScalaRunTime.replStringOf($line10.$read.INSTANCE.$iw.res3, 1000)
 


### PR DESCRIPTION
So this was originally reported to sbt as https://github.com/sbt/sbt/issues/5733.

When you invoke repl with "-Wconf:any:error" currently you get

```scala
           $line3.$read.INSTANCE.$iw
                                 ^
<synthetic>:6: error: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses

(To diagnose errors in synthetic code, try adding `// show` to the end of your input.)
```

I'm guessing this goes back all the way to 2006? (https://github.com/scala/scala/commit/01443e42ed009c7125fe5b5c07ec20ff5eadbd17#diff-6eef86d28757da64bbaee0b568952750R332) but it's now surfaced.

<s>This fixes that by putting it into `val _`.</s>

This fixes this behavior by exempting synthetic-looking things from the "pure expression" warnings.
