### PR TITLE
Fix Process.lazyLines mem leak #12185

### DIFF
--- a/src/library/scala/sys/process/ProcessBuilderImpl.scala
+++ b/src/library/scala/sys/process/ProcessBuilderImpl.scala
@@ -170,8 +170,11 @@ private[process] trait ProcessBuilderImpl {
       val lazilyListed = LazilyListed[String](nonZeroException, capacity)
       val process      = run(BasicIO(withInput, lazilyListed.process, log))
 
+      // extract done from lazilyListed so that the anonymous function below closes over just the done and not the whole lazilyListed (see https://github.com/scala/bug/issues/12185)
+      val done = lazilyListed.done
+
       Spawn("LazyLines") {
-        lazilyListed.done {
+        done {
           try process.exitValue()
           catch {
             case NonFatal(_) => -2


### PR DESCRIPTION
This PR prevents closing over `LazilyListed` leading to mem-leak in `Process.lazyLines`.

It also replaces a `NonFatal` catch with `Exception` catch changing the failure mode in case of out of memory from infinite-gc-loop-and-no-errors to some-threads-crash-logging-oome-to-stderr-but-the-jvm-stays-alive.

I have no idea how to write a regression test for it. I'm open for ideas.

Fixes scala/bug#12185.