### PR TITLE
Fix async phase under toolbox compilation

### DIFF
--- a/test/async/jvm/toolbox.scala
+++ b/test/async/jvm/toolbox.scala
@@ -1,0 +1,15 @@
+import tools.reflect._
+import reflect.runtime._
+object Test extends App {
+  val box = currentMirror.mkToolBox(options = "-Xasync")
+  val code =
+    """
+    import scala.concurrent._, scala.concurrent.duration._, ExecutionContext.Implicits._
+    import scala.tools.partest.async._
+    val f1 = Future(1)
+    val f2 = Future(2)
+    val res = Async.async { Async.await(f1) + Async.await(f2) }
+    Await.result(res, 1.second)
+    """.stripMargin
+  assert(box.eval(box.parse(code)) == 3)
+}


### PR DESCRIPTION
The async phase has an optimization to skip units if they are known not to have any async calls in them. This is done by storing the `SourceFile` of every tree that is handed to `markForAsyncTransform`, and then skipping over any unit that does not have such a source file.

However, toolbox parsing returns a tree with positions in a synthetic file named "&lt;toolbox&gt;"; however, the unit passed to the compiler later on in `compile` is made without a source file; therefore, the unit is skipped by the async phase, and the `@compileTimeOnly` errors are emitted.

This patch tries to synchronize the unit with the tree that is passed in.