### PR TITLE
Add Aux type aliases for s.c.g types

### DIFF
--- a/src/library/scala/collection/generic/IsIterable.scala
+++ b/src/library/scala/collection/generic/IsIterable.scala
@@ -129,6 +129,24 @@ trait IsIterable[Repr] extends IsIterableOnce[Repr] {
 
 object IsIterable extends IsIterableLowPriority {
 
+  /**
+   * Auxiliary type alias for specifying the type of `A` required for
+   * an `IsIterable` instance.
+   */
+  type AuxA[Repr, A0] = IsIterable[Repr] { type A = A0 }
+
+  /**
+   * Auxiliary type alias for specifying the type of `C` required for
+   * an `IsIterable` instance.
+   */
+  type AuxC[Repr, C0] = IsIterable[Repr] { type C = C0 }
+
+  /**
+   * Auxiliary type alias for specifying the types of `A` and `C` required
+   * for an `IsIterable` instance.
+   */
+  type AuxAC[Repr, A0, C0] = IsIterable[Repr] { type A = A0; type C = C0 }
+
   // Straightforward case: IterableOps subclasses
   implicit def iterableOpsIsIterable[A0, CC0[X] <: IterableOps[X, Iterable, CC0[X]]]: IsIterable[CC0[A0]] { type A = A0; type C = CC0[A0] } =
     new IsIterable[CC0[A0]] {

--- a/src/library/scala/collection/generic/IsIterableOnce.scala
+++ b/src/library/scala/collection/generic/IsIterableOnce.scala
@@ -52,6 +52,12 @@ trait IsIterableOnce[Repr] {
 
 object IsIterableOnce extends IsIterableOnceLowPriority {
 
+  /**
+   * Auxiliary type alias for specifying the type of `A` required for
+   * an `IsIterableOnce` instance.
+   */
+  type Aux[Repr, A0] = IsIterableOnce[Repr] { type A = A0 }
+
   // Straightforward case: IterableOnce subclasses
   implicit def iterableOnceIsIterableOnce[CC0[A] <: IterableOnce[A], A0]: IsIterableOnce[CC0[A0]] { type A = A0 } =
     new IsIterableOnce[CC0[A0]] {

--- a/src/library/scala/collection/generic/IsMap.scala
+++ b/src/library/scala/collection/generic/IsMap.scala
@@ -34,6 +34,7 @@ trait IsMap[Repr] extends IsIterable[Repr] {
   /** The type of values */
   type V
 
+  @deprecatedOverriding("this type should always be defined as `(K, V)`", since = "2.13.4")
   type A = (K, V)
 
   /** A conversion from the type `Repr` to `MapOps[K, V, Iterable, C]`
@@ -47,6 +48,36 @@ trait IsMap[Repr] extends IsIterable[Repr] {
 }
 
 object IsMap {
+
+  /**
+   * Auxiliary type alias for specifying the type of `K` required for
+   * an `IsMap` instance.
+   */
+  type AuxK[Repr, K0] = IsMap[Repr] { type K = K0 }
+
+  /**
+   * Auxiliary type alias for specifying the type of `K` required for
+   * an `IsMap` instance.
+   */
+  type AuxV[Repr, V0] = IsMap[Repr] { type V = V0 }
+
+  /**
+   * Auxiliary type alias for specifying the type of `C` required for
+   * an `IsMap` instance.
+   */
+  type AuxC[Repr, C0] = IsMap[Repr] { type C = C0 }
+
+  /**
+   * Auxiliary type alias for specifying the types of `K` and `V` required
+   * for an `IsMap` instance.
+   */
+  type AuxKV[Repr, K0, V0] = IsMap[Repr] { type K = K0; type V = V0 }
+
+  /**
+   * Auxiliary type alias for specifying the types of `K`, `V` and `C`
+   * required for an `IsMap` instance.
+   */
+  type AuxKVC[Repr, K0, V0, C0] = IsMap[Repr] { type K = K0; type V = V0; type C = C0 }
 
   /** Convenient type level function that takes a unary type constructor `F[_]`
     * and returns a binary type constructor that tuples its parameters and passes

--- a/src/library/scala/collection/generic/IsSeq.scala
+++ b/src/library/scala/collection/generic/IsSeq.scala
@@ -41,6 +41,24 @@ trait IsSeq[Repr] extends IsIterable[Repr] {
 
 object IsSeq {
 
+  /**
+   * Auxiliary type alias for specifying the type of `A` required for
+   * an `IsSeq` instance.
+   */
+  type AuxA[Repr, A0] = IsSeq[Repr] { type A = A0 }
+
+  /**
+   * Auxiliary type alias for specifying the type of `C` required for
+   * an `IsSeq` instance.
+   */
+  type AuxC[Repr, C0] = IsSeq[Repr] { type C = C0 }
+
+  /**
+   * Auxiliary type alias for specifying the types of `A` and `C` required
+   * for an `IsSeq` instance.
+   */
+  type AuxAC[Repr, A0, C0] = IsSeq[Repr] { type A = A0; type C = C0 }
+
   private val seqOpsIsSeqVal: IsSeq[Seq[Any]] =
     new IsSeq[Seq[Any]] {
       type A = Any


### PR DESCRIPTION
Add `Aux` pattern type aliases for `IsIterableOnce`,
`IsIterable`, `IsSeq` and `IsMap`.