### PR TITLE
Move reflection-related utils from AssertUtil to new ReflectUtil.

### DIFF
--- a/src/testkit/scala/tools/testkit/ReflectUtil.scala
+++ b/src/testkit/scala/tools/testkit/ReflectUtil.scala
@@ -1,0 +1,36 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.testkit
+
+import scala.reflect.ClassTag
+import scala.util.chaining._
+import java.lang.reflect.{Array => _, _}
+
+/** This module contains reflection-related utilities.
+ *
+ *  This object contains methods that will not work on Scala.js nor Scala
+ *  Native, making any test using `ReflectUtil` JVM-only.
+ */
+object ReflectUtil {
+  private lazy val modsField = classOf[Field].getDeclaredField("modifiers").tap(_.setAccessible(true))
+
+  def getFieldAccessible[T: ClassTag](n: String): Field =
+    implicitly[ClassTag[T]]
+      .runtimeClass.getDeclaredField(n)
+      .tap { f =>
+        if ((f.getModifiers & Modifier.FINAL) != 0)
+          modsField.setInt(f, f.getModifiers() & ~Modifier.FINAL)
+        if ((f.getModifiers & Modifier.PUBLIC) == 0)
+          f.setAccessible(true)
+      }
+}

--- a/test/junit/scala/collection/immutable/IntMapTest.scala
+++ b/test/junit/scala/collection/immutable/IntMapTest.scala
@@ -17,7 +17,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testkit.AssertUtil.{getFieldAccessible => f}
+import scala.tools.testkit.ReflectUtil.{getFieldAccessible => f}
 
 @RunWith(classOf[JUnit4])
 class IntMapTest {

--- a/test/junit/scala/collection/immutable/LongMapTest.scala
+++ b/test/junit/scala/collection/immutable/LongMapTest.scala
@@ -17,7 +17,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.testkit.AssertUtil.{getFieldAccessible => f}
+import scala.tools.testkit.ReflectUtil.{getFieldAccessible => f}
 
 @RunWith(classOf[JUnit4])
 class LongMapTest {


### PR DESCRIPTION
This allows `AssertUtil` to link again on Scala.js.

Previously, the field of type `java.lang.Field` would pollute all of `AssertUtil`, preventing any test using any of the methods of `AssertUtil` from linking on Scala.js.