### PR TITLE
Make SeqView.Sorted slightly less lazy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -423,6 +423,9 @@ val mimaFilterSettings = Seq {
     // Documentation for scala.jdk package
     ProblemFilters.exclude[MissingClassProblem]("scala.jdk.package"),
     ProblemFilters.exclude[MissingClassProblem]("scala.jdk.package$"),
+
+    // Private constructor for SeqView.Sorted
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.SeqView#Sorted.this"),
   ),
 }
 


### PR DESCRIPTION
Force evaluation of the wrapped collection upon creation
of a `SeqView.Sorted` instance by calling `.length`, so
that non-termination of an infinite collection occurs at
a call to `sorted`/`sortBy`/`sortWith` rather than at an
arbitrary method call.

Also avoid computing the length of the wrapped collection
twice (since that may require a traversal).