### PR TITLE
Set the tpt of extension methods' DefDef explicitly

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -145,14 +145,14 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
               .changeOwner(origMeth, extensionMeth)
             new SubstututeRecursion(origMeth, extensionMeth, unit).transform(tree)
           }
-          val castBody =
-            if (extensionBody.tpe <:< extensionMono.finalResultType)
-              extensionBody
-            else
-              gen.mkCastPreservingAnnotations(extensionBody, extensionMono.finalResultType) // scala/bug#7818 e.g. mismatched existential skolems
+
+          val resultType = extensionMono.finalResultType
+          val castBody = // scala/bug#7818 e.g. mismatched existential skolems
+            if (extensionBody.tpe <:< resultType) extensionBody
+            else gen.mkCastPreservingAnnotations(extensionBody, resultType)
 
           // Record the extension method. Later, in `Extender#transformStats`, these will be added to the companion object.
-          extensionDefs(companion) += DefDef(extensionMeth, castBody)
+          extensionDefs(companion) += newDefDef(extensionMeth, castBody)(tpt = TypeTree(resultType))
 
           // These three lines are assembling Foo.bar$extension[T1, T2, ...]($this)
           // which leaves the actual argument application for extensionCall.

--- a/test/files/pos/t12028.scala
+++ b/test/files/pos/t12028.scala
@@ -1,0 +1,12 @@
+import scala.annotation.unchecked.uncheckedVariance
+
+object Test {
+  trait TypeClass[F[_]] {
+    def action[A](foo: F[A], bar: F[A]): F[A]
+  }
+
+  class Syntax[F[+_], A](private val foo: F[A]) extends AnyVal {
+    def action[F1[+x] >: F[x] @uncheckedVariance](bar: F1[A])(implicit tc: TypeClass[F1]): F1[A] =
+      tc.action[A](foo, bar)
+  }
+}


### PR DESCRIPTION
The default `tpt` is computed from the method symbol
by mapping with`AsSeenFromMap` which extends `KeepOnlyTypeConstraints`.
This drops the `@uncheckedVariance` annotation,
which in turn alters the bound of a type parameter,
which in turn causes the creation of a new type parameter,
which in turn alters the method result type.

Also this will be a tad more efficient 🤗 
Fixes scala/bug#12028

Question: why does `AsSeenFromMap` extend `KeepOnlyTypeConstraints`?