### PR TITLE
Propagate type of bind tree

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4615,7 +4615,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             // since body1 is not necessarily equal to body, we must return a copied tree,
             // but we must still mutate the original bind
             tree setSymbol sym
-            treeCopy.Bind(tree, name, body1) setSymbol sym setType body1.tpe
+            treeCopy.Bind(tree, name, body1) setSymbol sym setType impliedType
         }
 
       def typedArrayValue(tree: ArrayValue) = {

--- a/test/files/neg/t11938.check
+++ b/test/files/neg/t11938.check
@@ -1,0 +1,11 @@
+t11938.scala:4: error: type mismatch;
+ found   : n.type (with underlying type Any)
+ required: scala.collection.immutable.Nil.type
+  val a: Nil.type = (Vector(): Any) match { case n @ Nil       => n } // error
+                                                                  ^
+t11938.scala:5: error: type mismatch;
+ found   : n.type (with underlying type Any)
+ required: scala.collection.immutable.Nil.type
+  val b: Nil.type = (Vector(): Any) match { case n @ (m @ Nil) => n } // error was: CCE
+                                                                  ^
+2 errors

--- a/test/files/neg/t11938.scala
+++ b/test/files/neg/t11938.scala
@@ -1,0 +1,6 @@
+// scalac: -Xlint -Werror
+
+class Test {
+  val a: Nil.type = (Vector(): Any) match { case n @ Nil       => n } // error
+  val b: Nil.type = (Vector(): Any) match { case n @ (m @ Nil) => n } // error was: CCE
+}


### PR DESCRIPTION
After inferring type of Bind for equals semantics,
use it for the tree type so enclosing binds know
about it.

Fixes scala/bug#11938
Resubmit of #8874, without the literal numbers complication.