### PR TITLE
Give partest some latitude when specifying test paths

### DIFF
--- a/src/partest/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AbstractRunner.scala
@@ -183,7 +183,8 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
       echo(RunnerSpec.helpMsg)
     }
     else {
-      val (individualTests, invalid) = config.parsed.residualArgs map (p => Path(p)) partition denotesTestPath
+      val norm = Function.chain(Seq(testIdentToTestPath, checkFileToTestFile, testFileToTestDir, testDirToTestFile))
+      val (individualTests, invalid) = config.parsed.residualArgs map (p => norm(Path(p))) partition denotesTestPath
       if (invalid.nonEmpty) {
         if (verbose)
           invalid foreach (p => echoWarning(s"Discarding invalid test path " + p))

--- a/src/partest/scala/tools/partest/nest/PathSettings.scala
+++ b/src/partest/scala/tools/partest/nest/PathSettings.scala
@@ -36,6 +36,8 @@ class PathSettings(testSourcePath: String) {
 
     candidates find isPartestDir getOrElse sys.error("Directory 'test' not found.")
   }
+
+  // Directory <root> (aka the repo root)
   val testParent = testRoot.parent
 
   // Directory <root>/test/files or .../scaladoc

--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -36,7 +36,7 @@ import scala.util.control.ControlThrowable
 
 /** pos/t1234.scala or pos/t1234 if dir */
 case class TestInfo(testFile: File) {
-  /** pos/t1234 */
+  /** pos/t1234.scala */
   val testIdent: String = testFile.testIdent
 
   /** pos */

--- a/src/partest/scala/tools/partest/package.scala
+++ b/src/partest/scala/tools/partest/package.scala
@@ -65,7 +65,7 @@ package object partest {
   implicit class FileOps(val f: File) {
     private def sf = SFile(f)
 
-    // e.g. pos/t1234
+    // e.g. pos/t1234.scala
     def withEnclosing: String = f.toPath.iterator.asScala.toList.takeRight(2).mkString("/")
     def testIdent = withEnclosing
 


### PR DESCRIPTION
Some of partest's output says run/t1234.scala, which is just teasing if
partest doesn't then take that as an input.

Also, if I've run with --update-check, I now have a list of changed
checkfiles in my git status: as those uniquely identify tests, let me
use that.

Finally, as t1234.check could mean t1234.scala or t1234/ (a directory):
fix that up too - I'm so over doing it myself, manually, Partest.

Fixes https://github.com/scala/bug/issues/11184