### PR TITLE
Resolve conflict with JDK15's new `isEmpty` method on `CharSequence`

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -334,12 +334,6 @@ trait Implicits {
     override def hashCode = 1
   }
 
-  val termArrayCharSequence = TermName("ArrayCharSequence")
-
-  val termCharArrayOps = TermName("charArrayOps")
-
-  val termIsEmpty = TermName("isEmpty")
-
   def SearchedPrefixImplicitInfo(pre: Type) = new ImplicitInfo(null, pre, NoSymbol)
 
   /** A constructor for types ?{ def/type name: tp }, used in infer view to member
@@ -454,21 +448,6 @@ trait Implicits {
       SearchFailure
     }
 
-    /** Check a case when `info1` is `ArrayCharSequence` and `info2` is `charArrayOps` from `scala.Predef`
-     *
-     * It can be true only when both this methods are imlicit the same type
-     * and it is a case when both are implemented `isEmpty`
-     * because `java.lang.CharSequence` has `isEmpty` since JDK 15
-     *
-     * Force to select scala implementation of `isEmpty` from `charArrayOps`
-     * because it produces bytecode that can be run on JDK before 15
-     */
-    def resolveJDK15CharSequenceConflict(info1: ImplicitInfo, info2: ImplicitInfo) =
-      info1.pre =:= info2.pre &&
-        info1.name == termArrayCharSequence && info2.name == termCharArrayOps &&
-        pt.typeArgs.size == 2 && pt.typeArgs.last.decls.containsName(termIsEmpty) &&
-        info1.pre.termSymbol.fullName == "scala.Predef"
-
     /** Is implicit info `info1` better than implicit info `info2`?
      */
     def improves(info1: ImplicitInfo, info2: ImplicitInfo) = {
@@ -479,7 +458,7 @@ trait Implicits {
           improvesCache get ((info1, info2)) match {
             case Some(b) => if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(improvesCachedCount); b
             case None =>
-              val result = resolveJDK15CharSequenceConflict(info1, info2) || isStrictlyMoreSpecific(info1.tpe, info2.tpe, info1.sym, info2.sym)
+              val result = isStrictlyMoreSpecific(info1.tpe, info2.tpe, info1.sym, info2.sym)
               improvesCache((info1, info2)) = result
               result
           }

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -669,4 +669,11 @@ final class Array[T](_length: Int) extends java.io.Serializable with java.lang.C
    *  @return A clone of the Array.
    */
   override def clone(): Array[T] = throw new Error()
+
+  /** Tests whether the Array is empty.
+   *
+   *  @return    `true` if the Array contains no elements, `false` otherwise.
+   */
+  // This method can only be added after changing the starr to 2.13.4
+  // def isEmpty: Boolean = throw new Error()
 }

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -468,6 +468,14 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
    *  @return             the last applicable index where target occurs, or -1 if not found.
    */
   def lastIndexOf(str: String, fromIndex: Int): Int = underlying.lastIndexOf(str, fromIndex)
+
+  /** Tests whether this builder is empty.
+   *
+   *  This method is required for JDK15+ compatibility
+   *
+   *  @return  `true` if this builder contains nothing, `false` otherwise.
+   */
+  override def isEmpty: Boolean = underlying.length() == 0
 }
 
 object StringBuilder {

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -500,6 +500,7 @@ trait Definitions extends api.StandardDefinitions {
       lazy val Array_update                = getMemberMethod(ArrayClass, nme.update)
       lazy val Array_length                = getMemberMethod(ArrayClass, nme.length)
       lazy val Array_clone                 = getMemberMethod(ArrayClass, nme.clone_)
+      lazy val Array_isEmpty               = getMemberIfDefined(ArrayClass, nme.isEmpty) // change to `getMemberMethod` eventually
 
     // reflection / structural types
     lazy val SoftReferenceClass     = requiredClass[java.lang.ref.SoftReference[_]]

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -187,12 +187,17 @@ trait Names extends api.Names {
 
 // Classes ----------------------------------------------------------------------
 
+  // Dummy trait to make Name#isEmpty with override keyword at JDK before 15
+  sealed trait CharSequenceIsName {
+    def isEmpty: Boolean
+  }
+
   /** The name class.
    *  TODO - resolve schizophrenia regarding whether to treat Names as Strings
    *  or Strings as Names.  Give names the key functions the absence of which
    *  make people want Strings all the time.
    */
-  sealed abstract class Name(protected val index: Int, protected val len: Int, protected val cachedString: String) extends NameApi with CharSequence {
+  sealed abstract class Name(protected val index: Int, protected val len: Int, protected val cachedString: String) extends NameApi with CharSequenceIsName with CharSequence {
     type ThisNameType >: Null <: Name
     protected[this] def thisName: ThisNameType
 
@@ -208,8 +213,9 @@ trait Names extends api.Names {
 
     /** The length of this name. */
     final def length: Int = len
-    final def isEmpty = length == 0
     final def nonEmpty = !isEmpty
+    // This method is override from CharSequenceIsName or CharSequenceIsName at JDK15+
+    override final def isEmpty = length == 0
 
     def nameKind: String
     def isTermName: Boolean

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -311,6 +311,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.Array_update
     definitions.Array_length
     definitions.Array_clone
+    definitions.Array_isEmpty
     definitions.SoftReferenceClass
     definitions.MethodClass
     definitions.EmptyMethodCacheClass

--- a/test/junit/scala/ArrayTest.scala
+++ b/test/junit/scala/ArrayTest.scala
@@ -1,9 +1,7 @@
 package scala
 
-import org.junit.Assert.assertArrayEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.{assertArrayEquals, assertFalse, assertTrue}
 import org.junit.Test
-
 import scala.runtime.BoxedUnit
 
 class ArrayTest {
@@ -16,7 +14,18 @@ class ArrayTest {
   }
 
   @Test
-  def testArrayCharIsEmpty(): Unit = {
-    assertTrue(new Array[Byte](0).isEmpty)
+  def testArrayIsEmpty(): Unit = {
+    def ie(a: Array[Int]) = a.isEmpty
+    def ce(a: Array[Char]) = a.isEmpty // scala/bug#12172
+    def re(a: Array[String]) = a.isEmpty
+    def ge[T](a: Array[T]) = a.isEmpty
+    val i0 = Array[Int]()
+    val i1 = Array(1)
+    val c0 = Array[Char]()
+    val c1 = Array[Char](1)
+    val s0 = Array[String]()
+    val s1 = Array("")
+    assertTrue(ie(i0) && ce(c0) && re(s0) && ge(i0) && ge(s0))
+    assertFalse(ie(i1) || ce(c1) || re(s1) || ge(i1) || ge(s1))
   }
 }

--- a/test/junit/scala/ArrayTest.scala
+++ b/test/junit/scala/ArrayTest.scala
@@ -1,6 +1,7 @@
 package scala
 
 import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 import scala.runtime.BoxedUnit
@@ -12,5 +13,10 @@ class ArrayTest {
     assertArrayEquals(expected, Array.copyOf(Array[Unit](), 32).asInstanceOf[Array[AnyRef]])
     assertArrayEquals(expected, Array.copyAs[Unit](Array[Nothing](), 32).asInstanceOf[Array[AnyRef]])
     assertArrayEquals(expected, Array.copyAs[Unit](Array[Unit](), 32).asInstanceOf[Array[AnyRef]])
+  }
+
+  @Test
+  def testArrayCharIsEmpty(): Unit = {
+    assertTrue(new Array[Byte](0).isEmpty)
   }
 }


### PR DESCRIPTION
`java.lang.CharSequence` has `isEmpty` method since JDK 15 that makes impossibly to compile scala by JDK15.

Fix it on the way that allows to compiled with JDK15 and before JDK15.

Fixes https://github.com/scala/bug/issues/12172