### PR TITLE
Backport zip test fix to delete advisedly

### DIFF
--- a/test/junit/scala/collection/SetMapRulesTest.scala
+++ b/test/junit/scala/collection/SetMapRulesTest.scala
@@ -14,7 +14,7 @@ package scala.collection
 
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import org.junit.{Ignore, Test}
+import org.junit.Test
 import org.junit.Assert._
 
 import scala.collection.JavaConverters._

--- a/test/junit/scala/reflect/io/ZipArchiveTest.scala
+++ b/test/junit/scala/reflect/io/ZipArchiveTest.scala
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.reflect.internal.util.ScalaClassLoader
+import scala.util.Properties
 
 @RunWith(classOf[JUnit4])
 class ZipArchiveTest {
@@ -41,7 +42,6 @@ class ZipArchiveTest {
     }
   }
 
-
   private def manifestAt(location: URI): URL = ScalaClassLoader.fromURLs(List(location.toURL), null).getResource("META-INF/MANIFEST.MF");
 
   // ZipArchive.fromManifestURL(URL)
@@ -60,7 +60,7 @@ class ZipArchiveTest {
       assertEquals("foo.class", f.name)
     } finally {
       archive.close()
-      Files.delete(jar)
+      advisedly(Files.delete(jar))
     }
   }
 
@@ -91,7 +91,7 @@ class ZipArchiveTest {
       assertFalse(zit.hasNext)
       assertEquals("foo.class", f.name)
     } finally {
-      Files.delete(z)
+      advisedly(Files.delete(z))
     }
   }
 
@@ -119,4 +119,6 @@ class ZipArchiveTest {
     }
     f
   }
+
+  private def advisedly(body: => Unit): Unit = if (!Properties.isWin) body
 }


### PR DESCRIPTION
Don't attempt to delete temp jars on windows.

The problematic i/o seems to be incurred by `ManifestResources::iterator`.