### PR TITLE
Add missing asSeenFrom in checkKindBoundsHK 

### DIFF
--- a/test/files/pos/t12142.scala
+++ b/test/files/pos/t12142.scala
@@ -1,0 +1,19 @@
+object Test {
+  trait Bounds {
+    type Upper <: Bounds
+  }
+
+  trait Narrow extends Bounds {
+    type Upper >: Narrow <: Bounds
+  }
+
+  trait Template[+X <: Bounds] extends Bounds {
+    val body :X
+    type Bound >: body.Upper <: Bounds
+    type Copy[+A <: Bound] <: Template[A]
+    type High[T[+A <: Narrow] <: Bounds]
+
+    def applied(narrow: Template[Narrow]): High[narrow.Copy] //ok
+    def indirect(narrow: Template[Narrow]): High[({ type T[+A <: Narrow] = narrow.Copy[A] })#T] //also ok
+  }
+}


### PR DESCRIPTION
Without it the bounds of higher-kinded type parameters lose their paths.

Fixes scala/bug#12142