### PR TITLE
Predef.unit to workaround "a pure expression does nothing"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -398,6 +398,8 @@ val mimaFilterSettings = Seq {
     // Fix for scala/bug#12059
     ProblemFilters.exclude[MissingClassProblem](s"scala.collection.MapView$$Keys"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.MapView$Values"),
+
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Predef.unit"),
   ),
 }
 

--- a/src/compiler/scala/tools/reflect/FastPredefUnit.scala
+++ b/src/compiler/scala/tools/reflect/FastPredefUnit.scala
@@ -1,0 +1,31 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.reflect
+
+import scala.reflect.macros.runtime.Context
+
+trait FastPredefUnit {
+  val c: Context
+  val global: c.universe.type = c.universe
+
+  import c.universe._
+  import treeInfo.Applied
+
+  def expandPredefUnit: Tree = c.macroApplication match {
+    case Applied(_, _, List(List(arg))) =>
+      q"""_root_.scala.Predef.locally { val _ = $arg }"""
+    case other =>
+      global.abort(s"Unexpected application ${showRaw(other)}")
+      other
+  }
+}

--- a/src/compiler/scala/tools/reflect/FastTrack.scala
+++ b/src/compiler/scala/tools/reflect/FastTrack.scala
@@ -39,6 +39,8 @@ class FastTrack[MacrosAndAnalyzer <: Macros with Analyzer](val macros: MacrosAnd
     new { val c: c0.type = c0 } with FastStringInterpolator
   private implicit def context2quasiquote(c0: MacroContext): QuasiquoteImpls { val c: c0.type } =
     new { val c: c0.type = c0 } with QuasiquoteImpls
+  private implicit def context2fastpredefunit(c0: MacroContext): FastPredefUnit { val c: c0.type } =
+    new { val c: c0.type = c0 } with FastPredefUnit
   private def makeBlackbox(sym: Symbol)(pf: PartialFunction[Applied, MacroContext => Tree]) =
     sym -> new FastTrackEntry(pf, isBlackbox = true)
   private def makeWhitebox(sym: Symbol)(pf: PartialFunction[Applied, MacroContext => Tree]) =
@@ -65,6 +67,7 @@ class FastTrack[MacrosAndAnalyzer <: Macros with Analyzer](val macros: MacrosAnd
       makeBlackbox(            StringContext_f) { case _                                          => _.interpolateF },
       makeBlackbox(            StringContext_s) { case _                                          => _.interpolateS },
       makeBlackbox(            StringContext_raw) { case _                                        => _.interpolateRaw },
+      makeBlackbox(                Predef_unit) { case _                                          => _.expandPredefUnit },
       makeBlackbox(ReflectRuntimeCurrentMirror) { case _                                          => c => currentMirror(c).tree },
       makeWhitebox(  QuasiquoteClass_api_apply) { case _                                          => _.expandQuasiquote },
       makeWhitebox(QuasiquoteClass_api_unapply) { case _                                          => _.expandQuasiquote }

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -346,6 +346,14 @@ object Predef extends LowPriorityImplicits {
    */
   def ??? : Nothing = throw new NotImplementedError
 
+  /** `unit` is used to force the evaluation of a side-effecting non-Unit expression
+   * while avoiding "a pure expression does nothing in statement position" warning.
+   *
+   *  @param value the expression to evaluate.
+   *  @group utilities
+   */
+  @inline final def unit(value: Any): Unit = ()
+
   // implicit classes -----------------------------------------------------
 
   /** @group implicit-classes-any */

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -13,6 +13,7 @@
 package scala
 
 import scala.language.implicitConversions
+import scala.language.experimental.macros
 
 import scala.collection.{mutable, immutable, ArrayOps, StringOps}, immutable.WrappedString
 import scala.annotation.{elidable, implicitNotFound}, elidable.ASSERTION
@@ -352,7 +353,7 @@ object Predef extends LowPriorityImplicits {
    *  @param value the expression to evaluate.
    *  @group utilities
    */
-  @inline final def unit(value: Any): Unit = ()
+  @inline final def unit(value: Any): Unit = macro ???
 
   // implicit classes -----------------------------------------------------
 

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1728,6 +1728,7 @@ trait Definitions extends api.StandardDefinitions {
       lazy val Predef_implicitly   = getMemberMethod(PredefModule, nme.implicitly)
       lazy val Predef_???          = DefinitionsClass.this.Predef_???
       lazy val Predef_any2stringaddMethod = getMemberMethod(PredefModule, nme.any2stringadd).suchThat(_.isMethod)
+      lazy val Predef_unit         = getMemberMethod(PredefModule, TermName("unit"))
 
       lazy val arrayApplyMethod       = getMemberMethod(ScalaRunTimeModule, nme.array_apply)
       lazy val arrayUpdateMethod      = getMemberMethod(ScalaRunTimeModule, nme.array_update)

--- a/test/files/run/predef-unit.check
+++ b/test/files/run/predef-unit.check
@@ -1,0 +1,2 @@
+flip pancake
+flop pancake

--- a/test/files/run/predef-unit.scala
+++ b/test/files/run/predef-unit.scala
@@ -1,0 +1,28 @@
+// scalac: -Werror -language:_
+
+object Test extends AnyRef with App {
+  lazy val task1 = new AnyRef {
+    val value: Int = {
+      println("flip pancake")
+      0
+    }
+  }
+
+  lazy val task2 = new AnyRef {
+    val value: Int = {
+      println("flop pancake")
+      0
+    }
+  }
+
+  def use() =
+    try {
+      unit(task1.value)
+      unit(task2.value)
+      ()
+    } catch {
+      case _: Throwable => ()
+    }
+
+  use()
+}


### PR DESCRIPTION
For some reason, in the recent releases "a pure expression does nothing in statement position" has gotten more accurate. Maybe because it moved to RefCheck in #8995?

Regardless, it's sometimes tricky to write `build.sbt` because often I would need to invoke multiple tasks such as `compile.value` and `copyResources.value` without using the return value, and it would cause "a pure expression does nothing in statement position" error.

The partest in the commit for example fails as follows without `unit(...)`:

```scala
predef-unit.scala:20: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
      task1.value
            ^
predef-unit.scala:21: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
      task2.value
            ^
error: No warnings can be incurred under -Werror.
2 warnings
1 error
```

As a workaround I propose `Predef.unit(a: Any): Unit = ()`, which forces the evaluation but discards it and returns the unit value, which the compiler seems to be happy with.

This seems to be a common occurrence since people have suggested various creative solutions in reply to https://twitter.com/eed3si9n/status/1293272725415505921.


```scala
(compile.value, ())._2

locally { val _ = compile.value }
```

https://github.com/AVSystem/scala-commons/blob/87c92cfcf5cbbd183fe5d77a841352b4e58ece39/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala#L81

```scala
  class UniversalOps[A](private val a: A) extends AnyVal {
    /**
      * Explicit syntax to discard the value of a side-effecting expression.
      * Useful when `-Ywarn-value-discard` compiler option is enabled.
      */
    @silent
    def discard: Unit = ()
  }
```
