### PR TITLE
[reverted] Dealias when necessary to substitute symbols

### DIFF
--- a/test/files/pos/t11383.scala
+++ b/test/files/pos/t11383.scala
@@ -1,0 +1,7 @@
+object Test {
+  trait DepFn[A] { type B; def apply(a: A): B }
+  object DepFn { type Aux[A, C] = DepFn[A] { type B = C } }
+  class Syntax(val i: Int) extends AnyVal {
+    def foo[A](e: Either[Int => A, DepFn.Aux[Int, A]]) = e.fold(_(i), _(i))
+  }
+}

--- a/test/files/pos/t9222.scala
+++ b/test/files/pos/t9222.scala
@@ -1,0 +1,10 @@
+object Test {
+  trait Elem {
+    type Peer
+  }
+
+  trait Impl[E[x] <: Elem { type Peer = x }] {
+    def foo[R](peer: E[R]#Peer) = ()
+    foo[Int](??? : E[Int]#Peer)
+  }
+}


### PR DESCRIPTION
Symbols that we want to substitute might hide behind type aliases,
causing type mismatch errors down the line.
This is easily reproduced with extension methods.

I'm not sure if this is the right solution, but it's the only one I could find.

Fixes scala/bug#9222
Fixes scala/bug#11383