### PR TITLE
Optimise factories for Array-based collections

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -426,6 +426,15 @@ val mimaFilterSettings = Seq {
 
     // Private constructor for SeqView.Sorted
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.SeqView#Sorted.this"),
+
+    // private convenience method for copying collections to Arrays (scala/scala#9232)
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.IterableOnce.copyElemsToArray"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.IterableOnce.copyElemsToArray$default$3"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.IterableOnce.copyElemsToArray$default$4"),
+
+    // this is safe because the default cannot be used; instead the single-param overload in
+    // `IterableOnceOps` is chosen (https://github.com/scala/scala/pull/9232#discussion_r501554458)
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.ArraySeq.copyToArray$default$2"),
   ),
 }
 

--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -237,8 +237,6 @@ sealed abstract class ArraySeq[+A]
 
   override protected[this] def className = "ArraySeq"
 
-  override def copyToArray[B >: A](xs: Array[B], start: Int = 0): Int = copyToArray[B](xs, start, length)
-
   override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {
     val copied = IterableOnce.elemsToCopyToArray(length, xs.length, start, len)
     if(copied > 0) {

--- a/src/library/scala/collection/immutable/WrappedString.scala
+++ b/src/library/scala/collection/immutable/WrappedString.scala
@@ -88,9 +88,6 @@ final class WrappedString(private val self: String) extends AbstractSeq[Char] wi
       case _       => super.lastIndexOf(elem, end)
     }
 
-  override def copyToArray[B >: Char](xs: Array[B], start: Int): Int =
-    copyToArray(xs, start, length)
-
   override def copyToArray[B >: Char](xs: Array[B], start: Int, len: Int): Int =
     (xs: Any) match {
       case chs: Array[Char] =>

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -219,8 +219,6 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   override protected[this] def stringPrefix = "ArrayBuffer"
 
-  override def copyToArray[B >: A](xs: Array[B], start: Int): Int = copyToArray[B](xs, start, length)
-
   override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {
     val copied = IterableOnce.elemsToCopyToArray(length, xs.length, start, len)
     if(copied > 0) {
@@ -258,8 +256,7 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
     val k = coll.knownSize
     if (k >= 0) {
       val array = new Array[AnyRef](k max DefaultInitialSize)
-      val it = coll.iterator
-      for (i <- 0 until k) array(i) = it.next().asInstanceOf[AnyRef]
+      IterableOnce.copyElemsToArray(coll, array.asInstanceOf[Array[Any]])
       new ArrayBuffer[B](array, k)
     }
     else new ArrayBuffer[B] ++= coll

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -59,14 +59,11 @@ sealed abstract class ArrayBuilder[T]
 
   override def addAll(xs: IterableOnce[T]): this.type = {
     val k = xs.knownSize
-    if(k > 0) {
+    if (k > 0) {
       ensureSize(this.size + k)
-      xs match {
-        case xs: Iterable[T] => xs.copyToArray(elems, this.size)
-        case _ => xs.iterator.copyToArray(elems, this.size)
-      }
+      IterableOnce.copyElemsToArray(xs, elems, this.size)
       size += k
-    } else if(k < 0) super.addAll(xs)
+    } else if (k < 0) super.addAll(xs)
     this
   }
 }

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -527,14 +527,9 @@ object ArrayDeque extends StrictOptimizedSeqFactory[ArrayDeque] {
     val s = coll.knownSize
     if (s >= 0) {
       val array = alloc(s)
-      val it = coll.iterator
-      var i = 0
-      while (it.hasNext) {
-        array(i) = it.next().asInstanceOf[AnyRef]
-        i += 1
-      }
+      IterableOnce.copyElemsToArray(coll, array.asInstanceOf[Array[Any]])
       new ArrayDeque[B](array, start = 0, end = s)
-    } else empty[B] ++= coll
+    } else new ArrayDeque[B]() ++= coll
   }
 
   def newBuilder[A]: Builder[A, ArrayDeque[A]] =

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -18,7 +18,6 @@ import java.util.Arrays
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.convert.impl._
 import scala.reflect.ClassTag
-import scala.runtime.ScalaRunTime
 import scala.util.hashing.MurmurHash3
 
 /**
@@ -74,8 +73,6 @@ sealed abstract class ArraySeq[T]
   /** Clones this object, including the underlying Array. */
   override def clone(): ArraySeq[T] = ArraySeq.make(array.clone()).asInstanceOf[ArraySeq[T]]
 
-  override def copyToArray[B >: T](xs: Array[B], start: Int): Int = copyToArray[B](xs, start, length)
-
   override def copyToArray[B >: T](xs: Array[B], start: Int, len: Int): Int = {
     val copied = IterableOnce.elemsToCopyToArray(length, xs.length, start, len)
     if(copied > 0) {
@@ -110,19 +107,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
   private[this] val EmptyArraySeq  = new ofRef[AnyRef](new Array[AnyRef](0))
   def empty[T : ClassTag]: ArraySeq[T] = EmptyArraySeq.asInstanceOf[ArraySeq[T]]
 
-  def from[A : ClassTag](it: scala.collection.IterableOnce[A]): ArraySeq[A] = {
-    val n = it.knownSize
-    if (n > -1) {
-      val elements = scala.Array.ofDim[A](n)
-      val iterator = it.iterator
-      var i = 0
-      while (i < n) {
-        ScalaRunTime.array_update(elements, i, iterator.next())
-        i = i + 1
-      }
-      make(elements)
-    } else make(ArrayBuffer.from(it).toArray)
-  }
+  def from[A : ClassTag](it: scala.collection.IterableOnce[A]): ArraySeq[A] = make(Array.from[A](it))
 
   def newBuilder[A : ClassTag]: Builder[A, ArraySeq[A]] = ArrayBuilder.make[A].mapResult(make)
 

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -348,8 +348,6 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     pq
   }
 
-  override def copyToArray[B >: A](xs: Array[B], start: Int): Int = copyToArray(xs, start, length)
-
   override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {
     val copied = IterableOnce.elemsToCopyToArray(length, xs.length, start, len)
     if (copied > 0) {


### PR DESCRIPTION
Optimise `from` methods on factories for `Array`-based
collections by having them call `copyToArray` on the
source collection.

Deprecate overriding the overloads of `copyToArray`
with fewer args, and remove overrides of those methods
from the standard library.

Fix incorrect doc about termination of `copyToArray`
for infinite collections.

Add helper method similar to `Array.from` for calling
`copyToArray` on an `IterableOnce`.