### PR TITLE
Avoid NPE after error

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -906,7 +906,7 @@ abstract class BTypes {
 
   final case class MethodBType(argumentTypes: Array[BType], returnType: BType) extends BType
 
-  object BTypeExporter {
+  object BTypeExporter extends AutoCloseable {
     private[this] val builderTL: ThreadLocal[StringBuilder] = new ThreadLocal[StringBuilder](){
       override protected def initialValue: StringBuilder = new StringBuilder(64)
     }

--- a/src/compiler/scala/tools/nsc/backend/jvm/ClassfileWriters.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/ClassfileWriters.scala
@@ -43,7 +43,7 @@ abstract class ClassfileWriters {
    *
    * Operations are threadsafe.
    */
-  sealed trait ClassfileWriter extends OutputFileWriter {
+  sealed trait ClassfileWriter extends OutputFileWriter with AutoCloseable {
     /**
      * Write a classfile
      */

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -102,11 +102,12 @@ abstract class GenBCode extends SubComponent {
       }
     }
 
-    private def close(): Unit = {
-      postProcessor.classfileWriter.close()
-      generatedClassHandler.close()
-      bTypes.BTypeExporter.close()
-    }
+    private def close(): Unit =
+      List[AutoCloseable](
+        postProcessor.classfileWriter,
+        generatedClassHandler,
+        bTypes.BTypeExporter,
+      ).filter(_ ne null).foreach(_.close())
   }
 }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
@@ -30,7 +30,7 @@ import scala.util.control.NonFatal
  * Interface to handle post-processing and classfile writing (see [[PostProcessor]]) of generated
  * classes, potentially in parallel.
  */
-private[jvm] sealed trait GeneratedClassHandler {
+private[jvm] sealed trait GeneratedClassHandler extends AutoCloseable {
   val postProcessor: PostProcessor
 
   /**

--- a/test/files/neg/t12134.check
+++ b/test/files/neg/t12134.check
@@ -1,0 +1,2 @@
+error: t12134-neg.obj/testy.jar (Permission denied)
+1 error

--- a/test/files/neg/t12134/ploogin_1.scala
+++ b/test/files/neg/t12134/ploogin_1.scala
@@ -1,0 +1,40 @@
+
+package t12134
+
+import scala.tools.nsc.{Global, Phase}
+import scala.tools.nsc.plugins.{Plugin, PluginComponent}
+
+import java.nio.file.Files.createFile
+import java.nio.file.Files.deleteIfExists
+import java.nio.file.Paths
+import java.nio.file.attribute.PosixFilePermissions.asFileAttribute
+import java.nio.file.attribute.PosixFilePermission.OWNER_READ
+import java.util.EnumSet
+
+/** A test plugin.  */
+class Unplugged(val global: Global) extends Plugin {
+  import global._
+
+  val name = "unplugged"
+  val description = "A plugin that creates local output before jvm writes classes."
+  val components = List[PluginComponent](TestComponent)
+
+  private object TestComponent extends PluginComponent {
+    val global: Unplugged.this.global.type = Unplugged.this.global
+    override val runsBefore = List("jvm")
+    val runsAfter = List("typer")
+    val phaseName = Unplugged.this.name
+    override def description = "Interfere with classwriter!"
+    def newPhase(prev: Phase) = new TestPhase(prev)
+    class TestPhase(prev: Phase) extends StdPhase(prev) {
+      override def description = TestComponent.this.description
+      def apply(unit: CompilationUnit): Unit = {
+        import scala.util.Try
+        global.settings.outdir.value = s"${global.settings.plugin.value.head}/${global.settings.outdir.value}"
+        val path = Paths.get(global.settings.outdir.value)
+        val perms = asFileAttribute(EnumSet.of(OWNER_READ))
+        Try(createFile(path, perms))
+      }
+    }
+  }
+}

--- a/test/files/neg/t12134/sample_2.scala
+++ b/test/files/neg/t12134/sample_2.scala
@@ -1,0 +1,9 @@
+// scalac: -Xplugin:. -Xplugin-require:unplugged -d testy.jar
+package sample
+
+// The unplugged plugin pre-emptively creates a read-only testy.jar.
+// Previously, compilation would NPE after failing to write the output.
+// Now the error is terse but accurate.
+// The plugin updates -d to put the file under partest output,
+// which happens to be the same as -Xplugin.
+object Main extends App

--- a/test/files/neg/t12134/scalac-plugin.xml
+++ b/test/files/neg/t12134/scalac-plugin.xml
@@ -1,0 +1,4 @@
+<plugin>
+<name>sample-plugin</name>
+<classname>t12134.Unplugged</classname>
+</plugin>


### PR DESCRIPTION
Error resulting in incomplete initialization
requires more care in clean-up.

The test plugin creates a read-only output file to test resilience of class file writing.

I wonder if GenBCode could have used that closeable registry thing.

Fixes scala/bug#12134