### PR TITLE
Add `@nolink` for forwards binary compatible overrides

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -398,6 +398,8 @@ val mimaFilterSettings = Seq {
     // Fix for scala/bug#12059
     ProblemFilters.exclude[MissingClassProblem](s"scala.collection.MapView$$Keys"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.MapView$Values"),
+
+    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.nolink"),
   ),
 }
 

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -116,6 +116,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val elidebelow         = IntSetting          ("-Xelide-below", "Calls to @elidable methods are omitted if method priority is lower than argument",
                                                 elidable.MINIMUM, None, elidable.byName get _)
   val noForwarders       = BooleanSetting      ("-Xno-forwarders", "Do not generate static forwarders in mirror classes.")
+  val useNolink          = BooleanSetting      ("-Xuse-nolink", "Allow generated classes to refer to methods annotated @nolink")
   val genPhaseGraph      = StringSetting       ("-Xgenerate-phase-graph", "file", "Generate the phase graphs (outputs .dot files) to fileX.dot.", "")
   val maxerrs            = IntSetting          ("-Xmaxerrs", "Maximum errors to print", 100, None, _ => None)
   val maxwarns           = IntSetting          ("-Xmaxwarns", "Maximum warnings to print", 100, None, _ => None)

--- a/src/library/scala/annotation/nolink.scala
+++ b/src/library/scala/annotation/nolink.scala
@@ -1,0 +1,45 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+
+/**
+ * Methods annotated `@nolink` are emitted normally in bytecode, but they cannot be
+ * referenced by client code. This allows adding binary compatible overrides when the
+ * bytecode signature is refined.
+ *
+ * Example:
+ *
+ * {{{
+ *   class A { def f: AnyRef = "A.f" }
+ *   class C extends A
+ * }}}
+ *
+ * Adding an override of `f` to `C` and refining the result type is not forwards
+ * binary compatible:
+ *
+ * {{{
+ *    class C extends A { override def f: String = "C.f" }
+ * }}}
+ *
+ * The class `C` gets a new method in bytecode with return type `String`. In order
+ * to implement overriding, the compiler generates a "bridge" method in `C` which
+ * has the same signature as the overridden method (return type `Object`).
+ *
+ * Annotating the override `@nolink` hides it and avoids client code to refer to
+ * to it. So an invocation `(new C).f` resolves to the method `A.f: AnyRef` and
+ * uses the signature `f: Object` in bytecode. Since the bridge method for `C.f`
+ * overrides the method `A.f`, at run-time the method `C.f` is invoked.
+ *
+ * The `-Xuse-nolink` compiler flag disables the special handling of methods `@nolink`.
+ */
+final class nolink extends StaticAnnotation

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -13,7 +13,7 @@
 package scala.collection
 package mutable
 
-import scala.annotation.tailrec
+import scala.annotation.{nolink, tailrec}
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.generic.DefaultSerializationProxy
 import scala.util.hashing.MurmurHash3
@@ -527,8 +527,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     this
   }
 
