### PR TITLE
[2.11.x] Introduced support of JDK15+

### DIFF
--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -440,6 +440,12 @@ final class StringBuilder(private val underlying: JavaStringBuilder)
    *  @return  the string assembled by this StringBuilder
    */
   def result(): String = toString
+
+  /** Tests whether this builder is empty.
+   *
+   *  @return  `true` if this builder contains nothing, `false` otherwise.
+   */
+  override def isEmpty: Boolean = underlying.length() == 0
 }
 
 object StringBuilder {

--- a/src/reflect/scala/reflect/api/Names.scala
+++ b/src/reflect/scala/reflect/api/Names.scala
@@ -103,6 +103,15 @@ trait Names {
     /** The encoded name, still represented as a name.
      */
     def encodedName: Name
+
+    /** The length of this name. */
+    def length: Int
+
+    /** Tests whether this name is empty. */
+    def isEmpty: Boolean
+
+    /** Tests whether this name is not empty. */
+    def nonEmpty: Boolean
   }
 
   /** Create a new term name.

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -197,9 +197,9 @@ trait Names extends api.Names {
     def next: Name with ThisNameType
 
     /** The length of this name. */
-    final def length: Int = len
-    final def isEmpty = length == 0
-    final def nonEmpty = !isEmpty
+    override final def length: Int = len
+    override final def isEmpty: Boolean = length == 0
+    override final def nonEmpty: Boolean = !isEmpty
 
     def nameKind: String
     def isTermName: Boolean


### PR DESCRIPTION
`java.lang.CharSequence` has `isEmpty` method since JDK 15 that makes impossibly to compile scala by JDK15.

Fix it on the way that allows to compiled with JDK15 and before JDK15.

Link to the issue: https://github.com/scala/bug/issues/12172