### PR TITLE
Add missing @serialversionuid on collections

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -25,6 +25,9 @@ object MimaFilters extends AutoPlugin {
 
     // #9314 #9315 #9507 NewRedBlackTree is private[collection]
     ProblemFilters.exclude[Problem]("scala.collection.immutable.NewRedBlackTree*"),
+
+    // #9166 add missing serialVersionUID
+    ProblemFilters.exclude[MissingFieldProblem]("*.serialVersionUID"),
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/collection/MapLike.scala
+++ b/src/library/scala/collection/MapLike.scala
@@ -172,6 +172,7 @@ self =>
 
   /** The implementation class of the set returned by `keySet`.
    */
+  @SerialVersionUID(1589106351530299313L)
   protected class DefaultKeySet extends AbstractSet[K] with Set[K] with Serializable {
     def contains(key : K) = self.contains(key)
     def iterator = keysIterator

--- a/src/library/scala/collection/SortedMapLike.scala
+++ b/src/library/scala/collection/SortedMapLike.scala
@@ -36,6 +36,7 @@ self =>
 
   override def keySet : SortedSet[A] = new DefaultKeySortedSet
 
+  @SerialVersionUID(-38666158592954763L)
   protected class DefaultKeySortedSet extends super.DefaultKeySet with SortedSet[A] {
     implicit def ordering = self.ordering
     override def + (elem: A): SortedSet[A] = (SortedSet[A]() ++ this + elem)

--- a/src/library/scala/collection/convert/Wrappers.scala
+++ b/src/library/scala/collection/convert/Wrappers.scala
@@ -27,6 +27,7 @@ private[collection] trait Wrappers {
     override def isEmpty = underlying.isEmpty
   }
 
+  @SerialVersionUID(7914730360012802566L)
   case class IteratorWrapper[A](underlying: Iterator[A]) extends ju.Iterator[A] with ju.Enumeration[A] {
     def hasNext = underlying.hasNext
     def next() = underlying.next()
@@ -39,23 +40,28 @@ private[collection] trait Wrappers {
     def asJava = new IteratorWrapper(underlying)
   }
 
+  @SerialVersionUID(-2624079708378729299L)
   case class JIteratorWrapper[A](underlying: ju.Iterator[A]) extends AbstractIterator[A] with Iterator[A] {
     def hasNext = underlying.hasNext
     def next() = underlying.next
   }
 
+  @SerialVersionUID(1480199642890917878L)
   case class JEnumerationWrapper[A](underlying: ju.Enumeration[A]) extends AbstractIterator[A] with Iterator[A] {
     def hasNext = underlying.hasMoreElements
     def next() = underlying.nextElement
   }
 
+  @SerialVersionUID(8702516763061989735L)
   case class IterableWrapper[A](underlying: Iterable[A]) extends ju.AbstractCollection[A] with IterableWrapperTrait[A] { }
 
+  @SerialVersionUID(4914368587801013118L)
   case class JIterableWrapper[A](underlying: jl.Iterable[A]) extends AbstractIterable[A] with Iterable[A] {
     def iterator = underlying.iterator
     def newBuilder[B] = new mutable.ArrayBuffer[B]
   }
 
+  @SerialVersionUID(-9156669203906593803L)
   case class JCollectionWrapper[A](underlying: ju.Collection[A]) extends AbstractIterable[A] with Iterable[A] {
     def iterator = underlying.iterator
     override def size = underlying.size
@@ -63,10 +69,12 @@ private[collection] trait Wrappers {
     def newBuilder[B] = new mutable.ArrayBuffer[B]
   }
 
+  @SerialVersionUID(-2066086677605085135L)
   case class SeqWrapper[A](underlying: Seq[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] {
     def get(i: Int) = underlying(i)
   }
 
+  @SerialVersionUID(-3277343097189933650L)
   case class MutableSeqWrapper[A](underlying: mutable.Seq[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] {
     def get(i: Int) = underlying(i)
     override def set(i: Int, elem: A) = {
@@ -76,6 +84,7 @@ private[collection] trait Wrappers {
     }
   }
 
+  @SerialVersionUID(2065310383330290590L)
   case class MutableBufferWrapper[A](underlying: mutable.Buffer[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] {
     def get(i: Int) = underlying(i)
     override def set(i: Int, elem: A) = { val p = underlying(i); underlying(i) = elem; p }
@@ -83,6 +92,7 @@ private[collection] trait Wrappers {
     override def remove(i: Int) = underlying remove i
   }
 
+  @SerialVersionUID(-7340917072424655477L)
   case class JListWrapper[A](underlying: ju.List[A]) extends mutable.AbstractBuffer[A] with mutable.Buffer[A] {
     def length = underlying.size
     override def isEmpty = underlying.isEmpty
@@ -132,6 +142,7 @@ private[collection] trait Wrappers {
     }
   }
 
+  @SerialVersionUID(-4801553198679985982L)
   case class MutableSetWrapper[A](underlying: mutable.Set[A]) extends SetWrapper[A](underlying) {
     override def add(elem: A) = {
       val sz = underlying.size
@@ -144,6 +155,7 @@ private[collection] trait Wrappers {
     override def clear() = underlying.clear()
   }
 
+  @SerialVersionUID(-8813164664953372494L)
   case class JSetWrapper[A](underlying: ju.Set[A]) extends mutable.AbstractSet[A] with mutable.Set[A] with mutable.SetLike[A, JSetWrapper[A]] {
 
     override def size = underlying.size
@@ -240,6 +252,7 @@ private[collection] trait Wrappers {
     }
   }
 
+  @SerialVersionUID(8668425014051911127L)
   case class MutableMapWrapper[A, B](underlying: mutable.Map[A, B]) extends MapWrapper[A, B](underlying) {
     override def put(k: A, v: B) = underlying.put(k, v) match {
       case Some(v1) => v1
@@ -300,10 +313,12 @@ private[collection] trait Wrappers {
     * This includes `get`, as `java.util.Map`'s API does not allow for an
     * atomic `get` when `null` values may be present.
     */
+  @SerialVersionUID(5258955232187049103L)
   case class JMapWrapper[A, B](underlying : ju.Map[A, B]) extends mutable.AbstractMap[A, B] with JMapWrapperLike[A, B, JMapWrapper[A, B]] {
     override def empty = JMapWrapper(new ju.HashMap[A, B])
   }
 
+  @SerialVersionUID(3929791676502269860L)
   class ConcurrentMapWrapper[A, B](override val underlying: concurrent.Map[A, B]) extends MutableMapWrapper[A, B](underlying) with juc.ConcurrentMap[A, B] {
 
     override def putIfAbsent(k: A, v: B) = underlying.putIfAbsent(k, v) match {
@@ -330,6 +345,7 @@ private[collection] trait Wrappers {
     * access is supported; multi-element operations such as maps and filters
     * are not guaranteed to be atomic.
     */
+  @SerialVersionUID(-8245743033724996882L)
   case class JConcurrentMapWrapper[A, B](underlying: juc.ConcurrentMap[A, B]) extends mutable.AbstractMap[A, B] with JMapWrapperLike[A, B, JConcurrentMapWrapper[A, B]] with concurrent.Map[A, B] {
     override def get(k: A) = Option(underlying get k)
 
@@ -345,6 +361,7 @@ private[collection] trait Wrappers {
       underlying.replace(k, oldvalue, newvalue)
   }
 
+  @SerialVersionUID(942915481780293390L)
   case class DictionaryWrapper[A, B](underlying: mutable.Map[A, B]) extends ju.Dictionary[A, B] {
     def size: Int = underlying.size
     def isEmpty: Boolean = underlying.isEmpty
@@ -372,6 +389,7 @@ private[collection] trait Wrappers {
     }
   }
 
+  @SerialVersionUID(-5214182838863307389L)
   case class JDictionaryWrapper[A, B](underlying: ju.Dictionary[A, B]) extends mutable.AbstractMap[A, B] with mutable.Map[A, B] {
     override def size: Int = underlying.size
 
@@ -391,6 +409,7 @@ private[collection] trait Wrappers {
     override def clear() = underlying.clear()
   }
 
+  @SerialVersionUID(1265445269473530406L)
   case class JPropertiesWrapper(underlying: ju.Properties) extends mutable.AbstractMap[String, String]
             with mutable.Map[String, String]
             with mutable.MapLike[String, String, JPropertiesWrapper] {

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -123,6 +123,7 @@ object BitSet extends BitSetFactory[BitSet] {
       else new BitSet1(elems - java.lang.Long.lowestOneBit(elems))
   }
 
+  @SerialVersionUID(-860417644893387539L)
   class BitSet2(val elems0: Long, elems1: Long) extends BitSet {
     protected def nwords = 2
     protected def word(idx: Int) = if (idx == 0) elems0 else if (idx == 1) elems1 else 0L
@@ -150,6 +151,7 @@ object BitSet extends BitSetFactory[BitSet] {
    *  implementation. Care needs to be taken not to modify the exposed
    *  array.
    */
+  @SerialVersionUID(807040099560956194L)
   class BitSetN(val elems: Array[Long]) extends BitSet {
     protected def nwords = elems.length
     protected def word(idx: Int) = if (idx < nwords) elems(idx) else 0L

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -347,6 +347,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
   }
 
   @deprecatedInheritance("This class will be made final in a future release.", "2.12.2")
+  @SerialVersionUID(4549809275616486327L)
   class HashMap1[A,+B](private[collection] val key: A, private[collection] val hash: Int, private[collection] val value: (B @uV), private[this] var kvOrNull: (A,B @uV)) extends HashMap[A,B] {
     override def size = 1
 
@@ -436,6 +437,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
     }
   }
 
+  @SerialVersionUID(-1917647429457579983L)
   private[collection] class HashMapCollision1[A, +B](private[collection] val hash: Int, val kvs: ListMap[A, B @uV])
           extends HashMap[A, B @uV] {
     // assert(kvs.size > 1)
@@ -551,6 +553,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
   }
 
   @deprecatedInheritance("This class will be made final in a future release.", "2.12.2")
+  @SerialVersionUID(834418348325321784L)
   class HashTrieMap[A, +B](
     private[HashMap] var bitmap0: Int,
     private[HashMap] var elems0: Array[HashMap[A, B @uV]],

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -259,8 +259,10 @@ object HashSet extends ImmutableSetFactory[HashSet] {
   /**
    * Common superclass of HashSet1 and HashSetCollision1, which are the two possible leaves of the Trie
    */
+  @SerialVersionUID(-8788235040812980474L)
   private[HashSet] sealed abstract class LeafHashSet[A](private[HashSet] final val hash: Int) extends HashSet[A]
 
+  @SerialVersionUID(7828248784025959392L)
   class HashSet1[A](private[HashSet] val key: A, hash: Int) extends LeafHashSet[A](hash) {
     override def size = 1
 
@@ -333,6 +335,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     override def foreach[U](f: A => U): Unit = f(key)
   }
 
+  @SerialVersionUID(-4499898620567995040L)
   private[immutable] class HashSetCollision1[A](hash: Int, val ks: ListSet[A],  override val size: Int) extends LeafHashSet[A](hash) {
 
     override protected def get0(key: A, hash: Int, level: Int): Boolean =
@@ -536,6 +539,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
    * elems: [a,b]
    * children:        ---b----------------a-----------
    */
+  @SerialVersionUID(-1260675327783828535L)
   class HashTrieSet[A](private[HashSet] var bitmap: Int, private[collection] var elems: Array[HashSet[A]], private[HashSet] var size0: Int)
         extends HashSet[A] {
     @inline override final def size = size0

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -64,6 +64,7 @@ object IntMap {
   def apply[T](elems: (Int, T)*): IntMap[T] =
     elems.foldLeft(empty[T])((x, y) => x.updated(y._1, y._2))
 
+  @SerialVersionUID(-9137650114085457282L)
   private[immutable] case object Nil extends IntMap[Nothing] {
     // Important! Without this equals method in place, an infinite
     // loop from Map.equals => size => pattern-match-on-Nil => equals
@@ -76,11 +77,13 @@ object IntMap {
     }
   }
 
+  @SerialVersionUID(3302720273753906158L)
   private[immutable] case class Tip[+T](key: Int, value: T) extends IntMap[T]{
     def withValue[S](s: S) =
       if (s.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) this.asInstanceOf[IntMap.Tip[S]]
       else IntMap.Tip(key, s)
   }
+  @SerialVersionUID(-523093388545197183L)
   private[immutable] case class Bin[+T](prefix: Int, mask: Int, left: IntMap[T], right: IntMap[T]) extends IntMap[T] {
     def bin[S](left: IntMap[S], right: IntMap[S]): IntMap[S] = {
       if ((this.left eq left) && (this.right eq right)) this.asInstanceOf[IntMap.Bin[S]]

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -62,6 +62,7 @@ object LongMap {
   def apply[T](elems: (Long, T)*): LongMap[T] =
     elems.foldLeft(empty[T])((x, y) => x.updated(y._1, y._2))
 
+@SerialVersionUID(1224320979026293120L)
   private[immutable] case object Nil extends LongMap[Nothing] {
     // Important, don't remove this! See IntMap for explanation.
     override def equals(that : Any) = that match {
@@ -71,11 +72,13 @@ object LongMap {
     }
   }
 
+@SerialVersionUID(4938010434684160500L)
   private[immutable] case class Tip[+T](key: Long, value: T) extends LongMap[T] {
     def withValue[S](s: S) =
       if (s.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) this.asInstanceOf[LongMap.Tip[S]]
       else LongMap.Tip(key, s)
   }
+@SerialVersionUID(2433491195925361636L)
   private[immutable] case class Bin[+T](prefix: Long, mask: Long, left: LongMap[T], right: LongMap[T]) extends LongMap[T] {
     def bin[S](left: LongMap[S], right: LongMap[S]): LongMap[S] = {
       if ((this.left eq left) && (this.right eq right)) this.asInstanceOf[LongMap.Bin[S]]

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -91,6 +91,7 @@ object Map extends ImmutableMapFactory[Map] {
 
   def empty[K, V]: Map[K, V] = EmptyMap.asInstanceOf[Map[K, V]]
 
+  @SerialVersionUID(-7464981207502461188L)
   class WithDefault[K, +V](underlying: Map[K, V], d: K => V) extends scala.collection.Map.WithDefault[K, V](underlying, d) with Map[K, V] {
     override def empty = new WithDefault(underlying.empty, d)
     override def updated[V1 >: V](key: K, value: V1): WithDefault[K, V1] = new WithDefault[K, V1](underlying.updated[V1](key, value), d)

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -39,6 +39,7 @@ package immutable
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@SerialVersionUID(-5580158174769432538L)
 abstract class NumericRange[T]
   (val start: T, val end: T, val step: T, val isInclusive: Boolean)
   (implicit num: Integral[T])
@@ -365,6 +366,7 @@ object NumericRange {
     }
   }
 
+  @SerialVersionUID(-5986512874781685419L)
   class Inclusive[T](start: T, end: T, step: T)(implicit num: Integral[T])
   extends NumericRange(start, end, step, true) {
     def copy(start: T, end: T, step: T): Inclusive[T] =
@@ -373,6 +375,7 @@ object NumericRange {
     def exclusive: Exclusive[T] = NumericRange(start, end, step)
   }
 
+  @SerialVersionUID(-7058074814271573640L)
   class Exclusive[T](start: T, end: T, step: T)(implicit num: Integral[T])
   extends NumericRange(start, end, step, false) {
     def copy(start: T, end: T, step: T): Exclusive[T] =

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -439,6 +439,7 @@ object Range {
   def count(start: Int, end: Int, step: Int): Int =
     count(start, end, step, isInclusive = false)
 
+  @SerialVersionUID(4237131469519710909L)
   final class Inclusive(start: Int, end: Int, step: Int) extends Range(start, end, step) {
 //    override def par = new ParRange(this)
     override def isInclusive = true

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -42,6 +42,7 @@ self =>
   override def updated [B1 >: B](key: A, value: B1): SortedMap[A, B1] = this + ((key, value))
   override def keySet: immutable.SortedSet[A] = new DefaultKeySortedSet
 
+  @SerialVersionUID(112809526508924148L)
   protected class DefaultKeySortedSet extends super.DefaultKeySortedSet with immutable.SortedSet[A] {
     override def + (elem: A): SortedSet[A] =
       if (this(elem)) this

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -22,6 +22,7 @@ import scala.reflect.ClassTag
  *
  *  @tparam T    the type of the elements for the builder.
  */
+@SerialVersionUID(-4721309866680431208L)
 abstract class ArrayBuilder[T] extends ReusableBuilder[T, Array[T]] with Serializable
 
 /** A companion object for array builders.
@@ -61,6 +62,7 @@ object ArrayBuilder {
    *
    *  @tparam T     type of elements for the array builder, subtype of `AnyRef` with a `ClassTag` context bound.
    */
+  @SerialVersionUID(-8376727444766075941L)
   final class ofRef[T <: AnyRef : ClassTag] extends ArrayBuilder[T] {
 
     private var elems: Array[T] = _
@@ -126,6 +128,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `byte`s. It can be reused. */
+  @SerialVersionUID(-3484148043254823366L)
   final class ofByte extends ArrayBuilder[Byte] {
 
     private var elems: Array[Byte] = _
@@ -191,6 +194,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `short`s. It can be reused. */
+  @SerialVersionUID(3295904306819377609L)
   final class ofShort extends ArrayBuilder[Short] {
 
     private var elems: Array[Short] = _
@@ -256,6 +260,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `char`s. It can be reused. */
+  @SerialVersionUID(-8284807600792805165L)
   final class ofChar extends ArrayBuilder[Char] {
 
     private var elems: Array[Char] = _
@@ -321,6 +326,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `int`s. It can be reused. */
+  @SerialVersionUID(-3033902589330485711L)
   final class ofInt extends ArrayBuilder[Int] {
 
     private var elems: Array[Int] = _
@@ -386,6 +392,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `long`s. It can be reused. */
+  @SerialVersionUID(-4278005356053656861L)
   final class ofLong extends ArrayBuilder[Long] {
 
     private var elems: Array[Long] = _
@@ -451,6 +458,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `float`s. It can be reused. */
+  @SerialVersionUID(-740775369715282824L)
   final class ofFloat extends ArrayBuilder[Float] {
 
     private var elems: Array[Float] = _
@@ -516,6 +524,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `double`s. It can be reused. */
+  @SerialVersionUID(2549152794429074790L)
   final class ofDouble extends ArrayBuilder[Double] {
 
     private var elems: Array[Double] = _
@@ -581,6 +590,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `boolean`s. It can be reused. */
+  @SerialVersionUID(-3574834070591819420L)
   class ofBoolean extends ArrayBuilder[Boolean] {
 
     private var elems: Array[Boolean] = _
@@ -646,6 +656,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `Unit` type. It can be reused. */
+  @SerialVersionUID(1995804197797796249L)
   final class ofUnit extends ArrayBuilder[Unit] {
 
     private var size: Int = 0

--- a/src/library/scala/collection/mutable/DefaultEntry.scala
+++ b/src/library/scala/collection/mutable/DefaultEntry.scala
@@ -17,6 +17,7 @@ package mutable
 /** Class used internally for default map model.
  *  @since 2.3
  */
+@SerialVersionUID(-3856907690109104385L)
 final class DefaultEntry[A, B](val key: A, var value: B)
       extends HashEntry[A, DefaultEntry[A, B]] with Serializable
 {

--- a/src/library/scala/collection/mutable/LinkedEntry.scala
+++ b/src/library/scala/collection/mutable/LinkedEntry.scala
@@ -17,6 +17,7 @@ package mutable
 /** Class for the linked hash map entry, used internally.
  *  @since 2.8
  */
+@SerialVersionUID(-2671939643954900582L)
 final class LinkedEntry[A, B](val key: A, var value: B)
       extends HashEntry[A, LinkedEntry[A, B]] with Serializable {
   var earlier: LinkedEntry[A, B] = null

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -143,6 +143,7 @@ object LinkedHashSet extends MutableSetFactory[LinkedHashSet] {
   /** Class for the linked hash set entry, used internally.
    *  @since 2.10
    */
+  @SerialVersionUID(6056749505994053009L)
   private[scala] final class Entry[A](val key: A) extends HashEntry[A, Entry[A]] with Serializable {
     var earlier: Entry[A] = null
     var later: Entry[A] = null

--- a/src/library/scala/collection/mutable/ListMap.scala
+++ b/src/library/scala/collection/mutable/ListMap.scala
@@ -38,6 +38,7 @@ import annotation.tailrec
  *  @define orderDependent
  *  @define orderDependentFold
  */
+@SerialVersionUID(-3362098515407812442L)
 class ListMap[A, B]
 extends AbstractMap[A, B]
    with Map[A, B]

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -36,6 +36,7 @@ import generic.CanBuildFrom
  *  rapidly as 2^30 is approached.
  *
  */
+@SerialVersionUID(3311432836435989440L)
 final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBufferSize: Int, initBlank: Boolean)
 extends AbstractMap[Long, V]
    with Map[Long, V]

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -64,6 +64,7 @@ object Map extends MutableMapFactory[Map] {
 
   def empty[K, V]: Map[K, V] = new HashMap[K, V]
 
+  @SerialVersionUID(3886083557164597477L)
   class WithDefault[K, V](underlying: Map[K, V], d: K => V) extends scala.collection.Map.WithDefault(underlying, d) with Map[K, V] {
     override def += (kv: (K, V)) = {underlying += kv; this}
     def -= (key: K) = {underlying -= key; this}

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -55,6 +55,7 @@ import generic._
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@SerialVersionUID(736425014438295802L)
 sealed class PriorityQueue[A](implicit val ord: Ordering[A])
    extends AbstractIterable[A]
       with Iterable[A]
@@ -67,6 +68,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
 {
   import ord._
 
+  @SerialVersionUID(3491656538574147683L)
   private class ResizableArrayAccess[A] extends AbstractSeq[A] with ResizableArray[A] with Serializable {
     def p_size0 = size0
     def p_size0_=(s: Int) = size0 = s

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -32,6 +32,7 @@ import generic._
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@SerialVersionUID(-5130636723247980089L)
 class Queue[A]
 extends MutableList[A]
    with LinearSeqOptimized[A, Queue[A]]

--- a/src/library/scala/collection/mutable/WeakHashMap.scala
+++ b/src/library/scala/collection/mutable/WeakHashMap.scala
@@ -42,6 +42,7 @@ import convert.Wrappers._
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@SerialVersionUID(-853182442555455877L)
 class WeakHashMap[A, B] extends JMapWrapper[A, B](new java.util.WeakHashMap)
 			   with JMapWrapperLike[A, B, WeakHashMap[A, B]] {
   override def empty = new WeakHashMap[A, B]

--- a/src/library/scala/collection/mutable/WrappedArray.scala
+++ b/src/library/scala/collection/mutable/WrappedArray.scala
@@ -186,6 +186,7 @@ object WrappedArray {
 
   def newBuilder[A]: Builder[A, IndexedSeq[A]] = new ArrayBuffer
 
+  @SerialVersionUID(3456489343829468865L)
   final class ofRef[T <: AnyRef](val array: Array[T]) extends WrappedArray[T] with Serializable {
     def elemTag = ClassTag[T](array.getClass.getComponentType)
     def length: Int = array.length
@@ -194,6 +195,7 @@ object WrappedArray {
     override def hashCode = MurmurHash3.wrappedArrayHash(array)
   }
 
+  @SerialVersionUID(-4502363748086738L)
   final class ofByte(val array: Array[Byte]) extends WrappedArray[Byte] with Serializable {
     def elemTag = ClassTag.Byte
     def length: Int = array.length
@@ -206,6 +208,7 @@ object WrappedArray {
     }
   }
 
+  @SerialVersionUID(3569089221887297170L)
   final class ofShort(val array: Array[Short]) extends WrappedArray[Short] with Serializable {
     def elemTag = ClassTag.Short
     def length: Int = array.length
@@ -218,6 +221,7 @@ object WrappedArray {
     }
   }
 
+  @SerialVersionUID(4353470320490138993L)
   final class ofChar(val array: Array[Char]) extends WrappedArray[Char] with Serializable {
     def elemTag = ClassTag.Char
     def length: Int = array.length
@@ -230,6 +234,7 @@ object WrappedArray {
     }
   }
 
+  @SerialVersionUID(-3796494337148298008L)
   final class ofInt(val array: Array[Int]) extends WrappedArray[Int] with Serializable {
     def elemTag = ClassTag.Int
     def length: Int = array.length
@@ -242,6 +247,7 @@ object WrappedArray {
     }
   }
 
+  @SerialVersionUID(7604729449860217276L)
   final class ofLong(val array: Array[Long]) extends WrappedArray[Long] with Serializable {
     def elemTag = ClassTag.Long
     def length: Int = array.length
@@ -254,6 +260,7 @@ object WrappedArray {
     }
   }
 
+  @SerialVersionUID(-5070075925231686368L)
   final class ofFloat(val array: Array[Float]) extends WrappedArray[Float] with Serializable {
     def elemTag = ClassTag.Float
     def length: Int = array.length
@@ -266,6 +273,7 @@ object WrappedArray {
     }
   }
 
+  @SerialVersionUID(6556610635003622495L)
   final class ofDouble(val array: Array[Double]) extends WrappedArray[Double] with Serializable {
     def elemTag = ClassTag.Double
     def length: Int = array.length
@@ -278,6 +286,7 @@ object WrappedArray {
     }
   }
 
+  @SerialVersionUID(-4835600351252182105L)
   final class ofBoolean(val array: Array[Boolean]) extends WrappedArray[Boolean] with Serializable {
     def elemTag = ClassTag.Boolean
     def length: Int = array.length
@@ -290,6 +299,7 @@ object WrappedArray {
     }
   }
 
+  @SerialVersionUID(3443664051778905707L)
   final class ofUnit(val array: Array[Unit]) extends WrappedArray[Unit] with Serializable {
     def elemTag = ClassTag.Unit
     def length: Int = array.length


### PR DESCRIPTION
Hi 👋 

I recently stumbled upon https://github.com/scala/bug/issues/5046 while trying to run some scala jobs on Flink. I see that this made it to 2.13 but Flink still runs 2.11/2.12 and per @SethTisue [comment](https://github.com/scala/bug/issues/5046#issuecomment-662011066) I backported some of the changes.

Also, per @lrytz https://github.com/scala/collection-strawman/issues/418 i thought I could set the new `@SerialVersionUID` to `2L` and keep the already set ones as is.

Let me know what you think! Thanks!