-  // TODO: rename to `mapValuesInPlace` and override the base version (not binary compatible)
-  private[mutable] def mapValuesInPlaceImpl(f: (K, V) => V): this.type = {
+  @nolink override def mapValuesInPlace(f: (K, V) => V): this.type = {
     val len = table.length
     var i = 0
     while (i < len) {

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -197,17 +197,15 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
     * @return   the map itself.
     */
   def mapValuesInPlace(f: (K, V) => V): this.type = {
-    if (nonEmpty) this match {
-      case hm: mutable.HashMap[_, _] => hm.asInstanceOf[mutable.HashMap[K, V]].mapValuesInPlaceImpl(f)
-      case _ =>
-        val array = this.toArray[Any]
-        val arrayLength = array.length
-        var i = 0
-        while (i < arrayLength) {
-          val (k, v) = array(i).asInstanceOf[(K, V)]
-          update(k, f(k, v))
-          i += 1
-        }
+    if (nonEmpty) {
+      val array = this.toArray[Any]
+      val arrayLength = array.length
+      var i = 0
+      while (i < arrayLength) {
+        val (k, v) = array(i).asInstanceOf[(K, V)]
+        update(k, f(k, v))
+        i += 1
+      }
     }
     this
   }

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1276,6 +1276,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val TailrecClass               = requiredClass[scala.annotation.tailrec]
     lazy val VarargsClass               = requiredClass[scala.annotation.varargs]
     lazy val NowarnClass                = getClassIfDefined("scala.annotation.nowarn")
+    lazy val NolinkClass                = getClassIfDefined("scala.annotation.nolink")
     lazy val uncheckedStableClass       = requiredClass[scala.annotation.unchecked.uncheckedStable]
     lazy val uncheckedVarianceClass     = requiredClass[scala.annotation.unchecked.uncheckedVariance]
 

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -423,6 +423,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.TailrecClass
     definitions.VarargsClass
     definitions.NowarnClass
+    definitions.NolinkClass
     definitions.uncheckedStableClass
     definitions.uncheckedVarianceClass
     definitions.ChildAnnotationClass

--- a/test/files/run/nolink.check
+++ b/test/files/run/nolink.check
@@ -1,0 +1,25 @@
+nolink.scala:25: warning: method f is annotated @nolink but the current method is not. This can lead to a binary incompatibilty.
+  override def f: Int = super.f + 22
+                              ^
+nolink.scala:27: warning: method g is annotated @nolink but the current method is not. This can lead to a binary incompatibilty.
+  override def g(i: Int): Int = super.g(i + 22) + 33
+                                      ^
+nolink.scala:31: warning: method f is annotated @nolink but the current method is not. This can lead to a binary incompatibilty.
+  override def f: String = super.f.trim()
+                                 ^
+nolink.scala:33: warning: method g is annotated @nolink but the current method is not. This can lead to a binary incompatibilty.
+  override def g(s: String): Int = super.g(s.trim) + 33
+                                         ^
+22
+22
+hai
+3
+44
+77
+hai
+36
+44
+77
+hai
+36
+T1

--- a/test/files/run/nolink.scala
+++ b/test/files/run/nolink.scala
@@ -1,0 +1,92 @@
+import scala.annotation.nolink
+
+abstract class A[T] {
+  def f: T
+  def g(t: T): Int
+}
+
+class BI extends A[Int] {
+  @nolink
+  def f: Int = 11
+
+  @nolink
+  def g(i: Int): Int = i + 11
+}
+
+class BS extends A[String] {
+  @nolink
+  def f: String = " hai "
+
+  @nolink
+  def g(s: String): Int = s.trim.length
+}
+
+class BIO1 extends BI {
+  override def f: Int = super.f + 22
+
+  override def g(i: Int): Int = super.g(i + 22) + 33
+}
+
+class BSO1 extends BS {
+  override def f: String = super.f.trim()
+
+  override def g(s: String): Int = super.g(s.trim) + 33
+}
+
+class BIO2 extends BI {
+  @nolink
+  override def f: Int = super.f + 22
+
+  @nolink
+  override def g(i: Int): Int = super.g(i + 22) + 33
+}
+
+class BSO2 extends BS {
+  @nolink
+  override def f: String = super.f.trim()
+
+  @nolink
+  override def g(s: String): Int = super.g(s.trim) + 33
+}
+
+trait T0 {
+  def meth: Object = "T0"
+}
+
+trait T1 extends T0 {
+  @nolink override def meth: String = "T1"
+}
+
+class C extends T1
+
+object Test {
+  def show(i: Int) = println(i)
+  def show(s: String) = println(s)
+  def main(args: Array[String]): Unit = {
+    val bi = new BI
+    show(bi.f + 11)
+    show(bi.g(11))
+
+    val bs = new BS
+    show(bs.f.trim)
+    show(bs.g(" hui "))
+
+    val bio1 = new BIO1
+    show(bio1.f + 11)
+    show(bio1.g(11))
+
+    val bso1 = new BSO1
+    show(bso1.f.trim)
+    show(bso1.g(" hui "))
+
+    val bio2 = new BIO2
+    show(bio2.f + 11)
+    show(bio2.g(11))
+
+    val bso2 = new BSO2
+    show(bso2.f.trim)
+    show(bso2.g(" hui "))
+
+    println((new C).meth)
+  }
+}


### PR DESCRIPTION
Methods annotated `@nolink` are emitted normally in bytecode but hidden
from client code, which allows adding binary compatible overrides when
the bytecode signature is refined.

```
class A { def f: AnyRef = "A.f" }
class C extends A { @nolink override def f: String = "C.f" }
```

The method `C.f: String` is hidden at compile-time, so `(new C).f`
resolves to `A.f`. At run-time, `C.f` is executed because the bridge
generated for `C.f` overrides `A.f`.

This is a probably safer and simpler alternative to #9141.

Closes scala/bug#11804. Hat-tip to @szeiger for the idea and for doing
the initial research and to @mkeskells for the idea of hiding the
methods from clients.