### PR TITLE
Deprecate Buffer#trim{Start,End}

### DIFF
--- a/src/library/scala/collection/mutable/Buffer.scala
+++ b/src/library/scala/collection/mutable/Buffer.scala
@@ -119,17 +119,16 @@ trait Buffer[A]
     *  @param n  the number of elements to remove from the beginning
     *            of this buffer.
     */
-  def trimStart(n: Int): Unit = remove(0, normalized(n))
+  @deprecated("use dropInPlace instead", since = "2.13.4")
+  def trimStart(n: Int): Unit = dropInPlace(n)
 
   /** Removes the last ''n'' elements of this buffer.
     *
     *  @param n  the number of elements to remove from the end
     *            of this buffer.
     */
-  def trimEnd(n: Int): Unit = {
-    val norm = normalized(n)
-    remove(length - norm, norm)
-  }
+  @deprecated("use dropRightInPlace instead", since = "2.13.4")
+  def trimEnd(n: Int): Unit = dropRightInPlace(n)
 
   def patchInPlace(from: Int, patch: scala.collection.IterableOnce[A], replaced: Int): this.type
 

--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -752,6 +752,6 @@ final class TestTranscript {
   private[this] val buf = ListBuffer[String]()
 
   def add(action: String): this.type = { buf += action ; this }
-  def append(text: String): Unit = { val s = buf.last ; buf.trimEnd(1) ; buf += (s + text) }
+  def append(text: String): Unit = { val s = buf.last ; buf.dropRightInPlace(1) ; buf += (s + text) }
   def toList = buf.toList
 }

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/SimpleHistory.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/SimpleHistory.scala
@@ -36,7 +36,7 @@ class SimpleHistory extends History {
   def get(idx: Int): CharSequence = buf(idx)
   def add(item: CharSequence): Unit = buf += item.toString
   def replace(item: CharSequence): Unit = {
-    buf trimEnd 1
+    buf dropRightInPlace 1
     add(item)
   }
 

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -1,15 +1,14 @@
 package scala.collection.mutable
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert.assertEquals
 
+import scala.annotation.nowarn
 import scala.tools.testkit.AssertUtil.assertThrows
 
-/* Test for scala/bug#9043 */
-@RunWith(classOf[JUnit4])
 class ArrayBufferTest {
+
+  /* Test for scala/bug#9043 */
   @Test
   def testInsertAll(): Unit = {
     val traver = ArrayBuffer(2, 4, 5, 7)
@@ -185,6 +184,7 @@ class ArrayBufferTest {
   def testRemoveManyWithTooLargeCount(): Unit =
     assertThrows[IndexOutOfBoundsException](ArrayBuffer(0).remove(index = 0, count = 100))
 
+  @nowarn("cat=deprecation")
   @Test
   def testTrimStart(): Unit = {
     val b1 = ArrayBuffer()
@@ -204,6 +204,7 @@ class ArrayBufferTest {
     assertEquals(ArrayBuffer.range(10, 100), b4)
   }
 
+  @nowarn("cat=deprecation")
   @Test
   def testTrimEnd(): Unit = {
     val b1 = ArrayBuffer()
@@ -344,7 +345,7 @@ class ArrayBufferTest {
 
   @Test def t11417_sortInPlace(): Unit = {
     val a = ArrayBuffer(5,4,3,2,1)
-    a.trimEnd(2)
+    a.dropRightInPlace(2)
     a.sortInPlace()
     assertEquals(List(3,4,5), a)
   }

--- a/test/junit/scala/collection/mutable/ArrayDequeTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayDequeTest.scala
@@ -1,15 +1,14 @@
 package scala.collection.mutable
 
 import scala.collection.immutable.List
-
 import org.junit.Test
 import org.junit.Assert._
 
+import scala.annotation.nowarn
 import scala.collection.SeqFactory
 
 class ArrayDequeTest {
 
-  @deprecated("Tests deprecated API", since="2.13")
   @Test
   def apply() = {
     val buffer = ArrayDeque.empty[Int]
@@ -22,10 +21,10 @@ class ArrayDequeTest {
       assertEquals(buffer.reverse, buffer2.reverse)
     }
 
-    apply(_.+=(1, 2, 3, 4, 5))
+    apply(_.+=(1, 2, 3, 4, 5)): @nowarn("cat=deprecation")
     apply(_.prepend(6).prepend(7).prepend(8))
-    apply(_.trimStart(2))
-    apply(_.trimEnd(3))
+    apply(_.dropInPlace(2))
+    apply(_.dropRightInPlace(3))
     apply(_.insert(2, -3))
     apply(_.insertAll(0, collection.Seq(9, 10, 11)))
     apply(_.insertAll(1, collection.Seq(12, 13)))

--- a/test/junit/scala/collection/mutable/ListBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ListBufferTest.scala
@@ -2,10 +2,9 @@ package scala.collection.mutable
 
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-@RunWith(classOf[JUnit4])
+import scala.annotation.nowarn
+
 class ListBufferTest {
 
   @Test
@@ -152,6 +151,7 @@ class ListBufferTest {
     ListBuffer(0).remove(idx = 0, count = 100)
   }
 
+  @nowarn("cat=deprecation")
   @Test
   def testTrimStart: Unit = {
     val b1 = ListBuffer()
@@ -171,6 +171,7 @@ class ListBufferTest {
     assertEquals(ListBuffer.range(10, 100), b4)
   }
 
+  @nowarn("cat=deprecation")
   @Test
   def testTrimEnd: Unit = {
     val b1 = ListBuffer()


### PR DESCRIPTION
Deprecate `Buffer#trimStart` and `Buffer#trimEnd` in
favour of `Buffer#dropInPlace` and
`Buffer#dropRightInPlace`, which are more consistent
with the rest of the API.

This is not high priority by any means, but it seems like
unnecessary duplication in the API.