### PR TITLE
Patmat: don't drop abstract subtypes prematurely

### DIFF
--- a/test/files/run/t11229.check
+++ b/test/files/run/t11229.check
@@ -1,0 +1,2 @@
+false
+true

--- a/test/files/run/t11229/Lib.scala
+++ b/test/files/run/t11229/Lib.scala
@@ -1,0 +1,11 @@
+// scalac: -Werror
+sealed trait A
+sealed trait AB extends A
+sealed trait AA extends A
+
+object Lib {
+  def f(a: A): Boolean = a match {
+       case _:AA => true
+       case _:AB => false
+  }
+}

--- a/test/files/run/t11229/Test.java
+++ b/test/files/run/t11229/Test.java
@@ -1,0 +1,6 @@
+public class Test {
+  public static void main(String... args) {
+    scala.Predef.println(Lib.f(new AB() {}));
+    scala.Predef.println(Lib.f(new AA() {}));
+  }
+}

--- a/test/tasty/neg/src-2/TestDelayedChained.check
+++ b/test/tasty/neg/src-2/TestDelayedChained.check
@@ -1,5 +1,5 @@
 TestDelayedChained_fail.scala:4: warning: match may not be exhaustive.
-It would fail on the following inputs: LeafB(), LeafC()
+It would fail on the following inputs: (_ : tastytest.DelayedChained.Internal.Branch), LeafB(), LeafC()
   def foo(r: DelayedChained.Root): Unit = r match { case _: DelayedChained.LeafA => ()  }
                                           ^
 error: No warnings can be incurred under -Werror.


### PR DESCRIPTION
In the code:

    sealed trait A
    sealed trait AB extends A
    sealed trait AA extends A

    object Lib {
      def f(a: A): Boolean = a match {
           case _:AA => true
           case _:AB => false
      }
    }

the reason the compiler was giving an unreachable warning ("warning:
unreachable code case _:AB => false") was that A, AB and AA are all
uninhabited due to the fact that they're both abstract and sealed, i.e.
they have no subclasses.  Which means that `case _:AB =>` is indeed
unreachable, as is, in fact, `case _:AA => ` (the reason it reports the
`case _: AB` branch I think is because the pattern match analyser is
investigating "if the type is AA, are any of the branches unreachable?"
first).

The fact that in the REPL you can extend a sealed trait is kind of an
implementation detail, a convenience for REPL usage.  I almost wrote the
test as a REPL test to reproduce it, but then remembered I could use
Java instead.

Just to get it out of the way: suppressing the warning when in the REPL
would be a terrible idea, IMO.

Let's just not filter sealed, abstract subclasses.

Fixes https://github.com/scala/bug/issues/11229