### PR TITLE
Fix exhaustivity uncheckableType's logic for tuples

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -213,9 +213,10 @@ trait TreeAndTypeAnalysis extends Debugging {
     // a type is "uncheckable" (for exhaustivity) if we don't statically know its subtypes (i.e., it's unsealed)
     // we consider tuple types with at least one component of a checkable type as a checkable type
     def uncheckableType(tp: Type): Boolean = {
-      val checkable = (
-           (isTupleType(tp) && tupleComponents(tp).exists(tp => !uncheckableType(tp)))
-        || enumerateSubtypes(tp, grouped = false).nonEmpty)
+      val checkable = {
+        if (isTupleType(tp)) tupleComponents(tp).exists(tp => !uncheckableType(tp))
+        else enumerateSubtypes(tp, grouped = false).nonEmpty
+      }
       // if (!checkable) debug.patmat("deemed uncheckable: "+ tp)
       !checkable
     }

--- a/test/files/pos/t10373.flags
+++ b/test/files/pos/t10373.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/pos/t10373.scala
+++ b/test/files/pos/t10373.scala
@@ -1,0 +1,15 @@
+abstract class Foo {
+    def bar(): Unit = this match {
+        case Foo_1() => //do something
+        case Foo_2() => //do something
+        // Works fine
+    }
+
+    def baz(that: Foo): Unit = (this, that) match {
+        case (Foo_1(), _) => //do something
+        case (Foo_2(), _) => //do something
+        // match may not be exhaustive
+    }
+}
+case class Foo_1() extends Foo
+case class Foo_2() extends Foo


### PR DESCRIPTION
As tuples (e.g. Tuple2) are case classes, for which `enumerateSubtypes`
returns `List(List(tp))` therefore making it "checkable", any tuple type
was accidentally always passing (or at least it has since that `isCase`
branch was added to `enumerateSubtypes`).  This was leading to false
positives in the exhaustivity checking, as a tuple of non-sealed types
was being deemed inexhaustive with a wildcard `(_, _)` counter-example.

Fixes scala/bug#10373