### PR TITLE
Avoid swallowing error message and crashing for X[A]#Inaccessible

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -54,6 +54,7 @@ abstract class Pickler extends SubComponent {
       syms.foreach { sym =>
         pickle.putDecl(sym)
       }
+      pickle.writeArray()
     }
   }
 
@@ -170,7 +171,7 @@ abstract class Pickler extends SubComponent {
     private lazy val nonClassRoot = findSymbol(root.ownersIterator)(!_.isClass)
     def include(sym: Symbol) = !noPrivates || !sym.isPrivate || (sym.owner.isTrait && sym.isAccessor)
 
-    def close(): Unit = { writeArray(); index = null; entries = null }
+    def close(): Unit = { index = null; entries = null }
 
     private def isRootSym(sym: Symbol) =
       sym.name.toTermName == rootName && sym.owner == rootOwner
@@ -626,7 +627,7 @@ abstract class Pickler extends SubComponent {
     }
 
     /** Write byte array */
-    private def writeArray() {
+    final def writeArray() {
       assert(writeIndex == 0)
       assert(index ne null, this)
       writeNat(MajorVersion)

--- a/test/files/neg/t12155.check
+++ b/test/files/neg/t12155.check
@@ -1,4 +1,4 @@
-t12155.scala:6: error: erroneous or inaccessible type
+t12155.scala:6: error: class Node in class C1 cannot be accessed in C1[A,_$1]
 class D[A, C](val x: C1[A, _]#Node[C]) {
                               ^
 one error found

--- a/test/files/neg/t12155.check
+++ b/test/files/neg/t12155.check
@@ -1,0 +1,4 @@
+t12155.scala:6: error: erroneous or inaccessible type
+class D[A, C](val x: C1[A, _]#Node[C]) {
+                              ^
+one error found

--- a/test/files/neg/t12155.scala
+++ b/test/files/neg/t12155.scala
@@ -1,0 +1,10 @@
+class C1[A, B] {
+  private class Node[X] {
+    def size = 42
+  }
+}
+class D[A, C](val x: C1[A, _]#Node[C]) {
+}
+class Client {
+  def test(d: D[_, _]) = d.x.size
+}


### PR DESCRIPTION
The extra ref-checking in d7814a23 (aka TypeTreeWithDeferredRefCheck) seems
to have been added in a way that obscures reporting of access errors. This
leads to downstream crashes in later phases.

This failure used to be caught by a backstop in the pickler phase which
emitted a "erroneous or inaccessible type" error, which regressed in
cf477a0e40 but is also fixed in this PR.

Fixes scala/bug#12155