### PR TITLE
optimise the iteration of a ListMap

### DIFF
--- a/test/benchmarks/src/main/scala/scala/collection/immutable/ListMapBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/ListMapBenchmark.scala
@@ -1,0 +1,62 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+
+//typical usage bench/jmh:run scala.collection.immutable.TreeMapBenchmark --prof gc --rf csv
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class ListMapBenchmark {
+
+  @Param(Array("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "100"))
+  var size: Int = _
+
+  var map1: ListMap[Int, Int] = _
+
+  @Setup(Level.Trial) def init: Unit = {
+    map1 = ListMap(List.tabulate(size)(i => (i -> i)): _*)
+  }
+
+  @Benchmark
+  def iterator(bh: Blackhole): Unit = {
+    val it = map1.iterator
+    bh.consume(it)
+  }
+
+  @Benchmark
+  def iteration(bh: Blackhole): Unit = {
+    val it = map1.iterator
+    bh.consume(it)
+    while (it.hasNext) {
+      bh.consume(it.next)
+    }
+  }
+}
+
+//for testing, debugging, optimising etc
+object ListMapTest extends App {
+
+  val bh = new Blackhole("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.")
+  val test = new ListMapBenchmark
+  test.size = 8
+  test.init
+
+  while (true) {
+    var j = 0
+    val start = System.nanoTime()
+    while (j < 10000000) {
+      test.iteration(bh)
+      j += 1
+    }
+    val end = System.nanoTime()
+    println((end - start) / 1000000)
+  }
+}


### PR DESCRIPTION
because of the ordering of a ListMap the iteration is reversed

Prieviously this involved creation of a List of values, which is CPU and allocation heavy

This PR takes a different approach - for small `ListMap`, use a custom `Iterator` and just find the `Node` ( this is  O(n*n), but still faster for small n)
for large `ListMap` use an array of the `Node`

Iterator is the basis for many other opertations.

benchmarks - 

  |   | IMPROVEMENT |   |   |   |   | BEFORE |   |   |   |   | AFTER |   |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Benchmark | Param: size | ns | %| bytes | % |   | ns | err | bytes | err |   | ns | err | bytes | err
iteration | 0 | 0.141328 | 2.5% |   |   |   | 5.69 | 0.41 | 0 | 0 |   | 5.55 | 0.46 | 0 | 0
iteration | 1 | 8.383685 | 32.1% | 16.00002 | 25.0% |   | 26.14 | 5.25 | 64 | 0 |   | 17.76 | 0.50 | 48 | 0
iteration | 2 | 8.308047 | 23.2% | 40.00002 | 35.7% |   | 35.79 | 0.46 | 112 | 0 |   | 27.48 | 0.25 | 72 | 0
iteration | 3 | 9.942713 | 19.9% | 64.00001 | 40.0% |   | 50.06 | 1.18 | 160 | 0 |   | 40.12 | 3.37 | 96 | 0
iteration | 4 | 8.320993 | 12.9% | 88 | 42.3% |   | 64.75 | 2.38 | 208 | 0 |   | 56.43 | 11.80 | 120 | 0
iteration | 5 | 15.32113 | 19.7% | 112 | 43.7% |   | 77.58 | 0.71 | 256 | 0 |   | 62.26 | 0.79 | 144 | 0
iteration | 6 | 15.88162 | 17.2% | 136 | 44.7% |   | 92.17 | 2.59 | 304 | 0 |   | 76.28 | 0.76 | 168 | 0
iteration | 7 | 13.04686 | 12.4% | 160 | 45.5% |   | 105.10 | 1.17 | 352 | 0 |   | 92.06 | 0.99 | 192 | 0
iteration | 8 | 7.53484 | 6.1% | 136 | 34.0% |   | 123.82 | 9.29 | 400 | 0 |   | 116.29 | 1.14 | 264 | 0
iteration | 9 | 30.85909 | 18.8% | 152 | 33.9% |   | 163.95 | 22.74 | 448 | 0 |   | 133.09 | 3.97 | 296 | 0
iteration | 10 | 75.44774 | 34.4% | 176.0001 | 35.5% |   | 219.52 | 29.18 | 496 | 0 |   | 144.07 | 2.26 | 320 | 0
iteration | 100 | 808.7523 | 35.6% | 1976.001 | 41.0% |   | 2,273.12 | 19.10 | 4,816 | 0 |   | 1,464.37 | 9.72 | 2,840 | 0
iterator | 0 | 5.014236 | 54.7% |   |   |   | 9.17 | 0.09 | 0 | 0 |   | 4.15 | 0.06 | 0 | 0
iterator | 1 | 16.1407 | 55.1% | 16.00003 | 25.0% |   | 29.31 | 0.36 | 64 | 0 |   | 13.17 | 0.46 | 48 | 0
iterator | 2 | 33.74993 | 77.7% | 88.00006 | 78.6% |   | 43.43 | 0.36 | 112 | 0 |   | 9.68 | 0.26 | 24 | 0
iterator | 3 | 47.8269 | 82.2% | 136.0001 | 85.0% |   | 58.15 | 0.72 | 160 | 0 |   | 10.33 | 0.70 | 24 | 0
iterator | 4 | 60.75889 | 84.5% | 184.0001 | 88.5% |   | 71.92 | 0.37 | 208 | 0 |   | 11.16 | 0.12 | 24 | 0
iterator | 5 | 73.8856 | 86.0% | 232.0001 | 90.6% |   | 85.89 | 0.67 | 256 | 0 |   | 12.01 | 0.30 | 24 | 0
iterator | 6 | 86.79454 | 86.7% | 280.0001 | 92.1% |   | 100.06 | 0.47 | 304 | 0 |   | 13.27 | 0.48 | 24 | 0
iterator | 7 | 99.84237 | 87.1% | 328.0002 | 93.2% |   | 114.63 | 2.36 | 352 | 0 |   | 14.79 | 0.50 | 24 | 0
iterator | 8 | 76.45972 | 60.4% | 328.0001 | 82.0% |   | 126.63 | 1.02 | 400 | 0 |   | 50.17 | 0.34 | 72 | 0
iterator | 9 | 86.43972 | 61.2% | 368.0001 | 82.1% |   | 141.25 | 1.18 | 448 | 0 |   | 54.81 | 3.10 | 80 | 0
iterator | 10 | 103.5409 | 64.5% | 416.0002 | 83.9% |   | 160.48 | 10.17 | 496 | 0 |   | 56.94 | 0.64 | 80 | 0
iterator | 100 | 895.5994 | 63.1% | 4376.001 | 90.9% |   | 1,418.22 | 5.69 | 4,816 | 0 |   | 522.62 | 6.02 | 440 | 0


