### PR TITLE
Handle NestedAnnotArg from Java sources

### DIFF
--- a/test/files/pos/t12133/I.java
+++ b/test/files/pos/t12133/I.java
@@ -1,0 +1,4 @@
+package pkg;
+
+@UniqueConstraint(columnNames = {"account_id_ok", "name"})
+public class I {}

--- a/test/files/pos/t12133/J.java
+++ b/test/files/pos/t12133/J.java
@@ -1,0 +1,4 @@
+package pkg;
+
+@Table(name = "portal", uniqueConstraints = @UniqueConstraint(columnNames = {"account_id_fk", "name"}))
+public class J {}

--- a/test/files/pos/t12133/Table.java
+++ b/test/files/pos/t12133/Table.java
@@ -1,0 +1,6 @@
+package pkg;
+
+public @interface Table {
+  String name();
+  UniqueConstraint[] uniqueConstraints();
+}

--- a/test/files/pos/t12133/UniqueConstraint.java
+++ b/test/files/pos/t12133/UniqueConstraint.java
@@ -1,0 +1,5 @@
+package pkg;
+
+public @interface UniqueConstraint {
+  String[] columnNames();
+}

--- a/test/files/pos/t12133/test.scala
+++ b/test/files/pos/t12133/test.scala
@@ -1,0 +1,4 @@
+class Test {
+  new pkg.I
+  new pkg.J
+}


### PR DESCRIPTION
Previously annotations in java sources were ignored.  Now that they're
parsed, some of the typer checks needed tweaks for the nested
annotations arguments case.

Fixes https://github.com/scala/bug/issues/12133

I incorrectly thought this was a parsing error for the longest time, so
I ran out of steam and submitting pretty much the first thing that made
the test case pass - so feedback welcome on how to strengthen the
change.