### PR TITLE
Avoid NPE in typedFunction with inferred parameters

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3109,7 +3109,14 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           // (based on where the function's parameter is applied to `meth`)
           val formalsFromApply =
             vparams.map { vd =>
-              if (!vd.tpt.isEmpty) Right(vd.tpt.tpe)
+              if (!vd.tpt.isEmpty) {
+                if (!vd.tpt.isTyped) {
+                  val vd1 = typedValDef(vd)
+                  if (vd1.isErroneous) Left(-1)
+                  else Right(vd1.tpt.tpe)
+                }
+                else Right(vd.tpt.tpe)
+              }
               else Left(args.indexWhere {
                 case Ident(name) => name == vd.name
                 case _           => false // TODO: this does not catch eta-expansion of an overloaded method that involves numeric widening scala/bug#9738 (and maybe similar patterns?)

--- a/test/files/neg/t12122.check
+++ b/test/files/neg/t12122.check
@@ -1,0 +1,9 @@
+t12122.scala:4: error: type mismatch;
+ found   : String
+ required: Int
+  def g = (i: String, s) => f(i, s)
+                              ^
+t12122.scala:9: error: not found: type Junk
+  def g = (i: Junk, s) => f(i, s)
+              ^
+2 errors

--- a/test/files/neg/t12122.scala
+++ b/test/files/neg/t12122.scala
@@ -1,0 +1,10 @@
+
+class C {
+  def f(i: Int, s: String) = s * i
+  def g = (i: String, s) => f(i, s)
+}
+
+class D {
+  def f(i: Int, s: String) = s * i
+  def g = (i: Junk, s) => f(i, s)
+}

--- a/test/files/pos/t12122.scala
+++ b/test/files/pos/t12122.scala
@@ -1,0 +1,5 @@
+
+class C {
+  def f(i: Int, s: String) = s * i
+  def g = (i: Int, s) => f(i, s)
+}


### PR DESCRIPTION
For `(x: T, y) => f(x, y)` where type of `y`
will be inferred from application, don't rely
on `T` if not yet typed.

Fixes scala/bug#12122