### PR TITLE
[2.12.x] Restore binary compatibility for doc.Settings

### DIFF
--- a/src/scaladoc/scala/tools/nsc/ScalaDoc.scala
+++ b/src/scaladoc/scala/tools/nsc/ScalaDoc.scala
@@ -14,6 +14,7 @@ package scala.tools.nsc
 
 import scala.tools.nsc.doc.DocFactory
 import scala.tools.nsc.reporters.ConsoleReporter
+import scala.tools.nsc.settings.DefaultPathFactory
 import scala.reflect.internal.Reporter
 import scala.reflect.internal.util.{ FakePos, NoPosition, Position }
 
@@ -26,7 +27,8 @@ class ScalaDoc {
   def process(args: Array[String]): Boolean = {
     var reporter: ScalaDocReporter = null
     val docSettings = new doc.Settings(msg => reporter.error(FakePos("scaladoc"), msg + "\n  scaladoc -help  gives more information"),
-                                       msg => reporter.printMessage(msg))
+                                       msg => reporter.printMessage(msg),
+                                       DefaultPathFactory)
     reporter = new ScalaDocReporter(docSettings)
     val command = new ScalaDoc.Command(args.toList, docSettings)
     def hasFiles = command.files.nonEmpty || docSettings.uncompilableFiles.nonEmpty

--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -22,6 +22,8 @@ import scala.tools.nsc.settings.{DefaultPathFactory, PathFactory}
   * @param error A function that prints a string to the appropriate error stream
   * @param printMsg A function that prints the string, without any extra boilerplate of error */
 class Settings(error: String => Unit, val printMsg: String => Unit = println(_), pathFactory: PathFactory = DefaultPathFactory) extends scala.tools.nsc.Settings(error, pathFactory) {
+  // https://github.com/tkawachi/sbt-doctest depends on this constructor being available
+  def this(error: String => Unit, printMsg: String => Unit) = this(error, printMsg, DefaultPathFactory)
 
   // TODO 2.13 Remove
   private def removalIn213 = "This flag is scheduled for removal in 2.13. If you have a case where you need this flag then please report a bug."


### PR DESCRIPTION
71c91d5cea6410a81001a362b6d74efc64b86877 broke binary compatibility for
scala.tools.nsc.doc.Settings.<init>. This api is used by
https://github.com/tkawachi/sbt-doctest which was broken by the change
to the signature.