### PR TITLE
fix publishing by using https URL for Maven Central

### DIFF
--- a/scripts/jobs/integrate/bootstrap
+++ b/scripts/jobs/integrate/bootstrap
@@ -119,7 +119,7 @@ function generateRepositoriesConfig(){
   jcenter-cache: $jcenterCacheUrl
   typesafe-ivy-releases: https://dl.bintray.com/typesafe/ivy-releases/, [organisation]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   sbt-plugin-releases: https://dl.bintray.com/sbt/sbt-plugin-releases/, [organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
-  maven-central
+  maven-central: https://repo1.maven.org/maven2
   local
 EOF
 }


### PR DESCRIPTION
this should have broken in January 2020 when Maven Central
shut off plain http access, but for reasons I don't fully
understand it only broke just recently when we reconfigured
the Artifactory instance on scala-ci

regardless, this is a good, correct change

gory details at scala/community-build#1216