### PR TITLE
Always keep a field for `private[this] var` class parameters

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -172,7 +172,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
       //   class Outer { def test = {class LocalParent; class LocalChild extends LocalParent } }
       //
       // See run/t9408.scala for related test cases.
-      def omittableParamAcc(sym: Symbol) = sym.isParamAccessor && sym.isPrivateLocal
+      def omittableParamAcc(sym: Symbol) = sym.isParamAccessor && sym.isPrivateLocal && !sym.isVariable
       def omittableOuterAcc(sym: Symbol) = isEffectivelyFinal && sym.isOuterAccessor && !sym.isOverridingSymbol
       val omittables = mutable.Set.empty[Symbol] ++ (decls filter (sym => omittableParamAcc(sym) || omittableOuterAcc(sym))) // the closure only captures isEffectivelyFinal
 
@@ -193,31 +193,9 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
           }
       }
 
-      class DetectVarUses(targets: mutable.Set[Symbol]) extends InternalTraverser {
-        override def traverse(tree: Tree): Unit = if (targets.nonEmpty) {
-          def mark(sym: Symbol): Unit = {
-            targets -= sym
-            omittables -= sym
-          }
-          tree match {
-            case _: Select if targets(tree.symbol) => mark(tree.symbol)
-            case Assign(lhs, _) if targets(lhs.symbol) => mark(lhs.symbol)
-            case _ =>
-          }
-          tree.traverse(this)
-        }
-      }
-
       if (omittables.nonEmpty)
         (defs.iterator ++ auxConstructors.iterator) foreach detectUsages.traverse
 
-      if (omittables.nonEmpty) {
-        val omittedVars = omittables.filter(_.isVariable)
-        if (omittedVars.nonEmpty) {
-          val detector = new DetectVarUses(omittedVars)
-          constructor.foreach(detector.traverse)
-        }
-      }
       omittables.toSet
     }
   } // OmittablesHelper

--- a/test/files/run/t12002.check
+++ b/test/files/run/t12002.check
@@ -1,1 +1,10 @@
 good boy!
+List()
+List()
+List()
+List(private int D.x)
+List(private int E.x)
+List(private int F.x)
+List(private int G.x)
+List(private final int H.x)
+List(private int I.x)

--- a/test/files/run/t12002.check
+++ b/test/files/run/t12002.check
@@ -1,7 +1,7 @@
 good boy!
 List()
 List()
-List()
+List(private int C.x)
 List(private int D.x)
 List(private int E.x)
 List(private int F.x)

--- a/test/files/run/t12002.scala
+++ b/test/files/run/t12002.scala
@@ -1,17 +1,24 @@
-// cf t6880
-class C(private[this] var c: String) {
+class C0(private[this] var c: String) {
   private[this] var x: String = _
   c = "good"
   x = c + " boy!"
   override def toString = x
 }
 
+class A(x: Int) { assert(x == 1) } // elided
+class B(private[this] val x: Int) { assert(x == 1) } // elided
+class C(private[this] var x: Int) { } // elided
+class D(private[this] var x: Int) { assert(x == 1) } // kept
+class E(private[this] var x: Int) { x = 2 } // kept
+class F(private[this] var x: Int) { x = 2; assert(x == 2) } // kept
+class G(private[this] var x: Int) { x = 2; assert(x == 2); def m() = assert(x == 2, "m" + x); m() } // kept
+class H(private val x: Int) { } // kept
+class I(private var x: Int) { } // kept
+
 object Test {
-  def main(args: Array[String]) = println {
-    new C("bad")
+  def fs(o: AnyRef) = println(o.getClass.getDeclaredFields.toList)
+  def main(args: Array[String]): Unit = {
+    println(new C0("bad"))
+    List(new A(1), new B(1), new C(1), new D(1), new E(1), new F(1), new G(1), new H(1), new I(1)).foreach(fs)
   }
 }
-
-// was
-// java.lang.NoSuchFieldError: c
-//         at C.<init>(t12002.scala:6)

--- a/test/files/run/t12002.scala
+++ b/test/files/run/t12002.scala
@@ -7,7 +7,7 @@ class C0(private[this] var c: String) {
 
 class A(x: Int) { assert(x == 1) } // elided
 class B(private[this] val x: Int) { assert(x == 1) } // elided
-class C(private[this] var x: Int) { } // elided
+class C(private[this] var x: Int) { } // kept
 class D(private[this] var x: Int) { assert(x == 1) } // kept
 class E(private[this] var x: Int) { x = 2 } // kept
 class F(private[this] var x: Int) { x = 2; assert(x == 2) } // kept


### PR DESCRIPTION
Reads of `var` class parameters in the constructor are not rewritten to
the constructor parameter, they keep referring to the field to ensure
potential field writes are reflected (this was fixed in #7688).

This means that the corresponding field cannot be elided even if it's
never written.

The alternative solution would be to detect `private[this] var` fields
that are only read in the constructor. However this is difficult to
implement, see #9143.

The second commit goes a step further by never eliding the field
for a `private[this] var` class parameter. Up for discussion.

Fixes scala/bug#12002 (the remaining part).

This needs to be backported to 2.12.x.