### PR TITLE
Try to parse Duration as Long before parsing as Double

### DIFF
--- a/test/files/jvm/duration-tck.scala
+++ b/test/files/jvm/duration-tck.scala
@@ -223,4 +223,12 @@ object Test extends App {
   
   // scala/bug#10320
   Duration("6803536004516701ns").toNanos mustBe 6803536004516701L
+
+  // scala/bug#12180
+  Duration("9007199254740992 microseconds").toString mustBe "9007199254740992 microseconds"
+  Duration("9007199254740993 microseconds").toString mustBe "9007199254740993 microseconds"
+  Duration("-9007199254740992 microseconds").toString mustBe "-9007199254740992 microseconds"
+  Duration("-9007199254740993 microseconds").toString mustBe "-9007199254740993 microseconds"
+  Duration("-7036832630452943 microseconds").toString mustBe "-7036832630452943 microseconds"
+  Duration("2.134 s") mustBe Duration(2134, MILLISECONDS)
 }


### PR DESCRIPTION
Applying this PR will try to parse a Duration as a Long before parsing it as a Double, following the proposal of @NthPortal. Fixes https://github.com/scala/bug/issues/12180. Also added a test for a fractional value.
I've left the `private[this] final val maxPreciseDouble` in place, even though it's not used anymore. If it's ok to remove it I can do that as well.