### PR TITLE
[after #9141] ListMap is reverse oriented, so optimise some APIs

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -45,6 +45,11 @@ object ListMap extends ImmutableMapFactory[ListMap] {
   @SerialVersionUID(-8256686706655863282L)
   private object EmptyListMap extends ListMap[Any, Nothing]
 
+  @tailrec private def dropRightInternal[A, B](map: ListMap[A, B], n: Int): ListMap[A, B] = {
+    if (n <= 0 || map.isEmpty) map
+    else dropRightInternal(map.init, n - 1)
+  }
+
   @tailrec private def foldRightInternal[A, B, Z](map: ListMap[A, B], prevValue: Z, op: ((A, B), Z) => Z): Z = {
     if (map.isEmpty) prevValue
     else foldRightInternal(map.init, op(map.last, prevValue), op)
@@ -132,6 +137,8 @@ sealed class ListMap[A, +B] extends AbstractMap[A, B]
   protected def value: B = throw new NoSuchElementException("value of empty map")
   protected def next: ListMap[A, B] = throw new NoSuchElementException("next of empty map")
 
+  override def dropRight(n: Int): ListMap[A, B] = ListMap.dropRightInternal(this, n)
+  override def take(n: Int): ListMap[A, B] = ListMap.dropRightInternal(this, size - n)
   override def foldRight[Z](z: Z)(op: ((A, B), Z) => Z): Z = ListMap.foldRightInternal(this, z, op)
   override def stringPrefix = "ListMap"
 

--- a/test/junit/scala/collection/immutable/ListMapTest.scala
+++ b/test/junit/scala/collection/immutable/ListMapTest.scala
@@ -109,6 +109,63 @@ class ListMapTest extends AllocationTest {
 
   }
 
+  @Test
+  def dropRightNonAllocating(): Unit = {
+    var m = ListMap.empty[Int, Int]
+    assertSame(ListMap(), nonAllocating(m.dropRight(-1)))
+    assertSame(ListMap(), nonAllocating(m.dropRight(0)))
+    assertSame(ListMap(), nonAllocating(m.dropRight(1)))
+    assertSame(ListMap(), nonAllocating(m.dropRight(10)))
+
+    m = ListMap(1 -> 1)
+    assertSame(m, nonAllocating(m.dropRight(-1)))
+    assertSame(m, nonAllocating(m.dropRight(0)))
+    assertSame(ListMap.empty, nonAllocating(m.dropRight(1)))
+    assertSame(ListMap.empty, nonAllocating(m.dropRight(10)))
+
+    m = ListMap(1 -> 1, 2 -> 2)
+    assertSame(m, nonAllocating(m.dropRight(-1)))
+    assertSame(m, nonAllocating(m.dropRight(0)))
+    assertEquals(ListMap(1 -> 1), nonAllocating(m.dropRight(1)))
+    assertEquals(ListMap.empty, nonAllocating(m.dropRight(2)))
+    assertSame(ListMap.empty, nonAllocating(m.dropRight(10)))
+
+    m = ListMap(1 -> 1, 2 -> 2, 3 -> 3)
+    assertSame(m, nonAllocating(m.dropRight(-1)))
+    assertSame(m, nonAllocating(m.dropRight(0)))
+    assertEquals(ListMap(1 -> 1, 2 -> 2), nonAllocating(m.dropRight(1)))
+    assertEquals(ListMap(1 -> 1), nonAllocating(m.dropRight(2)))
+    assertSame(ListMap.empty, nonAllocating(m.dropRight(10)))
+  }
+  @Test
+  def takeNonAllocating(): Unit = {
+    var m = ListMap.empty[Int, Int]
+    assertSame(ListMap(), nonAllocating(m.take(-1)))
+    assertSame(ListMap(), nonAllocating(m.take(0)))
+    assertSame(ListMap(), nonAllocating(m.take(1)))
+    assertSame(ListMap(), nonAllocating(m.take(10)))
+
+    m = ListMap(1 -> 1)
+    assertSame(ListMap.empty, nonAllocating(m.take(-1)))
+    assertSame(ListMap.empty, nonAllocating(m.take(0)))
+    assertSame(m, nonAllocating(m.take(1)))
+    assertSame(m, nonAllocating(m.take(10)))
+
+    m = ListMap(1 -> 1, 2 -> 2)
+    assertSame(ListMap.empty, nonAllocating(m.take(-1)))
+    assertSame(ListMap.empty, nonAllocating(m.take(0)))
+    assertEquals(ListMap(1 -> 1), nonAllocating(m.take(1)))
+    assertSame(m, nonAllocating(m.take(2)))
+    assertSame(m, nonAllocating(m.take(10)))
+
+    m = ListMap(1 -> 1, 2 -> 2, 3 -> 3)
+    assertSame(ListMap.empty, nonAllocating(m.take(-1)))
+    assertSame(ListMap.empty, nonAllocating(m.take(0)))
+    assertEquals(ListMap(1 -> 1), nonAllocating(m.take(1)))
+    assertEquals(ListMap(1 -> 1, 2 -> 2), nonAllocating(m.take(2)))
+    assertSame(m, nonAllocating(m.take(10)))
+  }
+
   /** we base the result on tuples of strings as ListMap is not specialised */
   private def tuples(n: Int) = ListMapTest.tupleStringCost * n
   private def someTuples(n: Int) = ListMapTest.someTupleStringCost * n


### PR DESCRIPTION
ListMap.dropRight and take should never allocate
(was ListMap.foldRight should not generate additional garbage (just the tuples), but spun that out in https://github.com/scala/scala/pull/9218)